### PR TITLE
chore(build): remove hono pnpm override

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "pnpm": {
     "overrides": {
       "axios": ">=1.12.0",
-      "hono": ">=4.10.3",
       "@walletconnect/logger": "3.0.0",
       "js-yaml": ">=4.1.1",
       "bitcoinjs-lib": "6.1.7"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,6 @@ settings:
 
 overrides:
   axios: '>=1.12.0'
-  hono: '>=4.10.3'
   '@walletconnect/logger': 3.0.0
   js-yaml: '>=4.1.1'
   bitcoinjs-lib: 6.1.7


### PR DESCRIPTION
Remove the hono>=4.10.3 override as natural resolution now provides a safe version (hono@4.10.4) that meets security requirements. The override was only affecting porto as a transitive dependency.

Validation completed:
- Build: passed
- Tests: passed
- Lint: passed
- Security audit: no vulnerabilities found
- Resolved version: hono@4.10.4 (satisfies >=4.10.3 requirement)