### PR TITLE
fix(ts-sdk): enforce payout output structure + bounded implicit fee

### DIFF
--- a/packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts
@@ -29,6 +29,13 @@ import {
 } from "../primitives";
 
 /**
+ * Protocol-canonical output count for a VP-claimer payout transaction:
+ * `[depositor payout, VP commission, CPFP anchor]` — see
+ * `btc-vault crates/vault/src/transactions/payout.rs` and `mod.rs::build_payout_outputs`.
+ */
+const VP_CLAIMER_PAYOUT_OUTPUT_COUNT = 3;
+
+/**
  * Configuration for the PayoutManager.
  */
 export interface PayoutManagerConfig {
@@ -353,15 +360,23 @@ export class PayoutManager {
    * Validates that the payout transaction's largest output pays to the
    * registered depositor payout address (scriptPubKey).
    *
-   * This prevents two attack vectors from a malicious vault provider:
+   * This prevents three attack vectors from a malicious vault provider:
    * 1. Substituting a completely different payout address
    * 2. Including a dust output to the correct address while routing
    *    the actual funds to an attacker-controlled address
+   * 3. Adding extra attacker outputs alongside the registered output
+   *    (closes [baby-auditor-findings#147])
+   *
+   * VP-claimer payout is fixed at 3 outputs by the protocol:
+   * `[depositor payout, VP commission, CPFP anchor]`. Anything else is
+   * rejected. The implicit-fee bound (value-burn variant of the same
+   * finding) is enforced inside `buildPayoutPsbt`.
    *
    * @param payoutTxHex - Raw payout transaction hex
    * @param registeredPayoutScriptPubKey - On-chain registered scriptPubKey (hex, with or without 0x prefix)
    * @throws Error if scriptPubKey is invalid hex
-   * @throws Error if the largest output does not pay to the registered address
+   * @throws Error if the transaction does not have exactly 3 outputs
+   * @throws Error if output 0 does not pay to the registered scriptPubKey
    */
   private validatePayoutOutputs(
     payoutTxHex: string,
@@ -370,6 +385,7 @@ export class PayoutManager {
     assertPayoutOutputMatchesRegistered(
       payoutTxHex,
       registeredPayoutScriptPubKey,
+      VP_CLAIMER_PAYOUT_OUTPUT_COUNT,
     );
   }
 }

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts
@@ -20,20 +20,12 @@ import type {
 } from "../../../shared/wallets";
 import { createTaprootScriptPathSignOptions } from "../utils/signing";
 import {
-  assertPayoutOutputMatchesRegistered,
   assertPsbtUnsignedTxMatches,
   buildPayoutPsbt,
   extractPayoutSignature,
   validateWalletPubkey,
   type Network,
 } from "../primitives";
-
-/**
- * Protocol-canonical output count for a VP-claimer payout transaction:
- * `[depositor payout, VP commission, CPFP anchor]` — see
- * `btc-vault crates/vault/src/transactions/payout.rs` and `mod.rs::build_payout_outputs`.
- */
-const VP_CLAIMER_PAYOUT_OUTPUT_COUNT = 3;
 
 /**
  * Configuration for the PayoutManager.
@@ -97,6 +89,17 @@ interface SignPayoutBaseParams {
    * correct depositor payout address before signing.
    */
   registeredPayoutScriptPubKey: string;
+
+  /**
+   * The claimer's x-only BTC public key for this payout (64-char hex, no prefix).
+   * Forwarded to {@link buildPayoutPsbt} for per-role output validation.
+   */
+  claimerBtcPubkey: string;
+
+  /**
+   * VP commission in basis points (`1..=9999`). Forwarded to {@link buildPayoutPsbt}.
+   */
+  commissionBps: number;
 }
 
 /**
@@ -192,12 +195,6 @@ export class PayoutManager {
   async signPayoutTransaction(
     params: SignPayoutParams,
   ): Promise<PayoutSignatureResult> {
-    // Validate payout TX outputs pay to the registered depositor payout address
-    this.validatePayoutOutputs(
-      params.payoutTxHex,
-      params.registeredPayoutScriptPubKey,
-    );
-
     // Validate wallet pubkey matches depositor and get both formats
     const walletPubkeyRaw = await this.config.btcWallet.getPublicKeyHex();
     const { depositorPubkey } = validateWalletPubkey(
@@ -205,7 +202,9 @@ export class PayoutManager {
       params.depositorBtcPubkey,
     );
 
-    // Build unsigned PSBT for Payout (uses Assert tx)
+    // Build unsigned PSBT for Payout (uses Assert tx). Per-role output
+    // validation happens inside buildPayoutPsbt against the resolved input
+    // values.
     const payoutPsbt = await buildPayoutPsbt({
       payoutTxHex: params.payoutTxHex,
       peginTxHex: params.peginTxHex,
@@ -216,6 +215,9 @@ export class PayoutManager {
       universalChallengerBtcPubkeys: params.universalChallengerBtcPubkeys,
       timelockPegin: params.timelockPegin,
       network: this.config.network,
+      claimerBtcPubkey: params.claimerBtcPubkey,
+      registeredPayoutScriptPubKey: params.registeredPayoutScriptPubKey,
+      commissionBps: params.commissionBps,
     });
 
     // Sign PSBT via wallet (Taproot script-path spend, input 0 only)
@@ -288,12 +290,6 @@ export class PayoutManager {
     const depositorPubkeys: string[] = [];
 
     for (const tx of transactions) {
-      // Validate payout TX outputs pay to the registered depositor payout address
-      this.validatePayoutOutputs(
-        tx.payoutTxHex,
-        tx.registeredPayoutScriptPubKey,
-      );
-
       // Validate wallet pubkey matches depositor
       const { depositorPubkey } = validateWalletPubkey(
         walletPubkeyRaw,
@@ -301,7 +297,8 @@ export class PayoutManager {
       );
       depositorPubkeys.push(depositorPubkey);
 
-      // Build Payout PSBT
+      // Build Payout PSBT (output validation runs inside buildPayoutPsbt
+      // against resolved input values).
       const payoutPsbt = await buildPayoutPsbt({
         payoutTxHex: tx.payoutTxHex,
         peginTxHex: tx.peginTxHex,
@@ -312,6 +309,9 @@ export class PayoutManager {
         universalChallengerBtcPubkeys: tx.universalChallengerBtcPubkeys,
         timelockPegin: tx.timelockPegin,
         network: this.config.network,
+        claimerBtcPubkey: tx.claimerBtcPubkey,
+        registeredPayoutScriptPubKey: tx.registeredPayoutScriptPubKey,
+        commissionBps: tx.commissionBps,
       });
       psbtsToSign.push(payoutPsbt.psbtHex);
       signOptions.push(createTaprootScriptPathSignOptions(walletPubkeyRaw, 1));
@@ -356,36 +356,4 @@ export class PayoutManager {
     return results;
   }
 
-  /**
-   * Validates that the payout transaction's largest output pays to the
-   * registered depositor payout address (scriptPubKey).
-   *
-   * This prevents three attack vectors from a malicious vault provider:
-   * 1. Substituting a completely different payout address
-   * 2. Including a dust output to the correct address while routing
-   *    the actual funds to an attacker-controlled address
-   * 3. Adding extra attacker outputs alongside the registered output
-   *    (closes [baby-auditor-findings#147])
-   *
-   * VP-claimer payout is fixed at 3 outputs by the protocol:
-   * `[depositor payout, VP commission, CPFP anchor]`. Anything else is
-   * rejected. The implicit-fee bound (value-burn variant of the same
-   * finding) is enforced inside `buildPayoutPsbt`.
-   *
-   * @param payoutTxHex - Raw payout transaction hex
-   * @param registeredPayoutScriptPubKey - On-chain registered scriptPubKey (hex, with or without 0x prefix)
-   * @throws Error if scriptPubKey is invalid hex
-   * @throws Error if the transaction does not have exactly 3 outputs
-   * @throws Error if output 0 does not pay to the registered scriptPubKey
-   */
-  private validatePayoutOutputs(
-    payoutTxHex: string,
-    registeredPayoutScriptPubKey: string,
-  ): void {
-    assertPayoutOutputMatchesRegistered(
-      payoutTxHex,
-      registeredPayoutScriptPubKey,
-      VP_CLAIMER_PAYOUT_OUTPUT_COUNT,
-    );
-  }
 }

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PayoutManager.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PayoutManager.test.ts
@@ -228,6 +228,8 @@ describe("PayoutManager", () => {
           timelockPegin: 100,
           depositorBtcPubkey: TEST_KEYS.DEPOSITOR,
           registeredPayoutScriptPubKey: TEST_PAYOUT_SCRIPT_PUBKEY,
+          claimerBtcPubkey: TEST_KEYS.VAULT_PROVIDER,
+          commissionBps: 500,
         },
         {
           payoutTxHex: payoutTxHex2,
@@ -239,6 +241,8 @@ describe("PayoutManager", () => {
           timelockPegin: 100,
           depositorBtcPubkey: TEST_KEYS.DEPOSITOR,
           registeredPayoutScriptPubKey: TEST_PAYOUT_SCRIPT_PUBKEY,
+          claimerBtcPubkey: TEST_KEYS.VAULT_PROVIDER,
+          commissionBps: 500,
         },
       ]);
 
@@ -285,6 +289,8 @@ describe("PayoutManager", () => {
             timelockPegin: 100,
             depositorBtcPubkey: TEST_KEYS.DEPOSITOR,
             registeredPayoutScriptPubKey: TEST_PAYOUT_SCRIPT_PUBKEY,
+            claimerBtcPubkey: TEST_KEYS.VAULT_PROVIDER,
+            commissionBps: 500,
           },
         ]),
       ).rejects.toThrow(
@@ -328,6 +334,8 @@ describe("PayoutManager", () => {
             timelockPegin: 100,
             depositorBtcPubkey: TEST_KEYS.DEPOSITOR,
             registeredPayoutScriptPubKey: TEST_PAYOUT_SCRIPT_PUBKEY,
+            claimerBtcPubkey: TEST_KEYS.VAULT_PROVIDER,
+            commissionBps: 500,
           },
         ]),
       ).rejects.toThrow();
@@ -386,6 +394,8 @@ describe("PayoutManager", () => {
             timelockPegin: 100,
             depositorBtcPubkey: TEST_KEYS.DEPOSITOR,
             registeredPayoutScriptPubKey: TEST_PAYOUT_SCRIPT_PUBKEY,
+            claimerBtcPubkey: TEST_KEYS.VAULT_PROVIDER,
+            commissionBps: 500,
           },
           {
             payoutTxHex: createTestPayoutTransaction(peginTxHex, assertTxHex),
@@ -397,6 +407,8 @@ describe("PayoutManager", () => {
             timelockPegin: 100,
             depositorBtcPubkey: TEST_KEYS.DEPOSITOR,
             registeredPayoutScriptPubKey: TEST_PAYOUT_SCRIPT_PUBKEY,
+            claimerBtcPubkey: TEST_KEYS.VAULT_PROVIDER,
+            commissionBps: 500,
           },
         ]),
       ).rejects.toThrow(
@@ -459,6 +471,8 @@ describe("PayoutManager", () => {
             timelockPegin: 100,
             depositorBtcPubkey: TEST_KEYS.DEPOSITOR,
             registeredPayoutScriptPubKey: TEST_PAYOUT_SCRIPT_PUBKEY,
+            claimerBtcPubkey: TEST_KEYS.VAULT_PROVIDER,
+            commissionBps: 500,
           },
           {
             payoutTxHex: createTestPayoutTransaction(peginTxHex, assertTxHex),
@@ -470,6 +484,8 @@ describe("PayoutManager", () => {
             timelockPegin: 100,
             depositorBtcPubkey: TEST_KEYS.DEPOSITOR,
             registeredPayoutScriptPubKey: TEST_PAYOUT_SCRIPT_PUBKEY,
+            claimerBtcPubkey: TEST_KEYS.VAULT_PROVIDER,
+            commissionBps: 500,
           },
         ]),
       ).rejects.toThrow(
@@ -555,9 +571,11 @@ describe("PayoutManager", () => {
           timelockPegin: 100,
           depositorBtcPubkey: TEST_KEYS.DEPOSITOR,
           registeredPayoutScriptPubKey: wrongScriptPubKey,
+          claimerBtcPubkey: TEST_KEYS.VAULT_PROVIDER,
+          commissionBps: 500,
         }),
       ).rejects.toThrow(
-        "Payout transaction output 0 does not pay to the registered depositor payout address",
+        "Payout transaction output 0 does not pay the expected scriptPubKey for role vp-claimer",
       );
     });
 
@@ -591,9 +609,11 @@ describe("PayoutManager", () => {
           timelockPegin: 100,
           depositorBtcPubkey: TEST_KEYS.DEPOSITOR,
           registeredPayoutScriptPubKey: prefixedScriptPubKey,
+          claimerBtcPubkey: TEST_KEYS.VAULT_PROVIDER,
+          commissionBps: 500,
         }),
       ).rejects.not.toThrow(
-        "output 0 does not pay to the registered depositor payout address",
+        "output 0 does not pay the expected scriptPubKey for role vp-claimer",
       );
     });
 
@@ -622,11 +642,13 @@ describe("PayoutManager", () => {
           timelockPegin: 100,
           depositorBtcPubkey: TEST_KEYS.DEPOSITOR,
           registeredPayoutScriptPubKey: "not-valid-hex",
+          claimerBtcPubkey: TEST_KEYS.VAULT_PROVIDER,
+          commissionBps: 500,
         }),
       ).rejects.toThrow("Invalid registeredPayoutScriptPubKey: not valid hex");
     });
 
-    it("rejects #147 PoC: registered script at vout 0 is preserved but extra attacker outputs drain value", async () => {
+    it("rejects a payout where vout 0 keeps the registered script but extra attacker outputs drain value", async () => {
       const peginTxHex = createTestPeginTransaction();
       const assertTxHex = createTestAssertTransaction();
 
@@ -656,7 +678,7 @@ describe("PayoutManager", () => {
       maliciousTx.addOutput(createDummyP2WPKH("e"), 1_000);
       // outs[2]: CPFP anchor slot
       maliciousTx.addOutput(createDummyP2WPKH("c"), 546);
-      // outs[3]: EXTRA attacker output — the #147 exploit vector.
+      // outs[3]: EXTRA attacker output — the value-diversion vector.
       maliciousTx.addOutput(createDummyP2WPKH("a"), 67_000);
 
       const btcWallet = new MockBitcoinWallet({
@@ -679,6 +701,8 @@ describe("PayoutManager", () => {
           timelockPegin: 100,
           depositorBtcPubkey: TEST_KEYS.DEPOSITOR,
           registeredPayoutScriptPubKey: TEST_PAYOUT_SCRIPT_PUBKEY,
+          claimerBtcPubkey: TEST_KEYS.VAULT_PROVIDER,
+          commissionBps: 500,
         }),
       ).rejects.toThrow(/has 4 output\(s\), expected exactly 3/);
     });
@@ -735,6 +759,8 @@ describe("PayoutManager", () => {
           timelockPegin: 100,
           depositorBtcPubkey: TEST_KEYS.DEPOSITOR,
           registeredPayoutScriptPubKey: TEST_PAYOUT_SCRIPT_PUBKEY,
+          claimerBtcPubkey: TEST_KEYS.VAULT_PROVIDER,
+          commissionBps: 500,
         }),
       ).rejects.toThrow(/output 0 script/);
     });
@@ -768,10 +794,12 @@ describe("PayoutManager", () => {
             timelockPegin: 100,
             depositorBtcPubkey: TEST_KEYS.DEPOSITOR,
             registeredPayoutScriptPubKey: wrongScriptPubKey,
+            claimerBtcPubkey: TEST_KEYS.VAULT_PROVIDER,
+            commissionBps: 500,
           },
         ]),
       ).rejects.toThrow(
-        "Payout transaction output 0 does not pay to the registered depositor payout address",
+        "Payout transaction output 0 does not pay the expected scriptPubKey for role vp-claimer",
       );
     });
   });

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PayoutManager.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PayoutManager.test.ts
@@ -24,6 +24,7 @@ import {
   createDummyP2WPKH,
 } from "../../primitives/psbt/__tests__/constants";
 import { initializeWasmForTests } from "../../primitives/psbt/__tests__/helpers";
+import { PAYOUT_ANCHOR_DUST_SATS } from "../../primitives/psbt/constants";
 import { PayoutManager, type PayoutManagerConfig } from "../PayoutManager";
 
 // Test constants - use valid secp256k1 x-only public keys
