### PR TITLE
fix(vault): chainlink price decimals and staleness

### DIFF
--- a/services/vault/src/clients/eth-contract/chainlink/__tests__/query.test.ts
+++ b/services/vault/src/clients/eth-contract/chainlink/__tests__/query.test.ts
@@ -1,0 +1,254 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockMulticall = vi.fn();
+
+vi.mock("@/clients/eth-contract/client", () => ({
+  ethClient: {
+    getPublicClient: () => ({
+      multicall: mockMulticall,
+    }),
+  },
+}));
+
+vi.mock("@/infrastructure", () => ({
+  logger: {
+    event: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+vi.mock("@/config/env", () => ({
+  ENV: {
+    BTC_PRICE_FEED: null,
+  },
+}));
+
+vi.mock("@babylonlabs-io/wallet-connector", () => ({
+  Network: {
+    MAINNET: 0,
+    SIGNET: 1,
+    TESTNET: 2,
+  },
+}));
+
+import type { ChainlinkRoundData } from "../query";
+import { getTokenPrices, isPriceFresh } from "../query";
+
+/** Simulated Chainlink round ID for test fixtures */
+const ROUND_ID = 100n;
+
+/** BTC price in USD used across test fixtures */
+const BTC_PRICE_USD = 65000;
+
+/** BTC price as Chainlink 8-decimal answer */
+const BTC_ANSWER_8_DECIMALS = BigInt(BTC_PRICE_USD) * 10n ** 8n;
+
+/** BTC price as Chainlink 18-decimal answer */
+const BTC_ANSWER_18_DECIMALS = BigInt(BTC_PRICE_USD) * 10n ** 18n;
+
+/** ETH price in USD */
+const ETH_PRICE_USD = 2500;
+
+/** ETH price as Chainlink 8-decimal answer */
+const ETH_ANSWER_8_DECIMALS = BigInt(ETH_PRICE_USD) * 10n ** 8n;
+
+/** Chainlink standard feed precision (8 decimals) */
+const STANDARD_DECIMALS = 8;
+
+/** Age in seconds for "fresh" test data */
+const FRESH_AGE_SECONDS = 10n;
+
+/** answeredInRound value representing an incomplete oracle round */
+const INCOMPLETE_ANSWERED_IN_ROUND = 99n;
+
+/** Two hours in seconds — exceeds the 1-hour staleness threshold */
+const TWO_HOURS_SECONDS = 7200n;
+
+function makeRoundData(
+  overrides: Partial<ChainlinkRoundData> = {},
+): ChainlinkRoundData {
+  const nowSeconds = BigInt(Math.floor(Date.now() / 1000));
+  return {
+    roundId: ROUND_ID,
+    answer: BTC_ANSWER_8_DECIMALS,
+    startedAt: nowSeconds - FRESH_AGE_SECONDS,
+    updatedAt: nowSeconds - FRESH_AGE_SECONDS,
+    answeredInRound: ROUND_ID,
+    ...overrides,
+  };
+}
+
+describe("isPriceFresh", () => {
+  it("returns true when round is complete and data is fresh", () => {
+    const roundData = makeRoundData();
+    expect(isPriceFresh(roundData)).toBe(true);
+  });
+
+  it("returns false when answeredInRound < roundId (incomplete round)", () => {
+    const roundData = makeRoundData({
+      roundId: ROUND_ID,
+      answeredInRound: INCOMPLETE_ANSWERED_IN_ROUND,
+    });
+    expect(isPriceFresh(roundData)).toBe(false);
+  });
+
+  it("returns false when data age exceeds max threshold", () => {
+    const nowSeconds = BigInt(Math.floor(Date.now() / 1000));
+    const roundData = makeRoundData({
+      updatedAt: nowSeconds - TWO_HOURS_SECONDS,
+    });
+    expect(isPriceFresh(roundData)).toBe(false);
+  });
+
+  it("respects custom maxAgeSeconds parameter", () => {
+    const nowSeconds = BigInt(Math.floor(Date.now() / 1000));
+    const roundData = makeRoundData({
+      updatedAt: nowSeconds - 60n,
+    });
+    expect(isPriceFresh(roundData, 30)).toBe(false);
+    expect(isPriceFresh(roundData, 120)).toBe(true);
+  });
+});
+
+describe("getTokenPrices", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function mockFeedResponse(answer: bigint, decimals: number) {
+    const nowSeconds = BigInt(Math.floor(Date.now() / 1000));
+    mockMulticall.mockResolvedValueOnce([
+      [
+        ROUND_ID,
+        answer,
+        nowSeconds - FRESH_AGE_SECONDS,
+        nowSeconds - FRESH_AGE_SECONDS,
+        ROUND_ID,
+      ],
+      decimals,
+    ]);
+  }
+
+  it("returns correct price using dynamic decimals for 8-decimal feed", async () => {
+    mockFeedResponse(BTC_ANSWER_8_DECIMALS, STANDARD_DECIMALS);
+
+    const result = await getTokenPrices(["BTC"]);
+
+    expect(result.prices["BTC"]).toBe(BTC_PRICE_USD);
+    expect(result.metadata["BTC"].isStale).toBe(false);
+    expect(result.metadata["BTC"].fetchFailed).toBe(false);
+  });
+
+  it("returns correct price using dynamic decimals for 18-decimal feed", async () => {
+    mockFeedResponse(BTC_ANSWER_18_DECIMALS, 18);
+
+    const result = await getTokenPrices(["BTC"]);
+
+    expect(result.prices["BTC"]).toBe(BTC_PRICE_USD);
+  });
+
+  it("populates alias tokens for BTC (vBTC, sBTC)", async () => {
+    mockFeedResponse(BTC_ANSWER_8_DECIMALS, STANDARD_DECIMALS);
+
+    const result = await getTokenPrices(["BTC"]);
+
+    expect(result.prices["vBTC"]).toBe(BTC_PRICE_USD);
+    expect(result.prices["sBTC"]).toBe(BTC_PRICE_USD);
+    expect(result.metadata["vBTC"]).toEqual(result.metadata["BTC"]);
+    expect(result.metadata["sBTC"]).toEqual(result.metadata["BTC"]);
+  });
+
+  it("populates alias token for ETH (WETH)", async () => {
+    mockFeedResponse(ETH_ANSWER_8_DECIMALS, STANDARD_DECIMALS);
+
+    const result = await getTokenPrices(["ETH"]);
+
+    expect(result.prices["ETH"]).toBe(ETH_PRICE_USD);
+    expect(result.prices["WETH"]).toBe(ETH_PRICE_USD);
+    expect(result.metadata["WETH"]).toEqual(result.metadata["ETH"]);
+  });
+
+  it("marks metadata as stale when answeredInRound < roundId", async () => {
+    const nowSeconds = BigInt(Math.floor(Date.now() / 1000));
+    mockMulticall.mockResolvedValueOnce([
+      [
+        ROUND_ID,
+        BTC_ANSWER_8_DECIMALS,
+        nowSeconds - FRESH_AGE_SECONDS,
+        nowSeconds - FRESH_AGE_SECONDS,
+        INCOMPLETE_ANSWERED_IN_ROUND,
+      ],
+      STANDARD_DECIMALS,
+    ]);
+
+    const result = await getTokenPrices(["BTC"]);
+
+    expect(result.prices["BTC"]).toBe(BTC_PRICE_USD);
+    expect(result.metadata["BTC"].isStale).toBe(true);
+  });
+
+  it("marks metadata as stale when data exceeds max age", async () => {
+    const nowSeconds = BigInt(Math.floor(Date.now() / 1000));
+    mockMulticall.mockResolvedValueOnce([
+      [
+        ROUND_ID,
+        BTC_ANSWER_8_DECIMALS,
+        nowSeconds - TWO_HOURS_SECONDS,
+        nowSeconds - TWO_HOURS_SECONDS,
+        ROUND_ID,
+      ],
+      STANDARD_DECIMALS,
+    ]);
+
+    const result = await getTokenPrices(["BTC"]);
+
+    expect(result.metadata["BTC"].isStale).toBe(true);
+  });
+
+  it("stores error metadata when multicall fails", async () => {
+    mockMulticall.mockRejectedValueOnce(new Error("RPC timeout"));
+
+    const result = await getTokenPrices(["BTC"]);
+
+    expect(result.prices["BTC"]).toBeUndefined();
+    expect(result.metadata["BTC"].fetchFailed).toBe(true);
+    expect(result.metadata["BTC"].error).toBe("RPC timeout");
+  });
+
+  it("stores error metadata for alias tokens when BTC fetch fails", async () => {
+    mockMulticall.mockRejectedValueOnce(new Error("RPC timeout"));
+
+    const result = await getTokenPrices(["BTC"]);
+
+    expect(result.metadata["vBTC"].fetchFailed).toBe(true);
+    expect(result.metadata["sBTC"].fetchFailed).toBe(true);
+  });
+
+  it("throws on non-positive price via getTokenPrices error handling", async () => {
+    const nowSeconds = BigInt(Math.floor(Date.now() / 1000));
+    mockMulticall.mockResolvedValueOnce([
+      [
+        ROUND_ID,
+        0n,
+        nowSeconds - FRESH_AGE_SECONDS,
+        nowSeconds - FRESH_AGE_SECONDS,
+        ROUND_ID,
+      ],
+      STANDARD_DECIMALS,
+    ]);
+
+    const result = await getTokenPrices(["BTC"]);
+
+    expect(result.prices["BTC"]).toBeUndefined();
+    expect(result.metadata["BTC"].fetchFailed).toBe(true);
+    expect(result.metadata["BTC"].error).toContain("price must be positive");
+  });
+
+  it("skips symbols with no feed address", async () => {
+    const result = await getTokenPrices(["UNKNOWN_TOKEN"]);
+
+    expect(result.prices["UNKNOWN_TOKEN"]).toBeUndefined();
+    expect(result.metadata["UNKNOWN_TOKEN"]).toBeUndefined();
+    expect(mockMulticall).not.toHaveBeenCalled();
+  });
+});

--- a/services/vault/src/clients/eth-contract/chainlink/__tests__/query.test.ts
+++ b/services/vault/src/clients/eth-contract/chainlink/__tests__/query.test.ts
@@ -31,6 +31,10 @@ vi.mock("@babylonlabs-io/wallet-connector", () => ({
   },
 }));
 
+vi.mock("@babylonlabs-io/config", () => ({
+  getBTCNetwork: vi.fn(() => 1), // Network.SIGNET
+}));
+
 import type { ChainlinkRoundData } from "../query";
 import { getTokenPrices, isPriceFresh } from "../query";
 
@@ -185,6 +189,48 @@ describe("getTokenPrices", () => {
 
     expect(result.prices["BTC"]).toBe(BTC_PRICE_USD);
     expect(result.metadata["BTC"].isStale).toBe(true);
+  });
+
+  it("logs incomplete round message when answeredInRound < roundId", async () => {
+    const { logger } = await import("@/infrastructure");
+    const nowSeconds = BigInt(Math.floor(Date.now() / 1000));
+    mockMulticall.mockResolvedValueOnce([
+      [
+        ROUND_ID,
+        BTC_ANSWER_8_DECIMALS,
+        nowSeconds - FRESH_AGE_SECONDS,
+        nowSeconds - FRESH_AGE_SECONDS,
+        INCOMPLETE_ANSWERED_IN_ROUND,
+      ],
+      STANDARD_DECIMALS,
+    ]);
+
+    await getTokenPrices(["BTC"]);
+
+    expect(logger.event).toHaveBeenCalledWith(
+      expect.stringContaining("incomplete round"),
+    );
+  });
+
+  it("logs age-based message when data exceeds max age", async () => {
+    const { logger } = await import("@/infrastructure");
+    const nowSeconds = BigInt(Math.floor(Date.now() / 1000));
+    mockMulticall.mockResolvedValueOnce([
+      [
+        ROUND_ID,
+        BTC_ANSWER_8_DECIMALS,
+        nowSeconds - TWO_HOURS_SECONDS,
+        nowSeconds - TWO_HOURS_SECONDS,
+        ROUND_ID,
+      ],
+      STANDARD_DECIMALS,
+    ]);
+
+    await getTokenPrices(["BTC"]);
+
+    expect(logger.event).toHaveBeenCalledWith(
+      expect.stringContaining("hours old"),
+    );
   });
 
   it("marks metadata as stale when data exceeds max age", async () => {

--- a/services/vault/src/clients/eth-contract/chainlink/index.ts
+++ b/services/vault/src/clients/eth-contract/chainlink/index.ts
@@ -1,5 +1,6 @@
 export {
   getTokenPrices,
+  isPriceFresh,
   type ChainlinkRoundData,
   type PriceMetadata,
 } from "./query";

--- a/services/vault/src/clients/eth-contract/chainlink/query.ts
+++ b/services/vault/src/clients/eth-contract/chainlink/query.ts
@@ -44,6 +44,9 @@ const CHAINLINK_PRICE_FEEDS: Record<Network, ChainlinkFeedAddresses> = {
   },
 };
 
+/** Maximum acceptable age for Chainlink price data (1 hour) */
+const CHAINLINK_MAX_PRICE_AGE_SECONDS = 3600;
+
 function getChainlinkFeedAddress(symbol: string): Address | null {
   const network = getBTCNetwork();
   const normalizedSymbol = symbol.toUpperCase();
@@ -79,6 +82,13 @@ const CHAINLINK_AGGREGATOR_V3_ABI = [
       { name: "updatedAt", type: "uint256" },
       { name: "answeredInRound", type: "uint80" },
     ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "decimals",
+    outputs: [{ name: "", type: "uint8" }],
     stateMutability: "view",
     type: "function",
   },
@@ -120,29 +130,44 @@ interface TokenPricesResult {
 }
 
 /**
- * Get latest price data from Chainlink price feed
+ * Get latest price data and decimals from Chainlink price feed in a single RPC call.
  *
  * @param feedAddress - Address of the Chainlink price feed contract
- * @returns Round data including price (answer field)
+ * @returns Round data including price (answer field) and feed decimals
  */
-async function getLatestRoundData(
+async function getLatestRoundDataWithDecimals(
   feedAddress: Address,
-): Promise<ChainlinkRoundData> {
+): Promise<{ roundData: ChainlinkRoundData; decimals: number }> {
   const publicClient = ethClient.getPublicClient();
 
+  const [roundDataResult, decimalsResult] = await publicClient.multicall({
+    contracts: [
+      {
+        address: feedAddress,
+        abi: CHAINLINK_AGGREGATOR_V3_ABI,
+        functionName: "latestRoundData",
+      },
+      {
+        address: feedAddress,
+        abi: CHAINLINK_AGGREGATOR_V3_ABI,
+        functionName: "decimals",
+      },
+    ],
+    allowFailure: false,
+  });
+
   const [roundId, answer, startedAt, updatedAt, answeredInRound] =
-    await publicClient.readContract({
-      address: feedAddress,
-      abi: CHAINLINK_AGGREGATOR_V3_ABI,
-      functionName: "latestRoundData",
-    });
+    roundDataResult;
 
   return {
-    roundId,
-    answer,
-    startedAt,
-    updatedAt,
-    answeredInRound,
+    roundData: {
+      roundId,
+      answer,
+      startedAt,
+      updatedAt,
+      answeredInRound,
+    },
+    decimals: decimalsResult,
   };
 }
 
@@ -154,10 +179,11 @@ async function getLatestRoundData(
  * @param maxAgeSeconds - Maximum age in seconds (default: 3600 = 1 hour)
  * @returns true if data is fresh, false if stale
  */
-function isPriceFresh(
+export function isPriceFresh(
   roundData: ChainlinkRoundData,
-  maxAgeSeconds: number = 3600,
+  maxAgeSeconds: number = CHAINLINK_MAX_PRICE_AGE_SECONDS,
 ): boolean {
+  if (roundData.answeredInRound < roundData.roundId) return false;
   const now = BigInt(Math.floor(Date.now() / 1000));
   const age = now - roundData.updatedAt;
   return age <= BigInt(maxAgeSeconds);
@@ -166,7 +192,8 @@ function isPriceFresh(
 async function fetchPriceFromFeed(
   feedAddress: Address,
 ): Promise<{ price: number; metadata: PriceMetadata }> {
-  const roundData = await getLatestRoundData(feedAddress);
+  const { roundData, decimals } =
+    await getLatestRoundDataWithDecimals(feedAddress);
 
   if (roundData.answer <= 0n) {
     throw new Error(
@@ -179,14 +206,14 @@ async function fetchPriceFromFeed(
   const isStale = !isPriceFresh(roundData);
 
   if (isStale) {
-    const ageHours = (ageSeconds / 3600).toFixed(1);
+    const ageHours = (ageSeconds / CHAINLINK_MAX_PRICE_AGE_SECONDS).toFixed(1);
     logger.event(
       `Chainlink price data is stale (${ageHours} hours old). Using last known price.`,
     );
   }
 
   return {
-    price: Number(roundData.answer) / 1e8,
+    price: Number(roundData.answer) / 10 ** decimals,
     metadata: {
       isStale,
       ageSeconds,

--- a/services/vault/src/clients/eth-contract/chainlink/query.ts
+++ b/services/vault/src/clients/eth-contract/chainlink/query.ts
@@ -47,6 +47,9 @@ const CHAINLINK_PRICE_FEEDS: Record<Network, ChainlinkFeedAddresses> = {
 /** Maximum acceptable age for Chainlink price data (1 hour) */
 const CHAINLINK_MAX_PRICE_AGE_SECONDS = 3600;
 
+/** Number of seconds in one hour — used for display formatting */
+const SECONDS_PER_HOUR = 3600;
+
 function getChainlinkFeedAddress(symbol: string): Address | null {
   const network = getBTCNetwork();
   const normalizedSymbol = symbol.toUpperCase();
@@ -211,9 +214,7 @@ async function fetchPriceFromFeed(
         `Chainlink price data is stale: incomplete round (answeredInRound=${roundData.answeredInRound} < roundId=${roundData.roundId}). Using last known price.`,
       );
     } else {
-      const ageHours = (ageSeconds / CHAINLINK_MAX_PRICE_AGE_SECONDS).toFixed(
-        1,
-      );
+      const ageHours = (ageSeconds / SECONDS_PER_HOUR).toFixed(1);
       logger.event(
         `Chainlink price data is stale (${ageHours} hours old). Using last known price.`,
       );

--- a/services/vault/src/clients/eth-contract/chainlink/query.ts
+++ b/services/vault/src/clients/eth-contract/chainlink/query.ts
@@ -206,10 +206,18 @@ async function fetchPriceFromFeed(
   const isStale = !isPriceFresh(roundData);
 
   if (isStale) {
-    const ageHours = (ageSeconds / CHAINLINK_MAX_PRICE_AGE_SECONDS).toFixed(1);
-    logger.event(
-      `Chainlink price data is stale (${ageHours} hours old). Using last known price.`,
-    );
+    if (roundData.answeredInRound < roundData.roundId) {
+      logger.event(
+        `Chainlink price data is stale: incomplete round (answeredInRound=${roundData.answeredInRound} < roundId=${roundData.roundId}). Using last known price.`,
+      );
+    } else {
+      const ageHours = (ageSeconds / CHAINLINK_MAX_PRICE_AGE_SECONDS).toFixed(
+        1,
+      );
+      logger.event(
+        `Chainlink price data is stale (${ageHours} hours old). Using last known price.`,
+      );
+    }
   }
 
   return {


### PR DESCRIPTION
## Summary

- **Fix hardcoded Chainlink decimals (https://github.com/babylonlabs-io/vault-provider-proxy/issues/43
):** Replace `/ 1e8` with dynamic `decimals()` read from the feed contract, batched via `multicall` alongside `latestRoundData` for zero extra latency
- **Fix missing staleness check (https://github.com/babylonlabs-io/vault-provider-proxy/issues/45):** Add Chainlink-recommended `answeredInRound >= roundId` validation to `isPriceFresh()`, catching incomplete oracle rounds
- **Add test coverage:** 14 new tests for `isPriceFresh` and `getTokenPrices` (previously untested)

Closes https://github.com/babylonlabs-io/vault-provider-proxy/issues/43
Closes https://github.com/babylonlabs-io/vault-provider-proxy/issues/45