### PR TITLE
feat(vault): hide proxy-disabled vault providers from the deposit picker

### DIFF
--- a/services/vault/src/components/simple/VaultProviderSelector.tsx
+++ b/services/vault/src/components/simple/VaultProviderSelector.tsx
@@ -109,9 +109,14 @@ export function VaultProviderSelector({
           variant="default"
           className="flex w-full flex-col gap-6 !rounded-lg !bg-primary-contrast !py-4"
         >
-          <span className="text-sm text-accent-secondary">
-            {COPY.deposit.form.providerSelectDescription}
-          </span>
+          {/* The "choose a provider" prompt only makes sense when there is
+              something to choose. Hidden in the empty state (e.g. every VP
+              disabled) so it doesn't contradict the empty message below. */}
+          {(isLoadingProviders || providers.length > 0) && (
+            <span className="text-sm text-accent-secondary">
+              {COPY.deposit.form.providerSelectDescription}
+            </span>
+          )}
 
           {isLoadingProviders ? (
             <div className="flex items-center justify-center py-2">

--- a/services/vault/src/hooks/__tests__/useDisabledVps.test.ts
+++ b/services/vault/src/hooks/__tests__/useDisabledVps.test.ts
@@ -1,0 +1,108 @@
+import { useQuery } from "@tanstack/react-query";
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { VpHealthSnapshot } from "../../types/vpHealth";
+import { useDisabledVps } from "../useDisabledVps";
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: vi.fn(),
+}));
+
+vi.mock("../../services/vpHealth", () => ({
+  fetchVpHealth: vi.fn(),
+}));
+
+const mockedUseQuery = vi.mocked(useQuery);
+
+function makeSnapshot(
+  address: string,
+  overrides: Partial<VpHealthSnapshot> = {},
+): VpHealthSnapshot {
+  return {
+    address,
+    totalRequests: 10,
+    successCount: 8,
+    errorCount: 2,
+    successRate: 0.8,
+    error5xxCount: 2,
+    avgResponseMs: 100,
+    p95ResponseMs: 200,
+    ...overrides,
+  };
+}
+
+describe("useDisabledVps", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns empty set when query has no data", () => {
+    mockedUseQuery.mockReturnValue({ data: undefined } as never);
+
+    const { result } = renderHook(() => useDisabledVps());
+    expect(result.current.size).toBe(0);
+  });
+
+  it("returns empty set when no VP is disabled", () => {
+    mockedUseQuery.mockReturnValue({
+      data: [
+        makeSnapshot("0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+        makeSnapshot("0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB", {
+          disabled: false,
+        }),
+      ],
+    } as never);
+
+    const { result } = renderHook(() => useDisabledVps());
+    expect(result.current.size).toBe(0);
+  });
+
+  it("collects addresses of disabled VPs, lowercased", () => {
+    mockedUseQuery.mockReturnValue({
+      data: [
+        makeSnapshot("0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", {
+          disabled: true,
+        }),
+        makeSnapshot("0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB", {
+          disabled: false,
+        }),
+      ],
+    } as never);
+
+    const { result } = renderHook(() => useDisabledVps());
+    expect(result.current.size).toBe(1);
+    expect(
+      result.current.has(
+        "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA".toLowerCase(),
+      ),
+    ).toBe(true);
+  });
+
+  it("treats a disabled VP independently of its success rate", () => {
+    mockedUseQuery.mockReturnValue({
+      data: [
+        makeSnapshot("0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", {
+          disabled: true,
+          successRate: 1,
+          totalRequests: 0,
+        }),
+      ],
+    } as never);
+
+    const { result } = renderHook(() => useDisabledVps());
+    expect(
+      result.current.has(
+        "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA".toLowerCase(),
+      ),
+    ).toBe(true);
+  });
+
+  it("returns empty set on fetch error (graceful degradation)", () => {
+    // When the fetch fails React Query exposes no data.
+    mockedUseQuery.mockReturnValue({ data: undefined } as never);
+
+    const { result } = renderHook(() => useDisabledVps());
+    expect(result.current.size).toBe(0);
+  });
+});

--- a/services/vault/src/hooks/deposit/__tests__/useVaultProviders.test.ts
+++ b/services/vault/src/hooks/deposit/__tests__/useVaultProviders.test.ts
@@ -23,6 +23,15 @@ vi.mock("../../useUnhealthyVps", () => ({
   useUnhealthyVps: () => new Set<string>(),
 }));
 
