### PR TITLE
fix: change blocksToDisplayTime behaviour

### DIFF
--- a/services/simple-staking/src/ui/common/components/ActivityCard/utils/activityCardTransformers.tsx
+++ b/services/simple-staking/src/ui/common/components/ActivityCard/utils/activityCardTransformers.tsx
@@ -126,7 +126,7 @@ export function transformDelegationToActivityCard(
   const unbondingDetail = options.unbondingTime
     ? {
         label: "Unbonding Period",
-        value: `~ ${blocksToDisplayTime(options.unbondingTime)}`,
+        value: `${blocksToDisplayTime(options.unbondingTime)}`,
       }
     : undefined;
 

--- a/services/simple-staking/src/ui/common/components/Delegations/DelegationList/components/SlashingContent.tsx
+++ b/services/simple-staking/src/ui/common/components/Delegations/DelegationList/components/SlashingContent.tsx
@@ -67,7 +67,7 @@ export const SlashingContent = ({
           {maxDecimals(satoshiToBtc(slashingAmount ?? 0), 8)} {coinName}
         </b>{" "}
         being deducted from your delegation. It will take {unbondingTime.blocks}{" "}
-        blocks (~ {unbondingTime.time}) before it becomes withdrawable.{" "}
+        blocks ({unbondingTime.time}) before it becomes withdrawable.{" "}
         <a
           className="text-secondary-main"
           target="_blank"

--- a/services/simple-staking/src/ui/common/components/Modals/PreviewModal.tsx
+++ b/services/simple-staking/src/ui/common/components/Modals/PreviewModal.tsx
@@ -141,7 +141,7 @@ export const PreviewModal = ({
         <>
           <Text variant="body1">{stakingTimelock} blocks</Text>
           <Text variant="body2" className="text-accent-secondary">
-            ~ {blocksToDisplayTime(stakingTimelock)}
+            {blocksToDisplayTime(stakingTimelock)}
           </Text>
         </>
       ),
@@ -149,7 +149,7 @@ export const PreviewModal = ({
     {
       key: "On Demand Unbonding",
       value: (
-        <Text variant="body1">Enabled (~ {unbondingTime} unbonding time)</Text>
+        <Text variant="body1">Enabled ({unbondingTime} unbonding time)</Text>
       ),
     },
     {

--- a/services/simple-staking/src/ui/common/components/Multistaking/MultistakingModal/MultistakingModal.tsx
+++ b/services/simple-staking/src/ui/common/components/Multistaking/MultistakingModal/MultistakingModal.tsx
@@ -206,9 +206,9 @@ export function MultistakingModal() {
       transactionFees: `${feeAmountBtc} ${coinSymbol}${displayUSD ? ` (${feeAmountUsd})` : ""}`,
       term: {
         blocks: `${formData.term} blocks`,
-        duration: `~ ${blocksToDisplayTime(formData.term)}`,
+        duration: `${blocksToDisplayTime(formData.term)}`,
       },
-      unbonding: `~ ${unbondingTime}`,
+      unbonding: `${unbondingTime}`,
       unbondingFee: `${unbondingFeeBtc} ${coinSymbol}${displayUSD ? ` (${unbondingFeeUsd})` : ""}`,
     };
   }, [formData, stakingInfo, btcInUsd, coinSymbol]);

--- a/services/simple-staking/src/ui/common/components/StakingExpansion/RenewTimelockModal.tsx
+++ b/services/simple-staking/src/ui/common/components/StakingExpansion/RenewTimelockModal.tsx
@@ -58,7 +58,7 @@ export const RenewTimelockModal = ({
                   {stakingEndInfo.blocks.toLocaleString()} Blocks
                 </Text>
                 <Text variant="caption" className="text-secondary mt-1 block">
-                  ~ {stakingEndInfo.displayTime}
+                  {stakingEndInfo.displayTime}
                 </Text>
               </div>
             </div>

--- a/services/simple-staking/src/ui/common/components/StakingExpansion/StakingExpansionModalSystem.tsx
+++ b/services/simple-staking/src/ui/common/components/StakingExpansion/StakingExpansionModalSystem.tsx
@@ -213,9 +213,9 @@ function StakingExpansionModalSystemInner() {
       transactionFees: `${feeAmountBtc} ${coinSymbol}${displayUSD ? ` (${feeAmountUsd})` : ""}`,
       term: {
         blocks: `${formData.stakingTimelock} blocks`,
-        duration: `~ ${blocksToDisplayTime(formData.stakingTimelock)}`,
+        duration: `${blocksToDisplayTime(formData.stakingTimelock)}`,
       },
-      unbonding: `~ ${unbondingTime}`,
+      unbonding: `${unbondingTime}`,
       unbondingFee: `${unbondingFeeBtc} ${coinSymbol}${displayUSD ? ` (${unbondingFeeUsd})` : ""}`,
     };
 

--- a/services/simple-staking/src/ui/common/utils/time.ts
+++ b/services/simple-staking/src/ui/common/utils/time.ts
@@ -48,11 +48,25 @@ export const blocksToDisplayTime = (blocks: number | undefined): string => {
     return `${roundedWeeks} weeks`;
   }
 
-  // Otherwise, return the difference in days and round up to the nearest day
-  return formatDistanceStrict(startDate, endDate, {
+  // Hybrid day formatting under 30 days:
+  // - Use formatDistanceStrict with roundingMethod 'round' to get nearest day count
+  // - If under 1 day, display '< 1 day'
+  // - If not an exact integer number of days, prefix with '~'
+  const daysDecimal = hours / 24;
+  if (daysDecimal < 1) {
+    return "< 1 day";
+  }
+
+  const roundedLabel = formatDistanceStrict(startDate, endDate, {
     unit: "day",
-    roundingMethod: "ceil",
+    roundingMethod: "round",
   });
+  const roundedDays = Number.parseInt(roundedLabel, 10);
+  const isInteger = Math.abs(daysDecimal - Math.round(daysDecimal)) < 1e-9;
+  if (isInteger) {
+    return `${roundedDays} ${roundedDays === 1 ? "day" : "days"}`;
+  }
+  return `~${roundedDays} ${roundedDays === 1 ? "day" : "days"}`;
 };
 
 interface Duration {

--- a/services/simple-staking/tests/utils/time.test.ts
+++ b/services/simple-staking/tests/utils/time.test.ts
@@ -1,32 +1,101 @@
 import { blocksToDisplayTime, durationTillNow } from "@/ui/common/utils/time";
 
 describe("blocksToDisplayTime", () => {
+  beforeEach(() => {
+    // Freeze time to ensure consistent test results
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2024-01-01T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("should return '-' if block is undefined", () => {
+    expect(blocksToDisplayTime(undefined)).toBe("-");
+  });
+
   it("should return '-' if block is 0", () => {
     expect(blocksToDisplayTime(0)).toBe("-");
   });
 
-  it("should convert 1 block to 1 day", () => {
-    expect(blocksToDisplayTime(1)).toBe("1 day");
+  it("should show < 1 day for very small durations (e.g., 1 block)", () => {
+    expect(blocksToDisplayTime(1)).toBe("< 1 day");
   });
 
-  it("should convert 200 blocks to 2 days", () => {
-    expect(blocksToDisplayTime(200)).toBe("2 days");
+  it("should show < 1 day for 6 blocks (1 hour)", () => {
+    expect(blocksToDisplayTime(6)).toBe("< 1 day");
   });
 
-  it("should convert 900 blocks to 7 days", () => {
-    expect(blocksToDisplayTime(900)).toBe("7 days");
+  it("should convert 200 blocks to ~1 day", () => {
+    expect(blocksToDisplayTime(200)).toBe("~1 day");
+  });
+
+  it("should convert 144 blocks to 1 day", () => {
+    // 144 blocks = 24 hours = 1 day
+    expect(blocksToDisplayTime(144)).toBe("1 day");
+  });
+
+  it("should convert 288 blocks to 2 days", () => {
+    // 288 blocks = 48 hours = 2 days
+    expect(blocksToDisplayTime(288)).toBe("2 days");
+  });
+
+  it("should convert 301 blocks to ~2 days", () => {
+    // 301 blocks ≈ 50.17 hours ≈ 2.09 days
+    expect(blocksToDisplayTime(301)).toBe("~2 days");
+  });
+
+  it("should convert 900 blocks to ~6 days", () => {
+    expect(blocksToDisplayTime(900)).toBe("~6 days");
+  });
+
+  it("should convert blocks just under 30 days threshold to days", () => {
+    // 29 days = 29 * 24 * 6 = 4176 blocks
+    expect(blocksToDisplayTime(4176)).toContain("day");
+  });
+
+  it("should convert 4320 blocks to 5 weeks", () => {
+    // 4320 blocks = 30 days = exactly at threshold, should be rounded to 5 weeks
+    expect(blocksToDisplayTime(4320)).toBe("5 weeks");
+  });
+
+  it("should convert blocks at 30 days threshold to weeks", () => {
+    // 4320 blocks = 30 days = threshold
+    expect(blocksToDisplayTime(4320)).toBe("5 weeks");
+  });
+
+  it("should convert blocks slightly over 30 days to weeks", () => {
+    // 4321 blocks = 30 days + 10 minutes, should round to 5 weeks
+    expect(blocksToDisplayTime(4321)).toBe("5 weeks");
   });
 
   it("should convert 30000 blocks to 30 weeks", () => {
     expect(blocksToDisplayTime(30000)).toBe("30 weeks");
   });
 
-  it("should convert 4320 blocks to 5 weeks", () => {
-    expect(blocksToDisplayTime(4320)).toBe("5 weeks");
-  });
-
   it("should convert 63000 blocks to 65 weeks", () => {
     expect(blocksToDisplayTime(63000)).toBe("65 weeks");
+  });
+
+  it("should round weeks to nearest 5 weeks", () => {
+    // 21600 blocks = 150 days = ~21.4 weeks, should round to 20 weeks
+    expect(blocksToDisplayTime(21600)).toBe("20 weeks");
+  });
+
+  it("should round weeks up to nearest 5 weeks when above midpoint", () => {
+    // 25200 blocks = 175 days = ~25 weeks, should round to 25 weeks
+    expect(blocksToDisplayTime(25200)).toBe("25 weeks");
+  });
+
+  it("should round weeks to nearest 5 weeks for values between 5-week intervals", () => {
+    // 32400 blocks = 225 days = ~32.1 weeks, ceil rounds to 33, then rounds to 35 weeks
+    expect(blocksToDisplayTime(32400)).toBe("35 weeks");
+  });
+
+  it("should handle large block values", () => {
+    // 100000 blocks = ~694 days = ~99 weeks, should round to 100 weeks
+    expect(blocksToDisplayTime(100000)).toBe("100 weeks");
   });
 });
 


### PR DESCRIPTION
- `blocksToDisplayTime`
  - "< 1 day" for durations under 24 hours
  - uses "round" instead of "ceil" for day calculations
  - adds "~" prefix only for non-integer day values (under 30 days)
  - shows exact values without "~" for integer day counts
- removed hardcoded "~" prefixes from UI components
- added test cases
