### PR TITLE
fix(vault): floor max borrow at token decimals, not 2

### DIFF
--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/__tests__/calculateMaxBorrowTokens.test.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/__tests__/calculateMaxBorrowTokens.test.ts
@@ -15,11 +15,12 @@ describe("calculateMaxBorrowTokens", () => {
       currentDebtUsd: 0,
       liquidationThresholdBps: 8000,
       tokenPriceUsd: 1,
+      tokenDecimals: 6,
     });
 
     const expectedUsd =
       (10000 * 8000) / BPS_SCALE / MIN_HEALTH_FACTOR_FOR_BORROW;
-    expect(result).toBe(Math.floor(expectedUsd * 100) / 100);
+    expect(result).toBe(Math.floor(expectedUsd * 1e6) / 1e6);
   });
 
   it("subtracts existing debt from borrowing capacity", () => {
@@ -29,11 +30,12 @@ describe("calculateMaxBorrowTokens", () => {
       currentDebtUsd: 2000,
       liquidationThresholdBps: 8000,
       tokenPriceUsd: 1,
+      tokenDecimals: 6,
     });
 
     const expectedUsd =
       (10000 * 8000) / BPS_SCALE / MIN_HEALTH_FACTOR_FOR_BORROW - 2000;
-    expect(result).toBe(Math.floor(expectedUsd * 100) / 100);
+    expect(result).toBe(Math.floor(expectedUsd * 1e6) / 1e6);
   });
 
   it("converts USD cap to token units when token price is not $1", () => {
@@ -43,11 +45,12 @@ describe("calculateMaxBorrowTokens", () => {
       currentDebtUsd: 0,
       liquidationThresholdBps: 8000,
       tokenPriceUsd: 2,
+      tokenDecimals: 6,
     });
 
     const expectedUsd =
       (10000 * 8000) / BPS_SCALE / MIN_HEALTH_FACTOR_FOR_BORROW;
-    expect(result).toBe(Math.floor((expectedUsd / 2) * 100) / 100);
+    expect(result).toBe(Math.floor((expectedUsd / 2) * 1e6) / 1e6);
   });
 
   it("returns zero when existing debt exceeds borrowing capacity", () => {
@@ -56,6 +59,7 @@ describe("calculateMaxBorrowTokens", () => {
       currentDebtUsd: 8000,
       liquidationThresholdBps: 8000,
       tokenPriceUsd: 1,
+      tokenDecimals: 6,
     });
 
     expect(result).toBe(0);
@@ -67,23 +71,24 @@ describe("calculateMaxBorrowTokens", () => {
       currentDebtUsd: 0,
       liquidationThresholdBps: 8000,
       tokenPriceUsd: 1,
+      tokenDecimals: 6,
     });
 
     expect(result).toBe(0);
   });
 
-  it("floors result to two decimal places", () => {
-    // Choose inputs that would produce more than 2 decimals if unrounded
+  it("floors result to the token's native decimals", () => {
+    // Choose inputs that would produce more than tokenDecimals if unrounded
     const result = calculateMaxBorrowTokens({
       collateralValueUsd: 123.456,
       currentDebtUsd: 0,
       liquidationThresholdBps: 8000,
       tokenPriceUsd: 1,
+      tokenDecimals: 6,
     });
 
-    // Must match Math.floor(value * 100) / 100 exactly
     expect(Number.isFinite(result)).toBe(true);
-    expect(result * 100).toBe(Math.floor(result * 100));
+    expect(result * 1e6).toBe(Math.floor(result * 1e6));
   });
 
   it("returns zero when tokenPriceUsd is null", () => {
@@ -92,6 +97,7 @@ describe("calculateMaxBorrowTokens", () => {
       currentDebtUsd: 0,
       liquidationThresholdBps: 8000,
       tokenPriceUsd: null,
+      tokenDecimals: 6,
     });
 
     expect(result).toBe(0);
@@ -103,6 +109,7 @@ describe("calculateMaxBorrowTokens", () => {
       currentDebtUsd: 0,
       liquidationThresholdBps: 8000,
       tokenPriceUsd: 0,
+      tokenDecimals: 6,
     });
 
     expect(result).toBe(0);
@@ -115,10 +122,26 @@ describe("calculateMaxBorrowTokens", () => {
       currentDebtUsd: 0,
       liquidationThresholdBps: 7500,
       tokenPriceUsd: 1,
+      tokenDecimals: 6,
     });
 
     const expectedUsd =
       (10000 * 7500) / BPS_SCALE / MIN_HEALTH_FACTOR_FOR_BORROW;
-    expect(result).toBe(Math.floor(expectedUsd * 100) / 100);
+    expect(result).toBe(Math.floor(expectedUsd * 1e6) / 1e6);
+  });
+
+  it("preserves sub-cent precision for high-priced tokens (WBTC at ~$75k)", () => {
+    // Small collateral, high token price — pre-fix this floored to 0.
+    // $7.48 / $75000 ≈ 0.0000997 → must not round to 0 at 8 decimals.
+    const result = calculateMaxBorrowTokens({
+      collateralValueUsd: 8.976,
+      currentDebtUsd: 0,
+      liquidationThresholdBps: 8000,
+      tokenPriceUsd: 75000,
+      tokenDecimals: 8,
+    });
+
+    expect(result).toBeGreaterThan(0);
+    expect(result * 1e8).toBe(Math.floor(result * 1e8));
   });
 });

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/__tests__/calculateMaxBorrowTokens.test.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/__tests__/calculateMaxBorrowTokens.test.ts
@@ -144,4 +144,20 @@ describe("calculateMaxBorrowTokens", () => {
     expect(result).toBeGreaterThan(0);
     expect(result * 1e8).toBe(Math.floor(result * 1e8));
   });
