### PR TITLE
feat(wallet): enable OneKey for vault deposits via deriveContextHash

### DIFF
--- a/packages/babylon-wallet-connector/src/core/wallets/btc/index.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/index.ts
@@ -17,7 +17,8 @@ const metadata: ChainMetadata<"BTC", IBTCProvider, BTCConfig> = {
   chain: "BTC",
   name: "Bitcoin",
   icon,
-  wallets: [okx, injectable, appkit, onekey, unisat, ledger, ledgerV2, keystone],
+  // UniSat and OneKey (the deriveContextHash-capable wallets) lead the list.
+  wallets: [unisat, onekey, okx, injectable, appkit, ledger, ledgerV2, keystone],
 };
 
 export default metadata;

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/onekey/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/onekey/provider.ts
@@ -2,16 +2,24 @@ import { isAccountChangeEvent, DISCONNECT_EVENT, removeProviderListener } from "
 import type { BTCConfig, IBTCProvider, InscriptionIdentifier, SignPsbtOptions, WalletInfo } from "@/core/types";
 import { Network } from "@/core/types";
 import { mapSignInputsToToSignInputs } from "@/core/utils/psbtOptionsMapper";
-import { unsupportedDeriveContextHash } from "@/core/wallets/btc/unsupportedDeriveContextHash";
-import { ERROR_CODES, WalletError } from "@/error";
+import { ERROR_CODES, WalletError, isUserRejectionMessage } from "@/error";
 
 import logo from "./logo.svg";
 import { mapOneKeyNetwork } from "./network";
+import { MIN_ONEKEY_VERSION, checkOneKeyVersion } from "./version";
 
 export const WALLET_PROVIDER_NAME = "OneKey";
 
+// EIP-1193 code OneKey returns from `deriveContextHash` for non-HD accounts
+// (hardware / imported / watch-only) — its `rpc.methodNotSupported`, source:
+// OneKeyHQ/cross-inpage-provider packages/errors/src/error-constants.ts.
+const ONEKEY_METHOD_NOT_SUPPORTED_CODE = -32004;
+
 export class OneKeyProvider implements IBTCProvider {
   private provider: any;
+  // The `$onekey` injection hub (parent of `btcwallet`); carries `$walletInfo`
+  // and `$private`, the only reliable source of the OneKey app version.
+  private hub: any;
   private walletInfo: WalletInfo | undefined;
   private config: BTCConfig;
 
@@ -27,6 +35,7 @@ export class OneKeyProvider implements IBTCProvider {
       });
     }
 
+    this.hub = wallet;
     this.provider = wallet.btcwallet;
   }
 
@@ -58,6 +67,11 @@ export class OneKeyProvider implements IBTCProvider {
       }
     }
 
+    // Gate on the OneKey app version: deriveContextHash (required for vault
+    // deposits) only exists in >= 6.3.0. Surfaced as a terminal "update"
+    // prompt in the connect UI rather than failing later mid-deposit.
+    await this.ensureSupportedVersion();
+
     const address = await this.provider.getAddress();
     const publicKeyHex = await this.provider.getPublicKeyHex();
 
@@ -73,6 +87,47 @@ export class OneKeyProvider implements IBTCProvider {
         wallet: WALLET_PROVIDER_NAME,
       });
     }
