### PR TITLE
fix(aave): spoke address references, chain validation logic

### DIFF
--- a/services/vault/src/applications/aave/clients/transaction.ts
+++ b/services/vault/src/applications/aave/clients/transaction.ts
@@ -5,6 +5,7 @@
  * Only includes Core Spoke operations for regular users (no Arbitrageur operations).
  */
 
+import { getETHChain } from "@babylonlabs-io/config";
 import { BTCVaultRegistryABI } from "@babylonlabs-io/ts-sdk/tbv/core";
 import {
   AaveIntegrationAdapterABI,
@@ -80,6 +81,14 @@ async function executeTx(
   data: Hex,
   errorContext: string,
 ): Promise<TransactionResult> {
+  // Reject if the wallet is connected to the wrong chain (audit v2 #44).
+  const expectedChainId = getETHChain().id;
+  if (chain.id !== expectedChainId) {
+    throw new Error(
+      `Chain mismatch: expected chain ${expectedChainId}, got ${chain.id}. Please switch to the correct network.`,
+    );
+  }
+
   const publicClient = ethClient.getPublicClient();
   const account = walletClient.account?.address;
 

--- a/services/vault/src/applications/aave/clients/transaction.ts
+++ b/services/vault/src/applications/aave/clients/transaction.ts
@@ -81,7 +81,7 @@ async function executeTx(
   data: Hex,
   errorContext: string,
 ): Promise<TransactionResult> {
-  // Reject if the wallet is connected to the wrong chain (audit v2 #44).
+  // Reject if the wallet is connected to the wrong chain
   const expectedChainId = getETHChain().id;
   if (chain.id !== expectedChainId) {
     throw new Error(

--- a/services/vault/src/applications/aave/clients/transaction.ts
+++ b/services/vault/src/applications/aave/clients/transaction.ts
@@ -81,11 +81,13 @@ async function executeTx(
   data: Hex,
   errorContext: string,
 ): Promise<TransactionResult> {
-  // Reject if the wallet is connected to the wrong chain
+  // Reject if the wallet is connected to the wrong chain.
+  // Callers pass getETHChain() as `chain`, but the wallet itself may still be
+  // on a different network. Check the wallet's actual chain to catch this early.
   const expectedChainId = getETHChain().id;
-  if (chain.id !== expectedChainId) {
+  if (walletClient.chain?.id !== expectedChainId) {
     throw new Error(
-      `Chain mismatch: expected chain ${expectedChainId}, got ${chain.id}. Please switch to the correct network.`,
+      `Chain mismatch: expected chain ${expectedChainId}, got ${walletClient.chain?.id}. Please switch to the correct network.`,
     );
   }
 

--- a/services/vault/src/applications/aave/components/Detail/hooks/__tests__/useAaveReserveDetail.test.tsx
+++ b/services/vault/src/applications/aave/components/Detail/hooks/__tests__/useAaveReserveDetail.test.tsx
@@ -84,7 +84,7 @@ vi.mock("@/hooks/usePrices", () => ({
 // Mock useAaveConfig
 const mockUseAaveConfig = vi.fn(() => ({
   config: {
-    btcVaultCoreSpokeAddress: "0xSpokeAddress",
+    coreSpokeAddress: "0xSpokeAddress",
     btcVaultCoreVbtcReserveId: 1n,
   },
   vbtcReserve: {
@@ -317,7 +317,7 @@ describe("useAaveReserveDetail", () => {
   it("returns null for unknown token without Chainlink price", () => {
     mockUseAaveConfig.mockReturnValue({
       config: {
-        btcVaultCoreSpokeAddress: "0xSpokeAddress",
+        coreSpokeAddress: "0xSpokeAddress",
         btcVaultCoreVbtcReserveId: 1n,
       },
       vbtcReserve: {

--- a/services/vault/src/applications/aave/hooks/__tests__/useVaultSplitParams.test.tsx
+++ b/services/vault/src/applications/aave/hooks/__tests__/useVaultSplitParams.test.tsx
@@ -56,7 +56,7 @@ vi.mock("../../utils", () => ({
 vi.mock("../../context", () => ({
   useAaveConfig: vi.fn(() => ({
     config: {
-      btcVaultCoreSpokeAddress: "0xSpokeAddress",
+      coreSpokeAddress: "0xSpokeAddress",
       btcVaultCoreVbtcReserveId: 1n,
     },
     vbtcReserve: null,
@@ -213,7 +213,7 @@ describe("useVaultSplitParams", () => {
         adapterAddress: "0x1",
         vaultBtcAddress: "0x2",
         btcVaultRegistryAddress: "0x3",
-        btcVaultCoreSpokeAddress: "0xSpokeAddress",
+        coreSpokeAddress: "0xSpokeAddress",
         btcVaultCoreVbtcReserveId: 1n,
       },
       vbtcReserve: null,

--- a/services/vault/src/applications/aave/hooks/useAaveUserPosition.ts
+++ b/services/vault/src/applications/aave/hooks/useAaveUserPosition.ts
@@ -7,7 +7,6 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { useEffect, useMemo, useRef, useState } from "react";
-import type { Address } from "viem";
 
 import { satoshiToBtcNumber } from "@/utils/btcConversion";
 
@@ -84,7 +83,7 @@ export function useAaveUserPosition(
     borrowableReserves,
     isLoading: configLoading,
   } = useAaveConfig();
-  const spokeAddress = config?.btcVaultCoreSpokeAddress as Address | undefined;
+  const spokeAddress = config?.coreSpokeAddress;
   const vbtcReserveId = config?.btcVaultCoreVbtcReserveId;
 
   // Extract reserve IDs for fetching debt positions

--- a/services/vault/src/applications/aave/hooks/useBorrowTransaction.ts
+++ b/services/vault/src/applications/aave/hooks/useBorrowTransaction.ts
@@ -3,6 +3,7 @@
  * Handles the transaction execution for borrowing assets against collateral
  */
 
+import { getETHChain } from "@babylonlabs-io/config";
 import { useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { parseUnits } from "viem";
@@ -43,7 +44,7 @@ export function useBorrowTransaction(): UseBorrowTransactionResult {
   const { data: walletClient } = useWalletClient();
   const { address } = useAccount();
   const queryClient = useQueryClient();
-  const chain = walletClient?.chain;
+  const chain = getETHChain();
   const { handleError } = useError();
 
   const executeBorrow = async (
@@ -56,7 +57,7 @@ export function useBorrowTransaction(): UseBorrowTransactionResult {
     setIsProcessing(true);
     try {
       // Validate wallet connection
-      if (!walletClient || !chain) {
+      if (!walletClient) {
         throw new WalletError(
           "Please connect your wallet to continue",
           ErrorCode.WALLET_NOT_CONNECTED,

--- a/services/vault/src/applications/aave/hooks/useReorderVaults.ts
+++ b/services/vault/src/applications/aave/hooks/useReorderVaults.ts
@@ -5,6 +5,7 @@
  * to change the prefix ordering for liquidation priority.
  */
 
+import { getETHChain } from "@babylonlabs-io/config";
 import { useCallback, useState } from "react";
 import type { Hex } from "viem";
 import { useAccount, useWalletClient } from "wagmi";
@@ -40,14 +41,13 @@ export function useReorderVaults(): UseReorderVaultsResult {
   const [isProcessing, setIsProcessing] = useState(false);
   const { data: walletClient } = useWalletClient();
   const { address } = useAccount();
-  const chain = walletClient?.chain;
   const { handleError } = useError();
 
   const executeReorder = useCallback(
     async (permutedVaultIds: Hex[]) => {
       setIsProcessing(true);
       try {
-        if (!walletClient || !chain) {
+        if (!walletClient) {
           throw new WalletError(
             "Please connect your wallet to continue",
             ErrorCode.WALLET_NOT_CONNECTED,
@@ -61,7 +61,7 @@ export function useReorderVaults(): UseReorderVaultsResult {
           );
         }
 
-        await reorderVaultOrder(walletClient, chain, permutedVaultIds);
+        await reorderVaultOrder(walletClient, getETHChain(), permutedVaultIds);
 
         return true;
       } catch (error) {
@@ -86,7 +86,7 @@ export function useReorderVaults(): UseReorderVaultsResult {
         setIsProcessing(false);
       }
     },
-    [walletClient, chain, address, handleError],
+    [walletClient, address, handleError],
   );
 
   return {

--- a/services/vault/src/applications/aave/hooks/useRepayTransaction.ts
+++ b/services/vault/src/applications/aave/hooks/useRepayTransaction.ts
@@ -5,6 +5,7 @@
  * Manages React state and query invalidation.
  */
 
+import { getETHChain } from "@babylonlabs-io/config";
 import { useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import type { Address } from "viem";
@@ -57,7 +58,7 @@ export function useRepayTransaction({
   const { data: walletClient } = useWalletClient();
   const { address } = useAccount();
   const queryClient = useQueryClient();
-  const chain = walletClient?.chain;
+  const chain = getETHChain();
   const { handleError } = useError();
 
   const executeRepay = async (
@@ -70,7 +71,7 @@ export function useRepayTransaction({
     setIsProcessing(true);
     try {
       // Validate prerequisites
-      if (!walletClient || !chain) {
+      if (!walletClient) {
         throw new WalletError(
           "Please connect your wallet to continue",
           ErrorCode.WALLET_NOT_CONNECTED,

--- a/services/vault/src/applications/aave/hooks/useVaultSplitParams.ts
+++ b/services/vault/src/applications/aave/hooks/useVaultSplitParams.ts
@@ -93,7 +93,7 @@ export function useVaultSplitParams(
   connectedAddress?: string,
 ): UseVaultSplitParamsResult {
   const { config } = useAaveConfig();
-  const spokeAddress = config?.btcVaultCoreSpokeAddress as Address | undefined;
+  const spokeAddress = config?.coreSpokeAddress;
   const reserveId = config?.btcVaultCoreVbtcReserveId;
 
   // Reuses the cached query inside useAaveUserPosition — no duplicate RPCs.

--- a/services/vault/src/applications/aave/hooks/useWithdrawCollateralTransaction.ts
+++ b/services/vault/src/applications/aave/hooks/useWithdrawCollateralTransaction.ts
@@ -5,6 +5,7 @@
  * Position must have zero debt before withdrawal.
  */
 
+import { getETHChain } from "@babylonlabs-io/config";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useState } from "react";
 import type { Address, Hex } from "viem";
@@ -46,7 +47,6 @@ export function useWithdrawCollateralTransaction(): UseWithdrawCollateralTransac
   const { data: walletClient } = useWalletClient();
   const { address } = useAccount();
   const queryClient = useQueryClient();
-  const chain = walletClient?.chain;
   const { handleError } = useError();
   const { markVaultsAsPending } = usePendingVaults();
 
@@ -55,7 +55,7 @@ export function useWithdrawCollateralTransaction(): UseWithdrawCollateralTransac
       setIsProcessing(true);
       try {
         // Validate wallet connection
-        if (!walletClient || !chain) {
+        if (!walletClient) {
           throw new WalletError(
             "Please connect your wallet to continue",
             ErrorCode.WALLET_NOT_CONNECTED,
@@ -72,7 +72,7 @@ export function useWithdrawCollateralTransaction(): UseWithdrawCollateralTransac
         // Execute selective withdraw transaction
         await withdrawSelectedCollateral(
           walletClient,
-          chain,
+          getETHChain(),
           vaultIds as Hex[],
         );
 
@@ -109,14 +109,7 @@ export function useWithdrawCollateralTransaction(): UseWithdrawCollateralTransac
         setIsProcessing(false);
       }
     },
-    [
-      walletClient,
-      chain,
-      address,
-      queryClient,
-      handleError,
-      markVaultsAsPending,
-    ],
+    [walletClient, address, queryClient, handleError, markVaultsAsPending],
   );
 
   return {

--- a/services/vault/src/applications/aave/services/fetchConfig.ts
+++ b/services/vault/src/applications/aave/services/fetchConfig.ts
@@ -9,6 +9,7 @@ import { gql } from "graphql-request";
 import type { Address } from "viem";
 
 import { graphqlClient } from "../../../clients/graphql";
+import { getCoreSpokeAddress } from "../clients/transaction";
 
 /**
  * Aave configuration from GraphQL indexer
@@ -21,8 +22,8 @@ export interface AaveConfig {
   vaultBtcAddress: string;
   /** BTCVaultRegistry contract address */
   btcVaultRegistryAddress: string;
-  /** Core Spoke contract address (for user lending positions) */
-  btcVaultCoreSpokeAddress: string;
+  /** Core Spoke contract address (resolved on-chain from adapter) */
+  coreSpokeAddress: Address;
   /** vBTC reserve ID on Core Spoke */
   btcVaultCoreVbtcReserveId: bigint;
 }
@@ -102,7 +103,6 @@ interface GraphQLAaveAppConfigResponse {
     adapterAddress: string;
     vaultBtcAddress: string;
     btcVaultRegistryAddress: string;
-    btcVaultCoreSpokeAddress: string;
     btcVaultCoreVbtcReserveId: string;
   } | null;
   /** All reserves (we filter for vBTC and borrowable in code) */
@@ -123,7 +123,6 @@ const GET_AAVE_APP_CONFIG = gql`
       adapterAddress
       vaultBtcAddress
       btcVaultRegistryAddress
-      btcVaultCoreSpokeAddress
       btcVaultCoreVbtcReserveId
     }
     aaveReserves {
@@ -203,11 +202,16 @@ export async function fetchAaveAppConfig(): Promise<AaveAppConfig | null> {
 
   const vbtcReserveId = BigInt(response.aaveConfig.btcVaultCoreVbtcReserveId);
 
+  // Resolve spoke address on-chain from the trusted adapter contract,
+  // rather than relying on the untrusted GraphQL indexer (audit v2 #46).
+  const adapterAddress = response.aaveConfig.adapterAddress as Address;
+  const coreSpokeAddress = await getCoreSpokeAddress(adapterAddress);
+
   const config: AaveConfig = {
     adapterAddress: response.aaveConfig.adapterAddress,
     vaultBtcAddress: response.aaveConfig.vaultBtcAddress,
     btcVaultRegistryAddress: response.aaveConfig.btcVaultRegistryAddress,
-    btcVaultCoreSpokeAddress: response.aaveConfig.btcVaultCoreSpokeAddress,
+    coreSpokeAddress,
     btcVaultCoreVbtcReserveId: vbtcReserveId,
   };
 
@@ -236,52 +240,5 @@ export async function fetchAaveAppConfig(): Promise<AaveAppConfig | null> {
     config,
     vbtcReserve,
     borrowableReserves,
-  };
-}
-
-/** GraphQL response shape for config only */
-interface GraphQLAaveConfigResponse {
-  aaveConfig: {
-    id: number;
-    adapterAddress: string;
-    vaultBtcAddress: string;
-    btcVaultRegistryAddress: string;
-    btcVaultCoreSpokeAddress: string;
-    btcVaultCoreVbtcReserveId: string;
-  } | null;
-}
-
-const GET_AAVE_CONFIG = gql`
-  query GetAaveConfig {
-    aaveConfig(id: ${AAVE_CONFIG_ID}) {
-      id
-      adapterAddress
-      vaultBtcAddress
-      btcVaultRegistryAddress
-      btcVaultCoreSpokeAddress
-      btcVaultCoreVbtcReserveId
-    }
-  }
-`;
-
-/**
- * Fetches Aave configuration from the GraphQL indexer.
- */
-export async function fetchAaveConfig(): Promise<AaveConfig | null> {
-  const response =
-    await graphqlClient.request<GraphQLAaveConfigResponse>(GET_AAVE_CONFIG);
-
-  if (!response.aaveConfig) {
-    return null;
-  }
-
-  return {
-    adapterAddress: response.aaveConfig.adapterAddress,
-    vaultBtcAddress: response.aaveConfig.vaultBtcAddress,
-    btcVaultRegistryAddress: response.aaveConfig.btcVaultRegistryAddress,
-    btcVaultCoreSpokeAddress: response.aaveConfig.btcVaultCoreSpokeAddress,
-    btcVaultCoreVbtcReserveId: BigInt(
-      response.aaveConfig.btcVaultCoreVbtcReserveId,
-    ),
   };
 }

--- a/services/vault/src/applications/aave/services/fetchConfig.ts
+++ b/services/vault/src/applications/aave/services/fetchConfig.ts
@@ -203,7 +203,7 @@ export async function fetchAaveAppConfig(): Promise<AaveAppConfig | null> {
   const vbtcReserveId = BigInt(response.aaveConfig.btcVaultCoreVbtcReserveId);
 
   // Resolve spoke address on-chain from the trusted adapter contract,
-  // rather than relying on the untrusted GraphQL indexer (audit v2 #46).
+  // rather than relying on the untrusted GraphQL indexer
   const adapterAddress = response.aaveConfig.adapterAddress as Address;
   const coreSpokeAddress = await getCoreSpokeAddress(adapterAddress);
 

--- a/services/vault/src/applications/aave/services/fetchConfig.ts
+++ b/services/vault/src/applications/aave/services/fetchConfig.ts
@@ -205,7 +205,15 @@ export async function fetchAaveAppConfig(): Promise<AaveAppConfig | null> {
   // Resolve spoke address on-chain from the trusted adapter contract,
   // rather than relying on the untrusted GraphQL indexer
   const adapterAddress = response.aaveConfig.adapterAddress as Address;
-  const coreSpokeAddress = await getCoreSpokeAddress(adapterAddress);
+  let coreSpokeAddress: Address;
+  try {
+    coreSpokeAddress = await getCoreSpokeAddress(adapterAddress);
+  } catch (error) {
+    throw new Error(
+      `Failed to resolve Core Spoke address from adapter ${adapterAddress}`,
+      { cause: error },
+    );
+  }
 
   const config: AaveConfig = {
     adapterAddress: response.aaveConfig.adapterAddress,

--- a/services/vault/src/applications/aave/services/index.ts
+++ b/services/vault/src/applications/aave/services/index.ts
@@ -1,7 +1,6 @@
 // GraphQL: Aave config
 export {
   fetchAaveAppConfig,
-  fetchAaveConfig,
   type AaveAppConfig,
   type AaveConfig,
   type AaveReserveConfig,

--- a/services/vault/src/clients/eth-contract/transactionFactory.ts
+++ b/services/vault/src/clients/eth-contract/transactionFactory.ts
@@ -4,6 +4,7 @@
  * Includes pre-flight simulation to catch errors before user signs.
  */
 
+import { getETHChain } from "@babylonlabs-io/config";
 import {
   type Abi,
   type Address,
@@ -66,6 +67,14 @@ export async function executeWrite(
     args,
     errorContext,
   } = options;
+
+  // Reject if the wallet is connected to the wrong chain
+  const expectedChainId = getETHChain().id;
+  if (walletClient.chain?.id !== expectedChainId) {
+    throw new Error(
+      `Chain mismatch: expected chain ${expectedChainId}, got ${walletClient.chain?.id}. Please switch to the correct network.`,
+    );
+  }
 
   const publicClient = ethClient.getPublicClient();
   const account = walletClient.account;


### PR DESCRIPTION
## Summary

Fixes two MEDIUM audit findings in the Aave integration module.

### 1. Source Spoke address on-chain instead of GraphQL ([v2 #46](https://github.com/babylonlabs-io/vault-provider-proxy/issues/130))

`btcVaultCoreSpokeAddress` was fetched from the GraphQL indexer — an untrusted mirror — and used as the source of truth for user position reads, vault split params, health factor, and reorder suggestions. A stale or malicious indexer could feed a fake Spoke address, causing the UI to compute incorrect borrow capacity, liquidation distance, and reorder recommendations against a contract the adapter never references.

**Fix:** Resolve the Core Spoke address on-chain from the pinned `AaveIntegrationAdapter` via its immutable `BTC_VAULT_CORE_SPOKE` property (using the existing `getCoreSpokeAddress()` helper). The GraphQL field is removed from queries, interfaces, and response types. The dead `fetchAaveConfig()` function (no callers) is also removed.

### 2. Validate chain ID before Aave write transactions ([v2 #44](https://github.com/babylonlabs-io/vault-provider-proxy/issues/128))

All four Aave write hooks (`useBorrowTransaction`, `useRepayTransaction`, `useWithdrawCollateralTransaction`, `useReorderVaults`) extracted `chain` from `walletClient?.chain` without verifying it matched the configured TBV network. The transaction executor simulated against the correctly-configured public client but then submitted through the wallet's current chain — a split-brain path where preflight passes on the intended network while the actual transaction targets whatever chain the wallet happens to be on.

**Fix:** Hooks now use `getETHChain()` from the environment config as the authoritative chain source. Additionally, `executeTx()` validates `chain.id` against `getETHChain().id` before simulation, rejecting with a clear error on mismatch. This matches the pattern already used by the deposit Ethereum submit step.

Closes https://github.com/babylonlabs-io/vault-provider-proxy/issues/130
Closes https://github.com/babylonlabs-io/vault-provider-proxy/issues/128
