### PR TITLE
feat(ts-sdk, vault): extract proof-of-possession signing into public API

### DIFF
--- a/packages/babylon-ts-sdk/docs/api/clients.md
+++ b/packages/babylon-ts-sdk/docs/api/clients.md
@@ -1707,7 +1707,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:152](../.
 
 ### AddressTx
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts:326](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts#L326)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts:373](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts#L373)
 
 Transaction summary from address transactions endpoint.
 
@@ -1719,7 +1719,7 @@ Transaction summary from address transactions endpoint.
 txid: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts:327](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts#L327)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts:374](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts#L374)
 
 ##### status
 
@@ -1727,7 +1727,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts:
 status: object;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts:328](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts#L328)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts:375](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts#L375)
 
 ###### confirmed
 
@@ -3425,7 +3425,7 @@ Resolved contract addresses
 function pushTx(txHex, apiUrl): Promise<string>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts:126](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts#L126)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts:163](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts#L163)
 
 Push a signed transaction to the Bitcoin network.
 
@@ -3461,7 +3461,7 @@ Error if broadcasting fails
 function getTxInfo(txid, apiUrl): Promise<TxInfo>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts:170](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts#L170)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts:207](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts#L207)
 
 Get transaction information from mempool.
 
@@ -3493,7 +3493,7 @@ Transaction information
 function getTxHex(txid, apiUrl): Promise<string>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts:182](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts#L182)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts:220](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts#L220)
 
 Get the hex representation of a transaction.
 
@@ -3532,7 +3532,7 @@ function getUtxoInfo(
 apiUrl): Promise<UtxoInfo>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts:213](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts#L213)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts:252](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts#L252)
 
 Get UTXO information for a specific transaction output.
 
@@ -3573,7 +3573,7 @@ UTXO information with value and scriptPubKey
 function getAddressUtxos(address, apiUrl): Promise<MempoolUTXO[]>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts:246](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts#L246)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts:287](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts#L287)
 
 Get all UTXOs for a Bitcoin address.
 
@@ -3605,7 +3605,7 @@ Array of UTXOs sorted by value (largest first)
 function getMempoolApiUrl(network): string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts:317](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts#L317)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts:364](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts#L364)
 
 Get the mempool API URL for a given network.
 
@@ -3631,7 +3631,7 @@ The mempool API URL
 function getAddressTxs(address, apiUrl): Promise<AddressTx[]>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts:344](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts#L344)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts:391](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts#L391)
 
 Get recent transactions for a Bitcoin address.
 
@@ -3666,7 +3666,7 @@ Array of recent transactions
 function getNetworkFees(apiUrl): Promise<NetworkFees>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts:360](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts#L360)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts:408](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts#L408)
 
 Fetches Bitcoin network fee recommendations from mempool.space API.
 
@@ -3691,6 +3691,28 @@ Error if request fails or returns invalid data
 #### See
 
 https://mempool.space/docs/api/rest#get-recommended-fees
+
+***
+
+### validateRequestDepositorClaimerArtifactsResponse()
+
+```ts
+function validateRequestDepositorClaimerArtifactsResponse(response): asserts response is RequestDepositorClaimerArtifactsResponse;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/validators.ts:330](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/validators.ts#L330)
+
+Validate a requestDepositorClaimerArtifacts response.
+
+#### Parameters
+
+##### response
+
+`unknown`
+
+#### Returns
+
+`asserts response is RequestDepositorClaimerArtifactsResponse`
 
 ## Enumerations
 
@@ -3899,7 +3921,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 const MEMPOOL_API_URLS: object;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts:81](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts#L81)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts:118](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts#L118)
 
 Default mempool API URLs by network.
 

--- a/packages/babylon-ts-sdk/docs/api/managers.md
+++ b/packages/babylon-ts-sdk/docs/api/managers.md
@@ -3,7 +3,7 @@
 # managers
 
 Wallet-owning orchestration for the vault lifecycle. A vault goes from creation
-to `ACTIVE` through five phases — [Managers Quickstart](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/docs/quickstart/managers.md)
+to `ACTIVE` through six phases — [Managers Quickstart](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/docs/quickstart/managers.md)
 walks through them. A vault at `VERIFIED` is not done: the depositor must
 reveal the HTLC secret via `activateVault()` (services layer) or the vault
 expires.
@@ -11,10 +11,11 @@ expires.
 | # | Phase | SDK entry point | Contract status after |
 |---|-------|-----------------|-----------------------|
 | 1 | Prepare Pre-PegIn + PegIn txs | `PeginManager.preparePegin()` | n/a (off-chain) |
-| 2 | Register on Ethereum | `PeginManager.registerPeginOnChain()` | `PENDING` |
-| 3 | Broadcast Pre-PegIn on Bitcoin | `PeginManager.signAndBroadcast()` | still `PENDING` until VP observes the tx |
-| 4 | Sign payout authorisations | `pollAndSignPayouts()` (services, delegates to `PayoutManager`) | `PENDING` → `VERIFIED` |
-| 5 | Activate by revealing HTLC secret | `activateVault()` (services) | `VERIFIED` → `ACTIVE` |
+| 2 | Sign BTC proof-of-possession | `PeginManager.signProofOfPossession()` | n/a (off-chain, once per session) |
+| 3 | Register on Ethereum | `PeginManager.registerPeginOnChain()` | `PENDING` |
+| 4 | Broadcast Pre-PegIn on Bitcoin | `PeginManager.signAndBroadcast()` | still `PENDING` until VP observes the tx |
+| 5 | Sign payout authorisations | `pollAndSignPayouts()` (services, delegates to `PayoutManager`) | `PENDING` → `VERIFIED` |
+| 6 | Activate by revealing HTLC secret | `activateVault()` (services) | `VERIFIED` → `ACTIVE` |
 
 Optional exit after the CSV timelock expires: `buildAndBroadcastRefund()` (services).
 
@@ -28,7 +29,7 @@ High-level manager for payout transaction signing.
 
 #### Remarks
 
-After registering your peg-in on Ethereum (Step 2), the vault provider prepares
+After registering your peg-in on Ethereum (Step 3), the vault provider prepares
 claim/payout transaction pairs. You must sign each payout transaction using this
 manager and submit the signatures to the vault provider's RPC API.
 
@@ -188,7 +189,7 @@ Error if any signing operation fails
 
 ### PeginManager
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:458](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L458)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:515](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L515)
 
 #### Constructors
 
@@ -198,7 +199,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:458](
 new PeginManager(config): PeginManager;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:466](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L466)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:523](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L523)
 
 Creates a new PeginManager instance.
 
@@ -222,7 +223,7 @@ Manager configuration including wallets and contract addresses
 preparePegin(params): Promise<PreparePeginResult>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:490](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L490)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:547](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L547)
 
 Prepares a peg-in by building the Pre-PegIn HTLC transaction,
 funding it, constructing the PegIn transaction, and signing the PegIn input.
@@ -263,7 +264,7 @@ Error if wallet operations fail or insufficient funds
 signAndBroadcast(params): Promise<string>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:679](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L679)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:732](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L732)
 
 Signs and broadcasts a funded peg-in transaction to the Bitcoin network.
 
@@ -299,17 +300,22 @@ Error if signing or broadcasting fails
 registerPeginOnChain(params): Promise<RegisterPeginResult>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:819](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L819)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:875](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L875)
 
 Registers a peg-in on Ethereum by calling the BTCVaultRegistry contract.
 
 This method:
-1. Gets depositor ETH address from wallet
-2. Creates proof of possession (BTC signature of ETH address)
-3. Checks if vault already exists (pre-flight check)
-4. Encodes the contract call using viem
-5. Estimates gas (catches contract errors early with proper revert reasons)
-6. Sends transaction with pre-estimated gas via ethWallet.sendTransaction()
+1. Re-verifies the PopSignature against the currently connected ETH
+   and BTC wallets — refuses to proceed if either has changed
+2. Derives vault ID and checks if it already exists (pre-flight)
+3. Encodes the contract call using viem
+4. Estimates gas (catches contract errors early with proper revert
+   reasons)
+5. Sends transaction with pre-estimated gas via
+   ethWallet.sendTransaction()
+
+The PopSignature must be obtained via
+[signProofOfPossession](#signproofofpossession) before this call.
 
 ###### Parameters
 
@@ -317,7 +323,8 @@ This method:
 
 [`RegisterPeginParams`](#registerpeginparams)
 
-Registration parameters including BTC pubkey and unsigned tx
+Registration parameters including the PopSignature
+                and the prepared Pre-PegIn / PegIn transactions
 
 ###### Returns
 
@@ -327,15 +334,16 @@ Result containing Ethereum transaction hash and vault ID
 
 ###### Throws
 
-Error if signing or transaction fails
+Error if the PopSignature does not match the connected wallets
 
 ###### Throws
 
-Error if vault already exists
+Error if the vault already exists
 
 ###### Throws
 
-Error if contract simulation fails (e.g., invalid signature, unauthorized)
+Error if contract simulation fails (e.g., invalid signature,
+        unauthorized)
 
 ##### registerPeginBatchOnChain()
 
@@ -343,7 +351,7 @@ Error if contract simulation fails (e.g., invalid signature, unauthorized)
 registerPeginBatchOnChain(params): Promise<RegisterPeginBatchResult>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:982](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L982)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1036](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L1036)
 
 Register multiple pegins on Ethereum in a single transaction.
 
@@ -365,13 +373,30 @@ Batch registration parameters
 
 Batch result with per-vault IDs and single ETH tx hash
 
+##### signProofOfPossession()
+
+```ts
+signProofOfPossession(): Promise<PopSignature>;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1266](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L1266)
+
+Sign a BIP-322 BTC Proof-of-Possession binding the connected BTC
+wallet to the connected ETH account for this chain and vault
+registry. The returned [PopSignature](#popsignature) can be reused across
+every register call in the same session.
+
+###### Returns
+
+`Promise`\<[`PopSignature`](#popsignature)\>
+
 ##### getNetwork()
 
 ```ts
 getNetwork(): Network;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1237](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L1237)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1311](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L1311)
 
 Gets the configured Bitcoin network.
 
@@ -387,7 +412,7 @@ The Bitcoin network (mainnet, testnet, signet, regtest)
 getVaultContractAddress(): `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1246](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L1246)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1320](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L1320)
 
 Gets the configured BTCVaultRegistry contract address.
 
@@ -910,7 +935,7 @@ Depositor's BTC public key used for signing.
 
 ### PeginManagerConfig
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:69](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L69)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:125](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L125)
 
 Configuration for the PeginManager.
 
@@ -922,7 +947,7 @@ Configuration for the PeginManager.
 btcNetwork: Network;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:73](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L73)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:129](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L129)
 
 Bitcoin network to use for transactions.
 
@@ -932,7 +957,7 @@ Bitcoin network to use for transactions.
 btcWallet: BitcoinWallet;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:78](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L78)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:134](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L134)
 
 Bitcoin wallet for signing peg-in transactions.
 
@@ -942,7 +967,7 @@ Bitcoin wallet for signing peg-in transactions.
 ethWallet: object;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:84](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L84)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:140](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L140)
 
 Ethereum wallet for registering peg-in on-chain.
 Uses viem's WalletClient directly for proper gas estimation.
@@ -953,7 +978,7 @@ Uses viem's WalletClient directly for proper gas estimation.
 ethChain: Chain;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:90](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L90)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:146](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L146)
 
 Ethereum chain configuration.
 Required for proper gas estimation in contract calls.
@@ -964,7 +989,7 @@ Required for proper gas estimation in contract calls.
 vaultContracts: object;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:95](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L95)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:151](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L151)
 
 Vault contract addresses.
 
@@ -982,7 +1007,7 @@ BTCVaultRegistry contract address on Ethereum.
 mempoolApiUrl: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:107](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L107)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:163](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L163)
 
 Mempool API URL for fetching UTXO data and broadcasting transactions.
 Use MEMPOOL_API_URLS constant for standard mempool.space URLs, or provide
@@ -992,7 +1017,7 @@ a custom URL if running your own mempool instance.
 
 ### PreparePeginParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:113](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L113)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:169](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L169)
 
 Parameters for the pegin flow (pre-pegin + pegin transactions).
 
@@ -1004,7 +1029,7 @@ Parameters for the pegin flow (pre-pegin + pegin transactions).
 amounts: readonly bigint[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:119](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L119)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:175](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L175)
 
 Amounts to peg in per HTLC (in satoshis).
 Must have the same length as `hashlocks`.
@@ -1016,7 +1041,7 @@ For single deposits, pass a single-element array.
 vaultProviderBtcPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:125](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L125)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:181](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L181)
 
 Vault provider's BTC public key (x-only, 64-char hex).
 Can be provided with or without "0x" prefix (will be stripped automatically).
@@ -1027,7 +1052,7 @@ Can be provided with or without "0x" prefix (will be stripped automatically).
 vaultKeeperBtcPubkeys: readonly string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:131](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L131)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:187](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L187)
 
 Vault keeper BTC public keys (x-only, 64-char hex).
 Can be provided with or without "0x" prefix (will be stripped automatically).
@@ -1038,7 +1063,7 @@ Can be provided with or without "0x" prefix (will be stripped automatically).
 universalChallengerBtcPubkeys: readonly string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:137](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L137)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:193](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L193)
 
 Universal challenger BTC public keys (x-only, 64-char hex).
 Can be provided with or without "0x" prefix (will be stripped automatically).
@@ -1049,7 +1074,7 @@ Can be provided with or without "0x" prefix (will be stripped automatically).
 timelockPegin: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:142](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L142)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:198](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L198)
 
 CSV timelock in blocks for the PegIn vault output.
 
@@ -1059,7 +1084,7 @@ CSV timelock in blocks for the PegIn vault output.
 timelockRefund: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:147](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L147)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:203](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L203)
 
 CSV timelock in blocks for the Pre-PegIn HTLC refund path.
 
@@ -1069,7 +1094,7 @@ CSV timelock in blocks for the Pre-PegIn HTLC refund path.
 hashlocks: readonly string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:154](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L154)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:210](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L210)
 
 SHA256 hash commitment(s) for the HTLC (64 hex chars = 32 bytes each).
 Generated by the depositor as H = SHA256(secret).
@@ -1081,7 +1106,7 @@ For single deposits, pass a single-element array.
 protocolFeeRate: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:160](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L160)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:216](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L216)
 
 Protocol fee rate in sat/vB from the contract offchain params.
 Used by WASM for computing depositorClaimValue and min pegin fee.
@@ -1092,7 +1117,7 @@ Used by WASM for computing depositorClaimValue and min pegin fee.
 mempoolFeeRate: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:166](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L166)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:222](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L222)
 
 Mempool fee rate in sat/vB for funding the Pre-PegIn transaction.
 Used for UTXO selection and change calculation.
@@ -1103,7 +1128,7 @@ Used for UTXO selection and change calculation.
 councilQuorum: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:171](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L171)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:227](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L227)
 
 M in M-of-N council multisig (from contract params).
 
@@ -1113,7 +1138,7 @@ M in M-of-N council multisig (from contract params).
 councilSize: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:176](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L176)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:232](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L232)
 
 N in M-of-N council multisig (from contract params).
 
@@ -1123,7 +1148,7 @@ N in M-of-N council multisig (from contract params).
 availableUTXOs: readonly UTXO[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:181](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L181)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:237](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L237)
 
 Available UTXOs from the depositor's wallet for funding the Pre-PegIn transaction.
 
@@ -1133,7 +1158,7 @@ Available UTXOs from the depositor's wallet for funding the Pre-PegIn transactio
 changeAddress: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:186](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L186)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:242](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L242)
 
 Bitcoin address for receiving change from the Pre-PegIn transaction.
 
@@ -1141,7 +1166,7 @@ Bitcoin address for receiving change from the Pre-PegIn transaction.
 
 ### PreparePeginResult
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:208](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L208)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:264](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L264)
 
 #### Properties
 
@@ -1151,9 +1176,11 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:208](
 fundedPrePeginTxHex: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:210](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L210)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:270](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L270)
 
-Funded but unsigned Pre-PegIn transaction hex
+Funded, pre-witness Pre-PegIn tx hex. Pass this for register calls'
+`unsignedPrePeginTx` — despite the contract-side name, the registry
+stores the funded form so indexers can rebuild refund PSBTs.
 
 ##### prePeginTxid
 
@@ -1161,19 +1188,9 @@ Funded but unsigned Pre-PegIn transaction hex
 prePeginTxid: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:212](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L212)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:272](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L272)
 
 Funded Pre-PegIn transaction ID
-
-##### unsignedPrePeginTxHex
-
-```ts
-unsignedPrePeginTxHex: string;
-```
-
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:214](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L214)
-
-Unfunded Pre-PegIn transaction hex (for contract DA submission)
 
 ##### perVault
 
@@ -1181,7 +1198,7 @@ Unfunded Pre-PegIn transaction hex (for contract DA submission)
 perVault: PerVaultPeginData[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:216](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L216)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:274](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L274)
 
 Per-vault PegIn data — one entry per hashlock/amount
 
@@ -1191,7 +1208,7 @@ Per-vault PegIn data — one entry per hashlock/amount
 selectedUTXOs: UTXO[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:218](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L218)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:276](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L276)
 
 UTXOs selected to fund the Pre-PegIn transaction
 
@@ -1201,7 +1218,7 @@ UTXOs selected to fund the Pre-PegIn transaction
 fee: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:220](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L220)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:278](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L278)
 
 Transaction fee in satoshis
 
@@ -1211,7 +1228,7 @@ Transaction fee in satoshis
 changeAmount: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:222](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L222)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:280](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L280)
 
 Change amount in satoshis (if any)
 
@@ -1219,7 +1236,7 @@ Change amount in satoshis (if any)
 
 ### SignAndBroadcastParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:229](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L229)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:287](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L287)
 
 Parameters for signing and broadcasting a transaction.
 
@@ -1231,7 +1248,7 @@ Parameters for signing and broadcasting a transaction.
 fundedPrePeginTxHex: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:233](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L233)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:291](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L291)
 
 Funded Pre-PegIn transaction hex from preparePegin().
 
@@ -1241,7 +1258,7 @@ Funded Pre-PegIn transaction hex from preparePegin().
 depositorBtcPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:240](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L240)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:298](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L298)
 
 Depositor's BTC public key (x-only, 64-char hex).
 Can be provided with or without "0x" prefix.
@@ -1256,7 +1273,7 @@ optional localPrevouts: Record<string, {
 }>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:248](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L248)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:306](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L306)
 
 Optional pre-fetched prevout data for inputs not yet in the mempool.
 Key format: "txid:vout" (e.g. "abc123...def:0").
