### PR TITLE
feat(packages): add project constitution and feature specs

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,0 +1,100 @@
+# babylon-toolkit Constitution
+
+## Core Principles
+
+### I. Critical Paths Require Human Review (NON-NEGOTIABLE)
+
+The following paths handle irreversible value movement and must not be modified
+by an AI assistant alone. Any change requires two reviewers, and the author
+must be able to explain every changed line without an AI assistant open.
+
+- WASM boundary value computation (`packages/babylon-tbv-rust-wasm/src/index.ts`)
+- Fee calculation consistency (`packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts`,
+  `services/vault/src/utils/fee/peginFee.ts`)
+- Presigning payout transactions (`packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts`,
+  `services/vault/src/hooks/deposit/depositFlowSteps/payoutSigning.ts`)
+- Vault-secret derivation (frozen on-chain-binding API under
+  `packages/babylon-ts-sdk/src/tbv/core/vault-secrets/`,
+  `packages/babylon-ts-sdk/src/tbv/core/wots/blockDerivation.ts`,
+  `packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts`)
+- HTLC secret & vault activation (`services/vault/src/services/vault/vaultActivationService.ts`)
+- Multi-vault split transactions (`packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts`)
+- Non-standard wallet signing options (`packages/babylon-ts-sdk/src/tbv/core/utils/signing.ts`)
+
+Every WASM output consumed by JS must be asserted against expected bounds
+before use. Every signature produced with non-standard wallet options must be
+validated against the expected sighash before being treated as signed.
+
+### II. No Silent Fallbacks on Critical Paths
+
+Throw errors instead of defaulting to values that mask bugs. Never default to
+`0n`, `0`, `""`, `[]`, or `undefined` when a missing value indicates a real
+problem. Fallback values are acceptable only for optional UI/display concerns,
+never for financial calculations, transaction construction, or protocol
+parameters. If a value is required for correctness, its absence is an error
+and must surface loudly.
+
+### III. Zero Dead Code
+
+No unused functions, variables, imports, types, or components in source or
+tests. After every edit, trace impact: anything removed must have all
+references removed too (tests, imports, re-exports, mocks). No commented-out
+code, no `// removed` / `// deprecated` markers as substitutes for deletion,
+no re-exports or aliases for backward compatibility unless explicitly
+requested.
+
+### IV. Behavior-Driven Tests
+
+Each test verifies one specific behavior of production code, with a name
+that describes the exact behavior being tested. Never write tests for
+functions that don't exist in production code. When production code changes,
+update or remove corresponding tests immediately. Prefer inline setup over
+deeply nested helpers; three similar test functions are better than one
+parameterized abstraction. A new contributor should understand a test by
+reading it top-to-bottom.
+
+### V. Spec-Driven Development
+
+Every feature lives under `specs/NNN-feature-name/` with `spec.md` capturing
+user scenarios, acceptance scenarios, functional requirements, and success
+criteria. New features begin with `/speckit-specify` before any code is
+written. Plans (`plan.md`) and tasks (`tasks.md`) are derived from the spec,
+never the other way around. Specs describe behavior, not implementation: no
+file paths, no framework names, no code samples in `spec.md`.
+
+## Security & Supply Chain
+
+- Never log sensitive key material - no `console.log` of private keys, derived
+  secrets, or signing data.
+- Validate all data received from wallet APIs before use.
+- Never trust external GraphQL/RPC responses for security decisions without
+  validation.
+- All new dependencies must use pinned exact versions (no `^` ranges),
+  especially crypto packages. Audit new dependencies for supply chain risk
+  before adding.
+- Protocol parameters (`councilQuorum`, `feeRate`, etc.) come from on-chain
+  contracts via ABI calls. Never hardcode them. If a parameter is not yet
+  available from the contract, leave a `TODO` with context.
+
+## Development Workflow
+
+- Build prerequisites: Node 24 via nvm (`nvm use 24`), pnpm via Corepack.
+  Rebuild `core-ui` and `ts-sdk` before vault build.
+- Run `pnpm run lint` and `pnpm run test` in the affected service before
+  considering work done.
+- Commit messages start with `feat(packages):`.
+- React Query for server state; React Context for shared client state.
+  Centralize polling rather than per-row hook instantiation.
+- One component per file. File name matches component name. Function
+  components contain no business logic; business logic lives in hooks or
+  auxiliary methods.
+
+## Governance
+
+This constitution supersedes ad-hoc practices. All PRs touching `Critical
+Paths` (Principle I) must reference the relevant spec under `specs/` and
+include the required cross-checks. Amendments require documentation in this
+file plus a corresponding update to `CLAUDE.md` so the two stay in sync.
+Complexity must be justified in the spec; YAGNI by default.
+
+**Version**: 1.0.0 | **Ratified**: 2026-05-05 | **Last Amended**: 2026-05-05

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,25 @@ Run `pnpm run lint` and `pnpm run test` in the affected service before consideri
 
 ---
 
