### PR TITLE
fix(ts-sdk): enforce exact challenger set in depositor graph signing

### DIFF
--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/signDepositorGraph.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/signDepositorGraph.test.ts
@@ -116,8 +116,11 @@ const VP_PUBKEY = "f".repeat(64);
 const VK_PUBKEY = "1".repeat(64);
 const UC_PUBKEY = "2".repeat(64);
 const COUNCIL_MEMBER = "c".repeat(64);
-const CHALLENGER_A = "a".repeat(64);
-const CHALLENGER_B = "b".repeat(64);
+// Local challengers (per protocol: {VP, VKs} \ {depositor}). Tests use these
+// two as the canonical challenger pair so the supplied `challenger_presign_data`
+// matches `localChallengers` derived from the signing context.
+const CHALLENGER_A = VP_PUBKEY;
+const CHALLENGER_B = VK_PUBKEY;
 const REGISTERED_PAYOUT_SCRIPT = `0x5120${"e".repeat(64)}`;
 const PEGIN_TX_HEX = "cafebabe";
 const TIMELOCK_PEGIN = 50;
@@ -239,6 +242,7 @@ function createDepositorGraph(
 function createSigningContext(
   overrides?: Partial<DepositorGraphSigningContext>,
 ): DepositorGraphSigningContext {
+  // Default matches production: localChallengers = [VP_PUBKEY, VK_PUBKEY].
   return {
     peginTxHex: PEGIN_TX_HEX,
     depositorBtcPubkey: DEPOSITOR_PUBKEY,
@@ -261,7 +265,7 @@ function createSigningContext(
 
 describe("signDepositorGraph", () => {
   it("rebuilds the payout PSBT locally from authoritative connector params", async () => {
-    registerStandardMocks([CHALLENGER_A]);
+    registerStandardMocks([CHALLENGER_A, CHALLENGER_B]);
     const { buildPayoutPsbt } = await import(
       "../../../primitives/psbt/payout"
     );
@@ -269,7 +273,7 @@ describe("signDepositorGraph", () => {
     builder.mockClear();
 
     const wallet = createMockWallet({ supportsBatch: true });
-    const graph = createDepositorGraph([CHALLENGER_A]);
+    const graph = createDepositorGraph([CHALLENGER_A, CHALLENGER_B]);
     const ctx = createSigningContext();
 
     await signDepositorGraph({
@@ -340,7 +344,7 @@ describe("signDepositorGraph", () => {
   });
 
   it("validates the NoPayout output sink before signing each challenger", async () => {
-    registerStandardMocks([CHALLENGER_A]);
+    registerStandardMocks([CHALLENGER_A, CHALLENGER_B]);
     const { assertNoPayoutOutputMatchesChallenger } = await import(
       "../../../primitives/psbt/noPayout"
     );
@@ -348,7 +352,7 @@ describe("signDepositorGraph", () => {
     sinkValidator.mockClear();
 
     const wallet = createMockWallet({ supportsBatch: true });
-    const graph = createDepositorGraph([CHALLENGER_A]);
+    const graph = createDepositorGraph([CHALLENGER_A, CHALLENGER_B]);
 
     await signDepositorGraph({
       depositorGraph: graph,
@@ -364,7 +368,7 @@ describe("signDepositorGraph", () => {
   });
 
   it("propagates NoPayout output sink errors and never reaches the wallet", async () => {
-    registerStandardMocks([CHALLENGER_A]);
+    registerStandardMocks([CHALLENGER_A, CHALLENGER_B]);
     const { assertNoPayoutOutputMatchesChallenger } = await import(
       "../../../primitives/psbt/noPayout"
     );
@@ -377,7 +381,7 @@ describe("signDepositorGraph", () => {
     );
 
     const wallet = createMockWallet({ supportsBatch: true });
-    const graph = createDepositorGraph([CHALLENGER_A]);
+    const graph = createDepositorGraph([CHALLENGER_A, CHALLENGER_B]);
 
     await expect(
       signDepositorGraph({
@@ -392,7 +396,7 @@ describe("signDepositorGraph", () => {
   });
 
   it("rejects a NoPayout that doesn't have exactly 3 inputs", async () => {
-    registerStandardMocks([CHALLENGER_A]);
+    registerStandardMocks([CHALLENGER_A, CHALLENGER_B]);
     // Replace the nopayout tx with a 2-input variant
     registerMockTx(nopayoutTxHex(CHALLENGER_A), {
       ins: [
@@ -412,7 +416,7 @@ describe("signDepositorGraph", () => {
     });
 
     const wallet = createMockWallet({ supportsBatch: true });
-    const graph = createDepositorGraph([CHALLENGER_A]);
+    const graph = createDepositorGraph([CHALLENGER_A, CHALLENGER_B]);
 
     await expect(
       signDepositorGraph({
@@ -426,7 +430,7 @@ describe("signDepositorGraph", () => {
   });
 
   it("rejects a NoPayout whose Assert input references a different parent txid", async () => {
-    registerStandardMocks([CHALLENGER_A]);
+    registerStandardMocks([CHALLENGER_A, CHALLENGER_B]);
     registerMockTx(nopayoutTxHex(CHALLENGER_A), {
       ins: [
         {
@@ -453,7 +457,7 @@ describe("signDepositorGraph", () => {
     });
 
     const wallet = createMockWallet({ supportsBatch: true });
-    const graph = createDepositorGraph([CHALLENGER_A]);
+    const graph = createDepositorGraph([CHALLENGER_A, CHALLENGER_B]);
 
     await expect(
       signDepositorGraph({
@@ -467,7 +471,7 @@ describe("signDepositorGraph", () => {
   });
 
   it("rejects a NoPayout input that spends a non-zero vout of its parent", async () => {
-    registerStandardMocks([CHALLENGER_A]);
+    registerStandardMocks([CHALLENGER_A, CHALLENGER_B]);
     registerMockTx(nopayoutTxHex(CHALLENGER_A), {
       ins: [
         {
@@ -491,7 +495,7 @@ describe("signDepositorGraph", () => {
     });
 
     const wallet = createMockWallet({ supportsBatch: true });
-    const graph = createDepositorGraph([CHALLENGER_A]);
+    const graph = createDepositorGraph([CHALLENGER_A, CHALLENGER_B]);
 
     await expect(
       signDepositorGraph({
@@ -503,7 +507,8 @@ describe("signDepositorGraph", () => {
   });
 
   it("derives localChallengers as {VP, VKs} \\ {depositor}", async () => {
-    registerStandardMocks([CHALLENGER_A]);
+    const EXTRA_KEEPER = "9".repeat(64);
+    registerStandardMocks([VP_PUBKEY, EXTRA_KEEPER]);
     const { buildNoPayoutPsbt } = await import(
       "../../../primitives/psbt/noPayout"
     );
@@ -515,7 +520,7 @@ describe("signDepositorGraph", () => {
       supportsBatch: true,
       pubkey: `02${VK_PUBKEY}`,
     });
-    const graph = createDepositorGraph([CHALLENGER_A]);
+    const graph = createDepositorGraph([VP_PUBKEY, EXTRA_KEEPER]);
 
     // Make the depositor also one of the vault keepers - it should be filtered.
     await signDepositorGraph({
@@ -557,9 +562,9 @@ describe("signDepositorGraph", () => {
   });
 
   it("uses batch signing when wallet supports signPsbts", async () => {
-    registerStandardMocks([CHALLENGER_A]);
+    registerStandardMocks([CHALLENGER_A, CHALLENGER_B]);
     const wallet = createMockWallet({ supportsBatch: true });
-    const graph = createDepositorGraph([CHALLENGER_A]);
+    const graph = createDepositorGraph([CHALLENGER_A, CHALLENGER_B]);
 
     await signDepositorGraph({
       depositorGraph: graph,
@@ -572,9 +577,9 @@ describe("signDepositorGraph", () => {
   });
 
   it("falls back to sequential signPsbt when signPsbts is not available", async () => {
-    registerStandardMocks([CHALLENGER_A]);
+    registerStandardMocks([CHALLENGER_A, CHALLENGER_B]);
     const wallet = createMockWallet({ supportsBatch: false });
-    const graph = createDepositorGraph([CHALLENGER_A]);
+    const graph = createDepositorGraph([CHALLENGER_A, CHALLENGER_B]);
 
     await signDepositorGraph({
       depositorGraph: graph,
@@ -582,16 +587,17 @@ describe("signDepositorGraph", () => {
       signingContext: createSigningContext(),
     });
 
-    expect(wallet.signPsbt).toHaveBeenCalledTimes(2);
+    // 1 payout + 2 nopayouts (one per challenger).
+    expect(wallet.signPsbt).toHaveBeenCalledTimes(3);
   });
 
   it("throws when wallet returns wrong number of signed PSBTs", async () => {
-    registerStandardMocks([CHALLENGER_A]);
+    registerStandardMocks([CHALLENGER_A, CHALLENGER_B]);
     const wallet = createMockWallet({ supportsBatch: true });
     (wallet.signPsbts as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
       "only_one",
     ]);
-    const graph = createDepositorGraph([CHALLENGER_A]);
+    const graph = createDepositorGraph([CHALLENGER_A, CHALLENGER_B]);
 
     await expect(
       signDepositorGraph({
@@ -599,28 +605,13 @@ describe("signDepositorGraph", () => {
         btcWallet: wallet,
         signingContext: createSigningContext(),
       }),
-    ).rejects.toThrow("expected 2");
-  });
-
-  it("handles graph with no challengers (payout only)", async () => {
-    registerStandardMocks([]);
-    const wallet = createMockWallet({ supportsBatch: true });
-    const graph = createDepositorGraph([]);
-
-    const result = await signDepositorGraph({
-      depositorGraph: graph,
-      btcWallet: wallet,
-      signingContext: createSigningContext(),
-    });
-
-    expect(result.payout_signatures.payout_signature).toBeDefined();
-    expect(Object.keys(result.per_challenger)).toHaveLength(0);
+    ).rejects.toThrow("expected 3");
   });
 
   it("strips 0x prefix from depositor pubkey", async () => {
-    registerStandardMocks([CHALLENGER_A]);
+    registerStandardMocks([CHALLENGER_A, CHALLENGER_B]);
     const wallet = createMockWallet({ supportsBatch: true });
-    const graph = createDepositorGraph([CHALLENGER_A]);
+    const graph = createDepositorGraph([CHALLENGER_A, CHALLENGER_B]);
 
     const result = await signDepositorGraph({
       depositorGraph: graph,
@@ -634,7 +625,7 @@ describe("signDepositorGraph", () => {
   });
 
   it("validates the payout output against the registered scriptPubKey before signing", async () => {
-    registerStandardMocks([CHALLENGER_A]);
+    registerStandardMocks([CHALLENGER_A, CHALLENGER_B]);
     const { assertPayoutOutputMatchesRegistered } = await import(
       "../../../primitives/psbt/payout"
     );
@@ -642,7 +633,7 @@ describe("signDepositorGraph", () => {
     validator.mockClear();
 
     const wallet = createMockWallet({ supportsBatch: true });
-    const graph = createDepositorGraph([CHALLENGER_A]);
+    const graph = createDepositorGraph([CHALLENGER_A, CHALLENGER_B]);
 
     await signDepositorGraph({
       depositorGraph: graph,
@@ -657,7 +648,7 @@ describe("signDepositorGraph", () => {
   });
 
   it("propagates payout output validation errors and never reaches the wallet", async () => {
-    registerStandardMocks([CHALLENGER_A]);
+    registerStandardMocks([CHALLENGER_A, CHALLENGER_B]);
     const { assertPayoutOutputMatchesRegistered } = await import(
       "../../../primitives/psbt/payout"
     );
@@ -670,7 +661,7 @@ describe("signDepositorGraph", () => {
     );
 
     const wallet = createMockWallet({ supportsBatch: true });
-    const graph = createDepositorGraph([CHALLENGER_A]);
+    const graph = createDepositorGraph([CHALLENGER_A, CHALLENGER_B]);
 
     await expect(
       signDepositorGraph({
@@ -690,10 +681,10 @@ describe("signDepositorGraph", () => {
   // keyed by the wrong pubkey and extractPayoutSignature throws an opaque
   // "no signature found" error after multiple wallet popups.
   it("rejects when wallet pubkey does not match registered depositor pubkey", async () => {
-    registerStandardMocks([CHALLENGER_A]);
+    registerStandardMocks([CHALLENGER_A, CHALLENGER_B]);
     const otherDepositor = "e".repeat(64);
     const wallet = createMockWallet({ supportsBatch: true });
-    const graph = createDepositorGraph([CHALLENGER_A]);
+    const graph = createDepositorGraph([CHALLENGER_A, CHALLENGER_B]);
 
     await expect(
       signDepositorGraph({
@@ -704,6 +695,105 @@ describe("signDepositorGraph", () => {
         }),
       }),
     ).rejects.toThrow("Wallet public key does not match vault depositor");
+
+    expect(wallet.signPsbts).not.toHaveBeenCalled();
+    expect(wallet.signPsbt).not.toHaveBeenCalled();
+  });
+
+  // Audit #303: VP-supplied challenger_presign_data must be exactly the
+  // localChallengers set. Missing entries → activation with incomplete
+  // recovery material. Extra/duplicate entries → wallet signs PSBTs for
+  // challengers the protocol doesn't recognize.
+  it("rejects when VP omits a required local challenger", async () => {
+    // localChallengers = [CHALLENGER_A, CHALLENGER_B]; graph only supplies A.
+    registerStandardMocks([CHALLENGER_A]);
+    const wallet = createMockWallet({ supportsBatch: true });
+    const graph = createDepositorGraph([CHALLENGER_A]);
+
+    await expect(
+      signDepositorGraph({
+        depositorGraph: graph,
+        btcWallet: wallet,
+        signingContext: createSigningContext(),
+      }),
+    ).rejects.toThrow(/challenger set does not match localChallengers/);
+
+    expect(wallet.signPsbts).not.toHaveBeenCalled();
+    expect(wallet.signPsbt).not.toHaveBeenCalled();
+  });
+
+  it("rejects when VP returns an empty challenger_presign_data array", async () => {
+    registerStandardMocks([]);
+    const wallet = createMockWallet({ supportsBatch: true });
+    const graph = createDepositorGraph([]);
+
+    await expect(
+      signDepositorGraph({
+        depositorGraph: graph,
+        btcWallet: wallet,
+        signingContext: createSigningContext(),
+      }),
+    ).rejects.toThrow(/challenger set does not match localChallengers/);
+
+    expect(wallet.signPsbts).not.toHaveBeenCalled();
+    expect(wallet.signPsbt).not.toHaveBeenCalled();
+  });
+
+  it("rejects when VP injects a duplicate challenger entry", async () => {
+    registerStandardMocks([CHALLENGER_A, CHALLENGER_B]);
+    const wallet = createMockWallet({ supportsBatch: true });
+    // Two entries for CHALLENGER_A would otherwise produce two NoPayout
+    // signatures the protocol doesn't recognize.
+    const graph = createDepositorGraph([CHALLENGER_A, CHALLENGER_A]);
+
+    await expect(
+      signDepositorGraph({
+        depositorGraph: graph,
+        btcWallet: wallet,
+        signingContext: createSigningContext(),
+      }),
+    ).rejects.toThrow(/duplicate challenger entries/);
+
+    expect(wallet.signPsbts).not.toHaveBeenCalled();
+    expect(wallet.signPsbt).not.toHaveBeenCalled();
+  });
+
+  it("rejects when VP supplies an unexpected challenger not in localChallengers", async () => {
+    const STRANGER = "9".repeat(64);
+    registerStandardMocks([CHALLENGER_A, CHALLENGER_B, STRANGER]);
+    const wallet = createMockWallet({ supportsBatch: true });
+    const graph = createDepositorGraph([CHALLENGER_A, CHALLENGER_B, STRANGER]);
+
+    await expect(
+      signDepositorGraph({
+        depositorGraph: graph,
+        btcWallet: wallet,
+        signingContext: createSigningContext(),
+      }),
+    ).rejects.toThrow(/unexpected:.*9{64}/);
+
+    expect(wallet.signPsbts).not.toHaveBeenCalled();
+    expect(wallet.signPsbt).not.toHaveBeenCalled();
+  });
+
+  it("rejects misconfigured context where vault provider key equals a vault keeper key", async () => {
+    registerStandardMocks([CHALLENGER_A, CHALLENGER_B]);
+    const wallet = createMockWallet({ supportsBatch: true });
+    const graph = createDepositorGraph([CHALLENGER_A, CHALLENGER_B]);
+
+    // VP key == VK key: deriveLocalChallengers must fail loudly rather
+    // than producing a deduped set that downstream comparisons misread
+    // as a missing-challenger error.
+    await expect(
+      signDepositorGraph({
+        depositorGraph: graph,
+        btcWallet: wallet,
+        signingContext: createSigningContext({
+          vaultProviderBtcPubkey: VP_PUBKEY,
+          vaultKeeperBtcPubkeys: [VP_PUBKEY],
+        }),
+      }),
+    ).rejects.toThrow(/duplicates a vaultKeeper key/);
 
     expect(wallet.signPsbts).not.toHaveBeenCalled();
     expect(wallet.signPsbt).not.toHaveBeenCalled();

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts
@@ -96,7 +96,50 @@ function deriveLocalChallengers(
       "Cannot derive localChallengers: removing depositor from {vaultProvider, vaultKeepers} left an empty set",
     );
   }
+  // Catch upstream misconfiguration (VP key === a VK key) at its source.
+  // Otherwise downstream set comparisons would silently dedupe and report
+  // a misleading "missing challenger" error.
+  if (new Set(filtered).size !== filtered.length) {
+    throw new Error(
+      "Cannot derive localChallengers: vaultProvider key duplicates a vaultKeeper key — signing context is misconfigured",
+    );
+  }
   return filtered;
+}
+
+/**
+ * Reject VP-supplied `challenger_presign_data` whose pubkey set does not
+ * exactly equal `localChallengers`.
+ *
+ * Threat model: a malicious or buggy VP could omit, duplicate, or inject
+ * unrelated entries. Missing entries → depositor activates with incomplete
+ * recovery material (omitted challenger later becomes unenforceable).
+ * Duplicates or extras → wallet signs PSBTs for challengers the protocol
+ * doesn't recognize, handing the VP signatures it shouldn't have.
+ */
+function assertChallengerSetMatchesLocalChallengers(
+  challengerPresignData: PresignDataPerChallenger[],
+  localChallengers: string[],
+): void {
+  const suppliedList = challengerPresignData.map((c) =>
+    stripHexPrefix(c.challenger_pubkey).toLowerCase(),
+  );
+  const suppliedSet = new Set(suppliedList);
+  if (suppliedSet.size !== suppliedList.length) {
+    throw new Error(
+      "Depositor graph contains duplicate challenger entries in challenger_presign_data",
+    );
+  }
+  const expectedSet = new Set(localChallengers);
+  const missing = localChallengers.filter((c) => !suppliedSet.has(c));
+  const extra = suppliedList.filter((c) => !expectedSet.has(c));
+  if (missing.length > 0 || extra.length > 0) {
+    throw new Error(
+      `Depositor graph challenger set does not match localChallengers` +
+        (missing.length > 0 ? ` (missing: ${missing.join(", ")})` : "") +
+        (extra.length > 0 ? ` (unexpected: ${extra.join(", ")})` : ""),
+    );
+  }
 }
 
 /**
@@ -156,7 +199,19 @@ async function collectDepositorGraphPsbts(
   const signOptions: SignPsbtOptions[] = [];
   const challengerEntries: ChallengerEntry[] = [];
 
-  // 1. Validate the payout transaction's largest output pays to the
+  // 1. Fail-fast on a malformed VP response BEFORE doing any PSBT-build
+  //    work that would be wasted if the challenger set is wrong.
+  const localChallengers = deriveLocalChallengers(
+    ctx.vaultProviderBtcPubkey,
+    ctx.vaultKeeperBtcPubkeys,
+    ctx.depositorBtcPubkey,
+  );
+  assertChallengerSetMatchesLocalChallengers(
+    depositorGraph.challenger_presign_data,
+    localChallengers,
+  );
+
+  // 2. Validate the payout transaction's largest output pays to the
   //    depositor's on-chain registered payout scriptPubKey. The payout tx
   //    hex is supplied by the VP and otherwise unconstrained; this assertion
   //    pins the destination of the funds.
@@ -165,7 +220,7 @@ async function collectDepositorGraphPsbts(
     ctx.registeredPayoutScriptPubKey,
   );
 
-  // 2. Build the payout PSBT locally. Every sighash-relevant field
+  // 3. Build the payout PSBT locally. Every sighash-relevant field
   //    (witnessUtxo, tapLeafScript, controlBlock, tapInternalKey) is derived
   //    from on-chain trusted connector params, not from the VP. The VP-
   //    supplied assert tx hex is implicitly pinned by buildPayoutPsbt's
@@ -189,12 +244,7 @@ async function collectDepositorGraphPsbts(
     ),
   );
 
-  // 3. Per-challenger: build the NoPayout PSBT locally too.
-  const localChallengers = deriveLocalChallengers(
-    ctx.vaultProviderBtcPubkey,
-    ctx.vaultKeeperBtcPubkeys,
-    ctx.depositorBtcPubkey,
-  );
+  // 4. Per-challenger: build the NoPayout PSBT locally too.
   const claimerPubkey = stripHexPrefix(ctx.depositorBtcPubkey);
   const assertTxParsed = Transaction.fromHex(
     stripHexPrefix(depositorGraph.assert_tx.tx_hex),


### PR DESCRIPTION
## Summary

Closes audit finding
[#303](https://github.com/babylonlabs-io/baby-auditor-findings/issues/303) (HIGH).

`signDepositorGraph` previously trusted the VP-supplied `challenger_presign_data`
array to be complete. A malicious or buggy VP could return empty, partial,
duplicate, or extra entries — the depositor would sign whatever was supplied,
submit a `per_challenger` map built from those entries, and activate the vault
with broken depositor-as-claimer recovery material. Recovery later fails when
an omitted challenger is the one the depositor needs.

## Fix

Single check between `deriveLocalChallengers` and the per-challenger loop in
`collectDepositorGraphPsbts`:

- Reject duplicates (`Set(size) !== array.length`).
- Reject any `localChallengers` member not in the supplied set (missing).
- Reject any supplied pubkey not in `localChallengers` (unexpected).

Each failure throws a distinct, actionable message and prevents the wallet
from ever being asked to sign.