### PR TITLE
refactor(vault): invert vault-cap flag to DISABLE_VAULT_CAP kill-switch

### DIFF
--- a/.github/workflows/service-release-vault.yml
+++ b/.github/workflows/service-release-vault.yml
@@ -116,6 +116,8 @@ jobs:
           NEXT_PUBLIC_SENTRY_ENVIRONMENT: ${{ matrix.environment }}
           # Analytics
           GA4_MEASUREMENT_ID: ${{ vars.GA4_MEASUREMENT_ID }}
+          # Feature Flags
+          NEXT_PUBLIC_FF_DISABLE_VAULT_CAP: ${{ vars.NEXT_PUBLIC_FF_DISABLE_VAULT_CAP }}
 
       - name: Copy all index.html to fix path for deposit, activity, app/aave
         run: |

--- a/services/vault/.env.example
+++ b/services/vault/.env.example
@@ -38,6 +38,6 @@ NEXT_PUBLIC_TBV_SIDECAR_API_URL=https://sidecar-api.canon-devnet.babylonlabs.io
 # NEXT_PUBLIC_TBV_BTC_PRICE_FEED=0xc3223BDa48ae9803F5a2B25839455Ff2C0d5f99d
 
 # Feature Flags (all default to disabled; set to "true" to enable)
-# Enables the vault supply-cap UI (dashboard section + deposit-form validation).
-# When disabled, the CapPolicy contract is never read.
-# NEXT_PUBLIC_FF_VAULT_CAP=true
+# Kill-switch for the vault supply-cap UI (dashboard section + deposit-form validation).
+# When enabled, the CapPolicy contract is never read. Vault cap is on by default.
+# NEXT_PUBLIC_FF_DISABLE_VAULT_CAP=true