+// Mutable ref so individual tests can control which VPs are reported disabled.
+const { disabledRef } = vi.hoisted(() => ({
+  disabledRef: { current: new Set<string>() },
+}));
+
+vi.mock("../../useDisabledVps", () => ({
+  useDisabledVps: () => disabledRef.current,
+}));
+
 vi.mock("../../useLogos", () => {
   const stableLogos = {};
   return {
@@ -36,6 +45,7 @@ const mockedUseQuery = vi.mocked(useQuery);
 describe("useVaultProviders ref stability", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    disabledRef.current = new Set<string>();
   });
 
   it("returns a stable findProvider across re-renders when the providers query has no data", () => {
@@ -69,5 +79,52 @@ describe("useVaultProviders ref stability", () => {
     const first = result.current.findProvider;
     rerender();
     expect(result.current.findProvider).toBe(first);
+  });
+});
+
+describe("useVaultProviders disabled filtering", () => {
+  const ENABLED_ID = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+  const DISABLED_ID = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    disabledRef.current = new Set<string>();
+
+    mockedUseQuery.mockReturnValue({
+      data: {
+        vaultProviders: [
+          { id: ENABLED_ID, btcPubKey: "0xdead" },
+          { id: DISABLED_ID, btcPubKey: "0xbeef" },
+        ] as unknown as VaultProvider[],
+        vaultKeepers: [],
+      },
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    } as never);
+  });
+
+  it("excludes proxy-disabled VPs from the listable provider set", () => {
+    disabledRef.current = new Set<string>([DISABLED_ID]);
+
+    const { result } = renderHook(() => useVaultProviders());
+
+    const ids = result.current.allVaultProviders.map((p) => p.id);
+    expect(ids).toEqual([ENABLED_ID]);
+  });
+
+  it("still resolves a disabled VP via findProvider so existing vaults stay manageable", () => {
+    disabledRef.current = new Set<string>([DISABLED_ID]);
+
+    const { result } = renderHook(() => useVaultProviders());
+
+    expect(result.current.findProvider(DISABLED_ID)?.id).toBe(DISABLED_ID);
+  });
+
+  it("lists every VP when none are disabled", () => {
+    const { result } = renderHook(() => useVaultProviders());
+
+    const ids = result.current.allVaultProviders.map((p) => p.id);
+    expect(ids).toEqual([ENABLED_ID, DISABLED_ID]);
   });
 });

--- a/services/vault/src/hooks/deposit/useVaultProviders.ts
+++ b/services/vault/src/hooks/deposit/useVaultProviders.ts
@@ -18,7 +18,7 @@
  */
 
 import { useQuery } from "@tanstack/react-query";
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 
 import { useAaveConfig } from "../../applications/aave/context/AaveConfigContext";
 import { fetchAppProviders } from "../../services/providers";
@@ -27,6 +27,7 @@ import type {
   VaultKeeper,
   VaultProvider,
 } from "../../types";
+import { useDisabledVps } from "../useDisabledVps";
 import { toIdentity } from "../useLogos";
 import { useUnhealthyVps } from "../useUnhealthyVps";
 import { useWithLogos } from "../useWithLogos";
@@ -37,9 +38,12 @@ const getProviderIdentity = (p: VaultProvider) => toIdentity(p.btcPubKey);
 
 export interface UseVaultProvidersResult {
   /**
-   * Every vault provider — including runtime-unhealthy and metadata-rejected
-   * ones. The deposit picker uses this so unhealthy VPs can be shown (sorted
-   * to the bottom with a warning) rather than hidden.
+   * Every listable vault provider — including runtime-unhealthy and
+   * metadata-rejected ones (shown in the picker, sorted to the bottom with a
+   * warning) but EXCLUDING proxy-disabled VPs, which are hidden from the
+   * picker entirely. The deposit picker uses this list. To resolve a provider
+   * that an existing vault is bound to — which may be disabled — use
+   * {@link findProvider}, which searches the full unfiltered set.
    */
   allVaultProviders: VaultProvider[];
   /** Lowercased Ethereum addresses of runtime-unhealthy VPs (per `/vp-health`). */
@@ -94,18 +98,30 @@ export function useVaultProviders(
   });
 
   const unhealthyVps = useUnhealthyVps();
+  const disabledVps = useDisabledVps();
 
-  // All providers with logos (unfiltered) — used by every caller. The
-  // deposit picker sorts unhealthy / metadata-rejected VPs to the bottom
-  // instead of hiding them, and findProvider must resolve any provider that
-  // existing vaults are bound to (including ones whose rpcUrl later went bad).
+  // All providers with logos (unfiltered) — the source of truth for
+  // findProvider. The deposit picker sorts unhealthy / metadata-rejected VPs
+  // to the bottom instead of hiding them, and findProvider must resolve any
+  // provider that existing vaults are bound to (including ones that are now
+  // disabled, or whose rpcUrl later went bad).
   const allProviders = data?.vaultProviders ?? EMPTY_VAULT_PROVIDERS;
   const allProvidersWithLogos = useWithLogos(allProviders, getProviderIdentity);
 
