### PR TITLE
feat(vault): current ltv

### DIFF
--- a/services/vault/src/components/simple/DashboardPage.tsx
+++ b/services/vault/src/components/simple/DashboardPage.tsx
@@ -24,7 +24,11 @@ import { useApplicationCap } from "@/hooks/useApplicationCap";
 import { useDashboardState } from "@/hooks/useDashboardState";
 import { usePegoutPolling } from "@/hooks/usePegoutPolling";
 import { ClaimerPegoutStatusValue } from "@/models/pegoutStateMachine";
-import { formatBtcAmount, formatUsdValue } from "@/utils/formatting";
+import {
+  formatBtcAmount,
+  formatLtvPercent,
+  formatUsdValue,
+} from "@/utils/formatting";
 
 import { CollateralSection } from "./CollateralSection";
 import { LoansSection } from "./LoansSection";
@@ -98,6 +102,7 @@ export function DashboardPage() {
   // Format display values
   const totalCollateralValue = formatUsdValue(collateralValueUsd);
   const amountToRepay = formatUsdValue(debtValueUsd);
+  const ltv = formatLtvPercent(debtValueUsd, collateralValueUsd);
   const totalAmountBtc = formatBtcAmount(collateralBtc);
 
   const handleOpenWithdraw = useCallback(() => {
@@ -147,6 +152,7 @@ export function DashboardPage() {
           healthFactorStatus={healthFactorStatus}
           totalCollateralValue={totalCollateralValue}
           amountToRepay={amountToRepay}
+          ltv={ltv}
           isConnected={isConnected}
         />
 

--- a/services/vault/src/components/simple/OverviewSection.tsx
+++ b/services/vault/src/components/simple/OverviewSection.tsx
@@ -21,6 +21,7 @@ interface OverviewSectionProps {
   healthFactorStatus: HealthFactorStatus;
   totalCollateralValue: string;
   amountToRepay: string;
+  ltv: string;
   isConnected: boolean;
 }
 
@@ -29,6 +30,7 @@ export function OverviewSection({
   healthFactorStatus,
   totalCollateralValue,
   amountToRepay,
+  ltv,
   isConnected,
 }: OverviewSectionProps) {
   if (!isConnected) {
@@ -73,6 +75,16 @@ export function OverviewSection({
               ) : (
                 "-"
               )}
+            </span>
+          </div>
+
+          {/* Current LTV Row */}
+          <div className="flex items-center justify-between">
+            <span className="text-sm text-accent-secondary">
+              {COPY.overview.ltvLabel}
+            </span>
+            <span className="text-base text-accent-primary">
+              {showHealthFactor ? ltv : "-"}
             </span>
           </div>
 

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -453,6 +453,7 @@ export const COPY = {
   overview: {
     heading: "Overview",
     healthFactorLabel: "Health factor",
+    ltvLabel: "Current LTV",
     totalCollateralValueLabel: "Total Collateral Value",
     amountToRepayLabel: "Amount to repay",
     disconnected: {

--- a/services/vault/src/utils/__tests__/formatting.test.ts
+++ b/services/vault/src/utils/__tests__/formatting.test.ts
@@ -13,6 +13,7 @@ import {
   formatCompactUsd,
   formatDateTime,
   formatLLTV,
+  formatLtvPercent,
   formatOrdinal,
   formatProviderDisplayName,
   formatTimeAgo,
@@ -166,6 +167,34 @@ describe("Formatting Utilities", () => {
     it("should format to 1 decimal place", () => {
       // 85.5% = 855000000000000000
       expect(formatLLTV(855000000000000000n)).toBe("85.5%");
+    });
+  });
+
+  describe("formatLtvPercent", () => {
+    it("formats a typical position to 1 decimal", () => {
+      // Matches the values in the user-report screenshot.
+      expect(formatLtvPercent(1941.26, 2986.56)).toBe("65.0%");
+    });
+
+    it("renders exact halves", () => {
+      expect(formatLtvPercent(500, 1000)).toBe("50.0%");
+    });
+
+    it("renders ratios above 100% for underwater positions", () => {
+      expect(formatLtvPercent(1200, 1000)).toBe("120.0%");
+    });
+
+    it("returns '-' when debt is zero (no loan)", () => {
+      expect(formatLtvPercent(0, 1000)).toBe("-");
+    });
+
+    it("returns '-' when collateral is zero (would divide by zero)", () => {
+      expect(formatLtvPercent(100, 0)).toBe("-");
+    });
+
+    it("returns '-' for negative inputs", () => {
+      expect(formatLtvPercent(-1, 1000)).toBe("-");
+      expect(formatLtvPercent(100, -1)).toBe("-");
     });
   });
 

--- a/services/vault/src/utils/formatting.ts
+++ b/services/vault/src/utils/formatting.ts
@@ -106,6 +106,26 @@ export function formatBasisPointsAsPercent(bps: number): string {
   return `${percent}%`;
 }
 
+/** Decimal places shown in the Overview "Current LTV" row. Matches
+ * `formatLLTV` so the user-facing current LTV and protocol max-LTV render at
+ * the same resolution. */
+const LTV_DISPLAY_DECIMALS = 1;
+
+/**
+ * Format current loan-to-value (debt / collateral) as a percentage string.
+ * Returns "-" when either side is non-positive (no debt or no collateral →
+ * no meaningful LTV), matching the empty-state convention of the Health
+ * Factor row in OverviewSection.
+ */
+export function formatLtvPercent(
+  debtUsd: number,
+  collateralUsd: number,
+): string {
+  if (debtUsd <= 0 || collateralUsd <= 0) return "-";
+  const percent = (debtUsd / collateralUsd) * 100;
+  return `${percent.toFixed(LTV_DISPLAY_DECIMALS)}%`;
+}
+
 /**
  * Get the current BTC coin symbol based on network
  * @returns "BTC" for mainnet, "sBTC" for signet


### PR DESCRIPTION
- adds `current ltv` row

<img width="1041" height="365" alt="Screenshot_2026-05-28_12-55-37" src="https://github.com/user-attachments/assets/7d564845-a22d-4605-a90d-6c69c0f075f4" />
 