### PR TITLE
refactor(sdk): use WASM control blocks, centralize fee constants, fix…

### DIFF
--- a/packages/babylon-tbv-rust-wasm/README.md
+++ b/packages/babylon-tbv-rust-wasm/README.md
@@ -380,10 +380,11 @@ Creates a payout connector for signing payout transactions.
 - `taprootScriptHash` - Taproot script hash / tapLeafHash for PSBT signing
 - `scriptPubKey` - Taproot script pubkey (hex)
 - `address` - P2TR address
+- `payoutControlBlock` - Serialized control block for Taproot script path spend (hex)
 
-#### `getPeginPayoutScript(params: PayoutConnectorParams): Promise<string>`
+#### `getPeginPayoutScriptInfo(params: PayoutConnectorParams): Promise<{ payoutScript: string; payoutControlBlock: string }>`
 
-Returns the payout script hex from the PeginPayoutConnector without requiring a network parameter. Useful for building depositor Payout PSBTs where you only need the script (not the address).
+Returns the payout script and control block from the PeginPayoutConnector without requiring a network parameter. Useful for building payout PSBTs where you need the script and control block for Taproot script path spending.
 
 **Parameters:**
 - `params.depositor` - Depositor's x-only pubkey (hex)
@@ -393,7 +394,8 @@ Returns the payout script hex from the PeginPayoutConnector without requiring a 
 - `params.timelockPegin` - CSV timelock in blocks for PegIn output
 
 **Returns:**
-- Payout script hex string
+- `payoutScript` - Payout script hex string
+- `payoutControlBlock` - Serialized control block hex string
 
 #### `getAssertPayoutScriptInfo(params: AssertPayoutNoPayoutConnectorParams): Promise<AssertPayoutScriptInfo>`
 

--- a/packages/babylon-tbv-rust-wasm/src/index-node.ts
+++ b/packages/babylon-tbv-rust-wasm/src/index-node.ts
@@ -191,15 +191,16 @@ export async function createPayoutConnector(
       taprootScriptHash: connector.getTaprootScriptHash(),
       scriptPubKey: connector.getScriptPubKey(network),
       address: connector.getAddress(network),
+      payoutControlBlock: connector.getPayoutControlBlock(),
     };
   } finally {
     connector.free();
   }
 }
 
