### PR TITLE
feat(wallet): storage ttl and pubkey

### DIFF
--- a/packages/babylon-wallet-connector/src/core/storage.ts
+++ b/packages/babylon-wallet-connector/src/core/storage.ts
@@ -66,7 +66,16 @@ export const createAccountStorage = (ttl: number, networkMap?: Record<string, st
   function isExpired(map: Record<string, unknown>, scoped: string): boolean {
     const timestamps = getTimestamps(map);
     const ts = timestamps[scoped];
-    return ts != null && Date.now() - ts > ttl;
+    if (ts != null) {
+      return Date.now() - ts > ttl;
+    }
+    // Fall back to legacy shared timestamp for entries written before migration
+    const legacyTs = map._timestamp;
+    if (typeof legacyTs === "number") {
+      return Date.now() - legacyTs > ttl;
+    }
+    // No timestamp at all — treat as expired
+    return true;
   }
 
   return {

--- a/packages/babylon-wallet-connector/src/core/storage.ts
+++ b/packages/babylon-wallet-connector/src/core/storage.ts
@@ -54,35 +54,61 @@ function writeAccountsMap(map: Record<string, unknown>): void {
  *                     so entries are scoped per-network and won't cross-restore on network changes
  * @returns - key value storage
  */
-export const createAccountStorage = (ttl: number, networkMap?: Record<string, string>): HashMap => ({
-  get: (key: string) => {
-    const map = readAccountsMap();
-
-    if (map._timestamp && Date.now() - (map._timestamp as number) > ttl) {
-      return undefined;
+export const createAccountStorage = (ttl: number, networkMap?: Record<string, string>): HashMap => {
+  function getTimestamps(map: Record<string, unknown>): Record<string, number> {
+    const timestamps = map._timestamps;
+    if (timestamps && typeof timestamps === "object" && !Array.isArray(timestamps)) {
+      return timestamps as Record<string, number>;
     }
+    return {};
+  }
 
-    return map[scopeKey(key, networkMap)] as string | undefined;
-  },
-  has: (key: string) => {
-    const map = readAccountsMap();
+  function isExpired(map: Record<string, unknown>, scoped: string): boolean {
+    const timestamps = getTimestamps(map);
+    const ts = timestamps[scoped];
+    return ts != null && Date.now() - ts > ttl;
+  }
 
-    if (map._timestamp && Date.now() - (map._timestamp as number) > ttl) {
-      return false;
-    }
+  return {
+    get: (key: string) => {
+      const map = readAccountsMap();
+      const scoped = scopeKey(key, networkMap);
 
-    return Boolean(map[scopeKey(key, networkMap)]);
-  },
-  set: (key: string, value: string) => {
-    const map = readAccountsMap();
-    map[scopeKey(key, networkMap)] = value;
-    map._timestamp = Date.now();
-    writeAccountsMap(map);
-  },
-  delete: (key: string) => {
-    const map = readAccountsMap();
-    const deleted = Reflect.deleteProperty(map, scopeKey(key, networkMap));
-    writeAccountsMap(map);
-    return deleted;
-  },
-});
+      if (isExpired(map, scoped)) {
+        return undefined;
+      }
+
+      return map[scoped] as string | undefined;
+    },
+    has: (key: string) => {
+      const map = readAccountsMap();
+      const scoped = scopeKey(key, networkMap);
+
+      if (isExpired(map, scoped)) {
+        return false;
+      }
+
+      return Boolean(map[scoped]);
+    },
+    set: (key: string, value: string) => {
+      const map = readAccountsMap();
+      const scoped = scopeKey(key, networkMap);
+      const timestamps = getTimestamps(map);
+
+      map[scoped] = value;
+      map._timestamps = { ...timestamps, [scoped]: Date.now() };
+      writeAccountsMap(map);
+    },
+    delete: (key: string) => {
+      const map = readAccountsMap();
+      const scoped = scopeKey(key, networkMap);
+      const timestamps = getTimestamps(map);
+
+      const deleted = Reflect.deleteProperty(map, scoped);
+      delete timestamps[scoped];
+      map._timestamps = timestamps;
+      writeAccountsMap(map);
+      return deleted;
+    },
+  };
+};

--- a/packages/babylon-wallet-connector/src/core/storage.ts
+++ b/packages/babylon-wallet-connector/src/core/storage.ts
@@ -69,12 +69,7 @@ export const createAccountStorage = (ttl: number, networkMap?: Record<string, st
     if (ts != null) {
       return Date.now() - ts > ttl;
     }
-    // Fall back to legacy shared timestamp for entries written before migration
-    const legacyTs = map._timestamp;
-    if (typeof legacyTs === "number") {
-      return Date.now() - legacyTs > ttl;
-    }
-    // No timestamp at all — treat as expired
+    // No timestamp — treat as expired
     return true;
   }
 

--- a/packages/babylon-wallet-connector/src/core/utils/publicKey.ts
+++ b/packages/babylon-wallet-connector/src/core/utils/publicKey.ts
@@ -13,6 +13,13 @@ const HEX_PATTERN = /^[0-9a-fA-F]+$/;
  * @throws WalletError if the key format is invalid
  */
 export function toXOnlyPublicKeyHex(publicKeyHex: string): string {
+  if (publicKeyHex.length === 0) {
+    throw new WalletError({
+      code: ERROR_CODES.INVALID_PUBLIC_KEY,
+      message: "Invalid public key: must not be empty",
+    });
+  }
+
   if (!HEX_PATTERN.test(publicKeyHex)) {
     throw new WalletError({
       code: ERROR_CODES.INVALID_PUBLIC_KEY,

--- a/packages/babylon-wallet-connector/src/core/utils/publicKey.ts
+++ b/packages/babylon-wallet-connector/src/core/utils/publicKey.ts
@@ -1,0 +1,42 @@
+import { ERROR_CODES, WalletError } from "@/error";
+
+export const COMPRESSED_PUBLIC_KEY_HEX_LENGTH = 66;
+const X_ONLY_PUBLIC_KEY_HEX_LENGTH = 64;
+const HEX_PATTERN = /^[0-9a-fA-F]+$/;
+
+/**
+ * Converts a public key hex string to x-only format (32 bytes, no prefix).
+ * Validates the input format and rejects unexpected key types.
+ *
+ * @param publicKeyHex - Hex-encoded public key (compressed 66-char or x-only 64-char)
+ * @returns 64-character hex string representing the x-only public key
+ * @throws WalletError if the key format is invalid
+ */
+export function toXOnlyPublicKeyHex(publicKeyHex: string): string {
+  if (!HEX_PATTERN.test(publicKeyHex)) {
+    throw new WalletError({
+      code: ERROR_CODES.INVALID_PUBLIC_KEY,
+      message: `Invalid public key: contains non-hex characters`,
+    });
+  }
+
+  if (publicKeyHex.length === COMPRESSED_PUBLIC_KEY_HEX_LENGTH) {
+    const prefix = publicKeyHex.slice(0, 2);
+    if (prefix !== "02" && prefix !== "03") {
+      throw new WalletError({
+        code: ERROR_CODES.INVALID_PUBLIC_KEY,
+        message: `Invalid compressed public key prefix '${prefix}', expected '02' or '03'`,
+      });
+    }
+    return publicKeyHex.slice(2);
+  }
+
+  if (publicKeyHex.length === X_ONLY_PUBLIC_KEY_HEX_LENGTH) {
+    return publicKeyHex;
+  }
+
+  throw new WalletError({
+    code: ERROR_CODES.INVALID_PUBLIC_KEY,
+    message: `Unexpected public key length ${publicKeyHex.length} chars (expected ${COMPRESSED_PUBLIC_KEY_HEX_LENGTH} for compressed or ${X_ONLY_PUBLIC_KEY_HEX_LENGTH} for x-only)`,
+  });
+}

--- a/packages/babylon-wallet-connector/src/core/utils/wallet.ts
+++ b/packages/babylon-wallet-connector/src/core/utils/wallet.ts
@@ -4,8 +4,10 @@ import { toXOnly } from "bitcoinjs-lib/src/psbt/bip371";
 
 import { Network } from "@/core/types";
 import { initBTCCurve } from "@/core/utils/initBTCCurve";
+import { COMPRESSED_PUBLIC_KEY_HEX_LENGTH, toXOnlyPublicKeyHex } from "@/core/utils/publicKey";
 import { ERROR_CODES, WalletError } from "@/error";
-export const COMPRESSED_PUBLIC_KEY_HEX_LENGTH = 66;
+
+export { COMPRESSED_PUBLIC_KEY_HEX_LENGTH, toXOnlyPublicKeyHex };
 
 const NETWORKS = {
   [Network.MAINNET]: {
@@ -38,11 +40,9 @@ const NETWORKS = {
 };
 
 export const getTaprootAddress = (publicKey: string, network: Network) => {
-  if (publicKey.length == COMPRESSED_PUBLIC_KEY_HEX_LENGTH) {
-    publicKey = publicKey.slice(2);
-  }
+  const xOnlyHex = toXOnlyPublicKeyHex(publicKey);
 
-  const internalPubkey = Buffer.from(publicKey, "hex");
+  const internalPubkey = Buffer.from(xOnlyHex, "hex");
   const { address, output: scriptPubKey } = payments.p2tr({
     internalPubkey: toXOnly(internalPubkey),
     network: NETWORKS[network].config,

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/provider.ts
@@ -46,9 +46,69 @@ export class AppKitBTCProvider implements IBTCProvider {
   private address?: string;
   private publicKey?: string;
   private eventHandlers: Map<string, Set<(...args: unknown[]) => void>> = new Map();
+  private listeningForChanges = false;
+  private boundHandleAccountChange: ((event: Event) => void) | null = null;
 
   constructor(config: BTCConfig) {
     this.config = config;
+  }
+
+  /**
+   * Emit an event to all registered handlers for the given event name.
+   */
+  private emit(eventName: string, ...args: unknown[]): void {
+    const handlers = this.eventHandlers.get(eventName);
+    if (!handlers) return;
+    for (const handler of handlers) {
+      try {
+        handler(...args);
+      } catch (error) {
+        console.error(`[AppKit Provider] Error in ${eventName} handler:`, error);
+      }
+    }
+  }
+
+  /**
+   * Start listening for account changes from the bridge hook.
+   * Sets up a persistent window listener for APPKIT_BTC_CONNECTED_EVENT
+   * so account switches are propagated to BTCWalletProvider via event handlers.
+   */
+  private startListeningForAccountChanges(): void {
+    if (this.listeningForChanges || typeof window === "undefined") return;
+
+    this.boundHandleAccountChange = (event: Event) => {
+      const detail = (event as BtcConnectedEvent).detail;
+
+      if (!detail?.address) {
+        // No address means disconnect — notify handlers with empty accounts array
+        this.emit("accountChanged");
+        this.emit("accountsChanged", []);
+        return;
+      }
+
+      if (detail.address === this.address) {
+        return;
+      }
+
+      this.address = detail.address;
+      this.publicKey = detail.publicKey;
+
+      this.emit("accountChanged");
+      this.emit("accountsChanged", [detail.address]);
+    };
+
+    window.addEventListener(APPKIT_BTC_CONNECTED_EVENT, this.boundHandleAccountChange);
+    this.listeningForChanges = true;
+  }
+
+  private stopListeningForAccountChanges(): void {
+    if (!this.listeningForChanges || typeof window === "undefined" || !this.boundHandleAccountChange) {
+      return;
+    }
+
+    window.removeEventListener(APPKIT_BTC_CONNECTED_EVENT, this.boundHandleAccountChange);
+    this.boundHandleAccountChange = null;
+    this.listeningForChanges = false;
   }
 
   /**
@@ -99,6 +159,7 @@ export class AppKitBTCProvider implements IBTCProvider {
         });
 
         await waitForConnection;
+        this.startListeningForAccountChanges();
         return;
       }
 
@@ -114,6 +175,7 @@ export class AppKitBTCProvider implements IBTCProvider {
       const { modal } = this.getAppKitConfig();
       await modal.disconnect();
     } finally {
+      this.stopListeningForAccountChanges();
       this.address = undefined;
       this.publicKey = undefined;
     }
@@ -274,8 +336,8 @@ export class AppKitBTCProvider implements IBTCProvider {
     return [];
   }
 
-  // Cleanup method for proper resource management
   destroy(): void {
+    this.stopListeningForAccountChanges();
     this.eventHandlers.clear();
   }
 }

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/provider.ts
@@ -81,7 +81,6 @@ export class AppKitBTCProvider implements IBTCProvider {
 
       if (!detail?.address) {
         // No address means disconnect — notify handlers with empty accounts array
-        this.emit("accountChanged");
         this.emit("accountsChanged", []);
         return;
       }
@@ -93,7 +92,8 @@ export class AppKitBTCProvider implements IBTCProvider {
       this.address = detail.address;
       this.publicKey = detail.publicKey;
 
-      this.emit("accountChanged");
+      // Emit only accountsChanged (not both) because BTCWalletProvider registers
+      // the same handler for both events — emitting both would cause double execution.
       this.emit("accountsChanged", [detail.address]);
     };
 

--- a/packages/babylon-wallet-connector/src/providers/BTCWalletProvider.tsx
+++ b/packages/babylon-wallet-connector/src/providers/BTCWalletProvider.tsx
@@ -10,10 +10,11 @@ import {
 import type { networks } from "bitcoinjs-lib";
 
 import { ACCOUNT_CHANGE_EVENTS, DISCONNECT_EVENT } from "@/constants/walletEvents";
+import type { IBTCProvider, InscriptionIdentifier, Network, SignPsbtOptions } from "@/core/types";
+import { toXOnlyPublicKeyHex } from "@/core/utils/wallet";
 import { useChainConnector } from "@/hooks/useChainConnector";
 import { useVisibilityCheck } from "@/hooks/useVisibilityCheck";
 import { useWalletConnect } from "@/hooks/useWalletConnect";
-import type { IBTCProvider, InscriptionIdentifier, Network, SignPsbtOptions } from "@/core/types";
 
 export interface BTCWalletLifecycleCallbacks {
   onConnect?: (address: string, publicKeyNoCoord: string) => void | Promise<void>;
@@ -105,10 +106,7 @@ export const BTCWalletProvider = ({ children, callbacks }: BTCWalletProviderProp
           throw new Error("BTC wallet provider returned an empty public key");
         }
 
-        // Get public key without coordinates (remove first byte which indicates compression)
-        const publicKeyNoCoordHex = publicKeyHex.length === 66 
-          ? publicKeyHex.slice(2) 
-          : publicKeyHex;
+        const publicKeyNoCoordHex = toXOnlyPublicKeyHex(publicKeyHex);
 
         if (!publicKeyNoCoordHex) {
           throw new Error("Processed BTC public key (no coordinates) is empty");
@@ -187,10 +185,7 @@ export const BTCWalletProvider = ({ children, callbacks }: BTCWalletProviderProp
             throw new Error("BTC wallet provider returned an empty public key after account change");
           }
 
-          // Get public key without coordinates (remove first byte which indicates compression)
-          const newPublicKeyNoCoord = newPublicKeyHex.length === 66
-            ? newPublicKeyHex.slice(2)
-            : newPublicKeyHex;
+          const newPublicKeyNoCoord = toXOnlyPublicKeyHex(newPublicKeyHex);
 
           setAddress(newAddress);
           setPublicKeyNoCoord(newPublicKeyNoCoord);
@@ -252,7 +247,7 @@ export const BTCWalletProvider = ({ children, callbacks }: BTCWalletProviderProp
           disconnect();
           return;
         }
-        const pubKeyNoCoord = pubKeyHex.length === 66 ? pubKeyHex.slice(2) : pubKeyHex;
+        const pubKeyNoCoord = toXOnlyPublicKeyHex(pubKeyHex);
         setAddress(currentAddress);
         setPublicKeyNoCoord(pubKeyNoCoord);
         await callbacks?.onAddressChange?.(currentAddress, pubKeyNoCoord);

--- a/packages/babylon-wallet-connector/src/providers/BTCWalletProvider.tsx
+++ b/packages/babylon-wallet-connector/src/providers/BTCWalletProvider.tsx
@@ -166,9 +166,14 @@ export const BTCWalletProvider = ({ children, callbacks }: BTCWalletProviderProp
           return;
         }
 
-        // Re-connect to refresh the provider's internal cache
-        // This is necessary because providers cache walletInfo on connect
-        await btcWalletProvider.connectWallet();
+        // Check if the provider already updated its state (e.g. AppKit updates
+        // address/publicKey via its persistent listener before emitting accountChanged).
+        // Only re-connect if the address hasn't changed yet — other providers
+        // (OKX, Unisat) need connectWallet() to refresh their internal cache.
+        const currentAddress = await btcWalletProvider.getAddress();
+        if (currentAddress === address) {
+          await btcWalletProvider.connectWallet();
+        }
 
         const newAddress = await btcWalletProvider.getAddress();
 

--- a/packages/babylon-wallet-connector/tests/unit/accountStorage.test.ts
+++ b/packages/babylon-wallet-connector/tests/unit/accountStorage.test.ts
@@ -3,6 +3,7 @@ import { test, expect } from "@playwright/test";
 import { createAccountStorage } from "../../src/core/storage";
 
 const ONE_HOUR_MS = 3600_000;
+const STORAGE_KEY = "baby-connected-wallet-accounts";
 
 /**
  * Minimal localStorage polyfill for Node (Playwright unit tests run outside the browser).
@@ -23,44 +24,44 @@ function polyfillLocalStorage() {
 
 polyfillLocalStorage();
 
+let origDateNow: typeof Date.now;
+
 test.beforeEach(() => {
   localStorage.clear();
+  origDateNow = Date.now;
 });
 
 test.afterEach(() => {
+  Date.now = origDateNow;
   localStorage.clear();
 });
 
 test("per-entry TTL: expired BTC does not affect fresh ETH", () => {
-  const storage = createAccountStorage(ONE_HOUR_MS);
+  const baseTime = 1_000_000_000_000;
+  Date.now = () => baseTime;
 
-  const now = Date.now();
+  const storage = createAccountStorage(ONE_HOUR_MS);
   storage.set("BTC", "btc-wallet-1");
 
-  const origDateNow = Date.now;
-  Date.now = () => now + ONE_HOUR_MS + 1;
-
+  Date.now = () => baseTime + ONE_HOUR_MS + 1;
   storage.set("ETH", "eth-wallet-1");
 
   expect(storage.get("BTC")).toBeUndefined();
   expect(storage.has("BTC")).toBe(false);
   expect(storage.get("ETH")).toBe("eth-wallet-1");
   expect(storage.has("ETH")).toBe(true);
-
-  Date.now = origDateNow;
 });
 
 test("per-entry TTL: updating an entry refreshes only its timestamp", () => {
-  const storage = createAccountStorage(ONE_HOUR_MS);
+  const baseTime = 1_000_000_000_000;
+  Date.now = () => baseTime;
 
-  const now = Date.now();
+  const storage = createAccountStorage(ONE_HOUR_MS);
   storage.set("BTC", "btc-wallet-1");
   storage.set("ETH", "eth-wallet-1");
 
-  const origDateNow = Date.now;
-
   // Advance to near expiry and refresh only BTC
-  const almostExpired = now + ONE_HOUR_MS - 100;
+  const almostExpired = baseTime + ONE_HOUR_MS - 100;
   Date.now = () => almostExpired;
   storage.set("BTC", "btc-wallet-2");
 
@@ -69,8 +70,6 @@ test("per-entry TTL: updating an entry refreshes only its timestamp", () => {
 
   expect(storage.get("BTC")).toBe("btc-wallet-2");
   expect(storage.get("ETH")).toBeUndefined();
-
-  Date.now = origDateNow;
 });
 
 test("delete removes entry and its timestamp", () => {
@@ -83,51 +82,29 @@ test("delete removes entry and its timestamp", () => {
   expect(storage.has("BTC")).toBe(false);
 });
 
-test("legacy _timestamp format expires correctly after migration", () => {
-  const now = Date.now();
-
-  // Simulate old-format data written before migration (single _timestamp)
+test("entry without timestamp is treated as expired", () => {
   localStorage.setItem(
-    "baby-connected-wallet-accounts",
-    JSON.stringify({ BTC: "btc-wallet-old", _timestamp: now - ONE_HOUR_MS - 1 }),
+    STORAGE_KEY,
+    JSON.stringify({ BTC: "btc-wallet-old" }),
   );
 
   const storage = createAccountStorage(ONE_HOUR_MS);
 
-  // Legacy entry should be expired based on the old shared timestamp
   expect(storage.get("BTC")).toBeUndefined();
   expect(storage.has("BTC")).toBe(false);
 });
 
-test("legacy _timestamp format keeps fresh entries alive", () => {
-  const now = Date.now();
-
-  // Simulate old-format data that is still fresh
-  localStorage.setItem(
-    "baby-connected-wallet-accounts",
-    JSON.stringify({ BTC: "btc-wallet-old", _timestamp: now - 100 }),
-  );
-
-  const storage = createAccountStorage(ONE_HOUR_MS);
-
-  expect(storage.get("BTC")).toBe("btc-wallet-old");
-  expect(storage.has("BTC")).toBe(true);
-});
-
 test("network-scoped keys have independent TTLs", () => {
+  const baseTime = 1_000_000_000_000;
+  Date.now = () => baseTime;
+
   const networkMap = { BTC: "mainnet", ETH: "1" };
   const storage = createAccountStorage(ONE_HOUR_MS, networkMap);
-
-  const now = Date.now();
   storage.set("BTC", "btc-wallet-1");
 
-  const origDateNow = Date.now;
-  Date.now = () => now + ONE_HOUR_MS + 1;
-
+  Date.now = () => baseTime + ONE_HOUR_MS + 1;
   storage.set("ETH", "eth-wallet-1");
 
   expect(storage.get("BTC")).toBeUndefined();
   expect(storage.get("ETH")).toBe("eth-wallet-1");
-
-  Date.now = origDateNow;
 });

--- a/packages/babylon-wallet-connector/tests/unit/accountStorage.test.ts
+++ b/packages/babylon-wallet-connector/tests/unit/accountStorage.test.ts
@@ -1,0 +1,102 @@
+import { test, expect } from "@playwright/test";
+
+import { createAccountStorage } from "../../src/core/storage";
+
+const ONE_HOUR_MS = 3600_000;
+
+/**
+ * Minimal localStorage polyfill for Node (Playwright unit tests run outside the browser).
+ */
+function polyfillLocalStorage() {
+  if (typeof globalThis.localStorage !== "undefined") return;
+
+  const store = new Map<string, string>();
+  globalThis.localStorage = {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => { store.set(key, value); },
+    removeItem: (key: string) => { store.delete(key); },
+    clear: () => { store.clear(); },
+    get length() { return store.size; },
+    key: (index: number) => [...store.keys()][index] ?? null,
+  };
+}
+
+polyfillLocalStorage();
+
+test.beforeEach(() => {
+  localStorage.clear();
+});
+
+test.afterEach(() => {
+  localStorage.clear();
+});
+
+test("per-entry TTL: expired BTC does not affect fresh ETH", () => {
+  const storage = createAccountStorage(ONE_HOUR_MS);
+
+  const now = Date.now();
+  storage.set("BTC", "btc-wallet-1");
+
+  const origDateNow = Date.now;
+  Date.now = () => now + ONE_HOUR_MS + 1;
+
+  storage.set("ETH", "eth-wallet-1");
+
+  expect(storage.get("BTC")).toBeUndefined();
+  expect(storage.has("BTC")).toBe(false);
+  expect(storage.get("ETH")).toBe("eth-wallet-1");
+  expect(storage.has("ETH")).toBe(true);
+
+  Date.now = origDateNow;
+});
+
+test("per-entry TTL: updating an entry refreshes only its timestamp", () => {
+  const storage = createAccountStorage(ONE_HOUR_MS);
+
+  const now = Date.now();
+  storage.set("BTC", "btc-wallet-1");
+  storage.set("ETH", "eth-wallet-1");
+
+  const origDateNow = Date.now;
+
+  // Advance to near expiry and refresh only BTC
+  const almostExpired = now + ONE_HOUR_MS - 100;
+  Date.now = () => almostExpired;
+  storage.set("BTC", "btc-wallet-2");
+
+  // Advance past original TTL but within BTC's refreshed TTL
+  Date.now = () => almostExpired + 200;
+
+  expect(storage.get("BTC")).toBe("btc-wallet-2");
+  expect(storage.get("ETH")).toBeUndefined();
+
+  Date.now = origDateNow;
+});
+
+test("delete removes entry and its timestamp", () => {
+  const storage = createAccountStorage(ONE_HOUR_MS);
+
+  storage.set("BTC", "btc-wallet-1");
+  storage.delete("BTC");
+
+  expect(storage.get("BTC")).toBeUndefined();
+  expect(storage.has("BTC")).toBe(false);
+});
+
+test("network-scoped keys have independent TTLs", () => {
+  const networkMap = { BTC: "mainnet", ETH: "1" };
+  const storage = createAccountStorage(ONE_HOUR_MS, networkMap);
+
+  const now = Date.now();
+  storage.set("BTC", "btc-wallet-1");
+
+  const origDateNow = Date.now;
+  Date.now = () => now + ONE_HOUR_MS + 1;
+
+  storage.set("ETH", "eth-wallet-1");
+
+  expect(storage.get("BTC")).toBeUndefined();
+  expect(storage.get("ETH")).toBe("eth-wallet-1");
+
+  Date.now = origDateNow;
+});

--- a/packages/babylon-wallet-connector/tests/unit/accountStorage.test.ts
+++ b/packages/babylon-wallet-connector/tests/unit/accountStorage.test.ts
@@ -83,6 +83,37 @@ test("delete removes entry and its timestamp", () => {
   expect(storage.has("BTC")).toBe(false);
 });
 
+test("legacy _timestamp format expires correctly after migration", () => {
+  const now = Date.now();
+
+  // Simulate old-format data written before migration (single _timestamp)
+  localStorage.setItem(
+    "baby-connected-wallet-accounts",
+    JSON.stringify({ BTC: "btc-wallet-old", _timestamp: now - ONE_HOUR_MS - 1 }),
+  );
+
+  const storage = createAccountStorage(ONE_HOUR_MS);
+
+  // Legacy entry should be expired based on the old shared timestamp
+  expect(storage.get("BTC")).toBeUndefined();
+  expect(storage.has("BTC")).toBe(false);
+});
+
+test("legacy _timestamp format keeps fresh entries alive", () => {
+  const now = Date.now();
+
+  // Simulate old-format data that is still fresh
+  localStorage.setItem(
+    "baby-connected-wallet-accounts",
+    JSON.stringify({ BTC: "btc-wallet-old", _timestamp: now - 100 }),
+  );
+
+  const storage = createAccountStorage(ONE_HOUR_MS);
+
+  expect(storage.get("BTC")).toBe("btc-wallet-old");
+  expect(storage.has("BTC")).toBe(true);
+});
+
 test("network-scoped keys have independent TTLs", () => {
   const networkMap = { BTC: "mainnet", ETH: "1" };
   const storage = createAccountStorage(ONE_HOUR_MS, networkMap);

--- a/packages/babylon-wallet-connector/tests/unit/toXOnlyPublicKeyHex.test.ts
+++ b/packages/babylon-wallet-connector/tests/unit/toXOnlyPublicKeyHex.test.ts
@@ -1,0 +1,48 @@
+import { test, expect } from "@playwright/test";
+
+import { toXOnlyPublicKeyHex } from "../../src/core/utils/publicKey";
+
+const VALID_X_ONLY = "ab".repeat(32); // 64 hex chars
+const VALID_COMPRESSED_02 = "02" + VALID_X_ONLY;
+const VALID_COMPRESSED_03 = "03" + VALID_X_ONLY;
+
+test("strips 02 prefix from compressed public key", () => {
+  expect(toXOnlyPublicKeyHex(VALID_COMPRESSED_02)).toBe(VALID_X_ONLY);
+});
+
+test("strips 03 prefix from compressed public key", () => {
+  expect(toXOnlyPublicKeyHex(VALID_COMPRESSED_03)).toBe(VALID_X_ONLY);
+});
+
+test("returns x-only key as-is", () => {
+  expect(toXOnlyPublicKeyHex(VALID_X_ONLY)).toBe(VALID_X_ONLY);
+});
+
+test("rejects compressed key with invalid prefix", () => {
+  const invalidPrefix = "04" + VALID_X_ONLY;
+  expect(() => toXOnlyPublicKeyHex(invalidPrefix)).toThrow(
+    /Invalid compressed public key prefix '04'/,
+  );
+});
+
+test("rejects uncompressed public key (130 chars)", () => {
+  const uncompressed = "04" + "ab".repeat(64);
+  expect(() => toXOnlyPublicKeyHex(uncompressed)).toThrow(
+    /Unexpected public key length 130/,
+  );
+});
+
+test("rejects non-hex characters", () => {
+  const nonHex = "zz" + "ab".repeat(31);
+  expect(() => toXOnlyPublicKeyHex(nonHex)).toThrow(/non-hex characters/);
+});
+
+test("rejects empty string", () => {
+  expect(() => toXOnlyPublicKeyHex("")).toThrow(/non-hex characters/);
+});
+
+test("rejects unexpected length", () => {
+  expect(() => toXOnlyPublicKeyHex("abcd")).toThrow(
+    /Unexpected public key length 4/,
+  );
+});

--- a/packages/babylon-wallet-connector/tests/unit/toXOnlyPublicKeyHex.test.ts
+++ b/packages/babylon-wallet-connector/tests/unit/toXOnlyPublicKeyHex.test.ts
@@ -37,8 +37,8 @@ test("rejects non-hex characters", () => {
   expect(() => toXOnlyPublicKeyHex(nonHex)).toThrow(/non-hex characters/);
 });
 
-test("rejects empty string", () => {
-  expect(() => toXOnlyPublicKeyHex("")).toThrow(/non-hex characters/);
+test("rejects empty string with descriptive message", () => {
+  expect(() => toXOnlyPublicKeyHex("")).toThrow(/must not be empty/);
 });
 
 test("rejects unexpected length", () => {


### PR DESCRIPTION
## Summary

Fixes three audit findings in `packages/babylon-wallet-connector`:

### [MEDIUM] [#51](https://github.com/babylonlabs-io/vault-provider-proxy/issues/135): AppKit Bitcoin account changes not propagated

`AppKitBTCProvider.on()` stored callbacks but never fired them. The bridge hook dispatches `APPKIT_BTC_CONNECTED_EVENT` on account changes, but only `connectWallet()` temporarily listened for it — so switching BTC accounts while already connected left stale address/publicKey state with no `onAddressChange` callback.

**Fix:** After successful `connectWallet()`, a persistent window listener is set up for `APPKIT_BTC_CONNECTED_EVENT`. When a different address arrives, the provider updates its cached state and emits `accountChanged`/`accountsChanged` to all registered handlers. The listener is torn down on `disconnect()` and `destroy()`.

### [LOW] [#74](https://github.com/babylonlabs-io/vault-provider-proxy/issues/153): Shared TTL timestamp in account storage

`createAccountStorage` used a single `_timestamp` field for all entries. Updating any chain entry (e.g. ETH) refreshed the TTL for all entries (e.g. BTC), preventing stale connections from expiring independently.

**Fix:** Replaced single `_timestamp` with a per-entry `_timestamps` map. Each `set()` only updates that entry's timestamp; `get()`/`has()` check per-entry expiry. Old format auto-expires on next TTL check.

### [LOW] [#54](https://github.com/babylonlabs-io/vault-provider-proxy/issues/137): Public key x-only conversion without validation

The pattern `publicKeyHex.length === 66 ? publicKeyHex.slice(2) : publicKeyHex` was repeated 3 times in `BTCWalletProvider.tsx` and once in `wallet.ts` with no prefix or format validation — silently accepting malformed keys.

**Fix:** Extracted `toXOnlyPublicKeyHex()` utility that validates hex format, checks `02`/`03` prefix on compressed keys, rejects uncompressed keys (130 chars) and unexpected lengths with descriptive errors. All 4 call sites now use this function.

Closes https://github.com/babylonlabs-io/vault-provider-proxy/issues/135
Closes https://github.com/babylonlabs-io/vault-provider-proxy/issues/153
Closes https://github.com/babylonlabs-io/vault-provider-proxy/issues/137