### PR TITLE
chore(ts-sdk, vault): address post-merge review feedback from #1660/#…

### DIFF
--- a/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
@@ -61,6 +61,7 @@ import {
   isAddressFromPublicKey,
   stripHexPrefix,
   uint8ArrayToHex,
+  X_ONLY_PUBKEY_HEX_LEN,
 } from "../primitives/utils/bitcoin";
 import {
   calculateBtcTxHash,
@@ -470,6 +471,32 @@ export interface RegisterPeginBatchResult {
   vaults: BatchPeginResultItem[];
 }
 
+
+/**
+ * Detect a P2WPKH (Native SegWit) bech32 address for the configured network,
+ * used purely for diagnostic routing. Distinguishes P2WPKH (witness v0,
+ * 20-byte program) from P2WSH (v0, 32-byte program) and any other bech32
+ * shape, so the specific "use a P2TR" error fires only when the user
+ * actually has a P2WPKH address.
+ */
+function isP2wpkhAddressForNetwork(address: string, network: Network): boolean {
+  const expectedHrp: Record<Network, string> = {
+    bitcoin: "bc",
+    testnet: "tb",
+    signet: "tb",
+    regtest: "bcrt",
+  };
+  try {
+    const decoded = bitcoin.address.fromBech32(address);
+    return (
+      decoded.prefix === expectedHrp[network] &&
+      decoded.version === 0 &&
+      decoded.data.length === 20
+    );
+  } catch {
+    return false;
+  }
+}
 
 /**
  * Resolve prevout data for a transaction input.
@@ -1434,6 +1461,23 @@ export class PeginManager {
         this.config.btcNetwork,
       )
     ) {
+      // Diagnostic carve-out: x-only key + P2WPKH address always fails (y-parity
+      // is unknowable from x-only). Surface a specific, actionable message so
+      // Taproot-wallet integrators don't have to chase the generic mismatch.
+      const isXOnlyKey =
+        stripHexPrefix(verifiedDepositorBtcPubkeyRaw).length ===
+        X_ONLY_PUBKEY_HEX_LEN;
+      if (
+        isXOnlyKey &&
+        isP2wpkhAddressForNetwork(address, this.config.btcNetwork)
+      ) {
+        throw new Error(
+          `BTC payout address "${address}" is a P2WPKH (Native SegWit) address, ` +
+            `but the connected wallet only exposes an x-only public key. ` +
+            `P2WPKH validation requires a compressed key with known y-parity. ` +
+            `Use a P2TR (Taproot) payout address instead.`,
+        );
+      }
       throw new Error(
         `BTC payout address "${address}" is not derived from the connected ` +
           `wallet's public key. The payout sink must be controlled by the same ` +

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PeginManager.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PeginManager.test.ts
@@ -5,6 +5,8 @@
  * using primitives, utilities, and mock wallets.
  */
 
+import * as bitcoin from "bitcoinjs-lib";
+import { Buffer } from "buffer";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import { zeroAddress, type Address, type Chain, type PublicClient } from "viem";
 
@@ -1634,7 +1636,8 @@ describe("PeginManager", () => {
       // contract. With only an x-only key in hand, y-parity is unknowable;
       // accepting any P2WPKH derived from 02|x or 03|x would let an attacker
       // bind a script the wallet doesn't control. Both parities must be
-      // rejected at the helper level (parity-swap finding follow-up).
+      // rejected at the helper level (parity-swap finding follow-up). The
+      // diagnostic message points integrators at the actual fix (use P2TR).
       const xOnly = TEST_KEYS.DEPOSITOR;
       const evenAddr = deriveNativeSegwitAddress(`02${xOnly}`, "signet");
       const oddAddr = deriveNativeSegwitAddress(`03${xOnly}`, "signet");
@@ -1665,9 +1668,51 @@ describe("PeginManager", () => {
             popSignature,
           }),
         ).rejects.toThrow(
-          /BTC payout address .* is not derived from the connected wallet/i,
+          /P2WPKH .* x-only public key.*Use a P2TR/i,
         );
       }
+    });
+
+    it("registerPeginOnChain falls back to the generic mismatch error for an x-only key paired with a non-P2WPKH bech32 address (P2WSH)", async () => {
+      // Regression guard: the diagnostic carve-out must distinguish P2WPKH
+      // (witness v0, 20-byte program) from other v0 segwit shapes like
+      // P2WSH (32-byte program). A misfire here would tell a user with a
+      // P2WSH payout address to "use a P2TR" when the real problem is that
+      // their address simply isn't derived from the connected wallet.
+      const xOnly = TEST_KEYS.DEPOSITOR;
+      const p2wshAddress = bitcoin.payments.p2wsh({
+        hash: Buffer.alloc(32, 0xab),
+        network: bitcoin.networks.testnet,
+      }).address!;
+      expect(p2wshAddress.startsWith("tb1q")).toBe(true);
+
+      const btcWallet = new MockBitcoinWallet({ publicKeyHex: xOnly });
+      const ethWallet = new MockEthereumWallet();
+      const manager = new PeginManager({
+        btcNetwork: "signet",
+        btcWallet,
+        ethWallet: ethWallet as any,
+        ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
+        vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
+        mempoolApiUrl: MEMPOOL_API_URLS.signet,
+      });
+      const popSignature = await manager.signProofOfPossession();
+
+      await expect(
+        manager.registerPeginOnChain({
+          unsignedPrePeginTx: "0100000000010000000000",
+          depositorSignedPeginTx: MOCK_DEPOSITOR_SIGNED_PEGIN_TX,
+          vaultProvider: TEST_CONTRACT_ADDRESS,
+          hashlock: MOCK_HASHLOCK,
+          htlcVout: 0,
+          depositorPayoutBtcAddress: p2wshAddress,
+          depositorWotsPkHash: MOCK_WOTS_PK_HASH,
+          popSignature,
+        }),
+      ).rejects.toThrow(
+        /BTC payout address .* is not derived from the connected wallet/i,
+      );
     });
 
     it("registerPeginBatchOnChain rejects when any single request has a foreign payout address", async () => {

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/assertPsbtUnsignedTxMatches.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/assertPsbtUnsignedTxMatches.test.ts
@@ -144,6 +144,30 @@ describe("assertPsbtUnsignedTxMatches", () => {
     ).toThrow(/input 0 prevout txid differs/);
   });
 
+  it("throws when an input prevout vout has been changed", () => {
+    const requestedHex = buildBasePsbt({ prevoutVout: 0 }).toHex();
+    const returnedHex = buildBasePsbt({ prevoutVout: 1 }).toHex();
+    expect(() =>
+      assertPsbtUnsignedTxMatches({
+        requestedPsbtHex: requestedHex,
+        returnedPsbtHex: returnedHex,
+      }),
+    ).toThrow(/input 0 prevout vout differs \(requested=0, returned=1\)/);
+  });
+
+  it("throws when tx version differs", () => {
+    const requested = buildBasePsbt();
+    requested.setVersion(1);
+    const returned = buildBasePsbt();
+    returned.setVersion(2);
+    expect(() =>
+      assertPsbtUnsignedTxMatches({
+        requestedPsbtHex: requested.toHex(),
+        returnedPsbtHex: returned.toHex(),
+      }),
+    ).toThrow(/tx version differs \(requested=1, returned=2\)/);
+  });
+
   it("throws when input count differs", () => {
     const requestedHex = buildBasePsbt().toHex();
     const returned = buildBasePsbt();

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/utils/__tests__/bitcoin.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/utils/__tests__/bitcoin.test.ts
@@ -488,8 +488,9 @@ describe("Bitcoin Utilities", () => {
   });
 
   describe("isAddressFromPublicKey", () => {
-    // Any valid 32-byte x-only key works as a fixture; the exact value
-    // doesn't matter, only the derivation parity does.
+    // Using the secp256k1 generator point's x-coordinate (G.x); any valid
+    // 32-byte x-only key would do — the test only depends on derivation
+    // parity, not the value.
     const xOnly =
       "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
     const evenParity = `02${xOnly}`;
@@ -500,14 +501,26 @@ describe("Bitcoin Utilities", () => {
       expect(isAddressFromPublicKey(addr, xOnly, "signet")).toBe(true);
     });
 
-    it("matches a P2WPKH address derived from the same compressed key", () => {
+    it("matches a P2WPKH address derived from an even-parity compressed key", () => {
       const addr = deriveNativeSegwitAddress(evenParity, "signet");
       expect(isAddressFromPublicKey(addr, evenParity, "signet")).toBe(true);
     });
 
-    it("rejects an opposite-parity P2WPKH address for a compressed key", () => {
+    it("matches a P2WPKH address derived from an odd-parity compressed key", () => {
+      const addr = deriveNativeSegwitAddress(oddParity, "signet");
+      expect(isAddressFromPublicKey(addr, oddParity, "signet")).toBe(true);
+    });
+
+    it("rejects an opposite-parity P2WPKH address for an even-parity key", () => {
       const wrongAddr = deriveNativeSegwitAddress(oddParity, "signet");
       expect(isAddressFromPublicKey(wrongAddr, evenParity, "signet")).toBe(
+        false,
+      );
+    });
+
+    it("rejects an opposite-parity P2WPKH address for an odd-parity key", () => {
+      const wrongAddr = deriveNativeSegwitAddress(evenParity, "signet");
+      expect(isAddressFromPublicKey(wrongAddr, oddParity, "signet")).toBe(
         false,
       );
     });

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts
@@ -430,6 +430,11 @@ function extractDepositorGraphSignatures(
   challengerEntries: ChallengerEntry[],
   depositorPubkey: string,
 ): DepositorAsClaimerPresignatures {
+  // Positional invariant: psbtPairs[0] is the payout PSBT; per-challenger
+  // nopayouts live at indices recorded in `challengerEntries[].noPayoutIdx`.
+  // Set up by `collectDepositorGraphPsbts` (payout pushed first, then each
+  // nopayout). A future refactor that reorders the array would silently
+  // extract the wrong signature for the wrong slot — Critical Path #3.
   assertPsbtUnsignedTxMatches(psbtPairs[0]);
   const payoutSignature = extractPayoutSignature(
     psbtPairs[0].returnedPsbtHex,

--- a/services/vault/src/applications/aave/services/__tests__/getUserPositionsWithLiveData.test.ts
+++ b/services/vault/src/applications/aave/services/__tests__/getUserPositionsWithLiveData.test.ts
@@ -22,7 +22,6 @@ vi.mock("../../clients", () => ({
 
 vi.mock("../fetchPositions", () => ({
   fetchAaveActivePositionsWithCollaterals: mockFetchActive,
-  fetchAavePositionByDepositor: vi.fn(),
 }));
 
 import { getUserPositionsWithLiveData } from "../positionService";

--- a/services/vault/src/applications/aave/services/fetchPositions.ts
+++ b/services/vault/src/applications/aave/services/fetchPositions.ts
@@ -144,18 +144,6 @@ const GET_AAVE_ACTIVE_POSITIONS_WITH_COLLATERALS = gql`
   }
 `;
 
-const GET_AAVE_POSITION_BY_DEPOSITOR = gql`
-  query GetAavePositionByDepositor($depositorAddress: String!) {
-    aavePosition(depositorAddress: $depositorAddress) {
-      depositorAddress
-      proxyContract
-      totalCollateral
-      createdAt
-      updatedAt
-    }
-  }
-`;
-
 /**
  * Maps a GraphQL position item to AavePosition
  */
@@ -221,26 +209,4 @@ export async function fetchAaveActivePositionsWithCollaterals(
       mapGraphQLCollateralToAavePositionCollateral,
     ),
   }));
-}
-
-/**
- * Fetches a single Aave position by depositor address from the GraphQL indexer.
- *
- * @param depositorAddress - User's Ethereum address
- * @returns Aave position or null if not found
- */
-export async function fetchAavePositionByDepositor(
-  depositorAddress: string,
-): Promise<AavePosition | null> {
-  const response = await graphqlClient.request<{
-    aavePosition: GraphQLPositionItem | null;
-  }>(GET_AAVE_POSITION_BY_DEPOSITOR, {
-    depositorAddress: depositorAddress.toLowerCase(),
-  });
-
-  if (!response.aavePosition) {
-    return null;
-  }
-
-  return mapGraphQLPositionToAavePosition(response.aavePosition);
 }

--- a/services/vault/src/applications/aave/services/index.ts
+++ b/services/vault/src/applications/aave/services/index.ts
@@ -9,7 +9,6 @@ export {
 // GraphQL: Positions
 export {
   fetchAaveActivePositionsWithCollaterals,
-  fetchAavePositionByDepositor,
   type AavePosition,
   type AavePositionCollateral,
   type AavePositionWithCollaterals,


### PR DESCRIPTION
Single follow-up PR addressing 6 unaddressed review comments from gbarkhatov on
already-merged PRs #1660, #1671, #1672.

- **#1671** — Zero-dead-code: drop `fetchAavePositionByDepositor` chain (function + GraphQL
const + barrel re-export + stale mock).
- **#1672** — Positional-invariant comment in `extractDepositorGraphSignatures` (Critical
Path #3) + 2 missing mismatch-branch tests (`tx version differs`, `prevout vout differs`).
- **#1660** — Odd-parity P2WPKH positive + negative tests for `isAddressFromPublicKey`; G.x
comment on the test fixture; specific "x-only key + P2WPKH → use P2TR" diagnostic in
`PeginManager.resolvePayoutScriptPubKey`, with a P2WSH regression test guarding the
precision of the carve-out.