### PR TITLE
fix(sdk, config, vault): eliminate silent RPC fallbacks on protocol r…

### DIFF
--- a/packages/babylon-config/README.md
+++ b/packages/babylon-config/README.md
@@ -32,9 +32,14 @@ console.log(network); // 'mainnet', 'testnet', or 'localhost'
 
 ### Environment Variables
 
+Required:
+- `NEXT_PUBLIC_BTC_NETWORK` - `mainnet` or `signet`
+- `NEXT_PUBLIC_ETH_CHAINID` - `1` (mainnet) or `11155111` (sepolia)
+- `NEXT_PUBLIC_ETH_RPC_URL` - Ethereum RPC endpoint that can see the deployed contracts. No default — public RPCs do not see contracts on private/devnet deployments.
+
+Optional:
 - `NEXT_PUBLIC_NETWORK` - Network selection: `mainnet`, `testnet`, `localhost`, etc.
-- `NEXT_PUBLIC_ETH_CHAIN_ID` - Override chain ID
-- `NEXT_PUBLIC_ETH_RPC_URL` - Override RPC URL
+- `NEXT_PUBLIC_MEMPOOL_API` - Custom mempool API URL (default: `https://mempool.space`)
 
 ## Supported Networks
 

--- a/packages/babylon-config/src/network/eth.ts
+++ b/packages/babylon-config/src/network/eth.ts
@@ -4,11 +4,12 @@
  * Provides network configuration for Ethereum based on NEXT_PUBLIC_ETH_CHAINID.
  * Supports mainnet (1) and sepolia testnet (11155111).
  *
- * Required environment variable:
+ * Required environment variables:
  * - NEXT_PUBLIC_ETH_CHAINID: Must be "1" (mainnet) or "11155111" (sepolia)
- *
- * Optional environment variable:
- * - NEXT_PUBLIC_ETH_RPC_URL: Custom RPC URL (has defaults for each network)
+ * - NEXT_PUBLIC_ETH_RPC_URL: Ethereum RPC endpoint that can see the deployed
+ *   contracts. No default — public RPCs (drpc.org, publicnode.com) do not see
+ *   contracts on private/devnet deployments and silently produce misleading
+ *   "contract call failed" errors.
  */
 
 import type { ETHConfig } from "@babylonlabs-io/wallet-connector";
@@ -23,6 +24,16 @@ if (!chainIdStr) {
     "NEXT_PUBLIC_ETH_CHAINID environment variable is required. Must be set to '1' (mainnet) or '11155111' (sepolia).",
   );
 }
+
+const rawEthRpcUrl = process.env.NEXT_PUBLIC_ETH_RPC_URL;
+
+if (!rawEthRpcUrl) {
+  throw new Error(
+    "NEXT_PUBLIC_ETH_RPC_URL environment variable is required. Set it to an RPC endpoint that can see the deployed contracts (e.g. your devnet RPC). Public RPCs do not see contracts on private deployments.",
+  );
+}
+
+const ethRpcUrl: string = rawEthRpcUrl;
 
 const chainIdRaw = parseInt(chainIdStr, 10);
 
@@ -57,9 +68,7 @@ const config: Record<typeof ETH_MAINNET_CHAIN_ID | typeof ETH_SEPOLIA_CHAIN_ID, 
     name: "Ethereum Mainnet",
     chainId: ETH_MAINNET_CHAIN_ID,
     chainName: "Ethereum Mainnet",
