### PR TITLE
feat: table card

### DIFF
--- a/packages/babylon-core-ui/src/components/SubSection/SubSection.css
+++ b/packages/babylon-core-ui/src/components/SubSection/SubSection.css
@@ -1,5 +1,5 @@
 .bbn-subsection {
-  @apply flex rounded-lg p-6 text-accent-primary;
+  @apply flex w-full flex-col rounded-lg p-6 text-accent-primary;
 }
 
 .bbn-subsection-contained {

--- a/packages/babylon-core-ui/src/components/Table/Table.css
+++ b/packages/babylon-core-ui/src/components/Table/Table.css
@@ -22,9 +22,14 @@
 .bbn-table {
   @apply border-separate border-spacing-0;
 
+  &-row-gap {
+    border-spacing: 0 var(--bbn-table-row-gap, 0.5rem);
+  }
+
   /* Header row styles */
   &-header {
-    @apply bg-surface text-accent-secondary sticky top-0 z-30 transition-shadow;
+    background-color: var(--bbn-table-header-bg, var(--color-surface, #ffffff));
+    @apply text-accent-secondary sticky top-0 z-30 transition-shadow;
 
     tr {
       @apply relative;
@@ -37,6 +42,15 @@
     /* TODO: fix shadow color */
     &.scrolled-top {
       @apply shadow-[0_2px_4px_rgba(0,0,0,0.05)];
+    }
+
+    /* Transparent header variant */
+    &-transparent {
+      background-color: var(--bbn-table-header-bg, transparent);
+
+      th {
+        background-color: var(--bbn-table-header-bg, transparent);
+      }
     }
   }
 
@@ -53,11 +67,11 @@
           @apply border-l;
         }
 
-      &:last-child {
-        @apply border-r;
+        &:last-child {
+          @apply border-r;
+        }
       }
     }
-  }
 
     /* Odd row styles */
     tr:nth-child(odd) {
@@ -101,6 +115,120 @@
       overflow: hidden;
       text-overflow: ellipsis;
     }
+
+    /* Full width rows */
+    &-full {
+      tr {
+        width: 100%;
+      }
+    }
+
+    /* Disable alternate row colors */
+    &-no-alternate {
+      tr:nth-child(odd),
+      tr:nth-child(even) {
+        @apply bg-secondary-highlight;
+
+        td {
+          border-color: var(--bbn-table-row-border-color, transparent);
+        }
+      }
+
+      :is(.dark &) tr:nth-child(odd),
+      :is(.dark &) tr:nth-child(even) {
+        background-color: #111111;
+      }
+    }
+
+    /* Disable hover effects */
+    &-no-hover {
+      tr:nth-child(odd):hover,
+      tr:nth-child(even):hover {
+        @apply bg-secondary-highlight;
+
+        td {
+          border-color: var(--bbn-table-row-border-color, transparent);
+        }
+      }
+
+      :is(.dark &) tr:nth-child(odd):hover,
+      :is(.dark &) tr:nth-child(even):hover {
+        background-color: #111111;
+      }
+    }
+
+    /* Enable hover effects with custom color */
+    &-hover-custom {
+      tr:nth-child(odd):hover,
+      tr:nth-child(even):hover {
+        background-color: var(--bbn-table-row-hover-bg, var(--color-neutral-200, #e5e7eb));
+      }
+    }
+
+    /* Show border around rows (card-style) */
+    &-row-border {
+      tr {
+        td {
+          border-color: var(--bbn-table-row-border-color, var(--color-secondary-strokeLight, #e5e7eb));
+
+          &:first-child {
+            border-left-color: var(--bbn-table-row-border-color, var(--color-secondary-strokeLight, #e5e7eb));
+          }
+
+          &:last-child {
+            border-right-color: var(--bbn-table-row-border-color, var(--color-secondary-strokeLight, #e5e7eb));
+          }
+        }
+      }
+    }
+
+    /* Hide border (default for card style) */
+    &-no-border {
+      tr {
+        td {
+          @apply border-transparent;
+
+          &:first-child {
+            @apply border-l-transparent;
+          }
+
+          &:last-child {
+            @apply border-r-transparent;
+          }
+        }
+      }
+    }
+
+    /* Clickable rows - show pointer cursor */
+    &-clickable {
+      tr {
+        @apply cursor-pointer;
+      }
+    }
+  }
+
+  /* Rounded table - apply to entire table */
+  &-rounded {
+    tbody tr {
+      td {
+        &:first-child {
+          border-top-left-radius: var(--bbn-table-row-radius, 0.5rem);
+          border-bottom-left-radius: var(--bbn-table-row-radius, 0.5rem);
+          @apply border-l;
+        }
+
+        &:last-child {
+          border-top-right-radius: var(--bbn-table-row-radius, 0.5rem);
+          border-bottom-right-radius: var(--bbn-table-row-radius, 0.5rem);
+          @apply border-r;
+        }
+      }
+    }
+  }
+
+  /* Full row width with fixed layout for consistent column widths */
+  &-fullrow {
+    @apply w-full table-fixed;
   }
 
   /* Sortable column styles */

--- a/packages/babylon-core-ui/src/components/Table/Table.stories.tsx
+++ b/packages/babylon-core-ui/src/components/Table/Table.stories.tsx
@@ -335,3 +335,67 @@ export const HeaderVisibility: Story = {
     );
   },
 };
+
+/**
+ * Style Presets
+ *
+ * Available presets: 'default', 'card'
+ */
+export const StylePresets: Story = {
+  render: () => {
+    return (
+      <div className="space-y-8">
+        {/* Default */}
+        <div className="space-y-2">
+          <h3 className="text-lg font-semibold">Default</h3>
+          <Table data={data} columns={columns} />
+        </div>
+
+        {/* Card */}
+        <div className="space-y-2">
+          <h3 className="text-lg font-semibold">Card</h3>
+          <Table data={data} columns={columns} styleConfig="card" />
+        </div>
+      </div>
+    );
+  },
+};
+
+/**
+ * Custom Configuration
+ *
+ * Fine-grained control with nested options and value customization
+ */
+export const CustomConfiguration: Story = {
+  render: () => {
+    return (
+      <div className="space-y-8">
+        {/* Clickable Rows */}
+        <div className="space-y-2">
+          <h3 className="text-lg font-semibold">Clickable Rows (cursor: pointer)</h3>
+          <Table
+            data={data}
+            columns={columns}
+            styleConfig={{
+              layout: { fullWidth: true },
+              rows: { clickable: true },
+            }}
+          />
+        </div>
+
+        {/* Card with custom gap */}
+        <div className="space-y-2">
+          <h3 className="text-lg font-semibold">Custom Gap Size (1rem)</h3>
+          <Table
+            data={data}
+            columns={columns}
+            styleConfig={{
+              layout: { fullWidth: true, rowGap: true, rowGapSize: '1rem' },
+              rows: { alternateColors: false, rounded: true },
+            }}
+          />
+        </div>
+      </div>
+    );
+  },
+};

--- a/packages/babylon-core-ui/src/components/Table/types/index.ts
+++ b/packages/babylon-core-ui/src/components/Table/types/index.ts
@@ -12,6 +12,168 @@ export type ColumnProps<T = unknown> = {
 
 export type TableData = { id: string | number };
 
+/**
+ * Table style configuration for customizing visual appearance.
+ */
+export interface TableStyleConfig {
+  /**
+   * Layout options
+   */
+  layout?: {
+    /**
+     * Make the table take full width of its container
+     * @default false
+     */
+    fullWidth?: boolean;
+
+    /**
+     * Add vertical gaps between rows
+     * @default false
+     */
+    rowGap?: boolean;
+
+    /**
+     * Custom gap size between rows (requires rowGap: true)
+     * @example "0.5rem", "8px", "1rem"
+     * @default "0.5rem"
+     */
+    rowGapSize?: string;
+  };
+
+  /**
+   * Header options
+   */
+  header?: {
+    /**
+     * Show header background
+     * @default true
+     */
+    background?: boolean;
+
+    /**
+     * Custom header background color (CSS value or variable)
+     * @example "var(--color-surface)", "#f5f5f5", "transparent"
+     */
+    backgroundColor?: string;
+  };
+
+  /**
+   * Row visual options
+   */
+  rows?: {
+    /**
+     * Show alternating row background colors (zebra striping)
+     * @default true
+     */
+    alternateColors?: boolean;
+
+    /**
+     * Show hover effect on rows
+     * @default true
+     */
+    hoverEffect?: boolean;
+
+    /**
+     * Apply rounded corners to each row
+     * @default false
+     */
+    rounded?: boolean;
+
+    /**
+     * Custom border radius for rows (requires rounded: true)
+     * @example "0.5rem", "8px", "1rem"
+     * @default "0.5rem" (rounded-lg)
+     */
+    borderRadius?: string;
+
+    /**
+     * Show border around each row
+     * @default false
+     */
+    border?: boolean;
+
+    /**
+     * Custom border color (CSS value or variable)
+     * @example "var(--color-border)", "#e0e0e0", "rgba(0,0,0,0.1)"
+     */
+    borderColor?: string;
+
+    /**
+     * Custom row background color (CSS value or variable)
+     * Used when alternateColors is false
+     * @example "var(--color-surface-raised)", "#ffffff"
+     */
+    backgroundColor?: string;
+
+    /**
+     * Custom hover background color (CSS value or variable)
+     * @example "var(--color-surface-hover)", "#f0f0f0"
+     */
+    hoverColor?: string;
+
+    /**
+     * Show pointer cursor on rows (for clickable rows)
+     * @default false
+     */
+    clickable?: boolean;
+  };
+}
+
+/**
+ * @internal
+ * Flat table styles
+ */
+export interface _TableStyles {
+  fullWidth: boolean;
+  rowGap: boolean;
+  rowGapSize?: string;
+
+  background: boolean;
+  backgroundColor?: string;
+
+  alternateColors: boolean;
+  hoverEffect: boolean;
+  rounded: boolean;
+  border: boolean;
+  borderRadius?: string;
+  borderColor?: string;
+  rowBackgroundColor?: string;
+  hoverColor?: string;
+  clickable: boolean;
+}
+
+/**
+ * Preset style configurations for common table layouts
+ */
+export const TABLE_STYLE_PRESETS: Record<string, TableStyleConfig> = {
+  /**
+   * Default table style - alternating colors, hover effects, standard header
+   */
+  default: {},
+
+  /**
+   * Card style - transparent header, card-like rows with gaps
+   * Ideal for dashboard cards and modern interfaces
+   */
+  card: {
+    layout: {
+      fullWidth: true,
+      rowGap: true,
+    },
+    header: {
+      background: false,
+    },
+    rows: {
+      alternateColors: false,
+      hoverEffect: false,
+      rounded: true,
+      border: false,
+    },
+  },
+};
+
+export type TableStylePreset = keyof typeof TABLE_STYLE_PRESETS;
+
 export type TableProps<T extends TableData> = ControlledTableProps & {
   data: T[];
   columns: ColumnProps<T>[];
@@ -24,7 +186,15 @@ export type TableProps<T extends TableData> = ControlledTableProps & {
   onRowSelect?: (row: T | null) => void;
   onRowClick?: (row: T) => void;
   isRowSelectable?: (row: T) => boolean;
-  
+
+  /**
+   * Style configuration for the table.
+   * Can be a preset name ('default', 'card')
+   * or a custom TableStyleConfig object.
+   * Individual style options can be overridden when using presets.
+   */
+  styleConfig?: TableStylePreset | TableStyleConfig;
+
   // Multi-select support
   selectable?: boolean;
   selectedRows?: Array<string | number>;

--- a/services/vault/src/applications/aave/components/Overview/index.tsx
+++ b/services/vault/src/applications/aave/components/Overview/index.tsx
@@ -11,7 +11,6 @@ import { Avatar, Button, Container } from "@babylonlabs-io/core-ui";
 import { useState } from "react";
 import { useNavigate } from "react-router";
 
-// import { useBTCWallet, useETHWallet } from "@/context/wallet";
 import { AssetSelectionModal } from "../AssetSelectionModal";
 
 import { CollateralCard } from "./components/CollateralCard";


### PR DESCRIPTION
- added table card style varient for `Table` element in `core-ui`

used in collateral and activity table in vault

note: mobile is not properly fixed yet. will fix in another PR later

<img width="1148" height="452" alt="Screenshot 2025-12-12 at 6 07 59 PM" src="https://github.com/user-attachments/assets/ec6ff165-92f7-42b9-988d-338253faacff" />
<img width="1139" height="443" alt="Screenshot 2025-12-12 at 6 07 55 PM" src="https://github.com/user-attachments/assets/84311332-599d-451f-a616-eb7d67e6d9c3" />
