### PR TITLE
feat(simple-staking): no bsn in fp section

### DIFF
--- a/services/simple-staking/src/ui/common/components/Multistaking/MultistakingForm/FinalityProvidersSection.tsx
+++ b/services/simple-staking/src/ui/common/components/Multistaking/MultistakingForm/FinalityProvidersSection.tsx
@@ -123,6 +123,7 @@ export function FinalityProvidersSection() {
         actionText={actionText}
         onAdd={handleOpen}
         onRemove={handleRemove}
+        showChain={false} // No BSN chain display needed
       />
 
       <ChainSelectionModal


### PR DESCRIPTION
- removes `bsn` stuff after FP is selected

instead of this:
<img width="488" height="272" alt="image" src="https://github.com/user-attachments/assets/abc36ea4-0d90-4974-8dff-3caaf7fdae47" />

we would see this: 
<img width="737" height="159" alt="Screenshot_2026-01-12_16-05-42" src="https://github.com/user-attachments/assets/f97d5e57-ac0c-4b00-98cf-6a05d7e7a78c" />

suggestion to properly remove `bsn` related stuff in this PR: https://github.com/babylonlabs-io/babylon-toolkit/pull/893