@@ -1265,13 +1282,36 @@ Useful for split transactions where outputs are unconfirmed.
 
 ***
 
-### RegisterPeginParams
+### PopSignature
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:254](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L254)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:315](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L315)
 
-Parameters for registering a peg-in on Ethereum.
+BIP-322 BTC Proof-of-Possession binding a depositor's BTC key to their
+Ethereum account. Produced by [PeginManager.signProofOfPossession](#signproofofpossession)
+and reusable across every register call in the same session — the
+embedded identities are re-checked at register time.
 
 #### Properties
+
+##### btcPopSignature
+
+```ts
+btcPopSignature: `0x${string}`;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:317](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L317)
+
+BIP-322 signature over the PoP message (0x-prefixed hex).
+
+##### depositorEthAddress
+
+```ts
+depositorEthAddress: `0x${string}`;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:319](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L319)
+
+Ethereum address the PoP was signed for.
 
 ##### depositorBtcPubkey
 
@@ -1279,10 +1319,19 @@ Parameters for registering a peg-in on Ethereum.
 depositorBtcPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:259](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L259)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:321](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L321)
 
-Depositor's BTC public key (x-only, 64-char hex).
-Can be provided with or without "0x" prefix.
+BTC x-only public key (64-char hex, no 0x prefix).
+
+***
+
+### RegisterPeginParams
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:327](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L327)
+
+Parameters for registering a peg-in on Ethereum.
+
+#### Properties
 
 ##### unsignedPrePeginTx
 
@@ -1290,9 +1339,11 @@ Can be provided with or without "0x" prefix.
 unsignedPrePeginTx: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:264](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L264)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:333](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L333)
 
-Unsigned Pre-PegIn transaction hex (submitted to contract for data availability).
+Funded, pre-witness Pre-PegIn tx hex — pass
+[PreparePeginResult.fundedPrePeginTxHex](#fundedprepegintxhex). The contract-side
+parameter is named `unsignedPrePeginTx` but it stores the funded form.
 
 ##### depositorSignedPeginTx
 
@@ -1300,7 +1351,7 @@ Unsigned Pre-PegIn transaction hex (submitted to contract for data availability)
 depositorSignedPeginTx: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:269](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L269)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:338](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L338)
 
 Depositor-signed PegIn transaction hex (submitted to contract; vault ID derived from this).
 
@@ -1310,7 +1361,7 @@ Depositor-signed PegIn transaction hex (submitted to contract; vault ID derived 
 vaultProvider: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:274](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L274)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:343](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L343)
 
 Vault provider's Ethereum address.
 
@@ -1320,23 +1371,9 @@ Vault provider's Ethereum address.
 hashlock: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:279](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L279)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:348](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L348)
 
 SHA256 hashlock for HTLC activation (bytes32 hex with 0x prefix).
-
-##### onPopSigned()?
-
-```ts
-optional onPopSigned: () => void | Promise<void>;
-```
-
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:284](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L284)
-
-Optional callback invoked after PoP signing completes but before ETH transaction.
-
-###### Returns
-
-`void` \| `Promise`\<`void`\>
 
 ##### depositorPayoutBtcAddress?
 
@@ -1344,7 +1381,7 @@ Optional callback invoked after PoP signing completes but before ETH transaction
 optional depositorPayoutBtcAddress: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:293](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L293)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:357](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L357)
 
 Depositor's BTC payout address (e.g. bc1p..., bc1q...).
 Converted to scriptPubKey internally via bitcoinjs-lib.
@@ -1358,21 +1395,19 @@ via `btcWallet.getAddress()`.
 depositorWotsPkHash: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:296](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L296)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:360](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L360)
 
 Keccak256 hash of the depositor's WOTS public key (bytes32)
 
-##### preSignedBtcPopSignature?
+##### popSignature
 
 ```ts
-optional preSignedBtcPopSignature: `0x${string}`;
+popSignature: PopSignature;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:303](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L303)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:363](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L363)
 
-Pre-signed BTC PoP signature (hex with 0x prefix).
-When provided, the BTC wallet signing step is skipped and this signature is used directly.
-Useful for multi-vault deposits where PoP only needs to be signed once.
+Proof of possession from [PeginManager.signProofOfPossession](#signproofofpossession).
 
 ##### htlcVout
 
@@ -1380,7 +1415,7 @@ Useful for multi-vault deposits where PoP only needs to be signed once.
 htlcVout: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:310](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L310)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:370](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L370)
 
 Zero-based index of the HTLC output in the Pre-PegIn transaction that
 this PegIn spends. In a batch Pre-PegIn with N HTLC outputs, each vault
@@ -1390,7 +1425,7 @@ registration references a different htlcVout (0..N-1).
 
 ### RegisterPeginResult
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:316](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L316)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:376](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L376)
 
 Result of registering a peg-in on Ethereum.
 
@@ -1402,7 +1437,7 @@ Result of registering a peg-in on Ethereum.
 ethTxHash: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:320](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L320)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:380](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L380)
 
 Ethereum transaction hash for the peg-in registration.
 
@@ -1412,7 +1447,7 @@ Ethereum transaction hash for the peg-in registration.
 vaultId: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:326](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L326)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:386](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L386)
 
 Derived vault ID: keccak256(abi.encode(peginTxHash, depositor)).
 Used for contract reads/writes and indexer queries.
@@ -1423,52 +1458,22 @@ Used for contract reads/writes and indexer queries.
 peginTxHash: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:332](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L332)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:392](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L392)
 
 Raw Bitcoin pegin transaction hash (double-SHA256 of the signed pegin tx).
 Used for VP RPC operations which key on the BTC transaction ID.
-
-##### btcPopSignature
-
-```ts
-btcPopSignature: `0x${string}`;
-```
-
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:338](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L338)
-
-The BTC PoP signature used for this registration (hex with 0x prefix).
-Returned so callers can reuse it for subsequent pegins without re-signing.
 
 ***
 
 ### BatchPeginRequestItem
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:345](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L345)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:400](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L400)
 
 Single request in a batch pegin registration.
-All requests in a batch share the same vault provider and depositor.
+All requests in a batch share the same vault provider, depositor BTC
+pubkey, and Pre-PegIn transaction.
 
 #### Properties
-
-##### depositorBtcPubkey
-
-```ts
-depositorBtcPubkey: string;
-```
-
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:347](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L347)
-
-Depositor's BTC public key (x-only, 64-char hex or with 0x prefix)
-
-##### unsignedPrePeginTx
-
-```ts
-unsignedPrePeginTx: string;
-```
-
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:349](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L349)
-
-Unsigned Pre-PegIn tx hex (same for all vaults in batch)
 
 ##### depositorSignedPeginTx
 
@@ -1476,7 +1481,7 @@ Unsigned Pre-PegIn tx hex (same for all vaults in batch)
 depositorSignedPeginTx: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:351](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L351)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:402](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L402)
 
 Signed PegIn tx hex for this vault
 
@@ -1486,7 +1491,7 @@ Signed PegIn tx hex for this vault
 hashlock: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:353](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L353)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:404](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L404)
 
 SHA256 hashlock for HTLC activation (bytes32 hex)
 
@@ -1496,9 +1501,9 @@ SHA256 hashlock for HTLC activation (bytes32 hex)
 htlcVout: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:355](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L355)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:406](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L406)
 
-Zero-based HTLC output index in the Pre-PegIn tx
+Zero-based HTLC output index in the Pre-PegIn tx (unique per request)
 
 ##### depositorPayoutBtcAddress
 
@@ -1506,7 +1511,7 @@ Zero-based HTLC output index in the Pre-PegIn tx
 depositorPayoutBtcAddress: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:357](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L357)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:408](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L408)
 
 Depositor's BTC payout address (required — funds are sent here on payout)
 
@@ -1516,7 +1521,7 @@ Depositor's BTC payout address (required — funds are sent here on payout)
 depositorWotsPkHash: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:359](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L359)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:410](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L410)
 
 Keccak256 hash of the depositor's WOTS public key (bytes32)
 
@@ -1524,7 +1529,7 @@ Keccak256 hash of the depositor's WOTS public key (bytes32)
 
 ### RegisterPeginBatchParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:365](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L365)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:416](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L416)
 
 Parameters for registerPeginBatchOnChain.
 
@@ -1536,9 +1541,20 @@ Parameters for registerPeginBatchOnChain.
 vaultProvider: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:367](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L367)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:418](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L418)
 
 Vault provider address (shared across all vaults in batch)
+
+##### unsignedPrePeginTx
+
+```ts
+unsignedPrePeginTx: string;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:423](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L423)
+
+Funded, pre-witness Pre-PegIn tx hex — shared across every request in
+the batch. See [RegisterPeginParams.unsignedPrePeginTx](#unsignedprepegintx).
 
 ##### requests
 
@@ -1546,39 +1562,25 @@ Vault provider address (shared across all vaults in batch)
 requests: BatchPeginRequestItem[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:369](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L369)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:425](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L425)
 
 Individual pegin requests (one per vault)
 
