### PR TITLE
fix(vault): cache confirmed Pre-PegIn observations to stop redundant …

### DIFF
--- a/services/vault/src/context/deposit/PeginPollingContext.tsx
+++ b/services/vault/src/context/deposit/PeginPollingContext.tsx
@@ -11,11 +11,11 @@
  * - Optimistic UI updates for immediate feedback
  */
 
-import { stripHexPrefix } from "@babylonlabs-io/ts-sdk/tbv/core";
 import {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
   useState,
 } from "react";
@@ -27,14 +27,35 @@ import {
   getPeginState,
   LocalStorageStatus,
 } from "../../models/peginStateMachine";
+import {
+  addConfirmedPrePeginTxid,
+  loadConfirmedPrePeginTxids,
+} from "../../storage/confirmedPrePeginCache";
+import type { VaultActivity } from "../../types/activity";
 import type {
   DepositPollingResult,
   PeginPollingContextValue,
   PeginPollingProviderProps,
 } from "../../types/peginPolling";
 import { isTerminalPollingError } from "../../utils/peginPolling";
+import { canonicalizeTxid } from "../../utils/txid";
 import { isVaultOwnedByWallet } from "../../utils/vaultWarnings";
 import { useProtocolParamsContext } from "../ProtocolParamsContext";
+
+/**
+ * Whether a vault's localStorage status puts it in the window where the
+ * mempool can still tell us something new about Pre-PegIn depth.
+ * PAYOUT_SIGNED+ means the VP has already verified BTC at depth.
+ */
+function isPrePeginPollEligibleStatus(
+  status: LocalStorageStatus | undefined,
+): boolean {
+  return (
+    status === undefined ||
+    status === LocalStorageStatus.PENDING ||
+    status === LocalStorageStatus.CONFIRMING
+  );
+}
 
 /**
  * Resolve the effective local status for a deposit, accounting for
@@ -105,19 +126,77 @@ export function PeginPollingProvider({
     btcPublicKey,
   });
 
-  // Chain ground truth for "Pre-PegIn at protocol depth?" — independent of
-  // localStorage so a deposit doesn't get pinned on AWAIT_BTC_CONFIRMATION
-  // when BTC is already deep but the VP is still ingesting.
+  // Poll `prePeginTxHash` (depositor broadcast tx; `peginTxHash` is the VP
+  // activation tx and doesn't exist during PENDING). Include vaults where
+  // we haven't yet confirmed BTC-at-depth: no localStorage / PENDING /
+  // CONFIRMING. Skip PAYOUT_SIGNED / CONFIRMED / REFUND_BROADCAST (VP has
+  // already advanced past depth). Skip txids already in the persistent
+  // confirmed cache — chain doesn't rewind, repolling reads the same fact.
+  // State-machine consumer still sees the depth signal via the query's
+  // `placeholderData` carryover, so dropping from the poll set is safe.
   const { config, getOffchainParamsByVersion } = useProtocolParamsContext();
+  const [confirmedTxids, setConfirmedTxids] = useState<Set<string>>(
+    loadConfirmedPrePeginTxids,
+  );
+
+  const getRequiredPrePeginDepth = useCallback(
+    (activity: VaultActivity): number => {
+      const versioned =
+        activity.offchainParamsVersion !== undefined
+          ? getOffchainParamsByVersion(activity.offchainParamsVersion)
+          : undefined;
+      return (
+        versioned?.minPrepeginDepth ?? config.offchainParams.minPrepeginDepth
+      );
+    },
+    [getOffchainParamsByVersion, config.offchainParams.minPrepeginDepth],
+  );
+
+  const localStatusById = useMemo(() => {
+    const map = new Map<string, LocalStorageStatus>();
+    for (const p of pendingPegins) {
+      if (p.status) map.set(p.id, p.status as LocalStorageStatus);
+    }
+    return map;
+  }, [pendingPegins]);
+
   const pendingPrePeginTxids = useMemo(
     () =>
       activities
-        .filter((a) => (a.contractStatus ?? 0) === ContractStatus.PENDING)
-        .map((a) => a.peginTxHash),
-    [activities],
+        .filter((a) => {
+          if ((a.contractStatus ?? 0) !== ContractStatus.PENDING) return false;
+          if (!isPrePeginPollEligibleStatus(localStatusById.get(a.id)))
+            return false;
+          const txid = canonicalizeTxid(a.prePeginTxHash);
+          return !(txid && confirmedTxids.has(txid));
+        })
+        .map((a) => a.prePeginTxHash),
+    [activities, localStatusById, confirmedTxids],
   );
   const { confirmationsByTxid: prePeginConfirmationsByTxid } =
     usePrePeginMempoolConfirmations(pendingPrePeginTxids);
+
+  // Persist newly-confirmed observations and drop them from the polled set
+  // on next render. Functional setState keeps `confirmedTxids` out of the
+  // dep array so the effect doesn't re-fire every time the cache grows.
+  useEffect(() => {
+    if (prePeginConfirmationsByTxid.size === 0) return;
+    setConfirmedTxids((prev) => {
+      const next = new Set(prev);
+      let changed = false;
+      for (const activity of activities) {
+        const txid = canonicalizeTxid(activity.prePeginTxHash);
+        if (!txid || next.has(txid)) continue;
+        const observed = prePeginConfirmationsByTxid.get(txid);
+        if (observed === undefined) continue;
+        if (observed < getRequiredPrePeginDepth(activity)) continue;
+        addConfirmedPrePeginTxid(txid);
+        next.add(txid);
+        changed = true;
+      }
+      return changed ? next : prev;
+    });
+  }, [prePeginConfirmationsByTxid, activities, getRequiredPrePeginDepth]);
 
   // Optimistic status handlers
   const setOptimisticStatus = useCallback(
@@ -185,24 +264,15 @@ export function PeginPollingProvider({
         ? false
         : (pendingDepositorSignatures?.has(depositId) ?? false);
 
-      // Each vault is pinned to a specific offchainParamsVersion at registration
-      // (matches the in-flow modal's behavior; see commit 5b7048e). The poller
-      // fetches raw confirmation counts; we apply the per-deposit depth here so
-      // a governance change to `minPrepeginDepth` never misclassifies older
-      // deposits. Falls back to latest if the version isn't on the activity
-      // (older indexer data) — same as not gating, which is the safe direction.
-      const versionedParams =
-        activity.offchainParamsVersion !== undefined
-          ? getOffchainParamsByVersion(activity.offchainParamsVersion)
-          : undefined;
-      const requiredDepth =
-        versionedParams?.minPrepeginDepth ??
-        config.offchainParams.minPrepeginDepth;
+      // Per-vault depth (pinned to the registration's offchainParamsVersion)
+      // so a governance bump to `minPrepeginDepth` doesn't misclassify older
+      // deposits.
+      const requiredDepth = getRequiredPrePeginDepth(activity);
 
-      const confirmations = activity.peginTxHash
-        ? prePeginConfirmationsByTxid.get(
-            stripHexPrefix(activity.peginTxHash).toLowerCase(),
-          )
+      // Same key as `pendingPrePeginTxids` — depositor's broadcast tx.
+      const prePeginCanonical = canonicalizeTxid(activity.prePeginTxHash);
+      const confirmations = prePeginCanonical
+        ? prePeginConfirmationsByTxid.get(prePeginCanonical)
         : undefined;
       const prePeginBroadcastConfirmed =
         confirmations !== undefined && confirmations >= requiredDepth;
@@ -240,8 +310,7 @@ export function PeginPollingProvider({
       needsWotsKey,
       pendingIngestion,
       prePeginConfirmationsByTxid,
-      getOffchainParamsByVersion,
-      config.offchainParams.minPrepeginDepth,
+      getRequiredPrePeginDepth,
       isLoading,
       optimisticStatuses,
       optimisticRefundBroadcastAt,

--- a/services/vault/src/context/deposit/PeginPollingContext.tsx
+++ b/services/vault/src/context/deposit/PeginPollingContext.tsx
@@ -132,8 +132,10 @@ export function PeginPollingProvider({
   // CONFIRMING. Skip PAYOUT_SIGNED / CONFIRMED / REFUND_BROADCAST (VP has
   // already advanced past depth). Skip txids already in the persistent
   // confirmed cache — chain doesn't rewind, repolling reads the same fact.
-  // State-machine consumer still sees the depth signal via the query's
-  // `placeholderData` carryover, so dropping from the poll set is safe.
+  // State-machine consumer reads the depth signal from `confirmedTxids`
+  // OR'd with the live mempool map (see `getPollingResult` below), so
+  // dropping a confirmed txid from the poll set is safe across refreshes
+  // — not just bridged by React Query's in-memory `placeholderData`.
   const { config, getOffchainParamsByVersion } = useProtocolParamsContext();
   const [confirmedTxids, setConfirmedTxids] = useState<Set<string>>(
     loadConfirmedPrePeginTxids,
@@ -152,13 +154,20 @@ export function PeginPollingProvider({
     [getOffchainParamsByVersion, config.offchainParams.minPrepeginDepth],
   );
 
+  // Optimistic overrides (set immediately on user action) take precedence
+  // over `pendingPegins` so the filter correctly skips a just-PAYOUT_SIGNED
+  // vault even before localStorage syncs back. Mirrors `resolveLocalStatus`
+  // used by `getPollingResult` below.
   const localStatusById = useMemo(() => {
     const map = new Map<string, LocalStorageStatus>();
     for (const p of pendingPegins) {
-      if (p.status) map.set(p.id, p.status as LocalStorageStatus);
+      if (p.status) map.set(p.id, p.status);
+    }
+    for (const [id, status] of optimisticStatuses) {
+      map.set(id, status);
     }
     return map;
-  }, [pendingPegins]);
+  }, [pendingPegins, optimisticStatuses]);
 
   const pendingPrePeginTxids = useMemo(
     () =>
@@ -177,26 +186,37 @@ export function PeginPollingProvider({
     usePrePeginMempoolConfirmations(pendingPrePeginTxids);
 
   // Persist newly-confirmed observations and drop them from the polled set
-  // on next render. Functional setState keeps `confirmedTxids` out of the
-  // dep array so the effect doesn't re-fire every time the cache grows.
+  // on next render. The localStorage write and setState happen OUTSIDE the
+  // updater so the updater stays pure (React StrictMode invokes updaters
+  // twice in dev; side effects inside would double-write). The early
+  // return when nothing's newly confirmed prevents re-fires after the
+  // cache grows by an entry.
   useEffect(() => {
     if (prePeginConfirmationsByTxid.size === 0) return;
+
+    const newlyConfirmedTxids: string[] = [];
+    for (const activity of activities) {
+      const txid = canonicalizeTxid(activity.prePeginTxHash);
+      if (!txid || confirmedTxids.has(txid)) continue;
+      const observed = prePeginConfirmationsByTxid.get(txid);
+      if (observed === undefined) continue;
+      if (observed < getRequiredPrePeginDepth(activity)) continue;
+      newlyConfirmedTxids.push(txid);
+    }
+    if (newlyConfirmedTxids.length === 0) return;
+
+    newlyConfirmedTxids.forEach(addConfirmedPrePeginTxid);
     setConfirmedTxids((prev) => {
       const next = new Set(prev);
-      let changed = false;
-      for (const activity of activities) {
-        const txid = canonicalizeTxid(activity.prePeginTxHash);
-        if (!txid || next.has(txid)) continue;
-        const observed = prePeginConfirmationsByTxid.get(txid);
-        if (observed === undefined) continue;
-        if (observed < getRequiredPrePeginDepth(activity)) continue;
-        addConfirmedPrePeginTxid(txid);
-        next.add(txid);
-        changed = true;
-      }
-      return changed ? next : prev;
+      newlyConfirmedTxids.forEach((txid) => next.add(txid));
+      return next;
     });
-  }, [prePeginConfirmationsByTxid, activities, getRequiredPrePeginDepth]);
+  }, [
+    prePeginConfirmationsByTxid,
+    activities,
+    confirmedTxids,
+    getRequiredPrePeginDepth,
+  ]);
 
   // Optimistic status handlers
   const setOptimisticStatus = useCallback(
@@ -270,12 +290,21 @@ export function PeginPollingProvider({
       const requiredDepth = getRequiredPrePeginDepth(activity);
 
       // Same key as `pendingPrePeginTxids` — depositor's broadcast tx.
+      // The confirmed cache is also authoritative for "at depth": on a
+      // fresh page load the cached txid is filtered out of polling so the
+      // live map has no entry for it, but the depth fact persisted across
+      // sessions — without this OR, a cached vault would regress to
+      // "waiting for BTC confirmation" on every refresh.
       const prePeginCanonical = canonicalizeTxid(activity.prePeginTxHash);
+      const cachedAtDepth = prePeginCanonical
+        ? confirmedTxids.has(prePeginCanonical)
+        : false;
       const confirmations = prePeginCanonical
         ? prePeginConfirmationsByTxid.get(prePeginCanonical)
         : undefined;
       const prePeginBroadcastConfirmed =
-        confirmations !== undefined && confirmations >= requiredDepth;
+        cachedAtDepth ||
+        (confirmations !== undefined && confirmations >= requiredDepth);
 
       const peginState = getPeginState(contractStatus, {
         localStatus,
@@ -310,6 +339,7 @@ export function PeginPollingProvider({
       needsWotsKey,
       pendingIngestion,
       prePeginConfirmationsByTxid,
+      confirmedTxids,
       getRequiredPrePeginDepth,
       isLoading,
       optimisticStatuses,

--- a/services/vault/src/context/deposit/__tests__/PeginPollingContext.test.tsx
+++ b/services/vault/src/context/deposit/__tests__/PeginPollingContext.test.tsx
@@ -440,6 +440,72 @@ describe("PeginPollingContext", () => {
     });
   });
 
+  it("treats a cached confirmed txid as at-depth even when the mempool poll map is empty", async () => {
+    // Regression: on a fresh page load the cache excludes confirmed txids
+    // from polling, so `prePeginConfirmationsByTxid` has no entry for them.
+    // Without consulting the cache, `getPollingResult` would compute
+    // `prePeginBroadcastConfirmed = false` and the state machine would
+    // regress a cached CONFIRMING vault to "waiting for BTC confirmation"
+    // until the cache expired — defeating the whole persistence design.
+    const VAULT_ID = "0xvault" as Hex;
+    const PREPEGIN_HASH = "0xprepeginCached" as Hex;
+    const canonical = PREPEGIN_HASH.slice(2).toLowerCase();
+
+    localStorage.setItem(
+      "tbv-confirmed-prepegin-signet",
+      JSON.stringify({ [canonical]: Date.now() }),
+    );
+
+    // Empty mempool result (the poll skipped this txid because cache filter dropped it).
+    mockUsePrePeginMempoolConfirmations.mockReturnValue({
+      confirmationsByTxid: new Map<string, number>(),
+    });
+    mockQueryResult.pendingIngestion = new Set([VAULT_ID]);
+
+    const activity: VaultActivity = {
+      id: VAULT_ID,
+      collateral: { amount: "0.1", symbol: "BTC" },
+      providers: [{ id: "0xprovider" }],
+      peginTxHash: PREPEGIN_HASH,
+      prePeginTxHash: PREPEGIN_HASH,
+      contractStatus: ContractStatus.PENDING,
+      isInUse: false,
+      displayLabel: PEGIN_DISPLAY_LABELS.PENDING,
+      depositorBtcPubkey: BTC_PUBKEY,
+      unsignedPrePeginTx: "0xdeadbeef",
+      depositorPayoutBtcAddress: "0xpayoutscript" as Hex,
+      depositorWotsPkHash: "0xwotsh",
+    };
+
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <PeginPollingProvider
+        activities={[activity]}
+        pendingPegins={[
+          {
+            id: VAULT_ID,
+            timestamp: 0,
+            status: LocalStorageStatus.CONFIRMING,
+            peginTxHash: PREPEGIN_HASH,
+            unsignedTxHex: "0xdeadbeef",
+          },
+        ]}
+        btcPublicKey={BTC_PUBKEY}
+      >
+        {children}
+      </PeginPollingProvider>
+    );
+    const { result } = renderHook(() => usePeginPolling(), { wrapper });
+
+    // State machine routes to the "BTC at depth, VP ingesting" branch
+    // (driven by `prePeginBroadcastConfirmed`) without any mempool hit.
+    await waitFor(() => {
+      expect(
+        result.current.getPollingResult(VAULT_ID)?.peginState
+          .awaitingVpIngestion,
+      ).toBe(true);
+    });
+  });
+
   it("does not re-poll a Pre-PegIn txid present in the persistent confirmed cache", () => {
     // Page refresh equivalent: the cache was populated in a prior session
     // (or earlier dashboard mount). The provider should respect it on

--- a/services/vault/src/context/deposit/__tests__/PeginPollingContext.test.tsx
+++ b/services/vault/src/context/deposit/__tests__/PeginPollingContext.test.tsx
@@ -1,4 +1,4 @@
-import { act, renderHook } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import type { PropsWithChildren } from "react";
 import type { Hex } from "viem";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -27,12 +27,20 @@ vi.mock("../../../hooks/deposit/usePeginPollingQuery", () => ({
 }));
 
 // The mempool-truth hook adds network polling and a ProtocolParamsContext
-// dependency neither of which this test cares about — stub both so the
-// provider is renderable in isolation.
+// dependency neither of which this test cares about — stub it so the
+// provider is renderable in isolation. The spy lets the polling-filter
+// test assert which txids actually reach the mempool poller. `vi.hoisted`
+// keeps the spy reference live across vi.mock's factory hoist.
+const { mockUsePrePeginMempoolConfirmations } = vi.hoisted(() => ({
+  mockUsePrePeginMempoolConfirmations: vi.fn<
+    (txids: ReadonlyArray<string | undefined>) => {
+      confirmationsByTxid: Map<string, number>;
+    }
+  >(() => ({ confirmationsByTxid: new Map<string, number>() })),
+}));
 vi.mock("../../../hooks/deposit/usePrePeginMempoolConfirmations", () => ({
-  usePrePeginMempoolConfirmations: () => ({
-    confirmationsByTxid: new Map<string, number>(),
-  }),
+  usePrePeginMempoolConfirmations: (txids: ReadonlyArray<string | undefined>) =>
+    mockUsePrePeginMempoolConfirmations(txids),
 }));
 
 vi.mock("../../ProtocolParamsContext", () => ({
@@ -80,6 +88,14 @@ describe("PeginPollingContext", () => {
     mockQueryResult.pendingDepositorSignatures = undefined;
     mockQueryResult.isLoading = false;
     mockQueryResult.refetch.mockClear();
+    mockUsePrePeginMempoolConfirmations.mockReset();
+    // Default: empty confirmations. Individual tests can override via
+    // `mockReturnValue` to inject a depth-reached entry.
+    mockUsePrePeginMempoolConfirmations.mockReturnValue({
+      confirmationsByTxid: new Map<string, number>(),
+    });
+    // The persistent confirmed-txid cache leaks across tests otherwise.
+    localStorage.clear();
   });
 
   it("trusts an in-memory PAYOUT_SIGNED over a stale-cached transactionsReady so the Sign button hides immediately after signing", () => {
@@ -146,5 +162,337 @@ describe("PeginPollingContext", () => {
     expect(status?.peginState.availableActions).toContain(
       PeginAction.SIGN_PAYOUT_TRANSACTIONS,
     );
+  });
+
+  it("polls mempool using prePeginTxHash, not peginTxHash", () => {
+    // Regression: the dashboard previously polled `peginTxHash` (the VP's
+    // later activation tx, which doesn't exist on Bitcoin until post-
+    // verification), so every cycle 404'd for every PENDING vault. The
+    // correct key is `prePeginTxHash` — the tx the depositor actually
+    // broadcasts. Distinct values per activity below so a future regression
+    // that re-uses `peginTxHash` would surface in this assertion.
+    const VAULT_A = "0xvaultA" as Hex;
+    const VAULT_B = "0xvaultB" as Hex;
+    const PEGIN_A = "0xpeginA" as Hex; // VP activation tx — must NOT be polled
+    const PEGIN_B = "0xpeginB" as Hex;
+    const PREPEGIN_A = "0xprepeginA" as Hex; // depositor broadcast tx — polled
+    const PREPEGIN_B = "0xprepeginB" as Hex;
+
+    const baseActivity = (
+      id: Hex,
+      peginHash: Hex,
+      prePeginHash: Hex,
+    ): VaultActivity => ({
+      id,
+      collateral: { amount: "0.1", symbol: "BTC" },
+      providers: [{ id: "0xprovider" }],
+      peginTxHash: peginHash,
+      prePeginTxHash: prePeginHash,
+      contractStatus: ContractStatus.PENDING,
+      isInUse: false,
+      displayLabel: PEGIN_DISPLAY_LABELS.PENDING,
+      depositorBtcPubkey: BTC_PUBKEY,
+      unsignedPrePeginTx: "0xdeadbeef",
+      depositorPayoutBtcAddress: "0xpayoutscript" as Hex,
+      depositorWotsPkHash: "0xwotsh",
+    });
+
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <PeginPollingProvider
+        activities={[
+          baseActivity(VAULT_A, PEGIN_A, PREPEGIN_A),
+          baseActivity(VAULT_B, PEGIN_B, PREPEGIN_B),
+        ]}
+        pendingPegins={[]}
+        btcPublicKey={BTC_PUBKEY}
+      >
+        {children}
+      </PeginPollingProvider>
+    );
+    renderHook(() => usePeginPolling(), { wrapper });
+
+    // Poller receives the prePegin hashes — not the pegin hashes.
+    const lastCall =
+      mockUsePrePeginMempoolConfirmations.mock.calls.at(-1)?.[0] ?? [];
+    expect(new Set(lastCall)).toEqual(new Set([PREPEGIN_A, PREPEGIN_B]));
+    expect(lastCall).not.toContain(PEGIN_A);
+    expect(lastCall).not.toContain(PEGIN_B);
+  });
+
+  it("polls PENDING vaults whose Pre-PegIn might still need depth tracking", () => {
+    // Poll while the FE doesn't yet know the Pre-PegIn is verified by
+    // the VP — i.e., no localStorage entry, PENDING, or CONFIRMING.
+    // Skip PAYOUT_SIGNED (VP already validated BTC at depth to prepare
+    // payouts) and CONFIRMED (vault activated). The skipped states bring
+    // no new information from the mempool; polling them is wasted work.
+    const NO_LOCAL_ID = "0xnolocal" as Hex;
+    const PENDING_ID = "0xpending" as Hex;
+    const CONFIRMING_ID = "0xconfirming" as Hex;
+    const SIGNED_ID = "0xsigned" as Hex;
+    const FINALIZED_ID = "0xfinalized" as Hex;
+    const NON_PENDING_ID = "0xactive" as Hex;
+
+    const activity = (
+      id: Hex,
+      contractStatus: ContractStatus,
+    ): VaultActivity => ({
+      id,
+      collateral: { amount: "0.1", symbol: "BTC" },
+      providers: [{ id: "0xprovider" }],
+      peginTxHash: id,
+      prePeginTxHash: id,
+      contractStatus,
+      isInUse: false,
+      displayLabel: PEGIN_DISPLAY_LABELS.PENDING,
+      depositorBtcPubkey: BTC_PUBKEY,
+      unsignedPrePeginTx: "0xdeadbeef",
+      depositorPayoutBtcAddress: "0xpayoutscript" as Hex,
+      depositorWotsPkHash: "0xwotsh",
+    });
+
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <PeginPollingProvider
+        activities={[
+          activity(NO_LOCAL_ID, ContractStatus.PENDING),
+          activity(PENDING_ID, ContractStatus.PENDING),
+          activity(CONFIRMING_ID, ContractStatus.PENDING),
+          activity(SIGNED_ID, ContractStatus.PENDING),
+          activity(FINALIZED_ID, ContractStatus.PENDING),
+          activity(NON_PENDING_ID, ContractStatus.ACTIVE),
+        ]}
+        pendingPegins={[
+          {
+            id: PENDING_ID,
+            timestamp: 0,
+            status: LocalStorageStatus.PENDING,
+            peginTxHash: PENDING_ID,
+            unsignedTxHex: "0xdeadbeef",
+          },
+          {
+            id: CONFIRMING_ID,
+            timestamp: 0,
+            status: LocalStorageStatus.CONFIRMING,
+            peginTxHash: CONFIRMING_ID,
+            unsignedTxHex: "0xdeadbeef",
+          },
+          {
+            id: SIGNED_ID,
+            timestamp: 0,
+            status: LocalStorageStatus.PAYOUT_SIGNED,
+            peginTxHash: SIGNED_ID,
+            unsignedTxHex: "0xdeadbeef",
+          },
+          {
+            id: FINALIZED_ID,
+            timestamp: 0,
+            status: LocalStorageStatus.CONFIRMED,
+            peginTxHash: FINALIZED_ID,
+            unsignedTxHex: "0xdeadbeef",
+          },
+          // NO_LOCAL_ID intentionally absent — cross-browser / lost-state.
+        ]}
+        btcPublicKey={BTC_PUBKEY}
+      >
+        {children}
+      </PeginPollingProvider>
+    );
+    renderHook(() => usePeginPolling(), { wrapper });
+
+    const lastCall =
+      mockUsePrePeginMempoolConfirmations.mock.calls.at(-1)?.[0] ?? [];
+    expect(new Set(lastCall)).toEqual(
+      new Set([NO_LOCAL_ID, PENDING_ID, CONFIRMING_ID]),
+    );
+    expect(lastCall).not.toContain(SIGNED_ID);
+    expect(lastCall).not.toContain(FINALIZED_ID);
+    expect(lastCall).not.toContain(NON_PENDING_ID);
+  });
+
+  it("looks up confirmations by prePeginTxHash, not peginTxHash", () => {
+    // Companion to the polling-key test: the state-machine consumer at
+    // `PeginPollingContext.tsx` must read confirmations keyed by the same
+    // hash the poller writes. If the poller key drifts to `prePeginTxHash`
+    // and the lookup stays on `peginTxHash` (or vice versa), the depth
+    // signal silently goes dead.
+    const VAULT_ID = "0xvault" as Hex;
+    const PEGIN_HASH = "0xpeginHash" as Hex;
+    const PREPEGIN_HASH = "0xprepeginHash" as Hex;
+    const REQUIRED_DEPTH = 6;
+
+    // Seed the mock so the lookup site sees a confirmation count at depth
+    // ONLY when keyed by prePeginTxHash. If the consumer accidentally keys
+    // by peginTxHash, it would return undefined and we'd see PENDING below.
+    mockUsePrePeginMempoolConfirmations.mockReturnValue({
+      confirmationsByTxid: new Map([
+        [PREPEGIN_HASH.slice(2).toLowerCase(), REQUIRED_DEPTH],
+      ]),
+    });
+
+    const activity: VaultActivity = {
+      id: VAULT_ID,
+      collateral: { amount: "0.1", symbol: "BTC" },
+      providers: [{ id: "0xprovider" }],
+      peginTxHash: PEGIN_HASH,
+      prePeginTxHash: PREPEGIN_HASH,
+      contractStatus: ContractStatus.PENDING,
+      isInUse: false,
+      displayLabel: PEGIN_DISPLAY_LABELS.PENDING,
+      depositorBtcPubkey: BTC_PUBKEY,
+      unsignedPrePeginTx: "0xdeadbeef",
+      depositorPayoutBtcAddress: "0xpayoutscript" as Hex,
+      depositorWotsPkHash: "0xwotsh",
+    };
+    mockQueryResult.pendingIngestion = new Set([VAULT_ID]);
+
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <PeginPollingProvider
+        activities={[activity]}
+        pendingPegins={[
+          {
+            id: VAULT_ID,
+            timestamp: 0,
+            // Local CONFIRMING + VP `pendingIngestion` is the path where
+            // `prePeginBroadcastConfirmed` actually steers the state output —
+            // distinguishing "waiting for BTC confirmation" from "BTC at
+            // depth, VP still ingesting". Without CONFIRMING, the state
+            // machine returns SIGN_AND_BROADCAST_TO_BITCOIN before the
+            // mempool-depth branch can fire.
+            status: LocalStorageStatus.CONFIRMING,
+            peginTxHash: PEGIN_HASH,
+            unsignedTxHex: "0xdeadbeef",
+          },
+        ]}
+        btcPublicKey={BTC_PUBKEY}
+      >
+        {children}
+      </PeginPollingProvider>
+    );
+    const { result } = renderHook(() => usePeginPolling(), { wrapper });
+
+    // The state machine surfaces "Pre-PegIn confirmed, VP ingesting" when
+    // `prePeginBroadcastConfirmed` is true AND `pendingIngestion` is set.
+    // That path only fires if the confirmations lookup matched —
+    // i.e., the consumer keyed by `prePeginTxHash`.
+    const polling = result.current.getPollingResult(VAULT_ID);
+    expect(polling?.peginState.awaitingVpIngestion).toBe(true);
+  });
+
+  it("stops polling a Pre-PegIn txid once it has been observed at required depth", async () => {
+    // Once the mempool reports a Pre-PegIn at the protocol-required depth,
+    // the answer is permanent — the chain doesn't rewind, the block height
+    // is fixed, and repolling the same txid reads the same fact. The
+    // confirmed-txid cache lets us drop it from the polled set so we don't
+    // burn a `/tx/<txid>` request per cycle (and per page refresh) just to
+    // re-confirm what we already know.
+    const VAULT_ID = "0xvault" as Hex;
+    const PREPEGIN_HASH = "0xprepeginConfirmed" as Hex;
+    const REQUIRED_DEPTH = 6;
+    const canonical = PREPEGIN_HASH.slice(2).toLowerCase();
+
+    // Start with empty confirmations, then flip to depth-reached. The
+    // effect that captures the observation runs after render — we have to
+    // give React a tick for the state update + re-render that drops the
+    // confirmed txid from the next polled list.
+    mockUsePrePeginMempoolConfirmations.mockReturnValue({
+      confirmationsByTxid: new Map([[canonical, REQUIRED_DEPTH]]),
+    });
+
+    const activity: VaultActivity = {
+      id: VAULT_ID,
+      collateral: { amount: "0.1", symbol: "BTC" },
+      providers: [{ id: "0xprovider" }],
+      peginTxHash: PREPEGIN_HASH,
+      prePeginTxHash: PREPEGIN_HASH,
+      contractStatus: ContractStatus.PENDING,
+      isInUse: false,
+      displayLabel: PEGIN_DISPLAY_LABELS.PENDING,
+      depositorBtcPubkey: BTC_PUBKEY,
+      unsignedPrePeginTx: "0xdeadbeef",
+      depositorPayoutBtcAddress: "0xpayoutscript" as Hex,
+      depositorWotsPkHash: "0xwotsh",
+    };
+
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <PeginPollingProvider
+        activities={[activity]}
+        pendingPegins={[
+          {
+            id: VAULT_ID,
+            timestamp: 0,
+            status: LocalStorageStatus.CONFIRMING,
+            peginTxHash: PREPEGIN_HASH,
+            unsignedTxHex: "0xdeadbeef",
+          },
+        ]}
+        btcPublicKey={BTC_PUBKEY}
+      >
+        {children}
+      </PeginPollingProvider>
+    );
+    renderHook(() => usePeginPolling(), { wrapper });
+
+    // After the depth-observation effect runs, the next render's polled
+    // list drops the now-confirmed txid.
+    await waitFor(() => {
+      const lastCall =
+        mockUsePrePeginMempoolConfirmations.mock.calls.at(-1)?.[0] ?? [];
+      expect(lastCall).not.toContain(PREPEGIN_HASH);
+    });
+  });
+
+  it("does not re-poll a Pre-PegIn txid present in the persistent confirmed cache", () => {
+    // Page refresh equivalent: the cache was populated in a prior session
+    // (or earlier dashboard mount). The provider should respect it on
+    // mount and never poll the cached txid in this session.
+    const VAULT_ID = "0xvault" as Hex;
+    const PREPEGIN_HASH = "0xprepeginCached" as Hex;
+    const canonical = PREPEGIN_HASH.slice(2).toLowerCase();
+
+    // Simulate a prior session having persisted the confirmed txid.
+    // The cache shape is `{ txid → addedAt }` so the TTL pruner can run;
+    // seed with a recent timestamp so the entry isn't immediately evicted.
+    localStorage.setItem(
+      "tbv-confirmed-prepegin-signet",
+      JSON.stringify({ [canonical]: Date.now() }),
+    );
+
+    const activity: VaultActivity = {
+      id: VAULT_ID,
+      collateral: { amount: "0.1", symbol: "BTC" },
+      providers: [{ id: "0xprovider" }],
+      peginTxHash: PREPEGIN_HASH,
+      prePeginTxHash: PREPEGIN_HASH,
+      contractStatus: ContractStatus.PENDING,
+      isInUse: false,
+      displayLabel: PEGIN_DISPLAY_LABELS.PENDING,
+      depositorBtcPubkey: BTC_PUBKEY,
+      unsignedPrePeginTx: "0xdeadbeef",
+      depositorPayoutBtcAddress: "0xpayoutscript" as Hex,
+      depositorWotsPkHash: "0xwotsh",
+    };
+
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <PeginPollingProvider
+        activities={[activity]}
+        pendingPegins={[
+          {
+            id: VAULT_ID,
+            timestamp: 0,
+            status: LocalStorageStatus.CONFIRMING,
+            peginTxHash: PREPEGIN_HASH,
+            unsignedTxHex: "0xdeadbeef",
+          },
+        ]}
+        btcPublicKey={BTC_PUBKEY}
+      >
+        {children}
+      </PeginPollingProvider>
+    );
+    renderHook(() => usePeginPolling(), { wrapper });
+
+    // Every recorded polling-hook call should exclude the cached txid.
+    for (const call of mockUsePrePeginMempoolConfirmations.mock.calls) {
+      expect(call[0]).not.toContain(PREPEGIN_HASH);
+    }
   });
 });

--- a/services/vault/src/storage/__tests__/confirmedPrePeginCache.test.ts
+++ b/services/vault/src/storage/__tests__/confirmedPrePeginCache.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  addConfirmedPrePeginTxid,
+  loadConfirmedPrePeginTxids,
+} from "../confirmedPrePeginCache";
+
+vi.mock("@/config", () => ({
+  getBTCNetwork: () => "signet",
+}));
+
+const STORAGE_KEY = "tbv-confirmed-prepegin-signet";
+const TTL_MS = 30 * 24 * 60 * 60 * 1000;
+
+describe("confirmedPrePeginCache", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-01T00:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("stores a fresh observation and returns it on load", () => {
+    addConfirmedPrePeginTxid("aabb");
+    expect(loadConfirmedPrePeginTxids().has("aabb")).toBe(true);
+  });
+
+  it("returns an empty set when storage is empty", () => {
+    expect(loadConfirmedPrePeginTxids().size).toBe(0);
+  });
+
+  it("evicts entries older than the TTL on load", () => {
+    addConfirmedPrePeginTxid("fresh");
+    // Manually seed an old entry from "55 days ago" — past the 30d TTL.
+    const raw = localStorage.getItem(STORAGE_KEY);
+    const map = raw ? JSON.parse(raw) : {};
+    map["stale"] = Date.now() - 55 * 24 * 60 * 60 * 1000;
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(map));
+
+    const loaded = loadConfirmedPrePeginTxids();
+    expect(loaded.has("fresh")).toBe(true);
+    expect(loaded.has("stale")).toBe(false);
+  });
+
+  it("treats entries at exactly the TTL boundary as expired", () => {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    const map = raw ? JSON.parse(raw) : {};
+    // ts = now - TTL: cutoff is `now - TTL`, condition is `ts > cutoff`,
+    // so an entry exactly at the boundary should be dropped.
+    map["boundary"] = Date.now() - TTL_MS;
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(map));
+
+    expect(loadConfirmedPrePeginTxids().has("boundary")).toBe(false);
+  });
+
+  it("does not duplicate or refresh the timestamp when adding a known txid", () => {
+    addConfirmedPrePeginTxid("aabb");
+    const firstTs = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "{}")[
+      "aabb"
+    ];
+
+    vi.advanceTimersByTime(60 * 60 * 1000);
+    addConfirmedPrePeginTxid("aabb");
+    const secondTs = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "{}")[
+      "aabb"
+    ];
+
+    expect(secondTs).toBe(firstTs);
+  });
+
+  it("opportunistically prunes expired entries when adding a new one", () => {
+    // Seed an expired entry.
+    const map = { stale: Date.now() - 60 * 24 * 60 * 60 * 1000 };
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(map));
+
+    addConfirmedPrePeginTxid("fresh");
+
+    const persisted = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "{}");
+    expect(persisted).toEqual({ fresh: expect.any(Number) });
+  });
+
+  it("ignores corrupted storage values without throwing", () => {
+    localStorage.setItem(STORAGE_KEY, "not json {");
+    expect(loadConfirmedPrePeginTxids().size).toBe(0);
+  });
+
+  it("ignores empty/whitespace txid passed to add", () => {
+    addConfirmedPrePeginTxid("");
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+});

--- a/services/vault/src/storage/confirmedPrePeginCache.ts
+++ b/services/vault/src/storage/confirmedPrePeginCache.ts
@@ -1,0 +1,62 @@
+/**
+ * Persistent cache of Pre-PegIn txids the mempool has reported at
+ * protocol-required depth. Once observed at depth the answer is permanent
+ * (chain doesn't rewind), so we skip those txids in future polls — both
+ * within a session and across page refreshes. TTL bounds cache size so
+ * stale entries from long-resolved deposits don't accumulate forever.
+ */
+
+import { getBTCNetwork } from "@/config";
+
+const STORAGE_KEY = `tbv-confirmed-prepegin-${getBTCNetwork()}`;
+const CACHE_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+
+function readMap(): Record<string, number> {
+  try {
+    const parsed = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "{}");
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, number>)
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+function writeMap(map: Record<string, number>): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(map));
+  } catch {
+    /* quota / disabled — non-fatal */
+  }
+}
+
+function pruneExpired(
+  map: Record<string, number>,
+  now: number,
+): Record<string, number> {
+  const cutoff = now - CACHE_TTL_MS;
+  const out: Record<string, number> = {};
+  // `> cutoff` naturally drops NaN/strings/undefined — no separate typeof check needed.
+  for (const [txid, ts] of Object.entries(map)) {
+    if (ts > cutoff) out[txid] = ts;
+  }
+  return out;
+}
+
+export function loadConfirmedPrePeginTxids(): Set<string> {
+  const map = readMap();
+  const pruned = pruneExpired(map, Date.now());
+  if (Object.keys(pruned).length !== Object.keys(map).length) {
+    writeMap(pruned);
+  }
+  return new Set(Object.keys(pruned));
+}
+
+export function addConfirmedPrePeginTxid(canonicalTxid: string): void {
+  if (!canonicalTxid) return;
+  const now = Date.now();
+  const map = pruneExpired(readMap(), now);
+  if (map[canonicalTxid] !== undefined) return;
+  map[canonicalTxid] = now;
+  writeMap(map);
+}

