### PR TITLE
feat(vault): min deposit slider + split default

### DIFF
--- a/services/vault/src/components/simple/DepositForm.tsx
+++ b/services/vault/src/components/simple/DepositForm.tsx
@@ -199,32 +199,28 @@ export function DepositForm({
     ? `-- ${btcConfig.coinSymbol}`
     : `${Number(depositService.formatSatoshisToBtc(maxDepositSats))} ${btcConfig.coinSymbol}`;
 
-  // Disable only the slider (not the amount input or Max button) while there's
-  // no meaningful range to drag: the max is still loading, resolved to zero
-  // (supply cap reached), or resolved below the minimum deposit (balance too
-  // small after fees/reserves) — every slider position would be sub-minimum.
-  // Manual entry stays available, and any amount above the max is clamped down
-  // once it resolves.
-  const sliderDisabled =
-    !isMaxResolved ||
-    maxDepositSats === 0n ||
-    depositService.maxBelowMinimum(maxDepositSats, minDeposit);
+  // The slider (not the amount input or Max button) only has a meaningful drag
+  // range when the resolved max is strictly above the minimum. At or below it —
+  // still loading, cap-reached at 0, balance below the minimum, or exactly at
+  // the minimum (a zero-width range) — there's nothing to drag, so disable the
+  // slider. Manual entry and the Max button stay available; any amount above
+  // the max is clamped down once it resolves.
+  const hasDraggableRange =
+    maxDepositSats != null && maxDepositSats > minDeposit;
+  const sliderDisabled = !hasDraggableRange;
 
   // The slider operates in satoshis (integer values, 1-sat step) so the thumb
-  // can land exactly on the max. A coarse BTC step would leave the sat-precise
-  // max off the step grid, stranding the thumb short of the end.
-  //
-  // When a valid deposit range exists (max resolved and ≥ the minimum, i.e. the
-  // slider is enabled), start the slider at the protocol minimum so dragging can
-  // never produce a sub-minimum amount. In the disabled states (loading,
-  // cap-reached, balance-below-minimum) fall back to 0 to keep the range
-  // well-defined (min ≤ max) — the slider isn't interactive there anyway. Manual
-  // text entry below the minimum stays available and is still caught by
-  // validation.
-  const sliderMinSats = sliderDisabled ? 0 : Number(minDeposit);
-  // Floor the max one sat above the min so the `(value - min) / (max - min)`
-  // fill math never divides by zero — a loading (null) or cap-reached (0) max,
-  // or a balance sitting exactly at the minimum, would otherwise produce NaN.
+  // can land exactly on the max. With a draggable range, start the slider at
+  // the protocol minimum so dragging can never produce a sub-minimum amount;
+  // otherwise fall back to 0 so the range stays well-defined while the slider
+  // is disabled. Manual text entry below the minimum stays available and is
+  // still caught by validation.
+  const sliderMinSats = hasDraggableRange ? Number(minDeposit) : 0;
+  // Because the range is only enabled when maxDepositSats > minDeposit (and
+  // sats are integers), the rendered max equals the real max — no synthetic
+  // over-shoot. The `+ 1` floor is purely a `(value - min) / (max - min)`
+  // divide-by-zero guard for the disabled (min = 0) states, where the slider
+  // isn't interactive anyway.
   const sliderMaxSats = Math.max(
     sliderMinSats + 1,
     Number(maxDepositSats ?? 0n),

--- a/services/vault/src/components/simple/DepositForm.tsx
+++ b/services/vault/src/components/simple/DepositForm.tsx
@@ -200,18 +200,35 @@ export function DepositForm({
     : `${Number(depositService.formatSatoshisToBtc(maxDepositSats))} ${btcConfig.coinSymbol}`;
 
   // Disable only the slider (not the amount input or Max button) while there's
-  // no meaningful range to drag: the max is still loading, or it resolved to
-  // zero (supply cap reached). Manual entry stays available, and any amount
-  // above the max is clamped down once it resolves.
-  const sliderDisabled = !isMaxResolved || maxDepositSats === 0n;
+  // no meaningful range to drag: the max is still loading, resolved to zero
+  // (supply cap reached), or resolved below the minimum deposit (balance too
+  // small after fees/reserves) — every slider position would be sub-minimum.
+  // Manual entry stays available, and any amount above the max is clamped down
+  // once it resolves.
+  const sliderDisabled =
+    !isMaxResolved ||
+    maxDepositSats === 0n ||
+    depositService.maxBelowMinimum(maxDepositSats, minDeposit);
 
   // The slider operates in satoshis (integer values, 1-sat step) so the thumb
   // can land exactly on the max. A coarse BTC step would leave the sat-precise
-  // max off the step grid, stranding the thumb short of the end. Floor the
-  // rendered max to 1 so the Slider's `(value - min) / (max - min)` fill math
-  // never divides by zero — a loading (null) or cap-reached (0) max would
-  // otherwise produce NaN. The slider is disabled in both those states anyway.
-  const sliderMaxSats = Math.max(1, Number(maxDepositSats ?? 0n));
+  // max off the step grid, stranding the thumb short of the end.
+  //
+  // When a valid deposit range exists (max resolved and ≥ the minimum, i.e. the
+  // slider is enabled), start the slider at the protocol minimum so dragging can
+  // never produce a sub-minimum amount. In the disabled states (loading,
+  // cap-reached, balance-below-minimum) fall back to 0 to keep the range
+  // well-defined (min ≤ max) — the slider isn't interactive there anyway. Manual
+  // text entry below the minimum stays available and is still caught by
+  // validation.
+  const sliderMinSats = sliderDisabled ? 0 : Number(minDeposit);
+  // Floor the max one sat above the min so the `(value - min) / (max - min)`
+  // fill math never divides by zero — a loading (null) or cap-reached (0) max,
+  // or a balance sitting exactly at the minimum, would otherwise produce NaN.
+  const sliderMaxSats = Math.max(
+    sliderMinSats + 1,
+    Number(maxDepositSats ?? 0n),
+  );
   const sliderValueSats = Number(amountSats);
 
   const usdValue = useMemo(() => {
@@ -254,11 +271,6 @@ export function DepositForm({
     !!feeError ||
     estimatedFeeSats === null;
 
-  const splitNotReady =
-    partialLiquidation?.isEnabled &&
-    !partialLiquidation?.canSplit &&
-    !partialLiquidation?.isLoading;
-
   const cta = depositService.getDepositCtaState({
     amountSats,
     minDeposit,
@@ -276,7 +288,6 @@ export function DepositForm({
     isAddressBlocked,
     isWalletConnected,
     hasProvider: !!selectedProvider,
-    splitNotReady: !!splitNotReady,
     isFeeError,
     feeError,
     feeDisabled,
@@ -295,7 +306,7 @@ export function DepositForm({
           currencyName={btcConfig.name}
           onAmountChange={(e) => onAmountChange(e.target.value)}
           sliderValue={sliderValueSats}
-          sliderMin={0}
+          sliderMin={sliderMinSats}
           sliderMax={sliderMaxSats}
           sliderStep={1}
           sliderSteps={[]}

--- a/services/vault/src/components/simple/SimpleDeposit.tsx
+++ b/services/vault/src/components/simple/SimpleDeposit.tsx
@@ -210,7 +210,13 @@ function SimpleDepositContent({
   const partialLiquidationProps = !allowSplit
     ? undefined
     : {
-        isEnabled: isPartialLiquidation,
+        // Show the split as selected only when the user wants it AND the
+        // current amount can actually split. When the amount drops below the
+        // splittable threshold the selector falls back to "Do not split";
+        // raising it back above restores the selection because the underlying
+        // intent is preserved. An explicit "Do not split" click (intent =
+        // false) still sticks.
+        isEnabled: isPartialLiquidation && canSplit,
         onChange: setIsPartialLiquidation,
         canSplit,
         isLoading: isSplitLoading,

--- a/services/vault/src/hooks/deposit/__tests__/useDepositPageForm.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useDepositPageForm.test.tsx
@@ -71,6 +71,7 @@ vi.mock("../../../applications/aave/context", () => ({
 
 import { useApplications } from "../../useApplications";
 import { useUTXOs } from "../../useUTXOs";
+import { useAllocationPlanning } from "../useAllocationPlanning";
 import { useDepositPageForm } from "../useDepositPageForm";
 import { useEstimatedBtcFee } from "../useEstimatedBtcFee";
 
@@ -918,6 +919,18 @@ describe("useDepositPageForm", () => {
   });
 
   describe("Max pinning sync with vaultCount", () => {
+    // vaultCount is now the EFFECTIVE split: isPartialLiquidation && canSplit.
+    // These tests exercise the 1->2 transition, so the amount must be
+    // splittable — override the default canSplit (false) to true.
+    beforeEach(() => {
+      vi.mocked(useAllocationPlanning).mockReturnValue({
+        vaultAmounts: null,
+        canSplit: true,
+        splitRatioLabel: null,
+        isLoading: false,
+      });
+    });
+
     // Mocks resolve to:
     //   maxDeposit (fee-adjusted balance)        = 798_500n
     //   depositorClaimValue                       = 35_000n
@@ -986,6 +999,47 @@ describe("useDepositPageForm", () => {
         expect(result.current.maxDepositSats).toBe(724_500n);
       });
       expect(result.current.formData.amountBtc).toBe("0.001");
+    });
+  });
+
+  describe("effective split budgeting", () => {
+    // Set canSplit explicitly (clearAllMocks keeps mockReturnValue, so the
+    // prior describe's canSplit:true would otherwise leak in): the amount is
+    // below the splittable threshold here.
+    beforeEach(() => {
+      vi.mocked(useAllocationPlanning).mockReturnValue({
+        vaultAmounts: null,
+        canSplit: false,
+        splitRatioLabel: null,
+        isLoading: false,
+      });
+    });
+
+    it("budgets a single vault when partial liquidation is on but the amount cannot split", async () => {
+      // Even with the split intent enabled, vaultCount must stay 1 so the Max
+      // is not understated by reserving a second vault's claim + pegin fee.
+      // 798500 − 1*(35000+500) − 3000 = 760_000n (vaultCount 1), NOT 724_500n.
+      const { result } = renderHook(() => useDepositPageForm(), { wrapper });
+
+      act(() => {
+        result.current.setFormData({
+          selectedProvider: "0x1234567890abcdef1234567890abcdef12345678",
+        });
+      });
+
+      await waitFor(() => {
+        expect(result.current.maxDepositSats).toBe(760_000n);
+      });
+
+      act(() => {
+        result.current.setIsPartialLiquidation(true);
+      });
+
+      // Give the effect a chance to (incorrectly) re-budget; it must not.
+      await waitFor(() => {
+        expect(result.current.canSplit).toBe(false);
+      });
+      expect(result.current.maxDepositSats).toBe(760_000n);
     });
   });
 });

--- a/services/vault/src/hooks/deposit/__tests__/useDepositValidation.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useDepositValidation.test.tsx
@@ -149,6 +149,31 @@ describe("useDepositValidation", () => {
         "Remaining capacity (0.00005 BTC) is below the minimum deposit (0.0001 BTC)",
       );
     });
+
+    it("returns the 'available balance below minimum' error when the fee-adjusted max is below the minimum deposit", () => {
+      // maxDepositSats (8_000) is below the 10_000 minimum, so no amount is
+      // valid. Must win over the base minimum error so the inline/submit path
+      // matches the CTA instead of telling the user to raise an unraisable
+      // amount.
+      const { result } = renderHook(
+        () =>
+          useDepositValidation({
+            availableProviders: mockProviders,
+            maxDepositSats: 8_000n,
+          }),
+        {
+          wrapper,
+        },
+      );
+
+      const validationResult = result.current.validateAmount("0.0001");
+
+      expect(validationResult.valid).toBe(false);
+      expect(validationResult.error).toContain("Available balance (0.00008");
+      expect(validationResult.error).toContain(
+        "is below the minimum deposit (0.0001",
+      );
+    });
   });
 
   describe("validateProviders", () => {

--- a/services/vault/src/hooks/deposit/useDepositPageForm.ts
+++ b/services/vault/src/hooks/deposit/useDepositPageForm.ts
@@ -328,6 +328,20 @@ export function useDepositPageForm(): UseDepositPageFormResult {
   // estimate below can account for the batch output count.
   const [isPartialLiquidation, setIsPartialLiquidation] = useState(false);
 
+  // Split planning first: `canSplit` gates the effective vault count below,
+  // which drives the fee/output budgeting. Depends only on `amountSats` + the
+  // raw intent flag (not on fees or `vaultCount`), so it's safe to compute
+  // before the fee estimate without introducing a dependency cycle.
+  const {
+    vaultAmounts: splitVaultAmounts,
+    canSplit,
+    splitRatioLabel,
+    isLoading: isSplitLoading,
+  } = useAllocationPlanning({
+    amountSats,
+    isPartialLiquidation,
+  });
+
   // Batch-first: one Pre-PegIn tx with N HTLC outputs + 1 CPFP anchor +
   // 1 OP_RETURN auth-anchor. When partial liquidation is on, N = 2.
   // `hasAuthAnchor: true` mirrors the OP_RETURN output that
@@ -335,7 +349,13 @@ export function useDepositPageForm(): UseDepositPageFormResult {
   // signing time, so the Max fee budget here matches the fee the UTXO
   // selector will later spend. No PSBT is built here — this is integer
   // vbyte budgeting only.
-  const vaultCount = isPartialLiquidation ? 2 : 1;
+  //
+  // Budget for two vaults only when the split is actually in effect (user
+  // wants it AND the amount can split). When the amount drops below the
+  // splittable threshold the deposit falls back to a single vault, so the
+  // Max/fee reserves must follow — otherwise Max is understated and can
+  // falsely read "below the minimum deposit".
+  const vaultCount = isPartialLiquidation && canSplit ? 2 : 1;
   const numPeginOutputs = peginOutputCount(vaultCount, true);
 
   const {
@@ -414,16 +434,6 @@ export function useDepositPageForm(): UseDepositPageFormResult {
     enabled: vaultKeeperBtcPubkeys.length > 0,
     staleTime: STALE_TIME_MS,
     refetchOnWindowFocus: false,
-  });
-
-  const {
-    vaultAmounts: splitVaultAmounts,
-    canSplit,
-    splitRatioLabel,
-    isLoading: isSplitLoading,
-  } = useAllocationPlanning({
-    amountSats,
-    isPartialLiquidation,
   });
 
   // Adjust max deposit to reserve every per-HTLC and per-batch component that

--- a/services/vault/src/hooks/deposit/useDepositPageForm.ts
+++ b/services/vault/src/hooks/deposit/useDepositPageForm.ts
@@ -267,16 +267,6 @@ export function useDepositPageForm(): UseDepositPageFormResult {
   const { snapshot: capSnapshot, error: capError } = useApplicationCap(
     isWalletConnected ? ethAddress : undefined,
   );
-  // Only block validation when the on-chain cap read has explicitly errored.
-  // During the initial load `capSnapshot` is null but `capError` is not set —
-  // in that window the validator skips the cap check so the user can still
-  // interact with the form. The contract still enforces the cap at submit.
-  const validation = useDepositValidation({
-    availableProviders: selectableProviderIds,
-    effectiveRemaining: capSnapshot?.effectiveRemaining ?? null,
-    capUnavailable: capError !== null,
-  });
-
   // Display balance uses `availableUTXOs` so the user sees their real funds
   // even while the ordinals classifier is loading or has errored. Actual
   // spending uses `spendableMempoolUTXOs` (fee estimation) and the fail-closed
@@ -328,15 +318,6 @@ export function useDepositPageForm(): UseDepositPageFormResult {
     },
     [clearFieldError],
   );
-
-  // Validate amount on blur
-  const validateAmountOnBlur = useCallback(() => {
-    if (formData.amountBtc === "") return;
-    const amountResult = validation.validateAmount(formData.amountBtc);
-    if (!amountResult.valid) {
-      setErrors((prev) => ({ ...prev, amount: amountResult.error }));
-    }
-  }, [formData.amountBtc, validation, setErrors]);
 
   const amountSats = useMemo(() => {
     if (!formData.amountBtc) return 0n;
@@ -491,6 +472,30 @@ export function useDepositPageForm(): UseDepositPageFormResult {
     vaultCount,
     capSnapshot,
   ]);
+
+  // Declared after `adjustedMaxDepositSats` so the validator can reject amounts
+  // when the fee-adjusted max is below the protocol minimum (terminal balance
+  // state), keeping the inline/submit path in agreement with the CTA.
+  //
+  // Only block validation when the on-chain cap read has explicitly errored.
+  // During the initial load `capSnapshot` is null but `capError` is not set —
+  // in that window the validator skips the cap check so the user can still
+  // interact with the form. The contract still enforces the cap at submit.
+  const validation = useDepositValidation({
+    availableProviders: selectableProviderIds,
+    effectiveRemaining: capSnapshot?.effectiveRemaining ?? null,
+    capUnavailable: capError !== null,
+    maxDepositSats: adjustedMaxDepositSats,
+  });
+
+  // Validate amount on blur
+  const validateAmountOnBlur = useCallback(() => {
+    if (formData.amountBtc === "") return;
+    const amountResult = validation.validateAmount(formData.amountBtc);
+    if (!amountResult.valid) {
+      setErrors((prev) => ({ ...prev, amount: amountResult.error }));
+    }
+  }, [formData.amountBtc, validation, setErrors]);
 
   const applyMaxAmount = useCallback(() => {
     setIsMaxPinned(true);

--- a/services/vault/src/hooks/deposit/useDepositValidation.ts
+++ b/services/vault/src/hooks/deposit/useDepositValidation.ts
@@ -36,6 +36,13 @@ export interface UseDepositValidationParams {
    * an explicit error rather than silently passing as if no cap applied.
    */
   capUnavailable?: boolean;
+  /**
+   * Fee-adjusted depositable maximum in satoshis (balance minus network fee and
+   * protocol reserves), or null while it is still resolving. When this is below
+   * the protocol minimum deposit, no amount is valid; surfacing that keeps the
+   * inline/submit path in agreement with the CTA.
+   */
+  maxDepositSats?: bigint | null;
 }
 
 /**
@@ -48,6 +55,7 @@ export function useDepositValidation(
     availableProviders = [],
     effectiveRemaining = null,
     capUnavailable = false,
+    maxDepositSats = null,
   } = params;
 
   const { minDeposit, maxDeposit } = useProtocolParamsContext();
@@ -77,6 +85,19 @@ export function useDepositValidation(
         };
       }
 
+      // Symmetric terminal state on the balance/fee dimension: the fee-adjusted
+      // max is below the minimum, so no amount is valid. Mirrors the CTA's
+      // maxBelowMinimum branch instead of a minimum error the user can't satisfy.
+      if (depositService.maxBelowMinimum(maxDepositSats, minDeposit)) {
+        return {
+          valid: false,
+          error: depositService.maxBelowMinimumLabel(
+            maxDepositSats,
+            minDeposit,
+          ),
+        };
+      }
+
       const base = depositService.validateDepositAmount(
         satoshis,
         minDeposit,
@@ -89,7 +110,13 @@ export function useDepositValidation(
         effectiveRemaining,
       });
     },
-    [minDeposit, maxDeposit, effectiveRemaining, capUnavailable],
+    [
+      minDeposit,
+      maxDeposit,
+      effectiveRemaining,
+      capUnavailable,
+      maxDepositSats,
+    ],
   );
 
   const validateProviders = useCallback(

--- a/services/vault/src/services/deposit/__tests__/validations.test.ts
+++ b/services/vault/src/services/deposit/__tests__/validations.test.ts
@@ -9,6 +9,8 @@ import {
   type DepositCtaParams,
   getDepositButtonLabel,
   getDepositCtaState,
+  maxBelowMinimum,
+  maxBelowMinimumLabel,
   validateMultiVaultDepositInputs,
   validateProviderSelection,
 } from "../validations";
@@ -287,7 +289,6 @@ describe("Deposit Validations", () => {
       isAddressBlocked: false,
       isWalletConnected: true,
       hasProvider: true,
-      splitNotReady: false,
       isFeeError: false,
       feeError: null,
       feeDisabled: false,
@@ -396,17 +397,6 @@ describe("Deposit Validations", () => {
       expect(result).toEqual({
         disabled: true,
         label: "Select a vault provider",
-      });
-    });
-
-    it("returns split-not-ready message when split is not ready", () => {
-      const result = getDepositCtaState({
-        ...readyParams,
-        splitNotReady: true,
-      });
-      expect(result).toEqual({
-        disabled: true,
-        label: "Deposit amount too low to split into 2 BTC Vaults",
       });
     });
 
@@ -681,6 +671,51 @@ describe("Deposit Validations", () => {
       );
     });
 
+    it("shows the 'available balance below minimum' terminal message when the fee-adjusted max < minimum deposit", () => {
+      // Balance/fee dimension (not the supply cap): maxDepositSats resolved to a
+      // positive value below the minimum, so no amount can clear both bounds.
+      // The minimum-amount label would be a dead end (the user can't raise past
+      // a max that's below the minimum).
+      const result = getDepositCtaState({
+        ...readyParams,
+        minDeposit: 1_000_000n,
+        maxDepositSats: 960_398n,
+        effectiveRemaining: null,
+        amountSats: 100_000n,
+      });
+      expect(result).toEqual({
+        disabled: true,
+        label: maxBelowMinimumLabel(960_398n, 1_000_000n),
+      });
+    });
+
+    it("shows 'available balance below minimum' regardless of the entered amount (terminal state)", () => {
+      const result = getDepositCtaState({
+        ...readyParams,
+        minDeposit: 1_000_000n,
+        maxDepositSats: 960_398n,
+        effectiveRemaining: null,
+        amountSats: 0n,
+      });
+      expect(result.label).toBe(maxBelowMinimumLabel(960_398n, 1_000_000n));
+    });
+
+    it("prefers the cap message over the balance message when both are below the minimum", () => {
+      // maxDepositSats is clamped to effectiveRemaining, so when the supply cap
+      // is the binding cause both predicates are true — the more specific cap
+      // message must win.
+      const result = getDepositCtaState({
+        ...readyParams,
+        minDeposit: 1_000_000n,
+        effectiveRemaining: 300_000n,
+        maxDepositSats: 300_000n,
+        amountSats: 0n,
+      });
+      expect(result.label).toBe(
+        "Remaining capacity (0.003 BTC) is below the minimum deposit (0.01 BTC)",
+      );
+    });
+
     it("shows 'Supply cap reached' for an empty form when the cap is fully used (pre-existing precedence)", () => {
       // Documents that effectiveRemaining === 0n wins over "Enter an amount"
       // for a zero amount — behavior unchanged by the cap/label reorder.
@@ -740,6 +775,36 @@ describe("Deposit Validations", () => {
         minPeginFeeError: new Error("boom"),
       });
       expect(result.label).toBe("Fee estimate unavailable");
+    });
+  });
+
+  describe("maxBelowMinimum", () => {
+    it("is false while the max is still resolving (null)", () => {
+      expect(maxBelowMinimum(null, 1_000_000n)).toBe(false);
+    });
+
+    it("is false when the max resolved to zero (supply cap reached)", () => {
+      expect(maxBelowMinimum(0n, 1_000_000n)).toBe(false);
+    });
+
+    it("is false when the max equals the minimum", () => {
+      expect(maxBelowMinimum(1_000_000n, 1_000_000n)).toBe(false);
+    });
+
+    it("is false when the max is at or above the minimum", () => {
+      expect(maxBelowMinimum(1_500_000n, 1_000_000n)).toBe(false);
+    });
+
+    it("is true when the max is positive but below the minimum", () => {
+      expect(maxBelowMinimum(960_398n, 1_000_000n)).toBe(true);
+    });
+  });
+
+  describe("maxBelowMinimumLabel", () => {
+    it("names the available balance and the minimum deposit", () => {
+      const label = maxBelowMinimumLabel(500_000n, 1_000_000n);
+      expect(label).toContain("Available balance (0.005");
+      expect(label).toContain("is below the minimum deposit (0.01");
     });
   });
 });

--- a/services/vault/src/services/deposit/validations.ts
+++ b/services/vault/src/services/deposit/validations.ts
@@ -100,7 +100,6 @@ export interface DepositCtaParams extends DepositFormValidityParams {
   isAddressBlocked: boolean;
   isWalletConnected: boolean;
   hasProvider: boolean;
-  splitNotReady: boolean;
   isFeeError: boolean;
   feeError: string | null;
   feeDisabled: boolean;
@@ -198,6 +197,32 @@ export function capBelowMinimumLabel(
   return `Remaining capacity (${formatSatoshisToBtc(effectiveRemaining)} BTC) is below the minimum deposit (${formatSatoshisToBtc(minDeposit)} BTC)`;
 }
 
+/**
+ * True when the fee-adjusted depositable max is positive but below the protocol
+ * minimum deposit. In that state the balance/fee ceiling and the minimum lower
+ * bound leave an empty range — no amount can satisfy both — so deposits are
+ * impossible until the wallet balance grows. Surfacing this directly avoids the
+ * dead-end "Minimum X" guidance the user can never satisfy. Narrows
+ * `maxDepositSats` to a non-null bigint when true.
+ */
+export function maxBelowMinimum(
+  maxDepositSats: bigint | null,
+  minDeposit: bigint,
+): maxDepositSats is bigint {
+  return (
+    maxDepositSats !== null &&
+    maxDepositSats > 0n &&
+    maxDepositSats < minDeposit
+  );
+}
+
+export function maxBelowMinimumLabel(
+  maxDepositSats: bigint,
+  minDeposit: bigint,
+): string {
+  return `Available balance (${formatSatoshisToBtc(maxDepositSats)} ${getBtcSymbol()}) is below the minimum deposit (${formatSatoshisToBtc(minDeposit)} ${getBtcSymbol()})`;
+}
+
 export function getDepositButtonLabel(
   params: DepositFormValidityParams,
 ): string {
@@ -288,6 +313,18 @@ export function getDepositCtaState(params: DepositCtaParams): DepositCtaState {
       label: capBelowMinimumLabel(params.effectiveRemaining, params.minDeposit),
     };
   }
+  // Symmetric to capBelowMinimum, on the balance/fee dimension: the fee-adjusted
+  // max is positive but below the minimum, so no amount clears both bounds.
+  // Terminal — surface regardless of the entered amount instead of the dead-end
+  // "Minimum X" guidance. `maxDepositSats` is clamped to `effectiveRemaining`,
+  // so when the supply cap is the binding cause the capBelowMinimum branch above
+  // wins (more specific). Mirrored in useDepositValidation.validateAmount.
+  if (maxBelowMinimum(params.maxDepositSats, params.minDeposit)) {
+    return {
+      disabled: true,
+      label: maxBelowMinimumLabel(params.maxDepositSats, params.minDeposit),
+    };
+  }
   if (
     params.effectiveRemaining !== null &&
     params.amountSats > params.effectiveRemaining
@@ -307,13 +344,6 @@ export function getDepositCtaState(params: DepositCtaParams): DepositCtaState {
 
   if (!params.hasProvider) {
     return { disabled: true, label: "Select a vault provider" };
-  }
-
-  if (params.splitNotReady) {
-    return {
-      disabled: true,
-      label: "Deposit amount too low to split into 2 BTC Vaults",
-    };
   }
 
   // Surface a terminal `computeMinPeginFee` failure ahead of the "still


### PR DESCRIPTION
This PR fixes three related deposit-form papercuts. None of them were funds bugs — the deposit math was already correct — but the UI showed states that were confusing or impossible to act on.

1. When the wallet's depositable Max is below the protocol minimum, the slider used to stay draggable across a range where every value is below the minimum, and the button just read "Minimum 0.01 sBTC" — guidance you can never satisfy.
2. Even when the Max was above the minimum, the slider's lower bound was 0, so you could drag it down to a sub-minimum amount.
3. After selecting the "2 UTXO Split" option at a large amount, lowering the amount below the splittable threshold left the split still showing as selected instead of falling back to "Do not split UTXO".

## Fix 1 — Slider/CTA when the depositable Max is below the minimum

**What you saw:** With a small wallet, "Max" showed e.g. `0.00960398 sBTC` while the minimum deposit is `0.01 sBTC`. The slider was still draggable (so it always produced a sub-minimum amount), and the button was stuck on "Minimum 0.01 sBTC", which you can't fix by raising the amount because the Max itself is below the minimum.

**Why it happened:** The slider was only disabled while the Max was still loading or had resolved to exactly `0`. A Max that resolved to a positive value below the minimum wasn't treated as a terminal state, so the form fell through to the generic "Minimum X" message. A previous PR (https://github.com/babylonlabs-io/babylon-toolkit/pull/1767) already solved the exact same contradiction for the *supply-cap* limit (`capBelowMinimum`), but the equivalent handling for the *balance* limit was never added.

**What we did:** Added the missing symmetric case, mirroring the existing supply-cap pattern. New `maxBelowMinimum` / `maxBelowMinimumLabel` helpers in the deposit validation layer. When the fee-adjusted Max is positive but below the minimum, the slider is disabled and the button shows a clear, accurate message: "Available balance (X sBTC) is below the minimum deposit (Y sBTC)". The same check is mirrored in the inline/submit validation so the field error and the button always agree.

## Fix 2 — Slider can no longer pick a sub-minimum amount

**What you saw:** Even with a healthy balance, dragging the slider all the way left landed on a value below the minimum (the button then said "Minimum X").

**Why it happened:** The slider's lower bound was hard-coded to `0`.

**What we did:** When a valid range exists (Max is resolved and at or above the minimum), the slider's lower bound is now the protocol minimum, so dragging can never produce a sub-minimum amount. Typing a sub-minimum amount by hand is still allowed and still caught by validation. In the disabled states (loading, cap reached, or the Fix 1 terminal case) the lower bound falls back to `0` so the slider's internal math stays well-defined.

## Fix 3 — Split selector falls back to "Do not split" when the amount is too small

**What you saw:** Enter `0.04` and the "2 UTXO Split" option auto-selects ("2 UTXO Split - 26/74 (Recommended)"). Drag/type the amount down to `0.03` or `0.01` — where one of the two vaults would fall below the minimum — and the selector still showed the split as selected (just greyed out and without the ratio) instead of switching to "Do not split UTXO".

**Why it happened:** The selector's selected state was driven by the raw "user wants to split" flag. There was a one-time effect that auto-turns the split *on* the first time it becomes possible, but nothing turned it back off (for display) when the amount later became too small to split. The actual deposit was always safe — it already deposits as a single vault when the amount can't split — so this was purely a misleading display.

**What we did:** The selector now shows the split as selected only when the user wants it *and* the current amount can actually split. So it visibly falls back to "Do not split UTXO" when the amount is too small. Because we keep the user's underlying choice, raising the amount back above the threshold restores the split selection, while an explicit "Do not split" click still sticks. With this in place, the old "Deposit amount too low to split into 2 BTC Vaults" blocking message can no longer occur, so it was removed (along with its now-dead code and test).

## Approaches we considered

**Fix 1 (terminal state):** We considered only handling the screenshot case (Max below minimum) versus also reworking how the Max is computed to account for reserved UTXOs from in-flight deposits. We scoped the latter out — it's a separate, larger issue (the displayed Max doesn't subtract reserved UTXOs, which only surface at signing time) and not what this report was about. We mirrored the existing `capBelowMinimum` pattern rather than inventing a new one, so the two limits (supply cap vs balance) behave consistently.

**Fix 2 (slider lower bound):** The alternative was to leave the slider starting at 0 and rely on validation to reject sub-minimum amounts (the prior behaviour). We chose to clamp the slider's lower bound to the minimum because the report was literally "the slider lets me start under the minimum" — making the slider only able to express valid amounts is the most direct fix, and manual entry plus validation still covers the edge cases.

**Fix 3 (split fallback):** We considered an effect that force-resets the split flag to off whenever the amount drops below the threshold, versus deriving the displayed state as "wants split AND can split". We chose the derived approach because it's a smaller, race-free change, it preserves the user's intent (so raising the amount back restores the recommended split), and it doesn't accidentally override an explicit "Do not split" choice. The force-reset approach was both more code and had a worse edge case where re-raising the amount could override a deliberate "Do not split".

## Risk / scope

All changes are in the vault deposit form's UI and validation layer. No change to transaction construction, signing, fee math, or the WASM boundary — the deposit amounts and split execution were already correct and are untouched. The fixes only make the slider and the split selector show states the user can actually act on.

## Testing

- Added unit tests for the new `maxBelowMinimum` helper and the balance-below-minimum CTA/validation behaviour; removed the now-dead split-not-ready test.
- Full vault test suite passes (1487 passed, 4 skipped); lint clean.
- Manual: a wallet with balance just under the minimum disables the slider and shows the "Available balance … below the minimum deposit …" message; a healthy wallet's slider can no longer be dragged below the minimum; and entering `0.04` then lowering to `0.03`/`0.01` now falls back to "Do not split UTXO", with the split restored when the amount goes back up.
