### PR TITLE
feat(vault): adds atomic swap feature flag

### DIFF
--- a/services/vault/src/config/featureFlags.ts
+++ b/services/vault/src/config/featureFlags.ts
@@ -45,4 +45,15 @@ export default {
   get isSimplifiedTermsEnabled() {
     return process.env.NEXT_PUBLIC_FF_SIMPLIFIED_TERMS === "true";
   },
+
+  /**
+   * ATOMIC_SWAP_PEGIN feature flag
+   *
+   * Purpose: Controls whether the atomic swap pegin deposit flow is rendered
+   * Why needed: Allows gradual rollout of the new deposit flow while preserving the existing flow
+   * Default: false (existing deposit flow is rendered unless explicitly set to "true")
+   */
+  get isAtomicSwapPeginEnabled() {
+    return process.env.NEXT_PUBLIC_FF_ATOMIC_SWAP_PEGIN === "true";
+  },
 };


### PR DESCRIPTION
https://github.com/babylonlabs-io/babylon-toolkit/issues/1240

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new opt-in feature flag `isAtomicSwapPeginEnabled` to the vault's feature flag registry, gating the atomic swap pegin deposit flow behind `NEXT_PUBLIC_FF_ATOMIC_SWAP_PEGIN=true`. The change is minimal, well-documented inline, and consistent with the existing opt-in flag pattern established by `isSimplifiedTermsEnabled`.

**Key observations:**
- The implementation is correct — the flag safely defaults to `false`, so the existing deposit flow is unaffected until the env var is explicitly enabled.
- `README.md` is not updated: all other feature flags are documented in the `### Feature Flags` section of `services/vault/README.md`, but `NEXT_PUBLIC_FF_ATOMIC_SWAP_PEGIN` is missing from it. Consider adding an entry describing its purpose and how to enable it.
- The module-level comment (`"Default value for all feature flags is true"`) is outdated — both this flag and `isSimplifiedTermsEnabled` are opt-in (default `false`). Updating the comment to reflect both patterns would improve maintainability.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — the change is isolated to a single getter that defaults to `false`, so no existing functionality is affected.
- The change is a one-line getter addition following a well-established pattern in the codebase, with no side-effects and a safe default value. The only gaps are a missing README entry and a stale module comment, neither of which are blocking.
- No files require special attention beyond the minor documentation gaps noted above.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| services/vault/src/config/featureFlags.ts | Adds a new opt-in feature flag `isAtomicSwapPeginEnabled` (env var `NEXT_PUBLIC_FF_ATOMIC_SWAP_PEGIN`) defaulting to `false`; follows the same pattern as `isSimplifiedTermsEnabled`. Minor inconsistency with the module-level comment claiming all flags default to `true`. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Page renders deposit flow] --> B{isAtomicSwapPeginEnabled?}
    B -->|NEXT_PUBLIC_FF_ATOMIC_SWAP_PEGIN === 'true'| C[Render Atomic Swap Pegin deposit flow]
    B -->|env var unset or !== 'true'| D[Render existing deposit flow]
```

<sub>Last reviewed commit: 05dcf2d</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->