### PR TITLE
feat(wallet): staking to vault wording, rm 3rd option hw wallet

### DIFF
--- a/packages/babylon-wallet-connector/src/components/Inscriptions/index.tsx
+++ b/packages/babylon-wallet-connector/src/components/Inscriptions/index.tsx
@@ -29,12 +29,11 @@ export function Inscriptions({ className, config, onSubmit }: Props) {
 
       <DialogBody>
         <Text className="mb-8 text-accent-secondary">
-          By default, we will not use {coinName} that contains Inscriptions - such as Ordinals, NFTs, or Runes - in your
-          stakeable balance. This helps prevent any accidental loss of your Inscriptions due to staking, unbonding, or
-          withdrawal fees.
+          By default, we will not use {coinName} that contains Inscriptions - such as Ordinals, NFTs, or Runes - when
+          creating a BTC vault. This helps prevent any accidental loss of your Inscriptions due to transaction fees.
         </Text>
         <Text className="mb-10 text-accent-secondary">
-          If you would like to include {coinName} with Inscriptions in your stakeable balance, please select the option
+          If you would like to include {coinName} with Inscriptions when creating a BTC vault, please select the option
           below.
         </Text>
 
@@ -42,7 +41,7 @@ export function Inscriptions({ className, config, onSubmit }: Props) {
           <FieldControl
             label={
               <div>
-                <strong className="mr-2">Do not use</strong> {coinName} with Inscriptions for staking. (Recommended)
+                <strong className="mr-2">Do not use</strong> {coinName} with Inscriptions for BTC vaults. (Recommended)
               </div>
             }
             className="mb-8"
@@ -53,7 +52,7 @@ export function Inscriptions({ className, config, onSubmit }: Props) {
           <FieldControl
             label={
               <div>
-                <strong className="mr-2">Use</strong> {coinName} with Inscriptions in my stakable balance.
+                <strong className="mr-2">Use</strong> {coinName} with Inscriptions when creating a BTC vault.
               </div>
             }
             className="mb-8"

--- a/packages/babylon-wallet-connector/src/components/TermsOfService/index.tsx
+++ b/packages/babylon-wallet-connector/src/components/TermsOfService/index.tsx
@@ -16,7 +16,6 @@ export interface Props {
 const defaultState = {
   termsOfUse: false,
   inscriptions: false,
-  staking: false,
 } as const;
 
 export function TermsOfService({ className, onClose, onSubmit, simplifiedTerms = false }: Props) {
@@ -71,18 +70,12 @@ export function TermsOfService({ className, onClose, onSubmit, simplifiedTerms =
         </FieldControl>
 
         {!simplifiedTerms && (
-          <>
-            <FieldControl
-              label="I certify that I wish to stake bitcoin and agree that doing so may cause some or all of the bitcoin ordinals, NFTs, Runes, and other inscriptions in the connected bitcoin wallet to be lost. I acknowledge that this interface will not detect all Inscriptions."
-              className="mb-4"
-            >
-              <Checkbox checked={state["inscriptions"]} onChange={handleChange("inscriptions")} />
-            </FieldControl>
-
-            <FieldControl label="I acknowledge that the following are the only hardware wallets supporting Bitcoin Staking: (1) Keystone -- via QR code and (2) OneKey -- via the OneKey Chrome extension and the hardware devices (a) OneKey Pro and (b) OneKey Classic 1s (experimental, 3.10.1 firmware or higher) using Taproot only. Using any other hardware wallet through any means (such as connection to a software/extension/mobile wallet) can lead to permanent inability to withdraw the stake.">
-              <Checkbox checked={state["staking"]} onChange={handleChange("staking")} />
-            </FieldControl>
-          </>
+          <FieldControl
+            label="I certify that I wish to create a Bitcoin vault and agree that doing so may cause some or all of the bitcoin ordinals, NFTs, Runes, and other inscriptions in the connected bitcoin wallet to be lost. I acknowledge that this interface will not detect all Inscriptions."
+            className="mb-4"
+          >
+            <Checkbox checked={state["inscriptions"]} onChange={handleChange("inscriptions")} />
+          </FieldControl>
         )}
       </DialogBody>
 

--- a/packages/babylon-wallet-connector/tests/e2e/specs/connectOKXKeplr.spec.ts
+++ b/packages/babylon-wallet-connector/tests/e2e/specs/connectOKXKeplr.spec.ts
@@ -34,7 +34,7 @@ async function setupStorybookEnvironment(page: Page, storybook: FrameLocator) {
   await storybook.getByRole("button", { name: "Connect Wallet" }).click();
 
   // Accept terms
-  const terms = ["I certify that I have read", "I certify that I wish to", "I acknowledge that the following are"];
+  const terms = ["I certify that I have read", "I certify that I wish to"];
   for (const term of terms) {
     await storybook.getByText(term).click();
   }


### PR DESCRIPTION
- change `staking` to `Bitcoin vault`
- remove 3rd option (hardware wallets) for now, since we don't support them

Before:

<img width="2032" height="1162" alt="Screenshot_2026-05-27_15-59-06" src="https://github.com/user-attachments/assets/c8279e09-d473-414e-b42e-0a0d170c4f07" />

After 

1st screen (keep in mind, on devnet/testnet `simplifiedTerms` are enabled, so only 1st checkbox is visible)
<img width="2032" height="1162" alt="Screenshot_2026-05-27_16-53-34" src="https://github.com/user-attachments/assets/cc683dab-582c-41cd-a08a-3842e21e2b74" />

Ordinals
<img width="2032" height="1162" alt="Screenshot_2026-05-27_16-53-44" src="https://github.com/user-attachments/assets/6cea3ce9-ccdb-4ea9-82d1-3e48bdcd3f90" />
