### PR TITLE
feat(wallet): keystone derive context hash

### DIFF
--- a/packages/babylon-wallet-connector/package.json
+++ b/packages/babylon-wallet-connector/package.json
@@ -51,7 +51,7 @@
     "@keplr-wallet/provider-extension": "0.12.272",
     "@keplr-wallet/types": "0.12.272",
     "@keystonehq/animated-qr": "0.10.0",
-    "@keystonehq/keystone-sdk": "0.9.0",
+    "@keystonehq/keystone-sdk": "0.12.3",
     "@keystonehq/sdk": "0.22.1",
     "@ledgerhq/hw-transport": "6.31.10",
     "@ledgerhq/hw-transport-webhid": "6.30.6",

--- a/packages/babylon-wallet-connector/src/core/types.ts
+++ b/packages/babylon-wallet-connector/src/core/types.ts
@@ -335,6 +335,13 @@ export interface SignPsbtOptions {
    * Use this to restrict signing to specific inputs (e.g., only depositor's input in payout tx).
    */
   signInputs?: SignInputOptions[];
+  /**
+   * Human-readable label for the signing step (e.g. "Transaction 3 of 12").
+   * Honored by wallets that render their own signing UI — Keystone shows it
+   * above the QR code so the user can track progress through a batch. Wallets
+   * that sign in their extension popup ignore it.
+   */
+  displayMessage?: string;
 }
 
 export interface IBTCProvider extends IProvider {

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/keystone/canonicalNetworkName.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/keystone/canonicalNetworkName.ts
@@ -1,0 +1,17 @@
+import { Network } from "@/core/types";
+
+/**
+ * Maps a wallet {@link Network} to the canonical Bitcoin network name
+ * required by the `deriveContextHash` specification (`docs/specs/
+ * derive-context-hash.md` §2.2). The wallet injects
+ * `SHA-256(UTF8(canonicalNetworkName))` into the HKDF `info`, so these
+ * strings are part of the on-chain-binding derivation and must match the
+ * spec table exactly.
+ */
+const CANONICAL_NETWORK_NAME: Record<Network, string> = {
+  [Network.MAINNET]: "bitcoin-mainnet",
+  [Network.TESTNET]: "bitcoin-testnet",
+  [Network.SIGNET]: "bitcoin-signet",
+};
+
+export const canonicalNetworkName = (network: Network): string => CANONICAL_NETWORK_NAME[network];

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/keystone/contextHashOutput.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/keystone/contextHashOutput.ts
@@ -1,0 +1,15 @@
+/**
+ * A `deriveContextHash` result is a 32-byte value, hex-encoded as 64
+ * lowercase characters (`docs/specs/derive-context-hash.md` §2.1).
+ */
+export const CONTEXT_HASH_OUTPUT_HEX_LENGTH = 64;
+
+const LOWERCASE_HEX = /^[0-9a-f]+$/;
+
+/**
+ * Validates a hex-encoded `deriveContextHash` output before it is consumed
+ * as on-chain-binding vault material. Returns true only for a 64-char
+ * lowercase-hex string.
+ */
+export const isValidContextHashOutput = (value: string): boolean =>
+  value.length === CONTEXT_HASH_OUTPUT_HEX_LENGTH && LOWERCASE_HEX.test(value);

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/keystone/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/keystone/provider.ts
@@ -17,6 +17,7 @@ import {
   CONTEXT_HASH_OUTPUT_HEX_LENGTH,
   isValidContextHashOutput,
 } from "@/core/wallets/btc/keystone/contextHashOutput";
+import { findTaprootAccount } from "@/core/wallets/btc/keystone/taprootAccount";
 import { ERROR_CODES, WalletError } from "@/error";
 
 import logo from "./logo.svg";
@@ -65,7 +66,7 @@ export class KeystoneProvider implements IBTCProvider {
         link: "",
         description: [
           "1. Turn on your Keystone 3.",
-          '2. Click connect software wallet and select Bitcoin Wallets.',
+          "2. Click connect software wallet and select Bitcoin Wallets.",
           '3. Press the "Sync Keystone" button and scan the QR Code displayed on your Keystone hardware wallet',
           "4. The first Taproot address will be used for staking.",
         ],
@@ -91,29 +92,40 @@ export class KeystoneProvider implements IBTCProvider {
     // parse the QR Code and get extended public key and other required information
     const accountData = this.dataSdk.parseAccount(decodedResult.result);
 
-    // currently only the p2tr address will be used.
-    const P2TRINDEX = 3;
-    const xpub = accountData.keys[P2TRINDEX].extendedPublicKey;
+    // Select the Taproot (BIP86) account by parsing the derivation path, not a
+    // fixed index — the export order is not guaranteed (observed [84',49',44',86']).
+    //
+    // Note on coin_type vs. app network: Keystone exports whichever coin_type its
+    // active firmware dictates (standard mainnet firmware → 0'); the app only
+    // re-skins the address to `config.network`. On mainnet (0') this matches
+    // software wallets. For signet, the Keystone must run the separate BTC-only
+    // firmware with Signet mode connection enabled (coin_type 1') to derive the
+    // same key as software wallets like UniSat; otherwise the keys differ even
+    // for the same seed. This is intentionally not hard-enforced here (signet is
+    // dev-only).
+    const taprootAccount = findTaprootAccount(accountData.keys);
+
+    if (!taprootAccount?.extendedPublicKey)
+      throw new WalletError({
+        code: ERROR_CODES.EXTENSION_NOT_FOUND,
+        message: "Could not retrieve the Taproot extended public key",
+        wallet: WALLET_PROVIDER_NAME,
+      });
+
+    const xpub = taprootAccount.extendedPublicKey;
 
     this.keystoneWalletInfo = {
       mfp: accountData.masterFingerprint,
       extendedPublicKey: xpub,
-      path: accountData.keys[P2TRINDEX].path,
+      path: taprootAccount.path,
       address: undefined,
       publicKeyHex: undefined,
       scriptPubKeyHex: undefined,
     };
 
-    if (!this.keystoneWalletInfo.extendedPublicKey)
-      throw new WalletError({
-        code: ERROR_CODES.EXTENSION_NOT_FOUND,
-        message: "Could not retrieve the extended public key",
-        wallet: WALLET_PROVIDER_NAME,
-      });
-
     // generate the address and public key based on the xpub
     const { address, publicKeyHex, scriptPubKeyHex } = generateP2TRAddressFromXpub(
-      this.keystoneWalletInfo.extendedPublicKey,
+      xpub,
       "M/0/0",
       toNetwork(this.config.network),
     );

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/keystone/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/keystone/provider.ts
@@ -17,6 +17,7 @@ import {
   CONTEXT_HASH_OUTPUT_HEX_LENGTH,
   isValidContextHashOutput,
 } from "@/core/wallets/btc/keystone/contextHashOutput";
+import { signingProgressLabel } from "@/core/wallets/btc/keystone/signingProgress";
 import { findTaprootAccount } from "@/core/wallets/btc/keystone/taprootAccount";
 import { ERROR_CODES, WalletError } from "@/error";
 
@@ -201,7 +202,13 @@ export class KeystoneProvider implements IBTCProvider {
 
     const result = [];
     for (let index = 0; index < psbtsHexes.length; index++) {
-      const signedHex = await this.signPsbt(psbtsHexes[index], options?.[index]);
+      const itemOptions = options?.[index];
+      // Keystone signs one PSBT per QR scan, so surface batch progress above the
+      // QR (e.g. "Transaction 3 of 12") unless the caller supplied its own label.
+      const signedHex = await this.signPsbt(psbtsHexes[index], {
+        ...itemOptions,
+        displayMessage: itemOptions?.displayMessage ?? signingProgressLabel(index, psbtsHexes.length),
+      });
       result.push(signedHex);
     }
     return result;
@@ -320,7 +327,7 @@ export class KeystoneProvider implements IBTCProvider {
     const ur = this.dataSdk.btc.generatePSBT(Buffer.from(psbtHex, "hex"));
 
     // compose the signing process for the Keystone device
-    const signPsbt = composeQRProcess(SupportedResult.UR_PSBT);
+    const signPsbt = composeQRProcess(SupportedResult.UR_PSBT, options?.displayMessage);
 
     const keystoneContainer = await this.viewSDK.getSdk();
     const signePsbtUR = await signPsbt(keystoneContainer, ur);
@@ -436,14 +443,18 @@ export class KeystoneProvider implements IBTCProvider {
  * High order function to compose the QR generation and scanning process for specific data types.
  * Composes the QR code process for the Keystone device.
  * @param destinationDataType - The type of data to be read from the QR code.
+ * @param titleEnhance - Optional context appended to the modal titles (e.g.
+ *   "Transaction 3 of 12") so the user can track progress through a batch.
  * @returns A function that plays the UR in the QR code and reads the result.
  */
 const composeQRProcess =
-  (destinationDataType: SupportedResult) =>
+  (destinationDataType: SupportedResult, titleEnhance?: string) =>
   async (container: SDK, ur: UR): Promise<UR> => {
+    const suffix = titleEnhance ? ` · ${titleEnhance}` : "";
+
     // make the container play the UR in the QR code
     const status: PlayStatus = await container.play(ur, {
-      title: "Scan the QR Code",
+      title: `Scan the QR Code${suffix}`,
       description: "Please scan the QR code with your Keystone device.",
     });
 
@@ -456,7 +467,7 @@ const composeQRProcess =
       });
 
     const urResult = await container.read([destinationDataType], {
-      title: "Get the Signature from Keystone",
+      title: `Get the Signature from Keystone${suffix}`,
       description: "Please scan the QR code displayed on your Keystone",
       URTypeErrorMessage: "The scanned QR code can't be read. please verify and try again.",
     });

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/keystone/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/keystone/provider.ts
@@ -405,9 +405,6 @@ export class KeystoneProvider implements IBTCProvider {
     // `${path}/0/0` that this provider uses for address generation, PSBT
     // signing, and message signing. That leaf key is the `connectedPubkey` the
     // spec injects into the HKDF `info` (docs/specs/derive-context-hash.md §2.2).
-    // If the on-device firmware test (the §4.2 vector) fails, the firmware
-    // likely expects the account-level path instead — drop the `/0/0` suffix
-    // and use `this.keystoneWalletInfo.path`, then retest.
     const keyPath = `${this.keystoneWalletInfo.path}/0/0`;
 
     const ur = this.dataSdk.generateDeriveContextHashCall({

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/keystone/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/keystone/provider.ts
@@ -12,7 +12,11 @@ import type { BTCConfig, InscriptionIdentifier, SignPsbtOptions } from "@/core/t
 import { IBTCProvider, Network } from "@/core/types";
 import BIP322 from "@/core/utils/bip322";
 import { generateP2TRAddressFromXpub, toNetwork } from "@/core/utils/wallet";
-import { unsupportedDeriveContextHash } from "@/core/wallets/btc/unsupportedDeriveContextHash";
+import { canonicalNetworkName } from "@/core/wallets/btc/keystone/canonicalNetworkName";
+import {
+  CONTEXT_HASH_OUTPUT_HEX_LENGTH,
+  isValidContextHashOutput,
+} from "@/core/wallets/btc/keystone/contextHashOutput";
 import { ERROR_CODES, WalletError } from "@/error";
 
 import logo from "./logo.svg";
@@ -60,8 +64,8 @@ export class KeystoneProvider implements IBTCProvider {
         walletMode: "btc",
         link: "",
         description: [
-          "1. Turn on your Keystone 3 with BTC only firmware.",
-          '2. Click connect software wallet and use "Sparrow" for connection.',
+          "1. Turn on your Keystone 3.",
+          '2. Click connect software wallet and select Bitcoin Wallets.',
           '3. Press the "Sync Keystone" button and scan the QR Code displayed on your Keystone hardware wallet',
           "4. The first Taproot address will be used for staking.",
         ],
@@ -369,7 +373,51 @@ export class KeystoneProvider implements IBTCProvider {
     return psbt;
   };
 
-  deriveContextHash = unsupportedDeriveContextHash(WALLET_PROVIDER_NAME);
+  deriveContextHash = async (appName: string, context: string): Promise<string> => {
+    if (!this.keystoneWalletInfo?.path) {
+      throw new WalletError({
+        code: ERROR_CODES.WALLET_NOT_CONNECTED,
+        message: "Keystone Wallet not connected",
+        wallet: WALLET_PROVIDER_NAME,
+      });
+    }
+
+    // Bind the derivation to the exact connected key — the first Taproot leaf
+    // `${path}/0/0` that this provider uses for address generation, PSBT
+    // signing, and message signing. That leaf key is the `connectedPubkey` the
+    // spec injects into the HKDF `info` (docs/specs/derive-context-hash.md §2.2).
+    // If the on-device firmware test (the §4.2 vector) fails, the firmware
+    // likely expects the account-level path instead — drop the `/0/0` suffix
+    // and use `this.keystoneWalletInfo.path`, then retest.
+    const keyPath = `${this.keystoneWalletInfo.path}/0/0`;
+
+    const ur = this.dataSdk.generateDeriveContextHashCall({
+      appName,
+      network: canonicalNetworkName(this.config.network),
+      keyPath,
+      context,
+      origin: "babylon staking app",
+    });
+
+    const getContextHash = composeQRProcess(SupportedResult.UR_BYTES);
+    const keystoneContainer = await this.viewSDK.getSdk();
+    const contextHashUR = await getContextHash(keystoneContainer, ur);
+    const contextHash = this.dataSdk.parseURBytes(contextHashUR).toString("hex");
+
+    // Defense in depth (critical path): this output feeds on-chain vault
+    // commitments via deriveVaultRoot. Assert the device returned a 32-byte
+    // value before handing it on, so a malformed firmware response fails loud
+    // here rather than corrupting a deposit.
+    if (!isValidContextHashOutput(contextHash)) {
+      throw new WalletError({
+        code: ERROR_CODES.SIGNATURE_EXTRACT_ERROR,
+        message: `Keystone returned an invalid deriveContextHash output; expected ${CONTEXT_HASH_OUTPUT_HEX_LENGTH} lowercase hex characters`,
+        wallet: WALLET_PROVIDER_NAME,
+      });
+    }
+
+    return contextHash;
+  };
 }
 
 /**

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/keystone/signingProgress.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/keystone/signingProgress.ts
@@ -1,0 +1,10 @@
+/**
+ * Human-readable progress label shown above the Keystone QR while signing a
+ * batch of PSBTs, so the user can track how far through they are (Keystone signs
+ * one PSBT per QR scan, so a 10+ PSBT payout flow is otherwise opaque).
+ *
+ * @param index - zero-based position of the PSBT in the batch
+ * @param total - total number of PSBTs in the batch
+ */
+export const signingProgressLabel = (index: number, total: number): string =>
+  `Transaction ${index + 1} of ${total}`;

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/keystone/taprootAccount.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/keystone/taprootAccount.ts
@@ -1,0 +1,15 @@
+/** BIP86 Taproot purpose (the first hardened component of `m/86'/…`). */
+const TAPROOT_PURPOSE = 86;
+
+const purposeOf = (path: string): number => parseInt(path.split("/")[1], 10);
+
+/**
+ * Finds the Taproot (BIP86, purpose `86'`) account in a parsed Keystone export.
+ *
+ * Selected by parsing the derivation path rather than a fixed index: the
+ * Keystone export order is not guaranteed (e.g. `[84', 49', 44', 86']`), so a
+ * hardcoded position is unreliable. `parseInt` tolerates either hardened marker
+ * (`86'` or `86h`).
+ */
+export const findTaprootAccount = <T extends { path: string }>(keys: T[]): T | undefined =>
+  keys.find((key) => purposeOf(key.path) === TAPROOT_PURPOSE);

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/keystone/taprootAccount.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/keystone/taprootAccount.ts
@@ -1,15 +1,28 @@
 /** BIP86 Taproot purpose (the first hardened component of `m/86'/…`). */
 const TAPROOT_PURPOSE = 86;
 
-const purposeOf = (path: string): number => parseInt(path.split("/")[1], 10);
+/**
+ * Rewrites the `h` hardened marker to the apostrophe form (`86h` → `86'`).
+ *
+ * The Keystone SDK's `pathToKeypath` only marks a component hardened when it
+ * ends with `'`; an `h`-suffixed component would be silently encoded as
+ * non-hardened (`m/86h/0h/0h` → `m/86/0/0`), making the device derive a
+ * different key. Normalizing here keeps the stored path canonical for every
+ * consumer (deriveContextHash and PSBT/message signing all read it).
+ */
+const normalizeHardenedPath = (path: string): string => path.replace(/h(?=\/|$)/g, "'");
+
+const purposeOf = (path: string): number => parseInt(normalizeHardenedPath(path).split("/")[1], 10);
 
 /**
- * Finds the Taproot (BIP86, purpose `86'`) account in a parsed Keystone export.
+ * Finds the Taproot (BIP86, purpose `86'`) account in a parsed Keystone export
+ * and returns it with its `path` normalized to the apostrophe hardened form.
  *
  * Selected by parsing the derivation path rather than a fixed index: the
  * Keystone export order is not guaranteed (e.g. `[84', 49', 44', 86']`), so a
- * hardcoded position is unreliable. `parseInt` tolerates either hardened marker
- * (`86'` or `86h`).
+ * hardcoded position is unreliable.
  */
-export const findTaprootAccount = <T extends { path: string }>(keys: T[]): T | undefined =>
-  keys.find((key) => purposeOf(key.path) === TAPROOT_PURPOSE);
+export const findTaprootAccount = <T extends { path: string }>(keys: T[]): T | undefined => {
+  const account = keys.find((key) => purposeOf(key.path) === TAPROOT_PURPOSE);
+  return account ? { ...account, path: normalizeHardenedPath(account.path) } : undefined;
+};

--- a/packages/babylon-wallet-connector/tests/unit/deriveContextHash.test.ts
+++ b/packages/babylon-wallet-connector/tests/unit/deriveContextHash.test.ts
@@ -2,10 +2,10 @@
  * Unit tests for `deriveContextHash` adapter behavior.
  *
  * Tests the shared `unsupportedDeriveContextHash` helper used by every
- * non-supporting BTC adapter (OKX, Ledger v1/v2, Keystone, AppKit, Tomo,
+ * non-supporting BTC adapter (OKX, Ledger v1/v2, AppKit, Tomo,
  * Injectable fallback) and the injectable wrapper that stubs the method
- * when the underlying wallet doesn't implement it. UniSat and OneKey
- * forward to the wallet's native method instead of using this helper.
+ * when the underlying wallet doesn't implement it. UniSat, OneKey, and
+ * Keystone implement the method natively instead of using this helper.
  *
  * The provider classes themselves are not imported here — their
  * modules transitively pull in SVG asset imports that the unit-test

--- a/packages/babylon-wallet-connector/tests/unit/keystoneDeriveContextHash.test.ts
+++ b/packages/babylon-wallet-connector/tests/unit/keystoneDeriveContextHash.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Unit tests for the pure helpers behind Keystone's `deriveContextHash`
+ * implementation. The provider class itself is not imported here — its
+ * module pulls in an SVG asset the unit-test runner can't resolve — so the
+ * QR round-trip is exercised by the on-device manual test, while the
+ * network mapping and output validation (the parts that gate on-chain vault
+ * material) are pinned here.
+ */
+import { expect, test } from "@playwright/test";
+
+import { Network } from "../../src/core/types";
+import { canonicalNetworkName } from "../../src/core/wallets/btc/keystone/canonicalNetworkName";
+import { isValidContextHashOutput } from "../../src/core/wallets/btc/keystone/contextHashOutput";
+
+test.describe("canonicalNetworkName — Keystone network → spec canonical name", () => {
+  test("maps MAINNET to 'bitcoin-mainnet'", () => {
+    expect(canonicalNetworkName(Network.MAINNET)).toBe("bitcoin-mainnet");
+  });
+
+  test("maps TESTNET to 'bitcoin-testnet'", () => {
+    expect(canonicalNetworkName(Network.TESTNET)).toBe("bitcoin-testnet");
+  });
+
+  test("maps SIGNET to 'bitcoin-signet'", () => {
+    expect(canonicalNetworkName(Network.SIGNET)).toBe("bitcoin-signet");
+  });
+});
+
+test.describe("isValidContextHashOutput — deriveContextHash output validation", () => {
+  test("accepts a 64-char lowercase hex string", () => {
+    expect(isValidContextHashOutput("a".repeat(64))).toBe(true);
+    expect(isValidContextHashOutput("0123456789abcdef".repeat(4))).toBe(true);
+  });
+
+  test("rejects an output shorter than 64 characters", () => {
+    expect(isValidContextHashOutput("ab".repeat(31))).toBe(false);
+  });
+
+  test("rejects an output longer than 64 characters", () => {
+    expect(isValidContextHashOutput("a".repeat(66))).toBe(false);
+  });
+
+  test("rejects uppercase hex (spec requires lowercase)", () => {
+    expect(isValidContextHashOutput("A".repeat(64))).toBe(false);
+  });
+
+  test("rejects non-hex characters", () => {
+    expect(isValidContextHashOutput("g".repeat(64))).toBe(false);
+  });
+
+  test("rejects an empty string", () => {
+    expect(isValidContextHashOutput("")).toBe(false);
+  });
+});

--- a/packages/babylon-wallet-connector/tests/unit/keystoneSigningProgress.test.ts
+++ b/packages/babylon-wallet-connector/tests/unit/keystoneSigningProgress.test.ts
@@ -1,0 +1,17 @@
+/**
+ * Unit tests for the Keystone batch-signing progress label shown above the QR.
+ */
+import { expect, test } from "@playwright/test";
+
+import { signingProgressLabel } from "../../src/core/wallets/btc/keystone/signingProgress";
+
+test.describe("signingProgressLabel — batch progress shown in the Keystone QR modal", () => {
+  test("renders a 1-based position out of the total", () => {
+    expect(signingProgressLabel(0, 12)).toBe("Transaction 1 of 12");
+    expect(signingProgressLabel(11, 12)).toBe("Transaction 12 of 12");
+  });
+
+  test("handles a single-PSBT batch", () => {
+    expect(signingProgressLabel(0, 1)).toBe("Transaction 1 of 1");
+  });
+});

--- a/packages/babylon-wallet-connector/tests/unit/keystoneTaprootAccount.test.ts
+++ b/packages/babylon-wallet-connector/tests/unit/keystoneTaprootAccount.test.ts
@@ -31,9 +31,11 @@ test.describe("findTaprootAccount — selects the BIP86 account by path", () => 
     expect(findTaprootAccount(keys)?.path).toBe("m/86'/1'/0'");
   });
 
-  test("tolerates the 'h' hardened marker", () => {
+  test("matches the 'h' hardened marker and normalizes the returned path to apostrophes", () => {
+    // The Keystone SDK only treats a component as hardened when it ends with "'",
+    // so the selected path must be normalized before it is handed to the device.
     const keys = [{ path: "m/84h/0h/0h" }, { path: "m/86h/0h/0h" }];
-    expect(findTaprootAccount(keys)?.path).toBe("m/86h/0h/0h");
+    expect(findTaprootAccount(keys)?.path).toBe("m/86'/0'/0'");
   });
 
   test("returns undefined when no Taproot account is present", () => {

--- a/packages/babylon-wallet-connector/tests/unit/keystoneTaprootAccount.test.ts
+++ b/packages/babylon-wallet-connector/tests/unit/keystoneTaprootAccount.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Unit tests for Keystone Taproot account selection. The provider class is not
+ * imported here (its module pulls in an SVG asset the unit-test runner can't
+ * resolve), so the pure path-parsing selection is pinned directly.
+ */
+import { expect, test } from "@playwright/test";
+
+import { findTaprootAccount } from "../../src/core/wallets/btc/keystone/taprootAccount";
+
+// Mirrors the observed Keystone export order [84', 49', 44', 86'] — Taproot last,
+// proving selection must not rely on a fixed index.
+const KEYSTONE_EXPORT_ORDER = [
+  { path: "m/84'/0'/0'" },
+  { path: "m/49'/0'/0'" },
+  { path: "m/44'/0'/0'" },
+  { path: "m/86'/0'/0'" },
+];
+
+test.describe("findTaprootAccount — selects the BIP86 account by path", () => {
+  test("finds the 86' account regardless of its position in the export", () => {
+    expect(findTaprootAccount(KEYSTONE_EXPORT_ORDER)?.path).toBe("m/86'/0'/0'");
+  });
+
+  test("finds the 86' account when it is first", () => {
+    const keys = [{ path: "m/86'/1'/0'" }, { path: "m/84'/1'/0'" }];
+    expect(findTaprootAccount(keys)?.path).toBe("m/86'/1'/0'");
+  });
+
+  test("matches Taproot for any coin_type (testnet 1')", () => {
+    const keys = [{ path: "m/44'/1'/0'" }, { path: "m/86'/1'/0'" }];
+    expect(findTaprootAccount(keys)?.path).toBe("m/86'/1'/0'");
+  });
+
+  test("tolerates the 'h' hardened marker", () => {
+    const keys = [{ path: "m/84h/0h/0h" }, { path: "m/86h/0h/0h" }];
+    expect(findTaprootAccount(keys)?.path).toBe("m/86h/0h/0h");
+  });
+
+  test("returns undefined when no Taproot account is present", () => {
+    const keys = [{ path: "m/84'/0'/0'" }, { path: "m/49'/0'/0'" }];
+    expect(findTaprootAccount(keys)).toBeUndefined();
+  });
+
+  test("returns undefined for an empty export", () => {
+    expect(findTaprootAccount([])).toBeUndefined();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -389,8 +389,8 @@ importers:
         specifier: 0.10.0
         version: 0.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@keystonehq/keystone-sdk':
-        specifier: 0.9.0
-        version: 0.9.0
+        specifier: 0.12.3
+        version: 0.12.3
       '@keystonehq/sdk':
         specifier: 0.22.1
         version: 0.22.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -423,7 +423,7 @@ importers:
         version: 0.3.5-alpha.0(@ledgerhq/hw-transport-webhid@6.30.6)(@ledgerhq/hw-transport-webusb@6.29.10)(@ledgerhq/hw-transport@6.31.10)(bitcoinjs-lib@6.1.7)
       '@tomo-inc/wallet-connect-sdk':
         specifier: 1.0.0
-        version: 1.0.0(@bitcoinerlab/secp256k1@1.2.0)(@cosmjs/stargate@0.36.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(@keplr-wallet/types@0.12.272(starknet@6.24.1))(@keystonehq/animated-qr@0.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@keystonehq/keystone-sdk@0.9.0)(@keystonehq/sdk@0.22.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@scure/bip32@1.4.0)(@types/react@18.3.23)(bitcoinjs-lib@6.1.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 1.0.0(@bitcoinerlab/secp256k1@1.2.0)(@cosmjs/stargate@0.36.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(@keplr-wallet/types@0.12.272(starknet@6.24.1))(@keystonehq/animated-qr@0.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@keystonehq/keystone-sdk@0.12.3)(@keystonehq/sdk@0.22.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@scure/bip32@1.4.0)(@types/react@18.3.23)(bitcoinjs-lib@6.1.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       bip174:
         specifier: 2.1.1
         version: 2.1.1
@@ -2734,20 +2734,26 @@ packages:
   '@keystonehq/bc-ur-registry-arweave@0.5.3':
     resolution: {integrity: sha512-b5OAzhW7HLaOX7OEyWA+Bz+4EJIzCT7c+JXU0TElzpBD5rGo4ylf+StuyV6WnuKx5NV11fv9k2XDyHit26CCLA==}
 
+  '@keystonehq/bc-ur-registry-avalanche@0.0.4':
+    resolution: {integrity: sha512-I32b+k17jrGCPpYW3tlav+BKdGBI8cMZat/AiQnr66JUSuewl+Cn7E7UqrQ3L7qZbSXquYUKUjYXdtMTACNnyQ==}
+
   '@keystonehq/bc-ur-registry-btc@0.1.1':
     resolution: {integrity: sha512-LdYqItY1Y/M6fWJNE6L0HYZbKL8CGVP6OigG7T/gJ+SWnOGgYXj3at02aV7b9qZ7iNwJPkNrqsIDN5eajQcZjQ==}
 
-  '@keystonehq/bc-ur-registry-cardano@0.4.0':
-    resolution: {integrity: sha512-xkFkD+FIG72rZiMgCtuNvXm63ik53C1yL3w8nnAG+1q3x6vomo3hv/Ve5ZE0uL7kEXw6wQ8s8gW1MczR1xZxgg==}
+  '@keystonehq/bc-ur-registry-cardano@0.5.0':
+    resolution: {integrity: sha512-/95c2HkIGPCOfVrawIVGRZDNePxLH94Po9iC91GjV2uo7xuXhicg42IO4CDj6yBh0je9HQ0UoOMErwxyU3jNFg==}
 
   '@keystonehq/bc-ur-registry-cosmos@0.5.3':
     resolution: {integrity: sha512-bCmm2LMM4EHiLrjhfkbzfnwTXi4ez56MfwKYke8Z0roeaJbHmr2KkCg6/MePLjeK9PRbY0jKXBmCowMe2DhfhA==}
 
-  '@keystonehq/bc-ur-registry-eth@0.20.1':
-    resolution: {integrity: sha512-vQpqhj2DeDI1/xwY3eqj1PWgqqTdg53RgMVBUZUV3O8CSc0nbnH4SaP3cx85KEOO+4Loq6SXHbFJr1egalM2ng==}
+  '@keystonehq/bc-ur-registry-eth@0.22.1':
+    resolution: {integrity: sha512-JNHSDgFSkuJ48D3kJabAidHQ2tI7+lbm3uQM/usZVYg4HQfPd3vaCblpAWhC6u29YqOBkHDhVANSxikrKiU44g==}
 
   '@keystonehq/bc-ur-registry-evm@0.5.3':
     resolution: {integrity: sha512-K3tmY1Y2SDImtSnCPFoASMBNernbN/ZRIIkp8iKegDeyHtaPbzfNIdaEL/wUHVoieTgTOUTwyWZspBvvbgrivw==}
+
+  '@keystonehq/bc-ur-registry-iota@0.1.4':
+    resolution: {integrity: sha512-67l+ghoctcudnjyF2iory5pivekh/GaPtceIFqvfe+z5M+/CZoSn2V3grkq64ih0nwJCO1yUax9D+rCQMTubCg==}
 
   '@keystonehq/bc-ur-registry-keystone@0.4.3':
     resolution: {integrity: sha512-YTf0p9TYYq9+bfF/wMEE2gbhNiV1S0m31hMwnl+4kn3q1avwlrXZ6h30nANZXD31NQ8hMuLO8x7Ny+0AldmAOA==}
@@ -2767,14 +2773,20 @@ packages:
   '@keystonehq/bc-ur-registry-ton@0.1.2':
     resolution: {integrity: sha512-m36/QODXTbkQQacM8vIopt5RvE/uc/f9f4Jc9VFxsxKWmld3aGwrMsLB1SBSva31kawikOVSMEWXhXlQ07UJhA==}
 
+  '@keystonehq/bc-ur-registry-zcash@0.1.2':
+    resolution: {integrity: sha512-HkHSiz1WeMDaCMU75Uiu+Ozjaqe+rtInHuQFRUb6u89bH/+sJZb3XBkZ8lzJUwqlCMMWUZ0DbEtoRKYpb9kSzg==}
+
   '@keystonehq/bc-ur-registry@0.6.4':
     resolution: {integrity: sha512-j8Uy44DuAkvYkbf0jMxRY3UizJfn8wsEQr7GS3miRF44vcq7k0/yemVkftbn3jQ+0JYaUXf5wY7lVpLhAeW5nQ==}
 
   '@keystonehq/bc-ur-registry@0.7.0':
     resolution: {integrity: sha512-E6NUd6Y+YYM+IcYGOEXfO9+MU1s63Qjm8brtHftvNhxbdXhGtTYIsa4FQmqZ6q34q91bMkMqUQFsQYPmIxcxfg==}
 
-  '@keystonehq/keystone-sdk@0.9.0':
-    resolution: {integrity: sha512-sP2DFvQucmyz3mP+b11EYcc0sXuANHoH8esZpsGaf67+Rv4RcbJfx0Au7JZKrxwcKWLbKrI9a2h3J6Tt7SvoRQ==}
+  '@keystonehq/bc-ur-registry@0.8.0':
+    resolution: {integrity: sha512-o+R1r68SoTemZXiH4W6GPiU1e64YPuIoxXqqFNTIRvEV6c7NoKrDiYgnsARZpxn6sseElmJ2c2O8s8nXKrHVTg==}
+
+  '@keystonehq/keystone-sdk@0.12.3':
+    resolution: {integrity: sha512-VneFYPNkW39KgmR9Vaz2qQhIUoZbeXOX5YEAsf9XpkWHXhRaD9iW5cn+xu2sJS5EXyv8cvA5/ZyZez4Jy5R/Uw==}
 
   '@keystonehq/sdk@0.22.1':
     resolution: {integrity: sha512-yBX2L3ieoZ1llj8Ocsiu+doDP+XtoI8oUPkv50oP3aBnzqM0IBsL46upWIVUWt5DucHAdGLGcVx9FxR9sQYZBw==}
@@ -10178,6 +10190,7 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
@@ -12805,12 +12818,18 @@ snapshots:
       '@keystonehq/bc-ur-registry': 0.6.4
       uuid: 8.3.2
 
+  '@keystonehq/bc-ur-registry-avalanche@0.0.4':
+    dependencies:
+      '@keystonehq/bc-ur-registry': 0.6.4
+      buffer: 6.0.3
+      uuid: 8.3.2
+
   '@keystonehq/bc-ur-registry-btc@0.1.1':
     dependencies:
       '@keystonehq/bc-ur-registry': 0.6.4
       uuid: 8.3.2
 
-  '@keystonehq/bc-ur-registry-cardano@0.4.0':
+  '@keystonehq/bc-ur-registry-cardano@0.5.0':
     dependencies:
       '@keystonehq/bc-ur-registry': 0.6.4
       uuid: 8.3.2
@@ -12821,10 +12840,10 @@ snapshots:
       bs58check: 2.1.2
       uuid: 8.3.2
 
-  '@keystonehq/bc-ur-registry-eth@0.20.1':
+  '@keystonehq/bc-ur-registry-eth@0.22.1':
     dependencies:
       '@ethereumjs/util': 9.1.0
-      '@keystonehq/bc-ur-registry': 0.6.4
+      '@keystonehq/bc-ur-registry': 0.7.0
       hdkey: 2.1.0
       uuid: 8.3.2
 
@@ -12832,6 +12851,11 @@ snapshots:
     dependencies:
       '@keystonehq/bc-ur-registry': 0.6.4
       bs58check: 2.1.2
+      uuid: 9.0.1
+
+  '@keystonehq/bc-ur-registry-iota@0.1.4':
+    dependencies:
+      '@keystonehq/bc-ur-registry': 0.6.4
       uuid: 9.0.1
 
   '@keystonehq/bc-ur-registry-keystone@0.4.3':
@@ -12866,6 +12890,11 @@ snapshots:
       '@keystonehq/bc-ur-registry': 0.6.4
       uuid: 9.0.1
 
+  '@keystonehq/bc-ur-registry-zcash@0.1.2':
+    dependencies:
+      '@keystonehq/bc-ur-registry': 0.7.0
+      uuid: 9.0.1
+
   '@keystonehq/bc-ur-registry@0.6.4':
     dependencies:
       '@ngraveio/bc-ur': 1.1.13
@@ -12878,26 +12907,36 @@ snapshots:
       bs58check: 2.1.2
       tslib: 2.8.1
 
-  '@keystonehq/keystone-sdk@0.9.0':
+  '@keystonehq/bc-ur-registry@0.8.0':
+    dependencies:
+      '@ngraveio/bc-ur': 1.1.13
+      bs58check: 2.1.2
+      tslib: 2.8.1
+
+  '@keystonehq/keystone-sdk@0.12.3':
     dependencies:
       '@bufbuild/protobuf': 1.10.1
-      '@keystonehq/bc-ur-registry': 0.7.0
+      '@keystonehq/bc-ur-registry': 0.8.0
       '@keystonehq/bc-ur-registry-aptos': 0.6.3
       '@keystonehq/bc-ur-registry-arweave': 0.5.3
+      '@keystonehq/bc-ur-registry-avalanche': 0.0.4
       '@keystonehq/bc-ur-registry-btc': 0.1.1
-      '@keystonehq/bc-ur-registry-cardano': 0.4.0
+      '@keystonehq/bc-ur-registry-cardano': 0.5.0
       '@keystonehq/bc-ur-registry-cosmos': 0.5.3
-      '@keystonehq/bc-ur-registry-eth': 0.20.1
+      '@keystonehq/bc-ur-registry-eth': 0.22.1
       '@keystonehq/bc-ur-registry-evm': 0.5.3
+      '@keystonehq/bc-ur-registry-iota': 0.1.4
       '@keystonehq/bc-ur-registry-keystone': 0.4.3
       '@keystonehq/bc-ur-registry-near': 0.9.3
       '@keystonehq/bc-ur-registry-sol': 0.9.5
       '@keystonehq/bc-ur-registry-stellar': 0.0.4
       '@keystonehq/bc-ur-registry-sui': 0.4.0-alpha.0
       '@keystonehq/bc-ur-registry-ton': 0.1.2
+      '@keystonehq/bc-ur-registry-zcash': 0.1.2
       '@ngraveio/bc-ur': 1.1.13
       '@noble/hashes': 1.8.0
       bs58check: 3.0.1
+      buffer: 6.0.3
       pako: 2.1.0
       ripple-binary-codec: 1.11.0
       uuid: 9.0.1
@@ -15490,7 +15529,7 @@ snapshots:
       ledger-bitcoin: 0.2.3
       process: 0.11.10
 
-  '@tomo-inc/tomo-wallet-provider@1.2.0-beta.1(@bitcoinerlab/secp256k1@1.2.0)(@cosmjs/stargate@0.36.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(@keplr-wallet/types@0.12.272(starknet@6.24.1))(@keystonehq/animated-qr@0.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@keystonehq/keystone-sdk@0.9.0)(@keystonehq/sdk@0.22.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@scure/bip32@1.4.0)(bitcoinjs-lib@6.1.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(starknet@6.24.1)':
+  '@tomo-inc/tomo-wallet-provider@1.2.0-beta.1(@bitcoinerlab/secp256k1@1.2.0)(@cosmjs/stargate@0.36.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(@keplr-wallet/types@0.12.272(starknet@6.24.1))(@keystonehq/animated-qr@0.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@keystonehq/keystone-sdk@0.12.3)(@keystonehq/sdk@0.22.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@scure/bip32@1.4.0)(bitcoinjs-lib@6.1.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(starknet@6.24.1)':
     dependencies:
       '@bitcoinerlab/secp256k1': 1.2.0
       '@cosmjs/stargate': 0.36.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
@@ -15498,7 +15537,7 @@ snapshots:
       '@keplr-wallet/provider-extension': 0.12.272(starknet@6.24.1)
       '@keplr-wallet/types': 0.12.272(starknet@6.24.1)
       '@keystonehq/animated-qr': 0.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@keystonehq/keystone-sdk': 0.9.0
+      '@keystonehq/keystone-sdk': 0.12.3
       '@keystonehq/sdk': 0.22.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@scure/bip32': 1.4.0
       bitcoinjs-lib: 6.1.7
@@ -15511,9 +15550,9 @@ snapshots:
     transitivePeerDependencies:
       - starknet
 
-  '@tomo-inc/wallet-connect-sdk@1.0.0(@bitcoinerlab/secp256k1@1.2.0)(@cosmjs/stargate@0.36.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(@keplr-wallet/types@0.12.272(starknet@6.24.1))(@keystonehq/animated-qr@0.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@keystonehq/keystone-sdk@0.9.0)(@keystonehq/sdk@0.22.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@scure/bip32@1.4.0)(@types/react@18.3.23)(bitcoinjs-lib@6.1.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@tomo-inc/wallet-connect-sdk@1.0.0(@bitcoinerlab/secp256k1@1.2.0)(@cosmjs/stargate@0.36.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(@keplr-wallet/types@0.12.272(starknet@6.24.1))(@keystonehq/animated-qr@0.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@keystonehq/keystone-sdk@0.12.3)(@keystonehq/sdk@0.22.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@scure/bip32@1.4.0)(@types/react@18.3.23)(bitcoinjs-lib@6.1.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@tomo-inc/tomo-wallet-provider': 1.2.0-beta.1(@bitcoinerlab/secp256k1@1.2.0)(@cosmjs/stargate@0.36.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(@keplr-wallet/types@0.12.272(starknet@6.24.1))(@keystonehq/animated-qr@0.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@keystonehq/keystone-sdk@0.9.0)(@keystonehq/sdk@0.22.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@scure/bip32@1.4.0)(bitcoinjs-lib@6.1.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(starknet@6.24.1)
+      '@tomo-inc/tomo-wallet-provider': 1.2.0-beta.1(@bitcoinerlab/secp256k1@1.2.0)(@cosmjs/stargate@0.36.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(@keplr-wallet/types@0.12.272(starknet@6.24.1))(@keystonehq/animated-qr@0.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@keystonehq/keystone-sdk@0.12.3)(@keystonehq/sdk@0.22.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@scure/bip32@1.4.0)(bitcoinjs-lib@6.1.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(starknet@6.24.1)
       animate.css: 4.1.1
       buffer: 6.0.3
       classnames: 2.5.1

--- a/services/vault/src/context/wallet/VaultWalletConnectionProvider.tsx
+++ b/services/vault/src/context/wallet/VaultWalletConnectionProvider.tsx
@@ -21,17 +21,16 @@ import { getNetworkConfigETH } from "@/config/network";
 import { logger } from "@/infrastructure";
 
 // Vault deposits require the connected BTC wallet to implement the
-// `deriveContextHash` API (see docs/specs/derive-context-hash.md). UniSat
-// and OneKey expose a conformant implementation today, so every other BTC
-// adapter is gated off here. Re-enable an entry as soon as its wallet
-// vendor ships `deriveContextHash`. Each non-conforming adapter still
+// `deriveContextHash` API (see docs/specs/derive-context-hash.md). UniSat,
+// OneKey, and Keystone expose a conformant implementation today, so every
+// other BTC adapter is gated off here. Re-enable an entry as soon as its
+// wallet vendor ships `deriveContextHash`. Each non-conforming adapter still
 // throws `WALLET_METHOD_NOT_SUPPORTED` at the connector layer; this
 // list just keeps them out of the connection UI in the first place so
 // users don't pick something that can't complete a deposit.
 const DISABLED_WALLETS: string[] = [
   APPKIT_BTC_CONNECTOR_ID,
   "injectable",
-  "keystone",
   "ledger_btc",
   "ledger_btc_v2",
   "okx",


### PR DESCRIPTION
## What this PR does

- Implements `deriveContextHash` for the Keystone BTC wallet so Keystone can be used for vault deposits. Before this, Keystone returned a "method not supported" stub and could not complete a deposit.
- Bumps `@keystonehq/keystone-sdk` from `0.9.0` to `0.12.3`, which is the version that exposes the `generateDeriveContextHashCall` and `parseURBytes` methods the implementation relies on.
- Turns Keystone on in the vault app by removing it from the `DISABLED_WALLETS` list, so users can actually pick it in the connect dialog.
- Selects the Keystone Taproot account by parsing the derivation path instead of trusting a hardcoded array index, and normalizes the hardened path marker so the device is always asked for the correct (hardened) key.
- Adds small, pure, unit-tested helpers (canonical network name, output validation, Taproot selection) and updates the connect-dialog copy.

## Why

Vault deposits require the connected BTC wallet to implement the `deriveContextHash` API (see `docs/specs/derive-context-hash.md`). It is the primitive the protocol uses to derive vault secrets (HTLC hashlock pre-image, WOTS seed) deterministically from the wallet's key material, so the user can reproduce them later to activate and recover a deposit. Keystone was the last common hardware wallet still missing this method, so depositors using Keystone were blocked. This PR fills that gap and enables Keystone end to end.

This reworks the original Keystone PR at https://github.com/babylonlabs-io/babylon-toolkit/pull/1834 on top of the latest `main`, and adds the fixes needed to make Keystone actually usable in the app.

## Key changes and decisions

### 1. deriveContextHash implementation

The method forwards the dApp's `appName` and `context` unchanged, adds the wallet-side canonical network name and the key path, runs the Keystone QR round-trip, and returns the 32-byte result as lowercase hex. Before returning, we validate that the output is exactly 64 lowercase hex characters, because this value feeds on-chain vault commitments — a malformed firmware response should fail loudly at the source rather than silently corrupt a deposit (the SDK also re-validates it downstream).

### 2. keyPath binds to the actual connected key

We pass `${path}/0/0` (the first Taproot leaf) as the key path. This is the exact key Keystone already uses for its address and for signing, and it is the "connected public key" the spec expects to be bound into the derivation. The original PR passed the account-level path, which does not match that key. A comment in the code explains that if the on-device firmware test fails, the firmware may instead expect the account-level path, so the fallback is documented.

### 3. Pick the Taproot account by path, not by index

The old code used `accountData.keys[3]` and assumed index 3 is always Taproot. In testing, the real Keystone export order was `[84', 49', 44', 86']` — Taproot landed at index 3 only by luck. We now select the account whose path purpose is `86'` (BIP86 Taproot), which is robust to export ordering.

We also normalize the hardened marker on the selected path from `h` to `'` (e.g. `m/86h/0h/0h` → `m/86'/0'/0'`). The Keystone SDK only treats a path component as hardened when it ends with an apostrophe, so an `h`-style component would be silently sent to the device as non-hardened (`m/86/0/0`) and would derive a different key. Keystone exports apostrophes today, so this is defensive, but it keeps the stored path canonical for every consumer that reads it (both `deriveContextHash` and PSBT/message signing).

### 4. coin_type / network behavior — documented, not enforced

Keystone derives its key from whatever coin_type its active firmware dictates, and the app only re-skins the address to the configured network. On mainnet (coin_type `0'`) this matches software wallets, so the same seed gives the same key everywhere. On signet, the Keystone must run the separate BTC-only firmware with Signet mode (coin_type `1'`) to derive the same key as software wallets like UniSat — otherwise the same seed produces a different key, and switching between Keystone and a software wallet shows a "different BTC public key" error. We documented this in a code comment instead of adding a hard block, because signet is for development only and a strict check could break the dev flow when the device cannot export the matching coin_type. A Keystone-only deposit still reproduces its own key and context hash deterministically, so activation and recovery with the same Keystone work.

## Approaches considered

- Branch strategy: cherry-pick the original PR vs. branch fresh off the latest `main` and re-apply the changes. We chose the fresh branch and a clean `pnpm install` to regenerate the lockfile, which avoids `pnpm-lock.yaml` and `package.json` merge conflicts against the newer `main`.
- keyPath: account-level path (what the original PR did) vs. the Taproot leaf `${path}/0/0`. We chose the leaf because it is the key Keystone actually uses and what the spec binds, and left a comment describing the account-path fallback for the firmware test.
- Hardened marker: tolerate `h` at selection only vs. normalize `h` to `'` end to end. We chose to normalize, so the path handed to the Keystone SDK is always encoded as hardened and can never silently select the right account but derive the wrong key.
- Network mismatch handling: throw a strict "switch your Keystone to the right mode" error vs. just document the behavior. We chose to document it, because signet is dev-only and a strict check risks breaking development when the device cannot export the testnet coin_type.