### PR TITLE
fix(vault): simple borrow flow staleness

### DIFF
--- a/services/vault/src/components/simple/BorrowFlow/__tests__/useBorrowFormState.test.tsx
+++ b/services/vault/src/components/simple/BorrowFlow/__tests__/useBorrowFormState.test.tsx
@@ -51,7 +51,7 @@ const ASSET = {
   icon: "/usdc.svg",
 } as LoanContextValue["assetConfig"];
 
-// Aave SDK conventions (see packages/babylon-ts-sdk/src/tbv/integrations/aave/constants.ts):
+// Aave SDK conventions:
 //   totalCollateralValue is scaled by 1e26 per USD,
 //   totalDebtValueRay is scaled by 1e53 per USD.
 const USD_BASE = 10n ** 26n;

--- a/services/vault/src/components/simple/BorrowFlow/__tests__/useBorrowFormState.test.tsx
+++ b/services/vault/src/components/simple/BorrowFlow/__tests__/useBorrowFormState.test.tsx
@@ -1,3 +1,7 @@
+import {
+  AAVE_BASE_CURRENCY_DECIMALS,
+  AAVE_BASE_CURRENCY_RAY_DECIMALS,
+} from "@babylonlabs-io/ts-sdk/tbv/integrations/aave";
 import { act, renderHook } from "@testing-library/react";
 import { type ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
@@ -51,11 +55,8 @@ const ASSET = {
   icon: "/usdc.svg",
 } as LoanContextValue["assetConfig"];
 
-// Aave SDK conventions:
-//   totalCollateralValue is scaled by 1e26 per USD,
-//   totalDebtValueRay is scaled by 1e53 per USD.
-const USD_BASE = 10n ** 26n;
-const USD_RAY = 10n ** 53n;
+const USD_BASE = 10n ** BigInt(AAVE_BASE_CURRENCY_DECIMALS);
+const USD_RAY = 10n ** BigInt(AAVE_BASE_CURRENCY_RAY_DECIMALS);
 
 function buildAccountData(collateralUsd: bigint, debtUsd: bigint) {
   return {

--- a/services/vault/src/components/simple/BorrowFlow/__tests__/useBorrowFormState.test.tsx
+++ b/services/vault/src/components/simple/BorrowFlow/__tests__/useBorrowFormState.test.tsx
@@ -1,0 +1,265 @@
+import { act, renderHook } from "@testing-library/react";
+import { type ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  LoanProvider,
+  type LoanContextValue,
+} from "@/applications/aave/components/context/LoanContext";
+
+import { useBorrowFormState } from "../useBorrowFormState";
+
+const mockExecuteBorrow = vi.fn();
+vi.mock("@/applications/aave/hooks", () => ({
+  useBorrowTransaction: () => ({
+    executeBorrow: mockExecuteBorrow,
+    isProcessing: false,
+  }),
+}));
+
+// The shared test setup mocks "@/config" without FeatureFlags. Extend that
+// mock here so the hook's FeatureFlags.isBorrowDisabled read does not crash.
+vi.mock("@/config", () => ({
+  FeatureFlags: {
+    isBorrowDisabled: false,
+  },
+  getNetworkConfigBTC: () => ({
+    coinName: "Signet BTC",
+    coinSymbol: "sBTC",
+    networkName: "BTC signet",
+    mempoolApiUrl: "https://mempool.space/signet",
+    network: "signet",
+    icon: "/images/signet_bitcoin.svg",
+    name: "Signet Bitcoin",
+    displayUSD: false,
+  }),
+  getBTCNetwork: () => "signet",
+  CONTRACTS: {},
+  ENV: {},
+  isProductionEnv: () => false,
+  getCommitHash: () => "test-commit",
+}));
+
+const RESERVE = {
+  reserveId: 1n,
+  token: { address: "0xtoken", decimals: 18 },
+} as unknown as LoanContextValue["selectedReserve"];
+
+const ASSET = {
+  symbol: "USDC",
+  name: "USD Coin",
+  icon: "/usdc.svg",
+} as LoanContextValue["assetConfig"];
+
+// Aave SDK conventions (see packages/babylon-ts-sdk/src/tbv/integrations/aave/constants.ts):
+//   totalCollateralValue is scaled by 1e26 per USD,
+//   totalDebtValueRay is scaled by 1e53 per USD.
+const USD_BASE = 10n ** 26n;
+const USD_RAY = 10n ** 53n;
+
+function buildAccountData(collateralUsd: bigint, debtUsd: bigint) {
+  return {
+    riskPremium: 0n,
+    avgCollateralFactor: 0n,
+    healthFactor: 0n,
+    totalCollateralValue: collateralUsd * USD_BASE,
+    totalDebtValueRay: debtUsd * USD_RAY,
+    activeCollateralCount: 0n,
+    borrowCount: 0n,
+  };
+}
+
+function makeContext(
+  overrides: Partial<LoanContextValue> = {},
+): LoanContextValue {
+  return {
+    collateralValueUsd: 1000,
+    currentDebtAmount: 500,
+    totalDebtValueUsd: 500,
+    healthFactor: 1.6,
+    liquidationThresholdBps: 8000,
+    selectedReserve: RESERVE,
+    assetConfig: ASSET,
+    proxyContract: "0xproxy",
+    tokenPriceUsd: 1,
+    isPositionDataStale: false,
+    refetchPosition: vi.fn().mockResolvedValue(null),
+    onBorrowSuccess: () => {},
+    onRepaySuccess: () => {},
+    ...overrides,
+  };
+}
+
+function wrapWith(value: LoanContextValue) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <LoanProvider value={value}>{children}</LoanProvider>;
+  };
+}
+
+describe("useBorrowFormState — staleness gate (audit #251)", () => {
+  it("disables the button and shows 'Refreshing position...' when isPositionDataStale is true", () => {
+    const ctx = makeContext({ isPositionDataStale: true });
+    const { result } = renderHook(
+      () => useBorrowFormState({ onBorrowSuccess: () => {} }),
+      { wrapper: wrapWith(ctx) },
+    );
+
+    expect(result.current.isDisabled).toBe(true);
+    expect(result.current.buttonText).toBe("Refreshing position...");
+  });
+
+  it("does not disable on staleness when isPositionDataStale is false", () => {
+    const ctx = makeContext({ isPositionDataStale: false });
+    const { result } = renderHook(
+      () => useBorrowFormState({ onBorrowSuccess: () => {} }),
+      { wrapper: wrapWith(ctx) },
+    );
+
+    // borrowAmount starts at 0 so button text falls through to "Enter an amount",
+    // which is the validateBorrowAction path *after* the staleness short-circuit.
+    expect(result.current.buttonText).toBe("Enter an amount");
+  });
+});
+
+describe("useBorrowFormState — pre-sign HF gate (audit #251)", () => {
+  it("passes a preSignValidation closure into executeBorrow", async () => {
+    mockExecuteBorrow.mockReset();
+    mockExecuteBorrow.mockResolvedValue(true);
+
+    const ctx = makeContext();
+    const { result } = renderHook(
+      () => useBorrowFormState({ onBorrowSuccess: () => {} }),
+      { wrapper: wrapWith(ctx) },
+    );
+
+    await act(async () => {
+      await result.current.handleBorrow();
+    });
+
+    expect(mockExecuteBorrow).toHaveBeenCalledOnce();
+    const [, , preSignValidation] = mockExecuteBorrow.mock.calls[0];
+    expect(typeof preSignValidation).toBe("function");
+  });
+
+  it("preSignValidation throws when fresh position pushes projected HF below MIN_HEALTH_FACTOR_FOR_BORROW", async () => {
+    mockExecuteBorrow.mockReset();
+    mockExecuteBorrow.mockResolvedValue(true);
+
+    // Fresh position: $1000 collateral, $700 debt, 80% liq threshold.
+    // Pre-borrow HF = 1000 * 0.8 / 700 ≈ 1.14 — already below 1.2.
+    // Borrowing anything more keeps it below 1.2.
+    const refetchPosition = vi.fn().mockResolvedValue({
+      accountData: buildAccountData(1000n, 700n),
+    });
+    const ctx = makeContext({
+      collateralValueUsd: 1000,
+      totalDebtValueUsd: 700,
+      liquidationThresholdBps: 8000,
+      tokenPriceUsd: 1,
+      refetchPosition,
+    });
+
+    const { result } = renderHook(
+      () =>
+        useBorrowFormState({
+          onBorrowSuccess: () => {},
+        }),
+      { wrapper: wrapWith(ctx) },
+    );
+
+    act(() => {
+      result.current.setBorrowAmount(50);
+    });
+
+    await act(async () => {
+      await result.current.handleBorrow();
+    });
+
+    const [, , preSignValidation] = mockExecuteBorrow.mock.calls[0];
+    await expect(preSignValidation()).rejects.toThrow(
+      /Projected health factor.*would be below 1\.2/,
+    );
+    expect(refetchPosition).toHaveBeenCalled();
+  });
+
+  it("preSignValidation resolves without throwing when fresh position keeps projected HF safely above the floor", async () => {
+    mockExecuteBorrow.mockReset();
+    mockExecuteBorrow.mockResolvedValue(true);
+
+    // Fresh position: $1000 collateral, $100 debt, 80% liq threshold.
+    // Pre-borrow HF = 1000 * 0.8 / 100 = 8.0; borrowing 50 USDC at $1 keeps HF = 5.33.
+    const refetchPosition = vi.fn().mockResolvedValue({
+      accountData: buildAccountData(1000n, 100n),
+    });
+    const ctx = makeContext({
+      collateralValueUsd: 1000,
+      totalDebtValueUsd: 100,
+      liquidationThresholdBps: 8000,
+      tokenPriceUsd: 1,
+      refetchPosition,
+    });
+
+    const { result } = renderHook(
+      () => useBorrowFormState({ onBorrowSuccess: () => {} }),
+      { wrapper: wrapWith(ctx) },
+    );
+
+    act(() => {
+      result.current.setBorrowAmount(50);
+    });
+
+    await act(async () => {
+      await result.current.handleBorrow();
+    });
+
+    const [, , preSignValidation] = mockExecuteBorrow.mock.calls[0];
+    await expect(preSignValidation()).resolves.toBeUndefined();
+  });
+
+  it("preSignValidation throws when tokenPriceUsd is null at sign time", async () => {
+    mockExecuteBorrow.mockReset();
+    mockExecuteBorrow.mockResolvedValue(true);
+
+    const refetchPosition = vi.fn();
+    const ctx = makeContext({
+      tokenPriceUsd: null,
+      refetchPosition,
+    });
+
+    const { result } = renderHook(
+      () => useBorrowFormState({ onBorrowSuccess: () => {} }),
+      { wrapper: wrapWith(ctx) },
+    );
+
+    await act(async () => {
+      await result.current.handleBorrow();
+    });
+
+    const [, , preSignValidation] = mockExecuteBorrow.mock.calls[0];
+    await expect(preSignValidation()).rejects.toThrow(
+      /Token price unavailable/,
+    );
+    expect(refetchPosition).not.toHaveBeenCalled();
+  });
+
+  it("preSignValidation skips revalidation when refetchPosition returns null (first borrow)", async () => {
+    mockExecuteBorrow.mockReset();
+    mockExecuteBorrow.mockResolvedValue(true);
+
+    const refetchPosition = vi.fn().mockResolvedValue(null);
+    const ctx = makeContext({ refetchPosition });
+
+    const { result } = renderHook(
+      () => useBorrowFormState({ onBorrowSuccess: () => {} }),
+      { wrapper: wrapWith(ctx) },
+    );
+
+    await act(async () => {
+      await result.current.handleBorrow();
+    });
+
+    const [, , preSignValidation] = mockExecuteBorrow.mock.calls[0];
+    await expect(preSignValidation()).resolves.toBeUndefined();
+    expect(refetchPosition).toHaveBeenCalled();
+  });
+});

--- a/services/vault/src/components/simple/BorrowFlow/useBorrowFormState.ts
+++ b/services/vault/src/components/simple/BorrowFlow/useBorrowFormState.ts
@@ -11,6 +11,9 @@ import { useBorrowTransaction } from "@/applications/aave/hooks";
 import type { AaveReserveConfig } from "@/applications/aave/services/fetchConfig";
 import type { Asset } from "@/applications/aave/types";
 import {
+  aaveRayValueToUsd,
+  aaveValueToUsd,
+  calculateHealthFactor,
   getHealthFactorColor,
   getHealthFactorStatusFromValue,
   type HealthFactorColor,
@@ -75,6 +78,8 @@ export function useBorrowFormState({
     selectedReserve,
     assetConfig,
     tokenPriceUsd,
+    isPositionDataStale,
+    refetchPosition,
   } = useLoanContext();
 
   const { executeBorrow, isProcessing } = useBorrowTransaction();
@@ -99,6 +104,7 @@ export function useBorrowFormState({
     borrowAmount,
     metrics.healthFactorValue,
     maxBorrowAmount,
+    isPositionDataStale,
   );
 
   const sliderMax = Math.max(maxBorrowAmount, MIN_SLIDER_MAX);
@@ -129,9 +135,39 @@ export function useBorrowFormState({
   const handleMaxClick = () => setBorrowAmount(sliderMax);
 
   const handleBorrow = async () => {
+    const preSignValidation = async () => {
+      if (tokenPriceUsd == null) {
+        throw new Error("Token price unavailable. Cannot validate borrow.");
+      }
+
+      const freshPosition = await refetchPosition();
+      if (!freshPosition) return;
+
+      const freshCollateralUsd = aaveValueToUsd(
+        freshPosition.accountData.totalCollateralValue,
+      );
+      const freshDebtUsd = aaveRayValueToUsd(
+        freshPosition.accountData.totalDebtValueRay,
+      );
+      const projectedDebtUsd = freshDebtUsd + borrowAmount * tokenPriceUsd;
+      const projectedHF = calculateHealthFactor(
+        freshCollateralUsd,
+        projectedDebtUsd,
+        liquidationThresholdBps,
+      );
+
+      if (isFinite(projectedHF) && projectedHF < MIN_HEALTH_FACTOR_FOR_BORROW) {
+        throw new Error(
+          `Position data has changed. Projected health factor (${projectedHF.toFixed(2)}) ` +
+            `would be below ${MIN_HEALTH_FACTOR_FOR_BORROW}. Please reduce the borrow amount.`,
+        );
+      }
+    };
+
     const success = await executeBorrow(
       borrowAmount,
       selectedReserve as AaveReserveConfig,
+      preSignValidation,
     );
     if (success) {
       onBorrowSuccess(


### PR DESCRIPTION
## Summary

The "simple" `BorrowFlow` modal was signing borrow transactions without the two safety gates the canonical `LoanCard/Borrow` flow enforces:

1. **Staleness gate (UI)** — `useBorrowFormState` was calling `validateBorrowAction` with no `isPositionDataStale` argument, so the borrow button stayed enabled when the cached `useAaveUserPosition` data was stale (RPC outage, indexer lag, oracle hiccup). The user could click "Max" and "Borrow" against numbers that hadn't refreshed in minutes.
2. **Pre-sign HF gate (network)** — `executeBorrow` was called with no `preSignValidation` callback, so the on-chain borrow tx was sent without a fresh-position refetch + projected health-factor recheck. On-chain Aave only blocks `HF < 1.0`; the UI's `MIN_HEALTH_FACTOR_FOR_BORROW = 1.2` floor was therefore not enforced at sign time, and a tx the UI claimed was safe could land in the immediate-liquidation band `[1.0, 1.2)`.

Both safeguards already existed in `applications/aave/components/LoanCard/Borrow/index.tsx`. The wrapping `BorrowFlow/index.tsx` was already plumbing `isPositionDataStale` and `refetchPosition` through `LoanProvider` — they just weren't being read by the consumer hook.

## Changes

- `services/vault/src/components/simple/BorrowFlow/useBorrowFormState.ts`
  - Destructure `isPositionDataStale` and `refetchPosition` from `useLoanContext()`.
  - Pass `isPositionDataStale` as the 4th argument to `validateBorrowAction` so the button shows "Refreshing position..." and is disabled while the position query is stale.
  - Build a `preSignValidation` closure inside `handleBorrow` byte-identical to the one in `LoanCard/Borrow/index.tsx:86–113`:
    - Throw if `tokenPriceUsd == null`.
    - `await refetchPosition()`; if `null` (first borrow), skip revalidation.
    - Recompute projected HF from fresh `accountData.totalCollateralValue` / `totalDebtValueRay` plus `borrowAmount * tokenPriceUsd`.
    - Throw with the projected-HF figure if `projectedHF < MIN_HEALTH_FACTOR_FOR_BORROW`.
  - Pass the closure into `executeBorrow(borrowAmount, selectedReserve, preSignValidation)`. `useBorrowTransaction` already awaits it before calling `borrow(...)`.
  - Add `aaveRayValueToUsd`, `aaveValueToUsd`, `calculateHealthFactor` to the existing `@/applications/aave/utils` import.

- `services/vault/src/components/simple/BorrowFlow/__tests__/useBorrowFormState.test.tsx` (new)
  - Staleness gate: `isDisabled` is `true` and `buttonText === "Refreshing position..."` when `isPositionDataStale === true`; falls through to `"Enter an amount"` when `false`.
  - `executeBorrow` is called with a `preSignValidation` function in arg 3.
  - Closure throws `/Projected health factor.*would be below 1\.2/` when fresh `refetchPosition()` data places projected HF below the floor.
  - Closure resolves when projected HF is comfortably above the floor.
  - Closure throws `/Token price unavailable/` when `tokenPriceUsd === null` and does not call `refetchPosition` first.
  - Closure resolves without throwing when `refetchPosition()` returns `null` (first borrow case).

## Out of scope

- Extracting a shared `useBorrowSubmit` hook so `LoanCard/Borrow` and the simple flow share these safety gates by construction. Worth doing as a follow-up — this duplication is the divergence root cause that produced this finding — but it is a refactor in a CRITICAL PATH and belongs in its own PR with its own review.
- Surfacing `validateBorrowAction`'s `errorMessage` ("Health factor too low", "Amount exceeds maximum") in the simple flow's UI. The canonical flow does; the simple flow currently swallows it. Outside the audit's ask.

Closes [baby-auditor-findings#251](https://github.com/babylonlabs-io/baby-auditor-findings/issues/251).