### PR TITLE
ci: enable provenance to enable OIDC and remove NPM Token

### DIFF
--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -57,8 +57,6 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> .npmrc
           pnpm run ci:release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/babylon-core-ui/package.json
+++ b/packages/babylon-core-ui/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "types": "dist/index.d.ts",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git",

--- a/packages/babylon-proto-ts/package.json
+++ b/packages/babylon-proto-ts/package.json
@@ -49,6 +49,7 @@
     "@cosmjs/tendermint-rpc": "0.36.0"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/babylon-ts-sdk/package.json
+++ b/packages/babylon-ts-sdk/package.json
@@ -101,6 +101,7 @@
     "vitest": "^4.0.8"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/babylon-wallet-connector/package.json
+++ b/packages/babylon-wallet-connector/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "types": "dist/index.d.ts",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION

- OIDC connection has been configured on all the NPM packages.
- Removed NPM Token from the publish workflow
- Enabled provenance which handles the OIDC connection from the workflow to NPM