### PR TITLE
feat(packages): fix Input padding when suffix is present

### DIFF
--- a/packages/babylon-core-ui/src/components/Form/Input.css
+++ b/packages/babylon-core-ui/src/components/Form/Input.css
@@ -21,6 +21,10 @@
     @apply pointer-events-none opacity-50;
   }
 
+  &.bbn-input-has-suffix {
+    @apply pr-2;
+  }
+
   &-field {
     @apply placeholder-accent-disabled/50 w-full bg-transparent text-sm outline-none;
   }

--- a/packages/babylon-core-ui/src/components/Form/Input.tsx
+++ b/packages/babylon-core-ui/src/components/Form/Input.tsx
@@ -14,7 +14,7 @@ export interface InputProps
 export const Input = forwardRef<HTMLInputElement, InputProps>(
   ({ className, prefix, suffix, disabled = false, state = "default", ...props }, ref) => {
     return (
-      <div className={twJoin("bbn-input", disabled && "bbn-input-disabled", `bbn-input-${state}`)}>
+      <div className={twJoin("bbn-input", `bbn-input-${state}`, disabled && "bbn-input-disabled", suffix && "bbn-input-has-suffix")}>
         {prefix && <div className="bbn-input-prefix">{prefix}</div>}
         <input ref={ref} className={twJoin("bbn-input-field", className)} disabled={disabled} {...props} />
         {suffix && <div className="bbn-input-suffix">{suffix}</div>}


### PR DESCRIPTION
- Fix Input padding when suffix prop is present
- Add conditional CSS class for proper suffix spacing

Part of babylonlabs-io/simple-staking#1423