### PR TITLE
fix(vault): auto-advance deposit modal through remaining signing steps

### DIFF
--- a/services/vault/src/components/simple/ActivationGate.tsx
+++ b/services/vault/src/components/simple/ActivationGate.tsx
@@ -26,8 +26,10 @@ export function ActivationGate({
   const providerAddress = activity.providers?.[0]?.id;
   const peginTxid = activity.peginTxHash;
   const depositorPk = activity.depositorBtcPubkey;
-  const canDownloadArtifacts =
-    !!providerAddress && !!peginTxid && !!depositorPk;
+  const artifacts =
+    providerAddress && peginTxid && depositorPk
+      ? { providerAddress, peginTxid, depositorPk }
+      : null;
 
   return (
     <>
@@ -38,16 +40,16 @@ export function ActivationGate({
         onClose={onClose}
         onConfirm={() => setConfirmed(true)}
         onDownloadArtifacts={() => {
-          if (canDownloadArtifacts) setShowArtifactDownload(true);
+          if (artifacts) setShowArtifactDownload(true);
         }}
       />
 
-      {showArtifactDownload && canDownloadArtifacts && (
+      {showArtifactDownload && artifacts && (
         <ArtifactDownloadModal
           open
-          providerAddress={providerAddress as string}
-          peginTxid={peginTxid as string}
-          depositorPk={depositorPk as string}
+          providerAddress={artifacts.providerAddress}
+          peginTxid={artifacts.peginTxid}
+          depositorPk={artifacts.depositorPk}
           vaultId={activity.id}
           unsignedPrePeginTxHex={activity.unsignedPrePeginTx}
           onClose={() => setShowArtifactDownload(false)}

--- a/services/vault/src/components/simple/ActivationGate.tsx
+++ b/services/vault/src/components/simple/ActivationGate.tsx
@@ -1,0 +1,62 @@
+import { type ReactNode, useState } from "react";
+
+import { ArtifactDownloadModal } from "@/components/deposit/ArtifactDownloadModal";
+import type { VaultActivity } from "@/types/activity";
+
+import { ActivateConfirmationModal } from "./ActivateConfirmationModal";
+
+interface ActivationGateProps {
+  activity: VaultActivity;
+  onClose: () => void;
+  /** The activation step, rendered only once the user confirms. */
+  children: ReactNode;
+}
+
+export function ActivationGate({
+  activity,
+  onClose,
+  children,
+}: ActivationGateProps) {
+  const [confirmed, setConfirmed] = useState(false);
+  const [showArtifactDownload, setShowArtifactDownload] = useState(false);
+  const [downloadCompletedAt, setDownloadCompletedAt] = useState(0);
+
+  if (confirmed) return <>{children}</>;
+
+  const providerAddress = activity.providers?.[0]?.id;
+  const peginTxid = activity.peginTxHash;
+  const depositorPk = activity.depositorBtcPubkey;
+  const canDownloadArtifacts =
+    !!providerAddress && !!peginTxid && !!depositorPk;
+
+  return (
+    <>
+      <ActivateConfirmationModal
+        open
+        vaultId={activity.id}
+        downloadCompletedAt={downloadCompletedAt}
+        onClose={onClose}
+        onConfirm={() => setConfirmed(true)}
+        onDownloadArtifacts={() => {
+          if (canDownloadArtifacts) setShowArtifactDownload(true);
+        }}
+      />
+
+      {showArtifactDownload && canDownloadArtifacts && (
+        <ArtifactDownloadModal
+          open
+          providerAddress={providerAddress as string}
+          peginTxid={peginTxid as string}
+          depositorPk={depositorPk as string}
+          vaultId={activity.id}
+          unsignedPrePeginTxHex={activity.unsignedPrePeginTx}
+          onClose={() => setShowArtifactDownload(false)}
+          onComplete={() => {
+            setShowArtifactDownload(false);
+            setDownloadCompletedAt((n) => n + 1);
+          }}
+        />
+      )}
+    </>
+  );
+}

--- a/services/vault/src/components/simple/DepositSignContent.tsx
+++ b/services/vault/src/components/simple/DepositSignContent.tsx
@@ -8,8 +8,8 @@
  */
 
 import type { BitcoinWallet } from "@babylonlabs-io/ts-sdk/shared";
-import { useCallback } from "react";
-import type { Address } from "viem";
+import { useCallback, useState } from "react";
+import type { Address, Hex } from "viem";
 
 import { ArtifactDownloadModal } from "@/components/deposit/ArtifactDownloadModal";
 import { computeDepositDerivedState } from "@/components/deposit/DepositSignModal/depositStepHelpers";
@@ -17,6 +17,7 @@ import { useDepositFlow } from "@/hooks/deposit/useDepositFlow";
 import { useRunOnce } from "@/hooks/useRunOnce";
 
 import { DepositProgressView } from "./DepositProgressView";
+import { PostDepositContinuationContent } from "./PostDepositContinuationContent";
 
 interface DepositSignContentProps {
   vaultAmounts: bigint[];
@@ -55,10 +56,15 @@ export function DepositSignContent({
     ...flowParams,
   });
 
+  const [continuationVaultIds, setContinuationVaultIds] = useState<
+    Hex[] | null
+  >(null);
+
   const startFlow = useCallback(async () => {
     const result = await executeDeposit();
     if (result) {
       onRefetchActivities?.();
+      setContinuationVaultIds(result.pegins.map((pegin) => pegin.vaultId));
     }
   }, [executeDeposit, onRefetchActivities]);
 
@@ -72,6 +78,20 @@ export function DepositSignContent({
     abort();
     onClose();
   }, [abort, onClose]);
+
+  if (
+    continuationVaultIds &&
+    continuationVaultIds.length > 0 &&
+    flowParams.depositorEthAddress
+  ) {
+    return (
+      <PostDepositContinuationContent
+        vaultIds={continuationVaultIds}
+        depositorEthAddress={flowParams.depositorEthAddress}
+        onClose={onClose}
+      />
+    );
+  }
 
   return (
     <>

--- a/services/vault/src/components/simple/PendingDepositModals.tsx
+++ b/services/vault/src/components/simple/PendingDepositModals.tsx
@@ -5,10 +5,8 @@
  * pending deposit section. Uses SimpleDeposit in resume mode for all actions.
  */
 
-import { useEffect, useState } from "react";
 import type { Hex } from "viem";
 
-import { ArtifactDownloadModal } from "@/components/deposit/ArtifactDownloadModal";
 import { BroadcastSuccessModal } from "@/components/deposit/BroadcastSuccessModal";
 import { RefundModal } from "@/components/deposit/RefundModal";
 import { usePeginPolling } from "@/context/deposit/PeginPollingContext";
@@ -16,7 +14,7 @@ import type { SignModalData } from "@/hooks/deposit/usePayoutSignModal";
 import type { VaultActivity } from "@/types/activity";
 import type { VaultProvider } from "@/types/vaultProvider";
 
-import { ActivateConfirmationModal } from "./ActivateConfirmationModal";
+import { ActivationGate } from "./ActivationGate";
 import SimpleDeposit from "./SimpleDeposit";
 
 interface SignModalState {
@@ -84,25 +82,6 @@ export function PendingDepositModals({
   };
 
   const activatingActivity = activationModal.activatingActivity;
-  const [activationConfirmed, setActivationConfirmed] = useState(false);
-  const [showArtifactDownload, setShowArtifactDownload] = useState(false);
-  const [downloadCompletedAt, setDownloadCompletedAt] = useState(0);
-
-  useEffect(() => {
-    if (!activatingActivity) {
-      setActivationConfirmed(false);
-      setShowArtifactDownload(false);
-    }
-  }, [activatingActivity]);
-
-  const artifactProviderAddress = activatingActivity?.providers?.[0]?.id;
-  const artifactPeginTxid = activatingActivity?.peginTxHash;
-  const artifactDepositorPk = activatingActivity?.depositorBtcPubkey;
-  const canDownloadArtifacts =
-    !!activatingActivity &&
-    !!artifactProviderAddress &&
-    !!artifactPeginTxid &&
-    !!artifactDepositorPk;
 
   return (
     <>
@@ -144,46 +123,22 @@ export function PendingDepositModals({
         />
       )}
 
-      {/* Activation gate — confirmation + artifact-download nudge */}
-      {activatingActivity && ethAddress && !activationConfirmed && (
-        <ActivateConfirmationModal
-          open
-          vaultId={activatingActivity.id}
-          downloadCompletedAt={downloadCompletedAt}
-          onClose={activationModal.handleClose}
-          onConfirm={() => setActivationConfirmed(true)}
-          onDownloadArtifacts={() => {
-            if (canDownloadArtifacts) setShowArtifactDownload(true);
-          }}
-        />
-      )}
-
-      {activatingActivity && showArtifactDownload && canDownloadArtifacts && (
-        <ArtifactDownloadModal
-          open
-          providerAddress={artifactProviderAddress as string}
-          peginTxid={artifactPeginTxid as string}
-          depositorPk={artifactDepositorPk as string}
-          vaultId={activatingActivity.id}
-          unsignedPrePeginTxHex={activatingActivity.unsignedPrePeginTx}
-          onClose={() => setShowArtifactDownload(false)}
-          onComplete={() => {
-            setShowArtifactDownload(false);
-            setDownloadCompletedAt((n) => n + 1);
-          }}
-        />
-      )}
-
-      {/* Activation Modal — secret input + ETH tx */}
-      {activatingActivity && ethAddress && activationConfirmed && (
-        <SimpleDeposit
-          open
-          resumeMode="activate_vault"
-          onClose={activationModal.handleClose}
-          onResumeSuccess={activationModal.handleSuccess}
+      {/* Activation gate — confirmation + artifact-download nudge, then activate */}
+      {activatingActivity && ethAddress && (
+        <ActivationGate
+          key={activatingActivity.id}
           activity={activatingActivity}
-          depositorEthAddress={ethAddress}
-        />
+          onClose={activationModal.handleClose}
+        >
+          <SimpleDeposit
+            open
+            resumeMode="activate_vault"
+            onClose={activationModal.handleClose}
+            onResumeSuccess={activationModal.handleSuccess}
+            activity={activatingActivity}
+            depositorEthAddress={ethAddress}
+          />
+        </ActivationGate>
       )}
 
       {/* Refund Modal */}

--- a/services/vault/src/components/simple/PostDepositContinuationContent.tsx
+++ b/services/vault/src/components/simple/PostDepositContinuationContent.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import type { Address, Hex } from "viem";
 
 import { PeginPollingProvider } from "@/context/deposit/PeginPollingContext";
@@ -22,15 +23,23 @@ export function PostDepositContinuationContent({
   const btcPublicKey = useBtcPublicKey(btcConnected);
   const { activities, pendingPegins } = useVaultDeposits(depositorEthAddress);
 
+  const scoped = useMemo(() => {
+    const ids = new Set<string>(vaultIds);
+    return {
+      activities: activities.filter((a) => ids.has(a.id)),
+      pendingPegins: pendingPegins.filter((p) => ids.has(p.id)),
+    };
+  }, [vaultIds, activities, pendingPegins]);
+
   return (
     <PeginPollingProvider
-      activities={activities}
-      pendingPegins={pendingPegins}
+      activities={scoped.activities}
+      pendingPegins={scoped.pendingPegins}
       btcPublicKey={btcPublicKey}
     >
       <PostDepositContinuationView
         vaultIds={vaultIds}
-        activities={activities}
+        activities={scoped.activities}
         depositorEthAddress={depositorEthAddress}
         btcPublicKey={btcPublicKey}
         onClose={onClose}

--- a/services/vault/src/components/simple/PostDepositContinuationContent.tsx
+++ b/services/vault/src/components/simple/PostDepositContinuationContent.tsx
@@ -1,0 +1,40 @@
+import type { Address, Hex } from "viem";
+
+import { PeginPollingProvider } from "@/context/deposit/PeginPollingContext";
+import { useBTCWallet } from "@/context/wallet";
+import { useBtcPublicKey } from "@/hooks/useBtcPublicKey";
+import { useVaultDeposits } from "@/hooks/useVaultDeposits";
+
+import { PostDepositContinuationView } from "./PostDepositContinuationView";
+
+interface PostDepositContinuationContentProps {
+  vaultIds: Hex[];
+  depositorEthAddress: Address;
+  onClose: () => void;
+}
+
+export function PostDepositContinuationContent({
+  vaultIds,
+  depositorEthAddress,
+  onClose,
+}: PostDepositContinuationContentProps) {
+  const { connected: btcConnected } = useBTCWallet();
+  const btcPublicKey = useBtcPublicKey(btcConnected);
+  const { activities, pendingPegins } = useVaultDeposits(depositorEthAddress);
+
+  return (
+    <PeginPollingProvider
+      activities={activities}
+      pendingPegins={pendingPegins}
+      btcPublicKey={btcPublicKey}
+    >
+      <PostDepositContinuationView
+        vaultIds={vaultIds}
+        activities={activities}
+        depositorEthAddress={depositorEthAddress}
+        btcPublicKey={btcPublicKey}
+        onClose={onClose}
+      />
+    </PeginPollingProvider>
+  );
+}

--- a/services/vault/src/components/simple/PostDepositContinuationView.tsx
+++ b/services/vault/src/components/simple/PostDepositContinuationView.tsx
@@ -4,11 +4,12 @@ import { usePeginPolling } from "@/context/deposit/PeginPollingContext";
 import { COPY } from "@/copy";
 import { DepositFlowStep } from "@/hooks/deposit/depositFlowSteps";
 import {
-  ContractStatus,
   getPeginDisplayStep,
+  isVaultPastActivation,
   LocalStorageStatus,
   PeginAction,
   type PeginState,
+  USER_ACTIONABLE_PEGIN_ACTIONS,
 } from "@/models/peginStateMachine";
 import type { VaultActivity } from "@/types/activity";
 
@@ -28,21 +29,53 @@ interface PostDepositContinuationViewProps {
   onClose: () => void;
 }
 
-function isVaultPastActivation(peginState: PeginState | undefined): boolean {
-  if (!peginState) return false;
-  const { contractStatus, localStatus } = peginState;
-  if (
-    contractStatus === ContractStatus.VERIFIED &&
-    localStatus === LocalStorageStatus.CONFIRMED
-  ) {
-    return true;
-  }
+function isCandidateVault(state: PeginState | undefined): boolean {
   return (
-    contractStatus === ContractStatus.ACTIVE ||
-    contractStatus === ContractStatus.REDEEMED ||
-    contractStatus === ContractStatus.LIQUIDATED ||
-    contractStatus === ContractStatus.DEPOSITOR_WITHDRAWN
+    !!state &&
+    !isVaultPastActivation(state) &&
+    state.displayVariant !== "warning"
   );
+}
+
+function hasActionableStep(
+  state: PeginState | undefined,
+  btcPublicKey: string | undefined,
+): boolean {
+  if (!state) return false;
+  return (state.availableActions ?? []).some((action) => {
+    if (!USER_ACTIONABLE_PEGIN_ACTIONS.has(action)) return false;
+    // Mirror the render-branch prerequisite: payout signing also needs the
+    // depositor's BTC public key. Without this check a payout-only vault
+    // wins actionableIndex, fails the payout branch, and renders the wait
+    // view — stalling a later vault with a genuinely-actionable step.
+    if (action === PeginAction.SIGN_PAYOUT_TRANSACTIONS) {
+      return btcPublicKey !== undefined;
+    }
+    return true;
+  });
+}
+
+/**
+ * Step to freeze the stepper on for a warning (terminal failure) vault.
+ *
+ * `getPeginDisplayStep` returns `null` for warning states by design — it
+ * never shows progress for a failed deposit. We derive a frozen step from
+ * the vault's last persisted local status so the stepper shows the point
+ * of failure rather than a generic "Awaiting BTC confirmation."
+ */
+function stepForWarningVault(state: PeginState): DepositFlowStep {
+  switch (state.localStatus) {
+    case LocalStorageStatus.CONFIRMED:
+      return DepositFlowStep.ACTIVATE_VAULT;
+    case LocalStorageStatus.PAYOUT_SIGNED:
+      return DepositFlowStep.AWAIT_VP_VERIFICATION;
+    case LocalStorageStatus.CONFIRMING:
+      return DepositFlowStep.AWAIT_BTC_CONFIRMATION;
+    case LocalStorageStatus.PENDING:
+      return DepositFlowStep.BROADCAST_PRE_PEGIN;
+    default:
+      return DepositFlowStep.AWAIT_BTC_CONFIRMATION;
+  }
 }
 
 function StatusView({
@@ -87,10 +120,22 @@ export function PostDepositContinuationView({
 }: PostDepositContinuationViewProps) {
   const { refetch, getPollingResult } = usePeginPolling();
 
-  const currentVaultIndex = vaultIds.findIndex((id) => {
+  // Prefer a vault with a user-actionable step over a sibling that's
+  // merely waiting on the VP. Otherwise vault[0] in AWAIT_VP_VERIFICATION
+  // would stall vault[1]'s ready WOTS/payout/activation action — batches
+  // realistically diverge because the VP processes each vault at its own
+  // rate. Falls back to the first candidate so its wait state still shows
+  // when no sibling is actionable.
+  const actionableIndex = vaultIds.findIndex((id) => {
     const state = getPollingResult(id)?.peginState;
-    return !isVaultPastActivation(state) && state?.displayVariant !== "warning";
+    return isCandidateVault(state) && hasActionableStep(state, btcPublicKey);
   });
+  const currentVaultIndex =
+    actionableIndex !== -1
+      ? actionableIndex
+      : vaultIds.findIndex((id) =>
+          isCandidateVault(getPollingResult(id)?.peginState),
+        );
   const currentVaultId =
     currentVaultIndex === -1 ? undefined : vaultIds[currentVaultIndex];
   const pollingResult = currentVaultId
@@ -105,9 +150,12 @@ export function PostDepositContinuationView({
       .map((id) => getPollingResult(id)?.peginState)
       .find((state) => state?.displayVariant === "warning");
     if (warning) {
+      // Freeze the stepper at the point of failure based on the vault's
+      // last persisted localStatus — `getPeginDisplayStep` is null for
+      // warning states by design, so we map it ourselves.
       return (
         <StatusView
-          currentStep={DepositFlowStep.ACTIVATE_VAULT}
+          currentStep={stepForWarningVault(warning)}
           error={warning.message ?? COPY.common.somethingWentWrong.body}
           onClose={onClose}
         />
@@ -125,6 +173,17 @@ export function PostDepositContinuationView({
 
   const peginState = pollingResult?.peginState;
   const actions = peginState?.availableActions ?? [];
+
+  // Action-driven branches. PeginAction.SIGN_AND_BROADCAST_TO_BITCOIN is
+  // intentionally absent: the continuation only mounts after
+  // `executeDeposit()` resolves (Pre-PegIn broadcast + localStorage past
+  // CONFIRMING), so that action is never in `actions` here — the dashboard
+  // resume path covers sessions that aborted before broadcast.
+  //
+  // Artifact download is NOT auto-invoked: it's a real file download and
+  // silent downloads are user-hostile (the browser may block, the user may
+  // not be ready). The ActivationGate below renders a manual download
+  // button once that step is reached.
 
   if (activity && actions.includes(PeginAction.SUBMIT_WOTS_KEY)) {
     return (

--- a/services/vault/src/components/simple/PostDepositContinuationView.tsx
+++ b/services/vault/src/components/simple/PostDepositContinuationView.tsx
@@ -1,0 +1,183 @@
+import { useCallback, useState } from "react";
+import type { Address, Hex } from "viem";
+
+import { ArtifactDownloadModal } from "@/components/deposit/ArtifactDownloadModal";
+import {
+  useDepositPollingResult,
+  usePeginPolling,
+} from "@/context/deposit/PeginPollingContext";
+import { COPY } from "@/copy";
+import { DepositFlowStep } from "@/hooks/deposit/depositFlowSteps";
+import { getPeginDisplayStep, PeginAction } from "@/models/peginStateMachine";
+import type { VaultActivity } from "@/types/activity";
+import { hasArtifactsDownloaded } from "@/utils/artifactDownloadStorage";
+
+import { DepositProgressView } from "./DepositProgressView";
+import {
+  ResumeActivationContent,
+  ResumeSignContent,
+  ResumeWotsContent,
+} from "./ResumeDepositContent";
+
+interface PostDepositContinuationViewProps {
+  vaultIds: Hex[];
+  activities: VaultActivity[];
+  depositorEthAddress: Address;
+  btcPublicKey: string | undefined;
+  onClose: () => void;
+}
+
+export function PostDepositContinuationView({
+  vaultIds,
+  activities,
+  depositorEthAddress,
+  btcPublicKey,
+  onClose,
+}: PostDepositContinuationViewProps) {
+  const [currentVaultIndex, setCurrentVaultIndex] = useState(0);
+  const [artifactResolvedVaultIds, setArtifactResolvedVaultIds] = useState<
+    ReadonlySet<string>
+  >(() => new Set());
+  const { refetch } = usePeginPolling();
+
+  const currentVaultId = vaultIds[currentVaultIndex];
+  const pollingResult = useDepositPollingResult(currentVaultId ?? "");
+  const activity = currentVaultId
+    ? activities.find((a) => a.id === currentVaultId)
+    : undefined;
+
+  // Keyed to the shown index so a StrictMode double-success cannot skip a vault.
+  const advanceFrom = useCallback((fromIndex: number) => {
+    setCurrentVaultIndex((index) => (index === fromIndex ? index + 1 : index));
+  }, []);
+
+  const resolveArtifact = useCallback((vaultId: string) => {
+    setArtifactResolvedVaultIds((prev) => {
+      if (prev.has(vaultId)) return prev;
+      const next = new Set(prev);
+      next.add(vaultId);
+      return next;
+    });
+  }, []);
+
+  if (!currentVaultId) {
+    return (
+      <DepositProgressView
+        currentStep={DepositFlowStep.COMPLETED}
+        error={null}
+        isComplete
+        isProcessing={false}
+        canClose
+        canContinueInBackground={false}
+        payoutSigningProgress={null}
+        peginSigningProgress={null}
+        onClose={onClose}
+        successMessage={COPY.deposit.resume.activationSuccessMessage}
+      />
+    );
+  }
+
+  const peginState = pollingResult?.peginState;
+  const actions = peginState?.availableActions ?? [];
+  const isWarning = peginState?.displayVariant === "warning";
+
+  if (isWarning) {
+    return (
+      <DepositProgressView
+        currentStep={DepositFlowStep.ACTIVATE_VAULT}
+        error={peginState?.message ?? COPY.common.somethingWentWrong.body}
+        isComplete={false}
+        isProcessing={false}
+        canClose
+        canContinueInBackground={false}
+        payoutSigningProgress={null}
+        peginSigningProgress={null}
+        onClose={onClose}
+      />
+    );
+  }
+
+  if (activity && actions.includes(PeginAction.SUBMIT_WOTS_KEY)) {
+    return (
+      <ResumeWotsContent
+        key={`wots-${currentVaultId}`}
+        activity={activity}
+        onClose={onClose}
+        onSuccess={refetch}
+      />
+    );
+  }
+
+  if (
+    activity &&
+    btcPublicKey &&
+    actions.includes(PeginAction.SIGN_PAYOUT_TRANSACTIONS)
+  ) {
+    return (
+      <ResumeSignContent
+        key={`payout-${currentVaultId}`}
+        activity={activity}
+        btcPublicKey={btcPublicKey}
+        depositorEthAddress={depositorEthAddress}
+        onClose={onClose}
+        onSuccess={refetch}
+      />
+    );
+  }
+
+  if (activity && actions.includes(PeginAction.ACTIVATE_VAULT)) {
+    const providerAddress = activity.providers?.[0]?.id;
+    const peginTxid = activity.peginTxHash;
+    const depositorPk = activity.depositorBtcPubkey;
+    const canDownloadArtifacts =
+      !!providerAddress && !!peginTxid && !!depositorPk;
+    const needsArtifactDownload =
+      canDownloadArtifacts &&
+      !artifactResolvedVaultIds.has(currentVaultId) &&
+      !hasArtifactsDownloaded(currentVaultId);
+
+    if (needsArtifactDownload) {
+      return (
+        <ArtifactDownloadModal
+          open
+          providerAddress={providerAddress as string}
+          peginTxid={peginTxid as string}
+          depositorPk={depositorPk as string}
+          vaultId={currentVaultId}
+          unsignedPrePeginTxHex={activity.unsignedPrePeginTx}
+          onClose={onClose}
+          onComplete={() => resolveArtifact(currentVaultId)}
+        />
+      );
+    }
+
+    const isLastVault = currentVaultIndex >= vaultIds.length - 1;
+    return (
+      <ResumeActivationContent
+        key={`activate-${currentVaultId}`}
+        activity={activity}
+        depositorEthAddress={depositorEthAddress}
+        onClose={onClose}
+        onSuccess={isLastVault ? onClose : () => advanceFrom(currentVaultIndex)}
+      />
+    );
+  }
+
+  const waitStep = peginState
+    ? (getPeginDisplayStep(peginState) ?? DepositFlowStep.ACTIVATE_VAULT)
+    : DepositFlowStep.AWAIT_BTC_CONFIRMATION;
+
+  return (
+    <DepositProgressView
+      currentStep={waitStep}
+      error={null}
+      isComplete={false}
+      isProcessing
+      canClose
+      canContinueInBackground
+      payoutSigningProgress={null}
+      peginSigningProgress={null}
+      onClose={onClose}
+    />
+  );
+}

--- a/services/vault/src/components/simple/PostDepositContinuationView.tsx
+++ b/services/vault/src/components/simple/PostDepositContinuationView.tsx
@@ -87,9 +87,10 @@ export function PostDepositContinuationView({
 }: PostDepositContinuationViewProps) {
   const { refetch, getPollingResult } = usePeginPolling();
 
-  const currentVaultIndex = vaultIds.findIndex(
-    (id) => !isVaultPastActivation(getPollingResult(id)?.peginState),
-  );
+  const currentVaultIndex = vaultIds.findIndex((id) => {
+    const state = getPollingResult(id)?.peginState;
+    return !isVaultPastActivation(state) && state?.displayVariant !== "warning";
+  });
   const currentVaultId =
     currentVaultIndex === -1 ? undefined : vaultIds[currentVaultIndex];
   const pollingResult = currentVaultId
@@ -100,6 +101,18 @@ export function PostDepositContinuationView({
     : undefined;
 
   if (!currentVaultId) {
+    const warning = vaultIds
+      .map((id) => getPollingResult(id)?.peginState)
+      .find((state) => state?.displayVariant === "warning");
+    if (warning) {
+      return (
+        <StatusView
+          currentStep={DepositFlowStep.ACTIVATE_VAULT}
+          error={warning.message ?? COPY.common.somethingWentWrong.body}
+          onClose={onClose}
+        />
+      );
+    }
     return (
       <StatusView
         currentStep={DepositFlowStep.COMPLETED}
@@ -112,17 +125,6 @@ export function PostDepositContinuationView({
 
   const peginState = pollingResult?.peginState;
   const actions = peginState?.availableActions ?? [];
-  const isWarning = peginState?.displayVariant === "warning";
-
-  if (isWarning) {
-    return (
-      <StatusView
-        currentStep={DepositFlowStep.ACTIVATE_VAULT}
-        error={peginState?.message ?? COPY.common.somethingWentWrong.body}
-        onClose={onClose}
-      />
-    );
-  }
 
   if (activity && actions.includes(PeginAction.SUBMIT_WOTS_KEY)) {
     return (

--- a/services/vault/src/components/simple/PostDepositContinuationView.tsx
+++ b/services/vault/src/components/simple/PostDepositContinuationView.tsx
@@ -1,11 +1,6 @@
-import { useCallback, useEffect, useState } from "react";
 import type { Address, Hex } from "viem";
 
-import { ArtifactDownloadModal } from "@/components/deposit/ArtifactDownloadModal";
-import {
-  useDepositPollingResult,
-  usePeginPolling,
-} from "@/context/deposit/PeginPollingContext";
+import { usePeginPolling } from "@/context/deposit/PeginPollingContext";
 import { COPY } from "@/copy";
 import { DepositFlowStep } from "@/hooks/deposit/depositFlowSteps";
 import {
@@ -13,10 +8,11 @@ import {
   getPeginDisplayStep,
   LocalStorageStatus,
   PeginAction,
+  type PeginState,
 } from "@/models/peginStateMachine";
 import type { VaultActivity } from "@/types/activity";
-import { hasArtifactsDownloaded } from "@/utils/artifactDownloadStorage";
 
+import { ActivationGate } from "./ActivationGate";
 import { DepositProgressView } from "./DepositProgressView";
 import {
   ResumeActivationContent,
@@ -32,11 +28,9 @@ interface PostDepositContinuationViewProps {
   onClose: () => void;
 }
 
-function isVaultPastActivation(
-  contractStatus: ContractStatus | undefined,
-  localStatus: LocalStorageStatus | undefined,
-): boolean {
-  if (contractStatus === undefined) return false;
+function isVaultPastActivation(peginState: PeginState | undefined): boolean {
+  if (!peginState) return false;
+  const { contractStatus, localStatus } = peginState;
   if (
     contractStatus === ContractStatus.VERIFIED &&
     localStatus === LocalStorageStatus.CONFIRMED
@@ -51,6 +45,39 @@ function isVaultPastActivation(
   );
 }
 
+function StatusView({
+  currentStep,
+  onClose,
+  error = null,
+  isComplete = false,
+  isProcessing = false,
+  canContinueInBackground = false,
+  successMessage,
+}: {
+  currentStep: DepositFlowStep;
+  onClose: () => void;
+  error?: string | null;
+  isComplete?: boolean;
+  isProcessing?: boolean;
+  canContinueInBackground?: boolean;
+  successMessage?: string;
+}) {
+  return (
+    <DepositProgressView
+      currentStep={currentStep}
+      error={error}
+      isComplete={isComplete}
+      isProcessing={isProcessing}
+      canClose
+      canContinueInBackground={canContinueInBackground}
+      payoutSigningProgress={null}
+      peginSigningProgress={null}
+      onClose={onClose}
+      successMessage={successMessage}
+    />
+  );
+}
+
 export function PostDepositContinuationView({
   vaultIds,
   activities,
@@ -58,59 +85,25 @@ export function PostDepositContinuationView({
   btcPublicKey,
   onClose,
 }: PostDepositContinuationViewProps) {
-  const [currentVaultIndex, setCurrentVaultIndex] = useState(0);
-  const [artifactResolvedVaultIds, setArtifactResolvedVaultIds] = useState<
-    ReadonlySet<string>
-  >(() => new Set());
-  const { refetch } = usePeginPolling();
+  const { refetch, getPollingResult } = usePeginPolling();
 
-  const currentVaultId = vaultIds[currentVaultIndex];
-  const pollingResult = useDepositPollingResult(currentVaultId ?? "");
+  const currentVaultIndex = vaultIds.findIndex(
+    (id) => !isVaultPastActivation(getPollingResult(id)?.peginState),
+  );
+  const currentVaultId =
+    currentVaultIndex === -1 ? undefined : vaultIds[currentVaultIndex];
+  const pollingResult = currentVaultId
+    ? getPollingResult(currentVaultId)
+    : undefined;
   const activity = currentVaultId
     ? activities.find((a) => a.id === currentVaultId)
     : undefined;
 
-  // Keyed to the shown index so a StrictMode double-success cannot skip a vault.
-  const advanceFrom = useCallback((fromIndex: number) => {
-    setCurrentVaultIndex((index) => (index === fromIndex ? index + 1 : index));
-  }, []);
-
-  const resolveArtifact = useCallback((vaultId: string) => {
-    setArtifactResolvedVaultIds((prev) => {
-      if (prev.has(vaultId)) return prev;
-      const next = new Set(prev);
-      next.add(vaultId);
-      return next;
-    });
-  }, []);
-
-  const currentContractStatus = pollingResult?.peginState?.contractStatus;
-  const currentLocalStatus = pollingResult?.peginState?.localStatus;
-
-  useEffect(() => {
-    if (!currentVaultId) return;
-    if (isVaultPastActivation(currentContractStatus, currentLocalStatus)) {
-      advanceFrom(currentVaultIndex);
-    }
-  }, [
-    currentVaultId,
-    currentContractStatus,
-    currentLocalStatus,
-    currentVaultIndex,
-    advanceFrom,
-  ]);
-
   if (!currentVaultId) {
     return (
-      <DepositProgressView
+      <StatusView
         currentStep={DepositFlowStep.COMPLETED}
-        error={null}
         isComplete
-        isProcessing={false}
-        canClose
-        canContinueInBackground={false}
-        payoutSigningProgress={null}
-        peginSigningProgress={null}
         onClose={onClose}
         successMessage={COPY.deposit.resume.activationSuccessMessage}
       />
@@ -123,15 +116,9 @@ export function PostDepositContinuationView({
 
   if (isWarning) {
     return (
-      <DepositProgressView
+      <StatusView
         currentStep={DepositFlowStep.ACTIVATE_VAULT}
         error={peginState?.message ?? COPY.common.somethingWentWrong.body}
-        isComplete={false}
-        isProcessing={false}
-        canClose
-        canContinueInBackground={false}
-        payoutSigningProgress={null}
-        peginSigningProgress={null}
         onClose={onClose}
       />
     );
@@ -166,39 +153,19 @@ export function PostDepositContinuationView({
   }
 
   if (activity && actions.includes(PeginAction.ACTIVATE_VAULT)) {
-    const providerAddress = activity.providers?.[0]?.id;
-    const peginTxid = activity.peginTxHash;
-    const depositorPk = activity.depositorBtcPubkey;
-    const canDownloadArtifacts =
-      !!providerAddress && !!peginTxid && !!depositorPk;
-    const needsArtifactDownload =
-      canDownloadArtifacts &&
-      !artifactResolvedVaultIds.has(currentVaultId) &&
-      !hasArtifactsDownloaded(currentVaultId);
-
-    if (needsArtifactDownload) {
-      return (
-        <ArtifactDownloadModal
-          open
-          providerAddress={providerAddress as string}
-          peginTxid={peginTxid as string}
-          depositorPk={depositorPk as string}
-          vaultId={currentVaultId}
-          unsignedPrePeginTxHex={activity.unsignedPrePeginTx}
-          onClose={onClose}
-          onComplete={() => resolveArtifact(currentVaultId)}
-        />
-      );
-    }
-
     return (
-      <ResumeActivationContent
-        key={`activate-${currentVaultId}`}
+      <ActivationGate
+        key={`gate-${currentVaultId}`}
         activity={activity}
-        depositorEthAddress={depositorEthAddress}
         onClose={onClose}
-        onSuccess={refetch}
-      />
+      >
+        <ResumeActivationContent
+          activity={activity}
+          depositorEthAddress={depositorEthAddress}
+          onClose={onClose}
+          onSuccess={refetch}
+        />
+      </ActivationGate>
     );
   }
 
@@ -207,15 +174,10 @@ export function PostDepositContinuationView({
     : DepositFlowStep.AWAIT_BTC_CONFIRMATION;
 
   return (
-    <DepositProgressView
+    <StatusView
       currentStep={waitStep}
-      error={null}
-      isComplete={false}
       isProcessing
-      canClose
       canContinueInBackground
-      payoutSigningProgress={null}
-      peginSigningProgress={null}
       onClose={onClose}
     />
   );

--- a/services/vault/src/components/simple/PostDepositContinuationView.tsx
+++ b/services/vault/src/components/simple/PostDepositContinuationView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import type { Address, Hex } from "viem";
 
 import { ArtifactDownloadModal } from "@/components/deposit/ArtifactDownloadModal";
@@ -8,7 +8,12 @@ import {
 } from "@/context/deposit/PeginPollingContext";
 import { COPY } from "@/copy";
 import { DepositFlowStep } from "@/hooks/deposit/depositFlowSteps";
-import { getPeginDisplayStep, PeginAction } from "@/models/peginStateMachine";
+import {
+  ContractStatus,
+  getPeginDisplayStep,
+  LocalStorageStatus,
+  PeginAction,
+} from "@/models/peginStateMachine";
 import type { VaultActivity } from "@/types/activity";
 import { hasArtifactsDownloaded } from "@/utils/artifactDownloadStorage";
 
@@ -25,6 +30,25 @@ interface PostDepositContinuationViewProps {
   depositorEthAddress: Address;
   btcPublicKey: string | undefined;
   onClose: () => void;
+}
+
+function isVaultPastActivation(
+  contractStatus: ContractStatus | undefined,
+  localStatus: LocalStorageStatus | undefined,
+): boolean {
+  if (contractStatus === undefined) return false;
+  if (
+    contractStatus === ContractStatus.VERIFIED &&
+    localStatus === LocalStorageStatus.CONFIRMED
+  ) {
+    return true;
+  }
+  return (
+    contractStatus === ContractStatus.ACTIVE ||
+    contractStatus === ContractStatus.REDEEMED ||
+    contractStatus === ContractStatus.LIQUIDATED ||
+    contractStatus === ContractStatus.DEPOSITOR_WITHDRAWN
+  );
 }
 
 export function PostDepositContinuationView({
@@ -59,6 +83,22 @@ export function PostDepositContinuationView({
       return next;
     });
   }, []);
+
+  const currentContractStatus = pollingResult?.peginState?.contractStatus;
+  const currentLocalStatus = pollingResult?.peginState?.localStatus;
+
+  useEffect(() => {
+    if (!currentVaultId) return;
+    if (isVaultPastActivation(currentContractStatus, currentLocalStatus)) {
+      advanceFrom(currentVaultIndex);
+    }
+  }, [
+    currentVaultId,
+    currentContractStatus,
+    currentLocalStatus,
+    currentVaultIndex,
+    advanceFrom,
+  ]);
 
   if (!currentVaultId) {
     return (
@@ -151,14 +191,13 @@ export function PostDepositContinuationView({
       );
     }
 
-    const isLastVault = currentVaultIndex >= vaultIds.length - 1;
     return (
       <ResumeActivationContent
         key={`activate-${currentVaultId}`}
         activity={activity}
         depositorEthAddress={depositorEthAddress}
         onClose={onClose}
-        onSuccess={isLastVault ? onClose : () => advanceFrom(currentVaultIndex)}
+        onSuccess={refetch}
       />
     );
   }

--- a/services/vault/src/components/simple/ResumeDepositContent.tsx
+++ b/services/vault/src/components/simple/ResumeDepositContent.tsx
@@ -25,7 +25,7 @@ import {
 import { primeVpTokenRegistry } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
 import { calculateBtcTxHash } from "@babylonlabs-io/ts-sdk/tbv/core/utils";
 import { useChainConnector } from "@babylonlabs-io/wallet-connector";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { Address, Hex } from "viem";
 
 import { getVaultRegistryReader } from "@/clients/eth-contract/sdk-readers";
@@ -201,6 +201,17 @@ export function ResumeWotsContent({
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  // Track mount for setState guards after the long async chain below.
+  // The hosting modal can be closed mid-flight (PostDepositContinuationView
+  // unmounts on user close), so the post-await setLoading/setError below
+  // would otherwise warn about updates on an unmounted component.
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
   // Release the primed registry entry on unmount if activation didn't
   // happen (the normal release point in `useVaultActions`). Bounds
   // `authAnchorHex` lifetime when the user abandons the resume flow.
@@ -330,21 +341,25 @@ export function ResumeWotsContent({
         unsignedPrePeginTxHex: activity.unsignedPrePeginTx,
       });
 
-      setLoading(false);
-      // Refetch dashboard activities so the next action surfaces while
-      // the modal stays parked on "Close & continue later".
-      onSuccess();
-    } catch (err) {
-      const msg =
-        err instanceof Error ? err.message : "Failed to submit WOTS key";
-      // VP-side mismatch gets the same wording as the local pre-flight
-      // so the user can act on either path.
-      if (isWotsMismatchError(err)) {
-        setError(COPY.deposit.resume.wotsMismatchError);
-      } else {
-        setError(msg);
+      if (mountedRef.current) {
+        setLoading(false);
+        // Refetch dashboard activities so the next action surfaces while
+        // the modal stays parked on "Close & continue later".
+        onSuccess();
       }
-      setLoading(false);
+    } catch (err) {
+      if (mountedRef.current) {
+        const msg =
+          err instanceof Error ? err.message : "Failed to submit WOTS key";
+        // VP-side mismatch gets the same wording as the local pre-flight
+        // so the user can act on either path.
+        if (isWotsMismatchError(err)) {
+          setError(COPY.deposit.resume.wotsMismatchError);
+        } else {
+          setError(msg);
+        }
+        setLoading(false);
+      }
     } finally {
       root?.fill(0);
     }
@@ -423,6 +438,17 @@ export function ResumeActivationContent({
   // first render must show processing.
   const [loading, setLoading] = useState(true);
   const [localError, setLocalError] = useState<string | null>(null);
+
+  // Track mount for setState guards after the long async chain below.
+  // The hosting modal can be closed mid-flight, so the post-await
+  // setLoading/setLocalError below would otherwise warn about updates on
+  // an unmounted component.
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
 
   const {
     activating,
@@ -510,13 +536,17 @@ export function ResumeActivationContent({
       // error there, not a silent submission.
       await handleActivation(secretHex);
     } catch (err) {
-      const msg =
-        err instanceof Error ? err.message : "Failed to activate BTC Vault";
-      setLocalError(msg);
+      if (mountedRef.current) {
+        const msg =
+          err instanceof Error ? err.message : "Failed to activate BTC Vault";
+        setLocalError(msg);
+      }
     } finally {
+      // Memory wipes run regardless of mount: secret material must not
+      // linger if the user closed the modal mid-flight.
       root?.fill(0);
       secretBytes?.fill(0);
-      setLoading(false);
+      if (mountedRef.current) setLoading(false);
     }
   }, [
     activity,

--- a/services/vault/src/components/simple/__tests__/ActivationGate.test.tsx
+++ b/services/vault/src/components/simple/__tests__/ActivationGate.test.tsx
@@ -1,0 +1,133 @@
+import { fireEvent, render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { VaultActivity } from "@/types/activity";
+
+import { ActivationGate } from "../ActivationGate";
+
+vi.mock("../ActivateConfirmationModal", () => ({
+  ActivateConfirmationModal: ({
+    onConfirm,
+    onClose,
+    onDownloadArtifacts,
+    downloadCompletedAt,
+  }: {
+    onConfirm: () => void;
+    onClose: () => void;
+    onDownloadArtifacts: () => void;
+    downloadCompletedAt?: number;
+  }) => (
+    <div data-testid="confirm">
+      <span data-testid="confirm-tick">{String(downloadCompletedAt ?? 0)}</span>
+      <button type="button" data-testid="confirm-activate" onClick={onConfirm}>
+        activate
+      </button>
+      <button
+        type="button"
+        data-testid="confirm-download"
+        onClick={onDownloadArtifacts}
+      >
+        download
+      </button>
+      <button type="button" data-testid="confirm-close" onClick={onClose}>
+        close
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock("@/components/deposit/ArtifactDownloadModal", () => ({
+  ArtifactDownloadModal: ({
+    onComplete,
+    onClose,
+  }: {
+    onComplete: () => void;
+    onClose: () => void;
+  }) => (
+    <div data-testid="artifact">
+      <button
+        type="button"
+        data-testid="artifact-complete"
+        onClick={onComplete}
+      >
+        complete
+      </button>
+      <button type="button" data-testid="artifact-close" onClick={onClose}>
+        close
+      </button>
+    </div>
+  ),
+}));
+
+function activity(overrides?: Partial<VaultActivity>): VaultActivity {
+  return {
+    id: "0xvault",
+    providers: [{ id: "0xprovider" }],
+    peginTxHash: "0xpegin",
+    depositorBtcPubkey: "0xpk",
+    unsignedPrePeginTx: "0xtx",
+    ...overrides,
+  } as unknown as VaultActivity;
+}
+
+describe("ActivationGate", () => {
+  it("shows the confirmation gate, not the children, before confirming", () => {
+    const { getByTestId, queryByTestId } = render(
+      <ActivationGate activity={activity()} onClose={vi.fn()}>
+        <div data-testid="activation-step" />
+      </ActivationGate>,
+    );
+    expect(getByTestId("confirm")).toBeTruthy();
+    expect(queryByTestId("activation-step")).toBeNull();
+  });
+
+  it("renders the children only after the user confirms", () => {
+    const { getByTestId } = render(
+      <ActivationGate activity={activity()} onClose={vi.fn()}>
+        <div data-testid="activation-step" />
+      </ActivationGate>,
+    );
+    fireEvent.click(getByTestId("confirm-activate"));
+    expect(getByTestId("activation-step")).toBeTruthy();
+  });
+
+  it("opens artifact download from the gate and bumps the tick on completion", () => {
+    const { getByTestId, queryByTestId } = render(
+      <ActivationGate activity={activity()} onClose={vi.fn()}>
+        <div data-testid="activation-step" />
+      </ActivationGate>,
+    );
+    expect(getByTestId("confirm-tick").textContent).toBe("0");
+
+    fireEvent.click(getByTestId("confirm-download"));
+    expect(getByTestId("artifact")).toBeTruthy();
+
+    fireEvent.click(getByTestId("artifact-complete"));
+    expect(queryByTestId("artifact")).toBeNull();
+    expect(getByTestId("confirm-tick").textContent).toBe("1");
+  });
+
+  it("does not open artifact download when artifact inputs are missing", () => {
+    const { getByTestId, queryByTestId } = render(
+      <ActivationGate
+        activity={activity({ peginTxHash: undefined })}
+        onClose={vi.fn()}
+      >
+        <div data-testid="activation-step" />
+      </ActivationGate>,
+    );
+    fireEvent.click(getByTestId("confirm-download"));
+    expect(queryByTestId("artifact")).toBeNull();
+  });
+
+  it("forwards close from the confirmation gate", () => {
+    const onClose = vi.fn();
+    const { getByTestId } = render(
+      <ActivationGate activity={activity()} onClose={onClose}>
+        <div data-testid="activation-step" />
+      </ActivationGate>,
+    );
+    fireEvent.click(getByTestId("confirm-close"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/services/vault/src/components/simple/__tests__/DepositSignContent.test.tsx
+++ b/services/vault/src/components/simple/__tests__/DepositSignContent.test.tsx
@@ -1,0 +1,96 @@
+import type { BitcoinWallet } from "@babylonlabs-io/ts-sdk/shared";
+import { render } from "@testing-library/react";
+import type { Address } from "viem";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DepositSignContent } from "../DepositSignContent";
+
+const mockExecuteDeposit = vi.hoisted(() => vi.fn());
+
+vi.mock("@/hooks/deposit/useDepositFlow", () => ({
+  useDepositFlow: () => ({
+    executeDeposit: mockExecuteDeposit,
+    abort: vi.fn(),
+    currentStep: "DERIVE_VAULT_SECRET",
+    processing: false,
+    error: null,
+    isWaiting: false,
+    payoutSigningProgress: null,
+    peginSigningProgress: null,
+    artifactDownloadInfo: null,
+    continueAfterArtifactDownload: vi.fn(),
+    btcConfirmationDetail: null,
+  }),
+}));
+
+vi.mock("@/components/deposit/DepositSignModal/depositStepHelpers", () => ({
+  computeDepositDerivedState: () => ({
+    isComplete: false,
+    canClose: true,
+    isProcessing: true,
+    canContinueInBackground: false,
+  }),
+}));
+
+vi.mock("../PostDepositContinuationContent", () => ({
+  PostDepositContinuationContent: ({ vaultIds }: { vaultIds: string[] }) => (
+    <div data-testid="continuation" data-count={vaultIds.length} />
+  ),
+}));
+
+vi.mock("../DepositProgressView", () => ({
+  DepositProgressView: () => <div data-testid="progress" />,
+}));
+
+vi.mock("@/components/deposit/ArtifactDownloadModal", () => ({
+  ArtifactDownloadModal: () => <div data-testid="artifact" />,
+}));
+
+function renderContent(
+  overrides: Partial<{ onRefetchActivities: () => Promise<void> }> = {},
+) {
+  return render(
+    <DepositSignContent
+      vaultAmounts={[100000n]}
+      mempoolFeeRate={1}
+      btcWalletProvider={{} as unknown as BitcoinWallet}
+      depositorEthAddress={"0xeth" as Address}
+      selectedApplication="0xapp"
+      selectedProviders={["0xprovider"]}
+      vaultProviderBtcPubkey="0xvp"
+      vaultKeeperBtcPubkeys={["0xkeeper"]}
+      universalChallengerBtcPubkeys={["0xchallenger"]}
+      onClose={vi.fn()}
+      onRefetchActivities={overrides.onRefetchActivities}
+    />,
+  );
+}
+
+describe("DepositSignContent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("switches to the continuation view once the deposit returns pegins", async () => {
+    mockExecuteDeposit.mockResolvedValue({
+      pegins: [{ vaultId: "0xv0" }, { vaultId: "0xv1" }],
+      batchId: "batch",
+    });
+    const onRefetchActivities = vi.fn().mockResolvedValue(undefined);
+
+    const { findByTestId } = renderContent({ onRefetchActivities });
+
+    const continuation = await findByTestId("continuation");
+    expect(continuation.getAttribute("data-count")).toBe("2");
+    expect(onRefetchActivities).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays on the progress view when the deposit returns null", async () => {
+    mockExecuteDeposit.mockResolvedValue(null);
+
+    const { findByTestId, queryByTestId } = renderContent();
+
+    await findByTestId("progress");
+    expect(queryByTestId("continuation")).toBeNull();
+  });
+});

--- a/services/vault/src/components/simple/__tests__/PostDepositContinuationView.test.tsx
+++ b/services/vault/src/components/simple/__tests__/PostDepositContinuationView.test.tsx
@@ -35,6 +35,23 @@ vi.mock("@/models/peginStateMachine", () => ({
     ACTIVATE_VAULT: "ACTIVATE_VAULT",
     NONE: "NONE",
   },
+  ContractStatus: {
+    PENDING: 0,
+    VERIFIED: 1,
+    ACTIVE: 2,
+    REDEEMED: 3,
+    LIQUIDATED: 4,
+    INVALID: 5,
+    DEPOSITOR_WITHDRAWN: 6,
+    EXPIRED: 7,
+  },
+  LocalStorageStatus: {
+    PENDING: "pending",
+    PAYOUT_SIGNED: "payout_signed",
+    CONFIRMING: "confirming",
+    CONFIRMED: "confirmed",
+    REFUND_BROADCAST: "refund_broadcast",
+  },
   getPeginDisplayStep: vi.fn(() => "AWAIT_BTC_CONFIRMATION"),
 }));
 
@@ -74,13 +91,15 @@ vi.mock("../DepositProgressView", () => ({
 
 function resumeMock(testId: string) {
   return ({
+    activity,
     onSuccess,
     onClose,
   }: {
+    activity: VaultActivity;
     onSuccess: () => void;
     onClose: () => void;
   }) => (
-    <div data-testid={testId}>
+    <div data-testid={testId} data-vault={activity?.id}>
       <button
         type="button"
         data-testid={`${testId}-success`}
@@ -138,6 +157,8 @@ function activityWithId(id: string): VaultActivity {
 
 function resultWith(opts: {
   availableActions: string[];
+  contractStatus?: number;
+  localStatus?: string;
   displayVariant?: "pending" | "active" | "inactive" | "warning";
   message?: string;
 }) {
@@ -146,7 +167,8 @@ function resultWith(opts: {
     loading: false,
     error: null,
     peginState: {
-      contractStatus: 0,
+      contractStatus: opts.contractStatus ?? 0,
+      localStatus: opts.localStatus,
       availableActions: opts.availableActions,
       displayVariant: opts.displayVariant ?? "pending",
       displayLabel: "x",
@@ -249,29 +271,105 @@ describe("PostDepositContinuationView", () => {
     expect(queryByTestId("artifact")).toBeNull();
   });
 
-  it("closes the modal after the last vault activates", () => {
+  it("shows the completed view once the last vault finishes activating", () => {
     mockHasArtifactsDownloaded.mockReturnValue(true);
-    mockUseDepositPollingResult.mockReturnValue(
-      resultWith({ availableActions: [PeginAction.ACTIVATE_VAULT] }),
+    const VERIFIED = 1;
+    const states = new Map<string, ReturnType<typeof resultWith>>([
+      [
+        "0xvault0",
+        resultWith({
+          availableActions: [PeginAction.ACTIVATE_VAULT],
+          contractStatus: VERIFIED,
+        }),
+      ],
+    ]);
+    mockUseDepositPollingResult.mockImplementation((id: string) =>
+      states.get(id),
     );
-    const onClose = vi.fn();
-    fireEvent.click(renderView({ onClose }).getByTestId("activate-success"));
-    expect(onClose).toHaveBeenCalledTimes(1);
+
+    const { getByTestId, rerender } = renderView({
+      vaultIds: ["0xvault0" as Hex],
+    });
+    expect(getByTestId("activate")).toBeTruthy();
+
+    // Activation submitted: the polling layer reports the vault as
+    // VERIFIED + CONFIRMED, which drops ACTIVATE_VAULT from its actions.
+    states.set(
+      "0xvault0",
+      resultWith({
+        availableActions: [PeginAction.NONE],
+        contractStatus: VERIFIED,
+        localStatus: "confirmed",
+      }),
+    );
+    rerender(
+      <PostDepositContinuationView
+        vaultIds={["0xvault0" as Hex]}
+        activities={[activityWithId("0xvault0")]}
+        depositorEthAddress={ETH}
+        btcPublicKey="btcpub"
+        onClose={vi.fn()}
+      />,
+    );
+
+    // With no vault left to continue, the modal lands on the completed view
+    // rather than parking on a generic "awaiting confirmation" step.
+    expect(getByTestId("step").textContent).toBe("COMPLETED");
+    expect(getByTestId("complete").textContent).toBe("true");
   });
 
-  it("advances to the next vault after the first vault activates", () => {
+  it("advances to the next vault once the current vault finishes activating", () => {
     mockHasArtifactsDownloaded.mockReturnValue(true);
-    mockUseDepositPollingResult.mockReturnValue(
-      resultWith({ availableActions: [PeginAction.ACTIVATE_VAULT] }),
+    const VERIFIED = 1;
+    const states = new Map<string, ReturnType<typeof resultWith>>([
+      [
+        "0xvault0",
+        resultWith({
+          availableActions: [PeginAction.ACTIVATE_VAULT],
+          contractStatus: VERIFIED,
+        }),
+      ],
+      [
+        "0xvault1",
+        resultWith({
+          availableActions: [PeginAction.ACTIVATE_VAULT],
+          contractStatus: VERIFIED,
+        }),
+      ],
+    ]);
+    mockUseDepositPollingResult.mockImplementation((id: string) =>
+      states.get(id),
     );
-    const { getByTestId } = renderView({
+
+    const props = {
       vaultIds: ["0xvault0" as Hex, "0xvault1" as Hex],
       activities: [activityWithId("0xvault0"), activityWithId("0xvault1")],
-      onClose: vi.fn(),
-    });
-    // First vault: activation success advances; the second vault then activates.
-    fireEvent.click(getByTestId("activate-success"));
-    expect(getByTestId("activate")).toBeTruthy();
+    };
+    const { getByTestId, rerender } = renderView(props);
+    expect(getByTestId("activate").getAttribute("data-vault")).toBe("0xvault0");
+
+    // First vault's activation completes — its actions drop to NONE while the
+    // optimistic CONFIRMED status is reflected by the polling layer.
+    states.set(
+      "0xvault0",
+      resultWith({
+        availableActions: [PeginAction.NONE],
+        contractStatus: VERIFIED,
+        localStatus: "confirmed",
+      }),
+    );
+    rerender(
+      <PostDepositContinuationView
+        vaultIds={props.vaultIds}
+        activities={props.activities}
+        depositorEthAddress={ETH}
+        btcPublicKey="btcpub"
+        onClose={vi.fn()}
+      />,
+    );
+
+    // The continuation must advance to the second vault, not stall on the first.
+    expect(getByTestId("activate").getAttribute("data-vault")).toBe("0xvault1");
   });
 
   it("surfaces a closeable error on a warning state with no signing popup", () => {

--- a/services/vault/src/components/simple/__tests__/PostDepositContinuationView.test.tsx
+++ b/services/vault/src/components/simple/__tests__/PostDepositContinuationView.test.tsx
@@ -341,6 +341,64 @@ describe("PostDepositContinuationView", () => {
     expect(queryByTestId("activate")).toBeNull();
   });
 
+  it("drives a later actionable vault instead of stalling on an earlier warning vault", () => {
+    const states = new Map<string, ReturnType<typeof resultWith>>([
+      [
+        "0xvault0",
+        resultWith({
+          availableActions: [PeginAction.NONE],
+          contractStatus: 7,
+          displayVariant: "warning",
+          message: "This deposit has expired.",
+        }),
+      ],
+      [
+        "0xvault1",
+        resultWith({
+          availableActions: [PeginAction.ACTIVATE_VAULT],
+          contractStatus: 1,
+        }),
+      ],
+    ]);
+    mockGetPollingResult.mockImplementation((id: string) => states.get(id));
+
+    const { getByTestId, queryByTestId } = renderView({
+      vaultIds: ["0xvault0" as Hex, "0xvault1" as Hex],
+      activities: [activityWithId("0xvault0"), activityWithId("0xvault1")],
+    });
+    expect(queryByTestId("progress-view")).toBeNull();
+    expect(getByTestId("activate").getAttribute("data-vault")).toBe("0xvault1");
+  });
+
+  it("surfaces the warning once no other vault is actionable", () => {
+    const states = new Map<string, ReturnType<typeof resultWith>>([
+      [
+        "0xvault0",
+        resultWith({
+          availableActions: [PeginAction.NONE],
+          contractStatus: 7,
+          displayVariant: "warning",
+          message: "This deposit has expired.",
+        }),
+      ],
+      [
+        "0xvault1",
+        resultWith({
+          availableActions: [PeginAction.NONE],
+          contractStatus: 1,
+          localStatus: "confirmed",
+        }),
+      ],
+    ]);
+    mockGetPollingResult.mockImplementation((id: string) => states.get(id));
+
+    const { getByTestId } = renderView({
+      vaultIds: ["0xvault0" as Hex, "0xvault1" as Hex],
+      activities: [activityWithId("0xvault0"), activityWithId("0xvault1")],
+    });
+    expect(getByTestId("error").textContent).toBe("This deposit has expired.");
+  });
+
   it("closing during the wait fires no signing popup", () => {
     mockGetPollingResult.mockReturnValue(
       resultWith({ availableActions: [PeginAction.NONE] }),

--- a/services/vault/src/components/simple/__tests__/PostDepositContinuationView.test.tsx
+++ b/services/vault/src/components/simple/__tests__/PostDepositContinuationView.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render } from "@testing-library/react";
+import type { ReactNode } from "react";
 import type { Address, Hex } from "viem";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -7,17 +8,18 @@ import type { VaultActivity } from "@/types/activity";
 
 import { PostDepositContinuationView } from "../PostDepositContinuationView";
 
-const mockUseDepositPollingResult = vi.hoisted(() => vi.fn());
+const mockGetPollingResult = vi.hoisted(() => vi.fn());
 const mockRefetch = vi.hoisted(() => vi.fn());
-const mockHasArtifactsDownloaded = vi.hoisted(() => vi.fn(() => false));
 
 vi.mock("@/context/deposit/PeginPollingContext", () => ({
-  useDepositPollingResult: mockUseDepositPollingResult,
-  usePeginPolling: () => ({ refetch: mockRefetch }),
+  usePeginPolling: () => ({
+    refetch: mockRefetch,
+    getPollingResult: mockGetPollingResult,
+  }),
 }));
 
-vi.mock("@/utils/artifactDownloadStorage", () => ({
-  hasArtifactsDownloaded: mockHasArtifactsDownloaded,
+vi.mock("../ActivationGate", () => ({
+  ActivationGate: ({ children }: { children: ReactNode }) => <>{children}</>,
 }));
 
 vi.mock("@/hooks/deposit/depositFlowSteps", () => ({
@@ -120,29 +122,6 @@ vi.mock("../ResumeDepositContent", () => ({
   ResumeActivationContent: resumeMock("activate"),
 }));
 
-vi.mock("@/components/deposit/ArtifactDownloadModal", () => ({
-  ArtifactDownloadModal: ({
-    onComplete,
-    onClose,
-  }: {
-    onComplete: () => void;
-    onClose: () => void;
-  }) => (
-    <div data-testid="artifact">
-      <button
-        type="button"
-        data-testid="artifact-complete"
-        onClick={onComplete}
-      >
-        complete
-      </button>
-      <button type="button" data-testid="artifact-close" onClick={onClose}>
-        close
-      </button>
-    </div>
-  ),
-}));
-
 function activityWithId(id: string): VaultActivity {
   return {
     id,
@@ -207,11 +186,10 @@ function renderView(
 describe("PostDepositContinuationView", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockHasArtifactsDownloaded.mockReturnValue(false);
   });
 
   it("waits while the vault has no actionable step", () => {
-    mockUseDepositPollingResult.mockReturnValue(
+    mockGetPollingResult.mockReturnValue(
       resultWith({ availableActions: [PeginAction.NONE] }),
     );
     const { getByTestId, queryByTestId } = renderView();
@@ -222,21 +200,21 @@ describe("PostDepositContinuationView", () => {
   });
 
   it("auto-mounts WOTS submission when the VP needs the WOTS key", () => {
-    mockUseDepositPollingResult.mockReturnValue(
+    mockGetPollingResult.mockReturnValue(
       resultWith({ availableActions: [PeginAction.SUBMIT_WOTS_KEY] }),
     );
     expect(renderView().getByTestId("wots")).toBeTruthy();
   });
 
   it("auto-mounts payout signing when the VP is ready for signatures", () => {
-    mockUseDepositPollingResult.mockReturnValue(
+    mockGetPollingResult.mockReturnValue(
       resultWith({ availableActions: [PeginAction.SIGN_PAYOUT_TRANSACTIONS] }),
     );
     expect(renderView().getByTestId("payout")).toBeTruthy();
   });
 
   it("waits (no payout) when the BTC public key is unavailable", () => {
-    mockUseDepositPollingResult.mockReturnValue(
+    mockGetPollingResult.mockReturnValue(
       resultWith({ availableActions: [PeginAction.SIGN_PAYOUT_TRANSACTIONS] }),
     );
     const { queryByTestId, getByTestId } = renderView({
@@ -246,33 +224,14 @@ describe("PostDepositContinuationView", () => {
     expect(getByTestId("progress-view")).toBeTruthy();
   });
 
-  it("auto-mounts activation when verified and artifacts already downloaded", () => {
-    mockHasArtifactsDownloaded.mockReturnValue(true);
-    mockUseDepositPollingResult.mockReturnValue(
+  it("routes activation through the activation gate when the vault is verified", () => {
+    mockGetPollingResult.mockReturnValue(
       resultWith({ availableActions: [PeginAction.ACTIVATE_VAULT] }),
     );
-    const { getByTestId, queryByTestId } = renderView();
-    expect(getByTestId("activate")).toBeTruthy();
-    expect(queryByTestId("artifact")).toBeNull();
-  });
-
-  it("shows the artifact download before activation, then activates on complete", () => {
-    mockHasArtifactsDownloaded.mockReturnValue(false);
-    mockUseDepositPollingResult.mockReturnValue(
-      resultWith({ availableActions: [PeginAction.ACTIVATE_VAULT] }),
-    );
-    const { getByTestId, queryByTestId } = renderView();
-    expect(getByTestId("artifact")).toBeTruthy();
-    expect(queryByTestId("activate")).toBeNull();
-
-    fireEvent.click(getByTestId("artifact-complete"));
-
-    expect(getByTestId("activate")).toBeTruthy();
-    expect(queryByTestId("artifact")).toBeNull();
+    expect(renderView().getByTestId("activate")).toBeTruthy();
   });
 
   it("shows the completed view once the last vault finishes activating", () => {
-    mockHasArtifactsDownloaded.mockReturnValue(true);
     const VERIFIED = 1;
     const states = new Map<string, ReturnType<typeof resultWith>>([
       [
@@ -283,9 +242,7 @@ describe("PostDepositContinuationView", () => {
         }),
       ],
     ]);
-    mockUseDepositPollingResult.mockImplementation((id: string) =>
-      states.get(id),
-    );
+    mockGetPollingResult.mockImplementation((id: string) => states.get(id));
 
     const { getByTestId, rerender } = renderView({
       vaultIds: ["0xvault0" as Hex],
@@ -319,7 +276,6 @@ describe("PostDepositContinuationView", () => {
   });
 
   it("advances to the next vault once the current vault finishes activating", () => {
-    mockHasArtifactsDownloaded.mockReturnValue(true);
     const VERIFIED = 1;
     const states = new Map<string, ReturnType<typeof resultWith>>([
       [
@@ -337,9 +293,7 @@ describe("PostDepositContinuationView", () => {
         }),
       ],
     ]);
-    mockUseDepositPollingResult.mockImplementation((id: string) =>
-      states.get(id),
-    );
+    mockGetPollingResult.mockImplementation((id: string) => states.get(id));
 
     const props = {
       vaultIds: ["0xvault0" as Hex, "0xvault1" as Hex],
@@ -373,7 +327,7 @@ describe("PostDepositContinuationView", () => {
   });
 
   it("surfaces a closeable error on a warning state with no signing popup", () => {
-    mockUseDepositPollingResult.mockReturnValue(
+    mockGetPollingResult.mockReturnValue(
       resultWith({
         availableActions: [PeginAction.NONE],
         displayVariant: "warning",
@@ -388,7 +342,7 @@ describe("PostDepositContinuationView", () => {
   });
 
   it("closing during the wait fires no signing popup", () => {
-    mockUseDepositPollingResult.mockReturnValue(
+    mockGetPollingResult.mockReturnValue(
       resultWith({ availableActions: [PeginAction.NONE] }),
     );
     const onClose = vi.fn();
@@ -397,7 +351,7 @@ describe("PostDepositContinuationView", () => {
   });
 
   it("shows a completed view when there are no vaults to continue", () => {
-    mockUseDepositPollingResult.mockReturnValue(undefined);
+    mockGetPollingResult.mockReturnValue(undefined);
     const { getByTestId } = renderView({ vaultIds: [], activities: [] });
     expect(getByTestId("step").textContent).toBe("COMPLETED");
     expect(getByTestId("complete").textContent).toBe("true");

--- a/services/vault/src/components/simple/__tests__/PostDepositContinuationView.test.tsx
+++ b/services/vault/src/components/simple/__tests__/PostDepositContinuationView.test.tsx
@@ -55,6 +55,23 @@ vi.mock("@/models/peginStateMachine", () => ({
     REFUND_BROADCAST: "refund_broadcast",
   },
   getPeginDisplayStep: vi.fn(() => "AWAIT_BTC_CONFIRMATION"),
+  // Mirrors the production set; ContractStatus literals match the mock above.
+  USER_ACTIONABLE_PEGIN_ACTIONS: new Set([
+    "SUBMIT_WOTS_KEY",
+    "SIGN_PAYOUT_TRANSACTIONS",
+    "ACTIVATE_VAULT",
+  ]),
+  isVaultPastActivation: (
+    state: { contractStatus: number; localStatus?: string } | undefined,
+  ) => {
+    if (!state) return false;
+    // VERIFIED + CONFIRMED is the optimistic post-activation state.
+    if (state.contractStatus === 1 && state.localStatus === "confirmed") {
+      return true;
+    }
+    // ACTIVE, REDEEMED, LIQUIDATED, DEPOSITOR_WITHDRAWN.
+    return [2, 3, 4, 6].includes(state.contractStatus);
+  },
 }));
 
 vi.mock("@/copy", () => ({
@@ -368,6 +385,100 @@ describe("PostDepositContinuationView", () => {
     });
     expect(queryByTestId("progress-view")).toBeNull();
     expect(getByTestId("activate").getAttribute("data-vault")).toBe("0xvault1");
+  });
+
+  it("drives a later actionable vault instead of stalling on an earlier waiting vault", () => {
+    const states = new Map<string, ReturnType<typeof resultWith>>([
+      [
+        "0xvault0",
+        resultWith({
+          // Waiting on the VP: no actionable step, not a warning.
+          availableActions: [PeginAction.NONE],
+          contractStatus: 0,
+          localStatus: "payout_signed",
+        }),
+      ],
+      [
+        "0xvault1",
+        resultWith({
+          availableActions: [PeginAction.SUBMIT_WOTS_KEY],
+          contractStatus: 0,
+        }),
+      ],
+    ]);
+    mockGetPollingResult.mockImplementation((id: string) => states.get(id));
+
+    const { getByTestId, queryByTestId } = renderView({
+      vaultIds: ["0xvault0" as Hex, "0xvault1" as Hex],
+      activities: [activityWithId("0xvault0"), activityWithId("0xvault1")],
+    });
+    expect(queryByTestId("progress-view")).toBeNull();
+    expect(getByTestId("wots").getAttribute("data-vault")).toBe("0xvault1");
+  });
+
+  it("skips a payout-only vault when btcPublicKey is unavailable and picks the next actionable sibling", () => {
+    const states = new Map<string, ReturnType<typeof resultWith>>([
+      [
+        "0xvault0",
+        resultWith({
+          // Payout signing is available, but the prereq btcPublicKey is missing,
+          // so this vault must not win actionableIndex.
+          availableActions: [PeginAction.SIGN_PAYOUT_TRANSACTIONS],
+          contractStatus: 0,
+        }),
+      ],
+      [
+        "0xvault1",
+        resultWith({
+          availableActions: [PeginAction.SUBMIT_WOTS_KEY],
+          contractStatus: 0,
+        }),
+      ],
+    ]);
+    mockGetPollingResult.mockImplementation((id: string) => states.get(id));
+
+    const { getByTestId, queryByTestId } = render(
+      <PostDepositContinuationView
+        vaultIds={["0xvault0" as Hex, "0xvault1" as Hex]}
+        activities={[activityWithId("0xvault0"), activityWithId("0xvault1")]}
+        depositorEthAddress={ETH}
+        btcPublicKey={undefined}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(queryByTestId("payout")).toBeNull();
+    expect(queryByTestId("progress-view")).toBeNull();
+    expect(getByTestId("wots").getAttribute("data-vault")).toBe("0xvault1");
+  });
+
+  it("falls back to a waiting vault's progress view when no sibling is actionable", () => {
+    const states = new Map<string, ReturnType<typeof resultWith>>([
+      [
+        "0xvault0",
+        resultWith({
+          availableActions: [PeginAction.NONE],
+          contractStatus: 0,
+          localStatus: "payout_signed",
+        }),
+      ],
+      [
+        "0xvault1",
+        resultWith({
+          availableActions: [PeginAction.NONE],
+          contractStatus: 0,
+        }),
+      ],
+    ]);
+    mockGetPollingResult.mockImplementation((id: string) => states.get(id));
+
+    const { getByTestId, queryByTestId } = renderView({
+      vaultIds: ["0xvault0" as Hex, "0xvault1" as Hex],
+      activities: [activityWithId("0xvault0"), activityWithId("0xvault1")],
+    });
+    expect(queryByTestId("wots")).toBeNull();
+    expect(queryByTestId("payout")).toBeNull();
+    expect(queryByTestId("activate")).toBeNull();
+    expect(getByTestId("progress-view")).not.toBeNull();
   });
 
   it("surfaces the warning once no other vault is actionable", () => {

--- a/services/vault/src/components/simple/__tests__/PostDepositContinuationView.test.tsx
+++ b/services/vault/src/components/simple/__tests__/PostDepositContinuationView.test.tsx
@@ -1,0 +1,307 @@
+import { fireEvent, render } from "@testing-library/react";
+import type { Address, Hex } from "viem";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { PeginAction } from "@/models/peginStateMachine";
+import type { VaultActivity } from "@/types/activity";
+
+import { PostDepositContinuationView } from "../PostDepositContinuationView";
+
+const mockUseDepositPollingResult = vi.hoisted(() => vi.fn());
+const mockRefetch = vi.hoisted(() => vi.fn());
+const mockHasArtifactsDownloaded = vi.hoisted(() => vi.fn(() => false));
+
+vi.mock("@/context/deposit/PeginPollingContext", () => ({
+  useDepositPollingResult: mockUseDepositPollingResult,
+  usePeginPolling: () => ({ refetch: mockRefetch }),
+}));
+
+vi.mock("@/utils/artifactDownloadStorage", () => ({
+  hasArtifactsDownloaded: mockHasArtifactsDownloaded,
+}));
+
+vi.mock("@/hooks/deposit/depositFlowSteps", () => ({
+  DepositFlowStep: {
+    AWAIT_BTC_CONFIRMATION: "AWAIT_BTC_CONFIRMATION",
+    ACTIVATE_VAULT: "ACTIVATE_VAULT",
+    COMPLETED: "COMPLETED",
+  },
+}));
+
+vi.mock("@/models/peginStateMachine", () => ({
+  PeginAction: {
+    SUBMIT_WOTS_KEY: "SUBMIT_WOTS_KEY",
+    SIGN_PAYOUT_TRANSACTIONS: "SIGN_PAYOUT_TRANSACTIONS",
+    ACTIVATE_VAULT: "ACTIVATE_VAULT",
+    NONE: "NONE",
+  },
+  getPeginDisplayStep: vi.fn(() => "AWAIT_BTC_CONFIRMATION"),
+}));
+
+vi.mock("@/copy", () => ({
+  COPY: {
+    deposit: {
+      resume: { activationSuccessMessage: "Deposit successfully submitted!" },
+    },
+    common: {
+      somethingWentWrong: { body: "Please close this and try again." },
+    },
+  },
+}));
+
+vi.mock("../DepositProgressView", () => ({
+  DepositProgressView: ({
+    currentStep,
+    error,
+    isComplete,
+    onClose,
+  }: {
+    currentStep: string;
+    error?: string | null;
+    isComplete?: boolean;
+    onClose: () => void;
+  }) => (
+    <div data-testid="progress-view">
+      <span data-testid="step">{String(currentStep)}</span>
+      <span data-testid="error">{error ?? ""}</span>
+      <span data-testid="complete">{String(!!isComplete)}</span>
+      <button type="button" data-testid="progress-close" onClick={onClose}>
+        close
+      </button>
+    </div>
+  ),
+}));
+
+function resumeMock(testId: string) {
+  return ({
+    onSuccess,
+    onClose,
+  }: {
+    onSuccess: () => void;
+    onClose: () => void;
+  }) => (
+    <div data-testid={testId}>
+      <button
+        type="button"
+        data-testid={`${testId}-success`}
+        onClick={onSuccess}
+      >
+        success
+      </button>
+      <button type="button" data-testid={`${testId}-close`} onClick={onClose}>
+        close
+      </button>
+    </div>
+  );
+}
+
+vi.mock("../ResumeDepositContent", () => ({
+  ResumeWotsContent: resumeMock("wots"),
+  ResumeSignContent: resumeMock("payout"),
+  ResumeActivationContent: resumeMock("activate"),
+}));
+
+vi.mock("@/components/deposit/ArtifactDownloadModal", () => ({
+  ArtifactDownloadModal: ({
+    onComplete,
+    onClose,
+  }: {
+    onComplete: () => void;
+    onClose: () => void;
+  }) => (
+    <div data-testid="artifact">
+      <button
+        type="button"
+        data-testid="artifact-complete"
+        onClick={onComplete}
+      >
+        complete
+      </button>
+      <button type="button" data-testid="artifact-close" onClick={onClose}>
+        close
+      </button>
+    </div>
+  ),
+}));
+
+function activityWithId(id: string): VaultActivity {
+  return {
+    id,
+    collateral: { amount: "0.01", symbol: "BTC" },
+    providers: [{ id: "0xprovider" }],
+    displayLabel: "Pending",
+    peginTxHash: "0xpegintx",
+    unsignedPrePeginTx: "0xindexertx",
+    depositorBtcPubkey: "0xdepositorpk",
+  } as unknown as VaultActivity;
+}
+
+function resultWith(opts: {
+  availableActions: string[];
+  displayVariant?: "pending" | "active" | "inactive" | "warning";
+  message?: string;
+}) {
+  return {
+    depositId: "x",
+    loading: false,
+    error: null,
+    peginState: {
+      contractStatus: 0,
+      availableActions: opts.availableActions,
+      displayVariant: opts.displayVariant ?? "pending",
+      displayLabel: "x",
+      message: opts.message,
+    },
+    isOwnedByCurrentWallet: true,
+  };
+}
+
+const ETH = "0xeth" as Address;
+
+function renderView(
+  overrides: Partial<{
+    vaultIds: Hex[];
+    activities: VaultActivity[];
+    btcPublicKey: string | undefined;
+    onClose: () => void;
+  }> = {},
+) {
+  const vaultIds = overrides.vaultIds ?? ["0xvault0" as Hex];
+  return render(
+    <PostDepositContinuationView
+      vaultIds={vaultIds}
+      activities={
+        overrides.activities ?? vaultIds.map((id) => activityWithId(id))
+      }
+      depositorEthAddress={ETH}
+      btcPublicKey={
+        "btcPublicKey" in overrides ? overrides.btcPublicKey : "btcpub"
+      }
+      onClose={overrides.onClose ?? vi.fn()}
+    />,
+  );
+}
+
+describe("PostDepositContinuationView", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockHasArtifactsDownloaded.mockReturnValue(false);
+  });
+
+  it("waits while the vault has no actionable step", () => {
+    mockUseDepositPollingResult.mockReturnValue(
+      resultWith({ availableActions: [PeginAction.NONE] }),
+    );
+    const { getByTestId, queryByTestId } = renderView();
+    expect(getByTestId("progress-view")).toBeTruthy();
+    expect(queryByTestId("wots")).toBeNull();
+    expect(queryByTestId("payout")).toBeNull();
+    expect(queryByTestId("activate")).toBeNull();
+  });
+
+  it("auto-mounts WOTS submission when the VP needs the WOTS key", () => {
+    mockUseDepositPollingResult.mockReturnValue(
+      resultWith({ availableActions: [PeginAction.SUBMIT_WOTS_KEY] }),
+    );
+    expect(renderView().getByTestId("wots")).toBeTruthy();
+  });
+
+  it("auto-mounts payout signing when the VP is ready for signatures", () => {
+    mockUseDepositPollingResult.mockReturnValue(
+      resultWith({ availableActions: [PeginAction.SIGN_PAYOUT_TRANSACTIONS] }),
+    );
+    expect(renderView().getByTestId("payout")).toBeTruthy();
+  });
+
+  it("waits (no payout) when the BTC public key is unavailable", () => {
+    mockUseDepositPollingResult.mockReturnValue(
+      resultWith({ availableActions: [PeginAction.SIGN_PAYOUT_TRANSACTIONS] }),
+    );
+    const { queryByTestId, getByTestId } = renderView({
+      btcPublicKey: undefined,
+    });
+    expect(queryByTestId("payout")).toBeNull();
+    expect(getByTestId("progress-view")).toBeTruthy();
+  });
+
+  it("auto-mounts activation when verified and artifacts already downloaded", () => {
+    mockHasArtifactsDownloaded.mockReturnValue(true);
+    mockUseDepositPollingResult.mockReturnValue(
+      resultWith({ availableActions: [PeginAction.ACTIVATE_VAULT] }),
+    );
+    const { getByTestId, queryByTestId } = renderView();
+    expect(getByTestId("activate")).toBeTruthy();
+    expect(queryByTestId("artifact")).toBeNull();
+  });
+
+  it("shows the artifact download before activation, then activates on complete", () => {
+    mockHasArtifactsDownloaded.mockReturnValue(false);
+    mockUseDepositPollingResult.mockReturnValue(
+      resultWith({ availableActions: [PeginAction.ACTIVATE_VAULT] }),
+    );
+    const { getByTestId, queryByTestId } = renderView();
+    expect(getByTestId("artifact")).toBeTruthy();
+    expect(queryByTestId("activate")).toBeNull();
+
+    fireEvent.click(getByTestId("artifact-complete"));
+
+    expect(getByTestId("activate")).toBeTruthy();
+    expect(queryByTestId("artifact")).toBeNull();
+  });
+
+  it("closes the modal after the last vault activates", () => {
+    mockHasArtifactsDownloaded.mockReturnValue(true);
+    mockUseDepositPollingResult.mockReturnValue(
+      resultWith({ availableActions: [PeginAction.ACTIVATE_VAULT] }),
+    );
+    const onClose = vi.fn();
+    fireEvent.click(renderView({ onClose }).getByTestId("activate-success"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("advances to the next vault after the first vault activates", () => {
+    mockHasArtifactsDownloaded.mockReturnValue(true);
+    mockUseDepositPollingResult.mockReturnValue(
+      resultWith({ availableActions: [PeginAction.ACTIVATE_VAULT] }),
+    );
+    const { getByTestId } = renderView({
+      vaultIds: ["0xvault0" as Hex, "0xvault1" as Hex],
+      activities: [activityWithId("0xvault0"), activityWithId("0xvault1")],
+      onClose: vi.fn(),
+    });
+    // First vault: activation success advances; the second vault then activates.
+    fireEvent.click(getByTestId("activate-success"));
+    expect(getByTestId("activate")).toBeTruthy();
+  });
+
+  it("surfaces a closeable error on a warning state with no signing popup", () => {
+    mockUseDepositPollingResult.mockReturnValue(
+      resultWith({
+        availableActions: [PeginAction.NONE],
+        displayVariant: "warning",
+        message: "This deposit has expired.",
+      }),
+    );
+    const { getByTestId, queryByTestId } = renderView();
+    expect(getByTestId("error").textContent).toBe("This deposit has expired.");
+    expect(queryByTestId("wots")).toBeNull();
+    expect(queryByTestId("payout")).toBeNull();
+    expect(queryByTestId("activate")).toBeNull();
+  });
+
+  it("closing during the wait fires no signing popup", () => {
+    mockUseDepositPollingResult.mockReturnValue(
+      resultWith({ availableActions: [PeginAction.NONE] }),
+    );
+    const onClose = vi.fn();
+    fireEvent.click(renderView({ onClose }).getByTestId("progress-close"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows a completed view when there are no vaults to continue", () => {
+    mockUseDepositPollingResult.mockReturnValue(undefined);
+    const { getByTestId } = renderView({ vaultIds: [], activities: [] });
+    expect(getByTestId("step").textContent).toBe("COMPLETED");
+    expect(getByTestId("complete").textContent).toBe("true");
+  });
+});

--- a/services/vault/src/hooks/deposit/useActivationState.ts
+++ b/services/vault/src/hooks/deposit/useActivationState.ts
@@ -6,7 +6,7 @@
  * so the component stays a thin view layer.
  */
 
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { usePeginPolling } from "@/context/deposit/PeginPollingContext";
 import { logger } from "@/infrastructure";
@@ -47,6 +47,17 @@ export function useActivationState({
   const [localActivating, setLocalActivating] = useState(false);
   const [activated, setActivated] = useState(false);
 
+  // Track mount: `handleActivation` awaits an on-chain tx, so the consumer
+  // can unmount (modal closed) before the success/catch callbacks run.
+  // Without this guard, `setLocalActivating`/`setActivated` and the
+  // `setOptimisticStatus` context update fire on an unmounted tree.
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
   const { setOptimisticStatus } = usePeginPolling();
   const { pendingPegins, updatePendingPeginStatus } = usePeginStorage({
     ethAddress: depositorEthAddress,
@@ -69,6 +80,7 @@ export function useActivationState({
             // No-op: dashboard refetches after the user clicks Done.
           },
           onShowSuccessModal: () => {
+            if (!mountedRef.current) return;
             setOptimisticStatus(activity.id, LocalStorageStatus.CONFIRMED);
             setLocalActivating(false);
             setActivated(true);
@@ -78,7 +90,7 @@ export function useActivationState({
         logger.error(err instanceof Error ? err : new Error(String(err)), {
           data: { context: "Vault activation failed" },
         });
-        setLocalActivating(false);
+        if (mountedRef.current) setLocalActivating(false);
       }
     },
     [

--- a/services/vault/src/hooks/deposit/useVaultActions.ts
+++ b/services/vault/src/hooks/deposit/useVaultActions.ts
@@ -21,7 +21,7 @@ import {
   getSharedWagmiConfig,
   useChainConnector,
 } from "@babylonlabs-io/wallet-connector";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { Hex } from "viem";
 import { getWalletClient, switchChain } from "wagmi/actions";
 
@@ -105,6 +105,17 @@ export function useVaultActions(): UseVaultActionsReturn {
   // Activation state
   const [activating, setActivating] = useState(false);
   const [activationError, setActivationError] = useState<string | null>(null);
+
+  // Track mount: both handleBroadcast and handleActivation await slow
+  // on-chain work and then setState. The consumer (Resume*Content inside
+  // the deposit modal) can unmount mid-flight; without this guard those
+  // post-await setters fire on an unmounted component.
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
 
   // Connectors
   const btcConnector = useChainConnector("BTC");
@@ -293,21 +304,23 @@ export function useVaultActions(): UseVaultActionsReturn {
       onShowSuccessModal();
       onRefetchActivities();
 
-      setBroadcasting(false);
+      if (mountedRef.current) setBroadcasting(false);
     } catch (err) {
-      let errorMessage: string;
+      if (mountedRef.current) {
+        let errorMessage: string;
 
-      if (err instanceof UtxoNotAvailableError) {
-        // UTXO not available - provide specific error message
-        errorMessage = err.message;
-      } else if (err instanceof Error) {
-        errorMessage = err.message;
-      } else {
-        errorMessage = "Failed to broadcast transaction";
+        if (err instanceof UtxoNotAvailableError) {
+          // UTXO not available - provide specific error message
+          errorMessage = err.message;
+        } else if (err instanceof Error) {
+          errorMessage = err.message;
+        } else {
+          errorMessage = "Failed to broadcast transaction";
+        }
+
+        setBroadcastError(errorMessage);
+        setBroadcasting(false);
       }
-
-      setBroadcastError(errorMessage);
-      setBroadcasting(false);
     }
   };
 
@@ -411,17 +424,19 @@ export function useVaultActions(): UseVaultActionsReturn {
       onShowSuccessModal();
       onRefetchActivities();
 
-      setActivating(false);
+      if (mountedRef.current) setActivating(false);
     } catch (err) {
-      const rawMessage =
-        err instanceof Error ? err.message : "Failed to activate BTC Vault";
-      // Normalize the on-chain "vault not found" message so we don't leak
-      // implementation detail like the raw vault id into the UI.
-      const errorMessage = rawMessage.includes("not found on-chain")
-        ? "BTC Vault not found. The BTC Vault ID may be invalid."
-        : rawMessage;
-      setActivationError(errorMessage);
-      setActivating(false);
+      if (mountedRef.current) {
+        const rawMessage =
+          err instanceof Error ? err.message : "Failed to activate BTC Vault";
+        // Normalize the on-chain "vault not found" message so we don't leak
+        // implementation detail like the raw vault id into the UI.
+        const errorMessage = rawMessage.includes("not found on-chain")
+          ? "BTC Vault not found. The BTC Vault ID may be invalid."
+          : rawMessage;
+        setActivationError(errorMessage);
+        setActivating(false);
+      }
     }
   };
 

--- a/services/vault/src/models/peginStateMachine.ts
+++ b/services/vault/src/models/peginStateMachine.ts
@@ -159,6 +159,21 @@ export function canPerformAction(
   return state.availableActions.includes(action);
 }
 
+/**
+ * PegIn actions a depositor can drive inline from the deposit flow.
+ *
+ * Excludes:
+ *  - `NONE` — sentinel for "no action."
+ *  - `SIGN_AND_BROADCAST_TO_BITCOIN` — handled by the linear deposit flow and
+ *    the dashboard resume path, never by the post-deposit continuation.
+ *  - `REFUND_HTLC` — a terminal escape hatch, not an in-flow next step.
+ */
+export const USER_ACTIONABLE_PEGIN_ACTIONS: ReadonlySet<PeginAction> = new Set([
+  PeginAction.SUBMIT_WOTS_KEY,
+  PeginAction.SIGN_PAYOUT_TRANSACTIONS,
+  PeginAction.ACTIVATE_VAULT,
+]);
+
 // ============================================================================
 // getPeginState — frontend display layer on top of SDK protocol state
 // ============================================================================
@@ -591,6 +606,30 @@ export function getNextLocalStatus(
     default:
       return null;
   }
+}
+
+/**
+ * True when the vault is at or past activation success/failure: the
+ * post-deposit continuation should no longer pick it up.
+ *
+ * `VERIFIED + CONFIRMED` is the optimistic post-activation state used while
+ * the indexer catches up; the rest are terminal contract states.
+ */
+export function isVaultPastActivation(state: PeginState | undefined): boolean {
+  if (!state) return false;
+  const { contractStatus, localStatus } = state;
+  if (
+    contractStatus === ContractStatus.VERIFIED &&
+    localStatus === LocalStorageStatus.CONFIRMED
+  ) {
+    return true;
+  }
+  return (
+    contractStatus === ContractStatus.ACTIVE ||
+    contractStatus === ContractStatus.REDEEMED ||
+    contractStatus === ContractStatus.LIQUIDATED ||
+    contractStatus === ContractStatus.DEPOSITOR_WITHDRAWN
+  );
 }
 
 export function shouldRemoveFromLocalStorage(


### PR DESCRIPTION
The in-modal deposit flow ended at artifact download and submitted WOTS keys with a bounded poll, so when Bitcoin confirmation was slow the WOTS, payout, and activation signatures were never auto-invoked while the user stayed in the modal — they had to resume each step from the dashboard.

Mount a reactive continuation inside the same modal that polls vault status and auto-invokes each remaining step (WOTS key, payout signing, artifact download, vault activation) as soon as its precondition is ready, with no premature timeout while the modal is open. Reuses the existing resume components and centralized pegin polling; the linear deposit flow hook is left unchanged.