### PR TITLE
fix: show unbonding time properly

### DIFF
--- a/services/simple-staking/src/ui/common/components/ActivityCard/utils/activityCardTransformers.tsx
+++ b/services/simple-staking/src/ui/common/components/ActivityCard/utils/activityCardTransformers.tsx
@@ -11,7 +11,7 @@ import { FinalityProvider } from "@/ui/common/types/finalityProviders";
 import { satoshiToBtc } from "@/ui/common/utils/btc";
 import { maxDecimals } from "@/ui/common/utils/maxDecimals";
 import { getExpansionType } from "@/ui/common/utils/stakingExpansionUtils";
-import { durationTillNow } from "@/ui/common/utils/time";
+import { blocksToDisplayTime, durationTillNow } from "@/ui/common/utils/time";
 import FeatureFlagService from "@/ui/common/utils/FeatureFlagService";
 
 import { createBsnFpGroupedDetails } from "../../../utils/bsnFpGroupingUtils";
@@ -23,6 +23,7 @@ export interface ActivityCardTransformOptions {
   showExpansionSection?: boolean;
   hideExpansionCompletely?: boolean;
   isBroadcastedExpansion?: boolean;
+  unbondingTime?: number;
 }
 
 /**
@@ -122,6 +123,13 @@ export function transformDelegationToActivityCard(
   // Determine if we should show the expansion pending banner
   const showExpansionPendingBanner = !!options.isBroadcastedExpansion;
 
+  const unbondingDetail = options.unbondingTime
+    ? {
+        label: "Unbonding Period",
+        value: `~ ${blocksToDisplayTime(options.unbondingTime)}`,
+      }
+    : undefined;
+
   return {
     formattedAmount,
     icon: icon,
@@ -132,6 +140,7 @@ export function transformDelegationToActivityCard(
     isPendingExpansion,
     showExpansionPendingBanner,
     hideExpansionCompletely: options.hideExpansionCompletely,
+    optionalDetails: unbondingDetail ? [unbondingDetail] : [],
   };
 }
 

--- a/services/simple-staking/src/ui/common/components/Multistaking/MultistakingModal/MultistakingModal.tsx
+++ b/services/simple-staking/src/ui/common/components/Multistaking/MultistakingModal/MultistakingModal.tsx
@@ -168,9 +168,7 @@ export function MultistakingModal() {
     if (!formData || !stakingInfo) return null;
 
     const unbondingTime =
-      blocksToDisplayTime(
-        networkInfo?.params.bbnStakingParams?.latestParam?.unbondingTime,
-      ) || "7 days";
+      blocksToDisplayTime(stakingInfo?.unbondingTime) || "7 days";
 
     const stakeAmountBtc = maxDecimals(satoshiToBtc(formData.amount), 8);
     const stakeAmountUsd = calculateTokenValueInCurrency(
@@ -204,7 +202,7 @@ export function MultistakingModal() {
       unbonding: `~ ${unbondingTime}`,
       unbondingFee: `${unbondingFeeBtc} ${coinSymbol}${displayUSD ? ` (${unbondingFeeUsd})` : ""}`,
     };
-  }, [formData, stakingInfo, networkInfo, btcInUsd, coinSymbol]);
+  }, [formData, stakingInfo, btcInUsd, coinSymbol]);
 
   if (!step) return null;
 

--- a/services/simple-staking/src/ui/common/hooks/services/useActivityCardTransformation.ts
+++ b/services/simple-staking/src/ui/common/hooks/services/useActivityCardTransformation.ts
@@ -8,6 +8,7 @@ import {
 import { useBTCWallet } from "@/ui/common/context/wallet/BTCWalletProvider";
 import { ActionType } from "@/ui/common/hooks/services/useDelegationService";
 import { useExpansionVisibilityService } from "@/ui/common/hooks/services/useExpansionVisibilityService";
+import { useNetworkInfo } from "@/ui/common/hooks/client/api/useNetworkInfo";
 import {
   DelegationV2,
   DelegationWithFP,
@@ -41,16 +42,24 @@ export function useActivityCardTransformation(
   const { publicKeyNoCoord } = useBTCWallet();
   const { isBroadcastedExpansion } =
     useExpansionVisibilityService(publicKeyNoCoord);
+  const { data: networkInfo } = useNetworkInfo();
 
   return useMemo(() => {
     return delegations.map((delegation) => {
       // Check if this delegation is a broadcasted expansion
       const isBroadcasted = isBroadcastedExpansion(delegation);
 
+      const unbondingTime =
+        networkInfo?.params.bbnStakingParams.versions.find(
+          (v) => v.version === delegation.paramsVersion,
+        )?.unbondingTime ??
+        networkInfo?.params.bbnStakingParams.latestParam?.unbondingTime;
+
       // Transform delegation to activity card format
       const options: ActivityCardTransformOptions = {
         showExpansionSection: true,
         isBroadcastedExpansion: isBroadcasted,
+        unbondingTime: unbondingTime,
       };
       const cardData = transformDelegationToActivityCard(
         delegation,
@@ -93,5 +102,6 @@ export function useActivityCardTransformation(
     openConfirmationModal,
     isStakingManagerReady,
     isBroadcastedExpansion,
+    networkInfo,
   ]);
 }


### PR DESCRIPTION
resolves: https://github.com/babylonlabs-io/babylon-toolkit/issues/536

- show `Unbonding Period` on each delegation’s Activity card, computed from the delegation’s `paramsVersion` (falls back to latest param when missing)
- fixes mainnet unbonding period display bug 
- update staking modal to use `stakingInfo.unbondingTime`
