### PR TITLE
fix(utxo): duplicate utxos, race condition, dust threshold

### DIFF
--- a/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/__tests__/availability.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/__tests__/availability.test.ts
@@ -229,6 +229,32 @@ describe("UTXO availability validation", () => {
       expect(result.allAvailable).toBe(true);
     });
 
+    it("should throw when transaction contains duplicate inputs", () => {
+      const duplicateInputTx = createMultiInputTxHex([
+        {
+          txidLE:
+            "1111111111111111111111111111111111111111111111111111111111111111",
+          vout: 0,
+        },
+        {
+          txidLE:
+            "1111111111111111111111111111111111111111111111111111111111111111",
+          vout: 0,
+        },
+      ]);
+
+      const availableUtxos = [
+        {
+          txid: "1111111111111111111111111111111111111111111111111111111111111111",
+          vout: 0,
+        },
+      ];
+
+      expect(() =>
+        validateUtxosAvailable(duplicateInputTx, availableUtxos),
+      ).toThrow(/duplicate input/i);
+    });
+
     it("should accept UTXOs with extra properties beyond UtxoRef", () => {
       const availableUtxos = [
         {

--- a/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/__tests__/selectUtxos.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/__tests__/selectUtxos.test.ts
@@ -126,6 +126,75 @@ describe("selectUtxosForPegin", () => {
     );
   });
 
+  it("should throw when availableUTXOs contains duplicate txid:vout entries", () => {
+    const duplicateUTXOs: UTXO[] = [
+      {
+        txid: "tx1",
+        vout: 0,
+        value: 100000,
+        scriptPubKey:
+          "5120abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+      },
+      {
+        txid: "tx1",
+        vout: 0,
+        value: 100000,
+        scriptPubKey:
+          "5120abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+      },
+    ];
+
+    expect(() => selectUtxosForPegin(duplicateUTXOs, 50000n, 10, 2)).toThrow(
+      /Duplicate UTXO detected/,
+    );
+  });
+
+  it("should treat UTXOs with same txid but different vout as distinct", () => {
+    const sameHashDifferentVout: UTXO[] = [
+      {
+        txid: "tx1",
+        vout: 0,
+        value: 100000,
+        scriptPubKey:
+          "5120abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+      },
+      {
+        txid: "tx1",
+        vout: 1,
+        value: 50000,
+        scriptPubKey:
+          "5120abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+      },
+    ];
+
+    expect(() =>
+      selectUtxosForPegin(sameHashDifferentVout, 50000n, 10, 2),
+    ).not.toThrow();
+  });
+
+  it("should detect duplicate UTXOs case-insensitively", () => {
+    const mixedCaseDuplicates: UTXO[] = [
+      {
+        txid: "aAbBcCdD1234567890abcdef1234567890abcdef1234567890abcdef12345678",
+        vout: 0,
+        value: 100000,
+        scriptPubKey:
+          "5120abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+      },
+      {
+        txid: "AABBCCDD1234567890abcdef1234567890abcdef1234567890abcdef12345678",
+        vout: 0,
+        value: 100000,
+        scriptPubKey:
+          "5120abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+      },
+    ];
+
+    expect(() =>
+      selectUtxosForPegin(mixedCaseDuplicates, 50000n, 10, 2),
+    ).toThrow(/Duplicate UTXO detected/);
+  });
+
   it("should charge higher fee for more outputs", () => {
     const feeWith2Outputs = selectUtxosForPegin(mockUTXOs, 50000n, 10, 2).fee;
     const feeWith5Outputs = selectUtxosForPegin(mockUTXOs, 50000n, 10, 5).fee;

--- a/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts
@@ -105,6 +105,20 @@ export function validateUtxosAvailable(
     throw new Error("Transaction has no inputs");
   }
 
+  // Detect duplicate inputs (same txid:vout referenced more than once).
+  // This would produce an invalid Bitcoin transaction.
+  const inputKeys = new Set<string>();
+  for (const input of inputs) {
+    const key = `${input.txid.toLowerCase()}:${input.vout}`;
+    if (inputKeys.has(key)) {
+      throw new Error(
+        `Transaction contains duplicate input ${input.txid}:${input.vout}. ` +
+          `This would produce an invalid Bitcoin transaction.`,
+      );
+    }
+    inputKeys.add(key);
+  }
+
   // Create a set of available UTXOs for O(1) lookup (lowercase for consistency with reservation.ts)
   const availableSet = new Set(
     availableUtxos.map((utxo) => `${utxo.txid.toLowerCase()}:${utxo.vout}`),

--- a/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts
@@ -48,6 +48,25 @@ export interface UTXOSelectionResult {
 }
 
 /**
+ * Assert that no two UTXOs share the same txid:vout outpoint.
+ * Duplicates from a buggy or compromised UTXO source would produce
+ * an invalid Bitcoin transaction that double-spends the same outpoint.
+ */
+function assertNoDuplicateUtxos(utxos: UTXO[]): void {
+  const seen = new Set<string>();
+  for (const utxo of utxos) {
+    const key = `${utxo.txid.toLowerCase()}:${utxo.vout}`;
+    if (seen.has(key)) {
+      throw new Error(
+        `Duplicate UTXO detected: ${utxo.txid}:${utxo.vout}. ` +
+          `This indicates a data integrity issue with the UTXO source.`,
+      );
+    }
+    seen.add(key);
+  }
+}
+
+/**
  * Selects UTXOs to fund a peg-in transaction with iterative fee calculation.
  *
  * This function implements the btc-staking-ts approach:
@@ -82,6 +101,8 @@ export function selectUtxosForPegin(
   if (availableUTXOs.length === 0) {
     throw new Error("Insufficient funds: no UTXOs available");
   }
+
+  assertNoDuplicateUtxos(availableUTXOs);
 
   // Filter for script validity ONLY (matching btc-staking-ts approach)
   // No minimum value filter - we accept any UTXO with valid script

--- a/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/__tests__/vaultSplit.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/__tests__/vaultSplit.test.ts
@@ -222,30 +222,34 @@ describe("vaultSplit", () => {
       expect(result.sacrificialVault).toBeGreaterThan(0n);
     });
 
-    it("should throw when sacrificial vault amount is below HTLC dust threshold", () => {
+    it("should return zeroed vaults when sacrificial amount is below HTLC dust threshold", () => {
       // totalBtc = 100 sats → sacrificial ≈ 42 sats, protected ≈ 58 sats
       // Both are well below the 2000 sat HTLC dust threshold
-      expect(() =>
-        computeOptimalSplit({
-          totalBtc: 100n,
-          ...DEFAULT_PARAMS,
-        }),
-      ).toThrow(/below the effective dust threshold/);
+      const result = computeOptimalSplit({
+        totalBtc: 100n,
+        ...DEFAULT_PARAMS,
+      });
+
+      expect(result.sacrificialVault).toBe(0n);
+      expect(result.protectedVault).toBe(0n);
+      expect(result.targetSeizureBtc).toBe(0n);
     });
 
-    it("should throw when protected vault amount is below HTLC dust threshold", () => {
+    it("should return zeroed vaults when protected amount is below HTLC dust threshold", () => {
       // seizedFraction ≈ 0.8605, share ≈ 0.9035
       // totalBtc = 19739 → sacrificial ≈ 17835, protected ≈ 1904 (below 2000)
-      expect(() =>
-        computeOptimalSplit({
-          totalBtc: 19_739n,
-          CF: 0.75,
-          LB: 1.05,
-          THF: 1.1,
-          expectedHF: 0.82,
-          safetyMargin: 1.05,
-        }),
-      ).toThrow(/below the effective dust threshold/);
+      const result = computeOptimalSplit({
+        totalBtc: 19_739n,
+        CF: 0.75,
+        LB: 1.05,
+        THF: 1.1,
+        expectedHF: 0.82,
+        safetyMargin: 1.05,
+      });
+
+      expect(result.sacrificialVault).toBe(0n);
+      expect(result.protectedVault).toBe(0n);
+      expect(result.targetSeizureBtc).toBe(0n);
     });
   });
 

--- a/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/__tests__/vaultSplit.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/__tests__/vaultSplit.test.ts
@@ -212,14 +212,40 @@ describe("vaultSplit", () => {
       ).toThrow(RangeError);
     });
 
-    it("should handle small amounts correctly", () => {
+    it("should handle small amounts above dust threshold correctly", () => {
       const result = computeOptimalSplit({
-        totalBtc: 100n, // 100 sats
+        totalBtc: 100_000n, // 100k sats — well above dust
         ...DEFAULT_PARAMS,
       });
 
-      expect(result.sacrificialVault + result.protectedVault).toBe(100n);
+      expect(result.sacrificialVault + result.protectedVault).toBe(100_000n);
       expect(result.sacrificialVault).toBeGreaterThan(0n);
+    });
+
+    it("should throw when sacrificial vault amount is below HTLC dust threshold", () => {
+      // totalBtc = 100 sats → sacrificial ≈ 42 sats, protected ≈ 58 sats
+      // Both are well below the 2000 sat HTLC dust threshold
+      expect(() =>
+        computeOptimalSplit({
+          totalBtc: 100n,
+          ...DEFAULT_PARAMS,
+        }),
+      ).toThrow(/below the effective dust threshold/);
+    });
+
+    it("should throw when protected vault amount is below HTLC dust threshold", () => {
+      // seizedFraction ≈ 0.8605, share ≈ 0.9035
+      // totalBtc = 19739 → sacrificial ≈ 17835, protected ≈ 1904 (below 2000)
+      expect(() =>
+        computeOptimalSplit({
+          totalBtc: 19_739n,
+          CF: 0.75,
+          LB: 1.05,
+          THF: 1.1,
+          expectedHF: 0.82,
+          safetyMargin: 1.05,
+        }),
+      ).toThrow(/below the effective dust threshold/);
     });
   });
 

--- a/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts
+++ b/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts
@@ -233,25 +233,22 @@ export function computeOptimalSplit(
     sacrificialRaw > totalBtc ? totalBtc : sacrificialRaw;
   const protectedVault = totalBtc - sacrificialVault;
 
+  // If either vault is non-zero but below the effective dust threshold for
+  // HTLC outputs, the split is not viable — return zeroed vaults so the
+  // caller treats this as non-splittable. We avoid throwing because this
+  // function is called during render (useMemo) and throwing would crash
+  // the component instead of showing validation feedback.
   if (
-    sacrificialVault > 0n &&
-    sacrificialVault < HTLC_EFFECTIVE_DUST_THRESHOLD
+    (sacrificialVault > 0n &&
+      sacrificialVault < HTLC_EFFECTIVE_DUST_THRESHOLD) ||
+    (protectedVault > 0n && protectedVault < HTLC_EFFECTIVE_DUST_THRESHOLD)
   ) {
-    throw new Error(
-      `Sacrificial vault amount (${sacrificialVault} sats) is below the effective ` +
-        `dust threshold (${HTLC_EFFECTIVE_DUST_THRESHOLD} sats) for HTLC outputs. ` +
-        `This likely indicates an incorrectly configured minDeposit parameter.`,
-    );
-  }
-  if (
-    protectedVault > 0n &&
-    protectedVault < HTLC_EFFECTIVE_DUST_THRESHOLD
-  ) {
-    throw new Error(
-      `Protected vault amount (${protectedVault} sats) is below the effective ` +
-        `dust threshold (${HTLC_EFFECTIVE_DUST_THRESHOLD} sats) for HTLC outputs. ` +
-        `This likely indicates an incorrectly configured minDeposit parameter.`,
-    );
+    return {
+      sacrificialVault: 0n,
+      protectedVault: 0n,
+      seizedFraction,
+      targetSeizureBtc: 0n,
+    };
   }
 
   return {

--- a/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts
+++ b/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts
@@ -20,6 +20,16 @@
 
 const MAX_SAFE_BIGINT = BigInt(Number.MAX_SAFE_INTEGER);
 
+/**
+ * Effective dust threshold for HTLC outputs in satoshis.
+ *
+ * Standard P2TR dust is 330 sats, but HTLC scripts are larger than a standard
+ * P2TR key-path spend. A conservative estimate for an HTLC script-path output
+ * is ~2000 sats. This is a defense-in-depth check — in practice, minDeposit
+ * from the on-chain contract is orders of magnitude larger.
+ */
+const HTLC_EFFECTIVE_DUST_THRESHOLD = 2000n;
+
 export function assertSafePrecision(value: bigint, name: string): void {
   if (value > MAX_SAFE_BIGINT) {
     throw new RangeError(
@@ -222,6 +232,27 @@ export function computeOptimalSplit(
   const sacrificialVault =
     sacrificialRaw > totalBtc ? totalBtc : sacrificialRaw;
   const protectedVault = totalBtc - sacrificialVault;
+
+  if (
+    sacrificialVault > 0n &&
+    sacrificialVault < HTLC_EFFECTIVE_DUST_THRESHOLD
+  ) {
+    throw new Error(
+      `Sacrificial vault amount (${sacrificialVault} sats) is below the effective ` +
+        `dust threshold (${HTLC_EFFECTIVE_DUST_THRESHOLD} sats) for HTLC outputs. ` +
+        `This likely indicates an incorrectly configured minDeposit parameter.`,
+    );
+  }
+  if (
+    protectedVault > 0n &&
+    protectedVault < HTLC_EFFECTIVE_DUST_THRESHOLD
+  ) {
+    throw new Error(
+      `Protected vault amount (${protectedVault} sats) is below the effective ` +
+        `dust threshold (${HTLC_EFFECTIVE_DUST_THRESHOLD} sats) for HTLC outputs. ` +
+        `This likely indicates an incorrectly configured minDeposit parameter.`,
+    );
+  }
 
   return {
     sacrificialVault,

--- a/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
@@ -117,12 +117,17 @@ vi.mock("@/services/deposit/validations", () => ({
 
 vi.mock("@/models/peginStateMachine", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/models/peginStateMachine")>()),
-  LocalStorageStatus: { CONFIRMING: "CONFIRMING" },
+  LocalStorageStatus: { PENDING: "PENDING", CONFIRMING: "CONFIRMING" },
+}));
+
+vi.mock("@/services/vault/vaultUtxoValidationService", () => ({
+  assertUtxosAvailable: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("@/storage/peginStorage", () => ({
   addPendingPegin: vi.fn(),
   getPendingPegins: vi.fn(() => []),
+  updatePendingPeginStatus: vi.fn(),
 }));
 
 vi.mock("@babylonlabs-io/ts-sdk/tbv/core/utils", () => ({
@@ -534,7 +539,7 @@ describe("useDepositFlow", () => {
       });
     });
 
-    it("should save pegins with CONFIRMING status after broadcast", async () => {
+    it("should save pegins with PENDING status before broadcast", async () => {
       const { addPendingPegin } = vi.mocked(
         await import("@/storage/peginStorage"),
       );
@@ -548,8 +553,27 @@ describe("useDepositFlow", () => {
         expect(addPendingPegin).toHaveBeenCalledWith(
           "0xEthAddress123",
           expect.objectContaining({
-            status: "CONFIRMING",
+            status: "PENDING",
           }),
+        );
+      });
+    });
+
+    it("should update pegins to CONFIRMING status after broadcast", async () => {
+      const { updatePendingPeginStatus } = vi.mocked(
+        await import("@/storage/peginStorage"),
+      );
+
+      const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
+
+      await executeWithAutoArtifactDownload(result);
+
+      await waitFor(() => {
+        expect(updatePendingPeginStatus).toHaveBeenCalledTimes(2);
+        expect(updatePendingPeginStatus).toHaveBeenCalledWith(
+          "0xEthAddress123",
+          expect.any(String),
+          "CONFIRMING",
         );
       });
     });

--- a/services/vault/src/hooks/deposit/useDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useDepositFlow.ts
@@ -46,6 +46,7 @@ import {
   utxosToExpectedRecord,
 } from "@/services/vault/vaultPeginBroadcastService";
 import { preparePeginTransaction } from "@/services/vault/vaultTransactionService";
+import { assertUtxosAvailable } from "@/services/vault/vaultUtxoValidationService";
 import {
   computeWotsPublicKeysHash,
   deriveWotsBlockPublicKeys,
@@ -53,7 +54,11 @@ import {
   mnemonicToWotsSeed,
   type WotsPublicKeys,
 } from "@/services/wots";
-import { addPendingPegin, getPendingPegins } from "@/storage/peginStorage";
+import {
+  addPendingPegin,
+  getPendingPegins,
+  updatePendingPeginStatus,
+} from "@/storage/peginStorage";
 import { btcAddressToScriptPubKeyHex } from "@/utils/btc";
 import { satoshiToBtcNumber } from "@/utils/btcConversion";
 import { sanitizeErrorMessage } from "@/utils/errors/formatting";
@@ -412,7 +417,17 @@ export function useDepositFlow(
           depositorWotsPkHash: wotsPkHashes[i],
         }));
 
-        // 3d. Single batch ETH transaction for all vaults.
+        // 3d. Re-check UTXO availability before committing to ETH registration.
+        // This catches the common case where UTXOs were spent during the
+        // (potentially lengthy) PoP signing step. It does not eliminate the
+        // race entirely — UTXOs could still be spent between this check and
+        // the BTC broadcast — but it prevents the most likely failure mode.
+        await assertUtxosAvailable(
+          batchResult.fundedPrePeginTxHex,
+          confirmedBtcAddress,
+        );
+
+        // 3e. Single batch ETH transaction for all vaults.
         setCurrentStep(DepositFlowStep.SUBMIT_PEGIN);
         const batchRegistration = await registerPeginBatchAndWait({
           btcWalletProvider: confirmedBtcWallet,
@@ -439,37 +454,12 @@ export function useDepositFlow(
           }));
 
         // ========================================================================
-        // Step 4: Broadcast Pre-PegIn transaction to Bitcoin
-        // Broadcast immediately after ETH registration so the VP can verify
-        // the Pre-PegIn inputs on the Bitcoin network when it processes the
-        // Ethereum event. Nothing must throw between ETH registration and
-        // this broadcast — otherwise the VP has the event but no BTC tx.
-        // ========================================================================
-
-        setCurrentStep(DepositFlowStep.BROADCAST_PRE_PEGIN);
-
-        try {
-          await broadcastPrePeginTransaction({
-            unsignedTxHex: batchResult.fundedPrePeginTxHex,
-            btcWalletProvider: {
-              signPsbt: (psbtHex: string) =>
-                confirmedBtcWallet.signPsbt(psbtHex),
-            },
-            depositorBtcPubkey: batchResult.depositorBtcPubkey,
-            expectedUtxos: utxosToExpectedRecord(batchResult.selectedUTXOs),
-          });
-        } catch (error) {
-          const errorMsg =
-            error instanceof Error ? error.message : String(error);
-          throw new Error(
-            `Failed to broadcast batch Pre-PegIn transaction: ${errorMsg}`,
-          );
-        }
-
-        // ========================================================================
-        // Step 4b: Save Pegins to Storage
-        // Saved after both ETH registration and BTC broadcast succeed, so
-        // localStorage never contains ghost entries for un-broadcast pegins.
+        // Step 4: Persist pending pegins BEFORE broadcast
+        // Saved immediately after ETH registration so the selected UTXOs are
+        // reserved even if broadcast fails. Status is PENDING (not CONFIRMING)
+        // — the resume flow will show a "Broadcast" button for these entries.
+        // This prevents the race condition where a failed broadcast leaves
+        // no localStorage record, causing UTXOs to be reused in a new deposit.
         // ========================================================================
 
         for (const peginResult of peginResults) {
@@ -498,7 +488,7 @@ export function useDepositFlow(
             batchId,
             batchIndex: peginResult.vaultIndex + 1,
             batchTotal: vaultAmounts.length,
-            status: LocalStorageStatus.CONFIRMING,
+            status: LocalStorageStatus.PENDING,
             unsignedTxHex: peginResult.fundedPrePeginTxHex,
             selectedUTXOs: peginResult.selectedUTXOs.map((u) => ({
               txid: u.txid,
@@ -515,6 +505,42 @@ export function useDepositFlow(
               confirmedEthAddress,
             );
           }
+        }
+
+        // ========================================================================
+        // Step 4b: Broadcast Pre-PegIn transaction to Bitcoin
+        // Broadcast immediately after ETH registration so the VP can verify
+        // the Pre-PegIn inputs on the Bitcoin network when it processes the
+        // Ethereum event.
+        // ========================================================================
+
+        setCurrentStep(DepositFlowStep.BROADCAST_PRE_PEGIN);
+
+        try {
+          await broadcastPrePeginTransaction({
+            unsignedTxHex: batchResult.fundedPrePeginTxHex,
+            btcWalletProvider: {
+              signPsbt: (psbtHex: string) =>
+                confirmedBtcWallet.signPsbt(psbtHex),
+            },
+            depositorBtcPubkey: batchResult.depositorBtcPubkey,
+            expectedUtxos: utxosToExpectedRecord(batchResult.selectedUTXOs),
+          });
+        } catch (error) {
+          const errorMsg =
+            error instanceof Error ? error.message : String(error);
+          throw new Error(
+            `Failed to broadcast batch Pre-PegIn transaction: ${errorMsg}`,
+          );
+        }
+
+        // Broadcast succeeded — update pending pegins from PENDING to CONFIRMING
+        for (const peginResult of peginResults) {
+          updatePendingPeginStatus(
+            confirmedEthAddress,
+            peginResult.vaultId,
+            LocalStorageStatus.CONFIRMING,
+          );
         }
 
         // All vaults share the same Pre-PegIn tx — if broadcast succeeded,

--- a/services/vault/src/hooks/deposit/useDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useDepositFlow.ts
@@ -12,8 +12,11 @@
  * 3a. Derive WOTS public keys for all vaults
  * 3b. Sign BIP-322 proof-of-possession (one wallet popup per deposit session)
  * 3c. Build batch request array
- * 3d. Batch ETH registration (single submitPeginRequestBatch tx for all vaults)
- * 4. Broadcast Pre-PegIn transaction to Bitcoin + save to localStorage (CONFIRMING)
+ * 3d. Re-check UTXO availability before committing to ETH
+ * 3e. Batch ETH registration (single submitPeginRequestBatch tx for all vaults)
+ * 3f. Build pegin results from batch response
+ * 4a. Save pending pegins to localStorage (PENDING status, reserves UTXOs)
+ * 4b. Broadcast Pre-PegIn transaction to Bitcoin, update status to CONFIRMING
  * 5. Submit WOTS keys, poll VP, sign payout transactions
  * 6. Download vault artifacts (per vault, user-driven)
  * 7. Wait for contract verification, then activate vaults (reveal HTLC secret)
@@ -438,7 +441,7 @@ export function useDepositFlow(
           popSignature,
         });
 
-        // 3d. Build pegin results from batch response
+        // 3f. Build pegin results from batch response
         const peginResults: PeginCreationResult[] =
           batchRegistration.vaults.map((vault, i) => ({
             vaultIndex: i,
@@ -454,7 +457,7 @@ export function useDepositFlow(
           }));
 
         // ========================================================================
-        // Step 4: Persist pending pegins BEFORE broadcast
+        // Step 4a: Persist pending pegins BEFORE broadcast
         // Saved immediately after ETH registration so the selected UTXOs are
         // reserved even if broadcast fails. Status is PENDING (not CONFIRMING)
         // — the resume flow will show a "Broadcast" button for these entries.
@@ -499,11 +502,25 @@ export function useDepositFlow(
           });
 
           if (mnemonicId) {
-            linkPeginToMnemonic(
-              peginResult.peginTxHash,
-              mnemonicId,
-              confirmedEthAddress,
-            );
+            try {
+              linkPeginToMnemonic(
+                peginResult.peginTxHash,
+                mnemonicId,
+                confirmedEthAddress,
+              );
+            } catch (linkError) {
+              // Best-effort: mnemonic link is recoverable (VP rejects wrong
+              // key, user can re-derive). Must not block broadcast.
+              logger.warn(
+                "[deposit] Failed to link pegin to mnemonic, continuing with broadcast",
+                {
+                  data: {
+                    peginTxHash: peginResult.peginTxHash,
+                    error: linkError,
+                  },
+                },
+              );
+            }
           }
         }
 


### PR DESCRIPTION
Addresses audit v2 findings ([vault-provider-proxy#124](https://github.com/babylonlabs-io/vault-provider-proxy/issues/124), [#126](https://github.com/babylonlabs-io/vault-provider-proxy/issues/126), [#140](https://github.com/babylonlabs-io/vault-provider-proxy/issues/140)).

### Problem

Three UTXO-handling gaps in the deposit flow could cause users to pay Ethereum gas for deposits whose Bitcoin transaction can never be broadcast:

1. **Duplicate UTXOs not rejected (MEDIUM):** `selectUtxosForPegin()` accepted duplicate `txid:vout` entries from the UTXO source without validation. A buggy or compromised mempool/indexer could produce an invalid Bitcoin transaction with duplicate inputs — discovered only after ETH registration has already consumed gas.

2. **UTXO race condition (MEDIUM):** The initial deposit flow selected UTXOs from a cached list, registered vaults on Ethereum, and only then broadcast the Bitcoin transaction. If UTXOs were spent between selection and broadcast (e.g. from another tab), ETH registration succeeded but BTC broadcast failed. Worse, the pending pegin was only saved to localStorage *after* broadcast, so the failed attempt's UTXOs were never reserved — allowing them to be reused in subsequent deposits.

3. **No HTLC dust threshold (LOW):** Per-vault amounts in a multi-vault split were validated against `minDeposit` but not against Bitcoin's effective dust threshold for HTLC outputs. While `minDeposit` is orders of magnitude above dust in practice, a misconfigured on-chain parameter could produce unrelayable outputs.

### Solution

**[Issue #124](https://github.com/babylonlabs-io/vault-provider-proxy/issues/124) — Duplicate UTXO detection (belt and suspenders):**
- `selectUtxosForPegin()` now calls `assertNoDuplicateUtxos()` before processing, throwing on any duplicate `txid:vout` (case-insensitive)
- `validateUtxosAvailable()` now detects duplicate inputs in the built transaction, catching duplicates regardless of how the transaction was constructed

**[Issue #126](https://github.com/babylonlabs-io/vault-provider-proxy/issues/126) — UTXO race condition (two-part fix):**
- Added `assertUtxosAvailable()` call immediately before ETH registration — re-fetches UTXOs from the mempool API and verifies all selected inputs are still unspent. This catches the common case where UTXOs were spent during the PoP signing step
- Moved `addPendingPegin` to *before* broadcast with `PENDING` status (was after broadcast with `CONFIRMING`). After successful broadcast, updates to `CONFIRMING` via `updatePendingPeginStatus()`. This ensures:
  - UTXOs are reserved in localStorage even if broadcast fails
  - The resume flow shows a "Broadcast" button for registered-but-unbroadcast vaults (existing state machine already handles `PENDING` status correctly)

**[Issue #140](https://github.com/babylonlabs-io/vault-provider-proxy/issues/140) — HTLC dust threshold assertion:**
- Added `HTLC_EFFECTIVE_DUST_THRESHOLD = 2000n` constant (conservative estimate for HTLC script-path output dust)
- `computeOptimalSplit()` now throws if either non-zero vault amount falls below this threshold

Closes https://github.com/babylonlabs-io/vault-provider-proxy/issues/124
Closes https://github.com/babylonlabs-io/vault-provider-proxy/issues/126
Closes https://github.com/babylonlabs-io/vault-provider-proxy/issues/140