### PR TITLE
feat(packages): add variant prop to SubSection component

### DIFF
--- a/packages/babylon-core-ui/src/components/SubSection/SubSection.css
+++ b/packages/babylon-core-ui/src/components/SubSection/SubSection.css
@@ -1,0 +1,11 @@
+.bbn-subsection {
+  @apply flex rounded p-4 text-accent-primary;
+}
+
+.bbn-subsection-contained {
+  @apply bg-secondary-highlight;
+}
+
+.bbn-subsection-outlined {
+  @apply border border-current;
+}

--- a/packages/babylon-core-ui/src/components/SubSection/SubSection.tsx
+++ b/packages/babylon-core-ui/src/components/SubSection/SubSection.tsx
@@ -1,16 +1,22 @@
 import type { CSSProperties, ReactNode } from "react";
 import { twJoin } from "tailwind-merge";
+import "./SubSection.css";
 
 export const SubSection = ({
   children,
   style,
+  variant = "contained",
   className,
 }: {
   children: ReactNode;
   style?: CSSProperties;
+  variant?: "outlined" | "contained";
   className?: string;
 }) => (
-  <div className={twJoin("flex rounded bg-secondary-highlight p-4 text-accent-primary", className)} style={style}>
+  <div
+    className={twJoin("bbn-subsection", `bbn-subsection-${variant}`, className)}
+    style={style}
+  >
     {children}
   </div>
 );


### PR DESCRIPTION
- Add variant prop: outlined | contained to SubSection component
- Add CSS classes for variant styling

Part of babylonlabs-io/simple-staking#1423