### PR TITLE
fix(vault): guard reorderVaults against indexer-tampered amounts

### DIFF
--- a/services/vault/src/applications/aave/hooks/__tests__/useReorderVaults.test.tsx
+++ b/services/vault/src/applications/aave/hooks/__tests__/useReorderVaults.test.tsx
@@ -1,0 +1,195 @@
+/**
+ * Tests for useReorderVaults — verifies the on-chain integrity guards run
+ * before the wallet prompt fires.
+ */
+
+import { act, renderHook } from "@testing-library/react";
+import type { Hex } from "viem";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/config/env", () => ({
+  ENV: {
+    BTC_VAULT_REGISTRY: "0x1234567890123456789012345678901234567890",
+    AAVE_ADAPTER: "0xaaaa000000000000000000000000000000000ada",
+    GRAPHQL_ENDPOINT: "https://test.example.com/graphql",
+  },
+}));
+
+vi.mock("@/config/network", () => ({
+  getETHChain: vi.fn(() => ({ id: 11155111, name: "Sepolia" })),
+  getNetworkConfigETH: vi.fn(() => ({ chainId: 11155111, name: "sepolia" })),
+  getNetworkConfigBTC: vi.fn(() => ({
+    network: "signet",
+    mempoolApiUrl: "https://mempool.space/signet/api",
+  })),
+}));
+
+vi.mock("@/infrastructure", () => ({
+  logger: { error: vi.fn() },
+}));
+
+const mockHandleError = vi.fn();
+vi.mock("@/context/error", () => ({
+  useError: () => ({ handleError: mockHandleError }),
+}));
+
+const mockUseAccount = vi.fn();
+const mockUseWalletClient = vi.fn();
+vi.mock("wagmi", () => ({
+  useAccount: () => mockUseAccount(),
+  useWalletClient: () => mockUseWalletClient(),
+}));
+
+const mockGetAaveAdapterAddress = vi.fn(
+  () => "0xaaaa000000000000000000000000000000000ada",
+);
+vi.mock("../../config", () => ({
+  getAaveAdapterAddress: () => mockGetAaveAdapterAddress(),
+}));
+
+const mockAssertMembership = vi.fn();
+const mockAssertSuggestedOrder = vi.fn();
+const mockReorderVaultOrder = vi.fn();
+vi.mock("../../services", () => ({
+  assertReorderMembership: (...args: unknown[]) =>
+    mockAssertMembership(...args),
+  assertSuggestedOrderMatchesOnChain: (...args: unknown[]) =>
+    mockAssertSuggestedOrder(...args),
+  reorderVaultOrder: (...args: unknown[]) => mockReorderVaultOrder(...args),
+}));
+
+import type { ReorderVerificationContext } from "../../services";
+import { useReorderVaults } from "../useReorderVaults";
+
+const USER = "0x000000000000000000000000000000000000beef" as const;
+const VAULT_A =
+  "0xaaaa000000000000000000000000000000000000000000000000000000000001" as Hex;
+const VAULT_B =
+  "0xbbbb000000000000000000000000000000000000000000000000000000000002" as Hex;
+
+const CTX: ReorderVerificationContext = {
+  CF: 0.7,
+  THF: 1.1,
+  maxLB: 1.05,
+  btcPrice: 60_000,
+  totalDebtUsd: 10_000,
+};
+
+function setupConnectedWallet() {
+  mockUseAccount.mockReturnValue({ address: USER });
+  mockUseWalletClient.mockReturnValue({
+    data: { account: { address: USER }, chain: { id: 11155111 } },
+  });
+}
+
+describe("useReorderVaults — on-chain integrity guards", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupConnectedWallet();
+    // Guard A now returns the on-chain ordering so Guard B can feed it
+    // into calculate(...). Default mock returns the same IDs the test
+    // submits — individual tests can override.
+    mockAssertMembership.mockResolvedValue([VAULT_A, VAULT_B]);
+    mockAssertSuggestedOrder.mockResolvedValue(undefined);
+    mockReorderVaultOrder.mockResolvedValue({
+      transactionHash: "0xtx",
+    });
+  });
+
+  it("calls assertReorderMembership with the env-pinned adapter address before broadcasting", async () => {
+    const { result } = renderHook(() => useReorderVaults());
+
+    await act(async () => {
+      await result.current.executeReorder([VAULT_A, VAULT_B]);
+    });
+
+    expect(mockAssertMembership).toHaveBeenCalledTimes(1);
+    expect(mockAssertMembership.mock.calls[0][0]).toBe(
+      "0xaaaa000000000000000000000000000000000ada",
+    );
+    expect(mockAssertMembership.mock.calls[0][1]).toBe(USER);
+    expect(mockAssertMembership.mock.calls[0][2]).toEqual([VAULT_A, VAULT_B]);
+    expect(mockReorderVaultOrder).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocks the reorder tx and surfaces the error when membership fails", async () => {
+    mockAssertMembership.mockRejectedValue(new Error("multiset mismatch"));
+
+    const { result } = renderHook(() => useReorderVaults());
+
+    let resolved: boolean | undefined;
+    await act(async () => {
+      resolved = await result.current.executeReorder([VAULT_A, VAULT_B]);
+    });
+
+    expect(resolved).toBe(false);
+    expect(mockReorderVaultOrder).not.toHaveBeenCalled();
+    expect(mockHandleError).toHaveBeenCalled();
+  });
+
+  it("runs the optimal-order recompute only when suggestedOrderContext is provided", async () => {
+    const { result } = renderHook(() => useReorderVaults());
+
+    await act(async () => {
+      await result.current.executeReorder([VAULT_A, VAULT_B]);
+    });
+
+    expect(mockAssertSuggestedOrder).not.toHaveBeenCalled();
+    expect(mockReorderVaultOrder).toHaveBeenCalledTimes(1);
+  });
+
+  it("forwards the on-chain ordering and env-pinned adapter into the recompute when context is provided", async () => {
+    // Guard A returns the current on-chain order. Submitted order is
+    // [B, A] (a permutation). Guard B receives both.
+    mockAssertMembership.mockResolvedValue([VAULT_A, VAULT_B]);
+
+    const { result } = renderHook(() => useReorderVaults());
+
+    await act(async () => {
+      await result.current.executeReorder([VAULT_B, VAULT_A], {
+        suggestedOrderContext: CTX,
+      });
+    });
+
+    expect(mockAssertSuggestedOrder).toHaveBeenCalledWith(
+      [VAULT_B, VAULT_A],
+      [VAULT_A, VAULT_B],
+      "0xaaaa000000000000000000000000000000000ada",
+      CTX,
+    );
+    expect(mockReorderVaultOrder).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocks the reorder tx when the optimal-order recompute rejects", async () => {
+    mockAssertSuggestedOrder.mockRejectedValue(new Error("order mismatch"));
+
+    const { result } = renderHook(() => useReorderVaults());
+
+    let resolved: boolean | undefined;
+    await act(async () => {
+      resolved = await result.current.executeReorder([VAULT_A, VAULT_B], {
+        suggestedOrderContext: CTX,
+      });
+    });
+
+    expect(resolved).toBe(false);
+    expect(mockReorderVaultOrder).not.toHaveBeenCalled();
+    expect(mockHandleError).toHaveBeenCalled();
+  });
+
+  it("rejects when the wallet is not connected (before any on-chain read)", async () => {
+    mockUseAccount.mockReturnValue({ address: undefined });
+    mockUseWalletClient.mockReturnValue({ data: undefined });
+
+    const { result } = renderHook(() => useReorderVaults());
+
+    let resolved: boolean | undefined;
+    await act(async () => {
+      resolved = await result.current.executeReorder([VAULT_A]);
+    });
+
+    expect(resolved).toBe(false);
+    expect(mockAssertMembership).not.toHaveBeenCalled();
+    expect(mockReorderVaultOrder).not.toHaveBeenCalled();
+  });
+});

--- a/services/vault/src/applications/aave/hooks/usePositionNotifications.ts
+++ b/services/vault/src/applications/aave/hooks/usePositionNotifications.ts
@@ -8,6 +8,7 @@ import {
   type CalculatorResult,
   type Vault,
 } from "../positionNotifications";
+import type { ReorderVerificationContext } from "../services";
 
 import { useVaultSplitParams } from "./useVaultSplitParams";
 
