### PR TITLE
fix(vault): enforce on-chain status before btc pre pegin

### DIFF
--- a/services/vault/src/clients/eth-contract/btc-vault-registry/__tests__/query.test.ts
+++ b/services/vault/src/clients/eth-contract/btc-vault-registry/__tests__/query.test.ts
@@ -16,13 +16,15 @@ vi.mock("@/config/env", () => ({
 }));
 
 const mockGetVaultBasicInfo = vi.fn();
+const mockGetVaultData = vi.fn();
 vi.mock("../../sdk-readers", () => ({
   getVaultRegistryReader: () => ({
     getVaultBasicInfo: mockGetVaultBasicInfo,
+    getVaultData: mockGetVaultData,
   }),
 }));
 
-import { getBtcVaultBasicInfoFromChain } from "../query";
+import { getBtcVaultBasicInfoFromChain, getVaultFromChain } from "../query";
 
 const VAULT_A =
   "0xaaaa000000000000000000000000000000000000000000000000000000000001" as Hex;
@@ -96,5 +98,38 @@ describe("getBtcVaultBasicInfoFromChain", () => {
     await expect(
       getBtcVaultBasicInfoFromChain([VAULT_A, VAULT_B]),
     ).rejects.toThrow(/not registered on-chain/);
+  });
+});
+
+describe("getVaultFromChain", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // Status is the load-bearing field for the broadcast precondition; if a
+  // future refactor of the basic-info merge drops it, the broadcast gate
+  // would fall back to `undefined` and pass every comparison.
+  it("surfaces basic.status alongside protocol fields", async () => {
+    mockGetVaultData.mockResolvedValue({
+      basic: {
+        ...basicInfo(60_000_000n),
+        status: 4, // on-chain BTCVaultStatus.Expired
+      },
+      protocol: {
+        depositorSignedPeginTx: "0xdeadbeef" as Hex,
+        universalChallengersVersion: 1n,
+        appVaultKeepersVersion: 2n,
+        offchainParamsVersion: 3n,
+        hashlock: ("0x" + "1".repeat(64)) as Hex,
+        htlcVout: 0n,
+        prePeginTxHash: ("0x" + "2".repeat(64)) as Hex,
+      },
+    });
+
+    const result = await getVaultFromChain(VAULT_A);
+
+    expect(result.status).toBe(4);
+    expect(result.amount).toBe(60_000_000n);
+    expect(result.prePeginTxHash).toBe(("0x" + "2".repeat(64)) as Hex);
   });
 });

