### PR TITLE
fix(vault): send repay-all sentinel for max-capped Aave repay

### DIFF
--- a/services/vault/src/applications/aave/components/LoanCard/Repay/hooks/__tests__/pickRepayParams.test.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Repay/hooks/__tests__/pickRepayParams.test.ts
@@ -77,6 +77,45 @@ describe("pickRepayParams", () => {
     });
   });
 
+  it("returns 'partial' for an 18-decimal balance one base unit below debt (raw comparison, not rounded)", async () => {
+    // debt = 1e18 + 1, balance = 1e18. Both format to "1"/"1.000…001" and
+    // collapse to the JS number 1, so a rounded comparison would pick
+    // max-capped — whose sentinel repays the full debt while approving only the
+    // balance, reverting. The raw bigints differ, so this must be partial.
+    const result = await pickRepayParams({
+      refetchPosition: () =>
+        Promise.resolve(positionWithDebt(1_000_000_000_000_000_001n)),
+      refetchUserBalance: () =>
+        Promise.resolve(balanceResultOk(1_000_000_000_000_000_000n)),
+      reserveId: RESERVE_ID,
+      tokenDecimals: 18,
+    });
+
+    expect(result.kind).toBe("ok");
+    if (result.kind === "ok") {
+      expect(result.mode).toBe("partial");
+      expect(result.amountRaw).toBeNull();
+    }
+  });
+
+  it("returns 'max-capped' when an 18-decimal balance exactly equals debt", async () => {
+    // Raw balance == raw debt: max-capped is correct (approval covers the debt
+    // exactly, sentinel clears it in full).
+    const equalRaw = 1_000_000_000_000_000_000n;
+    const result = await pickRepayParams({
+      refetchPosition: () => Promise.resolve(positionWithDebt(equalRaw)),
+      refetchUserBalance: () => Promise.resolve(balanceResultOk(equalRaw)),
+      reserveId: RESERVE_ID,
+      tokenDecimals: 18,
+    });
+
+    expect(result.kind).toBe("ok");
+    if (result.kind === "ok") {
+      expect(result.mode).toBe("max-capped");
+      expect(result.amountRaw).toBe(equalRaw);
+    }
+  });
+
   it("returns 'partial' (no bigint) when balance is below debt", async () => {
     const result = await pickRepayParams({
       refetchPosition: () => Promise.resolve(positionWithDebt(100_000_000n)),

--- a/services/vault/src/applications/aave/components/LoanCard/Repay/hooks/pickRepayParams.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Repay/hooks/pickRepayParams.ts
@@ -6,8 +6,8 @@
  * then picks the cheapest repay path that actually clears the debt:
  *
  *   - balance ≥ debt × (1 + buffer)   → `"full"`     (repayFull adds buffer)
- *   - debt ≤ balance < debt × (1+buf) → `"max-capped"` (send full balance;
- *                                       adapter pulls min(balance, debt))
+ *   - debt ≤ balance < debt × (1+buf) → `"max-capped"` (approve full balance,
+ *                                       send repay-all sentinel; clears debt)
  *   - balance < debt                  → `"partial"`  (send full balance)
  *
  * Doing this at submit (not at Max-button click) avoids the stale-snapshot
@@ -65,6 +65,7 @@ export async function pickRepayParams({
   tokenDecimals,
 }: PickRepayParamsArgs): Promise<PickRepayParamsResult> {
   let freshDebtAmount: number;
+  let freshDebtRaw: bigint;
   let freshBalanceAmount: number;
   let freshBalanceRaw: bigint;
 
@@ -80,7 +81,7 @@ export async function pickRepayParams({
       throw freshBalanceResult.error ?? new Error("Balance refetch failed");
     }
 
-    const freshDebtRaw =
+    freshDebtRaw =
       freshPosition?.debtPositions?.get(reserveId)?.totalDebt ?? 0n;
     freshDebtAmount = Number(formatUnits(freshDebtRaw, tokenDecimals));
     freshBalanceRaw = freshBalanceResult.data ?? 0n;
@@ -114,10 +115,10 @@ export async function pickRepayParams({
       amountRaw: null,
     };
   }
-  if (freshBalanceAmount >= freshDebtAmount) {
-    // Caller passes `amountRaw` to `executeRepay` so the parseUnits round-trip
-    // in useRepayTransaction can't round up by 1 ULP and produce an approval
-    // larger than the user's actual balance.
+  // Compare raw bigints, not the rounded JS numbers: at 18 decimals a balance
+  // one base unit below the debt rounds equal, and max-capped's sentinel repays
+  // the full debt while approving only the balance — which would revert.
+  if (freshBalanceRaw >= freshDebtRaw) {
     return {
       kind: "ok",
       mode: "max-capped",

--- a/services/vault/src/applications/aave/hooks/useRepayTransaction.ts
+++ b/services/vault/src/applications/aave/hooks/useRepayTransaction.ts
@@ -37,10 +37,10 @@ import type { AaveReserveConfig } from "../services/fetchConfig";
  * - `"partial"` — user typed a specific amount; send it verbatim, no buffer.
  * - `"full"` — user wants to clear the debt and balance covers debt × (1 + buffer);
  *   service refetches debt at broadcast time and adds the buffer.
- * - `"max-capped"` — user wants to clear the debt but balance is between
- *   `debt` and `debt × (1 + buffer)`; approve and send the user's full balance,
- *   adapter pulls `min(balance, actualDebt)`. Residual ≤ accrual during
- *   broadcast (sub-cent in practice).
+ * - `"max-capped"` — balance is between `debt` and `debt × (1 + buffer)`;
+ *   approve the full balance as the cap and send the repay-all sentinel
+ *   (`maxUint256`). Adapter clears the full debt; reverts cleanly if accrued
+ *   interest exceeds the balance.
  */
 export type RepayMode = "partial" | "full" | "max-capped";
 

--- a/services/vault/src/applications/aave/services/__tests__/positionTransactions.test.ts
+++ b/services/vault/src/applications/aave/services/__tests__/positionTransactions.test.ts
@@ -2,6 +2,7 @@
  * Tests for Aave position transactions.
  */
 
+import { maxUint256 } from "viem";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Hoist mock functions so they can be used in vi.mock factories
@@ -260,7 +261,7 @@ describe("positionTransactions", () => {
     // Global default already starts simulatedAllowance at 0; no per-block
     // setup needed.
 
-    it("should approve and send the user's full balance verbatim (no buffer math)", async () => {
+    it("should approve the full balance as the cap and send the repay-all sentinel", async () => {
       const balanceAmount = 200_000_000n;
 
       await repayMaxCapped(
@@ -271,7 +272,7 @@ describe("positionTransactions", () => {
         balanceAmount,
       );
 
-      // The whole point of this path: approve exactly the cap, not cap × (1+buffer).
+      // Approve exactly the cap (the user's balance), not cap × (1+buffer).
       expect(mockApproveERC20).toHaveBeenCalledWith(
         mockWalletClient,
         mockChain,
@@ -280,13 +281,15 @@ describe("positionTransactions", () => {
         balanceAmount,
       );
 
+      // Send maxUint256 so the adapter clears the full current debt (including
+      // interest accrued during broadcast), capped by the approved balance.
       expect(mockRepayToCorePosition).toHaveBeenCalledWith(
         mockWalletClient,
         mockChain,
         "0xadapter",
         "0xuser",
         1n,
-        balanceAmount,
+        maxUint256,
       );
     });
 

--- a/services/vault/src/applications/aave/services/positionTransactions.ts
+++ b/services/vault/src/applications/aave/services/positionTransactions.ts
@@ -13,6 +13,7 @@ import type {
   TransactionReceipt,
   WalletClient,
 } from "viem";
+import { maxUint256 } from "viem";
 
 import { ERC20 } from "../../../clients/eth-contract";
 import { AaveAdapterTx, AaveSpoke } from "../clients";
@@ -184,30 +185,13 @@ export async function repayPartial(
 }
 
 /**
- * Repay as much as the user's balance permits, when balance is less than
- * `debt × (1 + buffer)` (so `repayFull` would refuse).
+ * Clear the full debt for the `debt ≤ balance < debt × (1 + buffer)` case
+ * (`pickRepayParams` only routes here when `balance ≥ debt`). Sends `maxUint256`
+ * (Aave's repay-all sentinel) so the adapter clears the current debt incl.
+ * interest accrued before broadcast, but caps the approval at `balanceAmount` —
+ * if accrual pushes debt past the balance the tx reverts cleanly, not silent dust.
  *
- * The adapter pulls `min(amount, currentDebtAtExecution)`, so sending the
- * user's full balance leaves at most `currentDebtAtExecution - balance` of
- * residual debt — which is the interest accrued between the caller's
- * balance check and the broadcast block (sub-cent in practice).
- *
- * `balanceAmount` is treated as the user's full on-chain balance at submit
- * time — the submit path resolves it via `pickRepayParams`, which refetches
- * debt + balance in the same tick as the wallet sign request. This function
- * deliberately does not refetch balance, so the pulled amount stays strictly
- * capped at whatever the caller passed.
- *
- * Approval/refund: the adapter pulls the full approved amount, routes the
- * debt, and refunds the excess in the same tx. Residual allowance after the
- * tx = 0; no `approve(0)` cleanup needed.
- *
- * @param walletClient - Connected wallet client
- * @param chain - Chain configuration
- * @param debtReserveId - Reserve ID for the debt token
- * @param tokenAddress - Token address for the debt
- * @param balanceAmount - The user's full token balance (the cap); approved and sent verbatim
- * @returns Transaction result
+ * @param balanceAmount - User's full balance; approved as the cap (amount sent is `maxUint256`)
  */
 export async function repayMaxCapped(
   walletClient: WalletClient,
@@ -236,7 +220,7 @@ export async function repayMaxCapped(
     balanceAmount,
   );
 
-  return repay(walletClient, chain, userAddress, debtReserveId, balanceAmount);
+  return repay(walletClient, chain, userAddress, debtReserveId, maxUint256);
 }
 
 /**


### PR DESCRIPTION
`repayMaxCapped` (the path taken when balance covers the debt but not the
full-repay buffer, i.e. `debt ≤ balance < debt × (1 + buffer)`) previously
sent the user's balance as the repay `amount`. The adapter repays
`min(amount, currentDebt)`, so when interest accrued between the submit-time
balance check and the broadcast block, it pulled the balance and left a
sub-cent residual debt — which then keeps accruing and the position never
reads as fully repaid.

Now we send `maxUint256` (Aave's repay-all sentinel), so the adapter clamps
the repay to the current debt at execution and clears it in full. The
**approval stays capped at the user's balance**: if accrued interest pushes
the debt above the balance, the transfer exceeds the allowance and the tx
reverts cleanly (the user retries) instead of leaving silent dust.

No partial-paydown regression: `pickRepayParams` only routes to `max-capped`
when `balance ≥ debt`; a balance below the debt goes to `repayPartial`.