### PR TITLE
fix(vault): integrate fetchVaultsByDepositor for cross-context UTXO reservation handling

### DIFF
--- a/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
@@ -69,6 +69,10 @@ vi.mock("@/services/vault/vaultActivationService", () => ({
     .mockResolvedValue({ hash: "0xActivationTxHash" }),
 }));
 
+vi.mock("@/services/vault/fetchVaults", () => ({
+  fetchVaultsByDepositor: vi.fn().mockResolvedValue([]),
+}));
+
 vi.mock("@/services/vault/vaultPeginBroadcastService", () => ({
   broadcastPrePeginTransaction: vi.fn().mockResolvedValue("mockBroadcastTxId"),
   utxosToExpectedRecord: vi.fn(
@@ -1002,6 +1006,7 @@ describe("useDepositFlow", () => {
       await waitFor(() => {
         expect(getPendingPegins).toHaveBeenCalledWith("0xEthAddress123");
         expect(collectReservedUtxoRefs).toHaveBeenCalledWith({
+          vaults: [],
           pendingPegins: mockPendingPegins,
           utxoReservations: [],
         });
@@ -1044,6 +1049,82 @@ describe("useDepositFlow", () => {
           "All available UTXOs are reserved",
         );
       });
+    });
+
+    it("forwards indexer-supplied PENDING/VERIFIED vaults to collectReservedUtxoRefs (cross-context reservation)", async () => {
+      // Cleared-localStorage / second-browser scenario: getPendingPegins and
+      // getUtxoReservations are empty, but the indexer reports a PENDING vault
+      // already registered for this depositor. The deposit flow must hand
+      // those vaults to collectReservedUtxoRefs so their on-chain Pre-PegIn
+      // inputs participate in the reservation set; otherwise the same UTXOs
+      // would be re-selected and the second registered vault would be
+      // unfundable.
+      const { fetchVaultsByDepositor } = vi.mocked(
+        await import("@/services/vault/fetchVaults"),
+      );
+      const { collectReservedUtxoRefs } = vi.mocked(
+        await import("@babylonlabs-io/ts-sdk/tbv/core/utils"),
+      );
+
+      const indexerVaults = [
+        {
+          id: "0xexistingvault",
+          status: 0, // ContractStatus.PENDING
+          unsignedPrePeginTx: "0xexistingvaultprepeginhex",
+        },
+      ];
+      vi.mocked(fetchVaultsByDepositor).mockResolvedValueOnce(
+        indexerVaults as any,
+      );
+
+      const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
+
+      await executeWithAutoArtifactDownload(result);
+
+      await waitFor(() => {
+        expect(fetchVaultsByDepositor).toHaveBeenCalledWith("0xEthAddress123");
+        expect(collectReservedUtxoRefs).toHaveBeenCalledWith({
+          vaults: indexerVaults,
+          pendingPegins: [],
+          utxoReservations: [],
+        });
+      });
+    });
+
+    it("fails closed and skips UTXO selection when fetchVaultsByDepositor throws (indexer outage)", async () => {
+      // If the indexer is unavailable we can't prove a registered-but-
+      // unbroadcast Pre-PegIn doesn't already encumber these UTXOs. Block
+      // the deposit instead of silently degrading to the local-only
+      // reservation set — that's the failure mode the audit is about.
+      const { fetchVaultsByDepositor } = vi.mocked(
+        await import("@/services/vault/fetchVaults"),
+      );
+      const { collectReservedUtxoRefs } = vi.mocked(
+        await import("@babylonlabs-io/ts-sdk/tbv/core/utils"),
+      );
+      const { preparePeginTransaction } = vi.mocked(
+        await import("@/services/vault/vaultTransactionService"),
+      );
+      const { registerPeginBatchAndWait } = vi.mocked(
+        await import("../depositFlowSteps"),
+      );
+
+      vi.mocked(fetchVaultsByDepositor).mockRejectedValueOnce(
+        new Error("indexer 503"),
+      );
+
+      const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
+
+      await executeWithAutoArtifactDownload(result);
+
+      await waitFor(() => {
+        expect(result.current.error).toMatch(
+          /Failed to fetch existing vaults for cross-context UTXO reservation/,
+        );
+      });
+      expect(collectReservedUtxoRefs).not.toHaveBeenCalled();
+      expect(preparePeginTransaction).not.toHaveBeenCalled();
+      expect(registerPeginBatchAndWait).not.toHaveBeenCalled();
     });
   });
 });

--- a/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
@@ -70,7 +70,7 @@ vi.mock("@/services/vault/vaultActivationService", () => ({
 }));
 
 vi.mock("@/services/vault/fetchVaults", () => ({
-  fetchVaultsByDepositor: vi.fn().mockResolvedValue([]),
+  fetchVaultsByDepositorStrict: vi.fn().mockResolvedValue([]),
 }));
 
 vi.mock("@/services/vault/vaultPeginBroadcastService", () => ({
@@ -1059,7 +1059,7 @@ describe("useDepositFlow", () => {
       // inputs participate in the reservation set; otherwise the same UTXOs
       // would be re-selected and the second registered vault would be
       // unfundable.
-      const { fetchVaultsByDepositor } = vi.mocked(
+      const { fetchVaultsByDepositorStrict } = vi.mocked(
         await import("@/services/vault/fetchVaults"),
       );
       const { collectReservedUtxoRefs } = vi.mocked(
@@ -1073,7 +1073,7 @@ describe("useDepositFlow", () => {
           unsignedPrePeginTx: "0xexistingvaultprepeginhex",
         },
       ];
-      vi.mocked(fetchVaultsByDepositor).mockResolvedValueOnce(
+      vi.mocked(fetchVaultsByDepositorStrict).mockResolvedValueOnce(
         indexerVaults as any,
       );
 
@@ -1082,7 +1082,9 @@ describe("useDepositFlow", () => {
       await executeWithAutoArtifactDownload(result);
 
       await waitFor(() => {
-        expect(fetchVaultsByDepositor).toHaveBeenCalledWith("0xEthAddress123");
+        expect(fetchVaultsByDepositorStrict).toHaveBeenCalledWith(
+          "0xEthAddress123",
+        );
         expect(collectReservedUtxoRefs).toHaveBeenCalledWith({
           vaults: indexerVaults,
           pendingPegins: [],
@@ -1091,12 +1093,12 @@ describe("useDepositFlow", () => {
       });
     });
 
-    it("fails closed and skips UTXO selection when fetchVaultsByDepositor throws (indexer outage)", async () => {
+    it("fails closed and skips UTXO selection when fetchVaultsByDepositorStrict throws (indexer outage)", async () => {
       // If the indexer is unavailable we can't prove a registered-but-
       // unbroadcast Pre-PegIn doesn't already encumber these UTXOs. Block
       // the deposit instead of silently degrading to the local-only
       // reservation set — that's the failure mode the audit is about.
-      const { fetchVaultsByDepositor } = vi.mocked(
+      const { fetchVaultsByDepositorStrict } = vi.mocked(
         await import("@/services/vault/fetchVaults"),
       );
       const { collectReservedUtxoRefs } = vi.mocked(
@@ -1109,7 +1111,7 @@ describe("useDepositFlow", () => {
         await import("../depositFlowSteps"),
       );
 
-      vi.mocked(fetchVaultsByDepositor).mockRejectedValueOnce(
+      vi.mocked(fetchVaultsByDepositorStrict).mockRejectedValueOnce(
         new Error("indexer 503"),
       );
 
@@ -1119,7 +1121,7 @@ describe("useDepositFlow", () => {
 
       await waitFor(() => {
         expect(result.current.error).toMatch(
-          /Failed to fetch existing vaults for cross-context UTXO reservation/,
+          /Unable to verify existing deposits/,
         );
       });
       expect(collectReservedUtxoRefs).not.toHaveBeenCalled();

--- a/services/vault/src/hooks/deposit/useDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useDepositFlow.ts
@@ -49,6 +49,7 @@ import { useProtocolParamsContext } from "@/context/ProtocolParamsContext";
 import { logger } from "@/infrastructure";
 import { LocalStorageStatus } from "@/models/peginStateMachine";
 import { validateMultiVaultDepositInputs } from "@/services/deposit/validations";
+import { fetchVaultsByDepositor } from "@/services/vault/fetchVaults";
 import type { PayoutSigningProgress } from "@/services/vault/vaultPayoutSignatureService";
 import {
   broadcastPrePeginTransaction,
@@ -344,10 +345,28 @@ export function useDepositFlow(
         };
 
         // Filter out UTXOs reserved by in-flight deposits to prevent
-        // double-spend failures across concurrent sessions/tabs.
+        // double-spend failures across concurrent sessions/tabs and across
+        // browser contexts (cleared storage, second profile, second device).
+        // Local browser state covers the same-context case; the indexer-supplied
+        // vault list covers the cross-context case where localStorage is empty
+        // but a PENDING/VERIFIED vault is already registered on Ethereum.
+        // Force a fresh read here (do NOT rely on the React Query cache) so
+        // staleness cannot reintroduce the cross-context double-spend window.
+        // Indexer unavailability is fail-closed: better to block the deposit
+        // than to silently skip the on-chain reservation set.
         const pendingPegins = getPendingPegins(confirmedEthAddress);
         const utxoReservations = getUtxoReservations(confirmedEthAddress);
+        let depositorVaults;
+        try {
+          depositorVaults = await fetchVaultsByDepositor(confirmedEthAddress);
+        } catch (err) {
+          const errorMsg = err instanceof Error ? err.message : String(err);
+          throw new Error(
+            `Failed to fetch existing vaults for cross-context UTXO reservation; aborting to avoid stranding a duplicate registration. Indexer error: ${errorMsg}`,
+          );
+        }
         const reservedUtxoRefs = collectReservedUtxoRefs({
+          vaults: depositorVaults,
           pendingPegins,
           utxoReservations,
         });

--- a/services/vault/src/hooks/deposit/useDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useDepositFlow.ts
@@ -49,7 +49,7 @@ import { useProtocolParamsContext } from "@/context/ProtocolParamsContext";
 import { logger } from "@/infrastructure";
 import { LocalStorageStatus } from "@/models/peginStateMachine";
 import { validateMultiVaultDepositInputs } from "@/services/deposit/validations";
-import { fetchVaultsByDepositor } from "@/services/vault/fetchVaults";
+import { fetchVaultsByDepositorStrict } from "@/services/vault/fetchVaults";
 import type { PayoutSigningProgress } from "@/services/vault/vaultPayoutSignatureService";
 import {
   broadcastPrePeginTransaction,
@@ -65,6 +65,7 @@ import {
   removeUtxoReservation,
   updatePendingPeginStatus,
 } from "@/storage/peginStorage";
+import type { Vault } from "@/types/vault";
 import { btcAddressToScriptPubKeyHex, stripHexPrefix } from "@/utils/btc";
 import { satoshiToBtcNumber } from "@/utils/btcConversion";
 import { sanitizeErrorMessage } from "@/utils/errors/formatting";
@@ -356,13 +357,21 @@ export function useDepositFlow(
         // than to silently skip the on-chain reservation set.
         const pendingPegins = getPendingPegins(confirmedEthAddress);
         const utxoReservations = getUtxoReservations(confirmedEthAddress);
-        let depositorVaults;
+        let depositorVaults: Vault[];
         try {
-          depositorVaults = await fetchVaultsByDepositor(confirmedEthAddress);
+          depositorVaults =
+            await fetchVaultsByDepositorStrict(confirmedEthAddress);
         } catch (err) {
           const errorMsg = err instanceof Error ? err.message : String(err);
+          logger.error(err instanceof Error ? err : new Error(errorMsg), {
+            tags: {
+              component: "useDepositFlow",
+              phase: "reservation-fetch",
+            },
+            data: { ethAddress: confirmedEthAddress },
+          });
           throw new Error(
-            `Failed to fetch existing vaults for cross-context UTXO reservation; aborting to avoid stranding a duplicate registration. Indexer error: ${errorMsg}`,
+            `Unable to verify existing deposits. Please try again. (${errorMsg})`,
           );
         }
         const reservedUtxoRefs = collectReservedUtxoRefs({

--- a/services/vault/src/services/vault/__tests__/fetchVaults.test.ts
+++ b/services/vault/src/services/vault/__tests__/fetchVaults.test.ts
@@ -7,6 +7,7 @@ import {
   fetchVaultById,
   fetchVaultRefundData,
   fetchVaultsByDepositor,
+  fetchVaultsByDepositorStrict,
 } from "../fetchVaults";
 
 vi.mock("../../../clients/graphql/client", () => ({
@@ -248,6 +249,106 @@ describe("fetchVaults", () => {
             component: "fetchVaults",
           }),
           data: expect.objectContaining({ rawStatus: "bogus_status" }),
+        }),
+      );
+    });
+  });
+
+  describe("fetchVaultsByDepositorStrict", () => {
+    // Sanity check: with healthy data the strict and forgiving variants
+    // produce equivalent output. The strict guarantee only kicks in when
+    // a row that contributes to the UTXO reservation set fails to transform.
+    it("returns the same vaults as the forgiving variant on a clean response", async () => {
+      const id1 = "0x" + "11".repeat(32);
+      const id2 = "0x" + "22".repeat(32);
+      mockedRequest.mockResolvedValue({
+        vaults: {
+          items: [
+            makeGraphQLVaultItem({ id: id1, status: "pending" }),
+            makeGraphQLVaultItem({ id: id2, status: "available" }),
+          ],
+          totalCount: 2,
+        },
+      });
+
+      const strict = await fetchVaultsByDepositorStrict(
+        "0xdepositor" as `0x${string}`,
+      );
+      const lenient = await fetchVaultsByDepositor(
+        "0xdepositor" as `0x${string}`,
+      );
+
+      expect(strict).toHaveLength(2);
+      expect(strict.map((v) => v.id)).toEqual([id1, id2]);
+      expect(strict).toEqual(lenient);
+    });
+
+    // PENDING and VERIFIED rows feed the reservation set; silently dropping
+    // one would let the depositor re-select the same UTXOs and double-
+    // register on Ethereum. This is the bug the strict variant exists to
+    // prevent.
+    it.each([
+      ["pending", "depositorWotsPkHash"],
+      ["signatures_collected", "depositorWotsPkHash"],
+      ["verified", "depositorWotsPkHash"],
+    ])(
+      "throws when a %s vault fails to transform (reservation-relevant)",
+      async (status, badField) => {
+        mockedRequest.mockResolvedValueOnce({
+          vaults: {
+            items: [
+              makeGraphQLVaultItem({
+                status,
+                [badField]: null,
+              }),
+            ],
+            totalCount: 1,
+          },
+        });
+
+        await expect(
+          fetchVaultsByDepositorStrict("0xdepositor" as `0x${string}`),
+        ).rejects.toThrow(
+          new RegExp(
+            `Reservation-relevant vault .* \\(status="${status}"\\) failed to transform`,
+          ),
+        );
+      },
+    );
+
+    // Non-reservation statuses never contribute to the reservation set, so a
+    // transform failure there has no security impact and the strict variant
+    // matches the forgiving variant: log and skip.
+    it("logs and skips when a non-reservation-relevant vault fails to transform", async () => {
+      const goodId = "0x" + "11".repeat(32);
+      const badId = "0x" + "22".repeat(32);
+      mockedRequest.mockResolvedValueOnce({
+        vaults: {
+          items: [
+            makeGraphQLVaultItem({ id: goodId, status: "pending" }),
+            makeGraphQLVaultItem({
+              id: badId,
+              status: "redeemed",
+              peginTxHash: null,
+            }),
+          ],
+          totalCount: 2,
+        },
+      });
+
+      const vaults = await fetchVaultsByDepositorStrict(
+        "0xdepositor" as `0x${string}`,
+      );
+
+      expect(vaults).toHaveLength(1);
+      expect(vaults[0].id).toBe(goodId);
+      expect(mockedLoggerError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining("peginTxHash"),
+        }),
+        expect.objectContaining({
+          tags: expect.objectContaining({ vaultId: badId }),
+          data: expect.objectContaining({ rawStatus: "redeemed" }),
         }),
       );
     });

--- a/services/vault/src/services/vault/fetchVaults.ts
+++ b/services/vault/src/services/vault/fetchVaults.ts
@@ -391,6 +391,66 @@ export async function fetchVaultsByDepositor(
 }
 
 /**
+ * GraphQL status strings that map to vault states which contribute to the
+ * UTXO reservation set (`ContractStatus.PENDING` / `ContractStatus.VERIFIED`
+ * in the SDK). A transform failure on any of these is security-relevant —
+ * silently dropping such a vault would let the depositor re-select the
+ * same Bitcoin outpoints and double-register on Ethereum.
+ */
+const RESERVATION_RELEVANT_STATUSES: ReadonlySet<GraphQLVaultStatus> = new Set([
+  "pending",
+  "signatures_collected",
+  "verified",
+]);
+
+/**
+ * Strict variant of {@link fetchVaultsByDepositor} for security-critical
+ * callers.
+ *
+ * Same network shape as the forgiving variant, but the per-item
+ * transform-failure policy is split by status:
+ * - PENDING/VERIFIED rows whose payload fails to transform → throw, so the
+ *   caller fails closed instead of silently treating the row as absent.
+ * - All other statuses (REDEEMED, LIQUIDATED, EXPIRED, …) → log and skip,
+ *   matching the forgiving variant. These rows do not contribute to the
+ *   reservation set, so a missing entry has no security impact.
+ *
+ * Use this from any path where "vault present but skipped" is unsafe.
+ * The dashboard list path should keep using the forgiving
+ * {@link fetchVaultsByDepositor} so one bad row never blanks the page.
+ */
+export async function fetchVaultsByDepositorStrict(
+  depositorAddress: Address,
+): Promise<Vault[]> {
+  const data = await graphqlClient.request<VaultsGraphQLResponse>(
+    GET_VAULTS_BY_DEPOSITOR,
+    { depositor: depositorAddress.toLowerCase() },
+  );
+
+  const vaults: Vault[] = [];
+  for (const item of data.vaults.items) {
+    try {
+      vaults.push(transformVaultItem(item));
+    } catch (error) {
+      const isReservationRelevant = RESERVATION_RELEVANT_STATUSES.has(
+        item.status,
+      );
+      if (isReservationRelevant) {
+        const reason = error instanceof Error ? error.message : String(error);
+        throw new Error(
+          `Reservation-relevant vault ${item.id} (status="${item.status}") failed to transform: ${reason}`,
+        );
+      }
+      logger.error(error instanceof Error ? error : new Error(String(error)), {
+        tags: { vaultId: item.id, component: "fetchVaults" },
+        data: { rawStatus: item.status },
+      });
+    }
+  }
+  return vaults;
+}
+
+/**
  * Fetch a single vault by ID from GraphQL
  *
  * @param vaultId - Vault ID (derived: keccak256(abi.encode(peginTxHash, depositor)))


### PR DESCRIPTION
# Summary

`useDepositFlow` rebuilt its reserved-UTXO set from browser-local sources only (`getPendingPegins` + `getUtxoReservations`, both keyed on the current browser's localStorage) and called `collectReservedUtxoRefs` without the `vaults` argument. The SDK already supports a canonical on-chain branch — when `vaults` are supplied, PENDING/VERIFIED vaults contribute input refs parsed from the indexer-supplied `unsignedPrePeginTx` — but the deposit hook never fed it that data. Any user whose localStorage didn't carry the prior PENDING entry (cleared site data, second browser/profile/device, incognito, or just a deferred broadcast in another tab) re-selected the same outpoints, signed a duplicate Pre-PegIn, and paid gas to register a second ETH vault that could never be funded on Bitcoin.

This PR wires the cross-context reservation by fetching the depositor's vaults via the indexer (`fetchVaultsByDepositor`) inside `executeDeposit` and passing the result to `collectReservedUtxoRefs`. The fetch happens as a fresh read (not via the React Query cache, whose 60s `staleTime` would otherwise re-open the gap) and is fail-closed: if the indexer is unavailable, the deposit aborts before any UTXO selection or signing.

# Issue

- https://github.com/babylonlabs-io/baby-auditor-findings/issues/275

# Analysis

Pre-fix call site at `services/vault/src/hooks/deposit/useDepositFlow.ts` invoked:

```ts
const reservedUtxoRefs = collectReservedUtxoRefs({
  pendingPegins,
  utxoReservations,
});
```

with `pendingPegins = getPendingPegins(confirmedEthAddress)` and `utxoReservations = getUtxoReservations(confirmedEthAddress)`. Both readers go through localStorage scoped to one ETH address in one browser profile.

The capability to bridge browser contexts already exists in the SDK at `packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts:193-201`:

```ts
for (const vault of vaults) {
  if (
    vault.status !== ContractStatus.PENDING &&
    vault.status !== ContractStatus.VERIFIED
  ) {
    continue;
  }
  reserved.push(...extractInputUtxoRefs(vault.unsignedPrePeginTx));
}
```

The deposit hook simply never supplied `vaults`. Likewise, the pre-ETH guard `assertUtxosAvailable` at `services/vault/src/services/vault/vaultUtxoValidationService.ts:27-34` queries mempool only — a registered-but-unbroadcast Pre-PegIn has not spent the funding outpoint on Bitcoin yet, so this check happily passes the duplicate registration through.

`fetchVaultsByDepositor` is already wired in the codebase (`services/vault/src/services/vault/fetchVaults.ts:371-391`), already used indirectly via `useVaults` at `services/vault/src/hooks/deposit/useDepositPageFlow.ts:113`, and produces objects whose `id`, `status`, and `unsignedPrePeginTx` shape is exactly what `collectReservedUtxoRefs` expects.

# Options Considered

- **Option A — Indexer-only, fresh fetch inside `useDepositFlow`** (chosen). Self-contained, matches the auditor's recommendation, no consumer API changes, forces a fresh read so the React Query 1-minute `staleTime` cannot reintroduce the cross-context gap.
- **Option B — Lift `useVaults` into props from `useDepositPageFlow`.** Avoids a duplicate fetch, but the cache is stale up to 60s and would still need an explicit `refetch()` to be authoritative — more wiring for the same effective outcome, and couples the hook to one entry-point caller.
- **Option C — Indexer + per-id contract cross-check** via `getBtcVaultBasicInfo`. Defense-in-depth against a compromised indexer, but the contract does not store `unsignedPrePeginTx`, so the contract layer can only confirm presence of the vault id, not byte-verify the reservation. Adds N RPC reads per attempt; defer as a follow-up.
- **Option D — Cross-browser encumbrance set keyed by BTC wallet identity.** Out of scope; introduces a new cross-trust dependency.

# Chosen Approach

Option A. It is the smallest correct change consistent with the auditor's recommendation, uses data paths the codebase already exposes, requires no new RPC client, and is fail-closed by construction. It also leaves room for the duplicate-finding #276 framing (same BTC wallet across distinct ETH accounts) to be addressed by a separate BTC-pubkey-keyed query without disturbing this fix.

# Implementation

Files changed:

- `services/vault/src/hooks/deposit/useDepositFlow.ts`
  - Added `import { fetchVaultsByDepositor } from "@/services/vault/fetchVaults";`.
  - In `executeDeposit`, between the existing `getPendingPegins` / `getUtxoReservations` reads and the `collectReservedUtxoRefs` call, fetch the depositor's vaults via `fetchVaultsByDepositor(confirmedEthAddress)` inside a try/catch. On rejection, throw a wrapped error: the existing flow `catch` block surfaces the message via `setError(...)`, runs the standard cleanup, and prevents any subsequent UTXO selection, PoP signing, or ETH registration.
  - Pass the result as `vaults: depositorVaults` into `collectReservedUtxoRefs`. PENDING/VERIFIED vaults now contribute their `unsignedPrePeginTx` input refs to the reserved set even when localStorage is empty.
  - Updated the surrounding code comment to describe the broader cross-context coverage and the fail-closed posture.

Behavioral effect: a deposit attempted from a context whose localStorage does not carry an existing PENDING/VERIFIED registration but where the indexer reports such a vault for the same ETH depositor will now refuse to re-select the same outpoints, falling through to `selectUtxosForDeposit`'s "all available UTXOs are reserved" / "insufficient unreserved UTXOs" error. Indexer unavailability blocks the deposit instead of silently downgrading to the local-only reservation set.

Both new tests fail against the pre-fix code: the first because `vaults` was never forwarded; the second because there was no indexer fetch and therefore no fail-closed gate.

# Risk / Follow-up

- **Coverage**: this fix is keyed on the depositor's ETH address. It addresses the auditor's primary scenario (cleared localStorage / second-browser, same ETH depositor). The duplicate finding [#276](https://github.com/babylonlabs-io/baby-auditor-findings/issues/275) framing — same BTC wallet across distinct ETH accounts — needs a separate BTC-pubkey-keyed query and is intentionally out of scope here.
- **Indexer trust**: the cross-context reservation set is delegated to the indexer. A stale or compromised indexer could under-report and partially re-open the gap. Defense-in-depth via per-id contract reads is a viable follow-up but cannot byte-verify `unsignedPrePeginTx` against the contract because that field is not stored on-chain.
- **Pre-indexer race**: a registration the indexer has not yet observed is invisible to this fix. The local UTXO reservation written in step 4a still covers same-browser cases.
- **Latency**: one additional GraphQL round-trip is added before SIGN_POP. The flow already issues several RPC/GraphQL calls in this region, so the user-perceived effect is small.

Closes https://github.com/babylonlabs-io/baby-auditor-findings/issues/275
