### PR TITLE
fix(vault): block sub-precision borrow amounts and cap HF display

### DIFF
--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/__tests__/validateBorrowAction.test.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/__tests__/validateBorrowAction.test.ts
@@ -14,6 +14,35 @@ describe("validateBorrowAction", () => {
     });
   });
 
+  it("disables with 'Amount too small' when the amount rounds to zero base units", () => {
+    // 0.0000000001 USDC (6 decimals) -> toFixed(6) = "0.000000" -> 0n on-chain,
+    // which the contract rejects with "Amount cannot be zero".
+    const result = validateBorrowAction(0.0000000001, Infinity, 10000, 6);
+
+    expect(result).toEqual({
+      isDisabled: true,
+      buttonText: "Amount too small",
+      errorMessage: "Minimum borrowable amount is 0.000001",
+    });
+  });
+
+  it("blocks a sub-unit amount that toFixed would round UP to one base unit", () => {
+    // 0.0000009 USDC -> toFixed(6) = "0.000001" (1 base unit). A round-to-zero
+    // check would miss this and let the borrow execute for more than entered;
+    // comparing against the minimum blocks all sub-unit amounts.
+    const result = validateBorrowAction(0.0000009, Infinity, 10000, 6);
+
+    expect(result.buttonText).toBe("Amount too small");
+    expect(result.errorMessage).toBe("Minimum borrowable amount is 0.000001");
+  });
+
+  it("allows the smallest representable amount (1 base unit)", () => {
+    // 0.000001 USDC is exactly 1 base unit at 6 decimals — not sub-unit.
+    const result = validateBorrowAction(0.000001, Infinity, 10000, 6);
+
+    expect(result.buttonText).toBe("Borrow");
+  });
+
   it("disables with 'Amount exceeds maximum' when borrow exceeds max", () => {
     const result = validateBorrowAction(50000, 0.16, 10000, 6);
 

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/validateBorrowAction.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/validateBorrowAction.ts
@@ -49,13 +49,28 @@ export function validateBorrowAction(
     };
   }
 
+  // The token's on-chain precision (capped at SAFE_TOFIXED_PRECISION) and the
+  // smallest representable amount (one base unit) at that precision.
+  const displayDecimals = Math.min(tokenDecimals, SAFE_TOFIXED_PRECISION);
+  const minBorrowable = 1 / 10 ** displayDecimals;
+
+  // Reject any sub-precision amount (below one base unit). The submit path
+  // sends `parseUnits(borrowAmount.toFixed(displayDecimals))`, which rounds:
+  // 0.0000001 USDC rounds DOWN to 0 (contract reverts "Amount cannot be zero")
+  // and 0.0000009 rounds UP to 1 base unit (borrows more than entered). Compare
+  // against the minimum directly so both cases are blocked, not just round-to-0.
+  if (borrowAmount < minBorrowable) {
+    return {
+      isDisabled: true,
+      buttonText: "Amount too small",
+      errorMessage: `Minimum borrowable amount is ${formatTokenAmount(minBorrowable, displayDecimals)}`,
+    };
+  }
+
   if (borrowAmount > maxBorrowAmount) {
-    // Format with the token's native precision (capped at SAFE_TOFIXED_PRECISION)
-    // so the error text matches what the slider's Max label and the underlying
-    // calculateMaxBorrowTokens floor expose. Default 6-decimal cap in
-    // formatTokenAmount would round small WBTC maxes (e.g. 0.0000099) down
-    // to "0" in the message even though the value is non-zero.
-    const displayDecimals = Math.min(tokenDecimals, SAFE_TOFIXED_PRECISION);
+    // Format with the token's native precision so the error text matches what
+    // the slider's Max label and calculateMaxBorrowTokens floor expose (the
+    // default 6-decimal cap would round a small WBTC max down to "0").
     return {
       isDisabled: true,
       buttonText: "Amount exceeds maximum",

--- a/services/vault/src/applications/aave/constants.ts
+++ b/services/vault/src/applications/aave/constants.ts
@@ -86,6 +86,15 @@ export const MIN_SLIDER_MAX = 0.0001;
 export const NEAR_ZERO_DEBT_DISPLAY_THRESHOLD = 0.01;
 
 /**
+ * Display ceiling for the health factor. A position only reaches a value this
+ * high with negligible debt relative to collateral — far beyond any realistic
+ * liquidation risk — so at or above it the UI shows "-" ("infinitely healthy")
+ * rather than a meaningless large number or, above ~1e21, the scientific
+ * notation JS `toFixed` produces (e.g. "1.7e+55"). Display-only.
+ */
+export const HEALTH_FACTOR_DISPLAY_CAP = 1000;
+
+/**
  * Fractional threshold (relative to total debt) below which projected
  * debt is treated as effectively zero for display purposes. Catches
  * cases where the slider snaps one step short of max (~0.1% residual)

--- a/services/vault/src/applications/aave/utils/__tests__/healthFactorDisplay.test.ts
+++ b/services/vault/src/applications/aave/utils/__tests__/healthFactorDisplay.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { HEALTH_FACTOR_DISPLAY_CAP } from "../../constants";
+import { formatHealthFactor } from "../healthFactorDisplay";
+
+describe("formatHealthFactor", () => {
+  it("returns '-' when there is no debt (null)", () => {
+    expect(formatHealthFactor(null)).toBe("-");
+  });
+
+  it("formats a normal health factor to two decimals", () => {
+    expect(formatHealthFactor(1.5)).toBe("1.50");
+  });
+
+  it("returns '-' for an absurdly high value instead of scientific notation", () => {
+    // Regression: a sub-precision borrow produced HF ~1.7e+55, which
+    // `toFixed(2)` renders as "1.700300179615284e+55".
+    expect(formatHealthFactor(1.700300179615284e55)).toBe("-");
+  });
+
+  it("returns '-' for a non-finite value (Infinity)", () => {
+    expect(formatHealthFactor(Infinity)).toBe("-");
+  });
+
+  it("returns '-' just above the display cap", () => {
+    expect(formatHealthFactor(HEALTH_FACTOR_DISPLAY_CAP + 1)).toBe("-");
+  });
+
+  it("still formats a value at the cap", () => {
+    expect(formatHealthFactor(HEALTH_FACTOR_DISPLAY_CAP)).toBe(
+      `${HEALTH_FACTOR_DISPLAY_CAP}.00`,
+    );
+  });
+});

--- a/services/vault/src/applications/aave/utils/healthFactorDisplay.ts
+++ b/services/vault/src/applications/aave/utils/healthFactorDisplay.ts
@@ -1,5 +1,7 @@
 import type { HealthFactorStatus } from "@babylonlabs-io/ts-sdk/tbv/integrations/aave";
 
+import { HEALTH_FACTOR_DISPLAY_CAP } from "../constants";
+
 export const HEALTH_FACTOR_COLORS = {
   GREEN: "#00E676",
   AMBER: "#FFC400",
@@ -26,7 +28,14 @@ export function getHealthFactorColor(
 }
 
 export function formatHealthFactor(healthFactor: number | null): string {
-  if (healthFactor === null) {
+  // null = no debt; non-finite or absurdly high = negligible debt. All render
+  // as "-" ("infinitely healthy") rather than "Infinity" or the scientific
+  // notation `toFixed` produces above ~1e21 (e.g. "1.7e+55").
+  if (
+    healthFactor === null ||
+    !isFinite(healthFactor) ||
+    healthFactor > HEALTH_FACTOR_DISPLAY_CAP
+  ) {
     return "-";
   }
   return healthFactor.toFixed(2);


### PR DESCRIPTION
## Summary

From a user report (Anja): borrowing a sub-precision amount (`0.0000…001` USDC)
was accepted, the health factor displayed as `1.700300179615284e+55`, and
clicking Borrow failed on-chain with *"Borrow failed: Amount cannot be zero"*.

Two linked bugs, both rooted in not handling tiny borrow amounts:
- `validateBorrowAction` only blocked `borrowAmount === 0`, so a tiny positive
  float passed. On submit, `parseUnits(borrowAmount.toFixed(min(decimals,
  SAFE_TOFIXED_PRECISION)))` (`useBorrowTransaction.ts:103`) rounds it to `0n`
  → contract revert.
- `formatHealthFactor` `toFixed(2)`s the projected HF, which is astronomically
  large for near-zero debt and goes to scientific notation above ~1e21.

## Changes

- **`validateBorrowAction.ts`** — reject amounts that round to zero at the
  token's precision: `Number(borrowAmount.toFixed(displayDecimals)) === 0` →
  disabled **"Amount too small"** + *"Minimum borrowable amount is 0.000001"*.
  Uses the same `toFixed(displayDecimals)` the submit path uses, so validation
  and on-chain agree. (Hoisted `displayDecimals`, reused by the max-amount branch.)
- **`formatHealthFactor` / `constants.ts`** — return `-` for `null`, non-finite,
  or values above `HEALTH_FACTOR_DISPLAY_CAP` (1000) instead of a meaningless
  large number or scientific notation. The numeric `healthFactorValue` is
  unchanged, so HF color and the borrow's `isFinite && < MIN` check still work.
  (Also removes the same display risk on the repay side, which shares the util.)