### PR TITLE
fix(packages): validate all external data from Mempool API

### DIFF
--- a/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/__tests__/mempoolApi.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/__tests__/mempoolApi.test.ts
@@ -287,6 +287,21 @@ describe("getNetworkFees", () => {
     );
   });
 
+  it("rejects fee rates with invalid ordering", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        fastestFee: 10,
+        halfHourFee: 30,
+        hourFee: 20,
+        economyFee: 10,
+        minimumFee: 1,
+      }),
+    );
+    await expect(getNetworkFees(API_URL)).rejects.toThrow(
+      /Fee rate ordering violation/,
+    );
+  });
+
   it("accepts fee rates at the maximum bound", async () => {
     mockFetch.mockResolvedValueOnce(
       jsonResponse({ ...validFees, fastestFee: 10000 }),

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts
@@ -340,6 +340,20 @@ export async function getNetworkFees(apiUrl: string): Promise<NetworkFees> {
     }
   }
 
+  if (
+    data.minimumFee > data.economyFee ||
+    data.economyFee > data.hourFee ||
+    data.hourFee > data.halfHourFee ||
+    data.halfHourFee > data.fastestFee
+  ) {
+    throw new Error(
+      `Fee rate ordering violation from mempool API: expected ` +
+        `minimumFee (${data.minimumFee}) <= economyFee (${data.economyFee}) <= ` +
+        `hourFee (${data.hourFee}) <= halfHourFee (${data.halfHourFee}) <= ` +
+        `fastestFee (${data.fastestFee}).`,
+    );
+  }
+
   return data as NetworkFees;
 }
 


### PR DESCRIPTION
Harden the mempool API client against malicious or malformed responses:

- UTXO values: reject negative, zero, fractional, and values exceeding 21M BTC in satoshis (isValidSatoshiValue). Applied in getAddressUtxos and getUtxoInfo.
- UTXO vout indices: reject negative and fractional output indices in both getUtxoInfo (isValidVout) and getAddressUtxos.
- Fee rates: reject negative, zero, fractional, NaN, Infinity, and rates above 10,000 sat/vB (isValidFeeRate). Applied in getNetworkFees, replacing the previous typeof-only check.

Addresses: Security audit findings 29 and 27