### PR TITLE
refactor(wallet-connector): unify tweak signer interface to disableTw…

### DIFF
--- a/packages/babylon-wallet-connector/README.md
+++ b/packages/babylon-wallet-connector/README.md
@@ -306,8 +306,6 @@ export interface SignInputOptions {
    * When true, sign with the untweaked internal key.
    */
   disableTweakSigner?: boolean;
-  /** Use tweaked signer for Taproot key path spend */
-  useTweakedSigner?: boolean;
 }
 
 export interface SignPsbtOptions {

--- a/packages/babylon-wallet-connector/src/core/types.ts
+++ b/packages/babylon-wallet-connector/src/core/types.ts
@@ -305,8 +305,6 @@ export interface SignInputOptions {
   sighashTypes?: number[];
   /** Disable tweak signer for Taproot script path spend (optional) */
   disableTweakSigner?: boolean;
-  /** Use tweaked signer for Taproot key path spend (optional) */
-  useTweakedSigner?: boolean;
 }
 
 export interface SignPsbtOptions {

--- a/packages/babylon-wallet-connector/src/core/utils/psbtOptionsMapper.ts
+++ b/packages/babylon-wallet-connector/src/core/utils/psbtOptionsMapper.ts
@@ -2,22 +2,17 @@ import type { SignInputOptions } from "@/core/types";
 
 /**
  * Maps our standard SignInputOptions format to the wallet provider's toSignInputs format.
- * This is used by wallets that follow the UniSat/OKX API convention.
+ * This is used by wallets that follow the OKX/OneKey API convention.
  *
  * @param signInputs - Array of sign input configurations
- * @param additionalFieldsFn - Optional callback to add wallet-specific fields to each input
  * @returns Array of inputs in toSignInputs format
  */
-export function mapSignInputsToToSignInputs(
-  signInputs: SignInputOptions[],
-  additionalFieldsFn?: (input: SignInputOptions) => Record<string, any>,
-) {
+export function mapSignInputsToToSignInputs(signInputs: SignInputOptions[]) {
   return signInputs.map((input) => ({
     index: input.index,
     publicKey: input.publicKey,
     address: input.address,
     sighashTypes: input.sighashTypes,
     disableTweakSigner: input.disableTweakSigner,
-    ...(additionalFieldsFn?.(input) || {}),
   }));
 }

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/unisat/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/unisat/provider.ts
@@ -4,7 +4,6 @@ import { isAccountChangeEvent, DISCONNECT_EVENT, removeProviderListener } from "
 import type { BTCConfig, IBTCProvider, InscriptionIdentifier, SignPsbtOptions, WalletInfo } from "@/core/types";
 import { Network } from "@/core/types";
 import { initBTCCurve } from "@/core/utils/initBTCCurve";
-import { mapSignInputsToToSignInputs } from "@/core/utils/psbtOptionsMapper";
 import { ERROR_CODES, WalletError } from "@/error";
 
 import logo from "./logo.svg";
@@ -128,8 +127,12 @@ export class UnisatProvider implements IBTCProvider {
       if (options?.signInputs && options.signInputs.length > 0) {
         signOptions = {
           autoFinalized: options.autoFinalized ?? false,
-          toSignInputs: mapSignInputsToToSignInputs(options.signInputs, (input) => ({
-            useTweakedSigner: input.useTweakedSigner,
+          toSignInputs: options.signInputs.map((input) => ({
+            index: input.index,
+            publicKey: input.publicKey,
+            address: input.address,
+            sighashTypes: input.sighashTypes,
+            useTweakedSigner: input.disableTweakSigner === true ? false : undefined,
           })),
         };
       } else {
@@ -176,8 +179,12 @@ export class UnisatProvider implements IBTCProvider {
         if (option?.signInputs && option.signInputs.length > 0) {
           return {
             autoFinalized: option.autoFinalized ?? false,
-            toSignInputs: mapSignInputsToToSignInputs(option.signInputs, (input) => ({
-              useTweakedSigner: input.useTweakedSigner,
+            toSignInputs: option.signInputs.map((input) => ({
+              index: input.index,
+              publicKey: input.publicKey,
+              address: input.address,
+              sighashTypes: input.sighashTypes,
+              useTweakedSigner: input.disableTweakSigner === true ? false : undefined,
             })),
           };
         }


### PR DESCRIPTION
- Remove `useTweakedSigner` from the public `SignInputOptions` interface — the adapter now only exposes `disableTweakSigner` (the industry-standard field used by OKX, sats-connect, and BIP-370)
- UniSat adapter translates internally: inverts `disableTweakSigner` to `useTweakedSigner` for UniSat's native API, building its own clean payload without leaking `disableTweakSigner` to UniSat
- Remove stale `useTweakedSigner` reference from README docs