### PR TITLE
feat(vault): redesign deposit error callout and map error msg

### DIFF
--- a/packages/babylon-core-ui/src/components/Callout/Callout.stories.tsx
+++ b/packages/babylon-core-ui/src/components/Callout/Callout.stories.tsx
@@ -1,0 +1,69 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { Callout } from "./Callout";
+
+const meta: Meta<typeof Callout> = {
+  title: "Components/Data Display/Indicators/Callout",
+  component: Callout,
+  tags: ["autodocs"],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Error: Story = {
+  args: {
+    variant: "error",
+    title: "Transaction failed",
+    children: (
+      <>
+        Your wallet <strong>doesn&rsquo;t have enough ETH</strong> to cover the
+        network fee.
+        <br />
+        Add more ETH and retry the transaction.
+      </>
+    ),
+  },
+};
+
+export const Warning: Story = {
+  args: {
+    variant: "warning",
+    title: "Slow network",
+    children:
+      "Bitcoin network fees are higher than usual. Your deposit may take longer to confirm.",
+  },
+};
+
+export const Success: Story = {
+  args: {
+    variant: "success",
+    title: "Deposit confirmed",
+    children: "Your BTC vault has been activated on the network.",
+  },
+};
+
+export const Info: Story = {
+  args: {
+    variant: "info",
+    title: "Heads up",
+    children: "Keep this browser tab open while we sign the remaining steps.",
+  },
+};
+
+export const WithoutTitle: Story = {
+  args: {
+    variant: "info",
+    children: "A short standalone callout with no title.",
+  },
+};
+
+export const LongBody: Story = {
+  args: {
+    variant: "error",
+    title: "Transaction failed",
+    children:
+      "Wallet returned an unrecognized error 0x70a08231000000000000000000000000abcdef0123456789abcdef0123456789abcdef. Try reconnecting your wallet and retrying the transaction.",
+  },
+};

--- a/packages/babylon-core-ui/src/components/Callout/Callout.tsx
+++ b/packages/babylon-core-ui/src/components/Callout/Callout.tsx
@@ -1,0 +1,76 @@
+import { type HTMLAttributes, type ReactNode } from "react";
+import { twMerge } from "tailwind-merge";
+
+import { CheckIcon, CloseIcon, InfoIcon, WarningIcon } from "../Icons";
+import { Text } from "../Text";
+
+export type CalloutVariant = "error" | "warning" | "success" | "info";
+
+export interface CalloutProps
+  extends Omit<HTMLAttributes<HTMLDivElement>, "title"> {
+  variant: CalloutVariant;
+  title?: ReactNode;
+  icon?: ReactNode;
+  children: ReactNode;
+}
+
+const VARIANT_BG: Record<CalloutVariant, string> = {
+  error: "bg-error-main",
+  warning: "bg-warning-main",
+  success: "bg-success-main",
+  info: "bg-info-main",
+};
+
+const DEFAULT_ICONS: Record<CalloutVariant, ReactNode> = {
+  error: <CloseIcon size={24} color="text-accent-contrast" />,
+  warning: <WarningIcon size={24} color="text-accent-contrast" />,
+  success: <CheckIcon size={24} color="text-accent-contrast" />,
+  info: <InfoIcon size={24} color="text-accent-contrast" />,
+};
+
+export function Callout({
+  variant,
+  title,
+  icon,
+  className,
+  children,
+  role,
+  ...rest
+}: CalloutProps) {
+  const resolvedRole = role ?? (variant === "error" ? "alert" : "status");
+
+  return (
+    <div
+      role={resolvedRole}
+      className={twMerge(
+        "flex w-full items-start gap-4 rounded-lg border border-secondary-strokeLight bg-secondary-highlight p-4",
+        className,
+      )}
+      {...rest}
+    >
+      <div
+        aria-hidden="true"
+        className={twMerge(
+          "flex h-10 w-10 shrink-0 items-center justify-center rounded-lg",
+          VARIANT_BG[variant],
+        )}
+      >
+        {icon ?? DEFAULT_ICONS[variant]}
+      </div>
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        {title && (
+          <Text variant="body1" className="break-words text-accent-primary">
+            {title}
+          </Text>
+        )}
+        <Text
+          as="div"
+          variant="body2"
+          className="break-words text-accent-secondary"
+        >
+          {children}
+        </Text>
+      </div>
+    </div>
+  );
+}

--- a/packages/babylon-core-ui/src/components/Callout/index.ts
+++ b/packages/babylon-core-ui/src/components/Callout/index.ts
@@ -1,0 +1,2 @@
+export { Callout } from "./Callout";
+export type { CalloutProps, CalloutVariant } from "./Callout";

--- a/packages/babylon-core-ui/src/index.tsx
+++ b/packages/babylon-core-ui/src/index.tsx
@@ -30,6 +30,7 @@ export * from "./components/CoStakingAmountItem";
 export * from "./components/DisplayHash";
 export * from "./components/Copy";
 export * from "./components/Icons";
+export * from "./components/Callout";
 export * from "./components/Warning";
 export * from "./components/Hint";
 export * from "./components/DismissibleSubSection";

--- a/services/vault/src/components/__tests__/Callout.test.tsx
+++ b/services/vault/src/components/__tests__/Callout.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * Contract tests for the core-ui Callout, exercised from the vault suite
+ * (core-ui has no test runner of its own). These pin the behaviours
+ * DepositProgressView relies on: the error variant is an assertive `alert`,
+ * other variants are polite `status`, each variant paints its own icon-box
+ * background, and every variant ships a default icon.
+ */
+
+import { Callout } from "@babylonlabs-io/core-ui";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+describe("Callout", () => {
+  it("renders the error variant as an alert (assertive announcement)", () => {
+    render(
+      <Callout variant="error" title="Transaction failed">
+        Add more ETH
+      </Callout>,
+    );
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+  });
+
+  it("renders non-error variants as a polite status", () => {
+    const { rerender } = render(<Callout variant="success">Done</Callout>);
+    expect(screen.getByRole("status")).toBeInTheDocument();
+
+    rerender(<Callout variant="warning">Careful</Callout>);
+    expect(screen.getByRole("status")).toBeInTheDocument();
+
+    rerender(<Callout variant="info">Heads up</Callout>);
+    expect(screen.getByRole("status")).toBeInTheDocument();
+  });
+
+  it("lets callers override the role via native div attributes", () => {
+    render(
+      <Callout variant="error" role="status">
+        Quiet error
+      </Callout>,
+    );
+    expect(screen.getByRole("status")).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("renders the title and body", () => {
+    render(
+      <Callout variant="error" title="Transaction failed">
+        Your wallet doesn&rsquo;t have enough ETH
+      </Callout>,
+    );
+    expect(screen.getByText("Transaction failed")).toBeInTheDocument();
+    expect(screen.getByText(/doesn.t have enough ETH/)).toBeInTheDocument();
+  });
+
+  it("paints the per-variant icon-box background", () => {
+    const cases: Array<[Parameters<typeof Callout>[0]["variant"], string]> = [
+      ["error", "bg-error-main"],
+      ["warning", "bg-warning-main"],
+      ["success", "bg-success-main"],
+      ["info", "bg-info-main"],
+    ];
+    for (const [variant, bgClass] of cases) {
+      const { container, unmount } = render(
+        <Callout variant={variant}>body</Callout>,
+      );
+      expect(container.querySelector(`.${bgClass}`)).not.toBeNull();
+      unmount();
+    }
+  });
+
+  it("ships a default icon inside the icon box for each variant", () => {
+    for (const variant of ["error", "warning", "success", "info"] as const) {
+      const { container, unmount } = render(
+        <Callout variant={variant}>body</Callout>,
+      );
+      // The icon box is the only square with a variant background; it should
+      // contain the default SVG icon.
+      expect(container.querySelector("svg")).not.toBeNull();
+      unmount();
+    }
+  });
+
+  it("renders a caller-supplied icon instead of the default", () => {
+    render(
+      <Callout variant="error" icon={<span data-testid="custom-icon" />}>
+        body
+      </Callout>,
+    );
+    expect(screen.getByTestId("custom-icon")).toBeInTheDocument();
+  });
+});

--- a/services/vault/src/components/deposit/DepositSignModal/depositStepHelpers.ts
+++ b/services/vault/src/components/deposit/DepositSignModal/depositStepHelpers.ts
@@ -5,10 +5,10 @@ import { DepositFlowStep } from "@/hooks/deposit/depositFlowSteps";
  */
 function canCloseModal(
   currentStep: DepositFlowStep,
-  error: string | null,
+  hasError: boolean,
   isWaiting: boolean = false,
 ): boolean {
-  if (error) return true;
+  if (hasError) return true;
   if (currentStep === DepositFlowStep.COMPLETED) return true;
   // Artifact download is closeable when the user is actively reviewing
   // (no current wait) or while we're waiting for VP verification.
@@ -37,16 +37,16 @@ export function computeDepositDerivedState(
   currentStep: DepositFlowStep,
   processing: boolean,
   isWaiting: boolean,
-  error: string | null,
+  hasError: boolean,
 ) {
   const isComplete = currentStep === DepositFlowStep.COMPLETED;
   return {
     isComplete,
-    canClose: canCloseModal(currentStep, error, isWaiting),
-    isProcessing: (processing || isWaiting) && !error && !isComplete,
+    canClose: canCloseModal(currentStep, hasError, isWaiting),
+    isProcessing: (processing || isWaiting) && !hasError && !isComplete,
     canContinueInBackground:
       isWaiting &&
       currentStep >= DepositFlowStep.AWAIT_BTC_CONFIRMATION &&
-      !error,
+      !hasError,
   };
 }

--- a/services/vault/src/components/simple/DepositProgressView/DepositProgressView.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/DepositProgressView.tsx
@@ -9,14 +9,20 @@
  * banners, action button.
  */
 
-import { Button, Heading, Loader, Text } from "@babylonlabs-io/core-ui";
+import {
+  Button,
+  Callout,
+  Heading,
+  Loader,
+  Text,
+} from "@babylonlabs-io/core-ui";
 import { type ReactNode, useMemo } from "react";
 
-import { StatusBanner } from "@/components/deposit/DepositSignModal/StatusBanner";
 import { COPY } from "@/copy";
 import { DepositFlowStep } from "@/hooks/deposit/depositFlowSteps/types";
 import type { PayoutSigningProgress } from "@/services/vault/vaultPayoutSignatureService";
 import type { PeginSigningProgress } from "@/services/vault/vaultTransactionService";
+import type { DepositErrorContent } from "@/utils/errors";
 
 import { BtcConfirmationDetailContainer } from "./BtcConfirmationDetailContainer";
 import { CompletedStepsPill } from "./CompletedStepsPill";
@@ -50,7 +56,7 @@ export interface BtcConfirmationDetailData {
 
 export interface DepositProgressViewProps {
   currentStep: DepositFlowStep;
-  error: string | null;
+  error: DepositErrorContent | null;
   isComplete: boolean;
   isProcessing: boolean;
   canClose: boolean;
@@ -195,14 +201,16 @@ export function DepositProgressView(props: DepositProgressViewProps) {
           activeStepDetail={activeStepDetail}
         />
 
-        {error && <StatusBanner variant="error">{error}</StatusBanner>}
-
-        {isComplete && (
-          <StatusBanner variant="success">{successMessage}</StatusBanner>
+        {error && (
+          <Callout variant="error" title={error.title}>
+            {error.body}
+          </Callout>
         )}
 
+        {isComplete && <Callout variant="success">{successMessage}</Callout>}
+
         {isTerminalSuccess && (
-          <StatusBanner variant="success">{terminalMessage}</StatusBanner>
+          <Callout variant="success">{terminalMessage}</Callout>
         )}
 
         <Button

--- a/services/vault/src/components/simple/DepositProgressView/__tests__/DepositProgressView.test.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/__tests__/DepositProgressView.test.tsx
@@ -534,7 +534,7 @@ describe("DepositProgressView", () => {
         <DepositProgressView
           {...baseProps}
           currentStep={DepositFlowStep.RETRIEVE_SECRET}
-          error="boom"
+          error={{ title: "Transaction failed", body: "boom" }}
           terminalMessage="Ready to activate."
         />,
       );

--- a/services/vault/src/components/simple/DepositSignContent.tsx
+++ b/services/vault/src/components/simple/DepositSignContent.tsx
@@ -76,7 +76,12 @@ export function DepositSignContent({
 
   // Derived state
   const { isComplete, canClose, isProcessing, canContinueInBackground } =
-    computeDepositDerivedState(currentStep, processing, isWaiting, error);
+    computeDepositDerivedState(
+      currentStep,
+      processing,
+      isWaiting,
+      error != null,
+    );
 
   const handleClose = useCallback(() => {
     abort();

--- a/services/vault/src/components/simple/PostDepositContinuationView.tsx
+++ b/services/vault/src/components/simple/PostDepositContinuationView.tsx
@@ -14,6 +14,7 @@ import {
   USER_ACTIONABLE_PEGIN_ACTIONS,
 } from "@/models/peginStateMachine";
 import type { VaultActivity } from "@/types/activity";
+import { type DepositErrorContent, mapDepositError } from "@/utils/errors";
 
 import { ActivationGate } from "./ActivationGate";
 import {
@@ -95,7 +96,7 @@ function StatusView({
 }: {
   currentStep: DepositFlowStep;
   onClose: () => void;
-  error?: string | null;
+  error?: DepositErrorContent | null;
   isComplete?: boolean;
   isProcessing?: boolean;
   canContinueInBackground?: boolean;
@@ -176,7 +177,9 @@ export function PostDepositContinuationView({
       return (
         <StatusView
           currentStep={stepForWarningVault(warning)}
-          error={warning.message ?? COPY.common.somethingWentWrong.body}
+          error={mapDepositError(
+            warning.message ?? COPY.common.somethingWentWrong.body,
+          )}
           onClose={onClose}
         />
       );

--- a/services/vault/src/components/simple/ResumeDepositContent.tsx
+++ b/services/vault/src/components/simple/ResumeDepositContent.tsx
@@ -54,6 +54,7 @@ import {
   shouldProbeWalletLiveness,
   verifyBtcWalletLiveness,
 } from "@/utils/btc";
+import { mapDepositError } from "@/utils/errors";
 import { getVpProxyUrl } from "@/utils/rpc";
 
 import { DepositProgressView } from "./DepositProgressView";
@@ -119,13 +120,17 @@ export function ResumeSignContent({
     renderStep,
     signing,
     renderIsWaiting,
-    error?.message ?? null,
+    error != null,
   );
 
   return (
     <DepositProgressView
       currentStep={renderStep}
-      error={error?.message ?? null}
+      // usePayoutSigningState already produces structured { title, message }
+      // errors with actionable guard titles (missing/mismatched payout address,
+      // wallet liveness, etc.). Pass them through directly so the callout keeps
+      // that title instead of collapsing to the generic mapped fallback.
+      error={error ? { title: error.title, body: error.message } : null}
       isComplete={derived.isComplete}
       isProcessing={derived.isProcessing}
       canClose={derived.canClose}
@@ -188,13 +193,13 @@ export function ResumeBroadcastContent({
     DepositFlowStep.BROADCAST_PRE_PEGIN,
     broadcasting,
     false,
-    error,
+    error != null,
   );
 
   return (
     <DepositProgressView
       currentStep={DepositFlowStep.BROADCAST_PRE_PEGIN}
-      error={error}
+      error={error ? mapDepositError(error) : null}
       isComplete={derived.isComplete}
       isProcessing={derived.isProcessing}
       canClose={derived.canClose}
@@ -449,7 +454,7 @@ export function ResumeWotsContent({
     renderStep,
     loading && !advanced,
     advanced,
-    error,
+    error != null,
   );
 
   // requiredDepth is pinned to the version this deposit registered against
@@ -477,7 +482,7 @@ export function ResumeWotsContent({
   return (
     <DepositProgressView
       currentStep={renderStep}
-      error={error}
+      error={error ? mapDepositError(error) : null}
       isComplete={derived.isComplete}
       isProcessing={derived.isProcessing}
       canClose={derived.canClose}
@@ -667,7 +672,7 @@ export function ResumeActivationContent({
     renderStep,
     activating || loading,
     activated && !active,
-    error,
+    error != null,
   );
 
   const handleDone = useCallback(() => {
@@ -681,7 +686,7 @@ export function ResumeActivationContent({
   return (
     <DepositProgressView
       currentStep={renderStep}
-      error={error}
+      error={error ? mapDepositError(error) : null}
       isComplete={derived.isComplete}
       isProcessing={derived.isProcessing}
       canClose={derived.canClose}

--- a/services/vault/src/components/simple/__tests__/PostDepositContinuationView.test.tsx
+++ b/services/vault/src/components/simple/__tests__/PostDepositContinuationView.test.tsx
@@ -85,9 +85,42 @@ vi.mock("@/copy", () => ({
   COPY: {
     deposit: {
       resume: { activationSuccessMessage: "Deposit successfully submitted!" },
+      errors: {
+        defaultTitle: "Transaction failed",
+        genericBody: "Something went wrong during your deposit.",
+        signingRejected: { title: "Signing rejected", body: "You rejected." },
+        walletNotConnected: {
+          title: "Wallet not connected",
+          body: "Reconnect.",
+        },
+        walletAccountChanged: {
+          title: "Wallet account changed",
+          body: "Restart.",
+        },
+        utxosUnavailable: { title: "Funds unavailable", body: "In use." },
+        broadcastFailed: { title: "Broadcast failed", body: "Try again." },
+        providerNotFound: { title: "Provider not found", body: "Refresh." },
+        versionMismatch: { title: "Parameters changed", body: "Restart." },
+        insufficientEthForGas: {
+          title: "Transaction failed",
+          body: "Not enough ETH.",
+        },
+      },
     },
     common: {
       somethingWentWrong: { body: "Please close this and try again." },
+      // formatting.ts builds FRIENDLY_MESSAGES from these at module load, and
+      // depositErrors.ts (imported transitively here) pulls formatting.ts in.
+      classifiedErrors: {
+        userRejection: "You rejected the request.",
+        insufficientFunds: "Not enough funds.",
+        walletDisconnected: "Wallet disconnected.",
+        unauthorized: "Not authorized.",
+        chainSwitchFailed: "Could not switch network.",
+        receiptTimeout: "Confirmation timed out.",
+        network: "Network error.",
+        staleDeploy: "Reload the page.",
+      },
     },
   },
 }));
@@ -100,13 +133,13 @@ vi.mock("../DepositProgressView", () => ({
     onClose,
   }: {
     currentStep: string;
-    error?: string | null;
+    error?: { title: string; body: string } | null;
     isComplete?: boolean;
     onClose: () => void;
   }) => (
     <div data-testid="progress-view">
       <span data-testid="step">{String(currentStep)}</span>
-      <span data-testid="error">{error ?? ""}</span>
+      <span data-testid="error">{error?.body ?? ""}</span>
       <span data-testid="complete">{String(!!isComplete)}</span>
       <button type="button" data-testid="progress-close" onClick={onClose}>
         close

--- a/services/vault/src/components/simple/__tests__/ResumeDepositContent.test.tsx
+++ b/services/vault/src/components/simple/__tests__/ResumeDepositContent.test.tsx
@@ -41,6 +41,7 @@ vi.mock("@babylonlabs-io/ts-sdk/tbv/core", () => ({
   expandWotsSeed: vi.fn(() => new Uint8Array(32)),
   hexToUint8Array: vi.fn(() => new Uint8Array(32)),
   isWotsMismatchError: vi.fn(() => false),
+  isRegisteredVaultVersionMismatchError: vi.fn(() => false),
   parseFundingOutpointsFromTx: mockParseFundingOutpointsFromTx,
   stripHexPrefix: vi.fn((hex: string) => hex.replace(/^0x/, "")),
   uint8ArrayToHex: vi.fn(() => "00".repeat(32)),
@@ -48,6 +49,9 @@ vi.mock("@babylonlabs-io/ts-sdk/tbv/core", () => ({
 
 vi.mock("@babylonlabs-io/ts-sdk/tbv/core/clients", () => ({
   primeVpTokenRegistry: vi.fn(),
+  // mapDepositError narrows on `instanceof JsonRpcError`; provide a real class
+  // so the check is callable (these tests never throw a JsonRpcError).
+  JsonRpcError: class JsonRpcError extends Error {},
 }));
 
 vi.mock("@babylonlabs-io/ts-sdk/tbv/core/utils", () => ({
@@ -191,7 +195,7 @@ vi.mock("../DepositProgressView", () => ({
     canContinueInBackground,
   }: {
     currentStep?: string;
-    error?: string | null;
+    error?: { title: string; body: string } | null;
     isComplete?: boolean;
     isProcessing?: boolean;
     terminalMessage?: string | null;
@@ -199,7 +203,7 @@ vi.mock("../DepositProgressView", () => ({
   }) => (
     <div data-testid="progress-view">
       <span data-testid="step">{String(currentStep)}</span>
-      <span data-testid="error">{error ?? ""}</span>
+      <span data-testid="error">{error?.body ?? ""}</span>
       <span data-testid="complete">{String(!!isComplete)}</span>
       <span data-testid="processing">{String(!!isProcessing)}</span>
       <span data-testid="terminal">{terminalMessage ?? ""}</span>

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -40,6 +40,12 @@
 const PRE_PEGIN_BROADCAST_CONFIRMATION_MESSAGE =
   "Your Bitcoin transaction has been broadcast to the network. It will be confirmed after receiving the required number of Bitcoin confirmations.";
 const SOMETHING_WENT_WRONG_HEADING = "Something went wrong";
+// Generic deposit-failure title; shared so per-bucket titles can't drift.
+const TRANSACTION_FAILED_TITLE = "Transaction failed";
+// Shared between the resume WOTS error string and the mapped callout body so
+// the wording stays in one place.
+const WRONG_WALLET_BODY =
+  "WOTS public key hash does not match the on-chain commitment — the wrong wallet is connected.";
 
 export const COPY = {
   pegin: {
@@ -336,8 +342,7 @@ export const COPY = {
       activationSuccessMessage: "Your BTC Vault has been activated.",
       readyToActivateMessage:
         "Your payout transactions are signed and verified. Your BTC Vault is ready to activate.",
-      wotsMismatchError:
-        "WOTS public key hash does not match the on-chain commitment — the wrong wallet is connected.",
+      wotsMismatchError: WRONG_WALLET_BODY,
     },
     warnings: {
       depositRecordNotSaved:
@@ -355,6 +360,90 @@ export const COPY = {
         `Please switch to ${network} in your wallet`,
       ethereumMainnet: "Ethereum Mainnet",
       sepoliaTestnet: "Sepolia Testnet",
+      // ----------------------------------------------------------------------
+      // Deposit-flow error callout copy (title + body). Consumed by
+      // `mapDepositError` (utils/errors/depositErrors.ts). `defaultTitle` is the
+      // generic fallback title shown in the error Callout; `genericBody` is the
+      // fallback body only when the raw error is unrecognized and unsafe to show.
+      // ----------------------------------------------------------------------
+      defaultTitle: TRANSACTION_FAILED_TITLE,
+      genericBody:
+        "Something went wrong during your deposit. Please try again.",
+      insufficientEthForGas: {
+        title: TRANSACTION_FAILED_TITLE,
+        body: "Your wallet doesn't have enough ETH to cover the network fee. Add more ETH and retry the transaction.",
+      },
+      signingRejected: {
+        title: "Signing rejected",
+        body: "You rejected the request in your wallet. Click Retry to approve it and continue.",
+      },
+      walletNotConnected: {
+        title: "Wallet not connected",
+        body: "Please reconnect your Bitcoin and Ethereum wallets, then try again.",
+      },
+      walletAccountChanged: {
+        title: "Wallet account changed",
+        body: "Your wallet account changed during the deposit. Please restart the deposit with the original account.",
+      },
+      utxosUnavailable: {
+        title: "Bitcoin funds unavailable",
+        body: "We couldn't confirm your Bitcoin funds are available. They may be in use by another deposit. Please try again in a moment.",
+      },
+      broadcastFailed: {
+        title: "Broadcast failed",
+        body: "We couldn't broadcast your Bitcoin transaction to the network. Please try again.",
+      },
+      providerNotFound: {
+        title: "Vault provider not found",
+        body: "The selected vault provider could not be found. Please refresh and try again.",
+      },
+      versionMismatch: {
+        title: "Protocol parameters changed",
+        body: "The protocol parameters changed while preparing your deposit. Please restart the deposit.",
+      },
+      wrongWalletAccount: {
+        title: "Wrong wallet account",
+        body: WRONG_WALLET_BODY,
+      },
+      // Vault-provider JSON-RPC error copy, consumed by `mapVpRpcError`
+      // (utils/errors/formatting.ts). Title + message are both user-facing.
+      vp: {
+        syncing: {
+          title: "Vault Provider Syncing",
+          message:
+            "The vault provider hasn't ingested your peg-in yet. Please wait a moment and try again.",
+        },
+        requestTimeout: {
+          title: "Request Timeout",
+          message:
+            "The vault provider took too long to respond. Please try again.",
+        },
+        providerNotFound: {
+          title: "Provider Not Found",
+          message:
+            "The vault provider could not be found in the on-chain registry. It may have been deregistered.",
+        },
+        connectionFailed: {
+          title: "Connection Failed",
+          message:
+            "Unable to connect to the vault provider. Please check your connection and try again.",
+        },
+        providerTimeout: {
+          title: "Provider Timeout",
+          message:
+            "The vault provider took too long to respond. Please try again later.",
+        },
+        providerUnavailable: {
+          title: "Provider Unavailable",
+          message:
+            "The vault provider is temporarily unreachable. Please try again later.",
+        },
+        rejected: {
+          title: "Signature Submission Failed",
+          message: (code: number) =>
+            `The vault provider rejected the request (error code: ${code}). Please try again or contact support.`,
+        },
+      },
     },
     payoutSigningGuards: {
       missingPayoutAddress: {

--- a/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
@@ -9,8 +9,12 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import type { Address, Hex } from "viem";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { COPY } from "@/copy";
+
 import { DepositFlowStep } from "../depositFlowSteps";
 import { useDepositFlow } from "../useDepositFlow";
+
+const DEPOSIT_ERRORS = COPY.deposit.errors;
 
 // ============================================================================
 // Mocks
@@ -585,8 +589,9 @@ describe("useDepositFlow", () => {
       await executeWithAutoArtifactDownload(result);
 
       await waitFor(() => {
-        expect(result.current.error).toMatch(
-          /signer-set or offchain-params versions changed/,
+        // Version-mismatch errors map to the friendly "parameters changed" copy.
+        expect(result.current.error?.body).toBe(
+          DEPOSIT_ERRORS.versionMismatch.body,
         );
       });
       expect(broadcastPrePeginTransaction).not.toHaveBeenCalled();
@@ -660,7 +665,8 @@ describe("useDepositFlow", () => {
       await executeWithAutoArtifactDownload(result);
 
       await waitFor(() => {
-        expect(result.current.error).toContain(
+        // Unrecognized errors fall through to the sanitized raw message.
+        expect(result.current.error?.body).toContain(
           "Vault keeper BTC pubkeys do not match",
         );
       });
@@ -955,8 +961,8 @@ describe("useDepositFlow", () => {
       await executeWithAutoArtifactDownload(result);
 
       await waitFor(() => {
-        expect(result.current.error).toContain(
-          "BTC wallet account changed during deposit flow",
+        expect(result.current.error?.body).toBe(
+          DEPOSIT_ERRORS.walletAccountChanged.body,
         );
       });
 
@@ -1099,8 +1105,9 @@ describe("useDepositFlow", () => {
       await executeWithAutoArtifactDownload(result);
 
       await waitFor(() => {
-        expect(result.current.error).toContain(
-          "Failed to broadcast batch Pre-PegIn transaction",
+        // Broadcast failures map to the friendly broadcast callout.
+        expect(result.current.error?.body).toBe(
+          DEPOSIT_ERRORS.broadcastFailed.body,
         );
       });
       // The depositRecordNotSaved warning collected BEFORE the broadcast
@@ -1124,7 +1131,9 @@ describe("useDepositFlow", () => {
       await executeWithAutoArtifactDownload(result);
 
       await waitFor(() => {
-        expect(result.current.error).toContain("Insufficient funds");
+        // A BTC sat shortfall isn't a known bucket, so the raw message is
+        // preserved in the callout body.
+        expect(result.current.error?.body).toContain("Insufficient funds");
         expect(result.current.processing).toBe(false);
       });
     });

--- a/services/vault/src/hooks/deposit/useDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useDepositFlow.ts
@@ -79,7 +79,7 @@ import {
   verifyBtcWalletLiveness,
 } from "@/utils/btc";
 import { satoshiToBtcNumber } from "@/utils/btcConversion";
-import { sanitizeErrorMessage } from "@/utils/errors/formatting";
+import { mapDepositError, type DepositErrorContent } from "@/utils/errors";
 import { formatBtcValue } from "@/utils/formatting";
 import { getVpProxyUrl } from "@/utils/rpc";
 
@@ -142,8 +142,8 @@ export interface UseDepositFlowReturn {
   currentVaultIndex: number | null;
   /** Whether the flow is currently processing */
   processing: boolean;
-  /** Error message if any step failed */
-  error: string | null;
+  /** Mapped error content (title + body) if any step failed */
+  error: DepositErrorContent | null;
   /**
    * Soft warnings accumulated by the most recent flow (e.g. "couldn't save a
    * local copy" when the deposit registered on-chain but `addPendingPegin`
@@ -234,7 +234,7 @@ export function useDepositFlow(
     null,
   );
   const [processing, setProcessing] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<DepositErrorContent | null>(null);
   const [isWaiting, setIsWaiting] = useState(false);
   // Soft warnings accumulated during the most recent run (per-vault payout
   // failures, localStorage write failures, etc.). Exposed so the UI can
@@ -1039,7 +1039,7 @@ export function useDepositFlow(
 
         // Don't show error if flow was aborted (user intentionally closed modal)
         if (!signal.aborted) {
-          setError(sanitizeErrorMessage(err));
+          setError(mapDepositError(err));
           logger.error(err instanceof Error ? err : new Error(String(err)), {
             data: {
               context: "Multi-vault deposit flow error",

--- a/services/vault/src/utils/errors/__tests__/depositErrors.test.ts
+++ b/services/vault/src/utils/errors/__tests__/depositErrors.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Tests for the deposit-flow error mapper.
+ *
+ * Each test pins one classification branch of `mapDepositError` to the copy it
+ * should produce. The mapper is pure, so these run without any React harness.
+ */
+
+import {
+  JsonRpcError,
+  RpcErrorCode,
+} from "@babylonlabs-io/ts-sdk/tbv/core/clients";
+import { describe, expect, it } from "vitest";
+
+import { COPY } from "@/copy";
+
+import { mapDepositError } from "../depositErrors";
+
+const ERRORS = COPY.deposit.errors;
+
+class FakeWalletError extends Error {
+  constructor(
+    public readonly code: string,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+describe("mapDepositError", () => {
+  it("maps a coded wallet rejection to the signing-rejected callout", () => {
+    const err = new FakeWalletError(
+      "CONNECTION_REJECTED",
+      "User rejected the PSBT signing request",
+    );
+    expect(mapDepositError(err)).toEqual(ERRORS.signingRejected);
+  });
+
+  it("maps a vault-provider JsonRpcError to its VP title and body", () => {
+    const err = new JsonRpcError(
+      RpcErrorCode.PEGIN_NOT_FOUND,
+      "PegIn not found",
+    );
+    const result = mapDepositError(err);
+    expect(result.title).toBe("Vault Provider Syncing");
+    expect(result.body).toContain("hasn't ingested");
+  });
+
+  it("maps a registered-version mismatch to the version-changed callout", () => {
+    const err = new Error("on-chain version differs");
+    err.name = "RegisteredVaultVersionMismatchError";
+    expect(mapDepositError(err)).toEqual(ERRORS.versionMismatch);
+  });
+
+  it("maps a wallet account change to the account-changed callout", () => {
+    const err = new Error(
+      "BTC wallet account changed during deposit flow. Please restart.",
+    );
+    expect(mapDepositError(err)).toEqual(ERRORS.walletAccountChanged);
+  });
+
+  it("maps an insufficient-ETH gas error to the insufficient-ETH callout", () => {
+    const err = new Error(
+      "execution reverted: insufficient funds for gas * price + value",
+    );
+    expect(mapDepositError(err)).toEqual(ERRORS.insufficientEthForGas);
+  });
+
+  it("maps viem's typed InsufficientFundsError (by name) to the insufficient-ETH callout", () => {
+    // classifyError keys off viem's error name, so it's robust even when the
+    // message wording changes across viem versions.
+    const err = Object.assign(new Error("Transaction execution failed"), {
+      name: "InsufficientFundsError",
+    });
+    expect(mapDepositError(err)).toEqual(ERRORS.insufficientEthForGas);
+  });
+
+  it("maps a wallet-not-connected error to the wallet callout", () => {
+    expect(
+      mapDepositError(new Error("BTC or ETH wallet not connected")),
+    ).toEqual(ERRORS.walletNotConnected);
+  });
+
+  it("maps the resume 'wallet is not connected' phrasing to the wallet callout", () => {
+    // Resume WOTS/activation set "BTC wallet is not connected" (note the "is").
+    expect(mapDepositError(new Error("BTC wallet is not connected"))).toEqual(
+      ERRORS.walletNotConnected,
+    );
+  });
+
+  it("maps a missing vault provider to the provider-not-found callout", () => {
+    expect(mapDepositError(new Error("Vault provider not found"))).toEqual(
+      ERRORS.providerNotFound,
+    );
+  });
+
+  it("maps UTXO-availability failures to the funds-unavailable callout", () => {
+    expect(mapDepositError(new Error("No spendable UTXOs available"))).toEqual(
+      ERRORS.utxosUnavailable,
+    );
+    expect(
+      mapDepositError(new Error("Failed to load UTXOs: network error")),
+    ).toEqual(ERRORS.utxosUnavailable);
+  });
+
+  it("maps a broadcast failure to the broadcast callout", () => {
+    expect(
+      mapDepositError(
+        new Error("Failed to broadcast batch Pre-PegIn transaction: timeout"),
+      ),
+    ).toEqual(ERRORS.broadcastFailed);
+  });
+
+  it("classifies a BTC broadcast wrapper over insufficient funds as broadcast, not ETH gas", () => {
+    // The flow wraps broadcast errors; the inner text can say "insufficient
+    // funds" (BTC-side) — that must not be read as an ETH gas shortfall.
+    expect(
+      mapDepositError(
+        new Error(
+          "Failed to broadcast batch Pre-PegIn transaction: insufficient funds",
+        ),
+      ),
+    ).toEqual(ERRORS.broadcastFailed);
+  });
+
+  it("classifies a wallet rejection wrapped by the broadcast catch as a signing rejection", () => {
+    // The broadcast step re-wraps inner errors in a fresh Error (losing the
+    // wallet code), so a rejection there must still be matched by phrasing.
+    expect(
+      mapDepositError(
+        new Error(
+          "Failed to broadcast batch Pre-PegIn transaction: User rejected the request",
+        ),
+      ),
+    ).toEqual(ERRORS.signingRejected);
+  });
+
+  it("treats a BTC funding shortfall as funds-unavailable, not an ETH gas shortfall", () => {
+    // "insufficient funds" without a gas marker is BTC-side, not ETH gas.
+    expect(
+      mapDepositError(new Error("Insufficient funds: no UTXOs available")),
+    ).toEqual(ERRORS.utxosUnavailable);
+  });
+
+  it("maps an uncoded user-rejection message to the signing-rejected callout", () => {
+    expect(
+      mapDepositError(new Error("MetaMask Tx Signature: User denied")),
+    ).toEqual(ERRORS.signingRejected);
+  });
+
+  it("falls back to the default title with the sanitized message", () => {
+    const result = mapDepositError(new Error("some unmapped internal failure"));
+    expect(result.title).toBe(ERRORS.defaultTitle);
+    expect(result.body).toBe("some unmapped internal failure");
+  });
+
+  it("uses genericBody (not the 'Unknown error' sentinel) for opaque throws", () => {
+    const result = mapDepositError({});
+    expect(result.title).toBe(ERRORS.defaultTitle);
+    expect(result.body).toBe(ERRORS.genericBody);
+    expect(result.body).not.toBe("[object Object]");
+  });
+
+  it("maps the resume WOTS-mismatch (wrong wallet) to its own callout", () => {
+    expect(
+      mapDepositError(new Error(COPY.deposit.resume.wotsMismatchError)),
+    ).toEqual(ERRORS.wrongWalletAccount);
+  });
+});

--- a/services/vault/src/utils/errors/depositErrors.ts
+++ b/services/vault/src/utils/errors/depositErrors.ts
@@ -1,0 +1,186 @@
+/**
+ * Deposit-flow error mapping.
+ *
+ * Converts the raw `unknown` errors thrown across the deposit lifecycle into a
+ * user-facing { title, body } shown in the error Callout (see
+ * `DepositProgressView`). Mapping happens at the catch site — where the typed
+ * error (JsonRpcError code, wallet rejection code, ContractError, version
+ * mismatch) is still intact — so the classification can be precise. By the time
+ * an error reaches the view it is already a friendly { title, body }.
+ *
+ * Enumerated error sources (the map's spec):
+ *  - Wallet rejection — user declines a signing prompt (CONNECTION_REJECTED, or
+ *    "user rejected" / "denied" in the message).
+ *  - Vault-provider RPC — JsonRpcError from the VP (syncing, timeout, network,
+ *    proxy timeout/unavailable, generic). Delegated to `mapVpRpcError`.
+ *  - Registered-version mismatch — protocol params rotated mid-deposit.
+ *  - Wallet not connected / wallet client missing.
+ *  - Wallet account changed mid-flow (the WOTS-vs-PoP key guard).
+ *  - Wrong wallet connected on resume (WOTS hash mismatch).
+ *  - Broadcast failure — Pre-PegIn could not be broadcast to Bitcoin.
+ *  - Insufficient ETH — the Ethereum registration tx can't cover gas. Detected
+ *    via the shared `classifyError` (viem typed error + node-message regex),
+ *    not by hand-matching gas wording.
+ *  - Vault provider not found.
+ *  - Bitcoin funds unavailable — UTXO load / availability (phrase-level match).
+ *  - Everything else — fall back to the sanitized raw message under the generic
+ *    "Transaction failed" title (preserves prior behavior, no info hidden).
+ */
+
+import { isRegisteredVaultVersionMismatchError } from "@babylonlabs-io/ts-sdk/tbv/core";
+import { JsonRpcError } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
+import { type ReactNode } from "react";
+
+import { COPY } from "@/copy";
+
+import {
+  classifyError,
+  isWalletRejectionError,
+  mapVpRpcError,
+  sanitizeErrorMessage,
+} from "./formatting";
+
+export interface DepositErrorContent {
+  title: string;
+  /**
+   * ReactNode (not just string) so a future error can embed a link, code span,
+   * or emphasized phrase. Today every mapped body is a plain copy string.
+   */
+  body: ReactNode;
+}
+
+const ERRORS = COPY.deposit.errors;
+
+/**
+ * Extract a lowercase message from an unknown error for substring matching.
+ * Includes viem's `shortMessage` (often where "insufficient funds" lives)
+ * alongside the standard `message`.
+ */
+function lowerMessage(err: unknown): string {
+  const parts: string[] = [];
+  if (err instanceof Error) {
+    parts.push(err.message);
+  } else if (typeof err === "string") {
+    parts.push(err);
+  }
+  if (err !== null && typeof err === "object") {
+    const obj = err as Record<string, unknown>;
+    if (typeof obj.shortMessage === "string") parts.push(obj.shortMessage);
+    if (typeof obj.message === "string") parts.push(obj.message);
+  }
+  return parts.join(" ").toLowerCase();
+}
+
+/**
+ * Map a deposit-flow error to a user-facing { title, body }.
+ * Pure: no side effects, safe to unit-test directly.
+ */
+export function mapDepositError(err: unknown): DepositErrorContent {
+  // 1. Wallet rejection (coded) — most specific signal.
+  if (isWalletRejectionError(err)) {
+    return ERRORS.signingRejected;
+  }
+
+  // 2. Vault-provider JSON-RPC errors — reuse the shared VP mapping.
+  if (err instanceof JsonRpcError) {
+    const { title, message } = mapVpRpcError(err);
+    return { title, body: message };
+  }
+
+  // 3. Protocol-parameter version mismatch (registered vault drifted).
+  if (isRegisteredVaultVersionMismatchError(err)) {
+    return ERRORS.versionMismatch;
+  }
+
+  const msg = lowerMessage(err);
+
+  // 4. Wallet account changed mid-flow (WOTS-vs-PoP key guard).
+  if (msg.includes("wallet account changed")) {
+    return ERRORS.walletAccountChanged;
+  }
+
+  // 4b. Wrong BTC wallet connected on resume: the submitted WOTS key hash
+  // doesn't match the on-chain commitment. Specific and recoverable (switch
+  // accounts), so it gets its own title instead of the generic fallback.
+  if (
+    msg.includes("wrong wallet is connected") ||
+    msg.includes("wots public key hash does not match")
+  ) {
+    return ERRORS.wrongWalletAccount;
+  }
+
+  // 5. Wallet not connected / wallet client unavailable. Checked before the
+  // broadcast bucket: the broadcast step wraps inner errors as "Failed to
+  // broadcast ...: <inner>", and a disconnect there should still read as a
+  // wallet problem, not a generic broadcast failure.
+  if (
+    msg.includes("wallet not connected") ||
+    msg.includes("wallet is not connected") ||
+    msg.includes("failed to get wallet client")
+  ) {
+    return ERRORS.walletNotConnected;
+  }
+
+  // 6. Wallet signing rejection. The coded path (step 1) misses rejections that
+  // happen inside the broadcast step, because that catch re-wraps them in a
+  // fresh Error (losing the code). Match the phrasing before the broadcast
+  // bucket so "Failed to broadcast ...: user rejected" reads as a rejection.
+  // Scope to wallet phrases ("user rejected/denied/cancelled") so unrelated
+  // "access denied"/"permission denied" errors don't get mislabeled.
+  if (
+    msg.includes("user rejected") ||
+    msg.includes("user denied") ||
+    msg.includes("user cancelled") ||
+    msg.includes("user canceled")
+  ) {
+    return ERRORS.signingRejected;
+  }
+
+  // 7. Pre-PegIn broadcast failure. Checked before the ETH-gas/UTXO buckets:
+  // the flow wraps broadcast errors as "Failed to broadcast batch Pre-PegIn
+  // transaction: <inner>", and that inner text can contain BTC-side
+  // "insufficient funds" — a broadcast wrapper must win over the ETH-gas
+  // classification.
+  if (msg.includes("broadcast")) {
+    return ERRORS.broadcastFailed;
+  }
+
+  // 8. Vault provider not found.
+  if (msg.includes("vault provider not found")) {
+    return ERRORS.providerNotFound;
+  }
+
+  // 9. Bitcoin funds unavailable — UTXO load / availability. Phrase-level
+  // matches (not a bare "utxo") so unrelated UTXO-mentioning errors (e.g. a
+  // stale snapshot or indexer outage) don't get absorbed here. Covers the
+  // known throws: "No spendable UTXOs available", "Spendable UTXOs unavailable
+  // ...", "Failed to load UTXOs". Checked BEFORE the ETH-gas bucket because
+  // `classifyError` reads "Insufficient funds: no UTXOs available" as a gas
+  // shortfall (no sats/pegin guard hit) — the UTXO phrase must win.
+  if (
+    msg.includes("spendable utxos") ||
+    msg.includes("utxos available") ||
+    msg.includes("failed to load utxos")
+  ) {
+    return ERRORS.utxosUnavailable;
+  }
+
+  // 10. Insufficient ETH to cover gas for the Ethereum registration tx. Defer
+  // to the shared `classifyError`, which checks viem's typed `name`
+  // ("InsufficientFundsError") plus its node-message regex and excludes the
+  // BTC selector's "Insufficient funds: need N sats" — more robust across viem
+  // upgrades than matching gas wording by hand.
+  if (classifyError(err) === "insufficient-funds") {
+    return ERRORS.insufficientEthForGas;
+  }
+
+  // 11. Fallback: keep the sanitized raw message under the generic title so no
+  // diagnostic info is hidden. `sanitizeErrorMessage` returns the "Unknown
+  // error" sentinel for opaque throws — swap that for the friendlier
+  // genericBody so the callout never shows "Unknown error".
+  const raw = sanitizeErrorMessage(err);
+  return {
+    title: ERRORS.defaultTitle,
+    body: raw === "Unknown error" ? ERRORS.genericBody : raw,
+  };
+}

--- a/services/vault/src/utils/errors/formatting.ts
+++ b/services/vault/src/utils/errors/formatting.ts
@@ -21,7 +21,7 @@ import { COPY } from "@/copy";
  */
 const WALLET_CONNECTION_REJECTED_CODE = "CONNECTION_REJECTED";
 
-function isWalletRejectionError(error: unknown): boolean {
+export function isWalletRejectionError(error: unknown): boolean {
   return (
     error instanceof Error &&
     "code" in error &&
@@ -112,7 +112,7 @@ const FRIENDLY_MESSAGES: Record<ErrorKind, string> = {
  *      on the first hit and never inspects deeper causes once a frame
  *      classifies.
  */
-function classifyError(err: unknown): ErrorKind | null {
+export function classifyError(err: unknown): ErrorKind | null {
   let cur: unknown = err;
   for (let depth = 0; depth <= 10 && cur && typeof cur === "object"; depth++) {
     const obj = cur as {
@@ -218,6 +218,46 @@ function classifyError(err: unknown): ErrorKind | null {
 }
 
 /**
+ * Map a vault-provider JSON-RPC error to a user-friendly title + message.
+ * Shared by `formatPayoutSignatureError` and the deposit-flow error mapper so
+ * the VP error copy stays in one place.
+ */
+export function mapVpRpcError(error: JsonRpcError): {
+  title: string;
+  message: string;
+} {
+  const vp = COPY.deposit.errors.vp;
+  if (error.code === RpcErrorCode.PEGIN_NOT_FOUND) {
+    return vp.syncing;
+  }
+  if (error.code === JSON_RPC_ERROR_CODES.TIMEOUT) {
+    return vp.requestTimeout;
+  }
+  // -32001: proxy "Provider not found" (message-specific) vs FE client "Network error" (generic)
+  if (
+    error.code === JSON_RPC_ERROR_CODES.NETWORK &&
+    error.message.toLowerCase().includes("provider not found")
+  ) {
+    return vp.providerNotFound;
+  }
+  if (error.code === JSON_RPC_ERROR_CODES.NETWORK) {
+    return vp.connectionFailed;
+  }
+  // Proxy-specific: VP request timed out at the proxy level
+  if (error.code === JSON_RPC_ERROR_CODES.PROXY_TIMEOUT) {
+    return vp.providerTimeout;
+  }
+  // Proxy-specific: VP unreachable, DNS failure, or response too large
+  if (error.code === JSON_RPC_ERROR_CODES.PROXY_UNAVAILABLE) {
+    return vp.providerUnavailable;
+  }
+  return {
+    title: vp.rejected.title,
+    message: vp.rejected.message(error.code),
+  };
+}
+
+/**
  * Extract a safe error message from an unknown error value.
  *
  * Known viem / EIP-1193 / wallet-connector failure categories collapse to a
@@ -287,58 +327,7 @@ export function formatPayoutSignatureError(error: unknown): {
   message: string;
 } {
   if (error instanceof JsonRpcError) {
-    if (error.code === RpcErrorCode.PEGIN_NOT_FOUND) {
-      return {
-        title: "Vault Provider Syncing",
-        message:
-          "The vault provider hasn't ingested your peg-in yet. Please wait a moment and try again.",
-      };
-    }
-    if (error.code === JSON_RPC_ERROR_CODES.TIMEOUT) {
-      return {
-        title: "Request Timeout",
-        message:
-          "The vault provider took too long to respond. Please try again.",
-      };
-    }
-    // -32001: proxy "Provider not found" (message-specific) vs FE client "Network error" (generic)
-    if (
-      error.code === JSON_RPC_ERROR_CODES.NETWORK &&
-      error.message.toLowerCase().includes("provider not found")
-    ) {
-      return {
-        title: "Provider Not Found",
-        message:
-          "The vault provider could not be found in the on-chain registry. It may have been deregistered.",
-      };
-    }
-    if (error.code === JSON_RPC_ERROR_CODES.NETWORK) {
-      return {
-        title: "Connection Failed",
-        message:
-          "Unable to connect to the vault provider. Please check your connection and try again.",
-      };
-    }
-    // Proxy-specific: VP request timed out at the proxy level
-    if (error.code === JSON_RPC_ERROR_CODES.PROXY_TIMEOUT) {
-      return {
-        title: "Provider Timeout",
-        message:
-          "The vault provider took too long to respond. Please try again later.",
-      };
-    }
-    // Proxy-specific: VP unreachable, DNS failure, or response too large
-    if (error.code === JSON_RPC_ERROR_CODES.PROXY_UNAVAILABLE) {
-      return {
-        title: "Provider Unavailable",
-        message:
-          "The vault provider is temporarily unreachable. Please try again later.",
-      };
-    }
-    return {
-      title: "Signature Submission Failed",
-      message: `The vault provider rejected the request (error code: ${error.code}). Please try again or contact support.`,
-    };
+    return mapVpRpcError(error);
   }
 
   if (isWalletRejectionError(error)) {

--- a/services/vault/src/utils/errors/index.ts
+++ b/services/vault/src/utils/errors/index.ts
@@ -1,3 +1,4 @@
 export * from "./contract";
+export * from "./depositErrors";
 export * from "./formatting";
 export * from "./types";


### PR DESCRIPTION
Add a reusable Callout component to `core-ui`,  replace the inline StatusBanner error in DepositProgressView with it.

## Screenshot
<img width="2544" height="1804" alt="image" src="https://github.com/user-attachments/assets/42f1d87f-4a72-4ae3-a047-e0a491c9ece0" />
