### PR TITLE
fix(vault): borrow repay

### DIFF
--- a/services/vault/src/applications/aave/components/Detail/hooks/__tests__/useAaveReserveDetail.test.tsx
+++ b/services/vault/src/applications/aave/components/Detail/hooks/__tests__/useAaveReserveDetail.test.tsx
@@ -543,4 +543,49 @@ describe("useAaveReserveDetail", () => {
 
     expect(result.current.error).toBeNull();
   });
+
+  // --- Staleness passthrough (#132) ---
+
+  it("passes through isPositionDataStale from useAaveUserPosition", () => {
+    mockUseAaveUserPosition.mockReturnValue({
+      position: null,
+      collateralValueUsd: 15000,
+      debtValueUsd: 0,
+      healthFactor: null,
+      healthFactorStatus: "healthy",
+      isPositionDataStale: true,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    const { result } = renderHook(
+      () => useAaveReserveDetail({ reserveId: "USDC", address: "0xUser" }),
+      { wrapper },
+    );
+
+    expect(result.current.isPositionDataStale).toBe(true);
+  });
+
+  it("exposes refetchPosition from useAaveUserPosition", () => {
+    const mockRefetch = vi.fn();
+    mockUseAaveUserPosition.mockReturnValue({
+      position: null,
+      collateralValueUsd: 15000,
+      debtValueUsd: 0,
+      healthFactor: null,
+      healthFactorStatus: "healthy",
+      isPositionDataStale: false,
+      isLoading: false,
+      error: null,
+      refetch: mockRefetch,
+    });
+
+    const { result } = renderHook(
+      () => useAaveReserveDetail({ reserveId: "USDC", address: "0xUser" }),
+      { wrapper },
+    );
+
+    expect(result.current.refetchPosition).toBe(mockRefetch);
+  });
 });

--- a/services/vault/src/applications/aave/components/Detail/hooks/useAaveReserveDetail.ts
+++ b/services/vault/src/applications/aave/components/Detail/hooks/useAaveReserveDetail.ts
@@ -23,6 +23,7 @@ import {
 } from "../../../constants";
 import { useAaveConfig } from "../../../context";
 import { useAaveUserPosition, useVaultSplitParams } from "../../../hooks";
+import type { AavePositionWithLiveData } from "../../../services";
 import type { AaveReserveConfig } from "../../../services/fetchConfig";
 import type { Asset } from "../../../types";
 
