### PR TITLE
feat(packages): tbv - prevent rust wasm from releasing

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -57,7 +57,7 @@
     }
   ],
   "release": {
-    "projects": ["packages/*"],
+    "projects": ["packages/*", "!packages/babylon-tbv-rust-wasm"],
     "projectsRelationship": "independent",
     "releaseTagPattern": "{projectName}/{version}",
     "changelog": {


### PR DESCRIPTION
Adds to https://github.com/babylonlabs-io/babylon-toolkit/pull/456
Prevents `nx` from releasing this package