### PR TITLE
fix(ts-sdk): forward auth-anchor hash into refund psbt

### DIFF
--- a/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/__tests__/assertAuthAnchorOpReturn.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/__tests__/assertAuthAnchorOpReturn.test.ts
@@ -1,7 +1,10 @@
 import * as bitcoin from "bitcoinjs-lib";
 import { describe, expect, it } from "vitest";
 
-import { assertAuthAnchorOpReturn } from "../assertAuthAnchorOpReturn";
+import {
+  assertAuthAnchorOpReturn,
+  findAuthAnchorOpReturn,
+} from "../assertAuthAnchorOpReturn";
 
 const ANCHOR_HASH = "ab".repeat(32);
 const OTHER_HASH = "cd".repeat(32);
@@ -127,5 +130,102 @@ describe("assertAuthAnchorOpReturn", () => {
     expect(() =>
       assertAuthAnchorOpReturn(txHex, 1, ANCHOR_HASH),
     ).toThrow(/non-zero value/);
+  });
+});
+
+describe("findAuthAnchorOpReturn", () => {
+  it("returns {vout, hash} for a single-vault tx (HTLC@0, OP_RETURN@1)", () => {
+    const txHex = buildTxHex([htlcOutput(), opReturnOutput(ANCHOR_HASH)]);
+    expect(findAuthAnchorOpReturn(txHex)).toEqual({
+      vout: 1,
+      hash: ANCHOR_HASH,
+    });
+  });
+
+  it("returns {vout, hash} for a two-vault tx (HTLCs@0,1, OP_RETURN@2)", () => {
+    const txHex = buildTxHex([
+      htlcOutput(),
+      htlcOutput(),
+      opReturnOutput(ANCHOR_HASH),
+    ]);
+    expect(findAuthAnchorOpReturn(txHex)).toEqual({
+      vout: 2,
+      hash: ANCHOR_HASH,
+    });
+  });
+
+  it("returns {vout, hash} even when followed by a CPFP-anchor-like output", () => {
+    // Real funded Pre-PegIns also carry a CPFP anchor / change output
+    // after the OP_RETURN. The finder must locate the anchor regardless
+    // of what comes after.
+    const txHex = buildTxHex([
+      htlcOutput(),
+      opReturnOutput(ANCHOR_HASH),
+      htlcOutput(),
+    ]);
+    expect(findAuthAnchorOpReturn(txHex)).toEqual({
+      vout: 1,
+      hash: ANCHOR_HASH,
+    });
+  });
+
+  it("strips a leading 0x prefix from the funded tx hex", () => {
+    const txHex = buildTxHex([htlcOutput(), opReturnOutput(ANCHOR_HASH)]);
+    expect(findAuthAnchorOpReturn(`0x${txHex}`)).toEqual({
+      vout: 1,
+      hash: ANCHOR_HASH,
+    });
+  });
+
+  it("returns undefined for a legacy (non-auth-anchored) tx with no OP_RETURN", () => {
+    const txHex = buildTxHex([htlcOutput(), htlcOutput()]);
+    expect(findAuthAnchorOpReturn(txHex)).toBeUndefined();
+  });
+
+  it("returns undefined when more than one OP_RETURN+PUSH32 output is present (ambiguous)", () => {
+    // A well-formed Pre-PegIn carries exactly one auth-anchor commitment.
+    // Two would either be a malformed tx or someone trying to confuse the
+    // reader; refuse to guess.
+    const txHex = buildTxHex([
+      htlcOutput(),
+      opReturnOutput(ANCHOR_HASH),
+      opReturnOutput(OTHER_HASH),
+    ]);
+    expect(findAuthAnchorOpReturn(txHex)).toBeUndefined();
+  });
+
+  it("ignores OP_RETURN outputs with non-zero value", () => {
+    // Non-standard OP_RETURNs (non-zero value) cannot have been emitted
+    // by the WASM builder — skip them rather than treat them as a hit.
+    const txHex = buildTxHex([
+      htlcOutput(),
+      opReturnOutput(ANCHOR_HASH, /* value */ 546),
+    ]);
+    expect(findAuthAnchorOpReturn(txHex)).toBeUndefined();
+  });
+
+  it("ignores OP_RETURN outputs with non-32-byte payloads", () => {
+    // OP_RETURN PUSH16 <16 bytes> — wrong push opcode, shorter payload.
+    const tooShort = {
+      scriptHex: `6a10${"ab".repeat(16)}`,
+      value: 0,
+    };
+    const txHex = buildTxHex([htlcOutput(), tooShort]);
+    expect(findAuthAnchorOpReturn(txHex)).toBeUndefined();
+  });
+
+  it("returns undefined for unparseable hex", () => {
+    expect(findAuthAnchorOpReturn("not a real tx hex")).toBeUndefined();
+  });
+
+  it("normalizes the hash to lowercase regardless of input case", () => {
+    // OP_RETURN payloads are raw bytes; the hex serialization picks a
+    // case. Normalize at the boundary so downstream byte-equality holds.
+    const upperHash = "CD".repeat(32);
+    const txHex = buildTxHex([htlcOutput(), opReturnOutput(upperHash)]);
+    expect(findAuthAnchorOpReturn(txHex)).toEqual({
+      vout: 1,
+      hash: "cd".repeat(32),
+    });
   });
 });

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/assertAuthAnchorOpReturn.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/assertAuthAnchorOpReturn.ts
@@ -78,3 +78,49 @@ export function assertAuthAnchorOpReturn(
     );
   }
 }
