### PR TITLE
feat(packages): correct Aave ray-scaled debt decimals from 35 to 53

### DIFF
--- a/packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/spoke.ts
+++ b/packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/spoke.ts
@@ -88,7 +88,7 @@ function mapPositionResult(result: PositionResult): AaveSpokeUserPosition {
  * **Return values:**
  * - `healthFactor` - WAD format (1e18 = 1.0). Below 1.0 = liquidatable
  * - `totalCollateralValue` - USD value in base currency (1e26 = $1)
- * - `totalDebtValueRay` - USD value in RAY-scaled base currency (1e35 = $1)
+ * - `totalDebtValueRay` - USD value in RAY-scaled base currency (1e53 = $1)
  * - `avgCollateralFactor` - Weighted average collateral factor in WAD (1e18 = 100%)
  * - `riskPremium` - Additional risk premium
  *

--- a/packages/babylon-ts-sdk/src/tbv/integrations/aave/constants.ts
+++ b/packages/babylon-ts-sdk/src/tbv/integrations/aave/constants.ts
@@ -63,11 +63,12 @@ export const AAVE_BASE_CURRENCY_DECIMALS = 26;
 
 /**
  * Aave RAY-scaled base currency decimals
- * Debt values (totalDebtValueRay) use 1e35 = $1 USD
+ * Debt values (totalDebtValueRay) use 1e53 = $1 USD
+ * (base currency 1e26 scaled by RAY 1e27).
  *
  * Reference: IAaveSpoke.sol UserAccountData.totalDebtValueRay
  */
-export const AAVE_BASE_CURRENCY_RAY_DECIMALS = 35;
+export const AAVE_BASE_CURRENCY_RAY_DECIMALS = 53;
 
 /**
  * WAD decimals (1e18 = 1.0)

--- a/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/__tests__/aaveConversions.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/__tests__/aaveConversions.test.ts
@@ -40,13 +40,13 @@ describe("aaveConversions", () => {
   });
 
   describe("aaveRayValueToUsd", () => {
-    it("should convert 1e35 to $1 USD", () => {
-      const value = 10n ** 35n;
+    it("should convert 1e53 to $1 USD", () => {
+      const value = 10n ** 53n;
       expect(aaveRayValueToUsd(value)).toBe(1);
     });
 
-    it("should convert 100e35 to $100 USD", () => {
-      const value = 100n * 10n ** 35n;
+    it("should convert 100e53 to $100 USD", () => {
+      const value = 100n * 10n ** 53n;
       expect(aaveRayValueToUsd(value)).toBeCloseTo(100);
     });
 
@@ -55,7 +55,7 @@ describe("aaveConversions", () => {
     });
 
     it("should handle fractional USD values", () => {
-      const value = 5n * 10n ** 34n;
+      const value = 5n * 10n ** 52n;
       expect(aaveRayValueToUsd(value)).toBe(0.5);
     });
   });

--- a/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/aaveConversions.ts
+++ b/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/aaveConversions.ts
@@ -25,9 +25,9 @@ export function aaveValueToUsd(value: bigint): number {
 /**
  * Convert Aave RAY-scaled base currency value to USD
  *
- * Debt values use higher precision: 1e35 = $1 USD.
+ * Debt values use higher precision: 1e53 = $1 USD.
  *
- * @param value - Value in RAY-scaled base currency (1e35 = $1)
+ * @param value - Value in RAY-scaled base currency (1e53 = $1)
  * @returns Value in USD
  */
 export function aaveRayValueToUsd(value: bigint): number {


### PR DESCRIPTION
<img width="1147" height="900" alt="Screenshot 2026-04-22 at 23 21 38" src="https://github.com/user-attachments/assets/53da467c-c7c0-4a68-8b05-c7df0376e650" />
