### PR TITLE
fix(vault): show tooltip message for invalid vaults on hover

### DIFF
--- a/services/vault/src/components/deposit/DepositOverview/DepositTableCells.tsx
+++ b/services/vault/src/components/deposit/DepositOverview/DepositTableCells.tsx
@@ -5,7 +5,7 @@
  * These use the centralized polling context for state.
  */
 
-import { Hint, StatusBadge } from "@babylonlabs-io/core-ui";
+import { StatusBadge } from "@babylonlabs-io/core-ui";
 import { useState } from "react";
 
 import { useDepositPollingResult } from "../../../context/deposit/PeginPollingContext";
@@ -61,12 +61,12 @@ export function StatusCell({ depositId }: { depositId: string }) {
   const { peginState } = pollingResult;
 
   return (
-    <Hint tooltip={peginState.message} attachToChildren>
+    <span title={peginState.message}>
       <StatusBadge
         status={peginState.displayVariant}
         label={peginState.displayLabel}
       />
-    </Hint>
+    </span>
   );
 }
 

--- a/services/vault/src/components/simple/PendingDepositCard.tsx
+++ b/services/vault/src/components/simple/PendingDepositCard.tsx
@@ -8,7 +8,7 @@
  * Must be rendered inside a PeginPollingProvider.
  */
 
-import { Avatar, Button, Card } from "@babylonlabs-io/core-ui";
+import { Avatar, Button, Card, Hint } from "@babylonlabs-io/core-ui";
 
 import {
   getActionStatus,
@@ -56,6 +56,18 @@ export function PendingDepositCard({
     }
   };
 
+  const button = (
+    <Button
+      variant="contained"
+      size="small"
+      className="rounded-full !bg-white !text-black hover:!bg-gray-100"
+      disabled={!isActionable || (loading && !transactions)}
+      onClick={handleClick}
+    >
+      {loading && !transactions ? "Loading..." : displayLabel}
+    </Button>
+  );
+
   return (
     <Card
       variant="filled"
@@ -74,15 +86,13 @@ export function PendingDepositCard({
           </span>
         </div>
 
-        <Button
-          variant="contained"
-          size="small"
-          className="rounded-full !bg-white !text-black hover:!bg-gray-100"
-          disabled={!isActionable || (loading && !transactions)}
-          onClick={handleClick}
-        >
-          {loading && !transactions ? "Loading..." : displayLabel}
-        </Button>
+        {peginState.message ? (
+          <Hint tooltip={peginState.message} attachToChildren>
+            {button}
+          </Hint>
+        ) : (
+          button
+        )}
       </div>
     </Card>
   );


### PR DESCRIPTION
Show explanatory message when users hover over invalid vault status, so they understand why a vault was marked invalid (UTXO spent in a different transaction)

<img width="961" height="376" alt="image" src="https://github.com/user-attachments/assets/b9158101-67e3-4a30-8416-4ec98800891a" />
