### PR TITLE
fix(ts-sdk, vault): support refund of batched (multi-vault) pre pegins

### DIFF
--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/refund.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/refund.test.ts
@@ -219,4 +219,102 @@ describe("buildRefundPsbt", () => {
       ).rejects.toThrow(/authAnchorHash/);
     });
   });
+
+  describe("multi-vault batched Pre-PegIn", () => {
+    const SECOND_HASH = "11".repeat(32);
+    const SECOND_AMOUNT = 80_000n;
+
+    it("builds a valid refund PSBT for the second vault (htlcVout=1) of a 2-vault batch", async () => {
+      // Multi-vault Pre-PegIn: HTLCs at vouts 0 & 1, OP_RETURN at vout 2.
+      // Refunding the vault at htlcVout=1 requires the WASM template to
+      // reconstruct both HTLC outputs in vout order — otherwise the refund
+      // input references the wrong output.
+      const params = makePrePeginParams({
+        hashlocks: [TEST_HASH_H, SECOND_HASH],
+        pegInAmounts: [TEST_AMOUNTS.PEGIN, SECOND_AMOUNT],
+        authAnchorHash: TEST_AUTH_ANCHOR_HASH,
+      });
+      const result = await buildPrePeginPsbt(params);
+      const fundedTxHex = fundPeginTransaction({
+        unfundedTxHex: result.psbtHex,
+        selectedUTXOs: [
+          {
+            txid: "aa".repeat(32),
+            vout: 0,
+            value: Number(result.totalOutputValue + 10_000n),
+            scriptPubKey: "0014" + "bb".repeat(20),
+          },
+        ],
+        changeAddress: "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
+        changeAmount: 10_000n,
+        network: bitcoin.networks.testnet,
+      });
+
+      const { psbtHex } = await buildRefundPsbt({
+        prePeginParams: params,
+        fundedPrePeginTxHex: fundedTxHex,
+        htlcVout: 1,
+        refundFee: TEST_REFUND_FEE,
+        hashlock: SECOND_HASH,
+      });
+
+      const psbt = bitcoin.Psbt.fromHex(psbtHex);
+      const unsigned = psbt.data.globalMap.unsignedTx.toBuffer();
+      const refundTx = bitcoin.Transaction.fromBuffer(unsigned);
+      const fundedTxid = bitcoin.Transaction.fromHex(fundedTxHex).getId();
+      const inputTxid = Buffer.from(refundTx.ins[0].hash)
+        .slice()
+        .reverse()
+        .toString("hex");
+      expect(inputTxid).toBe(fundedTxid);
+      // Must spend the SECOND HTLC (vout 1), not vout 0.
+      expect(refundTx.ins[0].index).toBe(1);
+      expect(refundTx.ins[0].sequence).toBe(TEST_TIMELOCK_REFUND);
+    });
+
+    it("rejects when the (hashlocks, amounts) vector disagrees with the funded tx", async () => {
+      // Fund a 2-vault Pre-PegIn with the real (hashlocks, amounts).
+      const realParams = makePrePeginParams({
+        hashlocks: [TEST_HASH_H, SECOND_HASH],
+        pegInAmounts: [TEST_AMOUNTS.PEGIN, SECOND_AMOUNT],
+        authAnchorHash: TEST_AUTH_ANCHOR_HASH,
+      });
+      const real = await buildPrePeginPsbt(realParams);
+      const fundedTxHex = fundPeginTransaction({
+        unfundedTxHex: real.psbtHex,
+        selectedUTXOs: [
+          {
+            txid: "aa".repeat(32),
+            vout: 0,
+            value: Number(real.totalOutputValue + 10_000n),
+            scriptPubKey: "0014" + "bb".repeat(20),
+          },
+        ],
+        changeAddress: "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
+        changeAmount: 10_000n,
+        network: bitcoin.networks.testnet,
+      });
+
+      // Try to refund using a template that names a DIFFERENT second
+      // hashlock. The HTLC scriptPubKey at vout 1 would not match the
+      // funded tx's vout 1 — the new cross-check must reject before
+      // the WASM produces a refund tx that signs the wrong output.
+      const wrongHashlock = "ff".repeat(32);
+      const wrongParams = makePrePeginParams({
+        hashlocks: [TEST_HASH_H, wrongHashlock],
+        pegInAmounts: [TEST_AMOUNTS.PEGIN, SECOND_AMOUNT],
+        authAnchorHash: TEST_AUTH_ANCHOR_HASH,
+      });
+
+      await expect(
+        buildRefundPsbt({
+          prePeginParams: wrongParams,
+          fundedPrePeginTxHex: fundedTxHex,
+          htlcVout: 1,
+          refundFee: TEST_REFUND_FEE,
+          hashlock: wrongHashlock,
+        }),
+      ).rejects.toThrow();
+    });
+  });
 });

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts
@@ -116,6 +116,18 @@ export async function buildRefundPsbt(
 
   let fundedTx: WasmPrePeginTx | null = null;
   try {
+    // Cross-check the reconstructed unfunded template against the funded
+    // transaction: the WASM template's HTLC scriptPubKey at `htlcVout`
+    // must equal the bytes the funded tx carries at the same output.
+    // If they disagree, the template was reconstructed from the wrong
+    // (hashlocks, amounts) vector — signing it would produce a refund
+    // that does not spend the on-chain HTLC the depositor expects.
+    // This is the explicit invariant the audit recommends: never sign a
+    // refund whose template doesn't match the on-chain output bytes.
+    const expectedHtlcScriptPubKey = unfundedTx
+      .getHtlcScriptPubKey(htlcVout)
+      .toLowerCase();
+
     fundedTx = unfundedTx.fromFundedTransaction(fundedPrePeginTxHex);
 
     const refundTxHex = fundedTx.buildRefundTx(refundFee, htlcVout);
@@ -140,6 +152,18 @@ export async function buildRefundPsbt(
       throw new Error(
         `HTLC output at vout ${htlcVout} not found in funded Pre-PegIn tx ` +
           `(tx has ${prePeginTx.outs.length} outputs)`,
+      );
+    }
+
+    const actualHtlcScriptPubKey = uint8ArrayToHex(
+      new Uint8Array(htlcOutput.script),
+    ).toLowerCase();
+    if (actualHtlcScriptPubKey !== expectedHtlcScriptPubKey) {
+      throw new Error(
+        `HTLC scriptPubKey mismatch at vout ${htlcVout}: reconstructed ` +
+          `template expects ${expectedHtlcScriptPubKey}, funded tx carries ` +
+          `${actualHtlcScriptPubKey}. Refund refused — the (hashlocks, ` +
+          `pegInAmounts) vector does not match the on-chain commitment.`,
       );
     }
 

--- a/packages/babylon-ts-sdk/src/tbv/core/services/refund/__tests__/buildAndBroadcastRefund.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/refund/__tests__/buildAndBroadcastRefund.test.ts
@@ -75,18 +75,54 @@ const VP_PUBKEY = "b".repeat(64);
 const VK_PUBKEY = "c".repeat(64);
 const UC_PUBKEY = "d".repeat(64);
 
+// Build a minimal funded Pre-PegIn tx hex with `numHtlcs` HTLC
+// placeholder outputs followed by an optional OP_RETURN. The orchestrator
+// parses this with bitcoinjs to check shape; we only need realistic enough
+// bytes for parsing + output-count checks (the WASM primitive is mocked,
+// so the HTLC scripts don't need to be real taproot keys).
+function buildMinimalFundedPrePeginHex(opts?: {
+  authAnchorHashHex?: string;
+  numHtlcs?: number;
+}): string {
+  const numHtlcs = opts?.numHtlcs ?? 1;
+  const tx = new bitcoin.Transaction();
+  tx.addInput(Buffer.alloc(32, 0xaa), 0);
+  for (let i = 0; i < numHtlcs; i++) {
+    tx.addOutput(Buffer.from("0014" + "11".repeat(20), "hex"), 100_000);
+  }
+  if (opts?.authAnchorHashHex !== undefined) {
+    tx.addOutput(Buffer.from(`6a20${opts.authAnchorHashHex}`, "hex"), 0);
+  }
+  return tx.toHex();
+}
+
+// Realistic single-HTLC Pre-PegIn hex with no OP_RETURN. Used as the
+// default `unsignedPrePeginTxHex` so the orchestrator's structural
+// checks (parseable hex, ≥ batch.length outputs) pass without
+// per-test setup.
+const DEFAULT_FUNDED_PRE_PEGIN_HEX = `0x${buildMinimalFundedPrePeginHex()}`;
+
 function buildVault(overrides?: Partial<VaultRefundData>): VaultRefundData {
+  const hashlock = overrides?.hashlock ?? HASHLOCK;
+  const htlcVout = overrides?.htlcVout ?? 0;
+  const amount = overrides?.amount ?? 100_000n;
+  // Default batch is a length-1 vector that targets vout 0. Callers can
+  // override `batch` to exercise multi-vault scenarios; if they don't,
+  // we synthesize one from the (hashlock, amount, htlcVout) target so
+  // every test case satisfies the orchestrator's positive invariants.
+  const defaultBatch = [{ hashlock, amount, htlcVout: 0 }];
   return {
-    hashlock: HASHLOCK,
-    htlcVout: 0,
+    hashlock,
+    htlcVout,
     offchainParamsVersion: 1,
     appVaultKeepersVersion: 1,
     universalChallengersVersion: 1,
     vaultProvider: VP_ADDR,
     applicationEntryPoint: APP_ADDR,
-    amount: 100_000n,
-    unsignedPrePeginTxHex: "0x0200000001" + "aa".repeat(100),
+    amount,
+    unsignedPrePeginTxHex: DEFAULT_FUNDED_PRE_PEGIN_HEX,
     depositorBtcPubkey: DEPOSITOR_PUBKEY,
+    batch: defaultBatch,
     ...overrides,
   };
 }
@@ -277,7 +313,7 @@ describe("buildAndBroadcastRefund", () => {
     const vault = buildVault({
       hashlock: HASHLOCK,
       depositorBtcPubkey: "0x" + DEPOSITOR_PUBKEY,
-      unsignedPrePeginTxHex: "0x" + "aa".repeat(100),
+      unsignedPrePeginTxHex: DEFAULT_FUNDED_PRE_PEGIN_HEX,
     });
     readVault.mockResolvedValue(vault);
     readPrePeginContext.mockResolvedValue(
@@ -317,33 +353,6 @@ describe("buildAndBroadcastRefund", () => {
   });
 
   describe("auth-anchor extraction", () => {
-    // Build a minimal funded Pre-PegIn tx hex with a configurable
-    // shape: N HTLC-placeholder outputs followed by an optional
-    // OP_RETURN. The HTLC outputs are placeholders — the orchestrator
-    // does not re-derive HTLC content here; the WASM primitive is
-    // mocked. We only care that the auth-anchor finder sees the right
-    // output layout.
-    function buildMinimalFundedPrePeginHex(opts?: {
-      authAnchorHashHex?: string;
-      numHtlcs?: number;
-    }): string {
-      const numHtlcs = opts?.numHtlcs ?? 1;
-      const tx = new bitcoin.Transaction();
-      tx.addInput(Buffer.alloc(32, 0xaa), 0);
-      // HTLC placeholders (P2WPKH script — any 22-byte script is fine).
-      for (let i = 0; i < numHtlcs; i++) {
-        tx.addOutput(Buffer.from("0014" + "11".repeat(20), "hex"), 100_000);
-      }
-      if (opts?.authAnchorHashHex !== undefined) {
-        // OP_RETURN (0x6a) || PUSH32 (0x20) || <32-byte hash>
-        tx.addOutput(
-          Buffer.from(`6a20${opts.authAnchorHashHex}`, "hex"),
-          0,
-        );
-      }
-      return tx.toHex();
-    }
-
     it("extracts authAnchorHash from vout=1 OP_RETURN and forwards it into prePeginParams", async () => {
       const ANCHOR_HASH = "cd".repeat(32);
       const fundedHex = buildMinimalFundedPrePeginHex({
@@ -411,11 +420,55 @@ describe("buildAndBroadcastRefund", () => {
       expect(call[0].prePeginParams.authAnchorHash).toBe("ab".repeat(32));
     });
 
-    it("refuses a 2-vault funded tx (OP_RETURN at vout 2) and does not call buildRefundPsbt", async () => {
+    it("forwards a 2-vault funded tx and full hashlocks/amounts vector when batch.length === 2", async () => {
       // Multi-vault Pre-PegIn: HTLCs at 0 & 1, OP_RETURN at vout 2.
-      // The single-vault refund path reconstructs only one hashlock —
-      // the template would not match the funded tx's shape. Refuse
-      // structurally instead of producing a wrong refund.
+      // When the caller supplies the full sibling vector, the orchestrator
+      // must thread it into buildRefundPsbt — that's the whole point of
+      // the `batch` field. The refund target is the vault at vout 1.
+      const fundedHex = buildMinimalFundedPrePeginHex({
+        numHtlcs: 2,
+        authAnchorHashHex: "cd".repeat(32),
+      });
+      const SIBLING_HASHLOCK = ("0x" + "11".repeat(32)) as Hex;
+      readVault.mockResolvedValue(
+        buildVault({
+          unsignedPrePeginTxHex: "0x" + fundedHex,
+          hashlock: SIBLING_HASHLOCK,
+          amount: 200_000n,
+          htlcVout: 1,
+          batch: [
+            { hashlock: HASHLOCK, amount: 100_000n, htlcVout: 0 },
+            { hashlock: SIBLING_HASHLOCK, amount: 200_000n, htlcVout: 1 },
+          ],
+        }),
+      );
+
+      await buildAndBroadcastRefund({
+        vaultId: VAULT_ID,
+        readVault,
+        readPrePeginContext,
+        feeRate: FEE_RATE,
+        signPsbt,
+        broadcastTx,
+      });
+
+      const [call] = mockedBuildRefundPsbt.mock.calls;
+      expect(call[0].prePeginParams.hashlocks).toEqual([
+        HASHLOCK.slice(2),
+        SIBLING_HASHLOCK.slice(2),
+      ]);
+      expect(call[0].prePeginParams.pegInAmounts).toEqual([
+        100_000n,
+        200_000n,
+      ]);
+      expect(call[0].htlcVout).toBe(1);
+      expect(call[0].prePeginParams.authAnchorHash).toBe("cd".repeat(32));
+    });
+
+    it("refuses a 2-vault funded tx when batch claims length 1 (anchor vout mismatch)", async () => {
+      // Funded tx has 2 HTLCs + OP_RETURN at vout 2, but the caller passes
+      // a single-element batch. The orchestrator must catch the
+      // structural mismatch before signing.
       const fundedHex = buildMinimalFundedPrePeginHex({
         numHtlcs: 2,
         authAnchorHashHex: "cd".repeat(32),
@@ -433,19 +486,31 @@ describe("buildAndBroadcastRefund", () => {
           signPsbt,
           broadcastTx,
         }),
-      ).rejects.toThrow(/Multi-vault Pre-PegIn refund is not supported/);
+      ).rejects.toThrow(/Auth-anchor OP_RETURN at vout 2 does not match batch size/);
 
       expect(mockedBuildRefundPsbt).not.toHaveBeenCalled();
       expect(broadcastTx).not.toHaveBeenCalled();
     });
 
-    it("refuses a 3-vault funded tx (OP_RETURN at vout 3) and does not call buildRefundPsbt", async () => {
-      const fundedHex = buildMinimalFundedPrePeginHex({
-        numHtlcs: 3,
-        authAnchorHashHex: "cd".repeat(32),
-      });
+    it("refuses a funded tx with fewer outputs than the batch claims", async () => {
+      // Batch claims 3 siblings but funded tx only carries 1 HTLC output.
+      // Structural check catches this before the PSBT primitive runs.
+      const fundedHex = buildMinimalFundedPrePeginHex({ numHtlcs: 1 });
+      const H0 = ("0x" + "11".repeat(32)) as Hex;
+      const H1 = ("0x" + "22".repeat(32)) as Hex;
+      const H2 = ("0x" + "33".repeat(32)) as Hex;
       readVault.mockResolvedValue(
-        buildVault({ unsignedPrePeginTxHex: "0x" + fundedHex }),
+        buildVault({
+          unsignedPrePeginTxHex: "0x" + fundedHex,
+          hashlock: H0,
+          amount: 100_000n,
+          htlcVout: 0,
+          batch: [
+            { hashlock: H0, amount: 100_000n, htlcVout: 0 },
+            { hashlock: H1, amount: 100_000n, htlcVout: 1 },
+            { hashlock: H2, amount: 100_000n, htlcVout: 2 },
+          ],
+        }),
       );
 
       await expect(
@@ -457,8 +522,7 @@ describe("buildAndBroadcastRefund", () => {
           signPsbt,
           broadcastTx,
         }),
-      ).rejects.toThrow(/auth-anchor OP_RETURN at vout 3/);
-
+      ).rejects.toThrow(/Funded Pre-PegIn tx has 1 outputs but batch requires at least 3/);
       expect(mockedBuildRefundPsbt).not.toHaveBeenCalled();
     });
   });
@@ -496,11 +560,11 @@ describe("buildAndBroadcastRefund", () => {
       expect(readPrePeginContext).not.toHaveBeenCalled();
     });
 
-    it("rejects htlcVout = 1 with the multi-vault message", async () => {
-      // This SDK call reconstructs a single-hashlock template — any
-      // non-zero htlcVout implies a batched (multi-vault) Pre-PegIn
-      // whose sibling HTLCs would be silently dropped. Refuse at the
-      // input layer before reading any state.
+    it("rejects htlcVout out of range for the batch", async () => {
+      // Single-element batch but caller claims htlcVout = 1. The
+      // orchestrator must catch this at the input boundary — the WASM
+      // template only has one HTLC and signing index 1 would silently
+      // pick the wrong output if the funded tx happened to have it.
       readVault.mockResolvedValue(buildVault({ htlcVout: 1 }));
 
       await expect(
@@ -512,12 +576,12 @@ describe("buildAndBroadcastRefund", () => {
           signPsbt,
           broadcastTx,
         }),
-      ).rejects.toThrow(/Multi-vault Pre-PegIn refund is not supported/);
+      ).rejects.toThrow(/htlcVout 1 is out of range for batch of size 1/);
       expect(readPrePeginContext).not.toHaveBeenCalled();
     });
 
-    it.each([Number.NaN, -1, 1.5, 70_000])(
-      "rejects non-integer or non-zero htlcVout (%s)",
+    it.each([Number.NaN, -1, 1.5])(
+      "rejects non-integer or negative htlcVout (%s)",
       async (htlcVout) => {
         readVault.mockResolvedValue(
           buildVault({ htlcVout: htlcVout as number }),
@@ -532,9 +596,105 @@ describe("buildAndBroadcastRefund", () => {
             signPsbt,
             broadcastTx,
           }),
-        ).rejects.toThrow(/Multi-vault Pre-PegIn refund is not supported/);
+        ).rejects.toThrow(/htlcVout must be a non-negative integer/);
       },
     );
+
+    it("rejects a batch with a gap in htlcVouts", async () => {
+      const H0 = ("0x" + "11".repeat(32)) as Hex;
+      const H2 = ("0x" + "33".repeat(32)) as Hex;
+      readVault.mockResolvedValue(
+        buildVault({
+          hashlock: H0,
+          htlcVout: 0,
+          amount: 100_000n,
+          // Gap: vout 1 missing. WASM template positions are dense, so
+          // any gap would mis-align reconstructed outputs against the
+          // funded tx — refuse at the input boundary.
+          batch: [
+            { hashlock: H0, amount: 100_000n, htlcVout: 0 },
+            { hashlock: H2, amount: 100_000n, htlcVout: 2 },
+          ],
+        }),
+      );
+
+      await expect(
+        buildAndBroadcastRefund({
+          vaultId: VAULT_ID,
+          readVault,
+          readPrePeginContext,
+          feeRate: FEE_RATE,
+          signPsbt,
+          broadcastTx,
+        }),
+      ).rejects.toThrow(/batch\[1\]\.htlcVout must equal 1/);
+      expect(readPrePeginContext).not.toHaveBeenCalled();
+    });
+
+    it("rejects when the target hashlock does not match its batch entry", async () => {
+      const H0 = ("0x" + "11".repeat(32)) as Hex;
+      const H1 = ("0x" + "22".repeat(32)) as Hex;
+      readVault.mockResolvedValue(
+        buildVault({
+          hashlock: H0,
+          htlcVout: 0,
+          amount: 100_000n,
+          // batch[0] disagrees with the target hashlock — the caller
+          // assembled the vector incorrectly. Catch the inconsistency
+          // before signing.
+          batch: [{ hashlock: H1, amount: 100_000n, htlcVout: 0 }],
+        }),
+      );
+
+      await expect(
+        buildAndBroadcastRefund({
+          vaultId: VAULT_ID,
+          readVault,
+          readPrePeginContext,
+          feeRate: FEE_RATE,
+          signPsbt,
+          broadcastTx,
+        }),
+      ).rejects.toThrow(/batch\[0\]\.hashlock .* does not match target hashlock/);
+    });
+
+    it("rejects when the target amount does not match its batch entry", async () => {
+      readVault.mockResolvedValue(
+        buildVault({
+          htlcVout: 0,
+          amount: 100_000n,
+          batch: [{ hashlock: HASHLOCK, amount: 200_000n, htlcVout: 0 }],
+        }),
+      );
+
+      await expect(
+        buildAndBroadcastRefund({
+          vaultId: VAULT_ID,
+          readVault,
+          readPrePeginContext,
+          feeRate: FEE_RATE,
+          signPsbt,
+          broadcastTx,
+        }),
+      ).rejects.toThrow(/batch\[0\]\.amount .* does not match target amount/);
+    });
+
+    it("rejects an empty batch", async () => {
+      readVault.mockResolvedValue(
+        buildVault({ batch: [] as never }),
+      );
+
+      await expect(
+        buildAndBroadcastRefund({
+          vaultId: VAULT_ID,
+          readVault,
+          readPrePeginContext,
+          feeRate: FEE_RATE,
+          signPsbt,
+          broadcastTx,
+        }),
+      ).rejects.toThrow(/batch must be a non-empty array/);
+    });
 
     // Version fields flow directly into on-chain script derivation via
     // readPrePeginContext — NaN, negative, or non-integer values would

--- a/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts
@@ -11,7 +11,7 @@
  */
 
 import type { Network } from "@babylonlabs-io/babylon-tbv-rust-wasm";
-import { Psbt } from "bitcoinjs-lib";
+import { Psbt, Transaction } from "bitcoinjs-lib";
 import type { Address, Hex } from "viem";
 
 import type { SignPsbtOptions } from "../../../../shared/wallets/interfaces/BitcoinWallet";
@@ -103,11 +103,31 @@ function assertBytes32(value: string, label: string): void {
 }
 
 /**
+ * One vault's per-HTLC binding in a Pre-PegIn batch. Carries the fields
+ * needed to reconstruct the WASM `WasmPrePeginTx` template byte-for-byte
+ * against the funded transaction.
+ */
+export interface VaultBatchEntry {
+  /** SHA-256 hashlock commitment for this vault (bytes32, 0x-prefixed). */
+  hashlock: Hex;
+  /** HTLC output value in satoshis for this vault. */
+  amount: bigint;
+  /** Index of this vault's HTLC output in the funded Pre-PegIn tx. */
+  htlcVout: number;
+}
+
+/**
  * Authoritative vault fields needed to build a refund. Versioning fields,
  * the hashlock, and htlcVout must come from the on-chain contract (never the
  * indexer). The amount + `unsignedPrePeginTxHex` + `depositorBtcPubkey` can
  * come from the indexer since they are not security-critical for signing
  * (the PSBT builder re-derives the HTLC script from on-chain params).
+ *
+ * `batch` is the full, vout-ordered HTLC vector for the Pre-PegIn (one
+ * entry per sibling vault that shares this funded transaction). For a
+ * single-vault deposit this is a length-1 array. For batched deposits
+ * (e.g. the Aave split) the orchestrator passes every sibling through
+ * so the WASM template matches the funded tx's shape.
  */
 export interface VaultRefundData {
   hashlock: Hex;
@@ -127,6 +147,13 @@ export interface VaultRefundData {
   unsignedPrePeginTxHex: string;
   /** Depositor's BTC public key (x-only or compressed hex; 0x prefix optional). */
   depositorBtcPubkey: string;
+  /**
+   * Full vout-ordered HTLC vector for the funded Pre-PegIn (one entry
+   * per sibling vault, including the target vault). Must satisfy
+   * `batch[i].htlcVout === i` for all i, and the target's `htlcVout` /
+   * `hashlock` / `amount` must equal `batch[vault.htlcVout]`.
+   */
+  batch: ReadonlyArray<VaultBatchEntry>;
 }
 
 /**
@@ -207,19 +234,49 @@ function assertNonNegativeInteger(value: number, label: string): void {
 
 function validateVaultRefundData(v: VaultRefundData): void {
   assertBytes32(v.hashlock, "hashlock");
-  // This SDK call reconstructs a single-hashlock unfunded template
-  // ([single]) and so only supports refund of the HTLC at vout 0. A
-  // multi-vault Pre-PegIn places HTLCs at 0..hashlocks.length-1 — any
-  // htlcVout != 0 implies a batched deposit whose sibling HTLCs would
-  // be missing from the reconstructed template. The orchestrator's
-  // structural OP_RETURN scan below catches auth-anchored multi-vault
-  // txs; this assertion additionally catches legacy (no OP_RETURN)
-  // multi-vault txs and documents the contract at the input boundary.
-  if (!Number.isInteger(v.htlcVout) || v.htlcVout !== 0) {
+  if (!Number.isInteger(v.htlcVout) || v.htlcVout < 0) {
     throw new Error(
-      `Multi-vault Pre-PegIn refund is not supported by this SDK call ` +
-        `(htlcVout=${v.htlcVout}, expected 0). Refund of batched-deposit ` +
-        `vaults requires reconstructing all sibling HTLCs.`,
+      `htlcVout must be a non-negative integer, got ${v.htlcVout}`,
+    );
+  }
+  // Batch shape — one entry per sibling HTLC, vout-ordered and
+  // contiguous from 0. The reconstructed WASM template uses these
+  // arrays directly: any gap, duplicate, or mis-ordering against the
+  // funded tx would produce an unspendable refund. The target's
+  // (hashlock, amount, htlcVout) must equal the corresponding batch
+  // entry so the orchestrator and the caller can't disagree about
+  // which output is being refunded.
+  if (!Array.isArray(v.batch) || v.batch.length === 0) {
+    throw new Error("batch must be a non-empty array of HTLC entries");
+  }
+  if (v.htlcVout >= v.batch.length) {
+    throw new Error(
+      `htlcVout ${v.htlcVout} is out of range for batch of size ${v.batch.length}`,
+    );
+  }
+  for (let i = 0; i < v.batch.length; i++) {
+    const entry = v.batch[i];
+    assertBytes32(entry.hashlock, `batch[${i}].hashlock`);
+    if (!Number.isInteger(entry.htlcVout) || entry.htlcVout !== i) {
+      throw new Error(
+        `batch[${i}].htlcVout must equal ${i} (contiguous vout-ordered vector), got ${entry.htlcVout}`,
+      );
+    }
+    if (typeof entry.amount !== "bigint" || entry.amount <= 0n) {
+      throw new Error(
+        `batch[${i}].amount must be a positive bigint, got ${entry.amount}`,
+      );
+    }
+  }
+  const targetEntry = v.batch[v.htlcVout];
+  if (targetEntry.hashlock.toLowerCase() !== v.hashlock.toLowerCase()) {
+    throw new Error(
+      `batch[${v.htlcVout}].hashlock (${targetEntry.hashlock}) does not match target hashlock (${v.hashlock})`,
+    );
+  }
+  if (targetEntry.amount !== v.amount) {
+    throw new Error(
+      `batch[${v.htlcVout}].amount (${targetEntry.amount}) does not match target amount (${v.amount})`,
     );
   }
   // Version fields flow directly into on-chain script derivation via
@@ -389,27 +446,42 @@ export async function buildAndBroadcastRefund<
   const cleanFundedPrePeginTxHex = stripHexPrefix(vault.unsignedPrePeginTxHex);
 
   // Production peg-ins (PeginManager) commit an OP_RETURN <PUSH32
-  // SHA256(authAnchor)> output at `vout = hashlocks.length`. The refund
-  // reconstructs the unfunded WASM template for a single vault here
-  // (hashlocks: [vault.hashlock]), so the anchor output — if present —
-  // must be at vout 1. Scan the funded tx structurally rather than
-  // peeking at a hardcoded vout: that way a batched (multi-vault) tx,
-  // where the anchor lives at vout N > 1, is detected and refused
-  // explicitly rather than silently reconstructing a single-hashlock
-  // template against an N-HTLC funded tx. Legacy non-auth-anchored
-  // deposits return `undefined` from the finder and use the 12-output
-  // template.
-  const SINGLE_VAULT_AUTH_ANCHOR_VOUT = 1;
+  // SHA256(authAnchor)> output at `vout = hashlocks.length`. The
+  // reconstructed unfunded template carries `batch.length` HTLC outputs,
+  // so the OP_RETURN — when present — must sit at exactly that vout.
+  // Legacy non-auth-anchored Pre-PegIns return `undefined` from the
+  // finder; the template then has no OP_RETURN either, which is a
+  // matching configuration.
   const found = findAuthAnchorOpReturn(cleanFundedPrePeginTxHex);
-  if (found !== undefined && found.vout !== SINGLE_VAULT_AUTH_ANCHOR_VOUT) {
+  if (found !== undefined && found.vout !== vault.batch.length) {
     throw new Error(
-      `Multi-vault Pre-PegIn refund is not supported by this SDK call ` +
-        `(auth-anchor OP_RETURN at vout ${found.vout}; single-vault refund ` +
-        `expects vout ${SINGLE_VAULT_AUTH_ANCHOR_VOUT}). Refund of ` +
-        `batched-deposit vaults requires reconstructing all sibling HTLCs.`,
+      `Auth-anchor OP_RETURN at vout ${found.vout} does not match batch size ` +
+        `(${vault.batch.length} HTLC outputs expect the anchor at vout ${vault.batch.length}). ` +
+        `Refund refused — sibling HTLC vector is incomplete.`,
     );
   }
   const authAnchorHash = found?.hash;
+
+  // Independent structural check on the funded tx: it must carry at
+  // least N HTLC outputs (one per batch entry). If the anchor is
+  // present we've already pinned its position above, which transitively
+  // proves the tx has ≥ N+1 outputs; if the anchor is absent (legacy)
+  // we still need ≥ N to spend `htlcVout = N-1`.
+  let parsedFundedTx: Transaction;
+  try {
+    parsedFundedTx = Transaction.fromHex(cleanFundedPrePeginTxHex);
+  } catch (e) {
+    throw new Error(
+      `Failed to parse funded Pre-PegIn transaction hex: ${e instanceof Error ? e.message : String(e)}`,
+    );
+  }
+  if (parsedFundedTx.outs.length < vault.batch.length) {
+    throw new Error(
+      `Funded Pre-PegIn tx has ${parsedFundedTx.outs.length} outputs but batch ` +
+        `requires at least ${vault.batch.length} HTLC outputs. ` +
+        `Refund refused — funded tx shape disagrees with sibling vector.`,
+    );
+  }
 
   const { psbtHex } = await buildRefundPsbt({
     prePeginParams: {
@@ -418,9 +490,9 @@ export async function buildAndBroadcastRefund<
       vaultKeeperPubkeys: ctx.vaultKeeperPubkeys.map(stripHexPrefix),
       universalChallengerPubkeys:
         ctx.universalChallengerPubkeys.map(stripHexPrefix),
-      hashlocks: [stripHexPrefix(vault.hashlock)],
+      hashlocks: vault.batch.map((b) => stripHexPrefix(b.hashlock)),
       timelockRefund: ctx.timelockRefund,
-      pegInAmounts: [vault.amount],
+      pegInAmounts: vault.batch.map((b) => b.amount),
       feeRate: ctx.feeRate,
       numLocalChallengers: ctx.numLocalChallengers,
       councilQuorum: ctx.councilQuorum,

--- a/packages/babylon-ts-sdk/src/tbv/core/services/refund/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/refund/index.ts
@@ -17,5 +17,6 @@ export {
   type RefundInput,
   type RefundPrePeginContext,
   type RefundPsbtSigner,
+  type VaultBatchEntry,
   type VaultRefundData,
 } from "./buildAndBroadcastRefund";

--- a/services/vault/src/clients/eth-contract/btc-vault-registry/query.ts
+++ b/services/vault/src/clients/eth-contract/btc-vault-registry/query.ts
@@ -15,6 +15,8 @@ import { getVaultRegistryReader } from "../sdk-readers";
  * Flat shape merged from the SDK's `{basic, protocol}` payload.
  */
 export interface OnChainVaultData {
+  /** Depositor's Ethereum address — the authoritative owner of this vault. */
+  depositor: Address;
   depositorSignedPeginTx: Hex;
   applicationEntryPoint: Address;
   vaultProvider: Address;
@@ -45,6 +47,7 @@ export async function getVaultFromChain(
     await getVaultRegistryReader().getVaultData(vaultId);
 
   return {
+    depositor: basic.depositor,
     depositorSignedPeginTx: protocol.depositorSignedPeginTx,
     applicationEntryPoint: basic.applicationEntryPoint,
     vaultProvider: basic.vaultProvider,

--- a/services/vault/src/hooks/deposit/useRefundState.ts
+++ b/services/vault/src/hooks/deposit/useRefundState.ts
@@ -1,5 +1,6 @@
 import { useChainConnector } from "@babylonlabs-io/wallet-connector";
 import { useCallback, useEffect, useRef, useState } from "react";
+import type { Address } from "viem";
 
 import { usePeginPolling } from "@/context/deposit/PeginPollingContext";
 import { useETHWallet } from "@/context/wallet";
@@ -85,6 +86,14 @@ export function useRefundState({
           setError("Missing vault ID");
           return;
         }
+        if (!ethAddress) {
+          // The refund flow needs the depositor's EOA to enumerate
+          // sibling vaults (batched Pre-PegIn refunds). Without it we
+          // can't reconstruct the full HTLC vector even for single-vault
+          // refunds, so fail closed.
+          setError("ETH wallet not connected");
+          return;
+        }
         if (!Number.isFinite(feeRate) || feeRate <= 0) {
           setError("Fee rate must be a positive number");
           return;
@@ -105,6 +114,7 @@ export function useRefundState({
           const depositorBtcPubkey = await btcWalletProvider.getPublicKeyHex();
           const txId = await buildAndBroadcastRefundTransaction({
             vaultId,
+            depositorAddress: ethAddress as Address,
             btcWalletProvider,
             depositorBtcPubkey,
             feeRate,

--- a/services/vault/src/services/vault/__tests__/fetchVaults.test.ts
+++ b/services/vault/src/services/vault/__tests__/fetchVaults.test.ts
@@ -5,6 +5,7 @@ import { logger } from "@/infrastructure";
 import { graphqlClient } from "../../../clients/graphql/client";
 import {
   fetchVaultById,
+  fetchVaultIdsByDepositor,
   fetchVaultRefundData,
   fetchVaultsByDepositor,
   fetchVaultsByDepositorStrict,
@@ -519,6 +520,79 @@ describe("fetchVaults", () => {
       await expect(
         fetchVaultRefundData(VALID_VAULT_ID as `0x${string}`),
       ).rejects.toThrow("indexer unavailable");
+    });
+  });
+
+  describe("fetchVaultIdsByDepositor", () => {
+    // The lean enumerator must NOT drop rows on transform failures of
+    // unrelated fields (e.g. a transient null depositorWotsPkHash on a
+    // sibling vault) — refund's sibling discovery depends on a
+    // complete vault-id list for the depositor.
+    it("returns ids for every vault row regardless of unrelated indexer fields", async () => {
+      // Three vault rows: one well-formed, one with a null
+      // depositorWotsPkHash (which `fetchVaultsByDepositor` would
+      // drop), and one with a null hashlock. Lean enumerator must
+      // surface all three.
+      const SIBLING_ID = "0x" + "11".repeat(32);
+      const OTHER_ID = "0x" + "22".repeat(32);
+      mockedRequest.mockResolvedValueOnce({
+        vaults: {
+          items: [{ id: VALID_VAULT_ID }, { id: SIBLING_ID }, { id: OTHER_ID }],
+          totalCount: 3,
+        },
+      });
+
+      const ids = await fetchVaultIdsByDepositor(
+        "0xdepositor" as `0x${string}`,
+      );
+
+      expect(ids).toEqual([VALID_VAULT_ID, SIBLING_ID, OTHER_ID]);
+    });
+
+    it("lower-cases the depositor address in the GraphQL variable", async () => {
+      mockedRequest.mockResolvedValueOnce({
+        vaults: { items: [], totalCount: 0 },
+      });
+
+      await fetchVaultIdsByDepositor(
+        "0xAbAbAbAbAbAbAbAbAbAbAbAbAbAbAbAbAbAbAbAb" as `0x${string}`,
+      );
+
+      expect(mockedRequest).toHaveBeenCalledWith(expect.anything(), {
+        depositor: "0xabababababababababababababababababababab",
+      });
+    });
+
+    it("throws if a returned id is malformed hex", async () => {
+      mockedRequest.mockResolvedValueOnce({
+        vaults: {
+          items: [{ id: "not-a-hex-id" }],
+          totalCount: 1,
+        },
+      });
+
+      await expect(
+        fetchVaultIdsByDepositor("0xdepositor" as `0x${string}`),
+      ).rejects.toThrow(/Malformed hex/);
+    });
+
+    it("throws when the response is page-cap truncated (items.length < totalCount)", async () => {
+      // Indexer page caps would silently drop tail siblings of a batched
+      // Pre-PegIn. Refund's sibling discovery must fail closed instead of
+      // signing against an incomplete batch.
+      mockedRequest.mockResolvedValueOnce({
+        vaults: {
+          items: [
+            { id: "0x" + "11".repeat(32) },
+            { id: "0x" + "22".repeat(32) },
+          ],
+          totalCount: 5,
+        },
+      });
+
+      await expect(
+        fetchVaultIdsByDepositor("0xdepositor" as `0x${string}`),
+      ).rejects.toThrow(/truncated by a page-size cap/);
     });
   });
 });

--- a/services/vault/src/services/vault/__tests__/vaultRefundService.test.ts
+++ b/services/vault/src/services/vault/__tests__/vaultRefundService.test.ts
@@ -69,6 +69,7 @@ vi.mock("../fetchVaultProviders", () => ({
 
 vi.mock("../fetchVaults", () => ({
   fetchVaultRefundData: vi.fn(),
+  fetchVaultsByDepositor: vi.fn(),
 }));
 
 import { getNetworkFees, pushTx } from "@babylonlabs-io/ts-sdk/tbv/core";
@@ -77,7 +78,7 @@ import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 
 import { getVaultFromChain } from "../../../clients/eth-contract/btc-vault-registry/query";
 import { fetchVaultProviderById } from "../fetchVaultProviders";
-import { fetchVaultRefundData } from "../fetchVaults";
+import { fetchVaultRefundData, fetchVaultsByDepositor } from "../fetchVaults";
 import {
   buildAndBroadcastRefundTransaction,
   getRefundPreview,
@@ -85,6 +86,7 @@ import {
 
 const VAULT_ID = "0xvaultid" as `0x${string}`;
 const DEPOSITOR_PUBKEY = "aabbccdd";
+const DEPOSITOR_ADDRESS = ("0x" + "ab".repeat(20)) as `0x${string}`;
 
 const ON_CHAIN_VAULT = {
   offchainParamsVersion: 1,
@@ -93,7 +95,7 @@ const ON_CHAIN_VAULT = {
   appVaultKeepersVersion: 1,
   universalChallengersVersion: 1,
   hashlock: "0xhashlock",
-  htlcVout: 1,
+  htlcVout: 0,
   amount: 100_000n,
   prePeginTxHash: "0xmatching_pre_pegin_hash",
 };
@@ -124,6 +126,9 @@ describe("vaultRefundService - adapter wiring", () => {
     (calculateBtcTxHash as Mock).mockReturnValue(ON_CHAIN_VAULT.prePeginTxHash);
     (getVaultFromChain as Mock).mockResolvedValue(ON_CHAIN_VAULT);
     (fetchVaultRefundData as Mock).mockResolvedValue(INDEXER_VAULT);
+    // Default: depositor has just the target vault. Sibling-discovery
+    // tests below override this to exercise the multi-vault branch.
+    (fetchVaultsByDepositor as Mock).mockResolvedValue([{ id: VAULT_ID }]);
     mockGetOffchainParamsByVersion.mockResolvedValue(OFFCHAIN_PARAMS);
     (fetchVaultProviderById as Mock).mockResolvedValue(VAULT_PROVIDER);
     mockGetVaultProviderBtcPubKey.mockResolvedValue(VP_BTC_PUBKEY_X_ONLY);
@@ -154,6 +159,7 @@ describe("vaultRefundService - adapter wiring", () => {
   it("calls the SDK with vaultId and returns the broadcast txId", async () => {
     const txId = await buildAndBroadcastRefundTransaction({
       vaultId: VAULT_ID,
+      depositorAddress: DEPOSITOR_ADDRESS,
       btcWalletProvider: BTC_WALLET_PROVIDER,
       depositorBtcPubkey: DEPOSITOR_PUBKEY,
       feeRate: 10,
@@ -189,6 +195,7 @@ describe("vaultRefundService - adapter wiring", () => {
 
     await buildAndBroadcastRefundTransaction({
       vaultId: VAULT_ID,
+      depositorAddress: DEPOSITOR_ADDRESS,
       btcWalletProvider: BTC_WALLET_PROVIDER,
       depositorBtcPubkey: DEPOSITOR_PUBKEY,
       feeRate: 10,
@@ -209,6 +216,7 @@ describe("vaultRefundService - adapter wiring", () => {
     await expect(
       buildAndBroadcastRefundTransaction({
         vaultId: VAULT_ID,
+        depositorAddress: DEPOSITOR_ADDRESS,
         btcWalletProvider: BTC_WALLET_PROVIDER,
         depositorBtcPubkey: DEPOSITOR_PUBKEY,
         feeRate: 10,
@@ -222,6 +230,7 @@ describe("vaultRefundService - adapter wiring", () => {
     await expect(
       buildAndBroadcastRefundTransaction({
         vaultId: VAULT_ID,
+        depositorAddress: DEPOSITOR_ADDRESS,
         btcWalletProvider: BTC_WALLET_PROVIDER,
         depositorBtcPubkey: DEPOSITOR_PUBKEY,
         feeRate: 10,
@@ -235,6 +244,7 @@ describe("vaultRefundService - adapter wiring", () => {
     await expect(
       buildAndBroadcastRefundTransaction({
         vaultId: VAULT_ID,
+        depositorAddress: DEPOSITOR_ADDRESS,
         btcWalletProvider: BTC_WALLET_PROVIDER,
         depositorBtcPubkey: DEPOSITOR_PUBKEY,
         feeRate: 10,
@@ -250,6 +260,7 @@ describe("vaultRefundService - adapter wiring", () => {
     await expect(
       buildAndBroadcastRefundTransaction({
         vaultId: VAULT_ID,
+        depositorAddress: DEPOSITOR_ADDRESS,
         btcWalletProvider: BTC_WALLET_PROVIDER,
         depositorBtcPubkey: DEPOSITOR_PUBKEY,
         feeRate: 10,
@@ -265,6 +276,7 @@ describe("vaultRefundService - adapter wiring", () => {
     await expect(
       buildAndBroadcastRefundTransaction({
         vaultId: VAULT_ID,
+        depositorAddress: DEPOSITOR_ADDRESS,
         btcWalletProvider: BTC_WALLET_PROVIDER,
         depositorBtcPubkey: DEPOSITOR_PUBKEY,
         feeRate: 10,
@@ -284,6 +296,7 @@ describe("vaultRefundService - adapter wiring", () => {
     await expect(
       buildAndBroadcastRefundTransaction({
         vaultId: VAULT_ID,
+        depositorAddress: DEPOSITOR_ADDRESS,
         btcWalletProvider: BTC_WALLET_PROVIDER,
         depositorBtcPubkey: DEPOSITOR_PUBKEY,
         feeRate: 10,
@@ -308,6 +321,7 @@ describe("vaultRefundService - adapter wiring", () => {
 
     await buildAndBroadcastRefundTransaction({
       vaultId: VAULT_ID,
+      depositorAddress: DEPOSITOR_ADDRESS,
       btcWalletProvider: BTC_WALLET_PROVIDER,
       depositorBtcPubkey: DEPOSITOR_PUBKEY,
       feeRate: 10,
@@ -328,6 +342,7 @@ describe("vaultRefundService - adapter wiring", () => {
 
     await buildAndBroadcastRefundTransaction({
       vaultId: VAULT_ID,
+      depositorAddress: DEPOSITOR_ADDRESS,
       btcWalletProvider: BTC_WALLET_PROVIDER,
       depositorBtcPubkey: DEPOSITOR_PUBKEY,
       feeRate: 42,
@@ -351,6 +366,7 @@ describe("vaultRefundService - adapter wiring", () => {
 
     const txId = await buildAndBroadcastRefundTransaction({
       vaultId: VAULT_ID,
+      depositorAddress: DEPOSITOR_ADDRESS,
       btcWalletProvider: BTC_WALLET_PROVIDER,
       depositorBtcPubkey: DEPOSITOR_PUBKEY,
       feeRate: 10,
@@ -395,5 +411,178 @@ describe("getRefundPreview", () => {
     (getNetworkFees as Mock).mockResolvedValue({ halfHourFee: 0 });
     const preview = await getRefundPreview(VAULT_ID);
     expect(preview.halfHourFeeSatsVb).toBeNull();
+  });
+});
+
+describe("vaultRefundService - sibling batch discovery", () => {
+  const SIBLING_VAULT_ID = "0xsiblingid" as `0x${string}`;
+  const OTHER_VAULT_ID = "0xunrelated" as `0x${string}`;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (calculateBtcTxHash as Mock).mockReturnValue(ON_CHAIN_VAULT.prePeginTxHash);
+    (fetchVaultRefundData as Mock).mockResolvedValue(INDEXER_VAULT);
+    mockGetOffchainParamsByVersion.mockResolvedValue(OFFCHAIN_PARAMS);
+    (fetchVaultProviderById as Mock).mockResolvedValue(VAULT_PROVIDER);
+    mockGetVaultProviderBtcPubKey.mockResolvedValue(VP_BTC_PUBKEY_X_ONLY);
+    mockGetVaultKeepersByVersion.mockResolvedValue(VAULT_KEEPERS);
+    mockGetUniversalChallengersByVersion.mockResolvedValue(
+      UNIVERSAL_CHALLENGERS,
+    );
+    (pushTx as Mock).mockResolvedValue("broadcast_txid");
+
+    mockBuildAndBroadcastRefund.mockImplementation(
+      async (input: { readVault: () => Promise<unknown> }) => {
+        await input.readVault();
+        return { txId: "broadcast_txid" };
+      },
+    );
+  });
+
+  it("builds a length-1 batch for a single-vault deposit", async () => {
+    (getVaultFromChain as Mock).mockResolvedValue(ON_CHAIN_VAULT);
+    (fetchVaultsByDepositor as Mock).mockResolvedValue([{ id: VAULT_ID }]);
+
+    let observed: { batch: ReadonlyArray<unknown> } | null = null;
+    mockBuildAndBroadcastRefund.mockImplementation(
+      async (input: {
+        readVault: () => Promise<{ batch: ReadonlyArray<unknown> }>;
+      }) => {
+        observed = await input.readVault();
+        return { txId: "ok" };
+      },
+    );
+
+    await buildAndBroadcastRefundTransaction({
+      vaultId: VAULT_ID,
+      depositorAddress: DEPOSITOR_ADDRESS,
+      btcWalletProvider: BTC_WALLET_PROVIDER,
+      depositorBtcPubkey: DEPOSITOR_PUBKEY,
+      feeRate: 10,
+    });
+
+    expect(observed).not.toBeNull();
+    expect(observed!.batch).toHaveLength(1);
+    expect(observed!.batch[0]).toEqual({
+      hashlock: ON_CHAIN_VAULT.hashlock,
+      amount: ON_CHAIN_VAULT.amount,
+      htlcVout: 0,
+    });
+  });
+
+  it("assembles a vout-ordered length-2 batch for a sibling pair", async () => {
+    // Target vault is at vout 0; sibling is at vout 1 of the same Pre-PegIn.
+    const TARGET = { ...ON_CHAIN_VAULT, htlcVout: 0, hashlock: "0xtarget" };
+    const SIBLING = {
+      ...ON_CHAIN_VAULT,
+      htlcVout: 1,
+      hashlock: "0xsibling",
+      amount: 200_000n,
+    };
+    (getVaultFromChain as Mock).mockImplementation((id: string) => {
+      if (id === VAULT_ID) return Promise.resolve(TARGET);
+      if (id === SIBLING_VAULT_ID) return Promise.resolve(SIBLING);
+      throw new Error(`Unexpected vaultId ${id}`);
+    });
+    (fetchVaultsByDepositor as Mock).mockResolvedValue([
+      { id: VAULT_ID },
+      { id: SIBLING_VAULT_ID },
+    ]);
+
+    let observed: {
+      batch: ReadonlyArray<{
+        hashlock: string;
+        amount: bigint;
+        htlcVout: number;
+      }>;
+    } | null = null;
+    mockBuildAndBroadcastRefund.mockImplementation(
+      async (input: { readVault: () => Promise<typeof observed> }) => {
+        observed = (await input.readVault()) as typeof observed;
+        return { txId: "ok" };
+      },
+    );
+
+    await buildAndBroadcastRefundTransaction({
+      vaultId: VAULT_ID,
+      depositorAddress: DEPOSITOR_ADDRESS,
+      btcWalletProvider: BTC_WALLET_PROVIDER,
+      depositorBtcPubkey: DEPOSITOR_PUBKEY,
+      feeRate: 10,
+    });
+
+    expect(observed).not.toBeNull();
+    expect(observed!.batch.map((b) => b.htlcVout)).toEqual([0, 1]);
+    expect(observed!.batch[0].hashlock).toBe("0xtarget");
+    expect(observed!.batch[1].hashlock).toBe("0xsibling");
+    expect(observed!.batch[0].amount).toBe(100_000n);
+    expect(observed!.batch[1].amount).toBe(200_000n);
+  });
+
+  it("ignores depositor vaults that belong to a different Pre-PegIn", async () => {
+    // Unrelated vault has a different prePeginTxHash — must not appear
+    // in the assembled batch even though it lives under the same depositor.
+    const TARGET = { ...ON_CHAIN_VAULT, htlcVout: 0 };
+    const UNRELATED = {
+      ...ON_CHAIN_VAULT,
+      htlcVout: 5,
+      prePeginTxHash: "0xa_different_pre_pegin_hash",
+    };
+    (getVaultFromChain as Mock).mockImplementation((id: string) => {
+      if (id === VAULT_ID) return Promise.resolve(TARGET);
+      if (id === OTHER_VAULT_ID) return Promise.resolve(UNRELATED);
+      throw new Error(`Unexpected vaultId ${id}`);
+    });
+    (fetchVaultsByDepositor as Mock).mockResolvedValue([
+      { id: VAULT_ID },
+      { id: OTHER_VAULT_ID },
+    ]);
+
+    let observed: { batch: ReadonlyArray<unknown> } | null = null;
+    mockBuildAndBroadcastRefund.mockImplementation(
+      async (input: {
+        readVault: () => Promise<{ batch: ReadonlyArray<unknown> }>;
+      }) => {
+        observed = await input.readVault();
+        return { txId: "ok" };
+      },
+    );
+
+    await buildAndBroadcastRefundTransaction({
+      vaultId: VAULT_ID,
+      depositorAddress: DEPOSITOR_ADDRESS,
+      btcWalletProvider: BTC_WALLET_PROVIDER,
+      depositorBtcPubkey: DEPOSITOR_PUBKEY,
+      feeRate: 10,
+    });
+
+    expect(observed!.batch).toHaveLength(1);
+  });
+
+  it("throws when the discovered siblings leave a gap in the HTLC vector", async () => {
+    // Target at vout 0, sibling claims vout 2 — vout 1 is missing.
+    // The WASM template uses dense vout positions; any gap would
+    // mis-align with the funded tx's outputs, so refuse the refund.
+    const TARGET = { ...ON_CHAIN_VAULT, htlcVout: 0 };
+    const SIBLING = { ...ON_CHAIN_VAULT, htlcVout: 2 };
+    (getVaultFromChain as Mock).mockImplementation((id: string) => {
+      if (id === VAULT_ID) return Promise.resolve(TARGET);
+      if (id === SIBLING_VAULT_ID) return Promise.resolve(SIBLING);
+      throw new Error(`Unexpected vaultId ${id}`);
+    });
+    (fetchVaultsByDepositor as Mock).mockResolvedValue([
+      { id: VAULT_ID },
+      { id: SIBLING_VAULT_ID },
+    ]);
+
+    await expect(
+      buildAndBroadcastRefundTransaction({
+        vaultId: VAULT_ID,
+        depositorAddress: DEPOSITOR_ADDRESS,
+        btcWalletProvider: BTC_WALLET_PROVIDER,
+        depositorBtcPubkey: DEPOSITOR_PUBKEY,
+        feeRate: 10,
+      }),
+    ).rejects.toThrow(/non-contiguous HTLC vector/);
   });
 });

--- a/services/vault/src/services/vault/__tests__/vaultRefundService.test.ts
+++ b/services/vault/src/services/vault/__tests__/vaultRefundService.test.ts
@@ -69,7 +69,7 @@ vi.mock("../fetchVaultProviders", () => ({
 
 vi.mock("../fetchVaults", () => ({
   fetchVaultRefundData: vi.fn(),
-  fetchVaultsByDepositor: vi.fn(),
+  fetchVaultIdsByDepositor: vi.fn(),
 }));
 
 import { getNetworkFees, pushTx } from "@babylonlabs-io/ts-sdk/tbv/core";
@@ -78,7 +78,7 @@ import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 
 import { getVaultFromChain } from "../../../clients/eth-contract/btc-vault-registry/query";
 import { fetchVaultProviderById } from "../fetchVaultProviders";
-import { fetchVaultRefundData, fetchVaultsByDepositor } from "../fetchVaults";
+import { fetchVaultIdsByDepositor, fetchVaultRefundData } from "../fetchVaults";
 import {
   buildAndBroadcastRefundTransaction,
   getRefundPreview,
@@ -89,6 +89,9 @@ const DEPOSITOR_PUBKEY = "aabbccdd";
 const DEPOSITOR_ADDRESS = ("0x" + "ab".repeat(20)) as `0x${string}`;
 
 const ON_CHAIN_VAULT = {
+  // Authoritative on-chain depositor — matches DEPOSITOR_ADDRESS for the
+  // happy-path tests. The wallet-mismatch tests below override it.
+  depositor: DEPOSITOR_ADDRESS,
   offchainParamsVersion: 1,
   vaultProvider: "0xprovider",
   applicationEntryPoint: "0xapp",
@@ -128,7 +131,7 @@ describe("vaultRefundService - adapter wiring", () => {
     (fetchVaultRefundData as Mock).mockResolvedValue(INDEXER_VAULT);
     // Default: depositor has just the target vault. Sibling-discovery
     // tests below override this to exercise the multi-vault branch.
-    (fetchVaultsByDepositor as Mock).mockResolvedValue([{ id: VAULT_ID }]);
+    (fetchVaultIdsByDepositor as Mock).mockResolvedValue([VAULT_ID]);
     mockGetOffchainParamsByVersion.mockResolvedValue(OFFCHAIN_PARAMS);
     (fetchVaultProviderById as Mock).mockResolvedValue(VAULT_PROVIDER);
     mockGetVaultProviderBtcPubKey.mockResolvedValue(VP_BTC_PUBKEY_X_ONLY);
@@ -441,7 +444,7 @@ describe("vaultRefundService - sibling batch discovery", () => {
 
   it("builds a length-1 batch for a single-vault deposit", async () => {
     (getVaultFromChain as Mock).mockResolvedValue(ON_CHAIN_VAULT);
-    (fetchVaultsByDepositor as Mock).mockResolvedValue([{ id: VAULT_ID }]);
+    (fetchVaultIdsByDepositor as Mock).mockResolvedValue([VAULT_ID]);
 
     let observed: { batch: ReadonlyArray<unknown> } | null = null;
     mockBuildAndBroadcastRefund.mockImplementation(
@@ -484,9 +487,9 @@ describe("vaultRefundService - sibling batch discovery", () => {
       if (id === SIBLING_VAULT_ID) return Promise.resolve(SIBLING);
       throw new Error(`Unexpected vaultId ${id}`);
     });
-    (fetchVaultsByDepositor as Mock).mockResolvedValue([
-      { id: VAULT_ID },
-      { id: SIBLING_VAULT_ID },
+    (fetchVaultIdsByDepositor as Mock).mockResolvedValue([
+      VAULT_ID,
+      SIBLING_VAULT_ID,
     ]);
 
     let observed: {
@@ -533,9 +536,9 @@ describe("vaultRefundService - sibling batch discovery", () => {
       if (id === OTHER_VAULT_ID) return Promise.resolve(UNRELATED);
       throw new Error(`Unexpected vaultId ${id}`);
     });
-    (fetchVaultsByDepositor as Mock).mockResolvedValue([
-      { id: VAULT_ID },
-      { id: OTHER_VAULT_ID },
+    (fetchVaultIdsByDepositor as Mock).mockResolvedValue([
+      VAULT_ID,
+      OTHER_VAULT_ID,
     ]);
 
     let observed: { batch: ReadonlyArray<unknown> } | null = null;
@@ -570,9 +573,9 @@ describe("vaultRefundService - sibling batch discovery", () => {
       if (id === SIBLING_VAULT_ID) return Promise.resolve(SIBLING);
       throw new Error(`Unexpected vaultId ${id}`);
     });
-    (fetchVaultsByDepositor as Mock).mockResolvedValue([
-      { id: VAULT_ID },
-      { id: SIBLING_VAULT_ID },
+    (fetchVaultIdsByDepositor as Mock).mockResolvedValue([
+      VAULT_ID,
+      SIBLING_VAULT_ID,
     ]);
 
     await expect(
@@ -584,5 +587,56 @@ describe("vaultRefundService - sibling batch discovery", () => {
         feeRate: 10,
       }),
     ).rejects.toThrow(/non-contiguous HTLC vector/);
+  });
+
+  it("throws when the connected wallet differs from the on-chain depositor", async () => {
+    // Target vault is owned by ON_CHAIN_DEPOSITOR, but the user has a
+    // different wallet connected (mid-flow wallet swap, stale modal,
+    // or opened a vault they don't own). Refuse before touching the
+    // indexer — sibling enumeration against the wrong wallet would
+    // produce an incomplete batch and a confusing downstream error.
+    const ON_CHAIN_DEPOSITOR = ("0x" + "cd".repeat(20)) as `0x${string}`;
+    (getVaultFromChain as Mock).mockResolvedValue({
+      ...ON_CHAIN_VAULT,
+      depositor: ON_CHAIN_DEPOSITOR,
+    });
+
+    await expect(
+      buildAndBroadcastRefundTransaction({
+        vaultId: VAULT_ID,
+        depositorAddress: DEPOSITOR_ADDRESS,
+        btcWalletProvider: BTC_WALLET_PROVIDER,
+        depositorBtcPubkey: DEPOSITOR_PUBKEY,
+        feeRate: 10,
+      }),
+    ).rejects.toThrow(
+      /owned by .* but the connected wallet is .*Connect with the depositor wallet/,
+    );
+    // Indexer must not have been queried — fail-closed before doing
+    // sibling lookup against the wrong wallet.
+    expect(fetchVaultIdsByDepositor).not.toHaveBeenCalled();
+  });
+
+  it("enumerates siblings using the on-chain depositor (not the connected-wallet input)", async () => {
+    // Pass an upper-case variant of the on-chain depositor. The check
+    // is case-insensitive (Ethereum address checksum), and the indexer
+    // call must go out with the *on-chain* lowercase form — regardless
+    // of how the wallet provider spells the address.
+    const CHECKSUMMED = DEPOSITOR_ADDRESS.toUpperCase() as `0x${string}`;
+    (getVaultFromChain as Mock).mockResolvedValue(ON_CHAIN_VAULT);
+    (fetchVaultIdsByDepositor as Mock).mockResolvedValue([VAULT_ID]);
+
+    await buildAndBroadcastRefundTransaction({
+      vaultId: VAULT_ID,
+      depositorAddress: CHECKSUMMED,
+      btcWalletProvider: BTC_WALLET_PROVIDER,
+      depositorBtcPubkey: DEPOSITOR_PUBKEY,
+      feeRate: 10,
+    });
+
+    expect(fetchVaultIdsByDepositor).toHaveBeenCalledTimes(1);
+    expect(fetchVaultIdsByDepositor).toHaveBeenCalledWith(
+      ON_CHAIN_VAULT.depositor,
+    );
   });
 });

--- a/services/vault/src/services/vault/fetchVaults.ts
+++ b/services/vault/src/services/vault/fetchVaults.ts
@@ -470,6 +470,71 @@ export async function fetchVaultById(vaultId: Hex): Promise<Vault | null> {
 }
 
 /**
+ * Lean enumeration of a depositor's vault IDs for the refund flow.
+ *
+ * The refund path needs to discover sibling vaults that share a batched
+ * Pre-PegIn transaction. All authoritative fields (`hashlock`, `htlcVout`,
+ * `amount`, `prePeginTxHash`) are read from the on-chain contract per
+ * candidate; the indexer is only used to enumerate vault IDs.
+ *
+ * This query intentionally projects **only `id`** so a transient indexer
+ * issue on an unrelated field (e.g. a null `depositorWotsPkHash`) cannot
+ * cause `transformVaultItem` to drop a sibling row and silently produce
+ * an incomplete batch. CLAUDE.md §refund: no silent fallbacks on critical
+ * paths.
+ */
+const GET_VAULT_IDS_BY_DEPOSITOR = gql`
+  query GetVaultIdsByDepositor($depositor: String!) {
+    vaults(where: { depositor: $depositor }) {
+      items {
+        id
+      }
+      totalCount
+    }
+  }
+`;
+
+interface VaultIdsGraphQLResponse {
+  vaults: {
+    items: { id: string }[];
+    totalCount: number;
+  };
+}
+
+/**
+ * Fetch only the `id` of each vault owned by a depositor. Used by the
+ * refund flow's sibling discovery, where every other field is read
+ * from on-chain. Throws if any returned id is malformed hex — a
+ * malformed id can't be looked up on-chain anyway.
+ *
+ * **Pagination guard:** if the indexer applies a default page-size cap
+ * and the depositor has more vaults than the cap, `items.length` will
+ * be less than the reported `totalCount`. A silently-truncated list
+ * could omit a tail sibling of a batched Pre-PegIn, so we fail closed
+ * with an actionable error instead of returning a partial set. If a
+ * real user ever hits this, the fix is to add pagination (a follow-up
+ * with concrete numbers is better than guessing the cap now).
+ */
+export async function fetchVaultIdsByDepositor(
+  depositorAddress: Address,
+): Promise<Hex[]> {
+  const data = await graphqlClient.request<VaultIdsGraphQLResponse>(
+    GET_VAULT_IDS_BY_DEPOSITOR,
+    { depositor: depositorAddress.toLowerCase() },
+  );
+  const { items, totalCount } = data.vaults;
+  if (items.length !== totalCount) {
+    throw new Error(
+      `Indexer returned ${items.length} vault ids for ${depositorAddress} ` +
+        `but totalCount=${totalCount}. The response was truncated by a ` +
+        `page-size cap and refund's sibling enumeration would be ` +
+        `incomplete; refusing to proceed.`,
+    );
+  }
+  return items.map((item) => validateRequiredHex(item.id, "id", item.id));
+}
+
+/**
  * Minimal fields needed by the refund flow — excludes unrelated required
  * fields on the full {@link Vault} projection so that indexer schema drift or
  * partial responses on non-refund fields (e.g. `depositorWotsPkHash`) cannot

--- a/services/vault/src/services/vault/vaultRefundService.ts
+++ b/services/vault/src/services/vault/vaultRefundService.ts
@@ -38,15 +38,17 @@ import {
 import { getBTCNetworkForWASM } from "../../config/pegin";
 
 import { fetchVaultProviderById } from "./fetchVaultProviders";
-import { fetchVaultRefundData, fetchVaultsByDepositor } from "./fetchVaults";
+import { fetchVaultIdsByDepositor, fetchVaultRefundData } from "./fetchVaults";
 
 export interface BroadcastRefundParams {
   vaultId: Hex;
   /**
-   * Depositor's Ethereum address. Used to discover sibling vaults that
-   * share a batched Pre-PegIn transaction (Aave-split deposits, etc.)
-   * so the WASM refund template is reconstructed against the full HTLC
-   * vector rather than just the target vault's single hashlock.
+   * Connected wallet's Ethereum address. Cross-checked against the
+   * vault's on-chain `depositor` before sibling discovery — refund
+   * refuses if the user has a vault loaded that doesn't belong to the
+   * connected wallet (a mid-flow wallet swap or a stale modal).
+   * Sibling enumeration itself uses the *on-chain* depositor as the
+   * authoritative source, not this parameter.
    */
   depositorAddress: Address;
   btcWalletProvider: {
@@ -144,21 +146,44 @@ async function readTargetVault(vaultId: Hex): Promise<TargetVaultData> {
  * Sibling membership is decided by on-chain `prePeginTxHash` equality,
  * not by indexer hex comparison — that way a stale or compromised
  * indexer cannot fabricate or drop siblings. The indexer is only used
- * to enumerate the depositor's vault IDs; each candidate's authoritative
- * hashlock / htlcVout / amount comes from the contract.
+ * to enumerate vault IDs (via the lean `id`-only projection so a
+ * malformed unrelated field on a sibling row cannot silently shrink
+ * the batch); each candidate's authoritative hashlock / htlcVout /
+ * amount comes from the contract.
+ *
+ * Enumeration uses the **on-chain** depositor of the target vault, not
+ * the connected wallet. The connected wallet's address is treated as a
+ * sanity input: if it disagrees with the on-chain depositor (e.g. the
+ * user has a stale modal open after switching wallets), refund refuses
+ * with a clear error rather than silently looking up siblings in the
+ * wrong wallet's vault list.
  */
 async function discoverBatch(
   target: TargetVaultData,
   targetVaultId: Hex,
-  depositorAddress: Address,
+  connectedDepositorAddress: Address,
 ): Promise<ReadonlyArray<VaultBatchEntry>> {
+  const onChainDepositor = target.onChainVault.depositor;
+  if (
+    onChainDepositor.toLowerCase() !== connectedDepositorAddress.toLowerCase()
+  ) {
+    throw new Error(
+      `Vault ${targetVaultId} is owned by ${onChainDepositor}, but the ` +
+        `connected wallet is ${connectedDepositorAddress}. Connect with ` +
+        `the depositor wallet to refund this vault.`,
+    );
+  }
+
   const targetPrePeginTxHash = target.onChainVault.prePeginTxHash.toLowerCase();
-  const depositorVaults = await fetchVaultsByDepositor(depositorAddress);
+  // Use the on-chain depositor (not the parameter) as the enumeration
+  // source. They're equal here by the assertion above, but the on-chain
+  // value is the authoritative one to thread into the indexer query.
+  const depositorVaultIds = await fetchVaultIdsByDepositor(onChainDepositor);
 
   const targetIdLower = targetVaultId.toLowerCase();
-  const candidateIds = depositorVaults
-    .map((v) => v.id)
-    .filter((id) => id.toLowerCase() !== targetIdLower);
+  const candidateIds = depositorVaultIds.filter(
+    (id) => id.toLowerCase() !== targetIdLower,
+  );
 
   const candidateOnChain = await Promise.all(
     candidateIds.map((id) => getVaultFromChain(id)),

--- a/services/vault/src/services/vault/vaultRefundService.ts
+++ b/services/vault/src/services/vault/vaultRefundService.ts
@@ -21,6 +21,7 @@ import {
 import {
   buildAndBroadcastRefund,
   type RefundPrePeginContext,
+  type VaultBatchEntry,
   type VaultRefundData,
 } from "@babylonlabs-io/ts-sdk/tbv/core/services";
 import { calculateBtcTxHash } from "@babylonlabs-io/ts-sdk/tbv/core/utils";
@@ -37,10 +38,17 @@ import {
 import { getBTCNetworkForWASM } from "../../config/pegin";
 
 import { fetchVaultProviderById } from "./fetchVaultProviders";
-import { fetchVaultRefundData } from "./fetchVaults";
+import { fetchVaultRefundData, fetchVaultsByDepositor } from "./fetchVaults";
 
 export interface BroadcastRefundParams {
   vaultId: Hex;
+  /**
+   * Depositor's Ethereum address. Used to discover sibling vaults that
+   * share a batched Pre-PegIn transaction (Aave-split deposits, etc.)
+   * so the WASM refund template is reconstructed against the full HTLC
+   * vector rather than just the target vault's single hashlock.
+   */
+  depositorAddress: Address;
   btcWalletProvider: {
     signPsbt: (psbtHex: string, options?: SignPsbtOptions) => Promise<string>;
   };
@@ -60,12 +68,12 @@ export interface RefundPreview {
 
 export async function getRefundPreview(vaultId: Hex): Promise<RefundPreview> {
   const mempoolApiUrl = getMempoolApiUrl();
-  const [vault, feeRecommendation] = await Promise.all([
-    readVault(vaultId),
+  const [target, feeRecommendation] = await Promise.all([
+    readTargetVault(vaultId),
     getNetworkFees(mempoolApiUrl).catch(() => null),
   ]);
   return {
-    amountSats: vault.amount,
+    amountSats: target.onChainVault.amount,
     halfHourFeeSatsVb:
       feeRecommendation && feeRecommendation.halfHourFee > 0
         ? feeRecommendation.halfHourFee
@@ -73,7 +81,18 @@ export async function getRefundPreview(vaultId: Hex): Promise<RefundPreview> {
   };
 }
 
-async function readVault(vaultId: Hex): Promise<VaultRefundData> {
+interface TargetVaultData {
+  onChainVault: Awaited<ReturnType<typeof getVaultFromChain>>;
+  unsignedPrePeginTx: Hex;
+  depositorBtcPubkey: Hex;
+}
+
+/**
+ * Read the target vault's on-chain + indexer data without doing sibling
+ * discovery. Shared by the refund-preview path (which only needs amount)
+ * and the broadcast path (which then derives the full sibling batch).
+ */
+async function readTargetVault(vaultId: Hex): Promise<TargetVaultData> {
   // Signing-critical fields come from the on-chain contract — a compromised
   // indexer could otherwise substitute a different signer set, amount, or
   // transaction. From the indexer we pull only the Pre-PegIn tx hex (not
@@ -106,16 +125,101 @@ async function readVault(vaultId: Hex): Promise<VaultRefundData> {
   }
 
   return {
-    hashlock: onChainVault.hashlock,
-    htlcVout: onChainVault.htlcVout,
-    offchainParamsVersion: onChainVault.offchainParamsVersion,
-    appVaultKeepersVersion: onChainVault.appVaultKeepersVersion,
-    universalChallengersVersion: onChainVault.universalChallengersVersion,
-    vaultProvider: onChainVault.vaultProvider,
-    applicationEntryPoint: onChainVault.applicationEntryPoint,
-    amount: onChainVault.amount,
-    unsignedPrePeginTxHex: indexerRefundData.unsignedPrePeginTx,
+    onChainVault,
+    unsignedPrePeginTx: indexerRefundData.unsignedPrePeginTx,
     depositorBtcPubkey: indexerRefundData.depositorBtcPubkey,
+  };
+}
+
+/**
+ * Discover and validate the full vout-ordered HTLC vector for the
+ * funded Pre-PegIn that this vault belongs to.
+ *
+ * For a single-vault deposit the returned batch is length 1. For a
+ * batched deposit (e.g. an Aave split that committed two vaults to one
+ * Pre-PegIn) every sibling sharing the target's `prePeginTxHash` is
+ * pulled from chain so the WASM refund template can be reconstructed
+ * with the exact (hashlocks, amounts) vector the funded tx commits to.
+ *
+ * Sibling membership is decided by on-chain `prePeginTxHash` equality,
+ * not by indexer hex comparison — that way a stale or compromised
+ * indexer cannot fabricate or drop siblings. The indexer is only used
+ * to enumerate the depositor's vault IDs; each candidate's authoritative
+ * hashlock / htlcVout / amount comes from the contract.
+ */
+async function discoverBatch(
+  target: TargetVaultData,
+  targetVaultId: Hex,
+  depositorAddress: Address,
+): Promise<ReadonlyArray<VaultBatchEntry>> {
+  const targetPrePeginTxHash = target.onChainVault.prePeginTxHash.toLowerCase();
+  const depositorVaults = await fetchVaultsByDepositor(depositorAddress);
+
+  const targetIdLower = targetVaultId.toLowerCase();
+  const candidateIds = depositorVaults
+    .map((v) => v.id)
+    .filter((id) => id.toLowerCase() !== targetIdLower);
+
+  const candidateOnChain = await Promise.all(
+    candidateIds.map((id) => getVaultFromChain(id)),
+  );
+
+  const siblings: VaultBatchEntry[] = [
+    {
+      hashlock: target.onChainVault.hashlock,
+      amount: target.onChainVault.amount,
+      htlcVout: target.onChainVault.htlcVout,
+    },
+  ];
+  for (let i = 0; i < candidateIds.length; i++) {
+    const sib = candidateOnChain[i];
+    if (sib.prePeginTxHash.toLowerCase() !== targetPrePeginTxHash) continue;
+    siblings.push({
+      hashlock: sib.hashlock,
+      amount: sib.amount,
+      htlcVout: sib.htlcVout,
+    });
+  }
+
+  siblings.sort((a, b) => a.htlcVout - b.htlcVout);
+
+  // Strict invariant: the vector must cover [0, N-1] without gaps or
+  // duplicates. The WASM template uses these positions directly; a gap
+  // would silently mis-align with the funded tx's outputs.
+  for (let i = 0; i < siblings.length; i++) {
+    if (siblings[i].htlcVout !== i) {
+      const observed = siblings.map((s) => s.htlcVout).join(", ");
+      throw new Error(
+        `Sibling vault discovery produced a non-contiguous HTLC vector ` +
+          `for prePeginTxHash ${targetPrePeginTxHash}: expected vouts ` +
+          `[0..${siblings.length - 1}], observed [${observed}]. ` +
+          `Refund refused — sibling set incomplete or indexer out of sync.`,
+      );
+    }
+  }
+  return siblings;
+}
+
+async function readVaultForRefund(
+  vaultId: Hex,
+  depositorAddress: Address,
+): Promise<VaultRefundData> {
+  const target = await readTargetVault(vaultId);
+  const batch = await discoverBatch(target, vaultId, depositorAddress);
+
+  return {
+    hashlock: target.onChainVault.hashlock,
+    htlcVout: target.onChainVault.htlcVout,
+    offchainParamsVersion: target.onChainVault.offchainParamsVersion,
+    appVaultKeepersVersion: target.onChainVault.appVaultKeepersVersion,
+    universalChallengersVersion:
+      target.onChainVault.universalChallengersVersion,
+    vaultProvider: target.onChainVault.vaultProvider,
+    applicationEntryPoint: target.onChainVault.applicationEntryPoint,
+    amount: target.onChainVault.amount,
+    unsignedPrePeginTxHex: target.unsignedPrePeginTx,
+    depositorBtcPubkey: target.depositorBtcPubkey,
+    batch,
   };
 }
 
@@ -211,8 +315,14 @@ async function readPrePeginContext(
 export async function buildAndBroadcastRefundTransaction(
   params: BroadcastRefundParams,
 ): Promise<string> {
-  const { vaultId, btcWalletProvider, depositorBtcPubkey, feeRate, signal } =
-    params;
+  const {
+    vaultId,
+    depositorAddress,
+    btcWalletProvider,
+    depositorBtcPubkey,
+    feeRate,
+    signal,
+  } = params;
   const mempoolApiUrl = getMempoolApiUrl();
 
   // Override indexer-provided depositor pubkey with the caller's wallet key —
@@ -220,7 +330,7 @@ export async function buildAndBroadcastRefundTransaction(
   const { txId } = await buildAndBroadcastRefund({
     vaultId,
     readVault: async () => {
-      const data = await readVault(vaultId);
+      const data = await readVaultForRefund(vaultId, depositorAddress);
       return { ...data, depositorBtcPubkey };
     },
     readPrePeginContext: (vault) => readPrePeginContext(vault),


### PR DESCRIPTION
Closes https://github.com/babylonlabs-io/baby-auditor-findings/issues/257

Follow-up to https://github.com/babylonlabs-io/babylon-toolkit/pull/1688 (single-vault refund auth-anchor fix).

## What this PR does

Enables the SDK refund flow to handle **batched Pre-PegIn transactions** — deposits where one funded Bitcoin transaction commits to more than one HTLC output (today: the Aave-split flow, which puts a "sacrificial" vault and a "protected" vault into the same Pre-PegIn).

Concretely, the depositor can now refund any vault in a batch (HTLC at `vout = 0`, `vout = 1`, …) through the dApp UI. Before this PR, only single-vault refunds worked; batched-vault refund attempts were explicitly rejected with a "not supported" error.

## Why

When the SDK builds a refund PSBT, it rebuilds the original Pre-PegIn transaction inside WASM (`WasmPrePeginTx`) so it can derive the exact refund script that matches what's committed on-chain. That rebuild needs the **full vector of hashlocks and amounts** — one entry per HTLC output in the funded transaction.

The old refund code only knew about the **single vault** being refunded, so it passed a one-element vector into the WASM constructor. For a batched deposit (two HTLCs sharing one funded tx), the rebuilt template was the wrong shape compared to the funded transaction → reconstruction either errored out, or — worse — silently aligned to the wrong output and produced an unspendable refund PSBT.

PR https://github.com/babylonlabs-io/babylon-toolkit/pull/1688 mitigated the *security* side of this (no silent wrong signing) by adding two defensive `throw`s for any batched scenario. But that left a real **functional gap**: Aave-split depositors whose target vault sat at any `htlcVout > 0` could not refund through the dApp at all — their BTC was effectively stuck until someone ran a custom recovery tool. This PR closes that gap.

## Approaches considered

The blocker is **data**: to rebuild the full WASM template, we need every sibling vault's `hashlock`, `amount`, and `htlcVout` in vout order. The hashlocks live inside the Taproot script tree of each HTLC output, so they can't be read by parsing the funded transaction. We have to fetch them from somewhere.

| Option | Where sibling data comes from | Trade-off |
|---|---|---|
| **A. Client-side via existing depositor query** ← **chosen** | Existing `GET_VAULTS_BY_DEPOSITOR` GraphQL query, grouped by on-chain `prePeginTxHash` | No subgraph schema change. Each vault's authoritative hashlock/amount/htlcVout already reads from the contract. Discovery cost is bounded by the depositor's vault count. |
| B. Extend indexer schema | Add an indexed `prePeginTxHash` field + `vaults(where:{prePeginTxHash})` filter | Cleaner long-term — one query gets all siblings — but requires coordinating a subgraph deploy. |
| C. Persist sibling data client-side at batch creation | localStorage / IndexedDB when the batch is built | Drift risk: lost on browser changes, wiped data, different devices. The whole point of refund is that it must work even months later. |
| D. Keep blocking + offline recovery tool | None — accept the gap | Lowest dApp effort, worst depositor experience. Aave-split batches ship in production today. |

## Why A was chosen

- **No new infrastructure**: the indexer already returns the depositor's vault list, the contract already exposes `prePeginTxHash` per vault. We just combine what exists.
- **Authoritative data path**: per `CLAUDE.md §1`, signing-critical fields come from the on-chain contract. The indexer is only used to *enumerate vault IDs* — every hashlock, amount, and `htlcVout` that goes into the WASM template is pulled from the contract. A stale or compromised indexer cannot fabricate siblings.
- **Bounded scope**: depositor's vault count is small in practice (mostly Aave splits — 2 vaults). Sibling discovery is one indexer call + N parallel contract reads.
- **Drift-free**: option C's "persist locally" would invent new state that has to stay in sync with the funded transaction. The funded transaction already carries the truth on-chain.

## What's in the diff

**SDK** (`packages/babylon-ts-sdk`):
- `VaultRefundData` gains a `batch: ReadonlyArray<VaultBatchEntry>` field — the full vout-ordered HTLC vector.
- The orchestrator's two defensive `throw`s (`htlcVout !== 0` and `auth-anchor OP_RETURN at vout != 1`) are replaced with **positive invariants** that work for both `N=1` (single) and `N>1` (batched):
  - Batch covers `[0, N-1]` contiguously with no gaps or duplicates.
  - Target vault's `(hashlock, amount, htlcVout)` matches its batch entry.
  - Auth-anchor OP_RETURN — if present — sits at exactly `vout = batch.length`.
  - Funded tx has at least `batch.length` outputs.
- The refund primitive forwards the full `(hashlocks, pegInAmounts)` arrays into the WASM constructor, and adds the audit's explicit cross-check: the reconstructed HTLC `scriptPubKey` at `htlcVout` must equal the funded tx's `scriptPubKey` at that vout, byte-for-byte.

**Vault dApp** (`services/vault`):
- `vaultRefundService` does sibling discovery: enumerates the depositor's vaults via the existing `GET_VAULTS_BY_DEPOSITOR` query, reads on-chain `prePeginTxHash` for each candidate, filters siblings sharing the target's `prePeginTxHash`, sorts by `htlcVout`, and assembles the `batch` vector. Single-vault deposits get a length-1 batch transparently.
- The refund hook passes the connected ETH wallet address as `depositorAddress`, and refuses to start a refund without it.

## Notes for the reviewer

- The audit's exploit sketch ("a legitimate batch vault reaches signing with an incomplete refund graph") was already mitigated by https://github.com/babylonlabs-io/babylon-toolkit/pull/1688 — the defensive `throw`s prevented the silent-wrong-signing case. This PR removes those `throw`s and replaces them with positive invariants that *also* let valid batched refunds through.
- The scriptPubKey cross-check in `buildRefundPsbt` is the literal recommendation from the audit ("assert the derived HTLC scriptPubKey for `htlcVout` equals the funded Pre-PegIn output script"). It runs after every WASM reconstruction — defense in depth, single-vault and multi-vault alike.
