### PR TITLE
fix(vault): refine deposit progress stepper UI

### DIFF
--- a/services/vault/src/components/simple/DepositProgressView/DepositProgressView.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/DepositProgressView.tsx
@@ -21,6 +21,7 @@ import type { PeginSigningProgress } from "@/services/vault/vaultTransactionServ
 import { BtcConfirmationDetailContainer } from "./BtcConfirmationDetailContainer";
 import { CompletedStepsPill } from "./CompletedStepsPill";
 import { GroupedProgress } from "./GroupedProgress";
+import { PeginFeeWarning } from "./PeginFeeWarning";
 import { ProgressBar } from "./ProgressBar";
 import { ProviderWaitDetail } from "./ProviderWaitDetail";
 import {
@@ -100,8 +101,10 @@ export function DepositProgressView(props: DepositProgressViewProps) {
     currentStep === DepositFlowStep.AWAIT_ACTIVATION_CONFIRMATION;
 
   const activeStepDetail =
-    currentStep === DepositFlowStep.AWAIT_BTC_CONFIRMATION &&
-    btcConfirmationDetail ? (
+    currentStep === DepositFlowStep.SIGN_PEGIN_BTC ? (
+      <PeginFeeWarning />
+    ) : currentStep === DepositFlowStep.AWAIT_BTC_CONFIRMATION &&
+      btcConfirmationDetail ? (
       <BtcConfirmationDetailContainer
         startedAt={btcConfirmationDetail.startedAt}
         prePeginTxid={btcConfirmationDetail.prePeginTxid}

--- a/services/vault/src/components/simple/DepositProgressView/GroupHeader.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/GroupHeader.tsx
@@ -7,12 +7,20 @@ import { COPY } from "@/copy";
 import type { GroupStatus } from "./steps";
 
 interface GroupHeaderProps {
-  /** 1-based ordinal of the group, shown inside the indicator circle. */
+  /** 1-based ordinal of the group, rendered as a letter (A, B, C, …). */
   number: number;
   title: string;
   status: GroupStatus;
   completedInGroup: number;
   totalInGroup: number;
+}
+
+/**
+ * Group indicators use letters (A, B, C, …) so they read distinctly from the
+ * numbered sub-steps nested inside each group.
+ */
+function groupLetter(ordinal: number): string {
+  return String.fromCharCode("A".charCodeAt(0) + ordinal - 1);
 }
 
 function GroupIndicator({
@@ -52,7 +60,7 @@ function GroupIndicator({
           status === "active" ? "text-accent-primary" : "text-accent-secondary",
         )}
       >
-        {number}
+        {groupLetter(number)}
       </Text>
     </div>
   );

--- a/services/vault/src/components/simple/DepositProgressView/GroupedProgress.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/GroupedProgress.tsx
@@ -71,6 +71,7 @@ export function GroupedProgress({
                         label={step.label}
                         description={step.description}
                         detail={activeStepDetail}
+                        hasNext={subIndex < stepNumbers.length - 1}
                       />
                     </div>
                   );

--- a/services/vault/src/components/simple/DepositProgressView/PeginFeeWarning.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/PeginFeeWarning.tsx
@@ -1,0 +1,24 @@
+import { Text } from "@babylonlabs-io/core-ui";
+import { IoWarningOutline } from "react-icons/io5";
+
+import { COPY } from "@/copy";
+
+/**
+ * Inline caution shown while the depositor signs the peg-in BTC transaction.
+ * The security design requires a comparatively high fee, so we surface it in
+ * the step itself rather than letting the wallet's number come as a surprise.
+ */
+export function PeginFeeWarning() {
+  return (
+    <div className="mt-3 flex items-center gap-2 rounded-lg bg-warning-main/10 p-3">
+      <IoWarningOutline
+        size={16}
+        className="shrink-0 text-warning-main"
+        aria-hidden
+      />
+      <Text as="span" variant="body2" className="text-warning-main">
+        {COPY.deposit.steps.peginFeeWarning}
+      </Text>
+    </div>
+  );
+}

--- a/services/vault/src/components/simple/DepositProgressView/StepRow.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/StepRow.tsx
@@ -56,6 +56,8 @@ interface StepRowProps {
   description?: string;
   /** Detail panel rendered below the label; rendered only on the active step. */
   detail?: ReactNode;
+  /** True when another sub-step follows in the group (i.e. not the last). */
+  hasNext?: boolean;
 }
 
 export function StepRow({
@@ -64,8 +66,13 @@ export function StepRow({
   label,
   description,
   detail,
+  hasNext = false,
 }: StepRowProps) {
   const isActive = state === "active";
+  // A detail panel makes the active row taller than a circle. Fill the extra
+  // height with a connector segment so the timeline stays unbroken down to the
+  // next step's connector — but never dangle a line below the group's last step.
+  const showTrailingLine = isActive && Boolean(detail) && hasNext;
 
   return (
     <div
@@ -74,7 +81,12 @@ export function StepRow({
         isActive ? "items-start" : "items-center",
       )}
     >
-      <StepCircle state={state} number={number} />
+      <div className="flex w-8 flex-col items-center self-stretch">
+        <StepCircle state={state} number={number} />
+        {showTrailingLine && (
+          <div className="w-0 flex-1 border-l-2 border-secondary-strokeDark" />
+        )}
+      </div>
       <div className="flex flex-1 flex-col">
         <div className="flex items-baseline gap-2">
           <Text

--- a/services/vault/src/components/simple/DepositProgressView/__tests__/DepositProgressView.test.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/__tests__/DepositProgressView.test.tsx
@@ -50,7 +50,7 @@ describe("DepositProgressView", () => {
     });
 
     it("expands only the section containing the current step", () => {
-      // Step 7 lives in the "Sign WOTS" group.
+      // Step 7 lives in the "Set up claim" group.
       render(
         <DepositProgressView
           {...baseProps}
@@ -413,6 +413,34 @@ describe("DepositProgressView", () => {
 
       expect(
         screen.queryByTestId("btc-confirmation-detail"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("peg-in fee warning", () => {
+    it("warns about the high fee while the peg-in signing step is active", () => {
+      render(
+        <DepositProgressView
+          {...baseProps}
+          currentStep={DepositFlowStep.SIGN_PEGIN_BTC}
+        />,
+      );
+
+      expect(
+        screen.getByText(COPY.deposit.steps.peginFeeWarning),
+      ).toBeInTheDocument();
+    });
+
+    it("does not show the fee warning on other steps", () => {
+      render(
+        <DepositProgressView
+          {...baseProps}
+          currentStep={DepositFlowStep.SUBMIT_WOTS_KEYS}
+        />,
+      );
+
+      expect(
+        screen.queryByText(COPY.deposit.steps.peginFeeWarning),
       ).not.toBeInTheDocument();
     });
   });

--- a/services/vault/src/components/simple/DepositProgressView/__tests__/GroupedProgress.test.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/__tests__/GroupedProgress.test.tsx
@@ -25,7 +25,7 @@ describe("GroupedProgress", () => {
   });
 
   it("expands only the active group and hides other groups' sub-steps", () => {
-    // Step 7 -> "Sign WOTS" group is active.
+    // Step 7 -> "Set up claim" group is active.
     render(<GroupedProgress steps={steps} currentStep={7} />);
 
     // Active group sub-step is visible.
@@ -105,7 +105,7 @@ describe("GroupedProgress", () => {
 
   describe("accessibility", () => {
     it("labels the active sub-step for screen readers", () => {
-      // Step 7 -> "Sign WOTS" group active; step 7 is the active sub-step.
+      // Step 7 -> "Set up claim" group active; step 7 is the active sub-step.
       render(<GroupedProgress steps={steps} currentStep={7} />);
 
       expect(
@@ -116,7 +116,7 @@ describe("GroupedProgress", () => {
     it("exposes each group's status to screen readers", () => {
       render(<GroupedProgress steps={steps} currentStep={7} />);
 
-      // Register deposit done, Sign WOTS active, the latter two not started.
+      // Register deposit done, Set up claim active, the latter two not started.
       expect(
         screen.getByLabelText(COPY.deposit.a11y.groupStatus.completed),
       ).toBeInTheDocument();

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -135,7 +135,7 @@ export const COPY = {
       signAndBroadcastEth: "Sign and broadcast ETH registration",
       signAndBroadcastPrePegin: "Sign and broadcast BTC Pre-Pegin transaction",
       awaitBtcConfirmation: "Awaiting Bitcoin confirmation",
-      submitWotsKey: "Submit WOTS public key to vault provider",
+      submitWotsKey: "Submit Winternitz One-Time Signature (WOTS)",
       awaitPayoutTransactions:
         "Awaiting vault provider to prepare payout transactions",
       authenticateSession: "Authenticate session with vault provider",
@@ -146,12 +146,13 @@ export const COPY = {
       retrieveSecret: "Retrieve secret",
       revealSecret: "Sign and broadcast ETH activation transaction",
       awaitActivationConfirmation: "Awaiting vault activation confirmation",
+      peginFeeWarning: "Expect high transaction fee for security reasons",
       signingCounter: (completed: number, total: number) =>
         `(${completed} of ${total})`,
     },
     groups: {
       registerDeposit: "Register deposit",
-      signWots: "Sign WOTS",
+      signWots: "Set up claim",
       signPayout: "Sign payout",
       activateVault: "Activate vault",
       stepCounter: (completed: number, total: number) =>


### PR DESCRIPTION
- Label step groups with letters (A-D); keep sub-steps globally numbered
- Rename the "Sign WOTS" group to "Set up claim"
- Reword the WOTS sub-step to "Submit Winternitz One-Time Signature (WOTS)"
- Show a high-fee caution on the peg-in signing step

## Screenshot
<img width="2368" height="1804" alt="image" src="https://github.com/user-attachments/assets/2f230fd7-64c5-4148-8e8f-36cba942e806" />
