### PR TITLE
fix(vault): fail closed when Aave config fetch fails (audit #312)

### DIFF
--- a/services/vault/src/applications/aave/components/AssetSelectionModal/AssetSelectionModal.tsx
+++ b/services/vault/src/applications/aave/components/AssetSelectionModal/AssetSelectionModal.tsx
@@ -49,9 +49,8 @@ export function AssetSelectionModal({
   mode = LOAN_TAB.BORROW,
   assets,
 }: AssetSelectionModalProps) {
-  const { borrowableReserves, isLoading: configLoading } = useAaveConfig();
-  const { prices, isLoading: pricesLoading } = usePrices();
-  const isLoading = configLoading || pricesLoading;
+  const { borrowableReserves } = useAaveConfig();
+  const { prices, isLoading } = usePrices();
   const config = MODE_CONFIG[mode];
 
   const handleAssetClick = (assetSymbol: string) => {

--- a/services/vault/src/applications/aave/components/Detail/hooks/__tests__/useAaveReserveDetail.test.tsx
+++ b/services/vault/src/applications/aave/components/Detail/hooks/__tests__/useAaveReserveDetail.test.tsx
@@ -116,8 +116,6 @@ const mockUseAaveConfig = vi.fn(() => ({
       },
     },
   ],
-  isLoading: false,
-  error: null,
 }));
 
 vi.mock("../../../../context", () => ({
@@ -366,8 +364,6 @@ describe("useAaveReserveDetail", () => {
           },
         },
       ],
-      isLoading: false,
-      error: null,
     });
     mockUsePrices.mockReturnValue({
       prices: {},

--- a/services/vault/src/applications/aave/components/Detail/hooks/useAaveReserveDetail.ts
+++ b/services/vault/src/applications/aave/components/Detail/hooks/useAaveReserveDetail.ts
@@ -72,12 +72,7 @@ export function useAaveReserveDetail({
   reserveId,
   address,
 }: UseAaveReserveDetailProps): UseAaveReserveDetailResult {
-  // Fetch reserves from Aave config
-  const {
-    vbtcReserve,
-    allBorrowReserves,
-    isLoading: configLoading,
-  } = useAaveConfig();
+  const { vbtcReserve, allBorrowReserves } = useAaveConfig();
 
   // Find the selected reserve by symbol (from URL param). Match against the
   // full reserve set, not just borrowable ones - a user reaching this page
@@ -188,8 +183,7 @@ export function useAaveReserveDetail({
   }, [selectedReserve, chainlinkPrices, priceMetadata]);
 
   return {
-    isLoading:
-      configLoading || positionLoading || pricesLoading || splitParamsLoading,
+    isLoading: positionLoading || pricesLoading || splitParamsLoading,
     selectedReserve,
     assetConfig,
     vbtcReserve,

--- a/services/vault/src/applications/aave/context/AaveConfigContext.tsx
+++ b/services/vault/src/applications/aave/context/AaveConfigContext.tsx
@@ -8,7 +8,7 @@
  * - Borrowable reserves list (for asset selection)
  */
 
-import { Loader } from "@babylonlabs-io/core-ui";
+import { Button, Loader } from "@babylonlabs-io/core-ui";
 import { useQuery } from "@tanstack/react-query";
 import { createContext, useContext, type ReactNode } from "react";
 
@@ -20,49 +20,32 @@ import {
 } from "../services";
 
 interface AaveConfigContextValue {
-  /** Aave contract addresses and reserve IDs */
   config: AaveConfig | null;
-  /** vBTC reserve configuration (collateral reserve) */
   vbtcReserve: AaveReserveConfig | null;
-  /** Reserves available for new borrows (filtered by borrowable/paused/frozen) */
   borrowableReserves: AaveReserveConfig[];
-  /**
-   * All non-vBTC reserves regardless of borrowable/paused/frozen flags.
-   * Use this when resolving existing debt positions; users may have debt in a
-   * reserve that has since been frozen/paused/un-borrowable, and still need
-   * to be able to view and repay it.
-   */
+  /** Includes frozen/paused reserves so users can still repay legacy debt. */
   allBorrowReserves: AaveReserveConfig[];
-  /** Whether config is still loading */
-  isLoading: boolean;
-  /** Error if config fetch failed */
-  error: Error | null;
 }
 
 const AaveConfigContext = createContext<AaveConfigContextValue | null>(null);
 
 interface AaveConfigProviderProps {
   children: ReactNode;
+  /** Override the default unavailable panel. Pass `null` to suppress. */
+  errorFallback?: ReactNode;
 }
 
-/**
- * Provider that fetches Aave config on mount and provides it to children.
- * Wrap this around the Aave routes to ensure config is available.
- *
- * Children are not rendered until config is loaded, ensuring all child
- * components have access to valid config values (no undefined spokeAddress, etc.)
- */
-export function AaveConfigProvider({ children }: AaveConfigProviderProps) {
-  // Fetch all Aave config in a single GraphQL request
-  const { data, isLoading, error } = useQuery({
+export function AaveConfigProvider({
+  children,
+  errorFallback,
+}: AaveConfigProviderProps) {
+  const { data, isLoading, error, refetch } = useQuery({
     queryKey: ["aaveAppConfig"],
     queryFn: () => fetchAaveAppConfig(),
     staleTime: CONFIG_STALE_TIME_MS,
     refetchOnWindowFocus: false,
   });
 
-  // Don't render children until config is loaded.
-  // This ensures all child components have valid config values.
   if (isLoading) {
     return (
       <div className="flex min-h-[400px] items-center justify-center">
@@ -71,13 +54,28 @@ export function AaveConfigProvider({ children }: AaveConfigProviderProps) {
     );
   }
 
+  // Fail closed: a null config + empty reserves looks like "no position"
+  // while an on-chain position may still exist (audit #312).
+  if (error || data == null) {
+    if (errorFallback !== undefined) return <>{errorFallback}</>;
+    return (
+      <div className="flex min-h-[400px] flex-col items-center justify-center gap-3 px-4 text-center">
+        <p className="text-base font-medium">Something went wrong</p>
+        <p className="max-w-md text-sm text-accent-secondary">
+          Please try again in a moment.
+        </p>
+        <Button variant="contained" onClick={() => refetch()}>
+          Retry
+        </Button>
+      </div>
+    );
+  }
+
   const value: AaveConfigContextValue = {
-    config: data?.config ?? null,
-    vbtcReserve: data?.vbtcReserve ?? null,
-    borrowableReserves: data?.borrowableReserves ?? [],
-    allBorrowReserves: data?.allBorrowReserves ?? [],
-    isLoading: false,
-    error: error as Error | null,
+    config: data.config,
+    vbtcReserve: data.vbtcReserve,
+    borrowableReserves: data.borrowableReserves,
+    allBorrowReserves: data.allBorrowReserves,
   };
 
   return (
@@ -87,10 +85,6 @@ export function AaveConfigProvider({ children }: AaveConfigProviderProps) {
   );
 }
 
-/**
- * Hook to access Aave config from context.
- * Must be used within an AaveConfigProvider.
- */
 export function useAaveConfig(): AaveConfigContextValue {
   const ctx = useContext(AaveConfigContext);
   if (!ctx) {

--- a/services/vault/src/applications/aave/context/__tests__/AaveConfigContext.test.tsx
+++ b/services/vault/src/applications/aave/context/__tests__/AaveConfigContext.test.tsx
@@ -1,0 +1,168 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { fetchAaveAppConfig } from "../../services";
+import { AaveConfigProvider, useAaveConfig } from "../AaveConfigContext";
+
+vi.mock("../../services", () => ({
+  fetchAaveAppConfig: vi.fn(),
+}));
+
+vi.mock("@babylonlabs-io/core-ui", () => ({
+  Loader: () => <div data-testid="loader" />,
+  Button: ({
+    children,
+    onClick,
+  }: {
+    children: ReactNode;
+    onClick?: () => void;
+  }) => (
+    <button data-testid="retry" onClick={onClick}>
+      {children}
+    </button>
+  ),
+}));
+
+const mockFetch = vi.mocked(fetchAaveAppConfig);
+
+function ConsumerProbe() {
+  const ctx = useAaveConfig();
+  return (
+    <div data-testid="probe">
+      {ctx.config ? "config-present" : "config-null"}
+    </div>
+  );
+}
+
+function wrapper(): {
+  Wrapper: ({ children }: { children: ReactNode }) => JSX.Element;
+  client: QueryClient;
+} {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return {
+    client,
+    Wrapper: ({ children }) => (
+      <QueryClientProvider client={client}>
+        <AaveConfigProvider>{children}</AaveConfigProvider>
+      </QueryClientProvider>
+    ),
+  };
+}
+
+describe("AaveConfigProvider — fail-closed on fetch failure (audit #312)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the unavailable state when the GraphQL fetch throws", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("indexer down"));
+    const { Wrapper } = wrapper();
+
+    render(
+      <Wrapper>
+        <ConsumerProbe />
+      </Wrapper>,
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("loader")).not.toBeInTheDocument();
+    });
+
+    expect(screen.queryByTestId("probe")).not.toBeInTheDocument();
+    expect(screen.getByText(/Something went wrong/i)).toBeInTheDocument();
+    expect(screen.getByTestId("retry")).toBeInTheDocument();
+  });
+
+  it("renders the unavailable state when fetchAaveAppConfig returns null", async () => {
+    mockFetch.mockResolvedValueOnce(null);
+    const { Wrapper } = wrapper();
+
+    render(
+      <Wrapper>
+        <ConsumerProbe />
+      </Wrapper>,
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("loader")).not.toBeInTheDocument();
+    });
+
+    expect(screen.queryByTestId("probe")).not.toBeInTheDocument();
+    expect(screen.getByText(/Something went wrong/i)).toBeInTheDocument();
+  });
+
+  it("retries the fetch when the user clicks Retry", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("indexer down"));
+    const { Wrapper } = wrapper();
+
+    render(
+      <Wrapper>
+        <ConsumerProbe />
+      </Wrapper>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("retry")).toBeInTheDocument();
+    });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByTestId("retry"));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("respects errorFallback override (null suppresses the default panel)", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("indexer down"));
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    render(
+      <QueryClientProvider client={client}>
+        <AaveConfigProvider errorFallback={null}>
+          <ConsumerProbe />
+        </AaveConfigProvider>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("loader")).not.toBeInTheDocument();
+    });
+
+    expect(screen.queryByTestId("probe")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("retry")).not.toBeInTheDocument();
+    expect(screen.queryByText(/Something went wrong/i)).not.toBeInTheDocument();
+  });
+
+  it("renders children when fetch succeeds", async () => {
+    mockFetch.mockResolvedValueOnce({
+      config: {
+        adapterAddress: "0x1",
+        vaultBtcAddress: "0x2",
+        btcVaultRegistryAddress: "0x3",
+        coreSpokeAddress: "0x4" as `0x${string}`,
+        btcVaultCoreVbtcReserveId: 1n,
+      },
+      vbtcReserve: null,
+      borrowableReserves: [],
+      allBorrowReserves: [],
+    });
+    const { Wrapper } = wrapper();
+
+    render(
+      <Wrapper>
+        <ConsumerProbe />
+      </Wrapper>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("probe")).toHaveTextContent("config-present");
+    });
+  });
+});

