### PR TITLE
fix: refund modal

### DIFF
--- a/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts
@@ -39,7 +39,22 @@ const PUBKEY_HEX_RE = /^(?:0x)?(?:[0-9a-fA-F]{64}|[0-9a-fA-F]{66})$/;
 // input spending the HTLC refund leaf → 1 P2TR/P2WPKH output). Taproot
 // script-path witness: 64-byte Schnorr sig + refund script + control block.
 // This is protocol-owned knowledge; callers don't parameterise it.
-const REFUND_VSIZE = 160;
+export const REFUND_VSIZE = 160;
+
+/**
+ * Network fee (sats) the SDK will charge for a refund tx at the given
+ * sat/vB rate. Mirrors the internal computation in
+ * {@link buildAndBroadcastRefund} so callers (e.g. UI fee previews) don't
+ * have to duplicate the constant.
+ */
+export function estimateRefundFeeSats(feeRateSatsVb: number): bigint {
+  if (!Number.isFinite(feeRateSatsVb) || feeRateSatsVb <= 0) {
+    throw new Error(
+      `feeRateSatsVb must be a positive finite number, got ${feeRateSatsVb}`,
+    );
+  }
+  return BigInt(Math.ceil(feeRateSatsVb * REFUND_VSIZE));
+}
 // Refund tx has exactly one input — the HTLC output at htlcVout from the
 // Pre-PegIn tx. Used to tell the signer how many sign entries to generate.
 // (Not the taproot leaf index; the leaf is encoded into the PSBT by the

--- a/packages/babylon-ts-sdk/src/tbv/core/services/refund/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/refund/index.ts
@@ -7,6 +7,8 @@
 export { BIP68NotMatureError } from "./errors";
 export {
   buildAndBroadcastRefund,
+  estimateRefundFeeSats,
+  REFUND_VSIZE,
   type BtcBroadcastResult,
   type BtcBroadcaster,
   type RefundInput,

--- a/services/vault/src/clients/logo/__tests__/logoClient.test.ts
+++ b/services/vault/src/clients/logo/__tests__/logoClient.test.ts
@@ -42,13 +42,13 @@ describe("logoClient", () => {
 
     it("fetches logos from sidecar API with POST request", async () => {
       mockEnv.SIDECAR_API_URL = "https://sidecar-api.example.com";
-      const images = {
+      const mockResponse = {
         identity1: "https://s3-bucket/logo1.png",
         identity2: "https://s3-bucket/logo2.png",
       };
       mockFetch.mockResolvedValueOnce({
         ok: true,
-        json: () => Promise.resolve({ data: { images } }),
+        json: () => Promise.resolve(mockResponse),
       });
 
       const result = await fetchLogos(["identity1", "identity2"]);
@@ -63,7 +63,7 @@ describe("logoClient", () => {
           body: JSON.stringify({ identities: ["identity1", "identity2"] }),
         },
       );
-      expect(result).toEqual(images);
+      expect(result).toEqual(mockResponse);
     });
 
     it("returns empty object when API returns error", async () => {
@@ -92,38 +92,12 @@ describe("logoClient", () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: () =>
-          Promise.resolve({
-            data: { images: { identity1: "https://s3-bucket/logo1.png" } },
-          }),
+          Promise.resolve({ identity1: "https://s3-bucket/logo1.png" }),
       });
 
       const result = await fetchLogos(["identity1", "identity2"]);
 
       expect(result).toEqual({ identity1: "https://s3-bucket/logo1.png" });
-    });
-
-    it("returns empty object when sidecar returns an empty images map", async () => {
-      mockEnv.SIDECAR_API_URL = "https://sidecar-api.example.com";
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({ data: { images: {} } }),
-      });
-
-      const result = await fetchLogos(["identity1"]);
-
-      expect(result).toEqual({});
-    });
-
-    it("returns empty object when envelope is malformed", async () => {
-      mockEnv.SIDECAR_API_URL = "https://sidecar-api.example.com";
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({ unexpected: "shape" }),
-      });
-
-      const result = await fetchLogos(["identity1"]);
-
-      expect(result).toEqual({});
     });
   });
 });

--- a/services/vault/src/clients/logo/logoClient.ts
+++ b/services/vault/src/clients/logo/logoClient.ts
@@ -4,12 +4,6 @@ export interface LogoResponse {
   [identity: string]: string;
 }
 
