### PR TITLE
feat(vault): able to add more collaterals for aave

### DIFF
--- a/services/vault/src/applications/aave/components/AddCollateralModal/CollateralDetailsCard.tsx
+++ b/services/vault/src/applications/aave/components/AddCollateralModal/CollateralDetailsCard.tsx
@@ -12,25 +12,40 @@ import { useAaveConfig } from "../../context";
 import {
   formatHealthFactor,
   getHealthFactorColor,
-  getHealthFactorStatus,
+  getHealthFactorStatusFromValue,
 } from "../../utils/healthFactor";
 
 interface CollateralDetailsCardProps {
-  /** Projected health factor after adding collateral */
-  healthFactor: number | null;
-  /** Whether there is active debt */
-  hasDebt?: boolean;
+  /** Current health factor value (Infinity when no debt) */
+  currentHealthFactorValue: number;
+  /** Projected health factor value after adding collateral (Infinity when no debt) */
+  projectedHealthFactorValue: number;
+  /** Whether to show the before → after transition */
+  showTransition?: boolean;
 }
 
 export function CollateralDetailsCard({
-  healthFactor,
-  hasDebt = false,
+  currentHealthFactorValue,
+  projectedHealthFactorValue,
+  showTransition = false,
 }: CollateralDetailsCardProps) {
   const { borrowableReserves } = useAaveConfig();
 
-  const healthFactorStatus = getHealthFactorStatus(healthFactor, hasDebt);
-  const healthFactorColor = getHealthFactorColor(healthFactorStatus);
-  const healthFactorFormatted = formatHealthFactor(healthFactor);
+  const currentStatus = getHealthFactorStatusFromValue(
+    currentHealthFactorValue,
+  );
+  const currentColor = getHealthFactorColor(currentStatus);
+  const currentFormatted = formatHealthFactor(
+    isFinite(currentHealthFactorValue) ? currentHealthFactorValue : null,
+  );
+
+  const projectedStatus = getHealthFactorStatusFromValue(
+    projectedHealthFactorValue,
+  );
+  const projectedColor = getHealthFactorColor(projectedStatus);
+  const projectedFormatted = formatHealthFactor(
+    isFinite(projectedHealthFactorValue) ? projectedHealthFactorValue : null,
+  );
 
   // Get icons for borrowable assets
   const borrowableAssetIcons = borrowableReserves.map((reserve) => {
@@ -71,10 +86,24 @@ export function CollateralDetailsCard({
         {/* Health Factor Row */}
         <div className="flex items-center justify-between">
           <span className="text-sm text-accent-secondary">Health Factor</span>
-          <span className="flex items-center gap-2 text-base text-accent-primary">
-            <HeartIcon color={healthFactorColor} />
-            {healthFactorFormatted}
-          </span>
+          {showTransition ? (
+            <span className="flex items-center gap-2 text-base">
+              <span className="flex items-center gap-1 text-accent-secondary">
+                <HeartIcon color={currentColor} />
+                {currentFormatted}
+              </span>
+              <span className="text-accent-secondary">→</span>
+              <span className="flex items-center gap-1 text-accent-primary">
+                <HeartIcon color={projectedColor} />
+                {projectedFormatted}
+              </span>
+            </span>
+          ) : (
+            <span className="flex items-center gap-2 text-base text-accent-primary">
+              <HeartIcon color={projectedColor} />
+              {projectedFormatted}
+            </span>
+          )}
         </div>
       </div>
     </SubSection>

--- a/services/vault/src/applications/aave/components/AddCollateralModal/hooks/index.ts
+++ b/services/vault/src/applications/aave/components/AddCollateralModal/hooks/index.ts
@@ -1,0 +1,2 @@
+export { useAddCollateralModal } from "./useAddCollateralModal";
+export { useAddCollateralState } from "./useAddCollateralState";

--- a/services/vault/src/applications/aave/components/AddCollateralModal/hooks/useAddCollateralModal.ts
+++ b/services/vault/src/applications/aave/components/AddCollateralModal/hooks/useAddCollateralModal.ts
@@ -1,0 +1,110 @@
+/**
+ * Hook for Add Collateral modal
+ *
+ * Combines data fetching, state management, and transaction execution
+ * for the Add Collateral modal. Uses React Query's cache for data.
+ */
+
+import { useETHWallet } from "@/context/wallet";
+import { useBTCPrice } from "@/hooks/useBTCPrice";
+
+import { useAaveConfig } from "../../../context";
+import {
+  useAaveUserPosition,
+  useAaveVaults,
+  useAddCollateralTransaction,
+} from "../../../hooks";
+
+import { useAddCollateralState } from "./useAddCollateralState";
+
+export interface UseAddCollateralModalResult {
+  /** Selected collateral amount in BTC */
+  collateralAmount: number;
+  /** Set the collateral amount */
+  setCollateralAmount: (amount: number) => void;
+  /** Maximum collateral amount (sum of available vaults) */
+  maxCollateralAmount: number;
+  /** Collateral value in USD for selected amount */
+  selectedCollateralValueUsd: number;
+  /** Current health factor value for UI (Infinity when no debt) */
+  currentHealthFactorValue: number;
+  /** Projected health factor value after adding collateral */
+  projectedHealthFactorValue: number;
+  /** Slider steps based on vault bucket combinations */
+  collateralSteps: Array<{ value: number }>;
+  /** Execute the add collateral transaction */
+  handleDeposit: () => Promise<boolean>;
+  /** Whether transaction is processing */
+  isProcessing: boolean;
+  /** Whether deposit button should be disabled */
+  isDisabled: boolean;
+}
+
+/**
+ * Hook that provides all state and handlers for the Add Collateral modal
+ *
+ * Fetches data using React Query (reuses cached data from parent components)
+ * and provides transaction execution.
+ */
+export function useAddCollateralModal(): UseAddCollateralModalResult {
+  // Fetch wallet address
+  const { address } = useETHWallet();
+
+  // Fetch BTC price (uses React Query cache)
+  const { btcPriceUSD } = useBTCPrice();
+  const btcPrice = btcPriceUSD || 0;
+
+  // Fetch user's position data (uses React Query cache)
+  const { collateralValueUsd, debtValueUsd, healthFactor } =
+    useAaveUserPosition(address);
+
+  // Fetch vaults available for collateral (uses React Query cache)
+  const { availableForCollateral } = useAaveVaults(address);
+
+  // Get liquidation threshold from vBTC reserve config (from context)
+  // collateralFactor is the liquidation threshold in BPS (e.g., 8000 = 80%)
+  const { vbtcReserve, isLoading: configLoading } = useAaveConfig();
+  const liquidationThresholdBps = vbtcReserve?.reserve.collateralFactor;
+
+  // State for collateral selection and calculations
+  const {
+    collateralAmount,
+    setCollateralAmount,
+    maxCollateralAmount,
+    selectedVaultIds,
+    collateralValueUsd: selectedCollateralValueUsd,
+    currentHealthFactorValue,
+    projectedHealthFactorValue,
+    collateralSteps,
+  } = useAddCollateralState({
+    availableVaults: availableForCollateral,
+    currentCollateralUsd: collateralValueUsd,
+    currentDebtUsd: debtValueUsd,
+    liquidationThresholdBps,
+    btcPrice,
+    currentHealthFactor: healthFactor,
+  });
+
+  // Transaction hook
+  const { executeAddCollateral, isProcessing } = useAddCollateralTransaction();
+
+  const handleDeposit = async () => {
+    if (selectedVaultIds.length === 0) return false;
+    return executeAddCollateral(selectedVaultIds);
+  };
+
+  const isDisabled = collateralAmount === 0 || isProcessing || configLoading;
+
+  return {
+    collateralAmount,
+    setCollateralAmount,
+    maxCollateralAmount,
+    selectedCollateralValueUsd,
+    currentHealthFactorValue,
+    projectedHealthFactorValue,
+    collateralSteps,
+    handleDeposit,
+    isProcessing,
+    isDisabled,
+  };
+}

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/BorrowDetailsCard/BorrowDetailsCard.tsx
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/BorrowDetailsCard/BorrowDetailsCard.tsx
@@ -2,8 +2,7 @@ import { KeyValueList, SubSection } from "@babylonlabs-io/core-ui";
 
 import {
   getHealthFactorColor,
-  getHealthFactorStatus,
-  type HealthFactorStatus,
+  getHealthFactorStatusFromValue,
 } from "@/applications/aave/utils";
 import { HeartIcon, InfoIcon } from "@/components/shared";
 
@@ -31,16 +30,6 @@ function LabelWithInfo({ children }: { children: React.ReactNode }) {
 }
 
 /**
- * Get health factor status for preview calculations
- * Note: For preview values, we assume there is debt if the value > 0
- */
-function getPreviewHealthFactorStatus(value: number): HealthFactorStatus {
-  const hasDebt = value > 0;
-  const healthFactor = value > 0 ? value : null;
-  return getHealthFactorStatus(healthFactor, hasDebt);
-}
-
-/**
  * BorrowDetailsCard - Displays borrow rate and health factor with before → after indicators
  */
 export function BorrowDetailsCard({
@@ -51,11 +40,11 @@ export function BorrowDetailsCard({
   healthFactorOriginal,
   healthFactorOriginalValue,
 }: BorrowDetailsCardProps) {
-  const status = getPreviewHealthFactorStatus(healthFactorValue);
+  const status = getHealthFactorStatusFromValue(healthFactorValue);
   const color = getHealthFactorColor(status);
   const originalStatus =
     healthFactorOriginalValue !== undefined
-      ? getPreviewHealthFactorStatus(healthFactorOriginalValue)
+      ? getHealthFactorStatusFromValue(healthFactorOriginalValue)
       : undefined;
   const originalColor = originalStatus
     ? getHealthFactorColor(originalStatus)

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/index.tsx
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/index.tsx
@@ -9,6 +9,7 @@ import { AmountSlider, Button, SubSection } from "@babylonlabs-io/core-ui";
 import { useState } from "react";
 
 import { getCurrencyIconWithFallback } from "../../../../../services/token";
+import { MIN_SLIDER_MAX } from "../../../constants";
 
 import { BorrowDetailsCard } from "./BorrowDetailsCard";
 import { useBorrowMetrics } from "./hooks/useBorrowMetrics";
@@ -68,7 +69,7 @@ export function Borrow({
     metrics.healthFactorValue,
   );
 
-  const sliderMaxBorrow = Math.max(maxBorrowAmount, 0.0001);
+  const sliderMaxBorrow = Math.max(maxBorrowAmount, MIN_SLIDER_MAX);
 
   const handleBorrow = () => {
     // Call the onBorrow callback with 0 collateral (collateral already exists)

--- a/services/vault/src/applications/aave/constants.ts
+++ b/services/vault/src/applications/aave/constants.ts
@@ -77,3 +77,18 @@ export const HEALTH_FACTOR_WARNING_THRESHOLD = 1.5;
  * Prevents users from borrowing if resulting health factor would be below this.
  */
 export const MIN_HEALTH_FACTOR_FOR_BORROW = 1.2;
+
+/**
+ * Minimum slider max value to prevent division by zero
+ * when no vaults or borrow capacity available
+ */
+export const MIN_SLIDER_MAX = 0.0001;
+
+/**
+ * BTC token display constants
+ */
+export const BTC_TOKEN = {
+  icon: "/images/btc.png",
+  name: "Bitcoin",
+  symbol: "BTC",
+} as const;

--- a/services/vault/src/applications/aave/context/PendingVaultsContext.tsx
+++ b/services/vault/src/applications/aave/context/PendingVaultsContext.tsx
@@ -1,0 +1,102 @@
+/**
+ * Pending Vaults Context
+ *
+ * Tracks vault IDs that have been submitted for collateral but may not yet
+ * be reflected in the indexer. This prevents users from re-selecting the
+ * same vaults during the indexer delay.
+ */
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+
+interface PendingVaultsContextValue {
+  /** Set of vault IDs currently pending (submitted but not yet indexed) */
+  pendingVaultIds: Set<string>;
+  /** Mark vault IDs as pending after successful transaction */
+  markVaultsAsPending: (vaultIds: string[]) => void;
+  /** Clear pending status for vault IDs (called when indexer confirms) */
+  clearPendingVaults: (vaultIds: string[]) => void;
+  /** Clear all pending vaults */
+  clearAllPendingVaults: () => void;
+}
+
+const PendingVaultsContext = createContext<PendingVaultsContextValue | null>(
+  null,
+);
+
+interface PendingVaultsProviderProps {
+  children: ReactNode;
+}
+
+/**
+ * Provider that tracks pending vault IDs.
+ * Wrap this around the Aave routes.
+ */
+export function PendingVaultsProvider({
+  children,
+}: PendingVaultsProviderProps) {
+  const [pendingVaultIds, setPendingVaultIds] = useState<Set<string>>(
+    new Set(),
+  );
+
+  const markVaultsAsPending = useCallback((vaultIds: string[]) => {
+    setPendingVaultIds((prev) => {
+      const next = new Set(prev);
+      vaultIds.forEach((id) => next.add(id));
+      return next;
+    });
+  }, []);
+
+  const clearPendingVaults = useCallback((vaultIds: string[]) => {
+    setPendingVaultIds((prev) => {
+      const next = new Set(prev);
+      vaultIds.forEach((id) => next.delete(id));
+      return next;
+    });
+  }, []);
+
+  const clearAllPendingVaults = useCallback(() => {
+    setPendingVaultIds(new Set());
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      pendingVaultIds,
+      markVaultsAsPending,
+      clearPendingVaults,
+      clearAllPendingVaults,
+    }),
+    [
+      pendingVaultIds,
+      markVaultsAsPending,
+      clearPendingVaults,
+      clearAllPendingVaults,
+    ],
+  );
+
+  return (
+    <PendingVaultsContext.Provider value={value}>
+      {children}
+    </PendingVaultsContext.Provider>
+  );
+}
+
+/**
+ * Hook to access pending vaults context.
+ * Must be used within a PendingVaultsProvider.
+ */
+export function usePendingVaults(): PendingVaultsContextValue {
+  const ctx = useContext(PendingVaultsContext);
+  if (!ctx) {
+    throw new Error(
+      "usePendingVaults must be used within a PendingVaultsProvider",
+    );
+  }
+  return ctx;
+}

--- a/services/vault/src/applications/aave/context/index.ts
+++ b/services/vault/src/applications/aave/context/index.ts
@@ -1,1 +1,5 @@
 export { AaveConfigProvider, useAaveConfig } from "./AaveConfigContext";
+export {
+  PendingVaultsProvider,
+  usePendingVaults,
+} from "./PendingVaultsContext";

--- a/services/vault/src/applications/aave/hooks/index.ts
+++ b/services/vault/src/applications/aave/hooks/index.ts
@@ -8,4 +8,8 @@ export {
   type HealthFactorStatus,
   type UseAaveUserPositionResult,
 } from "./useAaveUserPosition";
-export { useAaveVaults } from "./useAaveVaults";
+export { useAaveVaults, type UseAaveVaultsResult } from "./useAaveVaults";
+export {
+  useAddCollateralTransaction,
+  type UseAddCollateralTransactionResult,
+} from "./useAddCollateralTransaction";

--- a/services/vault/src/applications/aave/hooks/useAddCollateralTransaction.ts
+++ b/services/vault/src/applications/aave/hooks/useAddCollateralTransaction.ts
@@ -1,0 +1,92 @@
+/**
+ * Hook for add collateral transaction
+ * Handles the transaction execution for adding vaults as collateral
+ */
+
+import { useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import type { Address, Hex } from "viem";
+import { useAccount, useWalletClient } from "wagmi";
+
+import { useError } from "../../../context/error";
+import {
+  ErrorCode,
+  WalletError,
+  mapViemErrorToContractError,
+} from "../../../utils/errors";
+import { invalidateVaultQueries } from "../../../utils/queryKeys";
+import { usePendingVaults } from "../context";
+import { addCollateral } from "../services";
+
+export interface UseAddCollateralTransactionResult {
+  /** Execute the add collateral transaction */
+  executeAddCollateral: (vaultIds: string[]) => Promise<boolean>;
+  /** Whether transaction is currently processing */
+  isProcessing: boolean;
+}
+
+/**
+ * Hook for executing add collateral transactions
+ *
+ * Returns the transaction handler and processing state.
+ * Handles wallet validation, error mapping, and cache invalidation.
+ */
+export function useAddCollateralTransaction(): UseAddCollateralTransactionResult {
+  const [isProcessing, setIsProcessing] = useState(false);
+  const { data: walletClient } = useWalletClient();
+  const { address } = useAccount();
+  const queryClient = useQueryClient();
+  const chain = walletClient?.chain;
+  const { handleError } = useError();
+  const { markVaultsAsPending } = usePendingVaults();
+
+  const executeAddCollateral = async (vaultIds: string[]) => {
+    if (vaultIds.length === 0) return false;
+
+    setIsProcessing(true);
+    try {
+      // Validate wallet connection
+      if (!walletClient || !chain) {
+        throw new WalletError(
+          "Please connect your wallet to continue",
+          ErrorCode.WALLET_NOT_CONNECTED,
+        );
+      }
+
+      // Execute the add collateral transaction
+      await addCollateral(walletClient, chain, vaultIds as Hex[]);
+
+      // Mark vaults as pending to prevent re-selection before indexer updates
+      markVaultsAsPending(vaultIds);
+
+      // Invalidate vault-related queries to refresh from indexer
+      await invalidateVaultQueries(queryClient, address as Address);
+
+      return true;
+    } catch (error) {
+      console.error("Add collateral failed:", error);
+
+      const mappedError =
+        error instanceof Error
+          ? mapViemErrorToContractError(error, "Add Collateral")
+          : new Error("An unexpected error occurred while adding collateral");
+
+      handleError({
+        error: mappedError,
+        displayOptions: {
+          showModal: true,
+          retryAction: () => executeAddCollateral(vaultIds),
+        },
+      });
+
+      return false;
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+
+  return {
+    executeAddCollateral,
+    isProcessing,
+  };
+}

--- a/services/vault/src/applications/aave/routes.tsx
+++ b/services/vault/src/applications/aave/routes.tsx
@@ -2,15 +2,17 @@ import { Route, Routes } from "react-router";
 
 import { AaveReserveDetail } from "./components/Detail";
 import { AaveOverview } from "./components/Overview";
-import { AaveConfigProvider } from "./context";
+import { AaveConfigProvider, PendingVaultsProvider } from "./context";
 
 export function AaveRoutes() {
   return (
     <AaveConfigProvider>
-      <Routes>
-        <Route index element={<AaveOverview />} />
-        <Route path="reserve/:reserveId" element={<AaveReserveDetail />} />
-      </Routes>
+      <PendingVaultsProvider>
+        <Routes>
+          <Route index element={<AaveOverview />} />
+          <Route path="reserve/:reserveId" element={<AaveReserveDetail />} />
+        </Routes>
+      </PendingVaultsProvider>
     </AaveConfigProvider>
   );
 }

--- a/services/vault/src/applications/aave/utils/__tests__/healthFactor.test.ts
+++ b/services/vault/src/applications/aave/utils/__tests__/healthFactor.test.ts
@@ -9,6 +9,7 @@ import {
   formatHealthFactor,
   getHealthFactorColor,
   getHealthFactorStatus,
+  getHealthFactorStatusFromValue,
   HEALTH_FACTOR_COLORS,
   isHealthFactorHealthy,
 } from "../healthFactor";
@@ -138,6 +139,28 @@ describe("healthFactor", () => {
 
     it("should return GRAY for no_debt status", () => {
       expect(getHealthFactorColor("no_debt")).toBe(HEALTH_FACTOR_COLORS.GRAY);
+    });
+  });
+
+  describe("getHealthFactorStatusFromValue", () => {
+    it("should return no_debt for Infinity (no debt)", () => {
+      expect(getHealthFactorStatusFromValue(Infinity)).toBe("no_debt");
+    });
+
+    it("should return danger when value < 1.0", () => {
+      expect(getHealthFactorStatusFromValue(0.99)).toBe("danger");
+      expect(getHealthFactorStatusFromValue(0.5)).toBe("danger");
+    });
+
+    it("should return warning when value >= 1.0 and < 1.5", () => {
+      expect(getHealthFactorStatusFromValue(1.0)).toBe("warning");
+      expect(getHealthFactorStatusFromValue(1.49)).toBe("warning");
+    });
+
+    it("should return safe when value >= 1.5", () => {
+      expect(getHealthFactorStatusFromValue(1.5)).toBe("safe");
+      expect(getHealthFactorStatusFromValue(2.0)).toBe("safe");
+      expect(getHealthFactorStatusFromValue(10.0)).toBe("safe");
     });
   });
 });

--- a/services/vault/src/applications/aave/utils/healthFactor.ts
+++ b/services/vault/src/applications/aave/utils/healthFactor.ts
@@ -100,6 +100,21 @@ export function isHealthFactorHealthy(healthFactor: number | null): boolean {
 }
 
 /**
+ * Get health factor status from a numeric value.
+ * Used for UI components that work with Infinity for no-debt scenarios.
+ *
+ * @param value - Health factor value (Infinity when no debt)
+ * @returns The status classification
+ */
+export function getHealthFactorStatusFromValue(
+  value: number,
+): HealthFactorStatus {
+  const hasDebt = isFinite(value);
+  const healthFactor = isFinite(value) ? value : null;
+  return getHealthFactorStatus(healthFactor, hasDebt);
+}
+
+/**
  * Calculate health factor
  * HF = (Collateral * Liquidation Threshold) / Total Debt
  *

--- a/services/vault/src/applications/aave/utils/index.ts
+++ b/services/vault/src/applications/aave/utils/index.ts
@@ -7,6 +7,7 @@ export {
   formatHealthFactor,
   getHealthFactorColor,
   getHealthFactorStatus,
+  getHealthFactorStatusFromValue,
   isHealthFactorHealthy,
 } from "./healthFactor";
 export type { HealthFactorColor, HealthFactorStatus } from "./healthFactor";

--- a/services/vault/src/utils/queryKeys.ts
+++ b/services/vault/src/utils/queryKeys.ts
@@ -9,6 +9,7 @@ import type { QueryClient } from "@tanstack/react-query";
 import type { Address } from "viem";
 
 import { CONTRACTS } from "../config/contracts";
+import { VAULTS_QUERY_KEY } from "../hooks/useVaults";
 
 /**
  * Query key factory for consistent key generation
@@ -61,6 +62,11 @@ export async function invalidateVaultQueries(
     // Invalidate pegin requests to update vault usage status (isInUse)
     queryClient.invalidateQueries({
       queryKey: queryKeys.peginRequests(address),
+    }),
+
+    // Invalidate vaults query to refresh vault list
+    queryClient.invalidateQueries({
+      queryKey: [VAULTS_QUERY_KEY, address],
     }),
   ]);
 }


### PR DESCRIPTION
- Refactor AddCollateralModal to be self-contained with its own data fetching and transaction handling
- Add useAddCollateralTransaction hook for executing add collateral transactions following the established Morpho pattern
- Add PendingVaultsContext to track vaults submitted for collateral during indexer delay, preventing duplicate submissions
- Fix health factor calculation to use collateralFactor (liquidation threshold) instead of collateralRisk
- Consolidate shared constants (BTC_TOKEN, MIN_SLIDER_MAX) to avoid duplication
- Add getHealthFactorStatusFromValue utility for numeric health factor values (using Infinity for no-debt)
- Update useAaveVaults to return both vaults and availableForCollateral for clearer API
- Show health factor transition (before → after) in CollateralDetailsCard when adding collateral