### PR TITLE
fix(vault): should also mark pending vault as invaild if UTXO spent

### DIFF
--- a/services/vault/src/hooks/deposit/__tests__/useUtxoValidation.test.ts
+++ b/services/vault/src/hooks/deposit/__tests__/useUtxoValidation.test.ts
@@ -138,7 +138,7 @@ describe("useUtxoValidation", () => {
   });
 
   describe("filtering deposits", () => {
-    it("should only check VERIFIED deposits", () => {
+    it("should check PENDING and VERIFIED deposits but not ACTIVE or later", () => {
       const activities = [
         createActivity(
           "pending",
@@ -174,8 +174,8 @@ describe("useUtxoValidation", () => {
         }),
       );
 
-      // Only VERIFIED should be checked and marked unavailable
-      expect(result.current.unavailableUtxos.has("pending")).toBe(false);
+      // PENDING and VERIFIED should be checked and marked unavailable
+      expect(result.current.unavailableUtxos.has("pending")).toBe(true);
       expect(result.current.unavailableUtxos.has("verified")).toBe(true);
       expect(result.current.unavailableUtxos.has("active")).toBe(false);
       expect(result.current.unavailableUtxos.has("redeemed")).toBe(false);


### PR DESCRIPTION
- UTXO validation (useUtxoValidation) only checked VERIFIED deposits for spent UTXOs, missing deposits still in PENDING status
- When two peg-ins share a UTXO and one is broadcast, the other would continue showing normal progress (Pending → Signing Required → Processing) until it reached VERIFIED — only then would it flip to "Invalid"
- Expanded the filter to include both PENDING and VERIFIED deposits so conflicts are detected as soon as the UTXO disappears from the wallet