### PR TITLE
fix(sdk): externalize buffer in Vite build to prevent polyfill conflicts

### DIFF
--- a/packages/babylon-ts-sdk/vite.config.ts
+++ b/packages/babylon-ts-sdk/vite.config.ts
@@ -36,6 +36,7 @@ export default defineConfig({
         "@bitcoin-js/tiny-secp256k1-asmjs",
         "@babylonlabs-io/babylon-tbv-rust-wasm",
         "viem",
+        "buffer",
       ],
       output: {
         sourcemapExcludeSources: false,


### PR DESCRIPTION
Problem: The SDK's Vite build was bundling the npm `buffer` polyfill package (feross/buffer) into the dist output. When running in Node.js, this created two distinct Buffer implementations: Node's native Buffer and the polyfill's Buffer. bitcoinjs-lib performs strict `Buffer.isBuffer()` checks which return false for polyfill Buffer instances, causing "argument should be a Buffer" errors during PSBT construction in the presigning flow.

Root cause: Vite's rollupOptions.external array listed bitcoinjs-lib, tiny-secp256k1, and viem — but not `buffer`. Since the SDK source imports from `buffer`, Vite resolved it to node_modules/buffer (the npm polyfill) and inlined it into the bundle. The polyfill's Buffer constructor differs from Node's native Buffer, so instanceof/isBuffer checks fail across the boundary.

Fix: Add "buffer" to rollupOptions.external so Vite emits `require("buffer")` in the CJS output instead of inlining the polyfill. In Node.js, `require("buffer")` resolves to the built-in module (built-ins shadow node_modules), so the SDK gets the native Buffer — the same one bitcoinjs-lib uses.