### PR TITLE
fix(vault): btc tx fee estimation should be displayed during pegIn cr…

### DIFF
--- a/services/vault/src/components/simple/DepositForm.tsx
+++ b/services/vault/src/components/simple/DepositForm.tsx
@@ -4,6 +4,7 @@ import { useMemo } from "react";
 import { ApplicationLogo } from "@/components/ApplicationLogo";
 import { DepositButton } from "@/components/shared";
 import { getNetworkConfigBTC } from "@/config";
+import { useBtcFeeDisplay } from "@/hooks/deposit/useBtcFeeDisplay";
 import { depositService } from "@/services/deposit";
 
 const btcConfig = getNetworkConfigBTC();
@@ -36,6 +37,10 @@ interface DepositFormProps {
   onProviderSelect: (providerId: string) => void;
 
   isValid: boolean;
+  estimatedFeeSats: bigint | null;
+  estimatedFeeRate: number;
+  isLoadingFee: boolean;
+  feeError: string | null;
   isDepositEnabled: boolean;
   isGeoBlocked: boolean;
   onDeposit: () => void;
@@ -55,6 +60,10 @@ export function DepositForm({
   selectedProvider,
   onProviderSelect,
   isValid,
+  estimatedFeeSats,
+  estimatedFeeRate,
+  isLoadingFee,
+  feeError,
   isDepositEnabled,
   isGeoBlocked,
   onDeposit,
@@ -84,18 +93,30 @@ export function DepositForm({
     label: p.name,
   }));
 
-  const fees = useMemo(() => {
-    // TODO: wire to real fee calculation hooks
-    return [
-      { label: "Bitcoin Network Fee", amount: "0 BTC", price: "($0 USD)" },
-      { label: "Ethereum Network Fee", amount: "0 ETH", price: "($0 USD)" },
-      { label: "Protocol Fee", amount: "0 BTC", price: "($0 USD)" },
-    ];
-  }, []);
+  const {
+    btcFee,
+    feeAmount,
+    feePrice,
+    isError: isFeeError,
+  } = useBtcFeeDisplay({
+    estimatedFeeSats,
+    btcPrice,
+    hasPriceFetchError,
+    isLoadingFee,
+    feeError,
+    hasAmount: !!amount && amount !== "0",
+  });
 
-  const ctaLabel = !amount || amount === "0" ? "Enter an amount" : "Deposit";
+  const hasAmount = !!amount && amount !== "0";
+  const feeDisabled = isLoadingFee || estimatedFeeRate <= 0 || btcFee === null;
+
+  const ctaLabel = !hasAmount
+    ? "Enter an amount"
+    : isFeeError
+      ? (feeError ?? "Fee estimate unavailable")
+      : "Deposit";
   const ctaDisabled =
-    !isValid || !isDepositEnabled || isGeoBlocked || !amount || amount === "0";
+    !isValid || !isDepositEnabled || isGeoBlocked || !hasAmount || feeDisabled;
 
   return (
     <div className="flex w-full flex-col gap-4">
@@ -163,19 +184,16 @@ export function DepositForm({
       </DepositButton>
 
       {/* Fee breakdown */}
-      <div className="flex flex-col gap-4">
-        {fees.map((fee) => (
-          <div
-            key={fee.label}
-            className="flex items-center justify-between text-sm"
+      <div className="flex items-center justify-between text-sm">
+        <span className="text-accent-primary">Bitcoin Network Fee</span>
+        <span>
+          <span
+            className={isFeeError ? "text-error-main" : "text-accent-primary"}
           >
-            <span className="text-accent-primary">{fee.label}</span>
-            <span>
-              <span className="text-accent-primary">{fee.amount}</span>{" "}
-              <span className="text-accent-secondary">{fee.price}</span>
-            </span>
-          </div>
-        ))}
+            {feeAmount}
+          </span>{" "}
+          <span className="text-accent-secondary">{feePrice}</span>
+        </span>
       </div>
     </div>
   );

--- a/services/vault/src/hooks/deposit/useBtcFeeDisplay.ts
+++ b/services/vault/src/hooks/deposit/useBtcFeeDisplay.ts
@@ -1,0 +1,102 @@
+import { useMemo } from "react";
+
+import { satoshiToBtcNumber } from "@/utils/btcConversion";
+
+export interface BtcFeeDisplay {
+  /** BTC fee as a number (for calculations), or null if unavailable */
+  btcFee: number | null;
+  /** USD equivalent of the fee, or null if price unavailable */
+  btcFeeUsd: number | null;
+  /** Formatted string for the fee amount column */
+  feeAmount: string;
+  /** Formatted string for the fee USD column */
+  feePrice: string;
+  /** Whether the display is in an error state */
+  isError: boolean;
+}
+
+/**
+ * Formats estimated BTC fee data into display-ready values.
+ *
+ * Follows the same computation pattern as useDepositReviewData in the old flow:
+ * satoshiToBtcNumber for BTC conversion, simple multiplication for USD.
+ */
+export function useBtcFeeDisplay(params: {
+  estimatedFeeSats: bigint | null;
+  btcPrice: number;
+  hasPriceFetchError: boolean;
+  isLoadingFee: boolean;
+  feeError: string | null;
+  hasAmount: boolean;
+}): BtcFeeDisplay {
+  const {
+    estimatedFeeSats,
+    btcPrice,
+    hasPriceFetchError,
+    isLoadingFee,
+    feeError,
+    hasAmount,
+  } = params;
+
+  const { btcFee, btcFeeUsd } = useMemo(() => {
+    if (estimatedFeeSats === null) return { btcFee: null, btcFeeUsd: null };
+    const fee = satoshiToBtcNumber(estimatedFeeSats);
+    const hasPrice = !hasPriceFetchError && btcPrice > 0;
+    return { btcFee: fee, btcFeeUsd: hasPrice ? fee * btcPrice : null };
+  }, [estimatedFeeSats, btcPrice, hasPriceFetchError]);
+
+  return useMemo(() => {
+    if (!hasAmount) {
+      return {
+        btcFee: null,
+        btcFeeUsd: null,
+        feeAmount: "-- BTC",
+        feePrice: "",
+        isError: false,
+      };
+    }
+    if (isLoadingFee) {
+      return {
+        btcFee: null,
+        btcFeeUsd: null,
+        feeAmount: "Estimating...",
+        feePrice: "",
+        isError: false,
+      };
+    }
+    if (feeError) {
+      return {
+        btcFee: null,
+        btcFeeUsd: null,
+        feeAmount: feeError,
+        feePrice: "",
+        isError: true,
+      };
+    }
+    if (btcFee === null) {
+      return {
+        btcFee: null,
+        btcFeeUsd: null,
+        feeAmount: "-- BTC",
+        feePrice: "",
+        isError: false,
+      };
+    }
+
+    const feePrice =
+      btcFeeUsd !== null
+        ? `($${btcFeeUsd.toLocaleString("en-US", {
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2,
+          })} USD)`
+        : "";
+
+    return {
+      btcFee,
+      btcFeeUsd,
+      feeAmount: `${btcFee.toFixed(8)} BTC`,
+      feePrice,
+      isError: false,
+    };
+  }, [hasAmount, isLoadingFee, feeError, btcFee, btcFeeUsd]);
+}


### PR DESCRIPTION
- Replace hardcoded "0 BTC ($0 USD)" fee display and static 10 sat/vB fee rate in the SimpleDeposit form with real values from mempool.space via the existing `useEstimatedBtcFee` hook
- Disable the Deposit button and show the error on the button label when fee estimation fails (e.g. insufficient funds)
- Extract fee display formatting into a `useBtcFeeDisplay` hook, matching the pattern used by the old deposit flow's `useDepositReviewData`