-interface SidecarLogoEnvelope {
-  data?: {
-    images?: LogoResponse;
-  };
-}
-
 export async function fetchLogos(identities: string[]): Promise<LogoResponse> {
   if (!ENV.SIDECAR_API_URL || identities.length === 0) {
     return {};
@@ -28,8 +22,8 @@ export async function fetchLogos(identities: string[]): Promise<LogoResponse> {
       return {};
     }
 
-    const body: SidecarLogoEnvelope = await response.json();
-    return body.data?.images ?? {};
+    const data: LogoResponse = await response.json();
+    return data;
   } catch {
     return {};
   }

--- a/services/vault/src/components/deposit/DepositSignModal/StatusBanner.tsx
+++ b/services/vault/src/components/deposit/DepositSignModal/StatusBanner.tsx
@@ -1,13 +1,14 @@
 import { Text } from "@babylonlabs-io/core-ui";
 
 interface StatusBannerProps {
-  variant: "error" | "success";
+  variant: "error" | "success" | "warning";
   children: React.ReactNode;
 }
 
 const VARIANT_STYLES = {
   error: "bg-error-main/10 text-error-main",
   success: "bg-success-main/10 text-success-main",
+  warning: "bg-warning-main/10 text-warning-main",
 } as const;
 
 /**

--- a/services/vault/src/components/deposit/RefundModal/FeeRateField.tsx
+++ b/services/vault/src/components/deposit/RefundModal/FeeRateField.tsx
@@ -1,0 +1,91 @@
+import { Button, Input } from "@babylonlabs-io/core-ui";
+import { useEffect, useRef, useState } from "react";
+import { MdEdit } from "react-icons/md";
+
+interface FeeRateFieldProps {
+  value: number;
+  onChange: (next: number) => void;
+  disabled?: boolean;
+}
+
+export function FeeRateField({
+  value,
+  onChange,
+  disabled = false,
+}: FeeRateFieldProps) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState<string>(String(value));
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  // Pressing Enter calls commit(), then setEditing(false) unmounts the
+  // Input — the synthetic blur React fires would re-enter commit() with the
+  // same draft and re-fire onChange. Guard so commit() runs at most once
+  // per editing session.
+  const committedRef = useRef(false);
+
+  useEffect(() => {
+    if (!editing) setDraft(String(value));
+  }, [editing, value]);
+
+  useEffect(() => {
+    if (editing) {
+      committedRef.current = false;
+      inputRef.current?.focus();
+    }
+  }, [editing]);
+
+  const commit = () => {
+    if (committedRef.current) return;
+    committedRef.current = true;
+    const parsed = Number(draft);
+    if (Number.isFinite(parsed) && parsed > 0 && parsed !== value) {
+      onChange(parsed);
+    }
+    setEditing(false);
+  };
+
+  const cancel = () => {
+    committedRef.current = true;
+    setDraft(String(value));
+    setEditing(false);
+  };
+
+  if (editing) {
+    return (
+      <Input
+        ref={inputRef}
+        type="number"
+        min={0.1}
+        step={0.1}
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            commit();
+          } else if (e.key === "Escape") {
+            e.preventDefault();
+            cancel();
+          }
+        }}
+        suffix={<span className="text-sm text-accent-secondary">sats/vB</span>}
+        wrapperClassName="w-[140px]"
+        className="text-right"
+      />
+    );
+  }
+
+  return (
+    <Button
+      variant="ghost"
+      color="primary"
+      size="medium"
+      disabled={disabled}
+      onClick={() => setEditing(true)}
+      className="flex items-center gap-2 !px-2"
+    >
+      <span className="text-base text-accent-primary">{value} sats/vB</span>
+      <MdEdit className="text-accent-secondary" aria-hidden="true" size={16} />
+    </Button>
+  );
+}

--- a/services/vault/src/components/deposit/RefundModal/RefundReviewContent.tsx
+++ b/services/vault/src/components/deposit/RefundModal/RefundReviewContent.tsx
@@ -1,0 +1,265 @@
+import { Button, Heading, Loader, Text } from "@babylonlabs-io/core-ui";
+import { useEffect, useState } from "react";
+import { MdInfoOutline } from "react-icons/md";
+
+import { StatusBanner } from "@/components/deposit/DepositSignModal/StatusBanner";
+import {
+  BTC_BLOCK_TIME_MINS,
+  FALLBACK_FEE_RATE_SATS_VB,
+  MINS_PER_HOUR,
+} from "@/constants";
+import { useProtocolParamsContext } from "@/context/ProtocolParamsContext";
+import { usePrice } from "@/hooks/usePrices";
+import { getRefundNetworkFeeSats } from "@/services/vault/vaultRefundService";
+import { satoshiToBtcNumber } from "@/utils/btcConversion";
+import { formatBtcValue, formatUsd, getBtcSymbol } from "@/utils/formatting";
+
+import { FeeRateField } from "./FeeRateField";
+
+// Bitcoin policy dust limit, set above taproot's ~330-sat floor so it also
+// covers P2WPKH refund destinations.
+const DUST_LIMIT_SATS = 546n;
+
+interface RefundReviewContentProps {
+  amountSats: bigint | null;
+  defaultFeeRateSatsVb: number | null;
+  previewLoading: boolean;
+  previewError: string | null;
+  refunding: boolean;
+  error: string | null;
+  onConfirm: (feeRate: number) => void;
+}
+
+export function RefundReviewContent({
+  amountSats,
+  defaultFeeRateSatsVb,
+  previewLoading,
+  previewError,
+  refunding,
+  error,
+  onConfirm,
+}: RefundReviewContentProps) {
+  const btcPriceUSD = usePrice("BTC");
+  const symbol = getBtcSymbol();
+  const { timelockRefund } = useProtocolParamsContext();
+  const estimatedHours = Math.ceil(
+    (timelockRefund * BTC_BLOCK_TIME_MINS) / MINS_PER_HOUR,
+  );
+
+  const [feeRate, setFeeRate] = useState<number | null>(null);
+  // True when the seeded feeRate came from the hard-coded floor because the
+  // mempool fee endpoint failed. Confirm is gated until the user either acks
+  // by editing the field or the mempool rate arrives.
+  const [usingFallback, setUsingFallback] = useState(false);
+
+  useEffect(() => {
+    if (feeRate !== null) return;
+    if (defaultFeeRateSatsVb && defaultFeeRateSatsVb > 0) {
+      setFeeRate(defaultFeeRateSatsVb);
+      setUsingFallback(false);
+      return;
+    }
+    if (!previewLoading) {
+      setFeeRate(FALLBACK_FEE_RATE_SATS_VB);
+      setUsingFallback(true);
+    }
+  }, [defaultFeeRateSatsVb, feeRate, previewLoading]);
+
+  const handleFeeRateChange = (next: number) => {
+    setFeeRate(next);
+    setUsingFallback(false);
+  };
+
+  const amountBtc = amountSats !== null ? satoshiToBtcNumber(amountSats) : null;
+  const networkFeeSats =
+    feeRate !== null && feeRate > 0 ? getRefundNetworkFeeSats(feeRate) : null;
+  const networkFeeBtc =
+    networkFeeSats !== null ? satoshiToBtcNumber(networkFeeSats) : null;
+  const youReceiveSats =
+    amountSats !== null && networkFeeSats !== null
+      ? amountSats - networkFeeSats
+      : null;
+  // Clamp at zero so a fee rate above the deposit doesn't render a
+  // confusing negative BTC value; Confirm is gated below by the dust check.
+  const youReceiveBtc =
+    youReceiveSats !== null
+      ? satoshiToBtcNumber(youReceiveSats > 0n ? youReceiveSats : 0n)
+      : null;
+
+  const isDust = youReceiveSats !== null && youReceiveSats <= DUST_LIMIT_SATS;
+
+  const canConfirm =
+    !refunding &&
+    !previewLoading &&
+    feeRate !== null &&
+    feeRate > 0 &&
+    youReceiveSats !== null &&
+    !isDust &&
+    !usingFallback;
+
+  const handleConfirmClick = () => {
+    if (feeRate === null || feeRate <= 0) return;
+    onConfirm(feeRate);
+  };
+
+  return (
+    <div className="mx-auto w-full max-w-[540px]">
+      <div className="rounded-t-2xl border border-b-0 border-secondary-strokeLight bg-surface p-6">
+        <Heading variant="h5" className="text-accent-primary">
+          Review Refund
+        </Heading>
+      </div>
+
+      <div className="rounded-b-2xl border border-secondary-strokeLight bg-surface p-6">
+        <div className="flex flex-col gap-4">
+          <DetailRow
+            label="Refund Amount"
+            primary={
+              amountBtc !== null
+                ? `${formatBtcValue(amountBtc)} ${symbol}`
+                : "—"
+            }
+            secondary={
+              amountBtc !== null && btcPriceUSD > 0
+                ? `${formatUsd(amountBtc * btcPriceUSD)} USD`
+                : undefined
+            }
+          />
+
+          <DetailRow
+            label="Network Fee Rate"
+            primaryNode={
+              feeRate !== null ? (
+                <FeeRateField
+                  value={feeRate}
+                  onChange={handleFeeRateChange}
+                  disabled={refunding}
+                />
+              ) : (
+                <span className="text-base text-accent-secondary">—</span>
+              )
+            }
+          />
+
+          <DetailRow
+            label="BTC Network Fee"
+            primary={
+              networkFeeBtc !== null
+                ? `${formatBtcValue(networkFeeBtc)} ${symbol}`
+                : "—"
+            }
+            secondary={
+              networkFeeBtc !== null && btcPriceUSD > 0
+                ? `${formatUsd(networkFeeBtc * btcPriceUSD)} USD`
+                : undefined
+            }
+          />
+
+          <div className="my-1 border-t border-secondary-strokeLight" />
+
+          <DetailRow
+            label="You'll receive"
+            primary={
+              youReceiveBtc !== null
+                ? `${formatBtcValue(youReceiveBtc)} ${symbol}`
+                : "—"
+            }
+            secondary={
+              youReceiveBtc !== null && btcPriceUSD > 0
+                ? `${formatUsd(youReceiveBtc * btcPriceUSD)} USD`
+                : undefined
+            }
+            emphasis
+          />
+
+          <div className="flex items-center gap-2 rounded-lg border border-secondary-strokeLight px-4 py-2">
+            <MdInfoOutline
+              className="shrink-0 text-accent-secondary"
+              size={18}
+              aria-hidden="true"
+            />
+            <Text variant="body2" className="text-accent-secondary">
+              Refund arrives within the Bitcoin challenge period — approximately{" "}
+              {estimatedHours} hours after the transaction is confirmed.
+            </Text>
+          </div>
+
+          {previewError && (
+            <StatusBanner variant="error">{previewError}</StatusBanner>
+          )}
+          {!error && !isDust && usingFallback && (
+            <StatusBanner variant="warning">
+              Could not fetch the mempool fee rate. The minimum relay fee may
+              not get your refund confirmed. Set a fee rate above to continue.
+            </StatusBanner>
+          )}
+          {!error && isDust && (
+            <StatusBanner variant="error">
+              Network fee is too high — your refund would be below the Bitcoin
+              dust limit. Lower the fee rate to continue.
+            </StatusBanner>
+          )}
+          {error && <StatusBanner variant="error">{error}</StatusBanner>}
+
+          <Button
+            variant="contained"
+            color="secondary"
+            className="w-full"
+            onClick={handleConfirmClick}
+            disabled={!canConfirm}
+          >
+            {refunding ? (
+              <span className="flex items-center justify-center gap-2">
+                <Loader size={16} className="text-accent-contrast" />
+                <span>Confirming…</span>
+              </span>
+            ) : error ? (
+              "Retry"
+            ) : (
+              "Confirm"
+            )}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface DetailRowProps {
+  label: string;
+  primary?: string;
+  primaryNode?: React.ReactNode;
+  secondary?: string;
+  emphasis?: boolean;
+}
+
+function DetailRow({
+  label,
+  primary,
+  primaryNode,
+  secondary,
+  emphasis = false,
+}: DetailRowProps) {
+  return (
+    <div className="flex items-start justify-between gap-6">
+      <Text
+        variant="body1"
+        className={emphasis ? "text-accent-primary" : "text-accent-secondary"}
+      >
+        {label}
+      </Text>
+      <div className="flex flex-col items-end">
+        {primaryNode ?? (
+          <Text variant="body1" className="text-right text-accent-primary">
+            {primary}
+          </Text>
+        )}
+        {secondary && (
+          <Text variant="body2" className="text-right text-accent-disabled">
+            {secondary}
+          </Text>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/services/vault/src/components/deposit/RefundModal/RefundSuccessContent.tsx
+++ b/services/vault/src/components/deposit/RefundModal/RefundSuccessContent.tsx
@@ -1,0 +1,69 @@
+import { Button, Heading, Text } from "@babylonlabs-io/core-ui";
+
+import { getNetworkConfigBTC } from "@/config";
+import { getBtcSymbol } from "@/utils/formatting";
+
+const btcConfig = getNetworkConfigBTC();
+
+interface RefundSuccessContentProps {
+  refundTxId: string;
+  onDone: () => void;
+}
+
+export function RefundSuccessContent({
+  refundTxId,
+  onDone,
+}: RefundSuccessContentProps) {
+  const explorerUrl = `${btcConfig.mempoolApiUrl}/tx/${refundTxId}`;
+  const btcSymbol = getBtcSymbol();
+
+  return (
+    <div className="mx-auto flex w-full max-w-[564px] flex-col gap-10 rounded-3xl border border-secondary-strokeLight bg-surface px-6 pb-6 pt-10">
+      <div className="flex flex-col items-center gap-6">
+        <img
+          src={btcConfig.icon}
+          alt={btcConfig.name}
+          className="h-[100px] w-[100px]"
+        />
+        <div className="flex w-full flex-col items-center gap-4 text-center">
+          <Heading variant="h5" className="text-accent-primary">
+            Broadcasting Refund
+          </Heading>
+          <Text variant="body1" className="text-accent-secondary">
+            Refund transaction broadcast successfully.
+          </Text>
+        </div>
+      </div>
+
+      <div className="flex flex-col items-center gap-4">
+        <div className="flex w-full gap-4">
+          <Button
+            variant="outlined"
+            color="primary"
+            className="flex-1 whitespace-nowrap"
+            onClick={() => {
+              window.open(explorerUrl, "_blank", "noopener,noreferrer");
+            }}
+          >
+            View on Blockchain explorer
+          </Button>
+          <Button
+            variant="contained"
+            color="secondary"
+            className="flex-1 whitespace-nowrap"
+            onClick={onDone}
+          >
+            Done
+          </Button>
+        </div>
+        <Text
+          variant="body2"
+          className="text-center text-xs text-accent-secondary"
+        >
+          Do not spend the {btcSymbol} used for this deposit until the
+          transactions are confirmed
+        </Text>
+      </div>
+    </div>
+  );
+}

--- a/services/vault/src/components/deposit/RefundModal/index.tsx
+++ b/services/vault/src/components/deposit/RefundModal/index.tsx
@@ -1,0 +1,80 @@
+import { FullScreenDialog } from "@babylonlabs-io/core-ui";
+import { useQuery } from "@tanstack/react-query";
+
+import { useRefundState } from "@/hooks/deposit/useRefundState";
+import { getRefundPreview } from "@/services/vault/vaultRefundService";
+import type { VaultActivity } from "@/types/activity";
+
+import { RefundReviewContent } from "./RefundReviewContent";
+import { RefundSuccessContent } from "./RefundSuccessContent";
+
+interface RefundModalProps {
+  open: boolean;
+  activity: VaultActivity;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+const REFUND_PREVIEW_QUERY_KEY = "REFUND_PREVIEW";
+
+export function RefundModal({
+  open,
+  activity,
+  onClose,
+  onSuccess,
+}: RefundModalProps) {
+  const { refunding, refundTxId, error, handleRefund } = useRefundState({
+    activity,
+  });
+
+  const previewQuery = useQuery({
+    queryKey: [REFUND_PREVIEW_QUERY_KEY, activity.id],
+    queryFn: () => getRefundPreview(activity.id),
+    enabled: open && !refundTxId,
+    staleTime: 60_000,
+  });
+
+  const previewError = previewQuery.error
+    ? previewQuery.error instanceof Error
+      ? previewQuery.error.message
+      : "Failed to load refund preview"
+    : null;
+
+  // Fire onSuccess only after the user acknowledges the result so the parent
+  // refetch doesn't race the success modal.
+  if (refundTxId) {
+    const handleDone = () => {
+      onSuccess();
+      onClose();
+    };
+    return (
+      <FullScreenDialog
+        open={open}
+        onClose={handleDone}
+        className="items-center justify-center p-6"
+      >
+        <RefundSuccessContent refundTxId={refundTxId} onDone={handleDone} />
+      </FullScreenDialog>
+    );
+  }
+
+  // Block close while a broadcast is in flight to avoid dismissing the dialog
+  // mid-signing.
+  return (
+    <FullScreenDialog
+      open={open}
+      onClose={refunding ? undefined : onClose}
+      className="items-center justify-center p-6"
+    >
+      <RefundReviewContent
+        amountSats={previewQuery.data?.amountSats ?? null}
+        defaultFeeRateSatsVb={previewQuery.data?.halfHourFeeSatsVb ?? null}
+        previewLoading={previewQuery.isLoading}
+        previewError={previewError}
+        refunding={refunding}
+        error={error}
+        onConfirm={handleRefund}
+      />
+    </FullScreenDialog>
+  );
+}

--- a/services/vault/src/components/simple/PendingDepositModals.tsx
+++ b/services/vault/src/components/simple/PendingDepositModals.tsx
@@ -8,6 +8,7 @@
 import type { Hex } from "viem";
 
 import { BroadcastSuccessModal } from "@/components/deposit/BroadcastSuccessModal";
+import { RefundModal } from "@/components/deposit/RefundModal";
 import { usePeginPolling } from "@/context/deposit/PeginPollingContext";
 import type { SignModalData } from "@/hooks/deposit/usePayoutSignModal";
 import type { VaultActivity } from "@/types/activity";
@@ -132,12 +133,11 @@ export function PendingDepositModals({
 
       {/* Refund Modal */}
       {refundModal.refundingActivity && (
-        <SimpleDeposit
+        <RefundModal
           open={!!refundModal.refundingActivity}
-          resumeMode="refund_htlc"
-          onClose={refundModal.handleClose}
-          onResumeSuccess={refundModal.handleSuccess}
           activity={refundModal.refundingActivity}
+          onClose={refundModal.handleClose}
+          onSuccess={refundModal.handleSuccess}
         />
       )}
 

