### PR TITLE
feat(vault): source Aave borrow price from on-chain oracle

### DIFF
--- a/packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/__tests__/oracle.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/__tests__/oracle.test.ts
@@ -1,0 +1,74 @@
+import type { Address, PublicClient } from "viem";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  getOracleAddress,
+  getReservesPrices,
+  getReservesPricesSafe,
+} from "../oracle.js";
+
+const SPOKE = "0x0000000000000000000000000000000000000001" as Address;
+const ORACLE = "0x0000000000000000000000000000000000000002" as Address;
+
+function makeClient(
+  impl: (call: { functionName: string; args?: unknown[] }) => unknown,
+): PublicClient {
+  return {
+    readContract: vi.fn(
+      async (call: { functionName: string; args?: unknown[] }) => impl(call),
+    ),
+  } as unknown as PublicClient;
+}
+
+describe("getOracleAddress", () => {
+  it("returns the address from Spoke.ORACLE()", async () => {
+    const client = makeClient(({ functionName }) => {
+      if (functionName !== "ORACLE") throw new Error("unexpected call");
+      return ORACLE;
+    });
+    expect(await getOracleAddress(client, SPOKE)).toBe(ORACLE);
+  });
+});
+
+describe("getReservesPrices", () => {
+  it("returns the prices array unchanged", async () => {
+    const prices = [8_000_000_000_000n, 100_000_000n];
+    const client = makeClient(({ functionName }) => {
+      if (functionName !== "getReservesPrices") {
+        throw new Error("unexpected call");
+      }
+      return prices;
+    });
+    expect(await getReservesPrices(client, ORACLE, [1n, 2n])).toEqual(prices);
+  });
+
+  it("propagates the revert when any reserve in the batch is bad", async () => {
+    const client = makeClient(() => {
+      throw new Error("execution reverted");
+    });
+    await expect(getReservesPrices(client, ORACLE, [7n])).rejects.toThrow();
+  });
+});
+
+describe("getReservesPricesSafe", () => {
+  it("isolates per-reserve reverts and returns nulls in place", async () => {
+    const client = makeClient(({ args }) => {
+      const [ids] = args as [bigint[]];
+      if (ids[0] === 99n) throw new Error("execution reverted");
+      return [123_456_789n];
+    });
+    const out = await getReservesPricesSafe(client, ORACLE, [1n, 99n, 2n]);
+    expect(out).toEqual([
+      { reserveId: 1n, priceRaw: 123_456_789n, error: null },
+      { reserveId: 99n, priceRaw: null, error: expect.any(Error) },
+      { reserveId: 2n, priceRaw: 123_456_789n, error: null },
+    ]);
+  });
+
+  it("returns empty array when called with no reserves", async () => {
+    const client = makeClient(() => {
+      throw new Error("should not be called");
+    });
+    expect(await getReservesPricesSafe(client, ORACLE, [])).toEqual([]);
+  });
+});

