### PR TITLE
feat(vault): show action-required pill in collapsed Pending Deposits card

### DIFF
--- a/services/vault/src/components/deposit/__tests__/actionStatus.test.ts
+++ b/services/vault/src/components/deposit/__tests__/actionStatus.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+
+import { ContractStatus, getPeginState } from "@/models/peginStateMachine";
+
+import type { DepositPollingResult } from "../../../context/deposit/PeginPollingContext";
+import { getSectionActionRequiredLabel } from "../actionStatus";
+
+function pollingResultWithAction(
+  depositId: string,
+  peginState: DepositPollingResult["peginState"],
+): DepositPollingResult {
+  return {
+    depositId,
+    transactions: null,
+    depositorGraph: null,
+    isReady: false,
+    loading: false,
+    error: null,
+    peginState,
+    isOwnedByCurrentWallet: true,
+    utxoUnavailable: false,
+  };
+}
+
+describe("getSectionActionRequiredLabel", () => {
+  it("returns null when no results", () => {
+    expect(getSectionActionRequiredLabel([])).toBeNull();
+  });
+
+  it("returns null when all results are undefined", () => {
+    expect(getSectionActionRequiredLabel([undefined, undefined])).toBeNull();
+  });
+
+  it("returns null when no deposit has an available action", () => {
+    const noActionState = getPeginState(ContractStatus.ACTIVE);
+    const results: (DepositPollingResult | undefined)[] = [
+      pollingResultWithAction("id1", noActionState),
+    ];
+    expect(getSectionActionRequiredLabel(results)).toBeNull();
+  });
+
+  it("returns Signing Required when one deposit needs signing", () => {
+    const signState = getPeginState(ContractStatus.PENDING, {
+      pendingIngestion: false,
+      transactionsReady: true,
+    });
+    const results: (DepositPollingResult | undefined)[] = [
+      pollingResultWithAction("id1", signState),
+    ];
+    expect(getSectionActionRequiredLabel(results)).toBe("Signing Required");
+  });
+
+  it("returns Broadcast required when one deposit needs broadcast", () => {
+    const broadcastState = getPeginState(ContractStatus.VERIFIED);
+    const results: (DepositPollingResult | undefined)[] = [
+      pollingResultWithAction("id1", broadcastState),
+    ];
+    expect(getSectionActionRequiredLabel(results)).toBe("Broadcast required");
+  });
+
+  it("returns Key required when one deposit needs lamport key", () => {
+    const keyState = getPeginState(ContractStatus.PENDING, {
+      needsLamportKey: true,
+    });
+    const results: (DepositPollingResult | undefined)[] = [
+      pollingResultWithAction("id1", keyState),
+    ];
+    expect(getSectionActionRequiredLabel(results)).toBe("Key required");
+  });
+
+  it("returns highest priority action when multiple deposits need different actions", () => {
+    const signState = getPeginState(ContractStatus.PENDING, {
+      pendingIngestion: false,
+      transactionsReady: true,
+    });
+    const keyState = getPeginState(ContractStatus.PENDING, {
+      needsLamportKey: true,
+    });
+    const results: (DepositPollingResult | undefined)[] = [
+      pollingResultWithAction("id1", keyState),
+      pollingResultWithAction("id2", signState),
+    ];
+    expect(getSectionActionRequiredLabel(results)).toBe("Signing Required");
+  });
+
+  it("skips undefined results and uses defined ones", () => {
+    const signState = getPeginState(ContractStatus.PENDING, {
+      pendingIngestion: false,
+      transactionsReady: true,
+    });
+    const results: (DepositPollingResult | undefined)[] = [
+      undefined,
+      pollingResultWithAction("id2", signState),
+    ];
+    expect(getSectionActionRequiredLabel(results)).toBe("Signing Required");
+  });
+});

--- a/services/vault/src/components/deposit/actionStatus.ts
+++ b/services/vault/src/components/deposit/actionStatus.ts
@@ -134,5 +134,44 @@ export function isArtifactDownloadAvailable(
   );
 }
 
+const ACTION_REQUIRED_BADGE_PRIORITY: PeginAction[] = [
+  PeginAction.SIGN_PAYOUT_TRANSACTIONS,
+  PeginAction.SIGN_AND_BROADCAST_TO_BITCOIN,
+  PeginAction.SUBMIT_LAMPORT_KEY,
+];
+
+const ACTION_REQUIRED_BADGE_LABELS: Record<PeginAction, string> = {
+  [PeginAction.SUBMIT_LAMPORT_KEY]: "Key required",
+  [PeginAction.SIGN_PAYOUT_TRANSACTIONS]: "Signing Required",
+  [PeginAction.SIGN_AND_BROADCAST_TO_BITCOIN]: "Broadcast required",
+  [PeginAction.NONE]: "",
+};
+
+export function getSectionActionRequiredLabel(
+  results: (DepositPollingResult | undefined)[],
+): string | null {
+  let highestPriorityAction: PeginAction | null = null;
+  for (const result of results) {
+    if (!result) continue;
+    const status = getActionStatus(result);
+    if (status.type !== "available") continue;
+    const action = status.action.action;
+    const currentRank = ACTION_REQUIRED_BADGE_PRIORITY.indexOf(action);
+    const existingRank =
+      highestPriorityAction === null
+        ? -1
+        : ACTION_REQUIRED_BADGE_PRIORITY.indexOf(highestPriorityAction);
+    if (currentRank >= 0 && (existingRank < 0 || currentRank < existingRank)) {
+      highestPriorityAction = action;
+    }
+  }
+  if (
+    highestPriorityAction === null ||
+    highestPriorityAction === PeginAction.NONE
+  )
+    return null;
+  return ACTION_REQUIRED_BADGE_LABELS[highestPriorityAction] ?? null;
+}
+
 // Re-export PeginAction for convenience
 export { PeginAction };

