### PR TITLE
fix(vault): align deposit progress steps with polled status

### DIFF
--- a/services/vault/src/components/simple/DepositProgressView/DepositProgressView.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/DepositProgressView.tsx
@@ -54,6 +54,14 @@ export interface DepositProgressViewProps {
   onClose: () => void;
   /** Override the default success message */
   successMessage?: string;
+  /**
+   * Terminal success message shown at the *current* (non-final) step — used
+   * when the deposit has reached a stable, closeable milestone that is not the
+   * end of the whole flow (e.g. "ready to activate" after payout signing).
+   * Unlike `isComplete`, this does not advance the stepper to 100%; it renders
+   * a success banner and a "Done" button while keeping the step position.
+   */
+  terminalMessage?: string | null;
   /** Override the default error retry handler (defaults to onClose) */
   onRetry?: () => void;
   /**
@@ -76,10 +84,15 @@ export function DepositProgressView(props: DepositProgressViewProps) {
     peginSigningProgress,
     onClose,
     successMessage = COPY.deposit.progress.defaultSuccessMessage,
+    terminalMessage,
     onRetry,
     btcConfirmationDetail,
     waitDetailPersistKey,
   } = props;
+
+  // A terminal-but-not-final milestone: closeable success without marking the
+  // whole flow complete (so the stepper keeps its real position).
+  const isTerminalSuccess = !isComplete && !error && Boolean(terminalMessage);
 
   // On completion, advance past the last row so every circle renders as ✓.
   const visualStep = isComplete
@@ -154,8 +167,12 @@ export function DepositProgressView(props: DepositProgressViewProps) {
           <StatusBanner variant="success">{successMessage}</StatusBanner>
         )}
 
+        {isTerminalSuccess && (
+          <StatusBanner variant="success">{terminalMessage}</StatusBanner>
+        )}
+
         <Button
-          disabled={!canClose}
+          disabled={!canClose && !isTerminalSuccess}
           variant="contained"
           color="secondary"
           className="w-full"
@@ -169,7 +186,7 @@ export function DepositProgressView(props: DepositProgressViewProps) {
             ) : (
               COPY.deposit.progress.buttons.close
             )
-          ) : isComplete ? (
+          ) : isComplete || isTerminalSuccess ? (
             COPY.deposit.progress.buttons.done
           ) : isProcessing ? (
             <span className="flex items-center justify-center gap-2">

--- a/services/vault/src/components/simple/DepositProgressView/__tests__/DepositProgressView.test.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/__tests__/DepositProgressView.test.tsx
@@ -75,7 +75,7 @@ describe("DepositProgressView", () => {
 
       // The finished "Register deposit" group reports 7/7.
       expect(
-        screen.getByText(COPY.deposit.groups.stepCounter(7, 7)),
+        screen.getByText(COPY.deposit.groups.stepCounter(6, 6)),
       ).toBeInTheDocument();
     });
   });
@@ -94,7 +94,7 @@ describe("DepositProgressView", () => {
         screen.getByText(COPY.deposit.steps.generateSecret),
       ).toBeInTheDocument();
       expect(
-        screen.getByText(COPY.deposit.steps.awaitBtcConfirmation),
+        screen.getByText(COPY.deposit.steps.confirmingDeposit),
       ).toBeInTheDocument();
 
       // Later groups' sub-steps are collapsed.
@@ -166,9 +166,9 @@ describe("DepositProgressView", () => {
         />,
       );
 
-      // AWAIT_BTC_CONFIRMATION is visual step 6 → 5 of 17 completed → 29%.
+      // AWAIT_BTC_CONFIRMATION is visual step 6 → 5 of 16 completed → 31%.
       const bar = screen.getByRole("progressbar");
-      expect(bar).toHaveAttribute("aria-valuenow", "29");
+      expect(bar).toHaveAttribute("aria-valuenow", "31");
       expect(bar).toHaveAttribute("aria-valuemax", "100");
     });
 
@@ -201,7 +201,7 @@ describe("DepositProgressView", () => {
         screen.getByText(COPY.deposit.steps.generateSecret),
       ).toBeInTheDocument();
       expect(
-        screen.getByText(COPY.deposit.steps.awaitBtcConfirmation),
+        screen.getByText(COPY.deposit.steps.confirmingDeposit),
       ).toBeInTheDocument();
       // Steps in other (collapsed) groups remain hidden.
       expect(
@@ -343,7 +343,7 @@ describe("DepositProgressView", () => {
       );
 
       expect(
-        screen.getByText(COPY.deposit.groups.stepCounter(7, 7)),
+        screen.getByText(COPY.deposit.groups.stepCounter(6, 6)),
       ).toBeInTheDocument();
       expect(
         screen.getAllByText(COPY.deposit.groups.stepCounter(4, 4)),
@@ -368,7 +368,7 @@ describe("DepositProgressView", () => {
       );
 
       expect(
-        screen.getByText(COPY.deposit.groups.stepCounter(7, 7)),
+        screen.getByText(COPY.deposit.groups.stepCounter(6, 6)),
       ).toBeInTheDocument();
       expect(screen.getByRole("progressbar")).toHaveAttribute(
         "aria-valuenow",
@@ -456,6 +456,67 @@ describe("DepositProgressView", () => {
       expect(
         screen.queryByText(COPY.deposit.steps.peginFeeWarning),
       ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("terminal success milestone (terminalMessage)", () => {
+    it("shows the terminal message and a Done button without completing the flow", () => {
+      render(
+        <DepositProgressView
+          {...baseProps}
+          currentStep={DepositFlowStep.RETRIEVE_SECRET}
+          canClose={false}
+          terminalMessage="Ready to activate."
+        />,
+      );
+
+      expect(screen.getByText("Ready to activate.")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Done" })).toBeInTheDocument();
+      // Not the final state: the progress bar is not full.
+      expect(screen.getByRole("progressbar")).not.toHaveAttribute(
+        "aria-valuenow",
+        "100",
+      );
+    });
+
+    it("enables the Done button even when canClose is false", () => {
+      render(
+        <DepositProgressView
+          {...baseProps}
+          currentStep={DepositFlowStep.RETRIEVE_SECRET}
+          canClose={false}
+          terminalMessage="Ready to activate."
+        />,
+      );
+
+      expect(screen.getByRole("button", { name: "Done" })).toBeEnabled();
+    });
+
+    it("suppresses the terminal banner when there is an error", () => {
+      render(
+        <DepositProgressView
+          {...baseProps}
+          currentStep={DepositFlowStep.RETRIEVE_SECRET}
+          error="boom"
+          terminalMessage="Ready to activate."
+        />,
+      );
+
+      expect(screen.queryByText("Ready to activate.")).not.toBeInTheDocument();
+    });
+
+    it("prefers the final success banner over the terminal message when complete", () => {
+      render(
+        <DepositProgressView
+          {...baseProps}
+          currentStep={DepositFlowStep.COMPLETED}
+          isComplete
+          terminalMessage="Ready to activate."
+        />,
+      );
+
+      expect(screen.queryByText("Ready to activate.")).not.toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Done" })).toBeInTheDocument();
     });
   });
 });

--- a/services/vault/src/components/simple/DepositProgressView/__tests__/GroupedProgress.test.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/__tests__/GroupedProgress.test.tsx
@@ -25,7 +25,7 @@ describe("GroupedProgress", () => {
   });
 
   it("expands only the active group and hides other groups' sub-steps", () => {
-    // Step 8 -> "Set up claim" group (8-9) is active.
+    // Step 8 -> "Set up claim" group (7-8) is active.
     render(<GroupedProgress steps={steps} currentStep={8} />);
 
     // Active group sub-step is visible.
@@ -47,14 +47,14 @@ describe("GroupedProgress", () => {
   it("shows the per-group completed counter on a finished group", () => {
     render(<GroupedProgress steps={steps} currentStep={8} />);
 
-    // Register deposit (steps 1-7) is fully done.
+    // Register deposit (steps 1-6) is fully done.
     expect(
-      screen.getByText(COPY.deposit.groups.stepCounter(7, 7)),
+      screen.getByText(COPY.deposit.groups.stepCounter(6, 6)),
     ).toBeInTheDocument();
   });
 
   it("renders completed sub-steps without a step number inside the active group", () => {
-    // Step 11 -> "Sign payout" group (global 10-13) active; global step 10 is already done.
+    // Step 11 -> "Sign payout" group (9-12) active; steps 9-10 are already done.
     render(<GroupedProgress steps={steps} currentStep={11} />);
 
     // Completed sub-step label is shown...
@@ -64,8 +64,7 @@ describe("GroupedProgress", () => {
     // ...but rendered as a checkmark row, not the numbered pending row "1".
     expect(screen.queryByText("1")).not.toBeInTheDocument();
 
-    // Pending sub-steps carry per-group numbers (3, 4 within the group).
-    expect(screen.getByText("3")).toBeInTheDocument();
+    // The remaining pending sub-step carries its per-group number (4 within the group).
     expect(screen.getByText("4")).toBeInTheDocument();
   });
 
@@ -91,9 +90,9 @@ describe("GroupedProgress", () => {
     expect(
       screen.queryByText(COPY.deposit.steps.generateSecret),
     ).not.toBeInTheDocument();
-    // Every group reports itself fully complete (7/7, 2/2, 4/4, 4/4).
+    // Every group reports itself fully complete (6/6, 2/2, 4/4, 4/4).
     expect(
-      screen.getByText(COPY.deposit.groups.stepCounter(7, 7)),
+      screen.getByText(COPY.deposit.groups.stepCounter(6, 6)),
     ).toBeInTheDocument();
     expect(
       screen.getByText(COPY.deposit.groups.stepCounter(2, 2)),
@@ -106,7 +105,7 @@ describe("GroupedProgress", () => {
   describe("accessibility", () => {
     it("labels the active sub-step for screen readers with the global step number", () => {
       // Step 8 -> "Set up claim" group active; screen reader gets global step 8,
-      // not the per-group display number 1.
+      // not the per-group display number 2.
       render(<GroupedProgress steps={steps} currentStep={8} />);
 
       expect(
@@ -115,12 +114,12 @@ describe("GroupedProgress", () => {
     });
 
     it("labels a pending sub-step for screen readers with the global step number", () => {
-      // Step 8 -> "Set up claim" group (8-9) active; global step 9 is pending and
+      // Step 7 -> "Set up claim" group (7-8) active; global step 8 is pending and
       // its screen-reader label keeps the global number, not the per-group number 2.
-      render(<GroupedProgress steps={steps} currentStep={8} />);
+      render(<GroupedProgress steps={steps} currentStep={7} />);
 
       expect(
-        screen.getByLabelText(COPY.deposit.a11y.stepPending(9)),
+        screen.getByLabelText(COPY.deposit.a11y.stepPending(8)),
       ).toBeInTheDocument();
     });
 

--- a/services/vault/src/components/simple/DepositProgressView/__tests__/steps.test.ts
+++ b/services/vault/src/components/simple/DepositProgressView/__tests__/steps.test.ts
@@ -14,9 +14,9 @@ import {
 } from "../steps";
 
 describe("getStepLabel", () => {
-  it("returns the awaiting-confirmation label for AWAIT_BTC_CONFIRMATION", () => {
+  it("returns the confirming-deposit label for AWAIT_BTC_CONFIRMATION", () => {
     expect(getStepLabel(DepositFlowStep.AWAIT_BTC_CONFIRMATION)).toBe(
-      COPY.deposit.steps.awaitBtcConfirmation,
+      COPY.deposit.steps.confirmingDeposit,
     );
   });
 
@@ -64,29 +64,22 @@ describe("getStepLabel", () => {
     );
   });
 
-  it("inserts AWAIT_VP_INGESTION right after AWAIT_BTC_CONFIRMATION", () => {
+  it("keeps AWAIT_BTC_CONFIRMATION at visual step 6 (VP-ingestion shares it)", () => {
     expect(getVisualStep(DepositFlowStep.AWAIT_BTC_CONFIRMATION)).toBe(6);
-    expect(getVisualStep(DepositFlowStep.AWAIT_VP_INGESTION)).toBe(7);
   });
 
-  it("returns the VP-ingestion label for AWAIT_VP_INGESTION", () => {
-    expect(getStepLabel(DepositFlowStep.AWAIT_VP_INGESTION)).toBe(
-      COPY.deposit.steps.awaitVpIngestion,
-    );
-  });
-
-  it("renumbers existing post-WOTS action steps after the payout wait", () => {
-    expect(getVisualStep(DepositFlowStep.SUBMIT_WOTS_KEYS)).toBe(8);
-    expect(getVisualStep(DepositFlowStep.AWAIT_PAYOUT_TRANSACTIONS)).toBe(9);
-    expect(getVisualStep(DepositFlowStep.SIGN_AUTH_ANCHOR)).toBe(10);
-    expect(getVisualStep(DepositFlowStep.SIGN_PAYOUTS)).toBe(11);
-    expect(getVisualStep(DepositFlowStep.SIGN_DEPOSITOR_GRAPH)).toBe(12);
-    expect(getVisualStep(DepositFlowStep.AWAIT_VP_VERIFICATION)).toBe(13);
-    expect(getVisualStep(DepositFlowStep.ARTIFACT_DOWNLOAD)).toBe(14);
-    expect(getVisualStep(DepositFlowStep.RETRIEVE_SECRET)).toBe(15);
-    expect(getVisualStep(DepositFlowStep.ACTIVATE_VAULT)).toBe(16);
+  it("numbers post-confirmation steps with no gap where VP-ingestion was", () => {
+    expect(getVisualStep(DepositFlowStep.SUBMIT_WOTS_KEYS)).toBe(7);
+    expect(getVisualStep(DepositFlowStep.AWAIT_PAYOUT_TRANSACTIONS)).toBe(8);
+    expect(getVisualStep(DepositFlowStep.SIGN_AUTH_ANCHOR)).toBe(9);
+    expect(getVisualStep(DepositFlowStep.SIGN_PAYOUTS)).toBe(10);
+    expect(getVisualStep(DepositFlowStep.SIGN_DEPOSITOR_GRAPH)).toBe(11);
+    expect(getVisualStep(DepositFlowStep.AWAIT_VP_VERIFICATION)).toBe(12);
+    expect(getVisualStep(DepositFlowStep.ARTIFACT_DOWNLOAD)).toBe(13);
+    expect(getVisualStep(DepositFlowStep.RETRIEVE_SECRET)).toBe(14);
+    expect(getVisualStep(DepositFlowStep.ACTIVATE_VAULT)).toBe(15);
     expect(getVisualStep(DepositFlowStep.AWAIT_ACTIVATION_CONFIRMATION)).toBe(
-      17,
+      16,
     );
   });
 });
@@ -154,10 +147,10 @@ describe("STEP_GROUPS", () => {
 
   it("groups the steps into the four expected sections", () => {
     expect(STEP_GROUPS.map((g) => [g.title, g.startStep, g.endStep])).toEqual([
-      [COPY.deposit.groups.registerDeposit, 1, 7],
-      [COPY.deposit.groups.signWots, 8, 9],
-      [COPY.deposit.groups.signPayout, 10, 13],
-      [COPY.deposit.groups.activateVault, 14, 17],
+      [COPY.deposit.groups.registerDeposit, 1, 6],
+      [COPY.deposit.groups.signWots, 7, 8],
+      [COPY.deposit.groups.signPayout, 9, 12],
+      [COPY.deposit.groups.activateVault, 13, 16],
     ]);
   });
 });
@@ -176,7 +169,7 @@ describe("buildStepGroups", () => {
     expect(register.status).toBe("active");
     expect(register.expanded).toBe(true);
     expect(register.completedInGroup).toBe(0);
-    expect(register.totalInGroup).toBe(7);
+    expect(register.totalInGroup).toBe(6);
 
     expect(wots.status).toBe("upcoming");
     expect(wots.expanded).toBe(false);
@@ -184,12 +177,12 @@ describe("buildStepGroups", () => {
     expect(activate.status).toBe("upcoming");
   });
 
-  it("marks earlier groups completed and activates the WOTS group at step 8", () => {
-    const [register, wots, payout] = buildStepGroups(8);
+  it("marks earlier groups completed and activates the WOTS group at step 7", () => {
+    const [register, wots, payout] = buildStepGroups(7);
 
     expect(register.status).toBe("completed");
     expect(register.expanded).toBe(false);
-    expect(register.completedInGroup).toBe(7);
+    expect(register.completedInGroup).toBe(6);
 
     expect(wots.status).toBe("active");
     expect(wots.expanded).toBe(true);
@@ -200,8 +193,8 @@ describe("buildStepGroups", () => {
   });
 
   it("counts completed sub-steps within the active group (mid-group resume)", () => {
-    // Step 13 is the last step of the Sign payout group (10..13): 3 done, 1 active.
-    const payout = buildStepGroups(13).find(
+    // Step 12 is the last step of the Sign payout group (9..12): 3 done, 1 active.
+    const payout = buildStepGroups(12).find(
       (g) => g.title === COPY.deposit.groups.signPayout,
     );
 

--- a/services/vault/src/components/simple/DepositProgressView/steps.ts
+++ b/services/vault/src/components/simple/DepositProgressView/steps.ts
@@ -35,8 +35,7 @@ export function buildStepItems(
     { label: COPY.deposit.steps.signLinkProofs },
     { label: COPY.deposit.steps.signAndBroadcastEth },
     { label: COPY.deposit.steps.signAndBroadcastPrePegin },
-    { label: COPY.deposit.steps.awaitBtcConfirmation },
-    { label: COPY.deposit.steps.awaitVpIngestion },
+    { label: COPY.deposit.steps.confirmingDeposit },
     { label: COPY.deposit.steps.submitWotsKey },
     { label: COPY.deposit.steps.awaitPayoutTransactions },
     { label: COPY.deposit.steps.authenticateSession },
@@ -67,10 +66,10 @@ export interface StepGroup {
 }
 
 export const STEP_GROUPS: StepGroup[] = [
-  { title: COPY.deposit.groups.registerDeposit, startStep: 1, endStep: 7 },
-  { title: COPY.deposit.groups.signWots, startStep: 8, endStep: 9 },
-  { title: COPY.deposit.groups.signPayout, startStep: 10, endStep: 13 },
-  { title: COPY.deposit.groups.activateVault, startStep: 14, endStep: 17 },
+  { title: COPY.deposit.groups.registerDeposit, startStep: 1, endStep: 6 },
+  { title: COPY.deposit.groups.signWots, startStep: 7, endStep: 8 },
+  { title: COPY.deposit.groups.signPayout, startStep: 9, endStep: 12 },
+  { title: COPY.deposit.groups.activateVault, startStep: 13, endStep: 16 },
 ];
 
 export type GroupStatus = "completed" | "active" | "upcoming";
@@ -151,28 +150,26 @@ export function getVisualStep(currentStep: DepositFlowStep): number {
       return 5;
     case DepositFlowStep.AWAIT_BTC_CONFIRMATION:
       return 6;
-    case DepositFlowStep.AWAIT_VP_INGESTION:
-      return 7;
     case DepositFlowStep.SUBMIT_WOTS_KEYS:
-      return 8;
+      return 7;
     case DepositFlowStep.AWAIT_PAYOUT_TRANSACTIONS:
-      return 9;
+      return 8;
     case DepositFlowStep.SIGN_AUTH_ANCHOR:
-      return 10;
+      return 9;
     case DepositFlowStep.SIGN_PAYOUTS:
-      return 11;
+      return 10;
     case DepositFlowStep.SIGN_DEPOSITOR_GRAPH:
-      return 12;
+      return 11;
     case DepositFlowStep.AWAIT_VP_VERIFICATION:
-      return 13;
+      return 12;
     case DepositFlowStep.ARTIFACT_DOWNLOAD:
-      return 14;
+      return 13;
     case DepositFlowStep.RETRIEVE_SECRET:
-      return 15;
+      return 14;
     case DepositFlowStep.ACTIVATE_VAULT:
-      return 16;
+      return 15;
     case DepositFlowStep.AWAIT_ACTIVATION_CONFIRMATION:
-      return 17;
+      return 16;
     case DepositFlowStep.COMPLETED:
       return TOTAL_VISUAL_STEPS + 1;
     default: {

--- a/services/vault/src/components/simple/PendingDepositSection.tsx
+++ b/services/vault/src/components/simple/PendingDepositSection.tsx
@@ -69,15 +69,32 @@ export function PendingDepositSection() {
     [pendingActivities],
   );
 
-  if (!hasPendingDeposits && !hasExpiredDeposits) return null;
+  // A resume modal is rendered inside this section (under its
+  // PeginPollingProvider). When the last pending deposit advances to a terminal
+  // contract state (e.g. activation confirmed → ACTIVE), it drops out of
+  // `pendingActivities`; without this guard the section — and the open modal —
+  // would unmount before the modal could show its success terminal. Keep it
+  // mounted while any action modal is open so the modal owns its own dismissal.
+  const hasOpenModal = Boolean(
+    signModal.signingData ||
+      broadcastModal.broadcastingActivity ||
+      broadcastModal.successOpen ||
+      wotsKeyModal.isOpen ||
+      activationModal.activatingActivity ||
+      artifactDownloadModal.isOpen ||
+      refundModal.refundingActivity,
+  );
+
+  if (!hasPendingDeposits && !hasExpiredDeposits && !hasOpenModal) return null;
 
   const count = pendingActivities.length;
 
   // `PeginPollingProvider` resolves per-deposit `minPrepeginDepth` via
-  // `useProtocolParamsContext` for the AWAIT_VP_INGESTION routing — the
-  // dashboard doesn't otherwise mount `ProtocolParamsProvider`, so do it
-  // here. Only fires when there is something pending (the section early-
-  // returns above), so we don't pay the params load on an empty dashboard.
+  // `useProtocolParamsContext` to tell a Bitcoin-confirmation wait apart from
+  // a VP-ingestion wait on the confirming-deposit step — the dashboard doesn't
+  // otherwise mount `ProtocolParamsProvider`, so do it here. Only fires when
+  // there is something pending (the section early-returns above), so we don't
+  // pay the params load on an empty dashboard.
   return (
     <ProtocolParamsProvider>
       <PeginPollingProvider

--- a/services/vault/src/components/simple/ResumeDepositContent.tsx
+++ b/services/vault/src/components/simple/ResumeDepositContent.tsx
@@ -31,6 +31,7 @@ import type { Address, Hex } from "viem";
 import { getVaultRegistryReader } from "@/clients/eth-contract/sdk-readers";
 import { computeDepositDerivedState } from "@/components/deposit/DepositSignModal/depositStepHelpers";
 import { usePayoutSigningState } from "@/components/deposit/PayoutSignModal/usePayoutSigningState";
+import { useDepositPollingResult } from "@/context/deposit/PeginPollingContext";
 import { COPY } from "@/copy";
 import {
   DepositFlowStep,
@@ -42,6 +43,10 @@ import { useBroadcastState } from "@/hooks/deposit/useBroadcastState";
 import { useReleaseVpTokenOnUnmount } from "@/hooks/deposit/useReleaseVpTokenOnUnmount";
 import { useRunOnce } from "@/hooks/useRunOnce";
 import { logger } from "@/infrastructure";
+import {
+  ContractStatus,
+  getPeginDisplayStep,
+} from "@/models/peginStateMachine";
 import type { VaultActivity } from "@/types/activity";
 import {
   shouldProbeWalletLiveness,
@@ -80,10 +85,34 @@ export function ResumeSignContent({
 
   useRunOnce(handleSign);
 
-  const renderStep = isComplete
-    ? DepositFlowStep.AWAIT_VP_VERIFICATION
-    : payoutSigningStep(progress.phase);
-  const renderIsWaiting = isComplete;
+  // Once signing is done the deposit waits on the vault provider. Track the
+  // live contract status so the "Awaiting vault provider verification" wait has
+  // a terminal condition instead of spinning forever (the pending-deposit card
+  // already reflects this state):
+  //  - VERIFIED → advance to "ready to activate" (closeable terminal milestone).
+  //  - ACTIVE   → the vault was activated elsewhere while this modal sat open,
+  //    so the whole flow is already complete; show COMPLETED, not the stale
+  //    "ready to activate" milestone (which would imply an activation step is
+  //    still pending and disagree with the dashboard).
+  const pollingResult = useDepositPollingResult(activity.id);
+  const contractStatus = pollingResult?.peginState?.contractStatus;
+  const verified = contractStatus === ContractStatus.VERIFIED;
+  const active = contractStatus === ContractStatus.ACTIVE;
+  const pastSigning = verified || active;
+  // "Ready to activate" is a VERIFIED-only milestone; once ACTIVE the flow is
+  // already complete and that message would be wrong.
+  const readyToActivate = isComplete && verified;
+
+  const renderStep = !isComplete
+    ? payoutSigningStep(progress.phase)
+    : active
+      ? DepositFlowStep.COMPLETED
+      : verified
+        ? DepositFlowStep.RETRIEVE_SECRET
+        : DepositFlowStep.AWAIT_VP_VERIFICATION;
+  // Only "waiting" while the VP is still verifying; VERIFIED and ACTIVE are both
+  // closeable terminals, not background waits.
+  const renderIsWaiting = isComplete && !pastSigning;
   const derived = computeDepositDerivedState(
     renderStep,
     signing,
@@ -99,6 +128,9 @@ export function ResumeSignContent({
       isProcessing={derived.isProcessing}
       canClose={derived.canClose}
       canContinueInBackground={derived.canContinueInBackground}
+      terminalMessage={
+        readyToActivate ? COPY.deposit.resume.readyToActivateMessage : undefined
+      }
       payoutSigningProgress={signing ? progress : null}
       peginSigningProgress={null}
       onClose={onClose}
@@ -382,15 +414,38 @@ export function ResumeWotsContent({
   // genuinely no provider it fires, so the real "not connected" error surfaces.
   useRunOnce(handleSubmit, !btcWalletProvider || Boolean(connectedBtcAddress));
 
-  const isSuccess = !loading && !error;
-  const renderStep = isSuccess
+  // Reconcile the displayed step with the polled VP status instead of trusting
+  // local `loading`/`error` alone. Without this the modal computes its step
+  // purely from local state, so after the user signs the WOTS submission it
+  // spins forever on SUBMIT_WOTS_KEYS (the local "waiting" has no terminal
+  // condition) — disagreeing with the dashboard's reactive pending card.
+  //
+  // `pastWots` is the polled discriminator: the VP has provably accepted the
+  // WOTS key and advanced once its display step moves past SUBMIT_WOTS_KEYS.
+  // This is safe by construction — the VP can only be past WOTS once the
+  // submission landed — so it never aborts a still-needed submit, and a re-run
+  // `handleSubmit` is a no-op the VP ignores. It also overrides a hung local
+  // submit so the modal never stalls on the WOTS spinner.
+  const pollingResult = useDepositPollingResult(activity.id);
+  const polledPeginState = pollingResult?.peginState;
+  const polledStep = polledPeginState
+    ? getPeginDisplayStep(polledPeginState)
+    : null;
+  const pastWots =
+    polledStep !== null && polledStep > DepositFlowStep.SUBMIT_WOTS_KEYS;
+
+  // Advance off the WOTS step once the local submit resolves OR the polled VP
+  // status confirms acceptance. Then the modal sits on the next step as a
+  // closeable background wait ("Close & continue later"), matching the other
+  // resume waits — no separate success banner needed.
+  const advanced = (!loading && !error) || pastWots;
+  const renderStep = advanced
     ? DepositFlowStep.AWAIT_PAYOUT_TRANSACTIONS
     : DepositFlowStep.SUBMIT_WOTS_KEYS;
-  const renderIsWaiting = isSuccess;
   const derived = computeDepositDerivedState(
     renderStep,
-    loading,
-    renderIsWaiting,
+    loading && !advanced,
+    advanced,
     error,
   );
 
@@ -562,15 +617,29 @@ export function ResumeActivationContent({
   useRunOnce(handleSubmit, !btcWalletProvider || Boolean(connectedBtcAddress));
 
   const error = localError ?? activationError;
-  const renderStep = activated
-    ? DepositFlowStep.AWAIT_ACTIVATION_CONFIRMATION
-    : activating
-      ? DepositFlowStep.ACTIVATE_VAULT
-      : DepositFlowStep.RETRIEVE_SECRET;
+
+  // After broadcasting the activation transaction the deposit waits for the
+  // contract to confirm. Track the live status so "Awaiting vault activation
+  // confirmation" has a terminal condition: once the contract reports ACTIVE we
+  // mark the flow complete instead of spinning forever (the dashboard already
+  // shows the vault as active by then).
+  const pollingResult = useDepositPollingResult(activity.id);
+  const active =
+    pollingResult?.peginState?.contractStatus === ContractStatus.ACTIVE;
+
+  const renderStep = active
+    ? DepositFlowStep.COMPLETED
+    : activated
+      ? DepositFlowStep.AWAIT_ACTIVATION_CONFIRMATION
+      : activating
+        ? DepositFlowStep.ACTIVATE_VAULT
+        : DepositFlowStep.RETRIEVE_SECRET;
+  // Waiting only while the broadcast is in flight or confirmation is pending;
+  // the ACTIVE milestone is a completed terminal, not a background wait.
   const derived = computeDepositDerivedState(
     renderStep,
     activating || loading,
-    activated,
+    activated && !active,
     error,
   );
 

--- a/services/vault/src/components/simple/__tests__/PendingDepositCard.test.tsx
+++ b/services/vault/src/components/simple/__tests__/PendingDepositCard.test.tsx
@@ -242,7 +242,7 @@ describe("PendingDepositCard — payout signing step number", () => {
       peginState: readyToSignPayoutsState(),
     });
     renderCard(false);
-    expect(screen.getByText("Step 10 of 17")).toBeInTheDocument();
+    expect(screen.getByText("Step 9 of 16")).toBeInTheDocument();
     expect(
       screen.getByText(COPY.deposit.steps.authenticateSession),
     ).toBeInTheDocument();

--- a/services/vault/src/components/simple/__tests__/ResumeDepositContent.test.tsx
+++ b/services/vault/src/components/simple/__tests__/ResumeDepositContent.test.tsx
@@ -10,10 +10,13 @@ import { render, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { getVaultRegistryReader } from "@/clients/eth-contract/sdk-readers";
+import { usePayoutSigningState } from "@/components/deposit/PayoutSignModal/usePayoutSigningState";
+import { useActivationState } from "@/hooks/deposit/useActivationState";
 import type { VaultActivity } from "@/types/activity";
 
 import {
   ResumeActivationContent,
+  ResumeSignContent,
   ResumeWotsContent,
 } from "../ResumeDepositContent";
 
@@ -24,6 +27,10 @@ const mockDeriveVaultRoot = vi.hoisted(() => vi.fn());
 const mockParseFundingOutpointsFromTx = vi.hoisted(() => vi.fn(() => []));
 const mockHandleActivation = vi.hoisted(() => vi.fn());
 const mockSubmitWotsPublicKey = vi.hoisted(() => vi.fn());
+const mockUseDepositPollingResult = vi.hoisted(() => vi.fn(() => undefined));
+const mockGetPeginDisplayStep = vi.hoisted(() =>
+  vi.fn<(state: unknown) => number | null>(() => null),
+);
 
 vi.mock("@babylonlabs-io/ts-sdk/tbv/core", () => ({
   computeWotsBlockPublicKeysHash: vi.fn(() => "0xwotshash"),
@@ -64,37 +71,47 @@ vi.mock("@/clients/eth-contract/sdk-readers", () => ({
   getVaultRegistryReader: vi.fn(),
 }));
 
+// Mirror the real derivation of `isProcessing`/`isComplete` from the
+// (processing, isWaiting, error) inputs so the tests genuinely exercise how
+// each Resume* view wires its state into DepositProgressView (a flat stub that
+// always returns isProcessing:false would mask the spinner-vs-terminal split).
 vi.mock("@/components/deposit/DepositSignModal/depositStepHelpers", () => ({
-  computeDepositDerivedState: vi.fn(() => ({
-    isComplete: false,
-    isProcessing: false,
-    canClose: true,
-    canContinueInBackground: false,
-  })),
+  computeDepositDerivedState: vi.fn(
+    (
+      currentStep: number,
+      processing: boolean,
+      isWaiting: boolean,
+      error: string | null,
+    ) => {
+      const isComplete = currentStep === 17; // DepositFlowStep.COMPLETED
+      return {
+        isComplete,
+        isProcessing: (processing || isWaiting) && !error && !isComplete,
+        canClose: true,
+        canContinueInBackground: isWaiting && !error,
+      };
+    },
+  ),
 }));
 
-vi.mock("@/hooks/deposit/depositFlowSteps", () => ({
-  DepositFlowStep: {
-    SIGN_PAYOUTS: "SIGN_PAYOUTS",
-    SIGN_AUTH_ANCHOR: "SIGN_AUTH_ANCHOR",
-    SIGN_DEPOSITOR_GRAPH: "SIGN_DEPOSITOR_GRAPH",
-    BROADCAST_PRE_PEGIN: "BROADCAST_PRE_PEGIN",
-    RETRIEVE_SECRET: "RETRIEVE_SECRET",
-    ACTIVATE_VAULT: "ACTIVATE_VAULT",
-    COMPLETED: "COMPLETED",
-    SUBMIT_WOTS_KEYS: "SUBMIT_WOTS_KEYS",
-    AWAIT_PAYOUT_TRANSACTIONS: "AWAIT_PAYOUT_TRANSACTIONS",
-    AWAIT_VP_VERIFICATION: "AWAIT_VP_VERIFICATION",
-    AWAIT_ACTIVATION_CONFIRMATION: "AWAIT_ACTIVATION_CONFIRMATION",
-    ARTIFACT_DOWNLOAD: "ARTIFACT_DOWNLOAD",
-  },
-  payoutSigningStep: (phase: "auth" | "claimers" | "graph") =>
-    phase === "auth"
-      ? "SIGN_AUTH_ANCHOR"
-      : phase === "graph"
-        ? "SIGN_DEPOSITOR_GRAPH"
-        : "SIGN_PAYOUTS",
-}));
+// Use the real numeric DepositFlowStep enum so ordered comparisons in
+// production (`polledStep > SUBMIT_WOTS_KEYS`) behave as they do at runtime;
+// a string-valued stub would make `9 > 8` compare as `"A" > "S"` and break
+// the pastWots discriminator under test.
+vi.mock("@/hooks/deposit/depositFlowSteps", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/hooks/deposit/depositFlowSteps/types")
+  >("@/hooks/deposit/depositFlowSteps/types");
+  return {
+    DepositFlowStep: actual.DepositFlowStep,
+    payoutSigningStep: (phase: "auth" | "claimers" | "graph") =>
+      phase === "auth"
+        ? actual.DepositFlowStep.SIGN_AUTH_ANCHOR
+        : phase === "graph"
+          ? actual.DepositFlowStep.SIGN_DEPOSITOR_GRAPH
+          : actual.DepositFlowStep.SIGN_PAYOUTS,
+  };
+});
 
 vi.mock("@/components/deposit/PayoutSignModal/usePayoutSigningState", () => ({
   usePayoutSigningState: vi.fn(() => ({
@@ -139,9 +156,48 @@ vi.mock("@/utils/rpc", () => ({
   getVpProxyUrl: vi.fn(() => "https://vp.example"),
 }));
 
+vi.mock("@/context/deposit/PeginPollingContext", () => ({
+  useDepositPollingResult: mockUseDepositPollingResult,
+}));
+
+vi.mock("@/models/peginStateMachine", () => ({
+  ContractStatus: {
+    PENDING: 0,
+    VERIFIED: 1,
+    ACTIVE: 2,
+    REDEEMED: 3,
+    LIQUIDATED: 4,
+    INVALID: 5,
+    DEPOSITOR_WITHDRAWN: 6,
+    EXPIRED: 7,
+  },
+  getPeginDisplayStep: mockGetPeginDisplayStep,
+}));
+
 vi.mock("../DepositProgressView", () => ({
-  DepositProgressView: ({ error }: { error?: string | null }) => (
-    <div data-testid="progress-view">{error ?? ""}</div>
+  DepositProgressView: ({
+    currentStep,
+    error,
+    isComplete,
+    isProcessing,
+    terminalMessage,
+    canContinueInBackground,
+  }: {
+    currentStep?: string;
+    error?: string | null;
+    isComplete?: boolean;
+    isProcessing?: boolean;
+    terminalMessage?: string | null;
+    canContinueInBackground?: boolean;
+  }) => (
+    <div data-testid="progress-view">
+      <span data-testid="step">{String(currentStep)}</span>
+      <span data-testid="error">{error ?? ""}</span>
+      <span data-testid="complete">{String(!!isComplete)}</span>
+      <span data-testid="processing">{String(!!isProcessing)}</span>
+      <span data-testid="terminal">{terminalMessage ?? ""}</span>
+      <span data-testid="background">{String(!!canContinueInBackground)}</span>
+    </div>
   ),
 }));
 
@@ -225,6 +281,93 @@ describe("ResumeWotsContent — Pre-PegIn tx hash trust boundary", () => {
   });
 });
 
+describe("ResumeWotsContent — polled-status terminal", () => {
+  // Real numeric enum values (mirrors DepositFlowStep): SUBMIT_WOTS_KEYS=7,
+  // AWAIT_PAYOUT_TRANSACTIONS=8.
+  const SUBMIT_WOTS_KEYS = 7;
+  const AWAIT_PAYOUT_TRANSACTIONS = 8;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCalculateBtcTxHash.mockReturnValue(ON_CHAIN_HASH);
+    mockGetVaultRegistryReader.mockReturnValue(readerWith(ON_CHAIN_HASH));
+    mockDeriveVaultRoot.mockResolvedValue(new Uint8Array(32));
+    mockSubmitWotsPublicKey.mockResolvedValue(undefined);
+    mockUseDepositPollingResult.mockReturnValue(undefined);
+    mockGetPeginDisplayStep.mockReturnValue(null);
+  });
+
+  function renderWots() {
+    return render(
+      <ResumeWotsContent
+        activity={baseActivity}
+        onClose={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    );
+  }
+
+  it("advances to a closeable background wait once the VP is past WOTS", async () => {
+    // VP has accepted the WOTS key and advanced; the modal moves off the WOTS
+    // step to the next step as a "Close & continue later" background wait —
+    // no separate success banner.
+    mockUseDepositPollingResult.mockReturnValue({
+      peginState: { contractStatus: 0 },
+    } as never);
+    mockGetPeginDisplayStep.mockReturnValue(AWAIT_PAYOUT_TRANSACTIONS);
+
+    const { getByTestId } = renderWots();
+
+    await waitFor(() =>
+      expect(getByTestId("step").textContent).toBe(
+        String(AWAIT_PAYOUT_TRANSACTIONS),
+      ),
+    );
+    // No success banner — the closeable background wait carries the state.
+    expect(getByTestId("terminal").textContent).toBe("");
+    expect(getByTestId("background").textContent).toBe("true");
+    expect(getByTestId("error").textContent).toBe("");
+  });
+
+  it("advances to the closeable background wait after the local submit resolves, before the VP confirms", async () => {
+    mockUseDepositPollingResult.mockReturnValue({
+      peginState: { contractStatus: 0 },
+    } as never);
+    mockGetPeginDisplayStep.mockReturnValue(SUBMIT_WOTS_KEYS);
+
+    const { getByTestId } = renderWots();
+
+    // The submit auto-fires; once it resolves the modal advances to the next
+    // step as a "Close & continue later" background wait with no terminal
+    // banner — even though the polled state has not yet confirmed acceptance.
+    await waitFor(() =>
+      expect(mockSubmitWotsPublicKey).toHaveBeenCalledTimes(1),
+    );
+    await waitFor(() =>
+      expect(getByTestId("step").textContent).toBe(
+        String(AWAIT_PAYOUT_TRANSACTIONS),
+      ),
+    );
+    expect(getByTestId("terminal").textContent).toBe("");
+    expect(getByTestId("background").textContent).toBe("true");
+    expect(getByTestId("processing").textContent).toBe("true");
+  });
+
+  it("shows the in-flight WOTS spinner with no terminal before any polled result", async () => {
+    // No polling result yet (polledStep === null): pastWots must be false and
+    // the in-flight submit shows the SUBMIT_WOTS_KEYS spinner.
+    mockUseDepositPollingResult.mockReturnValue(undefined);
+    // Keep the submit in flight so loading stays true on first render.
+    mockSubmitWotsPublicKey.mockReturnValue(new Promise(() => {}));
+
+    const { getByTestId } = renderWots();
+
+    expect(getByTestId("step").textContent).toBe(String(SUBMIT_WOTS_KEYS));
+    expect(getByTestId("terminal").textContent).toBe("");
+    expect(getByTestId("processing").textContent).toBe("true");
+  });
+});
+
 describe("ResumeActivationContent — Pre-PegIn tx hash trust boundary", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -274,5 +417,118 @@ describe("ResumeActivationContent — Pre-PegIn tx hash trust boundary", () => {
     });
     expect(mockParseFundingOutpointsFromTx).toHaveBeenCalledWith("0xindexertx");
     expect(mockHandleActivation).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("ResumeSignContent — reactive verification terminal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseDepositPollingResult.mockReturnValue(undefined);
+    vi.mocked(usePayoutSigningState).mockReturnValue({
+      signing: false,
+      progress: { phase: "claimers", completed: 0, total: 0 },
+      error: null,
+      isComplete: true,
+      handleSign: vi.fn(),
+    });
+  });
+
+  function renderSign() {
+    return render(
+      <ResumeSignContent
+        activity={baseActivity}
+        btcPublicKey="0xbtcpub"
+        depositorEthAddress={"0xdepositor" as never}
+        onClose={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    );
+  }
+
+  it("stays on the verification wait while the contract is still PENDING", () => {
+    mockUseDepositPollingResult.mockReturnValue({
+      peginState: { contractStatus: 0 },
+    } as never);
+
+    const { getByTestId } = renderSign();
+
+    // AWAIT_VP_VERIFICATION
+    expect(getByTestId("step").textContent).toBe("12");
+    expect(getByTestId("terminal").textContent).toBe("");
+  });
+
+  it("advances to ready-to-activate once the contract is VERIFIED", () => {
+    mockUseDepositPollingResult.mockReturnValue({
+      peginState: { contractStatus: 1 },
+    } as never);
+
+    const { getByTestId } = renderSign();
+
+    // RETRIEVE_SECRET
+    expect(getByTestId("step").textContent).toBe("14");
+    expect(getByTestId("terminal").textContent?.toLowerCase()).toContain(
+      "ready to activate",
+    );
+  });
+
+  it("marks the flow complete if the deposit advances to ACTIVE while parked", () => {
+    mockUseDepositPollingResult.mockReturnValue({
+      peginState: { contractStatus: 2 }, // ACTIVE — already activated elsewhere
+    } as never);
+
+    const { getByTestId } = renderSign();
+
+    // COMPLETED — the whole flow is done, so no stale "ready to activate".
+    expect(getByTestId("step").textContent).toBe("17");
+    expect(getByTestId("terminal").textContent).toBe("");
+  });
+});
+
+describe("ResumeActivationContent — reactive activation terminal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCalculateBtcTxHash.mockReturnValue(ON_CHAIN_HASH);
+    mockGetVaultRegistryReader.mockReturnValue(readerWith(ON_CHAIN_HASH));
+    mockDeriveVaultRoot.mockResolvedValue(new Uint8Array(32));
+    mockUseDepositPollingResult.mockReturnValue(undefined);
+    vi.mocked(useActivationState).mockReturnValue({
+      activating: false,
+      activated: true,
+      error: null,
+      handleActivation: mockHandleActivation,
+    });
+  });
+
+  function renderActivation() {
+    return render(
+      <ResumeActivationContent
+        activity={baseActivity}
+        depositorEthAddress="0xdepositor"
+        onClose={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    );
+  }
+
+  it("keeps awaiting confirmation after broadcast until the contract is ACTIVE", async () => {
+    mockUseDepositPollingResult.mockReturnValue({
+      peginState: { contractStatus: 1 }, // VERIFIED — broadcast landed, not yet ACTIVE
+    } as never);
+
+    const { getByTestId } = renderActivation();
+
+    // AWAIT_ACTIVATION_CONFIRMATION
+    await waitFor(() => expect(getByTestId("step").textContent).toBe("16"));
+  });
+
+  it("completes once the contract reports ACTIVE", async () => {
+    mockUseDepositPollingResult.mockReturnValue({
+      peginState: { contractStatus: 2 }, // ACTIVE
+    } as never);
+
+    const { getByTestId } = renderActivation();
+
+    // COMPLETED
+    await waitFor(() => expect(getByTestId("step").textContent).toBe("17"));
   });
 });

--- a/services/vault/src/context/deposit/__tests__/PeginPollingContext.test.tsx
+++ b/services/vault/src/context/deposit/__tests__/PeginPollingContext.test.tsx
@@ -3,6 +3,7 @@ import type { PropsWithChildren } from "react";
 import type { Hex } from "viem";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { COPY } from "../../../copy";
 import {
   ContractStatus,
   LocalStorageStatus,
@@ -378,7 +379,9 @@ describe("PeginPollingContext", () => {
     // That path only fires if the confirmations lookup matched —
     // i.e., the consumer keyed by `prePeginTxHash`.
     const polling = result.current.getPollingResult(VAULT_ID);
-    expect(polling?.peginState.awaitingVpIngestion).toBe(true);
+    expect(polling?.peginState.message).toBe(
+      COPY.pegin.messages.prePeginIngesting,
+    );
   });
 
   it("stops polling a Pre-PegIn txid once it has been observed at required depth", async () => {
@@ -504,9 +507,8 @@ describe("PeginPollingContext", () => {
     // (driven by `prePeginBroadcastConfirmed`) without any mempool hit.
     await waitFor(() => {
       expect(
-        result.current.getPollingResult(VAULT_ID)?.peginState
-          .awaitingVpIngestion,
-      ).toBe(true);
+        result.current.getPollingResult(VAULT_ID)?.peginState.message,
+      ).toBe(COPY.pegin.messages.prePeginIngesting);
     });
   });
 

--- a/services/vault/src/context/deposit/computeDepositPollingResult.ts
+++ b/services/vault/src/context/deposit/computeDepositPollingResult.ts
@@ -120,6 +120,12 @@ export function computeDepositPollingResult(
   const prePeginBroadcastConfirmed =
     cachedAtDepth ||
     (confirmations !== undefined && confirmations >= requiredDepth);
+  // Chain ground truth that the Pre-PegIn was broadcast at all: a present
+  // confirmation entry — or a cached at-depth observation — means the tx is on
+  // the network. Independent of localStorage, so every tab converges on the
+  // same status instead of re-offering "Broadcast" in a tab that lacks the
+  // local CONFIRMING marker. Self-heals: an evicted/dropped tx drops the entry.
+  const prePeginBroadcastSeen = cachedAtDepth || confirmations !== undefined;
 
   const isOwnedByCurrentWallet = isVaultOwnedByWallet(
     activity.depositorBtcPubkey,
@@ -162,6 +168,7 @@ export function computeDepositPollingResult(
     needsWotsKey: needsWotsKey?.has(depositId),
     pendingIngestion: pendingIngestion?.has(depositId),
     prePeginBroadcastConfirmed,
+    prePeginBroadcastSeen,
     expirationReason: activity.expirationReason,
     expiredAt: activity.expiredAt,
     canRefund,

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -70,7 +70,7 @@ export const COPY = {
       payoutsReadyForSigning:
         "Vault provider has prepared payout transactions. Click 'Sign Payouts' to pre-authorize your Bitcoin claim transactions.",
       prePeginBroadcast:
-        "Pre-Pegin transaction has been broadcast. Waiting for vault provider to detect your deposit.",
+        "Pre-Pegin transaction has been broadcast. Waiting for Bitcoin confirmation.",
       prePeginIngesting:
         "Pre-Pegin transaction confirmed. Waiting for vault provider to ingest your deposit.",
       waitingForDetection: "Waiting for vault provider to detect your deposit.",
@@ -142,9 +142,8 @@ export const COPY = {
       signLinkProofs: "Sign proofs to link your Bitcoin and ETH addresses",
       signAndBroadcastEth: "Sign and broadcast ETH registration",
       signAndBroadcastPrePegin: "Sign and broadcast BTC Pre-Pegin transaction",
-      awaitBtcConfirmation: "Awaiting Bitcoin confirmation",
-      awaitVpIngestion: "Awaiting vault provider ingestion",
-      submitWotsKey: "Submit Winternitz One-Time Signature (WOTS)",
+      confirmingDeposit: "Confirming deposit",
+      submitWotsKey: "Set up Winternitz One-Time Signature (WOTS)",
       awaitPayoutTransactions:
         "Awaiting vault provider to prepare payout transactions",
       authenticateSession: "Authenticate session with vault provider",
@@ -307,6 +306,8 @@ export const COPY = {
     resume: {
       broadcastSuccessMessage: PRE_PEGIN_BROADCAST_CONFIRMATION_MESSAGE,
       activationSuccessMessage: "Your BTC Vault has been activated.",
+      readyToActivateMessage:
+        "Your payout transactions are signed and verified. Your BTC Vault is ready to activate.",
       wotsMismatchError:
         "WOTS public key hash does not match the on-chain commitment — the wrong wallet is connected.",
     },

--- a/services/vault/src/hooks/deposit/depositFlowSteps/types.ts
+++ b/services/vault/src/hooks/deposit/depositFlowSteps/types.ts
@@ -30,55 +30,45 @@ export enum DepositFlowStep {
   /** Step 5: Sign and broadcast Pre-PegIn transaction to Bitcoin */
   BROADCAST_PRE_PEGIN = 5,
   /**
-   * Step 6: Awaiting Bitcoin confirmation of the Pre-PegIn tx (mempool-driven).
-   * Distinct from {@link AWAIT_VP_INGESTION}: this is the depositor's wait for
-   * BTC to reach the protocol-mandated `minPrepeginDepth`; once that is
-   * reached but the VP daemon is still at `PendingIngestion`, the stepper
-   * advances to `AWAIT_VP_INGESTION` so the BTC and VP-side waits are not
-   * conflated.
+   * Step 6: Confirming the deposit. The Pre-PegIn tx is broadcast and we are
+   * waiting for it to reach the protocol-mandated `minPrepeginDepth` AND for
+   * the VP daemon to ingest it. Covers both the BTC-confirmation wait and the
+   * (rarer) "BTC confirmed but VP still at `PendingIngestion`" wait — the two
+   * are distinguished by the status message, not by a separate step.
    */
   AWAIT_BTC_CONFIRMATION = 6,
+  /** Step 7: Submit WOTS public key to the Vault Provider. */
+  SUBMIT_WOTS_KEYS = 7,
+  /** Step 8: Wait for the Vault Provider to prepare payout transactions. */
+  AWAIT_PAYOUT_TRANSACTIONS = 8,
   /**
-   * Step 7: BTC depth reached, VP still ingesting (PendingIngestion).
-   * `PendingIngestion` covers the VP processing the ETH event + AML + BTC
-   * validation; the VP can only transition out once the Pre-PegIn has ≥1
-   * confirmation AND its validations pass. With BTC at safe depth, sitting
-   * here means the VP is still working (or stuck) — distinct from a BTC
-   * depth wait, and a useful diagnostic for stuck-deposit support.
-   */
-  AWAIT_VP_INGESTION = 7,
-  /** Step 8: Submit WOTS public key to the Vault Provider. */
-  SUBMIT_WOTS_KEYS = 8,
-  /** Step 9: Wait for the Vault Provider to prepare payout transactions. */
-  AWAIT_PAYOUT_TRANSACTIONS = 9,
-  /**
-   * Step 10: `deriveContextHash` for the VP auth anchor during payout
+   * Step 9: `deriveContextHash` for the VP auth anchor during payout
    * signing. Fires whenever the per-pegin VP-token cache misses inside
    * `signAndSubmitPayouts`. (Cache misses inside `submitWotsPublicKey`
    * still surface a wallet popup, but the stepper stays on
    * SUBMIT_WOTS_KEYS for that path.) The wallet popup is identical to
    * step 1 but binds a different context (auth anchor vs. vault root).
    */
-  SIGN_AUTH_ANCHOR = 10,
-  /** Step 11: Sign the VP/VK claimer payout transactions in BTC wallet */
-  SIGN_PAYOUTS = 11,
+  SIGN_AUTH_ANCHOR = 9,
+  /** Step 10: Sign the VP/VK claimer payout transactions in BTC wallet */
+  SIGN_PAYOUTS = 10,
   /**
-   * Step 12: Sign the depositor's own graph — 1 Payout + N per-challenger
+   * Step 11: Sign the depositor's own graph — 1 Payout + N per-challenger
    * NoPayout transactions — in BTC wallet (the second payout-signing round).
    */
-  SIGN_DEPOSITOR_GRAPH = 12,
-  /** Step 13: Wait for VP verification and ACK submission. */
-  AWAIT_VP_VERIFICATION = 13,
-  /** Step 14: Download vault artifacts */
-  ARTIFACT_DOWNLOAD = 14,
-  /** Step 15: Derive the HTLC secret from the BTC wallet, ahead of activation. */
-  RETRIEVE_SECRET = 15,
-  /** Step 16: Reveal HTLC secret on Ethereum to activate the vault */
-  ACTIVATE_VAULT = 16,
-  /** Step 17: Wait for activation confirmation / indexer catch-up. */
-  AWAIT_ACTIVATION_CONFIRMATION = 17,
-  /** Step 18: Deposit completed */
-  COMPLETED = 18,
+  SIGN_DEPOSITOR_GRAPH = 11,
+  /** Step 12: Wait for VP verification and ACK submission. */
+  AWAIT_VP_VERIFICATION = 12,
+  /** Step 13: Download vault artifacts */
+  ARTIFACT_DOWNLOAD = 13,
+  /** Step 14: Derive the HTLC secret from the BTC wallet, ahead of activation. */
+  RETRIEVE_SECRET = 14,
+  /** Step 15: Reveal HTLC secret on Ethereum to activate the vault */
+  ACTIVATE_VAULT = 15,
+  /** Step 16: Wait for activation confirmation / indexer catch-up. */
+  AWAIT_ACTIVATION_CONFIRMATION = 16,
+  /** Step 17: Deposit completed */
+  COMPLETED = 17,
 }
 
 // ============================================================================

