### PR TITLE
fix(vault): harden pending pegin localStorage validation

### DIFF
--- a/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/__tests__/reservation.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/__tests__/reservation.test.ts
@@ -1,6 +1,6 @@
 /** Tests for UTXO reservation utilities. */
 
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ContractStatus } from "../../../services/deposit/peginState";
 import {
@@ -26,33 +26,23 @@ function hasRef(refs: UtxoRef[], txid: string, vout: number): boolean {
   );
 }
 
+// Representative 32-byte txids as lowercase hex. Real Bitcoin txids are always
+// 64 hex chars; validators at the source boundary reject anything else.
+const TXID_A = "a".repeat(64);
+const TXID_B = "b".repeat(64);
+
 describe("UTXO Reservation", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
   describe("collectReservedUtxoRefs", () => {
-    const mockPendingPegin: PendingPeginLike = {
-      selectedUTXOs: [
-        { txid: "txid1", vout: 0 },
-        { txid: "txid2", vout: 1 },
-      ],
-    };
-
-    // Valid transaction hex for testing unsignedTxHex parsing
-    const VALID_TX_FOR_PENDING =
-      "0100000001" +
-      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" + // prev txid (LE)
-      "03000000" + // prev vout = 3
-      "6b" +
-      "483045022100884d142d86652a3f47ba4746ec719bbfbd040a570b1deccbb6498c75c4ae24cb02204b9f039ff08df09cbe9f6addac960298cad530a863ea8f53982c09db8f6e381301210484ecc0d46f1918b30928fa0e4ed99f16a0fb4fde0735e7ade8416ab9fe423cc5" +
-      "ffffffff" +
-      "01" +
-      "605af40500000000" +
-      "19" +
-      "76a914887c6824d03eb8997b1e28c1d81b4e5c8c96d41688ac" +
-      "00000000";
-
-    const mockPendingPeginWithTxHex: PendingPeginLike = {
-      unsignedTxHex: VALID_TX_FOR_PENDING,
-    };
-
     // Helper to create a valid transaction hex with a specific prev txid
     const createValidTxHex = (prevTxidLE: string, prevVout: number): string => {
       const voutHex = prevVout.toString(16).padStart(8, "0");
@@ -76,39 +66,64 @@ describe("UTXO Reservation", () => {
       );
     };
 
+    // Valid transaction hex that spends a single input at `TXID_A:3`.
+    const VALID_TX_PENDING_TXID_A =
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const VALID_TX_FOR_PENDING = createValidTxHex(VALID_TX_PENDING_TXID_A, 3);
+
+    const mockPendingPegin: PendingPeginLike = {
+      id: "0x1234",
+      unsignedTxHex: VALID_TX_FOR_PENDING,
+      // Present but ignored by `collectReservedUtxoRefs`; refs come from the
+      // transaction hex to avoid trusting a tamperable sidecar.
+      selectedUTXOs: [
+        {
+          txid: VALID_TX_PENDING_TXID_A,
+          vout: 3,
+        },
+      ],
+    };
+
     const createMockVault = (
       status: ContractStatus,
       unsignedPrePeginTx: string,
+      id?: string,
     ): VaultLike => ({
+      id,
       status,
       unsignedPrePeginTx,
     });
 
-    it("should collect refs from selectedUTXOs", () => {
+    it("should collect refs from the pending pegin's unsignedTxHex", () => {
       const reserved = collectReservedUtxoRefs({
         pendingPegins: [mockPendingPegin],
         vaults: [],
       });
 
-      expect(reserved).toHaveLength(2);
-      expect(hasRef(reserved, "txid1", 0)).toBe(true);
-      expect(hasRef(reserved, "txid2", 1)).toBe(true);
+      expect(reserved).toHaveLength(1);
+      expect(hasRef(reserved, VALID_TX_PENDING_TXID_A, 3)).toBe(true);
     });
 
-    it("should fall back to parsing unsignedTxHex when selectedUTXOs absent", () => {
+    it("ignores selectedUTXOs even when they would add extra refs", () => {
+      // The sidecar claims two UTXOs but the transaction only has one.
+      // collectReservedUtxoRefs must trust the transaction, not the sidecar.
+      const pegin: PendingPeginLike = {
+        ...mockPendingPegin,
+        selectedUTXOs: [
+          { txid: TXID_A, vout: 0 },
+          { txid: TXID_B, vout: 1 },
+        ],
+      };
+
       const reserved = collectReservedUtxoRefs({
-        pendingPegins: [mockPendingPeginWithTxHex],
+        pendingPegins: [pegin],
         vaults: [],
       });
 
       expect(reserved).toHaveLength(1);
-      expect(
-        hasRef(
-          reserved,
-          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-          3,
-        ),
-      ).toBe(true);
+      expect(hasRef(reserved, VALID_TX_PENDING_TXID_A, 3)).toBe(true);
+      expect(hasRef(reserved, TXID_A, 0)).toBe(false);
+      expect(hasRef(reserved, TXID_B, 1)).toBe(false);
     });
 
     it("should include refs from PENDING vaults", () => {
@@ -275,9 +290,8 @@ describe("UTXO Reservation", () => {
         vaults: [pendingVault],
       });
 
-      expect(reserved).toHaveLength(3); // 2 from pending + 1 from vault
-      expect(hasRef(reserved, "txid1", 0)).toBe(true);
-      expect(hasRef(reserved, "txid2", 1)).toBe(true);
+      expect(reserved).toHaveLength(2); // 1 from pending tx + 1 from vault
+      expect(hasRef(reserved, VALID_TX_PENDING_TXID_A, 3)).toBe(true);
       expect(
         hasRef(
           reserved,
@@ -300,6 +314,72 @@ describe("UTXO Reservation", () => {
       const reserved = collectReservedUtxoRefs({});
 
       expect(reserved).toHaveLength(0);
+    });
+
+    it("ignores pending-pegin refs when the pegin is already indexed on-chain", () => {
+      const ON_CHAIN_TXID =
+        "1111111111111111111111111111111111111111111111111111111111111111";
+      const sharedVaultId = "0xshared";
+      const onChainVault = createMockVault(
+        ContractStatus.PENDING,
+        createValidTxHex(ON_CHAIN_TXID, 0),
+        sharedVaultId,
+      );
+      const tamperedPending: PendingPeginLike = {
+        ...mockPendingPegin,
+        id: sharedVaultId,
+        unsignedTxHex: createValidTxHex("f".repeat(64), 99),
+      };
+
+      const reserved = collectReservedUtxoRefs({
+        pendingPegins: [tamperedPending],
+        vaults: [onChainVault],
+      });
+
+      expect(reserved).toHaveLength(1);
+      expect(hasRef(reserved, ON_CHAIN_TXID, 0)).toBe(true);
+      expect(hasRef(reserved, "f".repeat(64), 99)).toBe(false);
+    });
+
+    it("ignores pending-pegin refs even when matching vault has non-reserving status", () => {
+      // Pegin is on-chain but ACTIVE: the vault branch adds no refs (UTXO is
+      // spent), and the pending-pegin copy is skipped to avoid resurrecting
+      // stale/tampered refs after the real spend.
+      const sharedVaultId = "0xactiveshared";
+      const activeVault = createMockVault(
+        ContractStatus.ACTIVE,
+        createValidTxHex("c".repeat(64), 0),
+        sharedVaultId,
+      );
+      const pendingCopy: PendingPeginLike = {
+        ...mockPendingPegin,
+        id: sharedVaultId,
+      };
+
+      const reserved = collectReservedUtxoRefs({
+        pendingPegins: [pendingCopy],
+        vaults: [activeVault],
+      });
+
+      expect(reserved).toHaveLength(0);
+    });
+
+    it("logs and yields no refs when unsignedTxHex fails to parse", () => {
+      const tamperedPending: PendingPeginLike = {
+        id: "0xbadhex",
+        unsignedTxHex: "deadbeef", // parseable hex but not a valid transaction
+      };
+
+      const reserved = collectReservedUtxoRefs({
+        pendingPegins: [tamperedPending],
+        vaults: [],
+      });
+
+      expect(reserved).toHaveLength(0);
+      expect(warnSpy).toHaveBeenCalledWith(
+        "[utxoReservation] Failed to parse transaction hex; skipping inputs",
+        expect.objectContaining({ category: "utxoReservation" }),
+      );
     });
   });
 

--- a/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts
@@ -29,12 +29,23 @@ export interface UtxoRef {
 
 /** Narrow structural type for pending pegin data. */
 export interface PendingPeginLike {
+  /**
+   * Optional vault id. When present, used to skip pending pegins that are
+   * already indexed on-chain so the canonical vault copy wins over a
+   * tamperable off-chain entry.
+   */
+  id?: string;
   selectedUTXOs?: Array<{ txid: string; vout: number }>;
   unsignedTxHex?: string;
 }
 
 /** Narrow structural type for vault data. */
 export interface VaultLike {
+  /**
+   * Optional vault id. When present, enables on-chain correlation with
+   * pending pegins sharing the same id.
+   */
+  id?: string;
   status: number;
   unsignedPrePeginTx: string;
 }
@@ -61,7 +72,14 @@ export interface CollectReservedUtxoRefsParams {
 // Internal Helpers
 // ============================================================================
 
-/** Parse a transaction hex and return the UTXO references of all inputs. */
+/**
+ * Parse a transaction hex and return the UTXO references of all inputs.
+ *
+ * Parse failures are logged and yield no refs. A malformed hex from an
+ * untrusted source (e.g. off-chain storage) must not silently collapse the
+ * reservation set — logging makes tampering visible in telemetry instead
+ * of swallowing the error.
+ */
 function extractInputUtxoRefs(txHex: string): UtxoRef[] {
   try {
     const tx = Transaction.fromHex(stripHexPrefix(txHex));
@@ -69,7 +87,14 @@ function extractInputUtxoRefs(txHex: string): UtxoRef[] {
       const txid = Buffer.from(input.hash).reverse().toString("hex");
       return { txid, vout: input.index };
     });
-  } catch {
+  } catch (error) {
+    console.warn(
+      "[utxoReservation] Failed to parse transaction hex; skipping inputs",
+      {
+        category: "utxoReservation",
+        error: error instanceof Error ? error.message : String(error),
+      },
+    );
     return [];
   }
 }
@@ -117,7 +142,22 @@ function estimateMinimumFeeBuffer(feeRate: number): bigint {
 // ============================================================================
 
 /**
- * Collect UTXO refs from in-flight deposits (PENDING/VERIFIED vaults and pending pegins).
+ * Collect UTXO refs from in-flight deposits (PENDING/VERIFIED vaults and
+ * pending pegins).
+ *
+ * On-chain vault data is canonical: for any pending pegin whose `id` matches
+ * an indexed on-chain vault, the pending-pegin copy is ignored entirely —
+ * the `vaults` branch below extracts refs from the indexer-supplied
+ * `unsignedPrePeginTx` so tampered off-chain data cannot poison the
+ * reservation set once the vault is indexed.
+ *
+ * For pegins not yet indexed, refs are derived from the stored
+ * `unsignedTxHex` only. The `selectedUTXOs` sidecar is NOT used for
+ * reservation: if it disagreed with the transaction's inputs (e.g. because
+ * the off-chain source was tampered), trusting it would poison the reserved
+ * set. The transaction hex must be validated at the source boundary before
+ * being handed to this function; parsing and using its inputs is the single
+ * source of truth here.
  */
 export function collectReservedUtxoRefs(
   params: CollectReservedUtxoRefsParams,
@@ -125,18 +165,21 @@ export function collectReservedUtxoRefs(
   const reserved: UtxoRef[] = [];
   const { vaults = [], pendingPegins = [] } = params;
 
-  // Collect from pending pegins
+  const onChainVaultIds = new Set(
+    vaults
+      .map((v) => v.id?.toLowerCase())
+      .filter((id): id is string => id !== undefined),
+  );
+
   for (const pending of pendingPegins) {
-    if (pending.selectedUTXOs && pending.selectedUTXOs.length > 0) {
-      for (const utxo of pending.selectedUTXOs) {
-        reserved.push({ txid: utxo.txid, vout: utxo.vout });
-      }
-    } else if (pending.unsignedTxHex) {
+    if (pending.id && onChainVaultIds.has(pending.id.toLowerCase())) {
+      continue;
+    }
+    if (pending.unsignedTxHex) {
       reserved.push(...extractInputUtxoRefs(pending.unsignedTxHex));
     }
   }
 
-  // Collect from PENDING/VERIFIED vaults
   for (const vault of vaults) {
     if (
       vault.status !== ContractStatus.PENDING &&

--- a/services/vault/src/storage/__tests__/peginStorage.test.ts
+++ b/services/vault/src/storage/__tests__/peginStorage.test.ts
@@ -1,0 +1,331 @@
+/** Tests for pending peg-in localStorage integrity validation. */
+
+import type { Hex } from "viem";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { logger } from "@/infrastructure";
+
+import { STORAGE_KEY_PREFIX } from "../../constants";
+import { LocalStorageStatus } from "../../models/peginStateMachine";
+import { getPendingPegins, type PendingPeginRequest } from "../peginStorage";
+
+vi.mock("@/infrastructure", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    event: vi.fn(),
+  },
+}));
+
+const ETH_ADDRESS = "0x1234567890abcdef1234567890abcdef12345678";
+const storageKey = `${STORAGE_KEY_PREFIX}-${ETH_ADDRESS}`;
+
+const VALID_TXID_A = "a".repeat(64);
+const VALID_TXID_B = "b".repeat(64);
+// 32-byte hashes — vault id and pegin tx hash are both keccak/sha256 outputs.
+const VALID_VAULT_ID: Hex = `0x${"1".repeat(64)}`;
+const VALID_VAULT_ID_2: Hex = `0x${"2".repeat(64)}`;
+const VALID_PEGIN_TXHASH: Hex = `0x${"3".repeat(64)}`;
+
+const validPegin: PendingPeginRequest = {
+  id: VALID_VAULT_ID,
+  peginTxHash: VALID_PEGIN_TXHASH,
+  timestamp: 1700000000000,
+  status: LocalStorageStatus.PENDING,
+  unsignedTxHex: "0xdeadbeef",
+  selectedUTXOs: [
+    {
+      txid: VALID_TXID_A,
+      vout: 0,
+      value: "50000",
+      scriptPubKey: "deadbeef",
+    },
+  ],
+};
+
+describe("getPendingPegins integrity validation", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  it("returns entries whose security-critical fields pass validation", () => {
+    localStorage.setItem(storageKey, JSON.stringify([validPegin]));
+
+    const result = getPendingPegins(ETH_ADDRESS);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe(VALID_VAULT_ID);
+  });
+
+  it("accepts empty unsignedTxHex (cross-device resume flow)", () => {
+    const crossDevice: PendingPeginRequest = {
+      ...validPegin,
+      unsignedTxHex: "",
+    };
+    localStorage.setItem(storageKey, JSON.stringify([crossDevice]));
+
+    const result = getPendingPegins(ETH_ADDRESS);
+
+    expect(result).toHaveLength(1);
+  });
+
+  it("filters out entries whose unsignedTxHex contains non-hex characters", async () => {
+    const { logger } = await import("@/infrastructure");
+    const tampered = { ...validPegin, unsignedTxHex: "NOT_HEX!!!" };
+    localStorage.setItem(
+      storageKey,
+      JSON.stringify([tampered, { ...validPegin, id: VALID_VAULT_ID_2 }]),
+    );
+
+    const result = getPendingPegins(ETH_ADDRESS);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe(VALID_VAULT_ID_2);
+    expect(logger.warn).toHaveBeenCalledWith(
+      "[peginStorage] Skipping corrupted pending pegin entry",
+      expect.objectContaining({
+        category: "peginStorage",
+        vaultId: VALID_VAULT_ID,
+      }),
+    );
+  });
+
+  it("filters out entries whose unsignedTxHex has an odd byte count", () => {
+    const tampered = { ...validPegin, unsignedTxHex: "0xabc" }; // 3 hex chars
+    localStorage.setItem(storageKey, JSON.stringify([tampered]));
+
+    expect(getPendingPegins(ETH_ADDRESS)).toHaveLength(0);
+  });
+
+  it("filters entries whose selectedUTXOs has a non-hex txid", () => {
+    const tampered: PendingPeginRequest = {
+      ...validPegin,
+      selectedUTXOs: [
+        {
+          txid: "not-hex",
+          vout: 0,
+          value: "50000",
+          scriptPubKey: "deadbeef",
+        },
+      ],
+    };
+    localStorage.setItem(storageKey, JSON.stringify([tampered]));
+
+    expect(getPendingPegins(ETH_ADDRESS)).toHaveLength(0);
+  });
+
+  it("filters entries whose selectedUTXOs has negative vout", () => {
+    const tampered: PendingPeginRequest = {
+      ...validPegin,
+      selectedUTXOs: [
+        {
+          txid: VALID_TXID_A,
+          vout: -1,
+          value: "50000",
+          scriptPubKey: "deadbeef",
+        },
+      ],
+    };
+    localStorage.setItem(storageKey, JSON.stringify([tampered]));
+
+    expect(getPendingPegins(ETH_ADDRESS)).toHaveLength(0);
+  });
+
+  it("filters entries whose selectedUTXOs has non-integer value", () => {
+    const tampered: PendingPeginRequest = {
+      ...validPegin,
+      selectedUTXOs: [
+        {
+          txid: VALID_TXID_A,
+          vout: 0,
+          value: "not-a-number",
+          scriptPubKey: "deadbeef",
+        },
+      ],
+    };
+    localStorage.setItem(storageKey, JSON.stringify([tampered]));
+
+    expect(getPendingPegins(ETH_ADDRESS)).toHaveLength(0);
+  });
+
+  it("filters entries whose selectedUTXOs value exceeds safe integer range", () => {
+    const tampered: PendingPeginRequest = {
+      ...validPegin,
+      selectedUTXOs: [
+        {
+          txid: VALID_TXID_A,
+          vout: 0,
+          value: "99999999999999999999", // exceeds Number.MAX_SAFE_INTEGER
+          scriptPubKey: "deadbeef",
+        },
+      ],
+    };
+    localStorage.setItem(storageKey, JSON.stringify([tampered]));
+
+    expect(getPendingPegins(ETH_ADDRESS)).toHaveLength(0);
+  });
+
+  it("filters entries whose selectedUTXOs scriptPubKey is non-hex", () => {
+    const tampered: PendingPeginRequest = {
+      ...validPegin,
+      selectedUTXOs: [
+        {
+          txid: VALID_TXID_A,
+          vout: 0,
+          value: "50000",
+          scriptPubKey: "plain-text",
+        },
+      ],
+    };
+    localStorage.setItem(storageKey, JSON.stringify([tampered]));
+
+    expect(getPendingPegins(ETH_ADDRESS)).toHaveLength(0);
+  });
+
+  it("keeps valid entries alongside filtered tampered ones", () => {
+    const tampered = { ...validPegin, id: "0xbad", unsignedTxHex: "xyz" };
+    const good: PendingPeginRequest = {
+      ...validPegin,
+      id: VALID_VAULT_ID_2,
+      selectedUTXOs: [
+        {
+          txid: VALID_TXID_B,
+          vout: 3,
+          value: "12345",
+          scriptPubKey: "ab",
+        },
+      ],
+    };
+    localStorage.setItem(storageKey, JSON.stringify([tampered, good]));
+
+    const result = getPendingPegins(ETH_ADDRESS);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe(VALID_VAULT_ID_2);
+  });
+
+  it("filters entries whose id is a non-string (DoS protection)", () => {
+    // A non-string id would throw in normalizeTransactionId, fall into the
+    // outer catch block, and wipe the entire storage key. This test guards
+    // against that DoS path by forcing the validator to reject early.
+    const tampered = { ...validPegin, id: 42 as unknown as string };
+    const good = { ...validPegin, id: VALID_VAULT_ID_2 };
+    localStorage.setItem(storageKey, JSON.stringify([tampered, good]));
+
+    const result = getPendingPegins(ETH_ADDRESS);
+
+    // The tampered entry is filtered, the good entry survives. Critically,
+    // the storage key is NOT removed.
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe(VALID_VAULT_ID_2);
+    expect(localStorage.getItem(storageKey)).not.toBeNull();
+  });
+
+  it("filters entries whose id contains non-hex characters", () => {
+    const tampered = {
+      ...validPegin,
+      id: "0x" + "Z".repeat(64),
+    };
+    localStorage.setItem(storageKey, JSON.stringify([tampered]));
+
+    expect(getPendingPegins(ETH_ADDRESS)).toHaveLength(0);
+  });
+
+  it("filters entries whose id is shorter than 32 bytes", () => {
+    const tampered = { ...validPegin, id: "0x" + "1".repeat(40) };
+    localStorage.setItem(storageKey, JSON.stringify([tampered]));
+
+    expect(getPendingPegins(ETH_ADDRESS)).toHaveLength(0);
+  });
+
+  it("filters entries whose peginTxHash is shorter than 32 bytes", () => {
+    const tampered = {
+      ...validPegin,
+      peginTxHash: "0x" + "3".repeat(40),
+    };
+    localStorage.setItem(storageKey, JSON.stringify([tampered]));
+
+    expect(getPendingPegins(ETH_ADDRESS)).toHaveLength(0);
+  });
+
+  it("filters entries whose unsignedTxHex is bare '0x'", () => {
+    const tampered = { ...validPegin, unsignedTxHex: "0x" };
+    localStorage.setItem(storageKey, JSON.stringify([tampered]));
+
+    expect(getPendingPegins(ETH_ADDRESS)).toHaveLength(0);
+  });
+
+  it("filters entries whose scriptPubKey has odd hex length", () => {
+    const tampered: PendingPeginRequest = {
+      ...validPegin,
+      selectedUTXOs: [
+        {
+          txid: VALID_TXID_A,
+          vout: 0,
+          value: "50000",
+          scriptPubKey: "abc", // 3 hex chars — not a valid byte sequence
+        },
+      ],
+    };
+    localStorage.setItem(storageKey, JSON.stringify([tampered]));
+
+    expect(getPendingPegins(ETH_ADDRESS)).toHaveLength(0);
+  });
+
+  it("filters entries whose txid has the wrong length", () => {
+    const tampered: PendingPeginRequest = {
+      ...validPegin,
+      selectedUTXOs: [
+        {
+          txid: "a".repeat(60), // too short
+          vout: 0,
+          value: "50000",
+          scriptPubKey: "deadbeef",
+        },
+      ],
+    };
+    localStorage.setItem(storageKey, JSON.stringify([tampered]));
+
+    expect(getPendingPegins(ETH_ADDRESS)).toHaveLength(0);
+  });
+
+  it("returns empty array when the stored payload is not an array", () => {
+    localStorage.setItem(storageKey, JSON.stringify({ notAnArray: true }));
+
+    const result = getPendingPegins(ETH_ADDRESS);
+
+    expect(result).toEqual([]);
+    // The top-level array check does not trigger logger.error (reserved for
+    // JSON.parse failures). It quietly returns empty.
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it("accepts legacy ids stored without a 0x prefix", () => {
+    // normalizeTransactionId canonicalizes to `0x<hex>` on read. The validator
+    // must allow the legacy form (still 32-byte hex) so pre-existing entries
+    // are not silently dropped.
+    const legacyHex = "1".repeat(64);
+    const legacy = {
+      ...validPegin,
+      id: legacyHex as unknown as PendingPeginRequest["id"],
+    };
+    localStorage.setItem(storageKey, JSON.stringify([legacy]));
+
+    const result = getPendingPegins(ETH_ADDRESS);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe(`0x${legacyHex}`);
+  });
+
+  it("accepts entries without selectedUTXOs field", () => {
+    const pegin: PendingPeginRequest = {
+      ...validPegin,
+      selectedUTXOs: undefined,
+    };
+    localStorage.setItem(storageKey, JSON.stringify([pegin]));
+
+    expect(getPendingPegins(ETH_ADDRESS)).toHaveLength(1);
+  });
+});

--- a/services/vault/src/storage/peginStorage.ts
+++ b/services/vault/src/storage/peginStorage.ts
@@ -49,6 +49,116 @@ export interface PendingPeginRequest {
   batchTotal?: number; // Total vaults in batch (1 or 2)
 }
 
+// Hex with optional 0x prefix and at least one byte (even-length).
+// Matches `0x<even-hex>` or `<even-hex>`; rejects bare `0x` and odd lengths.
+const NON_EMPTY_HEX_RE = /^(0x)?([0-9a-fA-F]{2})+$/;
+// Bitcoin txids are always 32 bytes = exactly 64 hex chars.
+const TXID_HEX_RE = /^[0-9a-fA-F]{64}$/;
+// scriptPubKey is variable-length but must be an even number of hex chars.
+// Intentionally distinct from NON_EMPTY_HEX_RE: raw Bitcoin script is never
+// 0x-prefixed, so the prefix option is disallowed here. Do not "dedupe" these.
+const SCRIPT_PUBKEY_HEX_RE = /^([0-9a-fA-F]{2})+$/;
+// Valid LocalStorageStatus string values. Kept in lock-step with
+// OffChainTrackingStatus in models/peginStateMachine.ts.
+const VALID_LOCAL_STORAGE_STATUSES: ReadonlySet<string> = new Set([
+  "pending",
+  "payout_signed",
+  "confirming",
+  "confirmed",
+]);
+// Vault `id` is keccak256(abi.encode(peginTxHash, depositor)) — always 32 bytes.
+// `peginTxHash` is a Bitcoin tx hash — also 32 bytes. Accept the legacy form
+// without `0x` prefix (normalizeTransactionId canonicalizes downstream).
+const BYTES32_HEX_RE = /^(0x)?[0-9a-fA-F]{64}$/;
+
+/**
+ * Validate the security-critical fields of a pending peg-in read from
+ * localStorage.
+ *
+ * localStorage is an untrusted boundary: entries can be tampered by XSS,
+ * browser extensions, or a user manually editing devtools. Every field used in
+ * a security-relevant code path (UTXO reservation, on-chain vault matching,
+ * PSBT construction, or ID normalization) must pass a strict shape check. A
+ * non-string `id`, for example, would otherwise throw inside
+ * `normalizeTransactionId`, fall into the outer catch block, and wipe the
+ * whole storage key — a DoS from a single tampered entry.
+ */
+function hasValidSecurityFields(entry: unknown): entry is PendingPeginRequest {
+  if (!entry || typeof entry !== "object") return false;
+  const pegin = entry as Record<string, unknown>;
+
+  if (typeof pegin.id !== "string" || !BYTES32_HEX_RE.test(pegin.id)) {
+    return false;
+  }
+  if (
+    typeof pegin.peginTxHash !== "string" ||
+    !BYTES32_HEX_RE.test(pegin.peginTxHash)
+  ) {
+    return false;
+  }
+  if (
+    typeof pegin.timestamp !== "number" ||
+    !Number.isFinite(pegin.timestamp) ||
+    pegin.timestamp < 0
+  ) {
+    return false;
+  }
+
+  // `status` may be missing (legacy entries — line 200 back-fills to PENDING),
+  // but if present it must be one of the known enum string values. A tampered
+  // status (e.g. a number, or a non-enum string) could otherwise slip past
+  // the `pegin.status || ...` fallback and confuse the state machine.
+  if (pegin.status !== undefined) {
+    if (
+      typeof pegin.status !== "string" ||
+      !VALID_LOCAL_STORAGE_STATUSES.has(pegin.status)
+    ) {
+      return false;
+    }
+  }
+
+  if (typeof pegin.unsignedTxHex !== "string") return false;
+  // Empty string is the explicit cross-device "no local data" marker; anything
+  // else must be non-empty, even-length hex bytes (`0x` prefix optional).
+  if (
+    pegin.unsignedTxHex !== "" &&
+    !NON_EMPTY_HEX_RE.test(pegin.unsignedTxHex)
+  ) {
+    return false;
+  }
+
+  if (pegin.selectedUTXOs !== undefined) {
+    if (!Array.isArray(pegin.selectedUTXOs)) return false;
+    for (const candidate of pegin.selectedUTXOs) {
+      if (!candidate || typeof candidate !== "object") return false;
+      const utxo = candidate as Record<string, unknown>;
+      if (typeof utxo.txid !== "string" || !TXID_HEX_RE.test(utxo.txid)) {
+        return false;
+      }
+      if (
+        typeof utxo.vout !== "number" ||
+        !Number.isInteger(utxo.vout) ||
+        utxo.vout < 0
+      ) {
+        return false;
+      }
+      if (typeof utxo.value !== "string") return false;
+      const numValue = Number(utxo.value);
+      // Bitcoin outputs must carry value — a zero-sat UTXO is not a valid
+      // spendable output (dust rules aside, the protocol requires value > 0).
+      if (!Number.isSafeInteger(numValue) || numValue <= 0) return false;
+      if (
+        typeof utxo.scriptPubKey !== "string" ||
+        !SCRIPT_PUBKEY_HEX_RE.test(utxo.scriptPubKey)
+      ) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
 /**
  * Get storage key for a specific address
  */
@@ -87,11 +197,28 @@ export function getPendingPegins(ethAddress: string): PendingPeginRequest[] {
     const stored = localStorage.getItem(key);
     if (!stored) return [];
 
-    const parsed: PendingPeginRequest[] = JSON.parse(stored);
+    const parsed: unknown = JSON.parse(stored);
+    if (!Array.isArray(parsed)) return [];
+
+    // Filter out entries whose security-critical fields (unsignedTxHex,
+    // selectedUTXOs) fail a strict format check. A tampered entry would
+    // otherwise feed malformed hex into downstream consumers.
+    const validated = parsed.filter((entry): entry is PendingPeginRequest => {
+      if (hasValidSecurityFields(entry)) return true;
+      const maybeId =
+        entry && typeof entry === "object" && "id" in entry
+          ? String((entry as { id: unknown }).id)
+          : "unknown";
+      logger.warn("[peginStorage] Skipping corrupted pending pegin entry", {
+        category: "peginStorage",
+        vaultId: maybeId,
+      });
+      return false;
+    });
 
     // Normalize IDs to ensure they all have 0x prefix (handles legacy data)
     // Note: We do NOT save back to localStorage here to avoid side effects
-    const normalized = parsed.map((pegin) => ({
+    const normalized = validated.map((pegin) => ({
       ...pegin,
       id: normalizeTransactionId(pegin.id),
       // Ensure status field exists (backward compatibility)


### PR DESCRIPTION
## Summary

Closes audit finding #37 (MEDIUM): unsigned tx hex stored in `localStorage` was passed to the UTXO reservation and broadcast paths without integrity checks, leaving them vulnerable to tampering by XSS, browser extensions, or manual devtools edits.

## Changes

### `storage/peginStorage.ts`
Strict shape/format validation at the read boundary. Each entry must pass:
- `id` and `peginTxHash` — 32-byte hex (`0x`-prefix optional for legacy entries).
- `timestamp` — finite non-negative number.
- `unsignedTxHex` — empty (cross-device marker) or non-empty even-byte hex; rejects bare `0x` and odd lengths.
- Every `selectedUTXOs` entry — 64-char hex `txid`, integer `vout ≥ 0`, `value` in safe integer range, even-byte `scriptPubKey`.

Invalid entries are dropped individually with a `logger.warn` — the storage key is no longer wiped from a single bad record. Also closes a DoS where a non-string `id` would throw inside `normalizeTransactionId` and clear all pending pegins.

### `services/vault/utxoReservation.ts`
- `collectReservedUtxoRefs` now derives reservation refs only from `unsignedTxHex`. `selectedUTXOs` is no longer trusted for reservation, eliminating the sidecar inconsistency window.
- Pending pegins whose `id` matches an indexed on-chain vault are skipped so the trusted indexer copy wins.
- `extractInputUtxoRefs` logs on parse failure instead of silently returning an empty array (per CLAUDE.md's "never swallow errors silently").

### Tests
- New `storage/__tests__/peginStorage.test.ts` (20 tests): DoS guard, legacy non-prefixed ids, bare `0x`, odd-length hex, wrong-length `txid`, wrong-length `id`/`peginTxHash`, malformed `scriptPubKey`, mixed valid/tampered batches.
- `services/vault/__tests__/utxoReservation.test.ts` updated for the simpler reservation logic plus new on-chain preference cases.

## Residual risk (documented, out of scope for this PR)

- `collectReservedUtxoRefs` still derives refs from a localStorage-sourced `unsignedTxHex` after only a format check. A tampered-but-parseable hex could reserve UTXOs the attacker chose, causing `selectUtxosForDeposit` (from #1398) to refuse a new deposit — a DoS that requires XSS / browser-extension write access. Fully closing it means passing `vaults` from the indexer into `collectReservedUtxoRefs` so indexed pegins use canonical on-chain data; that's a call-site change in `useMultiVaultDepositFlow.ts` needing `useVaults` wired in. Worth a follow-up.
- `useVaultActions.handleBroadcast` still passes localStorage `selectedUTXOs` to `utxosToExpectedRecord` as trusted prevout data. Tampering causes P2TR signing failure (BIP 341 commits prevouts), not a silent exploit — fails loud, no funds at risk.

## Test plan
- [x] `pnpm --filter vault exec vitest run` — 1055 passed, 4 skipped, 65 files
- [x] `pnpm --filter vault exec eslint <changed files>` — 0 errors, 0 new warnings
- [x] `pnpm --filter vault exec tsc -b --noEmit tsconfig.lib.json` — clean
- [x] `pnpm run build` — all 7 projects + 1 dependent task green