### PR TITLE
feat(packages): add fluid prop and iconProps support to Accordion

### DIFF
--- a/packages/babylon-core-ui/src/components/Accordion/Accordion.css
+++ b/packages/babylon-core-ui/src/components/Accordion/Accordion.css
@@ -1,6 +1,10 @@
 .bbn-accordion {
   @apply transition-opacity;
 
+  &-fluid {
+    @apply w-full;
+  }
+
   &-summary {
     @apply text-accent-primary relative cursor-pointer pr-10 transition-colors;
   }

--- a/packages/babylon-core-ui/src/components/Accordion/Accordion.tsx
+++ b/packages/babylon-core-ui/src/components/Accordion/Accordion.tsx
@@ -21,6 +21,7 @@ export interface AccordionProps {
   onChange?: (expanded: boolean) => void;
   className?: string;
   disabled?: boolean;
+  fluid?: boolean;
 }
 
 export function Accordion({
@@ -29,6 +30,7 @@ export function Accordion({
   onChange,
   className,
   disabled = false,
+  fluid = false,
   children,
 }: PropsWithChildren<AccordionProps>) {
   const [expanded = false, setExpanded] = useControlledState({
@@ -53,7 +55,7 @@ export function Accordion({
 
   return (
     <Context.Provider value={context}>
-      <div className={twJoin("bbn-accordion", disabled && "bbn-accordion-disabled", className)}>{children}</div>
+      <div className={twJoin("bbn-accordion", disabled && "bbn-accordion-disabled", fluid && "bbn-accordion-fluid", className)}>{children}</div>
     </Context.Provider>
   );
 }

--- a/packages/babylon-core-ui/src/components/Accordion/components/AccordionSummary.tsx
+++ b/packages/babylon-core-ui/src/components/Accordion/components/AccordionSummary.tsx
@@ -1,18 +1,20 @@
 import { type PropsWithChildren, type ReactNode, useContext } from "react";
 import { twJoin } from "tailwind-merge";
 
-import { IconButton } from "@/components/Button";
+import { IconButton, IconButtonProps } from "@/components/Button";
 import { Context } from "../Accordion";
 
 interface AccordionSummaryProps {
   renderIcon?: (expanded: boolean) => ReactNode;
   className?: string;
   iconClassName?: string;
+  iconProps?: IconButtonProps;
 }
 
 export function AccordionSummary({
   className,
   iconClassName,
+  iconProps,
   children,
   renderIcon = () => null,
 }: PropsWithChildren<AccordionSummaryProps>) {
@@ -22,7 +24,7 @@ export function AccordionSummary({
   return (
     <div className={twJoin("bbn-accordion-summary", className)} onClick={toggle}>
       {children}
-      {icon && <IconButton className={twJoin("bbn-accordion-icon", iconClassName)}>{icon}</IconButton>}
+      {icon && <IconButton className={twJoin("bbn-accordion-icon", iconClassName)} {...iconProps}>{icon}</IconButton>}
     </div>
   );
 }


### PR DESCRIPTION
- Add fluid prop to AccordionProps interface  
- Add iconProps support to AccordionSummary component
- Add bbn-accordion-fluid CSS class for full-width layouts

Part of babylonlabs-io/simple-staking#1423