### PR TITLE
feat(sdk): stage Pre-PegIn SDK primitives and types for new peg-in flow

### DIFF
--- a/packages/babylon-tbv-rust-wasm/src/index.ts
+++ b/packages/babylon-tbv-rust-wasm/src/index.ts
@@ -22,6 +22,9 @@ export async function initWasm() {
 }
 
 /**
+ * TODO: Remove once the new Pre-PegIn flow replaces the current flow.
+ * The new flow uses createPrePeginTransaction() + buildPeginFromPrePegin() instead.
+ *
  * Creates an unfunded peg-in transaction with no inputs and one output.
  *
  * This function creates a Bitcoin transaction template that the frontend
@@ -109,6 +112,13 @@ export type {
   AssertNoPayoutScriptInfo,
   ChallengeAssertConnectorParams,
   ChallengeAssertScriptInfo,
+  PrePeginHtlcConnectorParams,
+  PrePeginHtlcConnectorInfo,
+  PrePeginTxParams,
+  PrePeginTxResult,
+  PeginFromPrePeginParams,
+  PeginFromPrePeginResult,
+  RefundFromPrePeginParams,
 } from "./types.js";
 
 // Export constants
@@ -126,6 +136,13 @@ export {
 // Export challenge assert connector utilities (depositor-as-claimer)
 export { getChallengeAssertScriptInfo } from "./challengeAssertConnector.js";
 
+// Pre-PegIn utilities — function exports are staged in
+// prePeginTx.ts and prePeginHtlcConnector.ts but NOT re-exported here
+// until WASM is rebuilt with Pre-PegIn support.
+// Only type exports are included above (compile-time only, no runtime impact).
+
+// TODO: Remove WasmPeginTx re-export once the new Pre-PegIn flow replaces the current flow.
+// The new flow constructs PegIn via WasmPrePeginTx.buildPeginTx() instead.
 // Re-export the raw WASM types if needed
 // @ts-expect-error - WASM files are in dist/generated/ (checked into git), not src/generated/
 export { WasmPeginTx, WasmPeginPayoutConnector } from "./generated/btc_vault.js";

--- a/packages/babylon-tbv-rust-wasm/src/prePeginHtlcConnector.ts
+++ b/packages/babylon-tbv-rust-wasm/src/prePeginHtlcConnector.ts
@@ -1,0 +1,41 @@
+// @ts-expect-error - WASM files are in dist/generated/ (checked into git), not src/generated/
+import { WasmPrePeginHtlcConnector } from "./generated/btc_vault.js";
+import { initWasm } from "./index.js";
+import type { PrePeginHtlcConnectorParams, PrePeginHtlcConnectorInfo, Network } from "./types.js";
+
+/**
+ * Creates a Pre-PegIn HTLC connector and returns all spending information.
+ *
+ * The HTLC connector defines the Taproot spending conditions for the
+ * Pre-PegIn output:
+ * - Leaf 0 (hashlock): Secret reveal + all-party signatures
+ * - Leaf 1 (refund): Depositor signature after CSV timelock
+ *
+ * @param params - HTLC connector parameters (public keys, hash commitment, timelock)
+ * @param network - Bitcoin network
+ * @returns HTLC connector info including address, scripts, and control blocks
+ */
+export async function createPrePeginHtlcConnector(
+  params: PrePeginHtlcConnectorParams,
+  network: Network,
+): Promise<PrePeginHtlcConnectorInfo> {
+  await initWasm();
+
+  const connector = new WasmPrePeginHtlcConnector(
+    params.depositor,
+    params.vaultProvider,
+    params.vaultKeepers,
+    params.universalChallengers,
+    params.hashH,
+    params.timelockRefund,
+  );
+
+  return {
+    address: connector.getAddress(network),
+    scriptPubKey: connector.getScriptPubKey(network),
+    hashlockScript: connector.getHashlockScript(),
+    hashlockControlBlock: connector.getHashlockControlBlock(),
+    refundScript: connector.getRefundScript(),
+    refundControlBlock: connector.getRefundControlBlock(),
+  };
+}

