### PR TITLE
feat(ts-sdk): extract Lamport core derivation to SDK and add localPre…

### DIFF
--- a/packages/babylon-ts-sdk/package.json
+++ b/packages/babylon-ts-sdk/package.json
@@ -78,6 +78,8 @@
   "dependencies": {
     "@babylonlabs-io/babylon-tbv-rust-wasm": "workspace:*",
     "@bitcoin-js/tiny-secp256k1-asmjs": "2.2.3",
+    "@noble/hashes": "2.0.1",
+    "@scure/bip39": "2.0.1",
     "bitcoinjs-lib": "6.1.7",
     "buffer": "6.0.3"
   },

--- a/packages/babylon-ts-sdk/src/tbv/core/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/index.ts
@@ -16,3 +16,4 @@ export * from "./utils";
 export * from "./managers";
 export * from "./clients";
 export * from "./contracts";
+export * from "./lamport";

--- a/packages/babylon-ts-sdk/src/tbv/core/lamport/__tests__/derivation.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/lamport/__tests__/derivation.test.ts
@@ -1,0 +1,289 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  computeLamportPkHash,
+  deriveLamportKeypair,
+  keypairToPublicKey,
+  mnemonicToLamportSeed,
+} from "../derivation";
+import { deriveLamportPkHash } from "../deriveLamportPkHash";
+import { isLamportMismatchError } from "../errors";
+
+const KNOWN_MNEMONIC =
+  "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+
+describe("lamport derivation (SDK)", () => {
+  describe("mnemonicToLamportSeed", () => {
+    it("produces a 64-byte seed", () => {
+      const seed = mnemonicToLamportSeed(KNOWN_MNEMONIC);
+      expect(seed).toBeInstanceOf(Uint8Array);
+      expect(seed.length).toBe(64);
+    });
+
+    it("is deterministic for the same mnemonic", () => {
+      const a = mnemonicToLamportSeed(KNOWN_MNEMONIC);
+      const b = mnemonicToLamportSeed(KNOWN_MNEMONIC);
+      expect(a).toEqual(b);
+    });
+  });
+
+  describe("deriveLamportKeypair", () => {
+    const freshSeed = () => mnemonicToLamportSeed(KNOWN_MNEMONIC);
+    const vaultId = "vault-1";
+    const depositorPk = "pk-abc";
+    const appContractAddress = "0x1234";
+
+    it("generates 508 preimage and hash slots per type", async () => {
+      const keypair = await deriveLamportKeypair(
+        freshSeed(),
+        vaultId,
+        depositorPk,
+        appContractAddress,
+      );
+      expect(keypair.falsePreimages).toHaveLength(508);
+      expect(keypair.truePreimages).toHaveLength(508);
+      expect(keypair.falseHashes).toHaveLength(508);
+      expect(keypair.trueHashes).toHaveLength(508);
+    });
+
+    it("produces 16-byte preimages and 20-byte hashes", async () => {
+      const keypair = await deriveLamportKeypair(
+        freshSeed(),
+        vaultId,
+        depositorPk,
+        appContractAddress,
+      );
+      keypair.falsePreimages.forEach((p) => expect(p.length).toBe(16));
+      keypair.truePreimages.forEach((p) => expect(p.length).toBe(16));
+      keypair.falseHashes.forEach((h) => expect(h.length).toBe(20));
+      keypair.trueHashes.forEach((h) => expect(h.length).toBe(20));
+    });
+
+    it("is deterministic for the same inputs", async () => {
+      const a = await deriveLamportKeypair(
+        freshSeed(),
+        vaultId,
+        depositorPk,
+        appContractAddress,
+      );
+      const b = await deriveLamportKeypair(
+        freshSeed(),
+        vaultId,
+        depositorPk,
+        appContractAddress,
+      );
+      expect(a.falsePreimages).toEqual(b.falsePreimages);
+      expect(a.truePreimages).toEqual(b.truePreimages);
+      expect(a.falseHashes).toEqual(b.falseHashes);
+      expect(a.trueHashes).toEqual(b.trueHashes);
+    });
+
+    it("rejects a seed that is not 64 bytes", async () => {
+      await expect(
+        deriveLamportKeypair(
+          new Uint8Array(32),
+          vaultId,
+          depositorPk,
+          appContractAddress,
+        ),
+      ).rejects.toThrow(/seed must be 64 bytes/);
+    });
+
+    it("produces different keys for different vault IDs", async () => {
+      const a = await deriveLamportKeypair(
+        freshSeed(),
+        "vault-1",
+        depositorPk,
+        appContractAddress,
+      );
+      const b = await deriveLamportKeypair(
+        freshSeed(),
+        "vault-2",
+        depositorPk,
+        appContractAddress,
+      );
+      expect(a.falsePreimages[0]).not.toEqual(b.falsePreimages[0]);
+    });
+  });
+
+  describe("keypairToPublicKey", () => {
+    it("converts keypair hashes to hex strings", async () => {
+      const seed = mnemonicToLamportSeed(KNOWN_MNEMONIC);
+      const keypair = await deriveLamportKeypair(
+        seed,
+        "vault-1",
+        "pk-abc",
+        "0x1234",
+      );
+      const pubkey = keypairToPublicKey(keypair);
+
+      expect(pubkey.false_list).toHaveLength(508);
+      expect(pubkey.true_list).toHaveLength(508);
+      pubkey.false_list.forEach((h: string) =>
+        expect(h).toMatch(/^[0-9a-f]{40}$/),
+      );
+      pubkey.true_list.forEach((h: string) =>
+        expect(h).toMatch(/^[0-9a-f]{40}$/),
+      );
+    });
+  });
+
+  describe("computeLamportPkHash", () => {
+    const freshSeed = () => mnemonicToLamportSeed(KNOWN_MNEMONIC);
+    const vaultId = "vault-1";
+    const depositorPk = "pk-abc";
+    const appContractAddress = "0x1234";
+
+    it("produces a deterministic hash for known inputs", async () => {
+      const keypair = await deriveLamportKeypair(
+        freshSeed(),
+        vaultId,
+        depositorPk,
+        appContractAddress,
+      );
+      const hash = computeLamportPkHash(keypair);
+      expect(hash).toBe(
+        "0x27242076796ab9f57b3734af2cc39bf367f26aecced2bdd200a609052657e98e",
+      );
+    });
+
+    it("returns the same hash for the same keypair derived twice", async () => {
+      const keypairA = await deriveLamportKeypair(
+        freshSeed(),
+        vaultId,
+        depositorPk,
+        appContractAddress,
+      );
+      const keypairB = await deriveLamportKeypair(
+        freshSeed(),
+        vaultId,
+        depositorPk,
+        appContractAddress,
+      );
+      expect(computeLamportPkHash(keypairA)).toBe(
+        computeLamportPkHash(keypairB),
+      );
+    });
+
+    it("produces different hashes for different vault IDs", async () => {
+      const keypairA = await deriveLamportKeypair(
+        freshSeed(),
+        "vault-1",
+        depositorPk,
+        appContractAddress,
+      );
+      const keypairB = await deriveLamportKeypair(
+        freshSeed(),
+        "vault-2",
+        depositorPk,
+        appContractAddress,
+      );
+      expect(computeLamportPkHash(keypairA)).not.toBe(
+        computeLamportPkHash(keypairB),
+      );
+    });
+
+    it("returns a 0x-prefixed 66-character hex string", async () => {
+      const keypair = await deriveLamportKeypair(
+        freshSeed(),
+        vaultId,
+        depositorPk,
+        appContractAddress,
+      );
+      const hash = computeLamportPkHash(keypair);
+      expect(hash).toMatch(/^0x[0-9a-f]{64}$/);
+      expect(hash.length).toBe(66);
+    });
+
+    it("changes when a single bit position hash is modified", async () => {
+      const keypair = await deriveLamportKeypair(
+        freshSeed(),
+        vaultId,
+        depositorPk,
+        appContractAddress,
+      );
+      const originalHash = computeLamportPkHash(keypair);
+
+      const tampered: typeof keypair = {
+        falsePreimages: keypair.falsePreimages,
+        truePreimages: keypair.truePreimages,
+        falseHashes: keypair.falseHashes,
+        trueHashes: keypair.trueHashes.map((h, i) => {
+          if (i === 507) {
+            const copy = new Uint8Array(h);
+            copy[0] ^= 0x01;
+            return copy;
+          }
+          return h;
+        }),
+      };
+
+      expect(computeLamportPkHash(tampered)).not.toBe(originalHash);
+    });
+  });
+
+  describe("deriveLamportPkHash", () => {
+    it("produces the same hash as manual seed + derive + compute", async () => {
+      const vaultId = "vault-1";
+      const depositorPk = "pk-abc";
+      const appContractAddress = "0x1234";
+
+      const hash = await deriveLamportPkHash(
+        KNOWN_MNEMONIC,
+        vaultId,
+        depositorPk,
+        appContractAddress,
+      );
+
+      expect(hash).toBe(
+        "0x27242076796ab9f57b3734af2cc39bf367f26aecced2bdd200a609052657e98e",
+      );
+    });
+  });
+
+  describe("isLamportMismatchError", () => {
+    it("returns true for the exact VP error message", () => {
+      const err = new Error(
+        "Lamport public key hash does not match on-chain commitment",
+      );
+      expect(isLamportMismatchError(err)).toBe(true);
+    });
+
+    it("returns true when the VP message is embedded in a wrapper error", () => {
+      const err = new Error(
+        "RPC error: Lamport public key hash does not match on-chain commitment (code 3002)",
+      );
+      expect(isLamportMismatchError(err)).toBe(true);
+    });
+
+    it("returns false for network errors", () => {
+      expect(isLamportMismatchError(new Error("fetch failed"))).toBe(false);
+    });
+
+    it("returns false for missing field errors", () => {
+      expect(
+        isLamportMismatchError(new Error("Missing transaction hash")),
+      ).toBe(false);
+    });
+
+    it("returns false for generic errors", () => {
+      expect(
+        isLamportMismatchError(new Error("Failed to submit lamport key")),
+      ).toBe(false);
+    });
+
+    it("handles string errors", () => {
+      expect(
+        isLamportMismatchError(
+          "Lamport public key hash does not match on-chain commitment",
+        ),
+      ).toBe(true);
+    });
+
+    it("handles non-error values", () => {
+      expect(isLamportMismatchError(null)).toBe(false);
+      expect(isLamportMismatchError(undefined)).toBe(false);
+      expect(isLamportMismatchError(42)).toBe(false);
+    });
+  });
+});

