### PR TITLE
feat(vault): show nominated BTC address on pending withdraw cards

### DIFF
--- a/services/vault/src/applications/aave/hooks/useAaveVaults.ts
+++ b/services/vault/src/applications/aave/hooks/useAaveVaults.ts
@@ -6,18 +6,20 @@
  * vaults available for collateral (not currently in use or pending).
  */
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { Address } from "viem";
 
 import { useVaultProviders } from "@/hooks/deposit/useVaultProviders";
 import { usePrice } from "@/hooks/usePrices";
 import { useVaults } from "@/hooks/useVaults";
+import { logger } from "@/infrastructure";
 import {
   ContractStatus,
   getPeginState,
   PEGIN_DISPLAY_LABELS,
 } from "@/models/peginStateMachine";
 import type { Vault, VaultProvider } from "@/types";
+import { scriptPubKeyHexToBtcAddress } from "@/utils/btc";
 import { satoshiToBtcNumber } from "@/utils/btcConversion";
 import { formatProviderDisplayName } from "@/utils/formatting";
 
@@ -65,6 +67,10 @@ export interface RedeemedVaultInfo {
   vaultProviderAddress: string;
   /** Timestamp in milliseconds when vault was created */
   createdAt: number;
+  /** Decoded BTC address the pegout will land at (from on-chain
+   *  `depositorPayoutBtcAddress` scriptPubKey). Undefined when the scriptPubKey
+   *  fails to decode — surfaced as "row omitted" rather than blocking the section. */
+  payoutBtcAddress?: string;
 }
 
 export interface UseAaveVaultsResult {
@@ -117,9 +123,16 @@ export function useAaveVaults(
     return vaults.filter((vault) => vault.status === ContractStatus.ACTIVE);
   }, [vaults]);
 