+
+/**
+ * Best-effort reader for the auth-anchor OP_RETURN payload at `vout` of
+ * a funded Pre-PegIn transaction.
+ *
+ * Returns the 32-byte payload as lowercase hex (no `0x` prefix) if the
+ * output at `vout` is exactly `OP_RETURN || PUSH32 || <32 bytes>` with
+ * a zero value. Returns `undefined` for any structural mismatch —
+ * missing output, wrong script shape, non-zero value — so legacy
+ * non-auth-anchored Pre-PegIns parse as "no anchor" rather than
+ * raising.
+ *
+ * Used by the refund flow to reconstruct the unfunded WASM template
+ * with the same output shape as the on-chain funded transaction.
+ * Assertion semantics (compare against an expected value, throw on
+ * mismatch) live in {@link assertAuthAnchorOpReturn}.
+ */
+export function readAuthAnchorOpReturn(
+  fundedPrePeginTxHex: string,
+  vout: number,
+): string | undefined {
+  let tx: bitcoin.Transaction;
+  try {
+    tx = bitcoin.Transaction.fromHex(stripHexPrefix(fundedPrePeginTxHex));
+  } catch {
+    // Best-effort: unparseable hex is also "no extractable anchor".
+    // The same hex flows into the refund PSBT primitive immediately
+    // after, where Transaction.fromHex will surface a real parse error.
+    return undefined;
+  }
+
+  if (tx.outs.length <= vout) return undefined;
+
+  const output = tx.outs[vout];
+  const script = output.script;
+  if (
+    script.length !== OP_RETURN_PUSH32_SCRIPT_LEN ||
+    script[0] !== OP_RETURN ||
+    script[1] !== OP_PUSH32
+  ) {
+    return undefined;
+  }
+  if (output.value !== 0) return undefined;
+
+  return script.slice(2).toString("hex").toLowerCase();
+}

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/assertAuthAnchorOpReturn.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/assertAuthAnchorOpReturn.ts
@@ -124,3 +124,49 @@ export function readAuthAnchorOpReturn(
 
   return script.slice(2).toString("hex").toLowerCase();
 }
+
+/**
+ * Scan a funded Pre-PegIn transaction for its auth-anchor commitment
+ * (an `OP_RETURN || PUSH32 || <32 bytes>` output with value 0).
+ *
+ * Returns `{ vout, hash }` when exactly one such output is found.
+ * Returns `undefined` when:
+ *   - the hex is unparseable,
+ *   - no matching output exists (legacy non-auth-anchored Pre-PegIn),
+ *   - more than one matching output exists (ambiguous / malformed).
+ *
+ * Used by the refund orchestrator to (a) locate the on-chain anchor
+ * regardless of how many HTLCs preceded it and (b) detect multi-vault
+ * funded transactions structurally: the single-vault refund path
+ * reconstructs only one hashlock and expects the anchor at vout 1, so
+ * any other vout signals a layout this call cannot safely refund.
+ */
+export function findAuthAnchorOpReturn(
+  fundedPrePeginTxHex: string,
+): { vout: number; hash: string } | undefined {
+  let tx: bitcoin.Transaction;
+  try {
+    tx = bitcoin.Transaction.fromHex(stripHexPrefix(fundedPrePeginTxHex));
+  } catch {
+    return undefined;
+  }
+
+  const hits: { vout: number; hash: string }[] = [];
+  for (let i = 0; i < tx.outs.length; i++) {
+    const output = tx.outs[i];
+    const script = output.script;
+    if (
+      script.length === OP_RETURN_PUSH32_SCRIPT_LEN &&
+      script[0] === OP_RETURN &&
+      script[1] === OP_PUSH32 &&
+      output.value === 0
+    ) {
+      hits.push({
+        vout: i,
+        hash: script.slice(2).toString("hex").toLowerCase(),
+      });
+    }
+  }
+
+  return hits.length === 1 ? hits[0] : undefined;
+}

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/index.ts
@@ -8,6 +8,7 @@
 
 export {
   assertAuthAnchorOpReturn,
+  findAuthAnchorOpReturn,
   readAuthAnchorOpReturn,
 } from "./assertAuthAnchorOpReturn";
 export {

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/index.ts
@@ -6,7 +6,10 @@
  * @module managers/pegin
  */
 
-export { assertAuthAnchorOpReturn } from "./assertAuthAnchorOpReturn";
+export {
+  assertAuthAnchorOpReturn,
+  readAuthAnchorOpReturn,
+} from "./assertAuthAnchorOpReturn";
 export {
   expandPerVaultSecrets,
   type PerVaultExpansionResult,

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/refund.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/refund.test.ts
@@ -144,4 +144,79 @@ describe("buildRefundPsbt", () => {
       ).rejects.toThrow();
     });
   });
