### PR TITLE
fix(packages): undefined rollup allowlist

### DIFF
--- a/services/simple-staking/src/ui/common/services/finalityProviderFilterService.ts
+++ b/services/simple-staking/src/ui/common/services/finalityProviderFilterService.ts
@@ -45,9 +45,16 @@ const BSN_CONFIG = {
 
       return {
         allowlisted: (fp: FinalityProvider) =>
-          hasAllowlist ? allowSet.has(normalizeHex(fp.btcPk)) : true,
-        "non-allowlisted": (fp: FinalityProvider) =>
-          hasAllowlist ? !allowSet.has(normalizeHex(fp.btcPk)) : true,
+          hasAllowlist ? allowSet.has(normalizeHex(fp.btcPk)) : false,
+        "non-allowlisted": (fp: FinalityProvider) => {
+          if (!hasAllowlist) {
+            return (
+              fp.state === FinalityProviderStateEnum.ACTIVE ||
+              fp.state === FinalityProviderStateEnum.INACTIVE
+            );
+          }
+          return !allowSet.has(normalizeHex(fp.btcPk));
+        },
         slashed: (fp: FinalityProvider) =>
           fp.state === FinalityProviderStateEnum.SLASHED,
         jailed: (fp: FinalityProvider) =>
@@ -60,7 +67,7 @@ const BSN_CONFIG = {
       "slashed",
       "jailed",
     ] as const,
-    fallback: "allowlisted" as const,
+    fallback: "non-allowlisted" as const, // Default to non-allowlisted
   },
 } as const;
 

--- a/services/simple-staking/tests/services/finalityProviderFilterService.test.ts
+++ b/services/simple-staking/tests/services/finalityProviderFilterService.test.ts
@@ -1,0 +1,87 @@
+import {
+  filterFinalityProvidersByBsn,
+  type FinalityProviderFilterState,
+} from "@/ui/common/services/finalityProviderFilterService";
+import { 
+  FinalityProviderState as FinalityProviderStateEnum,
+  type FinalityProvider 
+} from "@/ui/common/types/finalityProviders";
+import type { Bsn } from "@/ui/common/types/bsn";
+
+describe("BSN Allowlist Filter Bug Fix", () => {
+  const mockFPs: FinalityProvider[] = [
+    { btcPk: "0x1111", state: FinalityProviderStateEnum.ACTIVE } as FinalityProvider,
+    { btcPk: "0x2222", state: FinalityProviderStateEnum.INACTIVE } as FinalityProvider,
+    { btcPk: "0x3333", state: FinalityProviderStateEnum.SLASHED } as FinalityProvider,
+  ];
+
+  const rollupWithAllowlist: Bsn = {
+    id: "test", name: "Test", description: "", logoUrl: "", type: "ROLLUP",
+    allowlist: ["1111"],
+  };
+
+  const rollupWithoutAllowlist: Bsn = {
+    id: "test", name: "Test", description: "", logoUrl: "", type: "ROLLUP",
+  };
+
+  const filter: FinalityProviderFilterState = {
+    searchTerm: "", providerStatus: "", allowlistStatus: "",
+  };
+
+  describe("ROLLUP without allowlist", () => {
+    it("should return NO allowlisted FPs when no allowlist exists", () => {
+      const result = filterFinalityProvidersByBsn(
+        mockFPs,
+        { ...filter, providerStatus: "allowlisted" },
+        rollupWithoutAllowlist,
+      );
+      
+      expect(result).toHaveLength(0);
+    });
+
+    it("should return only active/inactive FPs as non-allowlisted when no allowlist exists", () => {
+      const result = filterFinalityProvidersByBsn(
+        mockFPs,
+        { ...filter, providerStatus: "non-allowlisted" },
+        rollupWithoutAllowlist,
+      );
+      
+      expect(result).toHaveLength(2);
+      expect(result[0].state).toBe(FinalityProviderStateEnum.ACTIVE);
+      expect(result[1].state).toBe(FinalityProviderStateEnum.INACTIVE);
+    });
+  });
+
+  describe("ROLLUP with allowlist", () => {
+    it("should filter allowlisted providers correctly", () => {
+      const result = filterFinalityProvidersByBsn(
+        mockFPs,
+        { ...filter, providerStatus: "allowlisted" },
+        rollupWithAllowlist,
+      );
+      
+      expect(result).toHaveLength(1);
+      expect(result[0].btcPk).toBe("0x1111");
+    });
+
+    it("should filter non-allowlisted providers correctly", () => {
+      const result = filterFinalityProvidersByBsn(
+        mockFPs,
+        { ...filter, providerStatus: "non-allowlisted" },
+        rollupWithAllowlist,
+      );
+      
+      expect(result).toHaveLength(2);
+      expect(result[0].btcPk).toBe("0x2222");
+      expect(result[1].btcPk).toBe("0x3333");
+    });
+  });
+
+  describe("undefined BSN", () => {
+    it("handles undefined BSN gracefully", () => {
+      expect(() => {
+        filterFinalityProvidersByBsn(mockFPs, filter, undefined);
+      }).not.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
added test for fp filter service and fixed the null api allowlist return behaviour

<img width="888" height="794" alt="Screenshot 2025-09-16 at 4 00 59 PM" src="https://github.com/user-attachments/assets/75c9a28e-e87e-46e7-a4ae-67ca44c80e7c" />
<img width="892" height="785" alt="Screenshot 2025-09-16 at 4 00 56 PM" src="https://github.com/user-attachments/assets/28bd8a8a-665d-43ed-a6a2-8412fad7e1de" />