+
+  it("caps floor precision at 15 decimals for 18-decimal tokens", () => {
+    // 18-decimal token: floor must clamp at SAFE_TOFIXED_PRECISION (15) so the
+    // displayed max never exposes precision the borrow execution path
+    // (parseUnits(borrowAmount.toFixed(15), 18)) would silently truncate.
+    const result = calculateMaxBorrowTokens({
+      collateralValueUsd: 10000,
+      currentDebtUsd: 0,
+      liquidationThresholdBps: 8000,
+      tokenPriceUsd: 1,
+      tokenDecimals: 18,
+    });
+
+    // result * 10^15 must be an integer (floor cap)
+    expect(result * 1e15).toBe(Math.floor(result * 1e15));
+  });
 });

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/__tests__/useBorrowState.test.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/__tests__/useBorrowState.test.ts
@@ -15,6 +15,7 @@ const defaultProps = {
   currentDebtUsd: 0,
   liquidationThresholdBps: 8000,
   tokenPriceUsd: 1,
+  tokenDecimals: 6,
 };
 
 describe("useBorrowState", () => {

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/__tests__/validateBorrowAction.test.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/__tests__/validateBorrowAction.test.ts
@@ -5,7 +5,7 @@ import { validateBorrowAction } from "../validateBorrowAction";
 
 describe("validateBorrowAction", () => {
   it("disables with 'Enter an amount' when borrow amount is 0", () => {
-    const result = validateBorrowAction(0, Infinity, 10000);
+    const result = validateBorrowAction(0, Infinity, 10000, 6);
 
     expect(result).toEqual({
       isDisabled: true,
@@ -15,7 +15,7 @@ describe("validateBorrowAction", () => {
   });
 
   it("disables with 'Amount exceeds maximum' when borrow exceeds max", () => {
-    const result = validateBorrowAction(50000, 0.16, 10000);
+    const result = validateBorrowAction(50000, 0.16, 10000, 6);
 
     expect(result).toEqual({
       isDisabled: true,
@@ -25,7 +25,7 @@ describe("validateBorrowAction", () => {
   });
 
   it("disables with 'Health factor too low' when HF is below minimum", () => {
-    const result = validateBorrowAction(8000, 1.0, 10000);
+    const result = validateBorrowAction(8000, 1.0, 10000, 6);
 
     expect(result).toEqual({
       isDisabled: true,
@@ -35,7 +35,7 @@ describe("validateBorrowAction", () => {
   });
 
   it("disables when projected health factor is exactly 0", () => {
-    const result = validateBorrowAction(100, 0, 10000);
+    const result = validateBorrowAction(100, 0, 10000, 6);
 
     expect(result).toEqual({
       isDisabled: true,
@@ -45,7 +45,7 @@ describe("validateBorrowAction", () => {
   });
 
   it("enables borrow when amount is valid and HF is safe", () => {
-    const result = validateBorrowAction(5000, 2.0, 10000);
+    const result = validateBorrowAction(5000, 2.0, 10000, 6);
 
     expect(result).toEqual({
       isDisabled: false,
@@ -55,7 +55,7 @@ describe("validateBorrowAction", () => {
   });
 
   it("enables borrow when HF is Infinity (no debt)", () => {
-    const result = validateBorrowAction(1000, Infinity, 10000);
+    const result = validateBorrowAction(1000, Infinity, 10000, 6);
 
     expect(result).toEqual({
       isDisabled: false,
@@ -66,7 +66,7 @@ describe("validateBorrowAction", () => {
 
   it("prioritizes max amount check over health factor check", () => {
     // Amount exceeds max AND HF is low — should show max amount error
-    const result = validateBorrowAction(20000, 0.5, 10000);
+    const result = validateBorrowAction(20000, 0.5, 10000, 6);
 
     expect(result).toEqual({
       isDisabled: true,
@@ -76,7 +76,7 @@ describe("validateBorrowAction", () => {
   });
 
   it("enables borrow at exactly max amount with safe HF", () => {
-    const result = validateBorrowAction(10000, 1.5, 10000);
+    const result = validateBorrowAction(10000, 1.5, 10000, 6);
 
     expect(result).toEqual({
       isDisabled: false,
@@ -86,7 +86,7 @@ describe("validateBorrowAction", () => {
   });
 
   it("disables with 'Refreshing position...' when position data is stale", () => {
-    const result = validateBorrowAction(5000, 2.0, 10000, true);
+    const result = validateBorrowAction(5000, 2.0, 10000, 6, true);
 
     expect(result).toEqual({
       isDisabled: true,
@@ -96,15 +96,24 @@ describe("validateBorrowAction", () => {
   });
 
   it("does not block when isPositionDataStale is false", () => {
-    const result = validateBorrowAction(5000, 2.0, 10000, false);
+    const result = validateBorrowAction(5000, 2.0, 10000, 6, false);
 
     expect(result.isDisabled).toBe(false);
   });
 
   it("prioritizes staleness check over other validations", () => {
     // Stale AND amount is 0 — staleness should take priority
-    const result = validateBorrowAction(0, Infinity, 10000, true);
+    const result = validateBorrowAction(0, Infinity, 10000, 6, true);
 
     expect(result.buttonText).toBe("Refreshing position...");
+  });
+
+  it("formats error message with WBTC's 8-decimal precision", () => {
+    // 0.0000099 WBTC max — 6-decimal default (formatTokenAmount) would round
+    // this to "0.00"; using tokenDecimals=8 must preserve the value.
+    const result = validateBorrowAction(0.0001, 2.0, 0.0000099, 8);
+
+    expect(result.buttonText).toBe("Amount exceeds maximum");
+    expect(result.errorMessage).toBe("Maximum borrowable amount is 0.0000099");
   });
 });

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/calculateMaxBorrowTokens.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/calculateMaxBorrowTokens.ts
@@ -9,6 +9,8 @@ export interface CalculateMaxBorrowTokensParams {
   liquidationThresholdBps: number;
   /** Price of the borrow token in USD (null when oracle price is unavailable) */
   tokenPriceUsd: number | null;
+  /** Native token decimals (e.g., 8 for WBTC, 6 for USDC, 18 for ETH) */
+  tokenDecimals: number;
 }
 
 /**
@@ -22,14 +24,16 @@ export interface CalculateMaxBorrowTokensParams {
  *   maxBorrowTokens = maxAdditionalBorrowUsd / tokenPriceUsd
  *
  * Returns 0 when the resulting value would be negative (existing debt
- * already exceeds borrowing capacity). Floored to 2 decimals so the
- * slider never offers sub-cent precision.
+ * already exceeds borrowing capacity). Floored to the token's native
+ * decimals so high-priced tokens (e.g. WBTC at ~$75k) don't lose sub-cent
+ * precision and report Max 0.
  */
 export function calculateMaxBorrowTokens({
   collateralValueUsd,
   currentDebtUsd,
   liquidationThresholdBps,
   tokenPriceUsd,
+  tokenDecimals,
 }: CalculateMaxBorrowTokensParams): number {
   if (tokenPriceUsd == null || tokenPriceUsd <= 0) {
     return 0;
@@ -41,5 +45,6 @@ export function calculateMaxBorrowTokens({
     MIN_HEALTH_FACTOR_FOR_BORROW;
   const maxAdditionalBorrowUsd = maxTotalDebtUsd - currentDebtUsd;
   const maxBorrowTokens = maxAdditionalBorrowUsd / tokenPriceUsd;
-  return Math.floor(Math.max(0, maxBorrowTokens) * 100) / 100;
+  const scale = 10 ** tokenDecimals;
+  return Math.floor(Math.max(0, maxBorrowTokens) * scale) / scale;
 }

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/calculateMaxBorrowTokens.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/calculateMaxBorrowTokens.ts
@@ -1,4 +1,8 @@
-import { BPS_SCALE, MIN_HEALTH_FACTOR_FOR_BORROW } from "../../../../constants";
+import {
+  BPS_SCALE,
+  MIN_HEALTH_FACTOR_FOR_BORROW,
+  SAFE_TOFIXED_PRECISION,
+} from "../../../../constants";
 
 export interface CalculateMaxBorrowTokensParams {
   /** Collateral value in USD (from Aave oracle) */
@@ -24,9 +28,15 @@ export interface CalculateMaxBorrowTokensParams {
  *   maxBorrowTokens = maxAdditionalBorrowUsd / tokenPriceUsd
  *
  * Returns 0 when the resulting value would be negative (existing debt
- * already exceeds borrowing capacity). Floored to the token's native
- * decimals so high-priced tokens (e.g. WBTC at ~$75k) don't lose sub-cent
- * precision and report Max 0.
+ * already exceeds borrowing capacity).
+ *
+ * Floored to min(tokenDecimals, SAFE_TOFIXED_PRECISION) so:
+ *   1. High-priced tokens (e.g. WBTC at ~$75k) don't lose sub-cent
+ *      precision and report Max 0 (was a 2-decimal floor).
+ *   2. For 18-decimal tokens, the max never advertises precision below
+ *      what `parseUnits(borrowAmount.toFixed(15), decimals)` can preserve
+ *      in `useBorrowTransaction` — otherwise the Max button could set
+ *      a value the execution path silently truncates to zero.
  */
 export function calculateMaxBorrowTokens({
   collateralValueUsd,
@@ -45,6 +55,7 @@ export function calculateMaxBorrowTokens({
     MIN_HEALTH_FACTOR_FOR_BORROW;
   const maxAdditionalBorrowUsd = maxTotalDebtUsd - currentDebtUsd;
   const maxBorrowTokens = maxAdditionalBorrowUsd / tokenPriceUsd;
-  const scale = 10 ** tokenDecimals;
+  const floorDecimals = Math.min(tokenDecimals, SAFE_TOFIXED_PRECISION);
+  const scale = 10 ** floorDecimals;
   return Math.floor(Math.max(0, maxBorrowTokens) * scale) / scale;
 }

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/useBorrowState.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/useBorrowState.ts
@@ -18,6 +18,8 @@ export interface UseBorrowStateProps {
   liquidationThresholdBps: number;
   /** Price of the borrow token in USD (null when oracle price is unavailable) */
   tokenPriceUsd: number | null;
+  /** Native token decimals (e.g., 8 for WBTC, 6 for USDC, 18 for ETH) */
+  tokenDecimals: number;
 }
 
 export interface UseBorrowStateResult {
@@ -34,6 +36,7 @@ export function useBorrowState({
   currentDebtUsd,
   liquidationThresholdBps,
   tokenPriceUsd,
+  tokenDecimals,
 }: UseBorrowStateProps): UseBorrowStateResult {
   const [borrowAmount, setBorrowAmount] = useState(0);
 
@@ -44,12 +47,14 @@ export function useBorrowState({
         currentDebtUsd,
         liquidationThresholdBps,
         tokenPriceUsd,
+        tokenDecimals,
       }),
     [
       collateralValueUsd,
       currentDebtUsd,
       liquidationThresholdBps,
       tokenPriceUsd,
+      tokenDecimals,
     ],
   );
 

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/validateBorrowAction.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/validateBorrowAction.ts
@@ -5,7 +5,10 @@
  */
 
 import { formatTokenAmount } from "../../../../../../utils/formatting";
-import { MIN_HEALTH_FACTOR_FOR_BORROW } from "../../../../constants";
+import {
+  MIN_HEALTH_FACTOR_FOR_BORROW,
+  SAFE_TOFIXED_PRECISION,
+} from "../../../../constants";
 
 export interface BorrowValidationResult {
   isDisabled: boolean;
@@ -19,6 +22,7 @@ export interface BorrowValidationResult {
  * @param borrowAmount - Amount user wants to borrow
  * @param projectedHealthFactor - Health factor after the borrow
  * @param maxBorrowAmount - Maximum borrowable amount based on collateral and debt
+ * @param tokenDecimals - Native token decimals (e.g., 8 for WBTC, 6 for USDC, 18 for ETH)
  * @param isPositionDataStale - Whether position data may be outdated
  * @returns Validation result with disabled state, button text, and error message
  */
@@ -26,6 +30,7 @@ export function validateBorrowAction(
   borrowAmount: number,
   projectedHealthFactor: number,
   maxBorrowAmount: number,
+  tokenDecimals: number,
   isPositionDataStale = false,
 ): BorrowValidationResult {
   if (isPositionDataStale) {
@@ -45,10 +50,16 @@ export function validateBorrowAction(
   }
 
   if (borrowAmount > maxBorrowAmount) {
+    // Format with the token's native precision (capped at SAFE_TOFIXED_PRECISION)
+    // so the error text matches what the slider's Max label and the underlying
+    // calculateMaxBorrowTokens floor expose. Default 6-decimal cap in
+    // formatTokenAmount would round small WBTC maxes (e.g. 0.0000099) down
+    // to "0" in the message even though the value is non-zero.
+    const displayDecimals = Math.min(tokenDecimals, SAFE_TOFIXED_PRECISION);
     return {
       isDisabled: true,
       buttonText: "Amount exceeds maximum",
-      errorMessage: `Maximum borrowable amount is ${formatTokenAmount(maxBorrowAmount)}`,
+      errorMessage: `Maximum borrowable amount is ${formatTokenAmount(maxBorrowAmount, displayDecimals)}`,
     };
   }
 

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/validateBorrowAction.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/validateBorrowAction.ts
@@ -4,6 +4,7 @@
  * Validates whether user can perform the borrow action based on amount and health factor.
  */
 
+import { formatTokenAmount } from "../../../../../../utils/formatting";
 import { MIN_HEALTH_FACTOR_FOR_BORROW } from "../../../../constants";
 
 export interface BorrowValidationResult {
@@ -47,7 +48,7 @@ export function validateBorrowAction(
     return {
       isDisabled: true,
       buttonText: "Amount exceeds maximum",
-      errorMessage: `Maximum borrowable amount is ${maxBorrowAmount.toFixed(2)}`,
+      errorMessage: `Maximum borrowable amount is ${formatTokenAmount(maxBorrowAmount)}`,
     };
   }
 

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/index.tsx
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/index.tsx
@@ -56,6 +56,7 @@ export function Borrow() {
       currentDebtUsd: totalDebtValueUsd,
       liquidationThresholdBps,
       tokenPriceUsd,
+      tokenDecimals: selectedReserve.token.decimals,
     });
 
   const metrics = useBorrowMetrics({

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/index.tsx
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/index.tsx
@@ -22,7 +22,11 @@ import {
   formatTokenAmount,
   formatUsdValue,
 } from "../../../../../utils/formatting";
-import { AMOUNT_INPUT_CLASS_NAME, MIN_SLIDER_MAX } from "../../../constants";
+import {
+  AMOUNT_INPUT_CLASS_NAME,
+  MIN_SLIDER_MAX,
+  SAFE_TOFIXED_PRECISION,
+} from "../../../constants";
 import { useBorrowTransaction } from "../../../hooks";
 import { useLoanContext } from "../../context/LoanContext";
 
@@ -72,6 +76,7 @@ export function Borrow() {
     borrowAmount,
     metrics.healthFactorValue,
     maxBorrowAmount,
+    selectedReserve.token.decimals,
     isPositionDataStale,
   );
 
@@ -80,6 +85,10 @@ export function Borrow() {
   // accept range use the real `maxBorrowAmount` so the UI doesn't advertise
   // a value that validation will reject.
   const sliderTrackMax = maxBorrowAmount > 0 ? maxBorrowAmount : MIN_SLIDER_MAX;
+  const displayDecimals = Math.min(
+    selectedReserve.token.decimals,
+    SAFE_TOFIXED_PRECISION,
+  );
 
   const handleBorrow = async () => {
     // Defensive: the disabled prop already gates on `oracleAddress == null`.
@@ -125,7 +134,7 @@ export function Borrow() {
               setBorrowAmount(parseFloat(e.target.value) || 0)
             }
             balanceDetails={{
-              balance: formatTokenAmount(maxBorrowAmount),
+              balance: formatTokenAmount(maxBorrowAmount, displayDecimals),
               symbol: assetConfig.symbol,
               displayUSD: false,
             }}
@@ -138,7 +147,7 @@ export function Borrow() {
             sliderVariant="rainbow"
             leftField={{
               label: "Max",
-              value: `${formatTokenAmount(maxBorrowAmount)} ${assetConfig.symbol}`,
+              value: `${formatTokenAmount(maxBorrowAmount, displayDecimals)} ${assetConfig.symbol}`,
             }}
             onMaxClick={() => setBorrowAmount(maxBorrowAmount)}
             rightField={{

--- a/services/vault/src/applications/aave/constants.ts
+++ b/services/vault/src/applications/aave/constants.ts
@@ -118,3 +118,15 @@ export type LoanTab = (typeof LOAN_TAB)[keyof typeof LOAN_TAB];
  */
 export const AMOUNT_INPUT_CLASS_NAME =
   "w-auto min-w-32 rounded-md border border-gray-300 px-2 py-1 dark:border-[#3a3a3a]";
+
+/**
+ * Maximum decimal precision JS numbers can faithfully represent for
+ * `Number.prototype.toFixed`. Past 15 fractional digits, IEEE 754 doubles
+ * start showing artifacts (e.g. `(0.1).toFixed(18) === "0.100000000000000006"`).
+ *
+ * Both the max-borrow floor and the `parseUnits` conversion inside
+ * `useBorrowTransaction` must cap at this value, otherwise the UI can
+ * advertise a max that the execution path turns into 0 (and the borrow
+ * gets rejected as zero or as a different amount than displayed).
+ */
+export const SAFE_TOFIXED_PRECISION = 15;

--- a/services/vault/src/applications/aave/hooks/useBorrowTransaction.ts
+++ b/services/vault/src/applications/aave/hooks/useBorrowTransaction.ts
@@ -19,6 +19,7 @@ import {
 } from "@/utils/errors";
 
 import { getAaveAdapterAddress } from "../config";
+import { SAFE_TOFIXED_PRECISION } from "../constants";
 import {
   ReserveMismatchError,
   assertReserveMatchesOnChain,
@@ -93,10 +94,12 @@ export function useBorrowTransaction(): UseBorrowTransactionResult {
           `Failed to fetch on-chain decimals for ${reserve.token.address}`,
         );
       });
-      // Clamp toFixed precision to 15 to avoid IEEE 754 floating-point artifacts
-      // (e.g. (0.1).toFixed(18) === "0.100000000000000006"). parseUnits handles
-      // strings with fewer decimal places than the token's decimals correctly.
-      const SAFE_TOFIXED_PRECISION = 15;
+      // Clamp toFixed precision to SAFE_TOFIXED_PRECISION to avoid IEEE 754
+      // artifacts (e.g. (0.1).toFixed(18) === "0.100000000000000006"). The
+      // max-borrow floor in calculateMaxBorrowTokens uses the same cap so
+      // the displayed Max never exposes precision this path can't preserve.
+      // parseUnits handles strings with fewer decimal places than the token's
+      // decimals correctly.
       const borrowAmountBigInt = parseUnits(
         borrowAmount.toFixed(Math.min(onChainDecimals, SAFE_TOFIXED_PRECISION)),
         onChainDecimals,


### PR DESCRIPTION
## Summary

- `calculateMaxBorrowTokens` floored result at 2 decimals (`Math.floor(x * 100) / 100`). For WBTC (~$75k) sub-cent borrowable amounts were silently truncated to `0`, so the UI showed `Max 0 WBTC` and the slider stayed in "Amount exceeds maximum" even though the underlying capacity was non-zero (e.g. ~$7.48 ≈ 0.0001 WBTC).
- Added `tokenDecimals` to `calculateMaxBorrowTokens` and `useBorrowState`, plumbed `selectedReserve.token.decimals` through from `Borrow/index.tsx`. Floor now happens at `10^tokenDecimals` so WBTC keeps 8-decimal precision, USDC keeps 6, etc.
- Replaced `maxBorrowAmount.toFixed(2)` in `validateBorrowAction`'s error message with `formatTokenAmount(maxBorrowAmount)` so the "Maximum borrowable amount is …" text matches the slider label precision.

## Test plan

- [x] `vitest run` on `Borrow/hooks/__tests__/` → all 40 tests pass (`calculateMaxBorrowTokens`, `useBorrowState`, `validateBorrowAction`, `useBorrowMetrics`, `validateBorrowPreSign`).
- [x] Added regression test `preserves sub-cent precision for high-priced tokens (WBTC at ~$75k)`.
- [x] `pnpm run lint` → 0 errors (pre-existing warnings only).
- [ ] Manual: open Borrow tab with WBTC reserve, very small collateral → confirm `Max` label and slider both show a non-zero borrowable amount instead of `0 WBTC`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)