+## SPEC-DRIVEN DEVELOPMENT
+
+This repo uses [GitHub Spec Kit](https://github.com/github/spec-kit). Every feature lives under `specs/NNN-feature-name/` with a `spec.md` describing user scenarios, acceptance scenarios, functional requirements, and success criteria.
+
+- Project principles: [`.specify/memory/constitution.md`](./.specify/memory/constitution.md)
+- Existing feature specs: [`specs/`](./specs/)
+- Templates and scripts: [`.specify/`](./.specify/)
+
+E2E tests reference user-story IDs (`BT-XX`) defined inside each `spec.md`. When changing behavior covered by a spec, update the spec first, then code, then tests.
+
+Slash commands (Claude Code):
+- `/speckit-constitution` - amend project principles
+- `/speckit-specify` - create or update a feature spec
+- `/speckit-plan` - derive an implementation plan from a spec
+- `/speckit-tasks` - break a plan into tasks
+- `/speckit-implement` - execute tasks against the codebase
+
+---
+
 ## CRITICAL PATHS — HUMAN REVIEW REQUIRED
 
 These paths handle irreversible value movement. An AI-generated mistake here is silent: code compiles, tests pass, wrong BTC amount ships. **Any change touching these files requires two reviewers, and the author must be able to explain every changed line without an AI assistant open.**
@@ -188,3 +207,8 @@ These paths handle irreversible value movement. An AI-generated mistake here is 
 - **Naming**: Descriptive variable and function names. Avoid abbreviations unless domain-standard (tx, UTXO, PSBT).
 - **Components**: One component per file. File name matches component name.
 - **After changes**: Check for comments/docs that reference old behavior and update them.
+
+<!-- SPECKIT START -->
+For additional context about technologies to be used, project structure,
+shell commands, and other important information, read the current plan
+<!-- SPECKIT END -->

--- a/specs/001-wallet-connection/spec.md
+++ b/specs/001-wallet-connection/spec.md
@@ -1,0 +1,137 @@
+# Feature Specification: Wallet Connection
+
+**Feature Branch**: `001-wallet-connection`
+**Created**: 2026-05-05
+**Status**: Implemented (retroactive)
+**Input**: Migrated from `stories.yaml` (BT-01, BT-02, BT-03)
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story BT-01 - Connect a Bitcoin wallet (Priority: P1)
+
+The user selects one of eight supported Bitcoin wallets (OKX, Unisat, Ledger,
+Ledger v2, Keystone, OneKey, AppKit, or injectable `window.bitcoin`
+providers) and authorises the connection to obtain a Taproot address and
+public key. Without this step no deposit or signing action is possible.
+
+**Why this priority**: Every downstream flow (deposit, payout signing, refund,
+withdraw) requires a connected BTC wallet. Without it the dApp is unusable.
+
+**Independent Test**: Open the connect modal, complete authorisation against
+each supported provider, observe the connected Taproot address surface.
+
+**Acceptance Scenarios**:
+
+1. **Given** the connect modal is open, **When** it renders, **Then** all
+   supported BTC wallets are listed with their icons and names.
+2. **Given** the user authorises connection, **When** the wallet returns,
+   **Then** the app displays the connected Taproot (P2TR) address.
+3. **Given** the user rejects the connection prompt, **When** the wallet
+   responds, **Then** the modal closes without error and no address is stored.
+4. **Given** a connected BTC wallet, **When** the user disconnects, **Then**
+   the address and public key are cleared from app state.
+
+---
+
+### User Story BT-02 - Connect an Ethereum wallet (Priority: P1)
+
+The user connects an Ethereum-compatible wallet through WalletConnect / AppKit
+(covering 600+ wallets) to enable on-chain vault registration, WOTS key
+submission, vault activation, borrowing, and repayment on Ethereum.
+
+**Why this priority**: All Ethereum protocol steps (registration, activation,
+borrow, repay) require this connection.
+
+**Independent Test**: Trigger the ETH connect flow, complete pairing, see the
+Ethereum address surface in the UI; verify ETH-side actions become available.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user starts the Ethereum connect flow, **When** the modal
+   opens, **Then** the AppKit modal lists available Ethereum wallets.
+2. **Given** the user authorises connection, **When** the wallet returns,
+   **Then** the app displays the connected Ethereum address.
+3. **Given** no Ethereum wallet is connected, **When** the user attempts an
+   Ethereum transaction, **Then** the action is blocked.
+4. **Given** both BTC and ETH wallets are connected, **When** the user
+   disconnects the Ethereum wallet, **Then** only the Ethereum address is
+   removed; the BTC wallet remains connected.
+
+---
+
+### User Story BT-03 - Connect a Babylon chain wallet (Priority: P2)
+
+The user connects a Babylon (BBN / Cosmos) wallet - Keplr, Leap, OKX, or an
+injectable provider - to satisfy any Babylon-chain protocol steps in the
+deposit lifecycle.
+
+**Why this priority**: Required for Babylon-chain protocol steps but does not
+gate the BTC ↔ ETH path; lower priority than BT-01/BT-02.
+
+**Independent Test**: Open the Babylon wallet connect flow with at least
+Keplr, Leap, and OKX, complete authorisation, see the Babylon address.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Babylon connect modal is open, **When** it renders, **Then**
+   the wallet list shows at least Keplr, Leap, and OKX.
+2. **Given** the user authorises a Babylon wallet, **When** authorisation
+   completes, **Then** the Babylon address is displayed in the UI.
+3. **Given** the connected Babylon wallet is on a chain that does not match
+   the expected Babylon chain, **When** the user attempts to proceed,
+   **Then** the app surfaces a chain-mismatch error.
+
+### Edge Cases
+
+- The user closes the wallet connection modal mid-authorisation.
+- The injected wallet provider is present but returns an empty address list.
+- The user has multiple injected providers (e.g. OKX and Unisat) on the same
+  page.
+- A previously connected wallet is no longer available on app reload.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST list all eight supported Bitcoin wallets in the
+  connect modal with each wallet's icon and name.
+- **FR-002**: System MUST obtain a Taproot (P2TR) address and public key from
+  the connected Bitcoin wallet before any deposit or signing action is
+  permitted.
+- **FR-003**: System MUST clear the BTC address and public key from app
+  state when the user disconnects.
+- **FR-004**: System MUST present the AppKit modal (or equivalent) for
+  Ethereum wallet selection, supporting WalletConnect.
+- **FR-005**: System MUST block any Ethereum transaction submission when no
+  Ethereum wallet is connected.
+- **FR-006**: System MUST list at least Keplr, Leap, and OKX as Babylon
+  wallet options.
+- **FR-007**: System MUST surface a chain-mismatch error when the connected
+  Babylon wallet is on the wrong chain.
+- **FR-008**: System MUST handle user rejection of any connection prompt
+  gracefully - modal closes, no error, no partial state stored.
+
+### Key Entities
+
+- **Connected Wallet**: Wallet kind (BTC | ETH | BBN), provider identifier,
+  primary address, public key (where applicable), connection state.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A new user can complete BTC + ETH wallet connection in under
+  60 seconds on the first attempt.
+- **SC-002**: 100% of supported BTC wallets are reachable from the connect
+  modal without code changes.
+- **SC-003**: Disconnecting any one wallet never leaves another wallet's
+  state stale (verified by automated state-clear tests).
+
+## Assumptions
+
+- Users have a supported wallet extension installed or a mobile wallet
+  reachable via WalletConnect.
+- The injected `window.bitcoin` providers conform to the documented BTC
+  provider interface.
+- Babylon-chain steps may be invoked optionally; not every deposit requires
+  a connected Babylon wallet.

--- a/specs/002-application-selection/spec.md
+++ b/specs/002-application-selection/spec.md
@@ -1,0 +1,74 @@
+# Feature Specification: Application Selection
+
+**Feature Branch**: `002-application-selection`
+**Created**: 2026-05-05
+**Status**: Implemented (retroactive)
+**Input**: Migrated from `stories.yaml` (BT-23)
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story BT-23 - Choose a DeFi application for the deposit (Priority: P1)
+
+Before starting a deposit the user lands on an application selector page that
+shows available integrations (currently Aave). Selecting an application
+determines the vault split logic, collateral adapter, and downstream borrow
+and repay flows.
+
+**Why this priority**: This is the entry point to the deposit flow; without
+selection no deposit can begin.
+
+**Independent Test**: Visit the entry route, see the available applications,
+select one, observe the deposit form pre-scoped to that application.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user enters the dApp, **When** they reach the deposit entry
+   point, **Then** the application selector is the first page shown.
+2. **Given** the selector page is rendered, **When** an application card
+   loads, **Then** the card shows the application's name, a brief
+   description, and its supported assets.
+3. **Given** the user selects an available application, **When** the
+   selection is confirmed, **Then** they are routed to the deposit form
+   pre-scoped to that application.
+4. **Given** an application is unavailable (e.g. at capacity), **When** the
+   selector renders, **Then** the application card is shown as disabled,
+   not hidden.
+
+### Edge Cases
+
+- All applications are at capacity simultaneously.
+- An application is removed from the registry while the user is on the
+  selector page.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST present an application selector as the entry point
+  to the deposit flow.
+- **FR-002**: Each application card MUST show name, brief description, and
+  supported assets.
+- **FR-003**: Selecting an available application MUST route the user to the
+  deposit form pre-scoped to that application's vault split logic and
+  adapter.
+- **FR-004**: Unavailable applications MUST remain visible but be marked
+  disabled, with the reason surfaced.
+
+### Key Entities
+
+- **Application**: Identifier, display name, description, supported assets,
+  availability state, downstream adapter reference.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of registered applications appear on the selector without
+  code changes.
+- **SC-002**: Disabled applications are visually distinguishable from
+  available ones in usability tests.
+
+## Assumptions
+
+- Aave is the only supported integration today; the selector is built to
+  accept additional applications without restructuring.

--- a/specs/003-deposit/spec.md
+++ b/specs/003-deposit/spec.md
@@ -1,0 +1,250 @@
+# Feature Specification: Deposit Flow (BTC → Vault)
+
+**Feature Branch**: `003-deposit`
+**Created**: 2026-05-05
+**Status**: Implemented (retroactive)
+**Input**: Migrated from `stories.yaml` (BT-04 through BT-10)
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story BT-04 - Enter deposit amount and select vault provider (Priority: P1)
+
+From the deposit page the user types a BTC amount, selects a vault provider
+from the available registry, and sees real-time validation (minimum amount,
+remaining capacity, UTXO availability) before proceeding to the signing
+steps.
+
+**Why this priority**: First step of the deposit pipeline; gates every
+subsequent signing step.
+
+**Independent Test**: Submit boundary values to the form, verify validation
+behaviour and that the provider list comes from the on-chain registry.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user enters an amount below the protocol minimum or above
+   remaining vault capacity, **When** validation runs, **Then** the form
+   rejects the input.
+2. **Given** the deposit form loads, **When** the provider list renders,
+   **Then** it is populated from the on-chain registry, not hardcoded.
+3. **Given** a valid amount is entered, **When** the form recalculates,
+   **Then** fee estimates are shown before the user commits.
+4. **Given** any validation error is active, **When** the user views the
+   form, **Then** the Continue action is disabled.
+
+---
+
+### User Story BT-05 - Sign proof-of-possession over BTC public key (Priority: P1)
+
+As the first step of the deposit signing ceremony, the user signs a BIP-322
+message with their connected Bitcoin wallet. This binds the Bitcoin public
+key to the deposit session and is required by the protocol before vault
+registration.
+
+**Why this priority**: Without PoP the protocol rejects the deposit; required
+before any on-chain registration.
+
+**Independent Test**: Drive the wallet through a successful BIP-322 signing
+and through a rejection path; assert flow advances or returns accordingly.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user reaches the PoP step, **When** the modal renders,
+   **Then** it presents a human-readable explanation of what is being signed.
+2. **Given** the user confirms the signing request, **When** the app calls
+   the wallet, **Then** it invokes the wallet's BIP-322 signing method, not
+   a generic message-sign fallback.
+3. **Given** the wallet rejects or times out, **When** the rejection is
+   handled, **Then** the user is returned to the previous step with an
+   actionable error.
+4. **Given** a valid signature is returned, **When** verification succeeds,
+   **Then** the flow advances to vault registration automatically.
+
+---
+
+### User Story BT-06 - Register peg-in on Ethereum (Priority: P1)
+
+After proof-of-possession, the app submits an Ethereum transaction to the
+BTCVaultRegistry contract to register one or more vaults atomically. For
+multi-vault (Aave split) deposits this is a single batch registration call.
+The user signs via their connected Ethereum wallet.
+
+**Why this priority**: Anchors the deposit on Ethereum and is required before
+the BTC broadcast step.
+
+**Independent Test**: Submit a single-vault and a multi-vault registration;
+verify both go through one Ethereum transaction.
+
+**Acceptance Scenarios**:
+
+1. **Given** a deposit batch contains one or more vaults, **When**
+   registration is submitted, **Then** a single Ethereum transaction
+   registers all of them.
+2. **Given** no valid PoP exists, **When** registration is attempted,
+   **Then** the transaction is not submitted.
+3. **Given** the registration transaction is submitted, **When** the network
+   responds, **Then** on-chain confirmation is awaited before the flow
+   advances.
+4. **Given** the transaction reverts, **When** the failure is observed,
+   **Then** the user sees the revert reason and can retry.
+
+---
+
+### User Story BT-07 - Broadcast pre-peg-in transaction to Bitcoin (Priority: P1)
+
+The user signs the Pre-PegIn PSBT with their Bitcoin wallet and the app
+broadcasts it to the Bitcoin network. This funds the HTLC output(s) that
+lock the user's BTC. UTXOs are selected automatically by the SDK; the user
+only approves the signing request.
+
+**Why this priority**: This is the irreversible commitment of BTC; the
+deposit cannot proceed without it.
+
+**Independent Test**: Drive a full deposit through to broadcast; verify
+mempool confirmation and TXID persistence.
+
+**Acceptance Scenarios**:
+
+1. **Given** the prior steps succeeded, **When** broadcast is reached,
+   **Then** the PSBT is constructed before the signing request is shown.
+2. **Given** UTXOs are being selected, **When** the SDK runs the iterative
+   selection, **Then** fee accounting iterates and is not hardcoded.
+3. **Given** the transaction is broadcast, **When** the TXID returns,
+   **Then** the TXID is persisted in local storage so the flow can be
+   resumed across page refresh.
+4. **Given** the transaction is in the mempool, **When** the indexer/mempool
+   confirms, **Then** the app surfaces a confirmation message.
+
+---
+
+### User Story BT-08 - Sign payout transactions for vault payouts (Priority: P1)
+
+The vault provider sends pre-built payout PSBT(s); the user reviews and signs
+each one via their Bitcoin wallet. These pre-authorized payouts define how
+BTC will be returned to the user at withdrawal time.
+
+**Why this priority**: Without pre-signed payouts the vault cannot be
+redeemed; required before activation.
+
+**Independent Test**: Walk through a deposit until payout signing; assert
+displayed amounts come from independent (on-chain or WASM) computation, not
+from the provider verbatim.
+
+**Acceptance Scenarios**:
+
+1. **Given** the vault provider returns payout PSBTs, **When** the modal
+   renders, **Then** the payout amounts displayed are derived from on-chain
+   or WASM-computed values, not taken verbatim from the vault provider.
+2. **Given** multiple payout PSBTs, **When** signing runs, **Then** each
+   PSBT is signed individually with the user's Bitcoin wallet.
+3. **Given** the user rejects any payout signature, **When** the rejection
+   is handled, **Then** the flow pauses and presents a retry option.
+4. **Given** all payouts are signed, **When** validation passes, **Then**
+   the flow advances to artifact download.
+
+---
+
+### User Story BT-09 - Download vault artifacts (Priority: P2)
+
+After payout signing, the user is offered a download of the vault artifacts
+(WOTS keys, hashlock secrets, signed payouts) needed for future recovery.
+This is the only point in the flow where these can be exported.
+
+**Why this priority**: Critical for recovery, but skipping it does not block
+the activation step.
+
+**Independent Test**: Reach the artifact step, download the file, verify it
+is valid JSON containing all recovery-critical fields.
+
+**Acceptance Scenarios**:
+
+1. **Given** payout signing has completed, **When** the next step renders,
+   **Then** the download prompt is shown before vault activation.
+2. **Given** the user requests the download, **When** the file is
+   produced, **Then** it is in a documented JSON format including all
+   recovery-critical data.
+3. **Given** the user chooses to skip the download, **When** they
+   continue, **Then** they receive a warning about irrecoverability.
+4. **Given** the user has downloaded or skipped, **When** they continue,
+   **Then** the flow proceeds to vault activation in either case.
+
+---
+
+### User Story BT-10 - Activate vault by revealing HTLC secret (Priority: P1)
+
+The final deposit step: the user submits the HTLC hashlock preimage to the
+Ethereum BTCVaultRegistry, transitioning the vault from VERIFIED to ACTIVE
+and making the BTC collateral available for DeFi use.
+
+**Why this priority**: Final step that unlocks DeFi use of the deposit;
+required for any borrow flow.
+
+**Independent Test**: Complete a deposit, run activation, verify hash check
+and the resulting ACTIVE state on Ethereum.
+
+**Acceptance Scenarios**:
+
+1. **Given** activation is reached, **When** the secret is read, **Then**
+   it is derived from the vault's own seed, not from UI state.
+2. **Given** a candidate secret, **When** activation is about to submit,
+   **Then** the app verifies `hash(secret) === expectedHash` before
+   submitting the transaction.
+3. **Given** the activation transaction confirms, **When** state refreshes,
+   **Then** the vault status updates to ACTIVE.
+4. **Given** the vault is already ACTIVE (resumed session), **When** the
+   activation step runs, **Then** it is skipped automatically.
+
+### Edge Cases
+
+- The user refreshes mid-flow between any two steps.
+- The vault provider returns mismatched payout amounts.
+- A second deposit is initiated while one is in flight.
+- The Ethereum registration confirms but the BTC broadcast fails.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST validate amount, capacity, and UTXO availability
+  in real time before allowing the user to advance.
+- **FR-002**: Provider list MUST come from the on-chain registry.
+- **FR-003**: System MUST sign PoP with the wallet's BIP-322 method, not a
+  generic fallback.
+- **FR-004**: Multi-vault deposits MUST be registered in a single Ethereum
+  transaction.
+- **FR-005**: System MUST iterate UTXO selection with fee recalculation; no
+  hardcoded fee values.
+- **FR-006**: System MUST persist broadcast TXIDs to local storage for
+  refresh resilience.
+- **FR-007**: Payout amounts shown to the user MUST be independently
+  derived (on-chain or WASM), never taken verbatim from the vault provider.
+- **FR-008**: Vault artifacts MUST be exportable as documented JSON.
+- **FR-009**: Activation MUST verify `hash(secret) === expectedHash` before
+  submitting the transaction.
+
+### Key Entities
+
+- **Deposit Session**: Vault batch, amount, provider, fee estimate,
+  TXIDs, signing-ceremony state.
+- **Vault Artifact Bundle**: WOTS keys, hashlock secrets, signed payout
+  PSBTs.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A user can complete a single-vault deposit end-to-end without
+  external help.
+- **SC-002**: 0% mismatch between displayed payout amounts and
+  independently-computed values across all sessions.
+- **SC-003**: A refreshed deposit session resumes from the last completed
+  step without re-broadcasting any transaction.
+
+## Assumptions
+
+- The Vault Provider returns well-formed payout PSBTs that the depositor's
+  wallet can sign.
+- Mempool confirmation latency is bounded and acceptable for UX (single-block
+  expectation).
+- The depositor seed material can be regenerated within the active session
+  to validate hash preimages.

--- a/specs/004-vault-lifecycle/spec.md
+++ b/specs/004-vault-lifecycle/spec.md
@@ -1,0 +1,103 @@
+# Feature Specification: Vault Lifecycle
+
+**Feature Branch**: `004-vault-lifecycle`
+**Created**: 2026-05-05
+**Status**: Implemented (retroactive)
+**Input**: Migrated from `stories.yaml` (BT-11, BT-12)
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story BT-11 - View status of all vaults (Priority: P1)
+
+The dashboard shows every vault the user owns, its lifecycle status (Pending,
+Signing Required, Awaiting Key, Processing, Ready to Activate, Available, In
+Use, Redeemed, Liquidated, Expired, Refunding, Failed, Invalid), and the BTC
+value locked.
+
+**Why this priority**: The dashboard is the operational surface for all
+post-deposit actions; users need accurate status visibility.
+
+**Independent Test**: Seed accounts in each lifecycle state and assert the
+correct label, BTC amount, and polling behaviour.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user is viewing the dashboard, **When** statuses are
+   computed, **Then** each status is derived from on-chain contract state
+   combined with off-chain tracking state.
+2. **Given** the 14 distinct lifecycle states, **When** labels are mapped,
+   **Then** each display label maps to a distinct combination of contract
+   and off-chain states.
+3. **Given** a vault transitions, **When** polling runs, **Then** the
+   status refreshes automatically without a page reload.
+4. **Given** vaults in terminal states (Redeemed, Liquidated, Invalid),
+   **When** the dashboard renders, **Then** they remain visible but are
+   clearly marked as inactive.
+
+---
+
+### User Story BT-12 - Refund expired pre-peg-in HTLC (Priority: P2)
+
+If a deposit's HTLC times out before activation (e.g. the user abandoned the
+flow), the user can claim a refund. The app builds and broadcasts a refund
+transaction to the Bitcoin network that returns the locked BTC minus fees.
+
+**Why this priority**: Recovery path for abandoned deposits; not on the
+primary deposit path but essential for user trust.
+
+**Independent Test**: Force a vault into expired state; trigger the refund
+flow; observe PSBT signing and Bitcoin broadcast.
+
+**Acceptance Scenarios**:
+
+1. **Given** the vault's HTLC timeout has not elapsed, **When** the
+   dashboard renders, **Then** the Refund option is not presented.
+2. **Given** the timeout has elapsed, **When** the user opens the refund
+   flow, **Then** the refund fee is estimated before the user confirms.
+3. **Given** the refund is confirmed, **When** signing runs, **Then** the
+   refund PSBT is signed by the user's Bitcoin wallet before broadcast.
+4. **Given** the refund is broadcast, **When** the TXID returns, **Then**
+   the vault status transitions to Refunding and the TXID is recorded.
+
+### Edge Cases
+
+- A vault transitions between non-terminal and terminal state mid-poll.
+- The HTLC timeout passes while the user is on the dashboard.
+- A refund broadcast fails after the PSBT is signed.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST display all 14 lifecycle states using distinct
+  labels.
+- **FR-002**: Vault status MUST be derived from on-chain + off-chain state,
+  not a single source.
+- **FR-003**: Polling MUST refresh status without a page reload, and stop
+  for terminal states.
+- **FR-004**: Refund option MUST only appear after the HTLC timeout has
+  elapsed.
+- **FR-005**: Refund flow MUST present a fee estimate before user
+  confirmation.
+
+### Key Entities
+
+- **Vault**: Identifier, BTC amount, lifecycle state, contract state,
+  off-chain tracking state, terminal flag.
+- **Refund Session**: Source vault, fee estimate, refund PSBT, broadcast
+  TXID.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Dashboard reflects state changes within one poll interval of
+  the underlying chain update.
+- **SC-002**: 100% of expired pre-peg-in HTLCs surface a working refund
+  option.
+
+## Assumptions
+
+- A reliable indexer or RPC provides timely state updates for vault
+  computation.
+- HTLC timeouts and refund construction are documented in the SDK.

