### PR TITLE
fix(vault): lower min borrow health-factor floor to 1.05

### DIFF
--- a/packages/babylon-ts-sdk/src/tbv/integrations/aave/constants.ts
+++ b/packages/babylon-ts-sdk/src/tbv/integrations/aave/constants.ts
@@ -85,10 +85,10 @@ export const WAD_DECIMALS = 18;
 export const HEALTH_FACTOR_WARNING_THRESHOLD = 1.5;
 
 /**
- * Minimum health factor allowed for borrowing
- * Prevents users from borrowing if resulting health factor would be below this.
+ * Minimum health factor allowed for borrowing. Collateral factor doubles as the
+ * liquidation threshold here, so this floor is the only borrow→liquidation cushion.
  */
-export const MIN_HEALTH_FACTOR_FOR_BORROW = 1.2;
+export const MIN_HEALTH_FACTOR_FOR_BORROW = 1.05;
 
 /**
  * Buffer for full repayment to account for interest accrual


### PR DESCRIPTION
The dApp capped borrowing at ~62.5% of collateral value (collateral
factor ÷ 1.2) — well under the protocol's 75% and stricter than peer
lending protocols. Our collateral factor doubles as the liquidation
threshold, so 1.05 keeps a thin cushion while letting users borrow to ~71%.


https://babylonlabsworkspace.slack.com/archives/C07EG11U45A/p1780318291562439?thread_ts=1779883556.641029&cid=C07EG11U45A