### PR TITLE
fix(vault): rebind redeemed vaults to on-chain provider for pegout po…

### DIFF
--- a/services/vault/src/hooks/__tests__/usePegoutPolling.test.ts
+++ b/services/vault/src/hooks/__tests__/usePegoutPolling.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import type { RedeemedVaultInfo } from "@/applications/aave/hooks/useAaveVaults";
+
+import { groupVaultsByProvider } from "../usePegoutPolling";
+
+const VAULT_A: RedeemedVaultInfo = {
+  id: "0xaaaa",
+  peginTxHash: "0x" + "1".repeat(64),
+  amount: 100n,
+  vaultProviderAddress: "0xINDEXER_PROVIDER_ATTACKER",
+} as RedeemedVaultInfo;
+
+const VAULT_B: RedeemedVaultInfo = {
+  id: "0xbbbb",
+  peginTxHash: "0x" + "2".repeat(64),
+  amount: 200n,
+  vaultProviderAddress: "0xCANONICAL_PROVIDER",
+} as RedeemedVaultInfo;
+
+describe("groupVaultsByProvider — on-chain rebind (audit #281)", () => {
+  it("uses the on-chain provider, ignoring a poisoned indexer value", () => {
+    const onChain = new Map([["0xaaaa", "0xCANONICAL_PROVIDER" as const]]);
+    const grouped = groupVaultsByProvider([VAULT_A], onChain);
+    expect(grouped.size).toBe(1);
+    expect(grouped.has("0xCANONICAL_PROVIDER")).toBe(true);
+    expect(grouped.has("0xINDEXER_PROVIDER_ATTACKER")).toBe(false);
+  });
+
+  it("groups two vaults with the same on-chain provider together", () => {
+    const onChain = new Map([
+      ["0xaaaa", "0xVP1" as const],
+      ["0xbbbb", "0xVP1" as const],
+    ]);
+    const grouped = groupVaultsByProvider([VAULT_A, VAULT_B], onChain);
+    expect(grouped.size).toBe(1);
+    expect(grouped.get("0xVP1")?.vaults).toHaveLength(2);
+  });
+
+  it("skips vaults missing from the on-chain map (no indexer fallback)", () => {
+    const grouped = groupVaultsByProvider([VAULT_B], new Map());
+    expect(grouped.size).toBe(0);
+  });
+});

--- a/services/vault/src/hooks/usePegoutPolling.ts
+++ b/services/vault/src/hooks/usePegoutPolling.ts
@@ -15,8 +15,10 @@ import {
 } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { useEffect, useMemo, useRef } from "react";
+import type { Address, Hex } from "viem";
 
 import type { RedeemedVaultInfo } from "@/applications/aave/hooks/useAaveVaults";
+import { getVaultRegistryReader } from "@/clients/eth-contract/sdk-readers";
 import {
   POLLING_INTERVAL_MS,
   POLLING_RETRY_COUNT,
@@ -56,19 +58,33 @@ interface VaultPollCounters {
   unknownCounts: Map<string, number>;
 }
 
-function groupVaultsByProvider(
+// Always use the on-chain registry provider; never fall back to the
+// indexer-supplied address (audit #281). Vaults missing on-chain are
+// skipped — the polling query's "Initiating" seed loop then surfaces
+// them as warning-state and times them out after the standard window.
+export function groupVaultsByProvider(
   vaults: RedeemedVaultInfo[],
+  onChainProviders: Map<Hex, Address>,
 ): Map<string, VaultsByProvider> {
   const grouped = new Map<string, VaultsByProvider>();
 
   for (const vault of vaults) {
-    const providerAddress = vault.vaultProviderAddress;
-    if (!providerAddress || !providerAddress.startsWith("0x")) {
+    const providerAddress = onChainProviders.get(vault.id as Hex);
+    if (!providerAddress) {
       logger.warn(
-        `Invalid or missing provider address for vault ${vault.id}, skipping pegout poll`,
+        `On-chain provider for vault ${vault.id} is unavailable; skipping pegout poll (audit #281).`,
       );
       continue;
     }
+    if (
+      vault.vaultProviderAddress &&
+      vault.vaultProviderAddress.toLowerCase() !== providerAddress.toLowerCase()
+    ) {
+      logger.warn(
+        `Provider mismatch for vault ${vault.id}: indexer="${vault.vaultProviderAddress}", on-chain="${providerAddress}". Using on-chain (audit #281).`,
+      );
+    }
+
     const existing = grouped.get(providerAddress);
     const entry: VaultToPoll = { vault, providerAddress };
 
@@ -210,10 +226,43 @@ export function usePegoutPolling({
 
   const isEnabled = redeemedVaults.length > 0;
 
-  const queryKey = useMemo(
-    () => ["pegoutPolling", redeemedVaults.map((v) => v.id).join(",")],
+  const vaultIdsKey = useMemo(
+    () =>
+      redeemedVaults
+        .map((v) => v.id)
+        .sort()
+        .join(","),
     [redeemedVaults],
   );
+
+  // Vault → on-chain provider is immutable after registration, so cache
+  // forever.
+  const { data: onChainProviders } = useQuery({
+    queryKey: ["onChainVaultProviders", vaultIdsKey],
+    queryFn: async () => {
+      const reader = getVaultRegistryReader();
+      const ids = redeemedVaults.map((v) => v.id as Hex);
+      const settled = await Promise.allSettled(
+        ids.map((id) => reader.getVaultBasicInfo(id)),
+      );
+      const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+      const out = new Map<Hex, Address>();
+      settled.forEach((res, i) => {
+        if (res.status !== "fulfilled") return;
+        const provider = res.value.vaultProvider as Address;
+        // `getBtcVaultBasicInfo` returns a zeroed struct for unknown
+        // vault ids; drop those rather than poll the zero address.
+        if (provider.toLowerCase() === ZERO_ADDRESS) return;
+        out.set(ids[i]!, provider);
+      });
+      return out;
+    },
+    enabled: isEnabled,
+    staleTime: Infinity,
+    gcTime: Infinity,
+  });
+
+  const queryKey = useMemo(() => ["pegoutPolling", vaultIdsKey], [vaultIdsKey]);
 
   const { data, isLoading } = useQuery({
     queryKey,
@@ -224,7 +273,10 @@ export function usePegoutPolling({
         return new Map();
       }
 
-      const vaultsByProvider = groupVaultsByProvider(currentVaults);
+      const vaultsByProvider = groupVaultsByProvider(
+        currentVaults,
+        onChainProviders ?? new Map(),
+      );
 
       const results = new Map<string, PegoutPollingResult>();
 
@@ -264,7 +316,7 @@ export function usePegoutPolling({
 
       return results;
     },
-    enabled: isEnabled,
+    enabled: isEnabled && onChainProviders !== undefined,
     staleTime: 0,
     refetchInterval: (query) => {
       const statusMap = query.state.data;


### PR DESCRIPTION
Pegout polling routed VP RPC calls using `vault.vaultProviderAddress`
from the indexer's GraphQL projection. A poisoned indexer row could
make a different VP's terminal status (`PAYOUT_BROADCAST` / `FAILED`)
control the redeemed-vault UI, stopping polling while the canonical
provider hadn't paid out.

Read each redeemed vault's provider directly from `BTCVaultRegistry`
via a multicall, cache it (vault → provider is immutable after
registration), and use only that value when grouping for polling.
Vaults missing on-chain are skipped — never fall back to the
indexer — so the existing "Initiating" seed loop times them out as
warning state instead of risking an attacker-VP route.

Closes babylonlabs-io/baby-auditor-findings#281