### PR TITLE
feat: verified provider UI

### DIFF
--- a/packages/babylon-tbv-registry/README.md
+++ b/packages/babylon-tbv-registry/README.md
@@ -1,0 +1,55 @@
+# @babylonlabs-io/tbv-registry
+
+Client-side registry of verified vault providers for the Babylon TBV frontend.
+
+## Purpose
+
+On-chain vault provider metadata (name, RPC URL) is self-reported and cannot be
+trusted for display purposes. This package maintains a curated list of providers
+that have been verified by the Babylon team. The frontend uses this registry to:
+
+- Show a **verified badge** next to trusted provider avatars.
+- Override on-chain display names and RPC URLs with trusted values.
+- Gate provider selection (only verified providers can be selected for deposits).
+
+## Data file
+
+Provider entries live in
+[`src/vault-provider/verified-providers.json`](src/vault-provider/verified-providers.json).
+
+Each entry contains:
+
+| Field     | Type   | Required | Description                                |
+| --------- | ------ | -------- | ------------------------------------------ |
+| `address` | string | yes      | Ethereum address (lowercase, 0x-prefixed)  |
+| `name`    | string | yes      | Trusted display name                       |
+| `rpcUrl`  | string | yes      | Trusted RPC endpoint URL                   |
+| `iconUrl` | string | no       | Trusted icon/logo URL                      |
+
+## Adding or updating a verified provider
+
+1. Open `src/vault-provider/verified-providers.json`.
+2. Add a new entry or update an existing one. Ensure the `address` is
+   **lowercase** and **0x-prefixed**.
+3. Open a PR with the change. The PR description should include:
+   - The provider's on-chain registration transaction or address.
+   - Confirmation that the RPC URL has been tested and is reachable.
+   - Any relevant due-diligence context (e.g. who operates the provider).
+4. Get approval from at least one maintainer before merging.
+
+## Removing a provider
+
+Delete the entry from `verified-providers.json` and open a PR. The frontend
+will stop showing the verified badge and will fall back to on-chain metadata.
+
+## Usage
+
+```ts
+import { getVerifiedProvider } from "@babylonlabs-io/tbv-registry/vault-provider";
+
+const entry = getVerifiedProvider("0xaf8d9d665f4e27f3966a074dce5c50684bfbe358");
+if (entry) {
+  console.log(entry.name);   // "vault-provider-0"
+  console.log(entry.rpcUrl); // "https://rpc.vault-provider-0.vault-devnet.babylonlabs.io"
+}
+```

--- a/packages/babylon-tbv-registry/package.json
+++ b/packages/babylon-tbv-registry/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@babylonlabs-io/tbv-registry",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    },
+    "./vault-provider": {
+      "types": "./src/vault-provider/index.ts",
+      "default": "./src/vault-provider/index.ts"
+    }
+  },
+  "scripts": {
+    "lint": "eslint",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "^5.8.3"
+  }
+}

--- a/packages/babylon-tbv-registry/src/index.ts
+++ b/packages/babylon-tbv-registry/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./vault-provider";

--- a/packages/babylon-tbv-registry/src/vault-provider/index.ts
+++ b/packages/babylon-tbv-registry/src/vault-provider/index.ts
@@ -1,0 +1,40 @@
+/**
+ * Verified Vault Provider Registry
+ *
+ * A client-side registry of trusted vault providers. The frontend uses this
+ * to determine provider verification status and to override on-chain metadata
+ * (name, RPC URL, icon) with trusted values.
+ *
+ * To add or remove a verified provider, update verified-providers.json.
+ * See the package README.md for contribution guidelines.
+ */
+
+import providers from "./verified-providers.json";
+
+export interface VerifiedProviderEntry {
+  /** Ethereum address (lowercase, 0x-prefixed) */
+  address: string;
+  /** Trusted display name */
+  name: string;
+  /** Trusted RPC URL */
+  rpcUrl: string;
+  /** Optional trusted icon URL */
+  iconUrl?: string;
+}
+
+const VERIFIED_PROVIDERS: VerifiedProviderEntry[] = providers;
+
+/** Case-insensitive lookup map built once at startup */
+const verifiedMap = new Map<string, VerifiedProviderEntry>(
+  VERIFIED_PROVIDERS.map((entry) => [entry.address.toLowerCase(), entry]),
+);
+
+/**
+ * Look up a verified provider by Ethereum address.
+ * Returns undefined if the address is not in the registry.
+ */
+export function getVerifiedProvider(
+  address: string,
+): VerifiedProviderEntry | undefined {
+  return verifiedMap.get(address.toLowerCase());
+}

--- a/packages/babylon-tbv-registry/src/vault-provider/verified-providers.json
+++ b/packages/babylon-tbv-registry/src/vault-provider/verified-providers.json
@@ -1,0 +1,12 @@
+[
+  {
+    "address": "0xaf8d9d665f4e27f3966a074dce5c50684bfbe358",
+    "name": "vault-provider-0",
+    "rpcUrl": "https://rpc.vault-provider-0.vault-devnet.babylonlabs.io"
+  },
+  {
+    "address": "0x967c1c7fd472cbb7300d29d2b63351b5e3f81640",
+    "name": "vault-provider-1",
+    "rpcUrl": "https://rpc.vault-provider-1.vault-devnet.babylonlabs.io"
+  }
+]

--- a/packages/babylon-tbv-registry/tsconfig.json
+++ b/packages/babylon-tbv-registry/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -305,6 +305,12 @@ importers:
         specifier: ^0.23.0
         version: 0.23.0(rollup@4.46.1)(vite@6.4.1(@types/node@22.17.0)(jiti@2.5.1)(terser@5.44.0)(tsx@4.20.3)(yaml@2.8.2))
 
+  packages/babylon-tbv-registry:
+    devDependencies:
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.2
+
   packages/babylon-tbv-rust-wasm:
     devDependencies:
       '@internal/eslint-config':
@@ -415,13 +421,13 @@ importers:
         version: 6.29.10
       '@reown/appkit':
         specifier: 1.8.12
-        version: 1.8.12(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12)
+        version: 1.8.12(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.22.4)
       '@reown/appkit-adapter-bitcoin':
         specifier: 1.8.12
