### PR TITLE
fix(ts-sdk, vault): implement fee safety

### DIFF
--- a/packages/babylon-ts-sdk/src/tbv/core/services/refund/__tests__/buildAndBroadcastRefund.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/refund/__tests__/buildAndBroadcastRefund.test.ts
@@ -4,6 +4,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   BIP68NotMatureError,
   buildAndBroadcastRefund,
+  REFUND_MAX_FEE_FRACTION_DENOMINATOR,
+  REFUND_MAX_FEE_FRACTION_NUMERATOR,
+  REFUND_MAX_FEE_RATE_SATS_VB,
+  REFUND_VSIZE,
   type BtcBroadcaster,
   type RefundPrePeginContext,
   type VaultRefundData,
@@ -526,6 +530,93 @@ describe("buildAndBroadcastRefund", () => {
         }),
       ).rejects.toThrow(/feeRate must be a positive number/);
       expect(mockedBuildRefundPsbt).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("fee safety caps", () => {
+    it("rejects feeRate above REFUND_MAX_FEE_RATE_SATS_VB before PSBT construction", async () => {
+      await expect(
+        buildAndBroadcastRefund({
+          vaultId: VAULT_ID,
+          readVault,
+          readPrePeginContext,
+          feeRate: REFUND_MAX_FEE_RATE_SATS_VB + 1,
+          signPsbt,
+          broadcastTx,
+        }),
+      ).rejects.toThrow(
+        new RegExp(
+          `feeRate ${REFUND_MAX_FEE_RATE_SATS_VB + 1} sat/vB exceeds refund safety cap ${REFUND_MAX_FEE_RATE_SATS_VB} sat/vB`,
+        ),
+      );
+      expect(mockedBuildRefundPsbt).not.toHaveBeenCalled();
+      expect(signPsbt).not.toHaveBeenCalled();
+      expect(broadcastTx).not.toHaveBeenCalled();
+    });
+
+    it("rejects refund whose fee exceeds the fraction cap of vault.amount", async () => {
+      // Rate inside the per-vbyte ceiling but absolute fee > 10% of vault.
+      // Default vault.amount = 100_000n → fraction cap = 10_000 sats.
+      // feeRate=100 → refundFee = 100 * 160 = 16_000 > 10_000.
+      await expect(
+        buildAndBroadcastRefund({
+          vaultId: VAULT_ID,
+          readVault,
+          readPrePeginContext,
+          feeRate: 100,
+          signPsbt,
+          broadcastTx,
+        }),
+      ).rejects.toThrow(
+        /Refund fee 16000 sats exceeds the per-vault safety cap of 10000 sats/,
+      );
+      expect(mockedBuildRefundPsbt).not.toHaveBeenCalled();
+      expect(signPsbt).not.toHaveBeenCalled();
+      expect(broadcastTx).not.toHaveBeenCalled();
+    });
+
+    it("allows refund at exactly the rate cap when the vault is large enough to clear the fraction cap", async () => {
+      // refundFee at rate cap = REFUND_MAX_FEE_RATE_SATS_VB * REFUND_VSIZE.
+      // Pick vault.amount such that fraction cap >= refundFee.
+      const refundFeeAtRateCap = BigInt(REFUND_MAX_FEE_RATE_SATS_VB * REFUND_VSIZE);
+      const minVaultAmount =
+        (refundFeeAtRateCap * REFUND_MAX_FEE_FRACTION_DENOMINATOR) /
+        REFUND_MAX_FEE_FRACTION_NUMERATOR;
+      readVault.mockResolvedValue(buildVault({ amount: minVaultAmount }));
+
+      await buildAndBroadcastRefund({
+        vaultId: VAULT_ID,
+        readVault,
+        readPrePeginContext,
+        feeRate: REFUND_MAX_FEE_RATE_SATS_VB,
+        signPsbt,
+        broadcastTx,
+      });
+
+      expect(mockedBuildRefundPsbt).toHaveBeenCalledWith(
+        expect.objectContaining({ refundFee: refundFeeAtRateCap }),
+      );
+      expect(broadcastTx).toHaveBeenCalled();
+    });
+
+    it("allows refund whose fee exactly equals the fraction cap", async () => {
+      // vault.amount = 160_000 → fraction cap = 16_000 sats.
+      // feeRate=100 → refundFee = 16_000. Equality must pass (cap is `>`, not `>=`).
+      readVault.mockResolvedValue(buildVault({ amount: 160_000n }));
+
+      await buildAndBroadcastRefund({
+        vaultId: VAULT_ID,
+        readVault,
+        readPrePeginContext,
+        feeRate: 100,
+        signPsbt,
+        broadcastTx,
+      });
+
+      expect(mockedBuildRefundPsbt).toHaveBeenCalledWith(
+        expect.objectContaining({ refundFee: 16_000n }),
+      );
+      expect(broadcastTx).toHaveBeenCalled();
     });
   });
 