--- a/packages/babylon-tbv-rust-wasm/src/prePeginTx.ts
+++ b/packages/babylon-tbv-rust-wasm/src/prePeginTx.ts
@@ -1,0 +1,124 @@
+// @ts-expect-error - WASM files are in dist/generated/ (checked into git), not src/generated/
+import { WasmPrePeginTx } from "./generated/btc_vault.js";
+import { initWasm } from "./index.js";
+import type {
+  PrePeginTxParams,
+  PrePeginTxResult,
+  PeginFromPrePeginParams,
+  PeginFromPrePeginResult,
+  RefundFromPrePeginParams,
+} from "./types.js";
+
+/**
+ * Construct a WasmPrePeginTx instance from typed params.
+ * Centralises the 12-parameter constructor so any WASM API change
+ * only needs to be updated in one place.
+ */
+function createWasmPrePeginTx(params: PrePeginTxParams): InstanceType<typeof WasmPrePeginTx> {
+  return new WasmPrePeginTx(
+    params.depositor,
+    params.vaultProvider,
+    params.vaultKeepers,
+    params.universalChallengers,
+    params.hashH,
+    params.timelockRefund,
+    params.peginAmount,
+    params.feeRate,
+    params.numLocalChallengers,
+    params.councilQuorum,
+    params.councilSize,
+    params.network,
+  );
+}
+
+/**
+ * Creates an unfunded Pre-PegIn transaction.
+ *
+ * The Pre-PegIn transaction locks BTC in an HTLC output with two spend paths:
+ * - Hashlock path: Secret reveal + all-party signatures (for PegIn activation)
+ * - Refund path: Depositor reclaims after CSV timelock (if activation times out)
+ *
+ * The `depositorClaimValue` and `htlcValue` are auto-computed from the
+ * provided contract parameters (fee rate, council params, challenger counts).
+ *
+ * The returned transaction has no inputs. The frontend must fund it by
+ * selecting UTXOs, adding inputs, and adding a change output.
+ *
+ * @param params - Pre-PegIn parameters (public keys, hash commitment, amount, contract params)
+ * @returns Unfunded Pre-PegIn transaction details and HTLC output information
+ */
+export async function createPrePeginTransaction(
+  params: PrePeginTxParams,
+): Promise<PrePeginTxResult> {
+  await initWasm();
+
+  const tx = createWasmPrePeginTx(params);
+
+  return {
+    txHex: tx.toHex(),
+    txid: tx.getTxid(),
+    htlcScriptPubKey: tx.getHtlcScriptPubKey(),
+    htlcValue: tx.getHtlcValue(),
+    htlcAddress: tx.getHtlcAddress(),
+    peginAmount: tx.getPeginAmount(),
+    depositorClaimValue: tx.getDepositorClaimValue(),
+  };
+}
+
+/**
+ * Builds a PegIn transaction that spends a funded Pre-PegIn's HTLC output.
+ *
+ * The PegIn transaction has a single input spending Pre-PegIn output 0
+ * via the hashlock + all-party script (leaf 0). The fee is baked into
+ * the HTLC input/output difference (no additional fee calculation needed).
+ *
+ * Since Pre-PegIn inputs are SegWit/Taproot, the txid is stable after
+ * funding — signing does not change it.
+ *
+ * @param prePeginParams - The same params used to create the Pre-PegIn transaction
+ * @param peginParams - PegIn-specific params (timelock, funded Pre-PegIn txid)
+ * @returns PegIn transaction details
+ */
+export async function buildPeginFromPrePegin(
+  prePeginParams: PrePeginTxParams,
+  peginParams: PeginFromPrePeginParams,
+): Promise<PeginFromPrePeginResult> {
+  await initWasm();
+
+  const prePeginTx = createWasmPrePeginTx(prePeginParams);
+  const peginTx = prePeginTx.buildPeginTx(
+    peginParams.timelockPegin,
+    peginParams.fundedPrePeginTxid,
+  );
+
+  return {
+    txHex: peginTx.toHex(),
+    txid: peginTx.getTxid(),
+    vaultScriptPubKey: peginTx.getVaultScriptPubKey(),
+    vaultValue: peginTx.getVaultValue(),
+  };
+}
+
+/**
+ * Builds an unsigned refund transaction that spends a funded Pre-PegIn's
+ * HTLC output via the refund script (leaf 1) after the CSV timelock expires.
+ *
+ * The depositor signs this externally via their wallet. This is used when
+ * vault activation times out and the depositor needs to reclaim their BTC.
+ *
+ * @param prePeginParams - The same params used to create the Pre-PegIn transaction
+ * @param refundParams - Refund-specific params (fee, funded Pre-PegIn txid)
+ * @returns Unsigned refund transaction hex
+ */
+export async function buildRefundFromPrePegin(
+  prePeginParams: PrePeginTxParams,
+  refundParams: RefundFromPrePeginParams,
+): Promise<string> {
+  await initWasm();
+
+  const prePeginTx = createWasmPrePeginTx(prePeginParams);
+  return prePeginTx.buildRefundTx(
+    refundParams.refundFee,
+    refundParams.fundedPrePeginTxid,
+  );
+}

--- a/packages/babylon-tbv-rust-wasm/src/types.ts
+++ b/packages/babylon-tbv-rust-wasm/src/types.ts
@@ -146,3 +146,148 @@ export interface ChallengeAssertScriptInfo {
   /** The control block for the ChallengeAssert script (hex encoded) */
   controlBlock: string;
 }
