### PR TITLE
refactor(vault): derive ChallengeAssert input count from PSBT instead…

### DIFF
--- a/services/vault/src/clients/vault-provider-rpc/types.ts
+++ b/services/vault/src/clients/vault-provider-rpc/types.ts
@@ -25,7 +25,7 @@ export interface SubmitDepositorLamportKeyParams {
 
 /** Per-challenger signatures for the depositor-as-claimer flow. */
 export interface DepositorPreSigsPerChallenger {
-  challenge_assert_signatures: [string, string, string];
+  challenge_assert_signatures: string[];
   nopayout_signature: string;
 }
 
@@ -84,7 +84,7 @@ export interface PresignDataPerChallenger {
   challenger_pubkey: string;
   challenge_assert_tx: TransactionData;
   nopayout_tx: TransactionData;
-  /** Unsigned PSBT (base64) for the ChallengeAssert transaction (all 3 inputs). */
+  /** Unsigned PSBT (base64) for the ChallengeAssert transaction. */
   challenge_assert_psbt: string;
   /** Unsigned PSBT (base64) for the NoPayout transaction (input 0). */
   nopayout_psbt: string;

--- a/services/vault/src/services/vault/__tests__/depositorGraphSigningService.test.ts
+++ b/services/vault/src/services/vault/__tests__/depositorGraphSigningService.test.ts
@@ -75,6 +75,9 @@ function createMockParams(
   };
 }
 
+/** Number of ChallengeAssert inputs used in test fixtures. */
+const TEST_CHALLENGE_ASSERT_INPUT_COUNT = 3;
+
 /**
  * Configure Psbt.fromBase64 mock to return a fake PSBT whose getTransaction()
  * returns the matching tx_hex for verification to pass.
@@ -83,10 +86,12 @@ function setupPsbtVerificationMock(
   depositorGraph: DepositorGraphTransactions,
 ): void {
   const txHexByPsbt = new Map<string, string>();
+  const challengeAssertPsbts = new Set<string>();
   txHexByPsbt.set(depositorGraph.payout_psbt, depositorGraph.payout_tx.tx_hex);
   for (const c of depositorGraph.challenger_presign_data) {
     txHexByPsbt.set(c.nopayout_psbt, c.nopayout_tx.tx_hex);
     txHexByPsbt.set(c.challenge_assert_psbt, c.challenge_assert_tx.tx_hex);
+    challengeAssertPsbts.add(c.challenge_assert_psbt);
   }
 
   vi.mocked(Psbt.fromBase64).mockImplementation((b64: string) => {
@@ -97,6 +102,9 @@ function setupPsbtVerificationMock(
           toString: (encoding: string) =>
             encoding === "hex" ? (expectedHex ?? "mismatch") : "",
         }),
+        inputs: challengeAssertPsbts.has(b64)
+          ? Array(TEST_CHALLENGE_ASSERT_INPUT_COUNT).fill({})
+          : [{}],
       },
     } as any;
   });
@@ -363,7 +371,7 @@ describe("depositorGraphSigningService", () => {
       wallet.signPsbts.mockResolvedValue([]);
 
       await expect(signDepositorGraph(params)).rejects.toThrow(
-        /payout_psbt is missing/,
+        /Missing depositor payout PSBT/,
       );
     });
 
@@ -376,7 +384,7 @@ describe("depositorGraphSigningService", () => {
       wallet.signPsbts.mockResolvedValue(Array(3).fill("signed_hex"));
 
       await expect(signDepositorGraph(params)).rejects.toThrow(
-        /Missing nopayout_psbt/,
+        /Missing nopayout.*PSBT/,
       );
     });
 
@@ -390,7 +398,7 @@ describe("depositorGraphSigningService", () => {
       wallet.signPsbts.mockResolvedValue(Array(3).fill("signed_hex"));
 
       await expect(signDepositorGraph(params)).rejects.toThrow(
-        /Missing challenge_assert_psbt/,
+        /Missing challenge_assert.*PSBT/,
       );
     });
 
@@ -433,6 +441,7 @@ describe("depositorGraphSigningService", () => {
                       : "wrong_tx_hex"
                     : "",
               }),
+              inputs: [{}],
             },
           }) as any,
       );
@@ -470,6 +479,7 @@ describe("depositorGraphSigningService", () => {
                       : "wrong_tx_hex"
                     : "",
               }),
+              inputs: Array(TEST_CHALLENGE_ASSERT_INPUT_COUNT).fill({}),
             },
           }) as any,
       );

--- a/services/vault/src/services/vault/depositorGraphSigningService.ts
+++ b/services/vault/src/services/vault/depositorGraphSigningService.ts
@@ -9,7 +9,7 @@
  * produce signatures without extra context.
  *
  * Transaction counts: 1 Payout + N NoPayout + N ChallengeAssert = 1 + 2N total PSBTs
- * (each ChallengeAssert PSBT has 3 inputs signed in one go)
+ * (each ChallengeAssert PSBT's input count is derived from the PSBT itself)
  *
  * @see btc-vault docs/pegin.md — "Automatic Graph Creation & Presigning"
  */
@@ -31,12 +31,6 @@ import type {
 import { signPsbtsWithFallback, stripHexPrefix } from "../../utils/btc";
 import { sanitizeErrorMessage } from "../../utils/errors/formatting";
 
-/**
- * Number of ChallengeAssert inputs per challenger.
- * Protocol constant from btc-vault (NUM_UTXOS_FOR_CHALLENGE_ASSERT).
- */
-const NUM_CHALLENGE_ASSERT_INPUTS = 3;
-
 /** Convert a base64-encoded PSBT to hex (wallet signing format). */
 function base64ToHex(b64: string): string {
   return Buffer.from(b64, "base64").toString("hex");
@@ -55,17 +49,18 @@ export interface SignDepositorGraphParams {
 }
 
 /** Tracks which indices in the flat PSBT array belong to which challenger */
-interface ChallengerIndexEntry {
+interface ChallengerEntry {
   challengerPubkey: string;
   noPayoutIdx: number;
   challengeAssertIdx: number;
+  challengeAssertInputCount: number;
 }
 
 /** Result of the collect phase — flat PSBT array with index mapping */
 interface CollectedDepositorGraphPsbts {
   psbtHexes: string[];
   signOptions: SignPsbtOptions[];
-  challengerIndexMap: ChallengerIndexEntry[];
+  challengerEntries: ChallengerEntry[];
 }
 
 // ============================================================================
@@ -73,18 +68,18 @@ interface CollectedDepositorGraphPsbts {
 // ============================================================================
 
 /**
- * Verify that a base64-encoded PSBT's unsigned transaction matches the
- * expected transaction hex. Catches VP serialization bugs.
+ * Parse a base64-encoded PSBT and verify its unsigned transaction matches
+ * the expected transaction hex. Catches VP serialization bugs.
  *
+ * @returns the parsed Psbt (for callers that need to inspect inputs)
  * @throws if the PSBT's unsigned transaction doesn't match tx_hex
  */
-function verifyPsbtMatchesTxHex(
+function verifyAndParsePsbt(
   psbtBase64: string,
   expectedTxHex: string,
   label: string,
-): void {
+): Psbt {
   const psbt = Psbt.fromBase64(psbtBase64);
-  // psbt.data is a bip174 PsbtBase; getTransaction() returns the unsigned tx as a Buffer
   const unsignedTxHex = stripHexPrefix(
     psbt.data.getTransaction().toString("hex"),
   ).toLowerCase();
@@ -94,6 +89,25 @@ function verifyPsbtMatchesTxHex(
       `PSBT integrity check failed for ${label}: unsigned transaction does not match tx_hex`,
     );
   }
+  return psbt;
+}
+
+/**
+ * Validate that a PSBT field is present, verify it against expected tx_hex,
+ * and convert to hex for wallet signing.
+ *
+ * @throws if psbtBase64 is falsy or fails integrity check
+ */
+function validateAndConvertPsbt(
+  psbtBase64: string | undefined,
+  expectedTxHex: string,
+  label: string,
+): string {
+  if (!psbtBase64) {
+    throw new Error(`Missing ${label} PSBT`);
+  }
+  verifyAndParsePsbt(psbtBase64, expectedTxHex, label);
+  return base64ToHex(psbtBase64);
 }
 
 // ============================================================================
@@ -112,71 +126,71 @@ function collectDepositorGraphPsbts(
 ): CollectedDepositorGraphPsbts {
   const psbtHexes: string[] = [];
   const signOptions: SignPsbtOptions[] = [];
-  const challengerIndexMap: ChallengerIndexEntry[] = [];
+  const challengerEntries: ChallengerEntry[] = [];
 
   const singleInputOpts = createTaprootScriptPathSignOptions(
     walletPublicKey,
     1,
   );
-  const challengeAssertOpts = createTaprootScriptPathSignOptions(
-    walletPublicKey,
-    NUM_CHALLENGE_ASSERT_INPUTS,
-  );
 
   // Index 0: Payout PSBT
-  if (!depositorGraph.payout_psbt) {
-    throw new Error("depositorGraph.payout_psbt is missing");
-  }
-  verifyPsbtMatchesTxHex(
+  const payoutHex = validateAndConvertPsbt(
     depositorGraph.payout_psbt,
     depositorGraph.payout_tx.tx_hex,
     "depositor payout",
   );
-  psbtHexes.push(base64ToHex(depositorGraph.payout_psbt));
+  psbtHexes.push(payoutHex);
   signOptions.push(singleInputOpts);
 
-  // Per-challenger: 1 NoPayout + 1 ChallengeAssert (with 3 inputs)
+  // Per-challenger: 1 NoPayout + 1 ChallengeAssert
   for (const challenger of depositorGraph.challenger_presign_data) {
     const challengerPubkey = stripHexPrefix(challenger.challenger_pubkey);
 
-    // NoPayout PSBT
+    // NoPayout PSBT — single input
     const noPayoutIdx = psbtHexes.length;
-    if (!challenger.nopayout_psbt) {
-      throw new Error(
-        `Missing nopayout_psbt for challenger ${challengerPubkey}`,
-      );
-    }
-    verifyPsbtMatchesTxHex(
+    const noPayoutHex = validateAndConvertPsbt(
       challenger.nopayout_psbt,
       challenger.nopayout_tx.tx_hex,
       `nopayout (challenger ${challengerPubkey})`,
     );
-    psbtHexes.push(base64ToHex(challenger.nopayout_psbt));
+    psbtHexes.push(noPayoutHex);
     signOptions.push(singleInputOpts);
 
-    // ChallengeAssert PSBT — 1 PSBT with NUM_CHALLENGE_ASSERT_INPUTS inputs
+    // ChallengeAssert PSBT — input count derived from the PSBT itself
     const challengeAssertIdx = psbtHexes.length;
     if (!challenger.challenge_assert_psbt) {
       throw new Error(
-        `Missing challenge_assert_psbt for challenger ${challengerPubkey}`,
+        `Missing challenge_assert (challenger ${challengerPubkey}) PSBT`,
       );
     }
-    verifyPsbtMatchesTxHex(
+    const caPsbt = verifyAndParsePsbt(
       challenger.challenge_assert_psbt,
       challenger.challenge_assert_tx.tx_hex,
       `challenge_assert (challenger ${challengerPubkey})`,
     );
+    const challengeAssertInputCount = caPsbt.data.inputs.length;
+    if (challengeAssertInputCount === 0) {
+      throw new Error(
+        `ChallengeAssert PSBT for challenger ${challengerPubkey} has 0 inputs — expected at least 1`,
+      );
+    }
     psbtHexes.push(base64ToHex(challenger.challenge_assert_psbt));
-    signOptions.push(challengeAssertOpts);
+    signOptions.push(
+      createTaprootScriptPathSignOptions(
+        walletPublicKey,
+        challengeAssertInputCount,
+      ),
+    );
 
-    challengerIndexMap.push({
+    challengerEntries.push({
       challengerPubkey,
       noPayoutIdx,
       challengeAssertIdx,
+      challengeAssertInputCount,
     });
   }
 
-  return { psbtHexes, signOptions, challengerIndexMap };
+  return { psbtHexes, signOptions, challengerEntries };
 }
 
 // ============================================================================
@@ -188,7 +202,7 @@ function collectDepositorGraphPsbts(
  */
 function extractDepositorGraphSignatures(
   signedPsbtHexes: string[],
-  challengerIndexMap: ChallengerIndexEntry[],
+  challengerEntries: ChallengerEntry[],
   depositorPubkey: string,
 ): DepositorAsClaimerPresignatures {
   // Payout signature (index 0, input 0)
@@ -199,14 +213,14 @@ function extractDepositorGraphSignatures(
 
   // Per-challenger signatures
   const perChallenger: Record<string, DepositorPreSigsPerChallenger> = {};
-  for (const entry of challengerIndexMap) {
+  for (const entry of challengerEntries) {
     const caSignedPsbt = signedPsbtHexes[entry.challengeAssertIdx];
 
     perChallenger[entry.challengerPubkey] = {
       challenge_assert_signatures: Array.from(
-        { length: NUM_CHALLENGE_ASSERT_INPUTS },
+        { length: entry.challengeAssertInputCount },
         (_, i) => extractPayoutSignature(caSignedPsbt, depositorPubkey, i),
-      ) as [string, string, string],
+      ),
       nopayout_signature: extractPayoutSignature(
         signedPsbtHexes[entry.noPayoutIdx],
         depositorPubkey,
@@ -246,7 +260,7 @@ export async function signDepositorGraph(
   const walletPublicKey = await btcWallet.getPublicKeyHex();
 
   // 1. Collect pre-built PSBTs from VP response
-  const { psbtHexes, signOptions, challengerIndexMap } =
+  const { psbtHexes, signOptions, challengerEntries } =
     collectDepositorGraphPsbts(depositorGraph, walletPublicKey);
 
   // 2. Sign all PSBTs (batch when wallet supports it, sequential fallback for mobile)
@@ -273,7 +287,7 @@ export async function signDepositorGraph(
   // 3. Extract signatures and assemble presignatures
   return extractDepositorGraphSignatures(
     signedPsbtHexes,
-    challengerIndexMap,
+    challengerEntries,
     depositorPubkey,
   );
 }


### PR DESCRIPTION
## Summary
- Remove hardcoded `NUM_CHALLENGE_ASSERT_INPUTS = 3` constant — derive the ChallengeAssert input count from the
PSBT itself at runtime
- Widen `challenge_assert_signatures` type from `[string, string, string]` to `string[]` to support variable input
 counts
- Refactor `collectDepositorGraphPsbts`: extract `verifyAndParsePsbt` (returns parsed PSBT) and
`validateAndConvertPsbt` (existence check + verify + hex convert) helpers to reduce duplication
- Rename `challengerIndexMap` → `challengerEntries` for clarity

## Why
The protocol's ChallengeAssert input count may not always be 3. Deriving it from the PSBT makes the signing
service forward-compatible with protocol changes without requiring code updates.

## Follow-up
- Input count validation (assert expected count) will be added in a separate PR