### PR TITLE
feat: TBV local storage cache

### DIFF
--- a/routes/vault/src/clients/btc/mempool.ts
+++ b/routes/vault/src/clients/btc/mempool.ts
@@ -154,3 +154,86 @@ export async function pushTx(txHex: string): Promise<string> {
     throw new Error('Failed to broadcast BTC transaction: Unknown error');
   }
 }
+
+/**
+ * Transaction info response from mempool API
+ *
+ * NOTE: Copied from simple-staking for vault POC.
+ * TODO: Deduplicate when merging vault to main branch.
+ */
+interface TxInfoResponse {
+  txid: string;
+  version: number;
+  locktime: number;
+  vin: {
+    txid: string;
+    vout: number;
+    prevout: {
+      scriptpubkey: string;
+      scriptpubkey_asm: string;
+      scriptpubkey_type: string;
+      scriptpubkey_address: string;
+      value: number;
+    };
+    scriptsig: string;
+    scriptsig_asm: string;
+    witness: string[];
+    is_coinbase: boolean;
+    sequence: number;
+  }[];
+  vout: {
+    scriptpubkey: string;
+    scriptpubkey_asm: string;
+    scriptpubkey_type: string;
+    scriptpubkey_address: string;
+    value: number;
+  }[];
+  size: number;
+  weight: number;
+  fee: number;
+  status: {
+    confirmed: boolean;
+    block_height: number;
+    block_hash: string;
+    block_time: number;
+  };
+}
+
+/**
+ * Retrieve information about a transaction from mempool API
+ *
+ * NOTE: Copied from simple-staking for vault POC.
+ * TODO: Deduplicate when merging vault to main branch.
+ *
+ * @param txId - The transaction ID in string format
+ * @returns Promise resolving to transaction information
+ */
+export async function getTxInfo(txId: string): Promise<TxInfoResponse> {
+  const apiUrl = getMempoolApiUrl();
+
+  return fetchApi<TxInfoResponse>(`${apiUrl}/tx/${txId}`);
+}
+
+/**
+ * Retrieve the hex representation of a transaction from mempool API
+ *
+ * NOTE: Copied from simple-staking for vault POC.
+ * TODO: Deduplicate when merging vault to main branch.
+ *
+ * @param txId - The transaction ID in string format
+ * @returns Promise resolving to the transaction hex string
+ */
+export async function getTxHex(txId: string): Promise<string> {
+  const apiUrl = getMempoolApiUrl();
+
+  const response = await fetch(`${apiUrl}/tx/${txId}/hex`);
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(
+      `Mempool API error (${response.status}): ${errorText || response.statusText}`,
+    );
+  }
+
+  return await response.text();
+}