--- a/services/vault/src/hooks/deposit/usePrePeginMempoolConfirmations.ts
+++ b/services/vault/src/hooks/deposit/usePrePeginMempoolConfirmations.ts
@@ -5,8 +5,9 @@
  * (`CONFIRMING`), which can't tell BTC-wait from VP-stuck: localStorage stays
  * `CONFIRMING` whether the VP is still ingesting or BTC is still confirming.
  * Polling the mempool directly per pending Pre-PegIn txid resolves that
- * ambiguity for the state machine, which routes the deposit to either
- * `AWAIT_BTC_CONFIRMATION` or `AWAIT_VP_INGESTION` based on the result.
+ * ambiguity for the state machine, which surfaces either the Bitcoin-
+ * confirmation or the VP-ingestion status on the shared confirming-deposit
+ * step based on the result.
  *
  * Returns raw confirmation counts (not pre-thresholded). Per-deposit depth
  * is applied at the consumer because each vault is locked to its own

--- a/services/vault/src/models/__tests__/peginStateMachine.test.ts
+++ b/services/vault/src/models/__tests__/peginStateMachine.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
+import { COPY } from "@/copy";
 import { DepositFlowStep } from "@/hooks/deposit/depositFlowSteps/types";
 
 import {
@@ -44,7 +45,7 @@ describe("peginStateMachine", () => {
       );
     });
 
