### PR TITLE
fix(vault): pin BTC confirmation depth to the deposit's registered ve…

### DIFF
--- a/services/vault/src/components/simple/DepositProgressView/BtcConfirmationDetailContainer.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/BtcConfirmationDetailContainer.tsx
@@ -1,10 +1,9 @@
 /**
- * Wires the live confirmation poll and the protocol-required depth into the
- * presentational BtcConfirmationDetail. Mounted only while the deposit is on
- * the AWAIT_BTC_CONFIRMATION step, so the mempool poll runs only then.
+ * Wires the live confirmation poll into the presentational
+ * BtcConfirmationDetail. Mounted only while the deposit is on the
+ * AWAIT_BTC_CONFIRMATION step, so the mempool poll runs only then.
  */
 
-import { useProtocolParamsContext } from "@/context/ProtocolParamsContext";
 import { useBtcConfirmations } from "@/hooks/deposit/useBtcConfirmations";
 
 import { BtcConfirmationDetail } from "./BtcConfirmationDetail";
@@ -14,21 +13,26 @@ interface BtcConfirmationDetailContainerProps {
   startedAt: number;
   /** Pre-PegIn broadcast txid — the tx actually on the Bitcoin network. */
   prePeginTxid: string;
+  /**
+   * Required confirmation depth, pinned to the offchain-params version this
+   * deposit registered against — the version the VP gates the deposit on.
+   */
+  requiredDepth: number;
 }
 
 export function BtcConfirmationDetailContainer({
   startedAt,
   prePeginTxid,
+  requiredDepth,
 }: BtcConfirmationDetailContainerProps) {
   const { confirmations } = useBtcConfirmations(prePeginTxid);
-  const { config } = useProtocolParamsContext();
 
   return (
     <BtcConfirmationDetail
       startedAt={startedAt}
       prePeginTxid={prePeginTxid}
       confirmations={confirmations}
-      requiredDepth={config.offchainParams.minPrepeginDepth}
+      requiredDepth={requiredDepth}
     />
   );
 }

--- a/services/vault/src/components/simple/DepositProgressView/DepositProgressView.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/DepositProgressView.tsx
@@ -33,6 +33,8 @@ export interface BtcConfirmationDetailData {
   startedAt: number;
   /** Pre-PegIn broadcast txid — the tx actually on the Bitcoin network. */
   prePeginTxid: string;
+  /** Required confirmation depth, pinned to the deposit's registered version. */
+  requiredDepth: number;
 }
 
 export interface DepositProgressViewProps {
@@ -92,6 +94,7 @@ export function DepositProgressView(props: DepositProgressViewProps) {
       <BtcConfirmationDetailContainer
         startedAt={btcConfirmationDetail.startedAt}
         prePeginTxid={btcConfirmationDetail.prePeginTxid}
+        requiredDepth={btcConfirmationDetail.requiredDepth}
       />
     ) : null;
 

--- a/services/vault/src/components/simple/DepositProgressView/__tests__/DepositProgressView.test.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/__tests__/DepositProgressView.test.tsx
@@ -260,6 +260,7 @@ describe("DepositProgressView", () => {
           btcConfirmationDetail={{
             startedAt: NOW,
             prePeginTxid: PRE_PEGIN_TXID,
+            requiredDepth: 6,
           }}
         />,
       );
@@ -275,6 +276,7 @@ describe("DepositProgressView", () => {
           btcConfirmationDetail={{
             startedAt: NOW,
             prePeginTxid: PRE_PEGIN_TXID,
+            requiredDepth: 6,
           }}
         />,
       );

--- a/services/vault/src/hooks/deposit/useDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useDepositFlow.ts
@@ -160,13 +160,15 @@ export interface UseDepositFlowReturn {
   /** Callback to continue the flow after artifact download */
   continueAfterArtifactDownload: () => void;
   /**
-   * Data backing the "Awaiting Bitcoin confirmation" detail panel: the
-   * timestamp the step was first entered and the Pre-PegIn broadcast txid.
-   * `null` until the BTC broadcast completes.
+   * Data backing the "Awaiting Bitcoin confirmation" detail panel, snapshotted
+   * when the BTC wait begins: the timestamp, the Pre-PegIn broadcast txid, and
+   * the required confirmation depth of the offchain-params version this
+   * deposit registered against. `null` until the BTC broadcast completes.
    */
   btcConfirmationDetail: {
     startedAt: number;
     prePeginTxid: string;
+    requiredDepth: number;
   } | null;
 }
 
@@ -238,6 +240,7 @@ export function useDepositFlow(
   const [btcConfirmationDetail, setBtcConfirmationDetail] = useState<{
     startedAt: number;
     prePeginTxid: string;
+    requiredDepth: number;
   } | null>(null);
 
   const artifactResolverRef = useRef<(() => void) | null>(null);
@@ -799,13 +802,16 @@ export function useDepositFlow(
         // ========================================================================
 
         setCurrentStep(DepositFlowStep.AWAIT_BTC_CONFIRMATION);
-        // Snapshot the moment we enter the BTC-wait so the detail panel can
-        // render a stable "Started at". The Pre-PegIn broadcast txid is the
-        // tx that actually lands on Bitcoin — multi-vault siblings all share
-        // one Pre-PegIn broadcast — so it backs the confirmation poll.
+        // Snapshot the BTC-wait inputs. The Pre-PegIn broadcast txid is the tx
+        // that lands on Bitcoin (multi-vault siblings share one broadcast).
+        // requiredDepth is pinned to the offchain-params version this deposit
+        // registered against — the VP gates on that version's minPrepeginDepth
+        // (btc-vault claimer/pegin.rs check_prepegin_depth_and_transition), so
+        // a later governance change must not move the displayed target.
         setBtcConfirmationDetail({
           startedAt: Date.now(),
           prePeginTxid: prePeginBroadcastTxid,
+          requiredDepth: config.offchainParams.minPrepeginDepth,
         });
         setIsWaiting(true);
 


### PR DESCRIPTION
## Summary

Two follow-ups to #1720, both on the deposit "Awaiting Bitcoin confirmation" panel.

**1. Pin the confirmation depth to the deposit's registered params version.**
The panel read `minPrepeginDepth` from the live `ProtocolParams` context, but the VP gates a deposit
on the `minPrepeginDepth` of the offchain-params version the vault registered against — confirmed in
btc-vault `claimer/pegin.rs` `check_prepegin_depth_and_transition`
(`get_offchain_params_by_version(vault_data.offchain_params_version)`). Offchain params are versioned
 and immutable once added (`ProtocolParams.addOffchainParamsVersion` only appends), so a governance
change would make the panel disagree with the VP for every in-flight deposit on the prior version.
`useDepositFlow` now snapshots `requiredDepth` into `btcConfirmationDetail` at registration time;
`BtcConfirmationDetailContainer` no longer reads live params.

**2. Combine the count and estimate into one field.**
"Est. remaining" now reads `~30 min (3 of 6 blocks)` instead of two separate rows — `Finalizing...`
once the depth is reached, a loader until the first reading arrives. The block target is the on-chain
 `minPrepeginDepth` (pinned, per #1).