### PR TITLE
fix(vault): gate /activity on BTC+ETH wallet state

### DIFF
--- a/services/vault/src/__tests__/router.test.tsx
+++ b/services/vault/src/__tests__/router.test.tsx
@@ -41,6 +41,7 @@ vi.mock("../applications/aave/services", () => ({
 
 vi.mock("@/context/wallet", () => ({
   useETHWallet: () => ({ address: "0xethtest", connected: true }),
+  useBTCWallet: () => ({ connected: true }),
 }));
 
 vi.mock("../services/activity", async () => {

--- a/services/vault/src/__tests__/router.test.tsx
+++ b/services/vault/src/__tests__/router.test.tsx
@@ -42,6 +42,11 @@ vi.mock("../applications/aave/services", () => ({
 vi.mock("@/context/wallet", () => ({
   useETHWallet: () => ({ address: "0xethtest", connected: true }),
   useBTCWallet: () => ({ connected: true }),
+  useConnection: () => ({
+    isConnected: true,
+    btcConnected: true,
+    ethConnected: true,
+  }),
 }));
 
 vi.mock("../services/activity", async () => {

--- a/services/vault/src/components/pages/Activity.tsx
+++ b/services/vault/src/components/pages/Activity.tsx
@@ -6,14 +6,16 @@
 import { Card, Container, Loader } from "@babylonlabs-io/core-ui";
 import type { Hex } from "viem";
 
-import { useETHWallet } from "../../context/wallet";
+import { useBTCWallet, useETHWallet } from "../../context/wallet";
 import { useActivitiesWithPending } from "../../hooks/useActivitiesWithPending";
 import { ActivityEmptyState, ActivityTable } from "../Activity";
 
 export default function Activity() {
-  const { address, connected } = useETHWallet();
+  const { address, connected: ethConnected } = useETHWallet();
+  const { connected: btcConnected } = useBTCWallet();
+  const connected = btcConnected && ethConnected;
   const { data: activities, isLoading } = useActivitiesWithPending(
-    address as Hex,
+    connected ? (address as Hex) : undefined,
   );
 
   const hasActivities = activities && activities.length > 0;
@@ -36,7 +38,7 @@ export default function Activity() {
           ) : hasActivities ? (
             <ActivityTable activities={activities} />
           ) : (
-            <ActivityEmptyState isConnected={connected} />
+            <ActivityEmptyState isConnected={Boolean(connected)} />
           )}
         </div>
       </Card>

--- a/services/vault/src/components/pages/Activity.tsx
+++ b/services/vault/src/components/pages/Activity.tsx
@@ -6,16 +6,15 @@
 import { Card, Container, Loader } from "@babylonlabs-io/core-ui";
 import type { Hex } from "viem";
 
-import { useBTCWallet, useETHWallet } from "../../context/wallet";
+import { useConnection, useETHWallet } from "../../context/wallet";
 import { useActivitiesWithPending } from "../../hooks/useActivitiesWithPending";
 import { ActivityEmptyState, ActivityTable } from "../Activity";
 
 export default function Activity() {
-  const { address, connected: ethConnected } = useETHWallet();
-  const { connected: btcConnected } = useBTCWallet();
-  const connected = btcConnected && ethConnected;
+  const { address } = useETHWallet();
+  const { isConnected } = useConnection();
   const { data: activities, isLoading } = useActivitiesWithPending(
-    connected ? (address as Hex) : undefined,
+    isConnected ? (address as Hex) : undefined,
   );
 
   const hasActivities = activities && activities.length > 0;
@@ -38,7 +37,7 @@ export default function Activity() {
           ) : hasActivities ? (
             <ActivityTable activities={activities} />
           ) : (
-            <ActivityEmptyState isConnected={Boolean(connected)} />
+            <ActivityEmptyState isConnected={isConnected} />
           )}
         </div>
       </Card>

--- a/services/vault/src/components/pages/__tests__/Activity.test.tsx
+++ b/services/vault/src/components/pages/__tests__/Activity.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * Activity page wallet-gating tests.
+ *
+ * The Header treats the user as connected only when BOTH the BTC and ETH
+ * wallets are connected (see RootLayout.tsx). These tests lock in that the
+ * Activity page uses the same canonical signal: a stale ETH address alone
+ * must not trigger an indexer query or the "connected" empty state.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Outlet, Route, Routes } from "react-router";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const useBTCWalletMock = vi.fn();
+const useETHWalletMock = vi.fn();
+const useActivitiesWithPendingMock = vi.fn();
+
+vi.mock("@/context/wallet", () => ({
+  useBTCWallet: () => useBTCWalletMock(),
+  useETHWallet: () => useETHWalletMock(),
+}));
+
+vi.mock("../../../hooks/useActivitiesWithPending", () => ({
+  useActivitiesWithPending: (arg: unknown) => useActivitiesWithPendingMock(arg),
+}));
+
+import Activity from "../Activity";
+
+function renderActivity() {
+  return render(
+    <MemoryRouter initialEntries={["/activity"]}>
+      <Routes>
+        <Route element={<Outlet context={{ openDeposit: () => {} }} />}>
+          <Route path="/activity" element={<Activity />} />
+        </Route>
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("Activity page — wallet gating", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useActivitiesWithPendingMock.mockReturnValue({
+      data: [],
+      isLoading: false,
+    });
+  });
+
+  it("treats BTC-disconnected + ETH-stale-address as disconnected, skipping the indexer query", () => {
+    useBTCWalletMock.mockReturnValue({ connected: false, address: "" });
+    useETHWalletMock.mockReturnValue({
+      address: "0xabc0000000000000000000000000000000000001",
+      connected: true,
+    });
+
+    renderActivity();
+
+    expect(
+      screen.getByText("Connect your wallet to view your activity"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        "No activity yet. Make your first deposit to get started.",
+      ),
+    ).not.toBeInTheDocument();
+
+    expect(useActivitiesWithPendingMock).toHaveBeenCalledWith(undefined);
+  });
+
+  it("treats ETH-disconnected + BTC-connected as disconnected, skipping the indexer query", () => {
+    useBTCWalletMock.mockReturnValue({ connected: true, address: "bc1qtest" });
+    useETHWalletMock.mockReturnValue({
+      address: undefined,
+      connected: false,
+    });
+
+    renderActivity();
+
+    expect(
+      screen.getByText("Connect your wallet to view your activity"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        "No activity yet. Make your first deposit to get started.",
+      ),
+    ).not.toBeInTheDocument();
+
+    expect(useActivitiesWithPendingMock).toHaveBeenCalledWith(undefined);
+  });
+
+  it("treats both wallets connected as connected and renders the connected empty state", () => {
+    useBTCWalletMock.mockReturnValue({
+      connected: true,
+      address: "bc1qtest",
+    });
+    useETHWalletMock.mockReturnValue({
+      address: "0xabc0000000000000000000000000000000000001",
+      connected: true,
+    });
+
+    renderActivity();
+
+    expect(
+      screen.getByText(
+        "No activity yet. Make your first deposit to get started.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("Connect your wallet to view your activity"),
+    ).not.toBeInTheDocument();
+
+    expect(useActivitiesWithPendingMock).toHaveBeenCalledWith(
+      "0xabc0000000000000000000000000000000000001",
+    );
+  });
+});

--- a/services/vault/src/components/pages/__tests__/Activity.test.tsx
+++ b/services/vault/src/components/pages/__tests__/Activity.test.tsx
@@ -11,12 +11,12 @@ import { render, screen } from "@testing-library/react";
 import { MemoryRouter, Outlet, Route, Routes } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const useBTCWalletMock = vi.fn();
+const useConnectionMock = vi.fn();
 const useETHWalletMock = vi.fn();
 const useActivitiesWithPendingMock = vi.fn();
 
-vi.mock("@/context/wallet", () => ({
-  useBTCWallet: () => useBTCWalletMock(),
+vi.mock("../../../context/wallet", () => ({
+  useConnection: () => useConnectionMock(),
   useETHWallet: () => useETHWalletMock(),
 }));
 
@@ -48,7 +48,11 @@ describe("Activity page — wallet gating", () => {
   });
 
   it("treats BTC-disconnected + ETH-stale-address as disconnected, skipping the indexer query", () => {
-    useBTCWalletMock.mockReturnValue({ connected: false, address: "" });
+    useConnectionMock.mockReturnValue({
+      isConnected: false,
+      btcConnected: false,
+      ethConnected: true,
+    });
     useETHWalletMock.mockReturnValue({
       address: "0xabc0000000000000000000000000000000000001",
       connected: true,
@@ -69,7 +73,11 @@ describe("Activity page — wallet gating", () => {
   });
 
   it("treats ETH-disconnected + BTC-connected as disconnected, skipping the indexer query", () => {
-    useBTCWalletMock.mockReturnValue({ connected: true, address: "bc1qtest" });
+    useConnectionMock.mockReturnValue({
+      isConnected: false,
+      btcConnected: true,
+      ethConnected: false,
+    });
     useETHWalletMock.mockReturnValue({
       address: undefined,
       connected: false,
@@ -90,9 +98,10 @@ describe("Activity page — wallet gating", () => {
   });
 
   it("treats both wallets connected as connected and renders the connected empty state", () => {
-    useBTCWalletMock.mockReturnValue({
-      connected: true,
-      address: "bc1qtest",
+    useConnectionMock.mockReturnValue({
+      isConnected: true,
+      btcConnected: true,
+      ethConnected: true,
     });
     useETHWalletMock.mockReturnValue({
       address: "0xabc0000000000000000000000000000000000001",

--- a/services/vault/src/hooks/__tests__/useActivitiesWithPending.test.tsx
+++ b/services/vault/src/hooks/__tests__/useActivitiesWithPending.test.tsx
@@ -42,11 +42,12 @@ describe("useActivitiesWithPending", () => {
     const pending = [makePending("pending-1", 1_000)];
     getPendingActivitiesMock.mockReturnValue(pending);
 
-    const { result, rerender } = renderHook(
-      ({ addr }: { addr: typeof ADDR | undefined }) =>
-        useActivitiesWithPending(addr),
-      { initialProps: { addr: ADDR } },
-    );
+    type Props = { addr: typeof ADDR | undefined };
+    const initialProps: Props = { addr: ADDR };
+    const { result, rerender } = renderHook<
+      ReturnType<typeof useActivitiesWithPending>,
+      Props
+    >(({ addr }) => useActivitiesWithPending(addr), { initialProps });
 
     expect(result.current.data).toEqual(pending);
 

--- a/services/vault/src/hooks/__tests__/useActivitiesWithPending.test.tsx
+++ b/services/vault/src/hooks/__tests__/useActivitiesWithPending.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * Tests for useActivitiesWithPending hook
+ *
+ * Validates that activities returned to consumers are gated synchronously
+ * on userAddress, so a connected → disconnected transition does not leak
+ * the previous wallet's pendingActivities for one render.
+ */
+
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ActivityLog } from "../../types/activityLog";
+import { useActivitiesWithPending } from "../useActivitiesWithPending";
+
+const useActivitiesMock = vi.fn();
+const getPendingActivitiesMock = vi.fn();
+
+vi.mock("../useActivities", () => ({
+  useActivities: (arg: unknown) => useActivitiesMock(arg),
+}));
+
+vi.mock("../../services/activity", () => ({
+  getPendingActivities: (arg: unknown) => getPendingActivitiesMock(arg),
+}));
+
+const ADDR = "0xabc0000000000000000000000000000000000001" as const;
+
+function makePending(id: string, dateMs: number): ActivityLog {
+  return {
+    id,
+    date: new Date(dateMs),
+  } as ActivityLog;
+}
+
+describe("useActivitiesWithPending", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useActivitiesMock.mockReturnValue({ data: [], isLoading: false });
+  });
+
+  it("returns [] synchronously when userAddress is undefined, even if pending activities exist for a prior address", () => {
+    const pending = [makePending("pending-1", 1_000)];
+    getPendingActivitiesMock.mockReturnValue(pending);
+
+    const { result, rerender } = renderHook(
+      ({ addr }: { addr: typeof ADDR | undefined }) =>
+        useActivitiesWithPending(addr),
+      { initialProps: { addr: ADDR } },
+    );
+
+    expect(result.current.data).toEqual(pending);
+
+    rerender({ addr: undefined });
+
+    expect(result.current.data).toEqual([]);
+  });
+
+  it("returns merged activities when userAddress is provided", () => {
+    const pending = [makePending("pending-1", 2_000)];
+    const confirmed = [makePending("confirmed-1", 1_000)];
+    getPendingActivitiesMock.mockReturnValue(pending);
+    useActivitiesMock.mockReturnValue({ data: confirmed, isLoading: false });
+
+    const { result } = renderHook(() => useActivitiesWithPending(ADDR));
+
+    expect(result.current.data.map((a) => a.id)).toEqual([
+      "pending-1",
+      "confirmed-1",
+    ]);
+  });
+});

--- a/services/vault/src/hooks/useActivitiesWithPending.ts
+++ b/services/vault/src/hooks/useActivitiesWithPending.ts
@@ -71,6 +71,8 @@ export function useActivitiesWithPending(userAddress: Address | undefined) {
 
   // Merge confirmed and pending activities, deduplicating by ID
   const allActivities = useMemo(() => {
+    if (!userAddress) return [];
+
     const confirmed = confirmedActivities ?? [];
 
     // Create set of confirmed IDs for deduplication
@@ -85,7 +87,7 @@ export function useActivitiesWithPending(userAddress: Address | undefined) {
     return [...uniquePending, ...confirmed].sort(
       (a, b) => b.date.getTime() - a.date.getTime(),
     );
-  }, [confirmedActivities, pendingActivities]);
+  }, [confirmedActivities, pendingActivities, userAddress]);
 
   return {
     data: allActivities,


### PR DESCRIPTION
The Activity page only consulted useETHWallet().connected, which is Boolean(address). A stale ETH address from a previous session (or a partial disconnect where only BTC was dropped) left the page in the "connected" branch: it queried the indexer with the lingering address and rendered the "No activity yet" empty state — while the Header (which gates on btcConnected && ethConnected in RootLayout.tsx:85-91) correctly showed the Connect button.

Symptom on demo.vault-devnet.babylonlabs.io: Aave V4 activity rows visible alongside a Connect button.

Use the same canonical signal as the Header. When either wallet is disconnected, pass undefined to useActivitiesWithPending so React Query stays disabled, and render the disconnected empty-state copy.

Add three TDD-anchored unit tests covering: BTC-disconnected with a stale ETH address, ETH-disconnected with BTC connected, and both connected (the only state that should query the indexer and show the connected empty state).