--- a/packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/abis/AaveOracle.abi.json
+++ b/packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/abis/AaveOracle.abi.json
@@ -1,0 +1,33 @@
+[
+  {
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [{ "name": "", "type": "uint8" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "name": "reserveIds", "type": "uint256[]" }],
+    "name": "getReservesPrices",
+    "outputs": [{ "name": "", "type": "uint256[]" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "name": "reserveId", "type": "uint256" }],
+    "name": "getReserveSource",
+    "outputs": [{ "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "type": "error",
+    "name": "InvalidSource",
+    "inputs": [{ "name": "reserveId", "type": "uint256" }]
+  },
+  {
+    "type": "error",
+    "name": "InvalidPrice",
+    "inputs": [{ "name": "reserveId", "type": "uint256" }]
+  }
+]

--- a/packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/index.ts
@@ -16,6 +16,14 @@ export {
   hasDebt,
 } from "./spoke.js";
 
+// Oracle operations
+export {
+  getOracleAddress,
+  getReservesPrices,
+  getReservesPricesSafe,
+  type ReservePriceResult,
+} from "./oracle.js";
+
 // Transaction builders
 export {
   buildBorrowTx,

--- a/packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/oracle.ts
+++ b/packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/oracle.ts
@@ -1,0 +1,72 @@
+/**
+ * Read-only access to `IAaveOracle`. Prices are 8-decimal base units
+ * ($80,000 = 8_000_000_000_000n).
+ */
+
+import type { Address, PublicClient } from "viem";
+
+import AaveOracleABI from "./abis/AaveOracle.abi.json";
+import AaveSpokeABI from "./abis/AaveSpoke.abi.json";
+
+/** `Spoke.ORACLE` is `immutable`; the result is safe to cache forever. */
+export async function getOracleAddress(
+  publicClient: PublicClient,
+  spokeAddress: Address,
+): Promise<Address> {
+  const result = await publicClient.readContract({
+    address: spokeAddress,
+    abi: AaveSpokeABI,
+    functionName: "ORACLE",
+  });
+  return result as Address;
+}
+
+/** Batch read; reverts the WHOLE batch on the first bad reserve. */
+export async function getReservesPrices(
+  publicClient: PublicClient,
+  oracleAddress: Address,
+  reserveIds: bigint[],
+): Promise<bigint[]> {
+  const result = await publicClient.readContract({
+    address: oracleAddress,
+    abi: AaveOracleABI,
+    functionName: "getReservesPrices",
+    args: [reserveIds],
+  });
+  return result as bigint[];
+}
+
+export interface ReservePriceResult {
+  reserveId: bigint;
+  /** Raw 1e8 base units, or null on revert. */
+  priceRaw: bigint | null;
+  error: Error | null;
+}
+
+/** Per-reserve isolated read for display lists (one bad source ≠ whole list blank). */
+export async function getReservesPricesSafe(
+  publicClient: PublicClient,
+  oracleAddress: Address,
+  reserveIds: bigint[],
+): Promise<ReservePriceResult[]> {
+  return Promise.all(
+    reserveIds.map(
+      async (reserveId): Promise<ReservePriceResult> => {
+        try {
+          const [priceRaw] = await getReservesPrices(
+            publicClient,
+            oracleAddress,
+            [reserveId],
+          );
+          return { reserveId, priceRaw, error: null };
+        } catch (err) {
+          return {
+            reserveId,
+            priceRaw: null,
+            error: err instanceof Error ? err : new Error(String(err)),
+          };
+        }
+      },
+    ),
+  );
+}

--- a/packages/babylon-ts-sdk/src/tbv/integrations/aave/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/integrations/aave/index.ts
@@ -77,15 +77,19 @@ export {
   buildRepayTx,
   buildWithdrawCollateralsTx,
   getDynamicReserveConfig,
+  getOracleAddress,
   getPosition,
   getPositionSizeParams,
   getReserve,
+  getReservesPrices,
+  getReservesPricesSafe,
   getTargetHealthFactor,
   getUserAccountData,
   getUserPosition,
   getUserTotalDebt,
   hasCollateral,
   hasDebt,
+  type ReservePriceResult,
 } from "./clients/index.js";
 
 // Utilities

--- a/services/vault/src/applications/aave/clients/__tests__/aaveOracle.test.ts
+++ b/services/vault/src/applications/aave/clients/__tests__/aaveOracle.test.ts
@@ -1,0 +1,54 @@
+import {
+  getOracleAddress as sdkGetOracleAddress,
+  getReservesPrices as sdkGetReservesPrices,
+  getReservesPricesSafe as sdkGetReservesPricesSafe,
+} from "@babylonlabs-io/ts-sdk/tbv/integrations/aave";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  getOracleAddress,
+  getReservesPrices,
+  getReservesPricesSafe,
+} from "../aaveOracle";
+
+// vitest hoists vi.mock above imports automatically.
+vi.mock("@babylonlabs-io/ts-sdk/tbv/integrations/aave", () => ({
+  getOracleAddress: vi.fn(),
+  getReservesPrices: vi.fn(),
+  getReservesPricesSafe: vi.fn(),
+}));
+
+const FAKE_CLIENT = { __id: "fake-public-client" } as const;
+vi.mock("../../../../clients/eth-contract/client", () => ({
+  ethClient: { getPublicClient: () => FAKE_CLIENT },
+}));
+
+const SPOKE = "0x0000000000000000000000000000000000000001" as const;
+const ORACLE = "0x0000000000000000000000000000000000000002" as const;
+
+describe("vault aaveOracle wrapper", () => {
+  it("forwards getOracleAddress to the SDK with the injected client", async () => {
+    vi.mocked(sdkGetOracleAddress).mockResolvedValueOnce(ORACLE);
+    expect(await getOracleAddress(SPOKE)).toBe(ORACLE);
+    expect(sdkGetOracleAddress).toHaveBeenCalledWith(FAKE_CLIENT, SPOKE);
+  });
+
+  it("forwards getReservesPrices", async () => {
+    vi.mocked(sdkGetReservesPrices).mockResolvedValueOnce([8_000_000_000_000n]);
+    expect(await getReservesPrices(ORACLE, [1n])).toEqual([8_000_000_000_000n]);
+    expect(sdkGetReservesPrices).toHaveBeenCalledWith(FAKE_CLIENT, ORACLE, [
+      1n,
+    ]);
+  });
+
+  it("forwards getReservesPricesSafe", async () => {
+    vi.mocked(sdkGetReservesPricesSafe).mockResolvedValueOnce([
+      { reserveId: 1n, priceRaw: 100_000_000n, error: null },
+    ]);
+    const out = await getReservesPricesSafe(ORACLE, [1n]);
+    expect(out[0]?.priceRaw).toBe(100_000_000n);
+    expect(sdkGetReservesPricesSafe).toHaveBeenCalledWith(FAKE_CLIENT, ORACLE, [
+      1n,
+    ]);
+  });
+});

--- a/services/vault/src/applications/aave/clients/aaveOracle.ts
+++ b/services/vault/src/applications/aave/clients/aaveOracle.ts
@@ -1,0 +1,41 @@
+/** Vault-side wrapper that injects `ethClient` into the SDK oracle reads. */
+
+import {
+  getOracleAddress as sdkGetOracleAddress,
+  getReservesPrices as sdkGetReservesPrices,
+  getReservesPricesSafe as sdkGetReservesPricesSafe,
+  type ReservePriceResult,
+} from "@babylonlabs-io/ts-sdk/tbv/integrations/aave";
+import type { Address } from "viem";
+
+import { ethClient } from "../../../clients/eth-contract/client";
+
+export async function getOracleAddress(
+  spokeAddress: Address,
+): Promise<Address> {
+  return sdkGetOracleAddress(ethClient.getPublicClient(), spokeAddress);
+}
+
+export async function getReservesPrices(
+  oracleAddress: Address,
+  reserveIds: bigint[],
+): Promise<bigint[]> {
+  return sdkGetReservesPrices(
+    ethClient.getPublicClient(),
+    oracleAddress,
+    reserveIds,
+  );
+}
+
+export async function getReservesPricesSafe(
+  oracleAddress: Address,
+  reserveIds: bigint[],
+): Promise<ReservePriceResult[]> {
+  return sdkGetReservesPricesSafe(
+    ethClient.getPublicClient(),
+    oracleAddress,
+    reserveIds,
+  );
+}
+
+export type { ReservePriceResult };

--- a/services/vault/src/applications/aave/clients/index.ts
+++ b/services/vault/src/applications/aave/clients/index.ts
@@ -1,3 +1,9 @@
+export {
+  getOracleAddress,
+  getReservesPrices,
+  getReservesPricesSafe,
+  type ReservePriceResult,
+} from "./aaveOracle";
 export * as AaveSpoke from "./spoke";
 export type { AaveSpokeUserAccountData, AaveSpokeUserPosition } from "./spoke";
 export * as AaveAdapterTx from "./transaction";

--- a/services/vault/src/applications/aave/components/AssetSelectionModal/AssetSelectionModal.tsx
+++ b/services/vault/src/applications/aave/components/AssetSelectionModal/AssetSelectionModal.tsx
@@ -8,12 +8,13 @@ import {
   DialogHeader,
   ResponsiveDialog,
 } from "@babylonlabs-io/core-ui";
+import { useMemo } from "react";
 
-import { usePrices } from "@/hooks";
 import { getTokenByAddress } from "@/services/token/tokenService";
 
 import { LOAN_TAB, type LoanTab } from "../../constants";
 import { useAaveConfig } from "../../context";
+import { useAaveReservesPrices } from "../../hooks";
 import type { Asset } from "../../types";
 
 import { AssetListItem } from "./AssetListItem";
@@ -49,8 +50,15 @@ export function AssetSelectionModal({
   mode = LOAN_TAB.BORROW,
   assets,
 }: AssetSelectionModalProps) {
-  const { borrowableReserves } = useAaveConfig();
-  const { prices, isLoading } = usePrices();
+  const { config: aaveConfig, borrowableReserves } = useAaveConfig();
+  const reserveIds = useMemo(
+    () => borrowableReserves.map((r) => r.reserveId),
+    [borrowableReserves],
+  );
+  const { pricesByReserveId, isLoading } = useAaveReservesPrices({
+    spokeAddress: aaveConfig?.coreSpokeAddress,
+    reserveIds,
+  });
   const config = MODE_CONFIG[mode];
 
   const handleAssetClick = (assetSymbol: string) => {
@@ -97,7 +105,8 @@ export function AssetSelectionModal({
 
     return borrowableReserves.map((reserve) => {
       const tokenMetadata = getTokenByAddress(reserve.token.address);
-      const priceUsd = prices[reserve.token.symbol];
+      const priceUsd =
+        pricesByReserveId[reserve.reserveId.toString()] ?? undefined;
       return (
         <AssetListItem
           key={reserve.reserveId.toString()}

--- a/services/vault/src/applications/aave/components/Detail/hooks/__tests__/useAaveReserveDetail.test.tsx
+++ b/services/vault/src/applications/aave/components/Detail/hooks/__tests__/useAaveReserveDetail.test.tsx
@@ -67,20 +67,6 @@ vi.mock("@/services/token/tokenService", () => ({
   ),
 }));
 
-// Mock usePrices — returns Chainlink oracle prices
-const mockUsePrices = vi.fn(() => ({
-  prices: {} as Record<string, number>,
-  metadata: {},
-  isLoading: false,
-  error: null as Error | null,
-  hasStalePrices: false,
-  hasPriceFetchError: false,
-}));
-
-vi.mock("@/hooks/usePrices", () => ({
-  usePrices: () => mockUsePrices(),
-}));
-
 // Mock useAaveConfig
 const mockUseAaveConfig = vi.fn(() => ({
   config: {
@@ -122,7 +108,8 @@ vi.mock("../../../../context", () => ({
   useAaveConfig: () => mockUseAaveConfig(),
 }));
 
-// Mock useAaveUserPosition
+// Mock useAaveUserPosition / useVaultSplitParams / useAaveReservePrice via
+// the barrel they're imported from in useAaveReserveDetail.ts.
 const mockUseAaveUserPosition = vi.fn<(addr?: string) => unknown>(() => ({
   position: null,
   collateralValueUsd: 15000,
@@ -135,7 +122,6 @@ const mockUseAaveUserPosition = vi.fn<(addr?: string) => unknown>(() => ({
   refetch: vi.fn(),
 }));
 
-// Mock useVaultSplitParams
 const mockUseVaultSplitParams = vi.fn<(addr?: string) => unknown>(() => ({
   params: { THF: 1.1, CF: 0.75, LB: 1.05 },
   isLoading: false,
@@ -143,9 +129,28 @@ const mockUseVaultSplitParams = vi.fn<(addr?: string) => unknown>(() => ({
   refetch: vi.fn(),
 }));
 
+const mockUseAaveReservePrice = vi.fn<
+  (args: {
+    spokeAddress: Address | undefined;
+    reserveId: bigint | undefined;
+  }) => {
+    priceUsd: number | null;
+    isLoading: boolean;
+    error: Error | null;
+  }
+>(() => ({
+  priceUsd: null,
+  isLoading: false,
+  error: null,
+}));
+
 vi.mock("../../../../hooks", () => ({
   useAaveUserPosition: (addr?: string) => mockUseAaveUserPosition(addr),
   useVaultSplitParams: (addr?: string) => mockUseVaultSplitParams(addr),
+  useAaveReservePrice: (args: {
+    spokeAddress: Address | undefined;
+    reserveId: bigint | undefined;
+  }) => mockUseAaveReservePrice(args),
 }));
 
 // Import after mocks
@@ -166,17 +171,12 @@ describe("useAaveReserveDetail", () => {
     });
     vi.clearAllMocks();
 
-    // Reset network to signet (default for tests)
     mockGetBTCNetwork.mockReturnValue("signet");
 
-    // Reset to default mock values
-    mockUsePrices.mockReturnValue({
-      prices: {},
-      metadata: {},
+    mockUseAaveReservePrice.mockReturnValue({
+      priceUsd: null,
       isLoading: false,
       error: null,
-      hasStalePrices: false,
-      hasPriceFetchError: false,
     });
     mockUseVaultSplitParams.mockReturnValue({
       params: { THF: 1.1, CF: 0.75, LB: 1.05 },
@@ -197,16 +197,13 @@ describe("useAaveReserveDetail", () => {
     });
   });
 
-  // --- Token price from Chainlink (#131 / #1391) ---
+  // --- Token price from Aave on-chain oracle ---
 
-  it("returns Chainlink price when available", () => {
-    mockUsePrices.mockReturnValue({
-      prices: { USDC: 0.9998 },
-      metadata: {},
+  it("returns the Aave oracle price when present", () => {
+    mockUseAaveReservePrice.mockReturnValue({
+      priceUsd: 0.9998,
       isLoading: false,
       error: null,
-      hasStalePrices: false,
-      hasPriceFetchError: false,
     });
 
     const { result } = renderHook(
@@ -217,35 +214,11 @@ describe("useAaveReserveDetail", () => {
     expect(result.current.tokenPriceUsd).toBe(0.9998);
   });
 
-  it("falls back to $1 for known stablecoin on testnet when Chainlink feed is absent", async () => {
-    // getBTCNetwork returns "signet" by default in our mock
-    mockUsePrices.mockReturnValue({
-      prices: {},
-      metadata: {},
+  it("returns null when oracle returns null (no testnet fallback)", () => {
+    mockUseAaveReservePrice.mockReturnValue({
+      priceUsd: null,
       isLoading: false,
       error: null,
-      hasStalePrices: false,
-      hasPriceFetchError: false,
-    });
-
-    const { result } = renderHook(
-      () => useAaveReserveDetail({ reserveId: "USDC", address: "0xUser" }),
-      { wrapper },
-    );
-
-    expect(result.current.tokenPriceUsd).toBe(1.0);
-  });
-
-  it("returns null for stablecoin on mainnet when Chainlink price is missing", () => {
-    mockGetBTCNetwork.mockReturnValue("mainnet");
-
-    mockUsePrices.mockReturnValue({
-      prices: {},
-      metadata: {},
-      isLoading: false,
-      error: null,
-      hasStalePrices: false,
-      hasPriceFetchError: false,
     });
 
     const { result } = renderHook(
@@ -256,18 +229,11 @@ describe("useAaveReserveDetail", () => {
     expect(result.current.tokenPriceUsd).toBeNull();
   });
 
-  it("returns null when Chainlink price is stale on mainnet", () => {
-    mockGetBTCNetwork.mockReturnValue("mainnet");
-
-    mockUsePrices.mockReturnValue({
-      prices: { USDC: 0.9998 },
-      metadata: {
-        USDC: { isStale: true, ageSeconds: 7200, fetchFailed: false },
-      },
+  it("returns null when oracle errors (no testnet fallback)", () => {
+    mockUseAaveReservePrice.mockReturnValue({
+      priceUsd: null,
       isLoading: false,
-      error: null,
-      hasStalePrices: true,
-      hasPriceFetchError: false,
+      error: new Error("oracle revert"),
     });
 
     const { result } = renderHook(
@@ -278,55 +244,7 @@ describe("useAaveReserveDetail", () => {
     expect(result.current.tokenPriceUsd).toBeNull();
   });
 
-  it("returns null when Chainlink fetch failed on mainnet", () => {
-    mockGetBTCNetwork.mockReturnValue("mainnet");
-
-    mockUsePrices.mockReturnValue({
-      prices: { USDC: 1.0 },
-      metadata: {
-        USDC: {
-          isStale: false,
-          ageSeconds: 0,
-          fetchFailed: true,
-          error: "RPC timeout",
-        },
-      },
-      isLoading: false,
-      error: null,
-      hasStalePrices: false,
-      hasPriceFetchError: true,
-    });
-
-    const { result } = renderHook(
-      () => useAaveReserveDetail({ reserveId: "USDC", address: "0xUser" }),
-      { wrapper },
-    );
-
-    expect(result.current.tokenPriceUsd).toBeNull();
-  });
-
-  it("falls back to $1 for stale stablecoin price on testnet", () => {
-    // getBTCNetwork returns signet (1) by default
-    mockUsePrices.mockReturnValue({
-      prices: { USDC: 0.9998 },
-      metadata: {
-        USDC: { isStale: true, ageSeconds: 7200, fetchFailed: false },
-      },
-      isLoading: false,
-      error: null,
-      hasStalePrices: true,
-      hasPriceFetchError: false,
-    });
-
-    const { result } = renderHook(
-      () => useAaveReserveDetail({ reserveId: "USDC", address: "0xUser" }),
-      { wrapper },
-    );
-
-    expect(result.current.tokenPriceUsd).toBe(1.0);
-  });
-
-  it("returns null for unknown token without Chainlink price", () => {
+  it("returns null for a non-stablecoin reserve on testnet when oracle is unavailable", () => {
     mockUseAaveConfig.mockReturnValue({
       config: {
         coreSpokeAddress: "0xSpokeAddress",
@@ -367,13 +285,10 @@ describe("useAaveReserveDetail", () => {
         },
       ],
     });
-    mockUsePrices.mockReturnValue({
-      prices: {},
-      metadata: {},
+    mockUseAaveReservePrice.mockReturnValue({
+      priceUsd: null,
       isLoading: false,
       error: null,
-      hasStalePrices: false,
-      hasPriceFetchError: false,
     });
 
     const { result } = renderHook(
@@ -428,7 +343,6 @@ describe("useAaveReserveDetail", () => {
   });
 
   it("handles CF values that could produce floating-point imprecision", () => {
-    // 0.8333 * 10000 = 8333.0 in most cases, but test the rounding
     mockUseVaultSplitParams.mockReturnValue({
       params: { THF: 1.1, CF: 0.8333, LB: 1.05 },
       isLoading: false,
@@ -446,13 +360,10 @@ describe("useAaveReserveDetail", () => {
   // --- Loading state ---
 
   it("includes prices loading in isLoading", () => {
-    mockUsePrices.mockReturnValue({
-      prices: {},
-      metadata: {},
+    mockUseAaveReservePrice.mockReturnValue({
+      priceUsd: null,
       isLoading: true,
       error: null,
-      hasStalePrices: false,
-      hasPriceFetchError: false,
     });
 
     const { result } = renderHook(
@@ -479,13 +390,10 @@ describe("useAaveReserveDetail", () => {
   });
 
   it("is not loading when all sources have resolved", () => {
-    mockUsePrices.mockReturnValue({
-      prices: { USDC: 1.0 },
-      metadata: {},
+    mockUseAaveReservePrice.mockReturnValue({
+      priceUsd: 1.0,
       isLoading: false,
       error: null,
-      hasStalePrices: false,
-      hasPriceFetchError: false,
     });
     mockUseVaultSplitParams.mockReturnValue({
       params: { THF: 1.1, CF: 0.75, LB: 1.05 },
@@ -550,15 +458,12 @@ describe("useAaveReserveDetail", () => {
     expect(result.current.ancillaryError).toBeNull();
   });
 
-  it("propagates pricesError as ancillaryError (soft-warn, not a hard block)", () => {
-    const pricesError = new Error("Chainlink RPC failure");
-    mockUsePrices.mockReturnValue({
-      prices: {},
-      metadata: {},
+  it("propagates oracle pricesError as ancillaryError (soft-warn, not a hard block)", () => {
+    const pricesError = new Error("Oracle RPC failure");
+    mockUseAaveReservePrice.mockReturnValue({
+      priceUsd: null,
       isLoading: false,
       error: pricesError,
-      hasStalePrices: false,
-      hasPriceFetchError: true,
     });
 
     const { result } = renderHook(

--- a/services/vault/src/applications/aave/components/Detail/hooks/useAaveReserveDetail.ts
+++ b/services/vault/src/applications/aave/components/Detail/hooks/useAaveReserveDetail.ts
@@ -4,28 +4,25 @@
  * Fetches and combines:
  * - Reserve config from Aave
  * - User position data (with position-specific collateral factor)
- * - Chainlink oracle prices for borrow token
+ * - Aave on-chain oracle price for the selected borrow token
  * - Asset metadata for display
  */
 
-import { Network } from "@babylonlabs-io/wallet-connector";
 import { useMemo } from "react";
 import { formatUnits } from "viem";
 
-import { getBTCNetwork } from "@/config";
-import { usePrices } from "@/hooks/usePrices";
 import {
   getCurrencyIconWithFallback,
   getTokenByAddress,
 } from "@/services/token/tokenService";
 
-import {
-  BPS_SCALE,
-  KNOWN_STABLECOIN_SYMBOLS,
-  STABLECOIN_FALLBACK_PRICE_USD,
-} from "../../../constants";
+import { BPS_SCALE } from "../../../constants";
 import { useAaveConfig } from "../../../context";
-import { useAaveUserPosition, useVaultSplitParams } from "../../../hooks";
+import {
+  useAaveReservePrice,
+  useAaveUserPosition,
+  useVaultSplitParams,
+} from "../../../hooks";
 import type { VaultSplitParams } from "../../../hooks/useVaultSplitParams";
 import type { AavePositionWithLiveData } from "../../../services";
 import type { AaveReserveConfig } from "../../../services/fetchConfig";
@@ -90,7 +87,7 @@ export function useAaveReserveDetail({
   reserveId,
   address,
 }: UseAaveReserveDetailProps): UseAaveReserveDetailResult {
-  const { vbtcReserve, allBorrowReserves } = useAaveConfig();
+  const { config, vbtcReserve, allBorrowReserves } = useAaveConfig();
 
   // Find the selected reserve by symbol (from URL param). Match against the
   // full reserve set, not just borrowable ones - a user reaching this page
@@ -130,13 +127,15 @@ export function useAaveReserveDetail({
     refetch: refetchPosition,
   } = useAaveUserPosition(address);
 
-  // Chainlink oracle prices (cached app-wide via React Query)
+  // Aave on-chain oracle — source of liquidation truth, so FE checks can't drift.
   const {
-    prices: chainlinkPrices,
-    metadata: priceMetadata,
+    priceUsd: aavePriceUsd,
     isLoading: pricesLoading,
     error: pricesError,
-  } = usePrices();
+  } = useAaveReservePrice({
+    spokeAddress: config?.coreSpokeAddress,
+    reserveId: selectedReserve?.reserveId,
+  });
 
   // Position-specific collateral factor from contract
   const {
@@ -177,37 +176,15 @@ export function useAaveReserveDetail({
     ? Math.round(splitParams.CF * BPS_SCALE)
     : 0;
 
-  // Look up token price from Chainlink oracle. On testnet where stablecoin
-  // feeds are unavailable, fall back to $1 for known stablecoins only.
-  const tokenPriceUsd = useMemo((): number | null => {
-    if (!selectedReserve) return null;
-
-    const symbol = selectedReserve.token.symbol.toUpperCase();
-    const price = chainlinkPrices[symbol];
-    const metadata = priceMetadata[symbol];
-
-    // Reject stale or failed prices — a stale feed during a depeg event
-    // would produce an inflated max-borrow / HF
-    // Treat stale/failed the same as missing.
-    const isPriceReliable = !metadata?.isStale && !metadata?.fetchFailed;
-
-    if (price != null && price > 0 && isPriceReliable) {
-      return price;
-    }
-
-    // Testnet/signet: Chainlink doesn't publish stablecoin feeds on Sepolia.
-    // $1 is correct for mock-pegged test tokens. On mainnet a missing price
-    // is a real error — return null so the UI blocks the borrow flow.
-    const isKnownStablecoin = (
-      KNOWN_STABLECOIN_SYMBOLS as readonly string[]
-    ).includes(symbol);
-
-    if (getBTCNetwork() !== Network.MAINNET && isKnownStablecoin) {
-      return STABLECOIN_FALLBACK_PRICE_USD;
-    }
-
-    return null;
-  }, [selectedReserve, chainlinkPrices, priceMetadata]);
+  // Trust the Aave oracle; do not substitute. A null/error here disables
+  // borrow downstream rather than masking a misconfigured reserve.
+  const tokenPriceUsd = useMemo(
+    (): number | null =>
+      selectedReserve && aavePriceUsd != null && aavePriceUsd > 0
+        ? aavePriceUsd
+        : null,
+    [selectedReserve, aavePriceUsd],
+  );
 
   return {
     isLoading: positionLoading || pricesLoading || splitParamsLoading,

--- a/services/vault/src/applications/aave/components/Detail/index.tsx
+++ b/services/vault/src/applications/aave/components/Detail/index.tsx
@@ -14,6 +14,8 @@ import { getNetworkConfigBTC } from "@/config";
 import { useConnection, useETHWallet } from "@/context/wallet";
 
 import { LOAN_TAB } from "../../constants";
+import { useAaveConfig } from "../../context";
+import { useAaveOracleAddress } from "../../hooks";
 import { LoanProvider } from "../context/LoanContext";
 import { LoanCard } from "../LoanCard";
 import { BorrowSuccessModal } from "../LoanCard/Borrow/SuccessModal";
@@ -36,6 +38,11 @@ export function AaveReserveDetail() {
 
   const { isConnected } = useConnection();
   const { address } = useETHWallet();
+  const { config } = useAaveConfig();
+  // Loading/error surfaces via useAaveReservePrice (shared cache key).
+  const { oracleAddress } = useAaveOracleAddress({
+    spokeAddress: config?.coreSpokeAddress,
+  });
 
   // Fetch reserve and position data
   const {
@@ -81,7 +88,6 @@ export function AaveReserveDetail() {
     navigate("/");
   };
 
-  // Loading state
   if (isLoading) {
     return (
       <Container className={`${PAGE_CONTENT_CLASS} pb-6`}>
@@ -114,7 +120,7 @@ export function AaveReserveDetail() {
     );
   }
 
-  // Reserve not found
+  // Don't gate on oracleAddress — repay doesn't need it; lookup failure surfaces via ancillaryError on Borrow.
   if (!selectedReserve || !assetConfig || !vbtcReserve) {
     return (
       <Container className={`${PAGE_CONTENT_CLASS} pb-6`}>
@@ -128,7 +134,6 @@ export function AaveReserveDetail() {
     );
   }
 
-  // Build loan context with all data needed by Borrow/Repay components
   const loanContextValue = {
     collateralValueUsd,
     currentDebtAmount,
@@ -138,6 +143,7 @@ export function AaveReserveDetail() {
     selectedReserve,
     assetConfig,
     proxyContract,
+    oracleAddress,
     tokenPriceUsd,
     isPositionDataStale,
     refetchPosition,

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/__tests__/validateBorrowPreSign.test.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/__tests__/validateBorrowPreSign.test.ts
@@ -2,13 +2,25 @@ import {
   AAVE_BASE_CURRENCY_DECIMALS,
   AAVE_BASE_CURRENCY_RAY_DECIMALS,
 } from "@babylonlabs-io/ts-sdk/tbv/integrations/aave";
-import { describe, expect, it, vi } from "vitest";
+import type { Address } from "viem";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
+vi.mock("../../../../../clients/aaveOracle", () => ({
+  getReservesPrices: vi.fn(),
+}));
+
+import { getReservesPrices } from "../../../../../clients/aaveOracle";
 import type { AavePositionWithLiveData } from "../../../../../services";
 import { validateBorrowPreSign } from "../validateBorrowPreSign";
 
+const ORACLE = "0x0000000000000000000000000000000000000002" as Address;
+const RESERVE_ID = 2n;
+
 const USD_COLLATERAL = 10n ** BigInt(AAVE_BASE_CURRENCY_DECIMALS);
 const USD_DEBT_RAY = 10n ** BigInt(AAVE_BASE_CURRENCY_RAY_DECIMALS);
+
+/** Aave oracle is 8-decimal. $1 = 100_000_000n. */
+const PRICE_1USD_RAW = 100_000_000n;
 
 function makePosition(
   collateralUsd: bigint,
@@ -23,22 +35,9 @@ function makePosition(
 }
 
 describe("validateBorrowPreSign", () => {
-  it("throws when token price is unavailable", async () => {
-    const refetchSplitParams = vi.fn();
-    const refetchPosition = vi.fn();
-
-    await expect(
-      validateBorrowPreSign({
-        borrowAmount: 100,
-        tokenPriceUsd: null,
-        liquidationThresholdBps: 7500,
-        refetchSplitParams,
-        refetchPosition,
-      }),
-    ).rejects.toThrow("Token price unavailable");
-
-    expect(refetchSplitParams).not.toHaveBeenCalled();
-    expect(refetchPosition).not.toHaveBeenCalled();
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getReservesPrices).mockResolvedValue([PRICE_1USD_RAW]);
   });
 
   it("throws when refetchSplitParams returns null", async () => {
@@ -48,7 +47,8 @@ describe("validateBorrowPreSign", () => {
     await expect(
       validateBorrowPreSign({
         borrowAmount: 100,
-        tokenPriceUsd: 1,
+        oracleAddress: ORACLE,
+        reserveId: RESERVE_ID,
         liquidationThresholdBps: 7500,
         refetchSplitParams,
         refetchPosition,
@@ -57,24 +57,16 @@ describe("validateBorrowPreSign", () => {
   });
 
   it("aborts when on-chain CF moved since the screen was rendered (auditor #260)", async () => {
-    // User's screen was rendered with CF=0.75 (=7500 BPS). Governance has
-    // since lowered CF to 0.70 — same dynamicConfigKey, so React Query
-    // would have kept the cached 0.75 without an explicit refetch.
-    const refetchSplitParams = vi.fn().mockResolvedValue({
-      THF: 1.1,
-      CF: 0.7,
-      LB: 1.05,
-    });
-    // The two refetches run in parallel (`Promise.all`) for click-path
-    // latency, so refetchPosition may be called even though we abort.
-    // What matters is that the validator throws and the user never reaches
-    // the `borrow(...)` call.
+    const refetchSplitParams = vi
+      .fn()
+      .mockResolvedValue({ THF: 1.1, CF: 0.7, LB: 1.05 });
     const refetchPosition = vi.fn().mockResolvedValue(null);
 
     await expect(
       validateBorrowPreSign({
         borrowAmount: 100,
-        tokenPriceUsd: 1,
+        oracleAddress: ORACLE,
+        reserveId: RESERVE_ID,
         liquidationThresholdBps: 7500,
         refetchSplitParams,
         refetchPosition,
@@ -83,17 +75,16 @@ describe("validateBorrowPreSign", () => {
   });
 
   it("skips revalidation when refetchPosition returns null (first borrow)", async () => {
-    const refetchSplitParams = vi.fn().mockResolvedValue({
-      THF: 1.1,
-      CF: 0.75,
-      LB: 1.05,
-    });
+    const refetchSplitParams = vi
+      .fn()
+      .mockResolvedValue({ THF: 1.1, CF: 0.75, LB: 1.05 });
     const refetchPosition = vi.fn().mockResolvedValue(null);
 
     await expect(
       validateBorrowPreSign({
         borrowAmount: 100,
-        tokenPriceUsd: 1,
+        oracleAddress: ORACLE,
+        reserveId: RESERVE_ID,
         liquidationThresholdBps: 7500,
         refetchSplitParams,
         refetchPosition,
@@ -105,14 +96,9 @@ describe("validateBorrowPreSign", () => {
   });
 
   it("uses fresh liquidationThresholdBps for HF computation", async () => {
-    // CF unchanged at 0.75 → fresh liquidationThresholdBps = 7500.
-    // Collateral: $10000, debt: $0, borrow: $1000 worth.
-    // HF = 10000 * 0.75 / 1000 = 7.5 — well above MIN_HEALTH_FACTOR_FOR_BORROW.
-    const refetchSplitParams = vi.fn().mockResolvedValue({
-      THF: 1.1,
-      CF: 0.75,
-      LB: 1.05,
-    });
+    const refetchSplitParams = vi
+      .fn()
+      .mockResolvedValue({ THF: 1.1, CF: 0.75, LB: 1.05 });
     const refetchPosition = vi
       .fn()
       .mockResolvedValue(makePosition(10000n * USD_COLLATERAL, 0n));
@@ -120,7 +106,8 @@ describe("validateBorrowPreSign", () => {
     await expect(
       validateBorrowPreSign({
         borrowAmount: 1000,
-        tokenPriceUsd: 1,
+        oracleAddress: ORACLE,
+        reserveId: RESERVE_ID,
         liquidationThresholdBps: 7500,
         refetchSplitParams,
         refetchPosition,
@@ -129,13 +116,9 @@ describe("validateBorrowPreSign", () => {
   });
 
   it("throws when projected HF would fall below MIN_HEALTH_FACTOR_FOR_BORROW", async () => {
-    // Collateral $1000 at 0.75 CF, no existing debt, borrow $999 worth.
-    // HF = 1000 * 0.75 / 999 ≈ 0.751 — well below the safety threshold.
-    const refetchSplitParams = vi.fn().mockResolvedValue({
-      THF: 1.1,
-      CF: 0.75,
-      LB: 1.05,
-    });
+    const refetchSplitParams = vi
+      .fn()
+      .mockResolvedValue({ THF: 1.1, CF: 0.75, LB: 1.05 });
     const refetchPosition = vi
       .fn()
       .mockResolvedValue(makePosition(1000n * USD_COLLATERAL, 0n));
@@ -143,7 +126,36 @@ describe("validateBorrowPreSign", () => {
     await expect(
       validateBorrowPreSign({
         borrowAmount: 999,
-        tokenPriceUsd: 1,
+        oracleAddress: ORACLE,
+        reserveId: RESERVE_ID,
+        liquidationThresholdBps: 7500,
+        refetchSplitParams,
+        refetchPosition,
+      }),
+    ).rejects.toThrow(/Projected health factor/);
+  });
+
+  it("uses the FRESH oracle price, not a cached UI value", async () => {
+    // The UI may have cached BTC at $80,000, but the oracle now returns
+    // $100,000. With $80,000 collateral at CF=0.75 and a 1.0-unit borrow,
+    // a stale-price projection would compute HF = 80000 * 0.75 / 80000 = 0.75
+    // and pass. The fresh-price projection computes
+    // HF = 80000 * 0.75 / 100000 = 0.6, below threshold — must throw.
+    vi.mocked(getReservesPrices).mockResolvedValueOnce([
+      100_000n * PRICE_1USD_RAW,
+    ]);
+    const refetchSplitParams = vi
+      .fn()
+      .mockResolvedValue({ THF: 1.1, CF: 0.75, LB: 1.05 });
+    const refetchPosition = vi
+      .fn()
+      .mockResolvedValue(makePosition(80_000n * USD_COLLATERAL, 0n));
+
+    await expect(
+      validateBorrowPreSign({
+        borrowAmount: 1,
+        oracleAddress: ORACLE,
+        reserveId: RESERVE_ID,
         liquidationThresholdBps: 7500,
         refetchSplitParams,
         refetchPosition,
@@ -160,7 +172,8 @@ describe("validateBorrowPreSign", () => {
     await expect(
       validateBorrowPreSign({
         borrowAmount: 100,
-        tokenPriceUsd: 1,
+        oracleAddress: ORACLE,
+        reserveId: RESERVE_ID,
         liquidationThresholdBps: 7500,
         refetchSplitParams,
         refetchPosition,
@@ -168,51 +181,43 @@ describe("validateBorrowPreSign", () => {
     ).rejects.toThrow("RPC failure");
   });
 
-  it("runs refetchSplitParams and refetchPosition in parallel for click-path latency", async () => {
-    // Both refetches should be in flight at the same time. We assert this
-    // by resolving them in the opposite order from what a serial impl would
-    // produce: refetchPosition resolves before refetchSplitParams.
+  it("runs all three refetches in parallel for click-path latency", async () => {
     const splitParamsCallStarted = vi.fn();
     const positionCallStarted = vi.fn();
+    const priceCallStarted = vi.fn();
 
     const refetchSplitParams = vi.fn(async () => {
       splitParamsCallStarted();
-      // Yield to the microtask queue so refetchPosition can also start.
       await Promise.resolve();
       return { THF: 1.1, CF: 0.75, LB: 1.05 };
     });
     const refetchPosition = vi.fn(async () => {
       positionCallStarted();
-      return null; // first-borrow path
+      return null;
+    });
+    vi.mocked(getReservesPrices).mockImplementation(async () => {
+      priceCallStarted();
+      return [PRICE_1USD_RAW];
     });
 
     await validateBorrowPreSign({
       borrowAmount: 100,
-      tokenPriceUsd: 1,
+      oracleAddress: ORACLE,
+      reserveId: RESERVE_ID,
       liquidationThresholdBps: 7500,
       refetchSplitParams,
       refetchPosition,
     });
 
-    // Both refetches must have been initiated before either resolved —
-    // i.e. both call counters were non-zero by the time the first
-    // microtask boundary was reached. With a serial implementation,
-    // refetchPosition would not have started until after the first await
-    // inside refetchSplitParams resolved.
     expect(splitParamsCallStarted).toHaveBeenCalledTimes(1);
     expect(positionCallStarted).toHaveBeenCalledTimes(1);
+    expect(priceCallStarted).toHaveBeenCalledTimes(1);
   });
 
   it("uses fresh debt from refetched position, not stale UI state", async () => {
-    // The original UI showed $0 debt; in reality the user already has
-    // $900 debt at the moment of signing — borrowing another $100 against
-    // $1000 collateral at 0.75 CF puts HF = 1000 * 0.75 / 1000 = 0.75
-    // (below threshold). Validator must catch this using the FRESH debt.
-    const refetchSplitParams = vi.fn().mockResolvedValue({
-      THF: 1.1,
-      CF: 0.75,
-      LB: 1.05,
-    });
+    const refetchSplitParams = vi
+      .fn()
+      .mockResolvedValue({ THF: 1.1, CF: 0.75, LB: 1.05 });
     const refetchPosition = vi
       .fn()
       .mockResolvedValue(
@@ -222,7 +227,8 @@ describe("validateBorrowPreSign", () => {
     await expect(
       validateBorrowPreSign({
         borrowAmount: 100,
-        tokenPriceUsd: 1,
+        oracleAddress: ORACLE,
+        reserveId: RESERVE_ID,
         liquidationThresholdBps: 7500,
         refetchSplitParams,
         refetchPosition,

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/validateBorrowPreSign.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/validateBorrowPreSign.ts
@@ -1,15 +1,12 @@
 /**
- * Borrow pre-sign validation
- *
- * Runs immediately before submitting a borrow transaction. Refetches the
- * on-chain risk parameters (CF / THF / LB) and the user's position from the
- * contract — the cached values displayed in the UI may be up to
- * `CONFIG_STALE_TIME_MS` old, and React Query's query key does not change
- * when CF is updated for the same `dynamicConfigKey`. Without this refetch
- * a governance/operator update that lowered CF would let the user sign a
- * borrow whose UI safety check ran against an obsolete threshold (auditor
- * finding #260).
+ * Refetches every signing input from chain at submit time: CF/THF/LB
+ * (audit #260), account position, and the oracle price. Without the
+ * fresh oracle read, the React Query cache was the only input that could
+ * stay up to 60s stale through a price move.
  */
+import type { Address } from "viem";
+
+import { getReservesPrices } from "../../../../clients/aaveOracle";
 import { MIN_HEALTH_FACTOR_FOR_BORROW } from "../../../../constants";
 import type { VaultSplitParams } from "../../../../hooks/useVaultSplitParams";
 import type { AavePositionWithLiveData } from "../../../../services";
@@ -20,9 +17,15 @@ import {
   calculateHealthFactor,
 } from "../../../../utils";
 
+/** Aave oracle base unit (Spoke.ORACLE_DECIMALS = 8). */
+const ORACLE_SCALE = 1e8;
+
 export interface ValidateBorrowPreSignDeps {
   borrowAmount: number;
-  tokenPriceUsd: number | null;
+  /** Aave on-chain oracle address (resolved upstream and cached). */
+  oracleAddress: Address;
+  /** Reserve ID of the borrow asset. */
+  reserveId: bigint;
   /**
    * Liquidation threshold (in BPS) the user saw on the displayed metrics.
    * Compared against the freshly-fetched value to detect on-chain CF moves
@@ -33,32 +36,25 @@ export interface ValidateBorrowPreSignDeps {
   refetchPosition: () => Promise<AavePositionWithLiveData | null>;
 }
 
-/**
- * Throws if it is not safe to proceed with the borrow:
- *  - token price unavailable
- *  - split params could not be refetched
- *  - on-chain CF moved since the screen was rendered
- *  - projected post-borrow HF would fall below `MIN_HEALTH_FACTOR_FOR_BORROW`
- */
+/** Throws if the projected post-borrow HF would fall below MIN_HEALTH_FACTOR_FOR_BORROW, or any input is stale/missing. */
 export async function validateBorrowPreSign({
   borrowAmount,
-  tokenPriceUsd,
+  oracleAddress,
+  reserveId,
   liquidationThresholdBps,
   refetchSplitParams,
   refetchPosition,
 }: ValidateBorrowPreSignDeps): Promise<void> {
-  if (tokenPriceUsd == null) {
-    throw new Error("Token price unavailable. Cannot validate borrow.");
-  }
+  // AaveOracle reverts on missing source or non-positive underlying price
+  // (`InvalidSource` / `InvalidPrice`), so a returned value is always > 0.
+  const [{ freshLiquidationThresholdBps }, freshPosition, freshPriceRaw] =
+    await Promise.all([
+      assertCfUnchanged({ liquidationThresholdBps, refetchSplitParams }),
+      refetchPosition(),
+      getReservesPrices(oracleAddress, [reserveId]).then(([raw]) => raw),
+    ]);
 
-  // The two refetches are independent contract reads. Parallelizing halves
-  // the click-path latency. If `assertCfUnchanged` aborts, the in-flight
-  // position refetch result is discarded — one wasted eth_call in the rare
-  // CF-changed path is cheaper than serializing every borrow click.
-  const [{ freshLiquidationThresholdBps }, freshPosition] = await Promise.all([
-    assertCfUnchanged({ liquidationThresholdBps, refetchSplitParams }),
-    refetchPosition(),
-  ]);
+  const freshTokenPriceUsd = Number(freshPriceRaw) / ORACLE_SCALE;
 
   if (!freshPosition) return; // No position = first borrow, skip revalidation
 
@@ -68,7 +64,7 @@ export async function validateBorrowPreSign({
   const freshDebtUsd = aaveRayValueToUsd(
     freshPosition.accountData.totalDebtValueRay,
   );
-  const projectedDebtUsd = freshDebtUsd + borrowAmount * tokenPriceUsd;
+  const projectedDebtUsd = freshDebtUsd + borrowAmount * freshTokenPriceUsd;
   const projectedHF = calculateHealthFactor(
     freshCollateralUsd,
     projectedDebtUsd,

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/index.tsx
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/index.tsx
@@ -40,6 +40,7 @@ export function Borrow() {
     liquidationThresholdBps,
     selectedReserve,
     assetConfig,
+    oracleAddress,
     tokenPriceUsd,
     isPositionDataStale,
     refetchPosition,
@@ -80,10 +81,13 @@ export function Borrow() {
   const sliderTrackMax = maxBorrowAmount > 0 ? maxBorrowAmount : MIN_SLIDER_MAX;
 
   const handleBorrow = async () => {
+    // Defensive: the disabled prop already gates on `oracleAddress == null`.
+    if (oracleAddress == null) return;
     const success = await executeBorrow(borrowAmount, selectedReserve, () =>
       validateBorrowPreSign({
         borrowAmount,
-        tokenPriceUsd,
+        oracleAddress,
+        reserveId: selectedReserve.reserveId,
         liquidationThresholdBps,
         refetchSplitParams,
         refetchPosition,
@@ -168,11 +172,12 @@ export function Borrow() {
             Borrowing is temporarily unavailable. Please check back later.
           </Text>
         )}
-        {tokenPriceUsd == null && !FeatureFlags.isBorrowDisabled && (
-          <Text variant="body2" className="text-center text-warning-main">
-            Price data unavailable. Borrowing is temporarily disabled.
-          </Text>
-        )}
+        {(tokenPriceUsd == null || oracleAddress == null) &&
+          !FeatureFlags.isBorrowDisabled && (
+            <Text variant="body2" className="text-center text-warning-main">
+              Price data unavailable. Borrowing is temporarily disabled.
+            </Text>
+          )}
       </div>
 
       {/* Borrow Button */}
@@ -185,7 +190,8 @@ export function Borrow() {
           isDisabled ||
           isProcessing ||
           FeatureFlags.isBorrowDisabled ||
-          tokenPriceUsd == null
+          tokenPriceUsd == null ||
+          oracleAddress == null
         }
         onClick={handleBorrow}
         className="mt-6"

--- a/services/vault/src/applications/aave/components/context/LoanContext.tsx
+++ b/services/vault/src/applications/aave/components/context/LoanContext.tsx
@@ -6,6 +6,7 @@
  */
 
 import { createContext, useContext } from "react";
+import type { Address } from "viem";
 
 import type { VaultSplitParams } from "../../hooks/useVaultSplitParams";
 import type { AavePositionWithLiveData } from "../../services";
@@ -29,6 +30,12 @@ export interface LoanContextValue {
   assetConfig: Asset;
   /** User's proxy contract address (for debt queries) */
   proxyContract: string | undefined;
+  /**
+   * Aave oracle address (cached forever; `Spoke.ORACLE` is immutable).
+   * Null while loading or on lookup error. The Borrow flow gates on this;
+   * Repay does not consume the oracle.
+   */
+  oracleAddress: Address | null;
   /** Price of the selected borrow token in USD (null when oracle price is temporarily unavailable) */
   tokenPriceUsd: number | null;
   /** Whether position data may be stale (oracle-derived values possibly outdated) */

--- a/services/vault/src/applications/aave/constants.ts
+++ b/services/vault/src/applications/aave/constants.ts
@@ -72,19 +72,6 @@ export const POSITION_REFETCH_INTERVAL_MS = 30 * 1000;
 export const POSITION_STALENESS_THRESHOLD_MS = POSITION_REFETCH_INTERVAL_MS * 3;
 
 /**
- * Fallback price for stablecoins on testnet/signet where Chainlink does not
- * publish price feeds. On mainnet, real Chainlink oracle prices are always used.
- */
-export const STABLECOIN_FALLBACK_PRICE_USD = 1.0;
-
-/**
- * Tokens eligible for the $1 testnet fallback when no Chainlink feed exists.
- * On mainnet, Chainlink feeds exist for all these tokens and the fallback
- * is never used.
- */
-export const KNOWN_STABLECOIN_SYMBOLS = ["USDC", "USDT", "DAI"] as const;
-
-/**
  * Minimum slider max value to prevent division by zero
  * when no vaults or borrow capacity available
  */

--- a/services/vault/src/applications/aave/hooks/__tests__/useAaveOracleAddress.test.tsx
+++ b/services/vault/src/applications/aave/hooks/__tests__/useAaveOracleAddress.test.tsx
@@ -1,0 +1,74 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import type { Address } from "viem";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../clients/aaveOracle", () => ({
+  getOracleAddress: vi.fn(),
+}));
+
+import { getOracleAddress } from "../../clients/aaveOracle";
+import { useAaveOracleAddress } from "../useAaveOracleAddress";
+
+const SPOKE_A = "0x0000000000000000000000000000000000000001" as Address;
+const SPOKE_B = "0x0000000000000000000000000000000000000003" as Address;
+const ORACLE_A = "0x0000000000000000000000000000000000000002" as Address;
+const ORACLE_B = "0x0000000000000000000000000000000000000004" as Address;
+
+function wrapperWith(client: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+function newClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+}
+
+describe("useAaveOracleAddress", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns the oracle address and caches across same-spoke rerenders", async () => {
+    vi.mocked(getOracleAddress).mockResolvedValueOnce(ORACLE_A);
+    const client = newClient();
+    const { result, rerender } = renderHook(
+      ({ spoke }: { spoke: Address }) =>
+        useAaveOracleAddress({ spokeAddress: spoke }),
+      { wrapper: wrapperWith(client), initialProps: { spoke: SPOKE_A } },
+    );
+    await waitFor(() => expect(result.current.oracleAddress).toBe(ORACLE_A));
+    rerender({ spoke: SPOKE_A });
+    expect(getOracleAddress).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-fetches when spokeAddress changes", async () => {
+    vi.mocked(getOracleAddress)
+      .mockResolvedValueOnce(ORACLE_A)
+      .mockResolvedValueOnce(ORACLE_B);
+    const client = newClient();
+    const { result, rerender } = renderHook(
+      ({ spoke }: { spoke: Address }) =>
+        useAaveOracleAddress({ spokeAddress: spoke }),
+      { wrapper: wrapperWith(client), initialProps: { spoke: SPOKE_A } },
+    );
+    await waitFor(() => expect(result.current.oracleAddress).toBe(ORACLE_A));
+    rerender({ spoke: SPOKE_B });
+    await waitFor(() => expect(result.current.oracleAddress).toBe(ORACLE_B));
+    expect(getOracleAddress).toHaveBeenCalledTimes(2);
+  });
+
+  it("is disabled when spokeAddress is undefined", () => {
+    const { result } = renderHook(
+      () => useAaveOracleAddress({ spokeAddress: undefined }),
+      { wrapper: wrapperWith(newClient()) },
+    );
+    expect(result.current.oracleAddress).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+    expect(getOracleAddress).not.toHaveBeenCalled();
+  });
+});

--- a/services/vault/src/applications/aave/hooks/__tests__/useAaveReservePrice.test.tsx
+++ b/services/vault/src/applications/aave/hooks/__tests__/useAaveReservePrice.test.tsx
@@ -1,0 +1,100 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../clients/aaveOracle", () => ({
+  getOracleAddress: vi.fn(),
+  getReservesPrices: vi.fn(),
+}));
+
+import { getOracleAddress, getReservesPrices } from "../../clients/aaveOracle";
+import { useAaveReservePrice } from "../useAaveReservePrice";
+
+const SPOKE = "0x0000000000000000000000000000000000000001" as const;
+const ORACLE = "0x0000000000000000000000000000000000000002" as const;
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe("useAaveReservePrice", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getOracleAddress).mockResolvedValue(ORACLE);
+  });
+
+  it("returns USD price scaled from 1e8 base units", async () => {
+    vi.mocked(getReservesPrices).mockResolvedValueOnce([8_000_000_000_000n]);
+    const { result } = renderHook(
+      () => useAaveReservePrice({ spokeAddress: SPOKE, reserveId: 1n }),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.priceUsd).toBe(80_000));
+    expect(result.current.error).toBeNull();
+  });
+
+  it("returns null priceUsd and surfaces the error on oracle revert", async () => {
+    vi.mocked(getReservesPrices).mockRejectedValueOnce(
+      new Error("execution reverted: InvalidSource(7)"),
+    );
+    const { result } = renderHook(
+      () => useAaveReservePrice({ spokeAddress: SPOKE, reserveId: 7n }),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.priceUsd).toBeNull();
+    expect(result.current.error).toBeInstanceOf(Error);
+  });
+
+  it("clears stale priceUsd after a refetch fails (no stale-price leak)", async () => {
+    // First fetch succeeds, then a forced refetch fails. React Query keeps
+    // the prior `data` populated alongside `error`; the hook must zero it
+    // out so downstream consumers don't display a price next to an error.
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    vi.mocked(getReservesPrices)
+      .mockResolvedValueOnce([8_000_000_000_000n])
+      .mockRejectedValueOnce(new Error("RPC failure"));
+
+    const wrapperWithClient = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+
+    const { result } = renderHook(
+      () => useAaveReservePrice({ spokeAddress: SPOKE, reserveId: 1n }),
+      { wrapper: wrapperWithClient },
+    );
+
+    await waitFor(() => expect(result.current.priceUsd).toBe(80_000));
+
+    await client.refetchQueries({ queryKey: ["aaveReservePrice"] });
+
+    await waitFor(() => expect(result.current.error).toBeInstanceOf(Error));
+    expect(result.current.priceUsd).toBeNull();
+  });
+
+  it("is disabled when reserveId is undefined", () => {
+    const { result } = renderHook(
+      () => useAaveReservePrice({ spokeAddress: SPOKE, reserveId: undefined }),
+      { wrapper },
+    );
+    expect(result.current.priceUsd).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+    expect(getReservesPrices).not.toHaveBeenCalled();
+  });
+
+  it("is disabled when spokeAddress is undefined", () => {
+    const { result } = renderHook(
+      () => useAaveReservePrice({ spokeAddress: undefined, reserveId: 1n }),
+      { wrapper },
+    );
+    expect(result.current.priceUsd).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+    expect(getOracleAddress).not.toHaveBeenCalled();
+  });
+});

--- a/services/vault/src/applications/aave/hooks/__tests__/useAaveReservesPrices.test.tsx
+++ b/services/vault/src/applications/aave/hooks/__tests__/useAaveReservesPrices.test.tsx
@@ -1,0 +1,94 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../clients/aaveOracle", () => ({
+  getOracleAddress: vi.fn(),
+  getReservesPricesSafe: vi.fn(),
+}));
+
+import {
+  getOracleAddress,
+  getReservesPricesSafe,
+} from "../../clients/aaveOracle";
+import { useAaveReservesPrices } from "../useAaveReservesPrices";
+
+const SPOKE = "0x0000000000000000000000000000000000000001" as const;
+const ORACLE = "0x0000000000000000000000000000000000000002" as const;
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe("useAaveReservesPrices", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getOracleAddress).mockResolvedValue(ORACLE);
+  });
+
+  it("returns a record keyed by reserveId, leaving bad reserves null", async () => {
+    vi.mocked(getReservesPricesSafe).mockResolvedValueOnce([
+      { reserveId: 1n, priceRaw: 8_000_000_000_000n, error: null },
+      { reserveId: 2n, priceRaw: null, error: new Error("reverted") },
+      { reserveId: 3n, priceRaw: 100_000_000n, error: null },
+    ]);
+    const { result } = renderHook(
+      () =>
+        useAaveReservesPrices({
+          spokeAddress: SPOKE,
+          reserveIds: [1n, 2n, 3n],
+        }),
+      { wrapper },
+    );
+    await waitFor(() =>
+      expect(result.current.pricesByReserveId).toEqual({
+        "1": 80_000,
+        "2": null,
+        "3": 1,
+      }),
+    );
+  });
+
+  it("is disabled when reserveIds is empty", () => {
+    const { result } = renderHook(
+      () => useAaveReservesPrices({ spokeAddress: SPOKE, reserveIds: [] }),
+      { wrapper },
+    );
+    expect(result.current.pricesByReserveId).toEqual({});
+    expect(result.current.isLoading).toBe(false);
+    expect(getReservesPricesSafe).not.toHaveBeenCalled();
+  });
+
+  it("clears stale pricesByReserveId after a refetch fails", async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    vi.mocked(getReservesPricesSafe)
+      .mockResolvedValueOnce([
+        { reserveId: 1n, priceRaw: 8_000_000_000_000n, error: null },
+      ])
+      .mockRejectedValueOnce(new Error("RPC failure"));
+
+    const wrapperWithClient = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+
+    const { result } = renderHook(
+      () => useAaveReservesPrices({ spokeAddress: SPOKE, reserveIds: [1n] }),
+      { wrapper: wrapperWithClient },
+    );
+
+    await waitFor(() =>
+      expect(result.current.pricesByReserveId).toEqual({ "1": 80_000 }),
+    );
+
+    await client.refetchQueries({ queryKey: ["aaveReservesPrices"] });
+
+    await waitFor(() => expect(result.current.error).toBeInstanceOf(Error));
+    expect(result.current.pricesByReserveId).toEqual({});
+  });
+});

--- a/services/vault/src/applications/aave/hooks/index.ts
+++ b/services/vault/src/applications/aave/hooks/index.ts
@@ -4,6 +4,18 @@ export {
   type UseAaveBorrowedAssetsResult,
 } from "./useAaveBorrowedAssets";
 export {
+  useAaveOracleAddress,
+  type UseAaveOracleAddressResult,
+} from "./useAaveOracleAddress";
+export {
+  useAaveReservePrice,
+  type UseAaveReservePriceResult,
+} from "./useAaveReservePrice";
+export {
+  useAaveReservesPrices,
+  type UseAaveReservesPricesResult,
+} from "./useAaveReservesPrices";
+export {
   useAaveUserPosition,
   type HealthFactorStatus,
   type UseAaveUserPositionResult,

--- a/services/vault/src/applications/aave/hooks/useAaveOracleAddress.ts
+++ b/services/vault/src/applications/aave/hooks/useAaveOracleAddress.ts
@@ -1,0 +1,34 @@
+/** Reads `Spoke.ORACLE()` once per spoke. The on-chain field is `immutable`, so the result is cached forever. */
+
+import { useQuery } from "@tanstack/react-query";
+import type { Address } from "viem";
+
+import { getOracleAddress } from "../clients/aaveOracle";
+
+const QUERY_KEY = "aaveOracleAddress";
+
+export interface UseAaveOracleAddressResult {
+  oracleAddress: Address | null;
+  isLoading: boolean;
+  error: Error | null;
+}
+
+export function useAaveOracleAddress({
+  spokeAddress,
+}: {
+  spokeAddress: Address | undefined;
+}): UseAaveOracleAddressResult {
+  const enabled = spokeAddress != null;
+  const { data, isLoading, error } = useQuery({
+    queryKey: [QUERY_KEY, spokeAddress],
+    queryFn: () => getOracleAddress(spokeAddress!),
+    enabled,
+    staleTime: Infinity,
+    gcTime: Infinity,
+  });
+  return {
+    oracleAddress: data ?? null,
+    isLoading: enabled ? isLoading : false,
+    error: (error as Error | null) ?? null,
+  };
+}

--- a/services/vault/src/applications/aave/hooks/useAaveReservePrice.ts
+++ b/services/vault/src/applications/aave/hooks/useAaveReservePrice.ts
@@ -1,0 +1,67 @@
+/**
+ * Single-reserve USD price from the Aave on-chain oracle (the source of
+ * liquidation truth). Returns `priceUsd: null` on revert; do not substitute.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import type { Address } from "viem";
+
+import { getReservesPrices } from "../clients/aaveOracle";
+
+import { useAaveOracleAddress } from "./useAaveOracleAddress";
+
+/** Aave oracle base unit (Spoke.ORACLE_DECIMALS = 8). */
+const ORACLE_SCALE = 1e8;
+const QUERY_KEY = "aaveReservePrice";
+const ONE_MINUTE_MS = 60 * 1000;
+
+export interface UseAaveReservePriceResult {
+  priceUsd: number | null;
+  isLoading: boolean;
+  error: Error | null;
+}
+
+export function useAaveReservePrice({
+  spokeAddress,
+  reserveId,
+}: {
+  spokeAddress: Address | undefined;
+  reserveId: bigint | undefined;
+}): UseAaveReservePriceResult {
+  const {
+    oracleAddress,
+    isLoading: oracleLoading,
+    error: oracleError,
+  } = useAaveOracleAddress({ spokeAddress });
+
+  const priceEnabled = oracleAddress != null && reserveId != null;
+  const {
+    data,
+    isLoading: priceLoading,
+    error: priceError,
+  } = useQuery({
+    queryKey: [
+      QUERY_KEY,
+      oracleAddress,
+      reserveId == null ? null : reserveId.toString(),
+    ],
+    queryFn: async () => {
+      const [raw] = await getReservesPrices(oracleAddress!, [reserveId!]);
+      return Number(raw) / ORACLE_SCALE;
+    },
+    enabled: priceEnabled,
+    staleTime: ONE_MINUTE_MS,
+    refetchInterval: ONE_MINUTE_MS,
+  });
+
+  // Propagate oracle-address loading/error up; price query is disabled until address resolves.
+  // When a refetch fails React Query keeps the last successful `data`; clear it so consumers
+  // don't display stale price next to a fresh error.
+  const upstreamRequested = spokeAddress != null && reserveId != null;
+  const error = oracleError ?? (priceError as Error | null) ?? null;
+  return {
+    priceUsd: error ? null : (data ?? null),
+    isLoading: upstreamRequested && (oracleLoading || priceLoading),
+    error,
+  };
+}

--- a/services/vault/src/applications/aave/hooks/useAaveReservesPrices.ts
+++ b/services/vault/src/applications/aave/hooks/useAaveReservesPrices.ts
@@ -1,0 +1,73 @@
+/** Batched per-reserve safe oracle read for asset lists. Returns `Record<reserveId.toString(), number | null>`. */
+
+import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+import type { Address } from "viem";
+
+import { getReservesPricesSafe } from "../clients/aaveOracle";
+
+import { useAaveOracleAddress } from "./useAaveOracleAddress";
+
+const ORACLE_SCALE = 1e8;
+const QUERY_KEY = "aaveReservesPrices";
+const ONE_MINUTE_MS = 60 * 1000;
+
+export interface UseAaveReservesPricesResult {
+  pricesByReserveId: Record<string, number | null>;
+  isLoading: boolean;
+  error: Error | null;
+}
+
+export function useAaveReservesPrices({
+  spokeAddress,
+  reserveIds,
+}: {
+  spokeAddress: Address | undefined;
+  reserveIds: bigint[];
+}): UseAaveReservesPricesResult {
+  const {
+    oracleAddress,
+    isLoading: oracleLoading,
+    error: oracleError,
+  } = useAaveOracleAddress({ spokeAddress });
+
+  // Sort + stringify for a stable cache key regardless of input order.
+  const reserveIdsKey = useMemo(
+    () =>
+      [...reserveIds]
+        .map((id) => id.toString())
+        .sort()
+        .join(","),
+    [reserveIds],
+  );
+
+  const priceEnabled = oracleAddress != null && reserveIds.length > 0;
+  const {
+    data,
+    isLoading: priceLoading,
+    error: priceError,
+  } = useQuery({
+    queryKey: [QUERY_KEY, oracleAddress, reserveIdsKey],
+    queryFn: async () => {
+      const results = await getReservesPricesSafe(oracleAddress!, reserveIds);
+      const out: Record<string, number | null> = {};
+      for (const r of results) {
+        out[r.reserveId.toString()] =
+          r.priceRaw == null ? null : Number(r.priceRaw) / ORACLE_SCALE;
+      }
+      return out;
+    },
+    enabled: priceEnabled,
+    staleTime: ONE_MINUTE_MS,
+    refetchInterval: ONE_MINUTE_MS,
+  });
+
+  // Same stale-data guard as useAaveReservePrice: clear `data` when error is set.
+  const upstreamRequested = spokeAddress != null && reserveIds.length > 0;
+  const error = oracleError ?? (priceError as Error | null) ?? null;
+  return {
+    pricesByReserveId: error ? {} : (data ?? {}),
+    isLoading: upstreamRequested && (oracleLoading || priceLoading),
+    error,
+  };
+}

--- a/services/vault/src/applications/aave/services/assertReorderMatchesOnChain.ts
+++ b/services/vault/src/applications/aave/services/assertReorderMatchesOnChain.ts
@@ -54,7 +54,7 @@ export class PositionChangedError extends Error {
  * recomputes against indexer-supplied inputs.
  *
  * - CF, THF, maxLB: from `useVaultSplitParams` (Spoke reads)
- * - btcPrice: from Aave on-chain oracle via `usePrices`
+ * - btcPrice: from `usePrices` (Chainlink BTC/USD aggregator)
  * - totalDebtUsd: from `useAaveUserPosition().debtValueUsd`
  *   (`accountData.totalDebtValueRay`, a Spoke read)
  * - expectedHF: optional override; defaults to the calculator's

--- a/services/vault/src/clients/eth-contract/chainlink/query.ts
+++ b/services/vault/src/clients/eth-contract/chainlink/query.ts
@@ -56,11 +56,12 @@ function getChainlinkFeedAddress(symbol: string): Address | null {
   const network = getBTCNetwork();
   const normalizedSymbol = symbol.toUpperCase();
 
+  // vBTC: 1:1 synthetic BTC by protocol design. sBTC: FE display symbol for BTC on signet.
+  // WBTC is NOT here — it has real depeg risk; Aave borrow flow sources it from the Aave oracle.
   if (
     normalizedSymbol === "BTC" ||
     normalizedSymbol === "VBTC" ||
-    normalizedSymbol === "SBTC" ||
-    normalizedSymbol === "WBTC"
+    normalizedSymbol === "SBTC"
   ) {
     if (ENV.BTC_PRICE_FEED) {
       if (!btcPriceFeedOverrideWarned) {
@@ -276,10 +277,8 @@ export async function getTokenPrices(
       if (normalizedSymbol === "BTC") {
         prices["vBTC"] = result.price;
         prices["sBTC"] = result.price;
-        prices["WBTC"] = result.price;
         metadata["vBTC"] = result.metadata;
         metadata["sBTC"] = result.metadata;
-        metadata["WBTC"] = result.metadata;
       }
     } catch (error) {
       const errorMessage =
@@ -303,7 +302,6 @@ export async function getTokenPrices(
       if (normalizedSymbol === "BTC") {
         metadata["vBTC"] = metadata[symbol];
         metadata["sBTC"] = metadata[symbol];
-        metadata["WBTC"] = metadata[symbol];
       }
     }
   });


### PR DESCRIPTION
## Summary
Source the Aave borrow card's USD price (and its pre-sign HF check) from the on-chain Aave
oracle — the same oracle Aave uses for liquidation — instead of a Chainlink WBTC→BTC alias. The
FE projection now matches Aave's view by construction.

## Why
The Chainlink alias would understate borrow risk on mainnet during a wBTC premium event, and
`validateBorrowPreSign` was the only signing input still served from a 60s-cached UI value.