### PR TITLE
fix(vault): add staleness detection for Aave position data

### DIFF
--- a/services/vault/src/applications/aave/constants.ts
+++ b/services/vault/src/applications/aave/constants.ts
@@ -52,13 +52,12 @@ export const VAULT_SPLIT_SAFETY_MARGIN = 1.05;
 export const POSITION_REFETCH_INTERVAL_MS = 30 * 1000;
 
 /**
- * Multiplier applied to POSITION_REFETCH_INTERVAL_MS to determine
- * when position data is considered stale for UI warning purposes.
- * Data is flagged stale if the last successful fetch was more than
- * POSITION_REFETCH_INTERVAL_MS * this multiplier ago.
- * A value of 3 means data older than 90 seconds triggers a warning.
+ * Threshold (ms) after which position data is considered stale.
+ * If the last successful fetch was longer than this ago, the UI
+ * warns that oracle-derived values may be outdated.
+ * 3 × 30s refetch interval = 90s.
  */
-export const POSITION_STALENESS_MULTIPLIER = 3;
+export const POSITION_STALENESS_THRESHOLD_MS = POSITION_REFETCH_INTERVAL_MS * 3;
 
 /**
  * Minimum slider max value to prevent division by zero

--- a/services/vault/src/applications/aave/hooks/useAaveUserPosition.ts
+++ b/services/vault/src/applications/aave/hooks/useAaveUserPosition.ts
@@ -13,7 +13,7 @@ import { satoshiToBtcNumber } from "@/utils/btcConversion";
 
 import {
   POSITION_REFETCH_INTERVAL_MS,
-  POSITION_STALENESS_MULTIPLIER,
+  POSITION_STALENESS_THRESHOLD_MS,
 } from "../constants";
 import { useAaveConfig } from "../context";
 import {
@@ -98,14 +98,12 @@ export function useAaveUserPosition(
     [borrowableReserveIds],
   );
 
-  const stalenessThresholdMs =
-    POSITION_REFETCH_INTERVAL_MS * POSITION_STALENESS_MULTIPLIER;
-
   const {
     data: positions,
     isLoading: positionsLoading,
     error: positionsError,
     dataUpdatedAt,
+    isFetching,
     refetch,
   } = useQuery({
     queryKey: [
@@ -138,7 +136,9 @@ export function useAaveUserPosition(
 
     const checkStaleness = () => {
       const age = Date.now() - dataUpdatedAt;
-      setIsPositionDataStale(age > stalenessThresholdMs);
+      setIsPositionDataStale(
+        !isFetching && age > POSITION_STALENESS_THRESHOLD_MS,
+      );
     };
 
     checkStaleness();
@@ -153,7 +153,7 @@ export function useAaveUserPosition(
     return () => {
       clearInterval(stalenessTimerRef.current);
     };
-  }, [dataUpdatedAt, stalenessThresholdMs]);
+  }, [dataUpdatedAt, isFetching]);
 
   // User can only have one position (single vBTC collateral reserve)
   const position = positions?.[0] ?? null;


### PR DESCRIPTION
Track data freshness via React Query's dataUpdatedAt and flag positions as stale when 3 consecutive refetch cycles (90s) pass without a successful update, so the UI can warn users.

## Summary
- Add `POSITION_STALENESS_MULTIPLIER` constant (3x refetch interval = 90s threshold)
- New `isPositionDataStale` boolean returned from `useAaveUserPosition` hook
- Uses `dataUpdatedAt` from React Query + interval timer to re-evaluate staleness
- UI consumers can display a warning when oracle-derived values (health factor, collateral/debt) may be outdated

Closes babylonlabs-io/vault-provider-proxy#84
