### PR TITLE
chore(build): add pnpm-version-bumper skill

### DIFF
--- a/.claude/skills/pnpm-version-bumper/SKILL.md
+++ b/.claude/skills/pnpm-version-bumper/SKILL.md
@@ -1,0 +1,201 @@
+---
+name: pnpm-version-bumper
+description: Systematically bump package versions in pnpm monorepos by analyzing pnpm-lock.yaml, walking dependency trees, and finding the optimal parent package to upgrade. Use when the user asks to bump a package to meet a specific version requirement (e.g., "bump tmp to >=0.2.4", "upgrade package X to meet requirement Y", or "resolve version conflict for package Z"). Handles transitive dependencies and suggests overrides when needed.
+---
+
+# pnpm Version Bumper
+
+## Overview
+
+Systematically resolve package version conflicts in pnpm monorepos by analyzing the lockfile, walking the dependency tree, and finding the optimal parent package to upgrade. When walking the tree doesn't work, suggest pnpm overrides as a last resort.
+
+## Quick Start
+
+For a request like "Bump tmp to >=0.2.4":
+1. Check pnpm-lock.yaml for all installed versions (don't rely on `pnpm why` alone)
+2. Identify which versions don't meet the requirement
+3. Walk up the dependency tree from problem version to workspace package
+4. Find a parent package that can be upgraded to solve the problem
+5. Update package.json, run `pnpm install`, and verify
+
+## Core Workflow
+
+Execute these steps in order, reporting progress at each step for transparency.
+
+### 1. Install Dependencies and Identify Versions
+
+Run `pnpm install` to ensure lockfile is up to date.
+
+Use `grep -n "<package>@" pnpm-lock.yaml` to extract all installed versions from pnpm-lock.yaml. Do NOT rely on `pnpm why` alone as it can be misleading and may not show all versions.
+
+**Report to user:** "Found X versions of <package> in pnpm-lock.yaml: [list versions with line numbers]"
+
+### 2. Identify Problem Versions
+
+For each version found, check if it satisfies the requirement. Consider semver rules:
+- `>=X.Y.Z`: Version must be greater than or equal to X.Y.Z
+- `^X.Y.Z`: Compatible with X.Y.Z (same major version for X>0, same minor for 0.Y.Z)
+- `~X.Y.Z`: Approximately equivalent to X.Y.Z (same minor version)
+
+For complex semver ranges, read `references/semver-guide.md` for detailed rules.
+
+**Report to user:** "<package>@<version> [meets/does not meet] requirement <requirement>"
+
+If all versions meet requirement, inform user and stop - no work needed.
+
+### 3. Analyze Dependency Tree
+
+For each problematic version, run `pnpm why -r <package>@<version>` to show the full dependency chain from workspace package down to the problem package.
+
+**Report to user:** "Dependency chain for <package>@<version>:"
+
+Show the full output from pnpm why, then summarize the chain:
+"<workspace-package> → <parent-package>@<version> → <grandparent>@<version> → ... → <problem-package>@<version>"
+
+### 4. Walk Up the Tree
+
+Starting from the direct parent of the problem package, examine each package in the chain to see if upgrading it would solve the problem.
+
+For each parent package in the chain:
+
+**a. Check parent's current requirement:**
+- Run `npm view <parent-package>@<current-version> dependencies | grep <package>`
+- Extract the semver range requirement
+- **Report:** "<parent-package>@<current-version> requires <package>: <semver-range>"
+
+**b. Check if parent can be upgraded:**
+- Find what the grandparent requires: `npm view <grandparent>@<version> dependencies | grep <parent>`
+- List available versions: `npm view <parent-package> versions --json`
+- Filter to versions within grandparent's allowed range
+- Identify the latest acceptable version
+- **Report:** "Latest version of <parent-package> within allowed range: <version>"
+
+**c. Check if upgrading solves the problem:**
+- Run `npm view <parent-package>@<newer-version> dependencies`
+- Check if it uses a different/newer version of the problem package
+- Verify the new version meets the requirement
+- **Report:** "<parent-package>@<newer-version> uses <package>@<version>" (and state whether it meets requirement)
+
+**d. If solution found:**
+- **Report:** "Solution found! Upgrading <parent-package> from <old-version> to <new-version> will resolve the issue."
+- Find which workspace package depends on this parent
+- Update that workspace package's package.json to require the new version
+- Run `pnpm install`
+- Proceed to verification (step 5)
+- Stop - problem solved
+
+**e. If no solution at this level:**
+- **Report:** "No solution found by upgrading <parent-package>, checking next parent in chain..."
+- Continue to the next parent up the chain
+
+### 5. Verify Resolution
+
+After making changes, run these verification steps and report each result:
+
+**a.** Run `pnpm why -r <package>@<old-version>` - should return empty
+- **Report:** "✓ <package>@<old-version> no longer in dependency tree"
+
+**b.** Run `grep "<package>@<old-version>" pnpm-lock.yaml` - should return empty
+- **Report:** "✓ <package>@<old-version> not found in pnpm-lock.yaml"
+
+**c.** Run `grep "<package>@" pnpm-lock.yaml` - confirm only acceptable versions remain
+- **Report:** "✓ Only <package>@<version> remains (meets requirement <requirement>)"
+
+**d.** Run `pnpm why -r <package>` - show final dependency tree
+- **Report:** "Final dependency tree:" [show full output]
+
+**Final summary:** "Successfully bumped <package> by upgrading <parent-package> from <old-version> to <new-version>. All versions now meet requirement <requirement>."
+
+**Verification Failed?** It's common that there will be other branch of the dependency tree still using the old version. If so, return to step 4 and continue walking up the tree to find another parent to upgrade.
+
+### 6. Handle Edge Cases
+
+If walking up the tree exhausted all parents without finding a solution:
+
+**a. Check if problem package is a direct dependency:**
+- Look at the workspace package's package.json
+- If it's a direct dependency: Can update it directly in package.json
+- If it's a peer dependency: Consider if breaking change is acceptable
+- **Report findings and recommend action**
+
+**b. If no parent can be upgraded (all are already at latest versions):**
+- Read `references/overrides-guide.md` for detailed guidance
+- Explain that pnpm overrides are the last resort
+- Suggest specific override syntax: `"<parent>><package>": "<version>"`
+- **Explain risks:**
+  - May introduce breaking changes if package API changed
+  - Bypasses normal dependency resolution
+  - Requires manual maintenance and testing
+- **Report:** "No parent can be upgraded. Recommend using pnpm override: [show exact syntax]. This requires thorough testing."
+- Ask user for confirmation before proceeding with override
+
+**c. If upgrade would require breaking changes:**
+- Report clearly: "Upgrading <package> to meet requirement would require upgrading <parent> to version X.0.0, which is a major version change that may break compatibility."
+- Explain what the breaking change entails (if apparent from version jump)
+- Ask user: "Would you like to proceed with this major version upgrade, or explore alternatives like overrides?"
+
+## Decision Tree
+
+```
+User requests: "Bump <package> to meet <requirement>"
+│
+├─ Step 1: Find all versions in pnpm-lock.yaml
+│  └─ Report versions found
+│
+├─ Step 2: Check which versions don't meet requirement
+│  ├─ All versions OK? → Stop, inform user
+│  └─ Some versions fail? → Continue
+│
+├─ Step 3: Get dependency tree for problem versions
+│  └─ Report chain: workspace → ... → problem package
+│
+├─ Step 4: Walk up tree, check each parent
+│  ├─ Can parent be upgraded to fix? → YES
+│  │  ├─ Update workspace package.json
+│  │  ├─ Run pnpm install
+│  │  └─ Go to Step 5 (Verify)
+│  │
+│  └─ Can't be upgraded? → Continue to next parent
+│      ├─ More parents to check? → Loop to next parent
+│      └─ No more parents? → Go to Step 6 (Edge Cases)
+│
+├─ Step 5: Verify solution worked
+│  ├─ Old version gone?
+│  ├─ Only good versions remain?
+│  ├─ Verify success? -> YES
+│  │  └─ Report success to user
+│  └─ Verification failed? → NO
+|     └─ Return to Step 4
+│
+└─ Step 6: Handle edge cases
+   ├─ Direct dependency? → Update directly
+   ├─ Need override? → Suggest with risks, ask confirmation
+   └─ Breaking change required? → Explain, ask user how to proceed
+```
+
+## Bundled References
+
+This skill includes two reference files that are loaded only when needed:
+
+### references/semver-guide.md
+Load when you need to:
+- Understand complex semver range syntax
+- Manually check if a version satisfies a requirement
+- Explain why a version doesn't meet a requirement
+- Handle special cases with 0.x versions
+
+### references/overrides-guide.md
+Load when:
+- Walking up the tree found no solution
+- User asks about forcing a specific package version
+- You need to explain pnpm overrides syntax and risks
+- Recommending overrides as last resort
+
+## Best Practices
+
+1. **Always check pnpm-lock.yaml directly** - `pnpm why` can be misleading
+2. **Report progress at each step** - User should see what you're discovering
+3. **Try walking the tree first** - Overrides are last resort
+4. **Be specific with overrides** - Use `parent>package` syntax when possible
+5. **Explain risks clearly** - Breaking changes, testing requirements, maintenance burden
+6. **Verify thoroughly** - Check lockfile, dependency tree, and test if possible

--- a/.claude/skills/pnpm-version-bumper/references/overrides-guide.md
+++ b/.claude/skills/pnpm-version-bumper/references/overrides-guide.md
@@ -1,0 +1,251 @@
+# pnpm Overrides Guide
+
+## When to Use Overrides
+
+Overrides are a **last resort** for forcing a specific package version when:
+1. Walking up the dependency tree found no solution
+2. A parent package has a restrictive semver range that can't be upgraded
+3. You need to apply a security patch that parent packages haven't adopted yet
+4. A transitive dependency has a known bug that's fixed in a newer version
+
+**Do NOT use overrides** when:
+- A parent package CAN be upgraded to solve the problem
+- The override would introduce breaking changes you haven't tested
+- You're unsure about compatibility
+
+## pnpm.overrides Syntax
+
+In your root `package.json`, add a `pnpm.overrides` field:
+
+```json
+{
+  "name": "my-monorepo",
+  "pnpm": {
+    "overrides": {
+      "package-name": "version"
+    }
+  }
+}
+```
+
+### Basic Override Examples
+
+**Override all instances of a package:**
+```json
+{
+  "pnpm": {
+    "overrides": {
+      "tmp": "0.2.5"
+    }
+  }
+}
+```
+This forces ALL occurrences of `tmp` to use version 0.2.5, regardless of what parent packages specify.
+
+**Override only within a specific parent:**
+```json
+{
+  "pnpm": {
+    "overrides": {
+      "external-editor>tmp": "0.2.5"
+    }
+  }
+}
+```
+This forces `tmp` to 0.2.5 ONLY when it's a dependency of `external-editor`.
+
+**Override with a semver range:**
+```json
+{
+  "pnpm": {
+    "overrides": {
+      "tmp": ">=0.2.4"
+    }
+  }
+}
+```
+This ensures `tmp` is at least version 0.2.4.
+
+## Advanced Patterns
+
+### Nested Dependency Overrides
+
+```json
+{
+  "pnpm": {
+    "overrides": {
+      "@changesets/cli>external-editor>tmp": "0.2.5"
+    }
+  }
+}
+```
+Only override `tmp` when it's a dependency of `external-editor` which is a dependency of `@changesets/cli`.
+
+### Wildcard Overrides
+
+```json
+{
+  "pnpm": {
+    "overrides": {
+      "foo@2.x": "2.5.0"
+    }
+  }
+}
+```
+Override all 2.x versions of `foo` with 2.5.0.
+
+### Multiple Overrides
+
+```json
+{
+  "pnpm": {
+    "overrides": {
+      "tmp": "0.2.5",
+      "lodash": "4.17.21",
+      "external-editor>iconv-lite": "0.7.0"
+    }
+  }
+}
+```
+
+## Risks and Considerations
+
+### Breaking Changes
+- **Risk**: The overridden version may introduce breaking API changes
+- **Mitigation**: Test thoroughly before deploying
+- **Example**: Overriding `tmp@0.0.33` to `tmp@0.2.5` could break if `external-editor` depends on `tmp` 0.0.x-specific APIs
+
+### Build Failures
+- **Risk**: Parent package may not work with the overridden version
+- **Mitigation**: Run full test suite after applying override
+- **Example**: Type mismatches, missing methods, changed function signatures
+
+### Hidden Dependencies
+- **Risk**: Other packages may also depend on the package you're overriding
+- **Mitigation**: Use `pnpm why <package>` to see all dependents before overriding
+- **Example**: Overriding `lodash` might affect 20+ packages
+
+### Maintenance Burden
+- **Risk**: Overrides bypass normal dependency resolution, requiring manual maintenance
+- **Mitigation**: Document WHY each override exists and plan to remove it
+- **Example**: When parent packages update their dependencies, your override might become unnecessary or even harmful
+
+## Best Practices
+
+### 1. Document Your Overrides
+
+Add comments in package.json:
+```json
+{
+  "pnpm": {
+    "overrides": {
+      "tmp": "0.2.5"
+    }
+  },
+  "_comments": {
+    "overrides": {
+      "tmp": "Force >=0.2.4 due to security vulnerability CVE-XXXX. Remove when external-editor updates to 4.x (see issue #123)"
+    }
+  }
+}
+```
+
+### 2. Be Specific
+
+Prefer:
+```json
+"external-editor>tmp": "0.2.5"  // Only override in this context
+```
+
+Over:
+```json
+"tmp": "0.2.5"  // Affects everything
+```
+
+### 3. Plan for Removal
+
+Set a reminder to:
+1. Check if parent packages have updated
+2. Test removing the override
+3. Remove the override when it's no longer needed
+
+### 4. Test Thoroughly
+
+After adding an override:
+```bash
+# Clean install to ensure override takes effect
+rm -rf node_modules pnpm-lock.yaml
+pnpm install
+
+# Verify the override worked
+pnpm why <package>
+
+# Run tests
+pnpm test
+
+# Check build
+pnpm build
+```
+
+## Workflow for Applying Overrides
+
+1. **Confirm necessity**: Verify that walking up the dependency tree won't work
+2. **Check impact**: Run `pnpm why <package>` to see all affected dependencies
+3. **Choose specificity**: Use the most specific override pattern possible
+4. **Document reason**: Add a comment explaining why the override is needed
+5. **Apply override**: Add to pnpm.overrides in package.json
+6. **Clean install**: Delete lockfile and node_modules, run `pnpm install`
+7. **Verify**: Check that the correct version is now installed
+8. **Test thoroughly**: Run full test suite
+9. **Set reminder**: Plan to review and potentially remove the override later
+
+## Example: Applying Override for tmp
+
+**Scenario**: `tmp@0.0.33` doesn't meet security requirement `>=0.2.4`, and `external-editor@3.1.0` (which depends on it) is the latest version.
+
+**Solution**:
+
+```json
+{
+  "pnpm": {
+    "overrides": {
+      "external-editor>tmp": "0.2.5"
+    }
+  },
+  "_comments": {
+    "overrides": {
+      "tmp": "Override tmp to 0.2.5 for external-editor because external-editor@3.1.0 specifies ^0.0.33 which doesn't meet our >=0.2.4 security requirement. Remove when external-editor 4.x is released or we can switch to @inquirer/external-editor."
+    }
+  }
+}
+```
+
+Then:
+```bash
+rm -rf node_modules pnpm-lock.yaml
+pnpm install
+pnpm why tmp@0.0.33  # Should return empty
+pnpm why tmp         # Should show only 0.2.5
+```
+
+## When Overrides Don't Help
+
+Overrides can't solve:
+- Actual incompatibilities (your code WILL break if the API changed)
+- Peer dependency conflicts (different mechanism)
+- Platform-specific issues
+- Issues requiring code changes in your application
+
+In these cases, you may need to:
+- Wait for the parent package to update
+- Find an alternative package
+- Fork and patch the dependency
+- Refactor your code
+
+## When to Load This Reference
+
+Load this reference when:
+- Walking up the dependency tree found no solution
+- User asks about forcing a package version
+- You need to explain pnpm overrides syntax
+- You need to weigh the risks of using overrides

--- a/.claude/skills/pnpm-version-bumper/references/semver-guide.md
+++ b/.claude/skills/pnpm-version-bumper/references/semver-guide.md
@@ -1,0 +1,119 @@
+# Semver Quick Reference Guide
+
+Quick lookup for understanding and working with semantic versioning ranges in package managers.
+
+## Common Semver Range Symbols
+
+### Caret (`^`) - Compatible Releases
+
+`^X.Y.Z` allows changes that do not modify the left-most non-zero digit:
+- `^1.2.3` → `>=1.2.3 <2.0.0` (allows 1.2.4, 1.3.0, 1.9.9, but NOT 2.0.0)
+- `^0.2.3` → `>=0.2.3 <0.3.0` (allows 0.2.4, 0.2.9, but NOT 0.3.0)
+- `^0.0.3` → `>=0.0.3 <0.0.4` (allows ONLY 0.0.3 - very strict)
+
+**Key Insight**: For 0.x versions, caret is more restrictive than you might expect.
+
+### Tilde (`~`) - Patch-Level Changes
+
+`~X.Y.Z` allows patch-level changes if Y is specified:
+- `~1.2.3` → `>=1.2.3 <1.3.0` (allows 1.2.4, 1.2.9, but NOT 1.3.0)
+- `~1.2` → `>=1.2.0 <1.3.0`
+- `~1` → `>=1.0.0 <2.0.0`
+
+**Use Case**: When you want bug fixes but no new features.
+
+### Greater Than/Equal (`>=`, `>`, `<=`, `<`)
+
+Exact comparisons:
+- `>=1.2.3` → Any version 1.2.3 or higher
+- `>1.2.3` → Any version strictly greater than 1.2.3
+- `<=1.2.3` → Any version 1.2.3 or lower
+- `<1.2.3` → Any version strictly less than 1.2.3
+
+**Use Case**: Security requirements (e.g., `>=2.4.1` to avoid vulnerability in 2.4.0)
+
+### Exact Version
+
+`1.2.3` → Only version 1.2.3, nothing else
+
+**Use Case**: When you need deterministic builds (rare in package.json, common in lockfiles)
+
+### Hyphen Ranges (`X.Y.Z - A.B.C`)
+
+Inclusive ranges:
+- `1.2.3 - 2.3.4` → `>=1.2.3 <=2.3.4`
+
+### X-Ranges (`*`, `X`)
+
+Wildcards:
+- `*` → Any version
+- `1.x` or `1.*` → `>=1.0.0 <2.0.0`
+- `1.2.x` → `>=1.2.0 <1.3.0`
+
+## Special Cases with 0.x Versions
+
+**Critical**: Versions starting with `0.` are considered unstable:
+- `^0.2.5` does NOT allow `0.3.0` (breaking change in minor version)
+- `^0.0.5` does NOT allow `0.0.6` (every patch could break)
+- `~0.2.5` allows `0.2.6` but NOT `0.3.0`
+
+This is why upgrading from `tmp@0.0.33` to `tmp@0.2.5` is a breaking change for `^0.0.33`.
+
+## Checking If a Version Satisfies a Range
+
+### Manual Check Algorithm
+
+1. Parse the requirement symbol (`^`, `~`, `>=`, etc.)
+2. Apply the rules above
+3. Compare the version against the resulting range
+
+### Examples
+
+**Does 0.2.5 satisfy ^0.0.33?**
+- `^0.0.33` → `>=0.0.33 <0.0.34`
+- 0.2.5 is NOT in range [0.0.33, 0.0.34)
+- **Answer: NO**
+
+**Does 2.29.8 satisfy ^2.27.9?**
+- `^2.27.9` → `>=2.27.9 <3.0.0`
+- 2.29.8 is in range [2.27.9, 3.0.0)
+- **Answer: YES**
+
+**Does 1.0.2 satisfy >=1.0.0?**
+- 1.0.2 >= 1.0.0
+- **Answer: YES**
+
+## Common Gotchas
+
+1. **Caret with 0.x**: `^0.2.0` is NOT the same as `^1.2.0` - much more restrictive
+2. **Tilde vs Caret**: `~1.2.3` allows fewer versions than `^1.2.3`
+3. **Prerelease Versions**: `1.0.0-alpha.1` is less than `1.0.0`
+4. **Build Metadata**: `1.0.0+20130313144700` - metadata after `+` is ignored in comparisons
+
+## Quick Decision Tree
+
+```
+Need to check if version X satisfies requirement R?
+│
+├─ Is R exact (e.g., "1.2.3")?
+│  └─ YES → X must equal R exactly
+│
+├─ Is R a range (>=, >, <, <=)?
+│  └─ YES → Direct numerical comparison
+│
+├─ Is R caret (^)?
+│  ├─ Major > 0? → Allow same major, any minor/patch
+│  ├─ Major = 0, Minor > 0? → Allow same minor, any patch
+│  └─ Major = 0, Minor = 0? → Allow same patch only
+│
+└─ Is R tilde (~)?
+   └─ Allow same major.minor, any patch
+```
+
+## When to Load This Reference
+
+Load this reference when:
+- You need to manually determine if a version satisfies a requirement
+- The user asks about semver ranges
+- You encounter a complex or unfamiliar range pattern
+- You need to explain why a version doesn't satisfy a requirement

--- a/.gitignore
+++ b/.gitignore
@@ -51,4 +51,5 @@ Thumbs.db
 .vscode
 
 packages/*/.cursor
-.claude
+.claude/*
+!.claude/skills


### PR DESCRIPTION
If you are using Claude Code and next time you need to bump a dependency due to security risk, try with the prompt
```
Can you use pnpm-version-bumper skill to bump "{packageVersion}" to "{semverVersion}"?
```