### PR TITLE
feat(packages): co-staking rephrase

### DIFF
--- a/services/simple-staking/src/ui/common/components/Modals/CoStakingBoostModal.tsx
+++ b/services/simple-staking/src/ui/common/components/Modals/CoStakingBoostModal.tsx
@@ -3,7 +3,7 @@ import { useMemo } from "react";
 import { getNetworkConfigBTC } from "../../config/network/btc";
 import { getNetworkConfigBBN } from "../../config/network/bbn";
 import { useCoStakingState } from "../../state/CoStakingState";
-import { formatAPRPairAdaptive } from "../../utils/formatAPR";
+import { formatAPRPercentage } from "../../utils/formatAPR";
 
 import { SubmitModal } from "./SubmitModal";
 
@@ -22,9 +22,9 @@ export const CoStakingBoostModal: React.FC<FeedbackModalProps> = ({
   const { coinSymbol: babyCoinSymbol } = getNetworkConfigBBN();
   const { aprData, eligibility, hasValidBoostData } = useCoStakingState();
 
-  const { a: currentAPRDisplay } = useMemo(
-    () => formatAPRPairAdaptive(aprData.currentApr, aprData.boostApr),
-    [aprData.currentApr, aprData.boostApr],
+  const currentAPRDisplay = useMemo(
+    () => formatAPRPercentage(aprData.currentApr),
+    [aprData.currentApr],
   );
 
   const percentageIncrease = useMemo(() => {
@@ -34,10 +34,16 @@ export const CoStakingBoostModal: React.FC<FeedbackModalProps> = ({
     return ((boost - current) / current) * 100;
   }, [aprData.currentApr, aprData.boostApr]);
 
+  const boostPercentDisplay = useMemo(() => {
+    return percentageIncrease < 1
+      ? percentageIncrease.toFixed(1)
+      : Math.round(percentageIncrease).toString();
+  }, [percentageIncrease]);
+
   const submitButtonText = useMemo(
     () =>
-      `Stake ${eligibility.additionalBabyNeeded.toFixed(2)} ${babyCoinSymbol} to Boost APR by ${Math.round(percentageIncrease)}%`,
-    [eligibility.additionalBabyNeeded, babyCoinSymbol, percentageIncrease],
+      `Stake ${eligibility.additionalBabyNeeded.toFixed(2)} ${babyCoinSymbol} to Boost APR by ${boostPercentDisplay}%`,
+    [eligibility.additionalBabyNeeded, babyCoinSymbol, boostPercentDisplay],
   );
 
   // Don't render modal if boost data is not available
@@ -69,10 +75,7 @@ export const CoStakingBoostModal: React.FC<FeedbackModalProps> = ({
         Co-staking lets you earn more by pairing your {btcCoinSymbol} stake with{" "}
         {babyCoinSymbol}. Stake {eligibility.additionalBabyNeeded.toFixed(2)}{" "}
         {babyCoinSymbol} to boost your APR{" "}
-        <span className="text-accent-primary">
-          by {Math.round(percentageIncrease)}%
-        </span>
-        .
+        <span className="text-accent-primary">by {boostPercentDisplay}%</span>.
       </p>
     </SubmitModal>
   );


### PR DESCRIPTION
Rephrase to make the `boost` more obvious for the end user.

Before:

<img width="2032" height="1161" alt="Screenshot_2025-10-20_12-02-17" src="https://github.com/user-attachments/assets/106e0f1e-d4c1-4c2e-ac68-ea6a6a7c2eaa" />

After:

<img width="2032" height="1161" alt="Screenshot_2025-10-20_11-58-33" src="https://github.com/user-attachments/assets/ca851f71-5f50-46ff-94ce-088f91418954" />

Closes: https://github.com/babylonlabs-io/babylon-toolkit/issues/443