### PR TITLE
fix(vault): fail-closed aave debt discovery

### DIFF
--- a/services/vault/src/applications/aave/services/__tests__/getUserPositionsWithLiveData.test.ts
+++ b/services/vault/src/applications/aave/services/__tests__/getUserPositionsWithLiveData.test.ts
@@ -26,7 +26,10 @@ vi.mock("../fetchPositions", () => ({
   fetchAavePositionCollaterals: vi.fn(),
 }));
 
-import { getUserPositionsWithLiveData } from "../positionService";
+import {
+  IncompleteDebtDiscoveryError,
+  getUserPositionsWithLiveData,
+} from "../positionService";
 
 const DEPOSITOR = ("0x" + "1".repeat(40)) as `0x${string}`;
 const SPOKE = ("0x" + "2".repeat(40)) as `0x${string}`;
@@ -88,7 +91,7 @@ describe("getUserPositionsWithLiveData — fail-closed debt reserve discovery (a
         borrowableReserveIds: [],
         vbtcReserveId: VBTC_RESERVE_ID,
       }),
-    ).rejects.toThrow(/no reserve IDs were provided/);
+    ).rejects.toBeInstanceOf(IncompleteDebtDiscoveryError);
   });
 
   it("throws when fewer debt reserves are found than on-chain borrowCount", async () => {
@@ -107,7 +110,7 @@ describe("getUserPositionsWithLiveData — fail-closed debt reserve discovery (a
         borrowableReserveIds: [USDC_RESERVE_ID, DAI_RESERVE_ID],
         vbtcReserveId: VBTC_RESERVE_ID,
       }),
-    ).rejects.toThrow(/found 1.*incomplete/i);
+    ).rejects.toBeInstanceOf(IncompleteDebtDiscoveryError);
   });
 
   it("does not throw when borrowCount is 0 even with an empty reserve list", async () => {

--- a/services/vault/src/applications/aave/services/__tests__/positionService.test.ts
+++ b/services/vault/src/applications/aave/services/__tests__/positionService.test.ts
@@ -1,0 +1,266 @@
+import type { Address } from "viem";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../clients", () => ({
+  AaveSpoke: {
+    getUserPosition: vi.fn(),
+    getUserAccountData: vi.fn(),
+    getUserTotalDebt: vi.fn(),
+  },
+}));
+
+vi.mock("../fetchPositions", () => ({
+  fetchAaveActivePositionsWithCollaterals: vi.fn(),
+  fetchAavePositionByDepositor: vi.fn(),
+  fetchAavePositionCollaterals: vi.fn(),
+}));
+
+import { AaveSpoke } from "../../clients";
+import { fetchAaveActivePositionsWithCollaterals } from "../fetchPositions";
+import {
+  DebtPositionFetchError,
+  getUserPositionsWithLiveData,
+  IncompleteDebtDiscoveryError,
+  isDebtDiscoveryError,
+} from "../positionService";
+
+const mockGetUserPosition = vi.mocked(AaveSpoke.getUserPosition);
+const mockGetUserAccountData = vi.mocked(AaveSpoke.getUserAccountData);
+const mockGetUserTotalDebt = vi.mocked(AaveSpoke.getUserTotalDebt);
+const mockFetchActivePositions = vi.mocked(
+  fetchAaveActivePositionsWithCollaterals,
+);
+
+const DEPOSITOR = "0xUser";
+const SPOKE = "0x000000000000000000000000000000000000fa11" as Address;
+const PROXY = "0x000000000000000000000000000000000000beef" as Address;
+const VBTC_RESERVE_ID = 0n;
+const RESERVE_A = 1n;
+const RESERVE_B = 2n;
+
+const indexerPosition = {
+  proxyContract: PROXY,
+  depositor: DEPOSITOR,
+  totalCollateral: 100_000_000n,
+  collaterals: [],
+} as any;
+
+function spokePosition(
+  overrides: Partial<{ drawnShares: bigint; premiumShares: bigint }> = {},
+) {
+  return {
+    drawnShares: 0n,
+    premiumShares: 0n,
+    premiumOffsetRay: 0n,
+    suppliedShares: 0n,
+    dynamicConfigKey: 0,
+    ...overrides,
+  };
+}
+
+function accountData(borrowCount: bigint) {
+  return {
+    riskPremium: 0n,
+    avgCollateralFactor: 0n,
+    healthFactor: 0n,
+    totalCollateralValue: 0n,
+    totalDebtValueRay: 0n,
+    activeCollateralCount: 1n,
+    borrowCount,
+  };
+}
+
+describe("getUserPositionsWithLiveData", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetchActivePositions.mockResolvedValue([indexerPosition]);
+    mockGetUserTotalDebt.mockResolvedValue(0n);
+  });
+
+  it("rejects with DebtPositionFetchError when a per-reserve RPC fails, instead of silently dropping the reserve", async () => {
+    mockGetUserPosition.mockImplementation(
+      async (_spoke: Address, reserveId: bigint) => {
+        if (reserveId === VBTC_RESERVE_ID) return spokePosition();
+        if (reserveId === RESERVE_A)
+          return spokePosition({ drawnShares: 100n });
+        throw new Error("rpc connection lost");
+      },
+    );
+    mockGetUserAccountData.mockResolvedValue(accountData(2n));
+
+    const promise = getUserPositionsWithLiveData(DEPOSITOR, SPOKE, {
+      borrowableReserveIds: [RESERVE_A, RESERVE_B],
+      vbtcReserveId: VBTC_RESERVE_ID,
+    });
+
+    await expect(promise).rejects.toBeInstanceOf(DebtPositionFetchError);
+    await expect(promise).rejects.toMatchObject({ reserveId: RESERVE_B });
+  });
+
+  it("rejects with DebtPositionFetchError when getUserTotalDebt fails for a debt reserve", async () => {
+    mockGetUserPosition.mockImplementation(
+      async (_spoke: Address, reserveId: bigint) => {
+        if (reserveId === VBTC_RESERVE_ID) return spokePosition();
+        return spokePosition({ drawnShares: 100n });
+      },
+    );
+    mockGetUserAccountData.mockResolvedValue(accountData(2n));
+    mockGetUserTotalDebt.mockImplementation(
+      async (_spoke: Address, reserveId: bigint) => {
+        if (reserveId === RESERVE_B) throw new Error("rpc connection lost");
+        return 500n;
+      },
+    );
+
+    const promise = getUserPositionsWithLiveData(DEPOSITOR, SPOKE, {
+      borrowableReserveIds: [RESERVE_A, RESERVE_B],
+      vbtcReserveId: VBTC_RESERVE_ID,
+    });
+
+    await expect(promise).rejects.toBeInstanceOf(DebtPositionFetchError);
+    await expect(promise).rejects.toMatchObject({ reserveId: RESERVE_B });
+  });
+
+  it("rejects with IncompleteDebtDiscoveryError when borrowCount exceeds discovered debt reserves", async () => {
+    mockGetUserPosition.mockImplementation(
+      async (_spoke: Address, reserveId: bigint) => {
+        if (reserveId === VBTC_RESERVE_ID) return spokePosition();
+        if (reserveId === RESERVE_A)
+          return spokePosition({ drawnShares: 100n });
+        return spokePosition();
+      },
+    );
+    mockGetUserAccountData.mockResolvedValue(accountData(2n));
+
+    const promise = getUserPositionsWithLiveData(DEPOSITOR, SPOKE, {
+      borrowableReserveIds: [RESERVE_A, RESERVE_B],
+      vbtcReserveId: VBTC_RESERVE_ID,
+    });
+
+    await expect(promise).rejects.toBeInstanceOf(IncompleteDebtDiscoveryError);
+    await expect(promise).rejects.toMatchObject({
+      discovered: 1,
+      expected: 2n,
+      queriedReserveIds: [RESERVE_A, RESERVE_B],
+    });
+  });
+
+  it("resolves when discovered debt reserves match borrowCount", async () => {
+    mockGetUserPosition.mockImplementation(
+      async (_spoke: Address, reserveId: bigint) => {
+        if (reserveId === VBTC_RESERVE_ID) return spokePosition();
+        return spokePosition({ drawnShares: 100n });
+      },
+    );
+    mockGetUserAccountData.mockResolvedValue(accountData(2n));
+    mockGetUserTotalDebt.mockResolvedValue(500n);
+
+    const result = await getUserPositionsWithLiveData(DEPOSITOR, SPOKE, {
+      borrowableReserveIds: [RESERVE_A, RESERVE_B],
+      vbtcReserveId: VBTC_RESERVE_ID,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].debtPositions?.size).toBe(2);
+    expect(result[0].debtPositions?.get(RESERVE_A)?.totalDebt).toBe(500n);
+    expect(result[0].debtPositions?.get(RESERVE_B)?.totalDebt).toBe(500n);
+  });
+
+  it("skips per-reserve debt discovery when borrowCount is zero", async () => {
+    mockGetUserPosition.mockResolvedValue(spokePosition());
+    mockGetUserAccountData.mockResolvedValue(accountData(0n));
+
+    const result = await getUserPositionsWithLiveData(DEPOSITOR, SPOKE, {
+      borrowableReserveIds: [RESERVE_A, RESERVE_B],
+      vbtcReserveId: VBTC_RESERVE_ID,
+    });
+
+    expect(mockGetUserPosition).toHaveBeenCalledTimes(1);
+    expect(mockGetUserPosition).toHaveBeenCalledWith(
+      SPOKE,
+      VBTC_RESERVE_ID,
+      PROXY,
+    );
+    expect(result[0].debtPositions).toBeUndefined();
+  });
+
+  it("rejects with IncompleteDebtDiscoveryError when borrowCount > 0 but reserve list is empty", async () => {
+    mockGetUserPosition.mockResolvedValue(spokePosition());
+    mockGetUserAccountData.mockResolvedValue(accountData(1n));
+
+    const promise = getUserPositionsWithLiveData(DEPOSITOR, SPOKE, {
+      borrowableReserveIds: [],
+      vbtcReserveId: VBTC_RESERVE_ID,
+    });
+
+    await expect(promise).rejects.toBeInstanceOf(IncompleteDebtDiscoveryError);
+    await expect(promise).rejects.toMatchObject({
+      discovered: 0,
+      expected: 1n,
+      queriedReserveIds: [],
+    });
+  });
+
+  it("rejects when borrowableReserveIds is undefined and borrowCount > 0", async () => {
+    mockGetUserPosition.mockResolvedValue(spokePosition());
+    mockGetUserAccountData.mockResolvedValue(accountData(2n));
+
+    const promise = getUserPositionsWithLiveData(DEPOSITOR, SPOKE, {
+      vbtcReserveId: VBTC_RESERVE_ID,
+    });
+
+    await expect(promise).rejects.toBeInstanceOf(IncompleteDebtDiscoveryError);
+  });
+
+  it("does not block when discovered debt reserves exceed borrowCount", async () => {
+    mockGetUserPosition.mockImplementation(
+      async (_spoke: Address, reserveId: bigint) => {
+        if (reserveId === VBTC_RESERVE_ID) return spokePosition();
+        return spokePosition({ drawnShares: 1n });
+      },
+    );
+    mockGetUserAccountData.mockResolvedValue(accountData(1n));
+    mockGetUserTotalDebt.mockResolvedValue(1n);
+
+    const result = await getUserPositionsWithLiveData(DEPOSITOR, SPOKE, {
+      borrowableReserveIds: [RESERVE_A, RESERVE_B],
+      vbtcReserveId: VBTC_RESERVE_ID,
+    });
+
+    expect(result[0].debtPositions?.size).toBe(2);
+  });
+});
+
+describe("isDebtDiscoveryError", () => {
+  it("returns true for DebtPositionFetchError", () => {
+    expect(
+      isDebtDiscoveryError(new DebtPositionFetchError(1n, new Error("rpc"))),
+    ).toBe(true);
+  });
+
+  it("returns true for IncompleteDebtDiscoveryError", () => {
+    expect(
+      isDebtDiscoveryError(new IncompleteDebtDiscoveryError(0, 1n, [])),
+    ).toBe(true);
+  });
+
+  it("returns false for other errors and falsy values", () => {
+    expect(isDebtDiscoveryError(new Error("rpc connection lost"))).toBe(false);
+    expect(isDebtDiscoveryError(null)).toBe(false);
+    expect(isDebtDiscoveryError(undefined)).toBe(false);
+  });
+});
+
+describe("error class names", () => {
+  it("DebtPositionFetchError reports its own class name", () => {
+    const err = new DebtPositionFetchError(7n, new Error("rpc lost"));
+    expect(err.name).toBe("DebtPositionFetchError");
+    expect(err.toString()).toMatch(/^DebtPositionFetchError:/);
+  });
+
+  it("IncompleteDebtDiscoveryError reports its own class name", () => {
+    const err = new IncompleteDebtDiscoveryError(0, 1n, []);
+    expect(err.name).toBe("IncompleteDebtDiscoveryError");
+    expect(err.toString()).toMatch(/^IncompleteDebtDiscoveryError:/);
+  });
+});

