### PR TITLE
fix: add fingerprint to trackEvent

### DIFF
--- a/services/simple-staking/src/ui/baby/components/CoStakingBoostSection/index.tsx
+++ b/services/simple-staking/src/ui/baby/components/CoStakingBoostSection/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useCallback } from "react";
 import { MdRocketLaunch } from "react-icons/md";
 import { useSessionStorage } from "usehooks-ts";
 import { useNavigate } from "react-router";
@@ -51,7 +51,7 @@ export function CoStakingBoostSection({
     });
   };
 
-  const handleClose = () => {
+  const handleClose = useCallback(() => {
     trackEvent(
       AnalyticsCategory.CTA_CLICK,
       AnalyticsMessage.DISMISS_COSTAKING_PREFILL_CTA,
@@ -60,7 +60,7 @@ export function CoStakingBoostSection({
       },
     );
     setShowCoStakingBoostSection(false);
-  };
+  }, [setShowCoStakingBoostSection]);
 
   const formattedSuggestedAmount = useMemo(
     () => formatBalance(eligibility.additionalBabyNeeded || 0, babyCoinSymbol),

--- a/services/simple-staking/src/ui/common/utils/analytics.ts
+++ b/services/simple-staking/src/ui/common/utils/analytics.ts
@@ -66,12 +66,18 @@ export function trackEvent(
     }
   });
 
+  const timestamp = new Date().toISOString();
+
   Sentry.captureEvent({
     message,
     level: "debug",
     tags,
+    // Add a simple nonce into the fingerprint so that Sentry's
+    // client-side Dedupe integration does not drop consecutive
+    // analytics events that reuse the same `message`.
+    fingerprint: [message, timestamp],
     extra: {
-      timestamp: new Date().toISOString(),
+      timestamp,
       ...data,
     },
   });


### PR DESCRIPTION
This is needed for Sentry to not drop consecutive analytics events that reuse the same `message`.