### PR TITLE
feat(vault, ts-sdk): use on-chain contract readers for transaction-cr…

### DIFF
--- a/packages/babylon-ts-sdk/src/tbv/core/clients/eth/__tests__/protocol-params-reader.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/eth/__tests__/protocol-params-reader.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Address, Hex } from "viem";
+
+import { ViemProtocolParamsReader } from "../protocol-params-reader";
+
+const MOCK_ADDRESS = "0x1234567890abcdef1234567890abcdef12345678" as Address;
+
+const MOCK_TBV_PARAMS = {
+  minimumPegInAmount: 100000n,
+  maxPegInAmount: 10000000n,
+  pegInAckTimeout: 7200n,
+  pegInActivationTimeout: 14400n,
+  maxHtlcOutputCount: 5,
+};
+
+const MOCK_OFFCHAIN_PARAMS = {
+  timelockAssert: 150n,
+  timelockChallengeAssert: 300n,
+  securityCouncilKeys: [
+    "0xaaaa000000000000000000000000000000000000000000000000000000000000" as Hex,
+  ],
+  councilQuorum: 3,
+  feeRate: 2n,
+  babeTotalInstances: 128,
+  babeInstancesToFinalize: 64,
+  minVpCommissionBps: 500,
+  tRefund: 1008,
+  tStale: 288,
+  minPeginFeeRate: 1n,
+  proverProgramVersion: 1,
+  minPrepeginDepth: 6,
+};
+
+function createMockPublicClient(overrides?: {
+  tbvParams?: unknown;
+  offchainParams?: unknown;
+  version?: unknown;
+}) {
+  return {
+    readContract: vi.fn(
+      async ({
+        functionName,
+      }: {
+        functionName: string;
+        args?: unknown[];
+      }) => {
+        if (functionName === "getTBVProtocolParams") {
+          return overrides?.tbvParams ?? MOCK_TBV_PARAMS;
+        }
+        if (
+          functionName === "getLatestOffchainParams" ||
+          functionName === "getOffchainParamsByVersion"
+        ) {
+          return overrides?.offchainParams ?? MOCK_OFFCHAIN_PARAMS;
+        }
+        if (functionName === "latestOffchainParamsVersion") {
+          return overrides?.version ?? 3;
+        }
+        throw new Error(`Unknown function: ${functionName}`);
+      },
+    ),
+    multicall: vi.fn(async () => [
+      overrides?.tbvParams ?? MOCK_TBV_PARAMS,
+      overrides?.offchainParams ?? MOCK_OFFCHAIN_PARAMS,
+    ]),
+  };
+}
+
+describe("ViemProtocolParamsReader", () => {
+  it("returns TBV protocol params with correct field mapping", async () => {
+    const publicClient = createMockPublicClient();
+    const reader = new ViemProtocolParamsReader(
+      publicClient as never,
+      MOCK_ADDRESS,
+    );
+
+    const params = await reader.getTBVProtocolParams();
+
+    expect(params.minimumPegInAmount).toBe(100000n);
+    expect(params.maxPegInAmount).toBe(10000000n);
+    expect(params.pegInAckTimeout).toBe(7200n);
+    expect(params.pegInActivationTimeout).toBe(14400n);
+    expect(params.maxHtlcOutputCount).toBe(5);
+  });
+
+  it("returns offchain params with all 13 fields", async () => {
+    const publicClient = createMockPublicClient();
+    const reader = new ViemProtocolParamsReader(
+      publicClient as never,
+      MOCK_ADDRESS,
+    );
+
+    const params = await reader.getLatestOffchainParams();
+
+    expect(params.timelockAssert).toBe(150n);
+    expect(params.timelockChallengeAssert).toBe(300n);
+    expect(params.securityCouncilKeys).toHaveLength(1);
+    expect(params.councilQuorum).toBe(3);
+    expect(params.feeRate).toBe(2n);
+    expect(params.babeTotalInstances).toBe(128);
+    expect(params.babeInstancesToFinalize).toBe(64);
+    expect(params.minVpCommissionBps).toBe(500);
+    expect(params.tRefund).toBe(1008);
+    expect(params.tStale).toBe(288);
+    expect(params.minPeginFeeRate).toBe(1n);
+    expect(params.proverProgramVersion).toBe(1);
+    expect(params.minPrepeginDepth).toBe(6);
+  });
+
+  it("passes version to getOffchainParamsByVersion", async () => {
+    const publicClient = createMockPublicClient();
+    const reader = new ViemProtocolParamsReader(
+      publicClient as never,
+      MOCK_ADDRESS,
+    );
+
+    await reader.getOffchainParamsByVersion(5);
+
+    expect(publicClient.readContract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        functionName: "getOffchainParamsByVersion",
+        args: [5],
+      }),
+    );
+  });
+
+  it("returns latest offchain params version", async () => {
+    const publicClient = createMockPublicClient();
+    const reader = new ViemProtocolParamsReader(
+      publicClient as never,
+      MOCK_ADDRESS,
+    );
+
+    const version = await reader.getLatestOffchainParamsVersion();
+
+    expect(version).toBe(3);
+  });
+
+  it("derives timelockPegin from timelockAssert", async () => {
+    const publicClient = createMockPublicClient();
+    const reader = new ViemProtocolParamsReader(
+      publicClient as never,
+      MOCK_ADDRESS,
+    );
+
+    const timelockPegin = await reader.getTimelockPeginByVersion(1);
+
+    // timelockAssert = 150n → timelockPegin = 150
+    expect(timelockPegin).toBe(150);
+  });
+
+  it("getPegInConfiguration uses multicall for atomic reads", async () => {
+    const publicClient = createMockPublicClient();
+    const reader = new ViemProtocolParamsReader(
+      publicClient as never,
+      MOCK_ADDRESS,
+    );
+
+    const config = await reader.getPegInConfiguration();
+
+    // Verify multicall was used (single call, not two separate readContract calls)
+    expect(publicClient.multicall).toHaveBeenCalledTimes(1);
+    expect(publicClient.readContract).not.toHaveBeenCalled();
+
+    // Verify combined fields
+    expect(config.minimumPegInAmount).toBe(100000n);
+    expect(config.maxHtlcOutputCount).toBe(5);
+    expect(config.timelockPegin).toBe(150);
+    expect(config.timelockRefund).toBe(1008);
+    expect(config.minVpCommissionBps).toBe(500);
+    expect(config.offchainParams.proverProgramVersion).toBe(1);
+    expect(config.offchainParams.minPrepeginDepth).toBe(6);
+  });
+
+  it("throws when timelockAssert exceeds uint16 max (65535)", async () => {
+    const publicClient = createMockPublicClient({
+      offchainParams: {
+        ...MOCK_OFFCHAIN_PARAMS,
+        timelockAssert: 70000n,
+      },
+    });
+    const reader = new ViemProtocolParamsReader(
+      publicClient as never,
+      MOCK_ADDRESS,
+    );
+
+    await expect(reader.getTimelockPeginByVersion(1)).rejects.toThrow(
+      "exceeds uint16 max",
+    );
+  });
+
+  it("accepts timelockAssert at uint16 max boundary (65535)", async () => {
+    const publicClient = createMockPublicClient({
+      offchainParams: {
+        ...MOCK_OFFCHAIN_PARAMS,
+        timelockAssert: 65535n,
+      },
+    });
+    const reader = new ViemProtocolParamsReader(
+      publicClient as never,
+      MOCK_ADDRESS,
+    );
+
+    const timelockPegin = await reader.getTimelockPeginByVersion(1);
+    expect(timelockPegin).toBe(65535);
+  });
+
+  it("passes correct contract address to readContract", async () => {
+    const publicClient = createMockPublicClient();
+    const reader = new ViemProtocolParamsReader(
+      publicClient as never,
+      MOCK_ADDRESS,
+    );
+
+    await reader.getTBVProtocolParams();
+
+    expect(publicClient.readContract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        address: MOCK_ADDRESS,
+        functionName: "getTBVProtocolParams",
+      }),
+    );
+  });
+});

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/eth/__tests__/signer-set-reader.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/eth/__tests__/signer-set-reader.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Address, Hex } from "viem";
+
+import {
+  ViemUniversalChallengerReader,
+  ViemVaultKeeperReader,
+} from "../signer-set-reader";
+
+const MOCK_PROTOCOL_PARAMS_ADDRESS =
+  "0x1111111111111111111111111111111111111111" as Address;
+const MOCK_APP_REGISTRY_ADDRESS =
+  "0x2222222222222222222222222222222222222222" as Address;
+const MOCK_APP_ENTRY_POINT =
+  "0x3333333333333333333333333333333333333333" as Address;
+
+const MOCK_KEY_PAIRS = [
+  {
+    ethAddress: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" as Address,
+    btcPubKey:
+      "0xbbbb000000000000000000000000000000000000000000000000000000000000" as Hex,
+  },
+  {
+    ethAddress: "0xcccccccccccccccccccccccccccccccccccccccc" as Address,
+    btcPubKey:
+      "0xdddd000000000000000000000000000000000000000000000000000000000000" as Hex,
+  },
+];
+
+describe("ViemVaultKeeperReader", () => {
+  function createMockPublicClient(overrides?: {
+    keepers?: unknown;
+    version?: unknown;
+  }) {
+    return {
+      readContract: vi.fn(
+        async ({
+          functionName,
+        }: {
+          functionName: string;
+          args?: unknown[];
+        }) => {
+          if (
+            functionName === "getVaultKeepersByVersion" ||
+            functionName === "getCurrentVaultKeepers"
+          ) {
+            return overrides?.keepers ?? MOCK_KEY_PAIRS;
+          }
+          if (functionName === "getCurrentVaultKeepersVersion") {
+            return overrides?.version ?? 2;
+          }
+          throw new Error(`Unknown function: ${functionName}`);
+        },
+      ),
+    };
+  }
+
+  it("returns vault keepers with correct field mapping", async () => {
+    const publicClient = createMockPublicClient();
+    const reader = new ViemVaultKeeperReader(
+      publicClient as never,
+      MOCK_APP_REGISTRY_ADDRESS,
+    );
+
+    const keepers = await reader.getCurrentVaultKeepers(MOCK_APP_ENTRY_POINT);
+
+    expect(keepers).toHaveLength(2);
+    expect(keepers[0].ethAddress).toBe(MOCK_KEY_PAIRS[0].ethAddress);
+    expect(keepers[0].btcPubKey).toBe(MOCK_KEY_PAIRS[0].btcPubKey);
+    expect(keepers[1].ethAddress).toBe(MOCK_KEY_PAIRS[1].ethAddress);
+  });
+
+  it("passes appEntryPoint and version to getVaultKeepersByVersion", async () => {
+    const publicClient = createMockPublicClient();
+    const reader = new ViemVaultKeeperReader(
+      publicClient as never,
+      MOCK_APP_REGISTRY_ADDRESS,
+    );
+
+    await reader.getVaultKeepersByVersion(MOCK_APP_ENTRY_POINT, 3);
+
+    expect(publicClient.readContract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        address: MOCK_APP_REGISTRY_ADDRESS,
+        functionName: "getVaultKeepersByVersion",
+        args: [MOCK_APP_ENTRY_POINT, 3],
+      }),
+    );
+  });
+
+  it("returns empty array when no vault keepers exist", async () => {
+    const publicClient = createMockPublicClient({ keepers: [] });
+    const reader = new ViemVaultKeeperReader(
+      publicClient as never,
+      MOCK_APP_REGISTRY_ADDRESS,
+    );
+
+    const keepers = await reader.getCurrentVaultKeepers(MOCK_APP_ENTRY_POINT);
+
+    expect(keepers).toEqual([]);
+  });
+
+  it("returns current vault keepers version", async () => {
+    const publicClient = createMockPublicClient();
+    const reader = new ViemVaultKeeperReader(
+      publicClient as never,
+      MOCK_APP_REGISTRY_ADDRESS,
+    );
+
+    const version = await reader.getCurrentVaultKeepersVersion(
+      MOCK_APP_ENTRY_POINT,
+    );
+
+    expect(version).toBe(2);
+  });
+});
+
+describe("ViemUniversalChallengerReader", () => {
+  function createMockPublicClient(overrides?: {
+    challengers?: unknown;
+    version?: unknown;
+  }) {
+    return {
+      readContract: vi.fn(
+        async ({
+          functionName,
+        }: {
+          functionName: string;
+          args?: unknown[];
+        }) => {
+          if (
+            functionName === "getUniversalChallengersByVersion" ||
+            functionName === "getCurrentUniversalChallengers"
+          ) {
+            return overrides?.challengers ?? MOCK_KEY_PAIRS;
+          }
+          if (functionName === "latestUniversalChallengersVersion") {
+            return overrides?.version ?? 1;
+          }
+          throw new Error(`Unknown function: ${functionName}`);
+        },
+      ),
+    };
+  }
+
+  it("returns universal challengers with correct field mapping", async () => {
+    const publicClient = createMockPublicClient();
+    const reader = new ViemUniversalChallengerReader(
+      publicClient as never,
+      MOCK_PROTOCOL_PARAMS_ADDRESS,
+    );
+
+    const challengers = await reader.getCurrentUniversalChallengers();
+
+    expect(challengers).toHaveLength(2);
+    expect(challengers[0].ethAddress).toBe(MOCK_KEY_PAIRS[0].ethAddress);
+    expect(challengers[0].btcPubKey).toBe(MOCK_KEY_PAIRS[0].btcPubKey);
+  });
+
+  it("passes version to getUniversalChallengersByVersion", async () => {
+    const publicClient = createMockPublicClient();
+    const reader = new ViemUniversalChallengerReader(
+      publicClient as never,
+      MOCK_PROTOCOL_PARAMS_ADDRESS,
+    );
+
+    await reader.getUniversalChallengersByVersion(5);
+
+    expect(publicClient.readContract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        address: MOCK_PROTOCOL_PARAMS_ADDRESS,
+        functionName: "getUniversalChallengersByVersion",
+        args: [5],
+      }),
+    );
+  });
+
+  it("returns empty array when no universal challengers exist", async () => {
+    const publicClient = createMockPublicClient({ challengers: [] });
+    const reader = new ViemUniversalChallengerReader(
+      publicClient as never,
+      MOCK_PROTOCOL_PARAMS_ADDRESS,
+    );
+
+    const challengers = await reader.getCurrentUniversalChallengers();
+
+    expect(challengers).toEqual([]);
+  });
+
+  it("returns latest universal challengers version", async () => {
+    const publicClient = createMockPublicClient();
+    const reader = new ViemUniversalChallengerReader(
+      publicClient as never,
+      MOCK_PROTOCOL_PARAMS_ADDRESS,
+    );
+
+    const version = await reader.getLatestUniversalChallengersVersion();
+
+    expect(version).toBe(1);
+  });
+});

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/eth/contract-address-resolver.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/eth/contract-address-resolver.ts
@@ -1,0 +1,55 @@
+/**
+ * Contract Address Resolver
+ *
+ * Resolves ProtocolParams and ApplicationRegistry contract addresses
+ * from the BTCVaultRegistry contract. These addresses are needed to
+ * construct the SDK's contract readers.
+ *
+ * @module clients/eth/contract-address-resolver
+ */
+
+import type { Address, PublicClient } from "viem";
+
+import { BTCVaultRegistryABI } from "../../contracts/abis/BTCVaultRegistry.abi";
+
+export interface ProtocolAddresses {
+  /** Address of the ProtocolParams contract */
+  protocolParams: Address;
+  /** Address of the ApplicationRegistry contract */
+  applicationRegistry: Address;
+}
+
+/**
+ * Resolve ProtocolParams and ApplicationRegistry addresses from BTCVaultRegistry.
+ *
+ * Uses a single multicall for atomicity and efficiency.
+ *
+ * @param publicClient - viem PublicClient instance
+ * @param btcVaultRegistryAddress - Address of the BTCVaultRegistry contract
+ * @returns Resolved contract addresses
+ */
+export async function resolveProtocolAddresses(
+  publicClient: PublicClient,
+  btcVaultRegistryAddress: Address,
+): Promise<ProtocolAddresses> {
+  const [protocolParams, applicationRegistry] = await publicClient.multicall({
+    contracts: [
+      {
+        address: btcVaultRegistryAddress,
+        abi: BTCVaultRegistryABI,
+        functionName: "protocolParams",
+      },
+      {
+        address: btcVaultRegistryAddress,
+        abi: BTCVaultRegistryABI,
+        functionName: "applicationRegistry",
+      },
+    ],
+    allowFailure: false,
+  });
+
+  return {
+    protocolParams: protocolParams as Address,
+    applicationRegistry: applicationRegistry as Address,
+  };
+}

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/eth/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/eth/index.ts
@@ -1,7 +1,23 @@
+export {
+  resolveProtocolAddresses,
+  type ProtocolAddresses,
+} from "./contract-address-resolver";
+export { ViemProtocolParamsReader } from "./protocol-params-reader";
+export {
+  ViemUniversalChallengerReader,
+  ViemVaultKeeperReader,
+} from "./signer-set-reader";
 export { ViemVaultRegistryReader } from "./vault-registry-reader";
 export type {
+  AddressBTCKeyPair,
+  PegInConfiguration,
+  ProtocolParamsReader,
+  TBVProtocolParams,
+  UniversalChallengerReader,
   VaultBasicInfo,
-  VaultProtocolInfo,
   VaultData,
+  VaultKeeperReader,
+  VaultProtocolInfo,
   VaultRegistryReader,
+  VersionedOffchainParams,
 } from "./types";

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-reader.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-reader.ts
@@ -1,0 +1,201 @@
+/**
+ * Concrete ProtocolParams reader using viem's readContract and multicall.
+ *
+ * This is an optional utility — callers can use their own implementation
+ * of the ProtocolParamsReader interface.
+ */
+
+import type { Address, Hex, PublicClient } from "viem";
+
+import { ProtocolParamsABI } from "../../contracts/abis/ProtocolParams.abi";
+import type {
+  PegInConfiguration,
+  ProtocolParamsReader,
+  TBVProtocolParams,
+  VersionedOffchainParams,
+} from "./types";
+
+/**
+ * Maximum value for a Solidity uint16.
+ * PeginLogic.sol casts timelockAssert to uint16, so values above this are invalid.
+ */
+const UINT16_MAX = 65535;
+
+/**
+ * Raw shape viem returns for VersionedOffchainParams struct.
+ * viem resolves ABI struct outputs to named objects (not tuples).
+ */
+interface RawOffchainParams {
+  timelockAssert: bigint;
+  timelockChallengeAssert: bigint;
+  securityCouncilKeys: readonly Hex[];
+  councilQuorum: number;
+  feeRate: bigint;
+  babeTotalInstances: number;
+  babeInstancesToFinalize: number;
+  minVpCommissionBps: number;
+  tRefund: number;
+  tStale: number;
+  minPeginFeeRate: bigint;
+  proverProgramVersion: number;
+  minPrepeginDepth: number;
+}
+
+/** Raw shape viem returns for TBVProtocolParams struct. */
+interface RawTBVParams {
+  minimumPegInAmount: bigint;
+  maxPegInAmount: bigint;
+  pegInAckTimeout: bigint;
+  pegInActivationTimeout: bigint;
+  maxHtlcOutputCount: number;
+}
+
+/** Map viem struct result to VersionedOffchainParams. */
+function mapOffchainParams(result: RawOffchainParams): VersionedOffchainParams {
+  return {
+    timelockAssert: result.timelockAssert,
+    timelockChallengeAssert: result.timelockChallengeAssert,
+    securityCouncilKeys: [...result.securityCouncilKeys],
+    councilQuorum: result.councilQuorum,
+    feeRate: result.feeRate,
+    babeTotalInstances: result.babeTotalInstances,
+    babeInstancesToFinalize: result.babeInstancesToFinalize,
+    minVpCommissionBps: result.minVpCommissionBps,
+    tRefund: result.tRefund,
+    tStale: result.tStale,
+    minPeginFeeRate: result.minPeginFeeRate,
+    proverProgramVersion: result.proverProgramVersion,
+    minPrepeginDepth: result.minPrepeginDepth,
+  };
+}
+
+/** Map viem struct result to TBVProtocolParams. */
+function mapTBVParams(result: RawTBVParams): TBVProtocolParams {
+  return {
+    minimumPegInAmount: result.minimumPegInAmount,
+    maxPegInAmount: result.maxPegInAmount,
+    pegInAckTimeout: result.pegInAckTimeout,
+    pegInActivationTimeout: result.pegInActivationTimeout,
+    maxHtlcOutputCount: result.maxHtlcOutputCount,
+  };
+}
+
+/**
+ * Derive timelockPegin from timelockAssert.
+ *
+ * Matches PeginLogic.sol: `uint16(timelockAssert)`.
+ * The contract validates `timelockAssert <= type(uint16).max` on write,
+ * but we enforce the same bound here to reject invalid values early
+ * rather than silently truncating.
+ *
+ * @throws if timelockAssert exceeds uint16 max (65535)
+ */
+function deriveTimelockPegin(timelockAssert: bigint): number {
+  if (timelockAssert > BigInt(UINT16_MAX)) {
+    throw new Error(
+      `timelockAssert value ${timelockAssert} exceeds uint16 max (${UINT16_MAX})`,
+    );
+  }
+  return Number(timelockAssert);
+}
+
+/**
+ * Concrete protocol params reader using viem.
+ *
+ * Usage:
+ * ```ts
+ * const reader = new ViemProtocolParamsReader(publicClient, protocolParamsAddress);
+ * const config = await reader.getPegInConfiguration();
+ * ```
+ */
+export class ViemProtocolParamsReader implements ProtocolParamsReader {
+  constructor(
+    private publicClient: PublicClient,
+    private contractAddress: Address,
+  ) {}
+
+  async getTBVProtocolParams(): Promise<TBVProtocolParams> {
+    const result = (await this.publicClient.readContract({
+      address: this.contractAddress,
+      abi: ProtocolParamsABI,
+      functionName: "getTBVProtocolParams",
+    })) as RawTBVParams;
+
+    return mapTBVParams(result);
+  }
+
+  async getLatestOffchainParams(): Promise<VersionedOffchainParams> {
+    const result = (await this.publicClient.readContract({
+      address: this.contractAddress,
+      abi: ProtocolParamsABI,
+      functionName: "getLatestOffchainParams",
+    })) as RawOffchainParams;
+
+    return mapOffchainParams(result);
+  }
+
+  async getOffchainParamsByVersion(
+    version: number,
+  ): Promise<VersionedOffchainParams> {
+    const result = (await this.publicClient.readContract({
+      address: this.contractAddress,
+      abi: ProtocolParamsABI,
+      functionName: "getOffchainParamsByVersion",
+      args: [version],
+    })) as RawOffchainParams;
+
+    return mapOffchainParams(result);
+  }
+
+  async getLatestOffchainParamsVersion(): Promise<number> {
+    const result = (await this.publicClient.readContract({
+      address: this.contractAddress,
+      abi: ProtocolParamsABI,
+      functionName: "latestOffchainParamsVersion",
+    })) as number;
+
+    return result;
+  }
+
+  async getTimelockPeginByVersion(version: number): Promise<number> {
+    const params = await this.getOffchainParamsByVersion(version);
+    return deriveTimelockPegin(params.timelockAssert);
+  }
+
+  /**
+   * Read TBV protocol params and latest offchain params atomically via multicall.
+   * Prevents TOCTOU inconsistency if governance updates params between reads.
+   */
+  async getPegInConfiguration(): Promise<PegInConfiguration> {
+    const results = await this.publicClient.multicall({
+      contracts: [
+        {
+          address: this.contractAddress,
+          abi: ProtocolParamsABI,
+          functionName: "getTBVProtocolParams",
+        },
+        {
+          address: this.contractAddress,
+          abi: ProtocolParamsABI,
+          functionName: "getLatestOffchainParams",
+        },
+      ],
+      allowFailure: false,
+    });
+
+    const tbvParams = mapTBVParams(results[0] as RawTBVParams);
+    const offchainParams = mapOffchainParams(results[1] as RawOffchainParams);
+
+    return {
+      minimumPegInAmount: tbvParams.minimumPegInAmount,
+      maxPegInAmount: tbvParams.maxPegInAmount,
+      pegInAckTimeout: tbvParams.pegInAckTimeout,
+      pegInActivationTimeout: tbvParams.pegInActivationTimeout,
+      maxHtlcOutputCount: tbvParams.maxHtlcOutputCount,
+      timelockPegin: deriveTimelockPegin(offchainParams.timelockAssert),
+      timelockRefund: offchainParams.tRefund,
+      minVpCommissionBps: offchainParams.minVpCommissionBps,
+      offchainParams,
+    };
+  }
+}

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.ts
@@ -1,0 +1,131 @@
+/**
+ * Concrete signer-set readers for vault keepers and universal challengers.
+ *
+ * These are optional utilities — callers can use their own implementations
+ * of the VaultKeeperReader and UniversalChallengerReader interfaces.
+ */
+
+import type { Address, Hex, PublicClient } from "viem";
+
+import { ApplicationRegistryABI } from "../../contracts/abis/ApplicationRegistry.abi";
+import { ProtocolParamsABI } from "../../contracts/abis/ProtocolParams.abi";
+import type {
+  AddressBTCKeyPair,
+  UniversalChallengerReader,
+  VaultKeeperReader,
+} from "./types";
+
+/** Map viem tuple array to AddressBTCKeyPair[]. */
+function mapKeyPairs(
+  result: readonly { ethAddress: Address; btcPubKey: Hex }[],
+): AddressBTCKeyPair[] {
+  return result.map((pair) => ({
+    ethAddress: pair.ethAddress,
+    btcPubKey: pair.btcPubKey,
+  }));
+}
+
+/**
+ * Reads vault keepers from the ApplicationRegistry contract.
+ *
+ * Usage:
+ * ```ts
+ * const reader = new ViemVaultKeeperReader(publicClient, applicationRegistryAddress);
+ * const keepers = await reader.getCurrentVaultKeepers(appEntryPoint);
+ * ```
+ */
+export class ViemVaultKeeperReader implements VaultKeeperReader {
+  constructor(
+    private publicClient: PublicClient,
+    private contractAddress: Address,
+  ) {}
+
+  async getVaultKeepersByVersion(
+    appEntryPoint: Address,
+    version: number,
+  ): Promise<AddressBTCKeyPair[]> {
+    const result = (await this.publicClient.readContract({
+      address: this.contractAddress,
+      abi: ApplicationRegistryABI,
+      functionName: "getVaultKeepersByVersion",
+      args: [appEntryPoint, version],
+    })) as readonly { ethAddress: Address; btcPubKey: Hex }[];
+
+    return mapKeyPairs(result);
+  }
+
+  async getCurrentVaultKeepers(
+    appEntryPoint: Address,
+  ): Promise<AddressBTCKeyPair[]> {
+    const result = (await this.publicClient.readContract({
+      address: this.contractAddress,
+      abi: ApplicationRegistryABI,
+      functionName: "getCurrentVaultKeepers",
+      args: [appEntryPoint],
+    })) as readonly { ethAddress: Address; btcPubKey: Hex }[];
+
+    return mapKeyPairs(result);
+  }
+
+  async getCurrentVaultKeepersVersion(
+    appEntryPoint: Address,
+  ): Promise<number> {
+    const result = (await this.publicClient.readContract({
+      address: this.contractAddress,
+      abi: ApplicationRegistryABI,
+      functionName: "getCurrentVaultKeepersVersion",
+      args: [appEntryPoint],
+    })) as number;
+
+    return result;
+  }
+}
+
+/**
+ * Reads universal challengers from the ProtocolParams contract.
+ *
+ * Usage:
+ * ```ts
+ * const reader = new ViemUniversalChallengerReader(publicClient, protocolParamsAddress);
+ * const challengers = await reader.getCurrentUniversalChallengers();
+ * ```
+ */
+export class ViemUniversalChallengerReader implements UniversalChallengerReader {
+  constructor(
+    private publicClient: PublicClient,
+    private contractAddress: Address,
+  ) {}
+
+  async getUniversalChallengersByVersion(
+    version: number,
+  ): Promise<AddressBTCKeyPair[]> {
+    const result = (await this.publicClient.readContract({
+      address: this.contractAddress,
+      abi: ProtocolParamsABI,
+      functionName: "getUniversalChallengersByVersion",
+      args: [version],
+    })) as readonly { ethAddress: Address; btcPubKey: Hex }[];
+
+    return mapKeyPairs(result);
+  }
+
+  async getCurrentUniversalChallengers(): Promise<AddressBTCKeyPair[]> {
+    const result = (await this.publicClient.readContract({
+      address: this.contractAddress,
+      abi: ProtocolParamsABI,
+      functionName: "getCurrentUniversalChallengers",
+    })) as readonly { ethAddress: Address; btcPubKey: Hex }[];
+
+    return mapKeyPairs(result);
+  }
+
+  async getLatestUniversalChallengersVersion(): Promise<number> {
+    const result = (await this.publicClient.readContract({
+      address: this.contractAddress,
+      abi: ProtocolParamsABI,
+      functionName: "latestUniversalChallengersVersion",
+    })) as number;
+
+    return result;
+  }
+}

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts
@@ -7,6 +7,10 @@
 
 import type { Address, Hex } from "viem";
 