+  // Dedupes Sentry events when a malformed `depositorPayoutBtcAddress` would
+  // otherwise be re-logged on every polling tick or re-render. Keyed by
+  // `${vaultId}:${scriptPubKey}` so a backend fix that changes the scriptPubKey
+  // does get re-logged if it still fails. Cleared on hook unmount (page nav).
+  const loggedDecodeFailuresRef = useRef<Set<string>>(new Set());
+
   // Vaults with "redeemed" status — withdrawal initiated, VP is processing BTC payout
   const redeemedVaults: RedeemedVaultInfo[] = useMemo(() => {
     if (!vaults) return [];
+    const loggedKeys = loggedDecodeFailuresRef.current;
     return vaults
       .filter((vault) => vault.status === ContractStatus.REDEEMED)
       .map((vault) => {
@@ -128,6 +141,27 @@ export function useAaveVaults(
           provider?.name,
           vault.vaultProvider,
         );
+        let payoutBtcAddress: string | undefined;
+        try {
+          payoutBtcAddress = scriptPubKeyHexToBtcAddress(
+            vault.depositorPayoutBtcAddress,
+          );
+        } catch (error) {
+          const decodeKey = `${vault.id}:${vault.depositorPayoutBtcAddress}`;
+          if (!loggedKeys.has(decodeKey)) {
+            loggedKeys.add(decodeKey);
+            logger.error(
+              error instanceof Error ? error : new Error(String(error)),
+              {
+                data: {
+                  context:
+                    "Decode payout scriptPubKey for pending withdraw card",
+                  vaultId: vault.id,
+                },
+              },
+            );
+          }
+        }
         return {
           id: vault.id,
           peginTxHash: vault.peginTxHash,
@@ -136,6 +170,7 @@ export function useAaveVaults(
           providerIconUrl: provider?.iconUrl,
           vaultProviderAddress: vault.vaultProvider,
           createdAt: vault.createdAt,
+          payoutBtcAddress,
         };
       });
   }, [vaults, findProvider]);

--- a/services/vault/src/components/shared/CopyableHash.tsx
+++ b/services/vault/src/components/shared/CopyableHash.tsx
@@ -24,6 +24,9 @@ interface CopyableHashProps {
   explorerUrl?: string;
   /** When true, render a small BTC/ETH tag in front of the hash (useful in mixed-chain lists). */
   showChainBadge?: boolean;
+  /** Whether the value is a transaction hash (default) or an address. Affects
+   *  the copy button's aria-label so screen readers announce the correct kind. */
+  kind?: "tx" | "address";
 }
 
 function formatForChain(hash: string, chain: HashChain): string {
@@ -35,11 +38,12 @@ export function CopyableHash({
   chain,
   explorerUrl,
   showChainBadge = false,
+  kind = "tx",
 }: CopyableHashProps) {
   const { isCopied, copyToClipboard } = useCopy();
   const displayHash = formatForChain(hash, chain);
   const truncated = truncateHash(displayHash);
-  const copyLabel = `Copy ${chain} transaction hash ${truncated}`;
+  const copyLabel = `Copy ${chain} ${kind === "address" ? "address" : "transaction hash"} ${truncated}`;
 
   return (
     <span className="flex items-center gap-1.5 font-mono text-sm">

--- a/services/vault/src/components/simple/PendingWithdrawSection.tsx
+++ b/services/vault/src/components/simple/PendingWithdrawSection.tsx
@@ -96,6 +96,7 @@ export function PendingWithdrawSection({
                   providerName={vault.providerName}
                   providerIconUrl={vault.providerIconUrl}
                   providerAddress={vault.vaultProviderAddress}
+                  payoutBtcAddress={vault.payoutBtcAddress}
                   statusContent={
                     <VaultStatusBadge
                       dotColor={STATUS_DOT_COLORS[variant]}

--- a/services/vault/src/components/simple/VaultDetailCard.tsx
+++ b/services/vault/src/components/simple/VaultDetailCard.tsx
@@ -11,7 +11,10 @@ import { useEffect, useState, type ReactNode } from "react";
 import { CopyableHash } from "@/components/shared/CopyableHash";
 import { getNetworkConfigBTC } from "@/config";
 import { truncateAddress } from "@/utils/addressUtils";
-import { getBtcExplorerTxUrl } from "@/utils/explorer";
+import {
+  getBtcExplorerAddressUrl,
+  getBtcExplorerTxUrl,
+} from "@/utils/explorer";
 import {
   formatBtcAmount,
   formatDateTime,
@@ -71,6 +74,11 @@ interface VaultDetailCardProps {
   disabled?: boolean;
   /** Tooltip shown when hovering a `disabled` card. */
   disabledTooltip?: string;
+  /** Decoded BTC address the pegout will land at. Rendered as the
+   *  "Nominated Address" row when present. This is the address registered
+   *  on-chain at vault creation, which may differ from the currently
+   *  connected BTC wallet. */
+  payoutBtcAddress?: string;
 }
 
 export function VaultDetailCard({
@@ -87,6 +95,7 @@ export function VaultDetailCard({
   action,
   disabled,
   disabledTooltip,
+  payoutBtcAddress,
 }: VaultDetailCardProps) {
   const relativeTime = useRelativeTime(timestamp);
 
@@ -158,6 +167,19 @@ export function VaultDetailCard({
             hash={txHash}
             chain="BTC"
             explorerUrl={getBtcExplorerTxUrl(txHash)}
+          />
+        </VaultCardRow>
+      )}
+
+      {/* Nominated Address — destination registered at vault creation.
+          May differ from the currently connected BTC wallet. */}
+      {payoutBtcAddress && (
+        <VaultCardRow label="Nominated Address">
+          <CopyableHash
+            hash={payoutBtcAddress}
+            chain="BTC"
+            kind="address"
+            explorerUrl={getBtcExplorerAddressUrl(payoutBtcAddress)}
           />
         </VaultCardRow>
       )}

--- a/services/vault/src/utils/explorer.ts
+++ b/services/vault/src/utils/explorer.ts
@@ -18,6 +18,11 @@ export function getBtcExplorerTxUrl(txHash: string): string {
   return `${btcConfig.mempoolApiUrl}/tx/${stripHexPrefix(txHash)}`;
 }
 
+export function getBtcExplorerAddressUrl(address: string): string {
+  const btcConfig = getNetworkConfigBTC();
+  return `${btcConfig.mempoolApiUrl}/address/${address}`;
+}
+
 function getEthExplorerTxUrl(txHash: string): string {
   const { explorerUrl } = getNetworkConfigETH();
   return `${explorerUrl}/tx/${txHash}`;


### PR DESCRIPTION
Pending withdraw cards now display the BTC address the pegout will land at —
the address registered on-chain at vault creation, which may differ from the
currently connected BTC wallet. Decoded from `depositorPayoutBtcAddress` via
the existing `scriptPubKeyHexToBtcAddress` helper; copyable with a mempool
link. Decode failures log once per (vaultId, scriptPubKey) and omit the row
rather than block the section.

<img width="768" height="205" alt="image" src="https://github.com/user-attachments/assets/3ce2c5c8-8ed0-4825-8277-5109c82a3943" />
