### PR TITLE
fix(vault): let safe/multisig users broadcast the pre-pegIn on resume

### DIFF
--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -355,8 +355,6 @@ export const COPY = {
         `Please switch to ${network} in your wallet`,
       ethereumMainnet: "Ethereum Mainnet",
       sepoliaTestnet: "Sepolia Testnet",
-      crossDeviceBroadcastUnsupported:
-        "This pre-peg-in cannot be broadcast from the in-app button because the build-time parameters that pin its Bitcoin scripts are not available here. Please broadcast from the original device, or wait for the refund timeout.",
     },
     payoutSigningGuards: {
       missingPayoutAddress: {

--- a/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
+++ b/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
@@ -506,6 +506,40 @@ describe("useVaultActions — handleBroadcast version drift guard", () => {
     expect(getProtocolInfoBatch).not.toHaveBeenCalled();
   });
 
+  // The no-anchor path leans ENTIRELY on the on-chain prePeginTxHash match to
+  // pin the (indexer-served) tx, since there is no local copy to compare. Pin
+  // that this guard still refuses with no local record: a mismatch must abort
+  // before any signing. Without this, a future refactor that gated the hash
+  // check behind `if (pendingPegin)` would broadcast substituted indexer hex
+  // with every other test still green.
+  it("refuses the no-record broadcast when the on-chain prePeginTxHash mismatches", async () => {
+    mockGetVaultRegistryReader.mockReturnValue({
+      getProtocolInfoBatch: makeMatchingProtocolInfoBatch(),
+    } as unknown as ReturnType<typeof getVaultRegistryReader>);
+    // Indexer-served tx hashes to the beforeEach default
+    // ("0xmatching_pre_pegin_hash"); make the on-chain commitment differ.
+    mockGetVaultFromChain.mockResolvedValue({
+      prePeginTxHash: "0xonchain_hash_that_differs",
+      hashlock: "0xonchain_hashlock",
+      status: OnChainBtcVaultStatus.PENDING,
+    } as never);
+
+    const { result } = renderHook(() => useVaultActions());
+
+    await act(async () => {
+      await result.current.handleBroadcast({
+        ...baseBroadcastParams,
+        // No pendingPegin: relaxed no-anchor path.
+      });
+    });
+
+    expect(result.current.broadcastError).toContain(
+      "Transaction integrity check failed",
+    );
+    expect(mockBroadcastPrePeginTransaction).not.toHaveBeenCalled();
+    expect(mockSignPsbt).not.toHaveBeenCalled();
+  });
+
   // An entry whose `unsignedTxHex === ""` carries no local tx, so the resume
   // path broadcasts the indexer's tx (verified against on-chain prePeginTxHash
   // above). Any stored build versions are floating — not tied to that tx — so

--- a/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
+++ b/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
@@ -481,13 +481,15 @@ describe("useVaultActions — handleBroadcast version drift guard", () => {
     expect(mockBroadcastPrePeginTransaction).toHaveBeenCalledTimes(1);
   });
 
-  // Cross-device resume cannot recover the build-time versions, so we
-  // can't prove the indexer-served tx hex was built at any specific
-  // version. Refusing is strictly safer than broadcasting on a
-  // best-effort compare to current local config.
-  it("refuses cross-device broadcast when no local pendingPegin is available", async () => {
+  // Cross-device resume / Safe async / cleared storage: no local record
+  // exists, so the resume path falls back to the indexer's tx — already
+  // verified against the on-chain prePeginTxHash above. Broadcasting is safe
+  // on the strength of that match; with no local build versions tied to the
+  // tx, the on-chain version check is skipped rather than refusing.
+  it("broadcasts on the on-chain hash match when no local pendingPegin is available, skipping the version check", async () => {
+    const getProtocolInfoBatch = makeMatchingProtocolInfoBatch();
     mockGetVaultRegistryReader.mockReturnValue({
-      getProtocolInfoBatch: makeMatchingProtocolInfoBatch(),
+      getProtocolInfoBatch,
     } as unknown as ReturnType<typeof getVaultRegistryReader>);
 
     const { result } = renderHook(() => useVaultActions());
@@ -495,25 +497,23 @@ describe("useVaultActions — handleBroadcast version drift guard", () => {
     await act(async () => {
       await result.current.handleBroadcast({
         ...baseBroadcastParams,
-        // No pendingPegin: cross-device resume case.
+        // No pendingPegin: cross-device / Safe-async resume case.
       });
     });
 
-    expect(result.current.broadcastError).toContain(
-      "cannot be broadcast from the in-app button",
-    );
-    expect(mockBroadcastPrePeginTransaction).not.toHaveBeenCalled();
-    expect(mockSignPsbt).not.toHaveBeenCalled();
+    expect(result.current.broadcastError).toBeNull();
+    expect(mockBroadcastPrePeginTransaction).toHaveBeenCalledTimes(1);
+    expect(getProtocolInfoBatch).not.toHaveBeenCalled();
   });
 
-  // An entry whose `unsignedTxHex === ""` is the storage validator's
-  // "tracking record, no local tx" marker. The on-chain hash check would
-  // pass against the indexer's tx, but the stored build versions are not
-  // tied to that tx — they're floating. The guard would lie. Treat it
-  // the same as no local pendingPegin.
-  it("refuses broadcast when pendingPegin has empty unsignedTxHex even if build versions are present", async () => {
+  // An entry whose `unsignedTxHex === ""` carries no local tx, so the resume
+  // path broadcasts the indexer's tx (verified against on-chain prePeginTxHash
+  // above). Any stored build versions are floating — not tied to that tx — so
+  // the version check is skipped and broadcast proceeds on the hash match.
+  it("broadcasts the indexer tx and skips the version check when pendingPegin has empty unsignedTxHex", async () => {
+    const getProtocolInfoBatch = makeMatchingProtocolInfoBatch();
     mockGetVaultRegistryReader.mockReturnValue({
-      getProtocolInfoBatch: makeMatchingProtocolInfoBatch(),
+      getProtocolInfoBatch,
     } as unknown as ReturnType<typeof getVaultRegistryReader>);
 
     const { result } = renderHook(() => useVaultActions());
@@ -525,11 +525,37 @@ describe("useVaultActions — handleBroadcast version drift guard", () => {
       });
     });
 
-    expect(result.current.broadcastError).toContain(
-      "cannot be broadcast from the in-app button",
-    );
-    expect(mockBroadcastPrePeginTransaction).not.toHaveBeenCalled();
-    expect(mockSignPsbt).not.toHaveBeenCalled();
+    expect(result.current.broadcastError).toBeNull();
+    expect(mockBroadcastPrePeginTransaction).toHaveBeenCalledTimes(1);
+    expect(getProtocolInfoBatch).not.toHaveBeenCalled();
+  });
+
+  // Legacy entry: a local tx is present but predates the build-version fields.
+  // The tx is verified against on-chain prePeginTxHash above, so broadcast
+  // proceeds; the version check is skipped because the versions are absent.
+  it("broadcasts and skips the version check when a local tx is present but build versions are missing", async () => {
+    const getProtocolInfoBatch = makeMatchingProtocolInfoBatch();
+    mockGetVaultRegistryReader.mockReturnValue({
+      getProtocolInfoBatch,
+    } as unknown as ReturnType<typeof getVaultRegistryReader>);
+
+    const { result } = renderHook(() => useVaultActions());
+
+    await act(async () => {
+      await result.current.handleBroadcast({
+        ...baseBroadcastParams,
+        pendingPegin: {
+          ...basePendingPegin,
+          buildOffchainParamsVersion: undefined,
+          buildAppVaultKeepersVersion: undefined,
+          buildUniversalChallengersVersion: undefined,
+        },
+      });
+    });
+
+    expect(result.current.broadcastError).toBeNull();
+    expect(mockBroadcastPrePeginTransaction).toHaveBeenCalledTimes(1);
+    expect(getProtocolInfoBatch).not.toHaveBeenCalled();
   });
 
   // Mirrors the inline deposit path's cleanup: a confirmed mismatch

--- a/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
+++ b/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
@@ -530,6 +530,45 @@ describe("useVaultActions — handleBroadcast version drift guard", () => {
     expect(getProtocolInfoBatch).not.toHaveBeenCalled();
   });
 
+  // When we fall back to the indexer tx (empty local unsignedTxHex), the
+  // locally stored selectedUTXOs are NOT guaranteed to be that tx's inputs.
+  // Passing them as trusted `expectedUtxos` would make broadcast throw on
+  // any input they don't cover, recreating a dead-end. We must ignore them
+  // and let the broadcast resolve inputs from the mempool (expectedUtxos
+  // undefined).
+  it("ignores stale local UTXOs and uses the mempool fallback when broadcasting the indexer tx", async () => {
+    const getProtocolInfoBatch = makeMatchingProtocolInfoBatch();
+    mockGetVaultRegistryReader.mockReturnValue({
+      getProtocolInfoBatch,
+    } as unknown as ReturnType<typeof getVaultRegistryReader>);
+
+    const { result } = renderHook(() => useVaultActions());
+
+    await act(async () => {
+      await result.current.handleBroadcast({
+        ...baseBroadcastParams,
+        pendingPegin: {
+          ...basePendingPegin,
+          unsignedTxHex: "",
+          selectedUTXOs: [
+            {
+              txid: "abc123",
+              vout: 0,
+              value: "100000",
+              scriptPubKey: "0014abcdef",
+            },
+          ],
+        },
+      });
+    });
+
+    expect(result.current.broadcastError).toBeNull();
+    expect(mockBroadcastPrePeginTransaction).toHaveBeenCalledTimes(1);
+    expect(mockBroadcastPrePeginTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({ expectedUtxos: undefined }),
+    );
+  });
+
   // Legacy entry: a local tx is present but predates the build-version fields.
   // The tx is verified against on-chain prePeginTxHash above, so broadcast
   // proceeds; the version check is skipped because the versions are absent.

--- a/services/vault/src/hooks/deposit/useVaultActions.ts
+++ b/services/vault/src/hooks/deposit/useVaultActions.ts
@@ -239,48 +239,54 @@ export function useVaultActions(): UseVaultActionsReturn {
         ? utxosToExpectedRecord(pendingPegin.selectedUTXOs)
         : undefined;
 
-      // Resume broadcast must verify versions against the values used to
-      // construct `unsignedTxHex`, not the current local config — both
-      // could have rotated to a newer version while the BTC scripts are
-      // still pinned to the construction-time version. Refuse when
-      // there's no local anchor for the guard: cross-device resume (no
-      // pendingPegin), the cross-device "tracking record" form
-      // (`unsignedTxHex: ""` — the storage validator accepts it as a
-      // future-sync marker, but its build versions would not be tied to
-      // the indexer's tx we'd otherwise sign), or legacy entries missing
-      // build versions.
-      if (!pendingPegin || pendingPegin.unsignedTxHex === "") {
-        throw new Error(COPY.deposit.errors.crossDeviceBroadcastUnsupported);
-      }
+      // The integrity guarantee for this broadcast is the on-chain
+      // `prePeginTxHash` match asserted above: it commits to every input,
+      // output, and script of the registered Pre-PegIn, so a match proves
+      // `unsignedTxHex` is exactly the tx the contract registered — safe to
+      // broadcast regardless of which offchain-params / signer-set versions
+      // it was built against.
+      //
+      // When the local record supplies BOTH the tx we're broadcasting and its
+      // build versions (the normal same-session path), additionally re-verify
+      // those versions on-chain as defense-in-depth and drop the entry on a
+      // confirmed mismatch. The versions are only meaningful when tied to the
+      // local tx — if we fell back to the indexer's tx (`!localUnsignedTxHex`)
+      // any stored versions are floating, so we don't trust them. When there
+      // is no local anchor — cross-device resume, cleared storage, or a Safe
+      // whose asynchronous ETH execution outlived the dApp tab so
+      // `addPendingPegin` never ran — skip that redundant check and broadcast
+      // on the strength of the hash match. Refusing here would strand a vault
+      // that is provably safe to broadcast.
       const buildOffchainParamsVersion =
-        pendingPegin.buildOffchainParamsVersion;
+        pendingPegin?.buildOffchainParamsVersion;
       const buildAppVaultKeepersVersion =
-        pendingPegin.buildAppVaultKeepersVersion;
+        pendingPegin?.buildAppVaultKeepersVersion;
       const buildUniversalChallengersVersion =
-        pendingPegin.buildUniversalChallengersVersion;
+        pendingPegin?.buildUniversalChallengersVersion;
       if (
-        buildOffchainParamsVersion === undefined ||
-        buildAppVaultKeepersVersion === undefined ||
-        buildUniversalChallengersVersion === undefined
+        localUnsignedTxHex &&
+        buildOffchainParamsVersion !== undefined &&
+        buildAppVaultKeepersVersion !== undefined &&
+        buildUniversalChallengersVersion !== undefined
       ) {
-        throw new Error(COPY.deposit.errors.crossDeviceBroadcastUnsupported);
-      }
-      try {
-        await verifyRegisteredVaultVersions({
-          vaultRegistryReader: getVaultRegistryReader(),
-          vaultIds: [vaultId],
-          expectedOffchainParamsVersion: buildOffchainParamsVersion,
-          expectedAppVaultKeepersVersion: buildAppVaultKeepersVersion,
-          expectedUniversalChallengersVersion: buildUniversalChallengersVersion,
-        });
-      } catch (err) {
-        // Only a confirmed mismatch drops the entry — transient RPC
-        // failures keep it so the user can retry. Mirrors the inline
-        // deposit path at useDepositFlow.ts:661.
-        if (isRegisteredVaultVersionMismatchError(err)) {
-          removePendingPegin?.(vaultId);
+        try {
+          await verifyRegisteredVaultVersions({
+            vaultRegistryReader: getVaultRegistryReader(),
+            vaultIds: [vaultId],
+            expectedOffchainParamsVersion: buildOffchainParamsVersion,
+            expectedAppVaultKeepersVersion: buildAppVaultKeepersVersion,
+            expectedUniversalChallengersVersion:
+              buildUniversalChallengersVersion,
+          });
+        } catch (err) {
+          // Only a confirmed mismatch drops the entry — transient RPC
+          // failures keep it so the user can retry. Mirrors the inline
+          // deposit path at useDepositFlow.ts:661.
+          if (isRegisteredVaultVersionMismatchError(err)) {
+            removePendingPegin?.(vaultId);
+          }
+          throw err;
         }
-        throw err;
       }
 
       await broadcastPrePeginTransaction({

--- a/services/vault/src/hooks/deposit/useVaultActions.ts
+++ b/services/vault/src/hooks/deposit/useVaultActions.ts
@@ -281,7 +281,7 @@ export function useVaultActions(): UseVaultActionsReturn {
         } catch (err) {
           // Only a confirmed mismatch drops the entry — transient RPC
           // failures keep it so the user can retry. Mirrors the inline
-          // deposit path at useDepositFlow.ts:661.
+          // deposit path's version-check cleanup in useDepositFlow.
           if (isRegisteredVaultVersionMismatchError(err)) {
             removePendingPegin?.(vaultId);
           }

--- a/services/vault/src/hooks/deposit/useVaultActions.ts
+++ b/services/vault/src/hooks/deposit/useVaultActions.ts
@@ -233,11 +233,18 @@ export function useVaultActions(): UseVaultActionsReturn {
       // by unrelated transactions.
       await assertUtxosAvailable(unsignedTxHex, depositorAddress);
 
-      // Use trusted UTXO data from localStorage when available (stored at
-      // construction time), falling back to mempool API with cross-validation
-      const expectedUtxos = pendingPegin?.selectedUTXOs?.length
-        ? utxosToExpectedRecord(pendingPegin.selectedUTXOs)
-        : undefined;
+      // Use the locally stored UTXO set as trusted construction-time data
+      // ONLY when we're broadcasting the local tx. The stored UTXOs are the
+      // inputs of the local tx, not necessarily of the indexer's tx, so when
+      // we fell back to the indexer copy (`!localUnsignedTxHex`) we must pass
+      // `undefined` and let `broadcastPrePeginTransaction` resolve inputs from
+      // the mempool. `createPsbtFromTransaction` throws if `expectedUtxos` is
+      // supplied but doesn't cover every input, so a stale/partial local set
+      // paired with the indexer tx would dead-end the broadcast.
+      const expectedUtxos =
+        localUnsignedTxHex && pendingPegin?.selectedUTXOs?.length
+          ? utxosToExpectedRecord(pendingPegin.selectedUTXOs)
+          : undefined;
 
       // The integrity guarantee for this broadcast is the on-chain
       // `prePeginTxHash` match asserted above: it commits to every input,


### PR DESCRIPTION
## What this PR does

It lets a depositor click "Broadcast Pre-PegIn" and actually broadcast, even when the app has no local record of that deposit in this browser. Today the button refuses in that situation and dead-ends the deposit. This mainly affects Safe (multisig) wallets over WalletConnect, but also anyone who resumed on a different browser/device or cleared their browser storage.

## Why (the bug)

A depositor using a Safe wallet got permanently stuck at the "Sign and broadcast BTC Pre-PegIn transaction" step. The button showed: "This pre-peg-in cannot be broadcast from the in-app button because the build-time parameters that pin its Bitcoin scripts are not available here." No Bitcoin wallet popup ever appeared, so they could not finish — and their BTC was untouched (the Pre-PegIn was never broadcast).

Root cause is the asynchronous nature of a Safe transaction combined with where we save the deposit's local record:

- The deposit flow does: sign in BTC → register on Ethereum → save a local record → broadcast the Pre-PegIn. The local record is saved only after the Ethereum registration finishes.
- For a Safe, "register on Ethereum" does not finish in seconds. The wallet returns a Safe proposal hash (not a real tx hash), and the app then waits — polling the Safe Transaction Service for up to 4 hours — until the co-signers sign and execute the transaction. That wait is the spinning "Sign and broadcast ETH registration" step.
- If the user closes or reloads the tab during that long wait (which Safe users naturally do while collecting co-signers), the in-page code stops running. When the Safe transaction later executes, there is no app running to save the local record or broadcast the Pre-PegIn.
- The vault is now registered on-chain, so the app later offers a "Broadcast Pre-PegIn" button. But there is no local record in this browser, so a guard added in [#1708](https://github.com/babylonlabs-io/babylon-toolkit/pull/1708) refuses to broadcast.

That guard (also from [#1708](https://github.com/babylonlabs-io/babylon-toolkit/pull/1708)) refuses whenever the local record is missing the three "build version" fields it introduced. With no local record at all, those fields are absent, so it always refuses.

We reproduced this end-to-end on Sepolia with a 2-of-2 Safe (MetaMask + OKX): signed with the first owner, closed the tab while the app was still polling, executed with the second owner from the Safe UI, reopened the app, and clicked Broadcast — and hit the exact same dead-end.

## The key insight

The resume code already proves the transaction is safe before this guard runs. It takes the unsigned Pre-PegIn from the indexer and checks that its hash equals the `prePeginTxHash` the contract stored on-chain at registration. That hash commits to every input, output, and Bitcoin script of the transaction. So if the hash matches, the transaction we are about to broadcast is exactly the one the contract already committed to — broadcasting it cannot be wrong, no matter which protocol/signer-set "versions" it was built against.

In other words, the on-chain hash match is a stronger guarantee than the version-number comparison. The version check adds nothing on top of it for broadcast safety, yet it is the thing blocking these users. In the reproduction logs we saw the app log "tx-hash matches on-chain prePeginTxHash" and then, on the very next line, refuse to broadcast.

## The fix

In the resume broadcast path (`handleBroadcast` in `services/vault/src/hooks/deposit/useVaultActions.ts`):

- Keep the on-chain version comparison **only** when the local record actually supplies both the transaction we are broadcasting and its build versions (the normal same-session path). Behavior there is unchanged, including dropping the local entry on a confirmed mismatch.
- When there is no local anchor — no record, an empty stored transaction, or missing build versions — **skip** the version comparison and broadcast on the strength of the on-chain `prePeginTxHash` match that the function already performed.
- The broadcast call itself did not need to change. The transaction already falls back to the indexer copy when there is no local copy, the depositor's BTC public key already comes from the on-chain/indexer vault, and the UTXO data is already optional (it falls back to the mempool path).

This unblocks every Safe / cross-device / cleared-storage user from the in-app button, while leaving the existing same-session (EOA) path exactly as it was.

Also removed the now-unused error message `crossDeviceBroadcastUnsupported` from `services/vault/src/copy.ts`, since nothing throws it anymore.

## Approaches considered

- **Relax the resume guard to rely on the on-chain hash match (this PR).** Smallest, safest change. It leans on a check the code already does and that is strictly stronger than the version check. No change to the working same-session path.
- **Save the local record earlier — before the long Safe wait.** Would also help, but it writes a record before the on-chain registration is confirmed, which can leave a stale record if registration is rejected, and it adds new failure modes. It also would not help users who genuinely resume on another device or after clearing storage. Better as a separate follow-up to improve the flow, not as the fix for this dead-end.
- **Read the registered versions from the chain and compare them in the no-record case.** This is circular: we would be comparing on-chain values against themselves, which always passes and proves nothing. The real guarantee is the hash match, so this adds complexity with no safety benefit.

We chose the first approach because it removes the dead-end with the least new risk and reuses the guarantee the code already relies on.

## Safety note for reviewers (critical path)

This touches Pre-PegIn broadcasting, which moves real value, so please review carefully. The single claim to verify is: the on-chain `prePeginTxHash` match (already performed earlier in `handleBroadcast`, before the changed block) proves the indexer-served transaction is exactly the one the contract registered, which makes the build-version comparison redundant for broadcast safety. Every other gate is unchanged — vault must exist and be `PENDING` on-chain, the transaction-integrity (hash) check still aborts on any mismatch, and the same-session path still verifies versions and drops stale entries on a confirmed mismatch.

## Why activation and other Safe ETH steps are not affected

A reviewer may reasonably ask whether other Safe interactions (for example, activating the vault, which also goes through the ETH wallet) hit the same dead-end. They do not, and here is why. The dead-end needed three things at once: (1) an asynchronous Safe ETH transaction the app waits on, (2) a required follow-up action the app must perform after that transaction in the same session, and (3) a resume guard that refuses without local state. Only the deposit's "register on Ethereum, then broadcast the BTC Pre-PegIn" step had all three.

Activation has only the first. Its Ethereum transaction (revealing the HTLC secret) is itself the completion — once it executes, the vault is active on-chain. There is no follow-up Bitcoin broadcast, no dependency on a local record, and no refusing guard (the activation code already handles a missing local record and re-derives what it needs from the wallet and on-chain data). So if a user signs with one Safe owner, closes or reloads the tab, and executes with the second owner later, the secret is still revealed and the vault still activates; reopening the app reads the on-chain status and shows it active.

The same holds for Aave borrow and repay (used after the vault is collateralized). Borrow is a single Ethereum transaction; the on-chain transaction is the whole action, with no follow-up. Repay can be two transactions (an ERC-20 approve, then the repay), but the sequence is idempotent — before submitting, the app re-reads the on-chain allowance and skips the approve if it is already sufficient. Neither flow writes a resume record, touches Bitcoin, or has a refusing guard; the UI just re-reads the Aave position from chain on reload. So the same "sign with one owner, close the tab, execute with the other" pattern recovers cleanly. The only multi-step wrinkle is that closing the tab between the approve and the repay means the user simply clicks Repay again (the approve is already on-chain and gets skipped) — a normal retry, not a dead-end.

In all of these cases the only leftover is a cosmetic delay where an open tab takes a few seconds to notice the Safe transaction executed — a separate, non-blocking UI issue.

## Testing

- Unit tests in `services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts`: the two old "refuses" tests now assert that broadcast proceeds and that the on-chain version reader is not called; added a test for a record that has a local transaction but is missing build versions; kept the version-drift, mismatch-cleanup, transient-error, and hash-mismatch tests.
- Full vault test suite passes (1599 passed); vault lint has 0 errors; ts-sdk builds and lints clean.
- Manual end-to-end on Sepolia with a 2-of-2 Safe: re-ran the exact reproduction (sign owner 1 → close tab mid-poll → execute owner 2 in the Safe UI → reopen → Broadcast Pre-PegIn). With the fix, the Bitcoin wallet popup now appears, the Pre-PegIn broadcasts, and the deposit advances to "Awaiting Pre-PegIn tx inclusion". Also confirmed the normal same-session path still works.

## Follow-ups (not in this PR)

- The 4-hour blocking spinner during Safe co-signing is brittle UX. Consider saving the local record before the wait, or making the registration step resumable, so the dead-end cannot happen in the first place.
- Minor UI lag: the ETH-registration / activation step keeps spinning for ~10 seconds after the Safe transaction has already executed (visible in another tab). Separate UI-state issue.

## Related

- Introduced the guard and the build-version fields this PR relaxes: [#1708](https://github.com/babylonlabs-io/babylon-toolkit/pull/1708)
