### PR TITLE
fix(vault): normalize payout script comparison

### DIFF
--- a/services/vault/src/components/deposit/PayoutSignModal/__tests__/usePayoutSigningState.test.tsx
+++ b/services/vault/src/components/deposit/PayoutSignModal/__tests__/usePayoutSigningState.test.tsx
@@ -22,6 +22,12 @@ vi.mock("../../../../context/deposit/PeginPollingContext", () => ({
   }),
 }));
 
+vi.mock("../../../../models/peginStateMachine", () => ({
+  LocalStorageStatus: {
+    PAYOUT_SIGNED: "payout_signed",
+  },
+}));
+
 const mockFindProvider = vi.fn();
 vi.mock("../../../../hooks/deposit/useVaultProviders", () => ({
   useVaultProviders: () => ({ findProvider: mockFindProvider }),
@@ -41,6 +47,8 @@ const mockBtcAddressToScriptPubKeyHex = vi.fn();
 vi.mock("../../../../utils/btc", () => ({
   btcAddressToScriptPubKeyHex: (addr: string) =>
     mockBtcAddressToScriptPubKeyHex(addr),
+  stripHexPrefix: (hex: string) =>
+    hex.startsWith("0x") || hex.startsWith("0X") ? hex.slice(2) : hex,
 }));
 
 vi.mock("../../../../utils/errors/formatting", () => ({
@@ -179,6 +187,25 @@ describe("usePayoutSigningState", () => {
 
       expect(result.current.error?.title).toBe("Payout Address Mismatch");
       expect(mockSignAndSubmitPayouts).not.toHaveBeenCalled();
+    });
+
+    it("accepts byte-equal payout scripts when the indexer hex uses upper or mixed case", async () => {
+      mockBtcAddressToScriptPubKeyHex.mockReturnValue("0xabcdef1234");
+
+      const { result } = renderHookWithProps({
+        activity: {
+          ...ACTIVITY,
+          depositorPayoutBtcAddress: "0xABCdef1234" as Hex,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any,
+      });
+
+      await act(async () => {
+        await result.current.handleSign();
+      });
+
+      expect(result.current.error).toBeNull();
+      expect(mockSignAndSubmitPayouts).toHaveBeenCalledOnce();
     });
 
     it("rejects signing when the wallet address is unavailable instead of skipping the payout-address check", async () => {

--- a/services/vault/src/components/deposit/PayoutSignModal/usePayoutSigningState.ts
+++ b/services/vault/src/components/deposit/PayoutSignModal/usePayoutSigningState.ts
@@ -15,7 +15,10 @@ import { signAndSubmitPayouts } from "../../../hooks/deposit/depositFlowSteps/pa
 import { useVaultProviders } from "../../../hooks/deposit/useVaultProviders";
 import { LocalStorageStatus } from "../../../models/peginStateMachine";
 import type { VaultActivity } from "../../../types/activity";
-import { btcAddressToScriptPubKeyHex } from "../../../utils/btc";
+import {
+  btcAddressToScriptPubKeyHex,
+  stripHexPrefix,
+} from "../../../utils/btc";
 import { formatPayoutSignatureError } from "../../../utils/errors/formatting";
 
 import type { SigningProgressProps } from "./SigningProgress";
@@ -43,6 +46,10 @@ export interface UsePayoutSigningStateResult {
   isComplete: boolean;
   /** Handler to initiate signing */
   handleSign: () => Promise<void>;
+}
+
+function normalizeScriptPubKeyHex(scriptPubKey: string): string {
+  return stripHexPrefix(scriptPubKey).toLowerCase();
 }
 
 export function usePayoutSigningState({
@@ -139,7 +146,10 @@ export function usePayoutSigningState({
         });
         return;
       }
-      if (walletScriptPubKey !== activity.depositorPayoutBtcAddress) {
+      if (
+        normalizeScriptPubKeyHex(walletScriptPubKey) !==
+        normalizeScriptPubKeyHex(activity.depositorPayoutBtcAddress)
+      ) {
         setError({
           title: "Payout Address Mismatch",
           message:


### PR DESCRIPTION
## Summary

Normalize payout scriptPubKey hex before comparing the connected BTC wallet script against the indexer-provided `depositorPayoutBtcAddress`.

## Issue

Canonical audit issue: https://github.com/babylonlabs-io/baby-auditor-findings/issues/159

## Analysis

The finding is valid.

Evidence:
- `btcAddressToScriptPubKeyHex` uses `bitcoin.address.toOutputScript(...).toString("hex")`, which emits lowercase hex, then prefixes it with `0x`.
- `validateRequiredHex` accepts `^0x[0-9a-fA-F]+$` and returns the original string, so `depositorPayoutBtcAddress` can preserve upper- or mixed-case hex from the indexer.
- `usePayoutSigningState` previously compared `walletScriptPubKey !== activity.depositorPayoutBtcAddress` directly. Byte-equal scripts could fail the guard if the indexer returned uppercase hex.

## Options Considered

1. Normalize at ingestion in `fetchVaults`.
   - Pro: all downstream consumers see canonical lowercase hex.
   - Con: broader behavior change for all vault hex fields unless scoped carefully; not necessary to remediate the signing guard.

2. Compare decoded byte buffers.
   - Pro: strongest representation of byte equality.
   - Con: adds extra validation/throw handling in a guard that already receives hex-validated indexer data and locally generated wallet hex.

3. Normalize at the payout signing guard.
   - Pro: smallest targeted fix; preserves the security guard while avoiding case-only mismatches.
   - Con: other consumers of indexer hex still need their own normalization if they compare raw strings.

## Chosen Approach

Use callsite normalization in `usePayoutSigningState`: strip the `0x`/`0X` prefix and lowercase both scriptPubKey hex values before comparing them.

## Implementation

- Added a local `normalizeScriptPubKeyHex` helper in `usePayoutSigningState`.
- Updated the payout-address mismatch guard to compare normalized script hex values.
- Left the value passed to `signAndSubmitPayouts` unchanged, preserving existing downstream API behavior.
- Added a focused regression test proving mixed-case indexer hex does not block signing when bytes match.
- Kept the hook test isolated from SDK protocol exports by mocking only the `LocalStorageStatus` value the suite asserts.

## Tests

- Updated `usePayoutSigningState` hook tests.
- Added regression coverage for a lowercase wallet script (`0xabcdef1234`) matching a mixed-case indexer script (`0xABCdef1234`).
- Kept the existing mismatch test to ensure different bytes still fail closed.

## Verification

- `gh issue view 159 --repo babylonlabs-io/baby-auditor-findings` read successfully.
- `pnpm install --frozen-lockfile` passed.
- `pnpm --filter @babylonlabs-io/core-ui build` passed; needed to hydrate fresh-worktree package `dist` for test resolution.
- `pnpm --filter @babylonlabs-io/babylon-tbv-rust-wasm build` passed; needed for SDK build resolution.
- `pnpm --filter @babylonlabs-io/ts-sdk build` passed; needed to hydrate fresh-worktree package `dist` for test resolution.
- `pnpm --filter @babylonlabs-io/wallet-connector build` passed after `core-ui` build; needed to hydrate fresh-worktree package `dist` for test resolution.
- `pnpm --filter @services/vault test:run src/components/deposit/PayoutSignModal/__tests__/usePayoutSigningState.test.tsx` passed: 17 tests.
- `pnpm --filter @services/vault exec eslint src/components/deposit/PayoutSignModal/usePayoutSigningState.ts src/components/deposit/PayoutSignModal/__tests__/usePayoutSigningState.test.tsx` passed.
- `pnpm --filter @services/vault exec tsc --noEmit -p tsconfig.lib.json` passed.
- Claude verification result: `APPROVED`.
- Claude independently confirmed that `Buffer.toString("hex")` lowercases the wallet-side script, the indexer value has no case guarantee, callsite normalization is sufficient for the guard, downstream byte decoding is case-insensitive, and byte-different scripts still fail closed through the preserved mismatch test.

## Risk / Follow-up

Risk is low: the change only affects equality comparison for the payout-address guard and keeps byte-different scripts rejected.

Follow-up: consider canonical lowercase normalization for indexer hex fields at ingestion if other raw string comparisons are found.

## Manual Checklist

- [x] Confirmed finding against source code.
- [x] Implemented smallest safe callsite fix.
- [x] Added focused regression test.
- [x] Ran focused tests.
- [x] Ran lint on touched files.
- [x] Ran TypeScript check for vault service.
- [x] Claude verification completed by orchestrator.
- [x] Manual reviewer to inspect uncommitted changes.


Closes https://github.com/babylonlabs-io/baby-auditor-findings/issues/159
