### PR TITLE
feat(vault): add progress bar and step indicator to pending deposits

### DIFF
--- a/services/vault/src/components/simple/DepositProgressView/ProgressBar.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/ProgressBar.tsx
@@ -1,9 +1,16 @@
 interface ProgressBarProps {
   percent: number;
+  /** Explicit fill color (any CSS color). Defaults to the success (green) fill
+   * used by the in-flow stepper; pending deposit cards pass the asset color. */
+  color?: string;
 }
 
-export function ProgressBar({ percent }: ProgressBarProps) {
+export function ProgressBar({ percent, color }: ProgressBarProps) {
   const clamped = Math.max(0, Math.min(1, percent));
+  // When no explicit color is given, fall back to the green success fill class.
+  const fillClassName = color
+    ? "h-full transition-[width] duration-300"
+    : "h-full bg-success-light transition-[width] duration-300";
   return (
     <div
       role="progressbar"
@@ -13,8 +20,11 @@ export function ProgressBar({ percent }: ProgressBarProps) {
       className="h-1 w-full overflow-hidden rounded-full bg-secondary-strokeLight"
     >
       <div
-        className="h-full bg-success-light transition-[width] duration-300"
-        style={{ width: `${clamped * 100}%` }}
+        className={fillClassName}
+        style={{
+          width: `${clamped * 100}%`,
+          ...(color ? { backgroundColor: color } : {}),
+        }}
       />
     </div>
   );

--- a/services/vault/src/components/simple/DepositProgressView/__tests__/ProgressBar.test.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/__tests__/ProgressBar.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ProgressBar } from "../ProgressBar";
+
+describe("ProgressBar", () => {
+  it("defaults to the success (green) fill when no color is given", () => {
+    const { container } = render(<ProgressBar percent={0.5} />);
+    expect(container.querySelector(".bg-success-light")).toBeInTheDocument();
+  });
+
+  it("tints the fill with an explicit color and drops the default class", () => {
+    const { container } = render(<ProgressBar percent={0.5} color="#F7931A" />);
+    const fill = container.querySelector<HTMLElement>("[style]");
+    expect(fill).not.toBeNull();
+    expect(fill).toHaveStyle({ backgroundColor: "#F7931A" });
+    expect(
+      container.querySelector(".bg-success-light"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("clamps the reported percentage to the 0-100 range", () => {
+    render(<ProgressBar percent={1.5} />);
+    expect(screen.getByRole("progressbar")).toHaveAttribute(
+      "aria-valuenow",
+      "100",
+    );
+  });
+});

--- a/services/vault/src/components/simple/DepositProgressView/__tests__/steps.test.ts
+++ b/services/vault/src/components/simple/DepositProgressView/__tests__/steps.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { COPY } from "@/copy";
+import { DepositFlowStep } from "@/hooks/deposit/depositFlowSteps/types";
+
+import {
+  getStepFillPercent,
+  getStepLabel,
+  getVisualStep,
+  TOTAL_VISUAL_STEPS,
+} from "../steps";
+
+describe("getStepLabel", () => {
+  it("returns the awaiting-confirmation label for AWAIT_BTC_CONFIRMATION", () => {
+    expect(getStepLabel(DepositFlowStep.AWAIT_BTC_CONFIRMATION)).toBe(
+      COPY.deposit.steps.awaitBtcConfirmation,
+    );
+  });
+
+  it("returns the reveal-secret label for ACTIVATE_VAULT", () => {
+    expect(getStepLabel(DepositFlowStep.ACTIVATE_VAULT)).toBe(
+      COPY.deposit.steps.revealSecret,
+    );
+  });
+
+  it("returns the generate-secret label for the first step", () => {
+    expect(getStepLabel(DepositFlowStep.DERIVE_VAULT_SECRET)).toBe(
+      COPY.deposit.steps.generateSecret,
+    );
+  });
+
+  it("aligns the visual step index with the total step count", () => {
+    // The last actionable step must map within the bounds of the label list so
+    // getStepLabel never falls back to an empty string for a real step.
+    expect(getVisualStep(DepositFlowStep.ACTIVATE_VAULT)).toBe(
+      TOTAL_VISUAL_STEPS,
+    );
+  });
+});
+
+describe("getStepFillPercent", () => {
+  it("fills by completed steps, not the in-progress current step", () => {
+    // AWAIT_BTC_CONFIRMATION is visual step 6 -> 5 completed of 11.
+    expect(
+      getStepFillPercent(DepositFlowStep.AWAIT_BTC_CONFIRMATION),
+    ).toBeCloseTo(5 / TOTAL_VISUAL_STEPS);
+  });
+
+  it("never reports a full bar on the last actionable step", () => {
+    // ACTIVATE_VAULT is the last step; 10 completed of 11, never 100%.
+    expect(getStepFillPercent(DepositFlowStep.ACTIVATE_VAULT)).toBeCloseTo(
+      (TOTAL_VISUAL_STEPS - 1) / TOTAL_VISUAL_STEPS,
+    );
+    expect(getStepFillPercent(DepositFlowStep.ACTIVATE_VAULT)).toBeLessThan(1);
+  });
+});

--- a/services/vault/src/components/simple/DepositProgressView/steps.ts
+++ b/services/vault/src/components/simple/DepositProgressView/steps.ts
@@ -53,6 +53,23 @@ export function buildStepItems(
 
 export const TOTAL_VISUAL_STEPS = buildStepItems(null).length;
 
+/**
+ * Resolve the human-readable label for a deposit flow step, reusing the same
+ * step definitions that drive the in-flow stepper (single source of truth).
+ */
+export function getStepLabel(step: DepositFlowStep): string {
+  return buildStepItems(null)[getVisualStep(step) - 1]?.label ?? "";
+}
+
+/**
+ * Progress-bar fill (0–1) for a deposit flow step. Reflects completed steps —
+ * the current step is in progress, not done — matching the in-flow stepper's
+ * bar so the last actionable step never reads as 100%.
+ */
+export function getStepFillPercent(step: DepositFlowStep): number {
+  return Math.max(0, getVisualStep(step) - 1) / TOTAL_VISUAL_STEPS;
+}
+
 export function getVisualStep(currentStep: DepositFlowStep): number {
   switch (currentStep) {
     case DepositFlowStep.DERIVE_VAULT_SECRET:

--- a/services/vault/src/components/simple/DepositStepLabel.tsx
+++ b/services/vault/src/components/simple/DepositStepLabel.tsx
@@ -1,0 +1,32 @@
+/**
+ * DepositStepLabel
+ *
+ * "Step X of Y — <label>" line shown beneath the amount on pending deposit
+ * cards. The accompanying progress bar is rendered separately (full width).
+ */
+
+import { COPY } from "@/copy";
+
+interface DepositStepLabelProps {
+  /** 1-based current step within the deposit flow. */
+  visualStep: number;
+  /** Total number of steps in the deposit flow. */
+  totalSteps: number;
+  /** Human-readable label for the current step. */
+  label: string;
+}
+
+export function DepositStepLabel({
+  visualStep,
+  totalSteps,
+  label,
+}: DepositStepLabelProps) {
+  return (
+    <span className="text-sm">
+      <span className="text-accent-secondary">
+        {COPY.pegin.progress.stepCounter(visualStep, totalSteps)}{" "}
+      </span>
+      <span className="font-medium text-accent-primary">{label}</span>
+    </span>
+  );
+}

--- a/services/vault/src/components/simple/PendingDepositCard.tsx
+++ b/services/vault/src/components/simple/PendingDepositCard.tsx
@@ -12,13 +12,27 @@ import {
   isArtifactDownloadAvailable,
   PeginAction,
 } from "@/components/deposit/actionStatus";
+import { getNetworkConfigBTC } from "@/config";
 import { useDepositPollingResult } from "@/context/deposit/PeginPollingContext";
 import { COPY } from "@/copy";
+import { getPeginDisplayStep } from "@/models/peginStateMachine";
+import { getTokenBrandColor } from "@/services/token/tokenService";
 import type { VaultProvider } from "@/types/vaultProvider";
 import { truncateAddress } from "@/utils/addressUtils";
 
+import { ProgressBar } from "./DepositProgressView/ProgressBar";
+import {
+  getStepFillPercent,
+  getStepLabel,
+  getVisualStep,
+  TOTAL_VISUAL_STEPS,
+} from "./DepositProgressView/steps";
+import { DepositStepLabel } from "./DepositStepLabel";
 import { STATUS_DOT_COLORS } from "./statusColors";
 import { VaultDetailCard, VaultStatusBadge } from "./VaultDetailCard";
+
+// The deposited asset is Bitcoin; tint the progress bar with its brand color.
+const ASSET_BRAND_COLOR = getTokenBrandColor(getNetworkConfigBTC().coinSymbol);
 
 interface PendingDepositCardProps {
   depositId: string;
@@ -101,6 +115,11 @@ export function PendingDepositCard({
   const buttonDisabled = !isActionable || loading;
   const dotColor = STATUS_DOT_COLORS[peginState.displayVariant];
 
+  // Map the current state onto the shared deposit-flow step model so the card
+  // can show "Step X of Y" + a progress bar. `null` when there's no meaningful
+  // in-progress step (those states don't reach the pending sections).
+  const step = getPeginDisplayStep(peginState);
+
   // Resolve provider name
   const provider = vaultProviders.find((vp) => vp.id === providerId);
   const providerName =
@@ -114,12 +133,29 @@ export function PendingDepositCard({
       providerName={providerName}
       providerIconUrl={provider?.iconUrl}
       providerAddress={providerId}
-      statusContent={
+      headerEnd={
         <VaultStatusBadge
           dotColor={dotColor}
           label={peginState.displayLabel}
           tooltip={peginState.message}
         />
+      }
+      amountSubtext={
+        step !== null && (
+          <DepositStepLabel
+            visualStep={getVisualStep(step)}
+            totalSteps={TOTAL_VISUAL_STEPS}
+            label={getStepLabel(step)}
+          />
+        )
+      }
+      belowHeader={
+        step !== null && (
+          <ProgressBar
+            percent={getStepFillPercent(step)}
+            color={ASSET_BRAND_COLOR}
+          />
+        )
       }
       action={
         isActionable || showArtifactDownload ? (

--- a/services/vault/src/components/simple/VaultDetailCard.tsx
+++ b/services/vault/src/components/simple/VaultDetailCard.tsx
@@ -29,8 +29,16 @@ interface VaultDetailCardProps {
   providerIconUrl?: string;
   /** Vault provider Ethereum address, shown on hover over the provider label */
   providerAddress: string;
-  /** Status content — rendered as the value in the Status row */
-  statusContent: ReactNode;
+  /** Status content — rendered as the value in the Status row. Omit to hide the
+   * row entirely (e.g. when the status badge is rendered in the header). */
+  statusContent?: ReactNode;
+  /** Optional content rendered beneath the amount, in the same row as the icon
+   * (e.g. a step indicator). */
+  amountSubtext?: ReactNode;
+  /** Optional content rendered at the right end of the amount/header row. */
+  headerEnd?: ReactNode;
+  /** Optional content rendered immediately below the amount/header row. */
+  belowHeader?: ReactNode;
   /** Optional action button rendered at the bottom */
   action?: ReactNode;
 }
@@ -43,17 +51,32 @@ export function VaultDetailCard({
   providerIconUrl,
   providerAddress,
   statusContent,
+  amountSubtext,
+  headerEnd,
+  belowHeader,
   action,
 }: VaultDetailCardProps) {
   return (
     <div className="space-y-3 rounded-xl border border-secondary-strokeLight p-4">
-      {/* BTC icon + amount */}
-      <div className="flex items-center gap-2">
-        <Avatar url={btcConfig.icon} alt={btcConfig.coinSymbol} size="small" />
-        <span className="text-base font-medium text-accent-primary">
-          {formatBtcAmount(amountBtc)}
-        </span>
+      {/* BTC icon + amount (+ optional subtext), optional header-end content */}
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <Avatar
+            url={btcConfig.icon}
+            alt={btcConfig.coinSymbol}
+            size="small"
+          />
+          <div className="flex flex-col gap-0.5">
+            <span className="text-base font-medium text-accent-primary">
+              {formatBtcAmount(amountBtc)}
+            </span>
+            {amountSubtext}
+          </div>
+        </div>
+        {headerEnd}
       </div>
+
+      {belowHeader}
 
       {/* Date */}
       <div className="flex items-center justify-between">
@@ -64,10 +87,12 @@ export function VaultDetailCard({
       </div>
 
       {/* Status */}
-      <div className="flex items-center justify-between">
-        <span className="text-sm text-accent-secondary">Status</span>
-        {statusContent}
-      </div>
+      {statusContent && (
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-accent-secondary">Status</span>
+          {statusContent}
+        </div>
+      )}
 
       {/* Vault Provider */}
       <div className="flex items-center justify-between">

--- a/services/vault/src/components/simple/__tests__/DepositStepLabel.test.tsx
+++ b/services/vault/src/components/simple/__tests__/DepositStepLabel.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { DepositStepLabel } from "../DepositStepLabel";
+
+describe("DepositStepLabel", () => {
+  it("renders the step counter and the step label", () => {
+    render(
+      <DepositStepLabel
+        visualStep={6}
+        totalSteps={11}
+        label="Awaiting Bitcoin confirmation"
+      />,
+    );
+    expect(screen.getByText("Step 6 of 11")).toBeInTheDocument();
+    expect(
+      screen.getByText("Awaiting Bitcoin confirmation"),
+    ).toBeInTheDocument();
+  });
+});

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -119,6 +119,10 @@ export const COPY = {
       groupLabel: "Batched deposit",
       broadcastHelper: "Broadcasts once for all vaults in this deposit",
     },
+    progress: {
+      stepCounter: (current: number, total: number) =>
+        `Step ${current} of ${total}`,
+    },
   },
   deposit: {
     steps: {

--- a/services/vault/src/models/__tests__/peginStateMachine.test.ts
+++ b/services/vault/src/models/__tests__/peginStateMachine.test.ts
@@ -602,6 +602,15 @@ describe("peginStateMachine", () => {
       expect(getPeginDisplayStep(state)).toBe(DepositFlowStep.ACTIVATE_VAULT);
     });
 
+    it("returns null for a failed pending deposit so it does not look like it is progressing", () => {
+      const state = getPeginState(ContractStatus.PENDING, {
+        vpTerminalError: "Deposit rejected by the vault provider.",
+      });
+      expect(state.displayLabel).toBe(PEGIN_DISPLAY_LABELS.FAILED);
+      expect(state.displayVariant).toBe("warning");
+      expect(getPeginDisplayStep(state)).toBe(null);
+    });
+
     it("returns null for terminal states with no in-progress step", () => {
       expect(getPeginDisplayStep(getPeginState(ContractStatus.EXPIRED))).toBe(
         null,

--- a/services/vault/src/models/__tests__/peginStateMachine.test.ts
+++ b/services/vault/src/models/__tests__/peginStateMachine.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
 
+import { DepositFlowStep } from "@/hooks/deposit/depositFlowSteps/types";
+
 import {
   canPerformAction,
   ContractStatus,
   getNextLocalStatus,
+  getPeginDisplayStep,
   getPeginState,
   getPrimaryActionButton,
   LocalStorageStatus,
@@ -526,6 +529,86 @@ describe("peginStateMachine", () => {
           LocalStorageStatus.REFUND_BROADCAST,
         ),
       ).toBe(true);
+    });
+  });
+
+  // ==========================================================================
+  // getPeginDisplayStep — derives the live deposit flow step from real state
+  // ==========================================================================
+  describe("getPeginDisplayStep", () => {
+    it("maps a pending broadcast action to BROADCAST_PRE_PEGIN", () => {
+      const state = getPeginState(ContractStatus.PENDING, {
+        pendingIngestion: true,
+      });
+      expect(state.availableActions).toContain(
+        PeginAction.SIGN_AND_BROADCAST_TO_BITCOIN,
+      );
+      expect(getPeginDisplayStep(state)).toBe(
+        DepositFlowStep.BROADCAST_PRE_PEGIN,
+      );
+    });
+
+    it("maps the awaiting-confirmation PENDING state (no action) to AWAIT_BTC_CONFIRMATION", () => {
+      const state = getPeginState(ContractStatus.PENDING, {
+        localStatus: LocalStorageStatus.CONFIRMING,
+        pendingIngestion: true,
+      });
+      expect(state.availableActions).toEqual([PeginAction.NONE]);
+      expect(getPeginDisplayStep(state)).toBe(
+        DepositFlowStep.AWAIT_BTC_CONFIRMATION,
+      );
+    });
+
+    it("maps a pending WOTS-key action to SUBMIT_WOTS_KEYS", () => {
+      const state = getPeginState(ContractStatus.PENDING, {
+        needsWotsKey: true,
+      });
+      expect(state.availableActions).toContain(PeginAction.SUBMIT_WOTS_KEY);
+      expect(getPeginDisplayStep(state)).toBe(DepositFlowStep.SUBMIT_WOTS_KEYS);
+    });
+
+    it("maps a pending payout-signing action to SIGN_PAYOUTS", () => {
+      const state = getPeginState(ContractStatus.PENDING, {
+        localStatus: LocalStorageStatus.CONFIRMING,
+        pendingIngestion: false,
+        transactionsReady: true,
+      });
+      expect(state.availableActions).toContain(
+        PeginAction.SIGN_PAYOUT_TRANSACTIONS,
+      );
+      expect(getPeginDisplayStep(state)).toBe(DepositFlowStep.SIGN_PAYOUTS);
+    });
+
+    it("maps payouts-signed-and-awaiting-verification to ARTIFACT_DOWNLOAD", () => {
+      const state = getPeginState(ContractStatus.PENDING, {
+        localStatus: LocalStorageStatus.PAYOUT_SIGNED,
+      });
+      expect(state.availableActions).toEqual([PeginAction.NONE]);
+      expect(getPeginDisplayStep(state)).toBe(
+        DepositFlowStep.ARTIFACT_DOWNLOAD,
+      );
+    });
+
+    it("maps a VERIFIED vault ready to activate to ACTIVATE_VAULT", () => {
+      const state = getPeginState(ContractStatus.VERIFIED);
+      expect(getPeginDisplayStep(state)).toBe(DepositFlowStep.ACTIVATE_VAULT);
+    });
+
+    it("keeps a VERIFIED vault with activation broadcast on ACTIVATE_VAULT", () => {
+      const state = getPeginState(ContractStatus.VERIFIED, {
+        localStatus: LocalStorageStatus.CONFIRMED,
+      });
+      expect(state.displayLabel).toBe(PEGIN_DISPLAY_LABELS.PROCESSING);
+      expect(getPeginDisplayStep(state)).toBe(DepositFlowStep.ACTIVATE_VAULT);
+    });
+
+    it("returns null for terminal states with no in-progress step", () => {
+      expect(getPeginDisplayStep(getPeginState(ContractStatus.EXPIRED))).toBe(
+        null,
+      );
+      expect(getPeginDisplayStep(getPeginState(ContractStatus.ACTIVE))).toBe(
+        null,
+      );
     });
   });
 });

--- a/services/vault/src/models/peginStateMachine.ts
+++ b/services/vault/src/models/peginStateMachine.ts
@@ -15,6 +15,7 @@ import {
 } from "@babylonlabs-io/ts-sdk/tbv/core/services";
 
 import { COPY } from "@/copy";
+import { DepositFlowStep } from "@/hooks/deposit/depositFlowSteps/types";
 
 export { ContractStatus } from "@babylonlabs-io/ts-sdk/tbv/core/services";
 export type {
@@ -515,6 +516,55 @@ export function getPrimaryActionButton(state: PeginState): {
       action: PeginAction.REFUND_HTLC,
     };
   }
+  return null;
+}
+
+// ============================================================================
+// Progress step mapping — maps the live pegin state onto the shared deposit
+// flow model (the single source of truth for step numbers and labels lives in
+// DepositProgressView/steps.ts). Used to render a progress bar on pending
+// deposit cards. The step is derived from the actual contract status, pending
+// next action, and local tracking — not a fixed value — so it tracks the real
+// position of each deposit.
+// ============================================================================
+
+/**
+ * Derive a pending deposit's position in the deposit flow from its live state,
+ * or `null` when there is no meaningful in-progress step (terminal/active/
+ * expired states, which the pending sections already filter out).
+ *
+ * The next available action is the most reliable signal of where a deposit
+ * sits; when no action is pending we fall back to contract/local status to tell
+ * "awaiting Bitcoin confirmation" apart from "payouts signed, awaiting the VP".
+ */
+export function getPeginDisplayStep(state: PeginState): DepositFlowStep | null {
+  const { contractStatus, availableActions, localStatus } = state;
+
+  if (contractStatus === ContractStatus.PENDING) {
+    if (availableActions.includes(PeginAction.SIGN_AND_BROADCAST_TO_BITCOIN)) {
+      return DepositFlowStep.BROADCAST_PRE_PEGIN;
+    }
+    if (availableActions.includes(PeginAction.SUBMIT_WOTS_KEY)) {
+      return DepositFlowStep.SUBMIT_WOTS_KEYS;
+    }
+    if (availableActions.includes(PeginAction.SIGN_PAYOUT_TRANSACTIONS)) {
+      return DepositFlowStep.SIGN_PAYOUTS;
+    }
+    // No action pending. Once payouts are signed the deposit is waiting for the
+    // VP to verify on-chain (artifact-download stage); otherwise it is still
+    // waiting for the Pre-Pegin to confirm / be detected.
+    if (localStatus === LocalStorageStatus.PAYOUT_SIGNED) {
+      return DepositFlowStep.ARTIFACT_DOWNLOAD;
+    }
+    return DepositFlowStep.AWAIT_BTC_CONFIRMATION;
+  }
+
+  if (contractStatus === ContractStatus.VERIFIED) {
+    // Ready to activate, or activation already broadcast and awaiting
+    // confirmation — both sit on the final reveal/activate step.
+    return DepositFlowStep.ACTIVATE_VAULT;
+  }
+
   return null;
 }
 

--- a/services/vault/src/models/peginStateMachine.ts
+++ b/services/vault/src/models/peginStateMachine.ts
@@ -540,6 +540,11 @@ export function getPrimaryActionButton(state: PeginState): {
 export function getPeginDisplayStep(state: PeginState): DepositFlowStep | null {
   const { contractStatus, availableActions, localStatus } = state;
 
+  // A warning state (e.g. a terminal provider failure, expired, liquidated,
+  // invalid) is not in-progress — never show a step/progress bar for it, so a
+  // failed deposit doesn't look like it is still advancing.
+  if (state.displayVariant === "warning") return null;
+
   if (contractStatus === ContractStatus.PENDING) {
     if (availableActions.includes(PeginAction.SIGN_AND_BROADCAST_TO_BITCOIN)) {
       return DepositFlowStep.BROADCAST_PRE_PEGIN;

--- a/services/vault/src/services/token/tokenService.ts
+++ b/services/vault/src/services/token/tokenService.ts
@@ -125,6 +125,8 @@ const tokenMetadataCache = new Map<string, TokenMetadata>();
 
 const tokenBrandColorsMap: Record<string, string> = {
   BTC: "#F7931A",
+  SBTC: "#F7931A",
+  TBTC: "#F7931A",
   WBTC: "#F7931A",
   VBTC: "#F7931A",
   USDC: "#2775CA",


### PR DESCRIPTION
Surface each pending deposit's position in the deposit flow as a "Step X of Y" line beneath the amount plus an asset-colored progress bar, and move the status badge to the card header.

The step is derived from the deposit's live state (next available action, contract status, local tracking), reusing the in-flow stepper model as the single source of truth for step numbers and labels so the indicator reflects real progress rather than a fixed value.

## Screenshots
<img width="1366" height="1770" alt="image" src="https://github.com/user-attachments/assets/e7c0bec7-ac04-42e1-9154-95a545541f7c" />
