### PR TITLE
fix: show details of staking after verification

### DIFF
--- a/services/simple-staking/src/ui/common/components/Multistaking/MultistakingModal/MultistakingModal.tsx
+++ b/services/simple-staking/src/ui/common/components/Multistaking/MultistakingModal/MultistakingModal.tsx
@@ -76,7 +76,9 @@ export function MultistakingModal() {
       ?.btcConfirmationDepth || DEFAULT_CONFIRMATION_DEPTH;
 
   const detailsModalTitle =
-    (delegationV2StepOptions?.type as string) || "Transaction Details";
+    typeof delegationV2StepOptions?.type === "string"
+      ? delegationV2StepOptions.type
+      : "Transaction Details";
 
   const currentFinalityProviders = useWatch<
     { finalityProviders: Record<string, string> | string[] | undefined },


### PR DESCRIPTION
resolves: https://github.com/babylonlabs-io/babylon-toolkit/issues/538

- added `SignDetailsModal` to `MultistakingModal`
- keep existing pattern in `DelegationModal` and `StakingExpansionModalSystem`