### PR TITLE
feat(vault): enable partial vault withdrawal with HF preview

### DIFF
--- a/services/vault/src/applications/aave/constants.ts
+++ b/services/vault/src/applications/aave/constants.ts
@@ -38,6 +38,25 @@ export const CONFIG_RETRY_COUNT = 3;
 export const EXPECTED_HEALTH_FACTOR_AT_LIQUIDATION = 0.95;
 
 /**
+ * Block threshold for vault withdrawal: if the projected health factor
+ * after withdrawing the selected vaults would be below this value, the
+ * FE disables the Confirm button to avoid a guaranteed on-chain revert
+ * (Aave itself enforces HF >= 1.0 on withdrawal). This is the lowest HF
+ * at which the contract would still accept the call.
+ */
+export const WITHDRAW_HF_BLOCK_THRESHOLD = 1.0;
+
+/**
+ * Warning threshold for vault withdrawal: if the projected health factor
+ * after withdrawing would fall below this value (but stay above the block
+ * threshold), the withdrawal review step shows an inline at-risk warning.
+ * Narrower than the general HEALTH_FACTOR_WARNING_THRESHOLD used by the
+ * position overview — withdrawal warnings are a separate, per-action
+ * surface per product decision.
+ */
+export const WITHDRAW_HF_WARNING_THRESHOLD = 1.1;
+
+/**
  * Safety margin multiplier for sacrificial vault sizing.
  * 1.05 means the sacrificial vault is sized 5% larger than the
  * computed target seizure to account for price movements between

--- a/services/vault/src/applications/aave/utils/__tests__/withdrawEligibility.test.ts
+++ b/services/vault/src/applications/aave/utils/__tests__/withdrawEligibility.test.ts
@@ -3,51 +3,18 @@ import { describe, expect, it } from "vitest";
 import {
   canWithdrawAnyVault,
   computeProjectedHealthFactor,
-  getVaultWithdrawalUsd,
+  getWithdrawHfWarningState,
   isHealthFactorAtOrAbove,
   isVaultIndividuallyWithdrawable,
   type PositionSnapshot,
 } from "../withdrawEligibility";
 
-// $10,000 collateral, $5,000 debt, 80% LT → HF = 10000*0.8/5000 = 1.6
-// Collateral is 1 BTC total, split as [0.5, 0.3, 0.2].
+// 1 BTC of collateral at current HF 1.6 (arbitrary but unambiguous).
+// Splits used by the canWithdrawAnyVault tests below are [0.5, 0.3, 0.2].
 const BASE_POSITION: PositionSnapshot = {
   collateralBtc: 1,
-  collateralValueUsd: 10000,
-  debtValueUsd: 5000,
-  liquidationThresholdBps: 8000,
+  currentHealthFactor: 1.6,
 };
-
-describe("getVaultWithdrawalUsd", () => {
-  it("returns proportional USD share of total collateral", () => {
-    expect(getVaultWithdrawalUsd(0.3, 1, 10000)).toBe(3000);
-  });
-
-  it("throws when total collateral BTC is zero", () => {
-    expect(() => getVaultWithdrawalUsd(0.1, 0, 10000)).toThrow();
-  });
-
-  it("throws when total collateral BTC is negative", () => {
-    expect(() => getVaultWithdrawalUsd(0.1, -1, 10000)).toThrow();
-  });
-});
-
-describe("computeProjectedHealthFactor", () => {
-  it("returns Infinity when there is no debt", () => {
-    expect(computeProjectedHealthFactor(10000, 3000, 0, 8000)).toBe(Infinity);
-  });
-
-  it("recomputes HF on the remaining collateral after withdrawal", () => {
-    // $10,000 - $3,000 = $7,000 remaining, $5,000 debt, 80% LT → HF = 1.12
-    const hf = computeProjectedHealthFactor(10000, 3000, 5000, 8000);
-    expect(hf).toBeCloseTo(1.12, 5);
-  });
-
-  it("clamps remaining collateral at zero (never negative)", () => {
-    // Withdrawing more than total collateral still produces HF = 0, not negative
-    expect(computeProjectedHealthFactor(10000, 12000, 5000, 8000)).toBe(0);
-  });
-});
 
 describe("isHealthFactorAtOrAbove", () => {
   it("returns true for values exactly equal to the threshold", () => {
@@ -69,45 +36,70 @@ describe("isHealthFactorAtOrAbove", () => {
   });
 });
 
+describe("computeProjectedHealthFactor", () => {
+  it("returns Infinity when there is no debt", () => {
+    expect(computeProjectedHealthFactor(null, 1, 0.3)).toBe(Infinity);
+  });
+
+  it("scales current HF by the remaining collateral ratio", () => {
+    // Withdraw 0.3 of 1 BTC → 0.7 remains → HF drops by 0.7x.
+    expect(computeProjectedHealthFactor(1.6, 1, 0.3)).toBeCloseTo(1.12, 5);
+  });
+
+  it("is zero when the full collateral is withdrawn with debt", () => {
+    expect(computeProjectedHealthFactor(1.6, 1, 1)).toBe(0);
+  });
+
+  it("clamps remaining collateral at zero (never negative)", () => {
+    expect(computeProjectedHealthFactor(1.6, 1, 2)).toBe(0);
+  });
+
+  it("returns zero when collateralBtc is zero and HF is defined", () => {
+    expect(computeProjectedHealthFactor(1.6, 0, 0)).toBe(0);
+  });
+});
+
 describe("isVaultIndividuallyWithdrawable", () => {
   it("treats any vault as withdrawable when there is no debt", () => {
-    const noDebt = { ...BASE_POSITION, debtValueUsd: 0 };
+    const noDebt: PositionSnapshot = {
+      collateralBtc: 1,
+      currentHealthFactor: null,
+    };
     expect(isVaultIndividuallyWithdrawable(0.5, noDebt)).toBe(true);
     expect(isVaultIndividuallyWithdrawable(1, noDebt)).toBe(true);
   });
 
   it("allows withdrawal when projected HF stays at or above 1.0", () => {
-    // Remove 0.3 BTC → remaining $7,000, debt $5,000, 80% LT → HF 1.12 ≥ 1.0
+    // 0.3 BTC out of 1 BTC at HF 1.6 → 1.6 * 0.7 = 1.12 ≥ 1.0
     expect(isVaultIndividuallyWithdrawable(0.3, BASE_POSITION)).toBe(true);
   });
 
   it("blocks withdrawal when projected HF would fall below 1.0", () => {
-    // Remove 0.5 BTC → remaining $5,000, debt $5,000, 80% LT → HF 0.8 < 1.0
+    // 0.5 BTC → 1.6 * 0.5 = 0.8 < 1.0
     expect(isVaultIndividuallyWithdrawable(0.5, BASE_POSITION)).toBe(false);
   });
 
   it("allows withdrawal that lands exactly at the 1.0 block threshold", () => {
-    // Choose withdrawal that leaves HF = 1.0 exactly: remaining = debt / LT
-    // debt/LT = 5000 / 0.8 = 6250; withdraw value = 10000 - 6250 = 3750
-    // → vault BTC = 3750/10000 * 1 = 0.375
+    // Choose withdrawal that leaves HF = 1.0 exactly: remaining ratio = 1/HF
+    // 1 / 1.6 = 0.625, so withdraw 0.375 leaves exactly HF 1.0.
     expect(isVaultIndividuallyWithdrawable(0.375, BASE_POSITION)).toBe(true);
   });
 
-  it("allows withdrawal at the threshold even with tiny FP noise in inputs", () => {
-    // Real oracle values come back with long decimal tails. Simulate that
-    // by perturbing inputs by ~1e-10; the exact-1.0 case must not flip
-    // to blocked purely due to float error.
+  it("allows withdrawal at the threshold even with tiny FP noise", () => {
+    // Perturb inputs so floating-point error nudges the intermediate
+    // computation; the exact-1.0 case must not flip to blocked.
     const noisy: PositionSnapshot = {
       collateralBtc: 1 + 1e-12,
-      collateralValueUsd: 10000 + 1e-8,
-      debtValueUsd: 5000 - 1e-8,
-      liquidationThresholdBps: 8000,
+      currentHealthFactor: 1.6 - 1e-12,
     };
     expect(isVaultIndividuallyWithdrawable(0.375, noisy)).toBe(true);
   });
 
   it("returns false when collateralBtc is zero (no vaults)", () => {
-    const empty: PositionSnapshot = { ...BASE_POSITION, collateralBtc: 0 };
+    const empty: PositionSnapshot = {
+      collateralBtc: 0,
+      currentHealthFactor: 1.6,
+    };
     expect(isVaultIndividuallyWithdrawable(0, empty)).toBe(false);
   });
 });
@@ -115,26 +107,26 @@ describe("isVaultIndividuallyWithdrawable", () => {
 describe("canWithdrawAnyVault", () => {
   it("returns true when at least one in-use vault is individually withdrawable", () => {
     const vaults = [
-      { amountBtc: 0.5, inUse: true }, // would drop HF to 0.8 → blocked
-      { amountBtc: 0.3, inUse: true }, // would drop HF to 1.12 → allowed
-      { amountBtc: 0.2, inUse: true }, // would drop HF to 1.28 → allowed
+      { amountBtc: 0.5, inUse: true }, // HF 0.8 → blocked
+      { amountBtc: 0.3, inUse: true }, // HF 1.12 → allowed
+      { amountBtc: 0.2, inUse: true }, // HF 1.28 → allowed
     ];
     expect(canWithdrawAnyVault(vaults, BASE_POSITION)).toBe(true);
   });
 
   it("returns false when every in-use vault would individually breach HF 1.0", () => {
-    // Shift debt up so even smallest vault breaches: debt $7,900
-    // Remove 0.2 BTC → remaining $8,000, HF = 8000*0.8/7900 ≈ 0.810 < 1.0
-    const heavyDebt: PositionSnapshot = {
-      ...BASE_POSITION,
-      debtValueUsd: 7900,
+    // Current HF low enough that even smallest vault breaches.
+    // 0.2 BTC removal on HF 1.2 → 1.2 * 0.8 = 0.96 < 1.0.
+    const lowHf: PositionSnapshot = {
+      collateralBtc: 1,
+      currentHealthFactor: 1.2,
     };
     const vaults = [
-      { amountBtc: 0.5, inUse: true },
-      { amountBtc: 0.3, inUse: true },
-      { amountBtc: 0.2, inUse: true },
+      { amountBtc: 0.5, inUse: true }, // 1.2 * 0.5 = 0.6
+      { amountBtc: 0.3, inUse: true }, // 1.2 * 0.7 = 0.84
+      { amountBtc: 0.2, inUse: true }, // 1.2 * 0.8 = 0.96
     ];
-    expect(canWithdrawAnyVault(vaults, heavyDebt)).toBe(false);
+    expect(canWithdrawAnyVault(vaults, lowHf)).toBe(false);
   });
 
   it("ignores vaults that are not in use", () => {
@@ -147,5 +139,32 @@ describe("canWithdrawAnyVault", () => {
 
   it("returns false for an empty vault list", () => {
     expect(canWithdrawAnyVault([], BASE_POSITION)).toBe(false);
+  });
+});
+
+describe("getWithdrawHfWarningState", () => {
+  it("marks HF at or above 1.1 as safe (no warning, no block)", () => {
+    expect(getWithdrawHfWarningState(1.2)).toEqual({
+      wouldBreachHF: false,
+      isAtRisk: false,
+    });
+    expect(getWithdrawHfWarningState(Infinity)).toEqual({
+      wouldBreachHF: false,
+      isAtRisk: false,
+    });
+  });
+
+  it("marks HF between 1.0 and 1.1 as at-risk", () => {
+    expect(getWithdrawHfWarningState(1.05)).toEqual({
+      wouldBreachHF: false,
+      isAtRisk: true,
+    });
+  });
+
+  it("marks HF below 1.0 as blocking", () => {
+    expect(getWithdrawHfWarningState(0.95)).toEqual({
+      wouldBreachHF: true,
+      isAtRisk: false,
+    });
   });
 });

--- a/services/vault/src/applications/aave/utils/__tests__/withdrawEligibility.test.ts
+++ b/services/vault/src/applications/aave/utils/__tests__/withdrawEligibility.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  canWithdrawAnyVault,
+  computeProjectedHealthFactor,
+  getVaultWithdrawalUsd,
+  isHealthFactorAtOrAbove,
+  isVaultIndividuallyWithdrawable,
+  type PositionSnapshot,
+} from "../withdrawEligibility";
+
+// $10,000 collateral, $5,000 debt, 80% LT → HF = 10000*0.8/5000 = 1.6
+// Collateral is 1 BTC total, split as [0.5, 0.3, 0.2].
+const BASE_POSITION: PositionSnapshot = {
+  collateralBtc: 1,
+  collateralValueUsd: 10000,
+  debtValueUsd: 5000,
+  liquidationThresholdBps: 8000,
+};
+
+describe("getVaultWithdrawalUsd", () => {
+  it("returns proportional USD share of total collateral", () => {
+    expect(getVaultWithdrawalUsd(0.3, 1, 10000)).toBe(3000);
+  });
+
+  it("throws when total collateral BTC is zero", () => {
+    expect(() => getVaultWithdrawalUsd(0.1, 0, 10000)).toThrow();
+  });
+
+  it("throws when total collateral BTC is negative", () => {
+    expect(() => getVaultWithdrawalUsd(0.1, -1, 10000)).toThrow();
+  });
+});
+
+describe("computeProjectedHealthFactor", () => {
+  it("returns Infinity when there is no debt", () => {
+    expect(computeProjectedHealthFactor(10000, 3000, 0, 8000)).toBe(Infinity);
+  });
+
+  it("recomputes HF on the remaining collateral after withdrawal", () => {
+    // $10,000 - $3,000 = $7,000 remaining, $5,000 debt, 80% LT → HF = 1.12
+    const hf = computeProjectedHealthFactor(10000, 3000, 5000, 8000);
+    expect(hf).toBeCloseTo(1.12, 5);
+  });
+
+  it("clamps remaining collateral at zero (never negative)", () => {
+    // Withdrawing more than total collateral still produces HF = 0, not negative
+    expect(computeProjectedHealthFactor(10000, 12000, 5000, 8000)).toBe(0);
+  });
+});
+
+describe("isHealthFactorAtOrAbove", () => {
+  it("returns true for values exactly equal to the threshold", () => {
+    expect(isHealthFactorAtOrAbove(1.0, 1.0)).toBe(true);
+  });
+
+  it("tolerates sub-1e-9 float error below the threshold", () => {
+    // Proportional scaling can compute 0.9999999999... when the true
+    // value is 1.0. The helper treats these as at-threshold.
+    expect(isHealthFactorAtOrAbove(1.0 - 1e-12, 1.0)).toBe(true);
+  });
+
+  it("rejects values meaningfully below the threshold", () => {
+    expect(isHealthFactorAtOrAbove(0.9999, 1.0)).toBe(false);
+  });
+
+  it("accepts Infinity (no debt) against any threshold", () => {
+    expect(isHealthFactorAtOrAbove(Infinity, 1.1)).toBe(true);
+  });
+});
+
+describe("isVaultIndividuallyWithdrawable", () => {
+  it("treats any vault as withdrawable when there is no debt", () => {
+    const noDebt = { ...BASE_POSITION, debtValueUsd: 0 };
+    expect(isVaultIndividuallyWithdrawable(0.5, noDebt)).toBe(true);
+    expect(isVaultIndividuallyWithdrawable(1, noDebt)).toBe(true);
+  });
+
+  it("allows withdrawal when projected HF stays at or above 1.0", () => {
+    // Remove 0.3 BTC → remaining $7,000, debt $5,000, 80% LT → HF 1.12 ≥ 1.0
+    expect(isVaultIndividuallyWithdrawable(0.3, BASE_POSITION)).toBe(true);
+  });
+
+  it("blocks withdrawal when projected HF would fall below 1.0", () => {
+    // Remove 0.5 BTC → remaining $5,000, debt $5,000, 80% LT → HF 0.8 < 1.0
+    expect(isVaultIndividuallyWithdrawable(0.5, BASE_POSITION)).toBe(false);
+  });
+
+  it("allows withdrawal that lands exactly at the 1.0 block threshold", () => {
+    // Choose withdrawal that leaves HF = 1.0 exactly: remaining = debt / LT
+    // debt/LT = 5000 / 0.8 = 6250; withdraw value = 10000 - 6250 = 3750
+    // → vault BTC = 3750/10000 * 1 = 0.375
+    expect(isVaultIndividuallyWithdrawable(0.375, BASE_POSITION)).toBe(true);
+  });
+
+  it("allows withdrawal at the threshold even with tiny FP noise in inputs", () => {
+    // Real oracle values come back with long decimal tails. Simulate that
+    // by perturbing inputs by ~1e-10; the exact-1.0 case must not flip
+    // to blocked purely due to float error.
+    const noisy: PositionSnapshot = {
+      collateralBtc: 1 + 1e-12,
+      collateralValueUsd: 10000 + 1e-8,
+      debtValueUsd: 5000 - 1e-8,
+      liquidationThresholdBps: 8000,
+    };
+    expect(isVaultIndividuallyWithdrawable(0.375, noisy)).toBe(true);
+  });
+
+  it("returns false when collateralBtc is zero (no vaults)", () => {
+    const empty: PositionSnapshot = { ...BASE_POSITION, collateralBtc: 0 };
+    expect(isVaultIndividuallyWithdrawable(0, empty)).toBe(false);
+  });
+});
+
+describe("canWithdrawAnyVault", () => {
+  it("returns true when at least one in-use vault is individually withdrawable", () => {
+    const vaults = [
+      { amountBtc: 0.5, inUse: true }, // would drop HF to 0.8 → blocked
+      { amountBtc: 0.3, inUse: true }, // would drop HF to 1.12 → allowed
+      { amountBtc: 0.2, inUse: true }, // would drop HF to 1.28 → allowed
+    ];
+    expect(canWithdrawAnyVault(vaults, BASE_POSITION)).toBe(true);
+  });
+
+  it("returns false when every in-use vault would individually breach HF 1.0", () => {
+    // Shift debt up so even smallest vault breaches: debt $7,900
+    // Remove 0.2 BTC → remaining $8,000, HF = 8000*0.8/7900 ≈ 0.810 < 1.0
+    const heavyDebt: PositionSnapshot = {
+      ...BASE_POSITION,
+      debtValueUsd: 7900,
+    };
+    const vaults = [
+      { amountBtc: 0.5, inUse: true },
+      { amountBtc: 0.3, inUse: true },
+      { amountBtc: 0.2, inUse: true },
+    ];
+    expect(canWithdrawAnyVault(vaults, heavyDebt)).toBe(false);
+  });
+
+  it("ignores vaults that are not in use", () => {
+    const vaults = [
+      { amountBtc: 0.3, inUse: false }, // would be safe, but not in use
+      { amountBtc: 0.5, inUse: true }, // in use but would breach HF
+    ];
+    expect(canWithdrawAnyVault(vaults, BASE_POSITION)).toBe(false);
+  });
+
+  it("returns false for an empty vault list", () => {
+    expect(canWithdrawAnyVault([], BASE_POSITION)).toBe(false);
+  });
+});

--- a/services/vault/src/applications/aave/utils/index.ts
+++ b/services/vault/src/applications/aave/utils/index.ts
@@ -27,3 +27,14 @@ export {
 } from "./healthFactorDisplay";
 
 export type { HealthFactorColor } from "./healthFactorDisplay";
+
+// Withdrawal eligibility helpers (frontend-only)
+export {
+  canWithdrawAnyVault,
+  computeProjectedHealthFactor,
+  getVaultWithdrawalUsd,
+  isHealthFactorAtOrAbove,
+  isVaultIndividuallyWithdrawable,
+} from "./withdrawEligibility";
+
+export type { PositionSnapshot } from "./withdrawEligibility";

--- a/services/vault/src/applications/aave/utils/index.ts
+++ b/services/vault/src/applications/aave/utils/index.ts
@@ -32,9 +32,12 @@ export type { HealthFactorColor } from "./healthFactorDisplay";
 export {
   canWithdrawAnyVault,
   computeProjectedHealthFactor,
-  getVaultWithdrawalUsd,
+  getWithdrawHfWarningState,
   isHealthFactorAtOrAbove,
   isVaultIndividuallyWithdrawable,
 } from "./withdrawEligibility";
 
-export type { PositionSnapshot } from "./withdrawEligibility";
+export type {
+  PositionSnapshot,
+  WithdrawHfWarningState,
+} from "./withdrawEligibility";

--- a/services/vault/src/applications/aave/utils/withdrawEligibility.ts
+++ b/services/vault/src/applications/aave/utils/withdrawEligibility.ts
@@ -1,0 +1,121 @@
+/**
+ * Withdrawal eligibility and projected health factor helpers.
+ *
+ * Aave enforces HF >= 1.0 on withdrawal on-chain. These helpers mirror
+ * that check client-side to drive UX: gating the outer Withdraw button,
+ * greying out vaults that can't be individually released, and blocking
+ * the review step's Confirm for combined selections that would revert.
+ */
+
+import { calculateHealthFactor } from "@babylonlabs-io/ts-sdk/tbv/integrations/aave";
+
+import { WITHDRAW_HF_BLOCK_THRESHOLD } from "../constants";
+
+/**
+ * Tolerance for comparing projected health factors against thresholds.
+ * Proportional USD scaling (vaultUsd = totalUsd * vaultBtc / totalBtc)
+ * and the subsequent HF math run in float64, which introduces errors
+ * on the order of 1e-13 near HF = 1.0. A slightly wider epsilon avoids
+ * false negatives at the exact threshold — e.g., a withdrawal that
+ * lands at HF = 1.0 computing as 0.9999999999 and being incorrectly
+ * blocked.
+ */
+const HF_COMPARISON_EPSILON = 1e-9;
+
+/**
+ * True if `healthFactor` is at or above `threshold`, accounting for
+ * float64 error from proportional scaling. Use this everywhere the UI
+ * compares a projected HF against a threshold; direct `>=` / `<` can
+ * spuriously reject a case the on-chain math would accept.
+ */
+export function isHealthFactorAtOrAbove(
+  healthFactor: number,
+  threshold: number,
+): boolean {
+  return healthFactor >= threshold - HF_COMPARISON_EPSILON;
+}
+
+export interface PositionSnapshot {
+  /** Total collateral in BTC across the user's vaults. */
+  collateralBtc: number;
+  /** Total collateral in USD from Aave's oracle. */
+  collateralValueUsd: number;
+  /** Total debt in USD from Aave's oracle. */
+  debtValueUsd: number;
+  /** Liquidation threshold for the vBTC reserve in basis points. */
+  liquidationThresholdBps: number;
+}
+
+/**
+ * Convert a vault's BTC amount to its USD share of the total collateral.
+ * Exact because every vault holds the same asset (vBTC) priced by one oracle.
+ */
+export function getVaultWithdrawalUsd(
+  vaultBtc: number,
+  collateralBtc: number,
+  collateralValueUsd: number,
+): number {
+  if (collateralBtc <= 0) {
+    throw new Error(
+      "getVaultWithdrawalUsd: collateralBtc must be > 0 to compute proportional USD value",
+    );
+  }
+  return (collateralValueUsd * vaultBtc) / collateralBtc;
+}
+
+/**
+ * Health factor the user would land at after withdrawing `withdrawalValueUsd`
+ * of collateral. Returns `Infinity` when there is no debt.
+ */
+export function computeProjectedHealthFactor(
+  collateralValueUsd: number,
+  withdrawalValueUsd: number,
+  debtValueUsd: number,
+  liquidationThresholdBps: number,
+): number {
+  const remainingCollateralUsd = Math.max(
+    0,
+    collateralValueUsd - withdrawalValueUsd,
+  );
+  return calculateHealthFactor(
+    remainingCollateralUsd,
+    debtValueUsd,
+    liquidationThresholdBps,
+  );
+}
+
+/**
+ * True if the user could withdraw only this one vault without breaching
+ * the on-chain HF floor (1.0). Used to grey out unsafe vaults in the picker.
+ */
+export function isVaultIndividuallyWithdrawable(
+  vaultBtc: number,
+  position: PositionSnapshot,
+): boolean {
+  if (position.collateralBtc <= 0) return false;
+  const withdrawalUsd = getVaultWithdrawalUsd(
+    vaultBtc,
+    position.collateralBtc,
+    position.collateralValueUsd,
+  );
+  const projectedHF = computeProjectedHealthFactor(
+    position.collateralValueUsd,
+    withdrawalUsd,
+    position.debtValueUsd,
+    position.liquidationThresholdBps,
+  );
+  return isHealthFactorAtOrAbove(projectedHF, WITHDRAW_HF_BLOCK_THRESHOLD);
+}
+
+/**
+ * True if at least one in-use vault could be withdrawn individually
+ * without breaching the HF floor. Gates the outer Withdraw button.
+ */
+export function canWithdrawAnyVault(
+  vaults: readonly { amountBtc: number; inUse: boolean }[],
+  position: PositionSnapshot,
+): boolean {
+  return vaults.some(
+    (v) => v.inUse && isVaultIndividuallyWithdrawable(v.amountBtc, position),
+  );
+}

