### PR TITLE
fix(vault): zero sensitive seed material in lamport key derivation

### DIFF
--- a/services/vault/src/services/lamport/lamportService.ts
+++ b/services/vault/src/services/lamport/lamportService.ts
@@ -341,7 +341,7 @@ export function mnemonicToLamportSeed(mnemonic: string): Uint8Array {
  * The same (mnemonic, vaultId, depositorPk, appContractAddress) tuple always
  * produces the same keypair, enabling recovery from the mnemonic alone.
  *
- * @param seed               - 64-byte seed from {@link mnemonicToLamportSeed}.
+ * @param seed               - 64-byte seed from {@link mnemonicToLamportSeed}. Zeroed after use.
  * @param vaultId            - Unique identifier of the vault (e.g. pegin tx hash).
  * @param depositorPk        - Depositor's public key (hex string).
  * @param appContractAddress - Ethereum address of the application contract.


### PR DESCRIPTION
Zero the original BIP-39 seed in mnemonicToLamportSeed before returning the copy. Zero the seed parameter in deriveLamportKeypair alongside other intermediate buffer cleanup.

## Summary
- **https://github.com/babylonlabs-io/vault-provider-proxy/issues/35**: `mnemonicToLamportSeed()` now zeros the original 64-byte seed from `mnemonicToSeedSync` before returning the copy, preventing the master seed from lingering in the JS heap
- **https://github.com/babylonlabs-io/vault-provider-proxy/issues/72
**: `deriveLamportKeypair()` now zeros the `seed` parameter in its cleanup section alongside `chainCode`, `parentKey`, etc. — making the function self-contained for key material cleanup



Closes https://github.com/babylonlabs-io/vault-provider-proxy/issues/35 https://github.com/babylonlabs-io/vault-provider-proxy/issues/72
