### PR TITLE
Avoid making unless calls

### DIFF
--- a/packages/babylon-ts-sdk/docs/api/clients.md
+++ b/packages/babylon-ts-sdk/docs/api/clients.md
@@ -507,7 +507,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-rea
 
 ### VaultProviderRpcClient
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts:74](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts#L74)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts:79](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts#L79)
 
 Concrete VP RPC client implementing all service interfaces.
 
@@ -532,7 +532,7 @@ const status = await client.getPeginStatus({ pegin_txid: "abc..." });
 new VaultProviderRpcClient(baseUrl, options?): VaultProviderRpcClient;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts:79](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts#L79)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts:84](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts#L84)
 
 ###### Parameters
 
@@ -556,7 +556,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts:
 requestDepositorPresignTransactions(params, signal?): Promise<RequestDepositorPresignTransactionsResponse>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts:96](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts#L96)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts:102](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts#L102)
 
 Request the payout/claim/assert transactions that the depositor
 needs to pre-sign before the vault can be activated on Bitcoin.
@@ -585,7 +585,7 @@ needs to pre-sign before the vault can be activated on Bitcoin.
 submitDepositorPresignatures(params, signal?): Promise<void>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts:112](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts#L112)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts:118](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts#L118)
 
 Submit the depositor's pre-signatures for the payout transactions
 and the depositor-as-claimer graph.
@@ -614,7 +614,7 @@ and the depositor-as-claimer graph.
 submitDepositorWotsKey(params, signal?): Promise<void>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts:128](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts#L128)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts:134](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts#L134)
 
 Submit the depositor's WOTS public key to the vault provider.
 Called after the pegin is finalized on Ethereum, when the VP is in
@@ -644,7 +644,7 @@ Called after the pegin is finalized on Ethereum, when the VP is in
 requestDepositorClaimerArtifacts(params, signal?): Promise<RequestDepositorClaimerArtifactsResponse>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts:143](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts#L143)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts:149](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts#L149)
 
 Request the BaBe DecryptorArtifacts needed for the depositor to
 independently evaluate garbled circuits during a challenge.
@@ -673,7 +673,7 @@ independently evaluate garbled circuits during a challenge.
 getPeginStatus(params, signal?): Promise<GetPeginStatusResponse>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts:156](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts#L156)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts:162](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts#L162)
 
 Get the current pegin status from the vault provider daemon.
 
@@ -695,21 +695,23 @@ Get the current pegin status from the vault provider daemon.
 
 [`PeginStatusReader`](services.md#peginstatusreader).[`getPeginStatus`](services.md#getpeginstatus)
 
-##### getPegoutStatus()
+##### batchGetPeginStatus()
 
 ```ts
-getPegoutStatus(params, signal?): Promise<GetPegoutStatusResponse>;
+batchGetPeginStatus(params, signal?): Promise<BatchGetPeginStatusResponse>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts:170](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts#L170)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts:180](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts#L180)
 
-Get the current pegout status from the vault provider daemon.
+Get pegin status for many txids in one round trip. Per-result envelope
+isolates per-pegin failures from the overall RPC. Caller must chunk
+inputs at `VP_BATCH_MAX_SIZE`.
 
 ###### Parameters
 
 ###### params
 
-[`GetPegoutStatusParams`](#getpegoutstatusparams)
+[`BatchGetPeginStatusParams`](#batchgetpeginstatusparams)
 
 ###### signal?
 
@@ -717,7 +719,32 @@ Get the current pegout status from the vault provider daemon.
 
 ###### Returns
 
-`Promise`\<[`GetPegoutStatusResponse`](#getpegoutstatusresponse)\>
+`Promise`\<[`BatchGetPeginStatusResponse`](#batchgetpeginstatusresponse)\>
+
+##### batchGetPegoutStatus()
+
+```ts
+batchGetPegoutStatus(params, signal?): Promise<BatchGetPegoutStatusResponse>;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts:196](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts#L196)
+
+Get pegout status for many txids in one round trip. Same per-result
+envelope semantics as `batchGetPeginStatus`.
+
+###### Parameters
+
+###### params
+
+[`BatchGetPegoutStatusParams`](#batchgetpegoutstatusparams)
+
+###### signal?
+
+`AbortSignal`
+
+###### Returns
+
+`Promise`\<[`BatchGetPegoutStatusResponse`](#batchgetpegoutstatusresponse)\>
 
 ***
 
@@ -882,7 +909,7 @@ so `authAnchorHex` doesn't outlive the deposit session.
 
 ### JsonRpcError
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts:95](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts#L95)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts:101](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts#L101)
 
 #### Extends
 
@@ -900,7 +927,7 @@ new JsonRpcError(
    data?): JsonRpcError;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts:96](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts#L96)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts:102](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts#L102)
 
 ###### Parameters
 
@@ -942,7 +969,7 @@ Error.constructor
 code: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts:97](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts#L97)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts:103](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts#L103)
 
 ##### source
 
@@ -950,7 +977,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rp
 source: JsonRpcErrorSource = "local";
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts:100](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts#L100)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts:106](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts#L106)
 
 "wire" for server-returned envelopes; "local" for SDK-side failures.
 
@@ -960,7 +987,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rp
 optional data: unknown;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts:102](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts#L102)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts:108](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts#L108)
 
 Structured data from the server `error.data` field, if any.
 
@@ -968,7 +995,7 @@ Structured data from the server `error.data` field, if any.
 
 ### JsonRpcClient
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts:174](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts#L174)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts:194](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts#L194)
 
 Generic JSON-RPC 2.0 HTTP client with safe retry policy.
 
@@ -980,7 +1007,7 @@ Generic JSON-RPC 2.0 HTTP client with safe retry policy.
 new JsonRpcClient(config): JsonRpcClient;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts:184](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts#L184)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts:205](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts#L205)
 
 ###### Parameters
 
@@ -1003,7 +1030,7 @@ call<TParams, TResult>(
 signal?): Promise<TResult>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts:221](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts#L221)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts:247](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts#L247)
 
 Make a JSON-RPC request with optional retry for safe methods.
 
@@ -1060,7 +1087,7 @@ callRaw<TParams>(
 signal?): Promise<Response>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts:314](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts#L314)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts:346](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts#L346)
 
 Make a JSON-RPC request returning the raw Response (unparsed body).
 
@@ -1101,7 +1128,7 @@ large downloads must read the body themselves and re-invoke
 getBaseUrl(): string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts:450](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts#L450)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts:482](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts#L482)
 
 ###### Returns
 
@@ -1111,7 +1138,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rp
 
 ### VpResponseValidationError
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/validators.ts:45](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/validators.ts#L45)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/validators.ts:47](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/validators.ts#L47)
 
 Thrown when a VP RPC response fails runtime validation.
 
@@ -1130,7 +1157,7 @@ Thrown when a VP RPC response fails runtime validation.
 new VpResponseValidationError(detail): VpResponseValidationError;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/validators.ts:48](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/validators.ts#L48)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/validators.ts:50](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/validators.ts#L50)
 
 ###### Parameters
 
@@ -1156,7 +1183,7 @@ Error.constructor
 readonly detail: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/validators.ts:46](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/validators.ts#L46)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/validators.ts:48](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/validators.ts#L48)
 
 ## Interfaces
 
@@ -2432,7 +2459,7 @@ Minimum network fee
 
 ### VaultProviderRpcClientOptions
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts:40](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts#L40)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts:43](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts#L43)
 
 #### Properties
 
@@ -2442,7 +2469,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts:
 optional timeout: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts:42](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts#L42)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts:45](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts#L45)
 
 Timeout in milliseconds per request (default: 60000)
 
@@ -2452,7 +2479,7 @@ Timeout in milliseconds per request (default: 60000)
 optional retries: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts:44](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts#L44)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts:47](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts#L47)
 
 Number of retry attempts for safe methods (default: 3)
 
@@ -2462,7 +2489,7 @@ Number of retry attempts for safe methods (default: 3)
 optional retryDelay: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts:46](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts#L46)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts:49](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts#L49)
 
 Initial retry delay in milliseconds (default: 1000)
 
@@ -2472,10 +2499,10 @@ Initial retry delay in milliseconds (default: 1000)
 optional retryableFor: (method) => boolean;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts:52](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts#L52)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts:55](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts#L55)
 
 Custom retry predicate. Default retries only the idempotent read
-methods: `getPeginStatus`, `getPegoutStatus`,
+methods: `getPeginStatus`, `batchGetPeginStatus`, `batchGetPegoutStatus`,
 `requestDepositorPresignTransactions`.
 
 ###### Parameters
@@ -2494,7 +2521,7 @@ methods: `getPeginStatus`, `getPegoutStatus`,
 optional headers: Record<string, string>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts:54](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts#L54)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts:57](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts#L57)
 
 Custom headers.
 
@@ -2504,11 +2531,21 @@ Custom headers.
 optional tokenProvider: BearerTokenProvider;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts:60](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts#L60)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts:63](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts#L63)
 
 Per-request bearer-token source. A non-null return attaches
 `Authorization: Bearer <token>`; `null` skips auth. Wire a
 VpTokenProvider for depositor-gated methods.
+
+##### maxResponseBytes?
+
+```ts
+optional maxResponseBytes: number;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts:65](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts#L65)
+
+Maximum response body size, in bytes, for typed JSON-RPC calls
 
 ***
 
@@ -2750,6 +2787,105 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/to
 
 ***
 
+### BatchResultEntry
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchAttribution.ts:15](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchAttribution.ts#L15)
+
+Per-item entry in a VP batch response.
+
+#### Type Parameters
+
+##### T
+
+`T`
+
+#### Properties
+
+##### pegin\_txid
+
+```ts
+pegin_txid: string;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchAttribution.ts:16](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchAttribution.ts#L16)
+
+##### result
+
+```ts
+result: T | null;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchAttribution.ts:17](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchAttribution.ts#L17)
+
+##### error
+
+```ts
+error: string | null;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchAttribution.ts:18](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchAttribution.ts#L18)
+
+***
+
+### BatchAttributionResult
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchAttribution.ts:22](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchAttribution.ts#L22)
+
+Output of [attributeBatchResults](#attributebatchresults).
+
+#### Type Parameters
+
+##### T
+
+`T`
+
+#### Properties
+
+##### byTxid
+
+```ts
+byTxid: Map<string, {
+  result: T | null;
+  error: string | null;
+}>;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchAttribution.ts:24](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchAttribution.ts#L24)
+
+Lowercase requested txid -> per-item envelope.
+
+##### missing
+
+```ts
+missing: string[];
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchAttribution.ts:26](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchAttribution.ts#L26)
+
+Requested txids that did not appear in the response.
+
+##### unexpected
+
+```ts
+unexpected: string[];
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchAttribution.ts:28](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchAttribution.ts#L28)
+
+Echoed txids that were not in the request — logged + dropped.
+
+##### duplicate
+
+```ts
+duplicate: string[];
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchAttribution.ts:30](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchAttribution.ts#L30)
+
+Echoed txids that appeared more than once — first kept, rest dropped.
+
+***
+
 ### BearerTokenProvider
 
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts:44](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts#L44)
@@ -2858,18 +2994,30 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rp
 
 Initial retry delay in milliseconds (default: 1000)
 
+##### maxResponseBytes?
+
+```ts
+optional maxResponseBytes: number;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts:73](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts#L73)
+
+Maximum response body size, in bytes, for typed JSON-RPC calls.
+`callRaw` intentionally returns the unparsed Response and is not capped here.
+Default: 2 MiB.
+
 ##### retryableFor()?
 
 ```ts
 optional retryableFor: (method) => boolean;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts:74](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts#L74)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts:80](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts#L80)
 
 Predicate that decides which methods retry on transient errors.
-Default retries only `getPeginStatus`, `getPegoutStatus`, and
-`requestDepositorPresignTransactions`. Write methods are not
-retried by default.
+Default retries only `getPeginStatus`, `batchGetPeginStatus`,
+`batchGetPegoutStatus`, and `requestDepositorPresignTransactions`.
+Write methods are not retried by default.
 
 ###### Parameters
 
@@ -2887,7 +3035,7 @@ retried by default.
 optional tokenProvider: BearerTokenProvider;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts:81](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts#L81)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts:87](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts#L87)
 
 Per-request bearer-token source. A non-null return attaches
 `Authorization: Bearer <token>`; `null` skips auth. `call`
@@ -3716,29 +3864,12 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 
 ***
 
-### GetPegoutStatusParams
-
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:290](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L290)
-
-Params for querying pegout status from the VP daemon.
-
-#### Properties
-
-##### pegin\_txid
-
-```ts
-pegin_txid: string;
-```
-
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:291](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L291)
-
-***
-
 ### ClaimerPegoutStatus
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:295](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L295)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:293](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L293)
 
 Claimer-side pegout progress.
+Source: btc-vault crates/vaultd/src/rpc/server/pegout_status.rs ClaimerPegoutStatus.
 
 #### Properties
 
@@ -3748,7 +3879,7 @@ Claimer-side pegout progress.
 status: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:296](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L296)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:294](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L294)
 
 ##### failed
 
@@ -3756,55 +3887,68 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 failed: boolean;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:297](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L297)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:295](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L295)
 
-##### claim\_txid?
+##### claim\_txid
 
 ```ts
-optional claim_txid: string;
+claim_txid: string;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:296](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L296)
+
+##### claimer\_pubkey
+
+```ts
+claimer_pubkey: string;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:297](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L297)
+
+##### assert\_txid
+
+```ts
+assert_txid: string;
 ```
 
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:298](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L298)
 
-##### claimer\_pubkey?
+##### challenger\_pubkey
 
 ```ts
-optional claimer_pubkey: string;
+challenger_pubkey: string | null;
 ```
 
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:299](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L299)
 
-##### challenger\_pubkey?
+##### created\_at
 
 ```ts
-optional challenger_pubkey: string;
-```
-
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:300](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L300)
-
-##### created\_at?
-
-```ts
-optional created_at: string;
+created_at: number;
 ```
 
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:301](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L301)
 
-##### updated\_at?
+Unix epoch seconds.
+
+##### updated\_at
 
 ```ts
-optional updated_at: string;
+updated_at: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:302](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L302)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:303](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L303)
+
+Unix epoch seconds.
 
 ***
 
-### ChallengerPegoutStatus
+### ChallengerStatus
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:306](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L306)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:310](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L310)
 
 Challenger-side pegout progress.
+Source: btc-vault crates/vaultd/src/rpc/server/pegout_status.rs ChallengerStatus.
 
 #### Properties
 
@@ -3814,71 +3958,80 @@ Challenger-side pegout progress.
 status: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:307](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L307)
-
-##### claim\_txid?
-
-```ts
-optional claim_txid: string;
-```
-
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:308](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L308)
-
-##### claimer\_pubkey?
-
-```ts
-optional claimer_pubkey: string;
-```
-
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:309](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L309)
-
-##### assert\_txid?
-
-```ts
-optional assert_txid: string;
-```
-
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:310](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L310)
-
-##### challenge\_assert\_txid?
-
-```ts
-optional challenge_assert_txid: string;
-```
-
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:311](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L311)
 
-##### nopayout\_txid?
+##### claim\_txid
 
 ```ts
-optional nopayout_txid: string;
+claim_txid: string;
 ```
 
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:312](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L312)
 
-##### created\_at?
+##### claimer\_pubkey
 
 ```ts
-optional created_at: string;
+claimer_pubkey: string;
 ```
 
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:313](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L313)
 
-##### updated\_at?
+##### assert\_txid
 
 ```ts
-optional updated_at: string;
+assert_txid: string | null;
 ```
 
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:314](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L314)
+
+##### challenge\_assert\_x\_txid
+
+```ts
+challenge_assert_x_txid: string | null;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:315](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L315)
+
+##### challenge\_assert\_y\_txid
+
+```ts
+challenge_assert_y_txid: string | null;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:316](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L316)
+
+##### nopayout\_txid
+
+```ts
+nopayout_txid: string | null;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:317](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L317)
+
+##### created\_at
+
+```ts
+created_at: number;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:318](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L318)
+
+##### updated\_at
+
+```ts
+updated_at: number;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:319](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L319)
 
 ***
 
 ### GetPegoutStatusResponse
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:318](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L318)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:326](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L326)
 
-Response from `getPegoutStatus`.
+Pegout status response. Embedded by `batchGetPegoutStatus` per-result
+envelopes. Mirrors btc-vault `GetPegoutStatusResponse`.
 
 #### Properties
 
@@ -3888,7 +4041,7 @@ Response from `getPegoutStatus`.
 pegin_txid: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:319](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L319)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:327](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L327)
 
 ##### found
 
@@ -3896,23 +4049,165 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 found: boolean;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:320](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L320)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:328](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L328)
 
-##### claimer?
-
-```ts
-optional claimer: ClaimerPegoutStatus;
-```
-
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:321](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L321)
-
-##### challenger?
+##### claimer
 
 ```ts
-optional challenger: ChallengerPegoutStatus;
+claimer: ClaimerPegoutStatus | null;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:322](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L322)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:329](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L329)
+
+##### challengers
+
+```ts
+challengers: ChallengerStatus[];
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:330](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L330)
+
+***
+
+### BatchGetPeginStatusParams
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:338](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L338)
+
+Params for `batchGetPeginStatus`.
+
+#### Properties
+
+##### pegin\_txids
+
+```ts
+pegin_txids: string[];
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:340](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L340)
+
+Up to MAX_BATCH_SIZE (50) txids per call.
+
+***
+
+### BatchPeginStatusResult
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:344](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L344)
+
+Per-pegin entry in a `batchGetPeginStatus` response.
+
+#### Properties
+
+##### pegin\_txid
+
+```ts
+pegin_txid: string;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:345](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L345)
+
+##### result
+
+```ts
+result: GetPeginStatusResponse | null;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:346](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L346)
+
+##### error
+
+```ts
+error: string | null;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:347](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L347)
+
+***
+
+### BatchGetPeginStatusResponse
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:351](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L351)
+
+Response from `batchGetPeginStatus`. Results are returned in request order.
+
+#### Properties
+
+##### results
+
+```ts
+results: BatchPeginStatusResult[];
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:352](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L352)
+
+***
+
+### BatchGetPegoutStatusParams
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:356](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L356)
+
+Params for `batchGetPegoutStatus`.
+
+#### Properties
+
+##### pegin\_txids
+
+```ts
+pegin_txids: string[];
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:357](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L357)
+
+***
+
+### BatchPegoutStatusResult
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:361](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L361)
+
+Per-vault entry in a `batchGetPegoutStatus` response.
+
+#### Properties
+
+##### pegin\_txid
+
+```ts
+pegin_txid: string;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:362](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L362)
+
+##### result
+
+```ts
+result: GetPegoutStatusResponse | null;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:363](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L363)
+
+##### error
+
+```ts
+error: string | null;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:364](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L364)
+
+***
+
+### BatchGetPegoutStatusResponse
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:368](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L368)
+
+Response from `batchGetPegoutStatus`. Results are returned in request order.
+
+#### Properties
+
+##### results
+
+```ts
+results: BatchPegoutStatusResult[];
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:369](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L369)
 
 ## Type Aliases
 
@@ -3948,7 +4243,7 @@ frozen
 type JsonRpcErrorSource = "wire" | "local";
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts:93](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts#L93)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts:99](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts#L99)
 
 Identifies whether an error was produced locally (timeout, network
 failure, malformed response) or parsed from a wire-format JSON-RPC
@@ -4387,13 +4682,53 @@ ServerIdentityError on any validation failure.
 
 ***
 
+### attributeBatchResults()
+
+```ts
+function attributeBatchResults<T>(requestedTxids, results): BatchAttributionResult<T>;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchAttribution.ts:44](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchAttribution.ts#L44)
+
+Attribute batch results to requested txids defensively.
+
+Both `requestedTxids` and the echoed `pegin_txid` field on each result
+are lowercased before lookup. Duplicates and unexpected echoes are
+surfaced so callers can flag the affected items as errored rather than
+silently overwriting state.
+
+`requestedTxids` may contain duplicates; they are de-duplicated for the
+purposes of map keys (each unique txid becomes a single map entry).
+
+#### Type Parameters
+
+##### T
+
+`T`
+
+#### Parameters
+
+##### requestedTxids
+
+`string`[]
+
+##### results
+
+readonly [`BatchResultEntry`](#batchresultentry)\<`T`\>[]
+
+#### Returns
+
+[`BatchAttributionResult`](#batchattributionresult)\<`T`\>
+
+***
+
 ### validateRequestDepositorClaimerArtifactsResponse()
 
 ```ts
 function validateRequestDepositorClaimerArtifactsResponse(response): asserts response is RequestDepositorClaimerArtifactsResponse;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/validators.ts:328](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/validators.ts#L328)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/validators.ts:330](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/validators.ts#L330)
 
 Validate a requestDepositorClaimerArtifacts response.
 
@@ -4536,7 +4871,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 
 ### RpcErrorCode
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:330](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L330)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:384](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L384)
 
 JSON-RPC error codes returned by the vault provider.
 