--- a/services/vault/src/components/simple/ResumeDepositContent.tsx
+++ b/services/vault/src/components/simple/ResumeDepositContent.tsx
@@ -32,7 +32,6 @@ import { usePayoutSigningState } from "@/components/deposit/PayoutSignModal/useP
 import { submitWotsPublicKey } from "@/hooks/deposit/depositFlowSteps/wotsSubmission";
 import { useActivationState } from "@/hooks/deposit/useActivationState";
 import { useBroadcastState } from "@/hooks/deposit/useBroadcastState";
-import { useRefundState } from "@/hooks/deposit/useRefundState";
 import { useRunOnce } from "@/hooks/useRunOnce";
 import type { VaultActivity } from "@/types/activity";
 import { parseFundingOutpointsFromTx } from "@/utils/parseFundingOutpoints";
@@ -395,63 +394,6 @@ export function ResumeActivationContent({
       onClose={onClose}
       successMessage="Your vault has been activated. The vault provider can now claim the HTLC on Bitcoin."
       onRetry={error ? handleSubmit : undefined}
-    />
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Refund HTLC Content
-// ---------------------------------------------------------------------------
-
-export interface ResumeRefundContentProps {
-  activity: VaultActivity;
-  onClose: () => void;
-  onSuccess: () => void;
-}
-
-export function ResumeRefundContent({
-  activity,
-  onClose,
-  onSuccess,
-}: ResumeRefundContentProps) {
-  const { refunding, refundTxId, error, handleRefund } = useRefundState({
-    activity,
-  });
-
-  useRunOnce(handleRefund);
-
-  const hasSucceeded = !!refundTxId && !refunding;
-  const isComplete = hasSucceeded;
-  const canClose = hasSucceeded || !!error;
-  const isProcessing = refunding && !error;
-
-  // When the refund succeeds, the user closes the dialog themselves after
-  // seeing the confirmation. We call onSuccess() at that point so the parent
-  // refetches activities only after the user has acknowledged the result.
-  const handleClose = () => {
-    if (isComplete) {
-      onSuccess();
-    }
-    onClose();
-  };
-
-  return (
-    <DepositProgressView
-      currentStep={DepositFlowStep.BROADCAST_PRE_PEGIN}
-      isWaiting={false}
-      error={error}
-      isComplete={isComplete}
-      isProcessing={isProcessing}
-      canClose={canClose}
-      canContinueInBackground={false}
-      payoutSigningProgress={null}
-      onClose={handleClose}
-      successMessage={
-        refundTxId
-          ? `Refund transaction broadcast successfully. Transaction ID: ${refundTxId}`
-          : "Your refund transaction has been broadcast to Bitcoin."
-      }
-      onRetry={error ? handleRefund : undefined}
     />
   );
 }

--- a/services/vault/src/components/simple/SimpleDeposit.tsx
+++ b/services/vault/src/components/simple/SimpleDeposit.tsx
@@ -23,7 +23,6 @@ import { FadeTransition } from "./FadeTransition";
 import {
   ResumeActivationContent,
   ResumeBroadcastContent,
-  ResumeRefundContent,
   ResumeSignContent,
   ResumeWotsContent,
 } from "./ResumeDepositContent";
@@ -72,19 +71,12 @@ type ResumeActivationProps = SimpleDepositBaseProps & {
   onResumeSuccess: () => void;
 };
 
-type ResumeRefundProps = SimpleDepositBaseProps & {
-  resumeMode: "refund_htlc";
-  activity: VaultActivity;
-  onResumeSuccess: () => void;
-};
-
 export type SimpleDepositProps =
   | NewDepositProps
   | ResumeSignProps
   | ResumeBroadcastProps
   | ResumeWotsProps
-  | ResumeActivationProps
-  | ResumeRefundProps;
+  | ResumeActivationProps;
 
 // ---------------------------------------------------------------------------
 // New deposit flow content (form → sign → success)
@@ -363,24 +355,6 @@ export default function SimpleDeposit(props: SimpleDepositProps) {
             </div>
           </FullScreenDialog>
         </ProtocolParamsProvider>
-      );
-    }
-
-    if (resumeMode === "refund_htlc") {
-      return (
-        <FullScreenDialog
-          open={open}
-          onClose={onClose}
-          className="items-center justify-center p-6"
-        >
-          <div className="mx-auto w-full max-w-[520px]">
-            <ResumeRefundContent
-              activity={props.activity}
-              onClose={onClose}
-              onSuccess={props.onResumeSuccess}
-            />
-          </div>
-        </FullScreenDialog>
       );
     }
 

--- a/services/vault/src/components/simple/WithdrawFlow/WithdrawProgressView.tsx
+++ b/services/vault/src/components/simple/WithdrawFlow/WithdrawProgressView.tsx
@@ -1,12 +1,9 @@
 import { Button, Heading, Text } from "@babylonlabs-io/core-ui";
 
+import { BTC_BLOCK_TIME_MINS, MINS_PER_HOUR } from "@/constants";
 import { useProtocolParamsContext } from "@/context/ProtocolParamsContext";
 
 import { NominatedAddressValue } from "./NominatedAddressValue";
-
-/** Average Bitcoin block time in minutes */
-const BTC_BLOCK_TIME_MINS = 10;
-const MINS_PER_HOUR = 60;
 
 interface WithdrawProgressViewProps {
   /**

--- a/services/vault/src/constants.ts
+++ b/services/vault/src/constants.ts
@@ -28,3 +28,8 @@ export const MAX_UINT256 = 2n ** 256n - 1n;
 export const REPLAYS_ON_ERROR_RATE = Number.parseFloat(
   process.env.NEXT_PUBLIC_REPLAYS_RATE ?? "0.05",
 );
+
+// Bitcoin protocol constants
+export const BTC_BLOCK_TIME_MINS = 10;
+export const MINS_PER_HOUR = 60;
+export const FALLBACK_FEE_RATE_SATS_VB = 1;

--- a/services/vault/src/context/deposit/PeginPollingContext.tsx
+++ b/services/vault/src/context/deposit/PeginPollingContext.tsx
@@ -50,6 +50,22 @@ function resolveLocalStatus(
   return (optimistic ?? pendingPegin?.status) as LocalStorageStatus | undefined;
 }
 
+/**
+ * Resolve the broadcast timestamp anchoring the REFUND_BROADCAST suppression
+ * TTL. Falls back to the optimistic timestamp set right after broadcast (when
+ * localStorage has not yet been read back into `pendingPegins`).
+ */
+function resolveRefundBroadcastAt(
+  depositId: string,
+  optimisticRefundBroadcastAt: Map<string, number>,
+  pendingPegins: Array<{ id: string; refundBroadcastAt?: number }>,
+): number | undefined {
+  return (
+    optimisticRefundBroadcastAt.get(depositId) ??
+    pendingPegins.find((p) => p.id === depositId)?.refundBroadcastAt
+  );
+}
+
 const PeginPollingContext = createContext<PeginPollingContextValue | null>(
   null,
 );
@@ -70,6 +86,10 @@ export function PeginPollingProvider({
   const [optimisticStatuses, setOptimisticStatuses] = useState<
     Map<string, LocalStorageStatus>
   >(new Map());
+  // Companion timestamp for REFUND_BROADCAST so the suppression TTL is honored
+  // immediately, before localStorage is read back.
+  const [optimisticRefundBroadcastAt, setOptimisticRefundBroadcastAt] =
+    useState<Map<string, number>>(new Map());
 
   // Use the polling query hook
   const {
@@ -88,18 +108,34 @@ export function PeginPollingProvider({
 
   // Optimistic status handlers
   const setOptimisticStatus = useCallback(
-    (depositId: string, newStatus: LocalStorageStatus) => {
+    (
+      depositId: string,
+      newStatus: LocalStorageStatus,
+      refundBroadcastAt?: number,
+    ) => {
       setOptimisticStatuses((prev) => {
         const next = new Map(prev);
         next.set(depositId, newStatus);
         return next;
       });
+      if (refundBroadcastAt !== undefined) {
+        setOptimisticRefundBroadcastAt((prev) => {
+          const next = new Map(prev);
+          next.set(depositId, refundBroadcastAt);
+          return next;
+        });
+      }
     },
     [],
   );
 
   const clearOptimisticStatus = useCallback((depositId: string) => {
     setOptimisticStatuses((prev) => {
+      const next = new Map(prev);
+      next.delete(depositId);
+      return next;
+    });
+    setOptimisticRefundBroadcastAt((prev) => {
       const next = new Map(prev);
       next.delete(depositId);
       return next;
@@ -116,6 +152,11 @@ export function PeginPollingProvider({
       const localStatus = resolveLocalStatus(
         depositId,
         optimisticStatuses,
+        pendingPegins,
+      );
+      const refundBroadcastAt = resolveRefundBroadcastAt(
+        depositId,
+        optimisticRefundBroadcastAt,
         pendingPegins,
       );
 
@@ -138,6 +179,7 @@ export function PeginPollingProvider({
         expiredAt: activity.expiredAt,
         canRefund: !!activity.unsignedPrePeginTx,
         vpTerminalError,
+        refundBroadcastAt,
       });
 
       return {
@@ -164,6 +206,7 @@ export function PeginPollingProvider({
       pendingIngestion,
       isLoading,
       optimisticStatuses,
+      optimisticRefundBroadcastAt,
       btcPublicKey,
     ],
   );

--- a/services/vault/src/hooks/deposit/useRefundState.ts
+++ b/services/vault/src/hooks/deposit/useRefundState.ts
@@ -1,8 +1,12 @@
 import { useChainConnector } from "@babylonlabs-io/wallet-connector";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
+import { usePeginPolling } from "@/context/deposit/PeginPollingContext";
+import { useETHWallet } from "@/context/wallet";
 import { logger } from "@/infrastructure";
+import { LocalStorageStatus } from "@/models/peginStateMachine";
 import { buildAndBroadcastRefundTransaction } from "@/services/vault/vaultRefundService";
+import { usePeginStorage } from "@/storage/usePeginStorage";
 import type { VaultActivity } from "@/types/activity";
 
 export interface UseRefundStateProps {
@@ -10,73 +14,167 @@ export interface UseRefundStateProps {
 }
 
 export interface UseRefundStateResult {
-  /** Whether a refund broadcast is in progress */
   refunding: boolean;
-  /** Broadcasted refund transaction ID on success */
   refundTxId: string | null;
-  /** Error message if refund failed */
   error: string | null;
-  /** Handler to initiate refund */
-  handleRefund: () => Promise<void>;
+  handleRefund: (feeRate: number) => Promise<void>;
 }
+
+const EMPTY_CONFIRMED: VaultActivity[] = [];
 
 export function useRefundState({
   activity,
 }: UseRefundStateProps): UseRefundStateResult {
   const btcConnector = useChainConnector("BTC");
   const btcWalletProvider = btcConnector?.connectedWallet?.provider;
+  const { address: ethAddress } = useETHWallet();
+  const { setOptimisticStatus } = usePeginPolling();
+  const { pendingPegins, addPendingPegin, markRefundBroadcast } =
+    usePeginStorage({
+      ethAddress: ethAddress ?? "",
+      confirmedPegins: EMPTY_CONFIRMED,
+    });
+
   const [refunding, setRefunding] = useState(false);
   const [refundTxId, setRefundTxId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  // Destructure stable primitives to avoid re-creating handleRefund on every render
-  const { id: vaultId } = activity;
-
-  const handleRefund = useCallback(async () => {
-    if (!btcWalletProvider) {
-      setError("BTC wallet not connected");
-      return;
+  // Synchronous reentrancy guard. `refunding` updates async; rapid double-
+  // confirms before the next render could both pass the state check and
+  // race two wallet prompts.
+  const inFlightRef = useRef(false);
+  // Abort the in-flight refund if the hook unmounts (e.g. user closes the
+  // modal mid-wallet-prompt) so we don't broadcast/resolve against an
+  // unmounted component. Defer the abort one tick so React StrictMode's
+  // mount→cleanup→remount doesn't kill the controller we just created.
+  const abortRef = useRef<AbortController | null>(null);
+  const pendingAbortRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    if (pendingAbortRef.current !== null) {
+      clearTimeout(pendingAbortRef.current);
+      pendingAbortRef.current = null;
     }
-    if (!vaultId) {
-      setError("Missing vault ID");
-      return;
-    }
+    return () => {
+      pendingAbortRef.current = setTimeout(() => {
+        abortRef.current?.abort();
+        pendingAbortRef.current = null;
+      }, 0);
+    };
+  }, []);
 
-    setRefunding(true);
-    setError(null);
+  const {
+    id: vaultId,
+    peginTxHash,
+    unsignedPrePeginTx,
+    collateral,
+    providers,
+    applicationEntryPoint,
+  } = activity;
 
-    try {
-      // Fetch the pubkey live from the wallet (not from storage). The
-      // wallet's signPsbt signInputs[].publicKey requires the wallet's
-      // native format (typically compressed 33-byte sec1), and the
-      // stored activity holds the canonical x-only form used for
-      // on-chain/indexer identification.
-      const depositorBtcPubkey = await btcWalletProvider.getPublicKeyHex();
-      const txId = await buildAndBroadcastRefundTransaction({
-        vaultId,
-        btcWalletProvider,
-        depositorBtcPubkey,
-      });
-      setRefundTxId(txId);
-      setRefunding(false);
-      // onSuccess() is intentionally NOT called here.
-      // The success screen displays the txId and lets the user close the dialog.
-      // onSuccess() is called from ResumeRefundContent's onClose so the parent
-      // refetches activities only after the user has seen the confirmation.
-    } catch (err) {
-      logger.error(err instanceof Error ? err : new Error(String(err)), {
-        data: { context: "Refund failed", vaultId },
-      });
-      const message =
-        err instanceof Error ? err.message : "Refund transaction failed";
-      setError(
-        message.includes("non-BIP68-final")
-          ? "The Bitcoin timelock has not expired yet. Your refund will be available once enough blocks have been mined since the deposit transaction. Please try again later."
-          : message,
-      );
-      setRefunding(false);
-    }
-  }, [vaultId, btcWalletProvider]);
+  const handleRefund = useCallback(
+    async (feeRate: number) => {
+      if (inFlightRef.current || refunding) return;
+      inFlightRef.current = true;
+
+      try {
+        if (!btcWalletProvider) {
+          setError("BTC wallet not connected");
+          return;
+        }
+        if (!vaultId) {
+          setError("Missing vault ID");
+          return;
+        }
+        if (!Number.isFinite(feeRate) || feeRate <= 0) {
+          setError("Fee rate must be a positive number");
+          return;
+        }
+
+        setRefunding(true);
+        setError(null);
+
+        abortRef.current?.abort();
+        abortRef.current = new AbortController();
+
+        try {
+          // Fetch the pubkey live from the wallet (not from storage). The
+          // wallet's signPsbt signInputs[].publicKey requires the wallet's
+          // native format (typically compressed 33-byte sec1), and the
+          // stored activity holds the canonical x-only form used for
+          // on-chain/indexer identification.
+          const depositorBtcPubkey = await btcWalletProvider.getPublicKeyHex();
+          const txId = await buildAndBroadcastRefundTransaction({
+            vaultId,
+            btcWalletProvider,
+            depositorBtcPubkey,
+            feeRate,
+            signal: abortRef.current.signal,
+          });
+          setRefundTxId(txId);
+          setRefunding(false);
+
+          const refundBroadcastAt = Date.now();
+          setOptimisticStatus(
+            vaultId,
+            LocalStorageStatus.REFUND_BROADCAST,
+            refundBroadcastAt,
+          );
+
+          if (ethAddress && peginTxHash && unsignedPrePeginTx) {
+            const existing = pendingPegins.find((p) => p.id === vaultId);
+            if (existing) {
+              markRefundBroadcast(vaultId, refundBroadcastAt);
+            } else {
+              addPendingPegin({
+                id: vaultId,
+                peginTxHash,
+                unsignedTxHex: unsignedPrePeginTx,
+                amount: collateral.amount,
+                providerIds: providers.map((p) => p.id),
+                applicationEntryPoint,
+                depositorBtcPubkey,
+                status: LocalStorageStatus.REFUND_BROADCAST,
+                refundBroadcastAt,
+              });
+            }
+          }
+        } catch (err) {
+          if (err instanceof Error && err.name === "AbortError") {
+            setRefunding(false);
+            return;
+          }
+          logger.error(err instanceof Error ? err : new Error(String(err)), {
+            data: { context: "Refund failed", vaultId },
+          });
+          const message =
+            err instanceof Error ? err.message : "Refund transaction failed";
+          setError(
+            message.includes("non-BIP68-final")
+              ? "The Bitcoin timelock has not expired yet. Your refund will be available once enough blocks have been mined since the deposit transaction. Please try again later."
+              : message,
+          );
+          setRefunding(false);
+        }
+      } finally {
+        inFlightRef.current = false;
+      }
+    },
+    [
+      refunding,
+      vaultId,
+      btcWalletProvider,
+      ethAddress,
+      peginTxHash,
+      unsignedPrePeginTx,
+      collateral.amount,
+      providers,
+      applicationEntryPoint,
+      pendingPegins,
+      setOptimisticStatus,
+      addPendingPegin,
+      markRefundBroadcast,
+    ],
+  );
 
   return { refunding, refundTxId, error, handleRefund };
 }

--- a/services/vault/src/hooks/useVaultDeposits.ts
+++ b/services/vault/src/hooks/useVaultDeposits.ts
@@ -13,6 +13,7 @@ import {
   ContractStatus,
   getPeginState,
   LocalStorageStatus,
+  PEGIN_DISPLAY_LABELS,
 } from "../models/peginStateMachine";
 import { getPendingPegins } from "../storage/peginStorage";
 import { usePeginStorage } from "../storage/usePeginStorage";
@@ -87,10 +88,14 @@ export function useVaultDeposits(connectedAddress: Address | undefined) {
         {
           localStatus,
           isInUse: activity.isInUse,
+          refundBroadcastAt: pendingPegin?.refundBroadcastAt,
         },
       );
 
-      return state.displayLabel === "Processing";
+      return (
+        state.displayLabel === PEGIN_DISPLAY_LABELS.PROCESSING ||
+        state.displayLabel === PEGIN_DISPLAY_LABELS.REFUNDING
+      );
     });
 
     setNeedsFastPolling(hasProcessingActivity);

--- a/services/vault/src/models/__tests__/peginStateMachine.test.ts
+++ b/services/vault/src/models/__tests__/peginStateMachine.test.ts
@@ -314,6 +314,40 @@ describe("peginStateMachine", () => {
       const state = getPeginState(ContractStatus.EXPIRED);
       expect(state.availableActions).toEqual([PeginAction.NONE]);
     });
+
+    it("hides refund action and flips label to Refunding after the user has broadcast a refund", () => {
+      const now = 1_700_000_000_000;
+      const state = getPeginState(ContractStatus.EXPIRED, {
+        canRefund: true,
+        localStatus: LocalStorageStatus.REFUND_BROADCAST,
+        refundBroadcastAt: now - 60_000,
+        now,
+      });
+      expect(state.availableActions).toEqual([PeginAction.NONE]);
+      expect(state.displayLabel).toBe(PEGIN_DISPLAY_LABELS.REFUNDING);
+      expect(state.displayVariant).toBe("pending");
+    });
+
+    it("re-exposes refund action once the broadcast TTL has elapsed (dropped tx)", () => {
+      const now = 1_700_000_000_000;
+      const state = getPeginState(ContractStatus.EXPIRED, {
+        canRefund: true,
+        localStatus: LocalStorageStatus.REFUND_BROADCAST,
+        refundBroadcastAt: now - 7 * 60 * 60 * 1000,
+        now,
+      });
+      expect(state.availableActions).toEqual([PeginAction.REFUND_HTLC]);
+      expect(state.displayLabel).toBe(PEGIN_DISPLAY_LABELS.EXPIRED);
+    });
+
+    it("treats legacy REFUND_BROADCAST without timestamp as expired (allows retry)", () => {
+      const state = getPeginState(ContractStatus.EXPIRED, {
+        canRefund: true,
+        localStatus: LocalStorageStatus.REFUND_BROADCAST,
+      });
+      expect(state.availableActions).toEqual([PeginAction.REFUND_HTLC]);
+      expect(state.displayLabel).toBe(PEGIN_DISPLAY_LABELS.EXPIRED);
+    });
   });
 
   // ==========================================================================
@@ -448,6 +482,48 @@ describe("peginStateMachine", () => {
           LocalStorageStatus.CONFIRMING,
         ),
       ).toBe(false);
+    });
+
+    it("keeps REFUND_BROADCAST while contract is still EXPIRED and within TTL", () => {
+      const now = 1_700_000_000_000;
+      expect(
+        shouldRemoveFromLocalStorage(
+          ContractStatus.EXPIRED,
+          LocalStorageStatus.REFUND_BROADCAST,
+          now - 60_000,
+          now,
+        ),
+      ).toBe(false);
+    });
+
+    it("clears stale REFUND_BROADCAST past the TTL so the user can retry", () => {
+      const now = 1_700_000_000_000;
+      expect(
+        shouldRemoveFromLocalStorage(
+          ContractStatus.EXPIRED,
+          LocalStorageStatus.REFUND_BROADCAST,
+          now - 7 * 60 * 60 * 1000,
+          now,
+        ),
+      ).toBe(true);
+    });
+
+    it("clears legacy REFUND_BROADCAST without a broadcast timestamp", () => {
+      expect(
+        shouldRemoveFromLocalStorage(
+          ContractStatus.EXPIRED,
+          LocalStorageStatus.REFUND_BROADCAST,
+        ),
+      ).toBe(true);
+    });
+
+    it("removes REFUND_BROADCAST once contract reaches DEPOSITOR_WITHDRAWN", () => {
+      expect(
+        shouldRemoveFromLocalStorage(
+          ContractStatus.DEPOSITOR_WITHDRAWN,
+          LocalStorageStatus.REFUND_BROADCAST,
+        ),
+      ).toBe(true);
     });
   });
 });

--- a/services/vault/src/models/peginStateMachine.ts
+++ b/services/vault/src/models/peginStateMachine.ts
@@ -37,6 +37,7 @@ export enum OffChainTrackingStatus {
   PAYOUT_SIGNED = "payout_signed",
   CONFIRMING = "confirming",
   CONFIRMED = "confirmed",
+  REFUND_BROADCAST = "refund_broadcast",
 }
 
 export const LocalStorageStatus = OffChainTrackingStatus;
@@ -81,6 +82,7 @@ export const PEGIN_DISPLAY_LABELS = {
   REDEEMED: "Redeemed",
   LIQUIDATED: "Liquidated",
   EXPIRED: "Expired",
+  REFUNDING: "Refunding",
   FAILED: "Failed",
   INVALID: "Invalid",
   UNKNOWN: "Unknown",
@@ -112,7 +114,23 @@ export interface GetPeginStateOptions {
   expiredAt?: number;
   canRefund?: boolean;
   vpTerminalError?: string;
+  /**
+   * `Date.now()` value captured when the refund tx was broadcast. Anchors
+   * the TTL on the REFUND_BROADCAST optimistic suppression so a tx evicted
+   * from the mempool eventually re-exposes the refund action.
+   */
+  refundBroadcastAt?: number;
+  /** Override `Date.now()` used for the TTL check (testing only). */
+  now?: number;
 }
+
+/**
+ * How long to keep suppressing the refund action after a broadcast while the
+ * contract is still EXPIRED. Long enough to cover the realistic confirmation
+ * window with margin; short enough that a dropped/evicted tx unblocks retry
+ * before the user has to clear localStorage by hand.
+ */
+export const REFUND_BROADCAST_SUPPRESSION_MS = 6 * 60 * 60 * 1000;
 
 // ============================================================================
 // Expiration helpers
@@ -207,6 +225,8 @@ export function getPeginState(
       transactionsReady: options.transactionsReady,
       pendingIngestion: options.pendingIngestion,
     },
+    options.refundBroadcastAt,
+    options.now,
   );
   const actions = mapActions(sdkActions);
   const display = getDisplay(contractStatus, actions, options);
@@ -245,6 +265,8 @@ function applyTrackingOverrides(
   contractStatus: ContractStatus,
   localStatus?: LocalStorageStatus,
   vpState?: VpReconciliationState,
+  refundBroadcastAt?: number,
+  now?: number,
 ): SdkPeginAction[] {
   if (!localStatus) return sdkActions;
 
@@ -276,7 +298,28 @@ function applyTrackingOverrides(
     if (localStatus === LocalStorageStatus.CONFIRMED) return [];
   }
 
+  if (contractStatus === ContractStatus.EXPIRED) {
+    if (localStatus === LocalStorageStatus.REFUND_BROADCAST) {
+      if (isRefundBroadcastWithinTtl(refundBroadcastAt, now)) return [];
+    }
+  }
+
   return sdkActions;
+}
+
+/**
+ * The suppression must auto-expire — broadcast txs can be evicted from the
+ * mempool, and a sticky marker would otherwise hide the refund action while
+ * the vault is still EXPIRED on-chain. Legacy entries without a timestamp are
+ * treated as expired so the user can always retry.
+ */
+function isRefundBroadcastWithinTtl(
+  refundBroadcastAt: number | undefined,
+  now: number | undefined,
+): boolean {
+  if (refundBroadcastAt === undefined) return false;
+  const currentTime = now ?? Date.now();
+  return currentTime - refundBroadcastAt < REFUND_BROADCAST_SUPPRESSION_MS;
 }
 
 interface DisplayInfo {
@@ -290,8 +333,15 @@ function getDisplay(
   actions: PeginAction[],
   options: GetPeginStateOptions,
 ): DisplayInfo {
-  const { localStatus, isInUse, expirationReason, expiredAt, vpTerminalError } =
-    options;
+  const {
+    localStatus,
+    isInUse,
+    expirationReason,
+    expiredAt,
+    vpTerminalError,
+    refundBroadcastAt,
+    now,
+  } = options;
 
   const hasNoActions = actions.length === 1 && actions[0] === PeginAction.NONE;
 
@@ -410,6 +460,17 @@ function getDisplay(
   }
 
   if (contractStatus === ContractStatus.EXPIRED) {
+    if (
+      localStatus === LocalStorageStatus.REFUND_BROADCAST &&
+      isRefundBroadcastWithinTtl(refundBroadcastAt, now)
+    ) {
+      return {
+        displayLabel: PEGIN_DISPLAY_LABELS.REFUNDING,
+        displayVariant: "pending",
+        message:
+          "Refund transaction broadcast to Bitcoin. Waiting for on-chain confirmation...",
+      };
+    }
     return {
       displayLabel: PEGIN_DISPLAY_LABELS.EXPIRED,
       displayVariant: "warning",
@@ -494,7 +555,21 @@ export function getNextLocalStatus(
 export function shouldRemoveFromLocalStorage(
   contractStatus: ContractStatus,
   localStatus: LocalStorageStatus,
+  refundBroadcastAt?: number,
+  now?: number,
 ): boolean {
+  // Exception comes before the terminal-status check so the marker survives
+  // until the contract advances past EXPIRED — but only while the broadcast
+  // is still within the suppression TTL. Past the TTL the marker is stale
+  // and clearing it lets the EXPIRED state surface the refund action again.
+  if (
+    contractStatus === ContractStatus.EXPIRED &&
+    localStatus === LocalStorageStatus.REFUND_BROADCAST &&
+    isRefundBroadcastWithinTtl(refundBroadcastAt, now)
+  ) {
+    return false;
+  }
+
   if (
     contractStatus === ContractStatus.ACTIVE ||
     contractStatus === ContractStatus.REDEEMED ||

--- a/services/vault/src/services/vault/__tests__/vaultRefundService.test.ts
+++ b/services/vault/src/services/vault/__tests__/vaultRefundService.test.ts
@@ -7,6 +7,15 @@ vi.mock("@babylonlabs-io/ts-sdk/tbv/core/services", () => ({
   buildAndBroadcastRefund: (...args: unknown[]) =>
     mockBuildAndBroadcastRefund(...args),
   BIP68NotMatureError: class BIP68NotMatureError extends Error {},
+  REFUND_VSIZE: 160,
+  estimateRefundFeeSats: (rate: number) => {
+    if (!Number.isFinite(rate) || rate <= 0) {
+      throw new Error(
+        `feeRateSatsVb must be a positive finite number, got ${rate}`,
+      );
+    }
+    return BigInt(Math.ceil(rate * 160));
+  },
 }));
 
 vi.mock("@babylonlabs-io/ts-sdk/tbv/core", () => ({
@@ -63,7 +72,11 @@ import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import { getVaultFromChain } from "../../../clients/eth-contract/btc-vault-registry/query";
 import { fetchVaultProviderById } from "../fetchVaultProviders";
 import { fetchVaultRefundData } from "../fetchVaults";
-import { buildAndBroadcastRefundTransaction } from "../vaultRefundService";
+import {
+  buildAndBroadcastRefundTransaction,
+  getRefundNetworkFeeSats,
+  getRefundPreview,
+} from "../vaultRefundService";
 
 const VAULT_ID = "0xvaultid" as `0x${string}`;
 const DEPOSITOR_PUBKEY = "aabbccdd";
@@ -134,6 +147,7 @@ describe("vaultRefundService - adapter wiring", () => {
       vaultId: VAULT_ID,
       btcWalletProvider: BTC_WALLET_PROVIDER,
       depositorBtcPubkey: DEPOSITOR_PUBKEY,
+      feeRate: 10,
     });
 
     expect(mockBuildAndBroadcastRefund).toHaveBeenCalledOnce();
@@ -168,6 +182,7 @@ describe("vaultRefundService - adapter wiring", () => {
       vaultId: VAULT_ID,
       btcWalletProvider: BTC_WALLET_PROVIDER,
       depositorBtcPubkey: DEPOSITOR_PUBKEY,
+      feeRate: 10,
     });
 
     expect(observed).not.toBeNull();
@@ -187,6 +202,7 @@ describe("vaultRefundService - adapter wiring", () => {
         vaultId: VAULT_ID,
         btcWalletProvider: BTC_WALLET_PROVIDER,
         depositorBtcPubkey: DEPOSITOR_PUBKEY,
+        feeRate: 10,
       }),
     ).rejects.toThrow("Pre-PegIn transaction hash mismatch");
   });
@@ -199,6 +215,7 @@ describe("vaultRefundService - adapter wiring", () => {
         vaultId: VAULT_ID,
         btcWalletProvider: BTC_WALLET_PROVIDER,
         depositorBtcPubkey: DEPOSITOR_PUBKEY,
+        feeRate: 10,
       }),
     ).rejects.toThrow(`Vault ${VAULT_ID} not found`);
   });
@@ -211,6 +228,7 @@ describe("vaultRefundService - adapter wiring", () => {
         vaultId: VAULT_ID,
         btcWalletProvider: BTC_WALLET_PROVIDER,
         depositorBtcPubkey: DEPOSITOR_PUBKEY,
+        feeRate: 10,
       }),
     ).rejects.toThrow(
       `Vault provider ${ON_CHAIN_VAULT.vaultProvider} not found`,
@@ -225,6 +243,7 @@ describe("vaultRefundService - adapter wiring", () => {
         vaultId: VAULT_ID,
         btcWalletProvider: BTC_WALLET_PROVIDER,
         depositorBtcPubkey: DEPOSITOR_PUBKEY,
+        feeRate: 10,
       }),
     ).rejects.toThrow(
       `No vault keepers found for version ${ON_CHAIN_VAULT.appVaultKeepersVersion}`,
@@ -239,13 +258,14 @@ describe("vaultRefundService - adapter wiring", () => {
         vaultId: VAULT_ID,
         btcWalletProvider: BTC_WALLET_PROVIDER,
         depositorBtcPubkey: DEPOSITOR_PUBKEY,
+        feeRate: 10,
       }),
     ).rejects.toThrow(
       `Universal challengers not found for version ${ON_CHAIN_VAULT.universalChallengersVersion}`,
     );
   });
 
-  it("passes the mempool halfHourFee to the SDK as feeRate", async () => {
+  it("forwards the caller-provided feeRate to the SDK (no silent halfHourFee fallback)", async () => {
     let observedFeeRate = 0;
     mockBuildAndBroadcastRefund.mockImplementation(
       async (input: { feeRate: number }) => {
@@ -258,9 +278,12 @@ describe("vaultRefundService - adapter wiring", () => {
       vaultId: VAULT_ID,
       btcWalletProvider: BTC_WALLET_PROVIDER,
       depositorBtcPubkey: DEPOSITOR_PUBKEY,
+      feeRate: 42,
     });
 
-    expect(observedFeeRate).toBe(10);
+    expect(observedFeeRate).toBe(42);
+    // Broadcast path must NOT ping mempool for the fee — it uses the caller's.
+    expect(getNetworkFees).not.toHaveBeenCalled();
   });
 
   it("broadcastTx returns { txId } from mempool pushTx", async () => {
@@ -278,9 +301,67 @@ describe("vaultRefundService - adapter wiring", () => {
       vaultId: VAULT_ID,
       btcWalletProvider: BTC_WALLET_PROVIDER,
       depositorBtcPubkey: DEPOSITOR_PUBKEY,
+      feeRate: 10,
     });
 
     expect(observed).toEqual({ txId: "broadcast_txid" });
     expect(txId).toBe("broadcast_txid");
+  });
+});
+
+describe("getRefundNetworkFeeSats", () => {
+  it("returns ceil(rate * 160) in sats", () => {
+    expect(getRefundNetworkFeeSats(1)).toBe(160n);
+    expect(getRefundNetworkFeeSats(3)).toBe(480n);
+    expect(getRefundNetworkFeeSats(10)).toBe(1600n);
+  });
+
+  it("rounds up non-integer rates", () => {
+    // 1.5 × 160 = 240.0 (exact); pick a non-integer product instead
+    expect(getRefundNetworkFeeSats(1.0001)).toBe(161n);
+  });
+
+  it("rejects non-positive or non-finite rates", () => {
+    expect(() => getRefundNetworkFeeSats(0)).toThrow();
+    expect(() => getRefundNetworkFeeSats(-1)).toThrow();
+    expect(() => getRefundNetworkFeeSats(Number.NaN)).toThrow();
+    expect(() => getRefundNetworkFeeSats(Number.POSITIVE_INFINITY)).toThrow();
+  });
+});
+
+describe("getRefundPreview", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getVaultFromChain as Mock).mockResolvedValue(ON_CHAIN_VAULT);
+    (fetchVaultRefundData as Mock).mockResolvedValue(INDEXER_VAULT);
+    (getNetworkFees as Mock).mockResolvedValue({ halfHourFee: 7 });
+  });
+
+  it("returns the on-chain HTLC amount and mempool halfHourFee", async () => {
+    const preview = await getRefundPreview(VAULT_ID);
+    expect(preview.amountSats).toBe(ON_CHAIN_VAULT.amount);
+    expect(preview.halfHourFeeSatsVb).toBe(7);
+  });
+
+  it("throws when the vault is not found in the indexer", async () => {
+    (fetchVaultRefundData as Mock).mockResolvedValue(null);
+    await expect(getRefundPreview(VAULT_ID)).rejects.toThrow(
+      `Vault ${VAULT_ID} not found`,
+    );
+  });
+
+  it("returns null halfHourFeeSatsVb when the fee endpoint fails (vault data still loads)", async () => {
+    (getNetworkFees as Mock).mockRejectedValue(
+      new Error("mempool unreachable"),
+    );
+    const preview = await getRefundPreview(VAULT_ID);
+    expect(preview.amountSats).toBe(ON_CHAIN_VAULT.amount);
+    expect(preview.halfHourFeeSatsVb).toBeNull();
+  });
+
+  it("returns null halfHourFeeSatsVb when the fee endpoint reports zero", async () => {
+    (getNetworkFees as Mock).mockResolvedValue({ halfHourFee: 0 });
+    const preview = await getRefundPreview(VAULT_ID);
+    expect(preview.halfHourFeeSatsVb).toBeNull();
   });
 });

--- a/services/vault/src/services/vault/vaultRefundService.ts
+++ b/services/vault/src/services/vault/vaultRefundService.ts
@@ -15,6 +15,7 @@ import type { SignPsbtOptions } from "@babylonlabs-io/ts-sdk/shared";
 import { getNetworkFees, pushTx } from "@babylonlabs-io/ts-sdk/tbv/core";
 import {
   buildAndBroadcastRefund,
+  estimateRefundFeeSats,
   type RefundPrePeginContext,
   type VaultRefundData,
 } from "@babylonlabs-io/ts-sdk/tbv/core/services";
@@ -38,14 +39,41 @@ import {
 } from "./vaultPayoutSignatureService";
 
 export interface BroadcastRefundParams {
-  /** Vault ID: keccak256(abi.encode(peginTxHash, depositor)) */
   vaultId: Hex;
-  /** BTC wallet provider for signing */
   btcWalletProvider: {
     signPsbt: (psbtHex: string, options?: SignPsbtOptions) => Promise<string>;
   };
-  /** Depositor's BTC public key (compressed or x-only hex) for signing options */
   depositorBtcPubkey: string;
+  feeRate: number;
+  signal?: AbortSignal;
+}
+
+// Re-export the SDK helper so the UI can compute the same fee the SDK will
+// charge without duplicating the protocol-owned vsize constant.
+export const getRefundNetworkFeeSats = estimateRefundFeeSats;
+
+export interface RefundPreview {
+  amountSats: bigint;
+  /**
+   * Mempool's halfHourFee, or null if the fee endpoint failed. Vault data
+   * loads independently — a fee fetch failure must not block the refund.
+   */
+  halfHourFeeSatsVb: number | null;
+}
+
+export async function getRefundPreview(vaultId: Hex): Promise<RefundPreview> {
+  const mempoolApiUrl = getMempoolApiUrl();
+  const [vault, feeRecommendation] = await Promise.all([
+    readVault(vaultId),
+    getNetworkFees(mempoolApiUrl).catch(() => null),
+  ]);
+  return {
+    amountSats: vault.amount,
+    halfHourFeeSatsVb:
+      feeRecommendation && feeRecommendation.halfHourFee > 0
+        ? feeRecommendation.halfHourFee
+        : null,
+  };
 }
 
 async function readVault(vaultId: Hex): Promise<VaultRefundData> {
@@ -169,12 +197,9 @@ async function readPrePeginContext(
 export async function buildAndBroadcastRefundTransaction(
   params: BroadcastRefundParams,
 ): Promise<string> {
-  const { vaultId, btcWalletProvider, depositorBtcPubkey } = params;
+  const { vaultId, btcWalletProvider, depositorBtcPubkey, feeRate, signal } =
+    params;
   const mempoolApiUrl = getMempoolApiUrl();
-
-  // Pre-fetch the mempool fee rate — it doesn't depend on any value the SDK
-  // computes, so passing it in keeps the SDK's orchestration honest.
-  const { halfHourFee } = await getNetworkFees(mempoolApiUrl);
 
   // Override indexer-provided depositor pubkey with the caller's wallet key —
   // the wallet is the authoritative source for the depositor's signing key.
@@ -185,12 +210,13 @@ export async function buildAndBroadcastRefundTransaction(
       return { ...data, depositorBtcPubkey };
     },
     readPrePeginContext: (vault) => readPrePeginContext(vault),
-    feeRate: halfHourFee,
+    feeRate,
     signPsbt: (psbtHex, options) =>
       btcWalletProvider.signPsbt(psbtHex, options),
     broadcastTx: async (signedTxHex) => ({
       txId: await pushTx(signedTxHex, mempoolApiUrl),
     }),
+    signal,
   });
 
   return txId;

--- a/services/vault/src/storage/__tests__/peginStorage.test.ts
+++ b/services/vault/src/storage/__tests__/peginStorage.test.ts
@@ -339,6 +339,36 @@ describe("getPendingPegins integrity validation", () => {
 
     expect(getPendingPegins(ETH_ADDRESS)).toHaveLength(1);
   });
+
+  it("accepts entries with a valid refundBroadcastAt timestamp", () => {
+    const pegin: PendingPeginRequest = {
+      ...validPegin,
+      status: LocalStorageStatus.REFUND_BROADCAST,
+      refundBroadcastAt: 1_700_000_000_000,
+    };
+    localStorage.setItem(storageKey, JSON.stringify([pegin]));
+
+    const result = getPendingPegins(ETH_ADDRESS);
+    expect(result).toHaveLength(1);
+    expect(result[0].refundBroadcastAt).toBe(1_700_000_000_000);
+  });
+
+  it("filters entries whose refundBroadcastAt is non-numeric", () => {
+    const tampered = {
+      ...validPegin,
+      refundBroadcastAt: "not-a-number" as unknown as number,
+    };
+    localStorage.setItem(storageKey, JSON.stringify([tampered]));
+
+    expect(getPendingPegins(ETH_ADDRESS)).toHaveLength(0);
+  });
+
+  it("filters entries whose refundBroadcastAt is negative", () => {
+    const tampered = { ...validPegin, refundBroadcastAt: -1 };
+    localStorage.setItem(storageKey, JSON.stringify([tampered]));
+
+    expect(getPendingPegins(ETH_ADDRESS)).toHaveLength(0);
+  });
 });
 
 describe("UTXO reservation storage", () => {

--- a/services/vault/src/storage/peginStorage.ts
+++ b/services/vault/src/storage/peginStorage.ts
@@ -39,6 +39,10 @@ export interface PendingPeginRequest {
   status: LocalStorageStatus; // Track user actions (required, defaults to PENDING)
   peginTxHash: Hex; // Raw BTC pegin transaction hash
   depositorBtcPubkey?: string; // Depositor's BTC public key (x-only, for WOTS derivation in resume flow)
+  // Anchor for the REFUND_BROADCAST optimistic suppression TTL: a broadcast tx
+  // can be evicted from the mempool and never confirm, so the suppression must
+  // expire to let the user retry instead of permanently hiding the action.
+  refundBroadcastAt?: number;
   // Fields for cross-device broadcasting support
   unsignedTxHex: string; // Funded Pre-PegIn tx hex (for broadcasting later)
   selectedUTXOs?: Array<{
@@ -70,6 +74,7 @@ const VALID_LOCAL_STORAGE_STATUSES: ReadonlySet<string> = new Set([
   "payout_signed",
   "confirming",
   "confirmed",
+  "refund_broadcast",
 ]);
 // Vault `id` is keccak256(abi.encode(peginTxHash, depositor)) — always 32 bytes.
 // `peginTxHash` is a Bitcoin tx hash — also 32 bytes. Accept the legacy form
@@ -117,6 +122,16 @@ function hasValidSecurityFields(entry: unknown): entry is PendingPeginRequest {
     if (
       typeof pegin.status !== "string" ||
       !VALID_LOCAL_STORAGE_STATUSES.has(pegin.status)
+    ) {
+      return false;
+    }
+  }
+
+  if (pegin.refundBroadcastAt !== undefined) {
+    if (
+      typeof pegin.refundBroadcastAt !== "number" ||
+      !Number.isFinite(pegin.refundBroadcastAt) ||
+      pegin.refundBroadcastAt < 0
     ) {
       return false;
     }
@@ -339,6 +354,31 @@ export function updatePendingPeginStatus(
 }
 
 /**
+ * Mark a pending peg-in as having broadcast its refund tx, anchoring the
+ * timestamp used by the optimistic-suppression TTL.
+ */
+export function markRefundBroadcast(
+  ethAddress: string,
+  vaultId: string,
+  refundBroadcastAt: number,
+): void {
+  const existingPegins = getPendingPegins(ethAddress);
+  const normalizedId = normalizeTransactionId(vaultId);
+
+  const updatedPegins = existingPegins.map((pegin) =>
+    pegin.id === normalizedId
+      ? {
+          ...pegin,
+          status: LocalStorageStatus.REFUND_BROADCAST,
+          refundBroadcastAt,
+        }
+      : pegin,
+  );
+
+  savePendingPegins(ethAddress, updatedPegins);
+}
+
+/**
  * Filter and clean up old pending peg-ins
  *
  * Uses peginStateMachine.shouldRemoveFromLocalStorage() for cleanup logic:
@@ -374,7 +414,11 @@ export function filterPendingPegins(
 
     // If it exists on blockchain, use peginStateMachine to determine if we should remove it
     // This handles the logic for keeping status 0-1 and removing status 2+
-    return !shouldRemoveFromLocalStorage(confirmedPegin.status, pegin.status);
+    return !shouldRemoveFromLocalStorage(
+      confirmedPegin.status,
+      pegin.status,
+      pegin.refundBroadcastAt,
+    );
   });
 }
 

--- a/services/vault/src/storage/usePeginStorage.ts
+++ b/services/vault/src/storage/usePeginStorage.ts
@@ -26,6 +26,7 @@ import {
   addPendingPegin as addPendingPeginToStorage,
   filterPendingPegins,
   getPendingPegins,
+  markRefundBroadcast as markRefundBroadcastInStorage,
   type PendingPeginRequest,
   savePendingPegins,
   updatePendingPeginStatus as updatePendingPeginStatusInStorage,
@@ -52,6 +53,11 @@ export interface UsePeginStorageResult {
     vaultId: string,
     status: LocalStorageStatus,
   ) => void;
+  /**
+   * Mark a pegin as REFUND_BROADCAST and stamp the broadcast time used by the
+   * optimistic-suppression TTL.
+   */
+  markRefundBroadcast: (vaultId: string, refundBroadcastAt: number) => void;
 }
 
 /**
@@ -200,6 +206,7 @@ export function usePeginStorage({
             {
               localStatus: pendingPegin.status,
               isInUse: activity.isInUse,
+              refundBroadcastAt: pendingPegin.refundBroadcastAt,
             },
           );
           return {
@@ -240,10 +247,19 @@ export function usePeginStorage({
     [ethAddress],
   );
 
+  const markRefundBroadcast = useCallback(
+    (vaultId: string, refundBroadcastAt: number) => {
+      if (!ethAddress) return;
+      markRefundBroadcastInStorage(ethAddress, vaultId, refundBroadcastAt);
+    },
+    [ethAddress],
+  );
+
   return {
     allActivities,
     pendingPegins,
     addPendingPegin,
     updatePendingPeginStatus,
+    markRefundBroadcast,
   };
 }

--- a/services/vault/src/types/peginPolling.ts
+++ b/services/vault/src/types/peginPolling.ts
@@ -43,10 +43,16 @@ export interface PeginPollingContextValue {
   isLoading: boolean;
   /** Trigger a manual refetch for all deposits */
   refetch: () => void;
-  /** Optimistically update the local status for a deposit (immediate UI feedback) */
+  /**
+   * Optimistically update the local status for a deposit (immediate UI
+   * feedback). When transitioning to REFUND_BROADCAST, pass
+   * `refundBroadcastAt` so the suppression-TTL anchor is available before
+   * `pendingPegins` is re-read from localStorage.
+   */
   setOptimisticStatus: (
     depositId: string,
     newStatus: LocalStorageStatus,
+    refundBroadcastAt?: number,
   ) => void;
   /** Clear optimistic status (after actual data refresh) */
   clearOptimisticStatus: (depositId: string) => void;


### PR DESCRIPTION
Replaces the deposit-stepper-based refund UX with a focused two-phase flow matching the new Figma design: a Review Refund card, then a Broadcasting Refund success modal once the BTC tx is broadcast.

<img width="2544" height="1804" alt="image" src="https://github.com/user-attachments/assets/ae6d6263-5e4a-4184-b17a-6c92dfc1cd37" />
<img width="2544" height="1804" alt="image" src="https://github.com/user-attachments/assets/7d29fb32-6722-4738-9ac1-599a3e473152" />
