### PR TITLE
fix(vault): show VP icon and address tooltip on provider labels

### DIFF
--- a/services/vault/src/clients/logo/__tests__/logoClient.test.ts
+++ b/services/vault/src/clients/logo/__tests__/logoClient.test.ts
@@ -42,13 +42,13 @@ describe("logoClient", () => {
 
     it("fetches logos from sidecar API with POST request", async () => {
       mockEnv.SIDECAR_API_URL = "https://sidecar-api.example.com";
-      const mockResponse = {
+      const images = {
         identity1: "https://s3-bucket/logo1.png",
         identity2: "https://s3-bucket/logo2.png",
       };
       mockFetch.mockResolvedValueOnce({
         ok: true,
-        json: () => Promise.resolve(mockResponse),
+        json: () => Promise.resolve({ data: { images } }),
       });
 
       const result = await fetchLogos(["identity1", "identity2"]);
@@ -63,7 +63,7 @@ describe("logoClient", () => {
           body: JSON.stringify({ identities: ["identity1", "identity2"] }),
         },
       );
-      expect(result).toEqual(mockResponse);
+      expect(result).toEqual(images);
     });
 
     it("returns empty object when API returns error", async () => {
@@ -92,12 +92,38 @@ describe("logoClient", () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: () =>
-          Promise.resolve({ identity1: "https://s3-bucket/logo1.png" }),
+          Promise.resolve({
+            data: { images: { identity1: "https://s3-bucket/logo1.png" } },
+          }),
       });
 
       const result = await fetchLogos(["identity1", "identity2"]);
 
       expect(result).toEqual({ identity1: "https://s3-bucket/logo1.png" });
+    });
+
+    it("returns empty object when sidecar returns an empty images map", async () => {
+      mockEnv.SIDECAR_API_URL = "https://sidecar-api.example.com";
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: { images: {} } }),
+      });
+
+      const result = await fetchLogos(["identity1"]);
+
+      expect(result).toEqual({});
+    });
+
+    it("returns empty object when envelope is malformed", async () => {
+      mockEnv.SIDECAR_API_URL = "https://sidecar-api.example.com";
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ unexpected: "shape" }),
+      });
+
+      const result = await fetchLogos(["identity1"]);
+
+      expect(result).toEqual({});
     });
   });
 });

--- a/services/vault/src/clients/logo/logoClient.ts
+++ b/services/vault/src/clients/logo/logoClient.ts
@@ -4,6 +4,12 @@ export interface LogoResponse {
   [identity: string]: string;
 }
 
