### PR TITLE
fix(vault): force urgent banner from live health factor

### DIFF
--- a/services/vault/src/applications/aave/hooks/__tests__/usePositionNotifications.test.tsx
+++ b/services/vault/src/applications/aave/hooks/__tests__/usePositionNotifications.test.tsx
@@ -1,0 +1,170 @@
+/**
+ * Tests for usePositionNotifications — verifies the live-HF urgency
+ * guardrail layered on top of the calculator output.
+ */
+
+import { renderHook } from "@testing-library/react";
+import type { Hex } from "viem";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { CollateralVaultEntry } from "@/types/collateral";
+
+const mockUseDashboardState = vi.fn();
+vi.mock("@/hooks/useDashboardState", () => ({
+  useDashboardState: (...args: unknown[]) => mockUseDashboardState(...args),
+}));
+
+const mockUsePrices = vi.fn();
+vi.mock("@/hooks/usePrices", () => ({
+  usePrices: (...args: unknown[]) => mockUsePrices(...args),
+}));
+
+const mockUseVaultSplitParams = vi.fn();
+vi.mock("../useVaultSplitParams", () => ({
+  useVaultSplitParams: (...args: unknown[]) => mockUseVaultSplitParams(...args),
+}));
+
+import { usePositionNotifications } from "../usePositionNotifications";
+
+const VAULT_A =
+  "0xaaaa000000000000000000000000000000000000000000000000000000000001" as Hex;
+const VAULT_B =
+  "0xbbbb000000000000000000000000000000000000000000000000000000000002" as Hex;
+
+const USER = "0xuser" as const;
+
+function makeVault(
+  vaultId: Hex,
+  amountBtc: number,
+  liquidationIndex: number,
+): CollateralVaultEntry {
+  return {
+    id: vaultId,
+    vaultId,
+    amountBtc,
+    addedAt: 0,
+    inUse: true,
+    providerAddress: "0xprovider",
+    providerName: "Test VP",
+    liquidationIndex,
+  };
+}
+
+interface DashboardStateOverrides {
+  collateralVaults?: CollateralVaultEntry[];
+  debtValueUsd?: number;
+  healthFactor?: number | null;
+  isLoading?: boolean;
+}
+
+function setDashboardState(overrides: DashboardStateOverrides = {}) {
+  mockUseDashboardState.mockReturnValue({
+    collateralVaults: overrides.collateralVaults ?? [
+      makeVault(VAULT_A, 0.5, 0),
+      makeVault(VAULT_B, 0.5, 1),
+    ],
+    debtValueUsd: overrides.debtValueUsd ?? 30_000,
+    healthFactor: overrides.healthFactor ?? 2.0,
+    isLoading: overrides.isLoading ?? false,
+  });
+}
+
+function setHappyPrices() {
+  mockUsePrices.mockReturnValue({
+    prices: { BTC: 60_000 },
+    metadata: { BTC: { isStale: false, fetchFailed: false } },
+  });
+}
+
+function setHappySplitParams() {
+  mockUseVaultSplitParams.mockReturnValue({
+    params: { CF: 0.7, THF: 1.1, LB: 1.05 },
+    isLoading: false,
+  });
+}
+
+describe("usePositionNotifications — live-HF urgency guardrail", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setHappyPrices();
+    setHappySplitParams();
+  });
+
+  it("forces an urgent warning when live HF is below 1.0", () => {
+    setDashboardState({
+      collateralVaults: [makeVault(VAULT_A, 1.0, 0)],
+      // Tiny debt → calculator alone would not flag urgent.
+      debtValueUsd: 100,
+      healthFactor: 0.95,
+    });
+
+    const { result } = renderHook(() => usePositionNotifications(USER));
+
+    expect(result.current.status).toBe("ready");
+    expect(
+      result.current.result?.warnings.some((w) => w.type === "urgent"),
+    ).toBe(true);
+  });
+
+  it("forces an urgent warning when live HF is at the 1.05 threshold", () => {
+    setDashboardState({
+      collateralVaults: [makeVault(VAULT_A, 1.0, 0)],
+      debtValueUsd: 100,
+      healthFactor: 1.05,
+    });
+
+    const { result } = renderHook(() => usePositionNotifications(USER));
+
+    expect(
+      result.current.result?.warnings.some((w) => w.type === "urgent"),
+    ).toBe(true);
+  });
+
+  it("does not duplicate the urgent warning when the calculator already produced one", () => {
+    // Large debt → calculator's own URGENT_DISTANCE_PCT rule fires.
+    setDashboardState({
+      collateralVaults: [makeVault(VAULT_A, 1.0, 0)],
+      debtValueUsd: 40_000,
+      healthFactor: 1.0,
+    });
+
+    const { result } = renderHook(() => usePositionNotifications(USER));
+
+    const urgentCount =
+      result.current.result?.warnings.filter((w) => w.type === "urgent")
+        .length ?? 0;
+    expect(urgentCount).toBe(1);
+  });
+
+  it("does not force urgent for a healthy live HF", () => {
+    setDashboardState({
+      collateralVaults: [makeVault(VAULT_A, 1.0, 0)],
+      debtValueUsd: 100,
+      healthFactor: 2.0,
+    });
+
+    const { result } = renderHook(() => usePositionNotifications(USER));
+
+    expect(
+      result.current.result?.warnings.some((w) => w.type === "urgent"),
+    ).toBe(false);
+  });
+
+  it("returns ready with no spurious warnings when HF is healthy", () => {
+    setDashboardState({
+      collateralVaults: [
+        makeVault(VAULT_A, 0.5, 0),
+        makeVault(VAULT_B, 0.5, 1),
+      ],
+      debtValueUsd: 100,
+      healthFactor: 5.0,
+    });
+
+    const { result } = renderHook(() => usePositionNotifications(USER));
+
+    expect(result.current.status).toBe("ready");
+    expect(
+      result.current.result?.warnings.some((w) => w.type === "urgent"),
+    ).toBe(false);
+  });
+});

