### PR TITLE
fix(vault): ignore zero BTC price feed address

### DIFF
--- a/services/vault/src/config/__tests__/env.test.ts
+++ b/services/vault/src/config/__tests__/env.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { validateRequiredAddress, validateRequiredUrl } from "@/config/env";
+import {
+  parseOptionalAddress,
+  validateRequiredAddress,
+  validateRequiredUrl,
+} from "@/config/env";
 
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 const VALID_ADDRESS = "0x1234567890abcdef1234567890abcdef12345678";
@@ -62,6 +66,28 @@ describe("validateRequiredAddress", () => {
       errors,
     );
     expect(errors[0]).toContain("NEXT_PUBLIC_TBV_AAVE_CONTROLLER");
+  });
+});
+
+describe("parseOptionalAddress", () => {
+  it("accepts a valid EVM address", () => {
+    expect(parseOptionalAddress(VALID_ADDRESS)).toBe(VALID_ADDRESS);
+  });
+
+  it("returns undefined for a missing value", () => {
+    expect(parseOptionalAddress(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined for an empty string", () => {
+    expect(parseOptionalAddress("")).toBeUndefined();
+  });
+
+  it("returns undefined for a malformed address", () => {
+    expect(parseOptionalAddress("0x1234")).toBeUndefined();
+  });
+
+  it("returns undefined for the zero address", () => {
+    expect(parseOptionalAddress(ZERO_ADDRESS)).toBeUndefined();
   });
 });
 

--- a/services/vault/src/config/env.ts
+++ b/services/vault/src/config/env.ts
@@ -51,11 +51,17 @@ function parseOptionalUrl(value: string | undefined): string | undefined {
   return trimmed;
 }
 
-function parseOptionalAddress(value: string | undefined): Address | undefined {
+export function parseOptionalAddress(
+  value: string | undefined,
+): Address | undefined {
   const trimmed = value?.trim();
   if (!trimmed) return undefined;
   if (!isAddress(trimmed, { strict: false })) {
     logger.warn(`Invalid address in env config: "${trimmed}", ignoring.`);
+    return undefined;
+  }
+  if (trimmed.toLowerCase() === ZERO_ADDRESS) {
+    logger.warn(`Zero address in env config: "${trimmed}", ignoring.`);
     return undefined;
   }
   return trimmed as Address;


### PR DESCRIPTION
## Summary

Reject the EVM zero address when parsing the optional `NEXT_PUBLIC_TBV_BTC_PRICE_FEED` environment variable so a placeholder value is treated as unconfigured instead of as a usable Chainlink feed address.

## Issue

- https://github.com/babylonlabs-io/baby-auditor-findings/issues/167

Reported problem: `parseOptionalAddress` accepted any value passing `viem.isAddress(trimmed, { strict: false })`. That includes `0x0000000000000000000000000000000000000000`, while `validateRequiredAddress` already rejects the same value.

Finding status: confirmed.

## Analysis

The finding is valid.

Code evidence:
- `services/vault/src/config/env.ts` used `parseOptionalAddress` for `NEXT_PUBLIC_TBV_BTC_PRICE_FEED`.
- Before this change, `parseOptionalAddress` only rejected empty or malformed values and then returned `trimmed as Address`.
- `validateRequiredAddress` already had a zero-address guard, proving the local validation convention treats `0x0000000000000000000000000000000000000000` as invalid.
- `services/vault/src/clients/eth-contract/chainlink/query.ts` uses `ENV.BTC_PRICE_FEED` as an override when present, so accepting the zero address would route feed reads to `0x0`.

## Options Considered

1. Add a `BTC_PRICE_FEED`-specific check at the call site.
   - Rejected because the invalid value is address-level validation logic and belongs in the address parser.

2. Make optional zero addresses a fatal `envInitError`.
   - Rejected because optional parser behavior currently logs and ignores invalid optional configuration; returning `undefined` preserves that contract.

3. Mirror the required-address zero check in `parseOptionalAddress`.
   - Chosen because it is the smallest behavior change and matches the existing validation pattern.

## Chosen Approach

Export `parseOptionalAddress` for direct unit coverage and add a zero-address guard after syntactic address validation. The helper now logs a warning and returns `undefined` when the optional env value is the zero address.

## Implementation

- Updated `services/vault/src/config/env.ts`:
  - Exported `parseOptionalAddress`.
  - Added `trimmed.toLowerCase() === ZERO_ADDRESS` rejection.
  - Preserved existing optional-parser behavior: warn and ignore invalid optional values.

- Updated `services/vault/src/config/__tests__/env.test.ts`:
  - Added focused `parseOptionalAddress` tests for valid, missing, empty, malformed, and zero-address inputs.

## Tests

Added unit coverage asserting `parseOptionalAddress("0x0000000000000000000000000000000000000000")` returns `undefined`.

## Verification

- `gh issue view 167 --repo babylonlabs-io/baby-auditor-findings` - confirmed canonical issue details.
- `pnpm install --frozen-lockfile` - installed dependencies from the existing lockfile; no dependency versions were changed.
- `pnpm --filter @services/vault exec vitest run src/config/__tests__/env.test.ts` - passed, 22 tests.
- `pnpm --filter @services/vault exec prettier --check src/config/env.ts src/config/__tests__/env.test.ts` - passed.
- `pnpm --filter @services/vault exec eslint src/config/env.ts src/config/__tests__/env.test.ts` - passed.

Claude verification result: `APPROVED`.

Claude independently confirmed that `BTC_PRICE_FEED` flows through `parseOptionalAddress`, that the zero-address guard is consistent with the existing `validateRequiredAddress` behavior, and that the focused unit test directly covers the reported issue. Claude did not identify any important missing regression path.

## Risk / Follow-up

Risk is low. The change only affects optional env address parsing and makes zero-address placeholders behave like other ignored invalid optional values. Consumers that intentionally configured an optional feed as `0x0` will now see it as unconfigured, which is the desired behavior for this finding.

## Manual Checklist

- [x] Confirmed the finding against local code.
- [x] Implemented the smallest scoped fix.
- [x] Added focused unit tests.
- [x] Ran relevant verification commands.
- [x] Left changes uncommitted for manual review.
- [ ] Claude verification completed by orchestrator.


Closes https://github.com/babylonlabs-io/baby-auditor-findings/issues/167
