### PR TITLE
feat(vault): pending utxos message + tooltip

### DIFF
--- a/services/vault/src/components/simple/DepositForm.tsx
+++ b/services/vault/src/components/simple/DepositForm.tsx
@@ -313,9 +313,15 @@ export function DepositForm({
             // `effectiveRemaining` is null both when no cap applies and while
             // the cap read is loading; either way we omit the cap clause
             // until we know it's a real constraint.
-            tooltip: COPY.deposit.form.maxTooltip({
-              hasSupplyCap: effectiveRemaining !== null,
-            }),
+            //
+            // Drop the Max tooltip while the pending-confirmation note is shown
+            // so the row carries a single info icon (the pending one) rather
+            // than two competing tooltips.
+            tooltip: hasUnconfirmedBalanceOnly
+              ? undefined
+              : COPY.deposit.form.maxTooltip({
+                  hasSupplyCap: effectiveRemaining !== null,
+                }),
           }}
           rightField={{
             value: !hasAmount

--- a/services/vault/src/components/simple/DepositForm.tsx
+++ b/services/vault/src/components/simple/DepositForm.tsx
@@ -317,7 +317,11 @@ export function DepositForm({
               hasSupplyCap: effectiveRemaining !== null,
             }),
           }}
-          rightField={{ value: pendingConfirmationField ?? usdValue }}
+          rightField={{
+            value: !hasAmount
+              ? (pendingConfirmationField ?? usdValue)
+              : usdValue,
+          }}
           onMaxClick={onMaxClick}
           inputClassName="h-10 w-auto rounded-lg bg-primary-contrast px-4 [field-sizing:content]"
         />

--- a/services/vault/src/components/simple/DepositForm.tsx
+++ b/services/vault/src/components/simple/DepositForm.tsx
@@ -1,4 +1,4 @@
-import { AmountSlider, Card } from "@babylonlabs-io/core-ui";
+import { AmountSlider, Card, Hint, InfoIcon } from "@babylonlabs-io/core-ui";
 import { useMemo, useState } from "react";
 
 import { ApplicationLogo } from "@/components/ApplicationLogo";
