### PR TITLE
feat(vault): communicate VP via proxy

### DIFF
--- a/services/vault/.env.example
+++ b/services/vault/.env.example
@@ -16,6 +16,7 @@ NEXT_PUBLIC_ETH_RPC_URL=https://ethereum-sepolia-rpc.publicnode.com
 
 # Vault Services
 NEXT_PUBLIC_TBV_GRAPHQL_ENDPOINT=https://babylon-vault-indexer-api.vault-devnet.babylonlabs.io
+NEXT_PUBLIC_TBV_VP_PROXY_URL=https://vault-provider-proxy-api.vault-devnet.babylonlabs.io
 
 # Ordinals API (optional)
 # Used as fallback for inscription detection when wallet doesn't support getInscriptions().

--- a/services/vault/src/components/deposit/ArtifactDownloadModal/index.tsx
+++ b/services/vault/src/components/deposit/ArtifactDownloadModal/index.tsx
@@ -15,7 +15,7 @@ interface ArtifactDownloadModalProps {
   open: boolean;
   onClose: () => void;
   onComplete: () => void;
-  providerUrl: string;
+  providerAddress: string;
   peginTxid: string;
   depositorPk: string;
 }
@@ -24,7 +24,7 @@ export function ArtifactDownloadModal({
   open,
   onClose,
   onComplete,
-  providerUrl,
+  providerAddress,
   peginTxid,
   depositorPk,
 }: ArtifactDownloadModalProps) {
@@ -32,7 +32,7 @@ export function ArtifactDownloadModal({
     useArtifactDownload();
 
   const handleDownload = () => {
-    download(providerUrl, peginTxid, depositorPk);
+    download(providerAddress, peginTxid, depositorPk);
   };
 
   const handleComplete = () => {

--- a/services/vault/src/components/deposit/PayoutSignModal/usePayoutSigningState.ts
+++ b/services/vault/src/components/deposit/PayoutSignModal/usePayoutSigningState.ts
@@ -128,7 +128,6 @@ export function usePayoutSigningState({
     const providers = {
       vaultProvider: {
         address: provider.id as Hex,
-        url: provider.url,
         btcPubKey: provider.btcPubKey,
       },
       vaultKeepers: vaultKeepers.map((vk) => ({ btcPubKey: vk.btcPubKey })),
@@ -166,7 +165,7 @@ export function usePayoutSigningState({
     try {
       // Prepare signing context (fetches vault data, resolves pubkeys)
       // Uses versioned keepers and challengers based on vault's locked versions
-      const { context, vaultProviderUrl } = await prepareSigningContext({
+      const { context, vaultProviderAddress } = await prepareSigningContext({
         peginTxId: activity.txHash!,
         depositorBtcPubkey: btcPublicKey,
         providers,
@@ -201,7 +200,7 @@ export function usePayoutSigningState({
 
       // Submit signatures to vault provider
       await submitSignaturesToVaultProvider(
-        vaultProviderUrl,
+        vaultProviderAddress,
         activity.txHash!,
         btcPublicKey,
         signatures,

--- a/services/vault/src/components/simple/DashboardPage.tsx
+++ b/services/vault/src/components/simple/DashboardPage.tsx
@@ -15,7 +15,6 @@ import { useAaveVaults } from "@/applications/aave/hooks";
 import type { Asset } from "@/applications/aave/types";
 import type { RootLayoutContext } from "@/components/pages/RootLayout";
 import { useConnection, useETHWallet } from "@/context/wallet";
-import { useVaultProviders } from "@/hooks/deposit/useVaultProviders";
 import { useDashboardState } from "@/hooks/useDashboardState";
 import { usePegoutPolling } from "@/hooks/usePegoutPolling";
 import { ClaimerPegoutStatusValue } from "@/models/pegoutStateMachine";
@@ -57,10 +56,8 @@ export function DashboardPage() {
   const { vaults: aaveVaults, redeemedVaults } = useAaveVaults(
     isConnected ? address : undefined,
   );
-  const { findProvider } = useVaultProviders();
   const { pegoutStatuses } = usePegoutPolling({
     redeemedVaults,
-    findProvider,
   });
 
   // Filter out vaults whose payout has been broadcast (terminal success).

--- a/services/vault/src/components/simple/DepositSignContent.tsx
+++ b/services/vault/src/components/simple/DepositSignContent.tsx
@@ -93,7 +93,7 @@ export function DepositSignContent({
           open={!!artifactDownloadInfo}
           onClose={handleClose}
           onComplete={continueAfterArtifactDownload}
-          providerUrl={artifactDownloadInfo.providerUrl}
+          providerAddress={artifactDownloadInfo.providerAddress}
           peginTxid={artifactDownloadInfo.peginTxid}
           depositorPk={artifactDownloadInfo.depositorPk}
         />

--- a/services/vault/src/components/simple/MultiVaultDepositSignContent.tsx
+++ b/services/vault/src/components/simple/MultiVaultDepositSignContent.tsx
@@ -126,7 +126,7 @@ export function MultiVaultDepositSignContent({
           open={!!artifactDownloadInfo}
           onClose={handleClose}
           onComplete={continueAfterArtifactDownload}
-          providerUrl={artifactDownloadInfo.providerUrl}
+          providerAddress={artifactDownloadInfo.providerAddress}
           peginTxid={artifactDownloadInfo.peginTxid}
           depositorPk={artifactDownloadInfo.depositorPk}
         />

--- a/services/vault/src/components/simple/PendingDepositSection.tsx
+++ b/services/vault/src/components/simple/PendingDepositSection.tsx
@@ -61,7 +61,6 @@ export function PendingDepositSection() {
       pendingPegins={pendingPegins}
       btcPublicKey={btcPublicKey}
       btcAddress={btcAddress}
-      vaultProviders={vaultProviders}
     >
       <div className="w-full space-y-6">
         {/* Header row */}
@@ -129,7 +128,7 @@ export function PendingDepositSection() {
           open={artifactDownloadModal.isOpen}
           onClose={artifactDownloadModal.handleClose}
           onComplete={artifactDownloadModal.handleComplete}
-          providerUrl={artifactDownloadModal.params.providerUrl}
+          providerAddress={artifactDownloadModal.params.providerAddress}
           peginTxid={artifactDownloadModal.params.peginTxid}
           depositorPk={artifactDownloadModal.params.depositorPk}
         />

--- a/services/vault/src/components/simple/ResumeDepositContent.tsx
+++ b/services/vault/src/components/simple/ResumeDepositContent.tsx
@@ -30,7 +30,6 @@ import {
 } from "@/services/lamport";
 import type { VaultActivity } from "@/types/activity";
 import type { ClaimerTransactions } from "@/types/rpc";
-import type { VaultProvider } from "@/types/vaultProvider";
 
 import { DepositProgressView } from "./DepositProgressView";
 
@@ -152,26 +151,16 @@ export function ResumeBroadcastContent({
 
 export interface ResumeLamportContentProps {
   activity: VaultActivity;
-  vaultProviders: VaultProvider[];
   onClose: () => void;
   onSuccess: () => void;
 }
 
-function resolveProviderUrl(
-  activity: VaultActivity,
-  vaultProviders: VaultProvider[],
-): string | null {
-  const providerAddress = activity.providers[0]?.id;
-  if (!providerAddress) return null;
-  const provider = vaultProviders.find(
-    (p) => p.id.toLowerCase() === providerAddress.toLowerCase(),
-  );
-  return provider?.url ?? null;
+function resolveProviderAddress(activity: VaultActivity): string | null {
+  return activity.providers[0]?.id ?? null;
 }
 
 export function ResumeLamportContent({
   activity,
-  vaultProviders,
   onClose,
   onSuccess,
 }: ResumeLamportContentProps) {
@@ -204,9 +193,9 @@ export function ResumeLamportContent({
       setError(null);
 
       try {
-        const providerUrl = resolveProviderUrl(activity, vaultProviders);
-        if (!providerUrl) {
-          throw new Error("Could not resolve vault provider URL");
+        const providerAddress = resolveProviderAddress(activity);
+        if (!providerAddress) {
+          throw new Error("Could not resolve vault provider address");
         }
 
         const btcTxid = activity.txHash ?? null;
@@ -229,7 +218,7 @@ export function ResumeLamportContent({
           btcTxid,
           depositorBtcPubkey: activity.depositorBtcPubkey,
           appContractAddress: activity.applicationController,
-          providerUrl,
+          providerAddress,
           getMnemonic: () => Promise.resolve(mnemonic),
         });
 
@@ -255,7 +244,7 @@ export function ResumeLamportContent({
         setError(msg);
       }
     },
-    [activity, vaultProviders, ethAddress, onSuccess],
+    [activity, ethAddress, onSuccess],
   );
 
   const handleRetry = useCallback(() => {

--- a/services/vault/src/components/simple/SimpleDeposit.tsx
+++ b/services/vault/src/components/simple/SimpleDeposit.tsx
@@ -307,7 +307,6 @@ export default function SimpleDeposit(props: SimpleDepositProps) {
             <div className="mx-auto w-full max-w-[520px]">
               <ResumeLamportContent
                 activity={props.activity}
-                vaultProviders={props.vaultProviders}
                 onClose={onClose}
                 onSuccess={props.onResumeSuccess}
               />

--- a/services/vault/src/config/env.ts
+++ b/services/vault/src/config/env.ts
@@ -19,6 +19,7 @@ interface EnvVars {
   GRAPHQL_ENDPOINT: string;
   SIDECAR_API_URL: string;
   BTC_PRICE_FEED: Address | undefined;
+  VP_PROXY_URL: string;
 }
 
 interface EnvValidationResult {
@@ -53,6 +54,12 @@ function validateEnvVars(): EnvValidationResult {
       process.env.NEXT_PUBLIC_TBV_SIDECAR_API_URL ?? ""
     ).replace(/\/$/, ""),
 
+    // Vault provider proxy (required)
+    VP_PROXY_URL: (process.env.NEXT_PUBLIC_TBV_VP_PROXY_URL ?? "").replace(
+      /\/$/,
+      "",
+    ),
+
     // Price feed oracle override (optional)
     BTC_PRICE_FEED: parseOptionalAddress(
       process.env.NEXT_PUBLIC_TBV_BTC_PRICE_FEED,
@@ -63,6 +70,7 @@ function validateEnvVars(): EnvValidationResult {
     "BTC_VAULTS_MANAGER",
     "AAVE_CONTROLLER",
     "GRAPHQL_ENDPOINT",
+    "VP_PROXY_URL",
   ] as const;
 
   const missingVars = requiredVars.filter(
@@ -75,6 +83,7 @@ function validateEnvVars(): EnvValidationResult {
       BTC_VAULTS_MANAGER: "NEXT_PUBLIC_TBV_BTC_VAULTS_MANAGER",
       AAVE_CONTROLLER: "NEXT_PUBLIC_TBV_AAVE_CONTROLLER",
       GRAPHQL_ENDPOINT: "NEXT_PUBLIC_TBV_GRAPHQL_ENDPOINT",
+      VP_PROXY_URL: "NEXT_PUBLIC_TBV_VP_PROXY_URL",
     };
 
     const missingVarNames = missingVars.map((key) => envVarMap[key] || key);
@@ -85,6 +94,7 @@ function validateEnvVars(): EnvValidationResult {
         AAVE_CONTROLLER: ZERO_ADDRESS,
         GRAPHQL_ENDPOINT: "",
         SIDECAR_API_URL: "",
+        VP_PROXY_URL: "",
         BTC_PRICE_FEED: undefined,
       },
       error: `Missing: ${missingVarNames.join(", ")}`,

--- a/services/vault/src/context/deposit/PeginPollingContext.tsx
+++ b/services/vault/src/context/deposit/PeginPollingContext.tsx
@@ -87,7 +87,6 @@ export function PeginPollingProvider({
   pendingPegins,
   btcPublicKey,
   btcAddress,
-  vaultProviders,
 }: PeginPollingProviderProps) {
   // Optimistic status overrides (for immediate UI feedback after signing)
   const [optimisticStatuses, setOptimisticStatuses] = useState<
@@ -107,7 +106,6 @@ export function PeginPollingProvider({
     activities,
     pendingPegins,
     btcPublicKey,
-    vaultProviders,
   });
 
   // Fetch UTXOs and recent transactions using React Query (cached with 30s staleTime)

--- a/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
@@ -311,6 +311,12 @@ vi.mock("@/context/ProtocolParamsContext", () => ({
   })),
 }));
 
+// Mock VP proxy URL builder
+vi.mock("@/utils/rpc", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/utils/rpc")>()),
+  getVpProxyUrl: (address: string) => `https://proxy.test/rpc/${address}`,
+}));
+
 // Mock vault provider RPC
 vi.mock("@/clients/vault-provider-rpc", () => {
   return {

--- a/services/vault/src/hooks/deposit/__tests__/useMultiVaultDepositFlow.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useMultiVaultDepositFlow.test.tsx
@@ -24,6 +24,11 @@ vi.mock("@/utils/depositorClaimValue", () => ({
   computeDepositorClaimValue: vi.fn().mockResolvedValue(35000n),
 }));
 
+vi.mock("@/utils/rpc", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/utils/rpc")>()),
+  getVpProxyUrl: (address: string) => `https://proxy.test/rpc/${address}`,
+}));
+
 // Mock SDK functions
 vi.mock("@babylonlabs-io/ts-sdk", () => ({
   pushTx: vi.fn(),
@@ -426,7 +431,7 @@ async function setupDefaultMocks() {
   });
   vi.mocked(pollAndPreparePayoutSigning).mockResolvedValue({
     context: {} as any,
-    vaultProviderUrl: "https://provider.test",
+    vaultProviderAddress: "0xProvider123",
     preparedTransactions: [
       {
         claimerPubkeyXOnly: "claimerpubkey",
@@ -1369,7 +1374,7 @@ describe("useMultiVaultDepositFlow", () => {
         .mockRejectedValueOnce(new Error("Payout fail vault 0"))
         .mockResolvedValueOnce({
           context: {} as any,
-          vaultProviderUrl: "https://provider.test",
+          vaultProviderAddress: "0xProvider123",
           preparedTransactions: [
             {
               claimerPubkeyXOnly: "claimerpubkey",

--- a/services/vault/src/hooks/deposit/depositFlowSteps/lamportSubmission.ts
+++ b/services/vault/src/hooks/deposit/depositFlowSteps/lamportSubmission.ts
@@ -24,6 +24,7 @@ import {
 } from "@/services/lamport";
 import { waitForPeginStatus } from "@/services/vault/vaultPeginStatusService";
 import { stripHexPrefix } from "@/utils/btc";
+import { getVpProxyUrl } from "@/utils/rpc";
 
 import type { LamportSubmissionParams } from "./types";
 
@@ -72,7 +73,7 @@ export async function submitLamportPublicKey(
     btcTxid,
     depositorBtcPubkey,
     appContractAddress,
-    providerUrl,
+    providerAddress,
     getMnemonic,
     signal,
   } = params;
@@ -81,7 +82,7 @@ export async function submitLamportPublicKey(
 
   // Wait until VP has ingested the pegin and is ready for the Lamport key.
   const status = await waitForPeginStatus({
-    providerUrl,
+    providerAddress,
     btcTxid,
     targetStatuses: TARGET_STATUSES,
     timeoutMs: STATUS_POLL_TIMEOUT_MS,
@@ -113,7 +114,10 @@ export async function submitLamportPublicKey(
 
   signal?.throwIfAborted();
 
-  const rpcClient = new VaultProviderRpcApi(providerUrl, RPC_TIMEOUT_MS);
+  const rpcClient = new VaultProviderRpcApi(
+    getVpProxyUrl(providerAddress),
+    RPC_TIMEOUT_MS,
+  );
 
   await rpcClient.submitDepositorLamportKey({
     pegin_txid: stripHexPrefix(btcTxid),

--- a/services/vault/src/hooks/deposit/depositFlowSteps/payoutSigning.ts
+++ b/services/vault/src/hooks/deposit/depositFlowSteps/payoutSigning.ts
@@ -21,6 +21,7 @@ import {
 import { waitForPeginStatus } from "@/services/vault/vaultPeginStatusService";
 import { updatePendingPeginStatus } from "@/storage/peginStorage";
 import { stripHexPrefix } from "@/utils/btc";
+import { getVpProxyUrl } from "@/utils/rpc";
 
 import type { PayoutSigningContext, PayoutSigningParams } from "./types";
 
@@ -57,7 +58,7 @@ export async function pollAndPreparePayoutSigning(
     btcTxid,
     btcTxHex,
     depositorBtcPubkey,
-    providerUrl,
+    providerAddress,
     providerBtcPubKey,
     vaultKeepers,
     universalChallengers,
@@ -67,7 +68,7 @@ export async function pollAndPreparePayoutSigning(
 
   // Phase 1: Poll status until VP is ready for depositor signatures
   await waitForPeginStatus({
-    providerUrl,
+    providerAddress,
     btcTxid,
     targetStatuses: TARGET_STATUS,
     timeoutMs: MAX_POLLING_TIMEOUT_MS,
@@ -75,7 +76,10 @@ export async function pollAndPreparePayoutSigning(
   });
 
   // Phase 2: Fetch transaction data (VP is ready)
-  const rpcClient = new VaultProviderRpcApi(providerUrl, RPC_TIMEOUT_MS);
+  const rpcClient = new VaultProviderRpcApi(
+    getVpProxyUrl(providerAddress),
+    RPC_TIMEOUT_MS,
+  );
   const response = await rpcClient.requestDepositorPresignTransactions({
     pegin_txid: stripHexPrefix(btcTxid),
     depositor_pk: stripHexPrefix(depositorBtcPubkey),
@@ -97,7 +101,7 @@ export async function pollAndPreparePayoutSigning(
 
   return {
     context,
-    vaultProviderUrl: providerUrl,
+    vaultProviderAddress: providerAddress,
     preparedTransactions: prepareTransactionsForSigning(response.txs),
     depositorGraph: response.depositor_graph,
   };
@@ -107,7 +111,7 @@ export async function pollAndPreparePayoutSigning(
  * Submit payout signatures to vault provider.
  */
 export async function submitPayoutSignatures(
-  vaultProviderUrl: string,
+  vaultProviderAddress: string,
   btcTxid: string,
   depositorBtcPubkey: string,
   signatures: Record<string, ClaimerSignatures>,
@@ -115,7 +119,7 @@ export async function submitPayoutSignatures(
   depositorClaimerPresignatures: DepositorAsClaimerPresignatures,
 ): Promise<void> {
   await submitSignaturesToVaultProvider(
-    vaultProviderUrl,
+    vaultProviderAddress,
     btcTxid,
     depositorBtcPubkey,
     signatures,

--- a/services/vault/src/hooks/deposit/depositFlowSteps/types.ts
+++ b/services/vault/src/hooks/deposit/depositFlowSteps/types.ts
@@ -126,7 +126,7 @@ export interface LamportSubmissionParams {
   btcTxid: string;
   depositorBtcPubkey: string;
   appContractAddress: string;
-  providerUrl: string;
+  providerAddress: string;
   getMnemonic: () => Promise<string>;
   signal?: AbortSignal;
 }
@@ -140,7 +140,7 @@ export interface PayoutSigningParams {
   /** The pegin transaction hex from step 2 - used for signing context */
   btcTxHex: string;
   depositorBtcPubkey: string;
-  providerUrl: string;
+  providerAddress: string;
   providerBtcPubKey: string;
   vaultKeepers: Array<{ btcPubKey: string }>;
   universalChallengers: Array<{ btcPubKey: string }>;
@@ -152,7 +152,7 @@ export interface PayoutSigningParams {
 
 export interface PayoutSigningContext {
   context: SigningContext;
-  vaultProviderUrl: string;
+  vaultProviderAddress: string;
   preparedTransactions: PreparedTransaction[];
   depositorGraph: DepositorGraphTransactions;
 }

--- a/services/vault/src/hooks/deposit/useArtifactDownload.ts
+++ b/services/vault/src/hooks/deposit/useArtifactDownload.ts
@@ -21,7 +21,7 @@ export function useArtifactDownload() {
   });
 
   const download = useCallback(
-    async (providerUrl: string, peginTxid: string, depositorPk: string) => {
+    async (providerAddress: string, peginTxid: string, depositorPk: string) => {
       setState({
         loading: true,
         progress: "Fetching artifacts from vault provider...",
@@ -31,7 +31,7 @@ export function useArtifactDownload() {
 
       try {
         const artifacts = await fetchDepositorArtifacts(
-          providerUrl,
+          providerAddress,
           peginTxid,
           depositorPk,
         );

--- a/services/vault/src/hooks/deposit/useArtifactDownloadModal.ts
+++ b/services/vault/src/hooks/deposit/useArtifactDownloadModal.ts
@@ -1,51 +1,46 @@
 import { useCallback, useMemo, useState } from "react";
 
-import type { VaultProvider } from "../../types";
 import type { VaultActivity } from "../../types/activity";
 
 export interface ArtifactDownloadModalParams {
-  providerUrl: string;
+  providerAddress: string;
   peginTxid: string;
   depositorPk: string;
 }
 
 function getArtifactParams(
   activity: VaultActivity,
-  findProvider: (address: string) => VaultProvider | undefined,
 ): ArtifactDownloadModalParams | null {
-  const providerId = activity.providers?.[0]?.id;
-  const provider = providerId ? findProvider(providerId) : undefined;
-  const providerUrl = provider?.url;
+  const providerAddress = activity.providers?.[0]?.id;
   const peginTxid = activity.txHash || activity.id;
   const depositorPk = activity.depositorBtcPubkey;
 
-  if (!providerUrl || !peginTxid || !depositorPk) {
+  if (!providerAddress || !peginTxid || !depositorPk) {
     return null;
   }
-  return { providerUrl, peginTxid, depositorPk };
+  return { providerAddress, peginTxid, depositorPk };
 }
 
 export function useArtifactDownloadModal(options: {
   allActivities: VaultActivity[];
-  findProvider: (address: string) => VaultProvider | undefined;
   onSuccess?: () => void;
 }) {
-  const { allActivities, findProvider, onSuccess } = options;
+  const { allActivities, onSuccess } = options;
   const [activity, setActivity] = useState<VaultActivity | null>(null);
 
   const params = useMemo((): ArtifactDownloadModalParams | null => {
     if (!activity) return null;
-    return getArtifactParams(activity, findProvider);
-  }, [activity, findProvider]);
+    return getArtifactParams(activity);
+  }, [activity]);
 
   const handleArtifactDownloadClick = useCallback(
     (depositId: string) => {
       const found = allActivities.find((a) => a.id === depositId);
-      if (found && getArtifactParams(found, findProvider)) {
+      if (found && getArtifactParams(found)) {
         setActivity(found);
       }
     },
-    [allActivities, findProvider],
+    [allActivities],
   );
 
   const handleClose = useCallback(() => {

--- a/services/vault/src/hooks/deposit/useDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useDepositFlow.ts
@@ -67,7 +67,7 @@ export interface UseDepositFlowParams {
 }
 
 export interface ArtifactDownloadInfo {
-  providerUrl: string;
+  providerAddress: string;
   peginTxid: string;
   depositorPk: string;
 }
@@ -280,8 +280,8 @@ export function useDepositFlow(
         setIsWaiting(true);
 
         const provider = findProvider(selectedProviders[0] as Hex);
-        if (!provider?.url) {
-          throw new Error("Vault provider not found or has no RPC URL");
+        if (!provider) {
+          throw new Error("Vault provider not found");
         }
 
         // Step 2.5: Submit full Lamport PK to vault provider via RPC
@@ -290,7 +290,7 @@ export function useDepositFlow(
             btcTxid: registration.btcTxid,
             depositorBtcPubkey: prepared.depositorBtcPubkey,
             appContractAddress: selectedApplication,
-            providerUrl: provider.url,
+            providerAddress: provider.id,
             getMnemonic,
             signal,
           });
@@ -309,14 +309,14 @@ export function useDepositFlow(
 
         const {
           context,
-          vaultProviderUrl,
+          vaultProviderAddress,
           preparedTransactions,
           depositorGraph,
         } = await pollAndPreparePayoutSigning({
           btcTxid: registration.btcTxid,
           btcTxHex: prepared.btcTxHex,
           depositorBtcPubkey: prepared.depositorBtcPubkey,
-          providerUrl: provider.url,
+          providerAddress: provider.id,
           providerBtcPubKey: provider.btcPubKey,
           vaultKeepers: vaultKeepers.map((vk) => ({
             btcPubKey: vk.btcPubKey,
@@ -354,7 +354,7 @@ export function useDepositFlow(
           });
 
         await submitPayoutSignatures(
-          vaultProviderUrl,
+          vaultProviderAddress,
           registration.btcTxid,
           prepared.depositorBtcPubkey,
           signatures,
@@ -365,7 +365,7 @@ export function useDepositFlow(
 
         setCurrentStep(DepositFlowStep.ARTIFACT_DOWNLOAD);
         setArtifactDownloadInfo({
-          providerUrl: provider.url,
+          providerAddress: provider.id,
           peginTxid: registration.btcTxid,
           depositorPk: prepared.depositorBtcPubkey,
         });

--- a/services/vault/src/hooks/deposit/useMultiVaultDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useMultiVaultDepositFlow.ts
@@ -102,7 +102,7 @@ export interface UseMultiVaultDepositFlowParams {
 }
 
 export interface ArtifactDownloadInfo {
-  providerUrl: string;
+  providerAddress: string;
   peginTxid: string;
   depositorPk: string;
 }
@@ -688,8 +688,8 @@ export function useMultiVaultDepositFlow(
         // ========================================================================
 
         const provider = findProvider(primaryProvider as Hex);
-        if (!provider?.url) {
-          throw new Error("Vault provider has no RPC URL");
+        if (!provider) {
+          throw new Error("Vault provider not found");
         }
 
         for (const result of successfulPegins) {
@@ -698,7 +698,7 @@ export function useMultiVaultDepositFlow(
               btcTxid: result.vaultId,
               depositorBtcPubkey: result.depositorBtcPubkey,
               appContractAddress: selectedApplication,
-              providerUrl: provider.url,
+              providerAddress: provider.id,
               getMnemonic,
               signal,
             });
@@ -732,14 +732,14 @@ export function useMultiVaultDepositFlow(
             setIsWaiting(true);
             const {
               context,
-              vaultProviderUrl,
+              vaultProviderAddress,
               preparedTransactions,
               depositorGraph,
             } = await pollAndPreparePayoutSigning({
               btcTxid: result.vaultId, // Use vaultId for payout lookup
               btcTxHex: result.btcTxHex,
               depositorBtcPubkey: result.depositorBtcPubkey,
-              providerUrl: provider.url,
+              providerAddress: provider.id,
               providerBtcPubKey: provider.btcPubKey,
               vaultKeepers,
               universalChallengers: universalChallengerBtcPubkeys.map(
@@ -779,7 +779,7 @@ export function useMultiVaultDepositFlow(
 
             // Submit signatures
             await submitPayoutSignatures(
-              vaultProviderUrl,
+              vaultProviderAddress,
               result.vaultId,
               result.depositorBtcPubkey,
               signatures,
@@ -801,7 +801,7 @@ export function useMultiVaultDepositFlow(
                   context:
                     "[Multi-Vault] Failed to sign or submit payouts for vault",
                   vaultId: result.vaultId,
-                  providerUrl: provider.url,
+                  providerAddress: provider.id,
                 },
               },
             );
@@ -821,7 +821,7 @@ export function useMultiVaultDepositFlow(
           if (signal.aborted) break;
 
           setArtifactDownloadInfo({
-            providerUrl: provider.url,
+            providerAddress: provider.id,
             peginTxid: result.vaultId,
             depositorPk: result.depositorBtcPubkey,
           });

--- a/services/vault/src/hooks/deposit/usePeginPollingQuery.ts
+++ b/services/vault/src/hooks/deposit/usePeginPollingQuery.ts
@@ -20,7 +20,7 @@ import {
 } from "../../config/polling";
 import { DaemonStatus } from "../../models/peginStateMachine";
 import type { PendingPeginRequest } from "../../storage/peginStorage";
-import type { ClaimerTransactions, VaultProvider } from "../../types";
+import type { ClaimerTransactions } from "../../types";
 import type { VaultActivity } from "../../types/activity";
 import type {
   DepositsByProvider,
@@ -38,7 +38,6 @@ interface UsePeginPollingQueryParams {
   activities: VaultActivity[];
   pendingPegins: PendingPeginRequest[];
   btcPublicKey?: string;
-  vaultProviders: VaultProvider[];
 }
 
 /** Result from polling query */
@@ -183,7 +182,6 @@ export function usePeginPollingQuery({
   activities,
   pendingPegins,
   btcPublicKey,
-  vaultProviders,
 }: UsePeginPollingQueryParams): UsePeginPollingQueryResult {
   // Identify deposits that need polling
   const depositsToPoll = useMemo(
@@ -193,22 +191,18 @@ export function usePeginPollingQuery({
 
   // Use refs to access latest values in queryFn without stale closures
   const depositsRef = useRef(depositsToPoll);
-  const providersRef = useRef(vaultProviders);
   const btcPubKeyRef = useRef(btcPublicKey);
 
   // Keep refs updated
   useEffect(() => {
     depositsRef.current = depositsToPoll;
-    providersRef.current = vaultProviders;
     btcPubKeyRef.current = btcPublicKey;
-  }, [depositsToPoll, vaultProviders, btcPublicKey]);
+  }, [depositsToPoll, btcPublicKey]);
 
   // Only enable when all required data is ready:
   // - btcPublicKey from wallet
   // - deposits to poll (pending deposits)
-  // - vault providers loaded (needed for RPC URLs)
-  const isEnabled =
-    !!btcPublicKey && depositsToPoll.length > 0 && vaultProviders.length > 0;
+  const isEnabled = !!btcPublicKey && depositsToPoll.length > 0;
 
   const { data, isLoading, refetch } = useQuery({
     queryKey: [
@@ -218,7 +212,6 @@ export function usePeginPollingQuery({
     ],
     queryFn: async (): Promise<PollingQueryData> => {
       const currentDeposits = depositsRef.current;
-      const currentProviders = providersRef.current;
       const currentBtcPubKey = btcPubKeyRef.current;
 
       if (!currentBtcPubKey || currentDeposits.length === 0) {
@@ -232,10 +225,7 @@ export function usePeginPollingQuery({
       }
 
       // Group by provider using current values
-      const depositsByProvider = groupDepositsByProvider(
-        currentDeposits,
-        currentProviders,
-      );
+      const depositsByProvider = groupDepositsByProvider(currentDeposits);
 
       const transactions = new Map<string, ClaimerTransactions[]>();
       const depositorGraphs = new Map<string, DepositorGraphTransactions>();

--- a/services/vault/src/hooks/usePegoutPolling.ts
+++ b/services/vault/src/hooks/usePegoutPolling.ts
@@ -24,8 +24,8 @@ import {
   PEGOUT_TERMINAL_STATUSES,
   type PegoutDisplayState,
 } from "@/models/pegoutStateMachine";
-import type { VaultProvider } from "@/types";
 import { stripHexPrefix } from "@/utils/btc";
+import { getVpProxyUrl } from "@/utils/rpc";
 
 export interface PegoutPollingResult {
   displayState: PegoutDisplayState;
@@ -44,27 +44,26 @@ interface VaultsByProvider {
 
 function groupVaultsByProvider(
   vaults: RedeemedVaultInfo[],
-  findProvider: (address: string) => VaultProvider | undefined,
 ): Map<string, VaultsByProvider> {
   const grouped = new Map<string, VaultsByProvider>();
 
   for (const vault of vaults) {
-    const provider = findProvider(vault.vaultProviderAddress);
-    if (!provider) {
+    const providerAddress = vault.vaultProviderAddress;
+    if (!providerAddress || !providerAddress.startsWith("0x")) {
       logger.warn(
-        `Provider ${vault.vaultProviderAddress} not found, skipping pegout poll for vault ${vault.id}`,
+        `Invalid or missing provider address for vault ${vault.id}, skipping pegout poll`,
       );
       continue;
     }
-
-    const existing = grouped.get(provider.url);
-    const entry: VaultToPoll = { vault, providerUrl: provider.url };
+    const providerUrl = getVpProxyUrl(providerAddress);
+    const existing = grouped.get(providerAddress);
+    const entry: VaultToPoll = { vault, providerUrl };
 
     if (existing) {
       existing.vaults.push(entry);
     } else {
-      grouped.set(provider.url, {
-        providerUrl: provider.url,
+      grouped.set(providerAddress, {
+        providerUrl,
         vaults: [entry],
       });
     }
@@ -105,7 +104,6 @@ async function fetchPegoutStatusesFromProvider(
 
 interface UsePegoutPollingParams {
   redeemedVaults: RedeemedVaultInfo[];
-  findProvider: (address: string) => VaultProvider | undefined;
 }
 
 interface UsePegoutPollingResult {
@@ -115,15 +113,12 @@ interface UsePegoutPollingResult {
 
 export function usePegoutPolling({
   redeemedVaults,
-  findProvider,
 }: UsePegoutPollingParams): UsePegoutPollingResult {
   const vaultsRef = useRef(redeemedVaults);
-  const findProviderRef = useRef(findProvider);
 
   useEffect(() => {
     vaultsRef.current = redeemedVaults;
-    findProviderRef.current = findProvider;
-  }, [redeemedVaults, findProvider]);
+  }, [redeemedVaults]);
 
   const isEnabled = redeemedVaults.length > 0;
 
@@ -136,16 +131,12 @@ export function usePegoutPolling({
     queryKey,
     queryFn: async (): Promise<Map<string, PegoutPollingResult>> => {
       const currentVaults = vaultsRef.current;
-      const currentFindProvider = findProviderRef.current;
 
       if (currentVaults.length === 0) {
         return new Map();
       }
 
-      const vaultsByProvider = groupVaultsByProvider(
-        currentVaults,
-        currentFindProvider,
-      );
+      const vaultsByProvider = groupVaultsByProvider(currentVaults);
 
       const results = new Map<string, PegoutPollingResult>();
 

--- a/services/vault/src/hooks/usePendingDeposits.ts
+++ b/services/vault/src/hooks/usePendingDeposits.ts
@@ -6,7 +6,7 @@
  * sign/broadcast actions on pending deposits.
  */
 
-import { useCallback, useMemo } from "react";
+import { useMemo } from "react";
 import type { Address } from "viem";
 
 import { useBTCWallet, useETHWallet } from "@/context/wallet";
@@ -56,15 +56,8 @@ export function usePendingDeposits() {
     onSuccess: refetchActivities,
   });
 
-  const findProvider = useCallback(
-    (id: string) =>
-      vaultProviders.find((p) => p.id.toLowerCase() === id.toLowerCase()),
-    [vaultProviders],
-  );
-
   const artifactDownloadModal = useArtifactDownloadModal({
     allActivities: activities,
-    findProvider,
     onSuccess: refetchActivities,
   });
 

--- a/services/vault/src/services/artifacts/artifactDownloadService.ts
+++ b/services/vault/src/services/artifacts/artifactDownloadService.ts
@@ -9,6 +9,7 @@
 import { VaultProviderRpcApi } from "@/clients/vault-provider-rpc";
 import type { RequestDepositorClaimerArtifactsResponse } from "@/clients/vault-provider-rpc/types";
 import { stripHexPrefix } from "@/utils/btc";
+import { getVpProxyUrl } from "@/utils/rpc";
 
 /** Timeout for the artifact request RPC call (artifacts can be large). */
 const RPC_TIMEOUT_MS = 120 * 1000;
@@ -16,17 +17,20 @@ const RPC_TIMEOUT_MS = 120 * 1000;
 /**
  * Request the depositor-as-claimer artifacts from the vault provider.
  *
- * @param providerUrl - Base URL of the vault provider RPC endpoint.
- * @param peginTxid   - Bitcoin pegin transaction ID (hex, with or without 0x prefix).
- * @param depositorPk - Depositor's Bitcoin public key.
+ * @param providerAddress - Vault provider's Ethereum address.
+ * @param peginTxid       - Bitcoin pegin transaction ID (hex, with or without 0x prefix).
+ * @param depositorPk     - Depositor's Bitcoin public key.
  * @returns The artifact payload containing BaBe session data and challenger info.
  */
 export async function fetchDepositorArtifacts(
-  providerUrl: string,
+  providerAddress: string,
   peginTxid: string,
   depositorPk: string,
 ): Promise<RequestDepositorClaimerArtifactsResponse> {
-  const rpcClient = new VaultProviderRpcApi(providerUrl, RPC_TIMEOUT_MS);
+  const rpcClient = new VaultProviderRpcApi(
+    getVpProxyUrl(providerAddress),
+    RPC_TIMEOUT_MS,
+  );
   return rpcClient.requestDepositorClaimerArtifacts({
     pegin_txid: stripHexPrefix(peginTxid),
     depositor_pk: depositorPk,

--- a/services/vault/src/services/vault/__tests__/vaultPayoutSignatureService.test.ts
+++ b/services/vault/src/services/vault/__tests__/vaultPayoutSignatureService.test.ts
@@ -63,7 +63,6 @@ describe("vaultPayoutSignatureService", () => {
       claimerTransactions: [createClaimerTransactions("abc")],
       vaultProvider: {
         address: "0x123" as `0x${string}`,
-        url: "http://localhost:8080",
       },
       vaultKeepers: [{ btcPubKey: "0xabc" }],
       universalChallengers: [{ btcPubKey: "0xdef" }],
@@ -110,16 +109,7 @@ describe("vaultPayoutSignatureService", () => {
       expect(() =>
         validatePayoutSignatureParams({
           ...validParams,
-          vaultProvider: { url: "http://localhost" } as any,
-        }),
-      ).toThrow("Invalid vaultProvider");
-    });
-
-    it("should throw for missing vaultProvider url", () => {
-      expect(() =>
-        validatePayoutSignatureParams({
-          ...validParams,
-          vaultProvider: { address: "0x123" as `0x${string}` } as any,
+          vaultProvider: {} as any,
         }),
       ).toThrow("Invalid vaultProvider");
     });

--- a/services/vault/src/services/vault/vaultPayoutSignatureService.ts
+++ b/services/vault/src/services/vault/vaultPayoutSignatureService.ts
@@ -15,6 +15,7 @@ import {
   stripHexPrefix,
   validateXOnlyPubkey,
 } from "../../utils/btc";
+import { getVpProxyUrl } from "../../utils/rpc";
 import { fetchVaultKeepersByVersion } from "../providers/fetchProviders";
 
 import { fetchVaultProviderById } from "./fetchVaultProviders";
@@ -24,8 +25,6 @@ import { fetchVaultById } from "./fetchVaults";
 export interface PayoutVaultProvider {
   /** Provider's Ethereum address */
   address: Hex;
-  /** Provider's RPC URL */
-  url: string;
   /** Provider's BTC public key (optional - will be fetched if not provided) */
   btcPubKey?: string;
 }
@@ -64,7 +63,7 @@ export interface PrepareSigningContextParams {
 
 export interface PreparedSigningData {
   context: SigningContext;
-  vaultProviderUrl: string;
+  vaultProviderAddress: Hex;
 }
 
 /**
@@ -97,10 +96,8 @@ export function validatePayoutSignatureParams(params: {
     throw new Error("Invalid claimerTransactions: must be a non-empty array");
   }
 
-  if (!vaultProvider?.address || !vaultProvider?.url) {
-    throw new Error(
-      "Invalid vaultProvider: must have address and url properties",
-    );
+  if (!vaultProvider?.address) {
+    throw new Error("Invalid vaultProvider: must have an address");
   }
 
   if (!vaultKeepers || vaultKeepers.length === 0) {
@@ -154,13 +151,16 @@ export function getSortedUniversalChallengerPubkeys(
  * Submit payout signatures to vault provider RPC.
  */
 export async function submitSignaturesToVaultProvider(
-  vaultProviderUrl: string,
+  vaultProviderAddress: string,
   peginTxId: string,
   depositorBtcPubkey: string,
   signatures: Record<string, ClaimerSignatures>,
   depositorClaimerPresignatures: DepositorAsClaimerPresignatures,
 ): Promise<void> {
-  const rpcClient = new VaultProviderRpcApi(vaultProviderUrl, 30000);
+  const rpcClient = new VaultProviderRpcApi(
+    getVpProxyUrl(vaultProviderAddress),
+    30000,
+  );
 
   // The VP expects signatures for ALL claimers (VP + VKs + depositor).
   // The depositor's own payout signature comes from depositorClaimerPresignatures
@@ -326,7 +326,7 @@ export async function prepareSigningContext(
 
   return {
     context: signingContext,
-    vaultProviderUrl: vaultProvider.url,
+    vaultProviderAddress: vaultProvider.address,
   };
 }
 

--- a/services/vault/src/services/vault/vaultPeginStatusService.ts
+++ b/services/vault/src/services/vault/vaultPeginStatusService.ts
@@ -9,6 +9,7 @@
 import { VaultProviderRpcApi } from "@/clients/vault-provider-rpc";
 import { pollUntil } from "@/utils/async";
 import { stripHexPrefix } from "@/utils/btc";
+import { getVpProxyUrl } from "@/utils/rpc";
 
 /** Timeout for RPC requests (60 seconds) */
 const RPC_TIMEOUT_MS = 60 * 1000;
@@ -17,8 +18,8 @@ const RPC_TIMEOUT_MS = 60 * 1000;
 const DEFAULT_POLL_INTERVAL_MS = 10 * 1000;
 
 export interface WaitForPeginStatusParams {
-  /** Vault provider RPC URL */
-  providerUrl: string;
+  /** Vault provider Ethereum address */
+  providerAddress: string;
   /** BTC transaction ID (with or without 0x prefix) */
   btcTxid: string;
   /** Set of acceptable statuses — polling stops when the VP reports one of these */
@@ -42,7 +43,7 @@ export async function waitForPeginStatus(
   params: WaitForPeginStatusParams,
 ): Promise<string> {
   const {
-    providerUrl,
+    providerAddress,
     btcTxid,
     targetStatuses,
     timeoutMs,
@@ -50,7 +51,10 @@ export async function waitForPeginStatus(
     signal,
   } = params;
 
-  const rpcClient = new VaultProviderRpcApi(providerUrl, RPC_TIMEOUT_MS);
+  const rpcClient = new VaultProviderRpcApi(
+    getVpProxyUrl(providerAddress),
+    RPC_TIMEOUT_MS,
+  );
   const strippedTxid = stripHexPrefix(btcTxid);
 
   return pollUntil<string>(

--- a/services/vault/src/types/peginPolling.ts
+++ b/services/vault/src/types/peginPolling.ts
@@ -10,7 +10,7 @@ import type {
   PeginState,
 } from "../models/peginStateMachine";
 import type { PendingPeginRequest } from "../storage/peginStorage";
-import type { ClaimerTransactions, VaultProvider } from "../types";
+import type { ClaimerTransactions } from "../types";
 import type { VaultActivity } from "../types/activity";
 
 /** Result of polling for a single deposit */
@@ -62,8 +62,6 @@ export interface PeginPollingProviderProps extends PropsWithChildren {
   btcPublicKey?: string;
   /** Depositor's BTC address (for UTXO validation) */
   btcAddress?: string;
-  /** Vault providers data (pre-fetched at page level) */
-  vaultProviders: VaultProvider[];
 }
 
 /** Deposit prepared for polling */

--- a/services/vault/src/utils/errors/formatting.ts
+++ b/services/vault/src/utils/errors/formatting.ts
@@ -47,11 +47,38 @@ export function formatPayoutSignatureError(error: unknown): {
           "The vault provider took too long to respond. Please try again.",
       };
     }
+    // -32001: proxy "Provider not found" (message-specific) vs FE client "Network error" (generic)
+    if (
+      error.code === -32001 &&
+      error.message.toLowerCase().includes("provider not found")
+    ) {
+      return {
+        title: "Provider Not Found",
+        message:
+          "The vault provider could not be found in the on-chain registry. It may have been deregistered.",
+      };
+    }
     if (error.code === -32001) {
       return {
         title: "Connection Failed",
         message:
           "Unable to connect to the vault provider. Please check your connection and try again.",
+      };
+    }
+    // Proxy-specific: VP request timed out at the proxy level
+    if (error.code === -32002) {
+      return {
+        title: "Provider Timeout",
+        message:
+          "The vault provider took too long to respond. Please try again later.",
+      };
+    }
+    // Proxy-specific: VP unreachable, DNS failure, or response too large
+    if (error.code === -32003) {
+      return {
+        title: "Provider Unavailable",
+        message:
+          "The vault provider is temporarily unreachable. Please try again later.",
       };
     }
     return {

--- a/services/vault/src/utils/peginPolling.ts
+++ b/services/vault/src/utils/peginPolling.ts
@@ -4,13 +4,15 @@
 
 import type { Hex } from "viem";
 
+import { getVpProxyUrl } from "@/utils/rpc";
+
 import {
   ContractStatus,
   isPreDepositorSignaturesError,
   LocalStorageStatus,
 } from "../models/peginStateMachine";
 import type { PendingPeginRequest } from "../storage/peginStorage";
-import type { ClaimerTransactions, VaultProvider } from "../types";
+import type { ClaimerTransactions } from "../types";
 import type { VaultActivity } from "../types/activity";
 import type { DepositsByProvider, DepositToPoll } from "../types/peginPolling";
 
@@ -138,27 +140,23 @@ export function getDepositsNeedingPolling(
 }
 
 /**
- * Group deposits by vault provider URL for batched RPC calls
+ * Group deposits by vault provider for batched RPC calls via the proxy
  */
 export function groupDepositsByProvider(
   depositsToPoll: DepositToPoll[],
-  vaultProviders: VaultProvider[],
 ): Map<string, DepositsByProvider> {
   const grouped = new Map<string, DepositsByProvider>();
 
   for (const deposit of depositsToPoll) {
-    const provider = vaultProviders.find(
-      (p) => p.id.toLowerCase() === deposit.vaultProviderAddress?.toLowerCase(),
-    );
+    const providerAddress = deposit.vaultProviderAddress;
+    if (!providerAddress || !providerAddress.startsWith("0x")) continue;
 
-    if (!provider?.url) continue;
-
-    const existing = grouped.get(provider.url);
+    const existing = grouped.get(providerAddress);
     if (existing) {
       existing.deposits.push(deposit);
     } else {
-      grouped.set(provider.url, {
-        providerUrl: provider.url,
+      grouped.set(providerAddress, {
+        providerUrl: getVpProxyUrl(providerAddress),
         deposits: [deposit],
       });
     }

--- a/services/vault/src/utils/rpc/index.ts
+++ b/services/vault/src/utils/rpc/index.ts
@@ -7,3 +7,4 @@ export {
   type JsonRpcResponse,
   type JsonRpcSuccessResponse,
 } from "./json-rpc-client";
+export { getVpProxyUrl } from "./vpProxy";

--- a/services/vault/src/utils/rpc/vpProxy.ts
+++ b/services/vault/src/utils/rpc/vpProxy.ts
@@ -1,0 +1,24 @@
+import { ENV } from "@/config/env";
+
+/**
+ * Build the RPC URL for a vault provider via the proxy service.
+ *
+ * The proxy resolves the VP's actual RPC endpoint from the on-chain
+ * BTCVaultsMetadataRegistry, so callers only need the VP's Ethereum address.
+ *
+ * @param vpAddress - Vault provider Ethereum address (e.g. "0x1234...")
+ * @returns Proxy URL: `${VP_PROXY_URL}/rpc/${vpAddress}`
+ */
+export function getVpProxyUrl(vpAddress: string): string {
+  if (!ENV.VP_PROXY_URL) {
+    throw new Error(
+      "VP_PROXY_URL is not configured. Set NEXT_PUBLIC_TBV_VP_PROXY_URL.",
+    );
+  }
+  if (!vpAddress || !/^0x[0-9a-fA-F]{40}$/.test(vpAddress)) {
+    throw new Error(
+      `Invalid vault provider address: "${vpAddress}". Expected a 20-byte hex address starting with 0x.`,
+    );
+  }
+  return `${ENV.VP_PROXY_URL}/rpc/${vpAddress}`;
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how the app reaches vault providers by introducing a proxy-based URL builder and replacing direct VP URLs with on-chain provider addresses across deposit/payout/artifact flows; misconfiguration of `NEXT_PUBLIC_TBV_VP_PROXY_URL` or proxy behavior could break signing/polling paths.
> 
> **Overview**
> Updates vault-provider communication to go through a configurable proxy rather than calling provider RPC URLs directly. RPC-facing code paths (Lamport submission, payout signing/signature submission, artifact download, pegin/pegout polling) now pass a *provider address* and build the RPC endpoint via `getVpProxyUrl`.
> 
> Adds required env var `NEXT_PUBLIC_TBV_VP_PROXY_URL` (validated as `VP_PROXY_URL`) and introduces proxy-specific error formatting for new JSON-RPC error codes. Removes several UI/hook dependencies on `VaultProvider.url`/provider lookups (e.g., pending deposit polling, artifact download modal params, pegout polling), and updates tests to mock `getVpProxyUrl`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 513679cc2603f761398b1f9e54af77a8ecd6621b. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the direct vault provider (VP) URL lookup — which required a pre-fetched `VaultProvider` registry — with a single proxy service (`VP_PROXY_URL`) that resolves a VP's RPC endpoint on-demand from the on-chain `BTCVaultsMetadataRegistry`. Every call site that previously held a `providerUrl: string` now holds a `providerAddress: string` (the VP's Ethereum address), and a new `getVpProxyUrl(address)` utility constructs the final URL as `${VP_PROXY_URL}/rpc/${address}`. The change simplifies the data flow significantly: `VaultProvider.url` is eliminated from the type, `vaultProviders` no longer needs to be threaded through `PeginPollingProvider`, `usePeginPollingQuery`, `usePegoutPolling`, and various modal/hook props, and the polling enable guard no longer waits for the provider list to load.

Key changes:
- New `services/vault/src/utils/rpc/vpProxy.ts` with `getVpProxyUrl` that validates the address and constructs the proxy URL.
- `VP_PROXY_URL` added as a required env var (`NEXT_PUBLIC_TBV_VP_PROXY_URL`).
- All VP RPC clients in `vaultPeginStatusService`, `vaultPayoutSignatureService`, `artifactDownloadService`, `lamportSubmission`, and `payoutSigning` now build their URL via `getVpProxyUrl`.
- Proxy-specific JSON-RPC error codes (`-32001` "provider not found", `-32002` timeout, `-32003` unreachable) added to `formatPayoutSignatureError`.
- **Bug**: Both mock sites in `useMultiVaultDepositFlow.test.tsx` still use the old key `vaultProviderUrl` after the `PayoutSigningContext` interface was renamed to `vaultProviderAddress`, which will produce TypeScript errors and `undefined` at runtime.
- **Bug**: `groupVaultsByProvider` in `usePegoutPolling.ts` calls `getVpProxyUrl` without first guarding against an empty or malformed `vault.vaultProviderAddress`, unlike its counterpart in `peginPolling.ts`. A bad address will throw and abort polling for all vaults instead of gracefully skipping the single problematic entry.

<h3>Confidence Score: 3/5</h3>

- Needs fixes before merge — one test file has stale mock keys that will cause TypeScript errors and runtime failures, and pegout polling lacks a defensive guard that its sibling already has.
- The core architectural change (routing VP communication through a proxy) is clean and consistently applied across services. However, two concrete defects were found: (1) the `useMultiVaultDepositFlow` tests use `vaultProviderUrl` in two mock call-sites after the type was renamed to `vaultProviderAddress`, causing type errors and `undefined` to be passed to `getVpProxyUrl`; (2) `groupVaultsByProvider` in `usePegoutPolling.ts` omits the null/format guard that the analogous `groupDepositsByProvider` function correctly includes, meaning a vault with an empty or non-`0x` provider address will crash the entire polling query.
- `services/vault/src/hooks/deposit/__tests__/useMultiVaultDepositFlow.test.tsx` (stale mock keys) and `services/vault/src/hooks/usePegoutPolling.ts` (missing address guard).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| services/vault/src/utils/rpc/vpProxy.ts | New utility that builds the proxy URL from a VP Ethereum address; validation only checks `0x` prefix but not full address format. |
| services/vault/src/hooks/deposit/__tests__/useMultiVaultDepositFlow.test.tsx | Two mock sites still use the stale key `vaultProviderUrl` after the interface was renamed to `vaultProviderAddress`, causing `undefined` to be passed at runtime and TypeScript type errors. |
| services/vault/src/hooks/usePegoutPolling.ts | Removed per-provider lookup in favour of proxy URL construction, but `getVpProxyUrl` is called without a null/format guard, risking an unhandled throw that breaks polling for all vaults. |
| services/vault/src/config/env.ts | Adds `VP_PROXY_URL` as a required env var with proper validation, env-var name mapping, and fallback for the error state. |
| services/vault/src/services/vault/vaultPayoutSignatureService.ts | Removes `url` from `PayoutVaultProvider`, routes all VP RPC calls through `getVpProxyUrl`, and returns `vaultProviderAddress` instead of `vaultProviderUrl` from `prepareSigningContext`. |
| services/vault/src/utils/peginPolling.ts | Removes `vaultProviders` param from `groupDepositsByProvider`; correctly guards on empty `providerAddress` before calling `getVpProxyUrl`. |
| services/vault/src/utils/errors/formatting.ts | Adds proxy-specific error codes (-32001 "provider not found", -32002 timeout, -32003 unreachable) with user-friendly messages. |
| services/vault/src/hooks/deposit/usePeginPollingQuery.ts | Removes `vaultProviders` from params and the `isEnabled` guard that required providers to be loaded; polling can now start as soon as deposits and a BTC key are available. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant UI as Vault UI
    participant Proxy as VP Proxy Service
    participant Registry as BTCVaultsMetadataRegistry (on-chain)
    participant VP as Vault Provider RPC

    Note over UI: getVpProxyUrl(vpAddress)<br/>→ VP_PROXY_URL/rpc/{vpAddress}

    UI->>Proxy: POST /rpc/{vpAddress} (JSON-RPC request)
    Proxy->>Registry: Lookup RPC URL for vpAddress
    Registry-->>Proxy: providerRpcUrl

    alt Provider found
        Proxy->>VP: Forward JSON-RPC request
        VP-->>Proxy: JSON-RPC response
        Proxy-->>UI: Forward response
    else Provider not found
        Proxy-->>UI: Error -32001 "Provider not found"
    else VP timeout
        Proxy-->>UI: Error -32002 "Provider timeout"
    else VP unreachable
        Proxy-->>UI: Error -32003 "Provider unavailable"
    end
```

<sub>Last reviewed commit: ["feat(vault): communi..."](https://github.com/babylonlabs-io/babylon-toolkit/commit/513679cc2603f761398b1f9e54af77a8ecd6621b)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->