### PR TITLE
feat(vault): collateral factor on deposit form

### DIFF
--- a/services/vault/src/components/simple/CollateralFactorRow.tsx
+++ b/services/vault/src/components/simple/CollateralFactorRow.tsx
@@ -1,0 +1,41 @@
+import { computeMaxBorrowUsd } from "@/utils/collateral";
+import { formatCompactUsd } from "@/utils/formatting";
+
+const PERCENT_SCALE = 100;
+
+interface CollateralFactorRowProps {
+  collateralFactor: number | null;
+  amountBtc: string;
+  btcPrice: number;
+  hasPriceFetchError: boolean;
+}
+
+export function CollateralFactorRow({
+  collateralFactor,
+  amountBtc,
+  btcPrice,
+  hasPriceFetchError,
+}: CollateralFactorRowProps) {
+  if (collateralFactor === null) return null;
+
+  const percent = `${Math.round(collateralFactor * PERCENT_SCALE)}%`;
+
+  const maxBorrowUsd = hasPriceFetchError
+    ? null
+    : computeMaxBorrowUsd(amountBtc, btcPrice, collateralFactor);
+
+  return (
+    <div className="flex items-center justify-between text-sm">
+      <span className="text-accent-primary">Collateral Factor:</span>
+      <span>
+        <span className="text-accent-primary">{percent}</span>
+        {maxBorrowUsd !== null && (
+          <span className="text-accent-secondary">
+            {" "}
+            ({formatCompactUsd(maxBorrowUsd)} max USD)
+          </span>
+        )}
+      </span>
+    </div>
+  );
+}

--- a/services/vault/src/components/simple/DepositForm.tsx
+++ b/services/vault/src/components/simple/DepositForm.tsx
@@ -18,6 +18,7 @@ import { getNetworkConfigBTC } from "@/config";
 import { useBtcFeeDisplay } from "@/hooks/deposit/useBtcFeeDisplay";
 import { depositService } from "@/services/deposit";
 
+import { CollateralFactorRow } from "./CollateralFactorRow";
 import { FeesSection, type FeeRow } from "./FeesSection";
 
 const btcConfig = getNetworkConfigBTC();
