### PR TITLE
feat(vault): surface BTC Vault explorer links across the dashboard

### DIFF
--- a/services/vault/.env.example
+++ b/services/vault/.env.example
@@ -19,10 +19,10 @@ NEXT_PUBLIC_TBV_GRAPHQL_ENDPOINT=https://babylon-vault-indexer-api.vault-devnet.
 NEXT_PUBLIC_TBV_VP_PROXY_URL=https://vault-provider-proxy-api.vault-devnet.babylonlabs.io
 
 # Babylon BTC Vault block explorer (optional)
-# Base URL for the explorer page that hosts /provider/<address>, /tx/<hash>, etc.
+# Base URL for the explorer; hosts /provider/<addr>, /vault/<id>, /depositor/<addr>.
 # The vault provider picker links each VP row to <base>/provider/<vp-address>.
 # Defaults to the public testnet host; override for mainnet builds.
-# NEXT_PUBLIC_TBV_VP_EXPLORER_URL=https://babylon-btcvault-testnet.explorer.xangle.io
+NEXT_PUBLIC_TBV_VP_EXPLORER_URL=https://babylon-btcvault-testnet.explorer.xangle.io
 
 # Ordinals API (optional)
 # Used as fallback for inscription detection when wallet doesn't support getInscriptions().

--- a/services/vault/src/components/shared/ExplorerLink.tsx
+++ b/services/vault/src/components/shared/ExplorerLink.tsx
@@ -1,0 +1,41 @@
+import { IoOpenOutline } from "react-icons/io5";
+
+interface ExplorerLinkProps {
+  /**
+   * Target URL, typically from a `getVpExplorer*Url` builder. When `undefined`
+   * (explorer base unset or no id) the component renders nothing — so callers
+   * can pass the builder result straight through without their own guard.
+   */
+  href?: string;
+  /** Accessible name + tooltip (e.g. "View vault on explorer"). */
+  label: string;
+  /** Icon size in px. */
+  size?: number;
+  className?: string;
+}
+
+/**
+ * Icon-only external link to the Babylon BTC Vault explorer. Opens in a new tab
+ * with `rel="noopener noreferrer"`. Renders nothing without an `href`.
+ */
+export function ExplorerLink({
+  href,
+  label,
+  size = 16,
+  className = "text-accent-secondary transition-colors hover:text-accent-primary",
+}: ExplorerLinkProps) {
+  if (!href) return null;
+
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label={label}
+      title={label}
+      className={className}
+    >
+      <IoOpenOutline size={size} />
+    </a>
+  );
+}

