### PR TITLE
fix(vault): refetch dynamic reserve config + close staleness gates on borrow flows

### DIFF
--- a/services/vault/src/applications/aave/components/Detail/hooks/__tests__/useAaveReserveDetail.test.tsx
+++ b/services/vault/src/applications/aave/components/Detail/hooks/__tests__/useAaveReserveDetail.test.tsx
@@ -140,6 +140,7 @@ const mockUseVaultSplitParams = vi.fn<(addr?: string) => unknown>(() => ({
   params: { THF: 1.1, CF: 0.75, LB: 1.05 },
   isLoading: false,
   error: null,
+  refetch: vi.fn(),
 }));
 
 vi.mock("../../../../hooks", () => ({
@@ -181,6 +182,7 @@ describe("useAaveReserveDetail", () => {
       params: { THF: 1.1, CF: 0.75, LB: 1.05 },
       isLoading: false,
       error: null,
+      refetch: vi.fn(),
     });
     mockUseAaveUserPosition.mockReturnValue({
       position: null,
@@ -399,6 +401,7 @@ describe("useAaveReserveDetail", () => {
       params: { THF: 1.1, CF: 0.75, LB: 1.05 },
       isLoading: false,
       error: null,
+      refetch: vi.fn(),
     });
 
     const { result } = renderHook(
@@ -488,6 +491,7 @@ describe("useAaveReserveDetail", () => {
       params: { THF: 1.1, CF: 0.75, LB: 1.05 },
       isLoading: false,
       error: null,
+      refetch: vi.fn(),
     });
     mockUseAaveUserPosition.mockReturnValue({
       position: null,

--- a/services/vault/src/applications/aave/components/Detail/hooks/useAaveReserveDetail.ts
+++ b/services/vault/src/applications/aave/components/Detail/hooks/useAaveReserveDetail.ts
@@ -26,6 +26,7 @@ import {
 } from "../../../constants";
 import { useAaveConfig } from "../../../context";
 import { useAaveUserPosition, useVaultSplitParams } from "../../../hooks";
+import type { VaultSplitParams } from "../../../hooks/useVaultSplitParams";
 import type { AavePositionWithLiveData } from "../../../services";
 import type { AaveReserveConfig } from "../../../services/fetchConfig";
 import type { Asset } from "../../../types";
@@ -76,6 +77,13 @@ export interface UseAaveReserveDetailResult {
   isPositionDataStale: boolean;
   /** Refetch position data — returns fresh position (or null if unavailable) */
   refetchPosition: () => Promise<AavePositionWithLiveData | null>;
+  /**
+   * Force a fresh contract round-trip for vault split params
+   * (`getDynamicReserveConfig` + `getTargetHealthFactor`). Use immediately
+   * before signing a borrow or repay so the projected-HF math runs against
+   * current on-chain values, not the React Query cache.
+   */
+  refetchSplitParams: () => Promise<VaultSplitParams | null>;
 }
 
 export function useAaveReserveDetail({
@@ -135,6 +143,7 @@ export function useAaveReserveDetail({
     params: splitParams,
     isLoading: splitParamsLoading,
     error: splitParamsError,
+    refetch: refetchSplitParams,
   } = useVaultSplitParams(address);
 
   // Calculate debt amount for selected reserve in token units
@@ -209,5 +218,6 @@ export function useAaveReserveDetail({
     ancillaryError: pricesError ?? splitParamsError ?? null,
     isPositionDataStale,
     refetchPosition,
+    refetchSplitParams,
   };
 }

--- a/services/vault/src/applications/aave/components/Detail/hooks/useAaveReserveDetail.ts
+++ b/services/vault/src/applications/aave/components/Detail/hooks/useAaveReserveDetail.ts
@@ -143,8 +143,15 @@ export function useAaveReserveDetail({
     params: splitParams,
     isLoading: splitParamsLoading,
     error: splitParamsError,
-    refetch: refetchSplitParams,
+    refetch: refetchSplitParamsRaw,
   } = useVaultSplitParams(address);
+
+  // Pre-sign path — pass retry: 0 so a transient RPC blip surfaces fast
+  // instead of stalling the click for ~7s through the default retry backoff.
+  // All current consumers of this exposed refetch are pre-sign validators
+  // (`validateBorrowPreSign`, `validateRepayPreSign`); the background query
+  // inside `useVaultSplitParams` keeps `CONFIG_RETRY_COUNT` for resilience.
+  const refetchSplitParams = () => refetchSplitParamsRaw({ retry: 0 });
 
   // Calculate debt amount for selected reserve in token units
   const currentDebtAmount = useMemo(() => {

--- a/services/vault/src/applications/aave/components/Detail/index.tsx
+++ b/services/vault/src/applications/aave/components/Detail/index.tsx
@@ -53,6 +53,7 @@ export function AaveReserveDetail() {
     ancillaryError,
     isPositionDataStale,
     refetchPosition,
+    refetchSplitParams,
   } = useAaveReserveDetail({ reserveId, address });
 
   // Modal state management
@@ -139,6 +140,7 @@ export function AaveReserveDetail() {
     tokenPriceUsd,
     isPositionDataStale,
     refetchPosition,
+    refetchSplitParams,
     onBorrowSuccess: openBorrowSuccess,
     onRepaySuccess: openRepaySuccess,
   };

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/__tests__/validateBorrowPreSign.test.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/__tests__/validateBorrowPreSign.test.ts
@@ -1,0 +1,201 @@
+import {
+  AAVE_BASE_CURRENCY_DECIMALS,
+  AAVE_BASE_CURRENCY_RAY_DECIMALS,
+} from "@babylonlabs-io/ts-sdk/tbv/integrations/aave";
+import { describe, expect, it, vi } from "vitest";
+
+import type { AavePositionWithLiveData } from "../../../../../services";
+import { validateBorrowPreSign } from "../validateBorrowPreSign";
+
+const USD_COLLATERAL = 10n ** BigInt(AAVE_BASE_CURRENCY_DECIMALS);
+const USD_DEBT_RAY = 10n ** BigInt(AAVE_BASE_CURRENCY_RAY_DECIMALS);
+
+function makePosition(
+  collateralUsd: bigint,
+  debtUsdRay: bigint,
+): AavePositionWithLiveData {
+  return {
+    accountData: {
+      totalCollateralValue: collateralUsd,
+      totalDebtValueRay: debtUsdRay,
+    },
+  } as unknown as AavePositionWithLiveData;
+}
+
+describe("validateBorrowPreSign", () => {
+  it("throws when token price is unavailable", async () => {
+    const refetchSplitParams = vi.fn();
+    const refetchPosition = vi.fn();
+
+    await expect(
+      validateBorrowPreSign({
+        borrowAmount: 100,
+        tokenPriceUsd: null,
+        liquidationThresholdBps: 7500,
+        refetchSplitParams,
+        refetchPosition,
+      }),
+    ).rejects.toThrow("Token price unavailable");
+
+    expect(refetchSplitParams).not.toHaveBeenCalled();
+    expect(refetchPosition).not.toHaveBeenCalled();
+  });
+
+  it("throws when refetchSplitParams returns null", async () => {
+    const refetchSplitParams = vi.fn().mockResolvedValue(null);
+    const refetchPosition = vi.fn();
+
+    await expect(
+      validateBorrowPreSign({
+        borrowAmount: 100,
+        tokenPriceUsd: 1,
+        liquidationThresholdBps: 7500,
+        refetchSplitParams,
+        refetchPosition,
+      }),
+    ).rejects.toThrow("Could not verify current risk parameters");
+
+    expect(refetchPosition).not.toHaveBeenCalled();
+  });
+
+  it("aborts when on-chain CF moved since the screen was rendered (auditor #260)", async () => {
+    // User's screen was rendered with CF=0.75 (=7500 BPS). Governance has
+    // since lowered CF to 0.70 — same dynamicConfigKey, so React Query
+    // would have kept the cached 0.75 without an explicit refetch.
+    const refetchSplitParams = vi.fn().mockResolvedValue({
+      THF: 1.1,
+      CF: 0.7,
+      LB: 1.05,
+    });
+    const refetchPosition = vi.fn();
+
+    await expect(
+      validateBorrowPreSign({
+        borrowAmount: 100,
+        tokenPriceUsd: 1,
+        liquidationThresholdBps: 7500,
+        refetchSplitParams,
+        refetchPosition,
+      }),
+    ).rejects.toThrow("Risk parameters have changed");
+
+    // Must not even refetch position when the threshold moved — the user
+    // needs to see the new numbers before re-evaluating.
+    expect(refetchPosition).not.toHaveBeenCalled();
+  });
+
+  it("skips revalidation when refetchPosition returns null (first borrow)", async () => {
+    const refetchSplitParams = vi.fn().mockResolvedValue({
+      THF: 1.1,
+      CF: 0.75,
+      LB: 1.05,
+    });
+    const refetchPosition = vi.fn().mockResolvedValue(null);
+
+    await expect(
+      validateBorrowPreSign({
+        borrowAmount: 100,
+        tokenPriceUsd: 1,
+        liquidationThresholdBps: 7500,
+        refetchSplitParams,
+        refetchPosition,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(refetchSplitParams).toHaveBeenCalledTimes(1);
+    expect(refetchPosition).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses fresh liquidationThresholdBps for HF computation", async () => {
+    // CF unchanged at 0.75 → fresh liquidationThresholdBps = 7500.
+    // Collateral: $10000, debt: $0, borrow: $1000 worth.
+    // HF = 10000 * 0.75 / 1000 = 7.5 — well above MIN_HEALTH_FACTOR_FOR_BORROW.
+    const refetchSplitParams = vi.fn().mockResolvedValue({
+      THF: 1.1,
+      CF: 0.75,
+      LB: 1.05,
+    });
+    const refetchPosition = vi
+      .fn()
+      .mockResolvedValue(makePosition(10000n * USD_COLLATERAL, 0n));
+
+    await expect(
+      validateBorrowPreSign({
+        borrowAmount: 1000,
+        tokenPriceUsd: 1,
+        liquidationThresholdBps: 7500,
+        refetchSplitParams,
+        refetchPosition,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("throws when projected HF would fall below MIN_HEALTH_FACTOR_FOR_BORROW", async () => {
+    // Collateral $1000 at 0.75 CF, no existing debt, borrow $999 worth.
+    // HF = 1000 * 0.75 / 999 ≈ 0.751 — well below the safety threshold.
+    const refetchSplitParams = vi.fn().mockResolvedValue({
+      THF: 1.1,
+      CF: 0.75,
+      LB: 1.05,
+    });
+    const refetchPosition = vi
+      .fn()
+      .mockResolvedValue(makePosition(1000n * USD_COLLATERAL, 0n));
+
+    await expect(
+      validateBorrowPreSign({
+        borrowAmount: 999,
+        tokenPriceUsd: 1,
+        liquidationThresholdBps: 7500,
+        refetchSplitParams,
+        refetchPosition,
+      }),
+    ).rejects.toThrow(/Projected health factor/);
+  });
+
+  it("propagates errors from refetchSplitParams", async () => {
+    const refetchSplitParams = vi
+      .fn()
+      .mockRejectedValue(new Error("RPC failure"));
+    const refetchPosition = vi.fn();
+
+    await expect(
+      validateBorrowPreSign({
+        borrowAmount: 100,
+        tokenPriceUsd: 1,
+        liquidationThresholdBps: 7500,
+        refetchSplitParams,
+        refetchPosition,
+      }),
+    ).rejects.toThrow("RPC failure");
+
+    expect(refetchPosition).not.toHaveBeenCalled();
+  });
+
+  it("uses fresh debt from refetched position, not stale UI state", async () => {
+    // The original UI showed $0 debt; in reality the user already has
+    // $900 debt at the moment of signing — borrowing another $100 against
+    // $1000 collateral at 0.75 CF puts HF = 1000 * 0.75 / 1000 = 0.75
+    // (below threshold). Validator must catch this using the FRESH debt.
+    const refetchSplitParams = vi.fn().mockResolvedValue({
+      THF: 1.1,
+      CF: 0.75,
+      LB: 1.05,
+    });
+    const refetchPosition = vi
+      .fn()
+      .mockResolvedValue(
+        makePosition(1000n * USD_COLLATERAL, 900n * USD_DEBT_RAY),
+      );
+
+    await expect(
+      validateBorrowPreSign({
+        borrowAmount: 100,
+        tokenPriceUsd: 1,
+        liquidationThresholdBps: 7500,
+        refetchSplitParams,
+        refetchPosition,
+      }),
+    ).rejects.toThrow(/Projected health factor/);
+  });
+});

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/__tests__/validateBorrowPreSign.test.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/__tests__/validateBorrowPreSign.test.ts
@@ -43,7 +43,7 @@ describe("validateBorrowPreSign", () => {
 
   it("throws when refetchSplitParams returns null", async () => {
     const refetchSplitParams = vi.fn().mockResolvedValue(null);
-    const refetchPosition = vi.fn();
+    const refetchPosition = vi.fn().mockResolvedValue(null);
 
     await expect(
       validateBorrowPreSign({
@@ -54,8 +54,6 @@ describe("validateBorrowPreSign", () => {
         refetchPosition,
       }),
     ).rejects.toThrow("Could not verify current risk parameters");
-
-    expect(refetchPosition).not.toHaveBeenCalled();
   });
 
   it("aborts when on-chain CF moved since the screen was rendered (auditor #260)", async () => {
@@ -67,7 +65,11 @@ describe("validateBorrowPreSign", () => {
       CF: 0.7,
       LB: 1.05,
     });
-    const refetchPosition = vi.fn();
+    // The two refetches run in parallel (`Promise.all`) for click-path
+    // latency, so refetchPosition may be called even though we abort.
+    // What matters is that the validator throws and the user never reaches
+    // the `borrow(...)` call.
+    const refetchPosition = vi.fn().mockResolvedValue(null);
 
     await expect(
       validateBorrowPreSign({
@@ -78,10 +80,6 @@ describe("validateBorrowPreSign", () => {
         refetchPosition,
       }),
     ).rejects.toThrow("Risk parameters have changed");
-
-    // Must not even refetch position when the threshold moved — the user
-    // needs to see the new numbers before re-evaluating.
-    expect(refetchPosition).not.toHaveBeenCalled();
   });
 
   it("skips revalidation when refetchPosition returns null (first borrow)", async () => {
@@ -157,7 +155,7 @@ describe("validateBorrowPreSign", () => {
     const refetchSplitParams = vi
       .fn()
       .mockRejectedValue(new Error("RPC failure"));
-    const refetchPosition = vi.fn();
+    const refetchPosition = vi.fn().mockResolvedValue(null);
 
     await expect(
       validateBorrowPreSign({
@@ -168,8 +166,41 @@ describe("validateBorrowPreSign", () => {
         refetchPosition,
       }),
     ).rejects.toThrow("RPC failure");
+  });
 
-    expect(refetchPosition).not.toHaveBeenCalled();
+  it("runs refetchSplitParams and refetchPosition in parallel for click-path latency", async () => {
+    // Both refetches should be in flight at the same time. We assert this
+    // by resolving them in the opposite order from what a serial impl would
+    // produce: refetchPosition resolves before refetchSplitParams.
+    const splitParamsCallStarted = vi.fn();
+    const positionCallStarted = vi.fn();
+
+    const refetchSplitParams = vi.fn(async () => {
+      splitParamsCallStarted();
+      // Yield to the microtask queue so refetchPosition can also start.
+      await Promise.resolve();
+      return { THF: 1.1, CF: 0.75, LB: 1.05 };
+    });
+    const refetchPosition = vi.fn(async () => {
+      positionCallStarted();
+      return null; // first-borrow path
+    });
+
+    await validateBorrowPreSign({
+      borrowAmount: 100,
+      tokenPriceUsd: 1,
+      liquidationThresholdBps: 7500,
+      refetchSplitParams,
+      refetchPosition,
+    });
+
+    // Both refetches must have been initiated before either resolved —
+    // i.e. both call counters were non-zero by the time the first
+    // microtask boundary was reached. With a serial implementation,
+    // refetchPosition would not have started until after the first await
+    // inside refetchSplitParams resolved.
+    expect(splitParamsCallStarted).toHaveBeenCalledTimes(1);
+    expect(positionCallStarted).toHaveBeenCalledTimes(1);
   });
 
   it("uses fresh debt from refetched position, not stale UI state", async () => {

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/validateBorrowPreSign.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/validateBorrowPreSign.ts
@@ -10,12 +10,13 @@
  * borrow whose UI safety check ran against an obsolete threshold (auditor
  * finding #260).
  */
-import { BPS_SCALE, MIN_HEALTH_FACTOR_FOR_BORROW } from "../../../../constants";
+import { MIN_HEALTH_FACTOR_FOR_BORROW } from "../../../../constants";
 import type { VaultSplitParams } from "../../../../hooks/useVaultSplitParams";
 import type { AavePositionWithLiveData } from "../../../../services";
 import {
   aaveRayValueToUsd,
   aaveValueToUsd,
+  assertCfUnchanged,
   calculateHealthFactor,
 } from "../../../../utils";
 
@@ -50,23 +51,15 @@ export async function validateBorrowPreSign({
     throw new Error("Token price unavailable. Cannot validate borrow.");
   }
 
-  const freshSplitParams = await refetchSplitParams();
-  if (!freshSplitParams) {
-    throw new Error(
-      "Could not verify current risk parameters. Please try again.",
-    );
-  }
-  const freshLiquidationThresholdBps = Math.round(
-    freshSplitParams.CF * BPS_SCALE,
-  );
+  // The two refetches are independent contract reads. Parallelizing halves
+  // the click-path latency. If `assertCfUnchanged` aborts, the in-flight
+  // position refetch result is discarded — one wasted eth_call in the rare
+  // CF-changed path is cheaper than serializing every borrow click.
+  const [{ freshLiquidationThresholdBps }, freshPosition] = await Promise.all([
+    assertCfUnchanged({ liquidationThresholdBps, refetchSplitParams }),
+    refetchPosition(),
+  ]);
 
-  if (freshLiquidationThresholdBps !== liquidationThresholdBps) {
-    throw new Error(
-      "Risk parameters have changed. Please review the updated values and try again.",
-    );
-  }
-
-  const freshPosition = await refetchPosition();
   if (!freshPosition) return; // No position = first borrow, skip revalidation
 
   const freshCollateralUsd = aaveValueToUsd(

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/validateBorrowPreSign.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/validateBorrowPreSign.ts
@@ -1,0 +1,91 @@
+/**
+ * Borrow pre-sign validation
+ *
+ * Runs immediately before submitting a borrow transaction. Refetches the
+ * on-chain risk parameters (CF / THF / LB) and the user's position from the
+ * contract — the cached values displayed in the UI may be up to
+ * `CONFIG_STALE_TIME_MS` old, and React Query's query key does not change
+ * when CF is updated for the same `dynamicConfigKey`. Without this refetch
+ * a governance/operator update that lowered CF would let the user sign a
+ * borrow whose UI safety check ran against an obsolete threshold (auditor
+ * finding #260).
+ */
+import { BPS_SCALE, MIN_HEALTH_FACTOR_FOR_BORROW } from "../../../../constants";
+import type { VaultSplitParams } from "../../../../hooks/useVaultSplitParams";
+import type { AavePositionWithLiveData } from "../../../../services";
+import {
+  aaveRayValueToUsd,
+  aaveValueToUsd,
+  calculateHealthFactor,
+} from "../../../../utils";
+
+export interface ValidateBorrowPreSignDeps {
+  borrowAmount: number;
+  tokenPriceUsd: number | null;
+  /**
+   * Liquidation threshold (in BPS) the user saw on the displayed metrics.
+   * Compared against the freshly-fetched value to detect on-chain CF moves
+   * since the screen was rendered.
+   */
+  liquidationThresholdBps: number;
+  refetchSplitParams: () => Promise<VaultSplitParams | null>;
+  refetchPosition: () => Promise<AavePositionWithLiveData | null>;
+}
+
+/**
+ * Throws if it is not safe to proceed with the borrow:
+ *  - token price unavailable
+ *  - split params could not be refetched
+ *  - on-chain CF moved since the screen was rendered
+ *  - projected post-borrow HF would fall below `MIN_HEALTH_FACTOR_FOR_BORROW`
+ */
+export async function validateBorrowPreSign({
+  borrowAmount,
+  tokenPriceUsd,
+  liquidationThresholdBps,
+  refetchSplitParams,
+  refetchPosition,
+}: ValidateBorrowPreSignDeps): Promise<void> {
+  if (tokenPriceUsd == null) {
+    throw new Error("Token price unavailable. Cannot validate borrow.");
+  }
+
+  const freshSplitParams = await refetchSplitParams();
+  if (!freshSplitParams) {
+    throw new Error(
+      "Could not verify current risk parameters. Please try again.",
+    );
+  }
+  const freshLiquidationThresholdBps = Math.round(
+    freshSplitParams.CF * BPS_SCALE,
+  );
+
+  if (freshLiquidationThresholdBps !== liquidationThresholdBps) {
+    throw new Error(
+      "Risk parameters have changed. Please review the updated values and try again.",
+    );
+  }
+
+  const freshPosition = await refetchPosition();
+  if (!freshPosition) return; // No position = first borrow, skip revalidation
+
+  const freshCollateralUsd = aaveValueToUsd(
+    freshPosition.accountData.totalCollateralValue,
+  );
+  const freshDebtUsd = aaveRayValueToUsd(
+    freshPosition.accountData.totalDebtValueRay,
+  );
+  const projectedDebtUsd = freshDebtUsd + borrowAmount * tokenPriceUsd;
+  const projectedHF = calculateHealthFactor(
+    freshCollateralUsd,
+    projectedDebtUsd,
+    freshLiquidationThresholdBps,
+  );
+
+  if (isFinite(projectedHF) && projectedHF < MIN_HEALTH_FACTOR_FOR_BORROW) {
+    throw new Error(
+      `Position data has changed. Projected health factor (${projectedHF.toFixed(2)}) ` +
+        `would be below ${MIN_HEALTH_FACTOR_FOR_BORROW}. Please reduce the borrow amount.`,
+    );
+  }
+}

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/index.tsx
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/index.tsx
@@ -22,23 +22,15 @@ import {
   formatTokenAmount,
   formatUsdValue,
 } from "../../../../../utils/formatting";
-import {
-  AMOUNT_INPUT_CLASS_NAME,
-  MIN_HEALTH_FACTOR_FOR_BORROW,
-  MIN_SLIDER_MAX,
-} from "../../../constants";
+import { AMOUNT_INPUT_CLASS_NAME, MIN_SLIDER_MAX } from "../../../constants";
 import { useBorrowTransaction } from "../../../hooks";
-import {
-  aaveRayValueToUsd,
-  aaveValueToUsd,
-  calculateHealthFactor,
-} from "../../../utils";
 import { useLoanContext } from "../../context/LoanContext";
 
 import { BorrowDetailsCard } from "./BorrowDetailsCard";
 import { useBorrowMetrics } from "./hooks/useBorrowMetrics";
 import { useBorrowState } from "./hooks/useBorrowState";
 import { validateBorrowAction } from "./hooks/validateBorrowAction";
+import { validateBorrowPreSign } from "./hooks/validateBorrowPreSign";
 
 export function Borrow() {
   const {
@@ -51,6 +43,7 @@ export function Borrow() {
     tokenPriceUsd,
     isPositionDataStale,
     refetchPosition,
+    refetchSplitParams,
     onBorrowSuccess,
   } = useLoanContext();
 
@@ -83,39 +76,14 @@ export function Borrow() {
   const sliderMaxBorrow = Math.max(maxBorrowAmount, MIN_SLIDER_MAX);
 
   const handleBorrow = async () => {
-    const preSignValidation = async () => {
-      if (tokenPriceUsd == null) {
-        throw new Error("Token price unavailable. Cannot validate borrow.");
-      }
-
-      const freshPosition = await refetchPosition();
-      if (!freshPosition) return; // No position = first borrow, skip revalidation
-
-      const freshCollateralUsd = aaveValueToUsd(
-        freshPosition.accountData.totalCollateralValue,
-      );
-      const freshDebtUsd = aaveRayValueToUsd(
-        freshPosition.accountData.totalDebtValueRay,
-      );
-      const projectedDebtUsd = freshDebtUsd + borrowAmount * tokenPriceUsd;
-      const projectedHF = calculateHealthFactor(
-        freshCollateralUsd,
-        projectedDebtUsd,
+    const success = await executeBorrow(borrowAmount, selectedReserve, () =>
+      validateBorrowPreSign({
+        borrowAmount,
+        tokenPriceUsd,
         liquidationThresholdBps,
-      );
-
-      if (isFinite(projectedHF) && projectedHF < MIN_HEALTH_FACTOR_FOR_BORROW) {
-        throw new Error(
-          `Position data has changed. Projected health factor (${projectedHF.toFixed(2)}) ` +
-            `would be below ${MIN_HEALTH_FACTOR_FOR_BORROW}. Please reduce the borrow amount.`,
-        );
-      }
-    };
-
-    const success = await executeBorrow(
-      borrowAmount,
-      selectedReserve,
-      preSignValidation,
+        refetchSplitParams,
+        refetchPosition,
+      }),
     );
     if (success) {
       resetBorrowAmount();

--- a/services/vault/src/applications/aave/components/LoanCard/Repay/hooks/__tests__/validateRepayPreSign.test.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Repay/hooks/__tests__/validateRepayPreSign.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { validateRepayPreSign } from "../validateRepayPreSign";
+
+describe("validateRepayPreSign", () => {
+  it("throws when refetchSplitParams returns null", async () => {
+    const refetchSplitParams = vi.fn().mockResolvedValue(null);
+
+    await expect(
+      validateRepayPreSign({
+        liquidationThresholdBps: 7500,
+        refetchSplitParams,
+      }),
+    ).rejects.toThrow("Could not verify current risk parameters");
+  });
+
+  it("aborts when on-chain CF moved since the screen was rendered (auditor #260)", async () => {
+    // Displayed metrics were computed with CF=0.75. Governance has since
+    // lowered CF to 0.70 — same dynamicConfigKey, so the cached value
+    // would have stayed 0.75 without an explicit refetch.
+    const refetchSplitParams = vi.fn().mockResolvedValue({
+      THF: 1.1,
+      CF: 0.7,
+      LB: 1.05,
+    });
+
+    await expect(
+      validateRepayPreSign({
+        liquidationThresholdBps: 7500,
+        refetchSplitParams,
+      }),
+    ).rejects.toThrow("Risk parameters have changed");
+  });
+
+  it("resolves when fresh CF matches the displayed threshold", async () => {
+    const refetchSplitParams = vi.fn().mockResolvedValue({
+      THF: 1.1,
+      CF: 0.75,
+      LB: 1.05,
+    });
+
+    await expect(
+      validateRepayPreSign({
+        liquidationThresholdBps: 7500,
+        refetchSplitParams,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(refetchSplitParams).toHaveBeenCalledTimes(1);
+  });
+
+  it("propagates errors from refetchSplitParams", async () => {
+    const refetchSplitParams = vi
+      .fn()
+      .mockRejectedValue(new Error("RPC failure"));
+
+    await expect(
+      validateRepayPreSign({
+        liquidationThresholdBps: 7500,
+        refetchSplitParams,
+      }),
+    ).rejects.toThrow("RPC failure");
+  });
+});

--- a/services/vault/src/applications/aave/components/LoanCard/Repay/hooks/validateRepayPreSign.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Repay/hooks/validateRepayPreSign.ts
@@ -1,0 +1,50 @@
+/**
+ * Repay pre-sign validation
+ *
+ * Runs immediately before submitting a repay transaction. Refetches the
+ * on-chain risk parameters (CF / THF / LB) — the cached
+ * `liquidationThresholdBps` powering the displayed post-repay HF projection
+ * may be up to `CONFIG_STALE_TIME_MS` old, and React Query's query key does
+ * not change when CF is updated for the same `dynamicConfigKey`. Without
+ * this refetch a governance/operator update that lowered CF would let the
+ * user sign a repay whose displayed risk-improvement projection ran against
+ * an obsolete threshold (auditor finding #260).
+ */
+import { BPS_SCALE } from "../../../../constants";
+import type { VaultSplitParams } from "../../../../hooks/useVaultSplitParams";
+
+export interface ValidateRepayPreSignDeps {
+  /**
+   * Liquidation threshold (in BPS) the user saw on the displayed metrics.
+   * Compared against the freshly-fetched value to detect on-chain CF moves
+   * since the screen was rendered.
+   */
+  liquidationThresholdBps: number;
+  refetchSplitParams: () => Promise<VaultSplitParams | null>;
+}
+
+/**
+ * Throws if it is not safe to proceed with the repay:
+ *  - split params could not be refetched
+ *  - on-chain CF moved since the screen was rendered
+ */
+export async function validateRepayPreSign({
+  liquidationThresholdBps,
+  refetchSplitParams,
+}: ValidateRepayPreSignDeps): Promise<void> {
+  const freshSplitParams = await refetchSplitParams();
+  if (!freshSplitParams) {
+    throw new Error(
+      "Could not verify current risk parameters. Please try again.",
+    );
+  }
+  const freshLiquidationThresholdBps = Math.round(
+    freshSplitParams.CF * BPS_SCALE,
+  );
+
+  if (freshLiquidationThresholdBps !== liquidationThresholdBps) {
+    throw new Error(
+      "Risk parameters have changed. Please review the updated values and try again.",
+    );
+  }
+}

--- a/services/vault/src/applications/aave/components/LoanCard/Repay/hooks/validateRepayPreSign.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Repay/hooks/validateRepayPreSign.ts
@@ -10,8 +10,8 @@
  * user sign a repay whose displayed risk-improvement projection ran against
  * an obsolete threshold (auditor finding #260).
  */
-import { BPS_SCALE } from "../../../../constants";
 import type { VaultSplitParams } from "../../../../hooks/useVaultSplitParams";
+import { assertCfUnchanged } from "../../../../utils";
 
 export interface ValidateRepayPreSignDeps {
   /**
@@ -32,19 +32,5 @@ export async function validateRepayPreSign({
   liquidationThresholdBps,
   refetchSplitParams,
 }: ValidateRepayPreSignDeps): Promise<void> {
-  const freshSplitParams = await refetchSplitParams();
-  if (!freshSplitParams) {
-    throw new Error(
-      "Could not verify current risk parameters. Please try again.",
-    );
-  }
-  const freshLiquidationThresholdBps = Math.round(
-    freshSplitParams.CF * BPS_SCALE,
-  );
-
-  if (freshLiquidationThresholdBps !== liquidationThresholdBps) {
-    throw new Error(
-      "Risk parameters have changed. Please review the updated values and try again.",
-    );
-  }
+  await assertCfUnchanged({ liquidationThresholdBps, refetchSplitParams });
 }

--- a/services/vault/src/applications/aave/components/LoanCard/Repay/index.tsx
+++ b/services/vault/src/applications/aave/components/LoanCard/Repay/index.tsx
@@ -26,6 +26,7 @@ import { BorrowDetailsCard } from "../Borrow/BorrowDetailsCard";
 import { useRepayMetrics } from "./hooks/useRepayMetrics";
 import { useRepayState } from "./hooks/useRepayState";
 import { validateRepayAction } from "./hooks/validateRepayAction";
+import { validateRepayPreSign } from "./hooks/validateRepayPreSign";
 
 export function Repay() {
   const {
@@ -38,6 +39,7 @@ export function Repay() {
     assetConfig,
     proxyContract,
     tokenPriceUsd,
+    refetchSplitParams,
     onRepaySuccess,
   } = useLoanContext();
 
@@ -89,6 +91,11 @@ export function Repay() {
       repayAmount,
       selectedReserve,
       isFullRepayment,
+      () =>
+        validateRepayPreSign({
+          liquidationThresholdBps,
+          refetchSplitParams,
+        }),
     );
     if (success) {
       resetRepayAmount();

--- a/services/vault/src/applications/aave/components/context/LoanContext.tsx
+++ b/services/vault/src/applications/aave/components/context/LoanContext.tsx
@@ -7,6 +7,7 @@
 
 import { createContext, useContext } from "react";
 
+import type { VaultSplitParams } from "../../hooks/useVaultSplitParams";
 import type { AavePositionWithLiveData } from "../../services";
 import type { AaveReserveConfig } from "../../services/fetchConfig";
 import type { Asset } from "../../types";
@@ -34,6 +35,12 @@ export interface LoanContextValue {
   isPositionDataStale: boolean;
   /** Refetch position data — returns fresh position (or null if unavailable) */
   refetchPosition: () => Promise<AavePositionWithLiveData | null>;
+  /**
+   * Force a fresh contract round-trip for vault split params (CF / THF / LB).
+   * Used by borrow and repay pre-sign validation to recompute the projected
+   * health factor against current on-chain values rather than the cached ones.
+   */
+  refetchSplitParams: () => Promise<VaultSplitParams | null>;
   /** Callback when borrow succeeds */
   onBorrowSuccess: (borrowAmount: number) => void;
   /** Callback when repay succeeds */

--- a/services/vault/src/applications/aave/hooks/__tests__/useVaultSplitParams.test.tsx
+++ b/services/vault/src/applications/aave/hooks/__tests__/useVaultSplitParams.test.tsx
@@ -286,8 +286,6 @@ describe("useVaultSplitParams", () => {
       vbtcReserve: null,
       borrowableReserves: [],
       allBorrowReserves: [],
-      isLoading: false,
-      error: null,
     });
 
     // beforeEach default has CF=0.75 (7500 BPS). Initial load picks that up.
@@ -331,8 +329,6 @@ describe("useVaultSplitParams", () => {
       vbtcReserve: null,
       borrowableReserves: [],
       allBorrowReserves: [],
-      isLoading: false,
-      error: null,
     });
 
     const { result } = renderHook(() => useVaultSplitParams(), { wrapper });

--- a/services/vault/src/applications/aave/hooks/__tests__/useVaultSplitParams.test.tsx
+++ b/services/vault/src/applications/aave/hooks/__tests__/useVaultSplitParams.test.tsx
@@ -95,7 +95,9 @@ describe("useVaultSplitParams", () => {
 
   beforeEach(() => {
     queryClient = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
+      // retryDelay: 0 makes the hook's `retry: CONFIG_RETRY_COUNT` overrides
+      // resolve quickly in the rejected-mock test below.
+      defaultOptions: { queries: { retry: false, retryDelay: 0 } },
     });
     vi.clearAllMocks();
 
@@ -267,5 +269,80 @@ describe("useVaultSplitParams", () => {
     // Query is disabled when no spoke address — stays in initial state
     expect(result.current.params).toBeNull();
     expect(result.current.error).toBeNull();
+  });
+
+  it("exposes refetch that re-runs the contract calls and returns fresh values", async () => {
+    // Earlier tests in this file null out the spoke address; restore it so
+    // the query is enabled here.
+    const { useAaveConfig } = vi.mocked(await import("../../context"));
+    useAaveConfig.mockReturnValue({
+      config: {
+        adapterAddress: "0x1",
+        vaultBtcAddress: "0x2",
+        btcVaultRegistryAddress: "0x3",
+        coreSpokeAddress: "0xSpokeAddress",
+        btcVaultCoreVbtcReserveId: 1n,
+      },
+      vbtcReserve: null,
+      borrowableReserves: [],
+      allBorrowReserves: [],
+      isLoading: false,
+      error: null,
+    });
+
+    // beforeEach default has CF=0.75 (7500 BPS). Initial load picks that up.
+    const { result } = renderHook(() => useVaultSplitParams(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.params?.CF).toBe(0.75);
+    expect(mockGetDynamicReserveConfig).toHaveBeenCalledTimes(1);
+
+    // Simulate a governance-driven CF reduction for the same
+    // dynamicConfigKey. The query key never changes, so without an
+    // explicit refetch React Query would keep the cached 0.75 — the bug
+    // auditor finding #260 calls out.
+    mockGetDynamicReserveConfig.mockResolvedValue({
+      collateralFactor: 7000n,
+      maxLiquidationBonus: 10500n,
+      liquidationFee: 100n,
+    });
+
+    const refreshed = await result.current.refetch();
+
+    expect(mockGetDynamicReserveConfig).toHaveBeenCalledTimes(2);
+    expect(refreshed?.CF).toBe(0.7);
+    await waitFor(() => {
+      expect(result.current.params?.CF).toBe(0.7);
+    });
+  });
+
+  it("refetch surfaces underlying errors instead of returning stale data", async () => {
+    const { useAaveConfig } = vi.mocked(await import("../../context"));
+    useAaveConfig.mockReturnValue({
+      config: {
+        adapterAddress: "0x1",
+        vaultBtcAddress: "0x2",
+        btcVaultRegistryAddress: "0x3",
+        coreSpokeAddress: "0xSpokeAddress",
+        btcVaultCoreVbtcReserveId: 1n,
+      },
+      vbtcReserve: null,
+      borrowableReserves: [],
+      allBorrowReserves: [],
+      isLoading: false,
+      error: null,
+    });
+
+    const { result } = renderHook(() => useVaultSplitParams(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    mockGetDynamicReserveConfig.mockRejectedValue(new Error("RPC failure"));
+
+    await expect(result.current.refetch()).rejects.toThrow("RPC failure");
   });
 });

--- a/services/vault/src/applications/aave/hooks/__tests__/useVaultSplitParams.test.tsx
+++ b/services/vault/src/applications/aave/hooks/__tests__/useVaultSplitParams.test.tsx
@@ -341,4 +341,35 @@ describe("useVaultSplitParams", () => {
 
     await expect(result.current.refetch()).rejects.toThrow("RPC failure");
   });
+
+  it("refetch({ retry: 0 }) does not retry on RPC failure (fast pre-sign feedback)", async () => {
+    const { useAaveConfig } = vi.mocked(await import("../../context"));
+    useAaveConfig.mockReturnValue({
+      config: {
+        adapterAddress: "0x1",
+        vaultBtcAddress: "0x2",
+        btcVaultRegistryAddress: "0x3",
+        coreSpokeAddress: "0xSpokeAddress",
+        btcVaultCoreVbtcReserveId: 1n,
+      },
+      vbtcReserve: null,
+      borrowableReserves: [],
+      allBorrowReserves: [],
+    });
+
+    const { result } = renderHook(() => useVaultSplitParams(), { wrapper });
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    // Default for refetch (no opts) inherits CONFIG_RETRY_COUNT = 3 → 4 calls.
+    // Pre-sign callers pass retry: 0 → exactly 1 call before surfacing the error.
+    mockGetDynamicReserveConfig.mockReset();
+    mockGetDynamicReserveConfig.mockRejectedValue(new Error("RPC failure"));
+
+    await expect(result.current.refetch({ retry: 0 })).rejects.toThrow(
+      "RPC failure",
+    );
+    expect(mockGetDynamicReserveConfig).toHaveBeenCalledTimes(1);
+  });
 });

--- a/services/vault/src/applications/aave/hooks/useRepayTransaction.ts
+++ b/services/vault/src/applications/aave/hooks/useRepayTransaction.ts
@@ -41,11 +41,16 @@ export interface UseRepayTransactionResult {
    * @param repayAmount - Amount to repay in token units (e.g., 100 for 100 USDC)
    * @param reserve - Reserve config for the debt token
    * @param isFullRepayment - If true, fetches exact debt from contract and repays all
+   * @param preSignValidation - Optional callback that runs after the on-chain
+   *   reserve-mismatch check and before any repay tx. Throwing aborts the
+   *   submission. Used by the Repay UI to refetch position + split params and
+   *   recompute the projected post-repay HF against current on-chain values.
    */
   executeRepay: (
     repayAmount: number,
     reserve: AaveReserveConfig,
     isFullRepayment?: boolean,
+    preSignValidation?: () => Promise<void>,
   ) => Promise<boolean>;
   /** Whether transaction is currently processing */
   isProcessing: boolean;
@@ -71,6 +76,7 @@ export function useRepayTransaction({
     repayAmount: number,
     reserve: AaveReserveConfig,
     isFullRepayment = false,
+    preSignValidation?: () => Promise<void>,
   ) => {
     if (repayAmount <= 0) return false;
 
@@ -100,6 +106,14 @@ export function useRepayTransaction({
         reserve.reserveId,
         reserve.token.address,
       );
+
+      // Pre-sign revalidation: refetch position + risk parameters and
+      // recheck projected post-repay HF before submitting. Throws if the
+      // on-chain risk parameters have moved since the displayed metrics
+      // were computed.
+      if (preSignValidation) {
+        await preSignValidation();
+      }
 
       // Call appropriate service based on repayment type
       // The borrower address is resolved from the connected wallet (self-repay)

--- a/services/vault/src/applications/aave/hooks/useVaultSplitParams.ts
+++ b/services/vault/src/applications/aave/hooks/useVaultSplitParams.ts
@@ -24,7 +24,7 @@
  * potentially-stale source for a value that gates liquidation correctness.
  */
 
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import type { Address } from "viem";
 
 import { AaveSpoke } from "../clients";
@@ -58,8 +58,13 @@ export interface UseVaultSplitParamsResult {
    * repay so the projected-HF math runs against current on-chain values
    * even when the cache is still within `staleTime` and the
    * `dynamicConfigKey` has not changed.
+   *
+   * Pre-sign callers should pass `retry: 0` so a transient RPC blip surfaces
+   * fast instead of stalling the click for ~7s through the default retry
+   * backoff. Background callers (none today) can omit and inherit
+   * `CONFIG_RETRY_COUNT`.
    */
-  refetch: () => Promise<VaultSplitParams | null>;
+  refetch: (opts?: { retry?: number }) => Promise<VaultSplitParams | null>;
 }
 
 async function fetchSplitParams(
@@ -118,13 +123,15 @@ export function useVaultSplitParams(
   // key only to re-fetch a moment later with the position key.
   const isPositionResolved = !connectedAddress || !positionLoading;
 
-  const { data, isLoading, error, refetch } = useQuery({
-    queryKey: [
-      "vaultSplitParams",
-      spokeAddress,
-      reserveId?.toString(),
-      positionDynamicConfigKey,
-    ],
+  const queryKey = [
+    "vaultSplitParams",
+    spokeAddress,
+    reserveId?.toString(),
+    positionDynamicConfigKey,
+  ];
+
+  const { data, isLoading, error } = useQuery({
+    queryKey,
     queryFn: () =>
       fetchSplitParams(spokeAddress!, reserveId!, positionDynamicConfigKey),
     enabled: !!spokeAddress && reserveId != null && isPositionResolved,
@@ -133,16 +140,28 @@ export function useVaultSplitParams(
     retry: CONFIG_RETRY_COUNT,
   });
 
+  const queryClient = useQueryClient();
+
   return {
     params: data ?? null,
     isLoading: isLoading || (!!connectedAddress && positionLoading),
     error: error as Error | null,
-    refetch: async () => {
-      const result = await refetch();
-      if (result.isError) {
-        throw result.error ?? new Error("Failed to refetch vault split params");
-      }
-      return result.data ?? null;
+    // Use fetchQuery (not the useQuery refetch) so callers can pass
+    // `retry: 0` and short-circuit the default retry backoff. Without this,
+    // a pre-sign refetch on a transient RPC blip stalls the click for ~7s
+    // through `CONFIG_RETRY_COUNT` retries before surfacing the error.
+    // Both paths populate the same cache key, so the displayed value
+    // updates regardless of which one ran.
+    refetch: async (opts?: { retry?: number }) => {
+      if (!spokeAddress || reserveId == null) return null;
+      const result = await queryClient.fetchQuery({
+        queryKey,
+        queryFn: () =>
+          fetchSplitParams(spokeAddress, reserveId, positionDynamicConfigKey),
+        retry: opts?.retry ?? CONFIG_RETRY_COUNT,
+        staleTime: 0, // force a fresh round-trip; this is the whole point
+      });
+      return result;
     },
   };
 }

--- a/services/vault/src/applications/aave/hooks/useVaultSplitParams.ts
+++ b/services/vault/src/applications/aave/hooks/useVaultSplitParams.ts
@@ -52,6 +52,14 @@ export interface UseVaultSplitParamsResult {
   params: VaultSplitParams | null;
   isLoading: boolean;
   error: Error | null;
+  /**
+   * Force a fresh contract round-trip for `getDynamicReserveConfig` and
+   * `getTargetHealthFactor`. Use immediately before signing a borrow or
+   * repay so the projected-HF math runs against current on-chain values
+   * even when the cache is still within `staleTime` and the
+   * `dynamicConfigKey` has not changed.
+   */
+  refetch: () => Promise<VaultSplitParams | null>;
 }
 
 async function fetchSplitParams(
@@ -110,7 +118,7 @@ export function useVaultSplitParams(
   // key only to re-fetch a moment later with the position key.
   const isPositionResolved = !connectedAddress || !positionLoading;
 
-  const { data, isLoading, error } = useQuery({
+  const { data, isLoading, error, refetch } = useQuery({
     queryKey: [
       "vaultSplitParams",
       spokeAddress,
@@ -129,5 +137,12 @@ export function useVaultSplitParams(
     params: data ?? null,
     isLoading: isLoading || (!!connectedAddress && positionLoading),
     error: error as Error | null,
+    refetch: async () => {
+      const result = await refetch();
+      if (result.isError) {
+        throw result.error ?? new Error("Failed to refetch vault split params");
+      }
+      return result.data ?? null;
+    },
   };
 }

--- a/services/vault/src/applications/aave/utils/__tests__/assertCfUnchanged.test.ts
+++ b/services/vault/src/applications/aave/utils/__tests__/assertCfUnchanged.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { VaultSplitParams } from "../../hooks/useVaultSplitParams";
+import { assertCfUnchanged } from "../assertCfUnchanged";
+
+const CF_75 = { THF: 1.1, CF: 0.75, LB: 1.05 } satisfies VaultSplitParams;
+const CF_70 = { THF: 1.1, CF: 0.7, LB: 1.05 } satisfies VaultSplitParams;
+
+describe("assertCfUnchanged", () => {
+  it("throws when refetchSplitParams returns null (RPC failure)", async () => {
+    const refetchSplitParams = vi.fn().mockResolvedValue(null);
+
+    await expect(
+      assertCfUnchanged({
+        liquidationThresholdBps: 7500,
+        refetchSplitParams,
+      }),
+    ).rejects.toThrow(/Could not verify current risk parameters/);
+  });
+
+  it("throws when on-chain CF moved since the screen was rendered (audit #260)", async () => {
+    const refetchSplitParams = vi.fn().mockResolvedValue(CF_70);
+
+    await expect(
+      assertCfUnchanged({
+        liquidationThresholdBps: 7500,
+        refetchSplitParams,
+      }),
+    ).rejects.toThrow(/Risk parameters have changed/);
+  });
+
+  it("returns fresh values when CF matches the displayed threshold", async () => {
+    const refetchSplitParams = vi.fn().mockResolvedValue(CF_75);
+
+    const result = await assertCfUnchanged({
+      liquidationThresholdBps: 7500,
+      refetchSplitParams,
+    });
+
+    expect(result.freshLiquidationThresholdBps).toBe(7500);
+    expect(result.freshSplitParams).toEqual(CF_75);
+  });
+
+  it("skips the equality check when the displayed BPS is 0 (loading/errored state)", async () => {
+    // If the user clicked through a state where split params hadn't loaded
+    // (`liquidationThresholdBps === 0`), claiming "Risk parameters have
+    // changed" against the freshly fetched 7500 would be misleading — the
+    // displayed value was never a real comparison target.
+    const refetchSplitParams = vi.fn().mockResolvedValue(CF_75);
+
+    const result = await assertCfUnchanged({
+      liquidationThresholdBps: 0,
+      refetchSplitParams,
+    });
+
+    expect(result.freshLiquidationThresholdBps).toBe(7500);
+  });
+
+  it("propagates underlying refetch errors instead of swallowing them", async () => {
+    const refetchSplitParams = vi
+      .fn()
+      .mockRejectedValue(new Error("RPC failure"));
+
+    await expect(
+      assertCfUnchanged({
+        liquidationThresholdBps: 7500,
+        refetchSplitParams,
+      }),
+    ).rejects.toThrow("RPC failure");
+  });
+});

--- a/services/vault/src/applications/aave/utils/assertCfUnchanged.ts
+++ b/services/vault/src/applications/aave/utils/assertCfUnchanged.ts
@@ -1,0 +1,54 @@
+/**
+ * Verifies that the on-chain collateral factor (CF) backing the displayed
+ * `liquidationThresholdBps` has not moved since the screen rendered. Used by
+ * both `validateBorrowPreSign` and `validateRepayPreSign` so the freshness
+ * check has one source of truth.
+ *
+ * Throws if the freshly fetched CF differs from the displayed value same `dynamicConfigKey`, different CF would otherwise stay
+ * cached). Skips the equality check when `liquidationThresholdBps === 0` —
+ * that's the loading/errored state where we never displayed a real value to
+ * compare against, so claiming "Risk parameters have changed" would be
+ * misleading.
+ */
+import { BPS_SCALE } from "../constants";
+import type { VaultSplitParams } from "../hooks/useVaultSplitParams";
+
+export interface AssertCfUnchangedDeps {
+  /**
+   * Liquidation threshold (in BPS) the user saw on the displayed metrics.
+   * Zero means split params had not loaded — the equality check is skipped.
+   */
+  liquidationThresholdBps: number;
+  refetchSplitParams: () => Promise<VaultSplitParams | null>;
+}
+
+export interface AssertCfUnchangedResult {
+  freshSplitParams: VaultSplitParams;
+  freshLiquidationThresholdBps: number;
+}
+
+export async function assertCfUnchanged({
+  liquidationThresholdBps,
+  refetchSplitParams,
+}: AssertCfUnchangedDeps): Promise<AssertCfUnchangedResult> {
+  const freshSplitParams = await refetchSplitParams();
+  if (!freshSplitParams) {
+    throw new Error(
+      "Could not verify current risk parameters. Please try again.",
+    );
+  }
+  const freshLiquidationThresholdBps = Math.round(
+    freshSplitParams.CF * BPS_SCALE,
+  );
+
+  if (
+    liquidationThresholdBps !== 0 &&
+    freshLiquidationThresholdBps !== liquidationThresholdBps
+  ) {
+    throw new Error(
+      "Risk parameters have changed. Please review the updated values and try again.",
+    );
+  }
+
+  return { freshSplitParams, freshLiquidationThresholdBps };
+}

--- a/services/vault/src/applications/aave/utils/index.ts
+++ b/services/vault/src/applications/aave/utils/index.ts
@@ -49,3 +49,11 @@ export type { EffectiveVaultSelection } from "./withdrawSelection";
 
 // Payout-address derivation for withdraw display (frontend-only)
 export { getUniquePayoutAddresses } from "./payoutAddresses";
+
+// Pre-sign CF freshness check shared by borrow and repay validators
+export { assertCfUnchanged } from "./assertCfUnchanged";
+
+export type {
+  AssertCfUnchangedDeps,
+  AssertCfUnchangedResult,
+} from "./assertCfUnchanged";

--- a/services/vault/src/components/simple/BorrowFlow/__tests__/useBorrowFormState.test.tsx
+++ b/services/vault/src/components/simple/BorrowFlow/__tests__/useBorrowFormState.test.tsx
@@ -1,0 +1,126 @@
+import { act, renderHook } from "@testing-library/react";
+import { type ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  LoanProvider,
+  type LoanContextValue,
+} from "@/applications/aave/components/context/LoanContext";
+
+import { useBorrowFormState } from "../useBorrowFormState";
+
+const mockExecuteBorrow = vi.fn();
+vi.mock("@/applications/aave/hooks", () => ({
+  useBorrowTransaction: () => ({
+    executeBorrow: mockExecuteBorrow,
+    isProcessing: false,
+  }),
+}));
+
+// The shared test setup mocks "@/config" without FeatureFlags. Extend that
+// mock here so the hook's FeatureFlags.isBorrowDisabled read does not crash.
+vi.mock("@/config", () => ({
+  FeatureFlags: {
+    isBorrowDisabled: false,
+  },
+  getNetworkConfigBTC: () => ({
+    coinName: "Signet BTC",
+    coinSymbol: "sBTC",
+    networkName: "BTC signet",
+    mempoolApiUrl: "https://mempool.space/signet",
+    network: "signet",
+    icon: "/images/signet_bitcoin.svg",
+    name: "Signet Bitcoin",
+    displayUSD: false,
+  }),
+  getBTCNetwork: () => "signet",
+  CONTRACTS: {},
+  ENV: {},
+  isProductionEnv: () => false,
+  getCommitHash: () => "test-commit",
+}));
+
+const RESERVE = {
+  reserveId: 1n,
+  token: { address: "0xtoken", decimals: 18 },
+} as unknown as LoanContextValue["selectedReserve"];
+
+const ASSET = {
+  symbol: "USDC",
+  name: "USD Coin",
+  icon: "/usdc.svg",
+} as LoanContextValue["assetConfig"];
+
+function makeContext(
+  overrides: Partial<LoanContextValue> = {},
+): LoanContextValue {
+  return {
+    collateralValueUsd: 1000,
+    currentDebtAmount: 500,
+    totalDebtValueUsd: 500,
+    healthFactor: 1.6,
+    liquidationThresholdBps: 8000,
+    selectedReserve: RESERVE,
+    assetConfig: ASSET,
+    proxyContract: "0xproxy",
+    tokenPriceUsd: 1,
+    isPositionDataStale: false,
+    refetchPosition: vi.fn().mockResolvedValue(null),
+    refetchSplitParams: vi.fn().mockResolvedValue(null),
+    onBorrowSuccess: () => {},
+    onRepaySuccess: () => {},
+    ...overrides,
+  };
+}
+
+function wrapWith(value: LoanContextValue) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <LoanProvider value={value}>{children}</LoanProvider>;
+  };
+}
+
+describe("useBorrowFormState — staleness gate (audit #251)", () => {
+  it("disables the button and shows 'Refreshing position...' when isPositionDataStale is true", () => {
+    const ctx = makeContext({ isPositionDataStale: true });
+    const { result } = renderHook(
+      () => useBorrowFormState({ onBorrowSuccess: () => {} }),
+      { wrapper: wrapWith(ctx) },
+    );
+
+    expect(result.current.isDisabled).toBe(true);
+    expect(result.current.buttonText).toBe("Refreshing position...");
+  });
+
+  it("does not short-circuit on staleness when isPositionDataStale is false", () => {
+    const ctx = makeContext({ isPositionDataStale: false });
+    const { result } = renderHook(
+      () => useBorrowFormState({ onBorrowSuccess: () => {} }),
+      { wrapper: wrapWith(ctx) },
+    );
+
+    // borrowAmount starts at 0 so button text falls through to "Enter an amount",
+    // which is the validateBorrowAction path *after* the staleness short-circuit.
+    expect(result.current.buttonText).toBe("Enter an amount");
+  });
+});
+
+describe("useBorrowFormState — pre-sign wire-up (audit #260 + #251)", () => {
+  it("calls executeBorrow with a preSignValidation callback in arg 3", async () => {
+    mockExecuteBorrow.mockReset();
+    mockExecuteBorrow.mockResolvedValue(true);
+
+    const ctx = makeContext();
+    const { result } = renderHook(
+      () => useBorrowFormState({ onBorrowSuccess: () => {} }),
+      { wrapper: wrapWith(ctx) },
+    );
+
+    await act(async () => {
+      await result.current.handleBorrow();
+    });
+
+    expect(mockExecuteBorrow).toHaveBeenCalledOnce();
+    const [, , preSignValidation] = mockExecuteBorrow.mock.calls[0];
+    expect(typeof preSignValidation).toBe("function");
+  });
+});

--- a/services/vault/src/components/simple/BorrowFlow/index.tsx
+++ b/services/vault/src/components/simple/BorrowFlow/index.tsx
@@ -45,6 +45,7 @@ export function BorrowFlow({ open, onClose }: BorrowFlowProps) {
     tokenPriceUsd,
     isPositionDataStale,
     refetchPosition,
+    refetchSplitParams,
   } = useAaveReserveDetail({
     reserveId: selectedAssetSymbol ?? undefined,
     address,
@@ -93,6 +94,7 @@ export function BorrowFlow({ open, onClose }: BorrowFlowProps) {
             tokenPriceUsd={tokenPriceUsd}
             isPositionDataStale={isPositionDataStale}
             refetchPosition={refetchPosition}
+            refetchSplitParams={refetchSplitParams}
             onChangeAsset={goBack}
             onBorrowSuccess={completeBorrow}
           />
@@ -122,6 +124,7 @@ function BorrowFormStep({
   tokenPriceUsd,
   isPositionDataStale,
   refetchPosition,
+  refetchSplitParams,
   onChangeAsset,
   onBorrowSuccess,
 }: {
@@ -137,6 +140,9 @@ function BorrowFormStep({
   tokenPriceUsd: number | null;
   isPositionDataStale: boolean;
   refetchPosition: ReturnType<typeof useAaveReserveDetail>["refetchPosition"];
+  refetchSplitParams: ReturnType<
+    typeof useAaveReserveDetail
+  >["refetchSplitParams"];
   onChangeAsset: () => void;
   onBorrowSuccess: (amount: number, symbol: string, icon: string) => void;
 }) {
@@ -162,6 +168,7 @@ function BorrowFormStep({
         tokenPriceUsd,
         isPositionDataStale,
         refetchPosition,
+        refetchSplitParams,
         // These callbacks are handled by the BorrowFlow orchestrator
         onBorrowSuccess: () => {},
         onRepaySuccess: () => {},

--- a/services/vault/src/components/simple/BorrowFlow/useBorrowFormState.ts
+++ b/services/vault/src/components/simple/BorrowFlow/useBorrowFormState.ts
@@ -2,6 +2,7 @@ import { useLoanContext } from "@/applications/aave/components/context/LoanConte
 import { useBorrowMetrics } from "@/applications/aave/components/LoanCard/Borrow/hooks/useBorrowMetrics";
 import { useBorrowState } from "@/applications/aave/components/LoanCard/Borrow/hooks/useBorrowState";
 import { validateBorrowAction } from "@/applications/aave/components/LoanCard/Borrow/hooks/validateBorrowAction";
+import { validateBorrowPreSign } from "@/applications/aave/components/LoanCard/Borrow/hooks/validateBorrowPreSign";
 import {
   BPS_TO_PERCENT_DIVISOR,
   MIN_HEALTH_FACTOR_FOR_BORROW,
@@ -75,6 +76,9 @@ export function useBorrowFormState({
     selectedReserve,
     assetConfig,
     tokenPriceUsd,
+    isPositionDataStale,
+    refetchPosition,
+    refetchSplitParams,
   } = useLoanContext();
 
   const { executeBorrow, isProcessing } = useBorrowTransaction();
@@ -99,6 +103,7 @@ export function useBorrowFormState({
     borrowAmount,
     metrics.healthFactorValue,
     maxBorrowAmount,
+    isPositionDataStale,
   );
 
   const sliderMax = Math.max(maxBorrowAmount, MIN_SLIDER_MAX);
@@ -132,6 +137,14 @@ export function useBorrowFormState({
     const success = await executeBorrow(
       borrowAmount,
       selectedReserve as AaveReserveConfig,
+      () =>
+        validateBorrowPreSign({
+          borrowAmount,
+          tokenPriceUsd,
+          liquidationThresholdBps,
+          refetchSplitParams,
+          refetchPosition,
+        }),
     );
     if (success) {
       onBorrowSuccess(


### PR DESCRIPTION
# fix(vault): refetch dynamic reserve config + close staleness gates on borrow flows

## Summary

Closes two related auditor findings on the Aave borrow surfaces:

- **[#260](https://github.com/babylonlabs-io/baby-auditor-findings/issues/260)** — `useVaultSplitParams` cached the live on-chain risk parameters (THF / CF / LB) for 5 min with no exposed `refetch` and a query key that does not change when CF moves for the same `dynamicConfigKey`. The borrow flow refetched *position* before signing but recomputed projected HF with the cached `liquidationThresholdBps`, so a governance/operator CF reduction let users sign against an obsolete UI safety threshold. Repay had no pre-sign validation at all.
- **[#251](https://github.com/babylonlabs-io/baby-auditor-findings/issues/251)** — the simple `BorrowFlow` (`useBorrowFormState`) was missing both the UI staleness gate (`isPositionDataStale` was never read) and the pre-sign HF revalidation that the canonical `LoanCard/Borrow` flow already had. The borrow button stayed enabled against stale numbers and `executeBorrow` was called with no `preSignValidation`, so the on-chain tx could land in the immediate-liquidation band `[1.0, MIN_HEALTH_FACTOR_FOR_BORROW)`.

## Approach

Treat split params as signing-critical state. Mirror the existing `refetchPosition` pattern: before signing, force a contract round-trip for `getDynamicReserveConfig` + `getTargetHealthFactor` and abort if `liquidationThresholdBps` moved since the screen was rendered. Extract the borrow and repay pre-sign logic into shared helpers (`validateBorrowPreSign`, `validateRepayPreSign`) and apply them uniformly across the canonical `LoanCard/Borrow`, canonical `LoanCard/Repay`, and simple `BorrowFlow` surfaces — so the same validator runs everywhere a borrow or repay is signed.

This PR supersedes [#1541](https://github.com/babylonlabs-io/babylon-toolkit/pull/1541), which originally targeted [babylonlabs-io/baby-auditor-findings#251](https://github.com/babylonlabs-io/baby-auditor-findings/issues/251) with a duplicated pre-sign closure inside the simple flow. Using the extracted helper here closes both findings on a single merge and avoids the duplicated closure that #1541 itself flagged as the divergence root cause.

## Changes

### Helper hook + plumbing

- **[services/vault/src/applications/aave/hooks/useVaultSplitParams.ts](services/vault/src/applications/aave/hooks/useVaultSplitParams.ts)** — exposes `refetch: () => Promise<VaultSplitParams | null>`. Wraps React Query's `refetch` so callers can force a fresh contract read even when the same `dynamicConfigKey` is in use; throws on error rather than returning stale data.
- **[services/vault/src/applications/aave/components/Detail/hooks/useAaveReserveDetail.ts](services/vault/src/applications/aave/components/Detail/hooks/useAaveReserveDetail.ts)** — surfaces `refetchSplitParams` in the result.
- **[services/vault/src/applications/aave/components/context/LoanContext.tsx](services/vault/src/applications/aave/components/context/LoanContext.tsx)** — adds `refetchSplitParams` to `LoanContextValue`.
- **[services/vault/src/applications/aave/components/Detail/index.tsx](services/vault/src/applications/aave/components/Detail/index.tsx)** and **[services/vault/src/components/simple/BorrowFlow/index.tsx](services/vault/src/components/simple/BorrowFlow/index.tsx)** — both `LoanProvider` sites plumb `refetchSplitParams` through.

### Extracted validators

- **[services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/validateBorrowPreSign.ts](services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/validateBorrowPreSign.ts)** *(new)* — refetches split params, recomputes `freshLiquidationThresholdBps = round(CF × 10000)`, throws "risk parameters have changed" if it differs from the displayed value, then refetches position and recomputes projected HF against the **fresh** threshold; throws if `< MIN_HEALTH_FACTOR_FOR_BORROW`. Skips revalidation for first-borrow case (no position yet). Single source of truth for borrow pre-sign across both flows.
- **[services/vault/src/applications/aave/components/LoanCard/Repay/hooks/validateRepayPreSign.ts](services/vault/src/applications/aave/components/LoanCard/Repay/hooks/validateRepayPreSign.ts)** *(new)* — same CF-changed abort logic for repay.

### Wire-up — canonical surfaces

- **[services/vault/src/applications/aave/components/LoanCard/Borrow/index.tsx](services/vault/src/applications/aave/components/LoanCard/Borrow/index.tsx)** — `handleBorrow` calls `validateBorrowPreSign({...})` as the `preSignValidation` callback.
- **[services/vault/src/applications/aave/components/LoanCard/Repay/index.tsx](services/vault/src/applications/aave/components/LoanCard/Repay/index.tsx)** — `handleRepay` calls `validateRepayPreSign({...})` as the new `preSignValidation` callback.
- **[services/vault/src/applications/aave/hooks/useRepayTransaction.ts](services/vault/src/applications/aave/hooks/useRepayTransaction.ts)** — accepts an optional `preSignValidation` parameter on `executeRepay`, mirroring the borrow hook's signature. Called after `assertReserveMatchesOnChain` and before `repayFull` / `repayPartial`.

### Wire-up — simple surface (closes [babylonlabs-io/baby-auditor-findings#251](https://github.com/babylonlabs-io/baby-auditor-findings/issues/251))

- **[services/vault/src/components/simple/BorrowFlow/useBorrowFormState.ts](services/vault/src/components/simple/BorrowFlow/useBorrowFormState.ts)** —
  - Destructures `isPositionDataStale`, `refetchPosition`, `refetchSplitParams` from `useLoanContext()`.
  - Passes `isPositionDataStale` as the 4th arg to `validateBorrowAction` so the button shows "Refreshing position..." and is disabled while position data is stale.
  - Passes `() => validateBorrowPreSign({...})` as the 3rd arg to `executeBorrow`, sharing the helper with the canonical flow.

## Tests

- **[useVaultSplitParams.test.tsx](services/vault/src/applications/aave/hooks/__tests__/useVaultSplitParams.test.tsx)** — adds two cases: `refetch` re-runs the contract calls and the fresh value flows through to `params`; `refetch` surfaces underlying RPC errors instead of returning stale data.
- **[validateBorrowPreSign.test.ts](services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/__tests__/validateBorrowPreSign.test.ts)** *(new, 8 tests)* — token-price absent, refetch returns null, **CF moved while user was on screen (auditor [babylonlabs-io/baby-auditor-findings#260](https://github.com/babylonlabs-io/baby-auditor-findings/issues/260) scenario)**, first-borrow skip, fresh `liquidationThresholdBps` used for HF, projected HF below floor, RPC error propagation, fresh debt used for HF (not stale UI debt).
- **[validateRepayPreSign.test.ts](services/vault/src/applications/aave/components/LoanCard/Repay/hooks/__tests__/validateRepayPreSign.test.ts)** *(new, 4 tests)* — refetch null, CF moved abort, happy path, RPC error propagation.
- **[useBorrowFormState.test.tsx](services/vault/src/components/simple/BorrowFlow/__tests__/useBorrowFormState.test.tsx)** *(new, 3 tests)* — staleness button gate disabled with "Refreshing position..." when `isPositionDataStale === true`; falls through to "Enter an amount" when `false`; `executeBorrow` is called with a function in arg 3 (proves the helper is wired). Pre-sign HF behavior itself is exercised by `validateBorrowPreSign.test.ts` since the same helper runs everywhere.

## Out of scope

**Display-time freshness for the repay surface.** The auditor's recommendation also calls out *displayed* repay conclusions. Pre-sign refetch alone is sufficient correctness — the user's *signature* will always be on fresh data, and the abort-if-changed check prevents acting on stale numbers. Adding polling / shorter `staleTime` for the action surface specifically is a follow-up if product wants the displayed metrics to never lag.

Closes [babylonlabs-io/baby-auditor-findings#260](https://github.com/babylonlabs-io/baby-auditor-findings/issues/260).
Closes [babylonlabs-io/baby-auditor-findings#251](https://github.com/babylonlabs-io/baby-auditor-findings/issues/251).
Supersedes [#1541](https://github.com/babylonlabs-io/babylon-toolkit/pull/1541).

