### PR TITLE
fix(ts-sdk): refuse refund on ambiguous OP_RETURN funded tx

### DIFF
--- a/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/__tests__/assertAuthAnchorOpReturn.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/__tests__/assertAuthAnchorOpReturn.test.ts
@@ -3,7 +3,8 @@ import { describe, expect, it } from "vitest";
 
 import {
   assertAuthAnchorOpReturn,
-  findAuthAnchorOpReturn,
+  countHtlcOutputs,
+  readAuthAnchorOpReturn,
 } from "../assertAuthAnchorOpReturn";
 
 const ANCHOR_HASH = "ab".repeat(32);
@@ -133,100 +134,104 @@ describe("assertAuthAnchorOpReturn", () => {
   });
 });
 
-describe("findAuthAnchorOpReturn", () => {
-  it("returns {vout, hash} for a single-vault tx (HTLC@0, OP_RETURN@1)", () => {
-    const txHex = buildTxHex([htlcOutput(), opReturnOutput(ANCHOR_HASH)]);
-    expect(findAuthAnchorOpReturn(txHex)).toEqual({
-      vout: 1,
-      hash: ANCHOR_HASH,
-    });
-  });
-
-  it("returns {vout, hash} for a two-vault tx (HTLCs@0,1, OP_RETURN@2)", () => {
-    const txHex = buildTxHex([
-      htlcOutput(),
-      htlcOutput(),
-      opReturnOutput(ANCHOR_HASH),
-    ]);
-    expect(findAuthAnchorOpReturn(txHex)).toEqual({
-      vout: 2,
-      hash: ANCHOR_HASH,
-    });
-  });
-
-  it("returns {vout, hash} even when followed by a CPFP-anchor-like output", () => {
-    // Real funded Pre-PegIns also carry a CPFP anchor / change output
-    // after the OP_RETURN. The finder must locate the anchor regardless
-    // of what comes after.
+describe("countHtlcOutputs", () => {
+  it("counts 1 for a single-vault auth-anchored tx [HTLC, OP_RETURN, anchor]", () => {
     const txHex = buildTxHex([
       htlcOutput(),
       opReturnOutput(ANCHOR_HASH),
       htlcOutput(),
     ]);
-    expect(findAuthAnchorOpReturn(txHex)).toEqual({
-      vout: 1,
-      hash: ANCHOR_HASH,
-    });
+    expect(countHtlcOutputs(txHex)).toBe(1);
   });
 
-  it("strips a leading 0x prefix from the funded tx hex", () => {
-    const txHex = buildTxHex([htlcOutput(), opReturnOutput(ANCHOR_HASH)]);
-    expect(findAuthAnchorOpReturn(`0x${txHex}`)).toEqual({
-      vout: 1,
-      hash: ANCHOR_HASH,
-    });
-  });
-
-  it("returns undefined for a legacy (non-auth-anchored) tx with no OP_RETURN", () => {
+  it("counts 1 for a single-vault tx with no auth anchor [HTLC, anchor]", () => {
     const txHex = buildTxHex([htlcOutput(), htlcOutput()]);
-    expect(findAuthAnchorOpReturn(txHex)).toBeUndefined();
+    expect(countHtlcOutputs(txHex)).toBe(1);
   });
 
-  it("throws when more than one OP_RETURN+PUSH32 output is present (ambiguous)", () => {
-    // A well-formed Pre-PegIn carries exactly one auth-anchor commitment.
-    // Multiple matches are malformed input — refuse rather than guess.
+  it("counts 2 for a two-vault auth-anchored tx [HTLC, HTLC, OP_RETURN, anchor]", () => {
+    const txHex = buildTxHex([
+      htlcOutput(),
+      htlcOutput(),
+      opReturnOutput(ANCHOR_HASH),
+      htlcOutput(),
+    ]);
+    expect(countHtlcOutputs(txHex)).toBe(2);
+  });
+
+  it("counts 2 for a two-vault tx with no auth anchor [HTLC, HTLC, anchor]", () => {
+    const txHex = buildTxHex([htlcOutput(), htlcOutput(), htlcOutput()]);
+    expect(countHtlcOutputs(txHex)).toBe(2);
+  });
+
+  it("stops at the first OP_RETURN — a trailing extra OP_RETURN does not change the count", () => {
+    // [HTLC, OP_RETURN, OP_RETURN]: the second OP_RETURN sits in the
+    // last (CPFP-anchor) slot and is irrelevant; the HTLC count is 1.
     const txHex = buildTxHex([
       htlcOutput(),
       opReturnOutput(ANCHOR_HASH),
       opReturnOutput(OTHER_HASH),
     ]);
-    expect(() => findAuthAnchorOpReturn(txHex)).toThrow(
-      /OP_RETURN PUSH32 outputs/,
-    );
+    expect(countHtlcOutputs(txHex)).toBe(1);
   });
 
-  it("ignores OP_RETURN outputs with non-zero value", () => {
-    // Non-standard OP_RETURNs (non-zero value) cannot have been emitted
-    // by the WASM builder — skip them rather than treat them as a hit.
+  it("throws when the tx has fewer than 2 outputs", () => {
+    const txHex = buildTxHex([htlcOutput()]);
+    expect(() => countHtlcOutputs(txHex)).toThrow(/at least 2 outputs/);
+  });
+
+  it("strips a leading 0x prefix from the funded tx hex", () => {
+    const txHex = buildTxHex([htlcOutput(), opReturnOutput(ANCHOR_HASH)]);
+    expect(countHtlcOutputs(`0x${txHex}`)).toBe(1);
+  });
+});
+
+describe("readAuthAnchorOpReturn", () => {
+  it("returns the hash when vout points at an OP_RETURN PUSH32 output", () => {
     const txHex = buildTxHex([
       htlcOutput(),
-      opReturnOutput(ANCHOR_HASH, /* value */ 546),
+      opReturnOutput(ANCHOR_HASH),
+      htlcOutput(),
     ]);
-    expect(findAuthAnchorOpReturn(txHex)).toBeUndefined();
+    expect(readAuthAnchorOpReturn(txHex, 1)).toBe(ANCHOR_HASH);
   });
 
-  it("ignores OP_RETURN outputs with non-32-byte payloads", () => {
-    // OP_RETURN PUSH16 <16 bytes> — wrong push opcode, shorter payload.
-    const tooShort = {
-      scriptHex: `6a10${"ab".repeat(16)}`,
-      value: 0,
-    };
-    const txHex = buildTxHex([htlcOutput(), tooShort]);
-    expect(findAuthAnchorOpReturn(txHex)).toBeUndefined();
+  it("returns undefined when the output at vout is not an OP_RETURN (no auth anchor)", () => {
+    // [HTLC, anchor] — vout 1 is the CPFP anchor, not an OP_RETURN.
+    const txHex = buildTxHex([htlcOutput(), htlcOutput()]);
+    expect(readAuthAnchorOpReturn(txHex, 1)).toBeUndefined();
   });
 
-  it("returns undefined for unparseable hex", () => {
-    expect(findAuthAnchorOpReturn("not a real tx hex")).toBeUndefined();
+  it("returns undefined when vout is out of bounds", () => {
+    const txHex = buildTxHex([htlcOutput(), htlcOutput()]);
+    expect(readAuthAnchorOpReturn(txHex, 5)).toBeUndefined();
+  });
+
+  it("reads only the output at vout — an OP_RETURN elsewhere is ignored", () => {
+    // OP_RETURN at vout 2, but vout 1 is a plain output → no auth anchor.
+    const txHex = buildTxHex([
+      htlcOutput(),
+      htlcOutput(),
+      opReturnOutput(ANCHOR_HASH),
+    ]);
+    expect(readAuthAnchorOpReturn(txHex, 1)).toBeUndefined();
+  });
+
+  it("throws when the output at vout is an OP_RETURN but not a clean 32-byte push", () => {
+    // OP_RETURN PUSH16 <16 bytes> — an OP_RETURN, but malformed as an
+    // auth anchor. Must throw, not silently degrade to "no anchor".
+    const malformed = { scriptHex: `6a10${"ab".repeat(16)}`, value: 0 };
+    const txHex = buildTxHex([htlcOutput(), malformed]);
+    expect(() => readAuthAnchorOpReturn(txHex, 1)).toThrow(/malformed/);
+  });
+
+  it("strips a leading 0x prefix from the funded tx hex", () => {
+    const txHex = buildTxHex([htlcOutput(), opReturnOutput(ANCHOR_HASH)]);
+    expect(readAuthAnchorOpReturn(`0x${txHex}`, 1)).toBe(ANCHOR_HASH);
   });
 
   it("normalizes the hash to lowercase regardless of input case", () => {
-    // OP_RETURN payloads are raw bytes; the hex serialization picks a
-    // case. Normalize at the boundary so downstream byte-equality holds.
-    const upperHash = "CD".repeat(32);
-    const txHex = buildTxHex([htlcOutput(), opReturnOutput(upperHash)]);
-    expect(findAuthAnchorOpReturn(txHex)).toEqual({
-      vout: 1,
-      hash: "cd".repeat(32),
-    });
+    const txHex = buildTxHex([htlcOutput(), opReturnOutput("CD".repeat(32))]);
+    expect(readAuthAnchorOpReturn(txHex, 1)).toBe("cd".repeat(32));
   });
 });

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/__tests__/assertAuthAnchorOpReturn.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/__tests__/assertAuthAnchorOpReturn.test.ts
@@ -182,16 +182,17 @@ describe("findAuthAnchorOpReturn", () => {
     expect(findAuthAnchorOpReturn(txHex)).toBeUndefined();
   });
 
-  it("returns undefined when more than one OP_RETURN+PUSH32 output is present (ambiguous)", () => {
+  it("throws when more than one OP_RETURN+PUSH32 output is present (ambiguous)", () => {
     // A well-formed Pre-PegIn carries exactly one auth-anchor commitment.
-    // Two would either be a malformed tx or someone trying to confuse the
-    // reader; refuse to guess.
+    // Multiple matches are malformed input — refuse rather than guess.
     const txHex = buildTxHex([
       htlcOutput(),
       opReturnOutput(ANCHOR_HASH),
       opReturnOutput(OTHER_HASH),
     ]);
-    expect(findAuthAnchorOpReturn(txHex)).toBeUndefined();
+    expect(() => findAuthAnchorOpReturn(txHex)).toThrow(
+      /OP_RETURN PUSH32 outputs/,
+    );
   });
 
   it("ignores OP_RETURN outputs with non-zero value", () => {

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/assertAuthAnchorOpReturn.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/assertAuthAnchorOpReturn.ts
@@ -80,90 +80,79 @@ export function assertAuthAnchorOpReturn(
 }
 
 /**
- * Best-effort reader for the auth-anchor OP_RETURN payload at `vout` of
- * a funded Pre-PegIn transaction.
+ * Read the auth-anchor OP_RETURN payload at the fixed index `vout` of a
+ * funded Pre-PegIn transaction.
  *
- * Returns the 32-byte payload as lowercase hex (no `0x` prefix) if the
- * output at `vout` is exactly `OP_RETURN || PUSH32 || <32 bytes>` with
- * a zero value. Returns `undefined` for any structural mismatch —
- * missing output, wrong script shape, non-zero value — so legacy
- * non-auth-anchored Pre-PegIns parse as "no anchor" rather than
- * raising.
+ * Positional, matching the protocol: the auth anchor — when present — sits
+ * at `vout = htlcCount` (see {@link countHtlcOutputs}). Mirrors btc-vault
+ * `PrePegInTx::extract_auth_anchor_hash`:
+ *  - returns `undefined` when the output at `vout` is absent or is not an
+ *    OP_RETURN (no auth anchor — a legitimate shape);
+ *  - returns the 32-byte payload as lowercase hex when the output is a
+ *    well-formed `OP_RETURN || PUSH32 || <32 bytes>`;
+ *  - throws when the output IS an OP_RETURN but malformed — that must not
+ *    silently collapse to "no anchor".
  *
- * Used by the refund flow to reconstruct the unfunded WASM template
- * with the same output shape as the on-chain funded transaction.
- * Assertion semantics (compare against an expected value, throw on
- * mismatch) live in {@link assertAuthAnchorOpReturn}.
+ * @throws If `vout`'s output is an OP_RETURN that is not a clean 32-byte push.
  */
 export function readAuthAnchorOpReturn(
   fundedPrePeginTxHex: string,
   vout: number,
 ): string | undefined {
-  let tx: bitcoin.Transaction;
-  try {
-    tx = bitcoin.Transaction.fromHex(stripHexPrefix(fundedPrePeginTxHex));
-  } catch {
-    // Best-effort: unparseable hex is also "no extractable anchor".
-    // The same hex flows into the refund PSBT primitive immediately
-    // after, where Transaction.fromHex will surface a real parse error.
-    return undefined;
-  }
-
-  if (tx.outs.length <= vout) return undefined;
+  const tx = bitcoin.Transaction.fromHex(stripHexPrefix(fundedPrePeginTxHex));
 
   const output = tx.outs[vout];
-  const script = output.script;
-  if (
-    script.length !== OP_RETURN_PUSH32_SCRIPT_LEN ||
-    script[0] !== OP_RETURN ||
-    script[1] !== OP_PUSH32
-  ) {
-    return undefined;
-  }
-  if (output.value !== 0) return undefined;
+  if (output === undefined) return undefined;
 
+  const script = output.script;
+  // Not an OP_RETURN → no auth anchor at this position (legitimate).
+  if (script.length === 0 || script[0] !== OP_RETURN) return undefined;
+
+  // It IS an OP_RETURN — it must be the canonical 32-byte push, or throw.
+  if (script.length !== OP_RETURN_PUSH32_SCRIPT_LEN || script[1] !== OP_PUSH32) {
+    throw new Error(
+      `Auth-anchor OP_RETURN at vout ${vout} is malformed: expected ` +
+        `${OP_RETURN_PUSH32_SCRIPT_LEN}-byte OP_RETURN + PUSH32 layout, got a ` +
+        `${script.length}-byte script`,
+    );
+  }
   return script.slice(2).toString("hex").toLowerCase();
 }
 
 /**
- * Scan a funded Pre-PegIn transaction for its auth-anchor commitment
- * (an `OP_RETURN || PUSH32 || <32 bytes>` output with value 0).
+ * Count the HTLC outputs at the head of a funded Pre-PegIn transaction.
  *
- * Returns `{ vout, hash }` for exactly one match, `undefined` for zero
- * matches (legacy / unparseable). Throws on multiple matches — that
- * shape is malformed and must not silently collapse to "no anchor".
+ * Mirrors btc-vault `PrePegInTx::count_htlc_outputs` and the contract's
+ * `PeginLogic._countHtlcOutputs`: the HTLC outputs are the contiguous
+ * leading outputs before the first OP_RETURN; the optional auth-anchor
+ * OP_RETURN sits right after them, and the CPFP anchor is always the last
+ * output. Walks outputs `[0, len - 1)` (the last is the CPFP anchor) and
+ * stops at the first OP_RETURN.
+ *
+ * The returned count doubles as the auth-anchor index for
+ * {@link readAuthAnchorOpReturn}.
+ *
+ * Caveat (same as btc-vault's): for a Pre-PegIn with no auth-anchor
+ * OP_RETURN, a wallet-appended output after the CPFP anchor inflates the
+ * count — it is an upper bound. The refund's `count !== 1` check then fails
+ * closed (refuses), which is safe.
+ *
+ * @throws If the transaction has fewer than 2 outputs.
  */
-export function findAuthAnchorOpReturn(
-  fundedPrePeginTxHex: string,
-): { vout: number; hash: string } | undefined {
-  let tx: bitcoin.Transaction;
-  try {
-    tx = bitcoin.Transaction.fromHex(stripHexPrefix(fundedPrePeginTxHex));
-  } catch {
-    return undefined;
-  }
+export function countHtlcOutputs(fundedPrePeginTxHex: string): number {
+  const tx = bitcoin.Transaction.fromHex(stripHexPrefix(fundedPrePeginTxHex));
 
-  const hits: { vout: number; hash: string }[] = [];
-  for (let i = 0; i < tx.outs.length; i++) {
-    const output = tx.outs[i];
-    const script = output.script;
-    if (
-      script.length === OP_RETURN_PUSH32_SCRIPT_LEN &&
-      script[0] === OP_RETURN &&
-      script[1] === OP_PUSH32 &&
-      output.value === 0
-    ) {
-      hits.push({
-        vout: i,
-        hash: script.slice(2).toString("hex").toLowerCase(),
-      });
-    }
-  }
-
-  if (hits.length > 1) {
+  if (tx.outs.length < 2) {
     throw new Error(
-      `Funded Pre-PegIn has ${hits.length} OP_RETURN PUSH32 outputs (vouts ${hits.map((h) => h.vout).join(", ")}); expected at most 1.`,
+      `Funded Pre-PegIn must have at least 2 outputs (HTLC + CPFP anchor), ` +
+        `got ${tx.outs.length}`,
     );
   }
-  return hits[0];
+
+  let count = 0;
+  for (let i = 0; i < tx.outs.length - 1; i++) {
+    if (tx.outs[i].script[0] === OP_RETURN) break;
+    count++;
+  }
+  return count;
 }

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/assertAuthAnchorOpReturn.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/assertAuthAnchorOpReturn.ts
@@ -129,17 +129,9 @@ export function readAuthAnchorOpReturn(
  * Scan a funded Pre-PegIn transaction for its auth-anchor commitment
  * (an `OP_RETURN || PUSH32 || <32 bytes>` output with value 0).
  *
- * Returns `{ vout, hash }` when exactly one such output is found.
- * Returns `undefined` when:
- *   - the hex is unparseable,
- *   - no matching output exists (legacy non-auth-anchored Pre-PegIn),
- *   - more than one matching output exists (ambiguous / malformed).
- *
- * Used by the refund orchestrator to (a) locate the on-chain anchor
- * regardless of how many HTLCs preceded it and (b) detect multi-vault
- * funded transactions structurally: the single-vault refund path
- * reconstructs only one hashlock and expects the anchor at vout 1, so
- * any other vout signals a layout this call cannot safely refund.
+ * Returns `{ vout, hash }` for exactly one match, `undefined` for zero
+ * matches (legacy / unparseable). Throws on multiple matches — that
+ * shape is malformed and must not silently collapse to "no anchor".
  */
 export function findAuthAnchorOpReturn(
   fundedPrePeginTxHex: string,
@@ -168,5 +160,10 @@ export function findAuthAnchorOpReturn(
     }
   }
 
-  return hits.length === 1 ? hits[0] : undefined;
+  if (hits.length > 1) {
+    throw new Error(
+      `Funded Pre-PegIn has ${hits.length} OP_RETURN PUSH32 outputs (vouts ${hits.map((h) => h.vout).join(", ")}); expected at most 1.`,
+    );
+  }
+  return hits[0];
 }

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/index.ts
@@ -8,7 +8,7 @@
 
 export {
   assertAuthAnchorOpReturn,
-  findAuthAnchorOpReturn,
+  countHtlcOutputs,
   readAuthAnchorOpReturn,
 } from "./assertAuthAnchorOpReturn";
 export {

--- a/packages/babylon-ts-sdk/src/tbv/core/services/refund/__tests__/buildAndBroadcastRefund.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/refund/__tests__/buildAndBroadcastRefund.test.ts
@@ -525,6 +525,30 @@ describe("buildAndBroadcastRefund", () => {
       ).rejects.toThrow(/Funded Pre-PegIn tx has 1 outputs but batch requires at least 3/);
       expect(mockedBuildRefundPsbt).not.toHaveBeenCalled();
     });
+
+    it("refuses a funded tx with two OP_RETURN PUSH32 outputs (ambiguous)", async () => {
+      const tx = new bitcoin.Transaction();
+      tx.addInput(Buffer.alloc(32, 0xaa), 0);
+      tx.addOutput(Buffer.from("0014" + "11".repeat(20), "hex"), 100_000);
+      tx.addOutput(Buffer.from("6a20" + "cd".repeat(32), "hex"), 0);
+      tx.addOutput(Buffer.from("6a20" + "ef".repeat(32), "hex"), 0);
+      readVault.mockResolvedValue(
+        buildVault({ unsignedPrePeginTxHex: "0x" + tx.toHex() }),
+      );
+
+      await expect(
+        buildAndBroadcastRefund({
+          vaultId: VAULT_ID,
+          readVault,
+          readPrePeginContext,
+          feeRate: FEE_RATE,
+          signPsbt,
+          broadcastTx,
+        }),
+      ).rejects.toThrow(/OP_RETURN PUSH32 outputs/);
+
+      expect(mockedBuildRefundPsbt).not.toHaveBeenCalled();
+    });
   });
 
   describe("validation", () => {

--- a/packages/babylon-ts-sdk/src/tbv/core/services/refund/__tests__/buildAndBroadcastRefund.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/refund/__tests__/buildAndBroadcastRefund.test.ts
@@ -75,31 +75,35 @@ const VP_PUBKEY = "b".repeat(64);
 const VK_PUBKEY = "c".repeat(64);
 const UC_PUBKEY = "d".repeat(64);
 
-// Build a minimal funded Pre-PegIn tx hex with `numHtlcs` HTLC
-// placeholder outputs followed by an optional OP_RETURN. The orchestrator
-// parses this with bitcoinjs to check shape; we only need realistic enough
-// bytes for parsing + output-count checks (the WASM primitive is mocked,
-// so the HTLC scripts don't need to be real taproot keys).
+// Build a funded Pre-PegIn tx hex in the protocol layout:
+// `[HTLC..., (optional) auth-anchor OP_RETURN, CPFP anchor]`. The HTLC and
+// CPFP-anchor outputs are placeholders — the orchestrator does not re-derive
+// their content (the WASM primitive is mocked); only the OP_RETURN position
+// matters for the auth-anchor read.
 function buildMinimalFundedPrePeginHex(opts?: {
   authAnchorHashHex?: string;
   numHtlcs?: number;
 }): string {
   const numHtlcs = opts?.numHtlcs ?? 1;
+  const placeholder = Buffer.from("0014" + "11".repeat(20), "hex");
   const tx = new bitcoin.Transaction();
   tx.addInput(Buffer.alloc(32, 0xaa), 0);
+  // HTLC placeholders (P2WPKH script — any non-OP_RETURN script works).
   for (let i = 0; i < numHtlcs; i++) {
-    tx.addOutput(Buffer.from("0014" + "11".repeat(20), "hex"), 100_000);
+    tx.addOutput(placeholder, 100_000);
   }
   if (opts?.authAnchorHashHex !== undefined) {
+    // OP_RETURN (0x6a) || PUSH32 (0x20) || <32-byte hash>
     tx.addOutput(Buffer.from(`6a20${opts.authAnchorHashHex}`, "hex"), 0);
   }
+  // CPFP anchor — always the last output of a Pre-PegIn.
+  tx.addOutput(placeholder, 0);
   return tx.toHex();
 }
 
-// Realistic single-HTLC Pre-PegIn hex with no OP_RETURN. Used as the
-// default `unsignedPrePeginTxHex` so the orchestrator's structural
-// checks (parseable hex, ≥ batch.length outputs) pass without
-// per-test setup.
+// Realistic single-HTLC Pre-PegIn hex (no auth-anchor OP_RETURN). Used as the
+// default `unsignedPrePeginTxHex` so the orchestrator's structural checks
+// pass without per-test setup.
 const DEFAULT_FUNDED_PRE_PEGIN_HEX = `0x${buildMinimalFundedPrePeginHex()}`;
 
 function buildVault(overrides?: Partial<VaultRefundData>): VaultRefundData {
@@ -375,7 +379,7 @@ describe("buildAndBroadcastRefund", () => {
       expect(call[0].prePeginParams.authAnchorHash).toBe(ANCHOR_HASH);
     });
 
-    it("passes authAnchorHash = undefined when the funded tx has no OP_RETURN at vout 1 (legacy shape)", async () => {
+    it("passes authAnchorHash = undefined when the funded tx has no auth-anchor OP_RETURN", async () => {
       const fundedHex = buildMinimalFundedPrePeginHex();
       readVault.mockResolvedValue(
         buildVault({ unsignedPrePeginTxHex: "0x" + fundedHex }),
@@ -465,7 +469,7 @@ describe("buildAndBroadcastRefund", () => {
       expect(call[0].prePeginParams.authAnchorHash).toBe("cd".repeat(32));
     });
 
-    it("refuses a 2-vault funded tx when batch claims length 1 (anchor vout mismatch)", async () => {
+    it("refuses a 2-HTLC funded tx when batch claims length 1 (HTLC-count mismatch)", async () => {
       // Funded tx has 2 HTLCs + OP_RETURN at vout 2, but the caller passes
       // a single-element batch. The orchestrator must catch the
       // structural mismatch before signing.
@@ -486,7 +490,9 @@ describe("buildAndBroadcastRefund", () => {
           signPsbt,
           broadcastTx,
         }),
-      ).rejects.toThrow(/Auth-anchor OP_RETURN at vout 2 does not match batch size/);
+      ).rejects.toThrow(
+        /Funded Pre-PegIn has 2 HTLC outputs but the batch vector has 1/,
+      );
 
       expect(mockedBuildRefundPsbt).not.toHaveBeenCalled();
       expect(broadcastTx).not.toHaveBeenCalled();
@@ -494,7 +500,7 @@ describe("buildAndBroadcastRefund", () => {
 
     it("refuses a funded tx with fewer outputs than the batch claims", async () => {
       // Batch claims 3 siblings but funded tx only carries 1 HTLC output.
-      // Structural check catches this before the PSBT primitive runs.
+      // The structural HTLC-count check catches this before the PSBT primitive runs.
       const fundedHex = buildMinimalFundedPrePeginHex({ numHtlcs: 1 });
       const H0 = ("0x" + "11".repeat(32)) as Hex;
       const H1 = ("0x" + "22".repeat(32)) as Hex;
@@ -522,16 +528,50 @@ describe("buildAndBroadcastRefund", () => {
           signPsbt,
           broadcastTx,
         }),
-      ).rejects.toThrow(/Funded Pre-PegIn tx has 1 outputs but batch requires at least 3/);
+      ).rejects.toThrow(
+        /Funded Pre-PegIn has 1 HTLC outputs but the batch vector has 3/,
+      );
       expect(mockedBuildRefundPsbt).not.toHaveBeenCalled();
     });
 
-    it("refuses a funded tx with two OP_RETURN PUSH32 outputs (ambiguous)", async () => {
+    it("accepts a single-vault tx with a wallet-appended trailing OP_RETURN", async () => {
+      // Protocol layout: [HTLC, auth-anchor OP_RETURN, CPFP anchor]. A
+      // wallet may append its own OP_RETURN (e.g. a label) after that.
+      // The auth-anchor is read positionally at vout 1 (= htlcCount); the
+      // trailing OP_RETURN is irrelevant and must not block the refund —
+      // matching btc-vault, which reads the auth anchor at a fixed index.
+      const ANCHOR_HASH = "cd".repeat(32);
       const tx = new bitcoin.Transaction();
       tx.addInput(Buffer.alloc(32, 0xaa), 0);
       tx.addOutput(Buffer.from("0014" + "11".repeat(20), "hex"), 100_000);
-      tx.addOutput(Buffer.from("6a20" + "cd".repeat(32), "hex"), 0);
+      tx.addOutput(Buffer.from(`6a20${ANCHOR_HASH}`, "hex"), 0);
+      tx.addOutput(Buffer.from("0014" + "11".repeat(20), "hex"), 0);
       tx.addOutput(Buffer.from("6a20" + "ef".repeat(32), "hex"), 0);
+      readVault.mockResolvedValue(
+        buildVault({ unsignedPrePeginTxHex: "0x" + tx.toHex() }),
+      );
+
+      await buildAndBroadcastRefund({
+        vaultId: VAULT_ID,
+        readVault,
+        readPrePeginContext,
+        feeRate: FEE_RATE,
+        signPsbt,
+        broadcastTx,
+      });
+
+      const [call] = mockedBuildRefundPsbt.mock.calls;
+      expect(call[0].prePeginParams.authAnchorHash).toBe(ANCHOR_HASH);
+    });
+
+    it("refuses a funded tx whose vout-1 output is a malformed OP_RETURN", async () => {
+      // vout 1 IS an OP_RETURN but not a clean 32-byte push — must throw
+      // rather than silently degrade to "no auth anchor".
+      const tx = new bitcoin.Transaction();
+      tx.addInput(Buffer.alloc(32, 0xaa), 0);
+      tx.addOutput(Buffer.from("0014" + "11".repeat(20), "hex"), 100_000);
+      tx.addOutput(Buffer.from("6a10" + "ab".repeat(16), "hex"), 0);
+      tx.addOutput(Buffer.from("0014" + "11".repeat(20), "hex"), 0);
       readVault.mockResolvedValue(
         buildVault({ unsignedPrePeginTxHex: "0x" + tx.toHex() }),
       );
@@ -545,7 +585,7 @@ describe("buildAndBroadcastRefund", () => {
           signPsbt,
           broadcastTx,
         }),
-      ).rejects.toThrow(/OP_RETURN PUSH32 outputs/);
+      ).rejects.toThrow(/malformed/);
 
       expect(mockedBuildRefundPsbt).not.toHaveBeenCalled();
     });

--- a/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts
@@ -11,11 +11,11 @@
  */
 
 import type { Network } from "@babylonlabs-io/babylon-tbv-rust-wasm";
-import { Psbt, Transaction } from "bitcoinjs-lib";
+import { Psbt } from "bitcoinjs-lib";
 import type { Address, Hex } from "viem";
 
 import type { SignPsbtOptions } from "../../../../shared/wallets/interfaces/BitcoinWallet";
-import { findAuthAnchorOpReturn } from "../../managers/pegin";
+import { countHtlcOutputs, readAuthAnchorOpReturn } from "../../managers/pegin";
 import { assertPsbtUnsignedTxMatches } from "../../primitives/psbt/assertPsbtUnsignedTxMatches";
 import { buildRefundPsbt } from "../../primitives/psbt/refund";
 import {
@@ -445,43 +445,29 @@ export async function buildAndBroadcastRefund<
 
   const cleanFundedPrePeginTxHex = stripHexPrefix(vault.unsignedPrePeginTxHex);
 
-  // Production peg-ins (PeginManager) commit an OP_RETURN <PUSH32
-  // SHA256(authAnchor)> output at `vout = hashlocks.length`. The
-  // reconstructed unfunded template carries `batch.length` HTLC outputs,
-  // so the OP_RETURN — when present — must sit at exactly that vout.
-  // Legacy non-auth-anchored Pre-PegIns return `undefined` from the
-  // finder; the template then has no OP_RETURN either, which is a
-  // matching configuration.
-  const found = findAuthAnchorOpReturn(cleanFundedPrePeginTxHex);
-  if (found !== undefined && found.vout !== vault.batch.length) {
+  // Per the protocol a Pre-PegIn is laid out
+  // `[HTLC..., (optional) auth-anchor OP_RETURN, CPFP anchor]`. countHtlcOutputs
+  // (mirroring btc-vault `count_htlc_outputs` and the contract
+  // `_countHtlcOutputs`) returns the leading HTLC count. The reconstructed
+  // template carries one HTLC per batch entry, so the funded tx's HTLC count
+  // must equal the batch size — a mismatch means the sibling HTLC vector
+  // disagrees with the funded tx.
+  const htlcCount = countHtlcOutputs(cleanFundedPrePeginTxHex);
+  if (htlcCount !== vault.batch.length) {
     throw new Error(
-      `Auth-anchor OP_RETURN at vout ${found.vout} does not match batch size ` +
-        `(${vault.batch.length} HTLC outputs expect the anchor at vout ${vault.batch.length}). ` +
-        `Refund refused — sibling HTLC vector is incomplete.`,
+      `Funded Pre-PegIn has ${htlcCount} HTLC outputs but the batch vector ` +
+        `has ${vault.batch.length} entries; refund refused — funded tx shape ` +
+        `disagrees with the sibling HTLC vector.`,
     );
   }
-  const authAnchorHash = found?.hash;
-
-  // Independent structural check on the funded tx: it must carry at
-  // least N HTLC outputs (one per batch entry). If the anchor is
-  // present we've already pinned its position above, which transitively
-  // proves the tx has ≥ N+1 outputs; if the anchor is absent (legacy)
-  // we still need ≥ N to spend `htlcVout = N-1`.
-  let parsedFundedTx: Transaction;
-  try {
-    parsedFundedTx = Transaction.fromHex(cleanFundedPrePeginTxHex);
-  } catch (e) {
-    throw new Error(
-      `Failed to parse funded Pre-PegIn transaction hex: ${e instanceof Error ? e.message : String(e)}`,
-    );
-  }
-  if (parsedFundedTx.outs.length < vault.batch.length) {
-    throw new Error(
-      `Funded Pre-PegIn tx has ${parsedFundedTx.outs.length} outputs but batch ` +
-        `requires at least ${vault.batch.length} HTLC outputs. ` +
-        `Refund refused — funded tx shape disagrees with sibling vector.`,
-    );
-  }
+  // The auth-anchor OP_RETURN — if present — sits at `vout = htlcCount`. Read
+  // it positionally: a non-OP_RETURN output there means a deposit with no
+  // auth anchor (`undefined`); an OP_RETURN is parsed, and a malformed one
+  // throws rather than silently degrading to "no anchor".
+  const authAnchorHash = readAuthAnchorOpReturn(
+    cleanFundedPrePeginTxHex,
+    htlcCount,
+  );
 
   const { psbtHex } = await buildRefundPsbt({
     prePeginParams: {


### PR DESCRIPTION
Follow-up to #1688 (already merged). Closes a fail-open gap codex flagged on that PR: `findAuthAnchorOpReturn` returned `undefined` for both "no anchor"
(legacy, expected) and "multiple OP_RETURN PUSH32 hits" (malformed/ambiguous), so the refund orchestrator silently fell through as legacy single-vault and
reconstructed against `authAnchorHash = undefined`.

## Changes

- `findAuthAnchorOpReturn` now throws on multiple-hit. `undefined` is reserved for zero matches / unparseable hex.
- Existing assertion test flipped from `toBeUndefined()` → `toThrow(/OP_RETURN PUSH32 outputs/)`.
- New orchestrator test: funded tx with two OP_RETURN PUSH32 outputs rejects, `buildRefundPsbt` is not called.