--- a/services/vault/src/applications/aave/utils/withdrawEligibility.ts
+++ b/services/vault/src/applications/aave/utils/withdrawEligibility.ts
@@ -5,20 +5,27 @@
  * that check client-side to drive UX: gating the outer Withdraw button,
  * greying out vaults that can't be individually released, and blocking
  * the review step's Confirm for combined selections that would revert.
+ *
+ * We project HF by scaling Aave's authoritative on-chain health factor,
+ * not by re-deriving it from collateral/debt USD. All vaults hold the
+ * same asset (vBTC) priced by one oracle, so the ratio of remaining
+ * collateral BTC to total collateral BTC equals the ratio in USD, and
+ * HF is linear in that ratio when debt and liquidation threshold are
+ * held constant. Using on-chain HF as the baseline avoids replicating
+ * the contract's math (which has had unit-mismatch surprises in debt
+ * values) and guarantees we agree with the reading the user sees.
  */
 
-import { calculateHealthFactor } from "@babylonlabs-io/ts-sdk/tbv/integrations/aave";
-
-import { WITHDRAW_HF_BLOCK_THRESHOLD } from "../constants";
+import {
+  WITHDRAW_HF_BLOCK_THRESHOLD,
+  WITHDRAW_HF_WARNING_THRESHOLD,
+} from "../constants";
 
 /**
  * Tolerance for comparing projected health factors against thresholds.
- * Proportional USD scaling (vaultUsd = totalUsd * vaultBtc / totalBtc)
- * and the subsequent HF math run in float64, which introduces errors
- * on the order of 1e-13 near HF = 1.0. A slightly wider epsilon avoids
- * false negatives at the exact threshold — e.g., a withdrawal that
- * lands at HF = 1.0 computing as 0.9999999999 and being incorrectly
- * blocked.
+ * Proportional scaling runs in float64 and can produce a value a few
+ * ULPs below the intended result (e.g. `0.9999999999` for a true 1.0).
+ * A slightly wider epsilon avoids false negatives at the exact threshold.
  */
 const HF_COMPARISON_EPSILON = 1e-9;
 
