### PR TITLE
fix(vault): refuse stale-order reorder submissions from the modal

### DIFF
--- a/services/vault/src/applications/aave/hooks/__tests__/useReorderVaults.test.tsx
+++ b/services/vault/src/applications/aave/hooks/__tests__/useReorderVaults.test.tsx
@@ -48,11 +48,22 @@ vi.mock("../../config", () => ({
 }));
 
 const mockAssertMembership = vi.fn();
+const mockAssertBaseline = vi.fn();
 const mockAssertSuggestedOrder = vi.fn();
 const mockReorderVaultOrder = vi.fn();
+
+const { FakePositionChangedError } = vi.hoisted(() => {
+  class FakePositionChangedError extends Error {
+    readonly code = "POSITION_CHANGED_REFRESH_REQUIRED";
+  }
+  return { FakePositionChangedError };
+});
+
 vi.mock("../../services", () => ({
+  PositionChangedError: FakePositionChangedError,
   assertReorderMembership: (...args: unknown[]) =>
     mockAssertMembership(...args),
+  assertReorderBaseline: (...args: unknown[]) => mockAssertBaseline(...args),
   assertSuggestedOrderMatchesOnChain: (...args: unknown[]) =>
     mockAssertSuggestedOrder(...args),
   reorderVaultOrder: (...args: unknown[]) => mockReorderVaultOrder(...args),
@@ -90,6 +101,7 @@ describe("useReorderVaults — on-chain integrity guards", () => {
     // into calculate(...). Default mock returns the same IDs the test
     // submits — individual tests can override.
     mockAssertMembership.mockResolvedValue([VAULT_A, VAULT_B]);
+    mockAssertBaseline.mockReturnValue(undefined);
     mockAssertSuggestedOrder.mockResolvedValue(undefined);
     mockReorderVaultOrder.mockResolvedValue({
       transactionHash: "0xtx",
@@ -191,5 +203,58 @@ describe("useReorderVaults — on-chain integrity guards", () => {
     expect(resolved).toBe(false);
     expect(mockAssertMembership).not.toHaveBeenCalled();
     expect(mockReorderVaultOrder).not.toHaveBeenCalled();
+  });
+
+  it("forwards Guard A's live ordering into the baseline check when expectedCurrentVaultIds is provided", async () => {
+    mockAssertMembership.mockResolvedValue([VAULT_A, VAULT_B]);
+
+    const { result } = renderHook(() => useReorderVaults());
+
+    await act(async () => {
+      await result.current.executeReorder([VAULT_B, VAULT_A], {
+        expectedCurrentVaultIds: [VAULT_A, VAULT_B],
+      });
+    });
+
+    expect(mockAssertBaseline).toHaveBeenCalledTimes(1);
+    expect(mockAssertBaseline).toHaveBeenCalledWith(
+      [VAULT_A, VAULT_B],
+      [VAULT_A, VAULT_B],
+    );
+    expect(mockReorderVaultOrder).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call the baseline check on the banner CTA path (no expectedCurrentVaultIds)", async () => {
+    const { result } = renderHook(() => useReorderVaults());
+
+    await act(async () => {
+      await result.current.executeReorder([VAULT_A, VAULT_B]);
+    });
+
+    expect(mockAssertBaseline).not.toHaveBeenCalled();
+    expect(mockReorderVaultOrder).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocks the reorder tx and surfaces PositionChangedError unwrapped when the baseline differs", async () => {
+    const positionChangedError = new FakePositionChangedError(
+      "collateral order changed",
+    );
+    mockAssertBaseline.mockImplementation(() => {
+      throw positionChangedError;
+    });
+
+    const { result } = renderHook(() => useReorderVaults());
+
+    let resolved: boolean | undefined;
+    await act(async () => {
+      resolved = await result.current.executeReorder([VAULT_B, VAULT_A], {
+        expectedCurrentVaultIds: [VAULT_A, VAULT_B],
+      });
+    });
+
+    expect(resolved).toBe(false);
+    expect(mockReorderVaultOrder).not.toHaveBeenCalled();
+    expect(mockHandleError).toHaveBeenCalledTimes(1);
+    expect(mockHandleError.mock.calls[0][0].error).toBe(positionChangedError);
   });
 });

--- a/services/vault/src/applications/aave/hooks/useReorderVaults.ts
+++ b/services/vault/src/applications/aave/hooks/useReorderVaults.ts
@@ -20,6 +20,8 @@ import {
 
 import { getAaveAdapterAddress } from "../config";
 import {
+  PositionChangedError,
+  assertReorderBaseline,
   assertReorderMembership,
   assertSuggestedOrderMatchesOnChain,
   reorderVaultOrder,
@@ -34,6 +36,14 @@ export interface ExecuteReorderOptions {
    * drag-and-drop reorders omit this so users can pick non-optimal orders.
    */
   suggestedOrderContext?: ReorderVerificationContext;
+  /**
+   * The on-chain vault ordering the caller observed at the time it built
+   * the submission (e.g. the modal-open snapshot). When provided, the hook
+   * refuses to sign if the live ordering has drifted from this baseline
+   * — closes the same-set/different-order race the on-chain
+   * `InvalidVaultsPermutation` check cannot catch.
+   */
+  expectedCurrentVaultIds?: readonly Hex[];
 }
 
 export interface UseReorderVaultsResult {
@@ -90,6 +100,13 @@ export function useReorderVaults(): UseReorderVaultsResult {
           permutedVaultIds,
         );
 
+        if (options?.expectedCurrentVaultIds) {
+          assertReorderBaseline(
+            currentVaultIds,
+            options.expectedCurrentVaultIds,
+          );
+        }
+
         if (options?.suggestedOrderContext) {
           await assertSuggestedOrderMatchesOnChain(
             permutedVaultIds,
@@ -107,8 +124,13 @@ export function useReorderVaults(): UseReorderVaultsResult {
           error instanceof Error ? error : new Error(String(error)),
           { data: { context: "Reorder vaults failed" } },
         );
-        const mappedError =
-          error instanceof Error
+        // Surface a stale-baseline mismatch as its own user-facing error so
+        // the user understands they need to refresh, not retry. Retry with
+        // the same stale baseline cannot help.
+        const isPositionChanged = error instanceof PositionChangedError;
+        const mappedError = isPositionChanged
+          ? error
+          : error instanceof Error
             ? mapViemErrorToContractError(error, "Reorder Vaults")
             : new Error("An unexpected error occurred while reordering vaults");
 

--- a/services/vault/src/applications/aave/services/__tests__/assertReorderMatchesOnChain.test.ts
+++ b/services/vault/src/applications/aave/services/__tests__/assertReorderMatchesOnChain.test.ts
@@ -21,8 +21,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getBtcVaultBasicInfoFromChain } from "@/clients/eth-contract/btc-vault-registry/query";
 
 import {
+  PositionChangedError,
   ReorderMembershipMismatchError,
   SuggestedReorderMismatchError,
+  assertReorderBaseline,
   assertReorderMembership,
   assertSuggestedOrderMatchesOnChain,
   type ReorderVerificationContext,
@@ -375,5 +377,37 @@ describe("assertSuggestedOrderMatchesOnChain", () => {
         CONTEXT_BASE,
       ),
     ).rejects.toBeInstanceOf(SuggestedReorderMismatchError);
+  });
+});
+
+describe("assertReorderBaseline", () => {
+  it("resolves when live ordering equals the expected baseline", () => {
+    expect(() =>
+      assertReorderBaseline([VAULT_A, VAULT_B], [VAULT_A, VAULT_B]),
+    ).not.toThrow();
+  });
+
+  it("matches case-insensitively on the bytes32 hex", () => {
+    expect(() =>
+      assertReorderBaseline(
+        [VAULT_A.toLowerCase() as Hex, VAULT_B.toUpperCase() as Hex],
+        [VAULT_A.toUpperCase() as Hex, VAULT_B.toLowerCase() as Hex],
+      ),
+    ).not.toThrow();
+  });
+
+  it("throws PositionChangedError on same-set/different-order — the #262 PoC", () => {
+    // User opened modal at [A, B]. Live ordering raced to [B, A]. The
+    // multiset still matches (Guard A would pass), but the order
+    // differs — Guard C must catch it.
+    expect(() =>
+      assertReorderBaseline([VAULT_B, VAULT_A], [VAULT_A, VAULT_B]),
+    ).toThrow(PositionChangedError);
+  });
+
+  it("throws PositionChangedError when lengths differ", () => {
+    expect(() => assertReorderBaseline([VAULT_A], [VAULT_A, VAULT_B])).toThrow(
+      PositionChangedError,
+    );
   });
 });

--- a/services/vault/src/applications/aave/services/__tests__/assertReorderMatchesOnChain.test.ts
+++ b/services/vault/src/applications/aave/services/__tests__/assertReorderMatchesOnChain.test.ts
@@ -396,7 +396,7 @@ describe("assertReorderBaseline", () => {
     ).not.toThrow();
   });
 
-  it("throws PositionChangedError on same-set/different-order — the #262 PoC", () => {
+  it("throws PositionChangedError on same-set/different-order (concurrent-modification race)", () => {
     // User opened modal at [A, B]. Live ordering raced to [B, A]. The
     // multiset still matches (Guard A would pass), but the order
     // differs — Guard C must catch it.

--- a/services/vault/src/applications/aave/services/assertReorderMatchesOnChain.ts
+++ b/services/vault/src/applications/aave/services/assertReorderMatchesOnChain.ts
@@ -44,6 +44,10 @@ export class SuggestedReorderMismatchError extends Error {
   readonly code = "SUGGESTED_REORDER_MISMATCH";
 }
 
+export class PositionChangedError extends Error {
+  readonly code = "POSITION_CHANGED_REFRESH_REQUIRED";
+}
+
 /**
  * Trusted calculator inputs for the suggested-order recompute. All values
  * must be on-chain-anchored — the whole point of the guard is to refuse
@@ -221,6 +225,44 @@ export async function assertSuggestedOrderMatchesOnChain(
   if (!sameOrderedSequence(submittedVaultIds, expectedOrder)) {
     throw new SuggestedReorderMismatchError(
       "Suggested reorder does not match the calculator's output under on-chain amounts. Aborting to avoid signing an indexer-steered permutation.",
+    );
+  }
+}
+
+/**
+ * Guard C — verify the live on-chain vault ordering still matches the
+ * caller's modal-open baseline.
+ *
+ * The drag-and-drop reorder modal snapshots the indexer-derived vault
+ * list when it opens (so the user's drag state isn't stomped by
+ * background refetches). If live state changes while the modal is open
+ * — sibling-tab confirm, position-manager action, partial liquidation —
+ * the signed `bytes32[]` can still be a valid permutation of the live
+ * multiset and silently overwrites the new on-chain order with the
+ * stale one. The on-chain `InvalidVaultsPermutation` check is
+ * multiset-only and `eth_call` simulates the already-built calldata,
+ * so neither catches this.
+ *
+ * This guard is a pure function over the live ordering already returned
+ * by {@link assertReorderMembership}, so the modal path does not pay an
+ * extra `getPosition` RPC for the check.
+ *
+ * @param liveVaultIds - Ordering returned by
+ *   `AaveIntegrationAdapter.getPosition(user).vaultIds` — typically the
+ *   value `assertReorderMembership` just returned.
+ * @param expectedCurrentVaultIds - The vault order the caller believes
+ *   is live (e.g. the modal-open snapshot the user reviewed before
+ *   dragging).
+ * @throws {PositionChangedError} when the two orderings disagree in
+ *   length or strict order (case-insensitive on the bytes32 hex).
+ */
+export function assertReorderBaseline(
+  liveVaultIds: readonly Hex[],
+  expectedCurrentVaultIds: readonly Hex[],
+): void {
+  if (!sameOrderedSequence(liveVaultIds, expectedCurrentVaultIds)) {
+    throw new PositionChangedError(
+      "Your collateral order changed since you opened this dialog. Close it, review the refreshed order, and try again.",
     );
   }
 }

--- a/services/vault/src/applications/aave/services/index.ts
+++ b/services/vault/src/applications/aave/services/index.ts
@@ -58,8 +58,10 @@ export {
 
 // On-chain integrity guards
 export {
+  PositionChangedError,
   ReorderMembershipMismatchError,
   SuggestedReorderMismatchError,
+  assertReorderBaseline,
   assertReorderMembership,
   assertSuggestedOrderMatchesOnChain,
   type ReorderVerificationContext,

--- a/services/vault/src/components/simple/ReorderVaults/__tests__/useReorderModal.test.tsx
+++ b/services/vault/src/components/simple/ReorderVaults/__tests__/useReorderModal.test.tsx
@@ -1,0 +1,141 @@
+/**
+ * Tests for useReorderModal — verifies the modal-open baseline is
+ * captured, preserved across drag, and threaded into executeReorder so
+ * the signing-time guard can detect concurrent live-state changes.
+ */
+
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { CollateralVaultEntry } from "@/types/collateral";
+
+const mockExecuteReorder = vi.fn();
+vi.mock("@/applications/aave/hooks", () => ({
+  useReorderVaults: () => ({
+    executeReorder: mockExecuteReorder,
+    isProcessing: false,
+  }),
+}));
+
+import { useReorderModal } from "../useReorderModal";
+
+const VAULT_A_ID =
+  "0xaaaa000000000000000000000000000000000000000000000000000000000001";
+const VAULT_B_ID =
+  "0xbbbb000000000000000000000000000000000000000000000000000000000002";
+const VAULT_C_ID =
+  "0xcccc000000000000000000000000000000000000000000000000000000000003";
+
+function makeVault(
+  id: string,
+  vaultId: string,
+  liquidationIndex: number,
+): CollateralVaultEntry {
+  return {
+    id,
+    vaultId,
+    amountBtc: 0.5,
+    addedAt: 0,
+    inUse: true,
+    providerAddress: "0xprovider",
+    providerName: "Test VP",
+    liquidationIndex,
+  };
+}
+
+const VAULT_A = makeVault("a", VAULT_A_ID, 0);
+const VAULT_B = makeVault("b", VAULT_B_ID, 1);
+const VAULT_C = makeVault("c", VAULT_C_ID, 2);
+
+describe("useReorderModal — baseline capture for the #262 guard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExecuteReorder.mockResolvedValue(true);
+  });
+
+  it("forwards the modal-open baseline unchanged after the user drags", async () => {
+    const { result } = renderHook(
+      ({
+        vaults,
+        isOpen,
+      }: {
+        vaults: CollateralVaultEntry[];
+        isOpen: boolean;
+      }) => useReorderModal({ vaults, isOpen }),
+      { initialProps: { vaults: [VAULT_A, VAULT_B], isOpen: true } },
+    );
+
+    // Simulate a drag: swap A and B in the user's ordered list.
+    act(() => {
+      result.current.handleDragEnd({
+        active: { id: "a" },
+        over: { id: "b" },
+      } as unknown as Parameters<typeof result.current.handleDragEnd>[0]);
+    });
+
+    await act(async () => {
+      await result.current.handleConfirm();
+    });
+
+    expect(mockExecuteReorder).toHaveBeenCalledTimes(1);
+    const [submittedIds, options] = mockExecuteReorder.mock.calls[0];
+    expect(submittedIds).toEqual([VAULT_B_ID, VAULT_A_ID]);
+    expect(options).toEqual({
+      expectedCurrentVaultIds: [VAULT_A_ID, VAULT_B_ID],
+    });
+  });
+
+  it("does not update the baseline when `vaults` prop changes while the modal stays open", async () => {
+    // Indexer refetch produces a different list while modal is open.
+    // The baseline must NOT follow it — it represents what the user
+    // reviewed at modal-open.
+    const { result, rerender } = renderHook(
+      ({
+        vaults,
+        isOpen,
+      }: {
+        vaults: CollateralVaultEntry[];
+        isOpen: boolean;
+      }) => useReorderModal({ vaults, isOpen }),
+      { initialProps: { vaults: [VAULT_A, VAULT_B], isOpen: true } },
+    );
+
+    rerender({ vaults: [VAULT_C, VAULT_A, VAULT_B], isOpen: true });
+
+    await act(async () => {
+      await result.current.handleConfirm();
+    });
+
+    const [, options] = mockExecuteReorder.mock.calls[0];
+    expect(options).toEqual({
+      expectedCurrentVaultIds: [VAULT_A_ID, VAULT_B_ID],
+    });
+  });
+
+  it("re-snapshots the baseline when the modal closes and reopens", async () => {
+    const { result, rerender } = renderHook(
+      ({
+        vaults,
+        isOpen,
+      }: {
+        vaults: CollateralVaultEntry[];
+        isOpen: boolean;
+      }) => useReorderModal({ vaults, isOpen }),
+      { initialProps: { vaults: [VAULT_A, VAULT_B], isOpen: true } },
+    );
+
+    // Close.
+    rerender({ vaults: [VAULT_A, VAULT_B], isOpen: false });
+    // Reopen with a different vault set.
+    rerender({ vaults: [VAULT_C, VAULT_A], isOpen: true });
+
+    await act(async () => {
+      await result.current.handleConfirm();
+    });
+
+    const [, options] = mockExecuteReorder.mock.calls[0];
+    expect(options).toEqual({
+      expectedCurrentVaultIds: [VAULT_C_ID, VAULT_A_ID],
+    });
+  });
+});

--- a/services/vault/src/components/simple/ReorderVaults/__tests__/useReorderModal.test.tsx
+++ b/services/vault/src/components/simple/ReorderVaults/__tests__/useReorderModal.test.tsx
@@ -47,7 +47,7 @@ const VAULT_A = makeVault("a", VAULT_A_ID, 0);
 const VAULT_B = makeVault("b", VAULT_B_ID, 1);
 const VAULT_C = makeVault("c", VAULT_C_ID, 2);
 
-describe("useReorderModal — baseline capture for the #262 guard", () => {
+describe("useReorderModal — baseline capture for the signing-time staleness guard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockExecuteReorder.mockResolvedValue(true);

--- a/services/vault/src/components/simple/ReorderVaults/useReorderModal.ts
+++ b/services/vault/src/components/simple/ReorderVaults/useReorderModal.ts
@@ -25,6 +25,13 @@ export function useReorderModal({
 }: UseReorderModalParams): UseReorderModalResult {
   const [orderedVaults, setOrderedVaults] =
     useState<CollateralVaultEntry[]>(vaults);
+  // The vault ordering the user reviewed at modal open. Drag mutations
+  // only touch `orderedVaults`; this baseline stays put so the signing
+  // guard can detect concurrent live-state changes during the user's
+  // think-time.
+  const [baselineVaultIds, setBaselineVaultIds] = useState<readonly Hex[]>(() =>
+    vaults.map((v) => v.vaultId as Hex),
+  );
   const { executeReorder, isProcessing } = useReorderVaults();
 
   // Initialize order only when modal opens — intentionally excludes `vaults`
@@ -32,6 +39,7 @@ export function useReorderModal({
   useEffect(() => {
     if (isOpen) {
       setOrderedVaults(vaults);
+      setBaselineVaultIds(vaults.map((v) => v.vaultId as Hex));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen]);
@@ -54,8 +62,10 @@ export function useReorderModal({
 
   const handleConfirm = useCallback(async () => {
     const permutedVaultIds = orderedVaults.map((v) => v.vaultId as Hex);
-    return executeReorder(permutedVaultIds);
-  }, [orderedVaults, executeReorder]);
+    return executeReorder(permutedVaultIds, {
+      expectedCurrentVaultIds: baselineVaultIds,
+    });
+  }, [orderedVaults, baselineVaultIds, executeReorder]);
 
   return {
     orderedVaults,


### PR DESCRIPTION
## What's the problem?

The manual drag-and-drop reorder modal in `useReorderModal` deliberately snapshots the indexer-derived collateral list **once when the modal opens** and ignores later background refetches. That snapshot exists so a React Query refresh doesn't stomp the user's drag state — but it's also what gets encoded directly into the signed `reorderVaults(bytes32[])` calldata at confirmation time.

If anything changes the on-chain vault order **while the modal is open** — a sibling tab confirming another reorder, a position-manager action, a partial liquidation — the user signs a `bytes32[]` that's still a valid **permutation of the live multiset**. The on-chain `InvalidVaultsPermutation` check is multiset-only, so the contract accepts it. The pre-flight `eth_call` just simulates the already-built calldata, so it doesn't catch this either. Result: the user silently restores an obsolete liquidation prefix, potentially putting a vault they thought they had protected back into the first-seized group.

This is the exact race described in [audit #262](https://github.com/babylonlabs-io/baby-auditor-findings/issues/262), and it is **not** closed by [PR #1663](https://github.com/babylonlabs-io/babylon-toolkit/pull/1663) ([audit #155](https://github.com/babylonlabs-io/baby-auditor-findings/issues/155)). The Guard A added in [#1663](https://github.com/babylonlabs-io/babylon-toolkit/pull/1663) catches **multiset** drift — if a vault is added or removed during the user's think-time, Guard A rejects. But same-set/different-order drift (the [#262](https://github.com/babylonlabs-io/baby-auditor-findings/issues/262) PoC) sails through.

## What does this PR do?

Adds a third reorder guard — call it **Guard C** — that closes the order-drift race for the manual modal path. The guard fails closed before the wallet prompt fires; if it triggers, the user sees a typed refresh-required message and no signature is requested.

### How it works

1. **The modal captures a baseline at open time.** Alongside the existing `orderedVaults` snapshot (which drag mutates), the hook now also captures `baselineVaultIds` from `vaults.map(v => v.vaultId)`. Both states are set inside the same `useEffect([isOpen])`, so they only refresh on modal open/close — drag mutations only touch `orderedVaults`, baseline stays put.
2. **On confirm, the baseline is threaded through `executeReorder`.** New optional field on `ExecuteReorderOptions`: `expectedCurrentVaultIds: readonly Hex[]`.
3. **The hook re-uses Guard A's `getPosition` RPC.** Guard A (`assertReorderMembership`) already calls `AaveIntegrationAdapter.getPosition(user)` on every reorder and returns the live on-chain ordering. The new Guard C is a **pure function** consuming that return value — no second RPC, no extra latency, no widened blast radius.
4. **Guard C asserts strict-ordered equality against the baseline.** If live ordering differs from what the user reviewed at open time, it throws a typed `PositionChangedError`.
5. **The error is surfaced unwrapped.** Mirroring how `useBorrowTransaction` handles `ReserveMismatchError`, the hook's `catch` passes `PositionChangedError` through directly instead of mapping it to a generic contract error. The user sees "Your collateral order changed since you opened this dialog. Close it, review the refreshed order, and try again." Retry is suppressed implicitly because retrying with the same stale baseline can't help.

### Why a pure function instead of a second `getPosition` RPC

The simpler shape would be a self-contained `assertReorderBaseline` that calls `getPosition` itself. That works, but it also doubles the RPC count on every modal reorder — Guard A from [#1663](https://github.com/babylonlabs-io/babylon-toolkit/pull/1663) already reads `getPosition` and now returns the live ordering. Making Guard C a pure function over that return value gets the same protection with no duplicate read.

The banner "Apply Suggested Order" path is **not** changed by this PR — it doesn't pass `expectedCurrentVaultIds`, so Guard C is a no-op there. That CTA path is the subject of [audit #155](https://github.com/babylonlabs-io/baby-auditor-findings/issues/155) (mostly closed by Guard B's calculator recompute) and [audit #263](https://github.com/babylonlabs-io/baby-auditor-findings/issues/263) (display-side staleness).

## How the audit's exploit attempt now fails

| Step | What happens |
|---|---|
| User opens modal at live order `[A, B, C]` | Hook captures `baselineVaultIds = [A, B, C]` |
| Sibling tab confirms a reorder; live becomes `[C, B, A]` | Modal state unchanged; the user is still looking at the stale `[A, B, C]` |
| User drags to `[B, A, C]` and clicks Confirm | `handleConfirm` calls `executeReorder([B, A, C], { expectedCurrentVaultIds: [A, B, C] })` |
| Guard A (`assertReorderMembership`) | live multiset `{A, B, C}` == submitted multiset → passes, returns live order `[C, B, A]` |
| Guard C (`assertReorderBaseline`) | strict-ordered compare: `[C, B, A]` vs baseline `[A, B, C]` → **mismatch → throws `PositionChangedError`** |
| `reorderVaultOrder` | never called |
| User UI | typed error modal: "Your collateral order changed since you opened this dialog. Close it, review the refreshed order, and try again." |

## Branching and rebase

This PR is currently based on the `fix/155-indexer-supplied-collateral` branch ([PR #1663](https://github.com/babylonlabs-io/babylon-toolkit/pull/1663)) because Guard C reuses Guard A's typed reorder primitives from that PR. After [#1663](https://github.com/babylonlabs-io/babylon-toolkit/pull/1663) merges to `main`, this branch will be rebased onto `main` — the diff is purely additive in files [#1663](https://github.com/babylonlabs-io/babylon-toolkit/pull/1663) also touches, so the rebase should be clean and produce a single signed commit.

## Out of scope / known caveats

1. **Banner "Apply Suggested Order" path is not changed.** That path's stale-display surface is the subject of [audit #155](https://github.com/babylonlabs-io/baby-auditor-findings/issues/155) (closed by Guard B's calculator recompute) and [audit #263](https://github.com/babylonlabs-io/baby-auditor-findings/issues/263) (display-side liveness). Adding the baseline guard there would not help — the banner doesn't have a "user-reviewed snapshot" the way the manual modal does; it derives the suggestion from the same display data it just rendered.

2. **Read-then-include race remains.** A frontend live read can't fully eliminate the window between the guard's `eth_call` and the tx being included in a block. Fully closing that gap would require contract-side compare-and-swap support. This PR materially closes the modal-open-to-confirm window the audit specifically describes — the residual window is unaddressable from the dApp.

3. **Same-multiset reorders that are still optimal under the live state are also blocked.** If live `[A, B, C]` and the user happened to be opening to confirm the exact same state, the multiset / order comparison treats any drift as drift even if the user's intent happens to still be valid. This is correct fail-closed behavior: it forces the user to confirm against the refreshed display rather than signing against stale assumptions. The dApp can't know whether the user would still endorse the same action after seeing the new state.

Closes https://github.com/babylonlabs-io/baby-auditor-findings/issues/262
