### PR TITLE
chore(vault): remove the unused NEXT_PUBLIC_ENABLED_APPS

### DIFF
--- a/services/vault/src/applications/index.ts
+++ b/services/vault/src/applications/index.ts
@@ -11,9 +11,6 @@ export {
   getApplication,
   getApplicationByController,
   getApplicationMetadataByController,
-  getEnabledAppIds,
-  getEnabledApplications,
-  isApplicationEnabled,
   registerApplication,
 } from "./registry";
 

--- a/services/vault/src/applications/registry.ts
+++ b/services/vault/src/applications/registry.ts
@@ -33,29 +33,6 @@ export function getAllApplications(): ApplicationRegistration[] {
   return Array.from(applicationRegistry.values());
 }
 
-export function getEnabledAppIds(): string[] {
-  const whitelist = process.env.NEXT_PUBLIC_ENABLED_APPS;
-  if (!whitelist || typeof whitelist !== "string") {
-    return Array.from(applicationRegistry.keys());
-  }
-  return whitelist
-    .split(",")
-    .map((id) => id.trim().toLowerCase())
-    .filter(Boolean);
-}
-
-export function getEnabledApplications(): ApplicationRegistration[] {
-  const enabledIds = getEnabledAppIds();
-  return enabledIds
-    .map((id) => applicationRegistry.get(id))
-    .filter((app): app is ApplicationRegistration => app !== undefined);
-}
-
-export function isApplicationEnabled(appId: string): boolean {
-  const enabledIds = getEnabledAppIds();
-  return enabledIds.includes(appId.toLowerCase());
-}
-
 /**
  * Get application metadata by controller address
  * Used to enrich GraphQL data with local metadata

--- a/services/vault/src/hooks/useApplications.ts
+++ b/services/vault/src/hooks/useApplications.ts
@@ -1,22 +1,17 @@
 import { useQuery } from "@tanstack/react-query";
 
-import { getAppIdByController, getEnabledAppIds } from "../applications";
+import { getAppIdByController } from "../applications";
 import { fetchApplications } from "../services/applications";
 
 export const APPLICATIONS_KEY = "applications";
 
 export const useApplications = () => {
-  const enabledAppIds = getEnabledAppIds();
-
   return useQuery({
-    queryKey: [APPLICATIONS_KEY, enabledAppIds],
+    queryKey: [APPLICATIONS_KEY],
     queryFn: async () => {
       const allApps = await fetchApplications();
 
-      return allApps.filter((app) => {
-        const appId = getAppIdByController(app.id);
-        return appId && enabledAppIds.includes(appId);
-      });
+      return allApps.filter((app) => getAppIdByController(app.id));
     },
   });
 };

--- a/services/vault/src/router.tsx
+++ b/services/vault/src/router.tsx
@@ -1,6 +1,6 @@
 import { Route, Routes } from "react-router";
 
-import { getEnabledApplications } from "./applications";
+import { getAllApplications } from "./applications";
 import Activity from "./components/pages/Activity";
 import ApplicationsHome from "./components/pages/ApplicationsHome";
 import Deposit from "./components/pages/Deposit";
@@ -8,7 +8,7 @@ import RootLayout from "./components/pages/RootLayout";
 import NotFound from "./components/pages/not-found";
 
 export const Router = () => {
-  const enabledApps = getEnabledApplications();
+  const apps = getAllApplications();
 
   return (
     <Routes>
@@ -17,7 +17,7 @@ export const Router = () => {
         <Route path="activity" element={<Activity />} />
         <Route path="deposit" element={<Deposit />} />
 
-        {enabledApps.map((app) => (
+        {apps.map((app) => (
           <Route
             key={app.metadata.id}
             path={`app/${app.metadata.id}/*`}


### PR DESCRIPTION
`NEXT_PUBLIC_ENABLED_APPS` is no longer used, it can be removed from the codebase