### PR TITLE
fix(packages): ecc init

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
       "@walletconnect/logger": "3.0.0",
       "glob": ">=11.1.0",
       "babel-plugin-module-resolver>glob": "9.3.5",
-      "js-yaml": ">=4.1.1"
+      "js-yaml": ">=4.1.1",
+      "bitcoinjs-lib": "6.1.5"
     }
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,7 @@ overrides:
   glob: '>=11.1.0'
   babel-plugin-module-resolver>glob: 9.3.5
   js-yaml: '>=4.1.1'
+  bitcoinjs-lib: 6.1.5
 
 importers:
 
@@ -4096,7 +4097,7 @@ packages:
       '@keystonehq/keystone-sdk': 0.9.0
       '@keystonehq/sdk': 0.22.1
       '@scure/bip32': ^1.4.0
-      bitcoinjs-lib: ^6.1.5
+      bitcoinjs-lib: 6.1.5
       react: ^18
       react-dom: ^18
 
@@ -5196,10 +5197,6 @@ packages:
 
   bitcoinjs-lib@6.1.5:
     resolution: {integrity: sha512-yuf6xs9QX/E8LWE2aMJPNd0IxGofwfuVOiYdNUESkc+2bHHVKjhJd8qewqapeoolh9fihzHGoDCB5Vkr57RZCQ==}
-    engines: {node: '>=8.0.0'}
-
-  bitcoinjs-lib@6.1.7:
-    resolution: {integrity: sha512-tlf/r2DGMbF7ky1MgUqXHzypYHakkEnm0SZP23CJKIqNY/5uNAnMbFhMJdhjrL/7anfb/U8+AlpdjPWjPnAalg==}
     engines: {node: '>=8.0.0'}
 
   bl@4.1.0:
@@ -13609,7 +13606,7 @@ snapshots:
       '@wallet-standard/app': 1.1.0
       '@wallet-standard/base': 1.1.0
       '@walletconnect/universal-provider': 2.22.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12)
-      bitcoinjs-lib: 6.1.7
+      bitcoinjs-lib: 6.1.5
       sats-connect: 3.5.0(typescript@5.9.2)
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -18048,15 +18045,6 @@ snapshots:
       sha256-uint8array: 0.10.7
 
   bitcoinjs-lib@6.1.5:
-    dependencies:
-      '@noble/hashes': 1.8.0
-      bech32: 2.0.0
-      bip174: 2.1.1
-      bs58check: 3.0.1
-      typeforce: 1.18.0
-      varuint-bitcoin: 1.1.2
-
-  bitcoinjs-lib@6.1.7:
     dependencies:
       '@noble/hashes': 1.8.0
       bech32: 2.0.0

--- a/services/simple-staking/src/main.tsx
+++ b/services/simple-staking/src/main.tsx
@@ -1,3 +1,4 @@
+import { initBTCCurve } from "@babylonlabs-io/btc-staking-ts";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { ErrorBoundary } from "react-error-boundary";
@@ -9,6 +10,17 @@ import { Router } from "@/ui/router";
 
 import "@/ui/globals.css";
 import "../sentry.client.config";
+
+/**
+ * Initialize the ECC library for bitcoinjs-lib before app starts.
+ * This must be called before any Bitcoin operations.
+ *
+ * Note: We use pnpm.overrides in the workspace root package.json to ensure
+ * all packages (including @reown/appkit-adapter-bitcoin) use the same
+ * bitcoinjs-lib version, so this single initialization call works for the entire app.
+ * Can be removed once @reown/appkit-adapter-bitcoin makes bitcoinjs-lib a peer dependency.
+ */
+initBTCCurve();
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/services/simple-staking/src/ui/common/page.tsx
+++ b/services/simple-staking/src/ui/common/page.tsx
@@ -1,4 +1,3 @@
-import { initBTCCurve } from "@babylonlabs-io/btc-staking-ts";
 import {
   useWalletConnect,
   useAppKitBtcBridge,
@@ -16,10 +15,6 @@ import { Tabs } from "./components/Tabs";
 
 const Home = () => {
   const [activeTab, setActiveTab] = useState("stake");
-
-  useEffect(() => {
-    initBTCCurve();
-  }, []);
 
   const { connected } = useWalletConnect();
   const { isGeoBlocked, isLoading } = useHealthCheck();

--- a/services/simple-staking/vite.config.ts
+++ b/services/simple-staking/vite.config.ts
@@ -25,6 +25,13 @@ const enableSentryPlugin =
 
 // https://vite.dev/config/
 export default defineConfig({
+  optimizeDeps: {
+    include: [
+      "bitcoinjs-lib",
+      "@bitcoin-js/tiny-secp256k1-asmjs",
+      "@babylonlabs-io/btc-staking-ts",
+    ],
+  },
   build: {
     outDir: "dist",
     sourcemap: true,


### PR DESCRIPTION
Fixes the ECC initialization issue that prevented BTC wallet connections.

### Root Cause
`@reown/appkit-adapter-bitcoin` was using `bitcoinjs-lib@6.1.7` while
 other packages used `6.1.5`. Multiple versions created separate
module instances, breaking the ECC singleton initialization.

### Solution

The pnpm override + early initialization + Vite optimization ensures
a single bitcoinjs-lib instance is initialized before any wallet
operations.


Next step:
1. Ping reown on making their dependency as peer dependency
2. bump btc-staking-ts and all libs we use to the 6.1.7