### PR TITLE
feat(ts-sdk): emit OP_RETURN auth-anchor commitment in Pre-PegIn

### DIFF
--- a/packages/babylon-ts-sdk/docs/api/clients.md
+++ b/packages/babylon-ts-sdk/docs/api/clients.md
@@ -438,7 +438,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-rea
 getVaultProtocolInfo(vaultId): Promise<VaultProtocolInfo>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts:52](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts#L52)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts:60](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts#L60)
 
 ###### Parameters
 
@@ -460,7 +460,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-rea
 getVaultData(vaultId): Promise<VaultData>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts:87](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts#L87)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts:95](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts#L95)
 
 ###### Parameters
 

--- a/packages/babylon-ts-sdk/docs/api/managers.md
+++ b/packages/babylon-ts-sdk/docs/api/managers.md
@@ -189,7 +189,7 @@ Error if any signing operation fails
 
 ### PeginManager
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:570](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L570)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:530](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L530)
 
 #### Constructors
 
@@ -199,7 +199,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:570](
 new PeginManager(config): PeginManager;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:578](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L578)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:538](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L538)
 
 Creates a new PeginManager instance.
 
@@ -223,7 +223,7 @@ Manager configuration including wallets and contract addresses
 preparePegin(params): Promise<PreparePeginResult>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:591](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L591)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:551](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L551)
 
 Prepare a peg-in: sizing pass → vault-root derivation (one wallet
 popup) → per-vault WOTS / hashlock derivation → commit pass with
@@ -251,7 +251,7 @@ If the wallet rejects, insufficient funds, or an internal
 signAndBroadcast(params): Promise<string>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:895](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L895)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:855](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L855)
 
 Signs and broadcasts a funded peg-in transaction to the Bitcoin network.
 
@@ -287,7 +287,7 @@ Error if signing or broadcasting fails
 registerPeginOnChain(params): Promise<RegisterPeginResult>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1038](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L1038)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:998](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L998)
 
 Registers a peg-in on Ethereum by calling the BTCVaultRegistry contract.
 
@@ -338,7 +338,7 @@ Error if contract simulation fails (e.g., invalid signature,
 registerPeginBatchOnChain(params): Promise<RegisterPeginBatchResult>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1199](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L1199)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1159](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L1159)
 
 Register multiple pegins on Ethereum in a single transaction.
 
@@ -366,7 +366,7 @@ Batch result with per-vault IDs and single ETH tx hash
 signProofOfPossession(): Promise<PopSignature>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1429](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L1429)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1388](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L1388)
 
 Sign a BIP-322 BTC Proof-of-Possession binding the connected BTC
 wallet to the connected ETH account for this chain and vault
@@ -383,7 +383,7 @@ every register call in the same session.
 getNetwork(): Network;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1477](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L1477)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1436](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L1436)
 
 Gets the configured Bitcoin network.
 
@@ -399,7 +399,7 @@ The Bitcoin network (mainnet, testnet, signet, regtest)
 getVaultContractAddress(): `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1486](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L1486)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1445](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L1445)
 
 Gets the configured BTCVaultRegistry contract address.
 
@@ -972,7 +972,7 @@ Depositor's BTC public key used for signing.
 
 ### PeginManagerConfig
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:151](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L151)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:100](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L100)
 
 Configuration for the PeginManager.
 
@@ -984,7 +984,7 @@ Configuration for the PeginManager.
 btcNetwork: Network;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:155](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L155)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:104](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L104)
 
 Bitcoin network to use for transactions.
 
@@ -994,7 +994,7 @@ Bitcoin network to use for transactions.
 btcWallet: BitcoinWallet;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:160](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L160)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:109](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L109)
 
 Bitcoin wallet for signing peg-in transactions.
 
@@ -1004,7 +1004,7 @@ Bitcoin wallet for signing peg-in transactions.
 ethWallet: object;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:166](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L166)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:115](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L115)
 
 Ethereum wallet for registering peg-in on-chain.
 Uses viem's WalletClient directly for proper gas estimation.
@@ -1015,7 +1015,7 @@ Uses viem's WalletClient directly for proper gas estimation.
 ethChain: Chain;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:172](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L172)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:121](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L121)
 
 Ethereum chain configuration.
 Required for proper gas estimation in contract calls.
@@ -1026,7 +1026,7 @@ Required for proper gas estimation in contract calls.
 vaultContracts: object;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:177](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L177)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:126](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L126)
 
 Vault contract addresses.
 
@@ -1044,7 +1044,7 @@ BTCVaultRegistry contract address on Ethereum.
 mempoolApiUrl: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:189](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L189)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:138](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L138)
 
 Mempool API URL for fetching UTXO data and broadcasting transactions.
 Use MEMPOOL_API_URLS constant for standard mempool.space URLs, or provide
@@ -1054,7 +1054,7 @@ a custom URL if running your own mempool instance.
 
 ### PreparePeginParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:195](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L195)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:144](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L144)
 
 Parameters for the pegin flow (pre-pegin + pegin transactions).
 
@@ -1066,7 +1066,7 @@ Parameters for the pegin flow (pre-pegin + pegin transactions).
 amounts: readonly bigint[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:201](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L201)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:150](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L150)
 
 Amounts to peg in per HTLC (in satoshis).
 Must have the same length as `hashlocks`.
@@ -1078,7 +1078,7 @@ For single deposits, pass a single-element array.
 vaultProviderBtcPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:207](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L207)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:156](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L156)
 
 Vault provider's BTC public key (x-only, 64-char hex).
 Can be provided with or without "0x" prefix (will be stripped automatically).
@@ -1089,7 +1089,7 @@ Can be provided with or without "0x" prefix (will be stripped automatically).
 vaultKeeperBtcPubkeys: readonly string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:213](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L213)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:162](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L162)
 
 Vault keeper BTC public keys (x-only, 64-char hex).
 Can be provided with or without "0x" prefix (will be stripped automatically).
@@ -1100,7 +1100,7 @@ Can be provided with or without "0x" prefix (will be stripped automatically).
 universalChallengerBtcPubkeys: readonly string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:219](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L219)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:168](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L168)
 
 Universal challenger BTC public keys (x-only, 64-char hex).
 Can be provided with or without "0x" prefix (will be stripped automatically).
@@ -1111,7 +1111,7 @@ Can be provided with or without "0x" prefix (will be stripped automatically).
 timelockPegin: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:224](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L224)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:173](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L173)
 
 CSV timelock in blocks for the PegIn vault output.
 
@@ -1121,7 +1121,7 @@ CSV timelock in blocks for the PegIn vault output.
 timelockRefund: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:229](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L229)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:178](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L178)
 
 CSV timelock in blocks for the Pre-PegIn HTLC refund path.
 
@@ -1131,7 +1131,7 @@ CSV timelock in blocks for the Pre-PegIn HTLC refund path.
 protocolFeeRate: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:235](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L235)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:184](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L184)
 
 Protocol fee rate in sat/vB from the contract offchain params.
 Used by WASM for computing depositorClaimValue and min pegin fee.
@@ -1142,7 +1142,7 @@ Used by WASM for computing depositorClaimValue and min pegin fee.
 mempoolFeeRate: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:241](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L241)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:190](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L190)
 
 Mempool fee rate in sat/vB for funding the Pre-PegIn transaction.
 Used for UTXO selection and change calculation.
@@ -1153,7 +1153,7 @@ Used for UTXO selection and change calculation.
 councilQuorum: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:246](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L246)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:195](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L195)
 
 M in M-of-N council multisig (from contract params).
 
@@ -1163,7 +1163,7 @@ M in M-of-N council multisig (from contract params).
 councilSize: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:251](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L251)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:200](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L200)
 
 N in M-of-N council multisig (from contract params).
 
@@ -1173,7 +1173,7 @@ N in M-of-N council multisig (from contract params).
 availableUTXOs: readonly UTXO[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:256](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L256)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:205](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L205)
 
 Available UTXOs from the depositor's wallet for funding the Pre-PegIn transaction.
 
@@ -1183,7 +1183,7 @@ Available UTXOs from the depositor's wallet for funding the Pre-PegIn transactio
 changeAddress: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:261](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L261)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:210](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L210)
 
 Bitcoin address for receiving change from the Pre-PegIn transaction.
 
@@ -1191,7 +1191,7 @@ Bitcoin address for receiving change from the Pre-PegIn transaction.
 
 ### PerVaultPeginData
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:268](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L268)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:217](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L217)
 
 Per-vault PegIn data derived from a shared Pre-PegIn transaction
 
@@ -1203,7 +1203,7 @@ Per-vault PegIn data derived from a shared Pre-PegIn transaction
 htlcVout: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:270](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L270)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:219](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L219)
 
 Index of the HTLC output in the Pre-PegIn transaction (0, 1, 2, ...)
 
@@ -1213,7 +1213,7 @@ Index of the HTLC output in the Pre-PegIn transaction (0, 1, 2, ...)
 htlcValue: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:272](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L272)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:221](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L221)
 
 HTLC output value in satoshis
 
@@ -1223,7 +1223,7 @@ HTLC output value in satoshis
 peginTxHex: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:274](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L274)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:223](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L223)
 
 Depositor-signed PegIn transaction hex (for contract registration)
 
@@ -1233,7 +1233,7 @@ Depositor-signed PegIn transaction hex (for contract registration)
 peginTxid: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:276](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L276)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:225](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L225)
 
 PegIn transaction ID
 
@@ -1243,7 +1243,7 @@ PegIn transaction ID
 peginInputSignature: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:278](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L278)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:227](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L227)
 
 Depositor's Schnorr signature over PegIn input (HTLC leaf 0)
 
@@ -1253,7 +1253,7 @@ Depositor's Schnorr signature over PegIn input (HTLC leaf 0)
 vaultScriptPubKey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:280](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L280)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:229](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L229)
 
 Vault output scriptPubKey hex
 
@@ -1261,7 +1261,7 @@ Vault output scriptPubKey hex
 
 ### PreparePeginTransaction
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:287](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L287)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:236](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L236)
 
 Broadcast-ready transaction output of [PeginManager.preparePegin](#preparepegin).
 Safe to log / persist — contains no sensitive material.
@@ -1274,7 +1274,7 @@ Safe to log / persist — contains no sensitive material.
 fundedPrePeginTxHex: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:293](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L293)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:242](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L242)
 
 Funded, pre-witness Pre-PegIn tx hex. Pass this for register calls'
 `unsignedPrePeginTx` — despite the contract-side name, the registry
@@ -1286,7 +1286,7 @@ stores the funded form so indexers can rebuild refund PSBTs.
 prePeginTxid: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:295](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L295)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:244](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L244)
 
 Funded Pre-PegIn transaction ID
 
@@ -1296,7 +1296,7 @@ Funded Pre-PegIn transaction ID
 perVault: PerVaultPeginData[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:297](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L297)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:246](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L246)
 
 Per-vault PegIn data — one entry per amount
 
@@ -1306,7 +1306,7 @@ Per-vault PegIn data — one entry per amount
 selectedUTXOs: UTXO[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:299](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L299)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:248](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L248)
 
 UTXOs selected to fund the Pre-PegIn transaction
 
@@ -1316,7 +1316,7 @@ UTXOs selected to fund the Pre-PegIn transaction
 fee: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:301](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L301)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:250](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L250)
 
 Transaction fee in satoshis
 
@@ -1326,7 +1326,7 @@ Transaction fee in satoshis
 changeAmount: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:303](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L303)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:252](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L252)
 
 Change amount in satoshis (if any)
 
@@ -1334,7 +1334,7 @@ Change amount in satoshis (if any)
 
 ### PreparePeginDerivedSecrets
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:311](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L311)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:260](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L260)
 
 Sensitive material derived from the wallet root. Do not log; do not
 persist beyond the activation flow. Strings are immutable in JS, so
@@ -1348,7 +1348,7 @@ lifetime is GC-only — secrets stay live until the result is dropped.
 perVaultWotsKeys: WotsBlockPublicKey[][];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:313](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L313)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:262](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L262)
 
 Per-vault WOTS block public keys (one array per vault).
 
@@ -1358,7 +1358,7 @@ Per-vault WOTS block public keys (one array per vault).
 wotsPkHashes: `0x${string}`[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:315](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L315)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:264](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L264)
 
 Per-vault keccak256 of WOTS keys, ready as `depositorWotsPkHash`.
 
@@ -1368,16 +1368,33 @@ Per-vault keccak256 of WOTS keys, ready as `depositorWotsPkHash`.
 htlcSecretHexes: string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:320](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L320)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:269](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L269)
 
 Per-vault HTLC preimage hex (no 0x prefix). Re-derivable any time
 via `expandHashlockSecret(root, htlcVout)`; not persisted.
+
+##### authAnchorHex
+
+```ts
+authAnchorHex: string;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:280](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L280)
+
+Raw 32-byte auth-anchor preimage as 64-char lowercase hex (no `0x`).
+Sent to the VP via `auth_createDepositorToken` to obtain a bearer
+token; the VP validates `SHA256(authAnchorHex) === OP_RETURN_PUSH32`
+in the broadcast Pre-PegIn. Reveal is intentional: once exposed
+the anchor is public, but its scope is bound to a single
+`peginTxid`. Domain-separated from `htlcSecretHexes` and
+`perVaultWotsKeys` via the HKDF `info` label, so revealing it does
+not weaken the other derived secrets.
 
 ***
 
 ### PreparePeginResult
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:323](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L323)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:283](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L283)
 
 #### Properties
 
