### PR TITLE
fix(vault): decode Aave adapter reverts on vault activation

### DIFF
--- a/services/vault/src/clients/eth-contract/transactionFactory.ts
+++ b/services/vault/src/clients/eth-contract/transactionFactory.ts
@@ -44,6 +44,12 @@ export interface ExecuteWriteOptions {
   args: readonly unknown[];
   /** Error context for mapViemErrorToContractError */
   errorContext: string;
+  /**
+   * Extra ABIs for decoding reverts from contracts this call delegates into
+   * (e.g. activation reverts surfaced from the Aave adapter). Decoding only —
+   * not used for simulation or the write itself.
+   */
+  errorAbis?: readonly Abi[];
 }
 
 /**
@@ -67,6 +73,7 @@ export async function executeWrite(
     functionName,
     args,
     errorContext,
+    errorAbis,
   } = options;
 
   // Reject if the wallet is connected to the wrong chain
@@ -136,8 +143,12 @@ export async function executeWrite(
       receipt,
     };
   } catch (error) {
-    // Pass the ABI for better error decoding
-    throw mapViemErrorToContractError(error, errorContext, [abi as Abi]);
+    // Decode against the call's ABI plus any delegate ABIs (e.g. the Aave
+    // adapter, whose errors the registry surfaces on activation).
+    throw mapViemErrorToContractError(error, errorContext, [
+      abi as Abi,
+      ...(errorAbis ?? []),
+    ]);
   }
 }
 

--- a/services/vault/src/services/vault/__tests__/vaultActivationService.test.ts
+++ b/services/vault/src/services/vault/__tests__/vaultActivationService.test.ts
@@ -1,3 +1,4 @@
+import { AaveIntegrationAdapterABI } from "@babylonlabs-io/ts-sdk/tbv/integrations/aave";
 import type { Address, Hex, WalletClient } from "viem";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -54,6 +55,18 @@ describe("activateVaultWithSecret (vault adapter)", () => {
     expect(callArgs.errorContext).toBe("vault activation");
     expect(callArgs.walletClient).toBe(walletClient);
     expect(callArgs.chain).toEqual({ id: 11155111, name: "sepolia" });
+  });
+
+  it("supplies the Aave adapter ABI so adapter reverts (e.g. VaultCountExceedsMaximum) decode to a friendly message", async () => {
+    mockExecuteWrite.mockResolvedValueOnce({
+      transactionHash: txHash,
+      receipt: { status: "success" },
+    });
+
+    await activateVaultWithSecret({ vaultId, secret, hashlock, walletClient });
+
+    const callArgs = mockExecuteWrite.mock.calls[0][0];
+    expect(callArgs.errorAbis).toEqual([AaveIntegrationAdapterABI]);
   });
 
   it("returns the full TransactionResult (hash + receipt) from executeWrite", async () => {

--- a/services/vault/src/services/vault/vaultActivationService.ts
+++ b/services/vault/src/services/vault/vaultActivationService.ts
@@ -16,6 +16,7 @@ import {
   activateVault,
   type EthContractWriter,
 } from "@babylonlabs-io/ts-sdk/tbv/core/services";
+import { AaveIntegrationAdapterABI } from "@babylonlabs-io/ts-sdk/tbv/integrations/aave";
 import type { Hex, WalletClient } from "viem";
 
 import {
@@ -58,6 +59,11 @@ export async function activateVaultWithSecret(
       functionName: call.functionName,
       args: call.args,
       errorContext: "vault activation",
+      // activateVaultWithSecret delegates into the Aave adapter, which can
+      // revert with VaultCountExceedsMaximum / PositionAboveMaximum — errors
+      // absent from the registry ABI. Supply the adapter ABI so the friendly
+      // copy in errorMessages.ts is reachable instead of raw hex.
+      errorAbis: [AaveIntegrationAdapterABI],
     });
 
   return activateVault<TransactionResult>({

--- a/services/vault/src/utils/errors/__tests__/contract.test.ts
+++ b/services/vault/src/utils/errors/__tests__/contract.test.ts
@@ -2,6 +2,7 @@
  * Tests for contract error mapping utilities
  */
 
