### PR TITLE
fix(packages): single wagmi instance to be used across services and w…

### DIFF
--- a/packages/babylon-wallet-connector/src/index.tsx
+++ b/packages/babylon-wallet-connector/src/index.tsx
@@ -34,3 +34,6 @@ export {
     closeAppKitModal,
     type AppKitModalConfig,
 } from "@/core/wallets/eth/appkit/appKitModal";
+
+// Re-export wagmi hooks to ensure single instance across all consumers
+export * from "@/wagmiExports";

--- a/packages/babylon-wallet-connector/src/wagmiExports.ts
+++ b/packages/babylon-wallet-connector/src/wagmiExports.ts
@@ -1,0 +1,37 @@
+/**
+ * Re-export wagmi hooks to ensure all consumers use the same wagmi instance.
+ * This prevents "WagmiProviderNotFoundError" caused by multiple wagmi instances.
+ *
+ * Always import these hooks from @babylonlabs-io/wallet-connector instead of
+ * directly from 'wagmi' to ensure you're using the same instance as the WagmiProvider.
+ */
+
+export {
+  useAccount,
+  useBalance,
+  useBlockNumber,
+  useChainId,
+  useConnect,
+  useConnections,
+  useConnectorClient,
+  useConfig,
+  useDisconnect,
+  useEstimateGas,
+  useGasPrice,
+  usePrepareTransactionRequest,
+  useReadContract,
+  useReadContracts,
+  useSendTransaction,
+  useSignMessage,
+  useSignTypedData,
+  useSwitchChain,
+  useTransaction,
+  useTransactionReceipt,
+  useWaitForTransactionReceipt,
+  useWalletClient,
+  useWriteContract,
+  type UseAccountReturnType,
+  type UseBalanceReturnType,
+  type UseConnectReturnType,
+  type UseWalletClientReturnType,
+} from 'wagmi';

--- a/services/vault/src/components/Market/Detail/hooks/useBorrowTransaction.ts
+++ b/services/vault/src/components/Market/Detail/hooks/useBorrowTransaction.ts
@@ -3,8 +3,8 @@
  * Handles the borrow flow logic and transaction execution
  */
 
+import { useWalletClient } from "@babylonlabs-io/wallet-connector";
 import { parseUnits, type Hex } from "viem";
-import { useWalletClient } from "wagmi";
 
 import { BTCVaultsManager } from "../../../../clients/eth-contract";
 import { CONTRACTS } from "../../../../config/contracts";

--- a/services/vault/src/components/Market/Detail/hooks/useRepayTransaction.ts
+++ b/services/vault/src/components/Market/Detail/hooks/useRepayTransaction.ts
@@ -3,8 +3,8 @@
  * Handles the repay flow logic and transaction execution
  */
 
+import { useWalletClient } from "@babylonlabs-io/wallet-connector";
 import { parseUnits } from "viem";
-import { useWalletClient } from "wagmi";
 
 import { CONTRACTS } from "../../../../config/contracts";
 import {

--- a/services/vault/src/components/Overview/Deposits/DepositReviewModal/index.tsx
+++ b/services/vault/src/components/Overview/Deposits/DepositReviewModal/index.tsx
@@ -7,10 +7,10 @@ import {
   ResponsiveDialog,
   Text,
 } from "@babylonlabs-io/core-ui";
+import { useEstimateGas, useGasPrice } from "@babylonlabs-io/wallet-connector";
 import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
 import { formatEther } from "viem";
-import { useEstimateGas, useGasPrice } from "wagmi";
 
 import { CONTRACTS } from "../../../../config/contracts";
 import { satoshiToBtcNumber } from "../../../../utils/btcConversion";


### PR DESCRIPTION
We can only use a single wagmi instance, otherwise it will cause runtime error on its config not being initialised.
The error only happens on the build version.

This PR is not the perfect solution, but a good first step.