### PR TITLE
feat(wallet): steps loading

### DIFF
--- a/packages/babylon-wallet-connector/src/components/Loader/index.tsx
+++ b/packages/babylon-wallet-connector/src/components/Loader/index.tsx
@@ -1,21 +1,31 @@
-import { Heading, Loader } from "@babylonlabs-io/core-ui";
+import { Heading, Loader, Text } from "@babylonlabs-io/core-ui";
 import { twMerge } from "tailwind-merge";
 
 interface LoaderProps {
   className?: string;
   title?: string;
+  description?: string;
 }
 
-export function LoaderScreen({ className, title }: LoaderProps) {
+export function LoaderScreen({ className, title, description }: LoaderProps) {
   return (
     <div className={twMerge("flex flex-col items-center justify-center gap-6", className)}>
       <div className="flex items-center justify-center bg-primary-contrast p-6">
         <Loader className="text-primary-light" />
       </div>
-      {title && (
-        <Heading variant="h4" className="capitalize text-accent-primary">
-          {title}
-        </Heading>
+      {(title || description) && (
+        <div className="flex flex-col items-center gap-2 text-center">
+          {title && (
+            <Heading variant="h4" className="capitalize text-accent-primary">
+              {title}
+            </Heading>
+          )}
+          {description && (
+            <Text as="div" className="text-accent-secondary">
+              {description}
+            </Text>
+          )}
+        </div>
       )}
     </div>
   );

--- a/packages/babylon-wallet-connector/src/components/WalletProvider/components/Screen.tsx
+++ b/packages/babylon-wallet-connector/src/components/WalletProvider/components/Screen.tsx
@@ -37,7 +37,11 @@ const SCREENS = {
     <Inscriptions className={className} onSubmit={onToggleInscriptions} />
   ),
   LOADER: ({ className, current }: ScreenProps) => (
-    <LoaderScreen className={className} title={current?.params?.message as string} />
+    <LoaderScreen
+      className={className}
+      title={current?.params?.message as string}
+      description={current?.params?.description as string}
+    />
   ),
   ERROR: () => <Error className="min-h-0 md:w-[600px]" />,
   EMPTY: ({ className }: ScreenProps) => <div className={className} />,

--- a/packages/babylon-wallet-connector/src/context/State.context.tsx
+++ b/packages/babylon-wallet-connector/src/context/State.context.tsx
@@ -27,7 +27,7 @@ export interface State {
 export interface Actions {
   open?: () => void;
   close?: () => void;
-  displayLoader?: (message?: string) => void;
+  displayLoader?: (message?: string, description?: string) => void;
   displayChains?: () => void;
   displayWallets?: (chain: string) => void;
   displayInscriptions?: () => void;
@@ -109,8 +109,8 @@ export function StateProvider({ children, chains }: PropsWithChildren<StateProvi
         setState(({ chains }) => ({ ...defaultState, chains }));
       },
 
-      displayLoader: (message = "") => {
-        setState((state) => ({ ...state, screen: { type: "LOADER", params: { message } } }));
+      displayLoader: (message = "", description = "") => {
+        setState((state) => ({ ...state, screen: { type: "LOADER", params: { message, description } } }));
       },
 
       displayTermsOfService: () => {

--- a/packages/babylon-wallet-connector/src/core/Wallet.ts
+++ b/packages/babylon-wallet-connector/src/core/Wallet.ts
@@ -1,4 +1,4 @@
-import type { Account, IProvider, IWallet, Network } from "@/core/types";
+import type { Account, IProvider, IWallet, Network, ProgressReporter } from "@/core/types";
 
 export interface WalletOptions<P extends IProvider> {
   id: string;
@@ -41,12 +41,12 @@ export class Wallet<P extends IProvider> implements IWallet {
     return this._label ?? (this.installed ? "Installed" : "");
   }
 
-  async connect() {
+  async connect(onProgress?: ProgressReporter) {
     if (!this.provider) {
       throw Error("Provider not found");
     }
 
-    await this.provider.connectWallet();
+    await this.provider.connectWallet(onProgress);
     const [address, publicKeyHex] = await Promise.all([this.provider.getAddress(), this.provider.getPublicKeyHex()]);
 
     this.account = { address, publicKeyHex };

--- a/packages/babylon-wallet-connector/src/core/WalletConnector.ts
+++ b/packages/babylon-wallet-connector/src/core/WalletConnector.ts
@@ -7,7 +7,7 @@ import { ERROR_CODES, WalletError } from "@/error";
 type DisconnectableProvider = IProvider & { disconnect?: () => Promise<void> };
 
 export interface ConnectorEvents<P extends IProvider> {
-  connecting: (message?: string) => void;
+  connecting: (message?: string, description?: string) => void;
   connect: (wallet: Wallet<P>) => void;
   disconnect: (wallet: Wallet<P>) => void;
   error: (error: Error) => void;
@@ -41,7 +41,9 @@ export class WalletConnector<N extends string, P extends IProvider, C> implement
       }
       this._ee.emit("connecting", `Connecting ${selectedWallet.name}`);
 
-      await selectedWallet.connect();
+      const reportProgress = (message?: string, description?: string) =>
+        this._ee.emit("connecting", message, description);
+      await selectedWallet.connect(reportProgress);
       this._connectedWallet = selectedWallet;
       this._ee.emit("connect", this._connectedWallet);
 

--- a/packages/babylon-wallet-connector/src/core/types.ts
+++ b/packages/babylon-wallet-connector/src/core/types.ts
@@ -192,8 +192,10 @@ export interface IETHProvider extends IProvider {
   off(eventName: string, handler: Function): void;
 }
 
+export type ProgressReporter = (message?: string, description?: string) => void;
+
 export interface IProvider {
-  connectWallet: () => Promise<void>;
+  connectWallet: (onProgress?: ProgressReporter) => Promise<void>;
   getAddress: () => Promise<string>;
   getPublicKeyHex: () => Promise<string>;
 }

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/unisat/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/unisat/provider.ts
@@ -1,7 +1,7 @@
 import { Psbt, address as btcAddress, networks } from "bitcoinjs-lib";
 
 import { isAccountChangeEvent, DISCONNECT_EVENT, removeProviderListener } from "@/constants/walletEvents";
-import type { BTCConfig, IBTCProvider, InscriptionIdentifier, SignPsbtOptions, WalletInfo } from "@/core/types";
+import type { BTCConfig, IBTCProvider, InscriptionIdentifier, ProgressReporter, SignPsbtOptions, WalletInfo } from "@/core/types";
 import { Network } from "@/core/types";
 import { initBTCCurve } from "@/core/utils/initBTCCurve";
 import { resolveUseTweakedSigner } from "@/core/utils/psbtOptionsMapper";
@@ -93,7 +93,8 @@ export class UnisatProvider implements IBTCProvider {
       wallet: WALLET_PROVIDER_NAME,
     });
 
-  connectWallet = async (): Promise<void> => {
+  connectWallet = async (onProgress?: ProgressReporter): Promise<void> => {
+    onProgress?.("Connecting Unisat", "Approve the connection request in your Unisat extension");
     try {
       await withTimeout(this.provider.requestAccounts(), UNISAT_PROMPT_TIMEOUT_MS, () =>
         this.timeoutError("requesting accounts"),
@@ -117,17 +118,19 @@ export class UnisatProvider implements IBTCProvider {
     // Run after requestAccounts so origin permission is already granted —
     // getVersion() then resolves synchronously off PlatformEnv.VERSION with
     // no further user prompt.
+    onProgress?.("Checking Unisat version");
     await this.ensureSupportedVersion();
 
     // Unisat silently returns a wrong-network (or empty) account if the wallet
     // is on a chain the dApp does not target. Align the wallet to the configured
     // network before reading the address/pubkey so the connection cannot succeed
     // with a stale mainnet account when signet is required (and vice-versa).
-    await this.ensureExpectedChain();
+    await this.ensureExpectedChain(onProgress);
 
     // Use requestAccounts (not getAccounts) so per-chain dApp approval is
     // re-established after a chain switch. requestAccounts is idempotent on
     // already-authorized chains, so this does not produce an extra prompt.
+    onProgress?.("Finalizing connection");
     const accounts: string[] = await withTimeout(this.provider.requestAccounts(), UNISAT_PROMPT_TIMEOUT_MS, () =>
       this.timeoutError("requesting accounts"),
     );
@@ -197,7 +200,8 @@ export class UnisatProvider implements IBTCProvider {
     });
   };
 
-  private ensureExpectedChain = async (): Promise<void> => {
+  private ensureExpectedChain = async (onProgress?: ProgressReporter): Promise<void> => {
+    onProgress?.("Checking Bitcoin network");
     let currentChain: UnisatChainResponse;
     try {
       currentChain = await withTimeout(this.provider.getChain(), UNISAT_RPC_TIMEOUT_MS, () =>
@@ -225,6 +229,7 @@ export class UnisatProvider implements IBTCProvider {
     }
 
     try {
+      onProgress?.(`Switching to ${targetLabel}`, "Approve the network switch in your Unisat extension");
       await withTimeout(this.provider.switchChain(expectedChain), UNISAT_PROMPT_TIMEOUT_MS, () =>
         this.timeoutError(`switching to ${targetLabel}`),
       );

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/unisat/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/unisat/provider.ts
@@ -125,12 +125,15 @@ export class UnisatProvider implements IBTCProvider {
     // is on a chain the dApp does not target. Align the wallet to the configured
     // network before reading the address/pubkey so the connection cannot succeed
     // with a stale mainnet account when signet is required (and vice-versa).
-    await this.ensureExpectedChain(onProgress);
+    const didSwitchChain = await this.ensureExpectedChain(onProgress);
 
     // Use requestAccounts (not getAccounts) so per-chain dApp approval is
     // re-established after a chain switch. requestAccounts is idempotent on
     // already-authorized chains, so this does not produce an extra prompt.
-    onProgress?.("Finalizing connection");
+    onProgress?.(
+      "Finalizing connection",
+      didSwitchChain ? "Approve the connection request in your Unisat extension" : undefined,
+    );
     const accounts: string[] = await withTimeout(this.provider.requestAccounts(), UNISAT_PROMPT_TIMEOUT_MS, () =>
       this.timeoutError("requesting accounts"),
     );
@@ -200,7 +203,7 @@ export class UnisatProvider implements IBTCProvider {
     });
   };
 
-  private ensureExpectedChain = async (onProgress?: ProgressReporter): Promise<void> => {
+  private ensureExpectedChain = async (onProgress?: ProgressReporter): Promise<boolean> => {
     onProgress?.("Checking Bitcoin network");
     let currentChain: UnisatChainResponse;
     try {
@@ -215,7 +218,7 @@ export class UnisatProvider implements IBTCProvider {
       });
     }
 
-    if (mapUnisatChainToNetwork(currentChain.enum) === this.config.network) return;
+    if (mapUnisatChainToNetwork(currentChain.enum) === this.config.network) return false;
 
     const expectedChain = mapNetworkToUnisatChain(this.config.network);
     const targetLabel = this.config.networkName || this.config.network;
@@ -248,6 +251,8 @@ export class UnisatProvider implements IBTCProvider {
         wallet: WALLET_PROVIDER_NAME,
       });
     }
+
+    return true;
   };
 
   getAddress = async (): Promise<string> => {

--- a/packages/babylon-wallet-connector/src/hooks/useWalletConnectors.tsx
+++ b/packages/babylon-wallet-connector/src/hooks/useWalletConnectors.tsx
@@ -49,8 +49,8 @@ export function useWalletConnectors({ persistent, accountStorage, onError }: Pro
     const connectorArr = Object.values(connectors);
 
     const unsubscribeArr = connectorArr.filter(Boolean).map((connector) =>
-      connector.on("connecting", (message: string) => {
-        displayLoader?.(message);
+      connector.on("connecting", (message?: string, description?: string) => {
+        displayLoader?.(message, description);
       }),
     );
 


### PR DESCRIPTION
## What

When a depositor clicks **Connect → BTC → Unisat** in the vault, the modal used to show a single opaque "Connecting Unisat" spinner for the entire connect duration. Now it tells the user which step it's on, and when the wallet is waiting on the user it surfaces a short description telling them exactly what to do (e.g. "Approve the connection request in your Unisat extension"). Other BTC wallets (OKX, OneKey, Ledger, Keystone, AppKit) are unaffected and keep their existing single-string `Connecting <name>` message.

The Unisat stage map now is:

1. `Connecting Unisat` — "Approve the connection request in your Unisat extension" (initial `requestAccounts`)
2. `Checking Unisat version` (version compatibility check)
3. `Checking Bitcoin network` (read current chain)
4. `Switching to <network>` — "Approve the network switch in your Unisat extension" (only when the wallet is on the wrong network and we trigger `switchChain`)
5. `Finalizing connection` (re-establish per-chain approval + read pubkey)

## Why

Unisat's `connectWallet()` already runs four distinct phases internally — initial `requestAccounts`, version check, network check (with an optional `switchChain` prompt), then a final `requestAccounts` + `getPublicKey`. Each phase can stall on a user action inside the Unisat popup that the depositor can't see from the dApp, and some phases can fail in ways the old spinner did not explain (locked wallet, wrong network, outdated version). The depositor had no idea whether the dApp was working, whether they needed to click something in the extension, or whether something was broken.

The original suggestion was to "check wallet logged in / network points to sBTC/BTC / single address mode". The first two checks already exist in `ensureSupportedVersion` and `ensureExpectedChain` — the depositor just couldn't see them happening. So the real gap was visibility, not missing checks.

## Approaches considered

**1. Add new validation logic (single-address-mode check, explicit "is logged in" probe).** Rejected — Unisat has no single-address-mode toggle, and "logged in" is implicit in `requestAccounts` (the extension prompts the user to unlock). Adding paranoid checks would have been noise without a real user benefit.

**2. Just rotate the title string through phases.** Simpler, but it doesn't give the depositor actionable guidance when the wallet popup is waiting on them. The whole point of the change is to tell users "go click approve in your Unisat extension".

**3. Title + description sub-text per phase, threaded through the existing event system. (Chosen.)** A new optional `onProgress(message, description)` reporter callback flows from `WalletConnector` → `Wallet.connect` → the BTC provider. Only Unisat calls it; the existing `connecting` event signature gains an optional second arg; the `LoaderScreen` gains an optional description below the heading. Everything else (OKX, OneKey, Ledger, Keystone, AppKit) ignores the reporter and shows the existing default message.

## Why we picked approach 3

The real bug is visibility, not missing checks — so we surface what's already happening instead of adding new logic. The change is additive and backward-compatible: every existing provider keeps working untouched because the new reporter argument is optional. The wiring (event payload, reporter threading, loader description rendering) is the same shape we'd want if we ever extend stage messages to OKX or OneKey — that becomes a per-provider follow-up with no infrastructure changes. And the actionable sub-text ("Approve the connection request in your Unisat extension") is the part that actually helps the depositor — a title alone would not have closed the support gap.

## Out of scope

- Stage messages for OKX / OneKey / Ledger / Keystone / AppKit. They stay supported with the existing single-string behaviour. Adding stages to any of them is a per-provider edit using the plumbing this PR introduces.
- Cancel / back UI inside the loader. Today the loader is non-interactive; that does not change.

Additional issue created for OKX/OneKey/Ledger/Keystone etc https://github.com/babylonlabs-io/babylon-toolkit/issues/1793