### PR TITLE
fix(vault): stale price handling

### DIFF
--- a/services/vault/src/applications/aave/components/PositionNotificationsDebugPanel.tsx
+++ b/services/vault/src/applications/aave/components/PositionNotificationsDebugPanel.tsx
@@ -47,6 +47,7 @@ const STATUS_MESSAGES: Record<
   "no-wallet": "Wallet not connected",
   "no-vaults": "No collateral vaults found",
   "no-price": "Waiting for BTC price...",
+  "stale-price": "BTC price is stale or unavailable",
 };
 
 const INPUT_CLASS =

--- a/services/vault/src/applications/aave/components/PositionNotificationsDebugPanel.tsx
+++ b/services/vault/src/applications/aave/components/PositionNotificationsDebugPanel.tsx
@@ -471,14 +471,18 @@ function ManualInputPanel({
 interface PositionNotificationsDebugPanelProps {
   /** Called whenever the debug panel's display result changes, so the main banner can update */
   onResultChange?: (result: CalculatorResult | null) => void;
+  /** Called when simulated status changes (e.g. stale-price), so the main banner can show status-based UI */
+  onStatusChange?: (status: PositionNotificationsStatus | null) => void;
 }
 
 export function PositionNotificationsDebugPanel({
   onResultChange,
+  onStatusChange,
 }: PositionNotificationsDebugPanelProps) {
   const { address } = useETHWallet();
   const { result: hookResult, status } = usePositionNotifications(address);
   const [manualMode, setManualMode] = useState(false);
+  const [simulateStalePrice, setSimulateStalePrice] = useState(false);
   const [manualParams, setManualParams] =
     useState<CalculatorParams>(makeDefaultParams);
 
@@ -489,10 +493,16 @@ export function PositionNotificationsDebugPanel({
 
   const displayResult = manualMode ? manualResult : hookResult;
 
-  // Notify parent of result changes so the main banner updates
+  // Notify parent of result and status changes so the main banner updates
   useEffect(() => {
-    onResultChange?.(displayResult);
-  }, [displayResult, onResultChange]);
+    if (simulateStalePrice) {
+      onResultChange?.(null);
+      onStatusChange?.("stale-price");
+    } else {
+      onResultChange?.(displayResult);
+      onStatusChange?.(null);
+    }
+  }, [displayResult, simulateStalePrice, onResultChange, onStatusChange]);
 
   if (status === "flag-off") return null;
 
@@ -514,6 +524,15 @@ export function PositionNotificationsDebugPanel({
               className="rounded"
             />
             Manual Mode
+          </label>
+          <label className="flex cursor-pointer items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={simulateStalePrice}
+              onChange={(e) => setSimulateStalePrice(e.target.checked)}
+              className="rounded"
+            />
+            Simulate stale price
           </label>
           {manualMode && (
             <button

--- a/services/vault/src/applications/aave/hooks/usePositionNotifications.ts
+++ b/services/vault/src/applications/aave/hooks/usePositionNotifications.ts
@@ -53,9 +53,10 @@ export function usePositionNotifications(
       return { result: null, status: "flag-off" };
     if (!splitParams || isLoading) return { result: null, status: "loading" };
     if (!connectedAddress) return { result: null, status: "no-wallet" };
-    if (btcPrice <= 0) return { result: null, status: "no-price" };
     if (btcMetadata?.isStale || btcMetadata?.fetchFailed)
       return { result: null, status: "stale-price" };
+    if (!btcMetadata || btcPrice <= 0)
+      return { result: null, status: "no-price" };
     if (collateralVaults.length === 0)
       return { result: null, status: "no-vaults" };
 

--- a/services/vault/src/applications/aave/hooks/usePositionNotifications.ts
+++ b/services/vault/src/applications/aave/hooks/usePositionNotifications.ts
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 
 import featureFlags from "@/config/featureFlags";
 import { useDashboardState } from "@/hooks/useDashboardState";
-import { usePrice } from "@/hooks/usePrices";
+import { usePrices } from "@/hooks/usePrices";
 
 import {
   calculate,
@@ -18,6 +18,7 @@ export type PositionNotificationsStatus =
   | "no-wallet"
   | "no-vaults"
   | "no-price"
+  | "stale-price"
   | "ready";
 
 export interface UsePositionNotificationsResult {
@@ -38,7 +39,9 @@ export function usePositionNotifications(
     isLoading: dashboardLoading,
   } = useDashboardState(connectedAddress);
 
-  const btcPrice = usePrice("BTC");
+  const { prices, metadata } = usePrices();
+  const btcPrice = prices["BTC"] ?? 0;
+  const btcMetadata = metadata["BTC"];
 
   const isLoading = paramsLoading || dashboardLoading;
 
@@ -51,6 +54,8 @@ export function usePositionNotifications(
     if (!splitParams || isLoading) return { result: null, status: "loading" };
     if (!connectedAddress) return { result: null, status: "no-wallet" };
     if (btcPrice <= 0) return { result: null, status: "no-price" };
+    if (btcMetadata?.isStale || btcMetadata?.fetchFailed)
+      return { result: null, status: "stale-price" };
     if (collateralVaults.length === 0)
       return { result: null, status: "no-vaults" };
 
@@ -76,6 +81,7 @@ export function usePositionNotifications(
     isLoading,
     connectedAddress,
     btcPrice,
+    btcMetadata,
     collateralVaults,
     debtValueUsd,
   ]);

--- a/services/vault/src/clients/eth-contract/chainlink/__tests__/query.test.ts
+++ b/services/vault/src/clients/eth-contract/chainlink/__tests__/query.test.ts
@@ -312,17 +312,19 @@ describe("getTokenPrices", () => {
     const { logger } = await import("@/infrastructure");
     const originalFeed = ENV.BTC_PRICE_FEED;
 
-    ENV.BTC_PRICE_FEED =
-      "0x1234567890abcdef1234567890abcdef12345678" as `0x${string}`;
-    mockFeedResponse(BTC_ANSWER_8_DECIMALS, STANDARD_DECIMALS);
+    try {
+      ENV.BTC_PRICE_FEED =
+        "0x1234567890abcdef1234567890abcdef12345678" as `0x${string}`;
+      mockFeedResponse(BTC_ANSWER_8_DECIMALS, STANDARD_DECIMALS);
 
-    await getTokenPrices(["BTC"]);
+      await getTokenPrices(["BTC"]);
 
-    expect(logger.warn).toHaveBeenCalledWith(
-      expect.stringContaining("BTC_PRICE_FEED env override"),
-    );
-
-    ENV.BTC_PRICE_FEED = originalFeed;
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("BTC_PRICE_FEED env override"),
+      );
+    } finally {
+      ENV.BTC_PRICE_FEED = originalFeed;
+    }
   });
 
   it("skips symbols with no feed address", async () => {

--- a/services/vault/src/clients/eth-contract/chainlink/__tests__/query.test.ts
+++ b/services/vault/src/clients/eth-contract/chainlink/__tests__/query.test.ts
@@ -143,12 +143,16 @@ describe("getTokenPrices", () => {
     expect(result.metadata["BTC"].fetchFailed).toBe(false);
   });
 
-  it("returns correct price using dynamic decimals for 18-decimal feed", async () => {
+  it("rejects 18-decimal feed answer that exceeds safe integer range", async () => {
     mockFeedResponse(BTC_ANSWER_18_DECIMALS, 18);
 
     const result = await getTokenPrices(["BTC"]);
 
-    expect(result.prices["BTC"]).toBe(BTC_PRICE_USD);
+    expect(result.prices["BTC"]).toBeUndefined();
+    expect(result.metadata["BTC"].fetchFailed).toBe(true);
+    expect(result.metadata["BTC"].error).toContain(
+      "exceeds safe integer range",
+    );
   });
 
   it("populates alias tokens for BTC (vBTC, sBTC)", async () => {
@@ -288,6 +292,37 @@ describe("getTokenPrices", () => {
     expect(result.prices["BTC"]).toBeUndefined();
     expect(result.metadata["BTC"].fetchFailed).toBe(true);
     expect(result.metadata["BTC"].error).toContain("price must be positive");
+  });
+
+  it("rejects price exceeding safe integer range", async () => {
+    const unsafeAnswer = BigInt(Number.MAX_SAFE_INTEGER) + 1n;
+    mockFeedResponse(unsafeAnswer, STANDARD_DECIMALS);
+
+    const result = await getTokenPrices(["BTC"]);
+
+    expect(result.prices["BTC"]).toBeUndefined();
+    expect(result.metadata["BTC"].fetchFailed).toBe(true);
+    expect(result.metadata["BTC"].error).toContain(
+      "exceeds safe integer range",
+    );
+  });
+
+  it("logs warning when BTC_PRICE_FEED env override is active", async () => {
+    const { ENV } = await import("@/config/env");
+    const { logger } = await import("@/infrastructure");
+    const originalFeed = ENV.BTC_PRICE_FEED;
+
+    ENV.BTC_PRICE_FEED =
+      "0x1234567890abcdef1234567890abcdef12345678" as `0x${string}`;
+    mockFeedResponse(BTC_ANSWER_8_DECIMALS, STANDARD_DECIMALS);
+
+    await getTokenPrices(["BTC"]);
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("BTC_PRICE_FEED env override"),
+    );
+
+    ENV.BTC_PRICE_FEED = originalFeed;
   });
 
   it("skips symbols with no feed address", async () => {

--- a/services/vault/src/clients/eth-contract/chainlink/query.ts
+++ b/services/vault/src/clients/eth-contract/chainlink/query.ts
@@ -59,7 +59,13 @@ function getChainlinkFeedAddress(symbol: string): Address | null {
     normalizedSymbol === "VBTC" ||
     normalizedSymbol === "SBTC"
   ) {
-    return ENV.BTC_PRICE_FEED ?? CHAINLINK_PRICE_FEEDS[network].BTC;
+    if (ENV.BTC_PRICE_FEED) {
+      logger.warn(
+        `Using BTC_PRICE_FEED env override (${ENV.BTC_PRICE_FEED}) instead of hardcoded Chainlink address`,
+      );
+      return ENV.BTC_PRICE_FEED;
+    }
+    return CHAINLINK_PRICE_FEEDS[network].BTC;
   }
 
   if (normalizedSymbol === "WETH" || normalizedSymbol === "ETH") {
@@ -207,6 +213,12 @@ async function fetchPriceFromFeed(
   const ageSeconds =
     Math.floor(Date.now() / 1000) - Number(roundData.updatedAt);
   const isStale = !isPriceFresh(roundData);
+
+  if (roundData.answer > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new Error(
+      `Chainlink price exceeds safe integer range: ${roundData.answer}`,
+    );
+  }
 
   if (isStale) {
     if (roundData.answeredInRound < roundData.roundId) {

--- a/services/vault/src/clients/eth-contract/chainlink/query.ts
+++ b/services/vault/src/clients/eth-contract/chainlink/query.ts
@@ -50,6 +50,8 @@ const CHAINLINK_MAX_PRICE_AGE_SECONDS = 3600;
 /** Number of seconds in one hour — used for display formatting */
 const SECONDS_PER_HOUR = 3600;
 
+let btcPriceFeedOverrideWarned = false;
+
 function getChainlinkFeedAddress(symbol: string): Address | null {
   const network = getBTCNetwork();
   const normalizedSymbol = symbol.toUpperCase();
@@ -60,9 +62,12 @@ function getChainlinkFeedAddress(symbol: string): Address | null {
     normalizedSymbol === "SBTC"
   ) {
     if (ENV.BTC_PRICE_FEED) {
-      logger.warn(
-        `Using BTC_PRICE_FEED env override (${ENV.BTC_PRICE_FEED}) instead of hardcoded Chainlink address`,
-      );
+      if (!btcPriceFeedOverrideWarned) {
+        logger.warn(
+          `Using BTC_PRICE_FEED env override (${ENV.BTC_PRICE_FEED}) instead of hardcoded Chainlink address`,
+        );
+        btcPriceFeedOverrideWarned = true;
+      }
       return ENV.BTC_PRICE_FEED;
     }
     return CHAINLINK_PRICE_FEEDS[network].BTC;

--- a/services/vault/src/components/simple/DashboardPage.tsx
+++ b/services/vault/src/components/simple/DashboardPage.tsx
@@ -13,6 +13,7 @@ import { PositionNotificationsDebugPanel } from "@/applications/aave/components/
 import { LOAN_TAB, type LoanTab } from "@/applications/aave/constants";
 import { useSyncPendingVaults } from "@/applications/aave/context";
 import { useAaveVaults } from "@/applications/aave/hooks";
+import type { PositionNotificationsStatus } from "@/applications/aave/hooks/usePositionNotifications";
 import type { CalculatorResult } from "@/applications/aave/positionNotifications";
 import type { Asset } from "@/applications/aave/types";
 import type { RootLayoutContext } from "@/components/pages/RootLayout";
@@ -49,6 +50,8 @@ export function DashboardPage() {
   const [isAssetModalOpen, setIsAssetModalOpen] = useState(false);
   const [debugResultOverride, setDebugResultOverride] =
     useState<CalculatorResult | null>(null);
+  const [debugStatusOverride, setDebugStatusOverride] =
+    useState<PositionNotificationsStatus | null>(null);
   const [assetModalMode, setAssetModalMode] = useState<LoanTab>(
     LOAN_TAB.BORROW,
   );
@@ -147,6 +150,7 @@ export function DashboardPage() {
           onDeposit={openDeposit}
           onRepay={handleRepay}
           result={debugResultOverride ?? undefined}
+          statusOverride={debugStatusOverride ?? undefined}
           btcBalanceBtc={btcBalanceBtc}
         />
 
@@ -181,6 +185,7 @@ export function DashboardPage() {
         {featureFlags.isPositionNotificationsEnabled && (
           <PositionNotificationsDebugPanel
             onResultChange={setDebugResultOverride}
+            onStatusChange={setDebugStatusOverride}
           />
         )}
       </div>

--- a/services/vault/src/components/simple/PositionNotificationBanner/PositionNotificationBanner.tsx
+++ b/services/vault/src/components/simple/PositionNotificationBanner/PositionNotificationBanner.tsx
@@ -4,7 +4,10 @@ import { useCallback, useState } from "react";
 import type { Address, Hex } from "viem";
 import { useAccount } from "wagmi";
 
-import { usePositionNotifications } from "@/applications/aave/hooks/usePositionNotifications";
+import {
+  usePositionNotifications,
+  type PositionNotificationsStatus,
+} from "@/applications/aave/hooks/usePositionNotifications";
 import { useReorderVaults } from "@/applications/aave/hooks/useReorderVaults";
 import {
   deriveBannerState,
@@ -20,6 +23,8 @@ import {
   GREEN_BANNER_DETAIL,
   GREEN_BANNER_TITLE,
   SEVERITY_STYLES,
+  STALE_PRICE_BANNER_DETAIL,
+  STALE_PRICE_BANNER_TITLE,
 } from "./constants";
 
 interface PositionNotificationBannerProps {
@@ -28,6 +33,8 @@ interface PositionNotificationBannerProps {
   onRepay: () => void;
   /** Override result for debug panel — skips hook when provided */
   result?: CalculatorResult | null;
+  /** Override status for debug panel — used to simulate stale-price state */
+  statusOverride?: PositionNotificationsStatus;
   /** BTC wallet balance in BTC units — used to disable deposit buttons when insufficient */
   btcBalanceBtc?: number;
 }
@@ -37,6 +44,7 @@ export function PositionNotificationBanner({
   onDeposit,
   onRepay,
   result: resultOverride,
+  statusOverride,
   btcBalanceBtc,
 }: PositionNotificationBannerProps) {
   const {
@@ -72,9 +80,32 @@ export function PositionNotificationBanner({
     }
   }, [result, executeReorder]);
 
-  // When no override, respect feature flag and loading states
+  const effectiveStatus = statusOverride ?? status;
+
+  // When no override, respect feature flag
+  if (!hasOverride && !featureFlags.isPositionNotificationsEnabled) return null;
+
+  // Stale-price: show yellow warning regardless of result
+  if (effectiveStatus === "stale-price") {
+    return (
+      <div
+        className={`rounded-lg p-4 ${SEVERITY_STYLES.yellow}`}
+        role="status"
+        data-testid="position-notification-banner"
+        data-severity="yellow"
+      >
+        <Text variant="body2" className="text-sm font-semibold">
+          {STALE_PRICE_BANNER_TITLE}
+        </Text>
+        <Text variant="body2" className="mt-1 text-sm opacity-80">
+          {STALE_PRICE_BANNER_DETAIL}
+        </Text>
+      </div>
+    );
+  }
+
+  // When no override, respect loading states
   if (!hasOverride) {
-    if (!featureFlags.isPositionNotificationsEnabled) return null;
     if (status !== "ready" || isLoading || !result) return null;
   }
 

--- a/services/vault/src/components/simple/PositionNotificationBanner/__tests__/PositionNotificationBanner.test.tsx
+++ b/services/vault/src/components/simple/PositionNotificationBanner/__tests__/PositionNotificationBanner.test.tsx
@@ -599,6 +599,67 @@ describe("PositionNotificationBanner", () => {
     expect(hint.dataset.tooltip).toBe("Insufficient BTC balance");
   });
 
+  it("renders yellow stale-price banner when statusOverride is stale-price", () => {
+    render(
+      <Wrapper>
+        <PositionNotificationBanner
+          statusOverride="stale-price"
+          onDeposit={onDeposit}
+          onRepay={onRepay}
+        />
+      </Wrapper>,
+    );
+
+    const banner = screen.getByTestId("position-notification-banner");
+    expect(banner.dataset.severity).toBe("yellow");
+    expect(
+      screen.getByText("Position notifications temporarily unavailable"),
+    ).toBeTruthy();
+    expect(
+      screen.getByText(
+        "BTC price data is stale or unavailable. Notifications will resume when fresh price data is available.",
+      ),
+    ).toBeTruthy();
+  });
+
+  it("stale-price banner has no action buttons", () => {
+    render(
+      <Wrapper>
+        <PositionNotificationBanner
+          statusOverride="stale-price"
+          onDeposit={onDeposit}
+          onRepay={onRepay}
+        />
+      </Wrapper>,
+    );
+
+    expect(screen.queryByText("Add Collateral")).toBeNull();
+    expect(screen.queryByText("Repay Debt")).toBeNull();
+    expect(screen.queryByText("Apply Suggested Order")).toBeNull();
+  });
+
+  it("stale-price status overrides a valid result", () => {
+    const result = makeBaseResult();
+
+    render(
+      <Wrapper>
+        <PositionNotificationBanner
+          result={result}
+          statusOverride="stale-price"
+          onDeposit={onDeposit}
+          onRepay={onRepay}
+        />
+      </Wrapper>,
+    );
+
+    const banner = screen.getByTestId("position-notification-banner");
+    expect(banner.dataset.severity).toBe("yellow");
+    expect(
+      screen.getByText("Position notifications temporarily unavailable"),
+    ).toBeTruthy();
+    expect(screen.queryByText("Position optimally structured")).toBeNull();
+  });
+
   it("renders nothing for dust (hidden severity)", () => {
     const result = makeBaseResult({
       warnings: [

--- a/services/vault/src/components/simple/PositionNotificationBanner/constants.ts
+++ b/services/vault/src/components/simple/PositionNotificationBanner/constants.ts
@@ -12,3 +12,8 @@ export const SEVERITY_STYLES: Record<BannerSeverity, string> = {
 export const GREEN_BANNER_TITLE = "Position optimally structured";
 export const GREEN_BANNER_DETAIL =
   "Vault ordering is correct and partial liquidation is enabled.";
+
+export const STALE_PRICE_BANNER_TITLE =
+  "Position notifications temporarily unavailable";
+export const STALE_PRICE_BANNER_DETAIL =
+  "BTC price data is stale or unavailable. Notifications will resume when fresh price data is available.";


### PR DESCRIPTION
- [#134 (MEDIUM)](https://github.com/babylonlabs-io/vault-provider-proxy/issues/134): Position notifications now check BTC price staleness via usePrices() instead of usePrice(). When BTC price is stale or fetch-failed, returns "stale-price" status instead of computing misleading liquidation guidance from outdated data.
- [#144 (LOW)](https://github.com/babylonlabs-io/vault-provider-proxy/issues/144): getChainlinkFeedAddress now logs a warning when BTC_PRICE_FEED env override is active, making misconfigured deployments visible in logs.
- [#145 (LOW)](https://github.com/babylonlabs-io/vault-provider-proxy/issues/145): fetchPriceFromFeed now throws if Chainlink's answer exceeds Number.MAX_SAFE_INTEGER, preventing silent precision loss from BigInt → Number conversion.


Closes https://github.com/babylonlabs-io/vault-provider-proxy/issues/134
Closes https://github.com/babylonlabs-io/vault-provider-proxy/issues/144
Closes https://github.com/babylonlabs-io/vault-provider-proxy/issues/145