--- a/services/vault/src/applications/aave/services/index.ts
+++ b/services/vault/src/applications/aave/services/index.ts
@@ -37,10 +37,14 @@ export {
 
 // Position service (hybrid indexer + RPC)
 export {
+  DebtPositionFetchError,
+  IncompleteDebtDiscoveryError,
   canWithdrawCollateral,
   getPositionWithLiveData,
   getUserPositionsWithLiveData,
+  isDebtDiscoveryError,
   type AavePositionWithLiveData,
+  type DebtDiscoveryError,
   type DebtPosition,
   type GetUserPositionsOptions,
 } from "./positionService";

--- a/services/vault/src/applications/aave/services/positionService.ts
+++ b/services/vault/src/applications/aave/services/positionService.ts
@@ -18,6 +18,57 @@ import {
   type AavePositionCollateral,
 } from "./fetchPositions";
 
+export class DebtPositionFetchError extends Error {
+  readonly code = "DEBT_POSITION_FETCH_FAILED";
+  readonly reserveId: bigint;
+
+  constructor(reserveId: bigint, cause: unknown) {
+    super(
+      `Failed to fetch debt position for reserve ${reserveId}: ${
+        cause instanceof Error ? cause.message : String(cause)
+      }`,
+      { cause },
+    );
+    this.name = "DebtPositionFetchError";
+    this.reserveId = reserveId;
+  }
+}
+
+export class IncompleteDebtDiscoveryError extends Error {
+  readonly code = "INCOMPLETE_DEBT_DISCOVERY";
+  readonly discovered: number;
+  readonly expected: bigint;
+  readonly queriedReserveIds: bigint[];
+
+  constructor(
+    discovered: number,
+    expected: bigint,
+    queriedReserveIds: bigint[],
+  ) {
+    super(
+      `Discovered ${discovered} debt reserves but on-chain borrowCount is ${expected}. ` +
+        `Aborting to prevent the repay UI from omitting unrepayable debt.`,
+    );
+    this.name = "IncompleteDebtDiscoveryError";
+    this.discovered = discovered;
+    this.expected = expected;
+    this.queriedReserveIds = queriedReserveIds;
+  }
+}
+
+export type DebtDiscoveryError =
+  | DebtPositionFetchError
+  | IncompleteDebtDiscoveryError;
+
+export function isDebtDiscoveryError(
+  error: unknown,
+): error is DebtDiscoveryError {
+  return (
+    error instanceof DebtPositionFetchError ||
+    error instanceof IncompleteDebtDiscoveryError
+  );
+}
+
 /**
  * Debt position data for a single reserve
  */
@@ -134,21 +185,24 @@ export async function getUserPositionsWithLiveData(
 
   let debtPositions: Map<bigint, DebtPosition> | undefined;
   if (accountData.borrowCount > 0n) {
-    // Fail closed: a stale or skipped reserve list would otherwise let
-    // a debt reserve drop out of the repay picker.
     if (!borrowableReserveIds || borrowableReserveIds.length === 0) {
-      throw new Error(
-        `Aave debt reserve discovery: on-chain reports ${accountData.borrowCount} debt reserve(s) but no reserve IDs were provided to probe.`,
-      );
+      throw new IncompleteDebtDiscoveryError(0, accountData.borrowCount, []);
     }
+
     debtPositions = await fetchDebtPositionsForReserves(
       proxyAddress,
       spokeAddress,
       borrowableReserveIds,
     );
+
+    // `<` not `!==`: surplus discovery (e.g. dust-only positions that
+    // `hasDebtFromPosition` flags but `borrowCount` doesn't) is fine —
+    // only a deficit can hide repayable debt from the UI.
     if (BigInt(debtPositions.size) < accountData.borrowCount) {
-      throw new Error(
-        `Aave debt reserve discovery: on-chain reports ${accountData.borrowCount} debt reserve(s), found ${debtPositions.size}. The reserve list is likely incomplete.`,
+      throw new IncompleteDebtDiscoveryError(
+        debtPositions.size,
+        accountData.borrowCount,
+        borrowableReserveIds,
       );
     }
   }
@@ -188,38 +242,40 @@ async function fetchDebtPositionsForReserves(
           proxyAddress,
         );
         return { reserveId, position };
-      } catch {
-        return { reserveId, position: null };
+      } catch (cause) {
+        throw new DebtPositionFetchError(reserveId, cause);
       }
     }),
   );
 
