### PR TITLE
fix(vault): protocol params validation

### DIFF
--- a/services/vault/src/clients/eth-contract/protocol-params/__tests__/query.test.ts
+++ b/services/vault/src/clients/eth-contract/protocol-params/__tests__/query.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockReadContract = vi.fn();
+const mockGetChainId = vi.fn();
+const mockMulticall = vi.fn();
+
+vi.mock("@/clients/eth-contract/client", () => ({
+  ethClient: {
+    getPublicClient: () => ({
+      readContract: mockReadContract,
+      getChainId: mockGetChainId,
+      multicall: mockMulticall,
+    }),
+  },
+}));
+
+vi.mock("@/config/contracts", () => ({
+  CONTRACTS: {
+    BTC_VAULT_REGISTRY: "0xBTCVaultRegistry" as `0x${string}`,
+  },
+}));
+
+const PROTOCOL_PARAMS_ADDRESS = "0xProtocolParams" as `0x${string}`;
+
+const VALID_TBV_PARAMS = {
+  minimumPegInAmount: 100_000n,
+  maxPegInAmount: 10_000_000n,
+  pegInAckTimeout: 100n,
+  peginActivationTimeout: 200n,
+};
+
+const VALID_OFFCHAIN_PARAMS = {
+  timelockAssert: 150n,
+  timelockChallengeAssert: 300n,
+  securityCouncilKeys: ["0xaa", "0xbb", "0xcc"],
+  councilQuorum: 2,
+  feeRate: 1000n,
+  babeTotalInstances: 3,
+  babeInstancesToFinalize: 2,
+  minVpCommissionBps: 500,
+  tRefund: 144,
+  tStale: 288,
+  minPeginFeeRate: 1n,
+};
+
+type QueryModule = typeof import("../query");
+let query: QueryModule;
+
+beforeEach(async () => {
+  mockReadContract.mockReset();
+  mockGetChainId.mockReset();
+  mockMulticall.mockReset();
+  vi.resetModules();
+  query = await import("../query");
+});
+
+describe("getProtocolParamsAddress cache TTL", () => {
+  it("caches the protocol params address for subsequent calls", async () => {
+    mockGetChainId.mockResolvedValue(11155111);
+    mockReadContract.mockResolvedValue(PROTOCOL_PARAMS_ADDRESS);
+    mockMulticall.mockResolvedValue([VALID_TBV_PARAMS, VALID_OFFCHAIN_PARAMS]);
+
+    await query.getPegInConfiguration();
+    await query.getPegInConfiguration();
+
+    const registryCalls = mockReadContract.mock.calls.filter(
+      (c) => c[0].functionName === "protocolParams",
+    );
+    expect(registryCalls).toHaveLength(1);
+  });
+
+  it("refetches the protocol params address after the cache TTL expires", async () => {
+    vi.useFakeTimers();
+    try {
+      mockGetChainId.mockResolvedValue(11155111);
+      mockReadContract.mockResolvedValue(PROTOCOL_PARAMS_ADDRESS);
+      mockMulticall.mockResolvedValue([
+        VALID_TBV_PARAMS,
+        VALID_OFFCHAIN_PARAMS,
+      ]);
+
+      await query.getPegInConfiguration();
+
+      // TTL is 5 minutes; advance past it
+      vi.advanceTimersByTime(5 * 60 * 1000 + 1);
+      await query.getPegInConfiguration();
+
+      const registryCalls = mockReadContract.mock.calls.filter(
+        (c) => c[0].functionName === "protocolParams",
+      );
+      expect(registryCalls).toHaveLength(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("getPegInConfiguration validation", () => {
+  it("throws when contract returns invalid offchain params", async () => {
+    mockGetChainId.mockResolvedValue(11155111);
+    mockReadContract.mockResolvedValue(PROTOCOL_PARAMS_ADDRESS);
+    mockMulticall.mockResolvedValue([
+      VALID_TBV_PARAMS,
+      { ...VALID_OFFCHAIN_PARAMS, councilQuorum: 0 },
+    ]);
+
+    await expect(query.getPegInConfiguration()).rejects.toThrow(
+      /councilQuorum must be positive/,
+    );
+  });
+
+  it("throws when minimumPegInAmount exceeds maxPegInAmount", async () => {
+    mockGetChainId.mockResolvedValue(11155111);
+    mockReadContract.mockResolvedValue(PROTOCOL_PARAMS_ADDRESS);
+    mockMulticall.mockResolvedValue([
+      { ...VALID_TBV_PARAMS, minimumPegInAmount: 10n, maxPegInAmount: 5n },
+      VALID_OFFCHAIN_PARAMS,
+    ]);
+
+    await expect(query.getPegInConfiguration()).rejects.toThrow(
+      /maxPegInAmount.*must be >= minimumPegInAmount/,
+    );
+  });
+});

--- a/services/vault/src/clients/eth-contract/protocol-params/__tests__/query.test.ts
+++ b/services/vault/src/clients/eth-contract/protocol-params/__tests__/query.test.ts
@@ -95,6 +95,48 @@ describe("getProtocolParamsAddress cache TTL", () => {
   });
 });
 
+describe("getProtocolParamsAddress stale cache fallback", () => {
+  it("returns stale cached address when RPC refresh fails", async () => {
+    vi.useFakeTimers();
+    try {
+      mockGetChainId.mockResolvedValue(11155111);
+      mockReadContract.mockResolvedValue(PROTOCOL_PARAMS_ADDRESS);
+      mockMulticall.mockResolvedValue([
+        VALID_TBV_PARAMS,
+        VALID_OFFCHAIN_PARAMS,
+      ]);
+
+      // First call succeeds and populates the cache
+      await query.getPegInConfiguration();
+
+      // Advance past TTL
+      vi.advanceTimersByTime(5 * 60 * 1000 + 1);
+
+      // Registry read fails, but multicall still works (different contract)
+      mockReadContract.mockRejectedValueOnce(new Error("rpc unavailable"));
+      mockMulticall.mockResolvedValue([
+        VALID_TBV_PARAMS,
+        VALID_OFFCHAIN_PARAMS,
+      ]);
+
+      // Should succeed using stale cached address
+      const config = await query.getPegInConfiguration();
+      expect(config.minimumPegInAmount).toBe(100_000n);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("throws when RPC fails and there is no cached address", async () => {
+    mockGetChainId.mockResolvedValue(11155111);
+    mockReadContract.mockRejectedValue(new Error("rpc unavailable"));
+
+    await expect(query.getPegInConfiguration()).rejects.toThrow(
+      "rpc unavailable",
+    );
+  });
+});
+
 describe("getPegInConfiguration validation", () => {
   it("throws when contract returns invalid offchain params", async () => {
     mockGetChainId.mockResolvedValue(11155111);

--- a/services/vault/src/clients/eth-contract/protocol-params/__tests__/query.test.ts
+++ b/services/vault/src/clients/eth-contract/protocol-params/__tests__/query.test.ts
@@ -20,6 +20,13 @@ vi.mock("@/config/contracts", () => ({
   },
 }));
 
+const mockLoggerWarn = vi.fn();
+vi.mock("@/infrastructure", () => ({
+  logger: {
+    warn: (...args: unknown[]) => mockLoggerWarn(...args),
+  },
+}));
+
 const PROTOCOL_PARAMS_ADDRESS = "0xProtocolParams" as `0x${string}`;
 
 const VALID_TBV_PARAMS = {
@@ -50,6 +57,7 @@ beforeEach(async () => {
   mockReadContract.mockReset();
   mockGetChainId.mockReset();
   mockMulticall.mockReset();
+  mockLoggerWarn.mockReset();
   vi.resetModules();
   query = await import("../query");
 });
@@ -133,6 +141,43 @@ describe("getProtocolParamsAddress stale cache fallback", () => {
 
     await expect(query.getPegInConfiguration()).rejects.toThrow(
       "rpc unavailable",
+    );
+  });
+});
+
+describe("fetchAllOffchainParams historical validation", () => {
+  it("omits invalid historical versions and keeps valid ones", async () => {
+    mockGetChainId.mockResolvedValue(11155111);
+    mockReadContract
+      .mockResolvedValueOnce(PROTOCOL_PARAMS_ADDRESS) // registry lookup
+      .mockResolvedValueOnce(2n); // latestVersion
+
+    const invalidParams = { ...VALID_OFFCHAIN_PARAMS, councilQuorum: 0 };
+    mockMulticall.mockResolvedValue([invalidParams, VALID_OFFCHAIN_PARAMS]);
+
+    const result = await query.fetchAllOffchainParams();
+
+    expect(result.latestVersion).toBe(2);
+    expect(result.byVersion.has(1)).toBe(false);
+    expect(result.byVersion.has(2)).toBe(true);
+    expect(result.byVersion.get(2)).toEqual(VALID_OFFCHAIN_PARAMS);
+  });
+
+  it("logs a warning for invalid historical versions", async () => {
+    mockGetChainId.mockResolvedValue(11155111);
+    mockReadContract
+      .mockResolvedValueOnce(PROTOCOL_PARAMS_ADDRESS)
+      .mockResolvedValueOnce(1n);
+
+    const invalidParams = { ...VALID_OFFCHAIN_PARAMS, feeRate: 0n };
+    mockMulticall.mockResolvedValue([invalidParams]);
+
+    const result = await query.fetchAllOffchainParams();
+
+    expect(result.byVersion.size).toBe(0);
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.stringContaining("Offchain params v1 failed validation"),
+      expect.objectContaining({ category: "protocol-params" }),
     );
   });
 });

--- a/services/vault/src/clients/eth-contract/protocol-params/__tests__/validation.test.ts
+++ b/services/vault/src/clients/eth-contract/protocol-params/__tests__/validation.test.ts
@@ -1,0 +1,272 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  PegInConfiguration,
+  TBVProtocolParams,
+  VersionedOffchainParams,
+} from "../query";
+import {
+  validateOffchainParams,
+  validatePegInConfiguration,
+  validateTBVProtocolParams,
+} from "../validation";
+
+function validOffchainParams(
+  overrides: Partial<VersionedOffchainParams> = {},
+): VersionedOffchainParams {
+  return {
+    timelockAssert: 150n,
+    timelockChallengeAssert: 300n,
+    securityCouncilKeys: ["0xaa", "0xbb", "0xcc"],
+    councilQuorum: 2,
+    feeRate: 1000n,
+    babeTotalInstances: 3,
+    babeInstancesToFinalize: 2,
+    minVpCommissionBps: 500,
+    tRefund: 144,
+    tStale: 288,
+    minPeginFeeRate: 1n,
+    ...overrides,
+  };
+}
+
+function validPegInConfig(
+  overrides: Partial<PegInConfiguration> = {},
+  offchainOverrides: Partial<VersionedOffchainParams> = {},
+): PegInConfiguration {
+  return {
+    minimumPegInAmount: 100_000n,
+    maxPegInAmount: 10_000_000n,
+    pegInAckTimeout: 100n,
+    peginActivationTimeout: 200n,
+    timelockPegin: 150,
+    timelockRefund: 144,
+    minVpCommissionBps: 500,
+    offchainParams: validOffchainParams(offchainOverrides),
+    ...overrides,
+  };
+}
+
+describe("validateOffchainParams", () => {
+  it("accepts valid offchain params", () => {
+    expect(() => validateOffchainParams(validOffchainParams())).not.toThrow();
+  });
+
+  it("rejects timelockAssert of zero", () => {
+    expect(() =>
+      validateOffchainParams(validOffchainParams({ timelockAssert: 0n })),
+    ).toThrow(/timelockAssert must be positive/);
+  });
+
+  it("rejects timelockAssert exceeding uint16 max", () => {
+    expect(() =>
+      validateOffchainParams(validOffchainParams({ timelockAssert: 65536n })),
+    ).toThrow(/exceeds uint16 max/);
+  });
+
+  it("accepts timelockAssert at uint16 max boundary", () => {
+    expect(() =>
+      validateOffchainParams(validOffchainParams({ timelockAssert: 65535n })),
+    ).not.toThrow();
+  });
+
+  it("rejects timelockChallengeAssert of zero", () => {
+    expect(() =>
+      validateOffchainParams(
+        validOffchainParams({ timelockChallengeAssert: 0n }),
+      ),
+    ).toThrow(/timelockChallengeAssert must be positive/);
+  });
+
+  it("rejects tRefund of zero", () => {
+    expect(() =>
+      validateOffchainParams(validOffchainParams({ tRefund: 0 })),
+    ).toThrow(/tRefund must be positive/);
+  });
+
+  it("rejects tStale of zero", () => {
+    expect(() =>
+      validateOffchainParams(validOffchainParams({ tStale: 0 })),
+    ).toThrow(/tStale must be positive/);
+  });
+
+  it("rejects empty securityCouncilKeys", () => {
+    expect(() =>
+      validateOffchainParams(
+        validOffchainParams({ securityCouncilKeys: [], councilQuorum: 0 }),
+      ),
+    ).toThrow(/securityCouncilKeys must not be empty/);
+  });
+
+  it("rejects councilQuorum of zero", () => {
+    expect(() =>
+      validateOffchainParams(validOffchainParams({ councilQuorum: 0 })),
+    ).toThrow(/councilQuorum must be positive/);
+  });
+
+  it("rejects councilQuorum exceeding securityCouncilKeys count", () => {
+    expect(() =>
+      validateOffchainParams(
+        validOffchainParams({
+          securityCouncilKeys: ["0xaa", "0xbb"],
+          councilQuorum: 3,
+        }),
+      ),
+    ).toThrow(/councilQuorum \(3\) exceeds securityCouncilKeys count \(2\)/);
+  });
+
+  it("rejects feeRate of zero", () => {
+    expect(() =>
+      validateOffchainParams(validOffchainParams({ feeRate: 0n })),
+    ).toThrow(/feeRate must be positive/);
+  });
+
+  it("rejects minPeginFeeRate of zero", () => {
+    expect(() =>
+      validateOffchainParams(validOffchainParams({ minPeginFeeRate: 0n })),
+    ).toThrow(/minPeginFeeRate must be positive/);
+  });
+
+  it("rejects babeTotalInstances of zero", () => {
+    expect(() =>
+      validateOffchainParams(
+        validOffchainParams({
+          babeTotalInstances: 0,
+          babeInstancesToFinalize: 0,
+        }),
+      ),
+    ).toThrow(/babeTotalInstances must be positive/);
+  });
+
+  it("rejects babeInstancesToFinalize exceeding babeTotalInstances", () => {
+    expect(() =>
+      validateOffchainParams(
+        validOffchainParams({
+          babeTotalInstances: 2,
+          babeInstancesToFinalize: 3,
+        }),
+      ),
+    ).toThrow(/babeInstancesToFinalize \(3\) exceeds babeTotalInstances \(2\)/);
+  });
+
+  it("rejects minVpCommissionBps above 10000", () => {
+    expect(() =>
+      validateOffchainParams(
+        validOffchainParams({ minVpCommissionBps: 10001 }),
+      ),
+    ).toThrow(/minVpCommissionBps must be in \[0, 10000\]/);
+  });
+
+  it("accepts minVpCommissionBps at boundary values", () => {
+    expect(() =>
+      validateOffchainParams(validOffchainParams({ minVpCommissionBps: 0 })),
+    ).not.toThrow();
+    expect(() =>
+      validateOffchainParams(
+        validOffchainParams({ minVpCommissionBps: 10000 }),
+      ),
+    ).not.toThrow();
+  });
+
+  it("collects multiple errors into a single message", () => {
+    expect(() =>
+      validateOffchainParams(
+        validOffchainParams({
+          timelockAssert: 0n,
+          councilQuorum: 0,
+          feeRate: 0n,
+        }),
+      ),
+    ).toThrow(/timelockAssert.*councilQuorum.*feeRate/s);
+  });
+});
+
+function validTBVParams(
+  overrides: Partial<TBVProtocolParams> = {},
+): TBVProtocolParams {
+  return {
+    minimumPegInAmount: 100_000n,
+    maxPegInAmount: 10_000_000n,
+    pegInAckTimeout: 100n,
+    peginActivationTimeout: 200n,
+    ...overrides,
+  };
+}
+
+describe("validateTBVProtocolParams", () => {
+  it("accepts valid TBV params", () => {
+    expect(() => validateTBVProtocolParams(validTBVParams())).not.toThrow();
+  });
+
+  it("rejects minimumPegInAmount of zero", () => {
+    expect(() =>
+      validateTBVProtocolParams(validTBVParams({ minimumPegInAmount: 0n })),
+    ).toThrow(/minimumPegInAmount must be positive/);
+  });
+
+  it("rejects maxPegInAmount less than minimumPegInAmount", () => {
+    expect(() =>
+      validateTBVProtocolParams(
+        validTBVParams({
+          minimumPegInAmount: 1_000_000n,
+          maxPegInAmount: 500_000n,
+        }),
+      ),
+    ).toThrow(/maxPegInAmount.*must be >= minimumPegInAmount/);
+  });
+
+  it("rejects pegInAckTimeout of zero", () => {
+    expect(() =>
+      validateTBVProtocolParams(validTBVParams({ pegInAckTimeout: 0n })),
+    ).toThrow(/pegInAckTimeout must be positive/);
+  });
+
+  it("rejects peginActivationTimeout of zero", () => {
+    expect(() =>
+      validateTBVProtocolParams(validTBVParams({ peginActivationTimeout: 0n })),
+    ).toThrow(/peginActivationTimeout must be positive/);
+  });
+});
+
+describe("validatePegInConfiguration", () => {
+  it("accepts valid peg-in configuration", () => {
+    expect(() => validatePegInConfiguration(validPegInConfig())).not.toThrow();
+  });
+
+  it("rejects minimumPegInAmount of zero", () => {
+    expect(() =>
+      validatePegInConfiguration(validPegInConfig({ minimumPegInAmount: 0n })),
+    ).toThrow(/minimumPegInAmount must be positive/);
+  });
+
+  it("rejects maxPegInAmount less than minimumPegInAmount", () => {
+    expect(() =>
+      validatePegInConfiguration(
+        validPegInConfig({
+          minimumPegInAmount: 1_000_000n,
+          maxPegInAmount: 500_000n,
+        }),
+      ),
+    ).toThrow(/maxPegInAmount.*must be >= minimumPegInAmount/);
+  });
+
+  it("rejects pegInAckTimeout of zero", () => {
+    expect(() =>
+      validatePegInConfiguration(validPegInConfig({ pegInAckTimeout: 0n })),
+    ).toThrow(/pegInAckTimeout must be positive/);
+  });
+
+  it("rejects peginActivationTimeout of zero", () => {
+    expect(() =>
+      validatePegInConfiguration(
+        validPegInConfig({ peginActivationTimeout: 0n }),
+      ),
+    ).toThrow(/peginActivationTimeout must be positive/);
+  });
+
+  it("also validates offchain params within the configuration", () => {
+    expect(() =>
+      validatePegInConfiguration(validPegInConfig({}, { councilQuorum: 0 })),
+    ).toThrow(/councilQuorum must be positive/);
+  });
+});

--- a/services/vault/src/clients/eth-contract/protocol-params/query.ts
+++ b/services/vault/src/clients/eth-contract/protocol-params/query.ts
@@ -8,6 +8,7 @@
 import type { Abi, Address } from "viem";
 
 import { CONTRACTS } from "@/config/contracts";
+import { logger } from "@/infrastructure";
 
 import BTCVaultRegistryAbi from "../btc-vault-registry/abis/BTCVaultRegistry.abi.json";
 import { ethClient } from "../client";
@@ -310,8 +311,15 @@ export async function fetchAllOffchainParams(): Promise<AllOffchainParamsData> {
   const byVersion = new Map<number, VersionedOffchainParams>();
   for (let i = 0; i < versions.length; i++) {
     const params = results[i] as unknown as VersionedOffchainParams;
-    validateOffchainParams(params);
-    byVersion.set(versions[i], params);
+    try {
+      validateOffchainParams(params);
+      byVersion.set(versions[i], params);
+    } catch (error) {
+      logger.warn(
+        `Offchain params v${versions[i]} failed validation, skipping: ${error instanceof Error ? error.message : String(error)}`,
+        { category: "protocol-params" },
+      );
+    }
   }
 
   return { byVersion, latestVersion };

--- a/services/vault/src/clients/eth-contract/protocol-params/query.ts
+++ b/services/vault/src/clients/eth-contract/protocol-params/query.ts
@@ -100,17 +100,27 @@ async function getProtocolParamsAddress(): Promise<Address> {
     return cached.address;
   }
 
-  const address = await publicClient.readContract({
-    address: CONTRACTS.BTC_VAULT_REGISTRY,
-    abi: BTCVaultRegistryAbi,
-    functionName: "protocolParams",
-  });
+  try {
+    const address = await publicClient.readContract({
+      address: CONTRACTS.BTC_VAULT_REGISTRY,
+      abi: BTCVaultRegistryAbi,
+      functionName: "protocolParams",
+    });
 
-  protocolParamsAddressCache.set(chainId, {
-    address: address as Address,
-    fetchedAt: Date.now(),
-  });
-  return address as Address;
+    protocolParamsAddressCache.set(chainId, {
+      address: address as Address,
+      fetchedAt: Date.now(),
+    });
+    return address as Address;
+  } catch (error) {
+    // Stale-while-revalidate: if the RPC call fails but we have a
+    // previously fetched address, return it rather than blocking the UI.
+    // Governance upgrades are rare; transient RPC failures are not.
+    if (cached) {
+      return cached.address;
+    }
+    throw error;
+  }
 }
 
 /**

--- a/services/vault/src/clients/eth-contract/protocol-params/query.ts
+++ b/services/vault/src/clients/eth-contract/protocol-params/query.ts
@@ -13,6 +13,11 @@ import BTCVaultRegistryAbi from "../btc-vault-registry/abis/BTCVaultRegistry.abi
 import { ethClient } from "../client";
 
 import ProtocolParamsAbi from "./abis/ProtocolParams.abi.json";
+import {
+  validateOffchainParams,
+  validatePegInConfiguration,
+  validateTBVProtocolParams,
+} from "./validation";
 
 /**
  * TBV Protocol Parameters from the contract
@@ -65,10 +70,23 @@ export interface PegInConfiguration {
 }
 
 /**
+ * TTL for the protocol params address cache.
+ * Matches the React Query stale time in ProtocolParamsContext so that
+ * a governance contract upgrade is picked up on the next re-fetch cycle.
+ */
+const ADDRESS_CACHE_TTL_MS = 5 * 60 * 1000;
+
+interface CachedAddress {
+  address: Address;
+  fetchedAt: number;
+}
+
+/**
  * Cache for protocol params address, keyed by chainId.
  * This ensures correct address is used when switching networks.
+ * Entries expire after ADDRESS_CACHE_TTL_MS so governance upgrades are detected.
  */
-const protocolParamsAddressCache = new Map<number, Address>();
+const protocolParamsAddressCache = new Map<number, CachedAddress>();
 
 /**
  * Get the ProtocolParams contract address from BTCVaultRegistry
@@ -78,8 +96,8 @@ async function getProtocolParamsAddress(): Promise<Address> {
   const chainId = await publicClient.getChainId();
 
   const cached = protocolParamsAddressCache.get(chainId);
-  if (cached) {
-    return cached;
+  if (cached && Date.now() - cached.fetchedAt < ADDRESS_CACHE_TTL_MS) {
+    return cached.address;
   }
 
   const address = await publicClient.readContract({
@@ -88,7 +106,10 @@ async function getProtocolParamsAddress(): Promise<Address> {
     functionName: "protocolParams",
   });
 
-  protocolParamsAddressCache.set(chainId, address as Address);
+  protocolParamsAddressCache.set(chainId, {
+    address: address as Address,
+    fetchedAt: Date.now(),
+  });
   return address as Address;
 }
 
@@ -107,6 +128,7 @@ export async function getTBVProtocolParams(): Promise<TBVProtocolParams> {
 
   // Viem returns named tuple components as an object with named properties
   const result = params as TBVProtocolParams;
+  validateTBVProtocolParams(result);
 
   return {
     minimumPegInAmount: result.minimumPegInAmount,
@@ -130,7 +152,9 @@ export async function getLatestOffchainParams(): Promise<VersionedOffchainParams
     functionName: "getLatestOffchainParams",
   });
 
-  return result as VersionedOffchainParams;
+  const params = result as VersionedOffchainParams;
+  validateOffchainParams(params);
+  return params;
 }
 
 /**
@@ -169,7 +193,7 @@ export async function getPegInConfiguration(): Promise<PegInConfiguration> {
 
   const timelockRefund = Number(offchainParams.tRefund);
 
-  return {
+  const config: PegInConfiguration = {
     minimumPegInAmount: params.minimumPegInAmount,
     maxPegInAmount: params.maxPegInAmount,
     pegInAckTimeout: params.pegInAckTimeout,
@@ -179,6 +203,10 @@ export async function getPegInConfiguration(): Promise<PegInConfiguration> {
     minVpCommissionBps: offchainParams.minVpCommissionBps,
     offchainParams,
   };
+
+  validatePegInConfiguration(config);
+
+  return config;
 }
 
 /**
@@ -213,7 +241,9 @@ export async function getOffchainParamsByVersion(
     args: [versionNumber],
   });
 
-  return result as VersionedOffchainParams;
+  const params = result as VersionedOffchainParams;
+  validateOffchainParams(params);
+  return params;
 }
 
 /**
@@ -269,10 +299,9 @@ export async function fetchAllOffchainParams(): Promise<AllOffchainParamsData> {
 
   const byVersion = new Map<number, VersionedOffchainParams>();
   for (let i = 0; i < versions.length; i++) {
-    byVersion.set(
-      versions[i],
-      results[i] as unknown as VersionedOffchainParams,
-    );
+    const params = results[i] as unknown as VersionedOffchainParams;
+    validateOffchainParams(params);
+    byVersion.set(versions[i], params);
   }
 
   return { byVersion, latestVersion };

--- a/services/vault/src/clients/eth-contract/protocol-params/validation.ts
+++ b/services/vault/src/clients/eth-contract/protocol-params/validation.ts
@@ -1,0 +1,154 @@
+/**
+ * Validation for protocol parameters fetched from the ProtocolParams contract.
+ *
+ * These values feed Bitcoin script construction and deposit validation.
+ * Invalid params must be caught before they reach transaction-building code,
+ * since errors after wallet signing prompts are unrecoverable.
+ */
+
+import type {
+  PegInConfiguration,
+  TBVProtocolParams,
+  VersionedOffchainParams,
+} from "./query";
+
+/**
+ * Maximum value for a Solidity uint16.
+ * PeginLogic.sol casts timelockAssert to uint16, so values above this are invalid.
+ */
+const UINT16_MAX = 65535;
+
+/** Maximum valid value for basis points (100%) */
+const MAX_BASIS_POINTS = 10000;
+
+/**
+ * Validate offchain params consistency and bounds.
+ * Throws on invalid values to prevent constructing invalid Bitcoin scripts.
+ */
+export function validateOffchainParams(params: VersionedOffchainParams): void {
+  const errors: string[] = [];
+
+  if (params.timelockAssert <= 0n) {
+    errors.push(
+      `timelockAssert must be positive, got ${params.timelockAssert}`,
+    );
+  }
+  if (params.timelockAssert > BigInt(UINT16_MAX)) {
+    errors.push(
+      `timelockAssert ${params.timelockAssert} exceeds uint16 max (${UINT16_MAX})`,
+    );
+  }
+
+  if (params.timelockChallengeAssert <= 0n) {
+    errors.push(
+      `timelockChallengeAssert must be positive, got ${params.timelockChallengeAssert}`,
+    );
+  }
+
+  if (params.tRefund <= 0) {
+    errors.push(`tRefund must be positive, got ${params.tRefund}`);
+  }
+
+  if (params.tStale <= 0) {
+    errors.push(`tStale must be positive, got ${params.tStale}`);
+  }
+
+  if (params.securityCouncilKeys.length === 0) {
+    errors.push("securityCouncilKeys must not be empty");
+  }
+
+  if (params.councilQuorum <= 0) {
+    errors.push(`councilQuorum must be positive, got ${params.councilQuorum}`);
+  }
+  if (params.councilQuorum > params.securityCouncilKeys.length) {
+    errors.push(
+      `councilQuorum (${params.councilQuorum}) exceeds securityCouncilKeys count (${params.securityCouncilKeys.length})`,
+    );
+  }
+
+  if (params.feeRate <= 0n) {
+    errors.push(`feeRate must be positive, got ${params.feeRate}`);
+  }
+
+  if (params.minPeginFeeRate <= 0n) {
+    errors.push(
+      `minPeginFeeRate must be positive, got ${params.minPeginFeeRate}`,
+    );
+  }
+
+  if (params.babeTotalInstances <= 0) {
+    errors.push(
+      `babeTotalInstances must be positive, got ${params.babeTotalInstances}`,
+    );
+  }
+  if (params.babeInstancesToFinalize <= 0) {
+    errors.push(
+      `babeInstancesToFinalize must be positive, got ${params.babeInstancesToFinalize}`,
+    );
+  }
+  if (params.babeInstancesToFinalize > params.babeTotalInstances) {
+    errors.push(
+      `babeInstancesToFinalize (${params.babeInstancesToFinalize}) exceeds babeTotalInstances (${params.babeTotalInstances})`,
+    );
+  }
+
+  if (
+    params.minVpCommissionBps < 0 ||
+    params.minVpCommissionBps > MAX_BASIS_POINTS
+  ) {
+    errors.push(
+      `minVpCommissionBps must be in [0, ${MAX_BASIS_POINTS}], got ${params.minVpCommissionBps}`,
+    );
+  }
+
+  if (errors.length > 0) {
+    throw new Error(
+      `Invalid offchain protocol parameters: ${errors.join("; ")}`,
+    );
+  }
+}
+
+/**
+ * Validate TBV protocol params returned from the contract.
+ * Ensures amounts are positive and internally consistent.
+ */
+export function validateTBVProtocolParams(params: TBVProtocolParams): void {
+  const errors: string[] = [];
+
+  if (params.minimumPegInAmount <= 0n) {
+    errors.push(
+      `minimumPegInAmount must be positive, got ${params.minimumPegInAmount}`,
+    );
+  }
+
+  if (params.maxPegInAmount < params.minimumPegInAmount) {
+    errors.push(
+      `maxPegInAmount (${params.maxPegInAmount}) must be >= minimumPegInAmount (${params.minimumPegInAmount})`,
+    );
+  }
+
+  if (params.pegInAckTimeout <= 0n) {
+    errors.push(
+      `pegInAckTimeout must be positive, got ${params.pegInAckTimeout}`,
+    );
+  }
+
+  if (params.peginActivationTimeout <= 0n) {
+    errors.push(
+      `peginActivationTimeout must be positive, got ${params.peginActivationTimeout}`,
+    );
+  }
+
+  if (errors.length > 0) {
+    throw new Error(`Invalid TBV protocol parameters: ${errors.join("; ")}`);
+  }
+}
+
+/**
+ * Validate the full peg-in configuration after assembly.
+ * Checks both TBV params and offchain params consistency.
+ */
+export function validatePegInConfiguration(config: PegInConfiguration): void {
+  validateTBVProtocolParams(config);
+  validateOffchainParams(config.offchainParams);
+}


### PR DESCRIPTION
## Summary

- Add defensive validation for all protocol parameters fetched from the ProtocolParams contract, preventing invalid values from reaching Bitcoin script construction or deposit signing code
- Add TTL-based cache expiry (5 min) to the protocol params address lookup so governance contract upgrades are detected without a page refresh
- Addresses audit findings [#45 (MEDIUM)](https://github.com/babylonlabs-io/vault-provider-proxy/issues/129) and [#67 (LOW)](https://github.com/babylonlabs-io/vault-provider-proxy/issues/146)

## What changed

### Validation (`validation.ts`)
- **`validateOffchainParams`** — checks all fields: `timelockAssert` (positive + uint16 bound), `timelockChallengeAssert`, `tRefund`, `tStale`, `securityCouncilKeys` (non-empty), `councilQuorum` (positive + <= keys count), `feeRate`, `minPeginFeeRate`, `babeTotalInstances`, `babeInstancesToFinalize` (<= total), `minVpCommissionBps` ([0, 10000])
- **`validateTBVProtocolParams`** — checks `minimumPegInAmount`, `maxPegInAmount` (>= min), `pegInAckTimeout`, `peginActivationTimeout`
- **`validatePegInConfiguration`** — delegates to both validators above
- All validators use error-collector pattern (aggregates all failures into a single throw)

### Cache TTL (`query.ts`)
- Protocol params address cache entries now expire after 5 minutes (`ADDRESS_CACHE_TTL_MS`), matching the React Query stale time in `ProtocolParamsContext`

### Validation coverage across all code paths (`query.ts`)
- `getTBVProtocolParams` — validates via `validateTBVProtocolParams`
- `getLatestOffchainParams` — validates via `validateOffchainParams`
- `getPegInConfiguration` — validates via `validatePegInConfiguration`
- `getOffchainParamsByVersion` — validates via `validateOffchainParams`
- `fetchAllOffchainParams` — validates each version in the multicall loop


Closes https://github.com/babylonlabs-io/vault-provider-proxy/issues/129
Closes https://github.com/babylonlabs-io/vault-provider-proxy/issues/146