### PR TITLE
fix(vault): re-enable usage query on uncapped deployments so Protocol Cap renders

### DIFF
--- a/services/vault/src/hooks/__tests__/useApplicationCap.test.tsx
+++ b/services/vault/src/hooks/__tests__/useApplicationCap.test.tsx
@@ -92,16 +92,7 @@ describe("useApplicationCap", () => {
     });
   });
 
-  // Skipped: the new uncapped path waits for the usage query to settle, but
-  // this scenario is environment-flaky in CI (passes locally and via
-  // `nx affected --target=test`, times out in the GitHub Actions vitest run
-  // even after `mockReset()` and 4s waitFor). The production behaviour is
-  // covered by the live dashboard render against the devnet CapPolicy and
-  // by the capped-path tests above. Re-enable once the CI/vitest discrepancy
-  // is understood.
-  it.skip("uses real usage data when computing an uncapped snapshot", async () => {
-    vi.mocked(getApplicationCap).mockReset();
-    vi.mocked(getApplicationUsage).mockReset();
+  it("uses real usage data when computing an uncapped snapshot", async () => {
     vi.mocked(getApplicationCap).mockResolvedValue({
       totalCapBTC: 0n,
       perAddressCapBTC: 0n,
@@ -116,6 +107,10 @@ describe("useApplicationCap", () => {
     });
 
     await waitFor(() => expect(result.current.snapshot).not.toBeNull());
+    expect(getApplicationUsage).toHaveBeenCalledWith(
+      "0xaaveadapter",
+      undefined,
+    );
     expect(result.current.snapshot).toMatchObject({
       hasTotalCap: false,
       hasPerAddressCap: false,
@@ -140,12 +135,7 @@ describe("useApplicationCap", () => {
     expect(result.current.isLoading).toBe(true);
   });
 
-  // Skipped: see note on the test above. The error-shielding behaviour is
-  // already covered by the deposit-form contract (see `useDepositPageForm`,
-  // which only blocks on `capError !== null`).
-  it.skip("falls back to a synthetic snapshot and shields usage errors on an uncapped deployment", async () => {
-    vi.mocked(getApplicationCap).mockReset();
-    vi.mocked(getApplicationUsage).mockReset();
+  it("falls back to a synthetic snapshot and shields usage errors on an uncapped deployment", async () => {
     vi.mocked(getApplicationCap).mockResolvedValue({
       totalCapBTC: 0n,
       perAddressCapBTC: 0n,

--- a/services/vault/src/hooks/useApplicationCap.ts
+++ b/services/vault/src/hooks/useApplicationCap.ts
@@ -47,22 +47,25 @@ export function useApplicationCap(user?: string): UseApplicationCapResult {
     enabled,
   });
 
-  // Usage RPCs are skipped for uncapped deployments — the snapshot logic below
-  // ignores usage data when both cap parameters are 0 (CapPolicy.sol treats
-  // 0 as unlimited), so polling them is pure waste. Gating on caps being
-  // resolved AND non-zero adds one cap-RTT of latency for capped deployments
-  // on first load, but eliminates the polling stream entirely when uncapped.
-  const isCapped =
-    capsQuery.data !== undefined &&
-    (capsQuery.data.totalCapBTC > 0n || capsQuery.data.perAddressCapBTC > 0n);
+  // Usage is fetched whenever caps are known — both capped and uncapped
+  // deployments need the live `totalBTC` for the dashboard's
+  // SupplyCapSection ("Total Deposited"). The per-user leg of the multicall
+  // is only consumed by `remainingForUser` (gated on `hasPerAddressCap`), so
+  // when there is no per-address cap we drop the user from the call to skip
+  // an unused on-chain read.
+  const capsResolved = capsQuery.data !== undefined;
+  const userAddressForUsage =
+    capsQuery.data !== undefined && capsQuery.data.perAddressCapBTC > 0n
+      ? userAddress
+      : undefined;
 
   const usageQuery = useQuery({
-    queryKey: [APPLICATION_CAP_KEY, "usage", app, userAddress ?? null],
-    queryFn: () => getApplicationUsage(app, userAddress),
+    queryKey: [APPLICATION_CAP_KEY, "usage", app, userAddressForUsage ?? null],
+    queryFn: () => getApplicationUsage(app, userAddressForUsage),
     staleTime: CAP_STALE_TIME_MS,
     refetchInterval: CAP_REFETCH_INTERVAL_MS,
     refetchOnWindowFocus: false,
-    enabled: enabled && isCapped,
+    enabled: enabled && capsResolved,
   });
 
   const snapshot = useMemo<CapSnapshot | null>(() => {


### PR DESCRIPTION
## Summary

The dashboard's "Protocol Cap" section was hidden again on uncapped Aave-adapter deployments. PR #1498 (`fix(vault): show "Unlimited" instead of hiding Protocol Cap`) was supposed to keep the section visible labelled "Uncapped", but the symptom returned because of an interaction with the earlier perf PR #1501 (`Avoid making unless calls`):

- #1501 added `enabled: enabled && isCapped` to `usageQuery` on the assumption that uncapped deployments do not need usage data.
- #1498 then changed the snapshot `useMemo` so the uncapped branch *does* consume `usageQuery.data` (for "Total Deposited") and added a `usageSettled` wait before resolving.

With `enabled: false`, TanStack Query v5 never runs the `queryFn`, so `usageQuery.data` stays `undefined` and `usageQuery.error` stays `null` indefinitely. `usageSettled` is permanently `false`, the snapshot stays `null`, and `SupplyCapSection` short-circuits on `if (!snapshot) return null;` — the whole "Protocol Cap" header and both cards are unmounted.

## Changes

- `useApplicationCap.ts`: replace `enabled: enabled && isCapped` with `enabled: enabled && capsResolved`. Usage is now load-bearing for the uncapped dashboard, so the perf optimisation from #1501 cannot survive #1498's UI contract.
- `useApplicationCap.ts`: drop `userAddress` from the `getApplicationUsage` call when `perAddressCapBTC === 0n`. `userBTC` only feeds `remainingForUser`, which `capMath.computeCapSnapshot` already gates on `hasPerAddressCap`, so the per-user multicall leg was already unused in that case.
- `useApplicationCap.test.tsx`: unskip the two uncapped regression tests added by #1498. They were checked in as `it.skip` with a "CI flakiness" comment; the actual cause of the timeout was the same bug — `getApplicationUsage` was never invoked because `enabled: false`, so `waitFor` polled forever. Added an explicit `expect(getApplicationUsage).toHaveBeenCalledWith(...)` assertion so the regression cannot recur silently.

## Notes

- Restores 60s usage polling on uncapped deployments — intentional, the dashboard now needs the live `totalBTC`.
- Uncapped usage errors are still shielded from hook consumers (so the deposit form is not blocked), but `QueryCache.onError` in `config/queryClient.ts` will continue to log them.

## Test plan

- [x] `pnpm --filter vault exec vitest run useApplicationCap.test.tsx` — 6/6 pass (was 4/6 with 2 skipped)
- [x] `pnpm --filter vault exec vitest run SupplyCapSection capMath useDepositPageForm useApplicationCap` — 52/52 pass
- [x] `pnpm --filter vault run test` — 1140 pass, 4 unrelated skips
- [x] `pnpm --filter vault run lint` — 0 errors on changed files
- [ ] Smoke-test against the devnet CapPolicy: load the dashboard while connected and confirm the "Protocol Cap" header plus both cards (`Uncapped` / `Total Deposited`) render