### PR TITLE
feat(packages): add TopBanner

### DIFF
--- a/packages/babylon-core-ui/src/components/TopBanner/TopBanner.css
+++ b/packages/babylon-core-ui/src/components/TopBanner/TopBanner.css
@@ -1,0 +1,20 @@
+.bbn-top-banner {
+  @apply flex items-center justify-between gap-3 px-4 py-3 h-16 cursor-pointer;
+  @apply border-b border-secondary-strokeLight;
+
+  &-content {
+    @apply flex justify-center items-center gap-2 flex-1 min-w-0;
+  }
+
+  &-message {
+    @apply truncate text-accent-primary;
+  }
+
+  &-dismiss-btn {
+    @apply flex-shrink-0 p-1 hover:bg-accent-primary/10 rounded transition-colors;
+  }
+
+  &-dismiss-icon {
+    @apply text-accent-primary;
+  }
+}

--- a/packages/babylon-core-ui/src/components/TopBanner/TopBanner.stories.tsx
+++ b/packages/babylon-core-ui/src/components/TopBanner/TopBanner.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { TopBanner } from "./TopBanner";
+import { InfoIcon } from "../Icons";
+
+const meta: Meta<typeof TopBanner> = {
+  component: TopBanner,
+  title: "Components/Data Display/Indicators/TopBanner",
+  tags: ["autodocs"],
+  argTypes: {
+    visible: {
+      control: "boolean",
+      description: "Whether the banner is visible",
+    },
+    message: {
+      control: "text",
+      description: "Banner message text",
+    },
+    onClick: {
+      action: "clicked",
+      description: "Callback when banner is clicked",
+    },
+    onDismiss: {
+      action: "dismissed",
+      description: "Callback when banner is dismissed",
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    visible: true,
+    message: "Boost Your BTC Staking Rewards",
+    onClick: () => console.log("Banner clicked"),
+    onDismiss: () => console.log("Banner dismissed"),
+  },
+};
+
+export const WithInfoIcon: Story = {
+  args: {
+    visible: true,
+    message: "Boost Your BTC Staking Rewards",
+    onClick: () => console.log("Banner clicked"),
+    onDismiss: () => console.log("Banner dismissed"),
+    icon: <InfoIcon size={20} variant="accent-primary" />,
+  },
+};
+
+export const Hidden: Story = {
+  args: {
+    visible: false,
+    message: "Boost Your BTC Staking Rewards",
+    onClick: () => console.log("Banner clicked"),
+    onDismiss: () => console.log("Banner dismissed"),
+  },
+};

--- a/packages/babylon-core-ui/src/components/TopBanner/TopBanner.tsx
+++ b/packages/babylon-core-ui/src/components/TopBanner/TopBanner.tsx
@@ -1,0 +1,73 @@
+import { twJoin } from "tailwind-merge";
+import { CloseIcon } from "../Icons";
+import { Text } from "../Text";
+import "./TopBanner.css";
+
+export interface TopBannerProps {
+  /**
+   * Whether the banner is visible
+   */
+  visible: boolean;
+  /**
+   * Banner message text
+   */
+  message: string;
+  /**
+   * Callback when banner is clicked
+   */
+  onClick: () => void;
+  /**
+   * Callback when banner is dismissed
+   */
+  onDismiss: () => void;
+  /**
+   * Optional custom className
+   */
+  className?: string;
+  /**
+   * Optional custom icon
+   */
+  icon?: React.ReactNode;
+}
+
+export const TopBanner = ({
+  visible,
+  message,
+  onClick,
+  onDismiss,
+  className,
+  icon,
+}: TopBannerProps) => {
+  if (!visible) {
+    return null;
+  }
+
+  const handleDismiss = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onDismiss();
+  };
+
+  return (
+    <div
+      className={twJoin("bbn-top-banner", className)}
+      onClick={onClick}
+      role="button"
+      tabIndex={0}
+    >
+      <div className="bbn-top-banner-content">
+        {icon}
+        <Text variant="body2" className="bbn-top-banner-message">
+          {message}
+        </Text>
+      </div>
+      <button
+        onClick={handleDismiss}
+        className="bbn-top-banner-dismiss-btn"
+        aria-label="Dismiss banner"
+        type="button"
+      >
+        <CloseIcon size={16} className="bbn-top-banner-dismiss-icon" />
+      </button>
+    </div>
+  );
+};

--- a/packages/babylon-core-ui/src/components/TopBanner/index.ts
+++ b/packages/babylon-core-ui/src/components/TopBanner/index.ts
@@ -1,0 +1,1 @@
+export { TopBanner, type TopBannerProps } from "./TopBanner";

