### PR TITLE
fix(vault): defer artifact download to the activation gate

### DIFF
--- a/services/vault/src/components/deposit/DepositSignModal/depositStepHelpers.ts
+++ b/services/vault/src/components/deposit/DepositSignModal/depositStepHelpers.ts
@@ -10,9 +10,6 @@ function canCloseModal(
 ): boolean {
   if (hasError) return true;
   if (currentStep === DepositFlowStep.COMPLETED) return true;
-  // Artifact download is closeable when the user is actively reviewing
-  // (no current wait) or while we're waiting for VP verification.
-  if (currentStep === DepositFlowStep.ARTIFACT_DOWNLOAD) return true;
   if (
     isWaiting &&
     (currentStep === DepositFlowStep.AWAIT_BTC_CONFIRMATION ||

--- a/services/vault/src/components/simple/DepositProgressView/__tests__/steps.test.ts
+++ b/services/vault/src/components/simple/DepositProgressView/__tests__/steps.test.ts
@@ -69,12 +69,6 @@ describe("getStepLabel", () => {
     expect(getVisualStep(DepositFlowStep.AWAIT_BTC_CONFIRMATION)).toBe(6);
   });
 
-  it("collapses ARTIFACT_DOWNLOAD onto the RETRIEVE_SECRET visual step (modal overlay)", () => {
-    expect(getVisualStep(DepositFlowStep.ARTIFACT_DOWNLOAD)).toBe(
-      getVisualStep(DepositFlowStep.RETRIEVE_SECRET),
-    );
-  });
-
   it("numbers post-confirmation steps with no gap where VP-ingestion was", () => {
     expect(getVisualStep(DepositFlowStep.SUBMIT_WOTS_KEYS)).toBe(7);
     expect(getVisualStep(DepositFlowStep.AWAIT_PAYOUT_TRANSACTIONS)).toBe(8);
@@ -260,15 +254,16 @@ describe("derivePerVaultStep", () => {
     );
   });
 
-  it("places earlier vaults past artifact download during the artifact phase", () => {
-    // Flow is downloading vault 1's artifacts — vault 0 already downloaded.
-    expect(derivePerVaultStep(DepositFlowStep.ARTIFACT_DOWNLOAD, 1, 0)).toBe(
+  it("places earlier vaults past payout signing during the retrieve-secret/activation phase", () => {
+    // Flow is at RETRIEVE_SECRET for vault 1 — vault 0 is further along
+    // (heading into activation), vault 2 is still waiting on the VP.
+    expect(derivePerVaultStep(DepositFlowStep.RETRIEVE_SECRET, 1, 0)).toBe(
       DepositFlowStep.ACTIVATE_VAULT,
     );
-    expect(derivePerVaultStep(DepositFlowStep.ARTIFACT_DOWNLOAD, 1, 1)).toBe(
-      DepositFlowStep.ARTIFACT_DOWNLOAD,
+    expect(derivePerVaultStep(DepositFlowStep.RETRIEVE_SECRET, 1, 1)).toBe(
+      DepositFlowStep.RETRIEVE_SECRET,
     );
-    expect(derivePerVaultStep(DepositFlowStep.ARTIFACT_DOWNLOAD, 1, 2)).toBe(
+    expect(derivePerVaultStep(DepositFlowStep.RETRIEVE_SECRET, 1, 2)).toBe(
       DepositFlowStep.AWAIT_VP_VERIFICATION,
     );
   });

--- a/services/vault/src/components/simple/DepositProgressView/steps.ts
+++ b/services/vault/src/components/simple/DepositProgressView/steps.ts
@@ -83,8 +83,8 @@ export const TRUNK_END_VISUAL_STEP = 6;
 /**
  * Returns the per-vault current step for a single vault in a split deposit.
  *
- * The deposit flow processes WOTS, payout signing, and artifact download
- * sequentially across vaults — at any point one vault is the "active" one
+ * The deposit flow processes WOTS and payout signing sequentially across
+ * vaults — at any point one vault is the "active" one
  * (tracked by `currentVaultIndex`) while siblings have either finished the
  * active phase or are queued for their turn. This function maps that shared
  * state into a per-vault step so each column in the split UI shows the right
@@ -123,7 +123,7 @@ export function derivePerVaultStep(
       : DepositFlowStep.AWAIT_PAYOUT_TRANSACTIONS;
   }
 
-  // Artifact download / activation phase (visual step 13+).
+  // Retrieve-secret / activation phase (visual step 13+).
   return vaultIndex < currentVaultIndex
     ? DepositFlowStep.ACTIVATE_VAULT
     : DepositFlowStep.AWAIT_VP_VERIFICATION;
@@ -219,9 +219,6 @@ export function getVisualStep(currentStep: DepositFlowStep): number {
       return 11;
     case DepositFlowStep.AWAIT_VP_VERIFICATION:
       return 12;
-    // ARTIFACT_DOWNLOAD is surfaced as a modal overlay rather than its own
-    // stepper row, so it collapses onto the RETRIEVE_SECRET visual step.
-    case DepositFlowStep.ARTIFACT_DOWNLOAD:
     case DepositFlowStep.RETRIEVE_SECRET:
       return 13;
     case DepositFlowStep.ACTIVATE_VAULT:

--- a/services/vault/src/components/simple/DepositSignContent.tsx
+++ b/services/vault/src/components/simple/DepositSignContent.tsx
@@ -11,7 +11,6 @@ import type { BitcoinWallet } from "@babylonlabs-io/ts-sdk/shared";
 import { useCallback, useState } from "react";
 import type { Address, Hex } from "viem";
 
-import { ArtifactDownloadModal } from "@/components/deposit/ArtifactDownloadModal";
 import { computeDepositDerivedState } from "@/components/deposit/DepositSignModal/depositStepHelpers";
 import { COPY } from "@/copy";
 import { useDepositFlow } from "@/hooks/deposit/useDepositFlow";
@@ -53,8 +52,6 @@ export function DepositSignContent({
     isWaiting,
     payoutSigningProgress,
     peginSigningProgress,
-    artifactDownloadInfo,
-    continueAfterArtifactDownload,
     btcConfirmationDetail,
   } = useDepositFlow({
     vaultAmounts,
@@ -148,19 +145,6 @@ export function DepositSignContent({
         onClose={handleClose}
         btcConfirmationDetail={btcConfirmationDetail}
       />
-
-      {artifactDownloadInfo && (
-        <ArtifactDownloadModal
-          open
-          onClose={handleClose}
-          onComplete={continueAfterArtifactDownload}
-          providerAddress={artifactDownloadInfo.providerAddress}
-          peginTxid={artifactDownloadInfo.peginTxid}
-          depositorPk={artifactDownloadInfo.depositorPk}
-          vaultId={artifactDownloadInfo.vaultId}
-          unsignedPrePeginTxHex={artifactDownloadInfo.unsignedPrePeginTxHex}
-        />
-      )}
     </>
   );
 }

--- a/services/vault/src/components/simple/__tests__/DepositSignContent.test.tsx
+++ b/services/vault/src/components/simple/__tests__/DepositSignContent.test.tsx
@@ -18,8 +18,6 @@ vi.mock("@/hooks/deposit/useDepositFlow", () => ({
     isWaiting: false,
     payoutSigningProgress: null,
     peginSigningProgress: null,
-    artifactDownloadInfo: null,
-    continueAfterArtifactDownload: vi.fn(),
     btcConfirmationDetail: null,
   }),
 }));
@@ -41,10 +39,6 @@ vi.mock("../PostDepositContinuationContent", () => ({
 
 vi.mock("../DepositProgressView", () => ({
   DepositProgressView: () => <div data-testid="progress" />,
-}));
-
-vi.mock("@/components/deposit/ArtifactDownloadModal", () => ({
-  ArtifactDownloadModal: () => <div data-testid="artifact" />,
 }));
 
 function renderContent(

--- a/services/vault/src/components/simple/__tests__/ResumeDepositContent.test.tsx
+++ b/services/vault/src/components/simple/__tests__/ResumeDepositContent.test.tsx
@@ -87,7 +87,7 @@ vi.mock("@/components/deposit/DepositSignModal/depositStepHelpers", () => ({
       isWaiting: boolean,
       error: string | null,
     ) => {
-      const isComplete = currentStep === 17; // DepositFlowStep.COMPLETED
+      const isComplete = currentStep === 16; // DepositFlowStep.COMPLETED
       return {
         isComplete,
         isProcessing: (processing || isWaiting) && !error && !isComplete,
@@ -483,7 +483,7 @@ describe("ResumeSignContent — reactive verification terminal", () => {
     const { getByTestId } = renderSign();
 
     // RETRIEVE_SECRET
-    expect(getByTestId("step").textContent).toBe("14");
+    expect(getByTestId("step").textContent).toBe("13");
     expect(getByTestId("terminal").textContent?.toLowerCase()).toContain(
       "ready to activate",
     );
@@ -497,7 +497,7 @@ describe("ResumeSignContent — reactive verification terminal", () => {
     const { getByTestId } = renderSign();
 
     // COMPLETED — the whole flow is done, so no stale "ready to activate".
-    expect(getByTestId("step").textContent).toBe("17");
+    expect(getByTestId("step").textContent).toBe("16");
     expect(getByTestId("terminal").textContent).toBe("");
   });
 });
@@ -536,7 +536,7 @@ describe("ResumeActivationContent — reactive activation terminal", () => {
     const { getByTestId } = renderActivation();
 
     // AWAIT_ACTIVATION_CONFIRMATION
-    await waitFor(() => expect(getByTestId("step").textContent).toBe("16"));
+    await waitFor(() => expect(getByTestId("step").textContent).toBe("15"));
   });
 
   it("completes once the contract reports ACTIVE", async () => {
@@ -547,6 +547,6 @@ describe("ResumeActivationContent — reactive activation terminal", () => {
     const { getByTestId } = renderActivation();
 
     // COMPLETED
-    await waitFor(() => expect(getByTestId("step").textContent).toBe("17"));
+    await waitFor(() => expect(getByTestId("step").textContent).toBe("16"));
   });
 });

--- a/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
@@ -251,29 +251,13 @@ const MOCK_PARAMS = {
 // Helpers
 // ============================================================================
 
-async function executeWithAutoArtifactDownload(result: {
+async function executeDepositFlow(result: {
   current: ReturnType<typeof useDepositFlow>;
 }) {
   const promise = result.current.executeDeposit();
-
-  const drainArtifactPrompts = async () => {
-    while (true) {
-      const settled = await Promise.race([
-        promise.then(() => "settled" as const),
-        new Promise<"pending">((resolve) =>
-          setTimeout(() => resolve("pending"), 0),
-        ),
-      ]);
-      if (settled === "settled") return;
-      if (result.current.artifactDownloadInfo) {
-        await act(async () => {
-          result.current.continueAfterArtifactDownload();
-        });
-      }
-    }
-  };
-
-  await drainArtifactPrompts();
+  await act(async () => {
+    await promise;
+  });
   return promise;
 }
 
@@ -382,7 +366,7 @@ describe("useDepositFlow", () => {
 
       const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
 
-      await executeWithAutoArtifactDownload(result);
+      await executeDepositFlow(result);
 
       await waitFor(() => {
         expect(preparePeginTransaction).toHaveBeenCalledTimes(1);
@@ -414,7 +398,7 @@ describe("useDepositFlow", () => {
 
       const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
 
-      await executeWithAutoArtifactDownload(result);
+      await executeDepositFlow(result);
 
       await waitFor(() => {
         const callArgs = preparePeginTransaction.mock.calls[0]?.[2];
@@ -431,7 +415,7 @@ describe("useDepositFlow", () => {
       );
 
       const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
-      await executeWithAutoArtifactDownload(result);
+      await executeDepositFlow(result);
 
       await waitFor(() => {
         expect(signProofOfPossession).toHaveBeenCalledTimes(1);
@@ -461,7 +445,7 @@ describe("useDepositFlow", () => {
 
       const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
 
-      await executeWithAutoArtifactDownload(result);
+      await executeDepositFlow(result);
 
       await waitFor(() => {
         expect(registerPeginBatchAndWait).toHaveBeenCalledTimes(1);
@@ -498,7 +482,7 @@ describe("useDepositFlow", () => {
 
       const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
 
-      await executeWithAutoArtifactDownload(result);
+      await executeDepositFlow(result);
 
       await waitFor(() => {
         expect(addPendingPegin).toHaveBeenCalledTimes(2);
@@ -534,7 +518,7 @@ describe("useDepositFlow", () => {
 
       const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
 
-      await executeWithAutoArtifactDownload(result);
+      await executeDepositFlow(result);
 
       await waitFor(() => {
         expect(broadcastPrePeginTransaction).toHaveBeenCalledTimes(1);
@@ -554,7 +538,7 @@ describe("useDepositFlow", () => {
 
       const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
 
-      await executeWithAutoArtifactDownload(result);
+      await executeDepositFlow(result);
 
       await waitFor(() => {
         expect(addPendingPegin).toHaveBeenCalledTimes(2);
@@ -586,7 +570,7 @@ describe("useDepositFlow", () => {
 
       const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
 
-      await executeWithAutoArtifactDownload(result);
+      await executeDepositFlow(result);
 
       await waitFor(() => {
         // Version-mismatch errors map to the friendly "parameters changed" copy.
@@ -618,7 +602,7 @@ describe("useDepositFlow", () => {
 
       const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
 
-      await executeWithAutoArtifactDownload(result);
+      await executeDepositFlow(result);
 
       await waitFor(() => {
         expect(result.current.error).toBeTruthy();
@@ -662,7 +646,7 @@ describe("useDepositFlow", () => {
 
       const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
 
-      await executeWithAutoArtifactDownload(result);
+      await executeDepositFlow(result);
 
       await waitFor(() => {
         // Unrecognized errors fall through to the sanitized raw message.
@@ -683,7 +667,7 @@ describe("useDepositFlow", () => {
 
       const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
 
-      await executeWithAutoArtifactDownload(result);
+      await executeDepositFlow(result);
 
       await waitFor(() => {
         expect(updatePendingPeginStatus).toHaveBeenCalledTimes(2);
@@ -704,7 +688,7 @@ describe("useDepositFlow", () => {
 
       const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
 
-      await executeWithAutoArtifactDownload(result);
+      await executeDepositFlow(result);
 
       await waitFor(() => {
         expect(signAndSubmitPayouts).toHaveBeenCalledTimes(2);
@@ -716,7 +700,7 @@ describe("useDepositFlow", () => {
     it("should return result with pegins for each vault", async () => {
       const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
 
-      const depositResult = await executeWithAutoArtifactDownload(result);
+      const depositResult = await executeDepositFlow(result);
 
       expect(depositResult).toEqual(
         expect.objectContaining({
@@ -735,17 +719,17 @@ describe("useDepositFlow", () => {
       );
     });
 
-    it("should park on ARTIFACT_DOWNLOAD with isWaiting after payout signing", async () => {
+    it("settles at AWAIT_VP_VERIFICATION with isWaiting after payout signing", async () => {
       const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
 
-      await executeWithAutoArtifactDownload(result);
+      await executeDepositFlow(result);
 
       await waitFor(() => {
         expect(result.current.processing).toBe(false);
       });
 
       expect(result.current.currentStep).toBe(
-        DepositFlowStep.ARTIFACT_DOWNLOAD,
+        DepositFlowStep.AWAIT_VP_VERIFICATION,
       );
       expect(result.current.isWaiting).toBe(true);
     });
@@ -762,7 +746,7 @@ describe("useDepositFlow", () => {
 
       const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
 
-      await executeWithAutoArtifactDownload(result);
+      await executeDepositFlow(result);
 
       await waitFor(() => {
         expect(result.current.error).toBeTruthy();
@@ -782,7 +766,7 @@ describe("useDepositFlow", () => {
 
       const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
 
-      const depositResult = await executeWithAutoArtifactDownload(result);
+      const depositResult = await executeDepositFlow(result);
 
       // Flow should complete with warnings, not error
       expect(depositResult).not.toBeNull();
@@ -806,7 +790,7 @@ describe("useDepositFlow", () => {
 
       const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
 
-      const depositResult = await executeWithAutoArtifactDownload(result);
+      const depositResult = await executeDepositFlow(result);
 
       expect(depositResult).not.toBeNull();
       expect(depositResult?.warnings).toHaveLength(1);
@@ -835,7 +819,7 @@ describe("useDepositFlow", () => {
 
       const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
 
-      const depositResult = await executeWithAutoArtifactDownload(result);
+      const depositResult = await executeDepositFlow(result);
 
       // No warnings — both vaults recovered
       expect(depositResult).not.toBeNull();
@@ -857,7 +841,7 @@ describe("useDepositFlow", () => {
 
       const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
 
-      const depositResult = await executeWithAutoArtifactDownload(result);
+      const depositResult = await executeDepositFlow(result);
 
       expect(depositResult).not.toBeNull();
       expect(depositResult?.warnings).toHaveLength(2);
@@ -921,7 +905,7 @@ describe("useDepositFlow", () => {
 
       const { result } = renderHook(() => useDepositFlow(SINGLE_PARAMS));
 
-      await executeWithAutoArtifactDownload(result);
+      await executeDepositFlow(result);
 
       await waitFor(() => {
         expect(preparePeginTransaction).toHaveBeenCalledWith(
@@ -958,7 +942,7 @@ describe("useDepositFlow", () => {
 
       const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
 
-      await executeWithAutoArtifactDownload(result);
+      await executeDepositFlow(result);
 
       await waitFor(() => {
         expect(result.current.error?.body).toBe(
@@ -984,7 +968,7 @@ describe("useDepositFlow", () => {
       });
 
       const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
-      await executeWithAutoArtifactDownload(result);
+      await executeDepositFlow(result);
 
       await waitFor(() => {
         expect(result.current.peginSigningProgress).toEqual({
@@ -1020,7 +1004,7 @@ describe("useDepositFlow", () => {
           btcWalletProvider: batchWallet as any,
         }),
       );
-      await executeWithAutoArtifactDownload(result);
+      await executeDepositFlow(result);
 
       await waitFor(() => {
         expect(result.current.peginSigningProgress).toEqual({
@@ -1051,7 +1035,7 @@ describe("useDepositFlow", () => {
         });
 
       const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
-      const depositResult = await executeWithAutoArtifactDownload(result);
+      const depositResult = await executeDepositFlow(result);
 
       expect(depositResult).not.toBeNull();
       expect(result.current.error).toBeFalsy();
@@ -1068,7 +1052,7 @@ describe("useDepositFlow", () => {
       );
 
       const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
-      await executeWithAutoArtifactDownload(result);
+      await executeDepositFlow(result);
 
       expect(preparePeginTransaction).toHaveBeenCalledTimes(1);
       const peginCall = vi.mocked(preparePeginTransaction).mock.calls[0];
@@ -1102,7 +1086,7 @@ describe("useDepositFlow", () => {
       );
 
       const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
-      await executeWithAutoArtifactDownload(result);
+      await executeDepositFlow(result);
 
       await waitFor(() => {
         // Broadcast failures map to the friendly broadcast callout.
@@ -1128,7 +1112,7 @@ describe("useDepositFlow", () => {
       );
 
       const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
-      await executeWithAutoArtifactDownload(result);
+      await executeDepositFlow(result);
 
       await waitFor(() => {
         // A BTC sat shortfall isn't a known bucket, so the raw message is

--- a/services/vault/src/hooks/deposit/__tests__/useSplitVaultProgress.test.ts
+++ b/services/vault/src/hooks/deposit/__tests__/useSplitVaultProgress.test.ts
@@ -18,10 +18,15 @@ vi.mock("@/infrastructure", () => ({ logger: { error: vi.fn() } }));
 // the module under test only needs the enum. The test and the module share
 // this mock, so the enum values stay consistent between them.
 vi.mock("@/hooks/deposit/depositFlowSteps", () => ({
+  // Numeric values mirror the real DepositFlowStep enum so the module's
+  // ordered comparisons (e.g. the trunk-floor cap) behave as in production.
   DepositFlowStep: {
-    RETRIEVE_SECRET: "RETRIEVE_SECRET",
-    AWAIT_ACTIVATION_CONFIRMATION: "AWAIT_ACTIVATION_CONFIRMATION",
-    COMPLETED: "COMPLETED",
+    BROADCAST_PRE_PEGIN: 5,
+    AWAIT_BTC_CONFIRMATION: 6,
+    AWAIT_VP_VERIFICATION: 12,
+    RETRIEVE_SECRET: 13,
+    AWAIT_ACTIVATION_CONFIRMATION: 15,
+    COMPLETED: 16,
   },
 }));
 vi.mock("@/models/peginStateMachine", () => ({
@@ -94,5 +99,51 @@ describe("deriveSplitVaultProgress", () => {
     expect(perVaultSteps?.[1]).toBe(
       DepositFlowStep.AWAIT_ACTIVATION_CONFIRMATION,
     );
+  });
+
+  it("renders a sibling with no polled state at the shared-trunk floor, not the active vault's step", () => {
+    // The active vault is mid-payout (AWAIT_VP_VERIFICATION). A sibling whose
+    // polling result hasn't loaded yet (getPollingResult → undefined) must NOT
+    // mirror the active vault's ahead step — that falsely shows it as signed.
+    // It renders the trunk floor every registered+broadcast sibling has reached.
+    const getPollingResult = pollingFor({
+      "0xactive": {
+        displayStep: DepositFlowStep.AWAIT_VP_VERIFICATION,
+        pastActivation: false,
+      },
+      // "0xunpolled" intentionally absent → getPollingResult returns undefined.
+    });
+
+    const { perVaultSteps } = deriveSplitVaultProgress(
+      getPollingResult,
+      ["0xactive", "0xunpolled"],
+      "0xactive",
+      DepositFlowStep.AWAIT_VP_VERIFICATION,
+    );
+
+    expect(perVaultSteps?.[1]).toBe(DepositFlowStep.AWAIT_BTC_CONFIRMATION);
+  });
+
+  it("tracks the shared-trunk step for an unpolled sibling during the pre-broadcast phase", () => {
+    // While the batch is still on the shared trunk (e.g. resume-broadcast, where
+    // active = BROADCAST_PRE_PEGIN), an unpolled sibling tracks the active trunk
+    // step — flooring it to AWAIT_BTC_CONFIRMATION would overstate it as already
+    // past broadcast.
+    const getPollingResult = pollingFor({
+      "0xactive": {
+        displayStep: DepositFlowStep.BROADCAST_PRE_PEGIN,
+        pastActivation: false,
+      },
+      // "0xunpolled" intentionally absent → getPollingResult returns undefined.
+    });
+
+    const { perVaultSteps } = deriveSplitVaultProgress(
+      getPollingResult,
+      ["0xactive", "0xunpolled"],
+      "0xactive",
+      DepositFlowStep.BROADCAST_PRE_PEGIN,
+    );
+
+    expect(perVaultSteps?.[1]).toBe(DepositFlowStep.BROADCAST_PRE_PEGIN);
   });
 });

--- a/services/vault/src/hooks/deposit/depositFlowSteps/types.ts
+++ b/services/vault/src/hooks/deposit/depositFlowSteps/types.ts
@@ -59,14 +59,14 @@ export enum DepositFlowStep {
   SIGN_DEPOSITOR_GRAPH = 11,
   /** Step 12: Wait for VP verification and ACK submission. */
   AWAIT_VP_VERIFICATION = 12,
-  /** Step 14: Derive the HTLC secret from the BTC wallet, ahead of activation. */
-  RETRIEVE_SECRET = 14,
-  /** Step 15: Reveal HTLC secret on Ethereum to activate the vault */
-  ACTIVATE_VAULT = 15,
-  /** Step 16: Wait for activation confirmation / indexer catch-up. */
-  AWAIT_ACTIVATION_CONFIRMATION = 16,
-  /** Step 17: Deposit completed */
-  COMPLETED = 17,
+  /** Step 13: Derive the HTLC secret from the BTC wallet, ahead of activation. */
+  RETRIEVE_SECRET = 13,
+  /** Step 14: Reveal HTLC secret on Ethereum to activate the vault */
+  ACTIVATE_VAULT = 14,
+  /** Step 15: Wait for activation confirmation / indexer catch-up. */
+  AWAIT_ACTIVATION_CONFIRMATION = 15,
+  /** Step 16: Deposit completed */
+  COMPLETED = 16,
 }
 
 // ============================================================================

--- a/services/vault/src/hooks/deposit/depositFlowSteps/types.ts
+++ b/services/vault/src/hooks/deposit/depositFlowSteps/types.ts
@@ -59,8 +59,6 @@ export enum DepositFlowStep {
   SIGN_DEPOSITOR_GRAPH = 11,
   /** Step 12: Wait for VP verification and ACK submission. */
   AWAIT_VP_VERIFICATION = 12,
-  /** Step 13: Download vault artifacts */
-  ARTIFACT_DOWNLOAD = 13,
   /** Step 14: Derive the HTLC secret from the BTC wallet, ahead of activation. */
   RETRIEVE_SECRET = 14,
   /** Step 15: Reveal HTLC secret on Ethereum to activate the vault */

--- a/services/vault/src/hooks/deposit/useDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useDepositFlow.ts
@@ -1,30 +1,15 @@
 /**
  * Deposit Flow Hook
  *
- * Orchestrates the batch-first deposit flow. A single vault is just a batch of 1.
- * Creates ONE Pre-PegIn BTC transaction with N HTLC outputs (one per vault) and
- * registers them all atomically on Ethereum via submitPeginRequestBatch().
+ * Batch-first deposit: one Pre-PegIn BTC tx with N HTLC outputs (one per vault),
+ * registered atomically on Ethereum via submitPeginRequestBatch — all vaults
+ * succeed or none, and the Pre-PegIn is broadcast only after ETH registration,
+ * so a failed batch never strands BTC in unregistered HTLCs. A single vault is
+ * a batch of 1.
  *
- * Flow:
- * 0. Validation — check wallets, UTXOs, pubkeys, array alignment
- * 1. Get shared resources (ETH wallet client)
- * 2. Prepare pegin via SDK orchestrator (sizing pass + wallet root popup +
- *    per-vault WOTS / hashlock derivation + commit pass with batch PSBT signing).
- *    Returns broadcast-ready Pre-PegIn + per-vault derived secrets.
- * 3a. Sign BIP-322 proof-of-possession (one wallet popup per deposit session)
- * 3b. Build batch request array (recompute hashlocks from returned secrets)
- * 3c. Re-check UTXO availability before committing to ETH
- * 3d. Batch ETH registration (single submitPeginRequestBatch tx for all vaults)
- * 3e. Build pegin results from batch response
- * 4a. Save pending pegins to localStorage (PENDING status; resume cache)
- * 4b. Broadcast Pre-PegIn transaction to Bitcoin, update status to CONFIRMING
- * 5. Submit WOTS keys, poll VP, sign payout transactions
- * 6. Download vault artifacts (per vault, user-driven)
- * 7. Wait for contract verification, then activate vaults (reveal HTLC secret)
- *
- * ETH registration is atomic: submitPeginRequestBatch registers all vaults in a
- * single transaction, so either all succeed or all fail. If it fails, the Pre-PegIn
- * is NOT broadcast, so no BTC gets locked in unregistered HTLC outputs.
+ * Runs through WOTS submission and payout signing, then parks at
+ * AWAIT_VP_VERIFICATION and hands off to the continuation view (artifact
+ * download + activation happen at its ActivationGate).
  */
 
 import type { BitcoinWallet } from "@babylonlabs-io/ts-sdk/shared";

--- a/services/vault/src/hooks/deposit/useDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useDepositFlow.ts
@@ -121,16 +121,6 @@ export interface UseDepositFlowParams {
   universalChallengerBtcPubkeys: string[];
 }
 
-export interface ArtifactDownloadInfo {
-  providerAddress: string;
-  peginTxid: string;
-  depositorPk: string;
-  vaultId: Hex;
-  /** Funded (pre-signing) Pre-PegIn tx hex - lets the modal re-derive
-   * an auth anchor and re-prime the VP token registry on a cold cache. */
-  unsignedPrePeginTxHex: string;
-}
-
 export interface UseDepositFlowReturn {
   /** Execute the batch deposit flow */
   executeDeposit: () => Promise<MultiVaultDepositResult | null>;
@@ -157,10 +147,6 @@ export interface UseDepositFlowReturn {
   payoutSigningProgress: PayoutSigningProgress | null;
   /** Peg-in BTC signing progress (X of Y peg-in txs, split deposits only) */
   peginSigningProgress: PeginSigningProgress | null;
-  /** Artifact download info (when set, the UI should show the download modal) */
-  artifactDownloadInfo: ArtifactDownloadInfo | null;
-  /** Callback to continue the flow after artifact download */
-  continueAfterArtifactDownload: () => void;
   /**
    * Data backing the "Awaiting Bitcoin confirmation" detail panel, snapshotted
    * when the BTC wait begins: the timestamp, the Pre-PegIn broadcast txid, and
@@ -245,8 +231,6 @@ export function useDepositFlow(
     useState<PayoutSigningProgress | null>(null);
   const [peginSigningProgress, setPeginSigningProgress] =
     useState<PeginSigningProgress | null>(null);
-  const [artifactDownloadInfo, setArtifactDownloadInfo] =
-    useState<ArtifactDownloadInfo | null>(null);
   const [btcConfirmationDetail, setBtcConfirmationDetail] = useState<{
     startedAt: number;
     prePeginTxid: string;
@@ -254,14 +238,7 @@ export function useDepositFlow(
     depositIds: readonly string[];
   } | null>(null);
 
-  const artifactResolverRef = useRef<(() => void) | null>(null);
   const payoutClaimersDoneRef = useRef(false);
-
-  const continueAfterArtifactDownload = useCallback(() => {
-    setArtifactDownloadInfo(null);
-    artifactResolverRef.current?.();
-    artifactResolverRef.current = null;
-  }, []);
 
   // Abort controller for cancelling the flow
   const abortControllerRef = useRef<AbortController | null>(null);
@@ -269,8 +246,6 @@ export function useDepositFlow(
   const abort = useCallback(() => {
     abortControllerRef.current?.abort();
     abortControllerRef.current = null;
-    artifactResolverRef.current?.();
-    artifactResolverRef.current = null;
   }, []);
 
   // Abort on real unmount (route change, browser back) but survive StrictMode
@@ -916,8 +891,6 @@ export function useDepositFlow(
 
         baseStep = DepositFlowStep.AWAIT_PAYOUT_TRANSACTIONS;
 
-        const payoutSignedVaultIds = new Set<string>();
-
         for (let vi = 0; vi < broadcastedResults.length; vi++) {
           const result = broadcastedResults[vi];
 
@@ -953,7 +926,6 @@ export function useDepositFlow(
               },
             });
 
-            payoutSignedVaultIds.add(result.vaultId);
             setCurrentStep(DepositFlowStep.AWAIT_VP_VERIFICATION);
           } catch (error) {
             // If the user cancelled, stop immediately — don't continue with other vaults
@@ -981,43 +953,11 @@ export function useDepositFlow(
         setPayoutSigningProgress(null);
         setCurrentVaultIndex(null);
 
-        // ========================================================================
-        // Step 6: Download Vault Artifacts (per vault, sequential)
-        // ========================================================================
-
-        const readyResults = broadcastedResults.filter((r) =>
-          payoutSignedVaultIds.has(r.vaultId),
-        );
-
-        setCurrentStep(DepositFlowStep.ARTIFACT_DOWNLOAD);
-        setIsWaiting(false);
-
-        for (const result of readyResults) {
-          if (signal.aborted) break;
-
-          // Track which vault's artifact is being downloaded so the split UI
-          // can advance only that column.
-          setCurrentVaultIndex(result.vaultIndex);
-
-          setArtifactDownloadInfo({
-            providerAddress: provider.id,
-            peginTxid: result.peginTxHash,
-            depositorPk: result.depositorBtcPubkey,
-            vaultId: result.vaultId,
-            unsignedPrePeginTxHex: result.fundedPrePeginTxHex,
-          });
-
-          await new Promise<void>((resolve) => {
-            artifactResolverRef.current = resolve;
-          });
-
-          // The X button on ArtifactDownloadModal calls abort(), which
-          // resolves the resolver above. Re-check here so a dismissal
-          // exits the loop (and triggers the abort branch below)
-          // instead of advancing as if the artifact were downloaded.
-          signal.throwIfAborted();
-        }
-
+        // Payout signing done. Each signed vault is left at AWAIT_VP_VERIFICATION
+        // (set above). The flow hands off to the post-deposit continuation view,
+        // which polls each vault and surfaces the manual artifact-download +
+        // activation step at its ActivationGate (where the user can download or
+        // explicitly skip) — so we no longer block the flow on a download here.
         setIsWaiting(true);
 
         // Snapshot the warnings into hook state so the UI can show them
@@ -1107,8 +1047,6 @@ export function useDepositFlow(
     isWaiting,
     payoutSigningProgress,
     peginSigningProgress,
-    artifactDownloadInfo,
-    continueAfterArtifactDownload,
     btcConfirmationDetail,
   };
 }

--- a/services/vault/src/hooks/deposit/useSplitVaultProgress.ts
+++ b/services/vault/src/hooks/deposit/useSplitVaultProgress.ts
@@ -74,7 +74,13 @@ export function deriveSplitVaultProgress(
     // is finer-grained than the polled display step.
     if (index === currentVaultIndex) return activeStep;
     const state = getPollingResult(id)?.peginState;
-    if (!state) return activeStep;
+    // Unpolled non-active sibling: cap at the shared-trunk floor once the active
+    // vault diverges, so it never mirrors the active step ahead (false "signed").
+    if (!state) {
+      return activeStep <= DepositFlowStep.AWAIT_BTC_CONFIRMATION
+        ? activeStep
+        : DepositFlowStep.AWAIT_BTC_CONFIRMATION;
+    }
     const displayStep = getPeginDisplayStep(state);
     // An in-progress sibling has its own display step (this also covers the
     // optimistic VERIFIED+CONFIRMED → AWAIT_ACTIVATION_CONFIRMATION case).


### PR DESCRIPTION
## Summary

After payout signing, the deposit flow forced the standalone
`ArtifactDownloadModal` — download or cancel, no skip. Cancel called
`abort()`, dropping the depositor back to the dashboard, so the only ways
forward were to download the ~1 GB artifacts or bail. It also prompted too
early (right after payout signing) rather than at activation, even though
the newer `ActivationGate` already offers the same download at the correct
time with a risk-acknowledge skip.

This removes the forced step. The flow now hands off to the post-deposit
continuation view, where the activation gate handles artifacts. Both paths
— staying in the deposit modal until activation, and resuming later from the
dashboard — share that one gate.

## Changes

- `useDepositFlow.ts`: remove the blocking "Step 6: Download Vault Artifacts"
  loop and its state/refs (`artifactDownloadInfo`,
  `continueAfterArtifactDownload`, `artifactResolverRef`). The flow returns
  after payout signing with each vault left at `AWAIT_VP_VERIFICATION`.
- `DepositSignContent.tsx`: drop the `<ArtifactDownloadModal>` render.
- Remove the now-dead `DepositFlowStep.ARTIFACT_DOWNLOAD` and its stepper
  mapping / `canCloseModal` branch.
- `ArtifactDownloadModal` is retained — still used by `CollateralSection`
  for the re-download path.


<img width="983" height="669" alt="image" src="https://github.com/user-attachments/assets/e1df7549-30fb-439d-8a5c-1382262ea6ad" />


<img width="925" height="647" alt="image" src="https://github.com/user-attachments/assets/42dcd065-56b4-4bc7-9bd4-a324d85e49ee" />


<img width="733" height="827" alt="image" src="https://github.com/user-attachments/assets/fc4e71f0-72a2-4583-9497-c359798819a4" />
