### PR TITLE
fix(ci): serialize package-release workflow to prevent concurrent push race

### DIFF
--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -19,6 +19,10 @@ on:
         default: 'rc'
         type: string
 
+concurrency:
+  group: package-release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build_and_release:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## What's broken (in plain words)

Every time two PRs merge into `main` within a few minutes of each other, one of their release builds silently fails. The build itself passes (lint, test, build, version-bump, tag, GitHub Release are all created locally) — the failure happens at the very last step, where the workflow tries to push the new tag back to `main`. The push is rejected because _the other concurrent release run_ has already moved the remote ref. The release for that PR is then lost: no tag is pushed, no npm package is published, no GitHub release is created.

The failure is invisible to the merging author — the only signal is a red ❌ next to a workflow they don't typically read.

## Concrete incident

Run [25846633750](https://github.com/babylonlabs-io/babylon-toolkit/actions/runs/25846633750) (triggered by merging PR #1656, `fix(vault): reserve UTXOs before wallet signing`) failed with:

```
git push --follow-tags --no-verify --atomic
! [rejected]          main -> main (fetch first)
error: failed to push some refs to 'https://github.com/babylonlabs-io/babylon-toolkit'
hint: Updates were rejected because the remote contains work that you do not
hint: have locally.
```

Run [25846641428](https://github.com/babylonlabs-io/babylon-toolkit/actions/runs/25846641428) (triggered 13 seconds later by PR #1655) won the race. As a result, PR #1656's release was rolled into the next run's GitHub Release notes, and its tag/npm publish was effectively skipped at the time of merge.

This is **systemic, not a one-off.** Scanning the last day of `package-release.yml` runs:

| failed ❌ (triggered)                                                                                  | winner ✅ (triggered)                                                                                  | gap  |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------ | ---- |
| [25831057486](https://github.com/babylonlabs-io/babylon-toolkit/actions/runs/25831057486) (22:52:59)   | [25831074664](https://github.com/babylonlabs-io/babylon-toolkit/actions/runs/25831074664) (22:53:25)   | 26 s |
| [25831067339](https://github.com/babylonlabs-io/babylon-toolkit/actions/runs/25831067339) (22:53:14)   | [25831074664](https://github.com/babylonlabs-io/babylon-toolkit/actions/runs/25831074664) (22:53:25)   | 11 s |
| [25831591099](https://github.com/babylonlabs-io/babylon-toolkit/actions/runs/25831591099) (23:07:17)   | [25831604149](https://github.com/babylonlabs-io/babylon-toolkit/actions/runs/25831604149) (23:07:38)   | 21 s |
| [25846633750](https://github.com/babylonlabs-io/babylon-toolkit/actions/runs/25846633750) (06:58:41)   | [25846641428](https://github.com/babylonlabs-io/babylon-toolkit/actions/runs/25846641428) (06:58:54)   | 13 s |

Every failed release in that window has a successful sibling that ran in parallel and finished its push first. This will keep happening as long as merge cadence stays at "more than one merge per ~5 min".

## What this PR changes

One change, three lines added to `.github/workflows/package-release.yml`:

```yaml
concurrency:
  group: package-release-${{ github.ref }}
  cancel-in-progress: false
```

## Why this is enough

GitHub Actions' `concurrency` block queues runs whose group key matches. With `cancel-in-progress: false`, a second push-to-`main` doesn't cancel the in-progress release — it waits for it to finish, then starts fresh. By the time the queued run reaches `actions/checkout`, the remote `main` already includes the previous run's tag push, so its local `main` matches the remote and `git push --follow-tags --atomic` succeeds (the branch update is a no-op; the new tag is the only ref actually being added).

Keying on `${{ github.ref }}` means we serialize releases for the same branch only — a `workflow_dispatch` against a branch other than `main` (currently not a thing, but possible in future) wouldn't be needlessly blocked by an unrelated main release.

## Why not retry-with-rebase in `tools/release/index.ts`

The alternative would be: catch the rejection inside `gitPush()`, `git fetch`, fast-forward local `main`, re-anchor the tag, retry.

Rejected because:

- The new annotated tag is created by `releaseChangelog` at the _old_ `main` HEAD (the commit that triggered the workflow). Moving the tag to a different SHA after fast-forwarding would make the changelog/release notes point at a different commit from the one being released.
- Changes the highest-risk, lowest-visibility part of the release pipeline. The concurrency-block fix is declarative and changes zero code on the happy path.
- Doesn't address the underlying problem — two jobs would still both run the full ~5min build + test + publish pipeline in parallel, with the second-place finisher's work wasted.

## Cost

Release jobs take ~5–6 min. On bursty merge days, the second release in a burst will sit in queue for up to that long before starting. Releases aren't on the critical path of any user-facing operation; the alternative is silently lost releases that someone has to chase down (or, worse, that no one notices until a downstream consumer complains a version isn't on npm).

## Risk / residual gaps

- **Manual pushes to `main` from outside the workflow.** `main` is branch-protected; this isn't a real path. Concurrency doesn't help here, but doesn't make anything worse either.
- **Release script idempotency on retry.** Orthogonal: if `git push` succeeds but a subsequent step (e.g. `releasePublish` / npm) fails, a re-run can't cleanly resume because the tag and GitHub release already exist. Out of scope for this PR — call out for a follow-up.
- **Node.js 20 setup-node deprecation warning** on every run is unrelated and benign until June 2026. Not addressing here.

No source code changes. No changes to the release script (`tools/release/index.ts`). No package publishes. No version bumps.
