### PR TITLE
fix(vault): pre-bundle bitcoinjs-lib deps for Vite dev

### DIFF
--- a/services/vault/vite.config.ts
+++ b/services/vault/vite.config.ts
@@ -30,6 +30,11 @@ export default defineConfig({
   },
   optimizeDeps: {
     exclude: ["ws"],
+    include: [
+      "bitcoinjs-lib",
+      "@bitcoin-js/tiny-secp256k1-asmjs",
+      "@babylonlabs-io/wallet-connector",
+    ],
   },
   build: {
     outDir: "dist",


### PR DESCRIPTION
Force optimizeDeps.include for bitcoinjs-lib, tiny-secp256k1-asmjs, and @babylonlabs-io/wallet-connector so the runtime require("bitcoinjs-lib") inside the linked wallet-connector dist (from ledger-bitcoin-babylon- boilerplate) resolves through Vite's CJS interop. Without this, dev mode hits "Cannot read properties of undefined (reading 'payments')" in @bitcoinerlab/descriptors when the wallet modal opens.