### PR TITLE
docs(derive-context-hash): per public key level result

### DIFF
--- a/docs/specs/derive-context-hash.md
+++ b/docs/specs/derive-context-hash.md
@@ -1,10 +1,21 @@
 # `deriveContextHash` Specification
 
-**Spec revision**: 1.0
-**Algorithm version**: 0 (salt: `"derive-context-hash"`, no suffix)
-**Date**: 2026-04-07
+**Spec revision**: 2.0
+**Algorithm version**: 1 (salt: `"derive-context-hash"`, no suffix)
+**Date**: 2026-05-06
 **Authors**: Jerome Wang (Babylon Labs)
-**Status**: Draft — incorporates auditor feedback (Coinspect)
+**Status**: Draft — supersedes revision 1.0 (changes IKM source from a fixed BIP-32 path to the connected account's private key)
+
+---
+
+## Changes from revision 1.0
+
+- **IKM source changed.** In v1.0, HD wallets derived IKM from a fixed BIP-32 path `m/73681862'` from the seed root, making the output wallet-level (identical across all accounts under the same seed). In v2.0, HD wallets derive IKM from the **account-level** BIP-32 node `m/purpose'/coin_type'/account'` (3-deep, hardened) corresponding to the connected account, making the output **per-account-xpub** — different connected accounts produce different outputs, while different receive addresses under the same account share the same output.
+- **Imported wallets unchanged.** They already used the raw imported private key as IKM. v2.0 keeps this. The two paths (HD and imported) now have a symmetric "one identity = one IKM" mental model.
+- **Salt unchanged**: `"derive-context-hash"`. The IKM-source change alone produces different outputs from v1.0; no salt domain separation needed. The API is `@experimental` and the rollout is coordinated, so no version-discovery mechanism is added.
+- **Test vectors restructured.** §4.1 keeps function-level KAT vectors that pin the HKDF composition; §4.2 gives a new HD-wallet integration KAT for the v2.0 IKM source.
+
+A wallet that conformed to v1.0 will produce different outputs than a wallet that conforms to v2.0 for the same recovery phrase and `(appName, context)`. dApps that persisted v1.0 outputs must re-derive against v2.0.
 
 ---
 
@@ -94,7 +105,7 @@ dialog SHOULD also display the context bytes.
 ### 2.2 Derivation Algorithm
 
 ```
-ikm    = BIP-32 private key at path m/73681862'
+ikm    = the connected account's 32-byte private key
 salt   = "derive-context-hash"        (UTF-8 encoded)
 info   = SHA-256(UTF8(appName)) || context  (raw bytes)
 length = 32
@@ -110,55 +121,58 @@ length-confusion collisions between different `appName`/`context`
 combinations (e.g. appName `"foobar"` + context `0x01` vs
 appName `"foo"` + context `0x626172_01` can never collide).
 
-**IKM (Input Key Material):** The raw 32-byte private key scalar
-at BIP-32 derivation path `m/73681862'` (hardened), using
-standard BIP-32 derivation on secp256k1. This is the 32-byte
-big-endian scalar `k` only — excluding chain code, depth,
-fingerprint, child number, and any serialization prefix. If
-BIP-32 derivation produces an invalid child key (IL ≥ curve
+**IKM (Input Key Material):** the **connected account's** raw
+32-byte private key scalar (big-endian, excluding chain code,
+depth, fingerprint, child number, and any serialization prefix).
+Specifically:
+
+- **HD wallets (mnemonic):** the BIP-32 private key at the
+  **account-level node** `m/purpose'/coin_type'/account'`
+  (3-deep, hardened) — e.g. `m/44'/0'/0'` for the default BIP-44
+  account 0; `m/84'/0'/0'` for Native SegWit account 0;
+  `m/86'/0'/0'` for Taproot account 0. The IKM is the 32-byte
+  private key scalar at that node. All receive addresses
+  (`change/index` leaves) under the same account share the same
+  IKM and therefore the same output.
+- **HD wallets (imported xpriv):** the imported xpriv's own
+  private key. The imported xpriv represents the user's account
+  identity at whatever depth they imported.
+- **Imported (raw) private key wallets:** the raw 32-byte
+  imported private key, used directly as IKM (no BIP-32
+  derivation — imported keys lack a hierarchy).
+
+If BIP-32 derivation produces an invalid child key (IL ≥ curve
 order or resulting key is zero), the wallet MUST return an error
 rather than skip to the next index.
 
-The purpose index `73681862` is derived deterministically:
-`trunc31_be(SHA-256("derive-context-hash"))`. This avoids
-collision with registered BIP-43 purpose values (BIP-44 `44'`,
-BIP-85 `83696968'`, etc.) and the reserved range
-`10001'–19999'`.
+**Output is per-account-xpub.** Two different connected accounts
+under the same recovery phrase (different account index, or
+different purpose / address-type, e.g. BIP-44 vs BIP-86) produce
+different outputs for the same `(appName, context)`. Two
+different receive addresses under the same account-level xpub
+produce the **same** output. Two wallets that share the same
+recovery phrase, the same BIP-39 passphrase, and connect under
+the same account-level path produce the same output.
 
-The derivation path is dedicated to this method — it MUST NOT
-be used for signing or any other BIP-32 derivation. Using a
-BIP-32 derived key (rather than the raw BIP-39 seed) ensures
-hardware wallets can run the entire derivation internally on
-the secure element without exporting the private key. This
-requires a dedicated device app; the stock Bitcoin app on
-Ledger/Trezor does not support this operation.
+dApps that need per-address differentiation (rather than
+per-account) MUST encode the address (or any finer-grained
+identifier) into `context` themselves.
 
-The derivation path is fixed regardless of the wallet's active
-account or network. All accounts derived from the same seed
-share the same `deriveContextHash` root. Applications that need
-per-account isolation MUST encode an account identifier in
-their context.
-
-**Imported private keys:** Wallets that support imported (non-HD)
-private keys MAY offer `deriveContextHash` for those keys. Since
-imported keys lack a BIP-32 hierarchy, the wallet SHOULD use the
-raw 32-byte private key directly as IKM, skipping BIP-32
-derivation. Outputs from imported keys are not cross-wallet
-compatible — this is inherent to imported keys, which have no
-shared derivation tree. Wallets MUST clearly document this
-behavior to users and application developers.
-
-Note: BIP-39 passphrases produce different seeds from the same
-recovery phrase. Two wallets restored from the same recovery
-phrase but with different passphrases will produce different
-outputs.
+**Hardware wallets.** A hardware wallet that supports
+`deriveContextHash` MUST run the derivation internally; the
+private key MUST NOT leave the secure element. The IKM is the
+BIP-32 private key at the account-level node specified by the
+host. If the host-supplied path is outside the device's allowed
+set, the device MUST refuse. WebAuthn's PRF / `hmac-secret`
+extension is a related precedent.
 
 **Salt:** The fixed UTF-8 string `"derive-context-hash"`.
 Provides domain separation from BIP-32 and other HMAC-based
-derivation schemes. For future revisions, a `-v1`, `-v2`, etc.
+derivation schemes. For future revisions, a `-v2`, `-v3`, etc.
 suffix can be appended to the salt to indicate the version of
-the scheme. The current `derive-context-hash` salt is version 0
-without a suffix.
+the scheme. The current `derive-context-hash` salt covers both
+revisions 1.0 and 2.0 of this spec — they differ in IKM source
+only, which already produces independent outputs.
 
 **Length:** 32 bytes (256 bits).
 
@@ -238,18 +252,18 @@ schemes.
 
 ## 4. Test Vectors
 
-All test vectors derive the BIP-32 master key from the following
-BIP-39 seed (the canonical "abandon" recovery phrase, empty
-passphrase):
+The vectors in this section pin the HKDF function-level
+composition (i.e. the mathematical mapping from
+`(ikm, appName, context)` to output). They are independent of
+how a wallet sources `ikm` at runtime — the `ikm` value below is
+just an opaque fixed 32-byte test value treated as already-known
+input. Wallet integration tests should assert that the wallet
+correctly produces this `ikm` for the chosen connected account
+(see section 4.2 for an HD-wallet integration example).
 
-BIP-39 seed (hex):
-```
-5eb00bbddcf069084889a8ab9155568165f5c453ccb85e70811aaed6
-f6da5fc19a5ac40b389cd370d086206dec8aa6c43daea6690f20ad3d
-8d48b2d2ce9e38e4
-```
+### 4.1 HKDF function-level vectors
 
-BIP-32 private key at `m/73681862'` (hex):
+`ikm` (hex, fixed test value):
 ```
 391cdb922097ec9c96fc13cadb01d5745ccf31f5dbec3a3810344071
 4779ec85
@@ -312,6 +326,48 @@ output (hex):   d81e4a91f32eabd34df0e55ca36f26f2
 
 Vectors verified against Node.js `crypto.hkdf('sha256', ...)`
 and a manual HMAC-based implementation.
+
+### 4.2 HD-wallet integration example
+
+The following example shows how a conforming HD wallet derives
+IKM from the canonical "abandon" recovery phrase (empty
+passphrase). Normative for any wallet that exposes this method
+under default BIP-44 account 0; informative for other paths.
+
+BIP-39 mnemonic:
+```
+abandon abandon abandon abandon abandon abandon abandon
+abandon abandon abandon abandon about
+```
+
+BIP-39 seed (no passphrase, hex):
+```
+5eb00bbddcf069084889a8ab9155568165f5c453ccb85e70811aaed6
+f6da5fc19a5ac40b389cd370d086206dec8aa6c43daea6690f20ad3d
+8d48b2d2ce9e38e4
+```
+
+For a wallet connected to BIP-44 Bitcoin account 0, the
+account-level node is `m/44'/0'/0'` and its private key (hex)
+is:
+```
+fe64af825b5b78554c33a28b23085fc082f691b3c712cc1d4e66e133
+297da87a
+```
+
+Using that private key as `ikm`, with `appName = "test-app"`
+and `context = "deadbeef"`:
+```
+output (hex):   2909f0c437a8a8b51206ac02a3abb88a
+                1656a2266ec05c0102ae2209c3f2a30c
+```
+
+A wallet that connects under a different account-level path
+(e.g. `m/86'/0'/0'` for Taproot, or `m/84'/0'/1'` for a second
+Native SegWit account, or BIP-39 with a passphrase) will yield
+a different account-level private key and a different output.
+Different receive addresses under the same account share the
+same output.
 
 ---
 

--- a/docs/specs/derive-context-hash.md
+++ b/docs/specs/derive-context-hash.md
@@ -2,20 +2,19 @@
 
 **Spec revision**: 2.0
 **Algorithm version**: 1 (salt: `"derive-context-hash"`, no suffix)
-**Date**: 2026-05-06
+**Date**: 2026-05-09
 **Authors**: Jerome Wang (Babylon Labs)
-**Status**: Draft — supersedes revision 1.0 (changes IKM source from a fixed BIP-32 path to the connected leaf's private key)
+**Status**: Draft — supersedes revision 1.0 (per-position outputs; IKM cryptographically separated from spend-authorizing keys)
 
 ---
 
 ## Changes from revision 1.0
 
-- **IKM source changed.** In v1.0, HD wallets derived IKM from a fixed BIP-32 path `m/73681862'` from the seed root, making the output wallet-level (identical across all accounts under the same seed). In v2.0, HD wallets derive IKM from the **connected leaf private key** at the BIP-32 receive-address path (e.g. `m/44'/0'/0'/0/0` for the first receive address of BIP-44 account 0). Output is **per-public-key**: different connected receive addresses (different leaf pubkeys) produce different outputs.
-- **Imported wallets unchanged.** They already used the raw imported private key as IKM. v2.0 keeps this. HD and imported are symmetric: one connected public key = one IKM = one output.
-- **Salt unchanged**: `"derive-context-hash"`. The IKM-source change alone produces different outputs from v1.0; no salt domain separation needed. The API is `@experimental` and the rollout is coordinated, so no version-discovery mechanism is added.
-- **Test vectors restructured.** §4.1 keeps function-level KAT vectors that pin the HKDF composition; §4.2 gives a new HD-wallet integration KAT for the v2.0 IKM source.
+- **IKM source changed.** v1.0 derived IKM from a fixed wallet-level path `m/73681862'`. v2.0 derives IKM at `m/73681862' / coin_type' / account' / change / address_index`, where the `coin_type / account / change / address_index` segments are taken from the connected user leaf. Output rotates per-position. Imported (non-HD) wallets and HD wallets without master-seed access derive IKM via an HMAC-SHA-512 wrap of the connected key ([BIP-85][bip85] pattern).
+- **Salt unchanged**: `"derive-context-hash"`.
+- **Test vectors restructured.** §4.1 HKDF function-level KAT (unchanged). §4.2 HD-wallet integration KAT (sibling path). §4.3 imported-wallet integration KAT (HMAC wrap).
 
-A wallet that conformed to v1.0 will produce different outputs than a wallet that conforms to v2.0 for the same recovery phrase and `(appName, context)`. dApps that persisted v1.0 outputs must re-derive against v2.0.
+dApps that persisted v1.0 outputs must re-derive against v2.0.
 
 ---
 
@@ -105,7 +104,7 @@ dialog SHOULD also display the context bytes.
 ### 2.2 Derivation Algorithm
 
 ```
-ikm    = the connected leaf's 32-byte private key
+ikm    = derive_ikm(wallet)           (see "IKM" below)
 salt   = "derive-context-hash"        (UTF-8 encoded)
 info   = SHA-256(UTF8(appName)) || context  (raw bytes)
 length = 32
@@ -121,51 +120,98 @@ length-confusion collisions between different `appName`/`context`
 combinations (e.g. appName `"foobar"` + context `0x01` vs
 appName `"foo"` + context `0x626172_01` can never collide).
 
-**IKM (Input Key Material):** the **connected leaf's** raw
-32-byte private key scalar (big-endian, excluding chain code,
-depth, fingerprint, child number, and any serialization prefix).
-Specifically:
+**IKM (Input Key Material):** a 32-byte value cryptographically
+separated from any spend-authorizing key. Construction depends on
+wallet type:
 
-- **HD wallets (mnemonic / xpriv):** the BIP-32 leaf private key
-  at the receive-address path the dApp is connected to — e.g.
-  `m/44'/0'/0'/0/0` for the first receive address of BIP-44
-  account 0; `m/86'/0'/0'/0/0` for the first Taproot receive
-  address. The IKM is the 32-byte private key scalar at that
-  leaf. The wallet selects the path from its currently active
-  receive address.
-- **Imported (raw) private key wallets:** the raw 32-byte
-  imported private key, used directly as IKM (no BIP-32
-  derivation — imported keys lack a hierarchy).
+- **HD wallets with verified master-seed access (typically
+  mnemonic-imported):** the BIP-32 private key scalar at the
+  dedicated 5-level BIP-44-shaped path
+
+  ```
+  m / 73681862' / coin_type' / account' / change / address_index
+  ```
+
+  where `coin_type / account / change / address_index` are taken
+  from the connected user leaf. Example: connected leaf
+  `m/44'/0'/0'/0/0` → IKM at `m/73681862'/0'/0'/0/0`. The IKM
+  segments `coin_type'` and `account'` are always hardened
+  regardless of how the user-leaf path expresses them; only the
+  numeric values are reused. The IKM is the raw 32-byte scalar at
+  the leaf, big-endian.
+
+- **Imported (raw) private key wallets, and HD wallets that
+  cannot verify master-seed access to the BIP-32 tree that
+  produced the connected leaf (e.g. xpriv imports — including
+  depth-0 xprivs whose original `(coin_type, account, change)`
+  context the wallet does not preserve):** the leftmost 32 bytes
+  of an HMAC-SHA-512 wrap of the connected key under a fixed
+  domain label ([BIP-85][bip85] pattern):
+
+  ```
+  ikm = HMAC-SHA-512(
+          key = "derive-context-hash-from-k"  (UTF-8, 26 bytes),
+          msg = connected_privkey             (32 bytes)
+        ) [leftmost 32 bytes]
+  ```
+
+  Argument order matches BIP-85: the label is the HMAC key, the
+  private key is the HMAC message. (BIP-85 takes the rightmost
+  32 bytes of its HMAC output for xprv key material; this spec
+  takes the leftmost 32 bytes — the two are not interchangeable.)
+  Outputs from this construction are not interoperable with HD
+  wallets that have master-seed access; wallets MUST document
+  this to users.
+
+The connected leaf's signing key is never used as direct HKDF
+input.
 
 If BIP-32 derivation produces an invalid child key (IL ≥ curve
 order or resulting key is zero), the wallet MUST return an error
 rather than skip to the next index.
 
-**Output is per-public-key.** Each unique connected leaf public
-key produces a unique output for the same `(appName, context)`.
-Switching the connected receive address — to a different index,
-account, address type, network, or wallet — yields a different
-output. The same connected leaf called twice yields the same
-output. Two wallets that share the same recovery phrase, the
-same BIP-39 passphrase, and connect to the same leaf path
-produce the same output.
+**Wallet support requirement.** Wallets with master-seed access
+to the root that produced the connected leaf MUST use the
+5-level sibling path; falling back to the HMAC-wrap construction
+when sibling derivation fails (e.g. firmware policy blocks
+purpose `73681862'`) is NOT permitted. The HMAC-wrap construction
+is reserved for raw-imported private keys and HD wallets that
+genuinely lack master-seed access (e.g. sub-path xpriv imports).
+Wallets to which neither construction applies — for example,
+watch-only / xpub-only wallets with no private material, or
+hardware wallets whose firmware blocks the required derivation —
+MUST report this method as unsupported.
+
+**Constant pinning.** `73681862'` is fixed as the 31-bit integer
+obtained from the leftmost four bytes of `SHA-256(UTF8("derive-context-hash"))`,
+interpreted big-endian and masked with `0x7fffffff`; this
+evaluates to `73681862`. This avoids collision with registered
+BIP-43 purpose values.
+
+**BIP-39 passphrase.** Wallets that derive seeds from a BIP-39
+mnemonic MUST honor the active BIP-39 passphrase, if any, when
+deriving IKM. Two wallets restored from the same recovery
+phrase but with different passphrases will produce different
+outputs; ignoring the passphrase produces incompatible output.
+
+**Output is per-position.** For HD wallets with master access,
+IKM rotates with the `(coin_type, account, change,
+address_index)` quad of the connected user leaf. Switching the
+index, account, or coin yields a different output. Switching
+only the BIP-43 purpose (e.g. BIP-44 ↔ BIP-86) at the same
+`(coin, account, change, index)` does not rotate IKM, because
+the user's purpose segment is replaced by `73681862'` in the IKM
+path. The same connected leaf called twice yields the same
+output. Imported and master-less HD wallets follow the analogous
+property at the per-imported-key level.
 
 **Hardware wallets.** A hardware wallet that supports
 `deriveContextHash` MUST run the derivation internally; the
-private key MUST NOT leave the secure element. The IKM is the
-BIP-32 leaf private key at the receive-address path specified by
-the host (the same path the device is willing to sign for). If
-the host-supplied path is outside the device's allowed
-set, the device MUST refuse. WebAuthn's PRF / `hmac-secret`
-extension is a related precedent.
+private key MUST NOT leave the secure element. The device MUST
+allow derivation under custom BIP-43 purpose `73681862'`
+(devices that gate by purpose must allowlist it).
 
 **Salt:** The fixed UTF-8 string `"derive-context-hash"`.
-Provides domain separation from BIP-32 and other HMAC-based
-derivation schemes. For future revisions, a `-v2`, `-v3`, etc.
-suffix can be appended to the salt to indicate the version of
-the scheme. The current `derive-context-hash` salt covers both
-revisions 1.0 and 2.0 of this spec — they differ in IKM source
-only, which already produces independent outputs.
 
 **Length:** 32 bytes (256 bits).
 
@@ -245,17 +291,11 @@ schemes.
 
 ## 4. Test Vectors
 
-The vectors in this section pin the HKDF function-level
-composition (i.e. the mathematical mapping from
-`(ikm, appName, context)` to output). They are independent of
-how a wallet sources `ikm` at runtime — the `ikm` value below is
-just an opaque fixed 32-byte test value treated as already-known
-input. Wallet integration tests SHOULD NOT target the §4.1
-fixture — that value exists only to pin the HKDF math. See §4.2
-for the canonical HD-wallet integration vector (mnemonic →
-BIP-32 leaf private key → output) that wallets should reproduce.
-
 ### 4.1 HKDF function-level vectors
+
+These vectors pin the pure HKDF composition (the mathematical
+mapping from `(ikm, appName, context)` to output). They are
+independent of how the wallet sources `ikm` at runtime.
 
 `ikm` (hex, fixed test value):
 ```
@@ -274,7 +314,7 @@ d3fe48f1
 The `info` field for each vector is:
 `SHA-256(UTF8("test-app")) || decode_hex(context)`.
 
-### Vector 1
+#### Vector 1
 
 ```
 appName:        test-app
@@ -287,7 +327,7 @@ output (hex):   3b0e2d90a01122eed8a520648073892f
                 6b2d8f4419216023d63cdbd49500fca3
 ```
 
-### Vector 2
+#### Vector 2
 
 ```
 appName:        test-app
@@ -299,7 +339,7 @@ output (hex):   50775126782c1a5e4d60daa4666b2c75
                 90f0b5a445a4115b0abd411467c92597
 ```
 
-### Vector 3
+#### Vector 3
 
 ```
 appName:        test-app
@@ -321,46 +361,52 @@ output (hex):   d81e4a91f32eabd34df0e55ca36f26f2
 Vectors verified against Node.js `crypto.hkdf('sha256', ...)`
 and a manual HMAC-based implementation.
 
-### 4.2 HD-wallet integration example
+### 4.2 HD-wallet integration vector
 
-The following example shows how a conforming HD wallet derives
-IKM from the canonical "abandon" recovery phrase (empty
-passphrase). Normative for any wallet connected to the first
-receive address of BIP-44 account 0; informative for other paths.
-
-BIP-39 mnemonic:
-```
-abandon abandon abandon abandon abandon abandon abandon
-abandon abandon abandon abandon about
-```
-
-BIP-39 seed (no passphrase, hex):
+Canonical "abandon" mnemonic, empty BIP-39 passphrase. BIP-39
+seed (hex):
 ```
 5eb00bbddcf069084889a8ab9155568165f5c453ccb85e70811aaed6
 f6da5fc19a5ac40b389cd370d086206dec8aa6c43daea6690f20ad3d
 8d48b2d2ce9e38e4
 ```
 
-For a wallet connected to the first receive address of BIP-44
-Bitcoin account 0, the leaf is at `m/44'/0'/0'/0/0` and its
-private key (hex) is:
+For a connected user leaf at `(coin=0, account=0, change=0,
+index=0)` (e.g. `m/44'/0'/0'/0/0`), the IKM is the BIP-32 private
+key scalar at `m/73681862'/0'/0'/0/0` (hex):
 ```
-e284129cc0922579a535bbf4d1a3b25773090d28c909bc0fed73b5e0
-222cc372
-```
-
-Using that private key as `ikm`, with `appName = "test-app"`
-and `context = "deadbeef"`:
-```
-output (hex):   650b3fa2cf958ecd258544af2b812c3e
-                8a3f4f75ea5d030cb4dd175da551e356
+e8be9d66f2e9634904c07a4e5f663ac1
+4a614011780ee5c110b1988223ddd059
 ```
 
-A wallet that connects to a different receive address under
-the same account (e.g. `m/44'/0'/0'/0/1`) yields a different
-leaf private key and a different output. Same for switching
-the address type (`m/86'/0'/0'/0/0`), network (`m/44'/1'/...`),
-account index (`m/44'/0'/1'/0/0`), or BIP-39 passphrase.
+With `appName = "test-app"`, `context = "deadbeef"`:
+```
+output (hex):   7cf4ad428083057fb3c344795b8e124b
+                e7f3ef521929b1531909e682c1072f29
+```
+
+### 4.3 Imported-wallet integration vector
+
+For an imported (or master-less HD) wallet whose connected
+private key is (hex):
+```
+e284129cc0922579a535bbf4d1a3b257
+73090d28c909bc0fed73b5e0222cc372
+```
+
+The IKM is the leftmost 32 bytes of
+`HMAC-SHA-512("derive-context-hash-from-k", connected_privkey)`
+(hex):
+```
+350c0933c706cc78ddef8ba38abcafd1
+4f1cc5f94dee7004e994a97455a30863
+```
+
+With `appName = "test-app"`, `context = "deadbeef"`:
+```
+output (hex):   83a44b4012ec2e92831da086b092ace3
+                77698bbede4fd4dc54bc162663ed6a7d
+```
 
 ---
 
@@ -373,6 +419,7 @@ account index (`m/44'/0'/1'/0/0`), or BIP-39 passphrase.
 | BIP-32 | [HD Wallets][bip32] |
 | BIP-39 | [Recovery phrase / seed][bip39] |
 | BIP-43 | [Purpose Field][bip43] |
+| BIP-85 | [Deterministic Entropy From BIP-32 Keychains][bip85] |
 | UniSat wallet PR | [wallet#2][unisat2] |
 | Salt fix PR | [wallet#3][unisat3] |
 
@@ -381,5 +428,6 @@ account index (`m/44'/0'/1'/0/0`), or BIP-39 passphrase.
 [bip32]: https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki
 [bip39]: https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki
 [bip43]: https://github.com/bitcoin/bips/blob/master/bip-0043.mediawiki
+[bip85]: https://github.com/bitcoin/bips/blob/master/bip-0085.mediawiki
 [unisat2]: https://github.com/unisat-wallet/wallet/pull/2
 [unisat3]: https://github.com/unisat-wallet/wallet/pull/3

--- a/docs/specs/derive-context-hash.md
+++ b/docs/specs/derive-context-hash.md
@@ -4,14 +4,14 @@
 **Algorithm version**: 1 (salt: `"derive-context-hash"`, no suffix)
 **Date**: 2026-05-06
 **Authors**: Jerome Wang (Babylon Labs)
-**Status**: Draft — supersedes revision 1.0 (changes IKM source from a fixed BIP-32 path to the connected account's private key)
+**Status**: Draft — supersedes revision 1.0 (changes IKM source from a fixed BIP-32 path to the connected leaf's private key)
 
 ---
 
 ## Changes from revision 1.0
 
-- **IKM source changed.** In v1.0, HD wallets derived IKM from a fixed BIP-32 path `m/73681862'` from the seed root, making the output wallet-level (identical across all accounts under the same seed). In v2.0, HD wallets derive IKM from the **account-level** BIP-32 node `m/purpose'/coin_type'/account'` (3-deep, hardened) corresponding to the connected account, making the output **per-account-xpub** — different connected accounts produce different outputs, while different receive addresses under the same account share the same output.
-- **Imported wallets unchanged.** They already used the raw imported private key as IKM. v2.0 keeps this. The two paths (HD and imported) now have a symmetric "one identity = one IKM" mental model.
+- **IKM source changed.** In v1.0, HD wallets derived IKM from a fixed BIP-32 path `m/73681862'` from the seed root, making the output wallet-level (identical across all accounts under the same seed). In v2.0, HD wallets derive IKM from the **connected leaf private key** at the BIP-32 receive-address path (e.g. `m/44'/0'/0'/0/0` for the first receive address of BIP-44 account 0). Output is **per-public-key**: different connected receive addresses (different leaf pubkeys) produce different outputs.
+- **Imported wallets unchanged.** They already used the raw imported private key as IKM. v2.0 keeps this. HD and imported are symmetric: one connected public key = one IKM = one output.
 - **Salt unchanged**: `"derive-context-hash"`. The IKM-source change alone produces different outputs from v1.0; no salt domain separation needed. The API is `@experimental` and the rollout is coordinated, so no version-discovery mechanism is added.
 - **Test vectors restructured.** §4.1 keeps function-level KAT vectors that pin the HKDF composition; §4.2 gives a new HD-wallet integration KAT for the v2.0 IKM source.
 
@@ -105,7 +105,7 @@ dialog SHOULD also display the context bytes.
 ### 2.2 Derivation Algorithm
 
 ```
-ikm    = the connected account's 32-byte private key
+ikm    = the connected leaf's 32-byte private key
 salt   = "derive-context-hash"        (UTF-8 encoded)
 info   = SHA-256(UTF8(appName)) || context  (raw bytes)
 length = 32
@@ -121,22 +121,18 @@ length-confusion collisions between different `appName`/`context`
 combinations (e.g. appName `"foobar"` + context `0x01` vs
 appName `"foo"` + context `0x626172_01` can never collide).
 
-**IKM (Input Key Material):** the **connected account's** raw
+**IKM (Input Key Material):** the **connected leaf's** raw
 32-byte private key scalar (big-endian, excluding chain code,
 depth, fingerprint, child number, and any serialization prefix).
 Specifically:
 
-- **HD wallets (mnemonic):** the BIP-32 private key at the
-  **account-level node** `m/purpose'/coin_type'/account'`
-  (3-deep, hardened) — e.g. `m/44'/0'/0'` for the default BIP-44
-  account 0; `m/84'/0'/0'` for Native SegWit account 0;
-  `m/86'/0'/0'` for Taproot account 0. The IKM is the 32-byte
-  private key scalar at that node. All receive addresses
-  (`change/index` leaves) under the same account share the same
-  IKM and therefore the same output.
-- **HD wallets (imported xpriv):** the imported xpriv's own
-  private key. The imported xpriv represents the user's account
-  identity at whatever depth they imported.
+- **HD wallets (mnemonic / xpriv):** the BIP-32 leaf private key
+  at the receive-address path the dApp is connected to — e.g.
+  `m/44'/0'/0'/0/0` for the first receive address of BIP-44
+  account 0; `m/86'/0'/0'/0/0` for the first Taproot receive
+  address. The IKM is the 32-byte private key scalar at that
+  leaf. The wallet selects the path from its currently active
+  receive address.
 - **Imported (raw) private key wallets:** the raw 32-byte
   imported private key, used directly as IKM (no BIP-32
   derivation — imported keys lack a hierarchy).
@@ -145,24 +141,21 @@ If BIP-32 derivation produces an invalid child key (IL ≥ curve
 order or resulting key is zero), the wallet MUST return an error
 rather than skip to the next index.
 
-**Output is per-account-xpub.** Two different connected accounts
-under the same recovery phrase (different account index, or
-different purpose / address-type, e.g. BIP-44 vs BIP-86) produce
-different outputs for the same `(appName, context)`. Two
-different receive addresses under the same account-level xpub
-produce the **same** output. Two wallets that share the same
-recovery phrase, the same BIP-39 passphrase, and connect under
-the same account-level path produce the same output.
-
-dApps that need per-address differentiation (rather than
-per-account) MUST encode the address (or any finer-grained
-identifier) into `context` themselves.
+**Output is per-public-key.** Each unique connected leaf public
+key produces a unique output for the same `(appName, context)`.
+Switching the connected receive address — to a different index,
+account, address type, network, or wallet — yields a different
+output. The same connected leaf called twice yields the same
+output. Two wallets that share the same recovery phrase, the
+same BIP-39 passphrase, and connect to the same leaf path
+produce the same output.
 
 **Hardware wallets.** A hardware wallet that supports
 `deriveContextHash` MUST run the derivation internally; the
 private key MUST NOT leave the secure element. The IKM is the
-BIP-32 private key at the account-level node specified by the
-host. If the host-supplied path is outside the device's allowed
+BIP-32 leaf private key at the receive-address path specified by
+the host (the same path the device is willing to sign for). If
+the host-supplied path is outside the device's allowed
 set, the device MUST refuse. WebAuthn's PRF / `hmac-secret`
 extension is a related precedent.
 
@@ -257,9 +250,10 @@ composition (i.e. the mathematical mapping from
 `(ikm, appName, context)` to output). They are independent of
 how a wallet sources `ikm` at runtime — the `ikm` value below is
 just an opaque fixed 32-byte test value treated as already-known
-input. Wallet integration tests should assert that the wallet
-correctly produces this `ikm` for the chosen connected account
-(see section 4.2 for an HD-wallet integration example).
+input. Wallet integration tests SHOULD NOT target the §4.1
+fixture — that value exists only to pin the HKDF math. See §4.2
+for the canonical HD-wallet integration vector (mnemonic →
+BIP-32 leaf private key → output) that wallets should reproduce.
 
 ### 4.1 HKDF function-level vectors
 
@@ -331,8 +325,8 @@ and a manual HMAC-based implementation.
 
 The following example shows how a conforming HD wallet derives
 IKM from the canonical "abandon" recovery phrase (empty
-passphrase). Normative for any wallet that exposes this method
-under default BIP-44 account 0; informative for other paths.
+passphrase). Normative for any wallet connected to the first
+receive address of BIP-44 account 0; informative for other paths.
 
 BIP-39 mnemonic:
 ```
@@ -347,27 +341,26 @@ f6da5fc19a5ac40b389cd370d086206dec8aa6c43daea6690f20ad3d
 8d48b2d2ce9e38e4
 ```
 
-For a wallet connected to BIP-44 Bitcoin account 0, the
-account-level node is `m/44'/0'/0'` and its private key (hex)
-is:
+For a wallet connected to the first receive address of BIP-44
+Bitcoin account 0, the leaf is at `m/44'/0'/0'/0/0` and its
+private key (hex) is:
 ```
-fe64af825b5b78554c33a28b23085fc082f691b3c712cc1d4e66e133
-297da87a
+e284129cc0922579a535bbf4d1a3b25773090d28c909bc0fed73b5e0
+222cc372
 ```
 
 Using that private key as `ikm`, with `appName = "test-app"`
 and `context = "deadbeef"`:
 ```
-output (hex):   2909f0c437a8a8b51206ac02a3abb88a
-                1656a2266ec05c0102ae2209c3f2a30c
+output (hex):   650b3fa2cf958ecd258544af2b812c3e
+                8a3f4f75ea5d030cb4dd175da551e356
 ```
 
-A wallet that connects under a different account-level path
-(e.g. `m/86'/0'/0'` for Taproot, or `m/84'/0'/1'` for a second
-Native SegWit account, or BIP-39 with a passphrase) will yield
-a different account-level private key and a different output.
-Different receive addresses under the same account share the
-same output.
+A wallet that connects to a different receive address under
+the same account (e.g. `m/44'/0'/0'/0/1`) yields a different
+leaf private key and a different output. Same for switching
+the address type (`m/86'/0'/0'/0/0`), network (`m/44'/1'/...`),
+account index (`m/44'/0'/1'/0/0`), or BIP-39 passphrase.
 
 ---
 

--- a/packages/babylon-wallet-connector/docs/vault-integration-guide.md
+++ b/packages/babylon-wallet-connector/docs/vault-integration-guide.md
@@ -40,7 +40,7 @@ nice-to-have.
 | 64-byte Schnorr signatures (implicit `SIGHASH_DEFAULT`) | MUST | SDK rejects 65-byte sigs; the appended sighash byte changes the signed message and cannot be stripped ([`peginInput.ts`][peginInput], [`payout.ts`][payout]) |
 | Non-finalized PSBT return for PegIn input PSBTs | MUST | SDK extracts the depositor signature from `tapScriptSig`; finalized PegIn PSBTs throw outright ([`peginInput.ts`][peginInput]) |
 | BIP-322 simple message signing | MUST | Used for proof-of-possession ([`PeginManager.ts`][peginManager]) |
-| `deriveContextHash` (HKDF-SHA-256, BIP-32 hardened path `m/73681862'`) | MUST | Hashlock secret derivation — see [spec][spec] for derivation algorithm and test vectors |
+| `deriveContextHash` (HKDF-SHA-256, IKM = connected leaf private key) | MUST | Hashlock secret derivation — see [spec][spec] for derivation algorithm and test vectors |
 | `signPsbts` (batch signing) | STRONGLY RECOMMENDED | Without it, depositors approve N PSBTs one-by-one |
 | `getInscriptions` | OPTIONAL | UTXO filtering only |
 
@@ -146,7 +146,7 @@ creation and revealed during activation.
 Implementation requirements (see [spec][spec] for full
 detail and test vectors):
 
-- BIP-32 hardened derivation path `m/73681862'`.
+- IKM is the **connected leaf's** 32-byte private key (the BIP-32 leaf at the receive-address path the dApp is connected to, e.g. `m/86'/0'/0'/0/0`). For imported wallets, the raw imported private key. Output is per-public-key.
 - HKDF-SHA-256 with the spec's fixed salt and `info` constructed from `appName` + `context`.
 - 32-byte output (64 lowercase hex chars).
 - `appName` must match `[a-z0-9\-]`, 1–64 bytes.

--- a/packages/babylon-wallet-connector/docs/vault-integration-guide.md
+++ b/packages/babylon-wallet-connector/docs/vault-integration-guide.md
@@ -40,7 +40,7 @@ nice-to-have.
 | 64-byte Schnorr signatures (implicit `SIGHASH_DEFAULT`) | MUST | SDK rejects 65-byte sigs; the appended sighash byte changes the signed message and cannot be stripped ([`peginInput.ts`][peginInput], [`payout.ts`][payout]) |
 | Non-finalized PSBT return for PegIn input PSBTs | MUST | SDK extracts the depositor signature from `tapScriptSig`; finalized PegIn PSBTs throw outright ([`peginInput.ts`][peginInput]) |
 | BIP-322 simple message signing | MUST | Used for proof-of-possession ([`PeginManager.ts`][peginManager]) |
-| `deriveContextHash` (HKDF-SHA-256, IKM = connected leaf private key) | MUST | Hashlock secret derivation — see [spec][spec] for derivation algorithm and test vectors |
+| `deriveContextHash` (HKDF-SHA-256, IKM = key at `m/73681862'/coin'/account'/change/index`) | MUST | Hashlock secret derivation — see [spec][spec] for derivation algorithm and test vectors |
 | `signPsbts` (batch signing) | STRONGLY RECOMMENDED | Without it, depositors approve N PSBTs one-by-one |
 | `getInscriptions` | OPTIONAL | UTXO filtering only |
 
@@ -146,7 +146,7 @@ creation and revealed during activation.
 Implementation requirements (see [spec][spec] for full
 detail and test vectors):
 
-- IKM is the **connected leaf's** 32-byte private key (the BIP-32 leaf at the receive-address path the dApp is connected to, e.g. `m/86'/0'/0'/0/0`). For imported wallets, the raw imported private key. Output is per-public-key.
+- IKM is derived at the BIP-44-shaped path `m/73681862'/coin_type'/account'/change/address_index`, reusing the connected user leaf's `(coin_type, account, change, address_index)` quad — e.g. a wallet connected to user leaf `m/86'/0'/0'/0/0` derives IKM at `m/73681862'/0'/0'/0/0`. The connected leaf's signing key is never used as direct HKDF input. For imported wallets and master-less HD wallets, IKM is the leftmost 32 bytes of `HMAC-SHA-512("derive-context-hash-from-k", connected_privkey)`.
 - HKDF-SHA-256 with the spec's fixed salt and `info` constructed from `appName` + `context`.
 - 32-byte output (64 lowercase hex chars).
 - `appName` must match `[a-z0-9\-]`, 1–64 bytes.


### PR DESCRIPTION
## Summary

Spec revision 1.0 → 2.0. Changes the IKM source for `deriveContextHash`
from a fixed wallet-root BIP-32 path (`m/73681862'`) to the **connected
leaf's** 32-byte private key.

HD wallets now produce **per-public-key** outputs:
- Different connected receive addresses (different leaf pubkeys) → different outputs
- Same connected leaf called twice → same output
- Switching account, address type, index, or network → different output

Imported wallets are unchanged (already used the raw imported privkey
as IKM). HD and imported are now symmetric: one connected public key =
one IKM = one output.

## Breaking change

Output bytes change for any v1.0 caller. Salt is unchanged
(`"derive-context-hash"`). dApps that persisted v1.0 outputs must
re-derive against v2.0. The API is `@experimental` and the rollout is
coordinated, so no version-discovery mechanism is added.

## Other changes

- Test vectors restructured: §4.1 keeps function-level HKDF KATs; §4.2 adds an HD-wallet
integration KAT for the new IKM source.
- Hardware-wallet section tightened to contract-only requirements (no vendor-specific
implementation prescription).



Unisat PR: https://github.com/unisat-wallet/wallet/pull/5