@@ -23,6 +24,12 @@ export interface UsePositionNotificationsResult {
   result: CalculatorResult | null;
   status: PositionNotificationsStatus;
   isLoading: boolean;
+  /**
+   * Trusted calculator inputs to pass into the reorder signing guard so the
+   * optimizer can be re-run against on-chain amounts before the wallet
+   * prompt fires. Non-null only when `status === "ready"`.
+   */
+  reorderVerificationContext: ReorderVerificationContext | null;
 }
 
 export function usePositionNotifications(
@@ -43,18 +50,41 @@ export function usePositionNotifications(
 
   const isLoading = paramsLoading || dashboardLoading;
 
-  const { result, status } = useMemo((): {
+  const { result, status, reorderVerificationContext } = useMemo((): {
     result: CalculatorResult | null;
     status: PositionNotificationsStatus;
+    reorderVerificationContext: ReorderVerificationContext | null;
   } => {
-    if (!splitParams || isLoading) return { result: null, status: "loading" };
-    if (!connectedAddress) return { result: null, status: "no-wallet" };
+    if (!splitParams || isLoading)
+      return {
+        result: null,
+        status: "loading",
+        reorderVerificationContext: null,
+      };
+    if (!connectedAddress)
+      return {
+        result: null,
+        status: "no-wallet",
+        reorderVerificationContext: null,
+      };
     if (btcMetadata?.isStale || btcMetadata?.fetchFailed)
-      return { result: null, status: "stale-price" };
+      return {
+        result: null,
+        status: "stale-price",
+        reorderVerificationContext: null,
+      };
     if (!btcMetadata || btcPrice <= 0)
-      return { result: null, status: "no-price" };
+      return {
+        result: null,
+        status: "no-price",
+        reorderVerificationContext: null,
+      };
     if (collateralVaults.length === 0)
-      return { result: null, status: "no-vaults" };
+      return {
+        result: null,
+        status: "no-vaults",
+        reorderVerificationContext: null,
+      };
 
     const vaults: Vault[] = collateralVaults.map((entry) => ({
       id: entry.vaultId,
@@ -72,6 +102,13 @@ export function usePositionNotifications(
         maxLB: splitParams.LB,
       }),
       status: "ready",
+      reorderVerificationContext: {
+        CF: splitParams.CF,
+        THF: splitParams.THF,
+        maxLB: splitParams.LB,
+        btcPrice,
+        totalDebtUsd: debtValueUsd,
+      },
     };
   }, [
     splitParams,
@@ -83,5 +120,5 @@ export function usePositionNotifications(
     debtValueUsd,
   ]);
 
-  return { result, status, isLoading };
+  return { result, status, isLoading, reorderVerificationContext };
 }

--- a/services/vault/src/applications/aave/hooks/useReorderVaults.ts
+++ b/services/vault/src/applications/aave/hooks/useReorderVaults.ts
@@ -18,11 +18,30 @@ import {
   mapViemErrorToContractError,
 } from "@/utils/errors";
 
-import { reorderVaultOrder } from "../services";
+import { getAaveAdapterAddress } from "../config";
+import {
+  assertReorderMembership,
+  assertSuggestedOrderMatchesOnChain,
+  reorderVaultOrder,
+  type ReorderVerificationContext,
+} from "../services";
+
+export interface ExecuteReorderOptions {
+  /**
+   * Trusted calculator inputs from the auto-suggestion CTA. When provided,
+   * the hook re-runs the optimizer against on-chain amounts and refuses to
+   * sign if the result diverges from the submitted permutation. Manual
+   * drag-and-drop reorders omit this so users can pick non-optimal orders.
+   */
+  suggestedOrderContext?: ReorderVerificationContext;
+}
 
 export interface UseReorderVaultsResult {
   /** Execute the reorder transaction */
-  executeReorder: (permutedVaultIds: Hex[]) => Promise<boolean>;
+  executeReorder: (
+    permutedVaultIds: Hex[],
+    options?: ExecuteReorderOptions,
+  ) => Promise<boolean>;
   /** Whether transaction is currently processing */
   isProcessing: boolean;
 }
@@ -32,7 +51,9 @@ export interface UseReorderVaultsResult {
  *
  * Handles:
  * 1. Wallet validation
- * 2. Reorder transaction execution
+ * 2. On-chain integrity guards (membership; optimal-order recompute when
+ *    invoked from the auto-suggestion CTA)
+ * 3. Reorder transaction execution
  *
  * Cache invalidation is deferred to the success modal close handler
  * to give the indexer time to process the block.
@@ -44,7 +65,7 @@ export function useReorderVaults(): UseReorderVaultsResult {
   const { handleError } = useError();
 
   const executeReorder = useCallback(
-    async (permutedVaultIds: Hex[]) => {
+    async (permutedVaultIds: Hex[], options?: ExecuteReorderOptions) => {
       setIsProcessing(true);
       try {
         if (!walletClient) {
@@ -58,6 +79,23 @@ export function useReorderVaults(): UseReorderVaultsResult {
           throw new WalletError(
             "Wallet address not available",
             ErrorCode.WALLET_NOT_CONNECTED,
+          );
+        }
+
+        const adapterAddress = getAaveAdapterAddress();
+
+        const currentVaultIds = await assertReorderMembership(
+          adapterAddress,
+          address,
+          permutedVaultIds,
+        );
+
+        if (options?.suggestedOrderContext) {
+          await assertSuggestedOrderMatchesOnChain(
+            permutedVaultIds,
+            currentVaultIds,
+            adapterAddress,
+            options.suggestedOrderContext,
           );
         }
 

--- a/services/vault/src/applications/aave/services/__tests__/assertReorderMatchesOnChain.test.ts
+++ b/services/vault/src/applications/aave/services/__tests__/assertReorderMatchesOnChain.test.ts
@@ -1,0 +1,379 @@
+/**
+ * Tests for the reorder integrity guards.
+ *
+ * Guard A — `assertReorderMembership`: blocks submissions where the
+ * indexer-supplied vault set diverges from the user's on-chain position.
+ * Returns the current on-chain ordering so Guard B can feed it into the
+ * calculator.
+ *
+ * Guard B — `assertSuggestedOrderMatchesOnChain`: re-runs the full
+ * notification calculator with on-chain amounts and blocks submissions
+ * whose ordering disagrees (the same-set tamper attack), whose vaults
+ * are inactive or bound to a different application, or whose trusted
+ * calculator would not have suggested a reorder at all (rebalance
+ * suppression).
+ */
+
+import { getPosition } from "@babylonlabs-io/ts-sdk/tbv/integrations/aave";
+import type { Address, Hex } from "viem";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getBtcVaultBasicInfoFromChain } from "@/clients/eth-contract/btc-vault-registry/query";
+
+import {
+  ReorderMembershipMismatchError,
+  SuggestedReorderMismatchError,
+  assertReorderMembership,
+  assertSuggestedOrderMatchesOnChain,
+  type ReorderVerificationContext,
+} from "../assertReorderMatchesOnChain";
+
+vi.mock("@/clients/eth-contract/client", () => ({
+  ethClient: {
+    getPublicClient: vi.fn(() => ({ __mockPublicClient: true })),
+  },
+}));
+
+vi.mock("@/clients/eth-contract/btc-vault-registry/query", () => ({
+  getBtcVaultBasicInfoFromChain: vi.fn(),
+}));
+
+vi.mock("@babylonlabs-io/ts-sdk/tbv/integrations/aave", async () => {
+  const actual = await vi.importActual<
+    typeof import("@babylonlabs-io/ts-sdk/tbv/integrations/aave")
+  >("@babylonlabs-io/ts-sdk/tbv/integrations/aave");
+  return {
+    ...actual,
+    getPosition: vi.fn(),
+  };
+});
+
+const mockGetPosition = vi.mocked(getPosition);
+const mockGetBtcVaultBasicInfo = vi.mocked(getBtcVaultBasicInfoFromChain);
+
+const ADAPTER = "0x000000000000000000000000000000000000ada9" as Address;
+const OTHER_APP = "0x000000000000000000000000000000000000a1ce" as Address;
+const USER = "0x000000000000000000000000000000000000beef" as Address;
+const VAULT_A =
+  "0xaaaa000000000000000000000000000000000000000000000000000000000001" as Hex;
+const VAULT_B =
+  "0xbbbb000000000000000000000000000000000000000000000000000000000002" as Hex;
+const VAULT_C =
+  "0xcccc000000000000000000000000000000000000000000000000000000000003" as Hex;
+
+/**
+ * High-debt context where the optimizer prefers concentrating seizure on
+ * the larger vault first ([A=0.6, B=0.1] → suggested [A, B]). Current
+ * order in tests is [B, A] so `calculate()` will surface a non-null
+ * `suggestedVaultOrder = [A, B]`.
+ */
+const CONTEXT_BASE: ReorderVerificationContext = {
+  CF: 0.7,
+  THF: 1.1,
+  maxLB: 1.05,
+  btcPrice: 60_000,
+  totalDebtUsd: 10_000,
+};
+
+const STATUS_ACTIVE = 2;
+const STATUS_REDEEMED = 3;
+
+function activeInfo(amount: bigint, app: Address = ADAPTER) {
+  return {
+    amount,
+    status: STATUS_ACTIVE,
+    applicationEntryPoint: app,
+  };
+}
+
+function basicInfoMap(
+  entries: Array<[Hex, ReturnType<typeof activeInfo>]>,
+): Map<Hex, ReturnType<typeof activeInfo>> {
+  return new Map(entries.map(([id, info]) => [id.toLowerCase() as Hex, info]));
+}
+
+describe("assertReorderMembership", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("resolves and returns the on-chain ordering when the submitted multiset matches (case-insensitive)", async () => {
+    mockGetPosition.mockResolvedValue({
+      proxyContract: "0x1" as Address,
+      vaultIds: [VAULT_A.toLowerCase() as Hex, VAULT_B.toUpperCase() as Hex],
+    });
+
+    const onChain = await assertReorderMembership(ADAPTER, USER, [
+      VAULT_B,
+      VAULT_A,
+    ]);
+
+    expect(onChain).toEqual([VAULT_A.toLowerCase(), VAULT_B.toUpperCase()]);
+  });
+
+  it("calls getPosition against the env-pinned adapter address", async () => {
+    mockGetPosition.mockResolvedValue({
+      proxyContract: "0x1" as Address,
+      vaultIds: [VAULT_A],
+    });
+
+    await assertReorderMembership(ADAPTER, USER, [VAULT_A]);
+
+    expect(mockGetPosition).toHaveBeenCalledTimes(1);
+    expect(mockGetPosition.mock.calls[0][1]).toBe(ADAPTER);
+    expect(mockGetPosition.mock.calls[0][2]).toBe(USER);
+  });
+
+  it("throws ReorderMembershipMismatchError when a phantom vault is submitted", async () => {
+    mockGetPosition.mockResolvedValue({
+      proxyContract: "0x1" as Address,
+      vaultIds: [VAULT_A, VAULT_B],
+    });
+
+    await expect(
+      assertReorderMembership(ADAPTER, USER, [VAULT_A, VAULT_C]),
+    ).rejects.toBeInstanceOf(ReorderMembershipMismatchError);
+  });
+
+  it("throws when the submitted set is shorter than on-chain", async () => {
+    mockGetPosition.mockResolvedValue({
+      proxyContract: "0x1" as Address,
+      vaultIds: [VAULT_A, VAULT_B],
+    });
+
+    await expect(
+      assertReorderMembership(ADAPTER, USER, [VAULT_A]),
+    ).rejects.toBeInstanceOf(ReorderMembershipMismatchError);
+  });
+
+  it("throws when a vault is duplicated and another is dropped", async () => {
+    mockGetPosition.mockResolvedValue({
+      proxyContract: "0x1" as Address,
+      vaultIds: [VAULT_A, VAULT_B],
+    });
+
+    await expect(
+      assertReorderMembership(ADAPTER, USER, [VAULT_A, VAULT_A]),
+    ).rejects.toBeInstanceOf(ReorderMembershipMismatchError);
+  });
+
+  it("throws when the user has no on-chain position", async () => {
+    mockGetPosition.mockResolvedValue(null);
+
+    await expect(
+      assertReorderMembership(ADAPTER, USER, [VAULT_A]),
+    ).rejects.toBeInstanceOf(ReorderMembershipMismatchError);
+  });
+
+  it("propagates RPC errors from getPosition", async () => {
+    mockGetPosition.mockRejectedValue(new Error("rpc unavailable"));
+
+    await expect(
+      assertReorderMembership(ADAPTER, USER, [VAULT_A]),
+    ).rejects.toThrow("rpc unavailable");
+  });
+});
+
+describe("assertSuggestedOrderMatchesOnChain", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("resolves when the submission equals the calculator's suggested order under on-chain amounts", async () => {
+    // Current order [B, A] is suboptimal (smaller-first cliff). Calculator
+    // suggests [A, B] (larger-first). Submission matches.
+    mockGetBtcVaultBasicInfo.mockResolvedValue(
+      basicInfoMap([
+        [VAULT_A, activeInfo(60_000_000n)],
+        [VAULT_B, activeInfo(10_000_000n)],
+      ]),
+    );
+
+    await expect(
+      assertSuggestedOrderMatchesOnChain(
+        [VAULT_A, VAULT_B],
+        [VAULT_B, VAULT_A],
+        ADAPTER,
+        CONTEXT_BASE,
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it("rejects an attacker-chosen permutation under on-chain amounts (PoC)", async () => {
+    // Indexer steered the user to submit [B, A] (the current order, but
+    // labeled as "optimal" by tampered amounts). Calculator's true
+    // suggestion under on-chain amounts is [A, B] → mismatch.
+    mockGetBtcVaultBasicInfo.mockResolvedValue(
+      basicInfoMap([
+        [VAULT_A, activeInfo(60_000_000n)],
+        [VAULT_B, activeInfo(10_000_000n)],
+      ]),
+    );
+
+    await expect(
+      assertSuggestedOrderMatchesOnChain(
+        [VAULT_B, VAULT_A],
+        [VAULT_B, VAULT_A],
+        ADAPTER,
+        CONTEXT_BASE,
+      ),
+    ).rejects.toBeInstanceOf(SuggestedReorderMismatchError);
+  });
+
+  it("rejects when the trusted calculator would not have suggested a reorder (no debt)", async () => {
+    // No-debt scenario → calculator returns early with suggestedVaultOrder: null.
+    // Indexer would have fabricated a CTA; Guard B refuses.
+    mockGetBtcVaultBasicInfo.mockResolvedValue(
+      basicInfoMap([
+        [VAULT_A, activeInfo(60_000_000n)],
+        [VAULT_B, activeInfo(10_000_000n)],
+      ]),
+    );
+
+    await expect(
+      assertSuggestedOrderMatchesOnChain(
+        [VAULT_A, VAULT_B],
+        [VAULT_B, VAULT_A],
+        ADAPTER,
+        { ...CONTEXT_BASE, totalDebtUsd: 0 },
+      ),
+    ).rejects.toBeInstanceOf(SuggestedReorderMismatchError);
+  });
+
+  it("rejects when the current ordering is already optimal (calculator returns null)", async () => {
+    // Current order already matches calculator's optimum → no reorder needed.
+    // An indexer-fabricated submission would have to differ from current,
+    // but Guard B refuses because the calculator says "no suggestion".
+    mockGetBtcVaultBasicInfo.mockResolvedValue(
+      basicInfoMap([
+        [VAULT_A, activeInfo(60_000_000n)],
+        [VAULT_B, activeInfo(10_000_000n)],
+      ]),
+    );
+
+    await expect(
+      assertSuggestedOrderMatchesOnChain(
+        [VAULT_B, VAULT_A],
+        [VAULT_A, VAULT_B],
+        ADAPTER,
+        CONTEXT_BASE,
+      ),
+    ).rejects.toBeInstanceOf(SuggestedReorderMismatchError);
+  });
+
+  it("rejects when any vault is not in ACTIVE status", async () => {
+    mockGetBtcVaultBasicInfo.mockResolvedValue(
+      basicInfoMap([
+        [VAULT_A, activeInfo(60_000_000n)],
+        [
+          VAULT_B,
+          {
+            amount: 10_000_000n,
+            status: STATUS_REDEEMED,
+            applicationEntryPoint: ADAPTER,
+          },
+        ],
+      ]),
+    );
+
+    await expect(
+      assertSuggestedOrderMatchesOnChain(
+        [VAULT_A, VAULT_B],
+        [VAULT_B, VAULT_A],
+        ADAPTER,
+        CONTEXT_BASE,
+      ),
+    ).rejects.toBeInstanceOf(SuggestedReorderMismatchError);
+  });
+
+  it("rejects when a vault's applicationEntryPoint differs from the trusted adapter", async () => {
+    mockGetBtcVaultBasicInfo.mockResolvedValue(
+      basicInfoMap([
+        [VAULT_A, activeInfo(60_000_000n)],
+        [VAULT_B, activeInfo(10_000_000n, OTHER_APP)],
+      ]),
+    );
+
+    await expect(
+      assertSuggestedOrderMatchesOnChain(
+        [VAULT_A, VAULT_B],
+        [VAULT_B, VAULT_A],
+        ADAPTER,
+        CONTEXT_BASE,
+      ),
+    ).rejects.toBeInstanceOf(SuggestedReorderMismatchError);
+  });
+
+  it("matches applicationEntryPoint case-insensitively", async () => {
+    mockGetBtcVaultBasicInfo.mockResolvedValue(
+      basicInfoMap([
+        [VAULT_A, activeInfo(60_000_000n, ADAPTER.toUpperCase() as Address)],
+        [VAULT_B, activeInfo(10_000_000n)],
+      ]),
+    );
+
+    await expect(
+      assertSuggestedOrderMatchesOnChain(
+        [VAULT_A, VAULT_B],
+        [VAULT_B, VAULT_A],
+        ADAPTER,
+        CONTEXT_BASE,
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it("matches vault IDs case-insensitively against on-chain keys", async () => {
+    mockGetBtcVaultBasicInfo.mockResolvedValue(
+      basicInfoMap([
+        [VAULT_A, activeInfo(60_000_000n)],
+        [VAULT_B, activeInfo(10_000_000n)],
+      ]),
+    );
+
+    await expect(
+      assertSuggestedOrderMatchesOnChain(
+        [VAULT_A.toUpperCase() as Hex, VAULT_B],
+        [VAULT_B, VAULT_A],
+        ADAPTER,
+        CONTEXT_BASE,
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it("rejects empty submissions", async () => {
+    await expect(
+      assertSuggestedOrderMatchesOnChain([], [], ADAPTER, CONTEXT_BASE),
+    ).rejects.toBeInstanceOf(SuggestedReorderMismatchError);
+    expect(mockGetBtcVaultBasicInfo).not.toHaveBeenCalled();
+  });
+
+  it("propagates registry errors as fail-closed", async () => {
+    mockGetBtcVaultBasicInfo.mockRejectedValue(
+      new Error("vault not registered on-chain"),
+    );
+
+    await expect(
+      assertSuggestedOrderMatchesOnChain(
+        [VAULT_A, VAULT_B],
+        [VAULT_B, VAULT_A],
+        ADAPTER,
+        CONTEXT_BASE,
+      ),
+    ).rejects.toThrow("vault not registered on-chain");
+  });
+
+  it("throws SuggestedReorderMismatchError when the registry omits a vault from its response", async () => {
+    mockGetBtcVaultBasicInfo.mockResolvedValue(
+      basicInfoMap([[VAULT_A, activeInfo(60_000_000n)]]),
+    );
+
+    await expect(
+      assertSuggestedOrderMatchesOnChain(
+        [VAULT_A, VAULT_B],
+        [VAULT_B, VAULT_A],
+        ADAPTER,
+        CONTEXT_BASE,
+      ),
+    ).rejects.toBeInstanceOf(SuggestedReorderMismatchError);
+  });
+});

--- a/services/vault/src/applications/aave/services/assertReorderMatchesOnChain.ts
+++ b/services/vault/src/applications/aave/services/assertReorderMatchesOnChain.ts
@@ -1,0 +1,226 @@
+/**
+ * Assert that a `reorderVaults(bytes32[])` submission is well-formed against
+ * trusted on-chain state, before the wallet prompt fires.
+ *
+ * The reorder CTA builds its calldata from indexer-supplied vault IDs,
+ * amounts, and liquidation indexes. The on-chain adapter only rejects
+ * invalid permutations (`InvalidVaultsPermutation`), so a tampered indexer
+ * can return the user's real vault IDs but falsified amounts to steer the
+ * dApp-side optimizer toward an attacker-chosen-but-valid order.
+ *
+ * Two guards close that gap. Both fail closed.
+ *
+ * - `assertReorderMembership` reads `AaveIntegrationAdapter.getPosition(user)`
+ *   from the env-pinned adapter and refuses if the submitted multiset
+ *   disagrees with the on-chain set.
+ *
+ * - `assertSuggestedOrderMatchesOnChain` re-fetches per-vault basic info
+ *   from `BTCVaultRegistry.getBtcVaultBasicInfo` (amount, status,
+ *   applicationEntryPoint), re-runs the full `calculate(...)` pipeline
+ *   with on-chain amounts, and refuses if any per-vault status /
+ *   application check fails or if the trusted calculator's
+ *   `suggestedVaultOrder` does not equal the submission (including the
+ *   case where the trusted calculator would have suggested no reorder at
+ *   all). Only called when the caller is the auto-suggested CTA — manual
+ *   drag-and-drop reorders intentionally skip this guard so the user can
+ *   pick a non-optimal order.
+ */
+
+import { ContractStatus } from "@babylonlabs-io/ts-sdk/tbv/core/services";
+import { getPosition } from "@babylonlabs-io/ts-sdk/tbv/integrations/aave";
+import type { Address, Hex } from "viem";
+
+import { getBtcVaultBasicInfoFromChain } from "@/clients/eth-contract/btc-vault-registry/query";
+import { ethClient } from "@/clients/eth-contract/client";
+import { satoshiToBtcNumber } from "@/utils/btcConversion";
+
+import { calculate, type Vault } from "../positionNotifications";
+
+export class ReorderMembershipMismatchError extends Error {
+  readonly code = "REORDER_MEMBERSHIP_MISMATCH";
+}
+
+export class SuggestedReorderMismatchError extends Error {
+  readonly code = "SUGGESTED_REORDER_MISMATCH";
+}
+
+/**
+ * Trusted calculator inputs for the suggested-order recompute. All values
+ * must be on-chain-anchored — the whole point of the guard is to refuse
+ * recomputes against indexer-supplied inputs.
+ *
+ * - CF, THF, maxLB: from `useVaultSplitParams` (Spoke reads)
+ * - btcPrice: from Aave on-chain oracle via `usePrices`
+ * - totalDebtUsd: from `useAaveUserPosition().debtValueUsd`
+ *   (`accountData.totalDebtValueRay`, a Spoke read)
+ * - expectedHF: optional override; defaults to the calculator's
+ *   `EXPECTED_HEALTH_FACTOR_AT_LIQUIDATION`.
+ */
+export interface ReorderVerificationContext {
+  CF: number;
+  THF: number;
+  maxLB: number;
+  btcPrice: number;
+  totalDebtUsd: number;
+  expectedHF?: number;
+}
+
+function lower(id: Hex): string {
+  return id.toLowerCase();
+}
+
+function sameMultiset(a: readonly Hex[], b: readonly Hex[]): boolean {
+  if (a.length !== b.length) return false;
+  const counts = new Map<string, number>();
+  for (const id of a) counts.set(lower(id), (counts.get(lower(id)) ?? 0) + 1);
+  for (const id of b) {
+    const next = (counts.get(lower(id)) ?? 0) - 1;
+    if (next < 0) return false;
+    counts.set(lower(id), next);
+  }
+  return Array.from(counts.values()).every((n) => n === 0);
+}
+
+function sameOrderedSequence(a: readonly Hex[], b: readonly Hex[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (lower(a[i]) !== lower(b[i])) return false;
+  }
+  return true;
+}
+
+/**
+ * Guard A — verify the submitted vault IDs are exactly the user's current
+ * on-chain position. Runs on every reorder submission (auto-suggested CTA
+ * and manual drag-and-drop modal alike).
+ *
+ * Returns the on-chain ordering so callers (specifically Guard B) can
+ * feed it into the notification calculator without a second
+ * `getPosition` round-trip.
+ *
+ * @param trustedAdapterAddress - Env-pinned AaveIntegrationAdapter (same
+ *   address the tx will be sent to). Read straight from
+ *   `getAaveAdapterAddress()` at the call site.
+ * @returns the current on-chain ordering of `vaultIds`, exactly as the
+ *   adapter returned them.
+ * @throws {ReorderMembershipMismatchError} when the on-chain multiset
+ *   disagrees with the submitted multiset (case-insensitive), or when no
+ *   position exists.
+ */
+export async function assertReorderMembership(
+  trustedAdapterAddress: Address,
+  user: Address,
+  submittedVaultIds: readonly Hex[],
+): Promise<readonly Hex[]> {
+  const publicClient = ethClient.getPublicClient();
+  const position = await getPosition(publicClient, trustedAdapterAddress, user);
+  if (!position) {
+    throw new ReorderMembershipMismatchError(
+      `No on-chain position found for ${user} on adapter ${trustedAdapterAddress}. Aborting reorder to avoid signing against unknown vault membership.`,
+    );
+  }
+  if (!sameMultiset(submittedVaultIds, position.vaultIds)) {
+    throw new ReorderMembershipMismatchError(
+      `Reorder submission vault set does not match on-chain position. Submitted ${submittedVaultIds.length} vaults, on-chain has ${position.vaultIds.length}.`,
+    );
+  }
+  return position.vaultIds;
+}
+
+/**
+ * Guard B — verify the submitted ordering equals what the trusted
+ * notification calculator would have suggested.
+ *
+ * Re-runs the full `calculate(...)` pipeline (not just `computeOptimalOrder`)
+ * so that suppression rules — e.g. when an optimal reorder would create a
+ * rebalance condition the user currently doesn't have — are honored. A
+ * malicious indexer can otherwise fabricate a CTA whose submitted order
+ * equals `computeOptimalOrder(trusted).order` even though the trusted
+ * calculator would have returned `suggestedVaultOrder: null`.
+ *
+ * The calculator needs the **current** on-chain ordering as its `vaults`
+ * input so it can decide whether a reorder helps relative to that
+ * baseline; callers thread that through from `assertReorderMembership`'s
+ * return value to avoid a duplicate `getPosition` round-trip.
+ *
+ * Also validates per-vault on-chain status / applicationEntryPoint to
+ * match the audit recommendation literally (Guard A's membership check
+ * makes these structurally redundant, but they fail closed regardless).
+ *
+ * Only invoked from the auto-suggested CTA. The manual drag-and-drop modal
+ * intentionally does not call this guard, so users can choose a non-optimal
+ * order without being second-guessed by the dApp.
+ *
+ * @param currentVaultIds - Ordering returned by
+ *   `AaveIntegrationAdapter.getPosition(user).vaultIds`. Used as the
+ *   `vaults` input to `calculate(...)` so the suppression rules see the
+ *   user's actual current ordering.
+ * @throws {SuggestedReorderMismatchError} when any per-vault check fails,
+ *   the trusted calculator suggests no reorder, or the suggested order
+ *   does not equal the submission.
+ */
+export async function assertSuggestedOrderMatchesOnChain(
+  submittedVaultIds: readonly Hex[],
+  currentVaultIds: readonly Hex[],
+  trustedAdapterAddress: Address,
+  ctx: ReorderVerificationContext,
+): Promise<void> {
+  if (submittedVaultIds.length === 0) {
+    throw new SuggestedReorderMismatchError(
+      "Reorder submission is empty — refusing to sign.",
+    );
+  }
+
+  const basicInfo = await getBtcVaultBasicInfoFromChain(currentVaultIds);
+
+  const vaults: Vault[] = currentVaultIds.map((id, i) => {
+    const info = basicInfo.get(lower(id) as Hex);
+    if (info === undefined) {
+      throw new SuggestedReorderMismatchError(
+        `On-chain basic info for vault ${id} not returned by registry multicall.`,
+      );
+    }
+    if (info.status !== ContractStatus.ACTIVE) {
+      throw new SuggestedReorderMismatchError(
+        `Vault ${id} has on-chain status ${info.status}, expected ACTIVE (${ContractStatus.ACTIVE}). Refusing to recompute reorder against a non-active vault.`,
+      );
+    }
+    if (
+      info.applicationEntryPoint.toLowerCase() !==
+      trustedAdapterAddress.toLowerCase()
+    ) {
+      throw new SuggestedReorderMismatchError(
+        `Vault ${id} is bound to application ${info.applicationEntryPoint}, expected the env-pinned Aave adapter ${trustedAdapterAddress}.`,
+      );
+    }
+    return {
+      id: lower(id),
+      btc: satoshiToBtcNumber(info.amount),
+      name: `Vault ${i + 1}`,
+    };
+  });
+
+  const { suggestedVaultOrder } = calculate({
+    btcPrice: ctx.btcPrice,
+    totalDebtUsd: ctx.totalDebtUsd,
+    vaults,
+    CF: ctx.CF,
+    THF: ctx.THF,
+    maxLB: ctx.maxLB,
+    ...(ctx.expectedHF !== undefined ? { expectedHF: ctx.expectedHF } : {}),
+  });
+
+  if (suggestedVaultOrder === null) {
+    throw new SuggestedReorderMismatchError(
+      "Trusted calculator would not have suggested a reorder under on-chain amounts. Aborting to avoid signing an indexer-fabricated CTA.",
+    );
+  }
+
+  const expectedOrder = suggestedVaultOrder.map((v) => v.id as Hex);
+
+  if (!sameOrderedSequence(submittedVaultIds, expectedOrder)) {
+    throw new SuggestedReorderMismatchError(
+      "Suggested reorder does not match the calculator's output under on-chain amounts. Aborting to avoid signing an indexer-steered permutation.",
+    );
+  }
+}

--- a/services/vault/src/applications/aave/services/index.ts
+++ b/services/vault/src/applications/aave/services/index.ts
@@ -58,6 +58,13 @@ export {
 
 // On-chain integrity guards
 export {
+  ReorderMembershipMismatchError,
+  SuggestedReorderMismatchError,
+  assertReorderMembership,
+  assertSuggestedOrderMatchesOnChain,
+  type ReorderVerificationContext,
+} from "./assertReorderMatchesOnChain";
+export {
   ReserveMismatchError,
   assertReserveMatchesOnChain,
 } from "./assertReserveMatchesOnChain";

--- a/services/vault/src/clients/eth-contract/btc-vault-registry/__tests__/query.test.ts
+++ b/services/vault/src/clients/eth-contract/btc-vault-registry/__tests__/query.test.ts
@@ -1,6 +1,6 @@
 /**
- * Tests for getBtcVaultBasicInfoFromChain — the on-chain per-vault basic
- * info multicall used by the reorder integrity guard.
+ * Tests for getBtcVaultBasicInfoFromChain — the per-vault basic info
+ * lookup used by the reorder integrity guard.
  */
 
 import type { Address, Hex } from "viem";
@@ -15,11 +15,11 @@ vi.mock("@/config/env", () => ({
   },
 }));
 
-const mockMulticall = vi.fn();
-vi.mock("../../client", () => ({
-  ethClient: {
-    getPublicClient: () => ({ multicall: mockMulticall }),
-  },
+const mockGetVaultBasicInfo = vi.fn();
+vi.mock("../../sdk-readers", () => ({
+  getVaultRegistryReader: () => ({
+    getVaultBasicInfo: mockGetVaultBasicInfo,
+  }),
 }));
 
 import { getBtcVaultBasicInfoFromChain } from "../query";
@@ -31,74 +31,67 @@ const VAULT_B =
 const DEPOSITOR = "0x000000000000000000000000000000000000beef" as Address;
 const AAVE_ADAPTER = "0x000000000000000000000000000000000000ada9" as Address;
 
+function basicInfo(amount: bigint) {
+  return {
+    depositor: DEPOSITOR,
+    depositorBtcPubKey: ("0x" + "0".repeat(64)) as Hex,
+    amount,
+    vaultProvider: ("0x" + "1".repeat(40)) as Address,
+    status: 2,
+    applicationEntryPoint: AAVE_ADAPTER,
+    createdAt: 0n,
+  };
+}
+
 describe("getBtcVaultBasicInfoFromChain", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   it("returns amount, status, and applicationEntryPoint keyed by lowercased vault ID", async () => {
-    mockMulticall.mockResolvedValue([
-      {
-        depositor: DEPOSITOR,
-        amount: 60_000_000n,
-        status: 2,
-        applicationEntryPoint: AAVE_ADAPTER,
-      },
-      {
-        depositor: DEPOSITOR,
-        amount: 10_000_000n,
-        status: 2,
-        applicationEntryPoint: AAVE_ADAPTER,
-      },
-    ]);
+    mockGetVaultBasicInfo.mockImplementation(async (vaultId: Hex) => {
+      if (vaultId === VAULT_A) return basicInfo(60_000_000n);
+      if (vaultId === VAULT_B) return basicInfo(10_000_000n);
+      throw new Error(`unexpected vault ${vaultId}`);
+    });
 
     const result = await getBtcVaultBasicInfoFromChain([VAULT_A, VAULT_B]);
 
-    const a = result.get(VAULT_A.toLowerCase() as Hex);
-    expect(a).toEqual({
+    expect(result.get(VAULT_A.toLowerCase() as Hex)).toEqual({
       amount: 60_000_000n,
       status: 2,
       applicationEntryPoint: AAVE_ADAPTER,
     });
-    const b = result.get(VAULT_B.toLowerCase() as Hex);
-    expect(b).toEqual({
+    expect(result.get(VAULT_B.toLowerCase() as Hex)).toEqual({
       amount: 10_000_000n,
       status: 2,
       applicationEntryPoint: AAVE_ADAPTER,
     });
-    expect(mockMulticall).toHaveBeenCalledTimes(1);
-    const call = mockMulticall.mock.calls[0][0] as {
-      contracts: Array<{ functionName: string; args: readonly Hex[] }>;
-      allowFailure: boolean;
-    };
-    expect(call.allowFailure).toBe(false);
-    expect(call.contracts).toHaveLength(2);
-    expect(call.contracts[0].functionName).toBe("getBtcVaultBasicInfo");
-    expect(call.contracts[0].args).toEqual([VAULT_A]);
+    expect(mockGetVaultBasicInfo).toHaveBeenCalledTimes(2);
+    expect(mockGetVaultBasicInfo).toHaveBeenNthCalledWith(1, VAULT_A);
+    expect(mockGetVaultBasicInfo).toHaveBeenNthCalledWith(2, VAULT_B);
   });
 
   it("returns an empty map and skips RPC when no vault IDs are supplied", async () => {
     const result = await getBtcVaultBasicInfoFromChain([]);
 
     expect(result.size).toBe(0);
-    expect(mockMulticall).not.toHaveBeenCalled();
+    expect(mockGetVaultBasicInfo).not.toHaveBeenCalled();
   });
 
   it("throws when any returned vault has a zero depositor (unregistered)", async () => {
-    mockMulticall.mockResolvedValue([
-      {
-        depositor: DEPOSITOR,
-        amount: 60_000_000n,
-        status: 2,
-        applicationEntryPoint: AAVE_ADAPTER,
-      },
-      {
-        depositor: zeroAddress,
-        amount: 0n,
-        status: 0,
-        applicationEntryPoint: zeroAddress,
-      },
-    ]);
+    mockGetVaultBasicInfo.mockImplementation(async (vaultId: Hex) => {
+      if (vaultId === VAULT_A) return basicInfo(60_000_000n);
+      if (vaultId === VAULT_B) {
+        return {
+          ...basicInfo(0n),
+          depositor: zeroAddress,
+          applicationEntryPoint: zeroAddress,
+          status: 0,
+        };
+      }
+      throw new Error(`unexpected vault ${vaultId}`);
+    });
 
     await expect(
       getBtcVaultBasicInfoFromChain([VAULT_A, VAULT_B]),

--- a/services/vault/src/clients/eth-contract/btc-vault-registry/__tests__/query.test.ts
+++ b/services/vault/src/clients/eth-contract/btc-vault-registry/__tests__/query.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Tests for getBtcVaultBasicInfoFromChain — the on-chain per-vault basic
+ * info multicall used by the reorder integrity guard.
+ */
+
+import type { Address, Hex } from "viem";
+import { zeroAddress } from "viem";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/config/env", () => ({
+  ENV: {
+    BTC_VAULT_REGISTRY: "0x1234567890123456789012345678901234567890",
+    AAVE_ADAPTER: "0x1234567890123456789012345678901234567890",
+    GRAPHQL_ENDPOINT: "https://test.example.com/graphql",
+  },
+}));
+
+const mockMulticall = vi.fn();
+vi.mock("../../client", () => ({
+  ethClient: {
+    getPublicClient: () => ({ multicall: mockMulticall }),
+  },
+}));
+
+import { getBtcVaultBasicInfoFromChain } from "../query";
+
+const VAULT_A =
+  "0xaaaa000000000000000000000000000000000000000000000000000000000001" as Hex;
+const VAULT_B =
+  "0xbbbb000000000000000000000000000000000000000000000000000000000002" as Hex;
+const DEPOSITOR = "0x000000000000000000000000000000000000beef" as Address;
+const AAVE_ADAPTER = "0x000000000000000000000000000000000000ada9" as Address;
+
+describe("getBtcVaultBasicInfoFromChain", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns amount, status, and applicationEntryPoint keyed by lowercased vault ID", async () => {
+    mockMulticall.mockResolvedValue([
+      {
+        depositor: DEPOSITOR,
+        amount: 60_000_000n,
+        status: 2,
+        applicationEntryPoint: AAVE_ADAPTER,
+      },
+      {
+        depositor: DEPOSITOR,
+        amount: 10_000_000n,
+        status: 2,
+        applicationEntryPoint: AAVE_ADAPTER,
+      },
+    ]);
+
+    const result = await getBtcVaultBasicInfoFromChain([VAULT_A, VAULT_B]);
+
+    const a = result.get(VAULT_A.toLowerCase() as Hex);
+    expect(a).toEqual({
+      amount: 60_000_000n,
+      status: 2,
+      applicationEntryPoint: AAVE_ADAPTER,
+    });
+    const b = result.get(VAULT_B.toLowerCase() as Hex);
+    expect(b).toEqual({
+      amount: 10_000_000n,
+      status: 2,
+      applicationEntryPoint: AAVE_ADAPTER,
+    });
+    expect(mockMulticall).toHaveBeenCalledTimes(1);
+    const call = mockMulticall.mock.calls[0][0] as {
+      contracts: Array<{ functionName: string; args: readonly Hex[] }>;
+      allowFailure: boolean;
+    };
+    expect(call.allowFailure).toBe(false);
+    expect(call.contracts).toHaveLength(2);
+    expect(call.contracts[0].functionName).toBe("getBtcVaultBasicInfo");
+    expect(call.contracts[0].args).toEqual([VAULT_A]);
+  });
+
+  it("returns an empty map and skips RPC when no vault IDs are supplied", async () => {
+    const result = await getBtcVaultBasicInfoFromChain([]);
+
+    expect(result.size).toBe(0);
+    expect(mockMulticall).not.toHaveBeenCalled();
+  });
+
+  it("throws when any returned vault has a zero depositor (unregistered)", async () => {
+    mockMulticall.mockResolvedValue([
+      {
+        depositor: DEPOSITOR,
+        amount: 60_000_000n,
+        status: 2,
+        applicationEntryPoint: AAVE_ADAPTER,
+      },
+      {
+        depositor: zeroAddress,
+        amount: 0n,
+        status: 0,
+        applicationEntryPoint: zeroAddress,
+      },
+    ]);
+
+    await expect(
+      getBtcVaultBasicInfoFromChain([VAULT_A, VAULT_B]),
+    ).rejects.toThrow(/not registered on-chain/);
+  });
+});

--- a/services/vault/src/clients/eth-contract/btc-vault-registry/query.ts
+++ b/services/vault/src/clients/eth-contract/btc-vault-registry/query.ts
@@ -6,11 +6,8 @@
  * The actual contract reads, validations, and multicalls live in the SDK.
  */
 
-import { BTCVaultRegistryABI } from "@babylonlabs-io/ts-sdk/tbv/core";
-import { type Abi, type Address, type Hex, zeroAddress } from "viem";
+import { type Address, type Hex, zeroAddress } from "viem";
 
-import { CONTRACTS } from "../../../config/contracts";
-import { ethClient } from "../client";
 import { getVaultRegistryReader } from "../sdk-readers";
 
 /**
@@ -101,12 +98,17 @@ export interface OnChainVaultBasicInfo {
 }
 
 /**
- * Read per-vault signing-critical fields for many vaults in a single
- * multicall against `BTCVaultRegistry.getBtcVaultBasicInfo`.
+ * Read per-vault signing-critical fields for many vaults in parallel
+ * via the SDK's strongly-typed `ViemVaultRegistryReader.getVaultBasicInfo`.
  *
  * Returned map keys are lowercased vault IDs (case-insensitive lookup);
  * the same key form is used by the reorder integrity guard so the caller
  * does not need to worry about checksum casing.
+ *
+ * Delegates to the SDK's typed reader rather than running its own
+ * multicall+cast — the strongly-typed path catches ABI shape
+ * regressions at compile time instead of through a late `TypeError` in
+ * a downstream consumer.
  *
  * @throws if any input vault is unregistered on-chain (`depositor` is the
  * zero address). The reorder guard treats an unregistered vault as
@@ -117,35 +119,22 @@ export async function getBtcVaultBasicInfoFromChain(
 ): Promise<Map<Hex, OnChainVaultBasicInfo>> {
   if (vaultIds.length === 0) return new Map();
 
-  const publicClient = ethClient.getPublicClient();
-
-  const results = await publicClient.multicall({
-    contracts: vaultIds.map((vaultId) => ({
-      address: CONTRACTS.BTC_VAULT_REGISTRY,
-      abi: BTCVaultRegistryABI as Abi,
-      functionName: "getBtcVaultBasicInfo" as const,
-      args: [vaultId] as const,
-    })),
-    allowFailure: false,
-  });
+  const reader = getVaultRegistryReader();
+  const results = await Promise.all(
+    vaultIds.map((vaultId) => reader.getVaultBasicInfo(vaultId)),
+  );
 
   const out = new Map<Hex, OnChainVaultBasicInfo>();
   results.forEach((info, i) => {
-    const result = info as unknown as {
-      depositor: Address;
-      amount: bigint;
-      status: number;
-      applicationEntryPoint: Address;
-    };
-    if (result.depositor === zeroAddress) {
+    if (info.depositor === zeroAddress) {
       throw new Error(
         `Vault ${vaultIds[i]} not registered on-chain — refusing to recompute reorder against unverified basic info`,
       );
     }
     out.set(vaultIds[i].toLowerCase() as Hex, {
-      amount: result.amount,
-      status: result.status,
-      applicationEntryPoint: result.applicationEntryPoint,
+      amount: info.amount,
+      status: info.status,
+      applicationEntryPoint: info.applicationEntryPoint,
     });
   });
   return out;

--- a/services/vault/src/clients/eth-contract/btc-vault-registry/query.ts
+++ b/services/vault/src/clients/eth-contract/btc-vault-registry/query.ts
@@ -6,8 +6,11 @@
  * The actual contract reads, validations, and multicalls live in the SDK.
  */
 
-import type { Address, Hex } from "viem";
+import { BTCVaultRegistryABI } from "@babylonlabs-io/ts-sdk/tbv/core";
+import { type Abi, type Address, type Hex, zeroAddress } from "viem";
 
+import { CONTRACTS } from "../../../config/contracts";
+import { ethClient } from "../client";
 import { getVaultRegistryReader } from "../sdk-readers";
 
 /**
@@ -81,4 +84,69 @@ export async function getOffchainParamsVersionsFromChain(
   vaultIds: readonly Hex[],
 ): Promise<number[]> {
   return getVaultRegistryReader().getOffchainParamsVersionsByVaultIds(vaultIds);
+}
+
+/**
+ * Signing-critical subset of `getBtcVaultBasicInfo` used by the reorder
+ * integrity guard. Returned by `getBtcVaultBasicInfoFromChain` in a map
+ * keyed by lowercased vault ID.
+ */
+export interface OnChainVaultBasicInfo {
+  /** Vault deposit amount in satoshis. */
+  amount: bigint;
+  /** Numeric `BTCVaultStatus` (see `ContractStatus`). 2 = ACTIVE. */
+  status: number;
+  /** Application controller bound at vault creation. */
+  applicationEntryPoint: Address;
+}
+
+/**
+ * Read per-vault signing-critical fields for many vaults in a single
+ * multicall against `BTCVaultRegistry.getBtcVaultBasicInfo`.
+ *
+ * Returned map keys are lowercased vault IDs (case-insensitive lookup);
+ * the same key form is used by the reorder integrity guard so the caller
+ * does not need to worry about checksum casing.
+ *
+ * @throws if any input vault is unregistered on-chain (`depositor` is the
+ * zero address). The reorder guard treats an unregistered vault as
+ * untrusted membership and refuses to sign.
+ */
+export async function getBtcVaultBasicInfoFromChain(
+  vaultIds: readonly Hex[],
+): Promise<Map<Hex, OnChainVaultBasicInfo>> {
+  if (vaultIds.length === 0) return new Map();
+
+  const publicClient = ethClient.getPublicClient();
+
+  const results = await publicClient.multicall({
+    contracts: vaultIds.map((vaultId) => ({
+      address: CONTRACTS.BTC_VAULT_REGISTRY,
+      abi: BTCVaultRegistryABI as Abi,
+      functionName: "getBtcVaultBasicInfo" as const,
+      args: [vaultId] as const,
+    })),
+    allowFailure: false,
+  });
+
+  const out = new Map<Hex, OnChainVaultBasicInfo>();
+  results.forEach((info, i) => {
+    const result = info as unknown as {
+      depositor: Address;
+      amount: bigint;
+      status: number;
+      applicationEntryPoint: Address;
+    };
+    if (result.depositor === zeroAddress) {
+      throw new Error(
+        `Vault ${vaultIds[i]} not registered on-chain — refusing to recompute reorder against unverified basic info`,
+      );
+    }
+    out.set(vaultIds[i].toLowerCase() as Hex, {
+      amount: result.amount,
+      status: result.status,
+      applicationEntryPoint: result.applicationEntryPoint,
+    });
+  });
+  return out;
 }

--- a/services/vault/src/components/simple/PositionNotificationBanner/PositionNotificationBanner.tsx
+++ b/services/vault/src/components/simple/PositionNotificationBanner/PositionNotificationBanner.tsx
@@ -72,14 +72,11 @@ export function PositionNotificationBanner({
   }, [address, queryClient]);
 
   const handleApplyOrder = useCallback(async () => {
-    if (!result?.suggestedVaultOrder) return;
+    if (!result?.suggestedVaultOrder || !reorderVerificationContext) return;
     const vaultIds = result.suggestedVaultOrder.map((v) => v.id as Hex);
-    const success = await executeReorder(
-      vaultIds,
-      reorderVerificationContext
-        ? { suggestedOrderContext: reorderVerificationContext }
-        : undefined,
-    );
+    const success = await executeReorder(vaultIds, {
+      suggestedOrderContext: reorderVerificationContext,
+    });
     if (success) {
       setIsReorderSuccess(true);
     }

--- a/services/vault/src/components/simple/PositionNotificationBanner/PositionNotificationBanner.tsx
+++ b/services/vault/src/components/simple/PositionNotificationBanner/PositionNotificationBanner.tsx
@@ -50,6 +50,7 @@ export function PositionNotificationBanner({
     result: hookResult,
     status,
     isLoading,
+    reorderVerificationContext,
   } = usePositionNotifications(connectedAddress);
 
   const hasOverride = resultOverride !== undefined;
@@ -73,11 +74,16 @@ export function PositionNotificationBanner({
   const handleApplyOrder = useCallback(async () => {
     if (!result?.suggestedVaultOrder) return;
     const vaultIds = result.suggestedVaultOrder.map((v) => v.id as Hex);
-    const success = await executeReorder(vaultIds);
+    const success = await executeReorder(
+      vaultIds,
+      reorderVerificationContext
+        ? { suggestedOrderContext: reorderVerificationContext }
+        : undefined,
+    );
     if (success) {
       setIsReorderSuccess(true);
     }
-  }, [result, executeReorder]);
+  }, [result, executeReorder, reorderVerificationContext]);
 
   const effectiveStatus = statusOverride ?? status;
 

--- a/services/vault/src/components/simple/PositionNotificationBanner/__tests__/PositionNotificationBanner.test.tsx
+++ b/services/vault/src/components/simple/PositionNotificationBanner/__tests__/PositionNotificationBanner.test.tsx
@@ -79,11 +79,20 @@ vi.mock("@/applications/aave/hooks/useReorderVaults", () => ({
   }),
 }));
 
+const mockReorderVerificationContext = {
+  CF: 0.7,
+  THF: 1.1,
+  maxLB: 1.05,
+  btcPrice: 60_000,
+  totalDebtUsd: 10_000,
+};
+
 vi.mock("@/applications/aave/hooks/usePositionNotifications", () => ({
   usePositionNotifications: () => ({
     result: null,
     status: "ready" as const,
     isLoading: false,
+    reorderVerificationContext: mockReorderVerificationContext,
   }),
 }));
 
@@ -422,7 +431,7 @@ describe("PositionNotificationBanner", () => {
     expect(onRepay).toHaveBeenCalled();
   });
 
-  it("calls executeReorder with correct vault IDs when Apply Suggested Order is clicked", () => {
+  it("calls executeReorder with vault IDs and the verification context when Apply Suggested Order is clicked", () => {
     const suggestedOrder = [
       { id: "0xabc", name: "Vault 2", btc: 0.6 },
       { id: "0xdef", name: "Vault 1", btc: 0.1 },
@@ -449,7 +458,9 @@ describe("PositionNotificationBanner", () => {
     );
 
     fireEvent.click(screen.getByText("Apply Suggested Order"));
-    expect(mockExecuteReorder).toHaveBeenCalledWith(["0xabc", "0xdef"]);
+    expect(mockExecuteReorder).toHaveBeenCalledWith(["0xabc", "0xdef"], {
+      suggestedOrderContext: mockReorderVerificationContext,
+    });
   });
 
   it("renders secondary warnings below primary", () => {

--- a/services/vault/src/components/simple/PositionNotificationBanner/__tests__/PositionNotificationBanner.test.tsx
+++ b/services/vault/src/components/simple/PositionNotificationBanner/__tests__/PositionNotificationBanner.test.tsx
@@ -87,13 +87,17 @@ const mockReorderVerificationContext = {
   totalDebtUsd: 10_000,
 };
 
+const mockUsePositionNotifications = vi.fn(() => ({
+  result: null,
+  status: "ready" as const,
+  isLoading: false,
+  reorderVerificationContext: mockReorderVerificationContext as
+    | typeof mockReorderVerificationContext
+    | null,
+}));
+
 vi.mock("@/applications/aave/hooks/usePositionNotifications", () => ({
-  usePositionNotifications: () => ({
-    result: null,
-    status: "ready" as const,
-    isLoading: false,
-    reorderVerificationContext: mockReorderVerificationContext,
-  }),
+  usePositionNotifications: () => mockUsePositionNotifications(),
 }));
 
 vi.mock("wagmi", () => ({
@@ -461,6 +465,46 @@ describe("PositionNotificationBanner", () => {
     expect(mockExecuteReorder).toHaveBeenCalledWith(["0xabc", "0xdef"], {
       suggestedOrderContext: mockReorderVerificationContext,
     });
+  });
+
+  it("does not call executeReorder when the verification context is unavailable (debug-override path)", () => {
+    // resultOverride bypasses the hook's "ready" gate, but the hook can
+    // still expose a null verification context. Without it, Guard B can
+    // never run on the signing path — refuse to even attempt the tx.
+    mockUsePositionNotifications.mockReturnValueOnce({
+      result: null,
+      status: "ready" as const,
+      isLoading: false,
+      reorderVerificationContext: null,
+    });
+
+    const suggestedOrder = [
+      { id: "0xabc", name: "Vault 2", btc: 0.6 },
+      { id: "0xdef", name: "Vault 1", btc: 0.1 },
+    ];
+    const result = makeBaseResult({
+      warnings: [
+        {
+          type: "reorder",
+          title: "Better ordering",
+          detail: "Reorder reduces seizure.",
+        },
+      ],
+      suggestedVaultOrder: suggestedOrder,
+    });
+
+    render(
+      <Wrapper>
+        <PositionNotificationBanner
+          result={result}
+          onDeposit={onDeposit}
+          onRepay={onRepay}
+        />
+      </Wrapper>,
+    );
+
+    fireEvent.click(screen.getByText("Apply Suggested Order"));
+    expect(mockExecuteReorder).not.toHaveBeenCalled();
   });
 
   it("renders secondary warnings below primary", () => {


### PR DESCRIPTION
## What's the problem?

The "Apply Suggested Order" button on the position-notification banner takes its data straight from the GraphQL indexer:

- the list of vault IDs in the user's position,
- the BTC amount in each vault,
- the on-chain liquidation index.

It feeds those numbers into a calculator that picks the "best" order to seize collateral during liquidation, then asks the user to sign a `reorderVaults(bytes32[])` transaction that pins that order on-chain.

If the indexer is compromised, it can return the user's **real** vault IDs (so the on-chain contract is happy with the permutation) but **falsify** the amounts/indexes. The calculator then recommends an attacker-chosen order. The user clicks, signs, and from that moment on, liquidations seize the attacker-preferred vaults first — losing the user BTC they could have kept.

The on-chain contract only checks that the submitted vault IDs are a valid permutation of what it already knows. It can't tell a smart ordering from a malicious one.

## What does this PR do?

It adds two integrity checks inside `useReorderVaults.executeReorder`, **before** the wallet prompt fires. If either fails, no signature is requested and the user sees a clear error in the modal.

Both checks read directly from the on-chain Aave adapter and the BTCVaultRegistry, not from the indexer. That means even a fully compromised indexer cannot get past them.

### Check 1 — Same vaults?

Calls `AaveIntegrationAdapter.getPosition(user)` against the environment-pinned Aave adapter address. The set of vault IDs the user is trying to reorder must match the set the contract sees, exactly (case-insensitive). If a vault ID is missing, extra, or duplicated, we refuse to sign.

Runs on every reorder — both the "Apply Suggested Order" CTA and the manual drag-and-drop modal.

### Check 2 — Same suggestion?

This is the one that closes the actual attack. Only runs on the "Apply Suggested Order" CTA (not manual drag-and-drop, since manual reorders may intentionally be non-optimal).

1. For every vault in the user's position, call `BTCVaultRegistry.getBtcVaultBasicInfo` and read three trusted fields:
   - `amount` — the real BTC amount in each vault, in satoshis.
   - `status` — must be `ACTIVE` (numeric 2). Refuse otherwise.
   - `applicationEntryPoint` — must equal the env-pinned Aave adapter address. Refuse otherwise.
2. Re-run the **full** position-notification calculator (`calculate(...)` from `applications/aave/positionNotifications`) with those trusted amounts and the current on-chain vault ordering.
3. Compare the calculator's `suggestedVaultOrder` to what the user is about to sign:
   - If the calculator says "no reorder needed" (e.g. the current order is already optimal, or a reorder would create a worse rebalance condition), refuse — the indexer fabricated a CTA that wouldn't exist under honest data.
   - If the calculator says "reorder to X" but the user is about to sign "reorder to Y", refuse.

Re-running the **full** calculator (not just the raw optimizer) matters because the calculator can suppress an "optimal" reorder when applying it would create a rebalance condition the user doesn't currently have. A naïve check against the raw optimizer would miss that case and let the indexer fabricate a CTA.

### Why the trusted inputs are actually trusted

The calculator takes a few inputs besides per-vault amounts. All of them are already on-chain-anchored on `main`, so reusing them is safe:

- `CF`, `THF`, `maxLB` — from `useVaultSplitParams`, which reads them from the Aave Spoke contract.
- `btcPrice` — from `usePrices()`, the Aave on-chain oracle.
- `totalDebtUsd` — from `useAaveUserPosition().debtValueUsd`, which is derived from `accountData.totalDebtValueRay` (a Spoke read).
- Per-vault `amount` — re-fetched from `BTCVaultRegistry` inside the guard (not from the indexer).
- Vault membership — verified by Check 1 against the env-pinned adapter.

### Untouched

- The display path in `usePositionNotifications` still uses indexer amounts. That is fine — the indexer can mislead the *banner* into showing a CTA, but the user cannot sign anything the trusted guards reject. We did not refactor the hot-path render hook into an RPC reader.
- The manual drag-and-drop reorder modal keeps Check 1 (membership) but intentionally skips Check 2 — the user is choosing the order on purpose; second-guessing them would defeat the feature.

## How attackers' attempts now fail

| Tamper attempt | Where it's caught |
|---|---|
| Add a phantom vault ID to the suggested order | Check 1 — multiset mismatch |
| Drop a real vault ID from the suggested order | Check 1 — multiset mismatch |
| Real vault IDs + falsified amounts → steered permutation | Check 2 — calculator with on-chain amounts disagrees |
| Real vault IDs + fabricated CTA when no reorder is actually needed | Check 2 — `suggestedVaultOrder` is `null` |
| Reorder includes a redeemed/expired vault somehow | Check 2 — `status !== ACTIVE` |
| Vault belongs to a different application | Check 2 — `applicationEntryPoint` mismatch |

## Out of scope / known caveats

1. **The manual drag-and-drop modal still shows indexer-supplied amounts in its UI.** A compromised indexer can label vaults with fake amounts there, potentially tricking a user into manually choosing a bad order. Check 1 still catches set tampering, but not user-perception-driven order tampering. This shares a root cause with the broader display-path indexer-trust concern and warrants a separate follow-up — out of scope here, which targets the auto-suggestion CTA specifically.

2. **Fail-closed false positives are possible if the on-chain inputs rotate between banner render and click.** The calculator's suppression rules depend on `btcPrice` and `totalDebtUsd`, which can change. If they shift enough between the banner showing a CTA and the user clicking it, Check 2 may surface a `SUGGESTED_REORDER_MISMATCH` on an otherwise honest indexer. The user retries; the new banner reflects the rotated state. We considered this preferable to relaxing the check.

3. **Manual reorder modal does not call Check 2.** Intentional, as noted above. If you'd like the guard to also apply there (treating manual reorders as "must be optimal"), that's a UX change worth discussing separately — it would prevent users from picking a non-optimal order on purpose.

Closes https://github.com/babylonlabs-io/baby-auditor-findings/issues/155
