### PR TITLE
refactor(vault): centralise Taproot script-path sign options into sha…

### DIFF
--- a/packages/babylon-ts-sdk/src/shared/wallets/__tests__/signOptions.test.ts
+++ b/packages/babylon-ts-sdk/src/shared/wallets/__tests__/signOptions.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import { createTaprootScriptPathSignOptions } from "../signOptions";
+
+const TEST_PUBKEY =
+  "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
+
+describe("createTaprootScriptPathSignOptions", () => {
+  it("produces a single entry at index 0 for inputCount = 1", () => {
+    const opts = createTaprootScriptPathSignOptions(TEST_PUBKEY, 1);
+
+    expect(opts.autoFinalized).toBe(false);
+    expect(opts.signInputs).toEqual([
+      { index: 0, publicKey: TEST_PUBKEY, disableTweakSigner: true },
+    ]);
+  });
+
+  it("produces entries at indices 0, 1, 2 for inputCount = 3", () => {
+    const opts = createTaprootScriptPathSignOptions(TEST_PUBKEY, 3);
+
+    expect(opts.signInputs).toHaveLength(3);
+    expect(opts.signInputs!.map((s) => s.index)).toEqual([0, 1, 2]);
+    opts.signInputs!.forEach((s) => {
+      expect(s.publicKey).toBe(TEST_PUBKEY);
+      expect(s.disableTweakSigner).toBe(true);
+    });
+  });
+
+  it("throws for inputCount = 0", () => {
+    expect(() => createTaprootScriptPathSignOptions(TEST_PUBKEY, 0)).toThrow(
+      "inputCount must be a positive integer, got 0",
+    );
+  });
+
+  it("throws for negative inputCount", () => {
+    expect(() => createTaprootScriptPathSignOptions(TEST_PUBKEY, -1)).toThrow(
+      "inputCount must be a positive integer, got -1",
+    );
+  });
+
+  it("throws for NaN", () => {
+    expect(() =>
+      createTaprootScriptPathSignOptions(TEST_PUBKEY, NaN),
+    ).toThrow("inputCount must be a positive integer, got NaN");
+  });
+
+  it("throws for non-integer", () => {
+    expect(() =>
+      createTaprootScriptPathSignOptions(TEST_PUBKEY, 1.5),
+    ).toThrow("inputCount must be a positive integer, got 1.5");
+  });
+});

