### PR TITLE
fix(vault): fail closed when Aave debt reserve list is incomplete (au…

### DIFF
--- a/services/vault/src/applications/aave/components/Detail/PositionGate.tsx
+++ b/services/vault/src/applications/aave/components/Detail/PositionGate.tsx
@@ -1,0 +1,48 @@
+/**
+ * PositionGate
+ *
+ * Renders the audit-#311 fail-closed gate above the LoanCard:
+ * - positionError → hard-block + Retry button
+ * - ancillaryError → soft-warn banner + render children
+ * - neither → render children
+ */
+
+import { Button, Text } from "@babylonlabs-io/core-ui";
+import type { ReactNode } from "react";
+
+export interface PositionGateProps {
+  positionError: Error | null;
+  ancillaryError: Error | null;
+  refetchPosition: () => Promise<unknown>;
+  children: ReactNode;
+}
+
+export function PositionGate({
+  positionError,
+  ancillaryError,
+  refetchPosition,
+  children,
+}: PositionGateProps) {
+  if (positionError) {
+    return (
+      <div className="flex flex-col items-center gap-3">
+        <Text variant="body2" className="text-center text-warning-main">
+          Couldn&apos;t load your position. Please try again.
+        </Text>
+        <Button onClick={() => void refetchPosition()}>Retry</Button>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {ancillaryError ? (
+        <Text variant="body2" className="text-center text-warning-main">
+          Some data couldn&apos;t be loaded. Borrow may be unavailable; repay
+          still works from your loaded debt.
+        </Text>
+      ) : null}
+      {children}
+    </>
+  );
+}

--- a/services/vault/src/applications/aave/components/Detail/__tests__/PositionGate.test.tsx
+++ b/services/vault/src/applications/aave/components/Detail/__tests__/PositionGate.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * Tests for PositionGate — the audit-#311 fail-closed gate that the
+ * AaveReserveDetail page wraps around its LoanCard. Tested in isolation
+ * so we cover the gating behaviour without standing up the full page.
+ */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { PositionGate } from "../PositionGate";
+
+const Child = () => <div data-testid="child">child</div>;
+
+describe("PositionGate", () => {
+  it("hard-blocks children and shows Retry button when positionError is set", () => {
+    render(
+      <PositionGate
+        positionError={new Error("debt fetch failed")}
+        ancillaryError={null}
+        refetchPosition={vi.fn()}
+      >
+        <Child />
+      </PositionGate>,
+    );
+
+    expect(screen.queryByTestId("child")).toBeNull();
+    expect(screen.getByText(/Couldn't load your position/i)).toBeTruthy();
+    expect(screen.getByRole("button", { name: /retry/i })).toBeTruthy();
+  });
+
+  it("Retry button calls refetchPosition", () => {
+    const refetch = vi.fn();
+    render(
+      <PositionGate
+        positionError={new Error("debt fetch failed")}
+        ancillaryError={null}
+        refetchPosition={refetch}
+      >
+        <Child />
+      </PositionGate>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /retry/i }));
+    expect(refetch).toHaveBeenCalledOnce();
+  });
+
+  it("renders children with a soft-warn banner when only ancillaryError is set", () => {
+    render(
+      <PositionGate
+        positionError={null}
+        ancillaryError={new Error("price fetch failed")}
+        refetchPosition={vi.fn()}
+      >
+        <Child />
+      </PositionGate>,
+    );
+
+    expect(screen.getByTestId("child")).toBeTruthy();
+    expect(screen.getByText(/Some data couldn't be loaded/i)).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /retry/i })).toBeNull();
+  });
+
+  it("renders children with no banner when both errors are null", () => {
+    render(
+      <PositionGate
+        positionError={null}
+        ancillaryError={null}
+        refetchPosition={vi.fn()}
+      >
+        <Child />
+      </PositionGate>,
+    );
+
+    expect(screen.getByTestId("child")).toBeTruthy();
+    expect(screen.queryByText(/Couldn't load your position/i)).toBeNull();
+    expect(screen.queryByText(/Some data couldn't be loaded/i)).toBeNull();
+  });
+
+  it("positionError takes precedence even if ancillaryError is also set", () => {
+    render(
+      <PositionGate
+        positionError={new Error("debt fetch failed")}
+        ancillaryError={new Error("price fetch failed")}
+        refetchPosition={vi.fn()}
+      >
+        <Child />
+      </PositionGate>,
+    );
+
+    expect(screen.queryByTestId("child")).toBeNull();
+    expect(screen.queryByText(/Some data couldn't be loaded/i)).toBeNull();
+    expect(screen.getByText(/Couldn't load your position/i)).toBeTruthy();
+  });
+});

--- a/services/vault/src/applications/aave/components/Detail/hooks/__tests__/useAaveReserveDetail.test.tsx
+++ b/services/vault/src/applications/aave/components/Detail/hooks/__tests__/useAaveReserveDetail.test.tsx
@@ -527,7 +527,30 @@ describe("useAaveReserveDetail", () => {
 
   // --- Error propagation ---
 
-  it("propagates error from usePrices", () => {
+  it("propagates useAaveUserPosition error as positionError (audit #311 hard-block)", () => {
+    const debtError = new Error("Debt reserve fetch failure");
+    mockUseAaveUserPosition.mockReturnValue({
+      position: null,
+      collateralValueUsd: 0,
+      debtValueUsd: 0,
+      healthFactor: null,
+      healthFactorStatus: "healthy",
+      isPositionDataStale: false,
+      isLoading: false,
+      error: debtError,
+      refetch: vi.fn(),
+    });
+
+    const { result } = renderHook(
+      () => useAaveReserveDetail({ reserveId: "USDC", address: "0xUser" }),
+      { wrapper },
+    );
+
+    expect(result.current.positionError).toBe(debtError);
+    expect(result.current.ancillaryError).toBeNull();
+  });
+
+  it("propagates pricesError as ancillaryError (soft-warn, not a hard block)", () => {
     const pricesError = new Error("Chainlink RPC failure");
     mockUsePrices.mockReturnValue({
       prices: {},
@@ -543,10 +566,11 @@ describe("useAaveReserveDetail", () => {
       { wrapper },
     );
 
-    expect(result.current.error).toBe(pricesError);
+    expect(result.current.ancillaryError).toBe(pricesError);
+    expect(result.current.positionError).toBeNull();
   });
 
-  it("propagates error from useVaultSplitParams", () => {
+  it("propagates splitParams error as ancillaryError (soft-warn, not a hard block)", () => {
     const splitError = new Error("Contract RPC failure");
     mockUseVaultSplitParams.mockReturnValue({
       params: null,
@@ -559,16 +583,18 @@ describe("useAaveReserveDetail", () => {
       { wrapper },
     );
 
-    expect(result.current.error).toBe(splitError);
+    expect(result.current.ancillaryError).toBe(splitError);
+    expect(result.current.positionError).toBeNull();
   });
 
-  it("returns null error when no hooks have errors", () => {
+  it("returns null for both errors when no hooks have errors", () => {
     const { result } = renderHook(
       () => useAaveReserveDetail({ reserveId: "USDC", address: "0xUser" }),
       { wrapper },
     );
 
-    expect(result.current.error).toBeNull();
+    expect(result.current.positionError).toBeNull();
+    expect(result.current.ancillaryError).toBeNull();
   });
 
   // --- Staleness passthrough (#132) ---

--- a/services/vault/src/applications/aave/components/Detail/hooks/useAaveReserveDetail.ts
+++ b/services/vault/src/applications/aave/components/Detail/hooks/useAaveReserveDetail.ts
@@ -60,8 +60,18 @@ export interface UseAaveReserveDetailResult {
   healthFactor: number | null;
   /** Price of the selected borrow token in USD (null if unavailable) */
   tokenPriceUsd: number | null;
-  /** Error from price or split params fetch (null if no error) */
-  error: Error | null;
+  /**
+   * Position/debt-discovery error — hard-block the LoanCard (audit
+   * #311 fail-closed). A failure here means we can't trust the debt
+   * amount, so signing repay against it would risk under-/over-paying.
+   */
+  positionError: Error | null;
+  /**
+   * Ancillary errors from price or split-params fetches — soft-warn
+   * only. Repay can still validate from loaded debt + wallet balance,
+   * so unrelated infra failures should not remove the action path.
+   */
+  ancillaryError: Error | null;
   /** Whether position data may be stale (oracle-derived values possibly outdated) */
   isPositionDataStale: boolean;
   /** Refetch position data — returns fresh position (or null if unavailable) */
@@ -113,6 +123,7 @@ export function useAaveReserveDetail({
     healthFactor,
     isPositionDataStale,
     isLoading: positionLoading,
+    error: positionError,
     refetch: refetchPosition,
   } = useAaveUserPosition(address);
 
@@ -200,7 +211,8 @@ export function useAaveReserveDetail({
     totalDebtValueUsd: debtValueUsd,
     healthFactor,
     tokenPriceUsd,
-    error: pricesError ?? splitParamsError ?? null,
+    positionError: positionError ?? null,
+    ancillaryError: pricesError ?? splitParamsError ?? null,
     isPositionDataStale,
     refetchPosition,
   };

--- a/services/vault/src/applications/aave/components/Detail/index.tsx
+++ b/services/vault/src/applications/aave/components/Detail/index.tsx
@@ -5,7 +5,7 @@
  * Reserve is selected from the overview page and passed via URL param.
  */
 
-import { Container, Text } from "@babylonlabs-io/core-ui";
+import { Container } from "@babylonlabs-io/core-ui";
 import { useNavigate, useParams, useSearchParams } from "react-router";
 
 import { BackButton, EmptyState } from "@/components/shared";
@@ -19,6 +19,7 @@ import { BorrowSuccessModal } from "../LoanCard/Borrow/SuccessModal";
 import { RepaySuccessModal } from "../LoanCard/Repay/SuccessModal";
 
 import { useAaveReserveDetail, useBorrowRepayModals } from "./hooks";
+import { PositionGate } from "./PositionGate";
 
 const btcConfig = getNetworkConfigBTC();
 
@@ -48,7 +49,8 @@ export function AaveReserveDetail() {
     totalDebtValueUsd,
     healthFactor,
     tokenPriceUsd,
-    error,
+    positionError,
+    ancillaryError,
     isPositionDataStale,
     refetchPosition,
   } = useAaveReserveDetail({ reserveId, address });
@@ -146,13 +148,13 @@ export function AaveReserveDetail() {
       <Container className="pb-6">
         <div className="space-y-6">
           <BackButton label="Home" onClick={handleBack} />
-          {error && (
-            <Text variant="body2" className="text-center text-warning-main">
-              Some data could not be loaded. Borrow functionality may be
-              limited.
-            </Text>
-          )}
-          <LoanCard defaultTab={defaultTab} />
+          <PositionGate
+            positionError={positionError}
+            ancillaryError={ancillaryError}
+            refetchPosition={refetchPosition}
+          >
+            <LoanCard defaultTab={defaultTab} />
+          </PositionGate>
         </div>
       </Container>
 

--- a/services/vault/src/applications/aave/services/__tests__/getUserPositionsWithLiveData.test.ts
+++ b/services/vault/src/applications/aave/services/__tests__/getUserPositionsWithLiveData.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockGetUserPosition,
+  mockGetUserAccountData,
+  mockGetUserTotalDebt,
+  mockFetchActive,
+} = vi.hoisted(() => ({
+  mockGetUserPosition: vi.fn(),
+  mockGetUserAccountData: vi.fn(),
+  mockGetUserTotalDebt: vi.fn(),
+  mockFetchActive: vi.fn(),
+}));
+
+vi.mock("../../clients", () => ({
+  AaveSpoke: {
+    getUserPosition: mockGetUserPosition,
+    getUserAccountData: mockGetUserAccountData,
+    getUserTotalDebt: mockGetUserTotalDebt,
+  },
+}));
+
+vi.mock("../fetchPositions", () => ({
+  fetchAaveActivePositionsWithCollaterals: mockFetchActive,
+  fetchAavePositionByDepositor: vi.fn(),
+  fetchAavePositionCollaterals: vi.fn(),
+}));
+
+import { getUserPositionsWithLiveData } from "../positionService";
+
+const DEPOSITOR = ("0x" + "1".repeat(40)) as `0x${string}`;
+const SPOKE = ("0x" + "2".repeat(40)) as `0x${string}`;
+const PROXY = ("0x" + "3".repeat(40)) as `0x${string}`;
+const VBTC_RESERVE_ID = 1n;
+const USDC_RESERVE_ID = 2n;
+const DAI_RESERVE_ID = 3n;
+
+const ZERO_POSITION = {
+  drawnShares: 0n,
+  premiumShares: 0n,
+  suppliedShares: 0n,
+  dynamicConfigKey: 0,
+};
+
+const DEBT_POSITION = {
+  drawnShares: 1000n,
+  premiumShares: 0n,
+  suppliedShares: 0n,
+  dynamicConfigKey: 0,
+};
+
+function setupHappyPath(borrowCount: bigint) {
+  mockFetchActive.mockResolvedValue([
+    {
+      id: "pos-1",
+      depositor: DEPOSITOR,
+      proxyContract: PROXY,
+      reserveId: VBTC_RESERVE_ID,
+      totalCollateral: 100n,
+    },
+  ]);
+  mockGetUserAccountData.mockResolvedValue({
+    totalCollateralValue: 0n,
+    totalDebtValueRay: 0n,
+    healthFactor: 0n,
+    borrowCount,
+  });
+  mockGetUserPosition.mockImplementation(
+    async (_spoke: string, reserveId: bigint) => {
+      // vBTC collateral position has no debt
+      if (reserveId === VBTC_RESERVE_ID) return ZERO_POSITION;
+      return ZERO_POSITION;
+    },
+  );
+  mockGetUserTotalDebt.mockResolvedValue(0n);
+}
+
+describe("getUserPositionsWithLiveData — fail-closed debt reserve discovery (audit #311)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("throws when on-chain borrowCount > 0 but no reserve IDs were provided", async () => {
+    setupHappyPath(2n);
+
+    await expect(
+      getUserPositionsWithLiveData(DEPOSITOR, SPOKE, {
+        borrowableReserveIds: [],
+        vbtcReserveId: VBTC_RESERVE_ID,
+      }),
+    ).rejects.toThrow(/no reserve IDs were provided/);
+  });
+
+  it("throws when fewer debt reserves are found than on-chain borrowCount", async () => {
+    setupHappyPath(2n);
+    // Only one of the two probed reserves actually has debt.
+    mockGetUserPosition.mockImplementation(
+      async (_spoke: string, reserveId: bigint) => {
+        if (reserveId === USDC_RESERVE_ID) return DEBT_POSITION;
+        return ZERO_POSITION;
+      },
+    );
+    mockGetUserTotalDebt.mockResolvedValue(1000n);
+
+    await expect(
+      getUserPositionsWithLiveData(DEPOSITOR, SPOKE, {
+        borrowableReserveIds: [USDC_RESERVE_ID, DAI_RESERVE_ID],
+        vbtcReserveId: VBTC_RESERVE_ID,
+      }),
+    ).rejects.toThrow(/found 1.*incomplete/i);
+  });
+
+  it("does not throw when borrowCount is 0 even with an empty reserve list", async () => {
+    setupHappyPath(0n);
+
+    const result = await getUserPositionsWithLiveData(DEPOSITOR, SPOKE, {
+      borrowableReserveIds: [],
+      vbtcReserveId: VBTC_RESERVE_ID,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].debtPositions).toBeUndefined();
+  });
+
+  it("returns debtPositions when count matches borrowCount", async () => {
+    setupHappyPath(1n);
+    mockGetUserPosition.mockImplementation(
+      async (_spoke: string, reserveId: bigint) => {
+        if (reserveId === USDC_RESERVE_ID) return DEBT_POSITION;
+        return ZERO_POSITION;
+      },
+    );
+    mockGetUserTotalDebt.mockResolvedValue(1000n);
+
+    const result = await getUserPositionsWithLiveData(DEPOSITOR, SPOKE, {
+      borrowableReserveIds: [USDC_RESERVE_ID],
+      vbtcReserveId: VBTC_RESERVE_ID,
+    });
+
+    expect(result[0].debtPositions?.size).toBe(1);
+  });
+});

--- a/services/vault/src/applications/aave/services/positionService.ts
+++ b/services/vault/src/applications/aave/services/positionService.ts
@@ -132,18 +132,25 @@ export async function getUserPositionsWithLiveData(
     AaveSpoke.getUserAccountData(spokeAddress, proxyAddress),
   ]);
 
-  // Optionally fetch debt positions if borrowable reserves provided and user has debt
   let debtPositions: Map<bigint, DebtPosition> | undefined;
-  if (
-    borrowableReserveIds &&
-    borrowableReserveIds.length > 0 &&
-    accountData.borrowCount > 0n
-  ) {
+  if (accountData.borrowCount > 0n) {
+    // Fail closed: a stale or skipped reserve list would otherwise let
+    // a debt reserve drop out of the repay picker.
+    if (!borrowableReserveIds || borrowableReserveIds.length === 0) {
+      throw new Error(
+        `Aave debt reserve discovery: on-chain reports ${accountData.borrowCount} debt reserve(s) but no reserve IDs were provided to probe.`,
+      );
+    }
     debtPositions = await fetchDebtPositionsForReserves(
       proxyAddress,
       spokeAddress,
       borrowableReserveIds,
     );
+    if (BigInt(debtPositions.size) < accountData.borrowCount) {
+      throw new Error(
+        `Aave debt reserve discovery: on-chain reports ${accountData.borrowCount} debt reserve(s), found ${debtPositions.size}. The reserve list is likely incomplete.`,
+      );
+    }
   }
 
   return [


### PR DESCRIPTION
Reserve IDs to probe for user debt are derived from the indexer-supplied `allBorrowReserves`. If a reserve was skipped (stale indexer, RPC hiccup, compromise), `getUserPositionsWithLiveData` never probed it even though `accountData.borrowCount` still reported outstanding debt on-chain. The repay picker rendered with an empty / partial asset list and the user had no path to repay the missing debt.

