### PR TITLE
fix(vault): preserve PSBT finalization errors

### DIFF
--- a/services/vault/src/services/vault/__tests__/vaultPeginBroadcastService.test.ts
+++ b/services/vault/src/services/vault/__tests__/vaultPeginBroadcastService.test.ts
@@ -1,36 +1,47 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Use vi.hoisted so mocks can reference these before module initialization
-const { mockFetchUTXO, mockPsbt, mockTx, mockInput } = vi.hoisted(() => {
-  const input = {
-    hash: Buffer.from(
-      "abc123def456abc123def456abc123def456abc123def456abc123def456abc1",
-      "hex",
-    ),
-    index: 0,
-    sequence: 0xffffffff,
-  };
+const { mockFetchUTXO, mockPsbt, mockSignedPsbt, mockTx, mockInput } =
+  vi.hoisted(() => {
+    const input = {
+      hash: Buffer.from(
+        "abc123def456abc123def456abc123def456abc123def456abc123def456abc1",
+        "hex",
+      ),
+      index: 0,
+      sequence: 0xffffffff,
+    };
 
-  return {
-    mockFetchUTXO: vi
-      .fn()
-      .mockResolvedValue({ scriptPubKey: "0014aabb", value: 100000 }),
-    mockPsbt: {
-      setVersion: vi.fn(),
-      setLocktime: vi.fn(),
-      addInput: vi.fn(),
-      addOutput: vi.fn(),
-      toHex: vi.fn().mockReturnValue("mock-psbt-hex"),
-    },
-    mockTx: {
-      ins: [input],
-      outs: [{ script: Buffer.from("0014deadbeef", "hex"), value: 90000 }],
-      version: 2,
-      locktime: 0,
-    },
-    mockInput: input,
-  };
-});
+    return {
+      mockFetchUTXO: vi
+        .fn()
+        .mockResolvedValue({ scriptPubKey: "0014aabb", value: 100000 }),
+      mockPsbt: {
+        setVersion: vi.fn(),
+        setLocktime: vi.fn(),
+        addInput: vi.fn(),
+        addOutput: vi.fn(),
+        toHex: vi.fn().mockReturnValue("mock-psbt-hex"),
+      },
+      mockSignedPsbt: {
+        finalizeAllInputs: vi.fn(),
+        extractTransaction: vi.fn(() => ({ toHex: vi.fn(() => "signed-hex") })),
+        data: {
+          inputs: [{ finalScriptWitness: Buffer.from("00", "hex") }] as Array<{
+            finalScriptWitness?: Buffer;
+            finalScriptSig?: Buffer;
+          }>,
+        },
+      },
+      mockTx: {
+        ins: [input],
+        outs: [{ script: Buffer.from("0014deadbeef", "hex"), value: 90000 }],
+        version: 2,
+        locktime: 0,
+      },
+      mockInput: input,
+    };
+  });
 
 vi.mock("@babylonlabs-io/ts-sdk", () => ({
   pushTx: vi.fn().mockResolvedValue("mock-txid"),
@@ -43,11 +54,7 @@ vi.mock("bitcoinjs-lib", () => {
   function PsbtCtor() {
     return mockPsbt;
   }
-  PsbtCtor.fromHex = vi.fn(() => ({
-    finalizeAllInputs: vi.fn(),
-    extractTransaction: vi.fn(() => ({ toHex: vi.fn(() => "signed-hex") })),
-    data: { inputs: [{ finalScriptWitness: Buffer.from("00", "hex") }] },
-  }));
+  PsbtCtor.fromHex = vi.fn(() => mockSignedPsbt);
   return {
     Psbt: PsbtCtor,
     Transaction: { fromHex: vi.fn(() => mockTx) },
@@ -75,6 +82,17 @@ const TXID_B =
   "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
 const TXID_UPPER =
   "AABB00112233445566778899AABB00112233445566778899AABB001122334455";
+
+beforeEach(() => {
+  mockSignedPsbt.finalizeAllInputs.mockReset();
+  mockSignedPsbt.extractTransaction.mockReset();
+  mockSignedPsbt.extractTransaction.mockReturnValue({
+    toHex: vi.fn(() => "signed-hex"),
+  });
+  mockSignedPsbt.data = {
+    inputs: [{ finalScriptWitness: Buffer.from("00", "hex") }],
+  };
+});
 
 describe("utxosToExpectedRecord", () => {
   it("converts a valid UTXO array to a keyed record", () => {
@@ -221,5 +239,43 @@ describe("broadcastPrePeginTransaction — resolveInputUtxo behavior", () => {
         expectedUtxos: undefined,
       }),
     ).rejects.toThrow(/exceeds maximum reasonable fee/);
+  });
+
+  it("succeeds when finalizeAllInputs throws but all inputs are already finalized by the wallet", async () => {
+    mockSignedPsbt.finalizeAllInputs.mockImplementationOnce(() => {
+      throw new Error("Already finalized");
+    });
+
+    await expect(
+      broadcastPrePeginTransaction({
+        ...baseParams,
+        expectedUtxos: undefined,
+      }),
+    ).resolves.toBe("mock-txid");
+
+    expect(mockSignedPsbt.extractTransaction).toHaveBeenCalled();
+  });
+
+  it("preserves PSBT finalization errors when the wallet returns a partially signed PSBT", async () => {
+    mockSignedPsbt.finalizeAllInputs.mockImplementationOnce(() => {
+      throw new Error("Input #1 is not signed");
+    });
+    mockSignedPsbt.data = {
+      inputs: [
+        { finalScriptWitness: Buffer.from("00", "hex") },
+        {} as { finalScriptWitness?: Buffer; finalScriptSig?: Buffer },
+      ],
+    };
+
+    await expect(
+      broadcastPrePeginTransaction({
+        ...baseParams,
+        expectedUtxos: undefined,
+      }),
+    ).rejects.toThrow(
+      "PSBT finalization failed and wallet did not auto-finalize: Error: Input #1 is not signed",
+    );
+
+    expect(mockSignedPsbt.extractTransaction).not.toHaveBeenCalled();
   });
 });

--- a/services/vault/src/services/vault/vaultPeginBroadcastService.ts
+++ b/services/vault/src/services/vault/vaultPeginBroadcastService.ts
@@ -251,7 +251,8 @@ async function signAndFinalizePsbt(
     );
     if (!allFinalized) {
       throw new Error(
-        `PSBT finalization failed and wallet did not auto-finalize: ${error}`,
+        "PSBT finalization failed and wallet did not auto-finalize",
+        { cause: error },
       );
     }
   }

--- a/services/vault/src/services/vault/vaultPeginBroadcastService.ts
+++ b/services/vault/src/services/vault/vaultPeginBroadcastService.ts
@@ -212,6 +212,16 @@ function addOutputsToPsbt(psbt: Psbt, tx: Transaction): void {
   }
 }
 
+function formatError(error: unknown, includeErrorName = false): string {
+  if (error instanceof Error) {
+    const message = includeErrorName ? String(error) : error.message;
+    return error.cause
+      ? `${message}: ${formatError(error.cause, true)}`
+      : message;
+  }
+  return String(error);
+}
+
 /**
  * Convert unsigned transaction to PSBT format
  */
@@ -307,7 +317,7 @@ export async function broadcastPrePeginTransaction(
     // Broadcast to network
     return await pushTx(signedTxHex, getMempoolApiUrl());
   } catch (error) {
-    const message = error instanceof Error ? error.message : "Unknown error";
+    const message = error == null ? "Unknown error" : formatError(error);
     throw new Error(`Failed to broadcast Pre-PegIn transaction: ${message}`);
   }
 }

--- a/services/vault/src/services/vault/vaultPeginBroadcastService.ts
+++ b/services/vault/src/services/vault/vaultPeginBroadcastService.ts
@@ -243,8 +243,17 @@ async function signAndFinalizePsbt(
   // Finalize inputs if not already finalized
   try {
     signedPsbt.finalizeAllInputs();
-  } catch {
-    // Some wallets finalize automatically, ignore errors
+  } catch (error) {
+    // Some wallets finalize automatically, but only skip the error when every
+    // input is already finalized.
+    const allFinalized = signedPsbt.data.inputs.every(
+      (input) => input.finalScriptWitness || input.finalScriptSig,
+    );
+    if (!allFinalized) {
+      throw new Error(
+        `PSBT finalization failed and wallet did not auto-finalize: ${error}`,
+      );
+    }
   }
 
   return signedPsbt.extractTransaction().toHex();


### PR DESCRIPTION
# Summary

Preserve PSBT finalization failures in the vault Pre-PegIn broadcast path instead of swallowing every `finalizeAllInputs()` error before `extractTransaction()`.

# Issue

Canonical audit issue: https://github.com/babylonlabs-io/baby-auditor-findings/issues/162

# Analysis

The finding is valid. `services/vault/src/services/vault/vaultPeginBroadcastService.ts` previously caught all `signedPsbt.finalizeAllInputs()` errors with a bare `catch {}` and then always proceeded to `signedPsbt.extractTransaction()`. That means an actually incomplete wallet signature could be masked by a later, less actionable extraction error.

The SDK path in `packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts` already distinguishes the expected wallet-auto-finalized case from a real finalization failure by checking every PSBT input for `finalScriptWitness || finalScriptSig` before suppressing the finalization error.

# Options Considered

1. Remove the catch entirely. This would surface malformed or partially signed PSBTs, but would regress wallets that return already-finalized PSBTs and throw on a second finalization attempt.
2. Keep swallowing all finalization errors. This preserves current behavior, but leaves the audit finding unresolved and continues to hide partial signing failures.
3. Mirror the SDK guard. This preserves compatibility with already-finalized wallet PSBTs while surfacing incomplete finalization with a descriptive message.

# Chosen Approach

Use the SDK guard pattern in the vault service: if `finalizeAllInputs()` throws, only ignore it when every input is already finalized. Otherwise, throw a descriptive error that includes the original finalization failure.

# Implementation

- Updated `signAndFinalizePsbt` in `services/vault/src/services/vault/vaultPeginBroadcastService.ts` to verify all PSBT inputs have `finalScriptWitness` or `finalScriptSig` before suppressing a finalization exception.
- Updated `services/vault/src/services/vault/__tests__/vaultPeginBroadcastService.test.ts` to reuse a controllable signed PSBT mock and cover both partially signed and wallet-auto-finalized responses.

# Tests

- Added a regression test asserting a partially signed PSBT throws `PSBT finalization failed and wallet did not auto-finalize: Error: Input #1 is not signed`.
- The test also asserts `extractTransaction()` is not called after the finalization guard rejects the PSBT.
- Added a compatibility test asserting an already-finalized wallet PSBT still broadcasts successfully when `finalizeAllInputs()` throws.

# Verification

- `gh issue view 162 --repo babylonlabs-io/baby-auditor-findings` completed and confirmed the issue details.
- `pnpm install --frozen-lockfile` completed without lockfile changes.
- `pnpm --filter @babylonlabs-io/babylon-tbv-rust-wasm build` passed.
- `pnpm --filter @babylonlabs-io/ts-sdk build` passed after building the WASM wrapper package.
- `pnpm --filter @services/vault exec prettier --write src/services/vault/vaultPeginBroadcastService.ts src/services/vault/__tests__/vaultPeginBroadcastService.test.ts` passed.
- Claude changes requested cycle 1: added compatibility coverage for wallet-auto-finalized PSBTs where `finalizeAllInputs()` throws but every input has `finalScriptWitness` or `finalScriptSig`.
- `pnpm --filter @services/vault test:run src/services/vault/__tests__/vaultPeginBroadcastService.test.ts` passed: 14 tests.
- `pnpm --filter @services/vault exec eslint src/services/vault/vaultPeginBroadcastService.ts src/services/vault/__tests__/vaultPeginBroadcastService.test.ts` passed.
- `pnpm --filter @services/vault build` failed on pre-existing workspace package/type resolution issues for `@babylonlabs-io/core-ui` and `@babylonlabs-io/wallet-connector`, plus existing unrelated TypeScript errors; no remaining errors referenced the touched vault broadcast service test after the local test typing fix.
- Claude verification result after cycle 1: `APPROVED`.
- Claude confirmed the added compatibility test exercises the wallet-auto-finalized path where `finalizeAllInputs()` throws but every input already has final script data, and that the partial-signing error test covers the rejection branch before `extractTransaction()`.

# Risk / Follow-up

Risk is low: the change only affects the error path after wallet signing. Already-finalized wallet PSBTs remain accepted when all inputs are finalized, while partially signed or malformed responses now stop before transaction extraction with a clearer error.

Follow-up: the workspace build should be re-run in an environment where `@babylonlabs-io/core-ui` and `@babylonlabs-io/wallet-connector` package outputs are available or built.

# Manual Checklist

- [x] Read the full audit issue.
- [x] Confirmed the finding against code evidence before editing.
- [x] Borrowed the existing SDK guard pattern.
- [x] Added focused regression coverage.
- [x] Ran focused tests and lint.
- [x] Left changes uncommitted.


Closes https://github.com/babylonlabs-io/baby-auditor-findings/issues/162
