### PR TITLE
feat(packages): tbv disable network calls from staking

### DIFF
--- a/services/simple-staking/src/ui/common/hooks/client/api/useFinalityProviders.ts
+++ b/services/simple-staking/src/ui/common/hooks/client/api/useFinalityProviders.ts
@@ -21,9 +21,10 @@ interface Params {
   name?: string;
   sortBy?: string;
   order?: "asc" | "desc";
+  enabled?: boolean;
 }
 
-export function useFinalityProviders({ pk, sortBy, order, name }: Params = {}) {
+export function useFinalityProviders({ pk, sortBy, order, name, enabled }: Params = {}) {
   const { isOpen, handleError } = useError();
   const logger = useLogger();
 
@@ -51,6 +52,7 @@ export function useFinalityProviders({ pk, sortBy, order, name }: Params = {}) {
     },
     retry: (failureCount) => !isOpen && failureCount < API_DEFAULT_RETRY_COUNT,
     retryDelay: (count) => API_DEFAULT_RETRY_DELAY ** (count + 1) * ONE_SECOND,
+    enabled,
   });
 
   useEffect(() => {

--- a/services/simple-staking/src/ui/common/state/DelegationState.tsx
+++ b/services/simple-staking/src/ui/common/state/DelegationState.tsx
@@ -10,6 +10,7 @@ import {
   useState,
   type PropsWithChildren,
 } from "react";
+import { useLocation } from "react-router";
 import { useLocalStorage } from "usehooks-ts";
 
 import { useBTCWallet } from "@/ui/common/context/wallet/BTCWalletProvider";
@@ -78,9 +79,11 @@ const { StateProvider, useState: useDelegationState } =
   });
 
 export function DelegationState({ children }: PropsWithChildren) {
+  const location = useLocation();
+  const isVaultRoute = location.pathname.startsWith("/vault");
   const { publicKeyNoCoord } = useBTCWallet();
   const { data, fetchNextPage, isFetchingNextPage, hasNextPage, refetch } =
-    useDelegations();
+    useDelegations({ enabled: !isVaultRoute });
   const eventBus = useEventBus();
 
   // States

--- a/services/simple-staking/src/ui/common/state/DelegationV2State.tsx
+++ b/services/simple-staking/src/ui/common/state/DelegationV2State.tsx
@@ -6,6 +6,7 @@ import {
   useState,
   type PropsWithChildren,
 } from "react";
+import { useLocation } from "react-router";
 import { useLocalStorage } from "usehooks-ts";
 
 import { useBTCWallet } from "@/ui/common/context/wallet/BTCWalletProvider";
@@ -62,6 +63,8 @@ const { StateProvider, useState: useDelegationV2State } =
   });
 
 export function DelegationV2State({ children }: PropsWithChildren) {
+  const location = useLocation();
+  const isVaultRoute = location.pathname.startsWith("/vault");
   const [showLinkedDelegations, setLinkedDelegations] = useLocalStorage(
     "baby-linked-wallet-stakes-visibility",
     false,
@@ -79,7 +82,9 @@ export function DelegationV2State({ children }: PropsWithChildren) {
     isLoading,
     hasNextPage,
     refetch,
-  } = useDelegationsV2(!showLinkedDelegations ? bech32Address : undefined);
+  } = useDelegationsV2(!showLinkedDelegations ? bech32Address : undefined, {
+    enabled: !isVaultRoute,
+  });
   // States
   const { delegations, addPendingDelegation, updateDelegationStatus } =
     useDelegationStorage(

--- a/services/simple-staking/src/ui/common/state/FinalityProviderState.tsx
+++ b/services/simple-staking/src/ui/common/state/FinalityProviderState.tsx
@@ -1,6 +1,6 @@
 import { useDebounce } from "@uidotdev/usehooks";
 import { useCallback, useMemo, useState, type PropsWithChildren } from "react";
-import { useSearchParams } from "react-router";
+import { useLocation, useSearchParams } from "react-router";
 
 import { useFinalityProviders } from "@/ui/common/hooks/client/api/useFinalityProviders";
 import { useFinalityProvidersV2 } from "@/ui/common/hooks/client/api/useFinalityProvidersV2";
@@ -83,6 +83,8 @@ const { StateProvider, useState: useFpState } =
   createStateUtils<FinalityProviderState>(defaultState);
 
 export function FinalityProviderState({ children }: PropsWithChildren) {
+  const location = useLocation();
+  const isVaultRoute = location.pathname.startsWith("/vault");
   const [params] = useSearchParams();
   const fpParam = params.get("fp");
 
@@ -100,9 +102,10 @@ export function FinalityProviderState({ children }: PropsWithChildren) {
       name: debouncedSearch,
       // By default, if no bsn is passed, the FP endpoint will return babylon
       bsnId: "all",
+      enabled: !isVaultRoute,
     });
 
-  const { data: dataV1 } = useFinalityProviders();
+  const { data: dataV1 } = useFinalityProviders({ enabled: !isVaultRoute });
 
   const finalityProviders = useMemo(() => {
     if (!data?.finalityProviders) {

--- a/services/simple-staking/src/ui/common/state/index.tsx
+++ b/services/simple-staking/src/ui/common/state/index.tsx
@@ -5,6 +5,7 @@ import {
 } from "@babylonlabs-io/wallet-connector";
 import { useTheme } from "next-themes";
 import { useCallback, useMemo, type PropsWithChildren } from "react";
+import { useLocation } from "react-router";
 
 import { useOrdinals } from "@/ui/common/hooks/client/api/useOrdinals";
 import { useUTXOs } from "@/ui/common/hooks/client/api/useUTXOs";
@@ -64,6 +65,8 @@ const { StateProvider, useState: useApplicationState } =
 
 export function AppState({ children }: PropsWithChildren) {
   const { theme, setTheme } = useTheme();
+  const location = useLocation();
+  const isVaultRoute = location.pathname.startsWith("/vault");
 
   const { lockInscriptions: ordinalsExcluded, toggleLockInscriptions } =
     useInscriptionProvider();
@@ -81,13 +84,13 @@ export function AppState({ children }: PropsWithChildren) {
     isLoading: isOrdinalLoading,
     isError: isOrdinalError,
   } = useOrdinals(confirmedUTXOs, {
-    enabled: !isUTXOLoading,
+    enabled: !isVaultRoute && !isUTXOLoading,
   });
   const {
     data: networkInfo,
     isLoading: isNetworkInfoLoading,
     isError: isNetworkInfoError,
-  } = useNetworkInfo();
+  } = useNetworkInfo({ enabled: !isVaultRoute });
 
   // Computed
   const isLoading = isUTXOLoading || isOrdinalLoading || isNetworkInfoLoading;


### PR DESCRIPTION
Ugly PR implementation, but if we want to not wait for the irrelevant (for vault) network calls, we can add this

On /vault routes, the following staking API calls are now completely disabled:

```
❌ /healthcheck
❌ /v2/network-info
❌ /v1/finality-providers
❌ /v2/finality-providers
❌ /v1/staker/delegations
❌ /v2/delegations
❌ /v1/ordinals/verify-utxos
```