### PR TITLE
fix(vault): update health factor threshold marker

### DIFF
--- a/services/vault/src/components/shared/HealthFactorGauge.tsx
+++ b/services/vault/src/components/shared/HealthFactorGauge.tsx
@@ -53,7 +53,8 @@ export function HealthFactorGauge({
       >
         {/* Liquidation threshold marker at HF=1.0 */}
         <div
-          className="absolute top-1/2 h-4 w-px -translate-y-1/2 border-l border-dashed border-white"
+          data-testid="health-factor-liquidation-threshold"
+          className="absolute top-1/2 h-4 w-px -translate-y-1/2 border-l border-dashed border-secondary-strokeDark dark:border-white"
           style={{ left: `${LIQUIDATION_PERCENT}%` }}
         />
         {/* Current value indicator — ring whose center matches the container background */}

--- a/services/vault/src/components/shared/__tests__/HealthFactorGauge.test.tsx
+++ b/services/vault/src/components/shared/__tests__/HealthFactorGauge.test.tsx
@@ -26,6 +26,14 @@ describe("HealthFactorGauge", () => {
     expect(screen.getByRole("meter")).toHaveAttribute("aria-valuenow", "2.5");
   });
 
+  it("uses theme-aware threshold marker colors", () => {
+    render(<HealthFactorGauge value={2.5} status="safe" />);
+
+    expect(
+      screen.getByTestId("health-factor-liquidation-threshold"),
+    ).toHaveClass("border-secondary-strokeDark", "dark:border-white");
+  });
+
   it("renders warning label for warning status", () => {
     render(<HealthFactorGauge value={1.2} status="warning" />);
     expect(screen.getByText("At Risk")).toBeInTheDocument();


### PR DESCRIPTION
Update health factor threshold marker in light mode to make it visible

## Screenshot
### Before
<img width="2544" height="1804" alt="image" src="https://github.com/user-attachments/assets/31c0445f-7ac0-43ef-9518-ccd33a8dbf89" />

### After
<img width="2544" height="1804" alt="image" src="https://github.com/user-attachments/assets/5fcacde7-1d4d-49a4-a52e-859e6b7bc4dd" />
