### PR TITLE
feat(vault): distinguish BTC-wait from VP-ingestion-stall via mempool…

### DIFF
--- a/services/vault/src/clients/btc/confirmations.ts
+++ b/services/vault/src/clients/btc/confirmations.ts
@@ -1,0 +1,30 @@
+/**
+ * Mempool-API confirmation helper, shared by the dashboard batch poller
+ * (`usePrePeginMempoolConfirmations`) and the in-flow single-tx poller
+ * (`useBtcConfirmations`). Centralizing keeps the two in sync if the
+ * mempool call shape ever changes — both callers compute the same number
+ * for the same `(txid, tipHeight)`.
+ */
+
+import { stripHexPrefix } from "@babylonlabs-io/ts-sdk/tbv/core";
+import { getTxInfo } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
+
+import { computeConfirmations } from "@/components/simple/DepositProgressView/btcConfirmationProgress";
+
+/**
+ * Fetches the tx from `apiUrl` and returns its confirmation count relative
+ * to `tipHeight`. Mempool (unconfirmed) returns 0. The block that includes
+ * the tx is the 1st confirmation.
+ *
+ * Callers handle errors (404 before broadcast, 429 rate-limits, network
+ * blips) at their layer — this helper deliberately does not swallow them
+ * so each caller can choose the right fallback for its UX.
+ */
+export async function fetchConfirmations(
+  txid: string,
+  apiUrl: string,
+  tipHeight: number,
+): Promise<number> {
+  const info = await getTxInfo(stripHexPrefix(txid), apiUrl);
+  return computeConfirmations(info.status, tipHeight);
+}

--- a/services/vault/src/components/simple/DepositProgressView/__tests__/DepositProgressView.test.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/__tests__/DepositProgressView.test.tsx
@@ -50,7 +50,7 @@ describe("DepositProgressView", () => {
     });
 
     it("expands only the section containing the current step", () => {
-      // Step 7 lives in the "Set up claim" group.
+      // SUBMIT_WOTS_KEYS lives in the "Set up claim" group.
       render(
         <DepositProgressView
           {...baseProps}
@@ -73,9 +73,9 @@ describe("DepositProgressView", () => {
         screen.queryByText(COPY.deposit.steps.signPayouts),
       ).not.toBeInTheDocument();
 
-      // The finished "Register deposit" group reports 6/6.
+      // The finished "Register deposit" group reports 7/7.
       expect(
-        screen.getByText(COPY.deposit.groups.stepCounter(6, 6)),
+        screen.getByText(COPY.deposit.groups.stepCounter(7, 7)),
       ).toBeInTheDocument();
     });
   });
@@ -130,7 +130,7 @@ describe("DepositProgressView", () => {
       );
 
       expect(
-        screen.getByText(COPY.deposit.progress.stepsCompleted(5, 16)),
+        screen.getByText(COPY.deposit.progress.stepsCompleted(5, 17)),
       ).toBeInTheDocument();
     });
 
@@ -153,8 +153,9 @@ describe("DepositProgressView", () => {
         />,
       );
 
+      // AWAIT_BTC_CONFIRMATION is visual step 6 → 5 of 17 completed → 29%.
       const bar = screen.getByRole("progressbar");
-      expect(bar).toHaveAttribute("aria-valuenow", "31");
+      expect(bar).toHaveAttribute("aria-valuenow", "29");
       expect(bar).toHaveAttribute("aria-valuemax", "100");
     });
 
