### PR TITLE
feat(vault): add validation for non-null graphql fields

### DIFF
--- a/services/vault/src/services/vault/__tests__/fetchVaults.test.ts
+++ b/services/vault/src/services/vault/__tests__/fetchVaults.test.ts
@@ -89,6 +89,18 @@ describe("fetchVaults", () => {
       );
     });
 
+    it("returns vault when depositorLamportPkHash is present", async () => {
+      const hash = "0x" + "ab".repeat(32);
+      mockedRequest.mockResolvedValueOnce({
+        vault: makeGraphQLVaultItem({ depositorLamportPkHash: hash }),
+      });
+
+      const vault = await fetchVaultById("0xabc123" as `0x${string}`);
+
+      expect(vault).not.toBeNull();
+      expect(vault!.depositorLamportPkHash).toBe(hash);
+    });
+
     it("returns null when vault is not found", async () => {
       mockedRequest.mockResolvedValueOnce({ vault: null });
 

--- a/services/vault/src/services/vault/fetchVaults.ts
+++ b/services/vault/src/services/vault/fetchVaults.ts
@@ -156,15 +156,15 @@ function mapGraphQLStatusToVaultStatus(
 }
 
 /**
- * Validates that a required GraphQL field is non-null.
- * Throws if the field is null, since this indicates a buggy or compromised server response.
+ * Validates that a required GraphQL field is non-null and non-undefined.
+ * Throws if the field is nullish, since this indicates a buggy or compromised server response.
  */
 function validateRequiredField<T>(
-  value: T | null,
+  value: T | null | undefined,
   fieldName: string,
   vaultId: string,
 ): T {
-  if (value === null) {
+  if (value == null) {
     throw new Error(
       `Missing required field "${fieldName}" for vault ${vaultId}`,
     );


### PR DESCRIPTION
- added validation for non nun graphql field - `validateRequiredField`

closes https://github.com/babylonlabs-io/vault-provider-proxy/issues/77