### PR TITLE
fix(vault): aave borrow, chainlink oracle prices

### DIFF
--- a/services/vault/src/applications/aave/components/Detail/hooks/__tests__/useAaveReserveDetail.test.tsx
+++ b/services/vault/src/applications/aave/components/Detail/hooks/__tests__/useAaveReserveDetail.test.tsx
@@ -44,7 +44,7 @@ vi.mock("@babylonlabs-io/config", () => ({
 const mockGetBTCNetwork = vi.fn(() => 1); // Default: Network.SIGNET
 
 vi.mock("@/config", () => ({
-  getBTCNetwork: (...args: unknown[]) => mockGetBTCNetwork(...args),
+  getBTCNetwork: () => mockGetBTCNetwork(),
   getNetworkConfigBTC: vi.fn(() => ({
     network: "signet",
     mempoolApiUrl: "https://mempool.space/signet/api",
@@ -110,7 +110,7 @@ vi.mock("../../../../context", () => ({
 }));
 
 // Mock useAaveUserPosition
-const mockUseAaveUserPosition = vi.fn(() => ({
+const mockUseAaveUserPosition = vi.fn<(addr?: string) => unknown>(() => ({
   position: null,
   collateralValueUsd: 15000,
   debtValueUsd: 0,
@@ -123,15 +123,15 @@ const mockUseAaveUserPosition = vi.fn(() => ({
 }));
 
 // Mock useVaultSplitParams
-const mockUseVaultSplitParams = vi.fn(() => ({
+const mockUseVaultSplitParams = vi.fn<(addr?: string) => unknown>(() => ({
   params: { THF: 1.1, CF: 0.75, LB: 1.05 },
   isLoading: false,
   error: null,
 }));
 
 vi.mock("../../../../hooks", () => ({
-  useAaveUserPosition: (...args: unknown[]) => mockUseAaveUserPosition(...args),
-  useVaultSplitParams: (...args: unknown[]) => mockUseVaultSplitParams(...args),
+  useAaveUserPosition: (addr?: string) => mockUseAaveUserPosition(addr),
+  useVaultSplitParams: (addr?: string) => mockUseVaultSplitParams(addr),
 }));
 
 // Import after mocks

--- a/services/vault/src/applications/aave/components/Detail/hooks/__tests__/useAaveReserveDetail.test.tsx
+++ b/services/vault/src/applications/aave/components/Detail/hooks/__tests__/useAaveReserveDetail.test.tsx
@@ -69,7 +69,7 @@ const mockUsePrices = vi.fn(() => ({
   prices: {} as Record<string, number>,
   metadata: {},
   isLoading: false,
-  error: null,
+  error: null as Error | null,
   hasStalePrices: false,
   hasPriceFetchError: false,
 }));
@@ -423,5 +423,51 @@ describe("useAaveReserveDetail", () => {
     );
 
     expect(mockUseVaultSplitParams).toHaveBeenCalledWith("0xUserAddress");
+  });
+
+  // --- Error propagation ---
+
+  it("propagates error from usePrices", () => {
+    const pricesError = new Error("Chainlink RPC failure");
+    mockUsePrices.mockReturnValue({
+      prices: {},
+      metadata: {},
+      isLoading: false,
+      error: pricesError,
+      hasStalePrices: false,
+      hasPriceFetchError: true,
+    });
+
+    const { result } = renderHook(
+      () => useAaveReserveDetail({ reserveId: "USDC", address: "0xUser" }),
+      { wrapper },
+    );
+
+    expect(result.current.error).toBe(pricesError);
+  });
+
+  it("propagates error from useVaultSplitParams", () => {
+    const splitError = new Error("Contract RPC failure");
+    mockUseVaultSplitParams.mockReturnValue({
+      params: null,
+      isLoading: false,
+      error: splitError,
+    });
+
+    const { result } = renderHook(
+      () => useAaveReserveDetail({ reserveId: "USDC", address: "0xUser" }),
+      { wrapper },
+    );
+
+    expect(result.current.error).toBe(splitError);
+  });
+
+  it("returns null error when no hooks have errors", () => {
+    const { result } = renderHook(
+      () => useAaveReserveDetail({ reserveId: "USDC", address: "0xUser" }),
+      { wrapper },
+    );
+
+    expect(result.current.error).toBeNull();
   });
 });

--- a/services/vault/src/applications/aave/components/Detail/hooks/__tests__/useAaveReserveDetail.test.tsx
+++ b/services/vault/src/applications/aave/components/Detail/hooks/__tests__/useAaveReserveDetail.test.tsx
@@ -152,6 +152,9 @@ describe("useAaveReserveDetail", () => {
     });
     vi.clearAllMocks();
 
+    // Reset network to signet (default for tests)
+    mockGetBTCNetwork.mockReturnValue(1); // Network.SIGNET
+
     // Reset to default mock values
     mockUsePrices.mockReturnValue({
       prices: {},
@@ -236,6 +239,76 @@ describe("useAaveReserveDetail", () => {
     );
 
     expect(result.current.tokenPriceUsd).toBeNull();
+  });
+
+  it("returns null when Chainlink price is stale on mainnet", () => {
+    mockGetBTCNetwork.mockReturnValue(0); // Network.MAINNET
+
+    mockUsePrices.mockReturnValue({
+      prices: { USDC: 0.9998 },
+      metadata: {
+        USDC: { isStale: true, ageSeconds: 7200, fetchFailed: false },
+      },
+      isLoading: false,
+      error: null,
+      hasStalePrices: true,
+      hasPriceFetchError: false,
+    });
+
+    const { result } = renderHook(
+      () => useAaveReserveDetail({ reserveId: "USDC", address: "0xUser" }),
+      { wrapper },
+    );
+
+    expect(result.current.tokenPriceUsd).toBeNull();
+  });
+
+  it("returns null when Chainlink fetch failed on mainnet", () => {
+    mockGetBTCNetwork.mockReturnValue(0); // Network.MAINNET
+
+    mockUsePrices.mockReturnValue({
+      prices: { USDC: 1.0 },
+      metadata: {
+        USDC: {
+          isStale: false,
+          ageSeconds: 0,
+          fetchFailed: true,
+          error: "RPC timeout",
+        },
+      },
+      isLoading: false,
+      error: null,
+      hasStalePrices: false,
+      hasPriceFetchError: true,
+    });
+
+    const { result } = renderHook(
+      () => useAaveReserveDetail({ reserveId: "USDC", address: "0xUser" }),
+      { wrapper },
+    );
+
+    expect(result.current.tokenPriceUsd).toBeNull();
+  });
+
+  it("falls back to $1 for stale stablecoin price on testnet", () => {
+    // getBTCNetwork returns signet (1) by default
+    mockUsePrices.mockReturnValue({
+      prices: { USDC: 0.9998 },
+      metadata: {
+        USDC: { isStale: true, ageSeconds: 7200, fetchFailed: false },
+      },
+      isLoading: false,
+      error: null,
+      hasStalePrices: true,
+      hasPriceFetchError: false,
+    });
+
+    const { result } = renderHook(
+      () => useAaveReserveDetail({ reserveId: "USDC", address: "0xUser" }),
+      { wrapper },
+    );
+
+    expect(result.current.tokenPriceUsd).toBe(1.0);
   });
 
   it("returns null for unknown token without Chainlink price", () => {

--- a/services/vault/src/applications/aave/components/Detail/hooks/__tests__/useAaveReserveDetail.test.tsx
+++ b/services/vault/src/applications/aave/components/Detail/hooks/__tests__/useAaveReserveDetail.test.tsx
@@ -1,0 +1,427 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import type { Address } from "viem";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- Module mocks ---
+
+vi.mock("@/config/env", () => ({
+  ENV: {
+    BTC_VAULT_REGISTRY: "0x1234567890123456789012345678901234567890",
+    AAVE_ADAPTER: "0x1234567890123456789012345678901234567890",
+    GRAPHQL_ENDPOINT: "https://test.example.com/graphql",
+  },
+}));
+
+vi.mock("@babylonlabs-io/wallet-connector", () => ({
+  Network: {
+    MAINNET: 0,
+    SIGNET: 1,
+    TESTNET: 2,
+  },
+}));
+
+vi.mock("@babylonlabs-io/config", () => ({
+  getNetworkConfigETH: vi.fn(() => ({
+    chainId: 11155111,
+    name: "sepolia",
+  })),
+  getNetworkConfigBTC: vi.fn(() => ({
+    network: "signet",
+    mempoolApiUrl: "https://mempool.space/signet/api",
+    icon: "btc-icon",
+    name: "sBTC",
+    coinSymbol: "sBTC",
+  })),
+  getETHChain: vi.fn(() => ({
+    id: 11155111,
+    name: "Sepolia",
+  })),
+  getBTCNetwork: vi.fn(() => 1), // Network.SIGNET = 1
+}));
+
+const mockGetBTCNetwork = vi.fn(() => 1); // Default: Network.SIGNET
+
+vi.mock("@/config", () => ({
+  getBTCNetwork: (...args: unknown[]) => mockGetBTCNetwork(...args),
+  getNetworkConfigBTC: vi.fn(() => ({
+    network: "signet",
+    mempoolApiUrl: "https://mempool.space/signet/api",
+    icon: "btc-icon",
+    name: "sBTC",
+    coinSymbol: "sBTC",
+  })),
+}));
+
+vi.mock("@/clients/eth-contract/client", () => ({
+  ethClient: {
+    getPublicClient: vi.fn(() => ({})),
+  },
+}));
+
+vi.mock("@/services/token/tokenService", () => ({
+  getTokenByAddress: vi.fn(() => ({ icon: "usdc-icon" })),
+}));
+
+// Mock usePrices — returns Chainlink oracle prices
+const mockUsePrices = vi.fn(() => ({
+  prices: {} as Record<string, number>,
+  metadata: {},
+  isLoading: false,
+  error: null,
+  hasStalePrices: false,
+  hasPriceFetchError: false,
+}));
+
+vi.mock("@/hooks/usePrices", () => ({
+  usePrices: () => mockUsePrices(),
+}));
+
+// Mock useAaveConfig
+const mockUseAaveConfig = vi.fn(() => ({
+  config: {
+    btcVaultCoreSpokeAddress: "0xSpokeAddress",
+    btcVaultCoreVbtcReserveId: 1n,
+  },
+  vbtcReserve: {
+    reserveId: 1n,
+    reserve: { collateralFactor: 8000 },
+    token: { symbol: "vBTC", name: "vBTC", decimals: 8, address: "0xvBTC" },
+  },
+  borrowableReserves: [
+    {
+      reserveId: 2n,
+      reserve: { collateralFactor: 0 },
+      token: {
+        symbol: "USDC",
+        name: "USD Coin",
+        decimals: 6,
+        address: "0xUSDC" as Address,
+      },
+    },
+  ],
+  isLoading: false,
+  error: null,
+}));
+
+vi.mock("../../../../context", () => ({
+  useAaveConfig: () => mockUseAaveConfig(),
+}));
+
+// Mock useAaveUserPosition
+const mockUseAaveUserPosition = vi.fn(() => ({
+  position: null,
+  collateralValueUsd: 15000,
+  debtValueUsd: 0,
+  healthFactor: null,
+  healthFactorStatus: "healthy",
+  isPositionDataStale: false,
+  isLoading: false,
+  error: null,
+  refetch: vi.fn(),
+}));
+
+// Mock useVaultSplitParams
+const mockUseVaultSplitParams = vi.fn(() => ({
+  params: { THF: 1.1, CF: 0.75, LB: 1.05 },
+  isLoading: false,
+  error: null,
+}));
+
+vi.mock("../../../../hooks", () => ({
+  useAaveUserPosition: (...args: unknown[]) => mockUseAaveUserPosition(...args),
+  useVaultSplitParams: (...args: unknown[]) => mockUseVaultSplitParams(...args),
+}));
+
+// Import after mocks
+import { useAaveReserveDetail } from "../useAaveReserveDetail";
+
+describe("useAaveReserveDetail", () => {
+  let queryClient: QueryClient;
+
+  function wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  }
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    vi.clearAllMocks();
+
+    // Reset to default mock values
+    mockUsePrices.mockReturnValue({
+      prices: {},
+      metadata: {},
+      isLoading: false,
+      error: null,
+      hasStalePrices: false,
+      hasPriceFetchError: false,
+    });
+    mockUseVaultSplitParams.mockReturnValue({
+      params: { THF: 1.1, CF: 0.75, LB: 1.05 },
+      isLoading: false,
+      error: null,
+    });
+    mockUseAaveUserPosition.mockReturnValue({
+      position: null,
+      collateralValueUsd: 15000,
+      debtValueUsd: 0,
+      healthFactor: null,
+      healthFactorStatus: "healthy",
+      isPositionDataStale: false,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+  });
+
+  // --- Token price from Chainlink (#131 / #1391) ---
+
+  it("returns Chainlink price when available", () => {
+    mockUsePrices.mockReturnValue({
+      prices: { USDC: 0.9998 },
+      metadata: {},
+      isLoading: false,
+      error: null,
+      hasStalePrices: false,
+      hasPriceFetchError: false,
+    });
+
+    const { result } = renderHook(
+      () => useAaveReserveDetail({ reserveId: "USDC", address: "0xUser" }),
+      { wrapper },
+    );
+
+    expect(result.current.tokenPriceUsd).toBe(0.9998);
+  });
+
+  it("falls back to $1 for known stablecoin on testnet when Chainlink feed is absent", async () => {
+    // getBTCNetwork returns "signet" by default in our mock
+    mockUsePrices.mockReturnValue({
+      prices: {},
+      metadata: {},
+      isLoading: false,
+      error: null,
+      hasStalePrices: false,
+      hasPriceFetchError: false,
+    });
+
+    const { result } = renderHook(
+      () => useAaveReserveDetail({ reserveId: "USDC", address: "0xUser" }),
+      { wrapper },
+    );
+
+    expect(result.current.tokenPriceUsd).toBe(1.0);
+  });
+
+  it("returns null for stablecoin on mainnet when Chainlink price is missing", () => {
+    mockGetBTCNetwork.mockReturnValue(0); // Network.MAINNET = 0
+
+    mockUsePrices.mockReturnValue({
+      prices: {},
+      metadata: {},
+      isLoading: false,
+      error: null,
+      hasStalePrices: false,
+      hasPriceFetchError: false,
+    });
+
+    const { result } = renderHook(
+      () => useAaveReserveDetail({ reserveId: "USDC", address: "0xUser" }),
+      { wrapper },
+    );
+
+    expect(result.current.tokenPriceUsd).toBeNull();
+  });
+
+  it("returns null for unknown token without Chainlink price", () => {
+    mockUseAaveConfig.mockReturnValue({
+      config: {
+        btcVaultCoreSpokeAddress: "0xSpokeAddress",
+        btcVaultCoreVbtcReserveId: 1n,
+      },
+      vbtcReserve: {
+        reserveId: 1n,
+        reserve: { collateralFactor: 8000 },
+        token: {
+          symbol: "vBTC",
+          name: "vBTC",
+          decimals: 8,
+          address: "0xvBTC",
+        },
+      },
+      borrowableReserves: [
+        {
+          reserveId: 3n,
+          reserve: { collateralFactor: 0 },
+          token: {
+            symbol: "WBTC",
+            name: "Wrapped Bitcoin",
+            decimals: 8,
+            address: "0xWBTC" as Address,
+          },
+        },
+      ],
+      isLoading: false,
+      error: null,
+    });
+    mockUsePrices.mockReturnValue({
+      prices: {},
+      metadata: {},
+      isLoading: false,
+      error: null,
+      hasStalePrices: false,
+      hasPriceFetchError: false,
+    });
+
+    const { result } = renderHook(
+      () => useAaveReserveDetail({ reserveId: "WBTC", address: "0xUser" }),
+      { wrapper },
+    );
+
+    expect(result.current.tokenPriceUsd).toBeNull();
+  });
+
+  it("returns null tokenPriceUsd when no reserve is selected", () => {
+    const { result } = renderHook(
+      () => useAaveReserveDetail({ reserveId: undefined, address: "0xUser" }),
+      { wrapper },
+    );
+
+    expect(result.current.tokenPriceUsd).toBeNull();
+    expect(result.current.selectedReserve).toBeNull();
+  });
+
+  // --- Position-specific collateral factor (#147) ---
+
+  it("uses CF from useVaultSplitParams for liquidationThresholdBps", () => {
+    mockUseVaultSplitParams.mockReturnValue({
+      params: { THF: 1.1, CF: 0.75, LB: 1.05 },
+      isLoading: false,
+      error: null,
+    });
+
+    const { result } = renderHook(
+      () => useAaveReserveDetail({ reserveId: "USDC", address: "0xUser" }),
+      { wrapper },
+    );
+
+    expect(result.current.liquidationThresholdBps).toBe(7500);
+  });
+
+  it("returns 0 for liquidationThresholdBps when splitParams is null", () => {
+    mockUseVaultSplitParams.mockReturnValue({
+      params: null,
+      isLoading: false,
+      error: null,
+    });
+
+    const { result } = renderHook(
+      () => useAaveReserveDetail({ reserveId: "USDC", address: "0xUser" }),
+      { wrapper },
+    );
+
+    expect(result.current.liquidationThresholdBps).toBe(0);
+  });
+
+  it("handles CF values that could produce floating-point imprecision", () => {
+    // 0.8333 * 10000 = 8333.0 in most cases, but test the rounding
+    mockUseVaultSplitParams.mockReturnValue({
+      params: { THF: 1.1, CF: 0.8333, LB: 1.05 },
+      isLoading: false,
+      error: null,
+    });
+
+    const { result } = renderHook(
+      () => useAaveReserveDetail({ reserveId: "USDC", address: "0xUser" }),
+      { wrapper },
+    );
+
+    expect(result.current.liquidationThresholdBps).toBe(8333);
+  });
+
+  // --- Loading state ---
+
+  it("includes prices loading in isLoading", () => {
+    mockUsePrices.mockReturnValue({
+      prices: {},
+      metadata: {},
+      isLoading: true,
+      error: null,
+      hasStalePrices: false,
+      hasPriceFetchError: false,
+    });
+
+    const { result } = renderHook(
+      () => useAaveReserveDetail({ reserveId: "USDC", address: "0xUser" }),
+      { wrapper },
+    );
+
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it("includes splitParams loading in isLoading", () => {
+    mockUseVaultSplitParams.mockReturnValue({
+      params: null,
+      isLoading: true,
+      error: null,
+    });
+
+    const { result } = renderHook(
+      () => useAaveReserveDetail({ reserveId: "USDC", address: "0xUser" }),
+      { wrapper },
+    );
+
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it("is not loading when all sources have resolved", () => {
+    mockUsePrices.mockReturnValue({
+      prices: { USDC: 1.0 },
+      metadata: {},
+      isLoading: false,
+      error: null,
+      hasStalePrices: false,
+      hasPriceFetchError: false,
+    });
+    mockUseVaultSplitParams.mockReturnValue({
+      params: { THF: 1.1, CF: 0.75, LB: 1.05 },
+      isLoading: false,
+      error: null,
+    });
+    mockUseAaveUserPosition.mockReturnValue({
+      position: null,
+      collateralValueUsd: 15000,
+      debtValueUsd: 0,
+      healthFactor: null,
+      healthFactorStatus: "healthy",
+      isPositionDataStale: false,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    const { result } = renderHook(
+      () => useAaveReserveDetail({ reserveId: "USDC", address: "0xUser" }),
+      { wrapper },
+    );
+
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  // --- Integration: passes address to useVaultSplitParams ---
+
+  it("passes user address to useVaultSplitParams for position-specific CF lookup", () => {
+    renderHook(
+      () =>
+        useAaveReserveDetail({ reserveId: "USDC", address: "0xUserAddress" }),
+      { wrapper },
+    );
+
+    expect(mockUseVaultSplitParams).toHaveBeenCalledWith("0xUserAddress");
+  });
+});

--- a/services/vault/src/applications/aave/components/Detail/hooks/useAaveReserveDetail.ts
+++ b/services/vault/src/applications/aave/components/Detail/hooks/useAaveReserveDetail.ts
@@ -3,22 +3,26 @@
  *
  * Fetches and combines:
  * - Reserve config from Aave
- * - User position data
+ * - User position data (with position-specific collateral factor)
+ * - Chainlink oracle prices for borrow token
  * - Asset metadata for display
  */
 
+import { Network } from "@babylonlabs-io/wallet-connector";
 import { useMemo } from "react";
 import { formatUnits } from "viem";
 
-import { logger } from "@/infrastructure";
+import { getBTCNetwork } from "@/config";
+import { usePrices } from "@/hooks/usePrices";
 import { getTokenByAddress } from "@/services/token/tokenService";
 
 import {
+  BPS_SCALE,
   KNOWN_STABLECOIN_SYMBOLS,
   STABLECOIN_FALLBACK_PRICE_USD,
 } from "../../../constants";
 import { useAaveConfig } from "../../../context";
-import { useAaveUserPosition } from "../../../hooks";
+import { useAaveUserPosition, useVaultSplitParams } from "../../../hooks";
 import type { AaveReserveConfig } from "../../../services/fetchConfig";
 import type { Asset } from "../../../types";
 
@@ -95,6 +99,13 @@ export function useAaveReserveDetail({
     isLoading: positionLoading,
   } = useAaveUserPosition(address);
 
+  // Chainlink oracle prices (cached app-wide via React Query)
+  const { prices: chainlinkPrices, isLoading: pricesLoading } = usePrices();
+
+  // Position-specific collateral factor from contract
+  const { params: splitParams, isLoading: splitParamsLoading } =
+    useVaultSplitParams(address);
+
   // Calculate debt amount for selected reserve in token units
   const currentDebtAmount = useMemo(() => {
     if (!selectedReserve || !position?.debtPositions) {
@@ -112,72 +123,42 @@ export function useAaveReserveDetail({
     );
   }, [selectedReserve, position]);
 
-  // Get liquidation threshold from vBTC reserve
-  const liquidationThresholdBps = vbtcReserve?.reserve.collateralFactor ?? 0;
+  // Position-specific liquidation threshold from contract.
+  // Uses the user's stored dynamicConfigKey (not the indexer's reserve config)
+  // so it reflects the CF that the contract will actually use for liquidation.
+  const liquidationThresholdBps = splitParams
+    ? Math.round(splitParams.CF * BPS_SCALE)
+    : 0;
 
-  // Derive token price. Returns null when the price cannot be determined,
-  // in which case parent components render a fallback instead of LoanProvider.
-  //
-  // Current strategy: derive from debt ratio when debt exists, otherwise use
-  // the $1 stablecoin fallback for first-borrow of known stablecoins.
-  //
-  // The debt-ratio derivation assumes exactly one borrowable reserve, because
-  // debtValueUsd is the user's total debt across all reserves. A runtime
-  // assertion below fails loudly if that assumption is ever violated.
-  //
-  // TODO: Migrate to Chainlink price feeds via
-  // `services/vault/src/clients/eth-contract/chainlink/query.ts` once feeds
-  // are available for borrowable reserves on our target network. That would
-  // remove the single-reserve assumption and the stablecoin fallback.
+  // Look up token price from Chainlink oracle. On testnet where stablecoin
+  // feeds are unavailable, fall back to $1 for known stablecoins only.
   const tokenPriceUsd = useMemo((): number | null => {
     if (!selectedReserve) return null;
 
-    if (currentDebtAmount > 0 && debtValueUsd > 0) {
-      if (borrowableReserves.length !== 1) {
-        logger.error(
-          new Error(
-            "tokenPriceUsd debt-ratio derivation is only valid for a single borrowable reserve",
-          ),
-          {
-            data: {
-              context: "useAaveReserveDetail.tokenPriceUsd",
-              borrowableReserveCount: borrowableReserves.length,
-              selectedReserveSymbol: selectedReserve.token.symbol,
-            },
-          },
-        );
-        return null;
-      }
-      return debtValueUsd / currentDebtAmount;
+    const symbol = selectedReserve.token.symbol.toUpperCase();
+    const price = chainlinkPrices[symbol];
+
+    if (price != null && price > 0) {
+      return price;
     }
 
-    // First-time borrow: no debt to derive price from.
-    // Only safe for stablecoins — log and return null for unknown tokens.
-    const symbol = selectedReserve.token.symbol.toUpperCase();
+    // Testnet/signet: Chainlink doesn't publish stablecoin feeds on Sepolia.
+    // $1 is correct for mock-pegged test tokens. On mainnet a missing price
+    // is a real error — return null so the UI blocks the borrow flow.
     const isKnownStablecoin = (
       KNOWN_STABLECOIN_SYMBOLS as readonly string[]
     ).includes(symbol);
 
-    if (!isKnownStablecoin) {
-      logger.error(
-        new Error(
-          `Cannot derive token price for ${symbol}: no existing debt and token is not a known stablecoin`,
-        ),
-        {
-          data: {
-            context: "useAaveReserveDetail.tokenPriceUsd",
-            symbol,
-          },
-        },
-      );
-      return null;
+    if (getBTCNetwork() !== Network.MAINNET && isKnownStablecoin) {
+      return STABLECOIN_FALLBACK_PRICE_USD;
     }
 
-    return STABLECOIN_FALLBACK_PRICE_USD;
-  }, [currentDebtAmount, debtValueUsd, selectedReserve, borrowableReserves]);
+    return null;
+  }, [selectedReserve, chainlinkPrices]);
 
   return {
-    isLoading: configLoading || positionLoading,
+    isLoading:
+      configLoading || positionLoading || pricesLoading || splitParamsLoading,
     selectedReserve,
     assetConfig,
     vbtcReserve,

--- a/services/vault/src/applications/aave/components/Detail/hooks/useAaveReserveDetail.ts
+++ b/services/vault/src/applications/aave/components/Detail/hooks/useAaveReserveDetail.ts
@@ -56,6 +56,8 @@ export interface UseAaveReserveDetailResult {
   healthFactor: number | null;
   /** Price of the selected borrow token in USD (null if unavailable) */
   tokenPriceUsd: number | null;
+  /** Error from price or split params fetch (null if no error) */
+  error: Error | null;
 }
 
 export function useAaveReserveDetail({
@@ -100,11 +102,18 @@ export function useAaveReserveDetail({
   } = useAaveUserPosition(address);
 
   // Chainlink oracle prices (cached app-wide via React Query)
-  const { prices: chainlinkPrices, isLoading: pricesLoading } = usePrices();
+  const {
+    prices: chainlinkPrices,
+    isLoading: pricesLoading,
+    error: pricesError,
+  } = usePrices();
 
   // Position-specific collateral factor from contract
-  const { params: splitParams, isLoading: splitParamsLoading } =
-    useVaultSplitParams(address);
+  const {
+    params: splitParams,
+    isLoading: splitParamsLoading,
+    error: splitParamsError,
+  } = useVaultSplitParams(address);
 
   // Calculate debt amount for selected reserve in token units
   const currentDebtAmount = useMemo(() => {
@@ -169,5 +178,6 @@ export function useAaveReserveDetail({
     totalDebtValueUsd: debtValueUsd,
     healthFactor,
     tokenPriceUsd,
+    error: pricesError ?? splitParamsError ?? null,
   };
 }

--- a/services/vault/src/applications/aave/components/Detail/hooks/useAaveReserveDetail.ts
+++ b/services/vault/src/applications/aave/components/Detail/hooks/useAaveReserveDetail.ts
@@ -104,6 +104,7 @@ export function useAaveReserveDetail({
   // Chainlink oracle prices (cached app-wide via React Query)
   const {
     prices: chainlinkPrices,
+    metadata: priceMetadata,
     isLoading: pricesLoading,
     error: pricesError,
   } = usePrices();
@@ -146,8 +147,14 @@ export function useAaveReserveDetail({
 
     const symbol = selectedReserve.token.symbol.toUpperCase();
     const price = chainlinkPrices[symbol];
+    const metadata = priceMetadata[symbol];
 
-    if (price != null && price > 0) {
+    // Reject stale or failed prices — a stale feed during a depeg event
+    // would produce an inflated max-borrow / HF
+    // Treat stale/failed the same as missing.
+    const isPriceReliable = !metadata?.isStale && !metadata?.fetchFailed;
+
+    if (price != null && price > 0 && isPriceReliable) {
       return price;
     }
 
@@ -163,7 +170,7 @@ export function useAaveReserveDetail({
     }
 
     return null;
-  }, [selectedReserve, chainlinkPrices]);
+  }, [selectedReserve, chainlinkPrices, priceMetadata]);
 
   return {
     isLoading:

--- a/services/vault/src/applications/aave/components/Detail/index.tsx
+++ b/services/vault/src/applications/aave/components/Detail/index.tsx
@@ -5,7 +5,7 @@
  * Reserve is selected from the overview page and passed via URL param.
  */
 
-import { Container } from "@babylonlabs-io/core-ui";
+import { Container, Text } from "@babylonlabs-io/core-ui";
 import { useNavigate, useParams, useSearchParams } from "react-router";
 
 import { BackButton, EmptyState } from "@/components/shared";
@@ -48,6 +48,7 @@ export function AaveReserveDetail() {
     totalDebtValueUsd,
     healthFactor,
     tokenPriceUsd,
+    error,
   } = useAaveReserveDetail({ reserveId, address });
 
   // Modal state management
@@ -107,13 +108,8 @@ export function AaveReserveDetail() {
     );
   }
 
-  // Reserve not found or price unavailable
-  if (
-    !selectedReserve ||
-    !assetConfig ||
-    !vbtcReserve ||
-    tokenPriceUsd == null
-  ) {
+  // Reserve not found
+  if (!selectedReserve || !assetConfig || !vbtcReserve) {
     return (
       <Container className="pb-6">
         <div className="space-y-6">
@@ -146,6 +142,12 @@ export function AaveReserveDetail() {
       <Container className="pb-6">
         <div className="space-y-6">
           <BackButton label="Home" onClick={handleBack} />
+          {error && (
+            <Text variant="body2" className="text-center text-warning-main">
+              Some data could not be loaded. Borrow functionality may be
+              limited.
+            </Text>
+          )}
           <LoanCard defaultTab={defaultTab} />
         </div>
       </Container>

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/__tests__/calculateMaxBorrowTokens.test.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/__tests__/calculateMaxBorrowTokens.test.ts
@@ -86,6 +86,28 @@ describe("calculateMaxBorrowTokens", () => {
     expect(result * 100).toBe(Math.floor(result * 100));
   });
 
+  it("returns zero when tokenPriceUsd is null", () => {
+    const result = calculateMaxBorrowTokens({
+      collateralValueUsd: 10000,
+      currentDebtUsd: 0,
+      liquidationThresholdBps: 8000,
+      tokenPriceUsd: null,
+    });
+
+    expect(result).toBe(0);
+  });
+
+  it("returns zero when tokenPriceUsd is zero", () => {
+    const result = calculateMaxBorrowTokens({
+      collateralValueUsd: 10000,
+      currentDebtUsd: 0,
+      liquidationThresholdBps: 8000,
+      tokenPriceUsd: 0,
+    });
+
+    expect(result).toBe(0);
+  });
+
   it("respects a different liquidation threshold (7500 BPS)", () => {
     // $10,000 collateral, 75% LT, no debt, $1 token
     const result = calculateMaxBorrowTokens({

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/__tests__/useBorrowMetrics.test.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/__tests__/useBorrowMetrics.test.ts
@@ -69,6 +69,19 @@ describe("useBorrowMetrics", () => {
     expect(result.borrowRatio).toBeDefined();
   });
 
+  it("shows current values when tokenPriceUsd is null", () => {
+    const result = useBorrowMetrics({
+      ...baseProps,
+      borrowAmount: 100,
+      tokenPriceUsd: null,
+    });
+
+    // Should return current values with no projection, same as borrowAmount=0
+    expect(result.healthFactorValue).toBe(8.0);
+    expect(result.borrowRatioOriginal).toBeUndefined();
+    expect(result.healthFactorOriginal).toBeUndefined();
+  });
+
   it("returns Infinity health factor when no existing debt and borrowAmount is 0", () => {
     const result = useBorrowMetrics({
       ...baseProps,

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/calculateMaxBorrowTokens.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/calculateMaxBorrowTokens.ts
@@ -7,8 +7,8 @@ export interface CalculateMaxBorrowTokensParams {
   currentDebtUsd: number;
   /** Liquidation threshold in BPS (e.g., 8000 = 80%) */
   liquidationThresholdBps: number;
-  /** Price of the borrow token in USD */
-  tokenPriceUsd: number;
+  /** Price of the borrow token in USD (null when oracle price is unavailable) */
+  tokenPriceUsd: number | null;
 }
 
 /**
@@ -31,6 +31,10 @@ export function calculateMaxBorrowTokens({
   liquidationThresholdBps,
   tokenPriceUsd,
 }: CalculateMaxBorrowTokensParams): number {
+  if (tokenPriceUsd == null || tokenPriceUsd <= 0) {
+    return 0;
+  }
+
   const maxTotalDebtUsd =
     (collateralValueUsd * liquidationThresholdBps) /
     BPS_SCALE /

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/useBorrowMetrics.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/useBorrowMetrics.ts
@@ -22,8 +22,8 @@ export interface UseBorrowMetricsProps {
   liquidationThresholdBps: number;
   /** Current health factor (null if no debt) */
   currentHealthFactor: number | null;
-  /** Price of the borrow token in USD */
-  tokenPriceUsd: number;
+  /** Price of the borrow token in USD (null when oracle price is unavailable) */
+  tokenPriceUsd: number | null;
 }
 
 export interface UseBorrowMetricsResult {
@@ -48,8 +48,8 @@ export function useBorrowMetrics({
   currentHealthFactor,
   tokenPriceUsd,
 }: UseBorrowMetricsProps): UseBorrowMetricsResult {
-  // When no borrow amount entered, show current values (no projection)
-  if (borrowAmount === 0) {
+  // When no borrow amount entered or price unavailable, show current values (no projection)
+  if (borrowAmount === 0 || tokenPriceUsd == null) {
     // Use Infinity when no debt - represents "infinitely healthy" for UI purposes
     const healthValue = currentHealthFactor ?? Infinity;
     return {

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/useBorrowState.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/useBorrowState.ts
@@ -16,8 +16,8 @@ export interface UseBorrowStateProps {
   currentDebtUsd: number;
   /** Liquidation threshold in BPS (e.g., 8000 = 80%) */
   liquidationThresholdBps: number;
-  /** Price of the borrow token in USD */
-  tokenPriceUsd: number;
+  /** Price of the borrow token in USD (null when oracle price is unavailable) */
+  tokenPriceUsd: number | null;
 }
 
 export interface UseBorrowStateResult {

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/index.tsx
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/index.tsx
@@ -120,7 +120,10 @@ export function Borrow() {
             }}
             onMaxClick={() => setBorrowAmount(sliderMaxBorrow)}
             rightField={{
-              value: formatUsdValue(borrowAmount * tokenPriceUsd),
+              value:
+                tokenPriceUsd != null
+                  ? formatUsdValue(borrowAmount * tokenPriceUsd)
+                  : "–",
             }}
             sliderActiveColor={getTokenBrandColor(assetConfig.symbol)}
             inputClassName={AMOUNT_INPUT_CLASS_NAME}
@@ -142,10 +145,15 @@ export function Borrow() {
           <p className="text-sm text-error-main">{errorMessage}</p>
         )}
 
-        {/* Borrow Unavailable Message */}
+        {/* Borrow Unavailable Messages */}
         {FeatureFlags.isBorrowDisabled && (
           <Text variant="body2" className="text-center text-warning-main">
             Borrowing is temporarily unavailable. Please check back later.
+          </Text>
+        )}
+        {tokenPriceUsd == null && !FeatureFlags.isBorrowDisabled && (
+          <Text variant="body2" className="text-center text-warning-main">
+            Price data unavailable. Borrowing is temporarily disabled.
           </Text>
         )}
       </div>
@@ -156,7 +164,12 @@ export function Borrow() {
         color="secondary"
         size="large"
         fluid
-        disabled={isDisabled || isProcessing || FeatureFlags.isBorrowDisabled}
+        disabled={
+          isDisabled ||
+          isProcessing ||
+          FeatureFlags.isBorrowDisabled ||
+          tokenPriceUsd == null
+        }
         onClick={handleBorrow}
         className="mt-6"
       >

--- a/services/vault/src/applications/aave/components/LoanCard/Repay/hooks/__tests__/useRepayMetrics.test.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Repay/hooks/__tests__/useRepayMetrics.test.ts
@@ -65,6 +65,18 @@ describe("useRepayMetrics", () => {
     expect(result.healthFactorValue).toBe(Infinity);
   });
 
+  it("shows current values when tokenPriceUsd is null", () => {
+    const result = useRepayMetrics({
+      ...baseProps,
+      repayAmount: 1000,
+      tokenPriceUsd: null,
+    });
+
+    // Should return current values with no projection, same as repayAmount=0
+    expect(result.healthFactorValue).toBe(1.6);
+    expect(result.borrowRatioOriginal).toBeUndefined();
+  });
+
   it("clamps projected debt to zero (no negative debt)", () => {
     // Repay more than total debt
     const result = useRepayMetrics({

--- a/services/vault/src/applications/aave/components/LoanCard/Repay/hooks/useRepayMetrics.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Repay/hooks/useRepayMetrics.ts
@@ -24,8 +24,8 @@ export interface UseRepayMetricsProps {
   liquidationThresholdBps: number;
   /** Current health factor (null if no debt) */
   currentHealthFactor: number | null;
-  /** Price of the repay token in USD */
-  tokenPriceUsd: number;
+  /** Price of the repay token in USD (null when oracle price is unavailable) */
+  tokenPriceUsd: number | null;
 }
 
 export interface UseRepayMetricsResult {
@@ -50,8 +50,8 @@ export function useRepayMetrics({
   currentHealthFactor,
   tokenPriceUsd,
 }: UseRepayMetricsProps): UseRepayMetricsResult {
-  // When no repay amount entered, show current values (no projection)
-  if (repayAmount === 0) {
+  // When no repay amount entered or price unavailable, show current values (no projection)
+  if (repayAmount === 0 || tokenPriceUsd == null) {
     const healthValue = currentHealthFactor ?? Infinity;
     return {
       borrowRatio: calculateBorrowRatio(totalDebtValueUsd, collateralValueUsd),

--- a/services/vault/src/applications/aave/components/LoanCard/Repay/index.tsx
+++ b/services/vault/src/applications/aave/components/LoanCard/Repay/index.tsx
@@ -131,7 +131,10 @@ export function Repay() {
             }}
             onMaxClick={() => setRepayAmount(sliderMaxRepay)}
             rightField={{
-              value: formatUsdValue(repayAmount * tokenPriceUsd),
+              value:
+                tokenPriceUsd != null
+                  ? formatUsdValue(repayAmount * tokenPriceUsd)
+                  : "–",
             }}
             sliderActiveColor={getTokenBrandColor(assetConfig.symbol)}
             inputClassName={AMOUNT_INPUT_CLASS_NAME}

--- a/services/vault/src/applications/aave/components/context/LoanContext.tsx
+++ b/services/vault/src/applications/aave/components/context/LoanContext.tsx
@@ -27,8 +27,8 @@ export interface LoanContextValue {
   assetConfig: Asset;
   /** User's proxy contract address (for debt queries) */
   proxyContract: string | undefined;
-  /** Price of the selected borrow token in USD (from oracle or stablecoin fallback) */
-  tokenPriceUsd: number;
+  /** Price of the selected borrow token in USD (null when oracle price is temporarily unavailable) */
+  tokenPriceUsd: number | null;
   /** Callback when borrow succeeds */
   onBorrowSuccess: (borrowAmount: number) => void;
   /** Callback when repay succeeds */

--- a/services/vault/src/applications/aave/constants.ts
+++ b/services/vault/src/applications/aave/constants.ts
@@ -60,16 +60,15 @@ export const POSITION_REFETCH_INTERVAL_MS = 30 * 1000;
 export const POSITION_STALENESS_THRESHOLD_MS = POSITION_REFETCH_INTERVAL_MS * 3;
 
 /**
- * Fallback price for stablecoins when no oracle-derived price is available
- * (e.g., first-time borrow with no existing debt to derive price from).
- * Only used when the token is a known stablecoin — non-stablecoin tokens
- * without an oracle price will throw.
+ * Fallback price for stablecoins on testnet/signet where Chainlink does not
+ * publish price feeds. On mainnet, real Chainlink oracle prices are always used.
  */
 export const STABLECOIN_FALLBACK_PRICE_USD = 1.0;
 
 /**
- * Tokens whose USD price can safely be assumed as $1 when no oracle data
- * is available. Used as a guard for the stablecoin fallback price.
+ * Tokens eligible for the $1 testnet fallback when no Chainlink feed exists.
+ * On mainnet, Chainlink feeds exist for all these tokens and the fallback
+ * is never used.
  */
 export const KNOWN_STABLECOIN_SYMBOLS = ["USDC", "USDT", "DAI"] as const;
 

--- a/services/vault/src/components/simple/BorrowFlow/useBorrowFormState.ts
+++ b/services/vault/src/components/simple/BorrowFlow/useBorrowFormState.ts
@@ -160,7 +160,10 @@ export function useBorrowFormState({
     setBorrowAmount,
     sliderMax,
     maxAmountFormatted: `${formatTokenAmount(sliderMax)} ${assetConfig.symbol}`,
-    usdValueFormatted: formatUsdValue(borrowAmount * tokenPriceUsd),
+    usdValueFormatted:
+      tokenPriceUsd != null
+        ? formatUsdValue(borrowAmount * tokenPriceUsd)
+        : "–",
 
     isDisabled,
     buttonText: resolvedButtonText,


### PR DESCRIPTION
### Problem

Two audit findings identified incorrect inputs to borrow max / health factor calculations in the Aave flow:

**[#131 (MEDIUM)](https://github.com/babylonlabs-io/vault-provider-proxy/issues/131) — Token price assumes stablecoins always worth $1**
`useAaveReserveDetail` derived token price from a debt-ratio hack (only worked with 1 borrowable reserve) or fell back to a hardcoded `$1` for stablecoins. A stablecoin depeg would silently erode the 1.2 HF safety margin, allowing users to borrow more than safe against their collateral.

**[#147 (LOW)](https://github.com/babylonlabs-io/vault-provider-proxy/issues/147) — Collateral factor reads from indexer instead of user's position**
`liquidationThresholdBps` was read from the indexer's reserve-level `collateralFactor`. After a `dynamicConfigKey` rotation on-chain, this diverges from the position-specific value the contract actually uses for liquidation — meaning borrow limits and projected health factor could be wrong.

**[#1391](https://github.com/babylonlabs-io/babylon-toolkit/issues/1391) — Implementation spec for migrating to Chainlink feeds**
Detailed spec requesting migration of `tokenPriceUsd` to real oracle prices.

### Solution

Modified **one file** (`useAaveReserveDetail.ts`) to replace both incorrect data sources with existing hooks that already solve these problems:

#### Token Price ([#131](https://github.com/babylonlabs-io/vault-provider-proxy/issues/131) / [#1391](https://github.com/babylonlabs-io/babylon-toolkit/issues/1391))
- **Before:** Derived price from `debtValueUsd / currentDebtAmount` (only worked with exactly 1 borrowable reserve, broke on first borrow with no debt), or hardcoded `$1` for stablecoins regardless of network
- **After:** Uses `usePrices()` hook which fetches real Chainlink oracle prices (BTC, ETH, USDC, USDT, DAI) cached app-wide via React Query. On testnet/signet where Chainlink doesn't publish stablecoin feeds, falls back to `$1` only for known stablecoins. On mainnet, a missing price returns `null` and blocks the borrow flow.

#### Collateral Factor ([#147](https://github.com/babylonlabs-io/vault-provider-proxy/issues/147))
- **Before:** `vbtcReserve?.reserve.collateralFactor ?? 0` — reads the indexer's reserve-level CF which can be stale after a dynamicConfigKey rotation
- **After:** `useVaultSplitParams(address)` — reads the user's position-specific `dynamicConfigKey` from the contract and fetches the corresponding `getDynamicReserveConfig`, matching the exact CF the contract uses for liquidation math

### Scenarios now properly handled

| Scenario | Before | After |
|----------|--------|-------|
| Stablecoin depeg (e.g. USDC at $0.88) | Assumed $1 — user could overborrow | Max borrow decreases proportionally to real price |
| First borrow with no existing debt | Hardcoded $1 for stablecoins, `null` for others | Chainlink price used for all tokens |
| Multiple borrowable reserves | Debt-ratio derivation broke (assertion error) | Each token priced independently via Chainlink |
| dynamicConfigKey rotation on-chain | Stale indexer CF used — wrong HF/max borrow | Position-specific CF from contract |
| Mainnet with missing Chainlink feed | Would silently use $1 fallback | Returns `null` — UI blocks borrow flow |
| Testnet/signet stablecoin (no feed) | Always $1 regardless of network | $1 fallback only on non-mainnet for known stablecoins |

### Changes

| File | Change |
|------|--------|
| `Detail/hooks/useAaveReserveDetail.ts` | Replaced token price derivation with `usePrices()` + Chainlink lookup; replaced indexer CF with `useVaultSplitParams(address)`; added both to loading state |
| `aave/constants.ts` | Updated JSDoc to clarify testnet-only fallback purpose |
| `Detail/hooks/__tests__/useAaveReserveDetail.test.tsx` | New — 12 test cases covering Chainlink price, testnet fallback, mainnet null-on-missing, position-specific CF, loading states |

### No breaking changes

The hook's return type is unchanged — `tokenPriceUsd: number | null` and `liquidationThresholdBps: number`. All downstream consumers (`LoanCard`, `calculateMaxBorrowTokens`, `useBorrowMetrics`, `useRepayMetrics`) work identically since they only care about the values, not the source.

Closes https://github.com/babylonlabs-io/babylon-toolkit/issues/1391
Closes https://github.com/babylonlabs-io/vault-provider-proxy/issues/131
Closes https://github.com/babylonlabs-io/vault-provider-proxy/issues/147

Some screenshots with debug panel:

<img width="2032" height="1162" alt="Screenshot_2026-04-22_13-47-30" src="https://github.com/user-attachments/assets/8d4f9d83-b824-4e24-8001-478cdd6ec77e" />

<img width="2032" height="1162" alt="Screenshot_2026-04-22_13-47-41" src="https://github.com/user-attachments/assets/5145d46c-28e8-4649-8dbb-3510c9a45543" />

<img width="2032" height="1162" alt="Screenshot_2026-04-22_13-51-33" src="https://github.com/user-attachments/assets/eb8ea063-8732-4651-bb53-34b44f056cf9" />
