### PR TITLE
feat(wallet): btc wallet probe liveness

### DIFF
--- a/services/vault/src/components/deposit/PayoutSignModal/__tests__/usePayoutSigningState.test.tsx
+++ b/services/vault/src/components/deposit/PayoutSignModal/__tests__/usePayoutSigningState.test.tsx
@@ -52,6 +52,7 @@ vi.mock("../../../../utils/btc", () => ({
     hex.startsWith("0x") || hex.startsWith("0X") ? hex.slice(2) : hex,
   verifyBtcWalletLiveness: (...args: unknown[]) =>
     mockVerifyBtcWalletLiveness(...args),
+  shouldProbeWalletLiveness: () => true,
   BtcWalletLivenessError: class BtcWalletLivenessError extends Error {
     constructor(message: string) {
       super(message);

--- a/services/vault/src/components/deposit/PayoutSignModal/__tests__/usePayoutSigningState.test.tsx
+++ b/services/vault/src/components/deposit/PayoutSignModal/__tests__/usePayoutSigningState.test.tsx
@@ -44,11 +44,20 @@ vi.mock("@babylonlabs-io/wallet-connector", () => ({
 }));
 
 const mockBtcAddressToScriptPubKeyHex = vi.fn();
+const mockVerifyBtcWalletLiveness = vi.fn();
 vi.mock("../../../../utils/btc", () => ({
   btcAddressToScriptPubKeyHex: (addr: string) =>
     mockBtcAddressToScriptPubKeyHex(addr),
   stripHexPrefix: (hex: string) =>
     hex.startsWith("0x") || hex.startsWith("0X") ? hex.slice(2) : hex,
+  verifyBtcWalletLiveness: (...args: unknown[]) =>
+    mockVerifyBtcWalletLiveness(...args),
+  BtcWalletLivenessError: class BtcWalletLivenessError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = "BtcWalletLivenessError";
+    }
+  },
 }));
 
 vi.mock("../../../../utils/errors/formatting", () => ({
@@ -104,6 +113,7 @@ describe("usePayoutSigningState", () => {
     mockBtcConnector = null;
     setupHappyPath();
     mockSignAndSubmitPayouts.mockResolvedValue(undefined);
+    mockVerifyBtcWalletLiveness.mockResolvedValue(undefined);
   });
 
   describe("happy path", () => {

--- a/services/vault/src/components/deposit/PayoutSignModal/usePayoutSigningState.ts
+++ b/services/vault/src/components/deposit/PayoutSignModal/usePayoutSigningState.ts
@@ -19,7 +19,11 @@ import { signAndSubmitPayouts } from "../../../hooks/deposit/depositFlowSteps/pa
 import { useVaultProviders } from "../../../hooks/deposit/useVaultProviders";
 import { LocalStorageStatus } from "../../../models/peginStateMachine";
 import type { VaultActivity } from "../../../types/activity";
-import { btcAddressToScriptPubKeyHex } from "../../../utils/btc";
+import {
+  BtcWalletLivenessError,
+  btcAddressToScriptPubKeyHex,
+  verifyBtcWalletLiveness,
+} from "../../../utils/btc";
 import { formatPayoutSignatureError } from "../../../utils/errors/formatting";
 
 export interface SigningProgressProps {
@@ -177,6 +181,22 @@ export function usePayoutSigningState({
       // Guard explicitly instead of relying on a non-null assertion below.
       if (!activity.peginTxHash) {
         setError(COPY.deposit.payoutSigningGuards.missingPeginTransaction);
+        return;
+      }
+
+      // The wallet may have locked/disconnected since the modal opened. Probe
+      // it before signing so a locked wallet surfaces an actionable error
+      // instead of a silent no-op (modal opens, no signing popup appears).
+      try {
+        await verifyBtcWalletLiveness(btcWalletProvider, connectedBtcAddress);
+      } catch (err) {
+        setError({
+          title: COPY.wallet.liveness.errorTitle,
+          message:
+            err instanceof BtcWalletLivenessError
+              ? err.message
+              : COPY.wallet.liveness.unresponsive,
+        });
         return;
       }
 

--- a/services/vault/src/components/deposit/PayoutSignModal/usePayoutSigningState.ts
+++ b/services/vault/src/components/deposit/PayoutSignModal/usePayoutSigningState.ts
@@ -22,6 +22,7 @@ import type { VaultActivity } from "../../../types/activity";
 import {
   BtcWalletLivenessError,
   btcAddressToScriptPubKeyHex,
+  shouldProbeWalletLiveness,
   verifyBtcWalletLiveness,
 } from "../../../utils/btc";
 import { formatPayoutSignatureError } from "../../../utils/errors/formatting";
@@ -188,7 +189,11 @@ export function usePayoutSigningState({
       // it before signing so a locked wallet surfaces an actionable error
       // instead of a silent no-op (modal opens, no signing popup appears).
       try {
-        await verifyBtcWalletLiveness(btcWalletProvider, connectedBtcAddress);
+        await verifyBtcWalletLiveness(btcWalletProvider, connectedBtcAddress, {
+          probeConnection: shouldProbeWalletLiveness(
+            btcConnector?.connectedWallet?.id,
+          ),
+        });
       } catch (err) {
         setError({
           title: COPY.wallet.liveness.errorTitle,
@@ -255,6 +260,7 @@ export function usePayoutSigningState({
     findProvider,
     btcConnector?.connectedWallet?.account?.address,
     btcConnector?.connectedWallet?.provider,
+    btcConnector?.connectedWallet?.id,
     btcPublicKey,
     depositorEthAddress,
     setOptimisticStatus,

--- a/services/vault/src/components/simple/ResumeDepositContent.tsx
+++ b/services/vault/src/components/simple/ResumeDepositContent.tsx
@@ -40,7 +40,10 @@ import { useReleaseVpTokenOnUnmount } from "@/hooks/deposit/useReleaseVpTokenOnU
 import { useRunOnce } from "@/hooks/useRunOnce";
 import { logger } from "@/infrastructure";
 import type { VaultActivity } from "@/types/activity";
-import { verifyBtcWalletLiveness } from "@/utils/btc";
+import {
+  shouldProbeWalletLiveness,
+  verifyBtcWalletLiveness,
+} from "@/utils/btc";
 import { getVpProxyUrl } from "@/utils/rpc";
 
 import { DepositProgressView } from "./DepositProgressView";
@@ -131,7 +134,17 @@ export function ResumeBroadcastContent({
     onSuccess,
   });
 
-  useRunOnce(handleBroadcast);
+  const btcConnector = useChainConnector("BTC");
+  const btcWalletProvider = btcConnector?.connectedWallet?.provider;
+  const connectedBtcAddress = btcConnector?.connectedWallet?.account?.address;
+
+  // Defer the auto-run until the wallet has hydrated — see the note in
+  // ResumeWotsContent. Still fire when no provider is present so the genuine
+  // "not connected" error surfaces (handleBroadcast throws it).
+  useRunOnce(
+    handleBroadcast,
+    !btcWalletProvider || Boolean(connectedBtcAddress),
+  );
 
   const derived = computeDepositDerivedState(
     DepositFlowStep.BROADCAST_PRE_PEGIN,
@@ -254,7 +267,11 @@ export function ResumeWotsContent({
       // Probe the wallet before deriveVaultRoot fires the signing popup. A
       // wallet that locked since the modal opened fails fast here with an
       // actionable error instead of a silent no-op (no popup appears).
-      await verifyBtcWalletLiveness(btcWalletProvider, connectedBtcAddress);
+      await verifyBtcWalletLiveness(btcWalletProvider, connectedBtcAddress, {
+        probeConnection: shouldProbeWalletLiveness(
+          btcConnector?.connectedWallet?.id,
+        ),
+      });
 
       root = await deriveVaultRoot(btcWalletProvider, {
         depositorBtcPubkey: hexToUint8Array(depositorBtcPubkey),
@@ -331,11 +348,18 @@ export function ResumeWotsContent({
     activity,
     btcWalletProvider,
     connectedBtcAddress,
+    btcConnector?.connectedWallet?.id,
     trackPrimedTxid,
     onSuccess,
   ]);
 
-  useRunOnce(handleSubmit);
+  // Defer the auto-run until the wallet has hydrated. `connectedWallet.provider`
+  // is set synchronously on connect, but `account.address` lands a tick later
+  // (e.g. during fire-and-forget auto-reconnect). Without this gate, opening the
+  // modal mid-hydration would hit the "not connected" guard and—because
+  // useRunOnce never re-fires—stay stuck. Still fire when there is no provider
+  // at all so the genuine "not connected" error surfaces.
+  useRunOnce(handleSubmit, !btcWalletProvider || Boolean(connectedBtcAddress));
 
   const isSuccess = !loading && !error;
   const renderIsWaiting = isSuccess;
@@ -448,7 +472,11 @@ export function ResumeActivationContent({
       // Probe the wallet before deriveVaultRoot fires the signing popup. A
       // wallet that locked since the modal opened fails fast here with an
       // actionable error instead of a silent no-op (no popup appears).
-      await verifyBtcWalletLiveness(btcWalletProvider, connectedBtcAddress);
+      await verifyBtcWalletLiveness(btcWalletProvider, connectedBtcAddress, {
+        probeConnection: shouldProbeWalletLiveness(
+          btcConnector?.connectedWallet?.id,
+        ),
+      });
 
       root = await deriveVaultRoot(btcWalletProvider, {
         depositorBtcPubkey: hexToUint8Array(depositorBtcPubkey),
@@ -480,9 +508,18 @@ export function ResumeActivationContent({
       secretBytes?.fill(0);
       setLoading(false);
     }
-  }, [activity, btcWalletProvider, connectedBtcAddress, handleActivation]);
+  }, [
+    activity,
+    btcWalletProvider,
+    connectedBtcAddress,
+    btcConnector?.connectedWallet?.id,
+    handleActivation,
+  ]);
 
-  useRunOnce(handleSubmit);
+  // Defer the auto-run until the wallet has hydrated — see the note in
+  // ResumeWotsContent. Still fire when no provider is present so the genuine
+  // "not connected" error surfaces.
+  useRunOnce(handleSubmit, !btcWalletProvider || Boolean(connectedBtcAddress));
 
   const error = localError ?? activationError;
   const derived = computeDepositDerivedState(

--- a/services/vault/src/components/simple/ResumeDepositContent.tsx
+++ b/services/vault/src/components/simple/ResumeDepositContent.tsx
@@ -40,6 +40,7 @@ import { useReleaseVpTokenOnUnmount } from "@/hooks/deposit/useReleaseVpTokenOnU
 import { useRunOnce } from "@/hooks/useRunOnce";
 import { logger } from "@/infrastructure";
 import type { VaultActivity } from "@/types/activity";
+import { verifyBtcWalletLiveness } from "@/utils/btc";
 import { getVpProxyUrl } from "@/utils/rpc";
 
 import { DepositProgressView } from "./DepositProgressView";
@@ -175,6 +176,7 @@ export function ResumeWotsContent({
   const btcWalletProvider =
     (btcConnector?.connectedWallet?.provider as BitcoinWallet | undefined) ??
     null;
+  const connectedBtcAddress = btcConnector?.connectedWallet?.account?.address;
 
   // Starts true: useRunOnce auto-fires handleSubmit on mount, so the
   // first render must show processing — not a false-success banner from
@@ -188,7 +190,7 @@ export function ResumeWotsContent({
   const trackPrimedTxid = useReleaseVpTokenOnUnmount();
 
   const handleSubmit = useCallback(async () => {
-    if (!btcWalletProvider) {
+    if (!btcWalletProvider || !connectedBtcAddress) {
       setError("BTC wallet is not connected");
       setLoading(false);
       return;
@@ -248,6 +250,11 @@ export function ResumeWotsContent({
       const fundingOutpoints = parseFundingOutpointsFromTx(
         activity.unsignedPrePeginTx,
       );
+
+      // Probe the wallet before deriveVaultRoot fires the signing popup. A
+      // wallet that locked since the modal opened fails fast here with an
+      // actionable error instead of a silent no-op (no popup appears).
+      await verifyBtcWalletLiveness(btcWalletProvider, connectedBtcAddress);
 
       root = await deriveVaultRoot(btcWalletProvider, {
         depositorBtcPubkey: hexToUint8Array(depositorBtcPubkey),
@@ -320,7 +327,13 @@ export function ResumeWotsContent({
     } finally {
       root?.fill(0);
     }
-  }, [activity, btcWalletProvider, trackPrimedTxid, onSuccess]);
+  }, [
+    activity,
+    btcWalletProvider,
+    connectedBtcAddress,
+    trackPrimedTxid,
+    onSuccess,
+  ]);
 
   useRunOnce(handleSubmit);
 
@@ -370,6 +383,7 @@ export function ResumeActivationContent({
   const btcWalletProvider =
     (btcConnector?.connectedWallet?.provider as BitcoinWallet | undefined) ??
     null;
+  const connectedBtcAddress = btcConnector?.connectedWallet?.account?.address;
 
   // Starts true: useRunOnce auto-fires handleSubmit on mount, so the
   // first render must show processing.
@@ -387,7 +401,7 @@ export function ResumeActivationContent({
   });
 
   const handleSubmit = useCallback(async () => {
-    if (!btcWalletProvider) {
+    if (!btcWalletProvider || !connectedBtcAddress) {
       setLocalError("BTC wallet is not connected");
       setLoading(false);
       return;
@@ -431,6 +445,11 @@ export function ResumeActivationContent({
         activity.unsignedPrePeginTx,
       );
 
+      // Probe the wallet before deriveVaultRoot fires the signing popup. A
+      // wallet that locked since the modal opened fails fast here with an
+      // actionable error instead of a silent no-op (no popup appears).
+      await verifyBtcWalletLiveness(btcWalletProvider, connectedBtcAddress);
+
       root = await deriveVaultRoot(btcWalletProvider, {
         depositorBtcPubkey: hexToUint8Array(depositorBtcPubkey),
         fundingOutpoints,
@@ -461,7 +480,7 @@ export function ResumeActivationContent({
       secretBytes?.fill(0);
       setLoading(false);
     }
-  }, [activity, btcWalletProvider, handleActivation]);
+  }, [activity, btcWalletProvider, connectedBtcAddress, handleActivation]);
 
   useRunOnce(handleSubmit);
 

--- a/services/vault/src/components/simple/ResumeDepositContent.tsx
+++ b/services/vault/src/components/simple/ResumeDepositContent.tsx
@@ -138,8 +138,8 @@ export function ResumeBroadcastContent({
   const btcWalletProvider = btcConnector?.connectedWallet?.provider;
   const connectedBtcAddress = btcConnector?.connectedWallet?.account?.address;
 
-  // Defer the auto-run until the wallet has hydrated — see the note in
-  // ResumeWotsContent. Still fire when no provider is present so the genuine
+  // Defensive auto-run gate (effectively always-enabled today) — see the note
+  // in ResumeWotsContent. Fires when no provider is present so the genuine
   // "not connected" error surfaces (handleBroadcast throws it).
   useRunOnce(
     handleBroadcast,
@@ -353,12 +353,14 @@ export function ResumeWotsContent({
     onSuccess,
   ]);
 
-  // Defer the auto-run until the wallet has hydrated. `connectedWallet.provider`
-  // is set synchronously on connect, but `account.address` lands a tick later
-  // (e.g. during fire-and-forget auto-reconnect). Without this gate, opening the
-  // modal mid-hydration would hit the "not connected" guard and—because
-  // useRunOnce never re-fires—stay stuck. Still fire when there is no provider
-  // at all so the genuine "not connected" error surfaces.
+  // Defensive auto-run gate. Today this is effectively always-enabled: the
+  // connector exposes `connectedWallet` only after connect() completes, so
+  // `provider` and `account.address` are set together — there is no
+  // "provider present, address still hydrating" window. The gate is
+  // belt-and-suspenders for a future connector that surfaces a still-connecting
+  // wallet before its account hydrates: in that case useRunOnce (one-shot)
+  // would defer rather than fire into the "not connected" guard. When there is
+  // genuinely no provider it fires, so the real "not connected" error surfaces.
   useRunOnce(handleSubmit, !btcWalletProvider || Boolean(connectedBtcAddress));
 
   const isSuccess = !loading && !error;
@@ -516,8 +518,8 @@ export function ResumeActivationContent({
     handleActivation,
   ]);
 
-  // Defer the auto-run until the wallet has hydrated — see the note in
-  // ResumeWotsContent. Still fire when no provider is present so the genuine
+  // Defensive auto-run gate (effectively always-enabled today) — see the note
+  // in ResumeWotsContent. Fires when no provider is present so the genuine
   // "not connected" error surfaces.
   useRunOnce(handleSubmit, !btcWalletProvider || Boolean(connectedBtcAddress));
 

--- a/services/vault/src/components/simple/SimpleDeposit.tsx
+++ b/services/vault/src/components/simple/SimpleDeposit.tsx
@@ -1,4 +1,5 @@
 import { FullScreenDialog, Heading } from "@babylonlabs-io/core-ui";
+import { useChainConnector } from "@babylonlabs-io/wallet-connector";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { Address, Hex } from "viem";
 
@@ -14,7 +15,10 @@ import { useProtocolFeeRows } from "@/hooks/useProtocolFeeRows";
 import { depositService } from "@/services/deposit";
 import type { VaultActivity } from "@/types/activity";
 import type { VaultProvider } from "@/types/vaultProvider";
-import { verifyBtcWalletLiveness } from "@/utils/btc";
+import {
+  shouldProbeWalletLiveness,
+  verifyBtcWalletLiveness,
+} from "@/utils/btc";
 
 import { DepositState, DepositStep } from "../../context/deposit/DepositState";
 import { useDepositPageFlow } from "../../hooks/deposit/useDepositPageFlow";
@@ -102,6 +106,7 @@ function SimpleDepositContent({
   const { address: connectedEthAddress } = useETHWallet();
   const { address: connectedBtcAddress, reconnect: reconnectBtcWallet } =
     useBTCWallet();
+  const btcConnector = useChainConnector("BTC");
   const { rows: feeRows, collateralFactor } =
     useProtocolFeeRows(connectedEthAddress);
   const [walletConnectionError, setWalletConnectionError] = useState<
@@ -282,7 +287,11 @@ function SimpleDepositContent({
     if (btcWalletProvider && connectedBtcAddress) {
       setIsVerifyingWallet(true);
       try {
-        await verifyBtcWalletLiveness(btcWalletProvider, connectedBtcAddress);
+        await verifyBtcWalletLiveness(btcWalletProvider, connectedBtcAddress, {
+          probeConnection: shouldProbeWalletLiveness(
+            btcConnector?.connectedWallet?.id,
+          ),
+        });
       } catch (err) {
         setWalletConnectionError(
           err instanceof Error

--- a/services/vault/src/components/simple/__tests__/ResumeDepositContent.test.tsx
+++ b/services/vault/src/components/simple/__tests__/ResumeDepositContent.test.tsx
@@ -49,7 +49,14 @@ vi.mock("@babylonlabs-io/ts-sdk/tbv/core/utils", () => ({
 
 vi.mock("@babylonlabs-io/wallet-connector", () => ({
   useChainConnector: vi.fn(() => ({
-    connectedWallet: { provider: { id: "btc-wallet" } },
+    connectedWallet: {
+      account: { address: "tb1test" },
+      provider: {
+        id: "btc-wallet",
+        connectWallet: vi.fn().mockResolvedValue(undefined),
+        getAddress: vi.fn().mockResolvedValue("tb1test"),
+      },
+    },
   })),
 }));
 

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -313,6 +313,15 @@ export const COPY = {
   wallet: {
     geoBlockedTooltip: "Not available in your region",
     walletNotEligibleTooltip: "Wallet not eligible",
+    liveness: {
+      errorTitle: "Wallet Not Responding",
+      unresponsive:
+        "Your BTC wallet is not responding. Please open your wallet extension to confirm it is unlocked and connected, then try again.",
+      emptyAddress:
+        "Your BTC wallet did not return an address. Please reconnect your wallet and try again.",
+      addressMismatch:
+        "Your BTC wallet account has changed. Please reconnect your wallet and try again.",
+    },
   },
   collateral: {
     releaseDisabledTooltip:

--- a/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
+++ b/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
@@ -55,7 +55,9 @@ vi.mock("@babylonlabs-io/wallet-connector", () => ({
   getSharedWagmiConfig: vi.fn(() => ({})),
   useChainConnector: vi.fn(() => ({
     connectedWallet: {
+      account: { address: "bc1qdepositor" },
       provider: {
+        connectWallet: vi.fn().mockResolvedValue(undefined),
         getAddress: vi.fn().mockResolvedValue("bc1qdepositor"),
         signPsbt: mockSignPsbt,
       },

--- a/services/vault/src/hooks/deposit/useDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useDepositFlow.ts
@@ -45,6 +45,7 @@ import {
   collectReservedUtxoRefs,
   selectUtxosForDeposit,
 } from "@babylonlabs-io/ts-sdk/tbv/core/utils";
+import { useChainConnector } from "@babylonlabs-io/wallet-connector";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { v4 as uuidv4 } from "uuid";
 import type { Address, Hex } from "viem";
@@ -82,6 +83,7 @@ import {
 import type { Vault } from "@/types/vault";
 import {
   btcAddressToScriptPubKeyHex,
+  shouldProbeWalletLiveness,
   verifyBtcWalletLiveness,
 } from "@/utils/btc";
 import { satoshiToBtcNumber } from "@/utils/btcConversion";
@@ -221,6 +223,8 @@ export function useDepositFlow(
     universalChallengerBtcPubkeys,
   } = params;
 
+  const btcConnector = useChainConnector("BTC");
+
   // State
   const [currentStep, setCurrentStep] = useState<DepositFlowStep>(
     DepositFlowStep.DERIVE_VAULT_SECRET,
@@ -343,8 +347,17 @@ export function useDepositFlow(
         // step through any other path or if the wallet went dead between
         // click and modal mount. Probing here surfaces a clear, actionable
         // error before any irreversible state is written.
+        //
+        // The round-trip probe is gated to injected extensions (Unisat/OKX/
+        // OneKey) via shouldProbeWalletLiveness; AppKit/hardware wallets fall
+        // back to the cached-address check to avoid reopening their modal /
+        // re-engaging the device.
         if (btcWalletProvider && btcAddress) {
-          await verifyBtcWalletLiveness(btcWalletProvider, btcAddress);
+          await verifyBtcWalletLiveness(btcWalletProvider, btcAddress, {
+            probeConnection: shouldProbeWalletLiveness(
+              btcConnector?.connectedWallet?.id,
+            ),
+          });
         }
 
         validateMultiVaultDepositInputs({
@@ -1089,6 +1102,7 @@ export function useDepositFlow(
       vaultAmounts,
       mempoolFeeRate,
       btcWalletProvider,
+      btcConnector?.connectedWallet?.id,
       depositorEthAddress,
       selectedApplication,
       selectedProviders,

--- a/services/vault/src/hooks/deposit/useRefundState.ts
+++ b/services/vault/src/hooks/deposit/useRefundState.ts
@@ -9,6 +9,7 @@ import { LocalStorageStatus } from "@/models/peginStateMachine";
 import { buildAndBroadcastRefundTransaction } from "@/services/vault/vaultRefundService";
 import { usePeginStorage } from "@/storage/usePeginStorage";
 import type { VaultActivity } from "@/types/activity";
+import { verifyBtcWalletLiveness } from "@/utils/btc";
 
 export interface UseRefundStateProps {
   activity: VaultActivity;
@@ -28,6 +29,7 @@ export function useRefundState({
 }: UseRefundStateProps): UseRefundStateResult {
   const btcConnector = useChainConnector("BTC");
   const btcWalletProvider = btcConnector?.connectedWallet?.provider;
+  const connectedBtcAddress = btcConnector?.connectedWallet?.account?.address;
   const { address: ethAddress } = useETHWallet();
   const { setOptimisticStatus } = usePeginPolling();
   const { pendingPegins, addPendingPegin, markRefundBroadcast } =
@@ -78,7 +80,7 @@ export function useRefundState({
       inFlightRef.current = true;
 
       try {
-        if (!btcWalletProvider) {
+        if (!btcWalletProvider || !connectedBtcAddress) {
           setError("BTC wallet not connected");
           return;
         }
@@ -106,6 +108,12 @@ export function useRefundState({
         abortRef.current = new AbortController();
 
         try {
+          // The wallet may have locked since the refund modal opened;
+          // `getPublicKeyHex()` below is cached and would not reveal it. Probe
+          // with a round-trip first so a locked wallet fails fast with an
+          // actionable error instead of a silent no-op at signing time.
+          await verifyBtcWalletLiveness(btcWalletProvider, connectedBtcAddress);
+
           // Fetch the pubkey live from the wallet (not from storage). The
           // wallet's signPsbt signInputs[].publicKey requires the wallet's
           // native format (typically compressed 33-byte sec1), and the
@@ -173,6 +181,7 @@ export function useRefundState({
       refunding,
       vaultId,
       btcWalletProvider,
+      connectedBtcAddress,
       ethAddress,
       peginTxHash,
       unsignedPrePeginTx,

--- a/services/vault/src/hooks/deposit/useRefundState.ts
+++ b/services/vault/src/hooks/deposit/useRefundState.ts
@@ -9,7 +9,10 @@ import { LocalStorageStatus } from "@/models/peginStateMachine";
 import { buildAndBroadcastRefundTransaction } from "@/services/vault/vaultRefundService";
 import { usePeginStorage } from "@/storage/usePeginStorage";
 import type { VaultActivity } from "@/types/activity";
-import { verifyBtcWalletLiveness } from "@/utils/btc";
+import {
+  shouldProbeWalletLiveness,
+  verifyBtcWalletLiveness,
+} from "@/utils/btc";
 
 export interface UseRefundStateProps {
   activity: VaultActivity;
@@ -112,7 +115,15 @@ export function useRefundState({
           // `getPublicKeyHex()` below is cached and would not reveal it. Probe
           // with a round-trip first so a locked wallet fails fast with an
           // actionable error instead of a silent no-op at signing time.
-          await verifyBtcWalletLiveness(btcWalletProvider, connectedBtcAddress);
+          await verifyBtcWalletLiveness(
+            btcWalletProvider,
+            connectedBtcAddress,
+            {
+              probeConnection: shouldProbeWalletLiveness(
+                btcConnector?.connectedWallet?.id,
+              ),
+            },
+          );
 
           // Fetch the pubkey live from the wallet (not from storage). The
           // wallet's signPsbt signInputs[].publicKey requires the wallet's
@@ -182,6 +193,7 @@ export function useRefundState({
       vaultId,
       btcWalletProvider,
       connectedBtcAddress,
+      btcConnector?.connectedWallet?.id,
       ethAddress,
       peginTxHash,
       unsignedPrePeginTx,

--- a/services/vault/src/hooks/deposit/useVaultActions.ts
+++ b/services/vault/src/hooks/deposit/useVaultActions.ts
@@ -44,7 +44,10 @@ import {
 import { activateVaultWithSecret } from "../../services/vault/vaultActivationService";
 import { utxosToExpectedRecord } from "../../services/vault/vaultPeginBroadcastService";
 import type { PendingPeginRequest } from "../../storage/peginStorage";
-import { verifyBtcWalletLiveness } from "../../utils/btc";
+import {
+  shouldProbeWalletLiveness,
+  verifyBtcWalletLiveness,
+} from "../../utils/btc";
 
 export interface BroadcastPrePeginParams {
   vaultId: Hex;
@@ -196,7 +199,11 @@ export function useVaultActions(): UseVaultActionsReturn {
       // round-trip before any signing (a cached `getAddress()` would not reveal
       // a lock) so a locked/changed wallet fails fast with an actionable error
       // instead of a silent no-op (no signing popup appears).
-      await verifyBtcWalletLiveness(btcWalletProvider, connectedBtcAddress);
+      await verifyBtcWalletLiveness(btcWalletProvider, connectedBtcAddress, {
+        probeConnection: shouldProbeWalletLiveness(
+          btcConnector?.connectedWallet?.id,
+        ),
+      });
 
       // Get depositor's BTC public key (needed for Taproot signing)
       // Strip "0x" prefix since it comes from GraphQL (Ethereum-style hex)

--- a/services/vault/src/hooks/deposit/useVaultActions.ts
+++ b/services/vault/src/hooks/deposit/useVaultActions.ts
@@ -44,6 +44,7 @@ import {
 import { activateVaultWithSecret } from "../../services/vault/vaultActivationService";
 import { utxosToExpectedRecord } from "../../services/vault/vaultPeginBroadcastService";
 import type { PendingPeginRequest } from "../../storage/peginStorage";
+import { verifyBtcWalletLiveness } from "../../utils/btc";
 
 export interface BroadcastPrePeginParams {
   vaultId: Hex;
@@ -183,11 +184,19 @@ export function useVaultActions(): UseVaultActionsReturn {
 
       // Get BTC wallet provider
       const btcWalletProvider = btcConnector?.connectedWallet?.provider;
-      if (!btcWalletProvider) {
+      const connectedBtcAddress =
+        btcConnector?.connectedWallet?.account?.address;
+      if (!btcWalletProvider || !connectedBtcAddress) {
         throw new Error(
           "BTC wallet not connected. Please reconnect your wallet.",
         );
       }
+
+      // The wallet may have locked since the action started. Probe it with a
+      // round-trip before any signing (a cached `getAddress()` would not reveal
+      // a lock) so a locked/changed wallet fails fast with an actionable error
+      // instead of a silent no-op (no signing popup appears).
+      await verifyBtcWalletLiveness(btcWalletProvider, connectedBtcAddress);
 
       // Get depositor's BTC public key (needed for Taproot signing)
       // Strip "0x" prefix since it comes from GraphQL (Ethereum-style hex)

--- a/services/vault/src/hooks/useRunOnce.ts
+++ b/services/vault/src/hooks/useRunOnce.ts
@@ -3,14 +3,23 @@ import { useEffect, useRef } from "react";
 import { logger } from "@/infrastructure";
 
 /**
- * Execute a callback exactly once on mount.
+ * Execute a callback exactly once, the first time `enabled` is true.
+ *
  * Prevents re-execution on dependency changes or React strict mode double-mounts.
  * Supports both sync and async callbacks.
+ *
+ * `enabled` lets callers defer the run until a precondition holds (e.g. the
+ * wallet has finished hydrating). It still runs at most once: once it fires, it
+ * never fires again even if `enabled` toggles. Defaults to `true` so existing
+ * "run on mount" callers are unaffected.
  */
-export function useRunOnce(callback: () => void | Promise<void>) {
+export function useRunOnce(
+  callback: () => void | Promise<void>,
+  enabled: boolean = true,
+) {
   const started = useRef(false);
   useEffect(() => {
-    if (started.current) return;
+    if (started.current || !enabled) return;
     started.current = true;
     const result = callback();
     if (result instanceof Promise) {
@@ -20,5 +29,5 @@ export function useRunOnce(callback: () => void | Promise<void>) {
         }),
       );
     }
-  }, [callback]);
+  }, [callback, enabled]);
 }

--- a/services/vault/src/utils/btc/__tests__/verifyBtcWalletLiveness.test.ts
+++ b/services/vault/src/utils/btc/__tests__/verifyBtcWalletLiveness.test.ts
@@ -1,4 +1,3 @@
-import type { BitcoinWallet } from "@babylonlabs-io/ts-sdk/shared";
 import { describe, expect, it, vi } from "vitest";
 
 import {
@@ -8,30 +7,56 @@ import {
 
 const EXPECTED_ADDRESS = "tb1qexampledepositoraddressxxxxxxxxxxxxxxxxx";
 
-function makeWallet(getAddress: () => Promise<string>): BitcoinWallet {
+function makeWallet(opts: {
+  getAddress: () => Promise<string>;
+  connectWallet?: () => Promise<void>;
+}) {
   return {
-    getAddress,
-    getPublicKeyHex: vi.fn(),
-    signPsbt: vi.fn(),
-    signPsbts: vi.fn(),
-    signMessage: vi.fn(),
-    getNetwork: vi.fn(),
-    deriveContextHash: vi.fn(),
-  } as unknown as BitcoinWallet;
+    getAddress: opts.getAddress,
+    connectWallet: opts.connectWallet,
+  };
 }
 
 describe("verifyBtcWalletLiveness", () => {
-  it("resolves when the wallet returns the expected address", async () => {
-    const wallet = makeWallet(async () => EXPECTED_ADDRESS);
+  it("resolves when connectWallet succeeds and the wallet returns the expected address", async () => {
+    const connectWallet = vi.fn(async () => {});
+    const wallet = makeWallet({
+      connectWallet,
+      getAddress: async () => EXPECTED_ADDRESS,
+    });
 
     await expect(
       verifyBtcWalletLiveness(wallet, EXPECTED_ADDRESS),
     ).resolves.toBeUndefined();
+    // The round-trip probe must run before trusting the (possibly cached) address.
+    expect(connectWallet).toHaveBeenCalledOnce();
   });
 
-  it("throws BtcWalletLivenessError when getAddress rejects (locked or unresponsive wallet)", async () => {
-    const wallet = makeWallet(async () => {
-      throw new Error("Wallet extension is locked");
+  it("throws BtcWalletLivenessError when connectWallet rejects (locked or unresponsive wallet)", async () => {
+    const getAddress = vi.fn(async () => EXPECTED_ADDRESS);
+    const wallet = makeWallet({
+      connectWallet: async () => {
+        throw new Error("Connection to Unisat Wallet was rejected");
+      },
+      getAddress,
+    });
+
+    await expect(
+      verifyBtcWalletLiveness(wallet, EXPECTED_ADDRESS),
+    ).rejects.toMatchObject({
+      name: "BtcWalletLivenessError",
+      message: expect.stringContaining("not responding"),
+    });
+    // A locked wallet must fail the probe before the cached address is read.
+    expect(getAddress).not.toHaveBeenCalled();
+  });
+
+  it("throws BtcWalletLivenessError when getAddress rejects after a successful probe", async () => {
+    const wallet = makeWallet({
+      connectWallet: async () => {},
+      getAddress: async () => {
+        throw new Error("Wallet extension is locked");
+      },
     });
 
     await expect(
@@ -43,7 +68,10 @@ describe("verifyBtcWalletLiveness", () => {
   });
 
   it("throws BtcWalletLivenessError when getAddress resolves with an empty string", async () => {
-    const wallet = makeWallet(async () => "");
+    const wallet = makeWallet({
+      connectWallet: async () => {},
+      getAddress: async () => "",
+    });
 
     await expect(
       verifyBtcWalletLiveness(wallet, EXPECTED_ADDRESS),
@@ -54,9 +82,10 @@ describe("verifyBtcWalletLiveness", () => {
   });
 
   it("throws BtcWalletLivenessError when the wallet's address differs from the expected one (account changed)", async () => {
-    const wallet = makeWallet(
-      async () => "tb1qdifferentaccountaddressxxxxxxxxxxxxxxxxxx",
-    );
+    const wallet = makeWallet({
+      connectWallet: async () => {},
+      getAddress: async () => "tb1qdifferentaccountaddressxxxxxxxxxxxxxxxxxx",
+    });
 
     await expect(
       verifyBtcWalletLiveness(wallet, EXPECTED_ADDRESS),
@@ -66,8 +95,19 @@ describe("verifyBtcWalletLiveness", () => {
     });
   });
 
+  it("skips the probe when the wallet has no connectWallet method", async () => {
+    const wallet = makeWallet({ getAddress: async () => EXPECTED_ADDRESS });
+
+    await expect(
+      verifyBtcWalletLiveness(wallet, EXPECTED_ADDRESS),
+    ).resolves.toBeUndefined();
+  });
+
   it("exposes BtcWalletLivenessError as an Error subclass", async () => {
-    const wallet = makeWallet(async () => "");
+    const wallet = makeWallet({
+      connectWallet: async () => {},
+      getAddress: async () => "",
+    });
 
     await expect(
       verifyBtcWalletLiveness(wallet, EXPECTED_ADDRESS),

--- a/services/vault/src/utils/btc/__tests__/verifyBtcWalletLiveness.test.ts
+++ b/services/vault/src/utils/btc/__tests__/verifyBtcWalletLiveness.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   BtcWalletLivenessError,
+  shouldProbeWalletLiveness,
   verifyBtcWalletLiveness,
 } from "../verifyBtcWalletLiveness";
 
@@ -17,8 +18,23 @@ function makeWallet(opts: {
   };
 }
 
+describe("shouldProbeWalletLiveness", () => {
+  it("allows the round-trip probe for injected extensions", () => {
+    expect(shouldProbeWalletLiveness("unisat")).toBe(true);
+    expect(shouldProbeWalletLiveness("okx")).toBe(true);
+    expect(shouldProbeWalletLiveness("onekey")).toBe(true);
+  });
+
+  it("blocks the probe for AppKit, hardware, and unknown/undefined wallets", () => {
+    expect(shouldProbeWalletLiveness("appkit-btc-connector")).toBe(false);
+    expect(shouldProbeWalletLiveness("ledger")).toBe(false);
+    expect(shouldProbeWalletLiveness("keystone")).toBe(false);
+    expect(shouldProbeWalletLiveness(undefined)).toBe(false);
+  });
+});
+
 describe("verifyBtcWalletLiveness", () => {
-  it("resolves when connectWallet succeeds and the wallet returns the expected address", async () => {
+  it("does not round-trip via connectWallet unless probeConnection is set", async () => {
     const connectWallet = vi.fn(async () => {});
     const wallet = makeWallet({
       connectWallet,
@@ -28,11 +44,25 @@ describe("verifyBtcWalletLiveness", () => {
     await expect(
       verifyBtcWalletLiveness(wallet, EXPECTED_ADDRESS),
     ).resolves.toBeUndefined();
-    // The round-trip probe must run before trusting the (possibly cached) address.
+    expect(connectWallet).not.toHaveBeenCalled();
+  });
+
+  it("round-trips via connectWallet when probeConnection is set", async () => {
+    const connectWallet = vi.fn(async () => {});
+    const wallet = makeWallet({
+      connectWallet,
+      getAddress: async () => EXPECTED_ADDRESS,
+    });
+
+    await expect(
+      verifyBtcWalletLiveness(wallet, EXPECTED_ADDRESS, {
+        probeConnection: true,
+      }),
+    ).resolves.toBeUndefined();
     expect(connectWallet).toHaveBeenCalledOnce();
   });
 
-  it("throws BtcWalletLivenessError when connectWallet rejects (locked or unresponsive wallet)", async () => {
+  it("throws BtcWalletLivenessError when the probe's connectWallet rejects (locked wallet)", async () => {
     const getAddress = vi.fn(async () => EXPECTED_ADDRESS);
     const wallet = makeWallet({
       connectWallet: async () => {
@@ -42,7 +72,9 @@ describe("verifyBtcWalletLiveness", () => {
     });
 
     await expect(
-      verifyBtcWalletLiveness(wallet, EXPECTED_ADDRESS),
+      verifyBtcWalletLiveness(wallet, EXPECTED_ADDRESS, {
+        probeConnection: true,
+      }),
     ).rejects.toMatchObject({
       name: "BtcWalletLivenessError",
       message: expect.stringContaining("not responding"),
@@ -51,9 +83,8 @@ describe("verifyBtcWalletLiveness", () => {
     expect(getAddress).not.toHaveBeenCalled();
   });
 
-  it("throws BtcWalletLivenessError when getAddress rejects after a successful probe", async () => {
+  it("throws BtcWalletLivenessError when getAddress rejects", async () => {
     const wallet = makeWallet({
-      connectWallet: async () => {},
       getAddress: async () => {
         throw new Error("Wallet extension is locked");
       },
@@ -68,10 +99,7 @@ describe("verifyBtcWalletLiveness", () => {
   });
 
   it("throws BtcWalletLivenessError when getAddress resolves with an empty string", async () => {
-    const wallet = makeWallet({
-      connectWallet: async () => {},
-      getAddress: async () => "",
-    });
+    const wallet = makeWallet({ getAddress: async () => "" });
 
     await expect(
       verifyBtcWalletLiveness(wallet, EXPECTED_ADDRESS),
@@ -83,7 +111,6 @@ describe("verifyBtcWalletLiveness", () => {
 
   it("throws BtcWalletLivenessError when the wallet's address differs from the expected one (account changed)", async () => {
     const wallet = makeWallet({
-      connectWallet: async () => {},
       getAddress: async () => "tb1qdifferentaccountaddressxxxxxxxxxxxxxxxxxx",
     });
 
@@ -95,19 +122,18 @@ describe("verifyBtcWalletLiveness", () => {
     });
   });
 
-  it("skips the probe when the wallet has no connectWallet method", async () => {
+  it("skips the probe when probeConnection is set but the wallet has no connectWallet method", async () => {
     const wallet = makeWallet({ getAddress: async () => EXPECTED_ADDRESS });
 
     await expect(
-      verifyBtcWalletLiveness(wallet, EXPECTED_ADDRESS),
+      verifyBtcWalletLiveness(wallet, EXPECTED_ADDRESS, {
+        probeConnection: true,
+      }),
     ).resolves.toBeUndefined();
   });
 
   it("exposes BtcWalletLivenessError as an Error subclass", async () => {
-    const wallet = makeWallet({
-      connectWallet: async () => {},
-      getAddress: async () => "",
-    });
+    const wallet = makeWallet({ getAddress: async () => "" });
 
     await expect(
       verifyBtcWalletLiveness(wallet, EXPECTED_ADDRESS),

--- a/services/vault/src/utils/btc/__tests__/verifyBtcWalletLiveness.test.ts
+++ b/services/vault/src/utils/btc/__tests__/verifyBtcWalletLiveness.test.ts
@@ -27,7 +27,8 @@ describe("shouldProbeWalletLiveness", () => {
 
   it("blocks the probe for AppKit, hardware, and unknown/undefined wallets", () => {
     expect(shouldProbeWalletLiveness("appkit-btc-connector")).toBe(false);
-    expect(shouldProbeWalletLiveness("ledger")).toBe(false);
+    expect(shouldProbeWalletLiveness("ledger_btc")).toBe(false);
+    expect(shouldProbeWalletLiveness("ledger_btc_v2")).toBe(false);
     expect(shouldProbeWalletLiveness("keystone")).toBe(false);
     expect(shouldProbeWalletLiveness(undefined)).toBe(false);
   });

--- a/services/vault/src/utils/btc/index.ts
+++ b/services/vault/src/utils/btc/index.ts
@@ -8,4 +8,8 @@ export {
   btcAddressToScriptPubKeyHex,
   scriptPubKeyHexToBtcAddress,
 } from "./btcUtils";
-export { verifyBtcWalletLiveness } from "./verifyBtcWalletLiveness";
+export {
+  BtcWalletLivenessError,
+  shouldProbeWalletLiveness,
+  verifyBtcWalletLiveness,
+} from "./verifyBtcWalletLiveness";

--- a/services/vault/src/utils/btc/verifyBtcWalletLiveness.ts
+++ b/services/vault/src/utils/btc/verifyBtcWalletLiveness.ts
@@ -1,5 +1,7 @@
 import type { BitcoinWallet } from "@babylonlabs-io/ts-sdk/shared";
 
+import { COPY } from "@/copy";
+
 export class BtcWalletLivenessError extends Error {
   constructor(message: string) {
     super(message);
@@ -7,31 +9,67 @@ export class BtcWalletLivenessError extends Error {
   }
 }
 
-const UNRESPONSIVE_MESSAGE =
-  "Your BTC wallet is not responding. Please open your wallet extension to confirm it is unlocked and connected, then try again.";
+/**
+ * Minimal wallet shape needed to probe BTC wallet liveness.
+ *
+ * `getAddress()` on most providers (e.g. Unisat) returns a *cached* address and
+ * does not round-trip to the extension, so it cannot detect a locked wallet on
+ * its own. `connectWallet()` (→ `requestAccounts`) is the reliable probe: it is
+ * idempotent/silent when the wallet is already unlocked on the right chain, and
+ * rejects or times out when the wallet is locked or unresponsive.
+ *
+ * `connectWallet` is optional because the ts-sdk `BitcoinWallet` abstraction
+ * does not declare it; the wallet-connector providers passed in at runtime
+ * always implement it, so the probe runs in practice.
+ */
+type ProbableBtcWallet = Pick<BitcoinWallet, "getAddress"> & {
+  connectWallet?: () => Promise<void>;
+};
 
-const EMPTY_ADDRESS_MESSAGE =
-  "Your BTC wallet did not return an address. Please reconnect your wallet and try again.";
-
-const ADDRESS_MISMATCH_MESSAGE =
-  "Your BTC wallet account has changed. Please reconnect your wallet and try again.";
+/**
+ * Verify the connected BTC wallet is responsive and still holds the expected
+ * account, before asking it to sign or derive.
+ *
+ * Note on latency: the `connectWallet()` probe round-trips to the extension via
+ * `requestAccounts`, which uses the provider's own prompt timeout (e.g. Unisat's
+ * 60s). A locked wallet that hangs (rather than rejecting) can therefore block
+ * for up to that timeout before this throws — still strictly better than the
+ * silent no-op it replaces, where signing appeared to start but no popup ever
+ * showed.
+ *
+ * Note on the optional `connectWallet`: the `typeof === "function"` guard below
+ * is a deliberate structural fallback for the ts-sdk `BitcoinWallet` type, which
+ * does not declare `connectWallet`. It is NOT a live degrade path — every
+ * wallet-connector BTC provider implements `connectWallet` (it is declared on
+ * `IProvider`), so the round-trip always runs at runtime.
+ */
 
 export async function verifyBtcWalletLiveness(
-  wallet: BitcoinWallet,
+  wallet: ProbableBtcWallet,
   expectedAddress: string,
 ): Promise<void> {
+  // Round-trip to the extension first. A locked or unresponsive wallet rejects
+  // or times out here; a cached `getAddress()` alone would falsely pass.
+  if (typeof wallet.connectWallet === "function") {
+    try {
+      await wallet.connectWallet();
+    } catch {
+      throw new BtcWalletLivenessError(COPY.wallet.liveness.unresponsive);
+    }
+  }
+
   let observedAddress: string;
   try {
     observedAddress = await wallet.getAddress();
   } catch {
-    throw new BtcWalletLivenessError(UNRESPONSIVE_MESSAGE);
+    throw new BtcWalletLivenessError(COPY.wallet.liveness.unresponsive);
   }
 
   if (!observedAddress) {
-    throw new BtcWalletLivenessError(EMPTY_ADDRESS_MESSAGE);
+    throw new BtcWalletLivenessError(COPY.wallet.liveness.emptyAddress);
   }
 
   if (observedAddress !== expectedAddress) {
-    throw new BtcWalletLivenessError(ADDRESS_MISMATCH_MESSAGE);
+    throw new BtcWalletLivenessError(COPY.wallet.liveness.addressMismatch);
   }
 }

--- a/services/vault/src/utils/btc/verifyBtcWalletLiveness.ts
+++ b/services/vault/src/utils/btc/verifyBtcWalletLiveness.ts
@@ -10,47 +10,76 @@ export class BtcWalletLivenessError extends Error {
 }
 
 /**
+ * Wallet ids whose `connectWallet()` is a silent, idempotent re-request
+ * (`requestAccounts` / `connect`) — safe to call as a liveness probe on an
+ * already-connected wallet.
+ *
+ * Deliberately excludes:
+ * - AppKit (`appkit-btc-connector`): its `connectWallet()` opens the AppKit
+ *   modal and waits up to 60s for a fresh `connected` event, so probing it
+ *   would reopen the modal / hang for an already-connected user.
+ * - Hardware wallets (Ledger, Keystone): their `connectWallet()` re-engages the
+ *   device (Ledger app calls, Keystone QR scan), i.e. it is interactive.
+ *
+ * For those, the round-trip probe is skipped and we fall back to a cached
+ * `getAddress()` check; real lock-detection for them needs a dedicated
+ * non-interactive liveness primitive in wallet-connector (tracked separately).
+ *
+ * Source of truth for the ids: the per-wallet `index.ts` files under
+ * `packages/babylon-wallet-connector/src/core/wallets/btc`.
+ */
+const CONNECT_PROBE_WALLET_IDS = new Set(["unisat", "okx", "onekey"]);
+
+/**
+ * Whether `connectWallet()` can be used as a silent liveness probe for the
+ * given connected-wallet id. Pass `btcConnector?.connectedWallet?.id`.
+ */
+export function shouldProbeWalletLiveness(
+  walletId: string | undefined,
+): boolean {
+  return walletId !== undefined && CONNECT_PROBE_WALLET_IDS.has(walletId);
+}
+
+/**
  * Minimal wallet shape needed to probe BTC wallet liveness.
  *
  * `getAddress()` on most providers (e.g. Unisat) returns a *cached* address and
  * does not round-trip to the extension, so it cannot detect a locked wallet on
- * its own. `connectWallet()` (→ `requestAccounts`) is the reliable probe: it is
- * idempotent/silent when the wallet is already unlocked on the right chain, and
- * rejects or times out when the wallet is locked or unresponsive.
+ * its own. `connectWallet()` (→ `requestAccounts`) is the reliable probe for
+ * injected extensions, but it is unsafe for AppKit/hardware (see
+ * {@link shouldProbeWalletLiveness}), so callers opt in via `probeConnection`.
  *
  * `connectWallet` is optional because the ts-sdk `BitcoinWallet` abstraction
  * does not declare it; the wallet-connector providers passed in at runtime
- * always implement it, so the probe runs in practice.
+ * implement it.
  */
 type ProbableBtcWallet = Pick<BitcoinWallet, "getAddress"> & {
   connectWallet?: () => Promise<void>;
 };
 
-/**
- * Verify the connected BTC wallet is responsive and still holds the expected
- * account, before asking it to sign or derive.
- *
- * Note on latency: the `connectWallet()` probe round-trips to the extension via
- * `requestAccounts`, which uses the provider's own prompt timeout (e.g. Unisat's
- * 60s). A locked wallet that hangs (rather than rejecting) can therefore block
- * for up to that timeout before this throws — still strictly better than the
- * silent no-op it replaces, where signing appeared to start but no popup ever
- * showed.
- *
- * Note on the optional `connectWallet`: the `typeof === "function"` guard below
- * is a deliberate structural fallback for the ts-sdk `BitcoinWallet` type, which
- * does not declare `connectWallet`. It is NOT a live degrade path — every
- * wallet-connector BTC provider implements `connectWallet` (it is declared on
- * `IProvider`), so the round-trip always runs at runtime.
- */
+export interface VerifyBtcWalletLivenessOptions {
+  /**
+   * Round-trip to the extension via `connectWallet()` before reading the
+   * address. Only safe for wallets where that call is silent and idempotent —
+   * gate it with {@link shouldProbeWalletLiveness}. Defaults to `false`.
+   *
+   * Latency note: when enabled, a locked wallet that *hangs* (rather than
+   * rejecting) can block up to the provider's prompt timeout (e.g. Unisat's
+   * 60s) before this throws — still better than a silent "Signing…" with no
+   * popup.
+   */
+  probeConnection?: boolean;
+}
 
 export async function verifyBtcWalletLiveness(
   wallet: ProbableBtcWallet,
   expectedAddress: string,
+  options: VerifyBtcWalletLivenessOptions = {},
 ): Promise<void> {
-  // Round-trip to the extension first. A locked or unresponsive wallet rejects
-  // or times out here; a cached `getAddress()` alone would falsely pass.
-  if (typeof wallet.connectWallet === "function") {
+  // Round-trip to the extension first (only for probe-safe wallets). A locked
+  // or unresponsive wallet rejects or times out here; a cached `getAddress()`
+  // alone would falsely pass.
+  if (options.probeConnection && typeof wallet.connectWallet === "function") {
     try {
       await wallet.connectWallet();
     } catch {


### PR DESCRIPTION
# fix(wallet): probe BTC wallet liveness before signing

## What this fixes

When the BTC wallet (e.g. Unisat) is **locked**, the app still thinks it is connected. The user can click actions like **Sign payout transactions**, the modal opens, the button shows "Signing…" — but **no wallet popup ever appears**, and nothing tells the user what went wrong.

This PR makes the app check the wallet **before** it tries to sign. If the wallet is locked or unresponsive, the user immediately sees a clear, actionable message: *"Your BTC wallet is not responding. Please open your wallet extension to confirm it is unlocked and connected, then try again."*

It is a follow-up to the earlier Unisat connection work in [#1722](https://github.com/babylonlabs-io/babylon-toolkit/pull/1722). That PR hardened the connection layer (timeouts, reconnection) but did **not** add a pre-sign "is the wallet actually responsive?" check.

## Why the old behavior happened

Two separate problems:

1. **The resume actions never checked the wallet.** The first-time deposit flow already called a `verifyBtcWalletLiveness` helper, but the "resume" actions (sign payouts, broadcast, refund, submit WOTS, activate) skipped it entirely.
2. **The check itself could not detect a locked wallet.** `verifyBtcWalletLiveness` only called `getAddress()`, which for Unisat returns a **cached** value — it does not talk to the extension. A locked wallet still returned its old address, so the check passed. This blind spot affected the first-time deposit flow too.

## What changed

1. **Made the liveness check actually round-trip.** `verifyBtcWalletLiveness` now calls `connectWallet()` (which really talks to the extension) before reading the address. A locked/unresponsive wallet rejects or times out here with a clear error, instead of the cached `getAddress()` falsely passing.
2. **Gated that round-trip to wallets where it is safe.** `connectWallet()` is a silent, idempotent call only for injected extensions (**Unisat / OKX / OneKey**). For **AppKit** it would reopen the wallet modal, and for **hardware wallets (Ledger / Keystone)** it would re-engage the device. So the round-trip is opt-in via a small allowlist (`shouldProbeWalletLiveness`); non-allowlisted wallets fall back to the existing cached-address check and are never disrupted.
3. **Applied the gated check before every BTC-wallet signing/derivation path:** the **fresh deposit flow** (click-time check in `SimpleDeposit` + defense-in-depth in `useDepositFlow`) and every **resume action** — sign payouts, broadcast Pre-PegIn, refund, submit WOTS key, and activation secret derivation. (The on-chain `activateVault` step is ETH-only and out of scope.)
4. **Moved the user-facing messages into `copy.ts`**, per the convention that all user-visible text lives there.
5. **Hardened the resume modals' auto-run** with a small `enabled` gate on `useRunOnce`, so an auto-firing resume action waits for the wallet rather than racing it (defensive — see trade-offs).

## Approaches considered

**Why `connectWallet()` and not `getAddress()`?** `getAddress()` is cached and cannot reveal a locked wallet. `connectWallet()` round-trips to the extension, so it is the only reliable lock probe. When the wallet is already unlocked on the right chain, it is silent and adds no extra popup, so normal users see no difference.

**Why gate it to an allowlist instead of probing every wallet?** Because `connectWallet()` is not silent for all providers — AppKit opens its modal and hardware wallets re-engage the device. Probing those would interrupt an already-connected user. The allowlist limits the round-trip to the injected extensions where it is genuinely a no-op when healthy. (AppKit/hardware lock-detection then happens at the actual signing call, which already fails fast post-#1722.)

**Why check before signing instead of disabling the button?** Lowest-risk, and it matches what the fresh deposit flow already did. Disabling the button would require a new live "is the wallet healthy?" signal wired through the UI for the same end result.

**Why one shared helper?** All call sites reuse `verifyBtcWalletLiveness` / `shouldProbeWalletLiveness`, so behavior and wording stay identical and there is a single place to maintain.

## Known trade-offs (documented in code)

- **AppKit / hardware wallets are not pre-probed** — they keep the cached-address check, so a locked one is caught at the signing call rather than up-front. This is deliberate (avoids reopening their modal / re-engaging the device); a dedicated non-interactive liveness primitive for them is a possible follow-up.
- **~60s worst case on a hanging lock** — if a locked wallet *hangs* rather than rejecting, the probe can block up to the provider's prompt timeout (Unisat's ~60s) before erroring. Still far better than the old silent "Signing…", and the app can't shorten the wallet's internal timeout.
- **The `connectWallet` member is optional in the shared type** — the ts-sdk `BitcoinWallet` interface doesn't declare it; the wallet-connector providers passed at runtime do (it's on `IProvider`). Documented in a code comment.

## Note on the branch

Rebased onto the latest `main` to resolve a conflict with [#1711](https://github.com/babylonlabs-io/babylon-toolkit/pull/1711) (dead-code cleanup), which had removed the `BtcWalletLivenessError` barrel export this PR re-introduces and uses.

## Testing

- Unit tests for `verifyBtcWalletLiveness` and `shouldProbeWalletLiveness`: probe rejects → actionable error before the cached read; probe skipped for non-allowlisted wallets; account-change still detected.
- Full vault test suite, lint, and `tsc` all pass.
- Manual (the reported repro): connect Unisat + MetaMask, **lock Unisat** (without switching tabs), trigger a signing action → the "wallet is not responding" message appears up-front instead of a silent spinner. Unlock and retry → normal signing popup. Verified for the fresh deposit and the resume actions.

## Note for reviewers

The payout-signing path is on the project's critical-path list. This PR only **adds a pre-flight guard** — it does not change which transactions are signed or any signed values.
