### PR TITLE
fix(wallet): appkit btc spoofing

### DIFF
--- a/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/constants.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/constants.ts
@@ -7,7 +7,7 @@
  * (`useAppKitBtcBridge`) dispatches and `AppKitBTCProvider` listens
  * for. The event is delivered on the private `connectionEvents`
  * {@link EventTarget} held inside `SharedBtcAppKitConfig` — NOT on
- * `window`. See audit finding #242: dispatching this on `window`
- * lets any same-origin script spoof the connected address/pubkey.
+ * `window`. Dispatching this on `window` would let any same-origin
+ * script spoof the connected address/pubkey.
  */
 export const APPKIT_BTC_CONNECTED_EVENT = "babylon:appkit-btc-connected";

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/constants.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/constants.ts
@@ -1,8 +1,13 @@
 /**
- * Custom event names used for AppKit BTC wallet communication
+ * Custom event names used for AppKit BTC wallet communication.
  */
 
 /**
- * Event dispatched when AppKit BTC wallet connection is established
+ * Type tag for the connection-changed event the bridge hook
+ * (`useAppKitBtcBridge`) dispatches and `AppKitBTCProvider` listens
+ * for. The event is delivered on the private `connectionEvents`
+ * {@link EventTarget} held inside `SharedBtcAppKitConfig` — NOT on
+ * `window`. See audit finding #242: dispatching this on `window`
+ * lets any same-origin script spoof the connected address/pubkey.
  */
 export const APPKIT_BTC_CONNECTED_EVENT = "babylon:appkit-btc-connected";

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/provider.ts
@@ -53,6 +53,13 @@ export class AppKitBTCProvider implements IBTCProvider {
   private eventHandlers: Map<string, Set<(...args: unknown[]) => void>> = new Map();
   private listeningForChanges = false;
   private boundHandleAccountChange: ((event: Event) => void) | null = null;
+  /**
+   * The {@link EventTarget} we currently have a persistent listener on.
+   * Captured at registration time so we always remove the listener from
+   * the same target we added it to, even if the shared config singleton
+   * is replaced mid-session.
+   */
+  private boundConnectionEventsTarget: EventTarget | null = null;
 
   constructor(config: BTCConfig) {
     this.config = config;
@@ -75,11 +82,24 @@ export class AppKitBTCProvider implements IBTCProvider {
 
   /**
    * Start listening for account changes from the bridge hook.
-   * Sets up a persistent window listener for APPKIT_BTC_CONNECTED_EVENT
-   * so account switches are propagated to BTCWalletProvider via event handlers.
+   *
+   * The listener is attached to the private `connectionEvents`
+   * {@link EventTarget} held inside {@link SharedBtcAppKitConfig}, NOT on
+   * `window`. The previous implementation listened on `window` for
+   * `APPKIT_BTC_CONNECTED_EVENT` and adopted `event.detail.{address, publicKey}`
+   * as truth. Any same-origin script (XSS, malicious extension content
+   * script) could `window.dispatchEvent` a forged event with attacker-chosen
+   * values and overwrite this provider's cached address/pubkey, which then
+   * propagated through `accountsChanged` into `BTCWalletProvider` React
+   * state and downstream consumers (audit finding #242). Listening on a
+   * private `EventTarget` instance closes that channel — there is no
+   * global handle for an attacker to dispatch on.
    */
   private startListeningForAccountChanges(): void {
-    if (this.listeningForChanges || typeof window === "undefined") return;
+    if (this.listeningForChanges) return;
+    if (!hasSharedBtcAppKitConfig()) return;
+
+    const { connectionEvents } = getSharedBtcAppKitConfig();
 
     this.boundHandleAccountChange = (event: Event) => {
       const detail = (event as BtcConnectedEvent).detail;
@@ -102,17 +122,22 @@ export class AppKitBTCProvider implements IBTCProvider {
       this.emit("accountsChanged", [detail.address]);
     };
 
-    window.addEventListener(APPKIT_BTC_CONNECTED_EVENT, this.boundHandleAccountChange);
+    connectionEvents.addEventListener(APPKIT_BTC_CONNECTED_EVENT, this.boundHandleAccountChange);
+    this.boundConnectionEventsTarget = connectionEvents;
     this.listeningForChanges = true;
   }
 
   private stopListeningForAccountChanges(): void {
-    if (!this.listeningForChanges || typeof window === "undefined" || !this.boundHandleAccountChange) {
+    if (!this.listeningForChanges || !this.boundHandleAccountChange || !this.boundConnectionEventsTarget) {
       return;
     }
 
-    window.removeEventListener(APPKIT_BTC_CONNECTED_EVENT, this.boundHandleAccountChange);
+    this.boundConnectionEventsTarget.removeEventListener(
+      APPKIT_BTC_CONNECTED_EVENT,
+      this.boundHandleAccountChange,
+    );
     this.boundHandleAccountChange = null;
+    this.boundConnectionEventsTarget = null;
     this.listeningForChanges = false;
   }
 
@@ -131,44 +156,51 @@ export class AppKitBTCProvider implements IBTCProvider {
 
   async connectWallet(): Promise<void> {
     try {
-      // Open AppKit modal for Bitcoin wallet connection
-      if (typeof window !== "undefined") {
-        window.dispatchEvent(new CustomEvent(APPKIT_OPEN_EVENT));
-
-        // Wait for connection to complete
-        const waitForConnection = new Promise<void>((resolve, reject) => {
-          const timeout = setTimeout(() => {
-            console.error("[AppKit Provider] Connection timeout after 60 seconds");
-            cleanup();
-            reject(new Error("Connection timeout"));
-          }, 60000);
-
-          const handleAccountChange = (event: Event) => {
-            const detail = (event as BtcConnectedEvent).detail;
-            if (detail?.address) {
-              cleanup();
-              this.address = detail.address;
-              this.publicKey = detail.publicKey;
-              resolve();
-            } else {
-              console.warn("[AppKit Provider] Event received but no address in detail");
-            }
-          };
-
-          const cleanup = () => {
-            clearTimeout(timeout);
-            window.removeEventListener(APPKIT_BTC_CONNECTED_EVENT, handleAccountChange);
-          };
-
-          window.addEventListener(APPKIT_BTC_CONNECTED_EVENT, handleAccountChange);
-        });
-
-        await waitForConnection;
-        this.startListeningForAccountChanges();
-        return;
+      if (typeof window === "undefined") {
+        throw new Error("Window not available for AppKit modal");
       }
 
-      throw new Error("Window not available for AppKit modal");
+      // Resolve the shared config up front so we listen on the private
+      // connection-events bus, not on `window`. If the modal hasn't been
+      // initialized yet, fail loudly rather than fall back to a spoofable
+      // global channel.
+      const { connectionEvents } = this.getAppKitConfig();
+
+      // The modal-open trigger remains a window event because it is
+      // intentionally a UI hook (not a state source). It carries no
+      // payload that downstream code adopts as truth.
+      window.dispatchEvent(new CustomEvent(APPKIT_OPEN_EVENT));
+
+      // Wait for connection to complete
+      const waitForConnection = new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(() => {
+          console.error("[AppKit Provider] Connection timeout after 60 seconds");
+          cleanup();
+          reject(new Error("Connection timeout"));
+        }, 60000);
+
+        const handleAccountChange = (event: Event) => {
+          const detail = (event as BtcConnectedEvent).detail;
+          if (detail?.address) {
+            cleanup();
+            this.address = detail.address;
+            this.publicKey = detail.publicKey;
+            resolve();
+          } else {
+            console.warn("[AppKit Provider] Event received but no address in detail");
+          }
+        };
+
+        const cleanup = () => {
+          clearTimeout(timeout);
+          connectionEvents.removeEventListener(APPKIT_BTC_CONNECTED_EVENT, handleAccountChange);
+        };
+
+        connectionEvents.addEventListener(APPKIT_BTC_CONNECTED_EVENT, handleAccountChange);
+      });
+
+      await waitForConnection;
+      this.startListeningForAccountChanges();
     } catch (error) {
       console.error("[AppKit Provider] Failed to connect Bitcoin wallet:", error instanceof Error ? error.message : "Unknown error");
       throw new Error(`Failed to connect Bitcoin wallet: ${error instanceof Error ? error.message : "Unknown error"}`);

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/provider.ts
@@ -91,9 +91,9 @@ export class AppKitBTCProvider implements IBTCProvider {
    * script) could `window.dispatchEvent` a forged event with attacker-chosen
    * values and overwrite this provider's cached address/pubkey, which then
    * propagated through `accountsChanged` into `BTCWalletProvider` React
-   * state and downstream consumers (audit finding #242). Listening on a
-   * private `EventTarget` instance closes that channel — there is no
-   * global handle for an attacker to dispatch on.
+   * state and downstream consumers. Listening on a private `EventTarget`
+   * instance closes that channel — there is no global handle for an attacker
+   * to dispatch on.
    */
   private startListeningForAccountChanges(): void {
     if (this.listeningForChanges) return;

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/sharedConfig.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/sharedConfig.ts
@@ -8,20 +8,57 @@ import type { createAppKit } from "@reown/appkit/react";
  * and Bitcoin adapter that's provided by the application-level initialization.
  *
  * Usage:
- * 1. Application sets the config: setSharedBtcAppKitConfig({ modal, adapter })
+ * 1. Application sets the config: setSharedBtcAppKitConfig({ modal, adapter, network })
  * 2. AppKitBTCProvider uses: getSharedBtcAppKitConfig()
  */
 
+/**
+ * Shape callers pass to {@link setSharedBtcAppKitConfig}. `connectionEvents`
+ * is internal — callers may omit it and the setter will provision a private
+ * {@link EventTarget} for them.
+ */
+export interface SharedBtcAppKitConfigInput {
+  modal: ReturnType<typeof createAppKit>;
+  adapter: BitcoinAdapter;
+  network: "mainnet" | "signet";
+  /**
+   * Optional override for the private connection-events bus. Tests can
+   * inject a deterministic instance; production callers should leave this
+   * unset and let the setter create one.
+   */
+  connectionEvents?: EventTarget;
+}
+
+/**
+ * Resolved shape returned from {@link getSharedBtcAppKitConfig}. Always
+ * includes {@link SharedBtcAppKitConfig.connectionEvents} — the setter
+ * fills it in if the caller omitted one.
+ *
+ * `connectionEvents` is the in-process bus the bridge hook
+ * (`useAppKitBtcBridge`) uses to notify `AppKitBTCProvider` when the
+ * AppKit account changes. It deliberately is NOT exposed on `window`:
+ * a same-origin attacker (XSS, malicious extension content script) can
+ * dispatch arbitrary events on `window`, but cannot reach a private
+ * `EventTarget` instance held only by this singleton. This closes the
+ * spoof channel that previously let any same-origin script overwrite
+ * the cached connected address/pubkey.
+ */
 export interface SharedBtcAppKitConfig {
   modal: ReturnType<typeof createAppKit>;
   adapter: BitcoinAdapter;
   network: "mainnet" | "signet";
+  connectionEvents: EventTarget;
 }
 
 let sharedBtcAppKitConfig: SharedBtcAppKitConfig | null = null;
 
-export function setSharedBtcAppKitConfig(config: SharedBtcAppKitConfig): void {
-  sharedBtcAppKitConfig = config;
+export function setSharedBtcAppKitConfig(config: SharedBtcAppKitConfigInput): void {
+  sharedBtcAppKitConfig = {
+    modal: config.modal,
+    adapter: config.adapter,
+    network: config.network,
+    connectionEvents: config.connectionEvents ?? new EventTarget(),
+  };
 }
 
 export function getSharedBtcAppKitConfig(): SharedBtcAppKitConfig {
@@ -36,4 +73,12 @@ export function getSharedBtcAppKitConfig(): SharedBtcAppKitConfig {
 
 export function hasSharedBtcAppKitConfig(): boolean {
   return sharedBtcAppKitConfig !== null;
+}
+
+/**
+ * Test-only helper that wipes the singleton between tests. Not part of
+ * the public API surface.
+ */
+export function __resetSharedBtcAppKitConfigForTests(): void {
+  sharedBtcAppKitConfig = null;
 }

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/sharedConfig.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/sharedConfig.ts
@@ -57,7 +57,14 @@ export function setSharedBtcAppKitConfig(config: SharedBtcAppKitConfigInput): vo
     modal: config.modal,
     adapter: config.adapter,
     network: config.network,
-    connectionEvents: config.connectionEvents ?? new EventTarget(),
+    // Preserve the existing bus across repeated setter calls (e.g. HMR,
+    // network switch, re-init). Replacing it would strand any
+    // `AppKitBTCProvider` already listening on the prior `EventTarget`
+    // while the bridge dispatches on the new one — account-change events
+    // would silently stop propagating. An explicit caller override still
+    // wins for tests that need a deterministic instance.
+    connectionEvents:
+      config.connectionEvents ?? sharedBtcAppKitConfig?.connectionEvents ?? new EventTarget(),
   };
 }
 
@@ -78,6 +85,8 @@ export function hasSharedBtcAppKitConfig(): boolean {
 /**
  * Test-only helper that wipes the singleton between tests. Not part of
  * the public API surface.
+ *
+ * @internal
  */
 export function __resetSharedBtcAppKitConfigForTests(): void {
   sharedBtcAppKitConfig = null;

--- a/packages/babylon-wallet-connector/src/hooks/appkit/btc/useAppKitBtcBridge.ts
+++ b/packages/babylon-wallet-connector/src/hooks/appkit/btc/useAppKitBtcBridge.ts
@@ -15,12 +15,20 @@ interface UseAppKitBtcBridgeOptions {
 /**
  * Bridge AppKit Bitcoin connection state with babylon-wallet-connector
  *
- * This hook monitors AppKit's Bitcoin connection state and dispatches connection events
- * that AppKitBTCProvider.connectWallet() is waiting for. It does NOT call btcConnector.connect()
- * to avoid circular dependency issues.
+ * This hook monitors AppKit's Bitcoin connection state and dispatches
+ * connection events on the shared private `EventTarget` that
+ * `AppKitBTCProvider.connectWallet()` is waiting on. It does NOT call
+ * `btcConnector.connect()` to avoid circular dependency issues.
  *
- * To prevent race conditions, it listens for "babylon:open-appkit" events to coordinate
- * event dispatch timing with the provider's event listener registration.
+ * The connection-events bus is intentionally NOT `window` — see
+ * {@link SharedBtcAppKitConfig.connectionEvents}. A same-origin attacker
+ * (XSS or malicious extension) cannot dispatch on the private bus, so
+ * the cached connected address/pubkey on `AppKitBTCProvider` cannot be
+ * spoofed via `window.dispatchEvent`.
+ *
+ * To prevent race conditions, it listens for "babylon:open-appkit" events
+ * (a UI trigger, not a state source) to coordinate event dispatch timing
+ * with the provider's event-listener registration.
  */
 export const useAppKitBtcBridge = ({ onError }: UseAppKitBtcBridgeOptions = {}) => {
   const { isConnected, address, allAccounts } = useAppKitAccount({ namespace: "bip122" });
@@ -31,9 +39,12 @@ export const useAppKitBtcBridge = ({ onError }: UseAppKitBtcBridgeOptions = {}) 
   const dispatchConnectionEvent = useCallback(
     async (currentAddress: string) => {
       try {
+        // Resolve the shared config once — we need both the adapter (for
+        // network switching) and the private connection-events bus.
+        const { adapter, network, connectionEvents } = getSharedBtcAppKitConfig();
+
         // Switch to the configured network
         try {
-          const { adapter, network } = getSharedBtcAppKitConfig();
           // Map the network config to AppKit's network types
           const networkMap = {
             mainnet: bitcoin,
@@ -61,18 +72,18 @@ export const useAppKitBtcBridge = ({ onError }: UseAppKitBtcBridgeOptions = {}) 
           console.error("[AppKit BTC Bridge] Error fetching public key:", pkError instanceof Error ? pkError.message : "Unknown error");
         }
 
-        // Dispatch event to notify AppKitBTCProvider.connectWallet() that connection is ready
-        if (typeof window !== "undefined") {
-          const eventDetail = { address: currentAddress, publicKey };
-          window.dispatchEvent(
-            new CustomEvent(APPKIT_BTC_CONNECTED_EVENT, {
-              detail: eventDetail,
-            }),
-          );
+        // Dispatch on the private EventTarget so AppKitBTCProvider can pick
+        // up the change. We do NOT dispatch on `window` — that channel is
+        // reachable by any same-origin script and was the spoof vector.
+        const eventDetail = { address: currentAddress, publicKey };
+        connectionEvents.dispatchEvent(
+          new CustomEvent(APPKIT_BTC_CONNECTED_EVENT, {
+            detail: eventDetail,
+          }),
+        );
 
-          // Mark this address as dispatched to prevent duplicate events
-          lastDispatchedAddress.current = currentAddress;
-        }
+        // Mark this address as dispatched to prevent duplicate events
+        lastDispatchedAddress.current = currentAddress;
       } catch (error) {
         console.error("[AppKit BTC Bridge] Failed to process connection:", error instanceof Error ? error.message : "Unknown error");
         onError?.(error as Error);

--- a/packages/babylon-wallet-connector/tests/unit/appKitBtcConnectionBus.test.ts
+++ b/packages/babylon-wallet-connector/tests/unit/appKitBtcConnectionBus.test.ts
@@ -1,7 +1,5 @@
 /**
- * Regression tests for audit finding #242 — "AppKit BTC adapter trusts
- * addresses/pubkeys from a same-origin window CustomEvent — spoofable
- * by XSS or malicious extension".
+ * Regression tests for the AppKit BTC connection-events bus.
  *
  * Before the fix, `useAppKitBtcBridge` dispatched `babylon:appkit-btc-connected`
  * on `window`, and `AppKitBTCProvider` listened on `window` for that
@@ -125,7 +123,7 @@ test.describe("setSharedBtcAppKitConfig — connection-events bus", () => {
   });
 });
 
-test.describe("connection-events bus is NOT reachable from window (audit #242)", () => {
+test.describe("connection-events bus is NOT reachable from window", () => {
   test("a listener on connectionEvents receives events dispatched on connectionEvents", () => {
     setSharedBtcAppKitConfig({
       modal: fakeModal,

--- a/packages/babylon-wallet-connector/tests/unit/appKitBtcConnectionBus.test.ts
+++ b/packages/babylon-wallet-connector/tests/unit/appKitBtcConnectionBus.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Regression tests for audit finding #242 — "AppKit BTC adapter trusts
+ * addresses/pubkeys from a same-origin window CustomEvent — spoofable
+ * by XSS or malicious extension".
+ *
+ * Before the fix, `useAppKitBtcBridge` dispatched `babylon:appkit-btc-connected`
+ * on `window`, and `AppKitBTCProvider` listened on `window` for that
+ * event and adopted `event.detail.{address, publicKey}` as truth. Any
+ * same-origin script (XSS, malicious extension content script) could
+ * `window.dispatchEvent(...)` a forged event with attacker-chosen values
+ * and overwrite the provider's cached connected account.
+ *
+ * The fix moves the channel off `window` onto a private `EventTarget`
+ * held inside `SharedBtcAppKitConfig`. These tests pin the security
+ * property at the bus layer:
+ *
+ *  - `setSharedBtcAppKitConfig` provisions a private `EventTarget` for
+ *    `connectionEvents` when the caller doesn't supply one.
+ *  - The same `EventTarget` instance is returned across calls (the
+ *    bridge and provider must share it).
+ *  - Events dispatched on `window` with the connection-event name do
+ *    NOT reach listeners on `connectionEvents` — i.e. the spoof channel
+ *    is closed.
+ *
+ * The provider class itself is not imported here because its module
+ * graph pulls in SVG asset imports the unit-test runner can't resolve
+ * (same constraint as `tests/unit/deriveContextHash.test.ts`). The
+ * structural property tested below is what makes the provider's
+ * channel-choice fix correct.
+ */
+
+import { test, expect } from "@playwright/test";
+
+import { APPKIT_BTC_CONNECTED_EVENT } from "../../src/core/wallets/btc/appkit/constants";
+import {
+  __resetSharedBtcAppKitConfigForTests,
+  getSharedBtcAppKitConfig,
+  hasSharedBtcAppKitConfig,
+  setSharedBtcAppKitConfig,
+} from "../../src/core/wallets/btc/appkit/sharedConfig";
+
+// Minimal stand-ins for the modal/adapter — `sharedConfig` only stores
+// these by reference; nothing in the bus tests reads them.
+const fakeModal = {} as never;
+const fakeAdapter = {} as never;
+
+// Minimal `window` polyfill so the spoofing-attempt branch (`window.dispatchEvent`)
+// works in Node-mode Playwright unit tests. We back `window` with a real
+// `EventTarget` so add/remove/dispatch behave like the browser.
+interface MinimalWindow {
+  addEventListener: EventTarget["addEventListener"];
+  removeEventListener: EventTarget["removeEventListener"];
+  dispatchEvent: EventTarget["dispatchEvent"];
+}
+
+function ensureWindow(): MinimalWindow {
+  const g = globalThis as typeof globalThis & { window?: MinimalWindow };
+  if (g.window && typeof g.window.dispatchEvent === "function") {
+    return g.window;
+  }
+  const target = new EventTarget();
+  g.window = {
+    addEventListener: target.addEventListener.bind(target),
+    removeEventListener: target.removeEventListener.bind(target),
+    dispatchEvent: target.dispatchEvent.bind(target),
+  };
+  return g.window;
+}
+
+test.beforeEach(() => {
+  __resetSharedBtcAppKitConfigForTests();
+  ensureWindow();
+});
+
+test.afterEach(() => {
+  __resetSharedBtcAppKitConfigForTests();
+});
+
+test.describe("setSharedBtcAppKitConfig — connection-events bus", () => {
+  test("auto-creates a private EventTarget when the caller doesn't supply one", () => {
+    setSharedBtcAppKitConfig({
+      modal: fakeModal,
+      adapter: fakeAdapter,
+      network: "signet",
+    });
+
+    const cfg = getSharedBtcAppKitConfig();
+    expect(cfg.connectionEvents).toBeInstanceOf(EventTarget);
+  });
+
+  test("returns the same connection-events bus on repeated reads (bridge + provider must share it)", () => {
+    setSharedBtcAppKitConfig({
+      modal: fakeModal,
+      adapter: fakeAdapter,
+      network: "mainnet",
+    });
+
+    const first = getSharedBtcAppKitConfig().connectionEvents;
+    const second = getSharedBtcAppKitConfig().connectionEvents;
+    expect(second).toBe(first);
+  });
+
+  test("preserves a caller-supplied connection-events bus (test/inject hook)", () => {
+    const injected = new EventTarget();
+    setSharedBtcAppKitConfig({
+      modal: fakeModal,
+      adapter: fakeAdapter,
+      network: "signet",
+      connectionEvents: injected,
+    });
+
+    expect(getSharedBtcAppKitConfig().connectionEvents).toBe(injected);
+  });
+
+  test("hasSharedBtcAppKitConfig flips to true after set, and back to false on the test reset", () => {
+    expect(hasSharedBtcAppKitConfig()).toBe(false);
+    setSharedBtcAppKitConfig({
+      modal: fakeModal,
+      adapter: fakeAdapter,
+      network: "signet",
+    });
+    expect(hasSharedBtcAppKitConfig()).toBe(true);
+    __resetSharedBtcAppKitConfigForTests();
+    expect(hasSharedBtcAppKitConfig()).toBe(false);
+  });
+});
+
+test.describe("connection-events bus is NOT reachable from window (audit #242)", () => {
+  test("a listener on connectionEvents receives events dispatched on connectionEvents", () => {
+    setSharedBtcAppKitConfig({
+      modal: fakeModal,
+      adapter: fakeAdapter,
+      network: "signet",
+    });
+    const { connectionEvents } = getSharedBtcAppKitConfig();
+
+    const seen: Array<{ address?: string; publicKey?: string }> = [];
+    const listener = (event: Event) => {
+      const detail = (event as CustomEvent<{ address?: string; publicKey?: string }>).detail;
+      seen.push({ address: detail?.address, publicKey: detail?.publicKey });
+    };
+    connectionEvents.addEventListener(APPKIT_BTC_CONNECTED_EVENT, listener);
+
+    connectionEvents.dispatchEvent(
+      new CustomEvent(APPKIT_BTC_CONNECTED_EVENT, {
+        detail: { address: "tb1qlegit", publicKey: "02" + "11".repeat(32) },
+      }),
+    );
+
+    connectionEvents.removeEventListener(APPKIT_BTC_CONNECTED_EVENT, listener);
+
+    expect(seen).toEqual([{ address: "tb1qlegit", publicKey: "02" + "11".repeat(32) }]);
+  });
+
+  test("a listener on connectionEvents does NOT receive forged events dispatched on window (the spoof channel is closed)", () => {
+    setSharedBtcAppKitConfig({
+      modal: fakeModal,
+      adapter: fakeAdapter,
+      network: "signet",
+    });
+    const { connectionEvents } = getSharedBtcAppKitConfig();
+
+    const seen: Array<{ address?: string; publicKey?: string }> = [];
+    const listener = (event: Event) => {
+      const detail = (event as CustomEvent<{ address?: string; publicKey?: string }>).detail;
+      seen.push({ address: detail?.address, publicKey: detail?.publicKey });
+    };
+    connectionEvents.addEventListener(APPKIT_BTC_CONNECTED_EVENT, listener);
+
+    // Simulate a malicious same-origin script (XSS or extension content
+    // script) trying to spoof the connected BTC account by dispatching a
+    // forged CustomEvent on `window`. After the fix, this MUST NOT reach
+    // any listener attached to the private connection-events bus.
+    window.dispatchEvent(
+      new CustomEvent(APPKIT_BTC_CONNECTED_EVENT, {
+        detail: { address: "tb1qattacker", publicKey: "03" + "22".repeat(32) },
+      }),
+    );
+
+    connectionEvents.removeEventListener(APPKIT_BTC_CONNECTED_EVENT, listener);
+
+    expect(seen).toEqual([]);
+  });
+
+  test("a window listener does NOT see events dispatched on connectionEvents (channel is one-way private)", () => {
+    setSharedBtcAppKitConfig({
+      modal: fakeModal,
+      adapter: fakeAdapter,
+      network: "signet",
+    });
+    const { connectionEvents } = getSharedBtcAppKitConfig();
+
+    const seen: Array<{ address?: string }> = [];
+    const windowListener = (event: Event) => {
+      const detail = (event as CustomEvent<{ address?: string }>).detail;
+      seen.push({ address: detail?.address });
+    };
+    window.addEventListener(APPKIT_BTC_CONNECTED_EVENT, windowListener);
+
+    connectionEvents.dispatchEvent(
+      new CustomEvent(APPKIT_BTC_CONNECTED_EVENT, {
+        detail: { address: "tb1qlegit" },
+      }),
+    );
+
+    window.removeEventListener(APPKIT_BTC_CONNECTED_EVENT, windowListener);
+
+    // Ensures we don't accidentally re-dispatch on window — anything we
+    // emit here must stay private to the bus.
+    expect(seen).toEqual([]);
+  });
+});


### PR DESCRIPTION
# Summary

`AppKitBTCProvider` synchronized its connected BTC address/pubkey by listening on `window` for the `babylon:appkit-btc-connected` `CustomEvent` and adopting `event.detail.{address, publicKey}` as truth. The bridge hook (`useAppKitBtcBridge`) dispatched the same event with `window.dispatchEvent`, so any same-origin script — XSS, malicious extension content script, supply-chain-compromised script tag — could replay the event with attacker-chosen values and overwrite the cached account. The poisoned cache propagated through `accountsChanged` into `BTCWalletProvider` React state and downstream consumers (header, address screening, UTXO queries, payout-signing comparisons), enabling UI spoofing and address-poisoning.

This PR moves the bridge channel off `window` onto a private `EventTarget` instance held inside `SharedBtcAppKitConfig`. Same-origin scripts cannot dispatch on a private object reference they don't have, so the spoof vector is closed at the channel level. The change is local to `packages/babylon-wallet-connector/src/{core,hooks}/.../appkit/`, additive on the public API surface, and adds 7 regression tests pinning the security property.

# Issue

- https://github.com/babylonlabs-io/baby-auditor-findings/issues/242
- AppKit BTC adapter trusts addresses/pubkeys from a same-origin window CustomEvent — spoofable by XSS or malicious extension.
- Finding was CONFIRMED at HEAD.

# Analysis

The auditor's commit hash is stale, but the listed line ranges resolve to the same code paths today. Concretely (line numbers refer to the repo state before this PR):

- `packages/babylon-wallet-connector/src/core/wallets/btc/appkit/provider.ts:81-107` — `startListeningForAccountChanges` adds a persistent `window.addEventListener(APPKIT_BTC_CONNECTED_EVENT, ...)` and overwrites `this.address` / `this.publicKey` from `event.detail` after only a non-empty-address check. No origin/source/identity validation.
- `provider.ts:131-176` — `connectWallet` adds another `window` listener and trusts the first matching event whose `detail.address` is set, copying `detail.publicKey` verbatim into the cache.
- `provider.ts:189-226` — `getAddress` / `getPublicKeyHex` short-circuit on the cached values and only consult the AppKit adapter as a fallback. Once the cache is poisoned, every downstream consumer reads the spoofed value until the next legitimate AppKit account change or disconnect.
- `packages/babylon-wallet-connector/src/hooks/appkit/btc/useAppKitBtcBridge.ts:64-75` — the legitimate dispatcher uses `window.dispatchEvent(new CustomEvent(APPKIT_BTC_CONNECTED_EVENT, { detail }))`. Because the channel is `window`, any same-origin script can replay the same dispatch with arbitrary detail.

The realized impact is bounded — the spoofed value cannot reach a signed payload that survives chain verification. `AppKitBTCProvider.deriveContextHash` is `unsupportedDeriveContextHash("AppKit Bitcoin")` (`provider.ts:358`), PoP signing fails on-chain when the embedded pubkey mismatches the real signing key, and PSBT signing requires the wallet to actually own the inputs. But the wallet-connector package is shipped to other consumers, and the spoofed value still corrupts the connected-account UI, address screening inputs, and any flow that displays "your address" — credible address-poisoning surface. Fix is small and local, so it's worth taking.

# Options Considered

- **A. Read from the AppKit adapter, never from a window event.** Drop the `APPKIT_BTC_CONNECTED_EVENT` listener as the source of truth and always derive from `adapter.connections[0]`. Larger refactor; the adapter snapshot also doesn't reliably carry `publicKey` (runtime stores `connections[i].accounts: { address }[]` only), so a separate channel for the public key would still be needed. Out of scope for the smallest correct fix.
- **B. Move the bridge channel off `window` onto a private `EventTarget` shared between bridge and provider via `SharedBtcAppKitConfig`.** Same-origin scripts cannot dispatch on a private `EventTarget` reference they don't have. Closes the spoof channel entirely. Smallest correct change, self-contained inside the `appkit/` directory.
- **C. Validate every adopted event detail against `adapter.connections[]`.** Defense-in-depth on top of B. Useful in principle, but the runtime adapter snapshot doesn't reliably expose `publicKey`, and once B is in place the channel is private so there is no untrusted producer to validate. Adding C would only catch a future bridge bug at the cost of complicating the listener; left as a follow-up.

# Chosen Approach

**Option B** — minimal, self-contained, and closes the spoof channel structurally rather than via a runtime check. Three reasons:

Closes https://github.com/babylonlabs-io/baby-auditor-findings/issues/242 
