### PR TITLE
fix(vault): wbtc decimals

### DIFF
--- a/services/vault/src/applications/aave/components/Detail/index.tsx
+++ b/services/vault/src/applications/aave/components/Detail/index.tsx
@@ -167,6 +167,7 @@ export function AaveReserveDetail() {
         onViewLoan={handleCloseBorrowSuccess}
         borrowAmount={borrowSuccessData.amount}
         borrowSymbol={assetConfig.symbol}
+        decimals={selectedReserve.token.decimals}
         assetIcon={assetConfig.icon}
       />
 
@@ -176,6 +177,7 @@ export function AaveReserveDetail() {
         onViewLoan={handleCloseRepaySuccess}
         repayAmount={repaySuccessData.repayAmount}
         repaySymbol={assetConfig.symbol}
+        decimals={selectedReserve.token.decimals}
         assetIcon={assetConfig.icon}
       />
     </LoanProvider>

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/SuccessModal/BorrowSuccessModal.tsx
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/SuccessModal/BorrowSuccessModal.tsx
@@ -1,7 +1,7 @@
 import { Avatar } from "@babylonlabs-io/core-ui";
 
-import { SubmitModal } from "../../../../../../components/shared";
-import { formatAmount } from "../../../../../../utils/formatting";
+import { SubmitModal } from "@/components/shared";
+import { formatAmount } from "@/utils/formatting";
 
 interface BorrowSuccessModalProps {
   open: boolean;

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/SuccessModal/BorrowSuccessModal.tsx
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/SuccessModal/BorrowSuccessModal.tsx
@@ -1,6 +1,7 @@
 import { Avatar } from "@babylonlabs-io/core-ui";
 
 import { SubmitModal } from "../../../../../../components/shared";
+import { formatAmount } from "../../../../../../utils/formatting";
 
 interface BorrowSuccessModalProps {
   open: boolean;
@@ -8,6 +9,7 @@ interface BorrowSuccessModalProps {
   onViewLoan: () => void;
   borrowAmount: number;
   borrowSymbol: string;
+  decimals: number;
   assetIcon: string;
 }
 
@@ -22,13 +24,10 @@ export function BorrowSuccessModal({
   onViewLoan,
   borrowAmount,
   borrowSymbol,
+  decimals,
   assetIcon,
 }: BorrowSuccessModalProps) {
-  // Format amount with commas for readability
-  const formattedBorrow = borrowAmount.toLocaleString("en-US", {
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 2,
-  });
+  const formattedBorrow = formatAmount(borrowAmount, decimals);
 
   return (
     <SubmitModal

--- a/services/vault/src/applications/aave/components/LoanCard/Repay/SuccessModal/RepaySuccessModal.tsx
+++ b/services/vault/src/applications/aave/components/LoanCard/Repay/SuccessModal/RepaySuccessModal.tsx
@@ -1,7 +1,7 @@
 import { Avatar } from "@babylonlabs-io/core-ui";
 
-import { SubmitModal } from "../../../../../../components/shared";
-import { formatAmount } from "../../../../../../utils/formatting";
+import { SubmitModal } from "@/components/shared";
+import { formatAmount } from "@/utils/formatting";
 
 interface RepaySuccessModalProps {
   open: boolean;

--- a/services/vault/src/applications/aave/components/LoanCard/Repay/SuccessModal/RepaySuccessModal.tsx
+++ b/services/vault/src/applications/aave/components/LoanCard/Repay/SuccessModal/RepaySuccessModal.tsx
@@ -9,6 +9,7 @@ interface RepaySuccessModalProps {
   onViewLoan: () => void;
   repayAmount: number;
   repaySymbol: string;
+  decimals: number;
   assetIcon: string;
 }
 
@@ -23,9 +24,10 @@ export function RepaySuccessModal({
   onViewLoan,
   repayAmount,
   repaySymbol,
+  decimals,
   assetIcon,
 }: RepaySuccessModalProps) {
-  const formattedRepay = formatAmount(repayAmount);
+  const formattedRepay = formatAmount(repayAmount, decimals);
 
   return (
     <SubmitModal

--- a/services/vault/src/applications/aave/hooks/useAaveBorrowedAssets.ts
+++ b/services/vault/src/applications/aave/hooks/useAaveBorrowedAssets.ts
@@ -101,7 +101,7 @@ function transformToBorrowedAsset(
   const tokenAmount = Number(
     formatUnits(debtPosition.totalDebt, reserve.token.decimals),
   );
-  const amount = formatAmount(tokenAmount);
+  const amount = formatAmount(tokenAmount, reserve.token.decimals);
 
   return { symbol, amount, icon };
 }

--- a/services/vault/src/utils/__tests__/formatting.test.ts
+++ b/services/vault/src/utils/__tests__/formatting.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getNetworkConfigBTC } from "@/config";
 
 import {
+  formatAmount,
   formatBasisPointsAsPercent,
   formatBtcAmount,
   formatCompactUsd,
@@ -60,6 +61,26 @@ describe("Formatting Utilities", () => {
       expect(formatBtcAmount(21000000)).toBe(
         `21000000 ${btcConfig.coinSymbol}`,
       );
+    });
+  });
+
+  describe("formatAmount", () => {
+    it("preserves a small WBTC amount when the token's 8 decimals are passed", () => {
+      expect(formatAmount(0.00031, 8)).toBe("0.00031");
+    });
+
+    it("rounds the same small amount to '0' with the default 2 decimals", () => {
+      // Regression: borrowed/repaid amounts must pass token decimals, otherwise
+      // sub-0.005 WBTC borrows render as "0".
+      expect(formatAmount(0.00031, 2)).toBe("0");
+    });
+
+    it("trims trailing zeros rather than padding to max decimals", () => {
+      expect(formatAmount(1.5, 8)).toBe("1.5");
+    });
+
+    it("keeps comma grouping for large amounts", () => {
+      expect(formatAmount(1234.5, 6)).toBe("1,234.5");
     });
   });
 

--- a/services/vault/src/utils/__tests__/formatting.test.ts
+++ b/services/vault/src/utils/__tests__/formatting.test.ts
@@ -82,6 +82,22 @@ describe("Formatting Utilities", () => {
     it("keeps comma grouping for large amounts", () => {
       expect(formatAmount(1234.5, 6)).toBe("1,234.5");
     });
+
+    it("clamps decimals above the Intl limit instead of throwing", () => {
+      // uint8 token decimals can reach 255; Intl.NumberFormat rejects >100,
+      // so an unclamped value would throw a RangeError mid-render.
+      expect(() => formatAmount(1.5, 255)).not.toThrow();
+      expect(formatAmount(1.5, 255)).toBe("1.5");
+    });
+
+    it("preserves precision for realistic small amounts after clamping", () => {
+      expect(formatAmount(0.00031, 30)).toBe("0.00031");
+    });
+
+    it("clamps negative decimals to zero instead of throwing", () => {
+      expect(() => formatAmount(123, -1)).not.toThrow();
+      expect(formatAmount(123, -1)).toBe("123");
+    });
   });
 
   describe("formatUsdValue", () => {

--- a/services/vault/src/utils/formatting.ts
+++ b/services/vault/src/utils/formatting.ts
@@ -167,16 +167,30 @@ export function formatCompactUsd(usd: number): string {
 }
 
 /**
+ * Intl.NumberFormat caps `maximumFractionDigits` at 20 on the oldest engines we
+ * support (newer V8 allows up to 100). Token `decimals` reaches `formatAmount`
+ * as an unvalidated uint8 (0–255) from indexer metadata, so clamp to the
+ * universally-safe ceiling to avoid a RangeError. No display needs more than
+ * 20 fractional digits.
+ */
+const MAX_DISPLAY_FRACTION_DIGITS = 20;
+
+/**
  * Format a number amount for display with locale-aware formatting
  * @param amount - The numeric amount to format
- * @param maxDecimals - Maximum decimal places (default: 2)
+ * @param maxDecimals - Maximum decimal places (default: 2). Clamped to
+ *   [0, 20] before use, since values come from unvalidated token metadata.
  * @returns Formatted number string (e.g., "1,234.56" or "0")
  */
 export function formatAmount(amount: number, maxDecimals = 2): string {
   if (amount <= 0) return "0";
+  const safeMaxDecimals = Math.min(
+    Math.max(maxDecimals, 0),
+    MAX_DISPLAY_FRACTION_DIGITS,
+  );
   return amount.toLocaleString("en-US", {
     minimumFractionDigits: 0,
-    maximumFractionDigits: maxDecimals,
+    maximumFractionDigits: safeMaxDecimals,
   });
 }
 


### PR DESCRIPTION
## What this does

Borrowed and repaid token amounts now display with the correct number of decimals. Before, borrowing a small amount of WBTC (e.g. `0.00031`) showed up as `0` in the borrow success modal and in the Loans section. Now it correctly reads `0.00031 WBTC`.

## Why

WBTC is an 8-decimal token, but everywhere we displayed a borrowed/repaid amount we formatted it with a hard cap of 2 decimal places. So `0.00031` got rounded to `0.00` and rendered as `"0"`. Any WBTC borrow below `0.005` disappeared entirely, and amounts like `0.012345` lost precision. This is confusing and looks broken to the user — they borrowed real value but the UI told them it was `0`.

The bug lived in three display spots, all of which called the shared `formatAmount` helper (or an inline copy of it) without telling it how many decimals the token actually has:

- The borrow success modal had its own inline formatter hardcoded to 2 decimals.
- The repay success modal called `formatAmount(amount)` (defaults to 2 decimals).
- The Loans list (`useAaveBorrowedAssets`) also called `formatAmount(amount)` with the default.

The `formatAmount` helper itself was already correct — it just needed to be told the token's decimals.

## What changed

- `formatAmount` is now always called with the token's own decimal count (`reserve.token.decimals`), so each asset is formatted with the precision it actually needs.
- The borrow success modal no longer has its own inline 2-decimal formatter; it uses the shared `formatAmount` like the repay modal does, and both now receive a `decimals` prop from the reserve detail page.
- The Loans list passes the reserve's decimals when formatting each borrowed asset.
- Added unit tests for `formatAmount` that lock in the fix: a small WBTC amount with 8 decimals stays `0.00031`, the same amount with 2 decimals rounds to `0` (the regression we hit), trailing zeros are still trimmed (so big amounts stay clean, e.g. `1.5`, not `1.50000000`), and comma grouping is kept for large amounts (e.g. `1,234.5`).

## Approach — and why this one

There were a few ways to fix this:

1. **Pass the token's real decimals into `formatAmount` (chosen).** Smallest possible change, reuses the existing helper, and matches what the rest of the app already does — the activity feed already calls `formatAmount(amount, reserve.decimals)`. `formatAmount` trims trailing zeros, so larger amounts don't become noisy (`1.5 WBTC` stays `1.5`, not `1.50000000`). It also keeps stablecoins (USDC/USDT) looking normal because they only have 6 decimals and small values aren't an issue there.
2. **Hardcode a higher fixed precision everywhere (e.g. always show 8 decimals).** Rejected — it's a magic number, it looks noisy for stablecoins, and it would still be wrong for any token with a different decimal count.
3. **Write a new "smart"/significant-figures formatter.** Rejected — more code and more complexity for no real benefit, and it would be inconsistent with the existing pattern already used elsewhere.

Option 1 wins because it's the least code, it removes a duplicated inline formatter, and it keeps every display consistent with how amounts are already formatted in the activity feed — using each token's actual decimals instead of a one-size-fits-all cap.

## Testing

- Manual: borrow `0.00031` WBTC → the success modal reads `0.00031 WBTC has been borrowed...` and the Loans section shows `0.00031 WBTC`. Repaying shows the correct decimal amount too. A stablecoin borrow (e.g. USDC) still shows comma-grouped amounts as before.

Before

<img width="683" height="428" alt="Screenshot_2026-05-27_10-18-51" src="https://github.com/user-attachments/assets/08d060c8-517e-4058-8fcd-708b5598fc96" />

<img width="1027" height="306" alt="Screenshot_2026-05-27_10-19-41" src="https://github.com/user-attachments/assets/3d2519bb-e674-48fe-ae9e-7e95d3601559" />


After

<img width="1006" height="597" alt="Screenshot_2026-05-27_10-29-11" src="https://github.com/user-attachments/assets/40d2b831-ce42-45d0-a627-09729909283c" />

<img width="1033" height="331" alt="Screenshot_2026-05-27_10-28-34" src="https://github.com/user-attachments/assets/aba20a42-39f1-46ef-ad45-a9239592aefa" />
