### PR TITLE
fix(vault): combine the BTC confirmation count and estimate

### DIFF
--- a/services/vault/src/components/simple/DepositProgressView/BtcConfirmationDetail.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/BtcConfirmationDetail.tsx
@@ -24,6 +24,18 @@ function formatStartedAt(timestamp: number): string {
   });
 }
 
+/**
+ * Combined estimate text: minutes left plus the count of BTC blocks still
+ * to be mined. Once the depth is reached there is no wait left to estimate,
+ * so it reads as finalizing instead.
+ */
+function formatEstimate(confirmations: number, requiredDepth: number): string {
+  const copy = COPY.deposit.btcConfirmation;
+  const minutes = computeRemainingEstimateMinutes(confirmations, requiredDepth);
+  if (minutes === null) return copy.finalizing;
+  return copy.estRemainingValue(minutes, requiredDepth - confirmations);
+}
+
 export function BtcConfirmationDetail({
   startedAt,
   prePeginTxid,
@@ -31,12 +43,6 @@ export function BtcConfirmationDetail({
   requiredDepth,
 }: BtcConfirmationDetailProps) {
   const copy = COPY.deposit.btcConfirmation;
-
-  // undefined = still loading; null = depth reached (finalizing); number = wait.
-  const estimateMinutes =
-    confirmations === null
-      ? undefined
-      : computeRemainingEstimateMinutes(confirmations, requiredDepth);
 
   return (
     <div className="mt-3 flex flex-col gap-2 rounded-lg bg-secondary-highlight p-3">
@@ -51,31 +57,13 @@ export function BtcConfirmationDetail({
 
       <div className="flex items-center justify-between gap-2">
         <Text as="span" variant="body2" className="text-accent-secondary">
-          {copy.confirmations}:
+          {copy.estRemaining}:
         </Text>
         {confirmations === null ? (
           <Loader size={14} className="text-accent-primary" />
         ) : (
           <Text as="span" variant="body2" className="text-accent-primary">
-            {copy.confirmationProgress(
-              Math.min(confirmations, requiredDepth),
-              requiredDepth,
-            )}
-          </Text>
-        )}
-      </div>
-
-      <div className="flex items-center justify-between gap-2">
-        <Text as="span" variant="body2" className="text-accent-secondary">
-          {copy.estRemaining}:
-        </Text>
-        {estimateMinutes === undefined ? (
-          <Loader size={14} className="text-accent-primary" />
-        ) : (
-          <Text as="span" variant="body2" className="text-accent-primary">
-            {estimateMinutes === null
-              ? copy.finalizing
-              : copy.estRemainingValue(estimateMinutes)}
+            {formatEstimate(confirmations, requiredDepth)}
           </Text>
         )}
       </div>

--- a/services/vault/src/components/simple/DepositProgressView/__tests__/BtcConfirmationDetail.test.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/__tests__/BtcConfirmationDetail.test.tsx
@@ -36,7 +36,7 @@ describe("BtcConfirmationDetail", () => {
     );
   });
 
-  it("counts confirmations toward the required depth", () => {
+  it("shows the estimate with the BTC blocks left", () => {
     render(
       <BtcConfirmationDetail
         {...baseProps}
@@ -44,21 +44,10 @@ describe("BtcConfirmationDetail", () => {
         requiredDepth={6}
       />,
     );
-    expect(screen.getByText("3 of 6")).toBeInTheDocument();
+    expect(screen.getByText("~30 min (3 BTC blocks)")).toBeInTheDocument();
   });
 
-  it("estimates the remaining wait from the unconfirmed blocks", () => {
-    render(
-      <BtcConfirmationDetail
-        {...baseProps}
-        confirmations={3}
-        requiredDepth={6}
-      />,
-    );
-    expect(screen.getByText("~30 min")).toBeInTheDocument();
-  });
-
-  it("estimates the full wait before any confirmation lands", () => {
+  it("shows the full estimate before any confirmation lands", () => {
     render(
       <BtcConfirmationDetail
         {...baseProps}
@@ -66,8 +55,18 @@ describe("BtcConfirmationDetail", () => {
         requiredDepth={6}
       />,
     );
-    expect(screen.getByText("0 of 6")).toBeInTheDocument();
-    expect(screen.getByText("~60 min")).toBeInTheDocument();
+    expect(screen.getByText("~60 min (6 BTC blocks)")).toBeInTheDocument();
+  });
+
+  it("uses the singular when one BTC block is left", () => {
+    render(
+      <BtcConfirmationDetail
+        {...baseProps}
+        confirmations={5}
+        requiredDepth={6}
+      />,
+    );
+    expect(screen.getByText("~10 min (1 BTC block)")).toBeInTheDocument();
   });
 
   it("shows a finalizing state once the required depth is reached", () => {
@@ -79,10 +78,10 @@ describe("BtcConfirmationDetail", () => {
       />,
     );
     expect(screen.getByText("Finalizing...")).toBeInTheDocument();
-    expect(screen.queryByText(/min$/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/block/)).not.toBeInTheDocument();
   });
 
-  it("clamps the displayed count when confirmations overshoot the depth", () => {
+  it("shows a finalizing state when confirmations overshoot the depth", () => {
     render(
       <BtcConfirmationDetail
         {...baseProps}
@@ -90,11 +89,10 @@ describe("BtcConfirmationDetail", () => {
         requiredDepth={6}
       />,
     );
-    expect(screen.getByText("6 of 6")).toBeInTheDocument();
     expect(screen.getByText("Finalizing...")).toBeInTheDocument();
   });
 
-  it("shows no count until the first confirmation reading arrives", () => {
+  it("shows no estimate until the first confirmation reading arrives", () => {
     render(
       <BtcConfirmationDetail
         {...baseProps}
@@ -102,7 +100,7 @@ describe("BtcConfirmationDetail", () => {
         requiredDepth={6}
       />,
     );
-    expect(screen.queryByText(/ of 6/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/block/)).not.toBeInTheDocument();
     expect(screen.queryByText("Finalizing...")).not.toBeInTheDocument();
   });
 });

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -189,11 +189,11 @@ export const COPY = {
     },
     btcConfirmation: {
       startedAt: "Started at",
-      confirmations: "Confirmations",
-      confirmationProgress: (current: number, required: number) =>
-        `${current} of ${required}`,
       estRemaining: "Est. remaining",
-      estRemainingValue: (minutes: number) => `~${minutes} min`,
+      estRemainingValue: (minutes: number, blocksLeft: number) =>
+        `~${minutes} min (${blocksLeft} BTC ${
+          blocksLeft === 1 ? "block" : "blocks"
+        })`,
       finalizing: "Finalizing...",
       bitcoinTx: "Bitcoin TX",
     },


### PR DESCRIPTION
## Summary

Follow-up to #1720 — collapses the deposit "Awaiting Bitcoin confirmation" panel's two rows into one.

Before, the confirmation count and the time estimate sat on separate rows:

```
Confirmations:   3 of 6
Est. remaining:  ~30 min
```

They are two views of the same value, so this merges them into a single row:

```
Est. remaining:  ~30 min (3 BTC blocks)
```

- `~N min` — estimate derived from the remaining blocks at Bitcoin's ~10 min/block.
- `(M BTC blocks)` — blocks still to be mined to reach the required depth; "BTC" makes the unit explicit, and the singular is handled (`1 BTC block`).
- `Finalizing...` once the required depth is reached; a loader until the first reading arrives.

The required depth is the on-chain `minPrepeginDepth`, pinned to the deposit's registered params version (landed separately in #1723).

## Test plan

- `pnpm --filter vault run build` / `lint` / `test` — all green (1389 passed).
- `BtcConfirmationDetail` render-state tests updated for the combined field: estimate + block count, full estimate at zero confirmations, the singular case, finalizing, and loading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
