### PR TITLE
feat(wallet): keep btc + eth wallets connected on refresh

### DIFF
--- a/packages/babylon-wallet-connector/src/context/Chain.context.tsx
+++ b/packages/babylon-wallet-connector/src/context/Chain.context.tsx
@@ -107,7 +107,7 @@ export function ChainProvider({
 
   // Re-detect wallets whose extension injected after the one-shot detection
   // in `init()` above (e.g. UniSat's late `window.unisat` injection).
-  useWalletRedetection({ connectors, setConnectors, config, context, storage, disabledWallets });
+  useWalletRedetection({ connectors, setConnectors, config, context, storage, disabledWallets, persistent });
 
   // Auto-reconnect (and any other connect/disconnect) mutates `connectedWallet`
   // on the existing connector instance without changing the `connectors` object

--- a/packages/babylon-wallet-connector/src/hooks/redetectReconnect.ts
+++ b/packages/babylon-wallet-connector/src/hooks/redetectReconnect.ts
@@ -1,0 +1,36 @@
+import type { HashMap, IProvider } from "@/core/types";
+import type { WalletConnector } from "@/core/WalletConnector";
+
+/**
+ * Decision (kept pure, and free of the SVG-importing wallet metadata, so it can
+ * be unit-tested without React): which of the just-redetected connectors should
+ * have their previously-stored session reconnected.
+ *
+ * A connector qualifies only when sessions are persisted, the trigger allows
+ * reconnect (cold-start, not the interactive modal-open path — which must not
+ * race a manual connect), storage still names a wallet for that chain, that
+ * wallet is now installed, and the connector isn't already connected.
+ */
+export function selectRedetectReconnectTargets({
+  connectors,
+  storage,
+  allowReconnect,
+  persistent,
+}: {
+  connectors: WalletConnector<string, IProvider, any>[];
+  storage: Pick<HashMap, "get">;
+  allowReconnect: boolean;
+  persistent: boolean;
+}): { connector: WalletConnector<string, IProvider, any>; walletId: string }[] {
+  if (!allowReconnect || !persistent) return [];
+
+  const targets: { connector: WalletConnector<string, IProvider, any>; walletId: string }[] = [];
+  for (const connector of connectors) {
+    if (connector.connectedWallet) continue;
+    const storedWalletId = storage.get(connector.id);
+    if (!storedWalletId) continue;
+    if (!connector.wallets.some((w) => w.id === storedWalletId && w.installed)) continue;
+    targets.push({ connector, walletId: storedWalletId });
+  }
+  return targets;
+}

--- a/packages/babylon-wallet-connector/src/hooks/redetectReconnect.ts
+++ b/packages/babylon-wallet-connector/src/hooks/redetectReconnect.ts
@@ -8,24 +8,35 @@ import type { WalletConnector } from "@/core/WalletConnector";
  *
  * A connector qualifies only when sessions are persisted, the trigger allows
  * reconnect (cold-start, not the interactive modal-open path — which must not
- * race a manual connect), storage still names a wallet for that chain, that
- * wallet is now installed, and the connector isn't already connected.
+ * race a manual connect), its chain is **eligible** (it participated in a
+ * late-injection redetection this session — see `eligibleChainIds` below),
+ * storage still names a wallet for that chain, that wallet is now installed, and
+ * the connector isn't already connected.
+ *
+ * `eligibleChainIds` is the key guard: only chains that actually late-injected
+ * are eligible. ETH/AppKit never late-injects (it's always installed, so never
+ * `stale`/`appeared`), so it's never eligible — which is what keeps this from
+ * calling `ethConnector.connect()` and popping the AppKit modal on reload (core
+ * excludes ETH from auto-reconnect for the same reason).
  */
 export function selectRedetectReconnectTargets({
   connectors,
   storage,
   allowReconnect,
   persistent,
+  eligibleChainIds,
 }: {
   connectors: WalletConnector<string, IProvider, any>[];
   storage: Pick<HashMap, "get">;
   allowReconnect: boolean;
   persistent: boolean;
+  eligibleChainIds: Set<string>;
 }): { connector: WalletConnector<string, IProvider, any>; walletId: string }[] {
   if (!allowReconnect || !persistent) return [];
 
   const targets: { connector: WalletConnector<string, IProvider, any>; walletId: string }[] = [];
   for (const connector of connectors) {
+    if (!eligibleChainIds.has(connector.id)) continue;
     if (connector.connectedWallet) continue;
     const storedWalletId = storage.get(connector.id);
     if (!storedWalletId) continue;

--- a/packages/babylon-wallet-connector/src/hooks/useWalletRedetection.ts
+++ b/packages/babylon-wallet-connector/src/hooks/useWalletRedetection.ts
@@ -100,6 +100,19 @@ export function useWalletRedetection({
 
     let inFlight = false; // prevent overlapping passes (event vs. timeout vs. modal-open)
     let cancelled = false; // effect cleaned up
+    // Chains with a stored-session reconnect already in flight, so the two
+    // cold-start triggers (ready event + fallback timer) firing before it
+    // settles don't fire duplicate `connect()`s. Persists across redetect calls
+    // within this effect instance.
+    const reconnecting = new Set<string>();
+    // Chains that participated in late-injection redetection (their wallet
+    // `appeared` after the one-shot init detection) and still need their stored
+    // session restored. Only these are eligible for redetect reconnect — so
+    // ETH/AppKit (never late-injects) and normally-detected wallets (init
+    // auto-reconnect handles them) are excluded. Persists across passes so a
+    // modal-open detect-only pass that swaps a wallet in is still restored by a
+    // later cold-start pass.
+    const pendingRestore = new Set<string>();
 
     // `allowReconnect` is true only for the non-interactive cold-start triggers
     // (see listeners below); the modal-open trigger passes false.
@@ -114,85 +127,104 @@ export function useWalletRedetection({
     };
 
     const runRedetection = async (allowReconnect: boolean) => {
+      // 1. Re-detect connectors whose wallet injected after the one-shot
+      //    detection in init() (e.g. UniSat) and swap the now-installed ones in.
       const stale = (
         Object.values(connectorsRef.current).filter(Boolean) as WalletConnector<string, IProvider, any>[]
       ).filter((c) => !c.connectedWallet && c.wallets.some((w) => w.id !== "injectable" && !w.installed));
-      if (stale.length === 0) return;
 
-      const rebuilt = await Promise.all(
-        stale.map((c) =>
-          createWalletConnector<string, IProvider, any>({
-            // `persistent: false` — this rebuild only re-detects providers; it
-            // must not auto-reconnect a stored session, which would race a
-            // manual connect on the pre-rebuild connector and double-prompt.
-            persistent: false,
-            metadata: metadata[c.id as keyof typeof metadata],
-            context,
-            config: config.find((cc) => cc.chain === c.id)?.config,
-            accountStorage: storage,
-            disabledWallets,
-          }).catch(() => null),
-        ),
-      );
-      if (cancelled) return;
+      let swapIn: WalletConnector<string, IProvider, any>[] = [];
+      if (stale.length > 0) {
+        const rebuilt = await Promise.all(
+          stale.map((c) =>
+            createWalletConnector<string, IProvider, any>({
+              // `persistent: false` — this rebuild only re-detects providers; the
+              // stored-session reconnect is done explicitly in step 2 so it can
+              // also cover connectors an earlier detect-only pass already swapped in.
+              persistent: false,
+              metadata: metadata[c.id as keyof typeof metadata],
+              context,
+              config: config.find((cc) => cc.chain === c.id)?.config,
+              accountStorage: storage,
+              disabledWallets,
+            }).catch(() => null),
+          ),
+        );
+        if (cancelled) return;
 
-      // Keep only chains where a wallet that was NOT installed before is
-      // installed now (robust to the injectable-wallet de-dup reshaping the
-      // list, vs. a plain installed-count comparison).
-      const appeared = rebuilt.filter((c): c is WalletConnector<string, IProvider, any> => {
-        if (!c) return false;
-        const before = connectorsRef.current[c.id as keyof Connectors];
-        if (!before || before.connectedWallet) return false;
-        const wasInstalled = new Set(before.wallets.filter((w) => w.installed).map((w) => w.id));
-        return c.wallets.some((w) => w.installed && !wasInstalled.has(w.id));
-      });
-      if (appeared.length === 0) return;
+        // Keep only chains where a wallet that was NOT installed before is
+        // installed now (robust to the injectable-wallet de-dup reshaping the
+        // list, vs. a plain installed-count comparison).
+        const appeared = rebuilt.filter((c): c is WalletConnector<string, IProvider, any> => {
+          if (!c) return false;
+          const before = connectorsRef.current[c.id as keyof Connectors];
+          if (!before || before.connectedWallet) return false;
+          const wasInstalled = new Set(before.wallets.filter((w) => w.installed).map((w) => w.id));
+          return c.wallets.some((w) => w.installed && !wasInstalled.has(w.id));
+        });
 
-      // Connectors we'll actually swap in, computed synchronously: an
-      // `appeared` whose currently-in-state counterpart hasn't connected in the
-      // meantime. The in-state connectors and the updater's `prev` are the same
-      // instances and `connectedWallet` is mutated on the instance, so reading
-      // `connectorsRef.current` here is equivalent to reading `prev` — but it
-      // doesn't depend on side effects inside the (deferred / possibly
-      // double-invoked) state updater.
-      const current = connectorsRef.current;
-      const swapIn = appeared.filter((c) => !current[c.id as keyof Connectors]?.connectedWallet);
-      if (swapIn.length === 0) return;
+        // These chains late-injected — mark them eligible for stored-session
+        // restore (carried across passes, so a detect-only modal-open pass is
+        // still restored by a later cold-start pass).
+        for (const c of appeared) pendingRestore.add(c.id);
 
-      setConnectors((prev) => {
-        const next: Record<string, WalletConnector<string, IProvider, any>> = {};
-        for (const c of swapIn) {
-          // Re-check at commit time for the tiny window since `swapIn` was
-          // computed — never overwrite a now-connected connector.
-          if (prev[c.id as keyof Connectors]?.connectedWallet) continue;
-          next[c.id] = c;
+        // Swap in the appeared connectors whose currently-in-state counterpart
+        // hasn't connected in the meantime. Computed synchronously (not inside
+        // the updater) so it doesn't depend on side effects in the deferred /
+        // possibly double-invoked state updater.
+        const current = connectorsRef.current;
+        swapIn = appeared.filter((c) => !current[c.id as keyof Connectors]?.connectedWallet);
+        if (swapIn.length > 0) {
+          setConnectors((prev) => {
+            const next: Record<string, WalletConnector<string, IProvider, any>> = {};
+            for (const c of swapIn) {
+              // Re-check at commit time for the tiny window since `swapIn` was computed.
+              if (prev[c.id as keyof Connectors]?.connectedWallet) continue;
+              next[c.id] = c;
+            }
+            return Object.keys(next).length > 0 ? ({ ...prev, ...next } as Connectors) : prev;
+          });
         }
-        return Object.keys(next).length > 0 ? ({ ...prev, ...next } as Connectors) : prev;
-      });
+      }
 
-      // Restore a persisted session that lost the cold-start detection race.
-      // Computed from `swapIn` (not from inside the updater), so it is
-      // deterministic. The rebuilt connector is the same instance placed in
-      // state, so its `connect` event flows through the normal ChainProvider
-      // bump / BTCWalletProvider / selectWallet wiring (which also repopulates
-      // `selectedWallets`).
+      // 2. Restore persisted sessions (cold-start triggers only — the modal-open
+      //    trigger stays detect-only so it can't race a manual connect). Only
+      //    chains in `pendingRestore` (late-injected this session) are eligible,
+      //    so ETH/AppKit and normally-detected wallets are never reconnected
+      //    here. The in-state instance is taken from swapIn (this pass) or
+      //    current, so a session swapped in by an earlier detect-only pass is
+      //    still restored.
+      if (!allowReconnect || !persistent || pendingRestore.size === 0) return;
+      const inState: Record<string, WalletConnector<string, IProvider, any>> = {};
+      for (const c of Object.values(connectorsRef.current)) {
+        if (c) inState[c.id] = c as WalletConnector<string, IProvider, any>;
+      }
+      for (const c of swapIn) inState[c.id] = c;
+
       const reconnectTargets = selectRedetectReconnectTargets({
-        connectors: swapIn,
+        connectors: Object.values(inState),
         storage,
         allowReconnect,
         persistent,
+        eligibleChainIds: pendingRestore,
       });
       for (const { connector, walletId } of reconnectTargets) {
-        // Mirror the updater's commit-time skip: if the in-state connector for
-        // this chain connected in the window since `swapIn` was computed, the
-        // updater won't swap our rebuilt one in, so reconnecting it would just
-        // hit an orphan (harmless, but pointless). `current[id]` is the same
-        // live instance the updater reads as `prev[id]`, so this re-read sees a
-        // connection that landed in between.
-        if (current[connector.id as keyof Connectors]?.connectedWallet) continue;
+        if (reconnecting.has(connector.id)) continue;
+        reconnecting.add(connector.id);
         // Fire-and-forget: `connect` swallows its own errors (returns null on
         // failure); a locked/unresponsive wallet must not block re-detection.
-        void connector.connect(walletId);
+        // The connect event flows through the normal ChainProvider bump /
+        // BTCWalletProvider / selectWallet wiring (which repopulates selectedWallets).
+        void connector
+          .connect(walletId)
+          .then((wallet) => {
+            reconnecting.delete(connector.id);
+            // Restored — stop treating this chain as pending so later cold-start
+            // passes don't reconnect it again. On failure `connect` resolves
+            // null, so it stays pending and a later trigger retries.
+            if (wallet) pendingRestore.delete(connector.id);
+          })
+          .catch(() => reconnecting.delete(connector.id));
       }
     };
 

--- a/packages/babylon-wallet-connector/src/hooks/useWalletRedetection.ts
+++ b/packages/babylon-wallet-connector/src/hooks/useWalletRedetection.ts
@@ -8,6 +8,8 @@ import type { WalletConnector } from "@/core/WalletConnector";
 import metadata from "@/core/wallets";
 import type { ChainConfigArr, Connectors } from "@/context/Chain.context";
 
+import { selectRedetectReconnectTargets } from "./redetectReconnect";
+
 /** UniSat dispatches this on `window` once its provider is ready. */
 const UNISAT_READY_EVENT = "unisat#initialized";
 
@@ -31,6 +33,12 @@ interface UseWalletRedetectionParams {
   storage: HashMap;
   /** Wallet ids to exclude from connector construction. */
   disabledWallets?: string[];
+  /**
+   * Whether sessions are persisted (same flag passed to `createWalletConnector`).
+   * When true, a cold-start re-detection that re-installs a previously-stored
+   * wallet auto-reconnects it (see the reconnect block below).
+   */
+  persistent: boolean;
 }
 
 /**
@@ -57,11 +65,16 @@ interface UseWalletRedetectionParams {
  * never dropped. A single in-flight guard prevents overlapping passes (e.g. the
  * event and the timeout firing close together).
  *
- * The rebuild passes `persistent: false` — it only re-detects providers and
- * never auto-reconnects a stored session (which would race a manual connect
- * on the pre-rebuild connector and double-prompt the wallet). A session that
- * lost the race needs one manual reconnect, still strictly better than the
- * wallet showing as not installed.
+ * The connector *rebuild* always passes `persistent: false` so it does no
+ * auto-reconnect itself. Reconnect of a previously-stored session is then
+ * done explicitly, and only for the **cold-start** triggers (`unisat#initialized`
+ * and the fallback timeout) where the modal is closed and there is no manual
+ * connect to race. The interactive `WALLET_MODAL_OPEN_EVENT` trigger stays
+ * detect-only (`allowReconnect: false`) — the user is actively choosing a wallet
+ * there, so auto-reconnecting could double-prompt. Without this, a session that
+ * lost the cold-start detection race (extension injected after `init()`) would
+ * stay disconnected even though storage still names the wallet — leaving e.g.
+ * ETH reconnected while BTC/UniSat shows as "Connect".
  */
 export function useWalletRedetection({
   connectors,
@@ -70,6 +83,7 @@ export function useWalletRedetection({
   context,
   storage,
   disabledWallets,
+  persistent,
 }: UseWalletRedetectionParams): void {
   // Mirror the latest connectors into a ref so the effect reads current
   // state without depending on it (which would re-run it).
@@ -87,17 +101,19 @@ export function useWalletRedetection({
     let inFlight = false; // prevent overlapping passes (event vs. timeout vs. modal-open)
     let cancelled = false; // effect cleaned up
 
-    const redetect = async () => {
+    // `allowReconnect` is true only for the non-interactive cold-start triggers
+    // (see listeners below); the modal-open trigger passes false.
+    const redetect = async (allowReconnect: boolean) => {
       if (inFlight || cancelled) return;
       inFlight = true;
       try {
-        await runRedetection();
+        await runRedetection(allowReconnect);
       } finally {
         inFlight = false;
       }
     };
 
-    const runRedetection = async () => {
+    const runRedetection = async (allowReconnect: boolean) => {
       const stale = (
         Object.values(connectorsRef.current).filter(Boolean) as WalletConnector<string, IProvider, any>[]
       ).filter((c) => !c.connectedWallet && c.wallets.some((w) => w.id !== "injectable" && !w.installed));
@@ -132,36 +148,77 @@ export function useWalletRedetection({
       });
       if (appeared.length === 0) return;
 
+      // Connectors we'll actually swap in, computed synchronously: an
+      // `appeared` whose currently-in-state counterpart hasn't connected in the
+      // meantime. The in-state connectors and the updater's `prev` are the same
+      // instances and `connectedWallet` is mutated on the instance, so reading
+      // `connectorsRef.current` here is equivalent to reading `prev` — but it
+      // doesn't depend on side effects inside the (deferred / possibly
+      // double-invoked) state updater.
+      const current = connectorsRef.current;
+      const swapIn = appeared.filter((c) => !current[c.id as keyof Connectors]?.connectedWallet);
+      if (swapIn.length === 0) return;
+
       setConnectors((prev) => {
-        const merged: Record<string, WalletConnector<string, IProvider, any>> = {};
-        for (const c of appeared) {
-          // A connection may have landed since `appeared` was computed —
-          // never overwrite a now-connected connector.
+        const next: Record<string, WalletConnector<string, IProvider, any>> = {};
+        for (const c of swapIn) {
+          // Re-check at commit time for the tiny window since `swapIn` was
+          // computed — never overwrite a now-connected connector.
           if (prev[c.id as keyof Connectors]?.connectedWallet) continue;
-          merged[c.id] = c;
+          next[c.id] = c;
         }
-        return Object.keys(merged).length > 0 ? ({ ...prev, ...merged } as Connectors) : prev;
+        return Object.keys(next).length > 0 ? ({ ...prev, ...next } as Connectors) : prev;
       });
+
+      // Restore a persisted session that lost the cold-start detection race.
+      // Computed from `swapIn` (not from inside the updater), so it is
+      // deterministic. The rebuilt connector is the same instance placed in
+      // state, so its `connect` event flows through the normal ChainProvider
+      // bump / BTCWalletProvider / selectWallet wiring (which also repopulates
+      // `selectedWallets`).
+      const reconnectTargets = selectRedetectReconnectTargets({
+        connectors: swapIn,
+        storage,
+        allowReconnect,
+        persistent,
+      });
+      for (const { connector, walletId } of reconnectTargets) {
+        // Mirror the updater's commit-time skip: if the in-state connector for
+        // this chain connected in the window since `swapIn` was computed, the
+        // updater won't swap our rebuilt one in, so reconnecting it would just
+        // hit an orphan (harmless, but pointless). `current[id]` is the same
+        // live instance the updater reads as `prev[id]`, so this re-read sees a
+        // connection that landed in between.
+        if (current[connector.id as keyof Connectors]?.connectedWallet) continue;
+        // Fire-and-forget: `connect` swallows its own errors (returns null on
+        // failure); a locked/unresponsive wallet must not block re-detection.
+        void connector.connect(walletId);
+      }
     };
 
-    const timer = setTimeout(redetect, FALLBACK_MS);
+    const redetectColdStart = () => void redetect(true);
+    const redetectInteractive = () => void redetect(false);
+
+    const timer = setTimeout(redetectColdStart, FALLBACK_MS);
     const hasWindow = typeof window !== "undefined";
     if (hasWindow) {
-      // Cold-start race: re-detect once the extension signals it is ready.
-      window.addEventListener(UNISAT_READY_EVENT, redetect, { once: true });
+      // Cold-start race: re-detect (and restore the stored session) once the
+      // extension signals it is ready.
+      window.addEventListener(UNISAT_READY_EVENT, redetectColdStart, { once: true });
       // Catch-all for an injection slower than FALLBACK_MS: re-detect whenever
       // the user opens the modal. Repeatable (not `once`); the in-flight guard
       // and the no-stale-wallets early-return keep it cheap when nothing changed.
-      window.addEventListener(WALLET_MODAL_OPEN_EVENT, redetect);
+      // Detect-only (no reconnect) so it can't race the user's manual connect.
+      window.addEventListener(WALLET_MODAL_OPEN_EVENT, redetectInteractive);
     }
 
     return () => {
       cancelled = true;
       clearTimeout(timer);
       if (hasWindow) {
-        window.removeEventListener(UNISAT_READY_EVENT, redetect);
-        window.removeEventListener(WALLET_MODAL_OPEN_EVENT, redetect);
+        window.removeEventListener(UNISAT_READY_EVENT, redetectColdStart);
+        window.removeEventListener(WALLET_MODAL_OPEN_EVENT, redetectInteractive);
       }
     };
-  }, [connectorsBuilt, config, context, storage, disabledWallets, setConnectors]);
+  }, [connectorsBuilt, config, context, storage, disabledWallets, setConnectors, persistent]);
 }

--- a/packages/babylon-wallet-connector/src/providers/ETHWalletProvider.tsx
+++ b/packages/babylon-wallet-connector/src/providers/ETHWalletProvider.tsx
@@ -133,7 +133,38 @@ export const ETHWalletProvider = ({ children, callbacks }: ETHWalletProviderProp
       }
     });
 
-    return unsubscribe;
+    // Bridge a late wagmi rehydrate into the connector "connect" flow.
+    // checkExistingConnection() above only sees the account wagmi has already
+    // restored by mount time. On reload wagmi often finishes reconnecting from
+    // cookieStorage *after* that: the provider then emits "accountsChanged"
+    // with the restored address, but nothing has called ethConnector.connect()
+    // yet, so connectedWallet / selectedWallets / the connect listener above
+    // never fire and ETH silently fails to re-wire (the AppKit modal shows the
+    // account while the app still shows "Connect"). Listen for that late
+    // address and route it through the connector — a silent no-op when wagmi is
+    // already connected, so it never reopens the modal — which then drives the
+    // connect listener above and the auto-confirm-on-reload effect.
+    const bootstrapWallet = ethConnector.wallets[0];
+    const bootstrapProvider = bootstrapWallet?.provider;
+    const onLateReconnect = (accounts?: string[]) => {
+      if (!accounts?.[0] || address) return;
+      void ethConnector.connect(bootstrapWallet).catch((error) => {
+        console.error(
+          "ETH late reconnect failed:",
+          error instanceof Error ? error.message : "Unknown error",
+        );
+      });
+    };
+    if (bootstrapProvider && typeof bootstrapProvider.on === "function") {
+      bootstrapProvider.on("accountsChanged", onLateReconnect);
+    }
+
+    return () => {
+      unsubscribe();
+      if (bootstrapProvider && typeof bootstrapProvider.off === "function") {
+        bootstrapProvider.off("accountsChanged", onLateReconnect);
+      }
+    };
   }, [ethConnector, connectETH, address]);
 
   useEffect(() => {

--- a/packages/babylon-wallet-connector/src/providers/ETHWalletProvider.tsx
+++ b/packages/babylon-wallet-connector/src/providers/ETHWalletProvider.tsx
@@ -146,14 +146,33 @@ export const ETHWalletProvider = ({ children, callbacks }: ETHWalletProviderProp
     // connect listener above and the auto-confirm-on-reload effect.
     const bootstrapWallet = ethConnector.wallets[0];
     const bootstrapProvider = bootstrapWallet?.provider;
+    // wagmi can emit several `accountsChanged` while it rehydrates, before React
+    // re-renders with the new `address` — without this guard each one would see
+    // `address` empty and fire another `ethConnector.connect`. On success the
+    // address becomes truthy and the effect re-subscribes, so the flag only
+    // needs resetting on failure.
+    let lateReconnectInFlight = false;
     const onLateReconnect = (accounts?: string[]) => {
-      if (!accounts?.[0] || address) return;
-      void ethConnector.connect(bootstrapWallet).catch((error) => {
-        console.error(
-          "ETH late reconnect failed:",
-          error instanceof Error ? error.message : "Unknown error",
-        );
-      });
+      if (!accounts?.[0] || address || lateReconnectInFlight) return;
+      lateReconnectInFlight = true;
+      void ethConnector
+        .connect(bootstrapWallet)
+        .then((wallet) => {
+          // `connect` catches internally and resolves `null` on failure (it does
+          // not reject), so reset the guard here to allow a retry on the next
+          // accountsChanged. On success the address gets set and the effect
+          // re-subscribes, so the guard naturally stops further calls.
+          if (!wallet) lateReconnectInFlight = false;
+        })
+        .catch((error) => {
+          // Defensive only — `connect` shouldn't reject, but reset on an
+          // unexpected synchronous throw so we don't wedge the guard.
+          lateReconnectInFlight = false;
+          console.error(
+            "ETH late reconnect failed:",
+            error instanceof Error ? error.message : "Unknown error",
+          );
+        });
     };
     if (bootstrapProvider && typeof bootstrapProvider.on === "function") {
       bootstrapProvider.on("accountsChanged", onLateReconnect);

--- a/packages/babylon-wallet-connector/tests/unit/redetectReconnectTargets.test.ts
+++ b/packages/babylon-wallet-connector/tests/unit/redetectReconnectTargets.test.ts
@@ -26,9 +26,29 @@ test.describe("selectRedetectReconnectTargets — cold-start session restore", (
       storage: storageWith({ BTC: "unisat" }),
       allowReconnect: true,
       persistent: true,
+      eligibleChainIds: new Set(["BTC"]),
     });
 
     expect(targets).toEqual([{ connector: btc, walletId: "unisat" }]);
+  });
+
+  test("does not reconnect a chain that did not participate in redetection (e.g. ETH/AppKit)", () => {
+    // ETH/AppKit is always installed and stored, so without the eligibility
+    // gate it would be selected here — and connecting it would pop the AppKit
+    // modal on reload. It never late-injects, so it's never eligible.
+    const eth = connector("ETH", [
+      { id: "appkit-eth-connector", installed: true },
+    ]);
+
+    const targets = selectRedetectReconnectTargets({
+      connectors: [eth],
+      storage: storageWith({ ETH: "appkit-eth-connector" }),
+      allowReconnect: true,
+      persistent: true,
+      eligibleChainIds: new Set(["BTC"]), // only BTC late-injected
+    });
+
+    expect(targets).toEqual([]);
   });
 
   test("does not reconnect on the interactive (modal-open) trigger", () => {
@@ -39,6 +59,7 @@ test.describe("selectRedetectReconnectTargets — cold-start session restore", (
       storage: storageWith({ BTC: "unisat" }),
       allowReconnect: false,
       persistent: true,
+      eligibleChainIds: new Set(["BTC"]),
     });
 
     expect(targets).toEqual([]);
@@ -52,6 +73,7 @@ test.describe("selectRedetectReconnectTargets — cold-start session restore", (
       storage: storageWith({ BTC: "unisat" }),
       allowReconnect: true,
       persistent: false,
+      eligibleChainIds: new Set(["BTC"]),
     });
 
     expect(targets).toEqual([]);
@@ -65,6 +87,7 @@ test.describe("selectRedetectReconnectTargets — cold-start session restore", (
       storage: storageWith({}),
       allowReconnect: true,
       persistent: true,
+      eligibleChainIds: new Set(["BTC"]),
     });
 
     expect(targets).toEqual([]);
@@ -78,6 +101,7 @@ test.describe("selectRedetectReconnectTargets — cold-start session restore", (
       storage: storageWith({ BTC: "unisat" }),
       allowReconnect: true,
       persistent: true,
+      eligibleChainIds: new Set(["BTC"]),
     });
 
     expect(targets).toEqual([]);
@@ -95,6 +119,7 @@ test.describe("selectRedetectReconnectTargets — cold-start session restore", (
       storage: storageWith({ BTC: "unisat" }),
       allowReconnect: true,
       persistent: true,
+      eligibleChainIds: new Set(["BTC"]),
     });
 
     expect(targets).toEqual([]);

--- a/packages/babylon-wallet-connector/tests/unit/redetectReconnectTargets.test.ts
+++ b/packages/babylon-wallet-connector/tests/unit/redetectReconnectTargets.test.ts
@@ -1,0 +1,102 @@
+import { expect, test } from "@playwright/test";
+
+import { selectRedetectReconnectTargets } from "../../src/hooks/redetectReconnect";
+
+// After a late-injection re-detection re-installs a previously-stored wallet,
+// the cold-start triggers must restore that session — but only when it is safe
+// to do so. This pins the decision of WHICH redetected connectors get a
+// fire-and-forget reconnect. Connectors are faked as plain objects exposing only
+// the fields the selector reads (id, connectedWallet, wallets[].id/installed).
+const connector = (
+  id: string,
+  wallets: { id: string; installed: boolean }[],
+  connectedWallet: unknown = null,
+) => ({ id, connectedWallet, wallets }) as any;
+
+const storageWith = (entries: Record<string, string>) => ({
+  get: (key: string) => entries[key],
+});
+
+test.describe("selectRedetectReconnectTargets — cold-start session restore", () => {
+  test("reconnects a stored wallet that is now installed on a cold-start trigger", () => {
+    const btc = connector("BTC", [{ id: "unisat", installed: true }]);
+
+    const targets = selectRedetectReconnectTargets({
+      connectors: [btc],
+      storage: storageWith({ BTC: "unisat" }),
+      allowReconnect: true,
+      persistent: true,
+    });
+
+    expect(targets).toEqual([{ connector: btc, walletId: "unisat" }]);
+  });
+
+  test("does not reconnect on the interactive (modal-open) trigger", () => {
+    const btc = connector("BTC", [{ id: "unisat", installed: true }]);
+
+    const targets = selectRedetectReconnectTargets({
+      connectors: [btc],
+      storage: storageWith({ BTC: "unisat" }),
+      allowReconnect: false,
+      persistent: true,
+    });
+
+    expect(targets).toEqual([]);
+  });
+
+  test("does not reconnect when sessions are not persisted", () => {
+    const btc = connector("BTC", [{ id: "unisat", installed: true }]);
+
+    const targets = selectRedetectReconnectTargets({
+      connectors: [btc],
+      storage: storageWith({ BTC: "unisat" }),
+      allowReconnect: true,
+      persistent: false,
+    });
+
+    expect(targets).toEqual([]);
+  });
+
+  test("does not reconnect when storage has no stored wallet for the chain", () => {
+    const btc = connector("BTC", [{ id: "unisat", installed: true }]);
+
+    const targets = selectRedetectReconnectTargets({
+      connectors: [btc],
+      storage: storageWith({}),
+      allowReconnect: true,
+      persistent: true,
+    });
+
+    expect(targets).toEqual([]);
+  });
+
+  test("does not reconnect when the stored wallet is still not installed", () => {
+    const btc = connector("BTC", [{ id: "unisat", installed: false }]);
+
+    const targets = selectRedetectReconnectTargets({
+      connectors: [btc],
+      storage: storageWith({ BTC: "unisat" }),
+      allowReconnect: true,
+      persistent: true,
+    });
+
+    expect(targets).toEqual([]);
+  });
+
+  test("does not reconnect a connector that is already connected", () => {
+    const btc = connector(
+      "BTC",
+      [{ id: "unisat", installed: true }],
+      { id: "unisat" },
+    );
+
+    const targets = selectRedetectReconnectTargets({
+      connectors: [btc],
+      storage: storageWith({ BTC: "unisat" }),
+      allowReconnect: true,
+      persistent: true,
+    });
+
+    expect(targets).toEqual([]);
+  });
+});

--- a/services/vault/src/components/Wallet/Connect.tsx
+++ b/services/vault/src/components/Wallet/Connect.tsx
@@ -6,6 +6,7 @@ import {
   Hint,
 } from "@babylonlabs-io/core-ui";
 import {
+  useChainConnector,
   useWalletConnect,
   useWidgetState,
 } from "@babylonlabs-io/wallet-connector";
@@ -18,6 +19,8 @@ import { COPY } from "@/copy";
 
 import { useBTCWallet, useETHWallet } from "../../context/wallet";
 import { useAppState } from "../../state/AppState";
+
+import { resolveDisplayWallets } from "./resolveDisplayWallets";
 
 interface ConnectProps {
   loading?: boolean;
@@ -34,6 +37,8 @@ export const Connect: React.FC<ConnectProps> = ({ loading = false }) => {
   } = useBTCWallet();
   const { connected: ethConnected, address: ethAddress } = useETHWallet();
   const { selectedWallets } = useWidgetState();
+  const btcConnector = useChainConnector("BTC");
+  const ethConnector = useChainConnector("ETH");
   const { includeOrdinals, excludeOrdinals, ordinalsExcluded } = useAppState();
 
   const { isGeoBlocked, isLoading: isGeoLoading } = useGeoFencing();
@@ -42,15 +47,21 @@ export const Connect: React.FC<ConnectProps> = ({ loading = false }) => {
 
   const isWalletConnected = btcConnected && ethConnected;
 
-  const transformedWallets = useMemo(() => {
-    const result: Record<string, { name: string; icon: string }> = {};
-    Object.entries(selectedWallets).forEach(([key, wallet]) => {
-      if (wallet) {
-        result[key] = { name: wallet.name, icon: wallet.icon };
-      }
-    });
-    return result;
-  }, [selectedWallets]);
+  // Icon source must stay aligned with the (provider-level) connection state:
+  // `selectedWallets` is volatile widget state that can lag a reconnect on
+  // refresh, leaving the address shown but the icon blank. resolveDisplayWallets
+  // falls back to the connector's connected/installed wallet metadata.
+  const displayWallets = useMemo(
+    () =>
+      resolveDisplayWallets({
+        selectedWallets,
+        btcConnected,
+        ethConnected,
+        btcConnector,
+        ethConnector,
+      }),
+    [selectedWallets, btcConnected, ethConnected, btcConnector, ethConnector],
+  );
 
   const handleOpenChange = (open: boolean) => {
     setIsWalletMenuOpen(open);
@@ -65,10 +76,10 @@ export const Connect: React.FC<ConnectProps> = ({ loading = false }) => {
           trigger={
             <div className="cursor-pointer">
               <AvatarGroup max={3} variant="circular">
-                {selectedWallets["BTC"] && (
+                {displayWallets["BTC"] && (
                   <Avatar
-                    alt={selectedWallets["BTC"]?.name}
-                    url={selectedWallets["BTC"]?.icon}
+                    alt={displayWallets["BTC"].name}
+                    url={displayWallets["BTC"].icon}
                     size="large"
                     className={twMerge(
                       "box-content bg-accent-contrast object-contain",
@@ -77,10 +88,10 @@ export const Connect: React.FC<ConnectProps> = ({ loading = false }) => {
                     )}
                   />
                 )}
-                {selectedWallets["ETH"] && (
+                {displayWallets["ETH"] && (
                   <Avatar
-                    alt={selectedWallets["ETH"]?.name}
-                    url={selectedWallets["ETH"]?.icon}
+                    alt={displayWallets["ETH"].name}
+                    url={displayWallets["ETH"].icon}
                     size="large"
                     className={twMerge(
                       "box-content bg-accent-contrast object-contain",
@@ -94,7 +105,7 @@ export const Connect: React.FC<ConnectProps> = ({ loading = false }) => {
           }
           btcAddress={btcAddress}
           ethAddress={ethAddress}
-          selectedWallets={transformedWallets}
+          selectedWallets={displayWallets}
           publicKeyNoCoord={publicKeyNoCoord}
           ordinalsExcluded={ordinalsExcluded}
           onIncludeOrdinals={includeOrdinals}

--- a/services/vault/src/components/Wallet/__tests__/resolveDisplayWallets.test.ts
+++ b/services/vault/src/components/Wallet/__tests__/resolveDisplayWallets.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveDisplayWallets } from "../resolveDisplayWallets";
+
+// Fake connector exposing only the fields the resolver reads.
+const connector = (
+  wallets: { name: string; icon: string; installed: boolean }[],
+  connectedWallet: {
+    name: string;
+    icon: string;
+    installed: boolean;
+  } | null = null,
+) => ({ connectedWallet, wallets });
+
+const APPKIT = { name: "AppKit", icon: "appkit-icon", installed: true };
+const UNISAT = { name: "UniSat", icon: "unisat-icon", installed: true };
+
+describe("resolveDisplayWallets", () => {
+  it("falls back to the connector's installed wallet when selectedWallets is missing the chain", () => {
+    // The reported bug: ETH connected (address present) but selectedWallets.ETH
+    // was missed on refresh — the icon must still resolve from the connector.
+    const result = resolveDisplayWallets({
+      selectedWallets: { BTC: { name: "UniSat", icon: "unisat-icon" } },
+      btcConnected: true,
+      ethConnected: true,
+      btcConnector: connector([UNISAT]),
+      ethConnector: connector([APPKIT]),
+    });
+
+    expect(result["ETH"]).toEqual({ name: "AppKit", icon: "appkit-icon" });
+    expect(result["BTC"]).toEqual({ name: "UniSat", icon: "unisat-icon" });
+  });
+
+  it("prefers selectedWallets metadata over the connector fallback", () => {
+    const result = resolveDisplayWallets({
+      selectedWallets: { ETH: { name: "MetaMask", icon: "metamask-icon" } },
+      btcConnected: false,
+      ethConnected: true,
+      btcConnector: null,
+      ethConnector: connector([APPKIT]),
+    });
+
+    expect(result["ETH"]).toEqual({ name: "MetaMask", icon: "metamask-icon" });
+  });
+
+  it("uses connectedWallet before scanning installed wallets", () => {
+    const connected = {
+      name: "Connected",
+      icon: "connected-icon",
+      installed: true,
+    };
+    const result = resolveDisplayWallets({
+      selectedWallets: {},
+      btcConnected: false,
+      ethConnected: true,
+      btcConnector: null,
+      ethConnector: connector([APPKIT], connected),
+    });
+
+    expect(result["ETH"]).toEqual({
+      name: "Connected",
+      icon: "connected-icon",
+    });
+  });
+
+  it("omits a chain whose provider is not connected even if a wallet is resolvable", () => {
+    const result = resolveDisplayWallets({
+      selectedWallets: { ETH: { name: "AppKit", icon: "appkit-icon" } },
+      btcConnected: false,
+      ethConnected: false,
+      btcConnector: connector([UNISAT]),
+      ethConnector: connector([APPKIT]),
+    });
+
+    expect(result).toEqual({});
+  });
+
+  it("omits a connected chain when nothing is resolvable", () => {
+    const result = resolveDisplayWallets({
+      selectedWallets: {},
+      btcConnected: true,
+      ethConnected: false,
+      // No connector and no selected wallet → cannot resolve an icon.
+      btcConnector: null,
+      ethConnector: null,
+    });
+
+    expect(result).toEqual({});
+  });
+
+  it("ignores a not-installed wallet in the connector fallback", () => {
+    const result = resolveDisplayWallets({
+      selectedWallets: {},
+      btcConnected: true,
+      ethConnected: false,
+      btcConnector: connector([
+        { name: "UniSat", icon: "unisat-icon", installed: false },
+      ]),
+      ethConnector: null,
+    });
+
+    expect(result).toEqual({});
+  });
+});

--- a/services/vault/src/components/Wallet/resolveDisplayWallets.ts
+++ b/services/vault/src/components/Wallet/resolveDisplayWallets.ts
@@ -1,0 +1,83 @@
+/**
+ * Resolve the wallet metadata (name + icon) used to render the connected-wallet
+ * avatars in the header and the wallet menu.
+ *
+ * The header/menu connection state and addresses come from the provider hooks
+ * (`useBTCWallet` / `useETHWallet`), but the icon historically came only from
+ * the connector's `selectedWallets` widget state. On a page refresh the provider
+ * address can be restored a tick before (or without) `selectedWallets[chain]`
+ * being repopulated by the connector's `connect` event — so the address shows
+ * while the icon goes blank. To keep the icon aligned with the real connection
+ * state, fall back through progressively more stable sources:
+ *   1. `selectedWallets[chain]` — the live widget selection (best, has the exact wallet)
+ *   2. `connector.connectedWallet` — the connector's own connected wallet
+ *   3. `connector.wallets.find(installed)` — the installed wallet metadata
+ *      (stable: ETH only exposes AppKit; the vault only enables UniSat for BTC)
+ *
+ * A chain is only included when its provider reports connected, so we never show
+ * an icon for a wallet that isn't actually connected.
+ */
+
+interface WalletDisplayMeta {
+  name: string;
+  icon: string;
+}
+
+/** Minimal shape we read off an `IWallet` — keeps this helper test-friendly. */
+interface WalletLike {
+  name: string;
+  icon: string;
+  installed: boolean;
+}
+
+/** Minimal shape we read off a chain `WalletConnector`. */
+interface ConnectorLike {
+  connectedWallet: WalletLike | null;
+  wallets: WalletLike[];
+}
+
+function resolveChainWallet(
+  selected: { name: string; icon: string } | undefined,
+  connector: ConnectorLike | null | undefined,
+): WalletDisplayMeta | undefined {
+  const wallet =
+    selected ??
+    connector?.connectedWallet ??
+    connector?.wallets.find((w) => w.installed);
+
+  return wallet ? { name: wallet.name, icon: wallet.icon } : undefined;
+}
+
+export interface ResolveDisplayWalletsParams {
+  selectedWallets: Record<string, { name: string; icon: string } | undefined>;
+  btcConnected: boolean;
+  ethConnected: boolean;
+  btcConnector: ConnectorLike | null | undefined;
+  ethConnector: ConnectorLike | null | undefined;
+}
+
+/**
+ * Build the display map keyed by chain ("BTC" / "ETH"). Only connected chains
+ * with a resolvable wallet are included.
+ */
+export function resolveDisplayWallets({
+  selectedWallets,
+  btcConnected,
+  ethConnected,
+  btcConnector,
+  ethConnector,
+}: ResolveDisplayWalletsParams): Record<string, WalletDisplayMeta> {
+  const result: Record<string, WalletDisplayMeta> = {};
+
+  if (btcConnected) {
+    const btc = resolveChainWallet(selectedWallets["BTC"], btcConnector);
+    if (btc) result["BTC"] = btc;
+  }
+
+  if (ethConnected) {
+    const eth = resolveChainWallet(selectedWallets["ETH"], ethConnector);
+    if (eth) result["ETH"] = eth;
+  }
+
+  return result;
+}

--- a/services/vault/src/context/wallet/VaultWalletConnectionProvider.tsx
+++ b/services/vault/src/context/wallet/VaultWalletConnectionProvider.tsx
@@ -4,6 +4,7 @@ import {
   ETHWalletProvider,
   WalletProvider,
   createWalletConfig,
+  useChainConnector,
   useWalletConnect,
 } from "@babylonlabs-io/wallet-connector";
 import { useTheme } from "next-themes";
@@ -49,15 +50,33 @@ const context = typeof window !== "undefined" ? window : {};
 // reconnect arrives within the window we cancel, otherwise the disconnect is
 // real and we proceed. A real disconnect is therefore honoured, just delayed by
 // this bounded amount — never dropped.
-const BTC_DISCONNECT_DEBOUNCE_MS = 1500;
+//
+// The window has to outlast a slow Unisat wake-up + auto-reconnect handshake
+// (which is fire-and-forget on reload and can take up to the provider's RPC
+// timeout). 1500ms was shorter than that handshake, so a slow extension wake
+// was being treated as a real disconnect and wiped both wallets. The
+// `hasBtcConnectedRef` gate and verify-before-reset check below are the real
+// guards; this timer is only defence-in-depth.
+const BTC_DISCONNECT_DEBOUNCE_MS = 3000;
 
 /**
  * Component that provides wallet-specific providers with cross-disconnect logic
  */
 function WalletProviders({ children }: PropsWithChildren) {
   const { disconnect: disconnectAll } = useWalletConnect();
+  // Live BTC connector so the deferred reset can re-check the real connection
+  // state at fire time (see scheduleBtcReset). Kept in a ref so the debounced
+  // callbacks don't need to be re-created when the connector identity bumps.
+  const btcConnector = useChainConnector("BTC");
+  const btcConnectorRef = useRef(btcConnector);
+  btcConnectorRef.current = btcConnector;
   // Guard against re-entrancy when disconnectAll triggers disconnect events
   const isDisconnectingRef = useRef(false);
+  // Whether BTC has successfully connected at least once this session. A
+  // disconnect before the first successful connect is, by definition, a
+  // startup/reconnect blip — there is no live session to tear down — so we
+  // never escalate it to disconnectAll() (which would wipe BOTH wallets).
+  const hasBtcConnectedRef = useRef(false);
   // Pending debounced BTC reset (see BTC_DISCONNECT_DEBOUNCE_MS).
   const pendingBtcResetRef = useRef<ReturnType<typeof setTimeout> | undefined>(
     undefined,
@@ -82,17 +101,35 @@ function WalletProviders({ children }: PropsWithChildren) {
   // events disconnectAll() itself emits don't re-arm the timer.
   const scheduleBtcReset = useCallback(() => {
     if (isDisconnectingRef.current) return;
+    // A disconnect before BTC ever finished connecting this session is a
+    // startup/reconnect blip, not a real disconnect — there is no live session
+    // to tear down. Escalating it would wipe the persisted session for BOTH
+    // wallets (including ETH) over a wallet that simply hasn't woken up yet.
+    if (!hasBtcConnectedRef.current) return;
     if (pendingBtcResetRef.current !== undefined)
       clearTimeout(pendingBtcResetRef.current);
     pendingBtcResetRef.current = setTimeout(() => {
       pendingBtcResetRef.current = undefined;
+      // Verify-before-reset: the connector's reconnect handshake can complete
+      // (connectedWallet set) before the BTCWalletProvider finishes re-deriving
+      // the address and fires onConnect/cancelBtcReset. If the connector is in
+      // fact connected again, the disconnect was a blip — don't wipe.
+      if (btcConnectorRef.current?.connectedWallet) {
+        logger.info(
+          "Suppressed transient BTC disconnect (connector reconnected before reset fired)",
+          { category: "Wallet connection" },
+        );
+        return;
+      }
       void runWalletReset();
     }, BTC_DISCONNECT_DEBOUNCE_MS);
   }, [runWalletReset]);
 
-  // BTC (re)connected. If a reset is pending, the preceding disconnect was a
-  // transient blip — cancel it and keep both wallets connected.
+  // BTC (re)connected. Mark the session as having connected at least once, and
+  // if a reset is pending, the preceding disconnect was a transient blip —
+  // cancel it and keep both wallets connected.
   const cancelBtcReset = useCallback(() => {
+    hasBtcConnectedRef.current = true;
     if (pendingBtcResetRef.current === undefined) return;
     clearTimeout(pendingBtcResetRef.current);
     pendingBtcResetRef.current = undefined;

--- a/services/vault/src/context/wallet/VaultWalletConnectionProvider.tsx
+++ b/services/vault/src/context/wallet/VaultWalletConnectionProvider.tsx
@@ -4,7 +4,6 @@ import {
   ETHWalletProvider,
   WalletProvider,
   createWalletConfig,
-  useChainConnector,
   useWalletConnect,
 } from "@babylonlabs-io/wallet-connector";
 import { useTheme } from "next-themes";
@@ -55,8 +54,8 @@ const context = typeof window !== "undefined" ? window : {};
 // (which is fire-and-forget on reload and can take up to the provider's RPC
 // timeout). 1500ms was shorter than that handshake, so a slow extension wake
 // was being treated as a real disconnect and wiped both wallets. The
-// `hasBtcConnectedRef` gate and verify-before-reset check below are the real
-// guards; this timer is only defence-in-depth.
+// `hasBtcConnectedRef` gate (below) is the primary guard against startup blips;
+// this debounce + cancelBtcReset cover post-connect wake-up blips.
 const BTC_DISCONNECT_DEBOUNCE_MS = 3000;
 
 /**
@@ -64,12 +63,6 @@ const BTC_DISCONNECT_DEBOUNCE_MS = 3000;
  */
 function WalletProviders({ children }: PropsWithChildren) {
   const { disconnect: disconnectAll } = useWalletConnect();
-  // Live BTC connector so the deferred reset can re-check the real connection
-  // state at fire time (see scheduleBtcReset). Kept in a ref so the debounced
-  // callbacks don't need to be re-created when the connector identity bumps.
-  const btcConnector = useChainConnector("BTC");
-  const btcConnectorRef = useRef(btcConnector);
-  btcConnectorRef.current = btcConnector;
   // Guard against re-entrancy when disconnectAll triggers disconnect events
   const isDisconnectingRef = useRef(false);
   // Whether BTC has successfully connected at least once this session. A
@@ -110,17 +103,13 @@ function WalletProviders({ children }: PropsWithChildren) {
       clearTimeout(pendingBtcResetRef.current);
     pendingBtcResetRef.current = setTimeout(() => {
       pendingBtcResetRef.current = undefined;
-      // Verify-before-reset: the connector's reconnect handshake can complete
-      // (connectedWallet set) before the BTCWalletProvider finishes re-deriving
-      // the address and fires onConnect/cancelBtcReset. If the connector is in
-      // fact connected again, the disconnect was a blip — don't wipe.
-      if (btcConnectorRef.current?.connectedWallet) {
-        logger.info(
-          "Suppressed transient BTC disconnect (connector reconnected before reset fired)",
-          { category: "Wallet connection" },
-        );
-        return;
-      }
+      // A reconnect within the window cancels this timer via cancelBtcReset
+      // (fired from the provider's onConnect). If we get here, no reconnect
+      // arrived — treat it as a real disconnect. We deliberately do NOT consult
+      // the connector's `connectedWallet` as a liveness signal: an
+      // extension-initiated disconnect tears down BTCWalletProvider without
+      // calling connector.disconnect(), so `connectedWallet` stays stale-set
+      // and would wrongly suppress a genuine disconnect.
       void runWalletReset();
     }, BTC_DISCONNECT_DEBOUNCE_MS);
   }, [runWalletReset]);

--- a/services/vault/src/context/wallet/__tests__/VaultWalletConnectionProvider.test.tsx
+++ b/services/vault/src/context/wallet/__tests__/VaultWalletConnectionProvider.test.tsx
@@ -11,9 +11,6 @@ type BtcCallbacks = { onConnect: () => void; onDisconnect: () => void };
 
 const h = vi.hoisted(() => ({
   disconnectAll: vi.fn(async () => {}),
-  // Mutable BTC connector whose connectedWallet the verify-before-reset check
-  // reads at timer-fire time.
-  btcConnector: { connectedWallet: null as unknown },
   captured: { btc: undefined as undefined | BtcCallbacks },
 }));
 
@@ -32,7 +29,6 @@ vi.mock("@babylonlabs-io/wallet-connector", () => ({
   },
   ETHWalletProvider: ({ children }: { children: React.ReactNode }) => children,
   createWalletConfig: () => ({}),
-  useChainConnector: () => h.btcConnector,
   useWalletConnect: () => ({ disconnect: h.disconnectAll }),
 }));
 
@@ -57,7 +53,6 @@ describe("WalletConnectionProvider — BTC disconnect-blip guard", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     h.disconnectAll.mockClear();
-    h.btcConnector.connectedWallet = null;
     h.captured.btc = undefined;
   });
 
@@ -79,8 +74,11 @@ describe("WalletConnectionProvider — BTC disconnect-blip guard", () => {
     renderProvider();
 
     act(() => btc().onConnect());
+    // No reconnect (onConnect) within the window → a real disconnect. The reset
+    // must fire purely on the absence of a reconnect — it must NOT consult the
+    // connector's connectedWallet (an extension-initiated disconnect leaves that
+    // stale-set, which would wrongly suppress the cascade).
     act(() => btc().onDisconnect());
-    // No reconnect and the connector stays disconnected → real disconnect.
     await vi.advanceTimersByTimeAsync(PAST_DEBOUNCE_MS);
 
     expect(h.disconnectAll).toHaveBeenCalledTimes(1);
@@ -92,19 +90,6 @@ describe("WalletConnectionProvider — BTC disconnect-blip guard", () => {
     act(() => btc().onConnect());
     act(() => btc().onDisconnect());
     act(() => btc().onConnect()); // reconnect blip resolved
-    await vi.advanceTimersByTimeAsync(PAST_DEBOUNCE_MS);
-
-    expect(h.disconnectAll).not.toHaveBeenCalled();
-  });
-
-  it("cancels the reset when the connector reconnected before the timer fires", async () => {
-    renderProvider();
-
-    act(() => btc().onConnect());
-    act(() => btc().onDisconnect());
-    // Connector handshake completed (connectedWallet set) but the provider
-    // hasn't fired onConnect yet — verify-before-reset must catch this.
-    h.btcConnector.connectedWallet = { id: "unisat" };
     await vi.advanceTimersByTimeAsync(PAST_DEBOUNCE_MS);
 
     expect(h.disconnectAll).not.toHaveBeenCalled();

--- a/services/vault/src/context/wallet/__tests__/VaultWalletConnectionProvider.test.tsx
+++ b/services/vault/src/context/wallet/__tests__/VaultWalletConnectionProvider.test.tsx
@@ -1,0 +1,112 @@
+import { act, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { WalletConnectionProvider } from "../VaultWalletConnectionProvider";
+
+// Drive the BTC lifecycle callbacks that VaultWalletConnectionProvider passes
+// into BTCWalletProvider, and observe whether the destructive disconnectAll()
+// cascade fires. We mock the wallet-connector module so the test exercises the
+// real blip-guard logic against a controllable connect/disconnect event stream.
+type BtcCallbacks = { onConnect: () => void; onDisconnect: () => void };
+
+const h = vi.hoisted(() => ({
+  disconnectAll: vi.fn(async () => {}),
+  // Mutable BTC connector whose connectedWallet the verify-before-reset check
+  // reads at timer-fire time.
+  btcConnector: { connectedWallet: null as unknown },
+  captured: { btc: undefined as undefined | BtcCallbacks },
+}));
+
+vi.mock("@babylonlabs-io/wallet-connector", () => ({
+  APPKIT_BTC_CONNECTOR_ID: "appkit_btc",
+  WalletProvider: ({ children }: { children: React.ReactNode }) => children,
+  BTCWalletProvider: ({
+    children,
+    callbacks,
+  }: {
+    children: React.ReactNode;
+    callbacks: BtcCallbacks;
+  }) => {
+    h.captured.btc = callbacks;
+    return children;
+  },
+  ETHWalletProvider: ({ children }: { children: React.ReactNode }) => children,
+  createWalletConfig: () => ({}),
+  useChainConnector: () => h.btcConnector,
+  useWalletConnect: () => ({ disconnect: h.disconnectAll }),
+}));
+
+vi.mock("next-themes", () => ({ useTheme: () => ({ theme: "light" }) }));
+vi.mock("@/config/featureFlags", () => ({
+  default: { isSimplifiedTermsEnabled: false },
+}));
+vi.mock("@/infrastructure", () => ({
+  logger: { info: vi.fn(), error: vi.fn() },
+}));
+
+// Must stay in sync with BTC_DISCONNECT_DEBOUNCE_MS in the provider; advancing
+// past it is what would trigger the reset if the guard let it through.
+const PAST_DEBOUNCE_MS = 5000;
+
+const renderProvider = () =>
+  render(<WalletConnectionProvider>child</WalletConnectionProvider>);
+
+const btc = () => h.captured.btc as BtcCallbacks;
+
+describe("WalletConnectionProvider — BTC disconnect-blip guard", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    h.disconnectAll.mockClear();
+    h.btcConnector.connectedWallet = null;
+    h.captured.btc = undefined;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("does not tear down both wallets for a disconnect before BTC ever connected", async () => {
+    renderProvider();
+
+    // Startup blip: a disconnect arrives before the first successful connect.
+    act(() => btc().onDisconnect());
+    await vi.advanceTimersByTimeAsync(PAST_DEBOUNCE_MS);
+
+    expect(h.disconnectAll).not.toHaveBeenCalled();
+  });
+
+  it("tears down both wallets for a genuine disconnect after a successful connect", async () => {
+    renderProvider();
+
+    act(() => btc().onConnect());
+    act(() => btc().onDisconnect());
+    // No reconnect and the connector stays disconnected → real disconnect.
+    await vi.advanceTimersByTimeAsync(PAST_DEBOUNCE_MS);
+
+    expect(h.disconnectAll).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels the reset when a reconnect arrives within the debounce window", async () => {
+    renderProvider();
+
+    act(() => btc().onConnect());
+    act(() => btc().onDisconnect());
+    act(() => btc().onConnect()); // reconnect blip resolved
+    await vi.advanceTimersByTimeAsync(PAST_DEBOUNCE_MS);
+
+    expect(h.disconnectAll).not.toHaveBeenCalled();
+  });
+
+  it("cancels the reset when the connector reconnected before the timer fires", async () => {
+    renderProvider();
+
+    act(() => btc().onConnect());
+    act(() => btc().onDisconnect());
+    // Connector handshake completed (connectedWallet set) but the provider
+    // hasn't fired onConnect yet — verify-before-reset must catch this.
+    h.btcConnector.connectedWallet = { id: "unisat" };
+    await vi.advanceTimersByTimeAsync(PAST_DEBOUNCE_MS);
+
+    expect(h.disconnectAll).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## The problem

Users reported that after refreshing the page, their wallets sometimes stayed connected and sometimes didn't:

- Sometimes **both** UniSat (BTC) and MetaMask/AppKit (ETH) dropped back to a **"Connect"** button.
- Sometimes only **one** came back — most often the modal showed **AppKit connected** while Bitcoin still said **"Select Bitcoin Wallet"**.
- And sometimes both wallets were genuinely connected (addresses shown) but the **ETH icon was missing** from the header and the wallet menu, while the BTC icon showed.

It was intermittent and hard to reproduce — some people hit it constantly, others almost never.

This is a follow-up to [#1722](https://github.com/babylonlabs-io/babylon-toolkit/pull/1722) and [#1729](https://github.com/babylonlabs-io/babylon-toolkit/pull/1729), which hardened the connection layer but didn't cover the reconnect-on-refresh races below.

## Why it happened

On every refresh the app rebuilds the "are we connected?" state from scratch, from **two independent systems** that each restore at their own speed: BTC (UniSat) and ETH (wagmi/AppKit). The header only shows the wallet icons when **both** report an address, so whichever one loses the timing race leaves you looking at "Connect". We found four separate causes, all timing-dependent (which is why it was intermittent):

1. **A brief BTC hiccup wiped *both* wallets.** Right after a refresh, the UniSat extension can blink "disconnected" for a moment while it wakes up. The app waited 1.5s for it to come back, and if it didn't, it disconnected **everything** and erased the saved session — including the perfectly healthy ETH wallet. On a slow machine the extension often took longer than 1.5s to wake, so a harmless blink turned into "both gone."

2. **ETH didn't re-link after a late wake-up.** ETH relies on wagmi restoring the session from a cookie. The app checked for that **once**, very early. If wagmi finished restoring a moment later, the app never noticed — so AppKit knew the address internally (the modal showed it) but the app still showed "Connect".

3. **BTC didn't restore if UniSat loaded late.** UniSat injects itself into the page a little late. If the app's first scan ran before that, UniSat was marked "not installed", and the later re-scan that fixed the detection **did not** restore the saved session. Result: ETH reconnected, BTC didn't — the most common report.

4. **The wallet icon came from a different source than the connection state.** The header/menu read the wallet **address** from the live connection, but read the **icon** from separate "selected wallet" UI state that's rebuilt by reconnect events. On refresh that UI state could lag for a moment, so the address showed while the icon was blank — an ETH wallet that's connected but iconless.

## What we changed

**1. A momentary BTC blip can no longer disconnect everything.**
The app now treats the moments right after a refresh as a "still restoring" phase. It will only do the disconnect-everything cleanup for a **real** user-initiated disconnect — never for a wallet that simply hasn't finished waking up. (Implementation: don't run the cleanup before BTC has connected at least once this session; double-check BTC is genuinely gone right before cleaning up; and give the extension a bit more time.)
File: `services/vault/src/context/wallet/VaultWalletConnectionProvider.tsx`

**2. ETH now re-links when wagmi finishes restoring late.**
Instead of checking only once, the app listens for the moment the ETH account appears and routes it through the normal connect flow — which fills in the connection state and the wallet icon. This is silent when the wallet is already connected (it never re-opens the wallet popup).
File: `packages/babylon-wallet-connector/src/providers/ETHWalletProvider.tsx`

**3. BTC now restores the saved session after a late UniSat detection.**
When the late re-scan finds UniSat, and we have a saved "you were connected with UniSat" record, the app reconnects it automatically. It only does this on automatic page-load triggers (not when the user is actively picking a wallet in the modal), so **it can't interrupt a manual connect or pop up a duplicate prompt**.
Files: `packages/babylon-wallet-connector/src/hooks/useWalletRedetection.ts`, `packages/babylon-wallet-connector/src/hooks/redetectReconnect.ts` (new), `packages/babylon-wallet-connector/src/context/Chain.context.tsx`

**4. The wallet icon now follows the connection state.**
Instead of taking the icon only from the volatile "selected wallet" UI state, the header and menu now resolve it from the first available of: the selected wallet → the connector's connected wallet → the connector's installed wallet — and only when the provider actually reports that chain connected. So if a wallet is connected, its icon always renders; if it isn't, no icon is shown. This fixes both the header avatars and the menu rows.
Files: `services/vault/src/components/Wallet/resolveDisplayWallets.ts` (new), `services/vault/src/components/Wallet/Connect.tsx`

## Approaches we considered, and why we picked these

- **Blip handling — bigger timeout vs. a "still restoring" rule.** Just making the 1.5s wait longer would only move the problem (a slow-enough wake still loses). Instead we made it a *rule*: a wallet that never finished its first connect can't be "really disconnected," so we never wipe both wallets over it. The timeout is now just a backstop, not the real guard. This also keeps the saved session, so even a failed restore recovers on the next refresh instead of forcing a from-scratch reconnect.

- **ETH — wait/poll vs. listen for the event.** We chose to listen for wagmi's "account appeared" event and run it through the existing connect path, rather than polling or just setting an address. The key point: simply setting the address wouldn't restore the wallet icon and selection state — going through the real connect flow does.

- **BTC restore — reconnect on every re-scan vs. only on page-load triggers.** Reconnecting on *every* re-scan (including when the user opens the wallet modal) risked racing the user's own click and showing a duplicate UniSat prompt. So we restore the session only on the automatic page-load triggers, where the modal is closed and there's nothing to race. If the user opens the picker mid-restore, they still get a normal one-click connect.

- **Icon — fix the source vs. add a display fallback.** Fixes 1–3 reduce how often the "selected wallet" UI state lags, but two independent state sources can always drift for a tick. Rather than try to make that state perfect, we made the header/menu *derive* the icon from the connection state with a fallback chain. We deliberately did **not** persist wallet objects to disk (they carry live provider functions — wrong to serialize), and we kept the fix in the vault UI (lowest risk) rather than the shared connector.

## What this does *not* change (intentionally)

- **Wallet modal internal state** isn't persisted across refresh. We confirmed the app doesn't rely on it for connection truth — the header uses the live wallet addresses, and the icon now falls back to connector metadata (fix 4) — so there was nothing to persist.
- **The 1-hour BTC session expiry** is left as-is. If you leave a tab open for over an hour and refresh, BTC may ask you to reconnect while ETH (which expires on its own, longer schedule) stays connected. That's expected session expiry, not the bug above.
- **Multiple BTC wallets.** The icon fallback (fix 4) picks the first *installed* wallet as a last resort, which is unambiguous today because the vault only enables UniSat for BTC. If multiple BTC wallets are ever enabled, that last-resort step needs a deterministic wallet-id preference — tracked separately in https://github.com/babylonlabs-io/babylon-toolkit/issues/1747
## Notes for reviewers

- These changes are **connection-lifecycle/UI only** — no transaction values, signing, or secret derivation are touched.
- Fixes 1–3 live (mostly) in the shared `babylon-wallet-connector` package. Fix 4 is vault-only.
- **Behavior to verify manually** (hard to cover in automated tests): connect both wallets, then in DevTools throttle CPU 6× and refresh repeatedly. Both should reconnect on their own; at worst one is missing but the saved session is never wiped (next refresh recovers); opening the wallet modal mid-restore must not show a duplicate UniSat prompt; and whenever an address is shown its wallet icon must render too.

## Testing

- New unit tests: the BTC blip guard (vault), the BTC session-restore decision (wallet-connector), and the icon resolver (vault).
- Full suites pass: vault **1386 passed**, wallet-connector **138 unit tests passed**. Type-check and lint clean.

## Files changed

- `services/vault/src/context/wallet/VaultWalletConnectionProvider.tsx` (+ test) — fix 1
- `packages/babylon-wallet-connector/src/providers/ETHWalletProvider.tsx` — fix 2
- `packages/babylon-wallet-connector/src/hooks/useWalletRedetection.ts`, `.../hooks/redetectReconnect.ts` (new, + test), `.../context/Chain.context.tsx` — fix 3
- `services/vault/src/components/Wallet/resolveDisplayWallets.ts` (new, + test), `.../components/Wallet/Connect.tsx` — fix 4