@@ -329,7 +330,7 @@ describe("DepositProgressView", () => {
       );
 
       expect(
-        screen.getByText(COPY.deposit.groups.stepCounter(6, 6)),
+        screen.getByText(COPY.deposit.groups.stepCounter(7, 7)),
       ).toBeInTheDocument();
       expect(
         screen.getAllByText(COPY.deposit.groups.stepCounter(4, 4)),
@@ -354,7 +355,7 @@ describe("DepositProgressView", () => {
       );
 
       expect(
-        screen.getByText(COPY.deposit.groups.stepCounter(6, 6)),
+        screen.getByText(COPY.deposit.groups.stepCounter(7, 7)),
       ).toBeInTheDocument();
       expect(screen.getByRole("progressbar")).toHaveAttribute(
         "aria-valuenow",

--- a/services/vault/src/components/simple/DepositProgressView/__tests__/GroupedProgress.test.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/__tests__/GroupedProgress.test.tsx
@@ -25,8 +25,8 @@ describe("GroupedProgress", () => {
   });
 
   it("expands only the active group and hides other groups' sub-steps", () => {
-    // Step 7 -> "Set up claim" group is active.
-    render(<GroupedProgress steps={steps} currentStep={7} />);
+    // Step 8 -> "Set up claim" group (8-9) is active.
+    render(<GroupedProgress steps={steps} currentStep={8} />);
 
     // Active group sub-step is visible.
     expect(
@@ -38,35 +38,35 @@ describe("GroupedProgress", () => {
       screen.queryByText(COPY.deposit.steps.generateSecret),
     ).not.toBeInTheDocument();
 
-    // An upcoming group's sub-step (step 10) stays collapsed.
+    // An upcoming group's sub-step (Sign payouts) stays collapsed.
     expect(
       screen.queryByText(COPY.deposit.steps.signPayouts),
     ).not.toBeInTheDocument();
   });
 
   it("shows the per-group completed counter on a finished group", () => {
-    render(<GroupedProgress steps={steps} currentStep={7} />);
+    render(<GroupedProgress steps={steps} currentStep={8} />);
 
-    // Register deposit (steps 1-6) is fully done.
+    // Register deposit (steps 1-7) is fully done.
     expect(
-      screen.getByText(COPY.deposit.groups.stepCounter(6, 6)),
+      screen.getByText(COPY.deposit.groups.stepCounter(7, 7)),
     ).toBeInTheDocument();
   });
 
   it("renders completed sub-steps without a step number inside the active group", () => {
-    // Step 10 -> "Sign payout" group (9-12) active; step 9 is already done.
-    render(<GroupedProgress steps={steps} currentStep={10} />);
+    // Step 11 -> "Sign payout" group (10-13) active; step 10 is already done.
+    render(<GroupedProgress steps={steps} currentStep={11} />);
 
     // Completed sub-step label is shown...
     expect(
       screen.getByText(COPY.deposit.steps.authenticateSession),
     ).toBeInTheDocument();
-    // ...but rendered as a checkmark row, not the numbered pending row "9".
-    expect(screen.queryByText("9")).not.toBeInTheDocument();
+    // ...but rendered as a checkmark row, not the numbered pending row "10".
+    expect(screen.queryByText("10")).not.toBeInTheDocument();
 
     // Pending sub-steps still carry their global numbers.
-    expect(screen.getByText("11")).toBeInTheDocument();
     expect(screen.getByText("12")).toBeInTheDocument();
+    expect(screen.getByText("13")).toBeInTheDocument();
   });
 
   it("mounts the active-step detail panel inside the active step", () => {
@@ -91,9 +91,9 @@ describe("GroupedProgress", () => {
     expect(
       screen.queryByText(COPY.deposit.steps.generateSecret),
     ).not.toBeInTheDocument();
-    // Every group reports itself fully complete (6/6, 2/2, 4/4, 4/4).
+    // Every group reports itself fully complete (7/7, 2/2, 4/4, 4/4).
     expect(
-      screen.getByText(COPY.deposit.groups.stepCounter(6, 6)),
+      screen.getByText(COPY.deposit.groups.stepCounter(7, 7)),
     ).toBeInTheDocument();
     expect(
       screen.getByText(COPY.deposit.groups.stepCounter(2, 2)),
@@ -105,16 +105,16 @@ describe("GroupedProgress", () => {
 
   describe("accessibility", () => {
     it("labels the active sub-step for screen readers", () => {
-      // Step 7 -> "Set up claim" group active; step 7 is the active sub-step.
-      render(<GroupedProgress steps={steps} currentStep={7} />);
+      // Step 8 -> "Set up claim" group active; step 8 is the active sub-step.
+      render(<GroupedProgress steps={steps} currentStep={8} />);
 
       expect(
-        screen.getByLabelText(COPY.deposit.a11y.stepActive(7)),
+        screen.getByLabelText(COPY.deposit.a11y.stepActive(8)),
       ).toBeInTheDocument();
     });
 
     it("exposes each group's status to screen readers", () => {
-      render(<GroupedProgress steps={steps} currentStep={7} />);
+      render(<GroupedProgress steps={steps} currentStep={8} />);
 
       // Register deposit done, Set up claim active, the latter two not started.
       expect(

--- a/services/vault/src/components/simple/DepositProgressView/__tests__/steps.test.ts
+++ b/services/vault/src/components/simple/DepositProgressView/__tests__/steps.test.ts
@@ -64,25 +64,36 @@ describe("getStepLabel", () => {
     );
   });
 
+  it("inserts AWAIT_VP_INGESTION right after AWAIT_BTC_CONFIRMATION", () => {
+    expect(getVisualStep(DepositFlowStep.AWAIT_BTC_CONFIRMATION)).toBe(6);
+    expect(getVisualStep(DepositFlowStep.AWAIT_VP_INGESTION)).toBe(7);
+  });
+
+  it("returns the VP-ingestion label for AWAIT_VP_INGESTION", () => {
+    expect(getStepLabel(DepositFlowStep.AWAIT_VP_INGESTION)).toBe(
+      COPY.deposit.steps.awaitVpIngestion,
+    );
+  });
+
   it("renumbers existing post-WOTS action steps after the payout wait", () => {
-    expect(getVisualStep(DepositFlowStep.SUBMIT_WOTS_KEYS)).toBe(7);
-    expect(getVisualStep(DepositFlowStep.AWAIT_PAYOUT_TRANSACTIONS)).toBe(8);
-    expect(getVisualStep(DepositFlowStep.SIGN_AUTH_ANCHOR)).toBe(9);
-    expect(getVisualStep(DepositFlowStep.SIGN_PAYOUTS)).toBe(10);
-    expect(getVisualStep(DepositFlowStep.SIGN_DEPOSITOR_GRAPH)).toBe(11);
-    expect(getVisualStep(DepositFlowStep.AWAIT_VP_VERIFICATION)).toBe(12);
-    expect(getVisualStep(DepositFlowStep.ARTIFACT_DOWNLOAD)).toBe(13);
-    expect(getVisualStep(DepositFlowStep.RETRIEVE_SECRET)).toBe(14);
-    expect(getVisualStep(DepositFlowStep.ACTIVATE_VAULT)).toBe(15);
+    expect(getVisualStep(DepositFlowStep.SUBMIT_WOTS_KEYS)).toBe(8);
+    expect(getVisualStep(DepositFlowStep.AWAIT_PAYOUT_TRANSACTIONS)).toBe(9);
+    expect(getVisualStep(DepositFlowStep.SIGN_AUTH_ANCHOR)).toBe(10);
+    expect(getVisualStep(DepositFlowStep.SIGN_PAYOUTS)).toBe(11);
+    expect(getVisualStep(DepositFlowStep.SIGN_DEPOSITOR_GRAPH)).toBe(12);
+    expect(getVisualStep(DepositFlowStep.AWAIT_VP_VERIFICATION)).toBe(13);
+    expect(getVisualStep(DepositFlowStep.ARTIFACT_DOWNLOAD)).toBe(14);
+    expect(getVisualStep(DepositFlowStep.RETRIEVE_SECRET)).toBe(15);
+    expect(getVisualStep(DepositFlowStep.ACTIVATE_VAULT)).toBe(16);
     expect(getVisualStep(DepositFlowStep.AWAIT_ACTIVATION_CONFIRMATION)).toBe(
-      16,
+      17,
     );
   });
 });
 
 describe("getStepFillPercent", () => {
   it("fills by completed steps, not the in-progress current step", () => {
-    // AWAIT_BTC_CONFIRMATION is visual step 6 -> 5 completed of 16.
+    // AWAIT_BTC_CONFIRMATION is visual step 6 -> 5 completed of TOTAL.
     expect(
       getStepFillPercent(DepositFlowStep.AWAIT_BTC_CONFIRMATION),
     ).toBeCloseTo(5 / TOTAL_VISUAL_STEPS);
@@ -143,10 +154,10 @@ describe("STEP_GROUPS", () => {
 
   it("groups the steps into the four expected sections", () => {
     expect(STEP_GROUPS.map((g) => [g.title, g.startStep, g.endStep])).toEqual([
-      [COPY.deposit.groups.registerDeposit, 1, 6],
-      [COPY.deposit.groups.signWots, 7, 8],
-      [COPY.deposit.groups.signPayout, 9, 12],
-      [COPY.deposit.groups.activateVault, 13, 16],
+      [COPY.deposit.groups.registerDeposit, 1, 7],
+      [COPY.deposit.groups.signWots, 8, 9],
+      [COPY.deposit.groups.signPayout, 10, 13],
+      [COPY.deposit.groups.activateVault, 14, 17],
     ]);
   });
 });
@@ -165,7 +176,7 @@ describe("buildStepGroups", () => {
     expect(register.status).toBe("active");
     expect(register.expanded).toBe(true);
     expect(register.completedInGroup).toBe(0);
-    expect(register.totalInGroup).toBe(6);
+    expect(register.totalInGroup).toBe(7);
 
     expect(wots.status).toBe("upcoming");
     expect(wots.expanded).toBe(false);
@@ -173,12 +184,12 @@ describe("buildStepGroups", () => {
     expect(activate.status).toBe("upcoming");
   });
 
-  it("marks earlier groups completed and activates the WOTS group at step 7", () => {
-    const [register, wots, payout] = buildStepGroups(7);
+  it("marks earlier groups completed and activates the WOTS group at step 8", () => {
+    const [register, wots, payout] = buildStepGroups(8);
 
     expect(register.status).toBe("completed");
     expect(register.expanded).toBe(false);
-    expect(register.completedInGroup).toBe(6);
+    expect(register.completedInGroup).toBe(7);
 
     expect(wots.status).toBe("active");
     expect(wots.expanded).toBe(true);
@@ -189,8 +200,8 @@ describe("buildStepGroups", () => {
   });
 
   it("counts completed sub-steps within the active group (mid-group resume)", () => {
-    // Step 12 is the last step of the Sign payout group (9..12): 3 done, 1 active.
-    const payout = buildStepGroups(12).find(
+    // Step 13 is the last step of the Sign payout group (10..13): 3 done, 1 active.
+    const payout = buildStepGroups(13).find(
       (g) => g.title === COPY.deposit.groups.signPayout,
     );
 

--- a/services/vault/src/components/simple/DepositProgressView/steps.ts
+++ b/services/vault/src/components/simple/DepositProgressView/steps.ts
@@ -36,6 +36,7 @@ export function buildStepItems(
     { label: COPY.deposit.steps.signAndBroadcastEth },
     { label: COPY.deposit.steps.signAndBroadcastPrePegin },
     { label: COPY.deposit.steps.awaitBtcConfirmation },
+    { label: COPY.deposit.steps.awaitVpIngestion },
     { label: COPY.deposit.steps.submitWotsKey },
     { label: COPY.deposit.steps.awaitPayoutTransactions },
     { label: COPY.deposit.steps.authenticateSession },
@@ -66,10 +67,10 @@ export interface StepGroup {
 }
 
 export const STEP_GROUPS: StepGroup[] = [
-  { title: COPY.deposit.groups.registerDeposit, startStep: 1, endStep: 6 },
-  { title: COPY.deposit.groups.signWots, startStep: 7, endStep: 8 },
-  { title: COPY.deposit.groups.signPayout, startStep: 9, endStep: 12 },
-  { title: COPY.deposit.groups.activateVault, startStep: 13, endStep: 16 },
+  { title: COPY.deposit.groups.registerDeposit, startStep: 1, endStep: 7 },
+  { title: COPY.deposit.groups.signWots, startStep: 8, endStep: 9 },
+  { title: COPY.deposit.groups.signPayout, startStep: 10, endStep: 13 },
+  { title: COPY.deposit.groups.activateVault, startStep: 14, endStep: 17 },
 ];
 
 export type GroupStatus = "completed" | "active" | "upcoming";
@@ -150,26 +151,28 @@ export function getVisualStep(currentStep: DepositFlowStep): number {
       return 5;
     case DepositFlowStep.AWAIT_BTC_CONFIRMATION:
       return 6;
-    case DepositFlowStep.SUBMIT_WOTS_KEYS:
+    case DepositFlowStep.AWAIT_VP_INGESTION:
       return 7;
-    case DepositFlowStep.AWAIT_PAYOUT_TRANSACTIONS:
+    case DepositFlowStep.SUBMIT_WOTS_KEYS:
       return 8;
-    case DepositFlowStep.SIGN_AUTH_ANCHOR:
+    case DepositFlowStep.AWAIT_PAYOUT_TRANSACTIONS:
       return 9;
-    case DepositFlowStep.SIGN_PAYOUTS:
+    case DepositFlowStep.SIGN_AUTH_ANCHOR:
       return 10;
-    case DepositFlowStep.SIGN_DEPOSITOR_GRAPH:
+    case DepositFlowStep.SIGN_PAYOUTS:
       return 11;
-    case DepositFlowStep.AWAIT_VP_VERIFICATION:
+    case DepositFlowStep.SIGN_DEPOSITOR_GRAPH:
       return 12;
-    case DepositFlowStep.ARTIFACT_DOWNLOAD:
+    case DepositFlowStep.AWAIT_VP_VERIFICATION:
       return 13;
-    case DepositFlowStep.RETRIEVE_SECRET:
+    case DepositFlowStep.ARTIFACT_DOWNLOAD:
       return 14;
-    case DepositFlowStep.ACTIVATE_VAULT:
+    case DepositFlowStep.RETRIEVE_SECRET:
       return 15;
-    case DepositFlowStep.AWAIT_ACTIVATION_CONFIRMATION:
+    case DepositFlowStep.ACTIVATE_VAULT:
       return 16;
+    case DepositFlowStep.AWAIT_ACTIVATION_CONFIRMATION:
+      return 17;
     case DepositFlowStep.COMPLETED:
       return TOTAL_VISUAL_STEPS + 1;
     default: {

--- a/services/vault/src/components/simple/__tests__/PendingDepositCard.test.tsx
+++ b/services/vault/src/components/simple/__tests__/PendingDepositCard.test.tsx
@@ -183,17 +183,17 @@ describe("PendingDepositCard — payout signing step number", () => {
     });
   });
 
-  it("shows step 9 (authenticate session) while it is still waiting to sign", () => {
+  it("shows the authenticate-session step while it is still waiting to sign", () => {
     // The deposit is resting before it acts. Clicking "Sign Payouts" runs the
-    // auth-anchor step (9) first, so the card sits on step 9 with that step's
-    // label — not step 10, which would imply the auth-anchor step is done. The
-    // action button still reads "Sign Payouts".
+    // auth-anchor step first, so the card sits on that step with that step's
+    // label — not the next one, which would imply the auth-anchor step is
+    // done. The action button still reads "Sign Payouts".
     mockUseDepositPollingResult.mockReturnValue({
       loading: false,
       peginState: readyToSignPayoutsState(),
     });
     renderCard(false);
-    expect(screen.getByText("Step 9 of 16")).toBeInTheDocument();
+    expect(screen.getByText("Step 10 of 17")).toBeInTheDocument();
     expect(
       screen.getByText(COPY.deposit.steps.authenticateSession),
     ).toBeInTheDocument();

--- a/services/vault/src/context/deposit/PeginPollingContext.tsx
+++ b/services/vault/src/context/deposit/PeginPollingContext.tsx
@@ -11,6 +11,7 @@
  * - Optimistic UI updates for immediate feedback
  */
 
+import { stripHexPrefix } from "@babylonlabs-io/ts-sdk/tbv/core";
 import {
   createContext,
   useCallback,
@@ -20,6 +21,7 @@ import {
 } from "react";
 
 import { usePeginPollingQuery } from "../../hooks/deposit/usePeginPollingQuery";
+import { usePrePeginMempoolConfirmations } from "../../hooks/deposit/usePrePeginMempoolConfirmations";
 import {
   ContractStatus,
   getPeginState,
@@ -32,6 +34,7 @@ import type {
 } from "../../types/peginPolling";
 import { isTerminalPollingError } from "../../utils/peginPolling";
 import { isVaultOwnedByWallet } from "../../utils/vaultWarnings";
+import { useProtocolParamsContext } from "../ProtocolParamsContext";
 
 /**
  * Resolve the effective local status for a deposit, accounting for
@@ -102,6 +105,20 @@ export function PeginPollingProvider({
     btcPublicKey,
   });
 
+  // Chain ground truth for "Pre-PegIn at protocol depth?" — independent of
+  // localStorage so a deposit doesn't get pinned on AWAIT_BTC_CONFIRMATION
+  // when BTC is already deep but the VP is still ingesting.
+  const { config, getOffchainParamsByVersion } = useProtocolParamsContext();
+  const pendingPrePeginTxids = useMemo(
+    () =>
+      activities
+        .filter((a) => (a.contractStatus ?? 0) === ContractStatus.PENDING)
+        .map((a) => a.peginTxHash),
+    [activities],
+  );
+  const { confirmationsByTxid: prePeginConfirmationsByTxid } =
+    usePrePeginMempoolConfirmations(pendingPrePeginTxids);
+
   // Optimistic status handlers
   const setOptimisticStatus = useCallback(
     (
@@ -168,12 +185,35 @@ export function PeginPollingProvider({
         ? false
         : (pendingDepositorSignatures?.has(depositId) ?? false);
 
+      // Each vault is pinned to a specific offchainParamsVersion at registration
+      // (matches the in-flow modal's behavior; see commit 5b7048e). The poller
+      // fetches raw confirmation counts; we apply the per-deposit depth here so
+      // a governance change to `minPrepeginDepth` never misclassifies older
+      // deposits. Falls back to latest if the version isn't on the activity
+      // (older indexer data) — same as not gating, which is the safe direction.
+      const versionedParams =
+        activity.offchainParamsVersion !== undefined
+          ? getOffchainParamsByVersion(activity.offchainParamsVersion)
+          : undefined;
+      const requiredDepth =
+        versionedParams?.minPrepeginDepth ??
+        config.offchainParams.minPrepeginDepth;
+
+      const confirmations = activity.peginTxHash
+        ? prePeginConfirmationsByTxid.get(
+            stripHexPrefix(activity.peginTxHash).toLowerCase(),
+          )
+        : undefined;
+      const prePeginBroadcastConfirmed =
+        confirmations !== undefined && confirmations >= requiredDepth;
+
       const peginState = getPeginState(contractStatus, {
         localStatus,
         transactionsReady,
         isInUse: activity.isInUse,
         needsWotsKey: needsWotsKey?.has(depositId),
         pendingIngestion: pendingIngestion?.has(depositId),
+        prePeginBroadcastConfirmed,
         expirationReason: activity.expirationReason,
         expiredAt: activity.expiredAt,
         canRefund: !!activity.unsignedPrePeginTx,
@@ -199,6 +239,9 @@ export function PeginPollingProvider({
       errors,
       needsWotsKey,
       pendingIngestion,
+      prePeginConfirmationsByTxid,
+      getOffchainParamsByVersion,
+      config.offchainParams.minPrepeginDepth,
       isLoading,
       optimisticStatuses,
       optimisticRefundBroadcastAt,

--- a/services/vault/src/context/deposit/__tests__/PeginPollingContext.test.tsx
+++ b/services/vault/src/context/deposit/__tests__/PeginPollingContext.test.tsx
@@ -26,6 +26,22 @@ vi.mock("../../../hooks/deposit/usePeginPollingQuery", () => ({
   usePeginPollingQuery: () => mockQueryResult,
 }));
 
+// The mempool-truth hook adds network polling and a ProtocolParamsContext
+// dependency neither of which this test cares about — stub both so the
+// provider is renderable in isolation.
+vi.mock("../../../hooks/deposit/usePrePeginMempoolConfirmations", () => ({
+  usePrePeginMempoolConfirmations: () => ({
+    confirmationsByTxid: new Map<string, number>(),
+  }),
+}));
+
+vi.mock("../../ProtocolParamsContext", () => ({
+  useProtocolParamsContext: () => ({
+    config: { offchainParams: { minPrepeginDepth: 6 } },
+    getOffchainParamsByVersion: () => undefined,
+  }),
+}));
+
 const ACTIVITY_ID = "0xpegin" as Hex;
 const BTC_PUBKEY = "ab".repeat(32);
 

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -71,6 +71,8 @@ export const COPY = {
         "Vault provider has prepared payout transactions. Click 'Sign Payouts' to pre-authorize your Bitcoin claim transactions.",
       prePeginBroadcast:
         "Pre-Pegin transaction has been broadcast. Waiting for vault provider to detect your deposit.",
+      prePeginIngesting:
+        "Pre-Pegin transaction confirmed. Waiting for vault provider to ingest your deposit.",
       waitingForDetection: "Waiting for vault provider to detect your deposit.",
       waitingForPayoutPrep:
         "Waiting for vault provider to prepare claim and payout transactions...",
@@ -134,6 +136,7 @@ export const COPY = {
       signAndBroadcastEth: "Sign and broadcast ETH registration",
       signAndBroadcastPrePegin: "Sign and broadcast BTC Pre-Pegin transaction",
       awaitBtcConfirmation: "Awaiting Bitcoin confirmation",
+      awaitVpIngestion: "Awaiting vault provider ingestion",
       submitWotsKey: "Submit Winternitz One-Time Signature (WOTS)",
       awaitPayoutTransactions:
         "Awaiting vault provider to prepare payout transactions",

--- a/services/vault/src/hooks/deposit/depositFlowSteps/types.ts
+++ b/services/vault/src/hooks/deposit/depositFlowSteps/types.ts
@@ -30,42 +30,55 @@ export enum DepositFlowStep {
   /** Step 5: Sign and broadcast Pre-PegIn transaction to Bitcoin */
   BROADCAST_PRE_PEGIN = 5,
   /**
-   * Step 6: Awaiting Bitcoin confirmation of the Pre-PegIn tx before the
-   * Vault Provider will accept WOTS keys / return payout PSBTs.
+   * Step 6: Awaiting Bitcoin confirmation of the Pre-PegIn tx (mempool-driven).
+   * Distinct from {@link AWAIT_VP_INGESTION}: this is the depositor's wait for
+   * BTC to reach the protocol-mandated `minPrepeginDepth`; once that is
+   * reached but the VP daemon is still at `PendingIngestion`, the stepper
+   * advances to `AWAIT_VP_INGESTION` so the BTC and VP-side waits are not
+   * conflated.
    */
   AWAIT_BTC_CONFIRMATION = 6,
-  /** Step 7: Submit WOTS public key to the Vault Provider. */
-  SUBMIT_WOTS_KEYS = 7,
-  /** Step 8: Wait for the Vault Provider to prepare payout transactions. */
-  AWAIT_PAYOUT_TRANSACTIONS = 8,
   /**
-   * Step 9: `deriveContextHash` for the VP auth anchor during payout
+   * Step 7: BTC depth reached, VP still ingesting (PendingIngestion).
+   * `PendingIngestion` covers the VP processing the ETH event + AML + BTC
+   * validation; the VP can only transition out once the Pre-PegIn has ≥1
+   * confirmation AND its validations pass. With BTC at safe depth, sitting
+   * here means the VP is still working (or stuck) — distinct from a BTC
+   * depth wait, and a useful diagnostic for stuck-deposit support.
+   */
+  AWAIT_VP_INGESTION = 7,
+  /** Step 8: Submit WOTS public key to the Vault Provider. */
+  SUBMIT_WOTS_KEYS = 8,
+  /** Step 9: Wait for the Vault Provider to prepare payout transactions. */
+  AWAIT_PAYOUT_TRANSACTIONS = 9,
+  /**
+   * Step 10: `deriveContextHash` for the VP auth anchor during payout
    * signing. Fires whenever the per-pegin VP-token cache misses inside
    * `signAndSubmitPayouts`. (Cache misses inside `submitWotsPublicKey`
    * still surface a wallet popup, but the stepper stays on
    * SUBMIT_WOTS_KEYS for that path.) The wallet popup is identical to
    * step 1 but binds a different context (auth anchor vs. vault root).
    */
-  SIGN_AUTH_ANCHOR = 9,
-  /** Step 10: Sign the VP/VK claimer payout transactions in BTC wallet */
-  SIGN_PAYOUTS = 10,
+  SIGN_AUTH_ANCHOR = 10,
+  /** Step 11: Sign the VP/VK claimer payout transactions in BTC wallet */
+  SIGN_PAYOUTS = 11,
   /**
-   * Step 11: Sign the depositor's own graph — 1 Payout + N per-challenger
+   * Step 12: Sign the depositor's own graph — 1 Payout + N per-challenger
    * NoPayout transactions — in BTC wallet (the second payout-signing round).
    */
-  SIGN_DEPOSITOR_GRAPH = 11,
-  /** Step 12: Wait for VP verification and ACK submission. */
-  AWAIT_VP_VERIFICATION = 12,
-  /** Step 13: Download vault artifacts */
-  ARTIFACT_DOWNLOAD = 13,
-  /** Step 14: Derive the HTLC secret from the BTC wallet, ahead of activation. */
-  RETRIEVE_SECRET = 14,
-  /** Step 15: Reveal HTLC secret on Ethereum to activate the vault */
-  ACTIVATE_VAULT = 15,
-  /** Step 16: Wait for activation confirmation / indexer catch-up. */
-  AWAIT_ACTIVATION_CONFIRMATION = 16,
-  /** Step 17: Deposit completed */
-  COMPLETED = 17,
+  SIGN_DEPOSITOR_GRAPH = 12,
+  /** Step 13: Wait for VP verification and ACK submission. */
+  AWAIT_VP_VERIFICATION = 13,
+  /** Step 14: Download vault artifacts */
+  ARTIFACT_DOWNLOAD = 14,
+  /** Step 15: Derive the HTLC secret from the BTC wallet, ahead of activation. */
+  RETRIEVE_SECRET = 15,
+  /** Step 16: Reveal HTLC secret on Ethereum to activate the vault */
+  ACTIVATE_VAULT = 16,
+  /** Step 17: Wait for activation confirmation / indexer catch-up. */
+  AWAIT_ACTIVATION_CONFIRMATION = 17,
+  /** Step 18: Deposit completed */
+  COMPLETED = 18,
 }
 
 // ============================================================================

--- a/services/vault/src/hooks/deposit/useBtcConfirmations.ts
+++ b/services/vault/src/hooks/deposit/useBtcConfirmations.ts
@@ -6,15 +6,11 @@
  * Pre-PegIn depth rather than a wall-clock countdown to unschedulable blocks.
  */
 
-import { stripHexPrefix } from "@babylonlabs-io/ts-sdk/tbv/core";
-import {
-  getTipHeight,
-  getTxInfo,
-} from "@babylonlabs-io/ts-sdk/tbv/core/clients";
+import { getTipHeight } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
 import { useQuery } from "@tanstack/react-query";
 
 import { getMempoolApiUrl } from "@/clients/btc/config";
-import { computeConfirmations } from "@/components/simple/DepositProgressView/btcConfirmationProgress";
+import { fetchConfirmations } from "@/clients/btc/confirmations";
 
 /** Bitcoin blocks arrive ~every 10 min; a 30s poll catches each promptly. */
 const CONFIRMATION_POLL_INTERVAL_MS = 30 * 1000;
@@ -42,11 +38,8 @@ export function useBtcConfirmations(
     queryFn: async () => {
       if (!txid) throw new Error("useBtcConfirmations: txid is required");
       const apiUrl = getMempoolApiUrl();
-      const [info, tipHeight] = await Promise.all([
-        getTxInfo(stripHexPrefix(txid), apiUrl),
-        getTipHeight(apiUrl),
-      ]);
-      return computeConfirmations(info.status, tipHeight);
+      const tipHeight = await getTipHeight(apiUrl);
+      return fetchConfirmations(txid, apiUrl, tipHeight);
     },
   });
 

--- a/services/vault/src/hooks/deposit/usePrePeginMempoolConfirmations.ts
+++ b/services/vault/src/hooks/deposit/usePrePeginMempoolConfirmations.ts
@@ -1,0 +1,154 @@
+/**
+ * Mempool ground-truth signal for "Pre-PegIn confirmation depth?".
+ *
+ * The dashboard otherwise infers "broadcast happened" from localStorage
+ * (`CONFIRMING`), which can't tell BTC-wait from VP-stuck: localStorage stays
+ * `CONFIRMING` whether the VP is still ingesting or BTC is still confirming.
+ * Polling the mempool directly per pending Pre-PegIn txid resolves that
+ * ambiguity for the state machine, which routes the deposit to either
+ * `AWAIT_BTC_CONFIRMATION` or `AWAIT_VP_INGESTION` based on the result.
+ *
+ * Returns raw confirmation counts (not pre-thresholded). Per-deposit depth
+ * is applied at the consumer because each vault is locked to its own
+ * `offchainParamsVersion` — comparing to a single "latest" depth here would
+ * silently misclassify older deposits if governance ever bumped the value.
+ *
+ * Batched by unique txid so sibling vaults in a batched pegin (one BTC tx,
+ * many vaults) share a single fetch.
+ */
+
+import { stripHexPrefix } from "@babylonlabs-io/ts-sdk/tbv/core";
+import { getTipHeight } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMemo } from "react";
+
+import { getMempoolApiUrl } from "@/clients/btc/config";
+import { fetchConfirmations } from "@/clients/btc/confirmations";
+
+/**
+ * Dashboard cadence — Bitcoin blocks arrive ~every 10 min, so a 60s tick
+ * still catches each block within ~one minute while halving the per-tab
+ * mempool request volume compared to the in-flow modal's 30s poller. This
+ * runs across all pending deposits, possibly while the section is collapsed,
+ * so a slower cadence than the in-flow modal is the right tradeoff.
+ */
+const POLL_INTERVAL_MS = 60 * 1000;
+
+/**
+ * Just under the poll interval so tab refocus / remount doesn't trigger a
+ * second fetch within the same cycle, while still guaranteeing the periodic
+ * `refetchInterval` always fires.
+ */
+const STALE_TIME_MS = 55 * 1000;
+
+/**
+ * Cap on concurrent `getTxInfo` requests per tick. The default mempool
+ * endpoint is the public `mempool.space`, which rate-limits with 429s and
+ * docs an explicit ban policy for repeat offenders — without a cap, a user
+ * with batched pegins or many parallel deposits would fire N requests in
+ * one burst every cycle. 4 keeps the peak friendly while letting a typical
+ * (single-digit-N) user complete in one batch.
+ */
+const MAX_CONCURRENT_REQUESTS = 4;
+
+const QUERY_KEY_ROOT = "prePeginMempoolConfirmations";
+
+export interface PrePeginMempoolConfirmationsResult {
+  /**
+   * Map keyed by canonical (lowercased, no `0x`) Pre-PegIn txid → confirmation
+   * count on chain. Missing key = unknown (first fetch not yet resolved, or
+   * the tx is not in the mempool/chain and never has been).
+   */
+  confirmationsByTxid: Map<string, number>;
+}
+
+function canonicalize(txid: string): string {
+  return stripHexPrefix(txid).toLowerCase();
+}
+
+/**
+ * Run `task` against each item with at most `concurrency` in flight at
+ * once. Preserves input order in the result and never throws — caller
+ * decides how to handle individual failures by what `task` returns.
+ */
+async function mapWithConcurrency<T, R>(
+  items: ReadonlyArray<T>,
+  concurrency: number,
+  task: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+  const workers = Array.from(
+    { length: Math.min(concurrency, items.length) },
+    async () => {
+      while (true) {
+        const i = nextIndex++;
+        if (i >= items.length) return;
+        results[i] = await task(items[i]);
+      }
+    },
+  );
+  await Promise.all(workers);
+  return results;
+}
+
+export function usePrePeginMempoolConfirmations(
+  txids: ReadonlyArray<string | undefined>,
+): PrePeginMempoolConfirmationsResult {
+  const queryClient = useQueryClient();
+
+  // Stable, deduped, sorted key — order changes in `activities` must not
+  // refetch unnecessarily.
+  const uniqueTxids = useMemo(() => {
+    const set = new Set<string>();
+    for (const t of txids) {
+      if (t && t.length > 0) set.add(canonicalize(t));
+    }
+    return Array.from(set).sort();
+  }, [txids]);
+
+  const enabled = uniqueTxids.length > 0;
+  const queryKey = useMemo(
+    () => [QUERY_KEY_ROOT, uniqueTxids.join(",")] as const,
+    [uniqueTxids],
+  );
+
+  const query = useQuery({
+    queryKey,
+    enabled,
+    refetchInterval: POLL_INTERVAL_MS,
+    staleTime: STALE_TIME_MS,
+    // Preserve the prior batch across queryKey changes (a new pending pegin
+    // appearing/disappearing rotates the key). Without this, every list churn
+    // discards what we knew about unchanged txids and flickers their rows
+    // back to AWAIT_BTC_CONFIRMATION until the next fetch completes.
+    placeholderData: (prev) => prev,
+    queryFn: async () => {
+      const apiUrl = getMempoolApiUrl();
+      const tipHeight = await getTipHeight(apiUrl);
+      // Carry prior known confirmation counts forward on per-txid error so a
+      // transient 429 or network blip doesn't flicker an already-confirmed
+      // deposit's row backward to AWAIT_BTC_CONFIRMATION for one cycle.
+      const prior =
+        queryClient.getQueryData<Map<string, number>>(queryKey) ?? new Map();
+      const entries = await mapWithConcurrency(
+        uniqueTxids,
+        MAX_CONCURRENT_REQUESTS,
+        async (txid): Promise<[string, number] | null> => {
+          try {
+            const confs = await fetchConfirmations(txid, apiUrl, tipHeight);
+            return [txid, confs];
+          } catch {
+            const priorConfs = prior.get(txid);
+            return priorConfs !== undefined ? [txid, priorConfs] : null;
+          }
+        },
+      );
+      return new Map<string, number>(
+        entries.filter((e): e is [string, number] => e !== null),
+      );
+    },
+  });
+
+  return { confirmationsByTxid: query.data ?? new Map() };
+}

--- a/services/vault/src/models/__tests__/peginStateMachine.test.ts
+++ b/services/vault/src/models/__tests__/peginStateMachine.test.ts
@@ -44,6 +44,28 @@ describe("peginStateMachine", () => {
       );
     });
 
+    it("flags VP-ingestion wait when BTC is confirmed but VP still ingesting", () => {
+      const state = getPeginState(ContractStatus.PENDING, {
+        localStatus: LocalStorageStatus.CONFIRMING,
+        pendingIngestion: true,
+        prePeginBroadcastConfirmed: true,
+      });
+      expect(state.displayLabel).toBe(PEGIN_DISPLAY_LABELS.PENDING);
+      expect(state.availableActions).toEqual([PeginAction.NONE]);
+      expect(state.message).toContain("Waiting for vault provider to ingest");
+      expect(state.awaitingVpIngestion).toBe(true);
+    });
+
+    it("does NOT flag VP-ingestion wait when VP has already ingested", () => {
+      const state = getPeginState(ContractStatus.PENDING, {
+        localStatus: LocalStorageStatus.CONFIRMING,
+        pendingIngestion: false,
+        prePeginBroadcastConfirmed: true,
+      });
+      // BTC confirmed AND ingested → falls through to payout-prep branch.
+      expect(state.awaitingVpIngestion).toBeUndefined();
+    });
+
     it("shows preparing transactions when CONFIRMING and VP has ingested", () => {
       const state = getPeginState(ContractStatus.PENDING, {
         localStatus: LocalStorageStatus.CONFIRMING,
@@ -557,6 +579,22 @@ describe("peginStateMachine", () => {
       expect(state.availableActions).toEqual([PeginAction.NONE]);
       expect(getPeginDisplayStep(state)).toBe(
         DepositFlowStep.AWAIT_BTC_CONFIRMATION,
+      );
+    });
+
+    it("maps BTC-confirmed-but-VP-still-ingesting to AWAIT_VP_INGESTION", () => {
+      // The diagnostic case: localStorage says CONFIRMING (broadcast happened)
+      // and mempool reports the Pre-PegIn has reached the protocol depth, but
+      // the VP is still at PendingIngestion — surface the VP-side wait, not
+      // the BTC-side wait, so a stuck VP doesn't masquerade as a BTC delay.
+      const state = getPeginState(ContractStatus.PENDING, {
+        localStatus: LocalStorageStatus.CONFIRMING,
+        pendingIngestion: true,
+        prePeginBroadcastConfirmed: true,
+      });
+      expect(state.availableActions).toEqual([PeginAction.NONE]);
+      expect(getPeginDisplayStep(state)).toBe(
+        DepositFlowStep.AWAIT_VP_INGESTION,
       );
     });
 

--- a/services/vault/src/models/peginStateMachine.ts
+++ b/services/vault/src/models/peginStateMachine.ts
@@ -83,6 +83,13 @@ export interface PeginState {
   availableActions: PeginAction[];
   message?: string;
   awaitingPayoutPrep?: boolean;
+  /**
+   * Pre-PegIn BTC confirmations have reached the protocol-mandated depth,
+   * but the VP is still at `PendingIngestion`. Lets the stepper pin the
+   * deposit on `AWAIT_VP_INGESTION` so a stuck VP doesn't masquerade as a
+   * BTC-confirmation wait.
+   */
+  awaitingVpIngestion?: boolean;
 }
 
 export interface GetPeginStateOptions {
@@ -91,6 +98,14 @@ export interface GetPeginStateOptions {
   isInUse?: boolean;
   needsWotsKey?: boolean;
   pendingIngestion?: boolean;
+  /**
+   * True when the Pre-PegIn BTC tx has reached the protocol-mandated
+   * confirmation depth on mempool (chain ground truth). Lets the state
+   * machine distinguish "BTC depth still pending" from "BTC done, VP
+   * stuck at PendingIngestion" — those two collapse into the same UI
+   * if we rely on localStorage `CONFIRMING` alone.
+   */
+  prePeginBroadcastConfirmed?: boolean;
   expirationReason?: ExpirationReason;
   expiredAt?: number;
   canRefund?: boolean;
@@ -322,6 +337,7 @@ interface DisplayInfo {
   displayVariant: "pending" | "active" | "inactive" | "warning";
   message?: string;
   awaitingPayoutPrep?: boolean;
+  awaitingVpIngestion?: boolean;
 }
 
 function getDisplay(
@@ -375,6 +391,20 @@ function getDisplay(
         displayLabel: PEGIN_DISPLAY_LABELS.SIGNING_REQUIRED,
         displayVariant: "pending",
         message: COPY.pegin.messages.payoutsReadyForSigning,
+      };
+    }
+    // BTC confirmed at protocol depth (mempool ground truth), VP still
+    // ingesting. Distinct from "broadcast but not yet confirmed" — surfaces
+    // a stuck VP plainly instead of falsely blaming the BTC wait.
+    if (
+      options.pendingIngestion === true &&
+      options.prePeginBroadcastConfirmed === true
+    ) {
+      return {
+        displayLabel: PEGIN_DISPLAY_LABELS.PENDING,
+        displayVariant: "pending",
+        message: COPY.pegin.messages.prePeginIngesting,
+        awaitingVpIngestion: true,
       };
     }
     if (
@@ -574,12 +604,17 @@ export function getPeginDisplayStep(state: PeginState): DepositFlowStep | null {
     // No action pending. Once payouts are signed the deposit is waiting for VP
     // verification/ACK submission. If the VP has ingested the deposit but
     // payout transactions are not ready, it is preparing the signing package.
-    // Otherwise it is still waiting for Pre-PegIn confirmation/detection.
+    // If BTC depth is met but VP still says PendingIngestion, the wait is
+    // VP-side, not BTC-side. Otherwise it is still waiting for Pre-PegIn
+    // confirmation/detection.
     if (localStatus === LocalStorageStatus.PAYOUT_SIGNED) {
       return DepositFlowStep.AWAIT_VP_VERIFICATION;
     }
     if (state.awaitingPayoutPrep) {
       return DepositFlowStep.AWAIT_PAYOUT_TRANSACTIONS;
+    }
+    if (state.awaitingVpIngestion) {
+      return DepositFlowStep.AWAIT_VP_INGESTION;
     }
     return DepositFlowStep.AWAIT_BTC_CONFIRMATION;
   }

--- a/services/vault/src/types/activity.ts
+++ b/services/vault/src/types/activity.ts
@@ -126,6 +126,15 @@ export interface VaultActivity {
 
   /** Expiration reason, undefined if not expired */
   expirationReason?: ExpirationReason;
+
+  /**
+   * Offchain params version this vault was registered against. The protocol
+   * gates depth checks (e.g. `minPrepeginDepth`) on this version, not the
+   * latest, so any consumer comparing on-chain confirmation counts must
+   * look up the per-version param via `getOffchainParamsByVersion`. Falls
+   * back to latest if the vault predates the indexer exposing this field.
+   */
+  offchainParamsVersion?: number;
 }
 
 /**

--- a/services/vault/src/utils/vaultTransformers.ts
+++ b/services/vault/src/utils/vaultTransformers.ts
@@ -86,6 +86,7 @@ export function transformVaultToActivity(vault: Vault): VaultActivity {
     depositorWotsPkHash: vault.depositorWotsPkHash,
     expiredAt: vault.expiredAt,
     expirationReason: vault.expirationReason,
+    offchainParamsVersion: vault.offchainParamsVersion,
     // No action handlers - these are attached at the component level
     action: undefined,
     // No position details in deposit tab


### PR DESCRIPTION
A devnet pegin stuck at the VP's `PendingIngestion` status was displayed as "Step 6: Awaiting
Bitcoin Confirmation" — the dashboard collapsed BTC-wait and VP-stuck into the same step because
the state machine inferred progress from localStorage instead of chain state. This adds a new
`AWAIT_VP_INGESTION` step (7 of 17) that fires when the Pre-PegIn has reached protocol depth on
chain but the VP daemon is still ingesting, driven by a new mempool poller (60s cadence,
concurrency cap of 4, batched by unique txid) that feeds a `prePeginBroadcastConfirmed` flag into
the state machine so it can route between the BTC-side and VP-side waits accurately.