### PR TITLE
docs(wallet-connector): refocus vault integration guide on BTC wallet…

### DIFF
--- a/packages/babylon-wallet-connector/docs/vault-integration-guide.md
+++ b/packages/babylon-wallet-connector/docs/vault-integration-guide.md
@@ -1,54 +1,84 @@
-# Vault Wallet Integration Guide
+# BTC Wallet Integration Guide for Babylon Vault
 
 - [Overview](#overview)
+- [Capability Matrix](#capability-matrix)
 - [For Wallets Already Supporting BTC Staking][staking]
-- [Bitcoin Wallet Interface](#bitcoin-wallet-interface)
-  - [SignPsbtOptions](#signpsbtoptions)
-  - [deriveContextHash](#derivecontexthash)
-- [Ethereum Wallet Interface](#ethereum-wallet-interface)
 - [Vault Deposit Flow](#vault-deposit-flow)
-- [Source Code References](#source-code-references)
+- [Bitcoin Wallet Interface](#bitcoin-wallet-interface)
+- [Common Incompatibilities](#common-incompatibilities)
+- [Hardware Wallets](#hardware-wallets)
+- [Ethereum Wallet](#ethereum-wallet)
 
 [staking]: #for-wallets-already-supporting-btc-staking
+[spec]: ../../../docs/specs/derive-context-hash.md
 
 ## Overview
 
 Babylon's Trustless Bitcoin Vaults (TBV) let users lock
 BTC on Bitcoin and receive vaultBTC on Ethereum for use
-as DeFi collateral. Wallet partners must support **two
-chains**: a Bitcoin wallet for PSBT signing and message
-signing, and an Ethereum wallet via WalletConnect.
+as DeFi collateral. The user locks BTC into a Taproot
+script-path output, registers the vault on Ethereum, and
+later activates the vault by revealing a hashlock secret
+to mint the matching vaultBTC.
+
+This guide is for **BTC wallet vendors** integrating with
+TBV. The Ethereum side is hands-off — see
+[Ethereum Wallet](#ethereum-wallet).
+
+Status: pre-mainnet. Some details (notably
+`deriveContextHash`) may evolve before launch.
+
+## Capability Matrix
+
+**MUST** = deposits fail without it. **STRONGLY
+RECOMMENDED** = deposits work, UX degrades. **OPTIONAL** =
+nice-to-have.
+
+| Capability | Requirement | Why / where enforced |
+|---|---|---|
+| BIP-340 Schnorr + BIP-341 Taproot script-path spends with untweaked key | MUST | Vault HTLC scripts use Taproot script-path; SDK passes `useTweakedSigner: false` ([`signing.ts`][signing]) |
+| 64-byte Schnorr signatures (implicit `SIGHASH_DEFAULT`) | MUST | SDK rejects 65-byte sigs; the appended sighash byte changes the signed message and cannot be stripped ([`peginInput.ts`][peginInput], [`payout.ts`][payout]) |
+| Non-finalized PSBT return for PegIn input PSBTs | MUST | SDK extracts the depositor signature from `tapScriptSig`; finalized PegIn PSBTs throw outright ([`peginInput.ts`][peginInput]) |
+| BIP-322 simple message signing | MUST | Used for proof-of-possession ([`PeginManager.ts`][peginManager]) |
+| `deriveContextHash` (HKDF-SHA-256, BIP-32 hardened path `m/73681862'`) | MUST | Hashlock secret derivation — see [spec][spec] for derivation algorithm and test vectors |
+| `signPsbts` (batch signing) | STRONGLY RECOMMENDED | Without it, depositors approve N PSBTs one-by-one |
+| `getInscriptions` | OPTIONAL | UTXO filtering only |
+
+[signing]: ../../babylon-ts-sdk/src/tbv/core/utils/signing.ts
+[peginInput]: ../../babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts
+[payout]: ../../babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts
 
 ## For Wallets Already Supporting BTC Staking
+
+*Skip this section if your wallet has not previously
+integrated Babylon BTC staking.*
 
 If your wallet already implements `IBTCProvider` for
 Babylon BTC staking, here's what's new for TBV:
 
-- **`signPsbts()` is now critical** — TBV signs multiple
-  PSBTs per deposit + payout pre-signing. Without batch
-  signing, each PSBT requires a separate user approval.
-- **`SignPsbtOptions` expanded** — New field `signInputs`
-  with `useTweakedSigner` (set `false` for Taproot script
-  path spends).
-- **`deriveContextHash()` required** — TBV derives
-  hashlock secrets from wallet key material. See
-  [deriveContextHash](#derivecontexthash).
-- **Ethereum wallet required** — Staking was BTC-only.
-  TBV requires an ETH wallet for on-chain registration
-  and DeFi. Uses viem `WalletClient` — any
-  EIP-1193/wagmi/WalletConnect wallet works.
-- **No more BBN/Cosmos** — Staking used `IBBNProvider`.
-  TBV replaces this with Ethereum.
-
 | Aspect | TBV Vault | BTC Staking |
-|--------|-----------|-------------|
+|---|---|---|
 | BTC wallet | `IBTCProvider` | Same |
-| ETH wallet | **Required** — viem `WalletClient` | N/A |
-| Batch signing | Critical — multiple PSBTs | Delegation |
+| ETH wallet | **Required** — via WalletConnect (no work for the BTC wallet team) | N/A |
+| Batch signing | Critical — multiple PSBTs per deposit + payout pre-signing | Delegation only |
 | Message signing | `"bip322-simple"` for PoP | Same |
-| Taproot path | `useTweakedSigner: false` | Same |
-| Hashlock | `deriveContextHash` — new | N/A |
+| Taproot path | `useTweakedSigner: false` (untweaked key) | Same |
+| Schnorr signature size | **Strictly 64 bytes — no sighash byte** | Either accepted |
+| Hashlock derivation | `deriveContextHash` — new requirement | N/A |
 | Chains | **Dual**: BTC + ETH | BTC + Cosmos |
+
+## Vault Deposit Flow
+
+From the BTC wallet's perspective, a deposit triggers
+these signing prompts in order. Steps interleaved between
+these are Ethereum transactions handled by the user's ETH
+wallet — not this wallet's concern.
+
+1. **Derive vault root** — `deriveContextHash("babylon-vault", context)`, once per deposit batch (regardless of vault count). The SDK expands per-vault secrets locally from this root.
+2. **Sign Proof-of-Possession** — `signMessage(message, "bip322-simple")`, once per deposit session.
+3. **Batch-sign PegIn input PSBTs** — `signPsbts(psbtsHexes, options)` (Taproot script-path, untweaked, non-finalized). Falls back to sequential `signPsbt()` if batch unavailable.
+4. **Sign Pre-PegIn funding transaction** — `signPsbt(psbtHex)` after Ethereum registration succeeds. Standard funding-input signing across whatever UTXO types the wallet contributes.
+5. **Sign payout transactions** — `signPsbts(psbtsHexes, options)`. Multiple PSBTs per vault: claimer payout, no-payout, challenge-assert, and depositor-graph.
 
 ## Bitcoin Wallet Interface
 
@@ -57,20 +87,21 @@ TBV uses the `IBTCProvider` interface from
 are in [`src/core/types.ts`](../src/core/types.ts).
 
 | Method | Signature | Purpose |
-|--------|-----------|---------|
+|---|---|---|
 | `connectWallet` | `() => Promise<void>` | Connect to the wallet |
-| `getAddress` | `() => Promise<string>` | Get BTC address |
+| `getAddress` | `() => Promise<string>` | Get BTC address. The depositor identity for vault deposits is a Taproot account (P2TR `bc1p…` / `tb1p…`). |
 | `getPublicKeyHex` | `() => Promise<string>` | Get public key hex. Taproot: x-only (32 bytes, 64 hex, no `0x`). Compressed (33 bytes) also accepted — SDK strips first byte. |
-| `signPsbt` | `(psbtHex: string, options?: SignPsbtOptions) => Promise<string>` | Sign a single PSBT. Must support `useTweakedSigner`. See [SignPsbtOptions](#signpsbtoptions). |
+| `signPsbt` | `(psbtHex: string, options?: SignPsbtOptions) => Promise<string>` | Sign a single PSBT. See [SignPsbtOptions](#signpsbtoptions). |
 | `signPsbts` | `(psbtsHexes: string[], options?: SignPsbtOptions[]) => Promise<string[]>` | Batch sign PSBTs in one prompt. Falls back to sequential `signPsbt()` if unavailable. |
-| `signMessage` | `(message: string, type: "bip322-simple" \| "ecdsa") => Promise<string>` | Sign a message. TBV uses `"bip322-simple"` for PoP. |
+| `signMessage` | `(message: string, type: "bip322-simple" \| "ecdsa") => Promise<string>` | Sign a message. TBV uses `"bip322-simple"` for PoP. See [PoP message format](#pop-message-format). |
 | `deriveContextHash` | `(appName: string, context: string) => Promise<string>` | Derive 32-byte value via HKDF-SHA-256. See [deriveContextHash](#derivecontexthash) and [spec][spec]. |
-| `getNetwork` | `() => Promise<Network>` | Get BTC network |
-| `on` | `(eventName: string, cb: () => void) => void` | Register event listener |
-| `off` | `(eventName: string, cb: () => void) => void` | Unregister event listener |
+| `getNetwork` | `() => Promise<Network>` | Get BTC network. Wallet must operate on the network the dApp is configured for (signet vs mainnet); mismatch must error. |
+| `on` / `off` | `(eventName: string, cb: () => void) => void` | Register/unregister event listener |
 | `getInscriptions` | `() => Promise<InscriptionIdentifier[]>` | Optional. UTXO filtering. |
 
-[spec]: ../../../docs/specs/derive-context-hash.md
+Reference implementations:
+[Unisat](../src/core/wallets/btc/unisat/provider.ts),
+[OKX](../src/core/wallets/btc/okx/provider.ts).
 
 ### SignPsbtOptions
 
@@ -89,18 +120,16 @@ interface SignInputOptions {
 }
 ```
 
-**`useTweakedSigner`**: TBV vault transactions use
-Taproot **script path** spends. When
-`useTweakedSigner: false`, the wallet must sign with the
-**untweaked** private key (raw internal key). Signing with
-the tweaked key produces an invalid signature.
+For vault Taproot script-path PSBTs, the SDK always
+passes `autoFinalized: false` and `useTweakedSigner:
+false` ([`signing.ts`][signing]). Wallets MUST honor
+both: return a non-finalized PSBT with `tapScriptSig`
+entries, signed with the **untweaked internal key**.
+Auto-finalizing PegIn input PSBTs causes the SDK to
+throw — the depositor signature cannot be reliably
+extracted from the witness stack.
 
 ### deriveContextHash
-
-TBV uses `deriveContextHash("babylon-vault", context)` to
-derive hashlock secrets for HTLC deposits. The derived
-value is committed as a SHA-256 hashlock during vault
-creation and later revealed during activation.
 
 ```ts
 deriveContextHash(
@@ -109,120 +138,79 @@ deriveContextHash(
 ): Promise<string>
 ```
 
-- **`appName`** — `"babylon-vault"`. Must be
-  `[a-z0-9\-]`, 1–64 bytes. The wallet MUST display
-  this in the approval dialog alongside the requesting
-  origin.
-- **`context`** — Hex-encoded application-specific data
-  (e.g., transaction ID + output index + public key).
-  Must be non-empty, lowercase hex, even-length, no
-  `0x` prefix, max 1024 bytes. Different contexts
-  produce independent outputs.
-- **Returns** — 64-character lowercase hex string
-  (32 bytes).
+TBV uses `deriveContextHash("babylon-vault", context)` to
+derive hashlock secrets for HTLC deposits. The derived
+value is committed as a SHA-256 hashlock during vault
+creation and revealed during activation.
 
-The wallet MUST reject invalid `appName` or `context`
-inputs and MUST require user approval before returning
-the derived value.
+Implementation requirements (see [spec][spec] for full
+detail and test vectors):
 
-The wallet must implement HKDF-SHA-256 derivation per
-the [full specification][spec], which includes the
-derivation algorithm, BIP-32 key path, input validation
-rules, and test vectors for conformance testing.
+- BIP-32 hardened derivation path `m/73681862'`.
+- HKDF-SHA-256 with the spec's fixed salt and `info` constructed from `appName` + `context`.
+- 32-byte output (64 lowercase hex chars).
+- `appName` must match `[a-z0-9\-]`, 1–64 bytes.
+- `context` must be lowercase hex, even-length, non-empty, no `0x` prefix, max 1024 bytes.
+- Wallet MUST require user approval and display `appName` ("babylon-vault") and the requesting origin.
 
-## Ethereum Wallet Interface
+### PoP Message Format
 
-The ETH wallet must be compatible with WalletConnect.
-Connection is handled via AppKit / WalletConnect.
+The exact string signed in step 2 of the deposit flow:
 
-The full `IETHProvider` interface is documented in the
-[main README](../README.md#iethprovider).
+```
+${depositorEthAddress.toLowerCase()}:${ethChainId}:pegin:${btcVaultRegistryAddress.toLowerCase()}
+```
 
-## Vault Deposit Flow
+Concrete example (sepolia, chain ID `11155111`):
 
-From the wallet's perspective, a deposit triggers these
-signing prompts in order:
+```
+0xabcdef0123456789abcdef0123456789abcdef01:11155111:pegin:0x123456789abcdef0123456789abcdef012345678
+```
 
-### Step 1: Derive Hashlock Secret
+Source: [`PeginManager.ts`][peginManager]. Wallet UI
+should render this as readable text (lowercase Ethereum
+address, decimal chain ID, the literal token `pegin`,
+lowercase contract address) rather than raw bytes.
 
-**Method**: `deriveContextHash("babylon-vault", context)`
+[peginManager]: ../../babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
 
-The SDK derives a deterministic secret for each vault's
-hashlock. The secret is hashed (SHA-256) to produce the
-hashlock committed in the Bitcoin HTLC script and later
-revealed on Ethereum during activation.
+## Common Incompatibilities
 
-### Step 2: Sign Proof-of-Possession
+These are the patterns most likely to break a new
+integration. Each fails-closed in the SDK rather than
+silently producing wrong output.
 
-**Method**: `signMessage(message, "bip322-simple")`
+- **Auto-finalizing PegIn input PSBTs.** Must return non-finalized with `tapScriptSig`. Finalized PSBTs throw at extraction.
+- **65-byte Schnorr signatures** (with `SIGHASH_ALL` `0x01` appended). Must be exactly 64 bytes (implicit `SIGHASH_DEFAULT`). Rejected by the SDK rather than stripped.
+- **Tweaked-only Taproot signing.** Vault PSBTs are Taproot script-path spends and need the untweaked internal key. Honor `useTweakedSigner: false`.
+- **No `deriveContextHash` support.** Hashlock derivation is mandatory; the deposit cannot proceed without it.
+- **Mutating Pre-PegIn outputs.** The Pre-PegIn includes a 32-byte OP_RETURN at `vout = vaultCount` (exact 34-byte script). Wallets MUST NOT reorder outputs, strip/modify the OP_RETURN, change the fee, or add anti-fee-sniping `nLocktime` tweaks.
+- **Network mismatch.** Wallet must operate on the network the dApp is configured for (signet for testnet, mainnet for prod). Silent address-type swaps must error.
+- **No batch `signPsbts`.** Not a hard incompatibility, but UX degrades to N popups per deposit + payout-presigning round.
+- **Address-type drift on reconnect.** Returning P2WPKH after a Taproot address was used earlier in the session breaks the deposit. The wallet must keep the depositor identity stable for the session.
+- **PSBT version mismatch.** The SDK passes BIP-174 PSBTv0; wallets that only accept v2 will fail.
 
-A BIP-322 message proving the depositor owns the Bitcoin
-address. Signed once per deposit session — for
-multi-vault deposits, the first signature is reused for
-subsequent vaults.
+Conformance test vectors for `deriveContextHash` and the
+exact wire format are in the [spec][spec] (§4 — Test
+Vectors).
 
-### Step 3: Batch Sign PegIn Input PSBTs
+## Hardware Wallets
 
-**Method**: `signPsbts(psbtsHexes, options)`
+Hardware wallet support is preliminary. Stock Bitcoin apps
+on Ledger and Trezor do not expose `deriveContextHash`
+(custom HKDF beyond BIP-32), have limited BIP-322
+support, and have small-screen constraints that make
+batch payout signing impractical. Vendors with HW
+interest should plan for either a dedicated Babylon Vault
+app or a custom HKDF derivation extension to the stock
+Bitcoin app, plus full conformance against the spec test
+vectors and a mainnet/signet deposit-flow run before
+advertising support.
 
-The SDK constructs one PegIn input PSBT per vault in the
-deposit. All PSBTs are presented for batch signing. These
-are Taproot script path spends — `signInputs` will
-include `useTweakedSigner: false`. Falls back to
-sequential `signPsbt()` if the wallet does not support
-batch signing.
+## Ethereum Wallet
 
-### Step 4: Register Vaults on Ethereum
-
-**Method**: ETH `sendTransaction()`
-
-A single Ethereum transaction batch-registers all vaults
-in the deposit on the TBV smart contract with the signed
-PegIn data and PoP signature.
-
-### Step 5: Sign Pre-PegIn Funding Transaction
-
-**Method**: `signPsbt(psbtHex)`
-
-After Ethereum registration succeeds, the Bitcoin funding
-transaction (Pre-PegIn) is signed and broadcast. This is
-a single PSBT containing all vault HTLC outputs.
-
-### Step 6: Sign Payout Transactions
-
-**Method**: `signPsbts(psbtsHexes, options)`
-
-After Bitcoin confirmation, the wallet pre-signs payout
-transactions per vault:
-
-1. **Claimer payout signing** — payout, no-payout,
-   challenge-assert PSBTs per challenger
-2. **Depositor-as-claimer presigning** — depositor graph
-   PSBTs
-
-These signatures are stored by the vault provider and
-used if a payout event occurs later. Falls back to
-sequential `signPsbt()` if batch signing is unavailable.
-
-### Step 7: Activate Vault on Ethereum
-
-**Method**: ETH `sendTransaction()`
-
-After vault verification completes (~12 min), the wallet
-sends an `activateVaultWithSecret` transaction per vault
-to finalize activation. The hashlock secret derived in
-Step 1 is revealed on-chain.
-
-## Source Code References
-
-| Component | Path |
-|-----------|------|
-| `IBTCProvider` | [`src/core/types.ts`][types] |
-| `IETHProvider` | [`src/core/types.ts`][types] |
-| `deriveContextHash` spec | [spec][spec] |
-| Unisat (reference) | [`unisat/provider.ts`][unisat] |
-| OKX (reference) | [`okx/provider.ts`][okx] |
-
-[types]: ../src/core/types.ts
-[unisat]: ../src/core/wallets/btc/unisat/provider.ts
-[okx]: ../src/core/wallets/btc/okx/provider.ts
+Babylon handles the Ethereum side via AppKit /
+WalletConnect. BTC wallet vendors do not need a custom
+ETH adapter — any wallet listed in WalletConnect with
+standard EIP-1193 transaction signing works out of the
+box.


### PR DESCRIPTION
Restructure the vault integration guide so it reads as a single source
of truth for BTC wallet vendors. The Ethereum side is hands-off — any
wallet listed on WalletConnect works out of the box — so collapse it
to one short section instead of dual-chain coverage.