### PR TITLE
fix(vault): make unsignedPrePeginTx required to ensure refund availab…

### DIFF
--- a/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
+++ b/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
@@ -191,6 +191,7 @@ describe("useVaultActions — handleBroadcast transaction integrity", () => {
           timestamp: Date.now(),
           status: "PENDING" as never,
           peginTxHash: "0xpeginTxHash" as Hex,
+          unsignedTxHex: "",
         },
       });
     });

--- a/services/vault/src/hooks/deposit/useVaultActions.ts
+++ b/services/vault/src/hooks/deposit/useVaultActions.ts
@@ -115,16 +115,12 @@ export function useVaultActions(): UseVaultActionsReturn {
 
       const graphqlUnsignedTxHex = vault.unsignedPrePeginTx;
 
-      if (!graphqlUnsignedTxHex) {
-        throw new Error("Pre-pegin transaction not found. Please try again.");
-      }
-
       // Use the locally stored transaction as the source of truth when available.
       // The local copy was saved before ETH submission and is trustworthy.
       // A mismatch means the indexer is returning a different transaction — abort.
       const localUnsignedTxHex = pendingPegin?.unsignedTxHex;
       if (
-        localUnsignedTxHex !== undefined &&
+        localUnsignedTxHex &&
         stripHexPrefix(localUnsignedTxHex).toLowerCase() !==
           stripHexPrefix(graphqlUnsignedTxHex).toLowerCase()
       ) {
@@ -132,7 +128,7 @@ export function useVaultActions(): UseVaultActionsReturn {
           "Transaction mismatch: the indexer returned a transaction that differs from the locally stored copy. Aborting to prevent a potential attack.",
         );
       }
-      const unsignedTxHex = localUnsignedTxHex ?? graphqlUnsignedTxHex;
+      const unsignedTxHex = localUnsignedTxHex || graphqlUnsignedTxHex;
 
       // Get BTC wallet provider
       const btcWalletProvider = btcConnector?.connectedWallet?.provider;
@@ -191,6 +187,7 @@ export function useVaultActions(): UseVaultActionsReturn {
           applicationEntryPoint: activityApplicationEntryPoint,
           peginTxHash: vault.peginTxHash,
           depositorBtcPubkey: vault.depositorBtcPubkey,
+          unsignedTxHex: vault.unsignedPrePeginTx,
           status: nextStatus,
         });
       }

