### PR TITLE
fix(vault): align deposit progress step font sizes, steppers

### DIFF
--- a/services/vault/src/components/simple/DepositProgressView/ActiveStepRow.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/ActiveStepRow.tsx
@@ -27,7 +27,7 @@ export function ActiveStepRow({
         <div className="flex items-baseline gap-2">
           <Text
             as="span"
-            variant="body1"
+            variant="body2"
             className="font-medium text-accent-primary"
           >
             {label}

--- a/services/vault/src/components/simple/DepositProgressView/CompletedStepsPill.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/CompletedStepsPill.tsx
@@ -11,7 +11,7 @@ export function CompletedStepsPill({
   total,
 }: CompletedStepsPillProps) {
   return (
-    <div className="flex items-center gap-4 rounded-lg bg-success-main/10 p-2">
+    <div className="flex items-center gap-3 rounded-lg bg-success-main/10 p-2">
       <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-success-light">
         <IoCheckmarkSharp size={16} className="text-success-light" />
       </div>

--- a/services/vault/src/components/simple/DepositProgressView/PostSignProgress.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/PostSignProgress.tsx
@@ -24,28 +24,30 @@ export function PostSignProgress({
   return (
     <div className="flex flex-col">
       <CompletedStepsPill completed={completedCount} total={totalSteps} />
-      {visibleSteps.length > 0 && <StepConnector />}
-      {visibleSteps.map((step, index) => {
-        const stepNumber = completedCount + index + 1;
-        const isActive = index === 0;
-        const isLast = index === visibleSteps.length - 1;
+      <div className="flex flex-col pl-2">
+        {visibleSteps.length > 0 && <StepConnector />}
+        {visibleSteps.map((step, index) => {
+          const stepNumber = completedCount + index + 1;
+          const isActive = index === 0;
+          const isLast = index === visibleSteps.length - 1;
 
-        return (
-          <div key={stepNumber}>
-            {isActive ? (
-              <ActiveStepRow
-                number={stepNumber}
-                label={step.label}
-                description={step.description}
-                detail={activeStepDetail}
-              />
-            ) : (
-              <PendingStepRow number={stepNumber} label={step.label} />
-            )}
-            {!isLast && <StepConnector />}
-          </div>
-        );
-      })}
+          return (
+            <div key={stepNumber}>
+              {isActive ? (
+                <ActiveStepRow
+                  number={stepNumber}
+                  label={step.label}
+                  description={step.description}
+                  detail={activeStepDetail}
+                />
+              ) : (
+                <PendingStepRow number={stepNumber} label={step.label} />
+              )}
+              {!isLast && <StepConnector />}
+            </div>
+          );
+        })}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
- Use body2 (14px) for the active step label to match pending steps
- Restore 8px padding on the completed-steps pill and indent the step rows so the checkmark, spinner, and number circles share one vertical line

## Screenshot

<img width="740" height="663" alt="Screenshot 2026-05-20 at 16 06 21" src="https://github.com/user-attachments/assets/97e09cae-6baf-4049-bde6-f22acdcd7d5e" />
