### PR TITLE
fix(vault): verify on-chain prePeginTxHash before resume-flow wallet derivations

### DIFF
--- a/services/vault/src/components/simple/ResumeDepositContent.tsx
+++ b/services/vault/src/components/simple/ResumeDepositContent.tsx
@@ -22,6 +22,7 @@ import {
   uint8ArrayToHex,
 } from "@babylonlabs-io/ts-sdk/tbv/core";
 import { primeVpTokenRegistry } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
+import { calculateBtcTxHash } from "@babylonlabs-io/ts-sdk/tbv/core/utils";
 import { useChainConnector } from "@babylonlabs-io/wallet-connector";
 import { useCallback, useState } from "react";
 import type { Address, Hex } from "viem";
@@ -228,6 +229,24 @@ export function ResumeWotsContent({
       const depositorBtcPubkey = basic.depositorBtcPubKey;
       const htlcVout = protocol.htlcVout;
       const onChainWotsPkHash = protocol.depositorWotsPkHash;
+      const onChainPrePeginTxHash = protocol.prePeginTxHash;
+
+      // Validate that the indexer-provided Pre-PegIn tx matches the on-chain
+      // hash before feeding its outpoints into the wallet's deriveContextHash.
+      // Without this check, a compromised indexer can ask the wallet to derive
+      // over attacker-chosen funding outpoints; the downstream WOTS-hash
+      // compare would still reject, but the wallet has already produced a
+      // derivation over an attacker-chosen 72-byte context.
+      const computedTxHash = calculateBtcTxHash(activity.unsignedPrePeginTx);
+      if (
+        computedTxHash.toLowerCase() !== onChainPrePeginTxHash.toLowerCase()
+      ) {
+        throw new Error(
+          `Pre-PegIn transaction hash mismatch: computed ${computedTxHash} from indexer tx, ` +
+            `but on-chain contract has ${onChainPrePeginTxHash}. ` +
+            `Aborting to prevent potential attack.`,
+        );
+      }
 
       const fundingOutpoints = parseFundingOutpointsFromTx(
         activity.unsignedPrePeginTx,
@@ -278,6 +297,7 @@ export function ResumeWotsContent({
       }
 
       await submitWotsPublicKey({
+        vaultId: activity.id,
         peginTxHash,
         depositorBtcPubkey,
         providerAddress,
@@ -388,6 +408,24 @@ export function ResumeActivationContent({
       const { basic, protocol } = await reader.getVaultData(activity.id as Hex);
       const depositorBtcPubkey = basic.depositorBtcPubKey;
       const htlcVout = protocol.htlcVout;
+      const onChainPrePeginTxHash = protocol.prePeginTxHash;
+
+      // Validate that the indexer-provided Pre-PegIn tx matches the on-chain
+      // hash before feeding its outpoints into the wallet's deriveContextHash.
+      // Without this check, a compromised indexer can ask the wallet to derive
+      // over attacker-chosen funding outpoints; the downstream hashlock check
+      // would still reject, but the wallet has already produced a derivation
+      // over an attacker-chosen 72-byte context.
+      const computedTxHash = calculateBtcTxHash(activity.unsignedPrePeginTx);
+      if (
+        computedTxHash.toLowerCase() !== onChainPrePeginTxHash.toLowerCase()
+      ) {
+        throw new Error(
+          `Pre-PegIn transaction hash mismatch: computed ${computedTxHash} from indexer tx, ` +
+            `but on-chain contract has ${onChainPrePeginTxHash}. ` +
+            `Aborting to prevent potential attack.`,
+        );
+      }
 
       const fundingOutpoints = parseFundingOutpointsFromTx(
         activity.unsignedPrePeginTx,

--- a/services/vault/src/components/simple/ResumeDepositContent.tsx
+++ b/services/vault/src/components/simple/ResumeDepositContent.tsx
@@ -231,12 +231,8 @@ export function ResumeWotsContent({
       const onChainWotsPkHash = protocol.depositorWotsPkHash;
       const onChainPrePeginTxHash = protocol.prePeginTxHash;
 
-      // Validate that the indexer-provided Pre-PegIn tx matches the on-chain
-      // hash before feeding its outpoints into the wallet's deriveContextHash.
-      // Without this check, a compromised indexer can ask the wallet to derive
-      // over attacker-chosen funding outpoints; the downstream WOTS-hash
-      // compare would still reject, but the wallet has already produced a
-      // derivation over an attacker-chosen 72-byte context.
+      // Indexer-supplied tx is untrusted. Verify against on-chain
+      // prePeginTxHash before deriveVaultRoot fires the wallet popup.
       const computedTxHash = calculateBtcTxHash(activity.unsignedPrePeginTx);
       if (
         computedTxHash.toLowerCase() !== onChainPrePeginTxHash.toLowerCase()
@@ -410,12 +406,8 @@ export function ResumeActivationContent({
       const htlcVout = protocol.htlcVout;
       const onChainPrePeginTxHash = protocol.prePeginTxHash;
 
-      // Validate that the indexer-provided Pre-PegIn tx matches the on-chain
-      // hash before feeding its outpoints into the wallet's deriveContextHash.
-      // Without this check, a compromised indexer can ask the wallet to derive
-      // over attacker-chosen funding outpoints; the downstream hashlock check
-      // would still reject, but the wallet has already produced a derivation
-      // over an attacker-chosen 72-byte context.
+      // Indexer-supplied tx is untrusted. Verify against on-chain
+      // prePeginTxHash before deriveVaultRoot fires the wallet popup.
       const computedTxHash = calculateBtcTxHash(activity.unsignedPrePeginTx);
       if (
         computedTxHash.toLowerCase() !== onChainPrePeginTxHash.toLowerCase()

--- a/services/vault/src/components/simple/__tests__/ResumeDepositContent.test.tsx
+++ b/services/vault/src/components/simple/__tests__/ResumeDepositContent.test.tsx
@@ -1,0 +1,256 @@
+/**
+ * Tests for ResumeDepositContent — focused on the trust boundary around
+ * `activity.unsignedPrePeginTx`. Both ResumeWotsContent and ResumeActivationContent
+ * must verify the indexer-supplied tx hex against the on-chain prePeginTxHash
+ * BEFORE invoking the wallet's deriveContextHash; otherwise a compromised
+ * indexer can ask the wallet to derive over attacker-chosen funding outpoints.
+ */
+
+import { render, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getVaultRegistryReader } from "@/clients/eth-contract/sdk-readers";
+import type { VaultActivity } from "@/types/activity";
+
+import {
+  ResumeActivationContent,
+  ResumeWotsContent,
+} from "../ResumeDepositContent";
+
+const mockCalculateBtcTxHash = vi.hoisted(() =>
+  vi.fn(() => "0xmatching_pre_pegin_hash"),
+);
+const mockDeriveVaultRoot = vi.hoisted(() => vi.fn());
+const mockParseFundingOutpointsFromTx = vi.hoisted(() => vi.fn(() => []));
+const mockHandleActivation = vi.hoisted(() => vi.fn());
+const mockSubmitWotsPublicKey = vi.hoisted(() => vi.fn());
+
+vi.mock("@babylonlabs-io/ts-sdk/tbv/core", () => ({
+  computeWotsBlockPublicKeysHash: vi.fn(() => "0xwotshash"),
+  deriveVaultRoot: mockDeriveVaultRoot,
+  deriveWotsBlocksFromSeed: vi.fn(() => Promise.resolve([])),
+  expandAuthAnchor: vi.fn(() => new Uint8Array(32)),
+  expandHashlockSecret: vi.fn(() => new Uint8Array(32)),
+  expandWotsSeed: vi.fn(() => new Uint8Array(32)),
+  hexToUint8Array: vi.fn(() => new Uint8Array(32)),
+  isWotsMismatchError: vi.fn(() => false),
+  parseFundingOutpointsFromTx: mockParseFundingOutpointsFromTx,
+  uint8ArrayToHex: vi.fn(() => "00".repeat(32)),
+}));
+
+vi.mock("@babylonlabs-io/ts-sdk/tbv/core/clients", () => ({
+  primeVpTokenRegistry: vi.fn(),
+}));
+
+vi.mock("@babylonlabs-io/ts-sdk/tbv/core/utils", () => ({
+  calculateBtcTxHash: mockCalculateBtcTxHash,
+}));
+
+vi.mock("@babylonlabs-io/wallet-connector", () => ({
+  useChainConnector: vi.fn(() => ({
+    connectedWallet: { provider: { id: "btc-wallet" } },
+  })),
+}));
+
+vi.mock("@/clients/eth-contract/sdk-readers", () => ({
+  getVaultRegistryReader: vi.fn(),
+}));
+
+vi.mock("@/components/deposit/DepositSignModal/depositStepHelpers", () => ({
+  computeDepositDerivedState: vi.fn(() => ({
+    isComplete: false,
+    isProcessing: false,
+    canClose: true,
+    canContinueInBackground: false,
+  })),
+  DepositFlowStep: {
+    SIGN_PAYOUTS: "SIGN_PAYOUTS",
+    BROADCAST_PRE_PEGIN: "BROADCAST_PRE_PEGIN",
+    ACTIVATE_VAULT: "ACTIVATE_VAULT",
+    COMPLETED: "COMPLETED",
+  },
+}));
+
+vi.mock("@/components/deposit/PayoutSignModal/usePayoutSigningState", () => ({
+  usePayoutSigningState: vi.fn(() => ({
+    signing: false,
+    progress: null,
+    error: null,
+    isComplete: false,
+    handleSign: vi.fn(),
+  })),
+}));
+
+vi.mock("@/hooks/deposit/depositFlowSteps/wotsSubmission", () => ({
+  submitWotsPublicKey: mockSubmitWotsPublicKey,
+}));
+
+vi.mock("@/hooks/deposit/useActivationState", () => ({
+  useActivationState: vi.fn(() => ({
+    activating: false,
+    error: null,
+    handleActivation: mockHandleActivation,
+  })),
+}));
+
+vi.mock("@/hooks/deposit/useBroadcastState", () => ({
+  useBroadcastState: vi.fn(() => ({
+    broadcasting: false,
+    error: null,
+    handleBroadcast: vi.fn(),
+  })),
+}));
+
+vi.mock("@/hooks/deposit/useReleaseVpTokenOnUnmount", () => ({
+  useReleaseVpTokenOnUnmount: vi.fn(() => vi.fn()),
+}));
+
+vi.mock("@/infrastructure", () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
+vi.mock("@/utils/btc", () => ({
+  stripHexPrefix: vi.fn((hex: string) => hex.replace(/^0x/, "")),
+}));
+
+vi.mock("@/utils/rpc", () => ({
+  getVpProxyUrl: vi.fn(() => "https://vp.example"),
+}));
+
+vi.mock("../DepositProgressView", () => ({
+  DepositProgressView: ({ error }: { error?: string | null }) => (
+    <div data-testid="progress-view">{error ?? ""}</div>
+  ),
+}));
+
+const mockGetVaultRegistryReader = vi.mocked(getVaultRegistryReader);
+
+const ON_CHAIN_HASH = "0xmatching_pre_pegin_hash";
+const ATTACKER_HASH = "0xattacker_chosen_hash";
+
+const baseActivity: VaultActivity = {
+  id: "0xvaultId" as never,
+  collateral: { amount: "0.01", symbol: "BTC" },
+  providers: [{ id: "0xprovider" }],
+  displayLabel: "AwaitingDeposit" as never,
+  peginTxHash: "0xpegintx" as never,
+  unsignedPrePeginTx: "0xindexertx",
+  depositorWotsPkHash: "0xwotshash",
+};
+
+function readerWith(prePeginTxHash: string) {
+  return {
+    getVaultData: vi.fn().mockResolvedValue({
+      basic: { depositorBtcPubKey: "0xdepositorpub" },
+      protocol: {
+        htlcVout: 0,
+        depositorWotsPkHash: "0xwotshash",
+        prePeginTxHash,
+      },
+    }),
+    getVaultProviderBtcPubKey: vi.fn().mockResolvedValue(null),
+    getVaultBasicInfo: vi.fn(),
+    getVaultProtocolInfo: vi.fn(),
+  } as unknown as ReturnType<typeof getVaultRegistryReader>;
+}
+
+describe("ResumeWotsContent — Pre-PegIn tx hash trust boundary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCalculateBtcTxHash.mockReturnValue(ON_CHAIN_HASH);
+  });
+
+  it("aborts before deriveVaultRoot when indexer tx hash does not match on-chain", async () => {
+    mockCalculateBtcTxHash.mockReturnValue(ATTACKER_HASH);
+    mockGetVaultRegistryReader.mockReturnValue(readerWith(ON_CHAIN_HASH));
+
+    const { getByTestId } = render(
+      <ResumeWotsContent
+        activity={baseActivity}
+        onClose={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(getByTestId("progress-view").textContent).toContain(
+        "Pre-PegIn transaction hash mismatch",
+      );
+    });
+
+    expect(mockDeriveVaultRoot).not.toHaveBeenCalled();
+    expect(mockParseFundingOutpointsFromTx).not.toHaveBeenCalled();
+    expect(mockSubmitWotsPublicKey).not.toHaveBeenCalled();
+  });
+
+  it("proceeds to deriveVaultRoot when the indexer tx hash matches on-chain", async () => {
+    mockCalculateBtcTxHash.mockReturnValue(ON_CHAIN_HASH);
+    mockGetVaultRegistryReader.mockReturnValue(readerWith(ON_CHAIN_HASH));
+    mockDeriveVaultRoot.mockResolvedValue(new Uint8Array(32));
+
+    render(
+      <ResumeWotsContent
+        activity={baseActivity}
+        onClose={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockDeriveVaultRoot).toHaveBeenCalledTimes(1);
+    });
+    expect(mockParseFundingOutpointsFromTx).toHaveBeenCalledWith("0xindexertx");
+  });
+});
+
+describe("ResumeActivationContent — Pre-PegIn tx hash trust boundary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCalculateBtcTxHash.mockReturnValue(ON_CHAIN_HASH);
+  });
+
+  it("aborts before deriveVaultRoot when indexer tx hash does not match on-chain", async () => {
+    mockCalculateBtcTxHash.mockReturnValue(ATTACKER_HASH);
+    mockGetVaultRegistryReader.mockReturnValue(readerWith(ON_CHAIN_HASH));
+
+    const { getByTestId } = render(
+      <ResumeActivationContent
+        activity={baseActivity}
+        depositorEthAddress="0xdepositor"
+        onClose={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(getByTestId("progress-view").textContent).toContain(
+        "Pre-PegIn transaction hash mismatch",
+      );
+    });
+
+    expect(mockDeriveVaultRoot).not.toHaveBeenCalled();
+    expect(mockParseFundingOutpointsFromTx).not.toHaveBeenCalled();
+    expect(mockHandleActivation).not.toHaveBeenCalled();
+  });
+
+  it("proceeds to deriveVaultRoot when the indexer tx hash matches on-chain", async () => {
+    mockCalculateBtcTxHash.mockReturnValue(ON_CHAIN_HASH);
+    mockGetVaultRegistryReader.mockReturnValue(readerWith(ON_CHAIN_HASH));
+    mockDeriveVaultRoot.mockResolvedValue(new Uint8Array(32));
+
+    render(
+      <ResumeActivationContent
+        activity={baseActivity}
+        depositorEthAddress="0xdepositor"
+        onClose={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockDeriveVaultRoot).toHaveBeenCalledTimes(1);
+    });
+    expect(mockParseFundingOutpointsFromTx).toHaveBeenCalledWith("0xindexertx");
+    expect(mockHandleActivation).toHaveBeenCalledTimes(1);
+  });
+});

--- a/services/vault/src/hooks/deposit/depositFlowSteps/__tests__/ensureAuthenticatedVpClient.test.ts
+++ b/services/vault/src/hooks/deposit/depositFlowSteps/__tests__/ensureAuthenticatedVpClient.test.ts
@@ -6,14 +6,21 @@ import {
   VpTokenRegistry,
   vpTokenRegistry,
 } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
+import { calculateBtcTxHash } from "@babylonlabs-io/ts-sdk/tbv/core/utils";
+import type { Hex } from "viem";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ensureAuthenticatedVpClient } from "../ensureAuthenticatedVpClient";
 
+const ON_CHAIN_PRE_PEGIN_HASH = "0xmatching_pre_pegin_hash";
+const ATTACKER_HASH = "0xattacker_chosen_hash";
+
 const mockGetVaultProviderBtcPubKey = vi.fn();
+const mockGetVaultProtocolInfo = vi.fn();
 vi.mock("@/clients/eth-contract/sdk-readers", () => ({
   getVaultRegistryReader: () => ({
     getVaultProviderBtcPubKey: mockGetVaultProviderBtcPubKey,
+    getVaultProtocolInfo: mockGetVaultProtocolInfo,
   }),
 }));
 
@@ -32,8 +39,13 @@ vi.mock("@babylonlabs-io/ts-sdk/tbv/core", async (importOriginal) => {
   };
 });
 
+vi.mock("@babylonlabs-io/ts-sdk/tbv/core/utils", () => ({
+  calculateBtcTxHash: vi.fn(() => ON_CHAIN_PRE_PEGIN_HASH),
+}));
+
 const PEGIN_TXID = "a".repeat(64);
 const PEGIN_TX_HASH = `0x${PEGIN_TXID}`;
+const VAULT_ID = `0x${"f".repeat(64)}` as Hex;
 const PROVIDER_ADDRESS = `0x${"1".repeat(40)}`;
 const VALID_XONLY =
   "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
@@ -46,6 +58,10 @@ describe("ensureAuthenticatedVpClient", () => {
   beforeEach(() => {
     (vpTokenRegistry as VpTokenRegistry).clear();
     mockGetVaultProviderBtcPubKey.mockResolvedValue(VALID_XONLY);
+    mockGetVaultProtocolInfo.mockResolvedValue({
+      prePeginTxHash: ON_CHAIN_PRE_PEGIN_HASH,
+    });
+    vi.mocked(calculateBtcTxHash).mockReturnValue(ON_CHAIN_PRE_PEGIN_HASH);
     (deriveVaultRoot as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
       new Uint8Array(32).fill(0xcc),
     );
@@ -62,20 +78,44 @@ describe("ensureAuthenticatedVpClient", () => {
   it("cold-start: derives the auth anchor (one popup) and fetches the pubkey on cache miss", async () => {
     await ensureAuthenticatedVpClient({
       btcWallet: fakeWallet,
+      vaultId: VAULT_ID,
       unsignedPrePeginTxHex: "deadbeef",
       peginTxHash: PEGIN_TX_HASH,
       providerAddress: PROVIDER_ADDRESS,
       depositorBtcPubkey: "ab".repeat(32),
     });
 
+    expect(mockGetVaultProtocolInfo).toHaveBeenCalledOnce();
+    expect(mockGetVaultProtocolInfo).toHaveBeenCalledWith(VAULT_ID);
     expect(deriveVaultRoot).toHaveBeenCalledOnce();
     expect(mockGetVaultProviderBtcPubKey).toHaveBeenCalledOnce();
     expect(vpTokenRegistry.peek(PEGIN_TXID)).toBeDefined();
   });
 
-  it("cache hit: skips wallet derivation and on-chain read", async () => {
+  it("cold-start mismatch: throws before deriveVaultRoot when indexer tx hash does not match on-chain", async () => {
+    vi.mocked(calculateBtcTxHash).mockReturnValue(ATTACKER_HASH);
+
+    await expect(
+      ensureAuthenticatedVpClient({
+        btcWallet: fakeWallet,
+        vaultId: VAULT_ID,
+        unsignedPrePeginTxHex: "attackerhex",
+        peginTxHash: PEGIN_TX_HASH,
+        providerAddress: PROVIDER_ADDRESS,
+        depositorBtcPubkey: "ab".repeat(32),
+      }),
+    ).rejects.toThrow(/Pre-PegIn transaction hash mismatch/);
+
+    expect(mockGetVaultProtocolInfo).toHaveBeenCalledOnce();
+    expect(deriveVaultRoot).not.toHaveBeenCalled();
+    expect(mockGetVaultProviderBtcPubKey).not.toHaveBeenCalled();
+    expect(vpTokenRegistry.peek(PEGIN_TXID)).toBeUndefined();
+  });
+
+  it("cache hit: skips wallet derivation, on-chain prePeginTxHash read, and pubkey fetch", async () => {
     await ensureAuthenticatedVpClient({
       btcWallet: fakeWallet,
+      vaultId: VAULT_ID,
       unsignedPrePeginTxHex: "deadbeef",
       peginTxHash: PEGIN_TX_HASH,
       providerAddress: PROVIDER_ADDRESS,
@@ -85,6 +125,7 @@ describe("ensureAuthenticatedVpClient", () => {
 
     await ensureAuthenticatedVpClient({
       btcWallet: fakeWallet,
+      vaultId: VAULT_ID,
       unsignedPrePeginTxHex: "deadbeef",
       peginTxHash: PEGIN_TX_HASH,
       providerAddress: PROVIDER_ADDRESS,
@@ -92,6 +133,7 @@ describe("ensureAuthenticatedVpClient", () => {
     });
 
     expect(deriveVaultRoot).not.toHaveBeenCalled();
+    expect(mockGetVaultProtocolInfo).not.toHaveBeenCalled();
     expect(mockGetVaultProviderBtcPubKey).not.toHaveBeenCalled();
   });
 });

--- a/services/vault/src/hooks/deposit/depositFlowSteps/ensureAuthenticatedVpClient.ts
+++ b/services/vault/src/hooks/deposit/depositFlowSteps/ensureAuthenticatedVpClient.ts
@@ -23,7 +23,8 @@ import {
   VaultProviderRpcClient,
   vpTokenRegistry,
 } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
-import type { Address } from "viem";
+import { calculateBtcTxHash } from "@babylonlabs-io/ts-sdk/tbv/core/utils";
+import type { Address, Hex } from "viem";
 
 import { getVaultRegistryReader } from "@/clients/eth-contract/sdk-readers";
 import { stripHexPrefix } from "@/utils/btc";
@@ -31,6 +32,12 @@ import { getVpProxyUrl } from "@/utils/rpc";
 
 export interface EnsureAuthenticatedVpClientParams {
   btcWallet: BitcoinWallet;
+  /**
+   * On-chain vault id. Used on the cold path to fetch `prePeginTxHash`
+   * and validate `unsignedPrePeginTxHex` before the wallet's
+   * `deriveContextHash` is invoked over its funding outpoints.
+   */
+  vaultId: Hex;
   unsignedPrePeginTxHex: string;
   peginTxHash: string;
   providerAddress: string;
@@ -46,6 +53,25 @@ export async function ensureAuthenticatedVpClient(
   const cached = vpTokenRegistry.peek(peginTxid);
   if (cached) {
     return new VaultProviderRpcClient(baseUrl, { tokenProvider: cached });
+  }
+
+  // Cold path only: validate the indexer-supplied Pre-PegIn tx against
+  // the on-chain `prePeginTxHash` BEFORE invoking the wallet's
+  // `deriveContextHash`. Without this, a compromised indexer can ask
+  // the wallet to derive over attacker-chosen funding outpoints. Lives
+  // here (not at every caller) so every cold-path entry — payout
+  // signing on cross-device resume, WOTS submit on cache miss, future
+  // callers — fails closed by default. The cache-hit short-circuit
+  // above keeps the same-device hot path free of any extra read.
+  const reader = getVaultRegistryReader();
+  const protocol = await reader.getVaultProtocolInfo(params.vaultId);
+  const computedTxHash = calculateBtcTxHash(params.unsignedPrePeginTxHex);
+  if (computedTxHash.toLowerCase() !== protocol.prePeginTxHash.toLowerCase()) {
+    throw new Error(
+      `Pre-PegIn transaction hash mismatch: computed ${computedTxHash} from indexer tx, ` +
+        `but on-chain contract has ${protocol.prePeginTxHash}. ` +
+        `Aborting to prevent potential attack.`,
+    );
   }
 
   // Cold-start: derive auth anchor from the wallet (popup) and fetch

--- a/services/vault/src/hooks/deposit/depositFlowSteps/ensureAuthenticatedVpClient.ts
+++ b/services/vault/src/hooks/deposit/depositFlowSteps/ensureAuthenticatedVpClient.ts
@@ -95,10 +95,9 @@ export async function ensureAuthenticatedVpClient(
     root?.fill(0);
   }
 
-  const pinnedServerPubkey =
-    await getVaultRegistryReader().getVaultProviderBtcPubKey(
-      params.providerAddress as Address,
-    );
+  const pinnedServerPubkey = await reader.getVaultProviderBtcPubKey(
+    params.providerAddress as Address,
+  );
 
   return createAuthenticatedVpClient({
     baseUrl,

--- a/services/vault/src/hooks/deposit/depositFlowSteps/payoutSigning.ts
+++ b/services/vault/src/hooks/deposit/depositFlowSteps/payoutSigning.ts
@@ -17,7 +17,7 @@ import { stripHexPrefix } from "@/utils/btc";
 import { ensureAuthenticatedVpClient } from "./ensureAuthenticatedVpClient";
 
 export interface SignAndSubmitPayoutsParams {
-  vaultId: string;
+  vaultId: Hex;
   peginTxHash: string;
   depositorBtcPubkey: string;
   /** Optional hint; resolved from GraphQL if missing. */
@@ -62,7 +62,7 @@ export async function signAndSubmitPayouts(
   const peginTxid = stripHexPrefix(peginTxHash);
   const rpcClient = await ensureAuthenticatedVpClient({
     btcWallet,
-    vaultId: vaultId as Hex,
+    vaultId,
     unsignedPrePeginTxHex,
     peginTxHash,
     providerAddress: vaultProviderAddress,

--- a/services/vault/src/hooks/deposit/depositFlowSteps/payoutSigning.ts
+++ b/services/vault/src/hooks/deposit/depositFlowSteps/payoutSigning.ts
@@ -4,7 +4,7 @@
 
 import type { BitcoinWallet } from "@babylonlabs-io/ts-sdk/shared";
 import { runDepositorPresignFlow } from "@babylonlabs-io/ts-sdk/tbv/core/services";
-import type { Address } from "viem";
+import type { Address, Hex } from "viem";
 
 import { LocalStorageStatus } from "@/models/peginStateMachine";
 import {
@@ -62,6 +62,7 @@ export async function signAndSubmitPayouts(
   const peginTxid = stripHexPrefix(peginTxHash);
   const rpcClient = await ensureAuthenticatedVpClient({
     btcWallet,
+    vaultId: vaultId as Hex,
     unsignedPrePeginTxHex,
     peginTxHash,
     providerAddress: vaultProviderAddress,

--- a/services/vault/src/hooks/deposit/depositFlowSteps/types.ts
+++ b/services/vault/src/hooks/deposit/depositFlowSteps/types.ts
@@ -91,6 +91,8 @@ export interface PeginBatchRegisterResult {
 // ============================================================================
 
 export interface WotsSubmissionParams {
+  /** On-chain vault id — needed to validate `unsignedPrePeginTxHex` against `prePeginTxHash` on the cold-cache VP-auth path. */
+  vaultId: Hex;
   peginTxHash: string;
   depositorBtcPubkey: string;
   providerAddress: string;

--- a/services/vault/src/hooks/deposit/depositFlowSteps/wotsSubmission.ts
+++ b/services/vault/src/hooks/deposit/depositFlowSteps/wotsSubmission.ts
@@ -20,6 +20,7 @@ export async function submitWotsPublicKey(
   params: WotsSubmissionParams,
 ): Promise<void> {
   const {
+    vaultId,
     peginTxHash,
     depositorBtcPubkey,
     providerAddress,
@@ -32,6 +33,7 @@ export async function submitWotsPublicKey(
   const peginTxid = stripHexPrefix(peginTxHash);
   const rpcClient = await ensureAuthenticatedVpClient({
     btcWallet,
+    vaultId,
     unsignedPrePeginTxHex,
     peginTxHash,
     providerAddress,

--- a/services/vault/src/hooks/deposit/useDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useDepositFlow.ts
@@ -634,6 +634,7 @@ export function useDepositFlow(
           for (let attempt = 1; attempt <= MAX_WOTS_ATTEMPTS; attempt++) {
             try {
               await submitWotsPublicKey({
+                vaultId: result.vaultId,
                 peginTxHash: result.peginTxHash,
                 depositorBtcPubkey: result.depositorBtcPubkey,
                 providerAddress: provider.id,


### PR DESCRIPTION
## Summary

- Resume-flow handlers were feeding indexer-supplied `activity.unsignedPrePeginTx` into the wallet's `deriveContextHash` (via `deriveVaultRoot`) before any check against the on-chain `prePeginTxHash`. A compromised indexer / MITM could ask the wallet to derive over attacker-chosen 72-byte contexts.
- Added the same `calculateBtcTxHash(unsignedTx) === onChain.prePeginTxHash` check that already guards the broadcast and refund paths, in **all three** resume entry points.
- Centralised the check inside `ensureAuthenticatedVpClient` so every cold-cache caller — payout signing, WOTS submit, future callers — fails closed by default. Cache hits keep the existing fast path with no extra on-chain read.

## Context / problem

Across the codebase, `unsignedPrePeginTx` comes from the GraphQL indexer and is treated as untrusted. Two existing call sites already enforced the boundary:

- [`vaultRefundService.readVault`](services/vault/src/services/vault/vaultRefundService.ts#L98-L109)
- [`useVaultActions.handleBroadcast`](services/vault/src/hooks/deposit/useVaultActions.ts#L160-L168)

The audit finding flagged that the resume flows skipped the same check before invoking the wallet. Verified call chains with the gap:

1. `ResumeWotsContent.handleSubmit` → explicit `deriveVaultRoot(parseFundingOutpointsFromTx(activity.unsignedPrePeginTx))`. Downstream WOTS-hash compare rejects, but only **after** the wallet has signed a derivation over attacker-chosen outpoints.
2. `ResumeActivationContent.handleSubmit` → same shape, with the hashlock check happening after the wallet derivation.
3. `ResumeSignContent` → `usePayoutSigningState.handleSign` → `signAndSubmitPayouts` → `ensureAuthenticatedVpClient`. Cache-hit (`vpTokenRegistry.peek`) skips derivation only on same-device-same-tab. Cross-device, incognito, cleared storage, or fresh page load all reach `deriveVaultRoot` cold with no integrity check — exactly the resume scenarios the audit covers.

Severity: low (the downstream WOTS / hashlock / VP checks still reject, so no direct theft). The harm is per-click oracle access — the indexer can ask the wallet to derive vault roots over arbitrary funding outpoints, plus a misleading "wrong wallet is connected" error that misdirects users away from the real cause.

## What changed

### 1. Centralised guard in `ensureAuthenticatedVpClient`
[`services/vault/src/hooks/deposit/depositFlowSteps/ensureAuthenticatedVpClient.ts`](services/vault/src/hooks/deposit/depositFlowSteps/ensureAuthenticatedVpClient.ts)

- New required param: `vaultId: Hex`.
- On cache miss only (after `vpTokenRegistry.peek` short-circuits same-device callers), fetch `getVaultProtocolInfo(vaultId).prePeginTxHash` from the on-chain registry, compare against `calculateBtcTxHash(unsignedPrePeginTxHex)`, and throw before `deriveVaultRoot` runs.
- Cache-hit path is unchanged — no extra reader call on hot paths.

### 2. Plumbing
- [`types.ts`](services/vault/src/hooks/deposit/depositFlowSteps/types.ts) — added `vaultId: Hex` to `WotsSubmissionParams`.
- [`wotsSubmission.ts`](services/vault/src/hooks/deposit/depositFlowSteps/wotsSubmission.ts) — forwards `vaultId` to `ensureAuthenticatedVpClient`.
- [`payoutSigning.ts`](services/vault/src/hooks/deposit/depositFlowSteps/payoutSigning.ts) — forwards the existing `vaultId` from `SignAndSubmitPayoutsParams`.
- [`useDepositFlow.ts`](services/vault/src/hooks/deposit/useDepositFlow.ts) — passes `result.vaultId` at the same-device `submitWotsPublicKey` call site.
- [`ResumeDepositContent.tsx`](services/vault/src/components/simple/ResumeDepositContent.tsx) — `ResumeWotsContent` passes `activity.id` to `submitWotsPublicKey`.

### 3. Inline checks at the explicit `deriveVaultRoot` sites
[`services/vault/src/components/simple/ResumeDepositContent.tsx`](services/vault/src/components/simple/ResumeDepositContent.tsx)

`ResumeWotsContent.handleSubmit` and `ResumeActivationContent.handleSubmit` perform an **earlier** explicit `deriveVaultRoot` to compute WOTS keys / HTLC secret. These calls don't go through `ensureAuthenticatedVpClient`, so the centralised guard doesn't cover them. Added the same `calculateBtcTxHash` check inline in both, before `parseFundingOutpointsFromTx`. Reuses `protocol.prePeginTxHash` already returned by the existing `getVaultData` call — no extra RPC. Wording matches the existing two enforcement sites.

### 4. Tests
- [`ResumeDepositContent.test.tsx`](services/vault/src/components/simple/__tests__/ResumeDepositContent.test.tsx) — new file. For both `ResumeWotsContent` and `ResumeActivationContent`: tampered tx → wallet untouched + error surfaced; matching tx → derivation runs.
- [`ensureAuthenticatedVpClient.test.ts`](services/vault/src/hooks/deposit/depositFlowSteps/__tests__/ensureAuthenticatedVpClient.test.ts) — extended with: (a) cold-start match → derives normally, (b) cold-start mismatch → throws before `deriveVaultRoot`, no VP pubkey read, no token cached, (c) cache hit → no derivation **and** no `getVaultProtocolInfo` read (preserves the same-device perf invariant).

## Why this approach

We considered three options:

1. **Inline check at every resume handler** — minimal diff, but only covers the call sites we patch. New callers of `ensureAuthenticatedVpClient` would silently inherit the gap.
2. **Centralise inside `ensureAuthenticatedVpClient` (chosen for the VP-auth path)** — closes the cold path for every current and future caller. The cache-hit short-circuit means same-device flows pay zero extra on-chain reads. One extra param (`vaultId`) plumbed through two call sites.
3. **Push the check into the SDK primitives (`parseFundingOutpointsFromTx` / `deriveVaultRoot`)** — out of scope; would change frozen vault-secret primitives and force every caller to thread `prePeginTxHash`.

We use (2) for the VP-auth path and (1) for the explicit `deriveVaultRoot` calls in `ResumeWotsContent` / `ResumeActivationContent`, because those don't touch `ensureAuthenticatedVpClient`. Defense in depth at the two layers that actually call `deriveVaultRoot` on indexer data — not duplication.

A shared `assertPrePeginTxHashMatches` helper was deferred. Four call sites still tracks with the project's "three similar lines beats premature abstraction" rule; revisit when a fifth shows up.

## Notes

- `vaultRefundService.readVault` and `useVaultActions.handleBroadcast` were already correct — left alone.
- The existing `useVaultActions.handleActivation` was also already correct: it reads `hashlock` directly from the registry and validates `secret` against it before sending the ETH tx. The resume gap was upstream of that, in the secret derivation path, which this PR closes.


Closes https://github.com/babylonlabs-io/baby-auditor-findings/issues/163