--- a/routes/vault/src/components/PeginFlow/PeginSignModal/usePeginFlow.ts
+++ b/routes/vault/src/components/PeginFlow/PeginSignModal/usePeginFlow.ts
@@ -65,12 +65,18 @@ export function usePeginFlow({
   const [currentStep, setCurrentStep] = useState(1);
   const [processing, setProcessing] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [unsignedTxHex, setUnsignedTxHex] = useState<string | undefined>(undefined);
+  const [unsignedTxHex, setUnsignedTxHex] = useState<string | undefined>(
+    undefined,
+  );
   const [btcTxid, setBtcTxid] = useState<string | undefined>(undefined);
   const [ethTxHash, setEthTxHash] = useState<string | undefined>(undefined);
 
   // Fetch UTXOs for the connected BTC wallet
-  const { confirmedUTXOs, isLoading: isUTXOsLoading, error: utxoError } = useUTXOs(btcAddress);
+  const {
+    confirmedUTXOs,
+    isLoading: isUTXOsLoading,
+    error: utxoError,
+  } = useUTXOs(btcAddress);
 
   // Reset state when modal closes
   useEffect(() => {
@@ -112,10 +118,13 @@ export function usePeginFlow({
       }
 
       // Convert BTC amount to satoshis
-      const pegInAmountSats = BigInt(Math.round(amount * Number(SATOSHIS_PER_BTC)));
+      const pegInAmountSats = BigInt(
+        Math.round(amount * Number(SATOSHIS_PER_BTC)),
+      );
 
       // Calculate required amount: peg-in amount + transaction fee
-      const requiredAmount = pegInAmountSats + LOCAL_PEGIN_CONFIG.btcTransactionFee;
+      const requiredAmount =
+        pegInAmountSats + LOCAL_PEGIN_CONFIG.btcTransactionFee;
 
       // Select suitable UTXO
       const selectedUTXO = selectUTXOForPegin(confirmedUTXOs, requiredAmount);
@@ -182,11 +191,18 @@ export function usePeginFlow({
       setCurrentStep(3); // Set to 3 to show step 2 as complete (checkmark, not spinner)
       setProcessing(false);
 
-      // Pass all data to parent including unsigned TX and UTXO for storage
+      // Pass all data to parent including unsigned TX and UTXO for localStorage caching
       // Note: btcTxid is the EXPECTED transaction ID, BTC tx not yet broadcast
+      //
+      // CACHING STRATEGY:
+      // - Store unsignedTxHex & UTXO in localStorage as OPTIONAL cache (faster broadcasting)
+      // - Cross-device broadcasting works WITHOUT these cached values by:
+      //   1. Fetching unsignedTxHex from ETH contract
+      //   2. Deriving UTXO from unsignedTxHex + mempool API queries
       onSuccess({
         btcTxId: result.btcTxid,
         ethTxHash: result.transactionHash,
+        // unsignedTxHex + utxo -> Cache for performance (optional)
         unsignedTxHex: result.btcTxHex,
         utxo: {
           txid: selectedUTXO.txid,

--- a/routes/vault/src/components/VaultDeposit/VaultDeposit.tsx
+++ b/routes/vault/src/components/VaultDeposit/VaultDeposit.tsx
@@ -112,6 +112,7 @@ export function VaultDeposit({
             value: data.utxo.value.toString(),
             scriptPubKey: data.utxo.scriptPubKey,
           },
+          status: 'pending' as const,  // Initial status when creating pegin
         };
         addPendingPegin(peginData);
       }
@@ -157,6 +158,7 @@ export function VaultDeposit({
               connectedAddress={connectedAddress}
               pendingPegins={pendingPegins}
               updatePendingPeginStatus={updatePendingPeginStatus}
+              addPendingPegin={addPendingPegin}
               onRefetchActivities={refetchActivities}
               onShowSuccessModal={handleShowSuccessModal}
             />

--- a/routes/vault/src/hooks/usePeginStorage.ts
+++ b/routes/vault/src/hooks/usePeginStorage.ts
@@ -143,14 +143,17 @@ export function usePeginStorage({
   }, [pendingActivities, confirmedPegins]);
 
   // Add a new pending peg-in
+  // Accepts optional status parameter to support creating entries with 'confirming' status
+  // (used when broadcasting BTC from cross-device without localStorage)
   const addPendingPegin = useCallback(
-    (pegin: Omit<PendingPeginRequest, 'timestamp' | 'status'>) => {
+    (pegin: Omit<PendingPeginRequest, 'timestamp'>) => {
       if (!ethAddress) return;
 
       const newPegin: PendingPeginRequest = {
         ...pegin,
         timestamp: Date.now(),
-        status: 'pending',
+        // Use provided status or default to 'pending' if not specified
+        status: pegin.status || 'pending',
       };
 
       setPendingPegins((prev: PendingPeginRequest[]) => [...prev, newPegin]);

--- a/routes/vault/src/services/btc/utxoDerivationService.ts
+++ b/routes/vault/src/services/btc/utxoDerivationService.ts
@@ -1,0 +1,132 @@
+/**
+ * UTXO Derivation Service
+ *
+ * Derives UTXO information from unsigned Bitcoin transactions by:
+ * 1. Parsing the unsigned transaction to extract input references (txid, vout)
+ * 2. Querying mempool API to get full UTXO data (scriptPubKey, value)
+ *
+ * This enables cross-device pegin broadcasting without localStorage dependency.
+ *
+ * NOTE: Mempool API calls copied from simple-staking for vault POC.
+ * TODO: Deduplicate when merging vault to main branch.
+ */
+
+import { Transaction } from 'bitcoinjs-lib';
+
+import { getTxInfo } from '../../clients/btc/mempool';
+import type { UTXOInfo } from './broadcastService';
+
+/**
+ * Derive UTXO information from an unsigned Bitcoin transaction
+ *
+ * This function enables cross-device pegin support by reconstructing UTXO data
+ * from the unsigned transaction hex (stored in ETH contract) + mempool API queries.
+ *
+ * Process:
+ * 1. Parse unsigned TX to get input reference (txid, vout)
+ * 2. Fetch full transaction data from mempool API
+ * 3. Extract UTXO details (scriptPubKey, value) from the referenced output
+ *
+ * @param unsignedTxHex - Unsigned transaction hex (from ETH contract)
+ * @returns UTXO information needed for PSBT construction
+ * @throws Error if transaction parsing fails or UTXO not found in mempool
+ */
+export async function deriveUTXOFromUnsignedTx(
+  unsignedTxHex: string,
+): Promise<UTXOInfo> {
+  try {
+    // Step 1: Parse unsigned transaction to extract input reference
+    const cleanHex = unsignedTxHex.startsWith('0x')
+      ? unsignedTxHex.slice(2)
+      : unsignedTxHex;
+
+    const tx = Transaction.fromHex(cleanHex);
+
+    if (tx.ins.length === 0) {
+      throw new Error('Transaction has no inputs');
+    }
+
+    // Extract first input (pegin transactions only have one input)
+    const input = tx.ins[0];
+
+    // Bitcoin stores txid in reverse byte order
+    const txid = Buffer.from(input.hash).reverse().toString('hex');
+    const vout = input.index;
+
+    // Step 2: Fetch full UTXO data from mempool API
+    const utxoData = await fetchUTXOFromMempool(txid, vout);
+
+    return {
+      txid,
+      vout,
+      value: BigInt(utxoData.value),
+      scriptPubKey: utxoData.scriptPubKey,
+    };
+  } catch (error) {
+    if (error instanceof Error) {
+      throw new Error(
+        `Failed to derive UTXO from unsigned transaction: ${error.message}`,
+      );
+    }
+    throw new Error(
+      'Failed to derive UTXO from unsigned transaction: Unknown error',
+    );
+  }
+}
+
+/**
+ * Fetch UTXO data from mempool API
+ *
+ * Queries mempool.space API to get full transaction data and extract
+ * the specific output (UTXO) being spent.
+ *
+ * @param txid - Transaction ID containing the UTXO
+ * @param vout - Output index of the UTXO
+ * @returns UTXO data with scriptPubKey and value
+ * @throws Error if transaction not found or output index invalid
+ */
+async function fetchUTXOFromMempool(
+  txid: string,
+  vout: number,
+): Promise<{ scriptPubKey: string; value: number }> {
+  try {
+    // Fetch transaction info from mempool API
+    const txInfo = await getTxInfo(txid);
+
+    // Validate output index
+    if (vout >= txInfo.vout.length) {
+      throw new Error(
+        `Invalid output index ${vout}. Transaction ${txid} only has ${txInfo.vout.length} outputs.`,
+      );
+    }
+
+    // Extract output data
+    const output = txInfo.vout[vout];
+
+    if (!output) {
+      throw new Error(
+        `Output ${vout} not found in transaction ${txid}. This should not happen after validation.`,
+      );
+    }
+
+    return {
+      scriptPubKey: output.scriptpubkey,
+      value: output.value,
+    };
+  } catch (error) {
+    if (error instanceof Error) {
+      // Check for common error cases and provide helpful messages
+      if (
+        error.message.includes('404') ||
+        error.message.includes('not found')
+      ) {
+        throw new Error(
+          `Transaction ${txid} not found in mempool. The UTXO may have been spent or the transaction is not yet confirmed. Please try again later or contact support.`,
+        );
+      }
+
+      throw new Error(`Failed to fetch UTXO from mempool: ${error.message}`);
+    }
+    throw new Error('Failed to fetch UTXO from mempool: Unknown error');
+  }
+}

--- a/routes/vault/src/storage/peginStorage.ts
+++ b/routes/vault/src/storage/peginStorage.ts
@@ -16,8 +16,23 @@ export interface PendingPeginRequest {
   btcAddress: string; // BTC address used
   timestamp: number; // When the peg-in was initiated
   status: 'pending' | 'confirming' | 'confirmed';
-  // New fields for deferred BTC broadcasting
-  unsignedTxHex?: string; // Unsigned BTC transaction hex (for broadcasting after verification)
+
+  // OPTIONAL CACHE FIELDS (for performance optimization)
+  // These fields enable faster broadcasting but are NOT required for cross-device support.
+  // If missing, the system will:
+  // - Fetch unsignedTxHex from ETH contract
+  // - Derive UTXO from unsignedTxHex + mempool API queries
+
+  /**
+   * Unsigned BTC transaction hex (OPTIONAL cache)
+   * If missing, will be fetched from ETH contract
+   */
+  unsignedTxHex?: string;
+
+  /**
+   * UTXO data (OPTIONAL cache)
+   * If missing, will be derived from unsignedTxHex + mempool API
+   */
   utxo?: {
     txid: string;
     vout: number;


### PR DESCRIPTION
- Uses local storage as cache (so we don't hit mempool if it's there)
- rebuilds the data to make `sign + broadcast` work even without the local storage (multiple device support)

Closes https://github.com/babylonlabs-io/babylon-toolkit/issues/429