### PR TITLE
feat(packages): tbv - vault - redeem keys inferred

### DIFF
--- a/routes/vault/src/clients/eth-contract/vault-controller/abis/BTCVaultController.abi.json
+++ b/routes/vault/src/clients/eth-contract/vault-controller/abis/BTCVaultController.abi.json
@@ -131,11 +131,6 @@
         "internalType": "bytes32[]"
       },
       {
-        "name": "btcPubKey",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      },
-      {
         "name": "marketParams",
         "type": "tuple",
         "internalType": "struct MarketParams",
@@ -185,11 +180,6 @@
         "name": "pegInTxHashes",
         "type": "bytes32[]",
         "internalType": "bytes32[]"
-      },
-      {
-        "name": "btcPubKey",
-        "type": "bytes32",
-        "internalType": "bytes32"
       },
       {
         "name": "marketParams",
@@ -292,6 +282,19 @@
         "internalType": "uint256"
       }
     ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "depositorRedeemBTCVault",
+    "inputs": [
+      {
+        "name": "pegInTxHash",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [],
     "stateMutability": "nonpayable"
   },
   {
@@ -634,24 +637,6 @@
   },
   {
     "type": "function",
-    "name": "redeemBTCVault",
-    "inputs": [
-      {
-        "name": "pegInTxHash",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      },
-      {
-        "name": "redeemerPKs",
-        "type": "bytes32[]",
-        "internalType": "bytes32[]"
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
     "name": "renounceRole",
     "inputs": [
       {
@@ -724,7 +709,7 @@
       }
     ],
     "outputs": [],
-    "stateMutability": "nonpayable"
+    "stateMutability": "payable"
   },
   {
     "type": "function",
@@ -1093,27 +1078,12 @@
   },
   {
     "type": "error",
-    "name": "EmptyRedeemerKeys",
-    "inputs": []
-  },
-  {
-    "type": "error",
     "name": "InclusionProofVerificationFailed",
     "inputs": []
   },
   {
     "type": "error",
     "name": "InvalidAmount",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "InvalidBTCPublicKey",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "InvalidParticipantsList",
     "inputs": []
   },
   {

--- a/routes/vault/src/clients/eth-contract/vault-controller/transaction.ts
+++ b/routes/vault/src/clients/eth-contract/vault-controller/transaction.ts
@@ -317,10 +317,11 @@ export async function withdrawCollateralFromPosition(
 }
 
 /**
- * Redeem BTC vault (withdraw BTC back to user's account)
+ * Depositor redeems BTC vault (withdraw BTC back to depositor's account)
  *
- * This unlocks and withdraws the BTC collateral from an available vault back to the user's Bitcoin address.
+ * This unlocks and withdraws the BTC collateral from an available vault back to the depositor's Bitcoin address.
  * Can only be called on vaults that are in "Available" status (not locked in a position).
+ * The redeemer public key (vault provider's BTC key) is automatically inferred from the vault.
  *
  * Emits VaultRedeemable event which signals the vault system to release the BTC.
  *
@@ -328,15 +329,13 @@ export async function withdrawCollateralFromPosition(
  * @param chain - Chain configuration
  * @param contractAddress - BTCVaultController contract address
  * @param pegInTxHash - Peg-in transaction hash (vault ID) to redeem
- * @param redeemerPKs - Array of redeemer public keys (x-only, 32 bytes each)
  * @returns Transaction hash and receipt
  */
-export async function redeemBTCVault(
+export async function depositorRedeemBTCVault(
   walletClient: WalletClient,
   chain: Chain,
   contractAddress: Address,
   pegInTxHash: Hex,
-  redeemerPKs: Hex[],
 ): Promise<{ transactionHash: Hash; receipt: TransactionReceipt }> {
   const publicClient = ethClient.getPublicClient();
 
@@ -344,8 +343,8 @@ export async function redeemBTCVault(
     const hash = await walletClient.writeContract({
       address: contractAddress,
       abi: BTCVaultControllerABI,
-      functionName: 'redeemBTCVault',
-      args: [pegInTxHash, redeemerPKs],
+      functionName: 'depositorRedeemBTCVault',
+      args: [pegInTxHash],
       chain,
       account: walletClient.account!,
     });

--- a/routes/vault/src/services/vault/vaultTransactionService.ts
+++ b/routes/vault/src/services/vault/vaultTransactionService.ts
@@ -132,19 +132,12 @@ export async function redeemVault(
     );
   }
 
-  // Step 3: Get vault provider's BTC public key (they are the ones who can claim BTC)
-  const vaultProviderBtcKey = await BTCVaultsManager.getProviderBTCKey(
-    CONTRACTS.BTC_VAULTS_MANAGER,
-    vault.vaultProvider
-  );
-
-  // Step 4: Execute redeem transaction with vault provider's BTC key as redeemer
-  return VaultControllerTx.redeemBTCVault(
+  // Step 3: Execute redeem transaction (redeemer key is automatically inferred from vault provider)
+  return VaultControllerTx.depositorRedeemBTCVault(
     walletClient,
     chain,
     vaultControllerAddress,
-    pegInTxHash,
-    [vaultProviderBtcKey] // redeemerPKs - vault provider can claim the BTC
+    pegInTxHash
   );
 }
 


### PR DESCRIPTION
Adjust to https://github.com/babylonlabs-io/vault-contracts/pull/143

- `redeemBTCVault` -> `depositorRedeemBTCVault`
- `redeemerPKs` are inferred now

Should be merged once https://github.com/babylonlabs-io/vault-contracts/pull/143 is **_deployed_**