### PR TITLE
fix(vault): sync VP daemon status and RPC types with btc-vault

### DIFF
--- a/packages/babylon-ts-sdk/README.md
+++ b/packages/babylon-ts-sdk/README.md
@@ -41,14 +41,28 @@ This SDK handles the complex Bitcoin and Ethereum interactions needed to create 
 
 ```bash
 # npm
-npm install @babylonlabs-io/ts-sdk viem
+npm install @babylonlabs-io/ts-sdk viem bitcoinjs-lib @bitcoin-js/tiny-secp256k1-asmjs
 
 # yarn
-yarn add @babylonlabs-io/ts-sdk viem
+yarn add @babylonlabs-io/ts-sdk viem bitcoinjs-lib @bitcoin-js/tiny-secp256k1-asmjs
 
 # pnpm
-pnpm add @babylonlabs-io/ts-sdk viem
+pnpm add @babylonlabs-io/ts-sdk viem bitcoinjs-lib @bitcoin-js/tiny-secp256k1-asmjs
 ```
+
+### ECC Library Initialization
+
+The SDK uses `bitcoinjs-lib` for Taproot (P2TR) operations, which requires an ECC library to be initialized **before** any SDK function that touches Bitcoin addresses or PSBTs. Your application must call `initEccLib()` once at startup:
+
+```typescript
+import * as ecc from "@bitcoin-js/tiny-secp256k1-asmjs";
+import { initEccLib } from "bitcoinjs-lib";
+
+// Call once at app startup, before any SDK usage
+initEccLib(ecc);
+```
+
+For React apps, place this call in your entry point (e.g., `main.tsx`) before `createRoot()`. Failing to initialize will cause a runtime error: `"No ECC Library provided"`.
 
 ### Verify Installation
 

