### PR TITLE
fix(baby): click on max button should auto-fill the amount

### DIFF
--- a/packages/babylon-core-ui/src/components/AmountItem/AmountItem.tsx
+++ b/packages/babylon-core-ui/src/components/AmountItem/AmountItem.tsx
@@ -72,16 +72,16 @@ export const AmountItem = ({
                         <button
                             type="button"
                             onClick={onMaxClick}
-                            disabled={disabled}
+                            disabled={disabled || !onMaxClick}
                             className="cursor-pointer rounded bg-secondary-strokeLight px-2 py-0.5 text-xs text-accent-secondary transition-all hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
                         >
                             Max
                         </button>
                         <span>
-                            {typeof balanceDetails.balance === 'number' 
-                                ? balanceDetails.balance.toLocaleString('en-US', { 
+                            {typeof balanceDetails.balance === 'number'
+                                ? balanceDetails.balance.toLocaleString('en-US', {
                                     minimumFractionDigits: balanceDetails.decimals ?? 8,
-                                    maximumFractionDigits: balanceDetails.decimals ?? 8 
+                                    maximumFractionDigits: balanceDetails.decimals ?? 8
                                   })
                                 : balanceDetails.balance} {balanceDetails.symbol}
                         </span>

--- a/packages/babylon-core-ui/src/widgets/sections/AmountSubsection/AmountSubsection.tsx
+++ b/packages/babylon-core-ui/src/widgets/sections/AmountSubsection/AmountSubsection.tsx
@@ -26,6 +26,7 @@ interface Props {
   step?: string;
   autoFocus?: boolean;
   decimals?: number; // Enforce decimals
+  enableMaxButton?: boolean; // Enable Max button to fill max balance
 }
 
 export const AmountSubsection = ({
@@ -40,6 +41,7 @@ export const AmountSubsection = ({
   step = "any",
   autoFocus = true,
   decimals,
+  enableMaxButton,
 }: Props) => {
   const amount = useWatch({ name: fieldName, defaultValue: "" });
   const { setValue } = useFormContext();
@@ -82,6 +84,21 @@ export const AmountSubsection = ({
     }
   };
 
+  const handleMaxClick = () => {
+    if (balanceDetails?.balance !== undefined) {
+      const balanceValue = Number(balanceDetails.balance);
+      // Use specified decimals if provided, otherwise use full precision
+      const maxValue = balanceDetails.decimals !== undefined
+        ? maxDecimals(balanceValue, balanceDetails.decimals).toString()
+        : balanceValue.toString();
+      setValue(fieldName, maxValue, {
+        shouldValidate: true,
+        shouldDirty: true,
+        shouldTouch: true,
+      });
+    }
+  };
+
   let subtitle: string | undefined;
   if (balanceDetails) {
     subtitle = `${maxDecimals(Number(balanceDetails.balance), balanceDetails.decimals ?? BTC_DECIMAL_PLACES)} ${balanceDetails.symbol}`;
@@ -107,6 +124,7 @@ export const AmountSubsection = ({
           onKeyDown={handleKeyDown}
           amountUsd={amountUsd}
           subtitle={subtitle}
+          {...(enableMaxButton && { onMaxClick: handleMaxClick })}
         />
       </SubSection>
     </>

--- a/services/simple-staking/src/ui/baby/components/AmountField/index.tsx
+++ b/services/simple-staking/src/ui/baby/components/AmountField/index.tsx
@@ -7,9 +7,14 @@ const { logo, coinSymbol, displayUSD } = getNetworkConfigBBN();
 interface AmountFieldProps {
   balance?: number;
   price?: number;
+  enableMaxButton?: boolean;
 }
 
-export const AmountField = ({ balance, price }: AmountFieldProps) => {
+export const AmountField = ({
+  balance,
+  price,
+  enableMaxButton,
+}: AmountFieldProps) => {
   // Only create balanceDetails if balance is provided (price is optional)
   const balanceDetails =
     balance !== undefined
@@ -31,6 +36,7 @@ export const AmountField = ({ balance, price }: AmountFieldProps) => {
       currencyName={coinSymbol}
       placeholder="Enter Amount"
       {...(balanceDetails && { balanceDetails })}
+      enableMaxButton={enableMaxButton}
     />
   );
 };

--- a/services/simple-staking/src/ui/baby/components/UnbondingModal/index.tsx
+++ b/services/simple-staking/src/ui/baby/components/UnbondingModal/index.tsx
@@ -85,7 +85,7 @@ const UnbondingModalContent = ({
           earning rewards.
         </Text>
 
-        <AmountField balance={availableBalance} />
+        <AmountField balance={availableBalance} enableMaxButton />
 
         {!isEpochReady && (
           <Warning>


### PR DESCRIPTION
The max button will be enabled only in the unbonding path of BABY staking. In all other flows, it will remain disabled.

If we decide to make the max button clickable elsewhere, that should be handled in a separate PR. This PR does not intend to change the existing behaviour outside of the unbonding path.