### PR TITLE
fix(vault): derive timelockPegin from vault's locked offchainParamsVe…

### DIFF
--- a/services/vault/src/clients/eth-contract/btc-vault-registry/__tests__/query.test.ts
+++ b/services/vault/src/clients/eth-contract/btc-vault-registry/__tests__/query.test.ts
@@ -27,6 +27,7 @@ const FULL_VAULT = {
   vaultProvider: "0xVaultProvider" as `0x${string}`,
   universalChallengersVersion: 1,
   appVaultKeepersVersion: 2,
+  offchainParamsVersion: 3,
 };
 
 describe("getVaultFromChain", () => {
@@ -41,6 +42,7 @@ describe("getVaultFromChain", () => {
       vaultProvider: FULL_VAULT.vaultProvider,
       universalChallengersVersion: FULL_VAULT.universalChallengersVersion,
       appVaultKeepersVersion: FULL_VAULT.appVaultKeepersVersion,
+      offchainParamsVersion: FULL_VAULT.offchainParamsVersion,
     });
   });
 

--- a/services/vault/src/clients/eth-contract/btc-vault-registry/query.ts
+++ b/services/vault/src/clients/eth-contract/btc-vault-registry/query.ts
@@ -23,6 +23,8 @@ export interface OnChainVaultData {
   vaultProvider: Address;
   universalChallengersVersion: number;
   appVaultKeepersVersion: number;
+  /** Offchain params version locked at vault creation — use for timelockPegin lookup */
+  offchainParamsVersion: number;
 }
 
 /**
@@ -54,7 +56,8 @@ export async function getVaultFromChain(
     depositorSignedPeginTx: vault.depositorSignedPeginTx,
     applicationEntryPoint: vault.applicationEntryPoint,
     vaultProvider: vault.vaultProvider,
-    universalChallengersVersion: vault.universalChallengersVersion,
-    appVaultKeepersVersion: vault.appVaultKeepersVersion,
+    universalChallengersVersion: Number(vault.universalChallengersVersion),
+    appVaultKeepersVersion: Number(vault.appVaultKeepersVersion),
+    offchainParamsVersion: Number(vault.offchainParamsVersion),
   };
 }

--- a/services/vault/src/clients/eth-contract/protocol-params/query.ts
+++ b/services/vault/src/clients/eth-contract/protocol-params/query.ts
@@ -207,6 +207,20 @@ export async function getOffchainParamsByVersion(
   return result as VersionedOffchainParams;
 }
 
+/**
+ * Get timelockPegin for a specific offchain params version.
+ * timelockPegin = uint16(timelockAssert), matching PeginLogic.sol:115.
+ *
+ * Use the vault's locked offchainParamsVersion — using the latest version
+ * would produce invalid signatures if timelockAssert changed after vault creation.
+ */
+export async function getTimelockPeginByVersion(
+  offchainParamsVersion: number,
+): Promise<number> {
+  const params = await getOffchainParamsByVersion(offchainParamsVersion);
+  return Number(params.timelockAssert);
+}
+
 /** All offchain params grouped by version */
 export interface AllOffchainParamsData {
   byVersion: Map<number, VersionedOffchainParams>;

--- a/services/vault/src/components/deposit/PayoutSignModal/usePayoutSigningState.ts
+++ b/services/vault/src/components/deposit/PayoutSignModal/usePayoutSigningState.ts
@@ -82,11 +82,8 @@ export function usePayoutSigningState({
   const { findProvider, vaultKeepers } = useVaultProviders(
     activity.applicationEntryPoint,
   );
-  const {
-    latestUniversalChallengers,
-    getUniversalChallengersByVersion,
-    timelockPegin,
-  } = useProtocolParamsContext();
+  const { latestUniversalChallengers, getUniversalChallengersByVersion } =
+    useProtocolParamsContext();
   const btcConnector = useChainConnector("BTC");
   const { setOptimisticStatus } = usePeginPolling();
 
@@ -166,7 +163,6 @@ export function usePayoutSigningState({
         peginTxId: activity.txHash!,
         depositorBtcPubkey: btcPublicKey,
         providers,
-        timelockPegin,
         getUniversalChallengersByVersion,
       });
 
@@ -231,7 +227,6 @@ export function usePayoutSigningState({
     vaultKeepers,
     latestUniversalChallengers,
     getUniversalChallengersByVersion,
-    timelockPegin,
     btcConnector?.connectedWallet?.provider,
     btcPublicKey,
     depositorEthAddress,

--- a/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
@@ -273,12 +273,33 @@ vi.mock("@/services/vault/vaultActivationService", () => ({
     .mockResolvedValue({ hash: "0xActivationTxHash" }),
 }));
 
+// Mock pegin status polling (used by pollAndPreparePayoutSigning)
+vi.mock("@/services/vault/vaultPeginStatusService", () => ({
+  waitForPeginStatus: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Mock on-chain vault query (used by pollAndPreparePayoutSigning for timelockPegin)
+vi.mock("@/clients/eth-contract/btc-vault-registry/query", () => ({
+  getVaultFromChain: vi.fn().mockResolvedValue({
+    depositorSignedPeginTx: "0xmockpegintx",
+    applicationEntryPoint: "0xAaveAdapter123",
+    vaultProvider: "0xProvider123",
+    universalChallengersVersion: 1,
+    appVaultKeepersVersion: 1,
+    offchainParamsVersion: 1,
+  }),
+}));
+
 // Mock protocol params query to avoid ETH client initialization
 vi.mock("@/clients/eth-contract/protocol-params/query", () => ({
   getLatestOffchainParams: vi.fn().mockResolvedValue({
     timelockAssert: 100,
     securityCouncilKeys: ["0xcouncil1"],
   }),
+}));
+
+vi.mock("@/clients/eth-contract/protocol-params", () => ({
+  getTimelockPeginByVersion: vi.fn().mockResolvedValue(100),
 }));
 
 // Mock Lamport service (deriveLamportPkHash returns a mock hash)

--- a/services/vault/src/hooks/deposit/depositFlowSteps/payoutSigning.ts
+++ b/services/vault/src/hooks/deposit/depositFlowSteps/payoutSigning.ts
@@ -2,8 +2,10 @@
  * Step 3: Payout signing - poll for transactions and submit signatures
  */
 
-import type { Address } from "viem";
+import type { Address, Hex } from "viem";
 
+import { getVaultFromChain } from "@/clients/eth-contract/btc-vault-registry/query";
+import { getTimelockPeginByVersion } from "@/clients/eth-contract/protocol-params";
 import { VaultProviderRpcApi } from "@/clients/vault-provider-rpc";
 import type {
   ClaimerSignatures,
@@ -62,7 +64,6 @@ export async function pollAndPreparePayoutSigning(
     providerBtcPubKey,
     vaultKeepers,
     universalChallengers,
-    timelockPegin,
     signal,
   } = params;
 
@@ -84,6 +85,14 @@ export async function pollAndPreparePayoutSigning(
     pegin_txid: stripHexPrefix(btcTxid),
     depositor_pk: stripHexPrefix(depositorBtcPubkey),
   });
+
+  // Derive timelockPegin from the vault's locked offchainParamsVersion.
+  // Using the latest offchain params would produce invalid signatures if
+  // timelockAssert changed between vault creation and payout signing.
+  const vault = await getVaultFromChain(btcTxid as Hex);
+  const timelockPegin = await getTimelockPeginByVersion(
+    vault.offchainParamsVersion,
+  );
 
   const vaultKeeperBtcPubkeys = getSortedVaultKeeperPubkeys(vaultKeepers);
   const universalChallengerBtcPubkeys =

--- a/services/vault/src/hooks/deposit/depositFlowSteps/types.ts
+++ b/services/vault/src/hooks/deposit/depositFlowSteps/types.ts
@@ -167,8 +167,6 @@ export interface PayoutSigningParams {
   providerBtcPubKey: string;
   vaultKeepers: Array<{ btcPubKey: string }>;
   universalChallengers: Array<{ btcPubKey: string }>;
-  /** CSV timelock in blocks for the PegIn output */
-  timelockPegin: number;
   /** Optional AbortSignal for cancellation */
   signal?: AbortSignal;
 }

--- a/services/vault/src/hooks/deposit/useDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useDepositFlow.ts
@@ -360,7 +360,6 @@ export function useDepositFlow(
           universalChallengers: latestUniversalChallengers.map((uc) => ({
             btcPubKey: uc.btcPubKey,
           })),
-          timelockPegin,
           signal,
         });
 

--- a/services/vault/src/hooks/deposit/useMultiVaultDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useMultiVaultDepositFlow.ts
@@ -888,7 +888,6 @@ export function useMultiVaultDepositFlow(
                   btcPubKey,
                 }),
               ),
-              timelockPegin,
               signal,
             });
 

--- a/services/vault/src/services/vault/__tests__/vaultPayoutSignatureService.test.ts
+++ b/services/vault/src/services/vault/__tests__/vaultPayoutSignatureService.test.ts
@@ -25,12 +25,18 @@ vi.mock("../../../clients/vault-provider-rpc", () => ({
   VaultProviderRpcApi: vi.fn(),
 }));
 
+// Mock versioned timelockPegin lookup (used by prepareSigningContext)
+vi.mock("../../../clients/eth-contract/protocol-params", () => ({
+  getTimelockPeginByVersion: vi.fn(),
+}));
+
 // Mock config
 vi.mock("../../../config/pegin", () => ({
   getBTCNetworkForWASM: vi.fn().mockReturnValue("testnet"),
 }));
 
 import { getVaultFromChain } from "../../../clients/eth-contract/btc-vault-registry/query";
+import { getTimelockPeginByVersion } from "../../../clients/eth-contract/protocol-params";
 import type { ClaimerTransactions } from "../../../clients/vault-provider-rpc/types";
 import { fetchVaultKeepersByVersion } from "../../providers/fetchProviders";
 import { fetchVaultProviderById } from "../fetchVaultProviders";
@@ -543,6 +549,7 @@ describe("vaultPayoutSignatureService", () => {
       vaultProvider: "0xOnChainVaultProvider" as `0x${string}`,
       universalChallengersVersion: 1,
       appVaultKeepersVersion: 2,
+      offchainParamsVersion: 3,
     };
 
     const vaultKeepers = [
@@ -565,12 +572,12 @@ describe("vaultPayoutSignatureService", () => {
     it("sources peginTxHex from on-chain vault data, not params", async () => {
       vi.mocked(getVaultFromChain).mockResolvedValue(onChainVault);
       vi.mocked(fetchVaultKeepersByVersion).mockResolvedValue(vaultKeepers);
+      vi.mocked(getTimelockPeginByVersion).mockResolvedValue(100);
 
       const { context } = await prepareSigningContext({
         peginTxId,
         depositorBtcPubkey,
         providers,
-        timelockPegin: 100,
         getUniversalChallengersByVersion: () => universalChallengers,
       });
 
@@ -581,12 +588,12 @@ describe("vaultPayoutSignatureService", () => {
     it("fetches vault keepers using version from on-chain vault", async () => {
       vi.mocked(getVaultFromChain).mockResolvedValue(onChainVault);
       vi.mocked(fetchVaultKeepersByVersion).mockResolvedValue(vaultKeepers);
+      vi.mocked(getTimelockPeginByVersion).mockResolvedValue(100);
 
       await prepareSigningContext({
         peginTxId,
         depositorBtcPubkey,
         providers,
-        timelockPegin: 100,
         getUniversalChallengersByVersion: () => universalChallengers,
       });
 
@@ -603,12 +610,12 @@ describe("vaultPayoutSignatureService", () => {
       const getUniversalChallengersByVersion = vi
         .fn()
         .mockReturnValue(universalChallengers);
+      vi.mocked(getTimelockPeginByVersion).mockResolvedValue(100);
 
       await prepareSigningContext({
         peginTxId,
         depositorBtcPubkey,
         providers,
-        timelockPegin: 100,
         getUniversalChallengersByVersion,
       });
 
@@ -620,13 +627,13 @@ describe("vaultPayoutSignatureService", () => {
     it("throws when no universal challengers exist for the on-chain version", async () => {
       vi.mocked(getVaultFromChain).mockResolvedValue(onChainVault);
       vi.mocked(fetchVaultKeepersByVersion).mockResolvedValue(vaultKeepers);
+      vi.mocked(getTimelockPeginByVersion).mockResolvedValue(100);
 
       await expect(
         prepareSigningContext({
           peginTxId,
           depositorBtcPubkey,
           providers,
-          timelockPegin: 100,
           getUniversalChallengersByVersion: () => [],
         }),
       ).rejects.toThrow(
@@ -634,9 +641,28 @@ describe("vaultPayoutSignatureService", () => {
       );
     });
 
+    it("derives timelockPegin from vault's locked offchainParamsVersion", async () => {
+      vi.mocked(getVaultFromChain).mockResolvedValue(onChainVault);
+      vi.mocked(fetchVaultKeepersByVersion).mockResolvedValue(vaultKeepers);
+      vi.mocked(getTimelockPeginByVersion).mockResolvedValue(42);
+
+      const { context } = await prepareSigningContext({
+        peginTxId,
+        depositorBtcPubkey,
+        providers,
+        getUniversalChallengersByVersion: () => universalChallengers,
+      });
+
+      expect(getTimelockPeginByVersion).toHaveBeenCalledWith(
+        onChainVault.offchainParamsVersion,
+      );
+      expect(context.timelockPegin).toBe(42);
+    });
+
     it("resolves vault provider btc pubkey from GraphQL using on-chain address when not provided inline", async () => {
       vi.mocked(getVaultFromChain).mockResolvedValue(onChainVault);
       vi.mocked(fetchVaultKeepersByVersion).mockResolvedValue(vaultKeepers);
+      vi.mocked(getTimelockPeginByVersion).mockResolvedValue(100);
       vi.mocked(fetchVaultProviderById).mockResolvedValue({
         btcPubKey: "0xfetchedproviderkey",
       } as any);
@@ -648,7 +674,6 @@ describe("vaultPayoutSignatureService", () => {
           ...providers,
           vaultProvider: {},
         },
-        timelockPegin: 100,
         getUniversalChallengersByVersion: () => universalChallengers,
       });
 

--- a/services/vault/src/services/vault/vaultPayoutSignatureService.ts
+++ b/services/vault/src/services/vault/vaultPayoutSignatureService.ts
@@ -3,6 +3,7 @@ import { PayoutManager, type Network } from "@babylonlabs-io/ts-sdk/tbv/core";
 import type { Address, Hex } from "viem";
 
 import { getVaultFromChain } from "../../clients/eth-contract/btc-vault-registry/query";
+import { getTimelockPeginByVersion } from "../../clients/eth-contract/protocol-params";
 import { VaultProviderRpcApi } from "../../clients/vault-provider-rpc";
 import type {
   ClaimerSignatures,
@@ -53,8 +54,6 @@ export interface PrepareSigningContextParams {
   peginTxId: string;
   depositorBtcPubkey: string;
   providers: PayoutProviders;
-  /** CSV timelock in blocks for the PegIn output */
-  timelockPegin: number;
   /** Function to get UCs by version from context (avoids redundant fetch) */
   getUniversalChallengersByVersion: (version: number) => UniversalChallenger[];
 }
@@ -267,7 +266,6 @@ export async function prepareSigningContext(
     peginTxId,
     depositorBtcPubkey,
     providers,
-    timelockPegin,
     getUniversalChallengersByVersion,
   } = params;
   // Fetch signing-critical vault fields from the contract (authoritative source).
@@ -275,6 +273,10 @@ export async function prepareSigningContext(
   // substitute a different pegin transaction or signer-set versions and obtain
   // signatures over attacker-chosen graph parameters.
   const vault = await getVaultFromChain(peginTxId as Hex);
+
+  const timelockPegin = await getTimelockPeginByVersion(
+    vault.offchainParamsVersion,
+  );
 
   // Fetch versioned vault keepers (per-application)
   const vaultKeepers = await fetchVaultKeepersByVersion(


### PR DESCRIPTION
- Both payout signing paths (`prepareSigningContext` and `pollAndPreparePayoutSigning`) were using the latest `timelockAssert` from protocol params context. If `timelockAssert` changed between vault
creation and payout signing, signatures would be invalid. Now both paths fetch `timelockPegin` from the vault's locked `offchainParamsVersion` via on-chain contract read.
- Exposed `offchainParamsVersion` from `getVaultFromChain()` and added `Number()` normalization at the contract boundary for all version fields.
- Removed `timelockPegin` from `PayoutSigningParams` and `PrepareSigningContextParams` interfaces since it's now derived internally.