### PR TITLE
fix(vault): default safety-critical feature flags to disabled

### DIFF
--- a/services/vault/.env.example
+++ b/services/vault/.env.example
@@ -27,11 +27,6 @@ NEXT_PUBLIC_TBV_VP_PROXY_URL=https://vault-provider-proxy-api.vault-devnet.babyl
 NEXT_PUBLIC_TBV_BTC_VAULT_REGISTRY=0x2ec4128df7c515ecfbcdcf8813e9471249e134e6
 NEXT_PUBLIC_TBV_AAVE_ADAPTER=0xfa934e4f579b92e0e4d8a9f8e42b3ca00591acf0
 NEXT_PUBLIC_TBV_AAVE_SPOKE=0x659ef79b87067e1a32fa3819a7530469287aef7e
-# Feature Flags
-# Safety-critical kill-switches — must be explicitly set to "true" to enable functionality.
-NEXT_PUBLIC_FF_ENABLE_DEPOSIT=true
-NEXT_PUBLIC_FF_ENABLE_BORROW=true
-
 # Reown (WalletConnect) project ID for wallet integration
 NEXT_PUBLIC_REOWN_PROJECT_ID=your-reown-project-id-here
 

--- a/services/vault/README.md
+++ b/services/vault/README.md
@@ -74,14 +74,14 @@ Create a `.env` file with the following variables:
 
 ### Feature Flags
 
-- `NEXT_PUBLIC_FF_ENABLE_DEPOSIT` - Controls whether deposit functionality is available
-  - Default: `true` (deposits are enabled unless explicitly set to `"false"`)
-  - Set to `"false"` to disable deposit functionality during maintenance or incidents
+- `NEXT_PUBLIC_FF_DISABLE_DEPOSIT` - Kill-switch to disable deposit functionality during maintenance or incidents
+  - Default: `false` (deposits are enabled unless explicitly set to `"true"`)
+  - Set to `"true"` to disable deposit functionality
   - When disabled, users will see "Depositing Unavailable" and the deposit button will be disabled
 
-- `NEXT_PUBLIC_FF_ENABLE_BORROW` - Controls whether borrowing functionality is available
-  - Default: `true` (borrowing is enabled unless explicitly set to `"false"`)
-  - Set to `"false"` to disable borrowing functionality during maintenance or incidents
+- `NEXT_PUBLIC_FF_DISABLE_BORROW` - Kill-switch to disable borrowing functionality during maintenance or incidents
+  - Default: `false` (borrowing is enabled unless explicitly set to `"true"`)
+  - Set to `"true"` to disable borrowing functionality
   - When disabled, users will see "Borrowing Unavailable" and the borrow button will be disabled
 
 - `NEXT_PUBLIC_FF_SIMPLIFIED_TERMS` - Controls whether the wallet connection dialog shows simplified terms

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/index.tsx
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/index.tsx
@@ -75,7 +75,7 @@ export function Borrow() {
   };
 
   const getBorrowButtonText = () => {
-    if (!FeatureFlags.isBorrowEnabled) return "Borrowing Unavailable";
+    if (FeatureFlags.isBorrowDisabled) return "Borrowing Unavailable";
     if (isProcessing) return "Processing...";
     return buttonText;
   };
@@ -139,7 +139,7 @@ export function Borrow() {
         )}
 
         {/* Borrow Unavailable Message */}
