### PR TITLE
refactor(vault): import stripHexPrefix from SDK directly

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,12 +46,13 @@ These paths handle irreversible value movement. An AI-generated mistake here is 
 - Both systems must agree before broadcast. A mismatch underfunds the transaction.
 - **Rule:** When changing either, re-verify the other produces the same fee for a representative fixture. Cross-check assertions belong at the broadcast site, not only at the estimator.
 
-### 3. Presigning payout transactions
+### 3. Presigning depositor-graph transactions (Payout + NoPayout)
 - Files:
   - `packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts`
+  - `packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts` — orchestrator that derives `LocalChallengers`, asserts the VP-returned `challenger_presign_data` set equals `local ∪ universal`, and decides which per-challenger NoPayout PSBTs get pre-signed
   - `services/vault/src/hooks/deposit/depositFlowSteps/payoutSigning.ts`
-- The depositor pre-signs payout transactions built by the Vault Provider - values come from an external party with no independent verification.
-- **Rule:** Before the signature call, re-derive the expected payout amount from on-chain or WASM-computed sources and assert equality. Never sign a value handed to us verbatim.
+- The depositor pre-signs payout (and per-challenger NoPayout) transactions built by the Vault Provider — values and challenger sets come from an external party with no independent verification. Asymmetric failure: undersigning leaves recovery material missing for an active challenger; oversigning hands signatures to a key the protocol doesn't recognize.
+- **Rule:** Before the signature call, re-derive the expected payout amount from on-chain or WASM-computed sources and assert equality. For the challenger set, derive `LocalChallengers` from on-chain VK list (matching the Rust reference in `btc-vault crates/vault/src/tx_graph/graph.rs`) and assert the VP-returned set equals `local ∪ universal` exactly — no missing entries, no extras. Never sign a value or accept a challenger key handed to us verbatim.
 
 ### 4. Vault-secret derivation (frozen on-chain-binding API)
 - Files (all marked `@stability frozen` in JSDoc):

--- a/services/vault/src/components/deposit/PayoutSignModal/usePayoutSigningState.ts
+++ b/services/vault/src/components/deposit/PayoutSignModal/usePayoutSigningState.ts
@@ -6,6 +6,7 @@
  * only the React state, guard checks, and optimistic localStorage updates.
  */
 
+import { stripHexPrefix } from "@babylonlabs-io/ts-sdk/tbv/core";
 import { useChainConnector } from "@babylonlabs-io/wallet-connector";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { Hex } from "viem";
@@ -15,10 +16,7 @@ import { signAndSubmitPayouts } from "../../../hooks/deposit/depositFlowSteps/pa
 import { useVaultProviders } from "../../../hooks/deposit/useVaultProviders";
 import { LocalStorageStatus } from "../../../models/peginStateMachine";
 import type { VaultActivity } from "../../../types/activity";
-import {
-  btcAddressToScriptPubKeyHex,
-  stripHexPrefix,
-} from "../../../utils/btc";
+import { btcAddressToScriptPubKeyHex } from "../../../utils/btc";
 import { formatPayoutSignatureError } from "../../../utils/errors/formatting";
 
 import type { SigningProgressProps } from "./SigningProgress";

--- a/services/vault/src/components/shared/CopyableHash.tsx
+++ b/services/vault/src/components/shared/CopyableHash.tsx
@@ -7,9 +7,9 @@
  */
 
 import { CheckIcon, CopyIcon, useCopy } from "@babylonlabs-io/core-ui";
+import { stripHexPrefix } from "@babylonlabs-io/ts-sdk/tbv/core";
 
 import { truncateHash } from "@/utils/addressUtils";
-import { stripHexPrefix } from "@/utils/btc";
 
 const COPY_ICON_SIZE = 14;
 

