### PR TITLE
fix(packages): position of hint tooltip for all placements

### DIFF
--- a/packages/babylon-core-ui/src/components/Hint/Hint.tsx
+++ b/packages/babylon-core-ui/src/components/Hint/Hint.tsx
@@ -43,7 +43,7 @@ export function Hint({
   className,
   placement = "top",
   tooltipVariant = "primary",
-  offset = [0, 8],
+  offset = [8, 8],
 }: PropsWithChildren<HintProps>) {
   const id = useId();
   const statusColor = STATUS_COLORS[status];
@@ -51,10 +51,24 @@ export function Hint({
   // Create custom middleware for horizontal offset
   const customOffset = {
     name: 'customOffset',
-    fn: ({ x, y }: { x: number; y: number }) => ({
-      x: x + offset[0], // horizontal offset
-      y: y + offset[1], // vertical offset
-    }),
+    fn: ({ x, y, placement }: any) => {
+      let nextX = x;
+      let nextY = y;
+
+      // Apply offsets based on placement direction so that positive offsets
+      // move the tooltip away from the reference element on the main axis
+      if (placement === 'top') {
+        nextY = y - offset[1];
+      } else if (placement === 'bottom') {
+        nextY = y + offset[1];
+      } else if (placement === 'left') {
+        nextX = x - offset[0];
+      } else if (placement === 'right') {
+        nextX = x + offset[0];
+      }
+
+      return { x: nextX, y: nextY };
+    },
   };
 
   if (!tooltip) {
@@ -88,7 +102,6 @@ export function Hint({
           }
           data-tooltip-place={placement}
           data-tooltip-position-strategy="fixed"
-          data-tooltip-offset={0}
           data-tooltip-wrapper="span"
         >
           {children}
@@ -122,7 +135,6 @@ export function Hint({
           }
           data-tooltip-place={placement}
           data-tooltip-position-strategy="fixed"
-          data-tooltip-offset={0}
           data-tooltip-wrapper="span"
         >
           {tooltipIcon}


### PR DESCRIPTION
before:
<img width="770" height="254" alt="image" src="https://github.com/user-attachments/assets/c323c818-b0a9-49ea-8b40-4d310f9973fe" />

after:
- without icon:
  <img width="304" height="102" alt="image" src="https://github.com/user-attachments/assets/a87621a1-d145-47db-a441-6b4558f6103d" />
  <img width="308" height="107" alt="image" src="https://github.com/user-attachments/assets/5f7cd020-9e83-446a-87d8-2a9a51e394e0" />
  <img width="392" height="80" alt="image" src="https://github.com/user-attachments/assets/874d5f50-73a5-41a3-8dcf-2ebb44734530" />
  <img width="501" height="96" alt="image" src="https://github.com/user-attachments/assets/4ac771a8-69c5-4f3c-8acf-5f52cf03d3f5" />

- with icon:
  <img width="316" height="65" alt="image" src="https://github.com/user-attachments/assets/fb7fbdeb-9448-4462-85ee-b8f2fff0db70" />
  <img width="447" height="62" alt="image" src="https://github.com/user-attachments/assets/ff92a52d-c1e7-4795-8396-e8a65788d8d9" />
  <img width="313" height="93" alt="image" src="https://github.com/user-attachments/assets/92ca16df-05d4-40cf-a90c-0eb9b5926b26" />
  <img width="325" height="93" alt="image" src="https://github.com/user-attachments/assets/f9268ba0-d31b-4151-aebd-a0fe05bd4c31" />
