### PR TITLE
fix(vault): utxo reservation local storage

### DIFF
--- a/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/__tests__/reservation.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/__tests__/reservation.test.ts
@@ -364,6 +364,55 @@ describe("UTXO Reservation", () => {
       expect(reserved).toHaveLength(0);
     });
 
+    it("should collect refs from utxoReservations", () => {
+      const reservationTxid =
+        "9999999999999999999999999999999999999999999999999999999999999999";
+      const reserved = collectReservedUtxoRefs({
+        pendingPegins: [],
+        vaults: [],
+        utxoReservations: [
+          { unsignedTxHex: createValidTxHex(reservationTxid, 2) },
+        ],
+      });
+
+      expect(reserved).toHaveLength(1);
+      expect(hasRef(reserved, reservationTxid, 2)).toBe(true);
+    });
+
+    it("should combine refs from reservations with pending pegins and vaults", () => {
+      const reservationTxid =
+        "9999999999999999999999999999999999999999999999999999999999999999";
+      const vaultTxid =
+        "5555555555555555555555555555555555555555555555555555555555555555";
+      const vault = createMockVault(
+        ContractStatus.PENDING,
+        createValidTxHex(vaultTxid, 0),
+      );
+
+      const reserved = collectReservedUtxoRefs({
+        pendingPegins: [mockPendingPegin],
+        vaults: [vault],
+        utxoReservations: [
+          { unsignedTxHex: createValidTxHex(reservationTxid, 7) },
+        ],
+      });
+
+      expect(reserved).toHaveLength(3);
+      expect(hasRef(reserved, VALID_TX_PENDING_TXID_A, 3)).toBe(true);
+      expect(hasRef(reserved, vaultTxid, 0)).toBe(true);
+      expect(hasRef(reserved, reservationTxid, 7)).toBe(true);
+    });
+
+    it("should handle empty utxoReservations", () => {
+      const reserved = collectReservedUtxoRefs({
+        pendingPegins: [],
+        vaults: [],
+        utxoReservations: [],
+      });
+
+      expect(reserved).toHaveLength(0);
+    });
+
     it("logs and yields no refs when unsignedTxHex fails to parse", () => {
       const tamperedPending: PendingPeginLike = {
         id: "0xbadhex",

--- a/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts
@@ -63,9 +63,15 @@ export interface SelectUtxosForDepositParams<
   feeRate: number;
 }
 
+/** Narrow structural type for early UTXO reservations (pre-ETH-registration). */
+export interface UtxoReservationLike {
+  unsignedTxHex: string;
+}
+
 export interface CollectReservedUtxoRefsParams {
   vaults?: VaultLike[];
   pendingPegins?: PendingPeginLike[];
+  utxoReservations?: UtxoReservationLike[];
 }
 
 // ============================================================================
@@ -163,7 +169,11 @@ export function collectReservedUtxoRefs(
   params: CollectReservedUtxoRefsParams,
 ): UtxoRef[] {
   const reserved: UtxoRef[] = [];
-  const { vaults = [], pendingPegins = [] } = params;
+  const {
+    vaults = [],
+    pendingPegins = [],
+    utxoReservations = [],
+  } = params;
 
   const onChainVaultIds = new Set(
     vaults
@@ -188,6 +198,12 @@ export function collectReservedUtxoRefs(
       continue;
     }
     reserved.push(...extractInputUtxoRefs(vault.unsignedPrePeginTx));
+  }
+
+  // Early reservations written before ETH registration to prevent cross-tab
+  // UTXO conflicts. These are cleaned up when the deposit completes or fails.
+  for (const reservation of utxoReservations) {
+    reserved.push(...extractInputUtxoRefs(reservation.unsignedTxHex));
   }
 
   return reserved;

--- a/services/vault/src/constants.ts
+++ b/services/vault/src/constants.ts
@@ -12,6 +12,10 @@ export const STORAGE_KEY_PREFIX = "vault-pending-pegins";
 export const STORAGE_UPDATE_EVENT = "vault-pending-pegins-updated";
 export const MAX_PENDING_DURATION = 24 * 60 * 60 * 1000; // 24 hours - cleanup stale items
 
+// UTXO reservation constants (early reservation before ETH registration)
+export const UTXO_RESERVATION_KEY_PREFIX = "vault-utxo-reservations";
+export const UTXO_RESERVATION_TTL = 5 * ONE_MINUTE; // 5 minutes — auto-expire stale reservations from crashed tabs
+
 // Pending collateral storage constants
 export const PENDING_COLLATERAL_KEY_PREFIX = "vault-pending-collateral";
 

--- a/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
@@ -126,7 +126,10 @@ vi.mock("@/services/vault/vaultUtxoValidationService", () => ({
 
 vi.mock("@/storage/peginStorage", () => ({
   addPendingPegin: vi.fn(),
+  addUtxoReservation: vi.fn(),
   getPendingPegins: vi.fn(() => []),
+  getUtxoReservations: vi.fn(() => []),
+  removeUtxoReservation: vi.fn(),
   updatePendingPeginStatus: vi.fn(),
 }));
 
@@ -559,6 +562,31 @@ describe("useDepositFlow", () => {
       });
     });
 
+    it("should write early UTXO reservation and clean it up on success", async () => {
+      const { addUtxoReservation, removeUtxoReservation } = vi.mocked(
+        await import("@/storage/peginStorage"),
+      );
+
+      const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
+
+      await executeWithAutoArtifactDownload(result);
+
+      await waitFor(() => {
+        expect(addUtxoReservation).toHaveBeenCalledWith(
+          "0xEthAddress123",
+          expect.objectContaining({
+            unsignedTxHex: "batchFundedPrePeginHex",
+            batchId: "mock-batch-id-uuid",
+            timestamp: expect.any(Number),
+          }),
+        );
+        expect(removeUtxoReservation).toHaveBeenCalledWith(
+          "0xEthAddress123",
+          "mock-batch-id-uuid",
+        );
+      });
+    });
+
     it("should update pegins to CONFIRMING status after broadcast", async () => {
       const { updatePendingPeginStatus } = vi.mocked(
         await import("@/storage/peginStorage"),
@@ -669,9 +697,12 @@ describe("useDepositFlow", () => {
       });
     });
 
-    it("should set error when broadcast fails", async () => {
+    it("should set error when broadcast fails and clean up UTXO reservation", async () => {
       const { broadcastPrePeginTransaction } = vi.mocked(
         await import("@/services/vault/vaultPeginBroadcastService"),
+      );
+      const { removeUtxoReservation } = vi.mocked(
+        await import("@/storage/peginStorage"),
       );
       vi.mocked(broadcastPrePeginTransaction).mockRejectedValueOnce(
         new Error("Network error"),
@@ -684,6 +715,11 @@ describe("useDepositFlow", () => {
       await waitFor(() => {
         expect(result.current.error).toContain(
           "Failed to broadcast batch Pre-PegIn transaction",
+        );
+        // Catch block should clean up the early reservation
+        expect(removeUtxoReservation).toHaveBeenCalledWith(
+          "0xEthAddress123",
+          "mock-batch-id-uuid",
         );
       });
     });
@@ -932,6 +968,7 @@ describe("useDepositFlow", () => {
         expect(getPendingPegins).toHaveBeenCalledWith("0xEthAddress123");
         expect(collectReservedUtxoRefs).toHaveBeenCalledWith({
           pendingPegins: mockPendingPegins,
+          utxoReservations: [],
         });
         expect(selectUtxosForDeposit).toHaveBeenCalledWith(
           expect.objectContaining({

--- a/services/vault/src/hooks/deposit/useDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useDepositFlow.ts
@@ -59,7 +59,10 @@ import {
 } from "@/services/wots";
 import {
   addPendingPegin,
+  addUtxoReservation,
   getPendingPegins,
+  getUtxoReservations,
+  removeUtxoReservation,
   updatePendingPeginStatus,
 } from "@/storage/peginStorage";
 import { btcAddressToScriptPubKeyHex } from "@/utils/btc";
@@ -274,6 +277,11 @@ export function useDepositFlow(
       // Track background operation failures
       const warnings: string[] = [];
 
+      // Declared outside try so the catch block can clean up the early
+      // UTXO reservation if the flow fails after writing it.
+      let reservationBatchId: string | null = null;
+      let reservationEthAddress: string | null = null;
+
       try {
         // ========================================================================
         // Step 0: Validation
@@ -349,7 +357,11 @@ export function useDepositFlow(
         // Filter out UTXOs reserved by in-flight deposits to prevent
         // double-spend failures across concurrent sessions/tabs.
         const pendingPegins = getPendingPegins(confirmedEthAddress);
-        const reservedUtxoRefs = collectReservedUtxoRefs({ pendingPegins });
+        const utxoReservations = getUtxoReservations(confirmedEthAddress);
+        const reservedUtxoRefs = collectReservedUtxoRefs({
+          pendingPegins,
+          utxoReservations,
+        });
         const availableUTXOs = selectUtxosForDeposit({
           availableUtxos: spendableUTXOs,
           reservedUtxoRefs,
@@ -377,6 +389,17 @@ export function useDepositFlow(
             availableUTXOs,
           },
         );
+
+        // Reserve UTXOs in localStorage immediately so other tabs see them
+        // during the (potentially lengthy) PoP signing and ETH registration.
+        // Cleaned up after pending pegin entries are written, or on failure.
+        reservationBatchId = batchId;
+        reservationEthAddress = confirmedEthAddress;
+        addUtxoReservation(confirmedEthAddress, {
+          unsignedTxHex: batchResult.fundedPrePeginTxHex,
+          timestamp: Date.now(),
+          batchId,
+        });
 
         // ========================================================================
         // Step 3: Sign PoP + batch register all vaults on Ethereum
@@ -523,6 +546,11 @@ export function useDepositFlow(
             }
           }
         }
+
+        // Early reservation is now superseded by real pending pegin entries.
+        removeUtxoReservation(confirmedEthAddress, batchId);
+        reservationBatchId = null;
+        reservationEthAddress = null;
 
         // ========================================================================
         // Step 4b: Broadcast Pre-PegIn transaction to Bitcoin
@@ -769,6 +797,11 @@ export function useDepositFlow(
           warnings: warnings.length > 0 ? warnings : undefined,
         };
       } catch (err: unknown) {
+        // Clean up early UTXO reservation so the UTXOs are released for reuse.
+        if (reservationBatchId && reservationEthAddress) {
+          removeUtxoReservation(reservationEthAddress, reservationBatchId);
+        }
+
         // Don't show error if flow was aborted (user intentionally closed modal)
         if (!signal.aborted) {
           setError(sanitizeErrorMessage(err));

--- a/services/vault/src/storage/__tests__/peginStorage.test.ts
+++ b/services/vault/src/storage/__tests__/peginStorage.test.ts
@@ -5,9 +5,20 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { logger } from "@/infrastructure";
 
-import { STORAGE_KEY_PREFIX } from "../../constants";
+import {
+  STORAGE_KEY_PREFIX,
+  UTXO_RESERVATION_KEY_PREFIX,
+  UTXO_RESERVATION_TTL,
+} from "../../constants";
 import { LocalStorageStatus } from "../../models/peginStateMachine";
-import { getPendingPegins, type PendingPeginRequest } from "../peginStorage";
+import {
+  addUtxoReservation,
+  getPendingPegins,
+  getUtxoReservations,
+  type PendingPeginRequest,
+  removeUtxoReservation,
+  type UtxoReservation,
+} from "../peginStorage";
 
 vi.mock("@/infrastructure", () => ({
   logger: {
@@ -327,5 +338,119 @@ describe("getPendingPegins integrity validation", () => {
     localStorage.setItem(storageKey, JSON.stringify([pegin]));
 
     expect(getPendingPegins(ETH_ADDRESS)).toHaveLength(1);
+  });
+});
+
+describe("UTXO reservation storage", () => {
+  const reservationKey = `${UTXO_RESERVATION_KEY_PREFIX}-${ETH_ADDRESS}`;
+
+  const validReservation: UtxoReservation = {
+    unsignedTxHex: "0xdeadbeef",
+    timestamp: Date.now(),
+    batchId: "batch-1",
+  };
+
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  it("adds and retrieves a reservation", () => {
+    addUtxoReservation(ETH_ADDRESS, validReservation);
+
+    const result = getUtxoReservations(ETH_ADDRESS);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].batchId).toBe("batch-1");
+    expect(result[0].unsignedTxHex).toBe("0xdeadbeef");
+  });
+
+  it("removes a reservation by batchId", () => {
+    addUtxoReservation(ETH_ADDRESS, validReservation);
+    addUtxoReservation(ETH_ADDRESS, {
+      ...validReservation,
+      batchId: "batch-2",
+    });
+
+    removeUtxoReservation(ETH_ADDRESS, "batch-1");
+
+    const result = getUtxoReservations(ETH_ADDRESS);
+    expect(result).toHaveLength(1);
+    expect(result[0].batchId).toBe("batch-2");
+  });
+
+  it("replaces existing reservation with same batchId", () => {
+    addUtxoReservation(ETH_ADDRESS, validReservation);
+    addUtxoReservation(ETH_ADDRESS, {
+      ...validReservation,
+      unsignedTxHex: "0xcafebabe",
+    });
+
+    const result = getUtxoReservations(ETH_ADDRESS);
+    expect(result).toHaveLength(1);
+    expect(result[0].unsignedTxHex).toBe("0xcafebabe");
+  });
+
+  it("filters out expired reservations on read", () => {
+    const expired: UtxoReservation = {
+      unsignedTxHex: "0xdeadbeef",
+      timestamp: Date.now() - UTXO_RESERVATION_TTL - 1,
+      batchId: "expired-batch",
+    };
+    localStorage.setItem(reservationKey, JSON.stringify([expired]));
+
+    const result = getUtxoReservations(ETH_ADDRESS);
+
+    expect(result).toHaveLength(0);
+    // Expired entry should be cleaned up from storage
+    const stored = localStorage.getItem(reservationKey);
+    expect(stored).toBeNull();
+  });
+
+  it("keeps non-expired reservations when cleaning expired ones", () => {
+    const expired: UtxoReservation = {
+      unsignedTxHex: "0xdeadbeef",
+      timestamp: Date.now() - UTXO_RESERVATION_TTL - 1,
+      batchId: "expired-batch",
+    };
+    const fresh: UtxoReservation = {
+      unsignedTxHex: "0xcafebabe",
+      timestamp: Date.now(),
+      batchId: "fresh-batch",
+    };
+    localStorage.setItem(reservationKey, JSON.stringify([expired, fresh]));
+
+    const result = getUtxoReservations(ETH_ADDRESS);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].batchId).toBe("fresh-batch");
+  });
+
+  it("returns empty array for empty address", () => {
+    expect(getUtxoReservations("")).toEqual([]);
+  });
+
+  it("returns empty array when storage is empty", () => {
+    expect(getUtxoReservations(ETH_ADDRESS)).toEqual([]);
+  });
+
+  it("skips invalid entries from tampered storage", () => {
+    const tampered = [
+      { unsignedTxHex: 42, timestamp: Date.now(), batchId: "bad" },
+      validReservation,
+    ];
+    localStorage.setItem(reservationKey, JSON.stringify(tampered));
+
+    const result = getUtxoReservations(ETH_ADDRESS);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].batchId).toBe("batch-1");
+  });
+
+  it("removes storage key when last reservation is removed", () => {
+    addUtxoReservation(ETH_ADDRESS, validReservation);
+    removeUtxoReservation(ETH_ADDRESS, "batch-1");
+
+    expect(localStorage.getItem(reservationKey)).toBeNull();
   });
 });

--- a/services/vault/src/storage/peginStorage.ts
+++ b/services/vault/src/storage/peginStorage.ts
@@ -464,7 +464,10 @@ function saveReservations(
   } else {
     localStorage.setItem(key, JSON.stringify(reservations));
   }
-  dispatchStorageUpdateEvent(ethAddress);
+  // No dispatchStorageUpdateEvent here: reservations are stored under a
+  // separate key and read imperatively by useDepositFlow, not via the
+  // pendingPegins hook. Cross-tab notification works automatically via
+  // the native StorageEvent fired by localStorage writes.
 }
 
 /**

--- a/services/vault/src/storage/peginStorage.ts
+++ b/services/vault/src/storage/peginStorage.ts
@@ -18,7 +18,12 @@ import type { Hex } from "viem";
 
 import { logger } from "@/infrastructure";
 
-import { STORAGE_KEY_PREFIX, STORAGE_UPDATE_EVENT } from "../constants";
+import {
+  STORAGE_KEY_PREFIX,
+  STORAGE_UPDATE_EVENT,
+  UTXO_RESERVATION_KEY_PREFIX,
+  UTXO_RESERVATION_TTL,
+} from "../constants";
 import {
   LocalStorageStatus,
   shouldRemoveFromLocalStorage,
@@ -371,4 +376,139 @@ export function filterPendingPegins(
     // This handles the logic for keeping status 0-1 and removing status 2+
     return !shouldRemoveFromLocalStorage(confirmedPegin.status, pegin.status);
   });
+}
+
+// ============================================================================
+// UTXO Reservations — early cross-tab reservation before ETH registration
+// ============================================================================
+
+/**
+ * A lightweight reservation written to localStorage immediately after
+ * transaction preparation, BEFORE wallet interaction or ETH registration.
+ * This closes the TOCTOU race window where another tab could select the
+ * same UTXOs during the 1-3 minute signing/registration process.
+ */
+export interface UtxoReservation {
+  unsignedTxHex: string;
+  timestamp: number;
+  batchId: string;
+}
+
+function getReservationStorageKey(ethAddress: string): string {
+  return `${UTXO_RESERVATION_KEY_PREFIX}-${ethAddress}`;
+}
+
+function isValidReservation(entry: unknown): entry is UtxoReservation {
+  if (!entry || typeof entry !== "object") return false;
+  const r = entry as Record<string, unknown>;
+  return (
+    typeof r.unsignedTxHex === "string" &&
+    NON_EMPTY_HEX_RE.test(r.unsignedTxHex) &&
+    typeof r.timestamp === "number" &&
+    Number.isFinite(r.timestamp) &&
+    r.timestamp > 0 &&
+    typeof r.batchId === "string" &&
+    r.batchId.length > 0
+  );
+}
+
+/**
+ * Read all UTXO reservations for an address, filtering out expired entries.
+ * Expired entries are cleaned up on read to avoid accumulation from crashed tabs.
+ */
+export function getUtxoReservations(ethAddress: string): UtxoReservation[] {
+  if (!ethAddress) return [];
+
+  try {
+    const stored = localStorage.getItem(getReservationStorageKey(ethAddress));
+    if (!stored) return [];
+
+    const parsed: unknown = JSON.parse(stored);
+    if (!Array.isArray(parsed)) return [];
+
+    const now = Date.now();
+    const valid: UtxoReservation[] = [];
+    let hadExpired = false;
+
+    for (const entry of parsed) {
+      if (!isValidReservation(entry)) continue;
+      if (now - entry.timestamp > UTXO_RESERVATION_TTL) {
+        hadExpired = true;
+        continue;
+      }
+      valid.push(entry);
+    }
+
+    // Clean up expired entries lazily on read
+    if (hadExpired) {
+      saveReservations(ethAddress, valid);
+    }
+
+    return valid;
+  } catch (error) {
+    logger.warn("[peginStorage] Failed to read UTXO reservations", {
+      category: "peginStorage",
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return [];
+  }
+}
+
+function saveReservations(
+  ethAddress: string,
+  reservations: UtxoReservation[],
+): void {
+  const key = getReservationStorageKey(ethAddress);
+  if (reservations.length === 0) {
+    localStorage.removeItem(key);
+  } else {
+    localStorage.setItem(key, JSON.stringify(reservations));
+  }
+  dispatchStorageUpdateEvent(ethAddress);
+}
+
+/**
+ * Reserve UTXOs by writing the prepared transaction hex to localStorage.
+ * Called immediately after `preparePeginTransaction()`, before wallet
+ * interaction or ETH registration.
+ */
+export function addUtxoReservation(
+  ethAddress: string,
+  reservation: UtxoReservation,
+): void {
+  if (!ethAddress) return;
+
+  try {
+    const existing = getUtxoReservations(ethAddress);
+    // Replace any existing reservation with the same batchId
+    const filtered = existing.filter((r) => r.batchId !== reservation.batchId);
+    saveReservations(ethAddress, [...filtered, reservation]);
+  } catch (error) {
+    logger.warn("[peginStorage] Failed to write UTXO reservation", {
+      category: "peginStorage",
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+/**
+ * Remove a UTXO reservation after the deposit flow completes (success or
+ * failure). The real pending pegin entries supersede the early reservation.
+ */
+export function removeUtxoReservation(
+  ethAddress: string,
+  batchId: string,
+): void {
+  if (!ethAddress) return;
+
+  try {
+    const existing = getUtxoReservations(ethAddress);
+    const filtered = existing.filter((r) => r.batchId !== batchId);
+    saveReservations(ethAddress, filtered);
+  } catch (error) {
+    logger.warn("[peginStorage] Failed to remove UTXO reservation", {
+      category: "peginStorage",
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
 }

--- a/services/vault/src/storage/usePeginStorage.ts
+++ b/services/vault/src/storage/usePeginStorage.ts
@@ -9,7 +9,11 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { getNetworkConfigBTC } from "../config";
-import { STORAGE_UPDATE_EVENT } from "../constants";
+import {
+  STORAGE_KEY_PREFIX,
+  STORAGE_UPDATE_EVENT,
+  UTXO_RESERVATION_KEY_PREFIX,
+} from "../constants";
 import {
   ContractStatus,
   getPeginState,
@@ -80,7 +84,6 @@ export function usePeginStorage({
     const handleCustomEvent = (e: Event) => {
       const customEvent = e as CustomEvent<{ ethAddress: string }>;
       if (customEvent.detail.ethAddress === ethAddress) {
-        // Trigger refresh by incrementing version
         setStorageVersion((v) => v + 1);
       }
     };
@@ -89,6 +92,31 @@ export function usePeginStorage({
 
     return () => {
       window.removeEventListener(STORAGE_UPDATE_EVENT, handleCustomEvent);
+    };
+  }, [ethAddress]);
+
+  // Listen for native storage events from OTHER tabs.
+  // The native StorageEvent fires cross-tab when localStorage is modified,
+  // closing the gap where Tab B wouldn't see Tab A's writes until next poll.
+  // Includes UTXO_RESERVATION_KEY_PREFIX so deposit flows in other tabs
+  // trigger a re-read of pending state (reservations are read imperatively
+  // by useDepositFlow, but the version bump ensures derived UI stays fresh).
+  useEffect(() => {
+    if (!ethAddress) return;
+
+    const handleStorageEvent = (e: StorageEvent) => {
+      if (
+        e.key?.startsWith(STORAGE_KEY_PREFIX) ||
+        e.key?.startsWith(UTXO_RESERVATION_KEY_PREFIX)
+      ) {
+        setStorageVersion((v) => v + 1);
+      }
+    };
+
+    window.addEventListener("storage", handleStorageEvent);
+
+    return () => {
+      window.removeEventListener("storage", handleStorageEvent);
     };
   }, [ethAddress]);
 

--- a/services/vault/src/storage/usePeginStorage.ts
+++ b/services/vault/src/storage/usePeginStorage.ts
@@ -106,8 +106,8 @@ export function usePeginStorage({
 
     const handleStorageEvent = (e: StorageEvent) => {
       if (
-        e.key?.startsWith(STORAGE_KEY_PREFIX) ||
-        e.key?.startsWith(UTXO_RESERVATION_KEY_PREFIX)
+        e.key === `${STORAGE_KEY_PREFIX}-${ethAddress}` ||
+        e.key === `${UTXO_RESERVATION_KEY_PREFIX}-${ethAddress}`
       ) {
         setStorageVersion((v) => v + 1);
       }


### PR DESCRIPTION
## Summary

Fixes a TOCTOU race condition where two browser tabs could select the same UTXOs for deposit (audit v2 finding #19, MEDIUM).

The race window was from UTXO selection to localStorage write (~1-3 minutes), spanning WOTS derivation, PoP signing, and ETH registration. During this window, another tab reading localStorage would see no reservation and could select the same UTXOs — resulting in vaults registered on Ethereum but unfundable on Bitcoin.

### Changes

**Early UTXO reservation** — Writes a lightweight reservation to localStorage (separate key: `vault-utxo-reservations-{address}`) immediately after `preparePeginTransaction()`, **before** any wallet interaction or ETH registration. Other tabs see these reserved UTXOs via `collectReservedUtxoRefs` and avoid selecting them. Reservations are:
- Cleaned up on success (superseded by real pending pegin entries)
- Cleaned up on failure (catch block)
- Auto-expired after 5 minutes (TTL for crashed tabs)

**Cross-tab storage event listener** — Adds a native `StorageEvent` listener in `usePeginStorage` so Tab B immediately reacts to Tab A's localStorage writes. Previously only same-window `CustomEvent` was listened to — the native event fires cross-tab.

Closes https://github.com/babylonlabs-io/vault-provider-proxy/issues/113