--- a/services/vault/src/applications/aave/hooks/usePositionNotifications.ts
+++ b/services/vault/src/applications/aave/hooks/usePositionNotifications.ts
@@ -7,6 +7,7 @@ import {
   calculate,
   type CalculatorResult,
   type Vault,
+  type Warning,
 } from "../positionNotifications";
 import type { ReorderVerificationContext } from "../services";
 
@@ -32,6 +33,28 @@ export interface UsePositionNotificationsResult {
   reorderVerificationContext: ReorderVerificationContext | null;
 }
 
+/**
+ * Health-factor threshold at which the live-HF guardrail forces an
+ * `urgent` warning into the calculator result.
+ *
+ * Aligned with the calculator's own `URGENT_DISTANCE_PCT = 5%` rule —
+ * a position whose live oracle health factor sits at or below 1.05 is
+ * within the same band the calculator already considers urgent, so we
+ * surface the warning even when stale indexed data inflated `totalBtc`
+ * enough to suppress it.
+ */
+const LIVE_HF_URGENT_THRESHOLD = 1.05;
+
+function buildLiveHfUrgentWarning(healthFactor: number): Warning {
+  return {
+    type: "urgent",
+    title: `Critical — health factor ${healthFactor.toFixed(2)}`,
+    detail: `On-chain health factor is at or below ${LIVE_HF_URGENT_THRESHOLD.toFixed(2)}. The position can be liquidated at the current price.`,
+    suggestion:
+      "Add collateral or repay part of the debt to restore a safe Health Factor.",
+  };
+}
+
 export function usePositionNotifications(
   connectedAddress: string | undefined,
 ): UsePositionNotificationsResult {
@@ -41,6 +64,7 @@ export function usePositionNotifications(
   const {
     collateralVaults,
     debtValueUsd,
+    healthFactor,
     isLoading: dashboardLoading,
   } = useDashboardState(connectedAddress);
 
@@ -92,15 +116,39 @@ export function usePositionNotifications(
       name: `Vault ${entry.liquidationIndex + 1}`,
     }));
 