--- a/services/vault/src/components/simple/ResumeDepositContent.tsx
+++ b/services/vault/src/components/simple/ResumeDepositContent.tsx
@@ -19,6 +19,7 @@ import {
   hexToUint8Array,
   isWotsMismatchError,
   parseFundingOutpointsFromTx,
+  stripHexPrefix,
   uint8ArrayToHex,
 } from "@babylonlabs-io/ts-sdk/tbv/core";
 import { primeVpTokenRegistry } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
@@ -38,7 +39,6 @@ import { useReleaseVpTokenOnUnmount } from "@/hooks/deposit/useReleaseVpTokenOnU
 import { useRunOnce } from "@/hooks/useRunOnce";
 import { logger } from "@/infrastructure";
 import type { VaultActivity } from "@/types/activity";
-import { stripHexPrefix } from "@/utils/btc";
 import { getVpProxyUrl } from "@/utils/rpc";
 
 import { DepositProgressView } from "./DepositProgressView";

--- a/services/vault/src/components/simple/__tests__/ResumeDepositContent.test.tsx
+++ b/services/vault/src/components/simple/__tests__/ResumeDepositContent.test.tsx
@@ -35,6 +35,7 @@ vi.mock("@babylonlabs-io/ts-sdk/tbv/core", () => ({
   hexToUint8Array: vi.fn(() => new Uint8Array(32)),
   isWotsMismatchError: vi.fn(() => false),
   parseFundingOutpointsFromTx: mockParseFundingOutpointsFromTx,
+  stripHexPrefix: vi.fn((hex: string) => hex.replace(/^0x/, "")),
   uint8ArrayToHex: vi.fn(() => "00".repeat(32)),
 }));
 
