### PR TITLE
feat(wallet-connector, ts-sdk): add useTweakedSigner, deprecate disab…

### DIFF
--- a/packages/babylon-ts-sdk/docs/api/managers.md
+++ b/packages/babylon-ts-sdk/docs/api/managers.md
@@ -189,7 +189,7 @@ Error if any signing operation fails
 
 ### PeginManager
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:515](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L515)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:524](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L524)
 
 #### Constructors
 
@@ -199,7 +199,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:515](
 new PeginManager(config): PeginManager;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:523](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L523)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:532](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L532)
 
 Creates a new PeginManager instance.
 
@@ -223,7 +223,7 @@ Manager configuration including wallets and contract addresses
 preparePegin(params): Promise<PreparePeginResult>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:547](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L547)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:556](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L556)
 
 Prepares a peg-in by building the Pre-PegIn HTLC transaction,
 funding it, constructing the PegIn transaction, and signing the PegIn input.
@@ -264,7 +264,7 @@ Error if wallet operations fail or insufficient funds
 signAndBroadcast(params): Promise<string>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:732](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L732)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:744](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L744)
 
 Signs and broadcasts a funded peg-in transaction to the Bitcoin network.
 
@@ -300,7 +300,7 @@ Error if signing or broadcasting fails
 registerPeginOnChain(params): Promise<RegisterPeginResult>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:875](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L875)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:887](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L887)
 
 Registers a peg-in on Ethereum by calling the BTCVaultRegistry contract.
 
@@ -351,7 +351,7 @@ Error if contract simulation fails (e.g., invalid signature,
 registerPeginBatchOnChain(params): Promise<RegisterPeginBatchResult>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1036](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L1036)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1048](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L1048)
 
 Register multiple pegins on Ethereum in a single transaction.
 
@@ -379,7 +379,7 @@ Batch result with per-vault IDs and single ETH tx hash
 signProofOfPossession(): Promise<PopSignature>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1266](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L1266)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1278](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L1278)
 
 Sign a BIP-322 BTC Proof-of-Possession binding the connected BTC
 wallet to the connected ETH account for this chain and vault
@@ -396,7 +396,7 @@ every register call in the same session.
 getNetwork(): Network;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1311](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L1311)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1326](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L1326)
 
 Gets the configured Bitcoin network.
 