--- a/packages/babylon-ts-sdk/package.json
+++ b/packages/babylon-ts-sdk/package.json
@@ -82,13 +82,13 @@
   "description": "TypeScript SDK for Babylon protocol integrations",
   "dependencies": {
     "@babylonlabs-io/babylon-tbv-rust-wasm": "workspace:*",
-    "@bitcoin-js/tiny-secp256k1-asmjs": "2.2.3",
     "@noble/hashes": "2.0.1",
     "@scure/bip39": "2.0.1",
-    "bitcoinjs-lib": "6.1.7",
     "buffer": "6.0.3"
   },
   "peerDependencies": {
+    "@bitcoin-js/tiny-secp256k1-asmjs": "2.2.3",
+    "bitcoinjs-lib": "6.1.7",
     "viem": "^2.38.2"
   },
   "devDependencies": {

--- a/packages/babylon-ts-sdk/src/tbv/core/contracts/abis/BTCVaultRegistry.abi.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/contracts/abis/BTCVaultRegistry.abi.ts
@@ -9,7 +9,7 @@
 
 /**
  * Minimal ABI for BTCVaultRegistry contract.
- * Contains submitPeginRequest, submitPeginRequestBatch, activateVaultWithSecret, getPegInFee, and getBTCVault.
+ * Contains submitPeginRequest, submitPeginRequestBatch, activateVaultWithSecret, getPegInFee, and getBtcVaultBasicInfo.
  */
 export const BTCVaultRegistryABI = [
   {
@@ -217,7 +217,7 @@ export const BTCVaultRegistryABI = [
   },
   {
     type: "function",
-    name: "getBTCVault",
+    name: "getBtcVaultBasicInfo",
     inputs: [
       {
         name: "vaultId",
@@ -226,30 +226,13 @@ export const BTCVaultRegistryABI = [
       },
     ],
     outputs: [
-      {
-        name: "vault",
-        type: "tuple",
-        internalType: "struct IBTCVaultRegistry.BTCVault",
-        components: [
-          { name: "depositor", type: "address", internalType: "address" },
-          { name: "depositorBtcPubKey", type: "bytes32", internalType: "bytes32" },
-          { name: "depositorSignedPeginTx", type: "bytes", internalType: "bytes" },
-          { name: "amount", type: "uint256", internalType: "uint256" },
-          { name: "vaultProvider", type: "address", internalType: "address" },
-          { name: "status", type: "uint8", internalType: "enum IBTCVaultRegistry.BTCVaultStatus" },
-          { name: "applicationEntryPoint", type: "address", internalType: "address" },
-          { name: "universalChallengersVersion", type: "uint16", internalType: "uint16" },
-          { name: "appVaultKeepersVersion", type: "uint16", internalType: "uint16" },
-          { name: "offchainParamsVersion", type: "uint16", internalType: "uint16" },
-          { name: "createdAt", type: "uint256", internalType: "uint256" },
-          { name: "verifiedAt", type: "uint256", internalType: "uint256" },
-          { name: "depositorWotsPkHash", type: "bytes32", internalType: "bytes32" },
-          { name: "hashlock", type: "bytes32", internalType: "bytes32" },
-          { name: "htlcVout", type: "uint8", internalType: "uint8" },
-          { name: "depositorPopSignature", type: "bytes", internalType: "bytes" },
-          { name: "prePeginTxHash", type: "bytes32", internalType: "bytes32" },
-        ],
-      },
+      { name: "depositor", type: "address", internalType: "address" },
+      { name: "depositorBtcPubKey", type: "bytes32", internalType: "bytes32" },
+      { name: "amount", type: "uint256", internalType: "uint256" },
+      { name: "vaultProvider", type: "address", internalType: "address" },
+      { name: "status", type: "uint8", internalType: "enum IBTCVaultRegistry.BTCVaultStatus" },
+      { name: "applicationEntryPoint", type: "address", internalType: "address" },
+      { name: "createdAt", type: "uint256", internalType: "uint256" },
     ],
     stateMutability: "view",
   },

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
@@ -46,7 +46,6 @@ import {
   type Network,
 } from "../primitives";
 import {
-  ensureEcc,
   ensureHexPrefix,
   isAddressFromPublicKey,
   stripHexPrefix,
@@ -1143,15 +1142,15 @@ export class PeginManager {
         transport: http(),
       });
 
-      const vault = (await publicClient.readContract({
+      const result = (await publicClient.readContract({
         address: this.config.vaultContracts.btcVaultRegistry,
         abi: BTCVaultRegistryABI,
-        functionName: "getBTCVault",
+        functionName: "getBtcVaultBasicInfo",
         args: [vaultId],
-      })) as { depositor: Address };
+      })) as readonly [Address, ...unknown[]];
 
-      // If depositor is not zero address, vault exists
-      return vault.depositor !== zeroAddress;
+      // First element is depositor; if not zero address, vault exists
+      return result[0] !== zeroAddress;
     } catch {
       // If reading fails, assume vault doesn't exist and let contract handle it
       return false;
@@ -1168,8 +1167,6 @@ export class PeginManager {
   private async resolvePayoutScriptPubKey(
     depositorPayoutBtcAddress?: string,
   ): Promise<Hex> {
-    ensureEcc();
-
     let address: string;
 
     if (depositorPayoutBtcAddress) {

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PeginManager.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PeginManager.test.ts
@@ -52,8 +52,8 @@ vi.mock("viem", async (importOriginal) => {
         .fn()
         .mockImplementation(({ functionName }: { functionName: string }) => {
           if (functionName === "getPegInFee") return Promise.resolve(0n);
-          // getBTCVault — return vault with zero depositor (vault doesn't exist)
-          return Promise.resolve({ depositor: actual.zeroAddress });
+          // getBtcVaultBasicInfo — return tuple with zero depositor (vault doesn't exist)
+          return Promise.resolve([actual.zeroAddress]);
         }),
     })),
   };
@@ -672,7 +672,8 @@ describe("PeginManager", () => {
         .fn()
         .mockImplementation(({ functionName }: { functionName: string }) => {
           if (functionName === "getPegInFee") return Promise.resolve(0n);
-          return Promise.resolve({ depositor: viem.zeroAddress });
+          // getBtcVaultBasicInfo — return tuple with zero depositor (vault doesn't exist)
+          return Promise.resolve([viem.zeroAddress]);
         });
 
       // First call: checkVaultExists (default behavior)

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts
@@ -13,9 +13,8 @@
  * @module primitives/utils/bitcoin
  */
 
-import * as ecc from "@bitcoin-js/tiny-secp256k1-asmjs";
 import { Buffer } from "buffer";
-import { initEccLib, networks, payments } from "bitcoinjs-lib";
+import { networks, payments } from "bitcoinjs-lib";
 
 import type { Network } from "@babylonlabs-io/babylon-tbv-rust-wasm";
 import type { Hex } from "viem";
@@ -212,22 +211,27 @@ export function validateWalletPubkey(
 // Address derivation and validation
 // ============================================================================
 
-let eccInitialized = false;
-
 /**
- * Lazily initialize the ECC library for bitcoinjs-lib.
+ * Assert that the ECC library has been initialized via `initEccLib(ecc)`.
  *
- * Must be called before any P2TR / Taproot address operation.
- * Safe to call multiple times — only runs verification once.
- *
- * Why lazy: module-level `initEccLib(ecc)` breaks vitest because
- * `vi.mock()` hoists above imports, so the mocked bitcoinjs-lib
- * hasn't loaded the real ECC backend when the module evaluates.
+ * The consuming application must call `initEccLib(ecc)` from `bitcoinjs-lib`
+ * once at startup before using any SDK function that involves Taproot / P2TR
+ * operations. This guard provides a clear error message when that step was
+ * missed, instead of letting bitcoinjs-lib throw its generic
+ * "No ECC Library provided" error deep in a call stack.
  */
-export function ensureEcc(): void {
-  if (!eccInitialized) {
-    initEccLib(ecc);
-    eccInitialized = true;
+function assertEccInitialized(): void {
+  try {
+    payments.p2tr({ internalPubkey: Buffer.alloc(32, 1) });
+  } catch (e) {
+    if (e instanceof Error && e.message.includes("No ECC Library provided")) {
+      throw new Error(
+        "ECC library not initialized. " +
+          'You must call initEccLib(ecc) from "bitcoinjs-lib" before using the SDK. ' +
+          "See the ts-sdk README for setup instructions.",
+      );
+    }
+    // Any other error means ECC is loaded (e.g. invalid key is fine — ECC worked).
   }
 }
 
@@ -262,7 +266,7 @@ export function deriveTaprootAddress(
   publicKeyHex: string,
   network: Network,
 ): string {
-  ensureEcc();
+  assertEccInitialized();
   const xOnly = hexToUint8Array(processPublicKeyToXOnly(publicKeyHex));
   const { address } = payments.p2tr({
     internalPubkey: Buffer.from(xOnly),

--- a/packages/babylon-ts-sdk/src/tbv/core/utils/transaction/fundPeginTransaction.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/utils/transaction/fundPeginTransaction.ts
@@ -17,7 +17,6 @@
 import * as bitcoin from "bitcoinjs-lib";
 import { Buffer } from "buffer";
 
-import { ensureEcc } from "../../primitives/utils/bitcoin";
 import { DUST_THRESHOLD } from "../fee/constants";
 import type { UTXO } from "../utxo/selectUtxos";
 
@@ -130,8 +129,6 @@ export function parseUnfundedWasmTransaction(
 export function fundPeginTransaction(
   params: FundPeginTransactionParams,
 ): string {
-  ensureEcc();
-
   const { unfundedTxHex, selectedUTXOs, changeAddress, changeAmount, network } =
     params;
 

--- a/packages/babylon-ts-sdk/src/test/setup.ts
+++ b/packages/babylon-ts-sdk/src/test/setup.ts
@@ -3,12 +3,14 @@
  * This file runs before all test files
  */
 
+import * as ecc from "@bitcoin-js/tiny-secp256k1-asmjs";
+import { initEccLib } from "bitcoinjs-lib";
 import { beforeEach, vi } from "vitest";
+
+// Initialize ECC library for bitcoinjs-lib (required by P2TR / Taproot operations).
+initEccLib(ecc);
 
 // Clear all mocks before each test to prevent test interference
 beforeEach(() => {
   vi.clearAllMocks();
 });
-
-// Global test configuration
-// Add any global test utilities or mocks here

--- a/services/vault/src/clients/eth-contract/btc-vault-registry/__tests__/query.test.ts
+++ b/services/vault/src/clients/eth-contract/btc-vault-registry/__tests__/query.test.ts
@@ -21,53 +21,77 @@ import { getVaultFromChain } from "../query";
 const VAULT_ID =
   "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
 
-const FULL_VAULT = {
-  depositorSignedPeginTx: "0xdeadbeef",
-  applicationEntryPoint: "0xAppEntryPoint" as `0x${string}`,
+const BASIC_INFO = {
+  depositor: "0xDepositor" as `0x${string}`,
+  depositorBtcPubKey: "0xBtcPubKey" as `0x${string}`,
+  amount: 100000n,
   vaultProvider: "0xVaultProvider" as `0x${string}`,
+  status: 0,
+  applicationEntryPoint: "0xAppEntryPoint" as `0x${string}`,
+  createdAt: 12345n,
+};
+
+const PROTOCOL_INFO = {
+  depositorSignedPeginTx: "0xdeadbeef" as `0x${string}`,
   universalChallengersVersion: 1,
   appVaultKeepersVersion: 2,
   offchainParamsVersion: 3,
+  verifiedAt: 0n,
+  depositorWotsPkHash: "0x00" as `0x${string}`,
   hashlock:
     "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890" as `0x${string}`,
   htlcVout: 0,
+  depositorPopSignature: "0x00" as `0x${string}`,
+  prePeginTxHash: "0x00" as `0x${string}`,
+  vaultProviderCommissionBps: 10,
 };
 
 describe("getVaultFromChain", () => {
   it("returns signing-critical fields from the contract", async () => {
-    mockReadContract.mockResolvedValue(FULL_VAULT);
+    mockReadContract
+      .mockResolvedValueOnce(BASIC_INFO)
+      .mockResolvedValueOnce(PROTOCOL_INFO);
 
     const result = await getVaultFromChain(VAULT_ID);
 
     expect(result).toEqual({
-      depositorSignedPeginTx: FULL_VAULT.depositorSignedPeginTx,
-      applicationEntryPoint: FULL_VAULT.applicationEntryPoint,
-      vaultProvider: FULL_VAULT.vaultProvider,
-      universalChallengersVersion: FULL_VAULT.universalChallengersVersion,
-      appVaultKeepersVersion: FULL_VAULT.appVaultKeepersVersion,
-      offchainParamsVersion: FULL_VAULT.offchainParamsVersion,
-      hashlock: FULL_VAULT.hashlock,
-      htlcVout: FULL_VAULT.htlcVout,
+      depositorSignedPeginTx: PROTOCOL_INFO.depositorSignedPeginTx,
+      applicationEntryPoint: BASIC_INFO.applicationEntryPoint,
+      vaultProvider: BASIC_INFO.vaultProvider,
+      universalChallengersVersion: PROTOCOL_INFO.universalChallengersVersion,
+      appVaultKeepersVersion: PROTOCOL_INFO.appVaultKeepersVersion,
+      offchainParamsVersion: PROTOCOL_INFO.offchainParamsVersion,
+      hashlock: PROTOCOL_INFO.hashlock,
+      htlcVout: PROTOCOL_INFO.htlcVout,
     });
   });
 
-  it("calls readContract with the correct address, function, and vaultId arg", async () => {
-    mockReadContract.mockResolvedValue(FULL_VAULT);
+  it("calls readContract with the correct functions and vaultId arg", async () => {
+    mockReadContract
+      .mockResolvedValueOnce(BASIC_INFO)
+      .mockResolvedValueOnce(PROTOCOL_INFO);
 
     await getVaultFromChain(VAULT_ID);
 
     expect(mockReadContract).toHaveBeenCalledWith(
       expect.objectContaining({
         address: "0xBTCVaultRegistry",
-        functionName: "getBTCVault",
+        functionName: "getBtcVaultBasicInfo",
+        args: [VAULT_ID],
+      }),
+    );
+    expect(mockReadContract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        address: "0xBTCVaultRegistry",
+        functionName: "getBtcVaultProtocolInfo",
         args: [VAULT_ID],
       }),
     );
   });
 
   it("throws when depositorSignedPeginTx is empty", async () => {
-    mockReadContract.mockResolvedValue({
-      ...FULL_VAULT,
+    mockReadContract.mockResolvedValueOnce(BASIC_INFO).mockResolvedValueOnce({
+      ...PROTOCOL_INFO,
       depositorSignedPeginTx: "",
     });
 
@@ -77,8 +101,8 @@ describe("getVaultFromChain", () => {
   });
 
   it("throws when depositorSignedPeginTx is 0x", async () => {
-    mockReadContract.mockResolvedValue({
-      ...FULL_VAULT,
+    mockReadContract.mockResolvedValueOnce(BASIC_INFO).mockResolvedValueOnce({
+      ...PROTOCOL_INFO,
       depositorSignedPeginTx: "0x",
     });
 

--- a/services/vault/src/clients/eth-contract/btc-vault-registry/abis/BTCVaultRegistry.abi.json
+++ b/services/vault/src/clients/eth-contract/btc-vault-registry/abis/BTCVaultRegistry.abi.json
@@ -66,45 +66,6 @@
   },
   {
     "type": "function",
-    "name": "TBV_PROTOCOL_FREEZE_GUARDIAN",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
-    "stateMutability": "pure"
-  },
-  {
-    "type": "function",
-    "name": "TBV_PROTOCOL_PAUSING_GUARDIAN",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
-    "stateMutability": "pure"
-  },
-  {
-    "type": "function",
-    "name": "TIMELOCK_UPGRADER",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
     "name": "UPGRADE_INTERFACE_VERSION",
     "inputs": [],
     "outputs": [
@@ -134,6 +95,24 @@
         "name": "activationMetadata",
         "type": "bytes",
         "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "activateVaultWithSecretAndRedeem",
+    "inputs": [
+      {
+        "name": "vaultId",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "s",
+        "type": "bytes32",
+        "internalType": "bytes32"
       }
     ],
     "outputs": [],
@@ -173,7 +152,7 @@
   },
   {
     "type": "function",
-    "name": "btcVaults",
+    "name": "btcVaultsBasicInfo",
     "inputs": [
       {
         "name": "",
@@ -193,11 +172,6 @@
         "internalType": "bytes32"
       },
       {
-        "name": "depositorSignedPeginTx",
-        "type": "bytes",
-        "internalType": "bytes"
-      },
-      {
         "name": "amount",
         "type": "uint256",
         "internalType": "uint256"
@@ -210,12 +184,36 @@
       {
         "name": "status",
         "type": "uint8",
-        "internalType": "enum IBTCVaultRegistry.BTCVaultStatus"
+        "internalType": "enum BTCVaultTypes.BTCVaultStatus"
       },
       {
         "name": "applicationEntryPoint",
         "type": "address",
         "internalType": "address"
+      },
+      {
+        "name": "createdAt",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "btcVaultsProtocolInfo",
+    "inputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "depositorSignedPeginTx",
+        "type": "bytes",
+        "internalType": "bytes"
       },
       {
         "name": "universalChallengersVersion",
@@ -231,11 +229,6 @@
         "name": "offchainParamsVersion",
         "type": "uint16",
         "internalType": "uint16"
-      },
-      {
-        "name": "createdAt",
-        "type": "uint256",
-        "internalType": "uint256"
       },
       {
         "name": "verifiedAt",
@@ -266,6 +259,11 @@
         "name": "prePeginTxHash",
         "type": "bytes32",
         "internalType": "bytes32"
+      },
+      {
+        "name": "vaultProviderCommissionBps",
+        "type": "uint16",
+        "internalType": "uint16"
       }
     ],
     "stateMutability": "view"
@@ -329,14 +327,26 @@
   },
   {
     "type": "function",
-    "name": "fullPause",
-    "inputs": [],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    "name": "getBTCVaultAmountsBatch",
+    "inputs": [
+      {
+        "name": "vaultIds",
+        "type": "bytes32[]",
+        "internalType": "bytes32[]"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "amounts",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      }
+    ],
+    "stateMutability": "view"
   },
   {
     "type": "function",
-    "name": "getBTCVault",
+    "name": "getBtcVaultBasicInfo",
     "inputs": [
       {
         "name": "vaultId",
@@ -346,9 +356,9 @@
     ],
     "outputs": [
       {
-        "name": "vault",
+        "name": "vBasic",
         "type": "tuple",
-        "internalType": "struct IBTCVaultRegistry.BTCVault",
+        "internalType": "struct BTCVaultTypes.BTCVaultBasicInfo",
         "components": [
           {
             "name": "depositor",
@@ -359,11 +369,6 @@
             "name": "depositorBtcPubKey",
             "type": "bytes32",
             "internalType": "bytes32"
-          },
-          {
-            "name": "depositorSignedPeginTx",
-            "type": "bytes",
-            "internalType": "bytes"
           },
           {
             "name": "amount",
@@ -378,12 +383,43 @@
           {
             "name": "status",
             "type": "uint8",
-            "internalType": "enum IBTCVaultRegistry.BTCVaultStatus"
+            "internalType": "enum BTCVaultTypes.BTCVaultStatus"
           },
           {
             "name": "applicationEntryPoint",
             "type": "address",
             "internalType": "address"
+          },
+          {
+            "name": "createdAt",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getBtcVaultProtocolInfo",
+    "inputs": [
+      {
+        "name": "vaultId",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "vProtocol",
+        "type": "tuple",
+        "internalType": "struct BTCVaultRegistryTypes.BTCVaultProtocolInfo",
+        "components": [
+          {
+            "name": "depositorSignedPeginTx",
+            "type": "bytes",
+            "internalType": "bytes"
           },
           {
             "name": "universalChallengersVersion",
@@ -399,11 +435,6 @@
             "name": "offchainParamsVersion",
             "type": "uint16",
             "internalType": "uint16"
-          },
-          {
-            "name": "createdAt",
-            "type": "uint256",
-            "internalType": "uint256"
           },
           {
             "name": "verifiedAt",
@@ -434,27 +465,13 @@
             "name": "prePeginTxHash",
             "type": "bytes32",
             "internalType": "bytes32"
+          },
+          {
+            "name": "vaultProviderCommissionBps",
+            "type": "uint16",
+            "internalType": "uint16"
           }
         ]
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "getBTCVaultAmountsBatch",
-    "inputs": [
-      {
-        "name": "vaultIds",
-        "type": "bytes32[]",
-        "internalType": "bytes32[]"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "amounts",
-        "type": "uint256[]",
-        "internalType": "uint256[]"
       }
     ],
     "stateMutability": "view"
@@ -562,9 +579,9 @@
     ],
     "outputs": [
       {
-        "name": "vaults",
+        "name": "vBasics",
         "type": "tuple[]",
-        "internalType": "struct IBTCVaultRegistry.BTCVault[]",
+        "internalType": "struct BTCVaultTypes.BTCVaultBasicInfo[]",
         "components": [
           {
             "name": "depositor",
@@ -575,11 +592,6 @@
             "name": "depositorBtcPubKey",
             "type": "bytes32",
             "internalType": "bytes32"
-          },
-          {
-            "name": "depositorSignedPeginTx",
-            "type": "bytes",
-            "internalType": "bytes"
           },
           {
             "name": "amount",
@@ -594,12 +606,29 @@
           {
             "name": "status",
             "type": "uint8",
-            "internalType": "enum IBTCVaultRegistry.BTCVaultStatus"
+            "internalType": "enum BTCVaultTypes.BTCVaultStatus"
           },
           {
             "name": "applicationEntryPoint",
             "type": "address",
             "internalType": "address"
+          },
+          {
+            "name": "createdAt",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      },
+      {
+        "name": "vProtocols",
+        "type": "tuple[]",
+        "internalType": "struct BTCVaultRegistryTypes.BTCVaultProtocolInfo[]",
+        "components": [
+          {
+            "name": "depositorSignedPeginTx",
+            "type": "bytes",
+            "internalType": "bytes"
           },
           {
             "name": "universalChallengersVersion",
@@ -615,11 +644,6 @@
             "name": "offchainParamsVersion",
             "type": "uint16",
             "internalType": "uint16"
-          },
-          {
-            "name": "createdAt",
-            "type": "uint256",
-            "internalType": "uint256"
           },
           {
             "name": "verifiedAt",
@@ -650,6 +674,11 @@
             "name": "prePeginTxHash",
             "type": "bytes32",
             "internalType": "bytes32"
+          },
+          {
+            "name": "vaultProviderCommissionBps",
+            "type": "uint16",
+            "internalType": "uint16"
           }
         ]
       },
@@ -770,7 +799,7 @@
       {
         "name": "",
         "type": "tuple",
-        "internalType": "struct IBTCVaultRegistry.AddressBTCKeyPair",
+        "internalType": "struct BTCVaultTypes.AddressBTCKeyPair",
         "components": [
           {
             "name": "ethAddress",
@@ -1003,6 +1032,13 @@
   },
   {
     "type": "function",
+    "name": "pause",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
     "name": "pauseState",
     "inputs": [],
     "outputs": [
@@ -1010,6 +1046,25 @@
         "name": "",
         "type": "uint8",
         "internalType": "enum ITBVPausable.PauseState"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "peginInputSignatureCounts",
+    "inputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
       }
     ],
     "stateMutability": "view"
@@ -1197,7 +1252,7 @@
       {
         "name": "acks",
         "type": "tuple[]",
-        "internalType": "struct IBTCVaultRegistry.ACKSubmission[]",
+        "internalType": "struct BTCVaultRegistryTypes.ACKSubmission[]",
         "components": [
           {
             "name": "vaultId",
@@ -1452,7 +1507,7 @@
       {
         "name": "requests",
         "type": "tuple[]",
-        "internalType": "struct IBTCVaultRegistry.BatchPeginRequest[]",
+        "internalType": "struct BTCVaultRegistryTypes.BatchPeginRequest[]",
         "components": [
           {
             "name": "depositorBtcPubKey",
@@ -1630,6 +1685,19 @@
   },
   {
     "type": "event",
+    "name": "Frozen",
+    "inputs": [
+      {
+        "name": "freezer",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
     "name": "Initialized",
     "inputs": [
       {
@@ -1643,14 +1711,8 @@
   },
   {
     "type": "event",
-    "name": "PausedWith",
+    "name": "Paused",
     "inputs": [
-      {
-        "name": "state",
-        "type": "uint8",
-        "indexed": true,
-        "internalType": "enum ITBVPausable.PauseState"
-      },
       {
         "name": "pauser",
         "type": "address",
@@ -1809,7 +1871,7 @@
     "name": "Unfrozen",
     "inputs": [
       {
-        "name": "pauser",
+        "name": "unfreezer",
         "type": "address",
         "indexed": true,
         "internalType": "address"
@@ -1983,6 +2045,11 @@
   },
   {
     "type": "error",
+    "name": "DuplicateHashlock",
+    "inputs": []
+  },
+  {
+    "type": "error",
     "name": "ERC1967InvalidImplementation",
     "inputs": [
       {
@@ -2024,6 +2091,11 @@
   },
   {
     "type": "error",
+    "name": "InvalidBTCVaultStatus",
+    "inputs": []
+  },
+  {
+    "type": "error",
     "name": "InvalidHashlock",
     "inputs": []
   },
@@ -2060,11 +2132,6 @@
   },
   {
     "type": "error",
-    "name": "InvalidVaultStatus",
-    "inputs": []
-  },
-  {
-    "type": "error",
     "name": "NoAppVaultKeepersConfigured",
     "inputs": []
   },
@@ -2091,6 +2158,16 @@
   {
     "type": "error",
     "name": "TBV_AlreadyPaused",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "TBV_CannotUnfreezeWhilePaused",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "TBV_CannotUnpauseWhileFrozen",
     "inputs": []
   },
   {
@@ -2146,7 +2223,7 @@
   },
   {
     "type": "error",
-    "name": "VaultKeeperNotAuthorized",
+    "name": "UnauthorizedVaultKeeper",
     "inputs": []
   },
   {

--- a/services/vault/src/clients/eth-contract/btc-vault-registry/query.ts
+++ b/services/vault/src/clients/eth-contract/btc-vault-registry/query.ts
@@ -33,8 +33,37 @@ export interface OnChainVaultData {
   // in the PegInSubmitted event. Source it from the indexer instead.
 }
 
+/** Shape returned by getBtcVaultBasicInfo */
+interface OnChainVaultBasicInfo {
+  depositor: Address;
+  depositorBtcPubKey: Hex;
+  amount: bigint;
+  vaultProvider: Address;
+  status: number;
+  applicationEntryPoint: Address;
+  createdAt: bigint;
+}
+
+/** Shape returned by getBtcVaultProtocolInfo */
+interface OnChainVaultProtocolInfo {
+  depositorSignedPeginTx: Hex;
+  universalChallengersVersion: number;
+  appVaultKeepersVersion: number;
+  offchainParamsVersion: number;
+  verifiedAt: bigint;
+  depositorWotsPkHash: Hex;
+  hashlock: Hex;
+  htlcVout: number;
+  depositorPopSignature: Hex;
+  prePeginTxHash: Hex;
+  vaultProviderCommissionBps: number;
+}
+
 /**
  * Read signing-critical vault fields from the BTCVaultRegistry contract.
+ *
+ * The contract stores vault data in two separate structs (BasicInfo + ProtocolInfo).
+ * Both are fetched in parallel and merged into the unified OnChainVaultData shape.
  *
  * Throws if the vault does not exist on-chain (empty depositorSignedPeginTx).
  *
@@ -45,27 +74,40 @@ export async function getVaultFromChain(
 ): Promise<OnChainVaultData> {
   const publicClient = ethClient.getPublicClient();
 
-  const vault = (await publicClient.readContract({
-    address: CONTRACTS.BTC_VAULT_REGISTRY,
-    abi: BTCVaultRegistryAbi,
-    functionName: "getBTCVault",
-    args: [vaultId],
-  })) as OnChainVaultData;
+  const [basicInfo, protocolInfo] = await Promise.all([
+    publicClient.readContract({
+      address: CONTRACTS.BTC_VAULT_REGISTRY,
+      abi: BTCVaultRegistryAbi,
+      functionName: "getBtcVaultBasicInfo",
+      args: [vaultId],
+    }) as Promise<OnChainVaultBasicInfo>,
+    publicClient.readContract({
+      address: CONTRACTS.BTC_VAULT_REGISTRY,
+      abi: BTCVaultRegistryAbi,
+      functionName: "getBtcVaultProtocolInfo",
+      args: [vaultId],
+    }) as Promise<OnChainVaultProtocolInfo>,
+  ]);
 
-  if (!vault.depositorSignedPeginTx || vault.depositorSignedPeginTx === "0x") {
+  if (
+    !protocolInfo.depositorSignedPeginTx ||
+    protocolInfo.depositorSignedPeginTx === "0x"
+  ) {
     throw new Error(
       `Vault ${vaultId} not found on-chain or has no pegin transaction`,
     );
   }
 
   return {
-    depositorSignedPeginTx: vault.depositorSignedPeginTx,
-    applicationEntryPoint: vault.applicationEntryPoint,
-    vaultProvider: vault.vaultProvider,
-    universalChallengersVersion: Number(vault.universalChallengersVersion),
-    appVaultKeepersVersion: Number(vault.appVaultKeepersVersion),
-    offchainParamsVersion: Number(vault.offchainParamsVersion),
-    hashlock: vault.hashlock,
-    htlcVout: Number(vault.htlcVout),
+    depositorSignedPeginTx: protocolInfo.depositorSignedPeginTx,
+    applicationEntryPoint: basicInfo.applicationEntryPoint,
+    vaultProvider: basicInfo.vaultProvider,
+    universalChallengersVersion: Number(
+      protocolInfo.universalChallengersVersion,
+    ),
+    appVaultKeepersVersion: Number(protocolInfo.appVaultKeepersVersion),
+    offchainParamsVersion: Number(protocolInfo.offchainParamsVersion),
+    hashlock: protocolInfo.hashlock,
+    htlcVout: Number(protocolInfo.htlcVout),
   };
 }

--- a/services/vault/src/clients/vault-provider-rpc/__tests__/validators.test.ts
+++ b/services/vault/src/clients/vault-provider-rpc/__tests__/validators.test.ts
@@ -27,10 +27,14 @@ const validClaimerTransaction = {
 
 const validChallengerPresignData = {
   challenger_pubkey: VALID_PUBKEY,
-  challenge_assert_tx: { tx_hex: VALID_TX_HEX },
+  challenge_assert_x_tx: { tx_hex: VALID_TX_HEX },
+  challenge_assert_y_tx: { tx_hex: VALID_TX_HEX },
   nopayout_tx: { tx_hex: VALID_TX_HEX },
-  challenge_assert_psbt: VALID_PSBT,
   nopayout_psbt: VALID_PSBT,
+  challenge_assert_connectors: [
+    { wots_pks_json: '{"keys":[]}', gc_wots_keys_json: '{"keys":[]}' },
+  ],
+  output_label_hashes: ["a".repeat(64)],
 };
 
 const validDepositorGraph = {
@@ -177,6 +181,16 @@ describe("validateGetPeginStatusResponse", () => {
       validateGetPeginStatusResponse({
         ...validPeginStatusResponse,
         progress: "invalid",
+      }),
+    );
+    expect(detail).toContain('"progress" must be an object');
+  });
+
+  it("throws when progress is an array", () => {
+    const detail = getVpValidationDetail(() =>
+      validateGetPeginStatusResponse({
+        ...validPeginStatusResponse,
+        progress: [],
       }),
     );
     expect(detail).toContain('"progress" must be an object');

--- a/services/vault/src/clients/vault-provider-rpc/types.ts
+++ b/services/vault/src/clients/vault-provider-rpc/types.ts
@@ -54,10 +54,10 @@ export interface RequestDepositorClaimerArtifactsParams {
   depositor_pk: string;
 }
 
-/** Params for querying pegin status from the VP daemon. */
-export interface GetPeginStatusParams {
-  pegin_txid: string;
-}
+/** Params for querying pegin status from the VP daemon. Either pegin_txid or vault_id must be provided. */
+export type GetPeginStatusParams =
+  | { pegin_txid: string; vault_id?: never }
+  | { vault_id: string; pegin_txid?: never };
 
 // ============================================================================
 // Response Types
@@ -141,8 +141,17 @@ export interface ChallengerProgress {
 }
 
 export type GcDataProgress = ChallengerProgress;
-export type PresigningProgress = ChallengerProgress;
 export type AckCollectionProgress = ChallengerProgress;
+
+/** Extended presigning progress with all 3 concurrent phases. */
+export interface PresigningProgress extends ChallengerProgress {
+  /** Phase 2: whether the depositor-as-claimer graph has been created. */
+  depositor_graph_created?: boolean;
+  /** Phase 3: number of VK-challenger presigning sessions completed. */
+  vk_challenger_presigning_completed?: number;
+  /** Phase 3: total VK-challenger presigning sessions required. */
+  vk_challenger_presigning_total?: number;
+}
 
 /** Detailed progress breakdown for an in-progress pegin. */
 export interface PeginProgressDetails {

--- a/services/vault/src/clients/vault-provider-rpc/validators.ts
+++ b/services/vault/src/clients/vault-provider-rpc/validators.ts
@@ -87,6 +87,51 @@ function assertXOnlyPubkey(value: unknown, field: string): void {
 }
 
 /**
+ * Validate the optional presigning progress fields returned inside PeginProgressDetails.
+ * These fields are sent by newer VP versions; if present, they must have correct types.
+ */
+function validatePresigningProgressFields(
+  progress: Record<string, unknown>,
+): void {
+  const presigning = progress.presigning;
+  if (presigning === undefined || presigning === null) return;
+  if (typeof presigning !== "object") {
+    throw new VpResponseValidationError(
+      `VP response validation failed: "progress.presigning" must be an object if present`,
+    );
+  }
+
+  const p = presigning as Record<string, unknown>;
+
+  if (
+    p.depositor_graph_created !== undefined &&
+    typeof p.depositor_graph_created !== "boolean"
+  ) {
+    throw new VpResponseValidationError(
+      `VP response validation failed: "progress.presigning.depositor_graph_created" must be a boolean if present, got ${preview(p.depositor_graph_created)}`,
+    );
+  }
+
+  if (
+    p.vk_challenger_presigning_completed !== undefined &&
+    typeof p.vk_challenger_presigning_completed !== "number"
+  ) {
+    throw new VpResponseValidationError(
+      `VP response validation failed: "progress.presigning.vk_challenger_presigning_completed" must be a number if present, got ${preview(p.vk_challenger_presigning_completed)}`,
+    );
+  }
+
+  if (
+    p.vk_challenger_presigning_total !== undefined &&
+    typeof p.vk_challenger_presigning_total !== "number"
+  ) {
+    throw new VpResponseValidationError(
+      `VP response validation failed: "progress.presigning.vk_challenger_presigning_total" must be a number if present, got ${preview(p.vk_challenger_presigning_total)}`,
+    );
+  }
+}
+
+/**
  * Validate a getPeginStatus response.
  *
  * Throws if the status field is not a recognized DaemonStatus value.
@@ -127,6 +172,8 @@ export function validateGetPeginStatusResponse(
       `VP response validation failed: "progress" must be an object`,
     );
   }
+
+  validatePresigningProgressFields(r.progress as Record<string, unknown>);
 
   if (typeof r.health_info !== "string") {
     throw new VpResponseValidationError(

--- a/services/vault/src/clients/vault-provider-rpc/validators.ts
+++ b/services/vault/src/clients/vault-provider-rpc/validators.ts
@@ -95,7 +95,7 @@ function validatePresigningProgressFields(
 ): void {
   const presigning = progress.presigning;
   if (presigning === undefined || presigning === null) return;
-  if (typeof presigning !== "object") {
+  if (typeof presigning !== "object" || Array.isArray(presigning)) {
     throw new VpResponseValidationError(
       `VP response validation failed: "progress.presigning" must be an object if present`,
     );
@@ -167,7 +167,11 @@ export function validateGetPeginStatusResponse(
     );
   }
 
-  if (r.progress === null || typeof r.progress !== "object") {
+  if (
+    r.progress === null ||
+    typeof r.progress !== "object" ||
+    Array.isArray(r.progress)
+  ) {
     throw new VpResponseValidationError(
       `VP response validation failed: "progress" must be an object`,
     );
@@ -253,6 +257,21 @@ function validateClaimerTransactions(value: unknown, field: string): void {
   assertNonEmptyString(tx.payout_psbt, `${field}.payout_psbt`);
 }
 
+function validateChallengeAssertConnectorData(
+  value: unknown,
+  field: string,
+): void {
+  if (value === null || typeof value !== "object") {
+    throw new VpResponseValidationError(
+      `VP response validation failed: "${field}" must be an object`,
+    );
+  }
+
+  const c = value as Record<string, unknown>;
+  assertNonEmptyString(c.wots_pks_json, `${field}.wots_pks_json`);
+  assertNonEmptyString(c.gc_wots_keys_json, `${field}.gc_wots_keys_json`);
+}
+
 function validatePresignDataPerChallenger(value: unknown, field: string): void {
   if (value === null || typeof value !== "object") {
     throw new VpResponseValidationError(
@@ -264,15 +283,41 @@ function validatePresignDataPerChallenger(value: unknown, field: string): void {
 
   assertXOnlyPubkey(d.challenger_pubkey, `${field}.challenger_pubkey`);
   validateTransactionData(
-    d.challenge_assert_tx,
-    `${field}.challenge_assert_tx`,
+    d.challenge_assert_x_tx,
+    `${field}.challenge_assert_x_tx`,
+  );
+  validateTransactionData(
+    d.challenge_assert_y_tx,
+    `${field}.challenge_assert_y_tx`,
   );
   validateTransactionData(d.nopayout_tx, `${field}.nopayout_tx`);
-  assertNonEmptyString(
-    d.challenge_assert_psbt,
-    `${field}.challenge_assert_psbt`,
-  );
   assertNonEmptyString(d.nopayout_psbt, `${field}.nopayout_psbt`);
+
+  if (!Array.isArray(d.challenge_assert_connectors)) {
+    throw new VpResponseValidationError(
+      `VP response validation failed: "${field}.challenge_assert_connectors" must be an array`,
+    );
+  }
+
+  for (let i = 0; i < d.challenge_assert_connectors.length; i++) {
+    validateChallengeAssertConnectorData(
+      d.challenge_assert_connectors[i],
+      `${field}.challenge_assert_connectors[${i}]`,
+    );
+  }
+
+  if (!Array.isArray(d.output_label_hashes)) {
+    throw new VpResponseValidationError(
+      `VP response validation failed: "${field}.output_label_hashes" must be an array`,
+    );
+  }
+
+  for (let i = 0; i < d.output_label_hashes.length; i++) {
+    assertNonEmptyHex(
+      d.output_label_hashes[i],
+      `${field}.output_label_hashes[${i}]`,
+    );
+  }
 }
 
 /**

--- a/services/vault/src/hooks/deposit/depositFlowSteps/wotsSubmission.ts
+++ b/services/vault/src/hooks/deposit/depositFlowSteps/wotsSubmission.ts
@@ -16,7 +16,7 @@
  */
 
 import { VaultProviderRpcApi } from "@/clients/vault-provider-rpc";
-import { DaemonStatus } from "@/models/peginStateMachine";
+import { DaemonStatus, POST_WOTS_STATUSES } from "@/models/peginStateMachine";
 import { waitForPeginStatus } from "@/services/vault/vaultPeginStatusService";
 import { deriveWotsBlockPublicKeys, mnemonicToWotsSeed } from "@/services/wots";
 import { stripHexPrefix } from "@/utils/btc";
@@ -30,23 +30,8 @@ const RPC_TIMEOUT_MS = 60 * 1000;
 /** Maximum time to wait for VP to reach PendingDepositorWotsPK (5 min). */
 const STATUS_POLL_TIMEOUT_MS = 5 * 60 * 1000;
 
-/**
- * Statuses that come after WOTS key submission.
- * If the VP is already in one of these states, the key was already submitted
- * (e.g. via resume flow) and we can skip.
- */
-const POST_WOTS_STATUSES = new Set<string>([
-  DaemonStatus.PENDING_BABE_SETUP,
-  DaemonStatus.PENDING_CHALLENGER_PRESIGNING,
-  DaemonStatus.PENDING_PEGIN_SIGS_AVAILABILITY,
-  DaemonStatus.PENDING_DEPOSITOR_SIGNATURES,
-  DaemonStatus.PENDING_ACKS,
-  DaemonStatus.PENDING_ACTIVATION,
-  DaemonStatus.ACTIVATED,
-]);
-
 /** All statuses we accept — either ready for submission or already past it. */
-const TARGET_STATUSES = new Set<string>([
+const TARGET_STATUSES: ReadonlySet<DaemonStatus> = new Set([
   DaemonStatus.PENDING_DEPOSITOR_WOTS_PK,
   ...POST_WOTS_STATUSES,
 ]);
@@ -87,7 +72,7 @@ export async function submitWotsPublicKey(
   });
 
   // Key was already submitted in a previous session (e.g. resume flow)
-  if (POST_WOTS_STATUSES.has(status)) {
+  if (POST_WOTS_STATUSES.has(status as DaemonStatus)) {
     return;
   }
 

--- a/services/vault/src/hooks/deposit/usePeginPollingQuery.ts
+++ b/services/vault/src/hooks/deposit/usePeginPollingQuery.ts
@@ -19,7 +19,10 @@ import {
   POLLING_RETRY_DELAY_MS,
   RPC_TIMEOUT_MS,
 } from "../../config/polling";
-import { DaemonStatus } from "../../models/peginStateMachine";
+import {
+  DaemonStatus,
+  VP_TRANSIENT_STATUSES,
+} from "../../models/peginStateMachine";
 import type { PendingPeginRequest } from "../../storage/peginStorage";
 import type { ClaimerTransactions } from "../../types";
 import type { VaultActivity } from "../../types/activity";
@@ -75,19 +78,6 @@ interface UsePeginPollingQueryResult {
 }
 
 /**
- * Statuses where no depositor action is needed — VP is still processing
- * or has already moved past depositor interaction.
- */
-const TRANSIENT_STATUSES = new Set<string>([
-  DaemonStatus.PENDING_BABE_SETUP,
-  DaemonStatus.PENDING_CHALLENGER_PRESIGNING,
-  DaemonStatus.PENDING_PEGIN_SIGS_AVAILABILITY,
-  DaemonStatus.PENDING_ACKS,
-  DaemonStatus.PENDING_ACTIVATION,
-  DaemonStatus.ACTIVATED,
-]);
-
-/**
  * Fetch status and transactions from a single vault provider for multiple deposits.
  *
  * Uses the lightweight `getPeginStatus` RPC first, then only calls
@@ -130,7 +120,7 @@ async function fetchFromProvider(
         continue;
       }
 
-      if (TRANSIENT_STATUSES.has(status)) {
+      if (VP_TRANSIENT_STATUSES.has(status as DaemonStatus)) {
         errors.delete(depositId);
         needsWotsKey.delete(depositId);
         continue;
@@ -158,7 +148,7 @@ async function fetchFromProvider(
         continue;
       }
 
-      // Unknown status — clear errors and continue polling
+      // Unhandled status (e.g. ClaimPosted, PeggedOut) — clear errors, keep polling
       errors.delete(depositId);
       needsWotsKey.delete(depositId);
     } catch (error) {

--- a/services/vault/src/main.tsx
+++ b/services/vault/src/main.tsx
@@ -1,3 +1,5 @@
+import * as ecc from "@bitcoin-js/tiny-secp256k1-asmjs";
+import { initEccLib } from "bitcoinjs-lib";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { ErrorBoundary } from "react-error-boundary";
@@ -9,6 +11,10 @@ import { Router } from "@/router";
 
 import "@/globals.css";
 import "../sentry.client.config";
+
+// Initialize ECC library for bitcoinjs-lib (required by p2tr, Taproot operations).
+// Must run before any code that touches Bitcoin addresses or PSBTs.
+initEccLib(ecc);
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/services/vault/src/models/peginStateMachine.ts
+++ b/services/vault/src/models/peginStateMachine.ts
@@ -104,12 +104,15 @@ export enum DaemonStatus {
 // ============================================================================
 
 /**
- * All states before PendingDepositorSignatures (inclusive of WOTS key step).
- * Used to detect "VP is still processing" errors.
+ * States where the VP is still processing (no depositor action needed).
+ * Used by isPreDepositorSignaturesError to detect transient "Invalid state"
+ * errors that should be silently retried.
+ *
+ * Excludes PENDING_DEPOSITOR_WOTS_PK — that state requires depositor action
+ * (WOTS key submission), so retrying would loop forever.
  */
 export const PRE_DEPOSITOR_SIGNATURES_STATES: readonly DaemonStatus[] = [
   DaemonStatus.PENDING_INGESTION,
-  DaemonStatus.PENDING_DEPOSITOR_WOTS_PK,
   DaemonStatus.PENDING_BABE_SETUP,
   DaemonStatus.PENDING_CHALLENGER_PRESIGNING,
   DaemonStatus.PENDING_PEGIN_SIGS_AVAILABILITY,

--- a/services/vault/src/models/peginStateMachine.ts
+++ b/services/vault/src/models/peginStateMachine.ts
@@ -72,6 +72,7 @@ export enum LocalStorageStatus {
  *
  * State flow (happy path):
  * PendingIngestion -> PendingDepositorWotsPK -> PendingBabeSetup -> PendingChallengerPresigning
+ *   -> PendingPeginSigsAvailability -> PendingPrePegInConfirmations
  *   -> PendingDepositorSignatures -> PendingACKs -> PendingActivation -> Activated
  *
  * Terminal / branching states:
@@ -85,6 +86,7 @@ export enum DaemonStatus {
   PENDING_BABE_SETUP = "PendingBabeSetup",
   PENDING_CHALLENGER_PRESIGNING = "PendingChallengerPresigning",
   PENDING_PEGIN_SIGS_AVAILABILITY = "PendingPeginSigsAvailability",
+  PENDING_PRE_PEGIN_CONFIRMATIONS = "PendingPrePegInConfirmations",
   PENDING_DEPOSITOR_SIGNATURES = "PendingDepositorSignatures",
   PENDING_ACKS = "PendingACKs",
   PENDING_ACTIVATION = "PendingActivation",
@@ -94,16 +96,62 @@ export enum DaemonStatus {
   PEGGED_OUT = "PeggedOut",
 }
 
+// ============================================================================
+// Daemon Status Groups
+//
+// Canonical groupings of DaemonStatus values, derived from the happy-path
+// state flow. Consumers import these instead of maintaining local copies.
+// ============================================================================
+
 /**
- * States that occur before PendingDepositorSignatures.
- * When vault provider returns these states, frontend should wait/poll.
+ * All states before PendingDepositorSignatures (inclusive of WOTS key step).
+ * Used to detect "VP is still processing" errors.
  */
-export const PRE_DEPOSITOR_SIGNATURES_STATES = [
+export const PRE_DEPOSITOR_SIGNATURES_STATES: readonly DaemonStatus[] = [
   DaemonStatus.PENDING_INGESTION,
+  DaemonStatus.PENDING_DEPOSITOR_WOTS_PK,
   DaemonStatus.PENDING_BABE_SETUP,
   DaemonStatus.PENDING_CHALLENGER_PRESIGNING,
   DaemonStatus.PENDING_PEGIN_SIGS_AVAILABILITY,
-] as const;
+  DaemonStatus.PENDING_PRE_PEGIN_CONFIRMATIONS,
+];
+
+/**
+ * States after PendingDepositorSignatures where the depositor has no action.
+ */
+const POST_PAYOUT_SIGNATURE_STATUSES: readonly DaemonStatus[] = [
+  DaemonStatus.PENDING_ACKS,
+  DaemonStatus.PENDING_ACTIVATION,
+  DaemonStatus.ACTIVATED,
+];
+
+/**
+ * Statuses where no depositor action is needed — VP is still processing
+ * or has already moved past depositor interaction. Excludes PENDING_INGESTION
+ * (handled separately as "not found yet") and PENDING_DEPOSITOR_WOTS_PK
+ * (needs WOTS key submission).
+ *
+ * Used by the polling hook to decide whether to continue polling silently.
+ */
+export const VP_TRANSIENT_STATUSES: ReadonlySet<DaemonStatus> = new Set([
+  DaemonStatus.PENDING_BABE_SETUP,
+  DaemonStatus.PENDING_CHALLENGER_PRESIGNING,
+  DaemonStatus.PENDING_PEGIN_SIGS_AVAILABILITY,
+  DaemonStatus.PENDING_PRE_PEGIN_CONFIRMATIONS,
+  ...POST_PAYOUT_SIGNATURE_STATUSES,
+]);
+
+/**
+ * Statuses that come after WOTS key submission.
+ * If the VP is already in one of these states, the WOTS key was already
+ * submitted (e.g. via resume flow) and we can skip.
+ *
+ * = VP_TRANSIENT_STATUSES + PENDING_DEPOSITOR_SIGNATURES
+ */
+export const POST_WOTS_STATUSES: ReadonlySet<DaemonStatus> = new Set([
+  ...VP_TRANSIENT_STATUSES,
+  DaemonStatus.PENDING_DEPOSITOR_SIGNATURES,
+]);
 
 /**
  * Check if an error indicates the vault provider is still processing

--- a/services/vault/src/services/vault/vaultPeginStatusService.ts
+++ b/services/vault/src/services/vault/vaultPeginStatusService.ts
@@ -23,7 +23,7 @@ export interface WaitForPeginStatusParams {
   /** Raw BTC pegin transaction hash (with or without 0x prefix) */
   peginTxHash: string;
   /** Set of acceptable statuses — polling stops when the VP reports one of these */
-  targetStatuses: Set<string>;
+  targetStatuses: ReadonlySet<string>;
   /** Maximum time to wait in milliseconds */
   timeoutMs: number;
   /** Polling interval in milliseconds (default: 10s) */

--- a/services/vault/src/utils/btc/btcUtils.ts
+++ b/services/vault/src/utils/btc/btcUtils.ts
@@ -8,7 +8,6 @@ import type {
   BitcoinWallet,
   SignPsbtOptions,
 } from "@babylonlabs-io/ts-sdk/shared";
-import * as ecc from "@bitcoin-js/tiny-secp256k1-asmjs";
 import * as bitcoin from "bitcoinjs-lib";
 import { Buffer } from "buffer";
 
@@ -123,9 +122,6 @@ export function btcAddressToScriptPubKeyHex(address: string): string {
  * the depositor's registered payout address.
  */
 export function deriveBip86ScriptPubKeyHex(xOnlyPubkeyHex: string): string {
-  // Ensure ECC backend is initialized for p2tr (safe to call multiple times)
-  bitcoin.initEccLib(ecc);
-
   const cleanHex = stripHexPrefix(xOnlyPubkeyHex);
   validateXOnlyPubkey(cleanHex);
   const { network } = getNetworkConfigBTC();

--- a/services/vault/src/utils/errors/formatting.ts
+++ b/services/vault/src/utils/errors/formatting.ts
@@ -111,7 +111,10 @@ export function formatPayoutSignatureError(error: unknown): {
         message: "Please reconnect your Bitcoin wallet to continue.",
       };
     }
-    if (error.message.includes("Vault or pegin transaction not found")) {
+    if (
+      error.message.includes("Vault or pegin transaction not found") ||
+      error.message.includes("not found on-chain")
+    ) {
       return {
         title: "Deposit Not Found",
         message:
@@ -132,6 +135,15 @@ export function formatPayoutSignatureError(error: unknown): {
           "Failed to sign payout transactions. Please try again or reconnect your wallet.",
       };
     }
+    // Contract call errors (viem) — surface a meaningful message instead of swallowing
+    if (error.message.includes("reverted")) {
+      return {
+        title: "Contract Call Failed",
+        message:
+          "A contract call failed during payout signing. The on-chain vault data may be unavailable. Please try again or contact support.",
+      };
+    }
+
     return {
       title: "Payout Signing Error",
       message:


### PR DESCRIPTION
- Add `PendingPrePegInConfirmations` daemon status to match btc-vault's new state between `PendingPeginSigsAvailability` and `PendingDepositorSignatures` (decouples depositor UX from BTC confirmation waiting)
- Extend `PresigningProgress` with Phase 2/3 fields: `depositor_graph_created`, `vk_challenger_presigning_completed`, `vk_challenger_presigning_total`
- Add `vault_id` as alternative to `pegin_txid` in `GetPeginStatusParams` (modeled as discriminated union)
- Add runtime validation for new presigning progress fields in VP response validator
- Consolidate duplicate daemon status sets (`TRANSIENT_STATUSES`, `POST_WOTS_STATUSES`) into shared exports from `peginStateMachine.ts`
- Add missing `PendingDepositorWotsPK` to `PRE_DEPOSITOR_SIGNATURES_STATES`
- Widen `WaitForPeginStatusParams.targetStatuses` to `ReadonlySet`