### PR TITLE
feat(vault): wbtc icon

### DIFF
--- a/services/vault/src/services/token/tokenService.ts
+++ b/services/vault/src/services/token/tokenService.ts
@@ -25,7 +25,7 @@ const btcConfig = getNetworkConfigBTC();
 const TOKEN_ICONS: Record<string, string> = {
   BTC: btcConfig.icon,
   SBTC: btcConfig.icon,
-  WBTC: btcConfig.icon,
+  WBTC: "/images/wbtc.png",
   VBTC: btcConfig.icon,
   USDC: "/images/usdc.png",
   USDT: "/images/usdt.png",


### PR DESCRIPTION
- changes wbtc icon from `bitcoin` to `wbtc`

after this PR:

<img width="673" height="487" alt="Screenshot_2026-06-02_11-57-14" src="https://github.com/user-attachments/assets/af210359-95fc-4af6-9257-4449b92cebd4" />
