### PR TITLE
feat(packages): make CoStakingBoostModal closable

### DIFF
--- a/services/simple-staking/src/ui/common/components/Modals/CoStakingBoostModal.tsx
+++ b/services/simple-staking/src/ui/common/components/Modals/CoStakingBoostModal.tsx
@@ -10,11 +10,13 @@ import { SubmitModal } from "./SubmitModal";
 interface FeedbackModalProps {
   open: boolean;
   onClose: () => void;
+  onSubmit: () => void;
 }
 
 export const CoStakingBoostModal: React.FC<FeedbackModalProps> = ({
   open,
   onClose,
+  onSubmit,
 }) => {
   const { coinSymbol: btcCoinSymbol } = getNetworkConfigBTC();
   const { coinSymbol: babyCoinSymbol } = getNetworkConfigBBN();
@@ -42,7 +44,9 @@ export const CoStakingBoostModal: React.FC<FeedbackModalProps> = ({
       open={open}
       submitButton={submitButtonText}
       cancelButton=""
-      onSubmit={onClose}
+      onSubmit={onSubmit}
+      onClose={onClose}
+      showCloseButton={true}
     >
       <p className="text-center text-base text-accent-secondary">
         Your current APR is{" "}

--- a/services/simple-staking/src/ui/common/components/Modals/SubmitModal.tsx
+++ b/services/simple-staking/src/ui/common/components/Modals/SubmitModal.tsx
@@ -2,6 +2,7 @@ import {
   Button,
   DialogBody,
   DialogFooter,
+  DialogHeader,
   Heading,
   Loader,
   Text,
@@ -22,6 +23,7 @@ interface SubmitModalProps {
   submitButton?: string | JSX.Element;
   onClose?: () => void;
   onSubmit?: () => void;
+  showCloseButton?: boolean;
 }
 
 export const SubmitModal = ({
@@ -37,8 +39,16 @@ export const SubmitModal = ({
   submitButton = "Submit",
   onClose,
   onSubmit,
+  showCloseButton = false,
 }: PropsWithChildren<SubmitModalProps>) => (
   <ResponsiveDialog className={className} open={open} onClose={onClose}>
+    {showCloseButton && onClose && (
+      <DialogHeader
+        title="" // intentionally empty string to hide the title
+        onClose={onClose}
+        className="text-accent-primary"
+      />
+    )}
     <DialogBody className="py-16 text-center text-accent-primary">
       <div
         className={`mb-6 inline-flex items-center justify-center bg-primary-contrast ${iconParentClassName}`}

--- a/services/simple-staking/src/ui/common/components/Multistaking/MultistakingModal/MultistakingModal.tsx
+++ b/services/simple-staking/src/ui/common/components/Multistaking/MultistakingModal/MultistakingModal.tsx
@@ -213,7 +213,7 @@ export function MultistakingModal() {
 
   if (!step) return null;
 
-  const handleCloseBoostModal = () => {
+  const handleSubmitBoostModal = () => {
     resetState();
 
     // Navigate to baby page with flag to trigger prefill
@@ -291,7 +291,8 @@ export function MultistakingModal() {
       {FeatureFlagService.IsCoStakingEnabled ? (
         <CoStakingBoostModal
           open={step === "feedback-success"}
-          onClose={handleCloseBoostModal}
+          onClose={resetState}
+          onSubmit={handleSubmitBoostModal}
         />
       ) : (
         <SuccessFeedbackModal


### PR DESCRIPTION
added close button:
<img width="670" height="555" alt="image" src="https://github.com/user-attachments/assets/aec461d2-4ef4-4ef8-9708-0c8ef18b8070" />


Should we use the `DialogHeader` `title` instead of middle title, like this?
<img width="671" height="498" alt="image" src="https://github.com/user-attachments/assets/011dae43-118f-4f1f-8641-975a93b5d54b" />
