### PR TITLE
feat(vault): enhance split transaction fee handling

### DIFF
--- a/services/vault/src/hooks/deposit/__tests__/useMultiVaultDepositFlow.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useMultiVaultDepositFlow.test.tsx
@@ -35,6 +35,7 @@ vi.mock("@babylonlabs-io/ts-sdk", () => ({
 }));
 
 vi.mock("@babylonlabs-io/ts-sdk/tbv/core", () => ({
+  SPLIT_TX_FEE_SAFETY_MULTIPLIER: 5,
   createSplitTransaction: vi.fn(),
   createSplitTransactionPsbt: vi.fn(),
   ensureHexPrefix: (hex: string) => (hex.startsWith("0x") ? hex : `0x${hex}`),
@@ -96,6 +97,7 @@ vi.mock("@/services/vault", () => ({
   preparePeginFromSplitOutput: vi.fn(),
   registerSplitPeginOnChain: vi.fn(),
   broadcastPrePeginWithLocalUtxo: vi.fn(),
+  estimateSplitTxFee: vi.fn(() => 10000n),
 }));
 
 vi.mock("@/services/vault/vaultPayoutSignatureService", () => ({
@@ -908,6 +910,57 @@ describe("useMultiVaultDepositFlow", () => {
         splitTxId: "splitTxId" + "0".repeat(56),
         strategy: "SPLIT",
         warnings: undefined,
+      });
+    });
+
+    it("should call setMaximumFeeRate with dynamic value based on feeRate", async () => {
+      const { planUtxoAllocation } = vi.mocked(
+        await import("@/services/vault"),
+      );
+      const { Psbt } = vi.mocked(await import("bitcoinjs-lib"));
+
+      const mockSetMaximumFeeRate = vi.fn();
+      vi.mocked(Psbt.fromHex).mockReturnValue({
+        setMaximumFeeRate: mockSetMaximumFeeRate,
+        extractTransaction: vi.fn(() => ({
+          toHex: vi.fn(() => "mockSignedTxHex"),
+        })),
+      } as any);
+
+      vi.mocked(planUtxoAllocation).mockReturnValue(SPLIT_PLAN);
+
+      const { result } = renderHook(() =>
+        useMultiVaultDepositFlow(SPLIT_VAULT_PARAMS),
+      );
+
+      await executeWithAutoArtifactDownload(result);
+
+      await waitFor(() => {
+        // feeRate=10, multiplier=5 → maxAllowedFeeRate=50
+        expect(mockSetMaximumFeeRate).toHaveBeenCalledWith(50);
+      });
+    });
+
+    it("should throw when split transaction fee exceeds safety limit", async () => {
+      const { planUtxoAllocation, estimateSplitTxFee } = vi.mocked(
+        await import("@/services/vault"),
+      );
+
+      // Set estimated fee very low so actual fee (10,000 sats) exceeds 5x limit
+      vi.mocked(estimateSplitTxFee).mockReturnValueOnce(100n);
+
+      vi.mocked(planUtxoAllocation).mockReturnValue(SPLIT_PLAN);
+
+      const { result } = renderHook(() =>
+        useMultiVaultDepositFlow(SPLIT_VAULT_PARAMS),
+      );
+
+      await executeWithAutoArtifactDownload(result);
+
+      await waitFor(() => {
+        expect(result.current.error).toContain(
+          "Split transaction fee 10000 sats exceeds safety limit of 500 sats",
+        );
       });
     });
   });

--- a/services/vault/src/hooks/deposit/useMultiVaultDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useMultiVaultDepositFlow.ts
@@ -27,6 +27,7 @@ import {
   createSplitTransaction,
   createSplitTransactionPsbt,
   ensureHexPrefix,
+  SPLIT_TX_FEE_SAFETY_MULTIPLIER,
 } from "@babylonlabs-io/ts-sdk/tbv/core";
 import { Psbt } from "bitcoinjs-lib";
 import { Buffer } from "buffer";
@@ -43,6 +44,7 @@ import { validateMultiVaultDepositInputs } from "@/services/deposit/validations"
 import { deriveLamportPkHash, linkPeginToMnemonic } from "@/services/lamport";
 import {
   broadcastPrePeginWithLocalUtxo,
+  estimateSplitTxFee,
   planUtxoAllocation,
   preparePeginFromSplitOutput,
   registerSplitPeginOnChain,
@@ -206,6 +208,7 @@ interface SplitTxSignResult {
 async function createAndSignSplitTransaction(
   splitTx: NonNullable<AllocationPlan["splitTransaction"]>,
   btcWalletProvider: BitcoinWallet,
+  feeRate: number,
 ): Promise<SplitTxSignResult> {
   const network = getBTCNetworkForWASM();
 
@@ -238,10 +241,37 @@ async function createAndSignSplitTransaction(
     autoFinalized: true,
   });
 
-  // Extract signed transaction
+  // Extract signed transaction with dynamic fee rate limit
+  const maxAllowedFeeRate = Math.ceil(feeRate * SPLIT_TX_FEE_SAFETY_MULTIPLIER);
   const signedPsbt = Psbt.fromHex(signedPsbtHex);
-  signedPsbt.setMaximumFeeRate(100000); // Allow high fee rates for split transactions
+  signedPsbt.setMaximumFeeRate(maxAllowedFeeRate);
   const signedTx = signedPsbt.extractTransaction();
+
+  // Planner sanity check: verify planned fee is within expected bounds
+  const totalInputValue = splitTx.inputs.reduce(
+    (sum, input) => sum + BigInt(input.value),
+    0n,
+  );
+  const totalOutputValue = splitTx.outputs.reduce(
+    (sum, output) => sum + output.amount,
+    0n,
+  );
+  const actualFee = totalInputValue - totalOutputValue;
+  const expectedFee = estimateSplitTxFee(
+    splitTx.inputs.length,
+    splitTx.outputs.length,
+    feeRate,
+  );
+  const maxAllowedFee = expectedFee * BigInt(SPLIT_TX_FEE_SAFETY_MULTIPLIER);
+
+  if (actualFee > maxAllowedFee) {
+    throw new Error(
+      `Split transaction fee ${actualFee} sats exceeds safety limit of ${maxAllowedFee} sats ` +
+        `(${SPLIT_TX_FEE_SAFETY_MULTIPLIER}x estimated fee of ${expectedFee} sats ` +
+        `at ${feeRate} sat/vB). The allocation planner may have produced an incorrect fee.`,
+    );
+  }
+
   const signedHex = signedTx.toHex();
 
   return {
@@ -413,6 +443,7 @@ export function useMultiVaultDepositFlow(
           splitTxResult = await createAndSignSplitTransaction(
             plan.splitTransaction,
             confirmedBtcWallet,
+            feeRate,
           );
           // 2b. Broadcast split TX IMMEDIATELY
           try {


### PR DESCRIPTION
- fee multiplier constant usage in vault web app

- requires https://github.com/babylonlabs-io/babylon-toolkit/pull/1288 to be merged first
- requires `pnpm i` after the merge of the above PR, will update the lockfile

closes https://github.com/babylonlabs-io/vault-provider-proxy/issues/75