### PR TITLE
feat(vault): redesign recovery-artifact modals and dashboard disconnected state

### DIFF
--- a/services/vault/src/applications/aave/hooks/useAaveBorrowedAssets.ts
+++ b/services/vault/src/applications/aave/hooks/useAaveBorrowedAssets.ts
@@ -31,6 +31,9 @@ export interface BorrowedAsset {
   amount: string;
   /** Token icon URL */
   icon: string;
+  /** Borrow APR as a formatted string (e.g. "5.861%"). Optional until the
+   *  reserve-data fetch that produces this is wired up. */
+  borrowRate?: string;
 }
 
 /**

--- a/services/vault/src/components/Wallet/Connect.tsx
+++ b/services/vault/src/components/Wallet/Connect.tsx
@@ -24,9 +24,11 @@ import { resolveDisplayWallets } from "./resolveDisplayWallets";
 
 interface ConnectProps {
   loading?: boolean;
+  /** Override the default `ConnectButton` label (e.g. "Connect Wallet" for in-page CTAs). */
+  text?: string;
 }
 
-export const Connect: React.FC<ConnectProps> = ({ loading = false }) => {
+export const Connect: React.FC<ConnectProps> = ({ loading = false, text }) => {
   const { open, disconnect } = useWalletConnect();
   const [isWalletMenuOpen, setIsWalletMenuOpen] = useState(false);
 
@@ -125,6 +127,7 @@ export const Connect: React.FC<ConnectProps> = ({ loading = false }) => {
       loading={loading || isGeoLoading || isScreeningLoading}
       disabled={isGeoBlocked || isAddressBlocked}
       onClick={open}
+      text={text}
     />
   );
 

--- a/services/vault/src/components/deposit/ArtifactDownloadModal/index.tsx
+++ b/services/vault/src/components/deposit/ArtifactDownloadModal/index.tsx
@@ -3,18 +3,13 @@ import {
   DialogBody,
   DialogFooter,
   DialogHeader,
-  Loader,
   ResponsiveDialog,
-  Text,
-  Warning,
 } from "@babylonlabs-io/core-ui";
-import type { BitcoinWallet } from "@babylonlabs-io/ts-sdk/shared";
-import { useChainConnector } from "@babylonlabs-io/wallet-connector";
-import { useMemo } from "react";
+import { useState } from "react";
 import type { Hex } from "viem";
 
+import { RecoveryArtifactsCard } from "@/components/deposit/RecoveryArtifactsCard";
 import { COPY } from "@/copy";
-import { useArtifactDownload } from "@/hooks/deposit/useArtifactDownload";
 
 interface ArtifactDownloadModalProps {
   open: boolean;
@@ -45,124 +40,86 @@ export function ArtifactDownloadModal({
   vaultId,
   unsignedPrePeginTxHex,
 }: ArtifactDownloadModalProps) {
-  const btcConnector = useChainConnector("BTC");
-  const btcWallet =
-    (btcConnector?.connectedWallet?.provider as BitcoinWallet | undefined) ??
-    null;
-
-  const primeContext = useMemo(() => {
-    if (!btcWallet || !unsignedPrePeginTxHex) return null;
-    return {
-      vaultId,
-      unsignedPrePeginTxHex,
-      btcWallet,
-    };
-  }, [btcWallet, unsignedPrePeginTxHex, vaultId]);
-
-  const { loading, progress, error, downloaded, download, cancel, reset } =
-    useArtifactDownload({ vaultId, primeContext });
-
-  const handleDownload = () => {
-    download(providerAddress, peginTxid, depositorPk);
-  };
-
-  const handleComplete = () => {
-    reset();
-    onComplete();
-  };
-
-  const handleClose = () => {
-    reset();
-    onClose();
-  };
-
-  // TODO: Remove handleCancel (and the Cancel button below) once the backend
-  // delivers artifacts via streaming instead of a single oversized RPC response
-  // (~450 MB). Until then downloads reliably time out, so users must be able
-  // to dismiss the modal without waiting.
-  const handleCancel = () => {
-    cancel();
-    onClose();
-  };
+  const [downloaded, setDownloaded] = useState(false);
 
   return (
-    <ResponsiveDialog open={open} onClose={handleClose}>
+    <ResponsiveDialog
+      open={open}
+      onClose={onClose}
+      className="w-[564px] max-w-full"
+      dialogClassName="!rounded-2xl"
+    >
       <DialogHeader
-        title={COPY.deposit.artifactDownload.title}
-        onClose={handleClose}
-        className="text-accent-primary"
+        title=""
+        onClose={onClose}
+        // Float the close (×) button at the top-right with no border, so the
+        // title row sits absolutely over the body padding (matches the design).
+        className="text-accent-primary [&_.bbn-dialog-title]:!absolute [&_.bbn-dialog-title]:!right-5 [&_button]:!border-0"
       />
 
-      <DialogBody className="flex flex-col gap-4 px-4 pb-4 pt-4 text-accent-primary sm:px-6">
-        {!downloaded && !loading && (
-          <>
-            <Text variant="body2" className="text-accent-secondary">
+      <DialogBody className="flex flex-col items-stretch gap-10 px-6 pb-2 pt-2 text-accent-primary">
+        <div className="flex flex-col items-center gap-10">
+          <svg
+            width="90"
+            height="90"
+            viewBox="0 0 90 90"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            className="text-accent-primary"
+            aria-hidden="true"
+          >
+            <path
+              d="M75 43.125V26.25L58.125 7.5H18.75C16.6789 7.5 15 9.17893 15 11.25V78.75C15 80.8211 16.6789 82.5 18.75 82.5H41.25"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+            <path
+              d="M50.625 58.5C50.625 56.4999 63.75 52.5 63.75 52.5C63.75 52.5 76.875 56.4999 76.875 58.5C76.875 74.4999 63.75 82.5 63.75 82.5C63.75 82.5 50.625 74.4999 50.625 58.5Z"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+            <path
+              d="M56.25 7.5V26.25H75"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+          <div className="flex w-full flex-col items-center gap-4">
+            <h2 className="text-center text-[34px] font-normal leading-[1.235] tracking-[0.25px] text-accent-primary">
+              {COPY.deposit.artifactDownload.title}
+            </h2>
+            <p className="text-center text-xl font-normal leading-[1.6] tracking-[0.15px] text-accent-secondary">
               {COPY.deposit.artifactDownload.body}
-            </Text>
-
-            <Warning>
-              {COPY.deposit.artifactDownload.storeSafelyWarning}
-            </Warning>
-          </>
-        )}
-
-        {loading && (
-          <div className="flex flex-col items-center gap-3 py-8">
-            <Loader size={24} />
-            <Text variant="body2" className="text-accent-secondary">
-              {progress}
-            </Text>
+            </p>
           </div>
-        )}
+        </div>
 
-        {downloaded && (
-          <div className="flex flex-col gap-3 py-4">
-            <Text variant="body2" className="text-accent-secondary">
-              {COPY.deposit.artifactDownload.downloadedBody}
-            </Text>
-          </div>
-        )}
-
-        {error && (
-          <Text variant="body2" className="text-sm text-error-main">
-            {error}
-          </Text>
-        )}
+        <RecoveryArtifactsCard
+          providerAddress={providerAddress}
+          peginTxid={peginTxid}
+          depositorPk={depositorPk}
+          vaultId={vaultId}
+          unsignedPrePeginTxHex={unsignedPrePeginTxHex}
+          onDownloaded={() => setDownloaded(true)}
+        />
       </DialogBody>
 
-      <DialogFooter className="px-4 pb-6 sm:px-6">
-        {!downloaded ? (
-          <>
-            <Button
-              variant="contained"
-              className="w-full"
-              onClick={handleDownload}
-              disabled={loading}
-            >
-              {loading
-                ? COPY.deposit.artifactDownload.downloading
-                : COPY.deposit.artifactDownload.downloadButton}
-            </Button>
-            {/* TODO: Remove Cancel button once backend streaming is implemented (see handleCancel above) */}
-            {loading && (
-              <Button
-                variant="outlined"
-                className="w-full"
-                onClick={handleCancel}
-              >
-                {COPY.deposit.artifactDownload.cancelButton}
-              </Button>
-            )}
-          </>
-        ) : (
-          <Button
-            variant="contained"
-            className="w-full"
-            onClick={handleComplete}
-          >
-            {COPY.deposit.artifactDownload.continueButton}
-          </Button>
-        )}
+      <DialogFooter className="flex flex-row gap-4 px-6 pb-6 pt-4">
+        <Button
+          variant={downloaded ? "contained" : "outlined"}
+          className="h-10 w-full"
+          onClick={downloaded ? onComplete : onClose}
+        >
+          {downloaded
+            ? COPY.deposit.artifactDownload.continueButton
+            : COPY.deposit.artifactDownload.cancelButton}
+        </Button>
       </DialogFooter>
     </ResponsiveDialog>
   );

--- a/services/vault/src/components/deposit/ArtifactDownloadModal/index.tsx
+++ b/services/vault/src/components/deposit/ArtifactDownloadModal/index.tsx
@@ -5,11 +5,15 @@ import {
   DialogHeader,
   ResponsiveDialog,
 } from "@babylonlabs-io/core-ui";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { Hex } from "viem";
 
-import { RecoveryArtifactsCard } from "@/components/deposit/RecoveryArtifactsCard";
+import {
+  RecoveryArtifactsCard,
+  type RecoveryArtifactsCardHandle,
+} from "@/components/deposit/RecoveryArtifactsCard";
 import { COPY } from "@/copy";
+import { hasArtifactsDownloaded } from "@/utils/artifactDownloadStorage";
 
 interface ArtifactDownloadModalProps {
   open: boolean;
@@ -40,18 +44,38 @@ export function ArtifactDownloadModal({
   vaultId,
   unsignedPrePeginTxHex,
 }: ArtifactDownloadModalProps) {
-  const [downloaded, setDownloaded] = useState(false);
+  // Seed from localStorage so a reopened modal for an already-downloaded
+  // vault renders the Continue path immediately (the card itself flips to
+  // its green "Downloaded" state via the same check). Re-seeded whenever the
+  // modal opens against a different vault.
+  const [downloaded, setDownloaded] = useState(() =>
+    hasArtifactsDownloaded(vaultId),
+  );
+
+  useEffect(() => {
+    if (open) setDownloaded(hasArtifactsDownloaded(vaultId));
+  }, [open, vaultId]);
+
+  const cardRef = useRef<RecoveryArtifactsCardHandle>(null);
+
+  // Cancel any in-flight artifact download before the modal unmounts so a
+  // dismissed dialog doesn't leave the oversized RPC running in the
+  // background (and surprise the user with a file save later).
+  const handleClose = () => {
+    cardRef.current?.cancel();
+    onClose();
+  };
 
   return (
     <ResponsiveDialog
       open={open}
-      onClose={onClose}
+      onClose={handleClose}
       className="w-[564px] max-w-full"
       dialogClassName="!rounded-2xl"
     >
       <DialogHeader
         title=""
-        onClose={onClose}
+        onClose={handleClose}
         // Float the close (×) button at the top-right with no border, so the
         // title row sits absolutely over the body padding (matches the design).
         className="text-accent-primary [&_.bbn-dialog-title]:!absolute [&_.bbn-dialog-title]:!right-5 [&_button]:!border-0"
@@ -101,6 +125,7 @@ export function ArtifactDownloadModal({
         </div>
 
         <RecoveryArtifactsCard
+          ref={cardRef}
           providerAddress={providerAddress}
           peginTxid={peginTxid}
           depositorPk={depositorPk}
@@ -114,7 +139,7 @@ export function ArtifactDownloadModal({
         <Button
           variant={downloaded ? "contained" : "outlined"}
           className="h-10 w-full"
-          onClick={downloaded ? onComplete : onClose}
+          onClick={downloaded ? onComplete : handleClose}
         >
           {downloaded
             ? COPY.deposit.artifactDownload.continueButton

--- a/services/vault/src/components/deposit/RecoveryArtifactsCard.tsx
+++ b/services/vault/src/components/deposit/RecoveryArtifactsCard.tsx
@@ -1,0 +1,139 @@
+import { Loader } from "@babylonlabs-io/core-ui";
+import type { BitcoinWallet } from "@babylonlabs-io/ts-sdk/shared";
+import { useChainConnector } from "@babylonlabs-io/wallet-connector";
+import { useEffect, useMemo, useRef } from "react";
+import {
+  IoCheckmarkCircle,
+  IoDocumentText,
+  IoDownloadOutline,
+} from "react-icons/io5";
+import type { Hex } from "viem";
+
+import { COPY } from "@/copy";
+import { useArtifactDownload } from "@/hooks/deposit/useArtifactDownload";
+import { hasArtifactsDownloaded } from "@/utils/artifactDownloadStorage";
+
+interface RecoveryArtifactsCardProps {
+  providerAddress: string;
+  peginTxid: string;
+  depositorPk: string;
+  vaultId: Hex;
+  /**
+   * Unsigned Pre-PegIn tx hex (from indexer). When provided alongside a
+   * connected BTC wallet, the card can transparently re-authenticate
+   * with the vault provider on a cold token-registry cache (e.g. after
+   * a page reload) by deriving a fresh auth anchor.
+   */
+  unsignedPrePeginTxHex?: string;
+  /** Fired the first time the artifact download completes within this card. */
+  onDownloaded?: () => void;
+}
+
+export function RecoveryArtifactsCard({
+  providerAddress,
+  peginTxid,
+  depositorPk,
+  vaultId,
+  unsignedPrePeginTxHex,
+  onDownloaded,
+}: RecoveryArtifactsCardProps) {
+  const btcConnector = useChainConnector("BTC");
+  const btcWallet =
+    (btcConnector?.connectedWallet?.provider as BitcoinWallet | undefined) ??
+    null;
+
+  const primeContext = useMemo(() => {
+    if (!btcWallet || !unsignedPrePeginTxHex) return null;
+    return { vaultId, unsignedPrePeginTxHex, btcWallet };
+  }, [btcWallet, unsignedPrePeginTxHex, vaultId]);
+
+  const { loading, progress, error, downloaded, download, cancel } =
+    useArtifactDownload({ vaultId, primeContext });
+
+  const persisted = hasArtifactsDownloaded(vaultId);
+  const isDownloaded = downloaded || persisted;
+
+  const notifiedRef = useRef(false);
+  useEffect(() => {
+    if (downloaded && !notifiedRef.current) {
+      notifiedRef.current = true;
+      onDownloaded?.();
+    }
+  }, [downloaded, onDownloaded]);
+
+  const handleDownload = () => {
+    download(providerAddress, peginTxid, depositorPk);
+  };
+
+  return (
+    <div className="flex flex-col gap-4 rounded-lg border border-secondary-strokeLight bg-secondary-highlight p-4">
+      <div className="flex items-center gap-4">
+        <div className="flex h-11 w-[47px] shrink-0 items-center justify-center rounded-lg bg-secondary-main text-white">
+          <IoDocumentText size={24} />
+        </div>
+        <div className="flex min-w-0 flex-1 flex-col">
+          <span className="text-base leading-[1.5] tracking-[0.15px] text-accent-primary">
+            {COPY.deposit.recoveryArtifacts.cardTitle}
+          </span>
+          <div className="flex items-baseline justify-between gap-2">
+            <span className="truncate text-base leading-[1.5] tracking-[0.15px] text-accent-secondary">
+              {COPY.deposit.recoveryArtifacts.cardSubtitle}
+            </span>
+            <span className="shrink-0 text-sm leading-[1.43] tracking-[0.17px] text-accent-secondary">
+              {COPY.deposit.recoveryArtifacts.cardSize}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {isDownloaded ? (
+        <div className="flex h-9 w-full items-center justify-center gap-2 rounded-lg border border-success-main/40 bg-success-main/10 px-4 text-success-main">
+          <IoCheckmarkCircle size={16} />
+          <span className="text-sm leading-[1.43] tracking-[0.17px]">
+            {COPY.deposit.recoveryArtifacts.downloadedLabel}
+          </span>
+        </div>
+      ) : loading ? (
+        <div className="flex flex-col items-stretch gap-2">
+          <div className="flex h-9 w-full items-center justify-center gap-2 rounded-lg border border-secondary-strokeLight bg-neutral-200 px-4 text-accent-primary">
+            <Loader size={16} />
+            <span className="text-sm leading-[1.43] tracking-[0.17px]">
+              {COPY.deposit.recoveryArtifacts.downloadingButton}
+            </span>
+          </div>
+          {progress && (
+            <span className="text-center text-xs text-accent-secondary">
+              {progress}
+            </span>
+          )}
+          <button
+            type="button"
+            onClick={cancel}
+            className="text-center text-xs text-accent-secondary underline hover:text-accent-primary"
+          >
+            {COPY.deposit.recoveryArtifacts.cancelDownloadButton}
+          </button>
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={handleDownload}
+          className="flex h-9 w-full items-center justify-center gap-2 rounded-lg border border-secondary-strokeLight bg-neutral-200 px-4 text-accent-primary transition-colors hover:bg-secondary-highlight"
+        >
+          <IoDownloadOutline size={20} />
+          <span className="text-sm leading-[1.43] tracking-[0.17px]">
+            {error
+              ? COPY.deposit.recoveryArtifacts.retryButton
+              : COPY.deposit.recoveryArtifacts.downloadButton}
+          </span>
+        </button>
+      )}
+
+      {error && (
+        <span className="text-sm leading-[1.43] tracking-[0.17px] text-error-main">
+          {error}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/services/vault/src/components/deposit/RecoveryArtifactsCard.tsx
+++ b/services/vault/src/components/deposit/RecoveryArtifactsCard.tsx
@@ -1,7 +1,13 @@
 import { Loader } from "@babylonlabs-io/core-ui";
 import type { BitcoinWallet } from "@babylonlabs-io/ts-sdk/shared";
 import { useChainConnector } from "@babylonlabs-io/wallet-connector";
-import { useEffect, useMemo, useRef } from "react";
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+} from "react";
 import {
   IoCheckmarkCircle,
   IoDocumentText,
@@ -29,14 +35,29 @@ interface RecoveryArtifactsCardProps {
   onDownloaded?: () => void;
 }
 
-export function RecoveryArtifactsCard({
-  providerAddress,
-  peginTxid,
-  depositorPk,
-  vaultId,
-  unsignedPrePeginTxHex,
-  onDownloaded,
-}: RecoveryArtifactsCardProps) {
+/**
+ * Imperative handle exposed via ref. Lets the parent modal cancel any
+ * in-flight artifact download from its own close paths (X button, footer
+ * Cancel) so dismissing the modal doesn't leave the oversized RPC running.
+ */
+export interface RecoveryArtifactsCardHandle {
+  cancel: () => void;
+}
+
+export const RecoveryArtifactsCard = forwardRef<
+  RecoveryArtifactsCardHandle,
+  RecoveryArtifactsCardProps
+>(function RecoveryArtifactsCard(
+  {
+    providerAddress,
+    peginTxid,
+    depositorPk,
+    vaultId,
+    unsignedPrePeginTxHex,
+    onDownloaded,
+  },
+  ref,
+) {
   const btcConnector = useChainConnector("BTC");
   const btcWallet =
     (btcConnector?.connectedWallet?.provider as BitcoinWallet | undefined) ??
@@ -49,6 +70,8 @@ export function RecoveryArtifactsCard({
 
   const { loading, progress, error, downloaded, download, cancel } =
     useArtifactDownload({ vaultId, primeContext });
+
+  useImperativeHandle(ref, () => ({ cancel }), [cancel]);
 
   const persisted = hasArtifactsDownloaded(vaultId);
   const isDownloaded = downloaded || persisted;
@@ -115,18 +138,25 @@ export function RecoveryArtifactsCard({
           </button>
         </div>
       ) : (
-        <button
-          type="button"
-          onClick={handleDownload}
-          className="flex h-9 w-full items-center justify-center gap-2 rounded-lg border border-secondary-strokeLight bg-neutral-200 px-4 text-accent-primary transition-colors hover:bg-secondary-highlight"
-        >
-          <IoDownloadOutline size={20} />
-          <span className="text-sm leading-[1.43] tracking-[0.17px]">
-            {error
-              ? COPY.deposit.recoveryArtifacts.retryButton
-              : COPY.deposit.recoveryArtifacts.downloadButton}
-          </span>
-        </button>
+        <div className="flex flex-col items-stretch">
+          <button
+            type="button"
+            onClick={handleDownload}
+            className="flex h-9 w-full items-center justify-center gap-2 rounded-lg border border-secondary-strokeLight bg-neutral-200 px-4 text-accent-primary transition-colors hover:bg-secondary-highlight"
+          >
+            <IoDownloadOutline size={20} />
+            <span className="text-sm leading-[1.43] tracking-[0.17px]">
+              {error
+                ? COPY.deposit.recoveryArtifacts.retryButton
+                : COPY.deposit.recoveryArtifacts.downloadButton}
+            </span>
+          </button>
+          {!error && (
+            <span className="mt-2.5 text-center text-xs text-accent-secondary">
+              {COPY.deposit.recoveryArtifacts.walletSignatureHint}
+            </span>
+          )}
+        </div>
       )}
 
       {error && (
@@ -136,4 +166,4 @@ export function RecoveryArtifactsCard({
       )}
     </div>
   );
-}
+});

--- a/services/vault/src/components/pages/RootLayout.tsx
+++ b/services/vault/src/components/pages/RootLayout.tsx
@@ -3,7 +3,9 @@ import {
   Footer,
   FullScreenDialog,
   Header,
+  MobileLogo,
   Nav,
+  SmallLogo,
   StandardSettingsMenu,
   TestingBanner,
   Text,
@@ -118,7 +120,24 @@ export default function RootLayout() {
         <AddressTypeBanner visible={showAddressTypeBanner} />
         <Header
           size="md"
-          containerClassName={PAGE_CONTENT_CLASS}
+          // `!max-w-` overrides the `container` class's 2xl breakpoint max-width
+          // (1536px) that core-ui's Header applies by default, so the navbar is
+          // actually capped at 1400px on wide viewports.
+          containerClassName={`${PAGE_CONTENT_CLASS} !max-w-[1400px]`}
+          // Tint the logo brand-orange in light mode; keep the default
+          // light-on-dark contrast in dark mode. The wrapper's `[&_svg]` selector
+          // overrides the SVG's hardcoded `text-accent-primary` color, which the
+          // paths inherit through `fill-current`.
+          logo={
+            <div className="[&_svg]:!text-secondary-main dark:[&_svg]:!text-accent-primary">
+              <SmallLogo />
+            </div>
+          }
+          mobileLogo={
+            <div className="[&_svg]:!text-secondary-main dark:[&_svg]:!text-accent-primary">
+              <MobileLogo />
+            </div>
+          }
           navigation={<DesktopNavigation />}
           mobileNavigation={<MobileNavigation />}
           rightActions={
@@ -140,6 +159,7 @@ export default function RootLayout() {
             </div>
           }
         />
+
         <Outlet
           context={
             {
@@ -176,9 +196,16 @@ export default function RootLayout() {
           />
         </AaveConfigProvider>
         <div className="mt-auto">
+          {/* `[&>div]:!max-w-[1400px]` caps the Footer's inner Container at
+              1400px, overriding the `container` class's 1536px max-width at
+              the 2xl breakpoint so the footer aligns with the navbar.
+              `!bg-secondary-main` + `before:!bg-secondary-main` swap the light-
+              mode background (and its decorative top-edge pseudo) from the
+              default teal to brand orange; dark mode keeps `primary-main`. */}
           <Footer
             socialLinks={DEFAULT_SOCIAL_LINKS}
             copyrightYear={new Date().getFullYear()}
+            className="!bg-secondary-main before:!bg-secondary-main dark:!bg-primary-main dark:before:!bg-primary-main [&>div]:!max-w-[1400px]"
           />
         </div>
       </div>

--- a/services/vault/src/components/shared/layoutClasses.ts
+++ b/services/vault/src/components/shared/layoutClasses.ts
@@ -10,4 +10,4 @@ export const PAGE_CONTENT_CLASS = "max-w-[1400px] px-5 sm:px-5";
 export const CARD_DARK_BG_CLASS = "dark:bg-[#202020]";
 
 /** Width + vertical padding for the dashboard section summary cards. */
-export const SUMMARY_CARD_CLASS = "w-full !py-[34px]";
+export const SUMMARY_CARD_CLASS = "w-full border-0 !py-[34px]";

--- a/services/vault/src/components/simple/ActivateConfirmationModal.tsx
+++ b/services/vault/src/components/simple/ActivateConfirmationModal.tsx
@@ -6,19 +6,28 @@ import {
   DialogHeader,
   ResponsiveDialog,
 } from "@babylonlabs-io/core-ui";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { Hex } from "viem";
 
-import { RecoveryArtifactsCard } from "@/components/deposit/RecoveryArtifactsCard";
+import {
+  RecoveryArtifactsCard,
+  type RecoveryArtifactsCardHandle,
+} from "@/components/deposit/RecoveryArtifactsCard";
 import { COPY } from "@/copy";
 import { hasArtifactsDownloaded } from "@/utils/artifactDownloadStorage";
 
 interface ActivateConfirmationModalProps {
   open: boolean;
   vaultId: Hex;
-  providerAddress: string;
-  peginTxid: string;
-  depositorPk: string;
+  /**
+   * Artifact-download inputs. All three are required for the recovery card
+   * to attempt a download; if any are missing the card is hidden and the
+   * user can only proceed by acknowledging the risk and activating without
+   * artifacts.
+   */
+  providerAddress?: string;
+  peginTxid?: string;
+  depositorPk?: string;
   unsignedPrePeginTxHex?: string;
   onClose: () => void;
   onConfirm: () => void;
@@ -45,18 +54,28 @@ export function ActivateConfirmationModal({
     setAcknowledged(false);
   }, [open, vaultId]);
 
+  const cardRef = useRef<RecoveryArtifactsCardHandle>(null);
+
+  // Cancel any in-flight artifact download so closing the modal mid-download
+  // doesn't leave the oversized RPC request running in the background.
+  const handleClose = () => {
+    cardRef.current?.cancel();
+    onClose();
+  };
+
+  const canRenderCard = Boolean(providerAddress && peginTxid && depositorPk);
   const canActivate = downloaded || acknowledged;
 
   return (
     <ResponsiveDialog
       open={open}
-      onClose={onClose}
+      onClose={handleClose}
       className="w-[564px] max-w-full"
       dialogClassName="!rounded-2xl"
     >
       <DialogHeader
         title=""
-        onClose={onClose}
+        onClose={handleClose}
         // Float the close (×) button at the top-right with no border, so the
         // title row sits absolutely over the body padding (matches the design).
         className="text-accent-primary [&_.bbn-dialog-title]:!absolute [&_.bbn-dialog-title]:!right-5 [&_button]:!border-0"
@@ -90,14 +109,17 @@ export function ActivateConfirmationModal({
           </div>
         </div>
 
-        <RecoveryArtifactsCard
-          providerAddress={providerAddress}
-          peginTxid={peginTxid}
-          depositorPk={depositorPk}
-          vaultId={vaultId}
-          unsignedPrePeginTxHex={unsignedPrePeginTxHex}
-          onDownloaded={() => setDownloaded(true)}
-        />
+        {canRenderCard && (
+          <RecoveryArtifactsCard
+            ref={cardRef}
+            providerAddress={providerAddress as string}
+            peginTxid={peginTxid as string}
+            depositorPk={depositorPk as string}
+            vaultId={vaultId}
+            unsignedPrePeginTxHex={unsignedPrePeginTxHex}
+            onDownloaded={() => setDownloaded(true)}
+          />
+        )}
 
         {!downloaded && (
           <label className="flex w-full cursor-pointer items-start gap-4">
@@ -115,7 +137,11 @@ export function ActivateConfirmationModal({
       </DialogBody>
 
       <DialogFooter className="flex flex-row gap-4 px-6 pb-6 pt-4">
-        <Button variant="outlined" className="h-10 flex-1" onClick={onClose}>
+        <Button
+          variant="outlined"
+          className="h-10 flex-1"
+          onClick={handleClose}
+        >
           {COPY.deposit.activateConfirmation.cancelButton}
         </Button>
         <Button

--- a/services/vault/src/components/simple/ActivateConfirmationModal.tsx
+++ b/services/vault/src/components/simple/ActivateConfirmationModal.tsx
@@ -5,31 +5,34 @@ import {
   DialogFooter,
   DialogHeader,
   ResponsiveDialog,
-  Text,
-  Warning,
 } from "@babylonlabs-io/core-ui";
 import { useEffect, useState } from "react";
+import type { Hex } from "viem";
 
+import { RecoveryArtifactsCard } from "@/components/deposit/RecoveryArtifactsCard";
 import { COPY } from "@/copy";
 import { hasArtifactsDownloaded } from "@/utils/artifactDownloadStorage";
 
 interface ActivateConfirmationModalProps {
   open: boolean;
-  vaultId: string;
-  /** Tick that bumps after a download completes; forces a re-read of the flag. */
-  downloadCompletedAt?: number;
+  vaultId: Hex;
+  providerAddress: string;
+  peginTxid: string;
+  depositorPk: string;
+  unsignedPrePeginTxHex?: string;
   onClose: () => void;
   onConfirm: () => void;
-  onDownloadArtifacts: () => void;
 }
 
 export function ActivateConfirmationModal({
   open,
   vaultId,
-  downloadCompletedAt,
+  providerAddress,
+  peginTxid,
+  depositorPk,
+  unsignedPrePeginTxHex,
   onClose,
   onConfirm,
-  onDownloadArtifacts,
 }: ActivateConfirmationModalProps) {
   const [downloaded, setDownloaded] = useState(() =>
     hasArtifactsDownloaded(vaultId),
@@ -40,72 +43,90 @@ export function ActivateConfirmationModal({
     if (!open) return;
     setDownloaded(hasArtifactsDownloaded(vaultId));
     setAcknowledged(false);
-  }, [open, vaultId, downloadCompletedAt]);
+  }, [open, vaultId]);
+
+  const canActivate = downloaded || acknowledged;
 
   return (
-    <ResponsiveDialog open={open} onClose={onClose}>
+    <ResponsiveDialog
+      open={open}
+      onClose={onClose}
+      className="w-[564px] max-w-full"
+      dialogClassName="!rounded-2xl"
+    >
       <DialogHeader
-        title={COPY.deposit.activateConfirmation.title}
+        title=""
         onClose={onClose}
-        className="text-accent-primary"
+        // Float the close (×) button at the top-right with no border, so the
+        // title row sits absolutely over the body padding (matches the design).
+        className="text-accent-primary [&_.bbn-dialog-title]:!absolute [&_.bbn-dialog-title]:!right-5 [&_button]:!border-0"
       />
 
-      <DialogBody className="flex flex-col gap-4 px-4 pb-4 pt-4 text-accent-primary sm:px-6">
-        <Text variant="body2" className="text-accent-secondary">
-          {COPY.deposit.activateConfirmation.body}
-        </Text>
+      <DialogBody className="flex flex-col items-stretch gap-10 px-6 pb-2 pt-2 text-accent-primary">
+        <div className="flex flex-col items-center gap-10">
+          <svg
+            width="90"
+            height="90"
+            viewBox="0 0 90 90"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            className="text-accent-primary"
+            aria-hidden="true"
+          >
+            <path
+              d="M11.25 15.4793L45.0161 5.625L78.75 15.4793V35.6882C78.75 56.9291 65.1566 75.7864 45.0049 82.5009C24.8477 75.7866 11.25 56.925 11.25 35.6788V15.4793Z"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinejoin="round"
+            />
+          </svg>
+          <div className="flex w-full flex-col items-center gap-4">
+            <h2 className="text-center text-[34px] font-normal leading-[1.235] tracking-[0.25px] text-accent-primary">
+              {COPY.deposit.activateConfirmation.title}
+            </h2>
+            <p className="text-center text-xl font-normal leading-[1.6] tracking-[0.15px] text-accent-secondary">
+              {COPY.deposit.activateConfirmation.body}
+            </p>
+          </div>
+        </div>
 
-        {downloaded ? (
-          <Warning>
-            {COPY.deposit.activateConfirmation.alreadyDownloadedWarning}
-          </Warning>
-        ) : (
-          <>
-            <Warning>
-              {COPY.deposit.activateConfirmation.notDownloadedWarning}
-            </Warning>
-            <label className="flex cursor-pointer items-start gap-3">
-              <Checkbox
-                checked={acknowledged}
-                onChange={() => setAcknowledged((v) => !v)}
-                variant="default"
-                showLabel={false}
-              />
-              <span className="text-accent-primary">
-                {COPY.deposit.activateConfirmation.riskAcknowledgement}
-              </span>
-            </label>
-          </>
+        <RecoveryArtifactsCard
+          providerAddress={providerAddress}
+          peginTxid={peginTxid}
+          depositorPk={depositorPk}
+          vaultId={vaultId}
+          unsignedPrePeginTxHex={unsignedPrePeginTxHex}
+          onDownloaded={() => setDownloaded(true)}
+        />
+
+        {!downloaded && (
+          <label className="flex w-full cursor-pointer items-start gap-4">
+            <Checkbox
+              checked={acknowledged}
+              onChange={() => setAcknowledged((v) => !v)}
+              variant="default"
+              showLabel={false}
+            />
+            <span className="text-base leading-[1.5] tracking-[0.15px] text-accent-primary">
+              {COPY.deposit.activateConfirmation.riskAcknowledgement}
+            </span>
+          </label>
         )}
       </DialogBody>
 
-      <DialogFooter className="flex flex-col gap-3 px-4 pb-6 sm:px-6">
-        {downloaded ? (
-          <Button variant="contained" className="w-full" onClick={onConfirm}>
-            {COPY.deposit.activateConfirmation.activateButton}
-          </Button>
-        ) : (
-          <>
-            <Button
-              variant="contained"
-              className="w-full"
-              onClick={onDownloadArtifacts}
-            >
-              {COPY.deposit.activateConfirmation.downloadArtifactsButton}
-            </Button>
-            <Button
-              variant="outlined"
-              className="w-full"
-              onClick={onConfirm}
-              disabled={!acknowledged}
-            >
-              {
-                COPY.deposit.activateConfirmation
-                  .activateWithoutDownloadingButton
-              }
-            </Button>
-          </>
-        )}
+      <DialogFooter className="flex flex-row gap-4 px-6 pb-6 pt-4">
+        <Button variant="outlined" className="h-10 flex-1" onClick={onClose}>
+          {COPY.deposit.activateConfirmation.cancelButton}
+        </Button>
+        <Button
+          variant="contained"
+          color="secondary"
+          className="h-10 flex-1"
+          onClick={onConfirm}
+          disabled={!canActivate}
+        >
+          {COPY.deposit.activateConfirmation.activateButton}
+        </Button>
       </DialogFooter>
     </ResponsiveDialog>
   );

--- a/services/vault/src/components/simple/ActivationGate.tsx
+++ b/services/vault/src/components/simple/ActivationGate.tsx
@@ -1,6 +1,5 @@
 import { type ReactNode, useState } from "react";
 
-import { ArtifactDownloadModal } from "@/components/deposit/ArtifactDownloadModal";
 import type { VaultActivity } from "@/types/activity";
 
 import { ActivateConfirmationModal } from "./ActivateConfirmationModal";
@@ -18,47 +17,31 @@ export function ActivationGate({
   children,
 }: ActivationGateProps) {
   const [confirmed, setConfirmed] = useState(false);
-  const [showArtifactDownload, setShowArtifactDownload] = useState(false);
-  const [downloadCompletedAt, setDownloadCompletedAt] = useState(0);
 
   if (confirmed) return <>{children}</>;
 
   const providerAddress = activity.providers?.[0]?.id;
   const peginTxid = activity.peginTxHash;
   const depositorPk = activity.depositorBtcPubkey;
-  const artifacts =
-    providerAddress && peginTxid && depositorPk
-      ? { providerAddress, peginTxid, depositorPk }
-      : null;
+
+  // Activity arriving without these fields cannot be activated either:
+  // proceed to the activation step (children) so any downstream error
+  // surfaces in the activation flow rather than blocking the user on a
+  // disabled gate they can't recover from.
+  if (!providerAddress || !peginTxid || !depositorPk) {
+    return <>{children}</>;
+  }
 
   return (
-    <>
-      <ActivateConfirmationModal
-        open
-        vaultId={activity.id}
-        downloadCompletedAt={downloadCompletedAt}
-        onClose={onClose}
-        onConfirm={() => setConfirmed(true)}
-        onDownloadArtifacts={() => {
-          if (artifacts) setShowArtifactDownload(true);
-        }}
-      />
-
-      {showArtifactDownload && artifacts && (
-        <ArtifactDownloadModal
-          open
-          providerAddress={artifacts.providerAddress}
-          peginTxid={artifacts.peginTxid}
-          depositorPk={artifacts.depositorPk}
-          vaultId={activity.id}
-          unsignedPrePeginTxHex={activity.unsignedPrePeginTx}
-          onClose={() => setShowArtifactDownload(false)}
-          onComplete={() => {
-            setShowArtifactDownload(false);
-            setDownloadCompletedAt((n) => n + 1);
-          }}
-        />
-      )}
-    </>
+    <ActivateConfirmationModal
+      open
+      vaultId={activity.id}
+      providerAddress={providerAddress}
+      peginTxid={peginTxid}
+      depositorPk={depositorPk}
+      unsignedPrePeginTxHex={activity.unsignedPrePeginTx}
+      onClose={onClose}
+      onConfirm={() => setConfirmed(true)}
+    />
   );
 }

--- a/services/vault/src/components/simple/ActivationGate.tsx
+++ b/services/vault/src/components/simple/ActivationGate.tsx
@@ -20,25 +20,18 @@ export function ActivationGate({
 
   if (confirmed) return <>{children}</>;
 
-  const providerAddress = activity.providers?.[0]?.id;
-  const peginTxid = activity.peginTxHash;
-  const depositorPk = activity.depositorBtcPubkey;
-
-  // Activity arriving without these fields cannot be activated either:
-  // proceed to the activation step (children) so any downstream error
-  // surfaces in the activation flow rather than blocking the user on a
-  // disabled gate they can't recover from.
-  if (!providerAddress || !peginTxid || !depositorPk) {
-    return <>{children}</>;
-  }
-
+  // Always render the confirmation gate (even when the activity is missing
+  // any of providerAddress / peginTxid / depositorPk) so the user still
+  // sees the risk-acknowledgement checkbox before activating without
+  // artifacts. The modal hides the recovery-artifacts card when those
+  // fields aren't present and falls back to the acknowledgement-only path.
   return (
     <ActivateConfirmationModal
       open
       vaultId={activity.id}
-      providerAddress={providerAddress}
-      peginTxid={peginTxid}
-      depositorPk={depositorPk}
+      providerAddress={activity.providers?.[0]?.id}
+      peginTxid={activity.peginTxHash}
+      depositorPk={activity.depositorBtcPubkey}
       unsignedPrePeginTxHex={activity.unsignedPrePeginTx}
       onClose={onClose}
       onConfirm={() => setConfirmed(true)}

--- a/services/vault/src/components/simple/CollateralSection.tsx
+++ b/services/vault/src/components/simple/CollateralSection.tsx
@@ -266,35 +266,20 @@ export function CollateralSection({
           )}
         </Card>
       ) : (
-        <Card variant="filled" className="w-full">
-          <div className="flex flex-col items-center justify-center gap-2 py-20">
+        <Card variant="filled" className="w-full border-0">
+          <div className="flex flex-col items-center justify-center gap-2 py-4">
             <Avatar
               url={btcConfig.icon}
               alt={btcConfig.coinSymbol}
               size="xlarge"
-              className="mb-2 h-[100px] w-[100px]"
+              className="mb-4 h-[100px] w-[100px]"
             />
             <p className="text-[20px] text-accent-primary">
-              Deposit Bitcoin to get started
+              {COPY.collateral.empty.title}
             </p>
             <p className="text-[16px] text-accent-secondary">
-              Add {btcConfig.coinSymbol} as collateral so you can begin
-              borrowing assets.
+              {COPY.collateral.empty.body(btcConfig.coinSymbol)}
             </p>
-            <div className="mt-8">
-              {!isConnected ? (
-                <Connect />
-              ) : (
-                <DepositButton
-                  variant="outlined"
-                  size="medium"
-                  onClick={() => onDeposit()}
-                  className="rounded-full"
-                >
-                  Deposit {btcConfig.coinSymbol}
-                </DepositButton>
-              )}
-            </div>
           </div>
         </Card>
       )}

--- a/services/vault/src/components/simple/CollateralSection.tsx
+++ b/services/vault/src/components/simple/CollateralSection.tsx
@@ -24,7 +24,6 @@ import {
   CARD_DARK_BG_CLASS,
   SUMMARY_CARD_CLASS,
 } from "@/components/shared/layoutClasses";
-import { Connect } from "@/components/Wallet";
 import { getNetworkConfigBTC } from "@/config";
 import { COPY } from "@/copy";
 import type { ArtifactDownloadModalParams } from "@/hooks/deposit/useArtifactDownloadModal";

--- a/services/vault/src/components/simple/DisconnectedOverview.tsx
+++ b/services/vault/src/components/simple/DisconnectedOverview.tsx
@@ -1,0 +1,213 @@
+/**
+ * DisconnectedOverview Component
+ *
+ * Marketing / explainer panel rendered in place of the live Overview card
+ * when no wallet is connected. Left column: product pitch + Connect CTA +
+ * APR stats. Right column: 3-step "how it works" explainer.
+ */
+
+import { Avatar, MobileLogo } from "@babylonlabs-io/core-ui";
+import type { ReactNode } from "react";
+
+import { CARD_DARK_BG_CLASS } from "@/components/shared/layoutClasses";
+import { Connect } from "@/components/Wallet";
+import { COPY } from "@/copy";
+
+const COPY_OVERVIEW = COPY.overview.disconnected;
+
+interface AprStat {
+  label: string;
+  /** Display value (e.g. "3.7%"). Stat is omitted entirely when undefined. */
+  value: string | undefined;
+  /** Tailwind class for the value's text color. */
+  colorClass: string;
+}
+
+// Stub APR sources. Each entry's `value` should be wired to the real reserve
+// rate (variable borrow APR) once the data layer surfaces it. The three
+// entries below are commented out for now; restoring any one of them (with a
+// real `value`) will make that stat appear in the grid automatically.
+const APR_STATS: AprStat[] = [
+  // {
+  //   label: COPY_OVERVIEW.aprLabels.usdt,
+  //   value: undefined,
+  //   colorClass: "text-[#26A17B]",
+  // },
+  // {
+  //   label: COPY_OVERVIEW.aprLabels.usdc,
+  //   value: undefined,
+  //   colorClass: "text-[#2775CA]",
+  // },
+  // {
+  //   label: COPY_OVERVIEW.aprLabels.wbtc,
+  //   value: undefined,
+  //   colorClass: "text-[#F7931A]",
+  // },
+];
+
+function PanelCard({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className={`flex flex-col rounded-2xl bg-secondary-highlight p-10 ${CARD_DARK_BG_CLASS}`}
+    >
+      {children}
+    </div>
+  );
+}
+
+function BtcBadgeIcon({ badge }: { badge: "down" | "lock" }) {
+  // Light mode: white bg / #DDDDDD border / #666666 glyph.
+  // Dark  mode: #111111 bg / #2F2F2F border / #B0B0B0 glyph.
+  // `currentColor` lets the path inherit the text color set on the wrapper.
+  return (
+    <div className="relative inline-flex h-8 w-8">
+      <img src="/images/btc.png" alt="BTC" className="h-8 w-8 rounded-full" />
+      <div className="absolute -bottom-1 -right-1 flex h-4 w-4 items-center justify-center rounded-full border-[0.5px] border-[#DDDDDD] bg-white text-[#666666] dark:border-[#2F2F2F] dark:bg-[#111111] dark:text-[#B0B0B0]">
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 18 18"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          aria-hidden="true"
+        >
+          {badge === "down" ? (
+            <path
+              d="M13 9L12.295 8.295L9.5 11.085V5H8.5V11.085L5.71 8.29L5 9L9 13L13 9Z"
+              fill="currentColor"
+            />
+          ) : (
+            <path
+              d="M12 7H11.5V6C11.5 4.62 10.38 3.5 9 3.5C7.62 3.5 6.5 4.62 6.5 6V7H6C5.45 7 5 7.45 5 8V13C5 13.55 5.45 14 6 14H12C12.55 14 13 13.55 13 13V8C13 7.45 12.55 7 12 7ZM7.5 6C7.5 5.17 8.17 4.5 9 4.5C9.83 4.5 10.5 5.17 10.5 6V7H7.5V6ZM12 13H6V8H12V13ZM9 11.5C9.55 11.5 10 11.05 10 10.5C10 9.95 9.55 9.5 9 9.5C8.45 9.5 8 9.95 8 10.5C8 11.05 8.45 11.5 9 11.5Z"
+              fill="currentColor"
+            />
+          )}
+        </svg>
+      </div>
+    </div>
+  );
+}
+
+interface StepProps {
+  index: number;
+  icon: ReactNode;
+  title: string;
+  body: string;
+}
+
+function Step({ index, icon, title, body }: StepProps) {
+  return (
+    <div className="flex flex-col items-center gap-3 px-4 text-center">
+      {icon}
+      <div>
+        <span className="text-sm text-accent-secondary">
+          {COPY_OVERVIEW.steps.stepLabel(index)}
+        </span>
+        <h4 className="text-lg font-medium text-accent-primary">{title}</h4>
+        <p className="text-sm text-accent-secondary">{body}</p>
+      </div>
+    </div>
+  );
+}
+
+export function DisconnectedOverview() {
+  return (
+    <PanelCard>
+      <div className="grid grid-cols-1 gap-10 md:grid-cols-2 md:gap-12">
+        {/* Left: product pitch + Connect CTA + APR stats */}
+        <div className="flex flex-col justify-center">
+          <div className="flex items-center gap-4">
+            <span className="[&_svg]:!h-16 [&_svg]:!w-16 [&_svg]:!text-secondary-main dark:[&_svg]:!text-accent-primary">
+              <MobileLogo />
+            </span>
+            <img
+              src="/images/aave.svg"
+              alt="Aave"
+              className="h-16 w-16 rounded-full"
+            />
+          </div>
+
+          <h3 className="mt-10 text-[34px] font-normal leading-tight text-accent-primary">
+            {COPY_OVERVIEW.heroTitle}
+          </h3>
+          <p className="mt-4 text-base text-accent-secondary">
+            {COPY_OVERVIEW.heroBody}
+          </p>
+
+          <div className="mt-8">
+            <Connect text={COPY_OVERVIEW.connectButton} />
+          </div>
+
+          {(() => {
+            const loadedStats = APR_STATS.filter(
+              (s): s is AprStat & { value: string } => s.value !== undefined,
+            );
+            if (loadedStats.length === 0) return null;
+            return (
+              <div className="mt-10 grid grid-cols-3 gap-4">
+                {loadedStats.map((stat, i) => (
+                  <div
+                    key={stat.label}
+                    className={`flex flex-col gap-1 ${i > 0 ? "border-l border-secondary-strokeLight pl-4 dark:border-secondary-strokeDark" : ""}`}
+                  >
+                    <span className="text-xs text-accent-secondary">
+                      {stat.label}
+                    </span>
+                    <span className={`text-3xl font-normal ${stat.colorClass}`}>
+                      {stat.value}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            );
+          })()}
+        </div>
+
+        {/* Right: 3-step explainer (in the same panel) */}
+        <div className="flex flex-col gap-6 rounded-2xl bg-surface/40 p-6 dark:bg-black/20">
+          <Step
+            index={1}
+            icon={<BtcBadgeIcon badge="down" />}
+            title={COPY_OVERVIEW.steps.one.title}
+            body={COPY_OVERVIEW.steps.one.body}
+          />
+          <div className="border-t-[0.5px] border-secondary-strokeLight" />
+          <Step
+            index={2}
+            icon={
+              <div className="flex items-center">
+                <Avatar
+                  url="/images/usdt.png"
+                  alt="USDT"
+                  size="medium"
+                  className="h-8 w-8"
+                />
+                <Avatar
+                  url="/images/usdc.png"
+                  alt="USDC"
+                  size="medium"
+                  className="-ml-2 h-8 w-8"
+                />
+                <Avatar
+                  url="/images/wbtc.png"
+                  alt="WBTC"
+                  size="medium"
+                  className="-ml-2 h-8 w-8 bg-white"
+                />
+              </div>
+            }
+            title={COPY_OVERVIEW.steps.two.title}
+            body={COPY_OVERVIEW.steps.two.body}
+          />
+          <div className="border-t-[0.5px] border-secondary-strokeLight" />
+          <Step
+            index={3}
+            icon={<BtcBadgeIcon badge="lock" />}
+            title={COPY_OVERVIEW.steps.three.title}
+            body={COPY_OVERVIEW.steps.three.body}
+          />
+        </div>
+      </div>
+    </PanelCard>
+  );
+}

--- a/services/vault/src/components/simple/LoansSection.tsx
+++ b/services/vault/src/components/simple/LoansSection.tsx
@@ -1,12 +1,20 @@
 /**
  * LoansSection Component
- * Displays loan information with borrow/repay buttons and empty/active states
+ * Displays loan information with borrow/repay buttons and empty/active states.
+ * Each borrowed asset renders as its own expandable summary card, matching
+ * the visual pattern used by PendingDeposits / Collateral.
  */
 
 import { Avatar, Button, Card } from "@babylonlabs-io/core-ui";
+import { useState } from "react";
 
-import { Connect } from "@/components/Wallet";
+import { ExpandMenuButton } from "@/components/shared";
+import {
+  CARD_DARK_BG_CLASS,
+  SUMMARY_CARD_CLASS,
+} from "@/components/shared/layoutClasses";
 import { getNetworkConfigBTC } from "@/config";
+import { COPY } from "@/copy";
 
 const btcConfig = getNetworkConfigBTC();
 
@@ -14,6 +22,8 @@ interface LoanAsset {
   symbol: string;
   amount: string;
   icon: string;
+  /** Optional APR string (e.g. "5.861%"). When omitted, the row is hidden. */
+  borrowRate?: string;
 }
 
 interface LoansSectionProps {
@@ -33,10 +43,25 @@ export function LoansSection({
   onBorrow,
   onRepay,
 }: LoansSectionProps) {
+  const [expandedSymbols, setExpandedSymbols] = useState<Set<string>>(
+    () => new Set(),
+  );
+
+  const toggleExpanded = (symbol: string) => {
+    setExpandedSymbols((prev) => {
+      const next = new Set(prev);
+      if (next.has(symbol)) next.delete(symbol);
+      else next.add(symbol);
+      return next;
+    });
+  };
+
   return (
     <div className="w-full space-y-6">
       <div className="flex items-center justify-between">
-        <h2 className="text-[24px] font-normal text-accent-primary">Loans</h2>
+        <h2 className="text-[24px] font-normal text-accent-primary">
+          {COPY.loans.heading}
+        </h2>
         <div className="flex gap-3">
           <Button
             variant="outlined"
@@ -46,7 +71,7 @@ export function LoansSection({
             className="rounded-full"
             disabled={!isConnected || !hasCollateral}
           >
-            Borrow
+            {COPY.loans.borrowButton}
           </Button>
           {hasLoans && (
             <Button
@@ -57,34 +82,61 @@ export function LoansSection({
               className="rounded-full"
               disabled={!isConnected}
             >
-              Repay
+              {COPY.loans.repayButton}
             </Button>
           )}
         </div>
       </div>
 
-      <Card variant="filled" className="w-full">
-        {hasLoans ? (
-          <div className="space-y-4">
-            {borrowedAssets.map((asset) => (
-              <div
+      {hasLoans ? (
+        <div className="space-y-4">
+          {borrowedAssets.map((asset) => {
+            const isExpanded = expandedSymbols.has(asset.symbol);
+            return (
+              <Card
                 key={asset.symbol}
-                className="flex items-center justify-between"
+                variant="filled"
+                className={`${SUMMARY_CARD_CLASS} ${CARD_DARK_BG_CLASS}`}
               >
-                <span className="text-sm text-accent-secondary">Borrowed</span>
-                <div className="flex items-center gap-2">
-                  <Avatar url={asset.icon} alt={asset.symbol} size="small" />
-                  <span className="text-base text-accent-primary">
-                    {asset.amount} {asset.symbol}
-                  </span>
+                <div className="flex items-center justify-between gap-2">
+                  <div className="flex min-w-0 flex-1 items-center gap-2">
+                    <Avatar url={asset.icon} alt={asset.symbol} size="medium" />
+                    <span className="text-xl text-accent-primary">
+                      {asset.amount} {asset.symbol}
+                    </span>
+                  </div>
+                  {asset.borrowRate && (
+                    <div className="flex flex-shrink-0 items-center gap-2">
+                      <ExpandMenuButton
+                        isExpanded={isExpanded}
+                        onToggle={() => toggleExpanded(asset.symbol)}
+                        aria-label={COPY.loans.detailsAriaLabel(asset.symbol)}
+                      />
+                    </div>
+                  )}
                 </div>
-              </div>
-            ))}
-          </div>
-        ) : (
-          <div className="flex flex-col items-center justify-center gap-2 py-20">
+
+                {isExpanded && asset.borrowRate && (
+                  <div className="mt-4 border-t border-secondary-strokeLight pt-4 dark:border-secondary-strokeDark">
+                    <div className="flex items-center justify-between">
+                      <span className="text-base text-accent-secondary">
+                        {COPY.loans.borrowRateLabel}
+                      </span>
+                      <span className="text-base text-accent-primary">
+                        {asset.borrowRate}
+                      </span>
+                    </div>
+                  </div>
+                )}
+              </Card>
+            );
+          })}
+        </div>
+      ) : (
+        <Card variant="filled" className="w-full border-0">
+          <div className="flex flex-col items-center justify-center gap-2 py-4">
             {/* Overlapping token icons */}
-            <div className="mb-2 flex items-center">
+            <div className="mb-4 flex items-center">
               <Avatar
                 url="/images/btc.png"
                 alt="BTC"
@@ -106,16 +158,14 @@ export function LoansSection({
             </div>
 
             <p className="text-[20px] text-accent-primary">
-              Borrow assets using your {btcConfig.coinSymbol}
+              {COPY.loans.empty.title(btcConfig.coinSymbol)}
             </p>
-            <p className="text-[14px] text-accent-secondary">
-              Deposit {btcConfig.coinSymbol} as collateral to start borrowing.
+            <p className="text-[16px] text-accent-secondary">
+              {COPY.loans.empty.body(btcConfig.coinSymbol)}
             </p>
-
-            <div className="mt-8">{!isConnected ? <Connect /> : null}</div>
           </div>
-        )}
-      </Card>
+        </Card>
+      )}
     </div>
   );
 }

--- a/services/vault/src/components/simple/OverviewSection.tsx
+++ b/services/vault/src/components/simple/OverviewSection.tsx
@@ -1,9 +1,9 @@
 /**
  * OverviewSection Component
- * Displays overview information including Health Factor, Total Collateral Value, and Amount to Repay
+ * Displays overview information including Health Factor, Total Collateral
+ * Value, and Amount to Repay. Renders a marketing/explainer panel
+ * (DisconnectedOverview) when no wallet is connected.
  */
-
-import { Avatar } from "@babylonlabs-io/core-ui";
 
 import {
   formatHealthFactor,
@@ -12,6 +12,9 @@ import {
 } from "@/applications/aave/utils";
 import { HealthFactorGauge, HeartIcon } from "@/components/shared";
 import { CARD_DARK_BG_CLASS } from "@/components/shared/layoutClasses";
+import { COPY } from "@/copy";
+
+import { DisconnectedOverview } from "./DisconnectedOverview";
 
 interface OverviewSectionProps {
   healthFactor: number | null;
@@ -28,25 +31,20 @@ export function OverviewSection({
   amountToRepay,
   isConnected,
 }: OverviewSectionProps) {
+  if (!isConnected) {
+    return <DisconnectedOverview />;
+  }
+
   const healthFactorFormatted = formatHealthFactor(healthFactor);
   const healthFactorColor = getHealthFactorColor(healthFactorStatus);
-
-  const displayCollateral = isConnected ? totalCollateralValue : "--";
-  const displayRepay = isConnected ? amountToRepay : "--";
-  const showHealthFactor = isConnected && healthFactor !== null;
+  const showHealthFactor = healthFactor !== null;
 
   return (
     <div className="w-full space-y-6">
       <div className="flex items-center justify-between">
         <h2 className="text-[24px] font-normal text-accent-primary">
-          Overview
+          {COPY.overview.heading}
         </h2>
-        <Avatar
-          url="/images/aave.svg"
-          alt="Aave"
-          size="small"
-          className="h-8 w-8 !rounded-full"
-        />
       </div>
 
       <div
@@ -63,7 +61,9 @@ export function OverviewSection({
 
           {/* Health Factor Row */}
           <div className="flex items-center justify-between">
-            <span className="text-sm text-accent-secondary">Health factor</span>
+            <span className="text-sm text-accent-secondary">
+              {COPY.overview.healthFactorLabel}
+            </span>
             <span className="flex items-center gap-2 text-base text-accent-primary">
               {showHealthFactor ? (
                 <>
@@ -79,20 +79,20 @@ export function OverviewSection({
           {/* Total Collateral Value Row */}
           <div className="flex items-center justify-between">
             <span className="text-sm text-accent-secondary">
-              Total Collateral Value
+              {COPY.overview.totalCollateralValueLabel}
             </span>
             <span className="text-base text-accent-primary">
-              {displayCollateral}
+              {totalCollateralValue}
             </span>
           </div>
 
           {/* Amount to Repay Row */}
           <div className="flex items-center justify-between">
             <span className="text-sm text-accent-secondary">
-              Amount to repay
+              {COPY.overview.amountToRepayLabel}
             </span>
             <span className="text-base text-accent-primary">
-              {displayRepay}
+              {amountToRepay}
             </span>
           </div>
         </div>

--- a/services/vault/src/components/simple/SupplyCapSection.tsx
+++ b/services/vault/src/components/simple/SupplyCapSection.tsx
@@ -105,7 +105,7 @@ export function SupplyCapSection({
 
   return (
     <VaultCapFrame>
-      <CapCard label="Total Cap" btcDisplay={capDisplay} usd={capUsd} />
+      <CapCard label="Total Cap Available" btcDisplay={capDisplay} usd={capUsd} />
       <CapCard
         label="Total Deposited"
         btcDisplay={depositedDisplay}

--- a/services/vault/src/components/simple/__tests__/ActivateConfirmationModal.test.tsx
+++ b/services/vault/src/components/simple/__tests__/ActivateConfirmationModal.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import type { ReactNode } from "react";
+import { forwardRef, type ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { markArtifactsDownloaded } from "@/utils/artifactDownloadStorage";
@@ -40,16 +40,18 @@ vi.mock("@babylonlabs-io/core-ui", () => ({
 }));
 
 vi.mock("@/components/deposit/RecoveryArtifactsCard", () => ({
-  RecoveryArtifactsCard: (props: { onDownloaded?: () => void }) => (
-    <div data-testid="recovery-card">
-      <button
-        type="button"
-        data-testid="card-download-complete"
-        onClick={() => props.onDownloaded?.()}
-      >
-        download
-      </button>
-    </div>
+  RecoveryArtifactsCard: forwardRef<unknown, { onDownloaded?: () => void }>(
+    (props) => (
+      <div data-testid="recovery-card">
+        <button
+          type="button"
+          data-testid="card-download-complete"
+          onClick={() => props.onDownloaded?.()}
+        >
+          download
+        </button>
+      </div>
+    ),
   ),
 }));
 

--- a/services/vault/src/components/simple/__tests__/ActivateConfirmationModal.test.tsx
+++ b/services/vault/src/components/simple/__tests__/ActivateConfirmationModal.test.tsx
@@ -26,9 +26,6 @@ vi.mock("@babylonlabs-io/core-ui", () => ({
       onChange={props.onChange as () => void}
     />
   ),
-  Warning: (props: Record<string, unknown>) => (
-    <div data-testid="warning">{props.children as ReactNode}</div>
-  ),
   ResponsiveDialog: (props: Record<string, unknown>) =>
     props.open ? <div>{props.children as ReactNode}</div> : null,
   DialogHeader: (props: Record<string, unknown>) => (
@@ -42,113 +39,112 @@ vi.mock("@babylonlabs-io/core-ui", () => ({
   ),
 }));
 
+vi.mock("@/components/deposit/RecoveryArtifactsCard", () => ({
+  RecoveryArtifactsCard: (props: { onDownloaded?: () => void }) => (
+    <div data-testid="recovery-card">
+      <button
+        type="button"
+        data-testid="card-download-complete"
+        onClick={() => props.onDownloaded?.()}
+      >
+        download
+      </button>
+    </div>
+  ),
+}));
+
 const VAULT_ID = "0xabc123";
+const COMMON_PROPS = {
+  vaultId: VAULT_ID,
+  providerAddress: "0xprovider",
+  peginTxid: "0xpegin",
+  depositorPk: "0xpk",
+} as const;
 
 describe("ActivateConfirmationModal", () => {
   beforeEach(() => {
     window.localStorage.clear();
   });
 
-  it("shows the Download CTA and a disabled Activate-without-downloading button when not yet downloaded", () => {
+  it("disables the Activate button until the risk checkbox is ticked when not downloaded", () => {
     render(
       <ActivateConfirmationModal
         open
-        vaultId={VAULT_ID}
+        {...COMMON_PROPS}
         onClose={vi.fn()}
         onConfirm={vi.fn()}
-        onDownloadArtifacts={vi.fn()}
       />,
     );
 
-    expect(screen.getByText("Download Artifacts")).toBeInTheDocument();
-    const activateBtn = screen.getByText("Activate without downloading");
+    const activateBtn = screen.getByText("Activate Vault");
     expect(activateBtn).toBeDisabled();
+
+    fireEvent.click(screen.getByTestId("risk-checkbox"));
+    expect(activateBtn).not.toBeDisabled();
   });
 
-  it("enables the activate-without-downloading button after the checkbox is ticked", () => {
+  it("calls onConfirm when Activate Vault is clicked", () => {
     const onConfirm = vi.fn();
     render(
       <ActivateConfirmationModal
         open
-        vaultId={VAULT_ID}
+        {...COMMON_PROPS}
         onClose={vi.fn()}
         onConfirm={onConfirm}
-        onDownloadArtifacts={vi.fn()}
       />,
     );
 
     fireEvent.click(screen.getByTestId("risk-checkbox"));
-    const activateBtn = screen.getByText("Activate without downloading");
-    expect(activateBtn).not.toBeDisabled();
-    fireEvent.click(activateBtn);
+    fireEvent.click(screen.getByText("Activate Vault"));
     expect(onConfirm).toHaveBeenCalledTimes(1);
   });
 
-  it("invokes onDownloadArtifacts when the user clicks Download", () => {
-    const onDownloadArtifacts = vi.fn();
+  it("calls onClose when Cancel is clicked", () => {
+    const onClose = vi.fn();
     render(
       <ActivateConfirmationModal
         open
-        vaultId={VAULT_ID}
-        onClose={vi.fn()}
+        {...COMMON_PROPS}
+        onClose={onClose}
         onConfirm={vi.fn()}
-        onDownloadArtifacts={onDownloadArtifacts}
       />,
     );
-    fireEvent.click(screen.getByText("Download Artifacts"));
-    expect(onDownloadArtifacts).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByText("Cancel"));
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it("shows a single Activate primary CTA when artifacts are already downloaded", () => {
+  it("enables Activate Vault directly and hides the checkbox when artifacts were already downloaded", () => {
     markArtifactsDownloaded(VAULT_ID);
-    const onConfirm = vi.fn();
     render(
       <ActivateConfirmationModal
         open
-        vaultId={VAULT_ID}
+        {...COMMON_PROPS}
         onClose={vi.fn()}
-        onConfirm={onConfirm}
-        onDownloadArtifacts={vi.fn()}
+        onConfirm={vi.fn()}
       />,
     );
 
-    expect(screen.getByText("Activate")).toBeInTheDocument();
-    expect(
-      screen.queryByText("Activate without downloading"),
-    ).not.toBeInTheDocument();
-    expect(screen.queryByText("Download Artifacts")).not.toBeInTheDocument();
-
-    fireEvent.click(screen.getByText("Activate"));
-    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("Activate Vault")).not.toBeDisabled();
+    expect(screen.queryByTestId("risk-checkbox")).not.toBeInTheDocument();
   });
 
-  it("re-reads the downloaded flag when downloadCompletedAt changes", () => {
-    const { rerender } = render(
+  it("enables Activate Vault and removes the checkbox once the card reports a download", () => {
+    render(
       <ActivateConfirmationModal
         open
-        vaultId={VAULT_ID}
-        downloadCompletedAt={0}
+        {...COMMON_PROPS}
         onClose={vi.fn()}
         onConfirm={vi.fn()}
-        onDownloadArtifacts={vi.fn()}
       />,
     );
 
-    expect(screen.getByText("Download Artifacts")).toBeInTheDocument();
+    expect(screen.getByText("Activate Vault")).toBeDisabled();
+    expect(screen.getByTestId("risk-checkbox")).toBeInTheDocument();
 
-    markArtifactsDownloaded(VAULT_ID);
-    rerender(
-      <ActivateConfirmationModal
-        open
-        vaultId={VAULT_ID}
-        downloadCompletedAt={1}
-        onClose={vi.fn()}
-        onConfirm={vi.fn()}
-        onDownloadArtifacts={vi.fn()}
-      />,
-    );
+    fireEvent.click(screen.getByTestId("card-download-complete"));
 
-    expect(screen.getByText("Activate")).toBeInTheDocument();
-    expect(screen.queryByText("Download Artifacts")).not.toBeInTheDocument();
+    expect(screen.getByText("Activate Vault")).not.toBeDisabled();
+    expect(screen.queryByTestId("risk-checkbox")).not.toBeInTheDocument();
   });
 });

--- a/services/vault/src/components/simple/__tests__/ActivationGate.test.tsx
+++ b/services/vault/src/components/simple/__tests__/ActivationGate.test.tsx
@@ -9,50 +9,15 @@ vi.mock("../ActivateConfirmationModal", () => ({
   ActivateConfirmationModal: ({
     onConfirm,
     onClose,
-    onDownloadArtifacts,
-    downloadCompletedAt,
   }: {
     onConfirm: () => void;
     onClose: () => void;
-    onDownloadArtifacts: () => void;
-    downloadCompletedAt?: number;
   }) => (
     <div data-testid="confirm">
-      <span data-testid="confirm-tick">{String(downloadCompletedAt ?? 0)}</span>
       <button type="button" data-testid="confirm-activate" onClick={onConfirm}>
         activate
       </button>
-      <button
-        type="button"
-        data-testid="confirm-download"
-        onClick={onDownloadArtifacts}
-      >
-        download
-      </button>
       <button type="button" data-testid="confirm-close" onClick={onClose}>
-        close
-      </button>
-    </div>
-  ),
-}));
-
-vi.mock("@/components/deposit/ArtifactDownloadModal", () => ({
-  ArtifactDownloadModal: ({
-    onComplete,
-    onClose,
-  }: {
-    onComplete: () => void;
-    onClose: () => void;
-  }) => (
-    <div data-testid="artifact">
-      <button
-        type="button"
-        data-testid="artifact-complete"
-        onClick={onComplete}
-      >
-        complete
-      </button>
-      <button type="button" data-testid="artifact-close" onClick={onClose}>
         close
       </button>
     </div>
@@ -91,35 +56,6 @@ describe("ActivationGate", () => {
     expect(getByTestId("activation-step")).toBeTruthy();
   });
 
-  it("opens artifact download from the gate and bumps the tick on completion", () => {
-    const { getByTestId, queryByTestId } = render(
-      <ActivationGate activity={activity()} onClose={vi.fn()}>
-        <div data-testid="activation-step" />
-      </ActivationGate>,
-    );
-    expect(getByTestId("confirm-tick").textContent).toBe("0");
-
-    fireEvent.click(getByTestId("confirm-download"));
-    expect(getByTestId("artifact")).toBeTruthy();
-
-    fireEvent.click(getByTestId("artifact-complete"));
-    expect(queryByTestId("artifact")).toBeNull();
-    expect(getByTestId("confirm-tick").textContent).toBe("1");
-  });
-
-  it("does not open artifact download when artifact inputs are missing", () => {
-    const { getByTestId, queryByTestId } = render(
-      <ActivationGate
-        activity={activity({ peginTxHash: undefined })}
-        onClose={vi.fn()}
-      >
-        <div data-testid="activation-step" />
-      </ActivationGate>,
-    );
-    fireEvent.click(getByTestId("confirm-download"));
-    expect(queryByTestId("artifact")).toBeNull();
-  });
-
   it("forwards close from the confirmation gate", () => {
     const onClose = vi.fn();
     const { getByTestId } = render(
@@ -129,5 +65,18 @@ describe("ActivationGate", () => {
     );
     fireEvent.click(getByTestId("confirm-close"));
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips the gate and renders children when artifact inputs are missing", () => {
+    const { getByTestId, queryByTestId } = render(
+      <ActivationGate
+        activity={activity({ peginTxHash: undefined })}
+        onClose={vi.fn()}
+      >
+        <div data-testid="activation-step" />
+      </ActivationGate>,
+    );
+    expect(queryByTestId("confirm")).toBeNull();
+    expect(getByTestId("activation-step")).toBeTruthy();
   });
 });

--- a/services/vault/src/components/simple/__tests__/ActivationGate.test.tsx
+++ b/services/vault/src/components/simple/__tests__/ActivationGate.test.tsx
@@ -67,7 +67,7 @@ describe("ActivationGate", () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it("skips the gate and renders children when artifact inputs are missing", () => {
+  it("still renders the confirmation gate when artifact inputs are missing so the user must acknowledge the risk", () => {
     const { getByTestId, queryByTestId } = render(
       <ActivationGate
         activity={activity({ peginTxHash: undefined })}
@@ -76,7 +76,7 @@ describe("ActivationGate", () => {
         <div data-testid="activation-step" />
       </ActivationGate>,
     );
-    expect(queryByTestId("confirm")).toBeNull();
-    expect(getByTestId("activation-step")).toBeTruthy();
+    expect(getByTestId("confirm")).toBeTruthy();
+    expect(queryByTestId("activation-step")).toBeNull();
   });
 });

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -253,6 +253,8 @@ export const COPY = {
       cancelDownloadButton: "Cancel",
       downloadedLabel: "Downloaded",
       retryButton: "Retry",
+      walletSignatureHint:
+        "You may be asked to approve a signature in your wallet to authenticate.",
       cannotAuthenticate:
         "Cannot authenticate with the vault provider. Please refresh and try again.",
     },

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -231,29 +231,28 @@ export const COPY = {
       confirmButton: "Confirm",
     },
     activateConfirmation: {
-      title: "Activate your BTC Vault",
-      body: "Activating your BTC Vault reveals the HTLC secret on Ethereum and finalizes your deposit. Before continuing, make sure you have downloaded your BTC Vault artifacts — these files let you independently claim your funds if the vault provider is unavailable.",
-      alreadyDownloadedWarning:
-        "We've already recorded that you downloaded artifacts for this BTC Vault from this browser. If you've since cleared site data or switched devices, download them again before activating.",
-      notDownloadedWarning:
-        "You haven't downloaded the artifacts for this BTC Vault yet on this browser. If you lose them and the vault provider goes offline, you will not be able to independently claim your funds.",
+      title: "Activate your vault",
+      body: "Before activating, download your vault artifacts. These files may be needed later to recover access to your vault.",
       riskAcknowledgement:
-        "I understand the risk of activating without downloading my artifacts.",
-      activateButton: "Activate",
-      downloadArtifactsButton: "Download Artifacts",
-      activateWithoutDownloadingButton: "Activate without downloading",
+        "I understand the risks of continuing without the artifacts.",
+      activateButton: "Activate Vault",
+      cancelButton: "Cancel",
     },
     artifactDownload: {
       title: "Download BTC Vault Artifacts",
-      body: "Before broadcasting your Bitcoin transaction, you need to download your BTC Vault artifacts. These files are required to independently claim your funds if the vault provider is unavailable.",
-      storeSafelyWarning:
-        "Store these files safely on your local disk or external drive. If you lose them and the vault provider goes offline, you will not be able to independently claim your funds.",
-      downloadedBody:
-        "Artifacts downloaded successfully. Please save the file to a safe location before continuing.",
-      downloading: "Downloading...",
-      downloadButton: "Download Artifacts",
+      body: "Download your BTC Vault artifacts. These files are required to independently claim your funds if the vault provider is unavailable.",
       cancelButton: "Cancel",
       continueButton: "Continue",
+    },
+    recoveryArtifacts: {
+      cardTitle: "Recovery artifacts",
+      cardSubtitle: "Encrypted backup files",
+      cardSize: "Up to ~1 GB",
+      downloadButton: "Download Artifacts",
+      downloadingButton: "Downloading...",
+      cancelDownloadButton: "Cancel",
+      downloadedLabel: "Downloaded",
+      retryButton: "Retry",
       cannotAuthenticate:
         "Cannot authenticate with the vault provider. Please refresh and try again.",
     },
@@ -367,6 +366,55 @@ export const COPY = {
     releaseHfBreachTooltip: (threshold: number) =>
       `This selection would drop your health factor below ${threshold.toFixed(1)} and be rejected on-chain. Reduce the selection or repay debt first.`,
     uncapped: "Uncapped",
+    empty: {
+      title: "Deposit Bitcoin to get started",
+      body: (symbol: string) =>
+        `Add ${symbol} as collateral so you can begin borrowing assets.`,
+    },
+  },
+  loans: {
+    heading: "Loans",
+    borrowButton: "Borrow",
+    repayButton: "Repay",
+    borrowRateLabel: "Borrow rate",
+    detailsAriaLabel: (symbol: string) => `${symbol} loan details`,
+    empty: {
+      title: (symbol: string) => `Borrow assets using your ${symbol}`,
+      body: (symbol: string) =>
+        `Deposit ${symbol} as collateral to start borrowing.`,
+    },
+  },
+  overview: {
+    heading: "Overview",
+    healthFactorLabel: "Health factor",
+    totalCollateralValueLabel: "Total Collateral Value",
+    amountToRepayLabel: "Amount to repay",
+    disconnected: {
+      heroTitle: "Native Bitcoin backed borrowing",
+      heroBody:
+        "Powered by Babylon & Aave — deposit BTC and borrow stablecoins or WBTC.",
+      connectButton: "Connect Wallet",
+      aprLabels: {
+        usdt: "USDT APR",
+        usdc: "USDC APR",
+        wbtc: "WBTC APR",
+      },
+      steps: {
+        stepLabel: (n: number) => `step ${n}`,
+        one: {
+          title: "Deposit BTC as collateral",
+          body: "Lock your BTC in a secure smart contract.",
+        },
+        two: {
+          title: "Borrow USDC, USDT or WBTC",
+          body: "Get stablecoin liquidity powered by Aave.",
+        },
+        three: {
+          title: "Repay anytime to unlock BTC",
+          body: "Repay debt plus interest to reclaim BTC.",
+        },
+      },
+    },
   },
   banner: {
     addCollateral: "Add Collateral",

--- a/services/vault/src/hooks/deposit/useArtifactDownload.ts
+++ b/services/vault/src/hooks/deposit/useArtifactDownload.ts
@@ -106,7 +106,7 @@ export function useArtifactDownload(options?: {
       const ensurePrimedOrFail = async (): Promise<boolean> => {
         if (vpTokenRegistry.peek(normalizedPeginTxid)) return true;
         if (!primeContext) {
-          setError(COPY.deposit.artifactDownload.cannotAuthenticate);
+          setError(COPY.deposit.recoveryArtifacts.cannotAuthenticate);
           return false;
         }
         try {


### PR DESCRIPTION
<img width="1060" height="367" alt="Screenshot 2026-05-24 at 03 24 44" src="https://github.com/user-attachments/assets/614afc9c-6c10-4b2a-84a2-39c2a9b87e69" />
<img width="1486" height="922" alt="Screenshot 2026-05-24 at 03 24 27" src="https://github.com/user-attachments/assets/ec706c1e-60f6-4fe3-bfbb-055ea22e256c" />
<img width="1479" height="917" alt="Screenshot 2026-05-24 at 03 24 20" src="https://github.com/user-attachments/assets/929abd10-441c-4f46-b286-a37eeb29e8ff" />
<img width="617" height="747" alt="Screenshot 2026-05-24 at 03 39 14" src="https://github.com/user-attachments/assets/2c403d07-a257-442d-bcbb-b9252451298f" />
<img width="601" height="694" alt="Screenshot 2026-05-24 at 03 39 25" src="https://github.com/user-attachments/assets/45ec4e7a-dbce-445e-8067-d267f11569e1" />
