### PR TITLE
fix(ts-sdk): harden payout PSBT signature extraction

### DIFF
--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/payout.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/payout.test.ts
@@ -32,6 +32,58 @@ import {
 import { TEST_KEYS, initializeWasmForTests } from "./helpers";
 
 /**
+ * Encodes a non-negative integer as a Bitcoin compact-size varint.
+ * Matches the subset of varints supported by parseWitnessStack.
+ */
+function encodeVarInt(n: number): Buffer {
+  if (n < 0xfd) return Buffer.from([n]);
+  if (n <= 0xffff) {
+    const buf = Buffer.alloc(3);
+    buf[0] = 0xfd;
+    buf.writeUInt16LE(n, 1);
+    return buf;
+  }
+  if (n <= 0xffffffff) {
+    const buf = Buffer.alloc(5);
+    buf[0] = 0xfe;
+    buf.writeUInt32LE(n, 1);
+    return buf;
+  }
+  throw new Error(`varint too large for witness test helper: ${n}`);
+}
+
+/**
+ * Serializes a witness stack in BIP-141 format:
+ *   [varint item_count] [varint len, data]...
+ */
+function serializeWitnessStack(items: Buffer[]): Buffer {
+  const parts: Buffer[] = [encodeVarInt(items.length)];
+  for (const item of items) {
+    parts.push(encodeVarInt(item.length));
+    parts.push(item);
+  }
+  return Buffer.concat(parts);
+}
+
+/**
+ * Builds a PSBT with a single input that already carries a finalScriptWitness,
+ * simulating a wallet that auto-finalized the signed PSBT.
+ */
+function makeFinalizedPayoutPsbtHex(finalScriptWitness: Buffer): string {
+  const psbt = new Psbt();
+  psbt.addInput({
+    hash: NULL_TXID,
+    index: 0,
+    witnessUtxo: {
+      script: createDummyP2WPKH("0"),
+      value: TEST_WITNESS_UTXO_VALUE,
+    },
+    finalScriptWitness,
+  });
+  return psbt.toHex();
+}
+
+/**
  * Creates a test pegin transaction with a single P2TR output (simplified for testing).
  */
 function createTestPeginTransaction(): string {
@@ -493,6 +545,126 @@ describe("extractPayoutSignature", () => {
       expect(() =>
         extractPayoutSignature(psbtHex, TEST_KEYS.DEPOSITOR),
       ).toThrow(/Unexpected sighash type 0x83 at input 0\. Expected SIGHASH_ALL/);
+    });
+  });
+
+  describe("Signature extraction from finalized PSBT", () => {
+    it("extracts 64-byte signature from finalized witness [sig, script, controlBlock]", () => {
+      const signature = Buffer.alloc(64, 0xaa);
+      const script = Buffer.alloc(34, 0xbb);
+      const controlBlock = Buffer.alloc(33, 0xcc);
+      const finalScriptWitness = serializeWitnessStack([
+        signature,
+        script,
+        controlBlock,
+      ]);
+      const psbtHex = makeFinalizedPayoutPsbtHex(finalScriptWitness);
+
+      const extracted = extractPayoutSignature(psbtHex, TEST_KEYS.DEPOSITOR);
+
+      expect(extracted).toBe(signature.toString("hex"));
+      expect(extracted.length).toBe(128);
+    });
+
+    it("strips SIGHASH_ALL flag from 65-byte signature in finalized witness", () => {
+      const signature = Buffer.alloc(65);
+      signature.fill(0xdd, 0, 64);
+      signature[64] = Transaction.SIGHASH_ALL;
+      const script = Buffer.alloc(34, 0xee);
+      const controlBlock = Buffer.alloc(33, 0xff);
+      const finalScriptWitness = serializeWitnessStack([
+        signature,
+        script,
+        controlBlock,
+      ]);
+      const psbtHex = makeFinalizedPayoutPsbtHex(finalScriptWitness);
+
+      const extracted = extractPayoutSignature(psbtHex, TEST_KEYS.DEPOSITOR);
+
+      expect(extracted).toBe(Buffer.alloc(64, 0xdd).toString("hex"));
+    });
+
+    it("rejects finalized witness with fewer than 3 items", () => {
+      const signature = Buffer.alloc(64, 0xaa);
+      const finalScriptWitness = serializeWitnessStack([signature]);
+      const psbtHex = makeFinalizedPayoutPsbtHex(finalScriptWitness);
+
+      expect(() =>
+        extractPayoutSignature(psbtHex, TEST_KEYS.DEPOSITOR),
+      ).toThrow(/expected 3 items.*got 1/);
+    });
+
+    it("rejects finalized witness with more than 3 items (multisig or annex)", () => {
+      const sig1 = Buffer.alloc(64, 0xaa);
+      const sig2 = Buffer.alloc(64, 0xbb);
+      const script = Buffer.alloc(34, 0xcc);
+      const controlBlock = Buffer.alloc(33, 0xdd);
+      const finalScriptWitness = serializeWitnessStack([
+        sig1,
+        sig2,
+        script,
+        controlBlock,
+      ]);
+      const psbtHex = makeFinalizedPayoutPsbtHex(finalScriptWitness);
+
+      expect(() =>
+        extractPayoutSignature(psbtHex, TEST_KEYS.DEPOSITOR),
+      ).toThrow(/expected 3 items.*got 4/);
+    });
+
+    it("rejects finalized witness whose first item is not a valid Schnorr signature length", () => {
+      const invalidSig = Buffer.alloc(32, 0xaa);
+      const script = Buffer.alloc(34, 0xbb);
+      const controlBlock = Buffer.alloc(33, 0xcc);
+      const finalScriptWitness = serializeWitnessStack([
+        invalidSig,
+        script,
+        controlBlock,
+      ]);
+      const psbtHex = makeFinalizedPayoutPsbtHex(finalScriptWitness);
+
+      expect(() =>
+        extractPayoutSignature(psbtHex, TEST_KEYS.DEPOSITOR),
+      ).toThrow(/Unexpected signature length at input 0/);
+    });
+
+    it("rejects malformed finalized witness that is truncated", () => {
+      // Claims 1 item of length 64 but provides only 10 bytes of payload.
+      const truncated = Buffer.concat([
+        Buffer.from([0x01, 0x40]),
+        Buffer.alloc(10, 0),
+      ]);
+      const psbtHex = makeFinalizedPayoutPsbtHex(truncated);
+
+      expect(() =>
+        extractPayoutSignature(psbtHex, TEST_KEYS.DEPOSITOR),
+      ).toThrow(/Malformed witness data/);
+    });
+
+    it("rejects finalized witness with an 8-byte (0xff) varint", () => {
+      // 0xff marks an 8-byte varint which is not used for witness item counts
+      // and cannot be represented losslessly as a JS number.
+      const malformed = Buffer.from([0xff, 0, 0, 0, 0, 0, 0, 0, 0]);
+      const psbtHex = makeFinalizedPayoutPsbtHex(malformed);
+
+      expect(() =>
+        extractPayoutSignature(psbtHex, TEST_KEYS.DEPOSITOR),
+      ).toThrow(/8-byte varint \(0xff\) not supported/);
+    });
+
+    it("rejects finalized witness with trailing bytes after the parsed stack", () => {
+      const signature = Buffer.alloc(64, 0xaa);
+      const script = Buffer.alloc(34, 0xbb);
+      const controlBlock = Buffer.alloc(33, 0xcc);
+      const withTrailing = Buffer.concat([
+        serializeWitnessStack([signature, script, controlBlock]),
+        Buffer.from([0xde, 0xad, 0xbe, 0xef]),
+      ]);
+      const psbtHex = makeFinalizedPayoutPsbtHex(withTrailing);
+
+      expect(() =>
+        extractPayoutSignature(psbtHex, TEST_KEYS.DEPOSITOR),
+      ).toThrow(/trailing byte/);
     });
   });
 });

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts
@@ -25,6 +25,17 @@ import {
 } from "../utils/bitcoin";
 
 /**
+ * Number of items in a Taproot script-path spend witness stack for a
+ * single-signature script: [signature, script, controlBlock].
+ *
+ * The current payout script requires exactly one depositor signature. If the
+ * protocol evolves to require multiple signatures in the payout script, this
+ * invariant and the finalized-PSBT extraction path must be revisited because
+ * the first witness item would no longer necessarily be the depositor's.
+ */
+const TAPROOT_SINGLE_SIG_WITNESS_STACK_SIZE = 3;
+
+/**
  * Parameters for building an unsigned Payout PSBT
  *
  * Payout is used in the challenge path after Assert, when the claimer proves validity.
@@ -297,12 +308,21 @@ export function extractPayoutSignature(
   }
 
   // Case 2: Finalized PSBT — extract from finalScriptWitness
-  // Taproot script-path witness: [signature, script, controlBlock]
+  // Taproot single-signature script-path witness: [signature, script, controlBlock].
+  // Enforce the exact stack size so that if a wallet produces an unexpected
+  // finalization (e.g. a multi-signature stack, an annex, or malformed data),
+  // we fail loudly instead of silently returning witnessStack[0] which may
+  // not be the depositor's signature.
   if (input.finalScriptWitness && input.finalScriptWitness.length > 0) {
     const witnessStack = parseWitnessStack(input.finalScriptWitness);
-    if (witnessStack.length >= 1) {
-      return extractSchnorrSig(witnessStack[0], inputIndex);
+    if (witnessStack.length !== TAPROOT_SINGLE_SIG_WITNESS_STACK_SIZE) {
+      throw new Error(
+        `Unexpected finalized witness stack size at input ${inputIndex}: ` +
+          `expected ${TAPROOT_SINGLE_SIG_WITNESS_STACK_SIZE} items (signature, script, controlBlock), ` +
+          `got ${witnessStack.length}`,
+      );
     }
+    return extractSchnorrSig(witnessStack[0], inputIndex);
   }
 
   throw new Error(
@@ -336,39 +356,64 @@ function extractSchnorrSig(sig: Uint8Array, inputIndex: number): string {
 /**
  * Parse a BIP-141 serialized witness stack into individual stack items.
  * Format: [varint item_count] [varint len, data]...
+ *
+ * Throws on malformed input (truncated buffer, 8-byte varints, or trailing
+ * bytes) so callers never receive silently-corrupted witness items.
  * @internal
  */
 function parseWitnessStack(witness: Buffer): Buffer[] {
   const items: Buffer[] = [];
   let offset = 0;
 
+  const requireBytes = (n: number): void => {
+    if (offset + n > witness.length) {
+      throw new Error(
+        `Malformed witness data: need ${n} byte(s) at offset ${offset}, only ${witness.length - offset} remaining`,
+      );
+    }
+  };
+
   const readVarInt = (): number => {
+    requireBytes(1);
     const first = witness[offset++];
     if (first < 0xfd) return first;
     if (first === 0xfd) {
-      const val = witness[offset] | (witness[offset + 1] << 8);
+      requireBytes(2);
+      const val = (witness[offset] | (witness[offset + 1] << 8)) >>> 0;
       offset += 2;
       return val;
     }
     if (first === 0xfe) {
+      requireBytes(4);
       const val =
-        witness[offset] |
-        (witness[offset + 1] << 8) |
-        (witness[offset + 2] << 16) |
-        (witness[offset + 3] << 24);
+        (witness[offset] |
+          (witness[offset + 1] << 8) |
+          (witness[offset + 2] << 16) |
+          (witness[offset + 3] << 24)) >>>
+        0;
       offset += 4;
       return val;
     }
-    // 0xff — 8-byte, won't happen for witness data
-    offset += 8;
-    return 0;
+    // 0xff — 8-byte varint. Not used for witness sizes in practice and JS
+    // numbers cannot represent all 64-bit values exactly, so reject rather
+    // than risk silent truncation.
+    throw new Error(
+      `Malformed witness data: 8-byte varint (0xff) not supported at offset ${offset - 1}`,
+    );
   };
 
   const count = readVarInt();
   for (let i = 0; i < count; i++) {
     const len = readVarInt();
-    items.push(witness.subarray(offset, offset + len) as Buffer);
+    requireBytes(len);
+    items.push(Buffer.from(witness.subarray(offset, offset + len)));
     offset += len;
+  }
+
+  if (offset !== witness.length) {
+    throw new Error(
+      `Malformed witness data: ${witness.length - offset} trailing byte(s) after parsing ${count} item(s)`,
+    );
   }
 
   return items;


### PR DESCRIPTION
## Summary
- Enforce exact Taproot single-sig witness stack size (3 items: signature, script, controlBlock) in `extractPayoutSignature` so unexpected wallet finalizations fail loudly instead of silently returning a potentially-wrong signature.
- Make `parseWitnessStack` reject malformed witness data: require enough bytes before reads, fix a missing `>>> 0` on the 4-byte varint path, throw on unsupported 8-byte varints, and reject trailing bytes.
- Add tests covering the new invariants.

## Test plan
- [x] `pnpm --filter @babylonlabs-io/ts-sdk run test`
- [x] `pnpm run lint`