### PR TITLE
fix(vault): restore symbol-based token icon fallback

### DIFF
--- a/services/vault/src/applications/aave/components/CollateralModal/components/BorrowableAssetsValue.tsx
+++ b/services/vault/src/applications/aave/components/CollateralModal/components/BorrowableAssetsValue.tsx
@@ -5,7 +5,10 @@
 
 import { Avatar, AvatarGroup } from "@babylonlabs-io/core-ui";
 
-import { getTokenByAddress } from "@/services/token";
+import {
+  getCurrencyIconWithFallback,
+  getTokenByAddress,
+} from "@/services/token";
 
 import type { AaveReserveConfig } from "../../../services";
 
@@ -21,7 +24,10 @@ export function BorrowableAssetsValue({
     return {
       address: reserve.token.address,
       symbol: reserve.token.symbol,
-      icon: tokenMetadata?.icon,
+      icon: getCurrencyIconWithFallback(
+        tokenMetadata?.icon,
+        reserve.token.symbol,
+      ),
     };
   });
 

--- a/services/vault/src/applications/aave/components/Detail/hooks/__tests__/useAaveReserveDetail.test.tsx
+++ b/services/vault/src/applications/aave/components/Detail/hooks/__tests__/useAaveReserveDetail.test.tsx
@@ -62,6 +62,9 @@ vi.mock("@/clients/eth-contract/client", () => ({
 
 vi.mock("@/services/token/tokenService", () => ({
   getTokenByAddress: vi.fn(() => ({ icon: "usdc-icon" })),
+  getCurrencyIconWithFallback: vi.fn(
+    (icon: string | undefined) => icon ?? "fallback-icon",
+  ),
 }));
 
 // Mock usePrices — returns Chainlink oracle prices

--- a/services/vault/src/applications/aave/components/Detail/hooks/useAaveReserveDetail.ts
+++ b/services/vault/src/applications/aave/components/Detail/hooks/useAaveReserveDetail.ts
@@ -14,7 +14,10 @@ import { formatUnits } from "viem";
 
 import { getBTCNetwork } from "@/config";
 import { usePrices } from "@/hooks/usePrices";
-import { getTokenByAddress } from "@/services/token/tokenService";
+import {
+  getCurrencyIconWithFallback,
+  getTokenByAddress,
+} from "@/services/token/tokenService";
 
 import {
   BPS_SCALE,
@@ -88,7 +91,10 @@ export function useAaveReserveDetail({
     return {
       name: selectedReserve.token.name,
       symbol: selectedReserve.token.symbol,
-      icon: tokenMetadata?.icon ?? "",
+      icon: getCurrencyIconWithFallback(
+        tokenMetadata?.icon,
+        selectedReserve.token.symbol,
+      ),
     };
   }, [selectedReserve]);
 

--- a/services/vault/src/services/token/__tests__/tokenService.test.ts
+++ b/services/vault/src/services/token/__tests__/tokenService.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { getCurrencyIconWithFallback } from "@/services/token/tokenService";
+
+describe("getCurrencyIconWithFallback", () => {
+  it("returns the provided icon when set", () => {
+    expect(getCurrencyIconWithFallback("/images/usdc.png", "USDC")).toBe(
+      "/images/usdc.png",
+    );
+  });
+
+  it("falls back to the symbol-based path for known symbols when icon is missing", () => {
+    expect(getCurrencyIconWithFallback(undefined, "USDC")).toBe(
+      "/images/usdc.png",
+    );
+    expect(getCurrencyIconWithFallback(undefined, "usdt")).toBe(
+      "/images/usdt.png",
+    );
+  });
+
+  it("renders a letter SVG data URI when both icon and known symbol are missing", () => {
+    const result = getCurrencyIconWithFallback(undefined, "FOO");
+    expect(result.startsWith("data:image/svg+xml,")).toBe(true);
+    // The generated SVG encodes the first letter of the symbol, uppercased.
+    expect(decodeURIComponent(result)).toMatch(/<text[^>]*>\s*F\s*<\/text>/);
+  });
+});

--- a/services/vault/src/services/token/tokenService.ts
+++ b/services/vault/src/services/token/tokenService.ts
@@ -17,6 +17,21 @@ import { getNetworkConfigBTC } from "../../config";
 const btcConfig = getNetworkConfigBTC();
 
 /**
+ * Canonical icon path for each known token symbol.
+ * Only include symbols whose image exists under `public/images/` — the
+ * symbol-based fallback in `getCurrencyIconWithFallback` trusts these paths
+ * to load (otherwise the browser would render a broken-image).
+ */
+const TOKEN_ICONS: Record<string, string> = {
+  BTC: btcConfig.icon,
+  SBTC: btcConfig.icon,
+  WBTC: btcConfig.icon,
+  VBTC: btcConfig.icon,
+  USDC: "/images/usdc.png",
+  USDT: "/images/usdt.png",
+};
+
+/**
  * Token metadata interface
  */
 export interface TokenMetadata {
@@ -59,7 +74,7 @@ const TOKEN_REGISTRY: Record<string, TokenMetadata> = {
     symbol: "USDC",
     name: "USD Coin",
     decimals: 6,
-    icon: "/images/usdc.png",
+    icon: TOKEN_ICONS.USDC,
   },
   // USDC - Devnet/Sepolia (Mock)
   "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238": {
@@ -67,7 +82,7 @@ const TOKEN_REGISTRY: Record<string, TokenMetadata> = {
     symbol: "USDC",
     name: "USD Coin",
     decimals: 6,
-    icon: "/images/usdc.png",
+    icon: TOKEN_ICONS.USDC,
   },
   // USDC - Vault Devnet
   "0xc137E7382AA220D59Cc25f76f9aD72De962020Db": {
@@ -75,7 +90,7 @@ const TOKEN_REGISTRY: Record<string, TokenMetadata> = {
     symbol: "USDC",
     name: "USD Coin",
     decimals: 6,
-    icon: "/images/usdc.png",
+    icon: TOKEN_ICONS.USDC,
   },
   // USDT
   "0x94b008aA00579c1307B0EF2c499aD98a8ce58e58": {
@@ -83,7 +98,7 @@ const TOKEN_REGISTRY: Record<string, TokenMetadata> = {
     symbol: "USDT",
     name: "Tether USD",
     decimals: 6,
-    icon: "/images/usdt.png",
+    icon: TOKEN_ICONS.USDT,
   },
   // DAI
   "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1": {
@@ -195,16 +210,25 @@ function generateTokenIconFallback(symbol: string): string {
 }
 
 /**
+ * Look up a canonical icon URL by token symbol (case-insensitive).
+ * Used as a secondary fallback when address-based registry lookup misses —
+ * e.g. for USDC deployed at a testnet address not present in `TOKEN_REGISTRY`.
+ */
+function getIconForSymbol(symbol: string): string | undefined {
+  return TOKEN_ICONS[symbol.toUpperCase()];
+}
+
+/**
  * Get currency icon with fallback
- * Returns actual icon URL or generates a fallback SVG
+ * Returns actual icon URL, or a symbol-based path, or a generated letter SVG.
  *
  * @param icon - Icon URL (may be undefined)
- * @param symbol - Token symbol for fallback
+ * @param symbol - Token symbol used for symbol-based and letter fallbacks
  * @returns Icon URL or fallback data URI
  */
 export function getCurrencyIconWithFallback(
   icon: string | undefined,
   symbol: string,
 ): string {
-  return icon || generateTokenIconFallback(symbol);
+  return icon || getIconForSymbol(symbol) || generateTokenIconFallback(symbol);
 }


### PR DESCRIPTION
getTokenByAddress falls through to a placeholder with icon: undefined when a token address is not in the hard-coded TOKEN_REGISTRY, which caused the Dashboard Borrowed row (and every other icon-rendering site for that token) to render the letter-SVG fallback — e.g. an orange "U" circle instead of the USDC logo on testnet deployments whose USDC address is not registered.

<img width="2532" height="1804" alt="image" src="https://github.com/user-attachments/assets/169e6fc0-5a37-4bd8-9e2f-45b6bf5a2683" />
<img width="2532" height="1804" alt="image" src="https://github.com/user-attachments/assets/28e9a748-5939-40de-8115-5738a3f5289a" />
