### PR TITLE
feat(packages): add initial eligibility dashboard structure with mock data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22229,7 +22229,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
       "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "react": "*"
@@ -26273,7 +26272,8 @@
       "name": "@babylonlabs-io/babylon-campaigns",
       "version": "0.0.0-semantic-release",
       "dependencies": {
-        "@babylonlabs-io/core-ui": "*"
+        "@babylonlabs-io/core-ui": "*",
+        "react-icons": "^5.3.0"
       },
       "devDependencies": {
         "@chromatic-com/storybook": "^3.2.2",

--- a/packages/babylon-campaigns/package.json
+++ b/packages/babylon-campaigns/package.json
@@ -85,6 +85,7 @@
     ]
   },
   "dependencies": {
-    "@babylonlabs-io/core-ui": "*"
+    "@babylonlabs-io/core-ui": "*",
+    "react-icons": "^5.0.0"
   }
 }

--- a/packages/babylon-campaigns/package.json
+++ b/packages/babylon-campaigns/package.json
@@ -86,6 +86,6 @@
   },
   "dependencies": {
     "@babylonlabs-io/core-ui": "*",
-    "react-icons": "^5.0.0"
+    "react-icons": "^5.3.0"
   }
 }

--- a/packages/babylon-campaigns/src/eligibility-dashboard/EligibilityDashboard.tsx
+++ b/packages/babylon-campaigns/src/eligibility-dashboard/EligibilityDashboard.tsx
@@ -166,7 +166,7 @@ export const EligibilityDashboard: React.FC<EligibilityDashboardProps> = ({
         </div>
 
         <div className="mt-6">
-          <Button onClick={() => { }} fluid>
+          <Button onClick={() => { window.location.href = "/baby"; }} fluid>
             Stake More BABY To Boost Your Eligibility
           </Button>
         </div>

--- a/packages/babylon-campaigns/src/eligibility-dashboard/EligibilityDashboard.tsx
+++ b/packages/babylon-campaigns/src/eligibility-dashboard/EligibilityDashboard.tsx
@@ -106,7 +106,7 @@ export const EligibilityDashboard: React.FC<EligibilityDashboardProps> = ({
     <div className={`eligibility-dashboard ${className}`}>
       <Card className="flex w-full flex-col content-center justify-between">
         <div className="flex flex-col gap-6 mb-10">
-          <Heading variant="h5" className="">
+          <Heading variant="h5" className="text-accent-primary">
             Multi-Staking Eligibility
           </Heading>
 
@@ -120,7 +120,7 @@ export const EligibilityDashboard: React.FC<EligibilityDashboardProps> = ({
           </SubSection>
         </div>
         <div className="flex flex-col gap-2 mb-10">
-          <Heading variant="h6" className="">
+          <Heading variant="h6" className="text-accent-primary">
             Your Eligibility
           </Heading>
           <List orientation="horizontal">
@@ -137,7 +137,7 @@ export const EligibilityDashboard: React.FC<EligibilityDashboardProps> = ({
         </div>
 
         <SubSection className="mb-10" variant="outlined">
-          <Accordion fluid className="b-text-primary">
+          <Accordion fluid>
             <AccordionSummary
               className="b-p-2"
               renderIcon={expanded => (expanded ? <AiOutlineMinus /> : <AiOutlinePlus />)}
@@ -145,7 +145,7 @@ export const EligibilityDashboard: React.FC<EligibilityDashboardProps> = ({
                 size: "small",
               }}
             >
-              <Heading variant="h6">
+              <Heading variant="h6" className="text-accent-primary">
                 BTC Stakes Eligibility Overview
               </Heading>
             </AccordionSummary>
@@ -159,7 +159,7 @@ export const EligibilityDashboard: React.FC<EligibilityDashboardProps> = ({
         </SubSection>
 
         <div className="flex flex-col gap-2 mb-4">
-          <Heading variant="h6" className="">
+          <Heading variant="h6" className="text-accent-primary">
             Projected Multi-staking Eligibility
           </Heading>
           <Table fluid data={multiStakingEligibilityRows} columns={multiStakingEligibilityColumns} />

--- a/packages/babylon-campaigns/src/eligibility-dashboard/EligibilityDashboard.tsx
+++ b/packages/babylon-campaigns/src/eligibility-dashboard/EligibilityDashboard.tsx
@@ -1,22 +1,173 @@
 import React from "react";
-import { Card, Heading, Button } from "@babylonlabs-io/core-ui";
+import {
+  Card,
+  Heading,
+  Input,
+  Button,
+  FormControl,
+  ListItem,
+  List,
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
+  Table,
+  Text,
+  Copy,
+  CopyIcon,
+  ColumnProps,
+  DisplayHash,
+  SubSection,
+} from "@babylonlabs-io/core-ui";
+import { MdCancel } from "react-icons/md";
+import { AiOutlinePlus, AiOutlineMinus } from "react-icons/ai";
 
 export interface EligibilityDashboardProps {
   className?: string;
 }
+
+type EligibilityOverviewStakeRow = {
+  id: string;
+  txHash: string;
+  stakedOn: string; // ISO date
+  amountBtc: number;
+  eligibility: 'Eligible' | 'Ineligible' | 'Exceed Allocation';
+};
+
+const eligibilityOverviewColumns: ColumnProps<EligibilityOverviewStakeRow>[] = [
+  {
+    key: 'txHash',
+    header: 'Stake Tx Hash',
+    frozen: 'left',
+    render: (_value, row) => (
+      <div className="flex items-center gap-2">
+        <DisplayHash value={row.txHash} symbols={6} />
+        <Copy value={row.txHash}>
+          <CopyIcon size={14} className="text-accent-secondary" />
+        </Copy>
+      </div>
+    ),
+    sorter: (a, b) => a.txHash.localeCompare(b.txHash),
+  },
+  {
+    key: 'stakedOn',
+    header: 'Staked On',
+    render: (_value, row) =>
+      new Date(row.stakedOn).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' }),
+    sorter: (a, b) => +new Date(a.stakedOn) - +new Date(b.stakedOn),
+  },
+  {
+    key: 'amountBtc',
+    header: 'Amount',
+    render: (_value, row) => `${row.amountBtc} BTC`,
+    sorter: (a, b) => a.amountBtc - b.amountBtc,
+  },
+  {
+    key: 'eligibility',
+    header: 'Eligibility',
+    render: (_value, row) => {
+      return <Text variant="body2">{row.eligibility}</Text>;
+    },
+  },
+];
+
+const eligibilityOverviewRows: EligibilityOverviewStakeRow[] = [
+  { id: '1', txHash: '609b44H...9806D6', stakedOn: '2025-09-02', amountBtc: 0.05, eligibility: 'Eligible' },
+  { id: '2', txHash: '609b44H...9806D6', stakedOn: '2025-09-01', amountBtc: 0.0025, eligibility: 'Eligible' },
+  { id: '3', txHash: '609b44H...9806D6', stakedOn: '2025-08-10', amountBtc: 0.05, eligibility: 'Ineligible' },
+  { id: '4', txHash: '609b44H...9806D6', stakedOn: '2025-08-05', amountBtc: 0.0025, eligibility: 'Exceed Allocation' },
+];
+
+type MultiStakingEligibilityRow = {
+  id: string;
+  title: string;
+  amount: string;
+};
+
+const multiStakingEligibilityColumns: ColumnProps<MultiStakingEligibilityRow>[] = [
+  {
+    key: 'title',
+    header: '',
+  },
+  {
+    key: 'amount',
+    header: '',
+  },
+];
+
+const multiStakingEligibilityRows: MultiStakingEligibilityRow[] = [
+  { id: '1', title: 'Projected BABY Staking Points', amount: '205678.75' },
+  { id: '2', title: 'Projected Multi-Staking Amount', amount: '152.5 BTC' },
+];
 
 export const EligibilityDashboard: React.FC<EligibilityDashboardProps> = ({
   className = "",
 }) => {
   return (
     <div className={`eligibility-dashboard ${className}`}>
-      <Card className="p-6">
-        <Heading variant="h2" className="mb-4 text-accent-primary">
-          Eligibility Dashboard
-        </Heading>
+      <Card className="flex w-full flex-col content-center justify-between">
+        <div className="flex flex-col gap-6 mb-10">
+          <Heading variant="h5" className="">
+            Multi-Staking Eligibility
+          </Heading>
+
+          <SubSection>
+            <FormControl label="Use this tool to check if your BTC stakes qualify for Phase 3. Simply enter your BABY wallet address to view your eligible BTC stake total, the minimum BABY staking requirement, and how much more BABY you may need to stake. If your stakes do not yet meet the requirement, you will have the option to stake additional BABY directly from this page." hint="" state="default">
+              <Input
+                placeholder="BABY address"
+                suffix={<MdCancel size={24} className="cursor-pointer" />}
+              />
+            </FormControl>
+          </SubSection>
+        </div>
+        <div className="flex flex-col gap-2 mb-10">
+          <Heading variant="h6" className="">
+            Your Eligibility
+          </Heading>
+          <List orientation="horizontal">
+            <ListItem
+              title="BABY Staking Points"
+              value="23457678.23"
+              className="[&_div]:items-center"
+            />
+            <ListItem
+              title="Eligible BTC for Multi-Staking"
+              value="1.5 BTC"
+            />
+          </List>
+        </div>
+
+        <SubSection className="mb-10" variant="outlined">
+          <Accordion fluid className="b-text-primary">
+            <AccordionSummary
+              className="b-p-2"
+              renderIcon={expanded => (expanded ? <AiOutlineMinus /> : <AiOutlinePlus />)}
+              iconProps={{
+                size: "small",
+              }}
+            >
+              <Heading variant="h6">
+                BTC Stakes Eligibility Overview
+              </Heading>
+            </AccordionSummary>
+            <AccordionDetails
+              className="b-p-2 pt-6"
+              unmountOnExit
+            >
+              <Table fluid data={eligibilityOverviewRows} columns={eligibilityOverviewColumns} />
+            </AccordionDetails>
+          </Accordion>
+        </SubSection>
+
+        <div className="flex flex-col gap-2 mb-4">
+          <Heading variant="h6" className="">
+            Projected Multi-staking Eligibility
+          </Heading>
+          <Table fluid data={multiStakingEligibilityRows} columns={multiStakingEligibilityColumns} />
+        </div>
+
         <div className="mt-6">
-          <Button onClick={() => {}} variant="outlined">
-            Check eligibility
+          <Button onClick={() => { }} fluid>
+            Stake More BABY To Boost Your Eligibility
           </Button>
         </div>
       </Card>

--- a/packages/babylon-campaigns/src/index.css
+++ b/packages/babylon-campaigns/src/index.css
@@ -1,1 +1,5 @@
 @import "@babylonlabs-io/core-ui/style.css";
+
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/packages/babylon-campaigns/tsconfig.json
+++ b/packages/babylon-campaigns/tsconfig.json
@@ -1,7 +1,17 @@
 {
   "extends": "../../tsconfig.base.json",
   "files": [],
-  "references": [{ "path": "./tsconfig.lib.json" }, { "path": "./tsconfig.node.json" }],
+  "references": [
+    {
+      "path": "../babylon-core-ui"
+    },
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.node.json"
+    }
+  ],
   "compilerOptions": {
     "declaration": true
   }


### PR DESCRIPTION
Initial implementation of eligibility dashboard structure using existing core-ui components with mock data.

Depends on core-ui component enhancements from previous PRs.

- Basic dashboard structure with mock data
- Form input for wallet address
- Tables for eligibility overview and projections  
- Accordion for expandable sections
- Used existing core-ui components (some of them modified to accept custom props)

Not done yet:
- Theme/color customization (still using light theme defaults)
- Final responsive design polish

Part of babylonlabs-io/simple-staking#1423