### PR TITLE
feat(packages): baby client to support get validator set

### DIFF
--- a/packages/babylon-proto-ts/src/lib/lcd/baby.ts
+++ b/packages/babylon-proto-ts/src/lib/lcd/baby.ts
@@ -99,6 +99,23 @@ const createBabylonClient = ({ request }: Dependencies) => ({
       });
     }
   },
+
+  async getValidatorSet(epoch: number): Promise<{
+    addr: string;
+    power: string;
+  }[]> {
+    try {
+      return await fetchAllPages(
+        request,
+        `/babylon/epoching/v1/epochs/${epoch}/validator_set`,
+        "validators",
+      );
+    } catch (error: unknown) {
+      throw new Error(`Failed to fetch validator set for epoch ${epoch}`, {
+        cause: error,
+      });
+    }
+  },
 });
 
 export default createBabylonClient;


### PR DESCRIPTION
We will use LCD endpoint https://babylon-testnet-api.nodes.guru/babylon/epoching/v1/epochs/4922/validator_set to get the validator set which should vote in a given epoch.

This will be used to help determine if a validator is active