--- a/services/vault/src/utils/txid.ts
+++ b/services/vault/src/utils/txid.ts
@@ -1,0 +1,9 @@
+import { stripHexPrefix } from "@babylonlabs-io/ts-sdk/tbv/core";
+
+/**
+ * Canonical form used to key txid lookups across the polling layer and the
+ * confirmed-pegin cache: hex without the `0x` prefix, lowercased.
+ */
+export function canonicalizeTxid(hex: string | undefined): string | undefined {
+  return hex ? stripHexPrefix(hex).toLowerCase() : undefined;
+}


### PR DESCRIPTION
The dashboard polled `peginTxHash` — the VP's later activation tx, which doesn't exist on Bitcoin during `PENDING` — so every pending vault hit `/tx/<txid>` every
60s and 404'd, manifesting as *"Awaiting Bitcoin confirmation"* for Pre-PegIns long since at depth.

## Changes

1. Poll `prePeginTxHash` (depositor broadcast tx) at the polled-list and consumer-lookup sites.
2. Filter polled vaults by localStorage status: include `undefined` / `PENDING` / `CONFIRMING`; skip `PAYOUT_SIGNED` / `CONFIRMED` / `REFUND_BROADCAST` (VP has
already advanced past depth).
3. Persist depth-observed txids in localStorage with a 30-day TTL. Once a Pre-PegIn is at the required depth, the answer is permanent (chain doesn't rewind), so we
skip those txids in future polls — within a session and across page refreshes. The state machine continues to see the depth signal via React Query's
`placeholderData` carryover.