### PR TITLE
fix(ts-sdk): babe_sessions validation

### DIFF
--- a/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/__tests__/json-rpc-client.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/__tests__/json-rpc-client.test.ts
@@ -380,7 +380,7 @@ describe("JsonRpcClient", () => {
       tx_graph_json: "x".repeat(80),
       verifying_key_hex: "aabb",
       babe_sessions: {
-        challenger1: { decryptor_artifacts_hex: "ccdd" },
+        ["d".repeat(64)]: { decryptor_artifacts_hex: "ccdd" },
       },
     };
 

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/__tests__/validators.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/__tests__/validators.test.ts
@@ -549,11 +549,12 @@ describe("VP Response Validators", () => {
   });
 
   describe("validateRequestDepositorClaimerArtifactsResponse", () => {
+    const CHALLENGER_PUBKEY = "d".repeat(64);
     const validResponse = {
       tx_graph_json: "{ }",
       verifying_key_hex: "aabb",
       babe_sessions: {
-        challenger1: { decryptor_artifacts_hex: "ccdd" },
+        [CHALLENGER_PUBKEY]: { decryptor_artifacts_hex: "ccdd" },
       },
     };
 
@@ -563,13 +564,66 @@ describe("VP Response Validators", () => {
       ).not.toThrow();
     });
 
-    it("accepts response with empty babe_sessions", () => {
+    it("accepts compressed-pubkey-keyed sessions", () => {
+      expect(() =>
+        validateRequestDepositorClaimerArtifactsResponse({
+          ...validResponse,
+          babe_sessions: {
+            [VALID_COMPRESSED_PUBKEY]: { decryptor_artifacts_hex: "ccdd" },
+          },
+        }),
+      ).not.toThrow();
+    });
+
+    it("rejects empty babe_sessions", () => {
       expect(() =>
         validateRequestDepositorClaimerArtifactsResponse({
           ...validResponse,
           babe_sessions: {},
         }),
-      ).not.toThrow();
+      ).toThrow(VpResponseValidationError);
+    });
+
+    it("rejects babe_sessions whose keys are not BTC pubkeys", () => {
+      expect(() =>
+        validateRequestDepositorClaimerArtifactsResponse({
+          ...validResponse,
+          babe_sessions: {
+            attacker_label: { decryptor_artifacts_hex: "deadbeef" },
+          },
+        }),
+      ).toThrow(VpResponseValidationError);
+    });
+
+    it("rejects babe_sessions keyed by non-hex strings", () => {
+      expect(() =>
+        validateRequestDepositorClaimerArtifactsResponse({
+          ...validResponse,
+          babe_sessions: {
+            ["z".repeat(64)]: { decryptor_artifacts_hex: "deadbeef" },
+          },
+        }),
+      ).toThrow(VpResponseValidationError);
+    });
+
+    it("rejects babe_sessions keyed by wrong-length hex", () => {
+      expect(() =>
+        validateRequestDepositorClaimerArtifactsResponse({
+          ...validResponse,
+          babe_sessions: {
+            ["a".repeat(40)]: { decryptor_artifacts_hex: "deadbeef" },
+          },
+        }),
+      ).toThrow(VpResponseValidationError);
+    });
+
+    it("rejects babe_sessions when it is an array", () => {
+      expect(() =>
+        validateRequestDepositorClaimerArtifactsResponse({
+          ...validResponse,
+          babe_sessions: [],
+        }),
+      ).toThrow(VpResponseValidationError);
     });
 
     it("rejects null response", () => {
@@ -624,7 +678,7 @@ describe("VP Response Validators", () => {
       expect(() =>
         validateRequestDepositorClaimerArtifactsResponse({
           ...validResponse,
-          babe_sessions: { challenger1: null },
+          babe_sessions: { [CHALLENGER_PUBKEY]: null },
         }),
       ).toThrow(VpResponseValidationError);
     });
@@ -634,7 +688,7 @@ describe("VP Response Validators", () => {
         validateRequestDepositorClaimerArtifactsResponse({
           ...validResponse,
           babe_sessions: {
-            challenger1: { decryptor_artifacts_hex: "xyz" },
+            [CHALLENGER_PUBKEY]: { decryptor_artifacts_hex: "xyz" },
           },
         }),
       ).toThrow(VpResponseValidationError);

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/validators.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/validators.ts
@@ -370,7 +370,7 @@ export function validateRequestDepositorClaimerArtifactsResponse(
   }
 
   for (const [key, session] of sessionEntries) {
-    assertBtcPubkey(key, `babe_sessions key "${key}"`);
+    assertBtcPubkey(key, `babe_sessions["${key}"]`);
     if (session === null || typeof session !== "object") {
       throw new VpResponseValidationError(
         `VP response validation failed: "babe_sessions.${key}" must be an object`,

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/validators.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/validators.ts
@@ -350,15 +350,27 @@ export function validateRequestDepositorClaimerArtifactsResponse(
     );
   }
 
-  if (r.babe_sessions === null || typeof r.babe_sessions !== "object") {
+  if (
+    r.babe_sessions === null ||
+    typeof r.babe_sessions !== "object" ||
+    Array.isArray(r.babe_sessions)
+  ) {
     throw new VpResponseValidationError(
       `VP response validation failed: "babe_sessions" must be an object`,
     );
   }
 
-  for (const [key, session] of Object.entries(
+  const sessionEntries = Object.entries(
     r.babe_sessions as Record<string, unknown>,
-  )) {
+  );
+  if (sessionEntries.length === 0) {
+    throw new VpResponseValidationError(
+      `VP response validation failed: "babe_sessions" must contain at least one challenger entry`,
+    );
+  }
+
+  for (const [key, session] of sessionEntries) {
+    assertBtcPubkey(key, `babe_sessions key "${key}"`);
     if (session === null || typeof session !== "object") {
       throw new VpResponseValidationError(
         `VP response validation failed: "babe_sessions.${key}" must be an object`,

--- a/services/vault/src/services/artifacts/__tests__/artifactDownloadService.test.ts
+++ b/services/vault/src/services/artifacts/__tests__/artifactDownloadService.test.ts
@@ -15,12 +15,14 @@ const PEGIN_TXID =
   "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 const DEPOSITOR_PK =
   "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+const CHALLENGER_PUBKEY =
+  "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
 
 const VALID_ARTIFACT_RESULT = {
   tx_graph_json: "{}",
   verifying_key_hex: "aabb",
   babe_sessions: {
-    challenger1: { decryptor_artifacts_hex: "ccdd" },
+    [CHALLENGER_PUBKEY]: { decryptor_artifacts_hex: "ccdd" },
   },
 };
 
@@ -130,7 +132,42 @@ describe("fetchAndDownloadArtifacts", () => {
         result: {
           ...VALID_ARTIFACT_RESULT,
           babe_sessions: {
-            challenger1: { decryptor_artifacts_hex: "not-hex!" },
+            [CHALLENGER_PUBKEY]: { decryptor_artifacts_hex: "not-hex!" },
+          },
+        },
+        id: 1,
+      }),
+    );
+
+    await expect(
+      fetchAndDownloadArtifacts(PROVIDER_ADDRESS, PEGIN_TXID, DEPOSITOR_PK),
+    ).rejects.toBeInstanceOf(VpResponseValidationError);
+    expect(triggerDownloadSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects empty babe_sessions without triggering download", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      responseFor({
+        jsonrpc: "2.0",
+        result: { ...VALID_ARTIFACT_RESULT, babe_sessions: {} },
+        id: 1,
+      }),
+    );
+
+    await expect(
+      fetchAndDownloadArtifacts(PROVIDER_ADDRESS, PEGIN_TXID, DEPOSITOR_PK),
+    ).rejects.toBeInstanceOf(VpResponseValidationError);
+    expect(triggerDownloadSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects babe_sessions keyed by an arbitrary non-pubkey label without triggering download", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      responseFor({
+        jsonrpc: "2.0",
+        result: {
+          ...VALID_ARTIFACT_RESULT,
+          babe_sessions: {
+            attacker_label: { decryptor_artifacts_hex: "deadbeef" },
           },
         },
         id: 1,


### PR DESCRIPTION
## What's wrong today

When a deposit finishes, the vault provider (VP) sends back a "recovery artifact" — a file the depositor saves so they can recover their BTC later without help from the VP. The file contains the transaction graph, a verifying key, and a `babe_sessions` map: one entry per challenger, keyed by the challenger's pubkey, holding the decryptor material that lets the depositor unlock the graph.

The frontend runs `validateRequestDepositorClaimerArtifactsResponse` on this response, and **only triggers the file download if validation passes**. The problem: that validator is too lax. It accepts any of these as "valid":

```js
babe_sessions: {}                                        // empty
babe_sessions: { attacker_label: { decryptor_artifacts_hex: "deadbeef" } }  // arbitrary key
babe_sessions: []                                        // an array (passes `typeof === "object"`)
```

All three cases produce a file that **cannot recover the vault** — the decryptor material isn't keyed by the actual challenger pubkeys, or isn't there at all. But because the validator returns success, the browser saves the file under the expected `babylon-vault-artifacts-<peginTxid>.json` filename. The user thinks they have a working recovery artifact. They only find out it's useless months later, during an actual recovery, when the VP may be hostile or gone — which is exactly when this file is supposed to save them.

The current tests even pin the broken behavior — there's a test called `"accepts response with empty babe_sessions"` documenting the bug as if it were intended.

## What this PR changes

Three small additions to `validateRequestDepositorClaimerArtifactsResponse` in [`packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/validators.ts`](packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/validators.ts):

1. **Reject arrays.** `typeof [] === "object"` slipped past the old check. Now we also call `Array.isArray()`.
2. **Reject empty maps.** A `babe_sessions` map with zero entries can't recover anything, so we throw before the file save runs.
3. **Validate each key as a Bitcoin pubkey.** We reuse the `assertBtcPubkey` helper that already lives in the same file (and is already used elsewhere in this validator for challenger pubkeys). It requires the key to be either 64-char x-only hex or 66-char compressed hex. So `attacker_label` is rejected, but a valid challenger pubkey is accepted.

The per-entry value checks (null entries, non-hex `decryptor_artifacts_hex`) are unchanged.

## Why "simple shape rules" instead of "real binding"

The audit's full recommendation is much bigger: bind the artifact to the user's pegin txid, depositor pubkey, provider identity, and the *expected* challenger set from on-chain data, via a signed/digested manifest. That's the right end-state, but it's a multi-week, cross-repo effort — the manifest format has to be agreed with `btc-vault` (the server), and it would also have to fold in two sibling audit findings ([babylonlabs-io/baby-auditor-findings#152](https://github.com/babylonlabs-io/baby-auditor-findings/issues/152) large-body bypass and [babylonlabs-io/baby-auditor-findings#224](https://github.com/babylonlabs-io/baby-auditor-findings/issues/224) provider routing/auth).

This PR is the **smallest correct local fix**: it closes the audit's exact PoC cases (empty map, `attacker_label`) and removes the misleading "validator approves anything" signal. It is **not a full closure of [babylonlabs-io/baby-auditor-findings#304](https://github.com/babylonlabs-io/baby-auditor-findings/issues/304)** — a hostile VP that returns a non-empty map keyed by *random* 64-char hex (unrelated to your real challengers) still passes this validator. Closing that gap belongs in the joint [babylonlabs-io/baby-auditor-findings#152](https://github.com/babylonlabs-io/baby-auditor-findings/issues/152) / [babylonlabs-io/baby-auditor-findings#224](https://github.com/babylonlabs-io/baby-auditor-findings/issues/224) manifest workstream.

I deliberately did **not** thread `peginTxid`, `depositorPk`, or the expected challenger set into the validator here — doing so without the agreed manifest format would mean redoing it once that format lands.

## Reviewers to check

1. **`assertBtcPubkey` is the right helper.** It accepts both x-only (64-char) and compressed (66-char). If the BaBe protocol guarantees one format, I'd happily tighten — let me know which.
2. **No production caller is using `challenger1`-style placeholder keys.** I refreshed fixtures, but if any production code path was relying on string-keyed `babe_sessions` (it shouldn't — these are challenger pubkeys), that would break.

## Known residual risk (documented, not fixed here)

- A non-empty map keyed by any pubkey-shaped hex string still passes. Needs the chain-anchored manifest from [babylonlabs-io/baby-auditor-findings#152](https://github.com/babylonlabs-io/baby-auditor-findings/issues/152) / [babylonlabs-io/baby-auditor-findings#224](https://github.com/babylonlabs-io/baby-auditor-findings/issues/224) / [babylonlabs-io/baby-auditor-findings#304](https://github.com/babylonlabs-io/baby-auditor-findings/issues/304) jointly.
- The validator only runs for response bodies under 4096 bytes (see [`artifactDownloadService.ts:102`](services/vault/src/services/artifacts/artifactDownloadService.ts#L102)). Real ~450 MB artifacts skip it entirely. The audit's PoC is a small-payload case, which this fix does cover. Large-payload validation belongs in [babylonlabs-io/baby-auditor-findings#152](https://github.com/babylonlabs-io/baby-auditor-findings/issues/152)'s streaming/worker parser work.

Closes https://github.com/babylonlabs-io/baby-auditor-findings/issues/304
