### PR TITLE
fix(packages): Fix BABY Staking Pending Operations and Epoch Loading

### DIFF
--- a/packages/babylon-proto-ts/src/lib/lcd/baby.ts
+++ b/packages/babylon-proto-ts/src/lib/lcd/baby.ts
@@ -239,13 +239,14 @@ const createBabylonClient = ({ request }: Dependencies) => ({
 
   async getCurrentEpoch() {
     try {
-      const { current_epoch, epoch_boundary } = await request(
+      // Note: convertKeysDeep in http.ts already converts snake_case to camelCase
+      const { currentEpoch, epochBoundary } = await request(
         "/babylon/epoching/v1/current_epoch",
       );
 
       return {
-        epochBoundary: parseInt(epoch_boundary, 10),
-        currentEpoch: parseInt(current_epoch, 10),
+        epochBoundary: parseInt(epochBoundary, 10),
+        currentEpoch: parseInt(currentEpoch, 10),
       };
     } catch (error: unknown) {
       throw new Error(`Failed to fetch current epoch`, {

--- a/services/simple-staking/src/ui/baby/components/UnbondingModal/index.tsx
+++ b/services/simple-staking/src/ui/baby/components/UnbondingModal/index.tsx
@@ -14,6 +14,7 @@ import type { FieldValues } from "react-hook-form";
 
 import babylon from "@/infrastructure/babylon";
 import { AmountField } from "@/ui/baby/components/AmountField";
+import { usePendingOperationsService } from "@/ui/baby/hooks/services/usePendingOperationsService";
 import {
   useDelegationState,
   type Delegation,
@@ -47,6 +48,7 @@ const UnbondingModalContent = ({
 }) => {
   const { handleSubmit } = useFormContext();
   const { isValid } = useFormState();
+  const { isEpochReady } = usePendingOperationsService();
 
   const availableBalance = babylon.utils.ubbnToBaby(delegation.amount);
   const validatorName =
@@ -82,6 +84,12 @@ const UnbondingModalContent = ({
 
         <AmountField balance={availableBalance} price={1} />
 
+        {!isEpochReady && (
+          <Warning>
+            Epoch data is loading. Please wait a moment before unbonding.
+          </Warning>
+        )}
+
         <Warning>
           Once the unbonding period begins:
           <br />• You will not receive staking rewards for the unbonding tokens.
@@ -90,7 +98,10 @@ const UnbondingModalContent = ({
       </DialogBody>
 
       <DialogFooter className="mt-[80px] flex justify-end">
-        <Button onClick={handleSubmit(handleFormSubmit)} disabled={!isValid}>
+        <Button
+          onClick={handleSubmit(handleFormSubmit)}
+          disabled={!isValid || !isEpochReady}
+        >
           Unbond
         </Button>
       </DialogFooter>

--- a/services/simple-staking/src/ui/baby/state/StakingState.tsx
+++ b/services/simple-staking/src/ui/baby/state/StakingState.tsx
@@ -105,7 +105,7 @@ function StakingState({ children }: PropsWithChildren) {
     [],
   );
   // Subtract the pending stake amount from the balance
-  const { getTotalPendingStake } = usePendingOperationsService();
+  const { getTotalPendingStake, isEpochReady } = usePendingOperationsService();
   const availableBalance = balance - getTotalPendingStake();
 
   const balanceValidator = useMemo(
@@ -127,7 +127,14 @@ function StakingState({ children }: PropsWithChildren) {
         message: GEO_BLOCK_MESSAGE,
       };
     }
-  }, [isGeoBlocked]);
+    if (!isEpochReady) {
+      return {
+        title: "Loading",
+        message:
+          "Loading epoch data from the network. This will only take a moment.",
+      };
+    }
+  }, [isGeoBlocked, isEpochReady]);
 
   const fieldSchemas = useMemo(
     () =>

--- a/services/simple-staking/src/ui/common/utils/local_storage/epochStorage.ts
+++ b/services/simple-staking/src/ui/common/utils/local_storage/epochStorage.ts
@@ -1,22 +1,68 @@
 import { network } from "@/ui/common/config/network/bbn";
 
-export const BABY_CURRENT_EPOCH_KEY = `baby-current-epoch-${network}`;
+/**
+ * Combined storage structure for epoch and pending operations.
+ * This ensures epoch and pending operations are always in sync.
+ * When epoch changes, pending operations are automatically cleared.
+ */
+export interface BabyEpochData {
+  epoch: number;
+  pendingOperations: Record<string, any[]>; // walletAddress -> operations[]
+}
+
+const BABY_EPOCH_DATA_KEY = `baby-epoch-data-v1-${network}`;
+
+export function getBabyEpochData(): BabyEpochData | null {
+  try {
+    const value = localStorage.getItem(BABY_EPOCH_DATA_KEY);
+    if (!value) return null;
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
+}
+
+export function setBabyEpochData(data: BabyEpochData): void {
+  try {
+    localStorage.setItem(BABY_EPOCH_DATA_KEY, JSON.stringify(data));
+  } catch {
+    /* noop */
+  }
+}
 
 export function getCurrentEpoch(): number | undefined {
-  try {
-    const value = localStorage.getItem(BABY_CURRENT_EPOCH_KEY);
-    if (!value) return undefined;
-    const parsed = parseInt(value, 10);
-    return Number.isNaN(parsed) ? undefined : parsed;
-  } catch {
-    return undefined;
-  }
+  const data = getBabyEpochData();
+  return data?.epoch;
 }
 
 export function setCurrentEpoch(epoch: number): void {
   try {
     if (!Number.isFinite(epoch)) return;
-    localStorage.setItem(BABY_CURRENT_EPOCH_KEY, String(epoch));
+
+    const currentData = getBabyEpochData();
+
+    // If epoch changed, clear all pending operations
+    if (currentData && currentData.epoch !== epoch) {
+      setBabyEpochData({
+        epoch,
+        pendingOperations: {}, // Clear all pending operations on epoch change
+      });
+    } else if (currentData) {
+      // Same epoch, keep existing pending operations
+      setBabyEpochData({
+        ...currentData,
+        epoch,
+      });
+    } else {
+      // First time setting epoch
+      setBabyEpochData({
+        epoch,
+        pendingOperations: {},
+      });
+    }
+
+    // Emit custom event for same-tab updates
+    window.dispatchEvent(new Event("baby-epoch-updated"));
   } catch {
     /* noop */
   }


### PR DESCRIPTION
Users were getting "invalid shares amount" error when trying to unbond BABY tokens. Investigation revealed multiple root causes:
  1. API Bug: getCurrentEpoch() was returning NaN due to incorrect field destructuring (snake_case vs camelCase
  mismatch)
  2. Stale Pending Operations: Operations with epoch: undefined were never cleaned up, causing incorrect balance
  calculations
  3. Split Storage: Epoch and pending operations were stored separately, leading to synchronization issues

**Solution**

  1. Fixed API Response Parsing (baby.ts)

  - Changed destructuring from current_epoch to currentEpoch to match the camelCase conversion done by the HTTP
  client
  - This fixes the NaN epoch issue that was breaking all staking operations

  2. Unified Storage Architecture (epochStorage.ts)

  - Combined epoch and pending operations into a single BabyEpochData structure
  - Epoch changes now atomically clear all pending operations
  - Added event dispatching for cross-component synchronization

  3. Simplified Epoch Management

  - Removed redundant useCurrentEpoch hook
  - Now using single source of truth: useEpochPolling handles fetching, components read from localStorage
  - Removed duplicate loading states and unnecessary complexity

  4. Improved UX

  - Disable stake/unbond buttons until epoch is loaded (no error throwing)
  - Updated loading message to be user-friendly: "Loading epoch data from the network. This will only take a
  moment."