--- a/packages/babylon-ts-sdk/src/shared/wallets/signOptions.ts
+++ b/packages/babylon-ts-sdk/src/shared/wallets/signOptions.ts
@@ -16,6 +16,10 @@ export function createTaprootScriptPathSignOptions(
   publicKey: string,
   inputCount: number,
 ): SignPsbtOptions {
+  if (!Number.isInteger(inputCount) || inputCount < 1) {
+    throw new Error(`inputCount must be a positive integer, got ${inputCount}`);
+  }
+
   return {
     autoFinalized: false,
     signInputs: Array.from({ length: inputCount }, (_, i) => ({

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts
@@ -17,8 +17,8 @@
 import type {
   BitcoinWallet,
   SignPsbtOptions,
-} from "../../../shared/wallets/interfaces/BitcoinWallet";
-import { createTaprootScriptPathSignOptions } from "../../../shared/wallets/signOptions";
+} from "../../../shared/wallets";
+import { createTaprootScriptPathSignOptions } from "../../../shared/wallets";
 import {
   buildPayoutPsbt,
   extractPayoutSignature,

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
@@ -31,9 +31,8 @@ import {
   type WalletClient,
 } from "viem";
 
-import type { BitcoinWallet } from "../../../shared/wallets/interfaces/BitcoinWallet";
-import { createTaprootScriptPathSignOptions } from "../../../shared/wallets/signOptions";
-import type { Hash } from "../../../shared/wallets/interfaces/EthereumWallet";
+import type { BitcoinWallet, Hash } from "../../../shared/wallets";
+import { createTaprootScriptPathSignOptions } from "../../../shared/wallets";
 import { getUtxoInfo, pushTx } from "../clients/mempool";
 import { BTCVaultRegistryABI, handleContractError } from "../contracts";
 import {

--- a/services/vault/src/services/vault/__tests__/depositorGraphSigningService.test.ts
+++ b/services/vault/src/services/vault/__tests__/depositorGraphSigningService.test.ts
@@ -14,17 +14,6 @@ vi.mock("@babylonlabs-io/ts-sdk/tbv/core", () => ({
   extractPayoutSignature: vi.fn().mockReturnValue("default_sig_hex"),
 }));
 
-vi.mock("@babylonlabs-io/ts-sdk/shared", () => ({
-  createTaprootScriptPathSignOptions: (publicKey: string, inputCount: number) => ({
-    autoFinalized: false,
-    signInputs: Array.from({ length: inputCount }, (_, i) => ({
-      index: i,
-      publicKey,
-      disableTweakSigner: true,
-    })),
-  }),
-}));
-
 // Mock Psbt.fromBase64 for PSBT integrity verification
 vi.mock("bitcoinjs-lib", () => ({
   Psbt: {

--- a/services/vault/src/services/vault/depositorGraphSigningService.ts
+++ b/services/vault/src/services/vault/depositorGraphSigningService.ts
@@ -14,7 +14,10 @@
  * @see btc-vault docs/pegin.md — "Automatic Graph Creation & Presigning"
  */
 
-import type { BitcoinWallet, SignPsbtOptions } from "@babylonlabs-io/ts-sdk/shared";
+import type {
+  BitcoinWallet,
+  SignPsbtOptions,
+} from "@babylonlabs-io/ts-sdk/shared";
 import { createTaprootScriptPathSignOptions } from "@babylonlabs-io/ts-sdk/shared";
 import { extractPayoutSignature } from "@babylonlabs-io/ts-sdk/tbv/core";
 import { Psbt } from "bitcoinjs-lib";
@@ -111,7 +114,10 @@ function collectDepositorGraphPsbts(
   const signOptions: SignPsbtOptions[] = [];
   const challengerIndexMap: ChallengerIndexEntry[] = [];
 
-  const singleInputOpts = createTaprootScriptPathSignOptions(walletPublicKey, 1);
+  const singleInputOpts = createTaprootScriptPathSignOptions(
+    walletPublicKey,
+    1,
+  );
   const challengeAssertOpts = createTaprootScriptPathSignOptions(
     walletPublicKey,
     NUM_CHALLENGE_ASSERT_INPUTS,

--- a/services/vault/src/services/vault/multiVault/__tests__/vaultSplitPeginService.test.ts
+++ b/services/vault/src/services/vault/multiVault/__tests__/vaultSplitPeginService.test.ts
@@ -141,17 +141,6 @@ vi.mock("@babylonlabs-io/ts-sdk", () => ({
   pushTx: mockPushTx,
 }));
 
-vi.mock("@babylonlabs-io/ts-sdk/shared", () => ({
-  createTaprootScriptPathSignOptions: (publicKey: string, inputCount: number) => ({
-    autoFinalized: false,
-    signInputs: Array.from({ length: inputCount }, (_, i) => ({
-      index: i,
-      publicKey,
-      disableTweakSigner: true,
-    })),
-  }),
-}));
-
 vi.mock("@babylonlabs-io/config", () => ({
   getETHChain: vi.fn(() => ({ id: 11155111, name: "Sepolia" })),
 }));

--- a/services/vault/src/services/vault/multiVault/vaultSplitPeginService.ts
+++ b/services/vault/src/services/vault/multiVault/vaultSplitPeginService.ts
@@ -21,7 +21,10 @@
 
 import { getETHChain } from "@babylonlabs-io/config";
 import { pushTx } from "@babylonlabs-io/ts-sdk";
-import type { BitcoinWallet, SignPsbtOptions } from "@babylonlabs-io/ts-sdk/shared";
+import type {
+  BitcoinWallet,
+  SignPsbtOptions,
+} from "@babylonlabs-io/ts-sdk/shared";
 import { createTaprootScriptPathSignOptions } from "@babylonlabs-io/ts-sdk/shared";
 import type { UTXO } from "@babylonlabs-io/ts-sdk/tbv/core";
 import {


### PR DESCRIPTION
- Added `createTaprootScriptPathSignOptions(publicKey, inputCount)` in ts-sdk shared module
- Replaced 5 duplicated signInputs constructions across PeginManager, PayoutManager, depositorGraphSigningService, and vaultSplitPeginService
- Removed two local helpers (`taprootScriptSignOptions`, `challengeAssertSignOptions`) from depositorGraphSigningService that are now redundant