### PR TITLE
fix(vault): verify cached pre-pegin transaction hash

### DIFF
--- a/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
+++ b/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
@@ -16,6 +16,11 @@ import { activateVaultWithSecret } from "@/services/vault/vaultActivationService
 
 import { useVaultActions } from "../useVaultActions";
 
+const mockSignPsbt = vi.hoisted(() => vi.fn().mockResolvedValue("signedPsbt"));
+const mockCalculateBtcTxHash = vi.hoisted(() =>
+  vi.fn(() => "0xmatching_pre_pegin_hash"),
+);
+
 vi.mock("@babylonlabs-io/config", () => ({
   getETHChain: vi.fn(() => ({ id: 11155111 })),
 }));
@@ -25,7 +30,7 @@ vi.mock("@babylonlabs-io/ts-sdk/tbv/core", () => ({
 }));
 
 vi.mock("@babylonlabs-io/ts-sdk/tbv/core/utils", () => ({
-  calculateBtcTxHash: vi.fn(() => "0xmatching_pre_pegin_hash"),
+  calculateBtcTxHash: mockCalculateBtcTxHash,
   UtxoNotAvailableError: class UtxoNotAvailableError extends Error {
     constructor(message: string) {
       super(message);
@@ -56,7 +61,7 @@ vi.mock("@babylonlabs-io/wallet-connector", () => ({
     connectedWallet: {
       provider: {
         getAddress: vi.fn().mockResolvedValue("bc1qdepositor"),
-        signPsbt: vi.fn().mockResolvedValue("signedPsbt"),
+        signPsbt: mockSignPsbt,
       },
     },
   })),
@@ -157,6 +162,12 @@ const baseBroadcastParams = {
 describe("useVaultActions — handleBroadcast transaction integrity", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockCalculateBtcTxHash.mockReturnValue("0xmatching_pre_pegin_hash");
+    mockGetVaultFromChain.mockResolvedValue({
+      prePeginTxHash: "0xmatching_pre_pegin_hash",
+      hashlock: "0xonchain_hashlock",
+      offchainParamsVersion: 7,
+    } as never);
   });
 
   it("broadcasts using local tx when it matches GraphQL", async () => {
@@ -178,6 +189,7 @@ describe("useVaultActions — handleBroadcast transaction integrity", () => {
     });
 
     expect(result.current.broadcastError).toBeNull();
+    expect(mockGetVaultFromChain).toHaveBeenCalledWith("0xvaultId");
     expect(mockBroadcastPrePeginTransaction).toHaveBeenCalledWith(
       expect.objectContaining({ unsignedTxHex: TRUSTED_TX_HEX }),
     );
@@ -205,6 +217,36 @@ describe("useVaultActions — handleBroadcast transaction integrity", () => {
     });
 
     expect(result.current.broadcastError).toContain("Transaction mismatch");
+  });
+
+  it("throws when cached local tx matches GraphQL but mismatches on-chain hash", async () => {
+    mockFetchVaultById.mockResolvedValue(baseVault as never);
+    mockGetVaultFromChain.mockResolvedValue({
+      prePeginTxHash: "0xonchain_hash",
+    } as never);
+
+    mockCalculateBtcTxHash.mockReturnValue("0xdifferent_hash");
+
+    const { result } = renderHook(() => useVaultActions());
+
+    await act(async () => {
+      await result.current.handleBroadcast({
+        ...baseBroadcastParams,
+        pendingPegin: {
+          id: "0xvaultId" as Hex,
+          timestamp: Date.now(),
+          status: "PENDING" as never,
+          peginTxHash: "0xpeginTxHash" as Hex,
+          unsignedTxHex: TRUSTED_TX_HEX,
+        },
+      });
+    });
+
+    expect(result.current.broadcastError).toContain(
+      "Transaction integrity check failed",
+    );
+    expect(mockBroadcastPrePeginTransaction).not.toHaveBeenCalled();
+    expect(mockSignPsbt).not.toHaveBeenCalled();
   });
 
   it("uses GraphQL tx when no local copy is available (cross-device)", async () => {
@@ -346,10 +388,7 @@ describe("useVaultActions — handleBroadcast transaction integrity", () => {
       offchainParamsVersion: 7,
     } as never);
 
-    const { calculateBtcTxHash } = await import(
-      "@babylonlabs-io/ts-sdk/tbv/core/utils"
-    );
-    vi.mocked(calculateBtcTxHash).mockReturnValue("0xdifferent_hash");
+    mockCalculateBtcTxHash.mockReturnValue("0xdifferent_hash");
 
     const { result } = renderHook(() => useVaultActions());
 

--- a/services/vault/src/hooks/deposit/useVaultActions.ts
+++ b/services/vault/src/hooks/deposit/useVaultActions.ts
@@ -177,7 +177,6 @@ export function useVaultActions(): UseVaultActionsReturn {
         );
       }
 
-
       // Get BTC wallet provider
       const btcWalletProvider = btcConnector?.connectedWallet?.provider;
       if (!btcWalletProvider) {

--- a/services/vault/src/hooks/deposit/useVaultActions.ts
+++ b/services/vault/src/hooks/deposit/useVaultActions.ts
@@ -129,9 +129,8 @@ export function useVaultActions(): UseVaultActionsReturn {
 
       const graphqlUnsignedTxHex = vault.unsignedPrePeginTx;
 
-      // Use the locally stored transaction as the source of truth when available.
-      // The local copy was saved before ETH submission and is trustworthy.
-      // A mismatch means the indexer is returning a different transaction - abort.
+      // Prefer the locally stored transaction when available, while keeping the
+      // indexer comparison as a sanity check for drift or substitution.
       const localUnsignedTxHex = pendingPegin?.unsignedTxHex;
       if (
         localUnsignedTxHex &&
@@ -143,7 +142,9 @@ export function useVaultActions(): UseVaultActionsReturn {
         );
       }
 
-      // Fetch on-chain vault for both the cross-device tx integrity check and
+      const unsignedTxHex = localUnsignedTxHex || graphqlUnsignedTxHex;
+
+      // Fetch on-chain vault for both the transaction integrity check and
       // the offchain-params version check. Same TOCTOU concern as the
       // same-device deposit flow: a tx whose BTC scripts were built under
       // version v(N) must not be broadcast against an on-chain vault locked
@@ -151,21 +152,17 @@ export function useVaultActions(): UseVaultActionsReturn {
       // will not match the on-chain record.
       const onChainVault = await getVaultFromChain(vaultId);
 
-      // When no local copy exists (cross-device scenario), validate the
-      // indexer-provided transaction against the on-chain prePeginTxHash.
+      // Validate the selected transaction against the on-chain prePeginTxHash.
       // The tx hash commits to all inputs AND outputs, so a substituted
       // transaction would produce a different hash.
-      if (!localUnsignedTxHex) {
-        const computedHash = calculateBtcTxHash(graphqlUnsignedTxHex);
-        if (
-          computedHash.toLowerCase() !==
-          onChainVault.prePeginTxHash.toLowerCase()
-        ) {
-          throw new Error(
-            "Transaction integrity check failed: the indexer-provided Pre-PegIn transaction " +
-              "does not match the hash stored on-chain. Aborting to prevent a potential attack.",
-          );
-        }
+      const computedHash = calculateBtcTxHash(unsignedTxHex);
+      if (
+        computedHash.toLowerCase() !== onChainVault.prePeginTxHash.toLowerCase()
+      ) {
+        throw new Error(
+          "Transaction integrity check failed: the Pre-PegIn transaction " +
+            "does not match the hash stored on-chain. Aborting to prevent a potential attack.",
+        );
       }
 
       // Verify the local environment's offchain params version matches the
@@ -180,7 +177,6 @@ export function useVaultActions(): UseVaultActionsReturn {
         );
       }
 
-      const unsignedTxHex = localUnsignedTxHex || graphqlUnsignedTxHex;
 
       // Get BTC wallet provider
       const btcWalletProvider = btcConnector?.connectedWallet?.provider;


### PR DESCRIPTION
## Summary

Fixes the cached resume broadcast path so the selected Pre-PegIn transaction is always verified against the on-chain `prePeginTxHash` before UTXO checks or wallet signing can proceed.

## Issue

Canonical audit issue: https://github.com/babylonlabs-io/baby-auditor-findings/issues/164

Issue #164 reports that `handleBroadcast` trusted a localStorage `pendingPegin.unsignedTxHex` when it matched the GraphQL `vault.unsignedPrePeginTx`, without checking that cached transaction against the on-chain vault commitment.

## Analysis

Confirmed. In `services/vault/src/hooks/deposit/useVaultActions.ts`, the previous logic compared cached `pendingPegin.unsignedTxHex` to GraphQL `unsignedPrePeginTx`, but only called `getVaultFromChain(vaultId)` and `calculateBtcTxHash(...)` under the `if (!localUnsignedTxHex)` branch. That left the cached branch dependent on two untrusted sources agreeing: localStorage and the indexer.

The trust boundary is the same general area as issue #163, but this change is intentionally scoped to the `handleBroadcast` cached unsigned transaction path for #164.

## Options Considered

1. Remove the local-vs-GraphQL comparison and only trust the on-chain hash.
2. Keep the local-vs-GraphQL comparison and also verify the selected transaction against the on-chain hash.
3. Move the check into lower-level broadcast services.

## Chosen Approach

Option 2. This is the smallest safe fix: preserve the existing drift/substitution sanity check, then select either the cached transaction or GraphQL fallback and validate that exact transaction against the authoritative on-chain `prePeginTxHash`.

## Implementation

- Changed `handleBroadcast` to compute `unsignedTxHex` before integrity validation.
- Always fetch the on-chain vault and compare `calculateBtcTxHash(unsignedTxHex)` with `onChainVault.prePeginTxHash`.
- Kept the cached local-vs-GraphQL mismatch check as an earlier abort.
- Added a focused regression test where cached localStorage hex matches the tampered GraphQL response but mismatches the on-chain hash.
- Added a signer mock assertion so the regression verifies the abort happens before wallet signing can be reached.

## Tests

Updated `services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts`:

- Existing cached local transaction success path now asserts `getVaultFromChain` is called.
- New regression: `throws when cached local tx matches GraphQL but mismatches on-chain hash`.
- Existing cross-device mismatch test remains covered by the same always-on validation.

## Verification

- `gh issue view 164 --repo babylonlabs-io/baby-auditor-findings` succeeded and confirmed the finding details.
- `pnpm install --frozen-lockfile` passed; lockfile resolution was unchanged.
- `pnpm --filter @babylonlabs-io/core-ui build` passed.
- `pnpm --filter @babylonlabs-io/babylon-tbv-rust-wasm build` passed.
- `pnpm --filter @babylonlabs-io/wallet-connector build` passed after local `core-ui` outputs were available.
- `pnpm --filter @babylonlabs-io/ts-sdk build` passed after local WASM wrapper outputs were available.
- `pnpm --dir services/vault test:run src/hooks/deposit/__tests__/useVaultActions.test.ts` passed: 12 tests.
- `pnpm --dir services/vault exec prettier --check src/hooks/deposit/useVaultActions.ts src/hooks/deposit/__tests__/useVaultActions.test.ts` passed.
- `git diff --check` passed.
- Claude verification result: `APPROVED`.
- Claude independently confirmed that the pre-fix cached path skipped the authoritative `prePeginTxHash` check, that the fix now validates the exact selected transaction on every path, and that the regression test covers the coordinated localStorage-plus-GraphQL substitution scenario before signing is reached.
- Claude noted no dangerous overlap with issue #163; the fixes are additive and complementary.

## Risk / Follow-up

Risk is low. The cached and cross-device resume paths now both perform one on-chain read before signing. This may surface on-chain read failures earlier in the cached path, but that is appropriate for a signing integrity gate.

Follow-up for issue #163 should remain separate unless the orchestrator decides to deduplicate the broader trust-boundary work.

## Manual Checklist

- [x] Full issue reviewed with `gh issue view`.
- [x] Finding treated as unproven and confirmed against code.
- [x] Fix scoped to #164 `handleBroadcast` cached unsigned transaction path.
- [x] Focused regression test added.
- [x] No commits, pushes, merges, issue comments, dependency updates, or unrelated files touched.
- [x] Local Vitest execution completed.
- [x] Claude verification completed by orchestrator.


Closes https://github.com/babylonlabs-io/baby-auditor-findings/issues/164