--- a/specs/005-aave-collateral/spec.md
+++ b/specs/005-aave-collateral/spec.md
@@ -1,0 +1,92 @@
+# Feature Specification: Aave - Collateral
+
+**Feature Branch**: `005-aave-collateral`
+**Created**: 2026-05-05
+**Status**: Implemented (retroactive)
+**Input**: Migrated from `stories.yaml` (BT-13, BT-14)
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story BT-13 - View BTC collateral position on Aave (Priority: P1)
+
+The dashboard shows the user's total BTC locked as Aave collateral, its USD
+value, total outstanding debt, and current health factor. This gives the
+user a complete picture of their DeFi position before taking any action.
+
+**Why this priority**: Required context before any borrow or repay action.
+
+**Independent Test**: Seed an account with collateral and debt; assert the
+displayed total, USD value, debt, and health factor against on-chain state.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user has active vaults, **When** the collateral panel
+   renders, **Then** collateral value is computed from on-chain Aave
+   reserve data, not hardcoded prices.
+2. **Given** a computed health factor, **When** it renders, **Then** it is
+   displayed numerically and colour-coded (healthy / warning / critical).
+3. **Given** a new vault becomes ACTIVE, **When** state refreshes, **Then**
+   the collateral section updates.
+4. **Given** multiple contributing vaults, **When** the panel expands,
+   **Then** each vault is listed with its BTC amount.
+
+---
+
+### User Story BT-14 - Reorder collateral vaults (Priority: P2)
+
+When multiple vaults are deposited as collateral, the user can drag-and-drop
+to reorder them. The order determines which vaults are withdrawn first and
+affects liquidation cascade risk.
+
+**Why this priority**: Optimisation feature for users with multiple vaults;
+not blocking for single-vault users.
+
+**Independent Test**: With multiple vaults, drag to reorder, save, and
+verify the on-chain order via the adapter contract.
+
+**Acceptance Scenarios**:
+
+1. **Given** the reorder UI is open, **When** vaults render, **Then** each
+   vault shows its BTC value and current Aave status.
+2. **Given** the user saves a new order, **When** submission runs, **Then**
+   the order is submitted to the Aave adapter contract.
+3. **Given** the transaction confirms, **When** state refreshes, **Then**
+   the UI reflects the updated order.
+4. **Given** no vaults are in the ACTIVE state, **When** the panel renders,
+   **Then** reordering is disabled.
+
+### Edge Cases
+
+- A vault transitions out of ACTIVE during a reorder save.
+- Aave reserve data is temporarily unavailable.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST compute collateral value from on-chain Aave
+  reserve data; never hardcoded.
+- **FR-002**: Health factor MUST be visually colour-coded by risk band.
+- **FR-003**: Reorder save MUST submit the new order through the Aave
+  adapter contract.
+- **FR-004**: Reordering MUST be disabled when no vaults are ACTIVE.
+
+### Key Entities
+
+- **Collateral Position**: Total BTC, USD value, total debt, health factor,
+  contributing vault list (ordered).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Health factor and USD value displayed match on-chain values
+  to the precision of the source data.
+- **SC-002**: Order changes persist across page reload after on-chain
+  confirmation.
+
+## Assumptions
+
+- Aave reserve data and adapter contracts are accessible via the configured
+  RPC.
+- Health factor risk bands are documented and consistent across views.