@@ -4548,7 +4883,7 @@ JSON-RPC error codes returned by the vault provider.
 DATABASE_ERROR: -32005;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:331](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L331)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:385](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L385)
 
 ##### PRESIGN\_ERROR
 
@@ -4556,7 +4891,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 PRESIGN_ERROR: -32006;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:332](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L332)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:386](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L386)
 
 ##### JSON\_SERIALIZATION\_ERROR
 
@@ -4564,7 +4899,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 JSON_SERIALIZATION_ERROR: -32007;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:333](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L333)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:387](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L387)
 
 ##### TX\_GRAPH\_ERROR
 
@@ -4572,7 +4907,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 TX_GRAPH_ERROR: -32008;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:334](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L334)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:388](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L388)
 
 ##### INVALID\_GRAPH
 
@@ -4580,7 +4915,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 INVALID_GRAPH: -32009;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:335](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L335)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:389](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L389)
 
 ##### VALIDATION\_ERROR
 
@@ -4588,7 +4923,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 VALIDATION_ERROR: -32010;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:336](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L336)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:390](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L390)
 
 ##### NOT\_FOUND
 
@@ -4596,7 +4931,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 NOT_FOUND: -32011;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:337](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L337)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:391](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L391)
 
 ##### INTERNAL\_ERROR
 
@@ -4604,7 +4939,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 INTERNAL_ERROR: -32603;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:338](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L338)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:392](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L392)
 
 ## Variables
 
@@ -4656,7 +4991,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/to
 const JSON_RPC_ERROR_CODES: object;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts:109](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts#L109)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts:115](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts#L115)
 
 #### Type Declaration
 
@@ -4695,6 +5030,14 @@ readonly INVALID_RESPONSE: -32700 = -32700;
 ```
 
 SDK client: response missing "result" field (malformed JSON-RPC)
+
+##### RESPONSE\_TOO\_LARGE
+
+```ts
+readonly RESPONSE_TOO_LARGE: -32701 = -32701;
+```
+
+SDK client: response body exceeded the configured byte limit
 
 ***
 
@@ -4749,3 +5092,17 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 Statuses that come after WOTS key submission.
 If the VP is already in one of these states, the WOTS key was already
 submitted and we can skip.
+
+***
+
+### VP\_BATCH\_MAX\_SIZE
+
+```ts
+const VP_BATCH_MAX_SIZE: 50 = 50;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:377](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L377)
+
+Maximum number of items per batch call. Mirrors the server-side
+`MAX_BATCH_SIZE` in btc-vault (`crates/vaultd/src/rpc/server/vault_provider.rs:7`).
+Callers must chunk requests larger than this.

--- a/packages/babylon-ts-sdk/docs/api/managers.md
+++ b/packages/babylon-ts-sdk/docs/api/managers.md
@@ -23,7 +23,7 @@ Optional exit after the CSV timelock expires: `buildAndBroadcastRefund()` (servi
 
 ### PayoutManager
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:146](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L146)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:150](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L150)
 
 High-level manager for payout transaction signing.
 
@@ -56,7 +56,7 @@ manager and submit the signatures to the vault provider's RPC API.
 new PayoutManager(config): PayoutManager;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:154](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L154)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:158](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L158)
 
 Creates a new PayoutManager instance.
 
@@ -80,7 +80,7 @@ Manager configuration including wallet
 signPayoutTransaction(params): Promise<PayoutSignatureResult>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:180](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L180)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:184](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L184)
 
 Signs a Payout transaction and extracts the Schnorr signature.
 
@@ -126,7 +126,7 @@ Error if wallet operations fail or signature extraction fails
 getNetwork(): Network;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:229](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L229)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:233](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L233)
 
 Gets the configured Bitcoin network.
 
@@ -142,7 +142,7 @@ The Bitcoin network (mainnet, testnet, signet, regtest)
 supportsBatchSigning(): boolean;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:238](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L238)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:242](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L242)
 
 Checks if the wallet supports batch signing (signPsbts).
 
@@ -158,7 +158,7 @@ true if batch signing is supported
 signPayoutTransactionsBatch(transactions): Promise<object[]>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:251](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L251)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:255](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L255)
 
 Batch signs multiple payout transactions (1 per claimer).
 This allows signing all transactions with a single wallet interaction.
@@ -189,7 +189,7 @@ Error if any signing operation fails
 
 ### PeginManager
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:530](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L530)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:537](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L537)
 
 #### Constructors
 
@@ -199,7 +199,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:530](
 new PeginManager(config): PeginManager;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:538](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L538)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:545](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L545)
 
 Creates a new PeginManager instance.
 
@@ -223,7 +223,7 @@ Manager configuration including wallets and contract addresses
 preparePegin(params): Promise<PreparePeginResult>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:551](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L551)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:558](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L558)
 
 Prepare a peg-in: sizing pass → vault-root derivation (one wallet
 popup) → per-vault WOTS / hashlock derivation → commit pass with
@@ -251,7 +251,7 @@ If the wallet rejects, insufficient funds, or an internal
 signAndBroadcast(params): Promise<string>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:877](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L877)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:884](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L884)
 
 Signs and broadcasts a funded peg-in transaction to the Bitcoin network.
 
@@ -287,7 +287,7 @@ Error if signing or broadcasting fails
 registerPeginOnChain(params): Promise<RegisterPeginResult>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1020](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L1020)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1027](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L1027)
 
 Registers a peg-in on Ethereum by calling the BTCVaultRegistry contract.
 
@@ -338,7 +338,7 @@ Error if contract simulation fails (e.g., invalid signature,
 registerPeginBatchOnChain(params): Promise<RegisterPeginBatchResult>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1181](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L1181)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1186](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L1186)
 
 Register multiple pegins on Ethereum in a single transaction.
 
@@ -366,7 +366,7 @@ Batch result with per-vault IDs and single ETH tx hash
 signProofOfPossession(): Promise<PopSignature>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1410](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L1410)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1411](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L1411)
 
 Sign a BIP-322 BTC Proof-of-Possession binding the connected BTC
 wallet to the connected ETH account for this chain and vault
@@ -383,7 +383,7 @@ every register call in the same session.
 getNetwork(): Network;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1458](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L1458)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1459](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L1459)
 
 Gets the configured Bitcoin network.
 
@@ -399,7 +399,7 @@ The Bitcoin network (mainnet, testnet, signet, regtest)
 getVaultContractAddress(): `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1467](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L1467)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1468](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L1468)
 
 Gets the configured BTCVaultRegistry contract address.
 
@@ -786,7 +786,7 @@ Bitcoin wallet for signing payout transactions.
 
 ### SignPayoutParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:96](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L96)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:100](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L100)
 
 Parameters for signing a Payout transaction.
 
@@ -880,17 +880,21 @@ CSV timelock in blocks for the PegIn output.
 SignPayoutBaseParams.timelockPegin
 ```
 
-##### depositorBtcPubkey?
+##### depositorBtcPubkey
 
 ```ts
-optional depositorBtcPubkey: string;
+depositorBtcPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:80](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L80)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:84](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L84)
 
-Depositor's BTC public key (x-only, 64-char hex).
-This should be the public key that was used when creating the vault,
-as stored on-chain. If not provided, will be fetched from the wallet.
+Depositor's BTC public key (x-only, 64-char hex). This MUST be the
+key registered on-chain for the vault — typically read from
+`BTCVaultRegistry.getBtcVaultBasicInfo(...).depositorBtcPubKey`.
+
+Required: omitting it would degrade `validateWalletPubkey` to a
+self-comparison, allowing the wrong wallet to produce a signature
+over a script tree that doesn't match the on-chain UTXO.
 
 ###### Inherited from
 
@@ -904,7 +908,7 @@ SignPayoutBaseParams.depositorBtcPubkey
 registeredPayoutScriptPubKey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:87](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L87)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:91](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L91)
 
 The on-chain registered depositor payout scriptPubKey (hex, with or without 0x prefix).
 Used to validate that the VP-provided payout transaction actually pays to the
@@ -922,7 +926,7 @@ SignPayoutBaseParams.registeredPayoutScriptPubKey
 payoutTxHex: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:101](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L101)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:105](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L105)
 
 Payout transaction hex (unsigned).
 This is the transaction from the vault provider that needs depositor signature.
@@ -933,7 +937,7 @@ This is the transaction from the vault provider that needs depositor signature.
 assertTxHex: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:107](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L107)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:111](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L111)
 
 Assert transaction hex.
 Payout input 1 references Assert output 0.
@@ -942,7 +946,7 @@ Payout input 1 references Assert output 0.
 
 ### PayoutSignatureResult
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:113](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L113)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:117](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L117)
 
 Result of signing a payout transaction.
 
@@ -954,7 +958,7 @@ Result of signing a payout transaction.
 signature: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:117](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L117)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:121](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L121)
 
 64-byte Schnorr signature (128 hex characters).
 
@@ -964,7 +968,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:117]
 depositorBtcPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:122](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L122)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:126](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L126)
 
 Depositor's BTC public key used for signing.
 
@@ -972,7 +976,7 @@ Depositor's BTC public key used for signing.
 
 ### PeginManagerConfig
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:100](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L100)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:99](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L99)
 
 Configuration for the PeginManager.
 
@@ -984,7 +988,7 @@ Configuration for the PeginManager.
 btcNetwork: Network;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:104](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L104)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:103](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L103)
 
 Bitcoin network to use for transactions.
 
@@ -994,7 +998,7 @@ Bitcoin network to use for transactions.
 btcWallet: BitcoinWallet;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:109](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L109)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:108](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L108)
 
 Bitcoin wallet for signing peg-in transactions.
 
@@ -1004,7 +1008,7 @@ Bitcoin wallet for signing peg-in transactions.
 ethWallet: object;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:115](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L115)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:114](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L114)
 
 Ethereum wallet for registering peg-in on-chain.
 Uses viem's WalletClient directly for proper gas estimation.
@@ -1015,7 +1019,7 @@ Uses viem's WalletClient directly for proper gas estimation.
 ethChain: Chain;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:121](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L121)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:120](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L120)
 
 Ethereum chain configuration.
 Required for proper gas estimation in contract calls.
@@ -1023,8 +1027,10 @@ Required for proper gas estimation in contract calls.
 ##### publicClient
 
 ```ts
-publicClient: PublicClient;
+publicClient: object;
 ```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:128](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L128)
 
 Public client used for read calls (`readContract`, `estimateGas`,
 `waitForTransactionReceipt`). Pass a client configured with the
@@ -1037,7 +1043,7 @@ application instead of viem's stock chain default.
 vaultContracts: object;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:126](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L126)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:133](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L133)
 
 Vault contract addresses.
 
@@ -1055,7 +1061,7 @@ BTCVaultRegistry contract address on Ethereum.
 mempoolApiUrl: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:138](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L138)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:145](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L145)
 
 Mempool API URL for fetching UTXO data and broadcasting transactions.
 Use MEMPOOL_API_URLS constant for standard mempool.space URLs, or provide
@@ -1065,7 +1071,7 @@ a custom URL if running your own mempool instance.
 
 ### PreparePeginParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:144](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L144)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:151](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L151)
 
 Parameters for the pegin flow (pre-pegin + pegin transactions).
 
@@ -1077,7 +1083,7 @@ Parameters for the pegin flow (pre-pegin + pegin transactions).
 amounts: readonly bigint[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:150](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L150)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:157](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L157)
 
 Amounts to peg in per HTLC (in satoshis).
 Must have the same length as `hashlocks`.
@@ -1089,7 +1095,7 @@ For single deposits, pass a single-element array.
 vaultProviderBtcPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:156](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L156)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:163](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L163)
 
 Vault provider's BTC public key (x-only, 64-char hex).
 Can be provided with or without "0x" prefix (will be stripped automatically).
@@ -1100,7 +1106,7 @@ Can be provided with or without "0x" prefix (will be stripped automatically).
 vaultKeeperBtcPubkeys: readonly string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:162](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L162)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:169](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L169)
 
 Vault keeper BTC public keys (x-only, 64-char hex).
 Can be provided with or without "0x" prefix (will be stripped automatically).
@@ -1111,7 +1117,7 @@ Can be provided with or without "0x" prefix (will be stripped automatically).
 universalChallengerBtcPubkeys: readonly string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:168](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L168)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:175](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L175)
 
 Universal challenger BTC public keys (x-only, 64-char hex).
 Can be provided with or without "0x" prefix (will be stripped automatically).
@@ -1122,7 +1128,7 @@ Can be provided with or without "0x" prefix (will be stripped automatically).
 timelockPegin: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:173](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L173)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:180](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L180)
 
 CSV timelock in blocks for the PegIn vault output.
 
@@ -1132,7 +1138,7 @@ CSV timelock in blocks for the PegIn vault output.
 timelockRefund: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:178](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L178)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:185](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L185)
 
 CSV timelock in blocks for the Pre-PegIn HTLC refund path.
 
@@ -1142,7 +1148,7 @@ CSV timelock in blocks for the Pre-PegIn HTLC refund path.
 protocolFeeRate: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:184](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L184)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:191](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L191)
 
 Protocol fee rate in sat/vB from the contract offchain params.
 Used by WASM for computing depositorClaimValue and min pegin fee.
@@ -1153,7 +1159,7 @@ Used by WASM for computing depositorClaimValue and min pegin fee.
 mempoolFeeRate: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:190](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L190)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:197](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L197)
 
 Mempool fee rate in sat/vB for funding the Pre-PegIn transaction.
 Used for UTXO selection and change calculation.
@@ -1164,7 +1170,7 @@ Used for UTXO selection and change calculation.
 councilQuorum: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:195](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L195)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:202](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L202)
 
 M in M-of-N council multisig (from contract params).
 
@@ -1174,7 +1180,7 @@ M in M-of-N council multisig (from contract params).
 councilSize: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:200](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L200)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:207](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L207)
 
 N in M-of-N council multisig (from contract params).
 
@@ -1184,7 +1190,7 @@ N in M-of-N council multisig (from contract params).
 availableUTXOs: readonly UTXO[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:205](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L205)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:212](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L212)
 
 Available UTXOs from the depositor's wallet for funding the Pre-PegIn transaction.
 
@@ -1194,7 +1200,7 @@ Available UTXOs from the depositor's wallet for funding the Pre-PegIn transactio
 changeAddress: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:210](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L210)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:217](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L217)
 
 Bitcoin address for receiving change from the Pre-PegIn transaction.
 
@@ -1202,7 +1208,7 @@ Bitcoin address for receiving change from the Pre-PegIn transaction.
 
 ### PerVaultPeginData
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:217](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L217)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:224](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L224)
 
 Per-vault PegIn data derived from a shared Pre-PegIn transaction
 
@@ -1214,7 +1220,7 @@ Per-vault PegIn data derived from a shared Pre-PegIn transaction
 htlcVout: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:219](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L219)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:226](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L226)
 
 Index of the HTLC output in the Pre-PegIn transaction (0, 1, 2, ...)
 
@@ -1224,7 +1230,7 @@ Index of the HTLC output in the Pre-PegIn transaction (0, 1, 2, ...)
 htlcValue: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:221](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L221)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:228](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L228)
 
 HTLC output value in satoshis
 
@@ -1234,7 +1240,7 @@ HTLC output value in satoshis
 peginTxHex: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:223](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L223)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:230](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L230)
 
 Depositor-signed PegIn transaction hex (for contract registration)
 
@@ -1244,7 +1250,7 @@ Depositor-signed PegIn transaction hex (for contract registration)
 peginTxid: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:225](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L225)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:232](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L232)
 
 PegIn transaction ID
 
@@ -1254,7 +1260,7 @@ PegIn transaction ID
 peginInputSignature: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:227](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L227)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:234](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L234)
 
 Depositor's Schnorr signature over PegIn input (HTLC leaf 0)
 
@@ -1264,7 +1270,7 @@ Depositor's Schnorr signature over PegIn input (HTLC leaf 0)
 vaultScriptPubKey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:229](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L229)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:236](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L236)
 
 Vault output scriptPubKey hex
 
@@ -1272,7 +1278,7 @@ Vault output scriptPubKey hex
 
 ### PreparePeginTransaction
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:236](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L236)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:243](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L243)
 
 Broadcast-ready transaction output of [PeginManager.preparePegin](#preparepegin).
 Safe to log / persist — contains no sensitive material.
@@ -1285,7 +1291,7 @@ Safe to log / persist — contains no sensitive material.
 fundedPrePeginTxHex: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:242](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L242)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:249](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L249)
 
 Funded, pre-witness Pre-PegIn tx hex. Pass this for register calls'
 `unsignedPrePeginTx` — despite the contract-side name, the registry
@@ -1297,7 +1303,7 @@ stores the funded form so indexers can rebuild refund PSBTs.
 prePeginTxid: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:244](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L244)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:251](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L251)
 
 Funded Pre-PegIn transaction ID
 
@@ -1307,7 +1313,7 @@ Funded Pre-PegIn transaction ID
 perVault: PerVaultPeginData[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:246](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L246)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:253](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L253)
 
 Per-vault PegIn data — one entry per amount
 
@@ -1317,7 +1323,7 @@ Per-vault PegIn data — one entry per amount
 selectedUTXOs: UTXO[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:248](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L248)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:255](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L255)
 
 UTXOs selected to fund the Pre-PegIn transaction
 
@@ -1327,7 +1333,7 @@ UTXOs selected to fund the Pre-PegIn transaction
 fee: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:250](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L250)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:257](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L257)
 
 Transaction fee in satoshis
 
@@ -1337,7 +1343,7 @@ Transaction fee in satoshis
 changeAmount: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:252](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L252)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:259](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L259)
 
 Change amount in satoshis (if any)
 
@@ -1345,7 +1351,7 @@ Change amount in satoshis (if any)
 
 ### PreparePeginDerivedSecrets
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:260](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L260)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:267](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L267)
 
 Sensitive material derived from the wallet root. Do not log; do not
 persist beyond the activation flow. Strings are immutable in JS, so
@@ -1359,7 +1365,7 @@ lifetime is GC-only — secrets stay live until the result is dropped.
 perVaultWotsKeys: WotsBlockPublicKey[][];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:262](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L262)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:269](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L269)
 
 Per-vault WOTS block public keys (one array per vault).
 
@@ -1369,7 +1375,7 @@ Per-vault WOTS block public keys (one array per vault).
 wotsPkHashes: `0x${string}`[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:264](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L264)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:271](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L271)
 
 Per-vault keccak256 of WOTS keys, ready as `depositorWotsPkHash`.
 
@@ -1379,7 +1385,7 @@ Per-vault keccak256 of WOTS keys, ready as `depositorWotsPkHash`.
 htlcSecretHexes: string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:269](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L269)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:276](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L276)
 
 Per-vault HTLC preimage hex (no 0x prefix). Re-derivable any time
 via `expandHashlockSecret(root, htlcVout)`; not persisted.
@@ -1390,7 +1396,7 @@ via `expandHashlockSecret(root, htlcVout)`; not persisted.
 authAnchorHex: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:280](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L280)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:287](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L287)
 
 Raw 32-byte auth-anchor preimage as 64-char lowercase hex (no `0x`).
 Sent to the VP via `auth_createDepositorToken` to obtain a bearer
@@ -1405,7 +1411,7 @@ not weaken the other derived secrets.
 
 ### PreparePeginResult
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:283](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L283)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:290](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L290)
 
 #### Properties
 
@@ -1415,7 +1421,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:283](
 transaction: PreparePeginTransaction;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:285](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L285)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:292](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L292)
 
 Broadcast-ready Pre-PegIn + per-vault PegIn txs. Safe to log.
 
@@ -1425,7 +1431,7 @@ Broadcast-ready Pre-PegIn + per-vault PegIn txs. Safe to log.
 depositorBtcPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:292](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L292)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:299](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L299)
 
 x-only depositor pubkey snapshot used end-to-end across sizing,
 vault-root derivation, and PSBT signing. Safe to persist; not
@@ -1438,7 +1444,7 @@ derived secrets and signed PSBTs reference the same identity.
 derivedSecrets: PreparePeginDerivedSecrets;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:294](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L294)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:301](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L301)
 
 Sensitive derived material — see [PreparePeginDerivedSecrets](#preparepeginderivedsecrets).
 
@@ -1446,7 +1452,7 @@ Sensitive derived material — see [PreparePeginDerivedSecrets](#preparepeginder
 
 ### SignAndBroadcastParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:301](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L301)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:308](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L308)
 
 Parameters for signing and broadcasting a transaction.
 
@@ -1458,7 +1464,7 @@ Parameters for signing and broadcasting a transaction.
 fundedPrePeginTxHex: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:305](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L305)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:312](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L312)
 
 Funded Pre-PegIn transaction hex from preparePegin().
 
@@ -1468,7 +1474,7 @@ Funded Pre-PegIn transaction hex from preparePegin().
 depositorBtcPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:312](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L312)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:319](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L319)
 
 Depositor's BTC public key (x-only, 64-char hex).
 Can be provided with or without "0x" prefix.
@@ -1483,7 +1489,7 @@ optional localPrevouts: Record<string, {
 }>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:320](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L320)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:327](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L327)
 
 Optional pre-fetched prevout data for inputs not yet in the mempool.
 Key format: "txid:vout" (e.g. "abc123...def:0").
@@ -1494,7 +1500,7 @@ Useful for split transactions where outputs are unconfirmed.
 
 ### PopSignature
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:329](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L329)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:336](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L336)
 
 BIP-322 BTC Proof-of-Possession binding a depositor's BTC key to their
 Ethereum account. Produced by [PeginManager.signProofOfPossession](#signproofofpossession)
@@ -1509,7 +1515,7 @@ embedded identities are re-checked at register time.
 btcPopSignature: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:331](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L331)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:338](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L338)
 
 BIP-322 signature over the PoP message (0x-prefixed hex).
 
@@ -1519,7 +1525,7 @@ BIP-322 signature over the PoP message (0x-prefixed hex).
 depositorEthAddress: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:333](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L333)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:340](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L340)
 
 Ethereum address the PoP was signed for.
 
@@ -1529,7 +1535,7 @@ Ethereum address the PoP was signed for.
 depositorBtcPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:335](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L335)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:342](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L342)
 
 BTC x-only public key (64-char hex, no 0x prefix).
 
@@ -1537,7 +1543,7 @@ BTC x-only public key (64-char hex, no 0x prefix).
 
 ### RegisterPeginParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:341](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L341)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:348](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L348)
 
 Parameters for registering a peg-in on Ethereum.
 
@@ -1549,7 +1555,7 @@ Parameters for registering a peg-in on Ethereum.
 unsignedPrePeginTx: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:348](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L348)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:355](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L355)
 
 Funded, pre-witness Pre-PegIn tx hex — pass
 [PreparePeginTransaction.fundedPrePeginTxHex](#fundedprepegintxhex) from
@@ -1562,7 +1568,7 @@ is named `unsignedPrePeginTx` but it stores the funded form.
 depositorSignedPeginTx: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:353](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L353)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:360](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L360)
 
 Depositor-signed PegIn transaction hex (submitted to contract; vault ID derived from this).
 
@@ -1572,7 +1578,7 @@ Depositor-signed PegIn transaction hex (submitted to contract; vault ID derived 
 vaultProvider: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:358](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L358)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:365](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L365)
 
 Vault provider's Ethereum address.
 
@@ -1582,7 +1588,7 @@ Vault provider's Ethereum address.
 hashlock: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:363](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L363)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:370](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L370)
 
 SHA256 hashlock for HTLC activation (bytes32 hex with 0x prefix).
 
@@ -1592,7 +1598,7 @@ SHA256 hashlock for HTLC activation (bytes32 hex with 0x prefix).
 optional depositorPayoutBtcAddress: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:372](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L372)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:379](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L379)
 
 Depositor's BTC payout address (e.g. bc1p..., bc1q...).
 Converted to scriptPubKey internally via bitcoinjs-lib.
@@ -1606,7 +1612,7 @@ via `btcWallet.getAddress()`.
 depositorWotsPkHash: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:375](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L375)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:382](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L382)
 
 Keccak256 hash of the depositor's WOTS public key (bytes32)
 
@@ -1616,7 +1622,7 @@ Keccak256 hash of the depositor's WOTS public key (bytes32)
 popSignature: PopSignature;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:378](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L378)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:385](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L385)
 
 Proof of possession from [PeginManager.signProofOfPossession](#signproofofpossession).
 
@@ -1626,7 +1632,7 @@ Proof of possession from [PeginManager.signProofOfPossession](#signproofofposses
 htlcVout: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:385](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L385)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:392](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L392)
 
 Zero-based index of the HTLC output in the Pre-PegIn transaction that
 this PegIn spends. In a batch Pre-PegIn with N HTLC outputs, each vault
@@ -1636,7 +1642,7 @@ registration references a different htlcVout (0..N-1).
 
 ### RegisterPeginResult
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:391](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L391)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:398](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L398)
 
 Result of registering a peg-in on Ethereum.
 
@@ -1648,7 +1654,7 @@ Result of registering a peg-in on Ethereum.
 ethTxHash: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:395](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L395)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:402](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L402)
 
 Ethereum transaction hash for the peg-in registration.
 
@@ -1658,7 +1664,7 @@ Ethereum transaction hash for the peg-in registration.
 vaultId: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:401](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L401)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:408](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L408)
 
 Derived vault ID: keccak256(abi.encode(peginTxHash, depositor)).
 Used for contract reads/writes and indexer queries.
@@ -1669,7 +1675,7 @@ Used for contract reads/writes and indexer queries.
 peginTxHash: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:407](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L407)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:414](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L414)
 
 Raw Bitcoin pegin transaction hash (double-SHA256 of the signed pegin tx).
 Used for VP RPC operations which key on the BTC transaction ID.
@@ -1678,7 +1684,7 @@ Used for VP RPC operations which key on the BTC transaction ID.
 
 ### BatchPeginRequestItem
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:415](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L415)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:422](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L422)
 
 Single request in a batch pegin registration.
 All requests in a batch share the same vault provider, depositor BTC
@@ -1692,7 +1698,7 @@ pubkey, and Pre-PegIn transaction.
 depositorSignedPeginTx: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:417](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L417)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:424](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L424)
 
 Signed PegIn tx hex for this vault
 
@@ -1702,7 +1708,7 @@ Signed PegIn tx hex for this vault
 hashlock: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:419](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L419)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:426](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L426)
 
 SHA256 hashlock for HTLC activation (bytes32 hex)
 
@@ -1712,7 +1718,7 @@ SHA256 hashlock for HTLC activation (bytes32 hex)
 htlcVout: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:421](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L421)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:428](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L428)
 
 Zero-based HTLC output index in the Pre-PegIn tx (unique per request)
 
@@ -1722,7 +1728,7 @@ Zero-based HTLC output index in the Pre-PegIn tx (unique per request)
 depositorPayoutBtcAddress: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:423](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L423)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:430](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L430)
 
 Depositor's BTC payout address (required — funds are sent here on payout)
 
@@ -1732,7 +1738,7 @@ Depositor's BTC payout address (required — funds are sent here on payout)
 depositorWotsPkHash: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:425](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L425)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:432](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L432)
 
 Keccak256 hash of the depositor's WOTS public key (bytes32)
 
@@ -1740,7 +1746,7 @@ Keccak256 hash of the depositor's WOTS public key (bytes32)
 
 ### RegisterPeginBatchParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:431](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L431)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:438](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L438)
 
 Parameters for registerPeginBatchOnChain.
 
@@ -1752,7 +1758,7 @@ Parameters for registerPeginBatchOnChain.
 vaultProvider: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:433](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L433)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:440](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L440)
 
 Vault provider address (shared across all vaults in batch)
 
@@ -1762,7 +1768,7 @@ Vault provider address (shared across all vaults in batch)
 unsignedPrePeginTx: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:438](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L438)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:445](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L445)
 
 Funded, pre-witness Pre-PegIn tx hex — shared across every request in
 the batch. See [RegisterPeginParams.unsignedPrePeginTx](#unsignedprepegintx).
@@ -1773,7 +1779,7 @@ the batch. See [RegisterPeginParams.unsignedPrePeginTx](#unsignedprepegintx).
 requests: BatchPeginRequestItem[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:440](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L440)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:447](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L447)
 
 Individual pegin requests (one per vault)
 
@@ -1783,7 +1789,7 @@ Individual pegin requests (one per vault)
 popSignature: PopSignature;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:442](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L442)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:449](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L449)
 
 Proof of possession from [PeginManager.signProofOfPossession](#signproofofpossession).
 
@@ -1791,7 +1797,7 @@ Proof of possession from [PeginManager.signProofOfPossession](#signproofofposses
 
 ### BatchPeginResultItem
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:448](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L448)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:455](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L455)
 
 Per-vault result from a batch pegin registration.
 
@@ -1803,7 +1809,7 @@ Per-vault result from a batch pegin registration.
 vaultId: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:450](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L450)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:457](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L457)
 
 Derived vault ID: keccak256(abi.encode(peginTxHash, depositor))
 
@@ -1813,7 +1819,7 @@ Derived vault ID: keccak256(abi.encode(peginTxHash, depositor))
 peginTxHash: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:452](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L452)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:459](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L459)
 
 Raw BTC pegin transaction hash
 
@@ -1821,7 +1827,7 @@ Raw BTC pegin transaction hash
 
 ### RegisterPeginBatchResult
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:458](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L458)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:465](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L465)
 
 Result of registering a batch of pegins on Ethereum in a single transaction.
 
@@ -1833,7 +1839,7 @@ Result of registering a batch of pegins on Ethereum in a single transaction.
 ethTxHash: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:460](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L460)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:467](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L467)
 
 Ethereum transaction hash
 
@@ -1843,7 +1849,7 @@ Ethereum transaction hash
 vaults: BatchPeginResultItem[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:462](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L462)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:469](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L469)
 
 Per-vault results (same order as input requests)
 

--- a/packages/babylon-ts-sdk/docs/api/primitives.md
+++ b/packages/babylon-ts-sdk/docs/api/primitives.md
@@ -2205,17 +2205,17 @@ true if valid hex string
 ### validateWalletPubkey()
 
 ```ts
