### PR TITLE
fix(vault): graphql timeouts and multicall

### DIFF
--- a/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/__tests__/mempoolApi.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/__tests__/mempoolApi.test.ts
@@ -1,6 +1,21 @@
-import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 
-import { getAddressUtxos, getNetworkFees, getUtxoInfo } from "../mempoolApi";
+import {
+  getAddressUtxos,
+  getNetworkFees,
+  getTxHex,
+  getUtxoInfo,
+  pushTx,
+} from "../mempoolApi";
 
 const API_URL = "https://mempool.space/api";
 
@@ -308,5 +323,68 @@ describe("getNetworkFees", () => {
     );
     const result = await getNetworkFees(API_URL);
     expect(result.fastestFee).toBe(10000);
+  });
+});
+
+describe("request timeout", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function mockHangingFetch() {
+    mockFetch.mockImplementation(
+      (_url: string, options?: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          options?.signal?.addEventListener("abort", () => {
+            reject(
+              new DOMException(
+                "The operation was aborted.",
+                "AbortError",
+              ),
+            );
+          });
+        }),
+    );
+  }
+
+  it("aborts getNetworkFees after 30s timeout", async () => {
+    mockHangingFetch();
+
+    const promise = getNetworkFees(API_URL);
+    // Attach rejection handler before advancing timers to avoid unhandled rejection
+    const assertion = expect(promise).rejects.toThrow(/timed out after 30000ms/);
+    await vi.advanceTimersByTimeAsync(30_000);
+    await assertion;
+  });
+
+  it("aborts pushTx after 30s timeout", async () => {
+    mockHangingFetch();
+
+    const promise = pushTx("deadbeef", API_URL);
+    const assertion = expect(promise).rejects.toThrow(/timed out after 30000ms/);
+    await vi.advanceTimersByTimeAsync(30_000);
+    await assertion;
+  });
+
+  it("aborts getTxHex after 30s timeout", async () => {
+    mockHangingFetch();
+
+    const promise = getTxHex("txid123", API_URL);
+    const assertion = expect(promise).rejects.toThrow(/timed out after 30000ms/);
+    await vi.advanceTimersByTimeAsync(30_000);
+    await assertion;
+  });
+
+  it("aborts getAddressUtxos after 30s timeout", async () => {
+    mockHangingFetch();
+
+    const promise = getAddressUtxos("bc1qtest", API_URL);
+    const assertion = expect(promise).rejects.toThrow(/timed out after 30000ms/);
+    await vi.advanceTimersByTimeAsync(30_000);
+    await assertion;
   });
 });

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts
@@ -28,16 +28,26 @@ async function fetchWithTimeout(
     () => controller.abort(),
     MEMPOOL_REQUEST_TIMEOUT_MS,
   );
