### PR TITLE
feat(sdk): split tx fee multiplied constant

### DIFF
--- a/packages/babylon-ts-sdk/package.json
+++ b/packages/babylon-ts-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@babylonlabs-io/ts-sdk",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts
@@ -42,3 +42,11 @@ export function rateBasedTxBufferFee(feeRate: number): number {
     ? LOW_RATE_ESTIMATION_ACCURACY_BUFFER
     : 0;
 }
+
+/**
+ * Safety multiplier for split transaction fee validation.
+ * The signed PSBT's fee rate and absolute fee must not exceed this multiple
+ * of the planned values. 5x accounts for witness estimation variance while
+ * catching catastrophic wallet-side overpayment.
+ */
+export const SPLIT_TX_FEE_SAFETY_MULTIPLIER = 5;


### PR DESCRIPTION
- first part, adds a contant to update split tx fee multiplier

needed for https://github.com/babylonlabs-io/vault-provider-proxy/issues/75
vault implementation: https://github.com/babylonlabs-io/babylon-toolkit/pull/1289