### PR TITLE
feat(wallet-connector): refuse to connect outdated Unisat extensions

### DIFF
--- a/packages/babylon-wallet-connector/src/core/wallets/btc/unisat/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/unisat/provider.ts
@@ -8,6 +8,7 @@ import { resolveUseTweakedSigner } from "@/core/utils/psbtOptionsMapper";
 import { ERROR_CODES, WalletError, isUserRejectionMessage } from "@/error";
 
 import logo from "./logo.svg";
+import { MIN_UNISAT_VERSION, checkUnisatVersion } from "./version";
 
 enum UnisatChainEnum {
   BITCOIN_SIGNET = "BITCOIN_SIGNET",
@@ -89,6 +90,11 @@ export class UnisatProvider implements IBTCProvider {
       }
     }
 
+    // Run after requestAccounts so origin permission is already granted —
+    // getVersion() then resolves synchronously off PlatformEnv.VERSION with
+    // no further user prompt.
+    await this.ensureSupportedVersion();
+
     // Unisat silently returns a wrong-network (or empty) account if the wallet
     // is on a chain the dApp does not target. Align the wallet to the configured
     // network before reading the address/pubkey so the connection cannot succeed
@@ -114,6 +120,51 @@ export class UnisatProvider implements IBTCProvider {
         wallet: WALLET_PROVIDER_NAME,
       });
     }
