### PR TITLE
feat(ts-sdk): refuse to extract a signature when the wallet returned …

### DIFF
--- a/packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts
@@ -21,6 +21,7 @@ import type {
 import { createTaprootScriptPathSignOptions } from "../utils/signing";
 import {
   assertPayoutOutputMatchesRegistered,
+  assertPsbtUnsignedTxMatches,
   buildPayoutPsbt,
   extractPayoutSignature,
   validateWalletPubkey,
@@ -216,6 +217,11 @@ export class PayoutManager {
       createTaprootScriptPathSignOptions(walletPubkeyRaw, 1),
     );
 
+    assertPsbtUnsignedTxMatches({
+      requestedPsbtHex: payoutPsbt.psbtHex,
+      returnedPsbtHex: signedPsbtHex,
+    });
+
     // Extract Schnorr signature
     const signature = extractPayoutSignature(signedPsbtHex, depositorPubkey);
 
@@ -325,6 +331,10 @@ export class PayoutManager {
 
     for (let i = 0; i < transactions.length; i++) {
       const depositorPubkey = depositorPubkeys[i];
+      assertPsbtUnsignedTxMatches({
+        requestedPsbtHex: psbtsToSign[i],
+        returnedPsbtHex: signedPsbts[i],
+      });
       const payoutSignature = extractPayoutSignature(
         signedPsbts[i],
         depositorPubkey,

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/index.ts
@@ -122,6 +122,12 @@ export {
 } from "./psbt/payout";
 export type { PayoutParams, PayoutPsbtResult } from "./psbt/payout";
 
+export {
+  assertPsbtUnsignedTxMatches,
+  PsbtSubstitutionError,
+} from "./psbt/assertPsbtUnsignedTxMatches";
+export type { AssertPsbtUnsignedTxMatchesParams } from "./psbt/assertPsbtUnsignedTxMatches";
+
 export { buildDepositorPayoutPsbt } from "./psbt/depositorPayout";
 export type { DepositorPayoutParams } from "./psbt/depositorPayout";
 

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/assertPsbtUnsignedTxMatches.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/assertPsbtUnsignedTxMatches.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Tests for assertPsbtUnsignedTxMatches.
+ */
+
+import { Buffer } from "buffer";
+
+import { Psbt, networks } from "bitcoinjs-lib";
+import { describe, expect, it } from "vitest";
+
+import {
+  assertPsbtUnsignedTxMatches,
+  PsbtSubstitutionError,
+} from "../assertPsbtUnsignedTxMatches";
+
+const NETWORK = networks.testnet;
+
+const PREVOUT_TXID_A = Buffer.alloc(32, 0xaa);
+const PREVOUT_TXID_B = Buffer.alloc(32, 0xbb);
+
+const SCRIPT_DEPOSITOR = Buffer.from(`0014${"11".repeat(20)}`, "hex");
+const SCRIPT_ATTACKER = Buffer.from(`0014${"ee".repeat(20)}`, "hex");
+
+const FAKE_TAPROOT_KEY_SIG = Buffer.alloc(64, 0x42);
+
+function buildBasePsbt(opts?: {
+  prevoutTxid?: Buffer;
+  prevoutVout?: number;
+  prevoutSequence?: number;
+  outputScript?: Buffer;
+  outputValue?: number;
+  locktime?: number;
+}): Psbt {
+  const psbt = new Psbt({ network: NETWORK });
+  psbt.addInput({
+    hash: opts?.prevoutTxid ?? PREVOUT_TXID_A,
+    index: opts?.prevoutVout ?? 0,
+    sequence: opts?.prevoutSequence ?? 0xfffffffd,
+  });
+  psbt.addOutput({
+    script: opts?.outputScript ?? SCRIPT_DEPOSITOR,
+    value: opts?.outputValue ?? 90_000,
+  });
+  psbt.locktime = opts?.locktime ?? 0;
+  return psbt;
+}
+
+describe("assertPsbtUnsignedTxMatches", () => {
+  it("passes when the returned PSBT differs only by an added partial sig", () => {
+    const requestedHex = buildBasePsbt().toHex();
+    const returned = Psbt.fromHex(requestedHex);
+    returned.updateInput(0, { tapKeySig: FAKE_TAPROOT_KEY_SIG });
+    expect(() =>
+      assertPsbtUnsignedTxMatches({
+        requestedPsbtHex: requestedHex,
+        returnedPsbtHex: returned.toHex(),
+      }),
+    ).not.toThrow();
+  });
+
+  it("throws when an output address has been swapped", () => {
+    const requestedHex = buildBasePsbt().toHex();
+    const returnedHex = buildBasePsbt({ outputScript: SCRIPT_ATTACKER }).toHex();
+    expect(() =>
+      assertPsbtUnsignedTxMatches({
+        requestedPsbtHex: requestedHex,
+        returnedPsbtHex: returnedHex,
+      }),
+    ).toThrow(/output 0 scriptPubKey differs/);
+  });
+
+  it("redacts the prevout txid in mismatch errors using human (big-endian) byte order", () => {
+    // Build distinct prevout txids whose internal-LE hash bytes differ at
+    // the front; this ensures we observe the *reversed* form in the error.
+    const requestedHash = Buffer.from(
+      "1111111111111111111111111111111111111111111111111111111111111122",
+      "hex",
+    );
+    const returnedHash = Buffer.from(
+      "9999999999999999999999999999999999999999999999999999999999999988",
+      "hex",
+    );
+    const requestedHex = buildBasePsbt({ prevoutTxid: requestedHash }).toHex();
+    const returnedHex = buildBasePsbt({ prevoutTxid: returnedHash }).toHex();
+    let caught: Error | null = null;
+    try {
+      assertPsbtUnsignedTxMatches({
+        requestedPsbtHex: requestedHex,
+        returnedPsbtHex: returnedHex,
+      });
+    } catch (err) {
+      caught = err as Error;
+    }
+    expect(caught).not.toBeNull();
+    // Reversed (big-endian / explorer-displayed) prefixes — first 8 chars of
+    // the reversed bytes (so "...22" → "22…", "...88" → "88…").
+    expect(caught!.message).toContain("requested=22111111…");
+    expect(caught!.message).toContain("returned=88999999…");
+  });
+
+  it("redacts hex fields in mismatch errors so full UTXO/address data does not leak", () => {
+    const requestedHex = buildBasePsbt().toHex();
+    const returnedHex = buildBasePsbt({ outputScript: SCRIPT_ATTACKER }).toHex();
+    let caught: Error | null = null;
+    try {
+      assertPsbtUnsignedTxMatches({
+        requestedPsbtHex: requestedHex,
+        returnedPsbtHex: returnedHex,
+      });
+    } catch (err) {
+      caught = err as Error;
+    }
+    expect(caught).not.toBeNull();
+    // Full attacker scriptPubKey hex must NOT appear in the error.
+    expect(caught!.message).not.toContain(SCRIPT_ATTACKER.toString("hex"));
+    // Truncated 8-char prefix (with ellipsis) should appear instead.
+    expect(caught!.message).toMatch(/requested=[0-9a-f]{8}…, returned=[0-9a-f]{8}…/);
+  });
+
+  it("throws when an output value has been changed", () => {
+    const requestedHex = buildBasePsbt({ outputValue: 90_000 }).toHex();
+    const returnedHex = buildBasePsbt({ outputValue: 89_000 }).toHex();
+    expect(() =>
+      assertPsbtUnsignedTxMatches({
+        requestedPsbtHex: requestedHex,
+        returnedPsbtHex: returnedHex,
+      }),
+    ).toThrow(/output 0 value differs \(requested=90000, returned=89000\)/);
+  });
+
+  it("throws when an input prevout txid has been changed", () => {
+    const requestedHex = buildBasePsbt({ prevoutTxid: PREVOUT_TXID_A }).toHex();
+    const returnedHex = buildBasePsbt({ prevoutTxid: PREVOUT_TXID_B }).toHex();
+    expect(() =>
+      assertPsbtUnsignedTxMatches({
+        requestedPsbtHex: requestedHex,
+        returnedPsbtHex: returnedHex,
+      }),
+    ).toThrow(PsbtSubstitutionError);
+    expect(() =>
+      assertPsbtUnsignedTxMatches({
+        requestedPsbtHex: requestedHex,
+        returnedPsbtHex: returnedHex,
+      }),
+    ).toThrow(/input 0 prevout txid differs/);
+  });
+
+  it("throws when input count differs", () => {
+    const requestedHex = buildBasePsbt().toHex();
+    const returned = buildBasePsbt();
+    returned.addInput({
+      hash: PREVOUT_TXID_B,
+      index: 1,
+      sequence: 0xfffffffd,
+    });
+    expect(() =>
+      assertPsbtUnsignedTxMatches({
+        requestedPsbtHex: requestedHex,
+        returnedPsbtHex: returned.toHex(),
+      }),
+    ).toThrow(/input count differs \(requested=1, returned=2\)/);
+  });
+
+  it("throws when output count differs", () => {
+    const requestedHex = buildBasePsbt().toHex();
+    const returned = buildBasePsbt();
+    returned.addOutput({ script: SCRIPT_ATTACKER, value: 1_000 });
+    expect(() =>
+      assertPsbtUnsignedTxMatches({
+        requestedPsbtHex: requestedHex,
+        returnedPsbtHex: returned.toHex(),
+      }),
+    ).toThrow(/output count differs \(requested=1, returned=2\)/);
+  });
+
+  it("throws when locktime differs", () => {
+    const requestedHex = buildBasePsbt({ locktime: 0 }).toHex();
+    const returnedHex = buildBasePsbt({ locktime: 500_000 }).toHex();
+    expect(() =>
+      assertPsbtUnsignedTxMatches({
+        requestedPsbtHex: requestedHex,
+        returnedPsbtHex: returnedHex,
+      }),
+    ).toThrow(/tx locktime differs \(requested=0, returned=500000\)/);
+  });
+
+  it("throws when input sequence differs (RBF flag swap)", () => {
+    const requestedHex = buildBasePsbt({
+      prevoutSequence: 0xfffffffd,
+    }).toHex();
+    const returnedHex = buildBasePsbt({
+      prevoutSequence: 0xffffffff,
+    }).toHex();
+    expect(() =>
+      assertPsbtUnsignedTxMatches({
+        requestedPsbtHex: requestedHex,
+        returnedPsbtHex: returnedHex,
+      }),
+    ).toThrow(/input 0 sequence differs/);
+  });
+
+  it("throws with 'returned' label when the wallet returns malformed bytes", () => {
+    const requestedHex = buildBasePsbt().toHex();
+    expect(() =>
+      assertPsbtUnsignedTxMatches({
+        requestedPsbtHex: requestedHex,
+        returnedPsbtHex: "deadbeef",
+      }),
+    ).toThrow(/Failed to parse returned PSBT/);
+  });
+
+  it("throws with 'requested' label when the locally-built PSBT is malformed", () => {
+    const returnedHex = buildBasePsbt().toHex();
+    expect(() =>
+      assertPsbtUnsignedTxMatches({
+        requestedPsbtHex: "deadbeef",
+        returnedPsbtHex: returnedHex,
+      }),
+    ).toThrow(/Failed to parse requested PSBT/);
+  });
+});

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/assertPsbtUnsignedTxMatches.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/assertPsbtUnsignedTxMatches.ts
@@ -1,0 +1,132 @@
+/**
+ * Asserts a wallet-returned PSBT encodes the same unsigned transaction
+ * as the locally-built PSBT we asked the wallet to sign. Per-input PSBT
+ * metadata (witnessUtxo, tapLeafScript, sighashType) is intentionally NOT
+ * compared — those fields are committed to the Schnorr sighash and the
+ * vault provider's `verify_depositor_signature` rejects mismatches there.
+ * This primitive defends the path where a colluding VP would otherwise
+ * accept a wallet-substituted signature.
+ */
+
+import { Buffer } from "buffer";
+
+import { Psbt } from "bitcoinjs-lib";
+
+/**
+ * Thrown when a wallet-returned PSBT encodes a different unsigned
+ * transaction than the one the caller asked the wallet to sign.
+ */
+export class PsbtSubstitutionError extends Error {
+  constructor(detail: string) {
+    super(
+      `Wallet returned a PSBT for a different transaction: ${detail}`,
+    );
+    this.name = "PsbtSubstitutionError";
+  }
+}
+
+export interface AssertPsbtUnsignedTxMatchesParams {
+  /** PSBT we built locally and asked the wallet to sign. */
+  requestedPsbtHex: string;
+  /** PSBT the wallet returned after signing. */
+  returnedPsbtHex: string;
+}
+
+function parsePsbt(label: "requested" | "returned", hex: string): Psbt {
+  try {
+    return Psbt.fromHex(hex);
+  } catch (cause) {
+    const reason = cause instanceof Error ? cause.message : String(cause);
+    throw new Error(`Failed to parse ${label} PSBT: ${reason}`);
+  }
+}
+
+/**
+ * Length of the hex prefix included in mismatch errors. Short enough that
+ * full prevout txids and output scriptPubKeys never reach logs / error
+ * trackers, long enough to disambiguate during forensic triage.
+ */
+const REDACTED_HEX_PREFIX_LEN = 8;
+
+function redactHex(buf: Buffer): string {
+  return `${buf.toString("hex").slice(0, REDACTED_HEX_PREFIX_LEN)}…`;
+}
+
+/**
+ * `bitcoinjs-lib` exposes `txInputs[i].hash` in internal little-endian form;
+ * a human reading logs expects the big-endian txid an explorer would show.
+ * Reverse before truncating so the surfaced prefix matches what an operator
+ * can search for.
+ */
+function redactTxid(internalHash: Buffer): string {
+  const reversed = Buffer.from(internalHash).reverse();
+  return redactHex(reversed);
+}
+
+/**
+ * Compare two PSBTs and throw `PsbtSubstitutionError` unless they encode
+ * the same unsigned transaction (version, locktime, inputs, outputs).
+ *
+ * @throws PsbtSubstitutionError on any mismatch in the unsigned tx
+ * @throws Error if either PSBT cannot be parsed
+ */
+export function assertPsbtUnsignedTxMatches(
+  params: AssertPsbtUnsignedTxMatchesParams,
+): void {
+  const requested = parsePsbt("requested", params.requestedPsbtHex);
+  const returned = parsePsbt("returned", params.returnedPsbtHex);
+
+  if (requested.version !== returned.version) {
+    throw new PsbtSubstitutionError(
+      `tx version differs (requested=${requested.version}, returned=${returned.version})`,
+    );
+  }
+  if (requested.locktime !== returned.locktime) {
+    throw new PsbtSubstitutionError(
+      `tx locktime differs (requested=${requested.locktime}, returned=${returned.locktime})`,
+    );
+  }
+  if (requested.txInputs.length !== returned.txInputs.length) {
+    throw new PsbtSubstitutionError(
+      `input count differs (requested=${requested.txInputs.length}, returned=${returned.txInputs.length})`,
+    );
+  }
+  if (requested.txOutputs.length !== returned.txOutputs.length) {
+    throw new PsbtSubstitutionError(
+      `output count differs (requested=${requested.txOutputs.length}, returned=${returned.txOutputs.length})`,
+    );
+  }
+  for (let i = 0; i < requested.txInputs.length; i++) {
+    const r = requested.txInputs[i];
+    const s = returned.txInputs[i];
+    if (!r.hash.equals(s.hash)) {
+      throw new PsbtSubstitutionError(
+        `input ${i} prevout txid differs (requested=${redactTxid(r.hash)}, returned=${redactTxid(s.hash)})`,
+      );
+    }
+    if (r.index !== s.index) {
+      throw new PsbtSubstitutionError(
+        `input ${i} prevout vout differs (requested=${r.index}, returned=${s.index})`,
+      );
+    }
+    if (r.sequence !== s.sequence) {
+      throw new PsbtSubstitutionError(
+        `input ${i} sequence differs (requested=${r.sequence}, returned=${s.sequence})`,
+      );
+    }
+  }
+  for (let i = 0; i < requested.txOutputs.length; i++) {
+    const r = requested.txOutputs[i];
+    const s = returned.txOutputs[i];
+    if (!r.script.equals(s.script)) {
+      throw new PsbtSubstitutionError(
+        `output ${i} scriptPubKey differs (requested=${redactHex(r.script)}, returned=${redactHex(s.script)})`,
+      );
+    }
+    if (r.value !== s.value) {
+      throw new PsbtSubstitutionError(
+        `output ${i} value differs (requested=${r.value}, returned=${s.value})`,
+      );
+    }
+  }
+}

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/index.ts
@@ -43,3 +43,9 @@ export type { NoPayoutParams } from "./noPayout";
 
 export { buildChallengeAssertPsbt } from "./challengeAssert";
 export type { ChallengeAssertParams } from "./challengeAssert";
+
+export {
+  assertPsbtUnsignedTxMatches,
+  PsbtSubstitutionError,
+} from "./assertPsbtUnsignedTxMatches";
+export type { AssertPsbtUnsignedTxMatchesParams } from "./assertPsbtUnsignedTxMatches";

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/signDepositorGraph.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/signDepositorGraph.test.ts
@@ -103,6 +103,14 @@ vi.mock("../../../utils/signing", () => ({
   }),
 }));
 
+// Mock the substitution defense as a no-op. The PSBT hexes used in this
+// test file are mock strings that don't parse as real PSBTs (the underlying
+// build* primitives are mocked too); the substitution defense gets its own
+// dedicated tests against real PSBTs in primitives/psbt/__tests__/.
+vi.mock("../../../primitives/psbt/assertPsbtUnsignedTxMatches", () => ({
+  assertPsbtUnsignedTxMatches: vi.fn(),
+}));
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts
@@ -29,6 +29,10 @@ import type {
   PresignDataPerChallenger,
 } from "../../clients/vault-provider/types";
 import {
+  assertPsbtUnsignedTxMatches,
+  type AssertPsbtUnsignedTxMatchesParams,
+} from "../../primitives/psbt/assertPsbtUnsignedTxMatches";
+import {
   assertNoPayoutOutputMatchesChallenger,
   buildNoPayoutPsbt,
 } from "../../primitives/psbt/noPayout";
@@ -412,24 +416,32 @@ async function buildLocalNoPayoutPsbt(
 // Extract phase
 // ============================================================================
 
+/** A pair of a locally-built PSBT and the wallet-returned PSBT for it. */
+type PsbtPair = AssertPsbtUnsignedTxMatchesParams;
+
 /**
  * Extract all signatures from signed PSBTs and assemble into presignatures.
+ * Each pair is asserted to encode the same unsigned tx before its signature
+ * is extracted — defends against a wallet that returns a signature for a
+ * substituted transaction.
  */
 function extractDepositorGraphSignatures(
-  signedPsbtHexes: string[],
+  psbtPairs: PsbtPair[],
   challengerEntries: ChallengerEntry[],
   depositorPubkey: string,
 ): DepositorAsClaimerPresignatures {
+  assertPsbtUnsignedTxMatches(psbtPairs[0]);
   const payoutSignature = extractPayoutSignature(
-    signedPsbtHexes[0],
+    psbtPairs[0].returnedPsbtHex,
     depositorPubkey,
   );
 
   const perChallenger: Record<string, DepositorPreSigsPerChallenger> = {};
   for (const entry of challengerEntries) {
+    assertPsbtUnsignedTxMatches(psbtPairs[entry.noPayoutIdx]);
     perChallenger[entry.challengerPubkey] = {
       nopayout_signature: extractPayoutSignature(
-        signedPsbtHexes[entry.noPayoutIdx],
+        psbtPairs[entry.noPayoutIdx].returnedPsbtHex,
         depositorPubkey,
       ),
     };
@@ -566,9 +578,13 @@ export async function signDepositorGraph(
     );
   }
 
-  // 3. Extract signatures and assemble presignatures
+  // 3. Pair requested with signed and extract signatures
+  const psbtPairs: PsbtPair[] = psbtHexes.map((requestedPsbtHex, i) => ({
+    requestedPsbtHex,
+    returnedPsbtHex: signedPsbtHexes[i],
+  }));
   return extractDepositorGraphSignatures(
-    signedPsbtHexes,
+    psbtPairs,
     challengerEntries,
     depositorPubkey,
   );


### PR DESCRIPTION
Closes audit finding [baby-auditor-findings#153](https://github.com/babylonlabs-io/baby-auditor-findings/issues/153) (HIGH).

After `wallet.signPsbt(...)` returns, `PayoutManager` (single + batch) and `signDepositorGraph` extracted a Schnorr signature and submitted it to the
VP without verifying the wallet had signed the same unsigned tx the FE asked for. A compromised wallet could substitute a signed PSBT for a different
transaction and have the FE submit it. The VP's `verify_depositor_signature` would catch a substituted signature server-side, so this is
defense-in-depth — but it gives a clearer error than an opaque VP rejection and saves an RPC round-trip.

New primitive `assertPsbtUnsignedTxMatches` parses both PSBTs and compares only the unsigned tx (version, locktime, inputs, outputs). Per-input PSBT
metadata is committed to the Schnorr sighash and not re-checked here. Wired into all 3 call sites. Mismatch errors include redacted 8-char hex
prefixes (txids reversed to big-endian first); full UTXO/address data never reaches logs.

Touches Critical Path #3.