### PR TITLE
fix: value.split is not a function console error

### DIFF
--- a/services/simple-staking/src/ui/common/components/Staking/Form/validation/validation.ts
+++ b/services/simple-staking/src/ui/common/components/Staking/Form/validation/validation.ts
@@ -10,7 +10,7 @@ export const validateNoDecimalPoints = (value: string | number): boolean => {
 
 /**
  * Validates if the value has no more than 8 decimal points.
- * @param value The value to validate.
+ * @param value The value to validate, as a string or number.
  * @returns `true` if the value has no more than 8 decimal points, otherwise `false`.
  */
 export const validateDecimalPoints = (


### PR DESCRIPTION
resolves: https://github.com/babylonlabs-io/babylon-toolkit/issues/354