### PR TITLE
fix(vault): indexer validation

### DIFF
--- a/services/vault/src/clients/eth-contract/btc-vault-registry/__tests__/query.test.ts
+++ b/services/vault/src/clients/eth-contract/btc-vault-registry/__tests__/query.test.ts
@@ -63,6 +63,8 @@ describe("getVaultFromChain", () => {
       offchainParamsVersion: PROTOCOL_INFO.offchainParamsVersion,
       hashlock: PROTOCOL_INFO.hashlock,
       htlcVout: PROTOCOL_INFO.htlcVout,
+      amount: BASIC_INFO.amount,
+      prePeginTxHash: PROTOCOL_INFO.prePeginTxHash,
     });
   });
 

--- a/services/vault/src/clients/eth-contract/btc-vault-registry/query.ts
+++ b/services/vault/src/clients/eth-contract/btc-vault-registry/query.ts
@@ -29,6 +29,10 @@ export interface OnChainVaultData {
   hashlock: Hex;
   /** Index of the HTLC output in the Pre-PegIn transaction */
   htlcVout: number;
+  /** Vault deposit amount in satoshis */
+  amount: bigint;
+  /** Hash of the Pre-PegIn transaction (bytes32, 0x-prefixed) */
+  prePeginTxHash: Hex;
   // Note: depositorPayoutBtcAddress is not in the BTCVault struct — only emitted
   // in the PegInSubmitted event. Source it from the indexer instead.
 }
@@ -109,5 +113,7 @@ export async function getVaultFromChain(
     offchainParamsVersion: Number(protocolInfo.offchainParamsVersion),
     hashlock: protocolInfo.hashlock,
     htlcVout: Number(protocolInfo.htlcVout),
+    amount: basicInfo.amount,
+    prePeginTxHash: protocolInfo.prePeginTxHash,
   };
 }

--- a/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
+++ b/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
@@ -140,9 +140,9 @@ const baseVault = {
 };
 
 const baseBroadcastParams = {
-  activityId: "0xvaultId" as Hex,
-  activityAmount: "0.01",
-  activityProviders: [{ id: "0xprovider" }],
+  vaultId: "0xvaultId" as Hex,
+  amount: "0.01",
+  providers: [{ id: "0xprovider" }],
   onRefetchActivities: vi.fn(),
   onShowSuccessModal: vi.fn(),
 };