--- a/packages/babylon-ts-sdk/src/tbv/core/lamport/derivation.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/lamport/derivation.ts
@@ -1,0 +1,323 @@
+/**
+ * @module lamport/derivation
+ *
+ * Deterministic Lamport one-time-signature key derivation for Babylon vault
+ * deposits. Pure crypto functions extracted from the vault frontend into the
+ * shared SDK.
+ *
+ * See the vault frontend's `lamportService.ts` for the full derivation
+ * documentation.
+ */
+import { hmac } from "@noble/hashes/hmac.js";
+import { ripemd160 } from "@noble/hashes/legacy.js";
+import { sha256, sha512 } from "@noble/hashes/sha2.js";
+import { keccak_256 } from "@noble/hashes/sha3.js";
+import { mnemonicToSeedSync } from "@scure/bip39";
+
+import { stripHexPrefix } from "../primitives/utils/bitcoin";
+
+import type { LamportKeypair, LamportPublicKey } from "./types";
+
+/**
+ * Number of bit positions in the Lamport keypair. Corresponds to the number
+ * of garbled-circuit labels used in the BitVM-style protocol (PI_1 circuit).
+ */
+const PI_1_BITS = 508;
+
+/**
+ * Size in bytes of each Lamport preimage (garbled-circuit label size).
+ * Preimages are truncated from HMAC-SHA-512 output to this length.
+ */
+const GC_LABEL_SIZE = 16;
+
+/** Size in bytes of the parent key or derived key (first half of a 64-byte seed/HMAC). */
+const KEY_SIZE = 32;
+
+/** Size in bytes of the full BIP-39 seed / HMAC-SHA-512 output. */
+const SEED_SIZE = 64;
+
+/** Size of the index buffer used in per-bit derivation (1 byte flag + 4 byte big-endian index). */
+const INDEX_BUFFER_SIZE = 5;
+
+/** Size of the big-endian length prefix prepended to variable-length fields. */
+const LENGTH_PREFIX_SIZE = 4;
+
+// ---------------------------------------------------------------------------
+// Internal byte-manipulation utilities
+// ---------------------------------------------------------------------------
+
+/** Concatenate multiple `Uint8Array` buffers into a single array. */
+function concatBytes(...arrays: Uint8Array[]): Uint8Array {
+  const totalLength = arrays.reduce((sum, arr) => sum + arr.length, 0);
+  const result = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const arr of arrays) {
+    result.set(arr, offset);
+    offset += arr.length;
+  }
+  return result;
+}
+
+/** Encode a UTF-8 string as bytes. */
+function stringToBytes(str: string): Uint8Array {
+  return new TextEncoder().encode(str);
+}
+
+/**
+ * Prepend a 4-byte big-endian length prefix to `data`.
+ * Used to unambiguously concatenate variable-length fields in the vault
+ * derivation path.
+ */
+function lengthPrefixed(data: Uint8Array): Uint8Array {
+  const len = new Uint8Array(LENGTH_PREFIX_SIZE);
+  new DataView(len.buffer).setUint32(0, data.length, false);
+  return concatBytes(len, data);
+}
+
+// ---------------------------------------------------------------------------
+// Internal cryptographic primitives (@noble/hashes wrappers)
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute HMAC-SHA-512.
+ *
+ * Uses `@noble/hashes/hmac` which accepts `Uint8Array` directly,
+ * avoiding the unsafe `Uint8Array.buffer as ArrayBuffer` cast that
+ * the Web Crypto API would require.
+ *
+ * @param key  - HMAC key bytes.
+ * @param data - Message bytes.
+ * @returns 64-byte HMAC digest.
+ */
+function hmacSha512(key: Uint8Array, data: Uint8Array): Uint8Array {
+  return hmac(sha512, key, data);
+}
+
+/**
+ * Compute Hash160: `RIPEMD-160(SHA-256(data))`.
+ *
+ * This is the same hash function used in Bitcoin for address derivation.
+ *
+ * @param data - Input bytes.
+ * @returns 20-byte hash.
+ */
+function hash160(data: Uint8Array): Uint8Array {
+  return ripemd160(sha256(data));
+}
+
+/** Convert a byte array to a lowercase hex string. */
+const toHex = (bytes: Uint8Array) =>
+  Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+
+// ---------------------------------------------------------------------------
+// Seed and keypair derivation
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a BIP-39 mnemonic into a 64-byte seed.
+ *
+ * Internally uses PBKDF2 with 2048 rounds of HMAC-SHA-512 and the passphrase
+ * `"mnemonic"` (no user password), per the BIP-39 specification.
+ *
+ * @param mnemonic - A valid 12-word BIP-39 mnemonic.
+ * @returns 64-byte seed suitable for {@link deriveLamportKeypair}.
+ */
+export function mnemonicToLamportSeed(mnemonic: string): Uint8Array {
+  const seed = mnemonicToSeedSync(mnemonic);
+  return new Uint8Array(seed);
+}
+
+/**
+ * Derive a deterministic Lamport keypair for a specific vault.
+ *
+ * ### Derivation steps
+ *
+ * 1. **Split the seed** — bytes `[0..32)` = parent key, `[32..64)` = chain code.
+ *
+ * 2. **Child key derivation** —
+ *    ```
+ *    vaultData = lenPrefix(vaultId) || lenPrefix(depositorPk) || lenPrefix(appContractAddress)
+ *    hmac      = HMAC-SHA-512(chainCode, parentKey || vaultData)
+ *    derivedKey       = hmac[0..32)
+ *    derivedChainCode = hmac[32..64)
+ *    ```
+ *
+ * 3. **Bit-level key expansion** — For each bit index `i` in `[0, 508)`:
+ *    ```
+ *    falseHmac = HMAC-SHA-512(derivedChainCode, derivedKey || 0x00 || bigEndian32(i))
+ *    trueHmac  = HMAC-SHA-512(derivedChainCode, derivedKey || 0x01 || bigEndian32(i))
+ *
+ *    falsePreimage = falseHmac[0..16)     // 16 bytes = GC_LABEL_SIZE
+ *    truePreimage  = trueHmac[0..16)
+ *
+ *    falseHash = Hash160(falsePreimage)    // 20 bytes
+ *    trueHash  = Hash160(truePreimage)
+ *    ```
+ *
+ * 4. **Cleanup** — All intermediate key material is zeroed.
+ *
+ * The same (mnemonic, vaultId, depositorPk, appContractAddress) tuple always
+ * produces the same keypair, enabling recovery from the mnemonic alone.
+ *
+ * @param seed               - 64-byte seed from {@link mnemonicToLamportSeed}.
+ * @param vaultId            - Unique identifier of the vault (e.g. pegin tx hash).
+ * @param depositorPk        - Depositor's public key (hex string).
+ * @param appContractAddress - Ethereum address of the application contract.
+ * @returns A {@link LamportKeypair} with 508 preimage/hash pairs per branch.
+ */
+export async function deriveLamportKeypair(
+  seed: Uint8Array,
+  vaultId: string,
+  depositorPk: string,
+  appContractAddress: string,
+): Promise<LamportKeypair> {
+  if (seed.length !== SEED_SIZE) {
+    throw new Error(
+      `Lamport seed must be ${SEED_SIZE} bytes, got ${seed.length}`,
+    );
+  }
+
+  // Normalize BTC-style inputs by stripping 0x prefixes.
+  // appContractAddress is NOT stripped — Ethereum addresses include the 0x
+  // prefix in their canonical form, and existing on-chain commitments were
+  // computed with it included. Changing this would break hash determinism.
+  vaultId = stripHexPrefix(vaultId);
+  depositorPk = stripHexPrefix(depositorPk);
+
+  const chainCode = seed.slice(KEY_SIZE, SEED_SIZE);
+  const parentKey = seed.slice(0, KEY_SIZE);
+
+  // Track all intermediate buffers containing key material for cleanup.
+  const sensitiveBuffers: Uint8Array[] = [chainCode, parentKey];
+
+  try {
+    const vaultData = concatBytes(
+      lengthPrefixed(stringToBytes(vaultId)),
+      lengthPrefixed(stringToBytes(depositorPk)),
+      lengthPrefixed(stringToBytes(appContractAddress)),
+    );
+
+    const hmacInput = concatBytes(parentKey, vaultData);
+    sensitiveBuffers.push(hmacInput);
+
+    const hmacResult = hmacSha512(chainCode, hmacInput);
+    sensitiveBuffers.push(hmacResult);
+
+    const derivedKey = hmacResult.slice(0, KEY_SIZE);
+    const derivedChainCode = hmacResult.slice(KEY_SIZE, SEED_SIZE);
+    sensitiveBuffers.push(derivedKey, derivedChainCode);
+
+    const falsePreimages: Uint8Array[] = [];
+    const truePreimages: Uint8Array[] = [];
+    const falseHashes: Uint8Array[] = [];
+    const trueHashes: Uint8Array[] = [];
+
+    let succeeded = false;
+    try {
+      for (let bit = 0; bit < PI_1_BITS; bit++) {
+        const falseIndex = new Uint8Array(INDEX_BUFFER_SIZE);
+        falseIndex[0] = 0;
+        new DataView(falseIndex.buffer).setUint32(1, bit, false);
+
+        const trueIndex = new Uint8Array(INDEX_BUFFER_SIZE);
+        trueIndex[0] = 1;
+        new DataView(trueIndex.buffer).setUint32(1, bit, false);
+
+        const falseInput = concatBytes(derivedKey, falseIndex);
+        const trueInput = concatBytes(derivedKey, trueIndex);
+        const falseHmac = hmacSha512(derivedChainCode, falseInput);
+        const trueHmac = hmacSha512(derivedChainCode, trueInput);
+
+        try {
+          const falsePreimage = falseHmac.slice(0, GC_LABEL_SIZE);
+          const truePreimage = trueHmac.slice(0, GC_LABEL_SIZE);
+
+          falsePreimages.push(falsePreimage);
+          truePreimages.push(truePreimage);
+          falseHashes.push(hash160(falsePreimage));
+          trueHashes.push(hash160(truePreimage));
+        } finally {
+          falseInput.fill(0);
+          trueInput.fill(0);
+          falseHmac.fill(0);
+          trueHmac.fill(0);
+        }
+      }
+
+      succeeded = true;
+      return { falsePreimages, truePreimages, falseHashes, trueHashes };
+    } finally {
+      if (!succeeded) {
+        for (const p of falsePreimages) p.fill(0);
+        for (const p of truePreimages) p.fill(0);
+      }
+    }
+  } finally {
+    for (const buf of sensitiveBuffers) {
+      buf.fill(0);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Serialization
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract the public key from a Lamport keypair.
+ *
+ * The public key consists of the Hash160 digests (hex-encoded) for both
+ * the `false` and `true` branch of each bit position. This is the value
+ * submitted on-chain and to the vault provider for later signature
+ * verification.
+ *
+ * @param keypair - A derived {@link LamportKeypair}.
+ * @returns The {@link LamportPublicKey} with `false_list` and `true_list`,
+ *          each containing 508 hex strings of 40 characters (20 bytes).
+ */
+export function keypairToPublicKey(keypair: LamportKeypair): LamportPublicKey {
+  return {
+    false_list: keypair.falseHashes.map(toHex),
+    true_list: keypair.trueHashes.map(toHex),
+  };
+}
+
+/**
+ * Compute the keccak256 hash of a Lamport keypair's public key.
+ *
+ * Matches the Rust `InputLabelHashes::keccak256_hash()` implementation:
+ * `keccak256(falseHashes[0] || falseHashes[1] || ... || trueHashes[0] || trueHashes[1] || ...)`
+ *
+ * Each hash is 20 bytes (Hash160). Total input: `PI_1_BITS * 20 * 2` bytes.
+ * The result is committed on-chain as `depositorLamportPkHash` so the vault
+ * provider can later verify submitted Lamport public keys.
+ *
+ * @param keypair - A derived {@link LamportKeypair}.
+ * @returns 32-byte keccak256 digest as a `0x`-prefixed hex string.
+ */
+export function computeLamportPkHash(keypair: LamportKeypair): `0x${string}` {
+  if (keypair.falseHashes.length === 0 || keypair.trueHashes.length === 0) {
+    throw new Error(
+      "computeLamportPkHash: keypair hash arrays must not be empty",
+    );
+  }
+  const hashSize = keypair.falseHashes[0].length;
+  const totalBytes =
+    (keypair.falseHashes.length + keypair.trueHashes.length) * hashSize;
+  const buffer = new Uint8Array(totalBytes);
+
+  let offset = 0;
+  for (const h of keypair.falseHashes) {
+    buffer.set(h, offset);
+    offset += hashSize;
+  }
+  for (const h of keypair.trueHashes) {
+    buffer.set(h, offset);
+    offset += hashSize;
+  }
+
+  const digest = keccak_256(buffer);
+  return `0x${toHex(digest)}`;
+}

--- a/packages/babylon-ts-sdk/src/tbv/core/lamport/deriveLamportPkHash.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/lamport/deriveLamportPkHash.ts
@@ -1,0 +1,33 @@
+import { computeLamportPkHash, deriveLamportKeypair, mnemonicToLamportSeed } from "./derivation";
+
+/**
+ * Convenience wrapper: derive a Lamport keypair from a mnemonic and return
+ * the keccak256 hash of its public key. Handles seed creation and cleanup.
+ *
+ * Used before the ETH transaction to produce the `depositorLamportPkHash`
+ * that gets committed on-chain.
+ */
+export async function deriveLamportPkHash(
+  mnemonic: string,
+  peginTxid: string,
+  depositorBtcPubkey: string,
+  appContractAddress: string,
+): Promise<`0x${string}`> {
+  const seed = mnemonicToLamportSeed(mnemonic);
+  try {
+    const keypair = await deriveLamportKeypair(
+      seed,
+      peginTxid,
+      depositorBtcPubkey,
+      appContractAddress,
+    );
+    try {
+      return computeLamportPkHash(keypair);
+    } finally {
+      for (const p of keypair.falsePreimages) p.fill(0);
+      for (const p of keypair.truePreimages) p.fill(0);
+    }
+  } finally {
+    seed.fill(0);
+  }
+}

--- a/packages/babylon-ts-sdk/src/tbv/core/lamport/errors.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/lamport/errors.ts
@@ -1,0 +1,20 @@
+/**
+ * Check whether an error from the vault provider indicates that the
+ * submitted Lamport public key hash does not match the on-chain
+ * commitment. This signals that the wrong mnemonic was used.
+ */
+export function isLamportMismatchError(error: unknown): boolean {
+  const msg = (
+    error instanceof Error
+      ? error.message
+      : typeof error === "string"
+        ? error
+        : ""
+  ).toLowerCase();
+
+  return (
+    msg.includes("lamport") &&
+    msg.includes("hash") &&
+    msg.includes("does not match")
+  );
+}

--- a/packages/babylon-ts-sdk/src/tbv/core/lamport/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/lamport/index.ts
@@ -1,0 +1,9 @@
+export type { LamportKeypair, LamportPublicKey, LamportKeyProvider } from "./types";
+export {
+  mnemonicToLamportSeed,
+  deriveLamportKeypair,
+  keypairToPublicKey,
+  computeLamportPkHash,
+} from "./derivation";
+export { deriveLamportPkHash } from "./deriveLamportPkHash";
+export { isLamportMismatchError } from "./errors";

--- a/packages/babylon-ts-sdk/src/tbv/core/lamport/types.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/lamport/types.ts
@@ -1,0 +1,34 @@
+/**
+ * A Lamport keypair consisting of preimages (private) and their hashes
+ * (public) for both the `false` and `true` branch of each bit position.
+ *
+ * - `falsePreimages[i]` / `truePreimages[i]` — 16-byte secret preimages.
+ * - `falseHashes[i]`    / `trueHashes[i]`    — 20-byte Hash160 digests.
+ *
+ * All arrays have length 508 (PI_1_BITS).
+ */
+export interface LamportKeypair {
+  falsePreimages: Uint8Array[];
+  truePreimages: Uint8Array[];
+  falseHashes: Uint8Array[];
+  trueHashes: Uint8Array[];
+}
+
+/**
+ * Serialized Lamport public key as two lists of hex-encoded Hash160 digests.
+ * This is the format submitted on-chain and to the vault provider.
+ */
+export interface LamportPublicKey {
+  false_list: string[];
+  true_list: string[];
+}
+
+/**
+ * Provider interface for Lamport key operations.
+ * Frontend implements with mnemonic-based derivation;
+ * backend services can implement with HSM/KMS.
+ */
+export interface LamportKeyProvider {
+  deriveLamportKeypair(vaultId: string): Promise<LamportKeypair>;
+  getLamportPublicKey(vaultId: string): Promise<LamportPublicKey>;
+}

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
@@ -33,7 +33,7 @@ import {
 
 import type { BitcoinWallet, Hash } from "../../../shared/wallets";
 import { createTaprootScriptPathSignOptions } from "../../../shared/wallets";
-import { getUtxoInfo, pushTx } from "../clients/mempool";
+import { type UtxoInfo, getUtxoInfo, pushTx } from "../clients/mempool";
 import { BTCVaultRegistryABI, handleContractError } from "../contracts";
 import {
   buildPrePeginPsbt,
@@ -260,6 +260,14 @@ export interface SignAndBroadcastParams {
    * Required for Taproot signing.
    */
   depositorBtcPubkey: string;
+
+  /**
+   * Optional pre-fetched prevout data for inputs not yet in the mempool.
+   * Key format: "txid:vout" (e.g. "abc123...def:0").
+   * When provided, matching inputs skip the mempool API fetch.
+   * Useful for split transactions where outputs are unconfirmed.
+   */
+  localPrevouts?: Record<string, { scriptPubKey: string; value: number }>;
 }
 
 /**
@@ -345,6 +353,28 @@ export interface RegisterPeginResult {
    * Returned so callers can reuse it for subsequent pegins without re-signing.
    */
   btcPopSignature: Hex;
+}
+
+/**
+ * Resolve prevout data for a transaction input.
+ * Checks localPrevouts first; falls back to mempool API.
+ */
+function resolveUtxoInfo(
+  txid: string,
+  vout: number,
+  localPrevouts: Record<string, { scriptPubKey: string; value: number }> | undefined,
+  apiUrl: string,
+): Promise<UtxoInfo> {
+  const local = localPrevouts?.[`${txid}:${vout}`];
+  if (local) {
+    return Promise.resolve({
+      txid,
+      vout,
+      value: local.value,
+      scriptPubKey: local.scriptPubKey,
+    });
+  }
+  return getUtxoInfo(txid, vout, apiUrl);
 }
 
 /**
@@ -578,16 +608,13 @@ export class PeginManager {
     }
     const apiUrl = this.config.mempoolApiUrl;
 
-    // Fetch all UTXO data in parallel for better performance
+    // Resolve prevout data for each input (local cache or mempool API)
     const utxoDataPromises = tx.ins.map((input) => {
       const txid = Buffer.from(input.hash).reverse().toString("hex");
       const vout = input.index;
-      return getUtxoInfo(txid, vout, apiUrl).then((utxoData) => ({
-        input,
-        utxoData,
-        txid,
-        vout,
-      }));
+      return resolveUtxoInfo(txid, vout, params.localPrevouts, apiUrl).then(
+        (utxoData) => ({ input, utxoData, txid, vout }),
+      );
     });
 
     const inputsWithUtxoData = await Promise.all(utxoDataPromises);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -325,6 +325,12 @@ importers:
       '@bitcoin-js/tiny-secp256k1-asmjs':
         specifier: 2.2.3
         version: 2.2.3
+      '@noble/hashes':
+        specifier: 2.0.1
+        version: 2.0.1
+      '@scure/bip39':
+        specifier: 2.0.1
+        version: 2.0.1
       bitcoinjs-lib:
         specifier: 6.1.7
         version: 6.1.7


### PR DESCRIPTION
- **R1 (Lamport Core):** Extract deterministic Lamport one-time-signature key derivation from `services/vault`
into `packages/babylon-ts-sdk/src/tbv/core/lamport/`. Includes `mnemonicToLamportSeed`, `deriveLamportKeypair`,
`keypairToPublicKey`, `computeLamportPkHash`, `deriveLamportPkHash`, `isLamportMismatchError`, and types
(`LamportKeypair`, `LamportPublicKey`, `LamportKeyProvider`). All zeroization of intermediate key material
preserved with multi-layer try/finally cleanup.
- **R5 (Local Prevouts):** Add optional `localPrevouts` param to `SignAndBroadcastParams` so callers can supply
pre-fetched prevout data for unconfirmed split transaction outputs, skipping mempool API lookups.
- New dependencies: `@noble/hashes@2.0.1`, `@scure/bip39@2.0.1` (pinned exact versions)
- New export subpath: `@babylonlabs-io/ts-sdk/tbv/core/lamport`