@@ -73,6 +74,8 @@ interface DepositFormProps {
 
   partialLiquidation?: PartialLiquidationProps;
 
+  collateralFactor?: number | null;
+
   feeRows?: FeeRow[];
 
   /**
@@ -116,6 +119,7 @@ export function DepositForm({
   isAddressBlocked,
   onDeposit,
   partialLiquidation,
+  collateralFactor = null,
   feeRows,
   ordinalsCheckUnavailable = false,
   ordinalsCheckPending = false,
@@ -246,6 +250,12 @@ export function DepositForm({
           leftField={{ label: "Max", value: `${btcBalanceFormatted} BTC` }}
           rightField={{ value: usdValue }}
           onMaxClick={onMaxClick}
+        />
+        <CollateralFactorRow
+          collateralFactor={collateralFactor}
+          amountBtc={amount}
+          btcPrice={btcPrice}
+          hasPriceFetchError={hasPriceFetchError}
         />
       </Card>
 

--- a/services/vault/src/components/simple/SimpleDeposit.tsx
+++ b/services/vault/src/components/simple/SimpleDeposit.tsx
@@ -6,6 +6,7 @@ import { FeatureFlags } from "@/config";
 import { useAddressScreening } from "@/context/addressScreening";
 import { useGeoFencing } from "@/context/geofencing";
 import { ProtocolParamsProvider } from "@/context/ProtocolParamsContext";
+import { useETHWallet } from "@/context/wallet";
 import { useDialogStep } from "@/hooks/deposit/useDialogStep";
 import { useProtocolFeeRows } from "@/hooks/useProtocolFeeRows";
 import { depositService } from "@/services/deposit";
@@ -90,7 +91,9 @@ function SimpleDepositContent({
   const { isGeoBlocked, isLoading: isGeoLoading } = useGeoFencing();
   const { isBlocked: isAddressBlocked, isLoading: isScreeningLoading } =
     useAddressScreening();
-  const { rows: feeRows } = useProtocolFeeRows();
+  const { address: connectedEthAddress } = useETHWallet();
+  const { rows: feeRows, collateralFactor } =
+    useProtocolFeeRows(connectedEthAddress);
 
   const {
     formData,
@@ -267,6 +270,7 @@ function SimpleDepositContent({
                 isAddressBlocked={isAddressBlocked || isScreeningLoading}
                 onDeposit={handleDeposit}
                 partialLiquidation={partialLiquidationProps}
+                collateralFactor={collateralFactor}
                 feeRows={feeRows}
                 ordinalsCheckUnavailable={ordinalsCheckUnavailable}
                 ordinalsCheckPending={ordinalsCheckPending}

--- a/services/vault/src/components/simple/__tests__/CollateralFactorRow.test.tsx
+++ b/services/vault/src/components/simple/__tests__/CollateralFactorRow.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { CollateralFactorRow } from "../CollateralFactorRow";
+
+describe("CollateralFactorRow", () => {
+  it("renders nothing when collateralFactor is null", () => {
+    const { container } = render(
+      <CollateralFactorRow
+        collateralFactor={null}
+        amountBtc="1"
+        btcPrice={88_400}
+        hasPriceFetchError={false}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders percent only when amount is empty", () => {
+    render(
+      <CollateralFactorRow
+        collateralFactor={0.72}
+        amountBtc=""
+        btcPrice={88_400}
+        hasPriceFetchError={false}
+      />,
+    );
+    expect(screen.getByText("Collateral Factor:")).toBeInTheDocument();
+    expect(screen.getByText("72%")).toBeInTheDocument();
+    expect(screen.queryByText(/max USD/)).not.toBeInTheDocument();
+  });
+
+  it("renders percent only when amount is zero", () => {
+    render(
+      <CollateralFactorRow
+        collateralFactor={0.72}
+        amountBtc="0"
+        btcPrice={88_400}
+        hasPriceFetchError={false}
+      />,
+    );
+    expect(screen.getByText("72%")).toBeInTheDocument();
+    expect(screen.queryByText(/max USD/)).not.toBeInTheDocument();
+  });
+
+  it("renders percent and compact USD max when CF, amount, and price are present", () => {
+    render(
+      <CollateralFactorRow
+        collateralFactor={0.72}
+        amountBtc="1"
+        btcPrice={88_400}
+        hasPriceFetchError={false}
+      />,
+    );
+    expect(screen.getByText("72%")).toBeInTheDocument();
+    expect(screen.getByText(/\$63\.6k max USD/)).toBeInTheDocument();
+  });
+
+  it("hides USD suffix when hasPriceFetchError is true", () => {
+    render(
+      <CollateralFactorRow
+        collateralFactor={0.72}
+        amountBtc="1"
+        btcPrice={88_400}
+        hasPriceFetchError={true}
+      />,
+    );
+    expect(screen.getByText("72%")).toBeInTheDocument();
+    expect(screen.queryByText(/max USD/)).not.toBeInTheDocument();
+  });
+});

--- a/services/vault/src/hooks/useProtocolFeeRows.ts
+++ b/services/vault/src/hooks/useProtocolFeeRows.ts
@@ -85,6 +85,7 @@ function buildFeeRows(
 export function useProtocolFeeRows(connectedAddress?: string): {
   rows: FeeRow[];
   isLoading: boolean;
+  collateralFactor: number | null;
 } {
   const { minDeposit } = useProtocolParamsContext();
   const { params, isLoading } = useVaultSplitParams(connectedAddress);
@@ -94,5 +95,5 @@ export function useProtocolFeeRows(connectedAddress?: string): {
     [minDeposit, params],
   );
 
-  return { rows, isLoading };
+  return { rows, isLoading, collateralFactor: params?.CF ?? null };
 }

--- a/services/vault/src/utils/__tests__/collateral.test.ts
+++ b/services/vault/src/utils/__tests__/collateral.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import type { AavePositionCollateral } from "@/applications/aave/services/fetchPositions";
 import type { VaultProvider } from "@/types/vaultProvider";
 
-import { toCollateralVaultEntries } from "../collateral";
+import { computeMaxBorrowUsd, toCollateralVaultEntries } from "../collateral";
 
 function makeCollateral(
   overrides: Partial<AavePositionCollateral> = {},
@@ -161,6 +161,35 @@ describe("Collateral Utilities", () => {
       const result = toCollateralVaultEntries(collaterals);
 
       expect(result[0].amountBtc).toBe(0.5);
+    });
+  });
+
+  describe("computeMaxBorrowUsd", () => {
+    it("returns the product of amount, price, and CF", () => {
+      expect(computeMaxBorrowUsd("1", 88400, 0.72)).toBeCloseTo(63648);
+      expect(computeMaxBorrowUsd("0.5", 100000, 0.5)).toBe(25000);
+    });
+
+    it("returns null when collateralFactor is null", () => {
+      expect(computeMaxBorrowUsd("1", 88400, null)).toBeNull();
+    });
+
+    it("returns null when btcPrice is missing or non-positive", () => {
+      expect(computeMaxBorrowUsd("1", 0, 0.72)).toBeNull();
+      expect(computeMaxBorrowUsd("1", -1, 0.72)).toBeNull();
+      expect(computeMaxBorrowUsd("1", Number.NaN, 0.72)).toBeNull();
+    });
+
+    it("returns null when collateralFactor is non-positive or non-finite", () => {
+      expect(computeMaxBorrowUsd("1", 88400, 0)).toBeNull();
+      expect(computeMaxBorrowUsd("1", 88400, -0.1)).toBeNull();
+      expect(computeMaxBorrowUsd("1", 88400, Number.NaN)).toBeNull();
+    });
+
+    it("returns null for empty / non-numeric / zero amount strings", () => {
+      expect(computeMaxBorrowUsd("", 88400, 0.72)).toBeNull();
+      expect(computeMaxBorrowUsd("0", 88400, 0.72)).toBeNull();
+      expect(computeMaxBorrowUsd("abc", 88400, 0.72)).toBeNull();
     });
   });
 });

--- a/services/vault/src/utils/__tests__/formatting.test.ts
+++ b/services/vault/src/utils/__tests__/formatting.test.ts
@@ -8,6 +8,7 @@ import { getNetworkConfigBTC } from "@/config";
 
 import {
   formatBtcAmount,
+  formatCompactUsd,
   formatDateTime,
   formatLLTV,
   formatOrdinal,
@@ -305,6 +306,30 @@ describe("Formatting Utilities", () => {
       expect(formatTimeAgo(NOW + 1000)).toBe("just now");
       expect(formatTimeAgo(NOW + 60 * 60 * 1000)).toBe("just now");
       expect(formatTimeAgo(NOW + 365 * 24 * 60 * 60 * 1000)).toBe("just now");
+    });
+  });
+
+  describe("formatCompactUsd", () => {
+    it("returns '$0' for zero", () => {
+      expect(formatCompactUsd(0)).toBe("$0");
+    });
+
+    it("returns '$0' for negative input", () => {
+      expect(formatCompactUsd(-1)).toBe("$0");
+    });
+
+    it("delegates to non-compact format below 1000", () => {
+      expect(formatCompactUsd(999)).toBe("$999.00");
+      expect(formatCompactUsd(99.5)).toBe("$99.50");
+    });
+
+    it("formats thousands as '$Nk' with one decimal", () => {
+      expect(formatCompactUsd(1_000)).toBe("$1k");
+      expect(formatCompactUsd(63_600)).toBe("$63.6k");
+    });
+
+    it("formats millions as '$Nm'", () => {
+      expect(formatCompactUsd(1_500_000)).toBe("$1.5m");
     });
   });
 });

--- a/services/vault/src/utils/collateral.ts
+++ b/services/vault/src/utils/collateral.ts
@@ -56,3 +56,23 @@ export function toCollateralVaultEntries(
     };
   });
 }
+
+/**
+ * Computes the maximum borrowable USD value for a collateral position:
+ *   amountBtc * btcPrice * collateralFactor
+ *
+ * Returns `null` when any input is missing, non-finite, or non-positive,
+ * so callers can hide the field rather than render a misleading `$0`.
+ */
+export function computeMaxBorrowUsd(
+  amountBtc: string,
+  btcPrice: number,
+  collateralFactor: number | null,
+): number | null {
+  if (collateralFactor === null) return null;
+  if (!Number.isFinite(btcPrice) || btcPrice <= 0) return null;
+  if (!Number.isFinite(collateralFactor) || collateralFactor <= 0) return null;
+  const amount = parseFloat(amountBtc);
+  if (!Number.isFinite(amount) || amount <= 0) return null;
+  return amount * btcPrice * collateralFactor;
+}

--- a/services/vault/src/utils/formatting.ts
+++ b/services/vault/src/utils/formatting.ts
@@ -125,6 +125,22 @@ export function formatPriceUsd(priceUsd: number): string {
 }
 
 /**
+ * Format a USD value in compact notation (e.g., "$63.6k", "$1.2M").
+ * Uses one fractional digit for k/M/B magnitudes; for values below 1000
+ * falls back to the same formatting as `formatPriceUsd` for consistency.
+ * Returns `$0` for zero or negative input.
+ */
+export function formatCompactUsd(usd: number): string {
+  if (usd <= 0) return "$0";
+  if (usd < 1000) return formatPriceUsd(usd);
+  const compact = new Intl.NumberFormat("en-US", {
+    notation: "compact",
+    maximumFractionDigits: 1,
+  }).format(usd);
+  return `$${compact.toLowerCase()}`;
+}
+
+/**
  * Format a number amount for display with locale-aware formatting
  * @param amount - The numeric amount to format
  * @param maxDecimals - Maximum decimal places (default: 2)


### PR DESCRIPTION

<img width="2928" height="1804" alt="image" src="https://github.com/user-attachments/assets/0cc81c4c-5a8c-4607-a9b3-db9be77900ff" />


Display the on-chain Collateral Factor and resulting max-borrow USD directly inside the deposit-amount card, below the Max/USD line. Reuses the CF already fetched by useVaultSplitParams via useProtocolFeeRows — no new RPC. The hook is now keyed by the connected ETH address so users with existing positions see the CF that matches their position's stored dynamicConfigKey rather than the reserve's current key.