### PR TITLE
fix(vault): send Authorization header for the artifact-download RPC

### DIFF
--- a/services/vault/src/applications/aave/services/fetchPositions.ts
+++ b/services/vault/src/applications/aave/services/fetchPositions.ts
@@ -57,6 +57,12 @@ export interface AavePositionCollateral {
     depositorBtcPubKey: string;
     /** On-chain registered payout scriptPubKey (0x-prefixed hex). Where BTC is sent on withdraw. */
     depositorPayoutBtcAddress: string;
+    /**
+     * Unsigned pre-pegin BTC transaction hex (from PegInSubmitted event).
+     * Needed to re-derive the VP auth anchor when the in-memory token
+     * registry is cold (e.g. collateral artifact re-download).
+     */
+    unsignedPrePeginTx?: string;
   };
 }
 
@@ -93,6 +99,7 @@ interface GraphQLCollateralItem {
     inUse: boolean;
     depositorBtcPubKey: string;
     depositorPayoutBtcAddress: string;
+    unsignedPrePeginTx?: string;
   };
 }
 
@@ -136,6 +143,7 @@ const GET_AAVE_ACTIVE_POSITIONS_WITH_COLLATERALS = gql`
               inUse
               depositorBtcPubKey
               depositorPayoutBtcAddress
+              unsignedPrePeginTx
             }
           }
         }
@@ -182,6 +190,7 @@ function mapGraphQLCollateralToAavePositionCollateral(
           inUse: item.vault.inUse,
           depositorBtcPubKey: item.vault.depositorBtcPubKey,
           depositorPayoutBtcAddress: item.vault.depositorPayoutBtcAddress,
+          unsignedPrePeginTx: item.vault.unsignedPrePeginTx,
         }
       : undefined,
   };

--- a/services/vault/src/components/simple/CollateralSection.tsx
+++ b/services/vault/src/components/simple/CollateralSection.tsx
@@ -70,7 +70,11 @@ export function CollateralSection({
 }: CollateralSectionProps) {
   const [isExpanded, setIsExpanded] = useState(false);
   const [artifactParams, setArtifactParams] = useState<
-    (ArtifactDownloadModalParams & { vaultId: Hex }) | null
+    | (ArtifactDownloadModalParams & {
+        vaultId: Hex;
+        unsignedPrePeginTx?: string;
+      })
+    | null
   >(null);
   const [isReorderOpen, setIsReorderOpen] = useState(false);
   const [isReorderSuccess, setIsReorderSuccess] = useState(false);
@@ -186,6 +190,7 @@ export function CollateralSection({
         peginTxid: vault.peginTxHash,
         depositorPk: vault.depositorBtcPubkey,
         vaultId: vault.vaultId,
+        unsignedPrePeginTx: vault.unsignedPrePeginTx,
       });
     },
     [collateralVaults, findProvider],
@@ -303,6 +308,7 @@ export function CollateralSection({
           peginTxid={artifactParams.peginTxid}
           depositorPk={artifactParams.depositorPk}
           vaultId={artifactParams.vaultId}
+          unsignedPrePeginTxHex={artifactParams.unsignedPrePeginTx}
         />
       )}
 

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -255,6 +255,8 @@ export const COPY = {
       downloadButton: "Download Artifacts",
       cancelButton: "Cancel",
       continueButton: "Continue",
+      cannotAuthenticate:
+        "Cannot authenticate with the vault provider. Please refresh and try again.",
     },
     form: {
       computingAllocation: "Computing allocation...",

--- a/services/vault/src/hooks/deposit/__tests__/useArtifactDownload.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useArtifactDownload.test.tsx
@@ -44,7 +44,19 @@ const primeContext = {
   btcWallet: fakeWallet,
 };
 
-describe("useArtifactDownload — optimistic-then-prime-and-retry", () => {
+/** Seed the singleton registry so `peek()` returns a provider (hot cache). */
+function seedHotCache(): void {
+  createAuthenticatedVpClient({
+    baseUrl: "https://vp.test/rpc",
+    peginTxid: PEGIN_TXID,
+    authAnchorHex: "c".repeat(64),
+    pinnedServerPubkey: "ab".repeat(32) as unknown as Parameters<
+      typeof createAuthenticatedVpClient
+    >[0]["pinnedServerPubkey"],
+  });
+}
+
+describe("useArtifactDownload — prime then fetch", () => {
   beforeEach(() => {
     fetchMock.mockReset();
     ensureAuthMock.mockReset();
@@ -55,7 +67,12 @@ describe("useArtifactDownload — optimistic-then-prime-and-retry", () => {
     vi.restoreAllMocks();
   });
 
-  it("succeeds on the first attempt and never calls ensureAuthenticatedVpClient", async () => {
+  it("primes the bearer upfront when the registry is cold, then fetches once", async () => {
+    ensureAuthMock.mockResolvedValueOnce(
+      undefined as unknown as Awaited<
+        ReturnType<typeof ensureAuthenticatedVpClient>
+      >,
+    );
     fetchMock.mockResolvedValueOnce(undefined);
 
     const { result } = renderHook(() => useArtifactDownload({ primeContext }));
@@ -65,33 +82,6 @@ describe("useArtifactDownload — optimistic-then-prime-and-retry", () => {
     });
 
     await waitFor(() => expect(result.current.downloaded).toBe(true));
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(ensureAuthMock).not.toHaveBeenCalled();
-    expect(result.current.error).toBeNull();
-  });
-
-  it("primes the registry and retries once when the cache is cold at first attempt", async () => {
-    // First attempt rejects with a wire-source bearer rejection — the server's
-    // response when we send the request without an Authorization header.
-    fetchMock
-      .mockRejectedValueOnce(
-        new JsonRpcError(-32001, "missing or malformed Bearer token", "wire"),
-      )
-      .mockResolvedValueOnce(undefined);
-    ensureAuthMock.mockResolvedValueOnce(
-      undefined as unknown as Awaited<
-        ReturnType<typeof ensureAuthenticatedVpClient>
-      >,
-    );
-
-    const { result } = renderHook(() => useArtifactDownload({ primeContext }));
-
-    await act(async () => {
-      await result.current.download(PROVIDER_ADDRESS, PEGIN_TXID, DEPOSITOR_PK);
-    });
-
-    await waitFor(() => expect(result.current.downloaded).toBe(true));
-    expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(ensureAuthMock).toHaveBeenCalledTimes(1);
     expect(ensureAuthMock).toHaveBeenCalledWith({
       btcWallet: fakeWallet,
@@ -101,14 +91,26 @@ describe("useArtifactDownload — optimistic-then-prime-and-retry", () => {
       providerAddress: PROVIDER_ADDRESS,
       depositorBtcPubkey: DEPOSITOR_PK,
     });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(result.current.error).toBeNull();
   });
 
-  it("surfaces the original error when no prime context is provided", async () => {
-    fetchMock.mockRejectedValueOnce(
-      new JsonRpcError(-32001, "missing or malformed Bearer token", "wire"),
-    );
+  it("skips the upfront prime when the registry is already hot", async () => {
+    seedHotCache();
+    fetchMock.mockResolvedValueOnce(undefined);
 
+    const { result } = renderHook(() => useArtifactDownload({ primeContext }));
+
+    await act(async () => {
+      await result.current.download(PROVIDER_ADDRESS, PEGIN_TXID, DEPOSITOR_PK);
+    });
+
+    await waitFor(() => expect(result.current.downloaded).toBe(true));
+    expect(ensureAuthMock).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces an error and never fetches when cold and no prime context is provided", async () => {
     const { result } = renderHook(() =>
       useArtifactDownload({ primeContext: null }),
     );
@@ -117,46 +119,14 @@ describe("useArtifactDownload — optimistic-then-prime-and-retry", () => {
       await result.current.download(PROVIDER_ADDRESS, PEGIN_TXID, DEPOSITOR_PK);
     });
 
-    await waitFor(() =>
-      expect(result.current.error).toBe("missing or malformed Bearer token"),
-    );
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect(fetchMock).not.toHaveBeenCalled();
     expect(ensureAuthMock).not.toHaveBeenCalled();
     expect(result.current.downloaded).toBe(false);
+    expect(result.current.loading).toBe(false);
   });
 
-  it("retries at most once - propagates failure when the second attempt also fails", async () => {
-    fetchMock
-      .mockRejectedValueOnce(
-        new JsonRpcError(-32001, "missing or malformed Bearer token", "wire"),
-      )
-      .mockRejectedValueOnce(
-        new JsonRpcError(-32001, "missing or malformed Bearer token", "wire"),
-      );
-    ensureAuthMock.mockResolvedValueOnce(
-      undefined as unknown as Awaited<
-        ReturnType<typeof ensureAuthenticatedVpClient>
-      >,
-    );
-
-    const { result } = renderHook(() => useArtifactDownload({ primeContext }));
-
-    await act(async () => {
-      await result.current.download(PROVIDER_ADDRESS, PEGIN_TXID, DEPOSITOR_PK);
-    });
-
-    await waitFor(() =>
-      expect(result.current.error).toBe("missing or malformed Bearer token"),
-    );
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(ensureAuthMock).toHaveBeenCalledTimes(1);
-    expect(result.current.downloaded).toBe(false);
-  });
-
-  it("surfaces a prime failure as the modal error", async () => {
-    fetchMock.mockRejectedValueOnce(
-      new JsonRpcError(-32001, "missing or malformed Bearer token", "wire"),
-    );
+  it("surfaces a clean error when the upfront prime throws", async () => {
     ensureAuthMock.mockRejectedValueOnce(
       new Error("Pre-PegIn transaction hash mismatch"),
     );
@@ -170,24 +140,50 @@ describe("useArtifactDownload — optimistic-then-prime-and-retry", () => {
     await waitFor(() =>
       expect(result.current.error).toBe("Pre-PegIn transaction hash mismatch"),
     );
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).not.toHaveBeenCalled();
     expect(ensureAuthMock).toHaveBeenCalledTimes(1);
+    expect(result.current.loading).toBe(false);
     expect(result.current.downloaded).toBe(false);
   });
 
-  it("invalidates the cached token provider when the registry has a hot-but-stale entry", async () => {
-    // Pre-seed the singleton registry against the same peginTxid the hook
-    // will use (post-stripHexPrefix). This exercises the hot-but-stale
-    // branch of tryPrimeAndRetry: peek must return a provider whose
-    // invalidate() gets called before we re-acquire a fresh bearer.
-    createAuthenticatedVpClient({
-      baseUrl: "https://vp.test/rpc",
-      peginTxid: PEGIN_TXID,
-      authAnchorHex: "c".repeat(64),
-      pinnedServerPubkey: "ab".repeat(32) as unknown as Parameters<
-        typeof createAuthenticatedVpClient
-      >[0]["pinnedServerPubkey"],
+  it("does not fetch if the user cancels during the upfront prime", async () => {
+    let resolveEnsure: () => void = () => {};
+    const ensureDeferred = new Promise<unknown>((resolve) => {
+      resolveEnsure = () => resolve(undefined);
     });
+    ensureAuthMock.mockImplementationOnce(
+      () =>
+        ensureDeferred as unknown as ReturnType<
+          typeof ensureAuthenticatedVpClient
+        >,
+    );
+
+    const { result } = renderHook(() => useArtifactDownload({ primeContext }));
+
+    let downloadPromise: Promise<void> | undefined;
+    act(() => {
+      downloadPromise = result.current.download(
+        PROVIDER_ADDRESS,
+        PEGIN_TXID,
+        DEPOSITOR_PK,
+      );
+    });
+
+    act(() => {
+      result.current.cancel();
+    });
+
+    await act(async () => {
+      resolveEnsure();
+      await downloadPromise;
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result.current.downloaded).toBe(false);
+  });
+
+  it("retries once when the bearer expires mid-flight (hot-but-stale)", async () => {
+    seedHotCache();
     const seededProvider = vpTokenRegistry.peek(PEGIN_TXID);
     expect(seededProvider).toBeDefined();
     const invalidateSpy = vi.spyOn(
@@ -216,10 +212,43 @@ describe("useArtifactDownload — optimistic-then-prime-and-retry", () => {
 
     await waitFor(() => expect(result.current.downloaded).toBe(true));
     expect(invalidateSpy).toHaveBeenCalledTimes(1);
+    // Upfront prime skipped (hot cache); ensureAuth called only on the
+    // retry path after auth_expired.
     expect(ensureAuthMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries at most once - propagates failure when the retry also auth-fails", async () => {
+    seedHotCache();
+    fetchMock
+      .mockRejectedValueOnce(
+        new JsonRpcError(-32001, "missing or malformed Bearer token", "wire"),
+      )
+      .mockRejectedValueOnce(
+        new JsonRpcError(-32001, "missing or malformed Bearer token", "wire"),
+      );
+    ensureAuthMock.mockResolvedValueOnce(
+      undefined as unknown as Awaited<
+        ReturnType<typeof ensureAuthenticatedVpClient>
+      >,
+    );
+
+    const { result } = renderHook(() => useArtifactDownload({ primeContext }));
+
+    await act(async () => {
+      await result.current.download(PROVIDER_ADDRESS, PEGIN_TXID, DEPOSITOR_PK);
+    });
+
+    await waitFor(() =>
+      expect(result.current.error).toBe("missing or malformed Bearer token"),
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(ensureAuthMock).toHaveBeenCalledTimes(1);
+    expect(result.current.downloaded).toBe(false);
   });
 
   it("does not prime on a non-auth wire error", async () => {
+    seedHotCache();
     fetchMock.mockRejectedValueOnce(
       new JsonRpcError(-32001, "internal error", "wire"),
     );
@@ -237,6 +266,7 @@ describe("useArtifactDownload — optimistic-then-prime-and-retry", () => {
   });
 
   it("does not prime on a local JsonRpcError (transport / SDK failure)", async () => {
+    seedHotCache();
     fetchMock.mockRejectedValueOnce(
       new JsonRpcError(-32000, "request timed out", "local"),
     );
@@ -254,6 +284,7 @@ describe("useArtifactDownload — optimistic-then-prime-and-retry", () => {
   });
 
   it("does not prime on a VpResponseValidationError", async () => {
+    seedHotCache();
     fetchMock.mockRejectedValueOnce(
       new VpResponseValidationError("shape mismatch"),
     );

--- a/services/vault/src/hooks/deposit/useArtifactDownload.ts
+++ b/services/vault/src/hooks/deposit/useArtifactDownload.ts
@@ -8,6 +8,7 @@ import {
 import { useCallback, useRef, useState } from "react";
 import type { Hex } from "viem";
 
+import { COPY } from "@/copy";
 import { ensureAuthenticatedVpClient } from "@/hooks/deposit/depositFlowSteps/ensureAuthenticatedVpClient";
 import { isPreDepositorSignaturesError } from "@/models/peginStateMachine";
 import { fetchAndDownloadArtifacts } from "@/services/artifacts";
@@ -84,6 +85,53 @@ export function useArtifactDownload(options?: {
       });
 
       const normalizedPeginTxid = stripHexPrefix(peginTxid);
+
+      // Stop the flow with an error message. Used by every fail path
+      // below so the rendered modal state stays consistent.
+      const setError = (message: string) =>
+        setState({
+          loading: false,
+          progress: "",
+          error: message,
+          downloaded: false,
+        });
+
+      // Ensure the bearer is in cache before any artifact request. The
+      // RPC is auth-gated server-side (AUTH_GATED_METHODS), so a
+      // cold-cache attempt would be dead on arrival — prime once
+      // upfront so every fetchAndDownloadArtifacts() below goes out
+      // with a valid Authorization header. Returns false (with state
+      // already set) if the prime fails or the caller cancels during
+      // the await.
+      const ensurePrimedOrFail = async (): Promise<boolean> => {
+        if (vpTokenRegistry.peek(normalizedPeginTxid)) return true;
+        if (!primeContext) {
+          setError(COPY.deposit.artifactDownload.cannotAuthenticate);
+          return false;
+        }
+        try {
+          await ensureAuthenticatedVpClient({
+            btcWallet: primeContext.btcWallet,
+            vaultId: primeContext.vaultId,
+            unsignedPrePeginTxHex: primeContext.unsignedPrePeginTxHex,
+            peginTxHash: peginTxid,
+            providerAddress,
+            depositorBtcPubkey: depositorPk,
+          });
+        } catch (primeErr) {
+          if (cancelledRef.current) return false;
+          setError(
+            primeErr instanceof Error
+              ? primeErr.message
+              : "Authentication failed",
+          );
+          return false;
+        }
+        return !cancelledRef.current;
+      };
+
+      if (!(await ensurePrimedOrFail())) return;
+
       let primeAttempted = false;
 
       const tryPrimeAndRetry = async (): Promise<boolean> => {
@@ -161,26 +209,17 @@ export function useArtifactDownload(options?: {
               }
             } catch (primeErr) {
               if (cancelledRef.current) return;
-              setState({
-                loading: false,
-                progress: "",
-                error:
-                  primeErr instanceof Error
-                    ? primeErr.message
-                    : "Re-authentication failed",
-                downloaded: false,
-              });
+              setError(
+                primeErr instanceof Error
+                  ? primeErr.message
+                  : "Re-authentication failed",
+              );
               return;
             }
           }
 
           if (cancelledRef.current) return;
-          setState({
-            loading: false,
-            progress: "",
-            error: err instanceof Error ? err.message : "Download failed",
-            downloaded: false,
-          });
+          setError(err instanceof Error ? err.message : "Download failed");
           return;
         }
       }

--- a/services/vault/src/services/artifacts/artifactDownloadService.ts
+++ b/services/vault/src/services/artifacts/artifactDownloadService.ts
@@ -55,13 +55,12 @@ export async function fetchAndDownloadArtifacts(
 ): Promise<void> {
   const normalizedPeginTxid = stripHexPrefix(peginTxid);
 
-  // Reuse the bearer cached by the deposit flow. We deliberately do NOT
-  // trigger a wallet popup here: if the cache is cold (cross-device resume,
-  // refreshed tab) we send the request unauthenticated and let the server
-  // respond — the caller's retry loop surfaces the failure to the user.
-  // `callRaw` injects the header but does not reactively refresh on
-  // `auth_expired`, so a token that expires mid-download bubbles up as an
-  // error and the caller retries from scratch.
+  // The caller (useArtifactDownload) primes the bearer before invoking
+  // this service when the registry is cold, so peek() returns the active
+  // provider and the request goes out with a valid Authorization header
+  // for this auth-gated RPC. `callRaw` does not reactively refresh on
+  // `auth_expired`, so a token that expires mid-download bubbles up as
+  // an error and the caller's auth-failure retry path handles re-priming.
   const tokenProvider = vpTokenRegistry.peek(normalizedPeginTxid);
 
   const client = new JsonRpcClient({

--- a/services/vault/src/types/collateral.ts
+++ b/services/vault/src/types/collateral.ts
@@ -28,6 +28,13 @@ export interface CollateralVaultEntry {
    * sent on withdraw. Decoded for display via `scriptPubKeyHexToBtcAddress`.
    */
   depositorPayoutBtcAddress?: string;
+  /**
+   * Unsigned pre-pegin BTC transaction hex (from the indexer). Needed by
+   * the collateral artifact re-download path to re-derive the VP auth
+   * anchor when the in-memory token registry is cold. Optional because
+   * legacy / edge-case data may lack it.
+   */
+  unsignedPrePeginTx?: string;
   /** Liquidation priority index (0 = seized first) */
   liquidationIndex: number;
 }

--- a/services/vault/src/utils/collateral.ts
+++ b/services/vault/src/utils/collateral.ts
@@ -52,6 +52,7 @@ export function toCollateralVaultEntries(
       providerIconUrl: provider?.iconUrl,
       depositorBtcPubkey: c.vault?.depositorBtcPubKey,
       depositorPayoutBtcAddress: c.vault?.depositorPayoutBtcAddress,
+      unsignedPrePeginTx: c.vault?.unsignedPrePeginTx,
       liquidationIndex: c.liquidationIndex,
     };
   });


### PR DESCRIPTION
## Summary

`vaultProvider_requestDepositorClaimerArtifacts` is in `AUTH_GATED_METHODS`, but `fetchAndDownloadArtifacts` resolved its bearer via `vpTokenRegistry.peek()` — a
non-triggering reader. On a cold cache (tab refresh, cross-device resume) `peek()` returned `undefined`, `JsonRpcClient.buildHeaders` skipped the auth block, and
the first request hit the wire **without an `Authorization` header** on an always-gated endpoint. The existing `isAuthFailure` retry would then prime and re-send,
so it eventually worked end-to-end — but the first roundtrip was guaranteed dead-on-arrival, and the user-facing modal kept seeing a server "missing or malformed
Bearer token" before the retry succeeded.