### PR TITLE
feat(vault): don't show split pegin if already has active collateral

### DIFF
--- a/services/vault/src/components/simple/SimpleDeposit.tsx
+++ b/services/vault/src/components/simple/SimpleDeposit.tsx
@@ -1,5 +1,5 @@
 import { FullScreenDialog, Heading } from "@babylonlabs-io/core-ui";
-import { useCallback, useEffect } from "react";
+import { useCallback } from "react";
 import type { Hex } from "viem";
 
 import type { DepositorGraphTransactions } from "@/clients/vault-provider-rpc/types";
@@ -117,7 +117,7 @@ function SimpleDepositContent({ open, onClose }: SimpleDepositBaseProps) {
     vaultKeeperBtcPubkeys,
     universalChallengerBtcPubkeys,
     hasExistingVaults,
-    hasActivePegins,
+    hasActiveVaults,
     isSplitDeposit,
     setIsSplitDeposit,
     splitAllocationPlan,
@@ -133,14 +133,7 @@ function SimpleDepositContent({ open, onClose }: SimpleDepositBaseProps) {
     setTransactionHashes,
   } = useDepositPageFlow();
 
-  // Hide partial liquidation when user already has active (collateralized) vaults
-  useEffect(() => {
-    if (hasActivePegins && isPartialLiquidation) {
-      setIsPartialLiquidation(false);
-    }
-  }, [hasActivePegins, isPartialLiquidation, setIsPartialLiquidation]);
-
-  const partialLiquidationProps = hasActivePegins
+  const partialLiquidationProps = hasActiveVaults
     ? undefined
     : {
         isEnabled: isPartialLiquidation,
@@ -166,8 +159,9 @@ function SimpleDepositContent({ open, onClose }: SimpleDepositBaseProps) {
         formData.selectedProvider,
       ]);
       setFeeRate(estimatedFeeRate);
-      setIsSplitDeposit(isPartialLiquidation);
-      if (isPartialLiquidation && allocationPlan) {
+      const shouldSplit = isPartialLiquidation && !hasActiveVaults;
+      setIsSplitDeposit(shouldSplit);
+      if (shouldSplit && allocationPlan) {
         setSplitAllocationPlan(allocationPlan);
       }
       goToStep(DepositStep.MNEMONIC);

--- a/services/vault/src/hooks/deposit/useDepositPageFlow.ts
+++ b/services/vault/src/hooks/deposit/useDepositPageFlow.ts
@@ -44,7 +44,7 @@ export interface UseDepositPageFlowResult {
 
   // Vault data
   hasExistingVaults: boolean;
-  hasActivePegins: boolean;
+  hasActiveVaults: boolean;
 
   // Actions
   startDeposit: (
@@ -118,7 +118,7 @@ export function useDepositPageFlow(): UseDepositPageFlowResult {
 
   const { data: existingVaults } = useVaults(ethAddress);
   const hasExistingVaults = (existingVaults?.length ?? 0) > 0;
-  const hasActivePegins = useMemo(
+  const hasActiveVaults = useMemo(
     () => existingVaults?.some((v) => v.status === VaultStatus.ACTIVE) ?? false,
     [existingVaults],
   );
@@ -217,7 +217,7 @@ export function useDepositPageFlow(): UseDepositPageFlowResult {
     vaultKeeperBtcPubkeys,
     universalChallengerBtcPubkeys,
     hasExistingVaults,
-    hasActivePegins,
+    hasActiveVaults,
     isSplitDeposit,
     setIsSplitDeposit,
     splitAllocationPlan,


### PR DESCRIPTION
- stop suggesting split pegin if already has active pegins / collateral

closes https://github.com/babylonlabs-io/babylon-toolkit/issues/1175

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/flow gating change that only affects whether the split-deposit (partial liquidation) option is shown/enabled based on existing vault status.
> 
> **Overview**
> Prevents users with already-*active* vault collateral from being prompted to do a split deposit ("partial liquidation").
> 
> `useDepositPageFlow` now derives `hasActivePegins` from fetched vaults (status `ACTIVE`), and `SimpleDeposit` uses it to omit the `partialLiquidation` props (hiding the checkbox/status text) and force-disable partial liquidation via an effect when active vaults are present.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ab31a10281c627c1633f2ffea014bd39062b04a. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->