### PR TITLE
feat(sdk): rm wip integrations

### DIFF
--- a/packages/babylon-ts-sdk/README.md
+++ b/packages/babylon-ts-sdk/README.md
@@ -76,7 +76,6 @@ Complete flows and tutorials:
 
 - **[Using Managers](./docs/guides/managers.md)** - High-level orchestration for vault operations with wallet integration (recommended for most users)
 - **[Using Primitives](./docs/guides/primitives.md)** - Low-level primitives for advanced use cases and custom implementations
-- **[Protocol Integrations](./docs/guides/integrations.md)** - For protocol developers - ⚠️WIP
 
 ### 🔍 API Reference
 


### PR DESCRIPTION
- removes `wip` integrations part from `readme` of `ts-sdk/tbv`