### PR TITLE
chore(vault): show do not spent utxo warning during pegIn

### DIFF
--- a/services/vault/src/components/simple/DepositProgressView.tsx
+++ b/services/vault/src/components/simple/DepositProgressView.tsx
@@ -151,6 +151,14 @@ export function DepositProgressView({
             "Sign"
           )}
         </Button>
+
+        <Text
+          variant="body2"
+          className="text-center text-xs text-accent-secondary"
+        >
+          Do not spend the Bitcoin used for this deposit until the transaction
+          is confirmed on the network.
+        </Text>
       </div>
     </div>
   );


### PR DESCRIPTION
Please ignore the error panel.

see the message at the bottom of the modal

<img width="560" height="600" alt="image" src="https://github.com/user-attachments/assets/682fb97c-783b-4c0a-8ade-f0128d6d9f87" />