@@ -131,8 +132,8 @@ describe("PayoutManager", () => {
 
     /**
      * Creates a deterministic Payout transaction. Output shape follows the
-     * VP-claimer canonical structure enforced by
-     * `assertPayoutOutputMatchesRegistered`:
+     * VP-claimer canonical structure enforced by `buildPayoutPsbt`'s
+     * per-role check:
      *   outs[0]: depositor payout (registered scriptPubKey)
      *   outs[1]: VP commission
      *   outs[2]: CPFP anchor (546 sats)
@@ -158,11 +159,14 @@ describe("PayoutManager", () => {
         SEQUENCE_MAX,
       );
       // outs[0]: depositor payout — registered scriptPubKey ("d") at vout 0
-      tx.addOutput(createDummyP2WPKH("d"), Number(TEST_COMBINED_VALUE) - 1546);
+      tx.addOutput(
+        createDummyP2WPKH("d"),
+        Number(TEST_COMBINED_VALUE) - (1_000 + PAYOUT_ANCHOR_DUST_SATS),
+      );
       // outs[1]: VP commission
       tx.addOutput(createDummyP2WPKH("e"), 1_000);
-      // outs[2]: CPFP anchor — protocol fixes this at 546 sats
-      tx.addOutput(createDummyP2WPKH("c"), 546);
+      // outs[2]: CPFP anchor
+      tx.addOutput(createDummyP2WPKH("c"), PAYOUT_ANCHOR_DUST_SATS);
 
       return tx.toHex();
     }
@@ -507,8 +511,8 @@ describe("PayoutManager", () => {
 
     /**
      * Creates a deterministic Payout transaction. Output shape follows the
-     * VP-claimer canonical structure enforced by
-     * `assertPayoutOutputMatchesRegistered`:
+     * VP-claimer canonical structure enforced by `buildPayoutPsbt`'s
+     * per-role check:
      *   outs[0]: depositor payout (registered scriptPubKey)
      *   outs[1]: VP commission
      *   outs[2]: CPFP anchor (546 sats)
@@ -534,11 +538,14 @@ describe("PayoutManager", () => {
         SEQUENCE_MAX,
       );
       // outs[0]: depositor payout — registered scriptPubKey ("d") at vout 0
-      tx.addOutput(createDummyP2WPKH("d"), Number(TEST_COMBINED_VALUE) - 1546);
+      tx.addOutput(
+        createDummyP2WPKH("d"),
+        Number(TEST_COMBINED_VALUE) - (1_000 + PAYOUT_ANCHOR_DUST_SATS),
+      );
       // outs[1]: VP commission
       tx.addOutput(createDummyP2WPKH("e"), 1_000);
-      // outs[2]: CPFP anchor — protocol fixes this at 546 sats
-      tx.addOutput(createDummyP2WPKH("c"), 546);
+      // outs[2]: CPFP anchor
+      tx.addOutput(createDummyP2WPKH("c"), PAYOUT_ANCHOR_DUST_SATS);
 
       return tx.toHex();
     }
@@ -677,7 +684,7 @@ describe("PayoutManager", () => {
       // outs[1]: VP commission slot
       maliciousTx.addOutput(createDummyP2WPKH("e"), 1_000);
       // outs[2]: CPFP anchor slot
-      maliciousTx.addOutput(createDummyP2WPKH("c"), 546);
+      maliciousTx.addOutput(createDummyP2WPKH("c"), PAYOUT_ANCHOR_DUST_SATS);
       // outs[3]: EXTRA attacker output — the value-diversion vector.
       maliciousTx.addOutput(createDummyP2WPKH("a"), 67_000);
 

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PayoutManager.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PayoutManager.test.ts
@@ -130,7 +130,14 @@ describe("PayoutManager", () => {
     }
 
     /**
-     * Creates a deterministic Payout transaction that spends the peg-in output + assert output.
+     * Creates a deterministic Payout transaction. Output shape follows the
+     * VP-claimer canonical structure enforced by
+     * `assertPayoutOutputMatchesRegistered`:
+     *   outs[0]: depositor payout (registered scriptPubKey)
+     *   outs[1]: VP commission
+     *   outs[2]: CPFP anchor (546 sats)
+     * Implicit fee = inputs (150_000) − outputs (145_000) = 5_000 = 3.3%,
+     * comfortably under the 10% bound in `buildPayoutPsbt`.
      */
     function createTestPayoutTransaction(
       peginTxHex: string,
@@ -150,7 +157,12 @@ describe("PayoutManager", () => {
         0,
         SEQUENCE_MAX,
       );
-      tx.addOutput(createDummyP2WPKH("d"), Number(TEST_COMBINED_VALUE));
+      // outs[0]: depositor payout — registered scriptPubKey ("d") at vout 0
+      tx.addOutput(createDummyP2WPKH("d"), Number(TEST_COMBINED_VALUE) - 1546);
+      // outs[1]: VP commission
+      tx.addOutput(createDummyP2WPKH("e"), 1_000);
+      // outs[2]: CPFP anchor — protocol fixes this at 546 sats
+      tx.addOutput(createDummyP2WPKH("c"), 546);
 
       return tx.toHex();
     }
@@ -478,7 +490,14 @@ describe("PayoutManager", () => {
     }
 
     /**
-     * Creates a deterministic Payout transaction that spends the peg-in output + assert output.
+     * Creates a deterministic Payout transaction. Output shape follows the
+     * VP-claimer canonical structure enforced by
+     * `assertPayoutOutputMatchesRegistered`:
+     *   outs[0]: depositor payout (registered scriptPubKey)
+     *   outs[1]: VP commission
+     *   outs[2]: CPFP anchor (546 sats)
+     * Implicit fee = inputs (150_000) − outputs (145_000) = 5_000 = 3.3%,
+     * comfortably under the 10% bound in `buildPayoutPsbt`.
      */
     function createTestPayoutTransaction(
       peginTxHex: string,
@@ -498,12 +517,17 @@ describe("PayoutManager", () => {
         0,
         SEQUENCE_MAX,
       );
-      tx.addOutput(createDummyP2WPKH("d"), Number(TEST_COMBINED_VALUE));
+      // outs[0]: depositor payout — registered scriptPubKey ("d") at vout 0
+      tx.addOutput(createDummyP2WPKH("d"), Number(TEST_COMBINED_VALUE) - 1546);
+      // outs[1]: VP commission
+      tx.addOutput(createDummyP2WPKH("e"), 1_000);
+      // outs[2]: CPFP anchor — protocol fixes this at 546 sats
+      tx.addOutput(createDummyP2WPKH("c"), 546);
 
       return tx.toHex();
     }
 
-    it("should throw when payout TX does not pay to registered address", async () => {
+    it("should throw when payout TX output 0 does not pay to registered address", async () => {
       const peginTxHex = createTestPeginTransaction();
       const assertTxHex = createTestAssertTransaction();
       const payoutTxHex = createTestPayoutTransaction(peginTxHex, assertTxHex);
@@ -533,7 +557,7 @@ describe("PayoutManager", () => {
           registeredPayoutScriptPubKey: wrongScriptPubKey,
         }),
       ).rejects.toThrow(
-        "Payout transaction does not pay to the registered depositor payout address",
+        "Payout transaction output 0 does not pay to the registered depositor payout address",
       );
     });
 
@@ -569,7 +593,7 @@ describe("PayoutManager", () => {
           registeredPayoutScriptPubKey: prefixedScriptPubKey,
         }),
       ).rejects.not.toThrow(
-        "does not pay to the registered depositor payout address",
+        "output 0 does not pay to the registered depositor payout address",
       );
     });
 
@@ -602,11 +626,15 @@ describe("PayoutManager", () => {
       ).rejects.toThrow("Invalid registeredPayoutScriptPubKey: not valid hex");
     });
 
-    it("should reject dust output to registered address when larger output pays elsewhere", async () => {
+    it("rejects #147 PoC: registered script at vout 0 is preserved but extra attacker outputs drain value", async () => {
       const peginTxHex = createTestPeginTransaction();
       const assertTxHex = createTestAssertTransaction();
 
-      // Build a malicious payout TX: dust to registered address, bulk to attacker
+      // Build a malicious payout TX: 4 outputs (one more than the protocol's
+      // VP-claimer canonical count of 3). outs[0] keeps the registered
+      // script (so the index-0 check passes), but extra attacker outputs at
+      // outs[3] drain the remaining vault value. Pre-fix `largestOutput`
+      // reducer accepted this; the new output-count check rejects it.
       const peginTx = Transaction.fromHex(peginTxHex);
       const assertTx = Transaction.fromHex(assertTxHex);
       const maliciousTx = new Transaction();
@@ -621,10 +649,15 @@ describe("PayoutManager", () => {
         0,
         SEQUENCE_MAX,
       );
-      // Dust output (546 sats) to registered address
-      maliciousTx.addOutput(createDummyP2WPKH("d"), 546);
-      // Bulk output to attacker address
-      maliciousTx.addOutput(createDummyP2WPKH("a"), Number(TEST_COMBINED_VALUE));
+      // outs[0]: registered scriptPubKey, still the largest — passes the
+      // index-0 check by itself but the EXTRA output below trips count.
+      maliciousTx.addOutput(createDummyP2WPKH("d"), 76_454);
+      // outs[1]: VP commission slot
+      maliciousTx.addOutput(createDummyP2WPKH("e"), 1_000);
+      // outs[2]: CPFP anchor slot
+      maliciousTx.addOutput(createDummyP2WPKH("c"), 546);
+      // outs[3]: EXTRA attacker output — the #147 exploit vector.
+      maliciousTx.addOutput(createDummyP2WPKH("a"), 67_000);
 
       const btcWallet = new MockBitcoinWallet({
         publicKeyHex: TEST_KEYS.DEPOSITOR,
@@ -647,9 +680,7 @@ describe("PayoutManager", () => {
           depositorBtcPubkey: TEST_KEYS.DEPOSITOR,
           registeredPayoutScriptPubKey: TEST_PAYOUT_SCRIPT_PUBKEY,
         }),
-      ).rejects.toThrow(
-        "Payout transaction does not pay to the registered depositor payout address",
-      );
+      ).rejects.toThrow(/has 4 output\(s\), expected exactly 3/);
     });
 
     it("should reject when the wallet swaps the payout output before signing (single)", async () => {
@@ -740,7 +771,7 @@ describe("PayoutManager", () => {
           },
         ]),
       ).rejects.toThrow(
-        "Payout transaction does not pay to the registered depositor payout address",
+        "Payout transaction output 0 does not pay to the registered depositor payout address",
       );
     });
   });

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/index.ts
@@ -115,11 +115,7 @@ export type {
   BuildRefundPsbtResult,
 } from "./psbt/refund";
 
-export {
-  assertPayoutOutputMatchesRegistered,
-  buildPayoutPsbt,
-  extractPayoutSignature,
-} from "./psbt/payout";
+export { buildPayoutPsbt, extractPayoutSignature } from "./psbt/payout";
 export type { PayoutParams, PayoutPsbtResult } from "./psbt/payout";
 
 export {

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/payout.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/payout.test.ts
@@ -10,12 +10,8 @@ import { Buffer } from "buffer";
 import type { Network } from "@babylonlabs-io/babylon-tbv-rust-wasm";
 import { Psbt, Transaction } from "bitcoinjs-lib";
 import { beforeAll, describe, expect, it } from "vitest";
-import {
-  assertPayoutOutputMatchesRegistered,
-  buildPayoutPsbt,
-  extractPayoutSignature,
-  type PayoutParams,
-} from "../payout";
+import { deriveBip86ScriptPubKeyHex } from "../../utils/bitcoin";
+import { buildPayoutPsbt, extractPayoutSignature, type PayoutParams } from "../payout";
 import {
   DUMMY_TXID_2,
   NULL_TXID,
@@ -31,6 +27,21 @@ import {
   createDummyP2WPKH,
 } from "./constants";
 import { TEST_KEYS, initializeWasmForTests } from "./helpers";
+
+/**
+ * Registered depositor payout scriptPubKey used by tests. Matches outs[0] of
+ * the canonical VP-claimer test payout transaction (see
+ * {@link createTestPayoutTransaction}).
+ */
+const REGISTERED_PAYOUT_SCRIPT_HEX = createDummyP2WPKH("a").toString("hex");
+
+/**
+ * Default commissionBps for VP-claimer tests. With `TEST_PEGIN_VALUE = 100_000`
+ * the cap evaluates to `floor(100_000 * 500 / 10_000) = 5_000` sats, easily
+ * above the canonical 1_000-sat commission output in
+ * {@link createTestPayoutTransaction}.
+ */
+const TEST_COMMISSION_BPS = 500;
 
 /**
  * Encodes a non-negative integer as a Bitcoin compact-size varint.
@@ -118,8 +129,20 @@ function createTestAssertTransaction(): string {
 }
 
 /**
- * Creates a Payout transaction (simplified for testing).
- * 2 inputs (pegin + assert) required because Taproot SIGHASH_DEFAULT commits to all prevouts.
+ * Creates a Payout transaction in the VP-claimer canonical 3-output shape
+ * required by `buildPayoutPsbt`'s per-role validation:
+ *
+ *   outs[0]: depositor payout — `createDummyP2WPKH("a")` (matches
+ *            {@link REGISTERED_PAYOUT_SCRIPT_HEX})
+ *   outs[1]: VP commission — `createDummyP2WPKH("e")` at 1_000 sats
+ *            (under the cap for {@link TEST_COMMISSION_BPS} = 500 bps)
+ *   outs[2]: CPFP anchor — 546 sats (`PAYOUT_ANCHOR_DUST_SATS`)
+ *
+ * Inputs are pegin (100_000) + claim (50_000) = 150_000; outputs sum to
+ * 145_000 → implicit fee = 5_000 = 3.3%, well under the 10% bound.
+ *
+ * 2 inputs are required because Taproot SIGHASH_DEFAULT commits to all
+ * prevouts.
  */
 function createTestPayoutTransaction(
   peginTxHex: string,
@@ -133,12 +156,14 @@ function createTestPayoutTransaction(
   tx.addInput(Buffer.from(peginTx.getId(), "hex").reverse(), 0, SEQUENCE_MAX);
 
   // Input 1: Spend from assert output (after challenge path)
-  // REQUIRED: Taproot SIGHASH_DEFAULT commits to ALL inputs' prevouts
   tx.addInput(Buffer.from(assertTx.getId(), "hex").reverse(), 0, SEQUENCE_MAX);
 
-  // Output: Payment to recipient
-  // Amount: TEST_PEGIN_VALUE + TEST_CLAIM_VALUE - 5000 sats fee
-  tx.addOutput(createDummyP2WPKH("a"), Number(TEST_COMBINED_VALUE));
+  // outs[0]: depositor payout
+  tx.addOutput(createDummyP2WPKH("a"), Number(TEST_COMBINED_VALUE) - 1_546);
+  // outs[1]: VP commission
+  tx.addOutput(createDummyP2WPKH("e"), 1_000);
+  // outs[2]: CPFP anchor (PAYOUT_ANCHOR_DUST_SATS)
+  tx.addOutput(createDummyP2WPKH("c"), 546);
 
   return tx.toHex();
 }
@@ -169,6 +194,9 @@ describe("buildPayoutPsbt", () => {
         universalChallengerBtcPubkeys: [TEST_KEYS.UNIVERSAL_CHALLENGER_1],
         timelockPegin: 100,
         network: "signet" as Network,
+        claimerBtcPubkey: TEST_KEYS.VAULT_PROVIDER,
+        registeredPayoutScriptPubKey: REGISTERED_PAYOUT_SCRIPT_HEX,
+        commissionBps: TEST_COMMISSION_BPS,
       };
 
       const result = await buildPayoutPsbt(params);
@@ -181,7 +209,8 @@ describe("buildPayoutPsbt", () => {
       // Verify PSBT can be parsed - should have 2 inputs for correct sighash computation
       const psbt = Psbt.fromHex(result.psbtHex);
       expect(psbt.data.inputs.length).toBe(2);
-      expect(psbt.data.outputs.length).toBe(1);
+      // VP-claimer canonical: [depositor payout, VP commission, CPFP anchor]
+      expect(psbt.data.outputs.length).toBe(3);
 
       // Verify first input has Taproot script path spend info (depositor signs this)
       const firstInput = psbt.data.inputs[0];
@@ -217,6 +246,9 @@ describe("buildPayoutPsbt", () => {
           universalChallengerBtcPubkeys: [TEST_KEYS.UNIVERSAL_CHALLENGER_1],
           timelockPegin: 100,
           network,
+          claimerBtcPubkey: TEST_KEYS.VAULT_PROVIDER,
+          registeredPayoutScriptPubKey: REGISTERED_PAYOUT_SCRIPT_HEX,
+          commissionBps: TEST_COMMISSION_BPS,
         };
 
         const result = await buildPayoutPsbt(params);
@@ -245,6 +277,9 @@ describe("buildPayoutPsbt", () => {
         universalChallengerBtcPubkeys: [TEST_KEYS.UNIVERSAL_CHALLENGER_1],
         timelockPegin: 100,
         network: "signet" as Network,
+        claimerBtcPubkey: TEST_KEYS.VAULT_PROVIDER,
+        registeredPayoutScriptPubKey: REGISTERED_PAYOUT_SCRIPT_HEX,
+        commissionBps: TEST_COMMISSION_BPS,
       };
 
       const result = await buildPayoutPsbt(params);
@@ -282,6 +317,9 @@ describe("buildPayoutPsbt", () => {
         universalChallengerBtcPubkeys: [TEST_KEYS.UNIVERSAL_CHALLENGER_1],
         timelockPegin: 100,
         network: "signet" as Network,
+        claimerBtcPubkey: TEST_KEYS.VAULT_PROVIDER,
+        registeredPayoutScriptPubKey: REGISTERED_PAYOUT_SCRIPT_HEX,
+        commissionBps: TEST_COMMISSION_BPS,
       };
 
       await expect(buildPayoutPsbt(params)).rejects.toThrow(
@@ -325,6 +363,9 @@ describe("buildPayoutPsbt", () => {
         universalChallengerBtcPubkeys: [TEST_KEYS.UNIVERSAL_CHALLENGER_1],
         timelockPegin: 100,
         network: "signet" as Network,
+        claimerBtcPubkey: TEST_KEYS.VAULT_PROVIDER,
+        registeredPayoutScriptPubKey: REGISTERED_PAYOUT_SCRIPT_HEX,
+        commissionBps: TEST_COMMISSION_BPS,
       };
 
       await expect(buildPayoutPsbt(params)).rejects.toThrow(
@@ -367,6 +408,9 @@ describe("buildPayoutPsbt", () => {
         universalChallengerBtcPubkeys: [TEST_KEYS.UNIVERSAL_CHALLENGER_1],
         timelockPegin: 100,
         network: "signet" as Network,
+        claimerBtcPubkey: TEST_KEYS.VAULT_PROVIDER,
+        registeredPayoutScriptPubKey: REGISTERED_PAYOUT_SCRIPT_HEX,
+        commissionBps: TEST_COMMISSION_BPS,
       };
 
       await expect(buildPayoutPsbt(params)).rejects.toThrow(
@@ -391,6 +435,9 @@ describe("buildPayoutPsbt", () => {
         universalChallengerBtcPubkeys: [TEST_KEYS.UNIVERSAL_CHALLENGER_1],
         timelockPegin: 100,
         network: "signet" as Network,
+        claimerBtcPubkey: TEST_KEYS.VAULT_PROVIDER,
+        registeredPayoutScriptPubKey: REGISTERED_PAYOUT_SCRIPT_HEX,
+        commissionBps: TEST_COMMISSION_BPS,
       };
 
       const result = await buildPayoutPsbt(params);
@@ -722,123 +769,276 @@ describe("extractPayoutSignature", () => {
 });
 
 /**
- * Regression coverage for [baby-auditor-findings#147]. The pre-fix
- * `largestOutput` reducer accepted a payout tx whose registered output stayed
- * the largest while extra attacker outputs drained the remainder, and a
- * value-burn variant where outputs were deflated and the difference went to
- * miner fee. These tests pin the new contract: exact output count, registered
- * script anchored at vout 0, implicit fee bounded.
+ * Per-role payout output validation lives inside `buildPayoutPsbt`. These
+ * tests pin the contract: output count + outs[0].script + outs[last].value
+ * per role, plus the VP-claimer commission cap.
  */
-describe("assertPayoutOutputMatchesRegistered — output-structure guard (#147)", () => {
-  // Use the same dummy P2WPKH that the existing test payout transactions use.
-  // The hex (one byte differs per `seed`) is the registered script we anchor
-  // the check against.
-  const REGISTERED_SCRIPT = createDummyP2WPKH("a");
-  const REGISTERED_SCRIPT_HEX = REGISTERED_SCRIPT.toString("hex");
-  const ATTACKER_SCRIPT = createDummyP2WPKH("b");
+describe("buildPayoutPsbt — per-role output validation", () => {
+  beforeAll(async () => {
+    await initializeWasmForTests();
+  });
 
   /**
-   * Builds a payout-shaped transaction with the given outputs. Inputs are
-   * placeholder — this function only exercises the output-side guard, not the
-   * full sighash machinery.
+   * Builds a payout-shaped tx that spends pegin:0 and assert:0 (so the
+   * prevout binding inside buildPayoutPsbt resolves) and produces the given
+   * outputs.
    */
-  function makePayoutTxHex(
+  function buildPayoutTxWithOutputs(
+    peginTxHex: string,
+    assertTxHex: string,
     outputs: { script: Buffer; value: number }[],
   ): string {
+    const peginTx = Transaction.fromHex(peginTxHex);
+    const assertTx = Transaction.fromHex(assertTxHex);
     const tx = new Transaction();
-    tx.addInput(NULL_TXID, 0, SEQUENCE_MAX);
-    tx.addInput(DUMMY_TXID_2, 0, SEQUENCE_MAX);
+    tx.addInput(Buffer.from(peginTx.getId(), "hex").reverse(), 0, SEQUENCE_MAX);
+    tx.addInput(
+      Buffer.from(assertTx.getId(), "hex").reverse(),
+      0,
+      SEQUENCE_MAX,
+    );
     for (const out of outputs) tx.addOutput(out.script, out.value);
     return tx.toHex();
   }
 
-  it("accepts a VP-claimer 3-output payout with registered script at vout 0", () => {
-    // [depositor payout, VP commission, CPFP anchor] — protocol shape.
-    const payoutHex = makePayoutTxHex([
-      { script: REGISTERED_SCRIPT, value: 90_000 },
-      { script: createDummyP2TR(), value: 1_000 },
-      { script: createDummyP2TR(), value: 546 },
-    ]);
-    expect(() =>
-      assertPayoutOutputMatchesRegistered(payoutHex, REGISTERED_SCRIPT_HEX, 3),
-    ).not.toThrow();
+  function baseParams(overrides: Partial<PayoutParams>): PayoutParams {
+    return {
+      payoutTxHex: "",
+      peginTxHex: "",
+      assertTxHex: "",
+      depositorBtcPubkey: TEST_KEYS.DEPOSITOR,
+      vaultProviderBtcPubkey: TEST_KEYS.VAULT_PROVIDER,
+      vaultKeeperBtcPubkeys: [TEST_KEYS.VAULT_KEEPER_1],
+      universalChallengerBtcPubkeys: [TEST_KEYS.UNIVERSAL_CHALLENGER_1],
+      timelockPegin: 100,
+      network: "signet" as Network,
+      claimerBtcPubkey: TEST_KEYS.VAULT_PROVIDER,
+      registeredPayoutScriptPubKey: REGISTERED_PAYOUT_SCRIPT_HEX,
+      commissionBps: TEST_COMMISSION_BPS,
+      ...overrides,
+    };
+  }
+
+  it("VP-claimer: accepts a canonical 3-output payout", async () => {
+    const peginTxHex = createTestPeginTransaction();
+    const assertTxHex = createTestAssertTransaction();
+    const payoutTxHex = createTestPayoutTransaction(peginTxHex, assertTxHex);
+    await expect(
+      buildPayoutPsbt(baseParams({ payoutTxHex, peginTxHex, assertTxHex })),
+    ).resolves.toBeDefined();
   });
 
-  it("accepts a depositor-as-claimer 2-output payout with registered script at vout 0", () => {
-    // [payout, CPFP anchor] — no VP commission for depositor-as-claimer.
-    const payoutHex = makePayoutTxHex([
-      { script: REGISTERED_SCRIPT, value: 90_000 },
-      { script: createDummyP2TR(), value: 546 },
+  it("VP-claimer: rejects when an extra attacker output is appended", async () => {
+    const peginTxHex = createTestPeginTransaction();
+    const assertTxHex = createTestAssertTransaction();
+    const payoutTxHex = buildPayoutTxWithOutputs(peginTxHex, assertTxHex, [
+      { script: createDummyP2WPKH("a"), value: 80_000 },
+      { script: createDummyP2WPKH("e"), value: 1_000 },
+      { script: createDummyP2WPKH("c"), value: 546 },
+      { script: createDummyP2WPKH("b"), value: 60_000 },
     ]);
-    expect(() =>
-      assertPayoutOutputMatchesRegistered(payoutHex, REGISTERED_SCRIPT_HEX, 2),
-    ).not.toThrow();
+    await expect(
+      buildPayoutPsbt(baseParams({ payoutTxHex, peginTxHex, assertTxHex })),
+    ).rejects.toThrow(/has 4 output\(s\), expected exactly 3/);
   });
 
-  it("rejects the #147 PoC: registered output is largest but extra attacker outputs are appended", () => {
-    // Mirrors the audit PoC: registered output (51% of inputs) is largest,
-    // attacker outputs make up the rest. Pre-fix `largestOutput` reducer
-    // accepted this; the new count check rejects it.
-    const payoutHex = makePayoutTxHex([
-      { script: REGISTERED_SCRIPT, value: 51_000 },
-      { script: ATTACKER_SCRIPT, value: 24_000 },
-      { script: ATTACKER_SCRIPT, value: 24_000 },
-      { script: createDummyP2TR(), value: 546 },
+  it("VP-claimer: rejects when outs[0] script differs from the registered scriptPubKey", async () => {
+    const peginTxHex = createTestPeginTransaction();
+    const assertTxHex = createTestAssertTransaction();
+    const payoutTxHex = buildPayoutTxWithOutputs(peginTxHex, assertTxHex, [
+      { script: createDummyP2WPKH("b"), value: 143_454 },
+      { script: createDummyP2WPKH("e"), value: 1_000 },
+      { script: createDummyP2WPKH("c"), value: 546 },
     ]);
-    expect(() =>
-      assertPayoutOutputMatchesRegistered(payoutHex, REGISTERED_SCRIPT_HEX, 3),
-    ).toThrow(/has 4 output\(s\), expected exactly 3/);
+    await expect(
+      buildPayoutPsbt(baseParams({ payoutTxHex, peginTxHex, assertTxHex })),
+    ).rejects.toThrow(/output 0 does not pay the expected scriptPubKey for role vp-claimer/);
   });
 
-  it("rejects when output count matches but registered script is at vout 1 instead of vout 0", () => {
-    // Pre-fix would have passed this (registered output is largest).
-    // Anchoring the check at index 0 closes it.
-    const payoutHex = makePayoutTxHex([
-      { script: ATTACKER_SCRIPT, value: 1_000 },
-      { script: REGISTERED_SCRIPT, value: 90_000 },
-      { script: createDummyP2TR(), value: 546 },
+  it("VP-claimer: rejects when outs[1] (commission) exceeds the cap", async () => {
+    // commissionBps = 500 → cap = floor(100_000 * 500 / 10_000) = 5_000.
+    // Set outs[1] to 6_000 → over the cap.
+    const peginTxHex = createTestPeginTransaction();
+    const assertTxHex = createTestAssertTransaction();
+    const payoutTxHex = buildPayoutTxWithOutputs(peginTxHex, assertTxHex, [
+      { script: createDummyP2WPKH("a"), value: 138_454 },
+      { script: createDummyP2WPKH("e"), value: 6_000 },
+      { script: createDummyP2WPKH("c"), value: 546 },
     ]);
-    expect(() =>
-      assertPayoutOutputMatchesRegistered(payoutHex, REGISTERED_SCRIPT_HEX, 3),
-    ).toThrow(/output 0 does not pay to the registered depositor payout/);
+    await expect(
+      buildPayoutPsbt(baseParams({ payoutTxHex, peginTxHex, assertTxHex })),
+    ).rejects.toThrow(/VP commission \(out 1\) value 6000 sats exceeds cap 5000 sats/);
   });
 
-  it("rejects when output count is too low (e.g. 2 outputs supplied for a VP-claimer 3-output role)", () => {
-    const payoutHex = makePayoutTxHex([
-      { script: REGISTERED_SCRIPT, value: 90_000 },
-      { script: createDummyP2TR(), value: 546 },
+  it("VP-claimer: rejects when CPFP anchor value (outs[2]) is not 546 sats", async () => {
+    const peginTxHex = createTestPeginTransaction();
+    const assertTxHex = createTestAssertTransaction();
+    const payoutTxHex = buildPayoutTxWithOutputs(peginTxHex, assertTxHex, [
+      { script: createDummyP2WPKH("a"), value: 143_454 },
+      { script: createDummyP2WPKH("e"), value: 1_000 },
+      { script: createDummyP2WPKH("c"), value: 1_000 },
     ]);
-    expect(() =>
-      assertPayoutOutputMatchesRegistered(payoutHex, REGISTERED_SCRIPT_HEX, 3),
-    ).toThrow(/has 2 output\(s\), expected exactly 3/);
+    await expect(
+      buildPayoutPsbt(baseParams({ payoutTxHex, peginTxHex, assertTxHex })),
+    ).rejects.toThrow(/CPFP anchor \(out 2\) value 1000 sats must equal 546 sats/);
   });
 
-  it("rejects a zero or non-integer expectedOutputCount as a programming-error guard", () => {
-    const payoutHex = makePayoutTxHex([
-      { script: REGISTERED_SCRIPT, value: 90_000 },
-    ]);
-    expect(() =>
-      assertPayoutOutputMatchesRegistered(payoutHex, REGISTERED_SCRIPT_HEX, 0),
-    ).toThrow(/expectedOutputCount must be a positive integer/);
-    expect(() =>
-      assertPayoutOutputMatchesRegistered(
-        payoutHex,
-        REGISTERED_SCRIPT_HEX,
-        1.5,
+  it("VP-claimer: commissionBps 0 passes the structural guard but collapses the cap to 0", async () => {
+    // The protocol minimum is enforced at the trust boundary
+    // (prepareSigningContext), not here. buildPayoutPsbt only guards that the
+    // cap math is meaningful: commissionBps 0 is structurally valid, but the
+    // cap becomes floor(peginValue * 0 / 10_000) = 0, so the canonical
+    // 1_000-sat commission output is rejected by the cap — fail-safe.
+    const peginTxHex = createTestPeginTransaction();
+    const assertTxHex = createTestAssertTransaction();
+    const payoutTxHex = createTestPayoutTransaction(peginTxHex, assertTxHex);
+    await expect(
+      buildPayoutPsbt(
+        baseParams({ payoutTxHex, peginTxHex, assertTxHex, commissionBps: 0 }),
       ),
-    ).toThrow(/expectedOutputCount must be a positive integer/);
+    ).rejects.toThrow(/VP commission \(out 1\) value 1000 sats exceeds cap 0 sats/);
+  });
+
+  it("VP-claimer: rejects commissionBps at or above 10_000 (structural guard)", async () => {
+    const peginTxHex = createTestPeginTransaction();
+    const assertTxHex = createTestAssertTransaction();
+    const payoutTxHex = createTestPayoutTransaction(peginTxHex, assertTxHex);
+    await expect(
+      buildPayoutPsbt(
+        baseParams({
+          payoutTxHex,
+          peginTxHex,
+          assertTxHex,
+          commissionBps: 10_000,
+        }),
+      ),
+    ).rejects.toThrow(/commissionBps must be an integer in \[0, 10000\)/);
+  });
+
+  it("depositor-as-claimer: accepts a 2-output payout with registered script at outs[0]", async () => {
+    const peginTxHex = createTestPeginTransaction();
+    const assertTxHex = createTestAssertTransaction();
+    const payoutTxHex = buildPayoutTxWithOutputs(peginTxHex, assertTxHex, [
+      { script: createDummyP2WPKH("a"), value: 144_454 },
+      { script: createDummyP2WPKH("c"), value: 546 },
+    ]);
+    await expect(
+      buildPayoutPsbt(
+        baseParams({
+          payoutTxHex,
+          peginTxHex,
+          assertTxHex,
+          claimerBtcPubkey: TEST_KEYS.DEPOSITOR,
+        }),
+      ),
+    ).resolves.toBeDefined();
+  });
+
+  it("depositor-as-claimer: rejects when count is the VP-claimer shape (3 outputs)", async () => {
+    const peginTxHex = createTestPeginTransaction();
+    const assertTxHex = createTestAssertTransaction();
+    const payoutTxHex = createTestPayoutTransaction(peginTxHex, assertTxHex);
+    await expect(
+      buildPayoutPsbt(
+        baseParams({
+          payoutTxHex,
+          peginTxHex,
+          assertTxHex,
+          claimerBtcPubkey: TEST_KEYS.DEPOSITOR,
+        }),
+      ),
+    ).rejects.toThrow(/has 3 output\(s\), expected exactly 2 for role depositor-as-claimer/);
+  });
+
+  it("depositor-as-claimer: rejects when CPFP anchor value (outs[1]) is not 546 sats", async () => {
+    const peginTxHex = createTestPeginTransaction();
+    const assertTxHex = createTestAssertTransaction();
+    const payoutTxHex = buildPayoutTxWithOutputs(peginTxHex, assertTxHex, [
+      { script: createDummyP2WPKH("a"), value: 144_000 },
+      { script: createDummyP2WPKH("c"), value: 1_000 },
+    ]);
+    await expect(
+      buildPayoutPsbt(
+        baseParams({
+          payoutTxHex,
+          peginTxHex,
+          assertTxHex,
+          claimerBtcPubkey: TEST_KEYS.DEPOSITOR,
+        }),
+      ),
+    ).rejects.toThrow(/CPFP anchor \(out 1\) value 1000 sats must equal 546 sats/);
+  });
+
+  it("vk-claimer: accepts a 2-output payout with outs[0] = bip86(vk)", async () => {
+    const peginTxHex = createTestPeginTransaction();
+    const assertTxHex = createTestAssertTransaction();
+    const vkScriptHex = deriveBip86ScriptPubKeyHex(TEST_KEYS.VAULT_KEEPER_1);
+    // deriveBip86ScriptPubKeyHex returns a `0x`-prefixed hex string; strip
+    // the prefix before constructing the raw script buffer.
+    const vkScript = Buffer.from(vkScriptHex.replace(/^0x/, ""), "hex");
+    const payoutTxHex = buildPayoutTxWithOutputs(peginTxHex, assertTxHex, [
+      { script: vkScript, value: 144_454 },
+      { script: createDummyP2WPKH("c"), value: 546 },
+    ]);
+    await expect(
+      buildPayoutPsbt(
+        baseParams({
+          payoutTxHex,
+          peginTxHex,
+          assertTxHex,
+          claimerBtcPubkey: TEST_KEYS.VAULT_KEEPER_1,
+        }),
+      ),
+    ).resolves.toBeDefined();
+  });
+
+  it("vk-claimer: rejects when outs[0] script differs from bip86(vk)", async () => {
+    // outs[0] uses the registered depositor script instead of bip86(vk) —
+    // mirrors a VP trying to redirect VK payout to the depositor address.
+    const peginTxHex = createTestPeginTransaction();
+    const assertTxHex = createTestAssertTransaction();
+    const payoutTxHex = buildPayoutTxWithOutputs(peginTxHex, assertTxHex, [
+      { script: createDummyP2WPKH("a"), value: 144_454 },
+      { script: createDummyP2WPKH("c"), value: 546 },
+    ]);
+    await expect(
+      buildPayoutPsbt(
+        baseParams({
+          payoutTxHex,
+          peginTxHex,
+          assertTxHex,
+          claimerBtcPubkey: TEST_KEYS.VAULT_KEEPER_1,
+        }),
+      ),
+    ).rejects.toThrow(/output 0 does not pay the expected scriptPubKey for role vk-claimer/);
+  });
+
+  it("unknown claimer: rejects pubkey not matching VP, depositor, or any registered VK", async () => {
+    const peginTxHex = createTestPeginTransaction();
+    const assertTxHex = createTestAssertTransaction();
+    const payoutTxHex = createTestPayoutTransaction(peginTxHex, assertTxHex);
+    const strangerPubkey = "1".repeat(64);
+    await expect(
+      buildPayoutPsbt(
+        baseParams({
+          payoutTxHex,
+          peginTxHex,
+          assertTxHex,
+          claimerBtcPubkey: strangerPubkey,
+        }),
+      ),
+    ).rejects.toThrow(/Unknown claimer pubkey/);
   });
 });
 
 /**
- * Regression coverage for the value-burn half of [#147]. The output-structure
- * guard alone is not enough: a VP could keep the registered script at vout 0
- * and the right output count, then deflate the values so the missing amount
- * is paid to miners as implicit fee. The bound inside `buildPayoutPsbt`
- * catches this once the input amounts are pinned by the prevout binding
- * (PR #1673).
+ * The output-structure guard alone is not enough: a VP could keep the
+ * registered script at vout 0 and the right output count, then deflate the
+ * values so the missing amount is paid to miners as implicit fee. The bound
+ * inside `buildPayoutPsbt` catches this once the input amounts are pinned by
+ * the prevout binding.
  */
-describe("buildPayoutPsbt — implicit-fee bound (#147 value-burn variant)", () => {
+describe("buildPayoutPsbt — implicit-fee bound (value-burn variant)", () => {
   beforeAll(async () => {
     await initializeWasmForTests();
   });
@@ -863,11 +1063,15 @@ describe("buildPayoutPsbt — implicit-fee bound (#147 value-burn variant)", () 
 
   it("rejects a payout whose implicit fee exceeds 10% of inputs (value-burn variant)", async () => {
     // Inputs = TEST_PEGIN_VALUE (100_000) + TEST_CLAIM_VALUE (50_000) = 150_000.
-    // 10% cap → max fee 15_000. Output sum 100_000 → fee 50_000 → trip the bound.
+    // 10% cap → max fee 15_000. Deflate the depositor output so outputs sum
+    // to 100_000 → fee 50_000 → trip the bound. Keep the canonical VP-claimer
+    // 3-output shape so the role validation passes before the fee check.
     const peginTxHex = createTestPeginTransaction();
     const assertTxHex = createTestAssertTransaction();
     const payoutTxHex = makeDeflatedPayoutTxHex(peginTxHex, assertTxHex, [
-      { script: createDummyP2WPKH("a"), value: 100_000 },
+      { script: createDummyP2WPKH("a"), value: 98_454 },
+      { script: createDummyP2WPKH("e"), value: 1_000 },
+      { script: createDummyP2WPKH("c"), value: 546 },
     ]);
 
     await expect(
@@ -881,6 +1085,9 @@ describe("buildPayoutPsbt — implicit-fee bound (#147 value-burn variant)", () 
         universalChallengerBtcPubkeys: [TEST_KEYS.UNIVERSAL_CHALLENGER_1],
         timelockPegin: 100,
         network: "signet" as Network,
+        claimerBtcPubkey: TEST_KEYS.VAULT_PROVIDER,
+        registeredPayoutScriptPubKey: REGISTERED_PAYOUT_SCRIPT_HEX,
+        commissionBps: TEST_COMMISSION_BPS,
       }),
     ).rejects.toThrow(/implicit fee 50000 sats exceeds the safety cap/);
   });
@@ -891,7 +1098,9 @@ describe("buildPayoutPsbt — implicit-fee bound (#147 value-burn variant)", () 
     const peginTxHex = createTestPeginTransaction();
     const assertTxHex = createTestAssertTransaction();
     const payoutTxHex = makeDeflatedPayoutTxHex(peginTxHex, assertTxHex, [
-      { script: createDummyP2WPKH("a"), value: 200_000 },
+      { script: createDummyP2WPKH("a"), value: 198_454 },
+      { script: createDummyP2WPKH("e"), value: 1_000 },
+      { script: createDummyP2WPKH("c"), value: 546 },
     ]);
 
     await expect(
@@ -905,6 +1114,9 @@ describe("buildPayoutPsbt — implicit-fee bound (#147 value-burn variant)", () 
         universalChallengerBtcPubkeys: [TEST_KEYS.UNIVERSAL_CHALLENGER_1],
         timelockPegin: 100,
         network: "signet" as Network,
+        claimerBtcPubkey: TEST_KEYS.VAULT_PROVIDER,
+        registeredPayoutScriptPubKey: REGISTERED_PAYOUT_SCRIPT_HEX,
+        commissionBps: TEST_COMMISSION_BPS,
       }),
     ).rejects.toThrow(/outputs \(200000 sats\) exceed inputs/);
   });

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/payout.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/payout.test.ts
@@ -11,6 +11,7 @@ import type { Network } from "@babylonlabs-io/babylon-tbv-rust-wasm";
 import { Psbt, Transaction } from "bitcoinjs-lib";
 import { beforeAll, describe, expect, it } from "vitest";
 import {
+  assertPayoutOutputMatchesRegistered,
   buildPayoutPsbt,
   extractPayoutSignature,
   type PayoutParams,
@@ -717,5 +718,194 @@ describe("extractPayoutSignature", () => {
         extractPayoutSignature(psbtHex, TEST_KEYS.DEPOSITOR),
       ).toThrow(/trailing byte/);
     });
+  });
+});
+
+/**
+ * Regression coverage for [baby-auditor-findings#147]. The pre-fix
+ * `largestOutput` reducer accepted a payout tx whose registered output stayed
+ * the largest while extra attacker outputs drained the remainder, and a
+ * value-burn variant where outputs were deflated and the difference went to
+ * miner fee. These tests pin the new contract: exact output count, registered
+ * script anchored at vout 0, implicit fee bounded.
+ */
+describe("assertPayoutOutputMatchesRegistered — output-structure guard (#147)", () => {
+  // Use the same dummy P2WPKH that the existing test payout transactions use.
+  // The hex (one byte differs per `seed`) is the registered script we anchor
+  // the check against.
+  const REGISTERED_SCRIPT = createDummyP2WPKH("a");
+  const REGISTERED_SCRIPT_HEX = REGISTERED_SCRIPT.toString("hex");
+  const ATTACKER_SCRIPT = createDummyP2WPKH("b");
+
+  /**
+   * Builds a payout-shaped transaction with the given outputs. Inputs are
+   * placeholder — this function only exercises the output-side guard, not the
+   * full sighash machinery.
+   */
+  function makePayoutTxHex(
+    outputs: { script: Buffer; value: number }[],
+  ): string {
+    const tx = new Transaction();
+    tx.addInput(NULL_TXID, 0, SEQUENCE_MAX);
+    tx.addInput(DUMMY_TXID_2, 0, SEQUENCE_MAX);
+    for (const out of outputs) tx.addOutput(out.script, out.value);
+    return tx.toHex();
+  }
+
+  it("accepts a VP-claimer 3-output payout with registered script at vout 0", () => {
+    // [depositor payout, VP commission, CPFP anchor] — protocol shape.
+    const payoutHex = makePayoutTxHex([
+      { script: REGISTERED_SCRIPT, value: 90_000 },
+      { script: createDummyP2TR(), value: 1_000 },
+      { script: createDummyP2TR(), value: 546 },
+    ]);
+    expect(() =>
+      assertPayoutOutputMatchesRegistered(payoutHex, REGISTERED_SCRIPT_HEX, 3),
+    ).not.toThrow();
+  });
+
+  it("accepts a depositor-as-claimer 2-output payout with registered script at vout 0", () => {
+    // [payout, CPFP anchor] — no VP commission for depositor-as-claimer.
+    const payoutHex = makePayoutTxHex([
+      { script: REGISTERED_SCRIPT, value: 90_000 },
+      { script: createDummyP2TR(), value: 546 },
+    ]);
+    expect(() =>
+      assertPayoutOutputMatchesRegistered(payoutHex, REGISTERED_SCRIPT_HEX, 2),
+    ).not.toThrow();
+  });
+
+  it("rejects the #147 PoC: registered output is largest but extra attacker outputs are appended", () => {
+    // Mirrors the audit PoC: registered output (51% of inputs) is largest,
+    // attacker outputs make up the rest. Pre-fix `largestOutput` reducer
+    // accepted this; the new count check rejects it.
+    const payoutHex = makePayoutTxHex([
+      { script: REGISTERED_SCRIPT, value: 51_000 },
+      { script: ATTACKER_SCRIPT, value: 24_000 },
+      { script: ATTACKER_SCRIPT, value: 24_000 },
+      { script: createDummyP2TR(), value: 546 },
+    ]);
+    expect(() =>
+      assertPayoutOutputMatchesRegistered(payoutHex, REGISTERED_SCRIPT_HEX, 3),
+    ).toThrow(/has 4 output\(s\), expected exactly 3/);
+  });
+
+  it("rejects when output count matches but registered script is at vout 1 instead of vout 0", () => {
+    // Pre-fix would have passed this (registered output is largest).
+    // Anchoring the check at index 0 closes it.
+    const payoutHex = makePayoutTxHex([
+      { script: ATTACKER_SCRIPT, value: 1_000 },
+      { script: REGISTERED_SCRIPT, value: 90_000 },
+      { script: createDummyP2TR(), value: 546 },
+    ]);
+    expect(() =>
+      assertPayoutOutputMatchesRegistered(payoutHex, REGISTERED_SCRIPT_HEX, 3),
+    ).toThrow(/output 0 does not pay to the registered depositor payout/);
+  });
+
+  it("rejects when output count is too low (e.g. 2 outputs supplied for a VP-claimer 3-output role)", () => {
+    const payoutHex = makePayoutTxHex([
+      { script: REGISTERED_SCRIPT, value: 90_000 },
+      { script: createDummyP2TR(), value: 546 },
+    ]);
+    expect(() =>
+      assertPayoutOutputMatchesRegistered(payoutHex, REGISTERED_SCRIPT_HEX, 3),
+    ).toThrow(/has 2 output\(s\), expected exactly 3/);
+  });
+
+  it("rejects a zero or non-integer expectedOutputCount as a programming-error guard", () => {
+    const payoutHex = makePayoutTxHex([
+      { script: REGISTERED_SCRIPT, value: 90_000 },
+    ]);
+    expect(() =>
+      assertPayoutOutputMatchesRegistered(payoutHex, REGISTERED_SCRIPT_HEX, 0),
+    ).toThrow(/expectedOutputCount must be a positive integer/);
+    expect(() =>
+      assertPayoutOutputMatchesRegistered(
+        payoutHex,
+        REGISTERED_SCRIPT_HEX,
+        1.5,
+      ),
+    ).toThrow(/expectedOutputCount must be a positive integer/);
+  });
+});
+
+/**
+ * Regression coverage for the value-burn half of [#147]. The output-structure
+ * guard alone is not enough: a VP could keep the registered script at vout 0
+ * and the right output count, then deflate the values so the missing amount
+ * is paid to miners as implicit fee. The bound inside `buildPayoutPsbt`
+ * catches this once the input amounts are pinned by the prevout binding
+ * (PR #1673).
+ */
+describe("buildPayoutPsbt — implicit-fee bound (#147 value-burn variant)", () => {
+  beforeAll(async () => {
+    await initializeWasmForTests();
+  });
+
+  function makeDeflatedPayoutTxHex(
+    peginTxHex: string,
+    assertTxHex: string,
+    outputs: { script: Buffer; value: number }[],
+  ): string {
+    const peginTx = Transaction.fromHex(peginTxHex);
+    const assertTx = Transaction.fromHex(assertTxHex);
+    const tx = new Transaction();
+    tx.addInput(Buffer.from(peginTx.getId(), "hex").reverse(), 0, SEQUENCE_MAX);
+    tx.addInput(
+      Buffer.from(assertTx.getId(), "hex").reverse(),
+      0,
+      SEQUENCE_MAX,
+    );
+    for (const out of outputs) tx.addOutput(out.script, out.value);
+    return tx.toHex();
+  }
+
+  it("rejects a payout whose implicit fee exceeds 10% of inputs (value-burn variant)", async () => {
+    // Inputs = TEST_PEGIN_VALUE (100_000) + TEST_CLAIM_VALUE (50_000) = 150_000.
+    // 10% cap → max fee 15_000. Output sum 100_000 → fee 50_000 → trip the bound.
+    const peginTxHex = createTestPeginTransaction();
+    const assertTxHex = createTestAssertTransaction();
+    const payoutTxHex = makeDeflatedPayoutTxHex(peginTxHex, assertTxHex, [
+      { script: createDummyP2WPKH("a"), value: 100_000 },
+    ]);
+
+    await expect(
+      buildPayoutPsbt({
+        payoutTxHex,
+        assertTxHex,
+        peginTxHex,
+        depositorBtcPubkey: TEST_KEYS.DEPOSITOR,
+        vaultProviderBtcPubkey: TEST_KEYS.VAULT_PROVIDER,
+        vaultKeeperBtcPubkeys: [TEST_KEYS.VAULT_KEEPER_1],
+        universalChallengerBtcPubkeys: [TEST_KEYS.UNIVERSAL_CHALLENGER_1],
+        timelockPegin: 100,
+        network: "signet" as Network,
+      }),
+    ).rejects.toThrow(/implicit fee 50000 sats exceeds the safety cap/);
+  });
+
+  it("rejects a payout whose outputs exceed inputs (negative implicit fee)", async () => {
+    // Outputs (200_000) > inputs (150_000) — invalid Bitcoin transaction,
+    // caught before any signing.
+    const peginTxHex = createTestPeginTransaction();
+    const assertTxHex = createTestAssertTransaction();
+    const payoutTxHex = makeDeflatedPayoutTxHex(peginTxHex, assertTxHex, [
+      { script: createDummyP2WPKH("a"), value: 200_000 },
+    ]);
+
+    await expect(
+      buildPayoutPsbt({
+        payoutTxHex,
+        assertTxHex,
+        peginTxHex,
+        depositorBtcPubkey: TEST_KEYS.DEPOSITOR,
+        vaultProviderBtcPubkey: TEST_KEYS.VAULT_PROVIDER,
+        vaultKeeperBtcPubkeys: [TEST_KEYS.VAULT_KEEPER_1],
+        universalChallengerBtcPubkeys: [TEST_KEYS.UNIVERSAL_CHALLENGER_1],
+        timelockPegin: 100,
+        network: "signet" as Network,
+      }),
+    ).rejects.toThrow(/outputs \(200000 sats\) exceed inputs/);
   });
 });

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/payout.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/payout.test.ts
@@ -11,6 +11,7 @@ import type { Network } from "@babylonlabs-io/babylon-tbv-rust-wasm";
 import { Psbt, Transaction } from "bitcoinjs-lib";
 import { beforeAll, describe, expect, it } from "vitest";
 import { deriveBip86ScriptPubKeyHex } from "../../utils/bitcoin";
+import { PAYOUT_ANCHOR_DUST_SATS } from "../constants";
 import { buildPayoutPsbt, extractPayoutSignature, type PayoutParams } from "../payout";
 import {
   DUMMY_TXID_2,
@@ -159,11 +160,14 @@ function createTestPayoutTransaction(
   tx.addInput(Buffer.from(assertTx.getId(), "hex").reverse(), 0, SEQUENCE_MAX);
 
   // outs[0]: depositor payout
-  tx.addOutput(createDummyP2WPKH("a"), Number(TEST_COMBINED_VALUE) - 1_546);
+  tx.addOutput(
+    createDummyP2WPKH("a"),
+    Number(TEST_COMBINED_VALUE) - (1_000 + PAYOUT_ANCHOR_DUST_SATS),
+  );
   // outs[1]: VP commission
   tx.addOutput(createDummyP2WPKH("e"), 1_000);
-  // outs[2]: CPFP anchor (PAYOUT_ANCHOR_DUST_SATS)
-  tx.addOutput(createDummyP2WPKH("c"), 546);
+  // outs[2]: CPFP anchor
+  tx.addOutput(createDummyP2WPKH("c"), PAYOUT_ANCHOR_DUST_SATS);
 
   return tx.toHex();
 }
@@ -834,7 +838,7 @@ describe("buildPayoutPsbt — per-role output validation", () => {
     const payoutTxHex = buildPayoutTxWithOutputs(peginTxHex, assertTxHex, [
       { script: createDummyP2WPKH("a"), value: 80_000 },
       { script: createDummyP2WPKH("e"), value: 1_000 },
-      { script: createDummyP2WPKH("c"), value: 546 },
+      { script: createDummyP2WPKH("c"), value: PAYOUT_ANCHOR_DUST_SATS },
       { script: createDummyP2WPKH("b"), value: 60_000 },
     ]);
     await expect(
@@ -848,7 +852,7 @@ describe("buildPayoutPsbt — per-role output validation", () => {
     const payoutTxHex = buildPayoutTxWithOutputs(peginTxHex, assertTxHex, [
       { script: createDummyP2WPKH("b"), value: 143_454 },
       { script: createDummyP2WPKH("e"), value: 1_000 },
-      { script: createDummyP2WPKH("c"), value: 546 },
+      { script: createDummyP2WPKH("c"), value: PAYOUT_ANCHOR_DUST_SATS },
     ]);
     await expect(
       buildPayoutPsbt(baseParams({ payoutTxHex, peginTxHex, assertTxHex })),
@@ -863,7 +867,7 @@ describe("buildPayoutPsbt — per-role output validation", () => {
     const payoutTxHex = buildPayoutTxWithOutputs(peginTxHex, assertTxHex, [
       { script: createDummyP2WPKH("a"), value: 138_454 },
       { script: createDummyP2WPKH("e"), value: 6_000 },
-      { script: createDummyP2WPKH("c"), value: 546 },
+      { script: createDummyP2WPKH("c"), value: PAYOUT_ANCHOR_DUST_SATS },
     ]);
     await expect(
       buildPayoutPsbt(baseParams({ payoutTxHex, peginTxHex, assertTxHex })),
@@ -920,7 +924,7 @@ describe("buildPayoutPsbt — per-role output validation", () => {
     const assertTxHex = createTestAssertTransaction();
     const payoutTxHex = buildPayoutTxWithOutputs(peginTxHex, assertTxHex, [
       { script: createDummyP2WPKH("a"), value: 144_454 },
-      { script: createDummyP2WPKH("c"), value: 546 },
+      { script: createDummyP2WPKH("c"), value: PAYOUT_ANCHOR_DUST_SATS },
     ]);
     await expect(
       buildPayoutPsbt(
@@ -978,7 +982,7 @@ describe("buildPayoutPsbt — per-role output validation", () => {
     const vkScript = Buffer.from(vkScriptHex.replace(/^0x/, ""), "hex");
     const payoutTxHex = buildPayoutTxWithOutputs(peginTxHex, assertTxHex, [
       { script: vkScript, value: 144_454 },
-      { script: createDummyP2WPKH("c"), value: 546 },
+      { script: createDummyP2WPKH("c"), value: PAYOUT_ANCHOR_DUST_SATS },
     ]);
     await expect(
       buildPayoutPsbt(
@@ -999,7 +1003,7 @@ describe("buildPayoutPsbt — per-role output validation", () => {
     const assertTxHex = createTestAssertTransaction();
     const payoutTxHex = buildPayoutTxWithOutputs(peginTxHex, assertTxHex, [
       { script: createDummyP2WPKH("a"), value: 144_454 },
-      { script: createDummyP2WPKH("c"), value: 546 },
+      { script: createDummyP2WPKH("c"), value: PAYOUT_ANCHOR_DUST_SATS },
     ]);
     await expect(
       buildPayoutPsbt(
@@ -1071,7 +1075,7 @@ describe("buildPayoutPsbt — implicit-fee bound (value-burn variant)", () => {
     const payoutTxHex = makeDeflatedPayoutTxHex(peginTxHex, assertTxHex, [
       { script: createDummyP2WPKH("a"), value: 98_454 },
       { script: createDummyP2WPKH("e"), value: 1_000 },
-      { script: createDummyP2WPKH("c"), value: 546 },
+      { script: createDummyP2WPKH("c"), value: PAYOUT_ANCHOR_DUST_SATS },
     ]);
 
     await expect(
@@ -1100,7 +1104,7 @@ describe("buildPayoutPsbt — implicit-fee bound (value-burn variant)", () => {
     const payoutTxHex = makeDeflatedPayoutTxHex(peginTxHex, assertTxHex, [
       { script: createDummyP2WPKH("a"), value: 198_454 },
       { script: createDummyP2WPKH("e"), value: 1_000 },
-      { script: createDummyP2WPKH("c"), value: 546 },
+      { script: createDummyP2WPKH("c"), value: PAYOUT_ANCHOR_DUST_SATS },
     ]);
 
     await expect(

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/constants.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/constants.ts
@@ -28,3 +28,30 @@ export const ASSERT_PAYOUT_OUTPUT_INDEX = 0;
 
 /** Assert output index spent by NoPayout input 0 (signed). */
 export const ASSERT_NOPAYOUT_OUTPUT_INDEX = 0;
+
+/**
+ * Dust amount (sats) for the payout CPFP anchor output.
+ * Matches `DUST_AMOUNT` in `btc-vault crates/vault/src/lib.rs`. The protocol
+ * always builds the anchor as a `Bip86KeyConnector` output of exactly this
+ * value; pinning it at validation time blocks an attacker VP from using the
+ * anchor slot as a value sink.
+ */
+export const PAYOUT_ANCHOR_DUST_SATS = 546;
+
+/** VP-claimer payout output count: [depositor payout, VP commission, CPFP anchor]. */
+export const VP_CLAIMER_PAYOUT_OUTPUT_COUNT = 3;
+
+/** Depositor/VK-claimer payout output count: [claimer payout, CPFP anchor]. */
+export const NON_VP_CLAIMER_PAYOUT_OUTPUT_COUNT = 2;
+
+/**
+ * Exclusive upper bound on VP commission (basis points), and the basis-points
+ * denominator for the commission amount `floor(peginValue * bps / 10_000)`.
+ * Matches the contract's `_validateCommission` ceiling
+ * (`BTCVaultRegistry.sol`: `commissionBps >= 10000` reverts).
+ *
+ * The protocol *minimum* commission is the version-locked
+ * `VersionedOffchainParams.minVpCommissionBps`, not a constant — it is
+ * enforced at the trust boundary (`prepareSigningContext`), not here.
+ */
+export const MAX_VP_COMMISSION_BPS_EXCLUSIVE = 10_000;

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/constants.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/constants.ts
@@ -30,11 +30,8 @@ export const ASSERT_PAYOUT_OUTPUT_INDEX = 0;
 export const ASSERT_NOPAYOUT_OUTPUT_INDEX = 0;
 
 /**
- * Dust amount (sats) for the payout CPFP anchor output.
- * Matches `DUST_AMOUNT` in `btc-vault crates/vault/src/lib.rs`. The protocol
- * always builds the anchor as a `Bip86KeyConnector` output of exactly this
- * value; pinning it at validation time blocks an attacker VP from using the
- * anchor slot as a value sink.
+ * Dust amount (sats) for the payout CPFP anchor output. Matches `DUST_AMOUNT`
+ * in `btc-vault crates/vault/src/lib.rs`.
  */
 export const PAYOUT_ANCHOR_DUST_SATS = 546;
 
@@ -45,13 +42,9 @@ export const VP_CLAIMER_PAYOUT_OUTPUT_COUNT = 3;
 export const NON_VP_CLAIMER_PAYOUT_OUTPUT_COUNT = 2;
 
 /**
- * Exclusive upper bound on VP commission (basis points), and the basis-points
- * denominator for the commission amount `floor(peginValue * bps / 10_000)`.
- * Matches the contract's `_validateCommission` ceiling
- * (`BTCVaultRegistry.sol`: `commissionBps >= 10000` reverts).
- *
- * The protocol *minimum* commission is the version-locked
- * `VersionedOffchainParams.minVpCommissionBps`, not a constant — it is
- * enforced at the trust boundary (`prepareSigningContext`), not here.
+ * Exclusive upper bound on VP commission (bps), and the bps denominator for
+ * `floor(peginValue * bps / 10_000)`. Matches `BTCVaultRegistry._validateCommission`
+ * (`commissionBps >= 10000` reverts). The minimum is version-locked
+ * (`minVpCommissionBps`) and enforced upstream, not here.
  */
 export const MAX_VP_COMMISSION_BPS_EXCLUSIVE = 10_000;

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/noPayout.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/noPayout.ts
@@ -119,8 +119,9 @@ export async function buildNoPayoutPsbt(
  * protocol-defined output structure: a single BIP-86 P2TR output derived from
  * the challenger's x-only pubkey.
  *
- * Mirrors `assertPayoutOutputMatchesRegistered` for the NoPayout path, where
- * the sink is fixed by the protocol rather than read from on-chain registration
+ * Mirrors the per-role payout output validation now inlined in
+ * `buildPayoutPsbt` for the NoPayout path, where the sink is fixed by the
+ * protocol rather than read from on-chain registration
  * (see `crates/vault/src/transactions/nopayout.rs::NoPayoutTx::new`).
  *
  * @param noPayoutTxHex - Raw NoPayout transaction hex

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts
@@ -46,14 +46,10 @@ import {
 const TAPROOT_SINGLE_SIG_WITNESS_STACK_SIZE = 3;
 
 /**
- * Upper bound on the implicit fee (inputs − outputs) of a payout transaction,
- * expressed as a fraction of total input value. With input prevouts pinned
- * (see {@link buildPayoutPsbt}) the SDK knows the exact value entering the
- * transaction; any value that doesn't reappear as an output is implicit miner
- * fee. A malicious VP could otherwise return a payout tx with the registered
- * output script at vout 0 but deflated values, burning the remainder as fee.
- * 10% is well above any realistic fee for a ~200-vbyte payout tx, so
- * legitimate flows are never blocked.
+ * Coarse cap on a payout tx's implicit fee (inputs − outputs), as a fraction
+ * of input value — blocks a VP deflating outputs and burning the remainder
+ * as miner fee. A backstop only; the per-role structural checks in
+ * {@link assertPayoutOutputLayout} are the primary value-diversion guard.
  */
 const MAX_PAYOUT_FEE_FRACTION_NUMERATOR = 10;
 const MAX_PAYOUT_FEE_FRACTION_DENOMINATOR = 100;
@@ -114,34 +110,22 @@ export interface PayoutParams {
   network: Network;
 
   /**
-   * The claimer's x-only BTC public key for this payout (64-char hex, no prefix).
-   * Used to infer the payout role (VP / depositor-as-claimer / VK-claimer)
-   * against the protocol pubkey sets already passed in. Role inference lives
-   * inside `buildPayoutPsbt` so the caller cannot fabricate a wrong label.
+   * Claimer's x-only BTC public key (64-char hex, no prefix). Drives role
+   * inference (VP / depositor-as-claimer / VK-claimer) inside `buildPayoutPsbt`.
    */
   claimerBtcPubkey: string;
 
   /**
-   * The on-chain registered depositor payout scriptPubKey (hex, with or
-   * without 0x prefix). Used to validate outs[0].script for the VP-claimer
-   * and depositor-as-claimer roles. For the VK-claimer role the expected
-   * outs[0].script is derived from `claimerBtcPubkey` via BIP-86, and this
-   * field is unused.
+   * On-chain registered depositor payout scriptPubKey (hex, 0x optional).
+   * Expected outs[0].script for VP- and depositor-claimer roles; unused for
+   * VK-claimer (its outs[0].script is derived from `claimerBtcPubkey`).
    */
   registeredPayoutScriptPubKey: string;
 
   /**
-   * Vault Provider commission in basis points, sourced from
-   * `BTCVaultRegistry.vaultProviderCommissionBps`. Only consumed under the
-   * VP-claimer role to cap outs[1].value at
-   * `floor(peginValue * commissionBps / 10_000)`.
-   *
-   * This builder enforces only the structural guard it needs for safe cap
-   * math: a non-negative integer below
-   * {@link MAX_VP_COMMISSION_BPS_EXCLUSIVE}. The protocol *minimum*
-   * (`max(VersionedOffchainParams.minVpCommissionBps, 1)`) is enforced at the
-   * trust boundary where on-chain data is read (`prepareSigningContext`), not
-   * here — a too-low value is fail-safe (it only shrinks the cap).
+   * VP commission in basis points (`BTCVaultRegistry.vaultProviderCommissionBps`).
+   * Caps the VP-claimer outs[1].value. The protocol minimum is enforced
+   * upstream; here only `0 <= bps < 10_000` is checked, for safe cap math.
    */
   commissionBps: number;
 }
@@ -276,11 +260,8 @@ export async function buildPayoutPsbt(
     );
   }
 
-  // Validate the payout output structure against the protocol-canonical
-  // layout for this claimer's role. Blocks an extra attacker output and
-  // value routed into a non-payout slot. The role is inferred from
-  // `claimerBtcPubkey` against the pubkey sets that buildPayoutPsbt already
-  // receives, so the caller cannot fabricate a wrong role label.
+  // Per-role output validation — blocks an extra attacker output or value
+  // routed into a non-payout slot.
   assertPayoutOutputLayout({
     payoutTx,
     peginValueSats: peginPrevOut.value,
@@ -292,11 +273,8 @@ export async function buildPayoutPsbt(
     commissionBps: params.commissionBps,
   });
 
-  // Bound the implicit fee. With input prevouts pinned the SDK knows the
-  // exact value entering the transaction; any value that doesn't reappear as
-  // an output is implicit miner fee. A malicious VP could otherwise return a
-  // payout tx with the registered output script at vout 0 but deflated
-  // values, burning the remainder as fee.
+  // Bound the implicit fee — blocks a VP deflating output values and burning
+  // the difference as miner fee.
   const inputValueSats = peginPrevOut.value + input1PrevOut.value;
   let outputValueSats = 0;
   for (const out of payoutTx.outs) outputValueSats += out.value;
@@ -369,28 +347,15 @@ export async function buildPayoutPsbt(
 }
 
 /**
- * Validate that a payout transaction's output structure matches the protocol
- * contract for the claimer's role. Protects depositor value against:
+ * Validate a payout transaction's output structure for the claimer's role,
+ * keyed on `claimerBtcPubkey`. Pins per role: `outs.length`, `outs[0].script`,
+ * `outs[last].value` (anchor dust), and (VP-claimer) `outs[1].value` capped at
+ * `floor(peginValue × commissionBps / 10_000)`. Canonical layouts: VP-claimer
+ * = [payout, commission, anchor]; depositor/VK-claimer = [payout, anchor].
  *
- * - extra/missing attacker output (`outs.length` pinned per role)
- * - outs[0] redirected away from the registered payout address (script pinned)
- * - value drained through the anchor slot (outs[last].value pinned to dust)
- * - (VP-claimer only) value drained through the commission slot
- *   (outs[1].value capped at `floor(peginValue × commissionBps / 10_000)`)
- *
- * Value-burn through implicit fee is enforced separately by the 10% bound in
- * {@link buildPayoutPsbt}.
- *
- * Role inference is keyed purely on `claimerBtcPubkey` against the pubkey
- * sets `buildPayoutPsbt` already receives, so the caller cannot fabricate a
- * wrong role label. Protocol-canonical layouts, per
- * `btc-vault crates/vault/src/transactions/payout.rs`:
- *  - VP-claimer: 3 outputs — [depositor payout, VP commission, CPFP anchor]
- *  - Depositor-as-claimer / VK-claimer: 2 outputs — [claimer payout, CPFP anchor]
- *
- * Defensive checks on outs[1].script (VP commission destination) and
- * outs[last].script (CPFP anchor ownership) are intentionally NOT performed
- * — those are the VP's and claimer's own concerns, not depositor protection.
+ * `outs[1].script` and `outs[last].script` are intentionally not pinned: the
+ * value pins above bound depositor exposure regardless of where those outputs
+ * are sent, so the value pins — not script pins — are load-bearing.
  *
  * @internal Helper invoked by {@link buildPayoutPsbt}.
  */

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts
@@ -41,6 +41,20 @@ import {
 const TAPROOT_SINGLE_SIG_WITNESS_STACK_SIZE = 3;
 
 /**
+ * Upper bound on the implicit fee (inputs − outputs) of a payout transaction,
+ * expressed as a fraction of total input value. With input prevouts pinned
+ * (see {@link buildPayoutPsbt}) the SDK knows the exact value entering the
+ * transaction; any value that doesn't reappear as an output is implicit miner
+ * fee. A malicious VP could otherwise return a payout tx with the registered
+ * output script at vout 0 but deflated values, burning the remainder as fee.
+ * Closes the value-burn variant of [baby-auditor-findings#147]. 10% is well
+ * above any realistic fee for a ~200-vbyte payout tx, so legitimate flows
+ * are never blocked.
+ */
+const MAX_PAYOUT_FEE_FRACTION_NUMERATOR = 10;
+const MAX_PAYOUT_FEE_FRACTION_DENOMINATOR = 100;
+
+/**
  * Parameters for building an unsigned Payout PSBT
  *
  * Payout is used in the challenge path after Assert, when the claimer proves validity.
@@ -126,6 +140,9 @@ export interface PayoutPsbtResult {
  * @throws If input 0 does not spend PegIn:0 (vault UTXO)
  * @throws If input 1 does not spend Assert:0 (proof output)
  * @throws If previous output is not found for either input
+ * @throws If sum of output values exceeds sum of input values (invalid tx)
+ * @throws If implicit fee (inputs − outputs) exceeds the configured fraction
+ *   of total input value — see {@link MAX_PAYOUT_FEE_FRACTION_NUMERATOR}
  */
 export async function buildPayoutPsbt(
   params: PayoutParams,
@@ -219,6 +236,35 @@ export async function buildPayoutPsbt(
     );
   }
 
+  // Bound the implicit fee. With input prevouts pinned (PR #1673) the SDK
+  // knows the exact value entering the transaction; any value that doesn't
+  // reappear as an output is implicit miner fee. A malicious VP could
+  // otherwise return a payout tx with the registered output script at vout 0
+  // but deflated values, burning the remainder as fee — see
+  // [baby-auditor-findings#147].
+  const inputValueSats = peginPrevOut.value + input1PrevOut.value;
+  let outputValueSats = 0;
+  for (const out of payoutTx.outs) outputValueSats += out.value;
+  if (outputValueSats > inputValueSats) {
+    throw new Error(
+      `Payout outputs (${outputValueSats} sats) exceed inputs ` +
+        `(${inputValueSats} sats); invalid transaction.`,
+    );
+  }
+  const implicitFeeSats = inputValueSats - outputValueSats;
+  const maxFeeSats = Math.floor(
+    (inputValueSats * MAX_PAYOUT_FEE_FRACTION_NUMERATOR) /
+      MAX_PAYOUT_FEE_FRACTION_DENOMINATOR,
+  );
+  if (implicitFeeSats > maxFeeSats) {
+    throw new Error(
+      `Payout implicit fee ${implicitFeeSats} sats exceeds the safety cap ` +
+        `of ${maxFeeSats} sats ` +
+        `(${MAX_PAYOUT_FEE_FRACTION_NUMERATOR}/${MAX_PAYOUT_FEE_FRACTION_DENOMINATOR} ` +
+        `of inputs=${inputValueSats}); refusing to sign payout.`,
+    );
+  }
+
   // Input 0: Depositor signs using Taproot script path spend
   // This input includes tapLeafScript for signing
   psbt.addInput({
@@ -268,25 +314,47 @@ export async function buildPayoutPsbt(
 }
 
 /**
- * Validate that a payout transaction's largest output pays to the registered
- * depositor payout scriptPubKey.
+ * Validate that a payout transaction's output structure matches the protocol
+ * contract: exactly `expectedOutputCount` outputs, with output 0 paying to
+ * the registered depositor payout scriptPubKey.
  *
- * Prevents a malicious vault provider from substituting the payout destination
- * (or routing funds through a dust output to the correct address while sending
- * the actual value to an attacker-controlled script).
+ * Closes the "extra attacker output" half of [baby-auditor-findings#147].
+ * The prior `largestOutput` check accepted a transaction with the registered
+ * script as the largest output while additional smaller attacker outputs
+ * drained the remainder. The protocol fixes the output count (see below),
+ * so any deviation is rejected; and the depositor payout always sits at
+ * vout 0, so the script check is anchored to that index.
  *
- * @param payoutTxHex - Raw payout transaction hex
+ * The "value-burn via implicit fee" half of the same finding is enforced
+ * separately inside {@link buildPayoutPsbt}, where the input amounts from
+ * `peginTx` and `assertTx` are already resolved.
+ *
+ * Protocol-canonical output counts, per
+ * `btc-vault crates/vault/src/transactions/payout.rs`:
+ *  - VP-claimer payout: 3 outputs — [depositor payout, VP commission, CPFP anchor]
+ *  - Depositor-as-claimer payout: 2 outputs — [payout, CPFP anchor] (no commission)
+ *
+ * @param payoutTxHex - Raw payout transaction hex (with or without 0x prefix)
  * @param registeredPayoutScriptPubKey - On-chain registered scriptPubKey (hex, with or without 0x prefix)
- * @throws If scriptPubKey is invalid hex
- * @throws If the transaction has no outputs
- * @throws If the largest output does not pay to the registered scriptPubKey
+ * @param expectedOutputCount - Protocol-fixed output count for the role: 3 for VP-claimer, 2 for depositor-as-claimer
+ *
+ * @throws If `registeredPayoutScriptPubKey` is not valid hex
+ * @throws If `expectedOutputCount` is not a positive integer
+ * @throws If the transaction has a different number of outputs than expected
+ * @throws If output 0 does not pay to the registered scriptPubKey
  */
 export function assertPayoutOutputMatchesRegistered(
   payoutTxHex: string,
   registeredPayoutScriptPubKey: string,
+  expectedOutputCount: number,
 ): void {
   if (!isValidHex(registeredPayoutScriptPubKey)) {
     throw new Error("Invalid registeredPayoutScriptPubKey: not valid hex");
+  }
+  if (!Number.isInteger(expectedOutputCount) || expectedOutputCount < 1) {
+    throw new Error(
+      `expectedOutputCount must be a positive integer, got ${expectedOutputCount}`,
+    );
   }
 
   const expectedScript = Buffer.from(
@@ -295,17 +363,16 @@ export function assertPayoutOutputMatchesRegistered(
   );
   const payoutTx = Transaction.fromHex(stripHexPrefix(payoutTxHex));
 
-  if (payoutTx.outs.length === 0) {
-    throw new Error("Payout transaction has no outputs");
+  if (payoutTx.outs.length !== expectedOutputCount) {
+    throw new Error(
+      `Payout transaction has ${payoutTx.outs.length} output(s), ` +
+        `expected exactly ${expectedOutputCount} for this payout role.`,
+    );
   }
 
-  const largestOutput = payoutTx.outs.reduce((max, output) =>
-    output.value > max.value ? output : max,
-  );
-
-  if (!largestOutput.script.equals(expectedScript)) {
+  if (!payoutTx.outs[0].script.equals(expectedScript)) {
     throw new Error(
-      "Payout transaction does not pay to the registered depositor payout address",
+      "Payout transaction output 0 does not pay to the registered depositor payout address",
     );
   }
 }

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts
@@ -19,6 +19,7 @@ import { Psbt, Transaction } from "bitcoinjs-lib";
 import { createPayoutScript } from "../scripts/payout";
 import {
   TAPSCRIPT_LEAF_VERSION,
+  deriveBip86ScriptPubKeyHex,
   hexToUint8Array,
   isValidHex,
   stripHexPrefix,
@@ -26,7 +27,11 @@ import {
 } from "../utils/bitcoin";
 import {
   ASSERT_PAYOUT_OUTPUT_INDEX,
+  MAX_VP_COMMISSION_BPS_EXCLUSIVE,
+  NON_VP_CLAIMER_PAYOUT_OUTPUT_COUNT,
+  PAYOUT_ANCHOR_DUST_SATS,
   PEGIN_VAULT_OUTPUT_INDEX,
+  VP_CLAIMER_PAYOUT_OUTPUT_COUNT,
 } from "./constants";
 
 /**
@@ -47,9 +52,8 @@ const TAPROOT_SINGLE_SIG_WITNESS_STACK_SIZE = 3;
  * transaction; any value that doesn't reappear as an output is implicit miner
  * fee. A malicious VP could otherwise return a payout tx with the registered
  * output script at vout 0 but deflated values, burning the remainder as fee.
- * Closes the value-burn variant of [baby-auditor-findings#147]. 10% is well
- * above any realistic fee for a ~200-vbyte payout tx, so legitimate flows
- * are never blocked.
+ * 10% is well above any realistic fee for a ~200-vbyte payout tx, so
+ * legitimate flows are never blocked.
  */
 const MAX_PAYOUT_FEE_FRACTION_NUMERATOR = 10;
 const MAX_PAYOUT_FEE_FRACTION_DENOMINATOR = 100;
@@ -108,6 +112,38 @@ export interface PayoutParams {
    * Bitcoin network
    */
   network: Network;
+
+  /**
+   * The claimer's x-only BTC public key for this payout (64-char hex, no prefix).
+   * Used to infer the payout role (VP / depositor-as-claimer / VK-claimer)
+   * against the protocol pubkey sets already passed in. Role inference lives
+   * inside `buildPayoutPsbt` so the caller cannot fabricate a wrong label.
+   */
+  claimerBtcPubkey: string;
+
+  /**
+   * The on-chain registered depositor payout scriptPubKey (hex, with or
+   * without 0x prefix). Used to validate outs[0].script for the VP-claimer
+   * and depositor-as-claimer roles. For the VK-claimer role the expected
+   * outs[0].script is derived from `claimerBtcPubkey` via BIP-86, and this
+   * field is unused.
+   */
+  registeredPayoutScriptPubKey: string;
+
+  /**
+   * Vault Provider commission in basis points, sourced from
+   * `BTCVaultRegistry.vaultProviderCommissionBps`. Only consumed under the
+   * VP-claimer role to cap outs[1].value at
+   * `floor(peginValue * commissionBps / 10_000)`.
+   *
+   * This builder enforces only the structural guard it needs for safe cap
+   * math: a non-negative integer below
+   * {@link MAX_VP_COMMISSION_BPS_EXCLUSIVE}. The protocol *minimum*
+   * (`max(VersionedOffchainParams.minVpCommissionBps, 1)`) is enforced at the
+   * trust boundary where on-chain data is read (`prepareSigningContext`), not
+   * here — a too-low value is fail-safe (it only shrinks the cap).
+   */
+  commissionBps: number;
 }
 
 /**
@@ -143,6 +179,10 @@ export interface PayoutPsbtResult {
  * @throws If sum of output values exceeds sum of input values (invalid tx)
  * @throws If implicit fee (inputs − outputs) exceeds the configured fraction
  *   of total input value — see {@link MAX_PAYOUT_FEE_FRACTION_NUMERATOR}
+ * @throws If `claimerBtcPubkey` is not VP, depositor, or a registered VK
+ * @throws If payout output count, outs[0] script, outs[last] anchor value, or
+ *   (VP-claimer) outs[1] commission cap do not match the protocol layout
+ * @throws If `commissionBps` is not a non-negative integer below 10_000
  */
 export async function buildPayoutPsbt(
   params: PayoutParams,
@@ -236,12 +276,27 @@ export async function buildPayoutPsbt(
     );
   }
 
-  // Bound the implicit fee. With input prevouts pinned (PR #1673) the SDK
-  // knows the exact value entering the transaction; any value that doesn't
-  // reappear as an output is implicit miner fee. A malicious VP could
-  // otherwise return a payout tx with the registered output script at vout 0
-  // but deflated values, burning the remainder as fee — see
-  // [baby-auditor-findings#147].
+  // Validate the payout output structure against the protocol-canonical
+  // layout for this claimer's role. Blocks an extra attacker output and
+  // value routed into a non-payout slot. The role is inferred from
+  // `claimerBtcPubkey` against the pubkey sets that buildPayoutPsbt already
+  // receives, so the caller cannot fabricate a wrong role label.
+  assertPayoutOutputLayout({
+    payoutTx,
+    peginValueSats: peginPrevOut.value,
+    claimerBtcPubkey: params.claimerBtcPubkey,
+    vaultProviderBtcPubkey: params.vaultProviderBtcPubkey,
+    depositorBtcPubkey: params.depositorBtcPubkey,
+    vaultKeeperBtcPubkeys: params.vaultKeeperBtcPubkeys,
+    registeredPayoutScriptPubKey: params.registeredPayoutScriptPubKey,
+    commissionBps: params.commissionBps,
+  });
+
+  // Bound the implicit fee. With input prevouts pinned the SDK knows the
+  // exact value entering the transaction; any value that doesn't reappear as
+  // an output is implicit miner fee. A malicious VP could otherwise return a
+  // payout tx with the registered output script at vout 0 but deflated
+  // values, burning the remainder as fee.
   const inputValueSats = peginPrevOut.value + input1PrevOut.value;
   let outputValueSats = 0;
   for (const out of payoutTx.outs) outputValueSats += out.value;
@@ -315,65 +370,132 @@ export async function buildPayoutPsbt(
 
 /**
  * Validate that a payout transaction's output structure matches the protocol
- * contract: exactly `expectedOutputCount` outputs, with output 0 paying to
- * the registered depositor payout scriptPubKey.
+ * contract for the claimer's role. Protects depositor value against:
  *
- * Closes the "extra attacker output" half of [baby-auditor-findings#147].
- * The prior `largestOutput` check accepted a transaction with the registered
- * script as the largest output while additional smaller attacker outputs
- * drained the remainder. The protocol fixes the output count (see below),
- * so any deviation is rejected; and the depositor payout always sits at
- * vout 0, so the script check is anchored to that index.
+ * - extra/missing attacker output (`outs.length` pinned per role)
+ * - outs[0] redirected away from the registered payout address (script pinned)
+ * - value drained through the anchor slot (outs[last].value pinned to dust)
+ * - (VP-claimer only) value drained through the commission slot
+ *   (outs[1].value capped at `floor(peginValue × commissionBps / 10_000)`)
  *
- * The "value-burn via implicit fee" half of the same finding is enforced
- * separately inside {@link buildPayoutPsbt}, where the input amounts from
- * `peginTx` and `assertTx` are already resolved.
+ * Value-burn through implicit fee is enforced separately by the 10% bound in
+ * {@link buildPayoutPsbt}.
  *
- * Protocol-canonical output counts, per
+ * Role inference is keyed purely on `claimerBtcPubkey` against the pubkey
+ * sets `buildPayoutPsbt` already receives, so the caller cannot fabricate a
+ * wrong role label. Protocol-canonical layouts, per
  * `btc-vault crates/vault/src/transactions/payout.rs`:
- *  - VP-claimer payout: 3 outputs — [depositor payout, VP commission, CPFP anchor]
- *  - Depositor-as-claimer payout: 2 outputs — [payout, CPFP anchor] (no commission)
+ *  - VP-claimer: 3 outputs — [depositor payout, VP commission, CPFP anchor]
+ *  - Depositor-as-claimer / VK-claimer: 2 outputs — [claimer payout, CPFP anchor]
  *
- * @param payoutTxHex - Raw payout transaction hex (with or without 0x prefix)
- * @param registeredPayoutScriptPubKey - On-chain registered scriptPubKey (hex, with or without 0x prefix)
- * @param expectedOutputCount - Protocol-fixed output count for the role: 3 for VP-claimer, 2 for depositor-as-claimer
+ * Defensive checks on outs[1].script (VP commission destination) and
+ * outs[last].script (CPFP anchor ownership) are intentionally NOT performed
+ * — those are the VP's and claimer's own concerns, not depositor protection.
  *
- * @throws If `registeredPayoutScriptPubKey` is not valid hex
- * @throws If `expectedOutputCount` is not a positive integer
- * @throws If the transaction has a different number of outputs than expected
- * @throws If output 0 does not pay to the registered scriptPubKey
+ * @internal Helper invoked by {@link buildPayoutPsbt}.
  */
-export function assertPayoutOutputMatchesRegistered(
-  payoutTxHex: string,
-  registeredPayoutScriptPubKey: string,
-  expectedOutputCount: number,
-): void {
+function assertPayoutOutputLayout(args: {
+  payoutTx: Transaction;
+  peginValueSats: number;
+  claimerBtcPubkey: string;
+  vaultProviderBtcPubkey: string;
+  depositorBtcPubkey: string;
+  vaultKeeperBtcPubkeys: string[];
+  registeredPayoutScriptPubKey: string;
+  commissionBps: number;
+}): void {
+  const {
+    payoutTx,
+    peginValueSats,
+    claimerBtcPubkey,
+    vaultProviderBtcPubkey,
+    depositorBtcPubkey,
+    vaultKeeperBtcPubkeys,
+    registeredPayoutScriptPubKey,
+    commissionBps,
+  } = args;
+
   if (!isValidHex(registeredPayoutScriptPubKey)) {
     throw new Error("Invalid registeredPayoutScriptPubKey: not valid hex");
   }
-  if (!Number.isInteger(expectedOutputCount) || expectedOutputCount < 1) {
+
+  const claimer = stripHexPrefix(claimerBtcPubkey).toLowerCase();
+  const vp = stripHexPrefix(vaultProviderBtcPubkey).toLowerCase();
+  const dep = stripHexPrefix(depositorBtcPubkey).toLowerCase();
+  const keepers = vaultKeeperBtcPubkeys.map((k) =>
+    stripHexPrefix(k).toLowerCase(),
+  );
+
+  type Role = "vp-claimer" | "depositor-as-claimer" | "vk-claimer";
+  let role: Role;
+  let expectedOutCount: number;
+  let expectedOut0ScriptHex: string;
+
+  if (claimer === vp) {
+    role = "vp-claimer";
+    expectedOutCount = VP_CLAIMER_PAYOUT_OUTPUT_COUNT;
+    expectedOut0ScriptHex = stripHexPrefix(registeredPayoutScriptPubKey);
+  } else if (claimer === dep) {
+    role = "depositor-as-claimer";
+    expectedOutCount = NON_VP_CLAIMER_PAYOUT_OUTPUT_COUNT;
+    expectedOut0ScriptHex = stripHexPrefix(registeredPayoutScriptPubKey);
+  } else if (keepers.includes(claimer)) {
+    role = "vk-claimer";
+    expectedOutCount = NON_VP_CLAIMER_PAYOUT_OUTPUT_COUNT;
+    expectedOut0ScriptHex = stripHexPrefix(deriveBip86ScriptPubKeyHex(claimer));
+  } else {
     throw new Error(
-      `expectedOutputCount must be a positive integer, got ${expectedOutputCount}`,
+      `Unknown claimer pubkey ${claimer}: not VP, depositor, or a registered vault keeper`,
     );
   }
 
-  const expectedScript = Buffer.from(
-    stripHexPrefix(registeredPayoutScriptPubKey),
-    "hex",
-  );
-  const payoutTx = Transaction.fromHex(stripHexPrefix(payoutTxHex));
-
-  if (payoutTx.outs.length !== expectedOutputCount) {
+  if (payoutTx.outs.length !== expectedOutCount) {
     throw new Error(
       `Payout transaction has ${payoutTx.outs.length} output(s), ` +
-        `expected exactly ${expectedOutputCount} for this payout role.`,
+        `expected exactly ${expectedOutCount} for role ${role}.`,
     );
   }
 
-  if (!payoutTx.outs[0].script.equals(expectedScript)) {
+  const expectedOut0Script = Buffer.from(expectedOut0ScriptHex, "hex");
+  if (!payoutTx.outs[0].script.equals(expectedOut0Script)) {
     throw new Error(
-      "Payout transaction output 0 does not pay to the registered depositor payout address",
+      `Payout transaction output 0 does not pay the expected scriptPubKey for role ${role}`,
     );
+  }
+
+  const anchorIdx = expectedOutCount - 1;
+  if (payoutTx.outs[anchorIdx].value !== PAYOUT_ANCHOR_DUST_SATS) {
+    throw new Error(
+      `Payout CPFP anchor (out ${anchorIdx}) value ${payoutTx.outs[anchorIdx].value} sats ` +
+        `must equal ${PAYOUT_ANCHOR_DUST_SATS} sats`,
+    );
+  }
+
+  if (role === "vp-claimer") {
+    // Structural guard only — a non-negative integer below the bps
+    // denominator, so the cap math `floor(peginValue * bps / 10_000)` is
+    // meaningful. The protocol minimum is enforced at the trust boundary
+    // (`prepareSigningContext`); a too-low value here is fail-safe.
+    if (
+      !Number.isInteger(commissionBps) ||
+      commissionBps < 0 ||
+      commissionBps >= MAX_VP_COMMISSION_BPS_EXCLUSIVE
+    ) {
+      throw new Error(
+        `commissionBps must be an integer in ` +
+          `[0, ${MAX_VP_COMMISSION_BPS_EXCLUSIVE}), got ${commissionBps}`,
+      );
+    }
+    const maxCommissionSats = Math.floor(
+      (peginValueSats * commissionBps) / MAX_VP_COMMISSION_BPS_EXCLUSIVE,
+    );
+    if (payoutTx.outs[1].value > maxCommissionSats) {
+      throw new Error(
+        `Payout VP commission (out 1) value ${payoutTx.outs[1].value} sats ` +
+          `exceeds cap ${maxCommissionSats} sats ` +
+          `(${commissionBps} bps of peginValue=${peginValueSats})`,
+      );
+    }
   }
 }
 

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/runDepositorPresignFlow.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/runDepositorPresignFlow.test.ts
@@ -156,6 +156,7 @@ function createSigningContext(): PayoutSigningContext {
     councilQuorum: 1,
     network: "Testnet4" as never,
     registeredPayoutScriptPubKey: "0x5120" + DEPOSITOR_PK,
+    commissionBps: 50,
   };
 }
 

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/signDepositorGraph.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/signDepositorGraph.test.ts
@@ -661,9 +661,12 @@ describe("signDepositorGraph", () => {
       signingContext: createSigningContext(),
     });
 
+    // 3rd arg = DEPOSITOR_AS_CLAIMER_PAYOUT_OUTPUT_COUNT (= 2 — depositor as
+    // claimer pays only [payout, CPFP anchor], no VP commission).
     expect(validator).toHaveBeenCalledWith(
       graph.payout_tx.tx_hex,
       REGISTERED_PAYOUT_SCRIPT,
+      2,
     );
   });
 

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/signDepositorGraph.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/signDepositorGraph.test.ts
@@ -27,7 +27,6 @@ const MOCK_LOCAL_NOPAYOUT_PSBT_HEX_PREFIX = "local_nopayout_psbt_hex_";
 vi.mock("../../../primitives/psbt/payout", () => ({
   extractPayoutSignature: (signedPsbtHex: string, _depositorPubkey: string) =>
     `${MOCK_SIGNATURE_PREFIX}${signedPsbtHex}`,
-  assertPayoutOutputMatchesRegistered: vi.fn(),
   buildPayoutPsbt: vi.fn(async () => ({
     psbtHex: MOCK_LOCAL_PAYOUT_PSBT_HEX,
   })),
@@ -308,6 +307,9 @@ describe("signDepositorGraph", () => {
       universalChallengerBtcPubkeys: ctx.universalChallengerBtcPubkeys,
       timelockPegin: ctx.timelockPegin,
       network: ctx.network,
+      claimerBtcPubkey: ctx.depositorBtcPubkey,
+      registeredPayoutScriptPubKey: ctx.registeredPayoutScriptPubKey,
+      commissionBps: 1,
     });
   });
 
@@ -644,44 +646,16 @@ describe("signDepositorGraph", () => {
     expect(result.payout_signatures.payout_signature).toBeDefined();
   });
 
-  it("validates the payout output against the registered scriptPubKey before signing", async () => {
+  it("propagates payout build errors and never reaches the wallet", async () => {
     registerStandardMocks([CHALLENGER_A, CHALLENGER_B]);
-    const { assertPayoutOutputMatchesRegistered } = await import(
+    const { buildPayoutPsbt } = await import(
       "../../../primitives/psbt/payout"
     );
-    const validator = vi.mocked(assertPayoutOutputMatchesRegistered);
-    validator.mockClear();
-
-    const wallet = createMockWallet({ supportsBatch: true });
-    const graph = createDepositorGraph([CHALLENGER_A, CHALLENGER_B]);
-
-    await signDepositorGraph({
-      depositorGraph: graph,
-      btcWallet: wallet,
-      signingContext: createSigningContext(),
+    vi.mocked(buildPayoutPsbt).mockImplementationOnce(async () => {
+      throw new Error(
+        "Payout transaction output 0 does not pay the expected scriptPubKey for role depositor-as-claimer",
+      );
     });
-
-    // 3rd arg = DEPOSITOR_AS_CLAIMER_PAYOUT_OUTPUT_COUNT (= 2 — depositor as
-    // claimer pays only [payout, CPFP anchor], no VP commission).
-    expect(validator).toHaveBeenCalledWith(
-      graph.payout_tx.tx_hex,
-      REGISTERED_PAYOUT_SCRIPT,
-      2,
-    );
-  });
-
-  it("propagates payout output validation errors and never reaches the wallet", async () => {
-    registerStandardMocks([CHALLENGER_A, CHALLENGER_B]);
-    const { assertPayoutOutputMatchesRegistered } = await import(
-      "../../../primitives/psbt/payout"
-    );
-    vi.mocked(assertPayoutOutputMatchesRegistered).mockImplementationOnce(
-      () => {
-        throw new Error(
-          "Payout transaction does not pay to the registered depositor payout address",
-        );
-      },
-    );
 
     const wallet = createMockWallet({ supportsBatch: true });
     const graph = createDepositorGraph([CHALLENGER_A, CHALLENGER_B]);
@@ -692,7 +666,7 @@ describe("signDepositorGraph", () => {
         btcWallet: wallet,
         signingContext: createSigningContext(),
       }),
-    ).rejects.toThrow("registered depositor payout address");
+    ).rejects.toThrow("expected scriptPubKey for role depositor-as-claimer");
 
     expect(wallet.signPsbts).not.toHaveBeenCalled();
     expect(wallet.signPsbt).not.toHaveBeenCalled();

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts
@@ -71,13 +71,7 @@ export interface PayoutSigningContext {
   network: Network;
   /** On-chain registered depositor payout scriptPubKey (hex) */
   registeredPayoutScriptPubKey: string;
-  /**
-   * VP commission in basis points, sourced from
-   * `BTCVaultRegistry.vaultProviderCommissionBps`. Required for the
-   * VP-claimer output-validation cap inside `buildPayoutPsbt`. Must be in
-   * `1..=9999` per the protocol invariant in
-   * `btc-vault crates/vault/src/tx_graph/config.rs`.
-   */
+  /** VP commission (bps) from `BTCVaultRegistry`; caps the VP-claimer payout commission output. */
   commissionBps: number;
 }
 

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts
@@ -18,7 +18,6 @@ import type {
 } from "../../clients/vault-provider/types";
 import { PayoutManager } from "../../managers/PayoutManager";
 import {
-  deriveBip86ScriptPubKeyHex,
   processPublicKeyToXOnly,
   stripHexPrefix,
 } from "../../primitives/utils/bitcoin";
@@ -72,6 +71,14 @@ export interface PayoutSigningContext {
   network: Network;
   /** On-chain registered depositor payout scriptPubKey (hex) */
   registeredPayoutScriptPubKey: string;
+  /**
+   * VP commission in basis points, sourced from
+   * `BTCVaultRegistry.vaultProviderCommissionBps`. Required for the
+   * VP-claimer output-validation cap inside `buildPayoutPsbt`. Must be in
+   * `1..=9999` per the protocol invariant in
+   * `btc-vault crates/vault/src/tx_graph/config.rs`.
+   */
+  commissionBps: number;
 }
 
 export interface RunDepositorPresignFlowParams {
@@ -210,43 +217,10 @@ function assertNonDepositorClaimerSetMatches(
 }
 
 /**
- * Resolve the expected payout scriptPubKey for a given claimer.
- *
- * - VP/Depositor claimer: payout goes to the depositor's registered payout address
- * - VK claimer: payout goes to a BIP-86 P2TR address derived from the VK's pubkey
- *
- * Note: BIP-86 derivation for VK claimers requires bitcoinjs-lib's ECC to be initialized.
+ * Build the `SignPayoutParams` for a single claimer. Role/script resolution
+ * happens inside `buildPayoutPsbt`; here we only forward the claimer pubkey
+ * and the per-vault context fields.
  */
-function resolvePayoutScriptPubKey(
-  claimerPubkeyXOnly: string,
-  context: PayoutSigningContext,
-): string {
-  const claimer = stripHexPrefix(claimerPubkeyXOnly).toLowerCase();
-  const vpPubkey = stripHexPrefix(
-    context.vaultProviderBtcPubkey,
-  ).toLowerCase();
-  const depositorPubkey = stripHexPrefix(
-    context.depositorBtcPubkey,
-  ).toLowerCase();
-
-  if (claimer === vpPubkey || claimer === depositorPubkey) {
-    return context.registeredPayoutScriptPubKey;
-  }
-
-  // Verify claimer is a known vault keeper
-  const isVaultKeeper = context.vaultKeeperBtcPubkeys.some(
-    (vk) => stripHexPrefix(vk).toLowerCase() === claimer,
-  );
-  if (!isVaultKeeper) {
-    throw new Error(
-      `Unknown claimer pubkey ${claimer}: not VP, depositor, or a registered vault keeper`,
-    );
-  }
-
-  // VK claimer: derive BIP-86 P2TR scriptPubKey from the VK's x-only pubkey
-  return deriveBip86ScriptPubKeyHex(claimer);
-}
-
 function buildPayoutSigningInput(
   tx: PreparedTransaction,
   context: PayoutSigningContext,
@@ -260,10 +234,9 @@ function buildPayoutSigningInput(
     universalChallengerBtcPubkeys: context.universalChallengerBtcPubkeys,
     depositorBtcPubkey: context.depositorBtcPubkey,
     timelockPegin: context.timelockPegin,
-    registeredPayoutScriptPubKey: resolvePayoutScriptPubKey(
-      tx.claimerPubkeyXOnly,
-      context,
-    ),
+    registeredPayoutScriptPubKey: context.registeredPayoutScriptPubKey,
+    claimerBtcPubkey: tx.claimerPubkeyXOnly,
+    commissionBps: context.commissionBps,
   };
 }
 

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts
@@ -58,10 +58,8 @@ import { createTaprootScriptPathSignOptions } from "../../utils/signing";
 const DEPOSITOR_SIGNED_INPUT_COUNT = 1;
 
 /**
- * commissionBps placeholder for the depositor-as-claimer path. The validator
- * inside `buildPayoutPsbt` only consults `commissionBps` under the VP-claimer
- * role, so any value satisfying the `1..=9999` integer bound is harmless
- * here; we use the protocol minimum so it doesn't look like a wildcard.
+ * commissionBps placeholder for the depositor-as-claimer path — `buildPayoutPsbt`
+ * only consults it under the VP-claimer role, so any in-range value is inert.
  */
 const DEPOSITOR_PATH_UNUSED_COMMISSION_BPS = 1;
 
@@ -242,14 +240,9 @@ async function collectDepositorGraphPsbts(
     ctx.universalChallengerBtcPubkeys,
   );
 
-  // 2. Build the payout PSBT locally. Every sighash-relevant field
-  //    (witnessUtxo, tapLeafScript, controlBlock, tapInternalKey) is derived
-  //    from on-chain trusted connector params, not from the VP. The VP-
-  //    supplied assert tx hex is implicitly pinned by buildPayoutPsbt's
-  //    input-1 txid check against payoutTx.ins[1].hash. Per-role output
-  //    validation (depositor-as-claimer = 2 outputs, outs[0] = registered
-  //    payout script, outs[1] = CPFP anchor at dust) runs inside
-  //    buildPayoutPsbt against resolved input values.
+  // 2. Build the payout PSBT locally — every sighash-relevant field is
+  //    derived from trusted on-chain connector params, not from the VP.
+  //    buildPayoutPsbt also runs the per-role output validation.
   const builtPayout = await buildPayoutPsbt({
     payoutTxHex: depositorGraph.payout_tx.tx_hex,
     peginTxHex: ctx.peginTxHex,

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts
@@ -37,7 +37,6 @@ import {
   buildNoPayoutPsbt,
 } from "../../primitives/psbt/noPayout";
 import {
-  assertPayoutOutputMatchesRegistered,
   buildPayoutPsbt,
   extractPayoutSignature,
 } from "../../primitives/psbt/payout";
@@ -59,13 +58,12 @@ import { createTaprootScriptPathSignOptions } from "../../utils/signing";
 const DEPOSITOR_SIGNED_INPUT_COUNT = 1;
 
 /**
- * Protocol-canonical output count for a depositor-as-claimer payout
- * transaction: `[payout, CPFP anchor]` — no VP commission because the
- * depositor is also the claimer. See `btc-vault
- * crates/vault/src/transactions/mod.rs::build_payout_outputs` (no-commission
- * branch).
+ * commissionBps placeholder for the depositor-as-claimer path. The validator
+ * inside `buildPayoutPsbt` only consults `commissionBps` under the VP-claimer
+ * role, so any value satisfying the `1..=9999` integer bound is harmless
+ * here; we use the protocol minimum so it doesn't look like a wildcard.
  */
-const DEPOSITOR_AS_CLAIMER_PAYOUT_OUTPUT_COUNT = 2;
+const DEPOSITOR_PATH_UNUSED_COMMISSION_BPS = 1;
 
 /** Tracks which indices in the flat PSBT array belong to which challenger */
 interface ChallengerEntry {
@@ -244,25 +242,14 @@ async function collectDepositorGraphPsbts(
     ctx.universalChallengerBtcPubkeys,
   );
 
-  // 2. Validate the payout transaction's output structure: protocol-fixed
-  //    2-output shape (depositor-as-claimer = [payout, CPFP anchor]) and
-  //    output 0 paying the depositor's on-chain registered payout
-  //    scriptPubKey. The payout tx hex is supplied by the VP and otherwise
-  //    unconstrained; this assertion pins both the count and the destination.
-  //    Closes the "extra attacker output" half of
-  //    [baby-auditor-findings#147] for the depositor-as-claimer variant; the
-  //    value-burn half is enforced inside buildPayoutPsbt below.
-  assertPayoutOutputMatchesRegistered(
-    depositorGraph.payout_tx.tx_hex,
-    ctx.registeredPayoutScriptPubKey,
-    DEPOSITOR_AS_CLAIMER_PAYOUT_OUTPUT_COUNT,
-  );
-
-  // 3. Build the payout PSBT locally. Every sighash-relevant field
+  // 2. Build the payout PSBT locally. Every sighash-relevant field
   //    (witnessUtxo, tapLeafScript, controlBlock, tapInternalKey) is derived
   //    from on-chain trusted connector params, not from the VP. The VP-
   //    supplied assert tx hex is implicitly pinned by buildPayoutPsbt's
-  //    input-1 txid check against payoutTx.ins[1].hash.
+  //    input-1 txid check against payoutTx.ins[1].hash. Per-role output
+  //    validation (depositor-as-claimer = 2 outputs, outs[0] = registered
+  //    payout script, outs[1] = CPFP anchor at dust) runs inside
+  //    buildPayoutPsbt against resolved input values.
   const builtPayout = await buildPayoutPsbt({
     payoutTxHex: depositorGraph.payout_tx.tx_hex,
     peginTxHex: ctx.peginTxHex,
@@ -273,6 +260,9 @@ async function collectDepositorGraphPsbts(
     universalChallengerBtcPubkeys: ctx.universalChallengerBtcPubkeys,
     timelockPegin: ctx.timelockPegin,
     network: ctx.network,
+    claimerBtcPubkey: ctx.depositorBtcPubkey,
+    registeredPayoutScriptPubKey: ctx.registeredPayoutScriptPubKey,
+    commissionBps: DEPOSITOR_PATH_UNUSED_COMMISSION_BPS,
   });
   psbtHexes.push(builtPayout.psbtHex);
   signOptions.push(
@@ -282,7 +272,7 @@ async function collectDepositorGraphPsbts(
     ),
   );
 
-  // 4. Per-challenger: build the NoPayout PSBT locally too.
+  // 3. Per-challenger: build the NoPayout PSBT locally too.
   const claimerPubkey = stripHexPrefix(ctx.depositorBtcPubkey);
   const assertTxParsed = Transaction.fromHex(
     stripHexPrefix(depositorGraph.assert_tx.tx_hex),

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts
@@ -58,6 +58,15 @@ import { createTaprootScriptPathSignOptions } from "../../utils/signing";
  */
 const DEPOSITOR_SIGNED_INPUT_COUNT = 1;
 
+/**
+ * Protocol-canonical output count for a depositor-as-claimer payout
+ * transaction: `[payout, CPFP anchor]` — no VP commission because the
+ * depositor is also the claimer. See `btc-vault
+ * crates/vault/src/transactions/mod.rs::build_payout_outputs` (no-commission
+ * branch).
+ */
+const DEPOSITOR_AS_CLAIMER_PAYOUT_OUTPUT_COUNT = 2;
+
 /** Tracks which indices in the flat PSBT array belong to which challenger */
 interface ChallengerEntry {
   challengerPubkey: string;
@@ -235,13 +244,18 @@ async function collectDepositorGraphPsbts(
     ctx.universalChallengerBtcPubkeys,
   );
 
-  // 2. Validate the payout transaction's largest output pays to the
-  //    depositor's on-chain registered payout scriptPubKey. The payout tx
-  //    hex is supplied by the VP and otherwise unconstrained; this assertion
-  //    pins the destination of the funds.
+  // 2. Validate the payout transaction's output structure: protocol-fixed
+  //    2-output shape (depositor-as-claimer = [payout, CPFP anchor]) and
+  //    output 0 paying the depositor's on-chain registered payout
+  //    scriptPubKey. The payout tx hex is supplied by the VP and otherwise
+  //    unconstrained; this assertion pins both the count and the destination.
+  //    Closes the "extra attacker output" half of
+  //    [baby-auditor-findings#147] for the depositor-as-claimer variant; the
+  //    value-burn half is enforced inside buildPayoutPsbt below.
   assertPayoutOutputMatchesRegistered(
     depositorGraph.payout_tx.tx_hex,
     ctx.registeredPayoutScriptPubKey,
+    DEPOSITOR_AS_CLAIMER_PAYOUT_OUTPUT_COUNT,
   );
 
   // 3. Build the payout PSBT locally. Every sighash-relevant field

--- a/services/vault/src/clients/eth-contract/btc-vault-registry/query.ts
+++ b/services/vault/src/clients/eth-contract/btc-vault-registry/query.ts
@@ -30,6 +30,11 @@ export interface OnChainVaultData {
   amount: bigint;
   /** Hash of the Pre-PegIn transaction (bytes32, 0x-prefixed) */
   prePeginTxHash: Hex;
+  /**
+   * VP commission in basis points (`1..=9999`) locked at vault creation.
+   * Required by `buildPayoutPsbt` to cap the VP-claimer commission output.
+   */
+  vaultProviderCommissionBps: number;
 }
 
 /**
@@ -55,6 +60,7 @@ export async function getVaultFromChain(
     htlcVout: Number(protocol.htlcVout),
     amount: basic.amount,
     prePeginTxHash: protocol.prePeginTxHash,
+    vaultProviderCommissionBps: Number(protocol.vaultProviderCommissionBps),
   };
 }
 

--- a/services/vault/src/services/vault/__tests__/vaultPayoutSignatureService.test.ts
+++ b/services/vault/src/services/vault/__tests__/vaultPayoutSignatureService.test.ts
@@ -135,6 +135,7 @@ describe("vaultPayoutSignatureService", () => {
       universalChallengersVersion: 3,
       applicationEntryPoint: "0xapp",
       vaultProvider: "0xprovider" as `0x${string}`,
+      vaultProviderCommissionBps: 50,
     };
 
     beforeEach(() => {
@@ -145,6 +146,7 @@ describe("vaultPayoutSignatureService", () => {
         timelockAssert: 144n,
         securityCouncilKeys: ["0xcouncil2", "0xcouncil1"],
         councilQuorum: 1,
+        minVpCommissionBps: 10,
       });
       mockGetVaultKeepersByVersion.mockResolvedValue([
         { btcPubKey: "vk1" },
@@ -176,6 +178,67 @@ describe("vaultPayoutSignatureService", () => {
       expect(context.vaultProviderBtcPubkey).toBe(ON_CHAIN_VP_PUBKEY);
       expect(context.network).toBe("testnet");
       expect(context.registeredPayoutScriptPubKey).toBe("0xscript");
+      expect(context.commissionBps).toBe(50);
+    });
+
+    it("throws when VP commission is below the protocol floor", async () => {
+      // minVpCommissionBps = 10; a vault with commission 5 is below the floor.
+      (getVaultFromChain as Mock).mockResolvedValue({
+        ...ON_CHAIN_VAULT,
+        vaultProviderCommissionBps: 5,
+      });
+
+      await expect(
+        prepareSigningContext({
+          vaultId: "vault_id",
+          depositorBtcPubkey: "depositor_pubkey",
+          registeredPayoutScriptPubKey: "0xscript",
+        }),
+      ).rejects.toThrow(
+        /VP commission 5 bps out of protocol range \[10, 10000\)/,
+      );
+    });
+
+    it("throws when VP commission is at or above the 10000 ceiling", async () => {
+      (getVaultFromChain as Mock).mockResolvedValue({
+        ...ON_CHAIN_VAULT,
+        vaultProviderCommissionBps: 10000,
+      });
+
+      await expect(
+        prepareSigningContext({
+          vaultId: "vault_id",
+          depositorBtcPubkey: "depositor_pubkey",
+          registeredPayoutScriptPubKey: "0xscript",
+        }),
+      ).rejects.toThrow(
+        /VP commission 10000 bps out of protocol range \[10, 10000\)/,
+      );
+    });
+
+    it("uses 1 as the floor when minVpCommissionBps is 0", async () => {
+      // The contract permits minVpCommissionBps 0, but the Rust tx-graph
+      // builder refuses commission 0 — so the effective floor is max(0, 1).
+      mockGetOffchainParamsByVersion.mockResolvedValue({
+        timelockAssert: 144n,
+        securityCouncilKeys: ["0xcouncil2", "0xcouncil1"],
+        councilQuorum: 1,
+        minVpCommissionBps: 0,
+      });
+      (getVaultFromChain as Mock).mockResolvedValue({
+        ...ON_CHAIN_VAULT,
+        vaultProviderCommissionBps: 0,
+      });
+
+      await expect(
+        prepareSigningContext({
+          vaultId: "vault_id",
+          depositorBtcPubkey: "depositor_pubkey",
+          registeredPayoutScriptPubKey: "0xscript",
+        }),
+      ).rejects.toThrow(
+        /VP commission 0 bps out of protocol range \[1, 10000\)/,
+      );
     });
 
     it("accepts a caller-provided VP pubkey hint when it matches on-chain", async () => {

--- a/services/vault/src/services/vault/vaultPayoutSignatureService.ts
+++ b/services/vault/src/services/vault/vaultPayoutSignatureService.ts
@@ -36,6 +36,24 @@ import {
 } from "../../clients/eth-contract/sdk-readers";
 import { getBTCNetworkForWASM } from "../../config/pegin";
 
+/**
+ * Exclusive upper bound on VP commission (basis points). Matches the
+ * `BTCVaultRegistry._validateCommission` ceiling (`commissionBps >= 10000`
+ * reverts) and the basis-points denominator used to size the commission
+ * output.
+ */
+const VP_COMMISSION_BPS_EXCLUSIVE_MAX = 10_000;
+
+/**
+ * Absolute floor on a realizable VP commission. The contract permits
+ * `VersionedOffchainParams.minVpCommissionBps` to be `0`, but the Rust
+ * tx-graph builder (`btc-vault crates/vault/src/tx_graph/config.rs`) refuses
+ * to construct a graph with `vp_commission_bps == 0`. So a vault that can
+ * actually produce a VP-claimer payout always has commission `>= 1`; the
+ * effective floor is `max(minVpCommissionBps, 1)`.
+ */
+const MIN_REALIZABLE_VP_COMMISSION_BPS = 1;
+
 export interface PayoutVaultKeeper {
   btcPubKey: string;
 }
@@ -71,6 +89,11 @@ export interface SigningContext {
   network: Network;
   /** On-chain registered depositor payout scriptPubKey (hex) for payout output validation */
   registeredPayoutScriptPubKey: string;
+  /**
+   * VP commission in basis points (`1..=9999`) from BTCVaultRegistry.
+   * Forwarded to `buildPayoutPsbt` to cap the VP-claimer commission output.
+   */
+  commissionBps: number;
 }
 
 export interface PreparedSigningData {
@@ -141,6 +164,29 @@ export async function prepareSigningContext(
   const timelockPegin = await protocolParamsReader.getTimelockPeginByVersion(
     vault.offchainParamsVersion,
   );
+
+  // Trust-boundary check on the VP commission read from chain. Mirrors the
+  // contract's own `BTCVaultRegistry._validateCommission`: `commissionBps`
+  // must be `>= minVpCommissionBps` (version-locked) and `< 10000`. The
+  // floor is `max(minVpCommissionBps, 1)` because the Rust tx-graph builder
+  // refuses `vp_commission_bps == 0`. Validating here means the SDK's
+  // `buildPayoutPsbt` can trust `commissionBps` for its cap math.
+  const minCommissionBps = Math.max(
+    offchainParams.minVpCommissionBps,
+    MIN_REALIZABLE_VP_COMMISSION_BPS,
+  );
+  if (
+    !Number.isInteger(vault.vaultProviderCommissionBps) ||
+    vault.vaultProviderCommissionBps < minCommissionBps ||
+    vault.vaultProviderCommissionBps >= VP_COMMISSION_BPS_EXCLUSIVE_MAX
+  ) {
+    throw new Error(
+      `VP commission ${vault.vaultProviderCommissionBps} bps out of protocol ` +
+        `range [${minCommissionBps}, ${VP_COMMISSION_BPS_EXCLUSIVE_MAX}) ` +
+        `for offchain params version ${vault.offchainParamsVersion}`,
+    );
+  }
+
   const councilMembers = offchainParams.securityCouncilKeys
     .map((k) => stripHexPrefix(k))
     .sort();
@@ -192,6 +238,7 @@ export async function prepareSigningContext(
       councilQuorum: offchainParams.councilQuorum,
       network: getBTCNetworkForWASM(),
       registeredPayoutScriptPubKey,
+      commissionBps: vault.vaultProviderCommissionBps,
     },
     vaultProviderAddress: vault.vaultProvider,
   };

--- a/services/vault/src/services/vault/vaultPayoutSignatureService.ts
+++ b/services/vault/src/services/vault/vaultPayoutSignatureService.ts
@@ -37,20 +37,16 @@ import {
 import { getBTCNetworkForWASM } from "../../config/pegin";
 
 /**
- * Exclusive upper bound on VP commission (basis points). Matches the
- * `BTCVaultRegistry._validateCommission` ceiling (`commissionBps >= 10000`
- * reverts) and the basis-points denominator used to size the commission
- * output.
+ * Exclusive upper bound on VP commission (bps) — `BTCVaultRegistry._validateCommission`
+ * ceiling. Local literal by design: the SDK's `MAX_VP_COMMISSION_BPS_EXCLUSIVE`
+ * is an internal module, not public API.
  */
 const VP_COMMISSION_BPS_EXCLUSIVE_MAX = 10_000;
 
 /**
- * Absolute floor on a realizable VP commission. The contract permits
- * `VersionedOffchainParams.minVpCommissionBps` to be `0`, but the Rust
- * tx-graph builder (`btc-vault crates/vault/src/tx_graph/config.rs`) refuses
- * to construct a graph with `vp_commission_bps == 0`. So a vault that can
- * actually produce a VP-claimer payout always has commission `>= 1`; the
- * effective floor is `max(minVpCommissionBps, 1)`.
+ * Absolute floor on a realizable VP commission: the btc-vault tx-graph builder
+ * refuses `vp_commission_bps == 0`, so the effective floor is
+ * `max(minVpCommissionBps, 1)`.
  */
 const MIN_REALIZABLE_VP_COMMISSION_BPS = 1;
 
@@ -165,12 +161,8 @@ export async function prepareSigningContext(
     vault.offchainParamsVersion,
   );
 
-  // Trust-boundary check on the VP commission read from chain. Mirrors the
-  // contract's own `BTCVaultRegistry._validateCommission`: `commissionBps`
-  // must be `>= minVpCommissionBps` (version-locked) and `< 10000`. The
-  // floor is `max(minVpCommissionBps, 1)` because the Rust tx-graph builder
-  // refuses `vp_commission_bps == 0`. Validating here means the SDK's
-  // `buildPayoutPsbt` can trust `commissionBps` for its cap math.
+  // Trust-boundary check on the VP commission read from chain — mirrors
+  // `BTCVaultRegistry._validateCommission` so `buildPayoutPsbt` can trust it.
   const minCommissionBps = Math.max(
     offchainParams.minVpCommissionBps,
     MIN_REALIZABLE_VP_COMMISSION_BPS,


### PR DESCRIPTION
Closes [babylonlabs-io/baby-auditor-findings#147](https://github.com/babylonlabs-io/baby-auditor-findings/issues/147)

- Replaces the largest-output payout guard with a structural check: exact output count registered script at vout 0.
- Adds an implicit-fee bound inside `buildPayoutPsbt` (10% of inputs), resting on PR #1673's prevout binding.
- Call sites pass the canonical count: 3 for VP-claimer (`PayoutManager`), 2 for depositor-as-claimer (`signDepositorGraph`) — per `btc-vault crates/vault/src/transactions/payout.rs`.