### PR TITLE
fix(packages): fix vault build issue with polyfills

### DIFF
--- a/packages/babylon-ts-sdk/package.json
+++ b/packages/babylon-ts-sdk/package.json
@@ -70,7 +70,8 @@
   "dependencies": {
     "@babylonlabs-io/babylon-tbv-rust-wasm": "workspace:*",
     "@bitcoin-js/tiny-secp256k1-asmjs": "2.2.3",
-    "bitcoinjs-lib": "6.1.7"
+    "bitcoinjs-lib": "6.1.7",
+    "buffer": "6.0.3"
   },
   "devDependencies": {
     "@internal/eslint-config": "workspace:*",

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts
@@ -16,6 +16,7 @@ import {
   tapInternalPubkey,
 } from "@babylonlabs-io/babylon-tbv-rust-wasm";
 import * as ecc from "@bitcoin-js/tiny-secp256k1-asmjs";
+import { Buffer } from "buffer";
 import { initEccLib, payments, Psbt, Transaction } from "bitcoinjs-lib";
 import { createPayoutScript } from "../scripts/payout";
 import {
@@ -23,9 +24,6 @@ import {
   stripHexPrefix,
   uint8ArrayToHex,
 } from "../utils/bitcoin";
-
-// Use Buffer from global scope (provided by bitcoinjs-lib or polyfills)
-declare const Buffer: typeof import("buffer").Buffer;
 
 // Initialize ECC library for bitcoinjs-lib
 initEccLib(ecc);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -461,6 +461,9 @@ importers:
       bitcoinjs-lib:
         specifier: 6.1.7
         version: 6.1.7
+      buffer:
+        specifier: 6.0.3
+        version: 6.0.3
     devDependencies:
       '@internal/eslint-config':
         specifier: workspace:*

--- a/services/vault/vite.config.ts
+++ b/services/vault/vite.config.ts
@@ -1,6 +1,7 @@
-import react from "@vitejs/plugin-react";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+
+import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 import EnvironmentPlugin from "vite-plugin-environment";
 import { nodePolyfills } from "vite-plugin-node-polyfills";
@@ -26,10 +27,6 @@ export default defineConfig({
       input: {
         main: resolve(__dirname, "index.html"),
       },
-      // External shim is needed because nodePolyfills plugin transforms Buffer usage
-      // in dependencies (including ts-sdk's Buffer.from() calls). The Buffer global is
-      // provided by globals.Buffer=true, so the shim import can be external.
-      external: ["vite-plugin-node-polyfills/shims/buffer"],
       output: {
         manualChunks: {
           react: ["react", "react-dom"],
@@ -43,13 +40,7 @@ export default defineConfig({
     tsconfigPaths({
       projects: [resolve(__dirname, "./tsconfig.lib.json")],
     }),
-    nodePolyfills({
-      include: ["buffer", "crypto"],
-      globals: {
-        Buffer: true,
-      },
-      protocolImports: true,
-    }),
+    nodePolyfills({ include: ["buffer", "crypto"] }),
     EnvironmentPlugin("all", { prefix: "NEXT_PUBLIC_" }),
   ],
   define: {


### PR DESCRIPTION
**Root Cause:**
The ts-sdk was using Buffer from global scope via declare const Buffer without actually importing it. When the vault service's nodePolyfills plugin processed the ts-sdk's compiled dist during build, it tried to inject a buffer shim import that couldn't be resolved properly with pnpm's node_modules structure.

**Solution:**
1. Changed ts-sdk's payout.ts to explicitly import Buffer from the buffer package instead of relying on a global declaration
2. Added buffer as a dependency in ts-sdk's package.json
3. Simplified vault's vite config to match simple-staking (removed unnecessary globals and protocolImports options from nodePolyfills)