### PR TITLE
feat(vault): better error display

### DIFF
--- a/services/vault/src/utils/errors/__tests__/formatting.test.ts
+++ b/services/vault/src/utils/errors/__tests__/formatting.test.ts
@@ -74,11 +74,28 @@ describe("Error Formatting", () => {
       expect(sanitizeErrorMessage("a string error")).toBe("a string error");
     });
 
-    it("returns 'Unknown error' for non-Error objects", () => {
+    it("returns 'Unknown error' for non-Error objects without string message", () => {
       expect(sanitizeErrorMessage({ key: "value" })).toBe("Unknown error");
       expect(sanitizeErrorMessage(42)).toBe("Unknown error");
       expect(sanitizeErrorMessage(null)).toBe("Unknown error");
       expect(sanitizeErrorMessage(undefined)).toBe("Unknown error");
+    });
+
+    it("extracts .message from plain objects with a string message", () => {
+      expect(sanitizeErrorMessage({ message: "wallet rejected" })).toBe(
+        "wallet rejected",
+      );
+    });
+
+    it("returns 'Unknown error' when message is '[object Object]'", () => {
+      // Guards against an upstream wrap that did `new Error(\`...: ${obj}\`)`.
+      expect(sanitizeErrorMessage(new Error("[object Object]"))).toBe(
+        "Unknown error",
+      );
+      expect(sanitizeErrorMessage("[object Object]")).toBe("Unknown error");
+      expect(sanitizeErrorMessage({ message: "[object Object]" })).toBe(
+        "Unknown error",
+      );
     });
   });
 
@@ -122,6 +139,41 @@ describe("Error Formatting", () => {
       const result = formatPayoutSignatureError(error);
 
       expect(result.title).not.toBe("Signing Rejected");
+    });
+
+    it("extracts .message from plain objects (some wallets throw object literals)", () => {
+      const result = formatPayoutSignatureError({
+        code: -32603,
+        message: "VP rejected the signature",
+      });
+      expect(result.title).toBe("Payout Signing Error");
+      expect(result.message).toBe("VP rejected the signature");
+    });
+
+    it("falls back to static message for plain objects without string .message", () => {
+      const result = formatPayoutSignatureError({});
+      expect(result.message).not.toBe("[object Object]");
+      expect(result.message).toContain("unexpected error");
+    });
+
+    it("falls back to static message for null/undefined", () => {
+      expect(formatPayoutSignatureError(null).message).toContain(
+        "unexpected error",
+      );
+      expect(formatPayoutSignatureError(undefined).message).toContain(
+        "unexpected error",
+      );
+    });
+
+    it("falls back to static message when .message itself is '[object Object]'", () => {
+      const result = formatPayoutSignatureError({ message: "[object Object]" });
+      expect(result.message).not.toBe("[object Object]");
+      expect(result.message).toContain("unexpected error");
+    });
+
+    it("passes through string throws (WASM panics)", () => {
+      const result = formatPayoutSignatureError("wasm panic: out of bounds");
+      expect(result.message).toBe("wasm panic: out of bounds");
     });
 
     // Drift guard: production code inlines "CONNECTION_REJECTED" instead of

--- a/services/vault/src/utils/errors/formatting.ts
+++ b/services/vault/src/utils/errors/formatting.ts
@@ -28,11 +28,28 @@ function isWalletRejectionError(error: unknown): boolean {
 
 /**
  * Extract a safe error message from an unknown error value.
- * Never serializes arbitrary objects — only extracts .message from Error instances.
+ * Falls back to "Unknown error" for empty messages and for the literal
+ * "[object Object]" — the latter shows up when upstream code wrapped a
+ * plain object via template-literal interpolation.
  */
 export function sanitizeErrorMessage(err: unknown): string {
-  if (err instanceof Error) return err.message;
-  if (typeof err === "string") return err;
+  if (err instanceof Error) {
+    return err.message && err.message !== "[object Object]"
+      ? err.message
+      : "Unknown error";
+  }
+  if (typeof err === "string") {
+    return err && err !== "[object Object]" ? err : "Unknown error";
+  }
+  if (
+    err !== null &&
+    typeof err === "object" &&
+    "message" in err &&
+    typeof (err as { message: unknown }).message === "string"
+  ) {
+    const m = (err as { message: string }).message;
+    if (m && m !== "[object Object]") return m;
+  }
   return "Unknown error";
 }
 
@@ -180,11 +197,26 @@ export function formatPayoutSignatureError(error: unknown): {
     };
   }
 
-  // WASM panics and some wallet providers throw strings or plain objects
-  const msg = typeof error === "string" ? error : String(error);
+  // WASM panics and some wallet providers throw strings or plain objects.
+  // Extract a real string — never let `String(plainObject)` surface as
+  // "[object Object]" in the UI.
+  let msg = "";
+  if (typeof error === "string") {
+    msg = error;
+  } else if (
+    error !== null &&
+    typeof error === "object" &&
+    "message" in error &&
+    typeof (error as { message: unknown }).message === "string"
+  ) {
+    msg = (error as { message: string }).message;
+  }
   return {
     title: "Payout Signing Error",
-    message: msg || "An unexpected error occurred while signing payouts.",
+    message:
+      msg && msg !== "[object Object]"
+        ? msg
+        : "An unexpected error occurred while signing payouts.",
   };
 }
 


### PR DESCRIPTION
Provides a better display of errors

Before:

<img width="2032" height="1162" alt="Screenshot_2026-05-13_16-15-42" src="https://github.com/user-attachments/assets/83edcbf6-1bb4-46d6-8af6-acb4fc64ee04" />

After

<img width="2032" height="1162" alt="Screenshot_2026-05-13_16-20-33" src="https://github.com/user-attachments/assets/83d48b63-aecf-4f59-a81a-fac2bd9b7ba5" />