--- a/specs/006-aave-borrow/spec.md
+++ b/specs/006-aave-borrow/spec.md
@@ -1,0 +1,96 @@
+# Feature Specification: Aave - Borrow
+
+**Feature Branch**: `006-aave-borrow`
+**Created**: 2026-05-05
+**Status**: Implemented (retroactive)
+**Input**: Migrated from `stories.yaml` (BT-15, BT-16)
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story BT-15 - Borrow ERC-20 against BTC collateral (Priority: P1)
+
+From the Aave reserve detail page the user selects an asset (USDC, WETH,
+USDT, etc.), enters a borrow amount, reviews the resulting health factor,
+and submits the borrow transaction via their Ethereum wallet.
+
+**Why this priority**: Primary monetisation flow for users; the headline
+DeFi feature.
+
+**Independent Test**: With a known collateral position, borrow a calibrated
+amount; verify pre-submit health factor preview matches post-submit state.
+
+**Acceptance Scenarios**:
+
+1. **Given** a collateral position, **When** the borrow form renders,
+   **Then** the available borrow limit is calculated from collateral value
+   and liquidation threshold, not hardcoded.
+2. **Given** the user types a borrow amount, **When** the form
+   recalculates, **Then** the health factor preview updates in real time.
+3. **Given** the resulting health factor would fall below 1.25, **When**
+   the user attempts to submit, **Then** borrowing is blocked.
+4. **Given** a valid borrow is submitted, **When** the transaction
+   confirms, **Then** the new loan appears in the loans section.
+
+---
+
+### User Story BT-16 - Repay borrowed ERC-20 (Priority: P1)
+
+From the loan card the user enters a partial or full repayment amount for
+any borrowed asset and submits an Ethereum repay transaction. Repaying
+improves the health factor and reduces liquidation risk.
+
+**Why this priority**: Required to close out positions and respond to
+liquidation risk.
+
+**Independent Test**: With an open loan, run partial and full repayment;
+verify post-repay debt and health factor.
+
+**Acceptance Scenarios**:
+
+1. **Given** an open loan, **When** the repay form renders, **Then** the
+   user can select full repayment with a single click.
+2. **Given** a repayment amount is entered, **When** the form
+   recalculates, **Then** the health factor preview updates to reflect the
+   post-repayment state.
+3. **Given** the repay transaction confirms, **When** state refreshes,
+   **Then** the displayed debt balance is reduced.
+4. **Given** the user enters more than the outstanding debt, **When**
+   validation runs, **Then** submission is prevented.
+
+### Edge Cases
+
+- The borrow asset's price moves significantly between preview and submit.
+- A borrow transaction is in flight when the user opens a repay form.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Borrow limit MUST be derived from on-chain collateral value
+  and liquidation threshold.
+- **FR-002**: Health factor preview MUST update in real time on input
+  change.
+- **FR-003**: System MUST block submission when the resulting health
+  factor would be below 1.25.
+- **FR-004**: System MUST prevent repayment of more than the outstanding
+  debt.
+
+### Key Entities
+
+- **Loan**: Borrowed asset, amount outstanding, accrued interest, parent
+  collateral position.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Borrow preview matches post-confirmation health factor within
+  the precision of on-chain pricing.
+- **SC-002**: 100% of attempted borrows that would cross the 1.25 threshold
+  are blocked client-side.
+
+## Assumptions
+
+- Aave reserve and liquidation parameters are read from the Aave protocol,
+  not hardcoded.
+- Asset price updates are timely enough that the preview is meaningful.