@@ -38,50 +45,32 @@ export function isHealthFactorAtOrAbove(
 export interface PositionSnapshot {
   /** Total collateral in BTC across the user's vaults. */
   collateralBtc: number;
-  /** Total collateral in USD from Aave's oracle. */
-  collateralValueUsd: number;
-  /** Total debt in USD from Aave's oracle. */
-  debtValueUsd: number;
-  /** Liquidation threshold for the vBTC reserve in basis points. */
-  liquidationThresholdBps: number;
+  /**
+   * User's current on-chain health factor, or null when they have no debt.
+   * This is the authoritative value the contract reports; we scale it to
+   * project post-withdrawal HF.
+   */
+  currentHealthFactor: number | null;
 }
 
 /**
- * Convert a vault's BTC amount to its USD share of the total collateral.
- * Exact because every vault holds the same asset (vBTC) priced by one oracle.
- */
-export function getVaultWithdrawalUsd(
-  vaultBtc: number,
-  collateralBtc: number,
-  collateralValueUsd: number,
-): number {
-  if (collateralBtc <= 0) {
-    throw new Error(
-      "getVaultWithdrawalUsd: collateralBtc must be > 0 to compute proportional USD value",
-    );
-  }
-  return (collateralValueUsd * vaultBtc) / collateralBtc;
-}
-
-/**
- * Health factor the user would land at after withdrawing `withdrawalValueUsd`
+ * Health factor the user would land at after withdrawing `withdrawalBtc`
  * of collateral. Returns `Infinity` when there is no debt.
+ *
+ * Derivation: HF = collateral × LT / debt. Holding LT and debt constant,
+ * HF is proportional to collateral, so projectedHF = currentHF × (remaining
+ * / total). BTC ratio equals USD ratio because every vault is vBTC at one
+ * oracle price.
  */
 export function computeProjectedHealthFactor(
-  collateralValueUsd: number,
-  withdrawalValueUsd: number,
-  debtValueUsd: number,
-  liquidationThresholdBps: number,
+  currentHealthFactor: number | null,
+  collateralBtc: number,
+  withdrawalBtc: number,
 ): number {
-  const remainingCollateralUsd = Math.max(
-    0,
-    collateralValueUsd - withdrawalValueUsd,
-  );
-  return calculateHealthFactor(
-    remainingCollateralUsd,
-    debtValueUsd,
-    liquidationThresholdBps,
-  );
+  if (currentHealthFactor === null) return Infinity;
+  if (collateralBtc <= 0) return 0;
+  const remainingBtc = Math.max(0, collateralBtc - withdrawalBtc);
+  return currentHealthFactor * (remainingBtc / collateralBtc);
 }
 
 /**
@@ -93,18 +82,40 @@ export function isVaultIndividuallyWithdrawable(
   position: PositionSnapshot,
 ): boolean {
   if (position.collateralBtc <= 0) return false;
-  const withdrawalUsd = getVaultWithdrawalUsd(
-    vaultBtc,
-    position.collateralBtc,
-    position.collateralValueUsd,
-  );
   const projectedHF = computeProjectedHealthFactor(
-    position.collateralValueUsd,
-    withdrawalUsd,
-    position.debtValueUsd,
-    position.liquidationThresholdBps,
+    position.currentHealthFactor,
+    position.collateralBtc,
+    vaultBtc,
   );
   return isHealthFactorAtOrAbove(projectedHF, WITHDRAW_HF_BLOCK_THRESHOLD);
+}
+
+export interface WithdrawHfWarningState {
+  /** Projected HF would breach the on-chain block threshold; Confirm must be disabled. */
+  wouldBreachHF: boolean;
+  /** Projected HF sits between the block and warning thresholds; surface an at-risk warning. */
+  isAtRisk: boolean;
+}
+
+/**
+ * Classify the projected health factor into the UI states the withdraw
+ * flow surfaces (block / at-risk / safe). Selector and review both depend
+ * on this, so it lives here as the single source of truth.
+ */
+export function getWithdrawHfWarningState(
+  projectedHealthFactor: number,
+): WithdrawHfWarningState {
+  const wouldBreachHF = !isHealthFactorAtOrAbove(
+    projectedHealthFactor,
+    WITHDRAW_HF_BLOCK_THRESHOLD,
+  );
+  const isAtRisk =
+    !wouldBreachHF &&
+    !isHealthFactorAtOrAbove(
+      projectedHealthFactor,
+      WITHDRAW_HF_WARNING_THRESHOLD,
+    );
+  return { wouldBreachHF, isAtRisk };
 }
 
 /**

--- a/services/vault/src/components/simple/CollateralExpandedContent.tsx
+++ b/services/vault/src/components/simple/CollateralExpandedContent.tsx
@@ -3,7 +3,7 @@
  * Container for the scrollable vault list and withdraw button.
  */
 
