### PR TITLE
fix(vault): btc vault activation sentence

### DIFF
--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -301,8 +301,7 @@ export const COPY = {
     },
     resume: {
       broadcastSuccessMessage: PRE_PEGIN_BROADCAST_CONFIRMATION_MESSAGE,
-      activationSuccessMessage:
-        "Your BTC Vault has been activated. The vault provider can now claim the HTLC on Bitcoin.",
+      activationSuccessMessage: "Your BTC Vault has been activated.",
       wotsMismatchError:
         "WOTS public key hash does not match the on-chain commitment — the wrong wallet is connected.",
     },


### PR DESCRIPTION
<img width="1056" height="164" alt="image" src="https://github.com/user-attachments/assets/d11f56ef-b251-467d-a789-443c2bb54917" />

Removes the 2nd sentence in btc vault activation message
