### PR TITLE
fix(packages, vault): sync FE ABIs with vault-contracts-aave-v4

### DIFF
--- a/packages/babylon-ts-sdk/docs/api/integrations/aave.md
+++ b/packages/babylon-ts-sdk/docs/api/integrations/aave.md
@@ -912,52 +912,13 @@ Market position data or null if position doesn't exist
 
 ***
 
-### getPositionCollateral()
-
-```ts
-function getPositionCollateral(
-   publicClient, 
-   contractAddress, 
-user): Promise<bigint>;
-```
-
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/query.ts:65](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/query.ts#L65)
-
-Get total collateral for a user's position.
-
-#### Parameters
-
-##### publicClient
-
-Viem public client for reading contracts
-
-##### contractAddress
-
-`` `0x${string}` ``
-
-AaveIntegrationAdapter contract address
-
-##### user
-
-`` `0x${string}` ``
-
-User's Ethereum address
-
-#### Returns
-
-`Promise`\<`bigint`\>
-
-Total collateral amount in satoshis
-
-***
-
 ### getPositionSizeParams()
 
 ```ts
 function getPositionSizeParams(publicClient, contractAddress): Promise<PositionSizeParams>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/query.ts:90](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/query.ts#L90)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/query.ts:67](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/query.ts#L67)
 
 Get position size parameters from the adapter contract.
 
@@ -1053,7 +1014,7 @@ console.log("Debt (USD):", accountData.totalDebtValueRay);
 **Return values:**
 - `healthFactor` - WAD format (1e18 = 1.0). Below 1.0 = liquidatable
 - `totalCollateralValue` - USD value in base currency (1e26 = $1)
-- `totalDebtValueRay` - USD value in RAY-scaled base currency (1e35 = $1)
+- `totalDebtValueRay` - USD value in RAY-scaled base currency (1e53 = $1)
 - `avgCollateralFactor` - Weighted average collateral factor in WAD (1e18 = 100%)
 - `riskPremium` - Additional risk premium
 
@@ -1694,7 +1655,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/aaveConvers
 
 Convert Aave RAY-scaled base currency value to USD
 
-Debt values use higher precision: 1e35 = $1 USD.
+Debt values use higher precision: 1e53 = $1 USD.
 
 #### Parameters
 
@@ -1702,7 +1663,7 @@ Debt values use higher precision: 1e35 = $1 USD.
 
 `bigint`
 
-Value in RAY-scaled base currency (1e35 = $1)
+Value in RAY-scaled base currency (1e53 = $1)
 
 #### Returns
 
@@ -2709,13 +2670,14 @@ Reference: ISpoke.sol UserAccountData
 ### AAVE\_BASE\_CURRENCY\_RAY\_DECIMALS
 
 ```ts
-const AAVE_BASE_CURRENCY_RAY_DECIMALS: 35 = 35;
+const AAVE_BASE_CURRENCY_RAY_DECIMALS: 53 = 53;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/constants.ts:70](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/constants.ts#L70)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/constants.ts:71](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/constants.ts#L71)
 
 Aave RAY-scaled base currency decimals
-Debt values (totalDebtValueRay) use 1e35 = $1 USD
+Debt values (totalDebtValueRay) use 1e53 = $1 USD
+(base currency 1e26 scaled by RAY 1e27).
 
 Reference: IAaveSpoke.sol UserAccountData.totalDebtValueRay
 
@@ -2727,7 +2689,7 @@ Reference: IAaveSpoke.sol UserAccountData.totalDebtValueRay
 const WAD_DECIMALS: 18 = 18;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/constants.ts:78](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/constants.ts#L78)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/constants.ts:79](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/constants.ts#L79)
 
 WAD decimals (1e18 = 1.0)
 Used for health factor and collateral factor values
@@ -2742,7 +2704,7 @@ Reference: ISpoke.sol - "healthFactor expressed in WAD. 1e18 represents a health
 const HEALTH_FACTOR_WARNING_THRESHOLD: 1.5 = 1.5;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/constants.ts:84](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/constants.ts#L84)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/constants.ts:85](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/constants.ts#L85)
 
 Health factor warning threshold
 Positions below this are considered at risk of liquidation
@@ -2755,7 +2717,7 @@ Positions below this are considered at risk of liquidation
 const MIN_HEALTH_FACTOR_FOR_BORROW: 1.2 = 1.2;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/constants.ts:90](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/constants.ts#L90)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/constants.ts:91](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/constants.ts#L91)
 
 Minimum health factor allowed for borrowing
 Prevents users from borrowing if resulting health factor would be below this.
@@ -2768,7 +2730,7 @@ Prevents users from borrowing if resulting health factor would be below this.
 const FULL_REPAY_BUFFER_DIVISOR: 10000n = 10000n;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/constants.ts:97](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/constants.ts#L97)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/constants.ts:98](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/constants.ts#L98)
 
 Buffer for full repayment to account for interest accrual
 between fetching debt and transaction execution.

--- a/packages/babylon-ts-sdk/docs/api/managers.md
+++ b/packages/babylon-ts-sdk/docs/api/managers.md
@@ -189,7 +189,7 @@ Error if any signing operation fails
 
 ### PeginManager
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:515](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L515)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:524](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L524)
 
 #### Constructors
 
@@ -199,7 +199,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:515](
 new PeginManager(config): PeginManager;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:523](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L523)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:532](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L532)
 
 Creates a new PeginManager instance.
 
@@ -223,7 +223,7 @@ Manager configuration including wallets and contract addresses
 preparePegin(params): Promise<PreparePeginResult>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:547](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L547)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:556](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L556)
 
 Prepares a peg-in by building the Pre-PegIn HTLC transaction,
 funding it, constructing the PegIn transaction, and signing the PegIn input.
@@ -264,7 +264,7 @@ Error if wallet operations fail or insufficient funds
 signAndBroadcast(params): Promise<string>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:732](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L732)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:744](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L744)
 
 Signs and broadcasts a funded peg-in transaction to the Bitcoin network.
 
@@ -300,7 +300,7 @@ Error if signing or broadcasting fails
 registerPeginOnChain(params): Promise<RegisterPeginResult>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:875](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L875)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:887](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L887)
 
 Registers a peg-in on Ethereum by calling the BTCVaultRegistry contract.
 
@@ -351,7 +351,7 @@ Error if contract simulation fails (e.g., invalid signature,
 registerPeginBatchOnChain(params): Promise<RegisterPeginBatchResult>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1036](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L1036)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1048](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L1048)
 
 Register multiple pegins on Ethereum in a single transaction.
 
@@ -379,7 +379,7 @@ Batch result with per-vault IDs and single ETH tx hash
 signProofOfPossession(): Promise<PopSignature>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1266](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L1266)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1278](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L1278)
 
 Sign a BIP-322 BTC Proof-of-Possession binding the connected BTC
 wallet to the connected ETH account for this chain and vault
