### PR TITLE
fix(vault): validate and resume wots

### DIFF
--- a/services/vault/src/components/simple/ResumeDepositContent.tsx
+++ b/services/vault/src/components/simple/ResumeDepositContent.tsx
@@ -26,6 +26,7 @@ import { useRefundState } from "@/hooks/deposit/useRefundState";
 import { useRunOnce } from "@/hooks/useRunOnce";
 import { fetchVaultById } from "@/services/vault/fetchVaults";
 import {
+  computeWotsPublicKeysHash,
   deriveWotsBlockPublicKeys,
   getMnemonicIdForPegin,
   hasMnemonicEntry,
@@ -225,6 +226,20 @@ export function ResumeWotsContent({
           activity.applicationEntryPoint,
         );
         seed.fill(0);
+
+        if (!activity.depositorWotsPkHash) {
+          throw new Error(
+            "Missing on-chain WOTS public key hash — cannot verify mnemonic. " +
+              "The vault may not be fully indexed yet. Please try again shortly.",
+          );
+        }
+
+        const computedHash = computeWotsPublicKeysHash(wotsPublicKeys);
+        if (computedHash !== activity.depositorWotsPkHash) {
+          throw new Error(
+            "WOTS public key hash does not match the on-chain commitment — the provided mnemonic is incorrect",
+          );
+        }
 
         await submitWotsPublicKey({
           peginTxHash,

--- a/services/vault/src/components/simple/ResumeDepositContent.tsx
+++ b/services/vault/src/components/simple/ResumeDepositContent.tsx
@@ -227,13 +227,6 @@ export function ResumeWotsContent({
         );
         seed.fill(0);
 
-        if (!activity.depositorWotsPkHash) {
-          throw new Error(
-            "Missing on-chain WOTS public key hash — cannot verify mnemonic. " +
-              "The vault may not be fully indexed yet. Please try again shortly.",
-          );
-        }
-
         const computedHash = computeWotsPublicKeysHash(wotsPublicKeys);
         if (computedHash !== activity.depositorWotsPkHash) {
           throw new Error(
@@ -258,10 +251,10 @@ export function ResumeWotsContent({
         const msg =
           err instanceof Error ? err.message : "Failed to submit WOTS key";
 
-        // Only invalidate the stored mnemonic when the VP explicitly
-        // reports a WOTS hash mismatch (wrong mnemonic). Network
-        // errors, missing fields, etc. should not discard a potentially
-        // valid stored mnemonic.
+        // Invalidate the stored mnemonic when a WOTS hash mismatch is
+        // detected — either locally (computed vs on-chain hash) or by
+        // the VP. Network errors, missing fields, etc. should not
+        // discard a potentially valid stored mnemonic.
         if (isWotsMismatchError(err)) {
           setStoredFailed(true);
         }
@@ -277,6 +270,22 @@ export function ResumeWotsContent({
     setError(null);
     setShowMnemonic(true);
   }, []);
+
+  if (!activity.depositorWotsPkHash) {
+    return (
+      <DepositProgressView
+        currentStep={DepositFlowStep.SIGN_PAYOUTS}
+        isWaiting={false}
+        error="Vault is not fully indexed yet — WOTS key verification is not available. Please try again shortly."
+        isComplete={false}
+        isProcessing={false}
+        canClose={true}
+        canContinueInBackground={false}
+        payoutSigningProgress={null}
+        onClose={onClose}
+      />
+    );
+  }
 
   if (showMnemonic) {
     return (

--- a/services/vault/src/hooks/deposit/__tests__/useDepositPageFlow.test.ts
+++ b/services/vault/src/hooks/deposit/__tests__/useDepositPageFlow.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Tests for the one-shot getMnemonic pattern in useDepositPageFlow.
+ *
+ * The hook itself requires many context providers, so these tests verify
+ * the closure behaviour directly — the same logic used inside useMemo.
+ */
+
+import { describe, expect, it } from "vitest";
+
+describe("one-shot getMnemonic pattern", () => {
+  /**
+   * Simulates the closure created by the useMemo in useDepositPageFlow.
+   * Mirrors the production code:
+   *   mnemonicRef.current
+   *     ? async () => { const v = mnemonicRef.current; mnemonicRef.current = undefined; if (!v) throw ...; return v; }
+   *     : undefined
+   */
+  function createOneShotGetter(ref: { current: string | undefined }) {
+    if (!ref.current) return undefined;
+    return async () => {
+      const value = ref.current;
+      ref.current = undefined;
+      if (!value) {
+        throw new Error("Mnemonic has already been consumed");
+      }
+      return value;
+    };
+  }
+
+  it("returns the mnemonic and clears the ref on first call", async () => {
+    const ref = { current: "test mnemonic" };
+    const getMnemonic = createOneShotGetter(ref)!;
+
+    const result = await getMnemonic();
+
+    expect(result).toBe("test mnemonic");
+    expect(ref.current).toBeUndefined();
+  });
+
+  it("throws on second call after mnemonic was consumed", async () => {
+    const ref = { current: "test mnemonic" };
+    const getMnemonic = createOneShotGetter(ref)!;
+
+    await getMnemonic(); // consume
+
+    await expect(getMnemonic()).rejects.toThrow(
+      "Mnemonic has already been consumed",
+    );
+  });
+
+  it("returns undefined when ref has no mnemonic", () => {
+    const ref = { current: undefined };
+    const getMnemonic = createOneShotGetter(ref);
+
+    expect(getMnemonic).toBeUndefined();
+  });
+});

--- a/services/vault/src/hooks/deposit/useDepositPageFlow.ts
+++ b/services/vault/src/hooks/deposit/useDepositPageFlow.ts
@@ -180,7 +180,17 @@ export function useDepositPageFlow(): UseDepositPageFlowResult {
   }, []);
 
   const getMnemonic = useMemo<(() => Promise<string>) | undefined>(
-    () => (mnemonicRef.current ? async () => mnemonicRef.current! : undefined),
+    () =>
+      mnemonicRef.current
+        ? async () => {
+            const value = mnemonicRef.current;
+            mnemonicRef.current = undefined;
+            if (!value) {
+              throw new Error("Mnemonic has already been consumed");
+            }
+            return value;
+          }
+        : undefined,
     // eslint-disable-next-line react-hooks/exhaustive-deps -- mnemonicVersion triggers rebuild
     [mnemonicVersion],
   );
@@ -194,6 +204,7 @@ export function useDepositPageFlow(): UseDepositPageFlowResult {
 
   const onSignSuccess = (peginTxHash: string, ethTxHash: string) => {
     setTransactionHashes(peginTxHash, ethTxHash);
+    mnemonicRef.current = undefined;
     goToStep(DepositStep.SUCCESS);
   };
 


### PR DESCRIPTION
## Summary

Fixes two LOW-severity audit findings (v2 #79, #80) related to WOTS mnemonic lifecycle in the deposit flow:

- [**#79**](https://github.com/babylonlabs-io/vault-provider-proxy/issues/158): Make `getMnemonic` a one-shot function that clears `mnemonicRef` immediately after consumption, instead of leaving plaintext in memory until success/reset
- [**#80**](https://github.com/babylonlabs-io/vault-provider-proxy/issues/159): Make WOTS public key hash verification mandatory in the resume flow — refuse to link a peg-in to a mnemonic when the on-chain hash is unavailable, and throw on mismatch

## Changes

### Fix [#79](https://github.com/babylonlabs-io/vault-provider-proxy/issues/158) — `useDepositPageFlow.ts`

`getMnemonic` is now a one-shot closure: the first call returns the mnemonic and immediately clears `mnemonicRef.current`; a second call throws `"Mnemonic has already been consumed"`. This ensures the plaintext is cleared on **all** code paths (success, error, abort) — not just the success path via `onSignSuccess`. The existing `onSignSuccess` and `resetDeposit` cleanup is retained as defense-in-depth.

### Fix [#80](https://github.com/babylonlabs-io/vault-provider-proxy/issues/159) — `ResumeDepositContent.tsx`

The `depositorWotsPkHash` validation is now **mandatory** instead of conditional. When the hash is missing (e.g. pending-only activities where the indexer hasn't caught up), the flow throws with an actionable message rather than silently skipping validation. When the hash is present but mismatches, the existing `isWotsMismatchError` pattern catches it and sets `storedFailed = true`, prompting the user to re-enter their mnemonic. This prevents wrong-mnemonic mapping when the VP has already advanced past the WOTS stage.

Closes https://github.com/babylonlabs-io/vault-provider-proxy/issues/158
Closes https://github.com/babylonlabs-io/vault-provider-proxy/issues/159