+    const calculatorResult = calculate({
+      btcPrice,
+      totalDebtUsd: debtValueUsd,
+      vaults,
+      CF: splitParams.CF,
+      THF: splitParams.THF,
+      maxLB: splitParams.LB,
+    });
+
+    // Live-HF urgency guardrail. Even when the calculator's own
+    // distance check did not surface urgent (e.g. because stale indexed
+    // rows inflated `totalBtc`), force one based on the on-chain
+    // oracle's health factor. Trigger window aligns with the
+    // calculator's `URGENT_DISTANCE_PCT`. No duplicate if the
+    // calculator already produced an `urgent` warning.
+    const hasUrgent = calculatorResult.warnings.some(
+      (w) => w.type === "urgent",
+    );
+    const resultWithLiveHf: CalculatorResult =
+      !hasUrgent &&
+      healthFactor !== null &&
+      healthFactor <= LIVE_HF_URGENT_THRESHOLD
+        ? {
+            ...calculatorResult,
+            warnings: [
+              buildLiveHfUrgentWarning(healthFactor),
+              ...calculatorResult.warnings,
+            ],
+          }
+        : calculatorResult;
+
     return {
-      result: calculate({
-        btcPrice,
-        totalDebtUsd: debtValueUsd,
-        vaults,
-        CF: splitParams.CF,
-        THF: splitParams.THF,
-        maxLB: splitParams.LB,
-      }),
+      result: resultWithLiveHf,
       status: "ready",
       reorderVerificationContext: {
         CF: splitParams.CF,
@@ -118,6 +166,7 @@ export function usePositionNotifications(
     btcMetadata,
     collateralVaults,
     debtValueUsd,
+    healthFactor,
   ]);
 
   return { result, status, isLoading, reorderVerificationContext };


### PR DESCRIPTION
## What's the problem?

The position-notification banner builds its liquidation simulation from `collateralVaults` — rows the dApp gets from the GraphQL indexer, sorted by `liquidationIndex`. That set drives the calculator's "how much debt before liquidation?" math. The only staleness gate today is on BTC price metadata; the position itself is trusted as-is.

After a liquidation, withdrawal, or reorder that on-chain state reflects before the indexer catches up, the simulation runs against a vault set that no longer exists. Stale rows inflate the simulated total BTC, so distance-to-liquidation looks safe and the banner can stay green while the live position is at or near liquidation. The user gets no urgent warning when in fact they're about to be liquidated.

This is one of the two harms [audit #263](https://github.com/babylonlabs-io/baby-auditor-findings/issues/263) describes. The other — *"Apply Suggested Order CTA targets a vault set that is no longer live"* — is already closed by the signing-time guards in [PR #1663](https://github.com/babylonlabs-io/babylon-toolkit/pull/1663) (multiset rebind against the env-pinned adapter) and [PR #1664](https://github.com/babylonlabs-io/babylon-toolkit/pull/1664) (strict-order baseline rebind on the manual reorder modal). A stale CTA cannot be broadcast against a stale set; the contract enforces `InvalidVaultsPermutation`; the signing-time guards fail closed before any wallet prompt fires. This PR therefore focuses on the remaining display-side harm only.

## What does this PR do?

Adds a single guardrail in `usePositionNotifications`: a **live health-factor urgency override**.

After the calculator runs, the hook inspects `accountData.healthFactor` — which is already fetched per refresh via the on-chain Aave Spoke RPC, no new RPC traffic added. When the live health factor is at or below `LIVE_HF_URGENT_THRESHOLD` (1.05), an `urgent` warning is injected into the calculator result. If the calculator already produced an `urgent` warning of its own (its `URGENT_DISTANCE_PCT = 5%` rule), no duplicate is added. The `1.05` threshold aligns with that calculator rule so the override fires inside the same band the calculator would have, regardless of whether stale indexer rows inflated `totalBtc` enough to suppress the calculator's own check.

Net effect: even when stale indexer data makes the simulated position look safe, the banner is forced red whenever the on-chain oracle says the position is within liquidation range. The user is warned even if the displayed numbers are wrong.

## What changed (files)

- [services/vault/src/applications/aave/hooks/usePositionNotifications.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/services/vault/src/applications/aave/hooks/usePositionNotifications.ts) — adds `LIVE_HF_URGENT_THRESHOLD`, `buildLiveHfUrgentWarning(...)`, and the conditional `urgent`-warning injection at the end of the calculator-success branch. Consumes `healthFactor` from `useDashboardState` (already exposed pre-existing — no new plumbing).
- [services/vault/src/applications/aave/hooks/\_\_tests\_\_/usePositionNotifications.test.tsx](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/services/vault/src/applications/aave/hooks/__tests__/usePositionNotifications.test.tsx) (new) — 5 tests covering the threshold band, no-duplicate-when-calculator-already-urgent, healthy-HF no-op, and a clean-state regression.

That's it. No new RPC, no service-layer changes, no banner-status additions, no debug-panel updates, no signing-path changes.

## Why this is enough for [audit #263](https://github.com/babylonlabs-io/baby-auditor-findings/issues/263)

The audit's two stated harms map cleanly onto two existing defenses:

| Harm | Defense |
|---|---|
| Banner can stay green while live position is at or near liquidation | **This PR** — live-HF urgency override always fires when on-chain HF ≤ 1.05, regardless of what the calculator saw |
| "Apply Suggested Order" CTA targets a non-live vault set | [#1663](https://github.com/babylonlabs-io/babylon-toolkit/pull/1663) Guard A (multiset rebind) + [#1664](https://github.com/babylonlabs-io/babylon-toolkit/pull/1664) Guard C (strict-order baseline) at signing time. A stale CTA cannot consummate. |

The literal text of [audit #263](https://github.com/babylonlabs-io/baby-auditor-findings/issues/263) also suggests a display-layer membership gate (read live vault IDs via `AaveIntegrationAdapter.getPosition(user)` and refuse to render based on stale collateral). An earlier draft of this PR implemented that, and it was reviewed off in favor of the consequence-layer signing guards already in place — see the discussion on this PR. The signing-time defense closes the actual harm; an additional dashboard-layer read would have paid RPC cost on every position refresh purely to suppress a stale CTA that the chain would have rejected anyway.

## Out of scope / known caveats

1. **No display-layer membership comparison.** A compromised or lagging indexer can still surface a misleading reorder CTA. The CTA *cannot* execute against a stale set — that's the job of the signing-time guards in [#1663](https://github.com/babylonlabs-io/babylon-toolkit/pull/1663) / [#1664](https://github.com/babylonlabs-io/babylon-toolkit/pull/1664). Users in that situation will click, get a typed signing-time error, refetch, and retry. UX is briefly confusing but no funds move.
2. **The forced-urgent warning only fires when `healthFactor !== null`.** That aligns with `borrowCount > 0n` — without debt, HF is `Infinity` and there's no liquidation to warn about.

Closes https://github.com/babylonlabs-io/baby-auditor-findings/issues/263
