### PR TITLE
fix(packages): page creash when denominator is 0 and improve the type…

### DIFF
--- a/services/simple-staking/src/ui/baby/hooks/api/useEpochPolling.ts
+++ b/services/simple-staking/src/ui/baby/hooks/api/useEpochPolling.ts
@@ -3,7 +3,7 @@ import { useEffect, useRef } from "react";
 
 import babylon from "@/infrastructure/babylon";
 import { ONE_MINUTE } from "@/ui/common/constants";
-import { setCurrentEpoch } from "@/ui/common/utils/local_storage/epochStorage";
+import { setCurrentEpoch } from "@/ui/baby/utils/epochStorage";
 
 import { usePendingOperationsService } from "../services/usePendingOperationsService";
 

--- a/services/simple-staking/src/ui/baby/hooks/services/usePendingOperationsService.tsx
+++ b/services/simple-staking/src/ui/baby/hooks/services/usePendingOperationsService.tsx
@@ -13,7 +13,10 @@ import {
   getBabyEpochData,
   getCurrentEpoch,
   setBabyEpochData,
-} from "@/ui/common/utils/local_storage/epochStorage";
+  type PendingOperationStorage,
+  BABY_EPOCH_UPDATED_EVENT,
+  BABY_PENDING_OPERATIONS_UPDATED_EVENT,
+} from "@/ui/baby/utils/epochStorage";
 
 /**
  * Runtime representation of a pending BABY staking operation.
@@ -25,21 +28,7 @@ export interface PendingOperation {
   operationType: "stake" | "unstake";
   timestamp: number;
   walletAddress: string;
-  epoch?: number;
-}
-
-/**
- * localStorage-serializable format of PendingOperation.
- * Converts bigint → string because JSON doesn't support BigInt.
- * Use this type when reading/writing to localStorage.
- */
-export interface PendingOperationStorage {
-  validatorAddress: string;
-  amount: string; // Serialized bigint
-  operationType: "stake" | "unstake";
-  timestamp: number;
-  walletAddress: string;
-  epoch?: number;
+  epoch: number;
 }
 
 /**
@@ -118,11 +107,11 @@ function usePendingOperationsServiceInternal() {
 
     // Listen for epoch updates from useEpochPolling
     window.addEventListener("storage", syncEpoch);
-    window.addEventListener("baby-epoch-updated", syncEpoch);
+    window.addEventListener(BABY_EPOCH_UPDATED_EVENT, syncEpoch);
 
     return () => {
       window.removeEventListener("storage", syncEpoch);
-      window.removeEventListener("baby-epoch-updated", syncEpoch);
+      window.removeEventListener(BABY_EPOCH_UPDATED_EVENT, syncEpoch);
     };
   }, []);
 
@@ -192,7 +181,7 @@ function usePendingOperationsServiceInternal() {
     }
 
     // Emit custom event for same-tab updates (storage event only fires for other tabs)
-    window.dispatchEvent(new Event("baby-pending-operations-updated"));
+    window.dispatchEvent(new Event(BABY_PENDING_OPERATIONS_UPDATED_EVENT));
   }, [pendingOperations, bech32Address]);
 
   const addPendingOperation = useCallback(

--- a/services/simple-staking/src/ui/baby/hooks/services/useValidatorService.ts
+++ b/services/simple-staking/src/ui/baby/hooks/services/useValidatorService.ts
@@ -76,7 +76,8 @@ export function useValidatorService() {
       validatorList
         .map((validator) => {
           const tokens = parseFloat(validator.tokens);
-          const votingPower = tokens / (pool?.bondedTokens ?? 0);
+          const bondedTokens = pool?.bondedTokens ?? 0;
+          const votingPower = bondedTokens > 0 ? tokens / bondedTokens : 0;
           const commission = parseFloat(
             validator.commission.commissionRates.rate,
           );

--- a/services/simple-staking/src/ui/baby/utils/epochStorage.ts
+++ b/services/simple-staking/src/ui/baby/utils/epochStorage.ts
@@ -1,16 +1,35 @@
 import { network } from "@/ui/common/config/network/bbn";
 
 /**
+ * localStorage-serializable format of PendingOperation.
+ * Converts bigint → string because JSON doesn't support BigInt.
+ */
+export interface PendingOperationStorage {
+  validatorAddress: string;
+  amount: string; // Serialized bigint
+  operationType: "stake" | "unstake";
+  timestamp: number;
+  walletAddress: string;
+  epoch: number;
+}
+
+/**
  * Combined storage structure for epoch and pending operations.
  * This ensures epoch and pending operations are always in sync.
  * When epoch changes, pending operations are automatically cleared.
  */
 export interface BabyEpochData {
   epoch: number;
-  pendingOperations: Record<string, any[]>; // walletAddress -> operations[]
+  pendingOperations: Record<string, PendingOperationStorage[]>; // walletAddress -> operations[]
 }
 
+// Storage keys - centralized to avoid magic strings throughout the codebase
 const BABY_EPOCH_DATA_KEY = `baby-epoch-data-v1-${network}`;
+
+// Custom event names for cross-component communication
+export const BABY_EPOCH_UPDATED_EVENT = "baby-epoch-updated";
+export const BABY_PENDING_OPERATIONS_UPDATED_EVENT =
+  "baby-pending-operations-updated";
 
 export function getBabyEpochData(): BabyEpochData | null {
   try {
@@ -62,7 +81,7 @@ export function setCurrentEpoch(epoch: number): void {
     }
 
     // Emit custom event for same-tab updates
-    window.dispatchEvent(new Event("baby-epoch-updated"));
+    window.dispatchEvent(new Event(BABY_EPOCH_UPDATED_EVENT));
   } catch {
     /* noop */
   }


### PR DESCRIPTION
Post-fix cleanup following the pending operations bug fix. Improves type safety, code organization, and fixes a division-by-zero crash.

**Key Changes**

  1. Fixed Division by Zero Crash (useValidatorService.ts)
  - Added guard: votingPower = bondedTokens > 0 ? tokens / bondedTokens : 0
  - Prevents [DecimalError] Invalid argument: Infinity when pool data isn't loaded

  2. Removed Redundant Code
  - Deleted useCurrentEpoch hook (duplicate of useEpochPolling)
  - Simplified usePendingOperationsService by ~20 lines

  3. Improved Type Safety
  - Replaced any[] with PendingOperationStorage[]
  - Made epoch field required (was optional)
  - Removed duplicate interface definitions

  4. Better Organization
  - Moved epochStorage.ts from ui/common/ → ui/baby/utils/ (it's BABY-specific)
  - Centralized magic strings as constants:
  export const BABY_EPOCH_UPDATED_EVENT = "baby-epoch-updated";
  export const BABY_PENDING_OPERATIONS_UPDATED_EVENT = "baby-pending-operations-updated";

  5. Updated CoStakingState
  - Uses unified storage format
  - References constants instead of magic strings
