### PR TITLE
fix(vault, wallet-connect): redact sensitive data

### DIFF
--- a/packages/babylon-wallet-connector/src/components/WalletProvider/index.tsx
+++ b/packages/babylon-wallet-connector/src/components/WalletProvider/index.tsx
@@ -84,7 +84,7 @@ export function WalletProvider({
       // Config may have eth and/or btc properties
       initializeAppKitModal(appKitConfig);
     } catch (error) {
-      console.error("Failed to initialize AppKit modal:", error);
+      console.error("Failed to initialize AppKit modal:", error instanceof Error ? error.message : "Unknown error");
     }
   }, [appKitConfig]);
 

--- a/packages/babylon-wallet-connector/src/context/Chain.context.tsx
+++ b/packages/babylon-wallet-connector/src/context/Chain.context.tsx
@@ -83,7 +83,7 @@ export function ChainProvider({
         });
         return connector;
       } catch (error) {
-        console.error("[ChainProvider] failed to create connector for chain:", chain, error);
+        console.error("[ChainProvider] failed to create connector for chain:", chain, error instanceof Error ? error.message : "Unknown error");
         throw error;
       }
     });
@@ -99,7 +99,7 @@ export function ChainProvider({
         setConnectors(connectors);
       })
       .catch((error) => {
-        console.error("[ChainProvider] init failed with error:", error);
+        console.error("[ChainProvider] init failed with error:", error instanceof Error ? error.message : "Unknown error");
         onError?.(error);
       });
   }, [setConnectors, init, onError]);

--- a/packages/babylon-wallet-connector/src/core/index.ts
+++ b/packages/babylon-wallet-connector/src/core/index.ts
@@ -98,7 +98,7 @@ export const createWalletConnector = async <N extends string, P extends IProvide
     try {
       await connector.connect(connectedWalletId);
     } catch (error) {
-      console.error({ error })
+      console.error("Auto-reconnect failed:", error instanceof Error ? error.message : "Unknown error")
     }
   }
 

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/provider.ts
@@ -104,7 +104,7 @@ export class AppKitBTCProvider implements IBTCProvider {
 
       throw new Error("Window not available for AppKit modal");
     } catch (error) {
-      console.error("[AppKit Provider] Failed to connect Bitcoin wallet:", error);
+      console.error("[AppKit Provider] Failed to connect Bitcoin wallet:", error instanceof Error ? error.message : "Unknown error");
       throw new Error(`Failed to connect Bitcoin wallet: ${error instanceof Error ? error.message : "Unknown error"}`);
     }
   }
@@ -198,7 +198,7 @@ export class AppKitBTCProvider implements IBTCProvider {
 
       return Psbt.fromBase64(result.psbt).toHex();
     } catch (error) {
-      console.error("[AppKit Provider] signPsbt failed:", error);
+      console.error("[AppKit Provider] signPsbt failed:", error instanceof Error ? error.message : "Unknown error");
       throw new Error(`Failed to sign PSBT: ${error instanceof Error ? error.message : "Unknown error"}`);
     }
   }
@@ -243,7 +243,7 @@ export class AppKitBTCProvider implements IBTCProvider {
 
       return signature;
     } catch (error) {
-      console.error("[AppKit Provider] signMessage failed:", error);
+      console.error("[AppKit Provider] signMessage failed:", error instanceof Error ? error.message : "Unknown error");
       throw new Error(`Failed to sign message: ${error instanceof Error ? error.message : "Unknown error"}`);
     }
   }

--- a/packages/babylon-wallet-connector/src/core/wallets/eth/appkit/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/eth/appkit/provider.ts
@@ -166,7 +166,7 @@ export class AppKitProvider implements IETHProvider {
       this.address = result.accounts[0];
       this.chainId = result.chainId;
     } catch (error) {
-      console.error("Failed to connect wallet:", error);
+      console.error("Failed to connect wallet:", error instanceof Error ? error.message : "Unknown error");
       throw new Error(`Failed to connect wallet: ${error instanceof Error ? error.message : "Unknown error"}`);
     }
   }