+// ============================================================================
+// Vault Registry Types
+// ============================================================================
+
 /** Basic vault info from BTCVaultRegistry.getBtcVaultBasicInfo */
 export interface VaultBasicInfo {
   depositor: Address;
@@ -44,4 +48,106 @@ export interface VaultRegistryReader {
   getVaultBasicInfo(vaultId: Hex): Promise<VaultBasicInfo>;
   getVaultProtocolInfo(vaultId: Hex): Promise<VaultProtocolInfo>;
   getVaultData(vaultId: Hex): Promise<VaultData>;
+}
+
+// ============================================================================
+// Protocol Params Types (from IProtocolParams.sol)
+// ============================================================================
+
+/**
+ * TBV protocol parameters from the ProtocolParams contract.
+ * Matches Solidity struct `IProtocolParams.TBVProtocolParams` exactly.
+ *
+ * All uint64 amounts use bigint (satoshi values can exceed 2^53).
+ * uint8 uses number (bounded, max 255).
+ */
+export interface TBVProtocolParams {
+  minimumPegInAmount: bigint;
+  maxPegInAmount: bigint;
+  pegInAckTimeout: bigint;
+  pegInActivationTimeout: bigint;
+  maxHtlcOutputCount: number;
+}
+
+/**
+ * Versioned offchain parameters from the ProtocolParams contract.
+ * Matches Solidity struct `IProtocolParams.VersionedOffchainParams` exactly.
+ *
+ * bigint for: uint256 timelocks, uint64 fee rates/amounts.
+ * number for: uint8/uint16/uint32 fields (bounded, safe for JS arithmetic).
+ */
+export interface VersionedOffchainParams {
+  timelockAssert: bigint;
+  timelockChallengeAssert: bigint;
+  securityCouncilKeys: Hex[];
+  councilQuorum: number;
+  feeRate: bigint;
+  babeTotalInstances: number;
+  babeInstancesToFinalize: number;
+  minVpCommissionBps: number;
+  tRefund: number;
+  tStale: number;
+  minPeginFeeRate: bigint;
+  proverProgramVersion: number;
+  minPrepeginDepth: number;
+}
+
+/**
+ * Combined peg-in configuration read atomically via multicall.
+ * Prevents TOCTOU inconsistency if governance updates params between reads.
+ */
+export interface PegInConfiguration {
+  minimumPegInAmount: bigint;
+  maxPegInAmount: bigint;
+  pegInAckTimeout: bigint;
+  pegInActivationTimeout: bigint;
+  maxHtlcOutputCount: number;
+  timelockPegin: number;
+  timelockRefund: number;
+  minVpCommissionBps: number;
+  offchainParams: VersionedOffchainParams;
+}
+
+/** Interface for reading protocol parameters from the ProtocolParams contract. */
+export interface ProtocolParamsReader {
+  getTBVProtocolParams(): Promise<TBVProtocolParams>;
+  getOffchainParamsByVersion(version: number): Promise<VersionedOffchainParams>;
+  getLatestOffchainParams(): Promise<VersionedOffchainParams>;
+  getLatestOffchainParamsVersion(): Promise<number>;
+  getTimelockPeginByVersion(version: number): Promise<number>;
+  getPegInConfiguration(): Promise<PegInConfiguration>;
+}
+
+// ============================================================================
+// Signer-Set Types (from BTCVaultTypes.sol)
+// ============================================================================
+
+/**
+ * Matches Solidity struct `BTCVaultTypes.AddressBTCKeyPair` exactly.
+ * Used for vault keepers and universal challengers.
+ */
+export interface AddressBTCKeyPair {
+  ethAddress: Address;
+  btcPubKey: Hex;
+}
+
+/** Interface for reading vault keepers from the ApplicationRegistry contract. */
+export interface VaultKeeperReader {
+  getVaultKeepersByVersion(
+    appEntryPoint: Address,
+    version: number,
+  ): Promise<AddressBTCKeyPair[]>;
+  getCurrentVaultKeepers(
+    appEntryPoint: Address,
+  ): Promise<AddressBTCKeyPair[]>;
+  getCurrentVaultKeepersVersion(appEntryPoint: Address): Promise<number>;
+}
+
+/** Interface for reading universal challengers from the ProtocolParams contract. */
+export interface UniversalChallengerReader {
+  getUniversalChallengersByVersion(
+    version: number,
+  ): Promise<AddressBTCKeyPair[]>;
+  getCurrentUniversalChallengers(): Promise<AddressBTCKeyPair[]>;
+  getLatestUniversalChallengersVersion(): Promise<number>;
 }

--- a/packages/babylon-ts-sdk/src/tbv/core/contracts/abis/ApplicationRegistry.abi.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/contracts/abis/ApplicationRegistry.abi.ts
@@ -1,0 +1,97 @@
+/**
+ * ApplicationRegistry Contract ABI
+ *
+ * Minimal ABI containing only the vault keeper read functions needed by the SDK.
+ * Generated from vault-contracts-aave-v4 IApplicationRegistry.sol interface.
+ *
+ * @module contracts/abis/ApplicationRegistry
+ */
+
+export const ApplicationRegistryABI = [
+  {
+    type: "function",
+    name: "getVaultKeepersByVersion",
+    inputs: [
+      {
+        name: "appEntryPoint",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "versionNumber",
+        type: "uint16",
+        internalType: "uint16",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "tuple[]",
+        internalType: "struct BTCVaultTypes.AddressBTCKeyPair[]",
+        components: [
+          {
+            name: "ethAddress",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "btcPubKey",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+        ],
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "getCurrentVaultKeepers",
+    inputs: [
+      {
+        name: "appEntryPoint",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "tuple[]",
+        internalType: "struct BTCVaultTypes.AddressBTCKeyPair[]",
+        components: [
+          {
+            name: "ethAddress",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "btcPubKey",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+        ],
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "getCurrentVaultKeepersVersion",
+    inputs: [
+      {
+        name: "appEntryPoint",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "uint16",
+        internalType: "uint16",
+      },
+    ],
+    stateMutability: "view",
+  },
+] as const;

--- a/packages/babylon-ts-sdk/src/tbv/core/contracts/abis/BTCVaultRegistry.abi.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/contracts/abis/BTCVaultRegistry.abi.ts
@@ -356,4 +356,30 @@ export const BTCVaultRegistryABI = [
     ],
     stateMutability: "view",
   },
+  {
+    type: "function",
+    name: "protocolParams",
+    inputs: [],
+    outputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "contract IProtocolParams",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "applicationRegistry",
+    inputs: [],
+    outputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "contract IApplicationRegistry",
+      },
+    ],
+    stateMutability: "view",
+  },
 ] as const;

--- a/packages/babylon-ts-sdk/src/tbv/core/contracts/abis/ProtocolParams.abi.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/contracts/abis/ProtocolParams.abi.ts
@@ -1,0 +1,299 @@
+/**
+ * ProtocolParams Contract ABI
+ *
+ * Minimal ABI containing only the read functions needed by the SDK.
+ * Generated from vault-contracts-aave-v4 IProtocolParams.sol interface.
+ *
+ * @module contracts/abis/ProtocolParams
+ */
+
+export const ProtocolParamsABI = [
+  {
+    type: "function",
+    name: "getTBVProtocolParams",
+    inputs: [],
+    outputs: [
+      {
+        name: "",
+        type: "tuple",
+        internalType: "struct IProtocolParams.TBVProtocolParams",
+        components: [
+          {
+            name: "minimumPegInAmount",
+            type: "uint64",
+            internalType: "uint64",
+          },
+          {
+            name: "maxPegInAmount",
+            type: "uint64",
+            internalType: "uint64",
+          },
+          {
+            name: "pegInAckTimeout",
+            type: "uint64",
+            internalType: "uint64",
+          },
+          {
+            name: "pegInActivationTimeout",
+            type: "uint64",
+            internalType: "uint64",
+          },
+          {
+            name: "maxHtlcOutputCount",
+            type: "uint8",
+            internalType: "uint8",
+          },
+        ],
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "getLatestOffchainParams",
+    inputs: [],
+    outputs: [
+      {
+        name: "",
+        type: "tuple",
+        internalType: "struct IProtocolParams.VersionedOffchainParams",
+        components: [
+          {
+            name: "timelockAssert",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "timelockChallengeAssert",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "securityCouncilKeys",
+            type: "bytes32[]",
+            internalType: "bytes32[]",
+          },
+          {
+            name: "councilQuorum",
+            type: "uint8",
+            internalType: "uint8",
+          },
+          {
+            name: "feeRate",
+            type: "uint64",
+            internalType: "uint64",
+          },
+          {
+            name: "babeTotalInstances",
+            type: "uint16",
+            internalType: "uint16",
+          },
+          {
+            name: "babeInstancesToFinalize",
+            type: "uint8",
+            internalType: "uint8",
+          },
+          {
+            name: "minVpCommissionBps",
+            type: "uint16",
+            internalType: "uint16",
+          },
+          {
+            name: "tRefund",
+            type: "uint32",
+            internalType: "uint32",
+          },
+          {
+            name: "tStale",
+            type: "uint32",
+            internalType: "uint32",
+          },
+          {
+            name: "minPeginFeeRate",
+            type: "uint64",
+            internalType: "uint64",
+          },
+          {
+            name: "proverProgramVersion",
+            type: "uint16",
+            internalType: "uint16",
+          },
+          {
+            name: "minPrepeginDepth",
+            type: "uint32",
+            internalType: "uint32",
+          },
+        ],
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "getOffchainParamsByVersion",
+    inputs: [
+      {
+        name: "versionNumber",
+        type: "uint16",
+        internalType: "uint16",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "tuple",
+        internalType: "struct IProtocolParams.VersionedOffchainParams",
+        components: [
+          {
+            name: "timelockAssert",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "timelockChallengeAssert",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "securityCouncilKeys",
+            type: "bytes32[]",
+            internalType: "bytes32[]",
+          },
+          {
+            name: "councilQuorum",
+            type: "uint8",
+            internalType: "uint8",
+          },
+          {
+            name: "feeRate",
+            type: "uint64",
+            internalType: "uint64",
+          },
+          {
+            name: "babeTotalInstances",
+            type: "uint16",
+            internalType: "uint16",
+          },
+          {
+            name: "babeInstancesToFinalize",
+            type: "uint8",
+            internalType: "uint8",
+          },
+          {
+            name: "minVpCommissionBps",
+            type: "uint16",
+            internalType: "uint16",
+          },
+          {
+            name: "tRefund",
+            type: "uint32",
+            internalType: "uint32",
+          },
+          {
+            name: "tStale",
+            type: "uint32",
+            internalType: "uint32",
+          },
+          {
+            name: "minPeginFeeRate",
+            type: "uint64",
+            internalType: "uint64",
+          },
+          {
+            name: "proverProgramVersion",
+            type: "uint16",
+            internalType: "uint16",
+          },
+          {
+            name: "minPrepeginDepth",
+            type: "uint32",
+            internalType: "uint32",
+          },
+        ],
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "latestOffchainParamsVersion",
+    inputs: [],
+    outputs: [
+      {
+        name: "",
+        type: "uint16",
+        internalType: "uint16",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "getUniversalChallengersByVersion",
+    inputs: [
+      {
+        name: "versionNumber",
+        type: "uint16",
+        internalType: "uint16",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "tuple[]",
+        internalType: "struct BTCVaultTypes.AddressBTCKeyPair[]",
+        components: [
+          {
+            name: "ethAddress",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "btcPubKey",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+        ],
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "getCurrentUniversalChallengers",
+    inputs: [],
+    outputs: [
+      {
+        name: "",
+        type: "tuple[]",
+        internalType: "struct BTCVaultTypes.AddressBTCKeyPair[]",
+        components: [
+          {
+            name: "ethAddress",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "btcPubKey",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+        ],
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "latestUniversalChallengersVersion",
+    inputs: [],
+    outputs: [
+      {
+        name: "",
+        type: "uint16",
+        internalType: "uint16",
+      },
+    ],
+    stateMutability: "view",
+  },
+] as const;

--- a/packages/babylon-ts-sdk/src/tbv/core/contracts/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/contracts/index.ts
@@ -7,7 +7,9 @@
  * @module contracts
  */
 
+export { ApplicationRegistryABI } from "./abis/ApplicationRegistry.abi";
 export { BTCVaultRegistryABI } from "./abis/BTCVaultRegistry.abi";
+export { ProtocolParamsABI } from "./abis/ProtocolParams.abi";
 
 export {
   CONTRACT_ERRORS,

--- a/packages/babylon-ts-sdk/src/tbv/core/services/htlc/__tests__/htlc.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/htlc/__tests__/htlc.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+
+import { computeHashlock, validateSecretAgainstHashlock } from "../index";
+
+// Known test vector: SHA-256 of 32 zero bytes
+// sha256(0x0000...0000) = 0x66687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925
+const ZERO_SECRET =
+  "0x0000000000000000000000000000000000000000000000000000000000000000" as const;
+const ZERO_HASHLOCK =
+  "0x66687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925" as const;
+
+// Second test vector: SHA-256 of 32 0xFF bytes
+// sha256(0xffff...ffff) = 0xaf9613760f72635fbdb44a5a0a63c39f12af30f950a6ee5c971be188e89c4051
+const FF_SECRET =
+  "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff" as const;
+const FF_HASHLOCK =
+  "0xaf9613760f72635fbdb44a5a0a63c39f12af30f950a6ee5c971be188e89c4051" as const;
+
+describe("computeHashlock", () => {
+  it("produces correct SHA-256 for zero bytes", () => {
+    expect(computeHashlock(ZERO_SECRET)).toBe(ZERO_HASHLOCK);
+  });
+
+  it("produces correct SHA-256 for 0xFF bytes", () => {
+    expect(computeHashlock(FF_SECRET)).toBe(FF_HASHLOCK);
+  });
+
+  it("returns 0x-prefixed 66-char hex", () => {
+    const result = computeHashlock(ZERO_SECRET);
+    expect(result).toMatch(/^0x[0-9a-f]{64}$/);
+    expect(result.length).toBe(66);
+  });
+
+  it("throws if secret is not exactly 32 bytes", () => {
+    // Too short (31 bytes)
+    expect(() =>
+      computeHashlock(
+        "0x00000000000000000000000000000000000000000000000000000000000000",
+      ),
+    ).toThrow("must be exactly 32 bytes");
+
+    // Too long (33 bytes)
+    expect(() =>
+      computeHashlock(
+        "0x000000000000000000000000000000000000000000000000000000000000000000",
+      ),
+    ).toThrow("must be exactly 32 bytes");
+  });
+
+  it("throws length error when secret is missing 0x prefix", () => {
+    // Without 0x prefix, the string is 64 chars instead of 66, so the
+    // bytes32 length check fires first
+    expect(() =>
+      computeHashlock(
+        "0000000000000000000000000000000000000000000000000000000000000000" as `0x${string}`,
+      ),
+    ).toThrow("must be exactly 32 bytes");
+  });
+
+  it("throws on non-hex characters", () => {
+    expect(() =>
+      computeHashlock(
+        "0xgggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg",
+      ),
+    ).toThrow("non-hex characters");
+  });
+});
+
+describe("validateSecretAgainstHashlock", () => {
+  it("returns true for matching secret and hashlock", () => {
+    expect(validateSecretAgainstHashlock(ZERO_SECRET, ZERO_HASHLOCK)).toBe(
+      true,
+    );
+    expect(validateSecretAgainstHashlock(FF_SECRET, FF_HASHLOCK)).toBe(true);
+  });
+
+  it("returns false for mismatched secret and hashlock", () => {
+    expect(validateSecretAgainstHashlock(ZERO_SECRET, FF_HASHLOCK)).toBe(false);
+    expect(validateSecretAgainstHashlock(FF_SECRET, ZERO_HASHLOCK)).toBe(false);
+  });
+
+  it("is case-insensitive for hashlock comparison", () => {
+    const uppercaseHashlock =
+      ZERO_HASHLOCK.toUpperCase() as `0x${string}`;
+    expect(validateSecretAgainstHashlock(ZERO_SECRET, uppercaseHashlock)).toBe(
+      true,
+    );
+  });
+
+  it("throws if hashlock is not exactly 32 bytes", () => {
+    expect(() =>
+      validateSecretAgainstHashlock(ZERO_SECRET, "0xabcd"),
+    ).toThrow("must be exactly 32 bytes");
+  });
+
+  it("throws if secret is not exactly 32 bytes", () => {
+    expect(() =>
+      validateSecretAgainstHashlock("0xabcd", ZERO_HASHLOCK),
+    ).toThrow("must be exactly 32 bytes");
+  });
+
+  it("throws if hashlock contains non-hex characters", () => {
+    const invalidHashlock =
+      "0xzz687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925" as `0x${string}`;
+    expect(() =>
+      validateSecretAgainstHashlock(ZERO_SECRET, invalidHashlock),
+    ).toThrow("non-hex characters");
+  });
+});

--- a/packages/babylon-ts-sdk/src/tbv/core/services/htlc/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/htlc/index.ts
@@ -1,0 +1,106 @@
+/**
+ * HTLC Secret / Hashlock Utilities
+ *
+ * Pure functions for computing and validating SHA-256 hashlocks used in the
+ * vault deposit protocol's HTLC (Hash Time Lock Contract).
+ *
+ * The SDK does NOT generate secrets — that is the caller's responsibility.
+ * Today callers use `crypto.getRandomValues(32)`; when the `deriveContextHash`
+ * wallet API ships, callers will use `wallet.deriveContextHash("babylon-vault", ctx)`.
+ * These utilities work identically regardless of how the secret was produced.
+ *
+ * On-chain contract validation (BTCVaultRegistry.activateVaultWithSecret):
+ *   if (sha256(abi.encodePacked(s)) != hashlock) revert InvalidSecret();
+ *
+ * @module htlc
+ */
+
+import { sha256 } from "@noble/hashes/sha2.js";
+import type { Hex } from "viem";
+
+/** Expected hex length for a 0x-prefixed bytes32 value. */
+const HEX_BYTES32_LENGTH = 66; // "0x" + 64 hex chars
+
+/**
+ * Decode a 0x-prefixed hex string to bytes, with strict validation.
+ * @throws if the input is not a valid 0x-prefixed hex string
+ */
+function hexToBytes(hex: Hex): Uint8Array {
+  if (!hex.startsWith("0x") && !hex.startsWith("0X")) {
+    throw new Error("Expected 0x-prefixed hex string");
+  }
+  const clean = hex.slice(2);
+  if (clean.length % 2 !== 0) {
+    throw new Error(`Hex string has odd length: ${clean.length}`);
+  }
+  if (!/^[0-9a-fA-F]*$/.test(clean)) {
+    throw new Error("Hex string contains non-hex characters");
+  }
+  const bytes = new Uint8Array(clean.length / 2);
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = parseInt(clean.slice(i * 2, i * 2 + 2), 16);
+  }
+  return bytes;
+}
+
+/**
+ * Encode a Uint8Array as a 0x-prefixed lowercase hex string.
+ */
+function bytesToHex(bytes: Uint8Array): Hex {
+  return `0x${Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("")}`;
+}
+
+/**
+ * Validate that a value is a 0x-prefixed bytes32 (exactly 32 bytes).
+ * @throws if the value is not exactly 32 bytes
+ */
+function assertBytes32(value: Hex, label: string): void {
+  if (value.length !== HEX_BYTES32_LENGTH) {
+    throw new Error(
+      `${label} must be exactly 32 bytes (${HEX_BYTES32_LENGTH} hex chars with 0x prefix), got ${value.length}`,
+    );
+  }
+}
+
+/**
+ * Compute the SHA-256 hashlock from a secret preimage.
+ *
+ * Matches the on-chain validation: `sha256(abi.encodePacked(s))` where `s` is a `bytes32`.
+ * `abi.encodePacked(bytes32)` is just the raw 32 bytes — no ABI padding.
+ *
+ * @param secret - 0x-prefixed bytes32 secret (66 hex chars)
+ * @returns 0x-prefixed bytes32 SHA-256 hash
+ * @throws if secret is not exactly 32 bytes
+ */
+export function computeHashlock(secret: Hex): Hex {
+  assertBytes32(secret, "Secret");
+  const secretBytes = hexToBytes(secret);
+  const hash = sha256(secretBytes);
+  return bytesToHex(hash);
+}
+
+/**
+ * Validate that a secret's SHA-256 hash matches the expected hashlock.
+ *
+ * Use this for client-side pre-validation before sending the activation
+ * transaction to avoid wasting gas on a contract revert.
+ *
+ * @param secret - 0x-prefixed bytes32 secret (66 hex chars)
+ * @param hashlock - 0x-prefixed bytes32 expected hashlock from the vault
+ * @returns true if SHA-256(secret) matches the hashlock
+ * @throws if secret or hashlock is not exactly 32 bytes
+ */
+export function validateSecretAgainstHashlock(
+  secret: Hex,
+  hashlock: Hex,
+): boolean {
+  assertBytes32(secret, "Secret");
+  assertBytes32(hashlock, "Hashlock");
+  // Validate hashlock is valid hex (secret is validated inside computeHashlock)
+  hexToBytes(hashlock);
+
+  const computed = computeHashlock(secret);
+  return computed.toLowerCase() === hashlock.toLowerCase();
+}

--- a/packages/babylon-ts-sdk/src/tbv/core/services/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/index.ts
@@ -8,3 +8,4 @@
  */
 
 export * from "./deposit";
+export * from "./htlc";

--- a/packages/babylon-ts-sdk/src/tbv/core/wots/__tests__/blockDerivation.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/wots/__tests__/blockDerivation.test.ts
@@ -1,0 +1,323 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  computeWotsBlockPublicKeysHash,
+  deriveWotsBlockPublicKeys,
+} from "../blockDerivation";
+import { mnemonicToWotsSeed } from "../derivation";
+
+const KNOWN_MNEMONIC =
+  "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+
+describe("WOTS block derivation (SDK)", () => {
+  describe("deriveWotsBlockPublicKeys", () => {
+    const freshSeed = () => mnemonicToWotsSeed(KNOWN_MNEMONIC);
+    const vaultId = "vault-1";
+    const depositorPk = "pk-abc";
+    const appContractAddress = "0x1234";
+
+    it("produces 2 blocks with correct config", async () => {
+      const blocks = await deriveWotsBlockPublicKeys(
+        freshSeed(),
+        vaultId,
+        depositorPk,
+        appContractAddress,
+      );
+      expect(blocks).toHaveLength(2);
+      for (const block of blocks) {
+        expect(block.config).toEqual({ d: 4, n: 64, checksum_radix: 31 });
+      }
+    });
+
+    it("each block has 64 message terminals and 2 checksum terminals", async () => {
+      const blocks = await deriveWotsBlockPublicKeys(
+        freshSeed(),
+        vaultId,
+        depositorPk,
+        appContractAddress,
+      );
+      for (const block of blocks) {
+        expect(block.message_terminals).toHaveLength(64);
+        expect(block.checksum_major_terminal).toHaveLength(20);
+        expect(block.checksum_minor_terminal).toHaveLength(20);
+      }
+    });
+
+    it("all chain values are 20-byte arrays of valid bytes", async () => {
+      const blocks = await deriveWotsBlockPublicKeys(
+        freshSeed(),
+        vaultId,
+        depositorPk,
+        appContractAddress,
+      );
+      for (const block of blocks) {
+        for (const terminal of block.message_terminals) {
+          expect(terminal).toHaveLength(20);
+          terminal.forEach((b) => {
+            expect(typeof b).toBe("number");
+            expect(b).toBeGreaterThanOrEqual(0);
+            expect(b).toBeLessThanOrEqual(255);
+          });
+        }
+      }
+    });
+
+    it("is deterministic for the same inputs", async () => {
+      const a = await deriveWotsBlockPublicKeys(
+        freshSeed(),
+        vaultId,
+        depositorPk,
+        appContractAddress,
+      );
+      const b = await deriveWotsBlockPublicKeys(
+        freshSeed(),
+        vaultId,
+        depositorPk,
+        appContractAddress,
+      );
+      expect(a).toEqual(b);
+    });
+
+    it("produces different keys for different vault IDs", async () => {
+      const a = await deriveWotsBlockPublicKeys(
+        freshSeed(),
+        "vault-1",
+        depositorPk,
+        appContractAddress,
+      );
+      const b = await deriveWotsBlockPublicKeys(
+        freshSeed(),
+        "vault-2",
+        depositorPk,
+        appContractAddress,
+      );
+      expect(a[0].message_terminals[0]).not.toEqual(
+        b[0].message_terminals[0],
+      );
+    });
+
+    it("handles 0x-prefixed inputs the same as unprefixed", async () => {
+      const a = await deriveWotsBlockPublicKeys(
+        freshSeed(),
+        "0xdeadbeef",
+        "0xpk123",
+        "0x1234",
+      );
+      const b = await deriveWotsBlockPublicKeys(
+        freshSeed(),
+        "deadbeef",
+        "pk123",
+        "0x1234",
+      );
+      expect(a).toEqual(b);
+    });
+
+    it("rejects a seed that is not 64 bytes", async () => {
+      await expect(
+        deriveWotsBlockPublicKeys(
+          new Uint8Array(32),
+          vaultId,
+          depositorPk,
+          appContractAddress,
+        ),
+      ).rejects.toThrow(/seed must be exactly 64 bytes/);
+    });
+
+    it("zeroes the seed after derivation", async () => {
+      const seed = freshSeed();
+      await deriveWotsBlockPublicKeys(
+        seed,
+        vaultId,
+        depositorPk,
+        appContractAddress,
+      );
+      expect(seed.every((b) => b === 0)).toBe(true);
+    });
+
+    it("produces different keys for different app contract addresses", async () => {
+      const a = await deriveWotsBlockPublicKeys(
+        freshSeed(),
+        vaultId,
+        depositorPk,
+        "0x1234",
+      );
+      const b = await deriveWotsBlockPublicKeys(
+        freshSeed(),
+        vaultId,
+        depositorPk,
+        "0x5678",
+      );
+      expect(a[0].message_terminals[0]).not.toEqual(
+        b[0].message_terminals[0],
+      );
+    });
+
+    it("produces different keys for different depositor public keys", async () => {
+      const a = await deriveWotsBlockPublicKeys(
+        freshSeed(),
+        vaultId,
+        "pk-abc",
+        appContractAddress,
+      );
+      const b = await deriveWotsBlockPublicKeys(
+        freshSeed(),
+        vaultId,
+        "pk-xyz",
+        appContractAddress,
+      );
+      expect(a[0].message_terminals[0]).not.toEqual(
+        b[0].message_terminals[0],
+      );
+    });
+  });
+
+  describe("computeWotsBlockPublicKeysHash", () => {
+    const freshSeed = () => mnemonicToWotsSeed(KNOWN_MNEMONIC);
+    const vaultId = "vault-1";
+    const depositorPk = "pk-abc";
+    const appContractAddress = "0x1234";
+
+    it("returns a 0x-prefixed 66-character hex string", async () => {
+      const blocks = await deriveWotsBlockPublicKeys(
+        freshSeed(),
+        vaultId,
+        depositorPk,
+        appContractAddress,
+      );
+      const hash = computeWotsBlockPublicKeysHash(blocks);
+      expect(hash).toMatch(/^0x[0-9a-f]{64}$/);
+      expect(hash.length).toBe(66);
+    });
+
+    it("returns the same hash for the same keys derived twice", async () => {
+      const a = await deriveWotsBlockPublicKeys(
+        freshSeed(),
+        vaultId,
+        depositorPk,
+        appContractAddress,
+      );
+      const b = await deriveWotsBlockPublicKeys(
+        freshSeed(),
+        vaultId,
+        depositorPk,
+        appContractAddress,
+      );
+      expect(computeWotsBlockPublicKeysHash(a)).toBe(
+        computeWotsBlockPublicKeysHash(b),
+      );
+    });
+
+    it("produces different hashes for different vault IDs", async () => {
+      const a = await deriveWotsBlockPublicKeys(
+        freshSeed(),
+        "vault-1",
+        depositorPk,
+        appContractAddress,
+      );
+      const b = await deriveWotsBlockPublicKeys(
+        freshSeed(),
+        "vault-2",
+        depositorPk,
+        appContractAddress,
+      );
+      expect(computeWotsBlockPublicKeysHash(a)).not.toBe(
+        computeWotsBlockPublicKeysHash(b),
+      );
+    });
+
+    it("changes when a single chain terminal is modified", async () => {
+      const blocks = await deriveWotsBlockPublicKeys(
+        freshSeed(),
+        vaultId,
+        depositorPk,
+        appContractAddress,
+      );
+      const originalHash = computeWotsBlockPublicKeysHash(blocks);
+
+      // Deep-copy and flip one byte in the last message terminal of block 1
+      const tampered = blocks.map((b) => ({
+        ...b,
+        message_terminals: b.message_terminals.map((t) => [...t]),
+      }));
+      tampered[1].message_terminals[63][0] ^= 0x01;
+
+      expect(computeWotsBlockPublicKeysHash(tampered)).not.toBe(originalHash);
+    });
+
+    it("throws for empty public keys array", () => {
+      expect(() => computeWotsBlockPublicKeysHash([])).toThrow(
+        "must not be empty",
+      );
+    });
+
+    it("produces a pinned digest for a known mnemonic and inputs", async () => {
+      // Regression test: pin the hash so any change to canonical ordering
+      // or derivation logic is caught immediately.
+      // Derived from: mnemonic="abandon...about", vaultId="vault-1",
+      // depositorPk="pk-abc", appContractAddress="0x1234"
+      const PINNED_DIGEST =
+        "0x958560d5cf737d702391d3a4fef9bf23c597965b506740da3568f3df1f29f665";
+
+      const blocks = await deriveWotsBlockPublicKeys(
+        freshSeed(),
+        vaultId,
+        depositorPk,
+        appContractAddress,
+      );
+      expect(computeWotsBlockPublicKeysHash(blocks)).toBe(PINNED_DIGEST);
+    });
+
+    it("rejects blocks with wrong terminal length", () => {
+      const badBlock = {
+        config: { d: 4, n: 2, checksum_radix: 31 },
+        message_terminals: [
+          Array.from({ length: 20 }, () => 0),
+          Array.from({ length: 10 }, () => 0), // wrong: 10 instead of 20
+        ],
+        checksum_minor_terminal: Array.from({ length: 20 }, () => 0),
+        checksum_major_terminal: Array.from({ length: 20 }, () => 0),
+      };
+      expect(() => computeWotsBlockPublicKeysHash([badBlock])).toThrow(
+        "expected 20 bytes, got 10",
+      );
+    });
+
+    it("rejects blocks with out-of-range byte values", () => {
+      const badBlock = {
+        config: { d: 4, n: 1, checksum_radix: 31 },
+        message_terminals: [
+          [256, ...Array.from({ length: 19 }, () => 0)], // 256 is out of range
+        ],
+        checksum_minor_terminal: Array.from({ length: 20 }, () => 0),
+        checksum_major_terminal: Array.from({ length: 20 }, () => 0),
+      };
+      expect(() => computeWotsBlockPublicKeysHash([badBlock])).toThrow(
+        "invalid byte value 256",
+      );
+    });
+
+    it("rejects blocks with negative byte values", () => {
+      const badBlock = {
+        config: { d: 4, n: 1, checksum_radix: 31 },
+        message_terminals: [Array.from({ length: 20 }, () => 0)],
+        checksum_minor_terminal: [-1, ...Array.from({ length: 19 }, () => 0)],
+        checksum_major_terminal: Array.from({ length: 20 }, () => 0),
+      };
+      expect(() => computeWotsBlockPublicKeysHash([badBlock])).toThrow(
+        "invalid byte value -1",
+      );
+    });
+
+    it("rejects blocks with wrong checksum terminal length", () => {
+      const badBlock = {
+        config: { d: 4, n: 1, checksum_radix: 31 },
+        message_terminals: [Array.from({ length: 20 }, () => 0)],
+        checksum_minor_terminal: Array.from({ length: 5 }, () => 0), // wrong
+        checksum_major_terminal: Array.from({ length: 20 }, () => 0),
+      };
+      expect(() => computeWotsBlockPublicKeysHash([badBlock])).toThrow(
+        "checksum_minor_terminal: expected 20 bytes, got 5",
+      );
+    });
+  });
+});

--- a/packages/babylon-ts-sdk/src/tbv/core/wots/blockDerivation.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/wots/blockDerivation.ts
@@ -1,0 +1,406 @@
+/**
+ * WOTS Block Key Derivation
+ *
+ * Derives deterministic WOTS (Winternitz One-Time Signature) block public keys
+ * for Babylon vault deposits, matching the Rust `babe::wots` implementation.
+ *
+ * The SDK function takes a raw `seed: Uint8Array` and does not prescribe how
+ * the seed was produced. Today callers derive it from a BIP-39 mnemonic via
+ * `mnemonicToWotsSeed()`; when the `deriveContextHash` wallet API ships,
+ * callers will use a different seed expansion path. The core block derivation
+ * logic stays the same either way.
+ *
+ * @module wots/blockDerivation
+ */
+
+import type {
+  WotsBlockPublicKey,
+  WotsConfig,
+} from "../clients/vault-provider/types";
+
+import { hmac } from "@noble/hashes/hmac.js";
+import { ripemd160 } from "@noble/hashes/legacy.js";
+import { sha256, sha512 } from "@noble/hashes/sha2.js";
+import { keccak_256 } from "@noble/hashes/sha3.js";
+import type { Hex } from "viem";
+
+// ---------------------------------------------------------------------------
+// Constants — must match btc-vault / babe::wots
+// ---------------------------------------------------------------------------
+
+/** Size in bytes of the parent key or derived key (first half of 64-byte seed). */
+const KEY_SIZE = 32;
+
+/** Size in bytes of the full seed (BIP-39 produces 64 bytes). */
+const SEED_SIZE = 64;
+
+/** Size of the big-endian length prefix for variable-length fields. */
+const LENGTH_PREFIX_SIZE = 4;
+
+/** Hash160 output size in bytes (= RIPEMD-160(SHA-256(x))). */
+const CHAIN_ELEMENT_SIZE = 20;
+
+/** Bits per WOTS digit. Matches `babe::WOTS_DIGIT_BITS`. */
+const WOTS_DIGIT_BITS = 4;
+
+/** Number of checksum digits in canonical WOTS ordering. */
+const WOTS_CHECKSUM_DIGITS = 2;
+
+/** Digit index for the checksum minor chain (canonical ordering). */
+const CHECKSUM_MINOR_DIGIT_INDEX = 0;
+
+/** Digit index for the checksum major chain (canonical ordering). */
+const CHECKSUM_MAJOR_DIGIT_INDEX = 1;
+
+/**
+ * Message digit counts per assert block.
+ * Matches `btc_vault::ASSERT_WOTS_BLOCK_DIGIT_COUNTS`.
+ */
+const ASSERT_WOTS_BLOCK_DIGIT_COUNTS: readonly number[] = [64, 64];
+
+// ---------------------------------------------------------------------------
+// Byte utilities
+// ---------------------------------------------------------------------------
+
+function concatBytes(...arrays: Uint8Array[]): Uint8Array {
+  const totalLength = arrays.reduce((sum, arr) => sum + arr.length, 0);
+  const result = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const arr of arrays) {
+    result.set(arr, offset);
+    offset += arr.length;
+  }
+  return result;
+}
+
+function stringToBytes(str: string): Uint8Array {
+  return new TextEncoder().encode(str);
+}
+
+function lengthPrefixed(data: Uint8Array): Uint8Array {
+  const len = new Uint8Array(LENGTH_PREFIX_SIZE);
+  new DataView(len.buffer).setUint32(0, data.length, false);
+  return concatBytes(len, data);
+}
+
+function stripHexPrefix(hex: string): string {
+  return hex.startsWith("0x") || hex.startsWith("0X") ? hex.slice(2) : hex;
+}
+
+const toHex = (bytes: Uint8Array) =>
+  Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+
+// ---------------------------------------------------------------------------
+// Cryptographic primitives
+// ---------------------------------------------------------------------------
+
+function hmacSha512(key: Uint8Array, data: Uint8Array): Uint8Array {
+  return hmac(sha512, key, data);
+}
+
+function hash160(data: Uint8Array): Uint8Array {
+  return ripemd160(sha256(data));
+}
+
+// ---------------------------------------------------------------------------
+// WOTS chain derivation — mirrors Rust babe::wots
+// ---------------------------------------------------------------------------
+
+/** Maximum value representable by a single WOTS digit: `2^d - 1`. */
+function maxDigitValue(d: number): number {
+  return (1 << d) - 1;
+}
+
+/**
+ * Compute the default checksum radix for a given W_max.
+ * Matches Rust `default_checksum_radix(w_max)`.
+ */
+function defaultChecksumRadix(wMax: number): number {
+  let radix = 1;
+  while (radix * radix < wMax + 1) radix++;
+  return Math.max(radix, 2);
+}
+
+/** Create a WOTS config for a given message digit count. */
+function createWotsConfig(n: number): WotsConfig {
+  const d = WOTS_DIGIT_BITS;
+  const maxVal = maxDigitValue(d);
+  const wMax = n * maxVal;
+  return { d, n, checksum_radix: defaultChecksumRadix(wMax) };
+}
+
+/**
+ * Derive the starting chain value for a given digit index.
+ * Matches Rust `chain_start_for_digit(seed, digit_index)`:
+ *   hash160(seed || varint_le(digit_index))
+ */
+function chainStartForDigit(seed: Uint8Array, digitIndex: number): Uint8Array {
+  const suffixBytes: number[] = [];
+  let idx = digitIndex;
+  while (idx > 0) {
+    suffixBytes.push(idx & 0xff);
+    idx >>>= 8;
+  }
+  const preimage = new Uint8Array(seed.length + suffixBytes.length);
+  preimage.set(seed);
+  for (let i = 0; i < suffixBytes.length; i++) {
+    preimage[seed.length + i] = suffixBytes[i];
+  }
+  return hash160(preimage);
+}
+
+/**
+ * Compute the terminal value of a Hash160 chain of given length.
+ * Matches Rust `compute_chain(seed, len)` — returns chain[len].
+ */
+function computeChainTerminal(start: Uint8Array, steps: number): Uint8Array {
+  let current = start;
+  for (let i = 0; i < steps; i++) {
+    current = hash160(current);
+  }
+  return current;
+}
+
+// ---------------------------------------------------------------------------
+// Per-block public key derivation
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive a single WOTS block public key from a per-block seed.
+ */
+function deriveBlockPublicKey(
+  blockSeed: Uint8Array,
+  config: WotsConfig,
+): WotsBlockPublicKey {
+  const k = maxDigitValue(config.d);
+  const checksumMinorMax = config.checksum_radix - 1;
+  const checksumMajorMax = Math.floor((config.n * k) / config.checksum_radix);
+
+  // Message chain terminals (digit indices 2..n+2 in canonical order)
+  const messageTerminals: number[][] = [];
+  for (let digit = 0; digit < config.n; digit++) {
+    const start = chainStartForDigit(blockSeed, digit + WOTS_CHECKSUM_DIGITS);
+    const terminal = computeChainTerminal(start, k);
+    messageTerminals.push(Array.from(terminal));
+  }
+
+  // Checksum chain terminals
+  const checksumMinorStart = chainStartForDigit(
+    blockSeed,
+    CHECKSUM_MINOR_DIGIT_INDEX,
+  );
+  const checksumMinorTerminal = computeChainTerminal(
+    checksumMinorStart,
+    checksumMinorMax,
+  );
+
+  const checksumMajorStart = chainStartForDigit(
+    blockSeed,
+    CHECKSUM_MAJOR_DIGIT_INDEX,
+  );
+  const checksumMajorTerminal = computeChainTerminal(
+    checksumMajorStart,
+    checksumMajorMax,
+  );
+
+  return {
+    config,
+    message_terminals: messageTerminals,
+    checksum_major_terminal: Array.from(checksumMajorTerminal),
+    checksum_minor_terminal: Array.from(checksumMinorTerminal),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive deterministic WOTS block public keys for a specific vault.
+ *
+ * Produces an array of {@link WotsBlockPublicKey} (one per assert block),
+ * matching the Rust `Vec<babe::wots::PublicKey>` format expected by the
+ * vault provider's `submitDepositorWotsKey` RPC.
+ *
+ * The VP expects exactly 2 blocks and validates that keccak256 of the
+ * concatenated chain tips matches the on-chain `depositorWotsPkHash`.
+ *
+ * @param seed               - 64-byte seed (e.g. from `mnemonicToWotsSeed`). Zeroed after use.
+ * @param vaultId            - Vault identifier / pegin tx hash (hex, with or without 0x prefix).
+ * @param depositorPk        - Depositor's BTC public key (hex, with or without 0x prefix).
+ * @param appContractAddress - Application contract address.
+ * @returns Array of 2 WOTS block public keys.
+ * @throws If seed is not exactly 64 bytes.
+ */
+export async function deriveWotsBlockPublicKeys(
+  seed: Uint8Array,
+  vaultId: string,
+  depositorPk: string,
+  appContractAddress: string,
+): Promise<WotsBlockPublicKey[]> {
+  if (seed.length !== SEED_SIZE) {
+    throw new Error(
+      `WOTS seed must be exactly ${SEED_SIZE} bytes, got ${seed.length}`,
+    );
+  }
+
+  const cleanVaultId = stripHexPrefix(vaultId);
+  const cleanDepositorPk = stripHexPrefix(depositorPk);
+
+  const chainCode = seed.slice(KEY_SIZE, SEED_SIZE);
+  const parentKey = seed.slice(0, KEY_SIZE);
+  const hmacPreimage = concatBytes(
+    parentKey,
+    concatBytes(
+      lengthPrefixed(stringToBytes(cleanVaultId)),
+      lengthPrefixed(stringToBytes(cleanDepositorPk)),
+      lengthPrefixed(stringToBytes(stripHexPrefix(appContractAddress))),
+    ),
+  );
+  const hmacResult = hmacSha512(chainCode, hmacPreimage);
+  const derivedKey = hmacResult.slice(0, KEY_SIZE);
+
+  try {
+    const blocks: WotsBlockPublicKey[] = [];
+
+    for (
+      let blockIdx = 0;
+      blockIdx < ASSERT_WOTS_BLOCK_DIGIT_COUNTS.length;
+      blockIdx++
+    ) {
+      const n = ASSERT_WOTS_BLOCK_DIGIT_COUNTS[blockIdx];
+      const config = createWotsConfig(n);
+
+      // Derive per-block 20-byte seed: hash160(derivedKey || blockIndex)
+      const blockSeedInput = new Uint8Array(derivedKey.length + 1);
+      blockSeedInput.set(derivedKey);
+      blockSeedInput[derivedKey.length] = blockIdx;
+      const blockSeed = hash160(blockSeedInput);
+
+      try {
+        const block = deriveBlockPublicKey(blockSeed, config);
+
+        // Runtime validation (Codex review requirement)
+        if (block.config.d !== WOTS_DIGIT_BITS) {
+          throw new Error(`Block ${blockIdx}: expected d=${WOTS_DIGIT_BITS}, got d=${block.config.d}`);
+        }
+        if (block.config.n !== n) {
+          throw new Error(`Block ${blockIdx}: expected n=${n}, got n=${block.config.n}`);
+        }
+        if (block.message_terminals.length !== n) {
+          throw new Error(`Block ${blockIdx}: expected ${n} message terminals, got ${block.message_terminals.length}`);
+        }
+        for (let t = 0; t < block.message_terminals.length; t++) {
+          if (block.message_terminals[t].length !== CHAIN_ELEMENT_SIZE) {
+            throw new Error(`Block ${blockIdx} terminal ${t}: expected ${CHAIN_ELEMENT_SIZE} bytes, got ${block.message_terminals[t].length}`);
+          }
+        }
+        if (block.checksum_minor_terminal.length !== CHAIN_ELEMENT_SIZE) {
+          throw new Error(`Block ${blockIdx} checksum_minor: expected ${CHAIN_ELEMENT_SIZE} bytes`);
+        }
+        if (block.checksum_major_terminal.length !== CHAIN_ELEMENT_SIZE) {
+          throw new Error(`Block ${blockIdx} checksum_major: expected ${CHAIN_ELEMENT_SIZE} bytes`);
+        }
+
+        blocks.push(block);
+      } finally {
+        blockSeedInput.fill(0);
+        blockSeed.fill(0);
+      }
+    }
+
+    if (blocks.length !== ASSERT_WOTS_BLOCK_DIGIT_COUNTS.length) {
+      throw new Error(
+        `Expected ${ASSERT_WOTS_BLOCK_DIGIT_COUNTS.length} blocks, got ${blocks.length}`,
+      );
+    }
+
+    return blocks;
+  } finally {
+    hmacPreimage.fill(0);
+    chainCode.fill(0);
+    parentKey.fill(0);
+    hmacResult.fill(0);
+    derivedKey.fill(0);
+    seed.fill(0);
+  }
+}
+
+/** Validate a single chain terminal: correct length and all bytes in [0, 255]. */
+function validateTerminal(
+  terminal: number[],
+  blockIdx: number,
+  label: string,
+): void {
+  if (terminal.length !== CHAIN_ELEMENT_SIZE) {
+    throw new Error(
+      `Block ${blockIdx} ${label}: expected ${CHAIN_ELEMENT_SIZE} bytes, got ${terminal.length}`,
+    );
+  }
+  for (let j = 0; j < terminal.length; j++) {
+    const b = terminal[j];
+    if (!Number.isInteger(b) || b < 0 || b > 255) {
+      throw new Error(
+        `Block ${blockIdx} ${label}[${j}]: invalid byte value ${b}`,
+      );
+    }
+  }
+}
+
+/**
+ * Compute the keccak256 hash of WOTS block public keys.
+ *
+ * Matches Rust `btc_vault::wots_public_keys_keccak256`: for each block,
+ * chain tips are concatenated in canonical order
+ * `[checksum_minor, checksum_major, message_terminals...]`, then all
+ * blocks are concatenated and hashed.
+ *
+ * The result is committed on-chain as `depositorWotsPkHash` so the vault
+ * provider can verify submitted WOTS public keys.
+ *
+ * @param publicKeys - Array of WOTS block public keys (must not be empty).
+ * @returns 0x-prefixed keccak256 hex string.
+ */
+export function computeWotsBlockPublicKeysHash(
+  publicKeys: WotsBlockPublicKey[],
+): Hex {
+  if (publicKeys.length === 0) {
+    throw new Error("Public keys array must not be empty");
+  }
+
+  // Validate block structure before hashing to prevent silent zero-padding
+  // or byte wrapping from out-of-range number[] values
+  for (let i = 0; i < publicKeys.length; i++) {
+    const pk = publicKeys[i];
+    validateTerminal(pk.checksum_minor_terminal, i, "checksum_minor_terminal");
+    validateTerminal(pk.checksum_major_terminal, i, "checksum_major_terminal");
+    for (let t = 0; t < pk.message_terminals.length; t++) {
+      validateTerminal(pk.message_terminals[t], i, `message_terminal[${t}]`);
+    }
+  }
+
+  let totalTips = 0;
+  for (const pk of publicKeys) {
+    totalTips += WOTS_CHECKSUM_DIGITS + pk.message_terminals.length;
+  }
+
+  const buffer = new Uint8Array(totalTips * CHAIN_ELEMENT_SIZE);
+  let offset = 0;
+
+  for (const pk of publicKeys) {
+    // Canonical order: checksum_minor, checksum_major, then message terminals
+    buffer.set(pk.checksum_minor_terminal, offset);
+    offset += CHAIN_ELEMENT_SIZE;
+    buffer.set(pk.checksum_major_terminal, offset);
+    offset += CHAIN_ELEMENT_SIZE;
+    for (const terminal of pk.message_terminals) {
+      buffer.set(terminal, offset);
+      offset += CHAIN_ELEMENT_SIZE;
+    }
+  }
+
+  const digest = keccak_256(buffer);
+  return `0x${toHex(digest)}`;
+}

--- a/packages/babylon-ts-sdk/src/tbv/core/wots/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/wots/index.ts
@@ -5,5 +5,9 @@ export {
   keypairToPublicKey,
   computeWotsPkHash,
 } from "./derivation";
+export {
+  deriveWotsBlockPublicKeys,
+  computeWotsBlockPublicKeysHash,
+} from "./blockDerivation";
 export { deriveWotsPkHash } from "./deriveWotsPkHash";
 export { isWotsMismatchError } from "./errors";

--- a/services/vault/src/clients/eth-contract/sdk-readers.ts
+++ b/services/vault/src/clients/eth-contract/sdk-readers.ts
@@ -1,0 +1,99 @@
+/**
+ * SDK Reader Factory
+ *
+ * Provides lazy-initialized singleton instances of SDK contract readers
+ * for transaction-critical paths (payout signing, refund tx construction).
+ *
+ * Resolves ProtocolParams and ApplicationRegistry addresses from
+ * BTCVaultRegistry on first use, then caches the reader instances.
+ *
+ * Display-only data (ProtocolParamsContext, provider listings) continues
+ * to use the existing GraphQL/contract modules for performance.
+ */
+
+import {
+  resolveProtocolAddresses,
+  ViemProtocolParamsReader,
+  ViemUniversalChallengerReader,
+  ViemVaultKeeperReader,
+} from "@babylonlabs-io/ts-sdk/tbv/core/clients";
+
+import { CONTRACTS } from "../../config/contracts";
+
+import { ethClient } from "./client";
+
+let protocolParamsReader: ViemProtocolParamsReader | null = null;
+let vaultKeeperReader: ViemVaultKeeperReader | null = null;
+let universalChallengerReader: ViemUniversalChallengerReader | null = null;
+let initPromise: Promise<void> | null = null;
+
+/**
+ * Resolve addresses and construct all readers. Called once on first use.
+ * Uses promise memoization to prevent redundant RPC calls when multiple
+ * getters are called concurrently (e.g. Promise.all in refund service).
+ * Resets on failure so transient RPC errors can be retried.
+ */
+async function ensureReaders(): Promise<void> {
+  if (protocolParamsReader && vaultKeeperReader && universalChallengerReader) {
+    return;
+  }
+  if (initPromise) return initPromise;
+
+  initPromise = (async () => {
+    const publicClient = ethClient.getPublicClient();
+    const addresses = await resolveProtocolAddresses(
+      publicClient,
+      CONTRACTS.BTC_VAULT_REGISTRY,
+    );
+
+    // Construct all readers before assigning to singletons (atomic swap)
+    const ppReader = new ViemProtocolParamsReader(
+      publicClient,
+      addresses.protocolParams,
+    );
+    const vkReader = new ViemVaultKeeperReader(
+      publicClient,
+      addresses.applicationRegistry,
+    );
+    const ucReader = new ViemUniversalChallengerReader(
+      publicClient,
+      addresses.protocolParams,
+    );
+
+    protocolParamsReader = ppReader;
+    vaultKeeperReader = vkReader;
+    universalChallengerReader = ucReader;
+  })().catch((error) => {
+    initPromise = null;
+    throw error;
+  });
+
+  return initPromise;
+}
+
+/**
+ * Get the protocol params reader (contract-based).
+ * Use for transaction-critical timelock and offchain param lookups.
+ */
+export async function getProtocolParamsReader(): Promise<ViemProtocolParamsReader> {
+  await ensureReaders();
+  return protocolParamsReader!;
+}
+
+/**
+ * Get the vault keeper reader (contract-based).
+ * Use for transaction-critical versioned keeper lookups.
+ */
+export async function getVaultKeeperReader(): Promise<ViemVaultKeeperReader> {
+  await ensureReaders();
+  return vaultKeeperReader!;
+}
+
+/**
+ * Get the universal challenger reader (contract-based).
+ * Use for transaction-critical versioned challenger lookups.
+ */
+export async function getUniversalChallengerReader(): Promise<ViemUniversalChallengerReader> {
+  await ensureReaders();
+  return universalChallengerReader!;
+}

--- a/services/vault/src/components/deposit/PayoutSignModal/usePayoutSigningState.ts
+++ b/services/vault/src/components/deposit/PayoutSignModal/usePayoutSigningState.ts
@@ -85,8 +85,7 @@ export function usePayoutSigningState({
   const { findProvider, vaultKeepers } = useVaultProviders(
     activity.applicationEntryPoint,
   );
-  const { latestUniversalChallengers, getUniversalChallengersByVersion } =
-    useProtocolParamsContext();
+  const { latestUniversalChallengers } = useProtocolParamsContext();
   const btcConnector = useChainConnector("BTC");
   const { setOptimisticStatus } = usePeginPolling();
 
@@ -185,7 +184,6 @@ export function usePayoutSigningState({
         vaultId: activity.id,
         depositorBtcPubkey: btcPublicKey,
         vaultProviderBtcPubKey: provider.btcPubKey,
-        getUniversalChallengersByVersion,
         registeredPayoutScriptPubKey: activity.depositorPayoutBtcAddress,
       });
 
@@ -246,7 +244,6 @@ export function usePayoutSigningState({
     findProvider,
     vaultKeepers,
     latestUniversalChallengers,
-    getUniversalChallengersByVersion,
     btcConnector?.connectedWallet?.account?.address,
     btcConnector?.connectedWallet?.provider,
     btcPublicKey,

--- a/services/vault/src/hooks/deposit/depositFlowSteps/payoutSigning.ts
+++ b/services/vault/src/hooks/deposit/depositFlowSteps/payoutSigning.ts
@@ -19,20 +19,16 @@ import { updatePendingPeginStatus } from "@/storage/peginStorage";
 import { stripHexPrefix } from "@/utils/btc";
 import { createVpClient } from "@/utils/rpc";
 
-import type { UniversalChallenger } from "../../../types";
-
 export interface SignAndSubmitPayoutsParams {
   /** Derived vault ID (for contract reads + localStorage) */
   vaultId: string;
   /** Raw BTC pegin transaction hash */
   peginTxHash: string;
   depositorBtcPubkey: string;
-  /** Vault provider BTC public key hint (optional — resolved from contract if missing) */
+  /** Vault provider BTC public key hint (optional — resolved from GraphQL if missing) */
   providerBtcPubKey?: string;
   /** Depositor's registered payout scriptPubKey (hex) */
   registeredPayoutScriptPubKey: string;
-  /** Function to resolve UCs by their on-chain version */
-  getUniversalChallengersByVersion: (version: number) => UniversalChallenger[];
   /** Bitcoin wallet for signing */
   btcWallet: BitcoinWallet;
   /** Depositor's Ethereum address (for localStorage) */
@@ -60,7 +56,6 @@ export async function signAndSubmitPayouts(
     depositorBtcPubkey,
     providerBtcPubKey,
     registeredPayoutScriptPubKey,
-    getUniversalChallengersByVersion,
     btcWallet,
     depositorEthAddress,
     signal,
@@ -75,7 +70,6 @@ export async function signAndSubmitPayouts(
     vaultId,
     depositorBtcPubkey,
     vaultProviderBtcPubKey: providerBtcPubKey,
-    getUniversalChallengersByVersion,
     registeredPayoutScriptPubKey,
   });
 

--- a/services/vault/src/hooks/deposit/useDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useDepositFlow.ts
@@ -242,14 +242,8 @@ export function useDepositFlow(
   const { btcAddress, spendableUTXOs, isUTXOsLoading, utxoError } =
     useBtcWalletState();
   const { findProvider } = useVaultProviders(selectedApplication);
-  const {
-    config,
-    timelockPegin,
-    timelockRefund,
-    minDeposit,
-    maxDeposit,
-    getUniversalChallengersByVersion,
-  } = useProtocolParamsContext();
+  const { config, timelockPegin, timelockRefund, minDeposit, maxDeposit } =
+    useProtocolParamsContext();
 
   // ============================================================================
   // Main Execution Function
@@ -595,7 +589,6 @@ export function useDepositFlow(
               providerBtcPubKey: provider.btcPubKey,
               registeredPayoutScriptPubKey:
                 btcAddressToScriptPubKeyHex(confirmedBtcAddress),
-              getUniversalChallengersByVersion,
               btcWallet: confirmedBtcWallet,
               depositorEthAddress: confirmedEthAddress,
               signal,
@@ -738,7 +731,6 @@ export function useDepositFlow(
       vaultProviderBtcPubkey,
       vaultKeeperBtcPubkeys,
       universalChallengerBtcPubkeys,
-      getUniversalChallengersByVersion,
       timelockPegin,
       timelockRefund,
       config,

--- a/services/vault/src/services/providers/__tests__/fetchProviders.test.ts
+++ b/services/vault/src/services/providers/__tests__/fetchProviders.test.ts
@@ -1,11 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { graphqlClient } from "../../../clients/graphql";
-import {
-  fetchAppProviders,
-  fetchVaultKeepersByVersion,
-  getLatestVersionKeepers,
-} from "../fetchProviders";
+import { fetchAppProviders, getLatestVersionKeepers } from "../fetchProviders";
 
 vi.mock("../../../clients/graphql", () => ({
   graphqlClient: {
@@ -173,47 +169,6 @@ describe("fetchProviders", () => {
         { id: "0xkeeper1", btcPubKey: "0xpubkey1" },
         { id: "0xkeeper2", btcPubKey: "0xpubkey2" },
       ]);
-    });
-  });
-
-  describe("fetchVaultKeepersByVersion", () => {
-    it("should fetch keepers and map to VaultKeeper format", async () => {
-      mockRequest.mockResolvedValueOnce({
-        vaultKeeperApplications: {
-          items: [
-            {
-              vaultKeeper: "0xkeeper1",
-              version: 1,
-              vaultKeeperInfo: { btcPubKey: "0xpubkey1" },
-            },
-            {
-              vaultKeeper: "0xkeeper2",
-              version: 2,
-              vaultKeeperInfo: { btcPubKey: "0xpubkey2" },
-            },
-          ],
-        },
-      });
-
-      const result = await fetchVaultKeepersByVersion("0xAppController", 2);
-
-      expect(result).toEqual([
-        { id: "0xkeeper1", btcPubKey: "0xpubkey1" },
-        { id: "0xkeeper2", btcPubKey: "0xpubkey2" },
-      ]);
-    });
-
-    it("should pass correct variables to GraphQL query", async () => {
-      mockRequest.mockResolvedValueOnce({
-        vaultKeeperApplications: { items: [] },
-      });
-
-      await fetchVaultKeepersByVersion("0xABCDEF", 3);
-
-      expect(mockRequest).toHaveBeenCalledWith(expect.anything(), {
-        appController: "0xabcdef",
-        keepersVersion: 3,
-      });
     });
   });
 });

--- a/services/vault/src/services/providers/fetchProviders.ts
+++ b/services/vault/src/services/providers/fetchProviders.ts
@@ -29,19 +29,6 @@ interface GraphQLAppProvidersResponse {
   };
 }
 
-/** GraphQL response for versioned keepers-only query */
-interface VersionedKeepersResponse {
-  vaultKeeperApplications: {
-    items: Array<{
-      vaultKeeper: string;
-      version: number;
-      vaultKeeperInfo: {
-        btcPubKey: string;
-      };
-    }>;
-  };
-}
-
 const GET_APP_PROVIDERS = gql`
   query GetAppProviders($appController: String!) {
     vaultProviders(where: { applicationEntryPoint: $appController }) {
@@ -53,23 +40,6 @@ const GET_APP_PROVIDERS = gql`
       }
     }
     vaultKeeperApplications(where: { applicationEntryPoint: $appController }) {
-      items {
-        vaultKeeper
-        version
-        vaultKeeperInfo {
-          btcPubKey
-        }
-      }
-    }
-  }
-`;
-
-/** GraphQL query to fetch vault keepers by exact version */
-const GET_KEEPERS_BY_VERSION = gql`
-  query GetKeepersByVersion($appController: String!, $keepersVersion: Int!) {
-    vaultKeeperApplications(
-      where: { applicationEntryPoint: $appController, version: $keepersVersion }
-    ) {
       items {
         vaultKeeper
         version
@@ -101,33 +71,6 @@ export function getLatestVersionKeepers(
   }
 
   return result;
-}
-
-/**
- * Fetches vault keepers by version for a specific application.
- * Used for payout signing where we need the keepers that were locked
- * when the vault was created.
- *
- * @param applicationEntryPoint - The application controller address
- * @param appVaultKeepersVersion - The vault keepers version locked at vault creation
- * @returns Array of vault keepers for that version
- */
-export async function fetchVaultKeepersByVersion(
-  applicationEntryPoint: string,
-  appVaultKeepersVersion: number,
-): Promise<VaultKeeper[]> {
-  const response = await graphqlClient.request<VersionedKeepersResponse>(
-    GET_KEEPERS_BY_VERSION,
-    {
-      appController: applicationEntryPoint.toLowerCase(),
-      keepersVersion: appVaultKeepersVersion,
-    },
-  );
-
-  return response.vaultKeeperApplications.items.map((item) => ({
-    id: item.vaultKeeper,
-    btcPubKey: item.vaultKeeperInfo.btcPubKey,
-  }));
 }
 
 /**

--- a/services/vault/src/services/providers/index.ts
+++ b/services/vault/src/services/providers/index.ts
@@ -1,8 +1,4 @@
-export {
-  fetchAppProviders,
-  fetchVaultKeepersByVersion,
-  getLatestVersionKeepers,
-} from "./fetchProviders";
+export { fetchAppProviders, getLatestVersionKeepers } from "./fetchProviders";
 export {
   fetchAllUniversalChallengers,
   type UniversalChallengersData,

--- a/services/vault/src/services/vault/__tests__/vaultPayoutSignatureService.test.ts
+++ b/services/vault/src/services/vault/__tests__/vaultPayoutSignatureService.test.ts
@@ -2,8 +2,6 @@ import type { ClaimerTransactions } from "@babylonlabs-io/ts-sdk/tbv/core/client
 import { describe, expect, it, vi } from "vitest";
 
 import { getVaultFromChain } from "../../../clients/eth-contract/btc-vault-registry/query";
-import { getTimelockPeginByVersion } from "../../../clients/eth-contract/protocol-params";
-import { fetchVaultKeepersByVersion } from "../../providers/fetchProviders";
 import { fetchVaultProviderById } from "../fetchVaultProviders";
 import {
   getSortedUniversalChallengerPubkeys,
@@ -31,20 +29,29 @@ vi.mock("../../../clients/eth-contract/btc-vault-registry/query", () => ({
   getVaultFromChain: vi.fn(),
 }));
 
-// Mock versioned vault keeper fetch (used by prepareSigningContext)
-vi.mock("../../providers/fetchProviders", () => ({
-  fetchVaultKeepersByVersion: vi.fn(),
+// Mock SDK readers (used by prepareSigningContext for contract-based reads)
+const mockGetTimelockPeginByVersion = vi.fn();
+const mockGetVaultKeepersByVersion = vi.fn();
+const mockGetUniversalChallengersByVersion = vi.fn();
+vi.mock("../../../clients/eth-contract/sdk-readers", () => ({
+  getProtocolParamsReader: vi.fn().mockResolvedValue({
+    getTimelockPeginByVersion: (...args: unknown[]) =>
+      mockGetTimelockPeginByVersion(...args),
+  }),
+  getVaultKeeperReader: vi.fn().mockResolvedValue({
+    getVaultKeepersByVersion: (...args: unknown[]) =>
+      mockGetVaultKeepersByVersion(...args),
+  }),
+  getUniversalChallengerReader: vi.fn().mockResolvedValue({
+    getUniversalChallengersByVersion: (...args: unknown[]) =>
+      mockGetUniversalChallengersByVersion(...args),
+  }),
 }));
 
 // Mock RPC client
 vi.mock("@babylonlabs-io/ts-sdk/tbv/core/clients", async (importOriginal) => ({
   ...(await importOriginal()),
   VaultProviderRpcClient: vi.fn(),
-}));
-
-// Mock versioned timelockPegin lookup (used by prepareSigningContext)
-vi.mock("../../../clients/eth-contract/protocol-params", () => ({
-  getTimelockPeginByVersion: vi.fn(),
 }));
 
 // Mock config
@@ -733,14 +740,16 @@ describe("vaultPayoutSignatureService", () => {
 
     it("sources peginTxHex from on-chain vault data, not params", async () => {
       vi.mocked(getVaultFromChain).mockResolvedValue(onChainVault);
-      vi.mocked(fetchVaultKeepersByVersion).mockResolvedValue(vaultKeepers);
-      vi.mocked(getTimelockPeginByVersion).mockResolvedValue(100);
+      mockGetVaultKeepersByVersion.mockResolvedValue(vaultKeepers);
+      mockGetTimelockPeginByVersion.mockResolvedValue(100);
+      mockGetUniversalChallengersByVersion.mockResolvedValue(
+        universalChallengers,
+      );
 
       const { context } = await prepareSigningContext({
         vaultId,
         depositorBtcPubkey,
         vaultProviderBtcPubKey,
-        getUniversalChallengersByVersion: () => universalChallengers,
         registeredPayoutScriptPubKey: depositorPayoutBtcAddress,
       });
 
@@ -750,18 +759,20 @@ describe("vaultPayoutSignatureService", () => {
 
     it("fetches vault keepers using version from on-chain vault", async () => {
       vi.mocked(getVaultFromChain).mockResolvedValue(onChainVault);
-      vi.mocked(fetchVaultKeepersByVersion).mockResolvedValue(vaultKeepers);
-      vi.mocked(getTimelockPeginByVersion).mockResolvedValue(100);
+      mockGetVaultKeepersByVersion.mockResolvedValue(vaultKeepers);
+      mockGetTimelockPeginByVersion.mockResolvedValue(100);
+      mockGetUniversalChallengersByVersion.mockResolvedValue(
+        universalChallengers,
+      );
 
       await prepareSigningContext({
         vaultId,
         depositorBtcPubkey,
         vaultProviderBtcPubKey,
-        getUniversalChallengersByVersion: () => universalChallengers,
         registeredPayoutScriptPubKey: depositorPayoutBtcAddress,
       });
 
-      expect(fetchVaultKeepersByVersion).toHaveBeenCalledWith(
+      expect(mockGetVaultKeepersByVersion).toHaveBeenCalledWith(
         onChainVault.applicationEntryPoint,
         onChainVault.appVaultKeepersVersion,
       );
@@ -769,37 +780,35 @@ describe("vaultPayoutSignatureService", () => {
 
     it("selects universal challengers using version from on-chain vault", async () => {
       vi.mocked(getVaultFromChain).mockResolvedValue(onChainVault);
-      vi.mocked(fetchVaultKeepersByVersion).mockResolvedValue(vaultKeepers);
-
-      const getUniversalChallengersByVersion = vi
-        .fn()
-        .mockReturnValue(universalChallengers);
-      vi.mocked(getTimelockPeginByVersion).mockResolvedValue(100);
+      mockGetVaultKeepersByVersion.mockResolvedValue(vaultKeepers);
+      mockGetTimelockPeginByVersion.mockResolvedValue(100);
+      mockGetUniversalChallengersByVersion.mockResolvedValue(
+        universalChallengers,
+      );
 
       await prepareSigningContext({
         vaultId,
         depositorBtcPubkey,
         vaultProviderBtcPubKey,
-        getUniversalChallengersByVersion,
         registeredPayoutScriptPubKey: depositorPayoutBtcAddress,
       });
 
-      expect(getUniversalChallengersByVersion).toHaveBeenCalledWith(
+      expect(mockGetUniversalChallengersByVersion).toHaveBeenCalledWith(
         onChainVault.universalChallengersVersion,
       );
     });
 
     it("throws when no universal challengers exist for the on-chain version", async () => {
       vi.mocked(getVaultFromChain).mockResolvedValue(onChainVault);
-      vi.mocked(fetchVaultKeepersByVersion).mockResolvedValue(vaultKeepers);
-      vi.mocked(getTimelockPeginByVersion).mockResolvedValue(100);
+      mockGetVaultKeepersByVersion.mockResolvedValue(vaultKeepers);
+      mockGetTimelockPeginByVersion.mockResolvedValue(100);
+      mockGetUniversalChallengersByVersion.mockResolvedValue([]);
 
       await expect(
         prepareSigningContext({
           vaultId,
           depositorBtcPubkey,
           vaultProviderBtcPubKey,
-          getUniversalChallengersByVersion: () => [],
           registeredPayoutScriptPubKey: depositorPayoutBtcAddress,
         }),
       ).rejects.toThrow(
@@ -807,20 +816,42 @@ describe("vaultPayoutSignatureService", () => {
       );
     });
 
+    it("throws when no vault keepers exist for the on-chain version", async () => {
+      vi.mocked(getVaultFromChain).mockResolvedValue(onChainVault);
+      mockGetVaultKeepersByVersion.mockResolvedValue([]);
+      mockGetTimelockPeginByVersion.mockResolvedValue(100);
+      mockGetUniversalChallengersByVersion.mockResolvedValue(
+        universalChallengers,
+      );
+
+      await expect(
+        prepareSigningContext({
+          vaultId,
+          depositorBtcPubkey,
+          vaultProviderBtcPubKey,
+          registeredPayoutScriptPubKey: depositorPayoutBtcAddress,
+        }),
+      ).rejects.toThrow(
+        `No vault keepers found for version ${onChainVault.appVaultKeepersVersion}`,
+      );
+    });
+
     it("derives timelockPegin from vault's locked offchainParamsVersion", async () => {
       vi.mocked(getVaultFromChain).mockResolvedValue(onChainVault);
-      vi.mocked(fetchVaultKeepersByVersion).mockResolvedValue(vaultKeepers);
-      vi.mocked(getTimelockPeginByVersion).mockResolvedValue(42);
+      mockGetVaultKeepersByVersion.mockResolvedValue(vaultKeepers);
+      mockGetTimelockPeginByVersion.mockResolvedValue(42);
+      mockGetUniversalChallengersByVersion.mockResolvedValue(
+        universalChallengers,
+      );
 
       const { context } = await prepareSigningContext({
         vaultId,
         depositorBtcPubkey,
         vaultProviderBtcPubKey,
-        getUniversalChallengersByVersion: () => universalChallengers,
         registeredPayoutScriptPubKey: depositorPayoutBtcAddress,
       });
 
-      expect(getTimelockPeginByVersion).toHaveBeenCalledWith(
+      expect(mockGetTimelockPeginByVersion).toHaveBeenCalledWith(
         onChainVault.offchainParamsVersion,
       );
       expect(context.timelockPegin).toBe(42);
@@ -828,8 +859,11 @@ describe("vaultPayoutSignatureService", () => {
 
     it("resolves vault provider btc pubkey from GraphQL using on-chain address when not provided inline", async () => {
       vi.mocked(getVaultFromChain).mockResolvedValue(onChainVault);
-      vi.mocked(fetchVaultKeepersByVersion).mockResolvedValue(vaultKeepers);
-      vi.mocked(getTimelockPeginByVersion).mockResolvedValue(100);
+      mockGetVaultKeepersByVersion.mockResolvedValue(vaultKeepers);
+      mockGetTimelockPeginByVersion.mockResolvedValue(100);
+      mockGetUniversalChallengersByVersion.mockResolvedValue(
+        universalChallengers,
+      );
       vi.mocked(fetchVaultProviderById).mockResolvedValue({
         btcPubKey: "0xfetchedproviderkey",
       } as any);
@@ -838,7 +872,6 @@ describe("vaultPayoutSignatureService", () => {
         vaultId,
         depositorBtcPubkey,
         vaultProviderBtcPubKey: undefined,
-        getUniversalChallengersByVersion: () => universalChallengers,
         registeredPayoutScriptPubKey: depositorPayoutBtcAddress,
       });
 
@@ -850,14 +883,16 @@ describe("vaultPayoutSignatureService", () => {
 
     it("includes registeredPayoutScriptPubKey in signing context", async () => {
       vi.mocked(getVaultFromChain).mockResolvedValue(onChainVault);
-      vi.mocked(fetchVaultKeepersByVersion).mockResolvedValue(vaultKeepers);
-      vi.mocked(getTimelockPeginByVersion).mockResolvedValue(100);
+      mockGetVaultKeepersByVersion.mockResolvedValue(vaultKeepers);
+      mockGetTimelockPeginByVersion.mockResolvedValue(100);
+      mockGetUniversalChallengersByVersion.mockResolvedValue(
+        universalChallengers,
+      );
 
       const { context } = await prepareSigningContext({
         vaultId,
         depositorBtcPubkey,
         vaultProviderBtcPubKey,
-        getUniversalChallengersByVersion: () => universalChallengers,
         registeredPayoutScriptPubKey: depositorPayoutBtcAddress,
       });
 

--- a/services/vault/src/services/vault/__tests__/vaultRefundService.test.ts
+++ b/services/vault/src/services/vault/__tests__/vaultRefundService.test.ts
@@ -14,20 +14,27 @@ vi.mock("../../../clients/eth-contract/btc-vault-registry/query", () => ({
   getVaultFromChain: vi.fn(),
 }));
 
-vi.mock("../../../clients/eth-contract/protocol-params", () => ({
-  getOffchainParamsByVersion: vi.fn(),
-}));
-
 vi.mock("../../../config/pegin", () => ({
   getBTCNetworkForWASM: vi.fn().mockReturnValue("testnet"),
 }));
 
-vi.mock("../../providers", () => ({
-  fetchAllUniversalChallengers: vi.fn(),
-}));
-
-vi.mock("../../providers/fetchProviders", () => ({
-  fetchVaultKeepersByVersion: vi.fn(),
+// Mock SDK readers (used by buildAndBroadcastRefundTransaction for contract-based reads)
+const mockGetOffchainParamsByVersion = vi.fn();
+const mockGetVaultKeepersByVersion = vi.fn();
+const mockGetUniversalChallengersByVersion = vi.fn();
+vi.mock("../../../clients/eth-contract/sdk-readers", () => ({
+  getProtocolParamsReader: vi.fn().mockResolvedValue({
+    getOffchainParamsByVersion: (...args: unknown[]) =>
+      mockGetOffchainParamsByVersion(...args),
+  }),
+  getVaultKeeperReader: vi.fn().mockResolvedValue({
+    getVaultKeepersByVersion: (...args: unknown[]) =>
+      mockGetVaultKeepersByVersion(...args),
+  }),
+  getUniversalChallengerReader: vi.fn().mockResolvedValue({
+    getUniversalChallengersByVersion: (...args: unknown[]) =>
+      mockGetUniversalChallengersByVersion(...args),
+  }),
 }));
 
 vi.mock("../fetchVaultProviders", () => ({
@@ -60,9 +67,6 @@ import {
 import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 
 import { getVaultFromChain } from "../../../clients/eth-contract/btc-vault-registry/query";
-import { getOffchainParamsByVersion } from "../../../clients/eth-contract/protocol-params";
-import { fetchAllUniversalChallengers } from "../../providers";
-import { fetchVaultKeepersByVersion } from "../../providers/fetchProviders";
 import { fetchVaultProviderById } from "../fetchVaultProviders";
 import { fetchVaultById } from "../fetchVaults";
 import { buildAndBroadcastRefundTransaction } from "../vaultRefundService";
@@ -71,11 +75,11 @@ const VAULT_ID = "0xdeadbeef" as `0x${string}`;
 const DEPOSITOR_PUBKEY = "aabbccdd";
 
 const ON_CHAIN_VAULT = {
-  offchainParamsVersion: 1n,
+  offchainParamsVersion: 1,
   vaultProvider: "0xprovider",
   applicationEntryPoint: "0xapp",
-  appVaultKeepersVersion: 1n,
-  universalChallengersVersion: 1n,
+  appVaultKeepersVersion: 1,
+  universalChallengersVersion: 1,
   hashlock: "0xhashlock",
   htlcVout: 0,
 };
@@ -106,12 +110,12 @@ describe("vaultRefundService - buildAndBroadcastRefundTransaction", () => {
 
     (getVaultFromChain as Mock).mockResolvedValue(ON_CHAIN_VAULT);
     (fetchVaultById as Mock).mockResolvedValue(INDEXER_VAULT);
-    (getOffchainParamsByVersion as Mock).mockResolvedValue(OFFCHAIN_PARAMS);
+    mockGetOffchainParamsByVersion.mockResolvedValue(OFFCHAIN_PARAMS);
     (fetchVaultProviderById as Mock).mockResolvedValue(VAULT_PROVIDER);
-    (fetchVaultKeepersByVersion as Mock).mockResolvedValue(VAULT_KEEPERS);
-    (fetchAllUniversalChallengers as Mock).mockResolvedValue({
-      byVersion: new Map([[1n, UNIVERSAL_CHALLENGERS]]),
-    });
+    mockGetVaultKeepersByVersion.mockResolvedValue(VAULT_KEEPERS);
+    mockGetUniversalChallengersByVersion.mockResolvedValue(
+      UNIVERSAL_CHALLENGERS,
+    );
     (getNetworkFees as Mock).mockResolvedValue({ halfHourFee: 10 });
     (buildRefundPsbt as Mock).mockResolvedValue({ psbtHex: "psbt_hex" });
     (pushTx as Mock).mockResolvedValue("tx_id_abc123");
@@ -145,7 +149,7 @@ describe("vaultRefundService - buildAndBroadcastRefundTransaction", () => {
   });
 
   it("throws when no vault keepers are found", async () => {
-    (fetchVaultKeepersByVersion as Mock).mockResolvedValue([]);
+    mockGetVaultKeepersByVersion.mockResolvedValue([]);
 
     await expect(
       buildAndBroadcastRefundTransaction({
@@ -159,9 +163,7 @@ describe("vaultRefundService - buildAndBroadcastRefundTransaction", () => {
   });
 
   it("throws when no universal challengers are found for the version", async () => {
-    (fetchAllUniversalChallengers as Mock).mockResolvedValue({
-      byVersion: new Map(),
-    });
+    mockGetUniversalChallengersByVersion.mockResolvedValue([]);
 
     await expect(
       buildAndBroadcastRefundTransaction({

--- a/services/vault/src/services/vault/vaultPayoutSignatureService.ts
+++ b/services/vault/src/services/vault/vaultPayoutSignatureService.ts
@@ -8,9 +8,12 @@ import type {
 import type { Address, Hex } from "viem";
 
 import { getVaultFromChain } from "../../clients/eth-contract/btc-vault-registry/query";
-import { getTimelockPeginByVersion } from "../../clients/eth-contract/protocol-params";
+import {
+  getProtocolParamsReader,
+  getUniversalChallengerReader,
+  getVaultKeeperReader,
+} from "../../clients/eth-contract/sdk-readers";
 import { getBTCNetworkForWASM } from "../../config/pegin";
-import type { UniversalChallenger } from "../../types";
 import {
   deriveBip86ScriptPubKeyHex,
   processPublicKeyToXOnly,
@@ -18,7 +21,6 @@ import {
   validateXOnlyPubkey,
 } from "../../utils/btc";
 import { createVpClient } from "../../utils/rpc";
-import { fetchVaultKeepersByVersion } from "../providers/fetchProviders";
 
 import { fetchVaultProviderById } from "./fetchVaultProviders";
 
@@ -40,8 +42,6 @@ export interface PrepareSigningContextParams {
   depositorBtcPubkey: string;
   /** Vault provider's BTC public key hint (optional — resolved from GraphQL if missing) */
   vaultProviderBtcPubKey?: string;
-  /** Function to get UCs by version from context (avoids redundant fetch) */
-  getUniversalChallengersByVersion: (version: number) => UniversalChallenger[];
   /** Depositor's registered payout scriptPubKey (hex) for payout output validation */
   registeredPayoutScriptPubKey: string;
 }
@@ -284,8 +284,8 @@ export interface PayoutSigningProgress {
  * Prepare the signing context by fetching all required data.
  * Call this once, then use signPayout for each transaction.
  *
- * Uses versioned vault keepers (fetched) and universal challengers (from context)
- * based on the versions locked when the vault was created.
+ * Uses versioned vault keepers and universal challengers from on-chain contracts
+ * (authoritative source) based on the versions locked when the vault was created.
  */
 export async function prepareSigningContext(
   params: PrepareSigningContextParams,
@@ -294,7 +294,6 @@ export async function prepareSigningContext(
     vaultId,
     depositorBtcPubkey,
     vaultProviderBtcPubKey,
-    getUniversalChallengersByVersion,
     registeredPayoutScriptPubKey,
   } = params;
   // Fetch signing-critical vault fields from the contract (authoritative source).
@@ -305,20 +304,30 @@ export async function prepareSigningContext(
   // emits it in the PegInSubmitted event, it's not stored in the BTCVault struct.
   const vault = await getVaultFromChain(vaultId as Hex);
 
-  const timelockPegin = await getTimelockPeginByVersion(
+  const protocolParamsReader = await getProtocolParamsReader();
+  const timelockPegin = await protocolParamsReader.getTimelockPeginByVersion(
     vault.offchainParamsVersion,
   );
 
-  // Fetch versioned vault keepers (per-application)
-  const vaultKeepers = await fetchVaultKeepersByVersion(
+  // Fetch versioned vault keepers from the contract (authoritative source)
+  const vaultKeeperReader = await getVaultKeeperReader();
+  const vaultKeepers = await vaultKeeperReader.getVaultKeepersByVersion(
     vault.applicationEntryPoint,
     vault.appVaultKeepersVersion,
   );
 
-  // Get versioned universal challengers from context (system-wide)
-  const universalChallengers = getUniversalChallengersByVersion(
-    vault.universalChallengersVersion,
-  );
+  if (vaultKeepers.length === 0) {
+    throw new Error(
+      `No vault keepers found for version ${vault.appVaultKeepersVersion}`,
+    );
+  }
+
+  // Fetch versioned universal challengers from the contract (authoritative source)
+  const universalChallengerReader = await getUniversalChallengerReader();
+  const universalChallengers =
+    await universalChallengerReader.getUniversalChallengersByVersion(
+      vault.universalChallengersVersion,
+    );
 
   if (universalChallengers.length === 0) {
     throw new Error(

--- a/services/vault/src/services/vault/vaultRefundService.ts
+++ b/services/vault/src/services/vault/vaultRefundService.ts
@@ -21,10 +21,12 @@ import type { Hex } from "viem";
 
 import { getMempoolApiUrl } from "../../clients/btc/config";
 import { getVaultFromChain } from "../../clients/eth-contract/btc-vault-registry/query";
-import { getOffchainParamsByVersion } from "../../clients/eth-contract/protocol-params";
+import {
+  getProtocolParamsReader,
+  getUniversalChallengerReader,
+  getVaultKeeperReader,
+} from "../../clients/eth-contract/sdk-readers";
 import { getBTCNetworkForWASM } from "../../config/pegin";
-import { fetchAllUniversalChallengers } from "../providers";
-import { fetchVaultKeepersByVersion } from "../providers/fetchProviders";
 
 import { fetchVaultProviderById } from "./fetchVaultProviders";
 import { fetchVaultById } from "./fetchVaults";
@@ -91,7 +93,14 @@ export async function buildAndBroadcastRefundTransaction(
   if (!indexerVault) {
     throw new Error(`Vault ${vaultId} not found`);
   }
-  const offchainParams = await getOffchainParamsByVersion(
+  // Fetch transaction-critical data from contracts (authoritative source)
+  const [protocolReader, keeperReader, challengerReader] = await Promise.all([
+    getProtocolParamsReader(),
+    getVaultKeeperReader(),
+    getUniversalChallengerReader(),
+  ]);
+
+  const offchainParams = await protocolReader.getOffchainParamsByVersion(
     onChainVault.offchainParamsVersion,
   );
 
@@ -104,7 +113,7 @@ export async function buildAndBroadcastRefundTransaction(
     );
   }
 
-  const vaultKeepers = await fetchVaultKeepersByVersion(
+  const vaultKeepers = await keeperReader.getVaultKeepersByVersion(
     onChainVault.applicationEntryPoint,
     onChainVault.appVaultKeepersVersion,
   );
@@ -114,9 +123,10 @@ export async function buildAndBroadcastRefundTransaction(
     );
   }
 
-  const ucData = await fetchAllUniversalChallengers();
   const universalChallengersList =
-    ucData.byVersion.get(onChainVault.universalChallengersVersion) ?? [];
+    await challengerReader.getUniversalChallengersByVersion(
+      onChainVault.universalChallengersVersion,
+    );
   if (universalChallengersList.length === 0) {
     throw new Error(
       `Universal challengers not found for version ${onChainVault.universalChallengersVersion}`,
@@ -169,8 +179,14 @@ export async function buildAndBroadcastRefundTransaction(
 
   try {
     signedPsbt.finalizeAllInputs();
-  } catch {
-    // Some wallets finalize automatically
+  } catch (e: unknown) {
+    // Some wallets (e.g. Keystone) finalize inputs during signPsbt.
+    // If already finalized, bitcoinjs throws "Input is already finalized".
+    // Any other finalization error is a real problem — surface it.
+    const message = e instanceof Error ? e.message : String(e);
+    if (!message.includes("already finalized")) {
+      throw new Error(`Failed to finalize refund PSBT: ${message}`);
+    }
   }
 
   const signedTxHex = signedPsbt.extractTransaction().toHex();


### PR DESCRIPTION
- Adds SDK contract readers (ProtocolParamsReader, VaultKeeperReader,
  UniversalChallengerReader) with BTCVaultRegistry address resolution via multicall
- Migrates `vaultPayoutSignatureService` and `vaultRefundService` from GraphQL
  indexer to on-chain contract reads for vault keepers, universal challengers,
  timelocks, and offchain params
- Removes the `getUniversalChallengersByVersion` callback injection — challengers
  are now fetched directly from the contract like keepers
- Lazy-init singleton factory with promise memoization, atomic construction,
  and retry-on-failure for the reader instances
- GraphQL stays for display/bulk startup data (ProtocolParamsContext, provider listings)