### PR TITLE
fix(wallet-connector): make AppKit BTC getNetwork read live wallet ne…

### DIFF
--- a/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/network.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/network.ts
@@ -1,25 +1,65 @@
-/**
- * AppKit BTC network-id normalization.
- *
- * Pure module — no SVG / browser dependencies — so it can be unit-tested
- * in isolation from the full `AppKitBTCProvider` class.
- */
+/** AppKit BTC network mapping. Single source of truth for both directions. */
 
 import { bitcoin, bitcoinSignet } from "@reown/appkit/networks";
 
 import { Network } from "@/core/types";
+import { ERROR_CODES, WalletError } from "@/error";
 
-/**
- * Map an AppKit `caipNetworkId` to our `Network` enum.
- *
- * Returns `null` for any chain we don't support (regtest, testnet3,
- * fractal, etc.) so callers can throw `UNSUPPORTED_NETWORK` rather than
- * silently coercing.
- */
-export function caipNetworkIdToNetwork(
+const APPKIT_PROVIDER_NAME = "AppKit";
+
+const NETWORK_TO_CAIP_NETWORK = {
+  mainnet: bitcoin,
+  signet: bitcoinSignet,
+} as const;
+
+/** `Network` → AppKit caipNetwork (used by `adapter.switchNetwork`). */
+export function getCaipNetworkForNetwork(
+  network: "mainnet" | "signet",
+): typeof bitcoin | typeof bitcoinSignet {
+  return NETWORK_TO_CAIP_NETWORK[network];
+}
+
+function caipNetworkIdToNetwork(
   caipNetworkId: string | undefined,
 ): Network | null {
   if (caipNetworkId === bitcoin.caipNetworkId) return Network.MAINNET;
   if (caipNetworkId === bitcoinSignet.caipNetworkId) return Network.SIGNET;
   return null;
+}
+
+/**
+ * Resolve the live BTC network. Undefined `caipNetworkId` → trust
+ * config (some adapters never populate it). Defined-but-unsupported
+ * or mismatched-from-config → throw `UNSUPPORTED_NETWORK`.
+ */
+export function resolveLiveNetwork(
+  caipNetworkId: string | undefined,
+  configuredNetwork: Network,
+): Network {
+  if (caipNetworkId === undefined) {
+    return configuredNetwork;
+  }
+
+  const liveNetwork = caipNetworkIdToNetwork(caipNetworkId);
+  if (liveNetwork === null) {
+    throw new WalletError({
+      code: ERROR_CODES.UNSUPPORTED_NETWORK,
+      message:
+        `AppKit Bitcoin wallet is on an unsupported network ` +
+        `(caipNetworkId="${caipNetworkId}")`,
+      wallet: APPKIT_PROVIDER_NAME,
+    });
+  }
+
+  if (liveNetwork !== configuredNetwork) {
+    throw new WalletError({
+      code: ERROR_CODES.UNSUPPORTED_NETWORK,
+      message:
+        `AppKit Bitcoin wallet network mismatch: app expects ` +
+        `${configuredNetwork}, wallet is on ${liveNetwork}`,
+      wallet: APPKIT_PROVIDER_NAME,
+    });
+  }
+
+  return liveNetwork;
 }

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/network.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/network.ts
@@ -1,0 +1,25 @@
+/**
+ * AppKit BTC network-id normalization.
+ *
+ * Pure module — no SVG / browser dependencies — so it can be unit-tested
+ * in isolation from the full `AppKitBTCProvider` class.
+ */
+
+import { bitcoin, bitcoinSignet } from "@reown/appkit/networks";
+
+import { Network } from "@/core/types";
+
+/**
+ * Map an AppKit `caipNetworkId` to our `Network` enum.
+ *
+ * Returns `null` for any chain we don't support (regtest, testnet3,
+ * fractal, etc.) so callers can throw `UNSUPPORTED_NETWORK` rather than
+ * silently coercing.
+ */
+export function caipNetworkIdToNetwork(
+  caipNetworkId: string | undefined,
+): Network | null {
+  if (caipNetworkId === bitcoin.caipNetworkId) return Network.MAINNET;
+  if (caipNetworkId === bitcoinSignet.caipNetworkId) return Network.SIGNET;
+  return null;
+}

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/provider.ts
@@ -2,6 +2,7 @@ import type { BitcoinAdapter } from "@reown/appkit-adapter-bitcoin";
 import { Psbt } from "bitcoinjs-lib";
 
 import type { BTCConfig, IBTCProvider, InscriptionIdentifier, SignPsbtOptions } from "@/core/types";
+import { Network } from "@/core/types";
 import { resolveUseTweakedSigner } from "@/core/utils/psbtOptionsMapper";
 import { APPKIT_OPEN_EVENT } from "@/core/wallets/appkit/constants";
 import { unsupportedDeriveContextHash } from "@/core/wallets/btc/unsupportedDeriveContextHash";
@@ -9,7 +10,10 @@ import { ERROR_CODES, WalletError, isUserRejectionMessage } from "@/error";
 
 import { APPKIT_BTC_CONNECTED_EVENT } from "./constants";
 import icon from "./icon.svg";
+import { caipNetworkIdToNetwork } from "./network";
 import { getSharedBtcAppKitConfig, hasSharedBtcAppKitConfig } from "./sharedConfig";
+
+const APPKIT_PROVIDER_NAME = "AppKit";
 
 interface BtcConnectedEvent extends Event {
   detail?: { address?: string; publicKey?: string };
@@ -40,6 +44,7 @@ interface AppKitBtcWalletProvider {
 
 interface AdapterConnection {
   account?: { address?: string; publicKey?: string };
+  caipNetwork?: { caipNetworkId?: string };
 }
 
 function getAdapterConnections(adapter: BitcoinAdapter): AdapterConnection[] {
@@ -326,9 +331,63 @@ export class AppKitBTCProvider implements IBTCProvider {
     return signedPsbts;
   }
 
-  async getNetwork(): Promise<import("@/core/types").Network> {
-    // Return the configured network
-    return this.config.network;
+  async getNetwork(): Promise<Network> {
+    // Read the live network from the adapter, not config.network — if
+    // the wallet's network drifted (modal change, silent switchNetwork
+    // failure), signing a PSBT prepared for the configured chain
+    // against a wallet on a different chain would broadcast nowhere.
+    if (!hasSharedBtcAppKitConfig()) {
+      throw new WalletError({
+        code: ERROR_CODES.WALLET_NOT_CONNECTED,
+        message: "AppKit Bitcoin adapter is not initialized",
+        wallet: APPKIT_PROVIDER_NAME,
+      });
+    }
+
+    const { adapter } = this.getAppKitConfig();
+    const connections = getAdapterConnections(adapter);
+
+    if (connections.length === 0) {
+      throw new WalletError({
+        code: ERROR_CODES.WALLET_NOT_CONNECTED,
+        message: "AppKit Bitcoin wallet is not connected",
+        wallet: APPKIT_PROVIDER_NAME,
+      });
+    }
+
+    // Defense-in-depth — not every AppKit BTC connector keeps
+    // `connections[].caipNetwork` in sync after switchNetwork, so we
+    // only catch the ones that do.
+    const caipNetworkId = connections[0]?.caipNetwork?.caipNetworkId;
+
+    // Silent connector → trust config. Only throw below on a defined-
+    // but-unknown id (active "wrong chain" signal, not silence).
+    if (caipNetworkId === undefined) {
+      return this.config.network;
+    }
+
+    const liveNetwork = caipNetworkIdToNetwork(caipNetworkId);
+    if (liveNetwork === null) {
+      throw new WalletError({
+        code: ERROR_CODES.UNSUPPORTED_NETWORK,
+        message:
+          `AppKit Bitcoin wallet is on an unsupported network ` +
+          `(caipNetworkId="${caipNetworkId}")`,
+        wallet: APPKIT_PROVIDER_NAME,
+      });
+    }
+
+    if (liveNetwork !== this.config.network) {
+      throw new WalletError({
+        code: ERROR_CODES.UNSUPPORTED_NETWORK,
+        message:
+          `AppKit Bitcoin wallet network mismatch: app expects ` +
+          `${this.config.network}, wallet is on ${liveNetwork}`,
+        wallet: APPKIT_PROVIDER_NAME,
+      });
+    }
+
+    return liveNetwork;
   }
 
   async signMessage(message: string, type: "bip322-simple" | "ecdsa"): Promise<string> {

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/provider.ts
@@ -10,7 +10,7 @@ import { ERROR_CODES, WalletError, isUserRejectionMessage } from "@/error";
 
 import { APPKIT_BTC_CONNECTED_EVENT } from "./constants";
 import icon from "./icon.svg";
-import { caipNetworkIdToNetwork } from "./network";
+import { resolveLiveNetwork } from "./network";
 import { getSharedBtcAppKitConfig, hasSharedBtcAppKitConfig } from "./sharedConfig";
 
 const APPKIT_PROVIDER_NAME = "AppKit";
@@ -332,18 +332,10 @@ export class AppKitBTCProvider implements IBTCProvider {
   }
 
   async getNetwork(): Promise<Network> {
-    // Read the live network from the adapter, not config.network — if
-    // the wallet's network drifted (modal change, silent switchNetwork
-    // failure), signing a PSBT prepared for the configured chain
-    // against a wallet on a different chain would broadcast nowhere.
-    if (!hasSharedBtcAppKitConfig()) {
-      throw new WalletError({
-        code: ERROR_CODES.WALLET_NOT_CONNECTED,
-        message: "AppKit Bitcoin adapter is not initialized",
-        wallet: APPKIT_PROVIDER_NAME,
-      });
-    }
-
+    // Read the live network from the adapter, not config.network — the
+    // wallet's network can drift via the AppKit modal or a refused
+    // silent switchNetwork. Signing a PSBT prepared for the configured
+    // chain against a wallet on a different chain broadcasts nowhere.
     const { adapter } = this.getAppKitConfig();
     const connections = getAdapterConnections(adapter);
 
@@ -355,39 +347,9 @@ export class AppKitBTCProvider implements IBTCProvider {
       });
     }
 
-    // Defense-in-depth — not every AppKit BTC connector keeps
-    // `connections[].caipNetwork` in sync after switchNetwork, so we
-    // only catch the ones that do.
+    // `caipNetwork` may be missing — some adapters never populate it.
     const caipNetworkId = connections[0]?.caipNetwork?.caipNetworkId;
-
-    // Silent connector → trust config. Only throw below on a defined-
-    // but-unknown id (active "wrong chain" signal, not silence).
-    if (caipNetworkId === undefined) {
-      return this.config.network;
-    }
-
-    const liveNetwork = caipNetworkIdToNetwork(caipNetworkId);
-    if (liveNetwork === null) {
-      throw new WalletError({
-        code: ERROR_CODES.UNSUPPORTED_NETWORK,
-        message:
-          `AppKit Bitcoin wallet is on an unsupported network ` +
-          `(caipNetworkId="${caipNetworkId}")`,
-        wallet: APPKIT_PROVIDER_NAME,
-      });
-    }
-
-    if (liveNetwork !== this.config.network) {
-      throw new WalletError({
-        code: ERROR_CODES.UNSUPPORTED_NETWORK,
-        message:
-          `AppKit Bitcoin wallet network mismatch: app expects ` +
-          `${this.config.network}, wallet is on ${liveNetwork}`,
-        wallet: APPKIT_PROVIDER_NAME,
-      });
-    }
-
-    return liveNetwork;
+    return resolveLiveNetwork(caipNetworkId, this.config.network);
   }
 
   async signMessage(message: string, type: "bip322-simple" | "ecdsa"): Promise<string> {

--- a/packages/babylon-wallet-connector/src/hooks/appkit/btc/useAppKitBtcBridge.ts
+++ b/packages/babylon-wallet-connector/src/hooks/appkit/btc/useAppKitBtcBridge.ts
@@ -39,24 +39,19 @@ export const useAppKitBtcBridge = ({ onError }: UseAppKitBtcBridgeOptions = {}) 
   const dispatchConnectionEvent = useCallback(
     async (currentAddress: string) => {
       try {
-        // Resolve the shared config once — we need both the adapter (for
-        // network switching) and the private connection-events bus.
+        // Switch to the configured network. We do NOT swallow failures
+        // here: a wallet that refuses the switch leaves the adapter on
+        // the wrong chain, and `AppKitBTCProvider.getNetwork()` rejects
+        // a network mismatch later. Surface the failure to onError and
+        // skip the connection-event dispatch so downstream code never
+        // sees a connected-but-wrong-network state.
         const { adapter, network, connectionEvents } = getSharedBtcAppKitConfig();
-
-        // Switch to the configured network
-        try {
-          // Map the network config to AppKit's network types
-          const networkMap = {
-            mainnet: bitcoin,
-            signet: bitcoinSignet,
-          } as const;
-          const caipNetwork = networkMap[network];
-          await adapter.switchNetwork({ caipNetwork });
-        } catch (networkError) {
-          console.warn("[AppKit BTC Bridge] Failed to switch network:", networkError instanceof Error ? networkError.message : "Unknown error");
-          // Don't fail the connection if network switch fails
-          // Some wallets may already be on the correct network
-        }
+        const networkMap = {
+          mainnet: bitcoin,
+          signet: bitcoinSignet,
+        } as const;
+        const caipNetwork = networkMap[network];
+        await adapter.switchNetwork({ caipNetwork });
 
         // Fetch publicKey from allAccounts (this is where AppKit stores it)
         let publicKey: string | undefined;
@@ -87,6 +82,13 @@ export const useAppKitBtcBridge = ({ onError }: UseAppKitBtcBridgeOptions = {}) 
       } catch (error) {
         console.error("[AppKit BTC Bridge] Failed to process connection:", error instanceof Error ? error.message : "Unknown error");
         onError?.(error as Error);
+        // Mark this address as "handled" so the effect at the bottom of
+        // the hook does not re-fire `dispatchConnectionEvent` on every
+        // re-render of the AppKit hook (allAccounts identity churn).
+        // Without this, a failed switchNetwork would call onError on
+        // every render. The user must explicitly disconnect/reconnect
+        // (or change account) to retry.
+        lastDispatchedAddress.current = currentAddress;
       }
     },
     [allAccounts, onError],

--- a/packages/babylon-wallet-connector/src/hooks/appkit/btc/useAppKitBtcBridge.ts
+++ b/packages/babylon-wallet-connector/src/hooks/appkit/btc/useAppKitBtcBridge.ts
@@ -1,9 +1,9 @@
-import { bitcoin, bitcoinSignet } from "@reown/appkit/networks";
 import { useAppKitAccount } from "@reown/appkit/react";
 import { useCallback, useEffect, useRef } from "react";
 
 import { APPKIT_BTC_CONNECTOR_ID } from "@/core/wallets/btc/appkit";
 import { APPKIT_BTC_CONNECTED_EVENT } from "@/core/wallets/btc/appkit/constants";
+import { getCaipNetworkForNetwork } from "@/core/wallets/btc/appkit/network";
 import { getSharedBtcAppKitConfig } from "@/core/wallets/btc/appkit/sharedConfig";
 import { APPKIT_OPEN_EVENT } from "@/core/wallets/appkit/constants";
 import { useChainConnector } from "@/hooks/useChainConnector";
@@ -46,12 +46,9 @@ export const useAppKitBtcBridge = ({ onError }: UseAppKitBtcBridgeOptions = {}) 
         // skip the connection-event dispatch so downstream code never
         // sees a connected-but-wrong-network state.
         const { adapter, network, connectionEvents } = getSharedBtcAppKitConfig();
-        const networkMap = {
-          mainnet: bitcoin,
-          signet: bitcoinSignet,
-        } as const;
-        const caipNetwork = networkMap[network];
-        await adapter.switchNetwork({ caipNetwork });
+        await adapter.switchNetwork({
+          caipNetwork: getCaipNetworkForNetwork(network),
+        });
 
         // Fetch publicKey from allAccounts (this is where AppKit stores it)
         let publicKey: string | undefined;

--- a/packages/babylon-wallet-connector/tests/unit/appkitBtcGetNetwork.test.ts
+++ b/packages/babylon-wallet-connector/tests/unit/appkitBtcGetNetwork.test.ts
@@ -2,42 +2,44 @@ import { bitcoin, bitcoinSignet } from "@reown/appkit/networks";
 import { expect, test } from "@playwright/test";
 
 import { Network } from "../../src/core/types";
-import { caipNetworkIdToNetwork } from "../../src/core/wallets/btc/appkit/network";
+import { resolveLiveNetwork } from "../../src/core/wallets/btc/appkit/network";
+import { ERROR_CODES, WalletError } from "../../src/error";
 
-test.describe("caipNetworkIdToNetwork — AppKit BTC network normalization", () => {
-  test("maps bitcoin.caipNetworkId to MAINNET", () => {
-    expect(caipNetworkIdToNetwork(bitcoin.caipNetworkId)).toBe(Network.MAINNET);
+test.describe("resolveLiveNetwork — gating logic for AppKitBTCProvider.getNetwork", () => {
+  test("returns configured network when caipNetworkId is undefined (silent connector)", () => {
+    expect(resolveLiveNetwork(undefined, Network.SIGNET)).toBe(Network.SIGNET);
   });
 
-  test("maps bitcoinSignet.caipNetworkId to SIGNET", () => {
-    expect(caipNetworkIdToNetwork(bitcoinSignet.caipNetworkId)).toBe(
+  test("returns the live network when caipNetworkId matches the configured network", () => {
+    expect(resolveLiveNetwork(bitcoinSignet.caipNetworkId, Network.SIGNET)).toBe(
       Network.SIGNET,
     );
   });
 
-  test("returns null for an unrelated bip122 caipNetworkId (e.g. testnet)", () => {
-    // Bitcoin testnet3 genesis hash, not in our supported set
-    expect(
-      caipNetworkIdToNetwork("bip122:000000000933ea01ad0ee984209779ba"),
-    ).toBeNull();
+  test("throws UNSUPPORTED_NETWORK with both networks named when wallet is on a different supported network", () => {
+    let caught: unknown;
+    try {
+      resolveLiveNetwork(bitcoin.caipNetworkId, Network.SIGNET);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(WalletError);
+    expect((caught as WalletError).code).toBe(ERROR_CODES.UNSUPPORTED_NETWORK);
+    expect((caught as WalletError).message).toContain("expects signet");
+    expect((caught as WalletError).message).toContain("wallet is on mainnet");
   });
 
-  test("returns null for the empty string", () => {
-    expect(caipNetworkIdToNetwork("")).toBeNull();
-  });
-
-  test("returns null when caipNetworkId is undefined", () => {
-    expect(caipNetworkIdToNetwork(undefined)).toBeNull();
-  });
-
-  test("returns null for an attacker-supplied / garbage string", () => {
-    expect(caipNetworkIdToNetwork("evil:0xdeadbeef")).toBeNull();
-    expect(caipNetworkIdToNetwork("bip122:livenetX")).toBeNull();
-  });
-
-  test("returns null for a fractal mainnet caipNetworkId (chain not in our supported set)", () => {
-    expect(
-      caipNetworkIdToNetwork("bip122:fractalmainnet-placeholder-id"),
-    ).toBeNull();
+  test("throws UNSUPPORTED_NETWORK for a caipNetworkId outside the supported set", () => {
+    let caught: unknown;
+    try {
+      resolveLiveNetwork("bip122:000000000933ea01ad0ee984209779ba", Network.SIGNET);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(WalletError);
+    expect((caught as WalletError).code).toBe(ERROR_CODES.UNSUPPORTED_NETWORK);
+    expect((caught as WalletError).message).toContain(
+      "bip122:000000000933ea01ad0ee984209779ba",
+    );
   });
 });

--- a/packages/babylon-wallet-connector/tests/unit/appkitBtcGetNetwork.test.ts
+++ b/packages/babylon-wallet-connector/tests/unit/appkitBtcGetNetwork.test.ts
@@ -1,0 +1,43 @@
+import { bitcoin, bitcoinSignet } from "@reown/appkit/networks";
+import { expect, test } from "@playwright/test";
+
+import { Network } from "../../src/core/types";
+import { caipNetworkIdToNetwork } from "../../src/core/wallets/btc/appkit/network";
+
+test.describe("caipNetworkIdToNetwork — AppKit BTC network normalization", () => {
+  test("maps bitcoin.caipNetworkId to MAINNET", () => {
+    expect(caipNetworkIdToNetwork(bitcoin.caipNetworkId)).toBe(Network.MAINNET);
+  });
+
+  test("maps bitcoinSignet.caipNetworkId to SIGNET", () => {
+    expect(caipNetworkIdToNetwork(bitcoinSignet.caipNetworkId)).toBe(
+      Network.SIGNET,
+    );
+  });
+
+  test("returns null for an unrelated bip122 caipNetworkId (e.g. testnet)", () => {
+    // Bitcoin testnet3 genesis hash, not in our supported set
+    expect(
+      caipNetworkIdToNetwork("bip122:000000000933ea01ad0ee984209779ba"),
+    ).toBeNull();
+  });
+
+  test("returns null for the empty string", () => {
+    expect(caipNetworkIdToNetwork("")).toBeNull();
+  });
+
+  test("returns null when caipNetworkId is undefined", () => {
+    expect(caipNetworkIdToNetwork(undefined)).toBeNull();
+  });
+
+  test("returns null for an attacker-supplied / garbage string", () => {
+    expect(caipNetworkIdToNetwork("evil:0xdeadbeef")).toBeNull();
+    expect(caipNetworkIdToNetwork("bip122:livenetX")).toBeNull();
+  });
+
+  test("returns null for a fractal mainnet caipNetworkId (chain not in our supported set)", () => {
+    expect(
+      caipNetworkIdToNetwork("bip122:fractalmainnet-placeholder-id"),
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
…twork (audit #247)

AppKitBTCProvider.getNetwork() previously returned `this.config.network` unconditionally, ignoring what the wallet was actually on. Combined with useAppKitBtcBridge silently swallowing switchNetwork failures, the user (or another script) flipping the AppKit Bitcoin network in the modal — or the wallet refusing the silent switch — left the provider reporting the configured value while the wallet was on a different chain. PSBTs prepared for `config.network` would be signed against a wallet on the wrong chain.

Two changes:
- provider.ts: getNetwork() now reads the live caipNetworkId from `adapter.connections[0].caipNetwork.caipNetworkId`, maps it to our Network enum, and throws UNSUPPORTED_NETWORK if it's an unknown chain or doesn't match `config.network`.
- useAppKitBtcBridge.ts: stop swallowing switchNetwork failures. When the wallet refuses the switch, the outer try/catch surfaces the error via `onError` and the connection-event dispatch is skipped, so downstream code never sees a connected-but-wrong- network state.

Extracted the caip-id-to-network mapping into a pure ./network.ts module so it can be unit-tested without the SVG-loading provider.

Closes audit finding #247.