### PR TITLE
fix(vault): stop polling mismatched vaults and reduce console error spam

### DIFF
--- a/services/vault/src/hooks/useUTXOs.ts
+++ b/services/vault/src/hooks/useUTXOs.ts
@@ -16,7 +16,7 @@ import {
   type UTXO,
 } from "@babylonlabs-io/wallet-connector";
 import { useQuery } from "@tanstack/react-query";
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 
 import { getMempoolApiUrl } from "../clients/btc/config";
 import { useAppState } from "../state/AppState";
@@ -102,6 +102,16 @@ export function useUTXOs(
     enabled: !isLoading && confirmedUTXOs.length > 0,
   });
 
+  // Log ordinals API errors once when the error changes (not on every render)
+  useEffect(() => {
+    if (ordinalsError) {
+      console.warn(
+        "Ordinals API failed, treating all UTXOs as available:",
+        ordinalsError,
+      );
+    }
+  }, [ordinalsError]);
+
   // Filter UTXOs by inscriptions
   // Rename to match exported API naming convention (uppercase UTXO)
   // If ordinals API fails or is still loading, treat all UTXOs as available (non-blocking)
@@ -113,12 +123,6 @@ export function useUTXOs(
     // If ordinals API failed or still loading, treat all UTXOs as available
     // Ordinals check is optional - we don't block on it
     if (ordinalsError || isLoadingOrdinals) {
-      if (ordinalsError) {
-        console.warn(
-          "Ordinals API failed, treating all UTXOs as available:",
-          ordinalsError,
-        );
-      }
       return {
         availableUTXOs: confirmedUtxosForOrdinals,
         inscriptionUTXOs: [],

--- a/services/vault/src/utils/__tests__/peginPolling.test.ts
+++ b/services/vault/src/utils/__tests__/peginPolling.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Tests for pegin polling utilities
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  isTerminalPollingError,
+  isTransientPollingError,
+} from "../peginPolling";
+
+describe("isTransientPollingError", () => {
+  it("should return true for 'PegIn not found'", () => {
+    expect(isTransientPollingError(new Error("PegIn not found"))).toBe(true);
+  });
+
+  it("should return true for 'No transaction graphs found'", () => {
+    expect(
+      isTransientPollingError(new Error("No transaction graphs found")),
+    ).toBe(true);
+  });
+
+  it("should return true for 'Vault or pegin transaction not found'", () => {
+    expect(
+      isTransientPollingError(
+        new Error("Vault or pegin transaction not found"),
+      ),
+    ).toBe(true);
+  });
+
+  it("should return false for non-transient errors", () => {
+    expect(isTransientPollingError(new Error("Unauthorized depositor"))).toBe(
+      false,
+    );
+    expect(isTransientPollingError(new Error("Network error"))).toBe(false);
+  });
+
+  it("should return false for non-Error values", () => {
+    expect(isTransientPollingError("string error")).toBe(false);
+    expect(isTransientPollingError(null)).toBe(false);
+    expect(isTransientPollingError(undefined)).toBe(false);
+  });
+});
+
+describe("isTerminalPollingError", () => {
+  it("should return true for 'Unauthorized depositor'", () => {
+    expect(isTerminalPollingError(new Error("Unauthorized depositor"))).toBe(
+      true,
+    );
+  });
+
+  it("should return true when message contains the pattern", () => {
+    expect(
+      isTerminalPollingError(
+        new Error(
+          "Unauthorized depositor: Depositor public key does not match payout receiver for claimer",
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("should return false for transient errors", () => {
+    expect(isTerminalPollingError(new Error("PegIn not found"))).toBe(false);
+    expect(
+      isTerminalPollingError(new Error("No transaction graphs found")),
+    ).toBe(false);
+  });
+
+  it("should return false for generic errors", () => {
+    expect(isTerminalPollingError(new Error("Network error"))).toBe(false);
+    expect(isTerminalPollingError(new Error("Provider unreachable"))).toBe(
+      false,
+    );
+  });
+
+  it("should return false for non-Error values", () => {
+    expect(isTerminalPollingError("string error")).toBe(false);
+    expect(isTerminalPollingError(null)).toBe(false);
+    expect(isTerminalPollingError(undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
- Skip peg-in polling for vaults not owned by the connected BTC wallet, avoiding unnecessary RPC calls to vault providers that would always fail with "Unauthorized depositor"
- Stop polling entirely when a terminal error (e.g., wallet mismatch) is encountered, instead of retrying indefinitely
- Move ordinals API error logging from useMemo to useEffect so the warning logs once per error instead of on every React re-render