+
+  // Compose timeout signal with any caller-supplied signal so both can cancel
+  const signals = [controller.signal, options?.signal].filter(
+    Boolean,
+  ) as AbortSignal[];
+
   try {
-    const response = await fetch(url, {
+    // Don't clear timeout here — let it cover body consumption by callers
+    return await fetch(url, {
       ...options,
-      signal: controller.signal,
+      signal: AbortSignal.any(signals),
     });
-    clearTimeout(timeoutId);
-    return response;
   } catch (error) {
     clearTimeout(timeoutId);
-    if (error instanceof Error && error.name === "AbortError") {
+    if (
+      error != null &&
+      typeof error === "object" &&
+      "name" in error &&
+      error.name === "AbortError"
+    ) {
       throw new Error(
         `Mempool API request timed out after ${MEMPOOL_REQUEST_TIMEOUT_MS}ms: ${url}`,
       );

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts
@@ -12,6 +12,40 @@ import type { MempoolUTXO, NetworkFees, TxInfo, UtxoInfo } from "./types";
 /** Maximum valid satoshi value: 21 million BTC × 10^8 sats/BTC */
 const MAX_SATOSHIS = 21_000_000 * 1e8;
 
+/** Timeout for mempool API requests — prevents indefinite hangs from stalled endpoints */
+const MEMPOOL_REQUEST_TIMEOUT_MS = 30_000;
+
+/**
+ * Fetch wrapper with AbortController-based timeout.
+ * Ensures all mempool API requests fail bounded rather than hanging indefinitely.
+ */
+async function fetchWithTimeout(
+  url: string,
+  options?: RequestInit,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(
+    () => controller.abort(),
+    MEMPOOL_REQUEST_TIMEOUT_MS,
+  );
+  try {
+    const response = await fetch(url, {
+      ...options,
+      signal: controller.signal,
+    });
+    clearTimeout(timeoutId);
+    return response;
+  } catch (error) {
+    clearTimeout(timeoutId);
+    if (error instanceof Error && error.name === "AbortError") {
+      throw new Error(
+        `Mempool API request timed out after ${MEMPOOL_REQUEST_TIMEOUT_MS}ms: ${url}`,
+      );
+    }
+    throw error;
+  }
+}
+
 /**
  * Maximum sane fee rate in sat/vByte.
  * The April 2024 Runes spike peaked around 1,805 sat/vB — 10,000 provides ample headroom.
@@ -48,7 +82,7 @@ async function fetchApi<T>(
   options?: RequestInit,
 ): Promise<T> {
   try {
-    const response = await fetch(url, options);
+    const response = await fetchWithTimeout(url, options);
 
     if (!response.ok) {
       const errorText = await response.text();
@@ -81,7 +115,7 @@ async function fetchApi<T>(
  */
 export async function pushTx(txHex: string, apiUrl: string): Promise<string> {
   try {
-    const response = await fetch(`${apiUrl}/tx`, {
+    const response = await fetchWithTimeout(`${apiUrl}/tx`, {
       method: "POST",
       body: txHex,
       headers: {
@@ -137,7 +171,7 @@ export async function getTxInfo(txid: string, apiUrl: string): Promise<TxInfo> {
  */
 export async function getTxHex(txid: string, apiUrl: string): Promise<string> {
   try {
-    const response = await fetch(`${apiUrl}/tx/${txid}/hex`);
+    const response = await fetchWithTimeout(`${apiUrl}/tx/${txid}/hex`);
 
     if (!response.ok) {
       const errorText = await response.text();
@@ -314,7 +348,7 @@ export async function getAddressTxs(
  * @see https://mempool.space/docs/api/rest#get-recommended-fees
  */
 export async function getNetworkFees(apiUrl: string): Promise<NetworkFees> {
-  const response = await fetch(`${apiUrl}/v1/fees/recommended`);
+  const response = await fetchWithTimeout(`${apiUrl}/v1/fees/recommended`);
 
   if (!response.ok) {
     throw new Error(

--- a/services/vault/src/clients/eth-contract/protocol-params/query.ts
+++ b/services/vault/src/clients/eth-contract/protocol-params/query.ts
@@ -5,7 +5,7 @@
  * The ProtocolParams address is fetched from BTCVaultRegistry.
  */
 
-import type { Address } from "viem";
+import type { Abi, Address } from "viem";
 
 import { CONTRACTS } from "@/config/contracts";
 
@@ -139,10 +139,30 @@ export async function getLatestOffchainParams(): Promise<VersionedOffchainParams
  * all values needed for pegin transaction construction.
  */
 export async function getPegInConfiguration(): Promise<PegInConfiguration> {
-  const [params, offchainParams] = await Promise.all([
-    getTBVProtocolParams(),
-    getLatestOffchainParams(),
-  ]);
+  const publicClient = ethClient.getPublicClient();
+  const protocolParamsAddress = await getProtocolParamsAddress();
+
+  // Fetch both param sets in a single multicall to guarantee same-block atomicity.
+  // Separate RPC calls risk TOCTOU inconsistency if governance updates params between reads.
+  const [rawParams, rawOffchainParams] = await publicClient.multicall({
+    contracts: [
+      {
+        address: protocolParamsAddress,
+        abi: ProtocolParamsAbi,
+        functionName: "getTBVProtocolParams",
+      },
+      {
+        address: protocolParamsAddress,
+        abi: ProtocolParamsAbi,
+        functionName: "getLatestOffchainParams",
+      },
+    ],
+    allowFailure: false,
+  });
+
+  const params = rawParams as unknown as TBVProtocolParams;
+  const offchainParams =
+    rawOffchainParams as unknown as VersionedOffchainParams;
 
   // timelockPegin = uint16(timelockAssert), matching PeginLogic.sol:115
   const timelockPegin = Number(offchainParams.timelockAssert);
@@ -230,15 +250,29 @@ export async function fetchAllOffchainParams(): Promise<AllOffchainParamsData> {
     return { byVersion: new Map(), latestVersion: 0 };
   }
 
-  // Fetch all versions in parallel
+  const publicClient = ethClient.getPublicClient();
+  const protocolParamsAddress = await getProtocolParamsAddress();
+
+  // Fetch all versions in a single multicall for same-block consistency
   const versions = Array.from({ length: latestVersion }, (_, i) => i + 1);
-  const results = await Promise.all(
-    versions.map((v) => getOffchainParamsByVersion(v)),
-  );
+  const contracts = versions.map((v) => ({
+    address: protocolParamsAddress,
+    abi: ProtocolParamsAbi as Abi,
+    functionName: "getOffchainParamsByVersion" as const,
+    args: [v] as const,
+  }));
+
+  const results = await publicClient.multicall({
+    contracts,
+    allowFailure: false,
+  });
 
   const byVersion = new Map<number, VersionedOffchainParams>();
   for (let i = 0; i < versions.length; i++) {
-    byVersion.set(versions[i], results[i]);
+    byVersion.set(
+      versions[i],
+      results[i] as unknown as VersionedOffchainParams,
+    );
   }
 
   return { byVersion, latestVersion };

--- a/services/vault/src/clients/graphql/__tests__/client.test.ts
+++ b/services/vault/src/clients/graphql/__tests__/client.test.ts
@@ -1,0 +1,62 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+vi.mock("../../../config/env", () => ({
+  ENV: { GRAPHQL_ENDPOINT: "https://graphql.test/v1/graphql" },
+}));
+
+const mockFetch = vi.fn();
+
+beforeAll(() => {
+  vi.stubGlobal("fetch", mockFetch);
+});
+
+afterEach(() => {
+  mockFetch.mockReset();
+});
+
+afterAll(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("graphqlClient timeout", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("aborts requests after 30s timeout", async () => {
+    mockFetch.mockImplementation(
+      (_url: string, options?: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          options?.signal?.addEventListener("abort", () => {
+            reject(
+              new DOMException("The operation was aborted.", "AbortError"),
+            );
+          });
+        }),
+    );
+
+    // Dynamic import to pick up mocked env and fetch
+    const { graphqlClient } = await import("../client");
+
+    const promise = graphqlClient.request("{ vaults { id } }");
+    // Attach rejection handler before advancing timers to avoid unhandled rejection
+    const assertion = expect(promise).rejects.toThrow(
+      /timed out after 30000ms/,
+    );
+    await vi.advanceTimersByTimeAsync(30_000);
+    await assertion;
+  });
+});

--- a/services/vault/src/clients/graphql/client.ts
+++ b/services/vault/src/clients/graphql/client.ts
@@ -2,4 +2,39 @@ import { GraphQLClient } from "graphql-request";
 
 import { ENV } from "../../config/env";
 
-export const graphqlClient = new GraphQLClient(ENV.GRAPHQL_ENDPOINT);
+/** Timeout for GraphQL API requests — prevents indefinite hangs from stalled endpoints */
+const GRAPHQL_REQUEST_TIMEOUT_MS = 30_000;
+
+export const graphqlClient = new GraphQLClient(ENV.GRAPHQL_ENDPOINT, {
+  fetch: async (url, options) => {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(
+      () => controller.abort(),
+      GRAPHQL_REQUEST_TIMEOUT_MS,
+    );
+
+    try {
+      const response = await fetch(url, {
+        ...options,
+        signal: controller.signal,
+      });
+      clearTimeout(timeoutId);
+      return response;
+    } catch (error) {
+      clearTimeout(timeoutId);
+      // Check name directly — DOMException from Node.js built-in fetch may fail
+      // cross-realm instanceof checks in jsdom environments
+      if (
+        error != null &&
+        typeof error === "object" &&
+        "name" in error &&
+        error.name === "AbortError"
+      ) {
+        throw new Error(
+          `GraphQL request timed out after ${GRAPHQL_REQUEST_TIMEOUT_MS}ms`,
+        );
+      }
+      throw error;
+    }
+  },
+});

--- a/services/vault/src/clients/graphql/client.ts
+++ b/services/vault/src/clients/graphql/client.ts
@@ -13,17 +13,19 @@ export const graphqlClient = new GraphQLClient(ENV.GRAPHQL_ENDPOINT, {
       GRAPHQL_REQUEST_TIMEOUT_MS,
     );
 
+    // Compose timeout signal with any caller-supplied signal so both can cancel
+    const signals = [controller.signal, options?.signal].filter(
+      Boolean,
+    ) as AbortSignal[];
+
     try {
-      const response = await fetch(url, {
+      // Don't clear timeout — graphql-request parses body after this returns
+      return await fetch(url, {
         ...options,
-        signal: controller.signal,
+        signal: AbortSignal.any(signals),
       });
-      clearTimeout(timeoutId);
-      return response;
     } catch (error) {
       clearTimeout(timeoutId);
-      // Check name directly — DOMException from Node.js built-in fetch may fail
-      // cross-realm instanceof checks in jsdom environments
       if (
         error != null &&
         typeof error === "object" &&


### PR DESCRIPTION
- https://github.com/babylonlabs-io/vault-provider-proxy/issues/79: getPegInConfiguration() and fetchAllOffchainParams() now use multicall instead of separate RPC calls, guaranteeing same-block atomicity
- https://github.com/babylonlabs-io/vault-provider-proxy/issues/60: Added 30s AbortController timeouts to all mempool API and GraphQL client requests, preventing indefinite hangs from stalled endpoints

Closes https://github.com/babylonlabs-io/vault-provider-proxy/issues/79
Closes https://github.com/babylonlabs-io/vault-provider-proxy/issues/60
