### PR TITLE
fix(vault): graphql timeout is cleared after successful response

### DIFF
--- a/services/vault/src/clients/graphql/__tests__/client.test.ts
+++ b/services/vault/src/clients/graphql/__tests__/client.test.ts
@@ -36,6 +36,23 @@ describe("graphqlClient timeout", () => {
     vi.useRealTimers();
   });
 
+  it("clears timeout after successful response", async () => {
+    const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
+
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify({ data: { vaults: [] } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    const { graphqlClient } = await import("../client");
+    await graphqlClient.request("{ vaults { id } }");
+
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+    clearTimeoutSpy.mockRestore();
+  });
+
   it("aborts requests after 30s timeout", async () => {
     mockFetch.mockImplementation(
       (_url: string, options?: RequestInit) =>

--- a/services/vault/src/clients/graphql/__tests__/client.test.ts
+++ b/services/vault/src/clients/graphql/__tests__/client.test.ts
@@ -53,6 +53,35 @@ describe("graphqlClient timeout", () => {
     clearTimeoutSpy.mockRestore();
   });
 
+  it("rethrows caller-initiated abort without wrapping as timeout", async () => {
+    vi.useRealTimers();
+    const callerController = new AbortController();
+    const abortError = new DOMException(
+      "The operation was aborted.",
+      "AbortError",
+    );
+
+    mockFetch.mockImplementation(
+      (_url: string, options?: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          options?.signal?.addEventListener("abort", () => {
+            reject(abortError);
+          });
+        }),
+    );
+
+    const { graphqlClient } = await import("../client");
+    const customFetch = graphqlClient.requestConfig.fetch!;
+
+    const promise = customFetch("https://graphql.test/v1/graphql", {
+      signal: callerController.signal,
+    });
+    callerController.abort();
+
+    await expect(promise).rejects.toThrow("The operation was aborted.");
+    vi.useFakeTimers();
+  });
+
   it("aborts requests after 30s timeout", async () => {
     mockFetch.mockImplementation(
       (_url: string, options?: RequestInit) =>

--- a/services/vault/src/clients/graphql/client.ts
+++ b/services/vault/src/clients/graphql/client.ts
@@ -33,6 +33,7 @@ export const graphqlClient = new GraphQLClient(ENV.GRAPHQL_ENDPOINT, {
     } catch (error) {
       clearTimeout(timeoutId);
       if (
+        controller.signal.aborted &&
         error != null &&
         typeof error === "object" &&
         "name" in error &&

--- a/services/vault/src/clients/graphql/client.ts
+++ b/services/vault/src/clients/graphql/client.ts
@@ -19,10 +19,16 @@ export const graphqlClient = new GraphQLClient(ENV.GRAPHQL_ENDPOINT, {
     ) as AbortSignal[];
 
     try {
-      // Don't clear timeout — graphql-request parses body after this returns
-      return await fetch(url, {
+      const response = await fetch(url, {
         ...options,
         signal: AbortSignal.any(signals),
+      });
+      const body = await response.text();
+      clearTimeout(timeoutId);
+      return new Response(body, {
+        status: response.status,
+        statusText: response.statusText,
+        headers: response.headers,
       });
     } catch (error) {
       clearTimeout(timeoutId);


### PR DESCRIPTION
## Problem

The GraphQL client's custom fetch wrapper set a 30s setTimeout to abort stalled requests, but never called clearTimeout on the success path. Each successful request left a dangling timer + AbortController + closure in memory for up to 30 seconds.

## Fix

Consume the response body inside the wrapper via response.text() so the timeout covers both network round-trip and body parsing, then call clearTimeout and return a string-backed Response for graphql-request to parse.

Closes https://github.com/babylonlabs-io/vault-provider-proxy/issues/141