### PR TITLE
fix(packages): hide ctas if no data is available

### DIFF
--- a/services/simple-staking/src/ui/baby/components/CoStakingBoostSection/index.tsx
+++ b/services/simple-staking/src/ui/baby/components/CoStakingBoostSection/index.tsx
@@ -21,6 +21,7 @@ export function CoStakingBoostSection({
   const { delegations = [], isLoading } = useDelegationV2State();
   const {
     eligibility,
+    hasValidBoostData,
     isEnabled: isCoStakingEnabled,
     isLoading: isCoStakingLoading,
   } = useCoStakingState();
@@ -57,7 +58,7 @@ export function CoStakingBoostSection({
     !isLoading &&
     !isCoStakingLoading &&
     showCoStakingBoostSection &&
-    eligibility.additionalBabyNeeded > 0;
+    hasValidBoostData;
 
   return (
     shouldShowCoStakingBoostSection && (

--- a/services/simple-staking/src/ui/baby/widgets/StakingForm/index.tsx
+++ b/services/simple-staking/src/ui/baby/widgets/StakingForm/index.tsx
@@ -48,6 +48,7 @@ export default function StakingForm({
   const location = useLocation();
   const navigate = useNavigate();
   const { eligibility, isLoading: isCoStakingLoading } = useCoStakingState();
+  const { additionalBabyNeeded } = eligibility;
 
   const { babyStakeDraft, setBabyStakeDraft } = useFormPersistenceState();
   const formRef = useRef<FormRef<StakingFormFields>>(null);
@@ -97,22 +98,18 @@ export default function StakingForm({
     if (isCoStakingLoading) return;
 
     // Guard against zero or invalid values
-    if (eligibility.additionalBabyNeeded <= 0) return;
+    if (additionalBabyNeeded <= 0) return;
 
     if (formRef.current) {
-      formRef.current.setValue<"amount">(
-        "amount",
-        eligibility.additionalBabyNeeded,
-        {
-          shouldDirty: true,
-          shouldTouch: true,
-          shouldValidate: true,
-        },
-      );
+      formRef.current.setValue<"amount">("amount", additionalBabyNeeded, {
+        shouldDirty: true,
+        shouldTouch: true,
+        shouldValidate: true,
+      });
 
       const currentFormValues = formRef.current.getValues();
       setBabyStakeDraft({
-        amount: eligibility.additionalBabyNeeded,
+        amount: additionalBabyNeeded,
         validatorAddresses: currentFormValues.validatorAddresses,
         feeAmount: currentFormValues.feeAmount,
       });
@@ -133,7 +130,7 @@ export default function StakingForm({
   }, [
     location.state,
     navigate,
-    eligibility.additionalBabyNeeded,
+    additionalBabyNeeded,
     isCoStakingLoading,
     setBabyStakeDraft,
   ]);

--- a/services/simple-staking/src/ui/common/components/CoStakingBanner/CoStakingBanner.tsx
+++ b/services/simple-staking/src/ui/common/components/CoStakingBanner/CoStakingBanner.tsx
@@ -10,12 +10,14 @@ import {
   NAVIGATION_STATE_KEYS,
   type NavigationState,
 } from "@/ui/common/constants/navigation";
+import { useCoStakingState } from "@/ui/common/state/CoStakingState";
 
 const BANNER_DISMISSED_KEY = "bbn-costaking-banner-dismissed";
 
 export const CoStakingBanner = () => {
   const navigate = useNavigate();
   const { stakedBtcBalance } = useBalanceState();
+  const { hasValidBoostData } = useCoStakingState();
   const [dismissed, setDismissed] = useSessionStorage(
     BANNER_DISMISSED_KEY,
     false,
@@ -25,8 +27,10 @@ export const CoStakingBanner = () => {
   // Only show banner if:
   // 1. User has active BTC delegations (stakedBtcBalance > 0)
   // 2. User hasn't dismissed the banner
+  // 3. Boost data is available (APR values are valid and additionalBabyNeeded > 0)
   const hasActiveDelegations = stakedBtcBalance > 0;
-  const shouldShowBanner = hasActiveDelegations && !dismissed;
+  const shouldShowBanner =
+    hasActiveDelegations && !dismissed && hasValidBoostData;
 
   const handleBannerClick = useCallback(() => {
     navigate("/baby", {

--- a/services/simple-staking/src/ui/common/components/Modals/CoStakingBoostModal.tsx
+++ b/services/simple-staking/src/ui/common/components/Modals/CoStakingBoostModal.tsx
@@ -18,15 +18,18 @@ export const CoStakingBoostModal: React.FC<FeedbackModalProps> = ({
 }) => {
   const { coinSymbol: btcCoinSymbol } = getNetworkConfigBTC();
   const { coinSymbol: babyCoinSymbol } = getNetworkConfigBBN();
-  const { aprData } = useCoStakingState();
-
-  const { currentApr, boostApr, additionalBabyNeeded } = aprData;
+  const { aprData, eligibility, hasValidBoostData } = useCoStakingState();
 
   const submitButtonText = useMemo(
     () =>
-      `Stake ${additionalBabyNeeded.toFixed(2)} ${babyCoinSymbol} to Boost to ${formatAPRPercentage(boostApr)}%`,
-    [additionalBabyNeeded, babyCoinSymbol, boostApr],
+      `Stake ${eligibility.additionalBabyNeeded.toFixed(2)} ${babyCoinSymbol} to Boost to ${formatAPRPercentage(aprData.boostApr)}%`,
+    [eligibility.additionalBabyNeeded, babyCoinSymbol, aprData.boostApr],
   );
+
+  // Don't render modal if boost data is not available
+  if (!hasValidBoostData) {
+    return null;
+  }
 
   return (
     <SubmitModal
@@ -47,12 +50,12 @@ export const CoStakingBoostModal: React.FC<FeedbackModalProps> = ({
       <p className="text-center text-base text-accent-secondary">
         Your current APR is{" "}
         <span className="text-accent-primary">
-          {formatAPRPercentage(currentApr)}%
+          {formatAPRPercentage(aprData.currentApr)}%
         </span>
-        . Stake {additionalBabyNeeded.toFixed(2)} {babyCoinSymbol} to boost it
-        up to{" "}
+        . Stake {eligibility.additionalBabyNeeded.toFixed(2)} {babyCoinSymbol}{" "}
+        to boost it up to{" "}
         <span className="text-accent-primary">
-          {formatAPRPercentage(boostApr)}%
+          {formatAPRPercentage(aprData.boostApr)}%
         </span>
         . Co-staking lets you earn more by pairing your {btcCoinSymbol} stake
         with {babyCoinSymbol}.

--- a/services/simple-staking/src/ui/common/hooks/services/useCoStakingService.ts
+++ b/services/simple-staking/src/ui/common/hooks/services/useCoStakingService.ts
@@ -146,7 +146,6 @@ export const useCoStakingService = (
       return {
         currentApr: null,
         boostApr: null,
-        additionalBabyNeeded: 0,
         isLoading,
         error: isLoading ? undefined : "APR data not available",
       };
@@ -155,7 +154,6 @@ export const useCoStakingService = (
     return {
       currentApr: aprData.current.total_apr,
       boostApr: aprData.boost.total_apr,
-      additionalBabyNeeded: aprData.additional_baby_needed_for_boost,
       isLoading: false,
       error: undefined,
     };

--- a/services/simple-staking/src/ui/common/rewards/index.tsx
+++ b/services/simple-staking/src/ui/common/rewards/index.tsx
@@ -70,9 +70,7 @@ function RewardsPageContent() {
 
   const { claimRewards: btcClaimRewards } = useRewardsService();
 
-  const { eligibility, rawAprData } = useCoStakingState();
-
-  const additionalBabyNeeded = eligibility.additionalBabyNeeded;
+  const { eligibility, rawAprData, hasValidBoostData } = useCoStakingState();
 
   const btcRewardBaby = maxDecimals(
     ubbnToBaby(Number(btcRewardUbbn || 0)),
@@ -277,10 +275,10 @@ function RewardsPageContent() {
   const hasAnyRewards = hasBtcRewards || hasBabyRewards;
   const claimDisabled = !hasAnyRewards || processing;
 
-  const isStakeMoreActive = FF.IsCoStakingEnabled && additionalBabyNeeded > 0;
+  const isStakeMoreActive = FF.IsCoStakingEnabled && hasValidBoostData;
 
   const stakeMoreCta = isStakeMoreActive
-    ? `Stake ${formatter.format(additionalBabyNeeded)} ${bbnCoinSymbol} to Unlock Full Rewards`
+    ? `Stake ${formatter.format(eligibility.additionalBabyNeeded)} ${bbnCoinSymbol} to Unlock Full Rewards`
     : undefined;
 
   const tokens = useMemo(() => {

--- a/services/simple-staking/src/ui/common/state/CoStakingState.tsx
+++ b/services/simple-staking/src/ui/common/state/CoStakingState.tsx
@@ -99,6 +99,7 @@ interface CoStakingStateValue {
   scoreRatio: number;
   aprData: CoStakingAPRData;
   rawAprData: PersonalizedAPRResponse["data"] | null;
+  hasValidBoostData: boolean;
   isLoading: boolean;
   isEnabled: boolean;
   hasError: boolean;
@@ -121,11 +122,11 @@ const defaultState: CoStakingStateValue = {
   aprData: {
     currentApr: null,
     boostApr: null,
-    additionalBabyNeeded: 0,
     isLoading: false,
     error: undefined,
   },
   rawAprData: null,
+  hasValidBoostData: false,
   isLoading: false,
   isEnabled: false,
   hasError: false,
@@ -274,6 +275,19 @@ export function CoStakingState({ children }: PropsWithChildren) {
       void unsubscribeFns.forEach((unsubscribe) => void unsubscribe());
   }, [eventBus, refreshCoStakingData]);
 
+  // Computed: Check if all boost data is valid and available
+  const hasValidBoostData = useMemo(
+    () =>
+      Boolean(
+        aprData.currentApr &&
+          aprData.currentApr > 0 &&
+          aprData.boostApr &&
+          aprData.boostApr > 0 &&
+          eligibility.additionalBabyNeeded > 0,
+      ),
+    [aprData.currentApr, aprData.boostApr, eligibility.additionalBabyNeeded],
+  );
+
   const state = useMemo(
     () => ({
       params: coStakingParams?.params || null,
@@ -281,6 +295,7 @@ export function CoStakingState({ children }: PropsWithChildren) {
       scoreRatio,
       aprData,
       rawAprData: rawAprData ?? null,
+      hasValidBoostData,
       isLoading,
       isEnabled: isCoStakingEnabled,
       hasError: Boolean(error),
@@ -293,6 +308,7 @@ export function CoStakingState({ children }: PropsWithChildren) {
       scoreRatio,
       aprData,
       rawAprData,
+      hasValidBoostData,
       isLoading,
       isCoStakingEnabled,
       error,

--- a/services/simple-staking/src/ui/common/types/api/coStaking.ts
+++ b/services/simple-staking/src/ui/common/types/api/coStaking.ts
@@ -55,8 +55,6 @@ export interface CoStakingAPRData {
   currentApr: number | null;
   /** B% - Maximum APR user can earn at 100% eligibility (BTC APR + BABY APR + full co-staking bonus) */
   boostApr: number | null;
-  /** X - Additional BABY tokens needed to reach 100% eligibility and boost APR */
-  additionalBabyNeeded: number;
   isLoading: boolean;
   error?: string;
 }


### PR DESCRIPTION
- added `hasValidBoostData` field in `CoStakingState.tsx`
   - checks `currentApr && currentApr > 0`, `boostApr && boostApr > 0`, `additionalBabyNeeded > 0`

- updated all ctas to use `hasValidBoostData`

- removed duplicated field (`aprData.additionalBabyNeeded`, `eligibility.additionalBabyNeeded`)