### PR TITLE
fix(vault): show dust token amounts on the repay screen

### DIFF
--- a/packages/babylon-core-ui/src/widgets/sections/AmountSlider/AmountSlider.tsx
+++ b/packages/babylon-core-ui/src/widgets/sections/AmountSlider/AmountSlider.tsx
@@ -12,7 +12,11 @@ function toNumber(amount: string | number): number {
 function formatForInput(amount: string | number): string {
   const num = toNumber(amount);
   if (!Number.isFinite(num) || num === 0) return "";
-  return String(num);
+  // String(num) goes exponential below 1e-6 (dust "3e-8"); render fixed-point.
+  return num.toLocaleString("en-US", {
+    maximumFractionDigits: 20,
+    useGrouping: false,
+  });
 }
 
 interface BalanceDetails {

--- a/services/vault/src/applications/aave/components/LoanCard/Repay/hooks/__tests__/validateRepayAction.test.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Repay/hooks/__tests__/validateRepayAction.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import { validateRepayAction } from "../validateRepayAction";
+
+// Signature: (repayAmount, maxRepayAmount, currentDebtAmount?, userTokenBalance?, displayDecimals?)
+describe("validateRepayAction", () => {
+  describe("sub-unit guard", () => {
+    it("blocks an amount below one base unit with 'Amount too small'", () => {
+      // 1e-9 WBTC is below the 8-decimal base unit (1e-8); the submit path's
+      // toFixed(8) would round it to 0n and the tx would revert.
+      const result = validateRepayAction(0.000000001, 1, 1, 1, 8);
+
+      expect(result.isDisabled).toBe(true);
+      expect(result.buttonText).toBe("Amount too small");
+      expect(result.errorMessage).toBe(
+        "Minimum repayable amount is 0.00000001",
+      );
+    });
+
+    it("allows a dust debt at or above one base unit", () => {
+      // 0.00000003 WBTC = 3 base units — repayable.
+      const result = validateRepayAction(
+        0.00000003,
+        0.00000003,
+        0.00000003,
+        1,
+        8,
+      );
+
+      expect(result.isDisabled).toBe(false);
+      expect(result.buttonText).toBe("Repay");
+    });
+
+    it("does not apply the guard when displayDecimals is omitted", () => {
+      const result = validateRepayAction(0.0000001, 1, 1, 1);
+
+      expect(result.buttonText).toBe("Repay");
+    });
+  });
+
+  describe("messages format at the token's precision", () => {
+    it("shows dust shortfall amounts in full, not '0.00'", () => {
+      // debt 5e-8, balance 3e-8 (balance < debt -> shortfall), 8-decimal token.
+      const result = validateRepayAction(0, 1, 0.00000005, 0.00000003, 8);
+
+      expect(result.buttonText).toBe("Enter an amount");
+      expect(result.warningMessage).toContain("0.00000003"); // balance
+      expect(result.warningMessage).toContain("0.00000005"); // debt
+      expect(result.warningMessage).not.toContain("0.00 ");
+    });
+  });
+
+  describe("existing behavior", () => {
+    it("prompts for an amount at zero", () => {
+      const result = validateRepayAction(0, 10, 10, 20, 6);
+      expect(result.buttonText).toBe("Enter an amount");
+    });
+
+    it("blocks an amount above the debt", () => {
+      const result = validateRepayAction(15, 10, 10, 20, 6);
+      expect(result.buttonText).toBe("Amount exceeds debt");
+    });
+
+    it("blocks above a known balance shortfall with insufficient balance", () => {
+      const result = validateRepayAction(5, 4, 10, 4, 6);
+      expect(result.buttonText).toBe("Insufficient balance");
+      expect(result.errorMessage).toContain("You only have");
+    });
+
+    it("enables a valid partial repay", () => {
+      const result = validateRepayAction(5, 10, 10, 20, 6);
+      expect(result.isDisabled).toBe(false);
+      expect(result.buttonText).toBe("Repay");
+    });
+  });
+});

--- a/services/vault/src/applications/aave/components/LoanCard/Repay/hooks/validateRepayAction.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Repay/hooks/validateRepayAction.ts
@@ -25,6 +25,8 @@ export interface RepayValidationResult {
  * @param maxRepayAmount - Maximum repay amount (min of debt and balance)
  * @param currentDebtAmount - Current debt amount (optional, for better error messages)
  * @param userTokenBalance - User's token balance (optional, for better error messages)
+ * @param displayDecimals - Token's display precision; messages format at it so
+ *   dust isn't shown as "0.00", and amounts below one base unit are rejected.
  * @returns Validation result with disabled state, button text, and error/warning messages
  */
 export function validateRepayAction(
@@ -32,7 +34,22 @@ export function validateRepayAction(
   maxRepayAmount: number,
   currentDebtAmount?: number,
   userTokenBalance?: number,
+  displayDecimals?: number,
 ): RepayValidationResult {
+  // Below one base unit the submit path's toFixed(displayDecimals) rounds to 0n
+  // and the tx reverts, so block it (mirrors the borrow sub-unit guard).
+  if (repayAmount > 0 && displayDecimals !== undefined) {
+    const minRepayable = 1 / 10 ** displayDecimals; // one base unit at this precision
+    if (repayAmount < minRepayable) {
+      return {
+        isDisabled: true,
+        buttonText: "Amount too small",
+        errorMessage: `Minimum repayable amount is ${formatTokenAmount(minRepayable, displayDecimals)}`,
+        warningMessage: null,
+      };
+    }
+  }
+
   // Independent of the typed amount: if the user's balance is less than the
   // outstanding debt, surface that up front so a max-repay doesn't silently
   // leave the user with residual debt and no clear next step.
@@ -48,7 +65,7 @@ export function validateRepayAction(
   // producing a self-contradicting message. A blanket `.toFixed(6)` would
   // pad normal amounts with noisy zeros.
   const shortfallMessage = balanceShortfall
-    ? `Your balance (${formatTokenAmount(userTokenBalance as number)}) is less than your debt (${formatTokenAmount(currentDebtAmount as number)}). Repaying now will leave ${formatTokenAmount((currentDebtAmount as number) - (userTokenBalance as number))} in debt; acquire more tokens to fully clear it.`
+    ? `Your balance (${formatTokenAmount(userTokenBalance as number, displayDecimals)}) is less than your debt (${formatTokenAmount(currentDebtAmount as number, displayDecimals)}). Repaying now will leave ${formatTokenAmount((currentDebtAmount as number) - (userTokenBalance as number), displayDecimals)} in debt; acquire more tokens to fully clear it.`
     : null;
 
   if (repayAmount === 0) {
@@ -65,7 +82,7 @@ export function validateRepayAction(
       return {
         isDisabled: true,
         buttonText: "Insufficient balance",
-        errorMessage: `You only have ${formatTokenAmount(userTokenBalance as number)} tokens available. You need more tokens to fully repay your debt.`,
+        errorMessage: `You only have ${formatTokenAmount(userTokenBalance as number, displayDecimals)} tokens available. You need more tokens to fully repay your debt.`,
         warningMessage: null,
       };
     }

--- a/services/vault/src/applications/aave/components/LoanCard/Repay/index.tsx
+++ b/services/vault/src/applications/aave/components/LoanCard/Repay/index.tsx
@@ -85,24 +85,25 @@ export function Repay() {
     tokenPriceUsd,
   });
 
+  // Token's own precision so dust (e.g. 0.00000003 WBTC) isn't rounded to "0.00".
+  const displayDecimals = Math.min(
+    selectedReserve.token.decimals,
+    SAFE_TOFIXED_PRECISION,
+  );
+
   const { isDisabled, buttonText, errorMessage, warningMessage } =
     validateRepayAction(
       repayAmount,
       maxRepayAmount,
       currentDebtAmount,
       userTokenBalance,
+      displayDecimals,
     );
 
   // Cosmetic floor only: keeps the slider track from collapsing to zero
   // width when there's nothing to repay. Label + accept range use the real
   // `maxRepayAmount`.
   const sliderTrackMax = maxRepayAmount > 0 ? maxRepayAmount : MIN_SLIDER_MAX;
-
-  // Token's own precision so dust (e.g. 0.00000003 WBTC) isn't rounded to "0.00".
-  const repayDisplayDecimals = Math.min(
-    selectedReserve.token.decimals,
-    SAFE_TOFIXED_PRECISION,
-  );
 
   const [refetchError, setRefetchError] = useState<string | null>(null);
 
@@ -172,7 +173,7 @@ export function Repay() {
               setRepayAmount(parseFloat(e.target.value) || 0)
             }
             balanceDetails={{
-              balance: formatTokenAmount(maxRepayAmount, repayDisplayDecimals),
+              balance: formatTokenAmount(maxRepayAmount, displayDecimals),
               symbol: assetConfig.symbol,
               displayUSD: false,
             }}
@@ -185,7 +186,7 @@ export function Repay() {
             sliderVariant="rainbow"
             leftField={{
               label: "Max",
-              value: `${formatTokenAmount(maxRepayAmount, repayDisplayDecimals)} ${assetConfig.symbol}`,
+              value: `${formatTokenAmount(maxRepayAmount, displayDecimals)} ${assetConfig.symbol}`,
             }}
             onMaxClick={handleMaxClick}
             rightField={{

--- a/services/vault/src/applications/aave/components/LoanCard/Repay/index.tsx
+++ b/services/vault/src/applications/aave/components/LoanCard/Repay/index.tsx
@@ -19,7 +19,11 @@ import {
   formatTokenAmount,
   formatUsdValue,
 } from "../../../../../utils/formatting";
-import { AMOUNT_INPUT_CLASS_NAME, MIN_SLIDER_MAX } from "../../../constants";
+import {
+  AMOUNT_INPUT_CLASS_NAME,
+  MIN_SLIDER_MAX,
+  SAFE_TOFIXED_PRECISION,
+} from "../../../constants";
 import { useRepayTransaction, type RepayMode } from "../../../hooks";
 import { useLoanContext } from "../../context/LoanContext";
 import { BorrowDetailsCard } from "../Borrow/BorrowDetailsCard";
@@ -94,6 +98,12 @@ export function Repay() {
   // `maxRepayAmount`.
   const sliderTrackMax = maxRepayAmount > 0 ? maxRepayAmount : MIN_SLIDER_MAX;
 
+  // Token's own precision so dust (e.g. 0.00000003 WBTC) isn't rounded to "0.00".
+  const repayDisplayDecimals = Math.min(
+    selectedReserve.token.decimals,
+    SAFE_TOFIXED_PRECISION,
+  );
+
   const [refetchError, setRefetchError] = useState<string | null>(null);
 
   // Pure UI action: pre-fill the input with the cached max so the user sees
@@ -162,7 +172,7 @@ export function Repay() {
               setRepayAmount(parseFloat(e.target.value) || 0)
             }
             balanceDetails={{
-              balance: formatTokenAmount(maxRepayAmount),
+              balance: formatTokenAmount(maxRepayAmount, repayDisplayDecimals),
               symbol: assetConfig.symbol,
               displayUSD: false,
             }}
@@ -175,7 +185,7 @@ export function Repay() {
             sliderVariant="rainbow"
             leftField={{
               label: "Max",
-              value: `${formatTokenAmount(maxRepayAmount)} ${assetConfig.symbol}`,
+              value: `${formatTokenAmount(maxRepayAmount, repayDisplayDecimals)} ${assetConfig.symbol}`,
             }}
             onMaxClick={handleMaxClick}
             rightField={{

--- a/services/vault/src/applications/aave/hooks/useRepayTransaction.ts
+++ b/services/vault/src/applications/aave/hooks/useRepayTransaction.ts
@@ -22,6 +22,7 @@ import {
 } from "@/utils/errors";
 
 import { getAaveAdapterAddress } from "../config";
+import { SAFE_TOFIXED_PRECISION } from "../constants";
 import {
   ReserveMismatchError,
   assertReserveMatchesOnChain,
@@ -202,7 +203,6 @@ export function useRepayTransaction({
             `Failed to fetch on-chain decimals for ${reserve.token.address}`,
           );
         });
-        const SAFE_TOFIXED_PRECISION = 15;
         const amountBigInt = parseUnits(
           repayAmount.toFixed(
             Math.min(onChainDecimals, SAFE_TOFIXED_PRECISION),


### PR DESCRIPTION
On the Aave repay screen, a dust WBTC debt (0.00000003) showed the Max as "0.00 WBTC" and the amount input as "3e-8". Both are display-only bugs from not honoring the token's decimals.