### PR TITLE
fix(vault): make wallet-vs-indexer payout address check mandatory in …

### DIFF
--- a/services/vault/src/components/deposit/PayoutSignModal/__tests__/usePayoutSigningState.test.tsx
+++ b/services/vault/src/components/deposit/PayoutSignModal/__tests__/usePayoutSigningState.test.tsx
@@ -181,6 +181,25 @@ describe("usePayoutSigningState", () => {
       expect(mockSignAndSubmitPayouts).not.toHaveBeenCalled();
     });
 
+    it("rejects signing when the wallet address is unavailable instead of skipping the payout-address check", async () => {
+      // Regression: previously the wallet-vs-indexer scriptPubKey comparison
+      // was wrapped in `if (connectedBtcAddress)`, so a wallet with a connector
+      // but no readable address would silently bypass the security guard.
+      mockBtcConnector = {
+        connectedWallet: { provider: BTC_WALLET },
+      };
+
+      const { result } = renderHookWithProps();
+
+      await act(async () => {
+        await result.current.handleSign();
+      });
+
+      expect(result.current.error?.title).toBe("Wallet Address Unavailable");
+      expect(mockBtcAddressToScriptPubKeyHex).not.toHaveBeenCalled();
+      expect(mockSignAndSubmitPayouts).not.toHaveBeenCalled();
+    });
+
     it("errors when vault provider is not found", async () => {
       mockFindProvider.mockReturnValue(undefined);
 

--- a/services/vault/src/components/deposit/PayoutSignModal/usePayoutSigningState.ts
+++ b/services/vault/src/components/deposit/PayoutSignModal/usePayoutSigningState.ts
@@ -115,30 +115,38 @@ export function usePayoutSigningState({
 
       // Security: the indexer-sourced payout scriptPubKey must match the
       // connected wallet. A compromised indexer could otherwise trick signing
-      // over an attacker-chosen payout address.
+      // over an attacker-chosen payout address. Mandatory — never skip this
+      // guard if the wallet address can't be read; reject upfront instead.
       const connectedBtcAddress =
         btcConnector?.connectedWallet?.account?.address;
-      if (connectedBtcAddress) {
-        let walletScriptPubKey: string;
-        try {
-          walletScriptPubKey = btcAddressToScriptPubKeyHex(connectedBtcAddress);
-        } catch {
-          setError({
-            title: "Wallet Address Error",
-            message:
-              "Could not read your Bitcoin wallet address. Please reconnect the wallet and make sure it is on the correct Bitcoin network.",
-          });
-          return;
-        }
-        if (walletScriptPubKey !== activity.depositorPayoutBtcAddress) {
-          setError({
-            title: "Payout Address Mismatch",
-            message:
-              "The payout address from the indexer does not match your connected wallet. " +
-              "This may indicate a data integrity issue. Please verify your wallet connection.",
-          });
-          return;
-        }
+      if (!connectedBtcAddress) {
+        setError({
+          title: "Wallet Address Unavailable",
+          message:
+            "Connect the BTC wallet you used at deposit to verify the payout address before signing.",
+        });
+        return;
+      }
+
+      let walletScriptPubKey: string;
+      try {
+        walletScriptPubKey = btcAddressToScriptPubKeyHex(connectedBtcAddress);
+      } catch {
+        setError({
+          title: "Wallet Address Error",
+          message:
+            "Could not read your Bitcoin wallet address. Please reconnect the wallet and make sure it is on the correct Bitcoin network.",
+        });
+        return;
+      }
+      if (walletScriptPubKey !== activity.depositorPayoutBtcAddress) {
+        setError({
+          title: "Payout Address Mismatch",
+          message:
+            "The payout address from the indexer does not match your connected wallet. " +
+            "This may indicate a data integrity issue. Please verify your wallet connection.",
+        });
+        return;
       }
 
       // Guard `providers[0]` explicitly rather than casting a possibly-undefined


### PR DESCRIPTION
The wallet-vs-indexer scriptPubKey comparison in `usePayoutSigningState.handleSign`
was wrapped in `if (connectedBtcAddress) { ... }`, so a wallet connector that
returns no readable address silently bypassed the guard — the user could sign
a payout for whatever address the indexer claimed.

Reject upfront if the address is missing ("Wallet Address Unavailable"), then
run the comparison unconditionally. The wallet remains the source of truth
for the depositor's identity; the depositor must use the same wallet at
deposit and at payout signing time.