### PR TITLE
fix(vault): read activation hashlock from on-chain BTCVaultRegistry

### DIFF
--- a/services/vault/src/clients/eth-contract/sdk-readers.ts
+++ b/services/vault/src/clients/eth-contract/sdk-readers.ts
@@ -16,6 +16,7 @@ import {
   ViemProtocolParamsReader,
   ViemUniversalChallengerReader,
   ViemVaultKeeperReader,
+  ViemVaultRegistryReader,
 } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
 
 import { CONTRACTS } from "../../config/contracts";
@@ -25,6 +26,7 @@ import { ethClient } from "./client";
 let protocolParamsReader: ViemProtocolParamsReader | null = null;
 let vaultKeeperReader: ViemVaultKeeperReader | null = null;
 let universalChallengerReader: ViemUniversalChallengerReader | null = null;
+let vaultRegistryReader: ViemVaultRegistryReader | null = null;
 let initPromise: Promise<void> | null = null;
 
 /**
@@ -96,4 +98,22 @@ export async function getVaultKeeperReader(): Promise<ViemVaultKeeperReader> {
 export async function getUniversalChallengerReader(): Promise<ViemUniversalChallengerReader> {
   await ensureReaders();
   return universalChallengerReader!;
+}
+
+/**
+ * Get the vault registry reader (contract-based).
+ *
+ * Synchronous construction: the BTCVaultRegistry address is known statically
+ * via CONTRACTS, so this reader does NOT depend on `resolveProtocolAddresses`
+ * and skips the shared init path. That keeps activation a true one-RPC
+ * operation on cold start (just `getBtcVaultProtocolInfo`).
+ */
+export function getVaultRegistryReader(): ViemVaultRegistryReader {
+  if (!vaultRegistryReader) {
+    vaultRegistryReader = new ViemVaultRegistryReader(
+      ethClient.getPublicClient(),
+      CONTRACTS.BTC_VAULT_REGISTRY,
+    );
+  }
+  return vaultRegistryReader;
 }

--- a/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
+++ b/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
@@ -8,8 +8,10 @@ import { act, renderHook } from "@testing-library/react";
 import type { Hex } from "viem";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { getVaultRegistryReader } from "@/clients/eth-contract/sdk-readers";
 import { ContractStatus } from "@/models/peginStateMachine";
 import { broadcastPrePeginTransaction, fetchVaultById } from "@/services/vault";
+import { activateVaultWithSecret } from "@/services/vault/vaultActivationService";
 
 import { useVaultActions } from "../useVaultActions";
 
@@ -50,6 +52,10 @@ vi.mock("@/services/vault", () => ({
   },
 }));
 
+vi.mock("@/clients/eth-contract/sdk-readers", () => ({
+  getVaultRegistryReader: vi.fn(),
+}));
+
 vi.mock("@/services/vault/vaultActivationService", () => ({
   activateVaultWithSecret: vi.fn(),
 }));
@@ -83,6 +89,19 @@ const mockFetchVaultById = vi.mocked(fetchVaultById);
 const mockBroadcastPrePeginTransaction = vi.mocked(
   broadcastPrePeginTransaction,
 );
+const mockGetVaultRegistryReader = vi.mocked(getVaultRegistryReader);
+const mockActivateVaultWithSecret = vi.mocked(activateVaultWithSecret);
+
+/** Build a fake reader that returns a fixed protocolInfo from getVaultProtocolInfo. */
+function readerReturning(
+  protocolInfo: Record<string, unknown>,
+): ReturnType<typeof getVaultRegistryReader> {
+  return {
+    getVaultProtocolInfo: vi.fn().mockResolvedValue(protocolInfo),
+    getVaultBasicInfo: vi.fn(),
+    getVaultData: vi.fn(),
+  } as unknown as ReturnType<typeof getVaultRegistryReader>;
+}
 
 // Local copy produced by WASM — no 0x prefix
 const TRUSTED_TX_HEX = "70736274ff...trustedtx";