--- a/services/vault/src/applications/aave/hooks/__tests__/useVaultSplitParams.test.tsx
+++ b/services/vault/src/applications/aave/hooks/__tests__/useVaultSplitParams.test.tsx
@@ -219,8 +219,6 @@ describe("useVaultSplitParams", () => {
       vbtcReserve: null,
       borrowableReserves: [],
       allBorrowReserves: [],
-      isLoading: false,
-      error: null,
     });
 
     mockGetReserve.mockResolvedValue({
@@ -262,8 +260,6 @@ describe("useVaultSplitParams", () => {
       vbtcReserve: null,
       borrowableReserves: [],
       allBorrowReserves: [],
-      isLoading: false,
-      error: null,
     });
 
     const { result } = renderHook(() => useVaultSplitParams(), { wrapper });

--- a/services/vault/src/applications/aave/hooks/useAaveUserPosition.ts
+++ b/services/vault/src/applications/aave/hooks/useAaveUserPosition.ts
@@ -78,11 +78,7 @@ export interface UseAaveUserPositionResult {
 export function useAaveUserPosition(
   connectedAddress: string | undefined,
 ): UseAaveUserPositionResult {
-  const {
-    config,
-    allBorrowReserves,
-    isLoading: configLoading,
-  } = useAaveConfig();
+  const { config, allBorrowReserves } = useAaveConfig();
   const spokeAddress = config?.coreSpokeAddress;
   const vbtcReserveId = config?.btcVaultCoreVbtcReserveId;
 
@@ -198,7 +194,7 @@ export function useAaveUserPosition(
     healthFactor,
     healthFactorStatus,
     isPositionDataStale,
-    isLoading: positionsLoading || configLoading,
+    isLoading: positionsLoading,
     error: positionsError as Error | null,
     refetch: async () => {
       const result = await refetch();

--- a/services/vault/src/components/pages/RootLayout.tsx
+++ b/services/vault/src/components/pages/RootLayout.tsx
@@ -1,10 +1,12 @@
 import {
   DEFAULT_SOCIAL_LINKS,
   Footer,
+  FullScreenDialog,
   Header,
   Nav,
   StandardSettingsMenu,
   TestingBanner,
+  Text,
 } from "@babylonlabs-io/core-ui";
 import { useTheme } from "next-themes";
 import { useCallback, useState } from "react";
@@ -142,7 +144,28 @@ export default function RootLayout() {
             } satisfies RootLayoutContext
           }
         />
-        <AaveConfigProvider>
+        {/* On config failure, suppress the default panel (would leak
+            into page chrome) and instead surface an error modal only
+            when the user has actually opened the deposit dialog, so
+            the click has a visible recovery path. */}
+        <AaveConfigProvider
+          errorFallback={
+            <FullScreenDialog
+              open={isDepositOpen}
+              onClose={closeDeposit}
+              className="items-center justify-center p-6"
+            >
+              <div className="mx-auto flex w-full max-w-[520px] flex-col items-center gap-3 text-center">
+                <Text variant="body1" className="font-medium">
+                  Something went wrong
+                </Text>
+                <Text variant="body2" className="text-accent-secondary">
+                  Please close this and try again in a moment.
+                </Text>
+              </div>
+            </FullScreenDialog>
+          }
+        >
           <SimpleDeposit
             open={isDepositOpen}
             onClose={closeDeposit}

--- a/services/vault/src/components/simple/BorrowFlow/useBorrowAssetSelection.ts
+++ b/services/vault/src/components/simple/BorrowFlow/useBorrowAssetSelection.ts
@@ -21,9 +21,8 @@ export interface BorrowAssetSelectionState {
 }
 
 export function useBorrowAssetSelection(): BorrowAssetSelectionState {
-  const { borrowableReserves, isLoading: configLoading } = useAaveConfig();
-  const { prices, isLoading: pricesLoading } = usePrices();
-  const isLoading = configLoading || pricesLoading;
+  const { borrowableReserves } = useAaveConfig();
+  const { prices, isLoading } = usePrices();
 
   const assets: BorrowableAssetItem[] = borrowableReserves.map((reserve) => {
     const tokenMetadata = getTokenByAddress(reserve.token.address);


### PR DESCRIPTION
`AaveConfigProvider` previously rendered children with `config: null`, `borrowableReserves: []`, `allBorrowReserves: []` when the indexer fetch errored or returned null. Downstream dashboards rendered an empty "no Aave position" state, masking that the user's on-chain position still existed and could be at liquidation risk.

Block children render in the error path and show an explicit "temporarily unavailable" panel with retry instead. For mounts where the chrome shouldn't change on failure (e.g. the global SimpleDeposit modal at RootLayout), expose an `errorFallback` prop so the layout can suppress the default panel.