### PR TITLE
feat(vault): order on chain

### DIFF
--- a/services/vault/src/applications/aave/context/ReorderOverrideContext.tsx
+++ b/services/vault/src/applications/aave/context/ReorderOverrideContext.tsx
@@ -1,0 +1,109 @@
+/**
+ * Reorder Override Context
+ *
+ * Holds, in memory only, the vault ordering the user just submitted in a reorder
+ * (captured after the tx confirms — at which point the submitted order is the
+ * on-chain order). The dashboard sorts the collateral list by this order so the
+ * user sees the new order immediately, instead of waiting for the indexer to
+ * ingest the `VaultsReordered` event and rewrite `liquidationIndex`.
+ *
+ * Deliberately NOT persisted (no localStorage): it is best-effort immediate
+ * feedback. A page refresh mid-window drops it and the dashboard falls back to
+ * indexer ordering. The override is cleared once the indexer reconciles (see
+ * useDashboardState) or, as a backstop, after REORDER_OVERRIDE_TIMEOUT_MS.
+ */
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import type { Hex } from "viem";
+
+/**
+ * How long the in-memory post-reorder order override is held before it is
+ * auto-cleared, as a backstop in case the indexer never reflects the submitted
+ * order (e.g. a concurrent position change). Until then the dashboard shows the
+ * submitted order; reconciliation normally clears it sooner, once the indexer
+ * catches up. 90s ≈ 3 × the 30s position poll.
+ */
+const REORDER_OVERRIDE_TIMEOUT_MS = 90 * 1000;
+
+interface ReorderOverrideContextValue {
+  /**
+   * The submitted (post-confirmation) vault ordering to display while the
+   * indexer catches up, or `null` when there is no pending reorder to reflect.
+   */
+  reorderedOrder: readonly Hex[] | null;
+  /** Set the override to the submitted order and (re)arm the auto-clear timer. */
+  applyReorderedOrder: (order: readonly Hex[]) => void;
+  /** Clear the override (called when the indexer reconciles, or on unmount). */
+  clearReorderedOrder: () => void;
+}
+
+const ReorderOverrideContext =
+  createContext<ReorderOverrideContextValue | null>(null);
+
+export function ReorderOverrideProvider({ children }: { children: ReactNode }) {
+  const [reorderedOrder, setReorderedOrder] = useState<readonly Hex[] | null>(
+    null,
+  );
+  const timerRef = useRef<ReturnType<typeof setTimeout>>();
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = undefined;
+    }
+  }, []);
+
+  const clearReorderedOrder = useCallback(() => {
+    clearTimer();
+    setReorderedOrder(null);
+  }, [clearTimer]);
+
+  const applyReorderedOrder = useCallback(
+    (order: readonly Hex[]) => {
+      clearTimer();
+      setReorderedOrder(order);
+      timerRef.current = setTimeout(() => {
+        setReorderedOrder(null);
+        timerRef.current = undefined;
+      }, REORDER_OVERRIDE_TIMEOUT_MS);
+    },
+    [clearTimer],
+  );
+
+  // Clean up the timer if the provider unmounts mid-window.
+  useEffect(() => clearTimer, [clearTimer]);
+
+  const value = useMemo(
+    () => ({ reorderedOrder, applyReorderedOrder, clearReorderedOrder }),
+    [reorderedOrder, applyReorderedOrder, clearReorderedOrder],
+  );
+
+  return (
+    <ReorderOverrideContext.Provider value={value}>
+      {children}
+    </ReorderOverrideContext.Provider>
+  );
+}
+
+/**
+ * Access the reorder override context. Must be used within a
+ * ReorderOverrideProvider.
+ */
+export function useReorderOverride(): ReorderOverrideContextValue {
+  const ctx = useContext(ReorderOverrideContext);
+  if (!ctx) {
+    throw new Error(
+      "useReorderOverride must be used within a ReorderOverrideProvider",
+    );
+  }
+  return ctx;
+}

--- a/services/vault/src/applications/aave/context/__tests__/ReorderOverrideContext.test.tsx
+++ b/services/vault/src/applications/aave/context/__tests__/ReorderOverrideContext.test.tsx
@@ -1,0 +1,69 @@
+import { act, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  ReorderOverrideProvider,
+  useReorderOverride,
+} from "../ReorderOverrideContext";
+
+const VAULT_A = ("0x" + "a".repeat(64)) as `0x${string}`;
+const VAULT_B = ("0x" + "b".repeat(64)) as `0x${string}`;
+// The provider auto-clears the override after 90s (its internal backstop).
+const OVERRIDE_TIMEOUT_MS = 90 * 1000;
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <ReorderOverrideProvider>{children}</ReorderOverrideProvider>;
+}
+
+describe("ReorderOverrideContext", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("starts with no override", () => {
+    const { result } = renderHook(() => useReorderOverride(), { wrapper });
+    expect(result.current.reorderedOrder).toBeNull();
+  });
+
+  it("applyReorderedOrder sets the order", () => {
+    const { result } = renderHook(() => useReorderOverride(), { wrapper });
+    act(() => result.current.applyReorderedOrder([VAULT_A, VAULT_B]));
+    expect(result.current.reorderedOrder).toEqual([VAULT_A, VAULT_B]);
+  });
+
+  it("auto-clears the override after the backstop timeout", () => {
+    const { result } = renderHook(() => useReorderOverride(), { wrapper });
+    act(() => result.current.applyReorderedOrder([VAULT_A, VAULT_B]));
+
+    // Just before the timeout it is still held...
+    act(() => vi.advanceTimersByTime(OVERRIDE_TIMEOUT_MS - 1));
+    expect(result.current.reorderedOrder).not.toBeNull();
+
+    // ...and cleared once it elapses.
+    act(() => vi.advanceTimersByTime(1));
+    expect(result.current.reorderedOrder).toBeNull();
+  });
+
+  it("clearReorderedOrder clears immediately and cancels the timer", () => {
+    const { result } = renderHook(() => useReorderOverride(), { wrapper });
+    act(() => result.current.applyReorderedOrder([VAULT_A, VAULT_B]));
+    act(() => result.current.clearReorderedOrder());
+    expect(result.current.reorderedOrder).toBeNull();
+  });
+
+  it("throws when used outside the provider", () => {
+    // Silence the expected React error-boundary log for this intentional throw.
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    expect(() => renderHook(() => useReorderOverride())).toThrow(
+      /within a ReorderOverrideProvider/,
+    );
+    consoleError.mockRestore();
+  });
+});

