### PR TITLE
fix(sdk, vault): rebind wallet-signed PSBTs against the requested PSBT

### DIFF
--- a/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
@@ -46,6 +46,7 @@ import type { WotsBlockPublicKey } from "../clients/vault-provider/types";
 import { type UtxoInfo, getUtxoInfo, pushTx } from "../clients/mempool";
 import { BTCVaultRegistryABI, handleContractError } from "../contracts";
 import {
+  assertPsbtUnsignedTxMatches,
   buildPrePeginPsbt,
   buildPeginTxFromFundedPrePegin,
   buildPeginInputPsbt,
@@ -862,6 +863,11 @@ export class PeginManager {
 
     const perVault: PerVaultPeginData[] = [];
     for (let i = 0; i < signedPsbts.length; i++) {
+      assertPsbtUnsignedTxMatches({
+        requestedPsbtHex: psbtsToSign[i],
+        returnedPsbtHex: signedPsbts[i],
+      });
+
       const peginInputSignature = extractPeginInputSignature(
         signedPsbts[i],
         depositorBtcPubkey,
@@ -993,7 +999,15 @@ export class PeginManager {
     }
 
     // Step 4: Sign PSBT via wallet
-    const signedPsbtHex = await this.config.btcWallet.signPsbt(psbt.toHex());
+    const requestedPsbtHex = psbt.toHex();
+    const signedPsbtHex =
+      await this.config.btcWallet.signPsbt(requestedPsbtHex);
+
+    assertPsbtUnsignedTxMatches({
+      requestedPsbtHex,
+      returnedPsbtHex: signedPsbtHex,
+    });
+
     const signedPsbt = Psbt.fromHex(signedPsbtHex);
 
     // Step 5: Finalize and extract transaction

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PayoutManager.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PayoutManager.test.ts
@@ -652,6 +652,62 @@ describe("PayoutManager", () => {
       );
     });
 
+    it("should reject when the wallet swaps the payout output before signing (single)", async () => {
+      const peginTxHex = createTestPeginTransaction();
+      const assertTxHex = createTestAssertTransaction();
+      const payoutTxHex = createTestPayoutTransaction(peginTxHex, assertTxHex);
+
+      const tamperedOutputScript = createDummyP2WPKH("e");
+
+      const signPsbt = vi
+        .fn<(psbtHex: string) => Promise<string>>()
+        .mockImplementation(async (psbtHex: string) => {
+          const psbt = Psbt.fromHex(psbtHex);
+          (
+            psbt as unknown as {
+              __CACHE: { __TX: { outs: { script: Buffer }[] } };
+            }
+          ).__CACHE.__TX.outs[0].script = tamperedOutputScript;
+          psbt.data.inputs[0].tapScriptSig = [
+            {
+              pubkey: Buffer.from(TEST_KEYS.DEPOSITOR, "hex"),
+              signature: Buffer.from("aa".repeat(64), "hex"),
+              leafHash: Buffer.alloc(32, 0),
+            },
+          ];
+          return psbt.toHex();
+        });
+
+      const wallet: BitcoinWallet = {
+        getPublicKeyHex: vi.fn().mockResolvedValue(TEST_KEYS.DEPOSITOR),
+        signPsbt,
+        signPsbts: vi.fn(),
+        getAddress: vi.fn(),
+        signMessage: vi.fn(),
+        getNetwork: vi.fn().mockResolvedValue("signet"),
+        deriveContextHash: vi.fn().mockResolvedValue("0".repeat(64)),
+      };
+
+      const manager = new PayoutManager({
+        network: "signet",
+        btcWallet: wallet,
+      });
+
+      await expect(
+        manager.signPayoutTransaction({
+          payoutTxHex,
+          peginTxHex,
+          assertTxHex,
+          vaultProviderBtcPubkey: TEST_KEYS.VAULT_PROVIDER,
+          vaultKeeperBtcPubkeys: [TEST_KEYS.VAULT_KEEPER_1],
+          universalChallengerBtcPubkeys: [TEST_KEYS.UNIVERSAL_CHALLENGER_1],
+          timelockPegin: 100,
+          depositorBtcPubkey: TEST_KEYS.DEPOSITOR,
+          registeredPayoutScriptPubKey: TEST_PAYOUT_SCRIPT_PUBKEY,
+        }),
+      ).rejects.toThrow(/output 0 script/);
+    });
+
     it("should reject mismatched scriptPubKey in batch signing path", async () => {
       const peginTxHex = createTestPeginTransaction();
       const assertTxHex = createTestAssertTransaction();

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PeginManager.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PeginManager.test.ts
@@ -41,6 +41,21 @@ vi.mock("../../primitives/psbt/peginInput", async (importOriginal) => {
   };
 });
 
+// Mocked for the same reason: mock wallet returns non-PSBT hex.
+vi.mock(
+  "../../primitives/psbt/assertPsbtUnsignedTxMatches",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("../../primitives/psbt/assertPsbtUnsignedTxMatches")
+      >();
+    return {
+      ...actual,
+      assertPsbtUnsignedTxMatches: vi.fn(),
+    };
+  },
+);
+
 // Test chain configuration (minimal viem Chain)
 const TEST_CHAIN: Chain = {
   id: 11155111,
@@ -247,6 +262,93 @@ describe("PeginManager", () => {
       const signOptions = signPsbtsSpy.mock.calls[0][1];
       const publicKey = signOptions?.[0]?.signInputs?.[0]?.publicKey;
       expect(publicKey).toBe(compressedPubkey);
+    });
+
+    it("rebinds every wallet-signed PegIn PSBT against the requested one — one call per vault, paired by index", async () => {
+      const { assertPsbtUnsignedTxMatches } = await import(
+        "../../primitives/psbt/assertPsbtUnsignedTxMatches"
+      );
+      const { buildPeginInputPsbt } = await import(
+        "../../primitives/psbt/peginInput"
+      );
+      const rebind = vi.mocked(assertPsbtUnsignedTxMatches);
+      const builder = vi.mocked(buildPeginInputPsbt);
+      rebind.mockClear();
+      // Distinct per-call PSBT hex so we can prove each rebind call gets
+      // its own (requested, returned) pair instead of all calls being
+      // validated against index 0.
+      let buildCount = 0;
+      builder.mockImplementation(async () => ({
+        psbtHex: `requested_${buildCount++}`,
+      }));
+
+      const btcWallet = new MockBitcoinWallet({
+        publicKeyHex: TEST_KEYS.DEPOSITOR,
+      });
+      const ethWallet = new MockEthereumWallet();
+      const manager = new PeginManager({
+        btcNetwork: "signet",
+        btcWallet,
+        ethWallet: ethWallet as any,
+        ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
+        vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
+        mempoolApiUrl: MEMPOOL_API_URLS.signet,
+      });
+
+      // 2 vaults so we exercise the per-vault loop, not just index 0.
+      await manager.preparePegin({
+        amounts: [TEST_AMOUNTS.PEGIN, TEST_AMOUNTS.PEGIN],
+        ...BASE_PREPARE_PEGIN_PARAMS,
+      });
+
+      expect(rebind).toHaveBeenCalledTimes(2);
+      // Each rebind call must pair the per-vault request with the wallet's
+      // response for THAT vault — MockBitcoinWallet.signPsbts produces
+      // `<requested>deadbeef`, so `returned[i]` must be `requested[i]deadbeef`.
+      rebind.mock.calls.forEach(([params], i) => {
+        expect(params.requestedPsbtHex).toBe(`requested_${i}`);
+        expect(params.returnedPsbtHex).toBe(`requested_${i}deadbeef`);
+      });
+    });
+
+    it("aborts preparePegin before sig extraction when the rebind helper rejects", async () => {
+      const { assertPsbtUnsignedTxMatches } = await import(
+        "../../primitives/psbt/assertPsbtUnsignedTxMatches"
+      );
+      const { extractPeginInputSignature } = await import(
+        "../../primitives/psbt/peginInput"
+      );
+      const rebind = vi.mocked(assertPsbtUnsignedTxMatches);
+      const extract = vi.mocked(extractPeginInputSignature);
+      rebind.mockClear();
+      extract.mockClear();
+      rebind.mockImplementationOnce(() => {
+        throw new Error("input 0 prevout txid differs (requested=ab… …)");
+      });
+
+      const btcWallet = new MockBitcoinWallet({
+        publicKeyHex: TEST_KEYS.DEPOSITOR,
+      });
+      const ethWallet = new MockEthereumWallet();
+      const manager = new PeginManager({
+        btcNetwork: "signet",
+        btcWallet,
+        ethWallet: ethWallet as any,
+        ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
+        vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
+        mempoolApiUrl: MEMPOOL_API_URLS.signet,
+      });
+
+      await expect(
+        manager.preparePegin({
+          amounts: [TEST_AMOUNTS.PEGIN],
+          ...BASE_PREPARE_PEGIN_PARAMS,
+        }),
+      ).rejects.toThrow(/prevout txid differs/);
+
+      expect(extract).not.toHaveBeenCalled();
     });
 
     it("should prepare a pegin with valid params", async () => {
@@ -1152,6 +1254,62 @@ describe("PeginManager", () => {
           depositorBtcPubkey: TEST_KEYS.DEPOSITOR,
         }),
       ).rejects.toThrow();
+    });
+
+    it("aborts before broadcast when the rebind helper rejects the wallet's PSBT", async () => {
+      const { assertPsbtUnsignedTxMatches } = await import(
+        "../../primitives/psbt/assertPsbtUnsignedTxMatches"
+      );
+      const rebind = vi.mocked(assertPsbtUnsignedTxMatches);
+
+      const btcWallet = new MockBitcoinWallet({
+        publicKeyHex: TEST_KEYS.DEPOSITOR,
+      });
+      const ethWallet = new MockEthereumWallet();
+      const manager = new PeginManager({
+        btcNetwork: "signet",
+        btcWallet,
+        ethWallet: ethWallet as any,
+        ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
+        vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
+        mempoolApiUrl: MEMPOOL_API_URLS.signet,
+      });
+
+      const prepared = await manager.preparePegin({
+        amounts: [TEST_AMOUNTS.PEGIN],
+        ...BASE_PREPARE_PEGIN_PARAMS,
+      });
+
+      // Provide localPrevouts so we don't hit the mempool. The funded tx's
+      // input set is a subset of TEST_UTXOS.
+      const localPrevouts = TEST_UTXOS.reduce<
+        Record<string, { scriptPubKey: string; value: number }>
+      >((acc, u) => {
+        acc[`${u.txid}:${u.vout}`] = {
+          scriptPubKey: u.scriptPubKey,
+          value: u.value,
+        };
+        return acc;
+      }, {});
+
+      // Fail the next rebind call so signAndBroadcast aborts before
+      // finalize/extract/pushTx. mockClear keeps prior preparePegin calls
+      // from leaking into our assertion.
+      rebind.mockClear();
+      rebind.mockImplementationOnce(() => {
+        throw new Error("output 0 scriptPubKey differs");
+      });
+
+      await expect(
+        manager.signAndBroadcast({
+          fundedPrePeginTxHex: prepared.transaction.fundedPrePeginTxHex,
+          depositorBtcPubkey: TEST_KEYS.DEPOSITOR,
+          localPrevouts,
+        }),
+      ).rejects.toThrow(/scriptPubKey differs/);
+
+      expect(rebind).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/babylon-ts-sdk/src/tbv/core/services/refund/__tests__/buildAndBroadcastRefund.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/refund/__tests__/buildAndBroadcastRefund.test.ts
@@ -18,6 +18,21 @@ vi.mock("../../../primitives/psbt/refund", () => ({
     .mockResolvedValue({ psbtHex: "70736274ff01mock" }),
 }));
 
+// Mocked: bitcoinjs-lib is mocked below, real helper would fail to parse.
+vi.mock(
+  "../../../primitives/psbt/assertPsbtUnsignedTxMatches",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("../../../primitives/psbt/assertPsbtUnsignedTxMatches")
+      >();
+    return {
+      ...actual,
+      assertPsbtUnsignedTxMatches: vi.fn(),
+    };
+  },
+);
+
 // Finalize + extract uses bitcoinjs-lib. We stub Psbt.fromHex to return an
 // object with controllable `finalizeAllInputs` / `extractTransaction`.
 vi.mock("bitcoinjs-lib", async () => {
@@ -134,6 +149,63 @@ describe("buildAndBroadcastRefund", () => {
       "signPsbt",
       "broadcastTx",
     ]);
+  });
+
+  it("rebinds the wallet-signed PSBT against the requested PSBT before broadcasting", async () => {
+    const { assertPsbtUnsignedTxMatches } = await import(
+      "../../../primitives/psbt/assertPsbtUnsignedTxMatches"
+    );
+    const rebind = vi.mocked(assertPsbtUnsignedTxMatches);
+    rebind.mockClear();
+
+    readVault.mockResolvedValue(buildVault());
+    readPrePeginContext.mockResolvedValue(buildCtx());
+    signPsbt.mockResolvedValue("signedpsbthex");
+    broadcastTx.mockResolvedValue({ txId: "0xrefundtxid" });
+
+    await buildAndBroadcastRefund({
+      vaultId: VAULT_ID,
+      readVault,
+      readPrePeginContext,
+      feeRate: FEE_RATE,
+      signPsbt,
+      broadcastTx,
+    });
+
+    expect(rebind).toHaveBeenCalledTimes(1);
+    expect(rebind).toHaveBeenCalledWith({
+      requestedPsbtHex: "70736274ff01mock",
+      returnedPsbtHex: "signedpsbthex",
+    });
+  });
+
+  it("aborts before broadcast when the rebind helper rejects the wallet's PSBT", async () => {
+    const { assertPsbtUnsignedTxMatches } = await import(
+      "../../../primitives/psbt/assertPsbtUnsignedTxMatches"
+    );
+    const rebind = vi.mocked(assertPsbtUnsignedTxMatches);
+    rebind.mockClear();
+    rebind.mockImplementationOnce(() => {
+      throw new Error("output 0 script differs");
+    });
+
+    readVault.mockResolvedValue(buildVault());
+    readPrePeginContext.mockResolvedValue(buildCtx());
+    signPsbt.mockResolvedValue("signedpsbthex");
+    broadcastTx.mockClear();
+
+    await expect(
+      buildAndBroadcastRefund({
+        vaultId: VAULT_ID,
+        readVault,
+        readPrePeginContext,
+        feeRate: FEE_RATE,
+        signPsbt,
+        broadcastTx,
+      }),
+    ).rejects.toThrow(/output 0 script differs/);
+
+    expect(broadcastTx).not.toHaveBeenCalled();
   });
 
   it("forwards broadcastTx rich result unchanged (generic pass-through)", async () => {

--- a/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts
@@ -15,6 +15,7 @@ import { Psbt } from "bitcoinjs-lib";
 import type { Address, Hex } from "viem";
 
 import type { SignPsbtOptions } from "../../../../shared/wallets/interfaces/BitcoinWallet";
+import { assertPsbtUnsignedTxMatches } from "../../primitives/psbt/assertPsbtUnsignedTxMatches";
 import { buildRefundPsbt } from "../../primitives/psbt/refund";
 import {
   processPublicKeyToXOnly,
@@ -361,6 +362,12 @@ export async function buildAndBroadcastRefund<
     REFUND_INPUT_COUNT,
   );
   const signedPsbtHex = await signPsbt(psbtHex, signOptions);
+
+  assertPsbtUnsignedTxMatches({
+    requestedPsbtHex: psbtHex,
+    returnedPsbtHex: signedPsbtHex,
+  });
+
   const signedTxHex = finalizeAndExtract(signedPsbtHex);
   signal?.throwIfAborted();
 

--- a/services/vault/src/services/vault/__tests__/vaultPeginBroadcastService.test.ts
+++ b/services/vault/src/services/vault/__tests__/vaultPeginBroadcastService.test.ts
@@ -1,3 +1,5 @@
+import { pushTx } from "@babylonlabs-io/ts-sdk";
+import { assertPsbtUnsignedTxMatches } from "@babylonlabs-io/ts-sdk/tbv/core/primitives";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Use vi.hoisted so mocks can reference these before module initialization
@@ -70,6 +72,19 @@ vi.mock("@babylonlabs-io/ts-sdk/tbv/core/utils", async (importOriginal) => {
     getPsbtInputFields: vi.fn(() => ({ witnessUtxo: {} })),
   };
 });
+vi.mock(
+  "@babylonlabs-io/ts-sdk/tbv/core/primitives",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("@babylonlabs-io/ts-sdk/tbv/core/primitives")
+      >();
+    return {
+      ...actual,
+      assertPsbtUnsignedTxMatches: vi.fn(),
+    };
+  },
+);
 vi.mock("../../../clients/btc/config", () => ({
   getMempoolApiUrl: vi.fn(() => "https://mempool.test"),
 }));
@@ -261,6 +276,44 @@ describe("broadcastPrePeginTransaction — resolveInputUtxo behavior", () => {
     ).resolves.toBe("mock-txid");
 
     expect(mockSignedPsbt.extractTransaction).toHaveBeenCalled();
+  });
+
+  it("rebinds the wallet-signed PSBT against the requested PSBT before broadcasting", async () => {
+    vi.mocked(assertPsbtUnsignedTxMatches).mockClear();
+    vi.mocked(pushTx).mockClear();
+
+    const customWallet = {
+      signPsbt: vi.fn().mockResolvedValue("wallet-returned-psbt-hex"),
+    };
+
+    await broadcastPrePeginTransaction({
+      ...baseParams,
+      btcWalletProvider: customWallet,
+      expectedUtxos: undefined,
+    });
+
+    expect(assertPsbtUnsignedTxMatches).toHaveBeenCalledTimes(1);
+    expect(assertPsbtUnsignedTxMatches).toHaveBeenCalledWith({
+      requestedPsbtHex: "mock-psbt-hex",
+      returnedPsbtHex: "wallet-returned-psbt-hex",
+    });
+  });
+
+  it("aborts before broadcast when the rebind helper rejects the wallet's PSBT", async () => {
+    vi.mocked(assertPsbtUnsignedTxMatches).mockImplementationOnce(() => {
+      throw new Error("output 0 script differs");
+    });
+    vi.mocked(pushTx).mockClear();
+
+    await expect(
+      broadcastPrePeginTransaction({
+        ...baseParams,
+        expectedUtxos: undefined,
+      }),
+    ).rejects.toThrow(/output 0 script differs/);
+
+    expect(pushTx).not.toHaveBeenCalled();
+    expect(mockSignedPsbt.extractTransaction).not.toHaveBeenCalled();
   });
 
   it("preserves PSBT finalization errors when the wallet returns a partially signed PSBT", async () => {

--- a/services/vault/src/services/vault/vaultPeginBroadcastService.ts
+++ b/services/vault/src/services/vault/vaultPeginBroadcastService.ts
@@ -11,6 +11,7 @@ import {
   TXID_RE,
   pushTx,
 } from "@babylonlabs-io/ts-sdk";
+import { assertPsbtUnsignedTxMatches } from "@babylonlabs-io/ts-sdk/tbv/core/primitives";
 import { getPsbtInputFields } from "@babylonlabs-io/ts-sdk/tbv/core/utils";
 import { Psbt, Transaction } from "bitcoinjs-lib";
 import { Buffer } from "buffer";
@@ -248,6 +249,12 @@ async function signAndFinalizePsbt(
   btcWalletProvider: { signPsbt: (psbtHex: string) => Promise<string> },
 ): Promise<string> {
   const signedPsbtHex = await btcWalletProvider.signPsbt(psbtHex);
+
+  assertPsbtUnsignedTxMatches({
+    requestedPsbtHex: psbtHex,
+    returnedPsbtHex: signedPsbtHex,
+  });
+
   const signedPsbt = Psbt.fromHex(signedPsbtHex);
 
   // Finalize inputs if not already finalized


### PR DESCRIPTION
- New SDK helper `assertSignedPsbtMatchesRequest` rebinds wallet-returned PSBTs
against the locally-built PSBT, comparing every field that affects the resulting tx or
 Taproot sighash (tx version/locktime, inputs, outputs, witnessUtxo, witnessScript,
sighashType, tapInternalKey, tapLeafScript).
- Wired into all 7 wallet-sign-then-trust sites across the SDK and vault:
PayoutManager (single + batch), signDepositorGraph, PeginManager (preparePegin +
signAndBroadcast), buildAndBroadcastRefund, and vaultPeginBroadcastService.
- Strict mode (default) rejects unrequested wallet auto-finalization on sig-extraction
 paths that depend on tapScriptSig/tapLeafScript metadata. `allowFinalized: true` on
broadcast paths where Bitcoin consensus at relay is the backstop.