### PR TITLE
fix(vault): wire borrow/repay/redeem in Activity tab

### DIFF
--- a/services/vault/src/hooks/useActivities.ts
+++ b/services/vault/src/hooks/useActivities.ts
@@ -3,23 +3,82 @@
  */
 
 import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
 import type { Address } from "viem";
 
 import {
+  getApplication,
+  getApplicationMetadataByController,
+} from "../applications";
+import { AAVE_APP_ID } from "../applications/aave/config";
+import { useAaveConfig } from "../applications/aave/context";
+import {
   ACTIVITIES_QUERY_KEY,
   fetchUserActivities,
+  type FetchUserActivitiesDeps,
 } from "../services/activity";
+import type { ActivityApplication } from "../types/activityLog";
+
+const UNKNOWN_APP: ActivityApplication = {
+  id: "unknown",
+  name: "Unknown App",
+  logoUrl: "/images/unknown-app.svg",
+};
 
 /**
- * Hook to fetch user activities across all enabled applications
+ * Hook to fetch user activities across all enabled applications.
+ *
+ * Reads borrow-asset reserves and Aave application metadata from the
+ * AaveConfig context (which fetches them once at app startup) and threads
+ * them into the pure fetch function as inputs, so the activity service
+ * doesn't have to issue additional GraphQL requests or reach into the
+ * application registry.
  *
  * @param userAddress - User's Ethereum address
  * @returns Query result with activity data sorted by date (newest first)
  */
 export function useActivities(userAddress: Address | undefined) {
+  const { borrowableReserves, vbtcReserve } = useAaveConfig();
+
+  const deps: FetchUserActivitiesDeps = useMemo(() => {
+    const reserves = new Map<string, { symbol: string; decimals: number }>();
+    for (const r of borrowableReserves) {
+      reserves.set(r.reserveId.toString(), {
+        symbol: r.token.symbol,
+        decimals: r.token.decimals,
+      });
+    }
+    if (vbtcReserve) {
+      reserves.set(vbtcReserve.reserveId.toString(), {
+        symbol: vbtcReserve.token.symbol,
+        decimals: vbtcReserve.token.decimals,
+      });
+    }
+
+    const aaveMeta = getApplication(AAVE_APP_ID)?.metadata;
+    const borrowAppMetadata: ActivityApplication = aaveMeta
+      ? {
+          id: aaveMeta.id,
+          name: aaveMeta.name,
+          logoUrl: aaveMeta.logoUrl,
+        }
+      : UNKNOWN_APP;
+
+    return {
+      reserves,
+      borrowAppMetadata,
+      resolveVaultApp: (controllerAddress) => {
+        const meta = getApplicationMetadataByController(controllerAddress);
+        return meta
+          ? { id: meta.id, name: meta.name, logoUrl: meta.logoUrl }
+          : undefined;
+      },
+    };
+  }, [borrowableReserves, vbtcReserve]);
+
   return useQuery({
     queryKey: [ACTIVITIES_QUERY_KEY, userAddress],
-    queryFn: () => fetchUserActivities(userAddress!),
+    queryFn: () => fetchUserActivities(userAddress!, deps),
     enabled: !!userAddress,
     staleTime: 60 * 1000, // 1 minute
     gcTime: 5 * 60 * 1000, // 5 minutes

--- a/services/vault/src/services/activity/__tests__/fetchActivities.test.ts
+++ b/services/vault/src/services/activity/__tests__/fetchActivities.test.ts
@@ -180,6 +180,35 @@ describe("fetchUserActivities type mapping", () => {
     );
     expect(result).toHaveLength(6);
   });
+
+  it("drops unrecognised types instead of crashing the tab", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const rows: ActivityRow[] = [
+      activity({
+        type: "deposit",
+        logIndex: 0,
+        transactionHash: "0x" + "a".repeat(64),
+        vaultId: VAULT_A,
+      }),
+      activity({
+        type: "add_collateral",
+        logIndex: 1,
+        transactionHash: "0x" + "a".repeat(64),
+        vaultId: VAULT_A,
+      }),
+    ];
+    await setupGraphqlMock(rows);
+
+    const result = await fetchUserActivities(
+      USER as `0x${string}`,
+      buildDeps(),
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe("Deposit");
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
 });
 
 describe("fetchUserActivities position-scoped enrichment", () => {

--- a/services/vault/src/services/activity/__tests__/fetchActivities.test.ts
+++ b/services/vault/src/services/activity/__tests__/fetchActivities.test.ts
@@ -102,6 +102,7 @@ async function setupGraphqlMock(rows: ActivityRow[]) {
             items: ids.map((id) => ({
               id,
               applicationEntryPoint: "0xcontroller",
+              peginTxHash: `0xpegin-${id.slice(2, 10)}`,
             })),
           },
         } as never;
@@ -116,7 +117,7 @@ beforeEach(() => {
 });
 
 describe("fetchUserActivities type mapping", () => {
-  it("maps all 8 indexer types to display labels", async () => {
+  it("maps every emitted indexer type to its display label", async () => {
     const rows: ActivityRow[] = [
       activity({
         type: "deposit",
@@ -128,18 +129,6 @@ describe("fetchUserActivities type mapping", () => {
         type: "withdrawal",
         logIndex: 0,
         transactionHash: "0x" + "b".repeat(64),
-        vaultId: VAULT_A,
-      }),
-      activity({
-        type: "add_collateral",
-        logIndex: 0,
-        transactionHash: "0x" + "c".repeat(64),
-        vaultId: VAULT_A,
-      }),
-      activity({
-        type: "remove_collateral",
-        logIndex: 0,
-        transactionHash: "0x" + "d".repeat(64),
         vaultId: VAULT_A,
       }),
       activity({
@@ -183,15 +172,13 @@ describe("fetchUserActivities type mapping", () => {
       expect.arrayContaining([
         "Deposit",
         "Withdraw",
-        "Add Collateral",
-        "Remove Collateral",
         "Liquidation",
         "Borrow",
         "Repay",
         "Redeem",
       ]),
     );
-    expect(result).toHaveLength(8);
+    expect(result).toHaveLength(6);
   });
 });
 

--- a/services/vault/src/services/activity/__tests__/fetchActivities.test.ts
+++ b/services/vault/src/services/activity/__tests__/fetchActivities.test.ts
@@ -1,0 +1,375 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  fetchUserActivities,
+  type FetchUserActivitiesDeps,
+} from "../fetchActivities";
+
+vi.mock("@/clients/graphql", () => ({
+  graphqlClient: {
+    request: vi.fn(),
+  },
+}));
+
+vi.mock("@/config", () => ({
+  getNetworkConfigBTC: () => ({
+    coinSymbol: "sBTC",
+    icon: "/images/btc.svg",
+  }),
+}));
+
+const USER = "0x1111111111111111111111111111111111111111";
+const VAULT_A = "0x" + "a".repeat(64);
+const TX_DEPOSIT = "0x" + "1".repeat(64);
+const TX_BORROW = "0x" + "4".repeat(64);
+
+const AAVE_APP_META = {
+  id: "aave",
+  name: "Aave V4",
+  logoUrl: "/images/aave.svg",
+};
+
+const VAULT_APP_META = {
+  id: "aave",
+  name: "Aave V4",
+  logoUrl: "/images/aave.svg",
+};
+
+type ActivityRow = {
+  id: string;
+  vaultId: string | null;
+  depositor: string;
+  type: string;
+  amount: string;
+  debtReserveId: string | null;
+  timestamp: string;
+  blockNumber: string;
+  transactionHash: string;
+};
+
+type ActivityOverrides = Partial<Omit<ActivityRow, "id">> & {
+  logIndex?: number;
+};
+
+function activity(overrides: ActivityOverrides): ActivityRow {
+  const { logIndex = 0, ...rest } = overrides;
+  const base: ActivityRow = {
+    id: "",
+    vaultId: VAULT_A,
+    depositor: USER,
+    type: "deposit",
+    amount: "1000000", // 0.01 sBTC at 8 decimals
+    debtReserveId: null,
+    timestamp: "1700000000",
+    blockNumber: "100",
+    transactionHash: TX_DEPOSIT,
+    ...rest,
+  };
+  base.id = `${base.transactionHash}-${logIndex}-${base.type}`;
+  return base;
+}
+
+function buildDeps(
+  reserves: Array<{ id: string; symbol: string; decimals: number }> = [],
+  overrides: Partial<FetchUserActivitiesDeps> = {},
+): FetchUserActivitiesDeps {
+  const reserveMap = new Map<string, { symbol: string; decimals: number }>();
+  for (const r of reserves) {
+    reserveMap.set(r.id, { symbol: r.symbol, decimals: r.decimals });
+  }
+  return {
+    reserves: reserveMap,
+    borrowAppMetadata: AAVE_APP_META,
+    resolveVaultApp: () => VAULT_APP_META,
+    ...overrides,
+  };
+}
+
+async function setupGraphqlMock(rows: ActivityRow[]) {
+  const { graphqlClient } = await import("@/clients/graphql");
+  vi.mocked(graphqlClient.request).mockImplementation(
+    async (query: unknown) => {
+      const src = String(query);
+      if (src.includes("GetActivitiesPage")) {
+        const ids = Array.from(
+          new Set(
+            rows.map((a) => a.vaultId).filter((v): v is string => v != null),
+          ),
+        );
+        return {
+          vaultActivitys: { items: rows },
+          vaults: {
+            items: ids.map((id) => ({
+              id,
+              applicationEntryPoint: "0xcontroller",
+            })),
+          },
+        } as never;
+      }
+      throw new Error(`Unexpected query: ${src}`);
+    },
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("fetchUserActivities type mapping", () => {
+  it("maps all 8 indexer types to display labels", async () => {
+    const rows: ActivityRow[] = [
+      activity({
+        type: "deposit",
+        logIndex: 0,
+        transactionHash: "0x" + "a".repeat(64),
+        vaultId: VAULT_A,
+      }),
+      activity({
+        type: "withdrawal",
+        logIndex: 0,
+        transactionHash: "0x" + "b".repeat(64),
+        vaultId: VAULT_A,
+      }),
+      activity({
+        type: "add_collateral",
+        logIndex: 0,
+        transactionHash: "0x" + "c".repeat(64),
+        vaultId: VAULT_A,
+      }),
+      activity({
+        type: "remove_collateral",
+        logIndex: 0,
+        transactionHash: "0x" + "d".repeat(64),
+        vaultId: VAULT_A,
+      }),
+      activity({
+        type: "liquidation",
+        logIndex: 0,
+        transactionHash: "0x" + "e".repeat(64),
+        vaultId: VAULT_A,
+      }),
+      activity({
+        type: "borrow",
+        logIndex: 0,
+        transactionHash: "0x" + "f".repeat(64),
+        vaultId: null,
+        debtReserveId: "1",
+        amount: "1000000",
+      }),
+      activity({
+        type: "repay",
+        logIndex: 1,
+        transactionHash: "0x" + "f".repeat(64),
+        vaultId: null,
+        debtReserveId: "1",
+        amount: "500000",
+      }),
+      activity({
+        type: "redeem",
+        logIndex: 0,
+        transactionHash: "0x" + "9".repeat(64),
+        vaultId: VAULT_A,
+      }),
+    ];
+    await setupGraphqlMock(rows);
+
+    const result = await fetchUserActivities(
+      USER as `0x${string}`,
+      buildDeps([{ id: "1", symbol: "USDC", decimals: 6 }]),
+    );
+    const types = result.map((r) => r.type);
+
+    expect(types).toEqual(
+      expect.arrayContaining([
+        "Deposit",
+        "Withdraw",
+        "Add Collateral",
+        "Remove Collateral",
+        "Liquidation",
+        "Borrow",
+        "Repay",
+        "Redeem",
+      ]),
+    );
+    expect(result).toHaveLength(8);
+  });
+});
+
+describe("fetchUserActivities position-scoped enrichment", () => {
+  it("uses injected Aave metadata for Borrow/Repay rows", async () => {
+    const rows: ActivityRow[] = [
+      activity({
+        type: "repay",
+        logIndex: 0,
+        transactionHash: TX_BORROW,
+        vaultId: null,
+        debtReserveId: "1",
+        amount: "500000",
+      }),
+    ];
+    await setupGraphqlMock(rows);
+
+    const result = await fetchUserActivities(
+      USER as `0x${string}`,
+      buildDeps([{ id: "1", symbol: "USDC", decimals: 6 }]),
+    );
+    expect(result[0].application.id).toBe("aave");
+    expect(result[0].application.name).toBe("Aave V4");
+  });
+
+  it("formats borrow amount with reserve decimals, not BTC decimals", async () => {
+    const rows: ActivityRow[] = [
+      activity({
+        type: "borrow",
+        logIndex: 0,
+        transactionHash: TX_BORROW,
+        vaultId: null,
+        debtReserveId: "1",
+        amount: "1500000000", // 1500.000000 USDC at 6 decimals
+      }),
+    ];
+    await setupGraphqlMock(rows);
+
+    const result = await fetchUserActivities(
+      USER as `0x${string}`,
+      buildDeps([{ id: "1", symbol: "USDC", decimals: 6 }]),
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].amount.symbol).toBe("USDC");
+    expect(result[0].amount.value).toBe("1,500");
+  });
+
+  it("formats high-decimals tokens without JS number precision loss", async () => {
+    const rows: ActivityRow[] = [
+      activity({
+        type: "borrow",
+        logIndex: 0,
+        transactionHash: TX_BORROW,
+        vaultId: null,
+        debtReserveId: "1",
+        // 12,345,678.123456789012345678 DAI at 18 decimals
+        amount: "12345678123456789012345678",
+      }),
+    ];
+    await setupGraphqlMock(rows);
+
+    const result = await fetchUserActivities(
+      USER as `0x${string}`,
+      buildDeps([{ id: "1", symbol: "DAI", decimals: 18 }]),
+    );
+    expect(result[0].amount.symbol).toBe("DAI");
+    // Integer part must be exact (parseFloat would have lost precision here).
+    // Fractional part is capped at MAX_DISPLAY_FRACTION_DIGITS = 8.
+    expect(result[0].amount.value).toBe("12,345,678.12345678");
+  });
+
+  it("degrades gracefully when a borrow row has no debtReserveId", async () => {
+    const rows: ActivityRow[] = [
+      activity({
+        type: "borrow",
+        logIndex: 0,
+        transactionHash: TX_BORROW,
+        vaultId: null,
+        debtReserveId: null,
+        amount: "1000000",
+      }),
+    ];
+    await setupGraphqlMock(rows);
+
+    const result = await fetchUserActivities(
+      USER as `0x${string}`,
+      buildDeps(),
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe("Borrow");
+    expect(result[0].amount.symbol).toBe("—");
+    // When decimals aren't known, surface the raw amount string rather than
+    // blanking the whole Activity tab.
+    expect(result[0].amount.value).toBe("1000000");
+  });
+
+  it("degrades gracefully when an injected reserve is missing", async () => {
+    const rows: ActivityRow[] = [
+      activity({
+        type: "borrow",
+        logIndex: 0,
+        transactionHash: TX_BORROW,
+        vaultId: null,
+        debtReserveId: "1",
+        amount: "1000000",
+      }),
+    ];
+    await setupGraphqlMock(rows);
+
+    // Caller did not include reserve id "1".
+    const result = await fetchUserActivities(
+      USER as `0x${string}`,
+      buildDeps(),
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].amount.symbol).toBe("—");
+    expect(result[0].amount.value).toBe("1000000");
+  });
+
+  it("falls back to Unknown App when the injected borrowAppMetadata is unknown", async () => {
+    const rows: ActivityRow[] = [
+      activity({
+        type: "borrow",
+        logIndex: 0,
+        transactionHash: TX_BORROW,
+        vaultId: null,
+        debtReserveId: "1",
+        amount: "1000000",
+      }),
+    ];
+    await setupGraphqlMock(rows);
+
+    const result = await fetchUserActivities(
+      USER as `0x${string}`,
+      buildDeps([{ id: "1", symbol: "USDC", decimals: 6 }], {
+        borrowAppMetadata: {
+          id: "unknown",
+          name: "Unknown App",
+          logoUrl: "/images/unknown-app.svg",
+        },
+      }),
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].application.id).toBe("unknown");
+    expect(result[0].application.name).toBe("Unknown App");
+    expect(result[0].amount.symbol).toBe("USDC");
+  });
+});
+
+describe("fetchUserActivities GraphQL request shape", () => {
+  it("issues exactly one GraphQL request that returns activities + vaults together", async () => {
+    const { graphqlClient } = await import("@/clients/graphql");
+
+    const rows: ActivityRow[] = [
+      activity({
+        type: "deposit",
+        logIndex: 0,
+        transactionHash: TX_DEPOSIT,
+        vaultId: VAULT_A,
+      }),
+      activity({
+        type: "borrow",
+        logIndex: 1,
+        transactionHash: TX_BORROW,
+        vaultId: null,
+        debtReserveId: "1",
+        amount: "1000000",
+      }),
+    ];
+    await setupGraphqlMock(rows);
+
+    await fetchUserActivities(
+      USER as `0x${string}`,
+      buildDeps([{ id: "1", symbol: "USDC", decimals: 6 }]),
+    );
+
+    expect(vi.mocked(graphqlClient.request)).toHaveBeenCalledTimes(1);
+    const [query] = vi.mocked(graphqlClient.request).mock.calls[0];
+    expect(String(query)).toContain("GetActivitiesPage");
+  });
+});

--- a/services/vault/src/services/activity/__tests__/fetchActivities.test.ts
+++ b/services/vault/src/services/activity/__tests__/fetchActivities.test.ts
@@ -18,6 +18,10 @@ vi.mock("@/config", () => ({
   }),
 }));
 
+vi.mock("@/infrastructure", () => ({
+  logger: { warn: vi.fn(), info: vi.fn(), error: vi.fn() },
+}));
+
 const USER = "0x1111111111111111111111111111111111111111";
 const VAULT_A = "0x" + "a".repeat(64);
 const TX_DEPOSIT = "0x" + "1".repeat(64);
@@ -182,7 +186,7 @@ describe("fetchUserActivities type mapping", () => {
   });
 
   it("drops unrecognised types instead of crashing the tab", async () => {
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { logger } = await import("@/infrastructure");
     const rows: ActivityRow[] = [
       activity({
         type: "deposit",
@@ -196,6 +200,12 @@ describe("fetchUserActivities type mapping", () => {
         transactionHash: "0x" + "a".repeat(64),
         vaultId: VAULT_A,
       }),
+      activity({
+        type: "add_collateral",
+        logIndex: 2,
+        transactionHash: "0x" + "b".repeat(64),
+        vaultId: VAULT_A,
+      }),
     ];
     await setupGraphqlMock(rows);
 
@@ -206,8 +216,10 @@ describe("fetchUserActivities type mapping", () => {
 
     expect(result).toHaveLength(1);
     expect(result[0].type).toBe("Deposit");
-    expect(warn).toHaveBeenCalled();
-    warn.mockRestore();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("dropped unrecognised activity types"),
+      { counts: { add_collateral: 2 } },
+    );
   });
 });
 

--- a/services/vault/src/services/activity/fetchActivities.ts
+++ b/services/vault/src/services/activity/fetchActivities.ts
@@ -4,6 +4,7 @@ import { formatUnits } from "viem";
 
 import { graphqlClient } from "../../clients/graphql";
 import { getNetworkConfigBTC } from "../../config";
+import { logger } from "../../infrastructure";
 import type {
   ActivityApplication,
   ActivityChain,
@@ -212,11 +213,16 @@ export async function fetchUserActivities(
     peginTxHashByVaultId.set(v.id, v.peginTxHash);
   }
 
+  const droppedTypeCounts = new Map<string, number>();
+
   const rows = activities.flatMap(
     (item): Array<{ row: ActivityLog; raw: GraphQLVaultActivityItem }> => {
       const displayType = mapActivityType(item.type);
       if (!displayType) {
-        console.warn(`[activity] dropping unrecognised type "${item.type}"`);
+        droppedTypeCounts.set(
+          item.type,
+          (droppedTypeCounts.get(item.type) ?? 0) + 1,
+        );
         return [];
       }
 
@@ -277,6 +283,12 @@ export async function fetchUserActivities(
       ];
     },
   );
+
+  if (droppedTypeCounts.size > 0) {
+    logger.warn("[fetchActivities] dropped unrecognised activity types", {
+      counts: Object.fromEntries(droppedTypeCounts),
+    });
+  }
 
   return rows
     .sort((a, b) => {

--- a/services/vault/src/services/activity/fetchActivities.ts
+++ b/services/vault/src/services/activity/fetchActivities.ts
@@ -24,8 +24,6 @@ const MAX_DISPLAY_FRACTION_DIGITS = 8;
 type GraphQLActivityType =
   | "deposit"
   | "withdrawal"
-  | "add_collateral"
-  | "remove_collateral"
   | "liquidation"
   | "borrow"
   | "repay"
@@ -41,14 +39,12 @@ interface GraphQLVaultActivityItem {
   timestamp: string;
   blockNumber: string;
   transactionHash: string;
-  vault: {
-    peginTxHash: string;
-  } | null;
 }
 
 interface GraphQLVaultItem {
   id: string;
   applicationEntryPoint: string;
+  peginTxHash: string;
 }
 
 interface GraphQLActivityPageResponse {
@@ -96,15 +92,13 @@ const GET_ACTIVITIES_PAGE = gql`
         timestamp
         blockNumber
         transactionHash
-        vault {
-          peginTxHash
-        }
       }
     }
     vaults(where: { depositor: $depositor }) {
       items {
         id
         applicationEntryPoint
+        peginTxHash
       }
     }
   }
@@ -122,8 +116,6 @@ function mapActivityType(type: GraphQLActivityType): ActivityType {
   const typeMap: Record<GraphQLActivityType, ActivityType> = {
     deposit: "Deposit",
     withdrawal: "Withdraw",
-    add_collateral: "Add Collateral",
-    remove_collateral: "Remove Collateral",
     liquidation: "Liquidation",
     borrow: "Borrow",
     repay: "Repay",
@@ -147,12 +139,17 @@ function mapActivityType(type: GraphQLActivityType): ActivityType {
  * renders as "Pending..." rather than redirecting users to the ETH explorer
  * for what is logically a BTC operation.
  */
-function resolveDisplayTx(item: GraphQLVaultActivityItem): {
+function resolveDisplayTx(
+  item: GraphQLVaultActivityItem,
+  peginTxHashByVaultId: ReadonlyMap<string, string>,
+): {
   chain: ActivityChain;
   transactionHash: string;
 } {
   if (BTC_PRIMARY_ACTIVITIES.has(item.type)) {
-    const peginTxHash = item.vault?.peginTxHash;
+    const peginTxHash = item.vaultId
+      ? peginTxHashByVaultId.get(item.vaultId)
+      : undefined;
     const isValidPeginHash =
       typeof peginTxHash === "string" &&
       peginTxHash.length > 0 &&
@@ -212,8 +209,10 @@ export async function fetchUserActivities(
   if (activities.length === 0) return [];
 
   const vaultMap = new Map<string, string>();
+  const peginTxHashByVaultId = new Map<string, string>();
   for (const v of data.vaults.items) {
     vaultMap.set(v.id, v.applicationEntryPoint);
+    peginTxHashByVaultId.set(v.id, v.peginTxHash);
   }
 
   const rows = activities.map((item): ActivityLog => {
@@ -253,7 +252,10 @@ export async function fetchUserActivities(
       amountIcon = btcConfig.icon;
     }
 
-    const { chain, transactionHash } = resolveDisplayTx(item);
+    const { chain, transactionHash } = resolveDisplayTx(
+      item,
+      peginTxHashByVaultId,
+    );
 
     return {
       id: item.id,

--- a/services/vault/src/services/activity/fetchActivities.ts
+++ b/services/vault/src/services/activity/fetchActivities.ts
@@ -112,20 +112,17 @@ const BTC_PRIMARY_ACTIVITIES: ReadonlySet<GraphQLActivityType> = new Set([
   "deposit",
 ]);
 
-function mapActivityType(type: GraphQLActivityType): ActivityType {
-  const typeMap: Record<GraphQLActivityType, ActivityType> = {
-    deposit: "Deposit",
-    withdrawal: "Withdraw",
-    liquidation: "Liquidation",
-    borrow: "Borrow",
-    repay: "Repay",
-    redeem: "Redeem",
-  };
-  const mapped = typeMap[type];
-  if (!mapped) {
-    throw new Error(`Unknown activity type from GraphQL API: ${type}`);
-  }
-  return mapped;
+const TYPE_MAP: Record<GraphQLActivityType, ActivityType> = {
+  deposit: "Deposit",
+  withdrawal: "Withdraw",
+  liquidation: "Liquidation",
+  borrow: "Borrow",
+  repay: "Repay",
+  redeem: "Redeem",
+};
+
+function mapActivityType(type: string): ActivityType | undefined {
+  return TYPE_MAP[type as GraphQLActivityType];
 }
 
 /**
@@ -215,69 +212,73 @@ export async function fetchUserActivities(
     peginTxHashByVaultId.set(v.id, v.peginTxHash);
   }
 
-  const rows = activities.map((item): ActivityLog => {
-    const isPositionScoped = item.type === "borrow" || item.type === "repay";
+  const rows = activities.flatMap(
+    (item): Array<{ row: ActivityLog; raw: GraphQLVaultActivityItem }> => {
+      const displayType = mapActivityType(item.type);
+      if (!displayType) {
+        console.warn(`[activity] dropping unrecognised type "${item.type}"`);
+        return [];
+      }
 
-    let application: ActivityApplication;
-    if (isPositionScoped) {
-      // TODO: when more applications support borrow/repay, resolve via a
-      // positionAccount → app mapping instead of a single injected metadata.
-      application = deps.borrowAppMetadata;
-    } else {
-      const applicationEntryPoint = item.vaultId
-        ? vaultMap.get(item.vaultId)
-        : undefined;
-      application = applicationEntryPoint
-        ? (deps.resolveVaultApp(applicationEntryPoint) ?? UNKNOWN_APP)
-        : UNKNOWN_APP;
-    }
+      const isPositionScoped = item.type === "borrow" || item.type === "repay";
 
-    let amountValue: string;
-    let amountSymbol: string;
-    let amountIcon: string | undefined;
-    if (isPositionScoped) {
-      // Fall back gracefully for malformed / partially-indexed rows so a single
-      // bad row doesn't blank the whole Activity tab.
-      const reserve =
-        item.debtReserveId != null
-          ? deps.reserves.get(item.debtReserveId)
+      let application: ActivityApplication;
+      if (isPositionScoped) {
+        application = deps.borrowAppMetadata;
+      } else {
+        const applicationEntryPoint = item.vaultId
+          ? vaultMap.get(item.vaultId)
           : undefined;
-      amountValue = reserve
-        ? formatAmount(item.amount, reserve.decimals)
-        : item.amount;
-      amountSymbol = reserve?.symbol ?? "—";
-    } else {
-      amountValue = formatAmount(item.amount, BTC_DECIMALS);
-      amountSymbol = btcConfig.coinSymbol;
-      amountIcon = btcConfig.icon;
-    }
+        application = applicationEntryPoint
+          ? (deps.resolveVaultApp(applicationEntryPoint) ?? UNKNOWN_APP)
+          : UNKNOWN_APP;
+      }
 
-    const { chain, transactionHash } = resolveDisplayTx(
-      item,
-      peginTxHashByVaultId,
-    );
+      let amountValue: string;
+      let amountSymbol: string;
+      let amountIcon: string | undefined;
+      if (isPositionScoped) {
+        const reserve =
+          item.debtReserveId != null
+            ? deps.reserves.get(item.debtReserveId)
+            : undefined;
+        amountValue = reserve
+          ? formatAmount(item.amount, reserve.decimals)
+          : item.amount;
+        amountSymbol = reserve?.symbol ?? "—";
+      } else {
+        amountValue = formatAmount(item.amount, BTC_DECIMALS);
+        amountSymbol = btcConfig.coinSymbol;
+        amountIcon = btcConfig.icon;
+      }
 
-    return {
-      id: item.id,
-      date: new Date(parseInt(item.timestamp, 10) * 1000),
-      application,
-      type: mapActivityType(item.type),
-      amount: {
-        value: amountValue,
-        symbol: amountSymbol,
-        icon: amountIcon,
-      },
-      chain,
-      transactionHash,
-    };
-  });
+      const { chain, transactionHash } = resolveDisplayTx(
+        item,
+        peginTxHashByVaultId,
+      );
 
-  // Stable ordering for same-tx rows: (timestamp, blockNumber, logIndex) desc.
-  // logIndex is parsed from the indexer-generated id so we don't need a
-  // dedicated column. The GraphQL response is already sorted by timestamp
-  // desc; this enforces a deterministic tiebreaker on rows sharing a timestamp.
+      return [
+        {
+          row: {
+            id: item.id,
+            date: new Date(parseInt(item.timestamp, 10) * 1000),
+            application,
+            type: displayType,
+            amount: {
+              value: amountValue,
+              symbol: amountSymbol,
+              icon: amountIcon,
+            },
+            chain,
+            transactionHash,
+          },
+          raw: item,
+        },
+      ];
+    },
+  );
+
   return rows
-    .map((row, idx) => ({ row, raw: activities[idx] }))
     .sort((a, b) => {
       const tsDiff =
         parseInt(b.raw.timestamp, 10) - parseInt(a.raw.timestamp, 10);

--- a/services/vault/src/services/activity/fetchActivities.ts
+++ b/services/vault/src/services/activity/fetchActivities.ts
@@ -2,10 +2,10 @@ import { gql } from "graphql-request";
 import type { Address } from "viem";
 import { formatUnits } from "viem";
 
-import { getApplicationMetadataByController } from "../../applications";
 import { graphqlClient } from "../../clients/graphql";
 import { getNetworkConfigBTC } from "../../config";
 import type {
+  ActivityApplication,
   ActivityChain,
   ActivityLog,
   ActivityType,
@@ -13,21 +13,31 @@ import type {
 
 const btcConfig = getNetworkConfigBTC();
 
+// Native precision of a BTC vault amount (sats).
 const BTC_DECIMALS = 8;
+
+// Cap display precision so we never round the integer part of high-decimals
+// tokens through JS number space. Fractional digits beyond this are dropped
+// (not rounded) to keep formatting deterministic.
+const MAX_DISPLAY_FRACTION_DIGITS = 8;
 
 type GraphQLActivityType =
   | "deposit"
   | "withdrawal"
   | "add_collateral"
   | "remove_collateral"
-  | "liquidation";
+  | "liquidation"
+  | "borrow"
+  | "repay"
+  | "redeem";
 
 interface GraphQLVaultActivityItem {
   id: string;
-  vaultId: string;
+  vaultId: string | null;
   depositor: string;
   type: GraphQLActivityType;
   amount: string;
+  debtReserveId: string | null;
   timestamp: string;
   blockNumber: string;
   transactionHash: string;
@@ -36,25 +46,41 @@ interface GraphQLVaultActivityItem {
   } | null;
 }
 
-interface GraphQLVaultActivitiesResponse {
-  vaultActivitys: {
-    items: GraphQLVaultActivityItem[];
-  };
-}
-
 interface GraphQLVaultItem {
   id: string;
   applicationEntryPoint: string;
 }
 
-interface GraphQLVaultsResponse {
-  vaults: {
-    items: GraphQLVaultItem[];
-  };
+interface GraphQLActivityPageResponse {
+  vaultActivitys: { items: GraphQLVaultActivityItem[] };
+  vaults: { items: GraphQLVaultItem[] };
 }
 
-const GET_USER_ACTIVITIES = gql`
-  query GetUserActivities($depositor: String!) {
+/**
+ * The indexer encodes logIndex into the activity id as
+ * `${transactionHash}-${logIndex}-${type}`. Parse it out for deterministic
+ * same-tx ordering without requiring a dedicated column.
+ */
+function parseLogIndex(id: string): number {
+  const parts = id.split("-");
+  // parts[0] is transactionHash; parts[1] is logIndex.
+  const n = Number.parseInt(parts[1] ?? "", 10);
+  return Number.isFinite(n) ? n : 0;
+}
+
+/**
+ * Single GraphQL request that pulls the activity rows AND, in the same round
+ * trip, the vault rows referenced by those activities for application
+ * metadata enrichment. The frontend joins on `vault.id` client-side.
+ *
+ * We pass the depositor as a String into both queries: vaultActivitys uses it
+ * directly, and vaults reuses it as a depositor filter so the indexer only
+ * returns vault rows the user could conceivably reference. Borrow/repay rows
+ * (vaultId = null) carry no vault join — their app metadata comes from the
+ * caller-injected dependency map.
+ */
+const GET_ACTIVITIES_PAGE = gql`
+  query GetActivitiesPage($depositor: String!) {
     vaultActivitys(
       where: { depositor: $depositor }
       orderBy: "timestamp"
@@ -66,6 +92,7 @@ const GET_USER_ACTIVITIES = gql`
         depositor
         type
         amount
+        debtReserveId
         timestamp
         blockNumber
         transactionHash
@@ -74,12 +101,7 @@ const GET_USER_ACTIVITIES = gql`
         }
       }
     }
-  }
-`;
-
-const GET_VAULTS_BY_IDS = gql`
-  query GetVaultsByIds($vaultIds: [String!]!) {
-    vaults(where: { id_in: $vaultIds }) {
+    vaults(where: { depositor: $depositor }) {
       items {
         id
         applicationEntryPoint
@@ -103,6 +125,9 @@ function mapActivityType(type: GraphQLActivityType): ActivityType {
     add_collateral: "Add Collateral",
     remove_collateral: "Remove Collateral",
     liquidation: "Liquidation",
+    borrow: "Borrow",
+    repay: "Repay",
+    redeem: "Redeem",
   };
   const mapped = typeMap[type];
   if (!mapped) {
@@ -140,61 +165,125 @@ function resolveDisplayTx(item: GraphQLVaultActivityItem): {
   return { chain: "ETH", transactionHash: item.transactionHash };
 }
 
-function formatAmount(amount: string): string {
-  const formatted = formatUnits(BigInt(amount), BTC_DECIMALS);
-  const num = parseFloat(formatted);
-  return num.toLocaleString("en-US", {
-    minimumFractionDigits: 0,
-    maximumFractionDigits: BTC_DECIMALS,
-  });
+function formatAmount(amount: string, decimals: number): string {
+  // Format whole/fraction separately to avoid parseFloat precision loss on
+  // large or high-decimals values.
+  const [wholeRaw, fracRaw = ""] = formatUnits(BigInt(amount), decimals).split(
+    ".",
+  );
+  const whole = BigInt(wholeRaw).toLocaleString("en-US");
+  const frac = fracRaw.slice(0, MAX_DISPLAY_FRACTION_DIGITS).replace(/0+$/, "");
+  return frac.length > 0 ? `${whole}.${frac}` : whole;
+}
+
+const UNKNOWN_APP: ActivityApplication = {
+  id: "unknown",
+  name: "Unknown App",
+  logoUrl: "/images/unknown-app.svg",
+};
+
+/**
+ * Caller-injected dependencies. The hook layer reads these from the AaveConfig
+ * context provider (which already loads them once at app startup), keeping
+ * this service free of global registry / network dependencies for non-
+ * activity data.
+ */
+export interface FetchUserActivitiesDeps {
+  /** Map of debtReserveId -> { symbol, decimals }, e.g. from `useAaveConfig().borrowableReserves`. */
+  reserves: ReadonlyMap<string, { symbol: string; decimals: number }>;
+  /** Application metadata used for borrow/repay rows (currently always Aave). */
+  borrowAppMetadata: ActivityApplication;
+  /** Resolve vault-scoped application metadata by entry-point controller address. */
+  resolveVaultApp: (
+    controllerAddress: string,
+  ) => ActivityApplication | undefined;
 }
 
 export async function fetchUserActivities(
   address: Address,
+  deps: FetchUserActivitiesDeps,
 ): Promise<ActivityLog[]> {
-  const activitiesData =
-    await graphqlClient.request<GraphQLVaultActivitiesResponse>(
-      GET_USER_ACTIVITIES,
-      { depositor: address.toLowerCase() },
-    );
+  const data = await graphqlClient.request<GraphQLActivityPageResponse>(
+    GET_ACTIVITIES_PAGE,
+    { depositor: address.toLowerCase() },
+  );
 
-  const activities = activitiesData.vaultActivitys.items;
+  const activities = data.vaultActivitys.items;
   if (activities.length === 0) return [];
 
-  const vaultIds = Array.from(new Set(activities.map((a) => a.vaultId)));
-  const vaultsData = await graphqlClient.request<GraphQLVaultsResponse>(
-    GET_VAULTS_BY_IDS,
-    { vaultIds },
-  );
+  const vaultMap = new Map<string, string>();
+  for (const v of data.vaults.items) {
+    vaultMap.set(v.id, v.applicationEntryPoint);
+  }
 
-  const vaultMap = new Map(
-    vaultsData.vaults.items.map((v) => [v.id, v.applicationEntryPoint]),
-  );
+  const rows = activities.map((item): ActivityLog => {
+    const isPositionScoped = item.type === "borrow" || item.type === "repay";
 
-  return activities.map((item) => {
-    const applicationEntryPoint = vaultMap.get(item.vaultId);
-    const appMetadata = applicationEntryPoint
-      ? getApplicationMetadataByController(applicationEntryPoint)
-      : undefined;
+    let application: ActivityApplication;
+    if (isPositionScoped) {
+      // TODO: when more applications support borrow/repay, resolve via a
+      // positionAccount → app mapping instead of a single injected metadata.
+      application = deps.borrowAppMetadata;
+    } else {
+      const applicationEntryPoint = item.vaultId
+        ? vaultMap.get(item.vaultId)
+        : undefined;
+      application = applicationEntryPoint
+        ? (deps.resolveVaultApp(applicationEntryPoint) ?? UNKNOWN_APP)
+        : UNKNOWN_APP;
+    }
+
+    let amountValue: string;
+    let amountSymbol: string;
+    let amountIcon: string | undefined;
+    if (isPositionScoped) {
+      // Fall back gracefully for malformed / partially-indexed rows so a single
+      // bad row doesn't blank the whole Activity tab.
+      const reserve =
+        item.debtReserveId != null
+          ? deps.reserves.get(item.debtReserveId)
+          : undefined;
+      amountValue = reserve
+        ? formatAmount(item.amount, reserve.decimals)
+        : item.amount;
+      amountSymbol = reserve?.symbol ?? "—";
+    } else {
+      amountValue = formatAmount(item.amount, BTC_DECIMALS);
+      amountSymbol = btcConfig.coinSymbol;
+      amountIcon = btcConfig.icon;
+    }
 
     const { chain, transactionHash } = resolveDisplayTx(item);
 
     return {
       id: item.id,
       date: new Date(parseInt(item.timestamp, 10) * 1000),
-      application: {
-        id: appMetadata?.id ?? "unknown",
-        name: appMetadata?.name ?? "Unknown App",
-        logoUrl: appMetadata?.logoUrl ?? "/images/unknown-app.svg",
-      },
+      application,
       type: mapActivityType(item.type),
       amount: {
-        value: formatAmount(item.amount),
-        symbol: btcConfig.coinSymbol,
-        icon: btcConfig.icon,
+        value: amountValue,
+        symbol: amountSymbol,
+        icon: amountIcon,
       },
       chain,
       transactionHash,
     };
   });
+
+  // Stable ordering for same-tx rows: (timestamp, blockNumber, logIndex) desc.
+  // logIndex is parsed from the indexer-generated id so we don't need a
+  // dedicated column. The GraphQL response is already sorted by timestamp
+  // desc; this enforces a deterministic tiebreaker on rows sharing a timestamp.
+  return rows
+    .map((row, idx) => ({ row, raw: activities[idx] }))
+    .sort((a, b) => {
+      const tsDiff =
+        parseInt(b.raw.timestamp, 10) - parseInt(a.raw.timestamp, 10);
+      if (tsDiff !== 0) return tsDiff;
+      const blockDiff =
+        parseInt(b.raw.blockNumber, 10) - parseInt(a.raw.blockNumber, 10);
+      if (blockDiff !== 0) return blockDiff;
+      return parseLogIndex(b.raw.id) - parseLogIndex(a.raw.id);
+    })
+    .map(({ row }) => row);
 }

--- a/services/vault/src/services/activity/index.ts
+++ b/services/vault/src/services/activity/index.ts
@@ -1,4 +1,7 @@
-export { fetchUserActivities } from "./fetchActivities";
+export {
+  fetchUserActivities,
+  type FetchUserActivitiesDeps,
+} from "./fetchActivities";
 export { getPendingActivities } from "./pendingActivities";
 
 export const ACTIVITIES_QUERY_KEY = "user-activities";

--- a/services/vault/src/types/activityLog.ts
+++ b/services/vault/src/types/activityLog.ts
@@ -16,6 +16,7 @@ export type ActivityType =
   | "Liquidation"
   | "Borrow"
   | "Repay"
+  | "Redeem"
   // Pending activity types (not yet confirmed on-chain)
   | "Pending Deposit";
 

--- a/services/vault/src/types/activityLog.ts
+++ b/services/vault/src/types/activityLog.ts
@@ -11,13 +11,10 @@
 export type ActivityType =
   | "Deposit"
   | "Withdraw"
-  | "Add Collateral"
-  | "Remove Collateral"
   | "Liquidation"
   | "Borrow"
   | "Repay"
   | "Redeem"
-  // Pending activity types (not yet confirmed on-chain)
   | "Pending Deposit";
 
 /**


### PR DESCRIPTION
Activity tab previously rendered Deposit and Add Collateral as two rows for the same tx. Borrow, Repay, and Redeem did not appear at all because the indexer wasn't emitting them.

The indexer side is handled by babylon-vault-indexer #133 (borrow/repay/redeem emissions) and #141 (drops add_collateral / remove_collateral so the user-action projection has no paired duplicates). This PR is the corresponding frontend.

- Add Redeem to `ActivityType`; map indexer types `borrow`, `repay`, `redeem` to display labels.
- Drop `Add Collateral` / `Remove Collateral` from `ActivityType` and `GraphQLActivityType` — those rows are no longer emitted (#141), so the FE projection stays clean.
- Read `peginTxHash` from the existing `vaults` query rather than via a nested `vaultActivity → vault` relation (the relation isn't defined in `ponder.schema.ts`).
- Filter null `vaultId`s out of vault lookups so position-scoped rows (borrow/repay) don't break the join.
- Inject reserve metadata + borrow-app metadata via a deps interface so the service stays free of registry/network singletons.
- Format debt amounts via BigInt/string splitting to avoid `parseFloat` precision loss on high-decimals tokens; cap displayed fraction digits at 8.
- Degrade gracefully (`—` symbol, raw amount) when reserve metadata is missing, so a single malformed row never blanks the whole Activity tab.
- Parse `logIndex` from the indexer-generated id for deterministic same-tx ordering.