--- a/services/vault/src/components/simple/SupplyCapSection.tsx
+++ b/services/vault/src/components/simple/SupplyCapSection.tsx
@@ -56,7 +56,9 @@ function CapCardSkeleton() {
 function VaultCapFrame({ children }: { children: ReactNode }) {
   return (
     <div className="w-full space-y-4">
-      <h2 className="text-[24px] font-normal text-accent-primary">Protocol Cap</h2>
+      <h2 className="text-[24px] font-normal text-accent-primary">
+        Protocol Cap
+      </h2>
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">{children}</div>
     </div>
   );

--- a/services/vault/src/components/simple/SupplyCapSection.tsx
+++ b/services/vault/src/components/simple/SupplyCapSection.tsx
@@ -56,7 +56,7 @@ function CapCardSkeleton() {
 function VaultCapFrame({ children }: { children: ReactNode }) {
   return (
     <div className="w-full space-y-4">
-      <h2 className="text-[24px] font-normal text-accent-primary">Vault Cap</h2>
+      <h2 className="text-[24px] font-normal text-accent-primary">Protocol Cap</h2>
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">{children}</div>
     </div>
   );

--- a/services/vault/src/components/simple/__tests__/SupplyCapSection.test.tsx
+++ b/services/vault/src/components/simple/__tests__/SupplyCapSection.test.tsx
@@ -38,10 +38,10 @@ const unlimitedSnapshot: CapSnapshot = {
 };
 
 describe("SupplyCapSection", () => {
-  it("renders the Vault Cap header and both cards", () => {
+  it("renders the Protocol Cap header and both cards", () => {
     mockBtcPrice.mockReturnValue(69_003.07);
     render(<SupplyCapSection snapshot={cappedSnapshot} />);
-    expect(screen.getByText("Vault Cap")).toBeInTheDocument();
+    expect(screen.getByText("Protocol Cap")).toBeInTheDocument();
     expect(screen.getByText("Total Cap")).toBeInTheDocument();
     expect(screen.getByText("Total Deposited")).toBeInTheDocument();
   });
@@ -87,7 +87,7 @@ describe("SupplyCapSection", () => {
     const { container } = render(
       <SupplyCapSection snapshot={null} isLoading />,
     );
-    expect(screen.getByText("Vault Cap")).toBeInTheDocument();
+    expect(screen.getByText("Protocol Cap")).toBeInTheDocument();
     expect(container.querySelectorAll(".animate-pulse")).toHaveLength(2);
   });
 

--- a/services/vault/src/config/featureFlags.ts
+++ b/services/vault/src/config/featureFlags.ts
@@ -71,16 +71,16 @@ export default {
   },
 
   /**
-   * VAULT_CAP feature flag
+   * DISABLE_VAULT_CAP feature flag
    *
-   * Purpose: Enables the vault supply-cap UI on the dashboard and the
-   * remaining-capacity check in deposit-form validation. When disabled, the
-   * hook short-circuits without any on-chain CapPolicy reads.
-   * Why needed: Feature is expected to be temporary; allows quickly hiding it
-   * per environment without a code change.
-   * Default: false (disabled unless explicitly set to "true")
+   * Purpose: Kill-switch to hide the vault supply-cap UI (dashboard section
+   * and deposit-form remaining-capacity check). When enabled, the hook
+   * short-circuits without any on-chain CapPolicy reads.
+   * Why needed: Feature is on by default; this flag lets DevOps quickly
+   * disable it per environment without a code change.
+   * Default: false (vault cap is enabled unless explicitly set to "true")
    */
-  get isVaultCapEnabled() {
-    return process.env.NEXT_PUBLIC_FF_VAULT_CAP === "true";
+  get isVaultCapDisabled() {
+    return process.env.NEXT_PUBLIC_FF_DISABLE_VAULT_CAP === "true";
   },
 };

--- a/services/vault/src/hooks/__tests__/useApplicationCap.test.tsx
+++ b/services/vault/src/hooks/__tests__/useApplicationCap.test.tsx
@@ -10,7 +10,7 @@ vi.mock("@/config/contracts", () => ({
   },
 }));
 
-const featureFlagsMock = vi.hoisted(() => ({ isVaultCapEnabled: true }));
+const featureFlagsMock = vi.hoisted(() => ({ isVaultCapDisabled: false }));
 vi.mock("@/config/featureFlags", () => ({
   default: featureFlagsMock,
 }));
@@ -40,7 +40,7 @@ function buildWrapper() {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  featureFlagsMock.isVaultCapEnabled = true;
+  featureFlagsMock.isVaultCapDisabled = false;
 });
 
 describe("useApplicationCap", () => {
@@ -165,8 +165,8 @@ describe("useApplicationCap", () => {
     await waitFor(() => expect(result.current.error).toBeNull());
   });
 
-  it("returns a no-feature state and skips RPC when the vault-cap flag is disabled", () => {
-    featureFlagsMock.isVaultCapEnabled = false;
+  it("returns a no-feature state and skips RPC when the vault-cap kill-switch is set", () => {
+    featureFlagsMock.isVaultCapDisabled = true;
 
     const { result } = renderHook(() => useApplicationCap("0xuser"), {
       wrapper: buildWrapper(),

--- a/services/vault/src/hooks/useApplicationCap.ts
+++ b/services/vault/src/hooks/useApplicationCap.ts
@@ -3,9 +3,10 @@
  * current usage (protocol-total and optionally per-user).
  *
  * Reads from the on-chain CapPolicy contract, keyed by the configured Aave
- * adapter entry point. Gated by the `VAULT_CAP` feature flag — when disabled,
- * the hook short-circuits without any RPC reads and consumers see a stable
- * "no feature" state (`snapshot: null`, `isLoading: false`, `error: null`).
+ * adapter entry point. Gated by the `DISABLE_VAULT_CAP` kill-switch — when
+ * the flag is set, the hook short-circuits without any RPC reads and
+ * consumers see a stable "no feature" state (`snapshot: null`,
+ * `isLoading: false`, `error: null`).
  */
 
 import { useQuery } from "@tanstack/react-query";
@@ -32,7 +33,7 @@ export interface UseApplicationCapResult {
 }
 
 export function useApplicationCap(user?: string): UseApplicationCapResult {
-  const enabled = featureFlags.isVaultCapEnabled;
+  const enabled = !featureFlags.isVaultCapDisabled;
   const app = CONTRACTS.AAVE_ADAPTER;
   // Wallet adapters surface addresses as string; cast at the boundary.
   const userAddress = user ? (user as Address) : undefined;


### PR DESCRIPTION
Vault cap is now enabled by default; set NEXT_PUBLIC_FF_DISABLE_VAULT_CAP=true to hide the UI and skip CapPolicy reads. Matches the DISABLE_DEPOSIT / DISABLE_BORROW opt-out pattern used elsewhere in featureFlags.