### PR TITLE
fix(sdk): reject explicit Taproot sighash signatures

### DIFF
--- a/packages/babylon-ts-sdk/docs/api/primitives.md
+++ b/packages/babylon-ts-sdk/docs/api/primitives.md
@@ -1670,7 +1670,7 @@ function extractPayoutSignature(
    inputIndex): string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts:324](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts#L324)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts:325](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts#L325)
 
 Extract Schnorr signature from signed payout PSBT.
 
@@ -1678,8 +1678,9 @@ This function supports two cases:
 1. Non-finalized PSBT: Extracts from tapScriptSig field
 2. Finalized PSBT: Extracts from witness data
 
-The signature is returned as a 64-byte hex string (128 hex characters)
-with any sighash flag byte removed if present.
+The signature is returned as a 64-byte hex string (128 hex characters).
+Payout signatures must use implicit Taproot SIGHASH_DEFAULT, which is
+encoded by omitting the sighash byte.
 
 #### Parameters
 
@@ -1838,11 +1839,17 @@ If Pre-PegIn tx output 0 is not found
 function extractPeginInputSignature(signedPsbtHex, depositorPubkey): string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts:176](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts#L176)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts:182](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts#L182)
 
 Extract the depositor's Schnorr signature from a signed PegIn input PSBT.
 
-Supports both non-finalized PSBTs (tapScriptSig) and finalized PSBTs (witness).
+Supports non-finalized PSBTs with tapScriptSig entries. Finalized PSBTs are
+rejected because the witness stack does not reliably identify the depositor
+signature by public key.
+
+PegIn input signatures must use implicit Taproot SIGHASH_DEFAULT, which is
+encoded by omitting the sighash byte. Signatures with an appended sighash byte
+are rejected rather than stripped.
 
 #### Parameters
 
@@ -1876,7 +1883,7 @@ If no signature is found for the depositor's key
 function finalizePeginInputPsbt(signedPsbtHex): string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts:229](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts#L229)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts:235](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts#L235)
 
 Finalize a signed PegIn input PSBT and return the depositor-signed transaction hex.
 

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/payout.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/payout.test.ts
@@ -456,9 +456,7 @@ describe("extractPayoutSignature", () => {
       expect(extracted.length).toBe(128); // 64 bytes = 128 hex chars
     });
 
-    it("should extract 64-byte signature from 65-byte signature (strip sighash)", () => {
-      // Some wallets append a sighash flag byte (0x01) to Schnorr signatures
-      // We need to strip this to get the pure 64-byte signature
+    it("should reject 65-byte signature with SIGHASH_ALL", () => {
       const signature65 = Buffer.alloc(65);
       signature65.fill(0xbb, 0, 64); // Fill first 64 bytes
       signature65[64] = Transaction.SIGHASH_ALL;
@@ -481,12 +479,12 @@ describe("extractPayoutSignature", () => {
       });
 
       const psbtHex = psbt.toHex();
-      const extracted = extractPayoutSignature(psbtHex, TEST_KEYS.DEPOSITOR);
 
-      // Should strip the sighash flag and return only 64 bytes
-      const expected64 = Buffer.alloc(64, 0xbb).toString("hex");
-      expect(extracted).toBe(expected64);
-      expect(extracted.length).toBe(128); // 64 bytes = 128 hex chars
+      expect(() =>
+        extractPayoutSignature(psbtHex, TEST_KEYS.DEPOSITOR),
+      ).toThrow(
+        /Unexpected sighash byte 0x01 at input 0\. Expected implicit SIGHASH_DEFAULT as a 64-byte signature\./,
+      );
     });
 
     it("should reject 65-byte signature with SIGHASH_NONE", () => {
@@ -515,7 +513,9 @@ describe("extractPayoutSignature", () => {
 
       expect(() =>
         extractPayoutSignature(psbtHex, TEST_KEYS.DEPOSITOR),
-      ).toThrow(/Unexpected sighash type 0x02 at input 0\. Expected SIGHASH_ALL/);
+      ).toThrow(
+        /Unexpected sighash byte 0x02 at input 0\. Expected implicit SIGHASH_DEFAULT as a 64-byte signature\./,
+      );
     });
 
     it("should reject 65-byte signature with SIGHASH_SINGLE|ANYONECANPAY", () => {
@@ -544,7 +544,9 @@ describe("extractPayoutSignature", () => {
 
       expect(() =>
         extractPayoutSignature(psbtHex, TEST_KEYS.DEPOSITOR),
-      ).toThrow(/Unexpected sighash type 0x83 at input 0\. Expected SIGHASH_ALL/);
+      ).toThrow(
+        /Unexpected sighash byte 0x83 at input 0\. Expected implicit SIGHASH_DEFAULT as a 64-byte signature\./,
+      );
     });
   });
 
@@ -566,7 +568,7 @@ describe("extractPayoutSignature", () => {
       expect(extracted.length).toBe(128);
     });
 
-    it("strips SIGHASH_ALL flag from 65-byte signature in finalized witness", () => {
+    it("rejects SIGHASH_ALL flag in 65-byte signature from finalized witness", () => {
       const signature = Buffer.alloc(65);
       signature.fill(0xdd, 0, 64);
       signature[64] = Transaction.SIGHASH_ALL;
@@ -579,9 +581,11 @@ describe("extractPayoutSignature", () => {
       ]);
       const psbtHex = makeFinalizedPayoutPsbtHex(finalScriptWitness);
 
-      const extracted = extractPayoutSignature(psbtHex, TEST_KEYS.DEPOSITOR);
-
-      expect(extracted).toBe(Buffer.alloc(64, 0xdd).toString("hex"));
+      expect(() =>
+        extractPayoutSignature(psbtHex, TEST_KEYS.DEPOSITOR),
+      ).toThrow(
+        /Unexpected sighash byte 0x01 at input 0\. Expected implicit SIGHASH_DEFAULT as a 64-byte signature\./,
+      );
     });
 
     it("rejects finalized witness with fewer than 3 items", () => {

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/peginInput.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/peginInput.test.ts
@@ -2,9 +2,9 @@
  * Tests for extractPeginInputSignature sighash validation
  *
  * Verifies that the signature extraction correctly validates sighash types,
- * accepting implicit SIGHASH_DEFAULT (64-byte sig) and SIGHASH_ALL (0x01)
- * while rejecting all other types including explicit 0x00 (consensus-invalid
- * per BIP-342).
+ * accepting implicit SIGHASH_DEFAULT (64-byte sig) while rejecting signatures
+ * with appended sighash bytes. Per BIP-341, the sighash byte changes the
+ * Taproot message, so it must not be stripped.
  */
 
 import { Buffer } from "buffer";
@@ -60,21 +60,22 @@ describe("extractPeginInputSignature — sighash validation", () => {
     expect(() =>
       extractPeginInputSignature(psbtHex, TEST_KEYS.DEPOSITOR),
     ).toThrow(
-      /Unexpected sighash type 0x00 in PegIn input signature\. Expected SIGHASH_DEFAULT \(64-byte sig\) or SIGHASH_ALL \(0x01\)/,
+      /Unexpected sighash byte 0x00 in PegIn input signature\. Expected implicit SIGHASH_DEFAULT as a 64-byte signature\./,
     );
   });
 
-  it("accepts 65-byte signature with SIGHASH_ALL (0x01) and strips it", () => {
+  it("rejects 65-byte signature with SIGHASH_ALL (0x01)", () => {
     const signature65 = Buffer.alloc(65);
     signature65.fill(0xcc, 0, 64);
     signature65[64] = Transaction.SIGHASH_ALL;
 
     const psbtHex = createPsbtWithSignature(signature65);
 
-    const extracted = extractPeginInputSignature(psbtHex, TEST_KEYS.DEPOSITOR);
-
-    expect(extracted).toBe(Buffer.alloc(64, 0xcc).toString("hex"));
-    expect(extracted.length).toBe(128);
+    expect(() =>
+      extractPeginInputSignature(psbtHex, TEST_KEYS.DEPOSITOR),
+    ).toThrow(
+      /Unexpected sighash byte 0x01 in PegIn input signature\. Expected implicit SIGHASH_DEFAULT as a 64-byte signature\./,
+    );
   });
 
   it("rejects 65-byte signature with SIGHASH_NONE (0x02)", () => {
@@ -87,7 +88,7 @@ describe("extractPeginInputSignature — sighash validation", () => {
     expect(() =>
       extractPeginInputSignature(psbtHex, TEST_KEYS.DEPOSITOR),
     ).toThrow(
-      /Unexpected sighash type 0x02 in PegIn input signature\. Expected SIGHASH_DEFAULT \(64-byte sig\) or SIGHASH_ALL \(0x01\)/,
+      /Unexpected sighash byte 0x02 in PegIn input signature\. Expected implicit SIGHASH_DEFAULT as a 64-byte signature\./,
     );
   });
 
@@ -102,7 +103,7 @@ describe("extractPeginInputSignature — sighash validation", () => {
     expect(() =>
       extractPeginInputSignature(psbtHex, TEST_KEYS.DEPOSITOR),
     ).toThrow(
-      /Unexpected sighash type 0x83 in PegIn input signature\. Expected SIGHASH_DEFAULT \(64-byte sig\) or SIGHASH_ALL \(0x01\)/,
+      /Unexpected sighash byte 0x83 in PegIn input signature\. Expected implicit SIGHASH_DEFAULT as a 64-byte signature\./,
     );
   });
 

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts
@@ -310,8 +310,9 @@ export function assertPayoutOutputMatchesRegistered(
  * 1. Non-finalized PSBT: Extracts from tapScriptSig field
  * 2. Finalized PSBT: Extracts from witness data
  *
- * The signature is returned as a 64-byte hex string (128 hex characters)
- * with any sighash flag byte removed if present.
+ * The signature is returned as a 64-byte hex string (128 hex characters).
+ * Payout signatures must use implicit Taproot SIGHASH_DEFAULT, which is
+ * encoded by omitting the sighash byte.
  *
  * @param signedPsbtHex - Signed PSBT hex
  * @param depositorPubkey - Depositor's public key (x-only, 64-char hex)
@@ -375,22 +376,21 @@ export function extractPayoutSignature(
 }
 
 /**
- * Extract and validate a 64-byte Schnorr signature, stripping sighash flag if present.
- * Rejects signatures with sighash types other than SIGHASH_ALL (0x01) to prevent
- * acceptance of signatures that don't commit to all outputs (e.g. SIGHASH_NONE).
+ * Extract and validate a 64-byte Schnorr signature.
+ * Rejects 65-byte signatures because the appended sighash byte changes the
+ * Taproot message being signed; stripping it would produce an unverifiable
+ * SIGHASH_DEFAULT signature.
  * @internal
  */
 function extractSchnorrSig(sig: Uint8Array, inputIndex: number): string {
   if (sig.length === 64) {
     return uint8ArrayToHex(new Uint8Array(sig));
-  } else if (sig.length === 65) {
-    const sighashByte = sig[64];
-    if (sighashByte !== Transaction.SIGHASH_ALL) {
-      throw new Error(
-        `Unexpected sighash type 0x${sighashByte.toString(16).padStart(2, "0")} at input ${inputIndex}. Expected SIGHASH_ALL (0x01).`,
-      );
-    }
-    return uint8ArrayToHex(new Uint8Array(sig.subarray(0, 64)));
+  }
+  if (sig.length === 65) {
+    throw new Error(
+      `Unexpected sighash byte 0x${sig[64].toString(16).padStart(2, "0")} at input ${inputIndex}. ` +
+        "Expected implicit SIGHASH_DEFAULT as a 64-byte signature.",
+    );
   }
   throw new Error(
     `Unexpected signature length at input ${inputIndex}: ${sig.length}`,

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts
@@ -249,10 +249,10 @@ export function finalizePeginInputPsbt(signedPsbtHex: string): string {
 }
 
 /**
- * Extract and validate a 64-byte Schnorr signature, stripping sighash flag if present.
- * Accepts 64-byte sigs (implicit SIGHASH_DEFAULT) and 65-byte sigs with
- * SIGHASH_ALL (0x01). Rejects all other sighash types including 0x00, which
- * is consensus-invalid per BIP-342 when explicitly appended.
+ * Extract and validate a 64-byte Schnorr signature.
+ * PegIn input signatures must use implicit Taproot SIGHASH_DEFAULT, which is
+ * encoded by omitting the sighash byte. Reject 65-byte signatures instead of
+ * stripping the sighash byte because it changes the signed Taproot message.
  * @internal
  */
 export function extractSchnorrSig(sig: Uint8Array): string {
@@ -260,21 +260,10 @@ export function extractSchnorrSig(sig: Uint8Array): string {
     return uint8ArrayToHex(new Uint8Array(sig));
   }
   if (sig.length === 65) {
-    const sighashByte = sig[64];
-    // Only accept SIGHASH_ALL (0x01). Per BIP-342, SIGHASH_DEFAULT is signaled
-    // by omitting the sighash byte (64-byte sig). A 65-byte sig with byte 64
-    // set to 0x00 is consensus-invalid: Bitcoin Core rejects it with
-    // SCRIPT_ERR_SCHNORR_SIG_HASHTYPE. Accepting 0x00 here would let
-    // extractPeginInputSignature succeed (stripping the byte) while
-    // finalizePeginInputPsbt passes the raw 65-byte sig into the witness,
-    // producing a BTC transaction that can never confirm.
-    if (sighashByte !== Transaction.SIGHASH_ALL) {
-      throw new Error(
-        `Unexpected sighash type 0x${sighashByte.toString(16).padStart(2, "0")} in PegIn input signature. ` +
-          `Expected SIGHASH_DEFAULT (64-byte sig) or SIGHASH_ALL (0x01).`,
-      );
-    }
-    return uint8ArrayToHex(new Uint8Array(sig.subarray(0, 64)));
+    throw new Error(
+      `Unexpected sighash byte 0x${sig[64].toString(16).padStart(2, "0")} in PegIn input signature. ` +
+        "Expected implicit SIGHASH_DEFAULT as a 64-byte signature.",
+    );
   }
   throw new Error(`Unexpected PegIn input signature length: ${sig.length}`);
 }

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts
@@ -166,7 +166,13 @@ export async function buildPeginInputPsbt(
 /**
  * Extract the depositor's Schnorr signature from a signed PegIn input PSBT.
  *
- * Supports both non-finalized PSBTs (tapScriptSig) and finalized PSBTs (witness).
+ * Supports non-finalized PSBTs with tapScriptSig entries. Finalized PSBTs are
+ * rejected because the witness stack does not reliably identify the depositor
+ * signature by public key.
+ *
+ * PegIn input signatures must use implicit Taproot SIGHASH_DEFAULT, which is
+ * encoded by omitting the sighash byte. Signatures with an appended sighash byte
+ * are rejected rather than stripped.
  *
  * @param signedPsbtHex - Signed PSBT hex
  * @param depositorPubkey - Depositor's x-only public key (64-char hex)
@@ -267,4 +273,3 @@ export function extractSchnorrSig(sig: Uint8Array): string {
   }
   throw new Error(`Unexpected PegIn input signature length: ${sig.length}`);
 }
-


### PR DESCRIPTION
# Summary

Reject 65-byte Taproot Schnorr signatures in the payout and PegIn input PSBT signature extraction paths instead of accepting `SIGHASH_ALL` (`0x01`) and stripping the final byte.

# Issue

Canonical audit issue: https://github.com/babylonlabs-io/baby-auditor-findings/issues/161

The finding reports that `extractSchnorrSig` in both `packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts` and `packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts` accepted 65-byte signatures ending in `SIGHASH_ALL` and returned the first 64 bytes. In Taproot, a 65-byte signature with a sighash byte signs a different message than a 64-byte implicit `SIGHASH_DEFAULT` signature, so truncation can produce an unverifiable signature.

# Analysis

Confirmed. The payout PSBT builder explicitly omits `sighashType` for Taproot so wallets should produce implicit `SIGHASH_DEFAULT` signatures. The PegIn input path has the same protocol expectation.

Before this change:

- `payout.ts` accepted `sig.length === 65`, required byte `0x01`, and returned `sig.subarray(0, 64)`.
- `peginInput.ts` did the same for PegIn input signatures.
- Existing regression tests asserted that `SIGHASH_ALL` signatures were accepted and stripped.

Because BIP-341 includes the sighash type in the Taproot signature message, stripping `0x01` does not convert a `SIGHASH_ALL` signature into a valid implicit-default signature.

# Options Considered

1. Reject all 65-byte signatures.
   - Smallest change.
   - Matches the current PSBT builders, which request implicit Taproot `SIGHASH_DEFAULT`.
   - Produces an explicit SDK error instead of silently returning an unusable signature.

2. Preserve and forward the sighash byte.
   - Would require changing downstream APIs and consumers that currently expect a 64-byte signature.
   - Higher compatibility and verification risk for a protocol path that appears to require `SIGHASH_DEFAULT`.

3. Continue accepting only `SIGHASH_ALL` and stripping it.
   - Invalid because it preserves the reported silent truncation bug.

# Chosen Approach

Implemented option 1: reject any 65-byte signature with an explicit error naming the appended sighash byte and requiring implicit `SIGHASH_DEFAULT` as a 64-byte signature.

# Implementation

- Updated payout signature extraction to reject 65-byte signatures from both `tapScriptSig` and finalized witness extraction.
- Updated PegIn input signature extraction to reject 65-byte signatures.
- Updated comments to document that the protocol expects implicit Taproot `SIGHASH_DEFAULT`.
- Converted existing tests that expected `SIGHASH_ALL` stripping into tests that assert explicit rejection.
- Kept the change scoped to SDK PSBT source and focused tests.

# Tests

Updated focused tests:

- `packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/payout.test.ts`
- `packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/peginInput.test.ts`

Coverage includes:

- 64-byte implicit `SIGHASH_DEFAULT` signatures remain accepted.
- 65-byte `SIGHASH_ALL` (`0x01`) signatures are rejected.
- Other 65-byte sighash values continue to be rejected.
- Finalized payout witness extraction rejects a 65-byte `SIGHASH_ALL` signature.

# Verification

Commands run:

- `gh issue view 161 --repo babylonlabs-io/baby-auditor-findings`
- `pnpm install --frozen-lockfile`
- `pnpm --filter @babylonlabs-io/babylon-tbv-rust-wasm build`
- `pnpm vitest run src/tbv/core/primitives/psbt/__tests__/payout.test.ts src/tbv/core/primitives/psbt/__tests__/peginInput.test.ts` from `packages/babylon-ts-sdk`
- `pnpm build` from `packages/babylon-ts-sdk`
- `git diff --check`

Results:

- Focused Vitest files passed: 2 files, 28 tests.
- SDK build passed.
- Whitespace check passed.
- Claude verification result: `APPROVED`.
- Claude independently confirmed that stripping a 65-byte `SIGHASH_ALL` Taproot signature changes the signed-message interpretation, that both extraction helpers now reject 65-byte signatures instead of truncating them, and that the tests cover payout non-finalized, payout finalized-witness, and PegIn input paths.

# Risk / Follow-up

Risk is low and intentional: wallets that return 65-byte Taproot signatures will now receive an explicit error and must sign with implicit `SIGHASH_DEFAULT` for these protocol paths. If the protocol later supports non-default Taproot sighash modes, the API should preserve the sighash byte and downstream verification/broadcast paths should be updated accordingly.

# Manual Checklist

- [x] Read the full canonical audit issue.
- [x] Confirmed the finding against current code before editing.
- [x] Implemented the smallest protocol-aligned fix.
- [x] Added focused regression tests for 65-byte `SIGHASH_ALL` rejection.
- [x] Ran focused tests.
- [x] Ran SDK build.
- [x] Left changes uncommitted for manual review.
- [x] Claude verification completed by orchestrator.


Closes https://github.com/babylonlabs-io/baby-auditor-findings/issues/161
