### PR TITLE
feat(vault): showing detailed payout status

### DIFF
--- a/services/vault/src/applications/aave/hooks/useAaveVaults.ts
+++ b/services/vault/src/applications/aave/hooks/useAaveVaults.ts
@@ -6,7 +6,7 @@
  * vaults available for collateral (not currently in use or pending).
  */
 
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type { Address } from "viem";
 
 import { useVaultProviders } from "@/hooks/deposit/useVaultProviders";
@@ -61,6 +61,8 @@ export interface RedeemedVaultInfo {
   providerName: string;
   providerIconUrl?: string;
   providerVerified?: boolean;
+  /** Vault provider's Ethereum address (used to look up RPC URL for pegout polling) */
+  vaultProviderAddress: string;
   /** Timestamp in milliseconds when vault was created */
   createdAt: number;
 }
@@ -91,13 +93,19 @@ export function useAaveVaults(
   const hasPendingOperations = pendingVaults.size > 0;
   const { findProvider } = useVaultProviders();
 
+  // When redeemed vaults exist, we poll so the indexer's DEPOSITOR_WITHDRAWN
+  // update (from btc-monitor detecting the vault UTXO spend) gets picked up
+  // and the vault disappears from the pending withdraw section.
+  // Uses state (not ref) so the transition to zero redeemed vaults triggers
+  // a re-render that stops polling.
+  const [hasRedeemedVaults, setHasRedeemedVaults] = useState(false);
+
   const {
     data: vaults,
     isLoading: vaultsLoading,
     error,
   } = useVaults(depositorAddress as Address | undefined, {
-    // Poll when there are pending operations to detect when indexer confirms them
-    poll: hasPendingOperations,
+    poll: hasPendingOperations || hasRedeemedVaults,
   });
   const btcPriceUSD = usePrice("BTC");
 
@@ -126,10 +134,15 @@ export function useAaveVaults(
           providerName,
           providerIconUrl: provider?.iconUrl,
           providerVerified: provider?.verified ?? false,
+          vaultProviderAddress: vault.vaultProvider,
           createdAt: vault.createdAt,
         };
       });
   }, [vaults, findProvider]);
