### PR TITLE
fix(vault): disable unowned vault card in any state

### DIFF
--- a/services/vault/src/components/deposit/__tests__/actionStatus.test.ts
+++ b/services/vault/src/components/deposit/__tests__/actionStatus.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { ContractStatus, getPeginState } from "@/models/peginStateMachine";
+import {
+  ContractStatus,
+  getPeginState,
+  LocalStorageStatus,
+} from "@/models/peginStateMachine";
 
 import type { DepositPollingResult } from "../../../context/deposit/PeginPollingContext";
 import {
@@ -123,12 +127,60 @@ describe("getActionStatus — wallet ownership mismatch", () => {
 
     expect(status.type).toBe("disabled");
     if (status.type !== "disabled") return;
-    expect(status.action.action).toBe(PeginAction.ACTIVATE_VAULT);
+    expect(status.action?.action).toBe(PeginAction.ACTIVATE_VAULT);
     expect(status.tooltip).toMatch(
       /this btc vault was created with a different btc public key/i,
     );
     expect(status.tooltip).toContain("bcc5...f21c");
     expect(status.tooltip).not.toContain("0x");
+  });
+
+  it("returns disabled without an action for a pure-progress unowned vault (so the card still dims + shows the tooltip)", () => {
+    // PENDING+CONFIRMING+ingested+!transactionsReady is the "awaiting
+    // payout-prep" wait — no primary action. Without the ownership-
+    // priority fix this returned `unavailable` and unowned cards looked
+    // like the user's own in-progress card. The disable now fires
+    // regardless so the dim + tooltip flag the foreign ownership.
+    const waitingState = getPeginState(ContractStatus.PENDING, {
+      localStatus: LocalStorageStatus.CONFIRMING,
+      pendingIngestion: false,
+      transactionsReady: false,
+    });
+    const result = pollingResultWithAction("id1", waitingState, {
+      isOwnedByCurrentWallet: false,
+      depositorBtcPubkey: FOREIGN_PUBKEY,
+    });
+
+    const status = getActionStatus(result);
+
+    expect(status.type).toBe("disabled");
+    if (status.type !== "disabled") return;
+    expect(status.action).toBeUndefined();
+    expect(status.tooltip).toMatch(
+      /this btc vault was created with a different btc public key/i,
+    );
+  });
+
+  it("keeps the unowned dim + tooltip even when polling errored (ownership is independent of polling)", () => {
+    // Ownership comes from activity/indexer state, not the polling
+    // result, so a transient polling error must not flip the card back
+    // to a neutral noAction render. Otherwise the user sees an
+    // un-dimmed un-tooltipped card for someone else's vault any time
+    // the VP RPC hiccups.
+    const verifiedState = getPeginState(ContractStatus.VERIFIED);
+    const result = pollingResultWithAction("id1", verifiedState, {
+      isOwnedByCurrentWallet: false,
+      depositorBtcPubkey: FOREIGN_PUBKEY,
+      error: new Error("VP unreachable"),
+    });
+
+    const status = getActionStatus(result);
+
+    expect(status.type).toBe("disabled");
+    if (status.type !== "disabled") return;
+    expect(status.tooltip).toMatch(
+      /this btc vault was created with a different btc public key/i,
+    );
   });
 
   it("falls back to available when the vault has no known depositor pubkey", () => {

--- a/services/vault/src/components/deposit/actionStatus.ts
+++ b/services/vault/src/components/deposit/actionStatus.ts
@@ -32,37 +32,42 @@ export interface ActionAvailable {
 }
 
 /**
- * Action status when the would-be action is blocked by ownership mismatch.
- * The action button is still surfaced so the UI can render it disabled with
- * the tooltip explaining why.
+ * Action status when the vault is owned by a different wallet. `action` is
+ * present for states with a primary action (Sign, Broadcast, Refund, …) so
+ * the button can render dimmed; absent for pure-progress states (e.g.
+ * "awaiting BTC confirmation") — the card still dims and the tooltip still
+ * fires so unowned cards are always visually distinct.
  */
 export interface ActionDisabled {
   type: "disabled";
-  action: ActionButton;
+  action?: ActionButton;
   tooltip: string;
 }
 
 /**
- * Action status when no action should be rendered (no action exists for the
- * current state, or a polling error blocks it).
+ * Action status when there's nothing for the user to do — either the state
+ * has no current primary action (happy waiting path) or a polling error
+ * blocks it. Consumers render no button and don't dim the card.
  */
-export interface ActionUnavailable {
-  type: "unavailable";
+export interface ActionNoAction {
+  type: "noAction";
 }
 
 /**
  * Discriminated union for action status.
  */
-export type ActionStatus = ActionAvailable | ActionDisabled | ActionUnavailable;
+export type ActionStatus = ActionAvailable | ActionDisabled | ActionNoAction;
 
 /**
  * Determine action availability for a deposit.
  *
  * Resolution order:
- * 1. No action exists for this state, or a polling error blocks it → unavailable
- * 2. Action exists but the vault was created with a different wallet → disabled
- *    (the would-be action is surfaced so the UI can render it dimmed + tooltip)
- * 3. Otherwise → available
+ * 1. Vault created with a different wallet → disabled (dimmed + tooltip).
+ *    Surfaces the would-be action when one exists; otherwise the card
+ *    itself still dims so unowned cards are always visually distinct,
+ *    even on polling error or in pure-waiting states.
+ * 2. Polling error, or no action for this state → noAction.
+ * 3. Otherwise → available.
  */
 export function getActionStatus(
   pollingResult: DepositPollingResult,
@@ -70,22 +75,23 @@ export function getActionStatus(
   const { peginState, isOwnedByCurrentWallet, error, depositorBtcPubkey } =
     pollingResult;
 
+  // Ownership runs FIRST. It's derived from activity/indexer state, not
+  // from polling — and "this isn't your vault" is a stronger UI signal
+  // than "polling failed" or "no action right now", so unowned vaults
+  // dim + show the wallet-switch tooltip regardless of polling state.
+  // `isVaultOwnedByWallet` only returns false when both pubkeys are
+  // present and differ, so `depositorBtcPubkey` is guaranteed defined.
   const actionButton = getPrimaryActionButton(peginState);
-
-  if (error || !actionButton) {
-    return { type: "unavailable" };
-  }
-
-  // `isVaultOwnedByWallet` only returns false when both pubkeys are present
-  // and differ, so `depositorBtcPubkey` is guaranteed defined here. The
-  // explicit guard keeps TypeScript happy and stays defensive against future
-  // changes to the ownership predicate.
   if (!isOwnedByCurrentWallet && depositorBtcPubkey) {
     return {
       type: "disabled",
-      action: actionButton,
+      action: actionButton ?? undefined,
       tooltip: getWalletOwnershipWarning(depositorBtcPubkey),
     };
+  }
+
+  if (error || !actionButton) {
+    return { type: "noAction" };
   }
 
   return { type: "available", action: actionButton };

--- a/services/vault/src/components/simple/PendingDepositCard.tsx
+++ b/services/vault/src/components/simple/PendingDepositCard.tsx
@@ -84,9 +84,10 @@ export function PendingDepositCard({
   const broadcastSuppressed =
     !!suppressBroadcastAction &&
     (status.type === "available" || status.type === "disabled") &&
-    status.action.action === PeginAction.SIGN_AND_BROADCAST_TO_BITCOIN;
+    status.action?.action === PeginAction.SIGN_AND_BROADCAST_TO_BITCOIN;
   const hasAction =
-    (status.type === "available" || status.type === "disabled") &&
+    (status.type === "available" ||
+      (status.type === "disabled" && !!status.action)) &&
     !broadcastSuppressed;
   const isActionable = status.type === "available" && !broadcastSuppressed;
   const showArtifactDownload =
@@ -110,7 +111,7 @@ export function PendingDepositCard({
   };
 
   const actionLabel =
-    status.type === "available" || status.type === "disabled"
+    (status.type === "available" || status.type === "disabled") && status.action
       ? status.action.label
       : peginState.displayLabel;
   // `loading` is React Query's `isLoading` — true only on the very first fetch,

--- a/services/vault/src/components/simple/__tests__/BatchedDepositGroup.test.tsx
+++ b/services/vault/src/components/simple/__tests__/BatchedDepositGroup.test.tsx
@@ -59,7 +59,7 @@ const BROADCAST_AVAILABLE: ActionStatus = {
     label: "Broadcast Pre-Pegin",
   },
 };
-const NO_ACTION: ActionStatus = { type: "unavailable" };
+const NO_ACTION: ActionStatus = { type: "noAction" };
 
 function renderGroup(activities: VaultActivity[], onBroadcastClick = vi.fn()) {
   render(

--- a/services/vault/src/components/simple/__tests__/PendingDepositCard.test.tsx
+++ b/services/vault/src/components/simple/__tests__/PendingDepositCard.test.tsx
@@ -147,7 +147,7 @@ describe("PendingDepositCard — step gating during first load", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockIsArtifactDownloadAvailable.mockReturnValue(false);
-    mockGetActionStatus.mockReturnValue({ type: "unavailable", reasons: [] });
+    mockGetActionStatus.mockReturnValue({ type: "noAction" });
   });
 
   it("renders the step label once the first poll has resolved", () => {
@@ -197,11 +197,11 @@ describe("PendingDepositCard — disabled (ownership mismatch) surface", () => {
     expect(card).toHaveAttribute("data-disabled-tooltip", TOOLTIP);
   });
 
-  it("renders nothing in the action slot for unavailable status", () => {
+  it("renders nothing in the action slot for noAction status", () => {
     // For states with no action at all (e.g. ACTIVE vault with nothing to
     // do, or a polling error), the card should stay clean — no button, no
     // amber strip, no dimming.
-    mockGetActionStatus.mockReturnValue({ type: "unavailable" });
+    mockGetActionStatus.mockReturnValue({ type: "noAction" });
     renderCard(false);
 
     expect(screen.queryByRole("button")).not.toBeInTheDocument();


### PR DESCRIPTION
Cards for vaults you don't own (different BTC wallet) now dim and show the "connect with wallet X" tooltip in **any** state — including pure-progress states like "Awaiting Bitcoin confirmation" that used to render as if they were your own.

Root cause: `getActionStatus` checked ownership only after the no-action-button shortcut, so unowned vaults in waiting states fell through to `unavailable` (no dim, no tooltip).