### PR TITLE
refactor(vault): rename atomic swap references to pegin/HTLC terminology

### DIFF
--- a/packages/babylon-ts-sdk/docs/api/managers.md
+++ b/packages/babylon-ts-sdk/docs/api/managers.md
@@ -36,8 +36,8 @@ Use primitives instead when you need:
 ## Available Managers
 
 ### [PeginManager](#peginmanager)
-Orchestrates the atomic swap peg-in flow:
-- [prepareAtomicPegin()](#prepareatomicpegin) - Build Pre-PegIn HTLC and sign PegIn input
+Orchestrates the peg-in flow:
+- [preparePegin()](#preparepegin) - Build Pre-PegIn HTLC and sign PegIn input
 - [registerPeginOnChain()](#registerpeginonchain) - Submit to Ethereum
 - [signAndBroadcast()](#signandbroadcast) - Broadcast to Bitcoin
 
@@ -51,7 +51,7 @@ The 4-step peg-in flow uses both managers:
 
 | Step | Manager | Method |
 |------|---------|--------|
-| 1 | PeginManager | `prepareAtomicPegin()` |
+| 1 | PeginManager | `preparePegin()` |
 | 2 | PeginManager | `registerPeginOnChain()` |
 | 3 | PayoutManager | `signPayoutTransaction()` |
 | 4 | PeginManager | `signAndBroadcast()` |
@@ -246,11 +246,11 @@ by coordinating between SDK primitives, utilities, and wallet interfaces.
 
 #### Remarks
 
-The complete atomic swap peg-in flow consists of 4 steps:
+The complete peg-in flow consists of 4 steps:
 
 | Step | Method | Description |
 |------|--------|-------------|
-| 1 | [prepareAtomicPegin](#prepareatomicpegin) | Build Pre-PegIn HTLC, fund it, sign PegIn input |
+| 1 | [preparePegin](#preparepegin) | Build Pre-PegIn HTLC, fund it, sign PegIn input |
 | 2 | [registerPeginOnChain](#registerpeginonchain) | Submit to Ethereum contract with PoP |
 | 3 | [PayoutManager](#payoutmanager) | Sign BOTH payout authorizations |
 | 4 | [signAndBroadcast](#signandbroadcast) | Sign and broadcast Pre-PegIn tx to Bitcoin network |
@@ -298,15 +298,15 @@ Manager configuration including wallets and contract addresses
 
 #### Methods
 
-##### prepareAtomicPegin()
+##### preparePegin()
 
 ```ts
-prepareAtomicPegin(params): Promise<AtomicPeginResult>;
+preparePegin(params): Promise<PreparePeginResult>;
 ```
 
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:408](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L408)
 
-Prepares an atomic swap peg-in by building the Pre-PegIn HTLC transaction,
+Prepares a peg-in by building the Pre-PegIn HTLC transaction,
 funding it, constructing the PegIn transaction, and signing the PegIn input.
 
 This method orchestrates the following steps:
@@ -325,15 +325,15 @@ Use `signAndBroadcast()` AFTER registering on Ethereum to broadcast it.
 
 ###### params
 
-[`CreateAtomicPeginParams`](#createatomicpeginparams)
+[`PreparePeginParams`](#preparepeginparams)
 
-Atomic pegin parameters including amount, HTLC params, UTXOs
+Pegin parameters including amount, HTLC params, UTXOs
 
 ###### Returns
 
-`Promise`\<[`AtomicPeginResult`](#atomicpeginresult)\>
+`Promise`\<[`PreparePeginResult`](#preparepeginresult)\>
 
-Atomic pegin result with funded Pre-PegIn tx, signed PegIn input, and signatures
+Pegin result with funded Pre-PegIn tx, signed PegIn input, and signatures
 
 ###### Throws
 
@@ -1026,11 +1026,11 @@ a custom URL if running your own mempool instance.
 
 ***
 
-### CreateAtomicPeginParams
+### PreparePeginParams
 
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:107](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L107)
 
-Parameters for the atomic swap pegin flow (pre-pegin + pegin transactions).
+Parameters for the pegin flow (pre-pegin + pegin transactions).
 
 #### Properties
 
@@ -1168,11 +1168,11 @@ Bitcoin address for receiving change from the Pre-PegIn transaction.
 
 ***
 
-### AtomicPeginResult
+### PreparePeginResult
 
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:181](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L181)
 
-Result of preparing an atomic swap pegin.
+Result of preparing a pegin.
 
 #### Properties
 
@@ -1308,7 +1308,7 @@ fundedPrePeginTxHex: string;
 
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:250](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L250)
 
-Funded Pre-PegIn transaction hex from prepareAtomicPegin().
+Funded Pre-PegIn transaction hex from preparePegin().
 
 ##### depositorBtcPubkey
 
@@ -1381,7 +1381,7 @@ hashlock: `0x${string}`;
 
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:288](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L288)
 
-SHA256 hashlock for atomic swap activation (bytes32 hex with 0x prefix).
+SHA256 hashlock for HTLC activation (bytes32 hex with 0x prefix).
 
 ##### onPopSigned()?
 

--- a/packages/babylon-ts-sdk/docs/quickstart/managers.md
+++ b/packages/babylon-ts-sdk/docs/quickstart/managers.md
@@ -67,7 +67,7 @@ const peginManager = new PeginManager({
 import { PayoutManager } from "@babylonlabs-io/ts-sdk/tbv/core";
 
 // Step 1: Prepare transaction (builds Pre-PegIn HTLC + PegIn tx, signs PegIn input)
-const result = await peginManager.prepareAtomicPegin({
+const result = await peginManager.preparePegin({
   amount: 100000n, // satoshis
   vaultProviderBtcPubkey: "abc123...", // x-only, 64 hex chars
   vaultKeeperBtcPubkeys: ["def456..."], // x-only pubkeys
@@ -127,7 +127,7 @@ console.log("Broadcasted:", btcTxid);
 
 | Step | Method/Manager           | Returns                                                                           |
 | ---- | ------------------------ | --------------------------------------------------------------------------------- |
-| 1    | `prepareAtomicPegin()`   | `{ fundedPrePeginTxHex, peginTxHex, peginTxid, peginInputSignature, selectedUTXOs, fee, ... }` |
+| 1    | `preparePegin()`   | `{ fundedPrePeginTxHex, peginTxHex, peginTxid, peginInputSignature, selectedUTXOs, fee, ... }` |
 | 2    | `registerPeginOnChain()` | `{ ethTxHash, vaultId }`                                                          |
 | 3    | `PayoutManager` methods  | `{ signature }` per claimer                                                       |
 | 4    | `signAndBroadcast()`     | `btcTxid` (string)                                                                |

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
@@ -2,11 +2,11 @@
  * Peg-in Manager - Wallet Orchestration for Peg-in Operations
  *
  * This module provides the PeginManager class that orchestrates the complete
- * atomic swap peg-in flow using SDK primitives, utilities, and wallet interfaces.
+ * peg-in flow using SDK primitives, utilities, and wallet interfaces.
  *
  * @remarks
- * PeginManager handles the atomic swap peg-in flow:
- * 1. **prepareAtomicPegin()** - Build Pre-PegIn HTLC, fund it, sign PegIn input
+ * PeginManager handles the peg-in flow:
+ * 1. **preparePegin()** - Build Pre-PegIn HTLC, fund it, sign PegIn input
  * 2. **registerPeginOnChain()** - Submit to Ethereum contract with PoP
  * 3. *(Use {@link PayoutManager} for payout authorization signing)*
  * 4. **signAndBroadcast()** - Sign and broadcast Pre-PegIn tx to Bitcoin network
@@ -103,9 +103,9 @@ export interface PeginManagerConfig {
 }
 
 /**
- * Parameters for the atomic swap pegin flow (pre-pegin + pegin transactions).
+ * Parameters for the pegin flow (pre-pegin + pegin transactions).
  */
-export interface CreateAtomicPeginParams {
+export interface PreparePeginParams {
   /**
    * Amount to peg in (in satoshis).
    */
@@ -179,9 +179,9 @@ export interface CreateAtomicPeginParams {
 }
 
 /**
- * Result of preparing an atomic swap pegin.
+ * Result of preparing a pegin.
  */
-export interface AtomicPeginResult {
+export interface PreparePeginResult {
   /**
    * Funded but unsigned Pre-PegIn transaction hex.
    * Sign and broadcast this AFTER registering on Ethereum.
@@ -248,7 +248,7 @@ export interface AtomicPeginResult {
  */
 export interface SignAndBroadcastParams {
   /**
-   * Funded Pre-PegIn transaction hex from prepareAtomicPegin().
+   * Funded Pre-PegIn transaction hex from preparePegin().
    */
   fundedPrePeginTxHex: string;
 
@@ -286,7 +286,7 @@ export interface RegisterPeginParams {
   vaultProvider: Address;
 
   /**
-   * SHA256 hashlock for atomic swap activation (bytes32 hex with 0x prefix).
+   * SHA256 hashlock for HTLC activation (bytes32 hex with 0x prefix).
    */
   hashlock: Hex;
 
@@ -352,11 +352,11 @@ export interface RegisterPeginResult {
  * by coordinating between SDK primitives, utilities, and wallet interfaces.
  *
  * @remarks
- * The complete atomic swap peg-in flow consists of 4 steps:
+ * The complete peg-in flow consists of 4 steps:
  *
  * | Step | Method | Description |
  * |------|--------|-------------|
- * | 1 | {@link prepareAtomicPegin} | Build Pre-PegIn HTLC, fund it, sign PegIn input |
+ * | 1 | {@link preparePegin} | Build Pre-PegIn HTLC, fund it, sign PegIn input |
  * | 2 | {@link registerPeginOnChain} | Submit to Ethereum contract with PoP |
  * | 3 | {@link PayoutManager} | Sign BOTH payout authorizations |
  * | 4 | {@link signAndBroadcast} | Sign and broadcast Pre-PegIn tx to Bitcoin network |
@@ -389,7 +389,7 @@ export class PeginManager {
   }
 
   /**
-   * Prepares an atomic swap peg-in by building the Pre-PegIn HTLC transaction,
+   * Prepares a peg-in by building the Pre-PegIn HTLC transaction,
    * funding it, constructing the PegIn transaction, and signing the PegIn input.
    *
    * This method orchestrates the following steps:
@@ -404,13 +404,13 @@ export class PeginManager {
    * The returned `fundedPrePeginTxHex` is funded but unsigned (inputs unsigned).
    * Use `signAndBroadcast()` AFTER registering on Ethereum to broadcast it.
    *
-   * @param params - Atomic pegin parameters including amount, HTLC params, UTXOs
-   * @returns Atomic pegin result with funded Pre-PegIn tx, signed PegIn input, and signatures
+   * @param params - Pegin parameters including amount, HTLC params, UTXOs
+   * @returns Pegin result with funded Pre-PegIn tx, signed PegIn input, and signatures
    * @throws Error if wallet operations fail or insufficient funds
    */
-  async prepareAtomicPegin(
-    params: CreateAtomicPeginParams,
-  ): Promise<AtomicPeginResult> {
+  async preparePegin(
+    params: PreparePeginParams,
+  ): Promise<PreparePeginResult> {
     // Step 1: Get depositor BTC public key from wallet
     const depositorBtcPubkeyRaw = await this.config.btcWallet.getPublicKeyHex();
     // Convert 33-byte compressed (66 chars) to 32-byte x-only (64 chars) if needed

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PeginManager.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PeginManager.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for PeginManager
  *
- * Tests the manager's ability to orchestrate atomic swap peg-in operations
+ * Tests the manager's ability to orchestrate peg-in operations
  * using primitives, utilities, and mock wallets.
  */
 
@@ -85,7 +85,7 @@ const TEST_HASH_H = "ab".repeat(32);
 // Mock depositor Lamport public key hash (bytes32)
 const MOCK_LAMPORT_PK_HASH = `0x${"ab".repeat(32)}` as `0x${string}`;
 
-// Mock hashlock for atomic swap (bytes32)
+// Mock hashlock for HTLC (bytes32)
 const MOCK_HASHLOCK = `0x${"cd".repeat(32)}` as `0x${string}`;
 
 // Mock depositor-signed pegin tx hex
@@ -133,8 +133,8 @@ const TEST_CONTRACT_ADDRESS =
 const TEST_CHANGE_ADDRESS =
   "tb1plqg44wluw66vpkfccz23rdmtlepnx2m3yef57yyz66flgxdf4h8q7wu6pf";
 
-// Base params for prepareAtomicPegin — shared across tests
-const BASE_ATOMIC_PEGIN_PARAMS = {
+// Base params for preparePegin — shared across tests
+const BASE_PREPARE_PEGIN_PARAMS = {
   vaultProviderBtcPubkey: TEST_KEYS.VAULT_PROVIDER,
   vaultKeeperBtcPubkeys: [TEST_KEYS.VAULT_KEEPER_1],
   universalChallengerBtcPubkeys: [TEST_KEYS.UNIVERSAL_CHALLENGER_1],
@@ -200,8 +200,8 @@ describe("PeginManager", () => {
     });
   });
 
-  describe("prepareAtomicPegin", () => {
-    it("should prepare an atomic pegin with valid params", async () => {
+  describe("preparePegin", () => {
+    it("should prepare a pegin with valid params", async () => {
       const btcWallet = new MockBitcoinWallet({
         publicKeyHex: TEST_KEYS.DEPOSITOR,
       });
@@ -216,9 +216,9 @@ describe("PeginManager", () => {
         mempoolApiUrl: MEMPOOL_API_URLS.signet,
       });
 
-      const result = await manager.prepareAtomicPegin({
+      const result = await manager.preparePegin({
         amount: TEST_AMOUNTS.PEGIN,
-        ...BASE_ATOMIC_PEGIN_PARAMS,
+        ...BASE_PREPARE_PEGIN_PARAMS,
       });
 
       // Verify result structure
@@ -267,9 +267,9 @@ describe("PeginManager", () => {
         mempoolApiUrl: MEMPOOL_API_URLS.signet,
       });
 
-      const result = await manager.prepareAtomicPegin({
+      const result = await manager.preparePegin({
         amount: TEST_AMOUNTS.PEGIN_SMALL,
-        ...BASE_ATOMIC_PEGIN_PARAMS,
+        ...BASE_PREPARE_PEGIN_PARAMS,
       });
 
       expect(result.selectedUTXOs.length).toBeGreaterThanOrEqual(1);
@@ -298,9 +298,9 @@ describe("PeginManager", () => {
         mempoolApiUrl: MEMPOOL_API_URLS.signet,
       });
 
-      const result = await manager.prepareAtomicPegin({
+      const result = await manager.preparePegin({
         amount: TEST_AMOUNTS.PEGIN,
-        ...BASE_ATOMIC_PEGIN_PARAMS,
+        ...BASE_PREPARE_PEGIN_PARAMS,
         vaultKeeperBtcPubkeys: [TEST_KEYS.VAULT_KEEPER_1, TEST_KEYS.VAULT_KEEPER_2],
       });
 
@@ -323,9 +323,9 @@ describe("PeginManager", () => {
         mempoolApiUrl: MEMPOOL_API_URLS.signet,
       });
 
-      const result = await manager.prepareAtomicPegin({
+      const result = await manager.preparePegin({
         amount: TEST_AMOUNTS.PEGIN,
-        ...BASE_ATOMIC_PEGIN_PARAMS,
+        ...BASE_PREPARE_PEGIN_PARAMS,
       });
 
       // Selected UTXOs must cover all outputs (HTLC + CPFP anchor) + fee
@@ -359,9 +359,9 @@ describe("PeginManager", () => {
       const excessiveAmount = totalAvailable + 100_000n;
 
       await expect(
-        manager.prepareAtomicPegin({
+        manager.preparePegin({
           amount: excessiveAmount,
-          ...BASE_ATOMIC_PEGIN_PARAMS,
+          ...BASE_PREPARE_PEGIN_PARAMS,
         }),
       ).rejects.toThrow(/Insufficient funds/);
     });
@@ -382,9 +382,9 @@ describe("PeginManager", () => {
       });
 
       await expect(
-        manager.prepareAtomicPegin({
+        manager.preparePegin({
           amount: TEST_AMOUNTS.PEGIN,
-          ...BASE_ATOMIC_PEGIN_PARAMS,
+          ...BASE_PREPARE_PEGIN_PARAMS,
           availableUTXOs: [],
         }),
       ).rejects.toThrow(/no UTXOs available/);
@@ -406,9 +406,9 @@ describe("PeginManager", () => {
       });
 
       await expect(
-        manager.prepareAtomicPegin({
+        manager.preparePegin({
           amount: TEST_AMOUNTS.PEGIN,
-          ...BASE_ATOMIC_PEGIN_PARAMS,
+          ...BASE_PREPARE_PEGIN_PARAMS,
           vaultProviderBtcPubkey: "invalid-pubkey",
         }),
       ).rejects.toThrow();
@@ -430,9 +430,9 @@ describe("PeginManager", () => {
       });
 
       await expect(
-        manager.prepareAtomicPegin({
+        manager.preparePegin({
           amount: TEST_AMOUNTS.PEGIN,
-          ...BASE_ATOMIC_PEGIN_PARAMS,
+          ...BASE_PREPARE_PEGIN_PARAMS,
           vaultKeeperBtcPubkeys: [],
           universalChallengerBtcPubkeys: [],
         }),
@@ -459,9 +459,9 @@ describe("PeginManager", () => {
 
       const getPublicKeySpy = vi.spyOn(btcWallet, "getPublicKeyHex");
 
-      await manager.prepareAtomicPegin({
+      await manager.preparePegin({
         amount: TEST_AMOUNTS.PEGIN,
-        ...BASE_ATOMIC_PEGIN_PARAMS,
+        ...BASE_PREPARE_PEGIN_PARAMS,
       });
 
       expect(getPublicKeySpy).toHaveBeenCalled();
@@ -488,9 +488,9 @@ describe("PeginManager", () => {
       });
 
       await expect(
-        manager.prepareAtomicPegin({
+        manager.preparePegin({
           amount: TEST_AMOUNTS.PEGIN,
-          ...BASE_ATOMIC_PEGIN_PARAMS,
+          ...BASE_PREPARE_PEGIN_PARAMS,
         }),
       ).rejects.toThrow("Wallet connection failed");
     });
@@ -694,11 +694,11 @@ describe("PeginManager", () => {
 
       const params = {
         amount: TEST_AMOUNTS.PEGIN,
-        ...BASE_ATOMIC_PEGIN_PARAMS,
+        ...BASE_PREPARE_PEGIN_PARAMS,
       };
 
-      const result1 = await manager.prepareAtomicPegin(params);
-      const result2 = await manager.prepareAtomicPegin(params);
+      const result1 = await manager.preparePegin(params);
+      const result2 = await manager.preparePegin(params);
 
       expect(result1.vaultScriptPubKey).toBe(result2.vaultScriptPubKey);
       expect(result1.peginTxid).toBe(result2.peginTxid);
@@ -734,12 +734,12 @@ describe("PeginManager", () => {
 
       const params = {
         amount: TEST_AMOUNTS.PEGIN,
-        ...BASE_ATOMIC_PEGIN_PARAMS,
+        ...BASE_PREPARE_PEGIN_PARAMS,
         vaultKeeperBtcPubkeys: [TEST_KEYS.VAULT_KEEPER_2],
       };
 
-      const result1 = await manager1.prepareAtomicPegin(params);
-      const result2 = await manager2.prepareAtomicPegin(params);
+      const result1 = await manager1.preparePegin(params);
+      const result2 = await manager2.preparePegin(params);
 
       expect(result1.vaultScriptPubKey).not.toBe(result2.vaultScriptPubKey);
     });

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/index.ts
@@ -35,8 +35,8 @@
  * ## Available Managers
  *
  * ### {@link PeginManager}
- * Orchestrates the atomic swap peg-in flow:
- * - {@link PeginManager.prepareAtomicPegin | prepareAtomicPegin()} - Build Pre-PegIn HTLC and sign PegIn input
+ * Orchestrates the peg-in flow:
+ * - {@link PeginManager.preparePegin | preparePegin()} - Build Pre-PegIn HTLC and sign PegIn input
  * - {@link PeginManager.registerPeginOnChain | registerPeginOnChain()} - Submit to Ethereum
  * - {@link PeginManager.signAndBroadcast | signAndBroadcast()} - Broadcast to Bitcoin
  *
@@ -50,7 +50,7 @@
  *
  * | Step | Manager | Method |
  * |------|---------|--------|
- * | 1 | PeginManager | `prepareAtomicPegin()` |
+ * | 1 | PeginManager | `preparePegin()` |
  * | 2 | PeginManager | `registerPeginOnChain()` |
  * | 3 | PayoutManager | `signPayoutTransaction()` |
  * | 4 | PeginManager | `signAndBroadcast()` |
@@ -69,8 +69,8 @@
 
 export { PeginManager } from "./PeginManager";
 export type {
-  AtomicPeginResult,
-  CreateAtomicPeginParams,
+  PreparePeginResult,
+  PreparePeginParams,
   PeginManagerConfig,
   RegisterPeginParams,
   RegisterPeginResult,

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts
@@ -5,7 +5,7 @@
  * and deriving PegIn transactions from them, using the WASM implementation from
  * @babylonlabs-io/babylon-tbv-rust-wasm.
  *
- * Atomic Swap Flow:
+ * Pre-PegIn Flow:
  * 1. buildPrePeginPsbt()     — creates unfunded Pre-PegIn tx (HTLC output)
  * 2. [caller funds Pre-PegIn tx and computes txid]
  * 3. buildPeginTxFromFundedPrePegin() — derives PegIn tx spending the HTLC

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts
@@ -4,8 +4,8 @@
  * Builds the PSBT for the depositor to sign the PegIn transaction's HTLC input
  * (Pre-PegIn HTLC leaf 0 — the hashlock + all-party script).
  *
- * This is the "Sign Pegin transaction HTLC leaf 0 input" step in the atomic
- * swap activation flow. The depositor signs input 0 of the PegIn transaction,
+ * This is the "Sign Pegin transaction HTLC leaf 0 input" step in the pre-pegin
+ * flow. The depositor signs input 0 of the PegIn transaction,
  * which spends output 0 of the funded Pre-PegIn transaction via script-path.
  *
  * @module primitives/psbt/peginInput

--- a/services/vault/src/components/simple/SimpleDeposit.tsx
+++ b/services/vault/src/components/simple/SimpleDeposit.tsx
@@ -161,7 +161,7 @@ function SimpleDepositContent({ open, onClose }: SimpleDepositBaseProps) {
   const handleMnemonicComplete = useCallback(
     (mnemonic?: string, mnemonicId?: string) => {
       confirmMnemonic(mnemonic, mnemonicId);
-      // Always generate secrets — the atomic swap flow requires an HTLC preimage.
+      // Always generate secrets — the pegin flow requires an HTLC preimage.
       // The feature flag only controls whether the user sees the secret modal.
       const vaultCount =
         isSplitDeposit && splitAllocationPlan

--- a/services/vault/src/hooks/deposit/depositFlowSteps/ethereumSubmit.ts
+++ b/services/vault/src/hooks/deposit/depositFlowSteps/ethereumSubmit.ts
@@ -76,7 +76,7 @@ export async function getEthWalletClient(
 // ============================================================================
 
 /**
- * Build and fund the atomic swap pegin transactions. Returns the peginTxid so
+ * Build and fund the pegin transactions. Returns the peginTxid so
  * the caller can derive the Lamport keypair before on-chain registration.
  */
 export async function preparePegin(

--- a/services/vault/src/hooks/deposit/depositFlowSteps/types.ts
+++ b/services/vault/src/hooks/deposit/depositFlowSteps/types.ts
@@ -110,7 +110,7 @@ export interface PeginRegisterParams {
   peginTxHex: string;
   /** Funded Pre-PegIn tx hex — submitted as unsignedPrePeginTx for DA */
   fundedPrePeginTxHex: string;
-  /** SHA256 hashlock for atomic swap activation (hex with 0x prefix) */
+  /** SHA256 hashlock for HTLC activation (hex with 0x prefix) */
   hashlock: Hex;
   vaultProviderAddress: string;
   onPopSigned?: () => void;

--- a/services/vault/src/hooks/deposit/useVaultActions.ts
+++ b/services/vault/src/hooks/deposit/useVaultActions.ts
@@ -221,7 +221,7 @@ export function useVaultActions(): UseVaultActionsReturn {
       }
       if (!vault.hashlock) {
         throw new Error(
-          "Vault hashlock not found. The vault may not support atomic swap activation.",
+          "Vault hashlock not found. The vault may not support activation.",
         );
       }
 

--- a/services/vault/src/services/vault/__tests__/vaultTransactionService.test.ts
+++ b/services/vault/src/services/vault/__tests__/vaultTransactionService.test.ts
@@ -12,7 +12,7 @@ const { mockPreparePegin, MockPeginManager } = vi.hoisted(() => {
   const mockPreparePegin = vi.fn();
 
   class MockPeginManager {
-    prepareAtomicPegin = mockPreparePegin;
+    preparePegin = mockPreparePegin;
   }
 
   return { mockPreparePegin, MockPeginManager };

--- a/services/vault/src/services/vault/multiVault/vaultSplitPeginService.ts
+++ b/services/vault/src/services/vault/multiVault/vaultSplitPeginService.ts
@@ -122,7 +122,7 @@ export interface RegisterSplitPeginParams {
   unsignedPrePeginTxHex: string;
   /** PegIn tx hex — submitted to contract as depositorSignedPeginTx; vault ID derived from this */
   peginTxHex: string;
-  /** SHA256 hashlock for atomic swap activation (bytes32 hex with 0x prefix) */
+  /** SHA256 hashlock for HTLC activation (bytes32 hex with 0x prefix) */
   hashlock: Hex;
   /** Ethereum address of the vault provider */
   vaultProviderAddress: Address;
@@ -176,9 +176,9 @@ export interface BroadcastSplitPeginParams {
 // ============================================================================
 
 /**
- * Build an atomic swap pegin using local split UTXO data.
+ * Build a pegin using local split UTXO data.
  *
- * Unlike `PeginManager.prepareAtomicPegin()`, this function does **not** fetch
+ * Unlike `PeginManager.preparePegin()`, this function does **not** fetch
  * UTXO data from the mempool. Instead it accepts the split output directly,
  * making it suitable for spending outputs from unconfirmed split transactions.
  *

--- a/services/vault/src/services/vault/vaultTransactionService.ts
+++ b/services/vault/src/services/vault/vaultTransactionService.ts
@@ -32,7 +32,7 @@ export interface PeginUTXOParams {
 export type UTXO = SDKUtxo;
 
 /**
- * Parameters for preparing an atomic swap pegin transaction
+ * Parameters for preparing a pegin transaction
  */
 export interface PreparePeginParams {
   pegInAmount: bigint;
@@ -59,7 +59,7 @@ export interface PreparePeginParams {
 }
 
 /**
- * Result of preparing an atomic swap pegin transaction
+ * Result of preparing a pegin transaction
  */
 export interface PreparePeginResult {
   /** Vault ID: hash of the pegin tx (NOT the pre-pegin tx). */
@@ -84,7 +84,7 @@ export interface RegisterPeginOnChainParams {
   unsignedPrePeginTxHex: string;
   /** PegIn tx hex — submitted to contract as depositorSignedPeginTx; vault ID derived from this */
   peginTxHex: string;
-  /** SHA256 hashlock for atomic swap activation (bytes32 hex with 0x prefix) */
+  /** SHA256 hashlock for HTLC activation (bytes32 hex with 0x prefix) */
   hashlock: Hex;
   vaultProviderAddress: Address;
   onPopSigned?: () => void | Promise<void>;
@@ -134,7 +134,7 @@ function createPeginManager(
 }
 
 /**
- * Build and fund the atomic swap pegin transactions without submitting to Ethereum.
+ * Build and fund the pegin transactions without submitting to Ethereum.
  *
  * Creates the Pre-PegIn HTLC transaction, funds it, derives the PegIn transaction,
  * and signs the PegIn input. Returns both transactions and the depositor's signature
@@ -147,7 +147,7 @@ export async function preparePeginTransaction(
 ): Promise<PreparePeginResult> {
   const peginManager = createPeginManager(btcWallet, ethWallet);
 
-  const atomicResult = await peginManager.prepareAtomicPegin({
+  const peginResult = await peginManager.preparePegin({
     amount: params.pegInAmount,
     vaultProviderBtcPubkey: params.vaultProviderBtcPubkey,
     vaultKeeperBtcPubkeys: params.vaultKeeperBtcPubkeys,
@@ -170,12 +170,12 @@ export async function preparePeginTransaction(
       : depositorBtcPubkeyRaw;
 
   return {
-    btcTxHash: ensureHexPrefix(atomicResult.peginTxid),
-    fundedPrePeginTxHex: atomicResult.fundedPrePeginTxHex,
-    peginTxHex: atomicResult.peginTxHex,
-    peginInputSignature: atomicResult.peginInputSignature,
-    selectedUTXOs: atomicResult.selectedUTXOs,
-    fee: atomicResult.fee,
+    btcTxHash: ensureHexPrefix(peginResult.peginTxid),
+    fundedPrePeginTxHex: peginResult.fundedPrePeginTxHex,
+    peginTxHex: peginResult.peginTxHex,
+    peginInputSignature: peginResult.peginInputSignature,
+    selectedUTXOs: peginResult.selectedUTXOs,
+    fee: peginResult.fee,
     depositorBtcPubkey,
   };
 }

--- a/services/vault/src/types/vault.ts
+++ b/services/vault/src/types/vault.ts
@@ -50,10 +50,10 @@ export interface Vault {
   /** Version of vault keepers at vault creation */
   vkVersion: number;
 
-  /** Hashlock for atomic swap (HTLC hash) */
+  /** Hashlock for HTLC pegin flow */
   hashlock?: Hex;
 
-  /** Secret preimage for atomic swap (revealed after claim) */
+  /** Secret preimage for HTLC (revealed after claim) */
   secret?: Hex;
 
   /** Timestamp when pegin signatures were posted on-chain (milliseconds) */

--- a/services/vault/src/utils/htlcSecret.ts
+++ b/services/vault/src/utils/htlcSecret.ts
@@ -1,7 +1,7 @@
 /**
  * HTLC Secret Utilities
  *
- * The atomic swap pegin flow uses an HTLC (Hash Time Lock Contract) where the
+ * The pre-pegin flow uses an HTLC (Hash Time Lock Contract) where the
  * depositor commits to a secret preimage H = SHA256(secret). Secret generation
  * is handled by `secretUtils.ts`; this module provides validation utilities
  * for verifying a secret against an on-chain hashlock.


### PR DESCRIPTION
- Renamed `prepareAtomicPegin()` → `preparePegin()`, `CreateAtomicPeginParams` → `PreparePeginParams`, `AtomicPeginResult` → `PreparePeginResult` across ts-sdk
 and vault service
- Updated all comments/docs referencing "atomic swap" to use "pegin flow", "pre-pegin flow", or "HTLC" as appropriate
- No behavioral changes — pure rename/comment cleanup