+  };
+
+  private ensureSupportedVersion = async (): Promise<void> => {
+    // Missing method = an old build that pre-dates getVersion().
+    if (typeof this.provider.getVersion !== "function") {
+      throw new WalletError({
+        code: ERROR_CODES.INCOMPATIBLE_WALLET_VERSION,
+        message: `Your Unisat Wallet extension is out of date. Please update to version ${MIN_UNISAT_VERSION} or later and try again.`,
+        wallet: WALLET_PROVIDER_NAME,
+      });
+    }
+
+    // Locked wallet / busy / transient RPC error — not an upgrade issue, so
+    // surface as CONNECTION_FAILED rather than telling the user to update.
+    let raw: unknown;
+    try {
+      raw = await this.provider.getVersion();
+    } catch (error) {
+      throw new WalletError({
+        code: ERROR_CODES.CONNECTION_FAILED,
+        message: (error as Error)?.message || "Failed to read Unisat Wallet version",
+        wallet: WALLET_PROVIDER_NAME,
+      });
+    }
+
+    const result = checkUnisatVersion(raw);
+    if (result === "ok") return;
+
+    if (result === "below") {
+      throw new WalletError({
+        code: ERROR_CODES.INCOMPATIBLE_WALLET_VERSION,
+        message: `Your Unisat Wallet extension is out of date (${raw}). Please update to version ${MIN_UNISAT_VERSION} or later and try again.`,
+        wallet: WALLET_PROVIDER_NAME,
+        version: raw as string,
+      });
+    }
+
+    // Non-canonical version string (e.g. `v1.7.14`, `1.7.14-beta`, fork
+    // build): fail closed without claiming "out of date" — could be a fresh
+    // build that happens to emit a non-standard format.
+    throw new WalletError({
+      code: ERROR_CODES.INCOMPATIBLE_WALLET_VERSION,
+      message: `Unable to verify your Unisat Wallet version${typeof raw === "string" ? ` (got "${raw}")` : ""}. Please install the official Unisat Wallet ${MIN_UNISAT_VERSION} or later and try again.`,
+      wallet: WALLET_PROVIDER_NAME,
+    });
   };
 
   private ensureExpectedChain = async (): Promise<void> => {

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/unisat/version.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/unisat/version.ts
@@ -1,0 +1,33 @@
+// 1.7.14 is the first UniSat release that binds `deriveContextHash` to the
+// connected pubkey + network. Older builds derive a different hash for the
+// same inputs and would silently desync against btc-vault flows.
+// Source: unisat-wallet/wallet commit 51c0939298c621ecce7eba6acd7e7ec889ee1f61
+// ("feat(keyring): bind deriveContextHash to network + connected pubkey"),
+// first shipped in tag extension/v1.7.14.
+export const MIN_UNISAT_VERSION = "1.7.14";
+
+const MIN_UNISAT_PARTS = MIN_UNISAT_VERSION.split(".").map(Number) as [number, number, number];
+
+// Strict canonical semver — reject `v1.7.14`, `1.7.14-beta`, `dev`, leading
+// zeros (`01.7.14`, `1.07.14`), and any non-canonical format. The numeric
+// comparison below cannot be defeated by string collation quirks (e.g.
+// `localeCompare` ranks `"dev" > "1"`).
+const SEMVER_RE = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+
+export type UnisatVersionCheck = "ok" | "below" | "unparseable";
+
+/**
+ * Compares a raw `getVersion()` value against {@link MIN_UNISAT_VERSION}.
+ * Returns `"unparseable"` for non-string input or any string that is not
+ * strict canonical `MAJOR.MINOR.PATCH` — fail-closed for fork/canary builds
+ * that emit non-standard formats.
+ */
+export function checkUnisatVersion(raw: unknown): UnisatVersionCheck {
+  const match = typeof raw === "string" ? SEMVER_RE.exec(raw) : null;
+  if (!match) return "unparseable";
+  const cmp =
+    Number(match[1]) - MIN_UNISAT_PARTS[0] ||
+    Number(match[2]) - MIN_UNISAT_PARTS[1] ||
+    Number(match[3]) - MIN_UNISAT_PARTS[2];
+  return cmp >= 0 ? "ok" : "below";
+}

--- a/packages/babylon-wallet-connector/src/hooks/useWalletConnectors.tsx
+++ b/packages/babylon-wallet-connector/src/hooks/useWalletConnectors.tsx
@@ -5,8 +5,18 @@ import { useInscriptionProvider } from "@/context/Inscriptions.context";
 import { useLifeCycleHooks } from "@/context/LifecycleHooks.context";
 import { HashMap, IChain, IWallet } from "@/core/types";
 import { validateAddress, validateAddressWithPK } from "@/core/utils/wallet";
+import { ERROR_CODES, WalletError } from "@/error";
 
 import { useWidgetState } from "./useWidgetState";
+
+/**
+ * Connection-time WalletError codes that the user must see in-dialog —
+ * silently bouncing back to chain selection would leave the user with no
+ * idea why their wallet didn't connect.
+ */
+const TERMINAL_CONNECT_ERROR_CODES: ReadonlySet<string> = new Set([
+  ERROR_CODES.INCOMPATIBLE_WALLET_VERSION,
+]);
 
 interface Props {
   persistent: boolean;
@@ -201,12 +211,39 @@ export function useWalletConnectors({ persistent, accountStorage, onError }: Pro
     const unsubscribeArr = connectorArr.filter(Boolean).map((connector) =>
       connector.on("error", (error: Error) => {
         onError?.(error);
+
+        // Terminal errors (e.g. the wallet extension is too old) need an
+        // in-dialog message so the user can act on them. Anything else
+        // falls through to the existing "bounce back to chains" behaviour
+        // — host apps' `onError` callbacks still get the raw error.
+        // Guard on `displayError` directly so we still fall through to
+        // `displayChains?.()` below if the dialog state isn't wired up;
+        // otherwise the user could be stranded on the current screen.
+        if (
+          error instanceof WalletError &&
+          TERMINAL_CONNECT_ERROR_CODES.has(error.code) &&
+          displayError
+        ) {
+          const walletName = error.wallet ?? "your wallet";
+          displayError({
+            title: `Update ${walletName}`,
+            description:
+              error.message || `${walletName} needs to be updated before you can connect.`,
+            submitButton: "",
+            cancelButton: "Done",
+            onCancel: () => {
+              displayChains?.();
+            },
+          });
+          return;
+        }
+
         displayChains?.();
       }),
     );
 
     return () => unsubscribeArr.forEach((unsubscribe) => unsubscribe());
-  }, [onError, displayChains, connectors]);
+  }, [onError, displayChains, displayError, connectors]);
 
   useEffect(() => {
     const requiredChainIds = Object.values(chainMap).filter(Boolean).map(chain => chain.id);

--- a/packages/babylon-wallet-connector/tests/unit/unisatVersion.test.ts
+++ b/packages/babylon-wallet-connector/tests/unit/unisatVersion.test.ts
@@ -1,0 +1,88 @@
+import { expect, test } from "@playwright/test";
+
+import { checkUnisatVersion } from "../../src/core/wallets/btc/unisat/version";
+
+test.describe("checkUnisatVersion — UniSat extension version gate (MIN = 1.7.14)", () => {
+  test("returns 'ok' for the exact minimum '1.7.14'", () => {
+    expect(checkUnisatVersion("1.7.14")).toBe("ok");
+  });
+
+  test("returns 'ok' for a higher patch '1.7.15'", () => {
+    expect(checkUnisatVersion("1.7.15")).toBe("ok");
+  });
+
+  test("returns 'ok' for a higher minor '1.8.0'", () => {
+    expect(checkUnisatVersion("1.8.0")).toBe("ok");
+  });
+
+  test("returns 'ok' for a higher major '2.0.0'", () => {
+    expect(checkUnisatVersion("2.0.0")).toBe("ok");
+  });
+
+  test("returns 'ok' for '1.10.0' — numeric comparison, not string collation", () => {
+    expect(checkUnisatVersion("1.10.0")).toBe("ok");
+  });
+
+  test("returns 'below' for the previous patch '1.7.13'", () => {
+    expect(checkUnisatVersion("1.7.13")).toBe("below");
+  });
+
+  test("returns 'below' for an older minor '1.6.99'", () => {
+    expect(checkUnisatVersion("1.6.99")).toBe("below");
+  });
+
+  test("returns 'below' for an older major '0.99.99'", () => {
+    expect(checkUnisatVersion("0.99.99")).toBe("below");
+  });
+
+  // Non-canonical strings must NOT slip through as 'ok' or 'below' — those
+  // branches imply we successfully parsed a real version number. Fork or
+  // canary builds get a distinct "unable to verify" prompt downstream.
+  test("returns 'unparseable' for a v-prefixed version 'v1.7.14'", () => {
+    expect(checkUnisatVersion("v1.7.14")).toBe("unparseable");
+  });
+
+  test("returns 'unparseable' for a prerelease suffix '1.7.14-beta'", () => {
+    expect(checkUnisatVersion("1.7.14-beta")).toBe("unparseable");
+  });
+
+  test("returns 'unparseable' for a build-metadata suffix '1.7.14+abc'", () => {
+    expect(checkUnisatVersion("1.7.14+abc")).toBe("unparseable");
+  });
+
+  test("returns 'unparseable' for a non-numeric tag 'dev'", () => {
+    expect(checkUnisatVersion("dev")).toBe("unparseable");
+  });
+
+  test("returns 'unparseable' for a two-part string '1.7'", () => {
+    expect(checkUnisatVersion("1.7")).toBe("unparseable");
+  });
+
+  test("returns 'unparseable' for the empty string", () => {
+    expect(checkUnisatVersion("")).toBe("unparseable");
+  });
+
+  test("returns 'unparseable' for undefined (e.g. provider returns nothing)", () => {
+    expect(checkUnisatVersion(undefined)).toBe("unparseable");
+  });
+
+  test("returns 'unparseable' for a non-string value (number)", () => {
+    expect(checkUnisatVersion(1.714)).toBe("unparseable");
+  });
+
+  test("returns 'unparseable' for a leading-zero major '01.7.14'", () => {
+    expect(checkUnisatVersion("01.7.14")).toBe("unparseable");
+  });
+
+  test("returns 'unparseable' for a leading-zero minor '1.07.14'", () => {
+    expect(checkUnisatVersion("1.07.14")).toBe("unparseable");
+  });
+
+  test("returns 'unparseable' for a leading-zero patch '1.7.014'", () => {
+    expect(checkUnisatVersion("1.7.014")).toBe("unparseable");
+  });
+
+  test("returns 'below' for '0.0.0' — bare '0' components must parse, not get caught by the leading-zero reject", () => {
+    expect(checkUnisatVersion("0.0.0")).toBe("below");
+  });
+});


### PR DESCRIPTION
- Refuse to connect Unisat extensions below `MIN_UNISAT_VERSION = "1.7.14"` so users
on builds that predate recent Unisat API changes are pushed to upgrade instead of
silently misbehaving later in the flow. Cutoff is pinned to upstream commit
`51c0939298c621ecce7eba6acd7e7ec889ee1f61` ("feat(keyring): bind deriveContextHash
to network + connected pubkey"), first shipped in tag `extension/v1.7.14`.
- Version check uses strict canonical semver (`^(\d+)\.(\d+)\.(\d+)$`) and numeric
tuple comparison. Non-canonical strings (`v1.7.14`, `1.7.14-beta`, `dev`, fork
builds) are rejected with a distinct "unable to verify" message rather than a
potentially-misleading "out of date" prompt — fails closed without claiming the
user is behind.
- A `getVersion()` runtime exception (locked wallet, busy, transient RPC) maps
to `CONNECTION_FAILED`, not `INCOMPATIBLE_WALLET_VERSION` — avoids telling a
user with a locked wallet to upgrade.
- Terminal connect-time errors now flow through the in-dialog `displayError`
screen (previously the "error" event handler silently bounced back to chain
selection, so the user never saw the upgrade message). Routing uses
`error instanceof WalletError` for type-safe access to `.code` / `.wallet`.


<img width="816" height="462" alt="image" src="https://github.com/user-attachments/assets/4f3830d6-2dcf-4f36-a323-3b14bdc39f2e" />
