### PR TITLE
fix(vault): standardize on usehooks-ts, remove @uidotdev/usehooks

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -648,9 +648,6 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.74.4
         version: 5.90.20(react@18.3.1)
-      '@uidotdev/usehooks':
-        specifier: 2.4.1
-        version: 2.4.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       awilix:
         specifier: 12.0.5
         version: 12.0.5
@@ -928,9 +925,6 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.74.4
         version: 5.90.20(react@18.3.1)
-      '@uidotdev/usehooks':
-        specifier: 2.4.1
-        version: 2.4.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       bitcoinjs-lib:
         specifier: 6.1.7
         version: 6.1.7
@@ -4291,13 +4285,6 @@ packages:
   '@typescript-eslint/visitor-keys@8.44.1':
     resolution: {integrity: sha512-576+u0QD+Jp3tZzvfRfxon0EA2lzcDt3lhUbsC6Lgzy9x2VR4E+JUiNyGHi5T8vk0TV+fpJ5GLG1JsJuWCaKhw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@uidotdev/usehooks@2.4.1':
-    resolution: {integrity: sha512-1I+RwWyS+kdv3Mv0Vmc+p0dPYH0DTRAo04HLyXReYBL9AeseDWUJyi4THuksBJcu9F0Pih69Ak150VDnqbVnXg==}
-    engines: {node: '>=16'}
-    peerDependencies:
-      react: '>=18.0.0'
-      react-dom: '>=18.0.0'
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -15809,11 +15796,6 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.44.1
       eslint-visitor-keys: 4.2.1
-
-  '@uidotdev/usehooks@2.4.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     optional: true

--- a/services/simple-staking/eslint.config.js
+++ b/services/simple-staking/eslint.config.js
@@ -60,6 +60,17 @@ export default tseslint.config(
       "@typescript-eslint/no-unused-vars": "error",
       "@typescript-eslint/no-unused-expressions": "error",
       "import-x/no-unused-modules": "error",
+      "no-restricted-imports": [
+        "error",
+        {
+          paths: [
+            {
+              name: "@uidotdev/usehooks",
+              message: "Use usehooks-ts instead of @uidotdev/usehooks.",
+            },
+          ],
+        },
+      ],
       "no-restricted-globals": [
         "error",
         {

--- a/services/simple-staking/package.json
+++ b/services/simple-staking/package.json
@@ -38,7 +38,6 @@
     "@reown/appkit": "1.8.12",
     "@sentry/react": "8.33.0",
     "@tanstack/react-query": "^5.74.4",
-    "@uidotdev/usehooks": "2.4.1",
     "awilix": "12.0.5",
     "bitcoinjs-lib": "6.1.7",
     "core-js": "3.41.0",

--- a/services/simple-staking/src/ui/baby/components/FeeField/index.tsx
+++ b/services/simple-staking/src/ui/baby/components/FeeField/index.tsx
@@ -4,7 +4,7 @@ import {
   useFormContext,
   useWatch,
 } from "@babylonlabs-io/core-ui";
-import { useDebounce } from "@uidotdev/usehooks";
+import { useDebounceValue } from "usehooks-ts";
 import { useEffect } from "react";
 
 import babylon from "@/infrastructure/babylon";
@@ -34,7 +34,9 @@ export function FeeField({ babyPrice = 0, calculateFee }: FeeFieldProps) {
   const { trigger } = useFormContext();
   const { bech32Address } = useCosmosWallet();
   const values = useWatch({ name: ["amount", "validatorAddresses"] });
-  const [amount, validatorAddresses] = useDebounce(values, DELAY);
+  const [debouncedValues] = useDebounceValue(values, DELAY);
+  const amount = debouncedValues?.[0];
+  const validatorAddresses = debouncedValues?.[1];
   const validatorAddress = validatorAddresses?.[0];
   const babyValue = babylon.utils.ubbnToBaby(BigInt(value));
 

--- a/services/simple-staking/src/ui/baby/widgets/StakingForm/hooks/useValidationTracker.ts
+++ b/services/simple-staking/src/ui/baby/widgets/StakingForm/hooks/useValidationTracker.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { useDebounce } from "@uidotdev/usehooks";
+import { useDebounceValue } from "usehooks-ts";
 import type { FormRef } from "@babylonlabs-io/core-ui";
 
 import {
@@ -97,11 +97,11 @@ export function useValidationTracker({
     return () => subscription.unsubscribe();
   }, [formRef, updateFieldErrors]);
 
-  const debouncedAmountFieldError = useDebounce(
+  const [debouncedAmountFieldError] = useDebounceValue(
     enabledFields.amount ? amountError : undefined,
     300,
   );
-  const debouncedValidatorFieldError = useDebounce(
+  const [debouncedValidatorFieldError] = useDebounceValue(
     enabledFields.validatorAddresses ? validatorError : undefined,
     300,
   );

--- a/services/simple-staking/src/ui/baby/widgets/StakingForm/index.tsx
+++ b/services/simple-staking/src/ui/baby/widgets/StakingForm/index.tsx
@@ -1,7 +1,7 @@
 import { Form, type FormRef } from "@babylonlabs-io/core-ui";
 import { useMemo, useRef, useEffect, useCallback, useState } from "react";
 import { useLocation, useNavigate } from "react-router";
-import { useDebounce } from "@uidotdev/usehooks";
+import { useDebounceValue } from "usehooks-ts";
 
 import { AmountField } from "@/ui/baby/components/AmountField";
 import { FeeField } from "@/ui/baby/components/FeeField";
@@ -69,7 +69,7 @@ export default function StakingForm({
     string,
     unknown
   > | null>(null);
-  const debouncedAmountTrackingPayload = useDebounce(
+  const [debouncedAmountTrackingPayload] = useDebounceValue(
     amountTrackingPayload,
     300,
   );

--- a/services/simple-staking/src/ui/common/components/Multistaking/MultistakingForm/TimelockSection.tsx
+++ b/services/simple-staking/src/ui/common/components/Multistaking/MultistakingForm/TimelockSection.tsx
@@ -5,7 +5,7 @@ import {
   useFormContext,
   useWatch,
 } from "@babylonlabs-io/core-ui";
-import { useDebounce } from "@uidotdev/usehooks";
+import { useDebounceValue } from "usehooks-ts";
 import { useEffect, useRef, useState } from "react";
 
 import { type MultistakingFormFields } from "@/ui/common/state/MultistakingState";
@@ -37,7 +37,10 @@ export function TimelockSection() {
     useState<number>(minStakingTimeBlocks);
 
   // Debounced value for form updates (prevents lag during rapid slider changes)
-  const debouncedSliderValue = useDebounce(localSliderValue, DEBOUNCE_DELAY);
+  const [debouncedSliderValue] = useDebounceValue(
+    localSliderValue,
+    DEBOUNCE_DELAY,
+  );
 
   // Track whether we're actively dragging (to ignore form updates during drag)
   const isDraggingRef = useRef(false);

--- a/services/simple-staking/src/ui/common/state/FinalityProviderBsnState.tsx
+++ b/services/simple-staking/src/ui/common/state/FinalityProviderBsnState.tsx
@@ -1,4 +1,4 @@
-import { useDebounce } from "@uidotdev/usehooks";
+import { useDebounceValue } from "usehooks-ts";
 import {
   useCallback,
   useEffect,
@@ -146,7 +146,7 @@ export function FinalityProviderBsnState({ children }: PropsWithChildren) {
     allowlistStatus: "",
   });
   const [sortState, setSortState] = useState<SortState>({});
-  const debouncedSearch = useDebounce(filter.searchTerm, 300);
+  const [debouncedSearch] = useDebounceValue(filter.searchTerm, 300);
 
   const [selectedBsnId, setSelectedBsnId] = useState<string | undefined>(
     BBN_CHAIN_ID,

--- a/services/simple-staking/src/ui/common/state/FinalityProviderState.tsx
+++ b/services/simple-staking/src/ui/common/state/FinalityProviderState.tsx
@@ -1,4 +1,4 @@
-import { useDebounce } from "@uidotdev/usehooks";
+import { useDebounceValue } from "usehooks-ts";
 import { useCallback, useMemo, useState, type PropsWithChildren } from "react";
 import { useSearchParams } from "react-router";
 
@@ -91,7 +91,7 @@ export function FinalityProviderState({ children }: PropsWithChildren) {
     status: "active",
   });
   const [sortState, setSortState] = useState<SortState>({});
-  const debouncedSearch = useDebounce(filter.search, 300);
+  const [debouncedSearch] = useDebounceValue(filter.search, 300);
 
   const { data, hasNextPage, fetchNextPage, isFetching, isError } =
     useFinalityProvidersV2({

--- a/services/simple-staking/tests/app/hooks/services/errorHandling.test.tsx
+++ b/services/simple-staking/tests/app/hooks/services/errorHandling.test.tsx
@@ -12,9 +12,9 @@ jest.mock("@/ui/common/context/Error/ErrorProvider", () => ({
   },
 }));
 
-// Mock @uidotdev/usehooks to handle ESM module issue
-jest.mock("@uidotdev/usehooks", () => ({
-  useDebounce: jest.fn((value) => value),
+jest.mock("usehooks-ts", () => ({
+  ...jest.requireActual<object>("usehooks-ts"),
+  useDebounceValue: jest.fn((value: unknown) => [value, jest.fn()]),
 }));
 
 // Import after mocks

--- a/services/simple-staking/tests/app/hooks/services/useRegistrationService.test.tsx
+++ b/services/simple-staking/tests/app/hooks/services/useRegistrationService.test.tsx
@@ -6,9 +6,9 @@ jest.mock("@/ui/common/context/Error/ErrorProvider", () => ({
   useError: jest.fn(),
 }));
 
-// Mock @uidotdev/usehooks to handle ESM module issue
-jest.mock("@uidotdev/usehooks", () => ({
-  useDebounce: jest.fn((value) => value),
+jest.mock("usehooks-ts", () => ({
+  ...jest.requireActual<object>("usehooks-ts"),
+  useDebounceValue: jest.fn((value: unknown) => [value, jest.fn()]),
 }));
 
 // Mock nanoevents (ESM-only module) to avoid Jest parsing issues

--- a/services/simple-staking/tests/app/hooks/services/useStakingService.test.tsx
+++ b/services/simple-staking/tests/app/hooks/services/useStakingService.test.tsx
@@ -6,9 +6,9 @@ jest.mock("@/ui/common/context/Error/ErrorProvider", () => ({
   useError: jest.fn(),
 }));
 
-// Mock @uidotdev/usehooks to handle ESM module issue
-jest.mock("@uidotdev/usehooks", () => ({
-  useDebounce: jest.fn((value) => value),
+jest.mock("usehooks-ts", () => ({
+  ...jest.requireActual<object>("usehooks-ts"),
+  useDebounceValue: jest.fn((value: unknown) => [value, jest.fn()]),
 }));
 
 // Mock ESM dependency to prevent node_modules ESM parsing

--- a/services/simple-staking/tests/app/hooks/services/useV1TransactionService.test.tsx
+++ b/services/simple-staking/tests/app/hooks/services/useV1TransactionService.test.tsx
@@ -6,9 +6,9 @@ jest.mock("@/ui/common/context/Error/ErrorProvider", () => ({
   useError: jest.fn(),
 }));
 
-// Mock @uidotdev/usehooks to handle ESM module issue
-jest.mock("@uidotdev/usehooks", () => ({
-  useDebounce: jest.fn((value) => value),
+jest.mock("usehooks-ts", () => ({
+  ...jest.requireActual<object>("usehooks-ts"),
+  useDebounceValue: jest.fn((value: unknown) => [value, jest.fn()]),
 }));
 
 // Mock nanoevents (ESM-only module) to avoid Jest parsing issues

--- a/services/simple-staking/tests/app/state/DelegationState.test.tsx
+++ b/services/simple-staking/tests/app/state/DelegationState.test.tsx
@@ -13,12 +13,13 @@ jest.mock("@/ui/common/hooks/client/api/useDelegations", () => ({
   useDelegations: () => mockUseDelegations(),
 }));
 
-// Mock useLocalStorage
+// Mock useLocalStorage and useDebounceValue
 const mockSetDelegations = jest.fn();
 jest.mock("usehooks-ts", () => ({
   useLocalStorage: jest.fn().mockImplementation(() => {
     return [[], mockSetDelegations];
   }),
+  useDebounceValue: jest.fn((value: unknown) => [value, jest.fn()]),
 }));
 
 // Mock calculateDelegationsDiff

--- a/services/simple-staking/tests/app/state/StakingState.test.tsx
+++ b/services/simple-staking/tests/app/state/StakingState.test.tsx
@@ -37,15 +37,11 @@ jest.mock("@/ui/legacy/context/wallet/CosmosWalletProvider", () => ({
   useCosmosWallet: () => mockUseCosmosWallet(),
 }));
 
-jest.mock("@uidotdev/usehooks", () => ({
-  useDebounce: jest.fn((value) => value),
-}));
-
-// Mock useLocalStorage
+// Mock useLocalStorage and useDebounceValue
 const mockSetSuccessModalShown = jest.fn();
 const mockSetCancelModalShown = jest.fn();
 jest.mock("usehooks-ts", () => ({
-  useLocalStorage: jest.fn().mockImplementation((key) => {
+  useLocalStorage: jest.fn().mockImplementation((key: string) => {
     if (key === "bbn-staking-successFeedbackModalOpened") {
       return [false, mockSetSuccessModalShown];
     }
@@ -54,6 +50,7 @@ jest.mock("usehooks-ts", () => ({
     }
     return [null, jest.fn()];
   }),
+  useDebounceValue: jest.fn((value: unknown) => [value, jest.fn()]),
 }));
 
 // Import the actual component we're testing (after mocks are defined)

--- a/services/simple-staking/tests/utils/featureFlag/MultiStaking.test.tsx
+++ b/services/simple-staking/tests/utils/featureFlag/MultiStaking.test.tsx
@@ -4,8 +4,9 @@ import { render } from "@testing-library/react";
 
 import Home from "@/ui/common/page";
 
-jest.mock("@uidotdev/usehooks", () => ({
-  useDebounce: jest.fn((value) => value),
+jest.mock("usehooks-ts", () => ({
+  ...jest.requireActual<object>("usehooks-ts"),
+  useDebounceValue: jest.fn((value: unknown) => [value, jest.fn()]),
 }));
 
 jest.mock("@babylonlabs-io/btc-staking-ts", () => ({
@@ -37,10 +38,10 @@ jest.mock("@/ui/common/components/Staking/StakingForm", () => ({
 
 jest.mock("@/ui/common/components/Delegations/Activity", () => ({
   Activity: () => null,
-})); // Uses @uidotdev/usehooks
+}));
 jest.mock("@/ui/common/components/Header/Header", () => ({
   Header: () => null,
-})); // Uses @uidotdev/usehooks
+}));
 jest.mock("@/ui/common/components/Stats/Stats", () => ({ Stats: () => null })); // Has API dependencies
 jest.mock("@/ui/common/components/FAQ/FAQ", () => ({ FAQ: () => null })); // Uses ResizeObserver
 

--- a/services/simple-staking/tests/utils/usehooksMigration.test.ts
+++ b/services/simple-staking/tests/utils/usehooksMigration.test.ts
@@ -1,0 +1,53 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const SRC_DIR = path.resolve(__dirname, "../../src");
+
+function* walkDir(dir: string): Generator<string> {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name !== "node_modules" && entry.name !== "dist") {
+        yield* walkDir(fullPath);
+      }
+    } else if (
+      /\.(tsx?|jsx?|mtsx?|mjsx?)$/.test(entry.name) &&
+      !entry.name.endsWith(".d.ts")
+    ) {
+      yield fullPath;
+    }
+  }
+}
+
+const FILES_USING_USE_DEBOUNCE_VALUE = [
+  "ui/common/state/FinalityProviderState.tsx",
+  "ui/common/state/FinalityProviderBsnState.tsx",
+  "ui/baby/widgets/StakingForm/index.tsx",
+  "ui/baby/widgets/StakingForm/hooks/useValidationTracker.ts",
+  "ui/baby/components/FeeField/index.tsx",
+  "ui/common/components/Multistaking/MultistakingForm/TimelockSection.tsx",
+];
+
+describe("usehooks-ts migration (no @uidotdev/usehooks)", () => {
+  it("no source file imports @uidotdev/usehooks", () => {
+    const violations: string[] = [];
+    for (const filePath of walkDir(SRC_DIR)) {
+      const content = fs.readFileSync(filePath, "utf-8");
+      if (content.includes("@uidotdev/usehooks")) {
+        violations.push(path.relative(SRC_DIR, filePath));
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+
+  it("migrated debounce files use useDebounceValue from usehooks-ts", () => {
+    for (const relativePath of FILES_USING_USE_DEBOUNCE_VALUE) {
+      const filePath = path.join(SRC_DIR, relativePath);
+      const content = fs.readFileSync(filePath, "utf-8");
+      expect(content).toContain('from "usehooks-ts"');
+      expect(content).toContain("useDebounceValue");
+      expect(content).toMatch(/\[\s*[^\]]+\s*\]\s*=\s*useDebounceValue\(/);
+    }
+  });
+});

--- a/services/vault/eslint.config.js
+++ b/services/vault/eslint.config.js
@@ -56,6 +56,17 @@ export default tseslint.config(
       "@typescript-eslint/no-unused-vars": "error",
       "@typescript-eslint/no-unused-expressions": "error",
       "import-x/no-unused-modules": "error",
+      "no-restricted-imports": [
+        "error",
+        {
+          paths: [
+            {
+              name: "@uidotdev/usehooks",
+              message: "Use usehooks-ts instead of @uidotdev/usehooks.",
+            },
+          ],
+        },
+      ],
       "import-x/no-unresolved": [
         "error",
         {

--- a/services/vault/package.json
+++ b/services/vault/package.json
@@ -34,7 +34,6 @@
     "@scure/bip39": "2.0.1",
     "@sentry/react": "8.33.0",
     "@tanstack/react-query": "^5.74.4",
-    "@uidotdev/usehooks": "2.4.1",
     "bitcoinjs-lib": "6.1.7",
     "buffer": "6.0.3",
     "graphql": "^16.12.0",


### PR DESCRIPTION
We had two hook libraries with overlapping behavior: @uidotdev/usehooks and usehooks-ts. That led to extra bundle size and confusion about which one to use.

This PR standardizes on usehooks-ts and removes @uidotdev/usehooks

https://github.com/babylonlabs-io/babylon-toolkit/issues/1213