### PR TITLE
fix(vault): prevent Sign buttons flickering when signing a deposit

### DIFF
--- a/services/vault/src/hooks/deposit/usePeginPollingQuery.ts
+++ b/services/vault/src/hooks/deposit/usePeginPollingQuery.ts
@@ -5,7 +5,7 @@
  * transactions from all vault providers in parallel.
  */
 
-import { useQuery } from "@tanstack/react-query";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { useEffect, useMemo, useRef } from "react";
 
 import { VaultProviderRpcApi } from "../../clients/vault-provider-rpc";
@@ -209,6 +209,7 @@ export function usePeginPollingQuery({
     },
     retry: POLLING_RETRY_COUNT,
     retryDelay: POLLING_RETRY_DELAY_MS,
+    placeholderData: keepPreviousData,
   });
 
   // Trigger immediate fetch when query becomes enabled


### PR DESCRIPTION
- When multiple deposits are pending signing, clicking Sign on one causes the other deposits' Sign buttons to disappear for 1-2 seconds before reappearing
- Root cause: the React Query key in usePeginPollingQuery includes deposit IDs — when a signed deposit drops from the list, the key changes, causing a cache miss where data becomes undefined and isLoading flips to true
- Fix: add placeholderData: keepPreviousData so React Query serves the previous query's data while the new key fetches, keeping isLoading false and retaining transaction data for the remaining deposits