### PR TITLE
fix(vault): graphql response validation

### DIFF
--- a/services/vault/src/services/providers/__tests__/fetchProviders.test.ts
+++ b/services/vault/src/services/providers/__tests__/fetchProviders.test.ts
@@ -9,7 +9,19 @@ vi.mock("../../../clients/graphql", () => ({
   },
 }));
 
+vi.mock("@/infrastructure", () => ({
+  logger: { warn: vi.fn() },
+}));
+
 const mockRequest = vi.mocked(graphqlClient.request);
+
+// Valid test addresses and keys
+const VALID_ETH_ADDR_1 = "0x" + "a".repeat(40);
+const VALID_ETH_ADDR_2 = "0x" + "b".repeat(40);
+const VALID_ETH_ADDR_3 = "0x" + "c".repeat(40);
+const VALID_BTC_PUBKEY_1 = "0x" + "d".repeat(66);
+const VALID_BTC_PUBKEY_2 = "0x" + "e".repeat(66);
+const VALID_BTC_PUBKEY_3 = "0x" + "f".repeat(66);
 
 describe("fetchProviders", () => {
   describe("fetchAppProviders", () => {
@@ -19,19 +31,19 @@ describe("fetchProviders", () => {
         vaultKeeperApplications: {
           items: [
             {
-              vaultKeeper: "0xkeeper1",
+              vaultKeeper: VALID_ETH_ADDR_1,
               version: 1,
-              vaultKeeperInfo: { btcPubKey: "0xpubkey1" },
+              vaultKeeperInfo: { btcPubKey: VALID_BTC_PUBKEY_1 },
             },
             {
-              vaultKeeper: "0xkeeper1",
+              vaultKeeper: VALID_ETH_ADDR_1,
               version: 3,
-              vaultKeeperInfo: { btcPubKey: "0xpubkey1" },
+              vaultKeeperInfo: { btcPubKey: VALID_BTC_PUBKEY_1 },
             },
             {
-              vaultKeeper: "0xkeeper2",
+              vaultKeeper: VALID_ETH_ADDR_2,
               version: 2,
-              vaultKeeperInfo: { btcPubKey: "0xpubkey2" },
+              vaultKeeperInfo: { btcPubKey: VALID_BTC_PUBKEY_2 },
             },
           ],
         },
@@ -39,16 +51,15 @@ describe("fetchProviders", () => {
 
       const result = await fetchAppProviders("0xAppController");
 
-      // Raw items with version info
       expect(result.vaultKeeperItems).toEqual([
-        { id: "0xkeeper1", btcPubKey: "0xpubkey1", version: 1 },
-        { id: "0xkeeper1", btcPubKey: "0xpubkey1", version: 3 },
-        { id: "0xkeeper2", btcPubKey: "0xpubkey2", version: 2 },
+        { id: VALID_ETH_ADDR_1, btcPubKey: VALID_BTC_PUBKEY_1, version: 1 },
+        { id: VALID_ETH_ADDR_1, btcPubKey: VALID_BTC_PUBKEY_1, version: 3 },
+        { id: VALID_ETH_ADDR_2, btcPubKey: VALID_BTC_PUBKEY_2, version: 2 },
       ]);
 
       // Pre-computed latest version keepers (version 3 only)
       expect(result.vaultKeepers).toEqual([
-        { id: "0xkeeper1", btcPubKey: "0xpubkey1" },
+        { id: VALID_ETH_ADDR_1, btcPubKey: VALID_BTC_PUBKEY_1 },
       ]);
     });
 
@@ -69,20 +80,20 @@ describe("fetchProviders", () => {
         vaultProviders: {
           items: [
             {
-              id: "0xprovider1",
-              btcPubKey: "0xpk1",
+              id: VALID_ETH_ADDR_1,
+              btcPubKey: VALID_BTC_PUBKEY_1,
               name: "provider-1",
               rpcUrl: "https://rpc.example.com",
             },
             {
-              id: "0xprovider2",
-              btcPubKey: "0xpk2",
+              id: VALID_ETH_ADDR_2,
+              btcPubKey: VALID_BTC_PUBKEY_2,
               name: "provider-2",
               rpcUrl: null,
             },
             {
-              id: "0xprovider3",
-              btcPubKey: "0xpk3",
+              id: VALID_ETH_ADDR_3,
+              btcPubKey: VALID_BTC_PUBKEY_3,
               name: null,
               rpcUrl: "https://rpc3.example.com",
             },
@@ -95,14 +106,14 @@ describe("fetchProviders", () => {
 
       expect(result.vaultProviders).toEqual([
         {
-          id: "0xprovider1",
-          btcPubKey: "0xpk1",
+          id: VALID_ETH_ADDR_1,
+          btcPubKey: VALID_BTC_PUBKEY_1,
           name: "provider-1",
           url: "https://rpc.example.com",
         },
         {
-          id: "0xprovider3",
-          btcPubKey: "0xpk3",
+          id: VALID_ETH_ADDR_3,
+          btcPubKey: VALID_BTC_PUBKEY_3,
           name: undefined,
           url: "https://rpc3.example.com",
         },
@@ -121,6 +132,124 @@ describe("fetchProviders", () => {
         appController: "0xabcdef",
       });
     });
+
+    it("should filter out providers with invalid id", async () => {
+      mockRequest.mockResolvedValueOnce({
+        vaultProviders: {
+          items: [
+            {
+              id: "not-an-address",
+              btcPubKey: VALID_BTC_PUBKEY_1,
+              name: "bad-provider",
+              rpcUrl: "https://rpc.example.com",
+            },
+            {
+              id: VALID_ETH_ADDR_1,
+              btcPubKey: VALID_BTC_PUBKEY_1,
+              name: "good-provider",
+              rpcUrl: "https://rpc.example.com",
+            },
+          ],
+        },
+        vaultKeeperApplications: { items: [] },
+      });
+
+      const result = await fetchAppProviders("0xAppController");
+
+      expect(result.vaultProviders).toEqual([
+        {
+          id: VALID_ETH_ADDR_1,
+          btcPubKey: VALID_BTC_PUBKEY_1,
+          name: "good-provider",
+          url: "https://rpc.example.com",
+        },
+      ]);
+    });
+
+    it("should filter out providers with invalid btcPubKey", async () => {
+      mockRequest.mockResolvedValueOnce({
+        vaultProviders: {
+          items: [
+            {
+              id: VALID_ETH_ADDR_1,
+              btcPubKey: "0xinvalid",
+              name: "bad-pubkey-provider",
+              rpcUrl: "https://rpc.example.com",
+            },
+            {
+              id: VALID_ETH_ADDR_2,
+              btcPubKey: VALID_BTC_PUBKEY_2,
+              name: "good-provider",
+              rpcUrl: "https://rpc.example.com",
+            },
+          ],
+        },
+        vaultKeeperApplications: { items: [] },
+      });
+
+      const result = await fetchAppProviders("0xAppController");
+
+      expect(result.vaultProviders).toEqual([
+        {
+          id: VALID_ETH_ADDR_2,
+          btcPubKey: VALID_BTC_PUBKEY_2,
+          name: "good-provider",
+          url: "https://rpc.example.com",
+        },
+      ]);
+    });
+
+    it("should filter out keeper items with invalid vaultKeeper id", async () => {
+      mockRequest.mockResolvedValueOnce({
+        vaultProviders: { items: [] },
+        vaultKeeperApplications: {
+          items: [
+            {
+              vaultKeeper: "bad-address",
+              version: 1,
+              vaultKeeperInfo: { btcPubKey: VALID_BTC_PUBKEY_1 },
+            },
+            {
+              vaultKeeper: VALID_ETH_ADDR_1,
+              version: 1,
+              vaultKeeperInfo: { btcPubKey: VALID_BTC_PUBKEY_1 },
+            },
+          ],
+        },
+      });
+
+      const result = await fetchAppProviders("0xAppController");
+
+      expect(result.vaultKeeperItems).toEqual([
+        { id: VALID_ETH_ADDR_1, btcPubKey: VALID_BTC_PUBKEY_1, version: 1 },
+      ]);
+    });
+
+    it("should filter out keeper items with invalid btcPubKey", async () => {
+      mockRequest.mockResolvedValueOnce({
+        vaultProviders: { items: [] },
+        vaultKeeperApplications: {
+          items: [
+            {
+              vaultKeeper: VALID_ETH_ADDR_1,
+              version: 1,
+              vaultKeeperInfo: { btcPubKey: "0xshort" },
+            },
+            {
+              vaultKeeper: VALID_ETH_ADDR_2,
+              version: 1,
+              vaultKeeperInfo: { btcPubKey: VALID_BTC_PUBKEY_2 },
+            },
+          ],
+        },
+      });
+
+      const result = await fetchAppProviders("0xAppController");
+
+      expect(result.vaultKeeperItems).toEqual([
+        { id: VALID_ETH_ADDR_2, btcPubKey: VALID_BTC_PUBKEY_2, version: 1 },
+      ]);
+    });
   });
 
   describe("getLatestVersionKeepers", () => {
@@ -135,7 +264,6 @@ describe("fetchProviders", () => {
 
       const result = getLatestVersionKeepers(items);
 
-      // Only keepers from version 3: keeper1 and keeper3
       expect(result).toEqual([
         { id: "0xkeeper1", btcPubKey: "0xpubkey1" },
         { id: "0xkeeper3", btcPubKey: "0xpubkey3" },

--- a/services/vault/src/services/providers/fetchProviders.ts
+++ b/services/vault/src/services/providers/fetchProviders.ts
@@ -1,5 +1,7 @@
 import { gql } from "graphql-request";
 
+import { logger } from "@/infrastructure";
+
 import { graphqlClient } from "../../clients/graphql";
 import type {
   AppProvidersResponse,
@@ -7,6 +9,10 @@ import type {
   VaultKeeperItem,
   VaultProvider,
 } from "../../types/vaultProvider";
+import {
+  BTC_PUBKEY_HEX_PATTERN,
+  ETH_ADDRESS_PATTERN,
+} from "../../utils/validation";
 
 /** GraphQL response for app-specific providers and keepers */
 interface GraphQLAppProvidersResponse {
@@ -50,6 +56,50 @@ const GET_APP_PROVIDERS = gql`
     }
   }
 `;
+
+/**
+ * Validate critical fields on an app provider from GraphQL.
+ * Returns null (with a warning) if validation fails.
+ */
+function validateAppProvider(
+  item: GraphQLAppProvidersResponse["vaultProviders"]["items"][number],
+): typeof item | null {
+  if (!ETH_ADDRESS_PATTERN.test(item.id)) {
+    logger.warn(
+      `[fetchAppProviders] Skipping provider with invalid id: "${String(item.id).slice(0, 20)}"`,
+    );
+    return null;
+  }
+  if (!BTC_PUBKEY_HEX_PATTERN.test(item.btcPubKey)) {
+    logger.warn(
+      `[fetchAppProviders] Skipping provider ${item.id}: invalid btcPubKey format`,
+    );
+    return null;
+  }
+  return item;
+}
+
+/**
+ * Validate critical fields on a vault keeper item from GraphQL.
+ * Returns null (with a warning) if validation fails.
+ */
+function validateVaultKeeperItem(
+  item: GraphQLAppProvidersResponse["vaultKeeperApplications"]["items"][number],
+): typeof item | null {
+  if (!ETH_ADDRESS_PATTERN.test(item.vaultKeeper)) {
+    logger.warn(
+      `[fetchAppProviders] Skipping keeper with invalid id: "${String(item.vaultKeeper).slice(0, 20)}"`,
+    );
+    return null;
+  }
+  if (!BTC_PUBKEY_HEX_PATTERN.test(item.vaultKeeperInfo.btcPubKey)) {
+    logger.warn(
+      `[fetchAppProviders] Skipping keeper ${item.vaultKeeper}: invalid btcPubKey format`,
+    );
+    return null;
+  }
+  return item;
+}
 
 /**
  * Filters keeper items to the latest version and deduplicates.
@@ -98,6 +148,7 @@ export async function fetchAppProviders(
       (provider): provider is typeof provider & { rpcUrl: string } =>
         provider.rpcUrl !== null,
     )
+    .filter((provider) => validateAppProvider(provider) !== null)
     .map((provider) => ({
       id: provider.id,
       btcPubKey: provider.btcPubKey,
@@ -106,11 +157,13 @@ export async function fetchAppProviders(
     }));
 
   const vaultKeeperItems: VaultKeeperItem[] =
-    response.vaultKeeperApplications.items.map((item) => ({
-      id: item.vaultKeeper,
-      btcPubKey: item.vaultKeeperInfo.btcPubKey,
-      version: item.version,
-    }));
+    response.vaultKeeperApplications.items
+      .filter((item) => validateVaultKeeperItem(item) !== null)
+      .map((item) => ({
+        id: item.vaultKeeper,
+        btcPubKey: item.vaultKeeperInfo.btcPubKey,
+        version: item.version,
+      }));
 
   return {
     vaultProviders,

--- a/services/vault/src/services/vault/__tests__/fetchVaultProviders.test.ts
+++ b/services/vault/src/services/vault/__tests__/fetchVaultProviders.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { logger } from "@/infrastructure";
+
+import { graphqlClient } from "../../../clients/graphql/client";
+import {
+  fetchVaultProviderById,
+  fetchVaultProviders,
+} from "../fetchVaultProviders";
+
+vi.mock("../../../clients/graphql/client", () => ({
+  graphqlClient: {
+    request: vi.fn(),
+  },
+}));
+
+vi.mock("@/infrastructure", () => ({
+  logger: {
+    warn: vi.fn(),
+  },
+}));
+
+const mockedRequest = vi.mocked(graphqlClient.request);
+const mockedLoggerWarn = vi.mocked(logger.warn);
+
+const VALID_ETH_ADDRESS = "0x" + "ab".repeat(20);
+const VALID_BTC_PUBKEY = "0x" + "cc".repeat(32);
+
+function makeVaultProvider(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    id: VALID_ETH_ADDRESS,
+    btcPubKey: VALID_BTC_PUBKEY,
+    applicationEntryPoint: VALID_ETH_ADDRESS,
+    name: "Test Provider",
+    rpcUrl: "https://rpc.example.com",
+    grpcUrl: null,
+    registeredAt: "1700000000",
+    blockNumber: "100",
+    transactionHash: "0x" + "ff".repeat(32),
+    ...overrides,
+  };
+}
+
+describe("fetchVaultProviders", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it("returns valid vault providers", async () => {
+    mockedRequest.mockResolvedValueOnce({
+      vaultProviders: { items: [makeVaultProvider()] },
+    });
+
+    const providers = await fetchVaultProviders();
+
+    expect(providers).toHaveLength(1);
+    expect(providers[0].id).toBe(VALID_ETH_ADDRESS);
+  });
+
+  it("filters out provider with invalid id and logs warning", async () => {
+    mockedRequest.mockResolvedValueOnce({
+      vaultProviders: {
+        items: [makeVaultProvider({ id: "not-an-address" })],
+      },
+    });
+
+    const providers = await fetchVaultProviders();
+
+    expect(providers).toHaveLength(0);
+    expect(mockedLoggerWarn).toHaveBeenCalledWith(
+      expect.stringContaining("invalid id"),
+    );
+  });
+
+  it("filters out provider with invalid btcPubKey and logs warning", async () => {
+    mockedRequest.mockResolvedValueOnce({
+      vaultProviders: {
+        items: [makeVaultProvider({ btcPubKey: "not-hex" })],
+      },
+    });
+
+    const providers = await fetchVaultProviders();
+
+    expect(providers).toHaveLength(0);
+    expect(mockedLoggerWarn).toHaveBeenCalledWith(
+      expect.stringContaining("invalid btcPubKey"),
+    );
+  });
+
+  it("filters out provider with invalid applicationEntryPoint and logs warning", async () => {
+    mockedRequest.mockResolvedValueOnce({
+      vaultProviders: {
+        items: [makeVaultProvider({ applicationEntryPoint: "0xshort" })],
+      },
+    });
+
+    const providers = await fetchVaultProviders();
+
+    expect(providers).toHaveLength(0);
+    expect(mockedLoggerWarn).toHaveBeenCalledWith(
+      expect.stringContaining("invalid applicationEntryPoint"),
+    );
+  });
+
+  it("keeps valid providers and filters invalid ones", async () => {
+    mockedRequest.mockResolvedValueOnce({
+      vaultProviders: {
+        items: [
+          makeVaultProvider({ id: VALID_ETH_ADDRESS }),
+          makeVaultProvider({ id: "bad" }),
+          makeVaultProvider({ id: "0x" + "dd".repeat(20) }),
+        ],
+      },
+    });
+
+    const providers = await fetchVaultProviders();
+
+    expect(providers).toHaveLength(2);
+    expect(providers[0].id).toBe(VALID_ETH_ADDRESS);
+    expect(providers[1].id).toBe("0x" + "dd".repeat(20));
+  });
+
+  it("accepts compressed pubkey (66 hex chars after 0x)", async () => {
+    const compressedPubkey = "0x" + "aa".repeat(33);
+    mockedRequest.mockResolvedValueOnce({
+      vaultProviders: {
+        items: [makeVaultProvider({ btcPubKey: compressedPubkey })],
+      },
+    });
+
+    const providers = await fetchVaultProviders();
+
+    expect(providers).toHaveLength(1);
+  });
+});
+
+describe("fetchVaultProviderById", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it("returns null when provider is not found", async () => {
+    mockedRequest.mockResolvedValueOnce({ vaultProvider: null });
+
+    const result = await fetchVaultProviderById("0x" + "ab".repeat(20));
+    expect(result).toBeNull();
+  });
+
+  it("returns null and warns when provider has invalid fields", async () => {
+    mockedRequest.mockResolvedValueOnce({
+      vaultProvider: makeVaultProvider({ btcPubKey: "invalid" }),
+    });
+
+    const result = await fetchVaultProviderById("0x" + "ab".repeat(20));
+
+    expect(result).toBeNull();
+    expect(mockedLoggerWarn).toHaveBeenCalled();
+  });
+
+  it("returns validated provider", async () => {
+    mockedRequest.mockResolvedValueOnce({
+      vaultProvider: makeVaultProvider(),
+    });
+
+    const result = await fetchVaultProviderById("0x" + "ab".repeat(20));
+
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe(VALID_ETH_ADDRESS);
+  });
+});

--- a/services/vault/src/services/vault/__tests__/fetchVaults.test.ts
+++ b/services/vault/src/services/vault/__tests__/fetchVaults.test.ts
@@ -314,7 +314,7 @@ describe("fetchVaults", () => {
 
       await expect(
         fetchVaultById(VALID_VAULT_ID as `0x${string}`),
-      ).rejects.toThrow(/Malformed hex.*depositorBtcPubKey/);
+      ).rejects.toThrow(/Invalid BTC public key.*depositorBtcPubKey/);
     });
 
     it("throws when depositor has invalid address format", async () => {
@@ -355,9 +355,10 @@ describe("fetchVaults", () => {
         },
       });
 
-      const uppercaseId = VALID_VAULT_ID.replace("0x", "0x")
-        .toUpperCase()
-        .replace("0X", "0x") as `0x${string}`;
+      const uppercaseId = VALID_VAULT_ID.toUpperCase().replace(
+        "0X",
+        "0x",
+      ) as `0x${string}`;
       const result = await fetchVaultRefundData(uppercaseId);
 
       expect(result).toEqual({
@@ -410,7 +411,7 @@ describe("fetchVaults", () => {
 
       await expect(
         fetchVaultRefundData(VALID_VAULT_ID as `0x${string}`),
-      ).rejects.toThrow(/Malformed hex.*depositorBtcPubKey/);
+      ).rejects.toThrow(/Invalid BTC public key.*depositorBtcPubKey/);
     });
 
     it("propagates GraphQL request errors unchanged", async () => {

--- a/services/vault/src/services/vault/__tests__/fetchVaults.test.ts
+++ b/services/vault/src/services/vault/__tests__/fetchVaults.test.ts
@@ -18,28 +18,34 @@ vi.mock("../../../clients/graphql/client", () => ({
 vi.mock("@/infrastructure", () => ({
   logger: {
     error: vi.fn(),
+    warn: vi.fn(),
   },
 }));
 
 const mockedRequest = vi.mocked(graphqlClient.request);
 const mockedLoggerError = vi.mocked(logger.error);
 
+const VALID_VAULT_ID = "0x" + "ab".repeat(32);
+const VALID_ETH_ADDRESS = "0x" + "dd".repeat(20);
+const VALID_HEX_64 = "0x" + "cc".repeat(32);
+const VALID_HEX_SHORT = "0x" + "ee".repeat(16);
+
 function makeGraphQLVaultItem(
   overrides: Record<string, unknown> = {},
 ): Record<string, unknown> {
   return {
-    id: "0xabc123",
-    depositor: "0xdepositor",
-    depositorBtcPubKey: "0xbtcpub",
-    vaultProvider: "0xprovider",
+    id: VALID_VAULT_ID,
+    depositor: VALID_ETH_ADDRESS,
+    depositorBtcPubKey: VALID_HEX_64,
+    vaultProvider: VALID_ETH_ADDRESS,
     amount: "100000",
-    applicationEntryPoint: "0xcontroller",
+    applicationEntryPoint: VALID_ETH_ADDRESS,
     status: "pending",
     inUse: false,
     ackCount: 0,
-    depositorSignedPeginTx: "0xtx",
-    unsignedPrePeginTx: "0xpretx",
-    peginTxHash: "0xpeginhash",
+    depositorSignedPeginTx: VALID_HEX_SHORT,
+    unsignedPrePeginTx: VALID_HEX_SHORT,
+    peginTxHash: VALID_HEX_64,
     hashlock: "0x" + "00".repeat(32),
     htlcVout: 0,
     secret: null,
@@ -49,7 +55,7 @@ function makeGraphQLVaultItem(
     offchainParamsVersion: 1,
     currentOwner: null,
     referralCode: 0,
-    depositorPayoutBtcAddress: "0xpayout",
+    depositorPayoutBtcAddress: VALID_HEX_SHORT,
     depositorWotsPkHash: "0x" + "ab".repeat(32),
     btcPopSignature: null,
     pendingAt: "1700000000",
@@ -58,7 +64,7 @@ function makeGraphQLVaultItem(
     expiredAt: null,
     expirationReason: null,
     blockNumber: "100",
-    transactionHash: "0xtxhash",
+    transactionHash: "0x" + "ff".repeat(32),
     ...overrides,
   };
 }
@@ -85,7 +91,7 @@ describe("fetchVaults", () => {
           message: expect.stringContaining("depositorWotsPkHash"),
         }),
         expect.objectContaining({
-          tags: expect.objectContaining({ vaultId: "0xabc123" }),
+          tags: expect.objectContaining({ vaultId: VALID_VAULT_ID }),
         }),
       );
     });
@@ -108,12 +114,13 @@ describe("fetchVaults", () => {
     });
 
     it("maps peginTxHash and new optional fields correctly", async () => {
+      const peginHash = "0x" + "aa".repeat(32);
       const popSig = "0x" + "cc".repeat(32);
       mockedRequest.mockResolvedValueOnce({
         vaults: {
           items: [
             makeGraphQLVaultItem({
-              peginTxHash: "0xpegin123",
+              peginTxHash: peginHash,
               btcPopSignature: popSig,
             }),
           ],
@@ -126,7 +133,7 @@ describe("fetchVaults", () => {
       );
 
       expect(vaults).toHaveLength(1);
-      expect(vaults[0].peginTxHash).toBe("0xpegin123");
+      expect(vaults[0].peginTxHash).toBe(peginHash);
       expect(vaults[0].btcPopSignature).toBe(popSig);
     });
 
@@ -189,18 +196,21 @@ describe("fetchVaults", () => {
           message: expect.stringContaining("peginTxHash"),
         }),
         expect.objectContaining({
-          tags: expect.objectContaining({ vaultId: "0xabc123" }),
+          tags: expect.objectContaining({ vaultId: VALID_VAULT_ID }),
         }),
       );
     });
 
     it("skips vaults with unknown GraphQL status and returns valid ones", async () => {
+      const id1 = "0x" + "11".repeat(32);
+      const id2 = "0x" + "22".repeat(32);
+      const id3 = "0x" + "33".repeat(32);
       mockedRequest.mockResolvedValueOnce({
         vaults: {
           items: [
-            makeGraphQLVaultItem({ id: "0x1", status: "pending" }),
-            makeGraphQLVaultItem({ id: "0x2", status: "bogus_status" }),
-            makeGraphQLVaultItem({ id: "0x3", status: "available" }),
+            makeGraphQLVaultItem({ id: id1, status: "pending" }),
+            makeGraphQLVaultItem({ id: id2, status: "bogus_status" }),
+            makeGraphQLVaultItem({ id: id3, status: "available" }),
           ],
           totalCount: 3,
         },
@@ -211,16 +221,15 @@ describe("fetchVaults", () => {
       );
 
       expect(vaults).toHaveLength(2);
-      expect(vaults[0].id).toBe("0x1");
-      expect(vaults[1].id).toBe("0x3");
+      expect(vaults[0].id).toBe(id1);
+      expect(vaults[1].id).toBe(id3);
     });
 
     it("logs error to Sentry when vault has unknown status", async () => {
+      const badId = "0x" + "ba".repeat(32);
       mockedRequest.mockResolvedValueOnce({
         vaults: {
-          items: [
-            makeGraphQLVaultItem({ id: "0xbad", status: "bogus_status" }),
-          ],
+          items: [makeGraphQLVaultItem({ id: badId, status: "bogus_status" })],
           totalCount: 1,
         },
       });
@@ -235,7 +244,7 @@ describe("fetchVaults", () => {
         }),
         expect.objectContaining({
           tags: expect.objectContaining({
-            vaultId: "0xbad",
+            vaultId: badId,
             component: "fetchVaults",
           }),
           data: expect.objectContaining({ rawStatus: "bogus_status" }),
@@ -250,8 +259,10 @@ describe("fetchVaults", () => {
         vault: makeGraphQLVaultItem({ peginTxHash: null }),
       });
 
-      await expect(fetchVaultById("0xabc123" as `0x${string}`)).rejects.toThrow(
-        'Missing required field "peginTxHash" for vault 0xabc123',
+      await expect(
+        fetchVaultById(VALID_VAULT_ID as `0x${string}`),
+      ).rejects.toThrow(
+        `Missing required field "peginTxHash" for vault ${VALID_VAULT_ID}`,
       );
     });
 
@@ -260,8 +271,10 @@ describe("fetchVaults", () => {
         vault: makeGraphQLVaultItem({ depositorWotsPkHash: null }),
       });
 
-      await expect(fetchVaultById("0xabc123" as `0x${string}`)).rejects.toThrow(
-        'Missing required field "depositorWotsPkHash" for vault 0xabc123',
+      await expect(
+        fetchVaultById(VALID_VAULT_ID as `0x${string}`),
+      ).rejects.toThrow(
+        `Missing required field "depositorWotsPkHash" for vault ${VALID_VAULT_ID}`,
       );
     });
 
@@ -271,7 +284,7 @@ describe("fetchVaults", () => {
         vault: makeGraphQLVaultItem({ depositorWotsPkHash: hash }),
       });
 
-      const vault = await fetchVaultById("0xabc123" as `0x${string}`);
+      const vault = await fetchVaultById(VALID_VAULT_ID as `0x${string}`);
 
       expect(vault).not.toBeNull();
       expect(vault!.depositorWotsPkHash).toBe(hash);
@@ -280,7 +293,7 @@ describe("fetchVaults", () => {
     it("returns null when vault is not found", async () => {
       mockedRequest.mockResolvedValueOnce({ vault: null });
 
-      const result = await fetchVaultById("0xnotfound" as `0x${string}`);
+      const result = await fetchVaultById(VALID_VAULT_ID as `0x${string}`);
       expect(result).toBeNull();
     });
 
@@ -289,9 +302,39 @@ describe("fetchVaults", () => {
         vault: makeGraphQLVaultItem({ status: "some_future_status" }),
       });
 
-      await expect(fetchVaultById("0xabc123" as `0x${string}`)).rejects.toThrow(
-        'Unknown GraphQL vault status "some_future_status"',
-      );
+      await expect(
+        fetchVaultById(VALID_VAULT_ID as `0x${string}`),
+      ).rejects.toThrow('Unknown GraphQL vault status "some_future_status"');
+    });
+
+    it("throws when depositorBtcPubKey has invalid hex format", async () => {
+      mockedRequest.mockResolvedValueOnce({
+        vault: makeGraphQLVaultItem({ depositorBtcPubKey: "not-hex" }),
+      });
+
+      await expect(
+        fetchVaultById(VALID_VAULT_ID as `0x${string}`),
+      ).rejects.toThrow(/Malformed hex.*depositorBtcPubKey/);
+    });
+
+    it("throws when depositor has invalid address format", async () => {
+      mockedRequest.mockResolvedValueOnce({
+        vault: makeGraphQLVaultItem({ depositor: "0xshort" }),
+      });
+
+      await expect(
+        fetchVaultById(VALID_VAULT_ID as `0x${string}`),
+      ).rejects.toThrow(/Invalid address.*depositor/);
+    });
+
+    it("throws when vaultProvider has invalid address format", async () => {
+      mockedRequest.mockResolvedValueOnce({
+        vault: makeGraphQLVaultItem({ vaultProvider: "bad-address" }),
+      });
+
+      await expect(
+        fetchVaultById(VALID_VAULT_ID as `0x${string}`),
+      ).rejects.toThrow(/Invalid address.*vaultProvider/);
     });
   });
 
@@ -301,26 +344,30 @@ describe("fetchVaults", () => {
     });
 
     it("returns the minimal refund-needed fields, mapping to typed output", async () => {
+      const btcPub = "0x" + "aa".repeat(32);
+      const preTx = "0x" + "bb".repeat(16);
       mockedRequest.mockResolvedValueOnce({
         vault: {
-          id: "0xabc123",
-          depositorBtcPubKey: "0xbtcpub",
+          id: VALID_VAULT_ID,
+          depositorBtcPubKey: btcPub,
           amount: "150000",
-          unsignedPrePeginTx: "0xpretx",
+          unsignedPrePeginTx: preTx,
         },
       });
 
-      const result = await fetchVaultRefundData("0xABC123" as `0x${string}`);
+      const uppercaseId = VALID_VAULT_ID.replace("0x", "0x")
+        .toUpperCase()
+        .replace("0X", "0x") as `0x${string}`;
+      const result = await fetchVaultRefundData(uppercaseId);
 
       expect(result).toEqual({
-        depositorBtcPubkey: "0xbtcpub",
+        depositorBtcPubkey: btcPub,
         amount: 150_000n,
-        unsignedPrePeginTx: "0xpretx",
+        unsignedPrePeginTx: preTx,
       });
-      // GraphQL query was called with lowercased id
       expect(mockedRequest).toHaveBeenCalledOnce();
       expect(mockedRequest).toHaveBeenCalledWith(expect.anything(), {
-        id: "0xabc123",
+        id: VALID_VAULT_ID,
       });
     });
 
@@ -335,25 +382,42 @@ describe("fetchVaults", () => {
     it("throws when unsignedPrePeginTx is missing — refund cannot be built without it", async () => {
       mockedRequest.mockResolvedValueOnce({
         vault: {
-          id: "0xabc123",
-          depositorBtcPubKey: "0xbtcpub",
+          id: VALID_VAULT_ID,
+          depositorBtcPubKey: VALID_HEX_64,
           amount: "150000",
           unsignedPrePeginTx: null,
         },
       });
 
       await expect(
-        fetchVaultRefundData("0xabc123" as `0x${string}`),
+        fetchVaultRefundData(VALID_VAULT_ID as `0x${string}`),
       ).rejects.toThrow(
-        /Vault 0xabc123 is missing unsignedPrePeginTx; cannot build refund/,
+        new RegExp(
+          `Vault ${VALID_VAULT_ID} is missing unsignedPrePeginTx; cannot build refund`,
+        ),
       );
+    });
+
+    it("throws when depositorBtcPubKey has invalid hex format", async () => {
+      mockedRequest.mockResolvedValueOnce({
+        vault: {
+          id: VALID_VAULT_ID,
+          depositorBtcPubKey: "not-valid-hex",
+          amount: "150000",
+          unsignedPrePeginTx: VALID_HEX_SHORT,
+        },
+      });
+
+      await expect(
+        fetchVaultRefundData(VALID_VAULT_ID as `0x${string}`),
+      ).rejects.toThrow(/Malformed hex.*depositorBtcPubKey/);
     });
 
     it("propagates GraphQL request errors unchanged", async () => {
       mockedRequest.mockRejectedValueOnce(new Error("indexer unavailable"));
 
       await expect(
-        fetchVaultRefundData("0xabc123" as `0x${string}`),
+        fetchVaultRefundData(VALID_VAULT_ID as `0x${string}`),
       ).rejects.toThrow("indexer unavailable");
     });
   });

--- a/services/vault/src/services/vault/fetchVaultProviders.ts
+++ b/services/vault/src/services/vault/fetchVaultProviders.ts
@@ -7,7 +7,13 @@
 
 import { gql } from "graphql-request";
 
+import { logger } from "@/infrastructure";
+
 import { graphqlClient } from "../../clients/graphql/client";
+import {
+  BTC_PUBKEY_HEX_PATTERN,
+  ETH_ADDRESS_PATTERN,
+} from "../../utils/validation";
 
 const GET_VAULT_PROVIDERS = gql`
   query GetVaultProviders {
@@ -69,15 +75,49 @@ interface VaultProviderResponse {
 }
 
 /**
+ * Validate critical fields on a vault provider from GraphQL.
+ * Returns null (with a warning) if validation fails — one bad provider
+ * should not crash the entire list fetch.
+ */
+function validateVaultProvider(item: VaultProvider): VaultProvider | null {
+  if (!ETH_ADDRESS_PATTERN.test(item.id)) {
+    logger.warn(
+      `[fetchVaultProviders] Skipping provider with invalid id: "${item.id.slice(0, 20)}"`,
+    );
+    return null;
+  }
+  if (!BTC_PUBKEY_HEX_PATTERN.test(item.btcPubKey)) {
+    logger.warn(
+      `[fetchVaultProviders] Skipping provider ${item.id}: invalid btcPubKey format`,
+    );
+    return null;
+  }
+  if (!ETH_ADDRESS_PATTERN.test(item.applicationEntryPoint)) {
+    logger.warn(
+      `[fetchVaultProviders] Skipping provider ${item.id}: invalid applicationEntryPoint "${item.applicationEntryPoint.slice(0, 20)}"`,
+    );
+    return null;
+  }
+  return item;
+}
+
+/**
  * Fetch all vault providers from GraphQL
  *
- * @returns Array of vault providers
+ * @returns Array of vault providers (invalid entries are filtered out with warnings)
  */
 export async function fetchVaultProviders(): Promise<VaultProvider[]> {
   const data =
     await graphqlClient.request<VaultProvidersResponse>(GET_VAULT_PROVIDERS);
 
-  return data.vaultProviders.items;
+  const providers: VaultProvider[] = [];
+  for (const item of data.vaultProviders.items) {
+    const validated = validateVaultProvider(item);
+    if (validated) {
+      providers.push(validated);
+    }
+  }
+  return providers;
 }
 
 /**
@@ -94,5 +134,8 @@ export async function fetchVaultProviderById(
     { id: providerId.toLowerCase() },
   );
 
-  return data.vaultProvider;
+  if (!data.vaultProvider) {
+    return null;
+  }
+  return validateVaultProvider(data.vaultProvider);
 }

--- a/services/vault/src/services/vault/fetchVaultProviders.ts
+++ b/services/vault/src/services/vault/fetchVaultProviders.ts
@@ -82,7 +82,7 @@ interface VaultProviderResponse {
 function validateVaultProvider(item: VaultProvider): VaultProvider | null {
   if (!ETH_ADDRESS_PATTERN.test(item.id)) {
     logger.warn(
-      `[fetchVaultProviders] Skipping provider with invalid id: "${item.id.slice(0, 20)}"`,
+      `[fetchVaultProviders] Skipping provider with invalid id: "${String(item.id).slice(0, 20)}"`,
     );
     return null;
   }
@@ -94,7 +94,7 @@ function validateVaultProvider(item: VaultProvider): VaultProvider | null {
   }
   if (!ETH_ADDRESS_PATTERN.test(item.applicationEntryPoint)) {
     logger.warn(
-      `[fetchVaultProviders] Skipping provider ${item.id}: invalid applicationEntryPoint "${item.applicationEntryPoint.slice(0, 20)}"`,
+      `[fetchVaultProviders] Skipping provider ${item.id}: invalid applicationEntryPoint "${String(item.applicationEntryPoint).slice(0, 20)}"`,
     );
     return null;
   }

--- a/services/vault/src/services/vault/fetchVaults.ts
+++ b/services/vault/src/services/vault/fetchVaults.ts
@@ -13,6 +13,7 @@ import { logger } from "@/infrastructure";
 import { graphqlClient } from "../../clients/graphql/client";
 import type { ExpirationReason } from "../../models/peginStateMachine";
 import { type Vault, VaultStatus } from "../../types/vault";
+import { ETH_ADDRESS_PATTERN, VALID_HEX_PATTERN } from "../../utils/validation";
 
 /**
  * Common vault fields fragment
@@ -198,11 +199,44 @@ const ZERO_HASH =
   "0x0000000000000000000000000000000000000000000000000000000000000000";
 
 /**
+ * Validates that a required hex field from the indexer is well-formed.
+ * Throws if the value does not match 0x-prefixed hex — this indicates
+ * a buggy or compromised server response.
+ */
+function validateRequiredHex(
+  value: string,
+  fieldName: string,
+  vaultId: string,
+): Hex {
+  if (!VALID_HEX_PATTERN.test(value)) {
+    throw new Error(
+      `Malformed hex in required field "${fieldName}" for vault ${vaultId}: "${value.slice(0, 20)}"`,
+    );
+  }
+  return value as Hex;
+}
+
+/**
+ * Validates that a required address field from the indexer is a well-formed
+ * 20-byte Ethereum address. Throws on invalid format.
+ */
+function validateRequiredAddress(
+  value: string,
+  fieldName: string,
+  vaultId: string,
+): Address {
+  if (!ETH_ADDRESS_PATTERN.test(value)) {
+    throw new Error(
+      `Invalid address in field "${fieldName}" for vault ${vaultId}: "${value.slice(0, 20)}"`,
+    );
+  }
+  return value as Address;
+}
+
+/**
  * Normalize an optional hex field from the indexer.
  * Treats null, "0x" (empty bytes), and zero-hash as undefined.
  */
-const VALID_HEX_PATTERN = /^0x[0-9a-fA-F]+$/;
-
 function normalizeOptionalHex(value: string | null): Hex | undefined {
   if (!value || value === "0x" || value === ZERO_HASH) return undefined;
   if (!VALID_HEX_PATTERN.test(value)) {
@@ -231,40 +265,68 @@ function isValidExpirationReason(
  */
 function transformVaultItem(item: GraphQLVaultItem): Vault {
   return {
-    id: item.id as Hex,
-    peginTxHash: validateRequiredField(
-      item.peginTxHash,
+    id: validateRequiredHex(item.id, "id", item.id),
+    peginTxHash: validateRequiredHex(
+      validateRequiredField(item.peginTxHash, "peginTxHash", item.id),
       "peginTxHash",
       item.id,
-    ) as Hex,
-    depositor: item.depositor as Address,
-    depositorBtcPubkey: item.depositorBtcPubKey as Hex,
-    depositorSignedPeginTx: item.depositorSignedPeginTx as Hex,
-    unsignedPrePeginTx: validateRequiredField(
-      item.unsignedPrePeginTx,
+    ),
+    depositor: validateRequiredAddress(item.depositor, "depositor", item.id),
+    depositorBtcPubkey: validateRequiredHex(
+      item.depositorBtcPubKey,
+      "depositorBtcPubKey",
+      item.id,
+    ),
+    depositorSignedPeginTx: validateRequiredHex(
+      item.depositorSignedPeginTx,
+      "depositorSignedPeginTx",
+      item.id,
+    ),
+    unsignedPrePeginTx: validateRequiredHex(
+      validateRequiredField(
+        item.unsignedPrePeginTx,
+        "unsignedPrePeginTx",
+        item.id,
+      ),
       "unsignedPrePeginTx",
       item.id,
-    ) as Hex,
+    ),
     amount: BigInt(item.amount),
-    vaultProvider: item.vaultProvider as Address,
+    vaultProvider: validateRequiredAddress(
+      item.vaultProvider,
+      "vaultProvider",
+      item.id,
+    ),
     hashlock: normalizeOptionalHex(item.hashlock),
     htlcVout: item.htlcVout,
-    secret: item.secret ? (item.secret as Hex) : undefined,
+    secret: normalizeOptionalHex(item.secret),
     peginSigsPostedAt: item.peginSigsPostedAt
       ? parseInt(item.peginSigsPostedAt, 10) * 1000
       : undefined,
     status: mapGraphQLStatusToVaultStatus(item.status),
-    applicationEntryPoint: item.applicationEntryPoint as Address,
+    applicationEntryPoint: validateRequiredAddress(
+      item.applicationEntryPoint,
+      "applicationEntryPoint",
+      item.id,
+    ),
     appVaultKeepersVersion: item.appVaultKeepersVersion,
     universalChallengersVersion: item.universalChallengersVersion,
     offchainParamsVersion: item.offchainParamsVersion,
     currentOwner: item.currentOwner
-      ? (item.currentOwner as Address)
+      ? validateRequiredAddress(item.currentOwner, "currentOwner", item.id)
       : undefined,
     referralCode: item.referralCode,
-    depositorPayoutBtcAddress: item.depositorPayoutBtcAddress as Hex,
-    depositorWotsPkHash: validateRequiredField(
-      item.depositorWotsPkHash,
+    depositorPayoutBtcAddress: validateRequiredHex(
+      item.depositorPayoutBtcAddress,
+      "depositorPayoutBtcAddress",
+      item.id,
+    ),
+    depositorWotsPkHash: validateRequiredHex(
+      validateRequiredField(
+        item.depositorWotsPkHash,
+        "depositorWotsPkHash",
+        item.id,
+      ),
       "depositorWotsPkHash",
       item.id,
     ),
@@ -383,8 +445,16 @@ export async function fetchVaultRefundData(
     );
   }
   return {
-    depositorBtcPubkey: depositorBtcPubKey as Hex,
+    depositorBtcPubkey: validateRequiredHex(
+      depositorBtcPubKey,
+      "depositorBtcPubKey",
+      vaultId,
+    ),
     amount: BigInt(amount),
-    unsignedPrePeginTx: unsignedPrePeginTx as Hex,
+    unsignedPrePeginTx: validateRequiredHex(
+      unsignedPrePeginTx,
+      "unsignedPrePeginTx",
+      vaultId,
+    ),
   };
 }

--- a/services/vault/src/services/vault/fetchVaults.ts
+++ b/services/vault/src/services/vault/fetchVaults.ts
@@ -13,7 +13,11 @@ import { logger } from "@/infrastructure";
 import { graphqlClient } from "../../clients/graphql/client";
 import type { ExpirationReason } from "../../models/peginStateMachine";
 import { type Vault, VaultStatus } from "../../types/vault";
-import { ETH_ADDRESS_PATTERN, VALID_HEX_PATTERN } from "../../utils/validation";
+import {
+  BTC_PUBKEY_HEX_PATTERN,
+  ETH_ADDRESS_PATTERN,
+  VALID_HEX_PATTERN,
+} from "../../utils/validation";
 
 /**
  * Common vault fields fragment
@@ -217,6 +221,24 @@ function validateRequiredHex(
 }
 
 /**
+ * Validates that a required BTC public key field from the indexer has a valid
+ * encoding length (x-only 64, compressed 66, or uncompressed 130 hex chars).
+ * Throws on invalid format.
+ */
+function validateRequiredBtcPubkey(
+  value: string,
+  fieldName: string,
+  vaultId: string,
+): Hex {
+  if (!BTC_PUBKEY_HEX_PATTERN.test(value)) {
+    throw new Error(
+      `Invalid BTC public key in field "${fieldName}" for vault ${vaultId}: "${String(value).slice(0, 20)}"`,
+    );
+  }
+  return value as Hex;
+}
+
+/**
  * Validates that a required address field from the indexer is a well-formed
  * 20-byte Ethereum address. Throws on invalid format.
  */
@@ -272,7 +294,7 @@ function transformVaultItem(item: GraphQLVaultItem): Vault {
       item.id,
     ),
     depositor: validateRequiredAddress(item.depositor, "depositor", item.id),
-    depositorBtcPubkey: validateRequiredHex(
+    depositorBtcPubkey: validateRequiredBtcPubkey(
       item.depositorBtcPubKey,
       "depositorBtcPubKey",
       item.id,
@@ -445,7 +467,7 @@ export async function fetchVaultRefundData(
     );
   }
   return {
-    depositorBtcPubkey: validateRequiredHex(
+    depositorBtcPubkey: validateRequiredBtcPubkey(
       depositorBtcPubKey,
       "depositorBtcPubKey",
       vaultId,

--- a/services/vault/src/utils/rpc/vpProxy.ts
+++ b/services/vault/src/utils/rpc/vpProxy.ts
@@ -1,5 +1,7 @@
 import { ENV } from "@/config/env";
 
+import { ETH_ADDRESS_PATTERN } from "../validation";
+
 /**
  * Build the RPC URL for a vault provider via the proxy service.
  *
@@ -15,7 +17,7 @@ export function getVpProxyUrl(vpAddress: string): string {
       "VP_PROXY_URL is not configured. Set NEXT_PUBLIC_TBV_VP_PROXY_URL.",
     );
   }
-  if (!vpAddress || !/^0x[0-9a-fA-F]{40}$/.test(vpAddress)) {
+  if (!vpAddress || !ETH_ADDRESS_PATTERN.test(vpAddress)) {
     throw new Error(
       `Invalid vault provider address: "${vpAddress}". Expected a 20-byte hex address starting with 0x.`,
     );

--- a/services/vault/src/utils/validation.ts
+++ b/services/vault/src/utils/validation.ts
@@ -1,0 +1,14 @@
+/** Matches any 0x-prefixed hex string (at least one hex digit). */
+export const VALID_HEX_PATTERN = /^0x[0-9a-fA-F]+$/;
+
+/** Matches a 20-byte Ethereum address (0x + 40 hex chars). */
+export const ETH_ADDRESS_PATTERN = /^0x[0-9a-fA-F]{40}$/;
+
+/**
+ * Matches a 0x-prefixed BTC public key in any standard encoding:
+ * - x-only:       32 bytes → 64 hex chars
+ * - compressed:   33 bytes → 66 hex chars
+ * - uncompressed: 65 bytes → 130 hex chars
+ */
+export const BTC_PUBKEY_HEX_PATTERN =
+  /^0x(?:[0-9a-fA-F]{64}|[0-9a-fA-F]{66}|[0-9a-fA-F]{130})$/;


### PR DESCRIPTION
## Summary

Addresses audit finding [#62 (LOW)](https://github.com/babylonlabs-io/vault-provider-proxy/issues/143)

GraphQL responses from the indexer were typed via TypeScript generics (`graphqlClient.request<T>()`) but had no runtime validation. Critical fields like `btcPubKey`, `id`, `vaultProvider`, and `applicationEntryPoint` were cast (`as Hex`, `as Address`) without checking format. A compromised or buggy indexer could inject malformed data that propagates into signing contexts and transaction construction.

### Changes

**New: shared validation patterns** (`services/vault/src/utils/validation.ts`)
- `VALID_HEX_PATTERN` — any 0x-prefixed hex
- `ETH_ADDRESS_PATTERN` — 20-byte Ethereum address
- `BTC_PUBKEY_HEX_PATTERN` — exact valid BTC pubkey lengths (64, 66, or 130 hex chars)

**`fetchVaultProviders.ts`** — added `validateVaultProvider()` that validates `id`, `btcPubKey`, and `applicationEntryPoint`. Invalid providers are filtered out with a warning log (one bad provider doesn't crash the list).

**`fetchVaults.ts`** — added `validateRequiredHex()` and `validateRequiredAddress()`. Applied to all previously unvalidated casts: `id`, `depositorBtcPubKey`, `depositorSignedPeginTx`, `depositor`, `vaultProvider`, `applicationEntryPoint`, `depositorPayoutBtcAddress`, `depositorWotsPkHash`, `currentOwner`. Also applied to the refund flow (`fetchVaultRefundData`). Changed `secret` from raw cast to `normalizeOptionalHex()` for consistency.

**`vpProxy.ts`** — replaced inline address regex with shared `ETH_ADDRESS_PATTERN`.


Closes https://github.com/babylonlabs-io/vault-provider-proxy/issues/143