-        {!FeatureFlags.isBorrowEnabled && (
+        {FeatureFlags.isBorrowDisabled && (
           <Text variant="body2" className="text-center text-warning-main">
             Borrowing is temporarily unavailable. Please check back later.
           </Text>
@@ -152,7 +152,7 @@ export function Borrow() {
         color="secondary"
         size="large"
         fluid
-        disabled={isDisabled || isProcessing || !FeatureFlags.isBorrowEnabled}
+        disabled={isDisabled || isProcessing || FeatureFlags.isBorrowDisabled}
         onClick={handleBorrow}
         className="mt-6"
       >

--- a/services/vault/src/components/simple/BorrowFlow/BorrowForm.tsx
+++ b/services/vault/src/components/simple/BorrowFlow/BorrowForm.tsx
@@ -189,7 +189,7 @@ function BorrowFormView({ state, onChangeAsset }: BorrowFormViewProps) {
         size="large"
         fluid
         disabled={
-          state.isDisabled || state.isProcessing || !state.isBorrowEnabled
+          state.isDisabled || state.isProcessing || state.isBorrowDisabled
         }
         onClick={state.handleBorrow}
         className="mt-6"

--- a/services/vault/src/components/simple/BorrowFlow/useBorrowFormState.ts
+++ b/services/vault/src/components/simple/BorrowFlow/useBorrowFormState.ts
@@ -39,7 +39,7 @@ export interface BorrowFormState {
   isDisabled: boolean;
   buttonText: string;
   isProcessing: boolean;
-  isBorrowEnabled: boolean;
+  isBorrowDisabled: boolean;
   showLiquidationWarning: boolean;
 
   // Details card
@@ -138,7 +138,7 @@ export function useBorrowFormState({
     }
   };
 
-  const resolvedButtonText = !FeatureFlags.isBorrowEnabled
+  const resolvedButtonText = FeatureFlags.isBorrowDisabled
     ? "Borrowing Unavailable"
     : isProcessing
       ? "Processing..."
@@ -161,7 +161,7 @@ export function useBorrowFormState({
     isDisabled,
     buttonText: resolvedButtonText,
     isProcessing,
-    isBorrowEnabled: FeatureFlags.isBorrowEnabled,
+    isBorrowDisabled: FeatureFlags.isBorrowDisabled,
     showLiquidationWarning:
       borrowAmount > 0 &&
       isFinite(metrics.healthFactorValue) &&

--- a/services/vault/src/components/simple/DepositForm.tsx
+++ b/services/vault/src/components/simple/DepositForm.tsx
@@ -62,7 +62,7 @@ interface DepositFormProps {
   estimatedFeeRate: number;
   isLoadingFee: boolean;
   feeError: string | null;
-  isDepositEnabled: boolean;
+  isDepositDisabled: boolean;
   isGeoBlocked: boolean;
   onDeposit: () => void;
 
@@ -90,7 +90,7 @@ export function DepositForm({
   estimatedFeeRate,
   isLoadingFee,
   feeError,
-  isDepositEnabled,
+  isDepositDisabled,
   isGeoBlocked,
   onDeposit,
   partialLiquidation,
@@ -173,7 +173,7 @@ export function DepositForm({
         });
   const ctaDisabled =
     !isValid ||
-    !isDepositEnabled ||
+    isDepositDisabled ||
     isGeoBlocked ||
     !hasAmount ||
     feeDisabled ||
@@ -312,7 +312,7 @@ export function DepositForm({
         disabled={ctaDisabled}
         onClick={onDeposit}
       >
-        {isDepositEnabled ? ctaLabel : "Depositing Unavailable"}
+        {isDepositDisabled ? "Depositing Unavailable" : ctaLabel}
       </DepositButton>
 
       {/* Fee breakdown */}

--- a/services/vault/src/components/simple/SimpleDeposit.tsx
+++ b/services/vault/src/components/simple/SimpleDeposit.tsx
@@ -267,7 +267,7 @@ function SimpleDepositContent({ open, onClose }: SimpleDepositBaseProps) {
                 estimatedFeeRate={estimatedFeeRate}
                 isLoadingFee={isLoadingFee}
                 feeError={feeError}
-                isDepositEnabled={FeatureFlags.isDepositEnabled}
+                isDepositDisabled={FeatureFlags.isDepositDisabled}
                 isGeoBlocked={isGeoBlocked || isGeoLoading}
                 onDeposit={handleDeposit}
                 partialLiquidation={partialLiquidationProps}

--- a/services/vault/src/config/featureFlags.ts
+++ b/services/vault/src/config/featureFlags.ts
@@ -9,31 +9,28 @@
  * 1. All feature flags must be defined in this file for easy maintenance
  * 2. All feature flags must start with NEXT_PUBLIC_FF_ prefix
  * 3. All flags use opt-in semantics (=== "true") and default to false
- *    Safety-critical kill-switches (deposit, borrow) must be explicitly enabled per environment
  * 4. Feature flags are only configurable by DevOps in mainnet environments
  */
 
 export default {
   /**
-   * ENABLE_DEPOSIT feature flag
+   * DISABLE_DEPOSIT feature flag
    *
-   * Purpose: Controls whether deposit functionality is available
-   * Why needed: Allows disabling deposits during maintenance or incidents
-   * Default: false (deposits are disabled unless explicitly set to "true")
+   * Purpose: Kill-switch to disable deposit functionality during maintenance or incidents
+   * Default: false (deposits are enabled unless explicitly set to "true")
    */
-  get isDepositEnabled() {
-    return process.env.NEXT_PUBLIC_FF_ENABLE_DEPOSIT === "true";
+  get isDepositDisabled() {
+    return process.env.NEXT_PUBLIC_FF_DISABLE_DEPOSIT === "true";
   },
 
   /**
-   * ENABLE_BORROW feature flag
+   * DISABLE_BORROW feature flag
    *
-   * Purpose: Controls whether borrowing functionality is available
-   * Why needed: Allows disabling borrowing during maintenance or incidents
-   * Default: false (borrowing is disabled unless explicitly set to "true")
+   * Purpose: Kill-switch to disable borrowing functionality during maintenance or incidents
+   * Default: false (borrowing is enabled unless explicitly set to "true")
    */
-  get isBorrowEnabled() {
-    return process.env.NEXT_PUBLIC_FF_ENABLE_BORROW === "true";
+  get isBorrowDisabled() {
+    return process.env.NEXT_PUBLIC_FF_DISABLE_BORROW === "true";
   },
 
   /**

--- a/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
@@ -19,8 +19,8 @@ vi.mock("@/config/contracts", () => ({
 
 vi.mock("@/config", () => ({
   FeatureFlags: {
-    isDepositEnabled: true,
-    isBorrowEnabled: true,
+    isDepositDisabled: false,
+    isBorrowDisabled: false,
     isSimplifiedTermsEnabled: false,
   },
 }));


### PR DESCRIPTION
Deposit and borrow kill-switch flags used opt-out semantics (!== "false"), meaning an unset or misspelled env var silently enabled the feature. Switch to opt-in (=== "true") so omitted flags default to disabled — the safe direction for incident-response controls.

BREAKING CHANGE: All environments must now explicitly set NEXT_PUBLIC_FF_ENABLE_DEPOSIT=true and NEXT_PUBLIC_FF_ENABLE_BORROW=true to enable deposit and borrow functionality.

Addresses: Security audit finding [78](https://github.com/babylonlabs-io/vault-provider-proxy/issues/90)