### PR TITLE
fix(vault): enhance fetchVpHealth validation and timeout handling

### DIFF
--- a/services/vault/src/services/vpHealth/__tests__/fetchVpHealth.test.ts
+++ b/services/vault/src/services/vpHealth/__tests__/fetchVpHealth.test.ts
@@ -10,47 +10,53 @@ vi.mock("@/infrastructure", () => ({
 
 import { fetchVpHealth } from "../fetchVpHealth";
 
+const VALID_ADDRESS = "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa";
+
+function makeSnapshot(overrides: Record<string, unknown> = {}) {
+  return {
+    address: VALID_ADDRESS,
+    totalRequests: 10,
+    successCount: 8,
+    errorCount: 2,
+    successRate: 0.8,
+    error5xxCount: 2,
+    avgResponseMs: 100,
+    p95ResponseMs: 200,
+    ...overrides,
+  };
+}
+
+function mockFetchResponse(body: unknown, status = 200) {
+  vi.mocked(fetch).mockResolvedValueOnce(
+    new Response(JSON.stringify(body), { status }),
+  );
+}
+
 describe("fetchVpHealth", () => {
   beforeEach(() => {
+    vi.useFakeTimers();
     vi.stubGlobal("fetch", vi.fn());
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.unstubAllGlobals();
   });
 
-  it("returns snapshots on 200", async () => {
-    const snapshots = [
-      {
-        address: "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa",
-        totalRequests: 10,
-        successCount: 8,
-        errorCount: 2,
-        successRate: 0.8,
-        error5xxCount: 2,
-        avgResponseMs: 100,
-        p95ResponseMs: 200,
-      },
-    ];
-
-    vi.mocked(fetch).mockResolvedValueOnce(
-      new Response(JSON.stringify(snapshots), { status: 200 }),
-    );
+  it("returns snapshots on 200 with valid data", async () => {
+    const snapshots = [makeSnapshot()];
+    mockFetchResponse(snapshots);
 
     const result = await fetchVpHealth();
     expect(result).toEqual(snapshots);
-    expect(fetch).toHaveBeenCalledWith("https://proxy.example.com/vp-health");
+    expect(fetch).toHaveBeenCalledWith(
+      "https://proxy.example.com/vp-health",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
   });
 
   it("returns empty array on 500", async () => {
     vi.mocked(fetch).mockResolvedValueOnce(new Response("", { status: 500 }));
-
-    const result = await fetchVpHealth();
-    expect(result).toEqual([]);
-  });
-
-  it("returns empty array on 503", async () => {
-    vi.mocked(fetch).mockResolvedValueOnce(new Response("", { status: 503 }));
 
     const result = await fetchVpHealth();
     expect(result).toEqual([]);
@@ -61,5 +67,91 @@ describe("fetchVpHealth", () => {
 
     const result = await fetchVpHealth();
     expect(result).toEqual([]);
+  });
+
+  describe("timeout", () => {
+    it("aborts fetch after 15 seconds", async () => {
+      vi.mocked(fetch).mockImplementationOnce(
+        (_url, init) =>
+          new Promise((_resolve, reject) => {
+            (init as RequestInit).signal?.addEventListener("abort", () => {
+              reject(
+                new DOMException("The operation was aborted", "AbortError"),
+              );
+            });
+          }),
+      );
+
+      const promise = fetchVpHealth();
+      vi.advanceTimersByTime(15_000);
+
+      const result = await promise;
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("validation", () => {
+    it("drops entries with invalid Ethereum address", async () => {
+      mockFetchResponse([
+        makeSnapshot({ address: "not-an-address" }),
+        makeSnapshot({ address: VALID_ADDRESS }),
+      ]);
+
+      const result = await fetchVpHealth();
+      expect(result).toHaveLength(1);
+      expect(result[0].address).toBe(VALID_ADDRESS);
+    });
+
+    it("drops entries with successRate below 0", async () => {
+      mockFetchResponse([makeSnapshot({ successRate: -1 })]);
+
+      const result = await fetchVpHealth();
+      expect(result).toEqual([]);
+    });
+
+    it("drops entries with successRate above 1", async () => {
+      mockFetchResponse([makeSnapshot({ successRate: 2 })]);
+
+      const result = await fetchVpHealth();
+      expect(result).toEqual([]);
+    });
+
+    it("drops entries with negative totalRequests", async () => {
+      mockFetchResponse([makeSnapshot({ totalRequests: -5 })]);
+
+      const result = await fetchVpHealth();
+      expect(result).toEqual([]);
+    });
+
+    it("accepts successRate at boundary values 0 and 1", async () => {
+      mockFetchResponse([
+        makeSnapshot({ successRate: 0 }),
+        makeSnapshot({ successRate: 1 }),
+      ]);
+
+      const result = await fetchVpHealth();
+      expect(result).toHaveLength(2);
+    });
+
+    it("drops entries with non-string address", async () => {
+      mockFetchResponse([makeSnapshot({ address: 123 })]);
+
+      const result = await fetchVpHealth();
+      expect(result).toEqual([]);
+    });
+
+    it("drops entries with non-number successRate", async () => {
+      mockFetchResponse([makeSnapshot({ successRate: "high" })]);
+
+      const result = await fetchVpHealth();
+      expect(result).toEqual([]);
+    });
+
+    it("returns empty array for non-array response", async () => {
+      mockFetchResponse({ not: "an array" });
+
+      const result = await fetchVpHealth();
+      expect(result).toEqual([]);
+    });
   });
 });

--- a/services/vault/src/services/vpHealth/fetchVpHealth.ts
+++ b/services/vault/src/services/vpHealth/fetchVpHealth.ts
@@ -26,9 +26,9 @@ export async function fetchVpHealth(): Promise<VpHealthSnapshot[]> {
 
   try {
     const response = await fetch(url, { signal: controller.signal });
-    clearTimeout(timeoutId);
 
     if (!response.ok) {
+      clearTimeout(timeoutId);
       logger.warn("VP health endpoint returned non-OK status", {
         data: { status: response.status },
       });
@@ -36,6 +36,7 @@ export async function fetchVpHealth(): Promise<VpHealthSnapshot[]> {
     }
 
     const data: unknown = await response.json();
+    clearTimeout(timeoutId);
     if (!Array.isArray(data)) return [];
 
     return data.filter((item): item is VpHealthSnapshot => {

--- a/services/vault/src/services/vpHealth/fetchVpHealth.ts
+++ b/services/vault/src/services/vpHealth/fetchVpHealth.ts
@@ -1,6 +1,11 @@
+import { isAddress } from "viem";
+
 import { ENV } from "@/config/env";
 import { logger } from "@/infrastructure";
 import type { VpHealthSnapshot } from "@/types/vpHealth";
+
+/** Timeout for the VP health fetch, well under the 30s poll interval. */
+const VP_HEALTH_TIMEOUT_MS = 15_000;
 
 /**
  * Fetches vault-provider health snapshots from the VP proxy.
@@ -9,15 +14,19 @@ import type { VpHealthSnapshot } from "@/types/vpHealth";
  * sliding window. VPs absent from the response had no recent traffic and
  * are considered healthy by default.
  *
- * Returns an empty array on any failure (5xx, network error, etc.)
+ * Returns an empty array on any failure (5xx, network error, timeout, etc.)
  * so the caller never needs error handling — an empty result means
  * "assume all VPs are healthy" (graceful degradation).
  */
 export async function fetchVpHealth(): Promise<VpHealthSnapshot[]> {
   const url = `${ENV.VP_PROXY_URL}/vp-health`;
 
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), VP_HEALTH_TIMEOUT_MS);
+
   try {
-    const response = await fetch(url);
+    const response = await fetch(url, { signal: controller.signal });
+    clearTimeout(timeoutId);
 
     if (!response.ok) {
       logger.warn("VP health endpoint returned non-OK status", {
@@ -29,15 +38,23 @@ export async function fetchVpHealth(): Promise<VpHealthSnapshot[]> {
     const data: unknown = await response.json();
     if (!Array.isArray(data)) return [];
 
-    return data.filter(
-      (item): item is VpHealthSnapshot =>
-        typeof item === "object" &&
-        item !== null &&
-        typeof (item as Record<string, unknown>).address === "string" &&
-        typeof (item as Record<string, unknown>).successRate === "number" &&
-        typeof (item as Record<string, unknown>).totalRequests === "number",
-    );
+    return data.filter((item): item is VpHealthSnapshot => {
+      if (typeof item !== "object" || item === null) return false;
+
+      const record = item as Record<string, unknown>;
+
+      if (typeof record.address !== "string") return false;
+      if (typeof record.successRate !== "number") return false;
+      if (typeof record.totalRequests !== "number") return false;
+
+      if (!isAddress(record.address, { strict: false })) return false;
+      if (record.successRate < 0 || record.successRate > 1) return false;
+      if (record.totalRequests < 0) return false;
+
+      return true;
+    });
   } catch (error) {
+    clearTimeout(timeoutId);
     logger.warn("VP health endpoint unreachable", { data: { error } });
     return [];
   }


### PR DESCRIPTION
- Add 15-second fetch timeout via `AbortController` to `fetchVpHealth`, preventing hung connections from exhausting browser connection limits during 30s polling cycles

- Validate health response entries: reject `non-Ethereum` addresses (via `viem's` `isAddress`), `successRate` outside `[0, 1]`, and negative `totalRequests` — prevents a malicious proxy from censoring legitimate VPs or inflating scores

Closes https://github.com/babylonlabs-io/vault-provider-proxy/issues/117
Closes https://github.com/babylonlabs-io/vault-provider-proxy/issues/116