@@ -237,5 +256,110 @@ describe("useVaultActions — handleBroadcast transaction integrity", () => {
     expect(mockBroadcastPrePeginTransaction).toHaveBeenCalledWith(
       expect.objectContaining({ unsignedTxHex: GRAPHQL_TX_HEX }),
     );
+  });
+});
+
+describe("useVaultActions — handleActivation hashlock source", () => {
+  // SHA-256 of 0x000000...01 (32-byte preimage)
+  const SECRET =
+    "0x0000000000000000000000000000000000000000000000000000000000000001";
+  const ON_CHAIN_HASHLOCK =
+    "0xec4916dd28fc4c10d78e287ca5d9cc51ee1ae73cbfde08c6b37324cbfaac8bc5";
+
+  const baseActivationParams = {
+    vaultId: "0xvaultId" as Hex,
+    secretHex: SECRET,
+    depositorEthAddress: "0xdepositor",
+    onRefetchActivities: vi.fn(),
+    onShowSuccessModal: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses the on-chain hashlock and never reads the indexer hashlock", async () => {
+    const reader = readerReturning({
+      depositorSignedPeginTx: "0xdeadbeef",
+      hashlock: ON_CHAIN_HASHLOCK,
+    });
+    mockGetVaultRegistryReader.mockReturnValue(reader);
+    mockActivateVaultWithSecret.mockResolvedValue(undefined as never);
+
+    const { result } = renderHook(() => useVaultActions());
+
+    await act(async () => {
+      await result.current.handleActivation(baseActivationParams);
+    });
+
+    expect(reader.getVaultProtocolInfo).toHaveBeenCalledWith("0xvaultId");
+    // fetchVaultById must not be called for activation — indexer is untrusted
+    // for this validation step.
+    expect(mockFetchVaultById).not.toHaveBeenCalled();
+    expect(mockActivateVaultWithSecret).toHaveBeenCalledTimes(1);
+    expect(result.current.activationError).toBeNull();
+  });
+
+  it("rejects an invalid secret using the on-chain hashlock without sending the tx", async () => {
+    const reader = readerReturning({
+      depositorSignedPeginTx: "0xdeadbeef",
+      // Different hash — user's secret won't match
+      hashlock:
+        "0x1111111111111111111111111111111111111111111111111111111111111111",
+    });
+    mockGetVaultRegistryReader.mockReturnValue(reader);
+
+    const { result } = renderHook(() => useVaultActions());
+
+    await act(async () => {
+      await result.current.handleActivation(baseActivationParams);
+    });
+
+    expect(reader.getVaultProtocolInfo).toHaveBeenCalled();
+    expect(mockActivateVaultWithSecret).not.toHaveBeenCalled();
+    expect(result.current.activationError).toContain("Invalid secret");
+  });
+
+  it("rejects when on-chain hashlock is missing with a specific diagnostic", async () => {
+    const reader = readerReturning({
+      depositorSignedPeginTx: "0xdeadbeef",
+      hashlock: "0x",
+    });
+    mockGetVaultRegistryReader.mockReturnValue(reader);
+
+    const { result } = renderHook(() => useVaultActions());
+
+    await act(async () => {
+      await result.current.handleActivation(baseActivationParams);
+    });
+
+    expect(mockActivateVaultWithSecret).not.toHaveBeenCalled();
+    // Distinct error from the generic "Invalid secret" path so the user
+    // isn't misled into re-entering a correct secret.
+    expect(result.current.activationError).toBe(
+      "Vault hashlock not found. The vault may not support activation.",
+    );
+  });
+
+  it("surfaces a vault-not-found error when on-chain depositorSignedPeginTx is empty", async () => {
+    const reader = readerReturning({
+      depositorSignedPeginTx: "0x",
+      hashlock: ON_CHAIN_HASHLOCK,
+    });
+    mockGetVaultRegistryReader.mockReturnValue(reader);
+
+    const { result } = renderHook(() => useVaultActions());
+
+    await act(async () => {
+      await result.current.handleActivation(baseActivationParams);
+    });
+
+    expect(mockActivateVaultWithSecret).not.toHaveBeenCalled();
+    // Raw "not found on-chain" detail is normalized to a friendly message
+    // and the vault id is not echoed back in the UI.
+    expect(result.current.activationError).toBe(
+      "Vault not found. The vault ID may be invalid.",
+    );
+    expect(result.current.activationError).not.toContain("0xvaultId");
   });
 });

--- a/services/vault/src/hooks/deposit/useVaultActions.ts
+++ b/services/vault/src/hooks/deposit/useVaultActions.ts
@@ -14,6 +14,7 @@ import { useState } from "react";
 import type { Hex } from "viem";
 import { getWalletClient, switchChain } from "wagmi/actions";
 
+import { getVaultRegistryReader } from "../../clients/eth-contract/sdk-readers";
 import {
   ContractStatus,
   getNextLocalStatus,
@@ -240,12 +241,18 @@ export function useVaultActions(): UseVaultActionsReturn {
     setActivationError(null);
 
     try {
-      // Fetch vault to get hashlock for client-side validation
-      const vault = await fetchVaultById(vaultId);
-      if (!vault) {
-        throw new Error("Vault not found. Please try again.");
+      // Hashlock from on-chain — indexer is untrusted for signing-critical reads.
+      const reader = getVaultRegistryReader();
+      const protocolInfo = await reader.getVaultProtocolInfo(vaultId);
+      if (
+        !protocolInfo.depositorSignedPeginTx ||
+        protocolInfo.depositorSignedPeginTx === "0x"
+      ) {
+        throw new Error(
+          `Vault ${vaultId} not found on-chain or has no pegin transaction`,
+        );
       }
-      if (!vault.hashlock) {
+      if (!protocolInfo.hashlock || protocolInfo.hashlock === "0x") {
         throw new Error(
           "Vault hashlock not found. The vault may not support activation.",
         );
@@ -255,7 +262,7 @@ export function useVaultActions(): UseVaultActionsReturn {
       // SDK version is sync + requires 0x-prefixed inputs.
       const isValid = validateSecretAgainstHashlock(
         ensureHexPrefix(secretHex),
-        ensureHexPrefix(vault.hashlock),
+        ensureHexPrefix(protocolInfo.hashlock),
       );
       if (!isValid) {
         throw new Error(
@@ -290,8 +297,13 @@ export function useVaultActions(): UseVaultActionsReturn {
 
       setActivating(false);
     } catch (err) {
-      const errorMessage =
+      const rawMessage =
         err instanceof Error ? err.message : "Failed to activate vault";
+      // Normalize the on-chain "vault not found" message so we don't leak
+      // implementation detail like the raw vault id into the UI.
+      const errorMessage = rawMessage.includes("not found on-chain")
+        ? "Vault not found. The vault ID may be invalid."
+        : rawMessage;
       setActivationError(errorMessage);
       setActivating(false);
     }


### PR DESCRIPTION
Activation was reading `vault.hashlock` from the indexer (untrusted) to
validate the user's HTLC secret. Switch to BTCVaultRegistry via the SDK's
`ViemVaultRegistryReader.getVaultProtocolInfo`. Cold-start cost is exactly
one RPC — added a sync `getVaultRegistryReader()` factory decoupled from
`resolveProtocolAddresses` since the registry address is statically known.

Existence checked inline; "not found" surfaced via the existing friendly
`BTCVaultNotFound` copy so the UI doesn't leak the vault id.