### PR TITLE
fix(vault): pass down the btc PK for signInputs

### DIFF
--- a/services/vault/src/services/vault/__tests__/depositorGraphSigningService.test.ts
+++ b/services/vault/src/services/vault/__tests__/depositorGraphSigningService.test.ts
@@ -28,6 +28,7 @@ const VK_PUBKEY =
   "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
 const CHALLENGER_PUBKEY_1 =
   "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const WALLET_COMPRESSED_PUBKEY = "02" + DEPOSITOR_PUBKEY; // 66-char compressed pubkey
 
 function createMockDepositorGraph(
   numChallengers = 1,
@@ -93,6 +94,7 @@ function createMockParams(
     btcWallet: {
       signPsbts: vi.fn(),
       signPsbt: vi.fn(),
+      getPublicKeyHex: vi.fn().mockResolvedValue(WALLET_COMPRESSED_PUBKEY),
     } as any,
     offchainParams: {
       vaultProviderBtcPubkey: VP_PUBKEY,
@@ -134,27 +136,51 @@ describe("depositorGraphSigningService", () => {
       // 1 ChallengeAssert PSBT per challenger (not 3)
       expect(buildChallengeAssertPsbt).toHaveBeenCalledTimes(1);
 
-      // Batch sign should be called with 3 PSBTs and sign options
+      // Batch sign should be called with 3 PSBTs and sign options (including publicKey)
       expect(wallet.signPsbts).toHaveBeenCalledWith(
         ["psbt_payout_hex", "psbt_nopayout_hex", "psbt_ca_hex"],
         [
           // Payout: sign input 0
           {
             autoFinalized: false,
-            signInputs: [{ index: 0, disableTweakSigner: true }],
+            signInputs: [
+              {
+                index: 0,
+                publicKey: WALLET_COMPRESSED_PUBKEY,
+                disableTweakSigner: true,
+              },
+            ],
           },
           // NoPayout: sign input 0
           {
             autoFinalized: false,
-            signInputs: [{ index: 0, disableTweakSigner: true }],
+            signInputs: [
+              {
+                index: 0,
+                publicKey: WALLET_COMPRESSED_PUBKEY,
+                disableTweakSigner: true,
+              },
+            ],
           },
           // ChallengeAssert: sign inputs 0, 1, 2
           {
             autoFinalized: false,
             signInputs: [
-              { index: 0, disableTweakSigner: true },
-              { index: 1, disableTweakSigner: true },
-              { index: 2, disableTweakSigner: true },
+              {
+                index: 0,
+                publicKey: WALLET_COMPRESSED_PUBKEY,
+                disableTweakSigner: true,
+              },
+              {
+                index: 1,
+                publicKey: WALLET_COMPRESSED_PUBKEY,
+                disableTweakSigner: true,
+              },
+              {
+                index: 2,
+                publicKey: WALLET_COMPRESSED_PUBKEY,
+                disableTweakSigner: true,
+              },
             ],
           },
         ],
@@ -223,14 +249,32 @@ describe("depositorGraphSigningService", () => {
       expect(wallet.signPsbt).toHaveBeenCalledTimes(3);
       expect(wallet.signPsbt).toHaveBeenCalledWith("psbt_payout_hex", {
         autoFinalized: false,
-        signInputs: [{ index: 0, disableTweakSigner: true }],
+        signInputs: [
+          {
+            index: 0,
+            publicKey: WALLET_COMPRESSED_PUBKEY,
+            disableTweakSigner: true,
+          },
+        ],
       });
       expect(wallet.signPsbt).toHaveBeenCalledWith("psbt_ca_hex", {
         autoFinalized: false,
         signInputs: [
-          { index: 0, disableTweakSigner: true },
-          { index: 1, disableTweakSigner: true },
-          { index: 2, disableTweakSigner: true },
+          {
+            index: 0,
+            publicKey: WALLET_COMPRESSED_PUBKEY,
+            disableTweakSigner: true,
+          },
+          {
+            index: 1,
+            publicKey: WALLET_COMPRESSED_PUBKEY,
+            disableTweakSigner: true,
+          },
+          {
+            index: 2,
+            publicKey: WALLET_COMPRESSED_PUBKEY,
+            disableTweakSigner: true,
+          },
         ],
       });
     });
@@ -411,7 +455,13 @@ describe("depositorGraphSigningService", () => {
         [
           {
             autoFinalized: false,
-            signInputs: [{ index: 0, disableTweakSigner: true }],
+            signInputs: [
+              {
+                index: 0,
+                publicKey: WALLET_COMPRESSED_PUBKEY,
+                disableTweakSigner: true,
+              },
+            ],
           },
         ],
       );

--- a/services/vault/src/services/vault/depositorGraphSigningService.ts
+++ b/services/vault/src/services/vault/depositorGraphSigningService.ts
@@ -46,19 +46,24 @@ const NUM_CHALLENGE_ASSERT_INPUTS = 3;
  * Taproot script path sign options — disables tweak signer and prevents
  * auto-finalization so we can extract raw Schnorr signatures from tapScriptSig.
  */
-const TAPROOT_SCRIPT_SIGN_OPTIONS: SignPsbtOptions = {
-  autoFinalized: false,
-  signInputs: [{ index: 0, disableTweakSigner: true }],
-};
+function taprootScriptSignOptions(publicKey: string): SignPsbtOptions {
+  return {
+    autoFinalized: false,
+    signInputs: [{ index: 0, publicKey, disableTweakSigner: true }],
+  };
+}
 
 /** Sign options for ChallengeAssert PSBTs (one entry per input). */
-const CHALLENGE_ASSERT_SIGN_OPTIONS: SignPsbtOptions = {
-  autoFinalized: false,
-  signInputs: Array.from({ length: NUM_CHALLENGE_ASSERT_INPUTS }, (_, i) => ({
-    index: i,
-    disableTweakSigner: true,
-  })),
-};
+function challengeAssertSignOptions(publicKey: string): SignPsbtOptions {
+  return {
+    autoFinalized: false,
+    signInputs: Array.from({ length: NUM_CHALLENGE_ASSERT_INPUTS }, (_, i) => ({
+      index: i,
+      publicKey,
+      disableTweakSigner: true,
+    })),
+  };
+}
 
 /**
  * Offchain parameters needed for depositor graph signing
@@ -148,12 +153,16 @@ function buildChallengeAssertConnectorParams(
 async function buildDepositorGraphPsbts(
   depositorGraph: DepositorGraphTransactions,
   depositorPubkey: string,
+  walletPublicKey: string,
   peginPayoutParams: PayoutConnectorParams,
   assertConnectorParams: AssertPayoutNoPayoutConnectorParams,
 ): Promise<BuiltDepositorGraphPsbts> {
   const psbtHexes: string[] = [];
   const signOptions: SignPsbtOptions[] = [];
   const challengerIndexMap: ChallengerIndexEntry[] = [];
+
+  const taprootOpts = taprootScriptSignOptions(walletPublicKey);
+  const challengeAssertOpts = challengeAssertSignOptions(walletPublicKey);
 
   // Index 0: Payout PSBT (uses PeginPayoutConnector — same as VP/VK payout)
   try {
@@ -163,7 +172,7 @@ async function buildDepositorGraphPsbts(
       connectorParams: peginPayoutParams,
     });
     psbtHexes.push(payoutPsbt);
-    signOptions.push(TAPROOT_SCRIPT_SIGN_OPTIONS);
+    signOptions.push(taprootOpts);
   } catch (err) {
     throw new Error(
       `Failed to build depositor Payout PSBT: ${err instanceof Error ? err.message : String(err)}`,
@@ -194,7 +203,7 @@ async function buildDepositorGraphPsbts(
         connectorParams: assertConnectorParams,
       });
       psbtHexes.push(noPayoutPsbt);
-      signOptions.push(TAPROOT_SCRIPT_SIGN_OPTIONS);
+      signOptions.push(taprootOpts);
     } catch (err) {
       throw new Error(
         `Failed to build NoPayout PSBT for challenger ${challengerPubkey}: ${err instanceof Error ? err.message : String(err)}`,
@@ -216,7 +225,7 @@ async function buildDepositorGraphPsbts(
         connectorParamsPerInput,
       });
       psbtHexes.push(caPsbt);
-      signOptions.push(CHALLENGE_ASSERT_SIGN_OPTIONS);
+      signOptions.push(challengeAssertOpts);
     } catch (err) {
       throw new Error(
         `Failed to build ChallengeAssert PSBT for challenger ${challengerPubkey}: ${err instanceof Error ? err.message : String(err)}`,
@@ -374,6 +383,9 @@ export async function signDepositorGraph(
 
   const depositorPubkey = stripHexPrefix(depositorBtcPubkey);
 
+  // Get the wallet's compressed public key for signInputs identification
+  const walletPublicKey = await btcWallet.getPublicKeyHex();
+
   // Build connector params
   const peginPayoutParams: PayoutConnectorParams = {
     depositor: depositorPubkey,
@@ -397,6 +409,7 @@ export async function signDepositorGraph(
     await buildDepositorGraphPsbts(
       depositorGraph,
       depositorPubkey,
+      walletPublicKey,
       peginPayoutParams,
       assertConnectorParams,
     );
@@ -412,7 +425,7 @@ export async function signDepositorGraph(
     );
   } catch (err) {
     throw new Error(
-      `Failed to sign depositor graph transactions: ${err instanceof Error ? err.message : String(err)}`,
+      `Failed to sign depositor graph transactions: ${err instanceof Error ? err.message : JSON.stringify(err)}`,
     );
   }
 


### PR DESCRIPTION
This fixes the issue where wallet sign inputs not knowing which private key to use for signing multiple psbts.