### PR TITLE
feat(vault): show both pegin and pre-pegin tx hashes on deposit cards

### DIFF
--- a/services/vault/src/components/simple/BatchedDepositGroup.tsx
+++ b/services/vault/src/components/simple/BatchedDepositGroup.tsx
@@ -69,7 +69,8 @@ export function BatchedDepositGroup({
       depositId={activity.id}
       amount={activity.collateral.amount}
       timestamp={activity.timestamp}
-      txHash={activity.prePeginTxHash}
+      peginTxHash={activity.peginTxHash}
+      prePeginTxHash={activity.prePeginTxHash}
       providerId={activity.providers[0].id}
       vaultProviders={vaultProviders}
       suppressBroadcastAction={suppressBroadcast}

--- a/services/vault/src/components/simple/CollateralExpandedContent.tsx
+++ b/services/vault/src/components/simple/CollateralExpandedContent.tsx
@@ -56,6 +56,7 @@ export function CollateralExpandedContent({
               providerIconUrl={vault.providerIconUrl}
               providerAddress={vault.providerAddress}
               peginTxHash={vault.peginTxHash}
+              prePeginTxHash={vault.prePeginTxHash}
               liquidationIndex={vault.liquidationIndex}
               selected={isSelected}
               selectable={vault.inUse && isEligible}

--- a/services/vault/src/components/simple/CollateralVaultItem.tsx
+++ b/services/vault/src/components/simple/CollateralVaultItem.tsx
@@ -11,13 +11,12 @@ import {
   StatusBadge,
 } from "@babylonlabs-io/core-ui";
 
-import { CopyableHash } from "@/components/shared/CopyableHash";
 import { getNetworkConfigBTC } from "@/config";
 import { COPY } from "@/copy";
 import { truncateAddress } from "@/utils/addressUtils";
-import { getBtcExplorerTxUrl } from "@/utils/explorer";
 import { formatBtcAmount, formatOrdinal } from "@/utils/formatting";
 
+import { PeginTxHashRow } from "./PeginTxHashRow";
 import { VaultCardRow, VaultCardShell } from "./VaultCardShell";
 
 const btcConfig = getNetworkConfigBTC();
@@ -32,6 +31,8 @@ interface CollateralVaultItemProps {
   providerAddress: string;
   /** BTC peg-in transaction hash (hex, may include 0x prefix) */
   peginTxHash?: string;
+  /** Pre-PegIn transaction hash (hex, may include 0x prefix) */
+  prePeginTxHash?: string;
   liquidationIndex?: number;
   selected: boolean;
   selectable: boolean;
@@ -47,6 +48,7 @@ export function CollateralVaultItem({
   providerIconUrl,
   providerAddress,
   peginTxHash,
+  prePeginTxHash,
   liquidationIndex,
   selected,
   selectable,
@@ -108,16 +110,13 @@ export function CollateralVaultItem({
         </Hint>
       </VaultCardRow>
 
-      {/* Transaction hash row (BTC pegin) */}
-      {peginTxHash && (
-        <VaultCardRow label="Transaction Hash">
-          <CopyableHash
-            hash={peginTxHash}
-            chain="BTC"
-            explorerUrl={getBtcExplorerTxUrl(peginTxHash)}
-          />
-        </VaultCardRow>
-      )}
+      {/* Transaction hash row — Pegin + Pre-Pegin. The vault is active here, so
+          both txs are on Bitcoin and link to the explorer. */}
+      <PeginTxHashRow
+        peginTxHash={peginTxHash}
+        prePeginTxHash={prePeginTxHash}
+        linkPegin
+      />
 
       {/* Liquidation Order row */}
       {liquidationIndex !== undefined && (

--- a/services/vault/src/components/simple/ExpiredDepositSection.tsx
+++ b/services/vault/src/components/simple/ExpiredDepositSection.tsx
@@ -103,7 +103,8 @@ export function ExpiredDepositSection({
                 depositId={activity.id}
                 amount={activity.collateral.amount}
                 timestamp={activity.timestamp}
-                txHash={activity.prePeginTxHash}
+                peginTxHash={activity.peginTxHash}
+                prePeginTxHash={activity.prePeginTxHash}
                 providerId={activity.providers[0].id}
                 vaultProviders={vaultProviders}
                 onSignClick={onSignClick}

--- a/services/vault/src/components/simple/PeginTxHashRow.tsx
+++ b/services/vault/src/components/simple/PeginTxHashRow.tsx
@@ -1,0 +1,91 @@
+/**
+ * PeginTxHashRow — the "TX Hash" row showing a deposit's Pegin and Pre-Pegin
+ * Bitcoin transaction hashes side by side, each with copy-to-clipboard.
+ *
+ * The depositor broadcasts the Pre-PegIn tx early in the flow, so it is
+ * generally linkable to the explorer. The peg-in tx is only on Bitcoin once the
+ * vault provider broadcasts it (vault active), so its explorer link is gated via
+ * `linkPegin` — copy-only otherwise.
+ *
+ * Renders nothing when neither hash is available.
+ */
+
+import { CopyableHash } from "@/components/shared/CopyableHash";
+import { COPY } from "@/copy";
+import { getBtcExplorerTxUrl } from "@/utils/explorer";
+
+import { VaultCardRow } from "./VaultCardShell";
+
+interface PeginTxHashRowProps {
+  /** Raw BTC peg-in transaction hash (hex, may include 0x prefix). */
+  peginTxHash?: string;
+  /** Pre-PegIn transaction hash (hex, may include 0x prefix). */
+  prePeginTxHash?: string;
+  /**
+   * Link the peg-in hash to the BTC explorer. Off by default because the peg-in
+   * tx is not on Bitcoin until the vault provider broadcasts it (vault active).
+   */
+  linkPegin?: boolean;
+  /**
+   * Link the Pre-PegIn hash to the BTC explorer. On by default — the depositor
+   * broadcasts the Pre-PegIn early in the deposit flow.
+   */
+  linkPrePegin?: boolean;
+}
+
+function HashSegment({
+  label,
+  hash,
+  explorerUrl,
+}: {
+  label: string;
+  hash: string;
+  explorerUrl?: string;
+}) {
+  return (
+    <span className="flex items-center gap-1">
+      <span className="text-sm text-accent-secondary">{label}</span>
+      <CopyableHash hash={hash} chain="BTC" explorerUrl={explorerUrl} />
+    </span>
+  );
+}
+
+export function PeginTxHashRow({
+  peginTxHash,
+  prePeginTxHash,
+  linkPegin = false,
+  linkPrePegin = true,
+}: PeginTxHashRowProps) {
+  if (!peginTxHash && !prePeginTxHash) return null;
+
+  return (
+    <VaultCardRow label={COPY.pegin.txHash.label}>
+      <span className="flex flex-wrap items-center justify-end gap-x-3 gap-y-1">
+        {peginTxHash && (
+          <HashSegment
+            label={COPY.pegin.txHash.pegin}
+            hash={peginTxHash}
+            explorerUrl={
+              linkPegin ? getBtcExplorerTxUrl(peginTxHash) : undefined
+            }
+          />
+        )}
+        {peginTxHash && prePeginTxHash && (
+          <span
+            aria-hidden
+            className="h-4 w-px shrink-0 bg-secondary-strokeLight"
+          />
+        )}
+        {prePeginTxHash && (
+          <HashSegment
+            label={COPY.pegin.txHash.prePegin}
+            hash={prePeginTxHash}
+            explorerUrl={
+              linkPrePegin ? getBtcExplorerTxUrl(prePeginTxHash) : undefined
+            }
+          />
+        )}
+      </span>
+    </VaultCardRow>
+  );
+}

--- a/services/vault/src/components/simple/PendingDepositCard.tsx
+++ b/services/vault/src/components/simple/PendingDepositCard.tsx
@@ -15,7 +15,10 @@ import {
 import { getNetworkConfigBTC } from "@/config";
 import { useDepositPollingResult } from "@/context/deposit/PeginPollingContext";
 import { COPY } from "@/copy";
-import { getPeginDisplayStep } from "@/models/peginStateMachine";
+import {
+  canPerformAction,
+  getPeginDisplayStep,
+} from "@/models/peginStateMachine";
 import { getTokenBrandColor } from "@/services/token/tokenService";
 import type { VaultProvider } from "@/types/vaultProvider";
 import { truncateAddress } from "@/utils/addressUtils";
@@ -28,6 +31,7 @@ import {
   TOTAL_VISUAL_STEPS,
 } from "./DepositProgressView/steps";
 import { DepositStepLabel } from "./DepositStepLabel";
+import { PeginTxHashRow } from "./PeginTxHashRow";
 import { STATUS_DOT_COLORS } from "./statusColors";
 import { VaultDetailCard, VaultStatusBadge } from "./VaultDetailCard";
 
@@ -39,7 +43,10 @@ interface PendingDepositCardProps {
   amount: string;
   /** Milliseconds since epoch */
   timestamp?: number;
-  txHash?: string;
+  /** Raw BTC peg-in transaction hash (hex, may include 0x prefix). */
+  peginTxHash?: string;
+  /** Pre-PegIn transaction hash (hex, may include 0x prefix). */
+  prePeginTxHash?: string;
   providerId: string;
   vaultProviders: VaultProvider[];
   onSignClick: (depositId: string) => void;
@@ -61,7 +68,8 @@ export function PendingDepositCard({
   depositId,
   amount,
   timestamp,
-  txHash,
+  peginTxHash,
+  prePeginTxHash,
   providerId,
   vaultProviders,
   onSignClick,
@@ -120,6 +128,14 @@ export function PendingDepositCard({
   const buttonDisabled = !isActionable || loading;
   const dotColor = STATUS_DOT_COLORS[peginState.displayVariant];
 
+  // The Pre-PegIn tx is on Bitcoin only once the depositor has broadcast it.
+  // While the broadcast action is still pending, an explorer link would 404, so
+  // the Pre-PegIn hash stays copy-only until then.
+  const prePeginBroadcast = !canPerformAction(
+    peginState,
+    PeginAction.SIGN_AND_BROADCAST_TO_BITCOIN,
+  );
+
   // Map the current state onto the shared deposit-flow step model so the card
   // can show "Step X of Y" + a progress bar. `null` when there's no meaningful
   // in-progress step (those states don't reach the pending sections), and while
@@ -137,7 +153,13 @@ export function PendingDepositCard({
     <VaultDetailCard
       amountBtc={parseFloat(amount || "0")}
       timestamp={timestamp ?? 0}
-      txHash={txHash}
+      txHashRow={
+        <PeginTxHashRow
+          peginTxHash={peginTxHash}
+          prePeginTxHash={prePeginTxHash}
+          linkPrePegin={prePeginBroadcast}
+        />
+      }
       providerName={providerName}
       providerIconUrl={provider?.iconUrl}
       providerAddress={providerId}

--- a/services/vault/src/components/simple/PendingDepositSection.tsx
+++ b/services/vault/src/components/simple/PendingDepositSection.tsx
@@ -152,7 +152,8 @@ export function PendingDepositSection() {
                           depositId={group[0].id}
                           amount={group[0].collateral.amount}
                           timestamp={group[0].timestamp}
-                          txHash={group[0].prePeginTxHash}
+                          peginTxHash={group[0].peginTxHash}
+                          prePeginTxHash={group[0].prePeginTxHash}
                           providerId={group[0].providers[0].id}
                           vaultProviders={vaultProviders}
                           onSignClick={signModal.handleSignClick}

--- a/services/vault/src/components/simple/VaultDetailCard.tsx
+++ b/services/vault/src/components/simple/VaultDetailCard.tsx
@@ -10,6 +10,7 @@ import { useEffect, useState, type ReactNode } from "react";
 
 import { CopyableHash } from "@/components/shared/CopyableHash";
 import { getNetworkConfigBTC } from "@/config";
+import { COPY } from "@/copy";
 import { truncateAddress } from "@/utils/addressUtils";
 import {
   getBtcExplorerAddressUrl,
@@ -46,11 +47,13 @@ interface VaultDetailCardProps {
   amountBtc: number;
   /** Timestamp in milliseconds */
   timestamp: number;
-  /** BTC transaction hash to link in the explorer (hex, may include 0x prefix).
-   * For pending/expired deposits this is the Pre-PegIn tx the depositor
-   * broadcasts; the peg-in tx itself is not on Bitcoin until the vault
-   * provider broadcasts it later in the flow. */
+  /** Single BTC transaction hash to link in the explorer (hex, may include 0x
+   * prefix). Used by the withdraw section to show the vault's peg-in tx hash.
+   * Ignored when `txHashRow` is provided. */
   txHash?: string;
+  /** Custom transaction-hash row, rendered in place of the single-`txHash` row.
+   * Deposit cards pass a dual Pegin / Pre-Pegin row here (see PeginTxHashRow). */
+  txHashRow?: ReactNode;
   /** Vault provider display name */
   providerName: string;
   /** Vault provider icon URL */
@@ -85,6 +88,7 @@ export function VaultDetailCard({
   amountBtc,
   timestamp,
   txHash,
+  txHashRow,
   providerName,
   providerIconUrl,
   providerAddress,
@@ -160,16 +164,18 @@ export function VaultDetailCard({
         </Hint>
       </VaultCardRow>
 
-      {/* Transaction Hash (Pre-PegIn) */}
-      {txHash && (
-        <VaultCardRow label="Transaction Hash">
-          <CopyableHash
-            hash={txHash}
-            chain="BTC"
-            explorerUrl={getBtcExplorerTxUrl(txHash)}
-          />
-        </VaultCardRow>
-      )}
+      {/* Transaction Hash — a custom row (e.g. dual Pegin / Pre-Pegin) takes
+          precedence; otherwise fall back to the single-hash row. */}
+      {txHashRow ??
+        (txHash && (
+          <VaultCardRow label={COPY.pegin.txHash.singleLabel}>
+            <CopyableHash
+              hash={txHash}
+              chain="BTC"
+              explorerUrl={getBtcExplorerTxUrl(txHash)}
+            />
+          </VaultCardRow>
+        ))}
 
       {/* Nominated Address — destination registered at vault creation.
           May differ from the currently connected BTC wallet. */}

--- a/services/vault/src/components/simple/__tests__/PeginTxHashRow.test.tsx
+++ b/services/vault/src/components/simple/__tests__/PeginTxHashRow.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { COPY } from "@/copy";
+
+import { PeginTxHashRow } from "../PeginTxHashRow";
+
+// 0x-prefixed, all-1s vs all-2s so the two hashes are distinguishable in
+// explorer hrefs (mempool URLs strip the 0x prefix).
+const PEGIN_TX_HASH = `0x${"1".repeat(64)}`;
+const PRE_PEGIN_TX_HASH = `0x${"2".repeat(64)}`;
+const PEGIN_TXID = "1".repeat(64);
+const PRE_PEGIN_TXID = "2".repeat(64);
+
+describe("PeginTxHashRow", () => {
+  it("renders both Pegin and Pre-Pegin segments with the TX Hash label", () => {
+    render(
+      <PeginTxHashRow
+        peginTxHash={PEGIN_TX_HASH}
+        prePeginTxHash={PRE_PEGIN_TX_HASH}
+      />,
+    );
+
+    expect(screen.getByText(COPY.pegin.txHash.label)).toBeInTheDocument();
+    expect(screen.getByText(COPY.pegin.txHash.pegin)).toBeInTheDocument();
+    expect(screen.getByText(COPY.pegin.txHash.prePegin)).toBeInTheDocument();
+  });
+
+  it("links only the Pre-Pegin hash by default (pegin tx not yet on Bitcoin)", () => {
+    render(
+      <PeginTxHashRow
+        peginTxHash={PEGIN_TX_HASH}
+        prePeginTxHash={PRE_PEGIN_TX_HASH}
+      />,
+    );
+
+    const links = screen.getAllByRole("link");
+    expect(links).toHaveLength(1);
+    expect(links[0]).toHaveAttribute(
+      "href",
+      expect.stringContaining(PRE_PEGIN_TXID),
+    );
+    // Pegin hash is copy-only — no link points at its txid.
+    expect(
+      links.some((l) => l.getAttribute("href")?.includes(PEGIN_TXID)),
+    ).toBe(false);
+  });
+
+  it("links the Pegin hash too when linkPegin is set", () => {
+    render(
+      <PeginTxHashRow
+        peginTxHash={PEGIN_TX_HASH}
+        prePeginTxHash={PRE_PEGIN_TX_HASH}
+        linkPegin
+      />,
+    );
+
+    const links = screen.getAllByRole("link");
+    expect(links).toHaveLength(2);
+    expect(
+      links.some((l) => l.getAttribute("href")?.includes(PEGIN_TXID)),
+    ).toBe(true);
+    expect(
+      links.some((l) => l.getAttribute("href")?.includes(PRE_PEGIN_TXID)),
+    ).toBe(true);
+  });
+
+  it("renders a single segment without a divider when only one hash is present", () => {
+    render(<PeginTxHashRow prePeginTxHash={PRE_PEGIN_TX_HASH} />);
+
+    expect(screen.getByText(COPY.pegin.txHash.prePegin)).toBeInTheDocument();
+    expect(screen.queryByText(COPY.pegin.txHash.pegin)).not.toBeInTheDocument();
+  });
+
+  it("renders nothing when neither hash is available", () => {
+    const { container } = render(<PeginTxHashRow />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/services/vault/src/components/simple/__tests__/PendingDepositCard.test.tsx
+++ b/services/vault/src/components/simple/__tests__/PendingDepositCard.test.tsx
@@ -36,12 +36,14 @@ vi.mock("../VaultDetailCard", () => ({
     belowHeader,
     disabled,
     disabledTooltip,
+    txHashRow,
   }: {
     action?: ReactNode;
     amountSubtext?: ReactNode;
     belowHeader?: ReactNode;
     disabled?: boolean;
     disabledTooltip?: string;
+    txHashRow?: ReactNode;
   }) => (
     <div
       data-testid="vault-detail-card"
@@ -51,6 +53,7 @@ vi.mock("../VaultDetailCard", () => ({
       {action}
       <div data-testid="amount-subtext">{amountSubtext}</div>
       <div data-testid="below-header">{belowHeader}</div>
+      <div data-testid="tx-hash-row">{txHashRow}</div>
     </div>
   ),
   VaultStatusBadge: () => <div data-testid="status-badge" />,
@@ -62,6 +65,7 @@ const POLLING_RESULT = {
     displayLabel: "Pending",
     displayVariant: "pending",
     message: undefined,
+    availableActions: [],
   },
 };
 
@@ -207,6 +211,57 @@ describe("PendingDepositCard — disabled (ownership mismatch) surface", () => {
     expect(screen.queryByRole("button")).not.toBeInTheDocument();
     const card = screen.getByTestId("vault-detail-card");
     expect(card).toHaveAttribute("data-disabled", "false");
+  });
+});
+
+describe("PendingDepositCard — Pre-Pegin explorer link gating", () => {
+  const PRE_PEGIN_TX_HASH = `0x${"2".repeat(64)}`;
+  const PRE_PEGIN_TXID = "2".repeat(64);
+
+  function renderWithPrePegin(availableActions: PeginAction[]) {
+    mockUseDepositPollingResult.mockReturnValue({
+      loading: false,
+      peginState: {
+        displayLabel: "Pending",
+        displayVariant: "pending",
+        availableActions,
+      },
+    });
+    render(
+      <PendingDepositCard
+        depositId="0xvault"
+        amount="0.05"
+        prePeginTxHash={PRE_PEGIN_TX_HASH}
+        providerId="0xprovider"
+        vaultProviders={[]}
+        onSignClick={vi.fn()}
+        onBroadcastClick={vi.fn()}
+        onWotsKeyClick={vi.fn()}
+        onActivationClick={vi.fn()}
+        onRefundClick={vi.fn()}
+      />,
+    );
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsArtifactDownloadAvailable.mockReturnValue(false);
+    mockGetActionStatus.mockReturnValue({ type: "unavailable" });
+  });
+
+  it("keeps the Pre-Pegin hash copy-only while the broadcast action is pending", () => {
+    // Broadcast still pending → the Pre-PegIn tx is not on Bitcoin yet, so an
+    // explorer link would 404. The hash must be copy-only.
+    renderWithPrePegin([PeginAction.SIGN_AND_BROADCAST_TO_BITCOIN]);
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+
+  it("links the Pre-Pegin hash once the broadcast action is no longer pending", () => {
+    renderWithPrePegin([]);
+    expect(screen.getByRole("link")).toHaveAttribute(
+      "href",
+      expect.stringContaining(PRE_PEGIN_TXID),
+    );
   });
 });
 

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -60,6 +60,16 @@ export const COPY = {
       INVALID: "Invalid",
       UNKNOWN: "Unknown",
     },
+    txHash: {
+      // Row label for the dual Pegin / Pre-Pegin hash row on deposit and
+      // collateral cards.
+      label: "TX Hash",
+      // Row label for the single-hash row (withdraw section).
+      singleLabel: "Transaction Hash",
+      // Inline prefixes for each hash in the dual row.
+      pegin: "Pegin:",
+      prePegin: "Pre-Pegin:",
+    },
     messages: {
       payoutSignaturesSubmitted:
         "Payout signatures submitted. Vault provider is verifying and collecting acknowledgments...",

--- a/services/vault/src/types/collateral.ts
+++ b/services/vault/src/types/collateral.ts
@@ -9,6 +9,12 @@ export interface CollateralVaultEntry {
   vaultId: string;
   /** Raw BTC pegin transaction hash (for VP RPC operations like artifact download) */
   peginTxHash?: string;
+  /**
+   * Pre-PegIn transaction hash (txid of `unsignedPrePeginTx`). Derived for the
+   * collateral card's TX Hash row. Optional because legacy / edge-case data may
+   * lack a decodable pre-pegin tx.
+   */
+  prePeginTxHash?: string;
   /** Vault amount in BTC (converted from satoshis) */
   amountBtc: number;
   /** Unix timestamp in seconds when added as collateral */

--- a/services/vault/src/utils/collateral.ts
+++ b/services/vault/src/utils/collateral.ts
@@ -9,6 +9,7 @@ import type { VaultProvider } from "@/types/vaultProvider";
 
 import { truncateHash } from "./addressUtils";
 import { satoshiToBtcNumber } from "./btcConversion";
+import { derivePrePeginTxHash } from "./vaultTransformers";
 
 /** Vault statuses that should be excluded from the collateral display */
 const EXCLUDED_VAULT_STATUSES = new Set(["liquidated", "depositor_withdrawn"]);
@@ -44,6 +45,7 @@ export function toCollateralVaultEntries(
       id: `${c.depositorAddress}-${c.vaultId}`,
       vaultId: c.vaultId,
       peginTxHash: c.vault?.peginTxHash,
+      prePeginTxHash: derivePrePeginTxHash(c.vault?.unsignedPrePeginTx),
       amountBtc: satoshiToBtcNumber(c.amount),
       addedAt: Number(c.addedAt),
       inUse: c.vault?.inUse ?? false,


### PR DESCRIPTION
Replace the single-hash row on the pending-deposit and collateral vault cards with a dual "TX Hash" row showing the Pegin and Pre-Pegin Bitcoin transaction hashes side by side, each with copy-to-clipboard.

Explorer links are gated to when the transaction is actually on Bitcoin: the pre-pegin links once it has been broadcast, and the pegin links only on active collateral vaults (the VP broadcasts it at activation). The new shared PeginTxHashRow component centralizes this layout and gating.

## Screenshot
<img width="2912" height="1804" alt="image" src="https://github.com/user-attachments/assets/115fbdb5-8aba-4038-8079-06932959f3d1" />
