### PR TITLE
fix: rollup darwin build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,9 @@
         "typescript-eslint": "^8.44.1",
         "uuid": "11.1.0",
         "vite-plugin-top-level-await": "^1.6.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-darwin-arm64": "4.52.4"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -6871,17 +6874,17 @@
       }
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.46.1",
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.4.tgz",
+      "integrity": "sha512-QRWSW+bVccAvZF6cbNZBJwAehmvG9NwfWHwMy4GbWi/BQIA/laTIktebT2ipVjNncqE6GLPxOok5hsECgAxGZg==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@routes/vault": {
       "resolved": "routes/vault",

--- a/package.json
+++ b/package.json
@@ -55,5 +55,8 @@
     "@morpho-org/blue-sdk": "^5.0.0",
     "@morpho-org/blue-sdk-viem": "^4.0.0",
     "@tanstack/react-query": "^5.90.2"
+  },
+  "optionalDependencies": {
+    "@rollup/rollup-darwin-arm64": "4.52.4"
   }
 }


### PR DESCRIPTION
This bump https://github.com/babylonlabs-io/babylon-toolkit/commit/3bd0528739589da4cd79d02d1ffc8432a04c3970 intorduced possible local installation problem:

```
Changed: Vite 5.4.10 → 6.3.5 in packages (babylon-core-ui, babylon-campaigns, babylon-wallet-connector)
Side Effect: This introduced rollup 4.46.1 (via vite 6.3.5's dependency on rollup: ^4.34.9)
Critical Bug: npm workspace marked @rollup/rollup-darwin-arm64 as "peer": true in package-lock.json
```

This PR:

1. Root package takes precedence over workspace package dependency resolution
2. It's explicitly requested by the root package, so npm marks it as a direct optional dependency, not a peer
3. In package-lock.json, it changes from "peer": true to a proper installation entry with resolved and integrity
4. npm will actually download and install the binary

