### PR TITLE
fix(ts-sdk): cap server-identity proof lifetime (audit #244)

### DIFF
--- a/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/__tests__/serverIdentity.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/__tests__/serverIdentity.test.ts
@@ -134,6 +134,91 @@ describe("verifyServerIdentity", () => {
     }
   });
 
+  // Audit #244: a proof's expires_at must be bounded above so a
+  // compromised VP key isn't trusted indefinitely.
+  it("rejects a proof whose expiry is 50 years in the future (audit #244)", () => {
+    const FIFTY_YEARS_SECS = 50 * 365 * 24 * 3600;
+    try {
+      verifyServerIdentity({
+        proof: validProof({ expires_at: NOW + FIFTY_YEARS_SECS }),
+        pinnedServerPubkey: PINNED,
+        now: NOW,
+      });
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect((err as ServerIdentityError).reason).toBe("expires_too_far");
+    }
+  });
+
+  it("rejects a proof one second past the default 2h cap", () => {
+    const TWO_HOURS = 2 * 3600;
+    try {
+      verifyServerIdentity({
+        proof: validProof({ expires_at: NOW + TWO_HOURS + 1 }),
+        pinnedServerPubkey: PINNED,
+        now: NOW,
+      });
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect((err as ServerIdentityError).reason).toBe("expires_too_far");
+    }
+  });
+
+  it("accepts a proof at the default cap (2h boundary, exactly)", () => {
+    // expires_at - now === maxLifetimeSecs is allowed; only strictly
+    // greater than the cap is rejected. Crypto verify will fail (we
+    // didn't re-sign for the new expiry), so we expect that distinct
+    // failure — proving the cap check passed.
+    const TWO_HOURS = 2 * 3600;
+    try {
+      verifyServerIdentity({
+        proof: validProof({ expires_at: NOW + TWO_HOURS }),
+        pinnedServerPubkey: PINNED,
+        now: NOW,
+      });
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect((err as ServerIdentityError).reason).toBe(
+        "signature_verification_failed",
+      );
+    }
+  });
+
+  it("respects a caller-supplied maxLifetimeSecs override", () => {
+    // Tighten to 30 minutes; the golden 1h-into-future proof now fails.
+    const HALF_HOUR = 30 * 60;
+    try {
+      verifyServerIdentity({
+        proof: validProof(),
+        pinnedServerPubkey: PINNED,
+        now: NOW,
+        maxLifetimeSecs: HALF_HOUR,
+      });
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect((err as ServerIdentityError).reason).toBe("expires_too_far");
+    }
+  });
+
+  it.each([0, -1, -3600])(
+    "rejects non-positive maxLifetimeSecs=%s as invalid_max_lifetime",
+    (badCap) => {
+      try {
+        verifyServerIdentity({
+          proof: validProof(),
+          pinnedServerPubkey: PINNED,
+          now: NOW,
+          maxLifetimeSecs: badCap,
+        });
+        expect.fail(`should have thrown for maxLifetimeSecs=${badCap}`);
+      } catch (err) {
+        expect((err as ServerIdentityError).reason).toBe(
+          "invalid_max_lifetime",
+        );
+      }
+    },
+  );
+
   it("rejects wrong-length pinned pubkey", () => {
     expect(() =>
       verifyServerIdentity({

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts
@@ -41,6 +41,14 @@ const SERVER_IDENTITY_DOMAIN = new TextEncoder().encode(
 );
 
 /**
+ * Cap on `proof.expires_at - now`. Bounds how long a leaked VP
+ * ephemeral key stays usable; the bearer token's own TTL does not
+ * (different trust boundary). 2h = Rust ref VP's 1h rotation × 2 for
+ * clock skew. Override per call via `maxLifetimeSecs`.
+ */
+export const DEFAULT_MAX_PROOF_LIFETIME_SECS = 2 * 3600;
+
+/**
  * Wire representation from btc-vault's `ServerIdentityResponse`.
  */
 export interface ServerIdentityResponse {
@@ -65,6 +73,8 @@ export interface VerifyServerIdentityInput {
   pinnedServerPubkey: string;
   /** Current Unix timestamp in seconds. Injected for testability. */
   now: number;
+  /** Cap on `proof.expires_at - now` (seconds). Defaults to {@link DEFAULT_MAX_PROOF_LIFETIME_SECS}. */
+  maxLifetimeSecs?: number;
 }
 
 export class ServerIdentityError extends Error {
@@ -73,7 +83,9 @@ export class ServerIdentityError extends Error {
     public readonly reason:
       | "pinned_pubkey_mismatch"
       | "expired"
+      | "expires_too_far"
       | "invalid_expires_at"
+      | "invalid_max_lifetime"
       | "invalid_pubkey_encoding"
       | "invalid_ephemeral_pubkey"
       | "invalid_signature_encoding"
@@ -99,7 +111,7 @@ function hexToBytes(hex: string): Uint8Array {
  *
  * Checks:
  *   1. `server_pubkey` matches the pin.
- *   2. `expires_at > now` (with integer guards).
+ *   2. `now < expires_at <= now + maxLifetimeSecs` (with integer guards).
  *   3. `ephemeral_pubkey` is a well-formed 33-byte compressed pubkey.
  *   4. `signature` is a well-formed 64-byte Schnorr hex string.
  *   5. The BIP-322 Schnorr signature cryptographically verifies
@@ -115,6 +127,8 @@ function hexToBytes(hex: string): Uint8Array {
  */
 export function verifyServerIdentity(input: VerifyServerIdentityInput): void {
   const { proof, pinnedServerPubkey, now } = input;
+  const maxLifetimeSecs =
+    input.maxLifetimeSecs ?? DEFAULT_MAX_PROOF_LIFETIME_SECS;
 
   const pinned = stripHexPrefix(pinnedServerPubkey).toLowerCase();
   if (pinned.length !== X_ONLY_PUBKEY_HEX_LEN || !HEX_RE.test(pinned)) {
@@ -162,6 +176,19 @@ export function verifyServerIdentity(input: VerifyServerIdentityInput): void {
     throw new ServerIdentityError(
       `server identity proof expired at ${proof.expires_at}, now ${now}`,
       "expired",
+    );
+  }
+  if (!Number.isSafeInteger(maxLifetimeSecs) || maxLifetimeSecs <= 0) {
+    throw new ServerIdentityError(
+      `maxLifetimeSecs must be a positive safe integer; got ${JSON.stringify(maxLifetimeSecs)}`,
+      "invalid_max_lifetime",
+    );
+  }
+  if (proof.expires_at - now > maxLifetimeSecs) {
+    throw new ServerIdentityError(
+      `server identity proof expires too far in the future: ` +
+        `expires_at=${proof.expires_at}, now=${now}, max lifetime=${maxLifetimeSecs}s`,
+      "expires_too_far",
     );
   }
 


### PR DESCRIPTION
`verifyServerIdentity` only enforced `expires_at > now`. A malicious or compromised VP could issue a proof valid for years; if its ephemeral key leaked later, the attacker kept minting fresh short-lived bearer tokens until the long-lived proof finally expired. The bearer token's own short TTL doesn't bound this — they're different trust boundaries.

Add a `DEFAULT_MAX_PROOF_LIFETIME_SECS = 2 * 3600` cap (matching the Rust reference VP's 1h key-rotation interval × 2 for clock skew), expose `maxLifetimeSecs?` on the input so callers can tighten, and reject proofs whose `expires_at - now` exceeds the cap with reason `expires_too_far`. Tests cover the 50-year exploit, ±1s cap boundary, caller override, and `maxLifetimeSecs <= 0`.