-##### preSignedBtcPopSignature?
+##### popSignature
 
 ```ts
-optional preSignedBtcPopSignature: `0x${string}`;
+popSignature: PopSignature;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:371](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L371)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:427](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L427)
 
-Pre-signed BTC PoP signature (signed once, reused for all vaults)
-
-##### onPopSigned()?
-
-```ts
-optional onPopSigned: () => void | Promise<void>;
-```
-
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:373](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L373)
-
-Called after PoP is signed (before ETH tx)
-
-###### Returns
-
-`void` \| `Promise`\<`void`\>
+Proof of possession from [PeginManager.signProofOfPossession](#signproofofpossession).
 
 ***
 
 ### BatchPeginResultItem
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:379](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L379)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:433](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L433)
 
 Per-vault result from a batch pegin registration.
 
@@ -1590,7 +1592,7 @@ Per-vault result from a batch pegin registration.
 vaultId: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:381](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L381)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:435](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L435)
 
 Derived vault ID: keccak256(abi.encode(peginTxHash, depositor))
 
@@ -1600,7 +1602,7 @@ Derived vault ID: keccak256(abi.encode(peginTxHash, depositor))
 peginTxHash: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:383](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L383)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:437](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L437)
 
 Raw BTC pegin transaction hash
 
@@ -1608,7 +1610,7 @@ Raw BTC pegin transaction hash
 
 ### RegisterPeginBatchResult
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:389](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L389)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:443](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L443)
 
 Result of registering a batch of pegins on Ethereum in a single transaction.
 
@@ -1620,7 +1622,7 @@ Result of registering a batch of pegins on Ethereum in a single transaction.
 ethTxHash: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:391](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L391)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:445](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L445)
 
 Ethereum transaction hash
 
@@ -1630,19 +1632,9 @@ Ethereum transaction hash
 vaults: BatchPeginResultItem[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:393](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L393)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:447](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L447)
 
 Per-vault results (same order as input requests)
-
-##### btcPopSignature
-
-```ts
-btcPopSignature: `0x${string}`;
-```
-
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:395](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L395)
-
-The BTC PoP signature used (for reference)
 
 ## Type Aliases
 

--- a/packages/babylon-ts-sdk/docs/api/services.md
+++ b/packages/babylon-ts-sdk/docs/api/services.md
@@ -1175,9 +1175,11 @@ Pre-PegIn HTLC output value in satoshis.
 unsignedPrePeginTxHex: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:79](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L79)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:83](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L83)
 
-Funded (but pre-witness) Pre-PegIn transaction hex. 0x prefix optional.
+Funded, pre-witness Pre-PegIn transaction hex. 0x prefix optional.
+The name mirrors the contract/indexer schema; the bytes are the
+funded form (refund construction needs real outpoints).
 
 ##### depositorBtcPubkey
 
@@ -1185,7 +1187,7 @@ Funded (but pre-witness) Pre-PegIn transaction hex. 0x prefix optional.
 depositorBtcPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:81](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L81)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:85](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L85)
 
 Depositor's BTC public key (x-only or compressed hex; 0x prefix optional).
 
@@ -1193,7 +1195,7 @@ Depositor's BTC public key (x-only or compressed hex; 0x prefix optional).
 
 ### RefundPrePeginContext
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:96](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L96)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:100](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L100)
 
 Version-resolved protocol context that parameterises the HTLC's taproot
 scripts. The *signer-set* fields (`vaultKeeperPubkeys`,
@@ -1214,7 +1216,7 @@ script derivation).
 vaultProviderPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:97](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L97)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:101](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L101)
 
 ##### vaultKeeperPubkeys
 
@@ -1222,7 +1224,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 vaultKeeperPubkeys: readonly string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:98](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L98)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:102](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L102)
 
 ##### universalChallengerPubkeys
 
@@ -1230,7 +1232,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 universalChallengerPubkeys: readonly string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:99](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L99)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:103](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L103)
 
 ##### timelockRefund
 
@@ -1238,7 +1240,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 timelockRefund: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:100](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L100)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:104](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L104)
 
 ##### feeRate
 
@@ -1246,7 +1248,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 feeRate: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:101](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L101)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:105](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L105)
 
 ##### numLocalChallengers
 
@@ -1254,7 +1256,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 numLocalChallengers: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:102](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L102)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:106](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L106)
 
 ##### councilQuorum
 
@@ -1262,7 +1264,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 councilQuorum: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:103](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L103)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:107](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L107)
 
 ##### councilSize
 
@@ -1270,7 +1272,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 councilSize: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:104](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L104)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:108](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L108)
 
 ##### network
 
@@ -1278,13 +1280,13 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 network: Network;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:105](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L105)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:109](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L109)
 
 ***
 
 ### BtcBroadcastResult
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:109](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L109)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:113](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L113)
 
 Minimum shape required from a broadcast result.
 
@@ -1296,13 +1298,13 @@ Minimum shape required from a broadcast result.
 txId: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:110](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L110)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:114](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L114)
 
 ***
 
 ### RefundInput
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:122](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L122)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:126](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L126)
 
 #### Type Parameters
 
@@ -1318,7 +1320,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 vaultId: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:125](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L125)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:129](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L129)
 
 ##### readVault()
 
@@ -1326,7 +1328,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 readVault: () => Promise<VaultRefundData>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:131](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L131)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:135](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L135)
 
 Fetch authoritative on-chain + indexer vault data. The SDK passes no
 arguments — the caller closes over `vaultId` (or any other context it
@@ -1342,7 +1344,7 @@ needs).
 readPrePeginContext: (vault) => Promise<RefundPrePeginContext>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:136](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L136)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:140](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L140)
 
 Fetch the version-pinned refund context (sorted pubkeys, timelock, etc.)
 derived from the vault's locked versions.
@@ -1363,7 +1365,7 @@ derived from the vault's locked versions.
 feeRate: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:145](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L145)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:149](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L149)
 
 Mempool-derived sat/vB fee rate to use for the refund tx (positive
 number). Caller fetches this before invoking — it does not depend on
@@ -1376,7 +1378,7 @@ orchestration honest.
 signPsbt: RefundPsbtSigner;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:147](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L147)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:151](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L151)
 
 BTC wallet signer; receives a PSBT hex + taproot script-path options.
 
@@ -1386,7 +1388,7 @@ BTC wallet signer; receives a PSBT hex + taproot script-path options.
 broadcastTx: BtcBroadcaster<R>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:149](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L149)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:153](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L153)
 
 Broadcast callback — returns whatever shape the caller needs.
 
@@ -1396,7 +1398,7 @@ Broadcast callback — returns whatever shape the caller needs.
 optional signal: AbortSignal;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:151](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L151)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:155](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L155)
 
 Checked at every async boundary.
 
@@ -1450,7 +1452,7 @@ Reason why a vault expired
 type BtcBroadcaster<R> = (signedTxHex) => Promise<R>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:113](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L113)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:117](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L117)
 
 #### Type Parameters
 
@@ -1476,7 +1478,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 type RefundPsbtSigner = (psbtHex, opts) => Promise<string>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:117](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L117)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:121](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L121)
 
 #### Parameters
 
@@ -2045,7 +2047,7 @@ thresholds) are a consumer-side concern.
 function buildAndBroadcastRefund<R>(input): Promise<R>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:273](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L273)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:277](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L277)
 
 Build, sign, and broadcast a refund transaction for an expired vault.
 

--- a/packages/babylon-ts-sdk/docs/api/utils.md
+++ b/packages/babylon-ts-sdk/docs/api/utils.md
@@ -1321,3 +1321,75 @@ Safety multiplier for split transaction fee validation.
 The signed PSBT's fee rate and absolute fee must not exceed this multiple
 of the planned values. 5x accounts for witness estimation variance while
 catching catastrophic wallet-side overpayment.
+
+***
+
+### HEX\_RE
+
+```ts
+const HEX_RE: RegExp;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/validation.ts:9](../../packages/babylon-ts-sdk/src/tbv/core/utils/validation.ts#L9)
+
+Non-empty string of hexadecimal characters (case-insensitive).
+
+***
+
+### TXID\_RE
+
+```ts
+const TXID_RE: RegExp;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/validation.ts:12](../../packages/babylon-ts-sdk/src/tbv/core/utils/validation.ts#L12)
+
+Bitcoin txid: exactly 64 hex characters (32 bytes).
+
+***
+
+### BITCOIN\_ADDRESS\_RE
+
+```ts
+const BITCOIN_ADDRESS_RE: RegExp;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/validation.ts:21](../../packages/babylon-ts-sdk/src/tbv/core/utils/validation.ts#L21)
+
+Bitcoin address format gate: 25–90 alphanumeric characters.
+Covers legacy (P2PKH/P2SH), bech32 (P2WPKH/P2WSH), bech32m (P2TR),
+and regtest addresses (bcrt1... which are 62–64 chars for 32-byte witness programs).
+Upper bound of 90 provides headroom for future address formats.
+This is a format gate to prevent path-traversal — not full address validation.
+
+***
+
+### KNOWN\_SCRIPT\_PREFIXES
+
+```ts
+const KNOWN_SCRIPT_PREFIXES: readonly ["76a914", "a914", "0014", "0020", "5120"];
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/validation.ts:31](../../packages/babylon-ts-sdk/src/tbv/core/utils/validation.ts#L31)
+
+Known Bitcoin scriptPubKey prefixes:
+- P2PKH:  76a914...88ac (25 bytes)
+- P2SH:   a914...87    (23 bytes)
+- P2WPKH: 0014...      (22 bytes)
+- P2WSH:  0020...      (34 bytes)
+- P2TR:   5120...      (34 bytes)
+
+***
+
+### MAX\_REASONABLE\_FEE\_SATS
+
+```ts
+const MAX_REASONABLE_FEE_SATS: 1000000n = 1_000_000n;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/validation.ts:45](../../packages/babylon-ts-sdk/src/tbv/core/utils/validation.ts#L45)
+
+Upper bound on the implied miner fee (0.01 BTC = 1,000,000 sats).
+Catches inflated input values from a compromised mempool API — if inputs are
+grossly overstated the implied fee becomes unreasonably large. The April 2024
+Runes spike saw ~450 sat/vB; at 500 vB that's ~225k sats, well under this cap.

--- a/packages/babylon-ts-sdk/docs/get-started/README.md
+++ b/packages/babylon-ts-sdk/docs/get-started/README.md
@@ -29,23 +29,25 @@ Every vault lives in one of these on-chain states. Your SDK code transitions bet
 ```
   [ off-chain ]
        │
-       │  1. peginManager.preparePegin()        — build Pre-PegIn + PegIn PSBTs locally
+       │  1. peginManager.preparePegin()            — build Pre-PegIn + PegIn PSBTs locally
        │
-       │  2. peginManager.registerPeginOnChain() — submit vault + hashlock to Ethereum
+       │  2. peginManager.signProofOfPossession()   — BIP-322 PoP, one wallet popup per session
+       │
+       │  3. peginManager.registerPeginOnChain()    — submit vault + hashlock to Ethereum
        ▼
     PENDING
        │
-       │  3. peginManager.signAndBroadcast()    — put the Pre-PegIn tx on Bitcoin
+       │  4. peginManager.signAndBroadcast()        — put the Pre-PegIn tx on Bitcoin
        │  (contract status stays PENDING until the VP observes the BTC broadcast,
        │   builds the transaction graph, and posts presigned transactions back)
        │
-       │  4. pollAndSignPayouts()                — co-sign payout authorisations
+       │  5. pollAndSignPayouts()                    — co-sign payout authorisations
        ▼
    VERIFIED
        │ ┌─── activation window expires ───▶ EXPIRED ──┐
        │ │                                             │
        │ ▼                                             │
-       │ 5. activateVault(secret)                      │
+       │ 6. activateVault(secret)                      │
        │                                               │
        ▼                                               ▼
     ACTIVE                                  buildAndBroadcastRefund()
@@ -55,7 +57,7 @@ Every vault lives in one of these on-chain states. Your SDK code transitions bet
     REDEEMED                                     via refund path)
 ```
 
-The critical transition is `VERIFIED → ACTIVE`. Until the depositor reveals the HTLC secret on Ethereum (step 5), the vault is **not live** — miss the activation window and the only exit is refund after the CSV timelock.
+The critical transition is `VERIFIED → ACTIVE`. Until the depositor reveals the HTLC secret on Ethereum (step 6), the vault is **not live** — miss the activation window and the only exit is refund after the CSV timelock.
 
 ## Decide where to start
 

--- a/packages/babylon-ts-sdk/docs/guides/wallet-interfaces.md
+++ b/packages/babylon-ts-sdk/docs/guides/wallet-interfaces.md
@@ -162,7 +162,7 @@ const ethWallet = createWalletClient({
 
 A production Node wallet additionally handles:
 
-- **BIP-322 proof-of-possession** for `registerPeginOnChain()` (the SDK's `PeginManager` calls `signMessage(..., "bip322-simple")` over a canonical message).
+- **BIP-322 proof-of-possession** for `signProofOfPossession()` / `registerPeginOnChain()` (the SDK's `PeginManager` calls `signMessage(..., "bip322-simple")` over a canonical message).
 - **Finalizer customisation per input type** when integrating with hardware signers that don't emit a standard witness.
 - **KMS/HSM key custody** — wrap your cloud signer behind the same `signPsbt` / `signPsbts` / `signMessage` shape.
 

--- a/packages/babylon-ts-sdk/docs/quickstart/managers-advanced.md
+++ b/packages/babylon-ts-sdk/docs/quickstart/managers-advanced.md
@@ -124,6 +124,7 @@ Rules to watch:
 
 - Every vault must use the same `vaultProviderBtcPubkey`, `vaultKeeperBtcPubkeys`, `universalChallengerBtcPubkeys`, and protocol params. If you need different providers, register separately.
 - Each vault needs its own fresh HTLC secret + hashlock. Generate one per entry in the arrays, pair them by index.
+- Sign the proof-of-possession **once** (single wallet popup) and reuse the same `PopSignature` across every `registerPeginOnChain()` call in the batch.
 - `preparePegin().perVault[i]` returns one entry per vault — call `registerPeginOnChain()` for each. Broadcast the Pre-PegIn once.
 
 Example (builds on the happy-path config — `peginManager`, `btcWallet`, `vpEthAddress`, etc. are the same instances you set up in [Managers Quickstart → Configuration](./managers.md#configuration)):
@@ -150,7 +151,7 @@ declare const sharedBatchParams: Omit<
 >;
 
 // One fresh HTLC secret per vault. PERSIST all of them — you need them
-// independently for each vault's phase-5 activation.
+// independently for each vault's phase-6 activation.
 const secrets: Hex[] = [
   `0x${randomBytes(32).toString("hex")}` as Hex,
   `0x${randomBytes(32).toString("hex")}` as Hex,
@@ -170,16 +171,20 @@ const result = await peginManager.preparePegin({
   hashlocks: rawHashlocks,
 });
 
-// One registerPeginOnChain call per vault; they share the same Pre-PegIn tx.
+// Sign the BTC proof-of-possession ONCE for the whole batch.
+const popSignature = await peginManager.signProofOfPossession();
+
+// One registerPeginOnChain call per vault; they share the same Pre-PegIn
+// tx and the same PopSignature.
 for (let i = 0; i < result.perVault.length; i++) {
   await peginManager.registerPeginOnChain({
-    depositorBtcPubkey,
-    unsignedPrePeginTx: result.unsignedPrePeginTxHex,
+    unsignedPrePeginTx: result.fundedPrePeginTxHex,
     depositorSignedPeginTx: result.perVault[i].peginTxHex,
     hashlock: hashlocks[i],
     vaultProvider: vpEthAddress,
     depositorWotsPkHash: depositorWotsPkHashes[i],
     htlcVout: result.perVault[i].htlcVout,
+    popSignature,
   });
 }
 
@@ -190,7 +195,7 @@ await peginManager.signAndBroadcast({
 });
 ```
 
-Persist each `secrets[i]` alongside its `vaultId` so you can activate them independently in phase 5. Losing any one secret strands that vault at `VERIFIED` until refund.
+Persist each `secrets[i]` alongside its `vaultId` so you can activate them independently in phase 6. Losing any one secret strands that vault at `VERIFIED` until refund.
 
 ---
 

--- a/packages/babylon-ts-sdk/docs/quickstart/managers.md
+++ b/packages/babylon-ts-sdk/docs/quickstart/managers.md
@@ -1,6 +1,6 @@
 # Managers Quickstart
 
-End-to-end peg-in flow using the SDK's high-level managers and services. A vault goes from creation to `ACTIVE` through five phases; this doc walks you through them with runnable code.
+End-to-end peg-in flow using the SDK's high-level managers and services. A vault goes from creation to `ACTIVE` through six phases; this doc walks you through them with runnable code.
 
 > **New to the SDK?** Start with [Get Started](../get-started/README.md) first — it covers the four-layer architecture, trust model, config sourcing, and glossary. Come back here when you're ready to write code.
 >
@@ -19,17 +19,18 @@ Managers are the fastest path to a working flow when you're using a standard wal
 
 ---
 
-## The full vault lifecycle (5 phases)
+## The full vault lifecycle (6 phases)
 
 | # | Phase | SDK entry point | Contract status after |
 |---|-------|-----------------|-----------------------|
 | 1 | Prepare Pre-PegIn + PegIn txs | `peginManager.preparePegin()` | n/a (off-chain) |
-| 2 | Register on Ethereum | `peginManager.registerPeginOnChain()` | `PENDING` |
-| 3 | Broadcast Pre-PegIn on Bitcoin | `peginManager.signAndBroadcast()` | still `PENDING` until VP observes the tx |
-| 4 | Sign payout authorisations | `pollAndSignPayouts()` (service, delegates to `PayoutManager`) | `PENDING` → `VERIFIED` |
-| 5 | **Activate by revealing HTLC secret** | `activateVault()` (service) | `VERIFIED` → `ACTIVE` |
+| 2 | Sign BTC proof-of-possession (once per session) | `peginManager.signProofOfPossession()` | n/a (off-chain) |
+| 3 | Register on Ethereum | `peginManager.registerPeginOnChain()` | `PENDING` |
+| 4 | Broadcast Pre-PegIn on Bitcoin | `peginManager.signAndBroadcast()` | still `PENDING` until VP observes the tx |
+| 5 | Sign payout authorisations | `pollAndSignPayouts()` (service, delegates to `PayoutManager`) | `PENDING` → `VERIFIED` |
+| 6 | **Activate by revealing HTLC secret** | `activateVault()` (service) | `VERIFIED` → `ACTIVE` |
 
-> **Wait times:** between phases 2 and 3 you usually wait 1 BTC confirmation so the VP can index the Pre-PegIn. Between 3 and 4 the VP prepares transaction graphs (minutes). Phase 4 drives the contract to `VERIFIED` once all payout signatures are posted.
+> **Wait times:** phases 1–3 (prepare, PoP, register) run back-to-back with only wallet popups between them. After phase 4 (Bitcoin broadcast) you usually wait 1 BTC confirmation so the VP can index the Pre-PegIn and prepare transaction graphs (minutes). Phase 5 drives the contract to `VERIFIED` once all payout signatures are posted.
 >
 > **Wallet requirements:** BTC wallet needs UTXOs to cover the vault amount + network fees + the depositor-claim output. ETH wallet needs gas + the per-provider peg-in fee (queried from the contract) + gas for activation.
 >
@@ -39,7 +40,7 @@ Managers are the fastest path to a working flow when you're using a standard wal
 
 ## Before you start — generate and persist an HTLC secret
 
-Every vault is gated by an HTLC. The **secret** is a 32-byte random value you generate client-side. Its SHA-256 is the **hashlock** that gets registered on Ethereum. You must **persist the secret** until activation (phase 5) — without it you cannot activate, and the vault will sit at `VERIFIED` until it expires.
+Every vault is gated by an HTLC. The **secret** is a 32-byte random value you generate client-side. Its SHA-256 is the **hashlock** that gets registered on Ethereum. You must **persist the secret** until activation (phase 6) — without it you cannot activate, and the vault will sit at `VERIFIED` until it expires.
 
 ```typescript
 import { computeHashlock } from "@babylonlabs-io/ts-sdk/tbv/core/services";
@@ -55,7 +56,7 @@ const secret = `0x${randomBytes(32).toString("hex")}` as Hex;
 
 const hashlock = computeHashlock(secret); // 0x-prefixed bytes32
 
-// Persist `secret` in your app storage. You will need it in phase 5.
+// Persist `secret` in your app storage. You will need it in phase 6.
 ```
 
 **Hex format rules:**
@@ -142,7 +143,7 @@ declare const vpEthAddress: Address;
 // Known gaps); vault apps derive this out-of-band today.
 declare const depositorWotsPkHash: Hex;
 
-// 0. Generate + persist the HTLC secret. KEEP this — you need it in phase 5.
+// 0. Generate + persist the HTLC secret. KEEP this — you need it in phase 6.
 const secret = `0x${randomBytes(32).toString("hex")}` as Hex;
 const hashlock = computeHashlock(secret);     // 0x-prefixed
 const rawHashlock = stripHexPrefix(hashlock); // 64 hex chars, no 0x
@@ -170,25 +171,30 @@ const result = await peginManager.preparePegin({
 
 const firstVault = result.perVault[0];
 
-// 2. Register on Ethereum (generates PoP, submits the vault + hashlock).
+// 2. Sign the BTC proof-of-possession — one wallet popup. The returned
+//    PopSignature is reusable across every registerPeginOnChain call in
+//    this session (same depositor = same PoP).
+const popSignature = await peginManager.signProofOfPossession();
+
+// 3. Register on Ethereum (submits the vault + hashlock).
 const { vaultId, peginTxHash } = await peginManager.registerPeginOnChain({
-  depositorBtcPubkey,
-  unsignedPrePeginTx: result.unsignedPrePeginTxHex,
+  unsignedPrePeginTx: result.fundedPrePeginTxHex,
   depositorSignedPeginTx: firstVault.peginTxHex,
   hashlock,
   vaultProvider: vpEthAddress,
   depositorWotsPkHash,
   htlcVout: firstVault.htlcVout,
+  popSignature,
 });
 // Contract status: PENDING
 
-// 3. Broadcast the Pre-PegIn tx to Bitcoin.
+// 4. Broadcast the Pre-PegIn tx to Bitcoin.
 const btcTxid = await peginManager.signAndBroadcast({
   fundedPrePeginTxHex: result.fundedPrePeginTxHex,
   depositorBtcPubkey,
 });
 
-// 4. Wait for the VP, sign payouts, submit. The service polls the VP,
+// 5. Wait for the VP, sign payouts, submit. The service polls the VP,
 //    signs with your BitcoinWallet, and posts signatures back.
 const vpClient = new VaultProviderRpcClient(vaultProviderProxyUrl);
 
@@ -214,7 +220,7 @@ await pollAndSignPayouts({
 });
 // Contract status: VERIFIED
 
-// 5. Activate — reveal the HTLC secret. `writeContract` is the adapter
+// 6. Activate — reveal the HTLC secret. `writeContract` is the adapter
 //    that hands the SDK's prepared call to your ETH transport.
 await activateVault({
   btcVaultRegistryAddress: BTC_VAULT_REGISTRY,
@@ -243,11 +249,12 @@ await activateVault({
 
 | Phase | Method / Service | Returns |
 |---|---|---|
-| 1 | `peginManager.preparePegin()` | `{ fundedPrePeginTxHex, prePeginTxid, unsignedPrePeginTxHex, perVault[], selectedUTXOs, fee, changeAmount }`; each `perVault[i]` has `{ htlcVout, htlcValue, peginTxHex, peginTxid, peginInputSignature, vaultScriptPubKey }` |
-| 2 | `peginManager.registerPeginOnChain()` | `{ ethTxHash, vaultId, peginTxHash, btcPopSignature }` |
-| 3 | `peginManager.signAndBroadcast()` | `btcTxid` (string) |
-| 4 | `pollAndSignPayouts()` | `void` — side effect: signatures posted, contract moves to `VERIFIED` |
-| 5 | `activateVault()` | Whatever `writeContract` returns (typically `{ transactionHash }`) |
+| 1 | `peginManager.preparePegin()` | `{ fundedPrePeginTxHex, prePeginTxid, perVault[], selectedUTXOs, fee, changeAmount }`; each `perVault[i]` has `{ htlcVout, htlcValue, peginTxHex, peginTxid, peginInputSignature, vaultScriptPubKey }`. Pass `fundedPrePeginTxHex` as the `unsignedPrePeginTx` register param — the registry stores the funded pre-witness form. |
+| 2 | `peginManager.signProofOfPossession()` | `{ btcPopSignature, depositorEthAddress, depositorBtcPubkey }` — reusable across every `registerPeginOnChain` call in the session |
+| 3 | `peginManager.registerPeginOnChain()` | `{ ethTxHash, vaultId, peginTxHash }` |
+| 4 | `peginManager.signAndBroadcast()` | `btcTxid` (string) |
+| 5 | `pollAndSignPayouts()` | `void` — side effect: signatures posted, contract moves to `VERIFIED` |
+| 6 | `activateVault()` | Whatever `writeContract` returns (typically `{ transactionHash }`) |
 
 ---
 

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts
@@ -7,7 +7,7 @@
  *
  * The Payout transaction references the Assert transaction (input 1).
  *
- * @see {@link PeginManager} - For Steps 1, 2, and 4 of peg-in flow
+ * @see {@link PeginManager} - For Steps 1–4 of the peg-in flow
  * @see {@link buildPayoutPsbt} - Lower-level primitive for custom implementations
  * @see {@link extractPayoutSignature} - Extract signatures from signed PSBTs
  *
@@ -131,7 +131,7 @@ export interface PayoutSignatureResult {
  * High-level manager for payout transaction signing.
  *
  * @remarks
- * After registering your peg-in on Ethereum (Step 2), the vault provider prepares
+ * After registering your peg-in on Ethereum (Step 3), the vault provider prepares
  * claim/payout transaction pairs. You must sign each payout transaction using this
  * manager and submit the signatures to the vault provider's RPC API.
  *

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
@@ -83,7 +83,16 @@ function normalizeXOnlyPubkey(raw: unknown): string {
 
 /**
  * Normalize a wallet-returned BIP-322 signature into 0x-prefixed hex.
- * Accepts 0x-hex, unprefixed hex, or canonical standard base64.
+ *
+ * Accepts:
+ *  - 0x-prefixed lowercase/uppercase hex
+ *  - unprefixed hex (wins over base64 when input is pure `[0-9a-fA-F]+`)
+ *  - canonical standard base64 (`[A-Za-z0-9+/]` with `=` padding to a
+ *    multiple of 4 and no non-canonical encodings)
+ *
+ * Rejects URL-safe base64 (`-`/`_`) and base64 without padding. Wallets
+ * known to return BIP-322 signatures (Keystone, UniSat, OKX, OneKey,
+ * Unisat) all use standard base64; URL-safe is an explicit non-goal.
  */
 function normalizePopSignature(raw: unknown): Hex {
   if (typeof raw !== "string" || raw.length === 0) {
@@ -1294,9 +1303,12 @@ export class PeginManager {
     const currentBtcPubkey = normalizeXOnlyPubkey(
       await this.config.btcWallet.getPublicKeyHex(),
     );
-    if (currentBtcPubkey !== popSignature.depositorBtcPubkey) {
+    // Normalize the PoP-embedded key the same way in case a consumer
+    // serialized it through a path that changed casing or re-added 0x.
+    const popBtcPubkey = normalizeXOnlyPubkey(popSignature.depositorBtcPubkey);
+    if (currentBtcPubkey !== popBtcPubkey) {
       throw new Error(
-        `Proof of possession was signed with BTC pubkey ${popSignature.depositorBtcPubkey} ` +
+        `Proof of possession was signed with BTC pubkey ${popBtcPubkey} ` +
           `but the BTC wallet is currently connected to ${currentBtcPubkey}. ` +
           `Reconnect the original wallet or call signProofOfPossession() again.`,
       );

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
@@ -556,10 +556,13 @@ export class PeginManager {
   async preparePegin(
     params: PreparePeginParams,
   ): Promise<PreparePeginResult> {
-    // Step 1: Get depositor BTC public key from wallet
-    const depositorBtcPubkey = normalizeXOnlyPubkey(
-      await this.config.btcWallet.getPublicKeyHex(),
-    );
+    // Step 1: Get depositor BTC public key from wallet. Keep the raw
+    // wallet output (typically compressed sec1 66-char) for wallet sign
+    // calls — UniSat/OKX/OneKey expect their native format on
+    // signInputs[].publicKey — and derive the canonical x-only form for
+    // protocol/HTLC use.
+    const depositorBtcPubkeyRaw = await this.config.btcWallet.getPublicKeyHex();
+    const depositorBtcPubkey = normalizeXOnlyPubkey(depositorBtcPubkeyRaw);
 
     const vaultProviderBtcPubkey = stripHexPrefix(params.vaultProviderBtcPubkey);
     const vaultKeeperBtcPubkeys = params.vaultKeeperBtcPubkeys.map(stripHexPrefix);
@@ -647,7 +650,7 @@ export class PeginManager {
       peginTxResults.push(peginTxResult);
       psbtsToSign.push(peginInputPsbtResult.psbtHex);
       signOptions.push(
-        createTaprootScriptPathSignOptions(depositorBtcPubkey, 1),
+        createTaprootScriptPathSignOptions(depositorBtcPubkeyRaw, 1),
       );
     }
 

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
@@ -7,11 +7,12 @@
  * @remarks
  * PeginManager handles the peg-in flow:
  * 1. **preparePegin()** - Build Pre-PegIn HTLC, fund it, sign PegIn input
- * 2. **registerPeginOnChain()** - Submit to Ethereum contract with PoP
- * 3. *(Use {@link PayoutManager} for payout authorization signing)*
+ * 2. **signProofOfPossession()** - Sign BIP-322 PoP (one per deposit session)
+ * 3. **registerPeginOnChain()** - Submit to Ethereum contract with PoP
  * 4. **signAndBroadcast()** - Sign and broadcast Pre-PegIn tx to Bitcoin network
+ * 5. *(Use {@link PayoutManager} for payout authorization signing)*
  *
- * @see {@link PayoutManager} - For Step 3: sign payout transactions
+ * @see {@link PayoutManager} - For Step 5: sign payout transactions
  * @see {@link buildPrePeginPsbt} - Lower-level primitive used internally
  *
  * @module managers/PeginManager
@@ -24,6 +25,7 @@ import {
   createPublicClient,
   encodeFunctionData,
   http,
+  isAddressEqual,
   zeroAddress,
   type Address,
   type Chain,
@@ -48,6 +50,7 @@ import {
 import {
   ensureHexPrefix,
   isAddressFromPublicKey,
+  processPublicKeyToXOnly,
   stripHexPrefix,
 } from "../primitives/utils/bitcoin";
 import {
@@ -63,6 +66,58 @@ import {
 
 /** Referral code sent with pegin registration — 0 means no referral. */
 const NO_REFERRAL_CODE = 0;
+
+const HEX_SIGNATURE_REGEX = /^0x[0-9a-f]+$/i;
+const UNPREFIXED_HEX_SIGNATURE_REGEX = /^[0-9a-f]+$/i;
+const BASE64_SIGNATURE_REGEX = /^[A-Za-z0-9+/]+={0,2}$/;
+
+function normalizeXOnlyPubkey(raw: unknown): string {
+  if (typeof raw !== "string" || raw.length === 0) {
+    throw new Error("BTC wallet returned empty public key");
+  }
+  // Lowercase so case-sensitive equality checks downstream don't fail
+  // on uppercase wallet output (processPublicKeyToXOnly passes a 64-char
+  // input through unchanged).
+  return processPublicKeyToXOnly(raw).toLowerCase();
+}
+
+/**
+ * Normalize a wallet-returned BIP-322 signature into 0x-prefixed hex.
+ * Accepts 0x-hex, unprefixed hex, or canonical standard base64.
+ */
+function normalizePopSignature(raw: unknown): Hex {
+  if (typeof raw !== "string" || raw.length === 0) {
+    throw new Error("BTC wallet returned empty BIP-322 signature");
+  }
+
+  if (raw.startsWith("0x") || raw.startsWith("0X")) {
+    if (!HEX_SIGNATURE_REGEX.test(raw) || raw.length < 4 || raw.length % 2 !== 0) {
+      throw new Error("BTC wallet returned malformed hex BIP-322 signature");
+    }
+    return raw.toLowerCase() as Hex;
+  }
+
+  // Prefer hex when the input could be either: every hex char is also a
+  // valid base64 char, so the base64 branch alone would silently misdecode
+  // a wallet returning "deadbeef" instead of "0xdeadbeef".
+  if (UNPREFIXED_HEX_SIGNATURE_REGEX.test(raw)) {
+    if (raw.length % 2 !== 0) {
+      throw new Error("BTC wallet returned malformed hex BIP-322 signature");
+    }
+    return `0x${raw.toLowerCase()}` as Hex;
+  }
+
+  if (!BASE64_SIGNATURE_REGEX.test(raw) || raw.length % 4 !== 0) {
+    throw new Error("BTC wallet returned malformed base64 BIP-322 signature");
+  }
+  const bytes = Buffer.from(raw, "base64");
+  // Round-trip to reject non-canonical base64 (e.g. "AB==" decodes but
+  // re-encodes to "AA==").
+  if (bytes.length === 0 || bytes.toString("base64") !== raw) {
+    throw new Error("BTC wallet returned malformed base64 BIP-322 signature");
+  }
+  return `0x${bytes.toString("hex")}` as Hex;
+}
 
 /**
  * Configuration for the PeginManager.
@@ -207,12 +262,14 @@ export interface PerVaultPeginData {
 }
 
 export interface PreparePeginResult {
-  /** Funded but unsigned Pre-PegIn transaction hex */
+  /**
+   * Funded, pre-witness Pre-PegIn tx hex. Pass this for register calls'
+   * `unsignedPrePeginTx` — despite the contract-side name, the registry
+   * stores the funded form so indexers can rebuild refund PSBTs.
+   */
   fundedPrePeginTxHex: string;
   /** Funded Pre-PegIn transaction ID */
   prePeginTxid: string;
-  /** Unfunded Pre-PegIn transaction hex (for contract DA submission) */
-  unsignedPrePeginTxHex: string;
   /** Per-vault PegIn data — one entry per hashlock/amount */
   perVault: PerVaultPeginData[];
   /** UTXOs selected to fund the Pre-PegIn transaction */
@@ -250,17 +307,28 @@ export interface SignAndBroadcastParams {
 }
 
 /**
+ * BIP-322 BTC Proof-of-Possession binding a depositor's BTC key to their
+ * Ethereum account. Produced by {@link PeginManager.signProofOfPossession}
+ * and reusable across every register call in the same session — the
+ * embedded identities are re-checked at register time.
+ */
+export interface PopSignature {
+  /** BIP-322 signature over the PoP message (0x-prefixed hex). */
+  btcPopSignature: Hex;
+  /** Ethereum address the PoP was signed for. */
+  depositorEthAddress: Address;
+  /** BTC x-only public key (64-char hex, no 0x prefix). */
+  depositorBtcPubkey: string;
+}
+
+/**
  * Parameters for registering a peg-in on Ethereum.
  */
 export interface RegisterPeginParams {
   /**
-   * Depositor's BTC public key (x-only, 64-char hex).
-   * Can be provided with or without "0x" prefix.
-   */
-  depositorBtcPubkey: string;
-
-  /**
-   * Unsigned Pre-PegIn transaction hex (submitted to contract for data availability).
+   * Funded, pre-witness Pre-PegIn tx hex — pass
+   * {@link PreparePeginResult.fundedPrePeginTxHex}. The contract-side
+   * parameter is named `unsignedPrePeginTx` but it stores the funded form.
    */
   unsignedPrePeginTx: string;
 
@@ -280,11 +348,6 @@ export interface RegisterPeginParams {
   hashlock: Hex;
 
   /**
-   * Optional callback invoked after PoP signing completes but before ETH transaction.
-   */
-  onPopSigned?: () => void | Promise<void>;
-
-  /**
    * Depositor's BTC payout address (e.g. bc1p..., bc1q...).
    * Converted to scriptPubKey internally via bitcoinjs-lib.
    *
@@ -296,12 +359,8 @@ export interface RegisterPeginParams {
   /** Keccak256 hash of the depositor's WOTS public key (bytes32) */
   depositorWotsPkHash: Hex;
 
-  /**
-   * Pre-signed BTC PoP signature (hex with 0x prefix).
-   * When provided, the BTC wallet signing step is skipped and this signature is used directly.
-   * Useful for multi-vault deposits where PoP only needs to be signed once.
-   */
-  preSignedBtcPopSignature?: Hex;
+  /** Proof of possession from {@link PeginManager.signProofOfPossession}. */
+  popSignature: PopSignature;
 
   /**
    * Zero-based index of the HTLC output in the Pre-PegIn transaction that
@@ -331,28 +390,19 @@ export interface RegisterPeginResult {
    * Used for VP RPC operations which key on the BTC transaction ID.
    */
   peginTxHash: Hex;
-
-  /**
-   * The BTC PoP signature used for this registration (hex with 0x prefix).
-   * Returned so callers can reuse it for subsequent pegins without re-signing.
-   */
-  btcPopSignature: Hex;
 }
 
 /**
  * Single request in a batch pegin registration.
- * All requests in a batch share the same vault provider and depositor.
+ * All requests in a batch share the same vault provider, depositor BTC
+ * pubkey, and Pre-PegIn transaction.
  */
 export interface BatchPeginRequestItem {
-  /** Depositor's BTC public key (x-only, 64-char hex or with 0x prefix) */
-  depositorBtcPubkey: string;
-  /** Unsigned Pre-PegIn tx hex (same for all vaults in batch) */
-  unsignedPrePeginTx: string;
   /** Signed PegIn tx hex for this vault */
   depositorSignedPeginTx: string;
   /** SHA256 hashlock for HTLC activation (bytes32 hex) */
   hashlock: Hex;
-  /** Zero-based HTLC output index in the Pre-PegIn tx */
+  /** Zero-based HTLC output index in the Pre-PegIn tx (unique per request) */
   htlcVout: number;
   /** Depositor's BTC payout address (required — funds are sent here on payout) */
   depositorPayoutBtcAddress: string;
@@ -366,12 +416,15 @@ export interface BatchPeginRequestItem {
 export interface RegisterPeginBatchParams {
   /** Vault provider address (shared across all vaults in batch) */
   vaultProvider: Address;
+  /**
+   * Funded, pre-witness Pre-PegIn tx hex — shared across every request in
+   * the batch. See {@link RegisterPeginParams.unsignedPrePeginTx}.
+   */
+  unsignedPrePeginTx: string;
   /** Individual pegin requests (one per vault) */
   requests: BatchPeginRequestItem[];
-  /** Pre-signed BTC PoP signature (signed once, reused for all vaults) */
-  preSignedBtcPopSignature?: Hex;
-  /** Called after PoP is signed (before ETH tx) */
-  onPopSigned?: () => void | Promise<void>;
+  /** Proof of possession from {@link PeginManager.signProofOfPossession}. */
+  popSignature: PopSignature;
 }
 
 /**
@@ -392,8 +445,6 @@ export interface RegisterPeginBatchResult {
   ethTxHash: Hex;
   /** Per-vault results (same order as input requests) */
   vaults: BatchPeginResultItem[];
-  /** The BTC PoP signature used (for reference) */
-  btcPopSignature: Hex;
 }
 
 
@@ -426,17 +477,19 @@ function resolveUtxoInfo(
  * by coordinating between SDK primitives, utilities, and wallet interfaces.
  *
  * @remarks
- * The complete peg-in flow consists of 4 steps:
+ * The complete peg-in flow consists of 5 steps:
  *
  * | Step | Method | Description |
  * |------|--------|-------------|
  * | 1 | {@link preparePegin} | Build Pre-PegIn HTLC, fund it, sign PegIn input |
- * | 2 | {@link registerPeginOnChain} | Submit to Ethereum contract with PoP |
- * | 3 | {@link PayoutManager} | Sign BOTH payout authorizations |
+ * | 2 | {@link signProofOfPossession} | Sign BIP-322 PoP (one per deposit session) |
+ * | 3 | {@link registerPeginOnChain} | Submit to Ethereum contract |
  * | 4 | {@link signAndBroadcast} | Sign and broadcast Pre-PegIn tx to Bitcoin network |
+ * | 5 | {@link PayoutManager} | Sign BOTH payout authorizations |
  *
- * **Important:** Step 3 uses {@link PayoutManager}, not this class. After step 2,
- * the vault provider prepares 3 transactions per claimer:
+ * **Important:** Step 5 uses {@link PayoutManager}, not this class. After
+ * step 4, the vault provider observes the broadcast Pre-PegIn and prepares
+ * 3 transactions per claimer:
  * - `claim_tx` - Claim transaction
  * - `assert_tx` - Assert transaction
  * - `payout_tx` - Payout transaction
@@ -444,9 +497,11 @@ function resolveUtxoInfo(
  * You must sign the Payout transaction for each claimer:
  * - {@link PayoutManager.signPayoutTransaction} - uses assert_tx as input reference
  *
- * Submit all signatures to the vault provider before proceeding to step 4.
+ * Submit all signatures to the vault provider to drive the contract to
+ * `VERIFIED` (and then activate by revealing the HTLC secret, which is a
+ * services-layer step outside this manager).
  *
- * @see {@link PayoutManager} - Required for Step 3 (payout authorization)
+ * @see {@link PayoutManager} - Required for Step 5 (payout authorization)
  * @see {@link buildPrePeginPsbt} - Lower-level primitive for custom implementations
  * @see {@link https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/docs/quickstart/managers.md | Managers Quickstart}
  */
@@ -493,12 +548,9 @@ export class PeginManager {
     params: PreparePeginParams,
   ): Promise<PreparePeginResult> {
     // Step 1: Get depositor BTC public key from wallet
-    const depositorBtcPubkeyRaw = await this.config.btcWallet.getPublicKeyHex();
-    // Convert 33-byte compressed (66 chars) to 32-byte x-only (64 chars) if needed
-    const depositorBtcPubkey =
-      depositorBtcPubkeyRaw.length === 66
-        ? depositorBtcPubkeyRaw.slice(2)
-        : depositorBtcPubkeyRaw;
+    const depositorBtcPubkey = normalizeXOnlyPubkey(
+      await this.config.btcWallet.getPublicKeyHex(),
+    );
 
     const vaultProviderBtcPubkey = stripHexPrefix(params.vaultProviderBtcPubkey);
     const vaultKeeperBtcPubkeys = params.vaultKeeperBtcPubkeys.map(stripHexPrefix);
@@ -586,7 +638,7 @@ export class PeginManager {
       peginTxResults.push(peginTxResult);
       psbtsToSign.push(peginInputPsbtResult.psbtHex);
       signOptions.push(
-        createTaprootScriptPathSignOptions(depositorBtcPubkeyRaw, 1),
+        createTaprootScriptPathSignOptions(depositorBtcPubkey, 1),
       );
     }
 
@@ -619,7 +671,6 @@ export class PeginManager {
     return {
       fundedPrePeginTxHex,
       prePeginTxid,
-      unsignedPrePeginTxHex: prePeginResult.psbtHex,
       perVault,
       selectedUTXOs: utxoSelection.selectedUTXOs,
       fee: utxoSelection.fee,
@@ -696,22 +747,10 @@ export class PeginManager {
     psbt.setVersion(tx.version);
     psbt.setLocktime(tx.locktime);
 
-    // Strip 0x prefix if present before converting to Buffer
-    const cleanPubkey = depositorBtcPubkey.startsWith("0x")
-      ? depositorBtcPubkey.slice(2)
-      : depositorBtcPubkey;
-    // Validate x-only pubkey length and format (32 bytes = 64 hex chars)
-    if (cleanPubkey.length !== 64 || !/^[0-9a-fA-F]+$/.test(cleanPubkey)) {
-      throw new Error(
-        "Invalid depositorBtcPubkey: expected 64 hex characters (x-only pubkey)",
-      );
-    }
-    const publicKeyNoCoord = Buffer.from(cleanPubkey, "hex");
-    if (publicKeyNoCoord.length !== 32) {
-      throw new Error(
-        `Invalid depositorBtcPubkey length: expected 32 bytes, got ${publicKeyNoCoord.length}`,
-      );
-    }
+    const publicKeyNoCoord = Buffer.from(
+      normalizeXOnlyPubkey(depositorBtcPubkey),
+      "hex",
+    );
     const apiUrl = this.config.mempoolApiUrl;
 
     // Resolve prevout data for each input (local cache or mempool API)
@@ -813,53 +852,59 @@ export class PeginManager {
    * Registers a peg-in on Ethereum by calling the BTCVaultRegistry contract.
    *
    * This method:
-   * 1. Gets depositor ETH address from wallet
-   * 2. Creates proof of possession (BTC signature of ETH address)
-   * 3. Checks if vault already exists (pre-flight check)
-   * 4. Encodes the contract call using viem
-   * 5. Estimates gas (catches contract errors early with proper revert reasons)
-   * 6. Sends transaction with pre-estimated gas via ethWallet.sendTransaction()
+   * 1. Re-verifies the PopSignature against the currently connected ETH
+   *    and BTC wallets — refuses to proceed if either has changed
+   * 2. Derives vault ID and checks if it already exists (pre-flight)
+   * 3. Encodes the contract call using viem
+   * 4. Estimates gas (catches contract errors early with proper revert
+   *    reasons)
+   * 5. Sends transaction with pre-estimated gas via
+   *    ethWallet.sendTransaction()
    *
-   * @param params - Registration parameters including BTC pubkey and unsigned tx
+   * The PopSignature must be obtained via
+   * {@link signProofOfPossession} before this call.
+   *
+   * @param params - Registration parameters including the PopSignature
+   *                 and the prepared Pre-PegIn / PegIn transactions
    * @returns Result containing Ethereum transaction hash and vault ID
-   * @throws Error if signing or transaction fails
-   * @throws Error if vault already exists
-   * @throws Error if contract simulation fails (e.g., invalid signature, unauthorized)
+   * @throws Error if the PopSignature does not match the connected wallets
+   * @throws Error if the vault already exists
+   * @throws Error if contract simulation fails (e.g., invalid signature,
+   *         unauthorized)
    */
   async registerPeginOnChain(
     params: RegisterPeginParams,
   ): Promise<RegisterPeginResult> {
     const {
-      depositorBtcPubkey,
       unsignedPrePeginTx,
       depositorSignedPeginTx,
       vaultProvider,
       hashlock,
       htlcVout,
-      onPopSigned,
       depositorPayoutBtcAddress,
       depositorWotsPkHash,
-      preSignedBtcPopSignature,
+      popSignature,
     } = params;
 
-    // Step 1: Get depositor ETH address (from wallet account)
+    // Step 1: Re-verify the PoP artifact against the currently connected
+    // wallets so a mid-flow account/wallet switch fails here instead of
+    // surfacing downstream as an opaque contract revert.
     if (!this.config.ethWallet.account) {
       throw new Error("Ethereum wallet account not found");
     }
     const depositorEthAddress = this.config.ethWallet.account.address;
-
-    // Step 2: Create proof of possession (or reuse pre-signed one)
-    const btcPopSignature = await this.resolvePopSignature(
-      depositorEthAddress,
-      preSignedBtcPopSignature,
-    );
-
-    if (onPopSigned) {
-      await onPopSigned();
+    if (!isAddressEqual(popSignature.depositorEthAddress, depositorEthAddress)) {
+      throw new Error(
+        `Proof of possession was signed for ${popSignature.depositorEthAddress} ` +
+          `but the Ethereum wallet is currently connected to ${depositorEthAddress}. ` +
+          `Reconnect the original account or call signProofOfPossession() again.`,
+      );
     }
+    await this.assertPopMatchesBtcWallet(popSignature);
+    const btcPopSignature = popSignature.btcPopSignature;
 
-    // Step 3: Format parameters for contract call
-    const depositorBtcPubkeyHex = ensureHexPrefix(depositorBtcPubkey);
+    // Step 2: Format parameters for contract call
+    const depositorBtcPubkeyHex = ensureHexPrefix(popSignature.depositorBtcPubkey);
     const unsignedPrePeginTxHex = ensureHexPrefix(unsignedPrePeginTx);
     const depositorSignedPeginTxHex = ensureHexPrefix(depositorSignedPeginTx);
 
@@ -867,7 +912,7 @@ export class PeginManager {
       depositorPayoutBtcAddress,
     );
 
-    // Step 4: Calculate pegin tx hash and derive vault ID, then check if it already exists
+    // Step 3: Calculate pegin tx hash and derive vault ID, then check if it already exists
     const peginTxHash = calculateBtcTxHash(depositorSignedPeginTxHex);
     const derivedVaultIdHex = await deriveVaultId(
       stripHexPrefix(peginTxHash),
@@ -884,7 +929,7 @@ export class PeginManager {
       );
     }
 
-    // Step 5: Query required pegin fee from the contract
+    // Step 4: Query required pegin fee from the contract
     const publicClient = createPublicClient({
       chain: this.config.ethChain,
       transport: http(),
@@ -905,7 +950,7 @@ export class PeginManager {
       );
     }
 
-    // Step 6: Encode the contract call data
+    // Step 5: Encode the contract call data
     const callData = encodeFunctionData({
       abi: BTCVaultRegistryABI,
       functionName: "submitPeginRequest",
@@ -923,7 +968,7 @@ export class PeginManager {
       ],
     });
 
-    // Step 7: Estimate gas first to catch contract errors before showing wallet popup
+    // Step 6: Estimate gas first to catch contract errors before showing wallet popup
     // This ensures users see actual contract revert reasons instead of gas errors
     // The gas estimate is then passed to sendTransaction to avoid double estimation
     let gasEstimate: bigint;
@@ -939,7 +984,7 @@ export class PeginManager {
       handleContractError(error); // always throws (return type: never)
     }
 
-    // Step 8: Submit peg-in request to contract (estimation passed)
+    // Step 7: Submit peg-in request to contract (estimation passed)
     let ethTxHash: Hex;
     try {
       // Send transaction with pre-estimated gas to skip internal estimation
@@ -957,7 +1002,7 @@ export class PeginManager {
       handleContractError(error); // always throws (return type: never)
     }
 
-    // Step 9: Wait for transaction receipt and verify it was not reverted
+    // Step 8: Wait for transaction receipt and verify it was not reverted
     const receipt = await publicClient.waitForTransactionReceipt({
       hash: ethTxHash,
       timeout: RECEIPT_TIMEOUT_MS,
@@ -975,7 +1020,6 @@ export class PeginManager {
       ethTxHash: receipt.transactionHash,
       vaultId,
       peginTxHash,
-      btcPopSignature,
     };
   }
 
@@ -992,30 +1036,29 @@ export class PeginManager {
   async registerPeginBatchOnChain(
     params: RegisterPeginBatchParams,
   ): Promise<RegisterPeginBatchResult> {
-    const { vaultProvider, requests, preSignedBtcPopSignature, onPopSigned } =
+    const { vaultProvider, unsignedPrePeginTx, requests, popSignature } =
       params;
 
     if (requests.length === 0) {
       throw new Error("Batch pegin requires at least one request");
     }
 
-    // Step 1: Get depositor ETH address
+    // Step 1: Re-verify the PoP (same reasoning as registerPeginOnChain).
     if (!this.config.ethWallet.account) {
       throw new Error("Ethereum wallet account not found");
     }
     const depositorEthAddress = this.config.ethWallet.account.address;
-
-    // Step 2: Create proof of possession (or reuse pre-signed one)
-    const btcPopSignature = await this.resolvePopSignature(
-      depositorEthAddress,
-      preSignedBtcPopSignature,
-    );
-
-    if (onPopSigned) {
-      await onPopSigned();
+    if (!isAddressEqual(popSignature.depositorEthAddress, depositorEthAddress)) {
+      throw new Error(
+        `Proof of possession was signed for ${popSignature.depositorEthAddress} ` +
+          `but the Ethereum wallet is currently connected to ${depositorEthAddress}. ` +
+          `Reconnect the original account or call signProofOfPossession() again.`,
+      );
     }
+    await this.assertPopMatchesBtcWallet(popSignature);
+    const btcPopSignature = popSignature.btcPopSignature;
 
-    // Step 3: Resolve per-request payout scriptPubKey.
+    // Step 2: Resolve per-request payout scriptPubKey.
     const resolvedPayoutScripts: Hex[] = [];
     for (const req of requests) {
       resolvedPayoutScripts.push(
@@ -1023,7 +1066,7 @@ export class PeginManager {
       );
     }
 
-    // Step 4: Pre-compute vault IDs and check for duplicates
+    // Step 3: Pre-compute vault IDs and check for duplicates
     const vaultResults: BatchPeginResultItem[] = [];
     for (const req of requests) {
       const depositorSignedPeginTxHex = ensureHexPrefix(
@@ -1045,7 +1088,7 @@ export class PeginManager {
       vaultResults.push({ vaultId, peginTxHash });
     }
 
-    // Step 5: Query pegin fee and compute total
+    // Step 4: Query pegin fee and compute total
     const publicClient = createPublicClient({
       chain: this.config.ethChain,
       transport: http(),
@@ -1067,11 +1110,17 @@ export class PeginManager {
     }
     const totalFee = peginFee * BigInt(requests.length);
 
-    // Step 6: Build BatchPeginRequest[] tuple array
+    // Step 5: Build BatchPeginRequest[] tuple array. Depositor BTC pubkey,
+    // PoP, and Pre-PegIn tx hex are shared across the batch (carried on
+    // the top-level params / PopSignature, not per request).
+    const depositorBtcPubkeyHex = ensureHexPrefix(
+      popSignature.depositorBtcPubkey,
+    ) as Hex;
+    const unsignedPrePeginTxHex = ensureHexPrefix(unsignedPrePeginTx) as Hex;
     const batchRequests = requests.map((req, i) => ({
-      depositorBtcPubKey: ensureHexPrefix(req.depositorBtcPubkey) as Hex,
-      btcPopSignature: btcPopSignature as Hex,
-      unsignedPrePeginTx: ensureHexPrefix(req.unsignedPrePeginTx) as Hex,
+      depositorBtcPubKey: depositorBtcPubkeyHex,
+      btcPopSignature,
+      unsignedPrePeginTx: unsignedPrePeginTxHex,
       depositorSignedPeginTx: ensureHexPrefix(
         req.depositorSignedPeginTx,
       ) as Hex,
@@ -1082,14 +1131,14 @@ export class PeginManager {
       depositorWotsPkHash: req.depositorWotsPkHash,
     }));
 
-    // Step 7: Encode batch call data
+    // Step 6: Encode batch call data
     const callData = encodeFunctionData({
       abi: BTCVaultRegistryABI,
       functionName: "submitPeginRequestBatch",
       args: [depositorEthAddress, vaultProvider, batchRequests],
     });
 
-    // Step 8: Estimate gas
+    // Step 7: Estimate gas
     let gasEstimate: bigint;
     try {
       gasEstimate = await publicClient.estimateGas({
@@ -1102,7 +1151,7 @@ export class PeginManager {
       handleContractError(error); // always throws (return type: never)
     }
 
-    // Step 9: Submit batch transaction
+    // Step 8: Submit batch transaction
     let ethTxHash: Hex;
     try {
       ethTxHash = await this.config.ethWallet.sendTransaction({
@@ -1117,7 +1166,7 @@ export class PeginManager {
       handleContractError(error); // always throws (return type: never)
     }
 
-    // Step 10: Wait for receipt
+    // Step 9: Wait for receipt
     const receipt = await publicClient.waitForTransactionReceipt({
       hash: ethTxHash,
       timeout: RECEIPT_TIMEOUT_MS,
@@ -1134,7 +1183,6 @@ export class PeginManager {
     return {
       ethTxHash: receipt.transactionHash,
       vaults: vaultResults,
-      btcPopSignature,
     };
   }
 
@@ -1210,33 +1258,49 @@ export class PeginManager {
   }
 
   /**
-   * Resolve or create a BTC Proof-of-Possession signature.
-   *
-   * Reuses a pre-signed signature when provided (e.g. multi-vault deposits),
-   * otherwise signs a BIP-322 message with the BTC wallet.
+   * Sign a BIP-322 BTC Proof-of-Possession binding the connected BTC
+   * wallet to the connected ETH account for this chain and vault
+   * registry. The returned {@link PopSignature} can be reused across
+   * every register call in the same session.
    */
-  private async resolvePopSignature(
-    depositorEthAddress: Address,
-    preSignedBtcPopSignature?: Hex,
-  ): Promise<Hex> {
-    if (preSignedBtcPopSignature) {
-      return preSignedBtcPopSignature;
+  async signProofOfPossession(): Promise<PopSignature> {
+    if (!this.config.ethWallet.account) {
+      throw new Error("Ethereum wallet account not found");
     }
+    const depositorEthAddress = this.config.ethWallet.account.address;
+
+    const depositorBtcPubkey = normalizeXOnlyPubkey(
+      await this.config.btcWallet.getPublicKeyHex(),
+    );
 
     // Message format matches BTCProofOfPossession.sol buildMessage()
     const verifyingContract = this.config.vaultContracts.btcVaultRegistry;
     const popMessage = `${depositorEthAddress.toLowerCase()}:${this.config.ethChain.id}:pegin:${verifyingContract.toLowerCase()}`;
-    const btcPopSignatureRaw = await this.config.btcWallet.signMessage(
+    const raw = await this.config.btcWallet.signMessage(
       popMessage,
       "bip322-simple",
     );
 
-    // BTC wallets return base64, Ethereum contracts expect hex
-    if (btcPopSignatureRaw.startsWith("0x")) {
-      return btcPopSignatureRaw as Hex;
+    return {
+      btcPopSignature: normalizePopSignature(raw),
+      depositorEthAddress,
+      depositorBtcPubkey,
+    };
+  }
+
+  private async assertPopMatchesBtcWallet(
+    popSignature: PopSignature,
+  ): Promise<void> {
+    const currentBtcPubkey = normalizeXOnlyPubkey(
+      await this.config.btcWallet.getPublicKeyHex(),
+    );
+    if (currentBtcPubkey !== popSignature.depositorBtcPubkey) {
+      throw new Error(
+        `Proof of possession was signed with BTC pubkey ${popSignature.depositorBtcPubkey} ` +
+          `but the BTC wallet is currently connected to ${currentBtcPubkey}. ` +
+          `Reconnect the original wallet or call signProofOfPossession() again.`,
+      );
     }
-    const signatureBytes = Buffer.from(btcPopSignatureRaw, "base64");
-    return `0x${signatureBytes.toString("hex")}` as Hex;
   }
 
   /**

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PeginManager.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PeginManager.test.ts
@@ -228,7 +228,6 @@ describe("PeginManager", () => {
       // Verify result structure
       expect(result).toHaveProperty("fundedPrePeginTxHex");
       expect(result).toHaveProperty("prePeginTxid");
-      expect(result).toHaveProperty("unsignedPrePeginTxHex");
       expect(result).toHaveProperty("perVault");
       expect(result).toHaveProperty("selectedUTXOs");
       expect(result).toHaveProperty("fee");
@@ -505,14 +504,12 @@ describe("PeginManager", () => {
     });
   });
 
-  describe("registerPeginOnChain", () => {
-    it("should call ethWallet.sendTransaction with encoded contract data", async () => {
+  describe("signProofOfPossession", () => {
+    it("returns signature bound to connected ETH and BTC identities", async () => {
       const btcWallet = new MockBitcoinWallet({
         publicKeyHex: TEST_KEYS.DEPOSITOR,
       });
       const ethWallet = new MockEthereumWallet();
-
-      const sendTxSpy = vi.spyOn(ethWallet, "sendTransaction");
       const signMessageSpy = vi.spyOn(btcWallet, "signMessage");
 
       const manager = new PeginManager({
@@ -524,41 +521,19 @@ describe("PeginManager", () => {
         mempoolApiUrl: MEMPOOL_API_URLS.signet,
       });
 
-      const mockUnsignedPrePeginTx = "0100000000010000000000";
+      const pop = await manager.signProofOfPossession();
 
-      const result = await manager.registerPeginOnChain({
-        depositorBtcPubkey: TEST_KEYS.DEPOSITOR,
-        unsignedPrePeginTx: mockUnsignedPrePeginTx,
-        depositorSignedPeginTx: MOCK_DEPOSITOR_SIGNED_PEGIN_TX,
-        vaultProvider: TEST_CONTRACT_ADDRESS,
-        hashlock: MOCK_HASHLOCK,
-        htlcVout: 0,
-        depositorPayoutBtcAddress:
-          "tb1pmfr3p9j00pfxjh0zmgp99y8zftmd3s5pmedqhyptwy6lm87hf5ssk79hv2",
-        depositorWotsPkHash: MOCK_WOTS_PK_HASH,
-      });
-
-      expect(signMessageSpy).toHaveBeenCalled();
-      const signedMessage = signMessageSpy.mock.calls[0][0];
-      expect(signedMessage.toLowerCase()).toContain("0x");
-
-      expect(sendTxSpy).toHaveBeenCalled();
-      const txRequest = sendTxSpy.mock.calls[0][0];
-      expect(txRequest.to).toBe(TEST_CONTRACT_ADDRESS);
-      expect(txRequest.data).toBeDefined();
-      expect(txRequest.data).toContain("0x");
-
-      expect(result).toBeDefined();
-      expect(result.ethTxHash).toBeDefined();
-      expect(result.ethTxHash.startsWith("0x")).toBe(true);
-      expect(result.vaultId).toBeDefined();
-      expect(result.vaultId.startsWith("0x")).toBe(true);
+      expect(signMessageSpy).toHaveBeenCalledTimes(1);
+      expect(signMessageSpy.mock.calls[0][1]).toBe("bip322-simple");
+      expect(pop.depositorBtcPubkey).toBe(TEST_KEYS.DEPOSITOR);
+      expect(pop.depositorEthAddress).toBe(ethWallet.account!.address);
+      expect(pop.btcPopSignature.startsWith("0x")).toBe(true);
+      expect(pop.btcPopSignature).toMatch(/^0x[0-9a-f]+$/);
     });
 
-    it("should handle BTC wallet signing failure", async () => {
+    it("strips 0x prefix from depositor BTC pubkey", async () => {
       const btcWallet = new MockBitcoinWallet({
-        publicKeyHex: TEST_KEYS.DEPOSITOR,
-        shouldFailSigning: true,
+        publicKeyHex: `0x${TEST_KEYS.DEPOSITOR}`,
       });
       const ethWallet = new MockEthereumWallet();
 
@@ -571,9 +546,233 @@ describe("PeginManager", () => {
         mempoolApiUrl: MEMPOOL_API_URLS.signet,
       });
 
+      const pop = await manager.signProofOfPossession();
+      expect(pop.depositorBtcPubkey).toBe(TEST_KEYS.DEPOSITOR);
+    });
+
+    it("passes through hex wallet output unchanged (lowercase)", async () => {
+      const btcWallet = new MockBitcoinWallet({
+        publicKeyHex: TEST_KEYS.DEPOSITOR,
+      });
+      vi.spyOn(btcWallet, "signMessage").mockResolvedValueOnce(
+        "0xDEADBEEF",
+      );
+      const ethWallet = new MockEthereumWallet();
+
+      const manager = new PeginManager({
+        btcNetwork: "signet",
+        btcWallet,
+        ethWallet: ethWallet as any,
+        ethChain: TEST_CHAIN,
+        vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
+        mempoolApiUrl: MEMPOOL_API_URLS.signet,
+      });
+
+      const pop = await manager.signProofOfPossession();
+      expect(pop.btcPopSignature).toBe("0xdeadbeef");
+    });
+
+    it("rejects an empty signature from the wallet", async () => {
+      const btcWallet = new MockBitcoinWallet({
+        publicKeyHex: TEST_KEYS.DEPOSITOR,
+      });
+      vi.spyOn(btcWallet, "signMessage").mockResolvedValueOnce("");
+      const ethWallet = new MockEthereumWallet();
+
+      const manager = new PeginManager({
+        btcNetwork: "signet",
+        btcWallet,
+        ethWallet: ethWallet as any,
+        ethChain: TEST_CHAIN,
+        vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
+        mempoolApiUrl: MEMPOOL_API_URLS.signet,
+      });
+
+      await expect(manager.signProofOfPossession()).rejects.toThrow(
+        /empty/i,
+      );
+    });
+
+    it("rejects a malformed (non-canonical) base64 signature", async () => {
+      const btcWallet = new MockBitcoinWallet({
+        publicKeyHex: TEST_KEYS.DEPOSITOR,
+      });
+      // "AB==" decodes to 1 byte but canonical encoding would be "AA==".
+      vi.spyOn(btcWallet, "signMessage").mockResolvedValueOnce("AB==");
+      const ethWallet = new MockEthereumWallet();
+
+      const manager = new PeginManager({
+        btcNetwork: "signet",
+        btcWallet,
+        ethWallet: ethWallet as any,
+        ethChain: TEST_CHAIN,
+        vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
+        mempoolApiUrl: MEMPOOL_API_URLS.signet,
+      });
+
+      await expect(manager.signProofOfPossession()).rejects.toThrow(
+        /base64/i,
+      );
+    });
+
+    it("rejects a malformed hex signature", async () => {
+      const btcWallet = new MockBitcoinWallet({
+        publicKeyHex: TEST_KEYS.DEPOSITOR,
+      });
+      vi.spyOn(btcWallet, "signMessage").mockResolvedValueOnce("0xZZ");
+      const ethWallet = new MockEthereumWallet();
+
+      const manager = new PeginManager({
+        btcNetwork: "signet",
+        btcWallet,
+        ethWallet: ethWallet as any,
+        ethChain: TEST_CHAIN,
+        vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
+        mempoolApiUrl: MEMPOOL_API_URLS.signet,
+      });
+
+      await expect(manager.signProofOfPossession()).rejects.toThrow(
+        /hex/i,
+      );
+    });
+
+    it("treats unprefixed hex-looking output as hex, not base64", async () => {
+      const btcWallet = new MockBitcoinWallet({
+        publicKeyHex: TEST_KEYS.DEPOSITOR,
+      });
+      vi.spyOn(btcWallet, "signMessage").mockResolvedValueOnce("deadbeef");
+      const ethWallet = new MockEthereumWallet();
+
+      const manager = new PeginManager({
+        btcNetwork: "signet",
+        btcWallet,
+        ethWallet: ethWallet as any,
+        ethChain: TEST_CHAIN,
+        vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
+        mempoolApiUrl: MEMPOOL_API_URLS.signet,
+      });
+
+      const pop = await manager.signProofOfPossession();
+      expect(pop.btcPopSignature).toBe("0xdeadbeef");
+    });
+
+    it("accepts a compressed sec1 pubkey and drops the prefix byte", async () => {
+      const btcWallet = new MockBitcoinWallet({
+        publicKeyHex: `02${TEST_KEYS.DEPOSITOR}`,
+      });
+      const ethWallet = new MockEthereumWallet();
+
+      const manager = new PeginManager({
+        btcNetwork: "signet",
+        btcWallet,
+        ethWallet: ethWallet as any,
+        ethChain: TEST_CHAIN,
+        vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
+        mempoolApiUrl: MEMPOOL_API_URLS.signet,
+      });
+
+      const pop = await manager.signProofOfPossession();
+      expect(pop.depositorBtcPubkey).toBe(TEST_KEYS.DEPOSITOR);
+    });
+
+    it("rejects a BTC pubkey of non-standard length", async () => {
+      // 40 hex chars — neither x-only, compressed, nor uncompressed.
+      const btcWallet = new MockBitcoinWallet({
+        publicKeyHex: "ab".repeat(20),
+      });
+      const ethWallet = new MockEthereumWallet();
+
+      const manager = new PeginManager({
+        btcNetwork: "signet",
+        btcWallet,
+        ethWallet: ethWallet as any,
+        ethChain: TEST_CHAIN,
+        vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
+        mempoolApiUrl: MEMPOOL_API_URLS.signet,
+      });
+
+      await expect(manager.signProofOfPossession()).rejects.toThrow(
+        /public key length/i,
+      );
+    });
+
+    it("throws when ETH wallet has no account", async () => {
+      const btcWallet = new MockBitcoinWallet({
+        publicKeyHex: TEST_KEYS.DEPOSITOR,
+      });
+      const ethWallet = new MockEthereumWallet();
+      (ethWallet as any).account = undefined;
+
+      const manager = new PeginManager({
+        btcNetwork: "signet",
+        btcWallet,
+        ethWallet: ethWallet as any,
+        ethChain: TEST_CHAIN,
+        vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
+        mempoolApiUrl: MEMPOOL_API_URLS.signet,
+      });
+
+      await expect(manager.signProofOfPossession()).rejects.toThrow(
+        /wallet account not found/i,
+      );
+    });
+  });
+
+  describe("registerPeginOnChain", () => {
+    async function makeManagerWithPop() {
+      const btcWallet = new MockBitcoinWallet({
+        publicKeyHex: TEST_KEYS.DEPOSITOR,
+      });
+      const ethWallet = new MockEthereumWallet();
+      const manager = new PeginManager({
+        btcNetwork: "signet",
+        btcWallet,
+        ethWallet: ethWallet as any,
+        ethChain: TEST_CHAIN,
+        vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
+        mempoolApiUrl: MEMPOOL_API_URLS.signet,
+      });
+      const popSignature = await manager.signProofOfPossession();
+      return { manager, btcWallet, ethWallet, popSignature };
+    }
+
+    it("should call ethWallet.sendTransaction with encoded contract data", async () => {
+      const { manager, ethWallet, popSignature } = await makeManagerWithPop();
+      const sendTxSpy = vi.spyOn(ethWallet, "sendTransaction");
+
+      const result = await manager.registerPeginOnChain({
+        unsignedPrePeginTx: "0100000000010000000000",
+        depositorSignedPeginTx: MOCK_DEPOSITOR_SIGNED_PEGIN_TX,
+        vaultProvider: TEST_CONTRACT_ADDRESS,
+        hashlock: MOCK_HASHLOCK,
+        htlcVout: 0,
+        depositorPayoutBtcAddress:
+          "tb1pmfr3p9j00pfxjh0zmgp99y8zftmd3s5pmedqhyptwy6lm87hf5ssk79hv2",
+        depositorWotsPkHash: MOCK_WOTS_PK_HASH,
+        popSignature,
+      });
+
+      expect(sendTxSpy).toHaveBeenCalled();
+      const txRequest = sendTxSpy.mock.calls[0][0];
+      expect(txRequest.to).toBe(TEST_CONTRACT_ADDRESS);
+      expect(txRequest.data).toBeDefined();
+      expect(txRequest.data).toContain("0x");
+
+      expect(result.ethTxHash.startsWith("0x")).toBe(true);
+      expect(result.vaultId.startsWith("0x")).toBe(true);
+      expect(result).not.toHaveProperty("btcPopSignature");
+    });
+
+    it("should throw when ETH wallet is connected to a different account than the PoP", async () => {
+      const { manager, ethWallet, popSignature } = await makeManagerWithPop();
+      // Simulate account switch between signing PoP and submitting.
+      (ethWallet as any).account = {
+        ...ethWallet.account,
+        address: "0x1111111111111111111111111111111111111111",
+      };
+
       await expect(
         manager.registerPeginOnChain({
-          depositorBtcPubkey: TEST_KEYS.DEPOSITOR,
           unsignedPrePeginTx: "0100000000010000000000",
           depositorSignedPeginTx: MOCK_DEPOSITOR_SIGNED_PEGIN_TX,
           vaultProvider: TEST_CONTRACT_ADDRESS,
@@ -582,8 +781,32 @@ describe("PeginManager", () => {
           depositorPayoutBtcAddress:
             "tb1pmfr3p9j00pfxjh0zmgp99y8zftmd3s5pmedqhyptwy6lm87hf5ssk79hv2",
           depositorWotsPkHash: MOCK_WOTS_PK_HASH,
+          popSignature,
         }),
-      ).rejects.toThrow(/Mock signing failed/);
+      ).rejects.toThrow(/Proof of possession/i);
+    });
+
+    it("should throw when BTC wallet is connected to a different pubkey than the PoP", async () => {
+      const { manager, btcWallet, popSignature } =
+        await makeManagerWithPop();
+      // Simulate BTC wallet swap between signing PoP and submitting.
+      vi.spyOn(btcWallet, "getPublicKeyHex").mockResolvedValue(
+        TEST_KEYS.VAULT_KEEPER_1,
+      );
+
+      await expect(
+        manager.registerPeginOnChain({
+          unsignedPrePeginTx: "0100000000010000000000",
+          depositorSignedPeginTx: MOCK_DEPOSITOR_SIGNED_PEGIN_TX,
+          vaultProvider: TEST_CONTRACT_ADDRESS,
+          hashlock: MOCK_HASHLOCK,
+          htlcVout: 0,
+          depositorPayoutBtcAddress:
+            "tb1pmfr3p9j00pfxjh0zmgp99y8zftmd3s5pmedqhyptwy6lm87hf5ssk79hv2",
+          depositorWotsPkHash: MOCK_WOTS_PK_HASH,
+          popSignature,
+        }),
+      ).rejects.toThrow(/BTC wallet is currently connected/i);
     });
 
     it("should handle ETH wallet transaction failure", async () => {
@@ -593,7 +816,6 @@ describe("PeginManager", () => {
       const ethWallet = new MockEthereumWallet({
         shouldFailOperations: true,
       });
-
       const manager = new PeginManager({
         btcNetwork: "signet",
         btcWallet,
@@ -602,10 +824,12 @@ describe("PeginManager", () => {
         vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
         mempoolApiUrl: MEMPOOL_API_URLS.signet,
       });
+      // Produce popSignature while the wallet is still healthy for signing;
+      // the mock only fails ETH ops, not BTC signing.
+      const popSignature = await manager.signProofOfPossession();
 
       await expect(
         manager.registerPeginOnChain({
-          depositorBtcPubkey: TEST_KEYS.DEPOSITOR,
           unsignedPrePeginTx: "0100000000010000000000",
           depositorSignedPeginTx: MOCK_DEPOSITOR_SIGNED_PEGIN_TX,
           vaultProvider: TEST_CONTRACT_ADDRESS,
@@ -614,28 +838,16 @@ describe("PeginManager", () => {
           depositorPayoutBtcAddress:
             "tb1pmfr3p9j00pfxjh0zmgp99y8zftmd3s5pmedqhyptwy6lm87hf5ssk79hv2",
           depositorWotsPkHash: MOCK_WOTS_PK_HASH,
+          popSignature,
         }),
       ).rejects.toThrow(/Mock transaction failed/);
     });
 
     it("should handle hex-prefixed and non-prefixed inputs", async () => {
-      const btcWallet = new MockBitcoinWallet({
-        publicKeyHex: TEST_KEYS.DEPOSITOR,
-      });
-      const ethWallet = new MockEthereumWallet();
+      const { manager, ethWallet, popSignature } = await makeManagerWithPop();
       const sendTxSpy = vi.spyOn(ethWallet, "sendTransaction");
 
-      const manager = new PeginManager({
-        btcNetwork: "signet",
-        btcWallet,
-        ethWallet: ethWallet as any,
-        ethChain: TEST_CHAIN,
-        vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
-        mempoolApiUrl: MEMPOOL_API_URLS.signet,
-      });
-
       await manager.registerPeginOnChain({
-        depositorBtcPubkey: `0x${TEST_KEYS.DEPOSITOR}`,
         unsignedPrePeginTx: "0x0100000000010000000000",
         depositorSignedPeginTx: `0x${MOCK_DEPOSITOR_SIGNED_PEGIN_TX}`,
         vaultProvider: TEST_CONTRACT_ADDRESS,
@@ -644,13 +856,12 @@ describe("PeginManager", () => {
         depositorPayoutBtcAddress:
           "tb1pmfr3p9j00pfxjh0zmgp99y8zftmd3s5pmedqhyptwy6lm87hf5ssk79hv2",
         depositorWotsPkHash: MOCK_WOTS_PK_HASH,
+        popSignature,
       });
-
       expect(sendTxSpy).toHaveBeenCalled();
 
       sendTxSpy.mockClear();
       await manager.registerPeginOnChain({
-        depositorBtcPubkey: TEST_KEYS.DEPOSITOR,
         unsignedPrePeginTx: "0100000000010000000000",
         depositorSignedPeginTx: MOCK_DEPOSITOR_SIGNED_PEGIN_TX,
         vaultProvider: TEST_CONTRACT_ADDRESS,
@@ -659,8 +870,8 @@ describe("PeginManager", () => {
         depositorPayoutBtcAddress:
           "tb1pmfr3p9j00pfxjh0zmgp99y8zftmd3s5pmedqhyptwy6lm87hf5ssk79hv2",
         depositorWotsPkHash: MOCK_WOTS_PK_HASH,
+        popSignature,
       });
-
       expect(sendTxSpy).toHaveBeenCalled();
     });
 
@@ -672,17 +883,12 @@ describe("PeginManager", () => {
         .fn()
         .mockImplementation(({ functionName }: { functionName: string }) => {
           if (functionName === "getPegInFee") return Promise.resolve(0n);
-          // getBtcVaultBasicInfo — return tuple with zero depositor (vault doesn't exist)
           return Promise.resolve([viem.zeroAddress]);
         });
 
-      // First call: checkVaultExists (default behavior)
       mockedCreatePublicClient.mockReturnValueOnce({
         readContract: defaultReadContract,
       } as any);
-
-      // Second call: the main publicClient in registerPeginOnChain
-      // with waitForTransactionReceipt returning "reverted"
       mockedCreatePublicClient.mockReturnValueOnce({
         estimateGas: vi.fn().mockResolvedValue(100000n),
         waitForTransactionReceipt: vi.fn().mockResolvedValue({
@@ -692,23 +898,10 @@ describe("PeginManager", () => {
         readContract: defaultReadContract,
       } as any);
 
-      const btcWallet = new MockBitcoinWallet({
-        publicKeyHex: TEST_KEYS.DEPOSITOR,
-      });
-      const ethWallet = new MockEthereumWallet();
-
-      const manager = new PeginManager({
-        btcNetwork: "signet",
-        btcWallet,
-        ethWallet: ethWallet as any,
-        ethChain: TEST_CHAIN,
-        vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
-        mempoolApiUrl: MEMPOOL_API_URLS.signet,
-      });
+      const { manager, popSignature } = await makeManagerWithPop();
 
       await expect(
         manager.registerPeginOnChain({
-          depositorBtcPubkey: TEST_KEYS.DEPOSITOR,
           unsignedPrePeginTx: "0100000000010000000000",
           depositorSignedPeginTx: MOCK_DEPOSITOR_SIGNED_PEGIN_TX,
           vaultProvider: TEST_CONTRACT_ADDRESS,
@@ -717,9 +910,140 @@ describe("PeginManager", () => {
           depositorPayoutBtcAddress:
             "tb1pmfr3p9j00pfxjh0zmgp99y8zftmd3s5pmedqhyptwy6lm87hf5ssk79hv2",
           depositorWotsPkHash: MOCK_WOTS_PK_HASH,
+          popSignature,
         }),
       ).rejects.toThrow(/Transaction reverted/);
     });
+  });
+
+  describe("registerPeginBatchOnChain", () => {
+    const BASE_UNSIGNED_PRE_PEGIN = "0100000000010000000000";
+    const baseRequest = {
+      depositorSignedPeginTx: MOCK_DEPOSITOR_SIGNED_PEGIN_TX,
+      hashlock: MOCK_HASHLOCK,
+      depositorPayoutBtcAddress:
+        "tb1pmfr3p9j00pfxjh0zmgp99y8zftmd3s5pmedqhyptwy6lm87hf5ssk79hv2",
+      depositorWotsPkHash: MOCK_WOTS_PK_HASH,
+    } as const;
+
+    it("rejects a batch when ETH wallet switches after PoP was signed", async () => {
+      const btcWallet = new MockBitcoinWallet({
+        publicKeyHex: TEST_KEYS.DEPOSITOR,
+      });
+      const ethWallet = new MockEthereumWallet();
+      const manager = new PeginManager({
+        btcNetwork: "signet",
+        btcWallet,
+        ethWallet: ethWallet as any,
+        ethChain: TEST_CHAIN,
+        vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
+        mempoolApiUrl: MEMPOOL_API_URLS.signet,
+      });
+      const popSignature = await manager.signProofOfPossession();
+
+      (ethWallet as any).account = {
+        ...ethWallet.account,
+        address: "0x1111111111111111111111111111111111111111",
+      };
+
+      await expect(
+        manager.registerPeginBatchOnChain({
+          vaultProvider: TEST_CONTRACT_ADDRESS,
+          unsignedPrePeginTx: BASE_UNSIGNED_PRE_PEGIN,
+          popSignature,
+          requests: [
+            { ...baseRequest, htlcVout: 0, depositorSignedPeginTx: "aa" },
+            {
+              ...baseRequest,
+              htlcVout: 1,
+              depositorSignedPeginTx: "bb",
+              hashlock: MOCK_HASHLOCK_ALT,
+            },
+          ],
+        }),
+      ).rejects.toThrow(/Proof of possession/i);
+    });
+
+    it("rejects a batch when BTC wallet switches after PoP was signed", async () => {
+      const btcWallet = new MockBitcoinWallet({
+        publicKeyHex: TEST_KEYS.DEPOSITOR,
+      });
+      const ethWallet = new MockEthereumWallet();
+      const manager = new PeginManager({
+        btcNetwork: "signet",
+        btcWallet,
+        ethWallet: ethWallet as any,
+        ethChain: TEST_CHAIN,
+        vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
+        mempoolApiUrl: MEMPOOL_API_URLS.signet,
+      });
+      const popSignature = await manager.signProofOfPossession();
+
+      vi.spyOn(btcWallet, "getPublicKeyHex").mockResolvedValue(
+        TEST_KEYS.VAULT_KEEPER_1,
+      );
+
+      await expect(
+        manager.registerPeginBatchOnChain({
+          vaultProvider: TEST_CONTRACT_ADDRESS,
+          unsignedPrePeginTx: BASE_UNSIGNED_PRE_PEGIN,
+          popSignature,
+          requests: [
+            { ...baseRequest, htlcVout: 0, depositorSignedPeginTx: "aa" },
+            {
+              ...baseRequest,
+              htlcVout: 1,
+              depositorSignedPeginTx: "bb",
+              hashlock: MOCK_HASHLOCK_ALT,
+            },
+          ],
+        }),
+      ).rejects.toThrow(/BTC wallet is currently connected/i);
+    });
+
+    const MOCK_HASHLOCK_ALT = `0x${"ef".repeat(32)}` as `0x${string}`;
+
+    it("submits submitPeginRequestBatch encoding PoP + each request", async () => {
+      const btcWallet = new MockBitcoinWallet({
+        publicKeyHex: TEST_KEYS.DEPOSITOR,
+      });
+      const ethWallet = new MockEthereumWallet();
+      const sendTxSpy = vi.spyOn(ethWallet, "sendTransaction");
+      const manager = new PeginManager({
+        btcNetwork: "signet",
+        btcWallet,
+        ethWallet: ethWallet as any,
+        ethChain: TEST_CHAIN,
+        vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
+        mempoolApiUrl: MEMPOOL_API_URLS.signet,
+      });
+      const popSignature = await manager.signProofOfPossession();
+
+      const result = await manager.registerPeginBatchOnChain({
+        vaultProvider: TEST_CONTRACT_ADDRESS,
+        unsignedPrePeginTx: BASE_UNSIGNED_PRE_PEGIN,
+        popSignature,
+        requests: [
+          { ...baseRequest, htlcVout: 0, depositorSignedPeginTx: "aa" },
+          {
+            ...baseRequest,
+            htlcVout: 1,
+            depositorSignedPeginTx: "bb",
+            hashlock: MOCK_HASHLOCK_ALT,
+          },
+        ],
+      });
+
+      expect(result).not.toHaveProperty("btcPopSignature");
+      expect(result.vaults).toHaveLength(2);
+
+      expect(sendTxSpy).toHaveBeenCalledTimes(1);
+      const sentData = sendTxSpy.mock.calls[0][0].data as string;
+      expect(sentData).toContain(popSignature.btcPopSignature.slice(2));
+      // Depositor BTC pubkey comes from PopSignature, not per-request.
+      expect(sentData).toContain(popSignature.depositorBtcPubkey);
+    });
+
   });
 
   describe("signAndBroadcast", () => {

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PeginManager.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PeginManager.test.ts
@@ -205,6 +205,37 @@ describe("PeginManager", () => {
   });
 
   describe("preparePegin", () => {
+    it("passes the wallet's raw (compressed) pubkey to signPsbts", async () => {
+      // Regression: taproot signPsbt expects the wallet's native format
+      // on signInputs[].publicKey (UniSat/OKX/OneKey reject x-only with
+      // "invalid public key in toSignInput").
+      const compressedPubkey = `02${TEST_KEYS.DEPOSITOR}`;
+      const btcWallet = new MockBitcoinWallet({
+        publicKeyHex: compressedPubkey,
+      });
+      const ethWallet = new MockEthereumWallet();
+      const signPsbtsSpy = vi.spyOn(btcWallet, "signPsbts");
+
+      const manager = new PeginManager({
+        btcNetwork: "signet",
+        btcWallet,
+        ethWallet: ethWallet as any,
+        ethChain: TEST_CHAIN,
+        vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
+        mempoolApiUrl: MEMPOOL_API_URLS.signet,
+      });
+
+      await manager.preparePegin({
+        amounts: [TEST_AMOUNTS.PEGIN],
+        ...BASE_PREPARE_PEGIN_PARAMS,
+      });
+
+      expect(signPsbtsSpy).toHaveBeenCalled();
+      const signOptions = signPsbtsSpy.mock.calls[0][1];
+      const publicKey = signOptions?.[0]?.signInputs?.[0]?.publicKey;
+      expect(publicKey).toBe(compressedPubkey);
+    });
+
     it("should prepare a pegin with valid params", async () => {
       const btcWallet = new MockBitcoinWallet({
         publicKeyHex: TEST_KEYS.DEPOSITOR,

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/index.ts
@@ -2,7 +2,7 @@
  * @packageDocumentation
  *
  * Wallet-owning orchestration for the vault lifecycle. A vault goes from creation
- * to `ACTIVE` through five phases — {@link https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/docs/quickstart/managers.md | Managers Quickstart}
+ * to `ACTIVE` through six phases — {@link https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/docs/quickstart/managers.md | Managers Quickstart}
  * walks through them. A vault at `VERIFIED` is not done: the depositor must
  * reveal the HTLC secret via `activateVault()` (services layer) or the vault
  * expires.
@@ -10,10 +10,11 @@
  * | # | Phase | SDK entry point | Contract status after |
  * |---|-------|-----------------|-----------------------|
  * | 1 | Prepare Pre-PegIn + PegIn txs | `PeginManager.preparePegin()` | n/a (off-chain) |
- * | 2 | Register on Ethereum | `PeginManager.registerPeginOnChain()` | `PENDING` |
- * | 3 | Broadcast Pre-PegIn on Bitcoin | `PeginManager.signAndBroadcast()` | still `PENDING` until VP observes the tx |
- * | 4 | Sign payout authorisations | `pollAndSignPayouts()` (services, delegates to `PayoutManager`) | `PENDING` → `VERIFIED` |
- * | 5 | Activate by revealing HTLC secret | `activateVault()` (services) | `VERIFIED` → `ACTIVE` |
+ * | 2 | Sign BTC proof-of-possession | `PeginManager.signProofOfPossession()` | n/a (off-chain, once per session) |
+ * | 3 | Register on Ethereum | `PeginManager.registerPeginOnChain()` | `PENDING` |
+ * | 4 | Broadcast Pre-PegIn on Bitcoin | `PeginManager.signAndBroadcast()` | still `PENDING` until VP observes the tx |
+ * | 5 | Sign payout authorisations | `pollAndSignPayouts()` (services, delegates to `PayoutManager`) | `PENDING` → `VERIFIED` |
+ * | 6 | Activate by revealing HTLC secret | `activateVault()` (services) | `VERIFIED` → `ACTIVE` |
  *
  * Optional exit after the CSV timelock expires: `buildAndBroadcastRefund()` (services).
  *
@@ -22,6 +23,7 @@
 
 export { PeginManager } from "./PeginManager";
 export type {
+  PopSignature,
   PreparePeginResult,
   PreparePeginParams,
   PeginManagerConfig,

--- a/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts
@@ -16,7 +16,10 @@ import type { Address, Hex } from "viem";
 
 import type { SignPsbtOptions } from "../../../../shared/wallets/interfaces/BitcoinWallet";
 import { buildRefundPsbt } from "../../primitives/psbt/refund";
-import { stripHexPrefix } from "../../primitives/utils/bitcoin";
+import {
+  processPublicKeyToXOnly,
+  stripHexPrefix,
+} from "../../primitives/utils/bitcoin";
 import { createTaprootScriptPathSignOptions } from "../../utils/signing";
 
 import { BIP68NotMatureError } from "./errors";
@@ -304,9 +307,16 @@ export async function buildAndBroadcastRefund<
   const refundFee = BigInt(Math.ceil(feeRate * REFUND_VSIZE));
   signal?.throwIfAborted();
 
+  // `vault.depositorBtcPubkey` may arrive as wallet-native compressed sec1
+  // (33 bytes) because the caller fetches it live from the wallet for
+  // signing. WASM script derivation wants x-only (32 bytes), so normalize
+  // here; the raw form is kept for the wallet sign call below.
+  const xOnlyDepositorPubkey = processPublicKeyToXOnly(
+    vault.depositorBtcPubkey,
+  );
   const { psbtHex } = await buildRefundPsbt({
     prePeginParams: {
-      depositorPubkey: stripHexPrefix(vault.depositorBtcPubkey),
+      depositorPubkey: xOnlyDepositorPubkey,
       vaultProviderPubkey: stripHexPrefix(ctx.vaultProviderPubkey),
       vaultKeeperPubkeys: ctx.vaultKeeperPubkeys.map(stripHexPrefix),
       universalChallengerPubkeys:

--- a/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts
@@ -75,7 +75,11 @@ export interface VaultRefundData {
   applicationEntryPoint: Address;
   /** Pre-PegIn HTLC output value in satoshis. */
   amount: bigint;
-  /** Funded (but pre-witness) Pre-PegIn transaction hex. 0x prefix optional. */
+  /**
+   * Funded, pre-witness Pre-PegIn transaction hex. 0x prefix optional.
+   * The name mirrors the contract/indexer schema; the bytes are the
+   * funded form (refund construction needs real outpoints).
+   */
   unsignedPrePeginTxHex: string;
   /** Depositor's BTC public key (x-only or compressed hex; 0x prefix optional). */
   depositorBtcPubkey: string;

--- a/packages/babylon-ts-sdk/src/testing/MockBitcoinWallet.ts
+++ b/packages/babylon-ts-sdk/src/testing/MockBitcoinWallet.ts
@@ -1,7 +1,10 @@
 import { Buffer } from "buffer";
 
 import { BitcoinNetworks, type BitcoinNetwork } from "../shared/wallets/interfaces";
-import type { BitcoinWallet } from "../shared/wallets/interfaces/BitcoinWallet";
+import type {
+  BitcoinWallet,
+  SignPsbtOptions,
+} from "../shared/wallets/interfaces/BitcoinWallet";
 
 /**
  * Configuration for MockBitcoinWallet.
@@ -54,7 +57,10 @@ export class MockBitcoinWallet implements BitcoinWallet {
     return psbtHex + "deadbeef";
   }
 
-  async signPsbts(psbtsHexes: string[]): Promise<string[]> {
+  async signPsbts(
+    psbtsHexes: string[],
+    _options?: SignPsbtOptions[],
+  ): Promise<string[]> {
     const signedPsbts: string[] = [];
     for (const psbtHex of psbtsHexes) {
       const signedPsbt = await this.signPsbt(psbtHex);

--- a/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
@@ -57,6 +57,7 @@ vi.mock("../useVaultProviders", () => ({
 vi.mock("@/services/vault/vaultTransactionService", () => ({
   preparePeginTransaction: vi.fn(),
   registerPeginBatchOnChain: vi.fn(),
+  signProofOfPossession: vi.fn(),
 }));
 
 vi.mock("@/services/vault/vaultActivationService", () => ({
@@ -155,6 +156,7 @@ vi.mock("../depositFlowSteps", () => ({
   getEthWalletClient: vi.fn(),
   registerPeginBatchAndWait: vi.fn(),
   signAndSubmitPayouts: vi.fn(),
+  signProofOfPossession: vi.fn(),
   submitWotsPublicKey: vi.fn(),
   waitForContractVerification: vi.fn(),
 }));
@@ -193,7 +195,6 @@ const MOCK_DEPOSITOR_PUBKEY = "ab".repeat(32);
 
 const MOCK_BATCH_RESULT = {
   fundedPrePeginTxHex: "batchFundedPrePeginHex",
-  unsignedPrePeginTxHex: "batchUnsignedPrePeginHex",
   depositorBtcPubkey: MOCK_DEPOSITOR_PUBKEY,
   selectedUTXOs: [MOCK_UTXO_1, MOCK_UTXO_2],
   fee: 2000n,
@@ -272,6 +273,7 @@ async function setupDefaultMocks() {
     getEthWalletClient,
     registerPeginBatchAndWait,
     signAndSubmitPayouts,
+    signProofOfPossession,
     waitForContractVerification,
   } = vi.mocked(await import("../depositFlowSteps"));
 
@@ -316,6 +318,11 @@ async function setupDefaultMocks() {
   );
 
   vi.mocked(getEthWalletClient).mockResolvedValue(MOCK_ETH_WALLET as any);
+  vi.mocked(signProofOfPossession).mockResolvedValue({
+    btcPopSignature: "0xMockPopSignature" as Hex,
+    depositorEthAddress: "0xEthAddress123" as `0x${string}`,
+    depositorBtcPubkey: MOCK_DEPOSITOR_PUBKEY,
+  });
   vi.mocked(registerPeginBatchAndWait).mockResolvedValue({
     ethTxHash: "0xBatchEthTxHash" as Hex,
     vaults: [
@@ -328,7 +335,6 @@ async function setupDefaultMocks() {
         peginTxHash: "0xVault1BtcTxHash" as Hex,
       },
     ],
-    btcPopSignature: "0xMockPopSignature" as Hex,
   });
   vi.mocked(signAndSubmitPayouts).mockResolvedValue(undefined);
   vi.mocked(waitForContractVerification).mockResolvedValue(undefined);
@@ -391,6 +397,35 @@ describe("useDepositFlow", () => {
   });
 
   describe("Batch Registration", () => {
+    it("should sign PoP before registration and forward the artifact", async () => {
+      const { registerPeginBatchAndWait, signProofOfPossession } = vi.mocked(
+        await import("../depositFlowSteps"),
+      );
+
+      const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
+      await executeWithAutoArtifactDownload(result);
+
+      await waitFor(() => {
+        expect(signProofOfPossession).toHaveBeenCalledTimes(1);
+        expect(registerPeginBatchAndWait).toHaveBeenCalledTimes(1);
+      });
+
+      // PoP must be signed strictly before the register call.
+      const popInvocationOrder =
+        signProofOfPossession.mock.invocationCallOrder[0];
+      const registerInvocationOrder =
+        registerPeginBatchAndWait.mock.invocationCallOrder[0];
+      expect(popInvocationOrder).toBeLessThan(registerInvocationOrder);
+
+      // The artifact must be passed through to register unchanged.
+      const callArgs = registerPeginBatchAndWait.mock.calls[0]?.[0];
+      expect(callArgs?.popSignature).toEqual({
+        btcPopSignature: "0xMockPopSignature",
+        depositorEthAddress: "0xEthAddress123",
+        depositorBtcPubkey: MOCK_DEPOSITOR_PUBKEY,
+      });
+    });
+
     it("should call registerPeginBatchAndWait once with all vaults", async () => {
       const { registerPeginBatchAndWait } = vi.mocked(
         await import("../depositFlowSteps"),
@@ -405,6 +440,7 @@ describe("useDepositFlow", () => {
 
         const callArgs = registerPeginBatchAndWait.mock.calls[0]?.[0];
         expect(callArgs?.vaultProviderAddress).toBe("0xProvider123");
+        expect(callArgs?.unsignedPrePeginTx).toBe("batchFundedPrePeginHex");
         expect(callArgs?.requests).toHaveLength(2);
 
         // First vault: htlcVout = 0
@@ -412,7 +448,6 @@ describe("useDepositFlow", () => {
           expect.objectContaining({
             htlcVout: 0,
             depositorSignedPeginTx: "peginTxHex0",
-            unsignedPrePeginTx: "batchFundedPrePeginHex",
           }),
         );
 
@@ -421,7 +456,6 @@ describe("useDepositFlow", () => {
           expect.objectContaining({
             htlcVout: 1,
             depositorSignedPeginTx: "peginTxHex1",
-            unsignedPrePeginTx: "batchFundedPrePeginHex",
           }),
         );
       });
@@ -807,7 +841,6 @@ describe("useDepositFlow", () => {
             peginTxHash: "0xVault0BtcTxHash" as Hex,
           },
         ],
-        btcPopSignature: "0xPopSig" as Hex,
       });
 
       const { result } = renderHook(() => useDepositFlow(SINGLE_PARAMS));

--- a/services/vault/src/hooks/deposit/depositFlowSteps/ethereumSubmit.ts
+++ b/services/vault/src/hooks/deposit/depositFlowSteps/ethereumSubmit.ts
@@ -1,14 +1,19 @@
 /**
- * Steps 1-2: ETH wallet and Pegin submission
+ * Steps 1-3: ETH wallet acquisition, BIP-322 PoP signing, pegin submission.
  */
 
 import { getETHChain } from "@babylonlabs-io/config";
+import type { BitcoinWallet } from "@babylonlabs-io/ts-sdk/shared";
+import type { PopSignature } from "@babylonlabs-io/ts-sdk/tbv/core";
 import { getSharedWagmiConfig } from "@babylonlabs-io/wallet-connector";
 import type { Address, WalletClient } from "viem";
 import { getWalletClient, switchChain } from "wagmi/actions";
 
 import { logger } from "@/infrastructure";
-import { registerPeginBatchOnChain } from "@/services/vault/vaultTransactionService";
+import {
+  registerPeginBatchOnChain,
+  signProofOfPossession as sdkSignProofOfPossession,
+} from "@/services/vault/vaultTransactionService";
 
 import type {
   PeginBatchRegisterParams,
@@ -55,7 +60,18 @@ export async function getEthWalletClient(
 }
 
 // ============================================================================
-// Step 2b: Batch Register Pegins On-Chain (single ETH tx for N vaults)
+// Step 2: Sign BIP-322 Proof of Possession (one wallet popup per session)
+// ============================================================================
+
+export async function signProofOfPossession(
+  btcWalletProvider: BitcoinWallet,
+  walletClient: WalletClient,
+): Promise<PopSignature> {
+  return sdkSignProofOfPossession(btcWalletProvider, walletClient);
+}
+
+// ============================================================================
+// Step 3: Batch Register Pegins On-Chain (single ETH tx for N vaults)
 // ============================================================================
 
 /**
@@ -69,9 +85,9 @@ export async function registerPeginBatchAndWait(
     btcWalletProvider,
     walletClient,
     vaultProviderAddress,
+    unsignedPrePeginTx,
     requests,
-    preSignedBtcPopSignature,
-    onPopSigned,
+    popSignature,
   } = params;
 
   const result = await registerPeginBatchOnChain(
@@ -79,15 +95,14 @@ export async function registerPeginBatchAndWait(
     walletClient,
     {
       vaultProviderAddress: vaultProviderAddress as Address,
+      unsignedPrePeginTx,
       requests,
-      preSignedBtcPopSignature,
-      onPopSigned,
+      popSignature,
     },
   );
 
   return {
     ethTxHash: result.ethTxHash,
     vaults: result.vaults,
-    btcPopSignature: result.btcPopSignature,
   };
 }

--- a/services/vault/src/hooks/deposit/depositFlowSteps/index.ts
+++ b/services/vault/src/hooks/deposit/depositFlowSteps/index.ts
@@ -5,14 +5,15 @@
  * They are pure (no React state) and can be easily tested.
  * The deposit flow hook orchestrates these functions and manages state.
  *
- * Flow steps:
+ * Flow steps (align with the `DepositFlowStep` enum):
  * 0. Validation - validateMultiVaultDepositInputs
  * 1. Get ETH wallet - getEthWalletClient
  * 2a. Prepare pegin - preparePegin (build + fund BTC tx)
- * 2b. Register pegin batch - registerPeginBatchAndWait (PoP + single ETH tx)
- * 2.5. WOTS key RPC submission - submitWotsPublicKey
- * 3. Payout signing - signAndSubmitPayouts
- * 4. Broadcast - waitForContractVerification, broadcastBtcTransaction
+ * 2b. Sign proof of possession - signProofOfPossession (one BIP-322 wallet popup)
+ * 2c. Register pegin batch - registerPeginBatchAndWait (single ETH tx for all vaults)
+ * 3. Broadcast Pre-PegIn - broadcastBtcTransaction
+ * 3.5. WOTS key RPC submission - submitWotsPublicKey
+ * 4. Payout signing - waitForContractVerification, signAndSubmitPayouts
  */
 
 // Types and enums
@@ -30,21 +31,22 @@ export type {
 export { validateMultiVaultDepositInputs } from "./validation";
 export type { VaultMultiVaultDepositInputs } from "./validation";
 
-// Steps 1-2: ETH wallet and pegin submission
+// Steps 1-3: ETH wallet, proof of possession, pegin submission
 export {
   getEthWalletClient,
   registerPeginBatchAndWait,
+  signProofOfPossession,
 } from "./ethereumSubmit";
 
-// Step 2.5: WOTS key submission
-export { submitWotsPublicKey } from "./wotsSubmission";
-
-// Step 3: Payout signing
-export { signAndSubmitPayouts } from "./payoutSigning";
-export type { SignAndSubmitPayoutsParams } from "./payoutSigning";
-
-// Step 4: Broadcast
+// Step 3: Broadcast Pre-PegIn on Bitcoin
 export {
   broadcastBtcTransaction,
   waitForContractVerification,
 } from "./broadcast";
+
+// Step 3.5: WOTS key submission (RPC, happens after broadcast + VP indexing)
+export { submitWotsPublicKey } from "./wotsSubmission";
+
+// Step 4: Payout signing
+export { signAndSubmitPayouts } from "./payoutSigning";
+export type { SignAndSubmitPayoutsParams } from "./payoutSigning";

--- a/services/vault/src/hooks/deposit/depositFlowSteps/payoutSigning.ts
+++ b/services/vault/src/hooks/deposit/depositFlowSteps/payoutSigning.ts
@@ -1,5 +1,5 @@
 /**
- * Step 3: Payout signing — adapter over SDK's pollAndSignPayouts
+ * Step 4: Payout signing — adapter over SDK's pollAndSignPayouts
  *
  * Uses prepareSigningContext() to fetch VERSIONED vault keepers and
  * universal challengers from the contract, then delegates all signing

--- a/services/vault/src/hooks/deposit/depositFlowSteps/types.ts
+++ b/services/vault/src/hooks/deposit/depositFlowSteps/types.ts
@@ -53,7 +53,9 @@ export interface UtxoRef {
 }
 
 // ============================================================================
-// Steps 1-2: Pegin Submit
+// DepositFlowStep.SIGN_POP + SUBMIT_PEGIN — shared params for PoP signing
+// and the batch ETH tx (both operations reuse the same PopSignature and
+// Pre-PegIn tx, so the fields live on the batch params, not per-request).
 // ============================================================================
 
 export interface PeginBatchRegisterParams {

--- a/services/vault/src/hooks/deposit/depositFlowSteps/types.ts
+++ b/services/vault/src/hooks/deposit/depositFlowSteps/types.ts
@@ -3,6 +3,7 @@
  */
 
 import type { BitcoinWallet } from "@babylonlabs-io/ts-sdk/shared";
+import type { PopSignature } from "@babylonlabs-io/ts-sdk/tbv/core";
 import type { Hex, WalletClient } from "viem";
 
 import type { WotsPublicKeys } from "@/services/wots";
@@ -60,20 +61,18 @@ export interface PeginBatchRegisterParams {
   walletClient: WalletClient;
   /** Vault provider ETH address (shared for all vaults in batch) */
   vaultProviderAddress: string;
+  /** Shared Pre-PegIn tx hex for the whole batch */
+  unsignedPrePeginTx: string;
   /** Per-vault registration data */
   requests: Array<{
-    depositorBtcPubkey: string;
-    unsignedPrePeginTx: string;
     depositorSignedPeginTx: string;
     hashlock: Hex;
     htlcVout: number;
     depositorPayoutBtcAddress: string;
     depositorWotsPkHash: Hex;
   }>;
-  /** Pre-signed BTC PoP signature (signed once, reused for all) */
-  preSignedBtcPopSignature?: Hex;
-  /** Called after PoP is signed (before ETH tx) */
-  onPopSigned?: () => void;
+  /** Proof of possession from signProofOfPossession. */
+  popSignature: PopSignature;
 }
 
 export interface PeginBatchRegisterResult {
@@ -82,7 +81,6 @@ export interface PeginBatchRegisterResult {
     vaultId: Hex;
     peginTxHash: Hex;
   }>;
-  btcPopSignature: Hex;
 }
 
 // ============================================================================
@@ -100,7 +98,7 @@ export interface WotsSubmissionParams {
 }
 
 // ============================================================================
-// Step 4: Broadcast
+// Step 3: Broadcast
 // ============================================================================
 
 export interface BroadcastParams {

--- a/services/vault/src/hooks/deposit/useDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useDepositFlow.ts
@@ -9,8 +9,10 @@
  * 0. Validation — check wallets, UTXOs, pubkeys, array alignment
  * 1. Get shared resources (ETH wallet client, mnemonic)
  * 2. Batch Pre-PegIn creation (one BTC tx with N HTLC outputs)
- * 3a. Sign BIP-322 proof-of-possession (one wallet popup per deposit session)
- * 3b. Batch ETH registration (single submitPeginRequestBatch tx for all vaults)
+ * 3a. Derive WOTS public keys for all vaults
+ * 3b. Sign BIP-322 proof-of-possession (one wallet popup per deposit session)
+ * 3c. Build batch request array
+ * 3d. Batch ETH registration (single submitPeginRequestBatch tx for all vaults)
  * 4. Broadcast Pre-PegIn transaction to Bitcoin + save to localStorage (CONFIRMING)
  * 5. Submit WOTS keys, poll VP, sign payout transactions
  * 6. Download vault artifacts (per vault, user-driven)

--- a/services/vault/src/hooks/deposit/useDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useDepositFlow.ts
@@ -2,14 +2,15 @@
  * Deposit Flow Hook
  *
  * Orchestrates the batch-first deposit flow. A single vault is just a batch of 1.
- * Creates ONE Pre-PegIn BTC transaction with N HTLC outputs (one per vault),
- * registers each vault individually on Ethereum, then broadcasts the shared tx.
+ * Creates ONE Pre-PegIn BTC transaction with N HTLC outputs (one per vault) and
+ * registers them all atomically on Ethereum via submitPeginRequestBatch().
  *
  * Flow:
  * 0. Validation — check wallets, UTXOs, pubkeys, array alignment
  * 1. Get shared resources (ETH wallet client, mnemonic)
  * 2. Batch Pre-PegIn creation (one BTC tx with N HTLC outputs)
- * 3. Batch ETH registration (single submitPeginRequestBatch tx for all vaults)
+ * 3a. Sign BIP-322 proof-of-possession (one wallet popup per deposit session)
+ * 3b. Batch ETH registration (single submitPeginRequestBatch tx for all vaults)
  * 4. Broadcast Pre-PegIn transaction to Bitcoin + save to localStorage (CONFIRMING)
  * 5. Submit WOTS keys, poll VP, sign payout transactions
  * 6. Download vault artifacts (per vault, user-driven)
@@ -61,6 +62,7 @@ import {
   getEthWalletClient,
   registerPeginBatchAndWait,
   signAndSubmitPayouts,
+  signProofOfPossession,
   submitWotsPublicKey,
   waitForContractVerification,
   type DepositUtxo,
@@ -367,10 +369,8 @@ export function useDepositFlow(
         );
 
         // ========================================================================
-        // Step 3: Batch register all vaults on Ethereum (single ETH tx)
+        // Step 3: Sign PoP + batch register all vaults on Ethereum
         // ========================================================================
-
-        setCurrentStep(DepositFlowStep.SUBMIT_PEGIN);
 
         // 3a. Derive WOTS public keys for all vaults (must happen before ETH tx)
         // Keys are derived here and reused for both:
@@ -393,10 +393,16 @@ export function useDepositFlow(
           wotsPkHashes.push(computeWotsPublicKeysHash(wotsPublicKeys));
         }
 
-        // 3b. Build batch request array
+        // 3b. Sign PoP during SIGN_POP so the wallet popup is associated
+        // with this step, not the following SUBMIT_PEGIN.
+        setCurrentStep(DepositFlowStep.SIGN_POP);
+        const popSignature = await signProofOfPossession(
+          confirmedBtcWallet,
+          walletClient,
+        );
+
+        // 3c. Build batch request array.
         const batchRequests = batchResult.perVault.map((vault, i) => ({
-          depositorBtcPubkey: batchResult.depositorBtcPubkey,
-          unsignedPrePeginTx: batchResult.fundedPrePeginTxHex,
           depositorSignedPeginTx: vault.peginTxHex,
           hashlock: ensureHexPrefix(hashlocks[i]) as Hex,
           htlcVout: vault.htlcVout,
@@ -404,12 +410,15 @@ export function useDepositFlow(
           depositorWotsPkHash: wotsPkHashes[i],
         }));
 
-        // 3c. Single batch ETH transaction for all vaults
+        // 3d. Single batch ETH transaction for all vaults.
+        setCurrentStep(DepositFlowStep.SUBMIT_PEGIN);
         const batchRegistration = await registerPeginBatchAndWait({
           btcWalletProvider: confirmedBtcWallet,
           walletClient,
           vaultProviderAddress: primaryProvider,
+          unsignedPrePeginTx: batchResult.fundedPrePeginTxHex,
           requests: batchRequests,
+          popSignature,
         });
 
         // 3d. Build pegin results from batch response

--- a/services/vault/src/hooks/deposit/useRefundState.ts
+++ b/services/vault/src/hooks/deposit/useRefundState.ts
@@ -30,7 +30,7 @@ export function useRefundState({
   const [error, setError] = useState<string | null>(null);
 
   // Destructure stable primitives to avoid re-creating handleRefund on every render
-  const { id: vaultId, depositorBtcPubkey } = activity;
+  const { id: vaultId } = activity;
 
   const handleRefund = useCallback(async () => {
     if (!btcWalletProvider) {
@@ -41,15 +41,17 @@ export function useRefundState({
       setError("Missing vault ID");
       return;
     }
-    if (!depositorBtcPubkey) {
-      setError("Missing depositor BTC public key");
-      return;
-    }
 
     setRefunding(true);
     setError(null);
 
     try {
+      // Fetch the pubkey live from the wallet (not from storage). The
+      // wallet's signPsbt signInputs[].publicKey requires the wallet's
+      // native format (typically compressed 33-byte sec1), and the
+      // stored activity holds the canonical x-only form used for
+      // on-chain/indexer identification.
+      const depositorBtcPubkey = await btcWalletProvider.getPublicKeyHex();
       const txId = await buildAndBroadcastRefundTransaction({
         vaultId,
         btcWalletProvider,
@@ -74,7 +76,7 @@ export function useRefundState({
       );
       setRefunding(false);
     }
-  }, [vaultId, depositorBtcPubkey, btcWalletProvider]);
+  }, [vaultId, btcWalletProvider]);
 
   return { refunding, refundTxId, error, handleRefund };
 }

--- a/services/vault/src/services/vault/__tests__/vaultTransactionService.test.ts
+++ b/services/vault/src/services/vault/__tests__/vaultTransactionService.test.ts
@@ -21,6 +21,14 @@ const { mockPreparePegin, MockPeginManager } = vi.hoisted(() => {
 vi.mock("@babylonlabs-io/ts-sdk/tbv/core", () => ({
   PeginManager: MockPeginManager,
   ensureHexPrefix: (hex: string) => (hex.startsWith("0x") ? hex : `0x${hex}`),
+  // Strip 0x, slice compressed sec1 prefix, lowercase. Matches the real
+  // primitive's contract for the shapes the tests feed in.
+  processPublicKeyToXOnly: (raw: string) => {
+    const clean = raw.startsWith("0x") ? raw.slice(2) : raw;
+    const normalized =
+      clean.length === 66 && /^0[23]/i.test(clean) ? clean.slice(2) : clean;
+    return normalized.toLowerCase();
+  },
 }));
 
 vi.mock("@babylonlabs-io/config", () => ({
@@ -93,7 +101,6 @@ describe("vaultTransactionService - preparePeginTransaction", () => {
 
     mockPreparePegin.mockResolvedValue({
       fundedPrePeginTxHex: "0x123abc",
-      unsignedPrePeginTxHex: "0xunfunded",
       selectedUTXOs: [mockUTXOs[0]],
       fee: 1000n,
       perVault: [
@@ -140,7 +147,6 @@ describe("vaultTransactionService - preparePeginTransaction", () => {
       expect(result.perVault[0].peginTxHash).toBe("0xtxhash123");
       expect(result.perVault[0].peginTxHex).toBe("0xpeginHex");
       expect(result.fundedPrePeginTxHex).toBe("0x123abc");
-      expect(result.unsignedPrePeginTxHex).toBe("0xunfunded");
     });
 
     it("should handle multi-vault params", async () => {
@@ -152,7 +158,6 @@ describe("vaultTransactionService - preparePeginTransaction", () => {
 
       mockPreparePegin.mockResolvedValue({
         fundedPrePeginTxHex: "0x123abc",
-        unsignedPrePeginTxHex: "0xunfunded",
         selectedUTXOs: [mockUTXOs[0], mockUTXOs[1]],
         fee: 2000n,
         perVault: [

--- a/services/vault/src/services/vault/vaultTransactionService.ts
+++ b/services/vault/src/services/vault/vaultTransactionService.ts
@@ -9,9 +9,14 @@ import { getETHChain } from "@babylonlabs-io/config";
 import type { BitcoinWallet } from "@babylonlabs-io/ts-sdk/shared";
 import type {
   BatchPeginRequestItem,
+  PopSignature,
   UTXO as SDKUtxo,
 } from "@babylonlabs-io/ts-sdk/tbv/core";
-import { ensureHexPrefix, PeginManager } from "@babylonlabs-io/ts-sdk/tbv/core";
+import {
+  ensureHexPrefix,
+  PeginManager,
+  processPublicKeyToXOnly,
+} from "@babylonlabs-io/ts-sdk/tbv/core";
 import type { Address, Hex, WalletClient } from "viem";
 
 import { getMempoolApiUrl } from "../../clients/btc/config";
@@ -83,10 +88,8 @@ export interface PeginVaultResult {
  * Always batch-shaped — single vault is perVault with one element.
  */
 export interface PreparePeginResult {
-  /** Funded Pre-PegIn tx hex (shared across all vaults) */
+  /** Funded, pre-witness Pre-PegIn tx hex (shared across all vaults). */
   fundedPrePeginTxHex: string;
-  /** Unfunded Pre-PegIn tx hex (for contract DA submission) */
-  unsignedPrePeginTxHex: string;
   /** Per-vault results (one per HTLC output) */
   perVault: PeginVaultResult[];
   selectedUTXOs: UTXO[];
@@ -100,12 +103,12 @@ export interface PreparePeginResult {
 export interface RegisterPeginBatchOnChainParams {
   /** Vault provider address (shared across all vaults) */
   vaultProviderAddress: Address;
+  /** Shared Pre-PegIn tx hex for the whole batch */
+  unsignedPrePeginTx: string;
   /** Per-vault registration data */
   requests: BatchPeginRequestItem[];
-  /** Pre-signed BTC PoP signature (signed once, reused for all) */
-  preSignedBtcPopSignature?: Hex;
-  /** Called after PoP is signed (before ETH tx) */
-  onPopSigned?: () => void | Promise<void>;
+  /** Proof of possession from signProofOfPossession(). */
+  popSignature: PopSignature;
 }
 
 /**
@@ -119,8 +122,6 @@ export interface RegisterPeginBatchResult {
     vaultId: Hex;
     peginTxHash: Hex;
   }>;
-  /** The BTC PoP signature used */
-  btcPopSignature: Hex;
 }
 
 function createPeginManager(
@@ -172,15 +173,14 @@ export async function preparePeginTransaction(
     changeAddress: params.changeAddress,
   });
 
-  const depositorBtcPubkeyRaw = await btcWallet.getPublicKeyHex();
-  const depositorBtcPubkey =
-    depositorBtcPubkeyRaw.length === 66
-      ? depositorBtcPubkeyRaw.slice(2)
-      : depositorBtcPubkeyRaw;
+  // Lowercase: processPublicKeyToXOnly passes 64-char input through
+  // unchanged, and downstream equality checks are case-sensitive.
+  const depositorBtcPubkey = processPublicKeyToXOnly(
+    await btcWallet.getPublicKeyHex(),
+  ).toLowerCase();
 
   return {
     fundedPrePeginTxHex: result.fundedPrePeginTxHex,
-    unsignedPrePeginTxHex: result.unsignedPrePeginTxHex,
     perVault: result.perVault.map((v) => ({
       htlcVout: v.htlcVout,
       peginTxHash: ensureHexPrefix(v.peginTxid),
@@ -194,11 +194,17 @@ export async function preparePeginTransaction(
   };
 }
 
+export async function signProofOfPossession(
+  btcWallet: BitcoinWallet,
+  ethWallet: WalletClient,
+): Promise<PopSignature> {
+  const peginManager = createPeginManager(btcWallet, ethWallet);
+  return peginManager.signProofOfPossession();
+}
+
 /**
  * Batch-register multiple prepared pegins on Ethereum in a single transaction.
- *
  * Uses submitPeginRequestBatch() so users only sign one ETH tx for N vaults.
- * The PoP signature is signed once and included in each request.
  */
 export async function registerPeginBatchOnChain(
   btcWallet: BitcoinWallet,
@@ -209,14 +215,13 @@ export async function registerPeginBatchOnChain(
 
   const result = await peginManager.registerPeginBatchOnChain({
     vaultProvider: params.vaultProviderAddress,
+    unsignedPrePeginTx: params.unsignedPrePeginTx,
     requests: params.requests,
-    preSignedBtcPopSignature: params.preSignedBtcPopSignature,
-    onPopSigned: params.onPopSigned,
+    popSignature: params.popSignature,
   });
 
   return {
     ethTxHash: result.ethTxHash,
     vaults: result.vaults,
-    btcPopSignature: result.btcPopSignature,
   };
 }


### PR DESCRIPTION
- New public `PeginManager.signProofOfPossession()` returning a
  `PopSignature { btcPopSignature, depositorEthAddress, depositorBtcPubkey }`
  artifact. Register methods take it as a required `popSignature` parameter
  and re-verify both identities against the currently connected ETH/BTC
  wallets — mid-flow account switches fail loudly instead of submitting
  a stale proof.
- Vault hook now fires the BIP-322 wallet popup during the `SIGN_POP`
  step, not `SUBMIT_PEGIN` (was a UX bug — the PoP popup was bundled into
  the ETH submission step).
- Lifts shared `unsignedPrePeginTx` from per-request to top-level
  `RegisterPeginBatchParams`; same pattern as moving `depositorBtcPubkey`
  into `PopSignature`. Invariants enforced by types, not runtime checks.
- Adds aave-v4 activation error mappings (`PrePeginOutputAlreadyUsed`,
  `PeginTransactionAlreadyUsed`) to both the service error-name map and
  the SDK selector map, in preparation for the contract bump past
  `eefcf478`.
- Unifies BTC pubkey canonicalization through `processPublicKeyToXOnly`
  across `preparePegin`, `signProofOfPossession`, register-time checks,
  `signAndBroadcast`, and the vault wrapper. Removes a length-heuristic
  shadow normalization that mishandled 0x-prefixed compressed keys.
- Removes dead `PreparePeginResult.unsignedPrePeginTxHex` and clarifies
  the `unsignedPrePeginTx` naming confusion (contract parameter is
  labelled "unsigned" but stores the funded pre-witness form; refund
  PSBT construction depends on this).