### PR TITLE
feat(packages): support label as element in activity card details

### DIFF
--- a/packages/babylon-core-ui/src/widgets/sections/ActivityCard/ActivityCard.tsx
+++ b/packages/babylon-core-ui/src/widgets/sections/ActivityCard/ActivityCard.tsx
@@ -4,7 +4,7 @@ import { ActivityCardAmountSection } from "./components/ActivityCardAmountSectio
 import { ActivityCardDetailsSection } from "./components/ActivityCardDetailsSection";
 
 export interface ActivityCardDetailItem {
-  label: string;
+  label: string | React.ReactNode;
   value: string | React.ReactNode;
   collapsible?: boolean;
   nestedDetails?: ActivityCardDetailItem[];

--- a/packages/babylon-core-ui/src/widgets/sections/ActivityCard/components/ActivityCardDetailsSection.tsx
+++ b/packages/babylon-core-ui/src/widgets/sections/ActivityCard/components/ActivityCardDetailsSection.tsx
@@ -13,7 +13,7 @@ interface ActivityCardDetailsSectionProps {
 }
 
 interface DetailRowProps {
-  label: string;
+  label: string | React.ReactNode;
   value: string | React.ReactNode;
   collapsible?: boolean;
   nestedDetails?: ActivityCardDetailItem[];


### PR DESCRIPTION
`<Hint>` element should be used to show tooltip in this issue: https://github.com/babylonlabs-io/simple-staking/issues/1488

So we need support for `React.ReactNode` label in `ActivityCard`