@@ -1387,7 +1404,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:323](
 transaction: PreparePeginTransaction;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:325](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L325)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:285](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L285)
 
 Broadcast-ready Pre-PegIn + per-vault PegIn txs. Safe to log.
 
@@ -1397,7 +1414,7 @@ Broadcast-ready Pre-PegIn + per-vault PegIn txs. Safe to log.
 depositorBtcPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:332](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L332)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:292](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L292)
 
 x-only depositor pubkey snapshot used end-to-end across sizing,
 vault-root derivation, and PSBT signing. Safe to persist; not
@@ -1410,7 +1427,7 @@ derived secrets and signed PSBTs reference the same identity.
 derivedSecrets: PreparePeginDerivedSecrets;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:334](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L334)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:294](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L294)
 
 Sensitive derived material — see [PreparePeginDerivedSecrets](#preparepeginderivedsecrets).
 
@@ -1418,7 +1435,7 @@ Sensitive derived material — see [PreparePeginDerivedSecrets](#preparepeginder
 
 ### SignAndBroadcastParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:341](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L341)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:301](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L301)
 
 Parameters for signing and broadcasting a transaction.
 
@@ -1430,7 +1447,7 @@ Parameters for signing and broadcasting a transaction.
 fundedPrePeginTxHex: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:345](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L345)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:305](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L305)
 
 Funded Pre-PegIn transaction hex from preparePegin().
 
@@ -1440,7 +1457,7 @@ Funded Pre-PegIn transaction hex from preparePegin().
 depositorBtcPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:352](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L352)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:312](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L312)
 
 Depositor's BTC public key (x-only, 64-char hex).
 Can be provided with or without "0x" prefix.
@@ -1455,7 +1472,7 @@ optional localPrevouts: Record<string, {
 }>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:360](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L360)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:320](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L320)
 
 Optional pre-fetched prevout data for inputs not yet in the mempool.
 Key format: "txid:vout" (e.g. "abc123...def:0").
@@ -1466,7 +1483,7 @@ Useful for split transactions where outputs are unconfirmed.
 
 ### PopSignature
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:369](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L369)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:329](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L329)
 
 BIP-322 BTC Proof-of-Possession binding a depositor's BTC key to their
 Ethereum account. Produced by [PeginManager.signProofOfPossession](#signproofofpossession)
@@ -1481,7 +1498,7 @@ embedded identities are re-checked at register time.
 btcPopSignature: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:371](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L371)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:331](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L331)
 
 BIP-322 signature over the PoP message (0x-prefixed hex).
 
@@ -1491,7 +1508,7 @@ BIP-322 signature over the PoP message (0x-prefixed hex).
 depositorEthAddress: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:373](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L373)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:333](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L333)
 
 Ethereum address the PoP was signed for.
 
@@ -1501,7 +1518,7 @@ Ethereum address the PoP was signed for.
 depositorBtcPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:375](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L375)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:335](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L335)
 
 BTC x-only public key (64-char hex, no 0x prefix).
 
@@ -1509,7 +1526,7 @@ BTC x-only public key (64-char hex, no 0x prefix).
 
 ### RegisterPeginParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:381](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L381)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:341](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L341)
 
 Parameters for registering a peg-in on Ethereum.
 
@@ -1521,7 +1538,7 @@ Parameters for registering a peg-in on Ethereum.
 unsignedPrePeginTx: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:388](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L388)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:348](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L348)
 
 Funded, pre-witness Pre-PegIn tx hex — pass
 [PreparePeginTransaction.fundedPrePeginTxHex](#fundedprepegintxhex) from
@@ -1534,7 +1551,7 @@ is named `unsignedPrePeginTx` but it stores the funded form.
 depositorSignedPeginTx: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:393](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L393)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:353](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L353)
 
 Depositor-signed PegIn transaction hex (submitted to contract; vault ID derived from this).
 
@@ -1544,7 +1561,7 @@ Depositor-signed PegIn transaction hex (submitted to contract; vault ID derived 
 vaultProvider: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:398](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L398)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:358](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L358)
 
 Vault provider's Ethereum address.
 
@@ -1554,7 +1571,7 @@ Vault provider's Ethereum address.
 hashlock: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:403](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L403)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:363](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L363)
 
 SHA256 hashlock for HTLC activation (bytes32 hex with 0x prefix).
 
@@ -1564,7 +1581,7 @@ SHA256 hashlock for HTLC activation (bytes32 hex with 0x prefix).
 optional depositorPayoutBtcAddress: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:412](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L412)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:372](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L372)
 
 Depositor's BTC payout address (e.g. bc1p..., bc1q...).
 Converted to scriptPubKey internally via bitcoinjs-lib.
@@ -1578,7 +1595,7 @@ via `btcWallet.getAddress()`.
 depositorWotsPkHash: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:415](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L415)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:375](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L375)
 
 Keccak256 hash of the depositor's WOTS public key (bytes32)
 
@@ -1588,7 +1605,7 @@ Keccak256 hash of the depositor's WOTS public key (bytes32)
 popSignature: PopSignature;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:418](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L418)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:378](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L378)
 
 Proof of possession from [PeginManager.signProofOfPossession](#signproofofpossession).
 
@@ -1598,7 +1615,7 @@ Proof of possession from [PeginManager.signProofOfPossession](#signproofofposses
 htlcVout: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:425](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L425)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:385](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L385)
 
 Zero-based index of the HTLC output in the Pre-PegIn transaction that
 this PegIn spends. In a batch Pre-PegIn with N HTLC outputs, each vault
@@ -1608,7 +1625,7 @@ registration references a different htlcVout (0..N-1).
 
 ### RegisterPeginResult
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:431](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L431)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:391](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L391)
 
 Result of registering a peg-in on Ethereum.
 
@@ -1620,7 +1637,7 @@ Result of registering a peg-in on Ethereum.
 ethTxHash: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:435](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L435)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:395](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L395)
 
 Ethereum transaction hash for the peg-in registration.
 
@@ -1630,7 +1647,7 @@ Ethereum transaction hash for the peg-in registration.
 vaultId: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:441](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L441)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:401](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L401)
 
 Derived vault ID: keccak256(abi.encode(peginTxHash, depositor)).
 Used for contract reads/writes and indexer queries.
@@ -1641,7 +1658,7 @@ Used for contract reads/writes and indexer queries.
 peginTxHash: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:447](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L447)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:407](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L407)
 
 Raw Bitcoin pegin transaction hash (double-SHA256 of the signed pegin tx).
 Used for VP RPC operations which key on the BTC transaction ID.
@@ -1650,7 +1667,7 @@ Used for VP RPC operations which key on the BTC transaction ID.
 
 ### BatchPeginRequestItem
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:455](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L455)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:415](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L415)
 
 Single request in a batch pegin registration.
 All requests in a batch share the same vault provider, depositor BTC
@@ -1664,7 +1681,7 @@ pubkey, and Pre-PegIn transaction.
 depositorSignedPeginTx: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:457](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L457)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:417](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L417)
 
 Signed PegIn tx hex for this vault
 
@@ -1674,7 +1691,7 @@ Signed PegIn tx hex for this vault
 hashlock: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:459](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L459)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:419](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L419)
 
 SHA256 hashlock for HTLC activation (bytes32 hex)
 
@@ -1684,7 +1701,7 @@ SHA256 hashlock for HTLC activation (bytes32 hex)
 htlcVout: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:461](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L461)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:421](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L421)
 
 Zero-based HTLC output index in the Pre-PegIn tx (unique per request)
 
@@ -1694,7 +1711,7 @@ Zero-based HTLC output index in the Pre-PegIn tx (unique per request)
 depositorPayoutBtcAddress: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:463](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L463)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:423](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L423)
 
 Depositor's BTC payout address (required — funds are sent here on payout)
 
@@ -1704,7 +1721,7 @@ Depositor's BTC payout address (required — funds are sent here on payout)
 depositorWotsPkHash: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:465](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L465)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:425](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L425)
 
 Keccak256 hash of the depositor's WOTS public key (bytes32)
 
@@ -1712,7 +1729,7 @@ Keccak256 hash of the depositor's WOTS public key (bytes32)
 
 ### RegisterPeginBatchParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:471](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L471)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:431](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L431)
 
 Parameters for registerPeginBatchOnChain.
 
@@ -1724,7 +1741,7 @@ Parameters for registerPeginBatchOnChain.
 vaultProvider: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:473](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L473)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:433](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L433)
 
 Vault provider address (shared across all vaults in batch)
 
