### PR TITLE
feat(vault): vaulr reorder no hash

### DIFF
--- a/services/vault/src/components/simple/ReorderVaults/ReorderVaultItem.tsx
+++ b/services/vault/src/components/simple/ReorderVaults/ReorderVaultItem.tsx
@@ -4,21 +4,18 @@ import { CSS } from "@dnd-kit/utilities";
 import { IoReorderThree } from "react-icons/io5";
 
 import { getNetworkConfigBTC } from "@/config";
-import { truncateHash } from "@/utils/addressUtils";
 import { formatBtcAmount, formatOrdinal } from "@/utils/formatting";
 
 const btcConfig = getNetworkConfigBTC();
 
 interface ReorderVaultItemProps {
   id: string;
-  vaultId: string;
   amountBtc: number;
   position: number;
 }
 
 export function ReorderVaultItem({
   id,
-  vaultId,
   amountBtc,
   position,
 }: ReorderVaultItemProps) {
@@ -48,14 +45,12 @@ export function ReorderVaultItem({
     >
       <div className="flex items-center gap-3">
         <Avatar url={btcConfig.icon} alt={btcConfig.coinSymbol} size="small" />
-        <div className="flex flex-col">
-          <span className="text-base font-medium text-accent-primary">
-            {formatBtcAmount(amountBtc)} ({formatOrdinal(position)})
+        <span className="text-base font-medium text-accent-primary">
+          {formatBtcAmount(amountBtc)} -{" "}
+          <span className="font-mono text-sm opacity-75">
+            {formatOrdinal(position)}
           </span>
-          <span className="font-mono text-xs text-accent-secondary">
-            {truncateHash(vaultId)}
-          </span>
-        </div>
+        </span>
       </div>
       <button
         type="button"

--- a/services/vault/src/components/simple/ReorderVaults/ReorderVaultsModal.tsx
+++ b/services/vault/src/components/simple/ReorderVaults/ReorderVaultsModal.tsx
@@ -104,7 +104,6 @@ export function ReorderVaultsModal({
                 <ReorderVaultItem
                   key={vault.id}
                   id={vault.id}
-                  vaultId={vault.vaultId}
                   amountBtc={vault.amountBtc}
                   position={index + 1}
                 />


### PR DESCRIPTION
- removes hash from vault reorder
- changes font of `1st 2nd ... nth` to `mono`

<img width="688" height="397" alt="Screenshot_2026-04-02_12-21-40" src="https://github.com/user-attachments/assets/279f4a3d-40e5-4360-ab7a-b1983a61c864" />
