### PR TITLE
feat(vault): position notifications without feature flag

### DIFF
--- a/services/vault/.env.example
+++ b/services/vault/.env.example
@@ -36,6 +36,8 @@ NEXT_PUBLIC_TBV_SIDECAR_API_URL=https://sidecar-api.canon-devnet.babylonlabs.io
 # Kill-switch for the vault supply-cap UI (dashboard section + deposit-form validation).
 # When enabled, the CapPolicy contract is never read. Vault cap is on by default.
 # NEXT_PUBLIC_FF_DISABLE_VAULT_CAP=true
+# Shows the position notifications debug panel for testing notification scenarios
+# NEXT_PUBLIC_FF_POSITION_DEBUG_PANEL=true
 
 
 # Added by sync-env from devnet

--- a/services/vault/src/applications/aave/components/PositionNotificationsDebugPanel.tsx
+++ b/services/vault/src/applications/aave/components/PositionNotificationsDebugPanel.tsx
@@ -40,7 +40,7 @@ const WARNING_TYPE_COLORS: Record<WarningType, string> = {
 };
 
 const STATUS_MESSAGES: Record<
-  Exclude<PositionNotificationsStatus, "flag-off" | "ready">,
+  Exclude<PositionNotificationsStatus, "ready">,
   string
 > = {
   loading: "Loading position data...",
@@ -503,8 +503,6 @@ export function PositionNotificationsDebugPanel({
       onStatusChange?.(null);
     }
   }, [displayResult, simulateStalePrice, onResultChange, onStatusChange]);
-
-  if (status === "flag-off") return null;
 
   return (
     <details className="rounded-lg border border-dashed border-purple-400 bg-purple-50 p-4 dark:border-purple-700 dark:bg-purple-950/30">

--- a/services/vault/src/applications/aave/hooks/usePositionNotifications.ts
+++ b/services/vault/src/applications/aave/hooks/usePositionNotifications.ts
@@ -1,6 +1,5 @@
 import { useMemo } from "react";
 
-import featureFlags from "@/config/featureFlags";
 import { useDashboardState } from "@/hooks/useDashboardState";
 import { usePrices } from "@/hooks/usePrices";
 
@@ -13,7 +12,6 @@ import {
 import { useVaultSplitParams } from "./useVaultSplitParams";
 
 export type PositionNotificationsStatus =
-  | "flag-off"
   | "loading"
   | "no-wallet"
   | "no-vaults"
@@ -49,8 +47,6 @@ export function usePositionNotifications(
     result: CalculatorResult | null;
     status: PositionNotificationsStatus;
   } => {
-    if (!featureFlags.isPositionNotificationsEnabled)
-      return { result: null, status: "flag-off" };
     if (!splitParams || isLoading) return { result: null, status: "loading" };
     if (!connectedAddress) return { result: null, status: "no-wallet" };
     if (btcMetadata?.isStale || btcMetadata?.fetchFailed)

--- a/services/vault/src/components/simple/DashboardPage.tsx
+++ b/services/vault/src/components/simple/DashboardPage.tsx
@@ -182,7 +182,7 @@ export function DashboardPage() {
           onRepay={handleRepay}
         />
 
-        {featureFlags.isPositionNotificationsEnabled && (
+        {featureFlags.isPositionDebugPanelEnabled && (
           <PositionNotificationsDebugPanel
             onResultChange={setDebugResultOverride}
             onStatusChange={setDebugStatusOverride}

--- a/services/vault/src/components/simple/PositionNotificationBanner/PositionNotificationBanner.tsx
+++ b/services/vault/src/components/simple/PositionNotificationBanner/PositionNotificationBanner.tsx
@@ -13,7 +13,6 @@ import {
   deriveBannerState,
   type CalculatorResult,
 } from "@/applications/aave/positionNotifications";
-import featureFlags from "@/config/featureFlags";
 import { invalidateVaultQueries } from "@/utils/queryKeys";
 
 import { ReorderSuccessModal } from "../ReorderVaults";
@@ -81,9 +80,6 @@ export function PositionNotificationBanner({
   }, [result, executeReorder]);
 
   const effectiveStatus = statusOverride ?? status;
-
-  // When no override, respect feature flag
-  if (!hasOverride && !featureFlags.isPositionNotificationsEnabled) return null;
 
   // Stale-price: show yellow warning regardless of result
   if (effectiveStatus === "stale-price") {

--- a/services/vault/src/components/simple/PositionNotificationBanner/__tests__/PositionNotificationBanner.test.tsx
+++ b/services/vault/src/components/simple/PositionNotificationBanner/__tests__/PositionNotificationBanner.test.tsx
@@ -87,10 +87,6 @@ vi.mock("@/applications/aave/hooks/usePositionNotifications", () => ({
   }),
 }));
 
-vi.mock("@/config/featureFlags", () => ({
-  default: { isPositionNotificationsEnabled: true },
-}));
-
 vi.mock("wagmi", () => ({
   useAccount: () => ({ address: "0xTestAddress" }),
 }));

--- a/services/vault/src/config/featureFlags.ts
+++ b/services/vault/src/config/featureFlags.ts
@@ -59,15 +59,15 @@ export default {
   },
 
   /**
-   * POSITION_NOTIFICATIONS feature flag
+   * POSITION_DEBUG_PANEL feature flag
    *
-   * Purpose: Enables the position notifications calculator that analyzes
-   * vault structure and shows actionable warnings (cliff, reorder, rebalance, etc.)
-   * Why needed: Feature is being developed incrementally; hidden behind flag until ready
+   * Purpose: Shows the position notifications debug panel on the dashboard,
+   * allowing manual parameter overrides and simulation of notification states.
+   * Why needed: Dev/QA tool for testing position notification scenarios
    * Default: false (disabled unless explicitly set to "true")
    */
-  get isPositionNotificationsEnabled() {
-    return process.env.NEXT_PUBLIC_FF_POSITION_NOTIFICATIONS === "true";
+  get isPositionDebugPanelEnabled() {
+    return process.env.NEXT_PUBLIC_FF_POSITION_DEBUG_PANEL === "true";
   },
 
   /**


### PR DESCRIPTION
- shows positions notifications without FF
- FF `NEXT_PUBLIC_FF_POSITION_DEBUG_PANEL` only controls the debug panel - in case we need to test different scenarios with different data

@jeremy-babylonlabs @jrwbabylonlab @jonybur you can add

```
NEXT_PUBLIC_FF_POSITION_DEBUG_PANEL=true
```

to your `.env.local.`