+  };
+
+  // Reads the OneKey app/extension version from `$onekey.$walletInfo.version`.
+  // OneKey populates `$walletInfo` asynchronously on injection; if it isn't
+  // ready yet, call OneKey's own `$private.getConnectWalletInfo()` — the same
+  // method ProviderPrivate runs on injection — which repopulates `$walletInfo`.
+  // Returns `unknown`: external data validated by `checkOneKeyVersion`.
+  private getAppVersion = async (): Promise<unknown> => {
+    if (typeof this.hub?.$walletInfo?.version !== "string") {
+      try {
+        await this.hub?.$private?.getConnectWalletInfo?.();
+      } catch {
+        // Ignore — a missing version is handled as "unparseable" downstream.
+      }
+    }
+    return this.hub?.$walletInfo?.version;
+  };
+
+  private ensureSupportedVersion = async (): Promise<void> => {
+    const raw = await this.getAppVersion();
+    const result = checkOneKeyVersion(raw);
+    if (result === "ok") return;
+
+    if (result === "below") {
+      throw new WalletError({
+        code: ERROR_CODES.INCOMPATIBLE_WALLET_VERSION,
+        message: `Your OneKey Wallet is out of date (${raw}). Please update to version ${MIN_ONEKEY_VERSION} or later and try again.`,
+        wallet: WALLET_PROVIDER_NAME,
+        version: raw as string,
+      });
+    }
+
+    // Missing/non-canonical version ($walletInfo cache not ready, or a fork
+    // build): fail closed without claiming "out of date".
+    throw new WalletError({
+      code: ERROR_CODES.INCOMPATIBLE_WALLET_VERSION,
+      message: `Unable to verify your OneKey Wallet version${
+        typeof raw === "string" ? ` (got "${raw}")` : ""
+      }. Please update to OneKey ${MIN_ONEKEY_VERSION} or later and try again.`,
+      wallet: WALLET_PROVIDER_NAME,
+    });
   };
 
   getAddress = async (): Promise<string> => {
@@ -284,5 +339,60 @@ export class OneKeyProvider implements IBTCProvider {
     return logo;
   };
 
-  deriveContextHash = unsupportedDeriveContextHash(WALLET_PROVIDER_NAME);
+  deriveContextHash = async (appName: string, context: string): Promise<string> => {
+    if (!this.walletInfo)
+      throw new WalletError({
+        code: ERROR_CODES.WALLET_NOT_CONNECTED,
+        message: "OneKey Wallet not connected",
+        wallet: WALLET_PROVIDER_NAME,
+      });
+
+    // OneKey exposes deriveContextHash on the injected `$onekey.btcwallet`
+    // per docs/specs/derive-context-hash.md §2.1, shipped in OneKey >= 6.3.0.
+    // Older builds omit the method, so surface a typed
+    // WALLET_METHOD_NOT_SUPPORTED instead of an opaque "X is not a function".
+    if (typeof this.provider.deriveContextHash !== "function") {
+      throw new WalletError({
+        code: ERROR_CODES.WALLET_METHOD_NOT_SUPPORTED,
+        message:
+          "OneKey Wallet version does not support deriveContextHash. Update to a version that implements the deriveContextHash specification.",
+        wallet: WALLET_PROVIDER_NAME,
+      });
+    }
+
+    try {
+      return await this.provider.deriveContextHash(appName, context);
+    } catch (error) {
+      // User rejection surfaces as EIP-1193 4001 "User rejected the request."
+      // (OneKeyHQ/app-monorepo useDappApproveAction -> userRejectedRequest),
+      // matched by isUserRejectionMessage. Map to a typed rejection so callers
+      // can distinguish "user said no" from spec-validation failures.
+      if (isUserRejectionMessage((error as Error | undefined)?.message)) {
+        throw new WalletError({
+          code: ERROR_CODES.CONNECTION_REJECTED,
+          message: "OneKey Wallet rejected the deriveContextHash approval",
+          wallet: WALLET_PROVIDER_NAME,
+        });
+      }
+      // OneKey implements deriveContextHash for HD (app) wallets only; hardware,
+      // imported, and watch-only accounts reject before the approval dialog with
+      // methodNotSupported. Surface the typed capability error so callers branch
+      // on it deterministically instead of the raw "Method not supported." string.
+      if (
+        (error as { code?: number } | undefined)?.code ===
+        ONEKEY_METHOD_NOT_SUPPORTED_CODE
+      ) {
+        throw new WalletError({
+          code: ERROR_CODES.WALLET_METHOD_NOT_SUPPORTED,
+          message:
+            "This OneKey account does not support deriveContextHash. Connect a OneKey app (HD) wallet account.",
+          wallet: WALLET_PROVIDER_NAME,
+        });
+      }
+      // Everything else (appName charset, context hex format, length bounds,
+      // unsupported-network) is rethrown unwrapped to preserve the wallet's
+      // spec-validation diagnostics.
+      throw error;
+    }
+  };
 }

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/onekey/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/onekey/provider.ts
@@ -2,6 +2,7 @@ import { isAccountChangeEvent, DISCONNECT_EVENT, removeProviderListener } from "
 import type { BTCConfig, IBTCProvider, InscriptionIdentifier, SignPsbtOptions, WalletInfo } from "@/core/types";
 import { Network } from "@/core/types";
 import { mapSignInputsToToSignInputs } from "@/core/utils/psbtOptionsMapper";