-  const reservesWithDebt = positions.filter(
-    ({ position }) => position && hasDebtFromPosition(position),
+  const reservesWithDebt = positions.filter(({ position }) =>
+    hasDebtFromPosition(position),
   );
 
   const totalDebts = await Promise.all(
     reservesWithDebt.map(async ({ reserveId }) => {
-      const totalDebt = await AaveSpoke.getUserTotalDebt(
-        spokeAddress,
-        reserveId,
-        proxyAddress,
-      );
-      return { reserveId, totalDebt };
+      try {
+        const totalDebt = await AaveSpoke.getUserTotalDebt(
+          spokeAddress,
+          reserveId,
+          proxyAddress,
+        );
+        return { reserveId, totalDebt };
+      } catch (cause) {
+        throw new DebtPositionFetchError(reserveId, cause);
+      }
     }),
   );
 
   const debtMap = new Map(totalDebts.map((d) => [d.reserveId, d.totalDebt]));
 
   for (const { reserveId, position } of reservesWithDebt) {
-    if (position) {
-      results.set(reserveId, {
-        reserveId,
-        drawnShares: position.drawnShares,
-        premiumShares: position.premiumShares,
-        totalDebt: debtMap.get(reserveId) ?? 0n,
-      });
-    }
+    results.set(reserveId, {
+      reserveId,
+      drawnShares: position.drawnShares,
+      premiumShares: position.premiumShares,
+      totalDebt: debtMap.get(reserveId) ?? 0n,
+    });
   }
 
   return results;

--- a/services/vault/src/components/simple/BorrowFlow/index.tsx
+++ b/services/vault/src/components/simple/BorrowFlow/index.tsx
@@ -4,6 +4,7 @@ import { useAccount } from "wagmi";
 
 import { LoanProvider } from "@/applications/aave/components/context/LoanContext";
 import { useAaveReserveDetail } from "@/applications/aave/components/Detail/hooks/useAaveReserveDetail";
+import { isDebtDiscoveryError } from "@/applications/aave/services";
 import { FadeTransition } from "@/components/simple/FadeTransition";
 import { useDialogStep } from "@/hooks/deposit/useDialogStep";
 
@@ -45,10 +46,22 @@ export function BorrowFlow({ open, onClose }: BorrowFlowProps) {
     tokenPriceUsd,
     isPositionDataStale,
     refetchPosition,
+    positionError,
   } = useAaveReserveDetail({
     reserveId: selectedAssetSymbol ?? undefined,
     address,
   });
+
+  const isDebtDiscoveryIncomplete = isDebtDiscoveryError(positionError);
+
+  const debtDiscoveryBanner = (
+    <div className="mx-auto w-full max-w-[520px] py-8">
+      <div className="rounded-md border border-error-main/40 bg-error-main/10 p-4 text-error-main">
+        Cannot determine your full debt right now. Borrowing is temporarily
+        unavailable. Please try again.
+      </div>
+    </div>
+  );
 
   const handleClose = () => {
     onClose();
@@ -75,28 +88,34 @@ export function BorrowFlow({ open, onClose }: BorrowFlowProps) {
       )}
 
       <FadeTransition stepKey={renderedStep}>
-        {renderedStep === BorrowFlowStep.ASSET_SELECTION && (
-          <BorrowAssetSelection onSelectAsset={selectAsset} />
-        )}
+        {renderedStep === BorrowFlowStep.ASSET_SELECTION &&
+          (isDebtDiscoveryIncomplete ? (
+            debtDiscoveryBanner
+          ) : (
+            <BorrowAssetSelection onSelectAsset={selectAsset} />
+          ))}
 
-        {renderedStep === BorrowFlowStep.BORROW_FORM && (
-          <BorrowFormStep
-            isLoading={isLoading}
-            selectedReserve={selectedReserve}
-            assetConfig={assetConfig}
-            liquidationThresholdBps={liquidationThresholdBps}
-            proxyContract={proxyContract}
-            collateralValueUsd={collateralValueUsd}
-            currentDebtAmount={currentDebtAmount}
-            totalDebtValueUsd={totalDebtValueUsd}
-            healthFactor={healthFactor}
-            tokenPriceUsd={tokenPriceUsd}
-            isPositionDataStale={isPositionDataStale}
-            refetchPosition={refetchPosition}
-            onChangeAsset={goBack}
-            onBorrowSuccess={completeBorrow}
-          />
-        )}
+        {renderedStep === BorrowFlowStep.BORROW_FORM &&
+          (isDebtDiscoveryIncomplete ? (
+            debtDiscoveryBanner
+          ) : (
+            <BorrowFormStep
+              isLoading={isLoading}
+              selectedReserve={selectedReserve}
+              assetConfig={assetConfig}
+              liquidationThresholdBps={liquidationThresholdBps}
+              proxyContract={proxyContract}
+              collateralValueUsd={collateralValueUsd}
+              currentDebtAmount={currentDebtAmount}
+              totalDebtValueUsd={totalDebtValueUsd}
+              healthFactor={healthFactor}
+              tokenPriceUsd={tokenPriceUsd}
+              isPositionDataStale={isPositionDataStale}
+              refetchPosition={refetchPosition}
+              onChangeAsset={goBack}
+              onBorrowSuccess={completeBorrow}
+            />
+          ))}
 
         {renderedStep === BorrowFlowStep.SUCCESS && successData && (
           <BorrowSuccess data={successData} onClose={handleClose} />

--- a/services/vault/src/components/simple/DashboardPage.tsx
+++ b/services/vault/src/components/simple/DashboardPage.tsx
@@ -67,6 +67,7 @@ export function DashboardPage() {
     hasCollateral,
     collateralVaults,
     selectableBorrowedAssets,
+    debtDiscoveryFailed,
   } = useDashboardState(address);
 
   const { snapshot: capSnapshot, isLoading: isCapLoading } = useApplicationCap(
@@ -186,6 +187,7 @@ export function DashboardPage() {
           hasCollateral={hasCollateral}
           isConnected={isConnected}
           borrowedAssets={borrowedAssets}
+          debtDiscoveryFailed={debtDiscoveryFailed}
           onBorrow={handleBorrow}
           onRepay={handleRepay}
         />

--- a/services/vault/src/components/simple/LoansSection.tsx
+++ b/services/vault/src/components/simple/LoansSection.tsx
@@ -21,6 +21,8 @@ interface LoansSectionProps {
   hasCollateral: boolean;
   isConnected: boolean;
   borrowedAssets: LoanAsset[];
+  /** Block borrow/repay and show a banner; the borrowed-assets list is incomplete. */
+  debtDiscoveryFailed: boolean;
   onBorrow: () => void;
   onRepay: () => void;
 }
@@ -30,6 +32,7 @@ export function LoansSection({
   hasCollateral,
   isConnected,
   borrowedAssets,
+  debtDiscoveryFailed,
   onBorrow,
   onRepay,
 }: LoansSectionProps) {
@@ -44,18 +47,18 @@ export function LoansSection({
             size="medium"
             onClick={onBorrow}
             className="rounded-full"
-            disabled={!isConnected || !hasCollateral}
+            disabled={!isConnected || !hasCollateral || debtDiscoveryFailed}
           >
             Borrow
           </Button>
-          {hasLoans && (
+          {(hasLoans || debtDiscoveryFailed) && (
             <Button
               variant="outlined"
               color="primary"
               size="medium"
               onClick={onRepay}
               className="rounded-full"
-              disabled={!isConnected}
+              disabled={!isConnected || debtDiscoveryFailed}
             >
               Repay
             </Button>
@@ -64,7 +67,12 @@ export function LoansSection({
       </div>
 
       <Card variant="filled" className="w-full">
-        {hasLoans ? (
+        {debtDiscoveryFailed ? (
+          <div className="rounded-md border border-error-main/40 bg-error-main/10 p-4 text-error-main">
+            Cannot determine your full debt right now. Borrowing and repayment
+            are temporarily unavailable. Please try again.
+          </div>
+        ) : hasLoans ? (
           <div className="space-y-4">
             {borrowedAssets.map((asset) => (
               <div

--- a/services/vault/src/components/simple/__tests__/LoansSection.test.tsx
+++ b/services/vault/src/components/simple/__tests__/LoansSection.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/components/Wallet", () => ({
+  Connect: () => <button>Connect</button>,
+}));
+
+import { LoansSection } from "../LoansSection";
+
+const baseProps = {
+  hasLoans: true,
+  hasCollateral: true,
+  isConnected: true,
+  borrowedAssets: [{ symbol: "USDC", amount: "100", icon: "/usdc.png" }],
+  debtDiscoveryFailed: false,
+  onBorrow: vi.fn(),
+  onRepay: vi.fn(),
+};
+
+describe("LoansSection", () => {
+  it("renders the borrowed-assets list when discovery succeeded", () => {
+    render(<LoansSection {...baseProps} />);
+
+    expect(screen.getByText(/100 USDC/)).toBeInTheDocument();
+    expect(
+      screen.queryByText(/Cannot determine your full debt/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders blocking banner and disables both action buttons when discovery failed", () => {
+    render(<LoansSection {...baseProps} debtDiscoveryFailed={true} />);
+
+    expect(
+      screen.getByText(/Cannot determine your full debt/),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/100 USDC/)).not.toBeInTheDocument();
+
+    expect(screen.getByRole("button", { name: "Borrow" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Repay" })).toBeDisabled();
+  });
+
+  it("forces the Repay button to render when discovery failed even without loans", () => {
+    render(
+      <LoansSection
+        {...baseProps}
+        hasLoans={false}
+        debtDiscoveryFailed={true}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Repay" })).toBeDisabled();
+  });
+
+  it("disables Borrow when collateral is missing even if discovery succeeded", () => {
+    render(<LoansSection {...baseProps} hasCollateral={false} />);
+
+    expect(screen.getByRole("button", { name: "Borrow" })).toBeDisabled();
+  });
+});

--- a/services/vault/src/hooks/__tests__/useDashboardState.test.tsx
+++ b/services/vault/src/hooks/__tests__/useDashboardState.test.tsx
@@ -1,0 +1,89 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  DebtPositionFetchError,
+  IncompleteDebtDiscoveryError,
+} from "@/applications/aave/services";
+
+const mockUseAaveUserPosition = vi.fn<(addr?: string) => unknown>();
+const mockUseAaveBorrowedAssets = vi.fn<(props: unknown) => unknown>(() => ({
+  borrowedAssets: [],
+  totalDebtValueUsd: 0,
+  hasLoans: false,
+}));
+const mockUseVaultProviders = vi.fn(() => ({ findProvider: vi.fn() }));
+
+vi.mock("@/applications/aave/hooks", () => ({
+  useAaveUserPosition: (addr?: string) => mockUseAaveUserPosition(addr),
+  useAaveBorrowedAssets: (props: unknown) => mockUseAaveBorrowedAssets(props),
+}));
+
+vi.mock("@/hooks/deposit/useVaultProviders", () => ({
+  useVaultProviders: () => mockUseVaultProviders(),
+}));
+
+vi.mock("@/utils/collateral", () => ({
+  toCollateralVaultEntries: vi.fn(() => []),
+}));
+
+import { useDashboardState } from "../useDashboardState";
+
+const baseUserPosition = {
+  position: null,
+  collateralBtc: 0,
+  collateralValueUsd: 0,
+  debtValueUsd: 0,
+  healthFactor: null,
+  healthFactorStatus: "healthy",
+  isPositionDataStale: false,
+  isLoading: false,
+  error: null,
+  refetch: vi.fn(),
+};
+
+describe("useDashboardState", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseAaveUserPosition.mockReturnValue(baseUserPosition);
+  });
+
+  it("flags debtDiscoveryFailed=true when useAaveUserPosition errors with IncompleteDebtDiscoveryError", () => {
+    mockUseAaveUserPosition.mockReturnValue({
+      ...baseUserPosition,
+      error: new IncompleteDebtDiscoveryError(0, 1n, []),
+    });
+
+    const { result } = renderHook(() => useDashboardState("0xUser"));
+
+    expect(result.current.debtDiscoveryFailed).toBe(true);
+  });
+
+  it("flags debtDiscoveryFailed=true when useAaveUserPosition errors with DebtPositionFetchError", () => {
+    mockUseAaveUserPosition.mockReturnValue({
+      ...baseUserPosition,
+      error: new DebtPositionFetchError(7n, new Error("rpc lost")),
+    });
+
+    const { result } = renderHook(() => useDashboardState("0xUser"));
+
+    expect(result.current.debtDiscoveryFailed).toBe(true);
+  });
+
+  it("flags debtDiscoveryFailed=false on unrelated errors so they don't accidentally block borrow/repay", () => {
+    mockUseAaveUserPosition.mockReturnValue({
+      ...baseUserPosition,
+      error: new Error("some unrelated error"),
+    });
+
+    const { result } = renderHook(() => useDashboardState("0xUser"));
+
+    expect(result.current.debtDiscoveryFailed).toBe(false);
+  });
+
+  it("flags debtDiscoveryFailed=false when there is no error", () => {
+    const { result } = renderHook(() => useDashboardState("0xUser"));
+
+    expect(result.current.debtDiscoveryFailed).toBe(false);
+  });
+});

--- a/services/vault/src/hooks/useDashboardState.ts
+++ b/services/vault/src/hooks/useDashboardState.ts
@@ -10,6 +10,7 @@ import {
   useAaveBorrowedAssets,
   useAaveUserPosition,
 } from "@/applications/aave/hooks";
+import { isDebtDiscoveryError } from "@/applications/aave/services";
 import type { Asset } from "@/applications/aave/types";
 import { useVaultProviders } from "@/hooks/deposit/useVaultProviders";
 import type { CollateralVaultEntry } from "@/types/collateral";
@@ -27,7 +28,10 @@ export function useDashboardState(connectedAddress: string | undefined) {
     healthFactor,
     healthFactorStatus,
     isLoading,
+    error: positionError,
   } = useAaveUserPosition(connectedAddress);
+
+  const debtDiscoveryFailed = isDebtDiscoveryError(positionError);
 
   const { borrowedAssets, hasLoans } = useAaveBorrowedAssets({
     position,
@@ -73,5 +77,6 @@ export function useDashboardState(connectedAddress: string | undefined) {
     collateralVaults,
     selectableBorrowedAssets,
     isLoading,
+    debtDiscoveryFailed,
   };
 }


### PR DESCRIPTION
## Summary

`fetchDebtPositionsForReserves` previously caught per-reserve `getUserPosition` failures and converted them to `null`, then filtered them out — so a single RPC hiccup or a missing reserve row from the indexer would silently drop that reserve from `debtPositions` while `accountData.borrowCount` still reported nonzero debt. `useAaveBorrowedAssets` builds the repay list purely by intersecting `allBorrowReserves` with `debtPositions`, so the dashboard could show "you owe $X" while the repay screen had no asset to repay against. Funds aren't directly stolen, but the user is stuck holding live debt with no UI path to settle it — and liquidation risk continues to accrue.

This PR makes per-reserve debt discovery fail closed at every layer and surfaces the failure as a blocking banner across borrow/repay surfaces, so the user always sees an explicit "try again" rather than a silently incomplete picture of their debt.

## Approach

Introduce two typed errors thrown from `positionService.ts`:

- `DebtPositionFetchError` — wraps an underlying RPC failure for a specific reserve and preserves the reserve id in the error chain. Thrown for both `getUserPosition` and `getUserTotalDebt` failures (every per-reserve RPC on the discovery path).
- `IncompleteDebtDiscoveryError` — thrown when discovered debt-reserve count is below `accountData.borrowCount`, including the worst-case "indexer dropped every reserve row" branch where `borrowableReserveIds` is empty/undefined while `borrowCount > 0`.

Use a single predicate `isDebtDiscoveryError(error)` at every UI gate so the same set of failure modes blocks consistently. Borrow/repay surfaces (`Detail`, simple `BorrowFlow`, dashboard `LoansSection`) detect this state and render a blocking banner with both action buttons disabled.

## Out of scope

- **On-chain reserve enumeration in `fetchAaveAppConfig`.** The auditor's recommendation includes "fall back to reading reserve count and reserve ids from the pinned Core Spoke when indexed reserve data is incomplete." This PR chooses fail-closed-everywhere as the trade-off — a degraded indexer blocks borrow/repay rather than recovering via on-chain enumeration. The on-chain enumeration follow-up mirrors the pattern from #1542 and is tracked as a separate PR. If the audit requires literal compliance with all four sub-recommendations before sign-off, that follow-up should land before closing this finding.
- **Borrow flow's projected-HF math under partial discovery.** Not relevant here — when discovery fails, the position query throws and the borrow surface is blocked outright. The HF math never sees a partial state.

Closes https://github.com/babylonlabs-io/baby-auditor-findings/issues/231
