### PR TITLE
fix(vault): alias WBTC to BTC Chainlink price feed

### DIFF
--- a/services/vault/src/clients/eth-contract/chainlink/query.ts
+++ b/services/vault/src/clients/eth-contract/chainlink/query.ts
@@ -59,7 +59,8 @@ function getChainlinkFeedAddress(symbol: string): Address | null {
   if (
     normalizedSymbol === "BTC" ||
     normalizedSymbol === "VBTC" ||
-    normalizedSymbol === "SBTC"
+    normalizedSymbol === "SBTC" ||
+    normalizedSymbol === "WBTC"
   ) {
     if (ENV.BTC_PRICE_FEED) {
       if (!btcPriceFeedOverrideWarned) {
@@ -275,8 +276,10 @@ export async function getTokenPrices(
       if (normalizedSymbol === "BTC") {
         prices["vBTC"] = result.price;
         prices["sBTC"] = result.price;
+        prices["WBTC"] = result.price;
         metadata["vBTC"] = result.metadata;
         metadata["sBTC"] = result.metadata;
+        metadata["WBTC"] = result.metadata;
       }
     } catch (error) {
       const errorMessage =
@@ -300,6 +303,7 @@ export async function getTokenPrices(
       if (normalizedSymbol === "BTC") {
         metadata["vBTC"] = metadata[symbol];
         metadata["sBTC"] = metadata[symbol];
+        metadata["WBTC"] = metadata[symbol];
       }
     }
   });


### PR DESCRIPTION
## Summary
- WBTC borrow card was showing **"Price data unavailable. Borrowing is temporarily disabled."** on testnet because `chainlinkPrices["WBTC"]` resolved to `undefined`.
- Root cause: the Chainlink client (`services/vault/src/clients/eth-contract/chainlink/query.ts`) does not list WBTC and Sepolia has no native wBTC Chainlink feed.
- Fix: alias WBTC to the existing BTC feed (wBTC is pegged 1:1 to BTC), mirroring the established pattern already used for `vBTC` and `sBTC` — both the feed-address lookup and the post-fetch price/metadata write-back are updated.
- No contract, oracle deployment, or `tbv-networks` config changes required.

## Test plan
- [ ] Start vault-frontend against testnet, open the WBTC reserve detail/borrow card, and confirm the price renders and borrowing is enabled.
- [ ] Confirm BTC/vBTC/sBTC borrow cards still show price (no regression on existing aliases).
- [ ] Confirm no console errors related to price fetching.
- [ ] Spot-check that the WBTC price displayed matches the BTC price (1:1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)