### PR TITLE
fix(sync-env): enhance logging for security-critical keys

### DIFF
--- a/services/vault/.env.example
+++ b/services/vault/.env.example
@@ -41,3 +41,7 @@ NEXT_PUBLIC_TBV_SIDECAR_API_URL=https://sidecar-api.canon-devnet.babylonlabs.io
 # Kill-switch for the vault supply-cap UI (dashboard section + deposit-form validation).
 # When enabled, the CapPolicy contract is never read. Vault cap is on by default.
 # NEXT_PUBLIC_FF_DISABLE_VAULT_CAP=true
+
+
+# Added by sync-env from devnet
+NEXT_PUBLIC_TBV_BTC_PRICE_FEED=0xA5c0105B71D9D2CaDC151A1875a5B71C85AbF8DB

--- a/services/vault/.env.example
+++ b/services/vault/.env.example
@@ -32,11 +32,6 @@ NEXT_PUBLIC_REOWN_PROJECT_ID=your-reown-project-id-here
 # Sidecar API URL (for provider logos)
 NEXT_PUBLIC_TBV_SIDECAR_API_URL=https://sidecar-api.canon-devnet.babylonlabs.io
 
-# Price Feed Oracle Override (optional)
-# Override default Chainlink feed address with custom oracle (e.g. Babylon tbv-oracle).
-# Must implement Chainlink AggregatorV3 interface (latestRoundData) with 8 decimals.
-# NEXT_PUBLIC_TBV_BTC_PRICE_FEED=0xc3223BDa48ae9803F5a2B25839455Ff2C0d5f99d
-
 # Feature Flags (all default to disabled; set to "true" to enable)
 # Kill-switch for the vault supply-cap UI (dashboard section + deposit-form validation).
 # When enabled, the CapPolicy contract is never read. Vault cap is on by default.