--- a/specs/007-aave-position-monitoring/spec.md
+++ b/specs/007-aave-position-monitoring/spec.md
@@ -1,0 +1,100 @@
+# Feature Specification: Aave - Position Monitoring
+
+**Feature Branch**: `007-aave-position-monitoring`
+**Created**: 2026-05-05
+**Status**: Implemented (retroactive)
+**Input**: Migrated from `stories.yaml` (BT-17, BT-18)
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story BT-17 - Real-time health factor warnings (Priority: P1)
+
+A persistent banner appears when the health factor approaches or breaches
+the liquidation threshold (1.25). The banner severity (info / warning /
+critical) changes with the calculated risk level and tells the user what
+action to take.
+
+**Why this priority**: Direct safety surface; reduces avoidable
+liquidations.
+
+**Independent Test**: Drive the health factor across each band and verify
+banner presence, severity, and message content.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user's health factor is above 2.0 with no risk, **When**
+   the page renders, **Then** the banner is absent.
+2. **Given** the health factor is between 1.25 and 2.0, **When** the page
+   renders, **Then** a warning banner appears.
+3. **Given** the health factor is at or below 1.25, **When** the page
+   renders, **Then** a critical banner appears.
+4. **Given** any banner is shown, **When** it renders, **Then** the
+   message includes the current health factor value and a suggested
+   remediation.
+
+---
+
+### User Story BT-18 - Cascading liquidation risk simulation (Priority: P2)
+
+When multiple vaults are used as collateral, the position notification
+system simulates the sequential seizure of vaults to predict whether a
+single liquidation event could cascade and consume additional collateral.
+This is surfaced in the notification banner.
+
+**Why this priority**: Incremental safety insight; limited to multi-vault
+users.
+
+**Independent Test**: Configure ordered multi-vault scenarios that trigger
+a cascade and verify the banner identifies the count of at-risk vaults.
+
+**Acceptance Scenarios**:
+
+1. **Given** an ordered list of vaults and current debt at the current
+   price, **When** simulation runs, **Then** it iterates over the user's
+   ordered vault list.
+2. **Given** seizing one vault still leaves health factor below 1.25,
+   **When** the simulation finishes, **Then** the cascade warning is
+   shown.
+3. **Given** a cascade is predicted, **When** the warning renders, **Then**
+   it identifies how many vaults are at risk, not just that risk exists.
+4. **Given** collateral value, debt, or vault order changes, **When** state
+   refreshes, **Then** the simulation result updates.
+
+### Edge Cases
+
+- A price oracle update mid-simulation flips the cascade outcome.
+- A vault transitions out of ACTIVE during the simulation window.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST classify health factor into three bands and
+  surface a banner per band.
+- **FR-002**: Banner copy MUST include the current health factor and a
+  suggested remediation.
+- **FR-003**: Cascade simulation MUST iterate the user's ordered vault list.
+- **FR-004**: Cascade warning MUST report the count of at-risk vaults, not
+  a binary risk flag.
+
+### Key Entities
+
+- **Risk Banner**: Severity, message, current health factor, suggested
+  remediation.
+- **Cascade Simulation Result**: At-risk vault count, terminal health
+  factor under sequential seizure, snapshot inputs.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Banner severity changes within one poll interval of the
+  underlying state change.
+- **SC-002**: Cascade prediction matches a manual walk-through of the
+  ordered vaults for a sampled set of test scenarios.
+
+## Assumptions
+
+- Price oracle latency is consistent enough to make the simulation useful.
+- Vault ordering reflects the same order that on-chain liquidation would
+  follow.