--- a/services/vault/src/components/shared/__tests__/ExplorerLink.test.tsx
+++ b/services/vault/src/components/shared/__tests__/ExplorerLink.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ExplorerLink } from "../ExplorerLink";
+
+describe("ExplorerLink", () => {
+  it("renders an external link to href with the label as its accessible name", () => {
+    render(
+      <ExplorerLink
+        href="https://explorer.test/vault/0xabc"
+        label="View vault on explorer"
+      />,
+    );
+
+    const link = screen.getByRole("link", { name: "View vault on explorer" });
+    expect(link).toHaveAttribute("href", "https://explorer.test/vault/0xabc");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("renders nothing when href is undefined (no link when explorer is unconfigured)", () => {
+    const { container } = render(
+      <ExplorerLink label="View vault on explorer" />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+});

--- a/services/vault/src/components/shared/index.ts
+++ b/services/vault/src/components/shared/index.ts
@@ -3,6 +3,7 @@ export { DepositButton } from "./DepositButton";
 export { DetailsCard, type DetailRow } from "./DetailsCard";
 export { EmptyState } from "./EmptyState";
 export { ExpandMenuButton } from "./ExpandMenuButton";
+export { ExplorerLink } from "./ExplorerLink";
 export { HealthFactorGauge } from "./HealthFactorGauge";
 export { HeartIcon } from "./icons";
 export { SubmitModal } from "./SubmitModal";

--- a/services/vault/src/components/simple/CollateralVaultItem.tsx
+++ b/services/vault/src/components/simple/CollateralVaultItem.tsx
@@ -11,9 +11,14 @@ import {
   StatusBadge,
 } from "@babylonlabs-io/core-ui";
 
+import { ExplorerLink } from "@/components/shared";
 import { getNetworkConfigBTC } from "@/config";
 import { COPY } from "@/copy";
 import { truncateAddress } from "@/utils/addressUtils";
+import {
+  getVpExplorerProviderUrl,
+  getVpExplorerVaultUrl,
+} from "@/utils/explorer";
 import { formatBtcAmount, formatOrdinal } from "@/utils/formatting";
 
 import { PeginTxHashRow } from "./PeginTxHashRow";
@@ -73,6 +78,10 @@ export function CollateralVaultItem({
           <span className="text-xl font-medium text-accent-primary">
             {formatBtcAmount(amountBtc)}
           </span>
+          <ExplorerLink
+            href={getVpExplorerVaultUrl(vaultId)}
+            label={COPY.explorer.vaultLinkLabel}
+          />
         </div>
         <div onClick={(e: React.MouseEvent) => e.stopPropagation()}>
           <Checkbox
@@ -95,19 +104,26 @@ export function CollateralVaultItem({
 
       {/* Vault Provider row */}
       <VaultCardRow label="Vault provider">
-        <Hint
-          tooltip={truncateAddress(providerAddress)}
-          attachToChildren
-          placement="left"
-          className="text-sm text-accent-primary"
-        >
-          <span className="inline-flex items-center gap-1.5">
-            {providerIconUrl && (
-              <Avatar url={providerIconUrl} alt={providerName} size="tiny" />
-            )}
-            {providerName}
-          </span>
-        </Hint>
+        <span className="inline-flex items-center gap-1.5">
+          <Hint
+            tooltip={truncateAddress(providerAddress)}
+            attachToChildren
+            placement="left"
+            className="text-sm text-accent-primary"
+          >
+            <span className="inline-flex items-center gap-1.5">
+              {providerIconUrl && (
+                <Avatar url={providerIconUrl} alt={providerName} size="tiny" />
+              )}
+              {providerName}
+            </span>
+          </Hint>
+          <ExplorerLink
+            href={getVpExplorerProviderUrl(providerAddress)}
+            label={COPY.explorer.providerLinkLabel}
+            size={14}
+          />
+        </span>
       </VaultCardRow>
 
       {/* Status row */}

--- a/services/vault/src/components/simple/PendingDepositCard.tsx
+++ b/services/vault/src/components/simple/PendingDepositCard.tsx
@@ -26,6 +26,7 @@ import {
 import { getTokenBrandColor } from "@/services/token/tokenService";
 import type { VaultProvider } from "@/types/vaultProvider";
 import { truncateAddress } from "@/utils/addressUtils";
+import { getVpExplorerProviderUrl } from "@/utils/explorer";
 
 import { computeRemainingEstimateMinutes } from "./DepositProgressView/btcConfirmationProgress";
 import { ProgressBar } from "./DepositProgressView/ProgressBar";
@@ -137,6 +138,7 @@ export function PendingDepositCard({
       providerName={providerName}
       providerIconUrl={provider?.iconUrl}
       providerAddress={providerId}
+      providerExplorerUrl={getVpExplorerProviderUrl(providerId)}
       disabled={status.type === "disabled"}
       disabledTooltip={status.type === "disabled" ? status.tooltip : undefined}
       headerEnd={

--- a/services/vault/src/components/simple/PendingWithdrawSection.tsx
+++ b/services/vault/src/components/simple/PendingWithdrawSection.tsx
@@ -25,6 +25,10 @@ import { COPY } from "@/copy";
 import { useBtcMempoolConfirmations } from "@/hooks/useBtcMempoolConfirmations";
 import type { PegoutPollingResult } from "@/hooks/usePegoutPolling";
 import { ClaimerPegoutStatusValue } from "@/models/pegoutStateMachine";
+import {
+  getVpExplorerProviderUrl,
+  getVpExplorerVaultUrl,
+} from "@/utils/explorer";
 import { formatBtcAmount, formatDuration } from "@/utils/formatting";
 import { payoutEtaMinutes } from "@/utils/pegoutTiming";
 import { canonicalizeTxid } from "@/utils/txid";
@@ -206,6 +210,10 @@ function PendingWithdrawSectionContent({
                   providerName={vault.providerName}
                   providerIconUrl={vault.providerIconUrl}
                   providerAddress={vault.vaultProviderAddress}
+                  vaultExplorerUrl={getVpExplorerVaultUrl(vault.id)}
+                  providerExplorerUrl={getVpExplorerProviderUrl(
+                    vault.vaultProviderAddress,
+                  )}
                   payoutBtcAddress={vault.payoutBtcAddress}
                   statusContent={
                     <VaultStatusBadge

--- a/services/vault/src/components/simple/SupplyCapSection.tsx
+++ b/services/vault/src/components/simple/SupplyCapSection.tsx
@@ -15,6 +15,7 @@ import {
   formatSatoshisToBtcDisplay,
   satoshiToBtcNumber,
 } from "@/utils/btcConversion";
+import { getVpExplorerHomeUrl } from "@/utils/explorer";
 import { formatUsd, getBtcSymbol } from "@/utils/formatting";
 
 interface SupplyCapSectionProps {
@@ -53,6 +54,29 @@ function CapCardSkeleton() {
   );
 }
 
+/**
+ * Callout linking to the BTC Vault explorer. Hidden when the explorer base URL
+ * (NEXT_PUBLIC_TBV_VP_EXPLORER_URL) is not configured.
+ */
+function ExplorerCallout() {
+  const href = getVpExplorerHomeUrl();
+  if (!href) return null;
+  return (
+    <p className="text-sm text-accent-secondary">
+      {COPY.explorer.callout}{" "}
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="font-medium text-secondary-main underline underline-offset-2 transition-opacity hover:opacity-80"
+      >
+        {COPY.explorer.calloutLinkText}
+      </a>
+      .
+    </p>
+  );
+}
+
 function VaultCapFrame({ children }: { children: ReactNode }) {
   return (
     <div className="w-full space-y-4">
@@ -60,6 +84,7 @@ function VaultCapFrame({ children }: { children: ReactNode }) {
         Protocol Cap
       </h2>
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">{children}</div>
+      <ExplorerCallout />
     </div>
   );
 }

--- a/services/vault/src/components/simple/VaultDetailCard.tsx
+++ b/services/vault/src/components/simple/VaultDetailCard.tsx
@@ -8,6 +8,7 @@
 import { Avatar, Hint } from "@babylonlabs-io/core-ui";
 import { useEffect, useState, type ReactNode } from "react";
 
+import { ExplorerLink } from "@/components/shared";
 import { CopyableHash } from "@/components/shared/CopyableHash";
 import { getNetworkConfigBTC } from "@/config";
 import { COPY } from "@/copy";
@@ -66,6 +67,12 @@ interface VaultDetailCardProps {
   providerIconUrl?: string;
   /** Vault provider Ethereum address, shown on hover over the provider label */
   providerAddress: string;
+  /** Pre-built explorer URL for this vault's page. Pass only when the vault is
+   *  active/indexed (else it would 404); `undefined` renders no link. */
+  vaultExplorerUrl?: string;
+  /** Pre-built explorer URL for the vault provider's page; `undefined` renders
+   *  no link. */
+  providerExplorerUrl?: string;
   /** Status content — rendered as the value in the Status row. Omit to hide the
    * row entirely (e.g. when the status badge is rendered in the header). */
   statusContent?: ReactNode;
@@ -101,6 +108,8 @@ export function VaultDetailCard({
   providerName,
   providerIconUrl,
   providerAddress,
+  vaultExplorerUrl,
+  providerExplorerUrl,
   statusContent,
   amountSubtext,
   headerEnd,
@@ -128,9 +137,15 @@ export function VaultDetailCard({
             size="medium"
           />
           <div className="flex flex-col gap-0.5">
-            <span className="text-xl font-medium text-accent-primary">
-              {formatBtcAmount(amountBtc)}
-            </span>
+            <div className="flex items-center gap-2">
+              <span className="text-xl font-medium text-accent-primary">
+                {formatBtcAmount(amountBtc)}
+              </span>
+              <ExplorerLink
+                href={vaultExplorerUrl}
+                label={COPY.explorer.vaultLinkLabel}
+              />
+            </div>
             {amountSubtext}
           </div>
         </div>
@@ -156,24 +171,31 @@ export function VaultDetailCard({
 
       {/* Vault Provider */}
       <VaultCardRow label="Vault provider">
-        <Hint
-          tooltip={truncateAddress(providerAddress)}
-          attachToChildren
-          placement="left"
-          className="text-sm text-accent-primary"
-        >
-          <span className="inline-flex items-center gap-1.5">
-            {providerIconUrl && (
-              <Avatar
-                url={providerIconUrl}
-                alt={providerName}
-                size="small"
-                className="h-4 w-4"
-              />
-            )}
-            {providerName}
-          </span>
-        </Hint>
+        <span className="inline-flex items-center gap-1.5">
+          <Hint
+            tooltip={truncateAddress(providerAddress)}
+            attachToChildren
+            placement="left"
+            className="text-sm text-accent-primary"
+          >
+            <span className="inline-flex items-center gap-1.5">
+              {providerIconUrl && (
+                <Avatar
+                  url={providerIconUrl}
+                  alt={providerName}
+                  size="small"
+                  className="h-4 w-4"
+                />
+              )}
+              {providerName}
+            </span>
+          </Hint>
+          <ExplorerLink
+            href={providerExplorerUrl}
+            label={COPY.explorer.providerLinkLabel}
+            size={14}
+          />
+        </span>
       </VaultCardRow>
 
       {/* Date — hidden when no timestamp is supplied (e.g. cross-device rows). */}

--- a/services/vault/src/components/simple/VaultProviderSelector.tsx
+++ b/services/vault/src/components/simple/VaultProviderSelector.tsx
@@ -4,9 +4,10 @@ import {
   Card,
   Loader,
 } from "@babylonlabs-io/core-ui";
-import { IoChevronUp, IoOpenOutline, IoWarningOutline } from "react-icons/io5";
+import { IoChevronUp, IoWarningOutline } from "react-icons/io5";
 
 import { ApplicationLogo } from "@/components/ApplicationLogo";
+import { ExplorerLink } from "@/components/shared";
 import { COPY } from "@/copy";
 import type { VaultProviderListItem } from "@/types/vaultProvider";
 import {
@@ -195,16 +196,10 @@ export function VaultProviderSelector({
                     </button>
                     {provider.explorerUrl && (
                       <div className="flex shrink-0 items-center gap-2">
-                        <a
+                        <ExplorerLink
                           href={provider.explorerUrl}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          aria-label={FORM_COPY.providerExplorerLinkLabel}
-                          title={FORM_COPY.providerExplorerLinkLabel}
-                          className="text-accent-secondary transition-colors hover:text-accent-primary"
-                        >
-                          <IoOpenOutline size={16} />
-                        </a>
+                          label={FORM_COPY.providerExplorerLinkLabel}
+                        />
                       </div>
                     )}
                   </div>

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -585,6 +585,18 @@ export const COPY = {
         `Add ${symbol} as collateral so you can begin borrowing assets.`,
     },
   },
+  // Links to the Babylon BTC Vault explorer (Xangle). Only rendered when
+  // NEXT_PUBLIC_TBV_VP_EXPLORER_URL is set; icon links use these as the
+  // accessible name + tooltip.
+  explorer: {
+    vaultLinkLabel: "View vault on explorer",
+    providerLinkLabel: "View vault provider on explorer",
+    // Callout under the Protocol Cap section. `calloutLinkText` renders as the
+    // anchor to the explorer home; `callout` is the plain lead-in.
+    callout:
+      "Explore vault activity, liquidity metrics, and protocol statistics in the",
+    calloutLinkText: "BTC Trustless Vault Explorer",
+  },
   withdraw: {
     // Shared labels (review + initiated screens).
     estimatedTimeLabel: "Estimated time until payout",

--- a/services/vault/src/utils/__tests__/explorer.test.ts
+++ b/services/vault/src/utils/__tests__/explorer.test.ts
@@ -21,8 +21,12 @@ vi.mock("@/config", () => ({
 import {
   getBtcExplorerAddressUrl,
   getBtcExplorerTxUrl,
+  getVpExplorerHomeUrl,
   getVpExplorerProviderUrl,
+  getVpExplorerVaultUrl,
 } from "../explorer";
+
+const EXPLORER_BASE = "https://explorer.test.example";
 
 describe("getVpExplorerProviderUrl", () => {
   beforeEach(() => {
@@ -30,11 +34,21 @@ describe("getVpExplorerProviderUrl", () => {
   });
 
   it("builds a /provider/<address> URL against the configured explorer base", () => {
-    envMock.ENV.VP_EXPLORER_URL = "https://explorer.test.example";
+    envMock.ENV.VP_EXPLORER_URL = EXPLORER_BASE;
     const address = "0x1234567890abcdef1234567890abcdef12345678";
 
     expect(getVpExplorerProviderUrl(address)).toBe(
-      `https://explorer.test.example/provider/${address}`,
+      `${EXPLORER_BASE}/provider/${address}`,
+    );
+  });
+
+  it("lowercases a checksummed address (the explorer keys addresses lowercase)", () => {
+    envMock.ENV.VP_EXPLORER_URL = EXPLORER_BASE;
+
+    expect(
+      getVpExplorerProviderUrl("0xAbC1230000000000000000000000000000000DEF"),
+    ).toBe(
+      `${EXPLORER_BASE}/provider/0xabc1230000000000000000000000000000000def`,
     );
   });
 
@@ -44,6 +58,63 @@ describe("getVpExplorerProviderUrl", () => {
     expect(
       getVpExplorerProviderUrl("0x1234567890abcdef1234567890abcdef12345678"),
     ).toBeUndefined();
+  });
+
+  it("returns undefined for an empty address (no broken /provider/ link)", () => {
+    envMock.ENV.VP_EXPLORER_URL = EXPLORER_BASE;
+
+    expect(getVpExplorerProviderUrl("")).toBeUndefined();
+  });
+});
+
+describe("getVpExplorerVaultUrl", () => {
+  beforeEach(() => {
+    envMock.ENV.VP_EXPLORER_URL = undefined;
+  });
+
+  it("builds a /vault/<id> URL against the configured explorer base", () => {
+    envMock.ENV.VP_EXPLORER_URL = EXPLORER_BASE;
+    const vaultId =
+      "0x134a8d1a5ba0673a3ecab0522336fce3585082161af260a2debc09574c26b0d4";
+
+    expect(getVpExplorerVaultUrl(vaultId)).toBe(
+      `${EXPLORER_BASE}/vault/${vaultId}`,
+    );
+  });
+
+  it("lowercases the id (the explorer keys vault ids lowercase)", () => {
+    envMock.ENV.VP_EXPLORER_URL = EXPLORER_BASE;
+
+    expect(getVpExplorerVaultUrl("0xABCDEF")).toBe(
+      `${EXPLORER_BASE}/vault/0xabcdef`,
+    );
+  });
+
+  it("returns undefined when the explorer base URL is not configured", () => {
+    expect(getVpExplorerVaultUrl("0xabc")).toBeUndefined();
+  });
+
+  it("returns undefined for an empty/undefined vault id", () => {
+    envMock.ENV.VP_EXPLORER_URL = EXPLORER_BASE;
+
+    expect(getVpExplorerVaultUrl("")).toBeUndefined();
+    expect(getVpExplorerVaultUrl(undefined)).toBeUndefined();
+  });
+});
+
+describe("getVpExplorerHomeUrl", () => {
+  beforeEach(() => {
+    envMock.ENV.VP_EXPLORER_URL = undefined;
+  });
+
+  it("returns the configured explorer base URL", () => {
+    envMock.ENV.VP_EXPLORER_URL = EXPLORER_BASE;
+
+    expect(getVpExplorerHomeUrl()).toBe(EXPLORER_BASE);
+  });
+
+  it("returns undefined when the explorer base URL is not configured", () => {
+    expect(getVpExplorerHomeUrl()).toBeUndefined();
   });
 });
 

--- a/services/vault/src/utils/explorer.ts
+++ b/services/vault/src/utils/explorer.ts
@@ -8,7 +8,9 @@
  *      on whether that mirror is reachable, so they stay on the public
  *      explorer.
  * ETH: <chain explorer>/tx/<hash>                        (hash with 0x)
- * VP:  <NEXT_PUBLIC_TBV_VP_EXPLORER_URL>/provider/<addr>
+ * VP:  <NEXT_PUBLIC_TBV_VP_EXPLORER_URL>/{provider,vault,depositor}/<id>
+ *      Babylon BTC Vault explorer — vault-state pages only; it has NO
+ *      per-transaction pages, so BTC/ETH tx hashes stay on mempool/etherscan.
  */
 
 import { stripHexPrefix } from "@babylonlabs-io/ts-sdk/tbv/core";
@@ -41,18 +43,47 @@ function getEthExplorerTxUrl(txHash: string): string {
 }
 
 /**
- * Explorer URL for a vault-provider page on the Babylon BTC Vault explorer.
- * Used by the VP picker to link each VP (whose `id` is its registered ETH
- * address) so the depositor can inspect it. The base URL comes from
- * `NEXT_PUBLIC_TBV_VP_EXPLORER_URL` so the explorer host can be swapped
- * per deployment (testnet vs mainnet) without code changes.
+ * Build `<explorer base>/<path>/<value>` on the Babylon BTC Vault explorer, or
+ * `undefined` when the base is unconfigured (`NEXT_PUBLIC_TBV_VP_EXPLORER_URL`
+ * unset) or `value` is empty. Callers MUST treat `undefined` as "no link"
+ * rather than rendering a broken or environment-mismatched URL.
  *
- * Returns `undefined` when the env var is unset — callers MUST treat that
- * as "no link" rather than rendering a broken or environment-mismatched URL.
+ * `value` is lowercased: the explorer keys vault ids and addresses lowercase,
+ * and Ethereum addresses are case-insensitive (EIP-55 is display-only), so a
+ * checksummed address from the wallet would otherwise 404.
  */
-export function getVpExplorerProviderUrl(address: string): string | undefined {
-  if (!ENV.VP_EXPLORER_URL) return undefined;
-  return `${ENV.VP_EXPLORER_URL}/provider/${address}`;
+function buildVpExplorerUrl(
+  path: "provider" | "vault",
+  value: string | undefined,
+): string | undefined {
+  if (!ENV.VP_EXPLORER_URL || !value) return undefined;
+  return `${ENV.VP_EXPLORER_URL}/${path}/${value.toLowerCase()}`;
+}
+
+/**
+ * Provider page — `id` is the VP's registered ETH address. Used by the VP
+ * picker (and the vault card's "secured by") so the depositor can inspect it.
+ */
+export function getVpExplorerProviderUrl(
+  address: string | undefined,
+): string | undefined {
+  return buildVpExplorerUrl("provider", address);
+}
+
+/**
+ * Vault page — `vaultId` is `keccak256(abi.encode(peginTxHash, depositor))`,
+ * the canonical on-chain id the app already holds. Only resolves once the vault
+ * is indexed (active); gate the link on lifecycle state at the call site.
+ */
+export function getVpExplorerVaultUrl(
+  vaultId: string | undefined,
+): string | undefined {
+  return buildVpExplorerUrl("vault", vaultId);
+}
+
+/** Explorer home/landing. `undefined` when the base URL is unconfigured. */
+export function getVpExplorerHomeUrl(): string | undefined {
+  return ENV.VP_EXPLORER_URL || undefined;
 }
 
 export function getExplorerTxUrl(chain: ActivityChain, txHash: string): string {


### PR DESCRIPTION
## Summary

Surfaces the Babylon BTC Vault explorer (Xangle) throughout the dashboard,
where previously it was only linked from the deposit provider picker. Adds a
small set of contextual entry points so depositors can jump to a vault's,
provider's, or the protocol's explorer page.

## Where the links appear
- **Callout** under *Protocol Cap* → explorer home (primary, always-visible entry point).
- **Vault ↗** next to the BTC amount on **active** vault cards — Collateral and Pending Withdraw.
- **Provider ↗** in the "Vault provider" row of every vault card — Collateral, Pending Deposit, Pending Withdraw, Expired — plus the existing provider picker (refactored onto the
shared component).