### PR TITLE
fix(vault): deposit slider unfundable amount + supply-cap label

### DIFF
--- a/packages/babylon-core-ui/src/widgets/sections/AmountSlider/AmountSlider.tsx
+++ b/packages/babylon-core-ui/src/widgets/sections/AmountSlider/AmountSlider.tsx
@@ -53,6 +53,13 @@ export interface AmountSliderProps {
   sliderVariant?: "primary" | "success" | "warning" | "error" | "rainbow";
   sliderActiveColor?: string;
   sliderBackgroundColor?: string;
+  /**
+   * Disables only the range slider, leaving the amount input and Max button
+   * usable. Use when the slider has no meaningful range yet (e.g. the max is
+   * still loading) but manual entry should remain available. Combined with the
+   * general `disabled` prop, which disables the whole widget.
+   */
+  sliderDisabled?: boolean;
 
   // Bottom fields
   leftField?: BottomField;
@@ -81,6 +88,7 @@ export function AmountSlider({
   sliderVariant = "primary",
   sliderActiveColor,
   sliderBackgroundColor,
+  sliderDisabled = false,
   leftField,
   rightField,
   onMaxClick,
@@ -175,7 +183,7 @@ export function AmountSlider({
           onStepsChange={onSliderStepsChange}
           variant={sliderVariant}
           activeColor={sliderActiveColor}
-          disabled={disabled}
+          disabled={disabled || sliderDisabled}
         />
       </div>
 

--- a/services/vault/src/components/simple/DepositForm.tsx
+++ b/services/vault/src/components/simple/DepositForm.tsx
@@ -181,21 +181,27 @@ export function DepositForm({
     (panel: "split" | "provider") => (expanded: boolean) =>
       setOpenPanel(expanded ? panel : null);
   // The depositable max is unknown until the fee estimate, UTXOs, and the
-  // on-chain supply cap resolve. Until then the slider is disabled (mirroring
-  // the `--` Max label below) — never falling back to the raw balance, which
-  // would let the user select an amount above the real cap that then strands
-  // above the max once it resolves.
+  // on-chain supply cap resolve. Until then we never fall back to the raw
+  // balance, which would let the user select an amount above the real cap that
+  // then strands above the max once it resolves.
   const isMaxResolved = maxDepositSats != null;
   const maxDepositLabel = !isMaxResolved
     ? `-- ${btcConfig.coinSymbol}`
     : `${Number(depositService.formatSatoshisToBtc(maxDepositSats))} ${btcConfig.coinSymbol}`;
 
+  // Disable only the slider (not the amount input or Max button) while there's
+  // no meaningful range to drag: the max is still loading, or it resolved to
+  // zero (supply cap reached). Manual entry stays available, and any amount
+  // above the max is clamped down once it resolves.
+  const sliderDisabled = !isMaxResolved || maxDepositSats === 0n;
+
   // The slider operates in satoshis (integer values, 1-sat step) so the thumb
   // can land exactly on the max. A coarse BTC step would leave the sat-precise
-  // max off the step grid, stranding the thumb short of the end. While the max
-  // is loading the slider is disabled, so the `1` floor only keeps the Slider's
-  // fill/step math divisor non-zero.
-  const sliderMaxSats = isMaxResolved ? Number(maxDepositSats) : 1;
+  // max off the step grid, stranding the thumb short of the end. Floor the
+  // rendered max to 1 so the Slider's `(value - min) / (max - min)` fill math
+  // never divides by zero — a loading (null) or cap-reached (0) max would
+  // otherwise produce NaN. The slider is disabled in both those states anyway.
+  const sliderMaxSats = Math.max(1, Number(maxDepositSats ?? 0n));
   const sliderValueSats = Number(amountSats);
 
   const usdValue = useMemo(() => {
@@ -264,7 +270,7 @@ export function DepositForm({
           sliderMax={sliderMaxSats}
           sliderStep={1}
           sliderSteps={[]}
-          disabled={!isMaxResolved}
+          sliderDisabled={sliderDisabled}
           onSliderChange={(sats) =>
             onAmountChange(
               depositService.formatSatoshisToBtc(BigInt(Math.round(sats))),

--- a/services/vault/src/components/simple/DepositForm.tsx
+++ b/services/vault/src/components/simple/DepositForm.tsx
@@ -180,21 +180,22 @@ export function DepositForm({
   const setPanelExpanded =
     (panel: "split" | "provider") => (expanded: boolean) =>
       setOpenPanel(expanded ? panel : null);
-  // Fee-adjusted depositable max in satoshis. Falls back to the raw balance
-  // while the fee estimate is still loading.
-  const maxDepositSatsOrBalance = maxDepositSats ?? btcBalance;
-  // While the fee estimate is loading, the fallback to the raw balance would
-  // briefly show more than is actually depositable. Show a placeholder instead
-  // so the displayed Max never overstates the cap.
-  const maxDepositLabel =
-    maxDepositSats == null
-      ? `-- ${btcConfig.coinSymbol}`
-      : `${Number(depositService.formatSatoshisToBtc(maxDepositSats))} ${btcConfig.coinSymbol}`;
+  // The depositable max is unknown until the fee estimate, UTXOs, and the
+  // on-chain supply cap resolve. Until then the slider is disabled (mirroring
+  // the `--` Max label below) — never falling back to the raw balance, which
+  // would let the user select an amount above the real cap that then strands
+  // above the max once it resolves.
+  const isMaxResolved = maxDepositSats != null;
+  const maxDepositLabel = !isMaxResolved
+    ? `-- ${btcConfig.coinSymbol}`
+    : `${Number(depositService.formatSatoshisToBtc(maxDepositSats))} ${btcConfig.coinSymbol}`;
 
   // The slider operates in satoshis (integer values, 1-sat step) so the thumb
   // can land exactly on the max. A coarse BTC step would leave the sat-precise
-  // max off the step grid, stranding the thumb short of the end.
-  const sliderMaxSats = Number(maxDepositSatsOrBalance) || 1;
+  // max off the step grid, stranding the thumb short of the end. While the max
+  // is loading the slider is disabled, so the `1` floor only keeps the Slider's
+  // fill/step math divisor non-zero.
+  const sliderMaxSats = isMaxResolved ? Number(maxDepositSats) : 1;
   const sliderValueSats = Number(amountSats);
 
   const usdValue = useMemo(() => {
@@ -263,6 +264,7 @@ export function DepositForm({
           sliderMax={sliderMaxSats}
           sliderStep={1}
           sliderSteps={[]}
+          disabled={!isMaxResolved}
           onSliderChange={(sats) =>
             onAmountChange(
               depositService.formatSatoshisToBtc(BigInt(Math.round(sats))),

--- a/services/vault/src/hooks/deposit/__tests__/useDepositValidation.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useDepositValidation.test.tsx
@@ -125,6 +125,30 @@ describe("useDepositValidation", () => {
 
       expect(result.current.minDeposit).toBeGreaterThan(0n);
     });
+
+    it("returns the 'capacity below minimum' error when remaining cap is below the minimum deposit", () => {
+      // Remaining cap (5_000) is below the 10_000 minimum, so no amount can pass
+      // both bounds. This must win over the base minimum error so the message
+      // matches the CTA instead of telling the user to raise an amount they
+      // can never raise high enough.
+      const { result } = renderHook(
+        () =>
+          useDepositValidation({
+            availableProviders: mockProviders,
+            effectiveRemaining: 5_000n,
+          }),
+        {
+          wrapper,
+        },
+      );
+
+      const validationResult = result.current.validateAmount("0.0001");
+
+      expect(validationResult.valid).toBe(false);
+      expect(validationResult.error).toBe(
+        "Remaining capacity (0.00005 BTC) is below the minimum deposit (0.0001 BTC)",
+      );
+    });
   });
 
   describe("validateProviders", () => {

--- a/services/vault/src/hooks/deposit/useDepositPageForm.ts
+++ b/services/vault/src/hooks/deposit/useDepositPageForm.ts
@@ -498,6 +498,25 @@ export function useDepositPageForm(): UseDepositPageFormResult {
     );
   }, [isMaxPinned, adjustedMaxDepositSats]);
 
+  // When the depositable max resolves or shrinks (cap loads late, UTXO split
+  // auto-enables a second vault's reserve, fees resolve), clamp any amount left
+  // above it down to the max. A value selected against a higher, stale max — a
+  // slider thumb dragged before the real cap loaded — would otherwise strand
+  // above it and read "Insufficient balance". Keyed only on the max so it never
+  // fires mid-typing: a typed over-max amount keeps its validation message.
+  useEffect(() => {
+    if (adjustedMaxDepositSats == null) return;
+    setFormDataInternal((prev) => {
+      if (!prev.amountBtc) return prev;
+      const prevSats = depositService.parseBtcToSatoshis(prev.amountBtc);
+      if (prevSats <= adjustedMaxDepositSats) return prev;
+      return {
+        ...prev,
+        amountBtc: depositService.formatSatoshisToBtc(adjustedMaxDepositSats),
+      };
+    });
+  }, [adjustedMaxDepositSats]);
+
   const validateForm = useCallback(() => {
     const newErrors: typeof errors = {};
 

--- a/services/vault/src/hooks/deposit/useDepositValidation.ts
+++ b/services/vault/src/hooks/deposit/useDepositValidation.ts
@@ -63,6 +63,20 @@ export function useDepositValidation(
 
       const satoshis = depositService.parseBtcToSatoshis(amount);
 
+      // When the remaining cap is below the protocol minimum, no amount is
+      // valid. Surface that terminal reason before the base min/max check so it
+      // matches the CTA (`getDepositCtaState`) instead of showing a minimum
+      // error the user can never satisfy.
+      if (depositService.capBelowMinimum(effectiveRemaining, minDeposit)) {
+        return {
+          valid: false,
+          error: depositService.capBelowMinimumLabel(
+            effectiveRemaining,
+            minDeposit,
+          ),
+        };
+      }
+
       const base = depositService.validateDepositAmount(
         satoshis,
         minDeposit,

--- a/services/vault/src/services/deposit/__tests__/validations.test.ts
+++ b/services/vault/src/services/deposit/__tests__/validations.test.ts
@@ -563,6 +563,37 @@ describe("Deposit Validations", () => {
       expect(result).toEqual({ disabled: false, label: "Deposit" });
     });
 
+    it("shows the cap message, not 'Insufficient balance', when the supply cap is the binding max", () => {
+      // The supply cap is the limiter: maxDepositSats is clamped to
+      // effectiveRemaining, so an over-cap amount also exceeds maxDepositSats.
+      // The wallet has ample balance, so "Insufficient balance" would be wrong.
+      const result = getDepositCtaState({
+        ...readyParams,
+        amountSats: 800_000n,
+        maxDepositSats: 500_000n,
+        effectiveRemaining: 500_000n,
+      });
+      expect(result).toEqual({
+        disabled: true,
+        label: "Vault size exceeds remaining capacity (0.005 BTC)",
+      });
+    });
+
+    it("shows 'Insufficient balance' when the fee-adjusted max (not the cap) is the limiter", () => {
+      // maxDepositSats is below effectiveRemaining, so the limit is balance/fees
+      // rather than the supply cap — "Insufficient balance" is the right label.
+      const result = getDepositCtaState({
+        ...readyParams,
+        amountSats: 100_001n,
+        maxDepositSats: 100_000n,
+        effectiveRemaining: 500_000n,
+      });
+      expect(result).toEqual({
+        disabled: true,
+        label: "Insufficient balance",
+      });
+    });
+
     it("prioritizes amount label over ordinals-pending", () => {
       const result = getDepositCtaState({
         ...readyParams,

--- a/services/vault/src/services/deposit/__tests__/validations.test.ts
+++ b/services/vault/src/services/deposit/__tests__/validations.test.ts
@@ -650,6 +650,51 @@ describe("Deposit Validations", () => {
       expect(result).toEqual({ disabled: false, label: "Deposit" });
     });
 
+    it("shows the 'capacity below minimum' terminal message when remaining cap < minimum deposit", () => {
+      // cap 0.003 < min 0.005: no amount can clear both bounds. The amount here
+      // (above the cap) would otherwise read "Vault size exceeds remaining
+      // capacity", which is misleading — lowering it just hits the minimum.
+      const result = getDepositCtaState({
+        ...readyParams,
+        minDeposit: 500_000n,
+        effectiveRemaining: 300_000n,
+        amountSats: 400_000n,
+      });
+      expect(result).toEqual({
+        disabled: true,
+        label:
+          "Remaining capacity (0.003 BTC) is below the minimum deposit (0.005 BTC)",
+      });
+    });
+
+    it("shows 'capacity below minimum' regardless of the entered amount (terminal state)", () => {
+      // Same cap < min state, but with no amount entered: still terminal, so it
+      // takes precedence over "Enter an amount".
+      const result = getDepositCtaState({
+        ...readyParams,
+        minDeposit: 500_000n,
+        effectiveRemaining: 300_000n,
+        amountSats: 0n,
+      });
+      expect(result.label).toBe(
+        "Remaining capacity (0.003 BTC) is below the minimum deposit (0.005 BTC)",
+      );
+    });
+
+    it("shows 'Supply cap reached' for an empty form when the cap is fully used (pre-existing precedence)", () => {
+      // Documents that effectiveRemaining === 0n wins over "Enter an amount"
+      // for a zero amount — behavior unchanged by the cap/label reorder.
+      const result = getDepositCtaState({
+        ...readyParams,
+        amountSats: 0n,
+        effectiveRemaining: 0n,
+      });
+      expect(result).toEqual({
+        disabled: true,
+        label: "Supply cap reached — deposits temporarily paused",
+      });
+    });
+
     it("disables with 'Calculating fees...' when minPeginFee is still loading", () => {
       const result = getDepositCtaState({
         ...readyParams,

--- a/services/vault/src/services/deposit/validations.ts
+++ b/services/vault/src/services/deposit/validations.ts
@@ -172,6 +172,32 @@ export function amountExceedsMax(
   );
 }
 
+/**
+ * True when the remaining supply cap is positive but below the protocol minimum
+ * deposit. In that state the cap (upper bound) and the minimum (lower bound)
+ * leave an empty range — no amount can satisfy both — so deposits are
+ * impossible until the cap grows. Surfacing this directly avoids contradictory
+ * guidance where the cap check says "lower it" and the minimum check says
+ * "raise it". Narrows `effectiveRemaining` to a non-null bigint when true.
+ */
+export function capBelowMinimum(
+  effectiveRemaining: bigint | null,
+  minDeposit: bigint,
+): effectiveRemaining is bigint {
+  return (
+    effectiveRemaining !== null &&
+    effectiveRemaining > 0n &&
+    effectiveRemaining < minDeposit
+  );
+}
+
+export function capBelowMinimumLabel(
+  effectiveRemaining: bigint,
+  minDeposit: bigint,
+): string {
+  return `Remaining capacity (${formatSatoshisToBtc(effectiveRemaining)} BTC) is below the minimum deposit (${formatSatoshisToBtc(minDeposit)} BTC)`;
+}
+
 export function getDepositButtonLabel(
   params: DepositFormValidityParams,
 ): string {
@@ -250,6 +276,16 @@ export function getDepositCtaState(params: DepositCtaParams): DepositCtaState {
     return {
       disabled: true,
       label: "Supply cap reached — deposits temporarily paused",
+    };
+  }
+  // No amount can clear both the remaining cap and the protocol minimum — a
+  // terminal state, so surface it regardless of the entered amount rather than
+  // bouncing between "exceeds capacity" and "minimum" guidance. Mirrored in
+  // `useDepositValidation.validateAmount` so the inline/submit path agrees.
+  if (capBelowMinimum(params.effectiveRemaining, params.minDeposit)) {
+    return {
+      disabled: true,
+      label: capBelowMinimumLabel(params.effectiveRemaining, params.minDeposit),
     };
   }
   if (

--- a/services/vault/src/services/deposit/validations.ts
+++ b/services/vault/src/services/deposit/validations.ts
@@ -239,16 +239,13 @@ export function getDepositCtaState(params: DepositCtaParams): DepositCtaState {
     };
   }
 
-  // An amount that exceeds the fee-adjusted depositable balance can never be
-  // funded — surface it before the provider prompt, since selecting a provider
-  // cannot make an unfundable amount fundable.
-  if (amountExceedsMax(params.amountSats, params.maxDepositSats)) {
-    return { disabled: true, label: "Insufficient balance" };
-  }
-
   // Mirror `validateRemainingCapacity` from the SDK. The message strings must
   // match exactly so users see the same wording whether the block surfaces via
-  // the CTA or via a future inline error.
+  // the CTA or via a future inline error. These run before the generic
+  // `amountExceedsMax` check below: `maxDepositSats` is itself clamped to the
+  // supply cap, so a cap-bound amount also trips `amountExceedsMax` — and
+  // "Insufficient balance" would be wrong when the wallet has ample balance but
+  // the supply cap is the real limiter.
   if (params.effectiveRemaining === 0n) {
     return {
       disabled: true,
@@ -263,6 +260,13 @@ export function getDepositCtaState(params: DepositCtaParams): DepositCtaState {
       disabled: true,
       label: `Vault size exceeds remaining capacity (${formatSatoshisToBtc(params.effectiveRemaining)} BTC)`,
     };
+  }
+
+  // An amount that exceeds the fee-adjusted depositable balance can never be
+  // funded — surface it before the provider prompt, since selecting a provider
+  // cannot make an unfundable amount fundable.
+  if (amountExceedsMax(params.amountSats, params.maxDepositSats)) {
+    return { disabled: true, label: "Insufficient balance" };
   }
 
   if (!params.hasProvider) {


### PR DESCRIPTION
## Summary

Two related deposit-form bugs:

1. **The slider let you pick an amount the button then rejected with "Insufficient balance."** You could drag the slider to the very end, but the deposit button stayed disabled saying "Insufficient balance."
2. **"Insufficient balance" was the wrong message.** When the real limit was the protocol's supply cap (not your wallet), the form still said "Insufficient balance" — confusing for a user who has plenty of BTC in their wallet.

This PR fixes both: the slider can no longer select an unfundable amount, any amount left above the real maximum is snapped back down to it, and an over-cap amount now shows the accurate cap message.

## Why this happened (in simple words)

The deposit "Max" is not just your wallet balance. It's your balance **minus** network fee, minus protocol reserves, and **capped** by how much the application still allows you to deposit (the supply cap). Computing that real Max takes a moment — it needs the fee rate, your UTXOs, and an on-chain read of the supply cap.

While that Max was still loading, the slider quietly **fell back to your full wallet balance** as its upper bound. So you could drag all the way to your balance. A fraction of a second later the real Max finished loading at a much lower number — but the amount you had already dragged to was **left where it was**, now sitting above the real Max. The button correctly refused it, but the slider had let you get there in the first place.

On top of that, the real Max is itself capped to the supply cap, so an over-cap amount tripped the generic "amount exceeds max → Insufficient balance" check before it ever reached the more accurate "exceeds remaining capacity" check.

## What changed

Three small changes:

1. **Slider is bound to the real Max, and disabled while that Max is loading.** [services/vault/src/components/simple/DepositForm.tsx](services/vault/src/components/simple/DepositForm.tsx) — no more falling back to the raw wallet balance. While the Max is still loading, the slider is disabled (matching the `--` we already show for the Max label), so you can't drag to an amount that can't be funded.

2. **If the Max drops below your current amount, the amount is snapped down to the Max.** [services/vault/src/hooks/deposit/useDepositPageForm.ts](services/vault/src/hooks/deposit/useDepositPageForm.ts) — a small effect watches the resolved Max. When it resolves or shrinks (cap loads late, or the UTXO split auto-enables a second vault's reserve) and your amount is now above it, the amount is clamped down to the Max. It is keyed only on the Max — **not** on what you type — so typing a too-large amount still shows a validation message instead of silently changing your input.

3. **Show the accurate message when the supply cap is the limit.** [services/vault/src/services/deposit/validations.ts](services/vault/src/services/deposit/validations.ts) — the supply-cap checks now run *before* the generic "Insufficient balance" check. So an over-cap amount reads **"Vault size exceeds remaining capacity (X BTC)"**, while a genuine balance/fee shortfall still reads "Insufficient balance." This only changes the *label*; the button is disabled in both cases either way.

## Approaches we considered, and why we picked this one

- **A) Just clamp the amount down when the Max resolves (no slider change).** This alone fixes the stranded value, but it still lets the slider briefly show a misleading range (you'd drag to 7 BTC, then watch it jump down to 0.369). Correct, but jarring.

- **B) Just disable/limit the slider while the Max loads (no clamp).** This stops the most obvious case (slider falling back to balance during initial load), but it does **not** cover the case where the Max first resolves high and then *shrinks* a moment later when the supply cap finishes loading (or when the UTXO split turns on). A value picked in that short window would still be left stranded.

- **C) Do both (chosen).** Disabling the slider until the Max is known removes the misleading range up front, and the clamp is the safety net that handles any later shrink. Together they make it impossible to end up with an amount above the real Max, from any path.

For the label, the alternative was to reword "Insufficient balance" to be generic. We instead reused the **existing** "Vault size exceeds remaining capacity" message that was already in the code but unreachable, by simply reordering the checks — no new copy, minimal change.

We deliberately keyed the clamp on the Max only (not on the typed amount) so we never silently overwrite what a user is actively typing — typed-too-high still surfaces a clear message.

## Testing

- Added two unit tests in [services/vault/src/services/deposit/__tests__/validations.test.ts](services/vault/src/services/deposit/__tests__/validations.test.ts) that lock the label precedence: cap-bound amount → "Vault size exceeds remaining capacity", balance-limited amount → "Insufficient balance".
- Verified live with a temporary debug gate that simulates the supply cap loading late: dragged the slider to ~14 sBTC, and when the real Max resolved (0.369 sBTC) the amount was clamped back down to 0.369 and the button stayed valid — instead of stranding at 14 with "Insufficient balance." (All debug scaffolding was removed before this PR.)

## How a reviewer can verify manually

1. Connect a wallet whose balance is well above the supply cap.
2. Open Deposit and immediately try the slider while the Max still shows `--` → the slider is disabled until the Max resolves.
3. Type an amount above the remaining cap → button reads "Vault size exceeds remaining capacity (… BTC)", not "Insufficient balance."

## Automated review (AI) findings

Three findings were raised in automated review. Here's each, what we did, and why:

**Finding 3 — "Amount entry gets disabled" (valid → fixed).** Passing the shared `AmountSlider`'s `disabled` prop disabled the text input and the Max button too, not just the range slider — so while the Max was still loading the user couldn't type a deposit amount manually. We added a `sliderDisabled` prop to `AmountSlider` that gates only the inner range slider, and `DepositForm` now passes `sliderDisabled` instead of the global `disabled`. The amount input and Max button stay usable during loading; typed values are still validated and clamped to the resolved Max. While here we also floored the rendered slider max to `1`, so a resolved-zero Max (supply cap fully reached) can no longer produce a `0/0 = NaN` fill in the slider track.

**Finding 1 — "Minimum error gets masked" (valid → fixed).** When the remaining supply cap is below the protocol minimum deposit, no amount can satisfy both bounds at once. The CTA (capacity check) said "exceeds remaining capacity" (→ lower it) while the inline/submit validation (minimum check) said "Minimum X" (→ raise it) — contradictory and unwinnable. We added a shared `capBelowMinimum` check used by **both** the CTA (`getDepositCtaState`) and the inline/submit path (`validateAmount`), surfacing a single terminal message: "Remaining capacity (X BTC) is below the minimum deposit (Y BTC)". This contradiction was partly pre-existing (before this PR the same input just showed "Insufficient balance"), but since the PR is about correct cap/max messaging we closed it here rather than deferring.

**Finding 2 — "Empty amount is masked" (not a regression → no code change, documented).** The concern was that an empty form now shows "Supply cap reached" instead of "Enter an amount" when the cap is fully used. This precedence is pre-existing: the `effectiveRemaining === 0n` branch already ran before the "Enter an amount" label, and `amountExceedsMax` returns `false` for a zero amount, so the reorder in this PR did not change the zero-amount path at all. We added a test documenting the behavior. Showing "Supply cap reached" while deposits are paused is also arguably more useful than "Enter an amount".

These fixes touch one shared component (`AmountSlider` in `core-ui`) plus `DepositForm`, `validations.ts`, and `useDepositValidation.ts`, with added unit tests in `validations.test.ts` and `useDepositValidation.test.tsx`.
