### PR TITLE
fix(wallet-connector): correct OneKey getNetwork map (audit #246)

### DIFF
--- a/packages/babylon-wallet-connector/src/core/wallets/btc/onekey/network.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/onekey/network.ts
@@ -1,0 +1,29 @@
+/** OneKey network-name normalization. Pure module for unit testing. */
+
+import { Network } from "@/core/types";
+
+/**
+ * `"testnet"` → `Network.SIGNET` deliberately: OneKey returns
+ * `"testnet"` on the signet endpoint and lacks native signet support.
+ */
+const ONEKEY_NETWORK_TO_INTERNAL: Record<string, Network> = {
+  livenet: Network.MAINNET,
+  testnet: Network.SIGNET,
+  signet: Network.SIGNET,
+};
+
+/**
+ * Map a OneKey `getNetwork()` string (e.g. `"livenet"`) to our
+ * `Network` enum, or `null` for any unrecognised input. `unknown` +
+ * `Object.hasOwn` reject non-strings (toString coercion) and
+ * prototype keys (`constructor`, `__proto__`, ...).
+ */
+export function mapOneKeyNetwork(onekeyNetwork: unknown): Network | null {
+  if (typeof onekeyNetwork !== "string") {
+    return null;
+  }
+  if (!Object.hasOwn(ONEKEY_NETWORK_TO_INTERNAL, onekeyNetwork)) {
+    return null;
+  }
+  return ONEKEY_NETWORK_TO_INTERNAL[onekeyNetwork];
+}

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/onekey/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/onekey/provider.ts
@@ -6,12 +6,7 @@ import { unsupportedDeriveContextHash } from "@/core/wallets/btc/unsupportedDeri
 import { ERROR_CODES, WalletError } from "@/error";
 
 import logo from "./logo.svg";
-
-const INTERNAL_NETWORK_NAMES = {
-  [Network.MAINNET]: "livenet",
-  [Network.TESTNET]: "testnet",
-  [Network.SIGNET]: "signet",
-};
+import { mapOneKeyNetwork } from "./network";
 
 export const WALLET_PROVIDER_NAME = "OneKey";
 
@@ -163,19 +158,14 @@ export class OneKeyProvider implements IBTCProvider {
   getNetwork = async (): Promise<Network> => {
     const internalNetwork = await this.provider.getNetwork();
 
-    for (const [key, value] of Object.entries(INTERNAL_NETWORK_NAMES)) {
-      // TODO remove as soon as OneKey implements
-      if (value === "testnet") {
-        // in case of testnet return signet
-        return Network.SIGNET;
-      } else if (value === internalNetwork) {
-        return key as Network;
-      }
+    const mapped = mapOneKeyNetwork(internalNetwork);
+    if (mapped !== null) {
+      return mapped;
     }
 
     throw new WalletError({
       code: ERROR_CODES.UNSUPPORTED_NETWORK,
-      message: "Unsupported network from OneKey Wallet",
+      message: `Unsupported network from OneKey Wallet: "${internalNetwork}"`,
       wallet: WALLET_PROVIDER_NAME,
     });
   };

--- a/packages/babylon-wallet-connector/tests/unit/onekeyGetNetwork.test.ts
+++ b/packages/babylon-wallet-connector/tests/unit/onekeyGetNetwork.test.ts
@@ -1,0 +1,70 @@
+import { expect, test } from "@playwright/test";
+
+import { Network } from "../../src/core/types";
+import { mapOneKeyNetwork } from "../../src/core/wallets/btc/onekey/network";
+
+test.describe("mapOneKeyNetwork — OneKey network string normalization", () => {
+  test("maps 'livenet' to MAINNET", () => {
+    expect(mapOneKeyNetwork("livenet")).toBe(Network.MAINNET);
+  });
+
+  test("maps 'signet' to SIGNET", () => {
+    expect(mapOneKeyNetwork("signet")).toBe(Network.SIGNET);
+  });
+
+  test("maps 'testnet' to SIGNET (OneKey signet alias — wallet does not yet expose signet natively)", () => {
+    expect(mapOneKeyNetwork("testnet")).toBe(Network.SIGNET);
+  });
+
+  test("returns null for 'regtest'", () => {
+    expect(mapOneKeyNetwork("regtest")).toBeNull();
+  });
+
+  test("returns null for the empty string", () => {
+    expect(mapOneKeyNetwork("")).toBeNull();
+  });
+
+  test("returns null for 'fractalmainnet' (chain not in our supported set)", () => {
+    expect(mapOneKeyNetwork("fractalmainnet")).toBeNull();
+  });
+
+  test("returns null for an attacker-supplied string like 'livenetX'", () => {
+    expect(mapOneKeyNetwork("livenetX")).toBeNull();
+  });
+
+  test("returns null for an arbitrary garbage string", () => {
+    expect(mapOneKeyNetwork("\x00not-a-network\x00")).toBeNull();
+  });
+
+  // Prototype-key regressions — own-property check guards these.
+  test("returns null for the prototype key 'constructor'", () => {
+    expect(mapOneKeyNetwork("constructor")).toBeNull();
+  });
+
+  test("returns null for the prototype key 'toString'", () => {
+    expect(mapOneKeyNetwork("toString")).toBeNull();
+  });
+
+  test("returns null for the prototype key '__proto__'", () => {
+    expect(mapOneKeyNetwork("__proto__")).toBeNull();
+  });
+
+  test("returns null for the prototype key 'hasOwnProperty'", () => {
+    expect(mapOneKeyNetwork("hasOwnProperty")).toBeNull();
+  });
+
+  // Non-string regressions — typeof guard blocks toString coercion.
+  test("returns null for an object whose toString() returns a known network", () => {
+    const malicious = { toString: () => "livenet" } as unknown as string;
+    expect(mapOneKeyNetwork(malicious)).toBeNull();
+  });
+
+  test("returns null for null and undefined", () => {
+    expect(mapOneKeyNetwork(null as unknown as string)).toBeNull();
+    expect(mapOneKeyNetwork(undefined as unknown as string)).toBeNull();
+  });
+
+  test("returns null for a number", () => {
+    expect(mapOneKeyNetwork(0 as unknown as string)).toBeNull();
+  });
+});


### PR DESCRIPTION
OneKeyProvider.getNetwork iterated INTERNAL_NETWORK_NAMES and short- circuited with `return Network.SIGNET` whenever the iterated entry's value equaled "testnet" — before checking whether that entry actually matched the wallet's reply. Because the testnet entry was visited on the second iteration of every call, any input that wasn't "livenet" fell through to that branch (regtest, fractalmainnet, attacker- controlled garbage, etc.) and the adapter reported SIGNET to the SDK.

Replace the loop with a direct reverse-map lookup. "testnet" is still deliberately mapped to SIGNET (OneKey doesn't expose signet natively yet — testnet is its alias), but only when the wallet actually returns "testnet". Anything else now throws UNSUPPORTED_NETWORK with the unrecognised value in the message.

Extract the mapping into a pure ./network.ts module so the logic can be unit-tested without pulling in the SVG-loading provider class.

Closes audit finding #246.