+
+// ============================================================================
+// Pre-PegIn Types (New PegIn Flow)
+// ============================================================================
+
+/**
+ * Parameters for creating a Pre-PegIn HTLC connector.
+ *
+ * The HTLC connector defines the spending conditions for the Pre-PegIn output:
+ * - Leaf 0 (hashlock): Secret reveal + all-party signatures (Depositor + VP + VKs + UCs)
+ * - Leaf 1 (refund): Depositor signature after CSV timelock
+ */
+export interface PrePeginHtlcConnectorParams {
+  /** X-only public key of the depositor (hex encoded, 64 chars) */
+  depositor: string;
+  /** X-only public key of the vault provider (hex encoded, 64 chars) */
+  vaultProvider: string;
+  /** Array of x-only public keys of vault keepers (hex encoded) */
+  vaultKeepers: string[];
+  /** Array of x-only public keys of universal challengers (hex encoded) */
+  universalChallengers: string[];
+  /** SHA256 hash commitment h = SHA256(s) (hex encoded, 64 chars = 32 bytes) */
+  hashH: string;
+  /** CSV timelock for the refund path in blocks (must be non-zero) */
+  timelockRefund: number;
+}
+
+/**
+ * HTLC connector information for the Pre-PegIn output.
+ */
+export interface PrePeginHtlcConnectorInfo {
+  /** Taproot address for the HTLC output */
+  address: string;
+  /** Taproot scriptPubKey (hex encoded) */
+  scriptPubKey: string;
+  /** Hashlock + all-party spend script (leaf 0, hex encoded) */
+  hashlockScript: string;
+  /** Control block for spending via the hashlock leaf (hex encoded) */
+  hashlockControlBlock: string;
+  /** Refund script (leaf 1, hex encoded) */
+  refundScript: string;
+  /** Control block for spending via the refund leaf (hex encoded) */
+  refundControlBlock: string;
+}
+
+/**
+ * Parameters for creating an unfunded Pre-PegIn transaction.
+ *
+ * The Pre-PegIn transaction locks BTC in an HTLC output that can be spent
+ * either by revealing the secret (hashlock path) or by the depositor after
+ * the refund timelock expires.
+ *
+ * The `depositorClaimValue` and `htlcValue` are auto-computed by WASM from
+ * the provided contract parameters.
+ */
+export interface PrePeginTxParams {
+  /** X-only public key of the depositor (hex encoded, 64 chars) */
+  depositor: string;
+  /** X-only public key of the vault provider (hex encoded, 64 chars) */
+  vaultProvider: string;
+  /** Array of x-only public keys of vault keepers (hex encoded) */
+  vaultKeepers: string[];
+  /** Array of x-only public keys of universal challengers (hex encoded) */
+  universalChallengers: string[];
+  /** SHA256 hash commitment h = SHA256(s) (hex encoded, 64 chars = 32 bytes) */
+  hashH: string;
+  /** CSV timelock for the refund path in blocks (must be non-zero) */
+  timelockRefund: number;
+  /** Amount in satoshis to lock in the vault */
+  peginAmount: bigint;
+  /** Fee rate in sat/vB (from contract offchain params) */
+  feeRate: bigint;
+  /** Number of local challengers (from contract params) */
+  numLocalChallengers: number;
+  /** M in M-of-N council multisig (from contract params) */
+  councilQuorum: number;
+  /** N in M-of-N council multisig (from contract params) */
+  councilSize: number;
+  /** Bitcoin network */
+  network: Network;
+}
+
+/**
+ * Result of creating an unfunded Pre-PegIn transaction.
+ *
+ * This transaction has no inputs and two outputs:
+ * - Output 0: HTLC output (value = peginAmount + depositorClaimValue + peginFee)
+ * - Output 1: CPFP anchor (BIP-86 keypath for depositor)
+ *
+ * The frontend must fund this by selecting UTXOs, adding inputs, and a change output.
+ */
+export interface PrePeginTxResult {
+  /** Unfunded transaction hex (no inputs) */
+  txHex: string;
+  /** Transaction ID (changes after funding) */
+  txid: string;
+  /** HTLC output scriptPubKey (hex encoded) */
+  htlcScriptPubKey: string;
+  /** HTLC output value in satoshis (peginAmount + depositorClaimValue + peginFee) */
+  htlcValue: bigint;
+  /** Taproot address for the HTLC output */
+  htlcAddress: string;
+  /** Vault amount in satoshis */
+  peginAmount: bigint;
+  /** Auto-computed depositor claim value in satoshis */
+  depositorClaimValue: bigint;
+}
+
+/**
+ * Parameters for building a PegIn transaction from a funded Pre-PegIn.
+ */
+export interface PeginFromPrePeginParams {
+  /** CSV timelock in blocks for the PegIn output */
+  timelockPegin: number;
+  /** Txid of the funded (but not yet signed) Pre-PegIn transaction (hex, 64 chars) */
+  fundedPrePeginTxid: string;
+}
+
+/**
+ * Result of building a PegIn transaction from a Pre-PegIn.
+ *
+ * The PegIn tx has a single input spending Pre-PegIn output 0 (HTLC)
+ * via the hashlock + all-party script. The fee is baked into the
+ * HTLC input/output difference.
+ */
+export interface PeginFromPrePeginResult {
+  /** Transaction hex */
+  txHex: string;
+  /** Transaction ID */
+  txid: string;
+  /** Vault script pubkey (hex encoded) */
+  vaultScriptPubKey: string;
+  /** Vault output value in satoshis */
+  vaultValue: bigint;
+}
+
+/**
+ * Parameters for building a refund transaction from a funded Pre-PegIn.
+ */
+export interface RefundFromPrePeginParams {
+  /** Transaction fee in satoshis */
+  refundFee: bigint;
+  /** Txid of the funded Pre-PegIn transaction (hex, 64 chars) */
+  fundedPrePeginTxid: string;
+}

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
@@ -35,7 +35,10 @@ import type { BitcoinWallet } from "../../../shared/wallets/interfaces/BitcoinWa
 import type { Hash } from "../../../shared/wallets/interfaces/EthereumWallet";
 import { getUtxoInfo, pushTx } from "../clients/mempool";
 import { BTCVaultsManagerABI, handleContractError } from "../contracts";
