### PR TITLE
feat(packages): timelock renewal once

### DIFF
--- a/services/simple-staking/src/ui/common/components/Activity/components/ExpansionButton.tsx
+++ b/services/simple-staking/src/ui/common/components/Activity/components/ExpansionButton.tsx
@@ -9,6 +9,7 @@ interface ExpansionButtonProps {
   onClick: () => void;
   className?: string;
   disabled?: boolean;
+  hideArrow?: boolean;
 }
 
 export function ExpansionButton({
@@ -18,6 +19,7 @@ export function ExpansionButton({
   onClick,
   className = "",
   disabled = false,
+  hideArrow = false,
 }: ExpansionButtonProps) {
   return (
     <button
@@ -45,10 +47,12 @@ export function ExpansionButton({
           <span className="text-sm text-accent-primary">{text}</span>
           {counter && <span className="text-xs">{counter}</span>}
         </div>
-        <MdKeyboardArrowDown
-          size={24}
-          className="-rotate-90 transform text-current"
-        />
+        {!hideArrow && (
+          <MdKeyboardArrowDown
+            size={24}
+            className="-rotate-90 transform text-current"
+          />
+        )}
       </div>
     </button>
   );

--- a/services/simple-staking/src/ui/common/components/Activity/components/StakeExpansionSection.tsx
+++ b/services/simple-staking/src/ui/common/components/Activity/components/StakeExpansionSection.tsx
@@ -2,6 +2,7 @@ import {
   Accordion,
   AccordionDetails,
   AccordionSummary,
+  Hint,
   Text,
 } from "@babylonlabs-io/core-ui";
 import { AiOutlineMinus, AiOutlinePlus } from "react-icons/ai";
@@ -43,6 +44,7 @@ export function StakeExpansionSection({
   const {
     openVerifiedExpansionModalForDelegation,
     getVerifiedExpansionInfoForDelegation,
+    hasVerifiedTimelockRenewal,
   } = useVerifiedStakingExpansionService();
   const { isLoading: isUTXOsLoading } = useAppState();
 
@@ -136,6 +138,24 @@ export function StakeExpansionSection({
     delegation.stakingTxHashHex,
   );
 
+  // Check if this delegation has a verified timelock renewal
+  const hasVerifiedRenewal = hasVerifiedTimelockRenewal(
+    delegation.stakingTxHashHex,
+  );
+
+  // Create the renew button once with conditional arrow hiding
+  const renewButton = (
+    <ExpansionButton
+      Icon={iconRenew}
+      text="Renew Staking Term"
+      onClick={handleRenewStakingTerm}
+      disabled={
+        processing || isUTXOsLoading || isPendingExpansion || hasVerifiedRenewal
+      }
+      hideArrow={hasVerifiedRenewal}
+    />
+  );
+
   return (
     <div className="w-full">
       <Accordion
@@ -171,12 +191,16 @@ export function StakeExpansionSection({
                 isPendingExpansion
               }
             />
-            <ExpansionButton
-              Icon={iconRenew}
-              text="Renew Staking Term"
-              onClick={handleRenewStakingTerm}
-              disabled={processing || isUTXOsLoading || isPendingExpansion}
-            />
+            {hasVerifiedRenewal ? (
+              <Hint
+                tooltip="A timelock renewal is already verified. Please check 'Verified Stake Expansion' to complete it."
+                placement="top"
+              >
+                {renewButton}
+              </Hint>
+            ) : (
+              renewButton
+            )}
             <ExpansionButton
               Icon={iconHistory}
               text="Expansion History"


### PR DESCRIPTION
- when we renew the timelock and it is in `verified` state, we need to disable the button since it will produce the same exact `tx` hash
- added a tooltip (`Hint`) close to our disabled button so that user knows where to find his expansion

OG Staking:
<img width="789" height="568" alt="Screenshot_2025-09-10_16-15-52" src="https://github.com/user-attachments/assets/7ef3834c-c8ee-49dc-b521-69417d7f2323" />

Renewal verified:
<img width="785" height="619" alt="Screenshot_2025-09-10_16-16-52" src="https://github.com/user-attachments/assets/f92929fb-ea1a-469e-9bc0-1b84e344f05a" />

Tooltip via `Hint` component
<img width="785" height="619" alt="Screenshot_2025-09-10_16-16-52" src="https://github.com/user-attachments/assets/de0b66b7-946a-49b6-acf1-c1d7a8e4c4fb" />

Closes https://github.com/babylonlabs-io/babylon-toolkit/issues/158