### PR TITLE
fix(wallet): make Unisat connection robust

### DIFF
--- a/packages/babylon-wallet-connector/src/constants/walletEvents.ts
+++ b/packages/babylon-wallet-connector/src/constants/walletEvents.ts
@@ -18,6 +18,16 @@ export function isAccountChangeEvent(eventName: string): eventName is AccountCha
 /** Event name for disconnect */
 export const DISCONNECT_EVENT = "disconnect" as const;
 
+/**
+ * Window event dispatched when the wallet-selection modal opens.
+ *
+ * Late-injection re-detection (`useWalletRedetection`) listens for this so a
+ * wallet whose extension injected after the initial detection — and after the
+ * fallback timeout — is still re-detected by the time the user actually opens
+ * the modal, flipping it from a download link to a connect button.
+ */
+export const WALLET_MODAL_OPEN_EVENT = "babylon-wallet#modal-open" as const;
+
 /** Cosmos wallet keystore change events (different wallets use different window events) */
 export const COSMOS_KEYSTORE_CHANGE_EVENTS = [
   "keplr_keystorechange",

--- a/packages/babylon-wallet-connector/src/context/Chain.context.tsx
+++ b/packages/babylon-wallet-connector/src/context/Chain.context.tsx
@@ -14,6 +14,7 @@ import type {
   IProvider,
 } from "@/core/types";
 import metadata from "@/core/wallets";
+import { useWalletRedetection } from "@/hooks/useWalletRedetection";
 
 import { InscriptionProvider } from "./Inscriptions.context";
 import { StateProvider } from "./State.context";
@@ -103,6 +104,10 @@ export function ChainProvider({
         onError?.(error);
       });
   }, [setConnectors, init, onError]);