-export async function getPeginPayoutScript(
+export async function getPeginPayoutScriptInfo(
   params: PayoutConnectorParams,
-): Promise<string> {
+): Promise<{ payoutScript: string; payoutControlBlock: string }> {
   const connector = new WasmPeginPayoutConnector(
     params.depositor,
     params.vaultProvider,
@@ -209,7 +210,10 @@ export async function getPeginPayoutScript(
   );
 
   try {
-    return connector.getPayoutScript();
+    return {
+      payoutScript: connector.getPayoutScript(),
+      payoutControlBlock: connector.getPayoutControlBlock(),
+    };
   } finally {
     connector.free();
   }

--- a/packages/babylon-tbv-rust-wasm/src/index.ts
+++ b/packages/babylon-tbv-rust-wasm/src/index.ts
@@ -268,7 +268,7 @@ export type {
 export { TAP_INTERNAL_KEY, tapInternalPubkey } from "./constants.js";
 
 // Export payout connector utilities
-export { createPayoutConnector, getPeginPayoutScript } from "./payoutConnector.js";
+export { createPayoutConnector, getPeginPayoutScriptInfo } from "./payoutConnector.js";
 
 // Export assert payout/nopayout connector utilities (depositor-as-claimer)
 export {

--- a/packages/babylon-tbv-rust-wasm/src/payoutConnector.ts
+++ b/packages/babylon-tbv-rust-wasm/src/payoutConnector.ts
@@ -40,26 +40,31 @@ export async function createPayoutConnector(
     params.timelockPegin
   );
 
-  return {
-    payoutScript: connector.getPayoutScript(),
-    taprootScriptHash: connector.getTaprootScriptHash(),
-    scriptPubKey: connector.getScriptPubKey(network),
-    address: connector.getAddress(network),
-  };
+  try {
+    return {
+      payoutScript: connector.getPayoutScript(),
+      taprootScriptHash: connector.getTaprootScriptHash(),
+      scriptPubKey: connector.getScriptPubKey(network),
+      address: connector.getAddress(network),
+      payoutControlBlock: connector.getPayoutControlBlock(),
+    };
+  } finally {
+    connector.free();
+  }
 }
 
 /**
- * Get just the payout script from the PeginPayoutConnector (no network needed).
+ * Get the payout script and control block from the PeginPayoutConnector (no network needed).
  *
- * Used by the depositor payout PSBT builder to get the correct taproot script
+ * Used by payout PSBT builders to get the correct taproot script and control block
  * for signing input 0 (PegIn vault UTXO).
  *
  * @param params - Payout connector parameters
- * @returns Payout script hex
+ * @returns Payout script and control block (hex encoded)
  */
-export async function getPeginPayoutScript(
+export async function getPeginPayoutScriptInfo(
   params: PayoutConnectorParams,
-): Promise<string> {
+): Promise<{ payoutScript: string; payoutControlBlock: string }> {
   await initWasm();
 
   const connector = new WasmPeginPayoutConnector(
@@ -70,5 +75,12 @@ export async function getPeginPayoutScript(
     params.timelockPegin
   );
 
-  return connector.getPayoutScript();
+  try {
+    return {
+      payoutScript: connector.getPayoutScript(),
+      payoutControlBlock: connector.getPayoutControlBlock(),
+    };
+  } finally {
+    connector.free();
+  }
 }

--- a/packages/babylon-tbv-rust-wasm/src/types.ts
+++ b/packages/babylon-tbv-rust-wasm/src/types.ts
@@ -143,6 +143,8 @@ export interface PayoutConnectorInfo {
   scriptPubKey: string;
   /** Pay-to-Taproot (P2TR) address */
   address: string;
+  /** Serialized control block for Taproot script path spend (hex encoded) */
+  payoutControlBlock: string;
 }
 
 /**

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
@@ -46,6 +46,7 @@ import {
   type Network,
 } from "../primitives";
 import {
+  ensureEcc,
   ensureHexPrefix,
   isAddressFromPublicKey,
   stripHexPrefix,
@@ -1167,6 +1168,8 @@ export class PeginManager {
   private async resolvePayoutScriptPubKey(
     depositorPayoutBtcAddress?: string,
   ): Promise<Hex> {
+    ensureEcc();
+
     let address: string;
 
     if (depositorPayoutBtcAddress) {

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/constants.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/constants.ts
@@ -9,21 +9,10 @@
 
 import { Buffer } from "buffer";
 
-// ==================== Bitcoin Protocol Constants ====================
+import { TAPSCRIPT_LEAF_VERSION } from "../../utils/bitcoin";
 
-/**
- * Tapscript leaf version as defined in BIP-341.
- *
- * The value 0xc0 (binary: 11000000) represents:
- * - Bit 0: Parity bit for output key y-coordinate
- * - Bits 1-7: Leaf version (0xc0 >> 1 = 0x60)
- *
- * This is the standard leaf version for Tapscript execution.
- *
- * @see https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki
- * @see Rust: bitcoin::taproot::LeafVersion::TapScript
- */
-export const TAPSCRIPT_LEAF_VERSION = 0xc0;
+// Re-export for test convenience
+export { TAPSCRIPT_LEAF_VERSION };
 
 /**
  * Maximum sequence value (no relative timelock).

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/challengeAssert.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/challengeAssert.ts
@@ -20,6 +20,7 @@ import { Buffer } from "buffer";
 import { Psbt, Transaction } from "bitcoinjs-lib";
 
 import {
+  TAPSCRIPT_LEAF_VERSION,
   hexToUint8Array,
   stripHexPrefix,
 } from "../utils/bitcoin";
@@ -90,7 +91,7 @@ export async function buildChallengeAssertPsbt(
       },
       tapLeafScript: [
         {
-          leafVersion: 0xc0,
+          leafVersion: TAPSCRIPT_LEAF_VERSION,
           script: Buffer.from(scriptBytes),
           controlBlock: Buffer.from(controlBlockBytes),
         },

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/depositorPayout.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/depositorPayout.ts
@@ -15,20 +15,17 @@
 
 import {
   type PayoutConnectorParams,
-  getPeginPayoutScript,
+  getPeginPayoutScriptInfo,
   tapInternalPubkey,
 } from "@babylonlabs-io/babylon-tbv-rust-wasm";
-import * as ecc from "@bitcoin-js/tiny-secp256k1-asmjs";
 import { Buffer } from "buffer";
-import { initEccLib, payments, Psbt, Transaction } from "bitcoinjs-lib";
+import { Psbt, Transaction } from "bitcoinjs-lib";
 
 import {
+  TAPSCRIPT_LEAF_VERSION,
   hexToUint8Array,
   stripHexPrefix,
 } from "../utils/bitcoin";
-
-// Initialize ECC library for bitcoinjs-lib
-initEccLib(ecc);
 
 /**
  * Parameters for building a depositor Payout PSBT
@@ -58,10 +55,12 @@ export async function buildDepositorPayoutPsbt(
   const payoutTxHex = stripHexPrefix(params.payoutTxHex);
   const payoutTx = Transaction.fromHex(payoutTxHex);
 
-  // Get payout script from WASM (PeginPayoutConnector — same as VP/VK payout)
-  const payoutScriptHex = await getPeginPayoutScript(params.connectorParams);
-  const scriptBytes = hexToUint8Array(payoutScriptHex);
-  const controlBlock = computeControlBlock(tapInternalPubkey, scriptBytes);
+  // Get payout script and control block from WASM (PeginPayoutConnector)
+  const { payoutScript, payoutControlBlock } = await getPeginPayoutScriptInfo(
+    params.connectorParams,
+  );
+  const scriptBytes = hexToUint8Array(payoutScript);
+  const controlBlock = hexToUint8Array(payoutControlBlock);
 
   const psbt = new Psbt();
   psbt.setVersion(payoutTx.version);
@@ -90,7 +89,7 @@ export async function buildDepositorPayoutPsbt(
     if (i === 0) {
       inputData.tapLeafScript = [
         {
-          leafVersion: 0xc0,
+          leafVersion: TAPSCRIPT_LEAF_VERSION,
           script: Buffer.from(scriptBytes),
           controlBlock: Buffer.from(controlBlock),
         },
@@ -112,31 +111,3 @@ export async function buildDepositorPayoutPsbt(
   return psbt.toHex();
 }
 
-/**
- * Compute control block for Taproot script path spend.
- * @internal
- */
-function computeControlBlock(
-  internalKey: Uint8Array,
-  script: Uint8Array,
-): Uint8Array {
-  const scriptTree = { output: Buffer.from(script) };
-  const payment = payments.p2tr({
-    internalPubkey: Buffer.from(internalKey),
-    scriptTree,
-  });
-
-  const outputKey = payment.pubkey;
-  if (!outputKey) {
-    throw new Error("Failed to compute output key");
-  }
-
-  const leafVersion = 0xc0;
-  const parity = outputKey[0] === 0x03 ? 1 : 0;
-  const controlByte = leafVersion | parity;
-
-  const result = new Uint8Array(1 + internalKey.length);
-  result[0] = controlByte;
-  result.set(internalKey, 1);
-  return result;
-}

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/noPayout.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/noPayout.ts
@@ -18,6 +18,7 @@ import { Buffer } from "buffer";
 import { Psbt, Transaction } from "bitcoinjs-lib";
 
 import {
+  TAPSCRIPT_LEAF_VERSION,
   hexToUint8Array,
   stripHexPrefix,
 } from "../utils/bitcoin";
@@ -88,7 +89,7 @@ export async function buildNoPayoutPsbt(
     if (i === 0) {
       inputData.tapLeafScript = [
         {
-          leafVersion: 0xc0,
+          leafVersion: TAPSCRIPT_LEAF_VERSION,
           script: Buffer.from(scriptBytes),
           controlBlock: Buffer.from(controlBlockBytes),
         },

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts
@@ -14,18 +14,15 @@ import {
   type Network,
   tapInternalPubkey,
 } from "@babylonlabs-io/babylon-tbv-rust-wasm";
-import * as ecc from "@bitcoin-js/tiny-secp256k1-asmjs";
 import { Buffer } from "buffer";
-import { initEccLib, payments, Psbt, Transaction } from "bitcoinjs-lib";
+import { Psbt, Transaction } from "bitcoinjs-lib";
 import { createPayoutScript } from "../scripts/payout";
 import {
+  TAPSCRIPT_LEAF_VERSION,
   hexToUint8Array,
   stripHexPrefix,
   uint8ArrayToHex,
 } from "../utils/bitcoin";
-
-// Initialize ECC library for bitcoinjs-lib
-initEccLib(ecc);
 
 /**
  * Parameters for building an unsigned Payout PSBT
@@ -133,7 +130,7 @@ export async function buildPayoutPsbt(
   });
 
   const payoutScriptBytes = hexToUint8Array(payoutConnector.payoutScript);
-  const controlBlock = computeControlBlock(tapInternalPubkey, payoutScriptBytes);
+  const controlBlock = hexToUint8Array(payoutConnector.payoutControlBlock);
 
   // Parse transactions
   const payoutTx = Transaction.fromHex(payoutTxHex);
@@ -215,7 +212,7 @@ export async function buildPayoutPsbt(
     },
     tapLeafScript: [
       {
-        leafVersion: 0xc0,
+        leafVersion: TAPSCRIPT_LEAF_VERSION,
         script: Buffer.from(payoutScriptBytes),
         controlBlock: Buffer.from(controlBlock),
       },
@@ -377,44 +374,3 @@ function parseWitnessStack(witness: Buffer): Buffer[] {
   return items;
 }
 
-/**
- * Compute control block for Taproot script path spend.
- *
- * For a single script (no tree), the control block format is:
- * [leaf_version | parity] || [internal_key_x_only]
- *
- * The leaf version for Tapscript is 0xc0, and the parity bit indicates
- * whether the output key has an odd or even y-coordinate.
- *
- * @param internalKey - Taproot internal public key (x-only, 32 bytes)
- * @param script - Taproot script to compute control block for
- * @returns Control block buffer
- *
- * @internal
- */
-function computeControlBlock(
-  internalKey: Uint8Array,
-  script: Uint8Array,
-): Uint8Array {
-  // Convert to actual Buffer instances for bitcoinjs-lib runtime type checks
-  const scriptTree = { output: Buffer.from(script) };
-  const payment = payments.p2tr({
-    internalPubkey: Buffer.from(internalKey),
-    scriptTree,
-  });
-
-  const outputKey = payment.pubkey;
-  if (!outputKey) {
-    throw new Error("Failed to compute output key");
-  }
-
-  // Control block: [leaf_version | parity] || [internal_key_x_only]
-  const leafVersion = 0xc0;
-  const parity = outputKey[0] === 0x03 ? 1 : 0; // 0x02 = even, 0x03 = odd
-  const controlByte = leafVersion | parity;
-
-  const result = new Uint8Array(1 + internalKey.length);
-  result[0] = controlByte;
-  result.set(internalKey, 1);
-  return result;
-}

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts
@@ -18,7 +18,7 @@ import {
 } from "@babylonlabs-io/babylon-tbv-rust-wasm";
 import { Buffer } from "buffer";
 import { Psbt, Transaction } from "bitcoinjs-lib";
-import { hexToUint8Array, stripHexPrefix, uint8ArrayToHex } from "../utils/bitcoin";
+import { TAPSCRIPT_LEAF_VERSION, hexToUint8Array, stripHexPrefix, uint8ArrayToHex } from "../utils/bitcoin";
 
 /**
  * Parameters for building the PegIn input PSBT
@@ -144,7 +144,7 @@ export async function buildPeginInputPsbt(
     },
     tapLeafScript: [
       {
-        leafVersion: 0xc0,
+        leafVersion: TAPSCRIPT_LEAF_VERSION,
         script: Buffer.from(hashlockScript),
         controlBlock: Buffer.from(hashlockControlBlock),
       },

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts
@@ -20,7 +20,7 @@ import {
 import { Buffer } from "buffer";
 import { Psbt, Transaction } from "bitcoinjs-lib";
 
-import { hexToUint8Array, uint8ArrayToHex } from "../utils/bitcoin";
+import { TAPSCRIPT_LEAF_VERSION, hexToUint8Array, uint8ArrayToHex } from "../utils/bitcoin";
 import type { PrePeginParams } from "./pegin";
 
 /**
@@ -157,7 +157,7 @@ export async function buildRefundPsbt(
       },
       tapLeafScript: [
         {
-          leafVersion: 0xc0,
+          leafVersion: TAPSCRIPT_LEAF_VERSION,
           script: Buffer.from(hexToUint8Array(htlcConnector.refundScript)),
           controlBlock: Buffer.from(
             hexToUint8Array(htlcConnector.refundControlBlock),

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts
@@ -113,6 +113,14 @@ export interface PayoutScriptResult {
    * that can be used to receive funds into the vault.
    */
   address: string;
+
+  /**
+   * Serialized control block for Taproot script path spend (hex encoded).
+   *
+   * Computed by the Rust WASM PeginPayoutConnector. Used directly in
+   * tapLeafScript when building payout PSBTs.
+   */
+  payoutControlBlock: string;
 }
 
 /**
@@ -152,5 +160,6 @@ export async function createPayoutScript(
     taprootScriptHash: connector.taprootScriptHash,
     scriptPubKey: connector.scriptPubKey,
     address: connector.address,
+    payoutControlBlock: connector.payoutControlBlock,
   };
 }

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts
@@ -21,6 +21,13 @@ import type { Network } from "@babylonlabs-io/babylon-tbv-rust-wasm";
 import type { Hex } from "viem";
 
 /**
+ * BIP-341 Tapscript leaf version for script-path spends.
+ * @see https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki
+ * @see Rust: bitcoin::taproot::LeafVersion::TapScript
+ */
+export const TAPSCRIPT_LEAF_VERSION = 0xc0;
+
+/**
  * Strip "0x" prefix from hex string if present.
  *
  * Bitcoin expects plain hex (no "0x" prefix), but frontend often uses
@@ -207,7 +214,17 @@ export function validateWalletPubkey(
 
 let eccInitialized = false;
 
-function ensureEcc(): void {
+/**
+ * Lazily initialize the ECC library for bitcoinjs-lib.
+ *
+ * Must be called before any P2TR / Taproot address operation.
+ * Safe to call multiple times — only runs verification once.
+ *
+ * Why lazy: module-level `initEccLib(ecc)` breaks vitest because
+ * `vi.mock()` hoists above imports, so the mocked bitcoinjs-lib
+ * hasn't loaded the real ECC backend when the module evaluates.
+ */
+export function ensureEcc(): void {
   if (!eccInitialized) {
     initEccLib(ecc);
     eccInitialized = true;

--- a/packages/babylon-ts-sdk/src/tbv/core/utils/transaction/createSplitTransaction.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/utils/transaction/createSplitTransaction.ts
@@ -17,6 +17,7 @@ import { address as bitcoinAddress, Psbt, Transaction } from "bitcoinjs-lib";
 import { Buffer } from "buffer";
 
 import type { Network } from "../../primitives";
+import { ensureEcc } from "../../primitives/utils/bitcoin";
 import type { UTXO } from "../utxo/selectUtxos";
 
 import { getNetwork } from "./fundPeginTransaction";
@@ -90,6 +91,8 @@ export function createSplitTransaction(
   outputs: SplitOutput[],
   network: Network,
 ): SplitTransactionResult {
+  ensureEcc();
+
   // Validate inputs
   if (inputs.length === 0) {
     throw new Error("No input UTXOs provided for split transaction");

--- a/packages/babylon-ts-sdk/src/tbv/core/utils/transaction/fundPeginTransaction.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/utils/transaction/fundPeginTransaction.ts
@@ -17,6 +17,7 @@
 import * as bitcoin from "bitcoinjs-lib";
 import { Buffer } from "buffer";
 
+import { ensureEcc } from "../../primitives/utils/bitcoin";
 import { DUST_THRESHOLD } from "../fee/constants";
 import type { UTXO } from "../utxo/selectUtxos";
 
@@ -129,6 +130,8 @@ export function parseUnfundedWasmTransaction(
 export function fundPeginTransaction(
   params: FundPeginTransactionParams,
 ): string {
+  ensureEcc();
+
   const { unfundedTxHex, selectedUTXOs, changeAddress, changeAmount, network } =
     params;
 

--- a/services/vault/src/services/vault/utxoReservation.ts
+++ b/services/vault/src/services/vault/utxoReservation.ts
@@ -5,6 +5,12 @@
  * and selecting available UTXOs with smart fallback logic.
  */
 
+import {
+  FEE_SAFETY_MARGIN,
+  MAX_NON_LEGACY_OUTPUT_SIZE,
+  P2TR_INPUT_SIZE,
+  TX_BUFFER_SIZE_OVERHEAD,
+} from "@babylonlabs-io/ts-sdk/tbv/core";
 import { Transaction } from "bitcoinjs-lib";
 import { Buffer } from "buffer";
 
@@ -83,27 +89,17 @@ function isUtxoReserved(
  * - Transaction overhead (11 vBytes)
  * - 10% safety margin
  *
- * Constants from SDK (packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts):
- * - P2TR_INPUT_SIZE = 58 vBytes
- * - MAX_NON_LEGACY_OUTPUT_SIZE = 43 vBytes
- * - TX_BUFFER_SIZE_OVERHEAD = 11 vBytes
- * - FEE_SAFETY_MARGIN = 1.1
  */
 function estimateMinimumFeeBuffer(feeRate: number): bigint {
   const ASSUMED_INPUTS = 2;
-  const P2TR_INPUT_SIZE = 58;
-  const P2TR_OUTPUT_SIZE = 43;
-  const TX_OVERHEAD = 11;
-  const SAFETY_MARGIN = 1.1;
 
-  // txSize = (2 inputs × 58) + (vault output 43) + (change output 43) + (overhead 11)
   const estimatedTxSize =
-    ASSUMED_INPUTS * P2TR_INPUT_SIZE + // inputs
-    P2TR_OUTPUT_SIZE + // vault output
-    P2TR_OUTPUT_SIZE + // change output
-    TX_OVERHEAD; // overhead
+    ASSUMED_INPUTS * P2TR_INPUT_SIZE +
+    MAX_NON_LEGACY_OUTPUT_SIZE + // vault output
+    MAX_NON_LEGACY_OUTPUT_SIZE + // change output
+    TX_BUFFER_SIZE_OVERHEAD;
 
-  const estimatedFee = Math.ceil(estimatedTxSize * feeRate * SAFETY_MARGIN);
+  const estimatedFee = Math.ceil(estimatedTxSize * feeRate * FEE_SAFETY_MARGIN);
   return BigInt(estimatedFee);
 }
 

--- a/services/vault/src/services/wots/wotsService.ts
+++ b/services/vault/src/services/wots/wotsService.ts
@@ -41,12 +41,24 @@
  *   block seed) carry entropy.
  * - Only public key terminals are returned; secret chain starts stay local.
  *
- * ## TODO: WASM migration
+ * ## Note: intentional TS-only implementation
  *
- * This TypeScript WOTS implementation mirrors the Rust `babe::wots` crate.
- * It should be replaced with WASM bindings from btc-vault that expose
- * `deriveAssertWotsPublicKeys(seed)` and `computeWotsPublicKeysHash(keys)`
- * to avoid duplicating cryptographic logic. Track in btc-vault.
+ * This TypeScript WOTS implementation mirrors the Rust `babe::wots` crate's
+ * cryptographic primitives (Hash160 chains, checksum digits, public key
+ * serialization) but the derivation path is fundamentally different:
+ *
+ * - **Rust (VP-side):** generates WOTS keypairs from pure random entropy
+ *   via `WotsBigBlockKeypairs::generate()`. No mnemonic, no seed hierarchy.
+ * - **TypeScript (depositor-side):** derives WOTS keys deterministically from
+ *   a BIP-39 mnemonic → HMAC-based child derivation → per-block seeds, so the
+ *   depositor can re-derive keys from their mnemonic backup.
+ *
+ * The mnemonic/seed hierarchy is wallet-layer logic that does not belong in
+ * Rust/WASM. Only the low-level chain computation (`from_seed`, `hash160`,
+ * checksum) is duplicated, and this is acceptable because:
+ *   1. The logic is simple and well-tested against Rust reference vectors.
+ *   2. Exposing it via WASM would require passing the depositor's secret seed
+ *      material across the JS↔WASM boundary with no security benefit.
  */
 import { hmac } from "@noble/hashes/hmac.js";
 import { ripemd160 } from "@noble/hashes/legacy.js";


### PR DESCRIPTION
- **WASM control block:** Replace manual Taproot control block computation in `depositorPayout.ts` and `payout.ts`
with `getPayoutControlBlock()` already exposed by Rust WASM `WasmPeginPayoutConnector`. Removes ~60 lines of
duplicated crypto logic.
- **WASM memory leak fix:** Add `try/finally { connector.free() }` to browser `payoutConnector.ts` (pre-existing
leak, Node.js entry already had it).
- **ECC initialization cleanup:** Remove module-level `initEccLib(ecc)` side-effects from `depositorPayout.ts` and
`payout.ts`. Centralize into `ensureEcc()` in `primitives/utils/bitcoin.ts`, called lazily by the 3 functions that
actually need P2TR operations.
- **Fee constants:** `utxoReservation.ts` now imports `P2TR_INPUT_SIZE`, `MAX_NON_LEGACY_OUTPUT_SIZE`,
`TX_BUFFER_SIZE_OVERHEAD`, `FEE_SAFETY_MARGIN` from SDK instead of hardcoding duplicates.
- **WOTS comment:** Replace misleading "TODO: WASM migration" with explanation of why TS-only implementation is
intentional (mnemonic/seed derivation is wallet-layer logic, not Rust/WASM).