### PR TITLE
feat(vault): borrow repay improvements

### DIFF
--- a/packages/babylon-core-ui/src/widgets/sections/AmountSlider/AmountSlider.tsx
+++ b/packages/babylon-core-ui/src/widgets/sections/AmountSlider/AmountSlider.tsx
@@ -1,7 +1,18 @@
 import type React from "react";
+import { useEffect, useState } from "react";
 import { twJoin, twMerge } from "tailwind-merge";
 import { Slider, type SliderStep } from "../../../components/Slider";
 import { sanitizeNumericInput } from "../../../utils/helpers";
+
+function toNumber(amount: string | number): number {
+  return typeof amount === "number" ? amount : parseFloat(amount);
+}
+
+function formatForInput(amount: string | number): string {
+  const num = toNumber(amount);
+  if (!Number.isFinite(num) || num === 0) return "";
+  return String(num);
+}
 
 interface BalanceDetails {
   balance: number | string;
@@ -72,6 +83,24 @@ export function AmountSlider({
   className,
   inputClassName,
 }: AmountSliderProps) {
+  // Local string mirror so partial decimals like "0." survive a re-render
+  // (a controlled `value={amount}` would collapse "0." back to "0").
+  const [rawInput, setRawInput] = useState<string>(() => formatForInput(amount));
+
+  // Sync from external amount changes (Max, slider, reset). Skip when the
+  // current string already parses to the same number — that's the user
+  // mid-typing case.
+  useEffect(() => {
+    const external = toNumber(amount);
+    const current = parseFloat(rawInput);
+    const sameNumber =
+      (Number.isFinite(current) && current === external) ||
+      (!Number.isFinite(current) && !Number.isFinite(external));
+    if (sameNumber) return;
+    setRawInput(formatForInput(amount));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [amount]);
+
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "ArrowUp" || e.key === "ArrowDown") {
       e.preventDefault();
@@ -81,9 +110,10 @@ export function AmountSlider({
   const handleAmountChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = sanitizeNumericInput(e.target.value);
     if (value === undefined) {
-      e.target.value = String(amount);
+      e.target.value = rawInput;
       return;
     }
+    setRawInput(value);
     e.target.value = value;
     onAmountChange?.(e);
   };
@@ -109,7 +139,7 @@ export function AmountSlider({
         <input
           type="text"
           inputMode="decimal"
-          value={amount}
+          value={rawInput}
           onChange={handleAmountChange}
           onKeyDown={handleKeyDown}
           disabled={disabled}

--- a/services/vault/src/applications/aave/components/LoanCard/Repay/hooks/__tests__/pickRepayParams.test.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Repay/hooks/__tests__/pickRepayParams.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Tests for pickRepayParams — the submit-time freshness + mode-pick step.
+ */
+
+import type { QueryObserverResult } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+
+import { pickRepayParams } from "../pickRepayParams";
+
+vi.mock("@/infrastructure", () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
+const RESERVE_ID = 7n;
+const DECIMALS = 6;
+
+function balanceResultOk(raw: bigint): QueryObserverResult<bigint, Error> {
+  return {
+    data: raw,
+    isError: false,
+    error: null,
+  } as unknown as QueryObserverResult<bigint, Error>;
+}
+
+function balanceResultError(
+  message = "rpc down",
+): QueryObserverResult<bigint, Error> {
+  return {
+    data: undefined,
+    isError: true,
+    error: new Error(message),
+  } as unknown as QueryObserverResult<bigint, Error>;
+}
+
+/** Build a minimal `AavePositionWithLiveData`-shaped object exposing only
+ * the path `pickRepayParams` reads (`debtPositions.get(id).totalDebt`). */
+function positionWithDebt(debtRaw: bigint) {
+  return {
+    debtPositions: new Map([[RESERVE_ID, { totalDebt: debtRaw }]]),
+  } as never;
+}
+
+describe("pickRepayParams", () => {
+  it("returns 'full' when balance covers debt × (1 + buffer)", async () => {
+    // 100 USDC debt, balance 102 USDC — well above the 0.5% buffer threshold.
+    const result = await pickRepayParams({
+      refetchPosition: () => Promise.resolve(positionWithDebt(100_000_000n)),
+      refetchUserBalance: () => Promise.resolve(balanceResultOk(102_000_000n)),
+      reserveId: RESERVE_ID,
+      tokenDecimals: DECIMALS,
+    });
+
+    expect(result).toEqual({
+      kind: "ok",
+      mode: "full",
+      amount: 100,
+      amountRaw: null,
+    });
+  });
+
+  it("returns 'max-capped' with the exact bigint when balance is between debt and debt × (1+buffer)", async () => {
+    // 100 USDC debt, balance 100.1 USDC — covers debt but not the 0.5% buffer.
+    // The 0.1 USDC sits inside the buffer band.
+    const balanceRaw = 100_100_000n;
+    const result = await pickRepayParams({
+      refetchPosition: () => Promise.resolve(positionWithDebt(100_000_000n)),
+      refetchUserBalance: () => Promise.resolve(balanceResultOk(balanceRaw)),
+      reserveId: RESERVE_ID,
+      tokenDecimals: DECIMALS,
+    });
+
+    expect(result).toEqual({
+      kind: "ok",
+      mode: "max-capped",
+      amount: 100.1,
+      amountRaw: balanceRaw,
+    });
+  });
+
+  it("returns 'partial' (no bigint) when balance is below debt", async () => {
+    const result = await pickRepayParams({
+      refetchPosition: () => Promise.resolve(positionWithDebt(100_000_000n)),
+      refetchUserBalance: () => Promise.resolve(balanceResultOk(40_000_000n)),
+      reserveId: RESERVE_ID,
+      tokenDecimals: DECIMALS,
+    });
+
+    expect(result).toEqual({
+      kind: "ok",
+      mode: "partial",
+      amount: 40,
+      amountRaw: null,
+    });
+  });
+
+  it("returns 'partial' with min(debt, balance) when one side is zero", async () => {
+    const result = await pickRepayParams({
+      refetchPosition: () => Promise.resolve(positionWithDebt(0n)),
+      refetchUserBalance: () => Promise.resolve(balanceResultOk(50_000_000n)),
+      reserveId: RESERVE_ID,
+      tokenDecimals: DECIMALS,
+    });
+
+    // Early-exit branch when either side is non-positive — partial of the smaller.
+    expect(result).toEqual({
+      kind: "ok",
+      mode: "partial",
+      amount: 0,
+      amountRaw: null,
+    });
+  });
+
+  it("returns an error result when refetchUserBalance reports isError", async () => {
+    const result = await pickRepayParams({
+      refetchPosition: () => Promise.resolve(positionWithDebt(100_000_000n)),
+      refetchUserBalance: () => Promise.resolve(balanceResultError()),
+      reserveId: RESERVE_ID,
+      tokenDecimals: DECIMALS,
+    });
+
+    expect(result.kind).toBe("error");
+    if (result.kind === "error") {
+      expect(result.message).toMatch(/Couldn't refresh balance\/debt/i);
+    }
+  });
+
+  it("returns an error result when refetchPosition throws", async () => {
+    const result = await pickRepayParams({
+      refetchPosition: () =>
+        Promise.reject(new Error("position rpc unavailable")),
+      refetchUserBalance: () => Promise.resolve(balanceResultOk(100_000_000n)),
+      reserveId: RESERVE_ID,
+      tokenDecimals: DECIMALS,
+    });
+
+    expect(result.kind).toBe("error");
+  });
+
+  it("returns an error result when refetchUserBalance throws", async () => {
+    const result = await pickRepayParams({
+      refetchPosition: () => Promise.resolve(positionWithDebt(100_000_000n)),
+      refetchUserBalance: () => Promise.reject(new Error("network down")),
+      reserveId: RESERVE_ID,
+      tokenDecimals: DECIMALS,
+    });
+
+    expect(result.kind).toBe("error");
+  });
+
+  it("treats a position with no entry for the reserve as zero debt → partial", async () => {
+    // Position object exists, but no debt for the requested reserveId.
+    const positionWithUnrelatedReserve = {
+      debtPositions: new Map([[999n, { totalDebt: 5n }]]),
+    } as never;
+
+    const result = await pickRepayParams({
+      refetchPosition: () => Promise.resolve(positionWithUnrelatedReserve),
+      refetchUserBalance: () => Promise.resolve(balanceResultOk(50_000_000n)),
+      reserveId: RESERVE_ID,
+      tokenDecimals: DECIMALS,
+    });
+
+    // Zero debt + non-zero balance → partial branch with amount = min(0, 50) = 0.
+    expect(result).toEqual({
+      kind: "ok",
+      mode: "partial",
+      amount: 0,
+      amountRaw: null,
+    });
+  });
+});

--- a/services/vault/src/applications/aave/components/LoanCard/Repay/hooks/__tests__/useRepayState.test.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Repay/hooks/__tests__/useRepayState.test.ts
@@ -69,44 +69,62 @@ describe("useRepayState", () => {
     });
   });
 
-  describe("isFullRepayment (explicit mode)", () => {
-    it("defaults to false (partial mode)", () => {
+  describe("isMaxIntent", () => {
+    it("defaults to false", () => {
       const { result } = renderHook(() =>
         useRepayState({ currentDebtAmount: 100, userTokenBalance: 100 }),
       );
 
-      expect(result.current.isFullRepayment).toBe(false);
+      expect(result.current.isMaxIntent).toBe(false);
     });
 
-    it("is true when setRepayAmountWithMode is called with 'full'", () => {
-      const { result } = renderHook(() =>
-        useRepayState({ currentDebtAmount: 100, userTokenBalance: 100 }),
-      );
-
-      act(() => {
-        result.current.setRepayAmountWithMode(100, "full");
-      });
-
-      expect(result.current.isFullRepayment).toBe(true);
-    });
-
-    it("resets to false when setRepayAmount is called (manual input)", () => {
+    it("is true after setRepayAmountMax", () => {
       const { result } = renderHook(() =>
         useRepayState({ currentDebtAmount: 100, userTokenBalance: 100 }),
       );
 
       act(() => {
-        result.current.setRepayAmountWithMode(100, "full");
+        result.current.setRepayAmountMax(100);
       });
-      expect(result.current.isFullRepayment).toBe(true);
 
-      act(() => {
-        result.current.setRepayAmount(99);
-      });
-      expect(result.current.isFullRepayment).toBe(false);
+      expect(result.current.isMaxIntent).toBe(true);
+      expect(result.current.repayAmount).toBe(100);
     });
 
-    it("is false even when amount equals debt if mode is partial (typed, not Max)", () => {
+    it("is cleared by setRepayAmount (typed/sliderd input)", () => {
+      const { result } = renderHook(() =>
+        useRepayState({ currentDebtAmount: 100, userTokenBalance: 100 }),
+      );
+
+      act(() => {
+        result.current.setRepayAmountMax(100);
+      });
+      expect(result.current.isMaxIntent).toBe(true);
+
+      act(() => {
+        result.current.setRepayAmount(50);
+      });
+
+      expect(result.current.isMaxIntent).toBe(false);
+    });
+
+    it("is cleared by resetRepayAmount", () => {
+      const { result } = renderHook(() =>
+        useRepayState({ currentDebtAmount: 100, userTokenBalance: 100 }),
+      );
+
+      act(() => {
+        result.current.setRepayAmountMax(100);
+      });
+      act(() => {
+        result.current.resetRepayAmount();
+      });
+
+      expect(result.current.isMaxIntent).toBe(false);
+      expect(result.current.repayAmount).toBe(0);
+    });
+
+    it("remains false when the user types an amount equal to debt", () => {
       const { result } = renderHook(() =>
         useRepayState({ currentDebtAmount: 100, userTokenBalance: 100 }),
       );
@@ -115,116 +133,9 @@ describe("useRepayState", () => {
         result.current.setRepayAmount(100);
       });
 
-      // Typed 100 manually — partial mode, not full repay
-      expect(result.current.isFullRepayment).toBe(false);
-    });
-
-    it("is false when balance limits max below debt (partial repay via Max)", () => {
-      const { result } = renderHook(() =>
-        useRepayState({ currentDebtAmount: 100, userTokenBalance: 50 }),
-      );
-
-      // Max button with balance < debt should set partial
-      act(() => {
-        result.current.setRepayAmountWithMode(50, "partial");
-      });
-
-      expect(result.current.isFullRepayment).toBe(false);
-    });
-
-    it("resets mode on resetRepayAmount", () => {
-      const { result } = renderHook(() =>
-        useRepayState({ currentDebtAmount: 100, userTokenBalance: 100 }),
-      );
-
-      act(() => {
-        result.current.setRepayAmountWithMode(100, "full");
-      });
-      act(() => {
-        result.current.resetRepayAmount();
-      });
-
-      expect(result.current.isFullRepayment).toBe(false);
-      expect(result.current.repayAmount).toBe(0);
-    });
-
-    it("is false when max is zero", () => {
-      const { result } = renderHook(() =>
-        useRepayState({ currentDebtAmount: 0, userTokenBalance: 100 }),
-      );
-
-      expect(result.current.isFullRepayment).toBe(false);
-    });
-  });
-
-  describe("repayMode (tri-state)", () => {
-    it("defaults to 'partial'", () => {
-      const { result } = renderHook(() =>
-        useRepayState({ currentDebtAmount: 100, userTokenBalance: 100 }),
-      );
-
-      expect(result.current.repayMode).toBe("partial");
-    });
-
-    it("is 'full' when setRepayAmountWithMode('full') is called", () => {
-      const { result } = renderHook(() =>
-        useRepayState({ currentDebtAmount: 100, userTokenBalance: 100 }),
-      );
-
-      act(() => {
-        result.current.setRepayAmountWithMode(100, "full");
-      });
-
-      expect(result.current.repayMode).toBe("full");
-      expect(result.current.isFullRepayment).toBe(true);
-    });
-
-    it("is 'max-capped' when balance covers debt but not the safety buffer", () => {
-      // Caller has decided "balance < debt × (1 + buffer)" so we send the
-      // full balance and let the adapter pull min(balance, actualDebt).
-      const { result } = renderHook(() =>
-        useRepayState({ currentDebtAmount: 100.001, userTokenBalance: 100 }),
-      );
-
-      act(() => {
-        result.current.setRepayAmountWithMode(100, "max-capped");
-      });
-
-      expect(result.current.repayMode).toBe("max-capped");
-      // max-capped is NOT a full repayment — adapter may leave sub-cent dust.
-      expect(result.current.isFullRepayment).toBe(false);
+      // Typed 100 is partial intent — submit must not refetch + remap.
+      expect(result.current.isMaxIntent).toBe(false);
       expect(result.current.repayAmount).toBe(100);
-    });
-
-    it("resets to 'partial' when setRepayAmount is called (manual input)", () => {
-      const { result } = renderHook(() =>
-        useRepayState({ currentDebtAmount: 100, userTokenBalance: 100 }),
-      );
-
-      act(() => {
-        result.current.setRepayAmountWithMode(100, "max-capped");
-      });
-      expect(result.current.repayMode).toBe("max-capped");
-
-      act(() => {
-        result.current.setRepayAmount(50);
-      });
-      expect(result.current.repayMode).toBe("partial");
-    });
-
-    it("resets mode on resetRepayAmount", () => {
-      const { result } = renderHook(() =>
-        useRepayState({ currentDebtAmount: 100, userTokenBalance: 100 }),
-      );
-
-      act(() => {
-        result.current.setRepayAmountWithMode(100, "max-capped");
-      });
-      act(() => {
-        result.current.resetRepayAmount();
-      });
-
-      expect(result.current.repayMode).toBe("partial");
     });
   });
 
@@ -265,79 +176,6 @@ describe("useRepayState", () => {
       });
 
       expect(result.current.repayAmount).toBe(0);
-    });
-  });
-
-  describe("repayAmountRaw (exact bigint cap)", () => {
-    it("defaults to null", () => {
-      const { result } = renderHook(() =>
-        useRepayState({ currentDebtAmount: 100, userTokenBalance: 100 }),
-      );
-
-      expect(result.current.repayAmountRaw).toBeNull();
-    });
-
-    it("stores the bigint when passed to setRepayAmountWithMode", () => {
-      const { result } = renderHook(() =>
-        useRepayState({ currentDebtAmount: 100.001, userTokenBalance: 100 }),
-      );
-
-      // 100 USDC at 6 decimals
-      const cap = 100_000_000n;
-      act(() => {
-        result.current.setRepayAmountWithMode(100, "max-capped", cap);
-      });
-
-      // The float is just for display; the raw bigint is the source of truth
-      // for the actual approval/transfer amount.
-      expect(result.current.repayAmountRaw).toBe(cap);
-      expect(result.current.repayAmount).toBe(100);
-      expect(result.current.repayMode).toBe("max-capped");
-    });
-
-    it("remains null when setRepayAmountWithMode is called without the bigint", () => {
-      const { result } = renderHook(() =>
-        useRepayState({ currentDebtAmount: 100, userTokenBalance: 100 }),
-      );
-
-      act(() => {
-        result.current.setRepayAmountWithMode(100, "full");
-      });
-
-      expect(result.current.repayAmountRaw).toBeNull();
-    });
-
-    it("is cleared by setRepayAmount (manual typed input)", () => {
-      const { result } = renderHook(() =>
-        useRepayState({ currentDebtAmount: 100.001, userTokenBalance: 100 }),
-      );
-
-      act(() => {
-        result.current.setRepayAmountWithMode(100, "max-capped", 100_000_000n);
-      });
-      expect(result.current.repayAmountRaw).toBe(100_000_000n);
-
-      // User typed something else — the bigint cap is no longer the source of truth
-      act(() => {
-        result.current.setRepayAmount(50);
-      });
-
-      expect(result.current.repayAmountRaw).toBeNull();
-    });
-
-    it("is cleared by resetRepayAmount", () => {
-      const { result } = renderHook(() =>
-        useRepayState({ currentDebtAmount: 100.001, userTokenBalance: 100 }),
-      );
-
-      act(() => {
-        result.current.setRepayAmountWithMode(100, "max-capped", 100_000_000n);
-      });
-      act(() => {
-        result.current.resetRepayAmount();
-      });
-
-      expect(result.current.repayAmountRaw).toBeNull();
     });
   });
 });

--- a/services/vault/src/applications/aave/components/LoanCard/Repay/hooks/pickRepayParams.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Repay/hooks/pickRepayParams.ts
@@ -1,0 +1,134 @@
+/**
+ * Submit-time freshness check + repay-mode selection.
+ *
+ * Called by the Repay submit path when the user has signaled Max intent.
+ * Refetches debt + balance on-chain (synchronously, awaiting the network),
+ * then picks the cheapest repay path that actually clears the debt:
+ *
+ *   - balance ≥ debt × (1 + buffer)   → `"full"`     (repayFull adds buffer)
+ *   - debt ≤ balance < debt × (1+buf) → `"max-capped"` (send full balance;
+ *                                       adapter pulls min(balance, debt))
+ *   - balance < debt                  → `"partial"`  (send full balance)
+ *
+ * Doing this at submit (not at Max-button click) avoids the stale-snapshot
+ * window between click and submit — the bigint we feed into `repayMaxCapped`
+ * is read from chain in the same tick we ask the wallet to sign.
+ */
+import type { QueryObserverResult } from "@tanstack/react-query";
+import { formatUnits } from "viem";
+
+import { logger } from "@/infrastructure";
+
+import { FULL_REPAY_BUFFER_FRACTION } from "../../../../constants";
+import type { RepayMode } from "../../../../hooks/useRepayTransaction";
+import type { AavePositionWithLiveData } from "../../../../services";
+
+/**
+ * Refetch position data — already unwraps the React Query result and throws
+ * on `isError`, matching the shape exposed by `useAaveUserPosition.refetch`.
+ */
+type RefetchPosition = () => Promise<AavePositionWithLiveData | null>;
+
+/**
+ * Refetch user balance — returns the raw React Query result so the caller
+ * can inspect `isError` (matches `useERC20Balance.refetch`).
+ */
+type RefetchUserBalance = () => Promise<QueryObserverResult<bigint, Error>>;
+
+export interface PickRepayParamsArgs {
+  refetchPosition: RefetchPosition;
+  refetchUserBalance: RefetchUserBalance;
+  reserveId: bigint;
+  tokenDecimals: number;
+}
+
+export type PickRepayParamsResult =
+  | {
+      kind: "ok";
+      mode: RepayMode;
+      amount: number;
+      /** Exact bigint balance — required by `repayMaxCapped`, null otherwise. */
+      amountRaw: bigint | null;
+    }
+  | {
+      kind: "error";
+      message: string;
+    };
+
+const REFETCH_ERROR_MESSAGE =
+  "Couldn't refresh balance/debt — please try again.";
+
+export async function pickRepayParams({
+  refetchPosition,
+  refetchUserBalance,
+  reserveId,
+  tokenDecimals,
+}: PickRepayParamsArgs): Promise<PickRepayParamsResult> {
+  let freshDebtAmount: number;
+  let freshBalanceAmount: number;
+  let freshBalanceRaw: bigint;
+
+  try {
+    const [freshPosition, freshBalanceResult] = await Promise.all([
+      refetchPosition(),
+      refetchUserBalance(),
+    ]);
+
+    // `refetchUserBalance` is the raw React Query refetch — it resolves with
+    // a result object even on failure. Treat `isError` as a thrown error.
+    if (freshBalanceResult.isError) {
+      throw freshBalanceResult.error ?? new Error("Balance refetch failed");
+    }
+
+    const freshDebtRaw =
+      freshPosition?.debtPositions?.get(reserveId)?.totalDebt ?? 0n;
+    freshDebtAmount = Number(formatUnits(freshDebtRaw, tokenDecimals));
+    freshBalanceRaw = freshBalanceResult.data ?? 0n;
+    freshBalanceAmount = Number(formatUnits(freshBalanceRaw, tokenDecimals));
+  } catch (error) {
+    logger.warn("Repay submit refetch failed", {
+      data: {
+        context: "Aave repay submit (Max intent)",
+        error: error instanceof Error ? error.message : String(error),
+      },
+    });
+    return { kind: "error", message: REFETCH_ERROR_MESSAGE };
+  }
+
+  if (freshDebtAmount <= 0 || freshBalanceAmount <= 0) {
+    return {
+      kind: "ok",
+      mode: "partial",
+      amount: Math.min(freshDebtAmount, freshBalanceAmount),
+      amountRaw: null,
+    };
+  }
+
+  const fullRepayThreshold = freshDebtAmount * (1 + FULL_REPAY_BUFFER_FRACTION);
+
+  if (freshBalanceAmount >= fullRepayThreshold) {
+    return {
+      kind: "ok",
+      mode: "full",
+      amount: freshDebtAmount,
+      amountRaw: null,
+    };
+  }
+  if (freshBalanceAmount >= freshDebtAmount) {
+    // Caller passes `amountRaw` to `executeRepay` so the parseUnits round-trip
+    // in useRepayTransaction can't round up by 1 ULP and produce an approval
+    // larger than the user's actual balance.
+    return {
+      kind: "ok",
+      mode: "max-capped",
+      amount: freshBalanceAmount,
+      amountRaw: freshBalanceRaw,
+    };
+  }
+  return {
+    kind: "ok",
+    mode: "partial",
+    amount: freshBalanceAmount,
+    amountRaw: null,
+  };
+}

--- a/services/vault/src/applications/aave/components/LoanCard/Repay/hooks/useRepayState.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Repay/hooks/useRepayState.ts
@@ -1,50 +1,40 @@
 /**
  * Repay state management hook
  *
- * Manages repay amount and tracks which repay path the user is invoking.
- * Uses explicit mode tracking instead of tolerance-based detection.
+ * Tracks the current repay amount and whether the user invoked it via the
+ * Max button. The repay *mode* (`full` / `max-capped` / `partial`) is
+ * resolved at submit time from a fresh on-chain read — not here — to avoid
+ * snapshotting stale balance/debt at click time and consuming it seconds
+ * (or minutes) later at submit.
  */
 
 import { useCallback, useMemo, useState } from "react";
 
-import type { RepayMode } from "../../../../hooks/useRepayTransaction";
-
 export interface UseRepayStateProps {
-  /** Current debt amount for selected reserve in token units */
+  /** Current debt amount for selected reserve in token units (cached). */
   currentDebtAmount: number;
-  /** User's token balance for the selected reserve */
+  /** User's token balance for the selected reserve (cached). */
   userTokenBalance: number;
 }
 
 export interface UseRepayStateResult {
   repayAmount: number;
-  /**
-   * Optional exact raw amount (in the token's smallest unit) corresponding
-   * to `repayAmount`. Set by the Max button in `"max-capped"` mode so the
-   * downstream tx uses the exact on-chain bigint balance and avoids the
-   * float round-trip — which, for ≥16-significant-digit raw values (any
-   * 18-decimal token with > ~10 tokens in the wallet), can round up by 1
-   * ULP and produce an approval larger than the user's balance.
-   */
-  repayAmountRaw: bigint | null;
-  /** Sets repay amount and resets mode to partial (used by typed input / slider) */
+  /** Sets repay amount as a typed/sliderd value; clears Max intent. */
   setRepayAmount: (amount: number) => void;
   /**
-   * Sets repay amount and mode atomically (used by Max button).
-   * Pass `amountRaw` to record the exact bigint amount — recommended in
-   * `"max-capped"` mode where rounding direction matters.
+   * Sets repay amount as the cached `maxRepayAmount` and marks Max intent.
+   * The submit path checks `isMaxIntent` and refetches fresh debt+balance
+   * to decide the actual repay mode and final amount.
    */
-  setRepayAmountWithMode: (
-    amount: number,
-    mode: RepayMode,
-    amountRaw?: bigint,
-  ) => void;
+  setRepayAmountMax: (amount: number) => void;
   resetRepayAmount: () => void;
+  /**
+   * Display-only ceiling derived from cached props. The true cap at submit
+   * time is whatever the fresh on-chain read returns.
+   */
   maxRepayAmount: number;
-  /** Which repay path the current amount should use. Set explicitly. */
-  repayMode: RepayMode;
-  /** Whether the current repay clears the full debt (mode === "full"). */
-  isFullRepayment: boolean;
+  /** True iff the user invoked the Max button and hasn't typed since. */
+  isMaxIntent: boolean;
 }
 
 export function useRepayState({
@@ -52,51 +42,36 @@ export function useRepayState({
   userTokenBalance,
 }: UseRepayStateProps): UseRepayStateResult {
   const [repayAmount, setRepayAmountFloat] = useState(0);
-  const [repayMode, setRepayMode] = useState<RepayMode>("partial");
-  const [repayAmountRaw, setRepayAmountRawBigInt] = useState<bigint | null>(
-    null,
-  );
+  const [isMaxIntent, setIsMaxIntent] = useState(false);
 
-  // Max repay is the minimum of debt and available balance
+  // Max repay is the minimum of debt and available balance.
   const maxRepayAmount = useMemo(() => {
     return Math.max(0, Math.min(currentDebtAmount, userTokenBalance));
   }, [currentDebtAmount, userTokenBalance]);
 
-  // Manual input / slider always sets partial mode and drops the raw bigint
-  // (it only applies to the Max-button path).
+  // Typed/sliderd input always drops Max intent — submit will treat it as
+  // a verbatim partial repay rather than refetching to pick a mode.
   const setRepayAmount = useCallback((amount: number) => {
     setRepayAmountFloat(amount);
-    setRepayMode("partial");
-    setRepayAmountRawBigInt(null);
+    setIsMaxIntent(false);
   }, []);
 
-  // Max button sets amount + mode atomically. `amountRaw` is optional but
-  // strongly recommended in "max-capped" mode.
-  const setRepayAmountWithMode = useCallback(
-    (amount: number, mode: RepayMode, amountRaw?: bigint) => {
-      setRepayAmountFloat(amount);
-      setRepayMode(mode);
-      setRepayAmountRawBigInt(amountRaw ?? null);
-    },
-    [],
-  );
+  const setRepayAmountMax = useCallback((amount: number) => {
+    setRepayAmountFloat(amount);
+    setIsMaxIntent(true);
+  }, []);
 
   const resetRepayAmount = useCallback(() => {
     setRepayAmountFloat(0);
-    setRepayMode("partial");
-    setRepayAmountRawBigInt(null);
+    setIsMaxIntent(false);
   }, []);
-
-  const isFullRepayment = repayMode === "full";
 
   return {
     repayAmount,
-    repayAmountRaw,
     setRepayAmount,
-    setRepayAmountWithMode,
+    setRepayAmountMax,
     resetRepayAmount,
     maxRepayAmount,
-    repayMode,
-    isFullRepayment,
+    isMaxIntent,
   };
 }

--- a/services/vault/src/applications/aave/components/LoanCard/Repay/index.tsx
+++ b/services/vault/src/applications/aave/components/LoanCard/Repay/index.tsx
@@ -95,40 +95,26 @@ export function Repay() {
       userTokenBalance,
     );
 
-  // Cosmetic minimum only — keeps the slider track from rendering at zero
-  // width when there is nothing to repay. The displayed "Max" label and the
-  // slider's accept range use the real `maxRepayAmount` so the UI doesn't
-  // advertise an amount that validation will reject.
+  // Cosmetic floor only: keeps the slider track from collapsing to zero
+  // width when there's nothing to repay. Label + accept range use the real
+  // `maxRepayAmount`.
   const sliderTrackMax = maxRepayAmount > 0 ? maxRepayAmount : MIN_SLIDER_MAX;
 
-  // Inline error surfaced when the Max-click refetch fails. We deliberately
-  // do not silently fall back to cached values — at boundaries that could
-  // pick the wrong repay mode (e.g. land in `max-capped` with a stale balance
-  // when fresh data would have been `full`, missing the safety buffer) or
-  // even leave `repayAmountRaw` undefined and fall through to the broken
-  // float round-trip. Better to ask the user to retry: React Query's 30s
-  // background refresh has typically refilled the cache by then anyway.
   const [maxClickError, setMaxClickError] = useState<string | null>(null);
 
-  // Max click: refresh debt and balance from chain so we don't decide the
-  // repay path on stale React Query data (up to 30s old). Then pick the
-  // cheapest path that actually clears the debt:
-  //
-  // - balance ≥ debt × (1 + buffer)   → "full" (repayFull adds the buffer)
-  // - debt ≤ balance < debt × (1+buf) → "max-capped" (send full balance;
-  //                                      adapter pulls min(balance, debt))
-  // - balance < debt                  → partial Max; validateRepayAction
-  //                                      will surface a "need more tokens"
-  //                                      message and keep submit disabled
-  //                                      for amount > maxRepayAmount.
-  //
-  // If either refetch fails (RPC blip, timeout), surface an explicit error
-  // and bail without touching state. Falling back to cached values can pick
-  // the wrong mode at boundaries — and worse, would leave `freshBalanceRaw`
-  // undefined for the `max-capped` branch, which would then degrade to the
-  // float round-trip we explicitly fixed.
+  // Refetch fresh debt + balance before picking the repay mode. Stale values
+  // can land us in the wrong branch (e.g. `max-capped` without a raw bigint
+  // → broken float round-trip), so on any read failure we surface an error
+  // and bail rather than silently use cached values.
   const handleMaxClick = useCallback(async () => {
     setMaxClickError(null);
+
+    // React Query's default networkMode pauses queries when offline rather
+    // than throwing, so the try/catch alone would silently use stale data.
+    if (typeof navigator !== "undefined" && !navigator.onLine) {
+      setMaxClickError("Couldn't refresh balance/debt — please try again.");
+      return;
+    }
 
     let freshDebtAmount: number;
     let freshBalanceAmount: number;
@@ -140,13 +126,19 @@ export function Repay() {
         refetchUserBalance(),
       ]);
 
+      // React Query refetches don't reject on queryFn error — they surface
+      // it on the result. Treat as a failure here.
+      if (freshBalanceResult.isError) {
+        throw freshBalanceResult.error ?? new Error("Balance refetch failed");
+      }
+
       const freshDebtRaw =
         freshPosition?.debtPositions?.get(selectedReserve.reserveId)
           ?.totalDebt ?? 0n;
       freshDebtAmount = Number(
         formatUnits(freshDebtRaw, selectedReserve.token.decimals),
       );
-      freshBalanceRaw = freshBalanceResult?.data ?? 0n;
+      freshBalanceRaw = freshBalanceResult.data ?? 0n;
       freshBalanceAmount = Number(
         formatUnits(freshBalanceRaw, selectedReserve.token.decimals),
       );
@@ -175,11 +167,8 @@ export function Repay() {
     if (freshBalanceAmount >= fullRepayThreshold) {
       setRepayAmountWithMode(freshDebtAmount, "full");
     } else if (freshBalanceAmount >= freshDebtAmount) {
-      // Pass the raw bigint cap so the float round-trip in useRepayTransaction
-      // can never produce an approval amount > the user's actual balance.
-      // For ≥16-significant-digit raw balances (any 18-decimal token with > ~10
-      // tokens in the wallet) the round-trip can round up by 1 ULP, which
-      // would revert the tx. Sending the bigint sidesteps the conversion.
+      // Pass the raw bigint so the parseUnits round-trip in useRepayTransaction
+      // can't round up by 1 ULP and produce an approval > balance.
       setRepayAmountWithMode(freshBalanceAmount, "max-capped", freshBalanceRaw);
     } else {
       setRepayAmountWithMode(freshBalanceAmount, "partial");

--- a/services/vault/src/applications/aave/components/LoanCard/Repay/index.tsx
+++ b/services/vault/src/applications/aave/components/LoanCard/Repay/index.tsx
@@ -7,11 +7,9 @@
 
 import { AmountSlider, Button, SubSection } from "@babylonlabs-io/core-ui";
 import { useCallback, useState } from "react";
-import { formatUnits } from "viem";
 
 import { useETHWallet } from "@/context/wallet";
 import { useERC20Balance } from "@/hooks";
-import { logger } from "@/infrastructure";
 
 import {
   getCurrencyIconWithFallback,
@@ -21,15 +19,12 @@ import {
   formatTokenAmount,
   formatUsdValue,
 } from "../../../../../utils/formatting";
-import {
-  AMOUNT_INPUT_CLASS_NAME,
-  FULL_REPAY_BUFFER_FRACTION,
-  MIN_SLIDER_MAX,
-} from "../../../constants";
-import { useRepayTransaction } from "../../../hooks";
+import { AMOUNT_INPUT_CLASS_NAME, MIN_SLIDER_MAX } from "../../../constants";
+import { useRepayTransaction, type RepayMode } from "../../../hooks";
 import { useLoanContext } from "../../context/LoanContext";
 import { BorrowDetailsCard } from "../Borrow/BorrowDetailsCard";
 
+import { pickRepayParams } from "./hooks/pickRepayParams";
 import { useRepayMetrics } from "./hooks/useRepayMetrics";
 import { useRepayState } from "./hooks/useRepayState";
 import { validateRepayAction } from "./hooks/validateRepayAction";
@@ -67,12 +62,11 @@ export function Repay() {
 
   const {
     repayAmount,
-    repayAmountRaw,
     setRepayAmount,
-    setRepayAmountWithMode,
+    setRepayAmountMax,
     resetRepayAmount,
     maxRepayAmount,
-    repayMode,
+    isMaxIntent,
   } = useRepayState({
     currentDebtAmount,
     userTokenBalance,
@@ -100,104 +94,52 @@ export function Repay() {
   // `maxRepayAmount`.
   const sliderTrackMax = maxRepayAmount > 0 ? maxRepayAmount : MIN_SLIDER_MAX;
 
-  const [maxClickError, setMaxClickError] = useState<string | null>(null);
+  const [refetchError, setRefetchError] = useState<string | null>(null);
 
-  // Refetch fresh debt + balance before picking the repay mode. Stale values
-  // can land us in the wrong branch (e.g. `max-capped` without a raw bigint
-  // → broken float round-trip), so on any read failure we surface an error
-  // and bail rather than silently use cached values.
-  const handleMaxClick = useCallback(async () => {
-    setMaxClickError(null);
-
-    // React Query's default networkMode pauses queries when offline rather
-    // than throwing, so the try/catch alone would silently use stale data.
-    if (typeof navigator !== "undefined" && !navigator.onLine) {
-      setMaxClickError("Couldn't refresh balance/debt — please try again.");
-      return;
-    }
-
-    let freshDebtAmount: number;
-    let freshBalanceAmount: number;
-    let freshBalanceRaw: bigint;
-
-    try {
-      const [freshPosition, freshBalanceResult] = await Promise.all([
-        refetchPosition(),
-        refetchUserBalance(),
-      ]);
-
-      // React Query refetches don't reject on queryFn error — they surface
-      // it on the result. Treat as a failure here.
-      if (freshBalanceResult.isError) {
-        throw freshBalanceResult.error ?? new Error("Balance refetch failed");
-      }
-
-      const freshDebtRaw =
-        freshPosition?.debtPositions?.get(selectedReserve.reserveId)
-          ?.totalDebt ?? 0n;
-      freshDebtAmount = Number(
-        formatUnits(freshDebtRaw, selectedReserve.token.decimals),
-      );
-      freshBalanceRaw = freshBalanceResult.data ?? 0n;
-      freshBalanceAmount = Number(
-        formatUnits(freshBalanceRaw, selectedReserve.token.decimals),
-      );
-    } catch (error) {
-      logger.warn("Max click refetch failed", {
-        data: {
-          context: "Aave repay Max click",
-          error: error instanceof Error ? error.message : String(error),
-        },
-      });
-      setMaxClickError("Couldn't refresh balance/debt — please try again.");
-      return;
-    }
-
-    if (freshDebtAmount <= 0 || freshBalanceAmount <= 0) {
-      setRepayAmountWithMode(
-        Math.min(freshDebtAmount, freshBalanceAmount),
-        "partial",
-      );
-      return;
-    }
-
-    const fullRepayThreshold =
-      freshDebtAmount * (1 + FULL_REPAY_BUFFER_FRACTION);
-
-    if (freshBalanceAmount >= fullRepayThreshold) {
-      setRepayAmountWithMode(freshDebtAmount, "full");
-    } else if (freshBalanceAmount >= freshDebtAmount) {
-      // Pass the raw bigint so the parseUnits round-trip in useRepayTransaction
-      // can't round up by 1 ULP and produce an approval > balance.
-      setRepayAmountWithMode(freshBalanceAmount, "max-capped", freshBalanceRaw);
-    } else {
-      setRepayAmountWithMode(freshBalanceAmount, "partial");
-    }
-  }, [
-    refetchPosition,
-    refetchUserBalance,
-    selectedReserve.reserveId,
-    selectedReserve.token.decimals,
-    setRepayAmountWithMode,
-  ]);
+  // Pure UI action: pre-fill the input with the cached max so the user sees
+  // a number, and flag Max intent. The actual refetch + mode selection
+  // happens at submit time (see `handleRepay`) so the bigint we feed into
+  // `repayMaxCapped` is read from chain in the same tick we ask the wallet
+  // to sign — eliminating the click→submit stale-snapshot window.
+  const handleMaxClick = useCallback(() => {
+    setRefetchError(null);
+    setRepayAmountMax(maxRepayAmount);
+  }, [maxRepayAmount, setRepayAmountMax]);
 
   const handleRepay = async () => {
-    const success = await executeRepay(
-      repayAmount,
-      selectedReserve,
-      repayMode,
-      {
-        preSignValidation: () =>
-          validateRepayPreSign({
-            liquidationThresholdBps,
-            refetchSplitParams,
-          }),
-        repayAmountRaw,
-      },
-    );
+    let mode: RepayMode = "partial";
+    let amount = repayAmount;
+    let amountRaw: bigint | null = null;
+
+    if (isMaxIntent) {
+      const params = await pickRepayParams({
+        refetchPosition,
+        refetchUserBalance,
+        reserveId: selectedReserve.reserveId,
+        tokenDecimals: selectedReserve.token.decimals,
+      });
+      if (params.kind === "error") {
+        setRefetchError(params.message);
+        return;
+      }
+      mode = params.mode;
+      amount = params.amount;
+      amountRaw = params.amountRaw;
+    }
+
+    setRefetchError(null);
+
+    const success = await executeRepay(amount, selectedReserve, mode, {
+      preSignValidation: () =>
+        validateRepayPreSign({
+          liquidationThresholdBps,
+          refetchSplitParams,
+        }),
+      repayAmountRaw: amountRaw,
+    });
     if (success) {
       resetRepayAmount();
-      onRepaySuccess(repayAmount, 0);
+      onRepaySuccess(amount, 0);
     }
   };
 
@@ -259,10 +201,10 @@ export function Repay() {
         {errorMessage && (
           <p className="text-sm text-error-main">{errorMessage}</p>
         )}
-        {!errorMessage && maxClickError && (
-          <p className="text-sm text-warning-main">{maxClickError}</p>
+        {!errorMessage && refetchError && (
+          <p className="text-sm text-warning-main">{refetchError}</p>
         )}
-        {!errorMessage && !maxClickError && warningMessage && (
+        {!errorMessage && !refetchError && warningMessage && (
           <p className="text-sm text-warning-main">{warningMessage}</p>
         )}
       </div>

--- a/services/vault/src/applications/aave/hooks/index.ts
+++ b/services/vault/src/applications/aave/hooks/index.ts
@@ -25,6 +25,7 @@ export {
 } from "./useReorderVaults";
 export {
   useRepayTransaction,
+  type RepayMode,
   type UseRepayTransactionProps,
   type UseRepayTransactionResult,
 } from "./useRepayTransaction";

--- a/services/vault/src/applications/aave/hooks/useAaveUserPosition.ts
+++ b/services/vault/src/applications/aave/hooks/useAaveUserPosition.ts
@@ -119,6 +119,12 @@ export function useAaveUserPosition(
     enabled: !!connectedAddress && !!spokeAddress && vbtcReserveId != null,
     refetchOnMount: true,
     refetchInterval: POSITION_REFETCH_INTERVAL_MS,
+    // `"online"` (the default) pauses queries when `navigator.onLine` is
+    // false rather than running queryFn — `refetch()` then resolves with
+    // stale data and `isError` never flips. `"always"` lets real network
+    // failures surface through `isError`, which the repay submit path
+    // relies on to fail loudly instead of using stale debt values.
+    networkMode: "always",
   });
 
   // Track staleness: re-evaluate when dataUpdatedAt changes or on a timer

--- a/services/vault/src/applications/aave/services/__tests__/positionTransactions.test.ts
+++ b/services/vault/src/applications/aave/services/__tests__/positionTransactions.test.ts
@@ -93,10 +93,18 @@ describe("positionTransactions", () => {
     vi.clearAllMocks();
     simulatedAllowance = 0n;
     mockGetERC20Allowance.mockImplementation(async () => simulatedAllowance);
-    mockApproveERC20.mockImplementation(async (...args) => {
-      simulatedAllowance = args[4] as bigint;
-      return mockTxResult;
-    });
+    mockApproveERC20.mockImplementation(
+      async (
+        _walletClient: unknown,
+        _chain: unknown,
+        _tokenAddress: unknown,
+        _spenderAddress: unknown,
+        amount: bigint,
+      ) => {
+        simulatedAllowance = amount;
+        return mockTxResult;
+      },
+    );
     mockBorrowFromCorePosition.mockResolvedValue(mockTxResult);
     mockRepayToCorePosition.mockResolvedValue(mockTxResult);
     mockWithdrawCollaterals.mockResolvedValue(mockTxResult);

--- a/services/vault/src/applications/aave/services/__tests__/positionTransactions.test.ts
+++ b/services/vault/src/applications/aave/services/__tests__/positionTransactions.test.ts
@@ -74,9 +74,29 @@ describe("positionTransactions", () => {
     receipt: { status: "success" },
   };
 
+  // Shared mutable allowance state — simulates the on-chain allowance moving
+  // from its starting value to the just-approved amount. `ensureAllowance`
+  // verifies the post-approve allowance, so the mock must reflect that
+  // transition or every test would throw "Approval did not take effect".
+  let simulatedAllowance: bigint;
+
+  /**
+   * Override the simulated on-chain allowance for the current test. Use this
+   * instead of `mockGetERC20Allowance.mockResolvedValue(X)` so that
+   * approveERC20 calls still update the value (mimicking real chain state).
+   */
+  const setSimulatedAllowance = (value: bigint) => {
+    simulatedAllowance = value;
+  };
+
   beforeEach(() => {
     vi.clearAllMocks();
-    mockApproveERC20.mockResolvedValue(mockTxResult);
+    simulatedAllowance = 0n;
+    mockGetERC20Allowance.mockImplementation(async () => simulatedAllowance);
+    mockApproveERC20.mockImplementation(async (...args) => {
+      simulatedAllowance = args[4] as bigint;
+      return mockTxResult;
+    });
     mockBorrowFromCorePosition.mockResolvedValue(mockTxResult);
     mockRepayToCorePosition.mockResolvedValue(mockTxResult);
     mockWithdrawCollaterals.mockResolvedValue(mockTxResult);
@@ -164,7 +184,8 @@ describe("positionTransactions", () => {
   // ============================================================================
   describe("repayPartial", () => {
     beforeEach(() => {
-      mockGetERC20Allowance.mockResolvedValue(0n);
+      // Global default already starts simulatedAllowance at 0; only the
+      // balance needs to be set here.
       mockGetERC20Balance.mockResolvedValue(2000000n);
     });
 
@@ -201,7 +222,7 @@ describe("positionTransactions", () => {
 
     it("should skip approval when allowance sufficient", async () => {
       const amount = 1000000n;
-      mockGetERC20Allowance.mockResolvedValue(amount + 1000n);
+      setSimulatedAllowance(amount + 1000n);
 
       await repayPartial(
         mockWalletClient,
@@ -228,9 +249,8 @@ describe("positionTransactions", () => {
   // repayMaxCapped
   // ============================================================================
   describe("repayMaxCapped", () => {
-    beforeEach(() => {
-      mockGetERC20Allowance.mockResolvedValue(0n);
-    });
+    // Global default already starts simulatedAllowance at 0; no per-block
+    // setup needed.
 
     it("should approve and send the user's full balance verbatim (no buffer math)", async () => {
       const balanceAmount = 200_000_000n;
@@ -264,7 +284,7 @@ describe("positionTransactions", () => {
 
     it("should skip approval when allowance is sufficient", async () => {
       const balanceAmount = 200_000_000n;
-      mockGetERC20Allowance.mockResolvedValue(balanceAmount + 1n);
+      setSimulatedAllowance(balanceAmount + 1n);
 
       await repayMaxCapped(
         mockWalletClient,
@@ -321,8 +341,8 @@ describe("positionTransactions", () => {
     const amountToRepay = defaultDebt + defaultDebt / FULL_REPAY_BUFFER_DIVISOR;
 
     beforeEach(() => {
+      // Global default already starts simulatedAllowance at 0.
       mockGetUserTotalDebt.mockResolvedValue(defaultDebt);
-      mockGetERC20Allowance.mockResolvedValue(0n);
       mockGetERC20Balance.mockResolvedValue(amountToRepay + 1000n);
     });
 
@@ -369,7 +389,7 @@ describe("positionTransactions", () => {
       const currentDebt = 1000000n;
       const amountToRepay =
         currentDebt + currentDebt / FULL_REPAY_BUFFER_DIVISOR;
-      mockGetERC20Allowance.mockResolvedValue(amountToRepay + 1000n);
+      setSimulatedAllowance(amountToRepay + 1000n);
 
       await repayFull(
         mockWalletClient,
@@ -410,6 +430,30 @@ describe("positionTransactions", () => {
       ).rejects.toThrow(
         "insufficient balance to fully repay: not enough stablecoin to cover the debt plus interest",
       );
+    });
+
+    it("throws when post-approve allowance verification fails (RPC lag defense)", async () => {
+      // Override the global simulation: approveERC20 succeeds but the
+      // on-chain allowance state doesn't update — this is what a stale RPC
+      // response (the bug we're defending against) looks like to the caller.
+      // ensureAllowance should catch it pre-broadcast and surface a clear
+      // error instead of letting the user sign a doomed repay tx.
+      mockApproveERC20.mockReset();
+      mockApproveERC20.mockResolvedValue(mockTxResult);
+
+      await expect(
+        repayFull(
+          mockWalletClient,
+          mockChain,
+          1n,
+          "0xtoken" as any,
+          "0xproxy" as any,
+        ),
+      ).rejects.toThrow(/Approval did not take effect/);
+
+      // Crucially, the repay was never broadcast — the user would have signed
+      // a doomed tx if we'd skipped the verification.
+      expect(mockRepayToCorePosition).not.toHaveBeenCalled();
     });
 
     it("should throw error when wallet has no account", async () => {

--- a/services/vault/src/applications/aave/services/positionTransactions.ts
+++ b/services/vault/src/applications/aave/services/positionTransactions.ts
@@ -192,9 +192,11 @@ export async function repayPartial(
  * residual debt — which is the interest accrued between the caller's
  * balance check and the broadcast block (sub-cent in practice).
  *
- * Callers must have already verified `balanceAmount >= currentDebt` against
- * fresh on-chain values; this function does not refetch debt to keep the
- * pulled amount strictly capped at the user's balance.
+ * `balanceAmount` is treated as the user's full on-chain balance at submit
+ * time — the submit path resolves it via `pickRepayParams`, which refetches
+ * debt + balance in the same tick as the wallet sign request. This function
+ * deliberately does not refetch balance, so the pulled amount stays strictly
+ * capped at whatever the caller passed.
  *
  * Approval/refund: the adapter pulls the full approved amount, routes the
  * debt, and refunds the excess in the same tx. Residual allowance after the

--- a/services/vault/src/applications/aave/services/positionTransactions.ts
+++ b/services/vault/src/applications/aave/services/positionTransactions.ts
@@ -95,6 +95,49 @@ export async function repay(
 }
 
 /**
+ * Approve if needed, then verify the approval landed on-chain.
+ *
+ * We've seen the subsequent repay tx revert with `ERC20InsufficientAllowance`
+ * after the approve receipt returned cleanly — the public RPC can briefly
+ * serve pre-block state, so the next tx executes against a stale allowance.
+ * Re-reading turns a revert-after-signing into a pre-broadcast error.
+ */
+async function ensureAllowance(
+  walletClient: WalletClient,
+  chain: Chain,
+  tokenAddress: Address,
+  ownerAddress: Address,
+  spenderAddress: Address,
+  requiredAmount: bigint,
+): Promise<void> {
+  const currentAllowance = await ERC20.getERC20Allowance(
+    tokenAddress,
+    ownerAddress,
+    spenderAddress,
+  );
+  if (currentAllowance >= requiredAmount) return;
+
+  await ERC20.approveERC20(
+    walletClient,
+    chain,
+    tokenAddress,
+    spenderAddress,
+    requiredAmount,
+  );
+
+  const verifiedAllowance = await ERC20.getERC20Allowance(
+    tokenAddress,
+    ownerAddress,
+    spenderAddress,
+  );
+  if (verifiedAllowance < requiredAmount) {
+    throw new Error(
+      `Approval did not take effect on-chain (expected at least ${requiredAmount}, got ${verifiedAllowance}). This is usually a transient RPC lag — please refresh the page and try again.`,
+    );
+  }
+}
+
+/**
  * Repay a partial amount of debt
  *
  * Handles approval if needed, then executes repay.
@@ -128,21 +171,14 @@ export async function repayPartial(
     );
   }
 
-  const currentAllowance = await ERC20.getERC20Allowance(
+  await ensureAllowance(
+    walletClient,
+    chain,
     tokenAddress,
     userAddress,
     adapterAddress,
+    amount,
   );
-
-  if (currentAllowance < amount) {
-    await ERC20.approveERC20(
-      walletClient,
-      chain,
-      tokenAddress,
-      adapterAddress,
-      amount,
-    );
-  }
 
   return repay(walletClient, chain, userAddress, debtReserveId, amount);
 }
@@ -160,13 +196,9 @@ export async function repayPartial(
  * fresh on-chain values; this function does not refetch debt to keep the
  * pulled amount strictly capped at the user's balance.
  *
- * Residual-allowance note: we approve the full `balanceAmount` but the
- * adapter typically pulls less (≤ debt at execution). Leftover allowance
- * = `balanceAmount - debtPulled`, bounded by ~0.5 % of balance because we
- * only enter this path when `balance ≈ debt`. The pinned-adapter trust
- * model treats this residual as acceptable; eliminating it entirely would
- * require the adapter contract to accept a sentinel "repay all" amount so
- * the dApp can approve exactly what's owed.
+ * Approval/refund: the adapter pulls the full approved amount, routes the
+ * debt, and refunds the excess in the same tx. Residual allowance after the
+ * tx = 0; no `approve(0)` cleanup needed.
  *
  * @param walletClient - Connected wallet client
  * @param chain - Chain configuration
@@ -193,21 +225,14 @@ export async function repayMaxCapped(
 
   const adapterAddress = getAaveAdapterAddress();
 
-  const currentAllowance = await ERC20.getERC20Allowance(
+  await ensureAllowance(
+    walletClient,
+    chain,
     tokenAddress,
     userAddress,
     adapterAddress,
+    balanceAmount,
   );
-
-  if (currentAllowance < balanceAmount) {
-    await ERC20.approveERC20(
-      walletClient,
-      chain,
-      tokenAddress,
-      adapterAddress,
-      balanceAmount,
-    );
-  }
 
   return repay(walletClient, chain, userAddress, debtReserveId, balanceAmount);
 }
@@ -218,14 +243,9 @@ export async function repayMaxCapped(
  * Fetches exact debt from contract, handles approval, then repays.
  * Uses pinned adapter and spoke addresses from trusted environment config.
  *
- * Residual-allowance note: we approve `currentDebt × (1 + buffer)` to absorb
- * interest accrual between fetch and execution, but the adapter pulls only
- * what's actually owed. Leftover allowance ≈ `buffer × currentDebt − accrual`
- * — for a 200 USDC repay with the 0.5 % buffer this is ~1 USDC of lingering
- * allowance on the pinned adapter. The pinned-adapter trust model treats
- * this residual as acceptable; eliminating it would require the adapter to
- * read on-chain debt at execution so the dApp can approve exactly what's
- * owed.
+ * Approval/refund: the adapter pulls the full `currentDebt × (1 + buffer)`,
+ * routes the actual debt, and refunds the unused buffer in the same tx.
+ * Residual allowance after the tx = 0; no `approve(0)` cleanup needed.
  *
  * @param walletClient - Connected wallet client
  * @param chain - Chain configuration
@@ -260,19 +280,12 @@ export async function repayFull(
     throw new Error("No debt to repay");
   }
 
-  // Buffer for interest accrual between fetching debt and tx execution.
-  // The adapter only pulls what's actually owed; excess stays with the user.
-  //
-  // Uses **ceiling division** so any non-zero debt gets at least 1 base unit
-  // of buffer. Floor division (currentDebt / FULL_REPAY_BUFFER_DIVISOR) silently
-  // returns 0 for `currentDebt < FULL_REPAY_BUFFER_DIVISOR` — exactly the
-  // dust-scale case where a residual could otherwise linger forever as each
-  // repay sends the exact debt and the next block re-introduces a microcent.
+  // Ceiling division guarantees ≥ 1 base unit of buffer even for dust-scale
+  // debts where the percentage math would floor to 0.
   const bufferDelta =
     (currentDebt + FULL_REPAY_BUFFER_DIVISOR - 1n) / FULL_REPAY_BUFFER_DIVISOR;
   const amountToRepay = currentDebt + bufferDelta;
 
-  // Check user's token balance before proceeding
   const userBalance = await ERC20.getERC20Balance(tokenAddress, userAddress);
   if (userBalance < amountToRepay) {
     throw new Error(
@@ -280,22 +293,14 @@ export async function repayFull(
     );
   }
 
-  // Check existing allowance and approve if needed
-  const currentAllowance = await ERC20.getERC20Allowance(
+  await ensureAllowance(
+    walletClient,
+    chain,
     tokenAddress,
     userAddress,
     adapterAddress,
+    amountToRepay,
   );
-
-  if (currentAllowance < amountToRepay) {
-    await ERC20.approveERC20(
-      walletClient,
-      chain,
-      tokenAddress,
-      adapterAddress,
-      amountToRepay,
-    );
-  }
 
   return repay(walletClient, chain, userAddress, debtReserveId, amountToRepay);
 }

--- a/services/vault/src/hooks/useERC20Balance.ts
+++ b/services/vault/src/hooks/useERC20Balance.ts
@@ -60,6 +60,12 @@ export function useERC20Balance(
     enabled: Boolean(tokenAddress && walletAddress),
     // Refetch periodically to keep balance up to date
     refetchInterval: 30000,
+    // `"online"` (the default) pauses queries when `navigator.onLine` is
+    // false instead of running queryFn — silently returning stale data to
+    // callers awaiting `refetch()`. `"always"` runs the queryFn regardless
+    // so real network failures surface via `isError`, which is the contract
+    // the repay submit path depends on.
+    networkMode: "always",
   });
 
   const balance = useMemo(() => {


### PR DESCRIPTION
## Context

Follow-up to the merged Aave repay-dust PR (#1646). Four issues surfaced during manual testing and review of that PR; this PR addresses them. Scope is tight: 4 files, no behavior change for the happy path, all changes defensive or UX-only.

## Changes

### 1. Offline detection in `handleMaxClick` (P1, real bug fix)

[`services/vault/src/applications/aave/components/LoanCard/Repay/index.tsx`](services/vault/src/applications/aave/components/LoanCard/Repay/index.tsx)

The "fail-loud on refetch error" path added in #1646 didn't actually fire for the offline case. React Query's default `networkMode: "online"` **pauses** queries when the browser is offline rather than throwing — so the `try`/`catch` block swallowed the offline state and the `Couldn't refresh balance/debt — please try again.` warning never reached the UI. Console showed the error, the UI did not.

Two layers added:

- Explicit `navigator.onLine` check at the top of `handleMaxClick`. If offline, set the inline warning and bail before the awaits.
- `isError` check on the `refetchUserBalance` result. React Query refetches don't reject on `queryFn` failure; they surface the error on `.error`. Treat that as a failure path equivalent to a thrown error.

### 2. JSDoc corrections on `repayMaxCapped` / `repayFull` (P2, doc accuracy)

[`services/vault/src/applications/aave/services/positionTransactions.ts`](services/vault/src/applications/aave/services/positionTransactions.ts)

The JSDoc added in #1646 said the leftover ERC20 allowance after a repay was `~0.5% × debt` and pushed the cleanup question to a contract-side follow-up. Tx-receipt inspection (Sepolia) shows the adapter actually `transferFrom`s the **full approved amount**, routes the actual debt to the vault, and refunds the unused buffer back to the user in the same tx. Net residual allowance = 0; no `approve(0)` cleanup needed.

JSDoc on both functions is now corrected to reflect actual on-chain behavior.

### 3. Decimal input fix (P3, pre-existing UX bug surfaced during testing)

[`packages/babylon-core-ui/src/widgets/sections/AmountSlider/AmountSlider.tsx`](packages/babylon-core-ui/src/widgets/sections/AmountSlider/AmountSlider.tsx)

Typing `.` or `,` in any `AmountSlider`-driven input did nothing — the dot disappeared and the user couldn't enter decimals. Pasting worked. Root cause: the input was controlled by `value={amount}` where `amount` is the parsed number from the consumer. Typing `0.` made `parseFloat` collapse to `0`, the controlled re-render erased the dot, the cycle prevented any decimal from being typed.

Fix: track the raw input as a local string state. Sync from the `amount` prop only when it represents a **genuinely different** number than what the string currently parses to — so mid-typing states like `0.` survive a re-render, while external updates (Max click, slider, reset) still take effect.

This fix applies to **all four `AmountSlider` consumers**: Repay, Borrow, CollateralModal, DepositForm. No consumer changes needed.

### 4. Defensive allowance verification (insufficient-allowance investigation)

[`services/vault/src/applications/aave/services/positionTransactions.ts`](services/vault/src/applications/aave/services/positionTransactions.ts), [`services/vault/src/applications/aave/services/__tests__/positionTransactions.test.ts`](services/vault/src/applications/aave/services/__tests__/positionTransactions.test.ts)

During testing of #1646 the repay tx intermittently reverted with `ERC20InsufficientAllowance` even though the prior `approveERC20` call completed successfully. The user's workaround was "refresh + retry" which always worked. Most plausible root cause: **RPC consistency lag** — the approve tx's receipt indicates the approve made it into a block, but the public RPC node briefly serves pre-block state for subsequent reads, so the next on-chain action (the actual repay) executes against a stale allowance and reverts.

Added an `ensureAllowance` helper used by all three repay paths (`repayPartial`, `repayMaxCapped`, `repayFull`):

1. Read current allowance.
2. If already sufficient, return.
3. Otherwise, call `approveERC20` and **re-read** the allowance to verify it actually landed on-chain.
4. If still insufficient, throw a clear pre-broadcast error: _"Approval did not take effect on-chain ... please refresh the page and try again."_

This turns a revert-after-signing (user wastes gas + sees a generic "Transaction Reverted" error) into a clear pre-broadcast failure with actionable guidance.

Cost: one extra `getERC20Allowance` read per approve (~50 ms). Cheap for value-movement code.

### Test updates

[`services/vault/src/applications/aave/services/__tests__/positionTransactions.test.ts`](services/vault/src/applications/aave/services/__tests__/positionTransactions.test.ts)

- The shared `beforeEach` now mocks `getERC20Allowance` + `approveERC20` to **simulate the on-chain allowance transition** — when `approveERC20` is called with amount `X`, subsequent reads return `X`. This mirrors real chain state and is necessary because `ensureAllowance` re-reads post-approve. Without this, every approve-path test would throw "Approval did not take effect" on the verification step.
- Per-test `mockGetERC20Allowance.mockResolvedValue(X)` overrides were replaced with a `setSimulatedAllowance(X)` helper that updates the shared state.
- New test: `throws when post-approve allowance verification fails (RPC lag defense)` — overrides the simulation so `approveERC20` no-ops the allowance, asserts the `Approval did not take effect` error and that the repay was **never broadcast**.

<img width="2032" height="1162" alt="Screenshot_2026-05-13_15-36-06" src="https://github.com/user-attachments/assets/41ef3a7a-926a-490e-9b4c-eab1b82872f0" />