@@ -1734,7 +1751,7 @@ Vault provider address (shared across all vaults in batch)
 unsignedPrePeginTx: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:478](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L478)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:438](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L438)
 
 Funded, pre-witness Pre-PegIn tx hex — shared across every request in
 the batch. See [RegisterPeginParams.unsignedPrePeginTx](#unsignedprepegintx).
@@ -1745,7 +1762,7 @@ the batch. See [RegisterPeginParams.unsignedPrePeginTx](#unsignedprepegintx).
 requests: BatchPeginRequestItem[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:480](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L480)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:440](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L440)
 
 Individual pegin requests (one per vault)
 
@@ -1755,7 +1772,7 @@ Individual pegin requests (one per vault)
 popSignature: PopSignature;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:482](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L482)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:442](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L442)
 
 Proof of possession from [PeginManager.signProofOfPossession](#signproofofpossession).
 
@@ -1763,7 +1780,7 @@ Proof of possession from [PeginManager.signProofOfPossession](#signproofofposses
 
 ### BatchPeginResultItem
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:488](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L488)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:448](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L448)
 
 Per-vault result from a batch pegin registration.
 
@@ -1775,7 +1792,7 @@ Per-vault result from a batch pegin registration.
 vaultId: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:490](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L490)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:450](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L450)
 
 Derived vault ID: keccak256(abi.encode(peginTxHash, depositor))
 
@@ -1785,7 +1802,7 @@ Derived vault ID: keccak256(abi.encode(peginTxHash, depositor))
 peginTxHash: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:492](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L492)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:452](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L452)
 
 Raw BTC pegin transaction hash
 
@@ -1793,7 +1810,7 @@ Raw BTC pegin transaction hash
 
 ### RegisterPeginBatchResult
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:498](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L498)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:458](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L458)
 
 Result of registering a batch of pegins on Ethereum in a single transaction.
 
@@ -1805,7 +1822,7 @@ Result of registering a batch of pegins on Ethereum in a single transaction.
 ethTxHash: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:500](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L500)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:460](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L460)
 
 Ethereum transaction hash
 
@@ -1815,7 +1832,7 @@ Ethereum transaction hash
 vaults: BatchPeginResultItem[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:502](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L502)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:462](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L462)
 
 Per-vault results (same order as input requests)
 

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
@@ -18,9 +18,18 @@
  * @module managers/PeginManager
  */
 
+import { sha256 } from "@noble/hashes/sha2.js";
 import * as bitcoin from "bitcoinjs-lib";
 import { Psbt, Transaction } from "bitcoinjs-lib";
 import { Buffer } from "buffer";
