### PR TITLE
fix(vault): handle utxo reservation during receipt timeouts

### DIFF
--- a/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
@@ -758,6 +758,114 @@ describe("useDepositFlow", () => {
       });
     });
 
+    it("keeps the early UTXO reservation when registerPeginBatchAndWait throws (receipt timeout window)", async () => {
+      // Regression: a post-`sendTransaction` receipt timeout
+      // means the ETH registration may already be live or pending, but no
+      // durable `addPendingPegin` record was written. Releasing the early
+      // reservation in that window would let a second deposit reuse the
+      // same outpoints and strand one ETH-registered vault. The reservation
+      // must remain so its TTL keeps the UTXOs excluded.
+      const { registerPeginBatchAndWait } = vi.mocked(
+        await import("../depositFlowSteps"),
+      );
+      const { addPendingPegin, removeUtxoReservation } = vi.mocked(
+        await import("@/storage/peginStorage"),
+      );
+
+      vi.mocked(registerPeginBatchAndWait).mockRejectedValueOnce(
+        new Error(
+          "Timed out while waiting for transaction with hash 0xabc to be confirmed.",
+        ),
+      );
+
+      const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
+
+      await executeWithAutoArtifactDownload(result);
+
+      await waitFor(() => {
+        expect(result.current.error).toBeTruthy();
+        expect(result.current.processing).toBe(false);
+      });
+
+      // No durable resume entry was written (registration threw before
+      // pending pegins are persisted).
+      expect(addPendingPegin).not.toHaveBeenCalled();
+      // And — the bug being fixed — the early reservation must not be
+      // released.
+      expect(removeUtxoReservation).not.toHaveBeenCalled();
+    });
+
+    it("releases the early UTXO reservation for failures BEFORE registration is started", async () => {
+      // Pre-send failures (e.g. UTXO availability re-check) are safe to
+      // release because no ETH transaction was submitted, so there is no
+      // ambiguity about on-chain state.
+      const { assertUtxosAvailable } = vi.mocked(
+        await import("@/services/vault/vaultUtxoValidationService"),
+      );
+      const { registerPeginBatchAndWait } = vi.mocked(
+        await import("../depositFlowSteps"),
+      );
+      const { removeUtxoReservation } = vi.mocked(
+        await import("@/storage/peginStorage"),
+      );
+
+      vi.mocked(assertUtxosAvailable).mockRejectedValueOnce(
+        new Error("UTXO no longer available"),
+      );
+
+      const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
+
+      await executeWithAutoArtifactDownload(result);
+
+      await waitFor(() => {
+        expect(result.current.error).toBeTruthy();
+      });
+
+      // Sanity: registration must not have started for this case.
+      expect(registerPeginBatchAndWait).not.toHaveBeenCalled();
+      // Pre-send failure: reservation IS released.
+      expect(removeUtxoReservation).toHaveBeenCalledWith(
+        "0xEthAddress123",
+        "mock-batch-id-uuid",
+      );
+    });
+
+    it("releases the early UTXO reservation when a post-pending failure occurs (records supersede the reservation)", async () => {
+      // Once `addPendingPegin` has persisted per-vault records, the
+      // selected UTXOs are protected by those entries. A failure after
+      // that point can safely release the early reservation.
+      const { getOffchainParamsVersionsFromChain } = vi.mocked(
+        await import("@/clients/eth-contract/btc-vault-registry/query"),
+      );
+      const { addPendingPegin, removeUtxoReservation } = vi.mocked(
+        await import("@/storage/peginStorage"),
+      );
+
+      // Force an RPC error on the version check AFTER pending pegins are
+      // written and BEFORE the success-path removeUtxoReservation call.
+      // This simulates a connection failure rather than a true version
+      // mismatch — both paths reach the catch block, so the assertion
+      // holds either way.
+      vi.mocked(getOffchainParamsVersionsFromChain).mockRejectedValueOnce(
+        new Error("eth_call failed: connection reset"),
+      );
+
+      const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
+
+      await executeWithAutoArtifactDownload(result);
+
+      await waitFor(() => {
+        expect(result.current.error).toBeTruthy();
+      });
+
+      expect(addPendingPegin).toHaveBeenCalledTimes(2);
+      // Catch path released the now-redundant reservation.
+      expect(removeUtxoReservation).toHaveBeenCalledWith(
+        "0xEthAddress123",
+        "mock-batch-id-uuid",
+      );
+    });
+
     it("should continue past payout-signing failures with warnings", async () => {
       const { signAndSubmitPayouts } = vi.mocked(
         await import("../depositFlowSteps"),

--- a/services/vault/src/hooks/deposit/useDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useDepositFlow.ts
@@ -262,6 +262,15 @@ export function useDepositFlow(
       // UTXO reservation if the flow fails after writing it.
       let reservationBatchId: string | null = null;
       let reservationEthAddress: string | null = null;
+      // True once `registerPeginBatchAndWait` has been invoked, meaning the
+      // SDK may have submitted the ETH registration tx. Used in the catch
+      // path to avoid releasing the early UTXO reservation before we know
+      // whether the registration landed on-chain.
+      let registrationStarted = false;
+      // True once durable per-vault `addPendingPegin` records have been
+      // persisted. Once set, the early reservation is fully superseded and
+      // safe to remove on failure.
+      let pendingPersisted = false;
       // Track registry entries we primed so we can release them on
       // user-cancel (bound `authAnchorHex` lifetime to the flow).
       const primedRegistryTxids: string[] = [];
@@ -442,6 +451,13 @@ export function useDepositFlow(
 
         // 3e. Single batch ETH transaction for all vaults.
         setCurrentStep(DepositFlowStep.SUBMIT_PEGIN);
+        // Mark registration as started BEFORE the SDK call. From this point
+        // forward the ETH tx may be in the mempool or mined even if the call
+        // throws (e.g. `waitForTransactionReceipt` timeout after
+        // `sendTransaction` returned). The catch path uses this flag to keep
+        // the early UTXO reservation in place so the same outpoints cannot
+        // back a second deposit while the registration outcome is unknown.
+        registrationStarted = true;
         const batchRegistration = await registerPeginBatchAndWait({
           btcWalletProvider: confirmedBtcWallet,
           walletClient,
@@ -514,6 +530,12 @@ export function useDepositFlow(
               scriptPubKey: u.scriptPubKey,
             })),
           });
+          // At least one durable pending-pegin record now covers the
+          // same UTXOs as the early reservation (all vaults in a batch
+          // share `batchResult.selectedUTXOs`), so any subsequent failure
+          // can safely release the reservation. Set inside the loop so
+          // the flag is never `true` with zero records written.
+          pendingPersisted = true;
         }
 
         // 3g. Verify the on-chain vault was registered under the same offchain
@@ -856,8 +878,23 @@ export function useDepositFlow(
           warnings: warnings.length > 0 ? warnings : undefined,
         };
       } catch (err: unknown) {
-        // Clean up early UTXO reservation so the UTXOs are released for reuse.
-        if (reservationBatchId && reservationEthAddress) {
+        // Clean up the early UTXO reservation so the UTXOs are released for
+        // reuse — but ONLY when it is safe to do so. If
+        // `registerPeginBatchAndWait` was invoked and no durable pending
+        // pegin records were written, the ETH registration outcome is
+        // unknown (the failure can be a post-`sendTransaction` receipt
+        // timeout while the tx is still in the mempool or already mined).
+        // Releasing the reservation in that window would let the same
+        // outpoints back a second deposit, leaving one ETH-registered vault
+        // unbroadcastable. Leave the reservation in place and let the
+        // existing 5-minute TTL handle cleanup; the user can retry after
+        // expiry. The trade-off is a UX delay for genuine pre-receipt
+        // failures, which is acceptable versus a stranded vault.
+        if (
+          reservationBatchId &&
+          reservationEthAddress &&
+          (!registrationStarted || pendingPersisted)
+        ) {
           removeUtxoReservation(reservationEthAddress, reservationBatchId);
         }
 


### PR DESCRIPTION
# Summary

`useDepositFlow.ts` writes an early UTXO reservation before submitting the Ethereum batch registration, then unconditionally releases it in its catch block whenever the call throws. The SDK's `registerPeginBatchAndWait` waits for the receipt with a 120 s timeout *after* `sendTransaction` has already returned, so a receipt timeout (RPC stall, slow block) can throw while the ETH transaction is still in the mempool or already mined. In that window no `addPendingPegin` record exists, so releasing the reservation lets a second deposit re-select the same BTC outpoints and back a different ETH-registered vault — leaving the loser vault unbroadcastable.

This PR keeps the early reservation in place when the SDK call has been invoked but no durable per-vault record has been written yet, letting the existing 5-minute reservation TTL provide cleanup. Pre-send failures (no ETH submission attempted) and post-persistence failures (records already supersede the reservation) continue to release the reservation immediately.

# Issue

- https://github.com/babylonlabs-io/baby-auditor-findings/issues/308
- Confirmed at HEAD `e80fe2bc` — the audit references commit `405ee72b` but the failure path is unchanged.

# Analysis

Failure path:

- `useDepositFlow.ts` writes the early reservation immediately after `preparePeginTransaction`.
- `registerPeginBatchAndWait` is awaited *before* any `addPendingPegin` call.
- Inside `PeginManager`, `sendTransaction` returns once the ETH tx is in the mempool, then `waitForTransactionReceipt` runs with `RECEIPT_TIMEOUT_MS = 120_000`. If this throws, control returns to the deposit hook before any `addPendingPegin` write.
- The pre-fix catch block unconditionally calls `removeUtxoReservation` whenever `reservationBatchId` is set.
- `UTXO_RESERVATION_TTL` is 5 minutes, but the catch path deletes immediately so the TTL gives no protection.

The Bitcoin availability check in `vaultUtxoValidationService.ts` does not close this gap because an ETH-registered but unbroadcast Pre-PegIn still appears unspent on Bitcoin.

PR #1457 added the in-flow `addPendingPegin`-before-broadcast block, which closed the broadcast-failure window but not this receipt-timeout window — that block runs only after `registerPeginBatchAndWait` resolves.

# Options Considered

- **Option A — Site-local guard in the deposit hook.** Track `registrationStarted` (set before the SDK call) and `pendingPersisted` (set after pending records are written). In the catch block, release the reservation only when registration was never started, or when pending records have already superseded it. The 5-minute TTL becomes the cleanup mechanism for the receipt-timeout window. Trade-off: pre-receipt failures inside the SDK (gas estimation, wallet rejection) delay the user up to 5 minutes before they can retry — acceptable versus a stranded vault.
- **Option B — On timeout, query the registry by precomputed vault IDs before deciding cleanup, and write pending records when registration landed.** Closer to the auditor's recommended shape, but the failure mode that matters (RPC stall) is the same RPC we'd need to query, and the added complexity targets a narrow window.
- **Option C — Reshape the SDK to surface partial state on receipt timeout (typed error or post-send callback).** Cleanest invariant but changes a frozen, signing-critical surface; warrants its own PR.

# Chosen Approach

**Option A.** Smallest correct change consistent with the existing codebase, keeps the SDK boundary untouched, and restores the auditor's invariant — converting the exploit from "stranded vault" to a 5-minute UX delay for genuine pre-send failures. Option C remains a worthwhile follow-up to close the residual window where a long-pending mempool tx outlives the reservation TTL.

# Implementation

`services/vault/src/hooks/deposit/useDepositFlow.ts`:

- Added `let registrationStarted = false` and `let pendingPersisted = false` alongside the existing `reservationBatchId` / `reservationEthAddress` declarations.
- Set `registrationStarted = true` immediately before `registerPeginBatchAndWait`.
- Set `pendingPersisted = true` directly after the per-vault `addPendingPegin` loop completes.
- Updated the catch block to call `removeUtxoReservation` only when `(!registrationStarted || pendingPersisted)`.

Behavioural effect:

| Failure point                                | Reservation kept?  |
| -------------------------------------------- | ------------------ |
| Before `registerPeginBatchAndWait`           | Released           |
| Inside `registerPeginBatchAndWait` (the bug) | Kept (TTL handles) |
| After `addPendingPegin` loop completes       | Released           |

# Tests

Three regression tests added to the existing `Error Handling` block in `services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx`:

- `keeps the early UTXO reservation when registerPeginBatchAndWait throws (receipt timeout window)` — pins the auditor's scenario. Verified to fail against the unfixed hook.
- `releases the early UTXO reservation for failures BEFORE registration is started` — pins the pre-send branch.
- `releases the early UTXO reservation when a post-pending failure occurs (records supersede the reservation)` — pins the records-superseded branch using the existing version-multicall failure surface.

Verification (run from `services/vault`):

- `pnpm exec vitest run src/hooks/deposit/__tests__/useDepositFlow.test.tsx` → 31 passed.
- Sensitivity check: reverted the `useDepositFlow.ts` edits and reran — the new receipt-timeout test failed as expected (`removeUtxoReservation` called when it should not be). Fix restored afterwards.
- `pnpm exec eslint src/hooks/deposit/useDepositFlow.ts src/hooks/deposit/__tests__/useDepositFlow.test.tsx` → 0 errors.
- `pnpm exec tsc --noEmit -p tsconfig.lib.json` → clean.

Top-level: `pnpm i`, `pnpm lint`, `pnpm test`, `pnpm build` all pass.

# Risk / Follow-up

- The 5-minute `UTXO_RESERVATION_TTL` is now the bound on the receipt-timeout window. If a legitimately registered ETH vault stays unbroadcast longer than that (mempool delay > 5 min), the hole reopens. A durable fix — Option B's on-chain recovery read or Option C's SDK-level sent-registration state — is the recommended follow-up. This PR explicitly trades that residual risk for a small, reviewable change.

Closes https://github.com/babylonlabs-io/baby-auditor-findings/issues/308
