### PR TITLE
fix(packages): update the market graphql query to align with breaking…

### DIFF
--- a/services/vault/src/services/applications/morpho/fetchMarkets.ts
+++ b/services/vault/src/services/applications/morpho/fetchMarkets.ts
@@ -88,19 +88,19 @@ interface GraphQLMarketItem {
 
 /** GraphQL response shape for markets query */
 interface GraphQLMarketsResponse {
-  markets: {
+  morphoMarkets: {
     items: GraphQLMarketItem[];
   };
 }
 
 /** GraphQL response shape for single market query */
 interface GraphQLMarketByIdResponse {
-  market: GraphQLMarketItem | null;
+  morphoMarket: GraphQLMarketItem | null;
 }
 
 const GET_MORPHO_MARKETS = gql`
   query GetMorphoMarkets {
-    markets {
+    morphoMarkets {
       items {
         id
         loanTokenAddress
@@ -130,7 +130,7 @@ const GET_MORPHO_MARKETS = gql`
 
 const GET_MORPHO_MARKET_BY_ID = gql`
   query GetMorphoMarketById($id: String!) {
-    market(id: $id) {
+    morphoMarket(id: $id) {
       id
       loanTokenAddress
       collateralTokenAddress
@@ -201,7 +201,9 @@ export async function fetchMorphoMarkets(): Promise<MorphoMarketsResponse> {
   const response =
     await graphqlClient.request<GraphQLMarketsResponse>(GET_MORPHO_MARKETS);
 
-  const markets = response.markets.items.map(mapGraphQLMarketToMorphoMarket);
+  const markets = response.morphoMarkets.items.map(
+    mapGraphQLMarketToMorphoMarket,
+  );
 
   return { markets };
 }
@@ -220,9 +222,9 @@ export async function fetchMorphoMarketById(
     { id: marketId },
   );
 
-  if (!response.market) {
+  if (!response.morphoMarket) {
     return null;
   }
 
-  return mapGraphQLMarketToMorphoMarket(response.market);
+  return mapGraphQLMarketToMorphoMarket(response.morphoMarket);
 }


### PR DESCRIPTION
**Summary**

- Updated GraphQL queries to align with indexer breaking changes:
  - Renamed markets → morphoMarkets and market → morphoMarket
  - Removed nested app field from vault queries (no longer available)
- Implemented two-query pattern to fetch vault usage status:
  - Added GET_MORPHO_VAULT_STATUSES query to fetch morphoVaultStatuss
  - isInUse is now determined by checking if morphoStatus === "in_use" from the separate status table