### PR TITLE
feat(vault): token price for borrow and repay metrics

### DIFF
--- a/services/vault/src/applications/aave/components/Detail/hooks/useAaveReserveDetail.ts
+++ b/services/vault/src/applications/aave/components/Detail/hooks/useAaveReserveDetail.ts
@@ -119,20 +119,25 @@ export function useAaveReserveDetail({
   // exists currently — totalDebtValueUsd equals the selected reserve's debt.
   // TODO: Replace with per-reserve oracle price when Spoke exposes it.
   const tokenPriceUsd = useMemo(() => {
+    // Return placeholder while reserve is loading or not found.
+    // This value is never consumed — parent components guard against
+    // null selectedReserve before rendering LoanProvider.
+    if (!selectedReserve) return STABLECOIN_FALLBACK_PRICE_USD;
+
     if (currentDebtAmount > 0 && debtValueUsd > 0) {
       return debtValueUsd / currentDebtAmount;
     }
 
     // First-time borrow: no debt to derive price from.
     // Only safe for stablecoins — throw for unknown tokens.
-    const symbol = selectedReserve?.token.symbol.toUpperCase();
-    const isKnownStablecoin =
-      symbol != null &&
-      (KNOWN_STABLECOIN_SYMBOLS as readonly string[]).includes(symbol);
+    const symbol = selectedReserve.token.symbol.toUpperCase();
+    const isKnownStablecoin = (
+      KNOWN_STABLECOIN_SYMBOLS as readonly string[]
+    ).includes(symbol);
 
     if (!isKnownStablecoin) {
       throw new Error(
-        `Cannot derive token price for ${symbol ?? "unknown"}: no existing debt and token is not a known stablecoin. ` +
+        `Cannot derive token price for ${symbol}: no existing debt and token is not a known stablecoin. ` +
           `Add a per-reserve oracle price source to support non-stablecoin borrows.`,
       );
     }

--- a/services/vault/src/applications/aave/components/Detail/hooks/useAaveReserveDetail.ts
+++ b/services/vault/src/applications/aave/components/Detail/hooks/useAaveReserveDetail.ts
@@ -12,6 +12,10 @@ import { formatUnits } from "viem";
 
 import { getTokenByAddress } from "@/services/token/tokenService";
 
+import {
+  KNOWN_STABLECOIN_SYMBOLS,
+  STABLECOIN_FALLBACK_PRICE_USD,
+} from "../../../constants";
 import { useAaveConfig } from "../../../context";
 import { useAaveUserPosition } from "../../../hooks";
 import type { AaveReserveConfig } from "../../../services/fetchConfig";
@@ -45,6 +49,8 @@ export interface UseAaveReserveDetailResult {
   totalDebtValueUsd: number;
   /** Health factor (null if no debt) */
   healthFactor: number | null;
+  /** Price of the selected borrow token in USD */
+  tokenPriceUsd: number;
 }
 
 export function useAaveReserveDetail({
@@ -108,6 +114,32 @@ export function useAaveReserveDetail({
   // Get liquidation threshold from vBTC reserve
   const liquidationThresholdBps = vbtcReserve?.reserve.collateralFactor ?? 0;
 
+  // Derive token price from oracle data when debt exists, otherwise use
+  // stablecoin fallback. This is valid because only one borrowable reserve
+  // exists currently — totalDebtValueUsd equals the selected reserve's debt.
+  // TODO: Replace with per-reserve oracle price when Spoke exposes it.
+  const tokenPriceUsd = useMemo(() => {
+    if (currentDebtAmount > 0 && debtValueUsd > 0) {
+      return debtValueUsd / currentDebtAmount;
+    }
+
+    // First-time borrow: no debt to derive price from.
+    // Only safe for stablecoins — throw for unknown tokens.
+    const symbol = selectedReserve?.token.symbol.toUpperCase();
+    const isKnownStablecoin =
+      symbol != null &&
+      (KNOWN_STABLECOIN_SYMBOLS as readonly string[]).includes(symbol);
+
+    if (!isKnownStablecoin) {
+      throw new Error(
+        `Cannot derive token price for ${symbol ?? "unknown"}: no existing debt and token is not a known stablecoin. ` +
+          `Add a per-reserve oracle price source to support non-stablecoin borrows.`,
+      );
+    }
+
+    return STABLECOIN_FALLBACK_PRICE_USD;
+  }, [currentDebtAmount, debtValueUsd, selectedReserve]);
+
   return {
     isLoading: configLoading || positionLoading,
     selectedReserve,
@@ -119,5 +151,6 @@ export function useAaveReserveDetail({
     currentDebtAmount,
     totalDebtValueUsd: debtValueUsd,
     healthFactor,
+    tokenPriceUsd,
   };
 }

--- a/services/vault/src/applications/aave/components/Detail/hooks/useAaveReserveDetail.ts
+++ b/services/vault/src/applications/aave/components/Detail/hooks/useAaveReserveDetail.ts
@@ -10,6 +10,7 @@
 import { useMemo } from "react";
 import { formatUnits } from "viem";
 
+import { logger } from "@/infrastructure";
 import { getTokenByAddress } from "@/services/token/tokenService";
 
 import {
@@ -49,8 +50,8 @@ export interface UseAaveReserveDetailResult {
   totalDebtValueUsd: number;
   /** Health factor (null if no debt) */
   healthFactor: number | null;
-  /** Price of the selected borrow token in USD */
-  tokenPriceUsd: number;
+  /** Price of the selected borrow token in USD (null if unavailable) */
+  tokenPriceUsd: number | null;
 }
 
 export function useAaveReserveDetail({
@@ -114,36 +115,66 @@ export function useAaveReserveDetail({
   // Get liquidation threshold from vBTC reserve
   const liquidationThresholdBps = vbtcReserve?.reserve.collateralFactor ?? 0;
 
-  // Derive token price from oracle data when debt exists, otherwise use
-  // stablecoin fallback. This is valid because only one borrowable reserve
-  // exists currently — totalDebtValueUsd equals the selected reserve's debt.
-  // TODO: Replace with per-reserve oracle price when Spoke exposes it.
-  const tokenPriceUsd = useMemo(() => {
-    // Return placeholder while reserve is loading or not found.
-    // This value is never consumed — parent components guard against
-    // null selectedReserve before rendering LoanProvider.
-    if (!selectedReserve) return STABLECOIN_FALLBACK_PRICE_USD;
+  // Derive token price. Returns null when the price cannot be determined,
+  // in which case parent components render a fallback instead of LoanProvider.
+  //
+  // Current strategy: derive from debt ratio when debt exists, otherwise use
+  // the $1 stablecoin fallback for first-borrow of known stablecoins.
+  //
+  // The debt-ratio derivation assumes exactly one borrowable reserve, because
+  // debtValueUsd is the user's total debt across all reserves. A runtime
+  // assertion below fails loudly if that assumption is ever violated.
+  //
+  // TODO: Migrate to Chainlink price feeds via
+  // `services/vault/src/clients/eth-contract/chainlink/query.ts` once feeds
+  // are available for borrowable reserves on our target network. That would
+  // remove the single-reserve assumption and the stablecoin fallback.
+  const tokenPriceUsd = useMemo((): number | null => {
+    if (!selectedReserve) return null;
 
     if (currentDebtAmount > 0 && debtValueUsd > 0) {
+      if (borrowableReserves.length !== 1) {
+        logger.error(
+          new Error(
+            "tokenPriceUsd debt-ratio derivation is only valid for a single borrowable reserve",
+          ),
+          {
+            data: {
+              context: "useAaveReserveDetail.tokenPriceUsd",
+              borrowableReserveCount: borrowableReserves.length,
+              selectedReserveSymbol: selectedReserve.token.symbol,
+            },
+          },
+        );
+        return null;
+      }
       return debtValueUsd / currentDebtAmount;
     }
 
     // First-time borrow: no debt to derive price from.
-    // Only safe for stablecoins — throw for unknown tokens.
+    // Only safe for stablecoins — log and return null for unknown tokens.
     const symbol = selectedReserve.token.symbol.toUpperCase();
     const isKnownStablecoin = (
       KNOWN_STABLECOIN_SYMBOLS as readonly string[]
     ).includes(symbol);
 
     if (!isKnownStablecoin) {
-      throw new Error(
-        `Cannot derive token price for ${symbol}: no existing debt and token is not a known stablecoin. ` +
-          `Add a per-reserve oracle price source to support non-stablecoin borrows.`,
+      logger.error(
+        new Error(
+          `Cannot derive token price for ${symbol}: no existing debt and token is not a known stablecoin`,
+        ),
+        {
+          data: {
+            context: "useAaveReserveDetail.tokenPriceUsd",
+            symbol,
+          },
+        },
       );
+      return null;
     }
 
     return STABLECOIN_FALLBACK_PRICE_USD;
-  }, [currentDebtAmount, debtValueUsd, selectedReserve]);
+  }, [currentDebtAmount, debtValueUsd, selectedReserve, borrowableReserves]);
 
   return {
     isLoading: configLoading || positionLoading,

--- a/services/vault/src/applications/aave/components/Detail/index.tsx
+++ b/services/vault/src/applications/aave/components/Detail/index.tsx
@@ -47,6 +47,7 @@ export function AaveReserveDetail() {
     currentDebtAmount,
     totalDebtValueUsd,
     healthFactor,
+    tokenPriceUsd,
   } = useAaveReserveDetail({ reserveId, address });
 
   // Modal state management
@@ -130,6 +131,7 @@ export function AaveReserveDetail() {
     selectedReserve,
     assetConfig,
     proxyContract,
+    tokenPriceUsd,
     onBorrowSuccess: openBorrowSuccess,
     onRepaySuccess: openRepaySuccess,
   };

--- a/services/vault/src/applications/aave/components/Detail/index.tsx
+++ b/services/vault/src/applications/aave/components/Detail/index.tsx
@@ -107,8 +107,13 @@ export function AaveReserveDetail() {
     );
   }
 
-  // Reserve not found
-  if (!selectedReserve || !assetConfig || !vbtcReserve) {
+  // Reserve not found or price unavailable
+  if (
+    !selectedReserve ||
+    !assetConfig ||
+    !vbtcReserve ||
+    tokenPriceUsd == null
+  ) {
     return (
       <Container className="pb-6">
         <div className="space-y-6">

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/__tests__/calculateMaxBorrowTokens.test.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/__tests__/calculateMaxBorrowTokens.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  BPS_SCALE,
+  MIN_HEALTH_FACTOR_FOR_BORROW,
+} from "../../../../../constants";
+import { calculateMaxBorrowTokens } from "../calculateMaxBorrowTokens";
+
+describe("calculateMaxBorrowTokens", () => {
+  it("caps max borrow using liquidation threshold and safety margin", () => {
+    // $10,000 collateral, 80% LT, no existing debt, $1 token
+    // (10000 * 8000 / 10000) / 1.2 = 6666.66...
+    const result = calculateMaxBorrowTokens({
+      collateralValueUsd: 10000,
+      currentDebtUsd: 0,
+      liquidationThresholdBps: 8000,
+      tokenPriceUsd: 1,
+    });
+
+    const expectedUsd =
+      (10000 * 8000) / BPS_SCALE / MIN_HEALTH_FACTOR_FOR_BORROW;
+    expect(result).toBe(Math.floor(expectedUsd * 100) / 100);
+  });
+
+  it("subtracts existing debt from borrowing capacity", () => {
+    // $10,000 collateral, 80% LT, $2000 existing debt, $1 token
+    const result = calculateMaxBorrowTokens({
+      collateralValueUsd: 10000,
+      currentDebtUsd: 2000,
+      liquidationThresholdBps: 8000,
+      tokenPriceUsd: 1,
+    });
+
+    const expectedUsd =
+      (10000 * 8000) / BPS_SCALE / MIN_HEALTH_FACTOR_FOR_BORROW - 2000;
+    expect(result).toBe(Math.floor(expectedUsd * 100) / 100);
+  });
+
+  it("converts USD cap to token units when token price is not $1", () => {
+    // $10,000 collateral, 80% LT, no debt, token worth $2
+    const result = calculateMaxBorrowTokens({
+      collateralValueUsd: 10000,
+      currentDebtUsd: 0,
+      liquidationThresholdBps: 8000,
+      tokenPriceUsd: 2,
+    });
+
+    const expectedUsd =
+      (10000 * 8000) / BPS_SCALE / MIN_HEALTH_FACTOR_FOR_BORROW;
+    expect(result).toBe(Math.floor((expectedUsd / 2) * 100) / 100);
+  });
+
+  it("returns zero when existing debt exceeds borrowing capacity", () => {
+    const result = calculateMaxBorrowTokens({
+      collateralValueUsd: 10000,
+      currentDebtUsd: 8000,
+      liquidationThresholdBps: 8000,
+      tokenPriceUsd: 1,
+    });
+
+    expect(result).toBe(0);
+  });
+
+  it("returns zero when collateral is zero", () => {
+    const result = calculateMaxBorrowTokens({
+      collateralValueUsd: 0,
+      currentDebtUsd: 0,
+      liquidationThresholdBps: 8000,
+      tokenPriceUsd: 1,
+    });
+
+    expect(result).toBe(0);
+  });
+
+  it("floors result to two decimal places", () => {
+    // Choose inputs that would produce more than 2 decimals if unrounded
+    const result = calculateMaxBorrowTokens({
+      collateralValueUsd: 123.456,
+      currentDebtUsd: 0,
+      liquidationThresholdBps: 8000,
+      tokenPriceUsd: 1,
+    });
+
+    // Must match Math.floor(value * 100) / 100 exactly
+    expect(Number.isFinite(result)).toBe(true);
+    expect(result * 100).toBe(Math.floor(result * 100));
+  });
+
+  it("respects a different liquidation threshold (7500 BPS)", () => {
+    // $10,000 collateral, 75% LT, no debt, $1 token
+    const result = calculateMaxBorrowTokens({
+      collateralValueUsd: 10000,
+      currentDebtUsd: 0,
+      liquidationThresholdBps: 7500,
+      tokenPriceUsd: 1,
+    });
+
+    const expectedUsd =
+      (10000 * 7500) / BPS_SCALE / MIN_HEALTH_FACTOR_FOR_BORROW;
+    expect(result).toBe(Math.floor(expectedUsd * 100) / 100);
+  });
+});

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/__tests__/useBorrowMetrics.test.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/__tests__/useBorrowMetrics.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Tests for useBorrowMetrics
+ *
+ * Verifies that borrowAmount (in token units) is correctly converted
+ * to USD via tokenPriceUsd for health factor and borrow ratio calculations
+ * (Issues #48, #61).
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { useBorrowMetrics } from "../useBorrowMetrics";
+
+describe("useBorrowMetrics", () => {
+  const baseProps = {
+    collateralValueUsd: 10000,
+    currentDebtUsd: 1000,
+    liquidationThresholdBps: 8000,
+    currentHealthFactor: 8.0,
+  };
+
+  it("shows current values when borrowAmount is 0", () => {
+    const result = useBorrowMetrics({
+      ...baseProps,
+      borrowAmount: 0,
+      tokenPriceUsd: 1,
+    });
+
+    expect(result.healthFactorValue).toBe(8.0);
+    expect(result.borrowRatioOriginal).toBeUndefined();
+    expect(result.healthFactorOriginal).toBeUndefined();
+  });
+
+  it("converts token units to USD using tokenPriceUsd for health factor", () => {
+    // Borrow 100 tokens at $1 each = $100 additional debt
+    // Total debt = $1000 + $100 = $1100
+    // HF = (10000 * 0.8) / 1100 = 7.272...
+    const result = useBorrowMetrics({
+      ...baseProps,
+      borrowAmount: 100,
+      tokenPriceUsd: 1,
+    });
+
+    expect(result.healthFactorValue).toBeCloseTo((10000 * 0.8) / 1100, 5);
+  });
+
+  it("correctly handles non-$1 token prices", () => {
+    // Borrow 4 tokens at $1500 each = $6000 additional debt
+    // Total debt = $1000 + $6000 = $7000
+    // HF = (10000 * 0.8) / 7000 = 1.142...
+    const result = useBorrowMetrics({
+      ...baseProps,
+      borrowAmount: 4,
+      tokenPriceUsd: 1500,
+    });
+
+    expect(result.healthFactorValue).toBeCloseTo((10000 * 0.8) / 7000, 5);
+  });
+
+  it("shows projected and original borrow ratio when borrowing", () => {
+    const result = useBorrowMetrics({
+      ...baseProps,
+      borrowAmount: 500,
+      tokenPriceUsd: 1,
+    });
+
+    // Original ratio should be based on current debt only
+    expect(result.borrowRatioOriginal).toBeDefined();
+    // Projected ratio should include the new borrow
+    expect(result.borrowRatio).toBeDefined();
+  });
+
+  it("returns Infinity health factor when no existing debt and borrowAmount is 0", () => {
+    const result = useBorrowMetrics({
+      ...baseProps,
+      currentDebtUsd: 0,
+      currentHealthFactor: null,
+      borrowAmount: 0,
+      tokenPriceUsd: 1,
+    });
+
+    expect(result.healthFactorValue).toBe(Infinity);
+  });
+});

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/__tests__/useBorrowState.test.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/__tests__/useBorrowState.test.ts
@@ -1,154 +1,58 @@
 /**
- * Tests for useBorrowState hook
+ * Tests for useBorrowState hook state management.
  *
- * Verifies that maxBorrowAmount correctly incorporates the liquidation
- * threshold and MIN_HEALTH_FACTOR_FOR_BORROW safety margin (Issue #46).
+ * The maxBorrowAmount formula is covered by calculateMaxBorrowTokens.test.ts;
+ * this file only verifies the hook's state-holder responsibility.
  */
 
 import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
-import {
-  BPS_SCALE,
-  MIN_HEALTH_FACTOR_FOR_BORROW,
-} from "../../../../../constants";
 import { useBorrowState } from "../useBorrowState";
 
+const defaultProps = {
+  collateralValueUsd: 10000,
+  currentDebtUsd: 0,
+  liquidationThresholdBps: 8000,
+  tokenPriceUsd: 1,
+};
+
 describe("useBorrowState", () => {
-  describe("maxBorrowAmount with LTV cap", () => {
-    it("caps max borrow using liquidation threshold and safety margin", () => {
-      // $10,000 collateral, 80% LT, no existing debt, $1 token
-      // Expected: (10000 * 8000 / 10000) / 1.2 - 0 = 6666.66 USD = 6666.66 tokens
-      const { result } = renderHook(() =>
-        useBorrowState({
-          collateralValueUsd: 10000,
-          currentDebtUsd: 0,
-          liquidationThresholdBps: 8000,
-          tokenPriceUsd: 1,
-        }),
-      );
+  it("initializes borrowAmount to zero", () => {
+    const { result } = renderHook(() => useBorrowState(defaultProps));
 
-      const expectedMaxUsd =
-        (10000 * 8000) / BPS_SCALE / MIN_HEALTH_FACTOR_FOR_BORROW;
-      const expectedMaxTokens = Math.floor(expectedMaxUsd * 100) / 100;
-      expect(result.current.maxBorrowAmount).toBe(expectedMaxTokens);
-    });
-
-    it("subtracts existing debt from max borrow", () => {
-      // $10,000 collateral, 80% LT, $2000 existing debt, $1 token
-      // Expected: (10000 * 0.8) / 1.2 - 2000 = 4666.66 tokens
-      const { result } = renderHook(() =>
-        useBorrowState({
-          collateralValueUsd: 10000,
-          currentDebtUsd: 2000,
-          liquidationThresholdBps: 8000,
-          tokenPriceUsd: 1,
-        }),
-      );
-
-      const expectedMaxUsd =
-        (10000 * 8000) / BPS_SCALE / MIN_HEALTH_FACTOR_FOR_BORROW - 2000;
-      const expectedMaxTokens = Math.floor(expectedMaxUsd * 100) / 100;
-      expect(result.current.maxBorrowAmount).toBe(expectedMaxTokens);
-    });
-
-    it("converts USD cap to token units using tokenPriceUsd", () => {
-      // $10,000 collateral, 80% LT, no debt, token worth $2
-      // Max USD = (10000 * 0.8) / 1.2 = 6666.66
-      // Max tokens = 6666.66 / 2 = 3333.33
-      const { result } = renderHook(() =>
-        useBorrowState({
-          collateralValueUsd: 10000,
-          currentDebtUsd: 0,
-          liquidationThresholdBps: 8000,
-          tokenPriceUsd: 2,
-        }),
-      );
-
-      const expectedMaxUsd =
-        (10000 * 8000) / BPS_SCALE / MIN_HEALTH_FACTOR_FOR_BORROW;
-      const expectedMaxTokens = Math.floor((expectedMaxUsd / 2) * 100) / 100;
-      expect(result.current.maxBorrowAmount).toBe(expectedMaxTokens);
-    });
-
-    it("returns zero when debt exceeds borrowing capacity", () => {
-      // $10,000 collateral, 80% LT, $8000 debt (exceeds capacity)
-      const { result } = renderHook(() =>
-        useBorrowState({
-          collateralValueUsd: 10000,
-          currentDebtUsd: 8000,
-          liquidationThresholdBps: 8000,
-          tokenPriceUsd: 1,
-        }),
-      );
-
-      expect(result.current.maxBorrowAmount).toBe(0);
-    });
-
-    it("returns zero when collateral is zero", () => {
-      const { result } = renderHook(() =>
-        useBorrowState({
-          collateralValueUsd: 0,
-          currentDebtUsd: 0,
-          liquidationThresholdBps: 8000,
-          tokenPriceUsd: 1,
-        }),
-      );
-
-      expect(result.current.maxBorrowAmount).toBe(0);
-    });
+    expect(result.current.borrowAmount).toBe(0);
   });
 
-  describe("borrowAmount state", () => {
-    it("initializes to zero", () => {
-      const { result } = renderHook(() =>
-        useBorrowState({
-          collateralValueUsd: 10000,
-          currentDebtUsd: 0,
-          liquidationThresholdBps: 8000,
-          tokenPriceUsd: 1,
-        }),
-      );
+  it("updates borrowAmount when setBorrowAmount is called", () => {
+    const { result } = renderHook(() => useBorrowState(defaultProps));
 
-      expect(result.current.borrowAmount).toBe(0);
+    act(() => {
+      result.current.setBorrowAmount(500);
     });
 
-    it("updates when setBorrowAmount is called", () => {
-      const { result } = renderHook(() =>
-        useBorrowState({
-          collateralValueUsd: 10000,
-          currentDebtUsd: 0,
-          liquidationThresholdBps: 8000,
-          tokenPriceUsd: 1,
-        }),
-      );
+    expect(result.current.borrowAmount).toBe(500);
+  });
 
-      act(() => {
-        result.current.setBorrowAmount(500);
-      });
+  it("resets borrowAmount to zero when resetBorrowAmount is called", () => {
+    const { result } = renderHook(() => useBorrowState(defaultProps));
 
-      expect(result.current.borrowAmount).toBe(500);
+    act(() => {
+      result.current.setBorrowAmount(500);
     });
 
-    it("resets to zero when resetBorrowAmount is called", () => {
-      const { result } = renderHook(() =>
-        useBorrowState({
-          collateralValueUsd: 10000,
-          currentDebtUsd: 0,
-          liquidationThresholdBps: 8000,
-          tokenPriceUsd: 1,
-        }),
-      );
-
-      act(() => {
-        result.current.setBorrowAmount(500);
-      });
-
-      act(() => {
-        result.current.resetBorrowAmount();
-      });
-
-      expect(result.current.borrowAmount).toBe(0);
+    act(() => {
+      result.current.resetBorrowAmount();
     });
+
+    expect(result.current.borrowAmount).toBe(0);
+  });
+
+  it("exposes maxBorrowAmount computed from calculateMaxBorrowTokens", () => {
+    // Smoke test — proves the hook wires inputs through to the pure function.
+    // Formula correctness is covered by calculateMaxBorrowTokens.test.ts.
+    const { result } = renderHook(() => useBorrowState(defaultProps));
+
+    expect(result.current.maxBorrowAmount).toBeGreaterThan(0);
   });
 });

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/__tests__/useBorrowState.test.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/__tests__/useBorrowState.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Tests for useBorrowState hook
+ *
+ * Verifies that maxBorrowAmount correctly incorporates the liquidation
+ * threshold and MIN_HEALTH_FACTOR_FOR_BORROW safety margin (Issue #46).
+ */
+
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  BPS_SCALE,
+  MIN_HEALTH_FACTOR_FOR_BORROW,
+} from "../../../../../constants";
+import { useBorrowState } from "../useBorrowState";
+
+describe("useBorrowState", () => {
+  describe("maxBorrowAmount with LTV cap", () => {
+    it("caps max borrow using liquidation threshold and safety margin", () => {
+      // $10,000 collateral, 80% LT, no existing debt, $1 token
+      // Expected: (10000 * 8000 / 10000) / 1.2 - 0 = 6666.66 USD = 6666.66 tokens
+      const { result } = renderHook(() =>
+        useBorrowState({
+          collateralValueUsd: 10000,
+          currentDebtUsd: 0,
+          liquidationThresholdBps: 8000,
+          tokenPriceUsd: 1,
+        }),
+      );
+
+      const expectedMaxUsd =
+        (10000 * 8000) / BPS_SCALE / MIN_HEALTH_FACTOR_FOR_BORROW;
+      const expectedMaxTokens = Math.floor(expectedMaxUsd * 100) / 100;
+      expect(result.current.maxBorrowAmount).toBe(expectedMaxTokens);
+    });
+
+    it("subtracts existing debt from max borrow", () => {
+      // $10,000 collateral, 80% LT, $2000 existing debt, $1 token
+      // Expected: (10000 * 0.8) / 1.2 - 2000 = 4666.66 tokens
+      const { result } = renderHook(() =>
+        useBorrowState({
+          collateralValueUsd: 10000,
+          currentDebtUsd: 2000,
+          liquidationThresholdBps: 8000,
+          tokenPriceUsd: 1,
+        }),
+      );
+
+      const expectedMaxUsd =
+        (10000 * 8000) / BPS_SCALE / MIN_HEALTH_FACTOR_FOR_BORROW - 2000;
+      const expectedMaxTokens = Math.floor(expectedMaxUsd * 100) / 100;
+      expect(result.current.maxBorrowAmount).toBe(expectedMaxTokens);
+    });
+
+    it("converts USD cap to token units using tokenPriceUsd", () => {
+      // $10,000 collateral, 80% LT, no debt, token worth $2
+      // Max USD = (10000 * 0.8) / 1.2 = 6666.66
+      // Max tokens = 6666.66 / 2 = 3333.33
+      const { result } = renderHook(() =>
+        useBorrowState({
+          collateralValueUsd: 10000,
+          currentDebtUsd: 0,
+          liquidationThresholdBps: 8000,
+          tokenPriceUsd: 2,
+        }),
+      );
+
+      const expectedMaxUsd =
+        (10000 * 8000) / BPS_SCALE / MIN_HEALTH_FACTOR_FOR_BORROW;
+      const expectedMaxTokens = Math.floor((expectedMaxUsd / 2) * 100) / 100;
+      expect(result.current.maxBorrowAmount).toBe(expectedMaxTokens);
+    });
+
+    it("returns zero when debt exceeds borrowing capacity", () => {
+      // $10,000 collateral, 80% LT, $8000 debt (exceeds capacity)
+      const { result } = renderHook(() =>
+        useBorrowState({
+          collateralValueUsd: 10000,
+          currentDebtUsd: 8000,
+          liquidationThresholdBps: 8000,
+          tokenPriceUsd: 1,
+        }),
+      );
+
+      expect(result.current.maxBorrowAmount).toBe(0);
+    });
+
+    it("returns zero when collateral is zero", () => {
+      const { result } = renderHook(() =>
+        useBorrowState({
+          collateralValueUsd: 0,
+          currentDebtUsd: 0,
+          liquidationThresholdBps: 8000,
+          tokenPriceUsd: 1,
+        }),
+      );
+
+      expect(result.current.maxBorrowAmount).toBe(0);
+    });
+  });
+
+  describe("borrowAmount state", () => {
+    it("initializes to zero", () => {
+      const { result } = renderHook(() =>
+        useBorrowState({
+          collateralValueUsd: 10000,
+          currentDebtUsd: 0,
+          liquidationThresholdBps: 8000,
+          tokenPriceUsd: 1,
+        }),
+      );
+
+      expect(result.current.borrowAmount).toBe(0);
+    });
+
+    it("updates when setBorrowAmount is called", () => {
+      const { result } = renderHook(() =>
+        useBorrowState({
+          collateralValueUsd: 10000,
+          currentDebtUsd: 0,
+          liquidationThresholdBps: 8000,
+          tokenPriceUsd: 1,
+        }),
+      );
+
+      act(() => {
+        result.current.setBorrowAmount(500);
+      });
+
+      expect(result.current.borrowAmount).toBe(500);
+    });
+
+    it("resets to zero when resetBorrowAmount is called", () => {
+      const { result } = renderHook(() =>
+        useBorrowState({
+          collateralValueUsd: 10000,
+          currentDebtUsd: 0,
+          liquidationThresholdBps: 8000,
+          tokenPriceUsd: 1,
+        }),
+      );
+
+      act(() => {
+        result.current.setBorrowAmount(500);
+      });
+
+      act(() => {
+        result.current.resetBorrowAmount();
+      });
+
+      expect(result.current.borrowAmount).toBe(0);
+    });
+  });
+});

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/calculateMaxBorrowTokens.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/calculateMaxBorrowTokens.ts
@@ -1,0 +1,41 @@
+import { BPS_SCALE, MIN_HEALTH_FACTOR_FOR_BORROW } from "../../../../constants";
+
+export interface CalculateMaxBorrowTokensParams {
+  /** Collateral value in USD (from Aave oracle) */
+  collateralValueUsd: number;
+  /** Current debt in USD (from Aave oracle) */
+  currentDebtUsd: number;
+  /** Liquidation threshold in BPS (e.g., 8000 = 80%) */
+  liquidationThresholdBps: number;
+  /** Price of the borrow token in USD */
+  tokenPriceUsd: number;
+}
+
+/**
+ * Max tokens a user can borrow while keeping health factor >=
+ * MIN_HEALTH_FACTOR_FOR_BORROW.
+ *
+ * Derivation:
+ *   HF = (collateral * LT) / totalDebt >= MIN_HF
+ *   totalDebt <= (collateral * LT) / MIN_HF
+ *   maxAdditionalBorrowUsd = (collateral * LT) / MIN_HF - currentDebt
+ *   maxBorrowTokens = maxAdditionalBorrowUsd / tokenPriceUsd
+ *
+ * Returns 0 when the resulting value would be negative (existing debt
+ * already exceeds borrowing capacity). Floored to 2 decimals so the
+ * slider never offers sub-cent precision.
+ */
+export function calculateMaxBorrowTokens({
+  collateralValueUsd,
+  currentDebtUsd,
+  liquidationThresholdBps,
+  tokenPriceUsd,
+}: CalculateMaxBorrowTokensParams): number {
+  const maxTotalDebtUsd =
+    (collateralValueUsd * liquidationThresholdBps) /
+    BPS_SCALE /
+    MIN_HEALTH_FACTOR_FOR_BORROW;
+  const maxAdditionalBorrowUsd = maxTotalDebtUsd - currentDebtUsd;
+  const maxBorrowTokens = maxAdditionalBorrowUsd / tokenPriceUsd;
+  return Math.floor(Math.max(0, maxBorrowTokens) * 100) / 100;
+}

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/useBorrowMetrics.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/useBorrowMetrics.ts
@@ -2,7 +2,7 @@
  * Borrow metrics calculation hook
  *
  * Calculates display metrics for borrow UI including projected health factor.
- * Uses USD values directly from Aave oracle.
+ * borrowAmount is in token units; converted to USD via tokenPriceUsd for calculations.
  */
 
 import {
@@ -12,6 +12,7 @@ import {
 } from "../../../../utils";
 
 export interface UseBorrowMetricsProps {
+  /** Borrow amount in token units */
   borrowAmount: number;
   /** Collateral value in USD (from Aave oracle) */
   collateralValueUsd: number;
@@ -21,6 +22,8 @@ export interface UseBorrowMetricsProps {
   liquidationThresholdBps: number;
   /** Current health factor (null if no debt) */
   currentHealthFactor: number | null;
+  /** Price of the borrow token in USD */
+  tokenPriceUsd: number;
 }
 
 export interface UseBorrowMetricsResult {
@@ -43,6 +46,7 @@ export function useBorrowMetrics({
   currentDebtUsd,
   liquidationThresholdBps,
   currentHealthFactor,
+  tokenPriceUsd,
 }: UseBorrowMetricsProps): UseBorrowMetricsResult {
   // When no borrow amount entered, show current values (no projection)
   if (borrowAmount === 0) {
@@ -57,8 +61,8 @@ export function useBorrowMetrics({
     };
   }
 
-  // Calculate projected values after borrow
-  const totalDebtUsd = currentDebtUsd + borrowAmount;
+  // Calculate projected values after borrow (convert token units to USD)
+  const totalDebtUsd = currentDebtUsd + borrowAmount * tokenPriceUsd;
   const healthFactorValue = calculateHealthFactor(
     collateralValueUsd,
     totalDebtUsd,

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/useBorrowState.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/useBorrowState.ts
@@ -7,7 +7,7 @@
 
 import { useMemo, useState } from "react";
 
-import { BPS_SCALE, MIN_HEALTH_FACTOR_FOR_BORROW } from "../../../../constants";
+import { calculateMaxBorrowTokens } from "./calculateMaxBorrowTokens";
 
 export interface UseBorrowStateProps {
   /** Collateral value in USD (from Aave oracle) */
@@ -37,26 +37,21 @@ export function useBorrowState({
 }: UseBorrowStateProps): UseBorrowStateResult {
   const [borrowAmount, setBorrowAmount] = useState(0);
 
-  const maxBorrowAmount = useMemo(() => {
-    // Max borrow in USD that keeps health factor >= MIN_HEALTH_FACTOR_FOR_BORROW:
-    //   HF = (collateral * LT) / totalDebt >= MIN_HF
-    //   totalDebt <= (collateral * LT) / MIN_HF
-    //   maxAdditionalDebtUsd = (collateral * LT) / MIN_HF - currentDebt
-    const maxAdditionalBorrowUsd =
-      (collateralValueUsd * liquidationThresholdBps) /
-        BPS_SCALE /
-        MIN_HEALTH_FACTOR_FOR_BORROW -
-      currentDebtUsd;
-
-    // Convert USD cap to token units
-    const maxBorrowTokens = maxAdditionalBorrowUsd / tokenPriceUsd;
-    return Math.floor(Math.max(0, maxBorrowTokens) * 100) / 100;
-  }, [
-    collateralValueUsd,
-    currentDebtUsd,
-    liquidationThresholdBps,
-    tokenPriceUsd,
-  ]);
+  const maxBorrowAmount = useMemo(
+    () =>
+      calculateMaxBorrowTokens({
+        collateralValueUsd,
+        currentDebtUsd,
+        liquidationThresholdBps,
+        tokenPriceUsd,
+      }),
+    [
+      collateralValueUsd,
+      currentDebtUsd,
+      liquidationThresholdBps,
+      tokenPriceUsd,
+    ],
+  );
 
   const resetBorrowAmount = () => setBorrowAmount(0);
 

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/useBorrowState.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/useBorrowState.ts
@@ -1,37 +1,62 @@
 /**
  * Borrow state management hook
  *
- * Manages borrow amount and calculates max borrow based on position data.
+ * Manages borrow amount (in token units) and calculates max borrow
+ * based on position data, liquidation threshold, and safety margin.
  */
 
 import { useMemo, useState } from "react";
+
+import { BPS_SCALE, MIN_HEALTH_FACTOR_FOR_BORROW } from "../../../../constants";
 
 export interface UseBorrowStateProps {
   /** Collateral value in USD (from Aave oracle) */
   collateralValueUsd: number;
   /** Current debt in USD (from Aave oracle) */
   currentDebtUsd: number;
+  /** Liquidation threshold in BPS (e.g., 8000 = 80%) */
+  liquidationThresholdBps: number;
+  /** Price of the borrow token in USD */
+  tokenPriceUsd: number;
 }
 
 export interface UseBorrowStateResult {
+  /** Borrow amount in token units */
   borrowAmount: number;
   setBorrowAmount: (amount: number) => void;
   resetBorrowAmount: () => void;
+  /** Max borrowable amount in token units */
   maxBorrowAmount: number;
 }
 
 export function useBorrowState({
   collateralValueUsd,
   currentDebtUsd,
+  liquidationThresholdBps,
+  tokenPriceUsd,
 }: UseBorrowStateProps): UseBorrowStateResult {
   const [borrowAmount, setBorrowAmount] = useState(0);
 
   const maxBorrowAmount = useMemo(() => {
-    // Max borrow = collateral value minus existing debt
-    // UI validates health factor separately to warn about liquidation risk
-    const maxAdditionalBorrow = collateralValueUsd - currentDebtUsd;
-    return Math.floor(Math.max(0, maxAdditionalBorrow) * 100) / 100;
-  }, [collateralValueUsd, currentDebtUsd]);
+    // Max borrow in USD that keeps health factor >= MIN_HEALTH_FACTOR_FOR_BORROW:
+    //   HF = (collateral * LT) / totalDebt >= MIN_HF
+    //   totalDebt <= (collateral * LT) / MIN_HF
+    //   maxAdditionalDebtUsd = (collateral * LT) / MIN_HF - currentDebt
+    const maxAdditionalBorrowUsd =
+      (collateralValueUsd * liquidationThresholdBps) /
+        BPS_SCALE /
+        MIN_HEALTH_FACTOR_FOR_BORROW -
+      currentDebtUsd;
+
+    // Convert USD cap to token units
+    const maxBorrowTokens = maxAdditionalBorrowUsd / tokenPriceUsd;
+    return Math.floor(Math.max(0, maxBorrowTokens) * 100) / 100;
+  }, [
+    collateralValueUsd,
+    currentDebtUsd,
+    liquidationThresholdBps,
+    tokenPriceUsd,
+  ]);
 
   const resetBorrowAmount = () => setBorrowAmount(0);
 

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/index.tsx
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/index.tsx
@@ -39,6 +39,7 @@ export function Borrow() {
     liquidationThresholdBps,
     selectedReserve,
     assetConfig,
+    tokenPriceUsd,
     onBorrowSuccess,
   } = useLoanContext();
 
@@ -48,6 +49,8 @@ export function Borrow() {
     useBorrowState({
       collateralValueUsd,
       currentDebtUsd: totalDebtValueUsd,
+      liquidationThresholdBps,
+      tokenPriceUsd,
     });
 
   const metrics = useBorrowMetrics({
@@ -56,6 +59,7 @@ export function Borrow() {
     currentDebtUsd: totalDebtValueUsd,
     liquidationThresholdBps,
     currentHealthFactor: healthFactor,
+    tokenPriceUsd,
   });
 
   const { isDisabled, buttonText, errorMessage } = validateBorrowAction(
@@ -116,7 +120,7 @@ export function Borrow() {
             }}
             onMaxClick={() => setBorrowAmount(sliderMaxBorrow)}
             rightField={{
-              value: formatUsdValue(borrowAmount),
+              value: formatUsdValue(borrowAmount * tokenPriceUsd),
             }}
             sliderActiveColor={getTokenBrandColor(assetConfig.symbol)}
             inputClassName={AMOUNT_INPUT_CLASS_NAME}

--- a/services/vault/src/applications/aave/components/LoanCard/Repay/hooks/__tests__/useRepayMetrics.test.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Repay/hooks/__tests__/useRepayMetrics.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests for useRepayMetrics
+ *
+ * Verifies that repayAmount (in token units) is correctly converted
+ * to USD via tokenPriceUsd for health factor projections.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { useRepayMetrics } from "../useRepayMetrics";
+
+describe("useRepayMetrics", () => {
+  const baseProps = {
+    collateralValueUsd: 10000,
+    totalDebtValueUsd: 5000,
+    liquidationThresholdBps: 8000,
+    currentHealthFactor: 1.6,
+  };
+
+  it("shows current values when repayAmount is 0", () => {
+    const result = useRepayMetrics({
+      ...baseProps,
+      repayAmount: 0,
+      tokenPriceUsd: 1,
+    });
+
+    expect(result.healthFactorValue).toBe(1.6);
+    expect(result.borrowRatioOriginal).toBeUndefined();
+  });
+
+  it("converts token units to USD using tokenPriceUsd for debt projection", () => {
+    // Repay 1000 tokens at $1 = $1000 debt reduction
+    // Projected debt = $5000 - $1000 = $4000
+    // HF = (10000 * 0.8) / 4000 = 2.0
+    const result = useRepayMetrics({
+      ...baseProps,
+      repayAmount: 1000,
+      tokenPriceUsd: 1,
+    });
+
+    expect(result.healthFactorValue).toBeCloseTo(2.0, 5);
+  });
+
+  it("correctly handles non-$1 token prices", () => {
+    // Repay 2 tokens at $1500 each = $3000 debt reduction
+    // Projected debt = $5000 - $3000 = $2000
+    // HF = (10000 * 0.8) / 2000 = 4.0
+    const result = useRepayMetrics({
+      ...baseProps,
+      repayAmount: 2,
+      tokenPriceUsd: 1500,
+    });
+
+    expect(result.healthFactorValue).toBeCloseTo(4.0, 5);
+  });
+
+  it("returns Infinity health factor when full repayment", () => {
+    // Repay 5000 tokens at $1 = $5000 = full debt
+    const result = useRepayMetrics({
+      ...baseProps,
+      repayAmount: 5000,
+      tokenPriceUsd: 1,
+    });
+
+    expect(result.healthFactorValue).toBe(Infinity);
+  });
+
+  it("clamps projected debt to zero (no negative debt)", () => {
+    // Repay more than total debt
+    const result = useRepayMetrics({
+      ...baseProps,
+      repayAmount: 10000,
+      tokenPriceUsd: 1,
+    });
+
+    expect(result.healthFactorValue).toBe(Infinity);
+  });
+});

--- a/services/vault/src/applications/aave/components/LoanCard/Repay/hooks/__tests__/useRepayState.test.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Repay/hooks/__tests__/useRepayState.test.ts
@@ -116,14 +116,26 @@ describe("useRepayState", () => {
       expect(result.current.isFullRepayment).toBe(false);
     });
 
-    it("should be false when balance limits max below repay amount", () => {
+    it("should be false when balance limits max below debt (partial repay via Max)", () => {
       const { result } = renderHook(() =>
         useRepayState({ currentDebtAmount: 100, userTokenBalance: 50 }),
       );
 
-      // Max is 50 (limited by balance), repay 50 is full of what's available
+      // Max is 50 (limited by balance), but debt is 100 — this is a partial repay
       act(() => {
         result.current.setRepayAmount(50);
+      });
+
+      expect(result.current.isFullRepayment).toBe(false);
+    });
+
+    it("should be true when repay amount matches actual debt with excess balance", () => {
+      const { result } = renderHook(() =>
+        useRepayState({ currentDebtAmount: 100, userTokenBalance: 200 }),
+      );
+
+      act(() => {
+        result.current.setRepayAmount(100);
       });
 
       expect(result.current.isFullRepayment).toBe(true);

--- a/services/vault/src/applications/aave/components/LoanCard/Repay/hooks/useRepayMetrics.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Repay/hooks/useRepayMetrics.ts
@@ -2,7 +2,7 @@
  * Repay metrics calculation hook
  *
  * Calculates display metrics for repay UI including projected health factor.
- * Uses USD values directly from Aave oracle.
+ * repayAmount is in token units; converted to USD via tokenPriceUsd for calculations.
  * Repaying improves the health factor.
  */
 
@@ -24,6 +24,8 @@ export interface UseRepayMetricsProps {
   liquidationThresholdBps: number;
   /** Current health factor (null if no debt) */
   currentHealthFactor: number | null;
+  /** Price of the repay token in USD */
+  tokenPriceUsd: number;
 }
 
 export interface UseRepayMetricsResult {
@@ -46,6 +48,7 @@ export function useRepayMetrics({
   totalDebtValueUsd,
   liquidationThresholdBps,
   currentHealthFactor,
+  tokenPriceUsd,
 }: UseRepayMetricsProps): UseRepayMetricsResult {
   // When no repay amount entered, show current values (no projection)
   if (repayAmount === 0) {
@@ -59,7 +62,11 @@ export function useRepayMetrics({
     };
   }
 
-  const projectedTotalDebtUsd = Math.max(0, totalDebtValueUsd - repayAmount);
+  // Convert token units to USD for debt projection
+  const projectedTotalDebtUsd = Math.max(
+    0,
+    totalDebtValueUsd - repayAmount * tokenPriceUsd,
+  );
   const isFullRepayment = projectedTotalDebtUsd < FULL_REPAY_TOLERANCE;
 
   const healthFactorValue =

--- a/services/vault/src/applications/aave/components/LoanCard/Repay/hooks/useRepayState.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Repay/hooks/useRepayState.ts
@@ -35,13 +35,14 @@ export function useRepayState({
     return Math.max(0, Math.min(currentDebtAmount, userTokenBalance));
   }, [currentDebtAmount, userTokenBalance]);
 
-  // Determine if this is a full repayment (within tolerance for floating point)
+  // Full repayment only when repay amount covers the actual debt, not the balance-capped max.
+  // When balance < debt, pressing Max should route to partial repay, not full repay.
   const isFullRepayment = useMemo(() => {
     return (
-      maxRepayAmount > 0 &&
-      Math.abs(repayAmount - maxRepayAmount) < FULL_REPAY_TOLERANCE
+      currentDebtAmount > 0 &&
+      Math.abs(repayAmount - currentDebtAmount) < FULL_REPAY_TOLERANCE
     );
-  }, [repayAmount, maxRepayAmount]);
+  }, [repayAmount, currentDebtAmount]);
 
   const resetRepayAmount = () => setRepayAmount(0);
 

--- a/services/vault/src/applications/aave/components/LoanCard/Repay/index.tsx
+++ b/services/vault/src/applications/aave/components/LoanCard/Repay/index.tsx
@@ -37,6 +37,7 @@ export function Repay() {
     selectedReserve,
     assetConfig,
     proxyContract,
+    tokenPriceUsd,
     onRepaySuccess,
   } = useLoanContext();
 
@@ -70,6 +71,7 @@ export function Repay() {
     totalDebtValueUsd,
     liquidationThresholdBps,
     currentHealthFactor: healthFactor,
+    tokenPriceUsd,
   });
 
   const { isDisabled, buttonText, errorMessage } = validateRepayAction(
@@ -129,7 +131,7 @@ export function Repay() {
             }}
             onMaxClick={() => setRepayAmount(sliderMaxRepay)}
             rightField={{
-              value: formatUsdValue(repayAmount),
+              value: formatUsdValue(repayAmount * tokenPriceUsd),
             }}
             sliderActiveColor={getTokenBrandColor(assetConfig.symbol)}
             inputClassName={AMOUNT_INPUT_CLASS_NAME}

--- a/services/vault/src/applications/aave/components/context/LoanContext.tsx
+++ b/services/vault/src/applications/aave/components/context/LoanContext.tsx
@@ -27,6 +27,8 @@ export interface LoanContextValue {
   assetConfig: Asset;
   /** User's proxy contract address (for debt queries) */
   proxyContract: string | undefined;
+  /** Price of the selected borrow token in USD (from oracle or stablecoin fallback) */
+  tokenPriceUsd: number;
   /** Callback when borrow succeeds */
   onBorrowSuccess: (borrowAmount: number) => void;
   /** Callback when repay succeeds */

--- a/services/vault/src/applications/aave/constants.ts
+++ b/services/vault/src/applications/aave/constants.ts
@@ -60,6 +60,20 @@ export const POSITION_REFETCH_INTERVAL_MS = 30 * 1000;
 export const POSITION_STALENESS_THRESHOLD_MS = POSITION_REFETCH_INTERVAL_MS * 3;
 
 /**
+ * Fallback price for stablecoins when no oracle-derived price is available
+ * (e.g., first-time borrow with no existing debt to derive price from).
+ * Only used when the token is a known stablecoin — non-stablecoin tokens
+ * without an oracle price will throw.
+ */
+export const STABLECOIN_FALLBACK_PRICE_USD = 1.0;
+
+/**
+ * Tokens whose USD price can safely be assumed as $1 when no oracle data
+ * is available. Used as a guard for the stablecoin fallback price.
+ */
+export const KNOWN_STABLECOIN_SYMBOLS = ["USDC", "USDT", "DAI"] as const;
+
+/**
  * Minimum slider max value to prevent division by zero
  * when no vaults or borrow capacity available
  */

--- a/services/vault/src/applications/aave/constants.ts
+++ b/services/vault/src/applications/aave/constants.ts
@@ -81,7 +81,7 @@ export const MIN_SLIDER_MAX = 0.0001;
 
 /**
  * Tolerance for detecting full repayment
- * If repay amount is within this tolerance of max, treat as full repay
+ * If repay amount is within this tolerance of actual debt, treat as full repay
  */
 export const FULL_REPAY_TOLERANCE = 0.01;
 

--- a/services/vault/src/components/simple/BorrowFlow/index.tsx
+++ b/services/vault/src/components/simple/BorrowFlow/index.tsx
@@ -42,6 +42,7 @@ export function BorrowFlow({ open, onClose }: BorrowFlowProps) {
     currentDebtAmount,
     totalDebtValueUsd,
     healthFactor,
+    tokenPriceUsd,
   } = useAaveReserveDetail({
     reserveId: selectedAssetSymbol ?? undefined,
     address,
@@ -87,6 +88,7 @@ export function BorrowFlow({ open, onClose }: BorrowFlowProps) {
             currentDebtAmount={currentDebtAmount}
             totalDebtValueUsd={totalDebtValueUsd}
             healthFactor={healthFactor}
+            tokenPriceUsd={tokenPriceUsd}
             onChangeAsset={goBack}
             onBorrowSuccess={completeBorrow}
           />
@@ -113,6 +115,7 @@ function BorrowFormStep({
   currentDebtAmount,
   totalDebtValueUsd,
   healthFactor,
+  tokenPriceUsd,
   onChangeAsset,
   onBorrowSuccess,
 }: {
@@ -125,6 +128,7 @@ function BorrowFormStep({
   currentDebtAmount: number;
   totalDebtValueUsd: number;
   healthFactor: number | null;
+  tokenPriceUsd: number;
   onChangeAsset: () => void;
   onBorrowSuccess: (amount: number, symbol: string, icon: string) => void;
 }) {
@@ -147,6 +151,7 @@ function BorrowFormStep({
         selectedReserve,
         assetConfig,
         proxyContract,
+        tokenPriceUsd,
         // These callbacks are handled by the BorrowFlow orchestrator
         onBorrowSuccess: () => {},
         onRepaySuccess: () => {},

--- a/services/vault/src/components/simple/BorrowFlow/index.tsx
+++ b/services/vault/src/components/simple/BorrowFlow/index.tsx
@@ -128,11 +128,11 @@ function BorrowFormStep({
   currentDebtAmount: number;
   totalDebtValueUsd: number;
   healthFactor: number | null;
-  tokenPriceUsd: number;
+  tokenPriceUsd: number | null;
   onChangeAsset: () => void;
   onBorrowSuccess: (amount: number, symbol: string, icon: string) => void;
 }) {
-  if (isLoading || !selectedReserve || !assetConfig) {
+  if (isLoading || !selectedReserve || !assetConfig || tokenPriceUsd == null) {
     return (
       <div className="flex items-center justify-center py-20">
         <p className="text-accent-secondary">Loading...</p>

--- a/services/vault/src/components/simple/BorrowFlow/useBorrowFormState.ts
+++ b/services/vault/src/components/simple/BorrowFlow/useBorrowFormState.ts
@@ -74,6 +74,7 @@ export function useBorrowFormState({
     liquidationThresholdBps,
     selectedReserve,
     assetConfig,
+    tokenPriceUsd,
   } = useLoanContext();
 
   const { executeBorrow, isProcessing } = useBorrowTransaction();
@@ -81,6 +82,8 @@ export function useBorrowFormState({
   const { borrowAmount, setBorrowAmount, maxBorrowAmount } = useBorrowState({
     collateralValueUsd,
     currentDebtUsd: totalDebtValueUsd,
+    liquidationThresholdBps,
+    tokenPriceUsd,
   });
 
   const metrics = useBorrowMetrics({
@@ -89,6 +92,7 @@ export function useBorrowFormState({
     currentDebtUsd: totalDebtValueUsd,
     liquidationThresholdBps,
     currentHealthFactor: healthFactor,
+    tokenPriceUsd,
   });
 
   const { isDisabled, buttonText } = validateBorrowAction(
@@ -156,7 +160,7 @@ export function useBorrowFormState({
     setBorrowAmount,
     sliderMax,
     maxAmountFormatted: `${formatTokenAmount(sliderMax)} ${assetConfig.symbol}`,
-    usdValueFormatted: formatUsdValue(borrowAmount),
+    usdValueFormatted: formatUsdValue(borrowAmount * tokenPriceUsd),
 
     isDisabled,
     buttonText: resolvedButtonText,


### PR DESCRIPTION
## Summary

- **Fix max borrow amount ignoring LTV ratio ([#46](https://github.com/babylonlabs-io/vault-provider-proxy/issues/46)):** `maxBorrowAmount` now uses `(collateral * liquidationThreshold) / MIN_HEALTH_FACTOR` instead of `collateral - debt`, ensuring the slider cap always results in a health factor >= 1.2
- **Fix borrow amount unit ambiguity ([#48](https://github.com/babylonlabs-io/vault-provider-proxy/issues/48), [#61](https://github.com/babylonlabs-io/vault-provider-proxy/issues/61)):** Established clear unit discipline — slider operates in token units, with explicit `* tokenPriceUsd` conversion at USD boundaries (health factor, borrow ratio, USD display)
- **Fix repay side for the same unit bug: ([#47](https://github.com/babylonlabs-io/vault-provider-proxy/issues/47))** `useRepayMetrics` now also converts token units to USD via `tokenPriceUsd`
- **Fix `Max` repay routing when balance < debt ([#62](https://github.com/babylonlabs-io/vault-provider-proxy/issues/62)):** `isFullRepayment` now compares against actual debt instead of balance-capped max, so pressing Max with insufficient balance correctly routes to partial repay instead of failing

- **Add `tokenPriceUsd` to LoanContext:** Derived from oracle data when debt exists, with explicit stablecoin assertion fallback for first-time borrows

Closes https://github.com/babylonlabs-io/vault-provider-proxy/issues/46
Closes https://github.com/babylonlabs-io/vault-provider-proxy/issues/48
Closes https://github.com/babylonlabs-io/vault-provider-proxy/issues/61
Closes https://github.com/babylonlabs-io/vault-provider-proxy/issues/47
Closes https://github.com/babylonlabs-io/vault-provider-proxy/issues/62