### PR TITLE
feat(packages): refactor query client

### DIFF
--- a/services/vault/src/config/queryClient.ts
+++ b/services/vault/src/config/queryClient.ts
@@ -1,4 +1,4 @@
-import { QueryClient, QueryCache, MutationCache } from "@tanstack/react-query";
+import { MutationCache, QueryCache, QueryClient } from "@tanstack/react-query";
 
 const calculateRetryDelay = (attemptIndex: number): number => {
   return Math.min(1000 * 2 ** attemptIndex, 30000);

--- a/services/vault/src/providers.tsx
+++ b/services/vault/src/providers.tsx
@@ -4,8 +4,8 @@ import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { ThemeProvider } from "next-themes";
 import { Suspense, useEffect, useRef, useState } from "react";
 
-import { createQueryClient } from "@/config/queryClient";
 import { NotificationContainer } from "@/components/NotificationContainer";
+import { createQueryClient } from "@/config/queryClient";
 import { VaultWalletConnectionProvider } from "@/context/wallet";
 import { AppState } from "@/state/AppState";
 


### PR DESCRIPTION
**Problem**
React Query is initialized without default error handling configuration. Each hook manually sets `retry: 2` without consistent retry strategies or error callbacks.

**Acceptance Criteria:**
- QueryClient has centralized configuration with default options
- Global error handler logs errors appropriately
- Default retry strategy uses exponential backoff (max 3 retries)
- All new queries inherit sensible defaults