### PR TITLE
feat(packages): add activation uniqueness error mappings

### DIFF
--- a/packages/babylon-ts-sdk/src/tbv/core/contracts/errors.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/contracts/errors.ts
@@ -60,6 +60,12 @@ export const CONTRACT_ERRORS: Record<string, string> = {
   "0x979f4518":
     "Invalid pegin fee: The ETH fee sent does not match the required amount. " +
     "This may indicate a fee rate change during the transaction.",
+  // PrePeginOutputAlreadyUsed()
+  "0x5fad9694":
+    "This pre-pegin output has already been used to activate another vault.",
+  // PeginTransactionAlreadyUsed()
+  "0x7ed061c9":
+    "This pegin transaction has already been used to activate another vault.",
 };
 
 /**

--- a/services/vault/src/utils/errors/errorMessages.ts
+++ b/services/vault/src/utils/errors/errorMessages.ts
@@ -48,6 +48,10 @@ export const CONTRACT_ERROR_MESSAGES: Record<string, string> = {
   InclusionProofVerificationFailed:
     "Bitcoin inclusion proof verification failed.",
   BitcoinTransactionParsingFailed: "Failed to parse Bitcoin transaction.",
+  PrePeginOutputAlreadyUsed:
+    "This pre-pegin output has already been used to activate another vault.",
+  PeginTransactionAlreadyUsed:
+    "This pegin transaction has already been used to activate another vault.",
 
   // ============================================================================
   // Vault Provider errors


### PR DESCRIPTION
- Add `PrePeginOutputAlreadyUsed` and `PeginTransactionAlreadyUsed` error mappings to both the service error messages and SDK contract error selectors