--- a/services/vault/src/components/simple/PendingDepositActionBadge.tsx
+++ b/services/vault/src/components/simple/PendingDepositActionBadge.tsx
@@ -1,0 +1,41 @@
+import { Chip } from "@babylonlabs-io/core-ui";
+import { useMemo } from "react";
+import { IoWarningOutline } from "react-icons/io5";
+
+import { getSectionActionRequiredLabel } from "@/components/deposit/actionStatus";
+import { usePeginPolling } from "@/context/deposit/PeginPollingContext";
+
+interface PendingDepositActionBadgeProps {
+  pendingActivityIds: string[];
+  isExpanded: boolean;
+}
+
+export function PendingDepositActionBadge({
+  pendingActivityIds,
+  isExpanded,
+}: PendingDepositActionBadgeProps) {
+  const { getPollingResult } = usePeginPolling();
+
+  const label = useMemo(() => {
+    if (isExpanded || pendingActivityIds.length === 0) return null;
+    const results = pendingActivityIds.map((id) => getPollingResult(id));
+    return getSectionActionRequiredLabel(results);
+  }, [getPollingResult, isExpanded, pendingActivityIds]);
+
+  if (label === null) return null;
+
+  return (
+    <Chip
+      className="inline-flex items-center gap-1.5 text-accent-primary"
+      role="status"
+      aria-label={`Action required: ${label}`}
+      title={`A pending deposit requires action: ${label}`}
+    >
+      <IoWarningOutline
+        className="h-4 w-4 flex-shrink-0 text-warning-main"
+        aria-hidden
+      />
+      {label}
+    </Chip>
+  );
+}

--- a/services/vault/src/components/simple/PendingDepositSection.tsx
+++ b/services/vault/src/components/simple/PendingDepositSection.tsx
@@ -18,6 +18,7 @@ import { PeginPollingProvider } from "@/context/deposit/PeginPollingContext";
 import { usePendingDeposits } from "@/hooks/usePendingDeposits";
 import { formatBtcAmount } from "@/utils/formatting";
 
+import { PendingDepositActionBadge } from "./PendingDepositActionBadge";
 import { PendingDepositCard } from "./PendingDepositCard";
 import { PendingDepositModals } from "./PendingDepositModals";
 
@@ -73,9 +74,9 @@ export function PendingDepositSection() {
 
         {/* Summary card */}
         <Card variant="filled" className="w-full">
-          {/* Summary row: BTC icon + total amount + expand toggle */}
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-2">
+          {/* Summary row: BTC icon + amount | action badge (when collapsed) + expand toggle */}
+          <div className="flex items-center justify-between gap-2">
+            <div className="flex min-w-0 flex-1 items-center gap-2">
               <Avatar
                 url={btcConfig.icon}
                 alt={btcConfig.coinSymbol}
@@ -85,11 +86,17 @@ export function PendingDepositSection() {
                 {formatBtcAmount(totalBtcAmount)}
               </span>
             </div>
-            <ExpandMenuButton
-              isExpanded={isExpanded}
-              onToggle={() => setIsExpanded((prev) => !prev)}
-              aria-label="Pending deposit details"
-            />
+            <div className="flex flex-shrink-0 items-center gap-2">
+              <PendingDepositActionBadge
+                pendingActivityIds={pendingActivities.map((a) => a.id)}
+                isExpanded={isExpanded}
+              />
+              <ExpandMenuButton
+                isExpanded={isExpanded}
+                onToggle={() => setIsExpanded((prev) => !prev)}
+                aria-label="Pending deposit details"
+              />
+            </div>
           </div>
 
           {/* Expanded deposit list */}


### PR DESCRIPTION

<img width="808" height="724" alt="Screenshot 2026-03-12 at 14 58 43" src="https://github.com/user-attachments/assets/03903bf4-8b79-4050-b8c5-4d8d3b1c20db" />

Adds an action-required pill (e.g. "Signing Required", "Key required", "Broadcast required") inside the collapsed Pending Deposits summary card when at least one deposit needs user action, so users can see it without expanding the section. Pill is rendered on the right of the card using core-ui `Chip` and hides when the section is expanded. Logic reuses `getActionStatus` and a new `getSectionActionRequiredLabel` helper with priority: Sign > Broadcast > Key.