@@ -113,10 +114,6 @@ vi.mock("@/hooks/deposit/useReleaseVpTokenOnUnmount", () => ({
 
 vi.mock("@/infrastructure", () => ({
   logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn() },
-}));
-
-vi.mock("@/utils/btc", () => ({
-  stripHexPrefix: vi.fn((hex: string) => hex.replace(/^0x/, "")),
 }));
 
 vi.mock("@/utils/rpc", () => ({

--- a/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
+++ b/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
@@ -91,10 +91,6 @@ vi.mock("@/services/vault/vaultPeginBroadcastService", () => ({
   utxosToExpectedRecord: vi.fn(() => ({})),
 }));
 
-vi.mock("@/utils/btc", () => ({
-  stripHexPrefix: vi.fn((hex: string) => hex.replace("0x", "")),
-}));
-
 vi.mock("@/models/peginStateMachine", async (importOriginal) => {
   const actual =
     await importOriginal<typeof import("@/models/peginStateMachine")>();

--- a/services/vault/src/hooks/deposit/depositFlowSteps/ensureAuthenticatedVpClient.ts
+++ b/services/vault/src/hooks/deposit/depositFlowSteps/ensureAuthenticatedVpClient.ts
@@ -16,6 +16,7 @@ import {
   expandAuthAnchor,
   hexToUint8Array,
   parseFundingOutpointsFromTx,
+  stripHexPrefix,
   uint8ArrayToHex,
 } from "@babylonlabs-io/ts-sdk/tbv/core";
 import {
@@ -27,7 +28,6 @@ import { calculateBtcTxHash } from "@babylonlabs-io/ts-sdk/tbv/core/utils";
 import type { Address, Hex } from "viem";
 
 import { getVaultRegistryReader } from "@/clients/eth-contract/sdk-readers";
-import { stripHexPrefix } from "@/utils/btc";
 import { getVpProxyUrl } from "@/utils/rpc";
 
 export interface EnsureAuthenticatedVpClientParams {

--- a/services/vault/src/hooks/deposit/depositFlowSteps/payoutSigning.ts
+++ b/services/vault/src/hooks/deposit/depositFlowSteps/payoutSigning.ts
@@ -3,6 +3,7 @@
  */
 
 import type { BitcoinWallet } from "@babylonlabs-io/ts-sdk/shared";
+import { stripHexPrefix } from "@babylonlabs-io/ts-sdk/tbv/core";
 import { runDepositorPresignFlow } from "@babylonlabs-io/ts-sdk/tbv/core/services";
 import type { Address, Hex } from "viem";
 
@@ -12,7 +13,6 @@ import {
   type PayoutSigningProgress,
 } from "@/services/vault/vaultPayoutSignatureService";
 import { updatePendingPeginStatus } from "@/storage/peginStorage";
-import { stripHexPrefix } from "@/utils/btc";
 
 import { ensureAuthenticatedVpClient } from "./ensureAuthenticatedVpClient";
 

--- a/services/vault/src/hooks/deposit/depositFlowSteps/wotsSubmission.ts
+++ b/services/vault/src/hooks/deposit/depositFlowSteps/wotsSubmission.ts
@@ -2,9 +2,8 @@
  * Step 2.5: WOTS public key RPC submission — adapter over SDK.
  */
 
+import { stripHexPrefix } from "@babylonlabs-io/ts-sdk/tbv/core";
 import { submitWotsPublicKey as sdkSubmitWotsPublicKey } from "@babylonlabs-io/ts-sdk/tbv/core/services";
-
-import { stripHexPrefix } from "@/utils/btc";
 
 import { ensureAuthenticatedVpClient } from "./ensureAuthenticatedVpClient";
 import type { WotsSubmissionParams } from "./types";

--- a/services/vault/src/hooks/deposit/useDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useDepositFlow.ts
@@ -31,6 +31,7 @@ import type { BitcoinWallet } from "@babylonlabs-io/ts-sdk/shared";
 import {
   ensureHexPrefix,
   isRegisteredVaultVersionMismatchError,
+  stripHexPrefix,
   validateOnChainParticipantKeys,
   verifyRegisteredVaultVersions,
 } from "@babylonlabs-io/ts-sdk/tbv/core";
@@ -76,7 +77,7 @@ import {
   updatePendingPeginStatus,
 } from "@/storage/peginStorage";
 import type { Vault } from "@/types/vault";
-import { btcAddressToScriptPubKeyHex, stripHexPrefix } from "@/utils/btc";
+import { btcAddressToScriptPubKeyHex } from "@/utils/btc";
 import { satoshiToBtcNumber } from "@/utils/btcConversion";
 import { sanitizeErrorMessage } from "@/utils/errors/formatting";
 import { formatBtcValue } from "@/utils/formatting";

--- a/services/vault/src/hooks/deposit/usePeginPollingQuery.ts
+++ b/services/vault/src/hooks/deposit/usePeginPollingQuery.ts
@@ -9,6 +9,7 @@
  * re-fetches it at click-time.
  */
 
+import { stripHexPrefix } from "@babylonlabs-io/ts-sdk/tbv/core";
 import type { GetPeginStatusResponse } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
 import {
   batchPollByProvider,
@@ -32,7 +33,6 @@ import type {
   DepositsByProvider,
   DepositToPoll,
 } from "../../types/peginPolling";
-import { stripHexPrefix } from "../../utils/btc";
 import {
   getDepositsNeedingPolling,
   groupDepositsByProvider,

--- a/services/vault/src/hooks/deposit/useVaultActions.ts
+++ b/services/vault/src/hooks/deposit/useVaultActions.ts
@@ -2,7 +2,10 @@
  * Custom hook for vault actions (broadcast, activation)
  */
 
-import { ensureHexPrefix } from "@babylonlabs-io/ts-sdk/tbv/core";
+import {
+  ensureHexPrefix,
+  stripHexPrefix,
+} from "@babylonlabs-io/ts-sdk/tbv/core";
 import { vpTokenRegistry } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
 import { validateSecretAgainstHashlock } from "@babylonlabs-io/ts-sdk/tbv/core/services";
 import {
@@ -35,7 +38,6 @@ import {
 import { activateVaultWithSecret } from "../../services/vault/vaultActivationService";
 import { utxosToExpectedRecord } from "../../services/vault/vaultPeginBroadcastService";
 import type { PendingPeginRequest } from "../../storage/peginStorage";
-import { stripHexPrefix } from "../../utils/btc";
 
 export interface BroadcastPrePeginParams {
   vaultId: Hex;

--- a/services/vault/src/hooks/usePegoutPolling.ts
+++ b/services/vault/src/hooks/usePegoutPolling.ts
@@ -8,6 +8,7 @@
  * unknown-status thresholds.
  */
 
+import { stripHexPrefix } from "@babylonlabs-io/ts-sdk/tbv/core";
 import {
   batchPollByProvider,
   VpResponseValidationError,
@@ -32,7 +33,6 @@ import {
   TIMED_OUT_STATE,
   type PegoutDisplayState,
 } from "@/models/pegoutStateMachine";
-import { stripHexPrefix } from "@/utils/btc";
 import { createVpClient } from "@/utils/rpc";
 
 export interface PegoutPollingResult {

--- a/services/vault/src/services/artifacts/artifactDownloadService.ts
+++ b/services/vault/src/services/artifacts/artifactDownloadService.ts
@@ -15,6 +15,7 @@
  * parsed and validated.
  */
 
+import { stripHexPrefix } from "@babylonlabs-io/ts-sdk/tbv/core";
 import {
   JSON_RPC_ERROR_CODES,
   JsonRpcClient,
@@ -24,7 +25,6 @@ import {
   vpTokenRegistry,
 } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
 
-import { stripHexPrefix } from "@/utils/btc";
 import { getVpProxyUrl } from "@/utils/rpc";
 
 /** Timeout for the artifact request RPC call (artifacts can be large). */

--- a/services/vault/src/utils/btc/index.ts
+++ b/services/vault/src/utils/btc/index.ts
@@ -4,8 +4,6 @@
  * Centralized exports for Bitcoin-specific utility functions
  */
 
-export { stripHexPrefix } from "@babylonlabs-io/ts-sdk/tbv/core";
-
 export {
   btcAddressToScriptPubKeyHex,
   scriptPubKeyHexToBtcAddress,

--- a/services/vault/src/utils/explorer.ts
+++ b/services/vault/src/utils/explorer.ts
@@ -5,10 +5,11 @@
  * ETH:  <chain explorer>/tx/<hash>                      (hash with 0x)
  */
 
+import { stripHexPrefix } from "@babylonlabs-io/ts-sdk/tbv/core";
+
 import { getNetworkConfigBTC } from "@/config";
 import { getNetworkConfigETH } from "@/config/network";
 import type { ActivityChain } from "@/types/activityLog";
-import { stripHexPrefix } from "@/utils/btc";
 
 export function getBtcExplorerTxUrl(txHash: string): string {
   const btcConfig = getNetworkConfigBTC();


### PR DESCRIPTION
- Removes the `stripHexPrefix` bare re-export from `services/vault/src/utils/btc/index.ts` — CLAUDE.md zero-dead-code rule #6 violation. The 12
callsites now import directly from `@babylonlabs-io/ts-sdk/tbv/core`.
- The two genuinely vault-local helpers (`btcAddressToScriptPubKeyHex`, `scriptPubKeyHexToBtcAddress`) bind to `getNetworkConfigBTC()` and stay in
`btcUtils.ts` — they can't move to the SDK without a config refactor.
- Expands CLAUDE.md Critical Path #3 — renamed to *"Presigning depositor-graph transactions (Payout + NoPayout)"*, added `signDepositorGraph.ts` to
the file list, and extended the rule to cover challenger-set derivation (derive `LocalChallengers` from on-chain VKs matching `btc-vault
crates/vault/src/tx_graph/graph.rs`, assert `challenger_presign_data === local ∪ universal`). This means future changes to that file trigger the
two-reviewer / no-AI-explain rule.