### PR TITLE
fix(vault): utxo reservation - prevent double spend failures

### DIFF
--- a/services/vault/src/hooks/deposit/__tests__/useMultiVaultDepositFlow.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useMultiVaultDepositFlow.test.tsx
@@ -755,8 +755,9 @@ describe("useMultiVaultDepositFlow", () => {
         waitForContractVerification,
       } = vi.mocked(await import("../depositFlowSteps"));
 
-      // First vault's WOTS submission fails
+      // First vault's WOTS submission fails both attempts (retry exhausted)
       vi.mocked(submitWotsPublicKey)
+        .mockRejectedValueOnce(new Error("WOTS derivation error"))
         .mockRejectedValueOnce(new Error("WOTS derivation error"))
         .mockResolvedValueOnce(undefined);
 
@@ -783,6 +784,32 @@ describe("useMultiVaultDepositFlow", () => {
       expect(waitForContractVerification).toHaveBeenCalledWith(
         expect.objectContaining({ vaultId: "0xVault1Id" }),
       );
+    });
+
+    it("should retry WOTS submission once before skipping vault", async () => {
+      const { submitWotsPublicKey, pollAndPreparePayoutSigning } = vi.mocked(
+        await import("../depositFlowSteps"),
+      );
+
+      // First vault: fails once, succeeds on retry
+      // Second vault: succeeds first try
+      vi.mocked(submitWotsPublicKey)
+        .mockRejectedValueOnce(new Error("Network timeout"))
+        .mockResolvedValueOnce(undefined) // vault 1 retry succeeds
+        .mockResolvedValueOnce(undefined); // vault 2 succeeds
+
+      const { result } = renderHook(() =>
+        useMultiVaultDepositFlow(MOCK_PARAMS),
+      );
+
+      const depositResult = await executeWithAutoArtifactDownload(result);
+
+      // No warnings — both vaults recovered
+      expect(depositResult).not.toBeNull();
+      expect(depositResult?.warnings).toBeUndefined();
+
+      // Both vaults should proceed to payout signing
+      expect(pollAndPreparePayoutSigning).toHaveBeenCalledTimes(2);
     });
 
     it("should complete with warnings when all payout signings fail", async () => {

--- a/services/vault/src/hooks/deposit/__tests__/useMultiVaultDepositFlow.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useMultiVaultDepositFlow.test.tsx
@@ -128,6 +128,14 @@ vi.mock("@/models/peginStateMachine", async (importOriginal) => ({
 
 vi.mock("@/storage/peginStorage", () => ({
   addPendingPegin: vi.fn(),
+  getPendingPegins: vi.fn(() => []),
+}));
+
+vi.mock("@/services/vault/utxoReservation", () => ({
+  collectReservedUtxoRefs: vi.fn(() => []),
+  selectUtxosForDeposit: vi.fn(
+    ({ availableUtxos }: { availableUtxos: unknown[] }) => availableUtxos,
+  ),
 }));
 
 vi.mock("@/utils/secretUtils", () => ({
@@ -682,9 +690,14 @@ describe("useMultiVaultDepositFlow", () => {
       });
     });
 
-    it("should continue with other vaults when payout signing fails for one", async () => {
-      const { pollAndPreparePayoutSigning, submitPayoutSignatures } = vi.mocked(
-        await import("../depositFlowSteps"),
+    it("should only verify and activate vaults whose payout signing succeeded", async () => {
+      const {
+        pollAndPreparePayoutSigning,
+        submitPayoutSignatures,
+        waitForContractVerification,
+      } = vi.mocked(await import("../depositFlowSteps"));
+      const { activateVaultWithSecret } = vi.mocked(
+        await import("@/services/vault/vaultActivationService"),
       );
 
       // First vault fails payout signing, second succeeds
@@ -723,6 +736,79 @@ describe("useMultiVaultDepositFlow", () => {
 
       // Second vault's payouts should still be submitted
       expect(submitPayoutSignatures).toHaveBeenCalledTimes(1);
+
+      // Only the successful vault (vault 2) should be verified and activated
+      expect(waitForContractVerification).toHaveBeenCalledTimes(1);
+      expect(waitForContractVerification).toHaveBeenCalledWith(
+        expect.objectContaining({ vaultId: "0xVault1Id" }),
+      );
+      expect(activateVaultWithSecret).toHaveBeenCalledTimes(1);
+      expect(activateVaultWithSecret).toHaveBeenCalledWith(
+        expect.objectContaining({ vaultId: "0xVault1Id" }),
+      );
+    });
+
+    it("should skip payout signing for vaults whose WOTS key submission failed", async () => {
+      const {
+        submitWotsPublicKey,
+        pollAndPreparePayoutSigning,
+        waitForContractVerification,
+      } = vi.mocked(await import("../depositFlowSteps"));
+
+      // First vault's WOTS submission fails
+      vi.mocked(submitWotsPublicKey)
+        .mockRejectedValueOnce(new Error("WOTS derivation error"))
+        .mockResolvedValueOnce(undefined);
+
+      const { result } = renderHook(() =>
+        useMultiVaultDepositFlow(MOCK_PARAMS),
+      );
+
+      const depositResult = await executeWithAutoArtifactDownload(result);
+
+      expect(depositResult).not.toBeNull();
+      expect(depositResult?.warnings).toHaveLength(1);
+      expect(depositResult?.warnings?.[0]).toContain(
+        "WOTS key submission failed",
+      );
+
+      // Payout signing should only be attempted for vault 2 (vault 1 skipped)
+      expect(pollAndPreparePayoutSigning).toHaveBeenCalledTimes(1);
+      expect(pollAndPreparePayoutSigning).toHaveBeenCalledWith(
+        expect.objectContaining({ vaultId: "0xVault1Id" }),
+      );
+
+      // Only vault 2 should be verified
+      expect(waitForContractVerification).toHaveBeenCalledTimes(1);
+      expect(waitForContractVerification).toHaveBeenCalledWith(
+        expect.objectContaining({ vaultId: "0xVault1Id" }),
+      );
+    });
+
+    it("should complete with warnings when all payout signings fail", async () => {
+      const { pollAndPreparePayoutSigning, waitForContractVerification } =
+        vi.mocked(await import("../depositFlowSteps"));
+      const { activateVaultWithSecret } = vi.mocked(
+        await import("@/services/vault/vaultActivationService"),
+      );
+
+      // Both vaults fail payout signing
+      vi.mocked(pollAndPreparePayoutSigning)
+        .mockRejectedValueOnce(new Error("VP timeout"))
+        .mockRejectedValueOnce(new Error("VP timeout"));
+
+      const { result } = renderHook(() =>
+        useMultiVaultDepositFlow(MOCK_PARAMS),
+      );
+
+      const depositResult = await executeWithAutoArtifactDownload(result);
+
+      expect(depositResult).not.toBeNull();
+      expect(depositResult?.warnings).toHaveLength(2);
+
+      // No verification or activation should be attempted
+      expect(waitForContractVerification).not.toHaveBeenCalled();
+      expect(activateVaultWithSecret).not.toHaveBeenCalled();
     });
 
     it("should not show error when flow is aborted", async () => {
@@ -805,6 +891,95 @@ describe("useMultiVaultDepositFlow", () => {
         expect(registerPeginBatchAndWait).toHaveBeenCalledTimes(1);
         const callArgs = registerPeginBatchAndWait.mock.calls[0]?.[0];
         expect(callArgs?.requests).toHaveLength(1);
+      });
+    });
+  });
+
+  describe("UTXO Reservation", () => {
+    it("should filter reserved UTXOs before preparing pegin transaction", async () => {
+      const { getPendingPegins } = vi.mocked(
+        await import("@/storage/peginStorage"),
+      );
+      const { collectReservedUtxoRefs, selectUtxosForDeposit } = vi.mocked(
+        await import("@/services/vault/utxoReservation"),
+      );
+      const { preparePeginTransaction } = vi.mocked(
+        await import("@/services/vault/vaultTransactionService"),
+      );
+
+      const mockPendingPegins = [
+        {
+          id: "0xexisting",
+          peginTxHash: "0xexistinghash",
+          timestamp: Date.now(),
+          status: "pending",
+          unsignedTxHex: "existingtxhex",
+          selectedUTXOs: [
+            {
+              txid: MOCK_UTXO_1.txid,
+              vout: 0,
+              value: "500000",
+              scriptPubKey: "0xabc123",
+            },
+          ],
+        },
+      ];
+      const mockReservedRefs = [{ txid: MOCK_UTXO_1.txid, vout: 0 }];
+
+      vi.mocked(getPendingPegins).mockReturnValueOnce(mockPendingPegins as any);
+      vi.mocked(collectReservedUtxoRefs).mockReturnValueOnce(mockReservedRefs);
+      // Only return MOCK_UTXO_2 (MOCK_UTXO_1 is reserved)
+      vi.mocked(selectUtxosForDeposit).mockReturnValueOnce([MOCK_UTXO_2]);
+
+      const { result } = renderHook(() =>
+        useMultiVaultDepositFlow(MOCK_PARAMS),
+      );
+
+      await executeWithAutoArtifactDownload(result);
+
+      await waitFor(() => {
+        expect(getPendingPegins).toHaveBeenCalledWith("0xEthAddress123");
+        expect(collectReservedUtxoRefs).toHaveBeenCalledWith({
+          pendingPegins: mockPendingPegins,
+        });
+        expect(selectUtxosForDeposit).toHaveBeenCalledWith(
+          expect.objectContaining({
+            availableUtxos: [MOCK_UTXO_1, MOCK_UTXO_2],
+            reservedUtxoRefs: mockReservedRefs,
+          }),
+        );
+        // preparePeginTransaction should receive filtered UTXOs
+        expect(preparePeginTransaction).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.anything(),
+          expect.objectContaining({
+            availableUTXOs: [MOCK_UTXO_2],
+          }),
+        );
+      });
+    });
+
+    it("should throw when all UTXOs are reserved", async () => {
+      const { selectUtxosForDeposit } = vi.mocked(
+        await import("@/services/vault/utxoReservation"),
+      );
+
+      vi.mocked(selectUtxosForDeposit).mockImplementationOnce(() => {
+        throw new Error(
+          "All available UTXOs are reserved by pending deposits.",
+        );
+      });
+
+      const { result } = renderHook(() =>
+        useMultiVaultDepositFlow(MOCK_PARAMS),
+      );
+
+      await executeWithAutoArtifactDownload(result);
+
+      await waitFor(() => {
+        expect(result.current.error).toContain(
+          "All available UTXOs are reserved",
+        );
       });
     });
   });

--- a/services/vault/src/hooks/deposit/useMultiVaultDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useMultiVaultDepositFlow.ts
@@ -32,6 +32,10 @@ import { logger } from "@/infrastructure";
 import { LocalStorageStatus } from "@/models/peginStateMachine";
 import { validateMultiVaultDepositInputs } from "@/services/deposit/validations";
 import { signDepositorGraph } from "@/services/vault/depositorGraphSigningService";
+import {
+  collectReservedUtxoRefs,
+  selectUtxosForDeposit,
+} from "@/services/vault/utxoReservation";
 import { activateVaultWithSecret } from "@/services/vault/vaultActivationService";
 import {
   signPayoutTransactions,
@@ -43,7 +47,7 @@ import {
 } from "@/services/vault/vaultPeginBroadcastService";
 import { preparePeginTransaction } from "@/services/vault/vaultTransactionService";
 import { deriveWotsPkHash, linkPeginToMnemonic } from "@/services/wots";
-import { addPendingPegin } from "@/storage/peginStorage";
+import { addPendingPegin, getPendingPegins } from "@/storage/peginStorage";
 import { btcAddressToScriptPubKeyHex } from "@/utils/btc";
 import { satoshiToBtcNumber } from "@/utils/btcConversion";
 import { sanitizeErrorMessage } from "@/utils/errors/formatting";
@@ -316,6 +320,17 @@ export function useMultiVaultDepositFlow(
           (hex) => hashSecret(hex).slice(2), // strip 0x prefix
         );
 
+        // Filter out UTXOs reserved by in-flight deposits to prevent
+        // double-spend failures across concurrent sessions/tabs.
+        const pendingPegins = getPendingPegins(confirmedEthAddress);
+        const reservedUtxoRefs = collectReservedUtxoRefs({ pendingPegins });
+        const availableUTXOs = selectUtxosForDeposit({
+          availableUtxos: spendableUTXOs,
+          reservedUtxoRefs,
+          requiredAmount: vaultAmounts.reduce((sum, a) => sum + a, 0n),
+          feeRate: mempoolFeeRate,
+        });
+
         // ONE Pre-PegIn tx with N HTLC outputs (one per vault)
         const batchResult = await preparePeginTransaction(
           confirmedBtcWallet,
@@ -333,7 +348,7 @@ export function useMultiVaultDepositFlow(
             hashlocks,
             councilQuorum: config.offchainParams.councilQuorum,
             councilSize: config.offchainParams.securityCouncilKeys.length,
-            availableUTXOs: spendableUTXOs,
+            availableUTXOs,
           },
         );
 
@@ -485,6 +500,9 @@ export function useMultiVaultDepositFlow(
         setCurrentStep(DepositFlowStep.SIGN_PAYOUTS);
         setIsWaiting(true);
 
+        // Track per-vault outcomes so failed lanes don't block healthy siblings
+        const wotsFailedVaultIds = new Set<string>();
+
         for (const result of broadcastedResults) {
           try {
             await submitWotsPublicKey({
@@ -498,6 +516,7 @@ export function useMultiVaultDepositFlow(
           } catch (error) {
             // Re-throw abort errors so they're suppressed by the outer catch
             if (signal.aborted) throw error;
+            wotsFailedVaultIds.add(result.vaultId);
             const errorMsg =
               error instanceof Error ? error.message : String(error);
             const warning = `Vault ${result.vaultIndex + 1}: WOTS key submission failed - ${errorMsg}`;
@@ -519,8 +538,15 @@ export function useMultiVaultDepositFlow(
         // VP waits for Pre-PegIn BTC confirmation before being ready.
         // ========================================================================
 
+        const payoutSignedVaultIds = new Set<string>();
+
         for (let vi = 0; vi < broadcastedResults.length; vi++) {
           const result = broadcastedResults[vi];
+
+          // Skip vaults whose WOTS key submission failed — the VP won't have
+          // the keys needed, so payout signing would timeout.
+          if (wotsFailedVaultIds.has(result.vaultId)) continue;
+
           try {
             setCurrentVaultIndex(vi);
             setIsWaiting(true);
@@ -575,6 +601,8 @@ export function useMultiVaultDepositFlow(
               depositorClaimerPresignatures,
               result.vaultId,
             );
+
+            payoutSignedVaultIds.add(result.vaultId);
           } catch (error) {
             // If the user cancelled, stop immediately — don't continue with other vaults
             if (signal.aborted) throw error;
@@ -601,13 +629,20 @@ export function useMultiVaultDepositFlow(
         setPayoutSigningProgress(null);
         setCurrentVaultIndex(null);
 
+        // Only proceed with vaults that completed payout signing.
+        // Vaults that failed WOTS submission or payout signing will never
+        // reach VERIFIED — waiting for them would block healthy siblings.
+        const readyResults = broadcastedResults.filter((r) =>
+          payoutSignedVaultIds.has(r.vaultId),
+        );
+
         // ========================================================================
         // Step 6: Download Vault Artifacts (per vault, sequential)
         // ========================================================================
 
         setCurrentStep(DepositFlowStep.ARTIFACT_DOWNLOAD);
 
-        for (const result of broadcastedResults) {
+        for (const result of readyResults) {
           if (signal.aborted) break;
 
           setArtifactDownloadInfo({
@@ -627,38 +662,40 @@ export function useMultiVaultDepositFlow(
         // reveal HTLC secret on Ethereum
         // ========================================================================
 
-        setCurrentStep(DepositFlowStep.ACTIVATE_VAULT);
-        setIsWaiting(true);
-        await Promise.all(
-          broadcastedResults.map((r) =>
-            waitForContractVerification({ vaultId: r.vaultId, signal }),
-          ),
-        );
-        setIsWaiting(false);
+        if (readyResults.length > 0) {
+          setCurrentStep(DepositFlowStep.ACTIVATE_VAULT);
+          setIsWaiting(true);
+          await Promise.all(
+            readyResults.map((r) =>
+              waitForContractVerification({ vaultId: r.vaultId, signal }),
+            ),
+          );
+          setIsWaiting(false);
 
-        for (const result of broadcastedResults) {
-          try {
-            await activateVaultWithSecret({
-              vaultId: result.vaultId,
-              secret: ensureHexPrefix(result.htlcSecretHex),
-              walletClient,
-            });
-          } catch (error) {
-            if (signal.aborted) throw error;
+          for (const result of readyResults) {
+            try {
+              await activateVaultWithSecret({
+                vaultId: result.vaultId,
+                secret: ensureHexPrefix(result.htlcSecretHex),
+                walletClient,
+              });
+            } catch (error) {
+              if (signal.aborted) throw error;
 
-            const errorMsg =
-              error instanceof Error ? error.message : String(error);
-            const warning = `Vault ${result.vaultIndex + 1}: Activation failed - ${errorMsg}`;
-            warnings.push(warning);
-            logger.error(
-              error instanceof Error ? error : new Error(String(error)),
-              {
-                data: {
-                  context: "[Multi-Vault] Failed to activate vault",
-                  vaultId: result.vaultId,
+              const errorMsg =
+                error instanceof Error ? error.message : String(error);
+              const warning = `Vault ${result.vaultIndex + 1}: Activation failed - ${errorMsg}`;
+              warnings.push(warning);
+              logger.error(
+                error instanceof Error ? error : new Error(String(error)),
+                {
+                  data: {
+                    context: "[Multi-Vault] Failed to activate vault",
+                    vaultId: result.vaultId,
+                  },
                 },
-              },
-            );
+              );
+            }
           }
         }
 

--- a/services/vault/src/hooks/deposit/useMultiVaultDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useMultiVaultDepositFlow.ts
@@ -503,33 +503,56 @@ export function useMultiVaultDepositFlow(
         // Track per-vault outcomes so failed lanes don't block healthy siblings
         const wotsFailedVaultIds = new Set<string>();
 
+        const MAX_WOTS_ATTEMPTS = 2;
+
         for (const result of broadcastedResults) {
-          try {
-            await submitWotsPublicKey({
-              peginTxHash: result.peginTxHash,
-              depositorBtcPubkey: result.depositorBtcPubkey,
-              appContractAddress: selectedApplication,
-              providerAddress: provider.id,
-              getMnemonic,
-              signal,
-            });
-          } catch (error) {
-            // Re-throw abort errors so they're suppressed by the outer catch
-            if (signal.aborted) throw error;
-            wotsFailedVaultIds.add(result.vaultId);
-            const errorMsg =
-              error instanceof Error ? error.message : String(error);
-            const warning = `Vault ${result.vaultIndex + 1}: WOTS key submission failed - ${errorMsg}`;
-            warnings.push(warning);
-            logger.error(
-              error instanceof Error ? error : new Error(String(error)),
-              {
-                data: {
-                  context: "[Multi-Vault] Failed to submit WOTS key for vault",
-                  vaultId: result.vaultId,
+          let wotsSuccess = false;
+
+          for (let attempt = 1; attempt <= MAX_WOTS_ATTEMPTS; attempt++) {
+            try {
+              await submitWotsPublicKey({
+                peginTxHash: result.peginTxHash,
+                depositorBtcPubkey: result.depositorBtcPubkey,
+                appContractAddress: selectedApplication,
+                providerAddress: provider.id,
+                getMnemonic,
+                signal,
+              });
+              wotsSuccess = true;
+              break;
+            } catch (error) {
+              // Re-throw abort errors so they're suppressed by the outer catch
+              if (signal.aborted) throw error;
+
+              if (attempt < MAX_WOTS_ATTEMPTS) {
+                // submitWotsPublicKey is idempotent — if the VP already accepted
+                // the key but the response was lost, the retry will detect that
+                // the VP moved past the WOTS stage and return early.
+                logger.warn(
+                  `[Multi-Vault] WOTS submission failed for vault ${result.vaultId}, retrying (attempt ${attempt}/${MAX_WOTS_ATTEMPTS})`,
+                );
+                continue;
+              }
+
+              const errorMsg =
+                error instanceof Error ? error.message : String(error);
+              const warning = `Vault ${result.vaultIndex + 1}: WOTS key submission failed - ${errorMsg}`;
+              warnings.push(warning);
+              logger.error(
+                error instanceof Error ? error : new Error(String(error)),
+                {
+                  data: {
+                    context:
+                      "[Multi-Vault] Failed to submit WOTS key for vault",
+                    vaultId: result.vaultId,
+                  },
                 },
-              },
-            );
+              );
+            }
+          }
+
+          if (!wotsSuccess) {
+            wotsFailedVaultIds.add(result.vaultId);
           }
         }
 

--- a/services/vault/src/services/vault/__tests__/utxoReservation.test.ts
+++ b/services/vault/src/services/vault/__tests__/utxoReservation.test.ts
@@ -378,8 +378,8 @@ describe("UTXO Reservation", () => {
       });
     });
 
-    describe("fallback conditions", () => {
-      it("should fallback to all UTXOs when all are reserved", () => {
+    describe("insufficient unreserved UTXOs", () => {
+      it("should throw when all UTXOs are reserved", () => {
         const reserved: UtxoRef[] = [
           { txid: "txid1", vout: 0 },
           { txid: "txid2", vout: 1 },
@@ -387,41 +387,39 @@ describe("UTXO Reservation", () => {
           { txid: "txid4", vout: 2 },
         ];
 
-        const result = selectUtxosForDeposit({
-          availableUtxos: mockUTXOs,
-          reservedUtxoRefs: reserved,
-          requiredAmount: 100000n,
-          feeRate: DEFAULT_FEE_RATE,
-        });
-
-        expect(result).toHaveLength(4);
-        expect(result).toEqual(mockUTXOs);
+        expect(() =>
+          selectUtxosForDeposit({
+            availableUtxos: mockUTXOs,
+            reservedUtxoRefs: reserved,
+            requiredAmount: 100000n,
+            feeRate: DEFAULT_FEE_RATE,
+          }),
+        ).toThrow("All available UTXOs are reserved by pending deposits");
       });
 
-      it("should fallback when unreserved UTXOs are insufficient for required amount + fee", () => {
+      it("should throw when unreserved UTXOs are insufficient for required amount + fee", () => {
         // Reserve txid2 (100000) and txid4 (200000)
         // Unreserved: txid1 (50000) + txid3 (75000) = 125000
-        // Required: 200000 + ~2343 fee buffer -> unreserved insufficient -> fallback
+        // Required: 200000 + ~2343 fee buffer -> unreserved insufficient
         const reserved: UtxoRef[] = [
           { txid: "txid2", vout: 1 },
           { txid: "txid4", vout: 2 },
         ];
 
-        const result = selectUtxosForDeposit({
-          availableUtxos: mockUTXOs,
-          reservedUtxoRefs: reserved,
-          requiredAmount: 200000n,
-          feeRate: DEFAULT_FEE_RATE,
-        });
-
-        expect(result).toHaveLength(4);
-        expect(result).toEqual(mockUTXOs);
+        expect(() =>
+          selectUtxosForDeposit({
+            availableUtxos: mockUTXOs,
+            reservedUtxoRefs: reserved,
+            requiredAmount: 200000n,
+            feeRate: DEFAULT_FEE_RATE,
+          }),
+        ).toThrow("Insufficient unreserved UTXOs for this deposit amount");
       });
 
-      it("should NOT fallback when unreserved value covers required + fee buffer", () => {
+      it("should return unreserved UTXOs when they cover required + fee buffer", () => {
         // Reserve txid1 (50000), txid3 (75000), txid4 (200000)
         // Unreserved: txid2 (100000)
-        // Required: 95000 + ~2343 fee buffer ≈ 97343 < 100000 -> should NOT fallback
+        // Required: 95000 + ~2343 fee buffer ≈ 97343 < 100000 -> sufficient
         const reserved: UtxoRef[] = [
           { txid: "txid1", vout: 0 },
           { txid: "txid3", vout: 0 },
@@ -439,25 +437,24 @@ describe("UTXO Reservation", () => {
         expect(result[0].txid).toBe("txid2");
       });
 
-      it("should fallback when unreserved value insufficient for required + fee buffer", () => {
+      it("should throw when unreserved value insufficient for required + fee buffer", () => {
         // Reserve txid1 (50000), txid3 (75000), txid4 (200000)
         // Unreserved: txid2 (100000)
-        // Required: 98000 + ~2343 fee buffer ≈ 100343 > 100000 -> insufficient -> fallback
+        // Required: 98000 + ~2343 fee buffer ≈ 100343 > 100000 -> insufficient
         const reserved: UtxoRef[] = [
           { txid: "txid1", vout: 0 },
           { txid: "txid3", vout: 0 },
           { txid: "txid4", vout: 2 },
         ];
 
-        const result = selectUtxosForDeposit({
-          availableUtxos: mockUTXOs,
-          reservedUtxoRefs: reserved,
-          requiredAmount: 98000n,
-          feeRate: DEFAULT_FEE_RATE,
-        });
-
-        expect(result).toHaveLength(4);
-        expect(result).toEqual(mockUTXOs);
+        expect(() =>
+          selectUtxosForDeposit({
+            availableUtxos: mockUTXOs,
+            reservedUtxoRefs: reserved,
+            requiredAmount: 98000n,
+            feeRate: DEFAULT_FEE_RATE,
+          }),
+        ).toThrow("Insufficient unreserved UTXOs for this deposit amount");
       });
     });
 
@@ -524,30 +521,28 @@ describe("UTXO Reservation", () => {
     });
 
     describe("fee buffer calculation", () => {
-      it("should use fee buffer in sufficiency check", () => {
+      it("should throw when high fee rate makes unreserved insufficient", () => {
         // Reserve txid1 (50000), txid3 (75000), txid4 (200000)
         // Unreserved: txid2 (100000)
         // At 100 sat/vB: fee buffer ≈ 23430 sats
-        // Required: 80000 + 23430 = 103430 > 100000 -> fallback
+        // Required: 80000 + 23430 = 103430 > 100000 -> insufficient
         const reserved: UtxoRef[] = [
           { txid: "txid1", vout: 0 },
           { txid: "txid3", vout: 0 },
           { txid: "txid4", vout: 2 },
         ];
 
-        const result = selectUtxosForDeposit({
-          availableUtxos: mockUTXOs,
-          reservedUtxoRefs: reserved,
-          requiredAmount: 80000n,
-          feeRate: 100, // High fee rate
-        });
-
-        // Should fallback due to fee buffer
-        expect(result).toHaveLength(4);
-        expect(result).toEqual(mockUTXOs);
+        expect(() =>
+          selectUtxosForDeposit({
+            availableUtxos: mockUTXOs,
+            reservedUtxoRefs: reserved,
+            requiredAmount: 80000n,
+            feeRate: 100, // High fee rate
+          }),
+        ).toThrow("Insufficient unreserved UTXOs");
       });
 
-      it("should not fallback with low fee rate", () => {
+      it("should return unreserved UTXOs with low fee rate", () => {
         // Same setup but with fee rate of 1 sat/vB
         // Fee buffer ≈ 234 sats
         // Required: 80000 + 234 = 80234 < 100000 -> unreserved sufficient
@@ -564,7 +559,6 @@ describe("UTXO Reservation", () => {
           feeRate: 1, // Low fee rate
         });
 
-        // Should NOT fallback
         expect(result).toHaveLength(1);
         expect(result[0].txid).toBe("txid2");
       });

--- a/services/vault/src/services/vault/utxoReservation.ts
+++ b/services/vault/src/services/vault/utxoReservation.ts
@@ -142,18 +142,17 @@ export function collectReservedUtxoRefs(
 }
 
 /**
- * Select UTXOs for a deposit, filtering out reserved ones with smart fallback.
+ * Select UTXOs for a deposit, filtering out reserved ones.
  *
  * Logic:
  * 1. Filter out reserved UTXOs from the available pool
  * 2. If unreserved UTXOs are sufficient for the required amount + estimated fee, return them
- * 3. Otherwise, fallback to all available UTXOs (allows proceeding even with potential conflicts)
- *
- * This avoids double-spend failures when possible, but doesn't block the user
- * if they have no other choice (e.g., all UTXOs are in pending deposits).
+ * 3. Otherwise, throw — never silently reuse reserved UTXOs, as this risks double-spend
+ *    failures that strand registered-but-unbroadcastable vaults
  *
  * @param params - Selection parameters
- * @returns Array of UTXOs to use for the deposit
+ * @returns Array of unreserved UTXOs to use for the deposit
+ * @throws When all UTXOs are reserved or unreserved UTXOs are insufficient
  */
 export function selectUtxosForDeposit<
   T extends { txid: string; vout: number; value: number },
@@ -175,12 +174,13 @@ export function selectUtxosForDeposit<
     (utxo) => !isUtxoReserved(utxo, reservedUtxoRefs),
   );
 
-  // Fallback condition 1: No unreserved UTXOs
   if (unreserved.length === 0) {
-    return availableUtxos;
+    throw new Error(
+      "All available UTXOs are reserved by pending deposits. " +
+        "Wait for pending deposits to confirm or cancel them before starting a new deposit.",
+    );
   }
 
-  // Fallback condition 2: Unreserved UTXOs insufficient for required amount + fee
   const feeBuffer = estimateMinimumFeeBuffer(feeRate);
   const totalRequired = requiredAmount + feeBuffer;
   const unreservedTotal = unreserved.reduce(
@@ -188,9 +188,11 @@ export function selectUtxosForDeposit<
     0n,
   );
   if (unreservedTotal < totalRequired) {
-    return availableUtxos;
+    throw new Error(
+      "Insufficient unreserved UTXOs for this deposit amount. " +
+        "Wait for pending deposits to confirm or cancel them.",
+    );
   }
 
-  // Success: Use unreserved UTXOs
   return unreserved;
 }


### PR DESCRIPTION
## Summary
- Fix multi-vault deposit flow so failed lanes (WOTS key submission or payout signing) don't block healthy sibling vaults from proceeding to verification and activation
- Make UTXO reservation a hard boundary by throwing errors instead of silently falling back to reserved UTXOs, and wire reservation filtering into the multi-vault flow

## Details

### Finding [#46](https://github.com/babylonlabs-io/vault-provider-proxy/issues/58) — Stranded vaults on partial lane failure
Previously, `Promise.all(waitForContractVerification)` waited on every registered vault, including ones whose WOTS or payout-signing step had failed. Those vaults would never reach VERIFIED, blocking the entire batch — even siblings that were fully ready.

Now each vault's readiness is tracked independently via `wotsFailedVaultIds` and `payoutSignedVaultIds` Sets. Only vaults that completed all prerequisites proceed to artifact download, verification, and activation. Failed lanes produce warnings but don't stall the flow.

### Finding [#47](https://github.com/babylonlabs-io/vault-provider-proxy/issues/59) — UTXO reservation bypass
Previously, `selectUtxosForDeposit` fell back to all UTXOs (including reserved ones) when unreserved funds were insufficient, defeating the reservation mechanism. The multi-vault flow also skipped reservation filtering entirely, passing raw `spendableUTXOs` to the transaction builder.

Now `selectUtxosForDeposit` throws a hard error when unreserved UTXOs are insufficient, and the multi-vault flow filters reserved UTXOs via `getPendingPegins` → `collectReservedUtxoRefs` → `selectUtxosForDeposit` before building the transaction.


Closes https://github.com/babylonlabs-io/vault-provider-proxy/issues/58
Closes https://github.com/babylonlabs-io/vault-provider-proxy/issues/59