### PR TITLE
feat(sdk): partial liquidation comment improvements

### DIFF
--- a/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/__tests__/vaultSplit.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/__tests__/vaultSplit.test.ts
@@ -46,6 +46,16 @@ describe("vaultSplit", () => {
       expect(fraction).toBe(1);
     });
 
+    it("should return 1 when expectedHF is 0 (fully underwater)", () => {
+      const fraction = computeSeizedFraction(0.75, 1.05, 1.1, 0);
+      expect(fraction).toBe(1);
+    });
+
+    it("should return 1 when expectedHF is negative", () => {
+      const fraction = computeSeizedFraction(0.75, 1.05, 1.1, -0.5);
+      expect(fraction).toBe(1);
+    });
+
     it("should clamp to 0 when expectedHF >= THF", () => {
       // When expectedHF >= THF, (THF - expectedHF) <= 0, so fraction <= 0
       const fraction = computeSeizedFraction(0.75, 1.05, 1.1, 1.2);

--- a/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts
+++ b/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts
@@ -125,6 +125,11 @@ export function computeSeizedFraction(
   THF: number,
   expectedHF: number,
 ): number {
+  // HF ≤ 0 means position is fully underwater — full seizure
+  if (expectedHF <= 0) {
+    return 1;
+  }
+
   const liqPenalty = LB * CF;
 
   // If THF <= liq_penalty, full liquidation is inevitable
@@ -132,6 +137,8 @@ export function computeSeizedFraction(
     return 1;
   }
 
+  // Floating-point errors here are ~1e-15, negligible relative to the 5%
+  // safety margin applied by callers (computeOptimalSplit, checkRebalanceNeeded).
   const seizedFraction =
     (CF * (THF - expectedHF)) / (THF - liqPenalty) * (LB / expectedHF);
 
@@ -254,6 +261,11 @@ export function computeMinDepositForSplit(
 /**
  * Check if the sacrificial vault (index 0) needs to be increased to cover
  * the current target seizure amount.
+ *
+ * **Scope:** This function only checks whether the sacrificial vault's sizing
+ * is adequate. It does NOT detect whether a split exists — a single vault that
+ * exceeds the target coverage returns `needsRebalance: false`. Callers should
+ * check `vaultAmounts.length < 2` separately to detect unsplit positions.
  *
  * Used on position page load to detect when parameter changes (THF, CF, LB)
  * have made the current split insufficient.


### PR DESCRIPTION
@jrwbabylonlab additions for PR https://github.com/babylonlabs-io/babylon-toolkit/pull/1249

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts liquidation sizing math for `expectedHF <= 0`, which can change vault split/rebalance outcomes in edge cases and impacts liquidation-protection calculations.
> 
> **Overview**
> Updates Aave vault-splitting utilities to treat `expectedHF <= 0` as a fully underwater position, immediately returning a seized fraction of `1` (avoids divide-by-zero/invalid math) and adds unit tests for zero/negative `expectedHF`.
> 
> Clarifies `checkRebalanceNeeded` documentation to state it only validates sacrificial-vault coverage and does not detect whether a position is actually split (callers must check `vaultAmounts.length < 2`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2f623d408dec4e4b04c7ef54df40643736dc78b. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes targeted improvements to `computeSeizedFraction` and `checkRebalanceNeeded` in the partial-liquidation vault-split utility: it adds an early-return guard for `expectedHF ≤ 0`, improves inline documentation, and ships matching tests.

- **Guard for `expectedHF <= 0`** (`vaultSplit.ts` line 129–131): Without this guard, a zero or negative `expectedHF` would propagate through the formula as `LB / 0` (producing `Infinity`) or as a division by a negative value (producing a negative `seizedFraction` that gets clamped to `0`). Both outcomes are semantically wrong for a fully-underwater position; returning `1` (full seizure) is correct and now consistent with the existing `THF <= liqPenalty` path.
- **Floating-point comment** (`vaultSplit.ts` line 140–142): Correctly notes that the ~1e-15 rounding error from the multiply/divide chain is negligible compared to the 5 % safety margin applied by callers.
- **`checkRebalanceNeeded` scope note** (`vaultSplit.ts` lines 265–268): Clarifies a non-obvious invariant — the function only checks sacrificial-vault sizing, not whether a split exists — and guides callers to add the `vaultAmounts.length < 2` check themselves.
- **Tests** (`vaultSplit.test.ts` lines 49–57): Two new cases confirm `computeSeizedFraction` returns `1` for both `expectedHF = 0` and `expectedHF = -0.5`. Coverage of the guard in `computeOptimalSplit` / `checkRebalanceNeeded` is implicit through the shared `computeSeizedFraction` call.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — changes are additive, well-reasoned, and backed by explicit tests.
- All logic changes are guarded by a correct early-return, formula and clamping behavior are unchanged for valid inputs, and two targeted tests verify the new guard. No existing tests are modified and the rest of the test suite continues to exercise the original paths.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts | Adds an early-return guard for `expectedHF <= 0` to prevent a division-by-zero / semantically-wrong result, adds a floating-point precision comment, and expands the `checkRebalanceNeeded` JSDoc with a scope note. |
| packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/__tests__/vaultSplit.test.ts | Adds two test cases verifying the new `expectedHF <= 0` guard returns 1 for both the zero and negative cases; tests are well-placed and self-consistent. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["computeSeizedFraction(CF, LB, THF, expectedHF)"] --> B{"expectedHF <= 0?"}
    B -- "yes (NEW guard)" --> C["return 1 (full seizure)"]
    B -- no --> D{"THF <= LB × CF?"}
    D -- yes --> E["return 1 (full liquidation inevitable)"]
    D -- no --> F["seizedFraction = CF × (THF - expectedHF) / (THF - liqPenalty) × (LB / expectedHF)"]
    F --> G["return clamp(seizedFraction, 0, 1)"]
```

<sub>Last reviewed commit: b2f623d</sub>

<!-- /greptile_comment -->