### PR TITLE
fix(vault): correct payout-signing step on resumable deposit card

### DIFF
--- a/services/vault/src/components/simple/__tests__/PendingDepositCard.test.tsx
+++ b/services/vault/src/components/simple/__tests__/PendingDepositCard.test.tsx
@@ -160,3 +160,45 @@ describe("PendingDepositCard — step gating during first load", () => {
     expect(screen.queryByText(/^Step \d+ of \d+$/)).not.toBeInTheDocument();
   });
 });
+
+describe("PendingDepositCard — payout signing step number", () => {
+  const readyToSignPayoutsState = () => ({
+    contractStatus: ContractStatus.PENDING,
+    availableActions: [PeginAction.SIGN_PAYOUT_TRANSACTIONS],
+    localStatus: undefined,
+    displayVariant: "pending",
+    displayLabel: "Signing required",
+    message: COPY.pegin.messages.payoutsReadyForSigning,
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsArtifactDownloadAvailable.mockReturnValue(false);
+    mockGetActionStatus.mockReturnValue({
+      type: "available",
+      action: {
+        action: PeginAction.SIGN_PAYOUT_TRANSACTIONS,
+        label: COPY.pegin.primaryAction.SIGN_PAYOUT_TRANSACTIONS,
+      },
+    });
+  });
+
+  it("shows step 9 (authenticate session) while it is still waiting to sign", () => {
+    // The deposit is resting before it acts. Clicking "Sign Payouts" runs the
+    // auth-anchor step (9) first, so the card sits on step 9 with that step's
+    // label — not step 10, which would imply the auth-anchor step is done. The
+    // action button still reads "Sign Payouts".
+    mockUseDepositPollingResult.mockReturnValue({
+      loading: false,
+      peginState: readyToSignPayoutsState(),
+    });
+    renderCard(false);
+    expect(screen.getByText("Step 9 of 16")).toBeInTheDocument();
+    expect(
+      screen.getByText(COPY.deposit.steps.authenticateSession),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /sign payouts/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/services/vault/src/models/__tests__/peginStateMachine.test.ts
+++ b/services/vault/src/models/__tests__/peginStateMachine.test.ts
@@ -568,7 +568,11 @@ describe("peginStateMachine", () => {
       expect(getPeginDisplayStep(state)).toBe(DepositFlowStep.SUBMIT_WOTS_KEYS);
     });
 
-    it("maps a pending payout-signing action to SIGN_PAYOUTS", () => {
+    it("maps a pending payout-signing action to SIGN_AUTH_ANCHOR (the next step)", () => {
+      // A deposit waiting to sign payouts is resting before it acts: clicking
+      // "Sign Payouts" runs the auth-anchor step first, so the deposit is
+      // positioned on SIGN_AUTH_ANCHOR, not SIGN_PAYOUTS (which would count the
+      // auth-anchor step as already done).
       const state = getPeginState(ContractStatus.PENDING, {
         localStatus: LocalStorageStatus.CONFIRMING,
         pendingIngestion: false,
@@ -577,7 +581,7 @@ describe("peginStateMachine", () => {
       expect(state.availableActions).toContain(
         PeginAction.SIGN_PAYOUT_TRANSACTIONS,
       );
-      expect(getPeginDisplayStep(state)).toBe(DepositFlowStep.SIGN_PAYOUTS);
+      expect(getPeginDisplayStep(state)).toBe(DepositFlowStep.SIGN_AUTH_ANCHOR);
     });
 
     it("maps provider-processing-with-no-action to AWAIT_PAYOUT_TRANSACTIONS", () => {

--- a/services/vault/src/models/peginStateMachine.ts
+++ b/services/vault/src/models/peginStateMachine.ts
@@ -549,7 +549,12 @@ export function getPeginDisplayStep(state: PeginState): DepositFlowStep | null {
       return DepositFlowStep.SUBMIT_WOTS_KEYS;
     }
     if (availableActions.includes(PeginAction.SIGN_PAYOUT_TRANSACTIONS)) {
-      return DepositFlowStep.SIGN_PAYOUTS;
+      // The deposit is resting *before* it signs. When the user clicks "Sign
+      // Payouts" the flow first runs the auth-anchor step (deriveContextHash),
+      // then the payout signing — so the next step the deposit is positioned on
+      // is SIGN_AUTH_ANCHOR, not SIGN_PAYOUTS. Reporting SIGN_PAYOUTS here would
+      // count the auth-anchor step as already done and show one step too far.
+      return DepositFlowStep.SIGN_AUTH_ANCHOR;
     }
     // No action pending. Once payouts are signed the deposit is waiting for VP
     // verification/ACK submission. If the VP has ingested the deposit but


### PR DESCRIPTION
A deposit waiting to sign payouts is resting before it acts, but getPeginDisplayStep returned SIGN_PAYOUTS — implying the auth-anchor step (which runs first when the user clicks "Sign Payouts") was already done, so the card read one step too far ("Step 10 of 16").

Return the actual next step, SIGN_AUTH_ANCHOR, for that resting state, consistent with how the function already reports the next step for the broadcast and WOTS states. The card now reads "Step 9 of 16 — Authenticate session with vault provider"; the action button is unchanged.

## Screenshot

<img width="2044" height="788" alt="image" src="https://github.com/user-attachments/assets/cce9e0c7-80bd-40bf-8b20-0d6cb4ee96e7" />
