### PR TITLE
fix(ts-sdk): enforce prevouts in buildPayoutPsbt

### DIFF
--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/payout.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/payout.test.ts
@@ -288,19 +288,24 @@ describe("buildPayoutPsbt", () => {
       );
     });
 
-    it("should throw error when previous output not found", async () => {
-      const peginTxHex = createTestPeginTransaction();
+    it("rejects payout when input 0 references the correct PegIn txid but a non-zero vout", async () => {
+      // Multi-output PegIn so vout 1 exists and the vout check is what fires
+      // (not the "Previous output not found" defensive check).
+      const peginTx = new Transaction();
+      peginTx.addInput(NULL_TXID, 0xffffffff, SEQUENCE_MAX);
+      peginTx.addOutput(createDummyP2TR(), Number(TEST_PEGIN_VALUE));
+      peginTx.addOutput(createDummyP2TR(), Number(TEST_PEGIN_VALUE));
+      const peginTxHex = peginTx.toHex();
+
       const assertTxHex = createTestAssertTransaction();
       const assertTx = Transaction.fromHex(assertTxHex);
 
-      // Create a payout transaction that references an invalid output index for pegin
-      const peginTx = Transaction.fromHex(peginTxHex);
       const wrongTx = new Transaction();
       wrongTx.addInput(
         Buffer.from(peginTx.getId(), "hex").reverse(),
-        99,
+        1, // Correct PegIn txid, wrong vout
         SEQUENCE_MAX,
-      ); // Invalid index 99
+      );
       wrongTx.addInput(
         Buffer.from(assertTx.getId(), "hex").reverse(),
         0,
@@ -322,7 +327,49 @@ describe("buildPayoutPsbt", () => {
       };
 
       await expect(buildPayoutPsbt(params)).rejects.toThrow(
-        /Previous output not found/,
+        /Input 0 must spend PegIn:0/,
+      );
+    });
+
+    it("rejects payout when input 1 references the correct Assert txid but a non-zero vout", async () => {
+      // Multi-output Assert so vout 1 exists.
+      const peginTxHex = createTestPeginTransaction();
+      const peginTx = Transaction.fromHex(peginTxHex);
+
+      const assertTx = new Transaction();
+      assertTx.addInput(DUMMY_TXID_2, 0xffffffff, SEQUENCE_MAX);
+      assertTx.addOutput(createDummyP2WPKH("c"), Number(TEST_CLAIM_VALUE));
+      assertTx.addOutput(createDummyP2WPKH("e"), Number(TEST_CLAIM_VALUE));
+      const assertTxHex = assertTx.toHex();
+
+      const wrongTx = new Transaction();
+      wrongTx.addInput(
+        Buffer.from(peginTx.getId(), "hex").reverse(),
+        0,
+        SEQUENCE_MAX,
+      );
+      wrongTx.addInput(
+        Buffer.from(assertTx.getId(), "hex").reverse(),
+        1, // Correct Assert txid, wrong vout
+        SEQUENCE_MAX,
+      );
+      wrongTx.addOutput(createDummyP2WPKH("f"), Number(TEST_PAYOUT_VALUE));
+      const payoutTxHex = wrongTx.toHex();
+
+      const params: PayoutParams = {
+        payoutTxHex,
+        peginTxHex,
+        assertTxHex,
+        depositorBtcPubkey: TEST_KEYS.DEPOSITOR,
+        vaultProviderBtcPubkey: TEST_KEYS.VAULT_PROVIDER,
+        vaultKeeperBtcPubkeys: [TEST_KEYS.VAULT_KEEPER_1],
+        universalChallengerBtcPubkeys: [TEST_KEYS.UNIVERSAL_CHALLENGER_1],
+        timelockPegin: 100,
+        network: "signet" as Network,
+      };
+
+      await expect(buildPayoutPsbt(params)).rejects.toThrow(
+        /Input 1 must spend Assert:0/,
       );
     });
   });

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts
@@ -24,6 +24,10 @@ import {
   stripHexPrefix,
   uint8ArrayToHex,
 } from "../utils/bitcoin";
+import {
+  ASSERT_PAYOUT_OUTPUT_INDEX,
+  PEGIN_VAULT_OUTPUT_INDEX,
+} from "./constants";
 
 /**
  * Number of items in a Taproot script-path spend witness stack for a
@@ -119,8 +123,8 @@ export interface PayoutPsbtResult {
  * @returns Unsigned PSBT ready for depositor to sign
  *
  * @throws If payout transaction does not have exactly 2 inputs
- * @throws If input 0 does not reference the pegin transaction
- * @throws If input 1 does not reference the assert transaction
+ * @throws If input 0 does not spend PegIn:0 (vault UTXO)
+ * @throws If input 1 does not spend Assert:0 (proof output)
  * @throws If previous output is not found for either input
  */
 export async function buildPayoutPsbt(
@@ -172,29 +176,32 @@ export async function buildPayoutPsbt(
   const input0 = payoutTx.ins[0];
   const input1 = payoutTx.ins[1];
 
-  // Verify input 0 references the pegin transaction
+  // Verify input 0 spends PegIn:0 (the vault UTXO).
+  // Both txid AND vout must match the protocol contract — the vout is the
+  // input-side anchor that prevents a malicious VP from binding the
+  // depositor's signature to a different output of the same parent.
   const input0Txid = uint8ArrayToHex(
     new Uint8Array(input0.hash).slice().reverse(),
   );
   const peginTxid = peginTx.getId();
 
-  if (input0Txid !== peginTxid) {
+  if (input0Txid !== peginTxid || input0.index !== PEGIN_VAULT_OUTPUT_INDEX) {
     throw new Error(
-      `Input 0 does not reference pegin transaction. ` +
-        `Expected ${peginTxid}, got ${input0Txid}`,
+      `Input 0 must spend PegIn:${PEGIN_VAULT_OUTPUT_INDEX}. ` +
+        `Expected ${peginTxid}:${PEGIN_VAULT_OUTPUT_INDEX}, got ${input0Txid}:${input0.index}`,
     );
   }
 
-  // Verify input 1 references the assert transaction
+  // Verify input 1 spends Assert:0 (the proof output).
   const input1Txid = uint8ArrayToHex(
     new Uint8Array(input1.hash).slice().reverse(),
   );
-  const expectedInput1Txid = assertTx.getId();
+  const assertTxid = assertTx.getId();
 
-  if (input1Txid !== expectedInput1Txid) {
+  if (input1Txid !== assertTxid || input1.index !== ASSERT_PAYOUT_OUTPUT_INDEX) {
     throw new Error(
-      `Input 1 does not reference assert transaction. ` +
-        `Expected ${expectedInput1Txid}, got ${input1Txid}`,
+      `Input 1 must spend Assert:${ASSERT_PAYOUT_OUTPUT_INDEX}. ` +
+        `Expected ${assertTxid}:${ASSERT_PAYOUT_OUTPUT_INDEX}, got ${input1Txid}:${input1.index}`,
     );
   }
 


### PR DESCRIPTION
## What

`buildPayoutPsbt` now refuses to build a depositor Payout PSBT unless:

- input 0 spends **PegIn vout 0** (the vault UTXO), and
- input 1 spends **Assert vout 0** (the proof output).

Before this change, the function only checked the parent **txid** for each input. It blindly trusted the vout supplied by the vault provider (VP) and used it to pull `peginTx.outs[input0.index]` / `assertTx.outs[input1.index]` for the witness UTXO that the wallet then signs over.

## Why

The protocol contract is fixed: the depositor's Payout always spends `PegIn:0` and `Assert:0`. By skipping the vout check, a colluding VP could hand the wallet a payout transaction that uses the right txids but a different vout (e.g. vout 1 of the same parent). The wallet would then produce a Schnorr signature that — via Taproot SIGHASH_DEFAULT — commits to those alternate prevouts. The VP could later try to reuse that signature against a non-protocol branch.

This is also explicitly called out in `CLAUDE.md` §3 ("Presigning depositor-graph transactions"): *"Never sign a value or accept a challenger key handed to us verbatim."* The vout is the input-side anchor of that rule.

The sibling primitive `buildDepositorPayoutPsbt` already gets this right — it uses the same `PEGIN_VAULT_OUTPUT_INDEX` / `ASSERT_PAYOUT_OUTPUT_INDEX` constants. So the fix is just bringing `buildPayoutPsbt` in line with its sibling.

## Approaches considered

1. **Add the vout check inside `buildPayoutPsbt` itself** (chosen). Single source of truth — both call sites (`PayoutManager` and `signDepositorGraph`) inherit the protection automatically. Mirrors `buildDepositorPayoutPsbt` exactly.
2. **Add the vout check at each call site.** Rejected — duplicate logic in two places, easy for one to drift from the other, doesn't protect any third-party caller of the primitive.
3. **Also validate the full claim/assert parent chain.** The auditor mentions this as a secondary improvement. Larger scope, deferred as a follow-up — not blocking this fix.

## Notes for reviewer

- The "Previous output not found" defensive checks are kept on purpose. With vout 0 enforced they're effectively unreachable for any real Bitcoin transaction (a tx with zero outputs makes no sense), but they're cheap and harmless to keep as a guard.
- Related but out of scope (tracked separately): [#147](https://github.com/babylonlabs-io/baby-auditor-findings/issues/147) (output validation in same file), [#270](https://github.com/babylonlabs-io/baby-auditor-findings/issues/270), [#272](https://github.com/babylonlabs-io/baby-auditor-findings/issues/272).

Closes [babylonlabs-io/baby-auditor-findings#250](https://github.com/babylonlabs-io/baby-auditor-findings/issues/250)