@@ -396,7 +396,7 @@ every register call in the same session.
 getNetwork(): Network;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1311](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L1311)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1326](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L1326)
 
 Gets the configured Bitcoin network.
 
@@ -412,7 +412,7 @@ The Bitcoin network (mainnet, testnet, signet, regtest)
 getVaultContractAddress(): `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1320](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L1320)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1335](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L1335)
 
 Gets the configured BTCVaultRegistry contract address.
 
@@ -935,7 +935,7 @@ Depositor's BTC public key used for signing.
 
 ### PeginManagerConfig
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:125](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L125)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:134](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L134)
 
 Configuration for the PeginManager.
 
@@ -947,7 +947,7 @@ Configuration for the PeginManager.
 btcNetwork: Network;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:129](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L129)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:138](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L138)
 
 Bitcoin network to use for transactions.
 
@@ -957,7 +957,7 @@ Bitcoin network to use for transactions.
 btcWallet: BitcoinWallet;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:134](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L134)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:143](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L143)
 
 Bitcoin wallet for signing peg-in transactions.
 
@@ -967,7 +967,7 @@ Bitcoin wallet for signing peg-in transactions.
 ethWallet: object;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:140](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L140)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:149](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L149)
 
 Ethereum wallet for registering peg-in on-chain.
 Uses viem's WalletClient directly for proper gas estimation.
@@ -978,7 +978,7 @@ Uses viem's WalletClient directly for proper gas estimation.
 ethChain: Chain;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:146](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L146)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:155](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L155)
 
 Ethereum chain configuration.
 Required for proper gas estimation in contract calls.
@@ -989,7 +989,7 @@ Required for proper gas estimation in contract calls.
 vaultContracts: object;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:151](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L151)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:160](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L160)
 
 Vault contract addresses.
 
@@ -1007,7 +1007,7 @@ BTCVaultRegistry contract address on Ethereum.
 mempoolApiUrl: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:163](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L163)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:172](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L172)
 
 Mempool API URL for fetching UTXO data and broadcasting transactions.
 Use MEMPOOL_API_URLS constant for standard mempool.space URLs, or provide
@@ -1017,7 +1017,7 @@ a custom URL if running your own mempool instance.
 
 ### PreparePeginParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:169](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L169)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:178](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L178)
 
 Parameters for the pegin flow (pre-pegin + pegin transactions).
 
@@ -1029,7 +1029,7 @@ Parameters for the pegin flow (pre-pegin + pegin transactions).
 amounts: readonly bigint[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:175](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L175)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:184](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L184)
 
 Amounts to peg in per HTLC (in satoshis).
 Must have the same length as `hashlocks`.
@@ -1041,7 +1041,7 @@ For single deposits, pass a single-element array.
 vaultProviderBtcPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:181](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L181)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:190](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L190)
 
 Vault provider's BTC public key (x-only, 64-char hex).
 Can be provided with or without "0x" prefix (will be stripped automatically).
@@ -1052,7 +1052,7 @@ Can be provided with or without "0x" prefix (will be stripped automatically).
 vaultKeeperBtcPubkeys: readonly string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:187](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L187)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:196](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L196)
 
 Vault keeper BTC public keys (x-only, 64-char hex).
 Can be provided with or without "0x" prefix (will be stripped automatically).
@@ -1063,7 +1063,7 @@ Can be provided with or without "0x" prefix (will be stripped automatically).
 universalChallengerBtcPubkeys: readonly string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:193](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L193)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:202](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L202)
 
 Universal challenger BTC public keys (x-only, 64-char hex).
 Can be provided with or without "0x" prefix (will be stripped automatically).
@@ -1074,7 +1074,7 @@ Can be provided with or without "0x" prefix (will be stripped automatically).
 timelockPegin: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:198](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L198)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:207](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L207)
 
 CSV timelock in blocks for the PegIn vault output.
 
@@ -1084,7 +1084,7 @@ CSV timelock in blocks for the PegIn vault output.
 timelockRefund: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:203](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L203)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:212](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L212)
 
 CSV timelock in blocks for the Pre-PegIn HTLC refund path.
 
@@ -1094,7 +1094,7 @@ CSV timelock in blocks for the Pre-PegIn HTLC refund path.
 hashlocks: readonly string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:210](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L210)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:219](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L219)
 
 SHA256 hash commitment(s) for the HTLC (64 hex chars = 32 bytes each).
 Generated by the depositor as H = SHA256(secret).
@@ -1106,7 +1106,7 @@ For single deposits, pass a single-element array.
 protocolFeeRate: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:216](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L216)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:225](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L225)
 
 Protocol fee rate in sat/vB from the contract offchain params.
 Used by WASM for computing depositorClaimValue and min pegin fee.
@@ -1117,7 +1117,7 @@ Used by WASM for computing depositorClaimValue and min pegin fee.
 mempoolFeeRate: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:222](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L222)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:231](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L231)
 
 Mempool fee rate in sat/vB for funding the Pre-PegIn transaction.
 Used for UTXO selection and change calculation.
@@ -1128,7 +1128,7 @@ Used for UTXO selection and change calculation.
 councilQuorum: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:227](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L227)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:236](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L236)
 
 M in M-of-N council multisig (from contract params).
 
@@ -1138,7 +1138,7 @@ M in M-of-N council multisig (from contract params).
 councilSize: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:232](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L232)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:241](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L241)
 
 N in M-of-N council multisig (from contract params).
 
@@ -1148,7 +1148,7 @@ N in M-of-N council multisig (from contract params).
 availableUTXOs: readonly UTXO[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:237](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L237)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:246](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L246)
 
 Available UTXOs from the depositor's wallet for funding the Pre-PegIn transaction.
 
@@ -1158,7 +1158,7 @@ Available UTXOs from the depositor's wallet for funding the Pre-PegIn transactio
 changeAddress: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:242](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L242)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:251](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L251)
 
 Bitcoin address for receiving change from the Pre-PegIn transaction.
 
@@ -1166,7 +1166,7 @@ Bitcoin address for receiving change from the Pre-PegIn transaction.
 
 ### PreparePeginResult
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:264](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L264)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:273](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L273)
 
 #### Properties
 
@@ -1176,7 +1176,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:264](
 fundedPrePeginTxHex: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:270](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L270)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:279](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L279)
 
 Funded, pre-witness Pre-PegIn tx hex. Pass this for register calls'
 `unsignedPrePeginTx` — despite the contract-side name, the registry
@@ -1188,7 +1188,7 @@ stores the funded form so indexers can rebuild refund PSBTs.
 prePeginTxid: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:272](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L272)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:281](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L281)
 
 Funded Pre-PegIn transaction ID
 
@@ -1198,7 +1198,7 @@ Funded Pre-PegIn transaction ID
 perVault: PerVaultPeginData[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:274](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L274)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:283](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L283)
 
 Per-vault PegIn data — one entry per hashlock/amount
 
@@ -1208,7 +1208,7 @@ Per-vault PegIn data — one entry per hashlock/amount
 selectedUTXOs: UTXO[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:276](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L276)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:285](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L285)
 
 UTXOs selected to fund the Pre-PegIn transaction
 
@@ -1218,7 +1218,7 @@ UTXOs selected to fund the Pre-PegIn transaction
 fee: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:278](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L278)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:287](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L287)
 
 Transaction fee in satoshis
 
@@ -1228,7 +1228,7 @@ Transaction fee in satoshis
 changeAmount: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:280](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L280)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:289](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L289)
 
 Change amount in satoshis (if any)
 
@@ -1236,7 +1236,7 @@ Change amount in satoshis (if any)
 
 ### SignAndBroadcastParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:287](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L287)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:296](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L296)
 
 Parameters for signing and broadcasting a transaction.
 
@@ -1248,7 +1248,7 @@ Parameters for signing and broadcasting a transaction.
 fundedPrePeginTxHex: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:291](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L291)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:300](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L300)
 
 Funded Pre-PegIn transaction hex from preparePegin().
 
@@ -1258,7 +1258,7 @@ Funded Pre-PegIn transaction hex from preparePegin().
 depositorBtcPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:298](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L298)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:307](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L307)
 
 Depositor's BTC public key (x-only, 64-char hex).
 Can be provided with or without "0x" prefix.
@@ -1273,7 +1273,7 @@ optional localPrevouts: Record<string, {
 }>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:306](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L306)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:315](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L315)
 
 Optional pre-fetched prevout data for inputs not yet in the mempool.
 Key format: "txid:vout" (e.g. "abc123...def:0").
@@ -1284,7 +1284,7 @@ Useful for split transactions where outputs are unconfirmed.
 
 ### PopSignature
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:315](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L315)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:324](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L324)
 
 BIP-322 BTC Proof-of-Possession binding a depositor's BTC key to their
 Ethereum account. Produced by [PeginManager.signProofOfPossession](#signproofofpossession)
@@ -1299,7 +1299,7 @@ embedded identities are re-checked at register time.
 btcPopSignature: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:317](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L317)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:326](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L326)
 
 BIP-322 signature over the PoP message (0x-prefixed hex).
 
@@ -1309,7 +1309,7 @@ BIP-322 signature over the PoP message (0x-prefixed hex).
 depositorEthAddress: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:319](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L319)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:328](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L328)
 
 Ethereum address the PoP was signed for.
 
@@ -1319,7 +1319,7 @@ Ethereum address the PoP was signed for.
 depositorBtcPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:321](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L321)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:330](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L330)
 
 BTC x-only public key (64-char hex, no 0x prefix).
 
@@ -1327,7 +1327,7 @@ BTC x-only public key (64-char hex, no 0x prefix).
 
 ### RegisterPeginParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:327](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L327)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:336](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L336)
 
 Parameters for registering a peg-in on Ethereum.
 
@@ -1339,7 +1339,7 @@ Parameters for registering a peg-in on Ethereum.
 unsignedPrePeginTx: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:333](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L333)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:342](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L342)
 
 Funded, pre-witness Pre-PegIn tx hex — pass
 [PreparePeginResult.fundedPrePeginTxHex](#fundedprepegintxhex). The contract-side
@@ -1351,7 +1351,7 @@ parameter is named `unsignedPrePeginTx` but it stores the funded form.
 depositorSignedPeginTx: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:338](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L338)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:347](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L347)
 
 Depositor-signed PegIn transaction hex (submitted to contract; vault ID derived from this).
 
@@ -1361,7 +1361,7 @@ Depositor-signed PegIn transaction hex (submitted to contract; vault ID derived 
 vaultProvider: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:343](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L343)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:352](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L352)
 
 Vault provider's Ethereum address.
 
@@ -1371,7 +1371,7 @@ Vault provider's Ethereum address.
 hashlock: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:348](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L348)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:357](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L357)
 
 SHA256 hashlock for HTLC activation (bytes32 hex with 0x prefix).
 
@@ -1381,7 +1381,7 @@ SHA256 hashlock for HTLC activation (bytes32 hex with 0x prefix).
 optional depositorPayoutBtcAddress: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:357](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L357)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:366](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L366)
 
 Depositor's BTC payout address (e.g. bc1p..., bc1q...).
 Converted to scriptPubKey internally via bitcoinjs-lib.
@@ -1395,7 +1395,7 @@ via `btcWallet.getAddress()`.
 depositorWotsPkHash: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:360](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L360)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:369](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L369)
 
 Keccak256 hash of the depositor's WOTS public key (bytes32)
 
@@ -1405,7 +1405,7 @@ Keccak256 hash of the depositor's WOTS public key (bytes32)
 popSignature: PopSignature;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:363](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L363)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:372](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L372)
 
 Proof of possession from [PeginManager.signProofOfPossession](#signproofofpossession).
 
@@ -1415,7 +1415,7 @@ Proof of possession from [PeginManager.signProofOfPossession](#signproofofposses
 htlcVout: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:370](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L370)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:379](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L379)
 
 Zero-based index of the HTLC output in the Pre-PegIn transaction that
 this PegIn spends. In a batch Pre-PegIn with N HTLC outputs, each vault
@@ -1425,7 +1425,7 @@ registration references a different htlcVout (0..N-1).
 
 ### RegisterPeginResult
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:376](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L376)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:385](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L385)
 
 Result of registering a peg-in on Ethereum.
 
@@ -1437,7 +1437,7 @@ Result of registering a peg-in on Ethereum.
 ethTxHash: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:380](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L380)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:389](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L389)
 
 Ethereum transaction hash for the peg-in registration.
 
@@ -1447,7 +1447,7 @@ Ethereum transaction hash for the peg-in registration.
 vaultId: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:386](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L386)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:395](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L395)
 
 Derived vault ID: keccak256(abi.encode(peginTxHash, depositor)).
 Used for contract reads/writes and indexer queries.
@@ -1458,7 +1458,7 @@ Used for contract reads/writes and indexer queries.
 peginTxHash: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:392](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L392)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:401](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L401)
 
 Raw Bitcoin pegin transaction hash (double-SHA256 of the signed pegin tx).
 Used for VP RPC operations which key on the BTC transaction ID.
@@ -1467,7 +1467,7 @@ Used for VP RPC operations which key on the BTC transaction ID.
 
 ### BatchPeginRequestItem
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:400](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L400)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:409](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L409)
 
 Single request in a batch pegin registration.
 All requests in a batch share the same vault provider, depositor BTC
@@ -1481,7 +1481,7 @@ pubkey, and Pre-PegIn transaction.
 depositorSignedPeginTx: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:402](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L402)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:411](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L411)
 
 Signed PegIn tx hex for this vault
 
@@ -1491,7 +1491,7 @@ Signed PegIn tx hex for this vault
 hashlock: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:404](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L404)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:413](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L413)
 
 SHA256 hashlock for HTLC activation (bytes32 hex)
 
@@ -1501,7 +1501,7 @@ SHA256 hashlock for HTLC activation (bytes32 hex)
 htlcVout: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:406](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L406)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:415](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L415)
 
 Zero-based HTLC output index in the Pre-PegIn tx (unique per request)
 
@@ -1511,7 +1511,7 @@ Zero-based HTLC output index in the Pre-PegIn tx (unique per request)
 depositorPayoutBtcAddress: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:408](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L408)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:417](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L417)
 
 Depositor's BTC payout address (required — funds are sent here on payout)
 
@@ -1521,7 +1521,7 @@ Depositor's BTC payout address (required — funds are sent here on payout)
 depositorWotsPkHash: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:410](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L410)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:419](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L419)
 
 Keccak256 hash of the depositor's WOTS public key (bytes32)
 
@@ -1529,7 +1529,7 @@ Keccak256 hash of the depositor's WOTS public key (bytes32)
 
 ### RegisterPeginBatchParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:416](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L416)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:425](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L425)
 
 Parameters for registerPeginBatchOnChain.
 
@@ -1541,7 +1541,7 @@ Parameters for registerPeginBatchOnChain.
 vaultProvider: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:418](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L418)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:427](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L427)
 
 Vault provider address (shared across all vaults in batch)
 
@@ -1551,7 +1551,7 @@ Vault provider address (shared across all vaults in batch)
 unsignedPrePeginTx: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:423](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L423)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:432](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L432)
 
 Funded, pre-witness Pre-PegIn tx hex — shared across every request in
 the batch. See [RegisterPeginParams.unsignedPrePeginTx](#unsignedprepegintx).
@@ -1562,7 +1562,7 @@ the batch. See [RegisterPeginParams.unsignedPrePeginTx](#unsignedprepegintx).
 requests: BatchPeginRequestItem[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:425](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L425)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:434](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L434)
 
 Individual pegin requests (one per vault)
 
@@ -1572,7 +1572,7 @@ Individual pegin requests (one per vault)
 popSignature: PopSignature;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:427](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L427)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:436](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L436)
 
 Proof of possession from [PeginManager.signProofOfPossession](#signproofofpossession).
 
@@ -1580,7 +1580,7 @@ Proof of possession from [PeginManager.signProofOfPossession](#signproofofposses
 
 ### BatchPeginResultItem
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:433](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L433)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:442](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L442)
 
 Per-vault result from a batch pegin registration.
 
@@ -1592,7 +1592,7 @@ Per-vault result from a batch pegin registration.
 vaultId: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:435](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L435)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:444](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L444)
 
 Derived vault ID: keccak256(abi.encode(peginTxHash, depositor))
 
@@ -1602,7 +1602,7 @@ Derived vault ID: keccak256(abi.encode(peginTxHash, depositor))
 peginTxHash: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:437](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L437)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:446](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L446)
 
 Raw BTC pegin transaction hash
 
@@ -1610,7 +1610,7 @@ Raw BTC pegin transaction hash
 
 ### RegisterPeginBatchResult
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:443](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L443)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:452](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L452)
 
 Result of registering a batch of pegins on Ethereum in a single transaction.
 
@@ -1622,7 +1622,7 @@ Result of registering a batch of pegins on Ethereum in a single transaction.
 ethTxHash: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:445](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L445)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:454](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L454)
 
 Ethereum transaction hash
 
@@ -1632,7 +1632,7 @@ Ethereum transaction hash
 vaults: BatchPeginResultItem[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:447](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L447)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:456](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L456)
 
 Per-vault results (same order as input requests)
 

--- a/packages/babylon-ts-sdk/docs/api/services.md
+++ b/packages/babylon-ts-sdk/docs/api/services.md
@@ -1093,7 +1093,7 @@ AbortSignal for cancellation
 
 ### VaultRefundData
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:68](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L68)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:71](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L71)
 
 Authoritative vault fields needed to build a refund. Versioning fields,
 the hashlock, and htlcVout must come from the on-chain contract (never the
@@ -1109,7 +1109,7 @@ come from the indexer since they are not security-critical for signing
 hashlock: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:69](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L69)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:72](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L72)
 
 ##### htlcVout
 
@@ -1117,7 +1117,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 htlcVout: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:70](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L70)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:73](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L73)
 
 ##### offchainParamsVersion
 
@@ -1125,7 +1125,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 offchainParamsVersion: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:71](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L71)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:74](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L74)
 
 ##### appVaultKeepersVersion
 
@@ -1133,7 +1133,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 appVaultKeepersVersion: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:72](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L72)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:75](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L75)
 
 ##### universalChallengersVersion
 
@@ -1141,7 +1141,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 universalChallengersVersion: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:73](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L73)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:76](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L76)
 
 ##### vaultProvider
 
@@ -1149,7 +1149,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 vaultProvider: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:74](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L74)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:77](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L77)
 
 ##### applicationEntryPoint
 
@@ -1157,7 +1157,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 applicationEntryPoint: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:75](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L75)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:78](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L78)
 
 ##### amount
 
@@ -1165,7 +1165,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 amount: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:77](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L77)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:80](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L80)
 
 Pre-PegIn HTLC output value in satoshis.
 
@@ -1175,7 +1175,7 @@ Pre-PegIn HTLC output value in satoshis.
 unsignedPrePeginTxHex: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:83](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L83)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:86](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L86)
 
 Funded, pre-witness Pre-PegIn transaction hex. 0x prefix optional.
 The name mirrors the contract/indexer schema; the bytes are the
@@ -1187,7 +1187,7 @@ funded form (refund construction needs real outpoints).
 depositorBtcPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:85](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L85)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:88](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L88)
 
 Depositor's BTC public key (x-only or compressed hex; 0x prefix optional).
 
@@ -1195,7 +1195,7 @@ Depositor's BTC public key (x-only or compressed hex; 0x prefix optional).
 
 ### RefundPrePeginContext
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:100](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L100)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:103](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L103)
 
 Version-resolved protocol context that parameterises the HTLC's taproot
 scripts. The *signer-set* fields (`vaultKeeperPubkeys`,
@@ -1216,7 +1216,7 @@ script derivation).
 vaultProviderPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:101](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L101)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:104](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L104)
 
 ##### vaultKeeperPubkeys
 
@@ -1224,7 +1224,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 vaultKeeperPubkeys: readonly string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:102](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L102)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:105](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L105)
 
 ##### universalChallengerPubkeys
 
@@ -1232,7 +1232,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 universalChallengerPubkeys: readonly string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:103](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L103)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:106](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L106)
 
 ##### timelockRefund
 
@@ -1240,7 +1240,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 timelockRefund: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:104](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L104)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:107](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L107)
 
 ##### feeRate
 
@@ -1248,7 +1248,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 feeRate: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:105](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L105)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:108](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L108)
 
 ##### numLocalChallengers
 
@@ -1256,7 +1256,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 numLocalChallengers: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:106](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L106)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:109](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L109)
 
 ##### councilQuorum
 
@@ -1264,7 +1264,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 councilQuorum: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:107](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L107)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:110](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L110)
 
 ##### councilSize
 
@@ -1272,7 +1272,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 councilSize: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:108](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L108)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:111](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L111)
 
 ##### network
 
@@ -1280,13 +1280,13 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 network: Network;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:109](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L109)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:112](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L112)
 
 ***
 
 ### BtcBroadcastResult
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:113](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L113)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:116](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L116)
 
 Minimum shape required from a broadcast result.
 
@@ -1298,13 +1298,13 @@ Minimum shape required from a broadcast result.
 txId: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:114](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L114)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:117](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L117)
 
 ***
 
 ### RefundInput
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:126](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L126)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:129](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L129)
 
 #### Type Parameters
 
@@ -1320,7 +1320,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 vaultId: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:129](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L129)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:132](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L132)
 
 ##### readVault()
 
@@ -1328,7 +1328,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 readVault: () => Promise<VaultRefundData>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:135](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L135)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:138](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L138)
 
 Fetch authoritative on-chain + indexer vault data. The SDK passes no
 arguments — the caller closes over `vaultId` (or any other context it
@@ -1344,7 +1344,7 @@ needs).
 readPrePeginContext: (vault) => Promise<RefundPrePeginContext>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:140](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L140)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:143](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L143)
 
 Fetch the version-pinned refund context (sorted pubkeys, timelock, etc.)
 derived from the vault's locked versions.
@@ -1365,7 +1365,7 @@ derived from the vault's locked versions.
 feeRate: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:149](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L149)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:152](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L152)
 
 Mempool-derived sat/vB fee rate to use for the refund tx (positive
 number). Caller fetches this before invoking — it does not depend on
@@ -1378,7 +1378,7 @@ orchestration honest.
 signPsbt: RefundPsbtSigner;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:151](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L151)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:154](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L154)
 
 BTC wallet signer; receives a PSBT hex + taproot script-path options.
 
@@ -1388,7 +1388,7 @@ BTC wallet signer; receives a PSBT hex + taproot script-path options.
 broadcastTx: BtcBroadcaster<R>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:153](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L153)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:156](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L156)
 
 Broadcast callback — returns whatever shape the caller needs.
 
@@ -1398,7 +1398,7 @@ Broadcast callback — returns whatever shape the caller needs.
 optional signal: AbortSignal;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:155](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L155)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:158](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L158)
 
 Checked at every async boundary.
 
@@ -1452,7 +1452,7 @@ Reason why a vault expired
 type BtcBroadcaster<R> = (signedTxHex) => Promise<R>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:117](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L117)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:120](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L120)
 
 #### Type Parameters
 
@@ -1478,7 +1478,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 type RefundPsbtSigner = (psbtHex, opts) => Promise<string>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:121](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L121)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:124](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L124)
 
 #### Parameters
 
@@ -2047,7 +2047,7 @@ thresholds) are a consumer-side concern.
 function buildAndBroadcastRefund<R>(input): Promise<R>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:277](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L277)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:280](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L280)
 
 Build, sign, and broadcast a refund transaction for an expired vault.
 

--- a/packages/babylon-ts-sdk/src/tbv/core/contracts/abis/BTCVaultRegistry.abi.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/contracts/abis/BTCVaultRegistry.abi.ts
@@ -305,18 +305,18 @@ export const BTCVaultRegistryABI = [
       },
       {
         name: "universalChallengersVersion",
-        type: "uint32",
-        internalType: "uint32",
+        type: "uint16",
+        internalType: "uint16",
       },
       {
         name: "appVaultKeepersVersion",
-        type: "uint32",
-        internalType: "uint32",
+        type: "uint16",
+        internalType: "uint16",
       },
       {
         name: "offchainParamsVersion",
-        type: "uint32",
-        internalType: "uint32",
+        type: "uint16",
+        internalType: "uint16",
       },
       {
         name: "verifiedAt",

--- a/packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/index.ts
@@ -1,7 +1,6 @@
 // Query operations
 export {
   getPosition,
-  getPositionCollateral,
   getPositionSizeParams,
 } from "./query.js";
 

--- a/packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/query.ts
+++ b/packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/query.ts
@@ -55,29 +55,6 @@ export async function getPosition(
 }
 
 /**
- * Get total collateral for a user's position.
- *
- * @param publicClient - Viem public client for reading contracts
- * @param contractAddress - AaveIntegrationAdapter contract address
- * @param user - User's Ethereum address
- * @returns Total collateral amount in satoshis
- */
-export async function getPositionCollateral(
-  publicClient: PublicClient,
-  contractAddress: Address,
-  user: Address,
-): Promise<bigint> {
-  const result = await publicClient.readContract({
-    address: contractAddress,
-    abi: AaveIntegrationAdapterABI,
-    functionName: "getPositionCollateral",
-    args: [user],
-  });
-
-  return result as bigint;
-}
-
-/**
  * Get position size parameters from the adapter contract.
  *
  * Returns the maximum BTC position size and maximum vaults per position

--- a/packages/babylon-ts-sdk/src/tbv/integrations/aave/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/integrations/aave/index.ts
@@ -77,7 +77,6 @@ export {
   buildWithdrawCollateralsTx,
   getDynamicReserveConfig,
   getPosition,
-  getPositionCollateral,
   getPositionSizeParams,
   getReserve,
   getTargetHealthFactor,

--- a/services/vault/src/clients/eth-contract/protocol-params/__tests__/query.test.ts
+++ b/services/vault/src/clients/eth-contract/protocol-params/__tests__/query.test.ts
@@ -33,7 +33,7 @@ const VALID_TBV_PARAMS = {
   minimumPegInAmount: 100_000n,
   maxPegInAmount: 10_000_000n,
   pegInAckTimeout: 100n,
-  peginActivationTimeout: 200n,
+  pegInActivationTimeout: 200n,
 };
 
 const VALID_OFFCHAIN_PARAMS = {

--- a/services/vault/src/clients/eth-contract/protocol-params/__tests__/query.test.ts
+++ b/services/vault/src/clients/eth-contract/protocol-params/__tests__/query.test.ts
@@ -34,6 +34,7 @@ const VALID_TBV_PARAMS = {
   maxPegInAmount: 10_000_000n,
   pegInAckTimeout: 100n,
   pegInActivationTimeout: 200n,
+  maxHtlcOutputCount: 5,
 };
 
 const VALID_OFFCHAIN_PARAMS = {
@@ -48,6 +49,8 @@ const VALID_OFFCHAIN_PARAMS = {
   tRefund: 144,
   tStale: 288,
   minPeginFeeRate: 1n,
+  proverProgramVersion: 1,
+  minPrepeginDepth: 6,
 };
 
 type QueryModule = typeof import("../query");
@@ -207,5 +210,34 @@ describe("getPegInConfiguration validation", () => {
     await expect(query.getPegInConfiguration()).rejects.toThrow(
       /maxPegInAmount.*must be >= minimumPegInAmount/,
     );
+  });
+
+  it("forwards maxHtlcOutputCount from TBV params", async () => {
+    mockGetChainId.mockResolvedValue(11155111);
+    mockReadContract.mockReset();
+    mockReadContract
+      .mockResolvedValueOnce(PROTOCOL_PARAMS_ADDRESS)
+      .mockResolvedValueOnce({ ...VALID_TBV_PARAMS, maxHtlcOutputCount: 7 });
+
+    const params = await query.getTBVProtocolParams();
+    expect(params.maxHtlcOutputCount).toBe(7);
+  });
+
+  it("forwards proverProgramVersion and minPrepeginDepth from offchain params", async () => {
+    mockGetChainId.mockResolvedValue(11155111);
+    mockReadContract.mockResolvedValue(PROTOCOL_PARAMS_ADDRESS);
+    mockMulticall.mockResolvedValue([
+      VALID_TBV_PARAMS,
+      {
+        ...VALID_OFFCHAIN_PARAMS,
+        proverProgramVersion: 3,
+        minPrepeginDepth: 12,
+      },
+    ]);
+
+    const config = await query.getPegInConfiguration();
+    expect(config.maxHtlcOutputCount).toBe(VALID_TBV_PARAMS.maxHtlcOutputCount);
+    expect(config.offchainParams.proverProgramVersion).toBe(3);
+    expect(config.offchainParams.minPrepeginDepth).toBe(12);
   });
 });

--- a/services/vault/src/clients/eth-contract/protocol-params/__tests__/validation.test.ts
+++ b/services/vault/src/clients/eth-contract/protocol-params/__tests__/validation.test.ts
@@ -26,6 +26,8 @@ function validOffchainParams(
     tRefund: 144,
     tStale: 288,
     minPeginFeeRate: 1n,
+    proverProgramVersion: 1,
+    minPrepeginDepth: 6,
     ...overrides,
   };
 }
@@ -39,6 +41,7 @@ function validPegInConfig(
     maxPegInAmount: 10_000_000n,
     pegInAckTimeout: 100n,
     pegInActivationTimeout: 200n,
+    maxHtlcOutputCount: 5,
     timelockPegin: 150,
     timelockRefund: 144,
     minVpCommissionBps: 500,
@@ -127,6 +130,28 @@ describe("validateOffchainParams", () => {
     ).toThrow(/minPeginFeeRate must be positive/);
   });
 
+  it("rejects proverProgramVersion above uint16 max", () => {
+    expect(() =>
+      validateOffchainParams(
+        validOffchainParams({ proverProgramVersion: 65536 }),
+      ),
+    ).toThrow(/proverProgramVersion must be a uint16/);
+  });
+
+  it("rejects minPrepeginDepth of zero", () => {
+    expect(() =>
+      validateOffchainParams(validOffchainParams({ minPrepeginDepth: 0 })),
+    ).toThrow(/minPrepeginDepth must be a uint32/);
+  });
+
+  it("rejects minPrepeginDepth above uint32 max", () => {
+    expect(() =>
+      validateOffchainParams(
+        validOffchainParams({ minPrepeginDepth: 4_294_967_296 }),
+      ),
+    ).toThrow(/minPrepeginDepth must be a uint32/);
+  });
+
   it("rejects babeTotalInstances of zero", () => {
     expect(() =>
       validateOffchainParams(
@@ -189,6 +214,7 @@ function validTBVParams(
     maxPegInAmount: 10_000_000n,
     pegInAckTimeout: 100n,
     pegInActivationTimeout: 200n,
+    maxHtlcOutputCount: 5,
     ...overrides,
   };
 }
@@ -225,6 +251,18 @@ describe("validateTBVProtocolParams", () => {
     expect(() =>
       validateTBVProtocolParams(validTBVParams({ pegInActivationTimeout: 0n })),
     ).toThrow(/pegInActivationTimeout must be positive/);
+  });
+
+  it("rejects maxHtlcOutputCount of zero", () => {
+    expect(() =>
+      validateTBVProtocolParams(validTBVParams({ maxHtlcOutputCount: 0 })),
+    ).toThrow(/maxHtlcOutputCount must be an integer in \[1, 255\]/);
+  });
+
+  it("rejects maxHtlcOutputCount above uint8 max", () => {
+    expect(() =>
+      validateTBVProtocolParams(validTBVParams({ maxHtlcOutputCount: 256 })),
+    ).toThrow(/maxHtlcOutputCount must be an integer in \[1, 255\]/);
   });
 });
 

--- a/services/vault/src/clients/eth-contract/protocol-params/__tests__/validation.test.ts
+++ b/services/vault/src/clients/eth-contract/protocol-params/__tests__/validation.test.ts
@@ -38,7 +38,7 @@ function validPegInConfig(
     minimumPegInAmount: 100_000n,
     maxPegInAmount: 10_000_000n,
     pegInAckTimeout: 100n,
-    peginActivationTimeout: 200n,
+    pegInActivationTimeout: 200n,
     timelockPegin: 150,
     timelockRefund: 144,
     minVpCommissionBps: 500,
@@ -188,7 +188,7 @@ function validTBVParams(
     minimumPegInAmount: 100_000n,
     maxPegInAmount: 10_000_000n,
     pegInAckTimeout: 100n,
-    peginActivationTimeout: 200n,
+    pegInActivationTimeout: 200n,
     ...overrides,
   };
 }
@@ -221,10 +221,10 @@ describe("validateTBVProtocolParams", () => {
     ).toThrow(/pegInAckTimeout must be positive/);
   });
 
-  it("rejects peginActivationTimeout of zero", () => {
+  it("rejects pegInActivationTimeout of zero", () => {
     expect(() =>
-      validateTBVProtocolParams(validTBVParams({ peginActivationTimeout: 0n })),
-    ).toThrow(/peginActivationTimeout must be positive/);
+      validateTBVProtocolParams(validTBVParams({ pegInActivationTimeout: 0n })),
+    ).toThrow(/pegInActivationTimeout must be positive/);
   });
 });
 
@@ -256,12 +256,12 @@ describe("validatePegInConfiguration", () => {
     ).toThrow(/pegInAckTimeout must be positive/);
   });
 
-  it("rejects peginActivationTimeout of zero", () => {
+  it("rejects pegInActivationTimeout of zero", () => {
     expect(() =>
       validatePegInConfiguration(
-        validPegInConfig({ peginActivationTimeout: 0n }),
+        validPegInConfig({ pegInActivationTimeout: 0n }),
       ),
-    ).toThrow(/peginActivationTimeout must be positive/);
+    ).toThrow(/pegInActivationTimeout must be positive/);
   });
 
   it("also validates offchain params within the configuration", () => {

--- a/services/vault/src/clients/eth-contract/protocol-params/abis/ProtocolParams.abi.json
+++ b/services/vault/src/clients/eth-contract/protocol-params/abis/ProtocolParams.abi.json
@@ -1,100 +1,80 @@
 [
   {
     "type": "function",
-    "name": "minimumPegInAmount",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "maxPegInAmount",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "pegInAckTimeout",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "peginActivationTimeout",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "getTBVProtocolParams",
+    "name": "getLatestOffchainParams",
     "inputs": [],
     "outputs": [
       {
         "name": "",
         "type": "tuple",
-        "internalType": "struct IProtocolParams.TBVProtocolParams",
+        "internalType": "struct IProtocolParams.VersionedOffchainParams",
         "components": [
           {
-            "name": "minimumPegInAmount",
+            "name": "timelockAssert",
             "type": "uint256",
             "internalType": "uint256"
           },
           {
-            "name": "maxPegInAmount",
+            "name": "timelockChallengeAssert",
             "type": "uint256",
             "internalType": "uint256"
           },
           {
-            "name": "pegInAckTimeout",
-            "type": "uint256",
-            "internalType": "uint256"
+            "name": "securityCouncilKeys",
+            "type": "bytes32[]",
+            "internalType": "bytes32[]"
           },
           {
-            "name": "peginActivationTimeout",
-            "type": "uint256",
-            "internalType": "uint256"
+            "name": "councilQuorum",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "feeRate",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "babeTotalInstances",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "babeInstancesToFinalize",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "minVpCommissionBps",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "tRefund",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "tStale",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "minPeginFeeRate",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "proverProgramVersion",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "minPrepeginDepth",
+            "type": "uint32",
+            "internalType": "uint32"
           }
         ]
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "latestOffchainParamsVersion",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "uint16",
-        "internalType": "uint16"
       }
     ],
     "stateMutability": "view"
@@ -169,6 +149,16 @@
             "name": "minPeginFeeRate",
             "type": "uint64",
             "internalType": "uint64"
+          },
+          {
+            "name": "proverProgramVersion",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "minPrepeginDepth",
+            "type": "uint32",
+            "internalType": "uint32"
           }
         ]
       }
@@ -177,70 +167,105 @@
   },
   {
     "type": "function",
-    "name": "getLatestOffchainParams",
+    "name": "getTBVProtocolParams",
     "inputs": [],
     "outputs": [
       {
         "name": "",
         "type": "tuple",
-        "internalType": "struct IProtocolParams.VersionedOffchainParams",
+        "internalType": "struct IProtocolParams.TBVProtocolParams",
         "components": [
           {
-            "name": "timelockAssert",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
-            "name": "timelockChallengeAssert",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
-            "name": "securityCouncilKeys",
-            "type": "bytes32[]",
-            "internalType": "bytes32[]"
-          },
-          {
-            "name": "councilQuorum",
-            "type": "uint8",
-            "internalType": "uint8"
-          },
-          {
-            "name": "feeRate",
+            "name": "minimumPegInAmount",
             "type": "uint64",
             "internalType": "uint64"
           },
           {
-            "name": "babeTotalInstances",
-            "type": "uint16",
-            "internalType": "uint16"
-          },
-          {
-            "name": "babeInstancesToFinalize",
-            "type": "uint8",
-            "internalType": "uint8"
-          },
-          {
-            "name": "minVpCommissionBps",
-            "type": "uint16",
-            "internalType": "uint16"
-          },
-          {
-            "name": "tRefund",
-            "type": "uint32",
-            "internalType": "uint32"
-          },
-          {
-            "name": "tStale",
-            "type": "uint32",
-            "internalType": "uint32"
-          },
-          {
-            "name": "minPeginFeeRate",
+            "name": "maxPegInAmount",
             "type": "uint64",
             "internalType": "uint64"
+          },
+          {
+            "name": "pegInAckTimeout",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "pegInActivationTimeout",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "maxHtlcOutputCount",
+            "type": "uint8",
+            "internalType": "uint8"
           }
         ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "latestOffchainParamsVersion",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "maxPegInAmount",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "minimumPegInAmount",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "pegInAckTimeout",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "pegInActivationTimeout",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
       }
     ],
     "stateMutability": "view"

--- a/services/vault/src/clients/eth-contract/protocol-params/query.ts
+++ b/services/vault/src/clients/eth-contract/protocol-params/query.ts
@@ -27,7 +27,7 @@ export interface TBVProtocolParams {
   minimumPegInAmount: bigint;
   maxPegInAmount: bigint;
   pegInAckTimeout: bigint;
-  peginActivationTimeout: bigint;
+  pegInActivationTimeout: bigint;
 }
 
 /**
@@ -59,7 +59,7 @@ export interface PegInConfiguration {
   /** Timeout for ACK collection in ETH blocks */
   pegInAckTimeout: bigint;
   /** Timeout for pegin activation in ETH blocks */
-  peginActivationTimeout: bigint;
+  pegInActivationTimeout: bigint;
   /** CSV timelock in blocks for the PegIn vault output (from offchain params) */
   timelockPegin: number;
   /** CSV timelock in blocks for the Pre-PegIn HTLC refund path (from offchain params tRefund) */
@@ -145,7 +145,7 @@ export async function getTBVProtocolParams(): Promise<TBVProtocolParams> {
     minimumPegInAmount: result.minimumPegInAmount,
     maxPegInAmount: result.maxPegInAmount,
     pegInAckTimeout: result.pegInAckTimeout,
-    peginActivationTimeout: result.peginActivationTimeout,
+    pegInActivationTimeout: result.pegInActivationTimeout,
   };
 }
 
@@ -208,7 +208,7 @@ export async function getPegInConfiguration(): Promise<PegInConfiguration> {
     minimumPegInAmount: params.minimumPegInAmount,
     maxPegInAmount: params.maxPegInAmount,
     pegInAckTimeout: params.pegInAckTimeout,
-    peginActivationTimeout: params.peginActivationTimeout,
+    pegInActivationTimeout: params.pegInActivationTimeout,
     timelockPegin,
     timelockRefund,
     minVpCommissionBps: offchainParams.minVpCommissionBps,

--- a/services/vault/src/clients/eth-contract/protocol-params/query.ts
+++ b/services/vault/src/clients/eth-contract/protocol-params/query.ts
@@ -28,6 +28,8 @@ export interface TBVProtocolParams {
   maxPegInAmount: bigint;
   pegInAckTimeout: bigint;
   pegInActivationTimeout: bigint;
+  /** Upper bound on HTLC outputs per Pre-PegIn tx (uint8 on-chain). */
+  maxHtlcOutputCount: number;
 }
 
 /**
@@ -46,6 +48,10 @@ export interface VersionedOffchainParams {
   tRefund: number;
   tStale: number;
   minPeginFeeRate: bigint;
+  /** Prover program (ELF) version selector (uint16 on-chain). */
+  proverProgramVersion: number;
+  /** Minimum BTC confirmations before ACK signing (uint32 on-chain). */
+  minPrepeginDepth: number;
 }
 
 /**
@@ -60,6 +66,8 @@ export interface PegInConfiguration {
   pegInAckTimeout: bigint;
   /** Timeout for pegin activation in ETH blocks */
   pegInActivationTimeout: bigint;
+  /** Upper bound on HTLC outputs per Pre-PegIn tx */
+  maxHtlcOutputCount: number;
   /** CSV timelock in blocks for the PegIn vault output (from offchain params) */
   timelockPegin: number;
   /** CSV timelock in blocks for the Pre-PegIn HTLC refund path (from offchain params tRefund) */
@@ -146,6 +154,7 @@ export async function getTBVProtocolParams(): Promise<TBVProtocolParams> {
     maxPegInAmount: result.maxPegInAmount,
     pegInAckTimeout: result.pegInAckTimeout,
     pegInActivationTimeout: result.pegInActivationTimeout,
+    maxHtlcOutputCount: result.maxHtlcOutputCount,
   };
 }
 
@@ -209,6 +218,7 @@ export async function getPegInConfiguration(): Promise<PegInConfiguration> {
     maxPegInAmount: params.maxPegInAmount,
     pegInAckTimeout: params.pegInAckTimeout,
     pegInActivationTimeout: params.pegInActivationTimeout,
+    maxHtlcOutputCount: params.maxHtlcOutputCount,
     timelockPegin,
     timelockRefund,
     minVpCommissionBps: offchainParams.minVpCommissionBps,

--- a/services/vault/src/clients/eth-contract/protocol-params/validation.ts
+++ b/services/vault/src/clients/eth-contract/protocol-params/validation.ts
@@ -76,6 +76,26 @@ export function validateOffchainParams(params: VersionedOffchainParams): void {
     );
   }
 
+  if (
+    !Number.isInteger(params.proverProgramVersion) ||
+    params.proverProgramVersion < 0 ||
+    params.proverProgramVersion > 65535
+  ) {
+    errors.push(
+      `proverProgramVersion must be a uint16, got ${params.proverProgramVersion}`,
+    );
+  }
+
+  if (
+    !Number.isInteger(params.minPrepeginDepth) ||
+    params.minPrepeginDepth <= 0 ||
+    params.minPrepeginDepth > 4_294_967_295
+  ) {
+    errors.push(
+      `minPrepeginDepth must be a uint32 in [1, 4294967295], got ${params.minPrepeginDepth}`,
+    );
+  }
+
   if (params.babeTotalInstances <= 0) {
     errors.push(
       `babeTotalInstances must be positive, got ${params.babeTotalInstances}`,
@@ -136,6 +156,16 @@ export function validateTBVProtocolParams(params: TBVProtocolParams): void {
   if (params.pegInActivationTimeout <= 0n) {
     errors.push(
       `pegInActivationTimeout must be positive, got ${params.pegInActivationTimeout}`,
+    );
+  }
+
+  if (
+    !Number.isInteger(params.maxHtlcOutputCount) ||
+    params.maxHtlcOutputCount <= 0 ||
+    params.maxHtlcOutputCount > 255
+  ) {
+    errors.push(
+      `maxHtlcOutputCount must be an integer in [1, 255], got ${params.maxHtlcOutputCount}`,
     );
   }
 

--- a/services/vault/src/clients/eth-contract/protocol-params/validation.ts
+++ b/services/vault/src/clients/eth-contract/protocol-params/validation.ts
@@ -133,9 +133,9 @@ export function validateTBVProtocolParams(params: TBVProtocolParams): void {
     );
   }
 
-  if (params.peginActivationTimeout <= 0n) {
+  if (params.pegInActivationTimeout <= 0n) {
     errors.push(
-      `peginActivationTimeout must be positive, got ${params.peginActivationTimeout}`,
+      `pegInActivationTimeout must be positive, got ${params.pegInActivationTimeout}`,
     );
   }
 

--- a/services/vault/src/hooks/deposit/__tests__/useDepositValidation.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useDepositValidation.test.tsx
@@ -16,7 +16,7 @@ vi.mock("@/context/ProtocolParamsContext", () => ({
       minimumPegInAmount: 10000n,
       maxPegInAmount: 100_000_000n,
       pegInAckTimeout: 50400n,
-      peginActivationTimeout: 100800n,
+      pegInActivationTimeout: 100800n,
     },
     minDeposit: 10000n,
     maxDeposit: 100_000_000n,


### PR DESCRIPTION
Side-by-side ABI audit against `vault-contracts-aave-v4@main` (commit
`fa3eed2e`) turned up three drift items. This PR fixes them.

- **SDK dead API removed**: `getPositionCollateral` was exported from the
  SDK but its contract-side function was removed from `AaveAdapter`.
  Nothing inside the repo called it, but any external SDK consumer
  invoking it would hit `AbiFunctionNotFoundError` at runtime. Dropped
  the export + re-exports.

- **BTCVaultRegistry SDK ABI — version field types**: the three version
  fields on `getBtcVaultProtocolInfo` (`universalChallengersVersion`,
  `appVaultKeepersVersion`, `offchainParamsVersion`) were declared as
  `uint32` but the `BTCVaultProtocolInfo` struct uses `uint16`. Solidity
  ABI encoding pads every struct field to 32 bytes so decoding still
  worked, but the declared type was wrong. Corrected.

- **ProtocolParams vault service ABI — regenerated**: the old hand-maintained
  ABI was missing `maxHtlcOutputCount`, `proverProgramVersion` and
  `minPrepeginDepth`, had a casing typo (`peginActivationTimeout` vs
  contract's `pegInActivationTimeout`), and used `uint256` where the
  contract struct declares `uint64`/`uint8`. Replaced with a jq extraction
  from the Foundry artifact, keeping only the 8 functions the vault
  service calls. Renamed `peginActivationTimeout` → `pegInActivationTimeout`
  across `query.ts`, `validation.ts` and three test files.

Regenerated the SDK API docs so `getPositionCollateral` is gone there too.