### PR TITLE
fix(vault): use per-group substep numbering in deposit flow

### DIFF
--- a/services/vault/src/components/simple/DepositProgressView/GroupedProgress.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/GroupedProgress.tsx
@@ -51,23 +51,25 @@ export function GroupedProgress({
 
             {group.expanded && (
               <div className="ml-[15px] flex flex-col border-l-2 border-secondary-strokeDark py-2 pl-6">
-                {stepNumbers.map((stepNumber, subIndex) => {
-                  const step = steps[stepNumber - 1];
+                {stepNumbers.map((globalStepNum, subIndex) => {
+                  const step = steps[globalStepNum - 1];
                   if (!step) return null;
 
+                  const displayNumber = subIndex + 1;
+
                   const state: StepRowState =
-                    stepNumber < currentStep
+                    globalStepNum < currentStep
                       ? "completed"
-                      : stepNumber === currentStep
+                      : globalStepNum === currentStep
                         ? "active"
                         : "pending";
 
                   return (
-                    <div key={stepNumber}>
+                    <div key={globalStepNum}>
                       {subIndex > 0 && <StepConnector />}
                       <StepRow
                         state={state}
-                        number={stepNumber}
+                        number={displayNumber}
                         label={step.label}
                         description={step.description}
                         detail={activeStepDetail}

--- a/services/vault/src/components/simple/DepositProgressView/GroupedProgress.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/GroupedProgress.tsx
@@ -70,6 +70,7 @@ export function GroupedProgress({
                       <StepRow
                         state={state}
                         number={displayNumber}
+                        ariaNumber={globalStepNum}
                         label={step.label}
                         description={step.description}
                         detail={activeStepDetail}

--- a/services/vault/src/components/simple/DepositProgressView/StepRow.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/StepRow.tsx
@@ -10,9 +10,12 @@ export type StepRowState = "completed" | "active" | "pending";
 function StepCircle({
   state,
   number,
+  ariaNumber,
 }: {
   state: StepRowState;
   number: number;
+  /** Override for screen-reader label; defaults to `number` (visual) when absent. */
+  ariaNumber?: number;
 }) {
   const base = "flex h-8 w-8 shrink-0 items-center justify-center rounded-full";
 
@@ -28,7 +31,7 @@ function StepCircle({
     return (
       <div
         className={twMerge(base, "border-2 border-primary-light")}
-        aria-label={COPY.deposit.a11y.stepActive(number)}
+        aria-label={COPY.deposit.a11y.stepActive(ariaNumber ?? number)}
       >
         <Loader size={16} className="text-primary-light" />
       </div>
@@ -58,6 +61,8 @@ interface StepRowProps {
   detail?: ReactNode;
   /** True when another sub-step follows in the group (i.e. not the last). */
   hasNext?: boolean;
+  /** Override for screen-reader label; defaults to `number` (visual) when absent. */
+  ariaNumber?: number;
 }
 
 export function StepRow({
@@ -67,6 +72,7 @@ export function StepRow({
   description,
   detail,
   hasNext = false,
+  ariaNumber,
 }: StepRowProps) {
   const isActive = state === "active";
   // A detail panel makes the active row taller than a circle. Fill the extra
@@ -82,7 +88,7 @@ export function StepRow({
       )}
     >
       <div className="flex w-8 flex-col items-center self-stretch">
-        <StepCircle state={state} number={number} />
+        <StepCircle state={state} number={number} ariaNumber={ariaNumber} />
         {showTrailingLine && (
           <div className="w-0 flex-1 border-l-2 border-secondary-strokeDark" />
         )}

--- a/services/vault/src/components/simple/DepositProgressView/StepRow.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/StepRow.tsx
@@ -39,7 +39,10 @@ function StepCircle({
   }
 
   return (
-    <div className={twMerge(base, "border-2 border-secondary-strokeDark")}>
+    <div
+      className={twMerge(base, "border-2 border-secondary-strokeDark")}
+      aria-label={COPY.deposit.a11y.stepPending(ariaNumber ?? number)}
+    >
       <Text
         as="span"
         variant="body2"

--- a/services/vault/src/components/simple/DepositProgressView/__tests__/GroupedProgress.test.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/__tests__/GroupedProgress.test.tsx
@@ -104,12 +104,13 @@ describe("GroupedProgress", () => {
   });
 
   describe("accessibility", () => {
-    it("labels the active sub-step for screen readers", () => {
-      // Step 8 -> "Set up claim" group active; per-group display number is 1.
+    it("labels the active sub-step for screen readers with the global step number", () => {
+      // Step 8 -> "Set up claim" group active; screen reader gets global step 8,
+      // not the per-group display number 1.
       render(<GroupedProgress steps={steps} currentStep={8} />);
 
       expect(
-        screen.getByLabelText(COPY.deposit.a11y.stepActive(1)),
+        screen.getByLabelText(COPY.deposit.a11y.stepActive(8)),
       ).toBeInTheDocument();
     });
 

--- a/services/vault/src/components/simple/DepositProgressView/__tests__/GroupedProgress.test.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/__tests__/GroupedProgress.test.tsx
@@ -54,19 +54,19 @@ describe("GroupedProgress", () => {
   });
 
   it("renders completed sub-steps without a step number inside the active group", () => {
-    // Step 11 -> "Sign payout" group (10-13) active; step 10 is already done.
+    // Step 11 -> "Sign payout" group (global 10-13) active; global step 10 is already done.
     render(<GroupedProgress steps={steps} currentStep={11} />);
 
     // Completed sub-step label is shown...
     expect(
       screen.getByText(COPY.deposit.steps.authenticateSession),
     ).toBeInTheDocument();
-    // ...but rendered as a checkmark row, not the numbered pending row "10".
-    expect(screen.queryByText("10")).not.toBeInTheDocument();
+    // ...but rendered as a checkmark row, not the numbered pending row "1".
+    expect(screen.queryByText("1")).not.toBeInTheDocument();
 
-    // Pending sub-steps still carry their global numbers.
-    expect(screen.getByText("12")).toBeInTheDocument();
-    expect(screen.getByText("13")).toBeInTheDocument();
+    // Pending sub-steps carry per-group numbers (3, 4 within the group).
+    expect(screen.getByText("3")).toBeInTheDocument();
+    expect(screen.getByText("4")).toBeInTheDocument();
   });
 
   it("mounts the active-step detail panel inside the active step", () => {
@@ -105,11 +105,11 @@ describe("GroupedProgress", () => {
 
   describe("accessibility", () => {
     it("labels the active sub-step for screen readers", () => {
-      // Step 8 -> "Set up claim" group active; step 8 is the active sub-step.
+      // Step 8 -> "Set up claim" group active; per-group display number is 1.
       render(<GroupedProgress steps={steps} currentStep={8} />);
 
       expect(
-        screen.getByLabelText(COPY.deposit.a11y.stepActive(8)),
+        screen.getByLabelText(COPY.deposit.a11y.stepActive(1)),
       ).toBeInTheDocument();
     });
 

--- a/services/vault/src/components/simple/DepositProgressView/__tests__/GroupedProgress.test.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/__tests__/GroupedProgress.test.tsx
@@ -114,6 +114,16 @@ describe("GroupedProgress", () => {
       ).toBeInTheDocument();
     });
 
+    it("labels a pending sub-step for screen readers with the global step number", () => {
+      // Step 8 -> "Set up claim" group (8-9) active; global step 9 is pending and
+      // its screen-reader label keeps the global number, not the per-group number 2.
+      render(<GroupedProgress steps={steps} currentStep={8} />);
+
+      expect(
+        screen.getByLabelText(COPY.deposit.a11y.stepPending(9)),
+      ).toBeInTheDocument();
+    });
+
     it("exposes each group's status to screen readers", () => {
       render(<GroupedProgress steps={steps} currentStep={8} />);
 

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -164,6 +164,7 @@ export const COPY = {
     // purely visually (spinner, checkmark, hollow circle).
     a11y: {
       stepActive: (number: number) => `Step ${number} active`,
+      stepPending: (number: number) => `Step ${number} not started`,
       groupStatus: {
         completed: "Completed",
         active: "In progress",


### PR DESCRIPTION
Change deposit flow progress view to display step numbers 1,2,3... within each group instead of continuing global numbering across groups. Groups A-D now each restart at step 1 internally. All internal logic (getVisualStep, buildStepGroups, STEP_GROUPS, progress bar) is unchanged and continues using global indices.

## Screenshot

<img width="2912" height="1804" alt="image" src="https://github.com/user-attachments/assets/b4a0aac6-38d8-48e2-b9fb-08d7d008e019" />