-    it("flags VP-ingestion wait when BTC is confirmed but VP still ingesting", () => {
+    it("shows the VP-ingestion message at the confirming-deposit step when BTC is confirmed but VP still ingesting", () => {
       const state = getPeginState(ContractStatus.PENDING, {
         localStatus: LocalStorageStatus.CONFIRMING,
         pendingIngestion: true,
@@ -53,17 +54,89 @@ describe("peginStateMachine", () => {
       expect(state.displayLabel).toBe(PEGIN_DISPLAY_LABELS.PENDING);
       expect(state.availableActions).toEqual([PeginAction.NONE]);
       expect(state.message).toContain("Waiting for vault provider to ingest");
-      expect(state.awaitingVpIngestion).toBe(true);
+      expect(getPeginDisplayStep(state)).toBe(
+        DepositFlowStep.AWAIT_BTC_CONFIRMATION,
+      );
     });
 
-    it("does NOT flag VP-ingestion wait when VP has already ingested", () => {
+    it("drops the broadcast action and surfaces VP ingestion when BTC is confirmed at depth with no local tracking", () => {
+      // Cross-window / cleared-storage case: no localStatus CONFIRMING marker
+      // survives, so the SDK still offers SIGN_AND_BROADCAST. But the chain
+      // proves the Pre-PegIn is confirmed at protocol depth, so there is
+      // nothing left to broadcast — the deposit is waiting on the VP, not BTC.
+      const state = getPeginState(ContractStatus.PENDING, {
+        pendingIngestion: true,
+        prePeginBroadcastConfirmed: true,
+      });
+      expect(state.availableActions).not.toContain(
+        PeginAction.SIGN_AND_BROADCAST_TO_BITCOIN,
+      );
+      expect(state.message).toBe(COPY.pegin.messages.prePeginIngesting);
+      expect(getPeginDisplayStep(state)).toBe(
+        DepositFlowStep.AWAIT_BTC_CONFIRMATION,
+      );
+    });
+
+    it("keeps the broadcast action and shows 'not detected' when prePeginBroadcastConfirmed is not set", () => {
+      // Counter to the chain-truth override: with no chain confirmation signal
+      // the legit "broadcast may have failed" prompt must still appear.
+      const state = getPeginState(ContractStatus.PENDING, {
+        pendingIngestion: true,
+      });
+      expect(state.availableActions).toContain(
+        PeginAction.SIGN_AND_BROADCAST_TO_BITCOIN,
+      );
+      expect(state.message).toBe(COPY.pegin.messages.broadcastMayHaveFailed);
+      expect(getPeginDisplayStep(state)).toBe(
+        DepositFlowStep.BROADCAST_PRE_PEGIN,
+      );
+    });
+
+    it("drops the broadcast action and shows the BTC-confirmation wait when the Pre-PegIn is seen on chain but shallow, with no local tracking", () => {
+      // Cross-tab case (Image #11): the broadcasting tab wrote CONFIRMING; this
+      // tab has no local marker, so the SDK still offers SIGN_AND_BROADCAST.
+      // The chain proves the tx is already on the network, so every tab must
+      // agree it is broadcast and waiting on Bitcoin depth — not re-offer it.
+      const state = getPeginState(ContractStatus.PENDING, {
+        pendingIngestion: true,
+        prePeginBroadcastSeen: true,
+      });
+      expect(state.availableActions).not.toContain(
+        PeginAction.SIGN_AND_BROADCAST_TO_BITCOIN,
+      );
+      expect(state.message).toBe(COPY.pegin.messages.prePeginBroadcast);
+      expect(getPeginDisplayStep(state)).toBe(
+        DepositFlowStep.AWAIT_BTC_CONFIRMATION,
+      );
+    });
+
+    it("shows the VP-ingestion message (not the BTC-confirmation message) at step 6 when seen and confirmed at depth", () => {
+      const state = getPeginState(ContractStatus.PENDING, {
+        pendingIngestion: true,
+        prePeginBroadcastSeen: true,
+        prePeginBroadcastConfirmed: true,
+      });
+      expect(state.availableActions).not.toContain(
+        PeginAction.SIGN_AND_BROADCAST_TO_BITCOIN,
+      );
+      expect(state.message).toBe(COPY.pegin.messages.prePeginIngesting);
+      expect(getPeginDisplayStep(state)).toBe(
+        DepositFlowStep.AWAIT_BTC_CONFIRMATION,
+      );
+    });
+
+    it("does NOT show the VP-ingestion wait when VP has already ingested", () => {
       const state = getPeginState(ContractStatus.PENDING, {
         localStatus: LocalStorageStatus.CONFIRMING,
         pendingIngestion: false,
         prePeginBroadcastConfirmed: true,
       });
-      // BTC confirmed AND ingested → falls through to payout-prep branch.
-      expect(state.awaitingVpIngestion).toBeUndefined();
+      // BTC confirmed AND ingested → falls through to the payout-prep branch,
+      // not the VP-ingestion message.
+      expect(state.message).not.toBe(COPY.pegin.messages.prePeginIngesting);
+      expect(getPeginDisplayStep(state)).toBe(
+        DepositFlowStep.AWAIT_PAYOUT_TRANSACTIONS,
+      );
     });
 
     it("shows preparing transactions when CONFIRMING and VP has ingested", () => {
@@ -637,21 +710,26 @@ describe("peginStateMachine", () => {
       expect(getPeginDisplayStep(state)).toBe(
         DepositFlowStep.AWAIT_BTC_CONFIRMATION,
       );
+      // Step and message must agree: at AWAIT_BTC_CONFIRMATION the wait is on
+      // Bitcoin depth, so the message is the BTC-confirmation copy — not the
+      // "vault provider to detect/ingest" wording, which belongs to step 7.
+      expect(state.message).toBe(COPY.pegin.messages.prePeginBroadcast);
     });
 
-    it("maps BTC-confirmed-but-VP-still-ingesting to AWAIT_VP_INGESTION", () => {
+    it("maps BTC-confirmed-but-VP-still-ingesting to the confirming-deposit step", () => {
       // The diagnostic case: localStorage says CONFIRMING (broadcast happened)
       // and mempool reports the Pre-PegIn has reached the protocol depth, but
-      // the VP is still at PendingIngestion — surface the VP-side wait, not
-      // the BTC-side wait, so a stuck VP doesn't masquerade as a BTC delay.
+      // the VP is still at PendingIngestion. The step stays on the shared
+      // "confirming deposit" step; the VP-side wait is surfaced via the message.
       const state = getPeginState(ContractStatus.PENDING, {
         localStatus: LocalStorageStatus.CONFIRMING,
         pendingIngestion: true,
         prePeginBroadcastConfirmed: true,
       });
       expect(state.availableActions).toEqual([PeginAction.NONE]);
+      expect(state.message).toBe(COPY.pegin.messages.prePeginIngesting);
       expect(getPeginDisplayStep(state)).toBe(
-        DepositFlowStep.AWAIT_VP_INGESTION,
+        DepositFlowStep.AWAIT_BTC_CONFIRMATION,
       );
     });
 

--- a/services/vault/src/models/peginStateMachine.ts
+++ b/services/vault/src/models/peginStateMachine.ts
@@ -100,13 +100,6 @@ export interface PeginState {
   availableActions: PeginAction[];
   message?: string;
   awaitingPayoutPrep?: boolean;
-  /**
-   * Pre-PegIn BTC confirmations have reached the protocol-mandated depth,
-   * but the VP is still at `PendingIngestion`. Lets the stepper pin the
-   * deposit on `AWAIT_VP_INGESTION` so a stuck VP doesn't masquerade as a
-   * BTC-confirmation wait.
-   */
-  awaitingVpIngestion?: boolean;
   refundMaturityState?: RefundMaturityState;
   /** Blocks remaining until refund matures; set only when `maturing`. */
   refundMaturesInBlocks?: number;
@@ -132,6 +125,15 @@ export interface GetPeginStateOptions {
    * if we rely on localStorage `CONFIRMING` alone.
    */
   prePeginBroadcastConfirmed?: boolean;
+  /**
+   * True when the Pre-PegIn BTC tx is present on the network at all (in the
+   * mempool or a block — chain ground truth, independent of localStorage and
+   * of confirmation depth). Once seen, the broadcast action is moot in EVERY
+   * tab/device, so the dashboard stops re-offering "Broadcast" in a tab that
+   * happens to lack the local `CONFIRMING` marker. A superset of
+   * `prePeginBroadcastConfirmed` (confirmed ⇒ seen).
+   */
+  prePeginBroadcastSeen?: boolean;
   expirationReason?: ExpirationReason;
   expiredAt?: number;
   /**
@@ -278,7 +280,22 @@ export function getPeginState(
     options.refundBroadcastAt,
     options.now,
   );
-  const actions = mapActions(sdkActions);
+  // Chain ground truth overrides the localStorage-gated broadcast action:
+  // once the Pre-PegIn is on the network at all (seen in mempool/chain) there
+  // is nothing left to broadcast, so we drop the action in EVERY tab/device —
+  // not just the one holding the local CONFIRMING marker. A confirmed-at-depth
+  // deposit then surfaces as "ingesting" and a seen-but-shallow one as
+  // "awaiting Bitcoin confirmation", instead of a phantom "broadcast may have
+  // failed" prompt. (`prePeginBroadcastConfirmed ⊆ prePeginBroadcastSeen`; both
+  // are checked so a caller that sets only the former still suppresses.)
+  const chainAdjustedActions =
+    options.prePeginBroadcastSeen === true ||
+    options.prePeginBroadcastConfirmed === true
+      ? sdkActions.filter(
+          (a) => a !== SdkPeginAction.SIGN_AND_BROADCAST_TO_BITCOIN,
+        )
+      : sdkActions;
+  const actions = mapActions(chainAdjustedActions);
   const display = getDisplay(contractStatus, actions, options);
 
   return {
@@ -377,7 +394,6 @@ interface DisplayInfo {
   displayVariant: "pending" | "active" | "inactive" | "warning";
   message?: string;
   awaitingPayoutPrep?: boolean;
-  awaitingVpIngestion?: boolean;
   refundMaturityState?: RefundMaturityState;
   refundMaturesInBlocks?: number;
   inlineSubtext?: string;
@@ -437,8 +453,9 @@ function getDisplay(
       };
     }
     // BTC confirmed at protocol depth (mempool ground truth), VP still
-    // ingesting. Distinct from "broadcast but not yet confirmed" — surfaces
-    // a stuck VP plainly instead of falsely blaming the BTC wait.
+    // ingesting. Distinct from "broadcast but not yet confirmed" — the message
+    // surfaces a stuck VP plainly instead of falsely blaming the BTC wait,
+    // while the stepper stays on the shared "confirming deposit" step.
     if (
       options.pendingIngestion === true &&
       options.prePeginBroadcastConfirmed === true
@@ -447,12 +464,16 @@ function getDisplay(
         displayLabel: PEGIN_DISPLAY_LABELS.PENDING,
         displayVariant: "pending",
         message: COPY.pegin.messages.prePeginIngesting,
-        awaitingVpIngestion: true,
       };
     }
+    // Broadcast happened (chain says the tx is on the network, or the local
+    // CONFIRMING marker says so) but it is not yet confirmed at depth — a
+    // Bitcoin-confirmation wait. Keyed on `prePeginBroadcastSeen` too so every
+    // tab shows this, not just the one that broadcast.
     if (
       options.pendingIngestion === true &&
-      localStatus === LocalStorageStatus.CONFIRMING
+      (options.prePeginBroadcastSeen === true ||
+        localStatus === LocalStorageStatus.CONFIRMING)
     ) {
       return {
         displayLabel: PEGIN_DISPLAY_LABELS.PENDING,
@@ -688,17 +709,14 @@ export function getPeginDisplayStep(state: PeginState): DepositFlowStep | null {
     // No action pending. Once payouts are signed the deposit is waiting for VP
     // verification/ACK submission. If the VP has ingested the deposit but
     // payout transactions are not ready, it is preparing the signing package.
-    // If BTC depth is met but VP still says PendingIngestion, the wait is
-    // VP-side, not BTC-side. Otherwise it is still waiting for Pre-PegIn
-    // confirmation/detection.
+    // Otherwise it is still confirming the Pre-PegIn — whether waiting on BTC
+    // depth or on a VP still at PendingIngestion, both share the "confirming
+    // deposit" step and are told apart by the status message.
     if (localStatus === LocalStorageStatus.PAYOUT_SIGNED) {
       return DepositFlowStep.AWAIT_VP_VERIFICATION;
     }
     if (state.awaitingPayoutPrep) {
       return DepositFlowStep.AWAIT_PAYOUT_TRANSACTIONS;
-    }
-    if (state.awaitingVpIngestion) {
-      return DepositFlowStep.AWAIT_VP_INGESTION;
     }
     return DepositFlowStep.AWAIT_BTC_CONFIRMATION;
   }


### PR DESCRIPTION
Reconcile the deposit-flow stepper and pending-deposit cards with the actual polled status so the displayed step, status badge, and available action never disagree.

- Suppress the phantom "Broadcast Pre-Pegin" prompt once the Pre-PegIn transaction is seen/confirmed on the Bitcoin network, so the broadcast prompt stays consistent across tabs (chain ground truth overrides the stale SDK action set).
- Reconcile the WOTS resume modal with the polled vault-provider status: it advances off the WOTS step on a hung or duplicate submit instead of spinning forever, resolving to a closeable "Close & continue later" wait.
- Collapse the vault-provider ingestion wait into the shared "Confirming deposit" step, distinguished by status message rather than a separate rung.
- Surface a "Ready to activate" terminal milestone in the payout-signing resume flow once the vault provider posts verification on-chain.
- Align the confirming-deposit copy with Bitcoin confirmation and relabel the WOTS step to "Set up Winternitz One-Time Signature (WOTS)".