### PR TITLE
feat(vault): allow taproot address type only

### DIFF
--- a/services/vault/src/components/pages/ApplicationsHome.tsx
+++ b/services/vault/src/components/pages/ApplicationsHome.tsx
@@ -1,6 +1,7 @@
 import { Button, Container } from "@babylonlabs-io/core-ui";
 import { useNavigate } from "react-router";
 
+import { useAddressType } from "@/context/addressType";
 import { useGeoFencing } from "@/context/geofencing";
 
 import { getNetworkConfigBTC } from "../../config";
@@ -20,6 +21,7 @@ export default function ApplicationsHome() {
   const { data: statsData, isLoading: statsLoading } = useStats();
   const { metadata, hasStalePrices, hasPriceFetchError } = usePrices();
   const { isGeoBlocked } = useGeoFencing();
+  const { isSupportedAddress } = useAddressType();
 
   const isWalletConnected = btcConnected && ethConnected;
 
@@ -37,7 +39,7 @@ export default function ApplicationsHome() {
           vault provider and begin.
         </h2>
         <div className="mt-4 self-center">
-          {isWalletConnected && !isGeoBlocked ? (
+          {isWalletConnected && !isGeoBlocked && isSupportedAddress ? (
             <Button
               color="secondary"
               rounded

--- a/services/vault/src/components/pages/Deposit.tsx
+++ b/services/vault/src/components/pages/Deposit.tsx
@@ -1,8 +1,9 @@
-import { Button, Card, Container, Text } from "@babylonlabs-io/core-ui";
+import { Button, Card, Container, Hint, Text } from "@babylonlabs-io/core-ui";
 import { useNavigate } from "react-router";
 
 import { BackButton } from "@/components/shared";
 import { FeatureFlags } from "@/config";
+import { useAddressType } from "@/context/addressType";
 import { useGeoFencing } from "@/context/geofencing";
 import { ProtocolParamsProvider } from "@/context/ProtocolParamsContext";
 
@@ -21,6 +22,7 @@ import { SelectVaultProviderSection } from "./Deposit/SelectVaultProviderSection
 function DepositContent() {
   const navigate = useNavigate();
   const { isGeoBlocked } = useGeoFencing();
+  const { isSupportedAddress } = useAddressType();
 
   const handleBack = () => {
     navigate(-1);
@@ -134,20 +136,41 @@ function DepositContent() {
               </Text>
             )}
 
-            <Button
-              variant="contained"
-              color="secondary"
-              size="large"
-              disabled={
-                !isValid || !FeatureFlags.isDepositEnabled || isGeoBlocked
-              }
-              onClick={handleDeposit}
-              className="w-full"
-            >
-              {FeatureFlags.isDepositEnabled
-                ? "Deposit"
-                : "Depositing Unavailable"}
-            </Button>
+            {!isSupportedAddress ? (
+              <Hint
+                tooltip="Taproot address required. Please switch your wallet to use a Taproot address."
+                attachToChildren
+              >
+                <span className="w-full">
+                  <Button
+                    variant="contained"
+                    color="secondary"
+                    size="large"
+                    disabled
+                    className="w-full"
+                  >
+                    {FeatureFlags.isDepositEnabled
+                      ? "Deposit"
+                      : "Depositing Unavailable"}
+                  </Button>
+                </span>
+              </Hint>
+            ) : (
+              <Button
+                variant="contained"
+                color="secondary"
+                size="large"
+                disabled={
+                  !isValid || !FeatureFlags.isDepositEnabled || isGeoBlocked
+                }
+                onClick={handleDeposit}
+                className="w-full"
+              >
+                {FeatureFlags.isDepositEnabled
+                  ? "Deposit"
+                  : "Depositing Unavailable"}
+              </Button>
+            )}
           </div>
 
           <DepositFAQ />

--- a/services/vault/src/components/pages/RootLayout.tsx
+++ b/services/vault/src/components/pages/RootLayout.tsx
@@ -13,9 +13,11 @@ import { NavLink, Outlet, useLocation, useNavigate } from "react-router";
 import { twJoin } from "tailwind-merge";
 
 import { getNetworkConfigBTC, shouldDisplayTestingMsg } from "@/config";
+import { useAddressType } from "@/context/addressType";
 import { useGeoFencing } from "@/context/geofencing";
 
 import { useBTCWallet, useETHWallet } from "../../context/wallet";
+import { AddressTypeBanner } from "../shared/AddressTypeBanner";
 import { GeoBlockBanner } from "../shared/GeoBlockAlert";
 import { Connect } from "../Wallet";
 
@@ -76,8 +78,10 @@ export default function RootLayout() {
   const { connected: btcConnected } = useBTCWallet();
   const { connected: ethConnected } = useETHWallet();
   const { isGeoBlocked } = useGeoFencing();
+  const { isSupportedAddress } = useAddressType();
 
   const isWalletConnected = btcConnected && ethConnected;
+  const showAddressTypeBanner = isWalletConnected && !isSupportedAddress;
   const isDepositPage = location.pathname === "/deposit";
 
   return (
@@ -91,21 +95,25 @@ export default function RootLayout() {
       <div className="flex min-h-svh flex-col">
         <TestingBanner visible={shouldDisplayTestingMsg()} />
         <GeoBlockBanner visible={isGeoBlocked} />
+        <AddressTypeBanner visible={showAddressTypeBanner} />
         <Header
           size="sm"
           navigation={<DesktopNavigation />}
           mobileNavigation={<MobileNavigation />}
           rightActions={
             <div className="flex items-center gap-4">
-              {isWalletConnected && !isDepositPage && !isGeoBlocked && (
-                <Button
-                  variant="outlined"
-                  rounded
-                  onClick={() => navigate("/deposit")}
-                >
-                  Deposit {btcConfig.coinSymbol}
-                </Button>
-              )}
+              {isWalletConnected &&
+                !isDepositPage &&
+                !isGeoBlocked &&
+                isSupportedAddress && (
+                  <Button
+                    variant="outlined"
+                    rounded
+                    onClick={() => navigate("/deposit")}
+                  >
+                    Deposit {btcConfig.coinSymbol}
+                  </Button>
+                )}
               <Connect />
               <StandardSettingsMenu theme={theme} setTheme={setTheme} />
             </div>

--- a/services/vault/src/components/shared/AddressTypeBanner.tsx
+++ b/services/vault/src/components/shared/AddressTypeBanner.tsx
@@ -1,0 +1,26 @@
+import { Text } from "@babylonlabs-io/core-ui";
+import { PiWarningOctagonFill } from "react-icons/pi";
+
+interface AddressTypeBannerProps {
+  visible: boolean;
+}
+
+export function AddressTypeBanner({ visible }: AddressTypeBannerProps) {
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-row items-center justify-between gap-2 bg-amber-100 px-4 py-3 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300">
+      <div className="flex flex-row items-center gap-2">
+        <PiWarningOctagonFill className="flex-shrink-0" />
+        <Text variant="body1">
+          <strong>Taproot Address Required</strong>
+          <br />
+          This application requires a Taproot (P2TR) Bitcoin address. Please
+          switch your wallet to use a Taproot address to deposit.
+        </Text>
+      </div>
+    </div>
+  );
+}

--- a/services/vault/src/context/addressType/AddressTypeProvider.tsx
+++ b/services/vault/src/context/addressType/AddressTypeProvider.tsx
@@ -1,0 +1,55 @@
+import {
+  createContext,
+  useContext,
+  useMemo,
+  type PropsWithChildren,
+} from "react";
+
+import { useBTCWallet } from "@/context/wallet";
+
+import type { AddressTypeContextType } from "./types";
+
+const AddressTypeContext = createContext<AddressTypeContextType>({
+  isSupportedAddress: true,
+  isCheckingAddress: false,
+});
+
+/**
+ * Checks if a BTC address is a Taproot (P2TR) address.
+ * Taproot addresses start with bc1p (mainnet) or tb1p (testnet/signet).
+ * Bech32/Bech32m addresses are case-insensitive per spec, so we normalize to lowercase.
+ */
+function isTaprootAddress(address: string): boolean {
+  const normalized = address.trim().toLowerCase();
+  return normalized.startsWith("bc1p") || normalized.startsWith("tb1p");
+}
+
+export function AddressTypeProvider({ children }: PropsWithChildren) {
+  const { connected, address } = useBTCWallet();
+
+  const value = useMemo<AddressTypeContextType>(() => {
+    // If not connected, we consider it supported (no restriction yet)
+    if (!connected || !address) {
+      return {
+        isSupportedAddress: true,
+        isCheckingAddress: false,
+      };
+    }
+
+    // Check if the connected address is Taproot
+    const isTaproot = isTaprootAddress(address);
+
+    return {
+      isSupportedAddress: isTaproot,
+      isCheckingAddress: false,
+    };
+  }, [connected, address]);
+
+  return (
+    <AddressTypeContext.Provider value={value}>
+      {children}
+    </AddressTypeContext.Provider>
+  );
+}
+
+export const useAddressType = () => useContext(AddressTypeContext);

--- a/services/vault/src/context/addressType/index.ts
+++ b/services/vault/src/context/addressType/index.ts
@@ -1,0 +1,2 @@
+export { AddressTypeProvider, useAddressType } from "./AddressTypeProvider";
+export type { AddressTypeContextType } from "./types";

--- a/services/vault/src/context/addressType/types.ts
+++ b/services/vault/src/context/addressType/types.ts
@@ -1,0 +1,4 @@
+export interface AddressTypeContextType {
+  isSupportedAddress: boolean;
+  isCheckingAddress: boolean;
+}

--- a/services/vault/src/providers.tsx
+++ b/services/vault/src/providers.tsx
@@ -8,6 +8,7 @@ import { WagmiProvider } from "wagmi";
 import { NotificationContainer } from "@/components/shared/NotificationContainer";
 import { createQueryClient } from "@/config/queryClient";
 import { vaultWagmiConfig } from "@/config/wagmi";
+import { AddressTypeProvider } from "@/context/addressType";
 import { ErrorProvider } from "@/context/error";
 import { GeoFencingProvider } from "@/context/geofencing";
 import { WalletConnectionProvider } from "@/context/wallet";
@@ -37,7 +38,9 @@ function Providers({ children }: React.PropsWithChildren) {
                   <GeoFencingProvider>
                     <WagmiProvider config={vaultWagmiConfig} reconnectOnMount>
                       <WalletConnectionProvider>
-                        <AppState>{children}</AppState>
+                        <AddressTypeProvider>
+                          <AppState>{children}</AppState>
+                        </AddressTypeProvider>
                       </WalletConnectionProvider>
                     </WagmiProvider>
                   </GeoFencingProvider>


### PR DESCRIPTION
As per conversation with protocol team. we will only enable the taproot until protocol fully support other address types in the future.

<img width="926" height="989" alt="image" src="https://github.com/user-attachments/assets/11ec6665-1ab6-4a3e-8e7f-1b20382590a1" />
