### PR TITLE
fix(vault): assert Aave reserveId↔underlying mapping on-chain before …

### DIFF
--- a/services/vault/src/applications/aave/hooks/useBorrowTransaction.ts
+++ b/services/vault/src/applications/aave/hooks/useBorrowTransaction.ts
@@ -18,7 +18,12 @@ import {
   mapViemErrorToContractError,
 } from "@/utils/errors";
 
-import { borrow } from "../services";
+import { getAaveAdapterAddress } from "../config";
+import {
+  ReserveMismatchError,
+  assertReserveMatchesOnChain,
+  borrow,
+} from "../services";
 import type { AaveReserveConfig } from "../services/fetchConfig";
 
 export interface UseBorrowTransactionResult {
@@ -71,9 +76,16 @@ export function useBorrowTransaction(): UseBorrowTransactionResult {
         );
       }
 
-      // Fetch decimals on-chain to prevent a compromised GraphQL indexer from
-      // supplying a falsified value that would cause parseUnits to produce a
-      // materially different amount than the user intended.
+      // Verify the indexer-supplied (reserveId, token.address) pair maps to
+      // the same reserve on-chain via the env-pinned adapter the tx will
+      // execute against. Run before the decimals fetch so a mismatch surfaces
+      // its specific error instead of being masked by a parallel rejection.
+      await assertReserveMatchesOnChain(
+        getAaveAdapterAddress(),
+        reserve.reserveId,
+        reserve.token.address,
+      );
+
       const onChainDecimals = await ERC20.getERC20Decimals(
         reserve.token.address,
       ).catch(() => {
@@ -110,8 +122,16 @@ export function useBorrowTransaction(): UseBorrowTransactionResult {
       logger.error(error instanceof Error ? error : new Error(String(error)), {
         data: { context: "Borrow failed" },
       });
-      const mappedError =
-        error instanceof Error
+      // Surface the on-chain reserve-mismatch as its own user-facing error so
+      // the user sees an integrity warning, not a generic borrow failure.
+      // Retry is suppressed because retrying can't help against a compromised
+      // indexer.
+      const isReserveMismatch = error instanceof ReserveMismatchError;
+      const mappedError = isReserveMismatch
+        ? new Error(
+            "Asset integrity check failed: the borrowable asset returned by the indexer does not match what's registered on-chain. Refresh and try again. If this persists, do not proceed.",
+          )
+        : error instanceof Error
           ? mapViemErrorToContractError(error, "Borrow")
           : new Error("An unexpected error occurred while borrowing");
 
@@ -119,8 +139,9 @@ export function useBorrowTransaction(): UseBorrowTransactionResult {
         error: mappedError,
         displayOptions: {
           showModal: true,
-          retryAction: () =>
-            executeBorrow(borrowAmount, reserve, preSignValidation),
+          retryAction: isReserveMismatch
+            ? undefined
+            : () => executeBorrow(borrowAmount, reserve, preSignValidation),
         },
       });
 

--- a/services/vault/src/applications/aave/hooks/useRepayTransaction.ts
+++ b/services/vault/src/applications/aave/hooks/useRepayTransaction.ts
@@ -162,6 +162,9 @@ export function useRepayTransaction({
             ? mapViemErrorToContractError(error, "Repay")
             : new Error("An unexpected error occurred while repaying");
 
+      // Repay deliberately has no `retryAction`. If one is added later, mirror
+      // the borrow hook and gate it on `!(error instanceof ReserveMismatchError)`
+      // — retrying can't help against a compromised indexer.
       handleError({
         error: mappedError,
         displayOptions: {

--- a/services/vault/src/applications/aave/hooks/useRepayTransaction.ts
+++ b/services/vault/src/applications/aave/hooks/useRepayTransaction.ts
@@ -21,7 +21,13 @@ import {
   mapViemErrorToContractError,
 } from "@/utils/errors";
 
-import { repayFull, repayPartial } from "../services";
+import { getAaveAdapterAddress } from "../config";
+import {
+  ReserveMismatchError,
+  assertReserveMatchesOnChain,
+  repayFull,
+  repayPartial,
+} from "../services";
 import type { AaveReserveConfig } from "../services/fetchConfig";
 
 export interface UseRepayTransactionProps {
@@ -85,6 +91,16 @@ export function useRepayTransaction({
         );
       }
 
+      // Verify the indexer-supplied (reserveId, token.address) pair maps to
+      // the same reserve on-chain via the env-pinned adapter the tx will
+      // execute against. Without this, a compromised indexer could redirect
+      // a repayment to a different asset.
+      await assertReserveMatchesOnChain(
+        getAaveAdapterAddress(),
+        reserve.reserveId,
+        reserve.token.address,
+      );
+
       // Call appropriate service based on repayment type
       // The borrower address is resolved from the connected wallet (self-repay)
       // Adapter and spoke addresses are pinned from trusted environment config
@@ -135,10 +151,16 @@ export function useRepayTransaction({
       logger.error(error instanceof Error ? error : new Error(String(error)), {
         data: { context: "Repay failed" },
       });
+      // Surface the on-chain reserve-mismatch as its own user-facing error so
+      // the user sees an integrity warning, not a generic repay failure.
       const mappedError =
-        error instanceof Error
-          ? mapViemErrorToContractError(error, "Repay")
-          : new Error("An unexpected error occurred while repaying");
+        error instanceof ReserveMismatchError
+          ? new Error(
+              "Asset integrity check failed: the debt asset returned by the indexer does not match what's registered on-chain. Refresh and try again. If this persists, do not proceed.",
+            )
+          : error instanceof Error
+            ? mapViemErrorToContractError(error, "Repay")
+            : new Error("An unexpected error occurred while repaying");
 
       handleError({
         error: mappedError,

--- a/services/vault/src/applications/aave/services/__tests__/assertReserveMatchesOnChain.test.ts
+++ b/services/vault/src/applications/aave/services/__tests__/assertReserveMatchesOnChain.test.ts
@@ -1,0 +1,132 @@
+import type { Address } from "viem";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../clients/spoke", () => ({
+  getReserve: vi.fn(),
+}));
+
+vi.mock("../../clients/transaction", () => ({
+  getCoreSpokeAddress: vi.fn(),
+}));
+
+import { getReserve } from "../../clients/spoke";
+import { getCoreSpokeAddress } from "../../clients/transaction";
+import {
+  ReserveMismatchError,
+  _resetCoreSpokeCacheForTests,
+  assertReserveMatchesOnChain,
+} from "../assertReserveMatchesOnChain";
+
+const mockGetReserve = vi.mocked(getReserve);
+const mockGetCoreSpokeAddress = vi.mocked(getCoreSpokeAddress);
+
+const ADAPTER = "0x000000000000000000000000000000000000ada9" as Address;
+const SPOKE = "0x000000000000000000000000000000000000fa11" as Address;
+const TOKEN_USDC = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" as Address;
+const TOKEN_WBTC = "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599" as Address;
+const RESERVE_ID = 7n;
+
+function reserveResult(underlying: Address) {
+  return {
+    underlying,
+    hub: "0xhub" as Address,
+    assetId: 1,
+    decimals: 6,
+    collateralRisk: 0,
+    flags: 0,
+    dynamicConfigKey: 0,
+  };
+}
+
+describe("assertReserveMatchesOnChain", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _resetCoreSpokeCacheForTests();
+    mockGetCoreSpokeAddress.mockResolvedValue(SPOKE);
+  });
+
+  it("resolves the spoke from the trusted adapter, not from a caller-supplied value", async () => {
+    mockGetReserve.mockResolvedValue(
+      reserveResult(TOKEN_USDC.toLowerCase() as Address),
+    );
+
+    await assertReserveMatchesOnChain(ADAPTER, RESERVE_ID, TOKEN_USDC);
+
+    expect(mockGetCoreSpokeAddress).toHaveBeenCalledWith(ADAPTER);
+    expect(mockGetReserve).toHaveBeenCalledWith(SPOKE, RESERVE_ID);
+  });
+
+  it("resolves when on-chain underlying matches the expected token (case-insensitive)", async () => {
+    mockGetReserve.mockResolvedValue(
+      reserveResult(TOKEN_USDC.toLowerCase() as Address),
+    );
+
+    await expect(
+      assertReserveMatchesOnChain(ADAPTER, RESERVE_ID, TOKEN_USDC),
+    ).resolves.toBeUndefined();
+  });
+
+  it("throws ReserveMismatchError when on-chain underlying differs from expected token", async () => {
+    mockGetReserve.mockResolvedValue(reserveResult(TOKEN_WBTC));
+
+    await expect(
+      assertReserveMatchesOnChain(ADAPTER, RESERVE_ID, TOKEN_USDC),
+    ).rejects.toBeInstanceOf(ReserveMismatchError);
+  });
+
+  it("throws even when only the trailing checksum byte differs", async () => {
+    const subtleSwap = (TOKEN_USDC.slice(0, -2) + "00") as Address;
+    mockGetReserve.mockResolvedValue(reserveResult(subtleSwap));
+
+    await expect(
+      assertReserveMatchesOnChain(ADAPTER, RESERVE_ID, TOKEN_USDC),
+    ).rejects.toBeInstanceOf(ReserveMismatchError);
+  });
+
+  it("propagates errors from the on-chain read", async () => {
+    mockGetReserve.mockRejectedValue(new Error("rpc connection lost"));
+
+    await expect(
+      assertReserveMatchesOnChain(ADAPTER, RESERVE_ID, TOKEN_USDC),
+    ).rejects.toThrow("rpc connection lost");
+  });
+
+  it("propagates errors from the spoke-address resolution", async () => {
+    mockGetCoreSpokeAddress.mockRejectedValue(
+      new Error("adapter not deployed"),
+    );
+
+    await expect(
+      assertReserveMatchesOnChain(ADAPTER, RESERVE_ID, TOKEN_USDC),
+    ).rejects.toThrow("adapter not deployed");
+    expect(mockGetReserve).not.toHaveBeenCalled();
+  });
+
+  it("memoizes the spoke address per adapter so repeat calls skip the RPC", async () => {
+    mockGetReserve.mockResolvedValue(reserveResult(TOKEN_USDC));
+
+    await assertReserveMatchesOnChain(ADAPTER, RESERVE_ID, TOKEN_USDC);
+    await assertReserveMatchesOnChain(ADAPTER, 99n, TOKEN_USDC);
+    await assertReserveMatchesOnChain(ADAPTER, 42n, TOKEN_USDC);
+
+    expect(mockGetCoreSpokeAddress).toHaveBeenCalledTimes(1);
+    expect(mockGetReserve).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not cache a failed spoke-address resolution", async () => {
+    mockGetCoreSpokeAddress.mockRejectedValueOnce(
+      new Error("transient rpc error"),
+    );
+
+    await expect(
+      assertReserveMatchesOnChain(ADAPTER, RESERVE_ID, TOKEN_USDC),
+    ).rejects.toThrow("transient rpc error");
+
+    // Next call retries the resolution and succeeds.
+    mockGetCoreSpokeAddress.mockResolvedValue(SPOKE);
+    mockGetReserve.mockResolvedValue(reserveResult(TOKEN_USDC));
+    await assertReserveMatchesOnChain(ADAPTER, RESERVE_ID, TOKEN_USDC);
+
+    expect(mockGetCoreSpokeAddress).toHaveBeenCalledTimes(2);
+  });
+});

--- a/services/vault/src/applications/aave/services/__tests__/assertReserveMatchesOnChain.test.ts
+++ b/services/vault/src/applications/aave/services/__tests__/assertReserveMatchesOnChain.test.ts
@@ -29,7 +29,7 @@ const RESERVE_ID = 7n;
 function reserveResult(underlying: Address) {
   return {
     underlying,
-    hub: "0xhub" as Address,
+    hub: "0x000000000000000000000000000000000000beef" as Address,
     assetId: 1,
     decimals: 6,
     collateralRisk: 0,

--- a/services/vault/src/applications/aave/services/assertReserveMatchesOnChain.ts
+++ b/services/vault/src/applications/aave/services/assertReserveMatchesOnChain.ts
@@ -1,0 +1,71 @@
+/**
+ * Assert that an indexer-supplied reserve maps to the expected token on-chain.
+ *
+ * The borrow/repay flows take `reserveId` and `token.address` from GraphQL and
+ * pass them directly to the Aave adapter. A compromised indexer can swap the
+ * pair so the user sees one token in the UI but signs a tx against a different
+ * one (e.g. user thinks USDC, contract executes against WBTC). This guard
+ * resolves the reserve on-chain and fails closed if `underlying` doesn't match.
+ *
+ * Resolves the Core Spoke from the env-pinned adapter the tx path uses
+ * (NOT the indexer-supplied `aaveConfig.coreSpokeAddress`). Otherwise an
+ * attacker-controlled adapter+spoke pair could craft a matching
+ * `reserveId -> underlying` mapping that passes the check while the real
+ * tx executes against the env-pinned adapter where the same id may mean a
+ * different asset.
+ */
+
+import type { Address } from "viem";
+
+import { getReserve } from "../clients/spoke";
+import { getCoreSpokeAddress } from "../clients/transaction";
+
+export class ReserveMismatchError extends Error {
+  readonly code = "RESERVE_MISMATCH";
+}
+
+/**
+ * Memoize `BTC_VAULT_CORE_SPOKE` per adapter — it's an `immutable` property of
+ * the adapter contract, so re-reading it on every borrow/repay is wasted work.
+ * Cache the in-flight promise so concurrent calls dedupe to a single RPC.
+ */
+const coreSpokeCache = new Map<Address, Promise<Address>>();
+
+function getCachedCoreSpokeAddress(adapterAddress: Address): Promise<Address> {
+  const cached = coreSpokeCache.get(adapterAddress);
+  if (cached) return cached;
+  const pending = getCoreSpokeAddress(adapterAddress).catch((err) => {
+    // Don't poison the cache on transient failures.
+    coreSpokeCache.delete(adapterAddress);
+    throw err;
+  });
+  coreSpokeCache.set(adapterAddress, pending);
+  return pending;
+}
+
+/** Test-only: clear the per-adapter spoke-address memoization between tests. */
+export function _resetCoreSpokeCacheForTests(): void {
+  coreSpokeCache.clear();
+}
+
+/**
+ * @param trustedAdapterAddress - Env-pinned Aave adapter (the same address
+ *   the borrow/repay tx is sent to). The spoke is read from this adapter's
+ *   immutable `BTC_VAULT_CORE_SPOKE` property.
+ * @throws {ReserveMismatchError} when on-chain `underlying` doesn't match.
+ */
+export async function assertReserveMatchesOnChain(
+  trustedAdapterAddress: Address,
+  reserveId: bigint,
+  expectedTokenAddress: Address,
+): Promise<void> {
+  const spokeAddress = await getCachedCoreSpokeAddress(trustedAdapterAddress);
+  const onChain = await getReserve(spokeAddress, reserveId);
+  if (onChain.underlying.toLowerCase() !== expectedTokenAddress.toLowerCase()) {
+    throw new ReserveMismatchError(
+      `Reserve ${reserveId} resolves to ${onChain.underlying} on-chain, ` +
+        `but the indexer mapped it to ${expectedTokenAddress}. Aborting to ` +
+        `prevent borrowing or repaying the wrong asset.`,
+    );
+  }
+}

--- a/services/vault/src/applications/aave/services/index.ts
+++ b/services/vault/src/applications/aave/services/index.ts
@@ -54,3 +54,9 @@ export {
   repayPartial,
   withdrawSelectedCollateral,
 } from "./positionTransactions";
+
+// On-chain integrity guards
+export {
+  ReserveMismatchError,
+  assertReserveMatchesOnChain,
+} from "./assertReserveMatchesOnChain";


### PR DESCRIPTION
The borrow/repay flows passed `(reserveId, token.address)` from the indexer
straight to the adapter — a compromised indexer could swap the pair so the
user signs a tx against a different asset than the UI showed (auditor #5).

New helper resolves the spoke from the env-pinned adapter (the same one
the tx targets) and asserts `getReserve(reserveId).underlying === expected`
before the tx is sent. ReserveMismatchError surfaces a security-specific
error message; retry is disabled for borrow since retry can't help against
a compromised indexer.