+
+import {
+  assertAuthAnchorOpReturn,
+  expandPerVaultSecrets,
+  normalizePopSignature,
+  normalizeXOnlyPubkey,
+  signPsbtsWithFallback,
+} from "./pegin";
 import {
   createPublicClient,
   encodeFunctionData,
@@ -51,11 +60,9 @@ import {
   ensureHexPrefix,
   hexToUint8Array,
   isAddressFromPublicKey,
-  processPublicKeyToXOnly,
   stripHexPrefix,
   uint8ArrayToHex,
 } from "../primitives/utils/bitcoin";
-import { computeHashlock } from "../services";
 import {
   calculateBtcTxHash,
   fundPeginTransaction,
@@ -69,81 +76,23 @@ import {
 import { createTaprootScriptPathSignOptions } from "../utils/signing";
 import {
   deriveVaultRoot,
-  expandHashlockSecret,
-  expandWotsSeed,
+  expandAuthAnchor,
   type FundingOutpoint,
 } from "../vault-secrets";
-import {
-  computeWotsBlockPublicKeysHash,
-  deriveWotsBlocksFromSeed,
-} from "../wots";
 
 /** Referral code sent with pegin registration — 0 means no referral. */
 const NO_REFERRAL_CODE = 0;
 
-const HEX_SIGNATURE_REGEX = /^0x[0-9a-f]+$/i;
-const UNPREFIXED_HEX_SIGNATURE_REGEX = /^[0-9a-f]+$/i;
-const BASE64_SIGNATURE_REGEX = /^[A-Za-z0-9+/]+={0,2}$/;
-
-/** Sizing-pass placeholder; substitution invariance pinned in `pegin.test.ts`. */
-const PLACEHOLDER_HASHLOCK_HEX = "00".repeat(32);
-
-function normalizeXOnlyPubkey(raw: unknown): string {
-  if (typeof raw !== "string" || raw.length === 0) {
-    throw new Error("BTC wallet returned empty public key");
-  }
-  // Lowercase so case-sensitive equality checks downstream don't fail
-  // on uppercase wallet output (processPublicKeyToXOnly passes a 64-char
-  // input through unchanged).
-  return processPublicKeyToXOnly(raw).toLowerCase();
-}
-
 /**
- * Normalize a wallet-returned BIP-322 signature into 0x-prefixed hex.
- *
- * Accepts:
- *  - 0x-prefixed lowercase/uppercase hex
- *  - unprefixed hex (wins over base64 when input is pure `[0-9a-fA-F]+`)
- *  - canonical standard base64 (`[A-Za-z0-9+/]` with `=` padding to a
- *    multiple of 4 and no non-canonical encodings)
- *
- * Rejects URL-safe base64 (`-`/`_`) and base64 without padding. Wallets
- * known to return BIP-322 signatures (Keystone, UniSat, OKX, OneKey,
- * Unisat) all use standard base64; URL-safe is an explicit non-goal.
+ * 32-byte zero hex used as a placeholder during the sizing pass for any
+ * value whose content does not affect output sizes — currently the
+ * per-vault hashlocks and the auth-anchor commitment. The commit pass
+ * substitutes real values; UTXO selection and fee sizing are invariant
+ * under the swap because all four (placeholder hashlock, real
+ * SHA256(secret), placeholder anchor, real SHA256(authAnchor)) are
+ * 32-byte pushes. Substitution invariance is pinned in `pegin.test.ts`.
  */
-function normalizePopSignature(raw: unknown): Hex {
-  if (typeof raw !== "string" || raw.length === 0) {
-    throw new Error("BTC wallet returned empty BIP-322 signature");
-  }
-
-  if (raw.startsWith("0x") || raw.startsWith("0X")) {
-    if (!HEX_SIGNATURE_REGEX.test(raw) || raw.length < 4 || raw.length % 2 !== 0) {
-      throw new Error("BTC wallet returned malformed hex BIP-322 signature");
-    }
-    return raw.toLowerCase() as Hex;
-  }
-
-  // Prefer hex when the input could be either: every hex char is also a
-  // valid base64 char, so the base64 branch alone would silently misdecode
-  // a wallet returning "deadbeef" instead of "0xdeadbeef".
-  if (UNPREFIXED_HEX_SIGNATURE_REGEX.test(raw)) {
-    if (raw.length % 2 !== 0) {
-      throw new Error("BTC wallet returned malformed hex BIP-322 signature");
-    }
-    return `0x${raw.toLowerCase()}` as Hex;
-  }
-
-  if (!BASE64_SIGNATURE_REGEX.test(raw) || raw.length % 4 !== 0) {
-    throw new Error("BTC wallet returned malformed base64 BIP-322 signature");
-  }
-  const bytes = Buffer.from(raw, "base64");
-  // Round-trip to reject non-canonical base64 (e.g. "AB==" decodes but
-  // re-encodes to "AA==").
-  if (bytes.length === 0 || bytes.toString("base64") !== raw) {
-    throw new Error("BTC wallet returned malformed base64 BIP-322 signature");
-  }
-  return `0x${bytes.toString("hex")}` as Hex;
-}
+const SIZING_PASS_PLACEHOLDER_BYTES32_HEX = "00".repeat(32);
 
 /**
  * Configuration for the PeginManager.
@@ -318,6 +267,17 @@ export interface PreparePeginDerivedSecrets {
    * via `expandHashlockSecret(root, htlcVout)`; not persisted.
    */
   htlcSecretHexes: string[];
+  /**
+   * Raw 32-byte auth-anchor preimage as 64-char lowercase hex (no `0x`).
+   * Sent to the VP via `auth_createDepositorToken` to obtain a bearer
+   * token; the VP validates `SHA256(authAnchorHex) === OP_RETURN_PUSH32`
+   * in the broadcast Pre-PegIn. Reveal is intentional: once exposed
+   * the anchor is public, but its scope is bound to a single
+   * `peginTxid`. Domain-separated from `htlcSecretHexes` and
+   * `perVaultWotsKeys` via the HKDF `info` label, so revealing it does
+   * not weaken the other derived secrets.
+   */
+  authAnchorHex: string;
 }
 
 export interface PreparePeginResult {
@@ -602,6 +562,10 @@ export class PeginManager {
       await this.config.btcWallet.getPublicKeyHex();
     const depositorBtcPubkey = normalizeXOnlyPubkey(depositorBtcPubkeyRaw);
 
+    // Sizing pass uses a placeholder for the auth-anchor hash because
+    // the wallet popup that produces the real anchor hasn't run yet.
+    // The OP_RETURN's byte length is invariant under content swap, so
+    // UTXO selection and fees match the commit pass.
     const sizing = await this.prepareSizing(depositorBtcPubkey, params);
 
     const fundingOutpoints: FundingOutpoint[] = sizing.selectedUTXOs.map(
@@ -615,7 +579,28 @@ export class PeginManager {
       fundingOutpoints,
     });
 
-    const derived = await this.expandPerVaultSecrets(root, params.amounts.length);
+    // Take ownership of the auth anchor before per-vault expansion (which
+    // zeros `root`). Convert to hex immediately, then zero the buffer.
+    // `authAnchorHex` is a JS string — immutable, GC-only — and lives
+    // until the result is dropped. If anything in this window throws,
+    // `expandPerVaultSecrets` won't run to zero `root`, so we wipe it
+    // here on the throw path.
+    let authAnchorHex: string;
+    let authAnchorHash: string;
+    try {
+      const authAnchorBytes = expandAuthAnchor(root);
+      try {
+        authAnchorHex = uint8ArrayToHex(authAnchorBytes);
+        authAnchorHash = uint8ArrayToHex(sha256(authAnchorBytes));
+      } finally {
+        authAnchorBytes.fill(0);
+      }
+    } catch (err) {
+      root.fill(0);
+      throw err;
+    }
+
+    const derived = await expandPerVaultSecrets(root, params.amounts.length);
     const { perVaultWotsKeys, wotsPkHashes, htlcSecretHexes, hashlocks } =
       derived;
 
@@ -623,6 +608,7 @@ export class PeginManager {
       depositorBtcPubkeyRaw,
       depositorBtcPubkey,
       hashlocks,
+      authAnchorHash,
       sizing,
       params,
     });
@@ -638,6 +624,18 @@ export class PeginManager {
       }
     }
 
+    // Structural guarantee that the broadcast tx actually carries the
+    // OP_RETURN we'll later reveal a preimage for. Without this assertion
+    // a malicious WASM build could emit no OP_RETURN, the VP would still
+    // issue a token (if mis-configured) on a tx with no on-chain
+    // commitment, and the auth flow would degrade to a pure shared
+    // secret. Fail closed.
+    assertAuthAnchorOpReturn(
+      commit.fundedPrePeginTxHex,
+      params.amounts.length,
+      authAnchorHash,
+    );
+
     return {
       transaction: {
         ...commit,
@@ -650,56 +648,9 @@ export class PeginManager {
         perVaultWotsKeys,
         wotsPkHashes,
         htlcSecretHexes,
+        authAnchorHex,
       },
     };
-  }
-
-  /**
-   * Derive per-vault WOTS keys + HTLC preimages from the wallet root.
-   * Takes ownership of `root`: zeros the buffer (and per-vault secret
-   * buffers) before returning, regardless of how the caller exits.
-   */
-  private async expandPerVaultSecrets(
-    root: Uint8Array,
-    vaultCount: number,
-  ): Promise<{
-    perVaultWotsKeys: WotsBlockPublicKey[][];
-    wotsPkHashes: Hex[];
-    htlcSecretHexes: string[];
-    hashlocks: string[];
-  }> {
-    const perVaultWotsKeys: WotsBlockPublicKey[][] = [];
-    const wotsPkHashes: Hex[] = [];
-    const htlcSecretHexes: string[] = [];
-    const hashlocks: string[] = [];
-
-    try {
-      for (let i = 0; i < vaultCount; i++) {
-        const wotsSeed = expandWotsSeed(root, i);
-        try {
-          const wotsPublicKeys = await deriveWotsBlocksFromSeed(wotsSeed);
-          perVaultWotsKeys.push(wotsPublicKeys);
-          wotsPkHashes.push(computeWotsBlockPublicKeysHash(wotsPublicKeys));
-        } finally {
-          wotsSeed.fill(0);
-        }
-
-        const secretBytes = expandHashlockSecret(root, i);
-        try {
-          const secretHex = uint8ArrayToHex(secretBytes);
-          htlcSecretHexes.push(secretHex);
-          hashlocks.push(
-            computeHashlock(ensureHexPrefix(secretHex)).slice(2),
-          );
-        } finally {
-          secretBytes.fill(0);
-        }
-      }
-    } finally {
-      root.fill(0);
-    }
-
-    return { perVaultWotsKeys, wotsPkHashes, htlcSecretHexes, hashlocks };
   }
 
   /**
@@ -711,13 +662,19 @@ export class PeginManager {
    * `selectUtxosForPegin` in the commit pass would be deterministic given
    * the same inputs, but threading the result through guarantees the
    * domain separator structurally matches the funded tx inputs.
+   *
+   * Sizing runs before the wallet popup, so neither the real per-vault
+   * hashlocks nor the real `authAnchorHash` are known yet. Both slots
+   * are filled with a 32-byte placeholder; the commit pass swaps in the
+   * real values. Output budget is identical (32-byte push regardless of
+   * content), so UTXO selection is invariant under substitution.
    */
   private async prepareSizing(
     depositorBtcPubkey: string,
     params: PreparePeginParams,
   ): Promise<{ selectedUTXOs: UTXO[]; fee: bigint; changeAmount: bigint }> {
     const placeholderHashlocks = params.amounts.map(
-      () => PLACEHOLDER_HASHLOCK_HEX,
+      () => SIZING_PASS_PLACEHOLDER_BYTES32_HEX,
     );
     const numLocalChallengers = params.vaultKeeperBtcPubkeys.length;
 
@@ -735,14 +692,17 @@ export class PeginManager {
       councilQuorum: params.councilQuorum,
       councilSize: params.councilSize,
       network: this.config.btcNetwork,
+      authAnchorHash: SIZING_PASS_PLACEHOLDER_BYTES32_HEX,
     });
 
     const selection = selectUtxosForPegin(
       [...params.availableUTXOs],
       prePegin.totalOutputValue,
       params.mempoolFeeRate,
-      // No auth-anchor OP_RETURN in this PR (deferred to PR5).
-      peginOutputCount(prePegin.htlcValues.length),
+      peginOutputCount(
+        prePegin.htlcValues.length,
+        SIZING_PASS_PLACEHOLDER_BYTES32_HEX,
+      ),
     );
 
     return {
@@ -757,6 +717,7 @@ export class PeginManager {
     depositorBtcPubkeyRaw: string;
     depositorBtcPubkey: string;
     hashlocks: readonly string[];
+    authAnchorHash: string;
     sizing: { selectedUTXOs: UTXO[]; fee: bigint; changeAmount: bigint };
     params: PreparePeginParams;
   }): Promise<{
@@ -768,9 +729,32 @@ export class PeginManager {
       depositorBtcPubkeyRaw,
       depositorBtcPubkey,
       hashlocks,
+      authAnchorHash,
       sizing,
       params,
     } = args;
+
+    // Refuse to build the broadcast tx if the orchestrator forgot to
+    // substitute real values for the sizing-pass placeholder. A
+    // placeholder-zero hashlock would produce an HTLC that no real
+    // preimage can spend; a placeholder-zero auth anchor would let
+    // the depositor reveal a known-public preimage to the VP. Fail
+    // before signing, not after broadcast.
+    const placeholderLower = SIZING_PASS_PLACEHOLDER_BYTES32_HEX.toLowerCase();
+    for (let i = 0; i < hashlocks.length; i++) {
+      if (hashlocks[i].toLowerCase() === placeholderLower) {
+        throw new Error(
+          `preparePeginCommit refusing to build with sizing-pass placeholder ` +
+            `hashlock at vault ${i} — internal substitution bug`,
+        );
+      }
+    }
+    if (authAnchorHash.toLowerCase() === placeholderLower) {
+      throw new Error(
+        `preparePeginCommit refusing to build with sizing-pass placeholder ` +
+          `auth-anchor hash — internal substitution bug`,
+      );
+    }
 
     const vaultProviderBtcPubkey = stripHexPrefix(params.vaultProviderBtcPubkey);
     const vaultKeeperBtcPubkeys = params.vaultKeeperBtcPubkeys.map(stripHexPrefix);
@@ -791,6 +775,7 @@ export class PeginManager {
       councilQuorum: params.councilQuorum,
       councilSize: params.councilSize,
       network: this.config.btcNetwork,
+      authAnchorHash,
     };
 
     const prePeginResult = await buildPrePeginPsbt(prePeginParams);
@@ -841,7 +826,8 @@ export class PeginManager {
       );
     }
 
-    const signedPsbts = await this.signPsbtsWithFallback(
+    const signedPsbts = await signPsbtsWithFallback(
+      this.config.btcWallet,
       psbtsToSign,
       signOptions,
     );
@@ -872,41 +858,6 @@ export class PeginManager {
     };
   }
 
-  /**
-   * Signs multiple PSBTs using batch signing if available, falling back to sequential signing.
-   *
-   * Wallets that support native batch signing (e.g. UniSat) will sign all PSBTs
-   * in a single interaction. Others (e.g. Ledger, AppKit) implement signPsbts
-   * by looping signPsbt internally, so the UX depends on the wallet adapter.
-   */
-  private async signPsbtsWithFallback(
-    psbtsHexes: string[],
-    options: SignPsbtOptions[],
-  ): Promise<string[]> {
-    if (typeof this.config.btcWallet.signPsbts === "function") {
-      const signedPsbts = await this.config.btcWallet.signPsbts(
-        psbtsHexes,
-        options,
-      );
-      if (signedPsbts.length !== psbtsHexes.length) {
-        throw new Error(
-          `Expected ${psbtsHexes.length} signed PSBTs but received ${signedPsbts.length}`,
-        );
-      }
-      return signedPsbts;
-    }
-
-    // Fallback: sign sequentially
-    const signedPsbts: string[] = [];
-    for (let i = 0; i < psbtsHexes.length; i++) {
-      const signed = await this.config.btcWallet.signPsbt(
-        psbtsHexes[i],
-        options[i],
-      );
-      signedPsbts.push(signed);
-    }
-    return signedPsbts;
-  }
 
   /**
    * Signs and broadcasts a funded peg-in transaction to the Bitcoin network.

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PeginManager.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PeginManager.test.ts
@@ -302,6 +302,7 @@ describe("PeginManager", () => {
       expect(result.derivedSecrets.wotsPkHashes[0]).toMatch(
         /^0x[0-9a-f]{64}$/,
       );
+      expect(result.derivedSecrets.authAnchorHex).toMatch(/^[0-9a-f]{64}$/);
 
       // Pubkey snapshot returned at top level (safe to persist).
       expect(result.depositorBtcPubkey).toBe(TEST_KEYS.DEPOSITOR);
@@ -1286,6 +1287,201 @@ describe("PeginManager", () => {
           ...BASE_PREPARE_PEGIN_PARAMS,
         }),
       ).rejects.toThrow(/htlcVout\/index mismatch/);
+    });
+
+    it("emits OP_RETURN at vout=N with SHA256(authAnchor) push payload", async () => {
+      // Structural binding for the depositor bearer-token flow: the
+      // broadcast Pre-PegIn must commit to the auth anchor at a fixed
+      // location with a fixed encoding. A drifted layout (different
+      // vout, missing OP_RETURN, swapped script-prefix bytes) would let
+      // a depositor obtain a token whose on-chain witness doesn't bind
+      // their preimage to this Pre-PegIn.
+      const { sha256 } = await import("@noble/hashes/sha2.js");
+      const bitcoin = await import("bitcoinjs-lib");
+
+      const btcWallet = new MockBitcoinWallet({
+        publicKeyHex: TEST_KEYS.DEPOSITOR,
+      });
+      const ethWallet = new MockEthereumWallet();
+      const manager = new PeginManager({
+        btcNetwork: "signet",
+        btcWallet,
+        ethWallet: ethWallet as any,
+        ethChain: TEST_CHAIN,
+        vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
+        mempoolApiUrl: MEMPOOL_API_URLS.signet,
+      });
+
+      const result = await manager.preparePegin({
+        amounts: [TEST_AMOUNTS.PEGIN, TEST_AMOUNTS.PEGIN_SMALL],
+        ...BASE_PREPARE_PEGIN_PARAMS,
+      });
+
+      const tx = bitcoin.Transaction.fromHex(result.transaction.fundedPrePeginTxHex);
+      const opReturnVout = 2; // vault outputs at 0, 1; OP_RETURN at vaultCount
+      const script = tx.outs[opReturnVout].script;
+
+      // OP_RETURN (0x6a) || PUSH32 (0x20) || 32-byte hash
+      expect(script.length).toBe(34);
+      expect(script[0]).toBe(0x6a);
+      expect(script[1]).toBe(0x20);
+      expect(tx.outs[opReturnVout].value).toBe(0);
+
+      const pushedHashHex = script.slice(2).toString("hex");
+      const expectedHashHex = Buffer.from(
+        sha256(Buffer.from(result.derivedSecrets.authAnchorHex, "hex")),
+      ).toString("hex");
+      expect(pushedHashHex).toBe(expectedHashHex);
+    });
+
+    it("refuses to commit-build with sizing-pass placeholder values", async () => {
+      // Defense-in-depth against an orchestrator bug where the commit
+      // pass receives placeholder zeros instead of real wallet-derived
+      // hashlocks or auth anchor. A placeholder-zero hashlock would
+      // produce an unspendable HTLC; a placeholder auth anchor would
+      // let the depositor reveal a known-public preimage. Fail before
+      // signing, not after broadcast.
+      const btcWallet = new MockBitcoinWallet({
+        publicKeyHex: TEST_KEYS.DEPOSITOR,
+      });
+      const ethWallet = new MockEthereumWallet();
+      const manager = new PeginManager({
+        btcNetwork: "signet",
+        btcWallet,
+        ethWallet: ethWallet as any,
+        ethChain: TEST_CHAIN,
+        vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
+        mempoolApiUrl: MEMPOOL_API_URLS.signet,
+      });
+
+      // Force the placeholder all-zero auth-anchor hash to reach the
+      // commit pass by mocking expandAuthAnchor to return 32 zero bytes.
+      // SHA256(0x00..00) is not the placeholder, so we bypass that and
+      // mock the sha256 call too — actually simpler: directly inject by
+      // bypassing the orchestrator's substitution via a spy on the
+      // private commit method.
+      const placeholder = "00".repeat(32);
+      const original = (manager as any).preparePeginCommit.bind(manager);
+      (manager as any).preparePeginCommit = async (args: any) =>
+        original({ ...args, authAnchorHash: placeholder });
+
+      await expect(
+        manager.preparePegin({
+          amounts: [TEST_AMOUNTS.PEGIN],
+          ...BASE_PREPARE_PEGIN_PARAMS,
+        }),
+      ).rejects.toThrow(/placeholder auth-anchor hash/);
+    });
+
+    it("refuses to commit-build with sizing-pass placeholder hashlock", async () => {
+      const btcWallet = new MockBitcoinWallet({
+        publicKeyHex: TEST_KEYS.DEPOSITOR,
+      });
+      const ethWallet = new MockEthereumWallet();
+      const manager = new PeginManager({
+        btcNetwork: "signet",
+        btcWallet,
+        ethWallet: ethWallet as any,
+        ethChain: TEST_CHAIN,
+        vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
+        mempoolApiUrl: MEMPOOL_API_URLS.signet,
+      });
+
+      const placeholder = "00".repeat(32);
+      const original = (manager as any).preparePeginCommit.bind(manager);
+      (manager as any).preparePeginCommit = async (args: any) =>
+        original({ ...args, hashlocks: [placeholder] });
+
+      await expect(
+        manager.preparePegin({
+          amounts: [TEST_AMOUNTS.PEGIN],
+          ...BASE_PREPARE_PEGIN_PARAMS,
+        }),
+      ).rejects.toThrow(/placeholder.*hashlock/);
+    });
+
+    it("zeros the wallet root if auth-anchor expansion throws mid-flow", async () => {
+      // Memory-hygiene guard: `expandPerVaultSecrets` is what normally
+      // wipes the root. If `expandAuthAnchor` (which runs first) throws,
+      // `expandPerVaultSecrets` never runs — so `preparePegin` itself
+      // must wipe the root on the throw path. This pins that contract.
+      const vaultSecrets = await import("../../vault-secrets");
+      const expandAuthAnchorSpy = vi.spyOn(vaultSecrets, "expandAuthAnchor");
+      let capturedRoot: Uint8Array | null = null;
+      expandAuthAnchorSpy.mockImplementationOnce((root) => {
+        // Snapshot the root reference before throwing so the test can
+        // verify it gets zeroed by the catch block.
+        capturedRoot = root;
+        throw new Error("simulated auth-anchor failure");
+      });
+
+      const btcWallet = new MockBitcoinWallet({
+        publicKeyHex: TEST_KEYS.DEPOSITOR,
+      });
+      const ethWallet = new MockEthereumWallet();
+      const manager = new PeginManager({
+        btcNetwork: "signet",
+        btcWallet,
+        ethWallet: ethWallet as any,
+        ethChain: TEST_CHAIN,
+        vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
+        mempoolApiUrl: MEMPOOL_API_URLS.signet,
+      });
+
+      await expect(
+        manager.preparePegin({
+          amounts: [TEST_AMOUNTS.PEGIN],
+          ...BASE_PREPARE_PEGIN_PARAMS,
+        }),
+      ).rejects.toThrow(/simulated auth-anchor failure/);
+
+      expect(capturedRoot).not.toBeNull();
+      expect(capturedRoot!.every((b) => b === 0)).toBe(true);
+
+      expandAuthAnchorSpy.mockRestore();
+    });
+
+    it("throws when the broadcast tx is missing the OP_RETURN output", async () => {
+      // Defense against a non-conformant WASM build that fails to emit
+      // the OP_RETURN. Without this assertion the depositor would
+      // produce a Pre-PegIn whose on-chain content lacks the auth
+      // anchor commitment, but the vault flow would still try to mint
+      // a bearer token bound to that anchor — the VP rejects, but only
+      // after the user has burned BTC fees broadcasting.
+      const btcWallet = new MockBitcoinWallet({
+        publicKeyHex: TEST_KEYS.DEPOSITOR,
+      });
+      const ethWallet = new MockEthereumWallet();
+      const manager = new PeginManager({
+        btcNetwork: "signet",
+        btcWallet,
+        ethWallet: ethWallet as any,
+        ethChain: TEST_CHAIN,
+        vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
+        mempoolApiUrl: MEMPOOL_API_URLS.signet,
+      });
+
+      // Reach into the commit pass and surgically remove the OP_RETURN
+      // from the funded tx hex. Triggers the assertion in `preparePegin`.
+      const original = (manager as any).preparePeginCommit.bind(manager);
+      (manager as any).preparePeginCommit = async (args: any) => {
+        const result = await original(args);
+        const bitcoin = await import("bitcoinjs-lib");
+        const tx = bitcoin.Transaction.fromHex(result.fundedPrePeginTxHex);
+        // Drop the OP_RETURN output (vout = vaultCount = 1 in this test).
+        tx.outs = tx.outs.filter((_o, i) => i !== 1);
+        return {
+          ...result,
+          fundedPrePeginTxHex: tx.toHex(),
+        };
+      };
+
+      await expect(
+        manager.preparePegin({
+          amounts: [TEST_AMOUNTS.PEGIN],
+          ...BASE_PREPARE_PEGIN_PARAMS,
+        }),
+      ).rejects.toThrow(/auth-anchor OP_RETURN/);
     });
   });
 });

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/__tests__/assertAuthAnchorOpReturn.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/__tests__/assertAuthAnchorOpReturn.test.ts
@@ -1,0 +1,131 @@
+import * as bitcoin from "bitcoinjs-lib";
+import { describe, expect, it } from "vitest";
+
+import { assertAuthAnchorOpReturn } from "../assertAuthAnchorOpReturn";
+
+const ANCHOR_HASH = "ab".repeat(32);
+const OTHER_HASH = "cd".repeat(32);
+
+/** P2WPKH placeholder script for non-OP_RETURN outputs in fixtures. */
+const DUMMY_P2WPKH_SCRIPT = Buffer.from("0014" + "11".repeat(20), "hex");
+
+interface OutputSpec {
+  /** Either a hex script or a constructed Buffer. */
+  scriptHex: string;
+  value: number;
+}
+
+/**
+ * Build a minimal Bitcoin transaction with the requested outputs.
+ * Inputs use a fixed dummy outpoint; their content is irrelevant for
+ * the OP_RETURN assertion.
+ */
+function buildTxHex(outputs: OutputSpec[]): string {
+  const tx = new bitcoin.Transaction();
+  tx.addInput(Buffer.alloc(32, 0xaa), 0);
+  for (const out of outputs) {
+    tx.addOutput(Buffer.from(out.scriptHex, "hex"), out.value);
+  }
+  return tx.toHex();
+}
+
+function htlcOutput(): OutputSpec {
+  return { scriptHex: DUMMY_P2WPKH_SCRIPT.toString("hex"), value: 100_000 };
+}
+
+function opReturnOutput(payloadHex: string, value = 0): OutputSpec {
+  // OP_RETURN (0x6a) || PUSH32 (0x20) || <32-byte payload>
+  return { scriptHex: `6a20${payloadHex}`, value };
+}
+
+describe("assertAuthAnchorOpReturn", () => {
+  it("accepts a tx whose vout=N output is OP_RETURN PUSH32 <expected hash>", () => {
+    const txHex = buildTxHex([
+      htlcOutput(),
+      opReturnOutput(ANCHOR_HASH),
+      htlcOutput(),
+    ]);
+    expect(() =>
+      assertAuthAnchorOpReturn(txHex, 1, ANCHOR_HASH),
+    ).not.toThrow();
+  });
+
+  it("strips a leading 0x prefix from the funded tx hex", () => {
+    const txHex = buildTxHex([htlcOutput(), opReturnOutput(ANCHOR_HASH)]);
+    expect(() =>
+      assertAuthAnchorOpReturn(`0x${txHex}`, 1, ANCHOR_HASH),
+    ).not.toThrow();
+  });
+
+  it("matches against the expected hash case-insensitively", () => {
+    const txHex = buildTxHex([htlcOutput(), opReturnOutput(ANCHOR_HASH)]);
+    expect(() =>
+      assertAuthAnchorOpReturn(txHex, 1, ANCHOR_HASH.toUpperCase()),
+    ).not.toThrow();
+  });
+
+  it("throws when the tx has no output at vout=N", () => {
+    const txHex = buildTxHex([htlcOutput()]);
+    expect(() =>
+      assertAuthAnchorOpReturn(txHex, 1, ANCHOR_HASH),
+    ).toThrow(/auth-anchor OP_RETURN missing/);
+  });
+
+  it("throws when the script length is not 34 bytes", () => {
+    // OP_RETURN PUSH16 <16 bytes> — wrong length.
+    const tooShort: OutputSpec = {
+      scriptHex: `6a10${"ab".repeat(16)}`,
+      value: 0,
+    };
+    const txHex = buildTxHex([htlcOutput(), tooShort]);
+    expect(() =>
+      assertAuthAnchorOpReturn(txHex, 1, ANCHOR_HASH),
+    ).toThrow(/unexpected/);
+  });
+
+  it("throws when the first opcode is not OP_RETURN (0x6a)", () => {
+    // Replace OP_RETURN with OP_NOP (0x61); keep the rest of the layout.
+    const wrongOpcode: OutputSpec = {
+      scriptHex: `6120${ANCHOR_HASH}`,
+      value: 0,
+    };
+    const txHex = buildTxHex([htlcOutput(), wrongOpcode]);
+    expect(() =>
+      assertAuthAnchorOpReturn(txHex, 1, ANCHOR_HASH),
+    ).toThrow(/unexpected/);
+  });
+
+  it("throws when the push prefix is not OP_PUSH32 (0x20)", () => {
+    // OP_RETURN OP_PUSHDATA1 0x20 <32 bytes> — semantically equivalent
+    // to OP_RETURN PUSH32 but a different encoding. We reject it
+    // strictly: WASM emits the canonical PUSH32 form, so anything else
+    // signals a non-conformant build.
+    const pushdata1: OutputSpec = {
+      scriptHex: `6a4c20${ANCHOR_HASH}`,
+      value: 0,
+    };
+    const txHex = buildTxHex([htlcOutput(), pushdata1]);
+    expect(() =>
+      assertAuthAnchorOpReturn(txHex, 1, ANCHOR_HASH),
+    ).toThrow(/unexpected/);
+  });
+
+  it("throws when the pushed payload differs from the expected hash", () => {
+    const txHex = buildTxHex([htlcOutput(), opReturnOutput(OTHER_HASH)]);
+    expect(() =>
+      assertAuthAnchorOpReturn(txHex, 1, ANCHOR_HASH),
+    ).toThrow(/payload mismatch/);
+  });
+
+  it("throws when the OP_RETURN output has non-zero value", () => {
+    // Bitcoin permits non-zero OP_RETURN outputs (they're unspendable
+    // burns), but they're non-standard. The contract expects zero.
+    const txHex = buildTxHex([
+      htlcOutput(),
+      opReturnOutput(ANCHOR_HASH, /* value */ 546),
+    ]);
+    expect(() =>
+      assertAuthAnchorOpReturn(txHex, 1, ANCHOR_HASH),
+    ).toThrow(/non-zero value/);
+  });
+});

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/__tests__/expandPerVaultSecrets.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/__tests__/expandPerVaultSecrets.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from "vitest";
+
+import * as wots from "../../../wots";
+import { expandPerVaultSecrets } from "../expandPerVaultSecrets";
+
+function freshRoot(byte = 0xab): Uint8Array {
+  return new Uint8Array(32).fill(byte);
+}
+
+describe("expandPerVaultSecrets", () => {
+  it("returns one entry per vault across all four output arrays", async () => {
+    const root = freshRoot();
+    const result = await expandPerVaultSecrets(root, 3);
+
+    expect(result.perVaultWotsKeys).toHaveLength(3);
+    expect(result.wotsPkHashes).toHaveLength(3);
+    expect(result.htlcSecretHexes).toHaveLength(3);
+    expect(result.hashlocks).toHaveLength(3);
+  });
+
+  it("emits per-vault HTLC secrets in the canonical hex shape (no 0x, lowercase, 64 chars)", async () => {
+    const root = freshRoot();
+    const result = await expandPerVaultSecrets(root, 2);
+
+    for (const secretHex of result.htlcSecretHexes) {
+      expect(secretHex).toMatch(/^[0-9a-f]{64}$/);
+    }
+    for (const hashlock of result.hashlocks) {
+      expect(hashlock).toMatch(/^[0-9a-f]{64}$/);
+    }
+    for (const wotsHash of result.wotsPkHashes) {
+      expect(wotsHash).toMatch(/^0x[0-9a-f]{64}$/);
+    }
+  });
+
+  it("produces distinct secrets across vaults via HKDF htlcVout domain separation", async () => {
+    // Same root, different htlcVout → different secrets. This pins the
+    // per-vault domain separation that prevents one vault's HTLC from
+    // unlocking another's, even when they share a Pre-PegIn.
+    const root = freshRoot();
+    const result = await expandPerVaultSecrets(root, 3);
+
+    const unique = new Set(result.htlcSecretHexes);
+    expect(unique.size).toBe(3);
+
+    const uniqueHashlocks = new Set(result.hashlocks);
+    expect(uniqueHashlocks.size).toBe(3);
+
+    const uniqueWots = new Set(result.wotsPkHashes);
+    expect(uniqueWots.size).toBe(3);
+  });
+
+  it("is deterministic for the same root and vault count", async () => {
+    const a = await expandPerVaultSecrets(freshRoot(0x42), 2);
+    const b = await expandPerVaultSecrets(freshRoot(0x42), 2);
+    expect(a.htlcSecretHexes).toEqual(b.htlcSecretHexes);
+    expect(a.hashlocks).toEqual(b.hashlocks);
+    expect(a.wotsPkHashes).toEqual(b.wotsPkHashes);
+  });
+
+  it("yields different secrets for different roots", async () => {
+    const a = await expandPerVaultSecrets(freshRoot(0x01), 1);
+    const b = await expandPerVaultSecrets(freshRoot(0x02), 1);
+    expect(a.htlcSecretHexes).not.toEqual(b.htlcSecretHexes);
+  });
+
+  it("zeros the root buffer after a successful expansion", async () => {
+    const root = freshRoot(0x77);
+    await expandPerVaultSecrets(root, 1);
+    expect(root.every((b) => b === 0)).toBe(true);
+  });
+
+  it("zeros the root even if an inner expansion throws", async () => {
+    // Memory-hygiene contract: the helper takes ownership of `root`
+    // and must wipe it on every exit path, including when one of the
+    // dependencies (`deriveWotsBlocksFromSeed` here) fails mid-loop.
+    // Without the outer `try/finally` this would leak a live root
+    // into long-lived memory whenever HKDF/keccak/wots derivation
+    // hits an error.
+    const spy = vi
+      .spyOn(wots, "deriveWotsBlocksFromSeed")
+      .mockRejectedValueOnce(new Error("simulated wots failure"));
+
+    const root = freshRoot(0x55);
+    await expect(expandPerVaultSecrets(root, 2)).rejects.toThrow(
+      /simulated wots failure/,
+    );
+    expect(root.every((b) => b === 0)).toBe(true);
+
+    spy.mockRestore();
+  });
+
+  it("returns empty arrays for vaultCount = 0 (no expansion, root still zeroed)", async () => {
+    // Defensive: callers (PeginManager) reject zero vaults upstream,
+    // but the helper itself should not blow up — it must still wipe
+    // the root rather than leaving it live.
+    const root = freshRoot(0x33);
+    const result = await expandPerVaultSecrets(root, 0);
+    expect(result.htlcSecretHexes).toEqual([]);
+    expect(result.hashlocks).toEqual([]);
+    expect(result.wotsPkHashes).toEqual([]);
+    expect(result.perVaultWotsKeys).toEqual([]);
+    expect(root.every((b) => b === 0)).toBe(true);
+  });
+});

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/__tests__/normalizeWalletInputs.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/__tests__/normalizeWalletInputs.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  normalizePopSignature,
+  normalizeXOnlyPubkey,
+} from "../normalizeWalletInputs";
+
+const X_ONLY_LOWER =
+  "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+const X_ONLY_UPPER =
+  "79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798";
+const COMPRESSED_PUBKEY =
+  "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+
+describe("normalizeXOnlyPubkey", () => {
+  it("passes through 64-char x-only hex unchanged", () => {
+    expect(normalizeXOnlyPubkey(X_ONLY_LOWER)).toBe(X_ONLY_LOWER);
+  });
+
+  it("lowercases uppercase x-only hex so downstream equality checks succeed", () => {
+    expect(normalizeXOnlyPubkey(X_ONLY_UPPER)).toBe(X_ONLY_LOWER);
+  });
+
+  it("strips the parity byte from compressed SEC1 pubkeys", () => {
+    expect(normalizeXOnlyPubkey(COMPRESSED_PUBKEY)).toBe(X_ONLY_LOWER);
+  });
+
+  it("strips a leading 0x prefix", () => {
+    expect(normalizeXOnlyPubkey(`0x${X_ONLY_LOWER}`)).toBe(X_ONLY_LOWER);
+  });
+
+  it("throws on empty string", () => {
+    expect(() => normalizeXOnlyPubkey("")).toThrow(
+      /BTC wallet returned empty public key/,
+    );
+  });
+
+  it("throws on non-string input", () => {
+    expect(() => normalizeXOnlyPubkey(undefined)).toThrow(
+      /BTC wallet returned empty public key/,
+    );
+    expect(() => normalizeXOnlyPubkey(null)).toThrow(
+      /BTC wallet returned empty public key/,
+    );
+    expect(() => normalizeXOnlyPubkey(42)).toThrow(
+      /BTC wallet returned empty public key/,
+    );
+  });
+
+  it("throws on invalid hex characters", () => {
+    expect(() => normalizeXOnlyPubkey("zzzz")).toThrow();
+  });
+});
+
+describe("normalizePopSignature", () => {
+  it("accepts 0x-prefixed lowercase hex unchanged", () => {
+    expect(normalizePopSignature("0xdeadbeef")).toBe("0xdeadbeef");
+  });
+
+  it("lowercases 0x-prefixed uppercase hex", () => {
+    expect(normalizePopSignature("0xDEADBEEF")).toBe("0xdeadbeef");
+  });
+
+  it("0x-prefixes unprefixed hex when input is pure hex", () => {
+    // Hex precedence over base64 prevents silent misinterpretation of
+    // wallets that return bare hex like "deadbeef".
+    expect(normalizePopSignature("deadbeef")).toBe("0xdeadbeef");
+  });
+
+  it("decodes canonical standard base64 to 0x-prefixed hex", () => {
+    // "SGVsbG8=" -> "Hello" -> "48656c6c6f"
+    expect(normalizePopSignature("SGVsbG8=")).toBe("0x48656c6c6f");
+  });
+
+  it("rejects URL-safe base64 (- and _)", () => {
+    // URL-safe base64 of bytes that include non-standard chars
+    // "AB-_" uses URL-safe alphabet; standard base64 rejects '-' and '_'.
+    expect(() => normalizePopSignature("AB-_")).toThrow(
+      /malformed base64 BIP-322 signature/,
+    );
+  });
+
+  it("rejects base64 missing padding", () => {
+    // "SGVsbG8" (no padding) — pure hex regex rejects (G is not hex), so
+    // it falls through to base64 which requires length % 4 === 0.
+    expect(() => normalizePopSignature("SGVsbG8")).toThrow(
+      /malformed base64 BIP-322 signature/,
+    );
+  });
+
+  it("rejects non-canonical base64 (round-trip mismatch)", () => {
+    // "AB==" decodes to one byte (0x00) but re-encodes to "AA==", so
+    // the round-trip check rejects it.
+    expect(() => normalizePopSignature("AB==")).toThrow(
+      /malformed base64 BIP-322 signature/,
+    );
+  });
+
+  it("rejects malformed 0x-prefixed hex with odd length", () => {
+    expect(() => normalizePopSignature("0xabc")).toThrow(
+      /malformed hex BIP-322 signature/,
+    );
+  });
+
+  it("rejects malformed unprefixed hex with odd length", () => {
+    expect(() => normalizePopSignature("abc")).toThrow(
+      /malformed hex BIP-322 signature/,
+    );
+  });
+
+  it("rejects 0x prefix with no payload", () => {
+    expect(() => normalizePopSignature("0x")).toThrow(
+      /malformed hex BIP-322 signature/,
+    );
+  });
+
+  it("throws on empty string", () => {
+    expect(() => normalizePopSignature("")).toThrow(
+      /BTC wallet returned empty BIP-322 signature/,
+    );
+  });
+
+  it("throws on non-string input", () => {
+    expect(() => normalizePopSignature(undefined)).toThrow(
+      /BTC wallet returned empty BIP-322 signature/,
+    );
+  });
+});

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/__tests__/signPsbtsWithFallback.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/__tests__/signPsbtsWithFallback.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type {
+  BitcoinWallet,
+  SignPsbtOptions,
+} from "../../../../../shared/wallets";
+import { signPsbtsWithFallback } from "../signPsbtsWithFallback";
+
+function makeWallet(
+  overrides: Partial<BitcoinWallet> = {},
+): BitcoinWallet {
+  // Construct a minimal stub satisfying the structural shape used by
+  // signPsbtsWithFallback. Other BitcoinWallet methods are not invoked
+  // and are therefore left as throwing placeholders.
+  const stub: Partial<BitcoinWallet> = {
+    signPsbt: vi.fn(),
+    ...overrides,
+  };
+  return stub as BitcoinWallet;
+}
+
+describe("signPsbtsWithFallback", () => {
+  it("uses native batch signing when wallet.signPsbts is a function", async () => {
+    const signPsbts = vi
+      .fn<NonNullable<BitcoinWallet["signPsbts"]>>()
+      .mockResolvedValue(["signed-a", "signed-b"]);
+    const signPsbt = vi.fn<BitcoinWallet["signPsbt"]>();
+    const wallet = makeWallet({ signPsbts, signPsbt });
+    const psbts = ["a", "b"];
+    const opts: SignPsbtOptions[] = [
+      { autoFinalized: false },
+      { autoFinalized: false },
+    ];
+
+    const out = await signPsbtsWithFallback(wallet, psbts, opts);
+
+    expect(out).toEqual(["signed-a", "signed-b"]);
+    expect(signPsbts).toHaveBeenCalledTimes(1);
+    expect(signPsbts).toHaveBeenCalledWith(psbts, opts);
+    expect(signPsbt).not.toHaveBeenCalled();
+  });
+
+  it("throws if native batch returns a different number of signed PSBTs", async () => {
+    // Pin the arity invariant: the batch path must not silently drop or
+    // pad PSBTs. The error message must surface both counts so callers
+    // can debug a non-conformant wallet adapter.
+    const signPsbts = vi
+      .fn<NonNullable<BitcoinWallet["signPsbts"]>>()
+      .mockResolvedValue(["only-one"]);
+    const wallet = makeWallet({ signPsbts });
+
+    await expect(
+      signPsbtsWithFallback(wallet, ["a", "b"], [
+        { autoFinalized: false },
+        { autoFinalized: false },
+      ]),
+    ).rejects.toThrow(/Expected 2 signed PSBTs but received 1/);
+  });
+
+  it("falls back to sequential signPsbt when wallet.signPsbts is missing", async () => {
+    // Older adapters expose only signPsbt. The fallback must visit each
+    // PSBT in order with its corresponding options entry.
+    const signPsbt = vi
+      .fn<BitcoinWallet["signPsbt"]>()
+      .mockImplementation(async (psbtHex) => `signed-${psbtHex}`);
+    const wallet = makeWallet({ signPsbts: undefined, signPsbt });
+
+    const opts: SignPsbtOptions[] = [
+      { autoFinalized: false },
+      { autoFinalized: true },
+    ];
+    const out = await signPsbtsWithFallback(wallet, ["a", "b"], opts);
+
+    expect(out).toEqual(["signed-a", "signed-b"]);
+    expect(signPsbt).toHaveBeenCalledTimes(2);
+    expect(signPsbt).toHaveBeenNthCalledWith(1, "a", opts[0]);
+    expect(signPsbt).toHaveBeenNthCalledWith(2, "b", opts[1]);
+  });
+
+  it("returns an empty array for empty input regardless of which path is used", async () => {
+    const signPsbts = vi
+      .fn<NonNullable<BitcoinWallet["signPsbts"]>>()
+      .mockResolvedValue([]);
+    const batchWallet = makeWallet({ signPsbts });
+    expect(
+      await signPsbtsWithFallback(batchWallet, [], []),
+    ).toEqual([]);
+
+    const signPsbt = vi.fn<BitcoinWallet["signPsbt"]>();
+    const fallbackWallet = makeWallet({ signPsbts: undefined, signPsbt });
+    expect(
+      await signPsbtsWithFallback(fallbackWallet, [], []),
+    ).toEqual([]);
+    expect(signPsbt).not.toHaveBeenCalled();
+  });
+});

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/assertAuthAnchorOpReturn.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/assertAuthAnchorOpReturn.ts
@@ -1,0 +1,80 @@
+/**
+ * Structural verifier for the auth-anchor OP_RETURN in a funded
+ * Pre-PegIn transaction.
+ *
+ * @module managers/pegin/assertAuthAnchorOpReturn
+ */
+
+import * as bitcoin from "bitcoinjs-lib";
+
+import { stripHexPrefix } from "../../primitives/utils/bitcoin";
+
+/** OP_RETURN opcode. */
+const OP_RETURN = 0x6a;
+/** Push-32-bytes opcode (raw push, not OP_PUSHDATA1). */
+const OP_PUSH32 = 0x20;
+/** Encoded length of a standard OP_RETURN script with a 32-byte payload. */
+const OP_RETURN_PUSH32_SCRIPT_LEN = 1 + 1 + 32;
+
+/**
+ * Verify the broadcast Pre-PegIn carries the expected OP_RETURN
+ * commitment to the auth anchor.
+ *
+ * The OP_RETURN sits at `vout = vaultCount` (right after the per-vault
+ * HTLC outputs and before the depositor-claim/change outputs) and
+ * pushes the 32-byte `SHA256(authAnchor)`. The script encoding is
+ * exactly `OP_RETURN || PUSH32 || <32 bytes>` (34 bytes). A
+ * non-conformant WASM build that omitted the OP_RETURN, swapped its
+ * position, or changed its push payload would let the depositor
+ * obtain a valid bearer token for a Pre-PegIn whose on-chain
+ * commitment doesn't actually bind the anchor — degrading the auth
+ * from on-chain-bound to a shared secret. Fail closed.
+ *
+ * @throws If the OP_RETURN is missing, mis-located, mis-encoded, or
+ *         pushes a payload other than `expectedAuthAnchorHashHex`.
+ */
+export function assertAuthAnchorOpReturn(
+  fundedPrePeginTxHex: string,
+  vaultCount: number,
+  expectedAuthAnchorHashHex: string,
+): void {
+  const cleanHex = stripHexPrefix(fundedPrePeginTxHex);
+  const tx = bitcoin.Transaction.fromHex(cleanHex);
+
+  if (tx.outs.length <= vaultCount) {
+    throw new Error(
+      `Pre-PegIn auth-anchor OP_RETURN missing: tx has ${tx.outs.length} ` +
+        `outputs, expected at least ${vaultCount + 1} (vault outputs + OP_RETURN)`,
+    );
+  }
+
+  const opReturnOutput = tx.outs[vaultCount];
+  const script = opReturnOutput.script;
+  if (
+    script.length !== OP_RETURN_PUSH32_SCRIPT_LEN ||
+    script[0] !== OP_RETURN ||
+    script[1] !== OP_PUSH32
+  ) {
+    throw new Error(
+      `Pre-PegIn auth-anchor OP_RETURN at vout ${vaultCount} has unexpected ` +
+        `script encoding (got ${script.length}-byte script with prefix ` +
+        `0x${script.slice(0, Math.min(2, script.length)).toString("hex")}; ` +
+        `expected ${OP_RETURN_PUSH32_SCRIPT_LEN}-byte OP_RETURN + PUSH32 layout)`,
+    );
+  }
+
+  const pushedHex = script.slice(2).toString("hex").toLowerCase();
+  if (pushedHex !== expectedAuthAnchorHashHex.toLowerCase()) {
+    throw new Error(
+      `Pre-PegIn auth-anchor OP_RETURN payload mismatch at vout ${vaultCount}: ` +
+        `tx pushes ${pushedHex}, expected ${expectedAuthAnchorHashHex}`,
+    );
+  }
+
+  if (opReturnOutput.value !== 0) {
+    throw new Error(
+      `Pre-PegIn auth-anchor OP_RETURN at vout ${vaultCount} has non-zero ` +
+        `value ${opReturnOutput.value}; OP_RETURN outputs must be 0-value`,
+    );
+  }
+}

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/expandPerVaultSecrets.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/expandPerVaultSecrets.ts
@@ -1,0 +1,81 @@
+/**
+ * Per-vault HKDF expansion of WOTS keys + HTLC preimages from the
+ * wallet root.
+ *
+ * @module managers/pegin/expandPerVaultSecrets
+ */
+
+import type { Hex } from "viem";
+
+import type { WotsBlockPublicKey } from "../../clients/vault-provider/types";
+import {
+  ensureHexPrefix,
+  uint8ArrayToHex,
+} from "../../primitives/utils/bitcoin";
+import { computeHashlock } from "../../services";
+import {
+  expandHashlockSecret,
+  expandWotsSeed,
+} from "../../vault-secrets";
+import {
+  computeWotsBlockPublicKeysHash,
+  deriveWotsBlocksFromSeed,
+} from "../../wots";
+
+/**
+ * Result of {@link expandPerVaultSecrets}.
+ */
+export interface PerVaultExpansionResult {
+  perVaultWotsKeys: WotsBlockPublicKey[][];
+  /** Keccak256 of WOTS keys, ready as `depositorWotsPkHash` (0x-prefixed). */
+  wotsPkHashes: Hex[];
+  /** HTLC preimage hex per vault (no 0x prefix). */
+  htlcSecretHexes: string[];
+  /** SHA-256 of each HTLC preimage as 64-char hex (no 0x prefix). */
+  hashlocks: string[];
+}
+
+/**
+ * Derive per-vault WOTS keys + HTLC preimages from the wallet root.
+ *
+ * Takes ownership of `root`: zeros the buffer (and per-vault secret
+ * buffers) before returning, regardless of how the caller exits.
+ *
+ * @param root        32-byte wallet-derived root from `deriveVaultRoot`.
+ * @param vaultCount  Number of vaults (= length of `amounts`).
+ */
+export async function expandPerVaultSecrets(
+  root: Uint8Array,
+  vaultCount: number,
+): Promise<PerVaultExpansionResult> {
+  const perVaultWotsKeys: WotsBlockPublicKey[][] = [];
+  const wotsPkHashes: Hex[] = [];
+  const htlcSecretHexes: string[] = [];
+  const hashlocks: string[] = [];
+
+  try {
+    for (let i = 0; i < vaultCount; i++) {
+      const wotsSeed = expandWotsSeed(root, i);
+      try {
+        const wotsPublicKeys = await deriveWotsBlocksFromSeed(wotsSeed);
+        perVaultWotsKeys.push(wotsPublicKeys);
+        wotsPkHashes.push(computeWotsBlockPublicKeysHash(wotsPublicKeys));
+      } finally {
+        wotsSeed.fill(0);
+      }
+
+      const secretBytes = expandHashlockSecret(root, i);
+      try {
+        const secretHex = uint8ArrayToHex(secretBytes);
+        htlcSecretHexes.push(secretHex);
+        hashlocks.push(computeHashlock(ensureHexPrefix(secretHex)).slice(2));
+      } finally {
+        secretBytes.fill(0);
+      }
+    }
+  } finally {
+    root.fill(0);
+  }
+
+  return { perVaultWotsKeys, wotsPkHashes, htlcSecretHexes, hashlocks };
+}

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Internal-only re-exports for the Pre-PegIn / PegIn building blocks.
+ * Consumers should depend on `PeginManager`; these helpers exist to
+ * keep that file a thin coordinator.
+ *
+ * @module managers/pegin
+ */
+
+export { assertAuthAnchorOpReturn } from "./assertAuthAnchorOpReturn";
+export {
+  expandPerVaultSecrets,
+  type PerVaultExpansionResult,
+} from "./expandPerVaultSecrets";
+export {
+  normalizePopSignature,
+  normalizeXOnlyPubkey,
+} from "./normalizeWalletInputs";
+export { signPsbtsWithFallback } from "./signPsbtsWithFallback";

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/normalizeWalletInputs.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/normalizeWalletInputs.ts
@@ -1,0 +1,81 @@
+/**
+ * Normalizers for wallet-returned values consumed by the Pre-PegIn flow.
+ *
+ * @module managers/pegin/normalizeWalletInputs
+ */
+
+import { Buffer } from "buffer";
+import type { Hex } from "viem";
+
+import { processPublicKeyToXOnly } from "../../primitives/utils/bitcoin";
+
+const HEX_SIGNATURE_REGEX = /^0x[0-9a-f]+$/i;
+const UNPREFIXED_HEX_SIGNATURE_REGEX = /^[0-9a-f]+$/i;
+const BASE64_SIGNATURE_REGEX = /^[A-Za-z0-9+/]+={0,2}$/;
+
+/**
+ * Normalize a wallet-returned BTC public key to the canonical x-only
+ * 64-char lowercase hex form (no 0x prefix).
+ *
+ * Throws on empty/non-string input. Idempotent on x-only input.
+ */
+export function normalizeXOnlyPubkey(raw: unknown): string {
+  if (typeof raw !== "string" || raw.length === 0) {
+    throw new Error("BTC wallet returned empty public key");
+  }
+  // Lowercase so case-sensitive equality checks downstream don't fail
+  // on uppercase wallet output (processPublicKeyToXOnly passes a 64-char
+  // input through unchanged).
+  return processPublicKeyToXOnly(raw).toLowerCase();
+}
+
+/**
+ * Normalize a wallet-returned BIP-322 signature into 0x-prefixed hex.
+ *
+ * Accepts:
+ *  - 0x-prefixed lowercase/uppercase hex
+ *  - unprefixed hex (wins over base64 when input is pure `[0-9a-fA-F]+`)
+ *  - canonical standard base64 (`[A-Za-z0-9+/]` with `=` padding to a
+ *    multiple of 4 and no non-canonical encodings)
+ *
+ * Rejects URL-safe base64 (`-`/`_`) and base64 without padding. Wallets
+ * known to return BIP-322 signatures (Keystone, UniSat, OKX, OneKey,
+ * Unisat) all use standard base64; URL-safe is an explicit non-goal.
+ */
+export function normalizePopSignature(raw: unknown): Hex {
+  if (typeof raw !== "string" || raw.length === 0) {
+    throw new Error("BTC wallet returned empty BIP-322 signature");
+  }
+
+  if (raw.startsWith("0x") || raw.startsWith("0X")) {
+    if (
+      !HEX_SIGNATURE_REGEX.test(raw) ||
+      raw.length < 4 ||
+      raw.length % 2 !== 0
+    ) {
+      throw new Error("BTC wallet returned malformed hex BIP-322 signature");
+    }
+    return raw.toLowerCase() as Hex;
+  }
+
+  // Prefer hex when the input could be either: every hex char is also a
+  // valid base64 char, so the base64 branch alone would silently misdecode
+  // a wallet returning "deadbeef" instead of "0xdeadbeef".
+  if (UNPREFIXED_HEX_SIGNATURE_REGEX.test(raw)) {
+    if (raw.length % 2 !== 0) {
+      throw new Error("BTC wallet returned malformed hex BIP-322 signature");
+    }
+    return `0x${raw.toLowerCase()}` as Hex;
+  }
+
+  if (!BASE64_SIGNATURE_REGEX.test(raw) || raw.length % 4 !== 0) {
+    throw new Error("BTC wallet returned malformed base64 BIP-322 signature");
+  }
+  const bytes = Buffer.from(raw, "base64");
+  // Round-trip to reject non-canonical base64 (e.g. "AB==" decodes but
+  // re-encodes to "AA==").
+  if (bytes.length === 0 || bytes.toString("base64") !== raw) {
+    throw new Error("BTC wallet returned malformed base64 BIP-322 signature");
+  }
+  return `0x${bytes.toString("hex")}` as Hex;
+}

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/signPsbtsWithFallback.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/signPsbtsWithFallback.ts
@@ -1,0 +1,43 @@
+/**
+ * Batch-sign helper that prefers native `signPsbts` and falls back to
+ * sequential `signPsbt` for wallets that don't implement batch signing.
+ *
+ * @module managers/pegin/signPsbtsWithFallback
+ */
+
+import type {
+  BitcoinWallet,
+  SignPsbtOptions,
+} from "../../../../shared/wallets";
+
+/**
+ * Sign multiple PSBTs against a wallet. Wallets exposing native batch
+ * signing (e.g. UniSat) sign all PSBTs in a single interaction; others
+ * (Ledger, AppKit) loop `signPsbt` internally, so the popup UX depends
+ * on the wallet adapter.
+ *
+ * @throws If `signPsbts` returns a different number of signed PSBTs
+ *         than were submitted.
+ */
+export async function signPsbtsWithFallback(
+  wallet: BitcoinWallet,
+  psbtsHexes: string[],
+  options: SignPsbtOptions[],
+): Promise<string[]> {
+  if (typeof wallet.signPsbts === "function") {
+    const signedPsbts = await wallet.signPsbts(psbtsHexes, options);
+    if (signedPsbts.length !== psbtsHexes.length) {
+      throw new Error(
+        `Expected ${psbtsHexes.length} signed PSBTs but received ${signedPsbts.length}`,
+      );
+    }
+    return signedPsbts;
+  }
+
+  const signedPsbts: string[] = [];
+  for (let i = 0; i < psbtsHexes.length; i++) {
+    const signed = await wallet.signPsbt(psbtsHexes[i], options[i]);
+    signedPsbts.push(signed);
+  }
+  return signedPsbts;
+}

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/pegin.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/pegin.test.ts
@@ -358,6 +358,57 @@ describe("buildPrePeginPsbt", () => {
       expect(with_.htlcScriptPubKeys).toEqual(without.htlcScriptPubKeys);
       expect(with_.htlcValues).toEqual(without.htlcValues);
     });
+
+    it("totalOutputValue and tx structure are invariant under hashlock content", async () => {
+      // The sizing pass uses 32-byte placeholder hashlocks because the
+      // wallet popup that produces real ones hasn't run yet. The commit
+      // pass swaps in real values. UTXO selection MUST be invariant
+      // under that swap — otherwise sizing's fee/changeAmount would be
+      // wrong for the funded broadcast tx and broadcast underfunding
+      // (or change misaccounting) becomes possible. Mirrors the
+      // auth-anchor invariance test below.
+      const placeholderHashlocks = ["00".repeat(32), "00".repeat(32)];
+      const realHashlocks = ["ab".repeat(32), "cd".repeat(32)];
+      const sized = await buildPrePeginPsbt(
+        makePrePeginParams({
+          hashlocks: placeholderHashlocks,
+          pegInAmounts: [50_000n, 60_000n],
+        }),
+      );
+      const committed = await buildPrePeginPsbt(
+        makePrePeginParams({
+          hashlocks: realHashlocks,
+          pegInAmounts: [50_000n, 60_000n],
+        }),
+      );
+      expect(committed.totalOutputValue).toBe(sized.totalOutputValue);
+      expect(committed.htlcValues).toEqual(sized.htlcValues);
+      // HTLC scriptPubKey is a tweaked taproot output key that depends
+      // on the hashlock — these legitimately differ between sized and
+      // committed. We don't assert equality on htlcScriptPubKeys here.
+    });
+
+    it("totalOutputValue and fee sizing are invariant under authAnchorHash content", async () => {
+      // The sizing pass uses a 32-byte placeholder for `authAnchorHash`
+      // because the wallet popup that produces the real anchor hasn't
+      // run yet. The commit pass swaps in the real hash. UTXO selection
+      // and fee computation MUST be identical between the two so the
+      // funding outpoints used to derive the vault root are the same as
+      // the ones funding the broadcast tx — otherwise the resume flow
+      // re-derives a different root and activation fails.
+      const placeholderHash = "00".repeat(32);
+      const realHash = VALID_AUTH_ANCHOR_HASH;
+      const sized = await buildPrePeginPsbt(
+        makePrePeginParams({ authAnchorHash: placeholderHash }),
+      );
+      const committed = await buildPrePeginPsbt(
+        makePrePeginParams({ authAnchorHash: realHash }),
+      );
+      expect(committed.totalOutputValue).toBe(sized.totalOutputValue);
+      expect(committed.htlcValues).toEqual(sized.htlcValues);
+      expect(committed.htlcScriptPubKeys).toEqual(sized.htlcScriptPubKeys);
+      expect(committed.authAnchorVout).toBe(sized.authAnchorVout);
+    });
   });
 
   describe("Error handling", () => {


### PR DESCRIPTION
- Pre-PegIn transactions now carry an `OP_RETURN <PUSH32
SHA256(authAnchor)>` output committing to a wallet-derived auth
anchor. The raw 32-byte preimage is exposed to the deposit flow via
`derivedSecrets.authAnchorHex` so a follow-up PR can wire
`VpTokenProvider` into the VP RPC client and request bearer tokens
via `auth_createDepositorToken`.
- Adds a fail-closed `assertAuthAnchorOpReturn` check that verifies
the broadcast tx's OP_RETURN encoding, vout placement, and payload. A
 non-conformant WASM build that omitted, misplaced, or mis-encoded
the OP_RETURN would let a depositor obtain a token whose on-chain
commitment doesn't actually bind the anchor — this assertion makes
that failure mode loud.
- Refactors `PeginManager.ts` by extracting pure helpers into
`packages/babylon-ts-sdk/src/tbv/core/managers/pegin/` so the file
stops growing every PR. No behaviour change in the extracted
functions.