### PR TITLE
fix(vault): guard ethAddress in payout-sign modal render condition

### DIFF
--- a/services/vault/src/components/simple/PendingDepositModals.tsx
+++ b/services/vault/src/components/simple/PendingDepositModals.tsx
@@ -106,8 +106,11 @@ export function PendingDepositModals({
 
   return (
     <>
-      {/* Payout Sign Modal – full-screen with stepper */}
-      {signModal.signingData && btcPublicKey && (
+      {/* Payout Sign Modal – full-screen with stepper. The render condition
+       *  must guard `ethAddress` too: without it, payout signing's
+       *  localStorage write would key by `"undefined"`, leaving the deposit
+       *  on SIGN_PAYOUT_TRANSACTIONS after a successful sign. */}
+      {signModal.signingData && btcPublicKey && ethAddress && (
         <SimpleDeposit
           open
           resumeMode="sign_payouts"


### PR DESCRIPTION
PendingDepositModals' payout-sign branch only guarded `signingData &&
btcPublicKey` and then cast `ethAddress as Hex`. When `ethAddress` was
undefined the cast silently passed it through, and payout signing's
localStorage write would land in a bucket keyed by the string "undefined" —
leaving the deposit on SIGN_PAYOUT_TRANSACTIONS after a successful sign,
so the button reappeared on the next poll. Mirror the broadcast/activation
modals by guarding `ethAddress` before render; keep the Hex cast since
SimpleDeposit's payout-mode prop type requires it and the guard now ensures
the value is defined.