--- a/packages/babylon-wallet-connector/src/hooks/appkit/btc/useAppKitBtcBridge.ts
+++ b/packages/babylon-wallet-connector/src/hooks/appkit/btc/useAppKitBtcBridge.ts
@@ -42,7 +42,7 @@ export const useAppKitBtcBridge = ({ onError }: UseAppKitBtcBridgeOptions = {}) 
           const caipNetwork = networkMap[network];
           await adapter.switchNetwork({ caipNetwork });
         } catch (networkError) {
-          console.warn("[AppKit BTC Bridge] Failed to switch network:", networkError);
+          console.warn("[AppKit BTC Bridge] Failed to switch network:", networkError instanceof Error ? networkError.message : "Unknown error");
           // Don't fail the connection if network switch fails
           // Some wallets may already be on the correct network
         }
@@ -58,7 +58,7 @@ export const useAppKitBtcBridge = ({ onError }: UseAppKitBtcBridgeOptions = {}) 
             console.warn("[AppKit BTC Bridge] Public key not available in current account");
           }
         } catch (pkError) {
-          console.error("[AppKit BTC Bridge] Error fetching public key:", pkError);
+          console.error("[AppKit BTC Bridge] Error fetching public key:", pkError instanceof Error ? pkError.message : "Unknown error");
         }
 
         // Dispatch event to notify AppKitBTCProvider.connectWallet() that connection is ready
@@ -74,7 +74,7 @@ export const useAppKitBtcBridge = ({ onError }: UseAppKitBtcBridgeOptions = {}) 
           lastDispatchedAddress.current = currentAddress;
         }
       } catch (error) {
-        console.error("[AppKit BTC Bridge] Failed to process connection:", error);
+        console.error("[AppKit BTC Bridge] Failed to process connection:", error instanceof Error ? error.message : "Unknown error");
         onError?.(error as Error);
       }
     },
@@ -115,7 +115,7 @@ export const useAppKitBtcBridge = ({ onError }: UseAppKitBtcBridgeOptions = {}) 
       lastDispatchedAddress.current = null;
 
       btcConnector.disconnect().catch((error) => {
-        console.error("Failed to disconnect from babylon-wallet-connector:", error);
+        console.error("Failed to disconnect from babylon-wallet-connector:", error instanceof Error ? error.message : "Unknown error");
       });
     }
   }, [isConnected, address, btcConnector, onError, dispatchConnectionEvent]);

--- a/packages/babylon-wallet-connector/src/hooks/useVisibilityCheck.ts
+++ b/packages/babylon-wallet-connector/src/hooks/useVisibilityCheck.ts
@@ -31,7 +31,7 @@ export function useVisibilityCheck(
         timeoutRef.current = setTimeout(() => {
           // Wrap async callback to catch unhandled rejections
           Promise.resolve(onVisible()).catch((error) => {
-            console.error("Error in visibility check callback:", error);
+            console.error("Error in visibility check callback:", error instanceof Error ? error.message : "Unknown error");
           });
         }, delay);
       }

--- a/packages/babylon-wallet-connector/src/providers/BTCWalletProvider.tsx
+++ b/packages/babylon-wallet-connector/src/providers/BTCWalletProvider.tsx
@@ -85,7 +85,7 @@ export const BTCWalletProvider = ({ children, callbacks }: BTCWalletProviderProp
     try {
       await callbacks?.onDisconnect?.();
     } catch (error) {
-      console.error("Error in onDisconnect callback:", error);
+      console.error("Error in onDisconnect callback:", error instanceof Error ? error.message : "Unknown error");
     }
   }, [callbacks]);
 
@@ -198,7 +198,7 @@ export const BTCWalletProvider = ({ children, callbacks }: BTCWalletProviderProp
         }
       } catch (error: any) {
         // Connection failure during account change likely means wallet disconnected
-        console.error("Error handling BTC account change:", error);
+        console.error("Error handling BTC account change:", error instanceof Error ? error.message : "Unknown error");
         callbacks?.onError?.(error);
         disconnect();
       }
@@ -259,7 +259,7 @@ export const BTCWalletProvider = ({ children, callbacks }: BTCWalletProviderProp
       }
     } catch (error) {
       // Connection check failed - wallet likely disconnected
-      console.error("BTC wallet connection check failed:", error);
+      console.error("BTC wallet connection check failed:", error instanceof Error ? error.message : "Unknown error");
       disconnect();
     }
   }, [btcWalletProvider, address, callbacks, disconnect]);