--- a/services/vault/src/services/activity/__tests__/pendingActivities.test.ts
+++ b/services/vault/src/services/activity/__tests__/pendingActivities.test.ts
@@ -44,6 +44,7 @@ describe("getPendingActivities", () => {
         amount: "1.5",
         status: LocalStorageStatus.PENDING,
         applicationEntryPoint: "0xcontroller",
+        unsignedTxHex: "0xdeadbeef",
       };
 
       vi.mocked(getPendingPegins).mockReturnValue([mockPendingPegin]);
@@ -88,6 +89,7 @@ describe("getPendingActivities", () => {
         status: LocalStorageStatus.CONFIRMING,
         applicationEntryPoint: "0xcontroller",
         peginTxHash: "0xbtctxhash123",
+        unsignedTxHex: "0xdeadbeef",
       };
 
       vi.mocked(getPendingPegins).mockReturnValue([mockPendingPegin]);
@@ -118,6 +120,7 @@ describe("getPendingActivities", () => {
         timestamp: mockTimestamp,
         amount: "1.5",
         status: LocalStorageStatus.PENDING,
+        unsignedTxHex: "0xdeadbeef",
         // No applicationEntryPoint
       };
 
@@ -141,6 +144,7 @@ describe("getPendingActivities", () => {
         timestamp: mockTimestamp,
         status: LocalStorageStatus.PENDING,
         applicationEntryPoint: "0xcontroller",
+        unsignedTxHex: "0xdeadbeef",
         // No amount
       };
 
@@ -172,6 +176,7 @@ describe("getPendingActivities", () => {
         amount: "1.5",
         status: LocalStorageStatus.PENDING,
         applicationEntryPoint: "0xunknown",
+        unsignedTxHex: "0xdeadbeef",
       };
 
       vi.mocked(getPendingPegins).mockReturnValue([mockPendingPegin]);
@@ -197,6 +202,7 @@ describe("getPendingActivities", () => {
           amount: "1.0",
           status: LocalStorageStatus.PENDING,
           applicationEntryPoint: "0xcontroller",
+          unsignedTxHex: "0xdeadbeef",
         },
         {
           id: "0xnewer",
@@ -205,6 +211,7 @@ describe("getPendingActivities", () => {
           amount: "2.0",
           status: LocalStorageStatus.PENDING,
           applicationEntryPoint: "0xcontroller",
+          unsignedTxHex: "0xdeadbeef",
         },
       ];
 

--- a/services/vault/src/services/vault/__tests__/utxoReservation.test.ts
+++ b/services/vault/src/services/vault/__tests__/utxoReservation.test.ts
@@ -33,6 +33,7 @@ describe("UTXO Reservation", () => {
       peginTxHash: "0xpeginTxHash1234",
       timestamp: Date.now(),
       status: "pending" as any,
+      unsignedTxHex: "0xdeadbeef",
       selectedUTXOs: [
         { txid: "txid1", vout: 0, value: "50000", scriptPubKey: "script1" },
         { txid: "txid2", vout: 1, value: "100000", scriptPubKey: "script2" },

--- a/services/vault/src/services/vault/__tests__/vaultRefundService.test.ts
+++ b/services/vault/src/services/vault/__tests__/vaultRefundService.test.ts
@@ -130,21 +130,6 @@ describe("vaultRefundService - buildAndBroadcastRefundTransaction", () => {
     ).rejects.toThrow(`Vault ${VAULT_ID} not found`);
   });
 
-  it("throws when unsignedPrePeginTx is missing", async () => {
-    (fetchVaultById as Mock).mockResolvedValue({
-      ...INDEXER_VAULT,
-      unsignedPrePeginTx: null,
-    });
-
-    await expect(
-      buildAndBroadcastRefundTransaction({
-        vaultId: VAULT_ID,
-        btcWalletProvider: BTC_WALLET_PROVIDER,
-        depositorBtcPubkey: DEPOSITOR_PUBKEY,
-      }),
-    ).rejects.toThrow("Pre-PegIn transaction not available for this vault");
-  });
-
   it("throws when vault provider is not found", async () => {
     (fetchVaultProviderById as Mock).mockResolvedValue(null);
 

--- a/services/vault/src/services/vault/fetchVaults.ts
+++ b/services/vault/src/services/vault/fetchVaults.ts
@@ -240,7 +240,11 @@ function transformVaultItem(item: GraphQLVaultItem): Vault {
     depositor: item.depositor as Address,
     depositorBtcPubkey: item.depositorBtcPubKey as Hex,
     depositorSignedPeginTx: item.depositorSignedPeginTx as Hex,
-    unsignedPrePeginTx: item.unsignedPrePeginTx as Hex,
+    unsignedPrePeginTx: validateRequiredField(
+      item.unsignedPrePeginTx,
+      "unsignedPrePeginTx",
+      item.id,
+    ) as Hex,
     amount: BigInt(item.amount),
     vaultProvider: item.vaultProvider as Address,
     hashlock: normalizeOptionalHex(item.hashlock),

--- a/services/vault/src/services/vault/utxoReservation.ts
+++ b/services/vault/src/services/vault/utxoReservation.ts
@@ -135,9 +135,7 @@ export function collectReservedUtxoRefs(
     ) {
       continue;
     }
-    if (vault.unsignedPrePeginTx) {
-      reserved.push(...extractInputUtxoRefs(vault.unsignedPrePeginTx));
-    }
+    reserved.push(...extractInputUtxoRefs(vault.unsignedPrePeginTx));
   }
 
   return reserved;

--- a/services/vault/src/services/vault/vaultRefundService.ts
+++ b/services/vault/src/services/vault/vaultRefundService.ts
@@ -91,11 +91,6 @@ export async function buildAndBroadcastRefundTransaction(
   if (!indexerVault) {
     throw new Error(`Vault ${vaultId} not found`);
   }
-  if (!indexerVault.unsignedPrePeginTx) {
-    throw new Error(
-      "Pre-PegIn transaction not available for this vault. Cannot build refund transaction.",
-    );
-  }
   const offchainParams = await getOffchainParamsByVersion(
     onChainVault.offchainParamsVersion,
   );

--- a/services/vault/src/storage/peginStorage.ts
+++ b/services/vault/src/storage/peginStorage.ts
@@ -35,7 +35,7 @@ export interface PendingPeginRequest {
   peginTxHash: Hex; // Raw BTC pegin transaction hash
   depositorBtcPubkey?: string; // Depositor's BTC public key (x-only, for WOTS derivation in resume flow)
   // Fields for cross-device broadcasting support
-  unsignedTxHex?: string; // Funded Pre-PegIn tx hex (for broadcasting later)
+  unsignedTxHex: string; // Funded Pre-PegIn tx hex (for broadcasting later)
   selectedUTXOs?: Array<{
     // UTXOs used in the transaction
     txid: string;

--- a/services/vault/src/storage/usePeginStorage.ts
+++ b/services/vault/src/storage/usePeginStorage.ts
@@ -155,6 +155,7 @@ export function usePeginStorage({
         pendingMessage: "Transaction pending confirmation...",
         timestamp: pending.timestamp,
         depositorBtcPubkey: pending.depositorBtcPubkey,
+        unsignedPrePeginTx: pending.unsignedTxHex,
         depositorWotsPkHash: "",
       }));
 

--- a/services/vault/src/types/activity.ts
+++ b/services/vault/src/types/activity.ts
@@ -104,8 +104,8 @@ export interface VaultActivity {
   /** Depositor-signed pegin transaction hex */
   depositorSignedPeginTx?: string;
 
-  /** Unsigned pre-pegin transaction hex (spends depositor's UTXOs — used for UTXO validation) */
-  unsignedPrePeginTx?: string;
+  /** Unsigned pre-pegin transaction hex (spends depositor's UTXOs — used for UTXO validation and refund) */
+  unsignedPrePeginTx: string;
 
   /** Depositor-specified BTC payout address (raw scriptPubKey hex from indexer) */
   depositorPayoutBtcAddress?: Hex;

--- a/services/vault/src/types/vault.ts
+++ b/services/vault/src/types/vault.ts
@@ -41,8 +41,8 @@ export interface Vault {
   /** Depositor-signed pegin transaction hex (from contract struct) */
   depositorSignedPeginTx: Hex;
 
-  /** Unsigned pre-pegin transaction hex (from PegInSubmitted event, DA only) */
-  unsignedPrePeginTx?: Hex;
+  /** Unsigned pre-pegin transaction hex (from PegInSubmitted event) */
+  unsignedPrePeginTx: Hex;
 
   /** Amount in satoshis */
   amount: bigint;

--- a/services/vault/src/utils/__tests__/vaultTransformers.test.ts
+++ b/services/vault/src/utils/__tests__/vaultTransformers.test.ts
@@ -36,6 +36,7 @@ function makeVault(overrides: Partial<Vault> = {}): Vault {
     referralCode: 0,
     depositorPayoutBtcAddress: "0xpayout" as Hex,
     depositorWotsPkHash: "0x" + "ab".repeat(32),
+    unsignedPrePeginTx: "0xunsignedtx" as Hex,
     ...overrides,
   };
 }


### PR DESCRIPTION
- Make `unsignedPrePeginTx` required on `Vault`, `VaultActivity`, and `PendingPeginRequest` types, matching the indexer schema (`NOT NULL` in DB, `String!` in GraphQL) and localStorage (always stored at vault creation)
- Add `validateRequiredField()` in `fetchVaults.ts` to fail fast on unexpected null from the indexer
- Populate `unsignedPrePeginTx` from localStorage in `usePeginStorage.ts` — previously missing from pending vault activity construction, which could hide the refund button on expired vaults
- Add `unsignedTxHex` to cross-device localStorage entry creation in `useVaultActions.ts`
- Filter out legacy localStorage entries missing `unsignedTxHex` in `getPendingPegins()`
- Remove dead null guard in `useVaultActions.ts` (field is now guaranteed non-null)
- Fix stale "DA only" comment in vault type