### PR TITLE
fix(packages): color of list item title

### DIFF
--- a/packages/babylon-core-ui/src/components/List/List.css
+++ b/packages/babylon-core-ui/src/components/List/List.css
@@ -32,7 +32,7 @@
 
 
 .bbn-list-title {
-  @apply text-accent-primary;
+  @apply text-accent-secondary;
 
   &-adaptive {
     @apply text-base md:text-sm;


### PR DESCRIPTION
before:
<img width="463" height="102" alt="image" src="https://github.com/user-attachments/assets/c356a469-3e65-46d3-ba6d-ba5cb5a0c15f" />
<img width="481" height="108" alt="image" src="https://github.com/user-attachments/assets/2dc240d5-ee2d-42ce-8336-0a66e55ac41f" />

after:
<img width="467" height="102" alt="image" src="https://github.com/user-attachments/assets/ffdcd23a-a79a-47ab-ab0b-05c62be25bae" />
<img width="464" height="106" alt="image" src="https://github.com/user-attachments/assets/9dddcf4e-b611-47f2-aa6a-fac608110ad4" />

solves part of babylonlabs-io/simple-staking#1461