+import { withTimeout } from "@/core/utils/withTimeout";
 import { ERROR_CODES, WalletError, isUserRejectionMessage } from "@/error";
 
 import logo from "./logo.svg";
@@ -15,11 +16,22 @@ export const WALLET_PROVIDER_NAME = "OneKey";
 // OneKeyHQ/cross-inpage-provider packages/errors/src/error-constants.ts.
 const ONEKEY_METHOD_NOT_SUPPORTED_CODE = -32004;
 
+// Budget for non-interactive reads (version refresh, address, pubkey). Bounds a
+// stalled/asleep extension so connect can't hang waiting on it.
+const ONEKEY_RPC_TIMEOUT_MS = 10_000;
+
+// Budget for the interactive connect approval (waits on the user).
+const ONEKEY_PROMPT_TIMEOUT_MS = 60_000;
+
 export class OneKeyProvider implements IBTCProvider {
   private provider: any;
   // The `$onekey` injection hub (parent of `btcwallet`); carries `$walletInfo`
   // and `$private`, the only reliable source of the OneKey app version.
   private hub: any;
+  // Set once the app version has been verified >= MIN_ONEKEY_VERSION, so the
+  // gate runs on the initial connect only — liveness/reconnect probes reuse it
+  // and a transient version-read miss cannot disconnect a verified session.
+  private versionChecked = false;
   private walletInfo: WalletInfo | undefined;
   private config: BTCConfig;
 
@@ -39,10 +51,24 @@ export class OneKeyProvider implements IBTCProvider {
     this.provider = wallet.btcwallet;
   }
 
+  // Builds the rejection used when a OneKey call exceeds its timeout budget.
+  // Surfaced as CONNECTION_FAILED (not a version/network problem) so the user
+  // can retry rather than being told to update.
+  private timeoutError = (operation: string): WalletError =>
+    new WalletError({
+      code: ERROR_CODES.CONNECTION_FAILED,
+      message: `OneKey Wallet did not respond while ${operation}. Open the extension to confirm it is unlocked, then try again.`,
+      wallet: WALLET_PROVIDER_NAME,
+    });
+
   connectWallet = async (): Promise<void> => {
     try {
-      await this.provider.connectWallet();
+      await withTimeout(this.provider.connectWallet(), ONEKEY_PROMPT_TIMEOUT_MS, () =>
+        this.timeoutError("connecting"),
+      );
     } catch (error) {
+      if (error instanceof WalletError) throw error;
+
       const errorMessage = (error as Error)?.message || "";
 
       if (errorMessage.includes("single address mode") || errorMessage.includes("multiple addresses")) {
@@ -72,8 +98,12 @@ export class OneKeyProvider implements IBTCProvider {
     // prompt in the connect UI rather than failing later mid-deposit.
     await this.ensureSupportedVersion();
 
-    const address = await this.provider.getAddress();
-    const publicKeyHex = await this.provider.getPublicKeyHex();
+    const address = await withTimeout<string>(this.provider.getAddress(), ONEKEY_RPC_TIMEOUT_MS, () =>
+      this.timeoutError("reading the address"),
+    );
+    const publicKeyHex = await withTimeout<string>(this.provider.getPublicKeyHex(), ONEKEY_RPC_TIMEOUT_MS, () =>
+      this.timeoutError("reading the public key"),
+    );
 
     if (publicKeyHex && address) {
       this.walletInfo = {
@@ -93,22 +123,45 @@ export class OneKeyProvider implements IBTCProvider {
   // OneKey populates `$walletInfo` asynchronously on injection; if it isn't
   // ready yet, call OneKey's own `$private.getConnectWalletInfo()` — the same
   // method ProviderPrivate runs on injection — which repopulates `$walletInfo`.
+  // The refresh is bounded so a stalled extension can't hang connect; a read
+  // failure surfaces as CONNECTION_FAILED (retryable), not a version verdict.
   // Returns `unknown`: external data validated by `checkOneKeyVersion`.
-  private getAppVersion = async (): Promise<unknown> => {
-    if (typeof this.hub?.$walletInfo?.version !== "string") {
-      try {
-        await this.hub?.$private?.getConnectWalletInfo?.();
-      } catch {
-        // Ignore — a missing version is handled as "unparseable" downstream.
-      }
+  private readAppVersion = async (): Promise<unknown> => {
+    if (typeof this.hub?.$walletInfo?.version === "string") {
+      return this.hub.$walletInfo.version;
     }
+
+    try {
+      await withTimeout(
+        Promise.resolve(this.hub?.$private?.getConnectWalletInfo?.()),
+        ONEKEY_RPC_TIMEOUT_MS,
+        () => this.timeoutError("reading its version"),
+      );
+    } catch (error) {
+      if (error instanceof WalletError) throw error;
+      throw new WalletError({
+        code: ERROR_CODES.CONNECTION_FAILED,
+        message: (error as Error)?.message || "Failed to read OneKey Wallet version",
+        wallet: WALLET_PROVIDER_NAME,
+      });
+    }
+
     return this.hub?.$walletInfo?.version;
   };
 
+  // Gates connect on OneKey >= MIN_ONEKEY_VERSION (the floor for
+  // deriveContextHash). Runs once per provider instance; INCOMPATIBLE_WALLET_VERSION
+  // surfaces as the "update wallet" prompt in the connect dialog.
   private ensureSupportedVersion = async (): Promise<void> => {
-    const raw = await this.getAppVersion();
+    if (this.versionChecked) return;
+
+    const raw = await this.readAppVersion();
     const result = checkOneKeyVersion(raw);
-    if (result === "ok") return;
+
+    if (result === "ok") {
+      this.versionChecked = true;
+      return;
+    }
 
     if (result === "below") {
       throw new WalletError({
@@ -119,8 +172,8 @@ export class OneKeyProvider implements IBTCProvider {
       });
     }
 
-    // Missing/non-canonical version ($walletInfo cache not ready, or a fork
-    // build): fail closed without claiming "out of date".
+    // Read succeeded but value is missing/non-canonical (fork build): fail
+    // closed without claiming "out of date".
     throw new WalletError({
       code: ERROR_CODES.INCOMPATIBLE_WALLET_VERSION,
       message: `Unable to verify your OneKey Wallet version${

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/onekey/version.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/onekey/version.ts
@@ -1,0 +1,36 @@
+// 6.3.0 is the first OneKey app/extension release that ships
+// `deriveContextHash` (spec-conformant from the start), so it is the floor
+// for vault deposits. Source: OneKeyHQ/app-monorepo PR #11568 (merge commit
+// ffd9d1f0e0183685b4f5c29d4fa27d6462e1766d), first contained in tag v6.3.0;
+// the value matches `.env.version` at that tag. The version is read at runtime
+// from `window.$onekey.$walletInfo.version` (populated from
+// `wallet_getConnectWalletInfo` -> process.env.VERSION) — NOT from
+// `btcwallet.getVersion()` (hardcoded "1.4.10") or `btcwallet.version` (the
+// inpage-provider package version "2.2.69"), neither of which is the app version.
+export const MIN_ONEKEY_VERSION = "6.3.0";
+
+const MIN_ONEKEY_PARTS = MIN_ONEKEY_VERSION.split(".").map(Number) as [number, number, number];
+
+// Strict canonical semver — reject `v6.3.0`, `6.3.0-beta`, `dev`, leading
+// zeros (`06.3.0`, `6.03.0`), and any non-canonical format. The numeric
+// comparison below cannot be defeated by string collation quirks (e.g.
+// `localeCompare` ranks `"dev" > "1"`).
+const SEMVER_RE = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+
+export type OneKeyVersionCheck = "ok" | "below" | "unparseable";
+
+/**
+ * Compares a raw `$walletInfo.version` value against {@link MIN_ONEKEY_VERSION}.
+ * Returns `"unparseable"` for non-string input or any string that is not
+ * strict canonical `MAJOR.MINOR.PATCH` — fail-closed for fork/canary builds
+ * or a `$walletInfo` cache that has not populated yet.
+ */
+export function checkOneKeyVersion(raw: unknown): OneKeyVersionCheck {
+  const match = typeof raw === "string" ? SEMVER_RE.exec(raw) : null;
+  if (!match) return "unparseable";
+  const cmp =
+    Number(match[1]) - MIN_ONEKEY_PARTS[0] ||
+    Number(match[2]) - MIN_ONEKEY_PARTS[1] ||
+    Number(match[3]) - MIN_ONEKEY_PARTS[2];
+  return cmp >= 0 ? "ok" : "below";
+}

--- a/packages/babylon-wallet-connector/tests/unit/deriveContextHash.test.ts
+++ b/packages/babylon-wallet-connector/tests/unit/deriveContextHash.test.ts
@@ -2,9 +2,10 @@
  * Unit tests for `deriveContextHash` adapter behavior.
  *
  * Tests the shared `unsupportedDeriveContextHash` helper used by every
- * non-supporting BTC adapter (OKX, OneKey, Ledger v1/v2, Keystone,
- * AppKit, Tomo, Injectable fallback) and the injectable wrapper that
- * stubs the method when the underlying wallet doesn't implement it.
+ * non-supporting BTC adapter (OKX, Ledger v1/v2, Keystone, AppKit, Tomo,
+ * Injectable fallback) and the injectable wrapper that stubs the method
+ * when the underlying wallet doesn't implement it. UniSat and OneKey
+ * forward to the wallet's native method instead of using this helper.
  *
  * The provider classes themselves are not imported here — their
  * modules transitively pull in SVG asset imports that the unit-test

--- a/packages/babylon-wallet-connector/tests/unit/onekeyVersion.test.ts
+++ b/packages/babylon-wallet-connector/tests/unit/onekeyVersion.test.ts
@@ -1,0 +1,85 @@
+import { expect, test } from "@playwright/test";
+
+import { checkOneKeyVersion } from "../../src/core/wallets/btc/onekey/version";
+
+test.describe("checkOneKeyVersion — OneKey app version gate (MIN = 6.3.0)", () => {
+  test("returns 'ok' for the exact minimum '6.3.0'", () => {
+    expect(checkOneKeyVersion("6.3.0")).toBe("ok");
+  });
+
+  test("returns 'ok' for a higher patch '6.3.1'", () => {
+    expect(checkOneKeyVersion("6.3.1")).toBe("ok");
+  });
+
+  test("returns 'ok' for a higher minor '6.4.0'", () => {
+    expect(checkOneKeyVersion("6.4.0")).toBe("ok");
+  });
+
+  test("returns 'ok' for a higher major '7.0.0'", () => {
+    expect(checkOneKeyVersion("7.0.0")).toBe("ok");
+  });
+
+  test("returns 'ok' for '6.10.0' — numeric comparison, not string collation", () => {
+    expect(checkOneKeyVersion("6.10.0")).toBe("ok");
+  });
+
+  test("returns 'below' for the previous patch '6.2.99'", () => {
+    expect(checkOneKeyVersion("6.2.99")).toBe("below");
+  });
+
+  test("returns 'below' for an older minor '6.2.0'", () => {
+    expect(checkOneKeyVersion("6.2.0")).toBe("below");
+  });
+
+  test("returns 'below' for an older major '5.99.99'", () => {
+    expect(checkOneKeyVersion("5.99.99")).toBe("below");
+  });
+
+  // Non-canonical strings must NOT slip through as 'ok' or 'below' — those
+  // branches imply we successfully parsed a real version number. A
+  // `$walletInfo` cache that has not populated (undefined) or a fork build
+  // gets a distinct "unable to verify" prompt downstream.
+  test("returns 'unparseable' for a v-prefixed version 'v6.3.0'", () => {
+    expect(checkOneKeyVersion("v6.3.0")).toBe("unparseable");
+  });
+
+  test("returns 'unparseable' for a prerelease suffix '6.3.0-beta'", () => {
+    expect(checkOneKeyVersion("6.3.0-beta")).toBe("unparseable");
+  });
+
+  test("returns 'unparseable' for a build-metadata suffix '6.3.0+abc'", () => {
+    expect(checkOneKeyVersion("6.3.0+abc")).toBe("unparseable");
+  });
+
+  test("returns 'unparseable' for a four-part version '6.3.0.123'", () => {
+    expect(checkOneKeyVersion("6.3.0.123")).toBe("unparseable");
+  });
+
+  test("returns 'unparseable' for a non-numeric tag 'dev'", () => {
+    expect(checkOneKeyVersion("dev")).toBe("unparseable");
+  });
+
+  test("returns 'unparseable' for a two-part string '6.3'", () => {
+    expect(checkOneKeyVersion("6.3")).toBe("unparseable");
+  });
+
+  test("returns 'unparseable' for the empty string", () => {
+    expect(checkOneKeyVersion("")).toBe("unparseable");
+  });
+
+  test("returns 'unparseable' for undefined ($walletInfo not populated yet)", () => {
+    expect(checkOneKeyVersion(undefined)).toBe("unparseable");
+  });
+
+  test("returns 'unparseable' for a non-string value (number)", () => {
+    expect(checkOneKeyVersion(6.3)).toBe("unparseable");
+  });
+
+  test("returns 'unparseable' for a leading-zero major '06.3.0'", () => {
+    expect(checkOneKeyVersion("06.3.0")).toBe("unparseable");
+  });
+
+  test("returns 'unparseable' for a leading-zero minor '6.03.0'", () => {
+    expect(checkOneKeyVersion("6.03.0")).toBe("unparseable");
+  });
+});

--- a/services/vault/src/context/wallet/VaultWalletConnectionProvider.tsx
+++ b/services/vault/src/context/wallet/VaultWalletConnectionProvider.tsx
@@ -21,8 +21,8 @@ import { getNetworkConfigETH } from "@/config/network";
 import { logger } from "@/infrastructure";
 
 // Vault deposits require the connected BTC wallet to implement the
-// `deriveContextHash` API (see docs/specs/derive-context-hash.md). Only
-// UniSat exposes a conformant implementation today, so every other BTC
+// `deriveContextHash` API (see docs/specs/derive-context-hash.md). UniSat
+// and OneKey expose a conformant implementation today, so every other BTC
 // adapter is gated off here. Re-enable an entry as soon as its wallet
 // vendor ships `deriveContextHash`. Each non-conforming adapter still
 // throws `WALLET_METHOD_NOT_SUPPORTED` at the connector layer; this
@@ -35,7 +35,6 @@ const DISABLED_WALLETS: string[] = [
   "ledger_btc",
   "ledger_btc_v2",
   "okx",
-  "onekey",
 ];
 
 const context = typeof window !== "undefined" ? window : {};


### PR DESCRIPTION
OneKey shipped our deriveContextHash spec in 6.3.0, but our adapter still
hard-threw WALLET_METHOD_NOT_SUPPORTED and OneKey was hidden from the
connect UI. Forward to the native method, re-enable OneKey in the vault
allowlist, and gate connect on >= 6.3.0 so older builds prompt to update.