-        version: 1.8.12(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(valtio@2.1.7(@types/react@18.3.23)(react@18.3.1))(zod@4.1.12)
+        version: 1.8.12(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(valtio@2.1.7(@types/react@18.3.23)(react@18.3.1))(zod@3.22.4)
       '@reown/appkit-adapter-wagmi':
         specifier: 1.8.12
-        version: 1.8.12(@tanstack/react-query@5.90.20(react@18.3.1))(@types/react@18.3.23)(@wagmi/core@2.22.1(@tanstack/query-core@5.90.20)(@types/react@18.3.23)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.38.2(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12)))(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@5.0.10)(viem@2.38.2(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12))(wagmi@2.18.1(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.20(react@18.3.1))(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(viem@2.38.2(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12))(zod@4.1.12))(zod@4.1.12)
+        version: 1.8.12(@tanstack/react-query@5.90.20(react@18.3.1))(@types/react@18.3.23)(@wagmi/core@2.22.1(@tanstack/query-core@5.90.20)(@types/react@18.3.23)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.38.2(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.22.4)))(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@5.0.10)(viem@2.38.2(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.22.4))(wagmi@2.18.1(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.20(react@18.3.1))(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(viem@2.38.2(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.22.4))(zod@3.22.4))(zod@3.22.4)
       '@scure/bip32':
         specifier: 1.4.0
         version: 1.4.0
@@ -466,10 +472,10 @@ importers:
         version: 11.1.0
       viem:
         specifier: ^2.38.2
-        version: 2.38.2(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12)
+        version: 2.38.2(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.22.4)
       wagmi:
         specifier: 2.18.1
-        version: 2.18.1(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.20(react@18.3.1))(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(viem@2.38.2(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12))(zod@4.1.12)
+        version: 2.18.1(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.20(react@18.3.1))(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(viem@2.38.2(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.22.4))(zod@3.22.4)
     devDependencies:
       '@changesets/cli':
         specifier: ^2.29.8
@@ -901,6 +907,9 @@ importers:
       '@babylonlabs-io/core-ui':
         specifier: workspace:*
         version: link:../../packages/babylon-core-ui
+      '@babylonlabs-io/tbv-registry':
+        specifier: workspace:*
+        version: link:../../packages/babylon-tbv-registry
       '@babylonlabs-io/ts-sdk':
         specifier: workspace:*
         version: link:../../packages/babylon-ts-sdk
@@ -972,10 +981,10 @@ importers:
         version: 11.1.0
       viem:
         specifier: ^2.38.2
-        version: 2.38.2(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.22.4)
+        version: 2.38.2(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12)
       wagmi:
         specifier: 2.18.1
-        version: 2.18.1(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.20(react@18.3.1))(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(viem@2.38.2(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.22.4))(zod@3.22.4)
+        version: 2.18.1(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.20(react@18.3.1))(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(viem@2.38.2(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12))(zod@4.1.12)
     devDependencies:
       '@babel/core':
         specifier: ^7.24.7
@@ -6643,6 +6652,7 @@ packages:
   git-raw-commits@4.0.0:
     resolution: {integrity: sha512-ICsMM1Wk8xSGMowkOmPrzo2Fgmfo4bMHLNX6ytHjajRJUqvHOw/TFapQ+QG75c3X/tTDDhOSRPGC52dDbNM8FQ==}
     engines: {node: '>=16'}
+    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
     hasBin: true
 
   glob-parent@5.1.2:
@@ -13556,17 +13566,17 @@ snapshots:
 
   '@protobufjs/utf8@1.1.0': {}
 
-  '@reown/appkit-adapter-bitcoin@1.8.12(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(valtio@2.1.7(@types/react@18.3.23)(react@18.3.1))(zod@4.1.12)':
+  '@reown/appkit-adapter-bitcoin@1.8.12(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(valtio@2.1.7(@types/react@18.3.23)(react@18.3.1))(zod@3.22.4)':
     dependencies:
       '@exodus/bitcoin-wallet-standard': 0.0.0
-      '@reown/appkit': 1.8.12(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12)
-      '@reown/appkit-common': 1.8.12(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12)
-      '@reown/appkit-controllers': 1.8.12(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12)
+      '@reown/appkit': 1.8.12(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.22.4)
+      '@reown/appkit-common': 1.8.12(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.22.4)
+      '@reown/appkit-controllers': 1.8.12(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.22.4)
       '@reown/appkit-polyfills': 1.8.12
-      '@reown/appkit-utils': 1.8.12(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(valtio@2.1.7(@types/react@18.3.23)(react@18.3.1))(zod@4.1.12)
+      '@reown/appkit-utils': 1.8.12(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(valtio@2.1.7(@types/react@18.3.23)(react@18.3.1))(zod@3.22.4)
       '@wallet-standard/app': 1.1.0
       '@wallet-standard/base': 1.1.0
-      '@walletconnect/universal-provider': 2.22.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12)
+      '@walletconnect/universal-provider': 2.22.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.22.4)
       bitcoinjs-lib: 6.1.7
       sats-connect: 3.5.0(typescript@5.9.2)
     transitivePeerDependencies:
@@ -13599,22 +13609,22 @@ snapshots:
       - valtio
       - zod
 
-  '@reown/appkit-adapter-wagmi@1.8.12(@tanstack/react-query@5.90.20(react@18.3.1))(@types/react@18.3.23)(@wagmi/core@2.22.1(@tanstack/query-core@5.90.20)(@types/react@18.3.23)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.38.2(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12)))(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@5.0.10)(viem@2.38.2(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12))(wagmi@2.18.1(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.20(react@18.3.1))(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(viem@2.38.2(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12))(zod@4.1.12))(zod@4.1.12)':
+  '@reown/appkit-adapter-wagmi@1.8.12(@tanstack/react-query@5.90.20(react@18.3.1))(@types/react@18.3.23)(@wagmi/core@2.22.1(@tanstack/query-core@5.90.20)(@types/react@18.3.23)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.38.2(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.22.4)))(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@5.0.10)(viem@2.38.2(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.22.4))(wagmi@2.18.1(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.20(react@18.3.1))(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(viem@2.38.2(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.22.4))(zod@3.22.4))(zod@3.22.4)':
     dependencies:
-      '@reown/appkit': 1.8.12(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12)
-      '@reown/appkit-common': 1.8.12(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12)
-      '@reown/appkit-controllers': 1.8.12(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12)
+      '@reown/appkit': 1.8.12(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.22.4)
+      '@reown/appkit-common': 1.8.12(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.22.4)
+      '@reown/appkit-controllers': 1.8.12(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.22.4)
       '@reown/appkit-polyfills': 1.8.12
-      '@reown/appkit-scaffold-ui': 1.8.12(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(valtio@2.1.7(@types/react@18.3.23)(react@18.3.1))(zod@4.1.12)
-      '@reown/appkit-utils': 1.8.12(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(valtio@2.1.7(@types/react@18.3.23)(react@18.3.1))(zod@4.1.12)
+      '@reown/appkit-scaffold-ui': 1.8.12(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(valtio@2.1.7(@types/react@18.3.23)(react@18.3.1))(zod@3.22.4)
+      '@reown/appkit-utils': 1.8.12(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(valtio@2.1.7(@types/react@18.3.23)(react@18.3.1))(zod@3.22.4)
       '@reown/appkit-wallet': 1.8.12(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)
-      '@wagmi/core': 2.22.1(@tanstack/query-core@5.90.20)(@types/react@18.3.23)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.38.2(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12))
-      '@walletconnect/universal-provider': 2.22.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12)
+      '@wagmi/core': 2.22.1(@tanstack/query-core@5.90.20)(@types/react@18.3.23)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.38.2(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.22.4))
+      '@walletconnect/universal-provider': 2.22.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.22.4)
       valtio: 2.1.7(@types/react@18.3.23)(react@18.3.1)
-      viem: 2.38.2(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12)
-      wagmi: 2.18.1(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.20(react@18.3.1))(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(viem@2.38.2(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12))(zod@4.1.12)
+      viem: 2.38.2(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.22.4)
+      wagmi: 2.18.1(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.20(react@18.3.1))(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(viem@2.38.2(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.22.4))(zod@3.22.4)
     optionalDependencies:
-      '@wagmi/connectors': 6.0.1(@tanstack/react-query@5.90.20(react@18.3.1))(@types/react@18.3.23)(@wagmi/core@2.22.1(@tanstack/query-core@5.90.20)(@types/react@18.3.23)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.38.2(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12)))(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@5.0.10)(viem@2.38.2(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12))(wagmi@2.18.1(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.20(react@18.3.1))(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(viem@2.38.2(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12))(zod@4.1.12))(zod@4.1.12)
+      '@wagmi/connectors': 6.0.1(@tanstack/react-query@5.90.20(react@18.3.1))(@types/react@18.3.23)(@wagmi/core@2.22.1(@tanstack/query-core@5.90.20)(@types/react@18.3.23)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.38.2(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.22.4)))(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@5.0.10)(viem@2.38.2(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.22.4))(wagmi@2.18.1(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.20(react@18.3.1))(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(viem@2.38.2(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.22.4))(zod@3.22.4))(zod@3.22.4)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -13674,17 +13684,6 @@ snapshots:
       big.js: 6.2.2
       dayjs: 1.11.13
       viem: 2.38.2(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.22.4)
-    transitivePeerDependencies:
-      - bufferutil
-      - typescript
-      - utf-8-validate
-      - zod
-
-  '@reown/appkit-common@1.8.12(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12)':
-    dependencies:
-      big.js: 6.2.2
-      dayjs: 1.11.13
-      viem: 2.38.2(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -13796,41 +13795,6 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@reown/appkit-controllers@1.8.12(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12)':
-    dependencies:
-      '@reown/appkit-common': 1.8.12(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12)
-      '@reown/appkit-wallet': 1.8.12(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)
-      '@walletconnect/universal-provider': 2.22.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12)
-      valtio: 2.1.7(@types/react@18.3.23)(react@18.3.1)
-      viem: 2.38.2(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12)
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - ioredis
-      - react
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
   '@reown/appkit-pay@1.7.8(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.22.4)':
     dependencies:
       '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.22.4)
@@ -13909,42 +13873,6 @@ snapshots:
       '@reown/appkit-controllers': 1.8.12(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.22.4)
       '@reown/appkit-ui': 1.8.12(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.22.4)
       '@reown/appkit-utils': 1.8.12(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(valtio@2.1.7(@types/react@18.3.23)(react@18.3.1))(zod@3.22.4)
-      lit: 3.3.0
-      valtio: 2.1.7(@types/react@18.3.23)(react@18.3.1)
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - ioredis
-      - react
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
-  '@reown/appkit-pay@1.8.12(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12)':
-    dependencies:
-      '@reown/appkit-common': 1.8.12(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12)
-      '@reown/appkit-controllers': 1.8.12(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12)
-      '@reown/appkit-ui': 1.8.12(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12)
-      '@reown/appkit-utils': 1.8.12(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(valtio@2.1.7(@types/react@18.3.23)(react@18.3.1))(zod@4.1.12)
       lit: 3.3.0
       valtio: 2.1.7(@types/react@18.3.23)(react@18.3.1)
     transitivePeerDependencies:
@@ -14094,43 +14022,6 @@ snapshots:
       - valtio
       - zod
 
-  '@reown/appkit-scaffold-ui@1.8.12(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(valtio@2.1.7(@types/react@18.3.23)(react@18.3.1))(zod@4.1.12)':
-    dependencies:
-      '@reown/appkit-common': 1.8.12(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12)
-      '@reown/appkit-controllers': 1.8.12(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12)
-      '@reown/appkit-ui': 1.8.12(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12)
-      '@reown/appkit-utils': 1.8.12(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(valtio@2.1.7(@types/react@18.3.23)(react@18.3.1))(zod@4.1.12)
-      '@reown/appkit-wallet': 1.8.12(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)
-      lit: 3.3.0
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - ioredis
-      - react
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - valtio
-      - zod
-
   '@reown/appkit-ui@1.7.8(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.22.4)':
     dependencies:
       '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.22.4)
@@ -14206,42 +14097,6 @@ snapshots:
       '@phosphor-icons/webcomponents': 2.1.5
       '@reown/appkit-common': 1.8.12(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.22.4)
       '@reown/appkit-controllers': 1.8.12(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.22.4)
-      '@reown/appkit-wallet': 1.8.12(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)
-      lit: 3.3.0
-      qrcode: 1.5.3
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - ioredis
-      - react
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
-  '@reown/appkit-ui@1.8.12(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12)':
-    dependencies:
-      '@phosphor-icons/webcomponents': 2.1.5
-      '@reown/appkit-common': 1.8.12(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12)
-      '@reown/appkit-controllers': 1.8.12(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12)
       '@reown/appkit-wallet': 1.8.12(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)
       lit: 3.3.0
       qrcode: 1.5.3
@@ -14360,45 +14215,6 @@ snapshots:
       '@walletconnect/universal-provider': 2.22.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.22.4)
       valtio: 2.1.7(@types/react@18.3.23)(react@18.3.1)
       viem: 2.38.2(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.22.4)
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - ioredis
-      - react
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
-  '@reown/appkit-utils@1.8.12(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(valtio@2.1.7(@types/react@18.3.23)(react@18.3.1))(zod@4.1.12)':
-    dependencies:
-      '@reown/appkit-common': 1.8.12(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12)
-      '@reown/appkit-controllers': 1.8.12(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12)
-      '@reown/appkit-polyfills': 1.8.12
-      '@reown/appkit-wallet': 1.8.12(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)
-      '@wallet-standard/wallet': 1.1.0
-      '@walletconnect/logger': 3.0.0
-      '@walletconnect/universal-provider': 2.22.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12)
-      valtio: 2.1.7(@types/react@18.3.23)(react@18.3.1)
-      viem: 2.38.2(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -14550,51 +14366,6 @@ snapshots:
       semver: 7.7.2
       valtio: 2.1.7(@types/react@18.3.23)(react@18.3.1)
       viem: 2.38.2(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.22.4)
-    optionalDependencies:
-      '@lit/react': 1.0.8(@types/react@18.3.23)
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - ioredis
-      - react
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
-  '@reown/appkit@1.8.12(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12)':
-    dependencies:
-      '@reown/appkit-common': 1.8.12(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12)
-      '@reown/appkit-controllers': 1.8.12(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12)
-      '@reown/appkit-pay': 1.8.12(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12)
-      '@reown/appkit-polyfills': 1.8.12
-      '@reown/appkit-scaffold-ui': 1.8.12(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(valtio@2.1.7(@types/react@18.3.23)(react@18.3.1))(zod@4.1.12)
-      '@reown/appkit-ui': 1.8.12(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12)
-      '@reown/appkit-utils': 1.8.12(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(valtio@2.1.7(@types/react@18.3.23)(react@18.3.1))(zod@4.1.12)
-      '@reown/appkit-wallet': 1.8.12(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)
-      '@walletconnect/universal-provider': 2.22.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12)
-      bs58: 6.0.0
-      semver: 7.7.2
-      valtio: 2.1.7(@types/react@18.3.23)(react@18.3.1)
-      viem: 2.38.2(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12)
     optionalDependencies:
       '@lit/react': 1.0.8(@types/react@18.3.23)
     transitivePeerDependencies:
@@ -16422,50 +16193,6 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/core@2.22.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12)':
-    dependencies:
-      '@walletconnect/heartbeat': 1.2.2
-      '@walletconnect/jsonrpc-provider': 1.0.14
-      '@walletconnect/jsonrpc-types': 1.0.4
-      '@walletconnect/jsonrpc-utils': 1.0.8
-      '@walletconnect/jsonrpc-ws-connection': 1.0.16(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-      '@walletconnect/keyvaluestorage': 1.1.1
-      '@walletconnect/logger': 3.0.0
-      '@walletconnect/relay-api': 1.0.11
-      '@walletconnect/relay-auth': 1.1.0
-      '@walletconnect/safe-json': 1.0.2
-      '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.22.4
-      '@walletconnect/utils': 2.22.4(typescript@5.9.2)(zod@4.1.12)
-      '@walletconnect/window-getters': 1.0.1
-      es-toolkit: 1.39.3
-      events: 3.3.0
-      uint8arrays: 3.1.1
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - ioredis
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
   '@walletconnect/environment@1.0.1':
     dependencies:
       tslib: 1.14.1
@@ -16825,42 +16552,6 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/sign-client@2.22.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12)':
-    dependencies:
-      '@walletconnect/core': 2.22.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12)
-      '@walletconnect/events': 1.0.1
-      '@walletconnect/heartbeat': 1.2.2
-      '@walletconnect/jsonrpc-utils': 1.0.8
-      '@walletconnect/logger': 3.0.0
-      '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.22.4
-      '@walletconnect/utils': 2.22.4(typescript@5.9.2)(zod@4.1.12)
-      events: 3.3.0
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - ioredis
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
   '@walletconnect/time@1.0.2':
     dependencies:
       tslib: 1.14.1
@@ -17152,46 +16843,6 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/universal-provider@2.22.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12)':
-    dependencies:
-      '@walletconnect/events': 1.0.1
-      '@walletconnect/jsonrpc-http-connection': 1.0.8
-      '@walletconnect/jsonrpc-provider': 1.0.14
-      '@walletconnect/jsonrpc-types': 1.0.4
-      '@walletconnect/jsonrpc-utils': 1.0.8
-      '@walletconnect/keyvaluestorage': 1.1.1
-      '@walletconnect/logger': 3.0.0
-      '@walletconnect/sign-client': 2.22.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12)
-      '@walletconnect/types': 2.22.4
-      '@walletconnect/utils': 2.22.4(typescript@5.9.2)(zod@4.1.12)
-      es-toolkit: 1.39.3
-      events: 3.3.0
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - ioredis
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
   '@walletconnect/utils@2.21.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.22.4)':
     dependencies:
       '@noble/ciphers': 1.2.1
@@ -17389,51 +17040,6 @@ snapshots:
       bs58: 6.0.0
       detect-browser: 5.3.0
       ox: 0.9.3(typescript@5.9.2)(zod@3.22.4)
-      uint8arrays: 3.1.1
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - db0
-      - ioredis
-      - typescript
-      - uploadthing
-      - zod
-
-  '@walletconnect/utils@2.22.4(typescript@5.9.2)(zod@4.1.12)':
-    dependencies:
-      '@msgpack/msgpack': 3.1.2
-      '@noble/ciphers': 1.3.0
-      '@noble/curves': 1.9.7
-      '@noble/hashes': 1.8.0
-      '@scure/base': 1.2.6
-      '@walletconnect/jsonrpc-utils': 1.0.8
-      '@walletconnect/keyvaluestorage': 1.1.1
-      '@walletconnect/logger': 3.0.0
-      '@walletconnect/relay-api': 1.0.11
-      '@walletconnect/relay-auth': 1.1.0
-      '@walletconnect/safe-json': 1.0.2
-      '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.22.4
-      '@walletconnect/window-getters': 1.0.1
-      '@walletconnect/window-metadata': 1.0.1
-      blakejs: 1.2.1
-      bs58: 6.0.0
-      detect-browser: 5.3.0
-      ox: 0.9.3(typescript@5.9.2)(zod@4.1.12)
       uint8arrays: 3.1.1
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -21638,21 +21244,6 @@ snapshots:
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
       abitype: 1.1.1(typescript@5.9.2)(zod@3.22.4)
-      eventemitter3: 5.0.1
-    optionalDependencies:
-      typescript: 5.9.2
-    transitivePeerDependencies:
-      - zod
-
-  ox@0.9.3(typescript@5.9.2)(zod@4.1.12):
-    dependencies:
-      '@adraffy/ens-normalize': 1.11.1
-      '@noble/ciphers': 1.3.0
-      '@noble/curves': 1.9.1
-      '@noble/hashes': 1.8.0
-      '@scure/bip32': 1.7.0
-      '@scure/bip39': 1.6.0
-      abitype: 1.1.1(typescript@5.9.2)(zod@4.1.12)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.9.2

--- a/services/vault/package.json
+++ b/services/vault/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@babylonlabs-io/babylon-tbv-rust-wasm": "workspace:*",
     "@babylonlabs-io/config": "workspace:*",
+    "@babylonlabs-io/tbv-registry": "workspace:*",
     "@babylonlabs-io/core-ui": "workspace:*",
     "@babylonlabs-io/ts-sdk": "workspace:*",
     "@babylonlabs-io/wallet-connector": "workspace:*",

--- a/services/vault/src/applications/aave/hooks/useAaveVaults.ts
+++ b/services/vault/src/applications/aave/hooks/useAaveVaults.ts
@@ -49,6 +49,7 @@ function transformVaultToTableData(
     provider: {
       name: providerName,
       icon: provider?.iconUrl,
+      verified: provider?.verified ?? false,
     },
     status: peginState.displayLabel,
   };
@@ -59,6 +60,7 @@ export interface RedeemedVaultInfo {
   amountBtc: number;
   providerName: string;
   providerIconUrl?: string;
+  providerVerified?: boolean;
   /** Timestamp in milliseconds when vault was created */
   createdAt: number;
 }
@@ -123,6 +125,7 @@ export function useAaveVaults(
           amountBtc: satoshiToBtcNumber(vault.amount),
           providerName,
           providerIconUrl: provider?.iconUrl,
+          providerVerified: provider?.verified ?? false,
           createdAt: vault.createdAt,
         };
       });

--- a/services/vault/src/applications/aave/types.ts
+++ b/services/vault/src/applications/aave/types.ts
@@ -17,6 +17,8 @@ export interface VaultData {
     name: string;
     /** Icon URL - undefined will use Avatar component's built-in fallback */
     icon?: string;
+    /** Whether the provider is verified in the registry */
+    verified?: boolean;
   };
   /** Vault status from centralized state machine */
   status: PeginDisplayLabel;

--- a/services/vault/src/components/pages/RootLayout.tsx
+++ b/services/vault/src/components/pages/RootLayout.tsx
@@ -11,12 +11,16 @@ import { useState } from "react";
 import { NavLink, Outlet } from "react-router";
 import { twJoin } from "tailwind-merge";
 
+import { AAVE_APP_ID } from "@/applications/aave/config";
+import {
+  AaveConfigProvider,
+  PendingVaultsProvider,
+} from "@/applications/aave/context";
 import { DepositButton } from "@/components/shared";
 import { getNetworkConfigBTC, shouldDisplayTestingMsg } from "@/config";
 import { useAddressType } from "@/context/addressType";
 import { useGeoFencing } from "@/context/geofencing";
 
-import { AaveConfigProvider } from "../../applications/aave/context";
 import { useBTCWallet, useETHWallet } from "../../context/wallet";
 import { AddressTypeBanner } from "../shared/AddressTypeBanner";
 import { GeoBlockBanner } from "../shared/GeoBlockBanner";
@@ -121,10 +125,12 @@ export default function RootLayout() {
           }
         />
         <AaveConfigProvider>
-          <SimpleDeposit
-            open={isDepositOpen}
-            onClose={() => setIsDepositOpen(false)}
-          />
+          <PendingVaultsProvider appId={AAVE_APP_ID}>
+            <SimpleDeposit
+              open={isDepositOpen}
+              onClose={() => setIsDepositOpen(false)}
+            />
+          </PendingVaultsProvider>
         </AaveConfigProvider>
         <div className="mt-auto">
           <Footer

--- a/services/vault/src/components/shared/VerifiedBadge.tsx
+++ b/services/vault/src/components/shared/VerifiedBadge.tsx
@@ -1,0 +1,10 @@
+import { CheckIcon } from "@babylonlabs-io/core-ui";
+
+export function VerifiedBadge() {
+  return (
+    <span className="inline-flex shrink-0 items-center gap-0.5 rounded-full bg-green-100 px-1.5 py-0.5 text-xs font-medium text-green-700 dark:bg-green-900/30 dark:text-green-400">
+      <CheckIcon size={10} variant="success" />
+      Verified
+    </span>
+  );
+}

--- a/services/vault/src/components/shared/VerifiedProviderAvatar.tsx
+++ b/services/vault/src/components/shared/VerifiedProviderAvatar.tsx
@@ -1,0 +1,36 @@
+import { ProviderAvatar, type AvatarProps } from "@babylonlabs-io/core-ui";
+
+interface VerifiedProviderAvatarProps {
+  name: string;
+  url?: string;
+  size?: AvatarProps["size"];
+  verified?: boolean;
+}
+
+export function VerifiedProviderAvatar({
+  name,
+  url,
+  size = "medium",
+  verified,
+}: VerifiedProviderAvatarProps) {
+  const avatar = <ProviderAvatar name={name} url={url} size={size} />;
+
+  if (!verified) return avatar;
+
+  return (
+    <div className="relative inline-flex">
+      {avatar}
+      <span className="absolute bottom-0 right-[-1px] flex size-2 items-center justify-center overflow-hidden rounded-full border border-[#191919] bg-[white]">
+        <svg viewBox="0 0 8 8" fill="none" className="size-[5px]">
+          <path
+            d="M1.5 4.5L3.5 6.5L7 2"
+            stroke="#191919"
+            strokeWidth="1.2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </span>
+    </div>
+  );
+}

--- a/services/vault/src/components/shared/index.ts
+++ b/services/vault/src/components/shared/index.ts
@@ -11,3 +11,5 @@ export { NotificationContainer } from "./NotificationContainer";
 export { PriceWarningBanner } from "./PriceWarningBanner";
 export { SubmitModal } from "./SubmitModal";
 export { VaultDetailRows } from "./VaultDetailRows";
+export { VerifiedBadge } from "./VerifiedBadge";
+export { VerifiedProviderAvatar } from "./VerifiedProviderAvatar";

--- a/services/vault/src/components/simple/CollateralExpandedContent.tsx
+++ b/services/vault/src/components/simple/CollateralExpandedContent.tsx
@@ -33,6 +33,7 @@ export function CollateralExpandedContent({
             inUse={vault.inUse}
             providerName={vault.providerName}
             providerIconUrl={vault.providerIconUrl}
+            providerVerified={vault.providerVerified}
           />
         ))}
       </div>

--- a/services/vault/src/components/simple/CollateralVaultItem.tsx
+++ b/services/vault/src/components/simple/CollateralVaultItem.tsx
@@ -5,6 +5,7 @@
 
 import { Avatar, StatusBadge } from "@babylonlabs-io/core-ui";
 
+import { VerifiedProviderAvatar } from "@/components/shared";
 import { getNetworkConfigBTC } from "@/config";
 import { truncateHash } from "@/utils/addressUtils";
 import { formatBtcAmount, formatDateTime } from "@/utils/formatting";
@@ -20,6 +21,7 @@ interface CollateralVaultItemProps {
   inUse: boolean;
   providerName: string;
   providerIconUrl?: string;
+  providerVerified?: boolean;
 }
 
 export function CollateralVaultItem({
@@ -29,6 +31,7 @@ export function CollateralVaultItem({
   inUse,
   providerName,
   providerIconUrl,
+  providerVerified,
 }: CollateralVaultItemProps) {
   const formattedDate = formatDateTime(new Date(addedAt * SECONDS_TO_MS));
 
@@ -61,9 +64,12 @@ export function CollateralVaultItem({
       <div className="flex items-center justify-between">
         <span className="text-sm text-accent-secondary">Vault Provider</span>
         <div className="flex items-center gap-1.5">
-          {providerIconUrl && (
-            <Avatar url={providerIconUrl} alt={providerName} size="tiny" />
-          )}
+          <VerifiedProviderAvatar
+            name={providerName}
+            url={providerIconUrl}
+            size="small"
+            verified={providerVerified}
+          />
           <span className="text-sm text-accent-primary">{providerName}</span>
         </div>
       </div>

--- a/services/vault/src/components/simple/DashboardPage.tsx
+++ b/services/vault/src/components/simple/DashboardPage.tsx
@@ -49,9 +49,11 @@ export function DashboardPage() {
     hasDebt,
     collateralVaults,
     selectableBorrowedAssets,
-  } = useDashboardState(address);
+  } = useDashboardState(isConnected ? address : undefined);
 
-  const { vaults: aaveVaults, redeemedVaults } = useAaveVaults(address);
+  const { vaults: aaveVaults, redeemedVaults } = useAaveVaults(
+    isConnected ? address : undefined,
+  );
 
   // Sync pending vault operations (add/withdraw) with indexer data
   useSyncPendingVaults(aaveVaults);

--- a/services/vault/src/components/simple/DepositForm.tsx
+++ b/services/vault/src/components/simple/DepositForm.tsx
@@ -3,12 +3,12 @@ import {
   Card,
   Checkbox,
   Loader,
-  Select,
+  SelectWithIcon,
 } from "@babylonlabs-io/core-ui";
 import { useMemo } from "react";
 
 import { ApplicationLogo } from "@/components/ApplicationLogo";
-import { DepositButton } from "@/components/shared";
+import { DepositButton, VerifiedProviderAvatar } from "@/components/shared";
 import { getNetworkConfigBTC } from "@/config";
 import { useBtcFeeDisplay } from "@/hooks/deposit/useBtcFeeDisplay";
 import { depositService } from "@/services/deposit";
@@ -18,6 +18,8 @@ const btcConfig = getNetworkConfigBTC();
 interface Provider {
   id: string;
   name: string;
+  iconUrl?: string;
+  verified?: boolean;
 }
 
 interface Application {
@@ -114,6 +116,14 @@ export function DepositForm({
   const providerOptions = providers.map((p) => ({
     value: p.id,
     label: p.name,
+    icon: (
+      <VerifiedProviderAvatar
+        name={p.name}
+        url={p.iconUrl}
+        size="small"
+        verified={p.verified}
+      />
+    ),
   }));
 
   const {
@@ -205,8 +215,9 @@ export function DepositForm({
             No vault providers available at this time.
           </p>
         ) : (
-          <Select
-            className="border-0 bg-transparent"
+          <SelectWithIcon
+            className="border-0 bg-transparent !px-3 !py-2 [&_.bbn-select-with-icon-image>*]:!size-6 [&_.bbn-select-with-icon-image]:!size-6 [&_.bbn-select-with-icon-image]:!min-h-6 [&_.bbn-select-with-icon-image]:!min-w-6 [&_.bbn-select-with-icon-text]:!text-sm"
+            optionClassName="!px-3 !py-2 [&_.bbn-select-with-icon-option-image]:!size-6 [&_.bbn-select-with-icon-option-image]:!min-h-6 [&_.bbn-select-with-icon-option-image]:!min-w-6 [&_.bbn-select-with-icon-option-image>*]:!size-6 [&_.bbn-select-with-icon-option-text]:!text-sm"
             options={providerOptions}
             value={selectedProvider}
             placeholder="Select Vault Provider"

--- a/services/vault/src/components/simple/PendingDepositCard.tsx
+++ b/services/vault/src/components/simple/PendingDepositCard.tsx
@@ -104,6 +104,7 @@ export function PendingDepositCard({
       txHash={txHash}
       providerName={providerName}
       providerIconUrl={provider?.iconUrl}
+      providerVerified={provider?.verified}
       statusContent={
         <VaultStatusBadge
           dotColor={dotColor}

--- a/services/vault/src/components/simple/PendingWithdrawSection.tsx
+++ b/services/vault/src/components/simple/PendingWithdrawSection.tsx
@@ -76,6 +76,7 @@ export function PendingWithdrawSection({
                 txHash={vault.id}
                 providerName={vault.providerName}
                 providerIconUrl={vault.providerIconUrl}
+                providerVerified={vault.providerVerified}
                 statusContent={
                   <VaultStatusBadge
                     dotColor="bg-warning-main"

--- a/services/vault/src/components/simple/VaultDetailCard.tsx
+++ b/services/vault/src/components/simple/VaultDetailCard.tsx
@@ -14,6 +14,7 @@ import {
 } from "@babylonlabs-io/core-ui";
 import type { ReactNode } from "react";
 
+import { VerifiedProviderAvatar } from "@/components/shared";
 import { getNetworkConfigBTC } from "@/config";
 import { truncateHash } from "@/utils/addressUtils";
 import { formatBtcAmount, formatDateTime } from "@/utils/formatting";
@@ -35,6 +36,8 @@ interface VaultDetailCardProps {
   providerName: string;
   /** Vault provider icon URL */
   providerIconUrl?: string;
+  /** Whether the vault provider is verified */
+  providerVerified?: boolean;
   /** Status content — rendered as the value in the Status row */
   statusContent: ReactNode;
   /** Optional action button rendered at the bottom */
@@ -47,6 +50,7 @@ export function VaultDetailCard({
   txHash,
   providerName,
   providerIconUrl,
+  providerVerified,
   statusContent,
   action,
 }: VaultDetailCardProps) {
@@ -80,14 +84,12 @@ export function VaultDetailCard({
       <div className="flex items-center justify-between">
         <span className="text-sm text-accent-secondary">Vault Provider</span>
         <span className="flex items-center gap-1.5 text-sm text-accent-primary">
-          {providerIconUrl && (
-            <Avatar
-              url={providerIconUrl}
-              alt={providerName}
-              size="small"
-              className="h-4 w-4"
-            />
-          )}
+          <VerifiedProviderAvatar
+            name={providerName}
+            url={providerIconUrl}
+            size="small"
+            verified={providerVerified}
+          />
           {providerName}
         </span>
       </div>

--- a/services/vault/src/hooks/deposit/useDepositPageForm.ts
+++ b/services/vault/src/hooks/deposit/useDepositPageForm.ts
@@ -57,6 +57,7 @@ export interface UseDepositPageFormResult {
     name: string;
     btcPubkey: string;
     iconUrl?: string;
+    verified: boolean;
   }>;
   isLoadingProviders: boolean;
 
@@ -136,6 +137,7 @@ export function useDepositPageForm(): UseDepositPageFormResult {
       name: formatProviderDisplayName(p.name, p.id),
       btcPubkey: p.btcPubKey || "",
       iconUrl: p.iconUrl,
+      verified: p.verified,
     }));
   }, [rawProviders]);
 

--- a/services/vault/src/hooks/deposit/useVaultProviders.ts
+++ b/services/vault/src/hooks/deposit/useVaultProviders.ts
@@ -86,6 +86,7 @@ export function useVaultProviders(
   const vaultProvidersWithLogos = useWithLogos(
     data?.vaultProviders ?? [],
     (p) => toIdentity(p.btcPubKey),
+    (p) => p.iconUrl,
   );
 
   // Helper function to find provider by address

--- a/services/vault/src/hooks/useWithLogos.ts
+++ b/services/vault/src/hooks/useWithLogos.ts
@@ -22,11 +22,13 @@ import { useLogos } from "./useLogos";
  *
  * @param items - Array of items to enrich with logos
  * @param getIdentity - Function to extract the identity from each item
+ * @param getFallbackIcon - Optional function to extract a fallback icon URL from each item
  * @returns Array of items with `iconUrl` property added
  */
 export function useWithLogos<T>(
   items: T[],
   getIdentity: (item: T) => string,
+  getFallbackIcon?: (item: T) => string | undefined,
 ): (T & { iconUrl?: string })[] {
   // Compute identities and maintain mapping
   const itemsWithIdentities = useMemo(
@@ -51,8 +53,8 @@ export function useWithLogos<T>(
     () =>
       itemsWithIdentities.map(({ item, identity }) => ({
         ...item,
-        iconUrl: logos[identity],
+        iconUrl: logos[identity] ?? getFallbackIcon?.(item),
       })),
-    [itemsWithIdentities, logos],
+    [itemsWithIdentities, logos, getFallbackIcon],
   );
 }

--- a/services/vault/src/services/providers/__tests__/fetchProviders.test.ts
+++ b/services/vault/src/services/providers/__tests__/fetchProviders.test.ts
@@ -1,3 +1,4 @@
+import { getVerifiedProvider } from "@babylonlabs-io/tbv-registry/vault-provider";
 import { describe, expect, it, vi } from "vitest";
 
 import { graphqlClient } from "../../../clients/graphql";
@@ -13,7 +14,12 @@ vi.mock("../../../clients/graphql", () => ({
   },
 }));
 
+vi.mock("@babylonlabs-io/tbv-registry/vault-provider", () => ({
+  getVerifiedProvider: vi.fn(),
+}));
+
 const mockRequest = vi.mocked(graphqlClient.request);
+const mockGetVerifiedProvider = vi.mocked(getVerifiedProvider);
 
 describe("fetchProviders", () => {
   describe("fetchAppProviders", () => {
@@ -68,7 +74,147 @@ describe("fetchProviders", () => {
       expect(result.vaultKeepers).toEqual([]);
     });
 
-    it("should only return providers with rpcUrl", async () => {
+    it("should return all providers with verified flag from registry", async () => {
+      mockGetVerifiedProvider.mockImplementation((id: string) => {
+        if (id === "0xprovider1") {
+          return {
+            address: "0xprovider1",
+            name: "Registry Provider",
+            rpcUrl: "https://registry-rpc.example.com",
+            iconUrl: "https://registry-icon.example.com/logo.png",
+          };
+        }
+        return undefined;
+      });
+
+      mockRequest.mockResolvedValueOnce({
+        vaultProviders: {
+          items: [
+            {
+              id: "0xprovider1",
+              btcPubKey: "0xpk1",
+              name: "on-chain-name-1",
+              rpcUrl: "https://rpc1.example.com",
+            },
+            {
+              id: "0xprovider2",
+              btcPubKey: "0xpk2",
+              name: "on-chain-name-2",
+              rpcUrl: "https://rpc2.example.com",
+            },
+          ],
+        },
+        vaultKeeperApplications: { items: [] },
+      });
+
+      const result = await fetchAppProviders("0xAppController");
+
+      expect(result.vaultProviders).toEqual([
+        {
+          id: "0xprovider1",
+          btcPubKey: "0xpk1",
+          name: "Registry Provider",
+          url: "https://registry-rpc.example.com",
+          iconUrl: "https://registry-icon.example.com/logo.png",
+          verified: true,
+        },
+        {
+          id: "0xprovider2",
+          btcPubKey: "0xpk2",
+          name: "on-chain-name-2",
+          url: "https://rpc2.example.com",
+          iconUrl: undefined,
+          verified: false,
+        },
+      ]);
+    });
+
+    it("should use registry values over on-chain values", async () => {
+      mockGetVerifiedProvider.mockImplementation((id: string) => {
+        if (id === "0xprovider1") {
+          return {
+            address: "0xprovider1",
+            name: "Registry Name",
+            rpcUrl: "https://registry-rpc.example.com",
+            iconUrl: "https://registry-icon.example.com/logo.png",
+          };
+        }
+        return undefined;
+      });
+
+      mockRequest.mockResolvedValueOnce({
+        vaultProviders: {
+          items: [
+            {
+              id: "0xprovider1",
+              btcPubKey: "0xpk1",
+              name: "on-chain-name",
+              rpcUrl: "https://on-chain-rpc.example.com",
+            },
+          ],
+        },
+        vaultKeeperApplications: { items: [] },
+      });
+
+      const result = await fetchAppProviders("0xAppController");
+
+      expect(result.vaultProviders).toEqual([
+        {
+          id: "0xprovider1",
+          btcPubKey: "0xpk1",
+          name: "Registry Name",
+          url: "https://registry-rpc.example.com",
+          iconUrl: "https://registry-icon.example.com/logo.png",
+          verified: true,
+        },
+      ]);
+    });
+
+    it("should mark all providers as unverified when none match registry", async () => {
+      mockGetVerifiedProvider.mockReturnValue(undefined);
+
+      mockRequest.mockResolvedValueOnce({
+        vaultProviders: {
+          items: [
+            {
+              id: "0xprovider1",
+              btcPubKey: "0xpk1",
+              name: "on-chain-name-1",
+              rpcUrl: "https://rpc1.example.com",
+            },
+          ],
+        },
+        vaultKeeperApplications: { items: [] },
+      });
+
+      const result = await fetchAppProviders("0xAppController");
+
+      expect(result.vaultProviders).toEqual([
+        {
+          id: "0xprovider1",
+          btcPubKey: "0xpk1",
+          name: "on-chain-name-1",
+          url: "https://rpc1.example.com",
+          iconUrl: undefined,
+          verified: false,
+        },
+      ]);
+    });
+
+    it("should filter providers without rpcUrl", async () => {
+      mockGetVerifiedProvider.mockImplementation((id: string) => {
+        // Both providers are in registry
+        if (id === "0xprovider1" || id === "0xprovider2") {
+          return {
+            address: id,
+            name: "Registry Provider",
+            rpcUrl: "https://registry-rpc.example.com",
+            iconUrl: "https://registry-icon.example.com/logo.png",
+          };
+        }
+        return undefined;
+      });
+
       mockRequest.mockResolvedValueOnce({
         vaultProviders: {
           items: [
@@ -84,12 +230,6 @@ describe("fetchProviders", () => {
               name: "provider-2",
               rpcUrl: null,
             },
-            {
-              id: "0xprovider3",
-              btcPubKey: "0xpk3",
-              name: null,
-              rpcUrl: "https://rpc3.example.com",
-            },
           ],
         },
         vaultKeeperApplications: { items: [] },
@@ -97,18 +237,15 @@ describe("fetchProviders", () => {
 
       const result = await fetchAppProviders("0xAppController");
 
+      // Only provider1 should be returned (provider2 has null rpcUrl)
       expect(result.vaultProviders).toEqual([
         {
           id: "0xprovider1",
           btcPubKey: "0xpk1",
-          name: "provider-1",
-          url: "https://rpc.example.com",
-        },
-        {
-          id: "0xprovider3",
-          btcPubKey: "0xpk3",
-          name: undefined,
-          url: "https://rpc3.example.com",
+          name: "Registry Provider",
+          url: "https://registry-rpc.example.com",
+          iconUrl: "https://registry-icon.example.com/logo.png",
+          verified: true,
         },
       ]);
     });

--- a/services/vault/src/services/providers/fetchProviders.ts
+++ b/services/vault/src/services/providers/fetchProviders.ts
@@ -1,3 +1,4 @@
+import { getVerifiedProvider } from "@babylonlabs-io/tbv-registry/vault-provider";
 import { gql } from "graphql-request";
 
 import { graphqlClient } from "../../clients/graphql";
@@ -151,16 +152,18 @@ export async function fetchAppProviders(
   );
 
   const vaultProviders: VaultProvider[] = response.vaultProviders.items
-    .filter(
-      (provider): provider is typeof provider & { rpcUrl: string } =>
-        provider.rpcUrl !== null,
-    )
-    .map((provider) => ({
-      id: provider.id,
-      btcPubKey: provider.btcPubKey,
-      name: provider.name ?? undefined,
-      url: provider.rpcUrl,
-    }));
+    .filter((provider) => provider.rpcUrl !== null)
+    .map((provider) => {
+      const registryEntry = getVerifiedProvider(provider.id);
+      return {
+        id: provider.id,
+        btcPubKey: provider.btcPubKey,
+        name: registryEntry?.name ?? provider.name ?? undefined,
+        url: registryEntry?.rpcUrl ?? provider.rpcUrl!,
+        iconUrl: registryEntry?.iconUrl,
+        verified: !!registryEntry,
+      };
+    });
 
   const vaultKeeperItems: VaultKeeperItem[] =
     response.vaultKeeperApplications.items.map((item) => ({

--- a/services/vault/src/types/collateral.ts
+++ b/services/vault/src/types/collateral.ts
@@ -17,4 +17,6 @@ export interface CollateralVaultEntry {
   providerName: string;
   /** Vault provider icon URL (optional) */
   providerIconUrl?: string;
+  /** Whether the vault provider is verified */
+  providerVerified?: boolean;
 }

--- a/services/vault/src/types/vaultProvider.ts
+++ b/services/vault/src/types/vaultProvider.ts
@@ -53,6 +53,8 @@ export interface VaultProvider {
   url: string;
   /** Provider's icon URL (from icon service, optional) */
   iconUrl?: string;
+  /** Whether provider is in the verified registry */
+  verified: boolean;
 }
 
 /**

--- a/services/vault/src/utils/__tests__/collateral.test.ts
+++ b/services/vault/src/utils/__tests__/collateral.test.ts
@@ -40,6 +40,7 @@ describe("Collateral Utilities", () => {
           inUse: true,
           providerName: "0xprov...der1",
           providerIconUrl: undefined,
+          providerVerified: false,
         },
       ]);
     });
@@ -101,6 +102,7 @@ describe("Collateral Utilities", () => {
         inUse: false,
         providerName: "",
         providerIconUrl: undefined,
+        providerVerified: false,
       });
     });
 
@@ -112,6 +114,7 @@ describe("Collateral Utilities", () => {
         url: "https://provider.test",
         name: "Babylon Provider",
         iconUrl: "https://example.com/icon.png",
+        verified: true,
       };
       const findProvider = (address: string) =>
         address === "0xprovider1" ? mockProvider : undefined;
@@ -121,6 +124,7 @@ describe("Collateral Utilities", () => {
       expect(result[0]).toMatchObject({
         providerName: "Babylon Provider",
         providerIconUrl: "https://example.com/icon.png",
+        providerVerified: true,
       });
     });
 

--- a/services/vault/src/utils/collateral.ts
+++ b/services/vault/src/utils/collateral.ts
@@ -48,6 +48,7 @@ export function toCollateralVaultEntries(
       inUse: c.vault?.inUse ?? false,
       providerName: provider?.name ?? truncateHash(providerAddress),
       providerIconUrl: provider?.iconUrl,
+      providerVerified: provider?.verified ?? false,
     };
   });
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes provider fetching/selection to rely on new `verified` + `trusted*` GraphQL fields and to block unverified providers, which could hide providers or break deposits if indexer data isn’t populated correctly.
> 
> **Overview**
> Adds a new `@babylonlabs-io/tbv-registry` package that defines a hardcoded verified vault-provider registry (`getVerifiedProvider`) intended to supply trusted provider metadata.
> 
> Updates the vault deposit provider flow to consume new GraphQL fields (`verified`, `trustedName`, `trustedRpcUrl`, `trustedIconUrl`), **filtering out unverified providers** and overriding displayed name/RPC/icon with trusted values; the UI now shows a `VerifiedBadge` and disables row selection unless the provider is verified.
> 
> Tweaks `useWithLogos` so logo enrichment falls back to an item’s existing `iconUrl` when the logo service has no result.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d52572584c186ca957653d6d23f700b9bab03348. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

#1209 

<img width="3024" height="1724" alt="image" src="https://github.com/user-attachments/assets/3bb7124f-e797-4489-aaee-72ec2f32a1a6" />
<img width="3024" height="1724" alt="image" src="https://github.com/user-attachments/assets/7da19baf-5064-4179-b8e4-9170658055af" />

