### PR TITLE
fix(vault): simple withdraw flow staleness

### DIFF
--- a/services/vault/src/applications/aave/hooks/useWithdrawCollateralTransaction.ts
+++ b/services/vault/src/applications/aave/hooks/useWithdrawCollateralTransaction.ts
@@ -23,12 +23,20 @@ import { invalidateVaultQueries } from "@/utils/queryKeys";
 import { usePendingVaults } from "../context";
 import { withdrawSelectedCollateral } from "../services";
 
+import { WithdrawPreSignValidationError } from "./withdrawPreSignValidationError";
+
 export interface UseWithdrawCollateralTransactionResult {
   /**
    * Execute the withdraw collateral transaction
    * @param vaultIds - IDs of vaults currently used as collateral (to mark as pending)
+   * @param preSignValidation - Optional async check run after wallet validation
+   *   and immediately before broadcast. Throws to abort with the thrown error
+   *   surfaced through the standard error modal.
    */
-  executeWithdraw: (vaultIds: string[]) => Promise<boolean>;
+  executeWithdraw: (
+    vaultIds: string[],
+    preSignValidation?: () => Promise<void>,
+  ) => Promise<boolean>;
   /** Whether transaction is currently processing */
   isProcessing: boolean;
 }
@@ -51,7 +59,7 @@ export function useWithdrawCollateralTransaction(): UseWithdrawCollateralTransac
   const { markVaultsAsPending } = usePendingVaults();
 
   const executeWithdraw = useCallback(
-    async (vaultIds: string[]) => {
+    async (vaultIds: string[], preSignValidation?: () => Promise<void>) => {
       setIsProcessing(true);
       try {
         // Validate wallet connection
@@ -67,6 +75,12 @@ export function useWithdrawCollateralTransaction(): UseWithdrawCollateralTransac
             "Wallet address not available",
             ErrorCode.WALLET_NOT_CONNECTED,
           );
+        }
+
+        // Pre-sign revalidation: refetch position and recheck health factor
+        // before submitting the on-chain transaction. Throws if unsafe.
+        if (preSignValidation) {
+          await preSignValidation();
         }
 
         // Execute selective withdraw transaction
@@ -90,8 +104,15 @@ export function useWithdrawCollateralTransaction(): UseWithdrawCollateralTransac
           error instanceof Error ? error : new Error(String(error)),
           { data: { context: "Withdraw collateral failed" } },
         );
-        const mappedError =
-          error instanceof Error
+        // Pre-sign validation errors are user-facing copy ("Position data has
+        // changed…") that describes a client-side abort, not an on-chain
+        // failure. Pass them through unwrapped so the modal doesn't prepend
+        // a misleading "Withdraw Collateral failed:" prefix.
+        const isPreSignValidation =
+          error instanceof WithdrawPreSignValidationError;
+        const mappedError = isPreSignValidation
+          ? error
+          : error instanceof Error
             ? mapViemErrorToContractError(error, "Withdraw Collateral")
             : new Error(
                 "An unexpected error occurred while withdrawing collateral",

--- a/services/vault/src/applications/aave/hooks/withdrawPreSignValidationError.ts
+++ b/services/vault/src/applications/aave/hooks/withdrawPreSignValidationError.ts
@@ -1,0 +1,13 @@
+/**
+ * Typed marker for errors thrown by a caller-supplied `preSignValidation`
+ * passed to `executeWithdraw`. Lets the transaction hook's catch surface
+ * the error message verbatim instead of routing it through
+ * `mapViemErrorToContractError`, which would prepend a misleading
+ * "Withdraw Collateral failed:" prefix implying an on-chain revert that
+ * never happened.
+ *
+ * Mirrors the `ReserveMismatchError` pattern used by `useBorrowTransaction`.
+ */
+export class WithdrawPreSignValidationError extends Error {
+  readonly code = "WITHDRAW_PRE_SIGN_VALIDATION";
+}

--- a/services/vault/src/components/simple/DashboardPage.tsx
+++ b/services/vault/src/components/simple/DashboardPage.tsx
@@ -62,6 +62,8 @@ export function DashboardPage() {
     debtValueUsd,
     healthFactor,
     healthFactorStatus,
+    isPositionDataStale,
+    refetchPosition,
     borrowedAssets,
     hasLoans,
     hasCollateral,
@@ -207,6 +209,8 @@ export function DashboardPage() {
         collateralValueUsd={collateralValueUsd}
         currentHealthFactor={healthFactor}
         preSelectedVaultIds={selectedVaultIds}
+        isPositionDataStale={isPositionDataStale}
+        refetchPosition={refetchPosition}
       />
 
       {/* Asset Selection Modal for Borrow/Repay */}

--- a/services/vault/src/components/simple/WithdrawFlow/WithdrawReviewContent.tsx
+++ b/services/vault/src/components/simple/WithdrawFlow/WithdrawReviewContent.tsx
@@ -30,6 +30,11 @@ interface WithdrawReviewContentProps {
    */
   payoutAddresses: string[];
   isProcessing: boolean;
+  /**
+   * Cached position data is stale (>90s since last fetch). Confirm is disabled
+   * and the button shows a refresh hint until the next refetch lands.
+   */
+  isPositionDataStale: boolean;
   onConfirm: () => void;
 }
 
@@ -40,6 +45,7 @@ export function WithdrawReviewContent({
   projectedHealthFactor,
   payoutAddresses,
   isProcessing,
+  isPositionDataStale,
   onConfirm,
 }: WithdrawReviewContentProps) {
   const { defaultFeeRate } = useNetworkFees();
@@ -157,7 +163,7 @@ export function WithdrawReviewContent({
           variant="contained"
           color="secondary"
           className="w-full"
-          disabled={isProcessing || wouldBreachHF}
+          disabled={isProcessing || isPositionDataStale || wouldBreachHF}
           onClick={onConfirm}
         >
           {isProcessing ? (
@@ -167,6 +173,8 @@ export function WithdrawReviewContent({
                 Processing
               </Text>
             </span>
+          ) : isPositionDataStale ? (
+            "Refreshing position..."
           ) : (
             "Confirm"
           )}

--- a/services/vault/src/components/simple/WithdrawFlow/__tests__/withdrawPreSignValidation.test.ts
+++ b/services/vault/src/components/simple/WithdrawFlow/__tests__/withdrawPreSignValidation.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+
+import { WAD_DECIMALS } from "@/applications/aave/constants";
+import { WithdrawPreSignValidationError } from "@/applications/aave/hooks/withdrawPreSignValidationError";
+import type { AavePositionWithLiveData } from "@/applications/aave/services";
+import { SATOSHIS_PER_BTC } from "@/utils/btcConversion";
+
+import {
+  WITHDRAW_BLOCK_BREACH_MESSAGE,
+  validateFreshWithdraw,
+} from "../withdrawPreSignValidation";
+
+const WAD = 10n ** BigInt(WAD_DECIMALS);
+
+// 1 BTC of collateral, expressed in satoshis (bigint).
+const ONE_BTC_SATOSHIS = SATOSHIS_PER_BTC;
+
+/**
+ * Build a minimal `AavePositionWithLiveData` shape for the validator —
+ * only the fields the function actually reads need to be populated.
+ */
+function buildPosition(opts: {
+  totalCollateralSatoshis: bigint;
+  borrowCount: bigint;
+  healthFactorWad: bigint;
+}): AavePositionWithLiveData {
+  return {
+    totalCollateral: opts.totalCollateralSatoshis,
+    accountData: {
+      borrowCount: opts.borrowCount,
+      healthFactor: opts.healthFactorWad,
+    },
+  } as unknown as AavePositionWithLiveData;
+}
+
+describe("validateFreshWithdraw", () => {
+  it("returns silently when there is no position", () => {
+    expect(() => validateFreshWithdraw(null, 0.5)).not.toThrow();
+  });
+
+  it("returns silently when the position has no debt (borrowCount = 0)", () => {
+    // No debt → projected HF is +Infinity → no threshold can be breached,
+    // even though we're trying to withdraw the whole collateral.
+    const fresh = buildPosition({
+      totalCollateralSatoshis: ONE_BTC_SATOSHIS,
+      borrowCount: 0n,
+      healthFactorWad: 0n,
+    });
+    expect(() => validateFreshWithdraw(fresh, 1)).not.toThrow();
+  });
+
+  it("throws WithdrawPreSignValidationError with the block-breach message when projected HF < 1.0", () => {
+    // 1 BTC collateral, fresh HF = 1.5. Withdrawing 0.5 BTC leaves 0.5 BTC,
+    // so projected HF = 1.5 * 0.5 = 0.75 — below the 1.0 block threshold.
+    const fresh = buildPosition({
+      totalCollateralSatoshis: ONE_BTC_SATOSHIS,
+      borrowCount: 1n,
+      healthFactorWad: 15n * (WAD / 10n),
+    });
+    expect(() => validateFreshWithdraw(fresh, 0.5)).toThrowError(
+      WithdrawPreSignValidationError,
+    );
+    expect(() => validateFreshWithdraw(fresh, 0.5)).toThrowError(
+      WITHDRAW_BLOCK_BREACH_MESSAGE,
+    );
+  });
+
+  it("returns silently in the warn zone (1.0 ≤ projected HF < 1.1) — UI advisory handles it", () => {
+    // 1 BTC collateral, fresh HF = 1.5. Withdrawing 0.3 BTC leaves 0.7 BTC,
+    // so projected HF = 1.5 * 0.7 = 1.05 — at risk but ≥ 1.0. The pre-sign
+    // validator must not throw here; the dialog re-renders with the
+    // `isAtRisk` advisory after the cache update, and Confirm stays enabled
+    // so the user can deliberately accept the risk.
+    const fresh = buildPosition({
+      totalCollateralSatoshis: ONE_BTC_SATOSHIS,
+      borrowCount: 1n,
+      healthFactorWad: 15n * (WAD / 10n),
+    });
+    expect(() => validateFreshWithdraw(fresh, 0.3)).not.toThrow();
+  });
+
+  it("returns silently when projected HF clears the warn threshold", () => {
+    // 1 BTC collateral, fresh HF = 2.0. Withdrawing 0.3 BTC leaves 0.7 BTC,
+    // so projected HF = 2.0 * 0.7 = 1.4 — well clear of the block threshold.
+    const fresh = buildPosition({
+      totalCollateralSatoshis: ONE_BTC_SATOSHIS,
+      borrowCount: 1n,
+      healthFactorWad: 2n * WAD,
+    });
+    expect(() => validateFreshWithdraw(fresh, 0.3)).not.toThrow();
+  });
+
+  it("returns silently when projected HF lands exactly at 1.0 (float-tolerant)", () => {
+    // currentHF = 2.0, withdraw 0.5 → projected = 1.0. That's at the block
+    // threshold — `isHealthFactorAtOrAbove` accepts it (within float epsilon).
+    const fresh = buildPosition({
+      totalCollateralSatoshis: ONE_BTC_SATOSHIS,
+      borrowCount: 1n,
+      healthFactorWad: 2n * WAD,
+    });
+    expect(() => validateFreshWithdraw(fresh, 0.5)).not.toThrow();
+  });
+});

--- a/services/vault/src/components/simple/WithdrawFlow/index.tsx
+++ b/services/vault/src/components/simple/WithdrawFlow/index.tsx
@@ -2,6 +2,7 @@ import { FullScreenDialog } from "@babylonlabs-io/core-ui";
 import { useCallback, useMemo, useState } from "react";
 
 import { useWithdrawCollateralTransaction } from "@/applications/aave/hooks/useWithdrawCollateralTransaction";
+import type { AavePositionWithLiveData } from "@/applications/aave/services";
 import {
   computeProjectedHealthFactor,
   getEffectiveVaultSelection,
@@ -14,6 +15,7 @@ import type { CollateralVaultEntry } from "@/types/collateral";
 import { FadeTransition } from "../FadeTransition";
 
 import { useWithdrawFlow, WithdrawStep } from "./useWithdrawFlow";
+import { validateFreshWithdraw } from "./withdrawPreSignValidation";
 import { WithdrawProgressView } from "./WithdrawProgressView";
 import { WithdrawReviewContent } from "./WithdrawReviewContent";
 
@@ -28,6 +30,18 @@ export interface WithdrawFlowProps {
   currentHealthFactor: number | null;
   /** Vault IDs selected inline on the collateral list before opening the dialog. */
   preSelectedVaultIds: string[];
+  /**
+   * True when the cached Aave position used for the projected-HF computation
+   * exceeded the staleness threshold. Drives the Confirm button's disabled
+   * state so the user cannot sign on stale safety data.
+   */
+  isPositionDataStale: boolean;
+  /**
+   * Refetch the Aave position. Resolves to the freshly fetched position (or
+   * null if the user has no position). Invoked at the pre-sign boundary to
+   * re-validate the projected HF against on-chain values before broadcast.
+   */
+  refetchPosition: () => Promise<AavePositionWithLiveData | null>;
 }
 
 function WithdrawFlowContent({
@@ -38,6 +52,8 @@ function WithdrawFlowContent({
   collateralValueUsd,
   currentHealthFactor,
   preSelectedVaultIds,
+  isPositionDataStale,
+  refetchPosition,
 }: WithdrawFlowProps) {
   const { step, goToProgress, reset } = useWithdrawFlow();
   const { executeWithdraw, isProcessing } = useWithdrawCollateralTransaction();
@@ -91,7 +107,20 @@ function WithdrawFlowContent({
   ]);
 
   const handleConfirm = useCallback(async () => {
-    const success = await executeWithdraw(effectiveSelectedVaultIds);
+    // Pre-sign re-validation: refetch the position and re-check the projected
+    // HF against fresh on-chain values immediately before broadcast. Throws
+    // abort the in-flight confirm; `executeWithdraw`'s catch surfaces the
+    // error through the standard modal. The refetch also updates React Query
+    // so the dialog re-renders with fresh `currentHealthFactor` for re-review.
+    const preSignValidation = async () => {
+      const fresh = await refetchPosition();
+      validateFreshWithdraw(fresh, selectedBtc);
+    };
+
+    const success = await executeWithdraw(
+      effectiveSelectedVaultIds,
+      preSignValidation,
+    );
     if (success) {
       setSubmittedPayoutAddresses(selectedPayoutAddresses);
       goToProgress();
@@ -99,6 +128,8 @@ function WithdrawFlowContent({
   }, [
     executeWithdraw,
     effectiveSelectedVaultIds,
+    selectedBtc,
+    refetchPosition,
     selectedPayoutAddresses,
     goToProgress,
   ]);
@@ -119,6 +150,7 @@ function WithdrawFlowContent({
               projectedHealthFactor={projectedHealthFactor}
               payoutAddresses={selectedPayoutAddresses}
               isProcessing={isProcessing}
+              isPositionDataStale={isPositionDataStale}
               onConfirm={handleConfirm}
             />
           </div>

--- a/services/vault/src/components/simple/WithdrawFlow/index.tsx
+++ b/services/vault/src/components/simple/WithdrawFlow/index.tsx
@@ -2,6 +2,7 @@ import { FullScreenDialog } from "@babylonlabs-io/core-ui";
 import { useCallback, useMemo, useState } from "react";
 
 import { useWithdrawCollateralTransaction } from "@/applications/aave/hooks/useWithdrawCollateralTransaction";
+import { WithdrawPreSignValidationError } from "@/applications/aave/hooks/withdrawPreSignValidationError";
 import type { AavePositionWithLiveData } from "@/applications/aave/services";
 import {
   computeProjectedHealthFactor,
@@ -113,7 +114,14 @@ function WithdrawFlowContent({
     // error through the standard modal. The refetch also updates React Query
     // so the dialog re-renders with fresh `currentHealthFactor` for re-review.
     const preSignValidation = async () => {
-      const fresh = await refetchPosition();
+      let fresh: AavePositionWithLiveData | null;
+      try {
+        fresh = await refetchPosition();
+      } catch (error) {
+        throw new WithdrawPreSignValidationError(
+          error instanceof Error ? error.message : String(error),
+        );
+      }
       validateFreshWithdraw(fresh, selectedBtc);
     };
 

--- a/services/vault/src/components/simple/WithdrawFlow/withdrawPreSignValidation.ts
+++ b/services/vault/src/components/simple/WithdrawFlow/withdrawPreSignValidation.ts
@@ -1,0 +1,63 @@
+/**
+ * Pre-sign validation for the simple withdraw flow.
+ *
+ * The review dialog computes its projected health factor from cached
+ * `aaveUserPosition` data that refreshes on a 30s interval. Between
+ * refreshes, oracle / debt / collateral movement can put the live HF below
+ * the on-chain block threshold (1.0) while the dialog still shows a
+ * comfortable cached HF. This module reruns the projected-HF check against
+ * a freshly fetched position immediately before broadcast and throws if
+ * the block threshold would be crossed — aborting the in-flight Confirm
+ * before a transaction the contract would revert.
+ *
+ * The [1.0, 1.1) warning band is intentionally NOT enforced here. It is a
+ * UI advisory: `WithdrawReviewContent` surfaces it via `isAtRisk` while
+ * leaving Confirm enabled. The refetch run by this validator updates the
+ * React Query cache, so when the dialog re-renders it reflects the fresh
+ * HF and the right warning copy. Throwing on the warn band would create
+ * an infinite loop — the user could never legitimately accept the risk
+ * because every subsequent click would re-run this validator against the
+ * same fresh data.
+ */
+
+import { WITHDRAW_HF_BLOCK_THRESHOLD } from "@/applications/aave/constants";
+import { WithdrawPreSignValidationError } from "@/applications/aave/hooks/withdrawPreSignValidationError";
+import type { AavePositionWithLiveData } from "@/applications/aave/services";
+import {
+  computeProjectedHealthFactor,
+  isHealthFactorAtOrAbove,
+  wadToNumber,
+} from "@/applications/aave/utils";
+import { satoshiToBtcNumber } from "@/utils/btcConversion";
+
+export const WITHDRAW_BLOCK_BREACH_MESSAGE = `Position data has changed. This withdrawal would drop your health factor below ${WITHDRAW_HF_BLOCK_THRESHOLD.toFixed(1)} and be rejected on-chain. Reduce the selection or repay debt first.`;
+
+/**
+ * Validate a freshly fetched position against a withdrawal selection.
+ * Throws `WithdrawPreSignValidationError` when the projected HF would
+ * breach the on-chain block threshold (1.0). Returns silently when:
+ *   - `fresh` is null (no position / no debt — nothing to threaten),
+ *   - `borrowCount === 0n` (no debt — projected HF is +Infinity),
+ *   - or the projected HF is at or above the block threshold.
+ */
+export function validateFreshWithdraw(
+  fresh: AavePositionWithLiveData | null,
+  selectedBtc: number,
+): void {
+  if (!fresh) return;
+
+  const freshCurrentHF =
+    fresh.accountData.borrowCount > 0n
+      ? wadToNumber(fresh.accountData.healthFactor)
+      : null;
+  const freshCollateralBtc = satoshiToBtcNumber(fresh.totalCollateral);
+  const freshProjectedHF = computeProjectedHealthFactor(
+    freshCurrentHF,
+    freshCollateralBtc,
+    selectedBtc,
+  );
+
+  if (!isHealthFactorAtOrAbove(freshProjectedHF, WITHDRAW_HF_BLOCK_THRESHOLD)) {
+    throw new WithdrawPreSignValidationError(WITHDRAW_BLOCK_BREACH_MESSAGE);
+  }
+}

--- a/services/vault/src/hooks/useDashboardState.ts
+++ b/services/vault/src/hooks/useDashboardState.ts
@@ -26,7 +26,9 @@ export function useDashboardState(connectedAddress: string | undefined) {
     debtValueUsd,
     healthFactor,
     healthFactorStatus,
+    isPositionDataStale,
     isLoading,
+    refetch: refetchPosition,
   } = useAaveUserPosition(connectedAddress);
 
   const { borrowedAssets, hasLoans } = useAaveBorrowedAssets({
@@ -66,6 +68,8 @@ export function useDashboardState(connectedAddress: string | undefined) {
     debtValueUsd,
     healthFactor,
     healthFactorStatus,
+    isPositionDataStale,
+    refetchPosition,
     borrowedAssets,
     hasLoans,
     hasCollateral,


### PR DESCRIPTION
## Summary

The simple Withdraw modal computed selected-vault eligibility and projected health factor from a cached `aaveUserPosition` snapshot that refreshes only every 30s. Between refreshes, oracle / debt / collateral movement could put the live HF into the warning (≥1.0, <1.1) or block (<1.0) range while the dialog still showed a comfortable cached HF. The Confirm button stayed enabled and the user signed a withdrawal that the UI's own safety contract was supposed to gate.

This PR mirrors the two-layer pattern already shipped for the borrow flow:

1. **UI staleness gate** — Confirm is disabled while `isPositionDataStale === true`; the button shows "Refreshing position…".
2. **Pre-sign re-validation** — `handleConfirm` refetches the position and re-runs the projected-HF check against the freshly fetched on-chain values immediately before broadcast. Throws on either threshold breach (1.0 block, 1.1 warn) and aborts the in-flight Confirm; the existing error modal surfaces actionable copy. The refetch also lands in React Query, so when the user looks at the dialog again it reflects fresh values for re-review.

## Threshold policy at pre-sign

The audit recommendation is "block or warn according to the current thresholds." At the moment of signing, the only enforceable form of "warn" is "stop and force re-review with fresh data." The pre-sign closure therefore throws on **both** thresholds — a single hard stop that surfaces an explicit error rather than silently letting the click through. After the throw, the React Query cache has already updated, so the dialog re-renders with the fresh `currentHealthFactor` and the appropriate warning copy; a second click signs only if the user accepts the now-visible warning.

Closes https://github.com/babylonlabs-io/baby-auditor-findings/issues/265