### PR TITLE
feat(packages): hide co-staking from rewards if no FF is present

### DIFF
--- a/services/simple-staking/src/ui/common/rewards/index.tsx
+++ b/services/simple-staking/src/ui/common/rewards/index.tsx
@@ -353,7 +353,7 @@ function RewardsPageContent() {
                 babyRewardAmount={formatBalance(babyRewardBaby)}
                 babySymbol={bbnCoinSymbol}
                 coStakingAmount={
-                  coStakingAmountBaby !== undefined
+                  FF.IsCoStakingEnabled && coStakingAmountBaby !== undefined
                     ? formatBalance(coStakingAmountBaby)
                     : undefined
                 }


### PR DESCRIPTION
Hides `co-staking` from reward page if no `FF` is enabled

Before, `main` branch: 

<img width="779" height="510" alt="Screenshot_2025-10-20_11-44-24" src="https://github.com/user-attachments/assets/9c50d5f4-43e6-4cc4-8621-58356d344d36" />

Now:

<img width="786" height="447" alt="Screenshot_2025-10-20_11-43-52" src="https://github.com/user-attachments/assets/fa4fb1d8-47a3-4c2d-ab64-0d620ddfa2d1" />
