### PR TITLE
fix(ts-sdk): address PR #1404 review comments

### DIFF
--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/signAndSubmitPayouts.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/signAndSubmitPayouts.test.ts
@@ -1,0 +1,360 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { BitcoinWallet } from "../../../../../shared/wallets/interfaces";
+import {
+  DaemonStatus,
+  type ClaimerTransactions,
+  type DepositorGraphTransactions,
+  type GetPeginStatusResponse,
+  type RequestDepositorPresignTransactionsResponse,
+} from "../../../clients/vault-provider/types";
+import type { PeginStatusReader, PresignClient } from "../interfaces";
+import { pollAndSignPayouts, type PayoutSigningContext } from "../signAndSubmitPayouts";
+
+// ---------------------------------------------------------------------------
+// Mocks — we test the orchestration, not PSBT internals or PayoutManager
+// ---------------------------------------------------------------------------
+
+vi.mock("../signDepositorGraph", () => ({
+  signDepositorGraph: vi.fn(async () => ({
+    payout_signatures: { payout_signature: "depositor_payout_sig" },
+    per_challenger: {
+      ["c".repeat(64)]: { nopayout_signature: "depositor_nopayout_sig" },
+    },
+  })),
+}));
+
+vi.mock("../../../managers/PayoutManager", () => {
+  return {
+    PayoutManager: class MockPayoutManager {
+      supportsBatchSigning() {
+        return true;
+      }
+      async signPayoutTransactionsBatch(inputs: unknown[]) {
+        return (inputs as unknown[]).map(() => ({
+          payoutSignature: "mock_payout_sig",
+        }));
+      }
+      async signPayoutTransaction() {
+        return { signature: "mock_payout_sig" };
+      }
+    },
+  };
+});
+
+vi.mock("../../../primitives/utils/bitcoin", () => ({
+  processPublicKeyToXOnly: (pk: string) =>
+    pk.startsWith("0x") ? pk.slice(2) : pk.length === 66 ? pk.slice(2) : pk,
+  stripHexPrefix: (s: string) =>
+    s.startsWith("0x") ? s.slice(2) : s,
+}));
+
+vi.mock("bitcoinjs-lib", () => ({
+  payments: {
+    p2tr: ({ internalPubkey }: { internalPubkey: Buffer }) => ({
+      output: Buffer.from("5120" + internalPubkey.toString("hex"), "hex"),
+    }),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const VALID_TXID = "a".repeat(64);
+const DEPOSITOR_PK = "d".repeat(64);
+const VP_PUBKEY = "e".repeat(64);
+const VK_PUBKEY = "f".repeat(64);
+const CHALLENGER_PK = "c".repeat(64);
+
+function createMockStatusReader(
+  statuses: DaemonStatus[],
+): PeginStatusReader {
+  let callIdx = 0;
+  return {
+    getPeginStatus: vi.fn(
+      async (): Promise<GetPeginStatusResponse> => ({
+        pegin_txid: VALID_TXID,
+        status:
+          statuses[callIdx++] ?? DaemonStatus.PENDING_INGESTION,
+        progress: {},
+        health_info: "ok",
+      }),
+    ),
+  };
+}
+
+function createMockPresignClient(
+  response?: Partial<RequestDepositorPresignTransactionsResponse>,
+): PresignClient {
+  const defaultClaimer: ClaimerTransactions = {
+    claimer_pubkey: VP_PUBKEY,
+    claim_tx: { tx_hex: "deadbeef" },
+    assert_tx: { tx_hex: "deadbeef" },
+    payout_tx: { tx_hex: "deadbeef" },
+    payout_psbt: "mock_psbt",
+  };
+
+  const defaultDepositorGraph: DepositorGraphTransactions = {
+    claim_tx: { tx_hex: "deadbeef" },
+    assert_tx: { tx_hex: "deadbeef" },
+    payout_tx: { tx_hex: "deadbeef" },
+    payout_psbt: "mock_psbt",
+    challenger_presign_data: [
+      {
+        challenger_pubkey: CHALLENGER_PK,
+        challenge_assert_x_tx: { tx_hex: "deadbeef" },
+        challenge_assert_y_tx: { tx_hex: "deadbeef" },
+        nopayout_tx: { tx_hex: "deadbeef" },
+        nopayout_psbt: "mock_nopayout_psbt",
+        challenge_assert_connectors: [],
+        output_label_hashes: [],
+      },
+    ],
+    offchain_params_version: 1,
+  };
+
+  return {
+    requestDepositorPresignTransactions: vi.fn(async () => ({
+      txs: [defaultClaimer, ...(response?.txs?.slice(1) ?? [])],
+      depositor_graph:
+        response?.depositor_graph ?? defaultDepositorGraph,
+    })),
+    submitDepositorPresignatures: vi.fn(async () => {}),
+  };
+}
+
+function createMockWallet(): BitcoinWallet {
+  return {
+    getPublicKeyHex: vi.fn(async () => "w".repeat(64)),
+    signPsbt: vi.fn(async (hex: string) => `signed_${hex}`),
+    signPsbts: vi.fn(async (hexes: string[]) =>
+      hexes.map((h) => `signed_${h}`),
+    ),
+  } as unknown as BitcoinWallet;
+}
+
+function createSigningContext(): PayoutSigningContext {
+  return {
+    peginTxHex: "01000000" + "00".repeat(60),
+    vaultProviderBtcPubkey: VP_PUBKEY,
+    vaultKeeperBtcPubkeys: [VK_PUBKEY],
+    universalChallengerBtcPubkeys: [CHALLENGER_PK],
+    depositorBtcPubkey: DEPOSITOR_PK,
+    timelockPegin: 100,
+    network: "Testnet4" as never,
+    registeredPayoutScriptPubKey: "0x5120" + DEPOSITOR_PK,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("pollAndSignPayouts", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("skips when VP already past payout signing (ACTIVATED)", async () => {
+    const reader = createMockStatusReader([DaemonStatus.ACTIVATED]);
+    const presignClient = createMockPresignClient();
+
+    await pollAndSignPayouts({
+      statusReader: reader,
+      presignClient,
+      btcWallet: createMockWallet(),
+      peginTxid: VALID_TXID,
+      depositorPk: DEPOSITOR_PK,
+      signingContext: createSigningContext(),
+    });
+
+    expect(
+      presignClient.requestDepositorPresignTransactions,
+    ).not.toHaveBeenCalled();
+    expect(
+      presignClient.submitDepositorPresignatures,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("skips when VP is in PENDING_ACKS", async () => {
+    const reader = createMockStatusReader([DaemonStatus.PENDING_ACKS]);
+    const presignClient = createMockPresignClient();
+
+    await pollAndSignPayouts({
+      statusReader: reader,
+      presignClient,
+      btcWallet: createMockWallet(),
+      peginTxid: VALID_TXID,
+      depositorPk: DEPOSITOR_PK,
+      signingContext: createSigningContext(),
+    });
+
+    expect(
+      presignClient.requestDepositorPresignTransactions,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("fetches presign txs, signs, and submits when VP is ready", async () => {
+    const reader = createMockStatusReader([
+      DaemonStatus.PENDING_DEPOSITOR_SIGNATURES,
+    ]);
+    const presignClient = createMockPresignClient();
+    const wallet = createMockWallet();
+
+    await pollAndSignPayouts({
+      statusReader: reader,
+      presignClient,
+      btcWallet: wallet,
+      peginTxid: VALID_TXID,
+      depositorPk: DEPOSITOR_PK,
+      signingContext: createSigningContext(),
+    });
+
+    expect(
+      presignClient.requestDepositorPresignTransactions,
+    ).toHaveBeenCalledWith(
+      { pegin_txid: VALID_TXID, depositor_pk: DEPOSITOR_PK },
+      undefined, // signal
+    );
+
+    expect(
+      presignClient.submitDepositorPresignatures,
+    ).toHaveBeenCalledOnce();
+
+    // Verify the submission includes depositor's own claimer signatures
+    const submitCall = (
+      presignClient.submitDepositorPresignatures as ReturnType<typeof vi.fn>
+    ).mock.calls[0][0];
+    expect(submitCall.pegin_txid).toBe(VALID_TXID);
+    expect(submitCall.depositor_pk).toBe(DEPOSITOR_PK);
+    expect(submitCall.depositor_claimer_presignatures).toBeDefined();
+    expect(
+      submitCall.depositor_claimer_presignatures.payout_signatures
+        .payout_signature,
+    ).toBe("depositor_payout_sig");
+  });
+
+  it("polls until VP reaches PENDING_DEPOSITOR_SIGNATURES", async () => {
+    const reader = createMockStatusReader([
+      DaemonStatus.PENDING_INGESTION,
+      DaemonStatus.PENDING_DEPOSITOR_SIGNATURES,
+    ]);
+    const presignClient = createMockPresignClient();
+
+    const resultPromise = pollAndSignPayouts({
+      statusReader: reader,
+      presignClient,
+      btcWallet: createMockWallet(),
+      peginTxid: VALID_TXID,
+      depositorPk: DEPOSITOR_PK,
+      signingContext: createSigningContext(),
+    });
+
+    // Advance past the default poll interval (10s)
+    await vi.advanceTimersByTimeAsync(15_000);
+    await resultPromise;
+
+    expect(
+      presignClient.submitDepositorPresignatures,
+    ).toHaveBeenCalledOnce();
+  });
+
+  it("calls onProgress callback", async () => {
+    const reader = createMockStatusReader([
+      DaemonStatus.PENDING_DEPOSITOR_SIGNATURES,
+    ]);
+    const presignClient = createMockPresignClient();
+    const onProgress = vi.fn();
+
+    await pollAndSignPayouts({
+      statusReader: reader,
+      presignClient,
+      btcWallet: createMockWallet(),
+      peginTxid: VALID_TXID,
+      depositorPk: DEPOSITOR_PK,
+      signingContext: createSigningContext(),
+      onProgress,
+    });
+
+    // Progress should be called at least for start (0, N) and end (N, N)
+    expect(onProgress).toHaveBeenCalled();
+    const lastCall = onProgress.mock.calls[onProgress.mock.calls.length - 1];
+    expect(lastCall[0]).toBe(lastCall[1]); // completed === total
+  });
+
+  it("filters out depositor's own claimer entry from PayoutManager signing", async () => {
+    // Include the depositor as a claimer in the VP response
+    const depositorClaimer: ClaimerTransactions = {
+      claimer_pubkey: DEPOSITOR_PK,
+      claim_tx: { tx_hex: "deadbeef" },
+      assert_tx: { tx_hex: "deadbeef" },
+      payout_tx: { tx_hex: "deadbeef" },
+      payout_psbt: "mock_psbt",
+    };
+    const vpClaimer: ClaimerTransactions = {
+      claimer_pubkey: VP_PUBKEY,
+      claim_tx: { tx_hex: "deadbeef" },
+      assert_tx: { tx_hex: "deadbeef" },
+      payout_tx: { tx_hex: "deadbeef" },
+      payout_psbt: "mock_psbt",
+    };
+
+    const reader = createMockStatusReader([
+      DaemonStatus.PENDING_DEPOSITOR_SIGNATURES,
+    ]);
+    const presignClient: PresignClient = {
+      requestDepositorPresignTransactions: vi.fn(async () => ({
+        txs: [vpClaimer, depositorClaimer],
+        depositor_graph: {
+          claim_tx: { tx_hex: "deadbeef" },
+          assert_tx: { tx_hex: "deadbeef" },
+          payout_tx: { tx_hex: "deadbeef" },
+          payout_psbt: "mock_psbt",
+          challenger_presign_data: [],
+          offchain_params_version: 1,
+        },
+      })),
+      submitDepositorPresignatures: vi.fn(async () => {}),
+    };
+
+    await pollAndSignPayouts({
+      statusReader: reader,
+      presignClient,
+      btcWallet: createMockWallet(),
+      peginTxid: VALID_TXID,
+      depositorPk: DEPOSITOR_PK,
+      signingContext: createSigningContext(),
+    });
+
+    // Submission should have depositor's key in signatures (from signDepositorGraph)
+    const submitCall = (
+      presignClient.submitDepositorPresignatures as ReturnType<typeof vi.fn>
+    ).mock.calls[0][0];
+    expect(submitCall.signatures[DEPOSITOR_PK]).toBeDefined();
+    expect(
+      submitCall.signatures[DEPOSITOR_PK].payout_signature,
+    ).toBe("depositor_payout_sig");
+  });
+
+  it("throws when already aborted", async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      pollAndSignPayouts({
+        statusReader: createMockStatusReader([]),
+        presignClient: createMockPresignClient(),
+        btcWallet: createMockWallet(),
+        peginTxid: VALID_TXID,
+        depositorPk: DEPOSITOR_PK,
+        signingContext: createSigningContext(),
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow();
+  });
+});

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/signDepositorGraph.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/signDepositorGraph.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { BitcoinWallet } from "../../../../../shared/wallets/interfaces";
+import type { DepositorGraphTransactions } from "../../../clients/vault-provider/types";
+import { signDepositorGraph } from "../signDepositorGraph";
+
+// ---------------------------------------------------------------------------
+// Mock PSBT layer — Psbt.fromBase64 / fromHex and extractPayoutSignature
+// use real bitcoinjs-lib internals which need real PSBTs. We mock them to
+// test the orchestration logic (collect → sign → extract → assemble).
+// ---------------------------------------------------------------------------
+
+// Deterministic "signed hex" returned by the mock wallet
+const SIGNED_HEX_PREFIX = "signed_";
+
+// Deterministic "signature" returned by extractPayoutSignature mock
+const MOCK_SIGNATURE_PREFIX = "sig_";
+
+// Mock extractPayoutSignature — returns a deterministic signature based on input index
+vi.mock("../../../primitives/psbt/payout", () => ({
+  extractPayoutSignature: (signedPsbtHex: string, _depositorPubkey: string) => {
+    // Use the signedPsbtHex as the key for deterministic output
+    return `${MOCK_SIGNATURE_PREFIX}${signedPsbtHex}`;
+  },
+}));
+
+// Mock the PSBT verification/sanitization layer so we don't need real PSBTs
+vi.mock("bitcoinjs-lib", () => {
+  const mockPsbt = {
+    data: {
+      inputs: [{}],
+      getTransaction: () => ({
+        toString: () => "deadbeef",
+      }),
+    },
+    toHex: () => "mock_psbt_hex",
+  };
+  return {
+    Psbt: {
+      fromBase64: () => ({ ...mockPsbt }),
+      fromHex: () => ({
+        ...mockPsbt,
+        data: { inputs: [{}] },
+        toHex: () => "mock_psbt_hex",
+      }),
+    },
+  };
+});
+
+// Mock stripHexPrefix to pass through (the real one strips 0x)
+vi.mock("../../../primitives/utils/bitcoin", () => ({
+  stripHexPrefix: (s: string) =>
+    s.startsWith("0x") ? s.slice(2) : s,
+}));
+
+// Mock createTaprootScriptPathSignOptions
+vi.mock("../../../utils/signing", () => ({
+  createTaprootScriptPathSignOptions: (pubkey: string, inputCount: number) => ({
+    autoFinalized: false,
+    signInputs: Array.from({ length: inputCount }, (_, i) => ({
+      index: i,
+      publicKey: pubkey,
+      disableTweakSigner: true,
+    })),
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const DEPOSITOR_PUBKEY = "d".repeat(64);
+const WALLET_PUBKEY = "w".repeat(64);
+const CHALLENGER_A = "a".repeat(64);
+const CHALLENGER_B = "b".repeat(64);
+
+function createMockWallet(opts?: {
+  supportsBatch?: boolean;
+}): BitcoinWallet {
+  const signPsbt = vi.fn(async (hex: string) => `${SIGNED_HEX_PREFIX}${hex}`);
+  const signPsbts = opts?.supportsBatch
+    ? vi.fn(async (hexes: string[]) =>
+        hexes.map((h) => `${SIGNED_HEX_PREFIX}${h}`),
+      )
+    : undefined;
+
+  return {
+    getPublicKeyHex: vi.fn(async () => WALLET_PUBKEY),
+    signPsbt,
+    ...(signPsbts ? { signPsbts } : {}),
+  } as unknown as BitcoinWallet;
+}
+
+function createDepositorGraph(
+  challengerPubkeys: string[],
+): DepositorGraphTransactions {
+  return {
+    claim_tx: { tx_hex: "deadbeef" },
+    assert_tx: { tx_hex: "deadbeef" },
+    payout_tx: { tx_hex: "deadbeef" },
+    payout_psbt: btoa("mock_payout_psbt"),
+    challenger_presign_data: challengerPubkeys.map((pk) => ({
+      challenger_pubkey: pk,
+      challenge_assert_x_tx: { tx_hex: "deadbeef" },
+      challenge_assert_y_tx: { tx_hex: "deadbeef" },
+      nopayout_tx: { tx_hex: "deadbeef" },
+      nopayout_psbt: btoa(`mock_nopayout_${pk}`),
+      challenge_assert_connectors: [],
+      output_label_hashes: [],
+    })),
+    offchain_params_version: 1,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("signDepositorGraph", () => {
+  it("signs payout and nopayout PSBTs for each challenger", async () => {
+    const wallet = createMockWallet({ supportsBatch: true });
+    const graph = createDepositorGraph([CHALLENGER_A, CHALLENGER_B]);
+
+    const result = await signDepositorGraph({
+      depositorGraph: graph,
+      depositorBtcPubkey: DEPOSITOR_PUBKEY,
+      btcWallet: wallet,
+    });
+
+    // Payout signature present
+    expect(result.payout_signatures.payout_signature).toBeDefined();
+    expect(result.payout_signatures.payout_signature).toContain(
+      MOCK_SIGNATURE_PREFIX,
+    );
+
+    // Per-challenger nopayout signatures present
+    expect(result.per_challenger[CHALLENGER_A]).toBeDefined();
+    expect(
+      result.per_challenger[CHALLENGER_A].nopayout_signature,
+    ).toContain(MOCK_SIGNATURE_PREFIX);
+
+    expect(result.per_challenger[CHALLENGER_B]).toBeDefined();
+    expect(
+      result.per_challenger[CHALLENGER_B].nopayout_signature,
+    ).toContain(MOCK_SIGNATURE_PREFIX);
+  });
+
+  it("uses batch signing when wallet supports signPsbts", async () => {
+    const wallet = createMockWallet({ supportsBatch: true });
+    const graph = createDepositorGraph([CHALLENGER_A]);
+
+    await signDepositorGraph({
+      depositorGraph: graph,
+      depositorBtcPubkey: DEPOSITOR_PUBKEY,
+      btcWallet: wallet,
+    });
+
+    // signPsbts should be called (batch), not signPsbt (sequential)
+    expect(wallet.signPsbts).toHaveBeenCalledOnce();
+    expect(wallet.signPsbt).not.toHaveBeenCalled();
+  });
+
+  it("falls back to sequential signPsbt when signPsbts is not available", async () => {
+    const wallet = createMockWallet({ supportsBatch: false });
+    const graph = createDepositorGraph([CHALLENGER_A]);
+
+    await signDepositorGraph({
+      depositorGraph: graph,
+      depositorBtcPubkey: DEPOSITOR_PUBKEY,
+      btcWallet: wallet,
+    });
+
+    // 2 PSBTs total: 1 payout + 1 nopayout
+    expect(wallet.signPsbt).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws when wallet returns wrong number of signed PSBTs", async () => {
+    const wallet = createMockWallet({ supportsBatch: true });
+    // Override signPsbts to return wrong count
+    (wallet.signPsbts as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+      "only_one",
+    ]);
+    const graph = createDepositorGraph([CHALLENGER_A]);
+
+    await expect(
+      signDepositorGraph({
+        depositorGraph: graph,
+        depositorBtcPubkey: DEPOSITOR_PUBKEY,
+        btcWallet: wallet,
+      }),
+    ).rejects.toThrow("expected 2");
+  });
+
+  it("handles graph with no challengers (payout only)", async () => {
+    const wallet = createMockWallet({ supportsBatch: true });
+    const graph = createDepositorGraph([]);
+
+    const result = await signDepositorGraph({
+      depositorGraph: graph,
+      depositorBtcPubkey: DEPOSITOR_PUBKEY,
+      btcWallet: wallet,
+    });
+
+    expect(result.payout_signatures.payout_signature).toBeDefined();
+    expect(Object.keys(result.per_challenger)).toHaveLength(0);
+  });
+
+  it("strips 0x prefix from depositor pubkey", async () => {
+    const wallet = createMockWallet({ supportsBatch: true });
+    const graph = createDepositorGraph([CHALLENGER_A]);
+
+    const result = await signDepositorGraph({
+      depositorGraph: graph,
+      depositorBtcPubkey: `0x${DEPOSITOR_PUBKEY}`,
+      btcWallet: wallet,
+    });
+
+    // Should still produce valid signatures (no error about prefix)
+    expect(result.payout_signatures.payout_signature).toBeDefined();
+  });
+});

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/submitWotsPublicKey.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/submitWotsPublicKey.ts
@@ -74,7 +74,7 @@ export async function submitWotsPublicKey(
   });
 
   // Key was already submitted in a previous session (e.g. resume flow)
-  if (POST_WOTS_STATUSES.has(status as DaemonStatus)) {
+  if (POST_WOTS_STATUSES.has(status)) {
     return;
   }
 


### PR DESCRIPTION
- Remove redundant `as DaemonStatus` cast in `submitWotsPublicKey.ts:77` — return type of `waitForPeginStatus` is already `DaemonStatus`
- Add tests for `signDepositorGraph` (6 tests): batch/sequential signing, PSBT count validation, no-challenger edge case
- Add tests for `pollAndSignPayouts` (6 tests): resume-skip behavior, polling, progress callback, depositor claimer filtering