+import { AaveIntegrationAdapterABI } from "@babylonlabs-io/ts-sdk/tbv/integrations/aave";
 import { type Abi, encodeErrorResult } from "viem";
 import { describe, expect, it } from "vitest";
 
@@ -348,6 +349,80 @@ describe("Contract Error Mapping", () => {
       const result = mapViemErrorToContractError(error, "test", [TEST_ABI]);
 
       expect(result.code).toBe(ErrorCode.CONTRACT_REVERT);
+    });
+
+    it("decodes an Aave adapter VaultCountExceedsMaximum revert (0xb29ce077) to the per-position cap message when the adapter ABI is supplied", () => {
+      // Activation delegates into the Aave adapter, which reverts with this
+      // error — absent from the registry ABI viem decoded against, so
+      // simulateContract throws with the raw hex in `.raw` only. The mapper
+      // re-decodes it against the adapter ABI threaded in via errorAbis.
+      const error = {
+        message:
+          'The contract function "activateVaultWithSecret" reverted with the following signature: 0xb29ce077',
+        cause: {
+          name: "ContractFunctionRevertedError",
+          raw: encodeErrorResult({
+            abi: AaveIntegrationAdapterABI as Abi,
+            errorName: "VaultCountExceedsMaximum",
+            args: [11n, 10n],
+          }),
+        },
+      };
+      const result = mapViemErrorToContractError(error, "vault activation", [
+        AaveIntegrationAdapterABI as Abi,
+      ]);
+
+      expect(result.code).toBe(ErrorCode.CONTRACT_REVERT);
+      expect(result.reason).toBe("VaultCountExceedsMaximum");
+      expect(result.message).toBe(
+        "You have reached the maximum number of BTC Vaults per position.",
+      );
+    });
+
+    it("decodes an Aave adapter PositionAboveMaximum revert to the max-position-size message when the adapter ABI is supplied", () => {
+      const error = {
+        message: "execution reverted",
+        cause: {
+          name: "ContractFunctionRevertedError",
+          raw: encodeErrorResult({
+            abi: AaveIntegrationAdapterABI as Abi,
+            errorName: "PositionAboveMaximum",
+            args: [101n, 100n],
+          }),
+        },
+      };
+      const result = mapViemErrorToContractError(error, "vault activation", [
+        AaveIntegrationAdapterABI as Abi,
+      ]);
+
+      expect(result.reason).toBe("PositionAboveMaximum");
+      expect(result.message).toBe(
+        "Your total BTC Vault amount exceeds the maximum position size.",
+      );
+    });
+
+    it("does NOT resolve VaultCountExceedsMaximum without the adapter ABI — the registry ABI alone leaves it as raw hex (the bug)", () => {
+      const error = {
+        message:
+          'The contract function "activateVaultWithSecret" reverted with the following signature: 0xb29ce077',
+        cause: {
+          name: "ContractFunctionRevertedError",
+          raw: encodeErrorResult({
+            abi: AaveIntegrationAdapterABI as Abi,
+            errorName: "VaultCountExceedsMaximum",
+            args: [11n, 10n],
+          }),
+        },
+      };
+      // TEST_ABI stands in for the registry ABI — it lacks the adapter errors.
+      const result = mapViemErrorToContractError(error, "vault activation", [
+        TEST_ABI,
+      ]);
+
+      expect(result.reason).not.toBe("VaultCountExceedsMaximum");
+      expect(result.message).not.toBe(
+        "You have reached the maximum number of BTC Vaults per position.",
+      );
     });
   });
 


### PR DESCRIPTION
Activation delegates into the Aave adapter, which can revert with
VaultCountExceedsMaximum / PositionAboveMaximum — errors absent from the
BTCVaultRegistry ABI the activation call decoded against, so depositors
hit the position cap saw a raw 0x… selector instead of the friendly copy
that already exists. Thread the adapter ABI in via a new executeWrite
`errorAbis` option.


Closes #1810