--- a/packages/babylon-wallet-connector/src/providers/CosmosWalletProvider.tsx
+++ b/packages/babylon-wallet-connector/src/providers/CosmosWalletProvider.tsx
@@ -76,7 +76,7 @@ export const CosmosWalletProvider = ({
     try {
       await callbacks?.onDisconnect?.();
     } catch (error) {
-      console.error("Error in onDisconnect callback:", error);
+      console.error("Error in onDisconnect callback:", error instanceof Error ? error.message : "Unknown error");
     }
   }, [callbacks]);
 

--- a/packages/babylon-wallet-connector/src/providers/ETHWalletProvider.tsx
+++ b/packages/babylon-wallet-connector/src/providers/ETHWalletProvider.tsx
@@ -58,7 +58,7 @@ export const ETHWalletProvider = ({ children, callbacks }: ETHWalletProviderProp
     try {
       await callbacks?.onDisconnect?.();
     } catch (error) {
-      console.error("Error in onDisconnect callback:", error);
+      console.error("Error in onDisconnect callback:", error instanceof Error ? error.message : "Unknown error");
     }
   }, [ethConnector, callbacks]);
 
@@ -128,7 +128,7 @@ export const ETHWalletProvider = ({ children, callbacks }: ETHWalletProviderProp
             connectETH(addr);
           }
         } catch (error) {
-          console.error("Error getting ETH address:", error);
+          console.error("Error getting ETH address:", error instanceof Error ? error.message : "Unknown error");
         }
       }
     });
@@ -222,7 +222,7 @@ export const ETHWalletProvider = ({ children, callbacks }: ETHWalletProviderProp
       }
     } catch (error) {
       // Connection check failed - wallet likely disconnected
-      console.error("ETH wallet connection check failed:", error);
+      console.error("ETH wallet connection check failed:", error instanceof Error ? error.message : "Unknown error");
       disconnect();
     }
   }, [provider, address, callbacks, disconnect]);

--- a/services/vault/src/services/health/__tests__/healthCheckService.test.ts
+++ b/services/vault/src/services/health/__tests__/healthCheckService.test.ts
@@ -224,11 +224,14 @@ describe("healthCheckService", () => {
   });
 
   describe("createEnvConfigError", () => {
-    it("creates an error with the correct title and message", () => {
+    it("creates a generic error without leaking details to the user", () => {
       const error = createEnvConfigError("MISSING_VAR_1, MISSING_VAR_2");
 
       expect(error.title).toBe("Configuration Error");
-      expect(error.message).toContain("MISSING_VAR_1, MISSING_VAR_2");
+      expect(error.message).toBe(
+        "The application is missing required configuration. Please contact support.",
+      );
+      expect(error.message).not.toContain("MISSING_VAR_1");
     });
   });
 

--- a/services/vault/src/services/health/__tests__/healthCheckService.test.ts
+++ b/services/vault/src/services/health/__tests__/healthCheckService.test.ts
@@ -14,6 +14,14 @@ vi.mock("@/config/env", () => ({
   },
 }));
 
+vi.mock("@/infrastructure", () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+import { logger } from "@/infrastructure";
 import { ApiError } from "@/utils/errors/types";
 
 import {
@@ -232,6 +240,15 @@ describe("healthCheckService", () => {
         "The application is missing required configuration. Please contact support.",
       );
       expect(error.message).not.toContain("MISSING_VAR_1");
+    });
+
+    it("logs details to Sentry via logger.error", () => {
+      createEnvConfigError("MISSING_VAR_1, MISSING_VAR_2");
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.any(Error),
+        { data: { details: "MISSING_VAR_1, MISSING_VAR_2" } },
+      );
     });
   });
 

--- a/services/vault/src/services/health/__tests__/healthCheckService.test.ts
+++ b/services/vault/src/services/health/__tests__/healthCheckService.test.ts
@@ -245,10 +245,9 @@ describe("healthCheckService", () => {
     it("logs details to Sentry via logger.error", () => {
       createEnvConfigError("MISSING_VAR_1, MISSING_VAR_2");
 
-      expect(logger.error).toHaveBeenCalledWith(
-        expect.any(Error),
-        { data: { details: "MISSING_VAR_1, MISSING_VAR_2" } },
-      );
+      expect(logger.error).toHaveBeenCalledWith(expect.any(Error), {
+        data: { details: "MISSING_VAR_1, MISSING_VAR_2" },
+      });
     });
   });
 

