### PR TITLE
feat(packages): pass warning text through props on preview modal

### DIFF
--- a/packages/babylon-core-ui/src/widgets/sections/PreviewModal/PreviewModal.stories.tsx
+++ b/packages/babylon-core-ui/src/widgets/sections/PreviewModal/PreviewModal.stories.tsx
@@ -54,6 +54,10 @@ export const Default: Story = {
       unbonding: "~ 1 day",
       unbondingFee: "0 BTC",
     },
+    warnings: [
+      "1. No third party possesses your staked BTC. You are the only one who can unbond and withdraw your stake.",
+      "2. Your stake will first be sent to Babylon Genesis for verification (~20 seconds), then you will be prompted to submit it to the Bitcoin ledger. It will be marked as 'Pending' until it receives 10 Bitcoin confirmations.",
+    ],
   },
 };
 
@@ -82,8 +86,43 @@ export const ValidatorOnly: Story = {
       unbondingFee: "0 BTC",
     },
     visibleFields: ["Stake Amount", "Transaction Fees"],
-    attentionText:
-      "The staking transaction may take up to one (1) hour to process. Funds will not be deducted instantly; a sufficient available balance must be maintained until the transaction is confirmed and the deduction is finalized.",
+    warnings: [
+      "The staking transaction may take up to one (1) hour to process.",
+      "Funds will not be deducted instantly; maintain sufficient balance until confirmed.",
+    ],
     proceedLabel: "Stake",
+  },
+};
+
+export const CustomWarnings: Story = {
+  args: {
+    open: true,
+    processing: false,
+    onClose: () => { },
+    onProceed: () => { },
+    bsns: [
+      {
+        icon: <PlaceholderIcon text="B" bgColor="bg-black" />,
+        name: "Babylon Genesis",
+      },
+    ],
+    finalityProviders: [],
+    details: {
+      stakeAmount: "0.25 BTC",
+      feeRate: "4 sat/vB",
+      transactionFees: "0.00005 BTC",
+      term: {
+        blocks: "40320 blocks",
+        duration: "~ 4 weeks",
+      },
+      unbonding: "~ 1 day",
+      unbondingFee: "0 BTC",
+    },
+    warnings: [
+      "1. Custom line one for this integration.",
+      "2. Second line explaining processing behavior.",
+      "3. Optional extra note about timelock reset in expansions.",
+    ],
+    proceedLabel: "Proceed",
   },
 };

--- a/packages/babylon-core-ui/src/widgets/sections/PreviewModal/PreviewModal.tsx
+++ b/packages/babylon-core-ui/src/widgets/sections/PreviewModal/PreviewModal.tsx
@@ -53,8 +53,8 @@ interface PreviewModalProps {
    * Labels should match the exact ones defined internally (e.g. "Stake Amount", "Transaction Fees").
    */
   visibleFields?: string[];
-  /** Custom notice text displayed under "Attention!" heading. If not provided, default disclaimers are shown. */
-  attentionText?: string;
+  /** Warning lines rendered under the "Attention!" section. */
+  warnings: string[];
   /** Label for the primary action button; defaults to "Proceed to Signing" */
   proceedLabel?: string;
 }
@@ -68,7 +68,7 @@ export const PreviewModal = ({
   finalityProviders,
   details,
   visibleFields,
-  attentionText,
+  warnings,
   proceedLabel = "Proceed to Signing",
 }: PropsWithChildren<PreviewModalProps>) => {
   const allFields = [
@@ -165,23 +165,11 @@ export const PreviewModal = ({
           <Heading variant="h6" className="text-primary mb-2">
             Attention!
           </Heading>
-          {attentionText ? (
-            <Text variant="body2" className="text-secondary">
-              {attentionText}
+          {warnings.map((line, idx) => (
+            <Text key={idx} variant="body2" className="text-secondary">
+              {line}
             </Text>
-          ) : (
-            <>
-              <Text variant="body2" className="text-secondary">
-                1. No third party possesses your staked BTC. You are the only one who can unbond and withdraw your
-                stake.
-              </Text>
-              <Text variant="body2" className="text-secondary">
-                2. Your stake will first be sent to Babylon Genesis for verification (~20 seconds), then you will be
-                prompted to submit it to the Bitcoin ledger. It will be marked as 'Pending' until it receives 10
-                Bitcoin confirmations.
-              </Text>
-            </>
-          )}
+          ))}
         </div>
       </DialogBody>
       <DialogFooter className="flex flex-col gap-4 pb-8 pt-0 sm:flex-row">


### PR DESCRIPTION
<img width="1230" height="552" alt="Screenshot 2025-08-29 at 03 21 48" src="https://github.com/user-attachments/assets/1350fd4b-f96c-476d-9659-0aa3aff72264" />

Allows passing warning texts through props on the PreviewModal. This is so that we use the same logic for expansion and staking.

https://github.com/babylonlabs-io/simple-staking/issues/1406