### PR TITLE
feat(release): auto-bump dependents when workspace deps change

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -69,6 +69,7 @@
       "conventionalCommits": true,
       "preserveLocalDependencyProtocols": false,
       "fallbackCurrentVersionResolver": "disk",
+      "updateDependents": "always",
       "versionActionsOptions": {
         "skipLockFileUpdate": true
       }


### PR DESCRIPTION
## Summary
- Add `updateDependents: "always"` to `nx.json` release config so that when any package (e.g. `babylon-tbv-rust-wasm`) bumps, every package depending on it (e.g. `ts-sdk`) is also re-versioned and republished.

## Why
With `projectsRelationship: "independent"` + `conventionalCommits: true`, a WASM-only commit bumps WASM only. `ts-sdk`'s source uses `"workspace:*"`, which `preserveLocalDependencyProtocols: false` rewrites to an **exact** pin at publish time. Because the tarball is immutable, the SDK on npm keeps carrying the WASM version that existed at *its own* last publish — forever.

Example currently on npm:
- `ts-sdk@0.6.0` → `dependencies["@babylonlabs-io/babylon-tbv-rust-wasm"] = "0.1.0"` (frozen)
- Workspace WASM has since moved to `0.3.0`

Consumers installing both end up with two WASM copies and must use `pnpm.overrides` to deduplicate the single WASM instance the runtime requires.

`updateDependents: "always"` fixes this at the source: any time a dep is bumped, nx also bumps its dependents as a patch and rewrites their pins to the new version before publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)