### PR TITLE
fix(vault): cap protocol supply display decimals

### DIFF
--- a/services/vault/src/components/simple/SupplyCapSection.tsx
+++ b/services/vault/src/components/simple/SupplyCapSection.tsx
@@ -82,17 +82,16 @@ export function SupplyCapSection({
   if (!snapshot || !snapshot.hasTotalCap) return null;
 
   const coinSymbol = getBtcSymbol();
-  const capDisplay = `${formatSatoshisToBtcDisplay(snapshot.totalCapBTC)} ${coinSymbol}`;
-  const depositedDisplay = `${formatSatoshisToBtcDisplay(snapshot.totalBTC)} ${coinSymbol}`;
+  const capBtc = satoshiToBtcNumber(snapshot.totalCapBTC);
+  const depositedBtc = satoshiToBtcNumber(snapshot.totalBTC);
+  // Match simple-staking's formatBTCTvl: 2 decimals for >= 1 BTC, 8 for < 1 BTC.
+  const capDecimals = capBtc >= 1 ? 2 : 8;
+  const depositedDecimals = depositedBtc >= 1 ? 2 : 8;
+  const capDisplay = `${formatSatoshisToBtcDisplay(snapshot.totalCapBTC, capDecimals)} ${coinSymbol}`;
+  const depositedDisplay = `${formatSatoshisToBtcDisplay(snapshot.totalBTC, depositedDecimals)} ${coinSymbol}`;
 
-  const capUsd =
-    btcPriceUSD > 0
-      ? satoshiToBtcNumber(snapshot.totalCapBTC) * btcPriceUSD
-      : null;
-  const depositedUsd =
-    btcPriceUSD > 0
-      ? satoshiToBtcNumber(snapshot.totalBTC) * btcPriceUSD
-      : null;
+  const capUsd = btcPriceUSD > 0 ? capBtc * btcPriceUSD : null;
+  const depositedUsd = btcPriceUSD > 0 ? depositedBtc * btcPriceUSD : null;
 
   return (
     <VaultCapFrame>

--- a/services/vault/src/components/simple/__tests__/SupplyCapSection.test.tsx
+++ b/services/vault/src/components/simple/__tests__/SupplyCapSection.test.tsx
@@ -12,6 +12,10 @@ vi.mock("@/hooks/usePrices", () => ({
 
 const BTC_1000 = 100_000_000_000n;
 const BTC_10 = 1_000_000_000n;
+// 0.62225053 BTC (sub-1 value with 8 significant fractional digits)
+const BTC_FRACTIONAL = 62_225_053n;
+// 10.12345678 BTC (>= 1 value with a noisy fraction that should be truncated)
+const BTC_10_NOISY = 1_012_345_678n;
 
 const cappedSnapshot: CapSnapshot = {
   totalCapBTC: BTC_1000,
@@ -23,6 +27,18 @@ const cappedSnapshot: CapSnapshot = {
   remainingTotal: BTC_1000 - BTC_10,
   remainingForUser: null,
   effectiveRemaining: BTC_1000 - BTC_10,
+};
+
+const fractionalSnapshot: CapSnapshot = {
+  totalCapBTC: BTC_10_NOISY,
+  perAddressCapBTC: 0n,
+  totalBTC: BTC_FRACTIONAL,
+  userBTC: null,
+  hasTotalCap: true,
+  hasPerAddressCap: false,
+  remainingTotal: BTC_10_NOISY - BTC_FRACTIONAL,
+  remainingForUser: null,
+  effectiveRemaining: BTC_10_NOISY - BTC_FRACTIONAL,
 };
 
 const unlimitedSnapshot: CapSnapshot = {
@@ -80,6 +96,15 @@ describe("SupplyCapSection", () => {
   it("renders nothing when snapshot is null", () => {
     const { container } = render(<SupplyCapSection snapshot={null} />);
     expect(container).toBeEmptyDOMElement();
+  });
+
+  it("truncates values >= 1 BTC to 2 decimals and keeps < 1 BTC values at up to 8 decimals", () => {
+    mockBtcPrice.mockReturnValue(69_003.07);
+    render(<SupplyCapSection snapshot={fractionalSnapshot} />);
+    // 10.12345678 BTC >= 1 → 2 decimals → "10.12"
+    expect(screen.getByText(/10\.12 s?BTC/)).toBeInTheDocument();
+    // 0.62225053 BTC < 1 → 8 decimals preserved
+    expect(screen.getByText(/0\.62225053 s?BTC/)).toBeInTheDocument();
   });
 
   it("renders skeleton placeholders while loading with no snapshot yet", () => {


### PR DESCRIPTION
Adopt 2 decimals when >= 1 BTC, 8 decimals otherwise for stats

<img width="2532" height="1804" alt="image" src="https://github.com/user-attachments/assets/2c402c3c-91c5-459c-96cc-5212fc9227ff" />