-  // Find provider by address — searches ALL providers (including unhealthy
-  // and metadata-rejected) so that vault management flows (payout signing,
-  // dashboard, refund) still work for existing vaults bound to a provider
-  // whose rpcUrl later went bad.
+  // Listable subset shown in the picker: the full set minus proxy-disabled
+  // VPs. Disabled VPs are hidden entirely (cannot be selected for a new
+  // deposit); unhealthy / metadata-rejected VPs remain and are sorted to the
+  // bottom by the picker.
+  const listableProviders = useMemo(
+    () =>
+      allProvidersWithLogos.filter((p) => !disabledVps.has(p.id.toLowerCase())),
+    [allProvidersWithLogos, disabledVps],
+  );
+
+  // Find provider by address — searches ALL providers (including disabled,
+  // unhealthy, and metadata-rejected) so that vault management flows (payout
+  // signing, dashboard, refund) still work for existing vaults bound to a
+  // provider that was later disabled or whose rpcUrl went bad.
   const findProvider = useCallback(
     (address: string): VaultProvider | undefined => {
       return allProvidersWithLogos.find(
@@ -121,7 +137,7 @@ export function useVaultProviders(
   };
 
   return {
-    allVaultProviders: allProvidersWithLogos,
+    allVaultProviders: listableProviders,
     unhealthyVpIds: unhealthyVps,
     vaultKeepers: data?.vaultKeepers ?? EMPTY_VAULT_KEEPERS,
     loading: isLoading,

--- a/services/vault/src/hooks/useDisabledVps.ts
+++ b/services/vault/src/hooks/useDisabledVps.ts
@@ -1,0 +1,35 @@
+/**
+ * Hook that maintains a set of administratively-disabled vault provider
+ * addresses, derived from the periodically-polled VP proxy health endpoint.
+ *
+ * Design decisions:
+ * - A VP is "disabled" when it appears in the health response with
+ *   `disabled === true`. The deposit picker drops disabled VPs from its list
+ *   entirely (they cannot be selected for a new deposit), unlike unhealthy
+ *   VPs (see {@link useUnhealthyVps}) which are shown but sorted to the bottom.
+ * - VPs absent from the response, or present without the flag, are not
+ *   disabled.
+ * - On fetch error (5xx, network failure) the hook returns an empty set so
+ *   all VPs remain visible (graceful degradation) — a disabled VP momentarily
+ *   reappearing is preferable to hiding every VP when the proxy is down.
+ */
+
+import { useMemo } from "react";
+
+import { useVpHealthSnapshots } from "./useVpHealth";
+
+export function useDisabledVps(): Set<string> {
+  const snapshots = useVpHealthSnapshots();
+
+  return useMemo(() => {
+    if (!snapshots) return new Set<string>();
+
+    const disabled = new Set<string>();
+    for (const snapshot of snapshots) {
+      if (snapshot.disabled) {
+        disabled.add(snapshot.address.toLowerCase());
+      }
+    }
+    return disabled;
+  }, [snapshots]);
+}

--- a/services/vault/src/hooks/useUnhealthyVps.ts
+++ b/services/vault/src/hooks/useUnhealthyVps.ts
@@ -1,6 +1,6 @@
 /**
- * Hook that periodically polls the VP proxy health endpoint and maintains
- * a set of unhealthy vault provider addresses.
+ * Hook that maintains a set of runtime-unhealthy vault provider addresses,
+ * derived from the periodically-polled VP proxy health endpoint.
  *
  * Design decisions:
  * - A VP is "unhealthy" when it appears in the health response with a
@@ -11,16 +11,17 @@
  *   assumed healthy.
  * - On fetch error (5xx, network failure) the hook returns an empty set
  *   so all VPs remain visible (graceful degradation).
+ *
+ * "Unhealthy" is distinct from "disabled" (see {@link useDisabledVps}):
+ * unhealthy VPs are shown in the picker but sorted to the bottom with a
+ * warning, whereas disabled VPs are hidden entirely.
  */
 
-import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
 
-import { fetchVpHealth } from "../services/vpHealth";
 import type { VpHealthSnapshot } from "../types/vpHealth";
 
-/** Poll interval for the health endpoint */
-const POLL_INTERVAL_MS = 30_000;
+import { useVpHealthSnapshots } from "./useVpHealth";
 
 /** Minimum requests in the window before we judge a VP */
 const MIN_REQUESTS_FOR_EVALUATION = 3;
@@ -36,15 +37,7 @@ function isUnhealthy(snapshot: VpHealthSnapshot): boolean {
 }
 
 export function useUnhealthyVps(): Set<string> {
-  const { data: snapshots } = useQuery<VpHealthSnapshot[]>({
-    queryKey: ["vpHealth"],
-    queryFn: fetchVpHealth,
-    refetchInterval: POLL_INTERVAL_MS,
-    // fetchVpHealth returns [] on any failure (graceful degradation),
-    // so all VPs remain visible when the endpoint is down
-    retry: false,
-    refetchOnWindowFocus: false,
-  });
+  const snapshots = useVpHealthSnapshots();
 
   return useMemo(() => {
     if (!snapshots) return new Set<string>();

--- a/services/vault/src/hooks/useVpHealth.ts
+++ b/services/vault/src/hooks/useVpHealth.ts
@@ -1,0 +1,36 @@
+/**
+ * Shared subscription to the vault-provider-proxy `/vp-health` endpoint.
+ *
+ * Both {@link useUnhealthyVps} and {@link useDisabledVps} derive their sets
+ * from this single query. Centralizing the query (same `["vpHealth"]` key,
+ * same poll interval) guarantees the two hooks share one cache entry and one
+ * network fetch rather than polling the endpoint twice.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+
+import { fetchVpHealth } from "../services/vpHealth";
+import type { VpHealthSnapshot } from "../types/vpHealth";
+
+/** Poll interval for the health endpoint. */
+const POLL_INTERVAL_MS = 30_000;
+
+/**
+ * Returns the latest VP health snapshots, or `undefined` until the first
+ * fetch resolves. `fetchVpHealth` returns `[]` on any failure (graceful
+ * degradation), so a resolved-but-empty array means "assume all VPs healthy
+ * and enabled".
+ */
+export function useVpHealthSnapshots(): VpHealthSnapshot[] | undefined {
+  const { data } = useQuery<VpHealthSnapshot[]>({
+    queryKey: ["vpHealth"],
+    queryFn: fetchVpHealth,
+    refetchInterval: POLL_INTERVAL_MS,
+    // fetchVpHealth swallows failures into [], so a retry would never see a
+    // thrown error; disable it to keep the polling cadence predictable.
+    retry: false,
+    refetchOnWindowFocus: false,
+  });
+
+  return data;
+}

--- a/services/vault/src/services/vpHealth/__tests__/fetchVpHealth.test.ts
+++ b/services/vault/src/services/vpHealth/__tests__/fetchVpHealth.test.ts
@@ -153,5 +153,28 @@ describe("fetchVpHealth", () => {
       const result = await fetchVpHealth();
       expect(result).toEqual([]);
     });
+
+    it("preserves a disabled: true flag", async () => {
+      mockFetchResponse([makeSnapshot({ disabled: true })]);
+
+      const result = await fetchVpHealth();
+      expect(result).toHaveLength(1);
+      expect(result[0].disabled).toBe(true);
+    });
+
+    it("accepts snapshots without a disabled field", async () => {
+      mockFetchResponse([makeSnapshot()]);
+
+      const result = await fetchVpHealth();
+      expect(result).toHaveLength(1);
+      expect(result[0].disabled).toBeUndefined();
+    });
+
+    it("drops entries with a non-boolean disabled field", async () => {
+      mockFetchResponse([makeSnapshot({ disabled: "yes" })]);
+
+      const result = await fetchVpHealth();
+      expect(result).toEqual([]);
+    });
   });
 });

--- a/services/vault/src/services/vpHealth/fetchVpHealth.ts
+++ b/services/vault/src/services/vpHealth/fetchVpHealth.ts
@@ -52,6 +52,11 @@ export async function fetchVpHealth(): Promise<VpHealthSnapshot[]> {
       if (record.successRate < 0 || record.successRate > 1) return false;
       if (record.totalRequests < 0) return false;
 
+      // `disabled` is optional; reject only a malformed (non-boolean) value so
+      // a present flag is always trustworthy to act on (hiding the VP).
+      if (record.disabled !== undefined && typeof record.disabled !== "boolean")
+        return false;
+
       return true;
     });
   } catch (error) {

--- a/services/vault/src/types/vpHealth.ts
+++ b/services/vault/src/types/vpHealth.ts
@@ -22,4 +22,11 @@ export interface VpHealthSnapshot {
   avgResponseMs: number;
   /** 95th percentile response time in ms */
   p95ResponseMs: number;
+  /**
+   * When `true`, the proxy has administratively disabled this VP. Disabled
+   * VPs are hidden from the deposit picker entirely — unlike runtime-unhealthy
+   * VPs (low success rate), which are shown but sorted to the bottom with a
+   * warning. Absent or `false` means the VP is not disabled.
+   */
+  disabled?: boolean;
 }


### PR DESCRIPTION
Note that VP is not showed at all if it's disabled. Example from local env: 

<img width="631" height="247" alt="image" src="https://github.com/user-attachments/assets/a8bb76d4-d1de-4ca6-91cf-63b77554cfd4" />
