### PR TITLE
chore(ci): use gha-s3-frontend-push iam role for ci

### DIFF
--- a/.github/workflows/service-release-simple-staking.yml
+++ b/.github/workflows/service-release-simple-staking.yml
@@ -47,10 +47,8 @@ jobs:
         include:
           - environment: canon-devnet
             aws_account: 537927626649
-            prod: false
           - environment: btc-mainnet-devnet
             aws_account: 537927626649
-            prod: false
           - environment: testnet
             aws_account: 615368094160
             prod: true
@@ -58,8 +56,8 @@ jobs:
             aws_account: 490721144737
             prod: true
 
-    # Skip prod environments on feature branches (workflow_dispatch)
-    if: ${{ !matrix.prod || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/') }}
+    # Prod environments will fail OIDC on feature branches; allow failure so devnet jobs aren't blocked
+    continue-on-error: ${{ matrix.prod == true }}
     environment: ${{ matrix.environment }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/service-release-vault.yml
+++ b/.github/workflows/service-release-vault.yml
@@ -42,7 +42,7 @@ jobs:
     needs: [lint_test]
     runs-on: ubuntu-24.04
     strategy:
-      fail-fast: false # devnet envs must keep running even if prod envs fail (prod blocks workflow_dispatch from feature branches)
+      fail-fast: false
       matrix:
         include:
           - environment: vault-devnet
@@ -51,7 +51,10 @@ jobs:
             aws_account: 537927626649
           - environment: vault-testnet
             aws_account: 615368094160
+            prod: true
 
+    # Prod environments will fail OIDC on feature branches; allow failure so devnet jobs aren't blocked
+    continue-on-error: ${{ matrix.prod == true }}
     environment: ${{ matrix.environment }}
     steps:
       - name: Checkout repository


### PR DESCRIPTION
- Switch S3 publish workflows from `gha-deployment` to `gha-s3-frontend-push` IAM role
- Add `prod` flag with `continue-on-error` so prod environment OIDC failures on feature branches don't block devnet jobs. This only affects `workflow_dispatch` event