### PR TITLE
feat(packages): revert fail-closed inscription classifier gate

### DIFF
--- a/services/vault/src/hooks/__tests__/useUTXOs.test.ts
+++ b/services/vault/src/hooks/__tests__/useUTXOs.test.ts
@@ -1,9 +1,5 @@
 /**
  * Tests for useUTXOs hook
- *
- * Covers the split between non-blocking display (`availableUTXOs`) and
- * fail-closed spend paths (`spendableUTXOs` / `spendableMempoolUTXOs`) when
- * the ordinals classifier is loading or unavailable.
  */
 
 import { useQuery } from "@tanstack/react-query";
@@ -104,98 +100,6 @@ describe("useUTXOs", () => {
       createMempoolUtxo("txid2", 1, 200000),
       createMempoolUtxo("txid3", 2, 300000),
     ];
-
-    it("should fail closed on spendable UTXOs when ordinals API fails and inscriptions are excluded", () => {
-      // Setup: UTXOs loaded successfully
-      mockUseQuery.mockReturnValue({
-        data: confirmedUtxos,
-        isLoading: false,
-        error: null,
-        refetch: vi.fn(),
-      });
-
-      // Setup: Ordinals API returns error
-      mockUseOrdinals.mockReturnValue({
-        inscriptions: [],
-        isLoading: false,
-        error: new Error("Ordinals API returned 500"),
-        refetch: vi.fn(),
-      });
-
-      mockLoggerWarn.mockClear();
-
-      const { result } = renderHook(() => useUTXOs(testAddress));
-
-      // Display collections stay non-blocking so the UI can render totals.
-      expect(result.current.availableUTXOs).toHaveLength(3);
-      expect(result.current.inscriptionUTXOs).toHaveLength(0);
-      // Spend collections fail closed so callers cannot consume unclassified UTXOs.
-      expect(result.current.spendableUTXOs).toHaveLength(0);
-      expect(result.current.spendableMempoolUTXOs).toHaveLength(0);
-      expect(result.current.spendableBlockedByOrdinals).toBe(true);
-
-      expect(mockLoggerWarn).toHaveBeenCalledWith(
-        "Ordinals API failed - display UTXOs unaffected, spend paths blocked when inscriptions excluded",
-        expect.objectContaining({
-          data: { error: "Ordinals API returned 500" },
-        }),
-      );
-    });
-
-    it("should fail closed on spendable UTXOs while ordinals API is loading and inscriptions are excluded", () => {
-      // Setup: UTXOs loaded successfully
-      mockUseQuery.mockReturnValue({
-        data: confirmedUtxos,
-        isLoading: false,
-        error: null,
-        refetch: vi.fn(),
-      });
-
-      // Setup: Ordinals API is still loading
-      mockUseOrdinals.mockReturnValue({
-        inscriptions: [],
-        isLoading: true,
-        error: null,
-        refetch: vi.fn(),
-      });
-
-      const { result } = renderHook(() => useUTXOs(testAddress));
-
-      // Display collections stay non-blocking.
-      expect(result.current.availableUTXOs).toHaveLength(3);
-      expect(result.current.inscriptionUTXOs).toHaveLength(0);
-      // Spend collections fail closed until classification completes.
-      expect(result.current.spendableUTXOs).toHaveLength(0);
-      expect(result.current.spendableMempoolUTXOs).toHaveLength(0);
-      expect(result.current.spendableBlockedByOrdinals).toBe(true);
-
-      // Loading flag should be exposed for UI
-      expect(result.current.isLoadingOrdinals).toBe(true);
-    });
-
-    it("should remain non-blocking on spendable UTXOs when the user has opted in to inscriptions", () => {
-      mockUseAppState.mockReturnValue({ ordinalsExcluded: false });
-
-      mockUseQuery.mockReturnValue({
-        data: confirmedUtxos,
-        isLoading: false,
-        error: null,
-        refetch: vi.fn(),
-      });
-
-      mockUseOrdinals.mockReturnValue({
-        inscriptions: [],
-        isLoading: true,
-        error: null,
-        refetch: vi.fn(),
-      });
-
-      const { result } = renderHook(() => useUTXOs(testAddress));
-
-      expect(result.current.spendableUTXOs).toHaveLength(3);
-      expect(result.current.spendableMempoolUTXOs).toHaveLength(3);
-      expect(result.current.spendableBlockedByOrdinals).toBe(false);
-    });
 
     it("should filter inscription UTXOs when ordinals API succeeds", () => {
       // Setup: UTXOs loaded successfully

--- a/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
@@ -281,7 +281,6 @@ async function setupDefaultMocks() {
     spendableUTXOs: [MOCK_UTXO_1, MOCK_UTXO_2],
     isUTXOsLoading: false,
     utxoError: null,
-    spendableBlockedByOrdinals: false,
   } as any);
 
   vi.mocked(useProtocolParamsContext).mockReturnValue({

--- a/services/vault/src/hooks/deposit/useBtcWalletState.ts
+++ b/services/vault/src/hooks/deposit/useBtcWalletState.ts
@@ -9,17 +9,11 @@ export function useBtcWalletState() {
     spendableUTXOs,
     isLoading: isUTXOsLoading,
     error: utxoError,
-    spendableBlockedByOrdinals,
-    isLoadingOrdinals,
-    ordinalsError,
   } = useUTXOs(btcAddress);
   return {
     btcAddress,
     spendableUTXOs,
     isUTXOsLoading,
     utxoError,
-    spendableBlockedByOrdinals,
-    isLoadingOrdinals,
-    ordinalsError,
   };
 }

--- a/services/vault/src/hooks/deposit/useDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useDepositFlow.ts
@@ -237,15 +237,8 @@ export function useDepositFlow(
   }, [abort]);
 
   // Hooks
-  const {
-    btcAddress,
-    spendableUTXOs,
-    isUTXOsLoading,
-    utxoError,
-    spendableBlockedByOrdinals,
-    isLoadingOrdinals,
-    ordinalsError,
-  } = useBtcWalletState();
+  const { btcAddress, spendableUTXOs, isUTXOsLoading, utxoError } =
+    useBtcWalletState();
   const { findProvider } = useVaultProviders(selectedApplication);
   const { config, timelockPegin, timelockRefund, minDeposit, maxDeposit } =
     useProtocolParamsContext();
@@ -285,25 +278,6 @@ export function useDepositFlow(
         }
         if (utxoError) {
           throw new Error(`Failed to load UTXOs: ${utxoError.message}`);
-        }
-        if (spendableBlockedByOrdinals) {
-          if (ordinalsError) {
-            const ordinalsMessage =
-              ordinalsError instanceof Error
-                ? ordinalsError.message
-                : String(ordinalsError);
-            throw new Error(
-              `Inscription detection failed: ${ordinalsMessage}. Depositing is blocked until the ordinals classifier is available again.`,
-            );
-          }
-          if (isLoadingOrdinals) {
-            throw new Error(
-              "Inscription detection is still in progress. Please wait for the ordinals check to complete before depositing.",
-            );
-          }
-          throw new Error(
-            "Inscription detection is unavailable. Depositing is blocked until the ordinals classifier produces a result.",
-          );
         }
 
         if (!spendableUTXOs) {
@@ -904,9 +878,6 @@ export function useDepositFlow(
       spendableUTXOs,
       isUTXOsLoading,
       utxoError,
-      spendableBlockedByOrdinals,
-      isLoadingOrdinals,
-      ordinalsError,
       findProvider,
     ]);
 

--- a/services/vault/src/hooks/useUTXOs.ts
+++ b/services/vault/src/hooks/useUTXOs.ts
@@ -84,31 +84,27 @@ export function useUTXOs(
   // Log ordinals API errors once when the error changes (not on every render)
   useEffect(() => {
     if (ordinalsError) {
-      logger.warn(
-        "Ordinals API failed - display UTXOs unaffected, spend paths blocked when inscriptions excluded",
-        {
-          data: {
-            error:
-              ordinalsError instanceof Error
-                ? ordinalsError.message
-                : String(ordinalsError),
-          },
+      logger.warn("Ordinals API failed, treating all UTXOs as available", {
+        data: {
+          error:
+            ordinalsError instanceof Error
+              ? ordinalsError.message
+              : String(ordinalsError),
         },
-      );
+      });
     }
   }, [ordinalsError]);
 
   // Filter UTXOs by inscriptions
   // Rename to match exported API naming convention (uppercase UTXO)
-  // Display-only: if ordinals API failed or is still loading, treat all UTXOs as available for UI rendering.
-  // Spend paths use a separate fail-closed gate below (see `spendableBlockedByOrdinals`).
-  // UI should use isLoading/isLoadingOrdinals flags to show loading states.
+  // If ordinals API fails or is still loading, treat all UTXOs as available (non-blocking)
+  // UI should use isLoading/isLoadingOrdinals flags to show loading states
   const { availableUTXOs, inscriptionUTXOs } = useMemo(() => {
     if (confirmedUtxosForOrdinals.length === 0) {
       return { availableUTXOs: [], inscriptionUTXOs: [] };
     }
-    // Display-only fallback: treat all UTXOs as available so the UI can still render totals.
-    // Spend paths are gated separately below.
+    // If ordinals API failed or still loading, treat all UTXOs as available
+    // Ordinals check is optional - we don't block on it
     if (ordinalsError || isLoadingOrdinals) {
       return {
         availableUTXOs: confirmedUtxosForOrdinals,
@@ -130,29 +126,14 @@ export function useUTXOs(
     ordinalsError,
   ]);
 
-  // Fail-closed gate: when the user has opted to exclude inscriptions, we cannot
-  // safely classify UTXOs as spendable until the ordinals classifier has produced
-  // a result. Surfacing this separately from `availableUTXOs` keeps the existing
-  // non-blocking display semantics while preventing spend paths from consuming
-  // unclassified UTXOs.
-  const spendableBlockedByOrdinals =
-    ordinalsExcluded && (isLoadingOrdinals || Boolean(ordinalsError));
-
   // Determine spendable UTXOs based on preference
   // When ordinalsExcluded is true (default), use availableUTXOs (excludes inscriptions)
   // When ordinalsExcluded is false, use all confirmed UTXOs
-  // When ordinals classification is unknown (loading or errored) AND the user opted
-  // to exclude inscriptions, return an empty set so callers cannot spend
-  // potentially inscription-bearing UTXOs.
-  const spendableUTXOs = useMemo(() => {
-    if (spendableBlockedByOrdinals) return [];
-    return ordinalsExcluded ? availableUTXOs : confirmedUtxosForOrdinals;
-  }, [
-    spendableBlockedByOrdinals,
-    ordinalsExcluded,
-    availableUTXOs,
-    confirmedUtxosForOrdinals,
-  ]);
+  // If ordinals API failed/loading, availableUTXOs already contains all confirmed UTXOs
+  const spendableUTXOs = useMemo(
+    () => (ordinalsExcluded ? availableUTXOs : confirmedUtxosForOrdinals),
+    [ordinalsExcluded, availableUTXOs, confirmedUtxosForOrdinals],
+  );
 
   // Create a set of inscription UTXO identifiers for filtering MempoolUTXOs
   const inscriptionUTXOIds = useMemo(() => {
@@ -175,9 +156,8 @@ export function useUTXOs(
     confirmedUtxosForOrdinals.length > 0;
 
   // Spendable UTXOs in MempoolUTXO format (for SDK functions)
-  // Mirrors the fail-closed gate above.
+  // If ordinals API failed/loading, inscriptionUTXOIds will be empty, so all UTXOs pass filter
   const spendableMempoolUTXOs = useMemo(() => {
-    if (spendableBlockedByOrdinals) return [];
     if (!ordinalsExcluded) {
       return confirmedUTXOs;
     }
@@ -185,25 +165,14 @@ export function useUTXOs(
     return confirmedUTXOs.filter(
       (utxo) => !inscriptionUTXOIds.has(`${utxo.txid}:${utxo.vout}`),
     );
-  }, [
-    spendableBlockedByOrdinals,
-    ordinalsExcluded,
-    confirmedUTXOs,
-    inscriptionUTXOIds,
-  ]);
+  }, [ordinalsExcluded, confirmedUTXOs, inscriptionUTXOIds]);
 
   return {
     /** All UTXOs (including unconfirmed) */
     allUTXOs: data || [],
     /** Only confirmed UTXOs (may include inscriptions) */
     confirmedUTXOs,
-    /**
-     * Display-only: confirmed UTXOs with known inscriptions removed. When the
-     * ordinals classifier is loading or has errored, this falls back to all
-     * confirmed UTXOs so the UI can still render totals — so it is NOT
-     * fail-closed and must not be used for spend paths. Use `spendableUTXOs`
-     * (gated by `spendableBlockedByOrdinals`) for spending.
-     */
+    /** Confirmed UTXOs without inscriptions (safe to spend) */
     availableUTXOs,
     /** Confirmed UTXOs that contain inscriptions */
     inscriptionUTXOs,
@@ -211,8 +180,6 @@ export function useUTXOs(
     spendableUTXOs,
     /** Spendable UTXOs in MempoolUTXO format (for SDK functions) */
     spendableMempoolUTXOs,
-    /** True when spend paths are blocked because ordinals classification is not yet known */
-    spendableBlockedByOrdinals,
     /** Loading state */
     isLoading,
     /** Loading state (ordinals detection) */


### PR DESCRIPTION
Reverts #1416

The ordinals/inscription classifier is best-effort and its backend is unreliable, so blocking deposits when the check fails or is loading produces too many false positives.

The soft warning banner with acknowledgement checkbox in DepositForm (#1452) remains as the user-facing safeguard.