### PR TITLE
fix(vault): scope deposit banner to UTXO collision only

### DIFF
--- a/services/vault/src/components/simple/DepositSignContent.tsx
+++ b/services/vault/src/components/simple/DepositSignContent.tsx
@@ -49,7 +49,6 @@ export function DepositSignContent({
     currentStep,
     processing,
     error,
-    lastWarnings,
     isWaiting,
     payoutSigningProgress,
     peginSigningProgress,
@@ -84,28 +83,29 @@ export function DepositSignContent({
     onClose();
   }, [abort, onClose]);
 
-  // Hoisted above the success/processing split so the banner survives
+  // UTXO-overlap banner: informational, user can dismiss for the rest of
+  // the session. Hoisted above the success/processing split so it survives
   // the switch to PostDepositContinuation when `continuationVaultIds` is set.
-  const banner = (overlappingPendingVaultCount !== null ||
-    lastWarnings.length > 0) && (
-    <div
-      className="mb-3 flex flex-col gap-1 rounded-lg bg-amber-100 px-4 py-3 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300"
-      role="alert"
-    >
-      {overlappingPendingVaultCount !== null && (
-        <div className="text-sm">
-          {COPY.deposit.warnings.reusesReservedUtxos(
-            overlappingPendingVaultCount,
-          )}
-        </div>
-      )}
-      {lastWarnings.map((w, i) => (
-        <div key={i} className="text-sm">
-          {w}
-        </div>
-      ))}
-    </div>
-  );
+  const [utxoBannerDismissed, setUtxoBannerDismissed] = useState(false);
+  const banner = overlappingPendingVaultCount !== null &&
+    !utxoBannerDismissed && (
+      <div
+        className="relative mb-3 rounded-lg bg-amber-100 px-4 py-3 pr-8 text-sm text-amber-800 dark:bg-amber-900/30 dark:text-amber-300"
+        role="alert"
+      >
+        {COPY.deposit.warnings.reusesReservedUtxos(
+          overlappingPendingVaultCount,
+        )}
+        <button
+          type="button"
+          aria-label={COPY.deposit.warnings.dismissReusesReservedUtxos}
+          onClick={() => setUtxoBannerDismissed(true)}
+          className="absolute right-2 top-2 text-base leading-none opacity-60 hover:opacity-100"
+        >
+          ×
+        </button>
+      </div>
+    );
 
   if (
     continuationVaultIds &&

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -346,6 +346,7 @@ export const COPY = {
         count <= 1
           ? "This deposit and another of your pending BTC Vault deposits selected the same UTXOs. No BTC was committed in the other deposit, it will expire on its own."
           : `This deposit and ${count} of your other pending BTC Vault deposits selected the same UTXOs. No BTC was committed in the other deposits, they will expire on their own.`,
+      dismissReusesReservedUtxos: "Dismiss",
     },
     errors: {
       invalidSecret:


### PR DESCRIPTION
- #1774 inlined `lastWarnings.map(...)` next to the new UTXO-overlap banner in `DepositSignContent`.
Those per-vault timeout strings ("Vault N: WOTS submission failed", "Vault N: Payout signing failed")
had never been rendered before — they were tracked for telemetry only — and they read as related to the
UTXO message when they aren't. Drop that surface.
- Add a small × in the top-right of the UTXO banner so users can dismiss it for the rest of the modal
session.