### PR TITLE
fix(ts-sdk): assert presign-response claimer set matches on-chain

### DIFF
--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/runDepositorPresignFlow.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/runDepositorPresignFlow.test.ts
@@ -495,5 +495,50 @@ describe("runDepositorPresignFlow", () => {
         presignClient.submitDepositorPresignatures,
       ).toHaveBeenCalledOnce();
     });
+
+    it("filters out an uppercase-hex depositor entry consistently with the assertion", async () => {
+      // VP returns the depositor's claimer entry as uppercase hex (allowed
+      // by the VP-response schema validator) while signing context has it
+      // lowercase. Both the assertion and the depositor filter must
+      // normalize case identically, so:
+      //  - the assertion passes (set still equals {VP, VK})
+      //  - the depositor entry is filtered out before Phase 3 signing
+      //  - the submitted signatures map contains only the lowercase
+      //    depositor key, never the uppercase variant
+      const uppercaseDepositorEntry: ClaimerTransactions = {
+        ...depositorEntry,
+        claimer_pubkey: DEPOSITOR_PK.toUpperCase(),
+      };
+      const { promise, presignClient } = runWith([
+        vpEntry,
+        vkEntry,
+        uppercaseDepositorEntry,
+      ]);
+      await promise;
+
+      const submitCall = (
+        presignClient.submitDepositorPresignatures as ReturnType<typeof vi.fn>
+      ).mock.calls[0][0];
+      const keys = Object.keys(submitCall.signatures);
+      expect(keys).toContain(DEPOSITOR_PK);
+      expect(keys).not.toContain(DEPOSITOR_PK.toUpperCase());
+      // {VP, VK, depositor} = 3 keys, no duplicate cased-variant of the depositor
+      expect(keys).toHaveLength(3);
+    });
+
+    it("rejects [VP, VK, depositor, depositor] with a duplicate depositor entry", async () => {
+      // Duplicate detection must run on the full supplied list before the
+      // depositor entries are filtered out, otherwise a duplicated
+      // depositor entry slips through silently.
+      const { promise, presignClient, wallet } = runWith([
+        vpEntry,
+        vkEntry,
+        depositorEntry,
+        depositorEntry,
+      ]);
+      await expect(promise).rejects.toThrow(/duplicate/i);
+      expect(presignClient.submitDepositorPresignatures).not.toHaveBeenCalled();
+      expect(wallet.signPsbts).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/runDepositorPresignFlow.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/runDepositorPresignFlow.test.ts
@@ -47,6 +47,8 @@ vi.mock("../../../primitives/utils/bitcoin", () => ({
     pk.startsWith("0x") ? pk.slice(2) : pk.length === 66 ? pk.slice(2) : pk,
   stripHexPrefix: (s: string) =>
     s.startsWith("0x") ? s.slice(2) : s,
+  deriveBip86ScriptPubKeyHex: (xOnlyPubkey: string) =>
+    `0x5120${xOnlyPubkey}`,
 }));
 
 vi.mock("bitcoinjs-lib", () => ({
@@ -87,8 +89,15 @@ function createMockStatusReader(
 function createMockPresignClient(
   response?: Partial<RequestDepositorPresignTransactionsResponse>,
 ): PresignClient {
-  const defaultClaimer: ClaimerTransactions = {
+  const vpClaimer: ClaimerTransactions = {
     claimer_pubkey: VP_PUBKEY,
+    claim_tx: { tx_hex: "deadbeef" },
+    assert_tx: { tx_hex: "deadbeef" },
+    payout_tx: { tx_hex: "deadbeef" },
+    payout_psbt: "mock_psbt",
+  };
+  const vkClaimer: ClaimerTransactions = {
+    claimer_pubkey: VK_PUBKEY,
     claim_tx: { tx_hex: "deadbeef" },
     assert_tx: { tx_hex: "deadbeef" },
     payout_tx: { tx_hex: "deadbeef" },
@@ -116,7 +125,7 @@ function createMockPresignClient(
 
   return {
     requestDepositorPresignTransactions: vi.fn(async () => ({
-      txs: [defaultClaimer, ...(response?.txs?.slice(1) ?? [])],
+      txs: response?.txs ?? [vpClaimer, vkClaimer],
       depositor_graph:
         response?.depositor_graph ?? defaultDepositorGraph,
     })),
@@ -314,7 +323,8 @@ describe("runDepositorPresignFlow", () => {
   });
 
   it("filters out depositor's own claimer entry from PayoutManager signing", async () => {
-    // Include the depositor as a claimer in the VP response
+    // Include the depositor as a claimer in the VP response, alongside the
+    // required {VP, VK} set the new completeness assertion expects.
     const depositorClaimer: ClaimerTransactions = {
       claimer_pubkey: DEPOSITOR_PK,
       claim_tx: { tx_hex: "deadbeef" },
@@ -329,13 +339,20 @@ describe("runDepositorPresignFlow", () => {
       payout_tx: { tx_hex: "deadbeef" },
       payout_psbt: "mock_psbt",
     };
+    const vkClaimer: ClaimerTransactions = {
+      claimer_pubkey: VK_PUBKEY,
+      claim_tx: { tx_hex: "deadbeef" },
+      assert_tx: { tx_hex: "deadbeef" },
+      payout_tx: { tx_hex: "deadbeef" },
+      payout_psbt: "mock_psbt",
+    };
 
     const reader = createMockStatusReader([
       DaemonStatus.PENDING_DEPOSITOR_SIGNATURES,
     ]);
     const presignClient: PresignClient = {
       requestDepositorPresignTransactions: vi.fn(async () => ({
-        txs: [vpClaimer, depositorClaimer],
+        txs: [vpClaimer, vkClaimer, depositorClaimer],
         depositor_graph: {
           claim_tx: { tx_hex: "deadbeef" },
           assert_tx: { tx_hex: "deadbeef" },
@@ -382,5 +399,101 @@ describe("runDepositorPresignFlow", () => {
         signal: controller.signal,
       }),
     ).rejects.toThrow();
+  });
+
+  describe("non-depositor claimer set completeness", () => {
+    const vpEntry: ClaimerTransactions = {
+      claimer_pubkey: VP_PUBKEY,
+      claim_tx: { tx_hex: "deadbeef" },
+      assert_tx: { tx_hex: "deadbeef" },
+      payout_tx: { tx_hex: "deadbeef" },
+      payout_psbt: "mock_psbt",
+    };
+    const vkEntry: ClaimerTransactions = {
+      claimer_pubkey: VK_PUBKEY,
+      claim_tx: { tx_hex: "deadbeef" },
+      assert_tx: { tx_hex: "deadbeef" },
+      payout_tx: { tx_hex: "deadbeef" },
+      payout_psbt: "mock_psbt",
+    };
+    const depositorEntry: ClaimerTransactions = {
+      claimer_pubkey: DEPOSITOR_PK,
+      claim_tx: { tx_hex: "deadbeef" },
+      assert_tx: { tx_hex: "deadbeef" },
+      payout_tx: { tx_hex: "deadbeef" },
+      payout_psbt: "mock_psbt",
+    };
+    const unknownEntry: ClaimerTransactions = {
+      claimer_pubkey: "1".repeat(64),
+      claim_tx: { tx_hex: "deadbeef" },
+      assert_tx: { tx_hex: "deadbeef" },
+      payout_tx: { tx_hex: "deadbeef" },
+      payout_psbt: "mock_psbt",
+    };
+
+    function runWith(txs: ClaimerTransactions[]) {
+      const reader = createMockStatusReader([
+        DaemonStatus.PENDING_DEPOSITOR_SIGNATURES,
+      ]);
+      const presignClient = createMockPresignClient({ txs });
+      const wallet = createMockWallet();
+      const promise = runDepositorPresignFlow({
+        statusReader: reader,
+        presignClient,
+        btcWallet: wallet,
+        peginTxid: VALID_TXID,
+        depositorPk: DEPOSITOR_PK,
+        signingContext: createSigningContext(),
+      });
+      return { promise, presignClient, wallet };
+    }
+
+    it("rejects response that omits a registered vault keeper", async () => {
+      const { promise, presignClient, wallet } = runWith([vpEntry]);
+      await expect(promise).rejects.toThrow(/missing/i);
+      expect(presignClient.submitDepositorPresignatures).not.toHaveBeenCalled();
+      expect(wallet.signPsbts).not.toHaveBeenCalled();
+    });
+
+    it("rejects empty response", async () => {
+      const { promise, presignClient, wallet } = runWith([]);
+      await expect(promise).rejects.toThrow(/missing/i);
+      expect(presignClient.submitDepositorPresignatures).not.toHaveBeenCalled();
+      expect(wallet.signPsbts).not.toHaveBeenCalled();
+    });
+
+    it("rejects response containing a duplicate claimer entry", async () => {
+      const { promise, presignClient, wallet } = runWith([
+        vpEntry,
+        vkEntry,
+        vkEntry,
+      ]);
+      await expect(promise).rejects.toThrow(/duplicate/i);
+      expect(presignClient.submitDepositorPresignatures).not.toHaveBeenCalled();
+      expect(wallet.signPsbts).not.toHaveBeenCalled();
+    });
+
+    it("rejects response containing an unknown extra claimer before signing", async () => {
+      const { promise, presignClient, wallet } = runWith([
+        vpEntry,
+        vkEntry,
+        unknownEntry,
+      ]);
+      await expect(promise).rejects.toThrow(/unexpected/i);
+      expect(presignClient.submitDepositorPresignatures).not.toHaveBeenCalled();
+      expect(wallet.signPsbts).not.toHaveBeenCalled();
+    });
+
+    it("accepts the happy path with {VP, all VKs} plus the depositor entry", async () => {
+      const { promise, presignClient } = runWith([
+        vpEntry,
+        vkEntry,
+        depositorEntry,
+      ]);
+      await promise;
+      expect(
+        presignClient.submitDepositorPresignatures,
+      ).toHaveBeenCalledOnce();
+    });
   });
 });

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts
@@ -136,6 +136,66 @@ function prepareTransactionsForSigning(
 }
 
 /**
+ * Reject VP-supplied `response.txs` whose non-depositor claimer set does not
+ * exactly equal `{vaultProviderBtcPubkey} ∪ vaultKeeperBtcPubkeys`.
+ *
+ * The expected set is derived from on-chain context (sourced by the caller
+ * from the registry/contract reads that populate PayoutSigningContext). A
+ * malicious or buggy VP could otherwise omit registered vault keepers from
+ * the response; the depositor would sign only the supplied subset and submit
+ * a partial presignature map. If the VP later disappears, the omitted
+ * keepers cannot exercise their payout recovery branch and BTC can lock.
+ *
+ * The depositor's own claimer entry (if present in `response.txs`) is
+ * filtered out before diffing — its Payout PSBT is built locally and signed
+ * separately via signDepositorGraph, so its presence in `response.txs` is
+ * permitted but not required.
+ */
+function assertNonDepositorClaimerSetMatches(
+  suppliedTxs: ClaimerTransactions[],
+  expectedVpPubkey: string,
+  expectedVkPubkeys: string[],
+  depositorPubkeyXOnly: string,
+): void {
+  const norm = (k: string) =>
+    stripHexPrefix(processPublicKeyToXOnly(k)).toLowerCase();
+
+  const depositor = norm(depositorPubkeyXOnly);
+  const expectedList = [norm(expectedVpPubkey), ...expectedVkPubkeys.map(norm)];
+  const expected = new Set(expectedList);
+  if (expected.size !== expectedList.length) {
+    throw new Error(
+      "Cannot validate claimer set: signing context contains duplicate vault provider or vault keeper key",
+    );
+  }
+  if (expected.has(depositor)) {
+    throw new Error(
+      "Cannot validate claimer set: depositor key overlaps with vault provider or vault keeper set",
+    );
+  }
+
+  const supplied = suppliedTxs
+    .map((tx) => norm(tx.claimer_pubkey))
+    .filter((k) => k !== depositor);
+  const suppliedSet = new Set(supplied);
+  if (suppliedSet.size !== supplied.length) {
+    throw new Error(
+      "Presign response contains duplicate claimer entries",
+    );
+  }
+
+  const missing = expectedList.filter((c) => !suppliedSet.has(c));
+  const extra = supplied.filter((c) => !expected.has(c));
+  if (missing.length > 0 || extra.length > 0) {
+    throw new Error(
+      `Presign response claimer set does not match expected (vault provider ∪ vault keepers)` +
+        (missing.length > 0 ? ` (missing: ${missing.join(", ")})` : "") +
+        (extra.length > 0 ? ` (unexpected: ${extra.join(", ")})` : ""),
+    );
+  }
+}
+
+/**
  * Resolve the expected payout scriptPubKey for a given claimer.
  *
  * - VP/Depositor claimer: payout goes to the depositor's registered payout address
@@ -295,11 +355,21 @@ export async function runDepositorPresignFlow(
   signal?.throwIfAborted();
 
   // Phase 3: Sign VP/VK claimer payout transactions
+  // Fail-fast: assert the supplied non-depositor claimer set exactly equals
+  // the on-chain-derived {VP} ∪ {VKs} before any wallet prompts run. The
+  // depositor's own entry is permitted but not required (its payout is
+  // signed separately via signDepositorGraph in Phase 4).
+  const depositorPkNormalized = processPublicKeyToXOnly(depositorPk);
+  assertNonDepositorClaimerSetMatches(
+    response.txs,
+    signingContext.vaultProviderBtcPubkey,
+    signingContext.vaultKeeperBtcPubkeys,
+    depositorPk,
+  );
   // Filter out the depositor's own claimer entry — its payout is signed
   // separately via signDepositorGraph (Phase 4) using VP-provided PSBTs.
   // Including it here would cause a redundant wallet signing prompt whose
   // result is discarded when the depositor graph signature overwrites it.
-  const depositorPkNormalized = processPublicKeyToXOnly(depositorPk);
   const nonDepositorTxs = response.txs.filter(
     (tx) => processPublicKeyToXOnly(tx.claimer_pubkey) !== depositorPkNormalized,
   );

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts
@@ -136,6 +136,17 @@ function prepareTransactionsForSigning(
 }
 
 /**
+ * Canonical x-only lowercase form, used for all claimer pubkey set-equality
+ * comparisons in this module. `processPublicKeyToXOnly` already strips any
+ * `0x` prefix; the lowercase here removes case-sensitivity (the VP-response
+ * schema validator accepts uppercase hex, and `processPublicKeyToXOnly`
+ * preserves the case of already-x-only 64-char input).
+ */
+function normalizeClaimerPubkey(pubkey: string): string {
+  return processPublicKeyToXOnly(pubkey).toLowerCase();
+}
+
+/**
  * Reject VP-supplied `response.txs` whose non-depositor claimer set does not
  * exactly equal `{vaultProviderBtcPubkey} ∪ vaultKeeperBtcPubkeys`.
  *
@@ -149,7 +160,9 @@ function prepareTransactionsForSigning(
  * The depositor's own claimer entry (if present in `response.txs`) is
  * filtered out before diffing — its Payout PSBT is built locally and signed
  * separately via signDepositorGraph, so its presence in `response.txs` is
- * permitted but not required.
+ * permitted but not required. Duplicate detection runs on the full supplied
+ * list *before* the depositor filter, so a response containing
+ * `[VP, VK, depositor, depositor]` is rejected as malformed.
  */
 function assertNonDepositorClaimerSetMatches(
   suppliedTxs: ClaimerTransactions[],
@@ -157,11 +170,11 @@ function assertNonDepositorClaimerSetMatches(
   expectedVkPubkeys: string[],
   depositorPubkeyXOnly: string,
 ): void {
-  const norm = (k: string) =>
-    stripHexPrefix(processPublicKeyToXOnly(k)).toLowerCase();
-
-  const depositor = norm(depositorPubkeyXOnly);
-  const expectedList = [norm(expectedVpPubkey), ...expectedVkPubkeys.map(norm)];
+  const depositor = normalizeClaimerPubkey(depositorPubkeyXOnly);
+  const expectedList = [
+    normalizeClaimerPubkey(expectedVpPubkey),
+    ...expectedVkPubkeys.map(normalizeClaimerPubkey),
+  ];
   const expected = new Set(expectedList);
   if (expected.size !== expectedList.length) {
     throw new Error(
@@ -174,18 +187,19 @@ function assertNonDepositorClaimerSetMatches(
     );
   }
 
-  const supplied = suppliedTxs
-    .map((tx) => norm(tx.claimer_pubkey))
-    .filter((k) => k !== depositor);
-  const suppliedSet = new Set(supplied);
-  if (suppliedSet.size !== supplied.length) {
+  const suppliedAll = suppliedTxs.map((tx) =>
+    normalizeClaimerPubkey(tx.claimer_pubkey),
+  );
+  if (new Set(suppliedAll).size !== suppliedAll.length) {
     throw new Error(
       "Presign response contains duplicate claimer entries",
     );
   }
 
+  const suppliedNonDepositor = suppliedAll.filter((k) => k !== depositor);
+  const suppliedSet = new Set(suppliedNonDepositor);
   const missing = expectedList.filter((c) => !suppliedSet.has(c));
-  const extra = supplied.filter((c) => !expected.has(c));
+  const extra = suppliedNonDepositor.filter((c) => !expected.has(c));
   if (missing.length > 0 || extra.length > 0) {
     throw new Error(
       `Presign response claimer set does not match expected (vault provider ∪ vault keepers)` +
@@ -359,7 +373,7 @@ export async function runDepositorPresignFlow(
   // the on-chain-derived {VP} ∪ {VKs} before any wallet prompts run. The
   // depositor's own entry is permitted but not required (its payout is
   // signed separately via signDepositorGraph in Phase 4).
-  const depositorPkNormalized = processPublicKeyToXOnly(depositorPk);
+  const depositorPkNormalized = normalizeClaimerPubkey(depositorPk);
   assertNonDepositorClaimerSetMatches(
     response.txs,
     signingContext.vaultProviderBtcPubkey,
@@ -370,8 +384,10 @@ export async function runDepositorPresignFlow(
   // separately via signDepositorGraph (Phase 4) using VP-provided PSBTs.
   // Including it here would cause a redundant wallet signing prompt whose
   // result is discarded when the depositor graph signature overwrites it.
+  // Compare on the normalized form so an uppercase-hex depositor entry in
+  // the VP response is still filtered out consistently with the assertion.
   const nonDepositorTxs = response.txs.filter(
-    (tx) => processPublicKeyToXOnly(tx.claimer_pubkey) !== depositorPkNormalized,
+    (tx) => normalizeClaimerPubkey(tx.claimer_pubkey) !== depositorPkNormalized,
   );
   const preparedTransactions = prepareTransactionsForSigning(nonDepositorTxs);
   const claimerSignatures = await signPayoutTransactions(


### PR DESCRIPTION
Closes https://github.com/babylonlabs-io/baby-auditor-findings/issues/302

## TL;DR

Before the depositor signs anything, the vault provider (VP) hands us a list of payout transactions — one per non-depositor claimer (the VP itself plus every registered vault keeper). Today, we sign whatever the VP gave us. This PR adds a strict check: the supplied claimer set must exactly equal what the on-chain registry says it should be. If anything is missing, duplicated, or unexpected, we throw **before** any wallet prompt.

## Why this matters

A malicious or buggy VP can return a partial list. Concretely: VP returns only its own claimer entry and omits a registered vault keeper. The depositor signs only what was supplied. Activation succeeds. Later, if the VP disappears, the omitted vault keeper has no presigned payout — that keeper's recovery branch is unenforceable, and the user's BTC can be locked.

This is exactly the failure mode CLAUDE.md §3 (Critical Path #3) warns about:

> Before the signature call, re-derive the expected ... assert equality. Never sign a value handed to us verbatim.

Here, the "value handed to us verbatim" is the claimer set itself.

## What changed

**`packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts`**

- New private helper `assertNonDepositorClaimerSetMatches(suppliedTxs, vpPubkey, vkPubkeys, depositorPk)`. It normalizes pubkeys to x-only lowercase, detects duplicates in the supplied list, and computes both `missing` and `unexpected` diffs against `{VP} ∪ {VKs}`. It also guards against a misconfigured signing context (duplicate VK key, depositor key overlapping with VP/VK).
- The helper is called inside `runDepositorPresignFlow` **before** the existing depositor-filter, so any mismatch throws before `prepareTransactionsForSigning` runs and before the wallet shows any prompt.
- The depositor's own claimer entry is permitted but not required in `response.txs` (the depositor's payout PSBT is built locally and signed separately in Phase 4 via `signDepositorGraph`).

**`packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/runDepositorPresignFlow.test.ts`**

- Updated the default mock response to return `[VP, VK]` (it previously returned only `[VP]`, which would now trip the new completeness check).
- Extended the `primitives/utils/bitcoin` mock with `deriveBip86ScriptPubKeyHex` — the VK entry now exercises the BIP-86 derivation path.
- Added a new `non-depositor claimer set completeness` describe block with five regression tests:
  - omits a registered vault keeper → throws `/missing/`
  - empty response → throws `/missing/`
  - duplicates a claimer entry → throws `/duplicate/`
  - includes an unknown extra claimer → throws `/unexpected/` (the old code also rejected this, but only deep inside the signing loop — now it fails fast)
  - happy path with `{VP, VK, depositor}` → passes
- Every rejection test also asserts that `submitDepositorPresignatures` was never called and `wallet.signPsbts` was never called.

## Approaches considered

**1. Strict client-side set-equality check (this PR).**
Compare the supplied non-depositor claimer set against `{VP} ∪ {VKs}` from `PayoutSigningContext` (which the caller already populates from on-chain ABI reads). Throw on any mismatch. Small, well-bounded, follows an existing in-repo precedent (see below).

**2. Push the check down into a primitive.**
Move the validation into the VP-response schema validator at `packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/validators.ts`. The validator runs earlier, so this would catch the problem one layer up. Rejected: the validator only has the response in hand, not the on-chain trusted set. Plumbing the trusted set down to a schema validator widens its interface for a single caller, and the validator's job today is shape-only — keeping responsibilities split is cleaner.

**3. Rely on the on-chain activation contract to catch it.**
The activation contract may already enforce signature completeness when the VP submits. Rejected: even if it does, the user has already paid for and produced wallet signatures by then, and any error surfaces as an opaque on-chain failure after many wallet popups. Catching it client-side gives an actionable error message before any wallet prompt and matches the defense-in-depth posture of CLAUDE.md §3 (don't trust the VP at all on the signing path).

**4. Tighten only the existing "unknown claimer" check in `resolvePayoutScriptPubKey`.**
That function already throws on *extras*. We could move its enforcement earlier or extend its scope. Rejected: it cannot, by construction, detect *missing* entries — it only fires once per supplied entry. Detecting "missing" requires comparing the full supplied set against the expected set, which is a separate concern.

## Why approach 1

- **There is a direct in-repo precedent.** PR https://github.com/babylonlabs-io/babylon-toolkit/pull/1652 (commit `d4ed7182`) added `assertChallengerSetMatchesExpected` inside `signDepositorGraph.ts`, which does exactly the same thing for the **challenger** set on the NoPayout side. This PR is the symmetric fix for the **Payout** side. Same error vocabulary (`missing`/`unexpected`), same duplicate-detection idiom, same fail-fast placement. Reviewers already familiar with `#1652` will recognize the shape immediately.
- **Smallest blast radius.** One new helper, one call site, no API changes, no plumbing.
- **Right layer.** The data we need to compare already lives on `PayoutSigningContext`. Nothing new to thread through.
- **Fail-fast.** Throws before any wallet popup, so the user never signs anything for a malformed response.

## What this PR is deliberately *not* doing

- Not validating `response.depositor_graph` separately — the challenger-set validation there is already in place from https://github.com/babylonlabs-io/babylon-toolkit/pull/1652.
- Not requiring the depositor's own entry to be *present* in `response.txs`. Functionally Phase 3 ignores it (Phase 4 uses `response.depositor_graph` instead). Adding a presence requirement would expand scope without closing a real exploit path; happy to add later if anyone wants tighter VP-response well-formedness.
- Not adding any on-chain cross-check that the *submitted* signature map is complete — the client-side derivation is the trust boundary; further verification would belong on the activation contract.

## Risk

Low. The change is additive: existing well-formed VP responses (which already include the full `{VP, VKs}` set) are unaffected. The only behavioral change for production traffic is that malformed responses now throw with a descriptive error instead of silently producing a partial signature map.