--- a/services/vault/scripts/sync-env.mjs
+++ b/services/vault/scripts/sync-env.mjs
@@ -50,6 +50,7 @@ const SECURITY_CRITICAL_KEYS = new Set([
   "NEXT_PUBLIC_TBV_BTC_PRICE_FEED",
   "NEXT_PUBLIC_ETH_RPC_URL",
   "NEXT_PUBLIC_TBV_VP_PROXY_URL",
+  "NEXT_PUBLIC_TBV_GRAPHQL_ENDPOINT",
 ]);
 
 function formatChange({ key, from }) {
@@ -214,6 +215,14 @@ function main() {
     for (const change of updated) {
       console.log(formatChange(change));
     }
+
+    const criticalChanges = updated.filter(({ key }) => SECURITY_CRITICAL_KEYS.has(key));
+    if (criticalChanges.length > 0) {
+      const names = criticalChanges.map(({ key }) => key).join(", ");
+      console.error(`\n⚠ sync-env: security-critical values changed: ${names}`);
+      console.error("  Verify these are expected before running sync.\n");
+    }
+
     process.exit(1);
   }
 
@@ -255,7 +264,7 @@ function main() {
     if (criticalChanges.length > 0) {
       const names = criticalChanges.map(({ key }) => key).join(", ");
       console.error(`\n⚠ sync-env: security-critical values changed: ${names}`);
-      console.error("  Verify these are expected. If not, restore .env from git: git checkout -- .env\n");
+      console.error(`  Verify these are expected. If not, restore from git: git checkout -- ${label}\n`);
     }
 
     totalUpdated += updated.length;

--- a/services/vault/scripts/sync-env.mjs
+++ b/services/vault/scripts/sync-env.mjs
@@ -43,6 +43,19 @@ const FIELD_MAP = {
   "contracts.btcPriceFeed": "NEXT_PUBLIC_TBV_BTC_PRICE_FEED",
 };
 
+/** Keys whose changes warrant a prominent warning — contract addresses and endpoints. */
+const SECURITY_CRITICAL_KEYS = new Set([
+  "NEXT_PUBLIC_TBV_BTC_VAULT_REGISTRY",
+  "NEXT_PUBLIC_TBV_AAVE_ADAPTER",
+  "NEXT_PUBLIC_TBV_BTC_PRICE_FEED",
+  "NEXT_PUBLIC_ETH_RPC_URL",
+  "NEXT_PUBLIC_TBV_VP_PROXY_URL",
+]);
+
+function formatChange({ key, from }) {
+  return `  ${key}: ${from === "(missing)" ? "added" : "changed"}`;
+}
+
 function resolve(obj, path) {
   return path.split(".").reduce((o, k) => o?.[k], obj);
 }
@@ -198,8 +211,8 @@ function main() {
       return;
     }
     console.log(`sync-env: .env is stale (${updated.length} values differ from ${network}):`);
-    for (const { key, from, to } of updated) {
-      console.log(`  ${key}: ${from} → ${to}`);
+    for (const change of updated) {
+      console.log(formatChange(change));
     }
     process.exit(1);
   }
@@ -234,9 +247,17 @@ function main() {
 
     writeFileSync(path, serializeEnv(entries));
     console.log(`sync-env: updated ${updated.length} value(s) in ${label} from ${network}:`);
-    for (const { key, from, to } of updated) {
-      console.log(`  ${key}: ${from} → ${to}`);
+    for (const change of updated) {
+      console.log(formatChange(change));
     }
+
+    const criticalChanges = updated.filter(({ key }) => SECURITY_CRITICAL_KEYS.has(key));
+    if (criticalChanges.length > 0) {
+      const names = criticalChanges.map(({ key }) => key).join(", ");
+      console.error(`\n⚠ sync-env: security-critical values changed: ${names}`);
+      console.error("  Verify these are expected. If not, restore .env from git: git checkout -- .env\n");
+    }
+
     totalUpdated += updated.length;
   }
 

--- a/services/vault/scripts/sync-env.mjs
+++ b/services/vault/scripts/sync-env.mjs
@@ -43,8 +43,8 @@ const FIELD_MAP = {
   "contracts.btcPriceFeed": "NEXT_PUBLIC_TBV_BTC_PRICE_FEED",
 };
 
-/** Keys whose changes warrant a prominent warning — contract addresses and endpoints. */
-const SECURITY_CRITICAL_KEYS = new Set([
+/** Contract addresses and endpoints whose changes should be called out explicitly. */
+const CONTRACT_AND_ENDPOINT_KEYS = new Set([
   "NEXT_PUBLIC_TBV_BTC_VAULT_REGISTRY",
   "NEXT_PUBLIC_TBV_AAVE_ADAPTER",
   "NEXT_PUBLIC_TBV_BTC_PRICE_FEED",
@@ -148,6 +148,11 @@ function computeDiff(content, remote, network) {
 }
 
 function main() {
+  if (process.env.NODE_ENV === "production") {
+    console.error("sync-env: this script is for local development only.");
+    process.exit(1);
+  }
+
   const args = process.argv.slice(2);
   const checkOnly = args.includes("--check");
   const includeExample = args.includes("--all");
@@ -216,11 +221,11 @@ function main() {
       console.log(formatChange(change));
     }
 
-    const criticalChanges = updated.filter(({ key }) => SECURITY_CRITICAL_KEYS.has(key));
-    if (criticalChanges.length > 0) {
-      const names = criticalChanges.map(({ key }) => key).join(", ");
-      console.error(`\n⚠ sync-env: security-critical values changed: ${names}`);
-      console.error("  Verify these are expected before running sync.\n");
+    const contractChanges = updated.filter(({ key }) => CONTRACT_AND_ENDPOINT_KEYS.has(key));
+    if (contractChanges.length > 0) {
+      const names = contractChanges.map(({ key }) => key).join(", ");
+      console.error(`\n⚠ sync-env: contract addresses or endpoints changed: ${names}`);
+      console.error("  Verify these match the expected network before running sync.\n");
     }
 
     process.exit(1);
@@ -260,11 +265,11 @@ function main() {
       console.log(formatChange(change));
     }
 
-    const criticalChanges = updated.filter(({ key }) => SECURITY_CRITICAL_KEYS.has(key));
-    if (criticalChanges.length > 0) {
-      const names = criticalChanges.map(({ key }) => key).join(", ");
-      console.error(`\n⚠ sync-env: security-critical values changed: ${names}`);
-      console.error(`  Verify these are expected. If not, restore from git: git checkout -- ${label}\n`);
+    const contractChanges = updated.filter(({ key }) => CONTRACT_AND_ENDPOINT_KEYS.has(key));
+    if (contractChanges.length > 0) {
+      const names = contractChanges.map(({ key }) => key).join(", ");
+      console.error(`\n⚠ sync-env: contract addresses or endpoints changed: ${names}`);
+      console.error(`  Verify these match the expected network. If not, restore from git: git checkout -- ${label}\n`);
     }
 
     totalUpdated += updated.length;


### PR DESCRIPTION
- Redact env var values from `sync-env.mjs` log output — now prints `KEY: changed` / `KEY: added` instead of full old→new values, preventing potential API key leakage in CI logs
- Emit a prominent stderr warning when security-critical keys (contract addresses, RPC URL, VP proxy URL) are changed by the sync, so developers don't silently adopt potentially compromised values

Addresses audit v2 findings [#75](https://github.com/babylonlabs-io/vault-provider-proxy/issues/154) and [#78](https://github.com/babylonlabs-io/vault-provider-proxy/issues/157).
 
Closes https://github.com/babylonlabs-io/vault-provider-proxy/issues/157
Closes https://github.com/babylonlabs-io/vault-provider-proxy/issues/154