-    rpcUrl:
-      process.env.NEXT_PUBLIC_ETH_RPC_URL ||
-      "https://ethereum-rpc.publicnode.com",
+    rpcUrl: ethRpcUrl,
     explorerUrl: "https://etherscan.io",
     nativeCurrency: {
       name: "Ether",
@@ -72,9 +81,7 @@ const config: Record<typeof ETH_MAINNET_CHAIN_ID | typeof ETH_SEPOLIA_CHAIN_ID, 
     name: "Ethereum Sepolia",
     chainId: ETH_SEPOLIA_CHAIN_ID,
     chainName: "Sepolia Testnet",
-    rpcUrl:
-      process.env.NEXT_PUBLIC_ETH_RPC_URL ||
-      "https://ethereum-sepolia-rpc.publicnode.com",
+    rpcUrl: ethRpcUrl,
     explorerUrl: "https://sepolia.etherscan.io",
     nativeCurrency: {
       name: "Sepolia ETH",
@@ -94,22 +101,29 @@ export function getNetworkConfigETH(): Config {
 }
 
 /**
- * Get viem Chain object for the current network configuration
- * Used by contract clients that need Chain object
- * @returns viem Chain object (mainnet or sepolia)
+ * Get viem Chain object for the current network configuration.
+ *
+ * Returns the stock viem chain with `rpcUrls.default` overridden by
+ * `NEXT_PUBLIC_ETH_RPC_URL`, so any downstream code that calls
+ * `http()` without an explicit URL still routes to the configured RPC
+ * instead of viem's bundled public default (e.g. `sepolia.drpc.org`).
+ *
+ * @returns viem Chain object with the configured RPC URL baked in
  * @throws Error if chain ID is not supported
  */
 export function getETHChain(): Chain {
-  // Use chainId directly since it's already validated
-  switch (chainId) {
-    case ETH_MAINNET_CHAIN_ID:
-      return mainnet;
-    case ETH_SEPOLIA_CHAIN_ID:
-      return sepolia;
-    default:
-      throw new Error(
-        `No viem Chain object found for chain ID: ${chainId}. This should not happen as validation occurs at module load.`,
-      );
-  }
+  const baseChain =
+    chainId === ETH_MAINNET_CHAIN_ID ? mainnet : sepolia;
+  // Patch both `default` and `public` so any wagmi/AppKit/Reown internals
+  // that build RPC namespace maps from `rpcUrls.public` route through the
+  // configured endpoint instead of viem's bundled public RPC.
+  return {
+    ...baseChain,
+    rpcUrls: {
+      ...baseChain.rpcUrls,
+      default: { http: [ethRpcUrl] },
+      public: { http: [ethRpcUrl] },
+    },
+  };
 }
 

--- a/packages/babylon-ts-sdk/docs/api/managers.md
+++ b/packages/babylon-ts-sdk/docs/api/managers.md
@@ -1020,6 +1020,17 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:121](
 Ethereum chain configuration.
 Required for proper gas estimation in contract calls.
 
+##### publicClient
+
+```ts
+publicClient: PublicClient;
+```
+
+Public client used for read calls (`readContract`, `estimateGas`,
+`waitForTransactionReceipt`). Pass a client configured with the
+caller's RPC URL so reads hit the same endpoint as the rest of the
+application instead of viem's stock chain default.
+
 ##### vaultContracts
 
 ```ts

--- a/packages/babylon-ts-sdk/docs/quickstart/managers.md
+++ b/packages/babylon-ts-sdk/docs/quickstart/managers.md
@@ -68,17 +68,26 @@ The `btcVaultRegistry` is the Ethereum contract that handles BTC vault registrat
 import { PeginManager } from "@babylonlabs-io/ts-sdk/tbv/core";
 import type { BitcoinWallet } from "@babylonlabs-io/ts-sdk/shared";
 import { sepolia } from "viem/chains";
-import type { WalletClient } from "viem";
+import { createPublicClient, http, type WalletClient } from "viem";
 
 // You provide these — see the Wallet Interfaces guide linked below.
 declare const btcWallet: BitcoinWallet;
 declare const ethWallet: WalletClient;
+
+// Pass a public client configured with your RPC URL so SDK reads
+// hit the same endpoint as the rest of your app, not viem's
+// stock chain default.
+const publicClient = createPublicClient({
+  chain: sepolia,
+  transport: http("https://your-eth-rpc.example/"),
+});
 
 const peginManager = new PeginManager({
   btcNetwork: "signet",
   btcWallet,
   ethWallet,
   ethChain: sepolia,
+  publicClient,
   vaultContracts: {
     btcVaultRegistry: "0x...",
   },

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts
@@ -73,11 +73,15 @@ interface SignPayoutBaseParams {
   timelockPegin: number;
 
   /**
-   * Depositor's BTC public key (x-only, 64-char hex).
-   * This should be the public key that was used when creating the vault,
-   * as stored on-chain. If not provided, will be fetched from the wallet.
+   * Depositor's BTC public key (x-only, 64-char hex). This MUST be the
+   * key registered on-chain for the vault — typically read from
+   * `BTCVaultRegistry.getBtcVaultBasicInfo(...).depositorBtcPubKey`.
+   *
+   * Required: omitting it would degrade `validateWalletPubkey` to a
+   * self-comparison, allowing the wrong wallet to produce a signature
+   * over a script tree that doesn't match the on-chain UTXO.
    */
-  depositorBtcPubkey?: string;
+  depositorBtcPubkey: string;
 
   /**
    * The on-chain registered depositor payout scriptPubKey (hex, with or without 0x prefix).

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
@@ -31,14 +31,13 @@ import {
   signPsbtsWithFallback,
 } from "./pegin";
 import {
-  createPublicClient,
   encodeFunctionData,
-  http,
   isAddressEqual,
   zeroAddress,
   type Address,
   type Chain,
   type Hex,
+  type PublicClient,
   type WalletClient,
 } from "viem";
 
@@ -119,6 +118,14 @@ export interface PeginManagerConfig {
    * Required for proper gas estimation in contract calls.
    */
   ethChain: Chain;
+
+  /**
+   * Public client used for read calls (`readContract`, `estimateGas`,
+   * `waitForTransactionReceipt`). Pass a client configured with the
+   * caller's RPC URL so reads hit the same endpoint as the rest of the
+   * application instead of viem's stock chain default.
+   */
+  publicClient: PublicClient;
 
   /**
    * Vault contract addresses.
@@ -1075,10 +1082,7 @@ export class PeginManager {
     }
 
     // Step 4: Query required pegin fee from the contract
-    const publicClient = createPublicClient({
-      chain: this.config.ethChain,
-      transport: http(),
-    });
+    const publicClient = this.config.publicClient;
 
     let peginFee: bigint;
     try {
@@ -1088,10 +1092,11 @@ export class PeginManager {
         functionName: "getPegInFee",
         args: [vaultProvider],
       })) as bigint;
-    } catch {
+    } catch (error) {
       throw new Error(
         "Failed to query pegin fee from the contract. " +
           "Please check your network connection and that the contract address is correct.",
+        { cause: error },
       );
     }
 
@@ -1234,10 +1239,7 @@ export class PeginManager {
     }
 
     // Step 4: Query pegin fee and compute total
-    const publicClient = createPublicClient({
-      chain: this.config.ethChain,
-      transport: http(),
-    });
+    const publicClient = this.config.publicClient;
 
     let peginFee: bigint;
     try {
@@ -1247,10 +1249,11 @@ export class PeginManager {
         functionName: "getPegInFee",
         args: [vaultProvider],
       })) as bigint;
-    } catch {
+    } catch (error) {
       throw new Error(
         "Failed to query pegin fee from the contract. " +
           "Please check your network connection and that the contract address is correct.",
+        { cause: error },
       );
     }
     const totalFee = peginFee * BigInt(requests.length);
@@ -1334,29 +1337,27 @@ export class PeginManager {
   /**
    * Check if a vault already exists for a given vault ID.
    *
+   * The contract returns a default struct (with `depositor === zeroAddress`)
+   * when no vault is registered, so existence is signalled in the response,
+   * not via a thrown error. RPC/network failures are propagated rather than
+   * silently treated as "vault doesn't exist", which would otherwise let
+   * downstream calls run with stale assumptions.
+   *
    * @param vaultId - The Bitcoin transaction hash (vault ID)
    * @returns True if vault exists, false otherwise
+   * @throws If the underlying RPC read fails
    */
   private async checkVaultExists(vaultId: Hex): Promise<boolean> {
-    try {
-      // Create a public client to read from the contract
-      const publicClient = createPublicClient({
-        chain: this.config.ethChain,
-        transport: http(),
-      });
+    const publicClient = this.config.publicClient;
 
-      const result = (await publicClient.readContract({
-        address: this.config.vaultContracts.btcVaultRegistry,
-        abi: BTCVaultRegistryABI,
-        functionName: "getBtcVaultBasicInfo",
-        args: [vaultId],
-      })) as { depositor: Address };
+    const result = (await publicClient.readContract({
+      address: this.config.vaultContracts.btcVaultRegistry,
+      abi: BTCVaultRegistryABI,
+      functionName: "getBtcVaultBasicInfo",
+      args: [vaultId],
+    })) as { depositor: Address };
 
-      return result.depositor !== zeroAddress;
-    } catch {
-      // If reading fails, assume vault doesn't exist and let contract handle it
-      return false;
-    }
+    return result.depositor !== zeroAddress;
   }
 
   /**

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PayoutManager.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PayoutManager.test.ts
@@ -214,6 +214,7 @@ describe("PayoutManager", () => {
           vaultKeeperBtcPubkeys: [TEST_KEYS.VAULT_KEEPER_1],
           universalChallengerBtcPubkeys: [TEST_KEYS.UNIVERSAL_CHALLENGER_1],
           timelockPegin: 100,
+          depositorBtcPubkey: TEST_KEYS.DEPOSITOR,
           registeredPayoutScriptPubKey: TEST_PAYOUT_SCRIPT_PUBKEY,
         },
         {
@@ -224,6 +225,7 @@ describe("PayoutManager", () => {
           vaultKeeperBtcPubkeys: [TEST_KEYS.VAULT_KEEPER_1],
           universalChallengerBtcPubkeys: [TEST_KEYS.UNIVERSAL_CHALLENGER_1],
           timelockPegin: 100,
+          depositorBtcPubkey: TEST_KEYS.DEPOSITOR,
           registeredPayoutScriptPubKey: TEST_PAYOUT_SCRIPT_PUBKEY,
         },
       ]);
@@ -269,6 +271,7 @@ describe("PayoutManager", () => {
             vaultKeeperBtcPubkeys: [TEST_KEYS.VAULT_KEEPER_1],
             universalChallengerBtcPubkeys: [TEST_KEYS.UNIVERSAL_CHALLENGER_1],
             timelockPegin: 100,
+            depositorBtcPubkey: TEST_KEYS.DEPOSITOR,
             registeredPayoutScriptPubKey: TEST_PAYOUT_SCRIPT_PUBKEY,
           },
         ]),
@@ -311,6 +314,7 @@ describe("PayoutManager", () => {
             vaultKeeperBtcPubkeys: [TEST_KEYS.VAULT_KEEPER_1],
             universalChallengerBtcPubkeys: [TEST_KEYS.UNIVERSAL_CHALLENGER_1],
             timelockPegin: 100,
+            depositorBtcPubkey: TEST_KEYS.DEPOSITOR,
             registeredPayoutScriptPubKey: TEST_PAYOUT_SCRIPT_PUBKEY,
           },
         ]),
@@ -368,6 +372,7 @@ describe("PayoutManager", () => {
             vaultKeeperBtcPubkeys: [TEST_KEYS.VAULT_KEEPER_1],
             universalChallengerBtcPubkeys: [TEST_KEYS.UNIVERSAL_CHALLENGER_1],
             timelockPegin: 100,
+            depositorBtcPubkey: TEST_KEYS.DEPOSITOR,
             registeredPayoutScriptPubKey: TEST_PAYOUT_SCRIPT_PUBKEY,
           },
           {
@@ -378,6 +383,7 @@ describe("PayoutManager", () => {
             vaultKeeperBtcPubkeys: [TEST_KEYS.VAULT_KEEPER_1],
             universalChallengerBtcPubkeys: [TEST_KEYS.UNIVERSAL_CHALLENGER_1],
             timelockPegin: 100,
+            depositorBtcPubkey: TEST_KEYS.DEPOSITOR,
             registeredPayoutScriptPubKey: TEST_PAYOUT_SCRIPT_PUBKEY,
           },
         ]),
@@ -439,6 +445,7 @@ describe("PayoutManager", () => {
             vaultKeeperBtcPubkeys: [TEST_KEYS.VAULT_KEEPER_1],
             universalChallengerBtcPubkeys: [TEST_KEYS.UNIVERSAL_CHALLENGER_1],
             timelockPegin: 100,
+            depositorBtcPubkey: TEST_KEYS.DEPOSITOR,
             registeredPayoutScriptPubKey: TEST_PAYOUT_SCRIPT_PUBKEY,
           },
           {
@@ -449,6 +456,7 @@ describe("PayoutManager", () => {
             vaultKeeperBtcPubkeys: [TEST_KEYS.VAULT_KEEPER_1],
             universalChallengerBtcPubkeys: [TEST_KEYS.UNIVERSAL_CHALLENGER_1],
             timelockPegin: 100,
+            depositorBtcPubkey: TEST_KEYS.DEPOSITOR,
             registeredPayoutScriptPubKey: TEST_PAYOUT_SCRIPT_PUBKEY,
           },
         ]),
@@ -521,6 +529,7 @@ describe("PayoutManager", () => {
           vaultKeeperBtcPubkeys: [TEST_KEYS.VAULT_KEEPER_1],
           universalChallengerBtcPubkeys: [TEST_KEYS.UNIVERSAL_CHALLENGER_1],
           timelockPegin: 100,
+          depositorBtcPubkey: TEST_KEYS.DEPOSITOR,
           registeredPayoutScriptPubKey: wrongScriptPubKey,
         }),
       ).rejects.toThrow(
@@ -556,6 +565,7 @@ describe("PayoutManager", () => {
           vaultKeeperBtcPubkeys: [TEST_KEYS.VAULT_KEEPER_1],
           universalChallengerBtcPubkeys: [TEST_KEYS.UNIVERSAL_CHALLENGER_1],
           timelockPegin: 100,
+          depositorBtcPubkey: TEST_KEYS.DEPOSITOR,
           registeredPayoutScriptPubKey: prefixedScriptPubKey,
         }),
       ).rejects.not.toThrow(
@@ -586,6 +596,7 @@ describe("PayoutManager", () => {
           vaultKeeperBtcPubkeys: [TEST_KEYS.VAULT_KEEPER_1],
           universalChallengerBtcPubkeys: [TEST_KEYS.UNIVERSAL_CHALLENGER_1],
           timelockPegin: 100,
+          depositorBtcPubkey: TEST_KEYS.DEPOSITOR,
           registeredPayoutScriptPubKey: "not-valid-hex",
         }),
       ).rejects.toThrow("Invalid registeredPayoutScriptPubKey: not valid hex");
@@ -633,6 +644,7 @@ describe("PayoutManager", () => {
           vaultKeeperBtcPubkeys: [TEST_KEYS.VAULT_KEEPER_1],
           universalChallengerBtcPubkeys: [TEST_KEYS.UNIVERSAL_CHALLENGER_1],
           timelockPegin: 100,
+          depositorBtcPubkey: TEST_KEYS.DEPOSITOR,
           registeredPayoutScriptPubKey: TEST_PAYOUT_SCRIPT_PUBKEY,
         }),
       ).rejects.toThrow(
@@ -667,6 +679,7 @@ describe("PayoutManager", () => {
             vaultKeeperBtcPubkeys: [TEST_KEYS.VAULT_KEEPER_1],
             universalChallengerBtcPubkeys: [TEST_KEYS.UNIVERSAL_CHALLENGER_1],
             timelockPegin: 100,
+            depositorBtcPubkey: TEST_KEYS.DEPOSITOR,
             registeredPayoutScriptPubKey: wrongScriptPubKey,
           },
         ]),

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PeginManager.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PeginManager.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { beforeAll, describe, expect, it, vi } from "vitest";
-import type { Address, Chain } from "viem";
+import { zeroAddress, type Address, type Chain, type PublicClient } from "viem";
 
 import {
   MockBitcoinWallet,
@@ -37,28 +37,6 @@ vi.mock("../../primitives/psbt/peginInput", async (importOriginal) => {
   };
 });
 
-// Mock viem's createPublicClient to avoid HTTP requests during gas estimation
-vi.mock("viem", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("viem")>();
-  return {
-    ...actual,
-    createPublicClient: vi.fn(() => ({
-      estimateGas: vi.fn().mockResolvedValue(100000n),
-      waitForTransactionReceipt: vi.fn().mockResolvedValue({
-        status: "success",
-        transactionHash: "0x" + "ab".repeat(32),
-      }),
-      readContract: vi
-        .fn()
-        .mockImplementation(({ functionName }: { functionName: string }) => {
-          if (functionName === "getPegInFee") return Promise.resolve(0n);
-          // getBtcVaultBasicInfo — return struct with zero depositor (vault doesn't exist)
-          return Promise.resolve({ depositor: actual.zeroAddress });
-        }),
-    })),
-  };
-});
-
 // Test chain configuration (minimal viem Chain)
 const TEST_CHAIN: Chain = {
   id: 11155111,
@@ -68,6 +46,23 @@ const TEST_CHAIN: Chain = {
     default: { http: ["https://rpc.sepolia.org"] },
   },
 };
+
+// Mock public client passed into PeginManager config so tests don't
+// hit HTTP. Mirrors viem's PublicClient surface used by the manager.
+const TEST_PUBLIC_CLIENT = {
+  estimateGas: vi.fn().mockResolvedValue(100000n),
+  waitForTransactionReceipt: vi.fn().mockResolvedValue({
+    status: "success",
+    transactionHash: "0x" + "ab".repeat(32),
+  }),
+  readContract: vi
+    .fn()
+    .mockImplementation(({ functionName }: { functionName: string }) => {
+      if (functionName === "getPegInFee") return Promise.resolve(0n);
+      // getBtcVaultBasicInfo — return struct with zero depositor (vault doesn't exist)
+      return Promise.resolve({ depositor: zeroAddress });
+    }),
+} as unknown as PublicClient;
 
 // Test constants - use valid secp256k1 x-only public keys
 const TEST_KEYS = {
@@ -167,6 +162,7 @@ describe("PeginManager", () => {
         btcWallet,
         ethWallet: ethWallet as any,
         ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
         vaultContracts: {
           btcVaultRegistry: TEST_CONTRACT_ADDRESS,
         },
@@ -192,6 +188,7 @@ describe("PeginManager", () => {
           btcWallet,
           ethWallet: ethWallet as any,
           ethChain: TEST_CHAIN,
+          publicClient: TEST_PUBLIC_CLIENT,
           vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
           mempoolApiUrl: MEMPOOL_API_URLS.signet,
         });
@@ -218,6 +215,7 @@ describe("PeginManager", () => {
         btcWallet,
         ethWallet: ethWallet as any,
         ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
         vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
         mempoolApiUrl: MEMPOOL_API_URLS.signet,
       });
@@ -244,6 +242,7 @@ describe("PeginManager", () => {
         btcWallet,
         ethWallet: ethWallet as any,
         ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
         vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
         mempoolApiUrl: MEMPOOL_API_URLS.signet,
       });
@@ -319,6 +318,7 @@ describe("PeginManager", () => {
         btcWallet,
         ethWallet: ethWallet as any,
         ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
         vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
         mempoolApiUrl: MEMPOOL_API_URLS.signet,
       });
@@ -353,6 +353,7 @@ describe("PeginManager", () => {
         btcWallet,
         ethWallet: ethWallet as any,
         ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
         vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
         mempoolApiUrl: MEMPOOL_API_URLS.signet,
       });
@@ -380,6 +381,7 @@ describe("PeginManager", () => {
         btcWallet,
         ethWallet: ethWallet as any,
         ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
         vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
         mempoolApiUrl: MEMPOOL_API_URLS.signet,
       });
@@ -412,6 +414,7 @@ describe("PeginManager", () => {
         btcWallet,
         ethWallet: ethWallet as any,
         ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
         vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
         mempoolApiUrl: MEMPOOL_API_URLS.signet,
       });
@@ -441,6 +444,7 @@ describe("PeginManager", () => {
         btcWallet,
         ethWallet: ethWallet as any,
         ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
         vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
         mempoolApiUrl: MEMPOOL_API_URLS.signet,
       });
@@ -465,6 +469,7 @@ describe("PeginManager", () => {
         btcWallet,
         ethWallet: ethWallet as any,
         ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
         vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
         mempoolApiUrl: MEMPOOL_API_URLS.signet,
       });
@@ -489,6 +494,7 @@ describe("PeginManager", () => {
         btcWallet,
         ethWallet: ethWallet as any,
         ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
         vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
         mempoolApiUrl: MEMPOOL_API_URLS.signet,
       });
@@ -517,6 +523,7 @@ describe("PeginManager", () => {
         btcWallet,
         ethWallet: ethWallet as any,
         ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
         vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
         mempoolApiUrl: MEMPOOL_API_URLS.signet,
       });
@@ -547,6 +554,7 @@ describe("PeginManager", () => {
         btcWallet,
         ethWallet: ethWallet as any,
         ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
         vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
         mempoolApiUrl: MEMPOOL_API_URLS.signet,
       });
@@ -573,6 +581,7 @@ describe("PeginManager", () => {
         btcWallet,
         ethWallet: ethWallet as any,
         ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
         vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
         mempoolApiUrl: MEMPOOL_API_URLS.signet,
       });
@@ -598,6 +607,7 @@ describe("PeginManager", () => {
         btcWallet,
         ethWallet: ethWallet as any,
         ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
         vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
         mempoolApiUrl: MEMPOOL_API_URLS.signet,
       });
@@ -620,6 +630,7 @@ describe("PeginManager", () => {
         btcWallet,
         ethWallet: ethWallet as any,
         ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
         vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
         mempoolApiUrl: MEMPOOL_API_URLS.signet,
       });
@@ -640,6 +651,7 @@ describe("PeginManager", () => {
         btcWallet,
         ethWallet: ethWallet as any,
         ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
         vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
         mempoolApiUrl: MEMPOOL_API_URLS.signet,
       });
@@ -662,6 +674,7 @@ describe("PeginManager", () => {
         btcWallet,
         ethWallet: ethWallet as any,
         ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
         vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
         mempoolApiUrl: MEMPOOL_API_URLS.signet,
       });
@@ -683,6 +696,7 @@ describe("PeginManager", () => {
         btcWallet,
         ethWallet: ethWallet as any,
         ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
         vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
         mempoolApiUrl: MEMPOOL_API_URLS.signet,
       });
@@ -704,6 +718,7 @@ describe("PeginManager", () => {
         btcWallet,
         ethWallet: ethWallet as any,
         ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
         vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
         mempoolApiUrl: MEMPOOL_API_URLS.signet,
       });
@@ -723,6 +738,7 @@ describe("PeginManager", () => {
         btcWallet,
         ethWallet: ethWallet as any,
         ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
         vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
         mempoolApiUrl: MEMPOOL_API_URLS.signet,
       });
@@ -743,6 +759,7 @@ describe("PeginManager", () => {
         btcWallet,
         ethWallet: ethWallet as any,
         ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
         vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
         mempoolApiUrl: MEMPOOL_API_URLS.signet,
       });
@@ -764,6 +781,7 @@ describe("PeginManager", () => {
         btcWallet,
         ethWallet: ethWallet as any,
         ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
         vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
         mempoolApiUrl: MEMPOOL_API_URLS.signet,
       });
@@ -785,6 +803,7 @@ describe("PeginManager", () => {
         btcWallet,
         ethWallet: ethWallet as any,
         ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
         vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
         mempoolApiUrl: MEMPOOL_API_URLS.signet,
       });
@@ -877,6 +896,7 @@ describe("PeginManager", () => {
         btcWallet,
         ethWallet: ethWallet as any,
         ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
         vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
         mempoolApiUrl: MEMPOOL_API_URLS.signet,
       });
@@ -932,27 +952,10 @@ describe("PeginManager", () => {
     });
 
     it("should throw when transaction receipt status is reverted", async () => {
-      const viem = await import("viem");
-      const mockedCreatePublicClient = vi.mocked(viem.createPublicClient);
-
-      const defaultReadContract = vi
-        .fn()
-        .mockImplementation(({ functionName }: { functionName: string }) => {
-          if (functionName === "getPegInFee") return Promise.resolve(0n);
-          return Promise.resolve({ depositor: viem.zeroAddress });
-        });
-
-      mockedCreatePublicClient.mockReturnValueOnce({
-        readContract: defaultReadContract,
-      } as any);
-      mockedCreatePublicClient.mockReturnValueOnce({
-        estimateGas: vi.fn().mockResolvedValue(100000n),
-        waitForTransactionReceipt: vi.fn().mockResolvedValue({
-          status: "reverted",
-          transactionHash: "0x" + "ab".repeat(32),
-        }),
-        readContract: defaultReadContract,
-      } as any);
+      vi.mocked(TEST_PUBLIC_CLIENT.waitForTransactionReceipt).mockResolvedValueOnce({
+        status: "reverted",
+        transactionHash: `0x${"ab".repeat(32)}`,
+      } as never);
 
       const { manager, popSignature } = await makeManagerWithPop();
 
@@ -992,6 +995,7 @@ describe("PeginManager", () => {
         btcWallet,
         ethWallet: ethWallet as any,
         ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
         vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
         mempoolApiUrl: MEMPOOL_API_URLS.signet,
       });
@@ -1030,6 +1034,7 @@ describe("PeginManager", () => {
         btcWallet,
         ethWallet: ethWallet as any,
         ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
         vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
         mempoolApiUrl: MEMPOOL_API_URLS.signet,
       });
@@ -1070,6 +1075,7 @@ describe("PeginManager", () => {
         btcWallet,
         ethWallet: ethWallet as any,
         ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
         vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
         mempoolApiUrl: MEMPOOL_API_URLS.signet,
       });
@@ -1114,6 +1120,7 @@ describe("PeginManager", () => {
         btcWallet,
         ethWallet: ethWallet as any,
         ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
         vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
         mempoolApiUrl: MEMPOOL_API_URLS.signet,
       });
@@ -1139,6 +1146,7 @@ describe("PeginManager", () => {
         btcWallet,
         ethWallet: ethWallet as any,
         ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
         vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
         mempoolApiUrl: MEMPOOL_API_URLS.signet,
       });
@@ -1190,6 +1198,7 @@ describe("PeginManager", () => {
         btcWallet: btcWallet1,
         ethWallet: ethWallet as any,
         ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
         vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
         mempoolApiUrl: MEMPOOL_API_URLS.signet,
       });
@@ -1199,6 +1208,7 @@ describe("PeginManager", () => {
         btcWallet: btcWallet2,
         ethWallet: ethWallet as any,
         ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
         vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
         mempoolApiUrl: MEMPOOL_API_URLS.signet,
       });
@@ -1236,6 +1246,7 @@ describe("PeginManager", () => {
         btcWallet,
         ethWallet: ethWallet as any,
         ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
         vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
         mempoolApiUrl: MEMPOOL_API_URLS.signet,
       });
@@ -1262,6 +1273,7 @@ describe("PeginManager", () => {
         btcWallet,
         ethWallet: ethWallet as any,
         ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
         vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
         mempoolApiUrl: MEMPOOL_API_URLS.signet,
       });
@@ -1308,6 +1320,7 @@ describe("PeginManager", () => {
         btcWallet,
         ethWallet: ethWallet as any,
         ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
         vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
         mempoolApiUrl: MEMPOOL_API_URLS.signet,
       });
@@ -1350,6 +1363,7 @@ describe("PeginManager", () => {
         btcWallet,
         ethWallet: ethWallet as any,
         ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
         vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
         mempoolApiUrl: MEMPOOL_API_URLS.signet,
       });
@@ -1383,6 +1397,7 @@ describe("PeginManager", () => {
         btcWallet,
         ethWallet: ethWallet as any,
         ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
         vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
         mempoolApiUrl: MEMPOOL_API_URLS.signet,
       });
@@ -1424,6 +1439,7 @@ describe("PeginManager", () => {
         btcWallet,
         ethWallet: ethWallet as any,
         ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
         vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
         mempoolApiUrl: MEMPOOL_API_URLS.signet,
       });
@@ -1457,6 +1473,7 @@ describe("PeginManager", () => {
         btcWallet,
         ethWallet: ethWallet as any,
         ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
         vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
         mempoolApiUrl: MEMPOOL_API_URLS.signet,
       });

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/utils/__tests__/bitcoin.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/utils/__tests__/bitcoin.test.ts
@@ -427,27 +427,27 @@ describe("Bitcoin Utilities", () => {
       });
     });
 
-    describe("when expected depositor pubkey is not provided", () => {
-      it("should use wallet x-only pubkey as depositor pubkey", () => {
-        const result = validateWalletPubkey(xOnlyPubkey);
-
-        expect(result.walletPubkeyRaw).toBe(xOnlyPubkey);
-        expect(result.walletPubkeyXOnly).toBe(xOnlyPubkey);
-        expect(result.depositorPubkey).toBe(xOnlyPubkey);
+    describe("when expected depositor pubkey is missing", () => {
+      // The check would otherwise become a self-comparison (wallet vs wallet),
+      // which silently allows the wrong wallet to sign for a different vault.
+      it("should throw when expectedDepositorPubkey is omitted", () => {
+        expect(() =>
+          (validateWalletPubkey as (a: string) => unknown)(xOnlyPubkey),
+        ).toThrow(/requires expectedDepositorPubkey/);
       });
 
-      it("should convert compressed wallet pubkey to x-only for depositor", () => {
-        const result = validateWalletPubkey(compressedPubkey);
-
-        expect(result.walletPubkeyRaw).toBe(compressedPubkey);
-        expect(result.walletPubkeyXOnly).toBe(xOnlyPubkey);
-        expect(result.depositorPubkey).toBe(xOnlyPubkey);
+      it("should throw when expectedDepositorPubkey is undefined", () => {
+        expect(() =>
+          (
+            validateWalletPubkey as (a: string, b: string | undefined) => unknown
+          )(compressedPubkey, undefined),
+        ).toThrow(/requires expectedDepositorPubkey/);
       });
 
-      it("should handle undefined explicitly", () => {
-        const result = validateWalletPubkey(compressedPubkey, undefined);
-
-        expect(result.depositorPubkey).toBe(xOnlyPubkey);
+      it("should throw when expectedDepositorPubkey is empty string", () => {
+        expect(() => validateWalletPubkey(compressedPubkey, "")).toThrow(
+          /requires expectedDepositorPubkey/,
+        );
       });
     });
 
@@ -462,7 +462,7 @@ describe("Bitcoin Utilities", () => {
       });
 
       it("should throw on invalid wallet pubkey format", () => {
-        expect(() => validateWalletPubkey("invalid")).toThrow();
+        expect(() => validateWalletPubkey("invalid", xOnlyPubkey)).toThrow();
       });
 
       it("should handle real-world pubkey formats", () => {

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts
@@ -224,20 +224,28 @@ export interface WalletPubkeyValidationResult {
  *
  * This function:
  * 1. Converts the wallet pubkey to x-only format
- * 2. Uses the expected depositor pubkey if provided, otherwise falls back to wallet pubkey
- * 3. Validates they match (case-insensitive)
+ * 2. Validates the wallet x-only pubkey matches the expected depositor pubkey
+ *    (case-insensitive)
  *
  * @param walletPubkeyRaw - Raw public key from wallet (may be compressed 66 chars or x-only 64 chars)
- * @param expectedDepositorPubkey - Expected depositor public key (x-only, optional)
+ * @param expectedDepositorPubkey - Expected depositor public key (x-only).
+ *   Required: omitting it would degrade this check to a self-comparison.
  * @returns Validation result with both pubkey formats
+ * @throws If `expectedDepositorPubkey` is missing/empty
  * @throws If wallet pubkey doesn't match expected depositor pubkey
  */
 export function validateWalletPubkey(
   walletPubkeyRaw: string,
-  expectedDepositorPubkey?: string,
+  expectedDepositorPubkey: string,
 ): WalletPubkeyValidationResult {
+  if (!expectedDepositorPubkey) {
+    throw new Error(
+      "validateWalletPubkey requires expectedDepositorPubkey. Pass the on-chain registered depositor pubkey to avoid a self-comparison.",
+    );
+  }
+
   const walletPubkeyXOnly = processPublicKeyToXOnly(walletPubkeyRaw);
-  const depositorPubkey = expectedDepositorPubkey ?? walletPubkeyXOnly;
+  const depositorPubkey = expectedDepositorPubkey;
 
   if (walletPubkeyXOnly.toLowerCase() !== depositorPubkey.toLowerCase()) {
     throw new Error(

--- a/packages/babylon-wallet-connector/src/core/wallets/appkit/appKitModal.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/appkit/appKitModal.ts
@@ -3,8 +3,8 @@ import { WagmiAdapter } from "@reown/appkit-adapter-wagmi";
 import type { AppKitNetwork } from "@reown/appkit/networks";
 import { bitcoin, bitcoinSignet } from "@reown/appkit/networks";
 import { createAppKit } from "@reown/appkit/react";
+import { http, type Chain } from "viem";
 import { cookieStorage, createStorage } from "wagmi";
-import type { Chain } from "viem";
 
 import { setSharedBtcAppKitConfig } from "../btc/appkit/sharedConfig";
 import { setSharedWagmiConfig } from "../eth/appkit/sharedConfig";
@@ -100,11 +100,18 @@ export function initializeAppKitModal(config: AppKitModalConfig) {
       storage: cookieStorage,
     });
 
+    // Pin the transport to the chain's configured RPC URL. Without this,
+    // wagmi falls back to viem's bundled public RPC (e.g. sepolia.drpc.org)
+    // which doesn't see contracts on private/devnet deployments.
+    const ethRpcUrl = config.eth.chain.rpcUrls.default.http[0];
     wagmiAdapter = new WagmiAdapter({
       networks: ethNetworks,
       projectId,
       ssr: false,
       storage,
+      transports: {
+        [config.eth.chain.id]: http(ethRpcUrl),
+      },
     });
 
     adapters.push(wagmiAdapter);

--- a/services/vault/src/config/wagmi.ts
+++ b/services/vault/src/config/wagmi.ts
@@ -8,7 +8,7 @@
  * the wagmi config to ensure compatibility.
  */
 
-import { getETHChain } from "@babylonlabs-io/config";
+import { getETHChain, getNetworkConfigETH } from "@babylonlabs-io/config";
 import {
   initializeAppKitModal,
   type AppKitModalConfig,
@@ -84,14 +84,19 @@ function initializeVaultWagmi(): WagmiInitResult {
 }
 
 /**
- * Create a minimal fallback wagmi config for error states
+ * Create a minimal fallback wagmi config for error states.
+ *
+ * Uses the env-configured RPC URL rather than viem's stock chain default,
+ * so reads/writes hit the same endpoint that can see the deployed
+ * contracts even when AppKit initialization fails.
  */
 function createFallbackConfig() {
   const chain = getETHChain();
+  const { rpcUrl } = getNetworkConfigETH();
   return createConfig({
     chains: [chain],
     transports: {
-      [chain.id]: http(),
+      [chain.id]: http(rpcUrl),
     },
   });
 }

--- a/services/vault/src/services/vault/__tests__/vaultTransactionService.test.ts
+++ b/services/vault/src/services/vault/__tests__/vaultTransactionService.test.ts
@@ -63,6 +63,9 @@ vi.mock("../../../clients/eth-contract/client", () => ({
       getPublicClient: vi.fn(),
     })),
   },
+  ethClient: {
+    getPublicClient: vi.fn(() => ({})),
+  },
 }));
 
 describe("vaultTransactionService - preparePeginTransaction", () => {

--- a/services/vault/src/services/vault/vaultTransactionService.ts
+++ b/services/vault/src/services/vault/vaultTransactionService.ts
@@ -17,6 +17,7 @@ import { ensureHexPrefix, PeginManager } from "@babylonlabs-io/ts-sdk/tbv/core";
 import type { Address, Hex, WalletClient } from "viem";
 
 import { getMempoolApiUrl } from "../../clients/btc/config";
+import { ethClient } from "../../clients/eth-contract/client";
 import { CONTRACTS } from "../../config/contracts";
 import { getBTCNetworkForWASM } from "../../config/pegin";
 
@@ -153,6 +154,7 @@ function createPeginManager(
     btcWallet,
     ethWallet,
     ethChain: getETHChain(),
+    publicClient: ethClient.getPublicClient(),
     vaultContracts: {
       btcVaultRegistry: CONTRACTS.BTC_VAULT_REGISTRY,
     },

--- a/services/vault/vitest.config.ts
+++ b/services/vault/vitest.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
     env: {
       NEXT_PUBLIC_BTC_NETWORK: "signet",
       NEXT_PUBLIC_ETH_CHAINID: "11155111", // Sepolia
+      NEXT_PUBLIC_ETH_RPC_URL: "https://test.example/eth",
     },
     exclude: [
       "**/node_modules/**",


### PR DESCRIPTION
Multiple sites in the SDK and config layer were silently routing through
viem's stock chain default RPC (e.g. sepolia.drpc.org) when no transport
was passed, which on devnet deployments produces a misleading "Failed to
query pegin fee from the contract" error instead of a clear RPC failure.

ts-sdk:
- PeginManager: require `publicClient` in config; replace 3 internal
  `createPublicClient({ chain, transport: http() })` sites with the
  injected client; preserve `cause` when re-throwing fee-query errors;
  drop the silent catch in `checkVaultExists` so RPC failures surface
  as themselves instead of being mistaken for "vault doesn't exist".
- PayoutManager: make `depositorBtcPubkey` required so
  `validateWalletPubkey` cannot degrade to a self-comparison; throw
  when callers pass undefined/empty.

babylon-config:
- Make `NEXT_PUBLIC_ETH_RPC_URL` required and throw at module load.
- `getETHChain()` now bakes the configured RPC URL into the chain's
  `rpcUrls.default`, so any downstream code that calls bare `http()`
  still routes to the configured endpoint instead of viem's default.

wallet-connector:
- Pass explicit `transports: { [chain.id]: http(rpcUrl) }` to
  `WagmiAdapter`, derived from the chain's pinned URL.

vault:
- Pass `ethClient.getPublicClient()` into the SDK PeginManager.
- Fallback wagmi config now uses `getNetworkConfigETH().rpcUrl`
  instead of bare `http()`.