### PR TITLE
fix: show clear error when connecting to a wallet that doesn't support custom chains

### DIFF
--- a/services/simple-staking/src/ui/common/context/Error/ErrorProvider.tsx
+++ b/services/simple-staking/src/ui/common/context/Error/ErrorProvider.tsx
@@ -48,9 +48,6 @@ export const ErrorProvider: FC<ErrorProviderProps> = ({ children }) => {
 
   const dismissError = useCallback(() => {
     setState((prev) => ({ ...prev, isOpen: false }));
-    setTimeout(() => {
-      setState({ isOpen: false, error: { message: "" }, modalOptions: {} });
-    }, 300);
   }, []);
 
   const handleError = useCallback(
@@ -69,12 +66,18 @@ export const ErrorProvider: FC<ErrorProviderProps> = ({ children }) => {
       };
 
       if (shouldShowModal) {
-        setState({
-          isOpen: true,
-          error: errorData,
-          modalOptions: {
-            ...displayOptions,
-          },
+        setState((prev) => {
+          // Prevent flicker: if modal is already open with the same error message, don't update
+          if (prev.isOpen && prev.error.message === errorData.message) {
+            return prev;
+          }
+          return {
+            isOpen: true,
+            error: errorData,
+            modalOptions: {
+              ...displayOptions,
+            },
+          };
         });
       }
     },

--- a/services/simple-staking/src/ui/common/context/wallet/WalletConnectionProvider.tsx
+++ b/services/simple-staking/src/ui/common/context/wallet/WalletConnectionProvider.tsx
@@ -3,7 +3,7 @@ import {
   createWalletConfig,
 } from "@babylonlabs-io/wallet-connector";
 import { useTheme } from "next-themes";
-import { useCallback, type PropsWithChildren } from "react";
+import { useCallback, useMemo, type PropsWithChildren } from "react";
 import { useLocation } from "react-router";
 
 import { getNetworkConfigBBN } from "@/ui/common/config/network/bbn";
@@ -52,21 +52,33 @@ export const WalletConnectionProvider = ({ children }: PropsWithChildren) => {
     [handleError, logger],
   );
 
-  const requiredChains: ("BBN" | "BTC" | "ETH")[] =
-    location.pathname.startsWith("/baby")
-      ? ["BBN"]
-      : location.pathname.startsWith("/vault")
-        ? ["BTC", "ETH"]
-        : ["BTC", "BBN"];
+  const requiredChains: ("BBN" | "BTC" | "ETH")[] = useMemo(
+    () =>
+      location.pathname.startsWith("/baby")
+        ? ["BBN"]
+        : location.pathname.startsWith("/vault")
+          ? ["BTC", "ETH"]
+          : ["BTC", "BBN"],
+    [location.pathname],
+  );
 
-  const config = createWalletConfig({
-    chains: requiredChains,
-    networkConfigs: {
-      BTC: getNetworkConfigBTC(),
-      BBN: getNetworkConfigBBN(),
-      ETH: getNetworkConfigETH(),
-    },
-  });
+  const config = useMemo(
+    () =>
+      createWalletConfig({
+        chains: requiredChains,
+        networkConfigs: {
+          BTC: getNetworkConfigBTC(),
+          BBN: getNetworkConfigBBN(),
+          ETH: getNetworkConfigETH(),
+        },
+      }),
+    [requiredChains],
+  );
+
+  const disabledWallets = useMemo(
+    () => (FeatureFlagService.IsLedgerEnabled ? [] : ["ledget_btc"]),
+    [],
+  );
 
   return (
     <WalletProvider
@@ -75,7 +87,7 @@ export const WalletConnectionProvider = ({ children }: PropsWithChildren) => {
       config={config}
       context={context}
       onError={onError}
-      disabledWallets={FeatureFlagService.IsLedgerEnabled ? [] : ["ledget_btc"]}
+      disabledWallets={disabledWallets}
       requiredChains={requiredChains}
     >
       {children}


### PR DESCRIPTION
resolves: https://github.com/babylonlabs-io/babylon-toolkit/issues/532

- `ErrorProvider`
  - remove `setTimeout` delay when dismissing errors
  - prevent modal flicker by avoiding duplicate error updates for the same message
  - tested visually to make sure there is no problem

- `WalletConnectionProvider`
  - add handling for unsupported custom chain errors with guidance to use Keplr/Leap
  - use `useMemo` for `requiredChains`, `config`, and `disabledWallets` to avoid unnecessary recalculations

- tested with `OKX`, `Keplr`, `Leap`, `OneKey`, `Unisat`

https://github.com/user-attachments/assets/5585cf35-0d16-4f09-8096-b3d0fb1647b3

---

suggestion:
we can also not show (or gray out) okx in `Select Babylon Chain Wallet` section, maybe by adding `isOkxSupported` field to network configs