+interface SidecarLogoEnvelope {
+  data?: {
+    images?: LogoResponse;
+  };
+}
+
 export async function fetchLogos(identities: string[]): Promise<LogoResponse> {
   if (!ENV.SIDECAR_API_URL || identities.length === 0) {
     return {};
@@ -22,8 +28,8 @@ export async function fetchLogos(identities: string[]): Promise<LogoResponse> {
       return {};
     }
 
-    const data: LogoResponse = await response.json();
-    return data;
+    const body: SidecarLogoEnvelope = await response.json();
+    return body.data?.images ?? {};
   } catch {
     return {};
   }

--- a/services/vault/src/components/simple/CollateralExpandedContent.tsx
+++ b/services/vault/src/components/simple/CollateralExpandedContent.tsx
@@ -54,6 +54,7 @@ export function CollateralExpandedContent({
               inUse={vault.inUse}
               providerName={vault.providerName}
               providerIconUrl={vault.providerIconUrl}
+              providerAddress={vault.providerAddress}
               liquidationIndex={vault.liquidationIndex}
               selected={isSelected}
               selectable={vault.inUse && isEligible}

--- a/services/vault/src/components/simple/CollateralVaultItem.tsx
+++ b/services/vault/src/components/simple/CollateralVaultItem.tsx
@@ -3,7 +3,13 @@
  * Renders a single vault card within the expanded collateral view.
  */
 
-import { Avatar, Button, Checkbox, StatusBadge } from "@babylonlabs-io/core-ui";
+import {
+  Avatar,
+  Button,
+  Checkbox,
+  Hint,
+  StatusBadge,
+} from "@babylonlabs-io/core-ui";
 
 import { getNetworkConfigBTC } from "@/config";
 import { formatBtcAmount, formatOrdinal } from "@/utils/formatting";
@@ -16,6 +22,8 @@ interface CollateralVaultItemProps {
   inUse: boolean;
   providerName: string;
   providerIconUrl?: string;
+  /** Vault provider Ethereum address, shown on hover over the provider label */
+  providerAddress: string;
   liquidationIndex?: number;
   selected: boolean;
   selectable: boolean;
@@ -29,6 +37,7 @@ export function CollateralVaultItem({
   inUse,
   providerName,
   providerIconUrl,
+  providerAddress,
   liquidationIndex,
   selected,
   selectable,
@@ -77,12 +86,19 @@ export function CollateralVaultItem({
       {/* Vault Provider row */}
       <div className="flex items-center justify-between">
         <span className="text-sm text-accent-secondary">Vault Provider</span>
-        <div className="flex items-center gap-1.5">
-          {providerIconUrl && (
-            <Avatar url={providerIconUrl} alt={providerName} size="tiny" />
-          )}
-          <span className="text-sm text-accent-primary">{providerName}</span>
-        </div>
+        <Hint
+          tooltip={providerAddress}
+          attachToChildren
+          placement="left"
+          className="text-sm text-accent-primary"
+        >
+          <span className="inline-flex items-center gap-1.5">
+            {providerIconUrl && (
+              <Avatar url={providerIconUrl} alt={providerName} size="tiny" />
+            )}
+            {providerName}
+          </span>
+        </Hint>
       </div>
 
       {/* Liquidation Order row */}

--- a/services/vault/src/components/simple/CollateralVaultItem.tsx
+++ b/services/vault/src/components/simple/CollateralVaultItem.tsx
@@ -89,7 +89,7 @@ export function CollateralVaultItem({
         <Hint
           tooltip={providerAddress}
           attachToChildren
-          placement="left"
+          placement="top"
           className="text-sm text-accent-primary"
         >
           <span className="inline-flex items-center gap-1.5">

--- a/services/vault/src/components/simple/CollateralVaultItem.tsx
+++ b/services/vault/src/components/simple/CollateralVaultItem.tsx
@@ -12,6 +12,7 @@ import {
 } from "@babylonlabs-io/core-ui";
 
 import { getNetworkConfigBTC } from "@/config";
+import { truncateAddress } from "@/utils/addressUtils";
 import { formatBtcAmount, formatOrdinal } from "@/utils/formatting";
 
 const btcConfig = getNetworkConfigBTC();
@@ -87,9 +88,9 @@ export function CollateralVaultItem({
       <div className="flex items-center justify-between">
         <span className="text-sm text-accent-secondary">Vault Provider</span>
         <Hint
-          tooltip={providerAddress}
+          tooltip={truncateAddress(providerAddress)}
           attachToChildren
-          placement="top"
+          placement="left"
           className="text-sm text-accent-primary"
         >
           <span className="inline-flex items-center gap-1.5">

--- a/services/vault/src/components/simple/PendingDepositCard.tsx
+++ b/services/vault/src/components/simple/PendingDepositCard.tsx
@@ -99,6 +99,7 @@ export function PendingDepositCard({
       txHash={txHash}
       providerName={providerName}
       providerIconUrl={provider?.iconUrl}
+      providerAddress={providerId}
       statusContent={
         <VaultStatusBadge
           dotColor={dotColor}

--- a/services/vault/src/components/simple/PendingWithdrawSection.tsx
+++ b/services/vault/src/components/simple/PendingWithdrawSection.tsx
@@ -87,6 +87,7 @@ export function PendingWithdrawSection({
                   txHash={vault.peginTxHash}
                   providerName={vault.providerName}
                   providerIconUrl={vault.providerIconUrl}
+                  providerAddress={vault.vaultProviderAddress}
                   statusContent={
                     <VaultStatusBadge
                       dotColor={STATUS_DOT_COLORS[variant]}

--- a/services/vault/src/components/simple/VaultDetailCard.tsx
+++ b/services/vault/src/components/simple/VaultDetailCard.tsx
@@ -35,6 +35,8 @@ interface VaultDetailCardProps {
   providerName: string;
   /** Vault provider icon URL */
   providerIconUrl?: string;
+  /** Vault provider Ethereum address, shown on hover over the provider label */
+  providerAddress: string;
   /** Status content — rendered as the value in the Status row */
   statusContent: ReactNode;
   /** Optional action button rendered at the bottom */
@@ -47,6 +49,7 @@ export function VaultDetailCard({
   txHash,
   providerName,
   providerIconUrl,
+  providerAddress,
   statusContent,
   action,
 }: VaultDetailCardProps) {
@@ -79,17 +82,24 @@ export function VaultDetailCard({
       {/* Vault Provider */}
       <div className="flex items-center justify-between">
         <span className="text-sm text-accent-secondary">Vault Provider</span>
-        <span className="flex items-center gap-1.5 text-sm text-accent-primary">
-          {providerIconUrl && (
-            <Avatar
-              url={providerIconUrl}
-              alt={providerName}
-              size="small"
-              className="h-4 w-4"
-            />
-          )}
-          {providerName}
-        </span>
+        <Hint
+          tooltip={providerAddress}
+          attachToChildren
+          placement="left"
+          className="text-sm text-accent-primary"
+        >
+          <span className="inline-flex items-center gap-1.5">
+            {providerIconUrl && (
+              <Avatar
+                url={providerIconUrl}
+                alt={providerName}
+                size="small"
+                className="h-4 w-4"
+              />
+            )}
+            {providerName}
+          </span>
+        </Hint>
       </div>
 
       {/* Transaction Hash */}

--- a/services/vault/src/components/simple/VaultDetailCard.tsx
+++ b/services/vault/src/components/simple/VaultDetailCard.tsx
@@ -15,7 +15,7 @@ import {
 import type { ReactNode } from "react";
 
 import { getNetworkConfigBTC } from "@/config";
-import { truncateHash } from "@/utils/addressUtils";
+import { truncateAddress, truncateHash } from "@/utils/addressUtils";
 import { formatBtcAmount, formatDateTime } from "@/utils/formatting";
 
 const btcConfig = getNetworkConfigBTC();
@@ -83,9 +83,9 @@ export function VaultDetailCard({
       <div className="flex items-center justify-between">
         <span className="text-sm text-accent-secondary">Vault Provider</span>
         <Hint
-          tooltip={providerAddress}
+          tooltip={truncateAddress(providerAddress)}
           attachToChildren
-          placement="top"
+          placement="left"
           className="text-sm text-accent-primary"
         >
           <span className="inline-flex items-center gap-1.5">

--- a/services/vault/src/components/simple/VaultDetailCard.tsx
+++ b/services/vault/src/components/simple/VaultDetailCard.tsx
@@ -85,7 +85,7 @@ export function VaultDetailCard({
         <Hint
           tooltip={providerAddress}
           attachToChildren
-          placement="left"
+          placement="top"
           className="text-sm text-accent-primary"
         >
           <span className="inline-flex items-center gap-1.5">


### PR DESCRIPTION
Provider labels across the vault dApp now render the icon alongside the name and expose the full Ethereum address in a hover tooltip. Covers the pending deposit card, pending withdraw card, collateral vault item, and the withdraw vault selector

<img width="1230" height="502" alt="Screenshot 2026-04-23 at 22 24 35" src="https://github.com/user-attachments/assets/19818e59-4318-4f55-8399-ed40754488e8" />
