### PR TITLE
fix(vault): local storage reconciliation for pending state

### DIFF
--- a/services/vault/src/models/__tests__/peginStateMachine.test.ts
+++ b/services/vault/src/models/__tests__/peginStateMachine.test.ts
@@ -123,14 +123,15 @@ describe("peginStateMachine", () => {
       expect(state.displayLabel).toBe(PEGIN_DISPLAY_LABELS.SIGNING_REQUIRED);
     });
 
-    it("ignores stale CONFIRMING when VP reports no pending ingestion", () => {
+    it("ignores stale PAYOUT_SIGNED when VP reports pending ingestion", () => {
       const state = getPeginState(ContractStatus.PENDING, {
-        localStatus: LocalStorageStatus.CONFIRMING,
-        pendingIngestion: false,
-        transactionsReady: false,
+        localStatus: LocalStorageStatus.PAYOUT_SIGNED,
+        pendingIngestion: true,
       });
+      expect(state.availableActions).toContain(
+        PeginAction.SIGN_AND_BROADCAST_TO_BITCOIN,
+      );
       expect(state.displayLabel).toBe(PEGIN_DISPLAY_LABELS.PENDING);
-      expect(state.message).toContain("prepare Claim and Payout");
     });
   });
 

--- a/services/vault/src/models/__tests__/peginStateMachine.test.ts
+++ b/services/vault/src/models/__tests__/peginStateMachine.test.ts
@@ -101,6 +101,37 @@ describe("peginStateMachine", () => {
       expect(state.displayLabel).toBe(PEGIN_DISPLAY_LABELS.PROCESSING);
       expect(state.message).toContain("verifying and collecting");
     });
+
+    it("ignores stale PAYOUT_SIGNED when VP still needs WOTS key", () => {
+      const state = getPeginState(ContractStatus.PENDING, {
+        localStatus: LocalStorageStatus.PAYOUT_SIGNED,
+        needsWotsKey: true,
+      });
+      expect(state.availableActions).toContain(PeginAction.SUBMIT_WOTS_KEY);
+      expect(state.displayLabel).toBe(PEGIN_DISPLAY_LABELS.AWAITING_KEY);
+    });
+
+    it("ignores stale PAYOUT_SIGNED when VP has transactions ready", () => {
+      const state = getPeginState(ContractStatus.PENDING, {
+        localStatus: LocalStorageStatus.PAYOUT_SIGNED,
+        transactionsReady: true,
+        pendingIngestion: false,
+      });
+      expect(state.availableActions).toContain(
+        PeginAction.SIGN_PAYOUT_TRANSACTIONS,
+      );
+      expect(state.displayLabel).toBe(PEGIN_DISPLAY_LABELS.SIGNING_REQUIRED);
+    });
+
+    it("ignores stale CONFIRMING when VP reports no pending ingestion", () => {
+      const state = getPeginState(ContractStatus.PENDING, {
+        localStatus: LocalStorageStatus.CONFIRMING,
+        pendingIngestion: false,
+        transactionsReady: false,
+      });
+      expect(state.displayLabel).toBe(PEGIN_DISPLAY_LABELS.PENDING);
+      expect(state.message).toContain("prepare Claim and Payout");
+    });
   });
 
   // ==========================================================================

--- a/services/vault/src/models/peginStateMachine.ts
+++ b/services/vault/src/models/peginStateMachine.ts
@@ -202,6 +202,11 @@ export function getPeginState(
     protocolState.availableActions,
     contractStatus,
     options.localStatus,
+    {
+      needsWotsKey: options.needsWotsKey,
+      transactionsReady: options.transactionsReady,
+      pendingIngestion: options.pendingIngestion,
+    },
   );
   const actions = mapActions(sdkActions);
   const display = getDisplay(contractStatus, actions, options);
