### PR TITLE
feat(sdk): toc improvements

### DIFF
--- a/packages/babylon-ts-sdk/README.md
+++ b/packages/babylon-ts-sdk/README.md
@@ -63,6 +63,13 @@ New to the SDK? Start here:
 
 - **[Installation](./docs/get-started/installation.md)** - Install and verify the SDK
 
+### 🚀 Quickstart
+
+Step-by-step tutorials:
+
+- **[Managers Quickstart](./docs/quickstart/managers.md)** - Complete peg-in flow with wallet integration
+- **[Primitives Quickstart](./docs/quickstart/primitives.md)** - Low-level implementation guide
+
 ### 📖 Guides
 
 Complete flows and tutorials:
@@ -76,13 +83,6 @@ Complete flows and tutorials:
 Auto-generated from TSDoc comments using [TypeDoc](https://typedoc.org/):
 
 - **[API Reference](./docs/api/README.md)** - Complete auto-generated API documentation
-
-### 💡 Examples [⚠️WIP]
-
-Working example applications:
-
-- **[React App with Managers](./examples/managers-react/)** - Front-end implementation
-- **[Node.js with Primitives](./examples/primitives-nodejs/)** - Back-end integration with custom signing
 
 ## Development
 

--- a/packages/babylon-ts-sdk/docs/guides/primitives.md
+++ b/packages/babylon-ts-sdk/docs/guides/primitives.md
@@ -2,6 +2,22 @@
 
 Pure functions for building Bitcoin transactions for Babylon Trustless BTC Vault (TBV).
 
+## Table of Contents
+
+1. [Important: Primitives vs Managers](#️-important-primitives-vs-managers)
+2. [Understanding the SDK Layers](#understanding-the-sdk-layers)
+   - 2.1. [Level 1: Primitives (Pure Functions)](#level-1-primitives-pure-functions)
+   - 2.2. [Level 2: Utils (Helper Functions)](#level-2-utils-helper-functions)
+   - 2.3. [What You Must Still Implement](#what-you-must-still-implement)
+   - 2.4. [When to Use Primitives](#when-to-use-primitives)
+   - 2.5. [Level 3: Managers (Full Orchestration)](#level-3-managers-full-orchestration)
+3. [Installation](#installation)
+4. [Architecture Layers](#architecture-layers)
+5. [Setup](#setup)
+6. [Quickstart](#quickstart)
+   - 6.1. [Peg-in](#peg-in)
+   - 6.2. [Payout Authorization Signing (Peg-In Step 3)](#payout-authorization-signing-peg-in-step-3)
+
 ---
 
 ## ⚠️ Important: Primitives vs Managers


### PR DESCRIPTION
- improves TOC in docs
- follows progressive learning: `Setup → Working code → Understanding → Reference` -> industry standard pattern (Stripe, Vercel, AWS, etc)
- quickstart files are complete tutorials, guides provide architectural depth and error handling
- natural flow: `"Make it work" → "Understand why" → "Deep dive"`

added `TOC` for `packages/babylon-ts-sdk/docs/guides/primitives.md` the same way we have for `managers` 