### PR TITLE
fix(vault): reset mountedRef on remount for StrictMode

### DIFF
--- a/services/vault/src/utils/errors/__tests__/contract.test.ts
+++ b/services/vault/src/utils/errors/__tests__/contract.test.ts
@@ -2,7 +2,7 @@
  * Tests for contract error mapping utilities
  */
 
-import { type Abi } from "viem";
+import { type Abi, encodeErrorResult } from "viem";
 import { describe, expect, it } from "vitest";
 
 import { mapViemErrorToContractError } from "../contract";
@@ -18,6 +18,11 @@ const TEST_ABI: Abi = [
   {
     type: "error",
     name: "PositionNotFound",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "ActivationDeadlineExpired",
     inputs: [],
   },
   {
@@ -255,6 +260,37 @@ describe("Contract Error Mapping", () => {
       const result = mapViemErrorToContractError(error, "test", [TEST_ABI]);
 
       expect(result.code).toBe(ErrorCode.CONTRACT_REVERT);
+    });
+
+    it("decodes a viem ContractFunctionRevertedError that exposes raw hex in `.raw` only", () => {
+      // viem 2.38.x stores the DECODED result in `.data` ({ errorName, args })
+      // and the RAW revert hex in `.raw`. The mapper must read `.raw` to
+      // re-decode — this is the real shape `simulateContract` throws, and why
+      // the activation revert previously fell through to the raw viem dump.
+      const error = {
+        message:
+          'The contract function "activateVaultWithSecret" reverted. Error: ActivationDeadlineExpired()',
+        cause: {
+          name: "ContractFunctionRevertedError",
+          message: "reverted. Error: ActivationDeadlineExpired()",
+          // Decoded object — NOT a hex string, so the old `.data` check skips it.
+          data: { errorName: "ActivationDeadlineExpired", args: [] },
+          // Raw revert bytes live here.
+          raw: encodeErrorResult({
+            abi: TEST_ABI,
+            errorName: "ActivationDeadlineExpired",
+          }),
+        },
+      };
+      const result = mapViemErrorToContractError(error, "vault activation", [
+        TEST_ABI,
+      ]);
+
+      expect(result.code).toBe(ErrorCode.CONTRACT_REVERT);
+      expect(result.reason).toBe("ActivationDeadlineExpired");
+      expect(result.message).toBe(
+        "The activation deadline has passed. The BTC Vault can no longer be activated.",
+      );
     });
 
     it("should ignore empty error data", () => {

--- a/services/vault/src/utils/errors/contract.ts
+++ b/services/vault/src/utils/errors/contract.ts
@@ -47,6 +47,19 @@ function findErrorData(obj: unknown, depth = 0): `0x${string}` | undefined {
     return errorObj.revertData as `0x${string}`;
   }
 
+  // viem's ContractFunctionRevertedError keeps the DECODED result in `.data`
+  // ({ errorName, args }) and the RAW revert hex in `.raw`. The `.data` check
+  // above skips the decoded object (not a string), so read `.raw` here to
+  // recover the bytes for re-decoding.
+  if (
+    errorObj.raw &&
+    typeof errorObj.raw === "string" &&
+    errorObj.raw.startsWith("0x") &&
+    errorObj.raw.length >= 10
+  ) {
+    return errorObj.raw as `0x${string}`;
+  }
+
   // Check for RPC error structure (error.data from JSON-RPC response)
   if (errorObj.error && typeof errorObj.error === "object") {
     const rpcData = (errorObj.error as Record<string, unknown>)


### PR DESCRIPTION
Two pre-existing bugs hid contract-revert errors in the deposit/activation flow. A vault past
its activation deadline reverts at `simulateContract` with `ActivationDeadlineExpired()`
(correct on-chain behaviour) — but the UI hung on the activation step with no message. Two
independent causes:

### 1. StrictMode dropped the error (no message, step hung)
The resume/activation hooks used `useRef(true)` + an effect whose cleanup sets
`mountedRef.current = false` but whose setup never resets it to `true`. React 18 StrictMode runs
`setup → cleanup → setup` on mount in dev, so the ref ended up permanently `false`, and every
mount-guarded `setState` after the first `await` (including `setActivationError`) was skipped.
Fixed by resetting `mountedRef.current = true` in the effect setup — the same pattern
`useDepositFlow` already uses. No-op in production (StrictMode doesn't double-invoke there).

### 2. The error couldn't be decoded to friendly text (raw viem dump)
`findErrorData` looked for the revert hex only in `.data`/`.revertData`/`.error.data`. viem
2.38.x's `ContractFunctionRevertedError` stores the *decoded* result in `.data` (an object) and
the *raw* hex in `.raw`, so decoding failed and the mapper fell back to the raw viem message.
Fixed by reading `.raw`, so `decodeErrorResult` recovers the selector and maps it via
`errorMessages.ts`. This improves friendly-message mapping for **all** custom contract errors
app-wide, not just activation.

### Result
The activation step now shows: *"The activation deadline has passed. The BTC Vault can no longer
be activated."*