+
+  describe("authAnchorHash normalization (parity with peg-in primitives)", () => {
+    // PrePeginParams is shared with buildPrePeginPsbt and
+    // buildPeginTxFromFundedPrePegin, both of which normalize
+    // `authAnchorHash` (strip 0x, lowercase, validate length/charset)
+    // before crossing the WASM boundary. The refund primitive must
+    // behave identically — a direct caller reusing successful peg-in
+    // params shouldn't get a different validation surface.
+
+    it("accepts a 0x-prefixed authAnchorHash and matches the funded tx", async () => {
+      const { txHex, params } = await buildFundedPrePegin({
+        authAnchorHash: TEST_AUTH_ANCHOR_HASH,
+      });
+
+      const result = await buildRefundPsbt({
+        prePeginParams: { ...params, authAnchorHash: `0x${TEST_AUTH_ANCHOR_HASH}` },
+        fundedPrePeginTxHex: txHex,
+        htlcVout: 0,
+        refundFee: TEST_REFUND_FEE,
+        hashlock: TEST_HASH_H,
+      });
+
+      expect(typeof result.psbtHex).toBe("string");
+      expect(result.psbtHex.length).toBeGreaterThan(0);
+    });
+
+    it("accepts uppercase hex in authAnchorHash and matches the funded tx", async () => {
+      const { txHex, params } = await buildFundedPrePegin({
+        authAnchorHash: TEST_AUTH_ANCHOR_HASH,
+      });
+
+      const result = await buildRefundPsbt({
+        prePeginParams: { ...params, authAnchorHash: TEST_AUTH_ANCHOR_HASH.toUpperCase() },
+        fundedPrePeginTxHex: txHex,
+        htlcVout: 0,
+        refundFee: TEST_REFUND_FEE,
+        hashlock: TEST_HASH_H,
+      });
+
+      expect(typeof result.psbtHex).toBe("string");
+      expect(result.psbtHex.length).toBeGreaterThan(0);
+    });
+
+    it("rejects an authAnchorHash with the wrong length", async () => {
+      const { txHex, params } = await buildFundedPrePegin({
+        authAnchorHash: TEST_AUTH_ANCHOR_HASH,
+      });
+
+      await expect(
+        buildRefundPsbt({
+          prePeginParams: { ...params, authAnchorHash: "ab".repeat(31) },
+          fundedPrePeginTxHex: txHex,
+          htlcVout: 0,
+          refundFee: TEST_REFUND_FEE,
+          hashlock: TEST_HASH_H,
+        }),
+      ).rejects.toThrow(/authAnchorHash/);
+    });
+
+    it("rejects an authAnchorHash with non-hex characters", async () => {
+      const { txHex, params } = await buildFundedPrePegin({
+        authAnchorHash: TEST_AUTH_ANCHOR_HASH,
+      });
+
+      await expect(
+        buildRefundPsbt({
+          prePeginParams: { ...params, authAnchorHash: "zz".repeat(32) },
+          fundedPrePeginTxHex: txHex,
+          htlcVout: 0,
+          refundFee: TEST_REFUND_FEE,
+          hashlock: TEST_HASH_H,
+        }),
+      ).rejects.toThrow(/authAnchorHash/);
+    });
+  });
 });

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/refund.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/refund.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Tests for buildRefundPsbt — refund PSBT construction over a funded
+ * Pre-PegIn HTLC output via the CSV-timelocked refund script (leaf 1).
+ *
+ * Production peg-ins commit an OP_RETURN <PUSH32 SHA256(authAnchor)>
+ * output at `vout = hashlocks.length`, so the refund flow must rebuild
+ * the WASM unfunded template with the same output shape — otherwise
+ * the reconstructed template doesn't align with the funded tx and
+ * refund construction fails or yields an unspendable PSBT.
+ */
+
+import type { Network } from "@babylonlabs-io/babylon-tbv-rust-wasm";
+import * as bitcoin from "bitcoinjs-lib";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import { fundPeginTransaction } from "../../../utils/transaction/fundPeginTransaction";
+import { buildPrePeginPsbt, type PrePeginParams } from "../pegin";
+import { buildRefundPsbt } from "../refund";
+
+import { TEST_AMOUNTS, TEST_KEYS, initializeWasmForTests } from "./helpers";
+
+const TEST_HASH_H = "ab".repeat(32);
+const TEST_AUTH_ANCHOR_HASH = "cd".repeat(32);
+const TEST_TIMELOCK_REFUND = 50;
+const TEST_REFUND_FEE = 1_000n;
+const TEST_COUNCIL_QUORUM = 2;
+const TEST_COUNCIL_SIZE = 3;
+
+function makePrePeginParams(
+  overrides?: Partial<PrePeginParams>,
+): PrePeginParams {
+  return {
+    depositorPubkey: TEST_KEYS.DEPOSITOR,
+    vaultProviderPubkey: TEST_KEYS.VAULT_PROVIDER,
+    vaultKeeperPubkeys: [TEST_KEYS.VAULT_KEEPER_1],
+    universalChallengerPubkeys: [TEST_KEYS.UNIVERSAL_CHALLENGER_1],
+    hashlocks: [TEST_HASH_H],
+    timelockRefund: TEST_TIMELOCK_REFUND,
+    pegInAmounts: [TEST_AMOUNTS.PEGIN],
+    feeRate: 10n,
+    numLocalChallengers: 1,
+    councilQuorum: TEST_COUNCIL_QUORUM,
+    councilSize: TEST_COUNCIL_SIZE,
+    network: "signet" as Network,
+    ...overrides,
+  };
+}
+
+async function buildFundedPrePegin(overrides?: Partial<PrePeginParams>) {
+  const params = makePrePeginParams(overrides);
+  const result = await buildPrePeginPsbt(params);
+
+  const fundedTxHex = fundPeginTransaction({
+    unfundedTxHex: result.psbtHex,
+    selectedUTXOs: [
+      {
+        txid: "aa".repeat(32),
+        vout: 0,
+        value: Number(result.totalOutputValue + 10_000n),
+        scriptPubKey: "0014" + "bb".repeat(20),
+      },
+    ],
+    changeAddress: "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
+    changeAmount: 10_000n,
+    network: bitcoin.networks.testnet,
+  });
+
+  return { txHex: fundedTxHex, params, psbtResult: result };
+}
+
+describe("buildRefundPsbt", () => {
+  beforeAll(async () => {
+    await initializeWasmForTests();
+  });
+
+  describe("auth-anchor reconstruction", () => {
+    it("builds a valid refund PSBT for an auth-anchored funded Pre-PegIn", async () => {
+      const { txHex, params } = await buildFundedPrePegin({
+        authAnchorHash: TEST_AUTH_ANCHOR_HASH,
+      });
+
+      const { psbtHex } = await buildRefundPsbt({
+        prePeginParams: params,
+        fundedPrePeginTxHex: txHex,
+        htlcVout: 0,
+        refundFee: TEST_REFUND_FEE,
+        hashlock: TEST_HASH_H,
+      });
+
+      const psbt = bitcoin.Psbt.fromHex(psbtHex);
+      // Refund tx spends exactly the HTLC output of the funded Pre-PegIn.
+      const unsigned = psbt.data.globalMap.unsignedTx.toBuffer();
+      const refundTx = bitcoin.Transaction.fromBuffer(unsigned);
+      expect(refundTx.ins.length).toBe(1);
+      const fundedTxid = bitcoin.Transaction.fromHex(txHex).getId();
+      const inputTxid = Buffer.from(refundTx.ins[0].hash)
+        .slice()
+        .reverse()
+        .toString("hex");
+      expect(inputTxid).toBe(fundedTxid);
+      expect(refundTx.ins[0].index).toBe(0);
+      // CSV sequence comes from the WASM and equals `timelockRefund`.
+      expect(refundTx.ins[0].sequence).toBe(TEST_TIMELOCK_REFUND);
+    });
+
+    it("builds a valid refund PSBT for a legacy non-auth-anchored Pre-PegIn", async () => {
+      // No authAnchorHash → unfunded template has no OP_RETURN, funded tx
+      // has no OP_RETURN, reconstruction aligns by default.
+      const { txHex, params } = await buildFundedPrePegin();
+      expect(params.authAnchorHash).toBeUndefined();
+
+      const result = await buildRefundPsbt({
+        prePeginParams: params,
+        fundedPrePeginTxHex: txHex,
+        htlcVout: 0,
+        refundFee: TEST_REFUND_FEE,
+        hashlock: TEST_HASH_H,
+      });
+
+      expect(typeof result.psbtHex).toBe("string");
+      expect(result.psbtHex.length).toBeGreaterThan(0);
+    });
+
+    it("rejects auth-anchored funded Pre-PegIn when authAnchorHash in params disagrees with on-chain commitment", async () => {
+      // If `authAnchorHash` were not forwarded into the WASM
+      // constructor, the unfunded template would have no OP_RETURN at
+      // all and the funded tx's OP_RETURN would be ignored — so this
+      // assertion would *succeed* instead of rejecting. The fact that
+      // it rejects proves the hash flows through to the WASM, where the
+      // content mismatch is detected.
+      const { txHex, params } = await buildFundedPrePegin({
+        authAnchorHash: TEST_AUTH_ANCHOR_HASH,
+      });
+      const wrongHash = "ee".repeat(32);
+
+      await expect(
+        buildRefundPsbt({
+          prePeginParams: { ...params, authAnchorHash: wrongHash },
+          fundedPrePeginTxHex: txHex,
+          htlcVout: 0,
+          refundFee: TEST_REFUND_FEE,
+          hashlock: TEST_HASH_H,
+        }),
+      ).rejects.toThrow();
+    });
+  });
+});

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts
@@ -192,7 +192,7 @@ export async function buildPrePeginPsbt(
  * Validate and normalize an `authAnchorHash` hex string before passing
  * it to the WASM boundary. WASM expects exactly 64 lowercase hex chars.
  */
-function normalizeAuthAnchorHash(
+export function normalizeAuthAnchorHash(
   value: string | undefined,
 ): string | undefined {
   if (value === undefined) return undefined;

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts
@@ -21,7 +21,7 @@ import { Buffer } from "buffer";
 import { Psbt, Transaction } from "bitcoinjs-lib";
 
 import { TAPSCRIPT_LEAF_VERSION, hexToUint8Array, uint8ArrayToHex } from "../utils/bitcoin";
-import type { PrePeginParams } from "./pegin";
+import { normalizeAuthAnchorHash, type PrePeginParams } from "./pegin";
 
 /**
  * Parameters for building a refund PSBT
@@ -77,7 +77,13 @@ export async function buildRefundPsbt(
   // commit an OP_RETURN <PUSH32 SHA256(authAnchor)> output at
   // `vout = hashlocks.length`; the unfunded template must include it so
   // `fromFundedTransaction` aligns with the funded tx's output shape.
-  // Pass `undefined` only for legacy non-auth-anchored Pre-PegIns.
+  // Normalize identically to the peg-in primitives (`0x` strip,
+  // lowercase, length/charset validation) so a direct primitive caller
+  // reusing successful peg-in params doesn't hand unnormalized bytes to
+  // WASM. Pass `undefined` for legacy non-auth-anchored Pre-PegIns.
+  const normalizedAuthAnchorHash = normalizeAuthAnchorHash(
+    prePeginParams.authAnchorHash,
+  );
   const unfundedTx = new (WasmPrePeginTx as unknown as new (
     depositor: string,
     vault_provider: string,
@@ -105,7 +111,7 @@ export async function buildRefundPsbt(
     prePeginParams.councilQuorum,
     prePeginParams.councilSize,
     prePeginParams.network,
-    prePeginParams.authAnchorHash,
+    normalizedAuthAnchorHash,
   );
 
   let fundedTx: WasmPrePeginTx | null = null;

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts
@@ -72,7 +72,27 @@ export async function buildRefundPsbt(
   const { prePeginParams, fundedPrePeginTxHex, htlcVout, refundFee, hashlock } =
     params;
 
-  const unfundedTx = new WasmPrePeginTx(
+  // The 13th positional arg `auth_anchor_hash` is `Option<String>` in
+  // the Rust WASM constructor. Production peg-ins (PeginManager) always
+  // commit an OP_RETURN <PUSH32 SHA256(authAnchor)> output at
+  // `vout = hashlocks.length`; the unfunded template must include it so
+  // `fromFundedTransaction` aligns with the funded tx's output shape.
+  // Pass `undefined` only for legacy non-auth-anchored Pre-PegIns.
+  const unfundedTx = new (WasmPrePeginTx as unknown as new (
+    depositor: string,
+    vault_provider: string,
+    vault_keepers: string[],
+    universal_challengers: string[],
+    hashlocks: string[],
+    pegin_amounts: BigUint64Array,
+    timelock_refund: number,
+    fee_rate: bigint,
+    num_local_challengers: number,
+    council_quorum: number,
+    council_size: number,
+    network: string,
+    auth_anchor_hash?: string,
+  ) => typeof WasmPrePeginTx.prototype)(
     prePeginParams.depositorPubkey,
     prePeginParams.vaultProviderPubkey,
     prePeginParams.vaultKeeperPubkeys,
@@ -85,6 +105,7 @@ export async function buildRefundPsbt(
     prePeginParams.councilQuorum,
     prePeginParams.councilSize,
     prePeginParams.network,
+    prePeginParams.authAnchorHash,
   );
 
   let fundedTx: WasmPrePeginTx | null = null;

--- a/packages/babylon-ts-sdk/src/tbv/core/services/refund/__tests__/buildAndBroadcastRefund.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/refund/__tests__/buildAndBroadcastRefund.test.ts
@@ -74,7 +74,7 @@ const UC_PUBKEY = "d".repeat(64);
 function buildVault(overrides?: Partial<VaultRefundData>): VaultRefundData {
   return {
     hashlock: HASHLOCK,
-    htlcVout: 1,
+    htlcVout: 0,
     offchainParamsVersion: 1,
     appVaultKeepersVersion: 1,
     universalChallengersVersion: 1,
@@ -313,20 +313,23 @@ describe("buildAndBroadcastRefund", () => {
   });
 
   describe("auth-anchor extraction", () => {
-    // Build a minimal funded Pre-PegIn tx hex with a configurable shape:
-    // optional OP_RETURN at vout=1 carrying a 32-byte payload. The HTLC
-    // output at vout=0 is a placeholder — the orchestrator does not
-    // re-derive HTLC content here; the WASM primitive is mocked. We
-    // only care that `readAuthAnchorOpReturn` sees the right output
-    // shape.
+    // Build a minimal funded Pre-PegIn tx hex with a configurable
+    // shape: N HTLC-placeholder outputs followed by an optional
+    // OP_RETURN. The HTLC outputs are placeholders — the orchestrator
+    // does not re-derive HTLC content here; the WASM primitive is
+    // mocked. We only care that the auth-anchor finder sees the right
+    // output layout.
     function buildMinimalFundedPrePeginHex(opts?: {
       authAnchorHashHex?: string;
+      numHtlcs?: number;
     }): string {
+      const numHtlcs = opts?.numHtlcs ?? 1;
       const tx = new bitcoin.Transaction();
       tx.addInput(Buffer.alloc(32, 0xaa), 0);
-      // HTLC placeholder at vout 0 (P2WPKH script — any 22-byte script is
-      // fine; the parser only inspects vout 1 for the OP_RETURN).
-      tx.addOutput(Buffer.from("0014" + "11".repeat(20), "hex"), 100_000);
+      // HTLC placeholders (P2WPKH script — any 22-byte script is fine).
+      for (let i = 0; i < numHtlcs; i++) {
+        tx.addOutput(Buffer.from("0014" + "11".repeat(20), "hex"), 100_000);
+      }
       if (opts?.authAnchorHashHex !== undefined) {
         // OP_RETURN (0x6a) || PUSH32 (0x20) || <32-byte hash>
         tx.addOutput(
@@ -403,6 +406,57 @@ describe("buildAndBroadcastRefund", () => {
       const [call] = mockedBuildRefundPsbt.mock.calls;
       expect(call[0].prePeginParams.authAnchorHash).toBe("ab".repeat(32));
     });
+
+    it("refuses a 2-vault funded tx (OP_RETURN at vout 2) and does not call buildRefundPsbt", async () => {
+      // Multi-vault Pre-PegIn: HTLCs at 0 & 1, OP_RETURN at vout 2.
+      // The single-vault refund path reconstructs only one hashlock —
+      // the template would not match the funded tx's shape. Refuse
+      // structurally instead of producing a wrong refund.
+      const fundedHex = buildMinimalFundedPrePeginHex({
+        numHtlcs: 2,
+        authAnchorHashHex: "cd".repeat(32),
+      });
+      readVault.mockResolvedValue(
+        buildVault({ unsignedPrePeginTxHex: "0x" + fundedHex }),
+      );
+
+      await expect(
+        buildAndBroadcastRefund({
+          vaultId: VAULT_ID,
+          readVault,
+          readPrePeginContext,
+          feeRate: FEE_RATE,
+          signPsbt,
+          broadcastTx,
+        }),
+      ).rejects.toThrow(/Multi-vault Pre-PegIn refund is not supported/);
+
+      expect(mockedBuildRefundPsbt).not.toHaveBeenCalled();
+      expect(broadcastTx).not.toHaveBeenCalled();
+    });
+
+    it("refuses a 3-vault funded tx (OP_RETURN at vout 3) and does not call buildRefundPsbt", async () => {
+      const fundedHex = buildMinimalFundedPrePeginHex({
+        numHtlcs: 3,
+        authAnchorHashHex: "cd".repeat(32),
+      });
+      readVault.mockResolvedValue(
+        buildVault({ unsignedPrePeginTxHex: "0x" + fundedHex }),
+      );
+
+      await expect(
+        buildAndBroadcastRefund({
+          vaultId: VAULT_ID,
+          readVault,
+          readPrePeginContext,
+          feeRate: FEE_RATE,
+          signPsbt,
+          broadcastTx,
+        }),
+      ).rejects.toThrow(/auth-anchor OP_RETURN at vout 3/);
+
+      expect(mockedBuildRefundPsbt).not.toHaveBeenCalled();
+    });
   });
 
   describe("validation", () => {
@@ -438,8 +492,12 @@ describe("buildAndBroadcastRefund", () => {
       expect(readPrePeginContext).not.toHaveBeenCalled();
     });
 
-    it("rejects htlcVout out of range", async () => {
-      readVault.mockResolvedValue(buildVault({ htlcVout: 70000 }));
+    it("rejects htlcVout = 1 with the multi-vault message", async () => {
+      // This SDK call reconstructs a single-hashlock template — any
+      // non-zero htlcVout implies a batched (multi-vault) Pre-PegIn
+      // whose sibling HTLCs would be silently dropped. Refuse at the
+      // input layer before reading any state.
+      readVault.mockResolvedValue(buildVault({ htlcVout: 1 }));
 
       await expect(
         buildAndBroadcastRefund({
@@ -450,8 +508,29 @@ describe("buildAndBroadcastRefund", () => {
           signPsbt,
           broadcastTx,
         }),
-      ).rejects.toThrow(/htlcVout must be an integer/);
+      ).rejects.toThrow(/Multi-vault Pre-PegIn refund is not supported/);
+      expect(readPrePeginContext).not.toHaveBeenCalled();
     });
+
+    it.each([Number.NaN, -1, 1.5, 70_000])(
+      "rejects non-integer or non-zero htlcVout (%s)",
+      async (htlcVout) => {
+        readVault.mockResolvedValue(
+          buildVault({ htlcVout: htlcVout as number }),
+        );
+
+        await expect(
+          buildAndBroadcastRefund({
+            vaultId: VAULT_ID,
+            readVault,
+            readPrePeginContext,
+            feeRate: FEE_RATE,
+            signPsbt,
+            broadcastTx,
+          }),
+        ).rejects.toThrow(/Multi-vault Pre-PegIn refund is not supported/);
+      },
+    );
 
     // Version fields flow directly into on-chain script derivation via
     // readPrePeginContext — NaN, negative, or non-integer values would

--- a/packages/babylon-ts-sdk/src/tbv/core/services/refund/__tests__/buildAndBroadcastRefund.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/refund/__tests__/buildAndBroadcastRefund.test.ts
@@ -1,3 +1,4 @@
+import * as bitcoin from "bitcoinjs-lib";
 import type { Address, Hex } from "viem";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -35,7 +36,11 @@ vi.mock(
 
 // Finalize + extract uses bitcoinjs-lib. We stub Psbt.fromHex to return an
 // object with controllable `finalizeAllInputs` / `extractTransaction`.
-vi.mock("bitcoinjs-lib", async () => {
+// `Transaction` is kept real because the orchestrator also parses the
+// funded Pre-PegIn hex via `readAuthAnchorOpReturn` to extract the
+// auth-anchor commitment.
+vi.mock("bitcoinjs-lib", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("bitcoinjs-lib")>();
   const psbtInstance = {
     finalizeAllInputs: vi.fn(),
     extractTransaction: vi.fn(() => ({
@@ -43,6 +48,7 @@ vi.mock("bitcoinjs-lib", async () => {
     })),
   };
   return {
+    ...actual,
     Psbt: {
       fromHex: vi.fn(() => psbtInstance),
     },
@@ -304,6 +310,99 @@ describe("buildAndBroadcastRefund", () => {
     expect(call[0].hashlock).toBe(HASHLOCK.slice(2));
     expect(call[0].hashlock).not.toMatch(/^0x/);
     expect(call[0].fundedPrePeginTxHex).not.toMatch(/^0x/);
+  });
+
+  describe("auth-anchor extraction", () => {
+    // Build a minimal funded Pre-PegIn tx hex with a configurable shape:
+    // optional OP_RETURN at vout=1 carrying a 32-byte payload. The HTLC
+    // output at vout=0 is a placeholder — the orchestrator does not
+    // re-derive HTLC content here; the WASM primitive is mocked. We
+    // only care that `readAuthAnchorOpReturn` sees the right output
+    // shape.
+    function buildMinimalFundedPrePeginHex(opts?: {
+      authAnchorHashHex?: string;
+    }): string {
+      const tx = new bitcoin.Transaction();
+      tx.addInput(Buffer.alloc(32, 0xaa), 0);
+      // HTLC placeholder at vout 0 (P2WPKH script — any 22-byte script is
+      // fine; the parser only inspects vout 1 for the OP_RETURN).
+      tx.addOutput(Buffer.from("0014" + "11".repeat(20), "hex"), 100_000);
+      if (opts?.authAnchorHashHex !== undefined) {
+        // OP_RETURN (0x6a) || PUSH32 (0x20) || <32-byte hash>
+        tx.addOutput(
+          Buffer.from(`6a20${opts.authAnchorHashHex}`, "hex"),
+          0,
+        );
+      }
+      return tx.toHex();
+    }
+
+    it("extracts authAnchorHash from vout=1 OP_RETURN and forwards it into prePeginParams", async () => {
+      const ANCHOR_HASH = "cd".repeat(32);
+      const fundedHex = buildMinimalFundedPrePeginHex({
+        authAnchorHashHex: ANCHOR_HASH,
+      });
+      readVault.mockResolvedValue(
+        buildVault({ unsignedPrePeginTxHex: "0x" + fundedHex }),
+      );
+
+      await buildAndBroadcastRefund({
+        vaultId: VAULT_ID,
+        readVault,
+        readPrePeginContext,
+        feeRate: FEE_RATE,
+        signPsbt,
+        broadcastTx,
+      });
+
+      const [call] = mockedBuildRefundPsbt.mock.calls;
+      expect(call[0].prePeginParams.authAnchorHash).toBe(ANCHOR_HASH);
+    });
+
+    it("passes authAnchorHash = undefined when the funded tx has no OP_RETURN at vout 1 (legacy shape)", async () => {
+      const fundedHex = buildMinimalFundedPrePeginHex();
+      readVault.mockResolvedValue(
+        buildVault({ unsignedPrePeginTxHex: "0x" + fundedHex }),
+      );
+
+      await buildAndBroadcastRefund({
+        vaultId: VAULT_ID,
+        readVault,
+        readPrePeginContext,
+        feeRate: FEE_RATE,
+        signPsbt,
+        broadcastTx,
+      });
+
+      const [call] = mockedBuildRefundPsbt.mock.calls;
+      expect(call[0].prePeginParams.authAnchorHash).toBeUndefined();
+    });
+
+    it("normalizes the extracted hash to lowercase (matches WASM hex convention)", async () => {
+      // OP_RETURN payloads are raw bytes — they don't have an intrinsic
+      // case. The reader normalizes its hex output to lowercase so the
+      // unfunded WASM template and any expected-hash comparison stay
+      // byte-identical regardless of how callers spell their input.
+      const UPPER_ANCHOR_HASH = "AB".repeat(32);
+      const fundedHex = buildMinimalFundedPrePeginHex({
+        authAnchorHashHex: UPPER_ANCHOR_HASH,
+      });
+      readVault.mockResolvedValue(
+        buildVault({ unsignedPrePeginTxHex: "0x" + fundedHex }),
+      );
+
+      await buildAndBroadcastRefund({
+        vaultId: VAULT_ID,
+        readVault,
+        readPrePeginContext,
+        feeRate: FEE_RATE,
+        signPsbt,
+        broadcastTx,
+      });
+
+      const [call] = mockedBuildRefundPsbt.mock.calls;
+      expect(call[0].prePeginParams.authAnchorHash).toBe("ab".repeat(32));
+    });
   });
 
   describe("validation", () => {

--- a/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts
@@ -15,6 +15,7 @@ import { Psbt } from "bitcoinjs-lib";
 import type { Address, Hex } from "viem";
 
 import type { SignPsbtOptions } from "../../../../shared/wallets/interfaces/BitcoinWallet";
+import { readAuthAnchorOpReturn } from "../../managers/pegin";
 import { assertPsbtUnsignedTxMatches } from "../../primitives/psbt/assertPsbtUnsignedTxMatches";
 import { buildRefundPsbt } from "../../primitives/psbt/refund";
 import {
@@ -330,6 +331,23 @@ export async function buildAndBroadcastRefund<
   const xOnlyDepositorPubkey = processPublicKeyToXOnly(
     vault.depositorBtcPubkey,
   );
+
+  const cleanFundedPrePeginTxHex = stripHexPrefix(vault.unsignedPrePeginTxHex);
+
+  // Production peg-ins (PeginManager) commit an OP_RETURN <PUSH32
+  // SHA256(authAnchor)> output at `vout = hashlocks.length`. The refund
+  // reconstructs the unfunded WASM template for a single vault here
+  // (hashlocks: [vault.hashlock]), so the anchor output — if present —
+  // sits at vout 1. Forwarding the parsed hash makes the unfunded
+  // template's output shape match the funded tx; legacy
+  // non-auth-anchored deposits return `undefined` and use the
+  // 12-output template instead.
+  const SINGLE_VAULT_AUTH_ANCHOR_VOUT = 1;
+  const authAnchorHash = readAuthAnchorOpReturn(
+    cleanFundedPrePeginTxHex,
+    SINGLE_VAULT_AUTH_ANCHOR_VOUT,
+  );
+
   const { psbtHex } = await buildRefundPsbt({
     prePeginParams: {
       depositorPubkey: xOnlyDepositorPubkey,
@@ -345,8 +363,9 @@ export async function buildAndBroadcastRefund<
       councilQuorum: ctx.councilQuorum,
       councilSize: ctx.councilSize,
       network: ctx.network,
+      authAnchorHash,
     },
-    fundedPrePeginTxHex: stripHexPrefix(vault.unsignedPrePeginTxHex),
+    fundedPrePeginTxHex: cleanFundedPrePeginTxHex,
     htlcVout: vault.htlcVout,
     refundFee,
     // buildRefundPsbt's top-level `hashlock` param is documented as "no 0x

--- a/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts
@@ -15,7 +15,7 @@ import { Psbt } from "bitcoinjs-lib";
 import type { Address, Hex } from "viem";
 
 import type { SignPsbtOptions } from "../../../../shared/wallets/interfaces/BitcoinWallet";
-import { readAuthAnchorOpReturn } from "../../managers/pegin";
+import { findAuthAnchorOpReturn } from "../../managers/pegin";
 import { assertPsbtUnsignedTxMatches } from "../../primitives/psbt/assertPsbtUnsignedTxMatches";
 import { buildRefundPsbt } from "../../primitives/psbt/refund";
 import {
@@ -62,7 +62,6 @@ export function estimateRefundFeeSats(feeRateSatsVb: number): bigint {
 // (Not the taproot leaf index; the leaf is encoded into the PSBT by the
 // WASM PSBT builder based on the refund script path.)
 const REFUND_INPUT_COUNT = 1;
-const MAX_VOUT = 0xffff;
 const BIP68_ERROR_RE = /non-BIP68-final/i;
 
 function assertBytes32(value: string, label: string): void {
@@ -183,13 +182,19 @@ function assertNonNegativeInteger(value: number, label: string): void {
 
 function validateVaultRefundData(v: VaultRefundData): void {
   assertBytes32(v.hashlock, "hashlock");
-  if (
-    !Number.isInteger(v.htlcVout) ||
-    v.htlcVout < 0 ||
-    v.htlcVout > MAX_VOUT
-  ) {
+  // This SDK call reconstructs a single-hashlock unfunded template
+  // ([single]) and so only supports refund of the HTLC at vout 0. A
+  // multi-vault Pre-PegIn places HTLCs at 0..hashlocks.length-1 — any
+  // htlcVout != 0 implies a batched deposit whose sibling HTLCs would
+  // be missing from the reconstructed template. The orchestrator's
+  // structural OP_RETURN scan below catches auth-anchored multi-vault
+  // txs; this assertion additionally catches legacy (no OP_RETURN)
+  // multi-vault txs and documents the contract at the input boundary.
+  if (!Number.isInteger(v.htlcVout) || v.htlcVout !== 0) {
     throw new Error(
-      `htlcVout must be an integer 0-${MAX_VOUT}, got ${v.htlcVout}`,
+      `Multi-vault Pre-PegIn refund is not supported by this SDK call ` +
+        `(htlcVout=${v.htlcVout}, expected 0). Refund of batched-deposit ` +
+        `vaults requires reconstructing all sibling HTLCs.`,
     );
   }
   // Version fields flow directly into on-chain script derivation via
@@ -338,15 +343,24 @@ export async function buildAndBroadcastRefund<
   // SHA256(authAnchor)> output at `vout = hashlocks.length`. The refund
   // reconstructs the unfunded WASM template for a single vault here
   // (hashlocks: [vault.hashlock]), so the anchor output — if present —
-  // sits at vout 1. Forwarding the parsed hash makes the unfunded
-  // template's output shape match the funded tx; legacy
-  // non-auth-anchored deposits return `undefined` and use the
-  // 12-output template instead.
+  // must be at vout 1. Scan the funded tx structurally rather than
+  // peeking at a hardcoded vout: that way a batched (multi-vault) tx,
+  // where the anchor lives at vout N > 1, is detected and refused
+  // explicitly rather than silently reconstructing a single-hashlock
+  // template against an N-HTLC funded tx. Legacy non-auth-anchored
+  // deposits return `undefined` from the finder and use the 12-output
+  // template.
   const SINGLE_VAULT_AUTH_ANCHOR_VOUT = 1;
-  const authAnchorHash = readAuthAnchorOpReturn(
-    cleanFundedPrePeginTxHex,
-    SINGLE_VAULT_AUTH_ANCHOR_VOUT,
-  );
+  const found = findAuthAnchorOpReturn(cleanFundedPrePeginTxHex);
+  if (found !== undefined && found.vout !== SINGLE_VAULT_AUTH_ANCHOR_VOUT) {
+    throw new Error(
+      `Multi-vault Pre-PegIn refund is not supported by this SDK call ` +
+        `(auth-anchor OP_RETURN at vout ${found.vout}; single-vault refund ` +
+        `expects vout ${SINGLE_VAULT_AUTH_ANCHOR_VOUT}). Refund of ` +
+        `batched-deposit vaults requires reconstructing all sibling HTLCs.`,
+    );
+  }
+  const authAnchorHash = found?.hash;
 
   const { psbtHex } = await buildRefundPsbt({
     prePeginParams: {


### PR DESCRIPTION
# fix(ts-sdk): forward auth-anchor hash into refund PSBT reconstruction

Closes [babylonlabs-io/baby-auditor-findings#300](https://github.com/babylonlabs-io/baby-auditor-findings/issues/300)

## What this PR does

When the SDK builds a refund PSBT for an expired Pre-PegIn, it rebuilds the WASM `WasmPrePeginTx` template that originally produced the funded Pre-PegIn transaction. Today, every production peg-in (`PeginManager.preparePegin`) commits an `OP_RETURN <PUSH32 SHA256(authAnchor)>` output at `vout = hashlocks.length`. The refund primitive was passing only **12 of the 13** WASM constructor arguments — it dropped the `auth_anchor_hash` arg — so the unfunded template's output shape did **not** match the funded tx.

This PR:

- Adds a non-throwing helper `readAuthAnchorOpReturn(txHex, vout)` that returns the 32-byte OP_RETURN payload (lowercase hex) if the output at `vout` is exactly `OP_RETURN || PUSH32 || <32B>` with value 0, and `undefined` for any other shape (legacy non-auth-anchored deposits, parse failure, etc.).
- In `buildAndBroadcastRefund`, extracts that hash from the funded Pre-PegIn at `vout = 1` (single-vault refund passes `hashlocks: [vault.hashlock]`, so the OP_RETURN sits at vout 1) and threads it through `prePeginParams.authAnchorHash`.
- In `buildRefundPsbt`, forwards `prePeginParams.authAnchorHash` as the 13th WASM constructor arg — mirroring how the peg-in primitive (`buildPeginTxFromPrePegin`) already does it.
- Adds the first refund-flow primitive tests in the repo and an "auth-anchor extraction" test block on the orchestrator.

## Why

Refund is the depositor's last-resort recovery path after activation fails. The audit's concern was: if the unfunded template doesn't match the funded tx's output shape, refund construction either errors out at `fromFundedTransaction` or produces an unspendable refund PSBT — and the depositor's BTC stays locked.

Additionally, this is a CLAUDE.md §1 (WASM boundary) issue. The asymmetry between the peg-in path (passes the anchor hash) and the refund path (doesn't) is a code smell: the same value, sourced the same way, flowing into the same WASM constructor — but one path forgot it.

### Note on runtime severity

While verifying the fix, I confirmed something the audit didn't: the **current** WASM build's `fromFundedTransaction` is permissive when the unfunded template has one fewer output than the funded tx — it does _not_ throw on the count mismatch. It _is_ strict on content mismatch.

What that means in practice: in production today, a single-HTLC refund built without the auth-anchor hash would likely still produce a functionally valid PSBT (the HTLC layout starts at vout 0 either way). The bug is **latent** — but the fix is still required because:

1. The WASM API explicitly permits a strict check; a future `btc-vault` rebuild could flip this and break every refund in flight.
2. CLAUDE.md §1 demands that every value JS hands to WASM matches what the protocol expects.
3. The "wrong content" failure mode is **not** latent — a stale or substituted hash would already fail loudly today (the new content-mismatch test exercises this).

So: severity HIGH per CLAUDE.md §1, but not "every refund is broken right now."

## Approaches considered

| Option                                                                               | Where the extraction happens | Trade-off                                                                                                                                                        |
| ------------------------------------------------------------------------------------ | ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| **A. Extract in orchestrator, forward via `prePeginParams.authAnchorHash`** ← chosen | `buildAndBroadcastRefund.ts` | Matches the peg-in pattern (orchestrator extracts → primitive forwards). Funded tx is the byte-level source of truth, and the orchestrator already validates it. |
| B. Extract inside the primitive                                                      | `buildRefundPsbt`            | Less plumbing, but conflates "build a PSBT from a template" with "infer template fields from the funded tx". The primitive's job should be declarative.          |
| C. Persist `authAnchorHash` in `VaultRefundData`                                     | indexer / localStorage       | Adds new state that has to stay in sync with the funded tx. Drift risk for zero gain — the funded tx already carries the value.                                  |

I went with **A** because the funded tx is the only authoritative source for what was actually committed on-chain. Persisting alongside vault data (C) introduces drift risk, and inferring inside the primitive (B) makes the primitive less predictable. The orchestrator already validates the funded tx and is the natural place to derive one more field from it.

One deliberate deviation from the auditor's concrete-steps recommendation: I did **not** add `authAnchorHash` to `RefundPrePeginContext`. That interface is for _version-resolved protocol context_ (signer sets, timelocks, etc.) — protocol-level values resolved against on-chain version pins. The auth-anchor hash is a per-transaction artifact extracted from the funded tx itself; it belongs on `prePeginParams`, where there's already a typed slot (`PrePeginParams.authAnchorHash`).

## Scope

Single-vault refund only. Multi-vault batched refunds have a separate template-mismatch bug tracked at [babylonlabs-io/baby-auditor-findings#257](https://github.com/babylonlabs-io/baby-auditor-findings/issues/257) (sibling HTLCs dropped from the reconstructed template). The shared `readAuthAnchorOpReturn` helper and the new refund-flow test scaffold this PR adds are both reusable for that fix.
