### PR TITLE
fix(vault): sticky continue button with scrollable progress steps

### DIFF
--- a/services/vault/src/components/simple/DepositProgressView/DepositProgressView.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/DepositProgressView.tsx
@@ -118,7 +118,7 @@ export function DepositProgressView(props: DepositProgressViewProps) {
     ) : null;
 
   return (
-    <div className="w-full max-w-[520px]">
+    <div className="flex h-full w-full max-w-[520px] flex-col">
       <Heading variant="h5" className="text-accent-primary">
         {COPY.deposit.progress.heading}
       </Heading>
@@ -131,26 +131,32 @@ export function DepositProgressView(props: DepositProgressViewProps) {
         </div>
       )}
 
-      <div className="mt-6 flex flex-col gap-6">
-        {showOverallProgress && (
-          <CompletedStepsPill
-            completed={completedSteps}
-            total={TOTAL_VISUAL_STEPS}
+      {/* Scrollable middle: steps + status banners */}
+      <div className="mt-6 min-h-0 flex-1 overflow-y-auto">
+        <div className="flex flex-col gap-6">
+          {showOverallProgress && (
+            <CompletedStepsPill
+              completed={completedSteps}
+              total={TOTAL_VISUAL_STEPS}
+            />
+          )}
+
+          <GroupedProgress
+            steps={steps}
+            currentStep={visualStep}
+            activeStepDetail={activeStepDetail}
           />
-        )}
 
-        <GroupedProgress
-          steps={steps}
-          currentStep={visualStep}
-          activeStepDetail={activeStepDetail}
-        />
+          {error && <StatusBanner variant="error">{error}</StatusBanner>}
 
-        {error && <StatusBanner variant="error">{error}</StatusBanner>}
+          {isComplete && (
+            <StatusBanner variant="success">{successMessage}</StatusBanner>
+          )}
+        </div>
+      </div>
 
-        {isComplete && (
-          <StatusBanner variant="success">{successMessage}</StatusBanner>
-        )}
-
+      {/* Sticky footer: button + warning */}
+      <div className="mt-6 flex flex-shrink-0 flex-col gap-6">
         <Button
           disabled={!canClose}
           variant="contained"

--- a/services/vault/src/components/simple/DepositProgressView/StepRow.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/StepRow.tsx
@@ -69,16 +69,19 @@ export function StepRow({
   hasNext = false,
 }: StepRowProps) {
   const isActive = state === "active";
-  // A detail panel makes the active row taller than a circle. Fill the extra
-  // height with a connector segment so the timeline stays unbroken down to the
-  // next step's connector — but never dangle a line below the group's last step.
-  const showTrailingLine = isActive && Boolean(detail) && hasNext;
+  const hasDetail = isActive && Boolean(detail);
+  // A detail panel makes the active row taller than the circle. When there's
+  // no detail panel, align the circle and label vertically (items-center)
+  // to match the non-active step alignment. Fill the extra height from a
+  // detail panel with a connector segment so the timeline stays unbroken
+  // — but never dangle a line below the group's last step.
+  const showTrailingLine = hasDetail && hasNext;
 
   return (
     <div
       className={twMerge(
         "flex gap-3",
-        isActive ? "items-start" : "items-center",
+        hasDetail ? "items-start" : "items-center",
       )}
     >
       <div className="flex w-8 flex-col items-center self-stretch">

--- a/services/vault/src/components/simple/SimpleDeposit.tsx
+++ b/services/vault/src/components/simple/SimpleDeposit.tsx
@@ -377,7 +377,10 @@ function SimpleDepositContent({
         )}
 
         {renderedStep === DepositStep.SIGN && btcWalletProvider && (
-          <div className="mx-auto w-full max-w-[520px]">
+          <div
+            className="mx-auto flex w-full max-w-[520px] flex-col"
+            style={{ height: "calc(100dvh - 3rem)" }}
+          >
             <DepositSignContent
               vaultAmounts={
                 isSplitDeposit && splitVaultAmounts
@@ -419,7 +422,10 @@ export default function SimpleDeposit(props: SimpleDepositProps) {
             onClose={onClose}
             className="items-center justify-center p-6"
           >
-            <div className="mx-auto w-full max-w-[520px]">
+            <div
+              className="mx-auto flex w-full max-w-[520px] flex-col"
+              style={{ height: "calc(100dvh - 3rem)" }}
+            >
               <ResumeWotsContent
                 activity={props.activity}
                 onClose={onClose}
@@ -439,7 +445,10 @@ export default function SimpleDeposit(props: SimpleDepositProps) {
             onClose={onClose}
             className="items-center justify-center p-6"
           >
-            <div className="mx-auto w-full max-w-[520px]">
+            <div
+              className="mx-auto flex w-full max-w-[520px] flex-col"
+              style={{ height: "calc(100dvh - 3rem)" }}
+            >
               <ResumeActivationContent
                 activity={props.activity}
                 depositorEthAddress={props.depositorEthAddress}
@@ -459,7 +468,10 @@ export default function SimpleDeposit(props: SimpleDepositProps) {
           onClose={onClose}
           className="items-center justify-center p-6"
         >
-          <div className="mx-auto w-full max-w-[520px]">
+          <div
+            className="mx-auto flex w-full max-w-[520px] flex-col"
+            style={{ height: "calc(100dvh - 3rem)" }}
+          >
             {resumeMode === "sign_payouts" ? (
               <ResumeSignContent
                 activity={props.activity}


### PR DESCRIPTION
- Restructure DepositProgressView to flex column with scrollable middle and sticky footer (button + warning pinned to bottom)
- Add height constraints to SIGN step and resume flow wrappers in SimpleDeposit (calc(100dvh - 3rem))
- Fix StepRow active step vertical alignment: use items-center when no detail panel to match non-active step alignment