@@ -58,6 +59,10 @@ export interface UseAaveReserveDetailResult {
   tokenPriceUsd: number | null;
   /** Error from price or split params fetch (null if no error) */
   error: Error | null;
+  /** Whether position data may be stale (oracle-derived values possibly outdated) */
+  isPositionDataStale: boolean;
+  /** Refetch position data — returns fresh position (or null if unavailable) */
+  refetchPosition: () => Promise<AavePositionWithLiveData | null>;
 }
 
 export function useAaveReserveDetail({
@@ -98,7 +103,9 @@ export function useAaveReserveDetail({
     collateralValueUsd,
     debtValueUsd,
     healthFactor,
+    isPositionDataStale,
     isLoading: positionLoading,
+    refetch: refetchPosition,
   } = useAaveUserPosition(address);
 
   // Chainlink oracle prices (cached app-wide via React Query)
@@ -186,5 +193,7 @@ export function useAaveReserveDetail({
     healthFactor,
     tokenPriceUsd,
     error: pricesError ?? splitParamsError ?? null,
+    isPositionDataStale,
+    refetchPosition,
   };
 }

--- a/services/vault/src/applications/aave/components/Detail/index.tsx
+++ b/services/vault/src/applications/aave/components/Detail/index.tsx
@@ -49,6 +49,8 @@ export function AaveReserveDetail() {
     healthFactor,
     tokenPriceUsd,
     error,
+    isPositionDataStale,
+    refetchPosition,
   } = useAaveReserveDetail({ reserveId, address });
 
   // Modal state management
@@ -133,6 +135,8 @@ export function AaveReserveDetail() {
     assetConfig,
     proxyContract,
     tokenPriceUsd,
+    isPositionDataStale,
+    refetchPosition,
     onBorrowSuccess: openBorrowSuccess,
     onRepaySuccess: openRepaySuccess,
   };

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/__tests__/validateBorrowAction.test.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/__tests__/validateBorrowAction.test.ts
@@ -84,4 +84,27 @@ describe("validateBorrowAction", () => {
       errorMessage: null,
     });
   });
+
+  it("disables with 'Refreshing position...' when position data is stale", () => {
+    const result = validateBorrowAction(5000, 2.0, 10000, true);
+
+    expect(result).toEqual({
+      isDisabled: true,
+      buttonText: "Refreshing position...",
+      errorMessage: null,
+    });
+  });
+
+  it("does not block when isPositionDataStale is false", () => {
+    const result = validateBorrowAction(5000, 2.0, 10000, false);
+
+    expect(result.isDisabled).toBe(false);
+  });
+
+  it("prioritizes staleness check over other validations", () => {
+    // Stale AND amount is 0 — staleness should take priority
+    const result = validateBorrowAction(0, Infinity, 10000, true);
+
+    expect(result.buttonText).toBe("Refreshing position...");
+  });
 });

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/validateBorrowAction.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/validateBorrowAction.ts
@@ -18,13 +18,23 @@ export interface BorrowValidationResult {
  * @param borrowAmount - Amount user wants to borrow
  * @param projectedHealthFactor - Health factor after the borrow
  * @param maxBorrowAmount - Maximum borrowable amount based on collateral and debt
+ * @param isPositionDataStale - Whether position data may be outdated
  * @returns Validation result with disabled state, button text, and error message
  */
 export function validateBorrowAction(
   borrowAmount: number,
   projectedHealthFactor: number,
   maxBorrowAmount: number,
+  isPositionDataStale = false,
 ): BorrowValidationResult {
+  if (isPositionDataStale) {
+    return {
+      isDisabled: true,
+      buttonText: "Refreshing position...",
+      errorMessage: null,
+    };
+  }
+
   if (borrowAmount === 0) {
     return {
       isDisabled: true,

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/index.tsx
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/index.tsx
@@ -22,8 +22,17 @@ import {
   formatTokenAmount,
   formatUsdValue,
 } from "../../../../../utils/formatting";
-import { AMOUNT_INPUT_CLASS_NAME, MIN_SLIDER_MAX } from "../../../constants";
+import {
+  AMOUNT_INPUT_CLASS_NAME,
+  MIN_HEALTH_FACTOR_FOR_BORROW,
+  MIN_SLIDER_MAX,
+} from "../../../constants";
 import { useBorrowTransaction } from "../../../hooks";
+import {
+  aaveRayValueToUsd,
+  aaveValueToUsd,
+  calculateHealthFactor,
+} from "../../../utils";
 import { useLoanContext } from "../../context/LoanContext";
 
 import { BorrowDetailsCard } from "./BorrowDetailsCard";
@@ -40,6 +49,8 @@ export function Borrow() {
     selectedReserve,
     assetConfig,
     tokenPriceUsd,
+    isPositionDataStale,
+    refetchPosition,
     onBorrowSuccess,
   } = useLoanContext();
 
@@ -66,12 +77,46 @@ export function Borrow() {
     borrowAmount,
     metrics.healthFactorValue,
     maxBorrowAmount,
+    isPositionDataStale,
   );
 
   const sliderMaxBorrow = Math.max(maxBorrowAmount, MIN_SLIDER_MAX);
 
   const handleBorrow = async () => {
-    const success = await executeBorrow(borrowAmount, selectedReserve);
+    const preSignValidation = async () => {
+      if (tokenPriceUsd == null) {
+        throw new Error("Token price unavailable. Cannot validate borrow.");
+      }
+
+      const freshPosition = await refetchPosition();
+      if (!freshPosition) return; // No position = first borrow, skip revalidation
+
+      const freshCollateralUsd = aaveValueToUsd(
+        freshPosition.accountData.totalCollateralValue,
+      );
+      const freshDebtUsd = aaveRayValueToUsd(
+        freshPosition.accountData.totalDebtValueRay,
+      );
+      const projectedDebtUsd = freshDebtUsd + borrowAmount * tokenPriceUsd;
+      const projectedHF = calculateHealthFactor(
+        freshCollateralUsd,
+        projectedDebtUsd,
+        liquidationThresholdBps,
+      );
+
+      if (isFinite(projectedHF) && projectedHF < MIN_HEALTH_FACTOR_FOR_BORROW) {
+        throw new Error(
+          `Position data has changed. Projected health factor (${projectedHF.toFixed(2)}) ` +
+            `would be below ${MIN_HEALTH_FACTOR_FOR_BORROW}. Please reduce the borrow amount.`,
+        );
+      }
+    };
+
+    const success = await executeBorrow(
+      borrowAmount,
+      selectedReserve,
+      preSignValidation,
+    );
     if (success) {
       resetBorrowAmount();
       onBorrowSuccess(borrowAmount);

--- a/services/vault/src/applications/aave/components/LoanCard/Repay/hooks/__tests__/useRepayState.test.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Repay/hooks/__tests__/useRepayState.test.ts
@@ -14,7 +14,6 @@ describe("useRepayState", () => {
         useRepayState({ currentDebtAmount: 1.23456789, userTokenBalance: 100 }),
       );
 
-      // Should NOT truncate to 1.23
       expect(result.current.maxRepayAmount).toBe(1.23456789);
     });
 
@@ -70,8 +69,44 @@ describe("useRepayState", () => {
     });
   });
 
-  describe("isFullRepayment", () => {
-    it("should be true when repay amount equals max", () => {
+  describe("isFullRepayment (explicit mode)", () => {
+    it("defaults to false (partial mode)", () => {
+      const { result } = renderHook(() =>
+        useRepayState({ currentDebtAmount: 100, userTokenBalance: 100 }),
+      );
+
+      expect(result.current.isFullRepayment).toBe(false);
+    });
+
+    it("is true when setRepayAmountWithMode is called with 'full'", () => {
+      const { result } = renderHook(() =>
+        useRepayState({ currentDebtAmount: 100, userTokenBalance: 100 }),
+      );
+
+      act(() => {
+        result.current.setRepayAmountWithMode(100, "full");
+      });
+
+      expect(result.current.isFullRepayment).toBe(true);
+    });
+
+    it("resets to false when setRepayAmount is called (manual input)", () => {
+      const { result } = renderHook(() =>
+        useRepayState({ currentDebtAmount: 100, userTokenBalance: 100 }),
+      );
+
+      act(() => {
+        result.current.setRepayAmountWithMode(100, "full");
+      });
+      expect(result.current.isFullRepayment).toBe(true);
+
+      act(() => {
+        result.current.setRepayAmount(99);
+      });
+      expect(result.current.isFullRepayment).toBe(false);
+    });
+
+    it("is false even when amount equals debt if mode is partial (typed, not Max)", () => {
       const { result } = renderHook(() =>
         useRepayState({ currentDebtAmount: 100, userTokenBalance: 100 }),
       );
@@ -80,65 +115,45 @@ describe("useRepayState", () => {
         result.current.setRepayAmount(100);
       });
 
-      expect(result.current.isFullRepayment).toBe(true);
+      // Typed 100 manually — partial mode, not full repay
+      expect(result.current.isFullRepayment).toBe(false);
     });
 
-    it("should be true when repay amount is within tolerance of max", () => {
+    it("is false when balance limits max below debt (partial repay via Max)", () => {
       const { result } = renderHook(() =>
-        useRepayState({ currentDebtAmount: 100, userTokenBalance: 100 }),
+        useRepayState({ currentDebtAmount: 100, userTokenBalance: 50 }),
       );
 
-      // Within 0.01 tolerance
+      // Max button with balance < debt should set partial
       act(() => {
-        result.current.setRepayAmount(99.995);
-      });
-
-      expect(result.current.isFullRepayment).toBe(true);
-    });
-
-    it("should be false when repay amount is significantly less than max", () => {
-      const { result } = renderHook(() =>
-        useRepayState({ currentDebtAmount: 100, userTokenBalance: 100 }),
-      );
-
-      act(() => {
-        result.current.setRepayAmount(50);
+        result.current.setRepayAmountWithMode(50, "partial");
       });
 
       expect(result.current.isFullRepayment).toBe(false);
     });
 
-    it("should be false when max is zero", () => {
+    it("resets mode on resetRepayAmount", () => {
+      const { result } = renderHook(() =>
+        useRepayState({ currentDebtAmount: 100, userTokenBalance: 100 }),
+      );
+
+      act(() => {
+        result.current.setRepayAmountWithMode(100, "full");
+      });
+      act(() => {
+        result.current.resetRepayAmount();
+      });
+
+      expect(result.current.isFullRepayment).toBe(false);
+      expect(result.current.repayAmount).toBe(0);
+    });
+
+    it("is false when max is zero", () => {
       const { result } = renderHook(() =>
         useRepayState({ currentDebtAmount: 0, userTokenBalance: 100 }),
       );
 
       expect(result.current.isFullRepayment).toBe(false);
-    });
-
-    it("should be false when balance limits max below debt (partial repay via Max)", () => {
-      const { result } = renderHook(() =>
-        useRepayState({ currentDebtAmount: 100, userTokenBalance: 50 }),
-      );
-
-      // Max is 50 (limited by balance), but debt is 100 — this is a partial repay
-      act(() => {
-        result.current.setRepayAmount(50);
-      });
-
-      expect(result.current.isFullRepayment).toBe(false);
-    });
-
-    it("should be true when repay amount matches actual debt with excess balance", () => {
-      const { result } = renderHook(() =>
-        useRepayState({ currentDebtAmount: 100, userTokenBalance: 200 }),
-      );
-
-      act(() => {
-        result.current.setRepayAmount(100);
-      });
-
-      expect(result.current.isFullRepayment).toBe(true);
     });
   });
 

--- a/services/vault/src/applications/aave/components/LoanCard/Repay/hooks/useRepayMetrics.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Repay/hooks/useRepayMetrics.ts
@@ -6,7 +6,7 @@
  * Repaying improves the health factor.
  */
 
-import { FULL_REPAY_TOLERANCE } from "../../../../constants";
+import { NEAR_ZERO_DEBT_DISPLAY_THRESHOLD } from "../../../../constants";
 import {
   calculateBorrowRatio,
   calculateHealthFactor,
@@ -67,7 +67,8 @@ export function useRepayMetrics({
     0,
     totalDebtValueUsd - repayAmount * tokenPriceUsd,
   );
-  const isFullRepayment = projectedTotalDebtUsd < FULL_REPAY_TOLERANCE;
+  const isDebtNearZero =
+    projectedTotalDebtUsd < NEAR_ZERO_DEBT_DISPLAY_THRESHOLD;
 
   const healthFactorValue =
     projectedTotalDebtUsd > 0
@@ -94,11 +95,9 @@ export function useRepayMetrics({
         ? "-"
         : formatHealthFactor(healthFactorValue),
     healthFactorValue,
-    healthFactorOriginal: isFullRepayment
+    healthFactorOriginal: isDebtNearZero
       ? undefined
       : formatHealthFactor(currentHealthFactor),
-    healthFactorOriginalValue: isFullRepayment
-      ? undefined
-      : originalHealthValue,
+    healthFactorOriginalValue: isDebtNearZero ? undefined : originalHealthValue,
   };
 }

--- a/services/vault/src/applications/aave/components/LoanCard/Repay/hooks/useRepayState.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Repay/hooks/useRepayState.ts
@@ -2,11 +2,10 @@
  * Repay state management hook
  *
  * Manages repay amount and calculates max repay based on current debt in token units.
+ * Uses explicit mode tracking ("partial" | "full") instead of tolerance-based detection.
  */
 
-import { useMemo, useState } from "react";
-
-import { FULL_REPAY_TOLERANCE } from "../../../../constants";
+import { useCallback, useMemo, useState } from "react";
 
 export interface UseRepayStateProps {
   /** Current debt amount for selected reserve in token units */
@@ -17,10 +16,13 @@ export interface UseRepayStateProps {
 
 export interface UseRepayStateResult {
   repayAmount: number;
+  /** Sets repay amount and resets mode to partial (used by typed input / slider) */
   setRepayAmount: (amount: number) => void;
+  /** Sets repay amount and mode atomically (used by Max button) */
+  setRepayAmountWithMode: (amount: number, mode: "partial" | "full") => void;
   resetRepayAmount: () => void;
   maxRepayAmount: number;
-  /** Whether the current repay amount represents a full repayment */
+  /** Whether the current repay represents a full repayment (set explicitly, not by tolerance) */
   isFullRepayment: boolean;
 }
 
@@ -28,27 +30,40 @@ export function useRepayState({
   currentDebtAmount,
   userTokenBalance,
 }: UseRepayStateProps): UseRepayStateResult {
-  const [repayAmount, setRepayAmount] = useState(0);
+  const [repayAmount, setRepayAmountRaw] = useState(0);
+  const [repayMode, setRepayMode] = useState<"partial" | "full">("partial");
 
   // Max repay is the minimum of debt and available balance
   const maxRepayAmount = useMemo(() => {
     return Math.max(0, Math.min(currentDebtAmount, userTokenBalance));
   }, [currentDebtAmount, userTokenBalance]);
 
-  // Full repayment only when repay amount covers the actual debt, not the balance-capped max.
-  // When balance < debt, pressing Max should route to partial repay, not full repay.
-  const isFullRepayment = useMemo(() => {
-    return (
-      currentDebtAmount > 0 &&
-      Math.abs(repayAmount - currentDebtAmount) < FULL_REPAY_TOLERANCE
-    );
-  }, [repayAmount, currentDebtAmount]);
+  // Manual input / slider always sets partial mode
+  const setRepayAmount = useCallback((amount: number) => {
+    setRepayAmountRaw(amount);
+    setRepayMode("partial");
+  }, []);
 
-  const resetRepayAmount = () => setRepayAmount(0);
+  // Max button sets amount + mode atomically
+  const setRepayAmountWithMode = useCallback(
+    (amount: number, mode: "partial" | "full") => {
+      setRepayAmountRaw(amount);
+      setRepayMode(mode);
+    },
+    [],
+  );
+
+  const resetRepayAmount = useCallback(() => {
+    setRepayAmountRaw(0);
+    setRepayMode("partial");
+  }, []);
+
+  const isFullRepayment = repayMode === "full";
 
   return {
     repayAmount,
     setRepayAmount,
+    setRepayAmountWithMode,
     resetRepayAmount,
     maxRepayAmount,
     isFullRepayment,

--- a/services/vault/src/applications/aave/components/LoanCard/Repay/index.tsx
+++ b/services/vault/src/applications/aave/components/LoanCard/Repay/index.tsx
@@ -57,6 +57,7 @@ export function Repay() {
   const {
     repayAmount,
     setRepayAmount,
+    setRepayAmountWithMode,
     resetRepayAmount,
     maxRepayAmount,
     isFullRepayment,
@@ -129,7 +130,13 @@ export function Repay() {
               label: "Max",
               value: `${formatTokenAmount(sliderMaxRepay)} ${assetConfig.symbol}`,
             }}
-            onMaxClick={() => setRepayAmount(sliderMaxRepay)}
+            onMaxClick={() => {
+              const canCoverFullDebt = maxRepayAmount >= currentDebtAmount;
+              setRepayAmountWithMode(
+                sliderMaxRepay,
+                canCoverFullDebt ? "full" : "partial",
+              );
+            }}
             rightField={{
               value:
                 tokenPriceUsd != null

--- a/services/vault/src/applications/aave/components/LoanCard/Repay/index.tsx
+++ b/services/vault/src/applications/aave/components/LoanCard/Repay/index.tsx
@@ -133,7 +133,7 @@ export function Repay() {
             onMaxClick={() => {
               const canCoverFullDebt = maxRepayAmount >= currentDebtAmount;
               setRepayAmountWithMode(
-                sliderMaxRepay,
+                maxRepayAmount,
                 canCoverFullDebt ? "full" : "partial",
               );
             }}

--- a/services/vault/src/applications/aave/components/context/LoanContext.tsx
+++ b/services/vault/src/applications/aave/components/context/LoanContext.tsx
@@ -7,6 +7,7 @@
 
 import { createContext, useContext } from "react";
 
+import type { AavePositionWithLiveData } from "../../services";
 import type { AaveReserveConfig } from "../../services/fetchConfig";
 import type { Asset } from "../../types";
 
@@ -29,6 +30,10 @@ export interface LoanContextValue {
   proxyContract: string | undefined;
   /** Price of the selected borrow token in USD (null when oracle price is temporarily unavailable) */
   tokenPriceUsd: number | null;
+  /** Whether position data may be stale (oracle-derived values possibly outdated) */
+  isPositionDataStale: boolean;
+  /** Refetch position data — returns fresh position (or null if unavailable) */
+  refetchPosition: () => Promise<AavePositionWithLiveData | null>;
   /** Callback when borrow succeeds */
   onBorrowSuccess: (borrowAmount: number) => void;
   /** Callback when repay succeeds */

--- a/services/vault/src/applications/aave/constants.ts
+++ b/services/vault/src/applications/aave/constants.ts
@@ -98,10 +98,12 @@ export const KNOWN_STABLECOIN_SYMBOLS = ["USDC", "USDT", "DAI"] as const;
 export const MIN_SLIDER_MAX = 0.0001;
 
 /**
- * Tolerance for detecting full repayment
- * If repay amount is within this tolerance of actual debt, treat as full repay
+ * Threshold (in USD) below which projected debt is treated as
+ * effectively zero for display purposes (showing "-" for health factor
+ * instead of an astronomical number). This is a display-only concern
+ * and does NOT affect repay routing (full vs partial).
  */
-export const FULL_REPAY_TOLERANCE = 0.01;
+export const NEAR_ZERO_DEBT_DISPLAY_THRESHOLD = 0.01;
 
 /**
  * BTC token display constants

--- a/services/vault/src/applications/aave/hooks/useAaveUserPosition.ts
+++ b/services/vault/src/applications/aave/hooks/useAaveUserPosition.ts
@@ -201,6 +201,9 @@ export function useAaveUserPosition(
     error: positionsError as Error | null,
     refetch: async () => {
       const result = await refetch();
+      if (result.isError) {
+        throw result.error ?? new Error("Failed to refetch position data");
+      }
       return result.data?.[0] ?? null;
     },
   };

--- a/services/vault/src/applications/aave/hooks/useAaveUserPosition.ts
+++ b/services/vault/src/applications/aave/hooks/useAaveUserPosition.ts
@@ -63,8 +63,8 @@ export interface UseAaveUserPositionResult {
   isLoading: boolean;
   /** Error state */
   error: Error | null;
-  /** Refetch function */
-  refetch: () => Promise<void>;
+  /** Refetch function — returns fresh position data (or null if unavailable) */
+  refetch: () => Promise<AavePositionWithLiveData | null>;
 }
 
 /**
@@ -199,6 +199,9 @@ export function useAaveUserPosition(
     isPositionDataStale,
     isLoading: positionsLoading || configLoading,
     error: positionsError as Error | null,
-    refetch: async () => void refetch(),
+    refetch: async () => {
+      const result = await refetch();
+      return result.data?.[0] ?? null;
+    },
   };
 }

--- a/services/vault/src/applications/aave/hooks/useBorrowTransaction.ts
+++ b/services/vault/src/applications/aave/hooks/useBorrowTransaction.ts
@@ -25,6 +25,7 @@ export interface UseBorrowTransactionResult {
   executeBorrow: (
     borrowAmount: number,
     reserve: AaveReserveConfig,
+    preSignValidation?: () => Promise<void>,
   ) => Promise<boolean>;
   /** Whether transaction is currently processing */
   isProcessing: boolean;
@@ -48,6 +49,7 @@ export function useBorrowTransaction(): UseBorrowTransactionResult {
   const executeBorrow = async (
     borrowAmount: number,
     reserve: AaveReserveConfig,
+    preSignValidation?: () => Promise<void>,
   ) => {
     if (borrowAmount <= 0) return false;
 
@@ -87,6 +89,12 @@ export function useBorrowTransaction(): UseBorrowTransactionResult {
         onChainDecimals,
       );
 
+      // Pre-sign revalidation: refetch position and recheck health factor
+      // before submitting the on-chain transaction. Throws if unsafe.
+      if (preSignValidation) {
+        await preSignValidation();
+      }
+
       // Execute the borrow transaction
       // Adapter resolves borrower's proxy from msg.sender
       await borrow(walletClient, chain, reserve.reserveId, borrowAmountBigInt);
@@ -110,7 +118,8 @@ export function useBorrowTransaction(): UseBorrowTransactionResult {
         error: mappedError,
         displayOptions: {
           showModal: true,
-          retryAction: () => executeBorrow(borrowAmount, reserve),
+          retryAction: () =>
+            executeBorrow(borrowAmount, reserve, preSignValidation),
         },
       });
 

--- a/services/vault/src/components/simple/BorrowFlow/index.tsx
+++ b/services/vault/src/components/simple/BorrowFlow/index.tsx
@@ -43,6 +43,8 @@ export function BorrowFlow({ open, onClose }: BorrowFlowProps) {
     totalDebtValueUsd,
     healthFactor,
     tokenPriceUsd,
+    isPositionDataStale,
+    refetchPosition,
   } = useAaveReserveDetail({
     reserveId: selectedAssetSymbol ?? undefined,
     address,
@@ -89,6 +91,8 @@ export function BorrowFlow({ open, onClose }: BorrowFlowProps) {
             totalDebtValueUsd={totalDebtValueUsd}
             healthFactor={healthFactor}
             tokenPriceUsd={tokenPriceUsd}
+            isPositionDataStale={isPositionDataStale}
+            refetchPosition={refetchPosition}
             onChangeAsset={goBack}
             onBorrowSuccess={completeBorrow}
           />
@@ -116,6 +120,8 @@ function BorrowFormStep({
   totalDebtValueUsd,
   healthFactor,
   tokenPriceUsd,
+  isPositionDataStale,
+  refetchPosition,
   onChangeAsset,
   onBorrowSuccess,
 }: {
@@ -129,6 +135,8 @@ function BorrowFormStep({
   totalDebtValueUsd: number;
   healthFactor: number | null;
   tokenPriceUsd: number | null;
+  isPositionDataStale: boolean;
+  refetchPosition: ReturnType<typeof useAaveReserveDetail>["refetchPosition"];
   onChangeAsset: () => void;
   onBorrowSuccess: (amount: number, symbol: string, icon: string) => void;
 }) {
@@ -152,6 +160,8 @@ function BorrowFormStep({
         assetConfig,
         proxyContract,
         tokenPriceUsd,
+        isPositionDataStale,
+        refetchPosition,
         // These callbacks are handled by the BorrowFlow orchestrator
         onBorrowSuccess: () => {},
         onRepaySuccess: () => {},


### PR DESCRIPTION
Requires https://github.com/babylonlabs-io/babylon-toolkit/pull/1430 merging, then rebasing. Additional [commit](https://github.com/babylonlabs-io/babylon-toolkit/commit/83fcc21ce04b4b0310da62c62c8e874e989e229f) is based on PR implementation, so there's less "rebasing". Hence for now this PR is in draft mode.

## Summary

Addresses two audit findings in the Aave borrow/repay flow:

- **[#132](https://github.com/babylonlabs-io/vault-provider-proxy/issues/132) — Stale data borrow:** `executeBorrow` did not refetch position data before signing. The `isPositionDataStale` flag existed in `useAaveUserPosition` but was never consumed — a user could wait minutes on the borrow form and sign a transaction whose health factor projection was based on arbitrarily old data.
- **[#133](https://github.com/babylonlabs-io/vault-provider-proxy/issues/133) — Silent full repay:** Full repayment was detected via tolerance (`Math.abs(repayAmount - currentDebtAmount) < 0.01`). Entering 99.995 when debt is 100 silently upgraded to full repay via `repayFull`, sending more tokens than the user typed. No explicit intent tracking existed.

## Changes

### Issue [#132](https://github.com/babylonlabs-io/vault-provider-proxy/issues/132): Pre-sign revalidation + staleness gating

**Staleness gating:**
- Piped `isPositionDataStale` and `refetchPosition` from `useAaveUserPosition` → `useAaveReserveDetail` → `LoanContext` → `Borrow` component
- `validateBorrowAction` now accepts `isPositionDataStale` — when true, disables the button with "Refreshing position..."

**Pre-sign revalidation:**
- `useBorrowTransaction.executeBorrow` accepts an optional `preSignValidation` callback, called after wallet/decimals validation but before the on-chain borrow call
- `Borrow` component builds this callback: refetches position via `refetchPosition()`, derives fresh collateral/debt USD from `accountData`, computes projected HF with the borrow amount, and throws if HF would drop below `MIN_HEALTH_FACTOR_FOR_BORROW`

### Issue [#133](https://github.com/babylonlabs-io/vault-provider-proxy/issues/133): Explicit repay mode

- Replaced tolerance-based `isFullRepayment` detection in `useRepayState` with explicit `"partial" | "full"` mode tracking
- `setRepayAmount` (typed input / slider) always sets mode to `"partial"`
- New `setRepayAmountWithMode` (used by Max button) sets amount + mode atomically — `"full"` only when `balance >= debt`
- Renamed `FULL_REPAY_TOLERANCE` → `NEAR_ZERO_DEBT_DISPLAY_THRESHOLD` to clarify it's display-only (for showing "-" instead of astronomical HF when projected debt ≈ 0)

Closes https://github.com/babylonlabs-io/vault-provider-proxy/issues/132
Closes https://github.com/babylonlabs-io/vault-provider-proxy/issues/133