--- a/services/vault/src/applications/aave/context/index.ts
+++ b/services/vault/src/applications/aave/context/index.ts
@@ -4,3 +4,7 @@ export {
   usePendingVaults,
   useSyncPendingVaults,
 } from "./PendingVaultsContext";
+export {
+  ReorderOverrideProvider,
+  useReorderOverride,
+} from "./ReorderOverrideContext";

--- a/services/vault/src/components/simple/PositionNotificationBanner/PositionNotificationBanner.tsx
+++ b/services/vault/src/components/simple/PositionNotificationBanner/PositionNotificationBanner.tsx
@@ -4,6 +4,7 @@ import { useCallback, useState } from "react";
 import type { Address, Hex } from "viem";
 import { useAccount } from "wagmi";
 
+import { useReorderOverride } from "@/applications/aave/context";
 import {
   usePositionNotifications,
   type PositionNotificationsStatus,
@@ -55,6 +56,7 @@ export function PositionNotificationBanner({
   const result = hasOverride ? resultOverride : hookResult;
 
   const { executeReorder, isProcessing: isReordering } = useReorderVaults();
+  const { applyReorderedOrder } = useReorderOverride();
   const [isReorderSuccess, setIsReorderSuccess] = useState(false);
   const queryClient = useQueryClient();
   const { address } = useAccount();
@@ -76,9 +78,11 @@ export function PositionNotificationBanner({
       suggestedOrderContext: reorderVerificationContext,
     });
     if (success) {
+      // Show the just-submitted order immediately; the indexer catches up later.
+      applyReorderedOrder(vaultIds);
       setIsReorderSuccess(true);
     }
-  }, [result, executeReorder, reorderVerificationContext]);
+  }, [result, executeReorder, reorderVerificationContext, applyReorderedOrder]);
 
   const effectiveStatus = statusOverride ?? status;
 

--- a/services/vault/src/components/simple/PositionNotificationBanner/__tests__/PositionNotificationBanner.test.tsx
+++ b/services/vault/src/components/simple/PositionNotificationBanner/__tests__/PositionNotificationBanner.test.tsx
@@ -60,6 +60,15 @@ vi.mock("@/applications/aave/hooks/useReorderVaults", () => ({
   }),
 }));
 