@@ -412,7 +412,7 @@ The Bitcoin network (mainnet, testnet, signet, regtest)
 getVaultContractAddress(): `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1320](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L1320)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1335](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L1335)
 
 Gets the configured BTCVaultRegistry contract address.
 
@@ -472,21 +472,43 @@ Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet
 
 Sighash types (optional)
 
-##### disableTweakSigner?
+##### useTweakedSigner?
+
+```ts
+optional useTweakedSigner: boolean;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts:34](../../packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts#L34)
+
+Whether the wallet should sign with the tweaked (key-path) signer.
+Set `false` for Taproot script-path spends, where signing uses the
+untweaked internal key. If omitted, the wallet's default behavior
+applies.
+
+##### ~~disableTweakSigner?~~
 
 ```ts
 optional disableTweakSigner: boolean;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts:29](../../packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts#L29)
+Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts:45](../../packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts#L45)
 
-Disable tweak signer for Taproot script path spend (optional)
+###### Deprecated
+
+Use `useTweakedSigner` instead. `disableTweakSigner: true`
+is equivalent to `useTweakedSigner: false`; `useTweakedSigner` takes
+precedence when both are set.
+
+`useTweakedSigner` is the canonical field used by UniSat and newer OKX
+wallet versions. Migrating aligns our interface with the wallet-side
+convention and avoids the historical divergence in OKX's
+`disableTweakSigner` implementation.
 
 ***
 
 ### SignPsbtOptions
 
-Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts:35](../../packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts#L35)
+Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts:51](../../packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts#L51)
 
 SignPsbt options for advanced signing scenarios.
 
@@ -498,7 +520,7 @@ SignPsbt options for advanced signing scenarios.
 optional autoFinalized: boolean;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts:37](../../packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts#L37)
+Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts:53](../../packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts#L53)
 
 Whether to automatically finalize the PSBT after signing
 
@@ -508,7 +530,7 @@ Whether to automatically finalize the PSBT after signing
 optional signInputs: SignInputOptions[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts:43](../../packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts#L43)
+Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts:59](../../packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts#L59)
 
 Specific inputs to sign.
 If not provided, wallet will attempt to sign all inputs it can.
@@ -520,7 +542,7 @@ Use this to restrict signing to specific inputs (e.g., only depositor's input).
 optional contracts: object[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts:45](../../packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts#L45)
+Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts:61](../../packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts#L61)
 
 Contract information for the signing operation.
 
@@ -546,7 +568,7 @@ Contract parameters.
 optional action: object;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts:52](../../packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts#L52)
+Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts:68](../../packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts#L68)
 
 Action metadata.
 
@@ -562,7 +584,7 @@ Action name for tracking.
 
 ### BitcoinWallet
 
-Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts:63](../../packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts#L63)
+Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts:79](../../packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts#L79)
 
 This interface is designed to be compatible with @babylonlabs-io/wallet-connector's IBTCProvider
 
@@ -576,7 +598,7 @@ Supports Unisat, Ledger, OKX, OneKey, Keystone, and other Bitcoin wallets.
 getPublicKeyHex(): Promise<string>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts:73](../../packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts#L73)
+Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts:89](../../packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts#L89)
 
 Returns the wallet's public key as a hex string.
 
@@ -596,7 +618,7 @@ consumers should strip the first byte to get x-only format.
 getAddress(): Promise<string>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts:78](../../packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts#L78)
+Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts:94](../../packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts#L94)
 
 Returns the wallet's Bitcoin address.
 
@@ -610,7 +632,7 @@ Returns the wallet's Bitcoin address.
 signPsbt(psbtHex, options?): Promise<string>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts:87](../../packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts#L87)
+Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts:103](../../packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts#L103)
 
 Signs a PSBT and returns the signed PSBT as hex.
 
@@ -642,7 +664,7 @@ If the PSBT is invalid or signing fails
 signPsbts(psbtsHexes, options?): Promise<string[]>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts:97](../../packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts#L97)
+Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts:113](../../packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts#L113)
 
 Signs multiple PSBTs and returns the signed PSBTs as hex.
 This allows batch signing with a single wallet interaction.
@@ -675,7 +697,7 @@ If any PSBT is invalid or signing fails
 signMessage(message, type): Promise<string>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts:109](../../packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts#L109)
+Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts:125](../../packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts#L125)
 
 Signs a message for authentication or proof of ownership.
 
@@ -705,7 +727,7 @@ Base64-encoded signature
 getNetwork(): Promise<BitcoinNetwork>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts:119](../../packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts#L119)
+Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts:135](../../packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts#L135)
 
 Returns the Bitcoin network the wallet is connected to.
 
@@ -935,7 +957,7 @@ Depositor's BTC public key used for signing.
 
 ### PeginManagerConfig
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:125](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L125)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:134](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L134)
 
 Configuration for the PeginManager.
 
@@ -947,7 +969,7 @@ Configuration for the PeginManager.
 btcNetwork: Network;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:129](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L129)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:138](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L138)
 
 Bitcoin network to use for transactions.
 
@@ -957,7 +979,7 @@ Bitcoin network to use for transactions.
 btcWallet: BitcoinWallet;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:134](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L134)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:143](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L143)
 
 Bitcoin wallet for signing peg-in transactions.
 
@@ -967,7 +989,7 @@ Bitcoin wallet for signing peg-in transactions.
 ethWallet: object;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:140](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L140)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:149](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L149)
 
 Ethereum wallet for registering peg-in on-chain.
 Uses viem's WalletClient directly for proper gas estimation.
@@ -978,7 +1000,7 @@ Uses viem's WalletClient directly for proper gas estimation.
 ethChain: Chain;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:146](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L146)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:155](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L155)
 
 Ethereum chain configuration.
 Required for proper gas estimation in contract calls.
@@ -989,7 +1011,7 @@ Required for proper gas estimation in contract calls.
 vaultContracts: object;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:151](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L151)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:160](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L160)
 
 Vault contract addresses.
 
@@ -1007,7 +1029,7 @@ BTCVaultRegistry contract address on Ethereum.
 mempoolApiUrl: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:163](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L163)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:172](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L172)
 
 Mempool API URL for fetching UTXO data and broadcasting transactions.
 Use MEMPOOL_API_URLS constant for standard mempool.space URLs, or provide
@@ -1017,7 +1039,7 @@ a custom URL if running your own mempool instance.
 
 ### PreparePeginParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:169](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L169)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:178](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L178)
 
 Parameters for the pegin flow (pre-pegin + pegin transactions).
 
@@ -1029,7 +1051,7 @@ Parameters for the pegin flow (pre-pegin + pegin transactions).
 amounts: readonly bigint[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:175](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L175)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:184](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L184)
 
 Amounts to peg in per HTLC (in satoshis).
 Must have the same length as `hashlocks`.
@@ -1041,7 +1063,7 @@ For single deposits, pass a single-element array.
 vaultProviderBtcPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:181](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L181)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:190](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L190)
 
 Vault provider's BTC public key (x-only, 64-char hex).
 Can be provided with or without "0x" prefix (will be stripped automatically).
@@ -1052,7 +1074,7 @@ Can be provided with or without "0x" prefix (will be stripped automatically).
 vaultKeeperBtcPubkeys: readonly string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:187](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L187)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:196](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L196)
 
 Vault keeper BTC public keys (x-only, 64-char hex).
 Can be provided with or without "0x" prefix (will be stripped automatically).
@@ -1063,7 +1085,7 @@ Can be provided with or without "0x" prefix (will be stripped automatically).
 universalChallengerBtcPubkeys: readonly string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:193](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L193)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:202](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L202)
 
 Universal challenger BTC public keys (x-only, 64-char hex).
 Can be provided with or without "0x" prefix (will be stripped automatically).
@@ -1074,7 +1096,7 @@ Can be provided with or without "0x" prefix (will be stripped automatically).
 timelockPegin: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:198](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L198)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:207](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L207)
 
 CSV timelock in blocks for the PegIn vault output.
 
@@ -1084,7 +1106,7 @@ CSV timelock in blocks for the PegIn vault output.
 timelockRefund: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:203](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L203)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:212](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L212)
 
 CSV timelock in blocks for the Pre-PegIn HTLC refund path.
 
@@ -1094,7 +1116,7 @@ CSV timelock in blocks for the Pre-PegIn HTLC refund path.
 hashlocks: readonly string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:210](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L210)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:219](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L219)
 
 SHA256 hash commitment(s) for the HTLC (64 hex chars = 32 bytes each).
 Generated by the depositor as H = SHA256(secret).
@@ -1106,7 +1128,7 @@ For single deposits, pass a single-element array.
 protocolFeeRate: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:216](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L216)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:225](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L225)
 
 Protocol fee rate in sat/vB from the contract offchain params.
 Used by WASM for computing depositorClaimValue and min pegin fee.
@@ -1117,7 +1139,7 @@ Used by WASM for computing depositorClaimValue and min pegin fee.
 mempoolFeeRate: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:222](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L222)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:231](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L231)
 
 Mempool fee rate in sat/vB for funding the Pre-PegIn transaction.
 Used for UTXO selection and change calculation.
@@ -1128,7 +1150,7 @@ Used for UTXO selection and change calculation.
 councilQuorum: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:227](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L227)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:236](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L236)
 
 M in M-of-N council multisig (from contract params).
 
@@ -1138,7 +1160,7 @@ M in M-of-N council multisig (from contract params).
 councilSize: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:232](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L232)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:241](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L241)
 
 N in M-of-N council multisig (from contract params).
 
@@ -1148,7 +1170,7 @@ N in M-of-N council multisig (from contract params).
 availableUTXOs: readonly UTXO[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:237](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L237)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:246](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L246)
 
 Available UTXOs from the depositor's wallet for funding the Pre-PegIn transaction.
 
@@ -1158,7 +1180,7 @@ Available UTXOs from the depositor's wallet for funding the Pre-PegIn transactio
 changeAddress: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:242](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L242)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:251](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L251)
 
 Bitcoin address for receiving change from the Pre-PegIn transaction.
 
@@ -1166,7 +1188,7 @@ Bitcoin address for receiving change from the Pre-PegIn transaction.
 
 ### PreparePeginResult
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:264](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L264)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:273](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L273)
 
 #### Properties
 
@@ -1176,7 +1198,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:264](
 fundedPrePeginTxHex: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:270](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L270)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:279](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L279)
 
 Funded, pre-witness Pre-PegIn tx hex. Pass this for register calls'
 `unsignedPrePeginTx` — despite the contract-side name, the registry
@@ -1188,7 +1210,7 @@ stores the funded form so indexers can rebuild refund PSBTs.
 prePeginTxid: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:272](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L272)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:281](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L281)
 
 Funded Pre-PegIn transaction ID
 
@@ -1198,7 +1220,7 @@ Funded Pre-PegIn transaction ID
 perVault: PerVaultPeginData[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:274](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L274)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:283](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L283)
 
 Per-vault PegIn data — one entry per hashlock/amount
 
@@ -1208,7 +1230,7 @@ Per-vault PegIn data — one entry per hashlock/amount
 selectedUTXOs: UTXO[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:276](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L276)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:285](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L285)
 
 UTXOs selected to fund the Pre-PegIn transaction
 
@@ -1218,7 +1240,7 @@ UTXOs selected to fund the Pre-PegIn transaction
 fee: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:278](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L278)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:287](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L287)
 
 Transaction fee in satoshis
 
@@ -1228,7 +1250,7 @@ Transaction fee in satoshis
 changeAmount: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:280](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L280)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:289](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L289)
 
 Change amount in satoshis (if any)
 
@@ -1236,7 +1258,7 @@ Change amount in satoshis (if any)
 
 ### SignAndBroadcastParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:287](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L287)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:296](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L296)
 
 Parameters for signing and broadcasting a transaction.
 
@@ -1248,7 +1270,7 @@ Parameters for signing and broadcasting a transaction.
 fundedPrePeginTxHex: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:291](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L291)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:300](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L300)
 
 Funded Pre-PegIn transaction hex from preparePegin().
 
@@ -1258,7 +1280,7 @@ Funded Pre-PegIn transaction hex from preparePegin().
 depositorBtcPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:298](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L298)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:307](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L307)
 
 Depositor's BTC public key (x-only, 64-char hex).
 Can be provided with or without "0x" prefix.
@@ -1273,7 +1295,7 @@ optional localPrevouts: Record<string, {
 }>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:306](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L306)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:315](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L315)
 
 Optional pre-fetched prevout data for inputs not yet in the mempool.
 Key format: "txid:vout" (e.g. "abc123...def:0").
@@ -1284,7 +1306,7 @@ Useful for split transactions where outputs are unconfirmed.
 
 ### PopSignature
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:315](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L315)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:324](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L324)
 
 BIP-322 BTC Proof-of-Possession binding a depositor's BTC key to their
 Ethereum account. Produced by [PeginManager.signProofOfPossession](#signproofofpossession)
@@ -1299,7 +1321,7 @@ embedded identities are re-checked at register time.
 btcPopSignature: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:317](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L317)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:326](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L326)
 
 BIP-322 signature over the PoP message (0x-prefixed hex).
 
@@ -1309,7 +1331,7 @@ BIP-322 signature over the PoP message (0x-prefixed hex).
 depositorEthAddress: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:319](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L319)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:328](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L328)
 
 Ethereum address the PoP was signed for.
 
@@ -1319,7 +1341,7 @@ Ethereum address the PoP was signed for.
 depositorBtcPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:321](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L321)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:330](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L330)
 
 BTC x-only public key (64-char hex, no 0x prefix).
 
@@ -1327,7 +1349,7 @@ BTC x-only public key (64-char hex, no 0x prefix).
 
 ### RegisterPeginParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:327](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L327)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:336](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L336)
 
 Parameters for registering a peg-in on Ethereum.
 
@@ -1339,7 +1361,7 @@ Parameters for registering a peg-in on Ethereum.
 unsignedPrePeginTx: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:333](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L333)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:342](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L342)
 
 Funded, pre-witness Pre-PegIn tx hex — pass
 [PreparePeginResult.fundedPrePeginTxHex](#fundedprepegintxhex). The contract-side
@@ -1351,7 +1373,7 @@ parameter is named `unsignedPrePeginTx` but it stores the funded form.
 depositorSignedPeginTx: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:338](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L338)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:347](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L347)
 
 Depositor-signed PegIn transaction hex (submitted to contract; vault ID derived from this).
 
@@ -1361,7 +1383,7 @@ Depositor-signed PegIn transaction hex (submitted to contract; vault ID derived 
 vaultProvider: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:343](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L343)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:352](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L352)
 
 Vault provider's Ethereum address.
 
@@ -1371,7 +1393,7 @@ Vault provider's Ethereum address.
 hashlock: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:348](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L348)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:357](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L357)
 
 SHA256 hashlock for HTLC activation (bytes32 hex with 0x prefix).
 
@@ -1381,7 +1403,7 @@ SHA256 hashlock for HTLC activation (bytes32 hex with 0x prefix).
 optional depositorPayoutBtcAddress: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:357](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L357)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:366](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L366)
 
 Depositor's BTC payout address (e.g. bc1p..., bc1q...).
 Converted to scriptPubKey internally via bitcoinjs-lib.
@@ -1395,7 +1417,7 @@ via `btcWallet.getAddress()`.
 depositorWotsPkHash: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:360](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L360)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:369](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L369)
 
 Keccak256 hash of the depositor's WOTS public key (bytes32)
 
@@ -1405,7 +1427,7 @@ Keccak256 hash of the depositor's WOTS public key (bytes32)
 popSignature: PopSignature;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:363](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L363)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:372](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L372)
 
 Proof of possession from [PeginManager.signProofOfPossession](#signproofofpossession).
 
@@ -1415,7 +1437,7 @@ Proof of possession from [PeginManager.signProofOfPossession](#signproofofposses
 htlcVout: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:370](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L370)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:379](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L379)
 
 Zero-based index of the HTLC output in the Pre-PegIn transaction that
 this PegIn spends. In a batch Pre-PegIn with N HTLC outputs, each vault
@@ -1425,7 +1447,7 @@ registration references a different htlcVout (0..N-1).
 
 ### RegisterPeginResult
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:376](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L376)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:385](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L385)
 
 Result of registering a peg-in on Ethereum.
 
@@ -1437,7 +1459,7 @@ Result of registering a peg-in on Ethereum.
 ethTxHash: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:380](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L380)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:389](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L389)
 
 Ethereum transaction hash for the peg-in registration.
 
@@ -1447,7 +1469,7 @@ Ethereum transaction hash for the peg-in registration.
 vaultId: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:386](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L386)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:395](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L395)
 
 Derived vault ID: keccak256(abi.encode(peginTxHash, depositor)).
 Used for contract reads/writes and indexer queries.
@@ -1458,7 +1480,7 @@ Used for contract reads/writes and indexer queries.
 peginTxHash: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:392](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L392)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:401](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L401)
 
 Raw Bitcoin pegin transaction hash (double-SHA256 of the signed pegin tx).
 Used for VP RPC operations which key on the BTC transaction ID.
@@ -1467,7 +1489,7 @@ Used for VP RPC operations which key on the BTC transaction ID.
 
 ### BatchPeginRequestItem
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:400](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L400)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:409](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L409)
 
 Single request in a batch pegin registration.
 All requests in a batch share the same vault provider, depositor BTC
@@ -1481,7 +1503,7 @@ pubkey, and Pre-PegIn transaction.
 depositorSignedPeginTx: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:402](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L402)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:411](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L411)
 
 Signed PegIn tx hex for this vault
 
@@ -1491,7 +1513,7 @@ Signed PegIn tx hex for this vault
 hashlock: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:404](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L404)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:413](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L413)
 
 SHA256 hashlock for HTLC activation (bytes32 hex)
 
@@ -1501,7 +1523,7 @@ SHA256 hashlock for HTLC activation (bytes32 hex)
 htlcVout: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:406](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L406)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:415](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L415)
 
 Zero-based HTLC output index in the Pre-PegIn tx (unique per request)
 
@@ -1511,7 +1533,7 @@ Zero-based HTLC output index in the Pre-PegIn tx (unique per request)
 depositorPayoutBtcAddress: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:408](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L408)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:417](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L417)
 
 Depositor's BTC payout address (required — funds are sent here on payout)
 
@@ -1521,7 +1543,7 @@ Depositor's BTC payout address (required — funds are sent here on payout)
 depositorWotsPkHash: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:410](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L410)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:419](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L419)
 
 Keccak256 hash of the depositor's WOTS public key (bytes32)
 
@@ -1529,7 +1551,7 @@ Keccak256 hash of the depositor's WOTS public key (bytes32)
 
 ### RegisterPeginBatchParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:416](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L416)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:425](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L425)
 
 Parameters for registerPeginBatchOnChain.
 
@@ -1541,7 +1563,7 @@ Parameters for registerPeginBatchOnChain.
 vaultProvider: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:418](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L418)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:427](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L427)
 
 Vault provider address (shared across all vaults in batch)
 
@@ -1551,7 +1573,7 @@ Vault provider address (shared across all vaults in batch)
 unsignedPrePeginTx: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:423](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L423)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:432](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L432)
 
 Funded, pre-witness Pre-PegIn tx hex — shared across every request in
 the batch. See [RegisterPeginParams.unsignedPrePeginTx](#unsignedprepegintx).
@@ -1562,7 +1584,7 @@ the batch. See [RegisterPeginParams.unsignedPrePeginTx](#unsignedprepegintx).
 requests: BatchPeginRequestItem[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:425](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L425)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:434](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L434)
 
 Individual pegin requests (one per vault)
 
@@ -1572,7 +1594,7 @@ Individual pegin requests (one per vault)
 popSignature: PopSignature;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:427](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L427)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:436](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L436)
 
 Proof of possession from [PeginManager.signProofOfPossession](#signproofofpossession).
 
@@ -1580,7 +1602,7 @@ Proof of possession from [PeginManager.signProofOfPossession](#signproofofposses
 
 ### BatchPeginResultItem
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:433](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L433)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:442](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L442)
 
 Per-vault result from a batch pegin registration.
 
@@ -1592,7 +1614,7 @@ Per-vault result from a batch pegin registration.
 vaultId: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:435](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L435)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:444](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L444)
 
 Derived vault ID: keccak256(abi.encode(peginTxHash, depositor))
 
@@ -1602,7 +1624,7 @@ Derived vault ID: keccak256(abi.encode(peginTxHash, depositor))
 peginTxHash: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:437](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L437)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:446](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L446)
 
 Raw BTC pegin transaction hash
 
@@ -1610,7 +1632,7 @@ Raw BTC pegin transaction hash
 
 ### RegisterPeginBatchResult
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:443](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L443)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:452](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L452)
 
 Result of registering a batch of pegins on Ethereum in a single transaction.
 
@@ -1622,7 +1644,7 @@ Result of registering a batch of pegins on Ethereum in a single transaction.
 ethTxHash: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:445](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L445)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:454](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L454)
 
 Ethereum transaction hash
 
@@ -1632,7 +1654,7 @@ Ethereum transaction hash
 vaults: BatchPeginResultItem[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:447](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L447)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:456](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L456)
 
 Per-vault results (same order as input requests)
 

--- a/packages/babylon-ts-sdk/docs/api/services.md
+++ b/packages/babylon-ts-sdk/docs/api/services.md
@@ -1093,7 +1093,7 @@ AbortSignal for cancellation
 
 ### VaultRefundData
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:68](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L68)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:71](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L71)
 
 Authoritative vault fields needed to build a refund. Versioning fields,
 the hashlock, and htlcVout must come from the on-chain contract (never the
@@ -1109,7 +1109,7 @@ come from the indexer since they are not security-critical for signing
 hashlock: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:69](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L69)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:72](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L72)
 
 ##### htlcVout
 
@@ -1117,7 +1117,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 htlcVout: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:70](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L70)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:73](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L73)
 
 ##### offchainParamsVersion
 
@@ -1125,7 +1125,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 offchainParamsVersion: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:71](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L71)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:74](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L74)
 
 ##### appVaultKeepersVersion
 
@@ -1133,7 +1133,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 appVaultKeepersVersion: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:72](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L72)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:75](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L75)
 
 ##### universalChallengersVersion
 
@@ -1141,7 +1141,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 universalChallengersVersion: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:73](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L73)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:76](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L76)
 
 ##### vaultProvider
 
@@ -1149,7 +1149,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 vaultProvider: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:74](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L74)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:77](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L77)
 
 ##### applicationEntryPoint
 
@@ -1157,7 +1157,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 applicationEntryPoint: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:75](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L75)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:78](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L78)
 
 ##### amount
 
@@ -1165,7 +1165,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 amount: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:77](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L77)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:80](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L80)
 
 Pre-PegIn HTLC output value in satoshis.
 
@@ -1175,7 +1175,7 @@ Pre-PegIn HTLC output value in satoshis.
 unsignedPrePeginTxHex: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:83](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L83)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:86](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L86)
 
 Funded, pre-witness Pre-PegIn transaction hex. 0x prefix optional.
 The name mirrors the contract/indexer schema; the bytes are the
@@ -1187,7 +1187,7 @@ funded form (refund construction needs real outpoints).
 depositorBtcPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:85](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L85)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:88](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L88)
 
 Depositor's BTC public key (x-only or compressed hex; 0x prefix optional).
 
@@ -1195,7 +1195,7 @@ Depositor's BTC public key (x-only or compressed hex; 0x prefix optional).
 
 ### RefundPrePeginContext
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:100](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L100)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:103](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L103)
 
 Version-resolved protocol context that parameterises the HTLC's taproot
 scripts. The *signer-set* fields (`vaultKeeperPubkeys`,
@@ -1216,7 +1216,7 @@ script derivation).
 vaultProviderPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:101](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L101)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:104](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L104)
 
 ##### vaultKeeperPubkeys
 
@@ -1224,7 +1224,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 vaultKeeperPubkeys: readonly string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:102](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L102)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:105](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L105)
 
 ##### universalChallengerPubkeys
 
@@ -1232,7 +1232,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 universalChallengerPubkeys: readonly string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:103](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L103)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:106](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L106)
 
 ##### timelockRefund
 
@@ -1240,7 +1240,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 timelockRefund: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:104](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L104)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:107](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L107)
 
 ##### feeRate
 
@@ -1248,7 +1248,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 feeRate: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:105](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L105)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:108](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L108)
 
 ##### numLocalChallengers
 
@@ -1256,7 +1256,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 numLocalChallengers: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:106](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L106)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:109](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L109)
 
 ##### councilQuorum
 
@@ -1264,7 +1264,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 councilQuorum: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:107](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L107)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:110](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L110)
 
 ##### councilSize
 
@@ -1272,7 +1272,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 councilSize: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:108](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L108)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:111](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L111)
 
 ##### network
 
@@ -1280,13 +1280,13 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 network: Network;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:109](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L109)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:112](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L112)
 
 ***
 
 ### BtcBroadcastResult
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:113](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L113)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:116](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L116)
 
 Minimum shape required from a broadcast result.
 
@@ -1298,13 +1298,13 @@ Minimum shape required from a broadcast result.
 txId: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:114](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L114)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:117](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L117)
 
 ***
 
 ### RefundInput
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:126](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L126)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:129](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L129)
 
 #### Type Parameters
 
@@ -1320,7 +1320,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 vaultId: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:129](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L129)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:132](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L132)
 
 ##### readVault()
 
@@ -1328,7 +1328,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 readVault: () => Promise<VaultRefundData>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:135](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L135)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:138](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L138)
 
 Fetch authoritative on-chain + indexer vault data. The SDK passes no
 arguments — the caller closes over `vaultId` (or any other context it
@@ -1344,7 +1344,7 @@ needs).
 readPrePeginContext: (vault) => Promise<RefundPrePeginContext>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:140](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L140)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:143](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L143)
 
 Fetch the version-pinned refund context (sorted pubkeys, timelock, etc.)
 derived from the vault's locked versions.
@@ -1365,7 +1365,7 @@ derived from the vault's locked versions.
 feeRate: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:149](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L149)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:152](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L152)
 
 Mempool-derived sat/vB fee rate to use for the refund tx (positive
 number). Caller fetches this before invoking — it does not depend on
@@ -1378,7 +1378,7 @@ orchestration honest.
 signPsbt: RefundPsbtSigner;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:151](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L151)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:154](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L154)
 
 BTC wallet signer; receives a PSBT hex + taproot script-path options.
 
@@ -1388,7 +1388,7 @@ BTC wallet signer; receives a PSBT hex + taproot script-path options.
 broadcastTx: BtcBroadcaster<R>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:153](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L153)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:156](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L156)
 
 Broadcast callback — returns whatever shape the caller needs.
 
@@ -1398,7 +1398,7 @@ Broadcast callback — returns whatever shape the caller needs.
 optional signal: AbortSignal;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:155](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L155)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:158](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L158)
 
 Checked at every async boundary.
 
@@ -1452,7 +1452,7 @@ Reason why a vault expired
 type BtcBroadcaster<R> = (signedTxHex) => Promise<R>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:117](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L117)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:120](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L120)
 
 #### Type Parameters
 
@@ -1478,7 +1478,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 type RefundPsbtSigner = (psbtHex, opts) => Promise<string>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:121](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L121)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:124](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L124)
 
 #### Parameters
 
@@ -2047,7 +2047,7 @@ thresholds) are a consumer-side concern.
 function buildAndBroadcastRefund<R>(input): Promise<R>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:277](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L277)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:280](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L280)
 
 Build, sign, and broadcast a refund transaction for an expired vault.
 

--- a/packages/babylon-ts-sdk/docs/api/utils.md
+++ b/packages/babylon-ts-sdk/docs/api/utils.md
@@ -741,7 +741,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/signing.ts:15](../../pac
 Create SignPsbtOptions for Taproot script-path PSBT signing.
 
 All vault protocol signing operations are Taproot script-path spends that
-require `disableTweakSigner: true` (untweaked key) and `autoFinalized: false`
+require `useTweakedSigner: false` (untweaked key) and `autoFinalized: false`
 (to preserve tapScriptSig for Schnorr signature extraction).
 
 #### Parameters

--- a/packages/babylon-ts-sdk/docs/guides/wallet-interfaces.md
+++ b/packages/babylon-ts-sdk/docs/guides/wallet-interfaces.md
@@ -73,7 +73,7 @@ const ethWallet = createWalletClient({
 
 ## Node.js wallet from a seed
 
-Honour `SignPsbtOptions.signInputs[]` — the SDK uses per-input options so the same wallet works for key-path inputs (tweaked) and script-path inputs like the refund leaf or the PegIn HTLC input (untweaked, `disableTweakSigner: true`).
+Honour `SignPsbtOptions.signInputs[]` — the SDK uses per-input options so the same wallet works for key-path inputs (tweaked) and script-path inputs like the refund leaf or the PegIn HTLC input (untweaked, `useTweakedSigner: false`).
 
 ```typescript
 import * as bitcoin from "bitcoinjs-lib";
@@ -109,8 +109,8 @@ const signPsbtImpl = async (
 
   const signOne = (input: SignInputOptions) => {
     // Script-path spends (refund leaf 1, PegIn HTLC leaf 0) pass
-    // `disableTweakSigner: true` — use the raw BIP-32 node.
-    const signer = input.disableTweakSigner ? node : tweakedKey;
+    // `useTweakedSigner: false` — use the raw BIP-32 node.
+    const signer = input.useTweakedSigner === false ? node : tweakedKey;
     psbt.signInput(input.index, signer, input.sighashTypes);
   };
 

--- a/packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts
+++ b/packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts
@@ -25,7 +25,23 @@ export interface SignInputOptions {
   publicKey?: string;
   /** Sighash types (optional) */
   sighashTypes?: number[];
-  /** Disable tweak signer for Taproot script path spend (optional) */
+  /**
+   * Whether the wallet should sign with the tweaked (key-path) signer.
+   * Set `false` for Taproot script-path spends, where signing uses the
+   * untweaked internal key. If omitted, the wallet's default behavior
+   * applies.
+   */
+  useTweakedSigner?: boolean;
+  /**
+   * @deprecated Use `useTweakedSigner` instead. `disableTweakSigner: true`
+   * is equivalent to `useTweakedSigner: false`; `useTweakedSigner` takes
+   * precedence when both are set.
+   *
+   * `useTweakedSigner` is the canonical field used by UniSat and newer OKX
+   * wallet versions. Migrating aligns our interface with the wallet-side
+   * convention and avoids the historical divergence in OKX's
+   * `disableTweakSigner` implementation.
+   */
   disableTweakSigner?: boolean;
 }
 

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/signDepositorGraph.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/signDepositorGraph.test.ts
@@ -60,7 +60,7 @@ vi.mock("../../../utils/signing", () => ({
     signInputs: Array.from({ length: inputCount }, (_, i) => ({
       index: i,
       publicKey: pubkey,
-      disableTweakSigner: true,
+      useTweakedSigner: false,
     })),
   }),
 }));

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts
@@ -75,9 +75,10 @@ function verifyAndParsePsbt(
  * Sanitize a parsed PSBT for Taproot script-path signing.
  *
  * VP-provided PSBTs include tapBip32Derivation and tapMerkleRoot metadata
- * that causes some wallets (notably OKX) to ignore disableTweakSigner and
- * sign with a tweaked key. Stripping these fields forces the wallet to
- * rely solely on tapLeafScript for script-path signing.
+ * that causes some wallets (notably OKX) to ignore the tweak-signer
+ * directive (`useTweakedSigner` / legacy `disableTweakSigner`) and sign
+ * with a tweaked key. Stripping these fields forces the wallet to rely
+ * solely on tapLeafScript for script-path signing.
  */
 function sanitizePsbtForScriptPathSigning(psbt: Psbt): Psbt {
   const clone = Psbt.fromHex(psbt.toHex());
@@ -120,11 +121,6 @@ function collectDepositorGraphPsbts(
   const signOptions: SignPsbtOptions[] = [];
   const challengerEntries: ChallengerEntry[] = [];
 
-  const singleInputOpts = createTaprootScriptPathSignOptions(
-    walletPublicKey,
-    SINGLE_PSBT_INPUT_COUNT,
-  );
-
   // Index 0: Payout PSBT
   const payoutHex = validateAndConvertPsbt(
     depositorGraph.payout_psbt,
@@ -132,7 +128,9 @@ function collectDepositorGraphPsbts(
     "depositor payout",
   );
   psbtHexes.push(payoutHex);
-  signOptions.push(singleInputOpts);
+  signOptions.push(
+    createTaprootScriptPathSignOptions(walletPublicKey, SINGLE_PSBT_INPUT_COUNT),
+  );
 
   // Per-challenger: 1 NoPayout
   for (const challenger of depositorGraph.challenger_presign_data) {
@@ -145,7 +143,9 @@ function collectDepositorGraphPsbts(
       `nopayout (challenger ${challengerPubkey})`,
     );
     psbtHexes.push(noPayoutHex);
-    signOptions.push(singleInputOpts);
+    signOptions.push(
+      createTaprootScriptPathSignOptions(walletPublicKey, SINGLE_PSBT_INPUT_COUNT),
+    );
 
     challengerEntries.push({
       challengerPubkey,

--- a/packages/babylon-ts-sdk/src/tbv/core/utils/__tests__/signing.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/utils/__tests__/signing.test.ts
@@ -11,8 +11,16 @@ describe("createTaprootScriptPathSignOptions", () => {
 
     expect(opts.autoFinalized).toBe(false);
     expect(opts.signInputs).toEqual([
-      { index: 0, publicKey: TEST_PUBKEY, disableTweakSigner: true },
+      { index: 0, publicKey: TEST_PUBKEY, useTweakedSigner: false },
     ]);
+  });
+
+  it("does not emit the deprecated disableTweakSigner field", () => {
+    const opts = createTaprootScriptPathSignOptions(TEST_PUBKEY, 2);
+
+    opts.signInputs!.forEach((s) => {
+      expect(s).not.toHaveProperty("disableTweakSigner");
+    });
   });
 
   it("produces entries at indices 0, 1, 2 for inputCount = 3", () => {
@@ -22,7 +30,7 @@ describe("createTaprootScriptPathSignOptions", () => {
     expect(opts.signInputs!.map((s) => s.index)).toEqual([0, 1, 2]);
     opts.signInputs!.forEach((s) => {
       expect(s.publicKey).toBe(TEST_PUBKEY);
-      expect(s.disableTweakSigner).toBe(true);
+      expect(s.useTweakedSigner).toBe(false);
     });
   });
 

--- a/packages/babylon-ts-sdk/src/tbv/core/utils/signing.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/utils/signing.ts
@@ -4,7 +4,7 @@ import type { SignPsbtOptions } from "../../../shared/wallets/interfaces";
  * Create SignPsbtOptions for Taproot script-path PSBT signing.
  *
  * All vault protocol signing operations are Taproot script-path spends that
- * require `disableTweakSigner: true` (untweaked key) and `autoFinalized: false`
+ * require `useTweakedSigner: false` (untweaked key) and `autoFinalized: false`
  * (to preserve tapScriptSig for Schnorr signature extraction).
  *
  * @param publicKey - Signer's BTC public key (hex). Accepts both compressed
@@ -25,7 +25,7 @@ export function createTaprootScriptPathSignOptions(
     signInputs: Array.from({ length: inputCount }, (_, i) => ({
       index: i,
       publicKey,
-      disableTweakSigner: true,
+      useTweakedSigner: false,
     })),
   };
 }

--- a/packages/babylon-wallet-connector/README.md
+++ b/packages/babylon-wallet-connector/README.md
@@ -302,10 +302,12 @@ export interface SignInputOptions {
   /** Sighash types (optional) */
   sighashTypes?: number[];
   /**
-   * Disable tweak signer for Taproot script path spend.
-   * When true, sign with the untweaked internal key.
+   * Whether the wallet should sign with the tweaked (key-path) signer.
+   * Set `false` for Taproot script-path spends, where signing uses
+   * the untweaked internal key. If omitted, the wallet applies its
+   * default behavior.
    */
-  disableTweakSigner?: boolean;
+  useTweakedSigner?: boolean;
 }
 
 export interface SignPsbtOptions {

--- a/packages/babylon-wallet-connector/docs/vault-integration-guide.md
+++ b/packages/babylon-wallet-connector/docs/vault-integration-guide.md
@@ -28,7 +28,7 @@ Babylon BTC staking, here's what's new for TBV:
   PSBTs per deposit + payout pre-signing. Without batch
   signing, each PSBT requires a separate user approval.
 - **`SignPsbtOptions` expanded** — New field `signInputs`
-  with `disableTweakSigner` (required for Taproot script
+  with `useTweakedSigner` (set `false` for Taproot script
   path spends).
 - **`deriveContextHash()` required** — TBV derives
   hashlock secrets from wallet key material. See
@@ -46,7 +46,7 @@ Babylon BTC staking, here's what's new for TBV:
 | ETH wallet | **Required** — viem `WalletClient` | N/A |
 | Batch signing | Critical — multiple PSBTs | Delegation |
 | Message signing | `"bip322-simple"` for PoP | Same |
-| Taproot path | `disableTweakSigner: true` | Same |
+| Taproot path | `useTweakedSigner: false` | Same |
 | Hashlock | `deriveContextHash` — new | N/A |
 | Chains | **Dual**: BTC + ETH | BTC + Cosmos |
 
@@ -61,7 +61,7 @@ are in [`src/core/types.ts`](../src/core/types.ts).
 | `connectWallet` | `() => Promise<void>` | Connect to the wallet |
 | `getAddress` | `() => Promise<string>` | Get BTC address |
 | `getPublicKeyHex` | `() => Promise<string>` | Get public key hex. Taproot: x-only (32 bytes, 64 hex, no `0x`). Compressed (33 bytes) also accepted — SDK strips first byte. |
-| `signPsbt` | `(psbtHex: string, options?: SignPsbtOptions) => Promise<string>` | Sign a single PSBT. Must support `disableTweakSigner`. See [SignPsbtOptions](#signpsbtoptions). |
+| `signPsbt` | `(psbtHex: string, options?: SignPsbtOptions) => Promise<string>` | Sign a single PSBT. Must support `useTweakedSigner`. See [SignPsbtOptions](#signpsbtoptions). |
 | `signPsbts` | `(psbtsHexes: string[], options?: SignPsbtOptions[]) => Promise<string[]>` | Batch sign PSBTs in one prompt. Falls back to sequential `signPsbt()` if unavailable. |
 | `signMessage` | `(message: string, type: "bip322-simple" \| "ecdsa") => Promise<string>` | Sign a message. TBV uses `"bip322-simple"` for PoP. |
 | `deriveContextHash` | `(appName: string, context: string) => Promise<string>` | Derive 32-byte value via HKDF-SHA-256. See [deriveContextHash](#derivecontexthash) and [spec][spec]. |
@@ -85,13 +85,13 @@ interface SignInputOptions {
   address?: string;
   publicKey?: string;
   sighashTypes?: number[];
-  disableTweakSigner?: boolean;
+  useTweakedSigner?: boolean;
 }
 ```
 
-**`disableTweakSigner`**: TBV vault transactions use
+**`useTweakedSigner`**: TBV vault transactions use
 Taproot **script path** spends. When
-`disableTweakSigner: true`, the wallet must sign with the
+`useTweakedSigner: false`, the wallet must sign with the
 **untweaked** private key (raw internal key). Signing with
 the tweaked key produces an invalid signature.
 
@@ -168,7 +168,7 @@ subsequent vaults.
 The SDK constructs one PegIn input PSBT per vault in the
 deposit. All PSBTs are presented for batch signing. These
 are Taproot script path spends — `signInputs` will
-include `disableTweakSigner: true`. Falls back to
+include `useTweakedSigner: false`. Falls back to
 sequential `signPsbt()` if the wallet does not support
 batch signing.
 

--- a/packages/babylon-wallet-connector/src/core/types.ts
+++ b/packages/babylon-wallet-connector/src/core/types.ts
@@ -303,7 +303,23 @@ export interface SignInputOptions {
   publicKey?: string;
   /** Sighash types (optional) */
   sighashTypes?: number[];
-  /** Disable tweak signer for Taproot script path spend (optional) */
+  /**
+   * Whether the wallet should sign with the tweaked (key-path) signer.
+   * Set `false` for Taproot script-path spends, where signing uses the
+   * untweaked internal key. If omitted, the wallet's default behavior
+   * applies.
+   */
+  useTweakedSigner?: boolean;
+  /**
+   * @deprecated Use `useTweakedSigner` instead. `disableTweakSigner: true`
+   * is equivalent to `useTweakedSigner: false`; `useTweakedSigner` takes
+   * precedence when both are set.
+   *
+   * `useTweakedSigner` is the canonical field used by UniSat and newer OKX
+   * wallet versions. Migrating aligns our interface with the wallet-side
+   * convention and avoids the historical divergence in OKX's
+   * `disableTweakSigner` implementation.
+   */
   disableTweakSigner?: boolean;
 }
 

--- a/packages/babylon-wallet-connector/src/core/utils/psbtOptionsMapper.ts
+++ b/packages/babylon-wallet-connector/src/core/utils/psbtOptionsMapper.ts
@@ -1,18 +1,49 @@
 import type { SignInputOptions } from "@/core/types";
 
 /**
+ * Resolve the tweak-signer flag from SignInputOptions.
+ *
+ * Precedence: `useTweakedSigner` wins when both fields are set. Matches the
+ * resolution order used by upstream wallet implementations (e.g. UniSat's
+ * keyring). Returns `undefined` when neither field is provided so the wallet
+ * can apply its default.
+ */
+export function resolveUseTweakedSigner(input: {
+  useTweakedSigner?: boolean;
+  disableTweakSigner?: boolean;
+}): boolean | undefined {
+  if (typeof input.useTweakedSigner === "boolean") {
+    return input.useTweakedSigner;
+  }
+  if (typeof input.disableTweakSigner === "boolean") {
+    return !input.disableTweakSigner;
+  }
+  return undefined;
+}
+
+/**
  * Maps our standard SignInputOptions format to the wallet provider's toSignInputs format.
  * This is used by wallets that follow the OKX/OneKey API convention.
+ *
+ * Forwards both `useTweakedSigner` and `disableTweakSigner` in sync so older
+ * wallet versions that only understand `disableTweakSigner` and newer versions
+ * that understand `useTweakedSigner` both receive a consistent instruction.
  *
  * @param signInputs - Array of sign input configurations
  * @returns Array of inputs in toSignInputs format
  */
 export function mapSignInputsToToSignInputs(signInputs: SignInputOptions[]) {
-  return signInputs.map((input) => ({
-    index: input.index,
-    publicKey: input.publicKey,
-    address: input.address,
-    sighashTypes: input.sighashTypes,
-    disableTweakSigner: input.disableTweakSigner,
-  }));
+  return signInputs.map((input) => {
+    const useTweakedSigner = resolveUseTweakedSigner(input);
+    return {
+      index: input.index,
+      publicKey: input.publicKey,
+      address: input.address,
+      sighashTypes: input.sighashTypes,
+      ...(useTweakedSigner !== undefined && {
+        useTweakedSigner,
+        disableTweakSigner: !useTweakedSigner,
+      }),
+    };
+  });
 }

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/provider.ts
@@ -2,6 +2,7 @@ import type { BitcoinAdapter } from "@reown/appkit-adapter-bitcoin";
 import { Psbt } from "bitcoinjs-lib";
 
 import type { BTCConfig, IBTCProvider, InscriptionIdentifier, SignPsbtOptions } from "@/core/types";
+import { resolveUseTweakedSigner } from "@/core/utils/psbtOptionsMapper";
 import { APPKIT_OPEN_EVENT } from "@/core/wallets/appkit/constants";
 
 import { APPKIT_BTC_CONNECTED_EVENT } from "./constants";
@@ -17,6 +18,7 @@ interface AppKitSignInput {
   index: number;
   sighashTypes: number[];
   publicKey?: string;
+  useTweakedSigner?: boolean;
   disableTweakSigner?: boolean;
 }
 
@@ -240,13 +242,19 @@ export class AppKitBTCProvider implements IBTCProvider {
       const signInputs: AppKitSignInput[] | undefined =
         options?.autoFinalized || !options?.signInputs
           ? undefined
-          : options.signInputs.map((input) => ({
-              address: input.address ?? address,
-              index: input.index,
-              sighashTypes: input.sighashTypes ?? [],
-              ...(input.publicKey && { publicKey: input.publicKey }),
-              ...(input.disableTweakSigner && { disableTweakSigner: true }),
-            }));
+          : options.signInputs.map((input) => {
+              const useTweakedSigner = resolveUseTweakedSigner(input);
+              return {
+                address: input.address ?? address,
+                index: input.index,
+                sighashTypes: input.sighashTypes ?? [],
+                ...(input.publicKey && { publicKey: input.publicKey }),
+                ...(useTweakedSigner !== undefined && {
+                  useTweakedSigner,
+                  disableTweakSigner: !useTweakedSigner,
+                }),
+              };
+            });
 
       const result = await walletProvider.signPSBT({
         psbt: psbtBase64,

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/provider.ts
@@ -19,6 +19,7 @@ interface AppKitSignInput {
   sighashTypes: number[];
   publicKey?: string;
   useTweakedSigner?: boolean;
+  /** @deprecated Forwarded in sync with `useTweakedSigner` for older wallets only. */
   disableTweakSigner?: boolean;
 }
 

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/unisat/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/unisat/provider.ts
@@ -126,6 +126,11 @@ export class UnisatProvider implements IBTCProvider {
       // If signInputs is provided, use it directly instead of auto-generating
       // This allows callers to specify exactly which inputs to sign
       if (options?.signInputs && options.signInputs.length > 0) {
+        // UniSat's native field is `useTweakedSigner`; unlike OKX/OneKey/AppKit we
+        // intentionally do NOT forward `disableTweakSigner`. `mapSignInputsToToSignInputs`
+        // forwards both fields to cover older OKX versions that only understood the
+        // legacy field — UniSat has always understood `useTweakedSigner`, so the
+        // legacy field would be noise here.
         signOptions = {
           autoFinalized: options.autoFinalized ?? false,
           toSignInputs: options.signInputs.map((input) => {
@@ -179,7 +184,8 @@ export class UnisatProvider implements IBTCProvider {
       const signOptions = psbtsHexes.map((psbtHex, index) => {
         const option = options?.[index];
 
-        // If signInputs is provided, convert to toSignInputs format (like signPsbt does)
+        // If signInputs is provided, convert to toSignInputs format (like signPsbt does).
+        // Forwards only `useTweakedSigner` — see the note in signPsbt above.
         if (option?.signInputs && option.signInputs.length > 0) {
           return {
             autoFinalized: option.autoFinalized ?? false,

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/unisat/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/unisat/provider.ts
@@ -4,6 +4,7 @@ import { isAccountChangeEvent, DISCONNECT_EVENT, removeProviderListener } from "
 import type { BTCConfig, IBTCProvider, InscriptionIdentifier, SignPsbtOptions, WalletInfo } from "@/core/types";
 import { Network } from "@/core/types";
 import { initBTCCurve } from "@/core/utils/initBTCCurve";
+import { resolveUseTweakedSigner } from "@/core/utils/psbtOptionsMapper";
 import { ERROR_CODES, WalletError } from "@/error";
 
 import logo from "./logo.svg";
@@ -127,13 +128,16 @@ export class UnisatProvider implements IBTCProvider {
       if (options?.signInputs && options.signInputs.length > 0) {
         signOptions = {
           autoFinalized: options.autoFinalized ?? false,
-          toSignInputs: options.signInputs.map((input) => ({
-            index: input.index,
-            publicKey: input.publicKey,
-            address: input.address,
-            sighashTypes: input.sighashTypes,
-            useTweakedSigner: input.disableTweakSigner === true ? false : undefined,
-          })),
+          toSignInputs: options.signInputs.map((input) => {
+            const useTweakedSigner = resolveUseTweakedSigner(input);
+            return {
+              index: input.index,
+              publicKey: input.publicKey,
+              address: input.address,
+              sighashTypes: input.sighashTypes,
+              ...(useTweakedSigner !== undefined && { useTweakedSigner }),
+            };
+          }),
         };
       } else {
         // Default behavior: auto-generate toSignInputs for all unsigned inputs
@@ -179,13 +183,16 @@ export class UnisatProvider implements IBTCProvider {
         if (option?.signInputs && option.signInputs.length > 0) {
           return {
             autoFinalized: option.autoFinalized ?? false,
-            toSignInputs: option.signInputs.map((input) => ({
-              index: input.index,
-              publicKey: input.publicKey,
-              address: input.address,
-              sighashTypes: input.sighashTypes,
-              useTweakedSigner: input.disableTweakSigner === true ? false : undefined,
-            })),
+            toSignInputs: option.signInputs.map((input) => {
+              const useTweakedSigner = resolveUseTweakedSigner(input);
+              return {
+                index: input.index,
+                publicKey: input.publicKey,
+                address: input.address,
+                sighashTypes: input.sighashTypes,
+                ...(useTweakedSigner !== undefined && { useTweakedSigner }),
+              };
+            }),
           };
         }
 

--- a/packages/babylon-wallet-connector/tests/unit/psbtOptionsMapper.test.ts
+++ b/packages/babylon-wallet-connector/tests/unit/psbtOptionsMapper.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Unit tests for PSBT options mapping utilities.
+ *
+ * Covers the precedence rule between `useTweakedSigner` (canonical) and the
+ * deprecated `disableTweakSigner` field, and the "forward both in sync"
+ * contract used by the OKX and OneKey providers.
+ */
+
+import { test, expect } from "@playwright/test";
+
+import type { SignInputOptions } from "../../src/core/types";
+import {
+  mapSignInputsToToSignInputs,
+  resolveUseTweakedSigner,
+} from "../../src/core/utils/psbtOptionsMapper";
+
+// ============================================================================
+// resolveUseTweakedSigner
+// ============================================================================
+
+test.describe("resolveUseTweakedSigner", () => {
+  test("returns true when useTweakedSigner is true", () => {
+    expect(resolveUseTweakedSigner({ useTweakedSigner: true })).toBe(true);
+  });
+
+  test("returns false when useTweakedSigner is false", () => {
+    expect(resolveUseTweakedSigner({ useTweakedSigner: false })).toBe(false);
+  });
+
+  test("useTweakedSigner wins over disableTweakSigner when both are set (useTweakedSigner: true, disableTweakSigner: true)", () => {
+    expect(
+      resolveUseTweakedSigner({
+        useTweakedSigner: true,
+        disableTweakSigner: true,
+      }),
+    ).toBe(true);
+  });
+
+  test("useTweakedSigner wins over disableTweakSigner when both are set (useTweakedSigner: false, disableTweakSigner: false)", () => {
+    expect(
+      resolveUseTweakedSigner({
+        useTweakedSigner: false,
+        disableTweakSigner: false,
+      }),
+    ).toBe(false);
+  });
+
+  test("inverts legacy disableTweakSigner: true to useTweakedSigner: false", () => {
+    expect(resolveUseTweakedSigner({ disableTweakSigner: true })).toBe(false);
+  });
+
+  test("inverts legacy disableTweakSigner: false to useTweakedSigner: true", () => {
+    expect(resolveUseTweakedSigner({ disableTweakSigner: false })).toBe(true);
+  });
+
+  test("returns undefined when neither field is set", () => {
+    expect(resolveUseTweakedSigner({})).toBeUndefined();
+  });
+});
+
+// ============================================================================
+// mapSignInputsToToSignInputs
+// ============================================================================
+
+test.describe("mapSignInputsToToSignInputs", () => {
+  test("forwards useTweakedSigner and disableTweakSigner in sync when useTweakedSigner: false", () => {
+    const input: SignInputOptions = {
+      index: 0,
+      useTweakedSigner: false,
+    };
+
+    const [mapped] = mapSignInputsToToSignInputs([input]);
+
+    expect(mapped.useTweakedSigner).toBe(false);
+    expect(mapped.disableTweakSigner).toBe(true);
+  });
+
+  test("forwards useTweakedSigner and disableTweakSigner in sync when useTweakedSigner: true", () => {
+    const input: SignInputOptions = {
+      index: 0,
+      useTweakedSigner: true,
+    };
+
+    const [mapped] = mapSignInputsToToSignInputs([input]);
+
+    expect(mapped.useTweakedSigner).toBe(true);
+    expect(mapped.disableTweakSigner).toBe(false);
+  });
+
+  test("translates legacy disableTweakSigner: true to both fields set", () => {
+    const input: SignInputOptions = {
+      index: 0,
+      disableTweakSigner: true,
+    };
+
+    const [mapped] = mapSignInputsToToSignInputs([input]);
+
+    expect(mapped.useTweakedSigner).toBe(false);
+    expect(mapped.disableTweakSigner).toBe(true);
+  });
+
+  test("omits both tweak fields when neither is provided", () => {
+    const input: SignInputOptions = {
+      index: 0,
+    };
+
+    const [mapped] = mapSignInputsToToSignInputs([input]);
+
+    expect(mapped).not.toHaveProperty("useTweakedSigner");
+    expect(mapped).not.toHaveProperty("disableTweakSigner");
+  });
+
+  test("preserves index, publicKey, address, and sighashTypes", () => {
+    const input: SignInputOptions = {
+      index: 3,
+      publicKey: "0123456789abcdef",
+      address: "bc1qexample",
+      sighashTypes: [1],
+      useTweakedSigner: false,
+    };
+
+    const [mapped] = mapSignInputsToToSignInputs([input]);
+
+    expect(mapped.index).toBe(3);
+    expect(mapped.publicKey).toBe("0123456789abcdef");
+    expect(mapped.address).toBe("bc1qexample");
+    expect(mapped.sighashTypes).toEqual([1]);
+  });
+
+  test("honors useTweakedSigner precedence when both are provided", () => {
+    const input: SignInputOptions = {
+      index: 0,
+      useTweakedSigner: false,
+      disableTweakSigner: false, // contradictory; useTweakedSigner should win
+    };
+
+    const [mapped] = mapSignInputsToToSignInputs([input]);
+
+    expect(mapped.useTweakedSigner).toBe(false);
+    expect(mapped.disableTweakSigner).toBe(true);
+  });
+});

--- a/services/vault/src/utils/__tests__/signPsbtsWithFallback.test.ts
+++ b/services/vault/src/utils/__tests__/signPsbtsWithFallback.test.ts
@@ -42,11 +42,11 @@ describe("signPsbtsWithFallback", () => {
     const options = [
       {
         autoFinalized: false,
-        signInputs: [{ index: 0, disableTweakSigner: true }],
+        signInputs: [{ index: 0, useTweakedSigner: false }],
       },
       {
         autoFinalized: false,
-        signInputs: [{ index: 0, disableTweakSigner: true }],
+        signInputs: [{ index: 0, useTweakedSigner: false }],
       },
     ];
 


### PR DESCRIPTION
OKX is aligning with UniSat's canonical `useTweakedSigner` field for
script-path Taproot signing. Adds the new field to SignInputOptions,
marks the legacy `disableTweakSigner` @deprecated, and migrates
internal callers. When both are provided, useTweakedSigner wins.
OKX/OneKey/AppKit forward both fields in sync for compatibility
with old + new wallet versions.