### PR TITLE
fix: activity wrong redeem tx hash

### DIFF
--- a/services/vault/src/__tests__/router.test.tsx
+++ b/services/vault/src/__tests__/router.test.tsx
@@ -60,6 +60,10 @@ vi.mock("../services/activity", async () => {
   };
 });
 
+vi.mock("../services/activity/claimTxResolver", () => ({
+  resolveRedeemClaimTxids: vi.fn(async () => new Map()),
+}));
+
 async function renderAt(path: string): Promise<ReturnType<typeof render>> {
   const { Router } = await import("../router");
   const client = new QueryClient({

--- a/services/vault/src/components/deposit/RefundModal/RefundSuccessContent.tsx
+++ b/services/vault/src/components/deposit/RefundModal/RefundSuccessContent.tsx
@@ -2,6 +2,7 @@ import { Button, Heading, Text } from "@babylonlabs-io/core-ui";
 
 import { getNetworkConfigBTC } from "@/config";
 import { COPY } from "@/copy";
+import { getBtcExplorerTxUrl } from "@/utils/explorer";
 import { getBtcSymbol } from "@/utils/formatting";
 
 const btcConfig = getNetworkConfigBTC();
@@ -15,7 +16,7 @@ export function RefundSuccessContent({
   refundTxId,
   onDone,
 }: RefundSuccessContentProps) {
-  const explorerUrl = `${btcConfig.mempoolApiUrl}/tx/${refundTxId}`;
+  const explorerUrl = getBtcExplorerTxUrl(refundTxId);
   const btcSymbol = getBtcSymbol();
 
   return (

--- a/services/vault/src/services/activity/__tests__/claimTxResolver.test.ts
+++ b/services/vault/src/services/activity/__tests__/claimTxResolver.test.ts
@@ -5,9 +5,19 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // hoist time.
 const { batchGetPegoutStatus, createVpClient } = vi.hoisted(() => {
   const batchGetPegoutStatus = vi.fn();
+  // Typed with the real createVpClient call signature (address + options) so
+  // per-test mockImplementation((address) => …) and toHaveBeenCalledWith(addr,
+  // opts) both type-check; the default impl ignores its args.
   return {
     batchGetPegoutStatus,
-    createVpClient: vi.fn(() => ({ batchGetPegoutStatus })),
+    createVpClient: vi.fn<
+      (
+        address: string,
+        options?: unknown,
+      ) => {
+        batchGetPegoutStatus: typeof batchGetPegoutStatus;
+      }
+    >(() => ({ batchGetPegoutStatus })),
   };
 });
 
@@ -26,6 +36,13 @@ import {
 const VP_A = "0xaaaa000000000000000000000000000000000001";
 const VP_B = "0xbbbb000000000000000000000000000000000002";
 
+// Claim txids must be 64 hex chars (a BTC txid); the resolver drops anything else.
+const TXID_A1 = "a1".repeat(32);
+const TXID_A2 = "a2".repeat(32);
+const TXID_B3 = "b3".repeat(32);
+const TXID_LIVE = "cd".repeat(32);
+const TXID_PRE = "ef".repeat(32);
+
 function claimer(claim_txid: string, status: string = "PayoutBroadcast") {
   return {
     status,
@@ -41,7 +58,8 @@ function claimer(claim_txid: string, status: string = "PayoutBroadcast") {
 describe("resolveRedeemClaimTxids", () => {
   beforeEach(() => {
     batchGetPegoutStatus.mockReset();
-    createVpClient.mockClear();
+    createVpClient.mockReset();
+    createVpClient.mockImplementation(() => ({ batchGetPegoutStatus }));
   });
 
   it("bounds each VP call with a short timeout and no retries so a slow VP can't stall the tab", async () => {
@@ -80,7 +98,7 @@ describe("resolveRedeemClaimTxids", () => {
               result: {
                 pegin_txid: "pegin1",
                 found: true,
-                claimer: claimer("claimA1"),
+                claimer: claimer(TXID_A1),
                 challengers: [],
               },
               error: null,
@@ -90,7 +108,7 @@ describe("resolveRedeemClaimTxids", () => {
               result: {
                 pegin_txid: "pegin2",
                 found: true,
-                claimer: claimer("claimA2"),
+                claimer: claimer(TXID_A2),
                 challengers: [],
               },
               error: null,
@@ -105,7 +123,7 @@ describe("resolveRedeemClaimTxids", () => {
             result: {
               pegin_txid: "pegin3",
               found: true,
-              claimer: claimer("claimB3"),
+              claimer: claimer(TXID_B3),
               challengers: [],
             },
             error: null,
@@ -119,9 +137,9 @@ describe("resolveRedeemClaimTxids", () => {
       lookup,
     );
 
-    expect(map.get("0xv1")).toBe("claimA1");
-    expect(map.get("0xv2")).toBe("claimA2");
-    expect(map.get("0xv3")).toBe("claimB3");
+    expect(map.get("0xv1")).toBe(TXID_A1);
+    expect(map.get("0xv2")).toBe(TXID_A2);
+    expect(map.get("0xv3")).toBe(TXID_B3);
     expect(batchGetPegoutStatus).toHaveBeenCalledTimes(2);
   });
 
@@ -162,7 +180,7 @@ describe("resolveRedeemClaimTxids", () => {
           result: {
             pegin_txid: "pegin1",
             found: true,
-            claimer: claimer("claimPre", "ClaimEventReceived"),
+            claimer: claimer(TXID_PRE, "ClaimEventReceived"),
             challengers: [],
           },
           error: null,
@@ -187,7 +205,7 @@ describe("resolveRedeemClaimTxids", () => {
           result: {
             pegin_txid: "pegin1",
             found: true,
-            claimer: claimer("claimLive", "ClaimBroadcast"),
+            claimer: claimer(TXID_LIVE, "ClaimBroadcast"),
             challengers: [],
           },
           error: null,
@@ -197,7 +215,98 @@ describe("resolveRedeemClaimTxids", () => {
 
     const map = await resolveRedeemClaimTxids([{ vaultId: "0xv1" }], lookup);
 
-    expect(map.get("0xv1")).toBe("claimLive");
+    expect(map.get("0xv1")).toBe(TXID_LIVE);
+  });
+
+  it("drops claim txids that are not valid 64-char hex", async () => {
+    const lookup = new Map<string, RedeemVaultLookup>([
+      ["0xv1", { peginTxHash: "0xpegin1", vaultProvider: VP_A }],
+    ]);
+
+    batchGetPegoutStatus.mockResolvedValueOnce({
+      results: [
+        {
+          pegin_txid: "pegin1",
+          result: {
+            pegin_txid: "pegin1",
+            found: true,
+            claimer: claimer("not-a-real-txid"),
+            challengers: [],
+          },
+          error: null,
+        },
+      ],
+    });
+
+    const map = await resolveRedeemClaimTxids([{ vaultId: "0xv1" }], lookup);
+
+    expect(map.has("0xv1")).toBe(false);
+  });
+
+  it("skips vaults with a malformed provider address without calling the VP", async () => {
+    const lookup = new Map<string, RedeemVaultLookup>([
+      ["0xv1", { peginTxHash: "0xpegin1", vaultProvider: "0xnot-an-address" }],
+      ["0xv2", { peginTxHash: "0xpegin2", vaultProvider: VP_A }],
+    ]);
+
+    batchGetPegoutStatus.mockResolvedValueOnce({
+      results: [
+        {
+          pegin_txid: "pegin2",
+          result: {
+            pegin_txid: "pegin2",
+            found: true,
+            claimer: claimer(TXID_A2),
+            challengers: [],
+          },
+          error: null,
+        },
+      ],
+    });
+
+    const map = await resolveRedeemClaimTxids(
+      [{ vaultId: "0xv1" }, { vaultId: "0xv2" }],
+      lookup,
+    );
+
+    expect(map.has("0xv1")).toBe(false);
+    expect(map.get("0xv2")).toBe(TXID_A2);
+    expect(createVpClient).toHaveBeenCalledTimes(1);
+    expect(createVpClient).toHaveBeenCalledWith(VP_A, expect.anything());
+  });
+
+  it("soft-fails a provider whose client construction throws, keeping other providers", async () => {
+    const lookup = new Map<string, RedeemVaultLookup>([
+      ["0xv1", { peginTxHash: "0xpegin1", vaultProvider: VP_A }],
+      ["0xv2", { peginTxHash: "0xpegin2", vaultProvider: VP_B }],
+    ]);
+
+    createVpClient.mockImplementation((address: string) => {
+      if (address === VP_A) throw new Error("missing VP proxy url");
+      return { batchGetPegoutStatus };
+    });
+    batchGetPegoutStatus.mockResolvedValueOnce({
+      results: [
+        {
+          pegin_txid: "pegin2",
+          result: {
+            pegin_txid: "pegin2",
+            found: true,
+            claimer: claimer(TXID_B3),
+            challengers: [],
+          },
+          error: null,
+        },
+      ],
+    });
+
+    const map = await resolveRedeemClaimTxids(
+      [{ vaultId: "0xv1" }, { vaultId: "0xv2" }],
+      lookup,
+    );
+
+    expect(map.has("0xv1")).toBe(false);
+    expect(map.get("0xv2")).toBe(TXID_B3);
   });
 
   it("treats VP errors as soft failures and returns the partial map", async () => {
@@ -215,7 +324,7 @@ describe("resolveRedeemClaimTxids", () => {
               result: {
                 pegin_txid: "pegin1",
                 found: true,
-                claimer: claimer("claimA1"),
+                claimer: claimer(TXID_A1),
                 challengers: [],
               },
               error: null,
@@ -231,7 +340,7 @@ describe("resolveRedeemClaimTxids", () => {
       lookup,
     );
 
-    expect(map.get("0xv1")).toBe("claimA1");
+    expect(map.get("0xv1")).toBe(TXID_A1);
     expect(map.has("0xv2")).toBe(false);
   });
 

--- a/services/vault/src/services/activity/__tests__/claimTxResolver.test.ts
+++ b/services/vault/src/services/activity/__tests__/claimTxResolver.test.ts
@@ -1,0 +1,178 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// `vi.mock` factories are hoisted above the surrounding module; any mock
+// state they reference must be declared via `vi.hoisted` so it exists at
+// hoist time.
+const { batchGetPegoutStatus } = vi.hoisted(() => ({
+  batchGetPegoutStatus: vi.fn(),
+}));
+
+vi.mock("@/utils/rpc", () => ({
+  createVpClient: () => ({ batchGetPegoutStatus }),
+}));
+
+vi.mock("@/infrastructure", () => ({
+  logger: { warn: vi.fn(), info: vi.fn(), error: vi.fn() },
+}));
+
+import {
+  resolveRedeemClaimTxids,
+  type RedeemVaultLookup,
+} from "../claimTxResolver";
+
+const VP_A = "0xaaaa000000000000000000000000000000000001";
+const VP_B = "0xbbbb000000000000000000000000000000000002";
+
+function claimer(claim_txid: string) {
+  return {
+    status: "PayoutBroadcast",
+    failed: false,
+    claim_txid,
+    claimer_pubkey: "",
+    assert_txid: "",
+    created_at: 0,
+    updated_at: 0,
+  };
+}
+
+describe("resolveRedeemClaimTxids", () => {
+  beforeEach(() => {
+    batchGetPegoutStatus.mockReset();
+  });
+
+  it("returns an empty map when there are no redeem activities", async () => {
+    const map = await resolveRedeemClaimTxids([], new Map());
+    expect(map.size).toBe(0);
+    expect(batchGetPegoutStatus).not.toHaveBeenCalled();
+  });
+
+  it("batches calls per vault provider and maps vaultId -> claim_txid", async () => {
+    const lookup = new Map<string, RedeemVaultLookup>([
+      ["0xv1", { peginTxHash: "0xpegin1", vaultProvider: VP_A }],
+      ["0xv2", { peginTxHash: "0xpegin2", vaultProvider: VP_A }],
+      ["0xv3", { peginTxHash: "0xpegin3", vaultProvider: VP_B }],
+    ]);
+
+    batchGetPegoutStatus.mockImplementation(({ pegin_txids }) => {
+      if (pegin_txids.includes("pegin1") && pegin_txids.includes("pegin2")) {
+        return Promise.resolve({
+          results: [
+            {
+              pegin_txid: "pegin1",
+              result: {
+                pegin_txid: "pegin1",
+                found: true,
+                claimer: claimer("claimA1"),
+                challengers: [],
+              },
+              error: null,
+            },
+            {
+              pegin_txid: "pegin2",
+              result: {
+                pegin_txid: "pegin2",
+                found: true,
+                claimer: claimer("claimA2"),
+                challengers: [],
+              },
+              error: null,
+            },
+          ],
+        });
+      }
+      return Promise.resolve({
+        results: [
+          {
+            pegin_txid: "pegin3",
+            result: {
+              pegin_txid: "pegin3",
+              found: true,
+              claimer: claimer("claimB3"),
+              challengers: [],
+            },
+            error: null,
+          },
+        ],
+      });
+    });
+
+    const map = await resolveRedeemClaimTxids(
+      [{ vaultId: "0xv1" }, { vaultId: "0xv2" }, { vaultId: "0xv3" }],
+      lookup,
+    );
+
+    expect(map.get("0xv1")).toBe("claimA1");
+    expect(map.get("0xv2")).toBe("claimA2");
+    expect(map.get("0xv3")).toBe("claimB3");
+    expect(batchGetPegoutStatus).toHaveBeenCalledTimes(2);
+  });
+
+  it("omits vaults whose claimer is null or unfound (pending state)", async () => {
+    const lookup = new Map<string, RedeemVaultLookup>([
+      ["0xv1", { peginTxHash: "0xpegin1", vaultProvider: VP_A }],
+    ]);
+
+    batchGetPegoutStatus.mockResolvedValueOnce({
+      results: [
+        {
+          pegin_txid: "pegin1",
+          result: {
+            pegin_txid: "pegin1",
+            found: false,
+            claimer: null,
+            challengers: [],
+          },
+          error: null,
+        },
+      ],
+    });
+
+    const map = await resolveRedeemClaimTxids([{ vaultId: "0xv1" }], lookup);
+
+    expect(map.has("0xv1")).toBe(false);
+  });
+
+  it("treats VP errors as soft failures and returns the partial map", async () => {
+    const lookup = new Map<string, RedeemVaultLookup>([
+      ["0xv1", { peginTxHash: "0xpegin1", vaultProvider: VP_A }],
+      ["0xv2", { peginTxHash: "0xpegin2", vaultProvider: VP_B }],
+    ]);
+
+    batchGetPegoutStatus.mockImplementation(({ pegin_txids }) => {
+      if (pegin_txids.includes("pegin1")) {
+        return Promise.resolve({
+          results: [
+            {
+              pegin_txid: "pegin1",
+              result: {
+                pegin_txid: "pegin1",
+                found: true,
+                claimer: claimer("claimA1"),
+                challengers: [],
+              },
+              error: null,
+            },
+          ],
+        });
+      }
+      return Promise.reject(new Error("VP B is unreachable"));
+    });
+
+    const map = await resolveRedeemClaimTxids(
+      [{ vaultId: "0xv1" }, { vaultId: "0xv2" }],
+      lookup,
+    );
+
+    expect(map.get("0xv1")).toBe("claimA1");
+    expect(map.has("0xv2")).toBe(false);
+  });
+
+  it("skips redeem refs whose vault metadata is unknown", async () => {
+    const map = await resolveRedeemClaimTxids(
+      [{ vaultId: "0xMISSING" }],
+      new Map(),
+    );
+    expect(map.size).toBe(0);
+    expect(batchGetPegoutStatus).not.toHaveBeenCalled();
+  });
+});

--- a/services/vault/src/services/activity/__tests__/claimTxResolver.test.ts
+++ b/services/vault/src/services/activity/__tests__/claimTxResolver.test.ts
@@ -23,9 +23,9 @@ import {
 const VP_A = "0xaaaa000000000000000000000000000000000001";
 const VP_B = "0xbbbb000000000000000000000000000000000002";
 
-function claimer(claim_txid: string) {
+function claimer(claim_txid: string, status: string = "PayoutBroadcast") {
   return {
-    status: "PayoutBroadcast",
+    status,
     failed: false,
     claim_txid,
     claimer_pubkey: "",
@@ -130,6 +130,56 @@ describe("resolveRedeemClaimTxids", () => {
     const map = await resolveRedeemClaimTxids([{ vaultId: "0xv1" }], lookup);
 
     expect(map.has("0xv1")).toBe(false);
+  });
+
+  it("omits claim txids that are not yet broadcast on Bitcoin (ClaimEventReceived)", async () => {
+    const lookup = new Map<string, RedeemVaultLookup>([
+      ["0xv1", { peginTxHash: "0xpegin1", vaultProvider: VP_A }],
+    ]);
+
+    batchGetPegoutStatus.mockResolvedValueOnce({
+      results: [
+        {
+          pegin_txid: "pegin1",
+          result: {
+            pegin_txid: "pegin1",
+            found: true,
+            claimer: claimer("claimPre", "ClaimEventReceived"),
+            challengers: [],
+          },
+          error: null,
+        },
+      ],
+    });
+
+    const map = await resolveRedeemClaimTxids([{ vaultId: "0xv1" }], lookup);
+
+    expect(map.has("0xv1")).toBe(false);
+  });
+
+  it("includes the claim txid once the claim tx is broadcast (ClaimBroadcast)", async () => {
+    const lookup = new Map<string, RedeemVaultLookup>([
+      ["0xv1", { peginTxHash: "0xpegin1", vaultProvider: VP_A }],
+    ]);
+
+    batchGetPegoutStatus.mockResolvedValueOnce({
+      results: [
+        {
+          pegin_txid: "pegin1",
+          result: {
+            pegin_txid: "pegin1",
+            found: true,
+            claimer: claimer("claimLive", "ClaimBroadcast"),
+            challengers: [],
+          },
+          error: null,
+        },
+      ],
+    });
+
+    const map = await resolveRedeemClaimTxids([{ vaultId: "0xv1" }], lookup);
+
+    expect(map.get("0xv1")).toBe("claimLive");
   });
 
   it("treats VP errors as soft failures and returns the partial map", async () => {

--- a/services/vault/src/services/activity/__tests__/claimTxResolver.test.ts
+++ b/services/vault/src/services/activity/__tests__/claimTxResolver.test.ts
@@ -3,19 +3,22 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // `vi.mock` factories are hoisted above the surrounding module; any mock
 // state they reference must be declared via `vi.hoisted` so it exists at
 // hoist time.
-const { batchGetPegoutStatus } = vi.hoisted(() => ({
-  batchGetPegoutStatus: vi.fn(),
-}));
+const { batchGetPegoutStatus, createVpClient } = vi.hoisted(() => {
+  const batchGetPegoutStatus = vi.fn();
+  return {
+    batchGetPegoutStatus,
+    createVpClient: vi.fn(() => ({ batchGetPegoutStatus })),
+  };
+});
 
-vi.mock("@/utils/rpc", () => ({
-  createVpClient: () => ({ batchGetPegoutStatus }),
-}));
+vi.mock("@/utils/rpc", () => ({ createVpClient }));
 
 vi.mock("@/infrastructure", () => ({
   logger: { warn: vi.fn(), info: vi.fn(), error: vi.fn() },
 }));
 
 import {
+  CLAIM_TX_RPC_TIMEOUT_MS,
   resolveRedeemClaimTxids,
   type RedeemVaultLookup,
 } from "../claimTxResolver";
@@ -38,6 +41,21 @@ function claimer(claim_txid: string, status: string = "PayoutBroadcast") {
 describe("resolveRedeemClaimTxids", () => {
   beforeEach(() => {
     batchGetPegoutStatus.mockReset();
+    createVpClient.mockClear();
+  });
+
+  it("bounds each VP call with a short timeout and no retries so a slow VP can't stall the tab", async () => {
+    const lookup = new Map<string, RedeemVaultLookup>([
+      ["0xv1", { peginTxHash: "0xpegin1", vaultProvider: VP_A }],
+    ]);
+    batchGetPegoutStatus.mockResolvedValueOnce({ results: [] });
+
+    await resolveRedeemClaimTxids([{ vaultId: "0xv1" }], lookup);
+
+    expect(createVpClient).toHaveBeenCalledWith(VP_A, {
+      timeout: CLAIM_TX_RPC_TIMEOUT_MS,
+      retries: 0,
+    });
   });
 
   it("returns an empty map when there are no redeem activities", async () => {

--- a/services/vault/src/services/activity/__tests__/fetchActivities.test.ts
+++ b/services/vault/src/services/activity/__tests__/fetchActivities.test.ts
@@ -122,6 +122,7 @@ async function setupGraphqlMock(rows: RawActivity[]) {
             items: ids.map((id) => ({
               id,
               peginTxHash: `0xpegin-${id.slice(2, 10)}`,
+              vaultProvider: `0xvp-${id.slice(2, 10)}`,
             })),
             pageInfo: { hasNextPage: false, endCursor: null },
           },
@@ -254,6 +255,27 @@ describe("fetchUserActivities type mapping", () => {
       expect.stringContaining("dropped unrecognised activity type"),
       { type: "add_collateral" },
     );
+  });
+
+  it("requests vaultProvider in the vaults selection", async () => {
+    const { graphqlClient } = await import("@/clients/graphql");
+    const requestMock = vi.mocked(graphqlClient.request);
+    requestMock.mockReset();
+    requestMock.mockResolvedValueOnce({
+      vaultActivitys: {
+        items: [],
+        pageInfo: { hasNextPage: false, endCursor: null },
+      },
+      vaults: {
+        items: [],
+        pageInfo: { hasNextPage: false, endCursor: null },
+      },
+    } as never);
+
+    await fetchUserActivities(USER as `0x${string}`, buildDeps());
+
+    const firstCallQuery = String(requestMock.mock.calls[0]?.[0]);
+    expect(firstCallQuery).toMatch(/vaultProvider/);
   });
 
   it("warns only once per unknown type across repeated fetches", async () => {

--- a/services/vault/src/services/activity/__tests__/fetchActivities.test.ts
+++ b/services/vault/src/services/activity/__tests__/fetchActivities.test.ts
@@ -34,6 +34,10 @@ vi.mock("@/infrastructure", () => ({
   logger: { warn: vi.fn(), info: vi.fn(), error: vi.fn() },
 }));
 
+vi.mock("../claimTxResolver", () => ({
+  resolveRedeemClaimTxids: vi.fn(async () => new Map<string, string>()),
+}));
+
 const USER = "0x1111111111111111111111111111111111111111";
 const VAULT_A = "0x" + "a".repeat(64);
 const TX_DEPOSIT = "0x" + "1".repeat(64);
@@ -294,6 +298,76 @@ describe("fetchUserActivities type mapping", () => {
     await fetchUserActivities(USER as `0x${string}`, buildDeps());
 
     expect(logger.warn).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders redeem rows with the BTC claim txid, not the EVM tx hash", async () => {
+    const { resolveRedeemClaimTxids } = await import("../claimTxResolver");
+    const resolverMock = vi.mocked(resolveRedeemClaimTxids);
+    resolverMock.mockReset();
+    resolverMock.mockResolvedValueOnce(new Map([[VAULT_A, "claimBtcTxid123"]]));
+
+    const rows: RawActivity[] = [
+      activity({
+        type: "redeem",
+        logIndex: 0,
+        transactionHash: "0x" + "9".repeat(64),
+        vaultId: VAULT_A,
+      }),
+    ];
+    await setupGraphqlMock(rows);
+
+    const result = await fetchUserActivities(
+      USER as `0x${string}`,
+      buildDeps(),
+    );
+
+    const redeemRow = asStandard(result[0]);
+    expect(redeemRow.type).toBe("Redeem");
+    expect(redeemRow.chain).toBe("BTC");
+    expect(redeemRow.transactionHash).toBe("claimBtcTxid123");
+
+    // Pin the orchestrator -> resolver wiring: a regression that builds the
+    // lookup wrong (e.g. drops vaultProvider, or strips redeem refs) would
+    // still pass the rendering assertion via the stubbed return value above.
+    expect(resolverMock).toHaveBeenCalledTimes(1);
+    expect(resolverMock).toHaveBeenCalledWith(
+      [{ vaultId: VAULT_A }],
+      expect.any(Map),
+    );
+    const vaultLookupArg = resolverMock.mock.calls[0]![1] as ReadonlyMap<
+      string,
+      { peginTxHash: string; vaultProvider: string }
+    >;
+    expect(vaultLookupArg.get(VAULT_A)).toEqual({
+      peginTxHash: `0xpegin-${VAULT_A.slice(2, 10)}`,
+      vaultProvider: `0xvp-${VAULT_A.slice(2, 10)}`,
+    });
+  });
+
+  it("renders redeem rows as 'Pending…' (empty hash) when the resolver returns nothing", async () => {
+    const { resolveRedeemClaimTxids } = await import("../claimTxResolver");
+    vi.mocked(resolveRedeemClaimTxids).mockReset();
+    vi.mocked(resolveRedeemClaimTxids).mockResolvedValueOnce(new Map());
+
+    const rows: RawActivity[] = [
+      activity({
+        type: "redeem",
+        logIndex: 0,
+        transactionHash: "0x" + "9".repeat(64),
+        vaultId: VAULT_A,
+      }),
+    ];
+    await setupGraphqlMock(rows);
+
+    const result = await fetchUserActivities(
+      USER as `0x${string}`,
+      buildDeps(),
+    );
+
+    const redeemRow = asStandard(result[0]);
+    expect(redeemRow.type).toBe("Redeem");
+    expect(redeemRow.chain).toBe("BTC");
+    expect(redeemRow.transactionHash).toBe("");
   });
 });
 

--- a/services/vault/src/services/activity/claimTxResolver.ts
+++ b/services/vault/src/services/activity/claimTxResolver.ts
@@ -21,6 +21,7 @@ import {
 } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
 
 import { logger } from "@/infrastructure";
+import { getPegoutTxLinkFlags } from "@/models/pegoutStateMachine";
 import { createVpClient } from "@/utils/rpc";
 
 export interface RedeemVaultLookup {
@@ -80,7 +81,13 @@ export async function resolveRedeemClaimTxids(
           onItem: (entry, envelope) => {
             if (envelope.error !== null) return;
             const claimer = envelope.result?.claimer;
-            const claimTxid = claimer?.claim_txid;
+            if (!claimer) return;
+            // The claim txid is pre-computed at peg-in, so it exists before the
+            // claim tx is on-chain. Only surface it once the claimer status
+            // says it's been broadcast — otherwise the row would link to a tx
+            // that isn't in any mempool yet, the exact broken link this fixes.
+            if (!getPegoutTxLinkFlags(claimer.status).linkClaim) return;
+            const claimTxid = claimer.claim_txid;
             if (typeof claimTxid === "string" && claimTxid.length > 0) {
               out.set(entry.vaultId, claimTxid);
             }

--- a/services/vault/src/services/activity/claimTxResolver.ts
+++ b/services/vault/src/services/activity/claimTxResolver.ts
@@ -19,6 +19,7 @@ import {
   batchPollByProvider,
   type GetPegoutStatusResponse,
 } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
+import { isAddress } from "viem";
 
 import { logger } from "@/infrastructure";
 import { getPegoutTxLinkFlags } from "@/models/pegoutStateMachine";
@@ -31,6 +32,9 @@ import { createVpClient } from "@/utils/rpc";
  * "Pending…" and fill in on a later refetch.
  */
 export const CLAIM_TX_RPC_TIMEOUT_MS = 10_000;
+
+/** A Bitcoin txid is 32 bytes — exactly 64 hex chars, no `0x` prefix. */
+const BTC_TXID_REGEX = /^[0-9a-f]{64}$/i;
 
 export interface RedeemVaultLookup {
   peginTxHash: string;
@@ -62,9 +66,9 @@ export async function resolveRedeemClaimTxids(
       );
       continue;
     }
-    if (!info.vaultProvider || !info.vaultProvider.startsWith("0x")) {
+    if (!isAddress(info.vaultProvider, { strict: false })) {
       logger.warn(
-        "[claimTxResolver] redeem vault missing valid provider address; skipping",
+        "[claimTxResolver] redeem vault has an invalid provider address; skipping",
         { data: { vaultId, vaultProvider: info.vaultProvider } },
       );
       continue;
@@ -79,11 +83,14 @@ export async function resolveRedeemClaimTxids(
 
   await Promise.all(
     Array.from(byProvider, async ([providerAddress, entries]) => {
-      const rpcClient = createVpClient(providerAddress, {
-        timeout: CLAIM_TX_RPC_TIMEOUT_MS,
-        retries: 0,
-      });
       try {
+        // Inside the try: createVpClient (via getVpProxyUrl) can throw on a
+        // misconfigured proxy URL, and that must fail closed for this one VP
+        // rather than rejecting Promise.all and erroring the whole tab.
+        const rpcClient = createVpClient(providerAddress, {
+          timeout: CLAIM_TX_RPC_TIMEOUT_MS,
+          retries: 0,
+        });
         await batchPollByProvider<PerVaultEntry, GetPegoutStatusResponse>({
           items: entries,
           getTxid: (e) => stripHexPrefix(e.peginTxHash),
@@ -98,8 +105,13 @@ export async function resolveRedeemClaimTxids(
             // says it's been broadcast — otherwise the row would link to a tx
             // that isn't in any mempool yet, the exact broken link this fixes.
             if (!getPegoutTxLinkFlags(claimer.status).linkClaim) return;
+            // Don't trust the VP's txid shape — a malformed value would link to
+            // mempool.space/tx/<garbage> and 404.
             const claimTxid = claimer.claim_txid;
-            if (typeof claimTxid === "string" && claimTxid.length > 0) {
+            if (
+              typeof claimTxid === "string" &&
+              BTC_TXID_REGEX.test(claimTxid)
+            ) {
               out.set(entry.vaultId, claimTxid);
             }
           },
@@ -116,7 +128,7 @@ export async function resolveRedeemClaimTxids(
         });
       } catch (error) {
         logger.warn(
-          `[claimTxResolver] VP ${providerAddress} threw outside the batch envelope`,
+          `[claimTxResolver] VP ${providerAddress} claim-txid lookup failed; leaving its rows pending`,
           { data: { error: String(error) } },
         );
       }

--- a/services/vault/src/services/activity/claimTxResolver.ts
+++ b/services/vault/src/services/activity/claimTxResolver.ts
@@ -1,0 +1,109 @@
+/**
+ * Resolves the BTC `claim_txid` for each `redeem` activity row.
+ *
+ * The Activity tab needs a BTC explorer link for redeem rows, but the
+ * indexer only sees the EVM `VaultMarkedRedeemed` event — the BTC claim
+ * is broadcast off-chain by the vault provider's claimer. This module
+ * groups redeem vaults by `vaultProvider`, calls the SDK's
+ * `vaultProvider_batchGetPegoutStatus` RPC per provider, and returns a
+ * `vaultId -> claim_txid` map.
+ *
+ * Failure handling: any VP-level error, missing claimer, or unknown
+ * pegin_txid is dropped from the result. The activity row will then
+ * render the existing "Pending…" affordance — strictly better than
+ * surfacing the unrelated EVM hash, which is the bug this module fixes.
+ */
+
+import { stripHexPrefix } from "@babylonlabs-io/ts-sdk/tbv/core";
+import {
+  batchPollByProvider,
+  type GetPegoutStatusResponse,
+} from "@babylonlabs-io/ts-sdk/tbv/core/clients";
+
+import { logger } from "@/infrastructure";
+import { createVpClient } from "@/utils/rpc";
+
+export interface RedeemVaultLookup {
+  peginTxHash: string;
+  vaultProvider: string;
+}
+
+export interface RedeemActivityRef {
+  vaultId: string;
+}
+
+interface PerVaultEntry {
+  vaultId: string;
+  peginTxHash: string;
+}
+
+export async function resolveRedeemClaimTxids(
+  redeemActivities: readonly RedeemActivityRef[],
+  vaultLookup: ReadonlyMap<string, RedeemVaultLookup>,
+): Promise<Map<string, string>> {
+  if (redeemActivities.length === 0) return new Map();
+
+  const byProvider = new Map<string, PerVaultEntry[]>();
+  for (const { vaultId } of redeemActivities) {
+    const info = vaultLookup.get(vaultId);
+    if (!info) {
+      logger.warn(
+        "[claimTxResolver] redeem activity without vault metadata; skipping",
+        { data: { vaultId } },
+      );
+      continue;
+    }
+    if (!info.vaultProvider || !info.vaultProvider.startsWith("0x")) {
+      logger.warn(
+        "[claimTxResolver] redeem vault missing valid provider address; skipping",
+        { data: { vaultId, vaultProvider: info.vaultProvider } },
+      );
+      continue;
+    }
+    const bucket = byProvider.get(info.vaultProvider);
+    const entry: PerVaultEntry = { vaultId, peginTxHash: info.peginTxHash };
+    if (bucket) bucket.push(entry);
+    else byProvider.set(info.vaultProvider, [entry]);
+  }
+
+  const out = new Map<string, string>();
+
+  await Promise.all(
+    Array.from(byProvider, async ([providerAddress, entries]) => {
+      const rpcClient = createVpClient(providerAddress);
+      try {
+        await batchPollByProvider<PerVaultEntry, GetPegoutStatusResponse>({
+          items: entries,
+          getTxid: (e) => stripHexPrefix(e.peginTxHash),
+          batchCall: (pegin_txids) =>
+            rpcClient.batchGetPegoutStatus({ pegin_txids }),
+          onItem: (entry, envelope) => {
+            if (envelope.error !== null) return;
+            const claimer = envelope.result?.claimer;
+            const claimTxid = claimer?.claim_txid;
+            if (typeof claimTxid === "string" && claimTxid.length > 0) {
+              out.set(entry.vaultId, claimTxid);
+            }
+          },
+          onMissing: () => {},
+          onDuplicate: () => {},
+          onDuplicateBatch: () => {},
+          onWholeBatchError: (_chunk, error) => {
+            logger.warn(
+              `[claimTxResolver] batch failed for VP ${providerAddress}`,
+              { data: { error: String(error) } },
+            );
+          },
+          onUnexpected: () => {},
+        });
+      } catch (error) {
+        logger.warn(
+          `[claimTxResolver] VP ${providerAddress} threw outside the batch envelope`,
+          { data: { error: String(error) } },
+        );
+      }
+    }),
+  );
+
+  return out;
+}

--- a/services/vault/src/services/activity/claimTxResolver.ts
+++ b/services/vault/src/services/activity/claimTxResolver.ts
@@ -24,6 +24,14 @@ import { logger } from "@/infrastructure";
 import { getPegoutTxLinkFlags } from "@/models/pegoutStateMachine";
 import { createVpClient } from "@/utils/rpc";
 
+/**
+ * Per-VP RPC timeout for this best-effort, display-only enrichment. Tighter
+ * than the SDK's 60s default and with no retries: a slow or dead VP must not
+ * stall the whole Activity tab on initial render — its redeem rows just stay
+ * "Pending…" and fill in on a later refetch.
+ */
+export const CLAIM_TX_RPC_TIMEOUT_MS = 10_000;
+
 export interface RedeemVaultLookup {
   peginTxHash: string;
   vaultProvider: string;
@@ -71,7 +79,10 @@ export async function resolveRedeemClaimTxids(
 
   await Promise.all(
     Array.from(byProvider, async ([providerAddress, entries]) => {
-      const rpcClient = createVpClient(providerAddress);
+      const rpcClient = createVpClient(providerAddress, {
+        timeout: CLAIM_TX_RPC_TIMEOUT_MS,
+        retries: 0,
+      });
       try {
         await batchPollByProvider<PerVaultEntry, GetPegoutStatusResponse>({
           items: entries,

--- a/services/vault/src/services/activity/fetchActivities.ts
+++ b/services/vault/src/services/activity/fetchActivities.ts
@@ -17,6 +17,10 @@ import type { Address } from "viem";
 import { logger } from "../../infrastructure";
 import type { ActivityRow } from "../../types/activityLog";
 
+import {
+  resolveRedeemClaimTxids,
+  type RedeemVaultLookup,
+} from "./claimTxResolver";
 import { buildLiquidationGroup, classifyLiquidations } from "./classification";
 import {
   isStandardActivity,
@@ -64,6 +68,23 @@ export async function fetchUserActivities(
   for (const v of vaults) {
     peginTxHashByVaultId.set(v.id, v.peginTxHash);
   }
+
+  const vaultLookup = new Map<string, RedeemVaultLookup>();
+  for (const v of vaults) {
+    vaultLookup.set(v.id, {
+      peginTxHash: v.peginTxHash,
+      vaultProvider: v.vaultProvider,
+    });
+  }
+
+  const redeemRefs = activities
+    .filter((a) => a.type === "redeem" && a.vaultId != null)
+    .map((a) => ({ vaultId: a.vaultId as string }));
+
+  const redeemClaimTxByVaultId = await resolveRedeemClaimTxids(
+    redeemRefs,
+    vaultLookup,
+  );
 
   // Sibling repay events fire in the same EVM tx as a VaultLiquidated event.
   // Aave's RepaidFromPosition is position-scoped (vaultId is null) and fires
@@ -129,7 +150,14 @@ export async function fetchUserActivities(
     }
 
     if (isStandardActivity(item)) {
-      rows.push(projectStandardRow(item, peginTxHashByVaultId, deps));
+      rows.push(
+        projectStandardRow(
+          item,
+          peginTxHashByVaultId,
+          redeemClaimTxByVaultId,
+          deps,
+        ),
+      );
       continue;
     }
 

--- a/services/vault/src/services/activity/fetchActivities.ts
+++ b/services/vault/src/services/activity/fetchActivities.ts
@@ -65,12 +65,9 @@ export async function fetchUserActivities(
   if (activities.length === 0) return [];
 
   const peginTxHashByVaultId = new Map<string, string>();
-  for (const v of vaults) {
-    peginTxHashByVaultId.set(v.id, v.peginTxHash);
-  }
-
   const vaultLookup = new Map<string, RedeemVaultLookup>();
   for (const v of vaults) {
+    peginTxHashByVaultId.set(v.id, v.peginTxHash);
     vaultLookup.set(v.id, {
       peginTxHash: v.peginTxHash,
       vaultProvider: v.vaultProvider,

--- a/services/vault/src/services/activity/projection.ts
+++ b/services/vault/src/services/activity/projection.ts
@@ -44,16 +44,27 @@ export const VAULT_COLLATERAL_ASSET = {
 const MAX_DISPLAY_FRACTION_DIGITS = 8;
 
 /**
- * Activity types whose primary user-facing transaction is on Bitcoin (the peg-in tx).
- *  - `deposit`: links to the peg-in BTC tx.
- *  - `claim_expired`: the expired peg-in's depositor reclaimed their BTC. We
- *     render this as a refunded Deposit (red dot) and surface the original
- *     peg-in BTC tx hash so users can audit the deposit chain.
- *  Everything else is an EVM-only action (collateral ops, loans, withdraw).
+ * Activity types whose primary user-facing transaction is on Bitcoin and
+ * is keyed by the vault's pegin tx hash (indexer-provided).
+ *  - `deposit`: peg-in BTC tx
+ *  - `claim_expired`: refunded deposit, surfaces the original peg-in BTC tx
  */
-const BTC_PRIMARY_ACTIVITIES: ReadonlySet<GraphQLActivityType> = new Set([
+const BTC_PRIMARY_BY_PEGIN: ReadonlySet<GraphQLActivityType> = new Set([
   "deposit",
   "claim_expired",
+]);
+
+/**
+ * Activity types whose primary user-facing transaction is on Bitcoin but
+ * keyed by the claimer's `claim_txid` (resolved per-row at fetch time from
+ * the vault provider's claimer RPC — the EVM indexer cannot see this).
+ *  - `redeem`: BTC claim tx broadcast by the VP after the EVM redeem call.
+ *    The `VaultMarkedRedeemed` EVM event the indexer records is the contract
+ *    state flip, not the actual BTC movement — surfacing the EVM hash there
+ *    sends users to an explorer page that tells them nothing.
+ */
+const BTC_PRIMARY_BY_CLAIM: ReadonlySet<GraphQLActivityType> = new Set([
+  "redeem",
 ]);
 
 /**
@@ -120,17 +131,27 @@ function isValidTxHash(hash: string | null | undefined): hash is string {
 export function resolveDisplayTx(
   item: GraphQLVaultActivityItem,
   peginTxHashByVaultId: ReadonlyMap<string, string>,
+  redeemClaimTxByVaultId: ReadonlyMap<string, string> = new Map(),
 ): {
   chain: ActivityChain;
   transactionHash: string;
 } {
-  if (BTC_PRIMARY_ACTIVITIES.has(item.type)) {
+  if (BTC_PRIMARY_BY_PEGIN.has(item.type)) {
     const peginTxHash = item.vaultId
       ? peginTxHashByVaultId.get(item.vaultId)
       : undefined;
     return {
       chain: "BTC",
       transactionHash: isValidTxHash(peginTxHash) ? peginTxHash : "",
+    };
+  }
+  if (BTC_PRIMARY_BY_CLAIM.has(item.type)) {
+    const claimTxid = item.vaultId
+      ? redeemClaimTxByVaultId.get(item.vaultId)
+      : undefined;
+    return {
+      chain: "BTC",
+      transactionHash: isValidTxHash(claimTxid) ? claimTxid : "",
     };
   }
   return { chain: "ETH", transactionHash: item.transactionHash };
@@ -202,6 +223,7 @@ export function projectRefundedDeposit(
 export function projectStandardRow(
   item: GraphQLVaultActivityItem & { type: StandardGraphQLActivityType },
   peginTxHashByVaultId: ReadonlyMap<string, string>,
+  redeemClaimTxByVaultId: ReadonlyMap<string, string>,
   deps: FetchUserActivitiesDeps,
 ): ActivityLog {
   const isPositionScoped = item.type === "borrow" || item.type === "repay";
@@ -228,6 +250,7 @@ export function projectStandardRow(
   const { chain, transactionHash } = resolveDisplayTx(
     item,
     peginTxHashByVaultId,
+    redeemClaimTxByVaultId,
   );
 
   return {

--- a/services/vault/src/services/activity/query.ts
+++ b/services/vault/src/services/activity/query.ts
@@ -38,6 +38,7 @@ export interface GraphQLVaultActivityItem {
 export interface GraphQLVaultItem {
   id: string;
   peginTxHash: string;
+  vaultProvider: string;
 }
 
 interface GraphQLPageInfo {
@@ -134,6 +135,7 @@ const GET_ACTIVITIES_FIRST_PAGE = gql`
       items {
         id
         peginTxHash
+        vaultProvider
       }
       pageInfo {
         hasNextPage
@@ -154,6 +156,7 @@ const GET_VAULTS_NEXT_PAGE = gql`
       items {
         id
         peginTxHash
+        vaultProvider
       }
       pageInfo {
         hasNextPage

--- a/services/vault/src/utils/__tests__/explorer.test.ts
+++ b/services/vault/src/utils/__tests__/explorer.test.ts
@@ -4,9 +4,25 @@ const envMock = vi.hoisted(() => ({
   ENV: { VP_EXPLORER_URL: undefined as string | undefined },
 }));
 
+// `vi.hoisted` runs BEFORE module imports, so initializers must not
+// reference imported symbols. Use string literals here — the BTC network
+// value is a string enum whose `SIGNET`/`MAINNET` members are exactly
+// "signet"/"mainnet" at runtime (see wallet-connector `Network`).
+const btcNetworkMock = vi.hoisted(() => ({
+  current: "signet" as string,
+}));
+
 vi.mock("@/config/env", () => envMock);
 
-import { getVpExplorerProviderUrl } from "../explorer";
+vi.mock("@/config", () => ({
+  getBTCNetwork: () => btcNetworkMock.current,
+}));
+
+import {
+  getBtcExplorerAddressUrl,
+  getBtcExplorerTxUrl,
+  getVpExplorerProviderUrl,
+} from "../explorer";
 
 describe("getVpExplorerProviderUrl", () => {
   beforeEach(() => {
@@ -28,5 +44,32 @@ describe("getVpExplorerProviderUrl", () => {
     expect(
       getVpExplorerProviderUrl("0x1234567890abcdef1234567890abcdef12345678"),
     ).toBeUndefined();
+  });
+});
+
+describe("BTC explorer URLs ignore the mempool API host", () => {
+  it("uses mempool.space/signet for signet, even when the API host is a self-hosted mirror", () => {
+    btcNetworkMock.current = "signet";
+
+    expect(
+      getBtcExplorerAddressUrl(
+        "tb1pm4qdd3w3yk4mtn423ltwnu2k8j0y645vsm0wyyt227nf5pkhna2q90fk8a",
+      ),
+    ).toBe(
+      "https://mempool.space/signet/address/tb1pm4qdd3w3yk4mtn423ltwnu2k8j0y645vsm0wyyt227nf5pkhna2q90fk8a",
+    );
+
+    expect(getBtcExplorerTxUrl("0xabcd")).toBe(
+      "https://mempool.space/signet/tx/abcd",
+    );
+  });
+
+  it("uses mempool.space (no network path) for mainnet", () => {
+    btcNetworkMock.current = "mainnet";
+
+    expect(getBtcExplorerAddressUrl("bc1qexample")).toBe(
+      "https://mempool.space/address/bc1qexample",
+    );
+    expect(getBtcExplorerTxUrl("dead")).toBe("https://mempool.space/tx/dead");
   });
 });

--- a/services/vault/src/utils/explorer.ts
+++ b/services/vault/src/utils/explorer.ts
@@ -1,26 +1,38 @@
 /**
  * Block explorer URL helpers.
  *
- * BTC:  https://mempool.space/<network>/tx/<txid>      (hash without 0x)
- * ETH:  <chain explorer>/tx/<hash>                      (hash with 0x)
- * VP:   <NEXT_PUBLIC_TBV_VP_EXPLORER_URL>/provider/<address>
+ * BTC: always built against the canonical public explorer host
+ *      (`https://mempool.space/<network>`). The mempool *API* URL
+ *      (`NEXT_PUBLIC_MEMPOOL_API`) can point at a self-hosted mirror used
+ *      for UTXO / fee / broadcast calls; user-facing links must not depend
+ *      on whether that mirror is reachable, so they stay on the public
+ *      explorer.
+ * ETH: <chain explorer>/tx/<hash>                        (hash with 0x)
+ * VP:  <NEXT_PUBLIC_TBV_VP_EXPLORER_URL>/provider/<addr>
  */
 
 import { stripHexPrefix } from "@babylonlabs-io/ts-sdk/tbv/core";
 
-import { getNetworkConfigBTC } from "@/config";
+import { getBTCNetwork } from "@/config";
 import { ENV } from "@/config/env";
 import { getNetworkConfigETH } from "@/config/network";
 import type { ActivityChain } from "@/types/activityLog";
 
+const MEMPOOL_SPACE_HOST = "https://mempool.space";
+const BTC_SIGNET_NETWORK = "signet";
+
+function getBtcExplorerHost(): string {
+  return getBTCNetwork() === BTC_SIGNET_NETWORK
+    ? `${MEMPOOL_SPACE_HOST}/signet`
+    : MEMPOOL_SPACE_HOST;
+}
+
 export function getBtcExplorerTxUrl(txHash: string): string {
-  const btcConfig = getNetworkConfigBTC();
-  return `${btcConfig.mempoolApiUrl}/tx/${stripHexPrefix(txHash)}`;
+  return `${getBtcExplorerHost()}/tx/${stripHexPrefix(txHash)}`;
 }
 
 export function getBtcExplorerAddressUrl(address: string): string {
-  const btcConfig = getNetworkConfigBTC();
-  return `${btcConfig.mempoolApiUrl}/address/${address}`;
+  return `${getBtcExplorerHost()}/address/${address}`;
 }
 
 function getEthExplorerTxUrl(txHash: string): string {


### PR DESCRIPTION
The Activity tab surfaced two wrong/broken transaction links for depositors:

1. Redeem rows linked to a useless EVM hash. A redeem row showed the VaultMarkedRedeemed EVM tx — the contract state flip — as its "Transaction Hash". The meaningful tx for a redeem is the BTC claim broadcast by the vault provider's claimer, which the EVM indexer never observes (there is no EVM event carrying it).

3. BTC explorer links 403'd on testnet. Nominated-address and BTC-tx links were built from NEXT_PUBLIC_MEMPOOL_API, which on testnet is mempool.signet.babylonlabs.io — an API-only host. Every human explorer path on that host returns 403 (verified: /signet/address/… → 403, /address/… → 403, root → "Babylon Labs - Not Available", while /signet/api/address/… → 200). The env var is correct for the API; reusing it for browser links was the bug.

What changed

- Explorer host decoupled from the API host (utils/explorer.ts): a new getBtcExplorerHost() always builds against the public https://mempool.space/<network>. API calls still use the env-configured (NEXT_PUBLIC_MEMPOOL_API) host — only the user-facing links move. NEXT_PUBLIC_MEMPOOL_API itself is untouched.
- vaultProvider added to the activity vaults GraphQL selection (services/activity/query.ts), so the redeem path can reach each vault's provider.
- New claimTxResolver service (services/activity/claimTxResolver.ts): groups redeem vaults by vaultProvider, calls vaultProvider_batchGetPegoutStatus per VP (via the SDK's batchPollByProvider), and returns a vaultId → claim_txid map. Fails closed — any VP error, null claimer, or unbroadcast claim drops the entry so the row renders "Pending…" rather than a wrong link.
- Redeem rows now surface the BTC claim txid (services/activity/projection.ts, fetchActivities.ts): BTC-primary activities are split into pegin-keyed (deposit, claim_expired) and claim-keyed (redeem); redeem resolves to chain: "BTC" + the claim txid, or empty/"Pending…" until the claim is broadcast.

Testing

- New unit coverage for the resolver (per-VP batching, soft-fail on VP errors, null/unfound claimer, missing metadata) and for the redeem-row projection (claim txid present → BTC link; absent → pending).
- Explorer host tests assert mempool.space/signet on signet and mempool.space on mainnet regardless of the API host.
- Full services/vault suite green; tsc clean.
