### PR TITLE
fix(vault): activate pegin modal color dark theme

### DIFF
--- a/services/vault/src/components/simple/ResumeDepositContent.tsx
+++ b/services/vault/src/components/simple/ResumeDepositContent.tsx
@@ -354,7 +354,7 @@ export function ResumeActivationContent({
 
   // Secret input form
   return (
-    <div className="flex flex-col gap-6 rounded-2xl bg-secondary-contrast p-6">
+    <div className="flex flex-col gap-6 rounded-2xl bg-surface p-6">
       <div className="flex flex-col gap-2">
         <h3 className="text-lg font-semibold text-accent-primary">
           Activate Vault


### PR DESCRIPTION
- fixes activate pegin modal color on dark theme

Before: 
<img width="551" height="287" alt="Screenshot_2026-04-01_16-42-37" src="https://github.com/user-attachments/assets/d302f9b0-bb10-40dd-a3ad-98bc45ca004a" />

After
<img width="496" height="235" alt="Screenshot_2026-04-01_16-56-01" src="https://github.com/user-attachments/assets/6a0dd64b-67a6-40b9-aa47-01fe4d02ee4f" />


 