+const mockApplyReorderedOrder = vi.fn();
+vi.mock("@/applications/aave/context", () => ({
+  useReorderOverride: () => ({
+    reorderedOrder: null,
+    applyReorderedOrder: mockApplyReorderedOrder,
+    clearReorderedOrder: vi.fn(),
+  }),
+}));
+
 const mockReorderVerificationContext = {
   CF: 0.7,
   THF: 1.1,

--- a/services/vault/src/components/simple/ReorderVaults/ReorderVaultsModal.tsx
+++ b/services/vault/src/components/simple/ReorderVaults/ReorderVaultsModal.tsx
@@ -24,6 +24,7 @@ import {
 } from "@dnd-kit/sortable";
 import type { Hex } from "viem";
 
+import { useReorderOverride } from "@/applications/aave/context";
 import { COPY } from "@/copy";
 import type { CollateralVaultEntry } from "@/types/collateral";
 
@@ -64,6 +65,8 @@ export function ReorderVaultsModal({
     isOpen && hasOrderChanged,
   );
 
+  const { applyReorderedOrder } = useReorderOverride();
+
   const sensors = useSensors(
     useSensor(PointerSensor),
     useSensor(KeyboardSensor, {
@@ -77,6 +80,8 @@ export function ReorderVaultsModal({
   const handleConfirmClick = async () => {
     const success = await handleConfirm();
     if (success) {
+      // Show the just-submitted order immediately; the indexer catches up later.
+      applyReorderedOrder(vaultIds);
       onClose();
       onSuccess();
     }

--- a/services/vault/src/hooks/__tests__/useDashboardState.test.ts
+++ b/services/vault/src/hooks/__tests__/useDashboardState.test.ts
@@ -5,9 +5,26 @@ import { useDashboardState } from "../useDashboardState";
 
 const stableFindProvider = vi.fn(() => undefined);
 
+const VAULT_A = ("0x" + "a".repeat(64)) as `0x${string}`;
+const VAULT_B = ("0x" + "b".repeat(64)) as `0x${string}`;
+const VAULT_C = ("0x" + "c".repeat(64)) as `0x${string}`;
+
+// Mutable state read by the hoisted mocks below.
+let mockCollaterals: unknown[] | null = null;
+let mockReorderedOrder: readonly `0x${string}`[] | null = null;
+const mockClearReorderedOrder = vi.fn();
+
+vi.mock("@/applications/aave/context", () => ({
+  useReorderOverride: () => ({
+    reorderedOrder: mockReorderedOrder,
+    applyReorderedOrder: vi.fn(),
+    clearReorderedOrder: mockClearReorderedOrder,
+  }),
+}));
+
 vi.mock("@/applications/aave/hooks", () => ({
   useAaveUserPosition: () => ({
-    position: null,
+    position: mockCollaterals ? { collaterals: mockCollaterals } : null,
     collateralBtc: 0,
     collateralValueUsd: 0,
     debtValueUsd: 0,
@@ -32,9 +49,28 @@ vi.mock("@/hooks/deposit/useVaultProviders", () => ({
   }),
 }));
 
-describe("useDashboardState ref stability", () => {
+/** Minimal active collateral with a given vaultId and indexer liquidationIndex. */
+function collateral(vaultId: `0x${string}`, liquidationIndex: number) {
+  return {
+    depositorAddress: "0xdep",
+    vaultId,
+    amount: 100n,
+    addedAt: 0n,
+    removedAt: null,
+    liquidationIndex,
+    vault: undefined,
+  };
+}
+
+function vaultIds(entries: { vaultId: string }[]): string[] {
+  return entries.map((e) => e.vaultId);
+}
+
+describe("useDashboardState", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockCollaterals = null;
+    mockReorderedOrder = null;
   });
 
   it("returns a stable collateralVaults reference across re-renders when position?.collaterals is undefined", () => {
@@ -42,5 +78,69 @@ describe("useDashboardState ref stability", () => {
     const first = result.current.collateralVaults;
     rerender();
     expect(result.current.collateralVaults).toBe(first);
+  });
+
+  it("sorts by liquidationIndex when there is no reorder override", () => {
+    // Provide collaterals out of order; expect liquidationIndex ordering.
+    mockCollaterals = [
+      collateral(VAULT_B, 1),
+      collateral(VAULT_A, 0),
+      collateral(VAULT_C, 2),
+    ];
+
+    const { result } = renderHook(() => useDashboardState("0xabc"));
+
+    expect(vaultIds(result.current.collateralVaults)).toEqual([
+      VAULT_A,
+      VAULT_B,
+      VAULT_C,
+    ]);
+    expect(mockClearReorderedOrder).not.toHaveBeenCalled();
+  });
+
+  it("sorts by the submitted override when it is a valid permutation", () => {
+    // Indexer order is A,B,C but the submitted override says C,A,B.
+    mockCollaterals = [
+      collateral(VAULT_A, 0),
+      collateral(VAULT_B, 1),
+      collateral(VAULT_C, 2),
+    ];
+    mockReorderedOrder = [VAULT_C, VAULT_A, VAULT_B];
+
+    const { result } = renderHook(() => useDashboardState("0xabc"));
+
+    expect(vaultIds(result.current.collateralVaults)).toEqual([
+      VAULT_C,
+      VAULT_A,
+      VAULT_B,
+    ]);
+  });
+
+  it("clears the override once the indexer order matches it", () => {
+    mockCollaterals = [
+      collateral(VAULT_A, 0),
+      collateral(VAULT_B, 1),
+      collateral(VAULT_C, 2),
+    ];
+    // Indexer already reflects the override order.
+    mockReorderedOrder = [VAULT_A, VAULT_B, VAULT_C];
+
+    renderHook(() => useDashboardState("0xabc"));
+
+    expect(mockClearReorderedOrder).toHaveBeenCalled();
+  });
+
+  it("falls back to liquidationIndex and clears when the override no longer matches the vault set", () => {
+    // Override references a vault that is no longer collateral (e.g. withdrawn).
+    mockCollaterals = [collateral(VAULT_A, 0), collateral(VAULT_B, 1)];
+    mockReorderedOrder = [VAULT_B, VAULT_A, VAULT_C];
+
+    const { result } = renderHook(() => useDashboardState("0xabc"));
+
+    expect(vaultIds(result.current.collateralVaults)).toEqual([
+      VAULT_A,
+      VAULT_B,
+    ]);
+    expect(mockClearReorderedOrder).toHaveBeenCalled();
   });
 });

--- a/services/vault/src/hooks/__tests__/useDashboardState.test.ts
+++ b/services/vault/src/hooks/__tests__/useDashboardState.test.ts
@@ -114,6 +114,21 @@ describe("useDashboardState", () => {
       VAULT_A,
       VAULT_B,
     ]);
+    // Each row's liquidationIndex (used for the "Liquidation Order" ordinal)
+    // is rewritten to the override rank, so the badge matches the row position
+    // instead of showing the stale indexer index.
+    expect(
+      result.current.collateralVaults.map((v) => v.liquidationIndex),
+    ).toEqual([0, 1, 2]);
+    const indexByVault = new Map(
+      result.current.collateralVaults.map((v) => [
+        v.vaultId,
+        v.liquidationIndex,
+      ]),
+    );
+    expect(indexByVault.get(VAULT_C)).toBe(0);
+    expect(indexByVault.get(VAULT_A)).toBe(1);
+    expect(indexByVault.get(VAULT_B)).toBe(2);
   });
 
   it("clears the override once the indexer order matches it", () => {

--- a/services/vault/src/hooks/__tests__/useDashboardState.test.ts
+++ b/services/vault/src/hooks/__tests__/useDashboardState.test.ts
@@ -109,26 +109,12 @@ describe("useDashboardState", () => {
 
     const { result } = renderHook(() => useDashboardState("0xabc"));
 
-    expect(vaultIds(result.current.collateralVaults)).toEqual([
-      VAULT_C,
-      VAULT_A,
-      VAULT_B,
-    ]);
-    // Each row's liquidationIndex (used for the "Liquidation Order" ordinal)
-    // is rewritten to the override rank, so the badge matches the row position
-    // instead of showing the stale indexer index.
-    expect(
-      result.current.collateralVaults.map((v) => v.liquidationIndex),
-    ).toEqual([0, 1, 2]);
-    const indexByVault = new Map(
-      result.current.collateralVaults.map((v) => [
-        v.vaultId,
-        v.liquidationIndex,
-      ]),
-    );
-    expect(indexByVault.get(VAULT_C)).toBe(0);
-    expect(indexByVault.get(VAULT_A)).toBe(1);
-    expect(indexByVault.get(VAULT_B)).toBe(2);
+    const vaults = result.current.collateralVaults;
+    expect(vaultIds(vaults)).toEqual([VAULT_C, VAULT_A, VAULT_B]);
+    // The hook applies the override rewrite, so the first row's ordinal index
+    // matches its displayed position (exhaustive cases live in
+    // collateralOrder.test.ts).
+    expect(vaults[0]).toMatchObject({ vaultId: VAULT_C, liquidationIndex: 0 });
   });
 
   it("clears the override once the indexer order matches it", () => {

--- a/services/vault/src/hooks/useDashboardState.ts
+++ b/services/vault/src/hooks/useDashboardState.ts
@@ -4,8 +4,10 @@
  * Mirrors the data layer from useAaveOverviewState but scoped to what the dashboard needs.
  */
 
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
+import type { Hex } from "viem";
 
+import { useReorderOverride } from "@/applications/aave/context";
 import {
   useAaveBorrowedAssets,
   useAaveUserPosition,
@@ -17,6 +19,61 @@ import { toCollateralVaultEntries } from "@/utils/collateral";
 
 // Re-export for consumers
 export type { CollateralVaultEntry };
+
+/** Entries ordered ascending by the indexer's liquidationIndex (default order). */
+function byLiquidationIndex(
+  entries: CollateralVaultEntry[],
+): CollateralVaultEntry[] {
+  return [...entries].sort((a, b) => a.liquidationIndex - b.liquidationIndex);
+}
+
+/** Whether `order` is exactly the set of vault IDs in `entries`. */
+function orderMatchesEntrySet(
+  entries: CollateralVaultEntry[],
+  order: readonly Hex[],
+): boolean {
+  if (order.length !== entries.length) return false;
+  const ids = new Set(entries.map((e) => e.vaultId.toLowerCase()));
+  return (
+    ids.size === order.length && order.every((id) => ids.has(id.toLowerCase()))
+  );
+}
+
+/**
+ * Sort entries by the post-reorder submitted order so the new order shows
+ * immediately. Falls back to liquidationIndex when there is no override or it no
+ * longer describes the same vault set (e.g. a vault was withdrawn since).
+ */
+function sortByReorderedOverride(
+  entries: CollateralVaultEntry[],
+  order: readonly Hex[] | null,
+): CollateralVaultEntry[] {
+  if (!order || !orderMatchesEntrySet(entries, order)) {
+    return byLiquidationIndex(entries);
+  }
+  const rank = new Map<string, number>();
+  order.forEach((id, i) => rank.set(id.toLowerCase(), i));
+  return [...entries].sort(
+    (a, b) =>
+      rank.get(a.vaultId.toLowerCase())! - rank.get(b.vaultId.toLowerCase())!,
+  );
+}
+
+/**
+ * Whether the override should be dropped — true when there is no override, when
+ * it no longer matches the vault set, or when the indexer's liquidationIndex
+ * order already equals the override.
+ */
+function isReorderOverrideReconciled(
+  entries: CollateralVaultEntry[],
+  order: readonly Hex[] | null,
+): boolean {
+  if (!order) return true;
+  if (!orderMatchesEntrySet(entries, order)) return true;
+  return byLiquidationIndex(entries).every(
+    (e, i) => e.vaultId.toLowerCase() === order[i].toLowerCase(),
+  );
+}
 
 export function useDashboardState(connectedAddress: string | undefined) {
   const {
@@ -35,19 +92,34 @@ export function useDashboardState(connectedAddress: string | undefined) {
   });
 
   const { findProvider } = useVaultProviders();
+  const { reorderedOrder, clearReorderedOrder } = useReorderOverride();
 
   const hasCollateral = collateralBtc > 0;
   const hasDebt = debtValueUsd > 0;
 
+  // Display order normally comes from the indexer's `liquidationIndex`. Right
+  // after a reorder, `reorderedOrder` holds the submitted order so the new
+  // order shows immediately; it falls back to `liquidationIndex` once the
+  // override no longer matches the vault set.
   const collateralVaults = useMemo(
     (): CollateralVaultEntry[] =>
       position?.collaterals
-        ? toCollateralVaultEntries(position.collaterals, findProvider).sort(
-            (a, b) => a.liquidationIndex - b.liquidationIndex,
+        ? sortByReorderedOverride(
+            toCollateralVaultEntries(position.collaterals, findProvider),
+            reorderedOrder,
           )
         : [],
-    [position?.collaterals, findProvider],
+    [position?.collaterals, findProvider, reorderedOrder],
   );
+
+  // Drop the override once the indexer reflects the reordered sequence (or the
+  // vault set changed), handing display back to the indexer ordering.
+  useEffect(() => {
+    if (!reorderedOrder) return;
+    if (isReorderOverrideReconciled(collateralVaults, reorderedOrder)) {
+      clearReorderedOrder();
+    }
+  }, [collateralVaults, reorderedOrder, clearReorderedOrder]);
 
   // Transform borrowed assets for the asset selection modal
   const selectableBorrowedAssets = useMemo(

--- a/services/vault/src/hooks/useDashboardState.ts
+++ b/services/vault/src/hooks/useDashboardState.ts
@@ -41,8 +41,12 @@ function orderMatchesEntrySet(
 
 /**
  * Sort entries by the post-reorder submitted order so the new order shows
- * immediately. Falls back to liquidationIndex when there is no override or it no
- * longer describes the same vault set (e.g. a vault was withdrawn since).
+ * immediately. Also rewrites each entry's `liquidationIndex` to its rank in the
+ * override, so the per-row "Liquidation Order" ordinal matches the displayed
+ * position (otherwise rows would show stale indexer ordinals during the
+ * reconciliation window). Falls back to the indexer's liquidationIndex when
+ * there is no override or it no longer describes the same vault set (e.g. a
+ * vault was withdrawn since).
  */
 function sortByReorderedOverride(
   entries: CollateralVaultEntry[],
@@ -53,10 +57,12 @@ function sortByReorderedOverride(
   }
   const rank = new Map<string, number>();
   order.forEach((id, i) => rank.set(id.toLowerCase(), i));
-  return [...entries].sort(
-    (a, b) =>
-      rank.get(a.vaultId.toLowerCase())! - rank.get(b.vaultId.toLowerCase())!,
-  );
+  return entries
+    .map((entry) => ({
+      ...entry,
+      liquidationIndex: rank.get(entry.vaultId.toLowerCase())!,
+    }))
+    .sort((a, b) => a.liquidationIndex - b.liquidationIndex);
 }
 
 /**
@@ -97,29 +103,36 @@ export function useDashboardState(connectedAddress: string | undefined) {
   const hasCollateral = collateralBtc > 0;
   const hasDebt = debtValueUsd > 0;
 
-  // Display order normally comes from the indexer's `liquidationIndex`. Right
-  // after a reorder, `reorderedOrder` holds the submitted order so the new
-  // order shows immediately; it falls back to `liquidationIndex` once the
+  // Raw indexer entries (liquidationIndex straight from the indexer). These
+  // drive reconciliation — they reflect what the indexer currently believes,
+  // independent of any active override.
+  const rawCollateralVaults = useMemo(
+    (): CollateralVaultEntry[] =>
+      position?.collaterals
+        ? toCollateralVaultEntries(position.collaterals, findProvider)
+        : [],
+    [position?.collaterals, findProvider],
+  );
+
+  // Displayed entries. Normally indexer-ordered; right after a reorder,
+  // `reorderedOrder` holds the submitted order so the new order (and each row's
+  // ordinal) shows immediately. Falls back to indexer ordering once the
   // override no longer matches the vault set.
   const collateralVaults = useMemo(
     (): CollateralVaultEntry[] =>
-      position?.collaterals
-        ? sortByReorderedOverride(
-            toCollateralVaultEntries(position.collaterals, findProvider),
-            reorderedOrder,
-          )
-        : [],
-    [position?.collaterals, findProvider, reorderedOrder],
+      sortByReorderedOverride(rawCollateralVaults, reorderedOrder),
+    [rawCollateralVaults, reorderedOrder],
   );
 
   // Drop the override once the indexer reflects the reordered sequence (or the
-  // vault set changed), handing display back to the indexer ordering.
+  // vault set changed), handing display back to the indexer ordering. Compares
+  // against the raw indexer entries, not the override-rewritten ones.
   useEffect(() => {
     if (!reorderedOrder) return;
-    if (isReorderOverrideReconciled(collateralVaults, reorderedOrder)) {
+    if (isReorderOverrideReconciled(rawCollateralVaults, reorderedOrder)) {
       clearReorderedOrder();
     }
-  }, [collateralVaults, reorderedOrder, clearReorderedOrder]);
+  }, [rawCollateralVaults, reorderedOrder, clearReorderedOrder]);
 
   // Transform borrowed assets for the asset selection modal
   const selectableBorrowedAssets = useMemo(

--- a/services/vault/src/hooks/useDashboardState.ts
+++ b/services/vault/src/hooks/useDashboardState.ts
@@ -5,7 +5,6 @@
  */
 
 import { useEffect, useMemo } from "react";
-import type { Hex } from "viem";
 
 import { useReorderOverride } from "@/applications/aave/context";
 import {
@@ -16,70 +15,13 @@ import type { Asset } from "@/applications/aave/types";
 import { useVaultProviders } from "@/hooks/deposit/useVaultProviders";
 import type { CollateralVaultEntry } from "@/types/collateral";
 import { toCollateralVaultEntries } from "@/utils/collateral";
+import {
+  isReorderOverrideReconciled,
+  sortByReorderedOverride,
+} from "@/utils/collateralOrder";
 
 // Re-export for consumers
 export type { CollateralVaultEntry };
-
-/** Entries ordered ascending by the indexer's liquidationIndex (default order). */
-function byLiquidationIndex(
-  entries: CollateralVaultEntry[],
-): CollateralVaultEntry[] {
-  return [...entries].sort((a, b) => a.liquidationIndex - b.liquidationIndex);
-}
-
-/** Whether `order` is exactly the set of vault IDs in `entries`. */
-function orderMatchesEntrySet(
-  entries: CollateralVaultEntry[],
-  order: readonly Hex[],
-): boolean {
-  if (order.length !== entries.length) return false;
-  const ids = new Set(entries.map((e) => e.vaultId.toLowerCase()));
-  return (
-    ids.size === order.length && order.every((id) => ids.has(id.toLowerCase()))
-  );
-}
-
-/**
- * Sort entries by the post-reorder submitted order so the new order shows
- * immediately. Also rewrites each entry's `liquidationIndex` to its rank in the
- * override, so the per-row "Liquidation Order" ordinal matches the displayed
- * position (otherwise rows would show stale indexer ordinals during the
- * reconciliation window). Falls back to the indexer's liquidationIndex when
- * there is no override or it no longer describes the same vault set (e.g. a
- * vault was withdrawn since).
- */
-function sortByReorderedOverride(
-  entries: CollateralVaultEntry[],
-  order: readonly Hex[] | null,
-): CollateralVaultEntry[] {
-  if (!order || !orderMatchesEntrySet(entries, order)) {
-    return byLiquidationIndex(entries);
-  }
-  const rank = new Map<string, number>();
-  order.forEach((id, i) => rank.set(id.toLowerCase(), i));
-  return entries
-    .map((entry) => ({
-      ...entry,
-      liquidationIndex: rank.get(entry.vaultId.toLowerCase())!,
-    }))
-    .sort((a, b) => a.liquidationIndex - b.liquidationIndex);
-}
-
-/**
- * Whether the override should be dropped — true when there is no override, when
- * it no longer matches the vault set, or when the indexer's liquidationIndex
- * order already equals the override.
- */
-function isReorderOverrideReconciled(
-  entries: CollateralVaultEntry[],
-  order: readonly Hex[] | null,
-): boolean {
-  if (!order) return true;
-  if (!orderMatchesEntrySet(entries, order)) return true;
-  return byLiquidationIndex(entries).every(
-    (e, i) => e.vaultId.toLowerCase() === order[i].toLowerCase(),
-  );
-}
 
 export function useDashboardState(connectedAddress: string | undefined) {
   const {

--- a/services/vault/src/router.tsx
+++ b/services/vault/src/router.tsx
@@ -7,6 +7,7 @@ import { AAVE_APP_ID } from "./applications/aave/config";
 import {
   AaveConfigProvider,
   PendingVaultsProvider,
+  ReorderOverrideProvider,
 } from "./applications/aave/context";
 import RootLayout from "./components/pages/RootLayout";
 import NotFound from "./components/pages/not-found";
@@ -28,7 +29,9 @@ const RouteFallback = () => (
 const DashboardWithProviders = () => (
   <AaveConfigProvider>
     <PendingVaultsProvider appId={AAVE_APP_ID}>
-      <DashboardPage />
+      <ReorderOverrideProvider>
+        <DashboardPage />
+      </ReorderOverrideProvider>
     </PendingVaultsProvider>
   </AaveConfigProvider>
 );

--- a/services/vault/src/utils/__tests__/collateralOrder.test.ts
+++ b/services/vault/src/utils/__tests__/collateralOrder.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+
+import type { CollateralVaultEntry } from "@/types/collateral";
+
+import {
+  isReorderOverrideReconciled,
+  sortByReorderedOverride,
+} from "../collateralOrder";
+
+const VAULT_A = ("0x" + "a".repeat(64)) as `0x${string}`;
+const VAULT_B = ("0x" + "b".repeat(64)) as `0x${string}`;
+const VAULT_C = ("0x" + "c".repeat(64)) as `0x${string}`;
+
+function entry(
+  vaultId: string,
+  liquidationIndex: number,
+): CollateralVaultEntry {
+  return {
+    id: `0xdep-${vaultId}`,
+    vaultId,
+    amountBtc: 1,
+    addedAt: 0,
+    inUse: true,
+    providerAddress: "",
+    providerName: "",
+    liquidationIndex,
+  };
+}
+
+const ids = (entries: CollateralVaultEntry[]) => entries.map((e) => e.vaultId);
+
+describe("sortByReorderedOverride", () => {
+  it("orders by the override sequence when it is a valid permutation", () => {
+    const out = sortByReorderedOverride(
+      [entry(VAULT_A, 0), entry(VAULT_B, 1), entry(VAULT_C, 2)],
+      [VAULT_C, VAULT_A, VAULT_B],
+    );
+    expect(ids(out)).toEqual([VAULT_C, VAULT_A, VAULT_B]);
+  });
+
+  it("rewrites each entry's liquidationIndex to its override rank", () => {
+    // So the per-row "Liquidation Order" ordinal matches the displayed position
+    // instead of the stale indexer index.
+    const out = sortByReorderedOverride(
+      [entry(VAULT_A, 0), entry(VAULT_B, 1), entry(VAULT_C, 2)],
+      [VAULT_C, VAULT_A, VAULT_B],
+    );
+    const indexByVault = new Map(
+      out.map((e) => [e.vaultId, e.liquidationIndex]),
+    );
+    expect(indexByVault.get(VAULT_C)).toBe(0);
+    expect(indexByVault.get(VAULT_A)).toBe(1);
+    expect(indexByVault.get(VAULT_B)).toBe(2);
+  });
+
+  it("matches override IDs case-insensitively", () => {
+    const upperB = VAULT_B.toUpperCase().replace("0X", "0x") as `0x${string}`;
+    const out = sortByReorderedOverride(
+      [entry(VAULT_A.toLowerCase(), 0), entry(VAULT_B.toLowerCase(), 1)],
+      [upperB, VAULT_A],
+    );
+    expect(ids(out)).toEqual([VAULT_B.toLowerCase(), VAULT_A.toLowerCase()]);
+  });
+
+  it("falls back to liquidationIndex order when override is null", () => {
+    const out = sortByReorderedOverride(
+      [entry(VAULT_B, 1), entry(VAULT_A, 0)],
+      null,
+    );
+    expect(ids(out)).toEqual([VAULT_A, VAULT_B]);
+  });
+
+  it("falls back to liquidationIndex order when override is not the same vault set", () => {
+    const out = sortByReorderedOverride(
+      [entry(VAULT_A, 0), entry(VAULT_B, 1)],
+      [VAULT_B, VAULT_A, VAULT_C],
+    );
+    expect(ids(out)).toEqual([VAULT_A, VAULT_B]);
+  });
+});
+
+describe("isReorderOverrideReconciled", () => {
+  const entries = [entry(VAULT_A, 0), entry(VAULT_B, 1), entry(VAULT_C, 2)];
+
+  it("is reconciled when there is no override", () => {
+    expect(isReorderOverrideReconciled(entries, null)).toBe(true);
+  });
+
+  it("is reconciled when the indexer order already equals the override", () => {
+    expect(
+      isReorderOverrideReconciled(entries, [VAULT_A, VAULT_B, VAULT_C]),
+    ).toBe(true);
+  });
+
+  it("is NOT reconciled while the indexer order still differs", () => {
+    expect(
+      isReorderOverrideReconciled(entries, [VAULT_C, VAULT_A, VAULT_B]),
+    ).toBe(false);
+  });
+
+  it("is reconciled (give up) when the override no longer matches the vault set", () => {
+    expect(
+      isReorderOverrideReconciled(
+        [entry(VAULT_A, 0), entry(VAULT_B, 1)],
+        [VAULT_B, VAULT_A, VAULT_C],
+      ),
+    ).toBe(true);
+  });
+});

--- a/services/vault/src/utils/collateralOrder.ts
+++ b/services/vault/src/utils/collateralOrder.ts
@@ -1,0 +1,73 @@
+/**
+ * Collateral ordering helpers for the post-reorder display override.
+ *
+ * The dashboard normally orders collateral by the indexer's `liquidationIndex`.
+ * Right after a reorder, an in-memory override (the submitted order) takes over
+ * so the new order shows immediately, until the indexer catches up. These pure
+ * helpers apply that override and decide when it can be dropped.
+ */
+
+import type { Hex } from "viem";
+
+import type { CollateralVaultEntry } from "@/types/collateral";
+
+/** Entries ordered ascending by the indexer's liquidationIndex (default order). */
+function byLiquidationIndex(
+  entries: CollateralVaultEntry[],
+): CollateralVaultEntry[] {
+  return [...entries].sort((a, b) => a.liquidationIndex - b.liquidationIndex);
+}
+
+/** Whether `order` is exactly the set of vault IDs in `entries`. */
+function orderMatchesEntrySet(
+  entries: CollateralVaultEntry[],
+  order: readonly Hex[],
+): boolean {
+  if (order.length !== entries.length) return false;
+  const ids = new Set(entries.map((e) => e.vaultId.toLowerCase()));
+  return (
+    ids.size === order.length && order.every((id) => ids.has(id.toLowerCase()))
+  );
+}
+
+/**
+ * Sort entries by the post-reorder submitted order so the new order shows
+ * immediately. Also rewrites each entry's `liquidationIndex` to its rank in the
+ * override, so the per-row "Liquidation Order" ordinal matches the displayed
+ * position (otherwise rows would show stale indexer ordinals during the
+ * reconciliation window). Falls back to the indexer's liquidationIndex when
+ * there is no override or it no longer describes the same vault set (e.g. a
+ * vault was withdrawn since).
+ */
+export function sortByReorderedOverride(
+  entries: CollateralVaultEntry[],
+  order: readonly Hex[] | null,
+): CollateralVaultEntry[] {
+  if (!order || !orderMatchesEntrySet(entries, order)) {
+    return byLiquidationIndex(entries);
+  }
+  const rank = new Map<string, number>();
+  order.forEach((id, i) => rank.set(id.toLowerCase(), i));
+  return entries
+    .map((entry) => ({
+      ...entry,
+      liquidationIndex: rank.get(entry.vaultId.toLowerCase())!,
+    }))
+    .sort((a, b) => a.liquidationIndex - b.liquidationIndex);
+}
+
+/**
+ * Whether the override should be dropped — true when there is no override, when
+ * it no longer matches the vault set, or when the indexer's liquidationIndex
+ * order already equals the override.
+ */
+export function isReorderOverrideReconciled(
+  entries: CollateralVaultEntry[],
+  order: readonly Hex[] | null,
+): boolean {
+  if (!order) return true;
+  if (!orderMatchesEntrySet(entries, order)) return true;
+  return byLiquidationIndex(entries).every(
+    (e, i) => e.vaultId.toLowerCase() === order[i].toLowerCase(),
+  );
+}


### PR DESCRIPTION
# Show the new vault order immediately after a reorder

## What this does

When a user reorders their collateral vaults, the new order now shows in the dashboard **immediately** after the transaction is confirmed — instead of the user staring at the old order for several seconds until the backend catches up.

## Why

A vault reorder is an **on-chain transaction** (`AaveIntegrationAdapter.reorderVaults`). But the order shown on the dashboard does **not** come from the chain — it comes from the **indexer** (the `liquidationIndex` field on each collateral, which `useDashboardState` sorts by).

The indexer only updates `liquidationIndex` after it sees the on-chain `VaultsReordered` event and ingests it. That takes a few seconds. So right after the transaction succeeds, the dashboard re-reads the indexer, gets the **old** order back, and the user sees no change — even though their reorder already landed on-chain.

## How it works now

1. **Normal browsing is unchanged** — the order still comes from the indexer's `liquidationIndex`. No extra network calls, no chain polling.
2. **Right after a successful reorder**, we remember the order the user just submitted (after the tx is confirmed, that *is* the on-chain order) in a small **in-memory** context.
3. `useDashboardState` sorts the list by that remembered order, so the new order appears instantly.
4. The remembered order is dropped automatically once the indexer catches up (its order matches what we remembered), or if the vault set changes, with a 90-second safety timeout. After that we're back to plain indexer ordering.

This covers **both** ways to reorder: the manual drag-and-drop modal and the auto-suggested "Apply suggested order" banner.

## Approaches we considered

We discussed three options in the thread:

1. **Lock + poll** — lock the collateral section with a "Reordering in progress" message and poll until the indexer matches. Honest, but the user *still* doesn't see their new order during the wait — which is exactly the complaint.
2. **Optimistic (this PR)** — show the just-submitted order immediately, then let the indexer reconcile in the background.
3. **Read the order from chain** — make the dashboard always read the vault order from the chain instead of the indexer. Most "correct", but it meant reading from the chain on **every** dashboard refresh (every 30s), which adds constant RPC load that the team did not want ("only read after a reorder, not all the time"). It also rippled into ~20 files.

## Why we chose this approach

- **It actually fixes the complaint** — the user sees the new order right away.
- **No extra load** — we do **not** poll the chain. Normal browsing keeps reading from the indexer exactly as before; the only new work happens once, right after a reorder.
- **No localStorage** — the remembered order lives in memory only (the team explicitly wanted to avoid localStorage). Worst case, a page refresh during the few-second window falls back to the indexer order, which is fine.
- **Safe** — the order we show is the order the user just submitted, and the reorder hook already validates that submission against the chain *before* signing (existing guards), and waits for the transaction receipt before we treat it as done. So "submitted order" and "on-chain order" are the same thing at that point.
- **Small and contained** — 9 files, no changes to the transaction/signing path, no change to how the position data is fetched.

We started down approach `3` (reading from chain on every fetch) but reverted it because of the constant RPC load and the much larger footprint. This PR is the lean version of "show the chain truth right after a reorder" without paying for it on every refresh.

## Files changed (9)

New:
- `services/vault/src/applications/aave/context/ReorderOverrideContext.tsx` — the in-memory store for the just-reordered order (+ auto-clear timer).
- `services/vault/src/applications/aave/context/__tests__/ReorderOverrideContext.test.tsx`

Changed:
- `services/vault/src/applications/aave/context/index.ts` — export the new context.
- `services/vault/src/router.tsx` — mount the provider around the dashboard.
- `services/vault/src/hooks/useDashboardState.ts` — sort by the remembered order when present; clear it once the indexer reconciles.
- `services/vault/src/components/simple/ReorderVaults/ReorderVaultsModal.tsx` — remember the submitted order on success (manual reorder).
- `services/vault/src/components/simple/PositionNotificationBanner/PositionNotificationBanner.tsx` — same, for the auto-suggested reorder.
- Tests: `useDashboardState.test.ts`, `PositionNotificationBanner.test.tsx`.

Manual check: connect a wallet with ≥2 collateral vaults, reorder via the modal, sign, and confirm the list updates immediately and does not flicker back to the old order when the 30s position poll fires.

## Notes for the reviewer

- No new user-facing copy (the existing success modal is reused).
- This is in-memory only by design; it's best-effort immediate feedback, not a source of truth. The indexer remains the source of truth.
