### PR TITLE
feat(ts-sdk,vault,wallet): safe wallet multisig transaction receipt

### DIFF
--- a/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
@@ -1166,7 +1166,7 @@ export class PeginManager {
     if (receipt.status === "reverted") {
       handleContractError(
         new Error(
-          `Transaction reverted. Hash: ${ethTxHash}. ` +
+          `Transaction reverted. Hash: ${receipt.transactionHash}. ` +
             `Check the transaction on block explorer for details.`,
         ),
       );
@@ -1334,7 +1334,7 @@ export class PeginManager {
     if (receipt.status === "reverted") {
       handleContractError(
         new Error(
-          `Batch transaction reverted. Hash: ${ethTxHash}. ` +
+          `Batch transaction reverted. Hash: ${receipt.transactionHash}. ` +
             `Check the transaction on block explorer for details.`,
         ),
       );

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
@@ -71,6 +71,7 @@ import {
   selectUtxosForPegin,
   type UTXO,
   MAX_REASONABLE_FEE_SATS,
+  waitForTransactionReceiptSmartAware,
 } from "../utils";
 import { createTaprootScriptPathSignOptions } from "../utils/signing";
 import {
@@ -1152,8 +1153,13 @@ export class PeginManager {
       handleContractError(error); // always throws (return type: never)
     }
 
-    // Step 8: Wait for transaction receipt and verify it was not reverted
-    const receipt = await publicClient.waitForTransactionReceipt({
+    // Step 8: Wait for transaction receipt and verify it was not reverted.
+    // Smart-account-aware wrapper so Safe-style multisigs work alongside
+    // Externally Owned Accounts (EOAs — wallets controlled by a single
+    // private key, e.g. MetaMask). The EOA path is unchanged.
+    const receipt = await waitForTransactionReceiptSmartAware({
+      publicClient,
+      walletAddress: this.config.ethWallet.account.address,
       hash: ethTxHash,
       timeout: RECEIPT_TIMEOUT_MS,
     });
@@ -1315,7 +1321,13 @@ export class PeginManager {
     }
 
     // Step 9: Wait for receipt
-    const receipt = await publicClient.waitForTransactionReceipt({
+    // Use the smart-account-aware wrapper so Safe-style wallets (whose
+    // `eth_sendTransaction` returns a `safeTxHash`, not a real tx hash) work
+    // alongside Externally Owned Accounts (EOAs — wallets controlled by a
+    // single private key, e.g. MetaMask). The EOA path is unchanged.
+    const receipt = await waitForTransactionReceiptSmartAware({
+      publicClient,
+      walletAddress: this.config.ethWallet.account.address,
       hash: ethTxHash,
       timeout: RECEIPT_TIMEOUT_MS,
     });

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PeginManager.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PeginManager.test.ts
@@ -51,6 +51,11 @@ const TEST_CHAIN: Chain = {
 // hit HTTP. Mirrors viem's PublicClient surface used by the manager.
 const TEST_PUBLIC_CLIENT = {
   estimateGas: vi.fn().mockResolvedValue(100000n),
+  // Empty bytecode marks the connected wallet as an Externally Owned Account
+  // (EOA — controlled by a single private key, e.g. MetaMask), so the
+  // smart-account-aware receipt wait delegates directly to
+  // waitForTransactionReceipt.
+  getCode: vi.fn().mockResolvedValue("0x"),
   waitForTransactionReceipt: vi.fn().mockResolvedValue({
     status: "success",
     transactionHash: "0x" + "ab".repeat(32),

--- a/packages/babylon-ts-sdk/src/tbv/core/utils/eth/__tests__/waitForTransactionReceiptSmartAware.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/utils/eth/__tests__/waitForTransactionReceiptSmartAware.test.ts
@@ -1,0 +1,216 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PublicClient } from "viem";
+
+import { waitForTransactionReceiptSmartAware } from "../waitForTransactionReceiptSmartAware";
+
+const EOA_ADDRESS = "0xb60853e8F260DCEc66Bb9d469E6A672c66406753" as const;
+const SAFE_ADDRESS = "0x51C0f61E48E11C3D2c11660087C4c16F4A71Dd43" as const;
+const SAFE_TX_HASH =
+  "0x154a2d91a71aa2b94854b318854ec47f1a71cb420aa9ac7cc0f8cdfaeaf31c71" as const;
+const REAL_TX_HASH =
+  "0x2e7459a34ffc919d657626068ab3efe53159e62fa702decb4099131a86f923b7" as const;
+const SEPOLIA_CHAIN_ID = 11155111;
+const UNSUPPORTED_CHAIN_ID = 137;
+
+function makePublicClient(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    getCode: vi.fn(),
+    getChainId: vi.fn().mockResolvedValue(SEPOLIA_CHAIN_ID),
+    waitForTransactionReceipt: vi.fn(),
+    ...overrides,
+  } as unknown as PublicClient;
+}
+
+describe("waitForTransactionReceiptSmartAware", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("delegates to viem's waitForTransactionReceipt when the wallet is an EOA", async () => {
+    const expectedReceipt = {
+      status: "success" as const,
+      transactionHash: REAL_TX_HASH,
+    };
+    const publicClient = makePublicClient({
+      getCode: vi.fn().mockResolvedValue("0x"),
+      waitForTransactionReceipt: vi.fn().mockResolvedValue(expectedReceipt),
+    });
+
+    const receipt = await waitForTransactionReceiptSmartAware({
+      publicClient,
+      walletAddress: EOA_ADDRESS,
+      hash: REAL_TX_HASH,
+      timeout: 10_000,
+    });
+
+    expect(receipt).toBe(expectedReceipt);
+    expect(publicClient.waitForTransactionReceipt).toHaveBeenCalledTimes(1);
+    expect(publicClient.waitForTransactionReceipt).toHaveBeenCalledWith({
+      hash: REAL_TX_HASH,
+      confirmations: undefined,
+      timeout: 10_000,
+    });
+    expect(publicClient.getChainId).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("polls the Safe Transaction Service and resolves with the real tx receipt when the wallet is a smart account", async () => {
+    const expectedReceipt = {
+      status: "success" as const,
+      transactionHash: REAL_TX_HASH,
+    };
+    const publicClient = makePublicClient({
+      getCode: vi.fn().mockResolvedValue("0x60806040"),
+      waitForTransactionReceipt: vi.fn().mockResolvedValue(expectedReceipt),
+    });
+
+    // First poll: proposal not yet executed.
+    // Second poll: executed and successful, real tx hash available.
+    (fetch as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          isExecuted: false,
+          isSuccessful: null,
+          transactionHash: null,
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          isExecuted: true,
+          isSuccessful: true,
+          transactionHash: REAL_TX_HASH,
+        }),
+      });
+
+    const receipt = await waitForTransactionReceiptSmartAware({
+      publicClient,
+      walletAddress: SAFE_ADDRESS,
+      hash: SAFE_TX_HASH,
+      safePollIntervalMs: 1, // make the test fast
+    });
+
+    expect(receipt).toBe(expectedReceipt);
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(fetch).toHaveBeenNthCalledWith(
+      1,
+      `https://safe-transaction-sepolia.safe.global/api/v1/multisig-transactions/${SAFE_TX_HASH}/`,
+    );
+    expect(publicClient.waitForTransactionReceipt).toHaveBeenCalledWith({
+      hash: REAL_TX_HASH,
+      confirmations: undefined,
+    });
+  });
+
+  it("throws a descriptive error when the Safe transaction executed but reverted on chain", async () => {
+    const publicClient = makePublicClient({
+      getCode: vi.fn().mockResolvedValue("0x60806040"),
+    });
+
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        isExecuted: true,
+        isSuccessful: false,
+        transactionHash: REAL_TX_HASH,
+      }),
+    });
+
+    await expect(
+      waitForTransactionReceiptSmartAware({
+        publicClient,
+        walletAddress: SAFE_ADDRESS,
+        hash: SAFE_TX_HASH,
+        safePollIntervalMs: 1,
+      }),
+    ).rejects.toThrow(/executed on chain but reverted/);
+
+    expect(publicClient.waitForTransactionReceipt).not.toHaveBeenCalled();
+  });
+
+  it("throws a descriptive error when the connected smart account is on an unsupported chain", async () => {
+    const publicClient = makePublicClient({
+      getCode: vi.fn().mockResolvedValue("0x60806040"),
+      getChainId: vi.fn().mockResolvedValue(UNSUPPORTED_CHAIN_ID),
+    });
+
+    await expect(
+      waitForTransactionReceiptSmartAware({
+        publicClient,
+        walletAddress: SAFE_ADDRESS,
+        hash: SAFE_TX_HASH,
+      }),
+    ).rejects.toThrow(
+      `Safe Transaction Service not configured for chainId ${UNSUPPORTED_CHAIN_ID}`,
+    );
+
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("times out cleanly when the Safe proposal is never executed", async () => {
+    const publicClient = makePublicClient({
+      getCode: vi.fn().mockResolvedValue("0x60806040"),
+    });
+
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        isExecuted: false,
+        isSuccessful: null,
+        transactionHash: null,
+      }),
+    });
+
+    await expect(
+      waitForTransactionReceiptSmartAware({
+        publicClient,
+        walletAddress: SAFE_ADDRESS,
+        hash: SAFE_TX_HASH,
+        safePollIntervalMs: 1,
+        safePollTimeoutMs: 5,
+      }),
+    ).rejects.toThrow(/Timed out.*waiting for Safe transaction/);
+  });
+
+  it("retries on 404 (proposal not yet indexed) without surfacing an error", async () => {
+    const expectedReceipt = {
+      status: "success" as const,
+      transactionHash: REAL_TX_HASH,
+    };
+    const publicClient = makePublicClient({
+      getCode: vi.fn().mockResolvedValue("0x60806040"),
+      waitForTransactionReceipt: vi.fn().mockResolvedValue(expectedReceipt),
+    });
+
+    (fetch as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({ ok: false, status: 404 })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          isExecuted: true,
+          isSuccessful: true,
+          transactionHash: REAL_TX_HASH,
+        }),
+      });
+
+    await waitForTransactionReceiptSmartAware({
+      publicClient,
+      walletAddress: SAFE_ADDRESS,
+      hash: SAFE_TX_HASH,
+      safePollIntervalMs: 1,
+    });
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/babylon-ts-sdk/src/tbv/core/utils/eth/__tests__/waitForTransactionReceiptSmartAware.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/utils/eth/__tests__/waitForTransactionReceiptSmartAware.test.ts
@@ -103,6 +103,7 @@ describe("waitForTransactionReceiptSmartAware", () => {
     expect(fetch).toHaveBeenNthCalledWith(
       1,
       `https://safe-transaction-sepolia.safe.global/api/v1/multisig-transactions/${SAFE_TX_HASH}/`,
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
     expect(publicClient.waitForTransactionReceipt).toHaveBeenCalledWith({
       hash: REAL_TX_HASH,
@@ -180,6 +181,47 @@ describe("waitForTransactionReceiptSmartAware", () => {
         safePollTimeoutMs: 5,
       }),
     ).rejects.toThrow(/Timed out.*waiting for Safe transaction/);
+  });
+
+  it("retries when a single fetch hangs / aborts, without consuming the overall budget", async () => {
+    const expectedReceipt = {
+      status: "success" as const,
+      transactionHash: REAL_TX_HASH,
+    };
+    const publicClient = makePublicClient({
+      getCode: vi.fn().mockResolvedValue("0x60806040"),
+      waitForTransactionReceipt: vi.fn().mockResolvedValue(expectedReceipt),
+    });
+
+    // First poll: simulate the AbortController firing (transient timeout).
+    // Second poll: succeed.
+    const abortError = new Error("The operation was aborted.");
+    abortError.name = "AbortError";
+
+    (fetch as ReturnType<typeof vi.fn>)
+      .mockRejectedValueOnce(abortError)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          isExecuted: true,
+          isSuccessful: true,
+          transactionHash: REAL_TX_HASH,
+        }),
+      });
+
+    await waitForTransactionReceiptSmartAware({
+      publicClient,
+      walletAddress: SAFE_ADDRESS,
+      hash: SAFE_TX_HASH,
+      safePollIntervalMs: 1,
+    });
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(publicClient.waitForTransactionReceipt).toHaveBeenCalledWith({
+      hash: REAL_TX_HASH,
+      confirmations: undefined,
+    });
   });
 
   it("retries on 404 (proposal not yet indexed) without surfacing an error", async () => {

--- a/packages/babylon-ts-sdk/src/tbv/core/utils/eth/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/utils/eth/index.ts
@@ -1,0 +1,1 @@
+export * from "./waitForTransactionReceiptSmartAware";

--- a/packages/babylon-ts-sdk/src/tbv/core/utils/eth/waitForTransactionReceiptSmartAware.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/utils/eth/waitForTransactionReceiptSmartAware.ts
@@ -1,0 +1,165 @@
+/**
+ * Smart-account-aware wrapper around viem's `waitForTransactionReceipt`.
+ *
+ * Externally Owned Accounts (EOAs) — wallets controlled by a single private
+ * key, e.g. MetaMask or a hardware wallet. `eth_sendTransaction` returns a real
+ * Ethereum tx hash, which viem can poll directly. This wrapper detects an EOA
+ * via `eth_getCode` returning empty bytecode and delegates unchanged.
+ *
+ * Smart-contract accounts (e.g. Safe multisigs) — the wallet address is a
+ * deployed contract that decides whether to accept a transaction. WalletConnect's
+ * `eth_sendTransaction` returns a `safeTxHash` (an EIP-712 hash of the
+ * *proposal*) rather than a real tx hash, and the proposal is held in Safe's
+ * off-chain Transaction Service until quorum signs and executes it. We poll
+ * that service for the proposal until execution, then wait for receipt on the
+ * real Ethereum tx hash exposed in the service's response.
+ *
+ * @module utils/eth
+ */
+
+import type {
+  Address,
+  Hash,
+  PublicClient,
+  TransactionReceipt,
+} from "viem";
+
+/**
+ * Chains where the Safe Transaction Service is supported by this utility.
+ * Extend the map as more Safe-enabled chains are needed.
+ */
+const SAFE_TX_SERVICE_BASE_URLS: Record<number, string> = {
+  1: "https://safe-transaction-mainnet.safe.global",
+  11155111: "https://safe-transaction-sepolia.safe.global",
+};
+
+const DEFAULT_SAFE_POLL_INTERVAL_MS = 5_000;
+const DEFAULT_SAFE_POLL_TIMEOUT_MS = 4 * 60 * 60 * 1_000;
+
+export interface WaitForTransactionReceiptSmartAwareParams {
+  publicClient: PublicClient;
+  walletAddress: Address;
+  hash: Hash;
+  confirmations?: number;
+  /**
+   * Forwarded to viem on the EOA (externally owned account) path.
+   * Ignored on the smart-account path — see safePollTimeoutMs.
+   */
+  timeout?: number;
+  /** Total budget for waiting on Safe quorum + execution. Default 4h. */
+  safePollTimeoutMs?: number;
+  /** Poll cadence against the Safe Transaction Service. Default 5s. */
+  safePollIntervalMs?: number;
+}
+
+export async function waitForTransactionReceiptSmartAware(
+  params: WaitForTransactionReceiptSmartAwareParams,
+): Promise<TransactionReceipt> {
+  const {
+    publicClient,
+    walletAddress,
+    hash,
+    confirmations,
+    timeout,
+    safePollTimeoutMs = DEFAULT_SAFE_POLL_TIMEOUT_MS,
+    safePollIntervalMs = DEFAULT_SAFE_POLL_INTERVAL_MS,
+  } = params;
+
+  const code = await publicClient.getCode({ address: walletAddress });
+  const isSmartAccount = code !== undefined && code !== "0x";
+
+  if (!isSmartAccount) {
+    return publicClient.waitForTransactionReceipt({
+      hash,
+      confirmations,
+      timeout,
+    });
+  }
+
+  const chainId = await publicClient.getChainId();
+  const realTxHash = await pollSafeTransactionServiceUntilExecuted({
+    chainId,
+    safeTxHash: hash,
+    pollIntervalMs: safePollIntervalMs,
+    timeoutMs: safePollTimeoutMs,
+  });
+
+  return publicClient.waitForTransactionReceipt({
+    hash: realTxHash,
+    confirmations,
+  });
+}
+
+interface SafeMultisigTransaction {
+  isExecuted: boolean;
+  isSuccessful: boolean | null;
+  transactionHash: Hash | null;
+}
+
+async function pollSafeTransactionServiceUntilExecuted({
+  chainId,
+  safeTxHash,
+  pollIntervalMs,
+  timeoutMs,
+}: {
+  chainId: number;
+  safeTxHash: Hash;
+  pollIntervalMs: number;
+  timeoutMs: number;
+}): Promise<Hash> {
+  const baseUrl = SAFE_TX_SERVICE_BASE_URLS[chainId];
+  if (!baseUrl) {
+    throw new Error(
+      `Safe Transaction Service not configured for chainId ${chainId}. ` +
+        `Connected wallet appears to be a smart-contract account, but this ` +
+        `chain is not in the supported list. Either connect an EOA or extend ` +
+        `SAFE_TX_SERVICE_BASE_URLS in waitForTransactionReceiptSmartAware.ts.`,
+    );
+  }
+
+  const url = `${baseUrl}/api/v1/multisig-transactions/${safeTxHash}/`;
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    const response = await fetch(url).catch((err: unknown) => {
+      throw new Error(
+        `Network error while polling Safe Transaction Service: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    });
+
+    if (response.ok) {
+      const data = (await response.json()) as SafeMultisigTransaction;
+      if (data.isExecuted) {
+        if (data.isSuccessful === false) {
+          throw new Error(
+            `Safe transaction ${safeTxHash} was executed on chain but reverted. ` +
+              `Check the Safe queue UI for details.`,
+          );
+        }
+        if (data.transactionHash) {
+          return data.transactionHash;
+        }
+      }
+    } else if (response.status !== 404) {
+      throw new Error(
+        `Safe Transaction Service returned ${response.status} for ${safeTxHash}.`,
+      );
+    }
+
+    await sleep(pollIntervalMs);
+  }
+
+  throw new Error(
+    `Timed out after ${timeoutMs}ms waiting for Safe transaction ${safeTxHash} ` +
+      `to reach quorum and execute. The proposal is still pending in the Safe ` +
+      `queue — co-signers must sign and execute it before the dApp can proceed.`,
+  );
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}

--- a/packages/babylon-ts-sdk/src/tbv/core/utils/eth/waitForTransactionReceiptSmartAware.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/utils/eth/waitForTransactionReceiptSmartAware.ts
@@ -35,6 +35,7 @@ const SAFE_TX_SERVICE_BASE_URLS: Record<number, string> = {
 
 const DEFAULT_SAFE_POLL_INTERVAL_MS = 5_000;
 const DEFAULT_SAFE_POLL_TIMEOUT_MS = 4 * 60 * 60 * 1_000;
+const SAFE_TX_SERVICE_FETCH_TIMEOUT_MS = 10_000;
 
 export interface WaitForTransactionReceiptSmartAwareParams {
   publicClient: PublicClient;
@@ -121,13 +122,30 @@ async function pollSafeTransactionServiceUntilExecuted({
   const deadline = Date.now() + timeoutMs;
 
   while (Date.now() < deadline) {
-    const response = await fetch(url).catch((err: unknown) => {
-      throw new Error(
-        `Network error while polling Safe Transaction Service: ${
-          err instanceof Error ? err.message : String(err)
-        }`,
+    const controller = new AbortController();
+    const fetchTimeoutId = setTimeout(
+      () => controller.abort(),
+      SAFE_TX_SERVICE_FETCH_TIMEOUT_MS,
+    );
+
+    let response: Response;
+    try {
+      response = await fetch(url, { signal: controller.signal });
+    } catch (err) {
+      // Transient failure (AbortError on per-request timeout, DNS hiccup,
+      // connection reset, etc.). Log and continue to the next poll iteration
+      // instead of consuming the entire safePollTimeoutMs budget on one blip.
+      // The outer `while (Date.now() < deadline)` is what enforces the overall
+      // budget; this catch deliberately preserves it.
+      console.warn(
+        `Safe Transaction Service request failed (will retry in ${pollIntervalMs}ms): ` +
+          (err instanceof Error ? err.message : String(err)),
       );
-    });
+      await sleep(pollIntervalMs);
+      continue;
+    } finally {
+      clearTimeout(fetchTimeoutId);
+    }
 
     if (response.ok) {
       const data = (await response.json()) as SafeMultisigTransaction;
@@ -142,7 +160,15 @@ async function pollSafeTransactionServiceUntilExecuted({
           return data.transactionHash;
         }
       }
-    } else if (response.status !== 404) {
+    } else if (response.status === 404) {
+      // Proposal not yet indexed — keep polling silently.
+    } else if (response.status >= 500) {
+      // Transient server error — same treatment as a hung connection: log and retry.
+      console.warn(
+        `Safe Transaction Service returned ${response.status} for ${safeTxHash}; retrying in ${pollIntervalMs}ms.`,
+      );
+    } else {
+      // Other 4xx (403, 410, etc.) is likely permanent — surface immediately.
       throw new Error(
         `Safe Transaction Service returned ${response.status} for ${safeTxHash}.`,
       );

--- a/packages/babylon-ts-sdk/src/tbv/core/utils/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/utils/index.ts
@@ -10,3 +10,4 @@ export * from "./transaction";
 export * from "./btc";
 export * from "./signing";
 export * from "./validation";
+export * from "./eth";

--- a/services/vault/src/applications/aave/clients/transaction.ts
+++ b/services/vault/src/applications/aave/clients/transaction.ts
@@ -124,11 +124,18 @@ async function executeTx(
 
     // Check if transaction was reverted
     if (receipt.status === "reverted") {
-      await throwRevertError(publicClient, receipt, hash, to, data, account);
+      await throwRevertError(
+        publicClient,
+        receipt,
+        receipt.transactionHash,
+        to,
+        data,
+        account,
+      );
     }
 
     return {
-      transactionHash: hash,
+      transactionHash: receipt.transactionHash,
       receipt,
     };
   } catch (error) {

--- a/services/vault/src/applications/aave/clients/transaction.ts
+++ b/services/vault/src/applications/aave/clients/transaction.ts
@@ -6,6 +6,7 @@
  */
 
 import { BTCVaultRegistryABI } from "@babylonlabs-io/ts-sdk/tbv/core";
+import { waitForTransactionReceiptSmartAware } from "@babylonlabs-io/ts-sdk/tbv/core/utils";
 import {
   AaveIntegrationAdapterABI,
   buildBorrowTx,
@@ -111,7 +112,15 @@ async function executeTx(
       account: walletClient.account!,
     });
 
-    const receipt = await publicClient.waitForTransactionReceipt({ hash });
+    // Smart-account-aware: Externally Owned Account (EOA) wallets — controlled
+    // by a single private key, e.g. MetaMask — resolve via the real tx hash
+    // directly. Safe-style multisigs return a `safeTxHash` here that requires
+    // polling the Safe Transaction Service before the on-chain receipt exists.
+    const receipt = await waitForTransactionReceiptSmartAware({
+      publicClient,
+      walletAddress: account,
+      hash,
+    });
 
     // Check if transaction was reverted
     if (receipt.status === "reverted") {

--- a/services/vault/src/clients/eth-contract/transactionFactory.ts
+++ b/services/vault/src/clients/eth-contract/transactionFactory.ts
@@ -4,6 +4,7 @@
  * Includes pre-flight simulation to catch errors before user signs.
  */
 
+import { waitForTransactionReceiptSmartAware } from "@babylonlabs-io/ts-sdk/tbv/core/utils";
 import {
   type Abi,
   type Address,
@@ -103,7 +104,15 @@ export async function executeWrite(
       account,
     });
 
-    const receipt = await publicClient.waitForTransactionReceipt({ hash });
+    // Smart-account-aware: Externally Owned Account (EOA) wallets — controlled
+    // by a single private key, e.g. MetaMask — resolve via the real tx hash
+    // directly. Safe-style multisigs return a `safeTxHash` here that requires
+    // polling the Safe Transaction Service before the on-chain receipt exists.
+    const receipt = await waitForTransactionReceiptSmartAware({
+      publicClient,
+      walletAddress: account.address,
+      hash,
+    });
 
     // Check if transaction was reverted
     if (receipt.status === "reverted") {

--- a/services/vault/src/clients/eth-contract/transactionFactory.ts
+++ b/services/vault/src/clients/eth-contract/transactionFactory.ts
@@ -124,7 +124,7 @@ export async function executeWrite(
       await throwRevertError(
         publicClient,
         receipt,
-        hash,
+        receipt.transactionHash,
         address,
         callData,
         account.address,
@@ -132,7 +132,7 @@ export async function executeWrite(
     }
 
     return {
-      transactionHash: hash,
+      transactionHash: receipt.transactionHash,
       receipt,
     };
   } catch (error) {


### PR DESCRIPTION
## Summary

The vault dApp currently hangs when the connected ETH wallet is a Safe multisig: viem's `waitForTransactionReceipt` polls the `safeTxHash` returned by `eth_sendTransaction` as if it were a real Ethereum tx hash and times out, even though the underlying tx eventually executes on-chain. This PR adds a smart-account-aware wrapper around `waitForTransactionReceipt` that detects smart-contract accounts via `eth_getCode` and resolves the real on-chain tx hash by polling Safe's Transaction Service.

**Behavior preserved for Externally Owned Account (EOA) wallets** — MetaMask, OKX, Rabby, hardware wallets, etc. The EOA branch is a straight pass-through to viem's existing `waitForTransactionReceipt` with the original arguments.

## The bug

When the dApp connects to a Safe via WalletConnect:

1. dApp calls `walletClient.sendTransaction(...)` / `walletClient.writeContract(...)`.
2. Safe Web intercepts the RPC and proposes a multisig transaction in its off-chain Transaction Service. It returns a `safeTxHash` (an EIP-712 hash of the proposal) as the response to `eth_sendTransaction`.
3. The dApp passes that hash straight to `publicClient.waitForTransactionReceipt({ hash })`.
4. viem polls for that hash on the Ethereum RPC. It will never appear on chain — the real tx hash is a separate value generated only when one of the Safe signers eventually calls `execTransaction()`.
5. viem hits its timeout and throws.

Reproduced on Sepolia with a 2-of-2 Safe (`0x51C0f61E48E11C3D2c11660087C4c16F4A71Dd43`). Concrete evidence:
- `safeTxHash` returned to dApp: `0x154a2d91...` — never on chain.
- Real Ethereum tx hash after quorum executed: `0x2e7459a3...` — visible on Etherscan and in the Safe Transaction Service response under `transactionHash`.

**Four failure sites** in the codebase — all swapped to the new wrapper:
- [`PeginManager.ts:1323`](packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L1323) — batch pegin (SUBMIT_PEGIN, step 4 of the 12-step deposit flow).
- [`PeginManager.ts:1161`](packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L1161) — single-vault pegin (separate code path).
- [`transactionFactory.ts:111`](services/vault/src/clients/eth-contract/transactionFactory.ts#L111) — ACTIVATE_VAULT (step 11) and any other vault contract write.
- [`applications/aave/clients/transaction.ts:118`](services/vault/src/applications/aave/clients/transaction.ts#L118) — **all Aave Integration operations**: borrow, repay, withdraw collaterals, reorder vaults.

## The fix

A new utility, `waitForTransactionReceiptSmartAware`, replaces direct `waitForTransactionReceipt` calls at all four sites listed above.

**Flow:**

1. Call `publicClient.getCode({ address: walletAddress })`.
2. If `"0x"` (empty bytecode) → EOA. Delegate to `publicClient.waitForTransactionReceipt({ hash, confirmations, timeout })` unchanged.
3. Otherwise → smart-contract account. Look up the Safe Transaction Service URL for the current chain, poll `GET /api/v1/multisig-transactions/{safeTxHash}/` every 5 seconds (configurable) until the response shows `isExecuted: true && isSuccessful: true`. Extract `transactionHash` (the real Ethereum hash) and call `publicClient.waitForTransactionReceipt({ hash: realTxHash, confirmations })`.

**Edge cases handled explicitly:**
- Safe tx executed but reverted on chain → throws a clear error referencing the Safe queue UI.
- Chain has no configured Safe Transaction Service → throws explaining how to extend the URL map.
- Service returns 404 briefly while the proposal is being indexed → retries silently.
- Service returns 5xx → throws with status code.
- Quorum is never reached → throws after the configured `safePollTimeoutMs` (default 4 hours).

**Timeouts:**

| Phase | Default | Configurable via |
|---|---|---|
| Wait for Safe quorum + execution | 4 hours | `safePollTimeoutMs` |
| Poll cadence | 5 seconds | `safePollIntervalMs` |
| Inner `waitForTransactionReceipt` once real hash is known | viem default | `timeout` |

## Scope (deliberately tight)

**In scope:**
- Transport-layer fix at all four `waitForTransactionReceipt` sites (pegin batch, pegin single-vault, vault contract writes, Aave Integration operations).
- Detection of any smart-contract account via `eth_getCode`.
- Resolution via Safe Transaction Service for Safe wallets.
- Mainnet (chainId 1) and Sepolia (11155111) only.

**Out of scope** (deliberately, will be follow-up tickets):
- **UI changes.** No "Tx pending in your Safe queue — go sign quorum" state. Users see the existing "submitting transaction" spinner for the entire 4-hour budget.
- **Non-Safe smart wallets** (Fireblocks, Privy, Coinbase Smart Wallet, ERC-4337 bundlers, Argent, Sequence, etc.). They'll be detected as smart accounts and hit the Safe poll branch — which will 404 against the Safe service for the entire 4h timeout (or until user refreshes the page). This is a minor regression vs. today's behavior (where they'd fail at viem's ~3-minute timeout) but those wallets don't work today either. Explicitly listed as follow-ups in `markdown/safeglobal/SAFE-MANUAL-TEST.md`.
- **Resume after refresh / long delay.** The peginStorage layer doesn't yet recognize a Safe tx executed while the tab was closed. Separate finding.
- **Stuck-BTC recovery UX.** No `activateAndRedeem` or claim-path UI. Separate concern.
- **HTLC secret leakage at step 11 (ACTIVATE_VAULT).** Per the protocol team's analysis, this is informational, not a security blocker. Contract-level fix, not transport.

## Trust assumption introduced

We trust `safe-transaction-{network}.safe.global` to return the correct `transactionHash` for a given `safeTxHash`. Mitigation: the receipt is still fetched from our public RPC, so a malicious or compromised response would point to a non-existent or unrelated tx, and the inner `waitForTransactionReceipt` would time out (no such tx mined). Worst case is a silent hang, not a wrong-state confirmation. Same service is already trusted implicitly by anyone using Safe Web.

Three new files (utility + barrel + tests); five modified.

### Code-quality notes against CLAUDE.md

- **No magic numbers** — `DEFAULT_SAFE_POLL_INTERVAL_MS` and `DEFAULT_SAFE_POLL_TIMEOUT_MS` are named module-level constants.
- **No silent fallbacks** — every error path throws with an actionable message.
- **No dead code** — both new files are imported; the new util is re-exported through the SDK's `tbv/core/utils` public path so vault can consume it.
- **No backwards-compat shims** — pure additive change behind a new utility.

### Critical-path consideration

`transactionFactory.ts` is called by `vaultActivationService.ts`, which is listed in CLAUDE.md as a critical path (item 5 — HTLC secret submission). The behavior change here is "wait longer when wallet is a smart-contract account, then call viem on the real tx hash" — the value-flow semantics are unchanged. The hash returned to the rest of the pipeline is always a real on-chain tx hash, never a `safeTxHash`. The same invariant holds for the Aave Integration path (`applications/aave/clients/transaction.ts`): borrower/amount/reserve are untouched; only the receipt-wait phase changes. Worth a second reviewer for the activation site in particular.

## Test plan

### Automated — already verified locally

| Suite | Result |
|---|---|
| New utility unit tests (6 cases) | ✅ 6/6 pass |
| All `@babylonlabs-io/ts-sdk` tests | ✅ 1087/1087 pass |
| All `services/vault` tests | ✅ 1136/1136 pass (4 skipped, pre-existing) |
| `pnpm --filter @babylonlabs-io/ts-sdk run lint` | ✅ 0 errors |
| `pnpm --filter vault run lint` | ✅ 0 errors (75 pre-existing `any` warnings unchanged) |
| `pnpm --filter @babylonlabs-io/ts-sdk run build` | ✅ |

New tests cover:
- EOA path delegates to viem with identical arguments and never touches the Safe Transaction Service.
- Smart-account path polls the Safe service, retries while `isExecuted: false`, and resolves with the real tx hash.
- Reverted Safe execution surfaces a descriptive error.
- Unsupported chain throws with guidance on how to extend the URL map.
- Quorum never reached → clean timeout error after the configured budget.
- 404 during indexing lag is retried silently.

### Manual — to verify end-to-end with a real Safe

Setup (the reviewer will need this — same as the test plan in `markdown/safeglobal/`):
- Two EOA signer wallets on Sepolia (e.g. MetaMask + OKX Wallet) with Sepolia ETH.
- A 2-of-2 Safe on Sepolia at `app.safe.global`.
- Vault dApp on Sepolia (`NEXT_PUBLIC_ETH_CHAINID=11155111`, `NEXT_PUBLIC_BTC_NETWORK=signet`).
- BTC signet wallet funded with ~0.005 BTC.

Steps:

1. **Rebuild and run the dApp:**
   ```bash
   nvm use 24
   pnpm install
   pnpm --filter @babylonlabs-io/ts-sdk run build
   pnpm --filter vault run dev
   ```
2. **Connect Safe via WalletConnect** — paste the `wc:` URI from the dApp into Safe Web's WalletConnect button. Confirm the dApp shows the Safe address, not an EOA.
3. **Initiate a deposit** and proceed through BTC steps 1-3 (DERIVE_VAULT_SECRET, SIGN_PEGIN_BTC, SIGN_POP).
4. **Step 4 — SUBMIT_PEGIN (first ETH tx):**
   - The dApp proposes a Safe tx; the existing "submitting" UI remains.
   - In Safe Web, sign with both signers and execute.
   - **Expected:** within ~5 seconds of execution, the dApp advances to step 5 (BROADCAST_PRE_PEGIN). No timeout error.
5. **Proceed through BTC steps 5-10** to reach step 11.
6. **Step 11 — ACTIVATE_VAULT (second ETH tx):**
   - Same Safe propose → sign quorum → execute flow.
   - **Expected:** dApp advances to step 12 (COMPLETED). Note: the calldata containing the HTLC secret is still publicly readable in Safe's queue and Tx Service API between propose and execute — this is the contract-design issue tracked separately.
7. **Aave borrow with Safe** (covers the fourth call site):
   - From the dashboard, click Borrow on a reserve (e.g. USDC).
   - On the reserve page, click Borrow with an amount.
   - Same Safe propose → sign quorum → execute flow.
   - **Expected:** the dApp's "Processing..." spinner clears within ~5s of execution, the borrow-success modal appears, "View loan" navigates to the home page.
8. **Aave repay with Safe** (same code path, different operation):
   - From the dashboard, click Repay; complete the flow as above.

### EOA regression check

Run the same flow with a plain MetaMask connection (no Safe). Expected behavior: identical to before this PR. The new utility's EOA branch is a verbatim pass-through to viem.

## Follow-up tickets to file

- UI: dedicated "Transaction pending in your Safe queue" state with a deep-link to the proposed tx.
- Resume / recovery: detect that a Safe-pending pegin was executed while the tab was closed; advance the in-flight deposit state without re-proposing.
- Stuck-BTC recovery: surface `activateAndRedeem` / claim-path UX when activation never reaches quorum.
- Non-Safe smart wallets: branch the smart-account path to support ERC-4337 bundlers and other custody providers.
- Mark this PR's draft (kind of) scope formally as a precursor to a broader "smart-contract wallet support" workstream.