--- a/services/vault/src/clients/eth-contract/btc-vault-registry/query.ts
+++ b/services/vault/src/clients/eth-contract/btc-vault-registry/query.ts
@@ -37,6 +37,13 @@ export interface OnChainVaultData {
    * Required by `buildPayoutPsbt` to cap the VP-claimer commission output.
    */
   vaultProviderCommissionBps: number;
+  /**
+   * Live `BTCVaultStatus` enum value from `basic.status`. Compare against
+   * `OnChainBtcVaultStatus`, not the app-side `ContractStatus` — the
+   * indexer enum reassigns the contract's Expired(4) to LIQUIDATED and
+   * would mislabel a chain read.
+   */
+  status: number;
 }
 
 /**
@@ -64,6 +71,7 @@ export async function getVaultFromChain(
     amount: basic.amount,
     prePeginTxHash: protocol.prePeginTxHash,
     vaultProviderCommissionBps: Number(protocol.vaultProviderCommissionBps),
+    status: basic.status,
   };
 }
 

--- a/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
+++ b/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
@@ -190,6 +190,7 @@ describe("useVaultActions — handleBroadcast transaction integrity", () => {
     mockGetVaultFromChain.mockResolvedValue({
       prePeginTxHash: "0xmatching_pre_pegin_hash",
       hashlock: "0xonchain_hashlock",
+      status: OnChainBtcVaultStatus.PENDING,
     } as never);
     // Default reader: on-chain versions exactly match the build versions in
     // `basePendingPegin`. Tests that exercise drift override this per-case.
@@ -300,6 +301,61 @@ describe("useVaultActions — handleBroadcast transaction integrity", () => {
     expect(result.current.broadcastError).toContain("VERIFIED");
     expect(mockBroadcastPrePeginTransaction).not.toHaveBeenCalled();
   });
+
+  // Regression: a poisoned/lagging indexer can report PENDING while the
+  // contract has already moved off PENDING. The integrity hash check passes
+  // (prePeginTxHash doesn't change across status transitions), so the
+  // on-chain status read is the load-bearing gate that prevents BTC from
+  // being signed and broadcast into a flow that can no longer activate.
+  it("refuses to broadcast when GraphQL says PENDING but on-chain status is EXPIRED", async () => {
+    mockFetchVaultById.mockResolvedValue(baseVault as never);
+    mockGetVaultFromChain.mockResolvedValue({
+      prePeginTxHash: "0xmatching_pre_pegin_hash",
+      hashlock: "0xonchain_hashlock",
+      status: OnChainBtcVaultStatus.EXPIRED,
+    } as never);
+
+    const { result } = renderHook(() => useVaultActions());
+
+    await act(async () => {
+      await result.current.handleBroadcast({
+        ...baseBroadcastParams,
+        pendingPegin: { ...basePendingPegin },
+      });
+    });
+
+    expect(result.current.broadcastError).toMatch(/on-chain.*EXPIRED/);
+    expect(mockBroadcastPrePeginTransaction).not.toHaveBeenCalled();
+    expect(mockSignPsbt).not.toHaveBeenCalled();
+  });
+
+  // The on-chain BTCVaultStatus enum has Expired = 4. The app-side
+  // `ContractStatus` enum reassigns 4 to LIQUIDATED (indexer-only), so a
+  // naive `ContractStatus[status]` lookup mislabels on-chain Expired as
+  // LIQUIDATED — sending users / support down the wrong recovery path.
+  // handleBroadcast must use the on-chain label, not the app-side one.
+  it("labels on-chain status 4 as EXPIRED (not LIQUIDATED) in the broadcast error", async () => {
+    mockFetchVaultById.mockResolvedValue(baseVault as never);
+    mockGetVaultFromChain.mockResolvedValue({
+      prePeginTxHash: "0xmatching_pre_pegin_hash",
+      hashlock: "0xonchain_hashlock",
+      // 4 = on-chain BTCVaultStatus.Expired
+      status: 4,
+    } as never);
+
+    const { result } = renderHook(() => useVaultActions());
+
+    await act(async () => {
+      await result.current.handleBroadcast({
+        ...baseBroadcastParams,
+        pendingPegin: { ...basePendingPegin },
+      });
+    });
+
+    expect(result.current.broadcastError).toContain("EXPIRED");
+    expect(result.current.broadcastError).not.toContain("LIQUIDATED");
+    expect(mockBroadcastPrePeginTransaction).not.toHaveBeenCalled();
+  });
 });
 
 // Resume broadcasts must re-assert the three on-chain versions against the
@@ -313,9 +369,13 @@ describe("useVaultActions — handleBroadcast version drift guard", () => {
     vi.clearAllMocks();
     mockCalculateBtcTxHash.mockReturnValue("0xmatching_pre_pegin_hash");
     mockFetchVaultById.mockResolvedValue(baseVault as never);
+    // status: PENDING so the broadcast-status precondition (which runs before
+    // the version check this describe block exercises) lets execution reach
+    // the version drift logic.
     mockGetVaultFromChain.mockResolvedValue({
       prePeginTxHash: "0xmatching_pre_pegin_hash",
       hashlock: "0xonchain_hashlock",
+      status: OnChainBtcVaultStatus.PENDING,
     } as never);
   });
 

--- a/services/vault/src/hooks/deposit/useVaultActions.ts
+++ b/services/vault/src/hooks/deposit/useVaultActions.ts
@@ -165,6 +165,22 @@ export function useVaultActions(): UseVaultActionsReturn {
         );
       }
 
+      // Gate on a fresh on-chain status read. The GraphQL pre-check above is
+      // an indexer/Redis value that can lag the chain; if a vault has moved
+      // off PENDING since the indexer last refreshed, signing+broadcasting
+      // here would lock BTC into a flow that can no longer activate normally.
+      // Compare AND label against `OnChainBtcVaultStatus` (not the app-side
+      // `ContractStatus`, which reassigns the contract's Expired(4) to the
+      // indexer-only LIQUIDATED and would mislabel on-chain Expired).
+      if (onChainVault.status !== OnChainBtcVaultStatus.PENDING) {
+        const label =
+          OnChainBtcVaultStatus[onChainVault.status] ??
+          `UNKNOWN(${onChainVault.status})`;
+        throw new Error(
+          `Cannot broadcast: on-chain vault is in ${label} state. Broadcast is only valid during PENDING.`,
+        );
+      }
+
       // Get BTC wallet provider
       const btcWalletProvider = btcConnector?.connectedWallet?.provider;
       if (!btcWalletProvider) {


### PR DESCRIPTION
## What

`handleBroadcast` (the user-driven "Broadcast Pre-PegIn" action) now reads the live vault status from the BTCVaultRegistry contract and refuses to ask the BTC wallet to sign unless the chain itself reports `PENDING`. The existing GraphQL-side status check stays as a fast UX pre-filter; the new on-chain check is the load-bearing security gate.

Two small pieces, one chain read:

1. [services/vault/src/clients/eth-contract/btc-vault-registry/query.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/services/vault/src/clients/eth-contract/btc-vault-registry/query.ts) — `getVaultFromChain` now surfaces `basic.status` on the returned `OnChainVaultData`. The SDK reader was already fetching it; the wrapper was dropping it on the floor. No extra RPC.
2. [services/vault/src/hooks/deposit/useVaultActions.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/services/vault/src/hooks/deposit/useVaultActions.ts) — `handleBroadcast` asserts `onChainVault.status === OnChainBtcVaultStatus.PENDING` immediately after the existing prePeginTxHash integrity check, before the BTC wallet is touched. Fails closed with a message that explicitly names the on-chain status so users (and on-call) can tell which gate fired.

## Why

The "Broadcast" button gates on GraphQL-reported `vault.status === PENDING` (from `fetchVaultById`). That value can be served from a Redis `entity:vault:*` row, can lag the chain after a `PeginExpired` transition, or can be poisoned. The hash-integrity check that runs against `getVaultFromChain` only verifies `prePeginTxHash` — that hash doesn't change when a vault transitions from `PENDING` to `EXPIRED`/`LIQUIDATED`, so the check still passes.

Practical impact: with the indexer reporting stale `PENDING` while the contract has actually moved off `PENDING`, a user can sign + broadcast a Bitcoin Pre-PegIn into a vault that can no longer activate normally. The BTC is then locked into a forced refund/timeout recovery path, and the broadcast fee is burned for nothing. No privileged role or crypto break is needed — observable indexer lag is enough.

[CLAUDE.md](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/CLAUDE.md) §3 and §5 already call this pattern out: signing-critical decisions must derive from the chain, not from indexer-reported state.

## Approaches considered

1. **Add `status` to `OnChainVaultData` and assert in `handleBroadcast` (chosen).** Smallest change in the right layer. `getVaultFromChain` already calls `getVaultData` (basic + protocol fetched together), so surfacing `basic.status` adds zero RPC. The assertion lives next to the existing integrity check at the same trust boundary.

2. **Issue a separate `reader.getVaultBasicInfo(vaultId)` call from inside `handleBroadcast`.** Rejected. Doubles round-trips for the same precondition, and creates a second truth source for a value that the existing `getVaultData` call already returns. Activation in [#1685](https://github.com/babylonlabs-io/babylon-toolkit/pull/1685) uses this shape because that flow doesn't call `getVaultData`; broadcast already does.

3. **Remove the GraphQL pre-check entirely (auditor's "GraphQL as display only" framing).** Rejected for this PR. The on-chain check makes the GraphQL check redundant for security; removing it changes UX in the indexer-lag-behind-chain direction (false negatives, not the security-relevant direction). Out of scope for a security-targeted fix.

4. **Extract a shared `assertVaultStatusOnChain(vaultId, expected)` helper to reuse for [#1685](https://github.com/babylonlabs-io/babylon-toolkit/pull/1685).** Rejected for the same reason that PR rejected it: the two call sites read different sources of truth (this one from the merged `OnChainVaultData`, activation from `getVaultBasicInfo` for hashlock + status in one read) and expect different statuses. A shared helper would either parameterize both axes (becoming a thin wrapper) or hide the source-of-truth distinction that matters most. Inline both. If a third call site appears, revisit.

## Why this approach

- **One trust boundary, one assertion.** The chain read already happens for the hash check; checking status from the same read is the natural place.
- **No new abstractions for one consumer.** Per the [CLAUDE.md](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/CLAUDE.md) rule of thumb, three similar call sites would justify a helper. We have two, and they have different shapes.
- **Use `OnChainBtcVaultStatus` for both comparison and labeling.** This enum (added in [#1685](https://github.com/babylonlabs-io/babylon-toolkit/pull/1685)) mirrors the Solidity contract. The app-side `ContractStatus` enum reassigns the contract's `Expired(4)` to the indexer-only `LIQUIDATED`. Using `ContractStatus[n]` to label an on-chain status would mislabel `Expired` as `LIQUIDATED` and send users down the wrong recovery path. The error message and the test assertions both pin this down.

## Tests

[services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts):

- **Regression**: GraphQL returns `PENDING` (so the early gate passes) AND the on-chain prePeginTxHash matches (so integrity passes), but the on-chain `status` is `EXPIRED`. Asserts the error names the on-chain state and neither `broadcastPrePeginTransaction` nor `signPsbt` is called.
- **Labeling regression**: on-chain status `4` surfaces as `EXPIRED`, never `LIQUIDATED`. Catches accidental reuse of the indexer-side `ContractStatus` enum for labeling chain reads.
- Updated the default `mockGetVaultFromChain` shape so the existing happy-path tests pass the new precondition.

[services/vault/src/clients/eth-contract/btc-vault-registry/__tests__/query.test.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/services/vault/src/clients/eth-contract/btc-vault-registry/__tests__/query.test.ts):

- New `getVaultFromChain` test asserting `basic.status` round-trips end-to-end. Pins the field against accidental removal from the merged shape.

## Branching / merge order

This PR depends on [#1685](https://github.com/babylonlabs-io/babylon-toolkit/pull/1685) (the sibling fix for activation; introduces `OnChainBtcVaultStatus`). Opened as **draft** so merge order is enforced:

1. [#1685](https://github.com/babylonlabs-io/babylon-toolkit/pull/1685) merges to `main`.
2. This PR rebases cleanly onto `main`, is marked ready, and goes through review.

Closes https://github.com/babylonlabs-io/baby-auditor-findings/issues/273