--- a/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
+++ b/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
@@ -96,6 +96,7 @@ vi.mock("@/models/peginStateMachine", async (importOriginal) => {
     getNextLocalStatus: vi.fn(() => "CONFIRMING"),
     PeginAction: {
       SIGN_AND_BROADCAST_TO_BITCOIN: "SIGN_AND_BROADCAST_TO_BITCOIN",
+      ACTIVATE_VAULT: "ACTIVATE_VAULT",
     },
     LocalStorageStatus: {
       PENDING: "PENDING",

--- a/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
+++ b/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
@@ -8,6 +8,7 @@ import { act, renderHook } from "@testing-library/react";
 import type { Hex } from "viem";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { getVaultFromChain } from "@/clients/eth-contract/btc-vault-registry/query";
 import { getVaultRegistryReader } from "@/clients/eth-contract/sdk-readers";
 import { ContractStatus } from "@/models/peginStateMachine";
 import { broadcastPrePeginTransaction, fetchVaultById } from "@/services/vault";
@@ -21,6 +22,25 @@ vi.mock("@babylonlabs-io/config", () => ({
 
 vi.mock("@babylonlabs-io/ts-sdk/tbv/core", () => ({
   ensureHexPrefix: vi.fn((v: string) => (v.startsWith("0x") ? v : `0x${v}`)),
+}));
+
+vi.mock("@babylonlabs-io/ts-sdk/tbv/core/utils", () => ({
+  calculateBtcTxHash: vi.fn(() => "0xmatching_pre_pegin_hash"),
+  UtxoNotAvailableError: class UtxoNotAvailableError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = "UtxoNotAvailableError";
+    }
+  },
+}));
+
+vi.mock("@/clients/eth-contract/btc-vault-registry/query", () => ({
+  getVaultFromChain: vi.fn(() =>
+    Promise.resolve({
+      prePeginTxHash: "0xmatching_pre_pegin_hash",
+      hashlock: "0xonchain_hashlock",
+    }),
+  ),
 }));
 
 vi.mock("@babylonlabs-io/wallet-connector", () => ({
@@ -89,6 +109,7 @@ const mockFetchVaultById = vi.mocked(fetchVaultById);
 const mockBroadcastPrePeginTransaction = vi.mocked(
   broadcastPrePeginTransaction,
 );
+const mockGetVaultFromChain = vi.mocked(getVaultFromChain);
 const mockGetVaultRegistryReader = vi.mocked(getVaultRegistryReader);
 const mockActivateVaultWithSecret = vi.mocked(activateVaultWithSecret);
 
@@ -256,6 +277,32 @@ describe("useVaultActions — handleBroadcast transaction integrity", () => {
     expect(mockBroadcastPrePeginTransaction).toHaveBeenCalledWith(
       expect.objectContaining({ unsignedTxHex: GRAPHQL_TX_HEX }),
     );
+  });
+
+  it("throws when no local copy and indexer tx hash mismatches on-chain", async () => {
+    mockFetchVaultById.mockResolvedValue(baseVault as never);
+    mockGetVaultFromChain.mockResolvedValue({
+      prePeginTxHash: "0xonchain_hash",
+    } as never);
+
+    const { calculateBtcTxHash } = await import(
+      "@babylonlabs-io/ts-sdk/tbv/core/utils"
+    );
+    vi.mocked(calculateBtcTxHash).mockReturnValue("0xdifferent_hash");
+
+    const { result } = renderHook(() => useVaultActions());
+
+    await act(async () => {
+      await result.current.handleBroadcast({
+        ...baseBroadcastParams,
+        pendingPegin: undefined,
+      });
+    });
+
+    expect(result.current.broadcastError).toContain(
+      "Transaction integrity check failed",
+    );
+    expect(mockBroadcastPrePeginTransaction).not.toHaveBeenCalled();
   });
 });
 

--- a/services/vault/src/hooks/deposit/useBroadcastState.ts
+++ b/services/vault/src/hooks/deposit/useBroadcastState.ts
@@ -63,10 +63,10 @@ export function useBroadcastState({
     setLocalBroadcasting(true);
     try {
       await vaultHandleBroadcast({
-        activityId: activity.id,
-        activityAmount: activity.collateral.amount,
-        activityProviders: activity.providers,
-        activityApplicationEntryPoint: activity.applicationEntryPoint,
+        vaultId: activity.id,
+        amount: activity.collateral.amount,
+        providers: activity.providers,
+        applicationEntryPoint: activity.applicationEntryPoint,
         pendingPegin,
         updatePendingPeginStatus,
         addPendingPegin,

--- a/services/vault/src/hooks/deposit/useVaultActions.ts
+++ b/services/vault/src/hooks/deposit/useVaultActions.ts
@@ -5,7 +5,10 @@
 import { getETHChain } from "@babylonlabs-io/config";
 import { ensureHexPrefix } from "@babylonlabs-io/ts-sdk/tbv/core";
 import { validateSecretAgainstHashlock } from "@babylonlabs-io/ts-sdk/tbv/core/services";
-import { UtxoNotAvailableError } from "@babylonlabs-io/ts-sdk/tbv/core/utils";
+import {
+  calculateBtcTxHash,
+  UtxoNotAvailableError,
+} from "@babylonlabs-io/ts-sdk/tbv/core/utils";
 import {
   getSharedWagmiConfig,
   useChainConnector,
@@ -14,6 +17,7 @@ import { useState } from "react";
 import type { Hex } from "viem";
 import { getWalletClient, switchChain } from "wagmi/actions";
 
+import { getVaultFromChain } from "../../clients/eth-contract/btc-vault-registry/query";
 import { getVaultRegistryReader } from "../../clients/eth-contract/sdk-readers";
 import {
   ContractStatus,
@@ -136,6 +140,25 @@ export function useVaultActions(): UseVaultActionsReturn {
           "Transaction mismatch: the indexer returned a transaction that differs from the locally stored copy. Aborting to prevent a potential attack.",
         );
       }
+
+      // When no local copy exists (cross-device scenario), validate the
+      // indexer-provided transaction against the on-chain prePeginTxHash.
+      // The tx hash commits to all inputs AND outputs, so a substituted
+      // transaction would produce a different hash.
+      if (!localUnsignedTxHex) {
+        const onChainVault = await getVaultFromChain(activityId);
+        const computedHash = calculateBtcTxHash(graphqlUnsignedTxHex);
+        if (
+          computedHash.toLowerCase() !==
+          onChainVault.prePeginTxHash.toLowerCase()
+        ) {
+          throw new Error(
+            "Transaction integrity check failed: the indexer-provided Pre-PegIn transaction " +
+              "does not match the hash stored on-chain. Aborting to prevent a potential attack.",
+          );
+        }
+      }
+
       const unsignedTxHex = localUnsignedTxHex || graphqlUnsignedTxHex;
 
       // Get BTC wallet provider
@@ -254,7 +277,7 @@ export function useVaultActions(): UseVaultActionsReturn {
       }
       if (!protocolInfo.hashlock || protocolInfo.hashlock === "0x") {
         throw new Error(
-          "Vault hashlock not found. The vault may not support activation.",
+          "Vault hashlock not found on-chain. The vault may not support activation.",
         );
       }
 

--- a/services/vault/src/hooks/deposit/useVaultActions.ts
+++ b/services/vault/src/hooks/deposit/useVaultActions.ts
@@ -36,10 +36,10 @@ import type { PendingPeginRequest } from "../../storage/peginStorage";
 import { stripHexPrefix } from "../../utils/btc";
 
 export interface BroadcastPrePeginParams {
-  activityId: Hex;
-  activityAmount: string;
-  activityProviders: Array<{ id: string }>;
-  activityApplicationEntryPoint?: string;
+  vaultId: Hex;
+  amount: string;
+  providers: Array<{ id: string }>;
+  applicationEntryPoint?: string;
   pendingPegin?: PendingPeginRequest;
   updatePendingPeginStatus?: (
     vaultId: string,
@@ -97,10 +97,10 @@ export function useVaultActions(): UseVaultActionsReturn {
    */
   const handleBroadcast = async (params: BroadcastPrePeginParams) => {
     const {
-      activityId,
-      activityAmount,
-      activityProviders,
-      activityApplicationEntryPoint,
+      vaultId,
+      amount,
+      providers,
+      applicationEntryPoint,
       pendingPegin,
       updatePendingPeginStatus,
       addPendingPegin,
@@ -113,7 +113,7 @@ export function useVaultActions(): UseVaultActionsReturn {
 
     try {
       // Fetch vault data from GraphQL
-      const vault = await fetchVaultById(activityId);
+      const vault = await fetchVaultById(vaultId);
 
       if (!vault) {
         throw new Error("Vault not found. Please try again.");
@@ -146,7 +146,7 @@ export function useVaultActions(): UseVaultActionsReturn {
       // The tx hash commits to all inputs AND outputs, so a substituted
       // transaction would produce a different hash.
       if (!localUnsignedTxHex) {
-        const onChainVault = await getVaultFromChain(activityId);
+        const onChainVault = await getVaultFromChain(vaultId);
         const computedHash = calculateBtcTxHash(graphqlUnsignedTxHex);
         if (
           computedHash.toLowerCase() !==
@@ -209,14 +209,14 @@ export function useVaultActions(): UseVaultActionsReturn {
 
       if (pendingPegin && updatePendingPeginStatus && nextStatus) {
         // Case 1: localStorage entry EXISTS - update status
-        updatePendingPeginStatus(activityId, nextStatus);
+        updatePendingPeginStatus(vaultId, nextStatus);
       } else if (addPendingPegin && nextStatus) {
         // Case 2: NO localStorage entry (cross-device) - create one with status
         addPendingPegin({
-          id: activityId,
-          amount: activityAmount,
-          providerIds: activityProviders.map((p) => p.id),
-          applicationEntryPoint: activityApplicationEntryPoint,
+          id: vaultId,
+          amount,
+          providerIds: providers.map((p) => p.id),
+          applicationEntryPoint,
           peginTxHash: vault.peginTxHash,
           depositorBtcPubkey: vault.depositorBtcPubkey,
           unsignedTxHex: vault.unsignedPrePeginTx,
@@ -277,7 +277,7 @@ export function useVaultActions(): UseVaultActionsReturn {
       }
       if (!protocolInfo.hashlock || protocolInfo.hashlock === "0x") {
         throw new Error(
-          "Vault hashlock not found on-chain. The vault may not support activation.",
+          "Vault hashlock not found. The vault may not support activation.",
         );
       }
 

--- a/services/vault/src/services/vault/__tests__/fetchVaults.test.ts
+++ b/services/vault/src/services/vault/__tests__/fetchVaults.test.ts
@@ -350,7 +350,6 @@ describe("fetchVaults", () => {
         vault: {
           id: VALID_VAULT_ID,
           depositorBtcPubKey: btcPub,
-          amount: "150000",
           unsignedPrePeginTx: preTx,
         },
       });
@@ -363,7 +362,6 @@ describe("fetchVaults", () => {
 
       expect(result).toEqual({
         depositorBtcPubkey: btcPub,
-        amount: 150_000n,
         unsignedPrePeginTx: preTx,
       });
       expect(mockedRequest).toHaveBeenCalledOnce();

--- a/services/vault/src/services/vault/__tests__/vaultRefundService.test.ts
+++ b/services/vault/src/services/vault/__tests__/vaultRefundService.test.ts
@@ -18,6 +18,10 @@ vi.mock("../../../clients/btc/config", () => ({
   getMempoolApiUrl: vi.fn().mockReturnValue("https://mempool.space/api"),
 }));
 
+vi.mock("@babylonlabs-io/ts-sdk/tbv/core/utils", () => ({
+  calculateBtcTxHash: vi.fn(() => "0xmatching_pre_pegin_hash"),
+}));
+
 vi.mock("../../../clients/eth-contract/btc-vault-registry/query", () => ({
   getVaultFromChain: vi.fn(),
 }));
@@ -53,6 +57,7 @@ vi.mock("../fetchVaults", () => ({
 }));
 
 import { getNetworkFees, pushTx } from "@babylonlabs-io/ts-sdk/tbv/core";
+import { calculateBtcTxHash } from "@babylonlabs-io/ts-sdk/tbv/core/utils";
 import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 
 import { getVaultFromChain } from "../../../clients/eth-contract/btc-vault-registry/query";
@@ -71,6 +76,8 @@ const ON_CHAIN_VAULT = {
   universalChallengersVersion: 1,
   hashlock: "0xhashlock",
   htlcVout: 1,
+  amount: 100_000n,
+  prePeginTxHash: "0xmatching_pre_pegin_hash",
 };
 const OFFCHAIN_PARAMS = {
   tRefund: 144,
@@ -83,7 +90,6 @@ const VAULT_KEEPERS = [{ btcPubKey: "vk1" }, { btcPubKey: "vk2" }];
 const UNIVERSAL_CHALLENGERS = [{ btcPubKey: "uc1" }];
 const INDEXER_VAULT = {
   unsignedPrePeginTx: "0xrawtx",
-  amount: 100_000n,
   depositorBtcPubkey: "indexer_depositor_pubkey",
 };
 const BTC_WALLET_PROVIDER = {
@@ -94,6 +100,7 @@ describe("vaultRefundService - adapter wiring", () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
+    (calculateBtcTxHash as Mock).mockReturnValue(ON_CHAIN_VAULT.prePeginTxHash);
     (getVaultFromChain as Mock).mockResolvedValue(ON_CHAIN_VAULT);
     (fetchVaultRefundData as Mock).mockResolvedValue(INDEXER_VAULT);
     mockGetOffchainParamsByVersion.mockResolvedValue(OFFCHAIN_PARAMS);
@@ -166,9 +173,22 @@ describe("vaultRefundService - adapter wiring", () => {
     expect(observed).not.toBeNull();
     expect(observed!.hashlock).toBe(ON_CHAIN_VAULT.hashlock);
     expect(observed!.htlcVout).toBe(ON_CHAIN_VAULT.htlcVout);
-    expect(observed!.amount).toBe(INDEXER_VAULT.amount);
+    // Amount must come from on-chain contract, NOT the indexer.
+    expect(observed!.amount).toBe(ON_CHAIN_VAULT.amount);
     // Must be the caller-provided wallet pubkey, NOT the indexer value.
     expect(observed!.depositorBtcPubkey).toBe(DEPOSITOR_PUBKEY);
+  });
+
+  it("throws when indexer Pre-PegIn tx hash does not match on-chain", async () => {
+    (calculateBtcTxHash as Mock).mockReturnValue("0xdifferent_hash");
+
+    await expect(
+      buildAndBroadcastRefundTransaction({
+        vaultId: VAULT_ID,
+        btcWalletProvider: BTC_WALLET_PROVIDER,
+        depositorBtcPubkey: DEPOSITOR_PUBKEY,
+      }),
+    ).rejects.toThrow("Pre-PegIn transaction hash mismatch");
   });
 
   it("throws when vault is not found in indexer", async () => {

--- a/services/vault/src/services/vault/fetchVaults.ts
+++ b/services/vault/src/services/vault/fetchVaults.ts
@@ -417,7 +417,6 @@ export async function fetchVaultById(vaultId: Hex): Promise<Vault | null> {
  */
 export interface VaultRefundIndexerData {
   depositorBtcPubkey: Hex;
-  amount: bigint;
   unsignedPrePeginTx: Hex;
 }
 
@@ -426,7 +425,6 @@ const GET_VAULT_REFUND_DATA = gql`
     vault(id: $id) {
       id
       depositorBtcPubKey
-      amount
       unsignedPrePeginTx
     }
   }
@@ -435,7 +433,6 @@ const GET_VAULT_REFUND_DATA = gql`
 interface VaultRefundGraphQLItem {
   id: string;
   depositorBtcPubKey: string;
-  amount: string;
   unsignedPrePeginTx: string | null;
 }
 
@@ -460,7 +457,7 @@ export async function fetchVaultRefundData(
     return null;
   }
 
-  const { depositorBtcPubKey, amount, unsignedPrePeginTx } = data.vault;
+  const { depositorBtcPubKey, unsignedPrePeginTx } = data.vault;
   if (!unsignedPrePeginTx) {
     throw new Error(
       `Vault ${vaultId} is missing unsignedPrePeginTx; cannot build refund`,
@@ -472,7 +469,6 @@ export async function fetchVaultRefundData(
       "depositorBtcPubKey",
       vaultId,
     ),
-    amount: BigInt(amount),
     unsignedPrePeginTx: validateRequiredHex(
       unsignedPrePeginTx,
       "unsignedPrePeginTx",

--- a/services/vault/src/services/vault/vaultRefundService.ts
+++ b/services/vault/src/services/vault/vaultRefundService.ts
@@ -18,6 +18,7 @@ import {
   type RefundPrePeginContext,
   type VaultRefundData,
 } from "@babylonlabs-io/ts-sdk/tbv/core/services";
+import { calculateBtcTxHash } from "@babylonlabs-io/ts-sdk/tbv/core/utils";
 import type { Hex } from "viem";
 
 import { getMempoolApiUrl } from "../../clients/btc/config";
@@ -48,12 +49,12 @@ export interface BroadcastRefundParams {
 }
 
 async function readVault(vaultId: Hex): Promise<VaultRefundData> {
-  // Versioning fields, hashlock, and htlcVout come from the on-chain contract
-  // — a compromised indexer could otherwise substitute a different signer set.
-  // From the indexer we pull only what refund actually needs: amount + the
-  // funded Pre-PegIn tx hex + the depositor's BTC pubkey. Using a minimal
-  // query (not the full Vault projection) avoids refund being blocked by
-  // indexer schema drift on unrelated fields such as `depositorWotsPkHash`.
+  // Signing-critical fields come from the on-chain contract — a compromised
+  // indexer could otherwise substitute a different signer set, amount, or
+  // transaction. From the indexer we pull only the Pre-PegIn tx hex (not
+  // stored on-chain) and the depositor's BTC pubkey (overridden by the
+  // caller's wallet key before signing). The amount comes from the contract.
+  // The Pre-PegIn tx hex is validated against the on-chain prePeginTxHash.
   const [onChainVault, indexerRefundData] = await Promise.all([
     getVaultFromChain(vaultId),
     fetchVaultRefundData(vaultId),
@@ -61,6 +62,24 @@ async function readVault(vaultId: Hex): Promise<VaultRefundData> {
   if (!indexerRefundData) {
     throw new Error(`Vault ${vaultId} not found`);
   }
+
+  // Validate that the indexer-provided Pre-PegIn tx matches the on-chain hash.
+  // The tx hash commits to all inputs and outputs, so a substituted transaction
+  // would produce a different hash. SegWit txid excludes witness data, so
+  // hash(unsignedTx) === hash(signedTx) === prePeginTxHash.
+  const computedTxHash = calculateBtcTxHash(
+    indexerRefundData.unsignedPrePeginTx,
+  );
+  if (
+    computedTxHash.toLowerCase() !== onChainVault.prePeginTxHash.toLowerCase()
+  ) {
+    throw new Error(
+      `Pre-PegIn transaction hash mismatch: computed ${computedTxHash} from indexer tx, ` +
+        `but on-chain contract has ${onChainVault.prePeginTxHash}. ` +
+        `Aborting refund to prevent potential attack.`,
+    );
+  }
+
   return {
     hashlock: onChainVault.hashlock,
     htlcVout: onChainVault.htlcVout,
@@ -69,7 +88,7 @@ async function readVault(vaultId: Hex): Promise<VaultRefundData> {
     universalChallengersVersion: onChainVault.universalChallengersVersion,
     vaultProvider: onChainVault.vaultProvider,
     applicationEntryPoint: onChainVault.applicationEntryPoint,
-    amount: indexerRefundData.amount,
+    amount: onChainVault.amount,
     unsignedPrePeginTxHex: indexerRefundData.unsignedPrePeginTx,
     depositorBtcPubkey: indexerRefundData.depositorBtcPubkey,
   };


### PR DESCRIPTION
## Summary

Fixes three audit v2 findings (2 HIGH, 1 MEDIUM) that share a root cause: security-critical data sourced from the GraphQL indexer instead of the on-chain BTCVaultRegistry contract.

### Findings addressed

- **[HIGH] [#104](https://github.com/babylonlabs-io/vault-provider-proxy/issues/104) — Refund transaction uses indexer-sourced amount and Pre-PegIn tx without on-chain cross-validation.** A compromised indexer could return a manipulated `amount`, causing the refund PSBT to claim less BTC than owed (burning the difference as miner fees). The `unsignedPrePeginTx` from the indexer was also used without verifying it matches the on-chain record.

- **[HIGH] [#107](https://github.com/babylonlabs-io/vault-provider-proxy/issues/107) — Indexer-controlled Pre-PegIn transaction can be signed and broadcast when no local copy exists.** In the cross-device broadcast path, when `localStorage` has no cached transaction, the indexer-provided `unsignedPrePeginTx` was used directly. A compromised indexer could substitute a transaction spending the user's UTXOs to attacker-controlled outputs — only input availability was validated, not outputs.

- **[MEDIUM] [#115](https://github.com/babylonlabs-io/vault-provider-proxy/issues/115) — Activation secret validation uses indexer hashlock instead of on-chain contract data.** The `handleActivation` flow fetched the hashlock from GraphQL to validate the HTLC secret client-side. A compromised indexer returning a wrong hashlock could block activation until the vault expires, locking funds until the refund timelock.

### Changes

**Shared infrastructure** (`query.ts`):
- Extended `OnChainVaultData` and `getVaultFromChain()` to return `amount` (from `BasicInfo`) and `prePeginTxHash` (from `ProtocolInfo`) — both were already fetched from the contract but discarded in the return object.

**[#104](https://github.com/babylonlabs-io/vault-provider-proxy/issues/104) fix** (`vaultRefundService.ts`, `fetchVaults.ts`):
- Refund now uses `onChainVault.amount` instead of the indexer-sourced amount.
- Before using the indexer's `unsignedPrePeginTx`, its hash is computed via `calculateBtcTxHash()` and asserted to match the on-chain `prePeginTxHash`. A mismatch aborts the refund.
- Removed `amount` from `VaultRefundIndexerData`, the GraphQL query, and `fetchVaultRefundData()` (no longer consumed from indexer).

**[#107](https://github.com/babylonlabs-io/vault-provider-proxy/issues/107) fix** (`useVaultActions.ts`):
- When no local transaction copy exists (cross-device scenario), the indexer-provided transaction is validated against the on-chain `prePeginTxHash` before signing. The tx hash commits to all inputs AND outputs, so any substituted transaction produces a different hash. This relies on the SegWit property that txid excludes witness data, making `hash(unsignedTx) === hash(signedTx)`.

**[#115](https://github.com/babylonlabs-io/vault-provider-proxy/issues/115) fix** (`useVaultActions.ts`):
- `handleActivation` now fetches the hashlock from the on-chain contract via `getVaultFromChain()` instead of the indexer via `fetchVaultById()`.

Closes https://github.com/babylonlabs-io/vault-provider-proxy/issues/115
Closes https://github.com/babylonlabs-io/vault-provider-proxy/issues/107
Closes https://github.com/babylonlabs-io/vault-provider-proxy/issues/104