### PR TITLE
chore(workspace): add baby-tester as workspace member

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,58 @@ importers:
         specifier: 11.1.0
         version: 11.1.0
 
+  ../baby-tester:
+    dependencies:
+      '@babylonlabs-io/babylon-tbv-rust-wasm':
+        specifier: workspace:*
+        version: link:../babylon-toolkit/packages/babylon-tbv-rust-wasm
+      '@babylonlabs-io/ts-sdk':
+        specifier: workspace:*
+        version: link:../babylon-toolkit/packages/babylon-ts-sdk
+      '@bitcoin-js/tiny-secp256k1-asmjs':
+        specifier: 2.2.3
+        version: 2.2.3
+      bitcoinjs-lib:
+        specifier: 6.1.7
+        version: 6.1.7
+      buffer:
+        specifier: ^6.0.3
+        version: 6.0.3
+      chalk:
+        specifier: ^5.4.0
+        version: 5.4.1
+      commander:
+        specifier: ^13.0.0
+        version: 13.1.0
+      dotenv:
+        specifier: ^16.4.0
+        version: 16.6.1
+      smol-toml:
+        specifier: ^1.3.0
+        version: 1.6.0
+      viem:
+        specifier: ^2.38.2
+        version: 2.38.2(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.12)
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.17.0
+      eslint:
+        specifier: ^9.0.0
+        version: 9.32.0(jiti@2.5.1)
+      prettier:
+        specifier: ^3.6.0
+        version: 3.6.2
+      tsx:
+        specifier: ^4.19.0
+        version: 4.20.3
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.2
+      vitest:
+        specifier: ^4.0.8
+        version: 4.0.9(@types/debug@4.1.12)(@types/node@22.17.0)(@vitest/ui@4.0.9)(jiti@2.5.1)(jsdom@20.0.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(msw@2.11.6(@types/node@22.17.0)(typescript@5.9.2))(terser@5.44.0)(tsx@4.20.3)(yaml@2.8.2)
+
   packages/babylon-config:
     dependencies:
       '@babylonlabs-io/wallet-connector':
@@ -6616,6 +6668,7 @@ packages:
   git-raw-commits@4.0.0:
     resolution: {integrity: sha512-ICsMM1Wk8xSGMowkOmPrzo2Fgmfo4bMHLNX6ytHjajRJUqvHOw/TFapQ+QG75c3X/tTDDhOSRPGC52dDbNM8FQ==}
     engines: {node: '>=16'}
+    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
     hasBin: true
 
   glob-parent@5.1.2:
@@ -9338,6 +9391,10 @@ packages:
 
   slow-redact@0.3.2:
     resolution: {integrity: sha512-MseHyi2+E/hBRqdOi5COy6wZ7j7DxXRz9NkseavNYSvvWC06D8a5cidVZX3tcG5eCW3NIyVU4zT63hw0Q486jw==}
+
+  smol-toml@1.6.0:
+    resolution: {integrity: sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==}
+    engines: {node: '>= 18'}
 
   socket.io-client@4.8.1:
     resolution: {integrity: sha512-hJVXfu3E28NmzGk8o1sHhN3om52tRvwYeidbj7xKy2eIIse5IoKX3USlS6Tqt3BHAtflLIkCQBkzVrEEfWUyYQ==}
@@ -22804,6 +22861,8 @@ snapshots:
       is-fullwidth-code-point: 5.0.0
 
   slow-redact@0.3.2: {}
+
+  smol-toml@1.6.0: {}
 
   socket.io-client@4.8.1(bufferutil@4.0.9)(utf-8-validate@5.0.10):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,7 @@ packages:
   - packages/*
   - tools/*
   - services/*
+  - ../baby-tester
 
 ignoredBuiltDependencies:
   - '@sentry/cli'


### PR DESCRIPTION
baby-tester (testing automation tool) depends on ts-sdk and babylon-tbv-rust-wasm, and as the SDK is private right now it needs to be added to the workspace.