### PR TITLE
fix(vault): group batched-pegin deposits under one broadcast action

### DIFF
--- a/services/vault/src/components/simple/BatchedDepositGroup.tsx
+++ b/services/vault/src/components/simple/BatchedDepositGroup.tsx
@@ -1,0 +1,114 @@
+/**
+ * BatchedDepositGroup Component
+ *
+ * Handles the set of vaults funded by one shared Pre-PegIn Bitcoin
+ * transaction (a batched pegin).
+ *
+ * While the shared Pre-PegIn still needs broadcasting, the vaults render
+ * inside a grouped container with the broadcast button hoisted to the
+ * group (one button for the batch) and suppressed on the inner cards.
+ *
+ * Once the broadcast is done the batch has no shared action left — every
+ * remaining step (WOTS, sign, activate) is per-vault — so the grouping
+ * chrome is dropped and the vaults render as standalone cards.
+ */
+
+import { Button } from "@babylonlabs-io/core-ui";
+
+import {
+  getActionStatus,
+  PeginAction,
+} from "@/components/deposit/actionStatus";
+import { usePeginPolling } from "@/context/deposit/PeginPollingContext";
+import { COPY } from "@/copy";
+import type { VaultActivity } from "@/types/activity";
+import type { VaultProvider } from "@/types/vaultProvider";
+
+import { PendingDepositCard } from "./PendingDepositCard";
+
+interface BatchedDepositGroupProps {
+  /** Sibling vaults sharing one Pre-PegIn transaction (2 or more). */
+  activities: VaultActivity[];
+  vaultProviders: VaultProvider[];
+  onSignClick: (depositId: string) => void;
+  onBroadcastClick: (depositId: string) => void;
+  onWotsKeyClick: (depositId: string) => void;
+  onActivationClick: (depositId: string) => void;
+  onRefundClick: (depositId: string) => void;
+  onArtifactDownloadClick?: (depositId: string) => void;
+}
+
+export function BatchedDepositGroup({
+  activities,
+  vaultProviders,
+  onSignClick,
+  onBroadcastClick,
+  onWotsKeyClick,
+  onActivationClick,
+  onRefundClick,
+  onArtifactDownloadClick,
+}: BatchedDepositGroupProps) {
+  const { getPollingResult } = usePeginPolling();
+
+  // A sibling still needs the shared Pre-PegIn broadcast. One broadcast
+  // covers the whole batch, so clicking the hoisted button routes through
+  // any pending sibling.
+  const broadcastTarget = activities.find((activity) => {
+    const result = getPollingResult(activity.id);
+    if (!result) return false;
+    const status = getActionStatus(result);
+    return (
+      status.type === "available" &&
+      status.action.action === PeginAction.SIGN_AND_BROADCAST_TO_BITCOIN
+    );
+  });
+
+  const renderCard = (activity: VaultActivity, suppressBroadcast: boolean) => (
+    <PendingDepositCard
+      key={activity.id}
+      depositId={activity.id}
+      amount={activity.collateral.amount}
+      timestamp={activity.timestamp}
+      txHash={activity.peginTxHash}
+      providerId={activity.providers[0].id}
+      vaultProviders={vaultProviders}
+      suppressBroadcastAction={suppressBroadcast}
+      onSignClick={onSignClick}
+      onBroadcastClick={onBroadcastClick}
+      onWotsKeyClick={onWotsKeyClick}
+      onActivationClick={onActivationClick}
+      onRefundClick={onRefundClick}
+      onArtifactDownloadClick={onArtifactDownloadClick}
+    />
+  );
+
+  // Broadcast done — no shared action remains. Render the vaults as
+  // standalone cards, same as any non-batched deposit.
+  if (!broadcastTarget) {
+    return <>{activities.map((activity) => renderCard(activity, false))}</>;
+  }
+
+  return (
+    <div className="rounded-xl border border-accent-primary bg-primary-light/10 p-3">
+      <span className="mb-2 block text-xs text-accent-secondary">
+        {COPY.pegin.batchedDeposit.groupLabel}
+      </span>
+      <div className="space-y-3">
+        {activities.map((activity) => renderCard(activity, true))}
+      </div>
+      <div className="mt-3">
+        <Button
+          variant="contained"
+          color="primary"
+          className="w-full rounded-full"
+          onClick={() => onBroadcastClick(broadcastTarget.id)}
+        >
+          {COPY.pegin.primaryAction.SIGN_AND_BROADCAST_TO_BITCOIN}
+        </Button>
+        <span className="mt-2 block text-center text-xs text-accent-secondary">
+          {COPY.pegin.batchedDeposit.broadcastHelper}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/services/vault/src/components/simple/PendingDepositCard.tsx
+++ b/services/vault/src/components/simple/PendingDepositCard.tsx
@@ -34,6 +34,13 @@ interface PendingDepositCardProps {
   onActivationClick: (depositId: string) => void;
   onRefundClick: (depositId: string) => void;
   onArtifactDownloadClick?: (depositId: string) => void;
+  /**
+   * When true, the Pre-PegIn broadcast button is not rendered on this card.
+   * Set when the card sits inside a BatchedDepositGroup, where the broadcast
+   * is a batch-level action hoisted to the group. Other per-vault actions
+   * (sign, WOTS, activate, refund) still render.
+   */
+  suppressBroadcastAction?: boolean;
 }
 
 export function PendingDepositCard({
@@ -49,6 +56,7 @@ export function PendingDepositCard({
   onActivationClick,
   onRefundClick,
   onArtifactDownloadClick,
+  suppressBroadcastAction,
 }: PendingDepositCardProps) {
   const pollingResult = useDepositPollingResult(depositId);
 
@@ -56,7 +64,14 @@ export function PendingDepositCard({
 
   const { loading, peginState } = pollingResult;
   const status = getActionStatus(pollingResult);
-  const isActionable = status.type === "available";
+  // The Pre-PegIn broadcast is batch-level: when this card is inside a
+  // BatchedDepositGroup the broadcast button is hoisted to the group and
+  // suppressed here. Other per-vault actions still render.
+  const broadcastSuppressed =
+    !!suppressBroadcastAction &&
+    status.type === "available" &&
+    status.action.action === PeginAction.SIGN_AND_BROADCAST_TO_BITCOIN;
+  const isActionable = status.type === "available" && !broadcastSuppressed;
   const showArtifactDownload =
     onArtifactDownloadClick && isArtifactDownloadAvailable(pollingResult);
 

--- a/services/vault/src/components/simple/PendingDepositModals.tsx
+++ b/services/vault/src/components/simple/PendingDepositModals.tsx
@@ -27,6 +27,8 @@ interface SignModalState {
 
 interface BroadcastModalState {
   broadcastingActivity: VaultActivity | null;
+  /** All vault IDs sharing the Pre-PegIn being broadcast (batched pegin). */
+  broadcastingBatchIds: string[];
   handleClose: () => void;
   handleSuccess: () => void;
   successOpen: boolean;
@@ -125,6 +127,7 @@ export function PendingDepositModals({
           onClose={broadcastModal.handleClose}
           onResumeSuccess={broadcastModal.handleSuccess}
           activity={broadcastModal.broadcastingActivity}
+          batchVaultIds={broadcastModal.broadcastingBatchIds}
           depositorEthAddress={ethAddress}
         />
       )}

--- a/services/vault/src/components/simple/PendingDepositSection.tsx
+++ b/services/vault/src/components/simple/PendingDepositSection.tsx
@@ -16,8 +16,10 @@ import { ExpandMenuButton } from "@/components/shared";
 import { getNetworkConfigBTC } from "@/config";
 import { PeginPollingProvider } from "@/context/deposit/PeginPollingContext";
 import { usePendingDeposits } from "@/hooks/usePendingDeposits";
+import { groupActivitiesByBatch } from "@/utils/batchedPegin";
 import { formatBtcAmount } from "@/utils/formatting";
 
+import { BatchedDepositGroup } from "./BatchedDepositGroup";
 import { ExpiredDepositSection } from "./ExpiredDepositSection";
 import { PendingDepositActionBadge } from "./PendingDepositActionBadge";
 import { PendingDepositCard } from "./PendingDepositCard";
@@ -52,6 +54,13 @@ export function PendingDepositSection() {
         (sum, a) => sum + parseFloat(a.collateral.amount || "0"),
         0,
       ),
+    [pendingActivities],
+  );
+
+  // Vaults sharing one Pre-PegIn transaction (a batched pegin) render
+  // together so the shared broadcast is a single batch-level action.
+  const pendingGroups = useMemo(
+    () => groupActivitiesByBatch(pendingActivities),
     [pendingActivities],
   );
 
@@ -106,25 +115,45 @@ export function PendingDepositSection() {
               {/* Expanded deposit list */}
               {isExpanded && (
                 <div className="mt-4 max-h-[400px] space-y-3 overflow-y-auto">
-                  {pendingActivities.map((activity) => (
-                    <PendingDepositCard
-                      key={activity.id}
-                      depositId={activity.id}
-                      amount={activity.collateral.amount}
-                      timestamp={activity.timestamp}
-                      txHash={activity.peginTxHash}
-                      providerId={activity.providers[0].id}
-                      vaultProviders={vaultProviders}
-                      onSignClick={signModal.handleSignClick}
-                      onBroadcastClick={broadcastModal.handleBroadcastClick}
-                      onWotsKeyClick={wotsKeyModal.handleWotsKeyClick}
-                      onActivationClick={activationModal.handleActivationClick}
-                      onRefundClick={refundModal.handleRefundClick}
-                      onArtifactDownloadClick={
-                        artifactDownloadModal.handleArtifactDownloadClick
-                      }
-                    />
-                  ))}
+                  {pendingGroups.map((group) =>
+                    group.length > 1 ? (
+                      <BatchedDepositGroup
+                        key={group[0].id}
+                        activities={group}
+                        vaultProviders={vaultProviders}
+                        onSignClick={signModal.handleSignClick}
+                        onBroadcastClick={broadcastModal.handleBroadcastClick}
+                        onWotsKeyClick={wotsKeyModal.handleWotsKeyClick}
+                        onActivationClick={
+                          activationModal.handleActivationClick
+                        }
+                        onRefundClick={refundModal.handleRefundClick}
+                        onArtifactDownloadClick={
+                          artifactDownloadModal.handleArtifactDownloadClick
+                        }
+                      />
+                    ) : (
+                      <PendingDepositCard
+                        key={group[0].id}
+                        depositId={group[0].id}
+                        amount={group[0].collateral.amount}
+                        timestamp={group[0].timestamp}
+                        txHash={group[0].peginTxHash}
+                        providerId={group[0].providers[0].id}
+                        vaultProviders={vaultProviders}
+                        onSignClick={signModal.handleSignClick}
+                        onBroadcastClick={broadcastModal.handleBroadcastClick}
+                        onWotsKeyClick={wotsKeyModal.handleWotsKeyClick}
+                        onActivationClick={
+                          activationModal.handleActivationClick
+                        }
+                        onRefundClick={refundModal.handleRefundClick}
+                        onArtifactDownloadClick={
+                          artifactDownloadModal.handleArtifactDownloadClick
+                        }
+                      />
+                    ),
+                  )}
                 </div>
               )}
             </Card>

--- a/services/vault/src/components/simple/ResumeDepositContent.tsx
+++ b/services/vault/src/components/simple/ResumeDepositContent.tsx
@@ -105,6 +105,11 @@ export function ResumeSignContent({
 
 export interface ResumeBroadcastContentProps {
   activity: VaultActivity;
+  /**
+   * Every vault ID sharing this Pre-PegIn transaction (batched pegin).
+   * Includes `activity.id`. The broadcast confirms all of them.
+   */
+  batchVaultIds: string[];
   depositorEthAddress: string;
   onClose: () => void;
   onSuccess: () => void;
@@ -112,12 +117,14 @@ export interface ResumeBroadcastContentProps {
 
 export function ResumeBroadcastContent({
   activity,
+  batchVaultIds,
   depositorEthAddress,
   onClose,
   onSuccess,
 }: ResumeBroadcastContentProps) {
   const { broadcasting, error, handleBroadcast } = useBroadcastState({
     activity,
+    batchVaultIds,
     depositorEthAddress,
     onSuccess,
   });

--- a/services/vault/src/components/simple/SimpleDeposit.tsx
+++ b/services/vault/src/components/simple/SimpleDeposit.tsx
@@ -55,6 +55,12 @@ type ResumeSignProps = SimpleDepositBaseProps & {
 type ResumeBroadcastProps = SimpleDepositBaseProps & {
   resumeMode: "broadcast_btc";
   activity: VaultActivity;
+  /**
+   * Every vault ID sharing this Pre-PegIn transaction (batched pegin).
+   * Includes `activity.id`; a standalone deposit is a single-element list.
+   * The broadcast confirms all of them.
+   */
+  batchVaultIds: string[];
   depositorEthAddress: string;
   onResumeSuccess: () => void;
 };
@@ -402,6 +408,7 @@ export default function SimpleDeposit(props: SimpleDepositProps) {
             ) : (
               <ResumeBroadcastContent
                 activity={props.activity}
+                batchVaultIds={props.batchVaultIds}
                 depositorEthAddress={props.depositorEthAddress}
                 onClose={onClose}
                 onSuccess={props.onResumeSuccess}

--- a/services/vault/src/components/simple/__tests__/BatchedDepositGroup.test.tsx
+++ b/services/vault/src/components/simple/__tests__/BatchedDepositGroup.test.tsx
@@ -1,0 +1,147 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ActionStatus } from "@/components/deposit/actionStatus";
+import { PeginAction } from "@/components/deposit/actionStatus";
+import { COPY } from "@/copy";
+import type { VaultActivity } from "@/types/activity";
+
+import { BatchedDepositGroup } from "../BatchedDepositGroup";
+
+const mockGetPollingResult = vi.fn();
+const mockGetActionStatus = vi.fn();
+
+vi.mock("@/context/deposit/PeginPollingContext", () => ({
+  usePeginPolling: () => ({ getPollingResult: mockGetPollingResult }),
+}));
+
+vi.mock("@/components/deposit/actionStatus", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/components/deposit/actionStatus")>();
+  return {
+    ...actual,
+    getActionStatus: (...args: unknown[]) => mockGetActionStatus(...args),
+  };
+});
+
+// Stub the inner card — this suite covers the group wrapper, not the card.
+vi.mock("../PendingDepositCard", () => ({
+  PendingDepositCard: ({
+    depositId,
+    suppressBroadcastAction,
+  }: {
+    depositId: string;
+    suppressBroadcastAction?: boolean;
+  }) => (
+    <div
+      data-testid="deposit-card"
+      data-deposit-id={depositId}
+      data-suppressed={String(!!suppressBroadcastAction)}
+    />
+  ),
+}));
+
+function activity(id: string): VaultActivity {
+  return {
+    id: id as VaultActivity["id"],
+    collateral: { amount: "0.01", symbol: "BTC" },
+    providers: [{ id: "0xprovider" }],
+    displayLabel: "Pending" as VaultActivity["displayLabel"],
+    unsignedPrePeginTx: "0xdeadbeef",
+    depositorWotsPkHash: "0xwots",
+  };
+}
+
+const BROADCAST_AVAILABLE: ActionStatus = {
+  type: "available",
+  action: {
+    action: PeginAction.SIGN_AND_BROADCAST_TO_BITCOIN,
+    label: "Broadcast Pre-Pegin",
+  },
+};
+const NO_ACTION: ActionStatus = { type: "unavailable", reasons: [] };
+
+function renderGroup(activities: VaultActivity[], onBroadcastClick = vi.fn()) {
+  render(
+    <BatchedDepositGroup
+      activities={activities}
+      vaultProviders={[]}
+      onSignClick={vi.fn()}
+      onBroadcastClick={onBroadcastClick}
+      onWotsKeyClick={vi.fn()}
+      onActivationClick={vi.fn()}
+      onRefundClick={vi.fn()}
+    />,
+  );
+  return { onBroadcastClick };
+}
+
+describe("BatchedDepositGroup", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetPollingResult.mockReturnValue({ some: "result" });
+  });
+
+  it("groups siblings with a hoisted broadcast button while the broadcast is pending", () => {
+    mockGetActionStatus.mockReturnValue(BROADCAST_AVAILABLE);
+    renderGroup([activity("0xa"), activity("0xb")]);
+
+    expect(
+      screen.getByText(COPY.pegin.batchedDeposit.groupLabel),
+    ).toBeInTheDocument();
+
+    const cards = screen.getAllByTestId("deposit-card");
+    expect(cards).toHaveLength(2);
+    expect(cards.map((c) => c.dataset.depositId)).toEqual(["0xa", "0xb"]);
+    expect(cards.every((c) => c.dataset.suppressed === "true")).toBe(true);
+
+    expect(
+      screen.getByRole("button", { name: /broadcast pre-pegin/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("routes a hoisted broadcast click through a sibling that still needs broadcast", () => {
+    // First sibling already broadcast, second still pending.
+    mockGetActionStatus.mockImplementation((result: unknown) =>
+      (result as { pending?: boolean }).pending
+        ? BROADCAST_AVAILABLE
+        : NO_ACTION,
+    );
+    mockGetPollingResult.mockImplementation((id: string) => ({
+      pending: id === "0xb",
+    }));
+
+    const { onBroadcastClick } = renderGroup([
+      activity("0xa"),
+      activity("0xb"),
+    ]);
+
+    // A partly-broadcast batch stays grouped while any sibling is pending.
+    expect(
+      screen.getByText(COPY.pegin.batchedDeposit.groupLabel),
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /broadcast pre-pegin/i }),
+    );
+    expect(onBroadcastClick).toHaveBeenCalledWith("0xb");
+  });
+
+  it("dissolves into standalone cards once the broadcast is done", () => {
+    // No sibling needs broadcast — the batch has no shared action left, so
+    // the grouping chrome and hoisted button are dropped.
+    mockGetActionStatus.mockReturnValue(NO_ACTION);
+    renderGroup([activity("0xa"), activity("0xb")]);
+
+    expect(
+      screen.queryByText(COPY.pegin.batchedDeposit.groupLabel),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /broadcast pre-pegin/i }),
+    ).not.toBeInTheDocument();
+
+    const cards = screen.getAllByTestId("deposit-card");
+    expect(cards).toHaveLength(2);
+    expect(cards.every((c) => c.dataset.suppressed === "false")).toBe(true);
+  });
+});

--- a/services/vault/src/components/simple/__tests__/PendingDepositCard.test.tsx
+++ b/services/vault/src/components/simple/__tests__/PendingDepositCard.test.tsx
@@ -1,0 +1,112 @@
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ActionStatus } from "@/components/deposit/actionStatus";
+import { PeginAction } from "@/components/deposit/actionStatus";
+
+import { PendingDepositCard } from "../PendingDepositCard";
+
+const mockUseDepositPollingResult = vi.fn();
+const mockGetActionStatus = vi.fn();
+const mockIsArtifactDownloadAvailable = vi.fn(() => false);
+
+vi.mock("@/context/deposit/PeginPollingContext", () => ({
+  useDepositPollingResult: (id: string) => mockUseDepositPollingResult(id),
+}));
+
+vi.mock("@/components/deposit/actionStatus", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/components/deposit/actionStatus")>();
+  return {
+    ...actual,
+    getActionStatus: (...args: unknown[]) => mockGetActionStatus(...args),
+    isArtifactDownloadAvailable: () => mockIsArtifactDownloadAvailable(),
+  };
+});
+
+// Stub the layout card — expose the `action` slot so the test can assert
+// whether an action button was passed in.
+vi.mock("../VaultDetailCard", () => ({
+  VaultDetailCard: ({ action }: { action?: ReactNode }) => (
+    <div data-testid="vault-detail-card">{action}</div>
+  ),
+  VaultStatusBadge: () => <div data-testid="status-badge" />,
+}));
+
+const POLLING_RESULT = {
+  loading: false,
+  peginState: {
+    displayLabel: "Pending",
+    displayVariant: "pending",
+    message: undefined,
+  },
+};
+
+function broadcastAvailable(): ActionStatus {
+  return {
+    type: "available",
+    action: {
+      action: PeginAction.SIGN_AND_BROADCAST_TO_BITCOIN,
+      label: "Broadcast Pre-Pegin",
+    },
+  };
+}
+
+function activateAvailable(): ActionStatus {
+  return {
+    type: "available",
+    action: { action: PeginAction.ACTIVATE_VAULT, label: "Activate" },
+  };
+}
+
+function renderCard(suppressBroadcastAction: boolean) {
+  render(
+    <PendingDepositCard
+      depositId="0xvault"
+      amount="0.05"
+      providerId="0xprovider"
+      vaultProviders={[]}
+      onSignClick={vi.fn()}
+      onBroadcastClick={vi.fn()}
+      onWotsKeyClick={vi.fn()}
+      onActivationClick={vi.fn()}
+      onRefundClick={vi.fn()}
+      suppressBroadcastAction={suppressBroadcastAction}
+    />,
+  );
+}
+
+describe("PendingDepositCard — suppressBroadcastAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseDepositPollingResult.mockReturnValue(POLLING_RESULT);
+    mockIsArtifactDownloadAvailable.mockReturnValue(false);
+  });
+
+  it("hides the broadcast button when suppressBroadcastAction is set", () => {
+    mockGetActionStatus.mockReturnValue(broadcastAvailable());
+    renderCard(true);
+    expect(
+      screen.queryByRole("button", { name: /broadcast pre-pegin/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the broadcast button when suppressBroadcastAction is not set", () => {
+    mockGetActionStatus.mockReturnValue(broadcastAvailable());
+    renderCard(false);
+    expect(
+      screen.getByRole("button", { name: /broadcast pre-pegin/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("still renders a non-broadcast action when suppressBroadcastAction is set", () => {
+    // Suppression is scoped to the batch-level broadcast only — per-vault
+    // actions such as activation must still surface on the card.
+    mockGetActionStatus.mockReturnValue(activateAvailable());
+    renderCard(true);
+    expect(
+      screen.getByRole("button", { name: /activate/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -115,6 +115,10 @@ export const COPY = {
         prefix: "Expired",
       },
     },
+    batchedDeposit: {
+      groupLabel: "Batched deposit",
+      broadcastHelper: "Broadcasts once for all vaults in this deposit",
+    },
   },
   deposit: {
     steps: {

--- a/services/vault/src/hooks/__tests__/usePendingDeposits.test.tsx
+++ b/services/vault/src/hooks/__tests__/usePendingDeposits.test.tsx
@@ -51,6 +51,7 @@ vi.mock("@/hooks/deposit/usePayoutSignModal", () => ({
 vi.mock("@/hooks/deposit/useBroadcastModal", () => ({
   useBroadcastModal: vi.fn(() => ({
     broadcastingActivity: null,
+    broadcastingBatchIds: [],
     handleBroadcastClick: vi.fn(),
     handleClose: vi.fn(),
     handleSuccess: vi.fn(),

--- a/services/vault/src/hooks/deposit/__tests__/useBroadcastModal.test.ts
+++ b/services/vault/src/hooks/deposit/__tests__/useBroadcastModal.test.ts
@@ -1,0 +1,69 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { VaultActivity } from "@/types/activity";
+
+import { useBroadcastModal } from "../useBroadcastModal";
+
+function activity(
+  id: string,
+  unsignedPrePeginTx: string,
+  amount: string,
+): VaultActivity {
+  return {
+    id: id as VaultActivity["id"],
+    collateral: { amount, symbol: "BTC" },
+    providers: [{ id: "0xprovider" }],
+    displayLabel: "Pending" as VaultActivity["displayLabel"],
+    unsignedPrePeginTx,
+    depositorWotsPkHash: "0xwots",
+  };
+}
+
+describe("useBroadcastModal", () => {
+  it("resolves every sibling sharing the Pre-PegIn when a batched vault is clicked", () => {
+    const a = activity("0xa", "0xshared", "0.05");
+    const b = activity("0xb", "0xshared", "0.03");
+    const c = activity("0xc", "0xother", "0.10");
+
+    const { result } = renderHook(() =>
+      useBroadcastModal({ allActivities: [a, b, c], onSuccess: vi.fn() }),
+    );
+
+    act(() => result.current.handleBroadcastClick("0xa"));
+
+    expect(result.current.broadcastingActivity).toBe(a);
+    expect(result.current.broadcastingBatchIds).toEqual(["0xa", "0xb"]);
+    expect(result.current.isOpen).toBe(true);
+  });
+
+  it("resolves a single-vault batch for a standalone deposit", () => {
+    const a = activity("0xa", "0xshared", "0.05");
+    const c = activity("0xc", "0xother", "0.10");
+
+    const { result } = renderHook(() =>
+      useBroadcastModal({ allActivities: [a, c], onSuccess: vi.fn() }),
+    );
+
+    act(() => result.current.handleBroadcastClick("0xc"));
+
+    expect(result.current.broadcastingBatchIds).toEqual(["0xc"]);
+  });
+
+  it("sums the batch amounts for the success modal", () => {
+    const onSuccess = vi.fn();
+    const a = activity("0xa", "0xshared", "0.05");
+    const b = activity("0xb", "0xshared", "0.03");
+
+    const { result } = renderHook(() =>
+      useBroadcastModal({ allActivities: [a, b], onSuccess }),
+    );
+
+    act(() => result.current.handleBroadcastClick("0xa"));
+    act(() => result.current.handleSuccess());
+
+    expect(result.current.successAmount).toBe("0.08");
+    expect(result.current.successOpen).toBe(true);
+    expect(onSuccess).toHaveBeenCalledOnce();
+  });
+});

--- a/services/vault/src/hooks/deposit/__tests__/useBroadcastState.test.ts
+++ b/services/vault/src/hooks/deposit/__tests__/useBroadcastState.test.ts
@@ -1,0 +1,108 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { LocalStorageStatus } from "@/models/peginStateMachine";
+import type { VaultActivity } from "@/types/activity";
+
+import { useBroadcastState } from "../useBroadcastState";
+
+const mockVaultHandleBroadcast = vi.fn();
+const mockSetOptimisticStatus = vi.fn();
+const mockUpdatePendingPeginStatus = vi.fn();
+
+vi.mock("../useVaultActions", () => ({
+  useVaultActions: () => ({
+    broadcasting: false,
+    broadcastError: null,
+    handleBroadcast: mockVaultHandleBroadcast,
+  }),
+}));
+
+vi.mock("@/context/deposit/PeginPollingContext", () => ({
+  usePeginPolling: () => ({ setOptimisticStatus: mockSetOptimisticStatus }),
+}));
+
+vi.mock("@/storage/usePeginStorage", () => ({
+  usePeginStorage: () => ({
+    pendingPegins: [],
+    updatePendingPeginStatus: mockUpdatePendingPeginStatus,
+  }),
+}));
+
+vi.mock("@/infrastructure", () => ({
+  logger: { error: vi.fn() },
+}));
+
+function activity(id: string): VaultActivity {
+  return {
+    id: id as VaultActivity["id"],
+    collateral: { amount: "0.01", symbol: "BTC" },
+    providers: [{ id: "0xprovider" }],
+    displayLabel: "Pending" as VaultActivity["displayLabel"],
+    unsignedPrePeginTx: "0xdeadbeef",
+    depositorWotsPkHash: "0xwots",
+  };
+}
+
+describe("useBroadcastState — batched broadcast", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("marks every batch sibling CONFIRMING after a successful broadcast", async () => {
+    // A batched broadcast confirms every sibling at once — the success
+    // callback must propagate CONFIRMING to all of them, not just the
+    // clicked vault.
+    mockVaultHandleBroadcast.mockImplementation(
+      async (params: { onShowSuccessModal: () => void }) => {
+        params.onShowSuccessModal();
+      },
+    );
+    const onSuccess = vi.fn();
+
+    const { result } = renderHook(() =>
+      useBroadcastState({
+        activity: activity("0xa"),
+        batchVaultIds: ["0xa", "0xb"],
+        depositorEthAddress: "0xdepositor",
+        onSuccess,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.handleBroadcast();
+    });
+
+    for (const id of ["0xa", "0xb"]) {
+      expect(mockUpdatePendingPeginStatus).toHaveBeenCalledWith(
+        id,
+        LocalStorageStatus.CONFIRMING,
+      );
+      expect(mockSetOptimisticStatus).toHaveBeenCalledWith(
+        id,
+        LocalStorageStatus.CONFIRMING,
+      );
+    }
+    expect(onSuccess).toHaveBeenCalledOnce();
+  });
+
+  it("broadcasts the shared transaction once for the whole batch", () => {
+    mockVaultHandleBroadcast.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() =>
+      useBroadcastState({
+        activity: activity("0xa"),
+        batchVaultIds: ["0xa", "0xb"],
+        depositorEthAddress: "0xdepositor",
+        onSuccess: vi.fn(),
+      }),
+    );
+
+    act(() => {
+      void result.current.handleBroadcast();
+    });
+
+    expect(mockVaultHandleBroadcast).toHaveBeenCalledTimes(1);
+    expect(mockVaultHandleBroadcast.mock.calls[0][0].vaultId).toBe("0xa");
+  });
+});

--- a/services/vault/src/hooks/deposit/useBroadcastModal.ts
+++ b/services/vault/src/hooks/deposit/useBroadcastModal.ts
@@ -1,12 +1,19 @@
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 
 import type { VaultActivity } from "../../types/activity";
+import { getBatchSiblings } from "../../utils/batchedPegin";
+import { formatBtcValue } from "../../utils/formatting";
 
 /**
  * Hook to manage broadcast modal state and actions
  *
  * Provides state and callbacks for opening/closing the broadcast modal
  * and handling successful broadcast submission.
+ *
+ * A batched pegin shares one Pre-PegIn transaction across vaults, so a
+ * broadcast commits the whole batch. The modal therefore tracks every
+ * sibling: `broadcastingActivity` is the representative vault driving the
+ * resume UI, `broadcastingBatchIds` are all vaults the broadcast confirms.
  */
 export function useBroadcastModal(options: {
   allActivities: VaultActivity[];
@@ -14,43 +21,55 @@ export function useBroadcastModal(options: {
 }) {
   const { allActivities, onSuccess } = options;
 
-  const [broadcastingActivity, setBroadcastingActivity] =
-    useState<VaultActivity | null>(null);
+  const [broadcastingBatch, setBroadcastingBatch] = useState<
+    VaultActivity[] | null
+  >(null);
   const [successOpen, setSuccessOpen] = useState(false);
   const [successAmount, setSuccessAmount] = useState("");
 
-  // Handle clicking "Broadcast" button from table row
+  // Handle clicking "Broadcast" button from a deposit card or batch group
   const handleBroadcastClick = useCallback(
     (depositId: string) => {
       const activity = allActivities.find((a) => a.id === depositId);
-      if (activity) {
-        setBroadcastingActivity(activity);
-      }
+      if (!activity) return;
+      // Resolve every sibling sharing this Pre-PegIn tx — broadcasting it
+      // commits all of them. A standalone deposit resolves to one vault.
+      setBroadcastingBatch(getBatchSiblings(allActivities, activity));
     },
     [allActivities],
   );
 
   // Handle broadcast modal close
   const handleClose = useCallback(() => {
-    setBroadcastingActivity(null);
+    setBroadcastingBatch(null);
   }, []);
 
   // Handle broadcast success
   const handleSuccess = useCallback(() => {
-    setSuccessAmount(broadcastingActivity?.collateral.amount || "");
-    setBroadcastingActivity(null);
+    const totalBtc = (broadcastingBatch ?? []).reduce(
+      (sum, a) => sum + parseFloat(a.collateral.amount || "0"),
+      0,
+    );
+    setSuccessAmount(formatBtcValue(totalBtc));
+    setBroadcastingBatch(null);
     setSuccessOpen(true);
     onSuccess();
-  }, [broadcastingActivity, onSuccess]);
+  }, [broadcastingBatch, onSuccess]);
 
   // Handle success modal close
   const handleSuccessClose = useCallback(() => {
     setSuccessOpen(false);
   }, []);
 
+  const broadcastingBatchIds = useMemo(
+    () => broadcastingBatch?.map((a) => a.id) ?? [],
+    [broadcastingBatch],
+  );
+
   return {
-    broadcastingActivity,
-    isOpen: !!broadcastingActivity,
+    broadcastingActivity: broadcastingBatch?.[0] ?? null,
+    broadcastingBatchIds,
+    isOpen: !!broadcastingBatch,
     successOpen,
     successAmount,
     handleBroadcastClick,

--- a/services/vault/src/hooks/deposit/useBroadcastState.ts
+++ b/services/vault/src/hooks/deposit/useBroadcastState.ts
@@ -24,6 +24,12 @@ const EMPTY_CONFIRMED: VaultActivity[] = [];
 
 export interface UseBroadcastStateProps {
   activity: VaultActivity;
+  /**
+   * Every vault ID sharing this Pre-PegIn transaction (batched pegin).
+   * Includes `activity.id`. A single broadcast confirms all of them, so
+   * all are marked CONFIRMING on success.
+   */
+  batchVaultIds: string[];
   depositorEthAddress: string;
   onSuccess: () => void;
 }
@@ -39,6 +45,7 @@ export interface UseBroadcastStateResult {
 
 export function useBroadcastState({
   activity,
+  batchVaultIds,
   depositorEthAddress,
   onSuccess,
 }: UseBroadcastStateProps): UseBroadcastStateResult {
@@ -71,7 +78,13 @@ export function useBroadcastState({
           // status update below provides immediate UI feedback.
         },
         onShowSuccessModal: () => {
-          setOptimisticStatus(activity.id, LocalStorageStatus.CONFIRMING);
+          // A batched pegin shares one Pre-PegIn tx — this single broadcast
+          // confirms every sibling. Mark them all CONFIRMING (localStorage +
+          // optimistic) so no sibling keeps showing a stale broadcast action.
+          for (const id of batchVaultIds) {
+            updatePendingPeginStatus(id, LocalStorageStatus.CONFIRMING);
+            setOptimisticStatus(id, LocalStorageStatus.CONFIRMING);
+          }
           setLocalBroadcasting(false);
           onSuccess();
         },
@@ -84,6 +97,7 @@ export function useBroadcastState({
     }
   }, [
     activity,
+    batchVaultIds,
     pendingPegins,
     updatePendingPeginStatus,
     vaultHandleBroadcast,

--- a/services/vault/src/utils/__tests__/batchedPegin.test.ts
+++ b/services/vault/src/utils/__tests__/batchedPegin.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import type { VaultActivity } from "@/types/activity";
+
+import { getBatchSiblings, groupActivitiesByBatch } from "../batchedPegin";
+
+/** Minimal VaultActivity carrying only the fields batch-grouping reads. */
+function activity(id: string, unsignedPrePeginTx: string): VaultActivity {
+  return {
+    id: id as VaultActivity["id"],
+    collateral: { amount: "0.01", symbol: "BTC" },
+    providers: [{ id: "0xprovider" }],
+    displayLabel: "Pending" as VaultActivity["displayLabel"],
+    unsignedPrePeginTx,
+    depositorWotsPkHash: "0xwots",
+  };
+}
+
+describe("groupActivitiesByBatch", () => {
+  it("groups vaults sharing one Pre-PegIn transaction into a single batch", () => {
+    const a = activity("0xa", "0xdeadbeef");
+    const b = activity("0xb", "0xdeadbeef");
+    const groups = groupActivitiesByBatch([a, b]);
+    expect(groups).toEqual([[a, b]]);
+  });
+
+  it("keeps vaults with distinct Pre-PegIn transactions in separate groups", () => {
+    const a = activity("0xa", "0xaaaa");
+    const b = activity("0xb", "0xbbbb");
+    const groups = groupActivitiesByBatch([a, b]);
+    expect(groups).toEqual([[a], [b]]);
+  });
+
+  it("matches the Pre-PegIn hex regardless of 0x prefix or case", () => {
+    const a = activity("0xa", "0xDEADBEEF");
+    const b = activity("0xb", "deadbeef");
+    const groups = groupActivitiesByBatch([a, b]);
+    expect(groups).toEqual([[a, b]]);
+  });
+
+  it("does not group activities whose Pre-PegIn hex is the empty cross-device marker", () => {
+    // An empty unsignedPrePeginTx is the "no local tx" marker — two such
+    // activities are unrelated deposits, not a batch.
+    const a = activity("0xa", "");
+    const b = activity("0xb", "");
+    const groups = groupActivitiesByBatch([a, b]);
+    expect(groups).toEqual([[a], [b]]);
+  });
+
+  it("preserves first-occurrence order of batches", () => {
+    const a1 = activity("0xa1", "0xaaaa");
+    const b1 = activity("0xb1", "0xbbbb");
+    const a2 = activity("0xa2", "0xaaaa");
+    const groups = groupActivitiesByBatch([a1, b1, a2]);
+    expect(groups).toEqual([[a1, a2], [b1]]);
+  });
+});
+
+describe("getBatchSiblings", () => {
+  it("returns every vault sharing the Pre-PegIn transaction, including itself", () => {
+    const a = activity("0xa", "0xdeadbeef");
+    const b = activity("0xb", "0xdeadbeef");
+    const c = activity("0xc", "0xother");
+    expect(getBatchSiblings([a, b, c], a)).toEqual([a, b]);
+  });
+
+  it("returns only the activity itself when its Pre-PegIn transaction is unique", () => {
+    const a = activity("0xa", "0xaaaa");
+    const b = activity("0xb", "0xbbbb");
+    expect(getBatchSiblings([a, b], a)).toEqual([a]);
+  });
+
+  it("returns only the activity itself when its Pre-PegIn hex is empty", () => {
+    const a = activity("0xa", "");
+    const b = activity("0xb", "");
+    expect(getBatchSiblings([a, b], a)).toEqual([a]);
+  });
+});

--- a/services/vault/src/utils/batchedPegin.ts
+++ b/services/vault/src/utils/batchedPegin.ts
@@ -1,0 +1,61 @@
+/**
+ * Batched-pegin grouping.
+ *
+ * A batched pegin funds multiple vaults from one shared Pre-PegIn Bitcoin
+ * transaction. Vaults that share the same `unsignedPrePeginTx` therefore
+ * belong to the same batch, and broadcasting that single transaction
+ * commits all of them at once.
+ */
+
+import type { VaultActivity } from "@/types/activity";
+
+/** Normalize a Pre-PegIn tx hex for batch-grouping comparison. */
+function normalizePrePeginTx(hex: string): string {
+  const stripped = hex.startsWith("0x") ? hex.slice(2) : hex;
+  return stripped.toLowerCase();
+}
+
+/**
+ * Group key for an activity. Activities with a non-empty Pre-PegIn tx are
+ * keyed by it; an empty hex is the cross-device "no local tx" marker and
+ * must never be treated as a shared batch key, so those stay standalone.
+ */
+function batchKey(activity: VaultActivity): string {
+  const normalized = normalizePrePeginTx(activity.unsignedPrePeginTx);
+  return normalized.length > 0 ? normalized : `standalone:${activity.id}`;
+}
+
+/**
+ * Group deposit activities into batches. Activities sharing one Pre-PegIn
+ * transaction land in the same group; a standalone deposit is a group of
+ * one. Group order follows the first occurrence of each batch in the input.
+ */
+export function groupActivitiesByBatch(
+  activities: VaultActivity[],
+): VaultActivity[][] {
+  const groups = new Map<string, VaultActivity[]>();
+  for (const activity of activities) {
+    const key = batchKey(activity);
+    const existing = groups.get(key);
+    if (existing) {
+      existing.push(activity);
+    } else {
+      groups.set(key, [activity]);
+    }
+  }
+  return [...groups.values()];
+}
+
+/**
+ * Return every activity sharing `activity`'s Pre-PegIn transaction,
+ * including `activity` itself. A standalone (or empty-hex) activity
+ * resolves to a single-element list.
+ */
+export function getBatchSiblings(
+  activities: VaultActivity[],
+  activity: VaultActivity,
+): VaultActivity[] {
+  const key = batchKey(activity);
+  if (key.startsWith("standalone:")) return [activity];
+  return activities.filter((a) => batchKey(a) === key);
+}


### PR DESCRIPTION
## Summary
- A batched pegin funds N vaults from one shared Pre-PegIn BTC transaction. Broadcasting it
commits the whole batch, but the dashboard rendered a "Broadcast Pre-Pegin" button per vault.
Clicking one broadcast both; clicking the other failed `assertUtxosAvailable` with a misleading
"create a new peg-in request" error.
- Deposit cards now group by their shared `unsignedPrePeginTx` (indexer-sourced — works
cross-device, no localStorage dependency). Batch siblings render inside a `BatchedDepositGroup`
with a single hoisted broadcast button; a successful broadcast marks every sibling `CONFIRMING`.
Per-vault actions (sign, WOTS, activate) stay on individual cards.
- The deposit-modal flow already handled batches correctly — only the dashboard resume path was
per-vault. The BTC broadcast itself is unchanged (one tx, one call); only post-broadcast
bookkeeping became batch-aware.

Closes #1702


<img width="880" height="465" alt="image" src="https://github.com/user-attachments/assets/17d63d5d-0da0-4c02-bdab-03e824568c8d" />