-function validateWalletPubkey(walletPubkeyRaw, expectedDepositorPubkey?): WalletPubkeyValidationResult;
+function validateWalletPubkey(walletPubkeyRaw, expectedDepositorPubkey): WalletPubkeyValidationResult;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts:235](../../packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts#L235)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts:237](../../packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts#L237)
 
 Validate that a wallet's public key matches the expected depositor public key.
 
 This function:
 1. Converts the wallet pubkey to x-only format
-2. Uses the expected depositor pubkey if provided, otherwise falls back to wallet pubkey
-3. Validates they match (case-insensitive)
+2. Validates the wallet x-only pubkey matches the expected depositor pubkey
+   (case-insensitive)
 
 #### Parameters
 
@@ -2225,17 +2225,22 @@ This function:
 
 Raw public key from wallet (may be compressed 66 chars or x-only 64 chars)
 
-##### expectedDepositorPubkey?
+##### expectedDepositorPubkey
 
 `string`
 
-Expected depositor public key (x-only, optional)
+Expected depositor public key (x-only).
+  Required: omitting it would degrade this check to a self-comparison.
 
 #### Returns
 
 [`WalletPubkeyValidationResult`](#walletpubkeyvalidationresult)
 
 Validation result with both pubkey formats
+
+#### Throws
+
+If `expectedDepositorPubkey` is missing/empty
 
 #### Throws
 
@@ -2249,7 +2254,7 @@ If wallet pubkey doesn't match expected depositor pubkey
 function formatSatoshisToBtc(satoshis): string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts:262](../../packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts#L262)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts:270](../../packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts#L270)
 
 Format satoshis as a human-readable BTC string with trailing zeros removed.
 
@@ -2271,7 +2276,7 @@ Format satoshis as a human-readable BTC string with trailing zeros removed.
 function deriveTaprootAddress(publicKeyHex, network): string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts:328](../../packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts#L328)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts:336](../../packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts#L336)
 
 Derive a Taproot (P2TR) address from a public key.
 
@@ -2303,7 +2308,7 @@ Taproot address (bc1p... / tb1p... / bcrt1p...)
 function deriveNativeSegwitAddress(publicKeyHex, network): string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts:352](../../packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts#L352)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts:360](../../packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts#L360)
 
 Derive a Native SegWit (P2WPKH) address from a compressed public key.
 
@@ -2342,7 +2347,7 @@ function isAddressFromPublicKey(
    network): boolean;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts:389](../../packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts#L389)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts:397](../../packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts#L397)
 
 Validate that a BTC address was derived from the given public key.
 

--- a/packages/babylon-ts-sdk/docs/api/utils.md
+++ b/packages/babylon-ts-sdk/docs/api/utils.md
@@ -603,7 +603,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts:47](
 function getNetwork(network): Network;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts:307](../../packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts#L307)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts:315](../../packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts#L315)
 
 Map SDK network type to bitcoinjs-lib Network object.
 

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/__tests__/batchAttribution.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/__tests__/batchAttribution.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import { attributeBatchResults } from "../batchAttribution";
+
+const TXID_A = "a".repeat(64);
+const TXID_B = "b".repeat(64);
+const TXID_C = "c".repeat(64);
+
+describe("attributeBatchResults", () => {
+  it("attributes happy-path one-to-one results", () => {
+    const out = attributeBatchResults([TXID_A, TXID_B], [
+      { pegin_txid: TXID_A, result: { v: 1 }, error: null },
+      { pegin_txid: TXID_B, result: { v: 2 }, error: null },
+    ]);
+    expect(out.byTxid.get(TXID_A)?.result).toEqual({ v: 1 });
+    expect(out.byTxid.get(TXID_B)?.result).toEqual({ v: 2 });
+    expect(out.missing).toEqual([]);
+    expect(out.duplicate).toEqual([]);
+    expect(out.unexpected).toEqual([]);
+  });
+
+  it("normalizes case on both sides", () => {
+    const out = attributeBatchResults([TXID_A.toUpperCase()], [
+      { pegin_txid: TXID_A, result: { v: 1 }, error: null },
+    ]);
+    expect(out.byTxid.get(TXID_A)?.result).toEqual({ v: 1 });
+    expect(out.missing).toEqual([]);
+  });
+
+  it("flags requested txids missing from response", () => {
+    const out = attributeBatchResults([TXID_A, TXID_B], [
+      { pegin_txid: TXID_A, result: { v: 1 }, error: null },
+    ]);
+    expect(out.missing).toEqual([TXID_B]);
+  });
+
+  it("flags duplicate echoed txids and keeps first", () => {
+    const out = attributeBatchResults([TXID_A], [
+      { pegin_txid: TXID_A, result: { v: 1 }, error: null },
+      { pegin_txid: TXID_A, result: { v: 2 }, error: null },
+    ]);
+    expect(out.byTxid.get(TXID_A)?.result).toEqual({ v: 1 });
+    expect(out.duplicate).toEqual([TXID_A]);
+  });
+
+  it("flags unexpected echoed txids and drops them", () => {
+    const out = attributeBatchResults([TXID_A], [
+      { pegin_txid: TXID_A, result: { v: 1 }, error: null },
+      { pegin_txid: TXID_C, result: { v: 99 }, error: null },
+    ]);
+    expect(out.byTxid.size).toBe(1);
+    expect(out.byTxid.has(TXID_C)).toBe(false);
+    expect(out.unexpected).toEqual([TXID_C]);
+  });
+
+  it("preserves error envelope when result is null", () => {
+    const out = attributeBatchResults([TXID_A], [
+      { pegin_txid: TXID_A, result: null, error: "PegIn not found" },
+    ]);
+    expect(out.byTxid.get(TXID_A)).toEqual({
+      result: null,
+      error: "PegIn not found",
+    });
+  });
+
+  it("dedups requested txids", () => {
+    const out = attributeBatchResults([TXID_A, TXID_A], [
+      { pegin_txid: TXID_A, result: { v: 1 }, error: null },
+    ]);
+    expect(out.byTxid.size).toBe(1);
+    expect(out.missing).toEqual([]);
+  });
+});

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/__tests__/batchPoll.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/__tests__/batchPoll.test.ts
@@ -1,0 +1,350 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { batchPollByProvider } from "../batchPoll";
+import { VP_BATCH_MAX_SIZE } from "../types";
+
+interface Item {
+  id: string;
+  txid: string;
+}
+
+const A: Item = { id: "a", txid: "a".repeat(64) };
+const B: Item = { id: "b", txid: "b".repeat(64) };
+const C: Item = { id: "c", txid: "c".repeat(64) };
+const UNKNOWN_TXID = "f".repeat(64);
+
+function makeHandlers() {
+  return {
+    onItem: vi.fn(),
+    onMissing: vi.fn(),
+    onDuplicate: vi.fn(),
+    onWholeBatchError: vi.fn(),
+    onUnexpected: vi.fn(),
+  };
+}
+
+describe("batchPollByProvider", () => {
+  it("does not call the RPC for empty input", async () => {
+    const batchCall = vi.fn();
+    const h = makeHandlers();
+    await batchPollByProvider<Item, unknown>({
+      items: [],
+      getTxid: (i) => i.txid,
+      batchCall,
+      ...h,
+    });
+    expect(batchCall).not.toHaveBeenCalled();
+    expect(h.onItem).not.toHaveBeenCalled();
+  });
+
+  it("dispatches onItem per envelope on the happy path", async () => {
+    const h = makeHandlers();
+    const batchCall = vi.fn().mockResolvedValue({
+      results: [
+        { pegin_txid: A.txid, result: { v: 1 }, error: null },
+        { pegin_txid: B.txid, result: null, error: "PegIn not found" },
+      ],
+    });
+    await batchPollByProvider<Item, { v: number }>({
+      items: [A, B],
+      getTxid: (i) => i.txid,
+      batchCall,
+      ...h,
+    });
+    expect(h.onItem).toHaveBeenCalledTimes(2);
+    expect(h.onItem).toHaveBeenCalledWith(
+      A,
+      expect.objectContaining({ result: { v: 1 }, error: null }),
+    );
+    expect(h.onItem).toHaveBeenCalledWith(
+      B,
+      expect.objectContaining({ result: null, error: "PegIn not found" }),
+    );
+  });
+
+  it("chunks by batchSize and calls the RPC once per chunk", async () => {
+    const h = makeHandlers();
+    const batchCall = vi
+      .fn()
+      .mockResolvedValueOnce({
+        results: [
+          { pegin_txid: A.txid, result: { v: 1 }, error: null },
+          { pegin_txid: B.txid, result: { v: 2 }, error: null },
+        ],
+      })
+      .mockResolvedValueOnce({
+        results: [{ pegin_txid: C.txid, result: { v: 3 }, error: null }],
+      });
+    await batchPollByProvider<Item, { v: number }>({
+      items: [A, B, C],
+      getTxid: (i) => i.txid,
+      batchCall,
+      batchSize: 2,
+      ...h,
+    });
+    expect(batchCall).toHaveBeenCalledTimes(2);
+    expect(batchCall).toHaveBeenNthCalledWith(1, [A.txid, B.txid]);
+    expect(batchCall).toHaveBeenNthCalledWith(2, [C.txid]);
+    expect(h.onItem).toHaveBeenCalledTimes(3);
+  });
+
+  it("invokes onWholeBatchError per failed chunk and continues subsequent chunks", async () => {
+    const h = makeHandlers();
+    const boom = new Error("transport down");
+    const batchCall = vi
+      .fn()
+      .mockRejectedValueOnce(boom)
+      .mockResolvedValueOnce({
+        results: [{ pegin_txid: C.txid, result: { v: 3 }, error: null }],
+      });
+    await batchPollByProvider<Item, { v: number }>({
+      items: [A, B, C],
+      getTxid: (i) => i.txid,
+      batchCall,
+      batchSize: 2,
+      ...h,
+    });
+    expect(h.onWholeBatchError).toHaveBeenCalledTimes(1);
+    expect(h.onWholeBatchError).toHaveBeenCalledWith([A, B], boom);
+    expect(h.onItem).toHaveBeenCalledWith(
+      C,
+      expect.objectContaining({ result: { v: 3 } }),
+    );
+  });
+
+  it("invokes onMissing for items the server omitted", async () => {
+    const h = makeHandlers();
+    const batchCall = vi.fn().mockResolvedValue({
+      results: [{ pegin_txid: A.txid, result: { v: 1 }, error: null }],
+    });
+    await batchPollByProvider<Item, { v: number }>({
+      items: [A, B],
+      getTxid: (i) => i.txid,
+      batchCall,
+      ...h,
+    });
+    expect(h.onMissing).toHaveBeenCalledWith(B);
+    expect(h.onMissing).toHaveBeenCalledTimes(1);
+    expect(h.onItem).toHaveBeenCalledWith(A, expect.anything());
+    expect(h.onItem).toHaveBeenCalledTimes(1);
+  });
+
+  it("invokes onDuplicate and skips onItem for duplicated txids", async () => {
+    const h = makeHandlers();
+    const batchCall = vi.fn().mockResolvedValue({
+      results: [
+        { pegin_txid: A.txid, result: { v: 1 }, error: null },
+        { pegin_txid: A.txid, result: { v: 2 }, error: null },
+      ],
+    });
+    await batchPollByProvider<Item, { v: number }>({
+      items: [A],
+      getTxid: (i) => i.txid,
+      batchCall,
+      ...h,
+    });
+    expect(h.onDuplicate).toHaveBeenCalledWith(A);
+    expect(h.onDuplicate).toHaveBeenCalledTimes(1);
+    expect(h.onItem).not.toHaveBeenCalled();
+  });
+
+  it("fires onDuplicate exactly once per unique duplicated txid (triple echo)", async () => {
+    const h = makeHandlers();
+    const batchCall = vi.fn().mockResolvedValue({
+      results: [
+        { pegin_txid: A.txid, result: { v: 1 }, error: null },
+        { pegin_txid: A.txid, result: { v: 2 }, error: null },
+        { pegin_txid: A.txid, result: { v: 3 }, error: null },
+      ],
+    });
+    await batchPollByProvider<Item, { v: number }>({
+      items: [A],
+      getTxid: (i) => i.txid,
+      batchCall,
+      ...h,
+    });
+    expect(h.onDuplicate).toHaveBeenCalledTimes(1);
+    expect(h.onItem).not.toHaveBeenCalled();
+  });
+
+  it("dispatches onItem to non-duplicate items in a mixed batch", async () => {
+    const h = makeHandlers();
+    const batchCall = vi.fn().mockResolvedValue({
+      results: [
+        { pegin_txid: A.txid, result: { v: 1 }, error: null },
+        { pegin_txid: A.txid, result: { v: 2 }, error: null },
+        { pegin_txid: B.txid, result: { v: 3 }, error: null },
+      ],
+    });
+    await batchPollByProvider<Item, { v: number }>({
+      items: [A, B],
+      getTxid: (i) => i.txid,
+      batchCall,
+      ...h,
+    });
+    expect(h.onDuplicate).toHaveBeenCalledTimes(1);
+    expect(h.onDuplicate).toHaveBeenCalledWith(A);
+    expect(h.onItem).toHaveBeenCalledTimes(1);
+    expect(h.onItem).toHaveBeenCalledWith(
+      B,
+      expect.objectContaining({ result: { v: 3 } }),
+    );
+  });
+
+  it("invokes onDuplicateBatch once per chunk with the duplicate count", async () => {
+    const handlers = {
+      ...makeHandlers(),
+      onDuplicateBatch: vi.fn(),
+    };
+    const batchCall = vi.fn().mockResolvedValue({
+      results: [
+        { pegin_txid: A.txid, result: { v: 1 }, error: null },
+        { pegin_txid: A.txid, result: { v: 2 }, error: null },
+        { pegin_txid: B.txid, result: { v: 3 }, error: null },
+        { pegin_txid: B.txid, result: { v: 4 }, error: null },
+      ],
+    });
+    await batchPollByProvider<Item, { v: number }>({
+      items: [A, B],
+      getTxid: (i) => i.txid,
+      batchCall,
+      ...handlers,
+    });
+    expect(handlers.onDuplicateBatch).toHaveBeenCalledTimes(1);
+    expect(handlers.onDuplicateBatch).toHaveBeenCalledWith(2);
+  });
+
+  it("invokes onUnexpected with echoed-but-unrequested txids", async () => {
+    const h = makeHandlers();
+    const batchCall = vi.fn().mockResolvedValue({
+      results: [
+        { pegin_txid: A.txid, result: { v: 1 }, error: null },
+        { pegin_txid: UNKNOWN_TXID, result: { v: 99 }, error: null },
+      ],
+    });
+    await batchPollByProvider<Item, { v: number }>({
+      items: [A],
+      getTxid: (i) => i.txid,
+      batchCall,
+      ...h,
+    });
+    expect(h.onUnexpected).toHaveBeenCalledWith([UNKNOWN_TXID]);
+    expect(h.onItem).toHaveBeenCalledWith(A, expect.anything());
+    expect(h.onItem).toHaveBeenCalledTimes(1);
+  });
+
+  it("silently drops unexpected txids when onUnexpected is not provided", async () => {
+    const handlers = {
+      onItem: vi.fn(),
+      onMissing: vi.fn(),
+      onDuplicate: vi.fn(),
+      onWholeBatchError: vi.fn(),
+    };
+    const batchCall = vi.fn().mockResolvedValue({
+      results: [
+        { pegin_txid: A.txid, result: { v: 1 }, error: null },
+        { pegin_txid: UNKNOWN_TXID, result: { v: 99 }, error: null },
+      ],
+    });
+    await expect(
+      batchPollByProvider<Item, { v: number }>({
+        items: [A],
+        getTxid: (i) => i.txid,
+        batchCall,
+        ...handlers,
+      }),
+    ).resolves.toBeUndefined();
+    expect(handlers.onItem).toHaveBeenCalledTimes(1);
+  });
+
+  it("defaults batchSize to VP_BATCH_MAX_SIZE when omitted", async () => {
+    const h = makeHandlers();
+    const items: Item[] = Array.from(
+      { length: VP_BATCH_MAX_SIZE + 1 },
+      (_, i) => ({
+        id: `id-${i}`,
+        txid: i.toString(16).padStart(64, "0"),
+      }),
+    );
+    const batchCall = vi
+      .fn()
+      .mockResolvedValueOnce({ results: [] })
+      .mockResolvedValueOnce({ results: [] });
+    await batchPollByProvider<Item, unknown>({
+      items,
+      getTxid: (i) => i.txid,
+      batchCall,
+      ...h,
+    });
+    expect(batchCall).toHaveBeenCalledTimes(2);
+    expect(batchCall.mock.calls[0][0]).toHaveLength(VP_BATCH_MAX_SIZE);
+    expect(batchCall.mock.calls[1][0]).toHaveLength(1);
+  });
+
+  it("rejects non-positive batchSize up front", async () => {
+    const h = makeHandlers();
+    await expect(
+      batchPollByProvider<Item, unknown>({
+        items: [A],
+        getTxid: (i) => i.txid,
+        batchCall: vi.fn(),
+        batchSize: 0,
+        ...h,
+      }),
+    ).rejects.toThrow(/batchSize must be a positive integer/);
+    await expect(
+      batchPollByProvider<Item, unknown>({
+        items: [A],
+        getTxid: (i) => i.txid,
+        batchCall: vi.fn(),
+        batchSize: -1,
+        ...h,
+      }),
+    ).rejects.toThrow(/batchSize must be a positive integer/);
+  });
+
+  it("routes attribution-time errors through onWholeBatchError", async () => {
+    const h = makeHandlers();
+    // Forge a response shape that breaks `attributeBatchResults` by
+    // having a non-string `pegin_txid`. The helper must not abort the
+    // polling pass — the caller should see the error via
+    // `onWholeBatchError` and subsequent chunks should still execute.
+    const batchCall = vi
+      .fn()
+      .mockResolvedValueOnce({
+        results: [{ pegin_txid: 123, result: { v: 1 }, error: null } as never],
+      })
+      .mockResolvedValueOnce({
+        results: [{ pegin_txid: B.txid, result: { v: 2 }, error: null }],
+      });
+    await batchPollByProvider<Item, { v: number }>({
+      items: [A, B],
+      getTxid: (i) => i.txid,
+      batchCall,
+      batchSize: 1,
+      ...h,
+    });
+    expect(h.onWholeBatchError).toHaveBeenCalledTimes(1);
+    expect(h.onWholeBatchError.mock.calls[0][0]).toEqual([A]);
+    expect(h.onItem).toHaveBeenCalledWith(
+      B,
+      expect.objectContaining({ result: { v: 2 } }),
+    );
+  });
+
+  it("normalizes mixed-case txids to lowercase before calling the RPC", async () => {
+    const h = makeHandlers();
+    const upperItem: Item = { id: "u", txid: A.txid.toUpperCase() };
+    const batchCall = vi.fn().mockResolvedValue({
+      results: [{ pegin_txid: A.txid, result: { v: 1 }, error: null }],
+    });
+    await batchPollByProvider<Item, { v: number }>({
+      items: [upperItem],
+      getTxid: (i) => i.txid,
+      batchCall,
+      ...h,
+    });
+    expect(batchCall).toHaveBeenCalledWith([A.txid]);
+    expect(h.onItem).toHaveBeenCalledWith(upperItem, expect.anything());
+  });
+});

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/__tests__/validators.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/__tests__/validators.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from "vitest";
 import { DaemonStatus } from "../types";
 import {
   VpResponseValidationError,
+  validateBatchGetPeginStatusResponse,
+  validateBatchGetPegoutStatusResponse,
   validateGetPeginStatusResponse,
   validateGetPegoutStatusResponse,
   validateRequestDepositorClaimerArtifactsResponse,
@@ -409,22 +411,48 @@ describe("VP Response Validators", () => {
   });
 
   describe("validateGetPegoutStatusResponse", () => {
-    it("accepts a valid response with no claimer/challenger", () => {
+    const VALID_PUBKEY = "a".repeat(64);
+    const ANOTHER_TXID = "b".repeat(64);
+    const VALID_CLAIMER = {
+      status: "pending",
+      failed: false,
+      claim_txid: ANOTHER_TXID,
+      claimer_pubkey: VALID_PUBKEY,
+      assert_txid: ANOTHER_TXID,
+      challenger_pubkey: null,
+      created_at: 1700000000,
+      updated_at: 1700000001,
+    };
+    const VALID_CHALLENGER = {
+      status: "active",
+      claim_txid: ANOTHER_TXID,
+      claimer_pubkey: VALID_PUBKEY,
+      assert_txid: null,
+      challenge_assert_x_txid: null,
+      challenge_assert_y_txid: null,
+      nopayout_txid: null,
+      created_at: 1700000000,
+      updated_at: 1700000001,
+    };
+
+    it("accepts a valid not-found response (null claimer, empty challengers)", () => {
       expect(() =>
         validateGetPegoutStatusResponse({
           pegin_txid: VALID_TXID,
           found: false,
+          claimer: null,
+          challengers: [],
         }),
       ).not.toThrow();
     });
 
-    it("accepts a valid response with claimer and challenger", () => {
+    it("accepts a valid response with claimer and one challenger", () => {
       expect(() =>
         validateGetPegoutStatusResponse({
           pegin_txid: VALID_TXID,
           found: true,
-          claimer: { status: "pending", failed: false },
-          challenger: { status: "active" },
+          claimer: VALID_CLAIMER,
+          challengers: [VALID_CHALLENGER],
         }),
       ).not.toThrow();
     });
@@ -440,6 +468,8 @@ describe("VP Response Validators", () => {
         validateGetPegoutStatusResponse({
           pegin_txid: "short",
           found: false,
+          claimer: null,
+          challengers: [],
         }),
       ).toThrow(VpResponseValidationError);
     });
@@ -449,58 +479,72 @@ describe("VP Response Validators", () => {
         validateGetPegoutStatusResponse({
           pegin_txid: VALID_TXID,
           found: "yes",
+          claimer: null,
+          challengers: [],
         }),
       ).toThrow(VpResponseValidationError);
     });
 
-    it("rejects claimer with missing status", () => {
+    it("rejects claimer with missing mandatory fields", () => {
       expect(() =>
         validateGetPegoutStatusResponse({
           pegin_txid: VALID_TXID,
           found: true,
-          claimer: { failed: false },
+          claimer: { ...VALID_CLAIMER, claim_txid: undefined },
+          challengers: [],
         }),
       ).toThrow(VpResponseValidationError);
     });
 
-    it("rejects claimer with missing failed field", () => {
+    it("rejects claimer with non-numeric created_at (Rust returns i64)", () => {
       expect(() =>
         validateGetPegoutStatusResponse({
           pegin_txid: VALID_TXID,
           found: true,
-          claimer: { status: "pending" },
+          claimer: { ...VALID_CLAIMER, created_at: "1700000000" },
+          challengers: [],
         }),
       ).toThrow(VpResponseValidationError);
     });
 
-    it("rejects null claimer", () => {
+    it("rejects challengers when not an array", () => {
       expect(() =>
         validateGetPegoutStatusResponse({
           pegin_txid: VALID_TXID,
           found: true,
           claimer: null,
+          challengers: { status: "active" },
         }),
       ).toThrow(VpResponseValidationError);
     });
 
-    it("rejects challenger with missing status", () => {
+    it("rejects challenger entry with missing mandatory status", () => {
+      const bad = { ...VALID_CHALLENGER, status: undefined };
       expect(() =>
         validateGetPegoutStatusResponse({
           pegin_txid: VALID_TXID,
           found: true,
-          challenger: {},
+          claimer: null,
+          challengers: [bad],
         }),
       ).toThrow(VpResponseValidationError);
     });
 
-    it("rejects null challenger", () => {
+    it("accepts the optional split-assert txid fields when present", () => {
       expect(() =>
         validateGetPegoutStatusResponse({
           pegin_txid: VALID_TXID,
           found: true,
-          challenger: null,
+          claimer: null,
+          challengers: [
+            {
+              ...VALID_CHALLENGER,
+              challenge_assert_x_txid: ANOTHER_TXID,
+              challenge_assert_y_txid: ANOTHER_TXID,
+            },
+          ],
         }),
-      ).toThrow(VpResponseValidationError);
+      ).not.toThrow();
     });
   });
 
@@ -592,6 +636,161 @@ describe("VP Response Validators", () => {
           babe_sessions: {
             challenger1: { decryptor_artifacts_hex: "xyz" },
           },
+        }),
+      ).toThrow(VpResponseValidationError);
+    });
+  });
+
+  describe("validateBatchGetPeginStatusResponse", () => {
+    const validInner = {
+      pegin_txid: VALID_TXID,
+      status: DaemonStatus.ACTIVATED,
+      progress: {},
+      health_info: "ok",
+    };
+
+    it("accepts an empty results array", () => {
+      expect(() =>
+        validateBatchGetPeginStatusResponse({ results: [] }),
+      ).not.toThrow();
+    });
+
+    it("accepts a result entry with only `result` populated", () => {
+      expect(() =>
+        validateBatchGetPeginStatusResponse({
+          results: [
+            { pegin_txid: VALID_TXID, result: validInner, error: null },
+          ],
+        }),
+      ).not.toThrow();
+    });
+
+    it("accepts a result entry with only `error` populated", () => {
+      expect(() =>
+        validateBatchGetPeginStatusResponse({
+          results: [
+            { pegin_txid: VALID_TXID, result: null, error: "PegIn not found" },
+          ],
+        }),
+      ).not.toThrow();
+    });
+
+    it("rejects when response is not an object", () => {
+      expect(() => validateBatchGetPeginStatusResponse(null)).toThrow(
+        VpResponseValidationError,
+      );
+    });
+
+    it("rejects when results is not an array", () => {
+      expect(() =>
+        validateBatchGetPeginStatusResponse({ results: { foo: 1 } }),
+      ).toThrow(VpResponseValidationError);
+    });
+
+    it("rejects entry that is not an object", () => {
+      expect(() =>
+        validateBatchGetPeginStatusResponse({ results: ["not-an-object"] }),
+      ).toThrow(VpResponseValidationError);
+    });
+
+    it("rejects entry with missing pegin_txid", () => {
+      expect(() =>
+        validateBatchGetPeginStatusResponse({
+          results: [{ result: null, error: "boom" }],
+        }),
+      ).toThrow(VpResponseValidationError);
+    });
+
+    it("rejects entry with wrong-length pegin_txid", () => {
+      expect(() =>
+        validateBatchGetPeginStatusResponse({
+          results: [{ pegin_txid: "abcd", result: null, error: "boom" }],
+        }),
+      ).toThrow(VpResponseValidationError);
+    });
+
+    it("rejects entry where both result and error are populated", () => {
+      expect(() =>
+        validateBatchGetPeginStatusResponse({
+          results: [
+            { pegin_txid: VALID_TXID, result: validInner, error: "boom" },
+          ],
+        }),
+      ).toThrow(VpResponseValidationError);
+    });
+
+    it("rejects entry where neither result nor error is populated", () => {
+      expect(() =>
+        validateBatchGetPeginStatusResponse({
+          results: [{ pegin_txid: VALID_TXID, result: null, error: null }],
+        }),
+      ).toThrow(VpResponseValidationError);
+    });
+
+    it("rejects entry where error is not a string-or-null", () => {
+      expect(() =>
+        validateBatchGetPeginStatusResponse({
+          results: [{ pegin_txid: VALID_TXID, result: null, error: 42 }],
+        }),
+      ).toThrow(VpResponseValidationError);
+    });
+
+    it("propagates inner result validation failures", () => {
+      expect(() =>
+        validateBatchGetPeginStatusResponse({
+          results: [
+            {
+              pegin_txid: VALID_TXID,
+              result: {
+                pegin_txid: VALID_TXID,
+                status: "BogusStatus",
+                progress: {},
+                health_info: "ok",
+              },
+              error: null,
+            },
+          ],
+        }),
+      ).toThrow(VpResponseValidationError);
+    });
+  });
+
+  describe("validateBatchGetPegoutStatusResponse", () => {
+    const validInner = {
+      pegin_txid: VALID_TXID,
+      found: false,
+      claimer: null,
+      challengers: [],
+    };
+
+    it("accepts a happy-path batch", () => {
+      expect(() =>
+        validateBatchGetPegoutStatusResponse({
+          results: [
+            { pegin_txid: VALID_TXID, result: validInner, error: null },
+          ],
+        }),
+      ).not.toThrow();
+    });
+
+    it("rejects entry where both result and error are null", () => {
+      expect(() =>
+        validateBatchGetPegoutStatusResponse({
+          results: [{ pegin_txid: VALID_TXID, result: null, error: null }],
+        }),
+      ).toThrow(VpResponseValidationError);
+    });
+
+    it("propagates inner result validation failures (missing challengers array)", () => {
+      expect(() =>
+        validateBatchGetPegoutStatusResponse({
+          results: [
+            {
+              pegin_txid: VALID_TXID,
+              result: { ...validInner, challengers: undefined },
+              error: null,
+            },
+          ],
         }),
       ).toThrow(VpResponseValidationError);
     });

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts
@@ -19,10 +19,12 @@ import {
   type JsonRpcClientConfig,
 } from "./json-rpc-client";
 import type {
+  BatchGetPeginStatusParams,
+  BatchGetPeginStatusResponse,
+  BatchGetPegoutStatusParams,
+  BatchGetPegoutStatusResponse,
   GetPeginStatusParams,
   GetPeginStatusResponse,
-  GetPegoutStatusParams,
-  GetPegoutStatusResponse,
   RequestDepositorClaimerArtifactsParams,
   RequestDepositorClaimerArtifactsResponse,
   RequestDepositorPresignTransactionsParams,
@@ -31,8 +33,9 @@ import type {
   SubmitDepositorWotsKeyParams,
 } from "./types";
 import {
+  validateBatchGetPeginStatusResponse,
+  validateBatchGetPegoutStatusResponse,
   validateGetPeginStatusResponse,
-  validateGetPegoutStatusResponse,
   validateRequestDepositorClaimerArtifactsResponse,
   validateRequestDepositorPresignTransactionsResponse,
 } from "./validators";
@@ -46,7 +49,7 @@ export interface VaultProviderRpcClientOptions {
   retryDelay?: number;
   /**
    * Custom retry predicate. Default retries only the idempotent read
-   * methods: `getPeginStatus`, `getPegoutStatus`,
+   * methods: `getPeginStatus`, `batchGetPeginStatus`, `batchGetPegoutStatus`,
    * `requestDepositorPresignTransactions`.
    */
   retryableFor?: (method: string) => boolean;
@@ -169,17 +172,36 @@ export class VaultProviderRpcClient
     return response;
   }
 
-  /** Get the current pegout status from the vault provider daemon. */
-  async getPegoutStatus(
-    params: GetPegoutStatusParams,
+  /**
+   * Get pegin status for many txids in one round trip. Per-result envelope
+   * isolates per-pegin failures from the overall RPC. Caller must chunk
+   * inputs at `VP_BATCH_MAX_SIZE`.
+   */
+  async batchGetPeginStatus(
+    params: BatchGetPeginStatusParams,
     signal?: AbortSignal,
-  ): Promise<GetPegoutStatusResponse> {
-    const response = await this.client.call<GetPegoutStatusParams, unknown>(
-      "vaultProvider_getPegoutStatus",
-      params,
-      signal,
-    );
-    validateGetPegoutStatusResponse(response);
+  ): Promise<BatchGetPeginStatusResponse> {
+    const response = await this.client.call<
+      BatchGetPeginStatusParams,
+      unknown
+    >("vaultProvider_batchGetPeginStatus", params, signal);
+    validateBatchGetPeginStatusResponse(response);
+    return response;
+  }
+
+  /**
+   * Get pegout status for many txids in one round trip. Same per-result
+   * envelope semantics as `batchGetPeginStatus`.
+   */
+  async batchGetPegoutStatus(
+    params: BatchGetPegoutStatusParams,
+    signal?: AbortSignal,
+  ): Promise<BatchGetPegoutStatusResponse> {
+    const response = await this.client.call<
+      BatchGetPegoutStatusParams,
+      unknown
+    >("vaultProvider_batchGetPegoutStatus", params, signal);
+    validateBatchGetPegoutStatusResponse(response);
     return response;
   }
 }

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchAttribution.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchAttribution.ts
@@ -1,0 +1,81 @@
+/**
+ * Defensive helper for attributing per-item results in a VP batch RPC
+ * response back to the requested txids. The server promises 1:1 ordered
+ * results, but we don't trust that promise — a server bug could duplicate,
+ * skip, or scramble items, and silent attribution-by-array-index would
+ * mask the bug.
+ *
+ * Lowercases all txids on both sides to absorb case mismatch (the FE
+ * strips `0x` but doesn't otherwise normalize).
+ *
+ * @module tbv/core/clients/vault-provider/batchAttribution
+ */
+
+/** Per-item entry in a VP batch response. */
+export interface BatchResultEntry<T> {
+  pegin_txid: string;
+  result: T | null;
+  error: string | null;
+}
+
+/** Output of {@link attributeBatchResults}. */
+export interface BatchAttributionResult<T> {
+  /** Lowercase requested txid -> per-item envelope. */
+  byTxid: Map<string, { result: T | null; error: string | null }>;
+  /** Requested txids that did not appear in the response. */
+  missing: string[];
+  /** Echoed txids that were not in the request — logged + dropped. */
+  unexpected: string[];
+  /** Echoed txids that appeared more than once — first kept, rest dropped. */
+  duplicate: string[];
+}
+
+/**
+ * Attribute batch results to requested txids defensively.
+ *
+ * Both `requestedTxids` and the echoed `pegin_txid` field on each result
+ * are lowercased before lookup. Duplicates and unexpected echoes are
+ * surfaced so callers can flag the affected items as errored rather than
+ * silently overwriting state.
+ *
+ * `requestedTxids` may contain duplicates; they are de-duplicated for the
+ * purposes of map keys (each unique txid becomes a single map entry).
+ */
+export function attributeBatchResults<T>(
+  requestedTxids: string[],
+  results: ReadonlyArray<BatchResultEntry<T>>,
+): BatchAttributionResult<T> {
+  const requestedSet = new Set<string>();
+  for (const txid of requestedTxids) {
+    requestedSet.add(txid.toLowerCase());
+  }
+
+  const byTxid = new Map<
+    string,
+    { result: T | null; error: string | null }
+  >();
+  const seen = new Set<string>();
+  const duplicate: string[] = [];
+  const unexpected: string[] = [];
+
+  for (const entry of results) {
+    const lower = entry.pegin_txid.toLowerCase();
+    if (!requestedSet.has(lower)) {
+      unexpected.push(lower);
+      continue;
+    }
+    if (seen.has(lower)) {
+      duplicate.push(lower);
+      continue;
+    }
+    seen.add(lower);
+    byTxid.set(lower, { result: entry.result, error: entry.error });
+  }
+
+  const missing: string[] = [];
+  for (const txid of requestedSet) {
+    if (!seen.has(txid)) missing.push(txid);
+  }
+
+  return { byTxid, missing, unexpected, duplicate };
+}

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchPoll.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchPoll.ts
@@ -1,0 +1,145 @@
+/**
+ * Generic chunk + attribute + dispatch loop for VP batch RPCs.
+ *
+ * Wraps {@link attributeBatchResults} with chunking and per-callback
+ * dispatch so the FE polling hooks (and any future SDK consumer) only
+ * have to declare per-item handlers — chunking by `VP_BATCH_MAX_SIZE`,
+ * lowercase txid normalization, missing/duplicate/unexpected
+ * surfacing, and the duplicate-skip invariant in the byTxid loop are
+ * all owned here.
+ *
+ * @module tbv/core/clients/vault-provider/batchPoll
+ */
+
+import {
+  attributeBatchResults,
+  type BatchResultEntry,
+} from "./batchAttribution";
+import { VP_BATCH_MAX_SIZE } from "./types";
+
+export interface BatchPollByProviderOptions<TItem, TResult> {
+  /** Items to poll for this provider, e.g. `DepositToPoll[]`. */
+  items: TItem[];
+  /** Extract the canonical txid for each item. Helper lowercases it. */
+  getTxid: (item: TItem) => string;
+  /**
+   * Per-chunk RPC call. Receives lowercased txids; returns the batch
+   * envelope. Caller wraps `rpcClient.batchGet*Status({ pegin_txids })`.
+   */
+  batchCall: (
+    txids: string[],
+  ) => Promise<{ results: ReadonlyArray<BatchResultEntry<TResult>> }>;
+  /**
+   * Handle a per-item envelope. Exactly one of `result` / `error` is
+   * populated (validator invariant). Caller decides UI state, logging,
+   * etc. Not invoked for txids surfaced via {@link onDuplicate}.
+   *
+   * Note: `envelope.pegin_txid` is the lowercased txid the helper
+   * sent in the request, not whatever case/encoding the server echoed.
+   */
+  onItem: (item: TItem, envelope: BatchResultEntry<TResult>) => void;
+  /** Server omitted this item from the response. */
+  onMissing: (item: TItem) => void;
+  /** Server returned this item more than once. Caller picks UI state. */
+  onDuplicate: (item: TItem) => void;
+  /**
+   * Optional aggregate signal for an entire chunk where the server
+   * returned duplicates. Fires once per chunk (only if `count > 0`)
+   * AFTER all per-item `onDuplicate` dispatches. Caller typically logs
+   * the count alongside the provider name.
+   */
+  onDuplicateBatch?: (count: number) => void;
+  /**
+   * The whole chunk's RPC call failed (transport or response
+   * validation). Receives the chunk and the error. Caller decides how
+   * to project that onto per-item state.
+   */
+  onWholeBatchError: (chunk: TItem[], error: unknown) => void;
+  /**
+   * Server returned txids that were not in the request. Caller
+   * typically logs the count for observability — there's no recovery
+   * action since the original request items are unaffected. Optional;
+   * defaults to no-op.
+   */
+  onUnexpected?: (echoedTxids: string[]) => void;
+  /**
+   * Maximum items per RPC call. Defaults to {@link VP_BATCH_MAX_SIZE}.
+   * Exposed for tests so chunking can be exercised without 50+
+   * fixtures.
+   */
+  batchSize?: number;
+}
+
+export async function batchPollByProvider<TItem, TResult>(
+  options: BatchPollByProviderOptions<TItem, TResult>,
+): Promise<void> {
+  const {
+    items,
+    getTxid,
+    batchCall,
+    onItem,
+    onMissing,
+    onDuplicate,
+    onDuplicateBatch,
+    onWholeBatchError,
+    onUnexpected,
+    batchSize = VP_BATCH_MAX_SIZE,
+  } = options;
+
+  if (!Number.isInteger(batchSize) || batchSize <= 0) {
+    throw new Error(
+      `batchPollByProvider: batchSize must be a positive integer, got ${batchSize}`,
+    );
+  }
+
+  for (let i = 0; i < items.length; i += batchSize) {
+    const chunk = items.slice(i, i + batchSize);
+    const txidToItem = new Map<string, TItem>();
+    const txids: string[] = [];
+    for (const item of chunk) {
+      const lowerTxid = getTxid(item).toLowerCase();
+      txidToItem.set(lowerTxid, item);
+      txids.push(lowerTxid);
+    }
+
+    // Both the RPC call and attribution sit inside the same try/catch
+    // so a malformed-batch validator throw is routed through
+    // `onWholeBatchError` rather than aborting the polling pass.
+    let attribution;
+    try {
+      const response = await batchCall(txids);
+      attribution = attributeBatchResults<TResult>(txids, response.results);
+    } catch (error) {
+      onWholeBatchError(chunk, error);
+      continue;
+    }
+
+    if (onUnexpected && attribution.unexpected.length > 0) {
+      onUnexpected(attribution.unexpected);
+    }
+
+    const duplicateTxids = new Set(attribution.duplicate);
+    for (const txid of duplicateTxids) {
+      const item = txidToItem.get(txid);
+      if (item) onDuplicate(item);
+    }
+    if (onDuplicateBatch && duplicateTxids.size > 0) {
+      onDuplicateBatch(duplicateTxids.size);
+    }
+    for (const txid of attribution.missing) {
+      const item = txidToItem.get(txid);
+      if (item) onMissing(item);
+    }
+    for (const [txid, envelope] of attribution.byTxid) {
+      // Skip duplicates — already dispatched via onDuplicate above.
+      if (duplicateTxids.has(txid)) continue;
+      const item = txidToItem.get(txid);
+      if (!item) continue;
+      onItem(item, {
+        pegin_txid: txid,
+        result: envelope.result,
+        error: envelope.error,
+      });
+    }
+  }
+}

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/index.ts
@@ -10,5 +10,10 @@ export {
   VpResponseValidationError,
   validateRequestDepositorClaimerArtifactsResponse,
 } from "./validators";
+export {
+  attributeBatchResults,
+  type BatchAttributionResult,
+  type BatchResultEntry,
+} from "./batchAttribution";
 export * from "./types";
 export * from "./auth";

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/index.ts
@@ -10,10 +10,10 @@ export {
   VpResponseValidationError,
   validateRequestDepositorClaimerArtifactsResponse,
 } from "./validators";
+export type { BatchResultEntry } from "./batchAttribution";
 export {
-  attributeBatchResults,
-  type BatchAttributionResult,
-  type BatchResultEntry,
-} from "./batchAttribution";
+  batchPollByProvider,
+  type BatchPollByProviderOptions,
+} from "./batchPoll";
 export * from "./types";
 export * from "./auth";

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts
@@ -73,9 +73,9 @@ export interface JsonRpcClientConfig {
   maxResponseBytes?: number;
   /**
    * Predicate that decides which methods retry on transient errors.
-   * Default retries only `getPeginStatus`, `getPegoutStatus`, and
-   * `requestDepositorPresignTransactions`. Write methods are not
-   * retried by default.
+   * Default retries only `getPeginStatus`, `batchGetPeginStatus`,
+   * `batchGetPegoutStatus`, and `requestDepositorPresignTransactions`.
+   * Write methods are not retried by default.
    */
   retryableFor?: (method: string) => boolean;
   /**
@@ -158,7 +158,8 @@ const RETRYABLE_HTTP_STATUS_CODES: ReadonlySet<number> = new Set([
 /** Default retry predicate: only retry read-only / idempotent methods */
 const DEFAULT_RETRYABLE_METHODS: ReadonlySet<string> = new Set([
   "vaultProvider_getPeginStatus",
-  "vaultProvider_getPegoutStatus",
+  "vaultProvider_batchGetPeginStatus",
+  "vaultProvider_batchGetPegoutStatus",
   "vaultProvider_requestDepositorPresignTransactions",
 ]);
 

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts
@@ -286,41 +286,95 @@ export interface GetPeginStatusResponse {
 // Pegout Types
 // ============================================================================
 
-/** Params for querying pegout status from the VP daemon. */
-export interface GetPegoutStatusParams {
-  pegin_txid: string;
-}
-
-/** Claimer-side pegout progress. */
+/**
+ * Claimer-side pegout progress.
+ * Source: btc-vault crates/vaultd/src/rpc/server/pegout_status.rs ClaimerPegoutStatus.
+ */
 export interface ClaimerPegoutStatus {
   status: string;
   failed: boolean;
-  claim_txid?: string;
-  claimer_pubkey?: string;
-  challenger_pubkey?: string;
-  created_at?: string;
-  updated_at?: string;
+  claim_txid: string;
+  claimer_pubkey: string;
+  assert_txid: string;
+  challenger_pubkey: string | null;
+  /** Unix epoch seconds. */
+  created_at: number;
+  /** Unix epoch seconds. */
+  updated_at: number;
 }
 
-/** Challenger-side pegout progress. */
-export interface ChallengerPegoutStatus {
+/**
+ * Challenger-side pegout progress.
+ * Source: btc-vault crates/vaultd/src/rpc/server/pegout_status.rs ChallengerStatus.
+ */
+export interface ChallengerStatus {
   status: string;
-  claim_txid?: string;
-  claimer_pubkey?: string;
-  assert_txid?: string;
-  challenge_assert_txid?: string;
-  nopayout_txid?: string;
-  created_at?: string;
-  updated_at?: string;
+  claim_txid: string;
+  claimer_pubkey: string;
+  assert_txid: string | null;
+  challenge_assert_x_txid: string | null;
+  challenge_assert_y_txid: string | null;
+  nopayout_txid: string | null;
+  created_at: number;
+  updated_at: number;
 }
 
-/** Response from `getPegoutStatus`. */
+/**
+ * Pegout status response. Embedded by `batchGetPegoutStatus` per-result
+ * envelopes. Mirrors btc-vault `GetPegoutStatusResponse`.
+ */
 export interface GetPegoutStatusResponse {
   pegin_txid: string;
   found: boolean;
-  claimer?: ClaimerPegoutStatus;
-  challenger?: ChallengerPegoutStatus;
+  claimer: ClaimerPegoutStatus | null;
+  challengers: ChallengerStatus[];
 }
+
+// ============================================================================
+// Batch Status Types (peginStatus + pegoutStatus)
+// ============================================================================
+
+/** Params for `batchGetPeginStatus`. */
+export interface BatchGetPeginStatusParams {
+  /** Up to MAX_BATCH_SIZE (50) txids per call. */
+  pegin_txids: string[];
+}
+
+/** Per-pegin entry in a `batchGetPeginStatus` response. */
+export interface BatchPeginStatusResult {
+  pegin_txid: string;
+  result: GetPeginStatusResponse | null;
+  error: string | null;
+}
+
+/** Response from `batchGetPeginStatus`. Results are returned in request order. */
+export interface BatchGetPeginStatusResponse {
+  results: BatchPeginStatusResult[];
+}
+
+/** Params for `batchGetPegoutStatus`. */
+export interface BatchGetPegoutStatusParams {
+  pegin_txids: string[];
+}
+
+/** Per-vault entry in a `batchGetPegoutStatus` response. */
+export interface BatchPegoutStatusResult {
+  pegin_txid: string;
+  result: GetPegoutStatusResponse | null;
+  error: string | null;
+}
+
+/** Response from `batchGetPegoutStatus`. Results are returned in request order. */
+export interface BatchGetPegoutStatusResponse {
+  results: BatchPegoutStatusResult[];
+}
+
+/**
+ * Maximum number of items per batch call. Mirrors the server-side
+ * `MAX_BATCH_SIZE` in btc-vault (`crates/vaultd/src/rpc/server/vault_provider.rs:7`).
+ * Callers must chunk requests larger than this.
+ */
+export const VP_BATCH_MAX_SIZE = 50;
 
 // ============================================================================
 // Error Codes

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/validators.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/validators.ts
@@ -17,6 +17,8 @@ import { HEX_RE } from "../../utils/validation";
 
 import { DaemonStatus } from "./types";
 import type {
+  BatchGetPeginStatusResponse,
+  BatchGetPegoutStatusResponse,
   GetPeginStatusResponse,
   GetPegoutStatusResponse,
   RequestDepositorClaimerArtifactsResponse,
@@ -372,14 +374,16 @@ export function validateRequestDepositorClaimerArtifactsResponse(
 }
 
 /**
- * Validate a getPegoutStatus response.
+ * Validate a single pegout status payload. Embedded by
+ * `validateBatchGetPegoutStatusResponse`. Mirrors btc-vault
+ * `crates/vaultd/src/rpc/server/pegout_status.rs::GetPegoutStatusResponse`.
  */
 export function validateGetPegoutStatusResponse(
   response: unknown,
 ): asserts response is GetPegoutStatusResponse {
   if (response === null || typeof response !== "object") {
     throw new VpResponseValidationError(
-      `VP response validation failed: getPegoutStatus response is not an object`,
+      `VP response validation failed: pegout status payload is not an object`,
     );
   }
 
@@ -397,37 +401,178 @@ export function validateGetPegoutStatusResponse(
     );
   }
 
-  if (r.claimer !== undefined) {
-    if (r.claimer === null || typeof r.claimer !== "object") {
+  // `claimer` is `Option<ClaimerPegoutStatus>` server-side; null when absent.
+  if (r.claimer !== null) {
+    if (typeof r.claimer !== "object") {
       throw new VpResponseValidationError(
-        `VP response validation failed: "claimer" must be an object if present`,
+        `VP response validation failed: "claimer" must be an object or null, got ${preview(r.claimer)}`,
       );
     }
-    const claimer = r.claimer as Record<string, unknown>;
-    if (typeof claimer.status !== "string") {
-      throw new VpResponseValidationError(
-        `VP response validation failed: "claimer.status" must be a string, got ${preview(claimer.status)}`,
-      );
-    }
-    if (typeof claimer.failed !== "boolean") {
-      throw new VpResponseValidationError(
-        `VP response validation failed: "claimer.failed" must be a boolean, got ${preview(claimer.failed)}`,
-      );
-    }
+    validateClaimerPegoutStatus(r.claimer as Record<string, unknown>);
   }
 
-  if (r.challenger !== undefined) {
-    if (r.challenger === null || typeof r.challenger !== "object") {
+  // `challengers: Vec<ChallengerStatus>` server-side; always present (possibly empty).
+  if (!Array.isArray(r.challengers)) {
+    throw new VpResponseValidationError(
+      `VP response validation failed: "challengers" must be an array, got ${preview(r.challengers)}`,
+    );
+  }
+  for (let i = 0; i < r.challengers.length; i++) {
+    validateChallengerStatus(r.challengers[i], i);
+  }
+}
+
+function validateClaimerPegoutStatus(value: Record<string, unknown>): void {
+  assertNonEmptyString(value.status, "claimer.status");
+  if (typeof value.failed !== "boolean") {
+    throw new VpResponseValidationError(
+      `VP response validation failed: "claimer.failed" must be a boolean, got ${preview(value.failed)}`,
+    );
+  }
+  assertNonEmptyString(value.claim_txid, "claimer.claim_txid");
+  assertNonEmptyString(value.claimer_pubkey, "claimer.claimer_pubkey");
+  assertNonEmptyString(value.assert_txid, "claimer.assert_txid");
+  // `challenger_pubkey: Option<String>` — null when no challenge yet.
+  if (value.challenger_pubkey !== null && typeof value.challenger_pubkey !== "string") {
+    throw new VpResponseValidationError(
+      `VP response validation failed: "claimer.challenger_pubkey" must be a string or null, got ${preview(value.challenger_pubkey)}`,
+    );
+  }
+  if (typeof value.created_at !== "number") {
+    throw new VpResponseValidationError(
+      `VP response validation failed: "claimer.created_at" must be a number, got ${preview(value.created_at)}`,
+    );
+  }
+  if (typeof value.updated_at !== "number") {
+    throw new VpResponseValidationError(
+      `VP response validation failed: "claimer.updated_at" must be a number, got ${preview(value.updated_at)}`,
+    );
+  }
+}
+
+function validateChallengerStatus(value: unknown, index: number): void {
+  if (value === null || typeof value !== "object") {
+    throw new VpResponseValidationError(
+      `VP response validation failed: "challengers[${index}]" must be an object, got ${preview(value)}`,
+    );
+  }
+  const c = value as Record<string, unknown>;
+  assertNonEmptyString(c.status, `challengers[${index}].status`);
+  assertNonEmptyString(c.claim_txid, `challengers[${index}].claim_txid`);
+  assertNonEmptyString(c.claimer_pubkey, `challengers[${index}].claimer_pubkey`);
+  assertNullableString(c.assert_txid, `challengers[${index}].assert_txid`);
+  assertNullableString(
+    c.challenge_assert_x_txid,
+    `challengers[${index}].challenge_assert_x_txid`,
+  );
+  assertNullableString(
+    c.challenge_assert_y_txid,
+    `challengers[${index}].challenge_assert_y_txid`,
+  );
+  assertNullableString(c.nopayout_txid, `challengers[${index}].nopayout_txid`);
+  if (typeof c.created_at !== "number") {
+    throw new VpResponseValidationError(
+      `VP response validation failed: "challengers[${index}].created_at" must be a number, got ${preview(c.created_at)}`,
+    );
+  }
+  if (typeof c.updated_at !== "number") {
+    throw new VpResponseValidationError(
+      `VP response validation failed: "challengers[${index}].updated_at" must be a number, got ${preview(c.updated_at)}`,
+    );
+  }
+}
+
+function assertNullableString(value: unknown, field: string): void {
+  if (value !== null && typeof value !== "string") {
+    throw new VpResponseValidationError(
+      `VP response validation failed: "${field}" must be a string or null, got ${preview(value)}`,
+    );
+  }
+}
+
+/**
+ * Validate a `batchGetPeginStatus` response. Per-result envelope shape:
+ * `{ pegin_txid, result: GetPeginStatusResponse | null, error: string | null }`.
+ * The inner result (when non-null) is validated via the single-item validator.
+ */
+export function validateBatchGetPeginStatusResponse(
+  response: unknown,
+): asserts response is BatchGetPeginStatusResponse {
+  validateBatchEnvelope(response, "batchGetPeginStatus", (entry) => {
+    if (entry.result !== null) {
+      validateGetPeginStatusResponse(entry.result);
+    }
+  });
+}
+
+/** Validate a `batchGetPegoutStatus` response. Same envelope as peginStatus. */
+export function validateBatchGetPegoutStatusResponse(
+  response: unknown,
+): asserts response is BatchGetPegoutStatusResponse {
+  validateBatchEnvelope(response, "batchGetPegoutStatus", (entry) => {
+    if (entry.result !== null) {
+      validateGetPegoutStatusResponse(entry.result);
+    }
+  });
+}
+
+interface BatchResultEnvelope {
+  pegin_txid: string;
+  result: unknown;
+  error: string | null;
+}
+
+function validateBatchEnvelope(
+  response: unknown,
+  rpcName: string,
+  validateInnerResult: (entry: BatchResultEnvelope, index: number) => void,
+): void {
+  if (response === null || typeof response !== "object") {
+    throw new VpResponseValidationError(
+      `VP response validation failed: ${rpcName} response is not an object`,
+    );
+  }
+  const r = response as Record<string, unknown>;
+  if (!Array.isArray(r.results)) {
+    throw new VpResponseValidationError(
+      `VP response validation failed: "${rpcName}.results" must be an array, got ${preview(r.results)}`,
+    );
+  }
+  for (let i = 0; i < r.results.length; i++) {
+    const entry = r.results[i];
+    if (entry === null || typeof entry !== "object") {
       throw new VpResponseValidationError(
-        `VP response validation failed: "challenger" must be an object if present`,
+        `VP response validation failed: "${rpcName}.results[${i}]" must be an object, got ${preview(entry)}`,
       );
     }
-    const challenger = r.challenger as Record<string, unknown>;
-    if (typeof challenger.status !== "string") {
+    const e = entry as Record<string, unknown>;
+    if (
+      !isNonEmptyHex(e.pegin_txid) ||
+      e.pegin_txid.length !== TXID_HEX_LEN
+    ) {
       throw new VpResponseValidationError(
-        `VP response validation failed: "challenger.status" must be a string, got ${preview(challenger.status)}`,
+        `VP response validation failed: "${rpcName}.results[${i}].pegin_txid" must be a ${TXID_HEX_LEN}-char hex string, got ${preview(e.pegin_txid)}`,
       );
     }
+    if (e.error !== null && typeof e.error !== "string") {
+      throw new VpResponseValidationError(
+        `VP response validation failed: "${rpcName}.results[${i}].error" must be a string or null, got ${preview(e.error)}`,
+      );
+    }
+    // Exactly one of `result` / `error` must be populated. The server only
+    // ever sets one per item; treating both-null as a protocol violation
+    // surfaces server bugs early instead of letting them silently degrade.
+    if (e.result === null && e.error === null) {
+      throw new VpResponseValidationError(
+        `VP response validation failed: "${rpcName}.results[${i}]" has neither "result" nor "error" populated`,
+      );
+    }
+    if (e.result !== null && e.error !== null) {
+      throw new VpResponseValidationError(
+        `VP response validation failed: "${rpcName}.results[${i}]" has both "result" and "error" populated`,
+      );
+    }
+    validateInnerResult(e as unknown as BatchResultEnvelope, i);
   }
 }
 

--- a/packages/babylon-ts-sdk/src/tbv/core/services/pegout/state.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/pegout/state.ts
@@ -1,7 +1,7 @@
 /**
  * Pegout state definitions and protocol-level terminal checks.
  *
- * Maps VP-reported pegout statuses from `vaultProvider_getPegoutStatus`
+ * Maps VP-reported pegout statuses from `vaultProvider_batchGetPegoutStatus`
  * to protocol lifecycle states.
  *
  * Lifecycle:

--- a/services/vault/src/clients/eth-contract/cap-policy/__tests__/query.test.ts
+++ b/services/vault/src/clients/eth-contract/cap-policy/__tests__/query.test.ts
@@ -1,12 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockReadContract = vi.fn();
+const mockMulticall = vi.fn();
 const mockGetChainId = vi.fn();
 
 vi.mock("@/clients/eth-contract/client", () => ({
   ethClient: {
     getPublicClient: () => ({
       readContract: mockReadContract,
+      multicall: mockMulticall,
       getChainId: mockGetChainId,
     }),
   },
@@ -29,6 +31,7 @@ let query: QueryModule;
 
 beforeEach(async () => {
   mockReadContract.mockReset();
+  mockMulticall.mockReset();
   mockGetChainId.mockReset();
   // Reset module registry so the internal CapPolicy address cache starts
   // empty for each test without exposing a test-only reset helper.
@@ -146,22 +149,49 @@ describe("getApplicationUsage", () => {
     expect(userCalls).toHaveLength(0);
   });
 
-  it("returns total and user BTC when a user address is supplied", async () => {
+  it("returns total and user BTC via a single multicall when a user address is supplied", async () => {
     mockGetChainId.mockResolvedValue(11155111);
-    mockReadContract
-      .mockResolvedValueOnce(REGISTRY_CAP_POLICY)
-      .mockResolvedValueOnce(50n)
-      .mockResolvedValueOnce(3n);
+    mockReadContract.mockResolvedValueOnce(REGISTRY_CAP_POLICY);
+    mockMulticall.mockResolvedValueOnce([50n, 3n]);
 
     const usage = await query.getApplicationUsage(APP, USER);
 
     expect(usage).toEqual({ totalBTC: 50n, userBTC: 3n });
-    expect(mockReadContract).toHaveBeenCalledWith(
+    expect(mockMulticall).toHaveBeenCalledTimes(1);
+    expect(mockMulticall).toHaveBeenCalledWith(
       expect.objectContaining({
-        address: REGISTRY_CAP_POLICY,
-        functionName: "getApplicationUserBTC",
-        args: [APP, USER],
+        allowFailure: false,
+        contracts: [
+          expect.objectContaining({
+            address: REGISTRY_CAP_POLICY,
+            functionName: "getApplicationTotalBTC",
+            args: [APP],
+          }),
+          expect.objectContaining({
+            address: REGISTRY_CAP_POLICY,
+            functionName: "getApplicationUserBTC",
+            args: [APP, USER],
+          }),
+        ],
       }),
+    );
+    // No per-read readContract calls for the usage path when user is set.
+    const usageReadContractCalls = mockReadContract.mock.calls.filter(
+      (c) =>
+        c[0].functionName === "getApplicationTotalBTC" ||
+        c[0].functionName === "getApplicationUserBTC",
+    );
+    expect(usageReadContractCalls).toHaveLength(0);
+  });
+
+  it("propagates the multicall error so callers cannot treat a revert as success", async () => {
+    mockGetChainId.mockResolvedValue(11155111);
+    mockReadContract.mockResolvedValueOnce(REGISTRY_CAP_POLICY);
+    const multicallError = new Error("multicall reverted");
+    mockMulticall.mockRejectedValueOnce(multicallError);
+
+    await expect(query.getApplicationUsage(APP, USER)).rejects.toThrow(
+      multicallError,
     );
   });
 });

--- a/services/vault/src/clients/eth-contract/cap-policy/query.ts
+++ b/services/vault/src/clients/eth-contract/cap-policy/query.ts
@@ -104,6 +104,12 @@ export async function getApplicationCap(
 
 /**
  * Read current BTC usage for an application, optionally scoped to a user.
+ *
+ * When a user is provided, the protocol-total and per-user reads are
+ * collapsed into a single multicall round-trip — they target the same
+ * `CapPolicy` contract with no inter-dependency. `allowFailure: false`
+ * preserves the prior throw-on-revert semantics of the two separate
+ * `readContract` calls.
  */
 export async function getApplicationUsage(
   appEntryPoint: Address,
@@ -112,23 +118,33 @@ export async function getApplicationUsage(
   const publicClient = ethClient.getPublicClient();
   const capPolicy = await getCapPolicyAddress();
 
-  const totalBTC = (await publicClient.readContract({
-    address: capPolicy,
-    abi: CapPolicyAbi,
-    functionName: "getApplicationTotalBTC",
-    args: [appEntryPoint],
-  })) as bigint;
-
   if (!user) {
+    const totalBTC = (await publicClient.readContract({
+      address: capPolicy,
+      abi: CapPolicyAbi,
+      functionName: "getApplicationTotalBTC",
+      args: [appEntryPoint],
+    })) as bigint;
     return { totalBTC, userBTC: null };
   }
 
-  const userBTC = (await publicClient.readContract({
-    address: capPolicy,
-    abi: CapPolicyAbi,
-    functionName: "getApplicationUserBTC",
-    args: [appEntryPoint, user],
-  })) as bigint;
+  const [totalBTC, userBTC] = (await publicClient.multicall({
+    contracts: [
+      {
+        address: capPolicy,
+        abi: CapPolicyAbi,
+        functionName: "getApplicationTotalBTC",
+        args: [appEntryPoint],
+      },
+      {
+        address: capPolicy,
+        abi: CapPolicyAbi,
+        functionName: "getApplicationUserBTC",
+        args: [appEntryPoint, user],
+      },
+    ],
+    allowFailure: false,
+  })) as [bigint, bigint];
 
   return { totalBTC, userBTC };
 }

--- a/services/vault/src/components/deposit/__tests__/actionStatus.test.ts
+++ b/services/vault/src/components/deposit/__tests__/actionStatus.test.ts
@@ -11,9 +11,6 @@ function pollingResultWithAction(
 ): DepositPollingResult {
   return {
     depositId,
-    transactions: null,
-    depositorGraph: null,
-    isReady: false,
     loading: false,
     error: null,
     peginState,

--- a/services/vault/src/components/simple/PendingDepositCard.tsx
+++ b/services/vault/src/components/simple/PendingDepositCard.tsx
@@ -53,10 +53,7 @@ export function PendingDepositCard({
 
   if (!pollingResult) return null;
 
-  // `transactions` is destructured for the row-local readiness UX hint
-  // (button label / disabled state below). The signing flow itself no longer
-  // consumes them — the SDK's runDepositorPresignFlow re-polls the VP.
-  const { loading, transactions, peginState } = pollingResult;
+  const { loading, peginState } = pollingResult;
   const status = getActionStatus(pollingResult);
   const isActionable = status.type === "available";
   const showArtifactDownload =
@@ -81,10 +78,11 @@ export function PendingDepositCard({
 
   const actionLabel =
     status.type === "available" ? status.action.label : peginState.displayLabel;
-  // Show "Loading..." only when this row has no transactions snapshot yet —
-  // not on every refetch of the polling query.
-  const label = loading && !transactions ? "Loading..." : actionLabel;
-  const buttonDisabled = !isActionable || (loading && !transactions);
+  // `loading` is React Query's `isLoading` — true only on the very first fetch,
+  // not on subsequent polling refetches — so this gives a one-shot "Loading..."
+  // on initial mount without flickering on every poll cycle.
+  const label = loading ? "Loading..." : actionLabel;
+  const buttonDisabled = !isActionable || loading;
   const dotColor = STATUS_DOT_COLORS[peginState.displayVariant];
 
   // Resolve provider name

--- a/services/vault/src/context/deposit/PeginPollingContext.tsx
+++ b/services/vault/src/context/deposit/PeginPollingContext.tsx
@@ -30,10 +30,7 @@ import type {
   PeginPollingContextValue,
   PeginPollingProviderProps,
 } from "../../types/peginPolling";
-import {
-  areTransactionsReady,
-  isTerminalPollingError,
-} from "../../utils/peginPolling";
+import { isTerminalPollingError } from "../../utils/peginPolling";
 import { isVaultOwnedByWallet } from "../../utils/vaultWarnings";
 
 /**
@@ -93,11 +90,10 @@ export function PeginPollingProvider({
 
   // Use the polling query hook
   const {
-    data,
-    depositorGraphs,
     errors,
     needsWotsKey,
     pendingIngestion,
+    pendingDepositorSignatures,
     isLoading,
     refetch,
   } = usePeginPollingQuery({
@@ -160,9 +156,6 @@ export function PeginPollingProvider({
         pendingPegins,
       );
 
-      const transactions = data?.get(depositId) ?? null;
-      const isReady = transactions ? areTransactionsReady(transactions) : false;
-
       const depositError = errors?.get(depositId);
       const vpTerminalError =
         depositError && isTerminalPollingError(depositError)
@@ -171,7 +164,7 @@ export function PeginPollingProvider({
 
       const peginState = getPeginState(contractStatus, {
         localStatus,
-        transactionsReady: isReady,
+        transactionsReady: pendingDepositorSignatures?.has(depositId) ?? false,
         isInUse: activity.isInUse,
         needsWotsKey: needsWotsKey?.has(depositId),
         pendingIngestion: pendingIngestion?.has(depositId),
@@ -184,9 +177,6 @@ export function PeginPollingProvider({
 
       return {
         depositId,
-        transactions,
-        depositorGraph: depositorGraphs?.get(depositId) ?? null,
-        isReady,
         loading: isLoading,
         error: errors?.get(depositId) ?? null,
         peginState,
@@ -199,8 +189,7 @@ export function PeginPollingProvider({
     [
       activities,
       pendingPegins,
-      data,
-      depositorGraphs,
+      pendingDepositorSignatures,
       errors,
       needsWotsKey,
       pendingIngestion,

--- a/services/vault/src/hooks/__tests__/useVaultDeposits.test.ts
+++ b/services/vault/src/hooks/__tests__/useVaultDeposits.test.ts
@@ -1,0 +1,89 @@
+import { renderHook } from "@testing-library/react";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock,
+} from "vitest";
+
+import { FAST_POLL_INTERVAL, NORMAL_POLL_INTERVAL } from "@/constants";
+
+import { useVaultDeposits } from "../useVaultDeposits";
+
+vi.mock("../useVaults", () => ({
+  useVaults: vi.fn(),
+}));
+vi.mock("../../storage/usePeginStorage", () => ({
+  usePeginStorage: vi.fn(() => ({
+    allActivities: [],
+    pendingPegins: [],
+    addPendingPegin: vi.fn(),
+  })),
+}));
+vi.mock("../../storage/peginStorage", () => ({
+  getPendingPegins: vi.fn(() => []),
+}));
+
+const ADDRESS = "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" as const;
+
+let useVaultsMock: Mock;
+let setIntervalSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  const mod = await import("../useVaults");
+  useVaultsMock = vi.mocked(mod.useVaults) as unknown as Mock;
+  useVaultsMock.mockReturnValue({
+    data: undefined,
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  });
+  setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+});
+
+afterEach(() => {
+  setIntervalSpy.mockRestore();
+});
+
+describe("useVaultDeposits", () => {
+  it("delegates polling to React Query (no manual setInterval timer)", () => {
+    renderHook(() => useVaultDeposits(ADDRESS));
+    // Hook used to spawn a manual setInterval that ran alongside React
+    // Query, bypassing tab-visibility pause and dedup. Confirm that
+    // window-level timer is gone.
+    expect(setIntervalSpy).not.toHaveBeenCalled();
+  });
+
+  it("starts polling at NORMAL_POLL_INTERVAL when no Processing activity exists", () => {
+    renderHook(() => useVaultDeposits(ADDRESS));
+    expect(useVaultsMock).toHaveBeenLastCalledWith(ADDRESS, {
+      poll: true,
+      interval: NORMAL_POLL_INTERVAL,
+    });
+  });
+
+  it("does not enable polling when no wallet is connected", () => {
+    renderHook(() => useVaultDeposits(undefined));
+    // Hook still calls useVaults so React Query can manage the cache;
+    // the underlying query is gated by `enabled: !!depositorAddress`.
+    expect(useVaultsMock).toHaveBeenLastCalledWith(undefined, {
+      poll: true,
+      interval: NORMAL_POLL_INTERVAL,
+    });
+    // Importantly, no setInterval was scheduled regardless.
+    expect(setIntervalSpy).not.toHaveBeenCalled();
+  });
+
+  it("exports the FAST/NORMAL interval constants used as polling cadences", () => {
+    // Sanity check that the constants the hook depends on are wired
+    // through. If FAST_POLL_INTERVAL ever drops below 1s or
+    // NORMAL_POLL_INTERVAL above 5min the polling story changes
+    // materially — surface either as a test signal.
+    expect(FAST_POLL_INTERVAL).toBeGreaterThanOrEqual(1_000);
+    expect(NORMAL_POLL_INTERVAL).toBeLessThanOrEqual(5 * 60_000);
+  });
+});

--- a/services/vault/src/hooks/__tests__/useVaults.test.ts
+++ b/services/vault/src/hooks/__tests__/useVaults.test.ts
@@ -1,0 +1,62 @@
+import { useQuery } from "@tanstack/react-query";
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useVaults } from "../useVaults";
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: vi.fn(),
+}));
+
+vi.mock("../../services/vault/fetchVaults", () => ({
+  fetchVaultsByDepositor: vi.fn(),
+}));
+
+const mockedUseQuery = vi.mocked(useQuery);
+
+const ADDRESS = "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" as const;
+
+function getRefetchInterval(): unknown {
+  const args = mockedUseQuery.mock.calls.at(-1)?.[0];
+  if (!args || typeof args !== "object") return undefined;
+  return (args as { refetchInterval?: unknown }).refetchInterval;
+}
+
+describe("useVaults", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedUseQuery.mockReturnValue({ data: undefined } as never);
+  });
+
+  it("disables polling when poll is false (default)", () => {
+    renderHook(() => useVaults(ADDRESS));
+    expect(getRefetchInterval()).toBe(false);
+  });
+
+  it("disables polling even when interval is supplied if poll is false", () => {
+    renderHook(() => useVaults(ADDRESS, { interval: 30_000 }));
+    expect(getRefetchInterval()).toBe(false);
+  });
+
+  it("uses the default 5s interval when poll is true with no explicit interval", () => {
+    renderHook(() => useVaults(ADDRESS, { poll: true }));
+    expect(getRefetchInterval()).toBe(5_000);
+  });
+
+  it("uses the explicit interval when poll is true", () => {
+    renderHook(() => useVaults(ADDRESS, { poll: true, interval: 60_000 }));
+    expect(getRefetchInterval()).toBe(60_000);
+  });
+
+  it("propagates a new interval to React Query when the prop changes", () => {
+    const { rerender } = renderHook(
+      ({ interval }: { interval: number }) =>
+        useVaults(ADDRESS, { poll: true, interval }),
+      { initialProps: { interval: 15_000 } },
+    );
+    expect(getRefetchInterval()).toBe(15_000);
+
+    rerender({ interval: 60_000 });
+    expect(getRefetchInterval()).toBe(60_000);
+  });
+});

--- a/services/vault/src/hooks/deposit/usePeginPollingQuery.ts
+++ b/services/vault/src/hooks/deposit/usePeginPollingQuery.ts
@@ -1,14 +1,14 @@
 /**
  * Hook for polling peg-in transactions from vault providers
  *
- * Manages the React Query polling loop for fetching claim/payout
- * transactions from all vault providers in parallel.
+ * Manages the React Query polling loop for fetching the per-deposit VP daemon
+ * status. The cheap, unauthenticated `getPeginStatus` RPC is the readiness
+ * signal — once the daemon reports `PendingDepositorSignatures`, the deposit
+ * is marked ready and the heavy auth-gated `requestDepositorPresignTransactions`
+ * is deferred to the actual signing flow (`runDepositorPresignFlow`), which
+ * re-fetches it at click-time.
  */
 
-import type {
-  ClaimerTransactions,
-  DepositorGraphTransactions,
-} from "@babylonlabs-io/ts-sdk/tbv/core/clients";
 import {
   DaemonStatus,
   VP_TRANSIENT_STATUSES,
@@ -32,7 +32,6 @@ import type {
 } from "../../types/peginPolling";
 import { stripHexPrefix } from "../../utils/btc";
 import {
-  areTransactionsReady,
   getDepositsNeedingPolling,
   groupDepositsByProvider,
   isTerminalPollingError,
@@ -47,29 +46,25 @@ interface UsePeginPollingQueryParams {
 
 /** Result from polling query */
 interface PollingQueryData {
-  /** Map of depositId -> transactions */
-  transactions: Map<string, ClaimerTransactions[]>;
-  /** Map of depositId -> depositor graph (depositor-as-claimer) */
-  depositorGraphs: Map<string, DepositorGraphTransactions>;
   /** Map of depositId -> error (for deposits with provider connectivity issues) */
   errors: Map<string, Error>;
   /** Set of depositIds where vault provider needs the depositor's WOTS key */
   needsWotsKey: Set<string>;
   /** Set of depositIds where VP hasn't ingested the peg-in yet */
   pendingIngestion: Set<string>;
+  /** Set of depositIds where VP daemon reports `PendingDepositorSignatures` */
+  pendingDepositorSignatures: Set<string>;
 }
 
 interface UsePeginPollingQueryResult {
-  /** Map of depositId -> transactions */
-  data: Map<string, ClaimerTransactions[]> | undefined;
-  /** Map of depositId -> depositor graph */
-  depositorGraphs: Map<string, DepositorGraphTransactions> | undefined;
   /** Map of depositId -> error */
   errors: Map<string, Error> | undefined;
   /** Set of depositIds needing WOTS key submission */
   needsWotsKey: Set<string> | undefined;
   /** Set of depositIds where VP hasn't ingested the peg-in yet */
   pendingIngestion: Set<string> | undefined;
+  /** Set of depositIds where VP is ready for depositor presignatures */
+  pendingDepositorSignatures: Set<string> | undefined;
   /** Whether any polling is in progress */
   isLoading: boolean;
   /** Trigger manual refetch */
@@ -79,20 +74,19 @@ interface UsePeginPollingQueryResult {
 }
 
 /**
- * Fetch status and transactions from a single vault provider for multiple deposits.
+ * Fetch status from a single vault provider for multiple deposits.
  *
- * Uses the lightweight `getPeginStatus` RPC first, then only calls
- * `requestDepositorPresignTransactions` when the VP is in the right state.
+ * Uses only the lightweight, unauthenticated `getPeginStatus` RPC. The actual
+ * presign transaction payload is fetched at signing time by the SDK's
+ * `runDepositorPresignFlow`.
  */
 async function fetchFromProvider(
   providerAddress: string,
   deposits: DepositToPoll[],
-  btcPublicKey: string,
-  results: Map<string, ClaimerTransactions[]>,
-  depositorGraphs: Map<string, DepositorGraphTransactions>,
   errors: Map<string, Error>,
   needsWotsKey: Set<string>,
   pendingIngestion: Set<string>,
+  pendingDepositorSignatures: Set<string>,
 ): Promise<void> {
   const rpcClient = createVpClient(providerAddress);
 
@@ -101,7 +95,6 @@ async function fetchFromProvider(
     const strippedTxid = stripHexPrefix(deposit.activity.peginTxHash!);
 
     try {
-      // Phase 1: Lightweight status check
       const statusResponse = await rpcClient.getPeginStatus({
         pegin_txid: strippedTxid,
       });
@@ -145,17 +138,12 @@ async function fetchFromProvider(
         continue;
       }
 
-      // Phase 2: Status is PendingDepositorSignatures — fetch transaction data
+      // VP daemon reached the depositor-signing state. The status alone is
+      // a sufficient readiness signal — the daemon only enters this state
+      // after `all_presigning_phases_complete`, so the depositor-presign RPC
+      // is guaranteed to succeed when the user clicks Sign Payouts.
       if (status === DaemonStatus.PENDING_DEPOSITOR_SIGNATURES) {
-        const response = await rpcClient.requestDepositorPresignTransactions({
-          pegin_txid: strippedTxid,
-          depositor_pk: btcPublicKey,
-        });
-
-        if (response.txs && response.txs.length > 0) {
-          results.set(depositId, response.txs);
-        }
-        depositorGraphs.set(depositId, response.depositor_graph);
+        pendingDepositorSignatures.add(depositId);
         errors.delete(depositId);
         needsWotsKey.delete(depositId);
         continue;
@@ -232,22 +220,20 @@ export function usePeginPollingQuery({
 
       if (!currentBtcPubKey || currentDeposits.length === 0) {
         return {
-          transactions: new Map<string, ClaimerTransactions[]>(),
-          depositorGraphs: new Map<string, DepositorGraphTransactions>(),
           errors: new Map<string, Error>(),
           needsWotsKey: new Set<string>(),
           pendingIngestion: new Set<string>(),
+          pendingDepositorSignatures: new Set<string>(),
         };
       }
 
       // Group by provider using current values
       const depositsByProvider = groupDepositsByProvider(currentDeposits);
 
-      const transactions = new Map<string, ClaimerTransactions[]>();
-      const depositorGraphs = new Map<string, DepositorGraphTransactions>();
       const errors = new Map<string, Error>();
       const needsWotsKey = new Set<string>();
       const pendingIngestion = new Set<string>();
+      const pendingDepositorSignatures = new Set<string>();
 
       // Fetch from each provider in parallel
       const fetchPromises = Array.from(depositsByProvider.entries()).map(
@@ -255,22 +241,19 @@ export function usePeginPollingQuery({
           fetchFromProvider(
             providerAddress,
             deposits,
-            currentBtcPubKey,
-            transactions,
-            depositorGraphs,
             errors,
             needsWotsKey,
             pendingIngestion,
+            pendingDepositorSignatures,
           ),
       );
 
       await Promise.all(fetchPromises);
       return {
-        transactions,
-        depositorGraphs,
         errors,
         needsWotsKey,
         pendingIngestion,
+        pendingDepositorSignatures,
       };
     },
     enabled: isEnabled,
@@ -279,15 +262,15 @@ export function usePeginPollingQuery({
       const currentDeposits = depositsRef.current;
       if (currentDeposits.length === 0) return false;
 
-      const txMap = query.state.data?.transactions;
+      const readySet = query.state.data?.pendingDepositorSignatures;
       const errorMap = query.state.data?.errors;
 
       // Stop polling only when every deposit is resolved:
-      // either has ready transactions or hit a terminal error.
+      // either reached the depositor-signing state (VP has presign txs ready)
+      // or hit a terminal error.
       const allResolved = currentDeposits.every((d) => {
         const depositId = d.activity.id;
-        const txs = txMap?.get(depositId);
-        if (txs && areTransactionsReady(txs)) return true;
+        if (readySet?.has(depositId)) return true;
         const error = errorMap?.get(depositId);
         if (error && isTerminalPollingError(error)) return true;
         return false;
@@ -312,11 +295,10 @@ export function usePeginPollingQuery({
   }, [isEnabled, refetch]);
 
   return {
-    data: data?.transactions,
-    depositorGraphs: data?.depositorGraphs,
     errors: data?.errors,
     needsWotsKey: data?.needsWotsKey,
     pendingIngestion: data?.pendingIngestion,
+    pendingDepositorSignatures: data?.pendingDepositorSignatures,
     isLoading,
     refetch,
     depositsToPoll,

--- a/services/vault/src/hooks/deposit/usePeginPollingQuery.ts
+++ b/services/vault/src/hooks/deposit/usePeginPollingQuery.ts
@@ -9,8 +9,11 @@
  * re-fetches it at click-time.
  */
 
+import type { GetPeginStatusResponse } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
 import {
+  attributeBatchResults,
   DaemonStatus,
+  VP_BATCH_MAX_SIZE,
   VP_TRANSIENT_STATUSES,
   VpResponseValidationError,
 } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
@@ -74,10 +77,11 @@ interface UsePeginPollingQueryResult {
 }
 
 /**
- * Fetch status from a single vault provider for multiple deposits.
+ * Fetch status from a single vault provider for many deposits in one
+ * `batchGetPeginStatus` round trip per chunk of `VP_BATCH_MAX_SIZE`.
  *
- * Uses only the lightweight, unauthenticated `getPeginStatus` RPC. The actual
- * presign transaction payload is fetched at signing time by the SDK's
+ * Uses only the lightweight, unauthenticated `batchGetPeginStatus` RPC.
+ * The presign transaction payload is fetched at signing time by the SDK's
  * `runDepositorPresignFlow`.
  */
 async function fetchFromProvider(
@@ -90,89 +94,197 @@ async function fetchFromProvider(
 ): Promise<void> {
   const rpcClient = createVpClient(providerAddress);
 
-  for (const deposit of deposits) {
-    const depositId = deposit.activity.id;
-    const strippedTxid = stripHexPrefix(deposit.activity.peginTxHash!);
+  // Index the chunked deposits by lowercased txid so per-result attribution
+  // never relies on response ordering.
+  for (let i = 0; i < deposits.length; i += VP_BATCH_MAX_SIZE) {
+    const chunk = deposits.slice(i, i + VP_BATCH_MAX_SIZE);
+    const txidToDeposit = new Map<string, DepositToPoll>();
+    const txids: string[] = [];
+    for (const deposit of chunk) {
+      const lowerTxid = stripHexPrefix(
+        deposit.activity.peginTxHash!,
+      ).toLowerCase();
+      txidToDeposit.set(lowerTxid, deposit);
+      txids.push(lowerTxid);
+    }
 
+    let attribution;
     try {
-      const statusResponse = await rpcClient.getPeginStatus({
-        pegin_txid: strippedTxid,
+      const response = await rpcClient.batchGetPeginStatus({
+        pegin_txids: txids,
       });
-
-      const status = statusResponse.status;
-
-      if (status === DaemonStatus.PENDING_DEPOSITOR_WOTS_PK) {
-        needsWotsKey.add(depositId);
-        errors.delete(depositId);
-        continue;
-      }
-
-      if (status === DaemonStatus.PENDING_INGESTION) {
-        pendingIngestion.add(depositId);
-        errors.delete(depositId);
-        needsWotsKey.delete(depositId);
-        continue;
-      }
-
-      if (VP_TRANSIENT_STATUSES.has(status as DaemonStatus)) {
-        errors.delete(depositId);
-        needsWotsKey.delete(depositId);
-        continue;
-      }
-
-      if (status === DaemonStatus.EXPIRED) {
-        errors.set(depositId, new Error("Deposit expired"));
-        needsWotsKey.delete(depositId);
-        continue;
-      }
-
-      if (status === DaemonStatus.CLAIM_POSTED) {
-        errors.set(depositId, new Error("Claim transaction posted"));
-        needsWotsKey.delete(depositId);
-        continue;
-      }
-
-      if (status === DaemonStatus.PEGGED_OUT) {
-        errors.set(depositId, new Error("BTC has been returned to depositor"));
-        needsWotsKey.delete(depositId);
-        continue;
-      }
-
-      // VP daemon reached the depositor-signing state. The status alone is
-      // a sufficient readiness signal — the daemon only enters this state
-      // after `all_presigning_phases_complete`, so the depositor-presign RPC
-      // is guaranteed to succeed when the user clicks Sign Payouts.
-      if (status === DaemonStatus.PENDING_DEPOSITOR_SIGNATURES) {
-        pendingDepositorSignatures.add(depositId);
-        errors.delete(depositId);
-        needsWotsKey.delete(depositId);
-        continue;
-      }
-
-      // Transient VP status — clear errors, keep polling
-      errors.delete(depositId);
-      needsWotsKey.delete(depositId);
+      attribution = attributeBatchResults<GetPeginStatusResponse>(
+        txids,
+        response.results,
+      );
     } catch (error) {
-      // "PegIn not found" — VP hasn't ingested yet, keep polling
-      if (error instanceof Error && error.message.includes("PegIn not found")) {
-        errors.delete(depositId);
-        needsWotsKey.delete(depositId);
-        pendingIngestion.add(depositId);
-        continue;
-      }
-
+      // Whole-batch failure: every deposit in the chunk gets the same error.
+      // Mirrors the prior per-deposit catch behaviour, just shared across
+      // the batch.
       const errorObj =
         error instanceof Error ? error : new Error("Provider unreachable");
-      errors.set(depositId, errorObj);
-      logger.warn(`Failed to poll deposit ${depositId}`, {
-        error:
-          error instanceof VpResponseValidationError
-            ? error.detail
-            : error instanceof Error
-              ? error.message
-              : String(error),
+      const detail =
+        error instanceof VpResponseValidationError
+          ? error.detail
+          : errorObj.message;
+      logger.warn(
+        `Failed to poll ${chunk.length} deposit(s) from VP ${providerAddress}`,
+        { error: detail },
+      );
+      for (const deposit of chunk) {
+        errors.set(deposit.activity.id, errorObj);
+      }
+      continue;
+    }
+
+    if (attribution.unexpected.length > 0) {
+      logger.warn(
+        `VP ${providerAddress} returned ${attribution.unexpected.length} unexpected pegin txid(s); ignoring`,
+      );
+    }
+
+    // Missing or duplicated entries indicate a server protocol violation.
+    // Surface them as per-deposit errors so the affected rows show a
+    // failure state instead of silently retaining stale data.
+    const duplicateTxids = new Set(attribution.duplicate);
+    if (duplicateTxids.size > 0) {
+      logger.warn(
+        `VP ${providerAddress} returned ${duplicateTxids.size} duplicate pegin txid(s); marking those deposits errored`,
+      );
+      for (const txid of duplicateTxids) {
+        const deposit = txidToDeposit.get(txid);
+        if (deposit) {
+          errors.set(
+            deposit.activity.id,
+            new Error("Provider returned duplicate status entry"),
+          );
+        }
+      }
+    }
+    for (const txid of attribution.missing) {
+      const deposit = txidToDeposit.get(txid);
+      if (deposit) {
+        errors.set(
+          deposit.activity.id,
+          new Error("Provider omitted status entry"),
+        );
+      }
+    }
+
+    for (const [txid, envelope] of attribution.byTxid) {
+      // Skip txids that the server duplicated — already marked errored
+      // above. Re-processing the first envelope here would silently
+      // overwrite that error.
+      if (duplicateTxids.has(txid)) continue;
+
+      const deposit = txidToDeposit.get(txid);
+      if (!deposit) continue;
+      const depositId = deposit.activity.id;
+
+      if (envelope.error !== null) {
+        // Per-pegin errors are surfaced in logs even when other items in
+        // the same batch succeed, mirroring the prior single-pegin
+        // try/catch behaviour. "PegIn not found" is a routine pre-ingest
+        // signal, not a fault — skip the warn for that case.
+        if (!envelope.error.includes("PegIn not found")) {
+          logger.warn(`Failed to poll deposit ${depositId}`, {
+            error: envelope.error,
+          });
+        }
+        applyPerDepositError(envelope.error, depositId, {
+          errors,
+          needsWotsKey,
+          pendingIngestion,
+        });
+        continue;
+      }
+
+      // envelope.error === null && envelope.result !== null — guaranteed by
+      // the SDK validator (rejects both-null / both-present envelopes).
+      applyPerDepositStatus(envelope.result!, depositId, {
+        errors,
+        needsWotsKey,
+        pendingIngestion,
+        pendingDepositorSignatures,
       });
     }
+  }
+}
+
+interface DepositSets {
+  errors: Map<string, Error>;
+  needsWotsKey: Set<string>;
+  pendingIngestion: Set<string>;
+}
+
+function applyPerDepositError(
+  errorMessage: string,
+  depositId: string,
+  sets: DepositSets,
+): void {
+  // "PegIn not found" — VP hasn't ingested yet, treat as still-pending.
+  if (errorMessage.includes("PegIn not found")) {
+    sets.errors.delete(depositId);
+    sets.needsWotsKey.delete(depositId);
+    sets.pendingIngestion.add(depositId);
+    return;
+  }
+  sets.errors.set(depositId, new Error(errorMessage));
+}
+
+function applyPerDepositStatus(
+  statusResponse: GetPeginStatusResponse,
+  depositId: string,
+  sets: DepositSets & { pendingDepositorSignatures: Set<string> },
+): void {
+  const status = statusResponse.status;
+
+  if (status === DaemonStatus.PENDING_DEPOSITOR_WOTS_PK) {
+    sets.needsWotsKey.add(depositId);
+    sets.errors.delete(depositId);
+    return;
+  }
+
+  if (status === DaemonStatus.PENDING_INGESTION) {
+    sets.pendingIngestion.add(depositId);
+    sets.errors.delete(depositId);
+    sets.needsWotsKey.delete(depositId);
+    return;
+  }
+
+  if (VP_TRANSIENT_STATUSES.has(status as DaemonStatus)) {
+    sets.errors.delete(depositId);
+    sets.needsWotsKey.delete(depositId);
+    return;
+  }
+
+  if (status === DaemonStatus.EXPIRED) {
+    sets.errors.set(depositId, new Error("Deposit expired"));
+    sets.needsWotsKey.delete(depositId);
+    return;
+  }
+
+  if (status === DaemonStatus.CLAIM_POSTED) {
+    sets.errors.set(depositId, new Error("Claim transaction posted"));
+    sets.needsWotsKey.delete(depositId);
+    return;
+  }
+
+  if (status === DaemonStatus.PEGGED_OUT) {
+    sets.errors.set(depositId, new Error("BTC has been returned to depositor"));
+    sets.needsWotsKey.delete(depositId);
+    return;
+  }
+
+  // VP daemon reached the depositor-signing state. The status alone is
+  // a sufficient readiness signal — the daemon only enters this state
+  // after `all_presigning_phases_complete`, so the depositor-presign RPC
+  // is guaranteed to succeed when the user clicks Sign Payouts.
+  if (status === DaemonStatus.PENDING_DEPOSITOR_SIGNATURES) {
+    sets.pendingDepositorSignatures.add(depositId);
+    sets.errors.delete(depositId);
+    sets.needsWotsKey.delete(depositId);
+    return;
   }
 }
 

--- a/services/vault/src/hooks/deposit/usePeginPollingQuery.ts
+++ b/services/vault/src/hooks/deposit/usePeginPollingQuery.ts
@@ -11,9 +11,8 @@
 
 import type { GetPeginStatusResponse } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
 import {
-  attributeBatchResults,
+  batchPollByProvider,
   DaemonStatus,
-  VP_BATCH_MAX_SIZE,
   VP_TRANSIENT_STATUSES,
   VpResponseValidationError,
 } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
@@ -77,12 +76,13 @@ interface UsePeginPollingQueryResult {
 }
 
 /**
- * Fetch status from a single vault provider for many deposits in one
- * `batchGetPeginStatus` round trip per chunk of `VP_BATCH_MAX_SIZE`.
+ * Fetch status from a single vault provider via `batchGetPeginStatus`,
+ * chunked at `VP_BATCH_MAX_SIZE`. Defensive attribution + duplicate-skip
+ * + per-item dispatch live in the SDK's `batchPollByProvider`; this
+ * function only declares the per-item handlers.
  *
- * Uses only the lightweight, unauthenticated `batchGetPeginStatus` RPC.
- * The presign transaction payload is fetched at signing time by the SDK's
- * `runDepositorPresignFlow`.
+ * Unauthenticated RPC. The presign transaction payload is fetched at
+ * signing time by the SDK's `runDepositorPresignFlow`.
  */
 async function fetchFromProvider(
   providerAddress: string,
@@ -93,34 +93,49 @@ async function fetchFromProvider(
   pendingDepositorSignatures: Set<string>,
 ): Promise<void> {
   const rpcClient = createVpClient(providerAddress);
-
-  // Index the chunked deposits by lowercased txid so per-result attribution
-  // never relies on response ordering.
-  for (let i = 0; i < deposits.length; i += VP_BATCH_MAX_SIZE) {
-    const chunk = deposits.slice(i, i + VP_BATCH_MAX_SIZE);
-    const txidToDeposit = new Map<string, DepositToPoll>();
-    const txids: string[] = [];
-    for (const deposit of chunk) {
-      const lowerTxid = stripHexPrefix(
-        deposit.activity.peginTxHash!,
-      ).toLowerCase();
-      txidToDeposit.set(lowerTxid, deposit);
-      txids.push(lowerTxid);
-    }
-
-    let attribution;
-    try {
-      const response = await rpcClient.batchGetPeginStatus({
-        pegin_txids: txids,
+  await batchPollByProvider<DepositToPoll, GetPeginStatusResponse>({
+    items: deposits,
+    getTxid: (deposit) => stripHexPrefix(deposit.activity.peginTxHash!),
+    batchCall: (pegin_txids) => rpcClient.batchGetPeginStatus({ pegin_txids }),
+    onItem: (deposit, envelope) => {
+      const depositId = deposit.activity.id;
+      if (envelope.error !== null) {
+        // "PegIn not found" is a routine pre-ingest signal, not a fault.
+        if (!envelope.error.includes("PegIn not found")) {
+          logger.warn(`Failed to poll deposit ${depositId}`, {
+            error: envelope.error,
+          });
+        }
+        applyPerDepositError(envelope.error, depositId, {
+          errors,
+          needsWotsKey,
+          pendingIngestion,
+        });
+        return;
+      }
+      // envelope.result is non-null here by the validator's XOR invariant.
+      applyPerDepositStatus(envelope.result!, depositId, {
+        errors,
+        needsWotsKey,
+        pendingIngestion,
+        pendingDepositorSignatures,
       });
-      attribution = attributeBatchResults<GetPeginStatusResponse>(
-        txids,
-        response.results,
-      );
-    } catch (error) {
-      // Whole-batch failure: every deposit in the chunk gets the same error.
-      // Mirrors the prior per-deposit catch behaviour, just shared across
-      // the batch.
+    },
+    onMissing: (deposit) =>
+      errors.set(
+        deposit.activity.id,
+        new Error("Provider omitted status entry"),
+      ),
+    onDuplicate: (deposit) =>
+      errors.set(
+        deposit.activity.id,
+        new Error("Provider returned duplicate status entry"),
+      ),
+    onDuplicateBatch: (count) =>
+      logger.warn(
+        `VP ${providerAddress} returned ${count} duplicate pegin txid(s); marking those deposits errored`,
+      ),
+    onWholeBatchError: (chunk, error) => {
       const errorObj =
         error instanceof Error ? error : new Error("Provider unreachable");
       const detail =
@@ -134,81 +149,12 @@ async function fetchFromProvider(
       for (const deposit of chunk) {
         errors.set(deposit.activity.id, errorObj);
       }
-      continue;
-    }
-
-    if (attribution.unexpected.length > 0) {
+    },
+    onUnexpected: (echoed) =>
       logger.warn(
-        `VP ${providerAddress} returned ${attribution.unexpected.length} unexpected pegin txid(s); ignoring`,
-      );
-    }
-
-    // Missing or duplicated entries indicate a server protocol violation.
-    // Surface them as per-deposit errors so the affected rows show a
-    // failure state instead of silently retaining stale data.
-    const duplicateTxids = new Set(attribution.duplicate);
-    if (duplicateTxids.size > 0) {
-      logger.warn(
-        `VP ${providerAddress} returned ${duplicateTxids.size} duplicate pegin txid(s); marking those deposits errored`,
-      );
-      for (const txid of duplicateTxids) {
-        const deposit = txidToDeposit.get(txid);
-        if (deposit) {
-          errors.set(
-            deposit.activity.id,
-            new Error("Provider returned duplicate status entry"),
-          );
-        }
-      }
-    }
-    for (const txid of attribution.missing) {
-      const deposit = txidToDeposit.get(txid);
-      if (deposit) {
-        errors.set(
-          deposit.activity.id,
-          new Error("Provider omitted status entry"),
-        );
-      }
-    }
-
-    for (const [txid, envelope] of attribution.byTxid) {
-      // Skip txids that the server duplicated — already marked errored
-      // above. Re-processing the first envelope here would silently
-      // overwrite that error.
-      if (duplicateTxids.has(txid)) continue;
-
-      const deposit = txidToDeposit.get(txid);
-      if (!deposit) continue;
-      const depositId = deposit.activity.id;
-
-      if (envelope.error !== null) {
-        // Per-pegin errors are surfaced in logs even when other items in
-        // the same batch succeed, mirroring the prior single-pegin
-        // try/catch behaviour. "PegIn not found" is a routine pre-ingest
-        // signal, not a fault — skip the warn for that case.
-        if (!envelope.error.includes("PegIn not found")) {
-          logger.warn(`Failed to poll deposit ${depositId}`, {
-            error: envelope.error,
-          });
-        }
-        applyPerDepositError(envelope.error, depositId, {
-          errors,
-          needsWotsKey,
-          pendingIngestion,
-        });
-        continue;
-      }
-
-      // envelope.error === null && envelope.result !== null — guaranteed by
-      // the SDK validator (rejects both-null / both-present envelopes).
-      applyPerDepositStatus(envelope.result!, depositId, {
-        errors,
-        needsWotsKey,
-        pendingIngestion,
-        pendingDepositorSignatures,
-      });
-    }
-  }
+        `VP ${providerAddress} returned ${echoed.length} unexpected pegin txid(s); ignoring`,
+      ),
+  });
 }
 
 interface DepositSets {

--- a/services/vault/src/hooks/useApplicationCap.ts
+++ b/services/vault/src/hooks/useApplicationCap.ts
@@ -47,13 +47,22 @@ export function useApplicationCap(user?: string): UseApplicationCapResult {
     enabled,
   });
 
+  // Usage RPCs are skipped for uncapped deployments — the snapshot logic below
+  // ignores usage data when both cap parameters are 0 (CapPolicy.sol treats
+  // 0 as unlimited), so polling them is pure waste. Gating on caps being
+  // resolved AND non-zero adds one cap-RTT of latency for capped deployments
+  // on first load, but eliminates the polling stream entirely when uncapped.
+  const isCapped =
+    capsQuery.data !== undefined &&
+    (capsQuery.data.totalCapBTC > 0n || capsQuery.data.perAddressCapBTC > 0n);
+
   const usageQuery = useQuery({
     queryKey: [APPLICATION_CAP_KEY, "usage", app, userAddress ?? null],
     queryFn: () => getApplicationUsage(app, userAddress),
     staleTime: CAP_STALE_TIME_MS,
     refetchInterval: CAP_REFETCH_INTERVAL_MS,
     refetchOnWindowFocus: false,
-    enabled,
+    enabled: enabled && isCapped,
   });
 
   const snapshot = useMemo<CapSnapshot | null>(() => {

--- a/services/vault/src/hooks/usePegoutPolling.ts
+++ b/services/vault/src/hooks/usePegoutPolling.ts
@@ -9,8 +9,7 @@
  */
 
 import {
-  attributeBatchResults,
-  VP_BATCH_MAX_SIZE,
+  batchPollByProvider,
   VpResponseValidationError,
   type GetPegoutStatusResponse,
 } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
@@ -93,27 +92,30 @@ async function fetchPegoutStatusesFromProvider(
   counters: VaultPollCounters,
 ): Promise<void> {
   const rpcClient = createVpClient(providerAddress);
-
-  for (let i = 0; i < vaults.length; i += VP_BATCH_MAX_SIZE) {
-    const chunk = vaults.slice(i, i + VP_BATCH_MAX_SIZE);
-    const txidToVault = new Map<string, VaultToPoll>();
-    const txids: string[] = [];
-    for (const entry of chunk) {
-      const lowerTxid = stripHexPrefix(entry.vault.peginTxHash).toLowerCase();
-      txidToVault.set(lowerTxid, entry);
-      txids.push(lowerTxid);
-    }
-
-    let attribution;
-    try {
-      const response = await rpcClient.batchGetPegoutStatus({
-        pegin_txids: txids,
-      });
-      attribution = attributeBatchResults<GetPegoutStatusResponse>(
-        txids,
-        response.results,
-      );
-    } catch (error) {
+  await batchPollByProvider<VaultToPoll, GetPegoutStatusResponse>({
+    items: vaults,
+    getTxid: (entry) => stripHexPrefix(entry.vault.peginTxHash),
+    batchCall: (pegin_txids) => rpcClient.batchGetPegoutStatus({ pegin_txids }),
+    onItem: (entry, envelope) => {
+      const vaultId = entry.vault.id;
+      if (envelope.error !== null) {
+        logger.warn(`Failed to poll pegout status for ${vaultId}`, {
+          data: { error: envelope.error },
+        });
+        applyPegoutFailure(vaultId, results, counters);
+        return;
+      }
+      // envelope.result is non-null here by the validator's XOR invariant.
+      applyPegoutResult(vaultId, envelope.result!, results, counters);
+    },
+    onMissing: (entry) => applyPegoutFailure(entry.vault.id, results, counters),
+    onDuplicate: (entry) =>
+      applyPegoutFailure(entry.vault.id, results, counters),
+    onDuplicateBatch: (count) =>
+      logger.warn(
+        `VP ${providerAddress} returned ${count} duplicate pegout txid(s); marking those vaults as failed`,
+      ),
+    onWholeBatchError: (chunk, error) => {
       const message = error instanceof Error ? error.message : String(error);
       const detail =
         error instanceof VpResponseValidationError ? error.detail : message;
@@ -124,52 +126,12 @@ async function fetchPegoutStatusesFromProvider(
       for (const { vault } of chunk) {
         applyPegoutFailure(vault.id, results, counters);
       }
-      continue;
-    }
-
-    if (attribution.unexpected.length > 0) {
+    },
+    onUnexpected: (echoed) =>
       logger.warn(
-        `VP ${providerAddress} returned ${attribution.unexpected.length} unexpected pegout txid(s); ignoring`,
-      );
-    }
-    const duplicateTxids = new Set(attribution.duplicate);
-    if (duplicateTxids.size > 0) {
-      logger.warn(
-        `VP ${providerAddress} returned ${duplicateTxids.size} duplicate pegout txid(s); marking those vaults as failed`,
-      );
-      for (const txid of duplicateTxids) {
-        const entry = txidToVault.get(txid);
-        if (entry) applyPegoutFailure(entry.vault.id, results, counters);
-      }
-    }
-    for (const txid of attribution.missing) {
-      const entry = txidToVault.get(txid);
-      if (entry) applyPegoutFailure(entry.vault.id, results, counters);
-    }
-
-    for (const [txid, envelope] of attribution.byTxid) {
-      // Skip txids that the server duplicated — already marked failed
-      // above. Re-processing the first envelope would silently overwrite
-      // that failure (and reset failureCounts via applyPegoutResult).
-      if (duplicateTxids.has(txid)) continue;
-
-      const entry = txidToVault.get(txid);
-      if (!entry) continue;
-      const vaultId = entry.vault.id;
-
-      if (envelope.error !== null) {
-        logger.warn(`Failed to poll pegout status for ${vaultId}`, {
-          data: { error: envelope.error },
-        });
-        applyPegoutFailure(vaultId, results, counters);
-        continue;
-      }
-
-      // envelope.error === null && envelope.result !== null — guaranteed by
-      // the SDK validator (rejects both-null / both-present envelopes).
-      applyPegoutResult(vaultId, envelope.result!, results, counters);
-    }
-  }
+        `VP ${providerAddress} returned ${echoed.length} unexpected pegout txid(s); ignoring`,
+      ),
+  });
 }
 
 function applyPegoutFailure(

--- a/services/vault/src/hooks/usePegoutPolling.ts
+++ b/services/vault/src/hooks/usePegoutPolling.ts
@@ -1,13 +1,19 @@
 /**
  * Hook for polling pegout status from vault providers.
  *
- * Polls `vaultProvider_getPegoutStatus` for each redeemed vault,
- * batching requests by vault provider. Stops polling when all
- * vaults reach a terminal status (PayoutBroadcast or Failed) or
- * exceed consecutive failure / unknown-status thresholds.
+ * Issues one `vaultProvider_batchGetPegoutStatus` per provider per cycle
+ * (chunked at `VP_BATCH_MAX_SIZE`), grouping redeemed vaults by their
+ * vault provider. Stops polling when all vaults reach a terminal status
+ * (PayoutBroadcast or Failed) or exceed consecutive failure /
+ * unknown-status thresholds.
  */
 
-import { type GetPegoutStatusResponse } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
+import {
+  attributeBatchResults,
+  VP_BATCH_MAX_SIZE,
+  VpResponseValidationError,
+  type GetPegoutStatusResponse,
+} from "@babylonlabs-io/ts-sdk/tbv/core/clients";
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { useEffect, useMemo, useRef } from "react";
 
@@ -88,57 +94,134 @@ async function fetchPegoutStatusesFromProvider(
 ): Promise<void> {
   const rpcClient = createVpClient(providerAddress);
 
-  for (const { vault } of vaults) {
+  for (let i = 0; i < vaults.length; i += VP_BATCH_MAX_SIZE) {
+    const chunk = vaults.slice(i, i + VP_BATCH_MAX_SIZE);
+    const txidToVault = new Map<string, VaultToPoll>();
+    const txids: string[] = [];
+    for (const entry of chunk) {
+      const lowerTxid = stripHexPrefix(entry.vault.peginTxHash).toLowerCase();
+      txidToVault.set(lowerTxid, entry);
+      txids.push(lowerTxid);
+    }
+
+    let attribution;
     try {
-      const response = await rpcClient.getPegoutStatus({
-        pegin_txid: stripHexPrefix(vault.peginTxHash),
+      const response = await rpcClient.batchGetPegoutStatus({
+        pegin_txids: txids,
       });
-
-      const claimerStatus = response.claimer?.status;
-
-      // Reset failure counter on successful RPC call
-      counters.failureCounts.set(vault.id, 0);
-
-      if (!claimerStatus || !isRecognizedPegoutStatus(claimerStatus)) {
-        const prevUnknown = counters.unknownCounts.get(vault.id) ?? 0;
-        const newUnknown = prevUnknown + 1;
-        counters.unknownCounts.set(vault.id, newUnknown);
-
-        if (newUnknown >= PEGOUT_MAX_UNKNOWN_STATUS_POLLS) {
-          logger.warn(
-            `Pegout polling for ${vault.id} timed out after ${newUnknown} consecutive unknown status polls (last status: "${claimerStatus ?? ""}")`,
-          );
-          results.set(vault.id, { displayState: TIMED_OUT_STATE, response });
-          continue;
-        }
-      } else {
-        counters.unknownCounts.set(vault.id, 0);
-      }
-
-      const displayState = getPegoutDisplayState(claimerStatus, response.found);
-
-      results.set(vault.id, { displayState, response });
+      attribution = attributeBatchResults<GetPegoutStatusResponse>(
+        txids,
+        response.results,
+      );
     } catch (error) {
-      logger.warn(`Failed to poll pegout status for ${vault.id}`, {
-        data: { error: error instanceof Error ? error.message : String(error) },
-      });
+      const message = error instanceof Error ? error.message : String(error);
+      const detail =
+        error instanceof VpResponseValidationError ? error.detail : message;
+      logger.warn(
+        `Failed to poll ${chunk.length} pegout(s) from VP ${providerAddress}`,
+        { data: { error: detail } },
+      );
+      for (const { vault } of chunk) {
+        applyPegoutFailure(vault.id, results, counters);
+      }
+      continue;
+    }
 
-      const prevFailures = counters.failureCounts.get(vault.id) ?? 0;
-      const newFailures = prevFailures + 1;
-      counters.failureCounts.set(vault.id, newFailures);
-
-      if (newFailures >= PEGOUT_MAX_CONSECUTIVE_FAILURES) {
-        logger.warn(
-          `Pegout polling for ${vault.id} timed out after ${newFailures} consecutive failures`,
-        );
-        results.set(vault.id, { displayState: TIMED_OUT_STATE });
-      } else {
-        results.set(vault.id, {
-          displayState: getPegoutDisplayState(undefined, false),
-        });
+    if (attribution.unexpected.length > 0) {
+      logger.warn(
+        `VP ${providerAddress} returned ${attribution.unexpected.length} unexpected pegout txid(s); ignoring`,
+      );
+    }
+    const duplicateTxids = new Set(attribution.duplicate);
+    if (duplicateTxids.size > 0) {
+      logger.warn(
+        `VP ${providerAddress} returned ${duplicateTxids.size} duplicate pegout txid(s); marking those vaults as failed`,
+      );
+      for (const txid of duplicateTxids) {
+        const entry = txidToVault.get(txid);
+        if (entry) applyPegoutFailure(entry.vault.id, results, counters);
       }
     }
+    for (const txid of attribution.missing) {
+      const entry = txidToVault.get(txid);
+      if (entry) applyPegoutFailure(entry.vault.id, results, counters);
+    }
+
+    for (const [txid, envelope] of attribution.byTxid) {
+      // Skip txids that the server duplicated — already marked failed
+      // above. Re-processing the first envelope would silently overwrite
+      // that failure (and reset failureCounts via applyPegoutResult).
+      if (duplicateTxids.has(txid)) continue;
+
+      const entry = txidToVault.get(txid);
+      if (!entry) continue;
+      const vaultId = entry.vault.id;
+
+      if (envelope.error !== null) {
+        logger.warn(`Failed to poll pegout status for ${vaultId}`, {
+          data: { error: envelope.error },
+        });
+        applyPegoutFailure(vaultId, results, counters);
+        continue;
+      }
+
+      // envelope.error === null && envelope.result !== null — guaranteed by
+      // the SDK validator (rejects both-null / both-present envelopes).
+      applyPegoutResult(vaultId, envelope.result!, results, counters);
+    }
   }
+}
+
+function applyPegoutFailure(
+  vaultId: string,
+  results: Map<string, PegoutPollingResult>,
+  counters: VaultPollCounters,
+): void {
+  const prevFailures = counters.failureCounts.get(vaultId) ?? 0;
+  const newFailures = prevFailures + 1;
+  counters.failureCounts.set(vaultId, newFailures);
+
+  if (newFailures >= PEGOUT_MAX_CONSECUTIVE_FAILURES) {
+    logger.warn(
+      `Pegout polling for ${vaultId} timed out after ${newFailures} consecutive failures`,
+    );
+    results.set(vaultId, { displayState: TIMED_OUT_STATE });
+  } else {
+    results.set(vaultId, {
+      displayState: getPegoutDisplayState(undefined, false),
+    });
+  }
+}
+
+function applyPegoutResult(
+  vaultId: string,
+  response: GetPegoutStatusResponse,
+  results: Map<string, PegoutPollingResult>,
+  counters: VaultPollCounters,
+): void {
+  const claimerStatus = response.claimer?.status;
+
+  // Reset failure counter on successful RPC call
+  counters.failureCounts.set(vaultId, 0);
+
+  if (!claimerStatus || !isRecognizedPegoutStatus(claimerStatus)) {
+    const prevUnknown = counters.unknownCounts.get(vaultId) ?? 0;
+    const newUnknown = prevUnknown + 1;
+    counters.unknownCounts.set(vaultId, newUnknown);
+
+    if (newUnknown >= PEGOUT_MAX_UNKNOWN_STATUS_POLLS) {
+      logger.warn(
+        `Pegout polling for ${vaultId} timed out after ${newUnknown} consecutive unknown status polls (last status: "${claimerStatus ?? ""}")`,
+      );
+      results.set(vaultId, { displayState: TIMED_OUT_STATE, response });
+      return;
+    }
+  } else {
+    counters.unknownCounts.set(vaultId, 0);
+  }
+
+  const displayState = getPegoutDisplayState(claimerStatus, response.found);
+  results.set(vaultId, { displayState, response });
 }
 
 interface UsePegoutPollingParams {

--- a/services/vault/src/hooks/useVaultDeposits.ts
+++ b/services/vault/src/hooks/useVaultDeposits.ts
@@ -35,26 +35,18 @@ export function useVaultDeposits(connectedAddress: Address | undefined) {
     ? FAST_POLL_INTERVAL
     : NORMAL_POLL_INTERVAL;
 
-  // Fetch vault data from GraphQL
-  const { data, isLoading, error, refetch } = useVaults(connectedAddress);
+  const { data, isLoading, error, refetch } = useVaults(connectedAddress, {
+    poll: true,
+    interval: pollingInterval,
+  });
 
-  // Trigger refetch when wallet connects (address changes from undefined to a value)
+  // Forces a refresh on `undefined → sameAddress` reconnect, which RQ
+  // would otherwise serve from cache while still within `staleTime`.
   useEffect(() => {
     if (connectedAddress) {
       refetch();
     }
   }, [connectedAddress, refetch]);
-
-  // Set up dynamic polling interval
-  useEffect(() => {
-    if (!connectedAddress) return;
-
-    const interval = setInterval(() => {
-      refetch();
-    }, pollingInterval);
-
-    return () => clearInterval(interval);
-  }, [connectedAddress, pollingInterval, refetch]);
 
   // Transform vaults to vault activities
   const confirmedActivities = useMemo(() => {

--- a/services/vault/src/hooks/useVaults.ts
+++ b/services/vault/src/hooks/useVaults.ts
@@ -13,22 +13,23 @@ export const VAULTS_QUERY_KEY = "vaults";
 const PENDING_REFETCH_INTERVAL = 5 * 1000; // 5 seconds
 
 interface UseVaultsOptions {
-  /** Enable polling when true (e.g., when there are pending deposits) */
   poll?: boolean;
+  /** Polling interval in ms; only used when `poll: true`. Defaults to 5s. */
+  interval?: number;
 }
 
 /**
  * Hook to fetch vaults for a depositor
  *
  * @param depositorAddress - Depositor's Ethereum address
- * @param options - Optional configuration (poll: enable polling for pending deposits)
+ * @param options - Optional configuration (poll/interval)
  * @returns Query result with vault data
  */
 export function useVaults(
   depositorAddress: Address | undefined,
   options: UseVaultsOptions = {},
 ) {
-  const { poll = false } = options;
+  const { poll = false, interval = PENDING_REFETCH_INTERVAL } = options;
 
   return useQuery({
     queryKey: [VAULTS_QUERY_KEY, depositorAddress],
@@ -37,6 +38,6 @@ export function useVaults(
     staleTime: 60 * 1000, // 1 minute
     gcTime: 5 * 60 * 1000, // 5 minutes
     refetchOnWindowFocus: false,
-    refetchInterval: poll ? PENDING_REFETCH_INTERVAL : false,
+    refetchInterval: poll ? interval : false,
   });
 }

--- a/services/vault/src/types/peginPolling.ts
+++ b/services/vault/src/types/peginPolling.ts
@@ -2,10 +2,6 @@
  * Types for Peg-In Polling Context
  */
 
-import type {
-  ClaimerTransactions,
-  DepositorGraphTransactions,
-} from "@babylonlabs-io/ts-sdk/tbv/core/clients";
 import type { PropsWithChildren } from "react";
 
 import type {
@@ -19,12 +15,6 @@ import type { VaultActivity } from "../types/activity";
 export interface DepositPollingResult {
   /** Deposit/activity ID (txHash) */
   depositId: string;
-  /** Claim and payout transactions (null if not ready) */
-  transactions: ClaimerTransactions[] | null;
-  /** Depositor graph transactions (depositor-as-claimer, optional) */
-  depositorGraph: DepositorGraphTransactions | null;
-  /** Whether transactions are ready for signing */
-  isReady: boolean;
   /** Loading state for this deposit */
   loading: boolean;
   /** Error state for this deposit */

--- a/services/vault/src/utils/peginPolling.ts
+++ b/services/vault/src/utils/peginPolling.ts
@@ -2,7 +2,6 @@
  * Utility functions for Peg-In Polling
  */
 
-import type { ClaimerTransactions } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
 import type { Hex } from "viem";
 
 import {
@@ -82,22 +81,6 @@ export function isTransientPollingError(error: unknown): boolean {
   // Check for other transient patterns
   return TRANSIENT_ERROR_PATTERNS.some((pattern) =>
     error.message.includes(pattern),
-  );
-}
-
-/**
- * Check if transactions response has all required data for signing
- */
-export function areTransactionsReady(txs: ClaimerTransactions[]): boolean {
-  if (!txs || txs.length === 0) return false;
-  return txs.every(
-    (tx) =>
-      tx.claim_tx?.tx_hex &&
-      tx.payout_tx?.tx_hex &&
-      tx.assert_tx?.tx_hex &&
-      tx.claim_tx.tx_hex.length > 0 &&
-      tx.payout_tx.tx_hex.length > 0 &&
-      tx.assert_tx.tx_hex.length > 0,
   );
 }
 


### PR DESCRIPTION
Three RPC-cost reductions across the dashboard polling stack:

1. **Drop the heavy auth-gated `requestDepositorPresignTransactions` from polling.** Daemon status `PendingDepositorSignatures` is now the readiness signal — the SDK already
re-fetches the presign payload at click-time, so the polling-side fetch was wasted bandwidth.
2. **Skip `getApplicationUsage` polls when the application is uncapped.** CapPolicy treats `0 = unlimited`; the snapshot ignores usage data on that branch, so the per-minute reads
 were pure waste.
3. **Wire VP's existing batch endpoints end-to-end** (`batchGetPeginStatus`, `batchGetPegoutStatus`). N sequential per-deposit calls collapse to 1 batch call per provider per
chunk-of-50. Defensive attribution helper lowercase-normalizes txids and surfaces missing/duplicate/unexpected echoed txids as per-deposit errors. Also fixes pegout TS types to
match Rust source (plural `challengers`, mandatory claimer fields, integer timestamps, split `_x_/_y_txid`). Multicalls the two cap-usage reads when a user is connected.

**Net runtime impact:** 5 pending deposits = 1 RPC/cycle (was 5). 3 redeemed vaults = 1 RPC/cycle (was 3). Capped+user-connected dashboard = 2 round-trips/refresh (was 3). All
batch endpoints are server-side unauthenticated.