--- a/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts
@@ -42,6 +42,24 @@ const PUBKEY_HEX_RE = /^(?:0x)?(?:[0-9a-fA-F]{64}|[0-9a-fA-F]{66})$/;
 // This is protocol-owned knowledge; callers don't parameterise it.
 export const REFUND_VSIZE = 160;
 
+// Hard upper bound on the per-vbyte fee rate the SDK will sign a refund at.
+// Defense-in-depth: a compromised mempool endpoint can legally return up to
+// 10_000 sat/vB (see mempoolApi.ts `MAX_FEE_RATE`), which on a 160-vbyte
+// refund would burn up to 1.6M sats in miner fees. April 2024 Runes peak
+// `fastestFee` ≈ 1,805 sat/vB; `halfHourFee` at that peak was ~600. 500
+// covers realistic congestion with margin and blocks the pathological-
+// default attack 20× over.
+export const REFUND_MAX_FEE_RATE_SATS_VB = 500;
+
+// Hard upper bound on the absolute refund fee as a fraction of the vault
+// amount. Protects small vaults where even a moderate fee rate burns a
+// disproportionate share (e.g. on a 100k-sat vault, 500 sat/vB would burn
+// 80%). The fraction cap binds before the rate cap whenever the vault is
+// small. Expressed as numerator/denominator to keep arithmetic in bigint
+// and avoid float-precision drift in the comparison.
+export const REFUND_MAX_FEE_FRACTION_NUMERATOR = 10n;
+export const REFUND_MAX_FEE_FRACTION_DENOMINATOR = 100n;
+
 /**
  * Network fee (sats) the SDK will charge for a refund tx at the given
  * sat/vB rate. Mirrors the internal computation in
@@ -320,7 +338,31 @@ export async function buildAndBroadcastRefund<
   if (!Number.isFinite(feeRate) || feeRate <= 0) {
     throw new Error(`feeRate must be a positive number, got ${feeRate}`);
   }
+  // Rate cap: fail closed before PSBT construction if the seeded value
+  // exceeds the safety ceiling. A compromised mempool API (or upstream
+  // proxy / BGP hijack) can otherwise drive `halfHourFee` to the API's
+  // 10_000 sat/vB ceiling and burn the refund as miner fee.
+  if (feeRate > REFUND_MAX_FEE_RATE_SATS_VB) {
+    throw new Error(
+      `feeRate ${feeRate} sat/vB exceeds refund safety cap ` +
+        `${REFUND_MAX_FEE_RATE_SATS_VB} sat/vB; refusing to sign refund.`,
+    );
+  }
   const refundFee = BigInt(Math.ceil(feeRate * REFUND_VSIZE));
+  // Fraction cap: even within the rate ceiling, refuse to sign if the
+  // absolute fee would consume more than the configured percentage of the
+  // vault amount. Protects small vaults from disproportionate burn.
+  const maxFeeByFraction =
+    (vault.amount * REFUND_MAX_FEE_FRACTION_NUMERATOR) /
+    REFUND_MAX_FEE_FRACTION_DENOMINATOR;
+  if (refundFee > maxFeeByFraction) {
+    throw new Error(
+      `Refund fee ${refundFee} sats exceeds the per-vault safety cap ` +
+        `of ${maxFeeByFraction} sats ` +
+        `(${REFUND_MAX_FEE_FRACTION_NUMERATOR}/${REFUND_MAX_FEE_FRACTION_DENOMINATOR} ` +
+        `of vault.amount=${vault.amount}); refusing to sign refund.`,
+    );
+  }
   signal?.throwIfAborted();
 
   // `vault.depositorBtcPubkey` may arrive as wallet-native compressed sec1

--- a/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts
@@ -45,11 +45,18 @@ export const REFUND_VSIZE = 160;
 // Hard upper bound on the per-vbyte fee rate the SDK will sign a refund at.
 // Defense-in-depth: a compromised mempool endpoint can legally return up to
 // 10_000 sat/vB (see mempoolApi.ts `MAX_FEE_RATE`), which on a 160-vbyte
-// refund would burn up to 1.6M sats in miner fees. April 2024 Runes peak
-// `fastestFee` ≈ 1,805 sat/vB; `halfHourFee` at that peak was ~600. 500
-// covers realistic congestion with margin and blocks the pathological-
-// default attack 20× over.
-export const REFUND_MAX_FEE_RATE_SATS_VB = 500;
+// refund would burn up to 1.6M sats in miner fees.
+//
+// Sizing: during the April 2024 halving / Runes launch `fastestFee` peaked
+// around 1,800 sat/vB, and `halfHourFee` tracked close to it during the
+// worst of the congestion (~1,000–1,500 sat/vB range — the half-hour
+// bucket converges with the fastest bucket when the queue is deep enough).
+// 2000 leaves ~1.3× margin over that historical extreme so the cap doesn't
+// gate legitimate refunds during a comparable event, while still blocking
+// the obvious malicious case (10_000) by 5×. Small-vault burn is bounded
+// separately by REFUND_MAX_FEE_FRACTION_* below, so the rate cap is free
+// to be set generously here.
+export const REFUND_MAX_FEE_RATE_SATS_VB = 2000;
 
 // Hard upper bound on the absolute refund fee as a fraction of the vault
 // amount. Protects small vaults where even a moderate fee rate burns a

--- a/packages/babylon-ts-sdk/src/tbv/core/services/refund/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/refund/index.ts
@@ -8,6 +8,9 @@ export { BIP68NotMatureError } from "./errors";
 export {
   buildAndBroadcastRefund,
   estimateRefundFeeSats,
+  REFUND_MAX_FEE_FRACTION_DENOMINATOR,
+  REFUND_MAX_FEE_FRACTION_NUMERATOR,
+  REFUND_MAX_FEE_RATE_SATS_VB,
   REFUND_VSIZE,
   type BtcBroadcastResult,
   type BtcBroadcaster,

--- a/services/vault/src/components/deposit/RefundModal/RefundReviewContent.tsx
+++ b/services/vault/src/components/deposit/RefundModal/RefundReviewContent.tsx
@@ -1,5 +1,10 @@
 import { Button, Heading, Loader, Text } from "@babylonlabs-io/core-ui";
-import { estimateRefundFeeSats } from "@babylonlabs-io/ts-sdk/tbv/core/services";
+import {
+  estimateRefundFeeSats,
+  REFUND_MAX_FEE_FRACTION_DENOMINATOR,
+  REFUND_MAX_FEE_FRACTION_NUMERATOR,
+  REFUND_MAX_FEE_RATE_SATS_VB,
+} from "@babylonlabs-io/ts-sdk/tbv/core/services";
 import { useEffect, useState } from "react";
 import { MdInfoOutline } from "react-icons/md";
 
@@ -88,6 +93,22 @@ export function RefundReviewContent({
 
   const isDust = youReceiveSats !== null && youReceiveSats <= DUST_LIMIT_SATS;
 
+  // Mirror the SDK's two refund safety caps (see buildAndBroadcastRefund.ts).
+  // Sharing the constants prevents UI/SDK drift — without this the user
+  // could confirm a fee the SDK is about to throw on, which would leave the
+  // refund modal silently dead-ended after the wallet prompt.
+  const exceedsRateCap =
+    feeRate !== null && feeRate > REFUND_MAX_FEE_RATE_SATS_VB;
+  const maxFeeByFractionSats =
+    amountSats !== null
+      ? (amountSats * REFUND_MAX_FEE_FRACTION_NUMERATOR) /
+        REFUND_MAX_FEE_FRACTION_DENOMINATOR
+      : null;
+  const exceedsFractionCap =
+    networkFeeSats !== null &&
+    maxFeeByFractionSats !== null &&
+    networkFeeSats > maxFeeByFractionSats;
+
   const canConfirm =
     !refunding &&
     !previewLoading &&
@@ -95,7 +116,15 @@ export function RefundReviewContent({
     feeRate > 0 &&
     youReceiveSats !== null &&
     !isDust &&
+    !exceedsRateCap &&
+    !exceedsFractionCap &&
     !usingFallback;
+
+  const feeCapMessage = exceedsRateCap
+    ? `Network fee rate exceeds the safety cap of ${REFUND_MAX_FEE_RATE_SATS_VB} sat/vB. Lower the fee rate to continue.`
+    : exceedsFractionCap
+      ? `Network fee exceeds ${(REFUND_MAX_FEE_FRACTION_NUMERATOR * 100n) / REFUND_MAX_FEE_FRACTION_DENOMINATOR}% of the refund amount. Lower the fee rate to continue.`
+      : null;
 
   const handleConfirmClick = () => {
     if (feeRate === null || feeRate <= 0) return;
@@ -198,6 +227,9 @@ export function RefundReviewContent({
               Network fee is too high — your refund would be below the Bitcoin
               dust limit. Lower the fee rate to continue.
             </StatusBanner>
+          )}
+          {!error && !isDust && feeCapMessage && (
+            <StatusBanner variant="error">{feeCapMessage}</StatusBanner>
           )}
           {error && <StatusBanner variant="error">{error}</StatusBanner>}
 

--- a/services/vault/src/components/deposit/RefundModal/__tests__/RefundModal.test.tsx
+++ b/services/vault/src/components/deposit/RefundModal/__tests__/RefundModal.test.tsx
@@ -169,7 +169,7 @@ describe("RefundModal", () => {
     );
 
     expect(
-      await screen.findByText(/safety cap of 500 sat\/vB/i),
+      await screen.findByText(/safety cap of 2000 sat\/vB/i),
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /confirm/i })).toBeDisabled();
   });

--- a/services/vault/src/components/deposit/RefundModal/__tests__/RefundModal.test.tsx
+++ b/services/vault/src/components/deposit/RefundModal/__tests__/RefundModal.test.tsx
@@ -7,6 +7,7 @@ import { render, screen } from "@testing-library/react";
 import { useMemo, type ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { getRefundPreview } from "@/services/vault/vaultRefundService";
 import type { VaultActivity } from "@/types/activity";
 
 import { RefundModal } from "../index";
@@ -148,5 +149,54 @@ describe("RefundModal", () => {
     expect(
       await screen.findByText(/approximately 6 hours/i),
     ).toBeInTheDocument();
+  });
+
+  it("disables Confirm and shows the rate-cap banner when mempool returns a malicious fee rate", async () => {
+    vi.mocked(getRefundPreview).mockResolvedValueOnce({
+      amountSats: 100_000_000n,
+      halfHourFeeSatsVb: 10_000,
+    });
+
+    render(
+      <Wrapper>
+        <RefundModal
+          open
+          activity={ACTIVITY}
+          onClose={() => {}}
+          onSuccess={() => {}}
+        />
+      </Wrapper>,
+    );
+
+    expect(
+      await screen.findByText(/safety cap of 500 sat\/vB/i),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /confirm/i })).toBeDisabled();
+  });
+
+  it("disables Confirm and shows the fraction-cap banner for a small vault at a within-rate-cap fee", async () => {
+    // Small vault where rate is below the per-vbyte ceiling but absolute
+    // fee still consumes more than 10% of vault.amount.
+    // 100k-sat vault, halfHourFee=100 sat/vB → fee=16_000 > 10% of 100k.
+    vi.mocked(getRefundPreview).mockResolvedValueOnce({
+      amountSats: 100_000n,
+      halfHourFeeSatsVb: 100,
+    });
+
+    render(
+      <Wrapper>
+        <RefundModal
+          open
+          activity={ACTIVITY}
+          onClose={() => {}}
+          onSuccess={() => {}}
+        />
+      </Wrapper>,
+    );
+
+    expect(
+      await screen.findByText(/exceeds 10% of the refund amount/i),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /confirm/i })).toBeDisabled();
   });
 });


### PR DESCRIPTION
# Cap the refund fee so a bad mempool response can't burn the user's BTC

Closes [babylonlabs-io/baby-auditor-findings#154](https://github.com/babylonlabs-io/baby-auditor-findings/issues/154)

## What this PR does

Adds two safety caps to the BTC refund flow so the user's refund can never pay an unreasonable amount of miner fee, even if the mempool API returns a malicious or buggy fee rate.

The caps:

1. **Per-vbyte fee rate cap — `2000 sat/vB`.** The SDK refuses to sign a refund whose fee rate exceeds this.
2. **Per-vault fee fraction cap — `10%`.** The SDK refuses to sign a refund whose absolute fee would consume more than 10% of the vault amount.

Both caps are exported from the SDK and re-used in the UI, so the SDK and the UI can't drift. The "Confirm" button in the refund modal is disabled (with an explanatory banner) when either cap is exceeded.

## Why we needed this

Today the refund flow takes `halfHourFee` from `mempool.space`. The only upper bound is `10_000 sat/vB` in the mempool client (just sanity validation, not a policy cap).

That means: if mempool.space returns `halfHourFee: 10000` — which is a legal response — and the user clicks Confirm, the wallet signs a transaction that **pays 1.6M sats in miner fee**. On a 1.6M-sat vault that leaves the depositor 546 sats (the Bitcoin dust limit, which is the only existing check). The fee isn't stolen by an attacker, but it is irreversibly burned.

This is a defense-in-depth gap on a signing-critical path. `CLAUDE.md §2` is explicit about it: "fee consistency cross-check at the broadcast site, not only at the estimator." Relying on the user noticing the high fee in the modal is not enough — defaults get accepted.

## Approaches I considered

| Approach | Why I rejected it |
|---|---|
| Just lower `MAX_FEE_RATE` in the mempool client (e.g. from 10_000 → 1000) | Affects every caller of the mempool client, not only refund. And the user can still edit the field above the cap. |
| Only a percentage-of-vault cap | Breaks down for large vaults. At the malicious `10_000 sat/vB × 160 vsize = 1.6M sats` fee, a 1 BTC vault's 10% cap is `10M sats` — well above the malicious fee, so the cap wouldn't bind and the burn would proceed. |
| Only an absolute sats cap (e.g. "max 50k sats fee") — what the auditor originally suggested | Doesn't scale with vault size. A tiny vault is under-protected; a huge vault is over-protected. Works, but the rate-cap framing below reads more naturally to a user. |
| **Rate cap (sat/vB) + percentage cap (% of vault) — chosen** | Best of both. The rate cap is in the same unit the user types into the modal (`sat/vB`), so it's intuitive, and it's the only thing that defends large vaults against a malicious mempool. The percentage cap takes over for small vaults where even an in-rate-cap fee would burn a large share. |

## Why the chosen numbers

- **`2000 sat/vB`** — during the April 2024 halving / Runes launch `fastestFee` peaked around `1,800 sat/vB`, and `halfHourFee` tracked close to it during the worst of the congestion (~`1,000–1,500 sat/vB` range — the half-hour bucket converges with the fastest bucket when the queue is deep enough). `2000` leaves ~1.3× margin over that historical extreme so the cap doesn't gate legitimate refunds during a comparable event, while still blocking the obvious malicious case (`10_000`) by 5×. On a 160-vbyte refund this caps absolute burn at `320k sats`. Small-vault burn is handled separately by the fraction cap below, so the rate cap is free to be set generously.
- **`10%`** — covers the small-vault edge. A `100k-sat` vault gets a max fee of `10k sats` (~`62 sat/vB` effective). The fraction cap binds (i.e. is tighter than the rate cap) for vaults under ~`3.2M sats`; above that, the rate cap binds.

These are easy to change later — they're exported constants in one place.

## Where the changes live

**SDK:**
- `packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts` — defines `REFUND_MAX_FEE_RATE_SATS_VB`, `REFUND_MAX_FEE_FRACTION_NUMERATOR`, `REFUND_MAX_FEE_FRACTION_DENOMINATOR`. Throws in `buildAndBroadcastRefund()` *before* PSBT build / wallet sign / broadcast if either cap is exceeded.
- `packages/babylon-ts-sdk/src/tbv/core/services/refund/index.ts` — re-exports the new constants.

**UI:**
- `services/vault/src/components/deposit/RefundModal/RefundReviewContent.tsx` — imports the SDK constants, computes `exceedsRateCap` and `exceedsFractionCap`, adds them to `canConfirm`, and shows a clear error banner explaining which cap was hit.

**Tests:**
- SDK tests — 4 new cases covering: rate-cap rejection (no PSBT / sign / broadcast calls), fraction-cap rejection, success at exactly the rate cap on a large-enough vault, success at exactly the fraction-cap boundary.
- UI tests — 2 new cases covering: malicious `halfHourFee: 10000` disables Confirm and shows the rate-cap banner; small vault at an in-cap rate disables Confirm and shows the fraction-cap banner.