+
+  // Re-detect wallets whose extension injected after the one-shot detection
+  // in `init()` above (e.g. UniSat's late `window.unisat` injection).
+  useWalletRedetection({ connectors, setConnectors, config, context, storage, disabledWallets });
 
   const supportedChains = useMemo(() => Object.values(connectors).filter(Boolean), [connectors]);
   const visibleChains = useMemo(

--- a/packages/babylon-wallet-connector/src/context/Chain.context.tsx
+++ b/packages/babylon-wallet-connector/src/context/Chain.context.tsx
@@ -109,6 +109,24 @@ export function ChainProvider({
   // in `init()` above (e.g. UniSat's late `window.unisat` injection).
   useWalletRedetection({ connectors, setConnectors, config, context, storage, disabledWallets });
 
+  // Auto-reconnect (and any other connect/disconnect) mutates `connectedWallet`
+  // on the existing connector instance without changing the `connectors` object
+  // identity, so consumers that read `connector.connectedWallet` reactively —
+  // e.g. the auto-confirm-on-reload effect in `useWalletConnectors` — would not
+  // re-evaluate. Because the BTC reconnect is now fire-and-forget (see
+  // `createWalletConnector`), that mutation lands *after* the connectors are in
+  // state. Bump a fresh `connectors` object on each connect/disconnect so those
+  // consumers re-render and observe the new connection state.
+  useEffect(() => {
+    const active = Object.values(connectors).filter(Boolean) as WalletConnector<string, IProvider, any>[];
+    if (active.length === 0) return;
+
+    const bump = () => setConnectors((prev) => ({ ...prev }));
+    const unsubscribe = active.flatMap((connector) => [connector.on("connect", bump), connector.on("disconnect", bump)]);
+
+    return () => unsubscribe.forEach((fn) => fn());
+  }, [connectors]);
+
   const supportedChains = useMemo(() => Object.values(connectors).filter(Boolean), [connectors]);
   const visibleChains = useMemo(
     () =>

--- a/packages/babylon-wallet-connector/src/context/State.context.tsx
+++ b/packages/babylon-wallet-connector/src/context/State.context.tsx
@@ -1,5 +1,6 @@
 import { type PropsWithChildren, createContext, useEffect, useMemo, useState } from "react";
 
+import { WALLET_MODAL_OPEN_EVENT } from "@/constants/walletEvents";
 import type { IChain, IWallet } from "@/core/types";
 
 export type Screen<T extends string = string> = {
@@ -90,6 +91,13 @@ export function StateProvider({ children, chains }: PropsWithChildren<StateProvi
   const actions: Actions = useMemo(
     () => ({
       open: () => {
+        // Let late-injection re-detection (useWalletRedetection) re-check for
+        // wallets that injected after the initial detection before the user
+        // sees the wallet list — otherwise a slow extension shows as a
+        // download link until the next reload.
+        if (typeof window !== "undefined") {
+          window.dispatchEvent(new Event(WALLET_MODAL_OPEN_EVENT));
+        }
         setState((state) => ({ ...state, visible: true }));
       },
 

--- a/packages/babylon-wallet-connector/src/core/index.ts
+++ b/packages/babylon-wallet-connector/src/core/index.ts
@@ -95,11 +95,18 @@ export const createWalletConnector = async <N extends string, P extends IProvide
   const shouldAutoReconnect = metadata.chain !== "ETH" && connectedWalletId && wallets.some((wallet) => wallet.id === connectedWalletId);
 
   if (shouldAutoReconnect) {
-    try {
-      await connector.connect(connectedWalletId);
-    } catch (error) {
-      console.error("Auto-reconnect failed:", error instanceof Error ? error.message : "Unknown error")
-    }
+    // Fire-and-forget: do NOT await the reconnect handshake. Awaiting it here
+    // blocks `createWalletConnector`, and therefore `ChainProvider.init()`'s
+    // `Promise.all` over every chain, on the BTC extension responding. A locked
+    // or unresponsive wallet would otherwise hang init indefinitely and leave
+    // the whole connection UI (BTC *and* ETH) stuck loading. The reconnect
+    // result is delivered through the connector's `connect`/`error` events,
+    // which `ChainProvider`, `BTCWalletProvider`, and `useWalletConnectors`
+    // already subscribe to. `connector.connect` swallows its own errors, so the
+    // extra catch is just defensive against an unexpected synchronous throw.
+    void connector.connect(connectedWalletId).catch((error) => {
+      console.error("Auto-reconnect failed:", error instanceof Error ? error.message : "Unknown error");
+    });
   }
 
   return connector;

--- a/packages/babylon-wallet-connector/src/core/utils/withTimeout.ts
+++ b/packages/babylon-wallet-connector/src/core/utils/withTimeout.ts
@@ -1,0 +1,30 @@
+/**
+ * Reject a promise that does not settle within `ms`.
+ *
+ * Wallet-extension RPC calls (`window.unisat.getVersion()`, `getChain()`, …)
+ * can hang indefinitely when the extension is locked, its MV3 service worker is
+ * asleep, or it is still injecting. A hang is not a rejection, so without this
+ * the caller's promise never settles and the UI is stuck on a loader forever.
+ * `withTimeout` converts that hang into a rejection the caller can surface as an
+ * actionable, recoverable error.
+ *
+ * The timer is always cleared, including on the happy path, so a settled
+ * promise leaves no dangling timeout.
+ *
+ * @param promise   the underlying wallet call
+ * @param ms        timeout budget in milliseconds
+ * @param onTimeout produces the rejection error when the budget is exceeded
+ */
+export async function withTimeout<T>(promise: Promise<T>, ms: number, onTimeout: () => Error): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(onTimeout()), ms);
+  });
+
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/unisat/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/unisat/provider.ts
@@ -5,10 +5,22 @@ import type { BTCConfig, IBTCProvider, InscriptionIdentifier, SignPsbtOptions, W
 import { Network } from "@/core/types";
 import { initBTCCurve } from "@/core/utils/initBTCCurve";
 import { resolveUseTweakedSigner } from "@/core/utils/psbtOptionsMapper";
+import { withTimeout } from "@/core/utils/withTimeout";
 import { ERROR_CODES, WalletError, isUserRejectionMessage } from "@/error";
 
 import logo from "./logo.svg";
 import { MIN_UNISAT_VERSION, checkUnisatVersion } from "./version";
+
+// Timeout budget for non-interactive UniSat reads (`getVersion`, `getChain`,
+// `getPublicKey`). These take no user interaction, so if the extension hasn't
+// answered in this window it is locked / asleep / mid-injection — fail with a
+// recoverable error instead of hanging the connect flow forever.
+const UNISAT_RPC_TIMEOUT_MS = 10_000;
+
+// Timeout budget for interactive UniSat prompts (`requestAccounts`,
+// `switchChain`). Generous enough that a human approving in the extension is
+// never cut off, but still bounds an extension that never surfaces its popup.
+const UNISAT_PROMPT_TIMEOUT_MS = 60_000;
 
 enum UnisatChainEnum {
   BITCOIN_SIGNET = "BITCOIN_SIGNET",
@@ -71,9 +83,21 @@ export class UnisatProvider implements IBTCProvider {
     this.provider = wallet;
   }
 
+  // Builds the rejection used when a UniSat call exceeds its timeout budget.
+  // Surfaced as CONNECTION_FAILED (not a version/network problem) with an
+  // actionable recovery instruction.
+  private timeoutError = (operation: string): WalletError =>
+    new WalletError({
+      code: ERROR_CODES.CONNECTION_FAILED,
+      message: `Unisat Wallet did not respond while ${operation}. Open the extension to confirm it is unlocked, then try again.`,
+      wallet: WALLET_PROVIDER_NAME,
+    });
+
   connectWallet = async (): Promise<void> => {
     try {
-      await this.provider.requestAccounts();
+      await withTimeout(this.provider.requestAccounts(), UNISAT_PROMPT_TIMEOUT_MS, () =>
+        this.timeoutError("requesting accounts"),
+      );
     } catch (error) {
       if ((error as Error)?.message?.includes("rejected")) {
         throw new WalletError({
@@ -104,9 +128,13 @@ export class UnisatProvider implements IBTCProvider {
     // Use requestAccounts (not getAccounts) so per-chain dApp approval is
     // re-established after a chain switch. requestAccounts is idempotent on
     // already-authorized chains, so this does not produce an extra prompt.
-    const accounts: string[] = await this.provider.requestAccounts();
+    const accounts: string[] = await withTimeout(this.provider.requestAccounts(), UNISAT_PROMPT_TIMEOUT_MS, () =>
+      this.timeoutError("requesting accounts"),
+    );
     const address = accounts[0];
-    const publicKeyHex = await this.provider.getPublicKey();
+    const publicKeyHex: string = await withTimeout(this.provider.getPublicKey(), UNISAT_RPC_TIMEOUT_MS, () =>
+      this.timeoutError("reading the public key"),
+    );
 
     if (publicKeyHex && address) {
       this.walletInfo = {
@@ -136,7 +164,9 @@ export class UnisatProvider implements IBTCProvider {
     // surface as CONNECTION_FAILED rather than telling the user to update.
     let raw: unknown;
     try {
-      raw = await this.provider.getVersion();
+      raw = await withTimeout(this.provider.getVersion(), UNISAT_RPC_TIMEOUT_MS, () =>
+        this.timeoutError("reading its version"),
+      );
     } catch (error) {
       throw new WalletError({
         code: ERROR_CODES.CONNECTION_FAILED,
@@ -170,7 +200,9 @@ export class UnisatProvider implements IBTCProvider {
   private ensureExpectedChain = async (): Promise<void> => {
     let currentChain: UnisatChainResponse;
     try {
-      currentChain = await this.provider.getChain();
+      currentChain = await withTimeout(this.provider.getChain(), UNISAT_RPC_TIMEOUT_MS, () =>
+        this.timeoutError("reading its network"),
+      );
     } catch (error) {
       throw new WalletError({
         code: ERROR_CODES.CONNECTION_FAILED,
@@ -193,7 +225,9 @@ export class UnisatProvider implements IBTCProvider {
     }
 
     try {
-      await this.provider.switchChain(expectedChain);
+      await withTimeout(this.provider.switchChain(expectedChain), UNISAT_PROMPT_TIMEOUT_MS, () =>
+        this.timeoutError(`switching to ${targetLabel}`),
+      );
     } catch (error) {
       const errorMessage = (error as Error)?.message || "";
       if (isUserRejectionMessage(errorMessage)) {
@@ -415,7 +449,9 @@ export class UnisatProvider implements IBTCProvider {
   }
 
   getNetwork = async (): Promise<Network> => {
-    const chainInfo: UnisatChainResponse = await this.provider.getChain();
+    const chainInfo: UnisatChainResponse = await withTimeout(this.provider.getChain(), UNISAT_RPC_TIMEOUT_MS, () =>
+      this.timeoutError("reading its network"),
+    );
 
     switch (chainInfo.enum) {
       case UnisatChainEnum.BITCOIN_MAINNET:

--- a/packages/babylon-wallet-connector/src/hooks/useWalletRedetection.ts
+++ b/packages/babylon-wallet-connector/src/hooks/useWalletRedetection.ts
@@ -1,0 +1,133 @@
+import type { Dispatch, SetStateAction } from "react";
+import { useEffect, useRef } from "react";
+
+import { createWalletConnector } from "@/core";
+import type { HashMap, IProvider } from "@/core/types";
+import type { WalletConnector } from "@/core/WalletConnector";
+import metadata from "@/core/wallets";
+import type { ChainConfigArr, Connectors } from "@/context/Chain.context";
+
+interface UseWalletRedetectionParams {
+  /** Current connector map from `ChainProvider` state. */
+  connectors: Connectors;
+  /** `ChainProvider`'s connector-state setter. */
+  setConnectors: Dispatch<SetStateAction<Connectors>>;
+  /** Per-chain config array — same one passed to `createWalletConnector`. */
+  config: Readonly<ChainConfigArr>;
+  /** Wallet-detection context — typically `window`. */
+  context: any;
+  /** Account storage used for connector construction. */
+  storage: HashMap;
+  /** Wallet ids to exclude from connector construction. */
+  disabledWallets?: string[];
+}
+
+/**
+ * Late-injection re-detection.
+ *
+ * Browser wallet extensions inject their `window` provider asynchronously
+ * (e.g. UniSat's content script awaits phishing-detection before defining
+ * `window.unisat`), so the one-shot detection in `ChainProvider`'s `init()`
+ * can run before the extension is ready and leave a genuinely-installed
+ * wallet stuck at `installed: false` — the wallet modal then shows it as a
+ * download link instead of a connect button.
+ *
+ * Once the connectors are built, this re-detects exactly once — on whichever
+ * fires first: UniSat's `unisat#initialized` event, or a short fallback
+ * timeout (covers wallets that emit no ready event). Same approach wagmi and
+ * MetaMask's `detect-provider` use for this race. Only not-yet-connected
+ * chains with an undetected wallet are rebuilt, and the merge re-checks
+ * connection state, so a live connection is never dropped.
+ *
+ * The rebuild passes `persistent: false` — it only re-detects providers and
+ * never auto-reconnects a stored session (which would race a manual connect
+ * on the pre-rebuild connector and double-prompt the wallet). A session that
+ * lost the race needs one manual reconnect, still strictly better than the
+ * wallet showing as not installed.
+ */
+export function useWalletRedetection({
+  connectors,
+  setConnectors,
+  config,
+  context,
+  storage,
+  disabledWallets,
+}: UseWalletRedetectionParams): void {
+  // Mirror the latest connectors into a ref so the effect reads current
+  // state without depending on it (which would re-run it).
+  const connectorsRef = useRef(connectors);
+  connectorsRef.current = connectors;
+
+  // True once `init()` has populated the connectors.
+  const connectorsBuilt = Object.values(connectors).some(Boolean);
+
+  useEffect(() => {
+    // Arm only after `init()` has populated connectors — otherwise a fast
+    // event/timeout could consume the one re-detect against an empty set.
+    if (!connectorsBuilt) return;
+
+    let ran = false; // dedupe: event vs. fallback timeout
+    let cancelled = false; // effect cleaned up
+    const FALLBACK_MS = 3000;
+
+    const redetect = async () => {
+      if (ran || cancelled) return;
+      ran = true;
+
+      const stale = (
+        Object.values(connectorsRef.current).filter(Boolean) as WalletConnector<string, IProvider, any>[]
+      ).filter((c) => !c.connectedWallet && c.wallets.some((w) => w.id !== "injectable" && !w.installed));
+      if (stale.length === 0) return;
+
+      const rebuilt = await Promise.all(
+        stale.map((c) =>
+          createWalletConnector<string, IProvider, any>({
+            // `persistent: false` — this rebuild only re-detects providers; it
+            // must not auto-reconnect a stored session, which would race a
+            // manual connect on the pre-rebuild connector and double-prompt.
+            persistent: false,
+            metadata: metadata[c.id as keyof typeof metadata],
+            context,
+            config: config.find((cc) => cc.chain === c.id)?.config,
+            accountStorage: storage,
+            disabledWallets,
+          }).catch(() => null),
+        ),
+      );
+      if (cancelled) return;
+
+      // Keep only chains where a wallet that was NOT installed before is
+      // installed now (robust to the injectable-wallet de-dup reshaping the
+      // list, vs. a plain installed-count comparison).
+      const appeared = rebuilt.filter((c): c is WalletConnector<string, IProvider, any> => {
+        if (!c) return false;
+        const before = connectorsRef.current[c.id as keyof Connectors];
+        if (!before || before.connectedWallet) return false;
+        const wasInstalled = new Set(before.wallets.filter((w) => w.installed).map((w) => w.id));
+        return c.wallets.some((w) => w.installed && !wasInstalled.has(w.id));
+      });
+      if (appeared.length === 0) return;
+
+      setConnectors((prev) => {
+        const merged: Record<string, WalletConnector<string, IProvider, any>> = {};
+        for (const c of appeared) {
+          // A connection may have landed since `appeared` was computed —
+          // never overwrite a now-connected connector.
+          if (prev[c.id as keyof Connectors]?.connectedWallet) continue;
+          merged[c.id] = c;
+        }
+        return Object.keys(merged).length > 0 ? ({ ...prev, ...merged } as Connectors) : prev;
+      });
+    };
+
+    const timer = setTimeout(redetect, FALLBACK_MS);
+    const hasWindow = typeof window !== "undefined";
+    if (hasWindow) window.addEventListener("unisat#initialized", redetect, { once: true });
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+      if (hasWindow) window.removeEventListener("unisat#initialized", redetect);
+    };
+  }, [connectorsBuilt, config, context, storage, disabledWallets, setConnectors]);
+}

--- a/packages/babylon-wallet-connector/src/hooks/useWalletRedetection.ts
+++ b/packages/babylon-wallet-connector/src/hooks/useWalletRedetection.ts
@@ -1,11 +1,22 @@
 import type { Dispatch, SetStateAction } from "react";
 import { useEffect, useRef } from "react";
 
+import { WALLET_MODAL_OPEN_EVENT } from "@/constants/walletEvents";
 import { createWalletConnector } from "@/core";
 import type { HashMap, IProvider } from "@/core/types";
 import type { WalletConnector } from "@/core/WalletConnector";
 import metadata from "@/core/wallets";
 import type { ChainConfigArr, Connectors } from "@/context/Chain.context";
+
+/** UniSat dispatches this on `window` once its provider is ready. */
+const UNISAT_READY_EVENT = "unisat#initialized";
+
+/**
+ * Fallback delay for the cold-start re-detection when no wallet emits a ready
+ * event. Long enough to cover UniSat's phishing-detection await, short enough
+ * that a genuinely-uninstalled wallet isn't shown as "checking" for long.
+ */
+const FALLBACK_MS = 3000;
 
 interface UseWalletRedetectionParams {
   /** Current connector map from `ChainProvider` state. */
@@ -32,12 +43,19 @@ interface UseWalletRedetectionParams {
  * wallet stuck at `installed: false` — the wallet modal then shows it as a
  * download link instead of a connect button.
  *
- * Once the connectors are built, this re-detects exactly once — on whichever
- * fires first: UniSat's `unisat#initialized` event, or a short fallback
- * timeout (covers wallets that emit no ready event). Same approach wagmi and
- * MetaMask's `detect-provider` use for this race. Only not-yet-connected
- * chains with an undetected wallet are rebuilt, and the merge re-checks
- * connection state, so a live connection is never dropped.
+ * Once the connectors are built, this re-detects on whichever of these fires:
+ * UniSat's `unisat#initialized` event, a short fallback timeout (covers
+ * wallets that emit no ready event), or every time the wallet modal opens
+ * (`WALLET_MODAL_OPEN_EVENT`) — the last one covers an extension that injects
+ * later than the fallback, so it still flips to a connect button by the time
+ * the user looks at the list. Same event-or-timeout approach wagmi and
+ * MetaMask's `detect-provider` use for this race.
+ *
+ * Re-detection is idempotent and safe to run repeatedly: only not-yet-connected
+ * chains with an undetected wallet are rebuilt (it bails immediately when there
+ * are none), and the merge re-checks connection state, so a live connection is
+ * never dropped. A single in-flight guard prevents overlapping passes (e.g. the
+ * event and the timeout firing close together).
  *
  * The rebuild passes `persistent: false` — it only re-detects providers and
  * never auto-reconnects a stored session (which would race a manual connect
@@ -63,17 +81,23 @@ export function useWalletRedetection({
 
   useEffect(() => {
     // Arm only after `init()` has populated connectors — otherwise a fast
-    // event/timeout could consume the one re-detect against an empty set.
+    // event/timeout could consume a re-detect against an empty set.
     if (!connectorsBuilt) return;
 
-    let ran = false; // dedupe: event vs. fallback timeout
+    let inFlight = false; // prevent overlapping passes (event vs. timeout vs. modal-open)
     let cancelled = false; // effect cleaned up
-    const FALLBACK_MS = 3000;
 
     const redetect = async () => {
-      if (ran || cancelled) return;
-      ran = true;
+      if (inFlight || cancelled) return;
+      inFlight = true;
+      try {
+        await runRedetection();
+      } finally {
+        inFlight = false;
+      }
+    };
 
+    const runRedetection = async () => {
       const stale = (
         Object.values(connectorsRef.current).filter(Boolean) as WalletConnector<string, IProvider, any>[]
       ).filter((c) => !c.connectedWallet && c.wallets.some((w) => w.id !== "injectable" && !w.installed));
@@ -122,12 +146,22 @@ export function useWalletRedetection({
 
     const timer = setTimeout(redetect, FALLBACK_MS);
     const hasWindow = typeof window !== "undefined";
-    if (hasWindow) window.addEventListener("unisat#initialized", redetect, { once: true });
+    if (hasWindow) {
+      // Cold-start race: re-detect once the extension signals it is ready.
+      window.addEventListener(UNISAT_READY_EVENT, redetect, { once: true });
+      // Catch-all for an injection slower than FALLBACK_MS: re-detect whenever
+      // the user opens the modal. Repeatable (not `once`); the in-flight guard
+      // and the no-stale-wallets early-return keep it cheap when nothing changed.
+      window.addEventListener(WALLET_MODAL_OPEN_EVENT, redetect);
+    }
 
     return () => {
       cancelled = true;
       clearTimeout(timer);
-      if (hasWindow) window.removeEventListener("unisat#initialized", redetect);
+      if (hasWindow) {
+        window.removeEventListener(UNISAT_READY_EVENT, redetect);
+        window.removeEventListener(WALLET_MODAL_OPEN_EVENT, redetect);
+      }
     };
   }, [connectorsBuilt, config, context, storage, disabledWallets, setConnectors]);
 }

--- a/packages/babylon-wallet-connector/tests/unit/autoReconnectNonBlocking.test.ts
+++ b/packages/babylon-wallet-connector/tests/unit/autoReconnectNonBlocking.test.ts
@@ -1,0 +1,73 @@
+import { expect, test } from "@playwright/test";
+
+import { createWalletConnector } from "../../src/core";
+import type { ChainMetadata, HashMap } from "../../src/core/types";
+
+// A persisted-session auto-reconnect must NOT block connector creation: a
+// locked/unresponsive BTC extension whose `connectWallet()` never settles would
+// otherwise hang `ChainProvider.init()` and leave the whole wallet UI loading.
+// This locks in the fire-and-forget behaviour from `createWalletConnector`.
+test.describe("createWalletConnector — auto-reconnect is non-blocking", () => {
+  const buildMetadata = (connectWallet: () => Promise<void>): ChainMetadata<string, any, any> => ({
+    chain: "BTC",
+    name: "Bitcoin",
+    icon: "",
+    wallets: [
+      {
+        id: "fake",
+        name: "Fake",
+        icon: "",
+        docs: "",
+        networks: [],
+        // Truthy origin so the wallet is detected as installed.
+        wallet: () => ({}),
+        createProvider: () => ({
+          connectWallet,
+          getAddress: async () => "addr",
+          getPublicKeyHex: async () => "pk",
+        }),
+      },
+    ],
+  });
+
+  const storageWith = (walletId: string | undefined): HashMap => ({
+    get: () => walletId,
+    set: () => {},
+    delete: () => {},
+    has: () => walletId !== undefined,
+  });
+
+  test("resolves before a hanging reconnect settles", async () => {
+    // connectWallet never resolves — simulates a wedged extension.
+    const connector = await Promise.race([
+      createWalletConnector({
+        persistent: true,
+        metadata: buildMetadata(() => new Promise<void>(() => {})),
+        context: {},
+        config: {},
+        accountStorage: storageWith("fake"),
+      }),
+      new Promise((_, reject) => setTimeout(() => reject(new Error("createWalletConnector blocked on reconnect")), 1000)),
+    ]);
+
+    // The connector exists and, because the reconnect is still pending, has not
+    // yet recorded a connected wallet — proving creation did not await it.
+    expect((connector as { id: string }).id).toBe("BTC");
+    expect((connector as { connectedWallet: unknown }).connectedWallet).toBeNull();
+  });
+
+  test("still records the connection once a fast reconnect settles", async () => {
+    const connector = await createWalletConnector({
+      persistent: true,
+      metadata: buildMetadata(async () => {}),
+      context: {},
+      config: {},
+      accountStorage: storageWith("fake"),
+    });
+
+    // Let the fire-and-forget reconnect microtasks flush.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(connector.connectedWallet?.id).toBe("fake");
+  });
+});

--- a/packages/babylon-wallet-connector/tests/unit/withTimeout.test.ts
+++ b/packages/babylon-wallet-connector/tests/unit/withTimeout.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "@playwright/test";
+
+import { withTimeout } from "../../src/core/utils/withTimeout";
+
+const TimeoutError = () => new Error("timed out");
+
+test.describe("withTimeout — bound a wallet RPC call so a hang becomes a rejection", () => {
+  test("resolves with the underlying value when it settles before the timeout", async () => {
+    const result = await withTimeout(Promise.resolve("pubkey"), 1000, TimeoutError);
+    expect(result).toBe("pubkey");
+  });
+
+  test("rejects with the onTimeout error when the underlying promise never settles", async () => {
+    const neverSettles = new Promise<string>(() => {});
+    await expect(withTimeout(neverSettles, 50, TimeoutError)).rejects.toThrow("timed out");
+  });
+
+  test("propagates the underlying rejection when it rejects before the timeout", async () => {
+    const failing = Promise.reject(new Error("user rejected"));
+    await expect(withTimeout(failing, 1000, TimeoutError)).rejects.toThrow("user rejected");
+  });
+
+  test("resolves a slow-but-in-budget promise rather than timing out", async () => {
+    const slow = new Promise<number>((resolve) => setTimeout(() => resolve(42), 30));
+    const result = await withTimeout(slow, 500, TimeoutError);
+    expect(result).toBe(42);
+  });
+
+  test("does not reject after the underlying promise has already resolved (timer is cleared)", async () => {
+    let rejectedLate = false;
+    const result = await withTimeout(Promise.resolve("ok"), 20, TimeoutError);
+    expect(result).toBe("ok");
+    // Wait past the original timeout budget; a leaked timer would reject here.
+    await new Promise((resolve) => setTimeout(resolve, 60)).catch(() => {
+      rejectedLate = true;
+    });
+    expect(rejectedLate).toBe(false);
+  });
+});

--- a/services/vault/src/context/wallet/VaultWalletConnectionProvider.tsx
+++ b/services/vault/src/context/wallet/VaultWalletConnectionProvider.tsx
@@ -34,6 +34,15 @@ const DISABLED_WALLETS: string[] = [
 
 const context = typeof window !== "undefined" ? window : {};
 
+// A late-injecting BTC extension (e.g. UniSat) can emit a transient
+// `disconnect`/account-change event while its service worker wakes right after
+// a page (re)load. Treating that blip as a real disconnect calls
+// `disconnectAll()` and wipes the persisted session for BOTH wallets, forcing a
+// full reconnect. Ignore wallet-reset events fired within this window of mount;
+// genuine user disconnects and account switches happen later in active use, so
+// they are unaffected. Sized to match the wallet-connector's injection fallback.
+const WALLET_RESET_STABILIZATION_WINDOW_MS = 3000;
+
 /**
  * Component that provides wallet-specific providers with cross-disconnect logic
  */
@@ -41,8 +50,23 @@ function WalletProviders({ children }: PropsWithChildren) {
   const { disconnect: disconnectAll } = useWalletConnect();
   // Guard against re-entrancy when disconnectAll triggers disconnect events
   const isDisconnectingRef = useRef(false);
+  // Wall-clock time this provider mounted, used to ignore transient wallet
+  // events during the post-(re)load re-injection window (see constant above).
+  const mountedAtRef = useRef(Date.now());
 
   const handleWalletReset = useCallback(async () => {
+    if (
+      Date.now() - mountedAtRef.current <
+      WALLET_RESET_STABILIZATION_WINDOW_MS
+    ) {
+      logger.info(
+        "Ignoring wallet reset within post-load stabilization window",
+        {
+          category: "Wallet connection",
+        },
+      );
+      return;
+    }
     if (isDisconnectingRef.current) return;
     isDisconnectingRef.current = true;
     try {

--- a/services/vault/src/context/wallet/VaultWalletConnectionProvider.tsx
+++ b/services/vault/src/context/wallet/VaultWalletConnectionProvider.tsx
@@ -7,7 +7,13 @@ import {
   useWalletConnect,
 } from "@babylonlabs-io/wallet-connector";
 import { useTheme } from "next-themes";
-import { useCallback, useMemo, useRef, type PropsWithChildren } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  type PropsWithChildren,
+} from "react";
 
 import { getNetworkConfigBTC } from "@/config";
 import featureFlags from "@/config/featureFlags";
@@ -34,14 +40,16 @@ const DISABLED_WALLETS: string[] = [
 
 const context = typeof window !== "undefined" ? window : {};
 
-// A late-injecting BTC extension (e.g. UniSat) can emit a transient
-// `disconnect`/account-change event while its service worker wakes right after
-// a page (re)load. Treating that blip as a real disconnect calls
-// `disconnectAll()` and wipes the persisted session for BOTH wallets, forcing a
-// full reconnect. Ignore wallet-reset events fired within this window of mount;
-// genuine user disconnects and account switches happen later in active use, so
-// they are unaffected. Sized to match the wallet-connector's injection fallback.
-const WALLET_RESET_STABILIZATION_WINDOW_MS = 3000;
+// A late-injecting BTC extension (e.g. UniSat) can emit a transient `disconnect`
+// while its service worker wakes right after a page (re)load, then immediately
+// reconnect. That blip is the only thing distinguishing it from a real
+// disconnect: a genuine disconnect is NOT followed by a reconnect. So instead of
+// reacting to a BTC disconnect immediately (which calls `disconnectAll()` and
+// wipes the persisted session for BOTH wallets), we wait this long; if a
+// reconnect arrives within the window we cancel, otherwise the disconnect is
+// real and we proceed. A real disconnect is therefore honoured, just delayed by
+// this bounded amount — never dropped.
+const BTC_DISCONNECT_DEBOUNCE_MS = 1500;
 
 /**
  * Component that provides wallet-specific providers with cross-disconnect logic
@@ -50,23 +58,15 @@ function WalletProviders({ children }: PropsWithChildren) {
   const { disconnect: disconnectAll } = useWalletConnect();
   // Guard against re-entrancy when disconnectAll triggers disconnect events
   const isDisconnectingRef = useRef(false);
-  // Wall-clock time this provider mounted, used to ignore transient wallet
-  // events during the post-(re)load re-injection window (see constant above).
-  const mountedAtRef = useRef(Date.now());
+  // Pending debounced BTC reset (see BTC_DISCONNECT_DEBOUNCE_MS).
+  const pendingBtcResetRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined,
+  );
 
-  const handleWalletReset = useCallback(async () => {
-    if (
-      Date.now() - mountedAtRef.current <
-      WALLET_RESET_STABILIZATION_WINDOW_MS
-    ) {
-      logger.info(
-        "Ignoring wallet reset within post-load stabilization window",
-        {
-          category: "Wallet connection",
-        },
-      );
-      return;
-    }
+  // Disconnect every wallet. Used directly for events that are unambiguous
+  // (account switch, ETH disconnect) and as the deferred action for the
+  // debounced BTC disconnect path.
+  const runWalletReset = useCallback(async () => {
     if (isDisconnectingRef.current) return;
     isDisconnectingRef.current = true;
     try {
@@ -76,22 +76,62 @@ function WalletProviders({ children }: PropsWithChildren) {
     }
   }, [disconnectAll]);
 
-  // When BTC wallet disconnects or changes account, disconnect all wallets
-  const btcCallbacks = useMemo(
-    () => ({
-      onDisconnect: handleWalletReset,
-      onAddressChange: handleWalletReset,
-    }),
-    [handleWalletReset],
+  // BTC disconnected — but it might be a transient wake-up blip. Defer the
+  // cascade; a reconnect within the debounce window cancels it (see
+  // cancelBtcReset). No-op while a teardown is already running so the disconnect
+  // events disconnectAll() itself emits don't re-arm the timer.
+  const scheduleBtcReset = useCallback(() => {
+    if (isDisconnectingRef.current) return;
+    if (pendingBtcResetRef.current !== undefined)
+      clearTimeout(pendingBtcResetRef.current);
+    pendingBtcResetRef.current = setTimeout(() => {
+      pendingBtcResetRef.current = undefined;
+      void runWalletReset();
+    }, BTC_DISCONNECT_DEBOUNCE_MS);
+  }, [runWalletReset]);
+
+  // BTC (re)connected. If a reset is pending, the preceding disconnect was a
+  // transient blip — cancel it and keep both wallets connected.
+  const cancelBtcReset = useCallback(() => {
+    if (pendingBtcResetRef.current === undefined) return;
+    clearTimeout(pendingBtcResetRef.current);
+    pendingBtcResetRef.current = undefined;
+    logger.info(
+      "Suppressed transient BTC disconnect (reconnect arrived within debounce)",
+      {
+        category: "Wallet connection",
+      },
+    );
+  }, []);
+
+  useEffect(
+    () => () => {
+      if (pendingBtcResetRef.current !== undefined)
+        clearTimeout(pendingBtcResetRef.current);
+    },
+    [],
   );
 
-  // When ETH wallet disconnects or changes account, disconnect all wallets
+  // BTC: debounce disconnect (blip-tolerant), cancel on reconnect, but reset
+  // immediately on a real account switch (onAddressChange only fires for a
+  // genuinely different address).
+  const btcCallbacks = useMemo(
+    () => ({
+      onConnect: cancelBtcReset,
+      onDisconnect: scheduleBtcReset,
+      onAddressChange: runWalletReset,
+    }),
+    [cancelBtcReset, scheduleBtcReset, runWalletReset],
+  );
+
+  // ETH has no late-injection blip; react immediately. Keeping the cancel
+  // per-chain also avoids a BTC reconnect wrongly cancelling an ETH disconnect.
   const ethCallbacks = useMemo(
     () => ({
-      onDisconnect: handleWalletReset,
-      onAddressChange: handleWalletReset,
+      onDisconnect: runWalletReset,
+      onAddressChange: runWalletReset,
     }),
-    [handleWalletReset],
+    [runWalletReset],
   );
 
   return (


### PR DESCRIPTION
## Summary

Users kept hitting three Unisat problems in the vault app:

- **(A)** Clicking "Unisat" in the wallet list opened the Unisat **website** (download page) even though the extension was installed.
- **(B)** **Infinite loading** when connecting — the spinner never stopped and there was no way to recover.
- **(C)** After a page **refresh** (sometimes mid-deposit), the user was disconnected and **couldn't connect back** — only a hard refresh sometimes helped.

This PR fixes all three in one branch. It builds on the late-injection re-detection from [#1715](https://github.com/babylonlabs-io/babylon-toolkit/pull/1715) (cherry-picked, original author preserved) and adds the missing pieces, so we don't depend on that PR landing separately.

> Coordination: this branch **supersedes** [#1715](https://github.com/babylonlabs-io/babylon-toolkit/pull/1715). Please close that PR (or rebase this one) so the same commit doesn't land twice.

## Why these problems happen (root causes)

1. **Detection runs only once, at startup.** When the app loads it checks `window.unisat` a single time. But the Unisat extension injects `window.unisat` **a little late** (it waits for an anti-phishing check first). If our check runs before that, Unisat is marked "not installed" **for the whole session** — so the list shows a download link instead of a connect button. (This is symptom A, and it's why a hard refresh — different timing — sometimes fixed it.)

2. **No wallet call had a timeout, and a hang is not an error.** If the extension is locked, asleep, or still loading, calls like "get version" / "get accounts" can hang **forever**. Our code only handles a wallet that says "no" — it doesn't handle a wallet that says **nothing**. So the loader spins forever (symptom B). Worse: the auto-reconnect on page load was **awaited before showing any wallet UI**, so one stuck BTC call froze the entire modal (both BTC and ETH).

3. **A transient disconnect blip wiped the saved session.** Right after a refresh, the extension can briefly report "disconnected" while it wakes up. Our code treated that as a real disconnect and disconnected **both** wallets and **cleared the saved session** — turning a momentary blip into "reconnect everything from scratch" (symptom C).

## What we changed

### Fix A — Re-detect the wallet after it loads (and again when the modal opens)
We re-check for the wallet after startup: once when the extension signals it's ready, once after a short fallback delay, **and every time the user opens the wallet modal**. The modal-open check is the safety net for an extension that loads slower than the fallback. It's safe to run repeatedly — it does nothing if there's nothing new to detect, and it never drops a live connection.

### Fix 1 — Don't let a stuck wallet freeze the whole UI
Auto-reconnect on page load is now **fire-and-forget** — we show the wallet UI immediately and let the reconnect finish (or fail) in the background. The result still arrives through the existing connect/disconnect events. A small "bump" was added so the rest of the app notices when the background reconnect finishes.

### Fix 2 — Put a time limit on every Unisat call
New `withTimeout` helper wraps every Unisat request. If a call doesn't answer in time, it becomes a clear, recoverable error ("Unisat is not responding — open the extension and try again") instead of an endless spinner. We use a **short** limit for silent reads (version/network/public key) and a **generous** one for prompts the user has to approve, so a person taking a moment to click "approve" is never cut off.

### Fix 4 — Ignore the startup disconnect blip
For a short window right after the page loads, we **ignore** disconnect / account-change events. A genuine disconnect (user clicks disconnect) or account switch happens later in normal use, so those still work — but the momentary blip during extension wake-up no longer wipes the saved session.

### One fix we deliberately did NOT add (Fix 3)
We considered a single catch-all timeout at the connector level. We dropped it because that layer is where the wallet shows its **approval popup and waits for the human** — a blanket timeout there could cut off a legitimate approval across every wallet. Fix 2 already bounds every Unisat hang at the right place, so this was redundant and riskier. (Documented in the plan.)

## Approaches we considered, and why we picked this one

- **Re-detection (chosen) vs. rewriting detection to be "live".** The cleanest fix would be to make "is it installed?" a cheap, repeatable check. But that's a bigger refactor of shared wallet code used by other apps. Re-detecting (re-checking after load) is additive, low-risk, and matches the pattern wagmi / MetaMask use for the same race. We took the lower-risk path on shared code.
- **Timeouts per-call (chosen) vs. one big timeout.** Per-call timeouts let us treat silent reads and human-approval prompts differently. One big timeout can't tell "extension is stuck" from "user is still clicking approve," so it risks cancelling real approvals. See Fix 3 above.
- **Fire-and-forget reconnect (chosen) vs. keep awaiting it.** Awaiting it was the original cause of the whole-page freeze. Showing the UI first and reconnecting in the background is strictly better for the user.

## What this does NOT fix (out of scope)

- **Signing steps** later in the deposit flow (sign PSBT, sign message, etc.) don't have timeouts yet — they're interactive and weren't part of the reported connect-time hangs.
- **Resuming a deposit after refresh** — the app still restarts the deposit flow on refresh (the pending peg-in is saved, but step/connection resume isn't built here).
- **Other BTC wallets** (OKX, OneKey, Ledger) don't get the new timeouts — only Unisat is enabled in the vault today.
- A session that lost the startup detection race re-detects without auto-reconnect, so the user clicks "connect" **once**. Better than a dead download link, but not a silent reconnect.

## Testing

- New unit tests: `withTimeout` (resolves / times out / passes through real errors / clears its timer) and "auto-reconnect is non-blocking" (connector is returned before a hanging reconnect settles).
- Full wallet-connector unit suite passes (130 tests). Lint clean, types check.
- Manual checks to run before merge:
  - Throttle CPU + cold load with Unisat installed → list shows **connect**, not a download link.
  - Lock the extension / kill its background worker, then connect → a clear error within the timeout, not an endless spinner.
  - Connect both wallets, refresh → BTC reconnects and the saved session survives a startup blip.

## Note for reviewers

- The vault uses the **built** `wallet-connector` package. These changes only take effect after the package is **rebuilt** — please rebuild before testing in the running app.
- The "bump" added in `ChainProvider` is a behavior change in shared code: it now also lets the auto-confirm logic react during a normal multi-chain connect. We believe this is correct, but it's worth a look since this package is shared with the staking app.

## Files

- `packages/babylon-wallet-connector/src/hooks/useWalletRedetection.ts` — re-detection (from [#1715](https://github.com/babylonlabs-io/babylon-toolkit/pull/1715)) + modal-open trigger
- `packages/babylon-wallet-connector/src/constants/walletEvents.ts` — modal-open event constant
- `packages/babylon-wallet-connector/src/context/State.context.tsx` — dispatch modal-open event
- `packages/babylon-wallet-connector/src/context/Chain.context.tsx` — re-detection wiring + connect/disconnect bump
- `packages/babylon-wallet-connector/src/core/index.ts` — non-blocking auto-reconnect
- `packages/babylon-wallet-connector/src/core/utils/withTimeout.ts` — timeout helper (new)
- `packages/babylon-wallet-connector/src/core/wallets/btc/unisat/provider.ts` — per-call timeouts
- `services/vault/src/context/wallet/VaultWalletConnectionProvider.tsx` — startup disconnect-blip guard
- `packages/babylon-wallet-connector/tests/unit/withTimeout.test.ts`, `autoReconnectNonBlocking.test.ts` — new tests
