### PR TITLE
fix(wasm): re-export WASM classes from Node.js entry point

### DIFF
--- a/packages/babylon-tbv-rust-wasm/src/index-node.ts
+++ b/packages/babylon-tbv-rust-wasm/src/index-node.ts
@@ -343,3 +343,6 @@ export type {
 
 // Export constants
 export { TAP_INTERNAL_KEY, tapInternalPubkey } from "./constants.js";
+
+// Re-export WASM classes (mirrors index.ts browser entry)
+export { WasmPrePeginTx, WasmPeginTx, WasmPrePeginHtlcConnector, WasmPeginPayoutConnector };


### PR DESCRIPTION
The browser entry (index.ts) re-exports WasmPrePeginTx and other WASM classes, but the Node.js entry (index-node.ts) did not. This causes a SyntaxError at runtime when ts-sdk imports WasmPrePeginTx in a Node.js environment.