--- a/specs/008-withdraw/spec.md
+++ b/specs/008-withdraw/spec.md
@@ -1,0 +1,100 @@
+# Feature Specification: Withdraw Flow (Vault → BTC)
+
+**Feature Branch**: `008-withdraw`
+**Created**: 2026-05-05
+**Status**: Implemented (retroactive)
+**Input**: Migrated from `stories.yaml` (BT-19, BT-20)
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story BT-19 - Initiate vault withdrawal (pegout) (Priority: P1)
+
+From the withdraw flow the user selects one or more ACTIVE vaults to redeem
+and triggers the pegout process. The vault provider then orchestrates the
+on-chain claim and payout broadcast back to the user's Bitcoin address.
+
+**Why this priority**: Required for users to recover their BTC; mirrors the
+deposit path.
+
+**Independent Test**: With ACTIVE vaults and signed payouts on file,
+initiate withdrawal and verify the expected return amount and the resulting
+state transition.
+
+**Acceptance Scenarios**:
+
+1. **Given** the withdraw selection list, **When** it renders, **Then**
+   only vaults in ACTIVE state with signed payouts on file are selectable.
+2. **Given** selected vaults, **When** the user reviews the request,
+   **Then** the expected BTC return amount (net of fees) is displayed
+   before confirmation.
+3. **Given** the user confirms, **When** the request is submitted, **Then**
+   the vault transitions to a pending-pegout state on the Ethereum side.
+4. **Given** the state transitions, **When** the dashboard polls, **Then**
+   the UI reflects the updated status without a page reload.
+
+---
+
+### User Story BT-20 - Monitor in-flight withdrawal (Priority: P1)
+
+After initiating a withdrawal, the user can see the pegout lifecycle
+progressing through its seven states (`ClaimEventReceived` →
+`ClaimBroadcast` → `AssertBroadcast` → `PayoutBroadcast` or `Failed`).
+Polling continues automatically until a terminal state is reached.
+
+**Why this priority**: Without progress visibility, users cannot
+distinguish a healthy pegout from a stalled one.
+
+**Independent Test**: Drive a pegout through each state and verify display
+labels, terminal-state stop, and the stalled-detection thresholds.
+
+**Acceptance Scenarios**:
+
+1. **Given** a withdrawing vault, **When** the dashboard polls, **Then**
+   the current pegout state is displayed next to the vault.
+2. **Given** a terminal state (`PayoutBroadcast` or `Failed`), **When**
+   the state is observed, **Then** polling stops automatically.
+3. **Given** 10 consecutive polling failures or 20 unknown-status
+   responses, **When** the threshold is crossed, **Then** the UI marks the
+   withdrawal as effectively stalled and prompts the user to contact
+   support.
+4. **Given** `PayoutBroadcast` confirms, **When** state refreshes, **Then**
+   the vault status updates to REDEEMED and the BTC TXID is shown.
+
+### Edge Cases
+
+- A vault was ACTIVE at selection time but is no longer ACTIVE at submit.
+- The pegout TXID is provided but the BTC node has not yet seen it.
+- The indexer returns an unknown status code repeatedly.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Only ACTIVE vaults with signed payouts MUST be selectable.
+- **FR-002**: Expected return MUST be computed net of fees and shown
+  before confirmation.
+- **FR-003**: Polling MUST stop on terminal states.
+- **FR-004**: System MUST mark a withdrawal as stalled after 10 consecutive
+  polling failures or 20 unknown-status responses, and prompt the user to
+  contact support.
+
+### Key Entities
+
+- **Pegout Session**: Selected vaults, expected BTC return, current
+  pegout state, polling counters, BTC TXID (when available).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Healthy pegouts always end on `PayoutBroadcast` and surface
+  a BTC TXID.
+- **SC-002**: Stalled pegouts surface the support prompt within the
+  documented thresholds.
+
+## Assumptions
+
+- The vault provider broadcasts payouts in a timely manner once the on-
+  chain claim is confirmed.
+- The indexer or RPC provides distinguishable status codes for each
+  pegout state.

