### PR TITLE
feat(packages): co-staking API + node data calculations

### DIFF
--- a/services/simple-staking/src/ui/common/api/getAPR.ts
+++ b/services/simple-staking/src/ui/common/api/getAPR.ts
@@ -1,0 +1,18 @@
+import { API_ENDPOINTS } from "../constants/endpoints";
+import { CoStakingAPRResponse } from "../types/api/coStaking";
+
+import { apiWrapper } from "./apiWrapper";
+
+/**
+ * Fetch APR data from the backend API
+ * Returns APR values for BTC staking, BABY staking, Co-staking, and maximum APR
+ */
+export const getAPR = async (): Promise<CoStakingAPRResponse> => {
+  const { data } = await apiWrapper<CoStakingAPRResponse>(
+    "GET",
+    API_ENDPOINTS.APR,
+    "Error fetching APR data",
+  );
+
+  return data;
+};

--- a/services/simple-staking/src/ui/common/constants/endpoints.ts
+++ b/services/simple-staking/src/ui/common/constants/endpoints.ts
@@ -3,6 +3,7 @@ export const API_ENDPOINTS = {
 
   DELEGATION_V2: "/v2/delegation",
   DELEGATIONS_V2: "/v2/delegations",
+  APR: "/v2/apr",
   HEALTHCHECK: "/healthcheck",
   FINALITY_PROVIDERS: "/v1/finality-providers",
   STAKER_DELEGATIONS: "/v1/staker/delegations",

--- a/services/simple-staking/src/ui/common/types/api/coStaking.ts
+++ b/services/simple-staking/src/ui/common/types/api/coStaking.ts
@@ -1,4 +1,3 @@
-// TODO these types to be adjusted according to the actual API response
 export interface CoStakingParams {
   costaking_portion: string;
   score_ratio_btc_by_baby: string;
@@ -25,8 +24,34 @@ export interface CoStakingCurrentRewards {
   total_score: string;
 }
 
+/**
+ * APR data from backend /v2/apr endpoint
+ * These values are global and not user-specific
+ */
+export interface CoStakingAPRResponse {
+  /** Base APR for BTC staking */
+  btc_staking: number;
+  /** APR for BABY-only staking */
+  baby_staking: number;
+  /** Bonus APR for co-staking */
+  co_staking: number;
+  /** Maximum APR (btc_staking + baby_staking + co_staking) */
+  max_apr: number;
+}
+
+/**
+ * User-specific co-staking APR data
+ * These values are personalized based on the user's staking positions
+ */
 export interface CoStakingAPRData {
-  apr: number | null;
+  /** A% - User's current total APR (BTC APR + partial co-staking bonus) */
+  currentApr: number | null;
+  /** B% - Maximum APR user can earn at 100% eligibility (BTC APR + full co-staking bonus) */
+  boostApr: number | null;
+  /** X - Additional BABY tokens needed to reach 100% eligibility and boost APR */
+  additionalBabyNeeded: number;
+  /** Percentage of user's BTC stake that's eligible for co-staking rewards */
+  eligibilityPercentage: number;
   isLoading: boolean;
   error?: string;
 }

--- a/services/simple-staking/src/ui/common/utils/coStakingCalculations.ts
+++ b/services/simple-staking/src/ui/common/utils/coStakingCalculations.ts
@@ -67,3 +67,44 @@ export const formatBabyTokens = (value: number): string => {
   }
   return formatNumber(value, 2);
 };
+
+/**
+ * Calculates the user's current total APR based on their co-staking participation
+ *
+ * Co-staking APR is ADDITIVE - it's a bonus on top of BTC staking APR.
+ * Users earn:
+ * 1. Full BTC staking APR on their BTC stake
+ * 2. PLUS additional co-staking APR on the eligible portion of their BTC
+ *
+ * Formula: currentApr = btcStakingApr + (coStakingApr × eligibility%)
+ *
+ * @param activeSatoshis - Total satoshis staked by the user
+ * @param activeBaby - Total ubbn staked by the user
+ * @param scoreRatio - Score ratio (ubbn per satoshi required for full eligibility)
+ * @param btcStakingApr - Base BTC staking APR (earned on all BTC)
+ * @param coStakingApr - Co-staking bonus APR (earned on eligible BTC only)
+ * @returns User's current total APR (BTC APR + partial co-staking bonus)
+ */
+export const calculateCurrentAPR = (
+  activeSatoshis: number,
+  activeBaby: number,
+  scoreRatio: number,
+  btcStakingApr: number,
+  coStakingApr: number,
+): number => {
+  if (activeSatoshis === 0) return 0;
+  if (scoreRatio === 0) return btcStakingApr;
+
+  // Calculate eligibility percentage (what % of BTC qualifies for co-staking bonus)
+  const eligibilityPercentage =
+    calculateBTCEligibilityPercentage(
+      activeSatoshis.toString(),
+      activeBaby.toString(),
+      scoreRatio.toString(),
+    ) / 100;
+
+  // Current APR = Base BTC APR + (Co-staking bonus APR × eligibility)
+  const currentApr = btcStakingApr + coStakingApr * eligibilityPercentage;
+
+  return currentApr;
+};


### PR DESCRIPTION
Uses `API` and `node` for `X`, `A%`, `B%`

Requires https://github.com/babylonlabs-io/staking-api-service/pull/418 to be merged

Closes: https://github.com/babylonlabs-io/babylon-toolkit/issues/243