@@ -215,19 +220,47 @@ export function getPeginState(
 }
 
 /**
+ * VP-derived signals used to reconcile localStorage status.
+ *
+ * When localStorage claims the user has completed a step but VP daemon
+ * state contradicts that claim, the override is ignored. This prevents
+ * tampered or stale localStorage from hiding the correct action buttons.
+ */
+interface VpReconciliationState {
+  needsWotsKey?: boolean;
+  transactionsReady?: boolean;
+  pendingIngestion?: boolean;
+}
+
+/**
  * Suppress protocol actions when the user has already acted (tracked in
  * localStorage) but the on-chain state hasn't caught up yet.
+ *
+ * VP state is cross-checked to detect stale or tampered localStorage:
+ * if the VP daemon contradicts the claimed local status, the override
+ * is ignored and the full SDK action set is returned.
  */
 function applyTrackingOverrides(
   sdkActions: SdkPeginAction[],
   contractStatus: ContractStatus,
   localStatus?: LocalStorageStatus,
+  vpState?: VpReconciliationState,
 ): SdkPeginAction[] {
   if (!localStatus) return sdkActions;
 
   if (contractStatus === ContractStatus.PENDING) {
-    if (localStatus === LocalStorageStatus.PAYOUT_SIGNED) return [];
+    if (localStatus === LocalStorageStatus.PAYOUT_SIGNED) {
+      // If VP still needs WOTS key or has transactions ready for signing,
+      // the local status is stale or tampered — ignore the override.
+      if (vpState?.needsWotsKey || vpState?.transactionsReady) {
+        return sdkActions;
+      }
+      return [];
+    }
     if (localStatus === LocalStorageStatus.CONFIRMING) {
+      // If VP explicitly reports no pending ingestion (broadcast not
+      // detected), the local status is stale — ignore the override.
+      if (vpState?.pendingIngestion === false) return sdkActions;
       return sdkActions.filter(
         (a) => a !== SdkPeginAction.SIGN_AND_BROADCAST_TO_BITCOIN,
       );
@@ -255,6 +288,8 @@ function getDisplay(
   const { localStatus, isInUse, expirationReason, expiredAt, vpTerminalError } =
     options;
 
+  const hasNoActions = actions.length === 1 && actions[0] === PeginAction.NONE;
+
   if (contractStatus === ContractStatus.PENDING) {
     if (vpTerminalError) {
       return {
@@ -263,7 +298,7 @@ function getDisplay(
         message: vpTerminalError,
       };
     }
-    if (localStatus === LocalStorageStatus.PAYOUT_SIGNED) {
+    if (localStatus === LocalStorageStatus.PAYOUT_SIGNED && hasNoActions) {
       return {
         displayLabel: PEGIN_DISPLAY_LABELS.PROCESSING,
         displayVariant: "pending",

--- a/services/vault/src/models/peginStateMachine.ts
+++ b/services/vault/src/models/peginStateMachine.ts
@@ -253,7 +253,11 @@ function applyTrackingOverrides(
       // If VP still needs WOTS key, has transactions ready for signing,
       // or hasn't even ingested the deposit yet, the local status is
       // stale or tampered — ignore the override.
-      if (vpState?.needsWotsKey || vpState?.transactionsReady || vpState?.pendingIngestion) {
+      if (
+        vpState?.needsWotsKey ||
+        vpState?.transactionsReady ||
+        vpState?.pendingIngestion
+      ) {
         return sdkActions;
       }
       return [];

--- a/services/vault/src/models/peginStateMachine.ts
+++ b/services/vault/src/models/peginStateMachine.ts
@@ -250,9 +250,10 @@ function applyTrackingOverrides(
 
   if (contractStatus === ContractStatus.PENDING) {
     if (localStatus === LocalStorageStatus.PAYOUT_SIGNED) {
-      // If VP still needs WOTS key or has transactions ready for signing,
-      // the local status is stale or tampered — ignore the override.
-      if (vpState?.needsWotsKey || vpState?.transactionsReady) {
+      // If VP still needs WOTS key, has transactions ready for signing,
+      // or hasn't even ingested the deposit yet, the local status is
+      // stale or tampered — ignore the override.
+      if (vpState?.needsWotsKey || vpState?.transactionsReady || vpState?.pendingIngestion) {
         return sdkActions;
       }
       return [];

--- a/services/vault/src/utils/peginPolling.ts
+++ b/services/vault/src/utils/peginPolling.ts
@@ -8,7 +8,6 @@ import type { Hex } from "viem";
 import {
   ContractStatus,
   isPreDepositorSignaturesError,
-  LocalStorageStatus,
 } from "../models/peginStateMachine";
 import type { PendingPeginRequest } from "../storage/peginStorage";
 import type { VaultActivity } from "../types/activity";
@@ -116,9 +115,6 @@ export function getDepositsNeedingPolling(
     .map((activity) => {
       const pendingPegin = pendingPegins.find((p) => p.id === activity.id);
       const contractStatus = (activity.contractStatus ?? 0) as ContractStatus;
-      const localStatus = pendingPegin?.status as
-        | LocalStorageStatus
-        | undefined;
       // Note: Currently only single vault provider per deposit is supported
       const vaultProviderAddress = activity.providers[0]?.id as Hex | undefined;
 

--- a/services/vault/src/utils/peginPolling.ts
+++ b/services/vault/src/utils/peginPolling.ts
@@ -125,7 +125,6 @@ export function getDepositsNeedingPolling(
       // Check if this deposit should be polled
       const shouldPoll =
         contractStatus === ContractStatus.PENDING &&
-        localStatus !== LocalStorageStatus.PAYOUT_SIGNED &&
         !!btcPublicKey &&
         !!vaultProviderAddress &&
         !!activity.peginTxHash &&


### PR DESCRIPTION
### Context

The pegin state machine uses `localStatus` from localStorage to suppress action buttons while on-chain state catches up (e.g., hiding "Sign Payout" after the user already signed). An auditor flagged that tampering with localStorage could manipulate which actions the UI shows, potentially causing wasted gas or stuck deposits.

**Severity assessment:** The finding is partially valid but overstated as Medium. localStorage can only **suppress** actions, never add them — all action handlers (`handleBroadcast`, `handleActivation`) independently validate against server-side state before executing. The worst outcome is self-DoS (hiding your own buttons), not fund loss. Still, users could get stuck with no recovery path short of manually clearing localStorage.

### Changes

**`applyTrackingOverrides`** now cross-checks localStorage claims against VP daemon signals (`needsWotsKey`, `transactionsReady`, `pendingIngestion`) that are already available in `GetPeginStateOptions`. When the VP state contradicts the claimed local status, the override is ignored and the correct action buttons are shown:

| localStorage says | VP daemon says | Before | After |
|---|---|---|---|
| `payout_signed` | Still needs WOTS key | All actions hidden | Shows "Submit WOTS Key" |
| `payout_signed` | Transactions ready for signing | All actions hidden | Shows "Sign" |
| `confirming` | No broadcast detected (`pendingIngestion: false`) | Broadcast hidden | Shows correct protocol action |

**`getDisplay`** now gates the "Processing" label on `PAYOUT_SIGNED` behind an additional check that actions were actually suppressed, so reconciled states show the correct action-specific label.

Closes https://github.com/babylonlabs-io/vault-provider-proxy/issues/120