### PR TITLE
fix(vault): reserve UTXOs before wallet signing

### DIFF
--- a/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/__tests__/reservation.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/__tests__/reservation.test.ts
@@ -371,12 +371,36 @@ describe("UTXO Reservation", () => {
         pendingPegins: [],
         vaults: [],
         utxoReservations: [
-          { unsignedTxHex: createValidTxHex(reservationTxid, 2) },
+          { outpoints: [{ txid: reservationTxid, vout: 2 }] },
         ],
       });
 
       expect(reserved).toHaveLength(1);
       expect(hasRef(reserved, reservationTxid, 2)).toBe(true);
+    });
+
+    it("should collect every outpoint from a multi-input reservation", () => {
+      const txidA =
+        "1111111111111111111111111111111111111111111111111111111111111111";
+      const txidB =
+        "2222222222222222222222222222222222222222222222222222222222222222";
+
+      const reserved = collectReservedUtxoRefs({
+        pendingPegins: [],
+        vaults: [],
+        utxoReservations: [
+          {
+            outpoints: [
+              { txid: txidA, vout: 0 },
+              { txid: txidB, vout: 5 },
+            ],
+          },
+        ],
+      });
+
+      expect(reserved).toHaveLength(2);
+      expect(hasRef(reserved, txidA, 0)).toBe(true);
+      expect(hasRef(reserved, txidB, 5)).toBe(true);
     });
 
     it("should combine refs from reservations with pending pegins and vaults", () => {
@@ -393,7 +417,7 @@ describe("UTXO Reservation", () => {
         pendingPegins: [mockPendingPegin],
         vaults: [vault],
         utxoReservations: [
-          { unsignedTxHex: createValidTxHex(reservationTxid, 7) },
+          { outpoints: [{ txid: reservationTxid, vout: 7 }] },
         ],
       });
 

--- a/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts
@@ -65,7 +65,7 @@ export interface SelectUtxosForDepositParams<
 
 /** Narrow structural type for early UTXO reservations (pre-ETH-registration). */
 export interface UtxoReservationLike {
-  unsignedTxHex: string;
+  outpoints: ReadonlyArray<{ txid: string; vout: number }>;
 }
 
 export interface CollectReservedUtxoRefsParams {
@@ -203,7 +203,9 @@ export function collectReservedUtxoRefs(
   // Early reservations written before ETH registration to prevent cross-tab
   // UTXO conflicts. These are cleaned up when the deposit completes or fails.
   for (const reservation of utxoReservations) {
-    reserved.push(...extractInputUtxoRefs(reservation.unsignedTxHex));
+    for (const op of reservation.outpoints) {
+      reserved.push({ txid: op.txid, vout: op.vout });
+    }
   }
 
   return reserved;

--- a/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
@@ -604,8 +604,8 @@ describe("useDepositFlow", () => {
         expect(addUtxoReservation).toHaveBeenCalledTimes(2);
       });
 
-      // The whole point of #293: pre-claim must precede preparePegin so a
-      // sibling tab cannot select these outpoints during the wallet popup.
+      // Pre-claim must precede preparePegin so a sibling tab cannot select
+      // these outpoints during the wallet popup window.
       const preClaimOrder = addUtxoReservation.mock.invocationCallOrder[0];
       const prepareOrder = preparePeginTransaction.mock.invocationCallOrder[0];
       const narrowOrder = addUtxoReservation.mock.invocationCallOrder[1];

--- a/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
@@ -114,12 +114,26 @@ vi.mock("@/services/vault/vaultUtxoValidationService", () => ({
 
 vi.mock("@/storage/peginStorage", () => ({
   addPendingPegin: vi.fn(),
-  addUtxoReservation: vi.fn(),
+  addUtxoReservation: vi.fn(() => Promise.resolve()),
+  assertNoReservationConflict: vi.fn(),
   getPendingPegins: vi.fn(() => []),
   getUtxoReservations: vi.fn(() => []),
   removePendingPegin: vi.fn(),
   removeUtxoReservation: vi.fn(),
   updatePendingPeginStatus: vi.fn(),
+  UtxoReservationConflictError: class extends Error {
+    readonly conflictingBatchId: string;
+    readonly outpoint: { txid: string; vout: number };
+    constructor(
+      conflictingBatchId: string,
+      outpoint: { txid: string; vout: number },
+    ) {
+      super(`UTXO conflict (batch ${conflictingBatchId})`);
+      this.name = "UtxoReservationConflictError";
+      this.conflictingBatchId = conflictingBatchId;
+      this.outpoint = outpoint;
+    }
+  },
 }));
 
 vi.mock("@babylonlabs-io/ts-sdk/tbv/core/utils", () => ({
@@ -574,9 +588,12 @@ describe("useDepositFlow", () => {
       });
     });
 
-    it("should write early UTXO reservation and clean it up on success", async () => {
+    it("pre-claims candidate outpoints before preparePeginTransaction and narrows after", async () => {
       const { addUtxoReservation, removeUtxoReservation } = vi.mocked(
         await import("@/storage/peginStorage"),
+      );
+      const { preparePeginTransaction } = vi.mocked(
+        await import("@/services/vault/vaultTransactionService"),
       );
 
       const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
@@ -584,19 +601,109 @@ describe("useDepositFlow", () => {
       await executeWithAutoArtifactDownload(result);
 
       await waitFor(() => {
-        expect(addUtxoReservation).toHaveBeenCalledWith(
-          "0xEthAddress123",
-          expect.objectContaining({
-            unsignedTxHex: "batchFundedPrePeginHex",
-            batchId: "mock-batch-id-uuid",
-            timestamp: expect.any(Number),
-          }),
-        );
-        expect(removeUtxoReservation).toHaveBeenCalledWith(
-          "0xEthAddress123",
-          "mock-batch-id-uuid",
-        );
+        expect(addUtxoReservation).toHaveBeenCalledTimes(2);
       });
+
+      // The whole point of #293: pre-claim must precede preparePegin so a
+      // sibling tab cannot select these outpoints during the wallet popup.
+      const preClaimOrder = addUtxoReservation.mock.invocationCallOrder[0];
+      const prepareOrder = preparePeginTransaction.mock.invocationCallOrder[0];
+      const narrowOrder = addUtxoReservation.mock.invocationCallOrder[1];
+      expect(preClaimOrder).toBeLessThan(prepareOrder);
+      expect(prepareOrder).toBeLessThan(narrowOrder);
+
+      // First write: candidate outpoints from selectUtxosForDeposit.
+      expect(addUtxoReservation).toHaveBeenNthCalledWith(
+        1,
+        "0xEthAddress123",
+        expect.objectContaining({
+          batchId: "mock-batch-id-uuid",
+          outpoints: [
+            { txid: MOCK_UTXO_1.txid, vout: MOCK_UTXO_1.vout },
+            { txid: MOCK_UTXO_2.txid, vout: MOCK_UTXO_2.vout },
+          ],
+        }),
+      );
+
+      // Second write: narrowed to batchResult.selectedUTXOs (same batchId).
+      expect(addUtxoReservation).toHaveBeenNthCalledWith(
+        2,
+        "0xEthAddress123",
+        expect.objectContaining({
+          batchId: "mock-batch-id-uuid",
+          outpoints: [
+            { txid: MOCK_UTXO_1.txid, vout: MOCK_UTXO_1.vout },
+            { txid: MOCK_UTXO_2.txid, vout: MOCK_UTXO_2.vout },
+          ],
+        }),
+      );
+
+      expect(removeUtxoReservation).toHaveBeenCalledWith(
+        "0xEthAddress123",
+        "mock-batch-id-uuid",
+      );
+    });
+
+    it("aborts before preparePeginTransaction when the pre-claim conflicts with another batch", async () => {
+      const { addUtxoReservation, UtxoReservationConflictError } = vi.mocked(
+        await import("@/storage/peginStorage"),
+      );
+      const { preparePeginTransaction } = vi.mocked(
+        await import("@/services/vault/vaultTransactionService"),
+      );
+      const { registerPeginBatchAndWait, signProofOfPossession } = vi.mocked(
+        await import("../depositFlowSteps"),
+      );
+
+      addUtxoReservation.mockRejectedValueOnce(
+        new UtxoReservationConflictError("other-batch", {
+          txid: MOCK_UTXO_1.txid,
+          vout: MOCK_UTXO_1.vout,
+        }),
+      );
+
+      const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
+
+      await executeWithAutoArtifactDownload(result);
+
+      await waitFor(() => {
+        expect(result.current.error).toBeTruthy();
+      });
+
+      // Pre-claim threw → no wallet popup, no ETH registration.
+      expect(preparePeginTransaction).not.toHaveBeenCalled();
+      expect(signProofOfPossession).not.toHaveBeenCalled();
+      expect(registerPeginBatchAndWait).not.toHaveBeenCalled();
+    });
+
+    it("aborts before ETH registration when assertNoReservationConflict throws (defense in depth)", async () => {
+      const { assertNoReservationConflict, UtxoReservationConflictError } =
+        vi.mocked(await import("@/storage/peginStorage"));
+      const { registerPeginBatchAndWait } = vi.mocked(
+        await import("../depositFlowSteps"),
+      );
+      const { broadcastPrePeginTransaction } = vi.mocked(
+        await import("@/services/vault/vaultPeginBroadcastService"),
+      );
+
+      assertNoReservationConflict.mockImplementationOnce(() => {
+        throw new UtxoReservationConflictError("rival-batch", {
+          txid: MOCK_UTXO_1.txid,
+          vout: MOCK_UTXO_1.vout,
+        });
+      });
+
+      const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
+
+      await executeWithAutoArtifactDownload(result);
+
+      await waitFor(() => {
+        expect(result.current.error).toBeTruthy();
+      });
+
+      // The final-pass re-check fires after PoP signing but before ETH send.
+      expect(registerPeginBatchAndWait).not.toHaveBeenCalled();
+      expect(broadcastPrePeginTransaction).not.toHaveBeenCalled();
     });
 
     it("aborts before broadcast when on-chain offchainParamsVersion drifted from the build version", async () => {

--- a/services/vault/src/hooks/deposit/useDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useDepositFlow.ts
@@ -68,6 +68,7 @@ import { assertUtxosAvailable } from "@/services/vault/vaultUtxoValidationServic
 import {
   addPendingPegin,
   addUtxoReservation,
+  assertNoReservationConflict,
   getPendingPegins,
   getUtxoReservations,
   removePendingPegin,
@@ -405,6 +406,24 @@ export function useDepositFlow(
           feeRate: mempoolFeeRate,
         });
 
+        // Claim the candidate outpoints BEFORE `preparePeginTransaction`.
+        // That call drives `deriveVaultRoot` (wallet popup #1) and the batch
+        // PSBT commit pass (wallet popup #2) — together a 1-3 minute window
+        // during which a sibling tab must not be able to pick the same
+        // outpoints. The actually-used subset is decided inside
+        // `preparePegin` and the reservation is narrowed below; same batchId
+        // overwrites in place. Conflict throws and aborts before any popup.
+        reservationBatchId = batchId;
+        reservationEthAddress = confirmedEthAddress;
+        await addUtxoReservation(confirmedEthAddress, {
+          outpoints: availableUTXOs.map((u) => ({
+            txid: u.txid,
+            vout: u.vout,
+          })),
+          timestamp: Date.now(),
+          batchId,
+        });
+
         const [vaultKeeperReader, universalChallengerReader] =
           await Promise.all([
             getVaultKeeperReader(),
@@ -447,13 +466,14 @@ export function useDepositFlow(
           authAnchorHex,
         } = batchResult;
 
-        // Reserve UTXOs in localStorage immediately so other tabs see them
-        // during the (potentially lengthy) PoP signing and ETH registration.
-        // Cleaned up after pending pegin entries are written, or on failure.
-        reservationBatchId = batchId;
-        reservationEthAddress = confirmedEthAddress;
-        addUtxoReservation(confirmedEthAddress, {
-          unsignedTxHex: batchResult.fundedPrePeginTxHex,
+        // Narrow the pre-claim to the actually-selected inputs now that
+        // `preparePegin` has decided which subset to spend. Same batchId
+        // overwrites in place; same-batch writes never conflict.
+        await addUtxoReservation(confirmedEthAddress, {
+          outpoints: batchResult.selectedUTXOs.map((u) => ({
+            txid: u.txid,
+            vout: u.vout,
+          })),
           timestamp: Date.now(),
           batchId,
         });
@@ -502,6 +522,20 @@ export function useDepositFlow(
         await assertUtxosAvailable(
           batchResult.fundedPrePeginTxHex,
           confirmedBtcAddress,
+        );
+
+        // Final-pass conflict re-check. Defense in depth: catches the
+        // residual race where two tabs without `navigator.locks` both wrote
+        // a reservation in the same microtask. Any overlap from another
+        // batch aborts the flow before we bind an ETH vault to contended
+        // outpoints.
+        assertNoReservationConflict(
+          confirmedEthAddress,
+          batchId,
+          batchResult.selectedUTXOs.map((u) => ({
+            txid: u.txid,
+            vout: u.vout,
+          })),
         );
 
         // 3e. Single batch ETH transaction for all vaults.

--- a/services/vault/src/storage/__tests__/peginStorage.test.ts
+++ b/services/vault/src/storage/__tests__/peginStorage.test.ts
@@ -625,6 +625,52 @@ describe("UTXO reservation storage", () => {
     });
   });
 
+  describe("storage failure handling", () => {
+    // Aborting the deposit (instead of silently swallowing the storage error)
+    // prevents the cross-tab race from re-emerging: a swallowed write would
+    // let two concurrent tabs both pick the same outpoint and one would end
+    // up with an orphaned ETH vault. We translate the raw browser error to
+    // a clean, actionable message at the storage boundary so the caller's
+    // sanitizeErrorMessage path surfaces something readable.
+    it("throws a friendly error (not the raw browser error) when localStorage.setItem fails", async () => {
+      const quotaError = new DOMException(
+        "QuotaExceededError: storage is full",
+        "QuotaExceededError",
+      );
+      const setItemSpy = vi
+        .spyOn(Storage.prototype, "setItem")
+        .mockImplementationOnce(() => {
+          throw quotaError;
+        });
+
+      const err = await addUtxoReservation(ETH_ADDRESS, validReservation).catch(
+        (e: unknown) => e,
+      );
+
+      expect(err).toBeInstanceOf(Error);
+      expect(err).not.toBeInstanceOf(UtxoReservationConflictError);
+      expect((err as Error).message).toMatch(/Unable to record/i);
+      expect(vi.mocked(logger).warn).toHaveBeenCalledWith(
+        "[peginStorage] Failed to write UTXO reservation",
+        expect.objectContaining({ category: "peginStorage" }),
+      );
+
+      setItemSpy.mockRestore();
+    });
+
+    it("does not translate UtxoReservationConflictError (caller must detect by instanceof)", async () => {
+      await addUtxoReservation(ETH_ADDRESS, validReservation);
+
+      const err = await addUtxoReservation(ETH_ADDRESS, {
+        outpoints: [outpointA],
+        timestamp: Date.now(),
+        batchId: "batch-2",
+      }).catch((e: unknown) => e);
+
+      expect(err).toBeInstanceOf(UtxoReservationConflictError);
+    });
+  });
+
   describe("assertNoReservationConflict", () => {
     it("throws when another batch claims one of our outpoints", async () => {
       await addUtxoReservation(ETH_ADDRESS, validReservation);

--- a/services/vault/src/storage/__tests__/peginStorage.test.ts
+++ b/services/vault/src/storage/__tests__/peginStorage.test.ts
@@ -552,8 +552,8 @@ describe("UTXO reservation storage", () => {
   });
 
   it("silently drops legacy unsignedTxHex-only entries (schema rotation)", () => {
-    // Pre-#293 fix entries with only `unsignedTxHex` no longer validate. The
-    // 5-min TTL would have dropped them anyway; this just shortens the gap.
+    // Legacy entries with only `unsignedTxHex` no longer validate. The 5-min
+    // TTL would have dropped them anyway; this just shortens the gap.
     const legacy = [
       { unsignedTxHex: "0xdeadbeef", timestamp: Date.now(), batchId: "old" },
     ];

--- a/services/vault/src/storage/__tests__/peginStorage.test.ts
+++ b/services/vault/src/storage/__tests__/peginStorage.test.ts
@@ -14,12 +14,14 @@ import { LocalStorageStatus } from "../../models/peginStateMachine";
 import {
   addPendingPegin,
   addUtxoReservation,
+  assertNoReservationConflict,
   getPendingPegins,
   getUtxoReservations,
   type PendingPeginRequest,
   removePendingPegin,
   removeUtxoReservation,
   type UtxoReservation,
+  UtxoReservationConflictError,
 } from "../peginStorage";
 
 vi.mock("@/infrastructure", () => ({
@@ -402,8 +404,11 @@ describe("removePendingPegin", () => {
 describe("UTXO reservation storage", () => {
   const reservationKey = `${UTXO_RESERVATION_KEY_PREFIX}-${ETH_ADDRESS}`;
 
+  const outpointA = { txid: VALID_TXID_A, vout: 0 };
+  const outpointB = { txid: VALID_TXID_B, vout: 1 };
+
   const validReservation: UtxoReservation = {
-    unsignedTxHex: "0xdeadbeef",
+    outpoints: [outpointA],
     timestamp: Date.now(),
     batchId: "batch-1",
   };
@@ -413,20 +418,21 @@ describe("UTXO reservation storage", () => {
     vi.clearAllMocks();
   });
 
-  it("adds and retrieves a reservation", () => {
-    addUtxoReservation(ETH_ADDRESS, validReservation);
+  it("adds and retrieves a reservation", async () => {
+    await addUtxoReservation(ETH_ADDRESS, validReservation);
 
     const result = getUtxoReservations(ETH_ADDRESS);
 
     expect(result).toHaveLength(1);
     expect(result[0].batchId).toBe("batch-1");
-    expect(result[0].unsignedTxHex).toBe("0xdeadbeef");
+    expect(result[0].outpoints).toEqual([outpointA]);
   });
 
-  it("removes a reservation by batchId", () => {
-    addUtxoReservation(ETH_ADDRESS, validReservation);
-    addUtxoReservation(ETH_ADDRESS, {
+  it("removes a reservation by batchId", async () => {
+    await addUtxoReservation(ETH_ADDRESS, validReservation);
+    await addUtxoReservation(ETH_ADDRESS, {
       ...validReservation,
+      outpoints: [outpointB],
       batchId: "batch-2",
     });
 
@@ -437,21 +443,21 @@ describe("UTXO reservation storage", () => {
     expect(result[0].batchId).toBe("batch-2");
   });
 
-  it("replaces existing reservation with same batchId", () => {
-    addUtxoReservation(ETH_ADDRESS, validReservation);
-    addUtxoReservation(ETH_ADDRESS, {
+  it("replaces existing reservation with same batchId (narrow-after-prepare refresh)", async () => {
+    await addUtxoReservation(ETH_ADDRESS, validReservation);
+    await addUtxoReservation(ETH_ADDRESS, {
       ...validReservation,
-      unsignedTxHex: "0xcafebabe",
+      outpoints: [outpointA, outpointB],
     });
 
     const result = getUtxoReservations(ETH_ADDRESS);
     expect(result).toHaveLength(1);
-    expect(result[0].unsignedTxHex).toBe("0xcafebabe");
+    expect(result[0].outpoints).toEqual([outpointA, outpointB]);
   });
 
   it("filters out expired reservations on read", () => {
     const expired: UtxoReservation = {
-      unsignedTxHex: "0xdeadbeef",
+      outpoints: [outpointA],
       timestamp: Date.now() - UTXO_RESERVATION_TTL - 1,
       batchId: "expired-batch",
     };
@@ -460,19 +466,18 @@ describe("UTXO reservation storage", () => {
     const result = getUtxoReservations(ETH_ADDRESS);
 
     expect(result).toHaveLength(0);
-    // Expired entry should be cleaned up from storage
     const stored = localStorage.getItem(reservationKey);
     expect(stored).toBeNull();
   });
 
   it("keeps non-expired reservations when cleaning expired ones", () => {
     const expired: UtxoReservation = {
-      unsignedTxHex: "0xdeadbeef",
+      outpoints: [outpointA],
       timestamp: Date.now() - UTXO_RESERVATION_TTL - 1,
       batchId: "expired-batch",
     };
     const fresh: UtxoReservation = {
-      unsignedTxHex: "0xcafebabe",
+      outpoints: [outpointB],
       timestamp: Date.now(),
       batchId: "fresh-batch",
     };
@@ -492,9 +497,9 @@ describe("UTXO reservation storage", () => {
     expect(getUtxoReservations(ETH_ADDRESS)).toEqual([]);
   });
 
-  it("skips invalid entries from tampered storage", () => {
+  it("rejects reservations whose outpoints field is not an array", () => {
     const tampered = [
-      { unsignedTxHex: 42, timestamp: Date.now(), batchId: "bad" },
+      { outpoints: "not-an-array", timestamp: Date.now(), batchId: "bad" },
       validReservation,
     ];
     localStorage.setItem(reservationKey, JSON.stringify(tampered));
@@ -505,10 +510,148 @@ describe("UTXO reservation storage", () => {
     expect(result[0].batchId).toBe("batch-1");
   });
 
-  it("removes storage key when last reservation is removed", () => {
-    addUtxoReservation(ETH_ADDRESS, validReservation);
+  it("rejects reservations whose outpoints array is empty", () => {
+    const tampered = [
+      { outpoints: [], timestamp: Date.now(), batchId: "empty" },
+      validReservation,
+    ];
+    localStorage.setItem(reservationKey, JSON.stringify(tampered));
+
+    const result = getUtxoReservations(ETH_ADDRESS);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].batchId).toBe("batch-1");
+  });
+
+  it("rejects reservations whose outpoint has a non-hex txid", () => {
+    const tampered = [
+      {
+        outpoints: [{ txid: "NOT_HEX_!!!", vout: 0 }],
+        timestamp: Date.now(),
+        batchId: "bad",
+      },
+      validReservation,
+    ];
+    localStorage.setItem(reservationKey, JSON.stringify(tampered));
+
+    expect(getUtxoReservations(ETH_ADDRESS)).toHaveLength(1);
+  });
+
+  it("rejects reservations whose outpoint has a negative vout", () => {
+    const tampered = [
+      {
+        outpoints: [{ txid: VALID_TXID_A, vout: -1 }],
+        timestamp: Date.now(),
+        batchId: "bad",
+      },
+      validReservation,
+    ];
+    localStorage.setItem(reservationKey, JSON.stringify(tampered));
+
+    expect(getUtxoReservations(ETH_ADDRESS)).toHaveLength(1);
+  });
+
+  it("silently drops legacy unsignedTxHex-only entries (schema rotation)", () => {
+    // Pre-#293 fix entries with only `unsignedTxHex` no longer validate. The
+    // 5-min TTL would have dropped them anyway; this just shortens the gap.
+    const legacy = [
+      { unsignedTxHex: "0xdeadbeef", timestamp: Date.now(), batchId: "old" },
+    ];
+    localStorage.setItem(reservationKey, JSON.stringify(legacy));
+
+    expect(getUtxoReservations(ETH_ADDRESS)).toHaveLength(0);
+  });
+
+  it("removes storage key when last reservation is removed", async () => {
+    await addUtxoReservation(ETH_ADDRESS, validReservation);
     removeUtxoReservation(ETH_ADDRESS, "batch-1");
 
     expect(localStorage.getItem(reservationKey)).toBeNull();
+  });
+
+  describe("conflict detection", () => {
+    it("rejects an overlapping outpoint from a different batchId", async () => {
+      await addUtxoReservation(ETH_ADDRESS, validReservation);
+
+      await expect(
+        addUtxoReservation(ETH_ADDRESS, {
+          outpoints: [outpointA],
+          timestamp: Date.now(),
+          batchId: "batch-2",
+        }),
+      ).rejects.toBeInstanceOf(UtxoReservationConflictError);
+    });
+
+    it("carries the conflicting batchId and outpoint on the error", async () => {
+      await addUtxoReservation(ETH_ADDRESS, validReservation);
+
+      const err = await addUtxoReservation(ETH_ADDRESS, {
+        outpoints: [outpointA],
+        timestamp: Date.now(),
+        batchId: "batch-2",
+      }).catch((e: unknown) => e);
+
+      expect(err).toBeInstanceOf(UtxoReservationConflictError);
+      const conflict = err as UtxoReservationConflictError;
+      expect(conflict.conflictingBatchId).toBe("batch-1");
+      expect(conflict.outpoint).toEqual(outpointA);
+    });
+
+    it("treats txid comparison as case-insensitive", async () => {
+      await addUtxoReservation(ETH_ADDRESS, {
+        outpoints: [{ txid: VALID_TXID_A.toLowerCase(), vout: 0 }],
+        timestamp: Date.now(),
+        batchId: "batch-1",
+      });
+
+      await expect(
+        addUtxoReservation(ETH_ADDRESS, {
+          outpoints: [{ txid: VALID_TXID_A.toUpperCase(), vout: 0 }],
+          timestamp: Date.now(),
+          batchId: "batch-2",
+        }),
+      ).rejects.toBeInstanceOf(UtxoReservationConflictError);
+    });
+
+    it("allows non-overlapping reservations under a different batchId", async () => {
+      await addUtxoReservation(ETH_ADDRESS, validReservation);
+      await addUtxoReservation(ETH_ADDRESS, {
+        outpoints: [outpointB],
+        timestamp: Date.now(),
+        batchId: "batch-2",
+      });
+
+      expect(getUtxoReservations(ETH_ADDRESS)).toHaveLength(2);
+    });
+  });
+
+  describe("assertNoReservationConflict", () => {
+    it("throws when another batch claims one of our outpoints", async () => {
+      await addUtxoReservation(ETH_ADDRESS, validReservation);
+
+      expect(() =>
+        assertNoReservationConflict(ETH_ADDRESS, "batch-2", [outpointA]),
+      ).toThrow(UtxoReservationConflictError);
+    });
+
+    it("does not throw when only our own batch claims the outpoint", async () => {
+      await addUtxoReservation(ETH_ADDRESS, validReservation);
+
+      expect(() =>
+        assertNoReservationConflict(ETH_ADDRESS, "batch-1", [outpointA]),
+      ).not.toThrow();
+    });
+
+    it("returns silently for an empty address", () => {
+      expect(() =>
+        assertNoReservationConflict("", "batch-1", [outpointA]),
+      ).not.toThrow();
+    });
+
+    it("returns silently when no reservations exist", () => {
+      expect(() =>
+        assertNoReservationConflict(ETH_ADDRESS, "batch-1", [outpointA]),
+      ).not.toThrow();
+    });
   });
 });

--- a/services/vault/src/storage/peginStorage.ts
+++ b/services/vault/src/storage/peginStorage.ts
@@ -634,6 +634,12 @@ async function withReservationLock<T>(
  *
  * @throws {UtxoReservationConflictError} when an outpoint is already
  * claimed by another in-flight deposit.
+ * @throws {Error} with an actionable message when localStorage cannot be
+ * written (quota exceeded, blocked by private-browsing, etc.). We
+ * intentionally do not swallow these — silently degrading would let two
+ * concurrent tabs both pick the same outpoint and reintroduce the cross-
+ * tab race this function exists to prevent, for the exact users a
+ * fallback would supposedly help.
  */
 export async function addUtxoReservation(
   ethAddress: string,
@@ -641,22 +647,35 @@ export async function addUtxoReservation(
 ): Promise<void> {
   if (!ethAddress) return;
 
-  await withReservationLock(ethAddress, () => {
-    const existing = getUtxoReservations(ethAddress);
-    const conflict = findOutpointConflict(
-      existing,
-      reservation.batchId,
-      reservation.outpoints,
-    );
-    if (conflict) {
-      throw new UtxoReservationConflictError(
-        conflict.conflictingBatchId,
-        conflict.outpoint,
+  try {
+    await withReservationLock(ethAddress, () => {
+      const existing = getUtxoReservations(ethAddress);
+      const conflict = findOutpointConflict(
+        existing,
+        reservation.batchId,
+        reservation.outpoints,
       );
-    }
-    const filtered = existing.filter((r) => r.batchId !== reservation.batchId);
-    saveReservations(ethAddress, [...filtered, reservation]);
-  });
+      if (conflict) {
+        throw new UtxoReservationConflictError(
+          conflict.conflictingBatchId,
+          conflict.outpoint,
+        );
+      }
+      const filtered = existing.filter(
+        (r) => r.batchId !== reservation.batchId,
+      );
+      saveReservations(ethAddress, [...filtered, reservation]);
+    });
+  } catch (error) {
+    if (error instanceof UtxoReservationConflictError) throw error;
+    logger.warn("[peginStorage] Failed to write UTXO reservation", {
+      category: "peginStorage",
+      error: error instanceof Error ? error.message : String(error),
+    });
+    throw new Error(
+      "Unable to record the deposit reservation locally. Your browser may be blocking local storage (private browsing or quota). Try in a standard browser tab.",
+    );
+  }
 }
 
 /**

--- a/services/vault/src/storage/peginStorage.ts
+++ b/services/vault/src/storage/peginStorage.ts
@@ -447,33 +447,74 @@ export function filterPendingPegins(
 // ============================================================================
 
 /**
- * A lightweight reservation written to localStorage immediately after
- * transaction preparation, BEFORE wallet interaction or ETH registration.
- * This closes the TOCTOU race window where another tab could select the
- * same UTXOs during the 1-3 minute signing/registration process.
+ * A lightweight reservation written to localStorage BEFORE any wallet
+ * popup or Ethereum registration. Stored as outpoint pairs (`txid:vout`)
+ * since at pre-claim time no transaction has been built yet. Closes the
+ * TOCTOU race where a sibling tab could select the same funding outpoint
+ * during the 1-3 minute wallet-signing window inside `preparePegin`.
  */
 export interface UtxoReservation {
-  unsignedTxHex: string;
+  outpoints: Array<{ txid: string; vout: number }>;
   timestamp: number;
   batchId: string;
+}
+
+/**
+ * Thrown when `addUtxoReservation` detects an overlapping outpoint claim
+ * under a different `batchId`. Carries the conflicting batch and the
+ * offending outpoint so callers can surface a useful message.
+ */
+export class UtxoReservationConflictError extends Error {
+  readonly conflictingBatchId: string;
+  readonly outpoint: { txid: string; vout: number };
+
+  constructor(
+    conflictingBatchId: string,
+    outpoint: { txid: string; vout: number },
+  ) {
+    super(
+      `UTXO ${outpoint.txid}:${outpoint.vout} is already reserved by another in-flight deposit (batch ${conflictingBatchId}).`,
+    );
+    this.name = "UtxoReservationConflictError";
+    this.conflictingBatchId = conflictingBatchId;
+    this.outpoint = outpoint;
+  }
 }
 
 function getReservationStorageKey(ethAddress: string): string {
   return `${UTXO_RESERVATION_KEY_PREFIX}-${ethAddress}`;
 }
 
+function isValidOutpoint(
+  value: unknown,
+): value is { txid: string; vout: number } {
+  if (!value || typeof value !== "object") return false;
+  const o = value as Record<string, unknown>;
+  if (typeof o.txid !== "string" || !TXID_HEX_RE.test(o.txid)) return false;
+  if (typeof o.vout !== "number" || !Number.isInteger(o.vout) || o.vout < 0) {
+    return false;
+  }
+  return true;
+}
+
 function isValidReservation(entry: unknown): entry is UtxoReservation {
   if (!entry || typeof entry !== "object") return false;
   const r = entry as Record<string, unknown>;
+  if (!Array.isArray(r.outpoints) || r.outpoints.length === 0) return false;
+  for (const op of r.outpoints) {
+    if (!isValidOutpoint(op)) return false;
+  }
   return (
-    typeof r.unsignedTxHex === "string" &&
-    NON_EMPTY_HEX_RE.test(r.unsignedTxHex) &&
     typeof r.timestamp === "number" &&
     Number.isFinite(r.timestamp) &&
     r.timestamp > 0 &&
     typeof r.batchId === "string" &&
     r.batchId.length > 0
   );
+}
+
+function outpointKey(o: { txid: string; vout: number }): string {
+  return `${o.txid.toLowerCase()}:${o.vout}`;
 }
 
 /**
@@ -534,27 +575,111 @@ function saveReservations(
   // the native StorageEvent fired by localStorage writes.
 }
 
+function findOutpointConflict(
+  reservations: UtxoReservation[],
+  batchId: string,
+  outpoints: ReadonlyArray<{ txid: string; vout: number }>,
+):
+  | { conflictingBatchId: string; outpoint: { txid: string; vout: number } }
+  | undefined {
+  const claimed = new Map<string, string>(); // outpoint key -> batchId
+  for (const r of reservations) {
+    if (r.batchId === batchId) continue;
+    for (const op of r.outpoints) {
+      claimed.set(outpointKey(op), r.batchId);
+    }
+  }
+  for (const op of outpoints) {
+    const owner = claimed.get(outpointKey(op));
+    if (owner !== undefined) {
+      return {
+        conflictingBatchId: owner,
+        outpoint: { txid: op.txid, vout: op.vout },
+      };
+    }
+  }
+  return undefined;
+}
+
+async function withReservationLock<T>(
+  ethAddress: string,
+  fn: () => T,
+): Promise<T> {
+  // Web Locks API serializes the read-modify-write cross-tab. When the API
+  // is unavailable (very old browsers, jsdom test runners) we fall back to
+  // inline execution — still atomic within a single JS task; cross-tab
+  // races are then caught by the final-pass `assertNoReservationConflict`.
+  const locks = (
+    globalThis as {
+      navigator?: {
+        locks?: {
+          request?: (name: string, cb: () => unknown) => Promise<unknown>;
+        };
+      };
+    }
+  ).navigator?.locks;
+  if (locks?.request) {
+    const lockName = `pegin-reservation-${ethAddress}`;
+    return locks.request(lockName, () => fn()) as Promise<T>;
+  }
+  return fn();
+}
+
 /**
- * Reserve UTXOs by writing the prepared transaction hex to localStorage.
- * Called immediately after `preparePeginTransaction()`, before wallet
- * interaction or ETH registration.
+ * Reserve UTXOs by writing their outpoints to localStorage BEFORE wallet
+ * signing or Ethereum registration. Rejects any reservation whose
+ * outpoints overlap an existing entry under a different `batchId`.
+ * Same-`batchId` writes always overwrite in place (used by the
+ * pre-claim → narrow-after-preparePegin refresh).
+ *
+ * @throws {UtxoReservationConflictError} when an outpoint is already
+ * claimed by another in-flight deposit.
  */
-export function addUtxoReservation(
+export async function addUtxoReservation(
   ethAddress: string,
   reservation: UtxoReservation,
-): void {
+): Promise<void> {
   if (!ethAddress) return;
 
-  try {
+  await withReservationLock(ethAddress, () => {
     const existing = getUtxoReservations(ethAddress);
-    // Replace any existing reservation with the same batchId
+    const conflict = findOutpointConflict(
+      existing,
+      reservation.batchId,
+      reservation.outpoints,
+    );
+    if (conflict) {
+      throw new UtxoReservationConflictError(
+        conflict.conflictingBatchId,
+        conflict.outpoint,
+      );
+    }
     const filtered = existing.filter((r) => r.batchId !== reservation.batchId);
     saveReservations(ethAddress, [...filtered, reservation]);
-  } catch (error) {
-    logger.warn("[peginStorage] Failed to write UTXO reservation", {
-      category: "peginStorage",
-      error: error instanceof Error ? error.message : String(error),
-    });
+  });
+}
+
+/**
+ * Final-pass conflict check, invoked right before Ethereum registration.
+ * Defense-in-depth: catches the residual race where two tabs without
+ * Web Locks both wrote a reservation in the same microtask.
+ *
+ * @throws {UtxoReservationConflictError} when an outpoint is already
+ * claimed by another batch.
+ */
+export function assertNoReservationConflict(
+  ethAddress: string,
+  batchId: string,
+  outpoints: ReadonlyArray<{ txid: string; vout: number }>,
+): void {
+  if (!ethAddress) return;
+  const existing = getUtxoReservations(ethAddress);
+  const conflict = findOutpointConflict(existing, batchId, outpoints);
+  if (conflict) {
+    throw new UtxoReservationConflictError(
+      conflict.conflictingBatchId,
+      conflict.outpoint,
+    );
   }
 }
 


### PR DESCRIPTION
## What's the bug (in plain words)

Imagine you have a wallet with one Bitcoin coin worth 1 BTC. You open two browser tabs and start a deposit on each. Today's code lets **both** tabs pick the same coin, both ask you to sign in your wallet, and both register a vault on Ethereum. Only one Bitcoin transaction can actually broadcast (the second one is invalid — the coin is already spent), so the second tab ends up with a vault on Ethereum that can never be funded. That vault is stuck until the protocol timeout.

The race window is the 1–3 minutes during which the user is clicking "approve" on the wallet popups inside `preparePeginTransaction`. Today, the "this coin is taken" note is only written to `localStorage` **after** that popup completes — so during the popup window, a sibling tab sees no note and grabs the same coin.

## What this PR changes

Three layers of protection, applied in order:

1. **Pre-claim before any wallet popup.** Right after we decide which UTXOs we'd like to spend, we immediately write a reservation to `localStorage`. This happens **before** `preparePeginTransaction`, so any sibling tab that opens during the wallet popup window sees the reservation and excludes those UTXOs from its own selection.

2. **Conflict-aware writes.** The new `addUtxoReservation` rejects writes whose outpoints overlap an existing reservation under a different batch. If a second tab somehow makes it past selection and tries to claim the same coin, the write throws and the second deposit is aborted **before** any wallet popup happens.

3. **Final re-check before Ethereum.** Right before we send the Ethereum registration transaction, we re-read the reservation table and abort if another batch has claimed any of our coins in the meantime. This is the safety net for the rare environment where `navigator.locks` is unavailable and two tabs raced past the pre-claim at exactly the same instant.

For cross-tab atomicity, the read-modify-write inside `addUtxoReservation` runs inside `navigator.locks.request(...)` when the browser supports it (Chrome, Edge, Firefox, Safari 15.4+). In environments without Web Locks (very old browsers, jsdom test runners), the write falls back to a sequential read-then-write — still atomic within a single JS task, and the final re-check (layer 3) catches the residual cross-tab race.

## Files changed

| File | What changed |
|---|---|
| `services/vault/src/storage/peginStorage.ts` | `UtxoReservation` now stores `outpoints[]` instead of `unsignedTxHex` (we don't have a signed tx yet at pre-claim time). `addUtxoReservation` is now async, throws `UtxoReservationConflictError` on overlap, serializes the read-modify-write with `navigator.locks` when available. New `assertNoReservationConflict` helper for the final re-check. |
| `packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts` | `UtxoReservationLike` now carries `outpoints[]`. `collectReservedUtxoRefs` reads outpoints directly instead of parsing a transaction hex. |
| `services/vault/src/hooks/deposit/useDepositFlow.ts` | Pre-claim moved **before** `preparePeginTransaction`. Narrow refresh added **after** `preparePeginTransaction` (same batchId, narrowed to the actually-selected inputs). Final-pass `assertNoReservationConflict` added right before `registerPeginBatchAndWait`. |
| Test files (3) | New tests pin the call ordering, the conflict-abort path, and the final-pass abort path. Existing tests updated to the new outpoint-based schema. |

## Why this approach (and not alternatives)

- **Why pre-claim by outpoints, not by tx hex?** At pre-claim time, the transaction hasn't been built yet — the wallet popups inside `preparePeginTransaction` are what produce it. Outpoints (`txid:vout` pairs) are what we actually need to identify the contested resource. They're also what we always had to extract from the hex anyway (the old `collectReservedUtxoRefs` parsed the hex to get them).
- **Why replace `unsignedTxHex` rather than keep both fields?** The hex was an implementation detail of the old "where do we get outpoints" parsing path. Keeping both forever would be a backward-compat shim for an internal data shape that has no external consumers. Existing in-flight `localStorage` entries written by the old code fail the new validator and drop silently — the 5-minute TTL would have dropped them anyway, this just shortens the gap.
- **Why three layers instead of one?** The pre-claim alone closes the audit-reported race in 99%+ of cases. Conflict-aware writes close it in the multi-tab simultaneous-write case in modern browsers (via Web Locks). The final re-check is the safety net for environments without Web Locks. The total cost is ~10 extra lines of code and one extra test, and the failure mode we're protecting against (orphaned ETH vault permanently bound to unspendable outpoints) is irreversible.
- **Why not split `PeginManager.preparePegin` into a deterministic pre-sign phase + commit phase?** That was the auditor's suggested deeper restructure but it's a much bigger change touching frozen on-chain-binding code (CLAUDE.md "CRITICAL PATHS"). The auditor's recommendation explicitly listed the storage-level pre-claim as the acceptable minimal fix.

## Risk / residual gaps

- **Browsers without `navigator.locks`** (very old engines, jsdom): cross-tab atomicity on the read-modify-write degrades to sequential conflict detection. The final-pass `assertNoReservationConflict` is the safety net. Worst case: the final re-check catches it, the deposit aborts before ETH, no funds at risk.
- **Pre-existing entries in users' `localStorage`** (written by the old `addUtxoReservation` with `unsignedTxHex`): fail the new validator and are silently dropped. The 5-minute TTL would have done the same. No fund impact.
- **typedoc-generated `packages/babylon-ts-sdk/docs/api/utils.md`** still references the old `unsignedTxHex` field. Will regenerate on the next release docs build (`pnpm --filter @babylonlabs-io/ts-sdk docs:generate`). Not in scope for this PR. cc @jrwbabylonlab it generates 5+ files, we need to have a separate PR for this
- **Pre-claim reserves the candidate set, not just the inputs actually used.** `preparePegin` decides the final subset; we narrow the claim afterward. In the brief window before narrowing, the claim is mildly conservative — a sibling tab is blocked from coins the first tab won't end up spending. Acceptable trade-off vs. the bug being fixed.
- **Cross-browser / cleared-storage / second-device** UTXO reuse is out of scope here — that's covered by the already-landed [#275](https://github.com/babylonlabs-io/baby-auditor-findings/issues/275) (`fetchVaultsByDepositorStrict`).

Closes https://github.com/babylonlabs-io/baby-auditor-findings/issues/293