+
+  useEffect(() => {
+    setHasRedeemedVaults(redeemedVaults.length > 0);
+  }, [redeemedVaults.length]);
 
   const allVaults = useMemo(() => {
     return activeVaults.map((vault) => {

--- a/services/vault/src/clients/vault-provider-rpc/api.ts
+++ b/services/vault/src/clients/vault-provider-rpc/api.ts
@@ -3,6 +3,8 @@ import { JsonRpcClient } from "../../utils/rpc";
 import type {
   GetPeginStatusParams,
   GetPeginStatusResponse,
+  GetPegoutStatusParams,
+  GetPegoutStatusResponse,
   RequestDepositorClaimerArtifactsParams,
   RequestDepositorClaimerArtifactsResponse,
   RequestDepositorPresignTransactionsParams,
@@ -88,6 +90,16 @@ export class VaultProviderRpcApi {
   ): Promise<GetPeginStatusResponse> {
     return this.client.call<GetPeginStatusParams, GetPeginStatusResponse>(
       "vaultProvider_getPeginStatus",
+      params,
+    );
+  }
+
+  /** Get the current pegout status from the vault provider daemon. */
+  async getPegoutStatus(
+    params: GetPegoutStatusParams,
+  ): Promise<GetPegoutStatusResponse> {
+    return this.client.call<GetPegoutStatusParams, GetPegoutStatusResponse>(
+      "vaultProvider_getPegoutStatus",
       params,
     );
   }

--- a/services/vault/src/clients/vault-provider-rpc/types.ts
+++ b/services/vault/src/clients/vault-provider-rpc/types.ts
@@ -184,6 +184,46 @@ export interface GetPeginStatusResponse {
 }
 
 // ============================================================================
+// Pegout Types
+// ============================================================================
+
+/** Params for querying pegout status from the VP daemon. */
+export interface GetPegoutStatusParams {
+  pegin_txid: string;
+}
+
+/** Claimer-side pegout progress. */
+export interface ClaimerPegoutStatus {
+  status: string;
+  failed: boolean;
+  claim_txid?: string;
+  claimer_pubkey?: string;
+  challenger_pubkey?: string;
+  created_at?: string;
+  updated_at?: string;
+}
+
+/** Challenger-side pegout progress. */
+export interface ChallengerPegoutStatus {
+  status: string;
+  claim_txid?: string;
+  claimer_pubkey?: string;
+  assert_txid?: string;
+  challenge_assert_txid?: string;
+  nopayout_txid?: string;
+  created_at?: string;
+  updated_at?: string;
+}
+
+/** Response from `getPegoutStatus`. */
+export interface GetPegoutStatusResponse {
+  pegin_txid: string;
+  found: boolean;
+  claimer?: ClaimerPegoutStatus;
+  challenger?: ChallengerPegoutStatus;
+}
+
+// ============================================================================
 // Error Codes
 // ============================================================================
 

--- a/services/vault/src/components/simple/DashboardPage.tsx
+++ b/services/vault/src/components/simple/DashboardPage.tsx
@@ -5,7 +5,7 @@
  */
 
 import { Container } from "@babylonlabs-io/core-ui";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useNavigate, useOutletContext } from "react-router";
 
 import { AssetSelectionModal } from "@/applications/aave/components/AssetSelectionModal";
@@ -15,7 +15,10 @@ import { useAaveVaults } from "@/applications/aave/hooks";
 import type { Asset } from "@/applications/aave/types";
 import type { RootLayoutContext } from "@/components/pages/RootLayout";
 import { useConnection, useETHWallet } from "@/context/wallet";
+import { useVaultProviders } from "@/hooks/deposit/useVaultProviders";
 import { useDashboardState } from "@/hooks/useDashboardState";
+import { usePegoutPolling } from "@/hooks/usePegoutPolling";
+import { ClaimerPegoutStatusValue } from "@/models/pegoutStateMachine";
 import { formatBtcAmount, formatUsdValue } from "@/utils/formatting";
 
 import { CollateralSection } from "./CollateralSection";
@@ -53,6 +56,25 @@ export function DashboardPage() {
 
   const { vaults: aaveVaults, redeemedVaults } = useAaveVaults(
     isConnected ? address : undefined,
+  );
+  const { findProvider } = useVaultProviders();
+  const { pegoutStatuses } = usePegoutPolling({
+    redeemedVaults,
+    findProvider,
+  });
+
+  // Filter out vaults whose payout has been broadcast (terminal success).
+  // Failed vaults are intentionally kept visible so the user sees the error and can contact support.
+  const pendingWithdrawVaults = useMemo(
+    () =>
+      redeemedVaults.filter((vault) => {
+        const status = pegoutStatuses.get(vault.id);
+        return (
+          status?.response?.claimer?.status !==
+          ClaimerPegoutStatusValue.PAYOUT_BROADCAST
+        );
+      }),
+    [redeemedVaults, pegoutStatuses],
   );
 
   // Sync pending vault operations (add/withdraw) with indexer data
@@ -106,7 +128,10 @@ export function DashboardPage() {
 
         <PendingDepositSection />
 
-        <PendingWithdrawSection pendingWithdrawVaults={redeemedVaults} />
+        <PendingWithdrawSection
+          pendingWithdrawVaults={pendingWithdrawVaults}
+          pegoutStatuses={pegoutStatuses}
+        />
 
         <CollateralSection
           totalAmountBtc={totalAmountBtc}

--- a/services/vault/src/components/simple/PendingDepositCard.tsx
+++ b/services/vault/src/components/simple/PendingDepositCard.tsx
@@ -17,20 +17,11 @@ import {
   PeginAction,
 } from "@/components/deposit/actionStatus";
 import { useDepositPollingResult } from "@/context/deposit/PeginPollingContext";
-import type { PeginState } from "@/models/peginStateMachine";
 import type { VaultProvider } from "@/types/vaultProvider";
 import { truncateAddress } from "@/utils/addressUtils";
 
+import { STATUS_DOT_COLORS } from "./statusColors";
 import { VaultDetailCard, VaultStatusBadge } from "./VaultDetailCard";
-
-type DisplayVariant = PeginState["displayVariant"];
-
-const DOT_COLORS: Record<DisplayVariant, string> = {
-  pending: "bg-warning-main",
-  active: "bg-success-main",
-  inactive: "bg-gray-400",
-  warning: "bg-error-main",
-};
 
 interface PendingDepositCardProps {
   depositId: string;
@@ -90,7 +81,7 @@ export function PendingDepositCard({
   const label =
     loading && !transactions ? "Loading..." : peginState.displayLabel;
   const buttonDisabled = !isActionable || (loading && !transactions);
-  const dotColor = DOT_COLORS[peginState.displayVariant];
+  const dotColor = STATUS_DOT_COLORS[peginState.displayVariant];
 
   // Resolve provider name
   const provider = vaultProviders.find((vp) => vp.id === providerId);

--- a/services/vault/src/components/simple/PendingWithdrawSection.tsx
+++ b/services/vault/src/components/simple/PendingWithdrawSection.tsx
@@ -12,18 +12,22 @@ import { useState } from "react";
 import type { RedeemedVaultInfo } from "@/applications/aave/hooks/useAaveVaults";
 import { ExpandMenuButton } from "@/components/shared";
 import { getNetworkConfigBTC } from "@/config";
+import type { PegoutPollingResult } from "@/hooks/usePegoutPolling";
 import { formatBtcAmount } from "@/utils/formatting";
 
+import { STATUS_DOT_COLORS } from "./statusColors";
 import { VaultDetailCard, VaultStatusBadge } from "./VaultDetailCard";
 
 const btcConfig = getNetworkConfigBTC();
 
 interface PendingWithdrawSectionProps {
   pendingWithdrawVaults: RedeemedVaultInfo[];
+  pegoutStatuses: Map<string, PegoutPollingResult>;
 }
 
 export function PendingWithdrawSection({
   pendingWithdrawVaults,
+  pegoutStatuses,
 }: PendingWithdrawSectionProps) {
   const [isExpanded, setIsExpanded] = useState(false);
 
@@ -68,24 +72,32 @@ export function PendingWithdrawSection({
         {/* Expanded: individual vault detail cards */}
         {isExpanded && (
           <div className="mt-4 max-h-[400px] space-y-3 overflow-y-auto">
-            {pendingWithdrawVaults.map((vault) => (
-              <VaultDetailCard
-                key={vault.id}
-                amountBtc={vault.amountBtc}
-                timestamp={vault.createdAt}
-                txHash={vault.id}
-                providerName={vault.providerName}
-                providerIconUrl={vault.providerIconUrl}
-                providerVerified={vault.providerVerified}
-                statusContent={
-                  <VaultStatusBadge
-                    dotColor="bg-warning-main"
-                    label="Withdrawing"
-                    tooltip="Your BTC is being processed by the vault provider and will be sent to your nominated address."
-                  />
-                }
-              />
-            ))}
+            {pendingWithdrawVaults.map((vault) => {
+              const pollingResult = pegoutStatuses.get(vault.id);
+              const displayState = pollingResult?.displayState;
+              const label = displayState?.label ?? "Checking...";
+              const variant = displayState?.variant ?? "pending";
+              const tooltip = displayState?.message;
+
+              return (
+                <VaultDetailCard
+                  key={vault.id}
+                  amountBtc={vault.amountBtc}
+                  timestamp={vault.createdAt}
+                  txHash={vault.id}
+                  providerName={vault.providerName}
+                  providerIconUrl={vault.providerIconUrl}
+                  providerVerified={vault.providerVerified}
+                  statusContent={
+                    <VaultStatusBadge
+                      dotColor={STATUS_DOT_COLORS[variant]}
+                      label={label}
+                      tooltip={tooltip}
+                    />
+                  }
+                />
+              );
+            })}
           </div>
         )}
       </Card>

--- a/services/vault/src/components/simple/statusColors.ts
+++ b/services/vault/src/components/simple/statusColors.ts
@@ -1,0 +1,13 @@
+/**
+ * Shared dot color mappings for vault status badges.
+ *
+ * Maps display variant strings to Tailwind background classes
+ * used by VaultStatusBadge in pending deposit and withdraw cards.
+ */
+
+export const STATUS_DOT_COLORS = {
+  pending: "bg-warning-main",
+  active: "bg-success-main",
+  inactive: "bg-gray-400",
+  warning: "bg-error-main",
+} as const;

--- a/services/vault/src/config/polling.ts
+++ b/services/vault/src/config/polling.ts
@@ -1,0 +1,18 @@
+/**
+ * Shared polling configuration for vault provider RPC calls.
+ *
+ * Used by both pegin and pegout polling hooks to ensure
+ * consistent timeouts, intervals, and retry behavior.
+ */
+
+/** Timeout for a single RPC request to a vault provider (60 seconds) */
+export const RPC_TIMEOUT_MS = 60 * 1000;
+
+/** Interval between polling attempts (30 seconds) */
+export const POLLING_INTERVAL_MS = 30 * 1000;
+
+/** Number of retry attempts on query failure */
+export const POLLING_RETRY_COUNT = 3;
+
+/** Delay between retry attempts (5 seconds) */
+export const POLLING_RETRY_DELAY_MS = 5 * 1000;

--- a/services/vault/src/hooks/deposit/usePeginPollingQuery.ts
+++ b/services/vault/src/hooks/deposit/usePeginPollingQuery.ts
@@ -10,6 +10,12 @@ import { useEffect, useMemo, useRef } from "react";
 
 import { VaultProviderRpcApi } from "../../clients/vault-provider-rpc";
 import type { DepositorGraphTransactions } from "../../clients/vault-provider-rpc/types";
+import {
+  POLLING_INTERVAL_MS,
+  POLLING_RETRY_COUNT,
+  POLLING_RETRY_DELAY_MS,
+  RPC_TIMEOUT_MS,
+} from "../../config/polling";
 import { DaemonStatus } from "../../models/peginStateMachine";
 import type { PendingPeginRequest } from "../../storage/peginStorage";
 import type { ClaimerTransactions, VaultProvider } from "../../types";
@@ -25,15 +31,6 @@ import {
   groupDepositsByProvider,
   isTerminalPollingError,
 } from "../../utils/peginPolling";
-
-/** Timeout for RPC requests to vault provider (60 seconds) */
-const RPC_TIMEOUT_MS = 60 * 1000;
-/** Interval between polling attempts (30 seconds) */
-const POLLING_INTERVAL_MS = 30 * 1000;
-/** Number of retry attempts on failure */
-const POLLING_RETRY_COUNT = 3;
-/** Delay between retry attempts (5 seconds) */
-const POLLING_RETRY_DELAY_MS = 5 * 1000;
 
 interface UsePeginPollingQueryParams {
   activities: VaultActivity[];

--- a/services/vault/src/hooks/usePegoutPolling.ts
+++ b/services/vault/src/hooks/usePegoutPolling.ts
@@ -1,0 +1,194 @@
+/**
+ * Hook for polling pegout status from vault providers.
+ *
+ * Polls `vaultProvider_getPegoutStatus` for each redeemed vault,
+ * batching requests by vault provider. Stops polling when all
+ * vaults reach a terminal status (PayoutBroadcast or Failed).
+ */
+
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import { useEffect, useMemo, useRef } from "react";
+
+import type { RedeemedVaultInfo } from "@/applications/aave/hooks/useAaveVaults";
+import { VaultProviderRpcApi } from "@/clients/vault-provider-rpc";
+import type { GetPegoutStatusResponse } from "@/clients/vault-provider-rpc/types";
+import {
+  POLLING_INTERVAL_MS,
+  POLLING_RETRY_COUNT,
+  POLLING_RETRY_DELAY_MS,
+  RPC_TIMEOUT_MS,
+} from "@/config/polling";
+import {
+  getPegoutDisplayState,
+  PEGOUT_TERMINAL_STATUSES,
+  type PegoutDisplayState,
+} from "@/models/pegoutStateMachine";
+import type { VaultProvider } from "@/types";
+import { stripHexPrefix } from "@/utils/btc";
+
+export interface PegoutPollingResult {
+  displayState: PegoutDisplayState;
+  response?: GetPegoutStatusResponse;
+}
+
+interface VaultToPoll {
+  vault: RedeemedVaultInfo;
+  providerUrl: string;
+}
+
+interface VaultsByProvider {
+  providerUrl: string;
+  vaults: VaultToPoll[];
+}
+
+function groupVaultsByProvider(
+  vaults: RedeemedVaultInfo[],
+  findProvider: (address: string) => VaultProvider | undefined,
+): Map<string, VaultsByProvider> {
+  const grouped = new Map<string, VaultsByProvider>();
+
+  for (const vault of vaults) {
+    const provider = findProvider(vault.vaultProviderAddress);
+    if (!provider) {
+      console.warn(
+        `Provider ${vault.vaultProviderAddress} not found, skipping pegout poll for vault ${vault.id}`,
+      );
+      continue;
+    }
+
+    const existing = grouped.get(provider.url);
+    const entry: VaultToPoll = { vault, providerUrl: provider.url };
+
+    if (existing) {
+      existing.vaults.push(entry);
+    } else {
+      grouped.set(provider.url, {
+        providerUrl: provider.url,
+        vaults: [entry],
+      });
+    }
+  }
+
+  return grouped;
+}
+
+async function fetchPegoutStatusesFromProvider(
+  providerUrl: string,
+  vaults: VaultToPoll[],
+  results: Map<string, PegoutPollingResult>,
+): Promise<void> {
+  const rpcClient = new VaultProviderRpcApi(providerUrl, RPC_TIMEOUT_MS);
+
+  for (const { vault } of vaults) {
+    try {
+      const response = await rpcClient.getPegoutStatus({
+        pegin_txid: stripHexPrefix(vault.id),
+      });
+
+      const displayState = getPegoutDisplayState(
+        response.claimer?.status,
+        response.found,
+      );
+
+      results.set(vault.id, { displayState, response });
+    } catch (error) {
+      // VP unreachable or error — show "Initiating" gracefully, keep polling
+      console.warn(`Failed to poll pegout status for ${vault.id}:`, error);
+      results.set(vault.id, {
+        displayState: getPegoutDisplayState(undefined, false),
+      });
+    }
+  }
+}
+
+interface UsePegoutPollingParams {
+  redeemedVaults: RedeemedVaultInfo[];
+  findProvider: (address: string) => VaultProvider | undefined;
+}
+
+interface UsePegoutPollingResult {
+  pegoutStatuses: Map<string, PegoutPollingResult>;
+  isLoading: boolean;
+}
+
+export function usePegoutPolling({
+  redeemedVaults,
+  findProvider,
+}: UsePegoutPollingParams): UsePegoutPollingResult {
+  const vaultsRef = useRef(redeemedVaults);
+  const findProviderRef = useRef(findProvider);
+
+  useEffect(() => {
+    vaultsRef.current = redeemedVaults;
+    findProviderRef.current = findProvider;
+  }, [redeemedVaults, findProvider]);
+
+  const isEnabled = redeemedVaults.length > 0;
+
+  const queryKey = useMemo(
+    () => ["pegoutPolling", redeemedVaults.map((v) => v.id).join(",")],
+    [redeemedVaults],
+  );
+
+  const { data, isLoading } = useQuery({
+    queryKey,
+    queryFn: async (): Promise<Map<string, PegoutPollingResult>> => {
+      const currentVaults = vaultsRef.current;
+      const currentFindProvider = findProviderRef.current;
+
+      if (currentVaults.length === 0) {
+        return new Map();
+      }
+
+      const vaultsByProvider = groupVaultsByProvider(
+        currentVaults,
+        currentFindProvider,
+      );
+
+      const results = new Map<string, PegoutPollingResult>();
+
+      const fetchPromises = Array.from(vaultsByProvider.values()).map(
+        ({ providerUrl, vaults }) =>
+          fetchPegoutStatusesFromProvider(providerUrl, vaults, results),
+      );
+
+      await Promise.all(fetchPromises);
+
+      // Seed "Initiating" for vaults whose provider wasn't found (data inconsistency),
+      // so they're included in the terminal check and don't cause premature poll stop.
+      for (const vault of currentVaults) {
+        if (!results.has(vault.id)) {
+          results.set(vault.id, {
+            displayState: getPegoutDisplayState(undefined, false),
+          });
+        }
+      }
+
+      return results;
+    },
+    enabled: isEnabled,
+    staleTime: 0,
+    refetchInterval: (query) => {
+      const statusMap = query.state.data;
+      if (!statusMap || statusMap.size === 0) return POLLING_INTERVAL_MS;
+
+      // Stop polling when all vaults have reached a terminal status
+      const allTerminal = Array.from(statusMap.values()).every((result) => {
+        const claimerStatus = result.response?.claimer?.status;
+        return claimerStatus && PEGOUT_TERMINAL_STATUSES.has(claimerStatus);
+      });
+
+      return allTerminal ? false : POLLING_INTERVAL_MS;
+    },
+    retry: POLLING_RETRY_COUNT,
+    retryDelay: POLLING_RETRY_DELAY_MS,
+    placeholderData: keepPreviousData,
+  });
+
+  const pegoutStatuses = useMemo(() => {
+    if (!data) return new Map<string, PegoutPollingResult>();
+    return data;
+  }, [data]);
+
+  return { pegoutStatuses, isLoading };
+}

--- a/services/vault/src/models/pegoutStateMachine.ts
+++ b/services/vault/src/models/pegoutStateMachine.ts
@@ -1,0 +1,101 @@
+/**
+ * Pegout status lifecycle and display state mapping.
+ *
+ * Maps VP-reported pegout statuses (from `vaultProvider_getPegoutStatus`)
+ * to UI display labels, styling variants, and tooltip messages.
+ *
+ * Lifecycle:
+ *   ClaimEventReceived → ClaimBroadcast → AssertBroadcast → PayoutBroadcast (success)
+ *                                                          ↘ ChallengeAssertObserved → WronglyChallengedBroadcast → PayoutBroadcast
+ *                                                          ↘ ChallengeAssertObserved → Failed (challenger won)
+ */
+
+/** Claimer-side pegout statuses reported by the VP. */
+export enum ClaimerPegoutStatusValue {
+  CLAIM_EVENT_RECEIVED = "ClaimEventReceived",
+  CLAIM_BROADCAST = "ClaimBroadcast",
+  ASSERT_BROADCAST = "AssertBroadcast",
+  CHALLENGE_ASSERT_OBSERVED = "ChallengeAssertObserved",
+  WRONGLY_CHALLENGED_BROADCAST = "WronglyChallengedBroadcast",
+  PAYOUT_BROADCAST = "PayoutBroadcast",
+  FAILED = "Failed",
+}
+
+export type PegoutDisplayVariant = "pending" | "active" | "warning";
+
+export interface PegoutDisplayState {
+  label: string;
+  variant: PegoutDisplayVariant;
+  message: string;
+}
+
+/** Terminal statuses — polling should stop when reached. */
+export const PEGOUT_TERMINAL_STATUSES = new Set<string>([
+  ClaimerPegoutStatusValue.PAYOUT_BROADCAST,
+  ClaimerPegoutStatusValue.FAILED,
+]);
+
+const PEGOUT_STATUS_MAP: Record<string, PegoutDisplayState> = {
+  [ClaimerPegoutStatusValue.CLAIM_EVENT_RECEIVED]: {
+    label: "Processing",
+    variant: "pending",
+    message:
+      "Your withdrawal request has been received and is being processed.",
+  },
+  [ClaimerPegoutStatusValue.CLAIM_BROADCAST]: {
+    label: "Processing",
+    variant: "pending",
+    message:
+      "Your withdrawal is in progress. A transaction has been submitted to Bitcoin.",
+  },
+  [ClaimerPegoutStatusValue.ASSERT_BROADCAST]: {
+    label: "Confirming",
+    variant: "pending",
+    message:
+      "Waiting for Bitcoin network confirmations. This may take a few hours.",
+  },
+  [ClaimerPegoutStatusValue.CHALLENGE_ASSERT_OBSERVED]: {
+    label: "Under Review",
+    variant: "warning",
+    message:
+      "Your withdrawal is being reviewed for security. This may take additional time.",
+  },
+  [ClaimerPegoutStatusValue.WRONGLY_CHALLENGED_BROADCAST]: {
+    label: "Resuming",
+    variant: "pending",
+    message: "Security review passed. Your withdrawal is being finalized.",
+  },
+  [ClaimerPegoutStatusValue.PAYOUT_BROADCAST]: {
+    label: "BTC Sent",
+    variant: "active",
+    message: "Your BTC has been sent to your nominated address.",
+  },
+  [ClaimerPegoutStatusValue.FAILED]: {
+    label: "Failed",
+    variant: "warning",
+    message: "Withdrawal failed. Please contact support.",
+  },
+};
+
+const INITIATING_STATE: PegoutDisplayState = {
+  label: "Initiating",
+  variant: "pending",
+  message: "Your withdrawal is being prepared by the vault provider.",
+};
+
+/**
+ * Map VP pegout response to a UI display state.
+ *
+ * @param claimerStatus - The claimer status string from the VP (undefined if not found)
+ * @param found - Whether the VP has a record for this pegout
+ */
+export function getPegoutDisplayState(
+  claimerStatus: string | undefined,
+  found: boolean,
+): PegoutDisplayState {
+  if (!found || !claimerStatus) {
+    return INITIATING_STATE;
+  }
+
+  return PEGOUT_STATUS_MAP[claimerStatus] ?? INITIATING_STATE;
+}


### PR DESCRIPTION
- Poll each redeemed vault's pegout status from the vault provider via vaultProvider_getPegoutStatus RPC and display granular progress labels instead of a hardcoded "Withdrawing" badge
- Remove vaults from the pending withdraw list when the VP reports PayoutBroadcast (fast path) or when the indexer updates to DEPOSITOR_WITHDRAWN after btc-monitor detects the on-chain UTXO spend (definitive path)
- Keep the indexer polling active while redeemed vaults exist so the DEPOSITOR_WITHDRAWN transition gets picked up without a manual page refresh