### PR TITLE
fix(packages): show subset message on canon devnet

### DIFF
--- a/services/simple-staking/src/ui/baby/state/StakingState.tsx
+++ b/services/simple-staking/src/ui/baby/state/StakingState.tsx
@@ -115,7 +115,10 @@ function StakingState({ children }: PropsWithChildren) {
   );
 
   const isDisabled = useMemo(() => {
-    if (FeatureFlags.IsTestnetSunsetEnabled && bbnNetwork === "testnet") {
+    if (
+      FeatureFlags.IsTestnetSunsetEnabled &&
+      (bbnNetwork === "testnet" || bbnNetwork === "canonDevnet")
+    ) {
       return {
         title: "This testnet is sunsetting",
         message:


### PR DESCRIPTION
Allow devnet to show the subset message so that we can see what's going to be released on testnet
<img width="715" height="185" alt="image" src="https://github.com/user-attachments/assets/8139b5f2-0551-4693-b5cb-9fbdc03ee1bc" />
