### PR TITLE
fix: don't hide boost cta's if no active btcStakes

### DIFF
--- a/services/simple-staking/src/ui/baby/components/CoStakingBoostSection/index.tsx
+++ b/services/simple-staking/src/ui/baby/components/CoStakingBoostSection/index.tsx
@@ -5,8 +5,6 @@ import { useNavigate } from "react-router";
 import { Text, DismissibleSubSection } from "@babylonlabs-io/core-ui";
 
 import { useCoStakingState } from "@/ui/common/state/CoStakingState";
-import { useDelegationV2State } from "@/ui/common/state/DelegationV2State";
-import { DelegationV2StakingState } from "@/ui/common/types/delegationsV2";
 import { getNetworkConfigBTC } from "@/ui/common/config/network/btc";
 import { getNetworkConfigBBN } from "@/ui/common/config/network/bbn";
 import { formatBalance } from "@/ui/common/utils/formatCryptoBalance";
@@ -18,7 +16,6 @@ export function CoStakingBoostSection({
 }: {
   setActiveTab: (tab: TabId) => void;
 }) {
-  const { delegations = [], isLoading } = useDelegationV2State();
   const {
     eligibility,
     hasValidBoostData,
@@ -32,11 +29,6 @@ export function CoStakingBoostSection({
       initializeWithValue: true,
     });
   const navigate = useNavigate();
-
-  const hasActiveBtcDelegations = useMemo(
-    () => delegations.some((d) => d.state === DelegationV2StakingState.ACTIVE),
-    [delegations],
-  );
 
   const handlePrefill = () => {
     setActiveTab("stake");
@@ -54,8 +46,6 @@ export function CoStakingBoostSection({
 
   const shouldShowCoStakingBoostSection =
     isCoStakingEnabled &&
-    hasActiveBtcDelegations &&
-    !isLoading &&
     !isCoStakingLoading &&
     showCoStakingBoostSection &&
     hasValidBoostData;

--- a/services/simple-staking/src/ui/common/components/CoStakingBanner/CoStakingBanner.tsx
+++ b/services/simple-staking/src/ui/common/components/CoStakingBanner/CoStakingBanner.tsx
@@ -4,7 +4,6 @@ import { useNavigate } from "react-router";
 import { useSessionStorage } from "usehooks-ts";
 import { MdRocketLaunch } from "react-icons/md";
 
-import { useBalanceState } from "@/ui/common/state/BalanceState";
 import { getNetworkConfigBTC } from "@/ui/common/config/network/btc";
 import {
   NAVIGATION_STATE_KEYS,
@@ -16,7 +15,6 @@ const BANNER_DISMISSED_KEY = "bbn-costaking-banner-dismissed";
 
 export const CoStakingBanner = () => {
   const navigate = useNavigate();
-  const { stakedBtcBalance } = useBalanceState();
   const { hasValidBoostData } = useCoStakingState();
   const [dismissed, setDismissed] = useSessionStorage(
     BANNER_DISMISSED_KEY,
@@ -25,12 +23,9 @@ export const CoStakingBanner = () => {
   const { coinSymbol: btcCoinSymbol } = getNetworkConfigBTC();
 
   // Only show banner if:
-  // 1. User has active BTC delegations (stakedBtcBalance > 0)
-  // 2. User hasn't dismissed the banner
-  // 3. Boost data is available (APR values are valid and additionalBabyNeeded > 0)
-  const hasActiveDelegations = stakedBtcBalance > 0;
-  const shouldShowBanner =
-    hasActiveDelegations && !dismissed && hasValidBoostData;
+  // 1. User hasn't dismissed the banner
+  // 2. Boost data is available (APR values are valid and additionalBabyNeeded > 0)
+  const shouldShowBanner = !dismissed && hasValidBoostData;
 
   const handleBannerClick = useCallback(() => {
     navigate("/baby", {


### PR DESCRIPTION
resolves: https://github.com/babylonlabs-io/babylon-toolkit/issues/433
remove necessity of having active `btc` stakes to show boost `cta`s