### PR TITLE
feat(vault): show per-transaction peg-in signing progress

### DIFF
--- a/services/vault/src/components/simple/DepositProgressView/DepositProgressView.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/DepositProgressView.tsx
@@ -21,6 +21,7 @@ import { StatusBanner } from "@/components/deposit/DepositSignModal/StatusBanner
 import { COPY } from "@/copy";
 import { DepositFlowStep } from "@/hooks/deposit/depositFlowSteps/types";
 import type { PayoutSigningProgress } from "@/services/vault/vaultPayoutSignatureService";
+import type { PeginSigningProgress } from "@/services/vault/vaultTransactionService";
 
 import { BtcConfirmationDetail } from "./BtcConfirmationDetail";
 import { PostSignProgress } from "./PostSignProgress";
@@ -42,6 +43,8 @@ export interface DepositProgressViewProps {
   canClose: boolean;
   canContinueInBackground: boolean;
   payoutSigningProgress: PayoutSigningProgress | null;
+  /** Peg-in BTC signing progress; drives the (x of n) sub-counter for splits. */
+  peginSigningProgress: PeginSigningProgress | null;
   onClose: () => void;
   /** Override the default success message */
   successMessage?: string;
@@ -63,6 +66,7 @@ export function DepositProgressView(props: DepositProgressViewProps) {
     canClose,
     canContinueInBackground,
     payoutSigningProgress,
+    peginSigningProgress,
     onClose,
     successMessage = COPY.deposit.progress.defaultSuccessMessage,
     onRetry,
@@ -78,8 +82,8 @@ export function DepositProgressView(props: DepositProgressViewProps) {
   const showOverallProgress = completedSteps >= 1;
 
   const steps = useMemo(
-    () => buildStepItems(payoutSigningProgress),
-    [payoutSigningProgress],
+    () => buildStepItems(payoutSigningProgress, peginSigningProgress),
+    [payoutSigningProgress, peginSigningProgress],
   );
 
   const activeStepDetail =

--- a/services/vault/src/components/simple/DepositProgressView/__tests__/DepositProgressView.test.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/__tests__/DepositProgressView.test.tsx
@@ -12,6 +12,7 @@ const baseProps = {
   canClose: true,
   canContinueInBackground: false,
   payoutSigningProgress: null,
+  peginSigningProgress: null,
   onClose: vi.fn(),
 };
 
@@ -113,6 +114,65 @@ describe("DepositProgressView", () => {
 
       expect(screen.getByText("Sign payout transactions")).toBeInTheDocument();
       expect(screen.queryByText("(0 of 3)")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("peg-in signing sub-counter", () => {
+    it("shows the (x of n) counter on the active peg-in step for a split deposit", () => {
+      render(
+        <DepositProgressView
+          {...baseProps}
+          currentStep={DepositFlowStep.SIGN_PEGIN_BTC}
+          peginSigningProgress={{ completed: 0, total: 2 }}
+        />,
+      );
+
+      expect(
+        screen.getByText("Sign the peg-in BTC transaction"),
+      ).toBeInTheDocument();
+      expect(screen.getByText("(0 of 2)")).toBeInTheDocument();
+    });
+
+    it("renders (1 of 2) for an in-flight split deposit", () => {
+      render(
+        <DepositProgressView
+          {...baseProps}
+          currentStep={DepositFlowStep.SIGN_PEGIN_BTC}
+          peginSigningProgress={{ completed: 1, total: 2 }}
+        />,
+      );
+
+      expect(screen.getByText("(1 of 2)")).toBeInTheDocument();
+    });
+
+    it("omits the counter for a single-vault (non-split) deposit", () => {
+      render(
+        <DepositProgressView
+          {...baseProps}
+          currentStep={DepositFlowStep.SIGN_PEGIN_BTC}
+          peginSigningProgress={{ completed: 0, total: 1 }}
+        />,
+      );
+
+      expect(
+        screen.getByText("Sign the peg-in BTC transaction"),
+      ).toBeInTheDocument();
+      expect(screen.queryByText(/of 1\)/)).not.toBeInTheDocument();
+    });
+
+    it("omits the counter when no peg-in progress is set", () => {
+      render(
+        <DepositProgressView
+          {...baseProps}
+          currentStep={DepositFlowStep.SIGN_PEGIN_BTC}
+          peginSigningProgress={null}
+        />,
+      );
+
+      expect(
+        screen.getByText("Sign the peg-in BTC transaction"),
+      ).toBeInTheDocument();
+      expect(screen.queryByText(/^\(\d+ of \d+\)$/)).not.toBeInTheDocument();
     });
   });
 

--- a/services/vault/src/components/simple/DepositProgressView/steps.ts
+++ b/services/vault/src/components/simple/DepositProgressView/steps.ts
@@ -3,18 +3,31 @@ import type { StepperItem } from "@babylonlabs-io/core-ui";
 import { COPY } from "@/copy";
 import { DepositFlowStep } from "@/hooks/deposit/depositFlowSteps/types";
 import type { PayoutSigningProgress } from "@/services/vault/vaultPayoutSignatureService";
+import type { PeginSigningProgress } from "@/services/vault/vaultTransactionService";
 
 export const EXPECTED_CONFIRMATION_MINUTES = 15;
 
 export function buildStepItems(
   progress: PayoutSigningProgress | null,
+  peginProgress: PeginSigningProgress | null = null,
 ): StepperItem[] {
   const payoutTotal = progress?.totalClaimers ?? 0;
   const payoutCompleted = progress?.completed ?? 0;
 
+  // Only surface the (x of n) counter for split (multi-vault) deposits;
+  // a single-vault deposit signs one peg-in tx and needs no sub-counter.
+  const peginTotal = peginProgress?.total ?? 0;
+  const peginCounter =
+    peginTotal > 1
+      ? COPY.deposit.steps.signingCounter(
+          peginProgress?.completed ?? 0,
+          peginTotal,
+        )
+      : undefined;
+
   return [
     { label: COPY.deposit.steps.generateSecret },
-    { label: COPY.deposit.steps.signPeginBtc },
+    { label: COPY.deposit.steps.signPeginBtc, description: peginCounter },
     { label: COPY.deposit.steps.signLinkProofs },
     { label: COPY.deposit.steps.signAndBroadcastEth },
     { label: COPY.deposit.steps.signAndBroadcastPrePegin },
@@ -29,7 +42,9 @@ export function buildStepItems(
     {
       label: COPY.deposit.steps.signPayouts,
       description:
-        payoutTotal > 0 ? `(${payoutCompleted} of ${payoutTotal})` : undefined,
+        payoutTotal > 0
+          ? COPY.deposit.steps.signingCounter(payoutCompleted, payoutTotal)
+          : undefined,
     },
     { label: COPY.deposit.steps.downloadArtifact },
     { label: COPY.deposit.steps.revealSecret },

--- a/services/vault/src/components/simple/DepositSignContent.tsx
+++ b/services/vault/src/components/simple/DepositSignContent.tsx
@@ -46,6 +46,7 @@ export function DepositSignContent({
     error,
     isWaiting,
     payoutSigningProgress,
+    peginSigningProgress,
     artifactDownloadInfo,
     continueAfterArtifactDownload,
     btcConfirmationDetail,
@@ -82,6 +83,7 @@ export function DepositSignContent({
         canClose={canClose}
         canContinueInBackground={canContinueInBackground}
         payoutSigningProgress={payoutSigningProgress}
+        peginSigningProgress={peginSigningProgress}
         onClose={handleClose}
         btcConfirmationDetail={btcConfirmationDetail}
       />

--- a/services/vault/src/components/simple/ResumeDepositContent.tsx
+++ b/services/vault/src/components/simple/ResumeDepositContent.tsx
@@ -93,6 +93,7 @@ export function ResumeSignContent({
       canClose={derived.canClose}
       canContinueInBackground={derived.canContinueInBackground}
       payoutSigningProgress={signing ? progress : null}
+      peginSigningProgress={null}
       onClose={onClose}
       onRetry={error ? handleSign : undefined}
     />
@@ -140,6 +141,7 @@ export function ResumeBroadcastContent({
       canClose={derived.canClose}
       canContinueInBackground={derived.canContinueInBackground}
       payoutSigningProgress={null}
+      peginSigningProgress={null}
       onClose={onClose}
       successMessage={COPY.deposit.resume.broadcastSuccessMessage}
       onRetry={error ? handleBroadcast : undefined}
@@ -333,6 +335,7 @@ export function ResumeWotsContent({
       canClose={derived.canClose}
       canContinueInBackground={derived.canContinueInBackground}
       payoutSigningProgress={null}
+      peginSigningProgress={null}
       onClose={onClose}
       onRetry={error ? handleSubmit : undefined}
     />
@@ -483,6 +486,7 @@ export function ResumeActivationContent({
       canClose={activated || derived.canClose}
       canContinueInBackground={false}
       payoutSigningProgress={null}
+      peginSigningProgress={null}
       onClose={handleDone}
       successMessage={COPY.deposit.resume.activationSuccessMessage}
       onRetry={error ? handleSubmit : undefined}

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -130,6 +130,8 @@ export const COPY = {
       signPayouts: "Sign payout transactions",
       downloadArtifact: "Download artifact",
       revealSecret: "Sign and broadcast reveal secret",
+      signingCounter: (completed: number, total: number) =>
+        `(${completed} of ${total})`,
     },
     stepDescriptions: {
       deriveVaultSecret:

--- a/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
@@ -1394,4 +1394,67 @@ describe("useDepositFlow", () => {
       expect(registerPeginBatchAndWait).not.toHaveBeenCalled();
     });
   });
+
+  describe("Peg-in signing progress", () => {
+    it("advances the counter to n of n by signing each peg-in tx in its own popup", async () => {
+      const { preparePeginTransaction } = vi.mocked(
+        await import("@/services/vault/vaultTransactionService"),
+      );
+      // The SDK signs the peg-in PSBTs by calling the wallet wrapper's
+      // signPsbts once; the wrapper forces per-tx signing underneath.
+      vi.mocked(preparePeginTransaction).mockImplementation(async (wallet) => {
+        await wallet.signPsbts(["psbt0", "psbt1"], [{}, {}]);
+        return MOCK_BATCH_RESULT as any;
+      });
+
+      const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
+      await executeWithAutoArtifactDownload(result);
+
+      await waitFor(() => {
+        expect(result.current.peginSigningProgress).toEqual({
+          completed: 2,
+          total: 2,
+        });
+      });
+      // Per-tx: the single-PSBT signer is invoked once per vault.
+      expect(MOCK_BTC_WALLET.signPsbt).toHaveBeenCalledTimes(2);
+    });
+
+    it("never uses the wallet's native batch signPsbts for peg-in, so the counter can tick", async () => {
+      const { preparePeginTransaction } = vi.mocked(
+        await import("@/services/vault/vaultTransactionService"),
+      );
+      const nativeSignPsbt = vi.fn().mockResolvedValue("signedPsbt");
+      const nativeSignPsbts = vi
+        .fn()
+        .mockResolvedValue(["signedPsbt0", "signedPsbt1"]);
+      const batchWallet = {
+        ...MOCK_BTC_WALLET,
+        signPsbt: nativeSignPsbt,
+        signPsbts: nativeSignPsbts,
+      };
+      vi.mocked(preparePeginTransaction).mockImplementation(async (wallet) => {
+        await wallet.signPsbts(["psbt0", "psbt1"], [{}, {}]);
+        return MOCK_BATCH_RESULT as any;
+      });
+
+      const { result } = renderHook(() =>
+        useDepositFlow({
+          ...MOCK_PARAMS,
+          btcWalletProvider: batchWallet as any,
+        }),
+      );
+      await executeWithAutoArtifactDownload(result);
+
+      await waitFor(() => {
+        expect(result.current.peginSigningProgress).toEqual({
+          completed: 2,
+          total: 2,
+        });
+      });
+      // Peg-in is signed per-tx via signPsbt; the native batch path is unused.
+      expect(nativeSignPsbts).not.toHaveBeenCalled();
+      expect(nativeSignPsbt).toHaveBeenCalledTimes(2);
+    });
+  });
 });

--- a/services/vault/src/hooks/deposit/useDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useDepositFlow.ts
@@ -64,7 +64,10 @@ import {
   broadcastPrePeginTransaction,
   utxosToExpectedRecord,
 } from "@/services/vault/vaultPeginBroadcastService";
-import { preparePeginTransaction } from "@/services/vault/vaultTransactionService";
+import {
+  preparePeginTransaction,
+  type PeginSigningProgress,
+} from "@/services/vault/vaultTransactionService";
 import { assertUtxosAvailable } from "@/services/vault/vaultUtxoValidationService";
 import {
   addPendingPegin,
@@ -147,6 +150,8 @@ export interface UseDepositFlowReturn {
   isWaiting: boolean;
   /** Payout signing progress (X of Y signings) */
   payoutSigningProgress: PayoutSigningProgress | null;
+  /** Peg-in BTC signing progress (X of Y peg-in txs, split deposits only) */
+  peginSigningProgress: PeginSigningProgress | null;
   /** Artifact download info (when set, the UI should show the download modal) */
   artifactDownloadInfo: ArtifactDownloadInfo | null;
   /** Callback to continue the flow after artifact download */
@@ -223,6 +228,8 @@ export function useDepositFlow(
   const [isWaiting, setIsWaiting] = useState(false);
   const [payoutSigningProgress, setPayoutSigningProgress] =
     useState<PayoutSigningProgress | null>(null);
+  const [peginSigningProgress, setPeginSigningProgress] =
+    useState<PeginSigningProgress | null>(null);
   const [artifactDownloadInfo, setArtifactDownloadInfo] =
     useState<ArtifactDownloadInfo | null>(null);
   const [btcConfirmationDetail, setBtcConfirmationDetail] = useState<{
@@ -283,6 +290,7 @@ export function useDepositFlow(
 
       setProcessing(true);
       setError(null);
+      setPeginSigningProgress(null);
       setCurrentStep(DepositFlowStep.DERIVE_VAULT_SECRET);
 
       // Track background operation failures
@@ -362,24 +370,38 @@ export function useDepositFlow(
         // ========================================================================
 
         setCurrentStep(DepositFlowStep.DERIVE_VAULT_SECRET);
+        // Sign each peg-in PSBT one at a time so the (x of n) sub-counter can
+        // advance per signature. A native batch signPsbts signs every tx in a
+        // single popup and returns one result, hiding intra-batch progress
+        // from the dApp — so we override signPsbts to loop signPsbt instead,
+        // trading one popup for N popups in exchange for live progress.
+        const signOnePeginPsbt: typeof confirmedBtcWallet.signPsbt = async (
+          psbtHex,
+          opts,
+        ) => {
+          setCurrentStep(DepositFlowStep.SIGN_PEGIN_BTC);
+          const signed = await confirmedBtcWallet.signPsbt(psbtHex, opts);
+          setPeginSigningProgress((prev) =>
+            prev
+              ? { ...prev, completed: Math.min(prev.completed + 1, prev.total) }
+              : prev,
+          );
+          return signed;
+        };
         const phaseTrackingBtcWallet: typeof confirmedBtcWallet = {
           ...confirmedBtcWallet,
           deriveContextHash: (appName, context) => {
             setCurrentStep(DepositFlowStep.DERIVE_VAULT_SECRET);
             return confirmedBtcWallet.deriveContextHash(appName, context);
           },
-          signPsbt: (psbtHex, opts) => {
-            setCurrentStep(DepositFlowStep.SIGN_PEGIN_BTC);
-            return confirmedBtcWallet.signPsbt(psbtHex, opts);
+          signPsbt: signOnePeginPsbt,
+          signPsbts: async (psbtHexes, opts) => {
+            const signed: string[] = [];
+            for (let i = 0; i < psbtHexes.length; i++) {
+              signed.push(await signOnePeginPsbt(psbtHexes[i], opts?.[i]));
+            }
+            return signed;
           },
-          ...(confirmedBtcWallet.signPsbts
-            ? {
-                signPsbts: (psbtHexes, opts) => {
-                  setCurrentStep(DepositFlowStep.SIGN_PEGIN_BTC);
-                  return confirmedBtcWallet.signPsbts!(psbtHexes, opts);
-                },
-              }
-            : {}),
         };
 
         // Filter out UTXOs reserved by in-flight deposits to prevent
@@ -456,6 +478,10 @@ export function useDepositFlow(
           expectedVaultKeeperBtcPubkeys: vaultKeeperBtcPubkeys,
           expectedUniversalChallengerBtcPubkeys: universalChallengerBtcPubkeys,
         });
+
+        // Prime the peg-in signing sub-counter (one tx per vault) before the
+        // commit pass drives the wallet popup(s).
+        setPeginSigningProgress({ completed: 0, total: vaultAmounts.length });
 
         const batchResult = await preparePeginTransaction(
           phaseTrackingBtcWallet,
@@ -1061,6 +1087,7 @@ export function useDepositFlow(
     error,
     isWaiting,
     payoutSigningProgress,
+    peginSigningProgress,
     artifactDownloadInfo,
     continueAfterArtifactDownload,
     btcConfirmationDetail,

--- a/services/vault/src/services/vault/vaultTransactionService.ts
+++ b/services/vault/src/services/vault/vaultTransactionService.ts
@@ -116,6 +116,21 @@ export interface PreparePeginResult {
 }
 
 /**
+ * Detailed progress for peg-in BTC transaction signing (used by UI layer).
+ *
+ * A split (multi-vault) deposit produces one peg-in transaction per vault,
+ * each signed via the wallet (one batch popup for `signPsbts`-capable
+ * wallets, sequential popups otherwise). `total` is the number of peg-in
+ * transactions; `completed` advances as each is signed.
+ */
+export interface PeginSigningProgress {
+  /** Number of peg-in transactions signed so far. */
+  completed: number;
+  /** Total number of peg-in transactions to sign (one per vault). */
+  total: number;
+}
+
+/**
  * Parameters for batch-registering multiple prepared pegins on-chain in a single ETH tx.
  */
 export interface RegisterPeginBatchOnChainParams {


### PR DESCRIPTION
Surface multi-vault (split) peg-in signing in the deposit stepper as an (x of n) sub-counter on the "Sign the peg-in BTC transaction" step.

Force per-tx signing: the wallet wrapper's signPsbts loops signPsbt so each peg-in tx gets its own popup and the counter advances live (0/2 -> 1/2 -> 2/2) instead of jumping after one batch popup. The native batch signPsbts is not used for peg-in.

## Screenshot

<img width="1159" height="707" alt="Screenshot 2026-05-20 at 15 36 29" src="https://github.com/user-attachments/assets/b0245043-43a8-407e-836d-2fdc2bf31946" />