@@ -34,6 +34,14 @@ interface DepositFormProps {
   amount: string;
   amountSats: bigint;
   btcBalance: bigint;
+  /** Total value of unconfirmed (in-mempool) UTXOs in satoshis. Display-only. */
+  unconfirmedBalance: bigint;
+  /**
+   * True when the confirmed balance is zero but unconfirmed funds exist. Shows
+   * an inline "pending confirmation" notice so the user understands why the
+   * form reads zero while their wallet shows a balance.
+   */
+  hasUnconfirmedBalanceOnly: boolean;
   minDeposit: bigint;
   maxDeposit?: bigint;
   /**
@@ -137,6 +145,8 @@ export function DepositForm({
   amount,
   amountSats,
   btcBalance,
+  unconfirmedBalance,
+  hasUnconfirmedBalanceOnly,
   minDeposit,
   maxDeposit,
   maxDepositSats,
@@ -214,6 +224,25 @@ export function DepositForm({
     })} USD`;
   }, [amount, btcPrice, hasPriceFetchError]);
 
+  // When the confirmed balance reads zero but unconfirmed funds exist, show a
+  // "pending confirmation" note in the slider's right slot (where the USD value
+  // would sit — empty at a zero balance). The InfoIcon is wrapped with an
+  // attach-to-children Hint so the markup stays inline-valid inside the slider's
+  // right cell (a bare Hint would nest a div inside a span).
+  const pendingConfirmationField = hasUnconfirmedBalanceOnly ? (
+    <span className="inline-flex items-center gap-1 text-accent-secondary">
+      {COPY.deposit.form.pendingConfirmationNotice(
+        `${Number(depositService.formatSatoshisToBtc(unconfirmedBalance))} ${btcConfig.coinSymbol}`,
+      )}
+      <Hint
+        tooltip={COPY.deposit.form.pendingConfirmationTooltip}
+        attachToChildren
+      >
+        <InfoIcon size={16} className="text-secondary-strokeDark" />
+      </Hint>
+    </span>
+  ) : null;
+
   const selectedApp = applications.find((a) => a.id === selectedApplication);
 
   const hasAmount = !!amount && amount !== "0";
@@ -288,7 +317,7 @@ export function DepositForm({
               hasSupplyCap: effectiveRemaining !== null,
             }),
           }}
-          rightField={{ value: usdValue }}
+          rightField={{ value: pendingConfirmationField ?? usdValue }}
           onMaxClick={onMaxClick}
           inputClassName="h-10 w-auto rounded-lg bg-primary-contrast px-4 [field-sizing:content]"
         />

--- a/services/vault/src/components/simple/SimpleDeposit.tsx
+++ b/services/vault/src/components/simple/SimpleDeposit.tsx
@@ -120,6 +120,8 @@ function SimpleDepositContent({
     effectiveSelectedApplication,
     isWalletConnected,
     btcBalance,
+    unconfirmedBalance,
+    hasUnconfirmedBalanceOnly,
     btcPrice,
     hasPriceFetchError,
     applications,
@@ -332,6 +334,8 @@ function SimpleDepositContent({
                 amount={formData.amountBtc}
                 amountSats={amountSats}
                 btcBalance={btcBalance}
+                unconfirmedBalance={unconfirmedBalance}
+                hasUnconfirmedBalanceOnly={hasUnconfirmedBalanceOnly}
                 minDeposit={minDeposit}
                 maxDeposit={maxDeposit}
                 maxDepositSats={maxDepositSats}

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -275,7 +275,7 @@ export const COPY = {
       pendingConfirmationNotice: (amount: string) =>
         `${amount} pending confirmation`,
       pendingConfirmationTooltip:
-        "Only balances confirmed in a Bitcoin block are shown here. Your pending amount will appear once its transaction confirms.",
+        "Only balances confirmed in a Bitcoin block are shown here. This amount is still waiting to confirm.",
       doNotSplit: "Do not split UTXO",
       selectVaultProvider: "Select Vault Provider",
       providerSelectDescription: "Choose a provider to secure your BTC",

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -272,6 +272,10 @@ export const COPY = {
         opts.hasSupplyCap
           ? "Reserves a fee buffer, excludes inscription UTXOs, and stays within the supply cap."
           : "Reserves a fee buffer and excludes inscription UTXOs.",
+      pendingConfirmationNotice: (amount: string) =>
+        `${amount} pending confirmation`,
+      pendingConfirmationTooltip:
+        "Only balances confirmed in a Bitcoin block are shown here. Your pending amount will appear once its transaction confirms.",
       doNotSplit: "Do not split UTXO",
       selectVaultProvider: "Select Vault Provider",
       providerSelectDescription: "Choose a provider to secure your BTC",

--- a/services/vault/src/hooks/__tests__/useUTXOs.test.ts
+++ b/services/vault/src/hooks/__tests__/useUTXOs.test.ts
@@ -207,5 +207,56 @@ describe("useUTXOs", () => {
         true,
       );
     });
+
+    it("should sum unconfirmed UTXO values in unconfirmedBalance", () => {
+      const mixedUtxos: MempoolUTXO[] = [
+        createMempoolUtxo("confirmed1", 0, 100000, true),
+        createMempoolUtxo("unconfirmed1", 0, 200000, false),
+        createMempoolUtxo("unconfirmed2", 1, 50000, false),
+      ];
+
+      mockUseQuery.mockReturnValue({
+        data: mixedUtxos,
+        isLoading: false,
+        error: null,
+        refetch: vi.fn(),
+      });
+
+      mockUseOrdinals.mockReturnValue({
+        inscriptions: [],
+        isLoading: false,
+        error: null,
+        refetch: vi.fn(),
+      });
+
+      const { result } = renderHook(() => useUTXOs(testAddress));
+
+      expect(result.current.unconfirmedBalance).toBe(250000n);
+    });
+
+    it("should report zero unconfirmedBalance when all UTXOs are confirmed", () => {
+      const confirmedOnly: MempoolUTXO[] = [
+        createMempoolUtxo("confirmed1", 0, 100000, true),
+        createMempoolUtxo("confirmed2", 1, 300000, true),
+      ];
+
+      mockUseQuery.mockReturnValue({
+        data: confirmedOnly,
+        isLoading: false,
+        error: null,
+        refetch: vi.fn(),
+      });
+
+      mockUseOrdinals.mockReturnValue({
+        inscriptions: [],
+        isLoading: false,
+        error: null,
+        refetch: vi.fn(),
+      });
+
+      const { result } = renderHook(() => useUTXOs(testAddress));
+
+      expect(result.current.unconfirmedBalance).toBe(0n);
+    });
   });
 });

--- a/services/vault/src/hooks/__tests__/useUTXOs.test.ts
+++ b/services/vault/src/hooks/__tests__/useUTXOs.test.ts
@@ -232,6 +232,7 @@ describe("useUTXOs", () => {
       const { result } = renderHook(() => useUTXOs(testAddress));
 
       expect(result.current.unconfirmedBalance).toBe(250000n);
+      expect(result.current.confirmedBalance).toBe(100000n);
     });
 
     it("should report zero unconfirmedBalance when all UTXOs are confirmed", () => {
@@ -257,6 +258,33 @@ describe("useUTXOs", () => {
       const { result } = renderHook(() => useUTXOs(testAddress));
 
       expect(result.current.unconfirmedBalance).toBe(0n);
+      expect(result.current.confirmedBalance).toBe(400000n);
+    });
+
+    it("should report zero confirmedBalance when all UTXOs are unconfirmed", () => {
+      const unconfirmedOnly: MempoolUTXO[] = [
+        createMempoolUtxo("unconfirmed1", 0, 200000, false),
+        createMempoolUtxo("unconfirmed2", 1, 50000, false),
+      ];
+
+      mockUseQuery.mockReturnValue({
+        data: unconfirmedOnly,
+        isLoading: false,
+        error: null,
+        refetch: vi.fn(),
+      });
+
+      mockUseOrdinals.mockReturnValue({
+        inscriptions: [],
+        isLoading: false,
+        error: null,
+        refetch: vi.fn(),
+      });
+
+      const { result } = renderHook(() => useUTXOs(testAddress));
+
+      expect(result.current.confirmedBalance).toBe(0n);
+      expect(result.current.unconfirmedBalance).toBe(250000n);
     });
   });
 });

--- a/services/vault/src/hooks/deposit/__tests__/useDepositPageForm.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useDepositPageForm.test.tsx
@@ -70,6 +70,7 @@ vi.mock("../../../applications/aave/context", () => ({
 }));
 
 import { useApplications } from "../../useApplications";
+import { useUTXOs } from "../../useUTXOs";
 import { useDepositPageForm } from "../useDepositPageForm";
 import { useEstimatedBtcFee } from "../useEstimatedBtcFee";
 
@@ -192,6 +193,7 @@ vi.mock("../../useUTXOs", () => ({
         confirmed: true,
       },
     ],
+    unconfirmedBalance: 0n,
     isLoading: false,
     isLoadingOrdinals: false,
     error: null,
@@ -437,6 +439,33 @@ describe("useDepositPageForm", () => {
       isStale: false,
       promise: Promise.resolve([]),
     } as unknown as ReturnType<typeof useApplications>);
+    // Reset UTXO mock to the default funded address (800000 sats confirmed, no
+    // unconfirmed) so per-test overrides for the unconfirmed-balance cases
+    // don't leak — clearAllMocks keeps mockReturnValue overrides in place.
+    vi.mocked(useUTXOs).mockReturnValue({
+      availableUTXOs: [
+        { txid: "0x123", vout: 0, value: 500000, scriptPubKey: "0xabc" },
+        { txid: "0x456", vout: 1, value: 300000, scriptPubKey: "0xdef" },
+      ],
+      spendableMempoolUTXOs: [
+        {
+          txid: "0x123",
+          vout: 0,
+          value: 500000,
+          scriptPubKey: "0xabc",
+          confirmed: true,
+        },
+        {
+          txid: "0x456",
+          vout: 1,
+          value: 300000,
+          scriptPubKey: "0xdef",
+          confirmed: true,
+        },
+      ],
+      ordinalsCheckPending: false,
+      unconfirmedBalance: 0n,
+    } as unknown as ReturnType<typeof useUTXOs>);
   });
 
   const wrapper = ({ children }: { children: ReactNode }) => {
@@ -472,6 +501,37 @@ describe("useDepositPageForm", () => {
       const { result } = renderHook(() => useDepositPageForm(), { wrapper });
 
       expect(result.current.btcBalanceFormatted).toBe(0.008);
+    });
+
+    it("flags hasUnconfirmedBalanceOnly when confirmed balance is zero but unconfirmed funds exist", () => {
+      vi.mocked(useUTXOs).mockReturnValue({
+        availableUTXOs: [],
+        spendableMempoolUTXOs: [],
+        ordinalsCheckPending: false,
+        unconfirmedBalance: 50000n,
+      } as unknown as ReturnType<typeof useUTXOs>);
+
+      const { result } = renderHook(() => useDepositPageForm(), { wrapper });
+
+      expect(result.current.btcBalance).toBe(0n);
+      expect(result.current.unconfirmedBalance).toBe(50000n);
+      expect(result.current.hasUnconfirmedBalanceOnly).toBe(true);
+    });
+
+    it("does not flag hasUnconfirmedBalanceOnly when confirmed balance is non-zero", () => {
+      vi.mocked(useUTXOs).mockReturnValue({
+        availableUTXOs: [
+          { txid: "0x123", vout: 0, value: 500000, scriptPubKey: "0xabc" },
+        ],
+        spendableMempoolUTXOs: [],
+        ordinalsCheckPending: false,
+        unconfirmedBalance: 50000n,
+      } as unknown as ReturnType<typeof useUTXOs>);
+
+      const { result } = renderHook(() => useDepositPageForm(), { wrapper });
+
+      expect(result.current.btcBalance).toBe(500000n);
+      expect(result.current.hasUnconfirmedBalanceOnly).toBe(false);
     });
 
     it("should load applications", () => {

--- a/services/vault/src/hooks/deposit/__tests__/useDepositPageForm.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useDepositPageForm.test.tsx
@@ -193,6 +193,7 @@ vi.mock("../../useUTXOs", () => ({
         confirmed: true,
       },
     ],
+    confirmedBalance: 800000n,
     unconfirmedBalance: 0n,
     isLoading: false,
     isLoadingOrdinals: false,
@@ -464,6 +465,7 @@ describe("useDepositPageForm", () => {
         },
       ],
       ordinalsCheckPending: false,
+      confirmedBalance: 800000n,
       unconfirmedBalance: 0n,
     } as unknown as ReturnType<typeof useUTXOs>);
   });
@@ -508,6 +510,7 @@ describe("useDepositPageForm", () => {
         availableUTXOs: [],
         spendableMempoolUTXOs: [],
         ordinalsCheckPending: false,
+        confirmedBalance: 0n,
         unconfirmedBalance: 50000n,
       } as unknown as ReturnType<typeof useUTXOs>);
 
@@ -525,12 +528,33 @@ describe("useDepositPageForm", () => {
         ],
         spendableMempoolUTXOs: [],
         ordinalsCheckPending: false,
+        confirmedBalance: 500000n,
         unconfirmedBalance: 50000n,
       } as unknown as ReturnType<typeof useUTXOs>);
 
       const { result } = renderHook(() => useDepositPageForm(), { wrapper });
 
       expect(result.current.btcBalance).toBe(500000n);
+      expect(result.current.hasUnconfirmedBalanceOnly).toBe(false);
+    });
+
+    it("does not flag hasUnconfirmedBalanceOnly when confirmed funds exist but are all inscriptions", () => {
+      // Spendable balance is zero because the only confirmed UTXO is an
+      // inscription (excluded from availableUTXOs), yet confirmed funds exist.
+      // The notice must stay hidden — the zero spendable balance is not a
+      // pending-confirmation situation.
+      vi.mocked(useUTXOs).mockReturnValue({
+        availableUTXOs: [],
+        spendableMempoolUTXOs: [],
+        ordinalsCheckPending: false,
+        confirmedBalance: 300000n,
+        unconfirmedBalance: 50000n,
+      } as unknown as ReturnType<typeof useUTXOs>);
+
+      const { result } = renderHook(() => useDepositPageForm(), { wrapper });
+
+      expect(result.current.btcBalance).toBe(0n);
+      expect(result.current.unconfirmedBalance).toBe(50000n);
       expect(result.current.hasUnconfirmedBalanceOnly).toBe(false);
     });
 

--- a/services/vault/src/hooks/deposit/useDepositPageForm.ts
+++ b/services/vault/src/hooks/deposit/useDepositPageForm.ts
@@ -286,18 +286,22 @@ export function useDepositPageForm(): UseDepositPageFormResult {
     availableUTXOs,
     spendableMempoolUTXOs,
     ordinalsCheckPending,
+    confirmedBalance,
     unconfirmedBalance,
   } = useUTXOs(btcAddress);
   const btcBalance = useMemo(() => {
     return BigInt(calculateBalance(availableUTXOs || []));
   }, [availableUTXOs]);
 
-  // True when the confirmed balance is zero but the address has unconfirmed
-  // (in-mempool) funds. The deposit form uses this to explain why the wallet
-  // shows a balance the app does not — the app only counts confirmed UTXOs.
+  // True when the address has no confirmed funds at all but does have
+  // unconfirmed (in-mempool) funds. The deposit form uses this to explain why
+  // the wallet shows a balance the app does not — the app only counts confirmed
+  // UTXOs. Keyed on the raw confirmed balance (not the spendable `btcBalance`)
+  // so the notice never fires when confirmed funds exist but are hidden as
+  // inscriptions — that is a different reason for a zero spendable balance.
   const hasUnconfirmedBalanceOnly = useMemo(
-    () => btcBalance === 0n && unconfirmedBalance > 0n,
-    [btcBalance, unconfirmedBalance],
+    () => confirmedBalance === 0n && unconfirmedBalance > 0n,
+    [confirmedBalance, unconfirmedBalance],
   );
 
   const btcBalanceFormatted = useMemo(() => {

--- a/services/vault/src/hooks/deposit/useDepositPageForm.ts
+++ b/services/vault/src/hooks/deposit/useDepositPageForm.ts
@@ -76,6 +76,13 @@ export interface UseDepositPageFormResult {
 
   btcBalance: bigint;
   btcBalanceFormatted: number;
+  /** Total value of unconfirmed (in-mempool) UTXOs in satoshis. Display-only. */
+  unconfirmedBalance: bigint;
+  /**
+   * True when the confirmed balance is zero but unconfirmed funds exist. Drives
+   * the "pending confirmation" notice in the deposit form.
+   */
+  hasUnconfirmedBalanceOnly: boolean;
   btcPrice: number;
   priceMetadata: Record<string, PriceMetadata>;
   hasStalePrices: boolean;
@@ -275,11 +282,23 @@ export function useDepositPageForm(): UseDepositPageFormResult {
   // spending uses `spendableMempoolUTXOs` (fee estimation) and the fail-closed
   // gate inside `useDepositFlow`, which refuses to submit while classification
   // is unavailable.
-  const { availableUTXOs, spendableMempoolUTXOs, ordinalsCheckPending } =
-    useUTXOs(btcAddress);
+  const {
+    availableUTXOs,
+    spendableMempoolUTXOs,
+    ordinalsCheckPending,
+    unconfirmedBalance,
+  } = useUTXOs(btcAddress);
   const btcBalance = useMemo(() => {
     return BigInt(calculateBalance(availableUTXOs || []));
   }, [availableUTXOs]);
+
+  // True when the confirmed balance is zero but the address has unconfirmed
+  // (in-mempool) funds. The deposit form uses this to explain why the wallet
+  // shows a balance the app does not — the app only counts confirmed UTXOs.
+  const hasUnconfirmedBalanceOnly = useMemo(
+    () => btcBalance === 0n && unconfirmedBalance > 0n,
+    [btcBalance, unconfirmedBalance],
+  );
 
   const btcBalanceFormatted = useMemo(() => {
     if (!btcBalance) return 0;
@@ -562,6 +581,8 @@ export function useDepositPageForm(): UseDepositPageFormResult {
     isWalletConnected,
     btcBalance,
     btcBalanceFormatted,
+    unconfirmedBalance,
+    hasUnconfirmedBalanceOnly,
     btcPrice: btcPriceUSD,
     priceMetadata: metadata,
     hasStalePrices,

--- a/services/vault/src/hooks/useUTXOs.ts
+++ b/services/vault/src/hooks/useUTXOs.ts
@@ -66,6 +66,15 @@ export function useUTXOs(
     return data?.filter((utxo) => utxo.confirmed) || [];
   }, [data]);
 
+  // Raw confirmed balance — sum of every confirmed UTXO, including inscription
+  // UTXOs (which `availableUTXOs` / the spendable balance exclude). Display-only:
+  // used solely to decide whether a zero spendable balance is genuinely due to
+  // having no confirmed funds, rather than to confirmed funds being filtered out
+  // as inscriptions. Must not feed fee estimation, the spendable set, or signing.
+  const confirmedBalance = useMemo(() => {
+    return BigInt(calculateBalance(confirmedUTXOs));
+  }, [confirmedUTXOs]);
+
   // Sum of unconfirmed (in-mempool) UTXO values. Display-only: pending UTXOs
   // are never spendable and must not feed fee estimation, the spendable set,
   // or any signing path. Surfaced solely so the UI can explain why a freshly
@@ -175,6 +184,8 @@ export function useUTXOs(
     allUTXOs: data || [],
     /** Only confirmed UTXOs (may include inscriptions) */
     confirmedUTXOs,
+    /** Total value of confirmed UTXOs in satoshis, including inscription UTXOs (display-only) */
+    confirmedBalance,
     /** Total value of unconfirmed UTXOs in satoshis (display-only, never spendable) */
     unconfirmedBalance,
     /** Confirmed UTXOs without inscriptions (safe to spend) */

--- a/services/vault/src/hooks/useUTXOs.ts
+++ b/services/vault/src/hooks/useUTXOs.ts
@@ -66,6 +66,15 @@ export function useUTXOs(
     return data?.filter((utxo) => utxo.confirmed) || [];
   }, [data]);
 
+  // Sum of unconfirmed (in-mempool) UTXO values. Display-only: pending UTXOs
+  // are never spendable and must not feed fee estimation, the spendable set,
+  // or any signing path. Surfaced solely so the UI can explain why a freshly
+  // funded address still reads a zero confirmed balance.
+  const unconfirmedBalance = useMemo(() => {
+    const unconfirmedUTXOs = data?.filter((utxo) => !utxo.confirmed) || [];
+    return BigInt(calculateBalance(unconfirmedUTXOs));
+  }, [data]);
+
   // Convert to wallet-connector UTXO type for ordinals filtering
   const confirmedUtxosForOrdinals = useMemo(
     () => confirmedUTXOs.map(toWalletUtxo),
@@ -166,6 +175,8 @@ export function useUTXOs(
     allUTXOs: data || [],
     /** Only confirmed UTXOs (may include inscriptions) */
     confirmedUTXOs,
+    /** Total value of unconfirmed UTXOs in satoshis (display-only, never spendable) */
+    unconfirmedBalance,
     /** Confirmed UTXOs without inscriptions (safe to spend) */
     availableUTXOs,
     /** Confirmed UTXOs that contain inscriptions */


### PR DESCRIPTION
## What

When a user's wallet shows BTC but the deposit form shows a `0` balance, the form now displays a small inline note next to "Max" — e.g. `0.2 sBTC pending confirmation` — with an info icon whose tooltip explains that only confirmed funds are counted. The note only appears when the confirmed balance is `0` **and** the address has unconfirmed (in-mempool) funds. It disappears as soon as the funds confirm.

## Why

The vault app intentionally counts **confirmed** UTXOs only when computing a depositable balance. Most wallets, by contrast, include unconfirmed funds in the balance they show. The result is confusing: a user who just received BTC sees `0.2 BTC` in their wallet but `0 BTC` (Max: `0`) in our form until the transaction confirms in a block.

This was raised by several testers on signet, who suspected a bug. It is not a bug — it is expected behavior, and the team decision was explicit that we must **not** change how balances/UTXOs are fetched or which UTXOs are considered spendable. We only need to explain the difference to the user.

## Approaches considered

**1. Change the balance to include unconfirmed funds.** Rejected. This is exactly what we were told not to do — unconfirmed UTXOs are not safe to spend, and counting them would let users build deposits on funds that may never confirm. It would touch core balance/UTXO/fee logic.

**2. A persistent info icon that always explains the confirmed-only rule.** Rejected as noisy. The confusion only happens in one specific state (balance reads 0 while funds are pending), so showing the explanation always would add clutter for everyone else.

**3. (Chosen) A display-only note shown only in the confusing state.** We read the unconfirmed amount from data the app already fetches and surface a note only when the confirmed balance is `0` and unconfirmed funds exist. Nothing about balance/UTXO/fee/signing logic changes — this is purely UI text.

## Why this approach

- It directly addresses the reported confusion at the exact moment it happens, and stays out of the way otherwise.
- It is display-only and reuses data the app already fetches (`useUTXOs` already returned all UTXOs, including unconfirmed). No new network calls.
- It does not touch any value-bearing path. The unconfirmed amount is never fed into fee estimation, the spendable set, the Max amount, or any signing path — that separation is the whole point of the confirmed-only design, and the new field is documented as display-only to keep it that way.

## What changed

- [services/vault/src/hooks/useUTXOs.ts](services/vault/src/hooks/useUTXOs.ts) — derive and expose `unconfirmedBalance` (sum of in-mempool UTXO values) using the existing `calculateBalance` helper. Marked display-only / never spendable.
- [services/vault/src/hooks/deposit/useDepositPageForm.ts](services/vault/src/hooks/deposit/useDepositPageForm.ts) — expose `unconfirmedBalance` and a derived `hasUnconfirmedBalanceOnly` (`btcBalance === 0n && unconfirmedBalance > 0n`).
- [services/vault/src/components/simple/SimpleDeposit.tsx](services/vault/src/components/simple/SimpleDeposit.tsx) — pass the two new values to the form.
- [services/vault/src/components/simple/DepositForm.tsx](services/vault/src/components/simple/DepositForm.tsx) — render the note in the slider's right slot (same line as "Max", where the USD value normally sits but is empty at a zero balance), with an info-icon tooltip.
- [services/vault/src/copy.ts](services/vault/src/copy.ts) — add the note text and tooltip copy under `deposit.form`.

## Notes

- The currency symbol comes from the network config (`coinSymbol`), so it correctly reads `sBTC` on signet and `BTC` on mainnet. The underlying confirmed/unconfirmed logic is identical on both networks.
- Out of scope: the mixed case where the confirmed balance is greater than 0 but unconfirmed funds also exist. The note is scoped to the reported zero-balance confusion. Easy to extend later if wanted.