--- a/packages/babylon-core-ui/src/index.tsx
+++ b/packages/babylon-core-ui/src/index.tsx
@@ -28,6 +28,7 @@ export * from "./components/Icons";
 export * from "./components/Warning";
 export * from "./components/Hint";
 export * from "./components/DismissibleSubSection";
+export * from "./components/TopBanner";
 
 export * from "./elements/FinalityProviderLogo";
 export * from "./elements/FinalityProviderItem";

--- a/services/simple-staking/src/ui/common/components/CoStakingBanner/CoStakingBanner.tsx
+++ b/services/simple-staking/src/ui/common/components/CoStakingBanner/CoStakingBanner.tsx
@@ -1,0 +1,51 @@
+import { TopBanner } from "@babylonlabs-io/core-ui";
+import { useCallback } from "react";
+import { useNavigate } from "react-router";
+import { useSessionStorage } from "usehooks-ts";
+import { MdRocketLaunch } from "react-icons/md";
+
+import { useBalanceState } from "@/ui/common/state/BalanceState";
+import { getNetworkConfigBTC } from "@/ui/common/config/network/btc";
+
+const BANNER_DISMISSED_KEY = "bbn-costaking-banner-dismissed";
+
+export const CoStakingBanner = () => {
+  const navigate = useNavigate();
+  const { stakedBtcBalance } = useBalanceState();
+  const [dismissed, setDismissed] = useSessionStorage(
+    BANNER_DISMISSED_KEY,
+    false,
+  );
+  const { coinSymbol: btcCoinSymbol } = getNetworkConfigBTC();
+
+  // Only show banner if:
+  // 1. User has active BTC delegations (stakedBtcBalance > 0)
+  // 2. User hasn't dismissed the banner
+  const hasActiveDelegations = stakedBtcBalance > 0;
+  const shouldShowBanner = hasActiveDelegations && !dismissed;
+
+  const handleBannerClick = useCallback(() => {
+    navigate("/baby");
+  }, [navigate]);
+
+  const handleDismiss = useCallback(() => {
+    setDismissed(true);
+  }, [setDismissed]);
+
+  return (
+    <TopBanner
+      visible={shouldShowBanner}
+      message={`Boost Your ${btcCoinSymbol} Staking Rewards`}
+      onClick={handleBannerClick}
+      onDismiss={handleDismiss}
+      className="bg-gradient-to-b from-neutral-200 to-transparent dark:from-[#13323F]"
+      icon={
+        <MdRocketLaunch
+          size={24}
+          className="flex-shrink-0 text-info-light"
+          aria-hidden="true"
+        />
+      }
+    />
+  );
+};

--- a/services/simple-staking/src/ui/common/components/CoStakingBanner/index.ts
+++ b/services/simple-staking/src/ui/common/components/CoStakingBanner/index.ts
@@ -1,0 +1,1 @@
+export { CoStakingBanner } from "./CoStakingBanner";

--- a/services/simple-staking/src/ui/common/layout.tsx
+++ b/services/simple-staking/src/ui/common/layout.tsx
@@ -7,8 +7,10 @@ import { Network } from "@/ui/common/types/network";
 import "@/ui/globals.css";
 
 import { Banner } from "./components/Banner/Banner";
+import { CoStakingBanner } from "./components/CoStakingBanner";
 import { Footer } from "./components/Footer/Footer";
 import { Header } from "./components/Header/Header";
+import FF from "./utils/FeatureFlagService";
 
 export default function RootLayout() {
   const isMobile = useIsMobile();
@@ -25,6 +27,7 @@ export default function RootLayout() {
     >
       <div className="flex min-h-svh flex-col">
         <Banner />
+        {FF.IsCoStakingEnabled && <CoStakingBanner />}
         <Header />
 
         <Outlet />


### PR DESCRIPTION
- add `TopBanner` component in `core-ui` with stories
  - dismissible (session storage)
  - navigates to /baby on click
  - visible only for users with active BTC delegations
  - behind `IsCoStakingEnabled` flag

<img width="1481" height="234" alt="image" src="https://github.com/user-attachments/assets/4d8b3acb-0c86-49cd-af08-5ff7be677af1" />
<img width="1484" height="253" alt="image" src="https://github.com/user-attachments/assets/858ae0f0-3a4f-462f-a368-f8b3fb2da54e" />
<img width="1080" height="756" alt="image" src="https://github.com/user-attachments/assets/8e2ab129-273f-4654-9aee-a80c90048483" />
