### PR TITLE
fix(vault): wire onAddressChange to trigger global wallet reset

### DIFF
--- a/services/vault/src/context/wallet/VaultWalletConnectionProvider.tsx
+++ b/services/vault/src/context/wallet/VaultWalletConnectionProvider.tsx
@@ -35,36 +35,32 @@ function WalletProviders({ children }: PropsWithChildren) {
   // Guard against re-entrancy when disconnectAll triggers disconnect events
   const isDisconnectingRef = useRef(false);
 
-  // When BTC wallet disconnects, disconnect all wallets
+  const handleWalletReset = useCallback(async () => {
+    if (isDisconnectingRef.current) return;
+    isDisconnectingRef.current = true;
+    try {
+      await disconnectAll?.();
+    } finally {
+      isDisconnectingRef.current = false;
+    }
+  }, [disconnectAll]);
+
+  // When BTC wallet disconnects or changes account, disconnect all wallets
   const btcCallbacks = useMemo(
     () => ({
-      onDisconnect: () => {
-        if (isDisconnectingRef.current) return;
-        isDisconnectingRef.current = true;
-        try {
-          disconnectAll?.();
-        } finally {
-          isDisconnectingRef.current = false;
-        }
-      },
+      onDisconnect: handleWalletReset,
+      onAddressChange: handleWalletReset,
     }),
-    [disconnectAll],
+    [handleWalletReset],
   );
 
-  // When ETH wallet disconnects, disconnect all wallets
+  // When ETH wallet disconnects or changes account, disconnect all wallets
   const ethCallbacks = useMemo(
     () => ({
-      onDisconnect: () => {
-        if (isDisconnectingRef.current) return;
-        isDisconnectingRef.current = true;
-        try {
-          disconnectAll?.();
-        } finally {
-          isDisconnectingRef.current = false;
-        }
-      },
+      onDisconnect: handleWalletReset,
+      onAddressChange: handleWalletReset,
     }),
-    [disconnectAll],
+    [handleWalletReset],
   );
 
   return (


### PR DESCRIPTION
Treat wallet account changes the same as disconnects for multi-chain flows. Previously only onDisconnect was wired, allowing a user to switch BTC or ETH accounts mid-session without forcing a dual disconnect or clearing cached flow state.

Closes babylonlabs-io/vault-provider-proxy#64