### PR TITLE
feat(vault,ts-sdk): show real Pre-PegIn confirmation progress

### DIFF
--- a/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/__tests__/mempoolApi.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/__tests__/mempoolApi.test.ts
@@ -13,6 +13,7 @@ import {
   getAddressTxs,
   getAddressUtxos,
   getNetworkFees,
+  getTipHeight,
   getTxHex,
   getTxInfo,
   getUtxoInfo,
@@ -52,6 +53,17 @@ function jsonResponse(body: unknown): Response {
     headers: new Headers({ "content-type": "application/json" }),
     json: () => Promise.resolve(body),
     text: () => Promise.resolve(JSON.stringify(body)),
+  } as Response;
+}
+
+function textResponse(body: string): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    headers: new Headers({ "content-type": "text/plain" }),
+    json: () => Promise.reject(new Error("not json")),
+    text: () => Promise.resolve(body),
   } as Response;
 }
 
@@ -466,6 +478,25 @@ describe("getNetworkFees", () => {
     );
     const result = await getNetworkFees(API_URL);
     expect(result.fastestFee).toBe(10000);
+  });
+});
+
+describe("getTipHeight", () => {
+  it("returns the current block tip height as a number", async () => {
+    mockFetch.mockResolvedValueOnce(textResponse("868213"));
+    await expect(getTipHeight(API_URL)).resolves.toBe(868213);
+  });
+
+  it("tolerates surrounding whitespace in the plain-text response", async () => {
+    mockFetch.mockResolvedValueOnce(textResponse("  868213\n"));
+    await expect(getTipHeight(API_URL)).resolves.toBe(868213);
+  });
+
+  it("throws when the response is not a whole number", async () => {
+    mockFetch.mockResolvedValueOnce(textResponse("not-a-height"));
+    await expect(getTipHeight(API_URL)).rejects.toThrow(
+      /block tip height/i,
+    );
   });
 });
 

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/index.ts
@@ -11,6 +11,7 @@ export {
   getAddressUtxos,
   getMempoolApiUrl,
   getNetworkFees,
+  getTipHeight,
   getTxHex,
   getTxInfo,
   getUtxoInfo,

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts
@@ -210,6 +210,27 @@ export async function getTxInfo(txid: string, apiUrl: string): Promise<TxInfo> {
 }
 
 /**
+ * Get the current block tip height.
+ *
+ * Source: mempool.space API — `GET /api/blocks/tip/height` returns the height
+ * of the most recent block as a plain-text integer.
+ *
+ * @param apiUrl - Mempool API base URL
+ * @returns The height of the most recent block
+ * @throws Error if the response is not a whole number
+ */
+export async function getTipHeight(apiUrl: string): Promise<number> {
+  const raw = await fetchApi<string>(`${apiUrl}/blocks/tip/height`);
+  const trimmed = raw.trim();
+  if (!/^\d+$/.test(trimmed)) {
+    throw new Error(
+      `Mempool API returned an invalid block tip height: "${raw}"`,
+    );
+  }
+  return Number.parseInt(trimmed, 10);
+}
+
+/**
  * Get the hex representation of a transaction.
  *
  * @param txid - The transaction ID

--- a/services/vault/src/components/simple/DepositProgressView/BtcConfirmationDetail.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/BtcConfirmationDetail.tsx
@@ -1,19 +1,20 @@
 import { Loader, Text } from "@babylonlabs-io/core-ui";
-import { useEffect, useState } from "react";
 
 import { CopyableHash } from "@/components/shared/CopyableHash";
+import { COPY } from "@/copy";
 import { getBtcExplorerTxUrl } from "@/utils/explorer";
 
-import { EXPECTED_CONFIRMATION_MINUTES } from "./steps";
-
-const TICK_INTERVAL_MS = 30 * 1000;
-const MS_PER_MINUTE = 60 * 1000;
+import { computeRemainingEstimateMinutes } from "./btcConfirmationProgress";
 
 interface BtcConfirmationDetailProps {
   /** Date.now() when the AWAIT_BTC_CONFIRMATION step was first entered. */
   startedAt: number;
-  /** Raw BTC pegin transaction hash (with or without 0x). */
-  peginTxHash: string;
+  /** Pre-PegIn broadcast txid — the tx actually on the Bitcoin network. */
+  prePeginTxid: string;
+  /** Confirmations of the Pre-PegIn tx; null while the first reading loads. */
+  confirmations: number | null;
+  /** Protocol-required confirmation depth (`minPrepeginDepth`). */
+  requiredDepth: number;
 }
 
 function formatStartedAt(timestamp: number): string {
@@ -25,26 +26,23 @@ function formatStartedAt(timestamp: number): string {
 
 export function BtcConfirmationDetail({
   startedAt,
-  peginTxHash,
+  prePeginTxid,
+  confirmations,
+  requiredDepth,
 }: BtcConfirmationDetailProps) {
-  const [now, setNow] = useState<number>(() => Date.now());
+  const copy = COPY.deposit.btcConfirmation;
 
-  useEffect(() => {
-    const id = window.setInterval(() => setNow(Date.now()), TICK_INTERVAL_MS);
-    return () => window.clearInterval(id);
-  }, []);
-
-  const elapsedMinutes = Math.floor((now - startedAt) / MS_PER_MINUTE);
-  const remainingMinutes = Math.max(
-    0,
-    EXPECTED_CONFIRMATION_MINUTES - elapsedMinutes,
-  );
+  // undefined = still loading; null = depth reached (finalizing); number = wait.
+  const estimateMinutes =
+    confirmations === null
+      ? undefined
+      : computeRemainingEstimateMinutes(confirmations, requiredDepth);
 
   return (
     <div className="mt-3 flex flex-col gap-2 rounded-lg bg-secondary-highlight p-3">
       <div className="flex items-center justify-between gap-2">
         <Text as="span" variant="body2" className="text-accent-secondary">
-          Started at:
+          {copy.startedAt}:
         </Text>
         <Text as="span" variant="body2" className="text-accent-primary">
           {formatStartedAt(startedAt)}
@@ -53,24 +51,43 @@ export function BtcConfirmationDetail({
 
       <div className="flex items-center justify-between gap-2">
         <Text as="span" variant="body2" className="text-accent-secondary">
-          Est. Remaining:
+          {copy.confirmations}:
         </Text>
-        <span className="flex items-center gap-2">
+        {confirmations === null ? (
           <Loader size={14} className="text-accent-primary" />
+        ) : (
           <Text as="span" variant="body2" className="text-accent-primary">
-            ~{remainingMinutes} min
+            {copy.confirmationProgress(
+              Math.min(confirmations, requiredDepth),
+              requiredDepth,
+            )}
           </Text>
-        </span>
+        )}
       </div>
 
       <div className="flex items-center justify-between gap-2">
         <Text as="span" variant="body2" className="text-accent-secondary">
-          Bitcoin TX:
+          {copy.estRemaining}:
+        </Text>
+        {estimateMinutes === undefined ? (
+          <Loader size={14} className="text-accent-primary" />
+        ) : (
+          <Text as="span" variant="body2" className="text-accent-primary">
+            {estimateMinutes === null
+              ? copy.finalizing
+              : copy.estRemainingValue(estimateMinutes)}
+          </Text>
+        )}
+      </div>
+
+      <div className="flex items-center justify-between gap-2">
+        <Text as="span" variant="body2" className="text-accent-secondary">
+          {copy.bitcoinTx}:
         </Text>
         <CopyableHash
-          hash={peginTxHash}
+          hash={prePeginTxid}
           chain="BTC"
-          explorerUrl={getBtcExplorerTxUrl(peginTxHash)}
+          explorerUrl={getBtcExplorerTxUrl(prePeginTxid)}
         />
       </div>
     </div>

--- a/services/vault/src/components/simple/DepositProgressView/BtcConfirmationDetailContainer.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/BtcConfirmationDetailContainer.tsx
@@ -1,0 +1,34 @@
+/**
+ * Wires the live confirmation poll and the protocol-required depth into the
+ * presentational BtcConfirmationDetail. Mounted only while the deposit is on
+ * the AWAIT_BTC_CONFIRMATION step, so the mempool poll runs only then.
+ */
+
+import { useProtocolParamsContext } from "@/context/ProtocolParamsContext";
+import { useBtcConfirmations } from "@/hooks/deposit/useBtcConfirmations";
+
+import { BtcConfirmationDetail } from "./BtcConfirmationDetail";
+
+interface BtcConfirmationDetailContainerProps {
+  /** Date.now() when the AWAIT_BTC_CONFIRMATION step was first entered. */
+  startedAt: number;
+  /** Pre-PegIn broadcast txid — the tx actually on the Bitcoin network. */
+  prePeginTxid: string;
+}
+
+export function BtcConfirmationDetailContainer({
+  startedAt,
+  prePeginTxid,
+}: BtcConfirmationDetailContainerProps) {
+  const { confirmations } = useBtcConfirmations(prePeginTxid);
+  const { config } = useProtocolParamsContext();
+
+  return (
+    <BtcConfirmationDetail
+      startedAt={startedAt}
+      prePeginTxid={prePeginTxid}
+      confirmations={confirmations}
+      requiredDepth={config.offchainParams.minPrepeginDepth}
+    />
+  );
+}

--- a/services/vault/src/components/simple/DepositProgressView/DepositProgressView.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/DepositProgressView.tsx
@@ -23,7 +23,7 @@ import { DepositFlowStep } from "@/hooks/deposit/depositFlowSteps/types";
 import type { PayoutSigningProgress } from "@/services/vault/vaultPayoutSignatureService";
 import type { PeginSigningProgress } from "@/services/vault/vaultTransactionService";
 
-import { BtcConfirmationDetail } from "./BtcConfirmationDetail";
+import { BtcConfirmationDetailContainer } from "./BtcConfirmationDetailContainer";
 import { PostSignProgress } from "./PostSignProgress";
 import { ProgressBar } from "./ProgressBar";
 import { buildStepItems, getVisualStep, TOTAL_VISUAL_STEPS } from "./steps";
@@ -31,8 +31,8 @@ import { buildStepItems, getVisualStep, TOTAL_VISUAL_STEPS } from "./steps";
 export interface BtcConfirmationDetailData {
   /** Date.now() when the AWAIT_BTC_CONFIRMATION step was first entered. */
   startedAt: number;
-  /** Raw BTC pegin transaction hash (with or without 0x). */
-  peginTxHash: string;
+  /** Pre-PegIn broadcast txid — the tx actually on the Bitcoin network. */
+  prePeginTxid: string;
 }
 
 export interface DepositProgressViewProps {
@@ -89,9 +89,9 @@ export function DepositProgressView(props: DepositProgressViewProps) {
   const activeStepDetail =
     currentStep === DepositFlowStep.AWAIT_BTC_CONFIRMATION &&
     btcConfirmationDetail ? (
-      <BtcConfirmationDetail
+      <BtcConfirmationDetailContainer
         startedAt={btcConfirmationDetail.startedAt}
-        peginTxHash={btcConfirmationDetail.peginTxHash}
+        prePeginTxid={btcConfirmationDetail.prePeginTxid}
       />
     ) : null;
 

--- a/services/vault/src/components/simple/DepositProgressView/__tests__/BtcConfirmationDetail.test.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/__tests__/BtcConfirmationDetail.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { BtcConfirmationDetail } from "../BtcConfirmationDetail";
+
+const TXID = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2";
+
+const baseProps = {
+  startedAt: new Date("2026-01-01T13:44:00Z").getTime(),
+  prePeginTxid: TXID,
+};
+
+describe("BtcConfirmationDetail", () => {
+  it("shows when the confirmation wait started", () => {
+    render(
+      <BtcConfirmationDetail
+        {...baseProps}
+        confirmations={0}
+        requiredDepth={6}
+      />,
+    );
+    expect(screen.getByText(/Started at/)).toBeInTheDocument();
+  });
+
+  it("links the Pre-PegIn txid to the Bitcoin explorer", () => {
+    render(
+      <BtcConfirmationDetail
+        {...baseProps}
+        confirmations={0}
+        requiredDepth={6}
+      />,
+    );
+    expect(screen.getByRole("link")).toHaveAttribute(
+      "href",
+      expect.stringContaining(TXID),
+    );
+  });
+
+  it("counts confirmations toward the required depth", () => {
+    render(
+      <BtcConfirmationDetail
+        {...baseProps}
+        confirmations={3}
+        requiredDepth={6}
+      />,
+    );
+    expect(screen.getByText("3 of 6")).toBeInTheDocument();
+  });
+
+  it("estimates the remaining wait from the unconfirmed blocks", () => {
+    render(
+      <BtcConfirmationDetail
+        {...baseProps}
+        confirmations={3}
+        requiredDepth={6}
+      />,
+    );
+    expect(screen.getByText("~30 min")).toBeInTheDocument();
+  });
+
+  it("estimates the full wait before any confirmation lands", () => {
+    render(
+      <BtcConfirmationDetail
+        {...baseProps}
+        confirmations={0}
+        requiredDepth={6}
+      />,
+    );
+    expect(screen.getByText("0 of 6")).toBeInTheDocument();
+    expect(screen.getByText("~60 min")).toBeInTheDocument();
+  });
+
+  it("shows a finalizing state once the required depth is reached", () => {
+    render(
+      <BtcConfirmationDetail
+        {...baseProps}
+        confirmations={6}
+        requiredDepth={6}
+      />,
+    );
+    expect(screen.getByText("Finalizing...")).toBeInTheDocument();
+    expect(screen.queryByText(/min$/)).not.toBeInTheDocument();
+  });
+
+  it("clamps the displayed count when confirmations overshoot the depth", () => {
+    render(
+      <BtcConfirmationDetail
+        {...baseProps}
+        confirmations={8}
+        requiredDepth={6}
+      />,
+    );
+    expect(screen.getByText("6 of 6")).toBeInTheDocument();
+    expect(screen.getByText("Finalizing...")).toBeInTheDocument();
+  });
+
+  it("shows no count until the first confirmation reading arrives", () => {
+    render(
+      <BtcConfirmationDetail
+        {...baseProps}
+        confirmations={null}
+        requiredDepth={6}
+      />,
+    );
+    expect(screen.queryByText(/ of 6/)).not.toBeInTheDocument();
+    expect(screen.queryByText("Finalizing...")).not.toBeInTheDocument();
+  });
+});

--- a/services/vault/src/components/simple/DepositProgressView/__tests__/DepositProgressView.test.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/__tests__/DepositProgressView.test.tsx
@@ -1,9 +1,17 @@
 import { render, screen } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { DepositFlowStep } from "@/hooks/deposit/depositFlowSteps/types";
 
 import { DepositProgressView } from "../DepositProgressView";
+
+// The detail panel fetches confirmations and protocol params of its own;
+// this suite covers only whether DepositProgressView mounts it per step.
+vi.mock("../BtcConfirmationDetailContainer", () => ({
+  BtcConfirmationDetailContainer: () => (
+    <div data-testid="btc-confirmation-detail" />
+  ),
+}));
 
 const baseProps = {
   error: null,
@@ -89,7 +97,7 @@ describe("DepositProgressView", () => {
       ).not.toBeInTheDocument();
     });
 
-    it("renders the active step with its description", () => {
+    it("renders the label of the active step", () => {
       render(
         <DepositProgressView
           {...baseProps}
@@ -100,7 +108,6 @@ describe("DepositProgressView", () => {
       expect(
         screen.getByText("Awaiting Bitcoin confirmation"),
       ).toBeInTheDocument();
-      expect(screen.getByText("(~15 min)")).toBeInTheDocument();
     });
 
     it("renders pending steps as label-only (no descriptions)", () => {
@@ -241,69 +248,23 @@ describe("DepositProgressView", () => {
   });
 
   describe("BTC confirmation detail panel", () => {
-    const PEGIN_TX_HASH =
+    const PRE_PEGIN_TXID =
       "1b2c3d4e5f00000000000000000000000000000000000000000000000000000000";
-    const FIXED_NOW = new Date("2026-01-01T14:00:00Z").getTime();
+    const NOW = new Date("2026-01-01T14:00:00Z").getTime();
 
-    beforeEach(() => {
-      vi.useFakeTimers();
-      vi.setSystemTime(FIXED_NOW);
-    });
-
-    afterEach(() => {
-      vi.useRealTimers();
-    });
-
-    it("renders Started at, Est. Remaining, and Bitcoin TX when the active step is AWAIT_BTC_CONFIRMATION", () => {
-      const startedAt = new Date("2026-01-01T13:44:00Z").getTime();
+    it("renders the confirmation detail when the active step is AWAIT_BTC_CONFIRMATION", () => {
       render(
         <DepositProgressView
           {...baseProps}
           currentStep={DepositFlowStep.AWAIT_BTC_CONFIRMATION}
           btcConfirmationDetail={{
-            startedAt,
-            peginTxHash: PEGIN_TX_HASH,
+            startedAt: NOW,
+            prePeginTxid: PRE_PEGIN_TXID,
           }}
         />,
       );
 
-      expect(screen.getByText("Started at:")).toBeInTheDocument();
-      expect(screen.getByText("Est. Remaining:")).toBeInTheDocument();
-      expect(screen.getByText("Bitcoin TX:")).toBeInTheDocument();
-      expect(screen.getByText(/^~\d+ min$/)).toBeInTheDocument();
-    });
-
-    it("counts down Est. Remaining based on elapsed time", () => {
-      const elevenMinutesAgo = FIXED_NOW - 11 * 60 * 1000;
-      render(
-        <DepositProgressView
-          {...baseProps}
-          currentStep={DepositFlowStep.AWAIT_BTC_CONFIRMATION}
-          btcConfirmationDetail={{
-            startedAt: elevenMinutesAgo,
-            peginTxHash: PEGIN_TX_HASH,
-          }}
-        />,
-      );
-
-      // 15 expected - 11 elapsed = 4 remaining
-      expect(screen.getByText("~4 min")).toBeInTheDocument();
-    });
-
-    it("floors Est. Remaining at 0 once the expected wait has elapsed", () => {
-      const longAgo = FIXED_NOW - 60 * 60 * 1000;
-      render(
-        <DepositProgressView
-          {...baseProps}
-          currentStep={DepositFlowStep.AWAIT_BTC_CONFIRMATION}
-          btcConfirmationDetail={{
-            startedAt: longAgo,
-            peginTxHash: PEGIN_TX_HASH,
-          }}
-        />,
-      );
-
-      expect(screen.getByText("~0 min")).toBeInTheDocument();
+      expect(screen.getByTestId("btc-confirmation-detail")).toBeInTheDocument();
     });
 
     it("does not render the detail panel for steps other than AWAIT_BTC_CONFIRMATION", () => {
@@ -312,14 +273,15 @@ describe("DepositProgressView", () => {
           {...baseProps}
           currentStep={DepositFlowStep.SUBMIT_WOTS_KEYS}
           btcConfirmationDetail={{
-            startedAt: FIXED_NOW,
-            peginTxHash: PEGIN_TX_HASH,
+            startedAt: NOW,
+            prePeginTxid: PRE_PEGIN_TXID,
           }}
         />,
       );
 
-      expect(screen.queryByText("Started at:")).not.toBeInTheDocument();
-      expect(screen.queryByText("Bitcoin TX:")).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId("btc-confirmation-detail"),
+      ).not.toBeInTheDocument();
     });
 
     it("does not render the detail panel when btcConfirmationDetail is null", () => {
@@ -331,8 +293,9 @@ describe("DepositProgressView", () => {
         />,
       );
 
-      expect(screen.queryByText("Started at:")).not.toBeInTheDocument();
-      expect(screen.queryByText("Bitcoin TX:")).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId("btc-confirmation-detail"),
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/services/vault/src/components/simple/DepositProgressView/__tests__/btcConfirmationProgress.test.ts
+++ b/services/vault/src/components/simple/DepositProgressView/__tests__/btcConfirmationProgress.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  computeConfirmations,
+  computeRemainingEstimateMinutes,
+} from "../btcConfirmationProgress";
+
+describe("computeConfirmations", () => {
+  it("returns 0 for an unconfirmed (mempool) transaction", () => {
+    expect(computeConfirmations({ confirmed: false }, 800_000)).toBe(0);
+  });
+
+  it("counts the including block as the first confirmation", () => {
+    expect(
+      computeConfirmations({ confirmed: true, block_height: 800_000 }, 800_000),
+    ).toBe(1);
+  });
+
+  it("counts the including block plus every block mined on top", () => {
+    expect(
+      computeConfirmations({ confirmed: true, block_height: 799_995 }, 800_000),
+    ).toBe(6);
+  });
+
+  it("never returns a negative count when the tip lags the block height", () => {
+    expect(
+      computeConfirmations({ confirmed: true, block_height: 800_001 }, 800_000),
+    ).toBe(0);
+  });
+
+  it("throws when a confirmed transaction has no block height", () => {
+    expect(() => computeConfirmations({ confirmed: true }, 800_000)).toThrow(
+      /block_height/,
+    );
+  });
+});
+
+describe("computeRemainingEstimateMinutes", () => {
+  it("estimates the full wait at zero confirmations", () => {
+    expect(computeRemainingEstimateMinutes(0, 6)).toBe(60);
+  });
+
+  it("estimates the remaining blocks at ten minutes each", () => {
+    expect(computeRemainingEstimateMinutes(4, 6)).toBe(20);
+  });
+
+  it("returns null once the required depth is reached", () => {
+    expect(computeRemainingEstimateMinutes(6, 6)).toBeNull();
+  });
+
+  it("returns null when confirmations exceed the required depth", () => {
+    expect(computeRemainingEstimateMinutes(8, 6)).toBeNull();
+  });
+});

--- a/services/vault/src/components/simple/DepositProgressView/btcConfirmationProgress.ts
+++ b/services/vault/src/components/simple/DepositProgressView/btcConfirmationProgress.ts
@@ -1,0 +1,39 @@
+/**
+ * Pure helpers for the "Awaiting Bitcoin confirmation" detail panel.
+ *
+ * The deposit waits for the Pre-PegIn tx to reach the protocol-mandated
+ * confirmation depth (`minPrepeginDepth`, on-chain offchain param). These
+ * helpers turn raw mempool data + that depth into the counter and estimate
+ * the panel renders — no countdown, since block arrivals are not schedulable.
+ */
+
+/** Bitcoin difficulty retargeting aims for one block every 10 minutes. */
+const AVG_BTC_BLOCK_MINUTES = 10;
+
+/**
+ * Confirmation count for a transaction given the current chain tip.
+ * Unconfirmed (mempool) is 0; the block that includes the tx is the 1st.
+ */
+export function computeConfirmations(
+  status: { confirmed: boolean; block_height?: number },
+  tipHeight: number,
+): number {
+  if (!status.confirmed) return 0;
+  if (status.block_height === undefined) {
+    throw new Error("Confirmed transaction is missing block_height");
+  }
+  return Math.max(0, tipHeight - status.block_height + 1);
+}
+
+/**
+ * Estimated minutes until the Pre-PegIn reaches `requiredDepth`, at Bitcoin's
+ * ~10-minute block target. Returns `null` once the depth is met — there is no
+ * remaining wait to estimate and the deposit is finalizing.
+ */
+export function computeRemainingEstimateMinutes(
+  confirmations: number,
+  requiredDepth: number,
+): number | null {
+  if (confirmations >= requiredDepth) return null;
+  return (requiredDepth - confirmations) * AVG_BTC_BLOCK_MINUTES;
+}

--- a/services/vault/src/components/simple/DepositProgressView/steps.ts
+++ b/services/vault/src/components/simple/DepositProgressView/steps.ts
@@ -5,8 +5,6 @@ import { DepositFlowStep } from "@/hooks/deposit/depositFlowSteps/types";
 import type { PayoutSigningProgress } from "@/services/vault/vaultPayoutSignatureService";
 import type { PeginSigningProgress } from "@/services/vault/vaultTransactionService";
 
-export const EXPECTED_CONFIRMATION_MINUTES = 15;
-
 export function buildStepItems(
   progress: PayoutSigningProgress | null,
   peginProgress: PeginSigningProgress | null = null,
@@ -31,12 +29,7 @@ export function buildStepItems(
     { label: COPY.deposit.steps.signLinkProofs },
     { label: COPY.deposit.steps.signAndBroadcastEth },
     { label: COPY.deposit.steps.signAndBroadcastPrePegin },
-    {
-      label: COPY.deposit.steps.awaitBtcConfirmation,
-      description: COPY.deposit.steps.awaitBtcConfirmationDuration(
-        EXPECTED_CONFIRMATION_MINUTES,
-      ),
-    },
+    { label: COPY.deposit.steps.awaitBtcConfirmation },
     { label: COPY.deposit.steps.submitWotsKey },
     { label: COPY.deposit.steps.authenticateSession },
     {

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -132,7 +132,6 @@ export const COPY = {
       signAndBroadcastEth: "Sign and broadcast ETH registration",
       signAndBroadcastPrePegin: "Sign and broadcast BTC Pre-Pegin transaction",
       awaitBtcConfirmation: "Awaiting Bitcoin confirmation",
-      awaitBtcConfirmationDuration: (minutes: number) => `(~${minutes} min)`,
       submitWotsKey: "Submit WOTS public key to vault provider",
       authenticateSession: "Authenticate session with vault provider",
       signPayouts: "Sign payout transactions",
@@ -184,6 +183,16 @@ export const COPY = {
         done: "Done",
         sign: "Sign",
       },
+    },
+    btcConfirmation: {
+      startedAt: "Started at",
+      confirmations: "Confirmations",
+      confirmationProgress: (current: number, required: number) =>
+        `${current} of ${required}`,
+      estRemaining: "Est. remaining",
+      estRemainingValue: (minutes: number) => `~${minutes} min`,
+      finalizing: "Finalizing...",
+      bitcoinTx: "Bitcoin TX",
     },
     broadcastSuccess: {
       heading: "Pre-Pegin Broadcast",

--- a/services/vault/src/hooks/deposit/__tests__/useBtcConfirmations.test.ts
+++ b/services/vault/src/hooks/deposit/__tests__/useBtcConfirmations.test.ts
@@ -1,0 +1,76 @@
+import {
+  getTipHeight,
+  getTxInfo,
+} from "@babylonlabs-io/ts-sdk/tbv/core/clients";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useBtcConfirmations } from "../useBtcConfirmations";
+
+vi.mock("@babylonlabs-io/ts-sdk/tbv/core/clients", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  getTxInfo: vi.fn(),
+  getTipHeight: vi.fn(),
+}));
+
+const mockGetTxInfo = vi.mocked(getTxInfo);
+const mockGetTipHeight = vi.mocked(getTipHeight);
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return createElement(QueryClientProvider, { client }, children);
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useBtcConfirmations", () => {
+  it("does not query the mempool when no txid is provided", () => {
+    const { result } = renderHook(() => useBtcConfirmations(null), {
+      wrapper,
+    });
+
+    expect(result.current.confirmations).toBeNull();
+    expect(mockGetTxInfo).not.toHaveBeenCalled();
+    expect(mockGetTipHeight).not.toHaveBeenCalled();
+  });
+
+  it("derives the confirmation count from the tx status and the chain tip", async () => {
+    mockGetTxInfo.mockResolvedValue({
+      status: { confirmed: true, block_height: 799_995 },
+    } as Awaited<ReturnType<typeof getTxInfo>>);
+    mockGetTipHeight.mockResolvedValue(800_000);
+
+    const { result } = renderHook(
+      () =>
+        useBtcConfirmations(
+          "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+        ),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.confirmations).toBe(6));
+  });
+
+  it("reports zero confirmations for a tx still in the mempool", async () => {
+    mockGetTxInfo.mockResolvedValue({
+      status: { confirmed: false },
+    } as Awaited<ReturnType<typeof getTxInfo>>);
+    mockGetTipHeight.mockResolvedValue(800_000);
+
+    const { result } = renderHook(
+      () =>
+        useBtcConfirmations(
+          "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+        ),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.confirmations).toBe(0));
+  });
+});

--- a/services/vault/src/hooks/deposit/useBtcConfirmations.ts
+++ b/services/vault/src/hooks/deposit/useBtcConfirmations.ts
@@ -1,0 +1,54 @@
+/**
+ * Polls the Bitcoin mempool for the confirmation count of a transaction.
+ *
+ * Backs the "Awaiting Bitcoin confirmation" panel: confirmations are a fact
+ * on the chain, so the panel shows real progress toward the protocol-mandated
+ * Pre-PegIn depth rather than a wall-clock countdown to unschedulable blocks.
+ */
+
+import { stripHexPrefix } from "@babylonlabs-io/ts-sdk/tbv/core";
+import {
+  getTipHeight,
+  getTxInfo,
+} from "@babylonlabs-io/ts-sdk/tbv/core/clients";
+import { useQuery } from "@tanstack/react-query";
+
+import { getMempoolApiUrl } from "@/clients/btc/config";
+import { computeConfirmations } from "@/components/simple/DepositProgressView/btcConfirmationProgress";
+
+/** Bitcoin blocks arrive ~every 10 min; a 30s poll catches each promptly. */
+const CONFIRMATION_POLL_INTERVAL_MS = 30 * 1000;
+
+export interface BtcConfirmationsResult {
+  /**
+   * Confirmation count, or null while the first fetch runs or on error.
+   * Null and a real 0 are distinct: 0 means "broadcast, not yet mined".
+   */
+  confirmations: number | null;
+}
+
+/**
+ * @param txid - Pre-PegIn broadcast txid; pass `null` to disable polling.
+ */
+export function useBtcConfirmations(
+  txid: string | null,
+): BtcConfirmationsResult {
+  const enabled = txid !== null && txid.length > 0;
+
+  const query = useQuery({
+    queryKey: ["btcConfirmations", txid],
+    enabled,
+    refetchInterval: CONFIRMATION_POLL_INTERVAL_MS,
+    queryFn: async () => {
+      if (!txid) throw new Error("useBtcConfirmations: txid is required");
+      const apiUrl = getMempoolApiUrl();
+      const [info, tipHeight] = await Promise.all([
+        getTxInfo(stripHexPrefix(txid), apiUrl),
+        getTipHeight(apiUrl),
+      ]);
+      return computeConfirmations(info.status, tipHeight);
+    },
+  });
+
+  return { confirmations: query.data ?? null };
+}

--- a/services/vault/src/hooks/deposit/useDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useDepositFlow.ts
@@ -161,12 +161,12 @@ export interface UseDepositFlowReturn {
   continueAfterArtifactDownload: () => void;
   /**
    * Data backing the "Awaiting Bitcoin confirmation" detail panel: the
-   * timestamp the step was first entered and the pegin tx hash of the
-   * deposit. `null` until the BTC broadcast completes.
+   * timestamp the step was first entered and the Pre-PegIn broadcast txid.
+   * `null` until the BTC broadcast completes.
    */
   btcConfirmationDetail: {
     startedAt: number;
-    peginTxHash: string;
+    prePeginTxid: string;
   } | null;
 }
 
@@ -237,7 +237,7 @@ export function useDepositFlow(
     useState<ArtifactDownloadInfo | null>(null);
   const [btcConfirmationDetail, setBtcConfirmationDetail] = useState<{
     startedAt: number;
-    peginTxHash: string;
+    prePeginTxid: string;
   } | null>(null);
 
   const artifactResolverRef = useRef<(() => void) | null>(null);
@@ -731,8 +731,9 @@ export function useDepositFlow(
 
         setCurrentStep(DepositFlowStep.BROADCAST_PRE_PEGIN);
 
+        let prePeginBroadcastTxid: string;
         try {
-          await broadcastPrePeginTransaction({
+          prePeginBroadcastTxid = await broadcastPrePeginTransaction({
             unsignedTxHex: batchResult.fundedPrePeginTxHex,
             btcWalletProvider: {
               signPsbt: (psbtHex: string) =>
@@ -798,17 +799,14 @@ export function useDepositFlow(
         // ========================================================================
 
         setCurrentStep(DepositFlowStep.AWAIT_BTC_CONFIRMATION);
-        // Snapshot the moment we enter the BTC-wait so the detail panel
-        // can render a stable "Started at" / "Est. Remaining" pair. Pick
-        // the first broadcasted pegin tx hash — multi-vault deposits all
-        // share the same Pre-PegIn broadcast, but per-vault hashes are
-        // what the rest of the app surfaces to the user.
-        if (broadcastedResults[0]) {
-          setBtcConfirmationDetail({
-            startedAt: Date.now(),
-            peginTxHash: broadcastedResults[0].peginTxHash,
-          });
-        }
+        // Snapshot the moment we enter the BTC-wait so the detail panel can
+        // render a stable "Started at". The Pre-PegIn broadcast txid is the
+        // tx that actually lands on Bitcoin — multi-vault siblings all share
+        // one Pre-PegIn broadcast — so it backs the confirmation poll.
+        setBtcConfirmationDetail({
+          startedAt: Date.now(),
+          prePeginTxid: prePeginBroadcastTxid,
+        });
         setIsWaiting(true);
 
         let baseStep: DepositFlowStep = DepositFlowStep.AWAIT_BTC_CONFIRMATION;


### PR DESCRIPTION
## Summary

The pending-deposit "Awaiting Bitcoin confirmation" panel had two problems raised in review:
- The "Bitcoin TX" shown was the pegin-identity txid, not the broadcast Pre-PegIn tx — so it could
not be found in the mempool.
- "Est. Remaining ~15 min" was a hardcoded client-side countdown, unrelated to any real confirmation
data.


<img width="537" height="317" alt="image" src="https://github.com/user-attachments/assets/3e1ca2e9-ba2d-4d7f-a1cf-d44862051ce4" />
