### PR TITLE
feat(vault): show vp name and address

### DIFF
--- a/services/vault/src/applications/aave/components/Overview/components/VaultsTable/VaultsTable.tsx
+++ b/services/vault/src/applications/aave/components/Overview/components/VaultsTable/VaultsTable.tsx
@@ -104,7 +104,16 @@ export function VaultsTable({ vaults, onRedeem, onDeposit }: VaultsTableProps) {
       headerClassName: "w-[20%]",
       cellClassName: "w-[20%]",
       render: (_value, row) => (
-        <Avatar url={row.provider.icon} alt={row.provider.name} size="small" />
+        <div className="flex items-center gap-2">
+          <Avatar
+            url={row.provider.icon}
+            alt={row.provider.name}
+            size="small"
+          />
+          <span className="text-sm text-accent-primary">
+            {row.provider.name}
+          </span>
+        </div>
       ),
     },
     {

--- a/services/vault/src/applications/aave/hooks/useAaveVaults.ts
+++ b/services/vault/src/applications/aave/hooks/useAaveVaults.ts
@@ -19,6 +19,7 @@ import {
 } from "@/models/peginStateMachine";
 import type { Vault, VaultProvider } from "@/types";
 import { satoshiToBtcNumber } from "@/utils/btcConversion";
+import { formatProviderDisplayName } from "@/utils/formatting";
 
 import type { VaultData } from "../components/Overview/components/VaultsTable";
 import { usePendingVaults } from "../context";
@@ -37,10 +38,10 @@ function transformVaultToTableData(
 
   const peginState = getPeginState(vault.status, { isInUse: vault.isInUse });
 
-  // Use provider name if available, otherwise truncate the address
-  const providerName =
-    provider?.name ??
-    `${vault.vaultProvider.slice(0, 6)}...${vault.vaultProvider.slice(-4)}`;
+  const providerName = formatProviderDisplayName(
+    provider?.name,
+    vault.vaultProvider,
+  );
 
   return {
     id: vault.id,

--- a/services/vault/src/components/pages/Deposit/SelectVaultProviderSection.tsx
+++ b/services/vault/src/components/pages/Deposit/SelectVaultProviderSection.tsx
@@ -10,6 +10,8 @@ import {
 import { useState } from "react";
 import { AiOutlinePlus } from "react-icons/ai";
 
+import { formatProviderDisplayName } from "@/utils/formatting";
+
 import {
   SelectVaultProviderModal,
   type Provider,
@@ -84,7 +86,14 @@ export function SelectVaultProviderSection({
                   size="medium"
                 />
               )}
-              <span>{selectedProviderData?.name || "Add Vault Provider"}</span>
+              <span>
+                {selectedProviderData
+                  ? formatProviderDisplayName(
+                      selectedProviderData.name,
+                      selectedProviderData.id,
+                    )
+                  : "Add Vault Provider"}
+              </span>
             </div>
             <div className="flex h-8 w-8 items-center justify-center text-black dark:text-white">
               {selectedProviderData ? (

--- a/services/vault/src/hooks/deposit/__tests__/useDepositPageForm.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useDepositPageForm.test.tsx
@@ -222,7 +222,9 @@ vi.mock("../useAllocationPlanning", () => ({
 }));
 
 vi.mock("../../../utils/formatting", () => ({
-  formatProviderName: vi.fn((id: string) => `Provider ${id.slice(0, 6)}...`),
+  formatProviderDisplayName: vi.fn(
+    (name: string | undefined, id: string) => name || `${id.slice(0, 6)}...`,
+  ),
 }));
 
 vi.mock("../../../services/deposit", () => ({

--- a/services/vault/src/hooks/deposit/useDepositPageForm.ts
+++ b/services/vault/src/hooks/deposit/useDepositPageForm.ts
@@ -8,7 +8,7 @@ import { computeDepositorClaimValue } from "@/utils/depositorClaimValue";
 import { useProtocolParamsContext } from "../../context/ProtocolParamsContext";
 import { useBTCWallet, useConnection } from "../../context/wallet";
 import { depositService } from "../../services/deposit";
-import { formatProviderName } from "../../utils/formatting";
+import { formatProviderDisplayName } from "../../utils/formatting";
 import { useApplications } from "../useApplications";
 import { usePrice, usePrices } from "../usePrices";
 import { calculateBalance, useUTXOs } from "../useUTXOs";
@@ -133,7 +133,7 @@ export function useDepositPageForm(): UseDepositPageFormResult {
   const providers = useMemo(() => {
     return rawProviders.map((p) => ({
       id: p.id,
-      name: p.name ?? formatProviderName(p.id),
+      name: formatProviderDisplayName(p.name, p.id),
       btcPubkey: p.btcPubKey || "",
       iconUrl: p.iconUrl,
     }));

--- a/services/vault/src/utils/__tests__/formatting.test.ts
+++ b/services/vault/src/utils/__tests__/formatting.test.ts
@@ -10,7 +10,7 @@ import {
   formatBtcAmount,
   formatDateTime,
   formatLLTV,
-  formatProviderName,
+  formatProviderDisplayName,
   formatTimeAgo,
   formatUsdValue,
 } from "../formatting";
@@ -113,15 +113,41 @@ describe("Formatting Utilities", () => {
     });
   });
 
-  describe("formatProviderName", () => {
-    it("should truncate provider ID with ellipsis", () => {
-      const providerId = "0x1234567890abcdef1234567890abcdef12345678";
-      expect(formatProviderName(providerId)).toBe("Provider 0x1234...5678");
+  describe("formatProviderDisplayName", () => {
+    const longAddress = "0x1234567890abcdef1234567890abcdef12345678";
+
+    it("should return real name when provider has a meaningful name", () => {
+      expect(formatProviderDisplayName("Lombard", longAddress)).toBe("Lombard");
     });
 
-    it("should handle short provider IDs", () => {
-      const providerId = "0x12345678";
-      expect(formatProviderName(providerId)).toBe("Provider 0x1234...5678");
+    it("should append truncated address when includeAddress is true", () => {
+      expect(
+        formatProviderDisplayName("Lombard", longAddress, {
+          includeAddress: true,
+        }),
+      ).toBe("Lombard (0x1234...5678)");
+    });
+
+    it("should return address-based name as-is when name starts with 0x", () => {
+      expect(formatProviderDisplayName("0xabc123", longAddress)).toBe(
+        "0xabc123",
+      );
+    });
+
+    it("should return name as-is when it starts with 'Provider '", () => {
+      expect(
+        formatProviderDisplayName("Provider 0x1234...5678", longAddress),
+      ).toBe("Provider 0x1234...5678");
+    });
+
+    it("should fall back to truncated address when name is undefined", () => {
+      expect(formatProviderDisplayName(undefined, longAddress)).toBe(
+        "0x1234...5678",
+      );
+    });
+
+    it("should fall back to truncated address when name is empty string", () => {
+      expect(formatProviderDisplayName("", longAddress)).toBe("0x1234...5678");
     });
   });
 

--- a/services/vault/src/utils/formatting.ts
+++ b/services/vault/src/utils/formatting.ts
@@ -3,6 +3,7 @@
  */
 
 import { getNetworkConfigBTC } from "@/config";
+import { truncateAddress } from "@/utils/addressUtils";
 
 const btcConfig = getNetworkConfigBTC();
 
@@ -17,12 +18,27 @@ export function formatLLTV(lltv: string | bigint): string {
 }
 
 /**
- * Format provider ID for display by truncating the middle
- * @param providerId - The full provider ID string
- * @returns Formatted provider name (e.g., "Provider 0x1234...5678")
+ * Format a provider's display name for UI.
+ * Determines if the provider has a "real" name (not address-based) and formats accordingly.
+ *
+ * @param name - The provider's name (may be undefined or address-based like "0x..." or "Provider 0x...")
+ * @param id - The provider's ID (used for address fallback)
+ * @param options.includeAddress - If true, appends truncated address for real names (e.g., "Lombard (0x1234...5678)")
+ * @returns Formatted display name
  */
-export function formatProviderName(providerId: string): string {
-  return `Provider ${providerId.slice(0, 6)}...${providerId.slice(-4)}`;
+export function formatProviderDisplayName(
+  name: string | undefined,
+  id: string,
+  options?: { includeAddress?: boolean },
+): string {
+  const isRealName =
+    name && !name.startsWith("0x") && !name.startsWith("Provider ");
+
+  if (isRealName) {
+    return options?.includeAddress ? `${name} (${truncateAddress(id)})` : name;
+  }
+
+  return name || truncateAddress(id);
 }
 
 /**


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI-only change that centralizes vault provider name/address formatting; main risk is minor regressions in how provider identifiers are rendered across deposit and Aave vault views.
> 
> **Overview**
> **Vault provider labels are now rendered more clearly and consistently across the UI.** The Aave vaults table now shows the provider avatar *and* name, and provider names used in the Aave vault list and deposit provider selection are now derived via a shared `formatProviderDisplayName` helper (with address-based fallbacks).
> 
> Adds `formatProviderDisplayName` to `utils/formatting` (using `truncateAddress`) and updates/extends unit tests and mocks to cover the new formatting behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 63f9566398800262a54ee73a786c147b87c1c814. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->