### PR TITLE
fix(vault): clear full debt when repay slider is at max

### DIFF
--- a/services/vault/src/applications/aave/components/LoanCard/Repay/hooks/__tests__/useRepayState.test.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Repay/hooks/__tests__/useRepayState.test.ts
@@ -139,6 +139,112 @@ describe("useRepayState", () => {
     });
   });
 
+  describe("setRepayAmountSlider", () => {
+    it("sets Max intent and snaps to max when the slider reaches the top", () => {
+      const { result } = renderHook(() =>
+        useRepayState({ currentDebtAmount: 100, userTokenBalance: 100 }),
+      );
+
+      act(() => {
+        result.current.setRepayAmountSlider(100);
+      });
+
+      expect(result.current.isMaxIntent).toBe(true);
+      expect(result.current.repayAmount).toBe(100);
+    });
+
+    it("sets Max intent when the slider snaps one step short of max", () => {
+      // Native range input with step = max / 1000 can emit max - one step at
+      // the far right (99.9 for a max of 100). That last reachable step must
+      // still count as Max intent, and the display snaps to the true max.
+      const { result } = renderHook(() =>
+        useRepayState({ currentDebtAmount: 100, userTokenBalance: 100 }),
+      );
+
+      act(() => {
+        result.current.setRepayAmountSlider(99.9);
+      });
+
+      expect(result.current.isMaxIntent).toBe(true);
+      expect(result.current.repayAmount).toBe(100);
+    });
+
+    it("stays partial just below the one-step threshold", () => {
+      const { result } = renderHook(() =>
+        useRepayState({ currentDebtAmount: 100, userTokenBalance: 100 }),
+      );
+
+      act(() => {
+        result.current.setRepayAmountSlider(99.89);
+      });
+
+      expect(result.current.isMaxIntent).toBe(false);
+      expect(result.current.repayAmount).toBe(99.89);
+    });
+
+    it("sets Max intent at the balance-limited max when balance is below debt", () => {
+      const { result } = renderHook(() =>
+        useRepayState({ currentDebtAmount: 100, userTokenBalance: 50 }),
+      );
+
+      act(() => {
+        result.current.setRepayAmountSlider(50);
+      });
+
+      expect(result.current.isMaxIntent).toBe(true);
+      expect(result.current.repayAmount).toBe(50);
+    });
+
+    it("does not set Max intent when there is nothing to repay", () => {
+      const { result } = renderHook(() =>
+        useRepayState({ currentDebtAmount: 0, userTokenBalance: 100 }),
+      );
+
+      act(() => {
+        result.current.setRepayAmountSlider(0);
+      });
+
+      expect(result.current.isMaxIntent).toBe(false);
+      expect(result.current.repayAmount).toBe(0);
+    });
+
+    it("clears Max intent when the slider moves back down from the top", () => {
+      const { result } = renderHook(() =>
+        useRepayState({ currentDebtAmount: 100, userTokenBalance: 100 }),
+      );
+
+      act(() => {
+        result.current.setRepayAmountSlider(100);
+      });
+      expect(result.current.isMaxIntent).toBe(true);
+
+      act(() => {
+        result.current.setRepayAmountSlider(30);
+      });
+
+      expect(result.current.isMaxIntent).toBe(false);
+      expect(result.current.repayAmount).toBe(30);
+    });
+
+    it("works at WBTC's 8-decimal scale (slider at max clears in full)", () => {
+      // WBTC at ~$75k: a small loan is a tiny token amount. The tolerance is
+      // relative (max / SLIDER_STEP_COUNT), so it's scale-invariant — an
+      // absolute epsilon would fail here. The far-right value lands one step
+      // short of max; it must still snap to the full 8-decimal debt.
+      const wbtcDebt = 0.00133333;
+      const { result } = renderHook(() =>
+        useRepayState({ currentDebtAmount: wbtcDebt, userTokenBalance: 1 }),
+      );
+
+      act(() => {
+        result.current.setRepayAmountSlider(wbtcDebt - wbtcDebt / 1000);
+      });
+
+      expect(result.current.isMaxIntent).toBe(true);
+      expect(result.current.repayAmount).toBe(wbtcDebt);
+    });
+  });
+
   describe("repayAmount state", () => {
     it("should initialize to zero", () => {
       const { result } = renderHook(() =>

--- a/services/vault/src/applications/aave/components/LoanCard/Repay/hooks/useRepayState.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Repay/hooks/useRepayState.ts
@@ -10,6 +10,8 @@
 
 import { useCallback, useMemo, useState } from "react";
 
+import { SLIDER_STEP_COUNT } from "../../../../constants";
+
 export interface UseRepayStateProps {
   /** Current debt amount for selected reserve in token units (cached). */
   currentDebtAmount: number;
@@ -19,8 +21,15 @@ export interface UseRepayStateProps {
 
 export interface UseRepayStateResult {
   repayAmount: number;
-  /** Sets repay amount as a typed/sliderd value; clears Max intent. */
+  /** Sets repay amount as a typed value; clears Max intent. */
   setRepayAmount: (amount: number) => void;
+  /**
+   * Sets repay amount from the slider. At (or one step short of) the max it
+   * snaps to `maxRepayAmount` and marks Max intent — same as the Max button —
+   * so submit refetches and clears the full debt instead of leaving accrued
+   * dust from a stale partial amount. Below the top it's a partial repay.
+   */
+  setRepayAmountSlider: (amount: number) => void;
   /**
    * Sets repay amount as the cached `maxRepayAmount` and marks Max intent.
    * The submit path checks `isMaxIntent` and refetches fresh debt+balance
@@ -49,12 +58,32 @@ export function useRepayState({
     return Math.max(0, Math.min(currentDebtAmount, userTokenBalance));
   }, [currentDebtAmount, userTokenBalance]);
 
-  // Typed/sliderd input always drops Max intent — submit will treat it as
-  // a verbatim partial repay rather than refetching to pick a mode.
+  // Typed input always drops Max intent — submit treats it as a verbatim
+  // partial repay rather than refetching to pick a mode.
   const setRepayAmount = useCallback((amount: number) => {
     setRepayAmountFloat(amount);
     setIsMaxIntent(false);
   }, []);
+
+  // Slider input: the last reachable step counts as Max intent. The native
+  // range input's far-right value can land one step (max / SLIDER_STEP_COUNT)
+  // short of max due to float rounding, so use a one-step tolerance and snap
+  // the display to the true max. Below the top it's a verbatim partial repay.
+  const setRepayAmountSlider = useCallback(
+    (amount: number) => {
+      const atSliderMax =
+        maxRepayAmount > 0 &&
+        amount >= maxRepayAmount - maxRepayAmount / SLIDER_STEP_COUNT;
+      if (atSliderMax) {
+        setRepayAmountFloat(maxRepayAmount);
+        setIsMaxIntent(true);
+        return;
+      }
+      setRepayAmountFloat(amount);
+      setIsMaxIntent(false);
+    },
+    [maxRepayAmount],
+  );
 
   const setRepayAmountMax = useCallback((amount: number) => {
     setRepayAmountFloat(amount);
@@ -69,6 +98,7 @@ export function useRepayState({
   return {
     repayAmount,
     setRepayAmount,
+    setRepayAmountSlider,
     setRepayAmountMax,
     resetRepayAmount,
     maxRepayAmount,

--- a/services/vault/src/applications/aave/components/LoanCard/Repay/index.tsx
+++ b/services/vault/src/applications/aave/components/LoanCard/Repay/index.tsx
@@ -23,6 +23,7 @@ import {
   AMOUNT_INPUT_CLASS_NAME,
   MIN_SLIDER_MAX,
   SAFE_TOFIXED_PRECISION,
+  SLIDER_STEP_COUNT,
 } from "../../../constants";
 import { useRepayTransaction, type RepayMode } from "../../../hooks";
 import { useLoanContext } from "../../context/LoanContext";
@@ -67,6 +68,7 @@ export function Repay() {
   const {
     repayAmount,
     setRepayAmount,
+    setRepayAmountSlider,
     setRepayAmountMax,
     resetRepayAmount,
     maxRepayAmount,
@@ -180,9 +182,9 @@ export function Repay() {
             sliderValue={repayAmount}
             sliderMin={0}
             sliderMax={sliderTrackMax}
-            sliderStep={sliderTrackMax / 1000}
+            sliderStep={sliderTrackMax / SLIDER_STEP_COUNT}
             sliderSteps={[]}
-            onSliderChange={setRepayAmount}
+            onSliderChange={setRepayAmountSlider}
             sliderVariant="rainbow"
             leftField={{
               label: "Max",

--- a/services/vault/src/applications/aave/constants.ts
+++ b/services/vault/src/applications/aave/constants.ts
@@ -78,6 +78,14 @@ export const POSITION_STALENESS_THRESHOLD_MS = POSITION_REFETCH_INTERVAL_MS * 3;
 export const MIN_SLIDER_MAX = 0.0001;
 
 /**
+ * Number of discrete steps in the amount sliders (the native range input's
+ * `step` is `max / SLIDER_STEP_COUNT`). Float rounding of that division can
+ * make the far-right position land one step short of max, so "slider at max"
+ * detection uses a one-step tolerance keyed off this same count.
+ */
+export const SLIDER_STEP_COUNT = 1000;
+
+/**
  * Threshold (in USD) below which projected debt is treated as
  * effectively zero for display purposes (showing "-" for health factor
  * instead of an astronomical number). This is a display-only concern


### PR DESCRIPTION
## Summary

Dragging the repay slider fully right left a tiny residual debt (~0.000002 USDC)
that blocked collateral/sBTC withdrawal. The **Max button** repaid fully; the
**slider at max** did not.

**Cause:** the slider's `onSliderChange` used `setRepayAmount`, which clears
`isMaxIntent`. At submit, no-Max-intent skips the on-chain refetch and sends a
`"partial"` repay of the *cached* debt amount. Aave debt accrues interest every
block, so the cached figure underpays by the accrual between snapshot and mining,
leaving dust. The Max button avoids this by setting Max intent → live refetch →
`maxUint256` repay-all sentinel.

It is **not** a fee-rounding issue: the USDC `formatUnits → toFixed(6) → parseUnits`
path is lossless; a 2-base-unit shortfall can only come from interest accrual.

## Change

- `useRepayState.ts` — new `setRepayAmountSlider`: when the value is within one
  slider step of max (`amount >= max − max/SLIDER_STEP_COUNT`), snap to
  `maxRepayAmount` and set `isMaxIntent=true` (same path as the Max button);
  otherwise partial. The one-step tolerance absorbs the native range input
  landing one step short of max from float rounding — the behavior already
  documented at `constants.ts:100`.
- `index.tsx` — slider uses `setRepayAmountSlider`; typed input still uses
  `setRepayAmount`.
- `constants.ts` — extracted the magic `1000` to `SLIDER_STEP_COUNT`, shared by
  the slider `step` and the tolerance so they can't drift.

**Preserved on purpose:** typing the exact max stays a verbatim partial repay
(unchanged behavior/test). Balance-limited case (`balance < debt`) still works —
slider-to-max sets intent and `pickRepayParams` routes to partial-with-full-balance.