### PR TITLE
fix(vault): deposit flow, wots commitment

### DIFF
--- a/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
@@ -942,6 +942,8 @@ describe("useDepositFlow", () => {
         await import("@/services/vault/vaultActivationService"),
       );
 
+      const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
+
       // First activation succeeds but triggers abort
       vi.mocked(activateVaultWithSecret).mockImplementation(async () => {
         // After vault 1 activates, abort the flow
@@ -949,12 +951,10 @@ describe("useDepositFlow", () => {
         return { hash: "0xActivationTxHash" } as any;
       });
 
-      const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
-
       await executeWithAutoArtifactDownload(result);
 
-      // Only vault 1 should have been activated — vault 2 should be skipped
-      // because signal.aborted is checked at the top of the loop
+      // Only vault 1 should have been activated — vault 2 is skipped
+      // because signal.throwIfAborted() fires at the top of the next iteration
       expect(activateVaultWithSecret).toHaveBeenCalledTimes(1);
     });
   });

--- a/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
@@ -905,6 +905,60 @@ describe("useDepositFlow", () => {
     });
   });
 
+  describe("Pubkey Consistency (Issue #3)", () => {
+    it("rejects when PoP pubkey differs from preparePegin pubkey", async () => {
+      const { signProofOfPossession } = vi.mocked(
+        await import("../depositFlowSteps"),
+      );
+      const { registerPeginBatchAndWait } = vi.mocked(
+        await import("../depositFlowSteps"),
+      );
+
+      // PoP returns a different pubkey than preparePeginTransaction
+      vi.mocked(signProofOfPossession).mockResolvedValueOnce({
+        btcPopSignature: "0xMockPopSignature" as Hex,
+        depositorEthAddress: "0xEthAddress123" as `0x${string}`,
+        depositorBtcPubkey: "ff".repeat(32), // different from MOCK_DEPOSITOR_PUBKEY
+      });
+
+      const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
+
+      await executeWithAutoArtifactDownload(result);
+
+      await waitFor(() => {
+        expect(result.current.error).toContain(
+          "BTC wallet account changed during deposit flow",
+        );
+      });
+
+      // Registration must never be attempted with mismatched keys
+      expect(registerPeginBatchAndWait).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Abort Signal (Issue #4)", () => {
+    it("stops activation loop when signal is aborted after first vault", async () => {
+      const { activateVaultWithSecret } = vi.mocked(
+        await import("@/services/vault/vaultActivationService"),
+      );
+
+      // First activation succeeds but triggers abort
+      vi.mocked(activateVaultWithSecret).mockImplementation(async () => {
+        // After vault 1 activates, abort the flow
+        result.current.abort();
+        return { hash: "0xActivationTxHash" } as any;
+      });
+
+      const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
+
+      await executeWithAutoArtifactDownload(result);
+
+      // Only vault 1 should have been activated — vault 2 should be skipped
+      // because signal.aborted is checked at the top of the loop
+      expect(activateVaultWithSecret).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe("UTXO Reservation", () => {
     it("should filter reserved UTXOs before preparing pegin transaction", async () => {
       const { getPendingPegins } = vi.mocked(

--- a/services/vault/src/hooks/deposit/useDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useDepositFlow.ts
@@ -542,7 +542,7 @@ export function useDepositFlow(
         const MAX_WOTS_ATTEMPTS = 2;
 
         for (const result of broadcastedResults) {
-          if (signal.aborted) break;
+          signal.throwIfAborted();
 
           let wotsSuccess = false;
 
@@ -603,11 +603,11 @@ export function useDepositFlow(
         for (let vi = 0; vi < broadcastedResults.length; vi++) {
           const result = broadcastedResults[vi];
 
+          signal.throwIfAborted();
+
           // Skip vaults whose WOTS key submission failed — the VP won't have
           // the keys needed, so payout signing would timeout.
           if (wotsFailedVaultIds.has(result.vaultId)) continue;
-
-          if (signal.aborted) break;
 
           try {
             setCurrentVaultIndex(vi);
@@ -698,7 +698,7 @@ export function useDepositFlow(
           setIsWaiting(false);
 
           for (const result of readyResults) {
-            if (signal.aborted) break;
+            signal.throwIfAborted();
 
             try {
               await activateVaultWithSecret({

--- a/services/vault/src/hooks/deposit/useDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useDepositFlow.ts
@@ -374,6 +374,21 @@ export function useDepositFlow(
           walletClient,
         );
 
+        // Guard: the BTC pubkey used for WOTS derivation (in preparePegin)
+        // must match the pubkey that signed the PoP. A mismatch means the
+        // wallet account changed between the two steps — registering would
+        // bind WOTS keys to one identity and the PoP to another, making the
+        // vault unactivatable.
+        if (
+          popSignature.depositorBtcPubkey !== batchResult.depositorBtcPubkey
+        ) {
+          throw new Error(
+            "BTC wallet account changed during deposit flow. " +
+              "The signing key no longer matches the key used for vault setup. " +
+              "Please restart the deposit.",
+          );
+        }
+
         // 3c. Build batch request array.
         const batchRequests = batchResult.perVault.map((vault, i) => ({
           depositorSignedPeginTx: vault.peginTxHex,
@@ -527,6 +542,8 @@ export function useDepositFlow(
         const MAX_WOTS_ATTEMPTS = 2;
 
         for (const result of broadcastedResults) {
+          if (signal.aborted) break;
+
           let wotsSuccess = false;
 
           for (let attempt = 1; attempt <= MAX_WOTS_ATTEMPTS; attempt++) {
@@ -589,6 +606,8 @@ export function useDepositFlow(
           // Skip vaults whose WOTS key submission failed — the VP won't have
           // the keys needed, so payout signing would timeout.
           if (wotsFailedVaultIds.has(result.vaultId)) continue;
+
+          if (signal.aborted) break;
 
           try {
             setCurrentVaultIndex(vi);
@@ -679,11 +698,14 @@ export function useDepositFlow(
           setIsWaiting(false);
 
           for (const result of readyResults) {
+            if (signal.aborted) break;
+
             try {
               await activateVaultWithSecret({
                 vaultId: result.vaultId,
                 secret: ensureHexPrefix(htlcSecretHexes[result.vaultIndex]),
                 walletClient,
+                signal,
               });
             } catch (error) {
               if (signal.aborted) throw error;

--- a/services/vault/src/services/vault/vaultActivationService.ts
+++ b/services/vault/src/services/vault/vaultActivationService.ts
@@ -32,12 +32,16 @@ export interface ActivateVaultParams {
   secret: Hex;
   /** Ethereum wallet client for signing the transaction */
   walletClient: WalletClient;
+  /** Abort signal — checked before issuing the contract write */
+  signal?: AbortSignal;
 }
 
 export async function activateVaultWithSecret(
   params: ActivateVaultParams,
 ): Promise<TransactionResult> {
-  const { vaultId, secret, walletClient } = params;
+  const { vaultId, secret, walletClient, signal } = params;
+
+  signal?.throwIfAborted();
 
   const writer: EthContractWriter<TransactionResult> = (call) =>
     executeWrite({


### PR DESCRIPTION
### Problem

**Issue [#4](https://github.com/babylonlabs-io/baby-auditor-findings/issues/4) — Deposit flow continues after user abort.** The payout-signing, WOTS submission, and activation loops in `useDepositFlow` only checked `signal.aborted` inside `catch` blocks. After a user abort between vault iterations, the next iteration would call into the wallet (`signPsbt`, `writeContract`) before discovering the signal, surfacing unexpected wallet popups. Additionally, `activateVaultWithSecret` never received the abort signal, making activation non-cancellable.

**Issue [#3](https://github.com/babylonlabs-io/baby-auditor-findings/issues/3) — Stale BTC pubkey on wallet account switch.** `preparePeginTransaction` and `signProofOfPossession` each independently call `btcWallet.getPublicKeyHex()`. If the user switches BTC wallet accounts between these two steps, WOTS keys are derived from pubkey A while the PoP and on-chain registration use pubkey B. The existing `assertPopMatchesBtcWallet` guard only checks the PoP pubkey against the *current* wallet — it never compares against the pubkey used during WOTS derivation.

### Solution

**Issue [#4](https://github.com/babylonlabs-io/baby-auditor-findings/issues/4):**
- Add `if (signal.aborted) break;` at the **start** of each loop iteration (WOTS submission, payout signing, activation) — before any wallet I/O
- Add `signal?: AbortSignal` to `ActivateVaultParams` and call `signal?.throwIfAborted()` before the contract write
- Pass `signal` from `useDepositFlow` into `activateVaultWithSecret`

**Issue [#3](https://github.com/babylonlabs-io/baby-auditor-findings/issues/3):**
- Assert `popSignature.depositorBtcPubkey === batchResult.depositorBtcPubkey` immediately after PoP signing, before ETH registration. Throws a clear error if the wallet account changed mid-flow.

Closes https://github.com/babylonlabs-io/baby-auditor-findings/issues/4
Closes https://github.com/babylonlabs-io/baby-auditor-findings/issues/3