### PR TITLE
Tong/fix release log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,5 +43,5 @@ Thumbs.db
 
 .nx/cache
 .nx/workspace-data
-
 .roo
+.vscode

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -3,5 +3,7 @@ module.exports = {
   extends: ['@commitlint/config-conventional'],
   rules: {
     'footer-max-line-length': [0, 'always'], // disable the footer length limit
+    'scope-enum': [2, 'always', ['build', 'packages']],
+    'scope-empty': [2, 'never']
   },
 };

--- a/nx.json
+++ b/nx.json
@@ -57,21 +57,23 @@
     }
   ],
   "release": {
-    "projects": [
-      "packages/*"
-    ],
+    "projects": ["packages/*"],
     "projectsRelationship": "independent",
     "releaseTagPattern": "{projectName}/{version}",
     "changelog": {
       "projectChangelogs": {
         "createRelease": "github",
-        "file": false
+        "file": false,
+        "entryWhenNoChanges": false
       }
     },
     "version": {
       "conventionalCommits": true,
       "preserveLocalDependencyProtocols": false,
-      "fallbackCurrentVersionResolver": "disk"
+      "fallbackCurrentVersionResolver": "disk",
+      "versionActionsOptions": {
+        "skipLockFileUpdate": true
+      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1733,6 +1733,18 @@
       "resolved": "packages/babylon-proto-ts",
       "link": true
     },
+    "node_modules/@babylonlabs-io/example-lib": {
+      "resolved": "packages/example-lib",
+      "link": true
+    },
+    "node_modules/@babylonlabs-io/example-lib2": {
+      "resolved": "packages/example-lib2",
+      "link": true
+    },
+    "node_modules/@babylonlabs-io/example-lib3": {
+      "resolved": "packages/example-lib3",
+      "link": true
+    },
     "node_modules/@bufbuild/buf": {
       "version": "1.50.0",
       "resolved": "https://registry.npmjs.org/@bufbuild/buf/-/buf-1.50.0.tgz",
@@ -4130,17 +4142,17 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.34.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.34.0.tgz",
-      "integrity": "sha512-vxXJV1hVFx3IXz/oy2sICsJukaBrtDEQSBiV48/YIV5KWjX1dO+bcIr/kCPrW6weKXvsaGKFNlwH0v2eYdRRbA==",
+      "version": "8.37.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.37.0.tgz",
+      "integrity": "sha512-kVIaQE9vrN9RLCQMQ3iyRlVJpTiDUY6woHGb30JDkfJErqrQEmtdWH3gV0PBAfGZgQXoqzXOO0T3K6ioApbbAA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.34.0",
-        "@typescript-eslint/types": "8.34.0",
-        "@typescript-eslint/typescript-estree": "8.34.0",
-        "@typescript-eslint/visitor-keys": "8.34.0",
+        "@typescript-eslint/scope-manager": "8.37.0",
+        "@typescript-eslint/types": "8.37.0",
+        "@typescript-eslint/typescript-estree": "8.37.0",
+        "@typescript-eslint/visitor-keys": "8.37.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -4153,6 +4165,161 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/project-service": {
+      "version": "8.37.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.37.0.tgz",
+      "integrity": "sha512-BIUXYsbkl5A1aJDdYJCBAo8rCEbAvdquQ8AnLb6z5Lp1u3x5PNgSSx9A/zqYc++Xnr/0DVpls8iQ2cJs/izTXA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.37.0",
+        "@typescript-eslint/types": "^8.37.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.37.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.37.0.tgz",
+      "integrity": "sha512-0vGq0yiU1gbjKob2q691ybTg9JX6ShiVXAAfm2jGf3q0hdP6/BruaFjL/ManAR/lj05AvYCH+5bbVo0VtzmjOA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@typescript-eslint/types": "8.37.0",
+        "@typescript-eslint/visitor-keys": "8.37.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.37.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.37.0.tgz",
+      "integrity": "sha512-1/YHvAVTimMM9mmlPvTec9NP4bobA1RkDbMydxG8omqwJJLEW/Iy2C4adsAESIXU3WGLXFHSZUU+C9EoFWl4Zg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
+      "version": "8.37.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.37.0.tgz",
+      "integrity": "sha512-ax0nv7PUF9NOVPs+lmQ7yIE7IQmAf8LGcXbMvHX5Gm+YJUYNAl340XkGnrimxZ0elXyoQJuN5sbg6C4evKA4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.37.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.37.0.tgz",
+      "integrity": "sha512-zuWDMDuzMRbQOM+bHyU4/slw27bAUEcKSKKs3hcv2aNnc/tvE/h7w60dwVw8vnal2Pub6RT1T7BI8tFZ1fE+yg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.37.0",
+        "@typescript-eslint/tsconfig-utils": "8.37.0",
+        "@typescript-eslint/types": "8.37.0",
+        "@typescript-eslint/visitor-keys": "8.37.0",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.3.2",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.37.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.37.0.tgz",
+      "integrity": "sha512-YzfhzcTnZVPiLfP/oeKtDp2evwvHLMe0LOy7oe+hb9KKIumLNohYS9Hgp1ifwpu42YWxhZE8yieggz6JpqO/1w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@typescript-eslint/types": "8.37.0",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@typescript-eslint/project-service": {
@@ -8625,7 +8792,7 @@
     },
     "packages/babylon-proto-ts": {
       "name": "@babylonlabs-io/babylon-proto-ts",
-      "version": "1.0.2",
+      "version": "1.2.1",
       "license": "ISC",
       "dependencies": {
         "@bufbuild/protobuf": "^2.2.0",
@@ -8659,13 +8826,11 @@
     },
     "packages/example-lib": {
       "name": "@babylonlabs-io/example-lib",
-      "version": "0.1.0",
-      "extraneous": true
+      "version": "0.1.0"
     },
     "packages/example-lib2": {
       "name": "@babylonlabs-io/example-lib2",
       "version": "0.1.0",
-      "extraneous": true,
       "dependencies": {
         "@babylonlabs-io/example-lib": "*"
       }
@@ -8673,7 +8838,6 @@
     "packages/example-lib3": {
       "name": "@babylonlabs-io/example-lib3",
       "version": "0.1.0",
-      "extraneous": true,
       "dependencies": {
         "@babylonlabs-io/example-lib2": "*"
       }

--- a/packages/babylon-proto-ts/package.json
+++ b/packages/babylon-proto-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@babylonlabs-io/babylon-proto-ts",
-  "version": "1.0.2",
+  "version": "1.2.1",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {

--- a/packages/babylon-proto-ts/src/constants.ts
+++ b/packages/babylon-proto-ts/src/constants.ts
@@ -4,3 +4,4 @@ export const REGISTRY_TYPE_URLS = {
   MsgCreateBTCDelegation: "/babylon.btcstaking.v1.MsgCreateBTCDelegation",
   MsgWithdrawReward: "/babylon.incentive.MsgWithdrawReward",
 };
+export const foo = 'bar';

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -4,7 +4,8 @@ import { releaseChangelog, releasePublish, releaseVersion } from 'nx/release';
 const release = async () => {
   const { workspaceVersion, projectsVersionData } = await releaseVersion({
     gitCommit: false,
-    gitTag: true,
+    gitTag: false,
+    gitPush: false,
     verbose: true,
   });
 
@@ -21,7 +22,8 @@ const release = async () => {
     versionData: projectsVersionData,
     version: workspaceVersion,
     gitCommit: false,
-    gitTag: false,
+    gitTag: true,
+    gitPush: false,
     verbose: true,
   });
 


### PR DESCRIPTION
This PR fixes two issues:
* release change log should be working now
<img width="844" height="141" alt="image" src="https://github.com/user-attachments/assets/3a643f56-6f50-4ff3-89bd-f22e47b35e82" />

* enforcing the scope in commit message to avoid release of packages when non project related files are updated - for example pacakge-lock.json. This is the only workaround I can find.