### PR TITLE
fix(vault): validate resume-broadcast tx hex against on-chain prePegi…

### DIFF
--- a/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
+++ b/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
@@ -4,6 +4,7 @@
  * a malicious transaction for signing.
  */
 
+import { calculateBtcTxHash } from "@babylonlabs-io/ts-sdk/tbv/core/utils";
 import { act, renderHook } from "@testing-library/react";
 import type { Hex } from "viem";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -21,6 +22,16 @@ vi.mock("@babylonlabs-io/config", () => ({
 
 vi.mock("@babylonlabs-io/ts-sdk/tbv/core", () => ({
   ensureHexPrefix: vi.fn((v: string) => (v.startsWith("0x") ? v : `0x${v}`)),
+}));
+
+vi.mock("@babylonlabs-io/ts-sdk/tbv/core/utils", () => ({
+  calculateBtcTxHash: vi.fn(),
+  UtxoNotAvailableError: class UtxoNotAvailableError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = "UtxoNotAvailableError";
+    }
+  },
 }));
 
 vi.mock("@babylonlabs-io/wallet-connector", () => ({
@@ -91,6 +102,7 @@ const mockBroadcastPrePeginTransaction = vi.mocked(
 );
 const mockGetVaultRegistryReader = vi.mocked(getVaultRegistryReader);
 const mockActivateVaultWithSecret = vi.mocked(activateVaultWithSecret);
+const mockCalculateBtcTxHash = vi.mocked(calculateBtcTxHash);
 
 /** Build a fake reader that returns a fixed protocolInfo from getVaultProtocolInfo. */
 function readerReturning(
@@ -103,6 +115,18 @@ function readerReturning(
   } as unknown as ReturnType<typeof getVaultRegistryReader>;
 }
 
+/** Build a fake reader that returns fixed basic + protocol info from getVaultData. */
+function readerWithVaultData(
+  basic: Record<string, unknown>,
+  protocol: Record<string, unknown>,
+): ReturnType<typeof getVaultRegistryReader> {
+  return {
+    getVaultProtocolInfo: vi.fn().mockResolvedValue(protocol),
+    getVaultBasicInfo: vi.fn().mockResolvedValue(basic),
+    getVaultData: vi.fn().mockResolvedValue({ basic, protocol }),
+  } as unknown as ReturnType<typeof getVaultRegistryReader>;
+}
+
 // Local copy produced by WASM — no 0x prefix
 const TRUSTED_TX_HEX = "70736274ff...trustedtx";
 // Same transaction as returned by the indexer (viem Hex always has 0x prefix)
@@ -110,12 +134,31 @@ const GRAPHQL_TX_HEX = `0x${TRUSTED_TX_HEX}`;
 // A genuinely different transaction returned by a compromised indexer
 const ATTACKER_TX_HEX = "0x70736274ff...attackertx";
 
+const ON_CHAIN_PRE_PEGIN_HASH =
+  "0xaaaa000000000000000000000000000000000000000000000000000000000001";
+const ON_CHAIN_DEPOSITOR_BTC_PUBKEY =
+  "0x000000000000000000000000000000000000000000000000000000000000beef";
+
 const baseVault = {
   unsignedPrePeginTx: GRAPHQL_TX_HEX,
   depositorBtcPubkey: "0xdepositorBtcPubkey",
   peginTxHash: "0xabcd1234",
   status: ContractStatus.PENDING,
 };
+
+/** Default reader: returns matching pre-pegin hash + on-chain depositor pubkey. */
+function defaultReader() {
+  return readerWithVaultData(
+    {
+      depositorBtcPubKey: ON_CHAIN_DEPOSITOR_BTC_PUBKEY,
+      status: 0,
+    },
+    {
+      depositorSignedPeginTx: "0xdeadbeef",
+      prePeginTxHash: ON_CHAIN_PRE_PEGIN_HASH,
+    },
+  );
+}
 
 const baseBroadcastParams = {
   activityId: "0xvaultId" as Hex,
@@ -128,9 +171,12 @@ const baseBroadcastParams = {
 describe("useVaultActions — handleBroadcast transaction integrity", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetVaultRegistryReader.mockReturnValue(defaultReader());
+    // Default: tx hex hashes to the on-chain prePeginTxHash (i.e. trusted).
+    mockCalculateBtcTxHash.mockReturnValue(ON_CHAIN_PRE_PEGIN_HASH);
   });
 
-  it("broadcasts using local tx when it matches GraphQL", async () => {
+  it("broadcasts the local tx when its hash matches the on-chain prePeginTxHash", async () => {
     mockFetchVaultById.mockResolvedValue(baseVault as never);
 
     const { result } = renderHook(() => useVaultActions());
@@ -149,36 +195,38 @@ describe("useVaultActions — handleBroadcast transaction integrity", () => {
     });
 
     expect(result.current.broadcastError).toBeNull();
+    expect(mockCalculateBtcTxHash).toHaveBeenCalledWith(TRUSTED_TX_HEX);
     expect(mockBroadcastPrePeginTransaction).toHaveBeenCalledWith(
       expect.objectContaining({ unsignedTxHex: TRUSTED_TX_HEX }),
     );
   });
 
-  it("throws when local tx hex differs from GraphQL tx hex", async () => {
+  it("rejects when the candidate tx hash does not match on-chain prePeginTxHash", async () => {
     mockFetchVaultById.mockResolvedValue({
       ...baseVault,
       unsignedPrePeginTx: ATTACKER_TX_HEX,
     } as never);
+    // Indexer-supplied (or tampered local) tx hashes to something else.
+    mockCalculateBtcTxHash.mockReturnValue(
+      "0xbeef000000000000000000000000000000000000000000000000000000000002",
+    );
 
     const { result } = renderHook(() => useVaultActions());
 
     await act(async () => {
       await result.current.handleBroadcast({
         ...baseBroadcastParams,
-        pendingPegin: {
-          id: "0xvaultId" as Hex,
-          timestamp: Date.now(),
-          status: "PENDING" as never,
-          peginTxHash: "0xpeginTxHash" as Hex,
-          unsignedTxHex: TRUSTED_TX_HEX,
-        },
+        pendingPegin: undefined,
       });
     });
 
-    expect(result.current.broadcastError).toContain("Transaction mismatch");
+    expect(result.current.broadcastError).toContain(
+      "does not match the on-chain registration",
+    );
+    expect(mockBroadcastPrePeginTransaction).not.toHaveBeenCalled();
   });
 
-  it("uses GraphQL tx when no local copy is available (cross-device)", async () => {
+  it("falls back to indexer tx hex on cross-device and broadcasts when the on-chain hash matches", async () => {
     mockFetchVaultById.mockResolvedValue(baseVault as never);
 
     const { result } = renderHook(() => useVaultActions());
@@ -191,8 +239,29 @@ describe("useVaultActions — handleBroadcast transaction integrity", () => {
     });
 
     expect(result.current.broadcastError).toBeNull();
+    expect(mockCalculateBtcTxHash).toHaveBeenCalledWith(GRAPHQL_TX_HEX);
     expect(mockBroadcastPrePeginTransaction).toHaveBeenCalledWith(
       expect.objectContaining({ unsignedTxHex: GRAPHQL_TX_HEX }),
+    );
+  });
+
+  it("uses the on-chain depositor BTC pubkey for signing, not the indexer-supplied value", async () => {
+    mockFetchVaultById.mockResolvedValue(baseVault as never);
+
+    const { result } = renderHook(() => useVaultActions());
+
+    await act(async () => {
+      await result.current.handleBroadcast({
+        ...baseBroadcastParams,
+        pendingPegin: undefined,
+      });
+    });
+
+    expect(mockBroadcastPrePeginTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        depositorBtcPubkey:
+          "000000000000000000000000000000000000000000000000000000000000beef",
+      }),
     );
   });
 
@@ -215,6 +284,35 @@ describe("useVaultActions — handleBroadcast transaction integrity", () => {
     expect(mockBroadcastPrePeginTransaction).not.toHaveBeenCalled();
   });
 
+  it("rejects broadcast when on-chain status has progressed past PENDING even if indexer still reports PENDING", async () => {
+    mockFetchVaultById.mockResolvedValue(baseVault as never);
+    mockGetVaultRegistryReader.mockReturnValue(
+      readerWithVaultData(
+        {
+          depositorBtcPubKey: ON_CHAIN_DEPOSITOR_BTC_PUBKEY,
+          status: 1, // VERIFIED on-chain
+        },
+        {
+          depositorSignedPeginTx: "0xdeadbeef",
+          prePeginTxHash: ON_CHAIN_PRE_PEGIN_HASH,
+        },
+      ),
+    );
+
+    const { result } = renderHook(() => useVaultActions());
+
+    await act(async () => {
+      await result.current.handleBroadcast({
+        ...baseBroadcastParams,
+        pendingPegin: undefined,
+      });
+    });
+
+    expect(result.current.broadcastError).toContain("on-chain vault status");
+    expect(result.current.broadcastError).toContain("VERIFIED");
+    expect(mockBroadcastPrePeginTransaction).not.toHaveBeenCalled();
+  });
+
   it("rejects broadcast when vault has already progressed past PENDING", async () => {
     mockFetchVaultById.mockResolvedValue({
       ...baseVault,
@@ -234,7 +332,7 @@ describe("useVaultActions — handleBroadcast transaction integrity", () => {
     expect(mockBroadcastPrePeginTransaction).not.toHaveBeenCalled();
   });
 
-  it("uses GraphQL tx when pendingPegin has no unsignedTxHex (cross-device)", async () => {
+  it("uses indexer tx hex when pendingPegin has no unsignedTxHex (cross-device)", async () => {
     mockFetchVaultById.mockResolvedValue(baseVault as never);
 
     const { result } = renderHook(() => useVaultActions());

--- a/services/vault/src/hooks/deposit/useVaultActions.ts
+++ b/services/vault/src/hooks/deposit/useVaultActions.ts
@@ -5,7 +5,10 @@
 import { getETHChain } from "@babylonlabs-io/config";
 import { ensureHexPrefix } from "@babylonlabs-io/ts-sdk/tbv/core";
 import { validateSecretAgainstHashlock } from "@babylonlabs-io/ts-sdk/tbv/core/services";
-import { UtxoNotAvailableError } from "@babylonlabs-io/ts-sdk/tbv/core/utils";
+import {
+  calculateBtcTxHash,
+  UtxoNotAvailableError,
+} from "@babylonlabs-io/ts-sdk/tbv/core/utils";
 import {
   getSharedWagmiConfig,
   useChainConnector,
@@ -108,8 +111,14 @@ export function useVaultActions(): UseVaultActionsReturn {
     setBroadcastError(null);
 
     try {
-      // Fetch vault data from GraphQL
-      const vault = await fetchVaultById(activityId);
+      // Fetch indexer + on-chain in parallel. Indexer is needed for indexer-only
+      // statuses (EXPIRED/INVALID/...) which BTCVaultRegistry doesn't expose;
+      // on-chain provides the authoritative prePeginTxHash and depositorBtcPubKey
+      // for tx-integrity verification.
+      const [vault, onChain] = await Promise.all([
+        fetchVaultById(activityId),
+        getVaultRegistryReader().getVaultData(activityId),
+      ]);
 
       if (!vault) {
         throw new Error("Vault not found. Please try again.");
@@ -121,22 +130,38 @@ export function useVaultActions(): UseVaultActionsReturn {
         );
       }
 
-      const graphqlUnsignedTxHex = vault.unsignedPrePeginTx;
-
-      // Use the locally stored transaction as the source of truth when available.
-      // The local copy was saved before ETH submission and is trustworthy.
-      // A mismatch means the indexer is returning a different transaction — abort.
-      const localUnsignedTxHex = pendingPegin?.unsignedTxHex;
-      if (
-        localUnsignedTxHex &&
-        stripHexPrefix(localUnsignedTxHex).toLowerCase() !==
-          stripHexPrefix(graphqlUnsignedTxHex).toLowerCase()
-      ) {
+      // Cross-check on-chain status. Indexer is the only source for the
+      // 4-7 indexer-derived states (EXPIRED/INVALID/...) but for 0-3
+      // (Pending/Verified/Active/Redeemed) the contract is authoritative —
+      // a stale or malicious indexer reporting PENDING for a vault that's
+      // already moved past it would otherwise still trigger UTXO checks
+      // and a wallet prompt.
+      if (onChain.basic.status !== ContractStatus.PENDING) {
         throw new Error(
-          "Transaction mismatch: the indexer returned a transaction that differs from the locally stored copy. Aborting to prevent a potential attack.",
+          `Cannot broadcast: on-chain vault status is ${ContractStatus[onChain.basic.status]}. Broadcast is only valid during PENDING.`,
         );
       }
-      const unsignedTxHex = localUnsignedTxHex || graphqlUnsignedTxHex;
+
+      // Pick a candidate unsigned tx hex (prefer the local copy saved at
+      // construction time; fall back to the indexer for cross-device resume).
+      // Either source is untrusted on its own — the on-chain hash check below
+      // is the authoritative invariant.
+      const candidateUnsignedTxHex =
+        pendingPegin?.unsignedTxHex || vault.unsignedPrePeginTx;
+
+      // Authoritative integrity check: the candidate must hash to the
+      // prePeginTxHash registered on-chain. Closes the cross-device fallback
+      // gap (auditor #2) where a malicious indexer could substitute the tx.
+      const computedTxHash = calculateBtcTxHash(candidateUnsignedTxHex);
+      if (
+        computedTxHash.toLowerCase() !==
+        onChain.protocol.prePeginTxHash.toLowerCase()
+      ) {
+        throw new Error(
+          "Pre-PegIn transaction does not match the on-chain registration. Aborting to prevent broadcasting an unregistered transaction.",
+        );
+      }
+      const unsignedTxHex = candidateUnsignedTxHex;
 
       // Get BTC wallet provider
       const btcWalletProvider = btcConnector?.connectedWallet?.provider;
@@ -146,12 +171,14 @@ export function useVaultActions(): UseVaultActionsReturn {
         );
       }
 
-      // Get depositor's BTC public key (needed for Taproot signing)
-      // Strip "0x" prefix since it comes from GraphQL (Ethereum-style hex)
-      const depositorBtcPubkey = stripHexPrefix(vault.depositorBtcPubkey);
+      // Use the on-chain depositor BTC pubkey for Taproot signing options —
+      // never the indexer-supplied value.
+      const depositorBtcPubkey = stripHexPrefix(
+        onChain.basic.depositorBtcPubKey,
+      );
       if (!depositorBtcPubkey) {
         throw new Error(
-          "Depositor BTC public key not found. Please try creating the peg-in request again.",
+          "Depositor BTC public key not found on-chain. Please try creating the peg-in request again.",
         );
       }
 
@@ -188,15 +215,18 @@ export function useVaultActions(): UseVaultActionsReturn {
         // Case 1: localStorage entry EXISTS - update status
         updatePendingPeginStatus(activityId, nextStatus);
       } else if (addPendingPegin && nextStatus) {
-        // Case 2: NO localStorage entry (cross-device) - create one with status
+        // Case 2: NO localStorage entry (cross-device) - create one using the
+        // values we just validated against the contract, not the raw indexer
+        // response. Persisting indexer-tainted values would re-introduce the
+        // trust boundary on the next pending-activity flow.
         addPendingPegin({
           id: activityId,
           amount: activityAmount,
           providerIds: activityProviders.map((p) => p.id),
           applicationEntryPoint: activityApplicationEntryPoint,
           peginTxHash: vault.peginTxHash,
-          depositorBtcPubkey: vault.depositorBtcPubkey,
-          unsignedTxHex: vault.unsignedPrePeginTx,
+          depositorBtcPubkey: onChain.basic.depositorBtcPubKey,
+          unsignedTxHex,
           status: nextStatus,
         });
       }


### PR DESCRIPTION
Resume / cross-device broadcast was reading `unsignedPrePeginTx` and
`depositorBtcPubkey` from the indexer (untrusted) — a compromised indexer
could substitute a malicious tx (auditor #2). Now asserts
`calculateBtcTxHash(candidateUnsignedTxHex) === onChain.protocol.prePeginTxHash`
before signing and uses on-chain `depositorBtcPubKey` for signing options.
Status also cross-checked on-chain. localStorage writes persist validated
values, not raw indexer response.