### PR TITLE
feat(packages): coin symbol in APR

### DIFF
--- a/services/simple-staking/src/ui/common/components/Stats/Stats.tsx
+++ b/services/simple-staking/src/ui/common/components/Stats/Stats.tsx
@@ -78,8 +78,7 @@ export const Stats = memo(() => {
                 </p>
                 <p>
                   The second number is the {coinSymbol} Staking APR if you
-                  co-stake {coinSymbol}
-                  and BABY.
+                  co-stake {coinSymbol} and BABY.
                 </p>
                 <p>
                   Annual Percentage Reward (APR) is a dynamic estimate of the


### PR DESCRIPTION
- For tooltip of APR card changes from `BTC` to `coinSymbol` variable, so it's `sBTC` on `testnet` and `BTC` for `mainnet`