### PR TITLE
feat(vault): add wallet balance validation to Aave repay flow

### DIFF
--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/index.tsx
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/index.tsx
@@ -18,7 +18,10 @@ import {
   getCurrencyIconWithFallback,
   getTokenBrandColor,
 } from "../../../../../services/token";
-import { formatUsdValue } from "../../../../../utils/formatting";
+import {
+  formatTokenAmount,
+  formatUsdValue,
+} from "../../../../../utils/formatting";
 import { AMOUNT_INPUT_CLASS_NAME, MIN_SLIDER_MAX } from "../../../constants";
 import { useBorrowTransaction } from "../../../hooks";
 import { useLoanContext } from "../../context/LoanContext";
@@ -96,7 +99,7 @@ export function Borrow() {
               setBorrowAmount(parseFloat(e.target.value) || 0)
             }
             balanceDetails={{
-              balance: sliderMaxBorrow.toLocaleString(),
+              balance: formatTokenAmount(sliderMaxBorrow),
               symbol: assetConfig.symbol,
               displayUSD: false,
             }}
@@ -109,7 +112,7 @@ export function Borrow() {
             sliderVariant="rainbow"
             leftField={{
               label: "Max",
-              value: `${sliderMaxBorrow.toLocaleString()} ${assetConfig.symbol}`,
+              value: `${formatTokenAmount(sliderMaxBorrow)} ${assetConfig.symbol}`,
             }}
             onMaxClick={() => setBorrowAmount(sliderMaxBorrow)}
             rightField={{

--- a/services/vault/src/applications/aave/components/LoanCard/Repay/hooks/useRepayState.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Repay/hooks/useRepayState.ts
@@ -11,6 +11,8 @@ import { FULL_REPAY_TOLERANCE } from "../../../../constants";
 export interface UseRepayStateProps {
   /** Current debt amount for selected reserve in token units */
   currentDebtAmount: number;
+  /** User's token balance for the selected reserve */
+  userTokenBalance: number;
 }
 
 export interface UseRepayStateResult {
@@ -24,12 +26,14 @@ export interface UseRepayStateResult {
 
 export function useRepayState({
   currentDebtAmount,
+  userTokenBalance,
 }: UseRepayStateProps): UseRepayStateResult {
   const [repayAmount, setRepayAmount] = useState(0);
 
+  // Max repay is the minimum of debt and available balance
   const maxRepayAmount = useMemo(() => {
-    return Math.max(0, currentDebtAmount);
-  }, [currentDebtAmount]);
+    return Math.max(0, Math.min(currentDebtAmount, userTokenBalance));
+  }, [currentDebtAmount, userTokenBalance]);
 
   // Determine if this is a full repayment (within tolerance for floating point)
   const isFullRepayment = useMemo(() => {

--- a/services/vault/src/applications/aave/components/LoanCard/Repay/hooks/validateRepayAction.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Repay/hooks/validateRepayAction.ts
@@ -14,12 +14,16 @@ export interface RepayValidationResult {
  * Validates whether the repay action is allowed.
  *
  * @param repayAmount - Amount user wants to repay
- * @param maxRepayAmount - Maximum repay amount
+ * @param maxRepayAmount - Maximum repay amount (min of debt and balance)
+ * @param currentDebtAmount - Current debt amount (optional, for better error messages)
+ * @param userTokenBalance - User's token balance (optional, for better error messages)
  * @returns Validation result with disabled state, button text, and error message
  */
 export function validateRepayAction(
   repayAmount: number,
   maxRepayAmount: number,
+  currentDebtAmount?: number,
+  userTokenBalance?: number,
 ): RepayValidationResult {
   if (repayAmount === 0) {
     return {
@@ -30,6 +34,18 @@ export function validateRepayAction(
   }
 
   if (repayAmount > maxRepayAmount) {
+    // Determine the specific reason for the limit
+    if (
+      userTokenBalance !== undefined &&
+      currentDebtAmount !== undefined &&
+      userTokenBalance < currentDebtAmount
+    ) {
+      return {
+        isDisabled: true,
+        buttonText: "Insufficient balance",
+        errorMessage: `You only have ${userTokenBalance.toFixed(2)} tokens available. You need more tokens to fully repay your debt.`,
+      };
+    }
     return {
       isDisabled: true,
       buttonText: "Amount exceeds debt",

--- a/services/vault/src/hooks/index.ts
+++ b/services/vault/src/hooks/index.ts
@@ -17,6 +17,11 @@ export {
   type UseBTCBalanceResult,
 } from "./useBTCBalance";
 export { useBtcPublicKey } from "./useBtcPublicKey";
+export {
+  ERC20_BALANCE_QUERY_KEY,
+  useERC20Balance,
+  type UseERC20BalanceResult,
+} from "./useERC20Balance";
 export { toIdentity, useLogos, type UseLogosResult } from "./useLogos";
 export {
   useLtvCalculations,

--- a/services/vault/src/hooks/useERC20Balance.ts
+++ b/services/vault/src/hooks/useERC20Balance.ts
@@ -1,0 +1,72 @@
+/**
+ * Hook for fetching ERC20 token balance
+ *
+ * Reusable hook that fetches any ERC20 token balance for a given address.
+ * Automatically refetches periodically to keep the balance up to date.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+import type { Address } from "viem";
+import { formatUnits } from "viem";
+
+import { getERC20Balance } from "@/clients/eth-contract/erc20";
+
+/** Query key prefix for ERC20 balance queries */
+export const ERC20_BALANCE_QUERY_KEY = "erc20Balance";
+
+export interface UseERC20BalanceResult {
+  /** Balance in token units (formatted with decimals) */
+  balance: number;
+  /** Raw balance in smallest unit (bigint) */
+  balanceRaw: bigint;
+  /** Loading state */
+  isLoading: boolean;
+  /** Error state */
+  error: Error | null;
+  /** Function to manually refetch the balance */
+  refetch: () => Promise<unknown>;
+}
+
+/**
+ * Fetches ERC20 token balance for a wallet address
+ *
+ * @param tokenAddress - ERC20 token contract address
+ * @param walletAddress - Address to check balance for
+ * @param decimals - Token decimals (default: 18)
+ * @returns Balance data with loading/error states
+ */
+export function useERC20Balance(
+  tokenAddress: Address | string | undefined,
+  walletAddress: Address | string | undefined,
+  decimals: number = 18,
+): UseERC20BalanceResult {
+  const {
+    data: balanceRaw,
+    isLoading,
+    error,
+    refetch,
+  } = useQuery({
+    queryKey: [ERC20_BALANCE_QUERY_KEY, tokenAddress, walletAddress],
+    queryFn: async () => {
+      if (!tokenAddress || !walletAddress) return 0n;
+      return getERC20Balance(tokenAddress as Address, walletAddress as Address);
+    },
+    enabled: Boolean(tokenAddress && walletAddress),
+    // Refetch periodically to keep balance up to date
+    refetchInterval: 30000,
+  });
+
+  const balance = useMemo(() => {
+    if (!balanceRaw) return 0;
+    return Number(formatUnits(balanceRaw, decimals));
+  }, [balanceRaw, decimals]);
+
+  return {
+    balance,
+    balanceRaw: balanceRaw ?? 0n,
+    isLoading,
+    error: error as Error | null,
+    refetch,
+  };
+}

--- a/services/vault/src/utils/formatting.ts
+++ b/services/vault/src/utils/formatting.ts
@@ -165,3 +165,30 @@ export function formatTimeAgo(timestamp: number): string {
   }
   return "just now";
 }
+
+/**
+ * Format token amount for display with appropriate precision.
+ * Shows minimum 2 decimals, up to maxDecimals, trimming trailing zeros.
+ *
+ * @param amount - Token amount to format
+ * @param maxDecimals - Maximum decimal places (default: 6 for stablecoins)
+ * @returns Formatted string (e.g., "4.75" or "4.748593")
+ */
+export function formatTokenAmount(amount: number, maxDecimals = 6): string {
+  if (amount === 0) return "0";
+
+  // Format with max decimals, then trim trailing zeros
+  const formatted = amount.toFixed(maxDecimals);
+  // Remove trailing zeros but keep at least 2 decimal places
+  const trimmed = formatted.replace(/(\.\d*?[1-9])0+$|\.0+$/, "$1");
+
+  // Ensure at least 2 decimal places for consistency
+  const parts = trimmed.split(".");
+  if (parts.length === 1) {
+    return `${parts[0]}.00`;
+  }
+  if (parts[1].length === 1) {
+    return `${parts[0]}.${parts[1]}0`;
+  }
+  return trimmed;
+}


### PR DESCRIPTION
- Add wallet balance validation to repay flow - users can only repay up to their token balance
- Extract reusable `useERC20Balance` hook for fetching ERC20 token balances
- Add `formatTokenAmount` utility for consistent token amount formatting
- Improve error messaging when user has insufficient balance