### PR TITLE
feat(vault): hook up the loans, vaults with the actual rpc and graphq…

### DIFF
--- a/services/vault/src/applications/aave/components/Overview/components/LoansCard/LoansCard.tsx
+++ b/services/vault/src/applications/aave/components/Overview/components/LoansCard/LoansCard.tsx
@@ -5,17 +5,12 @@
 
 import { Avatar, Button, Card, SubSection } from "@babylonlabs-io/core-ui";
 
+import type { BorrowedAsset } from "@/applications/aave/hooks";
 import {
   formatHealthFactor,
   isHealthFactorHealthy,
 } from "@/applications/aave/utils";
 import { HeartIcon } from "@/components/shared";
-
-export interface BorrowedAsset {
-  symbol: string;
-  amount: string;
-  icon: string;
-}
 
 interface LoansCardProps {
   hasLoans: boolean;

--- a/services/vault/src/applications/aave/components/Overview/components/LoansCard/index.tsx
+++ b/services/vault/src/applications/aave/components/Overview/components/LoansCard/index.tsx
@@ -1,2 +1,1 @@
 export { LoansCard } from "./LoansCard";
-export type { BorrowedAsset } from "./LoansCard";

--- a/services/vault/src/applications/aave/components/Overview/components/VaultsTable/VaultsTable.tsx
+++ b/services/vault/src/applications/aave/components/Overview/components/VaultsTable/VaultsTable.tsx
@@ -8,20 +8,27 @@ import { Avatar, Button, Card, Popover, Table } from "@babylonlabs-io/core-ui";
 import { useRef, useState } from "react";
 
 import { InfoIcon, MenuButton } from "@/components/shared";
+import {
+  PEGIN_DISPLAY_LABELS,
+  type PeginDisplayLabel,
+} from "@/models/peginStateMachine";
+import { formatBtcValue, formatUsdValue } from "@/utils/formatting";
 
 import { VaultsEmptyState } from "./VaultsEmptyState";
 
 export interface VaultData {
   id: string;
-  amount: string;
-  amountValue: number;
-  usdValue: string;
-  usdValueNumber: number;
+  /** BTC amount (for display and sorting) */
+  amount: number;
+  /** USD value (for display and sorting) */
+  usdValue: number;
   provider: {
     name: string;
-    icon: string;
+    /** Icon URL - undefined will use Avatar component's built-in fallback */
+    icon?: string;
   };
-  status: "In use" | "Available";
+  /** Vault status from centralized state machine */
+  status: PeginDisplayLabel;
 }
 
 interface VaultsTableProps {
@@ -83,17 +90,15 @@ export function VaultsTable({
       header: "BTC Vault",
       headerClassName: "w-[50%]",
       cellClassName: "w-[50%]",
-      sorter: (a, b) => a.amountValue - b.amountValue,
+      sorter: (a, b) => a.amount - b.amount,
       render: (_value, row) => (
         <div className="flex items-center gap-3">
-          <Avatar
-            url="https://assets.coingecko.com/coins/images/1/standard/bitcoin.png?1696501400"
-            alt="BTC"
-            size="small"
-          />
+          <Avatar url="/images/btc.png" alt="BTC" size="small" />
           <span className="text-base text-accent-primary">
-            {row.amount}{" "}
-            <span className="text-accent-secondary">({row.usdValue})</span>
+            {formatBtcValue(row.amount)}{" "}
+            <span className="text-accent-secondary">
+              ({formatUsdValue(row.usdValue)})
+            </span>
           </span>
         </div>
       ),
@@ -117,7 +122,9 @@ export function VaultsTable({
         <div className="flex items-center gap-2">
           <div
             className={`h-2 w-2 rounded-full ${
-              row.status === "In use" ? "bg-green-500" : "bg-gray-400"
+              row.status === PEGIN_DISPLAY_LABELS.IN_USE
+                ? "bg-green-500"
+                : "bg-gray-400"
             }`}
           />
           <span className="text-sm text-accent-primary">{row.status}</span>

--- a/services/vault/src/applications/aave/hooks/index.ts
+++ b/services/vault/src/applications/aave/hooks/index.ts
@@ -1,4 +1,10 @@
 export {
+  useAaveBorrowedAssets,
+  type BorrowedAsset,
+  type UseAaveBorrowedAssetsResult,
+} from "./useAaveBorrowedAssets";
+export {
   useAaveUserPosition,
   type UseAaveUserPositionResult,
 } from "./useAaveUserPosition";
+export { useAaveVaults } from "./useAaveVaults";

--- a/services/vault/src/applications/aave/hooks/useAaveBorrowedAssets.ts
+++ b/services/vault/src/applications/aave/hooks/useAaveBorrowedAssets.ts
@@ -1,0 +1,186 @@
+/**
+ * Hook to fetch user's borrowed assets for the Aave overview page
+ *
+ * Uses the position data from useAaveUserPosition which already includes
+ * debt positions for all borrowable reserves (fetched in a single call).
+ *
+ * Since converting drawnShares to exact token amounts requires Hub contract
+ * interaction (not currently available), we use the aggregate totalDebtValue
+ * from getUserAccountData and distribute it proportionally based on debt shares.
+ */
+
+import { useMemo } from "react";
+
+import {
+  getCurrencyIconWithFallback,
+  getTokenByAddress,
+} from "@/services/token/tokenService";
+import { formatUsdValue } from "@/utils/formatting";
+
+import { useAaveConfig } from "../context";
+import type { AavePositionWithLiveData, DebtPosition } from "../services";
+import type { AaveReserveConfig } from "../services/fetchConfig";
+
+/**
+ * Borrowed asset for display
+ */
+export interface BorrowedAsset {
+  /** Token symbol */
+  symbol: string;
+  /** Display amount (formatted USD value) */
+  amount: string;
+  /** Token icon URL */
+  icon: string;
+}
+
+/**
+ * Result of useAaveBorrowedAssets hook
+ */
+export interface UseAaveBorrowedAssetsResult {
+  /** Array of borrowed assets */
+  borrowedAssets: BorrowedAsset[];
+  /** Total debt value in USD */
+  totalDebtValueUsd: number;
+  /** Whether any loans exist */
+  hasLoans: boolean;
+}
+
+/**
+ * Props for useAaveBorrowedAssets hook
+ */
+interface UseAaveBorrowedAssetsProps {
+  /** User's position with live data (from useAaveUserPosition) */
+  position: AavePositionWithLiveData | null;
+  /** Total debt value in USD (from useAaveUserPosition) */
+  debtValueUsd: number;
+}
+
+/**
+ * Reserve with its associated debt position
+ */
+interface ReserveWithDebt {
+  reserve: AaveReserveConfig;
+  debtPosition: DebtPosition;
+}
+
+/**
+ * Get total debt shares for a position (drawn + premium/interest)
+ */
+function getTotalDebtShares(debtPosition: DebtPosition): bigint {
+  return debtPosition.drawnShares + debtPosition.premiumShares;
+}
+
+/**
+ * Calculate total shares across all debt positions
+ */
+function calculateTotalShares(reservesWithDebt: ReserveWithDebt[]): bigint {
+  return reservesWithDebt.reduce(
+    (sum, { debtPosition }) => sum + getTotalDebtShares(debtPosition),
+    0n,
+  );
+}
+
+/**
+ * Calculate proportional debt value for a reserve based on its share of total debt
+ */
+function calculateProportionalDebtValue(
+  reserveShares: bigint,
+  totalShares: bigint,
+  totalDebtValueUsd: number,
+): number {
+  if (totalShares === 0n) return 0;
+  return (totalDebtValueUsd * Number(reserveShares)) / Number(totalShares);
+}
+
+/**
+ * Resolve token symbol from metadata or indexer data
+ * Falls back to "Unknown" if symbol looks like an address
+ */
+function resolveTokenSymbol(
+  tokenMetadata: ReturnType<typeof getTokenByAddress>,
+  indexerSymbol: string,
+): string {
+  // Check if registry has valid symbol (not an address)
+  if (tokenMetadata && !tokenMetadata.symbol.startsWith("0x")) {
+    return tokenMetadata.symbol;
+  }
+
+  // Check if indexer symbol looks like an address
+  const isSymbolAnAddress =
+    indexerSymbol.startsWith("0x") && indexerSymbol.length > 10;
+
+  return isSymbolAnAddress ? "Unknown" : indexerSymbol;
+}
+
+/**
+ * Transform a reserve with debt into a display-ready BorrowedAsset
+ */
+function transformToBorrowedAsset(
+  reserveWithDebt: ReserveWithDebt,
+  totalShares: bigint,
+  totalDebtValueUsd: number,
+): BorrowedAsset {
+  const { reserve, debtPosition } = reserveWithDebt;
+
+  const tokenMetadata = getTokenByAddress(reserve.token.address);
+  const symbol = resolveTokenSymbol(tokenMetadata, reserve.token.symbol);
+  const icon = getCurrencyIconWithFallback(tokenMetadata?.icon, symbol);
+
+  const reserveShares = getTotalDebtShares(debtPosition);
+  const debtValue = calculateProportionalDebtValue(
+    reserveShares,
+    totalShares,
+    totalDebtValueUsd,
+  );
+  const amount = formatUsdValue(debtValue).replace("$", "");
+
+  return { symbol, amount, icon };
+}
+
+/**
+ * Hook to derive borrowed assets from position data
+ *
+ * Uses the debtPositions already fetched by useAaveUserPosition,
+ * avoiding separate RPC calls.
+ *
+ * @param props - Position and debt data from useAaveUserPosition
+ * @returns Borrowed assets data for display
+ */
+export function useAaveBorrowedAssets({
+  position,
+  debtValueUsd,
+}: UseAaveBorrowedAssetsProps): UseAaveBorrowedAssetsResult {
+  const { borrowableReserves } = useAaveConfig();
+
+  const debtPositions = position?.debtPositions;
+
+  const borrowedAssets = useMemo((): BorrowedAsset[] => {
+    if (!debtPositions || debtPositions.size === 0) {
+      return [];
+    }
+
+    // Match reserves with their debt positions
+    const reservesWithDebt: ReserveWithDebt[] = borrowableReserves
+      .filter((r) => debtPositions.has(r.reserveId))
+      .map((reserve) => ({
+        reserve,
+        debtPosition: debtPositions.get(reserve.reserveId)!,
+      }));
+
+    if (reservesWithDebt.length === 0) {
+      return [];
+    }
+
+    const totalShares = calculateTotalShares(reservesWithDebt);
+
+    return reservesWithDebt.map((reserveWithDebt) =>
+      transformToBorrowedAsset(reserveWithDebt, totalShares, debtValueUsd),
+    );
+  }, [debtPositions, borrowableReserves, debtValueUsd]);
+
+  return {
+    borrowedAssets,
+    totalDebtValueUsd: debtValueUsd,
+    hasLoans: debtValueUsd > 0,
+  };
+}

--- a/services/vault/src/applications/aave/hooks/useAaveVaults.ts
+++ b/services/vault/src/applications/aave/hooks/useAaveVaults.ts
@@ -1,0 +1,71 @@
+/**
+ * Hook to fetch user's vaults for the Aave overview page
+ *
+ * Fetches vaults from GraphQL and transforms them to the format
+ * needed by the VaultsTable component.
+ */
+
+import type { Address } from "viem";
+
+import { useBTCPrice } from "@/hooks/useBTCPrice";
+import { useVaults } from "@/hooks/useVaults";
+import { ContractStatus, getPeginState } from "@/models/peginStateMachine";
+import type { Vault } from "@/types/vault";
+import { satoshiToBtcNumber } from "@/utils/btcConversion";
+
+import type { VaultData } from "../components/Overview/components/VaultsTable";
+
+/**
+ * Transform a Vault to VaultData for display in the table
+ */
+function transformVaultToTableData(
+  vault: Vault,
+  btcPriceUsd: number,
+): VaultData {
+  const btcAmount = satoshiToBtcNumber(vault.amount);
+  const usdValue = btcAmount * btcPriceUsd;
+
+  const peginState = getPeginState(vault.status, { isInUse: vault.isInUse });
+
+  return {
+    id: vault.id,
+    amount: btcAmount,
+    usdValue,
+    provider: {
+      // Use truncated address as name, icon is undefined to use Avatar fallback
+      name: `${vault.vaultProvider.slice(0, 6)}...${vault.vaultProvider.slice(-4)}`,
+    },
+    status: peginState.displayLabel,
+  };
+}
+
+/**
+ * Hook to fetch and transform user's vaults for the Aave overview
+ *
+ * @param depositorAddress - User's Ethereum address
+ * @returns Vaults data for the table, loading state, and error
+ */
+export function useAaveVaults(depositorAddress: Address | undefined) {
+  const {
+    data: vaults,
+    isLoading: vaultsLoading,
+    error,
+  } = useVaults(depositorAddress);
+  const { btcPriceUSD, loading: priceLoading } = useBTCPrice();
+
+  const isLoading = vaultsLoading || priceLoading;
+
+  // Filter to only active vaults (not redeemed) and transform for display
+  const vaultTableData: VaultData[] =
+    vaults && btcPriceUSD
+      ? vaults
+          .filter((vault) => vault.status === ContractStatus.ACTIVE)
+          .map((vault) => transformVaultToTableData(vault, btcPriceUSD))
+      : [];
+
+  return {
+    vaults: vaultTableData,
+    isLoading,
+    error,
+  };
+}

--- a/services/vault/src/applications/aave/services/index.ts
+++ b/services/vault/src/applications/aave/services/index.ts
@@ -45,6 +45,7 @@ export {
   getUserPositionForReserve,
   getUserPositionsWithLiveData,
   type AavePositionWithLiveData,
+  type DebtPosition,
 } from "./positionService";
 
 // Reserve service

--- a/services/vault/src/services/token/tokenService.ts
+++ b/services/vault/src/services/token/tokenService.ts
@@ -104,6 +104,14 @@ const TOKEN_REGISTRY: Record<string, TokenMetadata> = {
     decimals: 6,
     icon: "/images/usdc.png",
   },
+  // USDC - Vault Devnet
+  "0xc137E7382AA220D59Cc25f76f9aD72De962020Db": {
+    address: "0xc137E7382AA220D59Cc25f76f9aD72De962020Db" as Address,
+    symbol: "USDC",
+    name: "USD Coin",
+    decimals: 6,
+    icon: "/images/usdc.png",
+  },
   // USDT
   "0x94b008aA00579c1307B0EF2c499aD98a8ce58e58": {
     address: "0x94b008aA00579c1307B0EF2c499aD98a8ce58e58" as Address,

--- a/services/vault/src/utils/formatting.ts
+++ b/services/vault/src/utils/formatting.ts
@@ -22,14 +22,24 @@ export function formatProviderName(providerId: string): string {
 }
 
 /**
- * Format BTC amount for display
+ * Format BTC amount as a number string (without suffix)
+ * @param btcAmount - Amount in BTC (not satoshis). Zero or negative values return "0".
+ * @param decimals - Number of decimal places (default: 8)
+ * @returns Formatted number string (e.g., "1.23456789" or "0")
+ */
+export function formatBtcValue(btcAmount: number, decimals = 8): string {
+  if (btcAmount <= 0) return "0";
+  return btcAmount.toFixed(decimals);
+}
+
+/**
+ * Format BTC amount for display with suffix
  * @param btcAmount - Amount in BTC (not satoshis). Zero or negative values return "0 BTC".
  * @param decimals - Number of decimal places (default: 8)
  * @returns Formatted string (e.g., "1.23456789 BTC" or "0 BTC")
  */
 export function formatBtcAmount(btcAmount: number, decimals = 8): string {
-  if (btcAmount <= 0) return "0 BTC";
-  return `${btcAmount.toFixed(decimals)} BTC`;
+  return `${formatBtcValue(btcAmount, decimals)} BTC`;
 }
 
 /**


### PR DESCRIPTION

<img width="905" height="664" alt="image" src="https://github.com/user-attachments/assets/6c36636e-f06d-44e9-9993-0b1175a85d50" />


The above data is now populated by real data. mocked are removed.

There is an existing bug where the status of the vaults are not correctly reflected. Some of the vaults should shown as `in use` as we do have collaterals.
This will be handled in a separate PR