--- a/specs/009-activity/spec.md
+++ b/specs/009-activity/spec.md
@@ -1,0 +1,74 @@
+# Feature Specification: Activity Log
+
+**Feature Branch**: `009-activity`
+**Created**: 2026-05-05
+**Status**: Implemented (retroactive)
+**Input**: Migrated from `stories.yaml` (BT-21)
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story BT-21 - Chronological activity log of vault events (Priority: P2)
+
+The Activity page lists every significant event across the user's vaults -
+peg-in creation, confirmation, activation, peg-out initiation and
+completion, Aave borrow and repay operations, liquidations, and expirations
+- with timestamps and amounts.
+
+**Why this priority**: Auditing surface; not on the primary deposit or
+borrow path but essential for transparency.
+
+**Independent Test**: Generate one event of each type and verify all
+appear in a single ordered list, sourced from the indexer.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user has events of each type, **When** the Activity
+   page renders, **Then** all event types (deposit, withdraw, borrow,
+   repay, liquidation, expiration) appear in a single unified list.
+2. **Given** a row in the list, **When** it renders, **Then** it shows
+   event type, amount, status, and timestamp.
+3. **Given** the page loads, **When** events are fetched, **Then** they
+   come from the indexer, not reconstructed from local storage alone.
+4. **Given** multiple events, **When** the list renders, **Then** the
+   ordering is most-recent-first.
+
+### Edge Cases
+
+- A disconnected user visits the activity page (empty state).
+- A connected user has no events yet (zero-state).
+- The indexer is unreachable or returns partial data.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST list deposit, withdraw, borrow, repay,
+  liquidation, and expiration events in a single unified list.
+- **FR-002**: Each row MUST show event type, amount, status, and
+  timestamp.
+- **FR-003**: Events MUST be sourced from the indexer; local storage
+  alone is not authoritative.
+- **FR-004**: Ordering MUST be most-recent-first.
+- **FR-005**: System MUST distinguish disconnected vs connected-but-empty
+  states with appropriate empty-state copy.
+
+### Key Entities
+
+- **Activity Event**: Type (deposit | withdraw | borrow | repay |
+  liquidation | expiration), amount, status, timestamp, source vault or
+  loan reference.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: The list reflects new events within one indexer refresh
+  interval of their occurrence.
+- **SC-002**: Empty-state copy is distinct for disconnected vs no-activity
+  cases.
+
+## Assumptions
+
+- The indexer is the system of record for activity events.
+- Local storage is used only for transient session resilience, not as a
+  primary source.