-import { buildPeginPsbt, type Network } from "../primitives";
+import {
+  buildPeginPsbt,
+  type Network,
+} from "../primitives";
 import {
   isAddressFromPublicKey,
   stripHexPrefix,
@@ -195,6 +198,100 @@ export interface PeginResult {
   ethTxHash: Hash | null;
 }
 
+// ============================================================================
+// Pre-PegIn Types (New PegIn Flow)
+// ============================================================================
+
+/**
+ * Core Pre-PegIn transaction parameters (protocol-level, no funding details).
+ * Used by methods that don't require UTXO selection (refund, HTLC info).
+ */
+export interface PrePeginTransactionParams {
+  /** Amount to lock in the vault (in satoshis) */
+  amount: bigint;
+  /** Vault provider's Ethereum address */
+  vaultProvider: Address;
+  /** Vault provider's BTC public key (x-only, 64-char hex) */
+  vaultProviderBtcPubkey: string;
+  /** Vault keeper BTC public keys (x-only, 64-char hex) */
+  vaultKeeperBtcPubkeys: string[];
+  /** Universal challenger BTC public keys (x-only, 64-char hex) */
+  universalChallengerBtcPubkeys: string[];
+  /** SHA256 hash commitment h = SHA256(s) (hex, 64 chars = 32 bytes) */
+  hashH: string;
+  /** CSV timelock for the refund path in blocks */
+  timelockRefund: number;
+  /** Fee rate in sat/vB (from contract offchain params) */
+  feeRate: bigint;
+  /** Number of local challengers (from contract params) */
+  numLocalChallengers: number;
+  /** M in M-of-N council multisig (from contract params) */
+  councilQuorum: number;
+  /** N in M-of-N council multisig (from contract params) */
+  councilSize: number;
+}
+
+/**
+ * Parameters for preparing a Pre-PegIn transaction (new peg-in flow).
+ * Extends core params with funding details and PegIn timelock.
+ */
+export interface CreatePrePeginParams extends PrePeginTransactionParams {
+  /** CSV timelock in blocks for the PegIn output */
+  timelockPegin: number;
+  /** Available UTXOs from the depositor's wallet for funding */
+  availableUTXOs: UTXO[];
+  /** Wallet fee rate in satoshis per vbyte for the Pre-PegIn transaction */
+  walletFeeRate: number;
+  /** Bitcoin address for receiving change */
+  changeAddress: string;
+}
+
+/**
+ * Result of preparing a Pre-PegIn transaction.
+ */
+export interface PrePeginResult {
+  /** Funded but unsigned Pre-PegIn transaction hex */
+  fundedPrePeginTxHex: string;
+  /** Pre-PegIn transaction ID (funded, stable after signing since inputs are SegWit) */
+  prePeginTxid: string;
+  /** HTLC output scriptPubKey (hex) */
+  htlcScriptPubKey: string;
+  /** HTLC output value in satoshis */
+  htlcValue: bigint;
+  /** Auto-computed depositor claim value in satoshis */
+  depositorClaimValue: bigint;
+  /** UTXOs selected for funding */
+  selectedUTXOs: UTXO[];
+  /** Transaction fee in satoshis */
+  fee: bigint;
+  /** Change amount in satoshis */
+  changeAmount: bigint;
+}
+
+/**
+ * Result of building a PegIn from a Pre-PegIn.
+ */
+export interface PeginFromPrePeginResult {
+  /** PegIn transaction hex (depositor needs to sign their input) */
+  peginTxHex: string;
+  /** PegIn transaction ID (vault ID) */
+  peginTxid: string;
+  /** Vault script pubkey (hex) */
+  vaultScriptPubKey: string;
+  /** Vault output value in satoshis */
+  vaultValue: bigint;
+}
+
+/**
+ * Combined result of preparePrePegin + buildPeginFromPrePegin.
+ */
+export interface PrePeginWithPeginResult {
+  /** Pre-PegIn preparation result */
+  prePegin: PrePeginResult;
+  /** PegIn transaction derived from the Pre-PegIn */
+  pegin: PeginFromPrePeginResult;
+}
+
 /**
  * Parameters for signing and broadcasting a transaction.
  */
@@ -324,6 +421,9 @@ export class PeginManager {
   }
 
   /**
+   * TODO: Remove once the new Pre-PegIn flow replaces the current flow.
+   * The new flow uses preparePrePegin() instead.
+   *
    * Prepares a peg-in transaction by building and funding it.
    *
    * This method orchestrates the following steps:
@@ -403,6 +503,10 @@ export class PeginManager {
   }
 
   /**
+   * TODO: Remove once the new Pre-PegIn flow replaces the current flow.
+   * In the new flow, the Pre-PegIn tx is signed/broadcast separately, and the
+   * PegIn tx is submitted to Ethereum (not broadcast to Bitcoin directly).
+   *
    * Signs and broadcasts a funded peg-in transaction to the Bitcoin network.
    *
    * This method:
@@ -515,6 +619,12 @@ export class PeginManager {
   }
 
   /**
+   * TODO: Update once the new Pre-PegIn flow replaces the current flow.
+   * The new flow will pass different params to submitPeginRequest:
+   * unsignedPrePeginTx, depositorSignedPeginTx, and hashlock h (instead of unsignedPegInTx).
+   * VaultId will be derived from depositorSignedPeginTx (not unsigned tx).
+   * A new activateVaultWithSecret() call will also be needed after secret reveal.
+   *
    * Registers a peg-in on Ethereum by calling the BTCVaultsManager contract.
    *
    * This method:
@@ -660,6 +770,18 @@ export class PeginManager {
       handleContractError(error);
     }
   }
+
+  // ===========================================================================
+  // Pre-PegIn Methods (New PegIn Flow) — staged, will be wired in when WASM is
+  // rebuilt with Pre-PegIn support. See:
+  //   - primitives/psbt/prepegin.ts (primitive functions)
+  //   - Types: CreatePrePeginParams, PrePeginTransactionParams, etc. (above)
+  //
+  // Methods to add in future PR:
+  //   - preparePrePegin(params: CreatePrePeginParams): PrePeginWithPeginResult
+  //   - buildRefundTransaction(params: PrePeginTransactionParams, ...): string
+  //   - getPrePeginHtlcInfo(params: PrePeginTransactionParams): PrePeginHtlcInfo
+  // ===========================================================================
 
   /**
    * Check if a vault already exists for a given vault ID.

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/index.ts
@@ -36,15 +36,20 @@
  *
  * ### {@link PeginManager}
  * Orchestrates the peg-in deposit flow:
- * - {@link PeginManager.preparePegin | preparePegin()} - Build and fund transaction
+ * - {@link PeginManager.preparePegin | preparePegin()} - Build and fund transaction (current flow)
  * - {@link PeginManager.registerPeginOnChain | registerPeginOnChain()} - Submit to Ethereum
- * - {@link PeginManager.signAndBroadcast | signAndBroadcast()} - Broadcast to Bitcoin
+ * - {@link PeginManager.signAndBroadcast | signAndBroadcast()} - Broadcast to Bitcoin (current flow)
+ *
+ * New peg-in flow (Pre-PegIn) methods (planned):
+ * - `preparePrePegin()` - Build Pre-PegIn + derive PegIn
+ * - `buildRefundTransaction()` - Build refund for timed-out Pre-PegIn
+ * - `getPrePeginHtlcInfo()` - Get HTLC scripts/control blocks
  *
  * ### {@link PayoutManager}
  * Signs payout authorization transactions (Step 3 of peg-in).
  * - {@link PayoutManager.signPayoutTransaction | signPayoutTransaction()} - Sign payout (uses Assert tx as reference)
  *
- * ## Complete Peg-in Flow
+ * ## Complete Peg-in Flow (Current)
  *
  * The 4-step peg-in flow uses both managers:
  *
@@ -54,6 +59,15 @@
  * | 2 | PeginManager | `registerPeginOnChain()` |
  * | 3 | PayoutManager | `signPayoutTransaction()` |
  * | 4 | PeginManager | `signAndBroadcast()` |
+ *
+ * ## New Peg-in Flow (Pre-PegIn)
+ *
+ * | Step | Manager | Method |
+ * |------|---------|--------|
+ * | 1 | PeginManager | `preparePrePegin()` |
+ * | 2 | PeginManager | Sign & broadcast Pre-PegIn, register on Ethereum |
+ * | 3 | PayoutManager | `signPayoutTransaction()` |
+ * | 4 | PeginManager | Reveal secret to activate vault |
  *
  * **Step 3 Details:** The vault provider provides 3 transactions per claimer:
  * - `claim_tx` - Claim transaction
@@ -70,8 +84,13 @@
 export { PeginManager } from "./PeginManager";
 export type {
   CreatePeginParams,
+  CreatePrePeginParams,
   PeginManagerConfig,
   PeginResult,
+  PeginFromPrePeginResult,
+  PrePeginResult,
+  PrePeginTransactionParams,
+  PrePeginWithPeginResult,
   RegisterPeginParams,
   RegisterPeginResult,
   SignAndBroadcastParams,

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/index.ts
@@ -40,6 +40,10 @@
  *
  * ### PSBT Builders
  * - {@link buildPeginPsbt} - Create unfunded peg-in transaction
+ * - {@link buildPrePeginPsbt} - Create unfunded Pre-PegIn transaction (new peg-in flow)
+ * - {@link buildPeginFromPrePeginPsbt} - Build PegIn from funded Pre-PegIn (new peg-in flow)
+ * - {@link buildRefundFromPrePeginPsbt} - Build refund from funded Pre-PegIn (new peg-in flow)
+ * - {@link getPrePeginHtlcInfo} - Get HTLC scripts and control blocks (new peg-in flow)
  * - {@link buildPayoutPsbt} - Create payout PSBT for signing
  * - {@link extractPayoutSignature} - Extract Schnorr signature from signed PSBT
  * - {@link buildDepositorPayoutPsbt} - Create depositor's own Payout PSBT (depositor-as-claimer path)
@@ -67,6 +71,14 @@ export type { Network } from "@babylonlabs-io/babylon-tbv-rust-wasm";
 // PSBT builders
 export { buildPeginPsbt } from "./psbt/pegin";
 export type { PeginParams, PeginPsbtResult } from "./psbt/pegin";
+
+// Pre-PegIn primitives (new peg-in flow) — type-only exports until WASM is rebuilt
+export type {
+  PrePeginParams,
+  PrePeginPsbtResult,
+  PeginFromPrePeginPsbtResult,
+  PrePeginHtlcInfo,
+} from "./psbt/prepegin";
 
 export { buildPayoutPsbt, extractPayoutSignature } from "./psbt/payout";
 export type { PayoutParams, PayoutPsbtResult } from "./psbt/payout";

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/index.ts
@@ -6,6 +6,10 @@
  *
  * Exports:
  * - {@link buildPeginPsbt} - Create unfunded peg-in transaction
+ * - {@link buildPrePeginPsbt} - Create unfunded Pre-PegIn transaction (new peg-in flow)
+ * - {@link buildPeginFromPrePeginPsbt} - Build PegIn from funded Pre-PegIn (new peg-in flow)
+ * - {@link buildRefundFromPrePeginPsbt} - Build refund from funded Pre-PegIn (new peg-in flow)
+ * - {@link getPrePeginHtlcInfo} - Get HTLC scripts and control blocks (new peg-in flow)
  * - {@link buildPayoutPsbt} - Create payout PSBT for signing
  * - {@link extractPayoutSignature} - Extract Schnorr signature from signed PSBT
  * - {@link buildDepositorPayoutPsbt} - Create depositor's own Payout PSBT (depositor-as-claimer path)
@@ -17,6 +21,16 @@
 
 export { buildPeginPsbt } from "./pegin";
 export type { PeginParams, PeginPsbtResult } from "./pegin";
+
+// Pre-PegIn primitives — functions and types are staged in
+// prepegin.ts but NOT re-exported here until WASM is rebuilt
+// with Pre-PegIn support. Wire in exports in a future PR.
+export type {
+  PrePeginParams,
+  PrePeginPsbtResult,
+  PeginFromPrePeginPsbtResult,
+  PrePeginHtlcInfo,
+} from "./prepegin";
 
 export { buildPayoutPsbt, extractPayoutSignature } from "./payout";
 export type { PayoutParams, PayoutPsbtResult } from "./payout";

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts
@@ -91,6 +91,9 @@ export interface PeginPsbtResult {
 }
 
 /**
+ * TODO: Remove once the new Pre-PegIn flow replaces the current flow.
+ * The new flow uses buildPrePeginPsbt() + buildPeginFromPrePeginPsbt() instead.
+ *
  * Build unsigned peg-in PSBT using WASM.
  *
  * This is a pure function that wraps the Rust WASM implementation.

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/prepegin.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/prepegin.ts
@@ -1,0 +1,250 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck — Pre-PegIn imports not yet available until WASM is rebuilt with Pre-PegIn support
+/**
+ * Pre-PegIn PSBT Builder Primitive (New PegIn Flow)
+ *
+ * This module provides pure functions for building Pre-PegIn transactions
+ * and deriving PegIn/refund transactions from them.
+ *
+ * The Pre-PegIn transaction locks BTC in an HTLC with two spend paths:
+ * - Hashlock: Secret reveal + all-party signatures → enables PegIn activation
+ * - Refund: Depositor reclaims after CSV timelock → safety net if activation fails
+ *
+ * @module primitives/psbt/prepegin
+ */
+
+import {
+  createPrePeginTransaction,
+  buildPeginFromPrePegin as wasmBuildPeginFromPrePegin,
+  buildRefundFromPrePegin as wasmBuildRefundFromPrePegin,
+  createPrePeginHtlcConnector,
+  type Network,
+} from "@babylonlabs-io/babylon-tbv-rust-wasm";
+
+/**
+ * Parameters for building an unfunded Pre-PegIn transaction.
+ */
+export interface PrePeginParams {
+  /** Depositor's BTC public key (x-only, 64-char hex without 0x prefix) */
+  depositorPubkey: string;
+  /** Vault provider's BTC public key (x-only, 64-char hex) */
+  vaultProviderPubkey: string;
+  /** Array of vault keeper BTC public keys (x-only, 64-char hex) */
+  vaultKeeperPubkeys: string[];
+  /** Array of universal challenger BTC public keys (x-only, 64-char hex) */
+  universalChallengerPubkeys: string[];
+  /** SHA256 hash commitment h = SHA256(s) (hex, 64 chars = 32 bytes) */
+  hashH: string;
+  /** CSV timelock for the refund path in blocks (must be non-zero) */
+  timelockRefund: number;
+  /** Amount in satoshis to lock in the vault */
+  peginAmount: bigint;
+  /** Fee rate in sat/vB (from contract offchain params) */
+  feeRate: bigint;
+  /** Number of local challengers (from contract params) */
+  numLocalChallengers: number;
+  /** M in M-of-N council multisig (from contract params) */
+  councilQuorum: number;
+  /** N in M-of-N council multisig (from contract params) */
+  councilSize: number;
+  /** Bitcoin network */
+  network: Network;
+}
+
+/**
+ * Result of building an unfunded Pre-PegIn transaction.
+ */
+export interface PrePeginPsbtResult {
+  /** Unfunded transaction hex (no inputs, HTLC + anchor outputs) */
+  psbtHex: string;
+  /** Transaction ID (changes after funding) */
+  txid: string;
+  /** HTLC output scriptPubKey (hex) */
+  htlcScriptPubKey: string;
+  /** HTLC output value in satoshis */
+  htlcValue: bigint;
+  /** Taproot address for the HTLC output */
+  htlcAddress: string;
+  /** Vault amount in satoshis */
+  peginAmount: bigint;
+  /** Auto-computed depositor claim value in satoshis */
+  depositorClaimValue: bigint;
+}
+
+/**
+ * Result of building a PegIn transaction from a Pre-PegIn.
+ */
+export interface PeginFromPrePeginPsbtResult {
+  /** Transaction hex */
+  txHex: string;
+  /** Transaction ID */
+  txid: string;
+  /** Vault script pubkey (hex) */
+  vaultScriptPubKey: string;
+  /** Vault output value in satoshis */
+  vaultValue: bigint;
+}
+
+/**
+ * HTLC connector information for PSBT construction.
+ */
+export interface PrePeginHtlcInfo {
+  /** Taproot address for the HTLC output */
+  address: string;
+  /** Taproot scriptPubKey (hex) */
+  scriptPubKey: string;
+  /** Hashlock + all-party spend script (leaf 0, hex) */
+  hashlockScript: string;
+  /** Control block for hashlock leaf spending (hex) */
+  hashlockControlBlock: string;
+  /** Refund script (leaf 1, hex) */
+  refundScript: string;
+  /** Control block for refund leaf spending (hex) */
+  refundControlBlock: string;
+}
+
+/**
+ * Build an unfunded Pre-PegIn transaction using WASM.
+ *
+ * This creates a Bitcoin transaction with no inputs and two outputs:
+ * - Output 0: HTLC output (peginAmount + depositorClaimValue + peginFee)
+ * - Output 1: CPFP anchor (BIP-86 keypath for depositor)
+ *
+ * The caller must fund this transaction by selecting UTXOs, adding inputs,
+ * and adding a change output.
+ *
+ * @param params - Pre-PegIn parameters
+ * @returns Unfunded Pre-PegIn transaction details
+ */
+export async function buildPrePeginPsbt(
+  params: PrePeginParams,
+): Promise<PrePeginPsbtResult> {
+  const result = await createPrePeginTransaction({
+    depositor: params.depositorPubkey,
+    vaultProvider: params.vaultProviderPubkey,
+    vaultKeepers: params.vaultKeeperPubkeys,
+    universalChallengers: params.universalChallengerPubkeys,
+    hashH: params.hashH,
+    timelockRefund: params.timelockRefund,
+    peginAmount: params.peginAmount,
+    feeRate: params.feeRate,
+    numLocalChallengers: params.numLocalChallengers,
+    councilQuorum: params.councilQuorum,
+    councilSize: params.councilSize,
+    network: params.network,
+  });
+
+  return {
+    psbtHex: result.txHex,
+    txid: result.txid,
+    htlcScriptPubKey: result.htlcScriptPubKey,
+    htlcValue: result.htlcValue,
+    htlcAddress: result.htlcAddress,
+    peginAmount: result.peginAmount,
+    depositorClaimValue: result.depositorClaimValue,
+  };
+}
+
+/**
+ * Build a PegIn transaction that spends a funded Pre-PegIn's HTLC output.
+ *
+ * The PegIn transaction has a single input spending Pre-PegIn output 0
+ * via the hashlock + all-party script (leaf 0). The fee is already
+ * accounted for in the HTLC value.
+ *
+ * @param prePeginParams - The same params used to create the Pre-PegIn
+ * @param timelockPegin - CSV timelock in blocks for the PegIn output
+ * @param fundedPrePeginTxid - Txid of the funded Pre-PegIn transaction
+ * @returns PegIn transaction details
+ */
+export async function buildPeginFromPrePeginPsbt(
+  prePeginParams: PrePeginParams,
+  timelockPegin: number,
+  fundedPrePeginTxid: string,
+): Promise<PeginFromPrePeginPsbtResult> {
+  const result = await wasmBuildPeginFromPrePegin(
+    {
+      depositor: prePeginParams.depositorPubkey,
+      vaultProvider: prePeginParams.vaultProviderPubkey,
+      vaultKeepers: prePeginParams.vaultKeeperPubkeys,
+      universalChallengers: prePeginParams.universalChallengerPubkeys,
+      hashH: prePeginParams.hashH,
+      timelockRefund: prePeginParams.timelockRefund,
+      peginAmount: prePeginParams.peginAmount,
+      feeRate: prePeginParams.feeRate,
+      numLocalChallengers: prePeginParams.numLocalChallengers,
+      councilQuorum: prePeginParams.councilQuorum,
+      councilSize: prePeginParams.councilSize,
+      network: prePeginParams.network,
+    },
+    { timelockPegin, fundedPrePeginTxid },
+  );
+
+  return {
+    txHex: result.txHex,
+    txid: result.txid,
+    vaultScriptPubKey: result.vaultScriptPubKey,
+    vaultValue: result.vaultValue,
+  };
+}
+
+/**
+ * Build an unsigned refund transaction from a funded Pre-PegIn.
+ *
+ * The refund transaction spends the HTLC output via the refund script
+ * (leaf 1) after the CSV timelock expires. Used when vault activation
+ * times out and the depositor needs to reclaim their BTC.
+ *
+ * @param prePeginParams - The same params used to create the Pre-PegIn
+ * @param refundFee - Transaction fee in satoshis
+ * @param fundedPrePeginTxid - Txid of the funded Pre-PegIn transaction
+ * @returns Unsigned refund transaction hex
+ */
+export async function buildRefundFromPrePeginPsbt(
+  prePeginParams: PrePeginParams,
+  refundFee: bigint,
+  fundedPrePeginTxid: string,
+): Promise<string> {
+  return wasmBuildRefundFromPrePegin(
+    {
+      depositor: prePeginParams.depositorPubkey,
+      vaultProvider: prePeginParams.vaultProviderPubkey,
+      vaultKeepers: prePeginParams.vaultKeeperPubkeys,
+      universalChallengers: prePeginParams.universalChallengerPubkeys,
+      hashH: prePeginParams.hashH,
+      timelockRefund: prePeginParams.timelockRefund,
+      peginAmount: prePeginParams.peginAmount,
+      feeRate: prePeginParams.feeRate,
+      numLocalChallengers: prePeginParams.numLocalChallengers,
+      councilQuorum: prePeginParams.councilQuorum,
+      councilSize: prePeginParams.councilSize,
+      network: prePeginParams.network,
+    },
+    { refundFee, fundedPrePeginTxid },
+  );
+}
+
+/**
+ * Get HTLC connector information for building Pre-PegIn PSBTs.
+ *
+ * Returns the Taproot scripts and control blocks needed for both
+ * the hashlock (PegIn activation) and refund spending paths.
+ *
+ * @param params - Pre-PegIn parameters (uses the same params as buildPrePeginPsbt)
+ * @returns HTLC scripts, control blocks, and address
+ */
+export async function getPrePeginHtlcInfo(
+  params: PrePeginParams,
+): Promise<PrePeginHtlcInfo> {
+  return createPrePeginHtlcConnector(
+    {
+      depositor: params.depositorPubkey,
+      vaultProvider: params.vaultProviderPubkey,
+      vaultKeepers: params.vaultKeeperPubkeys,
+      universalChallengers: params.universalChallengerPubkeys,
+      hashH: params.hashH,
+      timelockRefund: params.timelockRefund,
+    },
+    params.network,
+  );
+}


### PR DESCRIPTION
- Add WASM wrappers for Pre-PegIn transaction construction (prePeginTx.ts) and HTLC connector (prePeginHtlcConnector.ts)
- Add SDK primitive functions: buildPrePeginPsbt, buildPeginFromPrePeginPsbt, buildRefundFromPrePeginPsbt, getPrePeginHtlcInfo
- Add Pre-PegIn type definitions at both WASM and SDK layers (PrePeginTransactionParams, CreatePrePeginParams, etc.)
- Add TODO comments on current flow methods (preparePegin, signAndBroadcast, registerPeginOnChain, buildPeginPsbt) for future removal
- Update JSDoc with new peg-in flow documentation