### PR TITLE
Fix: Prevent stale Bitcoin tipHeight in transaction creation

### DIFF
--- a/services/simple-staking/src/ui/common/hooks/services/useTransactionService.ts
+++ b/services/simple-staking/src/ui/common/hooks/services/useTransactionService.ts
@@ -44,7 +44,7 @@ export const useTransactionService = () => {
   const { data: networkFees } = useNetworkFees();
   const { defaultFeeRate } = getFeeRateFromMempool(networkFees);
   const {
-    btcTipQuery: { data: tipHeader },
+    btcTipQuery: { data: tipHeader, refetch: refetchBtcTip },
   } = useBbnQuery();
 
   const { bech32Address } = useCosmosWallet();
@@ -72,12 +72,16 @@ export const useTransactionService = () => {
    */
   const createDelegationEoi = useCallback(
     async (stakingInput: BtcStakingInputs, feeRate: number) => {
+      // Refetch the latest BTC tip height to prevent using stale data
+      const { data: latestTipHeader } = await refetchBtcTip();
+      const latestTipHeight = latestTipHeader?.height ?? 0;
+
       const btcStakingManager = createBtcStakingManager();
 
       validateCommonInputs(
         btcStakingManager,
         stakingInput,
-        tipHeight,
+        latestTipHeight,
         stakerInfo,
       );
 
@@ -94,7 +98,7 @@ export const useTransactionService = () => {
         await btcStakingManager!.preStakeRegistrationBabylonTransaction(
           stakerInfo,
           stakingInput,
-          tipHeight,
+          latestTipHeight,
           availableUTXOs,
           feeRate,
           bech32Address,
@@ -109,7 +113,7 @@ export const useTransactionService = () => {
       bech32Address,
       createBtcStakingManager,
       stakerInfo,
-      tipHeight,
+      refetchBtcTip,
       logger,
     ],
   );
@@ -166,11 +170,15 @@ export const useTransactionService = () => {
       stakingHeight: number,
       stakingInput: BtcStakingInputs,
     ) => {
+      // Refetch the latest BTC tip height to prevent using stale data
+      const { data: latestTipHeader } = await refetchBtcTip();
+      const latestTipHeight = latestTipHeader?.height ?? 0;
+
       const btcStakingManager = createBtcStakingManager();
       validateCommonInputs(
         btcStakingManager,
         stakingInput,
-        tipHeight,
+        latestTipHeight,
         stakerInfo,
       );
 
@@ -197,7 +205,7 @@ export const useTransactionService = () => {
         signedBabylonTx,
       };
     },
-    [bech32Address, createBtcStakingManager, stakerInfo, tipHeight, logger],
+    [bech32Address, createBtcStakingManager, stakerInfo, refetchBtcTip, logger],
   );
 
   /**
@@ -457,6 +465,10 @@ export const useTransactionService = () => {
       stakingExpansionInput: BtcStakingExpansionInputs,
       feeRate: number,
     ) => {
+      // Refetch the latest BTC tip height to prevent using stale data
+      const { data: latestTipHeader } = await refetchBtcTip();
+      const latestTipHeight = latestTipHeader?.height ?? 0;
+
       const btcStakingManager = createBtcStakingManager();
 
       validateCommonInputs(
@@ -467,7 +479,7 @@ export const useTransactionService = () => {
           stakingAmountSat: stakingExpansionInput.stakingAmountSat,
           stakingTimelock: stakingExpansionInput.stakingTimelock,
         },
-        tipHeight,
+        latestTipHeight,
         stakerInfo,
       );
 
@@ -498,7 +510,7 @@ export const useTransactionService = () => {
         await btcStakingManager!.stakingExpansionRegistrationBabylonTransaction(
           stakerInfo,
           stakingExpansionInput,
-          tipHeight,
+          latestTipHeight,
           availableUTXOs,
           feeRate,
           bech32Address,
@@ -519,7 +531,7 @@ export const useTransactionService = () => {
       bech32Address,
       createBtcStakingManager,
       stakerInfo,
-      tipHeight,
+      refetchBtcTip,
       logger,
       isUTXOsLoading,
     ],


### PR DESCRIPTION
### Problem
A race condition existed in `useTransactionService` where the Bitcoin `tipHeight` was calculated once on component
initialization and cached via `useMemo`. If there was a delay between initialization and when a user initiated a staking
transaction, the cached `tipHeight` could become stale. This could result in:
- Transactions being rejected by the network
- Malformed staking transactions
- Invalid transaction behavior if staking parameters changed during the delay window

### Solution
Refetch the latest Bitcoin tip height immediately before it's used in transaction creation by calling `refetchBtcTip()` from
 the `btcTipQuery`. This ensures transactions always use current blockchain state.

### Changes
Updated three transaction creation functions in `useTransactionService.ts`:
- `createDelegationEoi` - Creates BTC staking EOI transactions
- `transitionPhase1Delegation` - Transitions phase-1 delegations
- `createStakingExpansionEoi` - Creates staking expansion EOI transactions

Each function now:
1. Refetches the latest tip height: `await refetchBtcTip()`
2. Extracts fresh height: `latestTipHeight = latestTipHeader?.height ?? 0`
3. Uses the fresh value instead of stale cached value