--- a/specs/010-compliance/spec.md
+++ b/specs/010-compliance/spec.md
@@ -1,0 +1,77 @@
+# Feature Specification: Geofencing & Compliance
+
+**Feature Branch**: `010-compliance`
+**Created**: 2026-05-05
+**Status**: Implemented (retroactive)
+**Input**: Migrated from `stories.yaml` (BT-22)
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story BT-22 - Block restricted jurisdictions and flagged addresses (Priority: P1)
+
+The app checks the user's geolocation and screens their wallet addresses
+against sanctions lists on load. Users in restricted regions or with
+flagged addresses are shown a block screen rather than the dApp.
+
+**Why this priority**: Legal/compliance requirement; supersedes feature
+access.
+
+**Independent Test**: With a fixture for a restricted region or flagged
+address, verify the block screen replaces the dApp and that no
+client-side state can bypass the check.
+
+**Acceptance Scenarios**:
+
+1. **Given** the app is loading, **When** geolocation runs, **Then** the
+   geolocation check completes before any wallet connection is
+   permitted.
+2. **Given** a user from a restricted region, **When** the block screen
+   renders, **Then** it presents a clear explanation that the service is
+   unavailable in their region.
+3. **Given** a connected wallet, **When** address screening runs, **Then**
+   interaction is blocked if the address is flagged.
+4. **Given** geolocation or sanctions results, **When** they are stored,
+   **Then** they are not stored in a way the user can tamper with on the
+   client side to bypass the check.
+
+### Edge Cases
+
+- The geolocation provider is unreachable.
+- The sanctions screening service times out.
+- A user connects an address that is flagged after a previously-allowed
+  session.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST run geolocation before allowing any wallet
+  connection.
+- **FR-002**: Restricted users MUST see a block screen with a clear
+  explanation, not a generic error.
+- **FR-003**: System MUST screen wallet addresses against sanctions
+  lists after connection and block interaction on a flag.
+- **FR-004**: Compliance check results MUST not be stored client-side in
+  a way that can be tampered with to bypass the check.
+- **FR-005**: System MUST fail closed if any compliance check service is
+  unreachable.
+
+### Key Entities
+
+- **Compliance Result**: Geolocation outcome, sanctions outcome, source
+  (region or address), tamper-resistant identifier.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 0% of restricted-region or flagged-address sessions reach
+  the dApp.
+- **SC-002**: Compliance failures fail closed; no fallback grants access.
+
+## Assumptions
+
+- Geolocation and sanctions screening providers are configured and
+  reachable in production.
+- The compliance policy on which regions and which lists apply is set
+  outside this spec.


### PR DESCRIPTION
## What this is

The actual project content for our spec-driven workflow. Stacked on top of #<PR1> (Spec Kit toolchain) - merge that first.

This PR adds:

- **`.specify/memory/constitution.md`** - the project's principles. Codifies the rules we already follow informally: critical-path human review, dead-code policy, no magic numbers, no silent fallbacks on critical paths, etc. Spec Kit's `/speckit-*` commands enforce these as gates throughout the workflow.

- **10 feature specs in `specs/`** - one per critical user story, written in Spec Kit's spec template format. Each one captures user scenarios, acceptance scenarios, and functional requirements. These are the specs the e2e tests (in a follow-up PR) will be linked back to.

  - `001-wallet-connection`, `002-application-selection`, `003-deposit`, `004-vault-lifecycle`, `005-aave-collateral`, `006-aave-borrow`, `007-aave-position-monitoring`, `008-withdraw`, `009-activity`, `010-compliance`

- **`CLAUDE.md`** - new "SPEC-DRIVEN DEVELOPMENT" section so Claude Code picks up the workflow context.

## How to review

This is the substantive review for the spec-driven setup - read the specs and the constitution carefully.

- **Constitution**: are these the principles we actually want to enforce? Is anything missing or overly strict?
- **Each spec.md**: do the user scenarios and acceptance criteria match how the feature actually behaves? Are there gaps?
- **CLAUDE.md addition**: does the SDD section accurately describe how we expect Claude to use the workflow?

Specs are the source of truth for the e2e tests in the next PRs - if a scenario is wrong here, the test will be wrong too.

## What lands next

1. `pnpm spec-coverage` script + CLAUDE.md coverage section (the "BT-XX-ACn" tag convention check)
2. E2E tests, split by feature group