-import { Button } from "@babylonlabs-io/core-ui";
+import { Button, Text } from "@babylonlabs-io/core-ui";
 
 import type { CollateralVaultEntry } from "@/types/collateral";
 
@@ -13,6 +13,8 @@ interface CollateralExpandedContentProps {
   vaults: CollateralVaultEntry[];
   onWithdraw: () => void;
   canWithdraw: boolean;
+  /** Rendered as an inline helper below the Withdraw button when it is disabled. */
+  disabledReason?: string;
   onArtifactDownload?: (vaultId: string) => void;
 }
 
@@ -20,6 +22,7 @@ export function CollateralExpandedContent({
   vaults,
   onWithdraw,
   canWithdraw,
+  disabledReason,
   onArtifactDownload,
 }: CollateralExpandedContentProps) {
   return (
@@ -45,7 +48,6 @@ export function CollateralExpandedContent({
         ))}
       </div>
 
-      {/* Withdraw button — withdraws ALL collateral (Aave constraint) */}
       <Button
         variant="outlined"
         color="primary"
@@ -55,6 +57,15 @@ export function CollateralExpandedContent({
       >
         Withdraw
       </Button>
+      {!canWithdraw && disabledReason && (
+        <Text
+          variant="body2"
+          className="text-center text-accent-secondary"
+          data-testid="withdraw-disabled-reason"
+        >
+          {disabledReason}
+        </Text>
+      )}
     </div>
   );
 }

--- a/services/vault/src/components/simple/CollateralSection.tsx
+++ b/services/vault/src/components/simple/CollateralSection.tsx
@@ -5,10 +5,11 @@
 
 import { Avatar, Button, Card } from "@babylonlabs-io/core-ui";
 import { useQueryClient } from "@tanstack/react-query";
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import type { Address } from "viem";
 import { useAccount } from "wagmi";
 
+import { canWithdrawAnyVault } from "@/applications/aave/utils";
 import { ArtifactDownloadModal } from "@/components/deposit/ArtifactDownloadModal";
 import { DepositButton, ExpandMenuButton } from "@/components/shared";
 import { Connect } from "@/components/Wallet";
@@ -29,17 +30,26 @@ interface CollateralSectionProps {
   collateralVaults: CollateralVaultEntry[];
   hasCollateral: boolean;
   isConnected: boolean;
-  hasDebt: boolean;
+  collateralBtc: number;
+  collateralValueUsd: number;
+  debtValueUsd: number;
+  liquidationThresholdBps: number;
   onWithdraw: () => void;
   onDeposit: () => void;
 }
+
+const WITHDRAW_DISABLED_TOOLTIP =
+  "No vault can be released without putting your position at risk of liquidation. Repay debt first.";
 
 export function CollateralSection({
   totalAmountBtc,
   collateralVaults,
   hasCollateral,
   isConnected,
-  hasDebt,
+  collateralBtc,
+  collateralValueUsd,
+  debtValueUsd,
+  liquidationThresholdBps,
   onWithdraw,
   onDeposit,
 }: CollateralSectionProps) {
@@ -51,7 +61,24 @@ export function CollateralSection({
   const { findProvider } = useVaultProviders();
   const queryClient = useQueryClient();
   const { address } = useAccount();
-  const canWithdraw = !hasDebt;
+
+  const canWithdraw = useMemo(() => {
+    if (!hasCollateral) return false;
+    return canWithdrawAnyVault(collateralVaults, {
+      collateralBtc,
+      collateralValueUsd,
+      debtValueUsd,
+      liquidationThresholdBps,
+    });
+  }, [
+    hasCollateral,
+    collateralVaults,
+    collateralBtc,
+    collateralValueUsd,
+    debtValueUsd,
+    liquidationThresholdBps,
+  ]);
+
   const canReorder = collateralVaults.length >= 2;
 
   const handleReorderSuccessClose = useCallback(() => {
@@ -143,6 +170,7 @@ export function CollateralSection({
               vaults={collateralVaults}
               onWithdraw={onWithdraw}
               canWithdraw={canWithdraw}
+              disabledReason={WITHDRAW_DISABLED_TOOLTIP}
               onArtifactDownload={handleArtifactDownload}
             />
           )}

--- a/services/vault/src/components/simple/CollateralSection.tsx
+++ b/services/vault/src/components/simple/CollateralSection.tsx
@@ -31,9 +31,8 @@ interface CollateralSectionProps {
   hasCollateral: boolean;
   isConnected: boolean;
   collateralBtc: number;
-  collateralValueUsd: number;
-  debtValueUsd: number;
-  liquidationThresholdBps: number;
+  /** User's current on-chain health factor (null when no debt). */
+  currentHealthFactor: number | null;
   onWithdraw: () => void;
   onDeposit: () => void;
 }
@@ -47,9 +46,7 @@ export function CollateralSection({
   hasCollateral,
   isConnected,
   collateralBtc,
-  collateralValueUsd,
-  debtValueUsd,
-  liquidationThresholdBps,
+  currentHealthFactor,
   onWithdraw,
   onDeposit,
 }: CollateralSectionProps) {
@@ -66,18 +63,9 @@ export function CollateralSection({
     if (!hasCollateral) return false;
     return canWithdrawAnyVault(collateralVaults, {
       collateralBtc,
-      collateralValueUsd,
-      debtValueUsd,
-      liquidationThresholdBps,
+      currentHealthFactor,
     });
-  }, [
-    hasCollateral,
-    collateralVaults,
-    collateralBtc,
-    collateralValueUsd,
-    debtValueUsd,
-    liquidationThresholdBps,
-  ]);
+  }, [hasCollateral, collateralVaults, collateralBtc, currentHealthFactor]);
 
   const canReorder = collateralVaults.length >= 2;
 

--- a/services/vault/src/components/simple/DashboardPage.tsx
+++ b/services/vault/src/components/simple/DashboardPage.tsx
@@ -59,12 +59,12 @@ export function DashboardPage() {
     collateralBtc,
     collateralValueUsd,
     debtValueUsd,
+    liquidationThresholdBps,
     healthFactor,
     healthFactorStatus,
     borrowedAssets,
     hasLoans,
     hasCollateral,
-    hasDebt,
     collateralVaults,
     selectableBorrowedAssets,
   } = useDashboardState(address);
@@ -166,7 +166,10 @@ export function DashboardPage() {
           collateralVaults={collateralVaults}
           hasCollateral={hasCollateral}
           isConnected={isConnected}
-          hasDebt={hasDebt}
+          collateralBtc={collateralBtc}
+          collateralValueUsd={collateralValueUsd}
+          debtValueUsd={debtValueUsd}
+          liquidationThresholdBps={liquidationThresholdBps}
           onWithdraw={handleWithdraw}
           onDeposit={openDeposit}
         />
@@ -197,6 +200,9 @@ export function DashboardPage() {
         collateralVaults={collateralVaults}
         collateralBtc={collateralBtc}
         collateralValueUsd={collateralValueUsd}
+        debtValueUsd={debtValueUsd}
+        liquidationThresholdBps={liquidationThresholdBps}
+        currentHealthFactor={healthFactor}
       />
 
       {/* Asset Selection Modal for Borrow/Repay */}

--- a/services/vault/src/components/simple/DashboardPage.tsx
+++ b/services/vault/src/components/simple/DashboardPage.tsx
@@ -59,7 +59,6 @@ export function DashboardPage() {
     collateralBtc,
     collateralValueUsd,
     debtValueUsd,
-    liquidationThresholdBps,
     healthFactor,
     healthFactorStatus,
     borrowedAssets,
@@ -167,9 +166,7 @@ export function DashboardPage() {
           hasCollateral={hasCollateral}
           isConnected={isConnected}
           collateralBtc={collateralBtc}
-          collateralValueUsd={collateralValueUsd}
-          debtValueUsd={debtValueUsd}
-          liquidationThresholdBps={liquidationThresholdBps}
+          currentHealthFactor={healthFactor}
           onWithdraw={handleWithdraw}
           onDeposit={openDeposit}
         />
@@ -200,8 +197,6 @@ export function DashboardPage() {
         collateralVaults={collateralVaults}
         collateralBtc={collateralBtc}
         collateralValueUsd={collateralValueUsd}
-        debtValueUsd={debtValueUsd}
-        liquidationThresholdBps={liquidationThresholdBps}
         currentHealthFactor={healthFactor}
       />
 

--- a/services/vault/src/components/simple/WithdrawFlow/HealthFactorDelta.tsx
+++ b/services/vault/src/components/simple/WithdrawFlow/HealthFactorDelta.tsx
@@ -1,0 +1,25 @@
+import { formatHealthFactor } from "@/applications/aave/utils";
+
+interface HealthFactorDeltaProps {
+  /** Current on-chain health factor, or null when the user has no debt. */
+  current: number | null;
+  /** Projected health factor after the action. Infinity when no debt. */
+  projected: number;
+}
+
+/**
+ * Compact "current → projected" health factor rendering shared by the
+ * withdraw selector and review steps.
+ */
+export function HealthFactorDelta({
+  current,
+  projected,
+}: HealthFactorDeltaProps) {
+  return (
+    <span>
+      {formatHealthFactor(current)}
+      <span className="mx-1 text-accent-secondary">&rarr;</span>
+      {Number.isFinite(projected) ? formatHealthFactor(projected) : "∞"}
+    </span>
+  );
+}

--- a/services/vault/src/components/simple/WithdrawFlow/WithdrawReviewContent.tsx
+++ b/services/vault/src/components/simple/WithdrawFlow/WithdrawReviewContent.tsx
@@ -1,7 +1,15 @@
 import { Button, Heading, Loader, Text } from "@babylonlabs-io/core-ui";
 import { useMemo } from "react";
 
-import { BPS_SCALE } from "@/applications/aave/constants";
+import {
+  BPS_SCALE,
+  WITHDRAW_HF_BLOCK_THRESHOLD,
+  WITHDRAW_HF_WARNING_THRESHOLD,
+} from "@/applications/aave/constants";
+import {
+  formatHealthFactor,
+  isHealthFactorAtOrAbove,
+} from "@/applications/aave/utils";
 import { DetailsCard, type DetailRow } from "@/components/shared";
 import { useProtocolParamsContext } from "@/context/ProtocolParamsContext";
 import { useNetworkFees } from "@/hooks/useNetworkFees";
@@ -10,6 +18,10 @@ import { formatBtcAmount, formatUsdValue } from "@/utils/formatting";
 interface WithdrawReviewContentProps {
   totalAmountBtc: number;
   totalAmountUsd: number;
+  /** User's current on-chain health factor (null when no debt). */
+  currentHealthFactor: number | null;
+  /** Health factor after the selected vaults are withdrawn. Infinity when no debt. */
+  projectedHealthFactor: number;
   isProcessing: boolean;
   onConfirm: () => void;
 }
@@ -17,17 +29,46 @@ interface WithdrawReviewContentProps {
 export function WithdrawReviewContent({
   totalAmountBtc,
   totalAmountUsd,
+  currentHealthFactor,
+  projectedHealthFactor,
   isProcessing,
   onConfirm,
 }: WithdrawReviewContentProps) {
   const { defaultFeeRate } = useNetworkFees();
   const { minVpCommissionBps } = useProtocolParamsContext();
 
+  const wouldBreachHF = !isHealthFactorAtOrAbove(
+    projectedHealthFactor,
+    WITHDRAW_HF_BLOCK_THRESHOLD,
+  );
+  const isAtRisk =
+    !wouldBreachHF &&
+    !isHealthFactorAtOrAbove(
+      projectedHealthFactor,
+      WITHDRAW_HF_WARNING_THRESHOLD,
+    );
+
   const rows: DetailRow[] = useMemo(() => {
     const vpCommissionBtc = totalAmountBtc * (minVpCommissionBps / BPS_SCALE);
     const vpCommissionUsd = totalAmountUsd * (minVpCommissionBps / BPS_SCALE);
 
-    return [
+    const hfRow: DetailRow | null =
+      currentHealthFactor === null
+        ? null
+        : {
+            label: "Health Factor",
+            value: (
+              <span>
+                {formatHealthFactor(currentHealthFactor)}
+                <span className="mx-1 text-accent-secondary">&rarr;</span>
+                {Number.isFinite(projectedHealthFactor)
+                  ? formatHealthFactor(projectedHealthFactor)
+                  : "∞"}
+              </span>
+            ),
+          };
+
+    const baseRows: DetailRow[] = [
       {
         label: "Withdraw Amount",
         value: (
@@ -58,7 +99,16 @@ export function WithdrawReviewContent({
           ),
       },
     ];
-  }, [totalAmountBtc, totalAmountUsd, defaultFeeRate, minVpCommissionBps]);
+
+    return hfRow ? [baseRows[0], hfRow, ...baseRows.slice(1)] : baseRows;
+  }, [
+    totalAmountBtc,
+    totalAmountUsd,
+    currentHealthFactor,
+    projectedHealthFactor,
+    defaultFeeRate,
+    minVpCommissionBps,
+  ]);
 
   return (
     <div className="w-full">
@@ -69,11 +119,34 @@ export function WithdrawReviewContent({
       <div className="mt-6 flex flex-col gap-6">
         <DetailsCard rows={rows} />
 
+        {wouldBreachHF && (
+          <Text
+            variant="body2"
+            className="text-error-main"
+            data-testid="withdraw-hf-block-warning"
+          >
+            This withdrawal would drop your health factor below{" "}
+            {WITHDRAW_HF_BLOCK_THRESHOLD.toFixed(1)} and be rejected on-chain.
+            Reduce the selection or repay debt first.
+          </Text>
+        )}
+        {isAtRisk && (
+          <Text
+            variant="body2"
+            className="text-warning-main"
+            data-testid="withdraw-hf-at-risk-warning"
+          >
+            Your position will be at risk of liquidation after this withdrawal
+            (health factor below {WITHDRAW_HF_WARNING_THRESHOLD.toFixed(1)}).
+            Consider withdrawing less or repaying debt.
+          </Text>
+        )}
+
         <Button
           variant="contained"
           color="secondary"
           className="w-full"
-          disabled={isProcessing}
+          disabled={isProcessing || wouldBreachHF}
           onClick={onConfirm}
         >
           {isProcessing ? (

--- a/services/vault/src/components/simple/WithdrawFlow/WithdrawReviewContent.tsx
+++ b/services/vault/src/components/simple/WithdrawFlow/WithdrawReviewContent.tsx
@@ -6,14 +6,13 @@ import {
   WITHDRAW_HF_BLOCK_THRESHOLD,
   WITHDRAW_HF_WARNING_THRESHOLD,
 } from "@/applications/aave/constants";
-import {
-  formatHealthFactor,
-  isHealthFactorAtOrAbove,
-} from "@/applications/aave/utils";
+import { getWithdrawHfWarningState } from "@/applications/aave/utils";
 import { DetailsCard, type DetailRow } from "@/components/shared";
 import { useProtocolParamsContext } from "@/context/ProtocolParamsContext";
 import { useNetworkFees } from "@/hooks/useNetworkFees";
 import { formatBtcAmount, formatUsdValue } from "@/utils/formatting";
+
+import { HealthFactorDelta } from "./HealthFactorDelta";
 
 interface WithdrawReviewContentProps {
   totalAmountBtc: number;
@@ -24,6 +23,12 @@ interface WithdrawReviewContentProps {
   projectedHealthFactor: number;
   isProcessing: boolean;
   onConfirm: () => void;
+  /**
+   * Navigate back to the vault selector, preserving the current selection.
+   * Lets the user recover from a blocked or at-risk review without closing
+   * the dialog.
+   */
+  onEditSelection: () => void;
 }
 
 export function WithdrawReviewContent({
@@ -33,20 +38,14 @@ export function WithdrawReviewContent({
   projectedHealthFactor,
   isProcessing,
   onConfirm,
+  onEditSelection,
 }: WithdrawReviewContentProps) {
   const { defaultFeeRate } = useNetworkFees();
   const { minVpCommissionBps } = useProtocolParamsContext();
 
-  const wouldBreachHF = !isHealthFactorAtOrAbove(
+  const { wouldBreachHF, isAtRisk } = getWithdrawHfWarningState(
     projectedHealthFactor,
-    WITHDRAW_HF_BLOCK_THRESHOLD,
   );
-  const isAtRisk =
-    !wouldBreachHF &&
-    !isHealthFactorAtOrAbove(
-      projectedHealthFactor,
-      WITHDRAW_HF_WARNING_THRESHOLD,
-    );
 
   const rows: DetailRow[] = useMemo(() => {
     const vpCommissionBtc = totalAmountBtc * (minVpCommissionBps / BPS_SCALE);
@@ -58,13 +57,10 @@ export function WithdrawReviewContent({
         : {
             label: "Health Factor",
             value: (
-              <span>
-                {formatHealthFactor(currentHealthFactor)}
-                <span className="mx-1 text-accent-secondary">&rarr;</span>
-                {Number.isFinite(projectedHealthFactor)
-                  ? formatHealthFactor(projectedHealthFactor)
-                  : "∞"}
-              </span>
+              <HealthFactorDelta
+                current={currentHealthFactor}
+                projected={projectedHealthFactor}
+              />
             ),
           };
 
@@ -159,6 +155,16 @@ export function WithdrawReviewContent({
           ) : (
             "Confirm"
           )}
+        </Button>
+        <Button
+          variant="outlined"
+          color="primary"
+          className="w-full"
+          disabled={isProcessing}
+          onClick={onEditSelection}
+          data-testid="withdraw-change-selection"
+        >
+          Change Selection
         </Button>
       </div>
     </div>

--- a/services/vault/src/components/simple/WithdrawFlow/WithdrawVaultSelector.tsx
+++ b/services/vault/src/components/simple/WithdrawFlow/WithdrawVaultSelector.tsx
@@ -6,11 +6,18 @@ import {
   Heading,
   Text,
 } from "@babylonlabs-io/core-ui";
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 
+import {
+  WITHDRAW_HF_BLOCK_THRESHOLD,
+  WITHDRAW_HF_WARNING_THRESHOLD,
+} from "@/applications/aave/constants";
+import { getWithdrawHfWarningState } from "@/applications/aave/utils";
 import { getNetworkConfigBTC } from "@/config";
 import type { CollateralVaultEntry } from "@/types/collateral";
 import { formatBtcAmount } from "@/utils/formatting";
+
+import { HealthFactorDelta } from "./HealthFactorDelta";
 
 const btcConfig = getNetworkConfigBTC();
 
@@ -19,19 +26,29 @@ interface WithdrawVaultSelectorProps {
   /**
    * Map of vaultId → whether that vault can be withdrawn individually
    * without breaching HF 1.0. Vaults missing from the map or marked false
-   * are rendered greyed out and are not selectable.
+   * are rendered greyed out and cannot be newly selected (already-selected
+   * vaults can still be deselected even if their eligibility has flipped).
    */
   vaultEligibility: Map<string, boolean>;
-  onNext: (selectedVaultIds: string[]) => void;
+  /** Selected vault IDs, owned by the parent so back-navigation preserves them. */
+  selectedVaultIds: string[];
+  onSelectionChange: (selectedVaultIds: string[]) => void;
+  /** Current on-chain health factor, or null when the user has no debt. */
+  currentHealthFactor: number | null;
+  /** Projected health factor for the current selection; Infinity when no debt. */
+  projectedHealthFactor: number;
+  onNext: () => void;
 }
 
 export function WithdrawVaultSelector({
   vaults,
   vaultEligibility,
+  selectedVaultIds,
+  onSelectionChange,
+  currentHealthFactor,
+  projectedHealthFactor,
   onNext,
 }: WithdrawVaultSelectorProps) {
-  const [selectedVaultIds, setSelectedVaultIds] = useState<string[]>([]);
-
   const inUseVaults = useMemo(() => vaults.filter((v) => v.inUse), [vaults]);
 
   const eligibleVaults = useMemo(
@@ -45,28 +62,41 @@ export function WithdrawVaultSelector({
     eligibleVaults.length > 0 &&
     eligibleVaults.every((v) => selectedVaultIds.includes(v.vaultId));
 
+  // Would the combined selection breach HF 1.0? The contract would revert;
+  // disable Next rather than let the user walk into a blocked review step.
+  const { wouldBreachHF, isAtRisk } = getWithdrawHfWarningState(
+    projectedHealthFactor,
+  );
+
   const toggleSelection = (vaultId: string) => {
-    if (vaultEligibility.get(vaultId) !== true) return;
-    setSelectedVaultIds((prev) =>
-      prev.includes(vaultId)
-        ? prev.filter((id) => id !== vaultId)
-        : [...prev, vaultId],
+    const isCurrentlySelected = selectedVaultIds.includes(vaultId);
+    // Block new selections of ineligible vaults, but always allow deselect
+    // so a vault that flips to ineligible during a position refresh isn't
+    // stuck in the selection.
+    if (!isCurrentlySelected && vaultEligibility.get(vaultId) !== true) return;
+    onSelectionChange(
+      isCurrentlySelected
+        ? selectedVaultIds.filter((id) => id !== vaultId)
+        : [...selectedVaultIds, vaultId],
     );
   };
 
   const toggleAll = () => {
     if (allEligibleSelected) {
-      setSelectedVaultIds([]);
+      onSelectionChange([]);
     } else {
-      setSelectedVaultIds(eligibleVaults.map((v) => v.vaultId));
+      onSelectionChange(eligibleVaults.map((v) => v.vaultId));
     }
   };
 
   const handleNext = () => {
-    if (selectedVaultIds.length > 0) {
-      onNext(selectedVaultIds);
+    if (selectedVaultIds.length > 0 && !wouldBreachHF) {
+      onNext();
     }
   };
+
+  const showHfPreview =
+    currentHealthFactor !== null && selectedVaultIds.length > 0;
 
   return (
     <div className="w-full">
@@ -114,14 +144,15 @@ export function WithdrawVaultSelector({
         {inUseVaults.map((vault, index) => {
           const isEligible = vaultEligibility.get(vault.vaultId) === true;
           const isSelected = selectedVaultIds.includes(vault.vaultId);
+          const canInteract = isEligible || isSelected;
           const rowBg =
             index % 2 === 0 ? "bg-secondary-highlight/50" : "bg-transparent";
-          const hoverBg = isEligible
+          const hoverBg = canInteract
             ? index % 2 === 0
               ? "hover:bg-secondary-highlight"
               : "hover:bg-secondary-highlight/50"
             : "";
-          const cursor = isEligible ? "cursor-pointer" : "cursor-not-allowed";
+          const cursor = canInteract ? "cursor-pointer" : "cursor-not-allowed";
           const opacity = isEligible ? "" : "opacity-50";
 
           return (
@@ -130,11 +161,11 @@ export function WithdrawVaultSelector({
               className={`flex items-center justify-between gap-4 px-0 py-4 transition-colors ${rowBg} ${hoverBg} ${cursor} ${opacity}`}
               onClick={() => toggleSelection(vault.vaultId)}
               title={
-                isEligible
-                  ? undefined
-                  : "Withdrawing this vault would drop your health factor below 1.0."
+                !isEligible && !isSelected
+                  ? "Withdrawing this vault would drop your health factor below 1.0."
+                  : undefined
               }
-              aria-disabled={!isEligible}
+              aria-disabled={!canInteract}
             >
               <div className="flex flex-1 items-center gap-3 px-4">
                 <AvatarGroup size="medium">
@@ -162,7 +193,7 @@ export function WithdrawVaultSelector({
                   onChange={() => toggleSelection(vault.vaultId)}
                   variant="default"
                   showLabel={false}
-                  disabled={!isEligible}
+                  disabled={!canInteract}
                 />
               </div>
             </div>
@@ -170,12 +201,50 @@ export function WithdrawVaultSelector({
         })}
       </div>
 
+      {showHfPreview && (
+        <div
+          className="mt-4 flex items-center justify-between"
+          data-testid="withdraw-selector-hf-preview"
+        >
+          <Text variant="body2" className="text-accent-secondary">
+            Projected Health Factor
+          </Text>
+          <Text variant="body2" className="text-accent-primary">
+            <HealthFactorDelta
+              current={currentHealthFactor}
+              projected={projectedHealthFactor}
+            />
+          </Text>
+        </div>
+      )}
+      {showHfPreview && wouldBreachHF && (
+        <Text
+          variant="body2"
+          className="mt-2 text-error-main"
+          data-testid="withdraw-selector-block-warning"
+        >
+          This selection would drop your health factor below{" "}
+          {WITHDRAW_HF_BLOCK_THRESHOLD.toFixed(1)}. Deselect one or more vaults,
+          or repay debt first.
+        </Text>
+      )}
+      {showHfPreview && isAtRisk && (
+        <Text
+          variant="body2"
+          className="mt-2 text-warning-main"
+          data-testid="withdraw-selector-at-risk-warning"
+        >
+          This selection will put your position at risk of liquidation (health
+          factor below {WITHDRAW_HF_WARNING_THRESHOLD.toFixed(1)}).
+        </Text>
+      )}
+
       <div className="mt-6">
         <Button
           variant="contained"
           color="secondary"
           className="w-full"
-          disabled={selectedVaultIds.length === 0}
+          disabled={selectedVaultIds.length === 0 || wouldBreachHF}
           onClick={handleNext}
         >
           Next

--- a/services/vault/src/components/simple/WithdrawFlow/WithdrawVaultSelector.tsx
+++ b/services/vault/src/components/simple/WithdrawFlow/WithdrawVaultSelector.tsx
@@ -16,21 +16,37 @@ const btcConfig = getNetworkConfigBTC();
 
 interface WithdrawVaultSelectorProps {
   vaults: CollateralVaultEntry[];
+  /**
+   * Map of vaultId → whether that vault can be withdrawn individually
+   * without breaching HF 1.0. Vaults missing from the map or marked false
+   * are rendered greyed out and are not selectable.
+   */
+  vaultEligibility: Map<string, boolean>;
   onNext: (selectedVaultIds: string[]) => void;
 }
 
 export function WithdrawVaultSelector({
   vaults,
+  vaultEligibility,
   onNext,
 }: WithdrawVaultSelectorProps) {
   const [selectedVaultIds, setSelectedVaultIds] = useState<string[]>([]);
 
   const inUseVaults = useMemo(() => vaults.filter((v) => v.inUse), [vaults]);
 
-  const allSelected =
-    inUseVaults.length > 0 && selectedVaultIds.length === inUseVaults.length;
+  const eligibleVaults = useMemo(
+    () => inUseVaults.filter((v) => vaultEligibility.get(v.vaultId) === true),
+    [inUseVaults, vaultEligibility],
+  );
+
+  const hasIneligibleVaults = eligibleVaults.length < inUseVaults.length;
+
+  const allEligibleSelected =
+    eligibleVaults.length > 0 &&
+    eligibleVaults.every((v) => selectedVaultIds.includes(v.vaultId));
 
   const toggleSelection = (vaultId: string) => {
+    if (vaultEligibility.get(vaultId) !== true) return;
     setSelectedVaultIds((prev) =>
       prev.includes(vaultId)
         ? prev.filter((id) => id !== vaultId)
@@ -39,10 +55,10 @@ export function WithdrawVaultSelector({
   };
 
   const toggleAll = () => {
-    if (allSelected) {
+    if (allEligibleSelected) {
       setSelectedVaultIds([]);
     } else {
-      setSelectedVaultIds(inUseVaults.map((v) => v.vaultId));
+      setSelectedVaultIds(eligibleVaults.map((v) => v.vaultId));
     }
   };
 
@@ -62,9 +78,20 @@ export function WithdrawVaultSelector({
         Choose which vaults to withdraw from your collateral position.
       </Text>
 
+      {hasIneligibleVaults && (
+        <Text
+          variant="body2"
+          className="mt-2 text-warning-main"
+          data-testid="withdraw-ineligible-hint"
+        >
+          Greyed-out vaults cannot be withdrawn without dropping your health
+          factor below 1.0. Repay debt to unlock them.
+        </Text>
+      )}
+
       <div className="mt-6 flex flex-col">
         {/* Select all row */}
-        {inUseVaults.length > 1 && (
+        {eligibleVaults.length > 1 && (
           <div
             className="flex cursor-pointer items-center justify-between border-b border-primary-light/20 px-4 py-3"
             onClick={toggleAll}
@@ -74,7 +101,7 @@ export function WithdrawVaultSelector({
             </Text>
             <div onClick={(e: React.MouseEvent) => e.stopPropagation()}>
               <Checkbox
-                checked={allSelected}
+                checked={allEligibleSelected}
                 onChange={toggleAll}
                 variant="default"
                 showLabel={false}
@@ -85,17 +112,29 @@ export function WithdrawVaultSelector({
 
         {/* Vault list */}
         {inUseVaults.map((vault, index) => {
+          const isEligible = vaultEligibility.get(vault.vaultId) === true;
           const isSelected = selectedVaultIds.includes(vault.vaultId);
+          const rowBg =
+            index % 2 === 0 ? "bg-secondary-highlight/50" : "bg-transparent";
+          const hoverBg = isEligible
+            ? index % 2 === 0
+              ? "hover:bg-secondary-highlight"
+              : "hover:bg-secondary-highlight/50"
+            : "";
+          const cursor = isEligible ? "cursor-pointer" : "cursor-not-allowed";
+          const opacity = isEligible ? "" : "opacity-50";
 
           return (
             <div
               key={vault.id}
-              className={`flex cursor-pointer items-center justify-between gap-4 px-0 py-4 transition-colors ${
-                index % 2 === 0
-                  ? "bg-secondary-highlight/50 hover:bg-secondary-highlight"
-                  : "bg-transparent hover:bg-secondary-highlight/50"
-              }`}
+              className={`flex items-center justify-between gap-4 px-0 py-4 transition-colors ${rowBg} ${hoverBg} ${cursor} ${opacity}`}
               onClick={() => toggleSelection(vault.vaultId)}
+              title={
+                isEligible
+                  ? undefined
+                  : "Withdrawing this vault would drop your health factor below 1.0."
+              }
+              aria-disabled={!isEligible}
             >
               <div className="flex flex-1 items-center gap-3 px-4">
                 <AvatarGroup size="medium">
@@ -123,6 +162,7 @@ export function WithdrawVaultSelector({
                   onChange={() => toggleSelection(vault.vaultId)}
                   variant="default"
                   showLabel={false}
+                  disabled={!isEligible}
                 />
               </div>
             </div>

--- a/services/vault/src/components/simple/WithdrawFlow/index.tsx
+++ b/services/vault/src/components/simple/WithdrawFlow/index.tsx
@@ -2,6 +2,11 @@ import { FullScreenDialog } from "@babylonlabs-io/core-ui";
 import { useCallback, useMemo, useState } from "react";
 
 import { useWithdrawCollateralTransaction } from "@/applications/aave/hooks/useWithdrawCollateralTransaction";
+import {
+  computeProjectedHealthFactor,
+  isVaultIndividuallyWithdrawable,
+  type PositionSnapshot,
+} from "@/applications/aave/utils";
 import { ProtocolParamsProvider } from "@/context/ProtocolParamsContext";
 import { useDialogStep } from "@/hooks/deposit/useDialogStep";
 import type { CollateralVaultEntry } from "@/types/collateral";
@@ -19,6 +24,10 @@ export interface WithdrawFlowProps {
   collateralVaults: CollateralVaultEntry[];
   collateralBtc: number;
   collateralValueUsd: number;
+  debtValueUsd: number;
+  liquidationThresholdBps: number;
+  /** User's current on-chain health factor (null when no debt). */
+  currentHealthFactor: number | null;
 }
 
 function WithdrawFlowContent({
@@ -27,6 +36,9 @@ function WithdrawFlowContent({
   collateralVaults,
   collateralBtc,
   collateralValueUsd,
+  debtValueUsd,
+  liquidationThresholdBps,
+  currentHealthFactor,
 }: WithdrawFlowProps) {
   const { step, goToReview, goToProgress, reset } = useWithdrawFlow();
   const { executeWithdraw, isProcessing } = useWithdrawCollateralTransaction();
@@ -34,16 +46,57 @@ function WithdrawFlowContent({
 
   const renderedStep = useDialogStep(open, step, reset);
 
-  // Compute amounts for only the selected vaults
-  const { selectedBtc, selectedUsd } = useMemo(() => {
+  const position: PositionSnapshot = useMemo(
+    () => ({
+      collateralBtc,
+      collateralValueUsd,
+      debtValueUsd,
+      liquidationThresholdBps,
+    }),
+    [collateralBtc, collateralValueUsd, debtValueUsd, liquidationThresholdBps],
+  );
+
+  // Eligibility map: which in-use vaults can be withdrawn individually
+  // without breaching HF 1.0. Used by the selector to grey unsafe vaults.
+  const vaultEligibility = useMemo(() => {
+    const map = new Map<string, boolean>();
+    for (const v of collateralVaults) {
+      if (!v.inUse) continue;
+      map.set(
+        v.vaultId,
+        isVaultIndividuallyWithdrawable(v.amountBtc, position),
+      );
+    }
+    return map;
+  }, [collateralVaults, position]);
+
+  // Aggregate amounts and projected HF for the current selection.
+  const { selectedBtc, selectedUsd, projectedHealthFactor } = useMemo(() => {
     const selected = collateralVaults.filter(
       (v) => v.inUse && selectedVaultIds.includes(v.vaultId),
     );
     const btc = selected.reduce((sum, v) => sum + v.amountBtc, 0);
     const usd =
       collateralBtc > 0 ? collateralValueUsd * (btc / collateralBtc) : 0;
-    return { selectedBtc: btc, selectedUsd: usd };
-  }, [collateralVaults, selectedVaultIds, collateralBtc, collateralValueUsd]);
+    const projectedHF = computeProjectedHealthFactor(
+      collateralValueUsd,
+      usd,
+      debtValueUsd,
+      liquidationThresholdBps,
+    );
+    return {
+      selectedBtc: btc,
+      selectedUsd: usd,
+      projectedHealthFactor: projectedHF,
+    };
+  }, [
+    collateralVaults,
+    selectedVaultIds,
+    collateralBtc,
+    collateralValueUsd,
+    debtValueUsd,
+    liquidationThresholdBps,
+  ]);
 
   const handleSelectVaults = useCallback(
     (vaultIds: string[]) => {
@@ -71,6 +124,7 @@ function WithdrawFlowContent({
           <div className="mx-auto w-full max-w-[520px]">
             <WithdrawVaultSelector
               vaults={collateralVaults}
+              vaultEligibility={vaultEligibility}
               onNext={handleSelectVaults}
             />
           </div>
@@ -80,6 +134,8 @@ function WithdrawFlowContent({
             <WithdrawReviewContent
               totalAmountBtc={selectedBtc}
               totalAmountUsd={selectedUsd}
+              currentHealthFactor={currentHealthFactor}
+              projectedHealthFactor={projectedHealthFactor}
               isProcessing={isProcessing}
               onConfirm={handleConfirm}
             />

--- a/services/vault/src/components/simple/WithdrawFlow/index.tsx
+++ b/services/vault/src/components/simple/WithdrawFlow/index.tsx
@@ -23,9 +23,8 @@ export interface WithdrawFlowProps {
   onClose: () => void;
   collateralVaults: CollateralVaultEntry[];
   collateralBtc: number;
+  /** Total collateral USD for display-only rendering of the selected amount. */
   collateralValueUsd: number;
-  debtValueUsd: number;
-  liquidationThresholdBps: number;
   /** User's current on-chain health factor (null when no debt). */
   currentHealthFactor: number | null;
 }
@@ -36,24 +35,21 @@ function WithdrawFlowContent({
   collateralVaults,
   collateralBtc,
   collateralValueUsd,
-  debtValueUsd,
-  liquidationThresholdBps,
   currentHealthFactor,
 }: WithdrawFlowProps) {
-  const { step, goToReview, goToProgress, reset } = useWithdrawFlow();
+  const { step, goToSelect, goToReview, goToProgress, reset } =
+    useWithdrawFlow();
   const { executeWithdraw, isProcessing } = useWithdrawCollateralTransaction();
+  // Selection state is owned here (not in the selector) so it survives
+  // back-navigation from the review step and can drive the selector's
+  // live projected-HF preview.
   const [selectedVaultIds, setSelectedVaultIds] = useState<string[]>([]);
 
   const renderedStep = useDialogStep(open, step, reset);
 
   const position: PositionSnapshot = useMemo(
-    () => ({
-      collateralBtc,
-      collateralValueUsd,
-      debtValueUsd,
-      liquidationThresholdBps,
-    }),
-    [collateralBtc, collateralValueUsd, debtValueUsd, liquidationThresholdBps],
+    () => ({ collateralBtc, currentHealthFactor }),
+    [collateralBtc, currentHealthFactor],
   );
 
   // Eligibility map: which in-use vaults can be withdrawn individually
@@ -70,19 +66,34 @@ function WithdrawFlowContent({
     return map;
   }, [collateralVaults, position]);
 
+  // Selection may contain IDs that vanished from the user's position
+  // between picks (position refreshes every 30s). Normalize before every
+  // downstream use so the projection, the selector's gating, and the
+  // transaction never see stale IDs.
+  const { effectiveSelectedVaultIds, effectiveSelectedVaults } = useMemo(() => {
+    const inUseVaults = collateralVaults.filter((v) => v.inUse);
+    const inUseIds = new Set(inUseVaults.map((v) => v.vaultId));
+    const ids = selectedVaultIds.filter((id) => inUseIds.has(id));
+    const idSet = new Set(ids);
+    const selected = inUseVaults.filter((v) => idSet.has(v.vaultId));
+    return {
+      effectiveSelectedVaultIds: ids,
+      effectiveSelectedVaults: selected,
+    };
+  }, [collateralVaults, selectedVaultIds]);
+
   // Aggregate amounts and projected HF for the current selection.
   const { selectedBtc, selectedUsd, projectedHealthFactor } = useMemo(() => {
-    const selected = collateralVaults.filter(
-      (v) => v.inUse && selectedVaultIds.includes(v.vaultId),
+    const btc = effectiveSelectedVaults.reduce(
+      (sum, v) => sum + v.amountBtc,
+      0,
     );
-    const btc = selected.reduce((sum, v) => sum + v.amountBtc, 0);
     const usd =
       collateralBtc > 0 ? collateralValueUsd * (btc / collateralBtc) : 0;
     const projectedHF = computeProjectedHealthFactor(
-      collateralValueUsd,
-      usd,
-      debtValueUsd,
-      liquidationThresholdBps,
+      currentHealthFactor,
+      collateralBtc,
+      btc,
     );
     return {
       selectedBtc: btc,
@@ -90,28 +101,22 @@ function WithdrawFlowContent({
       projectedHealthFactor: projectedHF,
     };
   }, [
-    collateralVaults,
-    selectedVaultIds,
+    effectiveSelectedVaults,
     collateralBtc,
     collateralValueUsd,
-    debtValueUsd,
-    liquidationThresholdBps,
+    currentHealthFactor,
   ]);
 
-  const handleSelectVaults = useCallback(
-    (vaultIds: string[]) => {
-      setSelectedVaultIds(vaultIds);
-      goToReview();
-    },
-    [goToReview],
-  );
+  const handleNext = useCallback(() => {
+    goToReview();
+  }, [goToReview]);
 
   const handleConfirm = useCallback(async () => {
-    const success = await executeWithdraw(selectedVaultIds);
+    const success = await executeWithdraw(effectiveSelectedVaultIds);
     if (success) {
       goToProgress();
     }
-  }, [executeWithdraw, selectedVaultIds, goToProgress]);
+  }, [executeWithdraw, effectiveSelectedVaultIds, goToProgress]);
 
   return (
     <FullScreenDialog
@@ -125,7 +130,11 @@ function WithdrawFlowContent({
             <WithdrawVaultSelector
               vaults={collateralVaults}
               vaultEligibility={vaultEligibility}
-              onNext={handleSelectVaults}
+              selectedVaultIds={effectiveSelectedVaultIds}
+              onSelectionChange={setSelectedVaultIds}
+              currentHealthFactor={currentHealthFactor}
+              projectedHealthFactor={projectedHealthFactor}
+              onNext={handleNext}
             />
           </div>
         )}
@@ -138,6 +147,7 @@ function WithdrawFlowContent({
               projectedHealthFactor={projectedHealthFactor}
               isProcessing={isProcessing}
               onConfirm={handleConfirm}
+              onEditSelection={goToSelect}
             />
           </div>
         )}

--- a/services/vault/src/components/simple/WithdrawFlow/useWithdrawFlow.ts
+++ b/services/vault/src/components/simple/WithdrawFlow/useWithdrawFlow.ts
@@ -9,9 +9,10 @@ export enum WithdrawStep {
 export function useWithdrawFlow() {
   const [step, setStep] = useState(WithdrawStep.SELECT);
 
+  const goToSelect = useCallback(() => setStep(WithdrawStep.SELECT), []);
   const goToReview = useCallback(() => setStep(WithdrawStep.REVIEW), []);
   const goToProgress = useCallback(() => setStep(WithdrawStep.PROGRESS), []);
-  const reset = useCallback(() => setStep(WithdrawStep.SELECT), []);
+  const reset = goToSelect;
 
-  return { step, goToReview, goToProgress, reset };
+  return { step, goToSelect, goToReview, goToProgress, reset };
 }

--- a/services/vault/src/hooks/useDashboardState.ts
+++ b/services/vault/src/hooks/useDashboardState.ts
@@ -6,6 +6,7 @@
 
 import { useMemo } from "react";
 
+import { useAaveConfig } from "@/applications/aave/context";
 import {
   useAaveBorrowedAssets,
   useAaveUserPosition,
@@ -28,6 +29,9 @@ export function useDashboardState(connectedAddress: string | undefined) {
     healthFactorStatus,
     isLoading,
   } = useAaveUserPosition(connectedAddress);
+
+  const { vbtcReserve } = useAaveConfig();
+  const liquidationThresholdBps = vbtcReserve?.reserve.collateralFactor ?? 0;
 
   const { borrowedAssets, hasLoans } = useAaveBorrowedAssets({
     position,
@@ -64,6 +68,7 @@ export function useDashboardState(connectedAddress: string | undefined) {
     collateralBtc,
     collateralValueUsd,
     debtValueUsd,
+    liquidationThresholdBps,
     healthFactor,
     healthFactorStatus,
     borrowedAssets,

--- a/services/vault/src/hooks/useDashboardState.ts
+++ b/services/vault/src/hooks/useDashboardState.ts
@@ -6,7 +6,6 @@
 
 import { useMemo } from "react";
 
-import { useAaveConfig } from "@/applications/aave/context";
 import {
   useAaveBorrowedAssets,
   useAaveUserPosition,
@@ -29,9 +28,6 @@ export function useDashboardState(connectedAddress: string | undefined) {
     healthFactorStatus,
     isLoading,
   } = useAaveUserPosition(connectedAddress);
-
-  const { vbtcReserve } = useAaveConfig();
-  const liquidationThresholdBps = vbtcReserve?.reserve.collateralFactor ?? 0;
 
   const { borrowedAssets, hasLoans } = useAaveBorrowedAssets({
     position,
@@ -68,7 +64,6 @@ export function useDashboardState(connectedAddress: string | undefined) {
     collateralBtc,
     collateralValueUsd,
     debtValueUsd,
-    liquidationThresholdBps,
     healthFactor,
     healthFactorStatus,
     borrowedAssets,


### PR DESCRIPTION
- Enable partial vault withdrawal in the dApp. The Aave contract already
  supports `withdrawCollaterals(bytes32[])` with on-chain HF enforcement;
  the FE was incorrectly gating the Withdraw button on any debt.
- Grey out vaults that can't be individually released (HF < 1.0 after
  removal); let users pick any safe subset.
- Review step shows `current → projected` health factor with block
  (HF < 1.0) and at-risk (HF < 1.1) states.