--- a/services/vault/src/services/health/healthCheckService.ts
+++ b/services/vault/src/services/health/healthCheckService.ts
@@ -113,8 +113,13 @@ export function createWagmiInitError(): AppError {
 }
 
 export function createEnvConfigError(details: string): AppError {
+  logger.error(new Error("Environment configuration validation failed"), {
+    data: { details },
+  });
+
   return {
     title: "Configuration Error",
-    message: `The application is missing required configuration. Please contact support. (${details})`,
+    message:
+      "The application is missing required configuration. Please contact support.",
   };
 }

--- a/services/vault/src/utils/__tests__/telemetry.test.ts
+++ b/services/vault/src/utils/__tests__/telemetry.test.ts
@@ -256,8 +256,10 @@ describe("scrubSentryEvent", () => {
             stacktrace: {
               frames: [
                 {
-                  filename: "/app/0x742d35Cc6634C0532925a3b844Bc9e7595f2bD80/index.js",
-                  abs_path: "/abs/0x742d35Cc6634C0532925a3b844Bc9e7595f2bD80/index.js",
+                  filename:
+                    "/app/0x742d35Cc6634C0532925a3b844Bc9e7595f2bD80/index.js",
+                  abs_path:
+                    "/abs/0x742d35Cc6634C0532925a3b844Bc9e7595f2bD80/index.js",
                   module: "module.0x742d35Cc6634C0532925a3b844Bc9e7595f2bD80",
                   vars: {
                     depositorBtcPubkey: "a".repeat(64),

--- a/services/vault/src/utils/__tests__/telemetry.test.ts
+++ b/services/vault/src/utils/__tests__/telemetry.test.ts
@@ -22,6 +22,18 @@ describe("redactIdentifier", () => {
   it("returns values shorter than threshold unchanged", () => {
     expect(redactIdentifier("abc")).toBe("abc");
   });
+
+  it("returns [REDACTED] for short values when forceRedact is true", () => {
+    expect(redactIdentifier("seed", true)).toBe("[REDACTED]");
+    expect(redactIdentifier("abc", true)).toBe("[REDACTED]");
+    expect(redactIdentifier("abcd1234", true)).toBe("[REDACTED]");
+  });
+
+  it("still truncates long values normally with forceRedact", () => {
+    expect(redactIdentifier("bc1q5hj2k3l4m5n6p7q8r9s0t1u2v3w4x5", true)).toBe(
+      "bc1q...w4x5",
+    );
+  });
 });
 
 describe("scrubString", () => {
@@ -140,6 +152,14 @@ describe("redactData", () => {
     const result = redactData({ error: err }) as { error: { message: string } };
     expect(result.error).toEqual({ message: "Failed for [ETH_ADDR]" });
   });
+
+  it("redacts short sensitive field values with [REDACTED]", () => {
+    const data = { address: "0x1", publicKey: "abc", mnemonic: "word" };
+    const result = redactData(data);
+    expect(result.address).toBe("[REDACTED]");
+    expect(result.publicKey).toBe("[REDACTED]");
+    expect(result.mnemonic).toBe("[REDACTED]");
+  });
 });
 
 describe("scrubSentryEvent", () => {
@@ -224,5 +244,48 @@ describe("scrubSentryEvent", () => {
     expect(result.message).toBe("Something went wrong");
     expect(result.level).toBe("error");
     expect(result.extra?.version).toBe("1.0.0");
+  });
+
+  it("scrubs stack frame filename, abs_path, module, and vars", () => {
+    const event: SentryEvent = {
+      exception: {
+        values: [
+          {
+            type: "Error",
+            value: "something failed",
+            stacktrace: {
+              frames: [
+                {
+                  filename: "/app/0x742d35Cc6634C0532925a3b844Bc9e7595f2bD80/index.js",
+                  abs_path: "/abs/0x742d35Cc6634C0532925a3b844Bc9e7595f2bD80/index.js",
+                  module: "module.0x742d35Cc6634C0532925a3b844Bc9e7595f2bD80",
+                  vars: {
+                    depositorBtcPubkey: "a".repeat(64),
+                    localVar: "safe value",
+                  },
+                },
+                {
+                  filename: "safe-file.js",
+                  abs_path: undefined,
+                  module: undefined,
+                },
+              ],
+            },
+          },
+        ],
+      },
+    };
+    const result = scrubSentryEvent(event);
+    const frames = result.exception?.values?.[0].stacktrace?.frames;
+
+    expect(frames?.[0].filename).toBe("/app/[ETH_ADDR]/index.js");
+    expect(frames?.[0].abs_path).toBe("/abs/[ETH_ADDR]/index.js");
+    expect(frames?.[0].module).toBe("module.[ETH_ADDR]");
+    expect(frames?.[0].vars?.depositorBtcPubkey).toBe("aaaa...aaaa");
+    expect(frames?.[0].vars?.localVar).toBe("safe value");
+
+    expect(frames?.[1].filename).toBe("safe-file.js");
+    expect(frames?.[1].abs_path).toBeUndefined();
+    expect(frames?.[1].module).toBeUndefined();
   });
 });

--- a/services/vault/src/utils/telemetry.ts
+++ b/services/vault/src/utils/telemetry.ts
@@ -6,9 +6,9 @@ const REDACTED_IDENTIFIER_VISIBLE_CHARS = 4;
  * Redact a known-sensitive identifier to "first4...last4" format.
  * Preserves enough context for debugging while preventing full exposure.
  */
-export function redactIdentifier(value: string): string {
+export function redactIdentifier(value: string, forceRedact = false): string {
   if (value.length <= REDACTED_IDENTIFIER_VISIBLE_CHARS * 2) {
-    return value;
+    return forceRedact ? "[REDACTED]" : value;
   }
   const head = value.slice(0, REDACTED_IDENTIFIER_VISIBLE_CHARS);
   const tail = value.slice(-REDACTED_IDENTIFIER_VISIBLE_CHARS);
@@ -87,7 +87,7 @@ export function redactData<T>(obj: T): T {
     const result: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
       if (SENSITIVE_FIELD_NAMES.has(key) && typeof value === "string") {
-        result[key] = redactIdentifier(value);
+        result[key] = redactIdentifier(value, true);
       } else {
         result[key] = redactData(value);
       }
@@ -128,9 +128,23 @@ export function scrubSentryEvent<T extends SentryEvent>(event: T): T {
   }
 
   if (event.exception?.values) {
+    const scrubOptional = (v: string | undefined) => (v ? scrubString(v) : v);
+
     event.exception.values = event.exception.values.map((ex) => ({
       ...ex,
       value: ex.value ? scrubString(ex.value) : ex.value,
+      stacktrace: ex.stacktrace
+        ? {
+            ...ex.stacktrace,
+            frames: ex.stacktrace.frames?.map((frame) => ({
+              ...frame,
+              filename: scrubOptional(frame.filename),
+              abs_path: scrubOptional(frame.abs_path),
+              module: scrubOptional(frame.module),
+              vars: frame.vars ? redactData(frame.vars) : frame.vars,
+            })),
+          }
+        : ex.stacktrace,
     }));
   }
 


### PR DESCRIPTION
## Summary

Fixes four security audit v2 findings related to sensitive data exposure:

- **[#71](https://github.com/babylonlabs-io/vault-provider-proxy/issues/150) (LOW):** Remove env variable names and malformed values from user-facing error modal — now shows a generic message and logs details to Sentry only
- **[#34](https://github.com/babylonlabs-io/vault-provider-proxy/issues/123) (MEDIUM):** Extend `scrubSentryEvent` to scrub exception stack frame properties (`filename`, `abs_path`, `module`, `vars`) that could contain wallet addresses or key material
- **[#77](https://github.com/babylonlabs-io/vault-provider-proxy/issues/156) (LOW):** Always redact values in `SENSITIVE_FIELD_NAMES` regardless of length — short identifiers (≤8 chars) no longer pass through `redactIdentifier` unchanged
- **[#76](https://github.com/babylonlabs-io/vault-provider-proxy/issues/155) (LOW):** Replace raw error object logging with `error.message` at ~16 call sites in `wallet-connector` to prevent addresses, public keys, and PSBT data from leaking to console

Closes https://github.com/babylonlabs-io/vault-provider-proxy/issues/150
Closes https://github.com/babylonlabs-io/vault-provider-proxy/issues/155
Closes https://github.com/babylonlabs-io/vault-provider-proxy/issues/123
Closes https://github.com/babylonlabs-io/vault-provider-proxy/issues/156