### PR TITLE
fix(wallet): harden OneKey version read and dedupe version check

### DIFF
--- a/packages/babylon-wallet-connector/src/core/utils/checkMinVersion.ts
+++ b/packages/babylon-wallet-connector/src/core/utils/checkMinVersion.ts
@@ -1,0 +1,24 @@
+// Strict canonical semver — reject `v1.2.3`, `1.2.3-beta`, `dev`, leading
+// zeros (`01.2.3`, `1.02.3`), and any non-canonical format. The numeric
+// comparison cannot be defeated by string collation quirks (e.g.
+// `localeCompare` ranks `"dev" > "1"`).
+const SEMVER_RE = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+
+export type MinVersionCheck = "ok" | "below" | "unparseable";
+
+/**
+ * Compares a raw version value against a minimum strict `MAJOR.MINOR.PATCH`.
+ * Returns `"unparseable"` for non-string input or any string that is not
+ * strict canonical semver — fail-closed for fork/canary builds or an
+ * unpopulated value. `min` is a trusted, hard-coded `MAJOR.MINOR.PATCH`.
+ */
+export function checkMinVersion(raw: unknown, min: string): MinVersionCheck {
+  const match = typeof raw === "string" ? SEMVER_RE.exec(raw) : null;
+  if (!match) return "unparseable";
+  const [minMajor, minMinor, minPatch] = min.split(".").map(Number);
+  const cmp =
+    Number(match[1]) - minMajor ||
+    Number(match[2]) - minMinor ||
+    Number(match[3]) - minPatch;
+  return cmp >= 0 ? "ok" : "below";
+}

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/onekey/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/onekey/provider.ts
@@ -131,8 +131,9 @@ export class OneKeyProvider implements IBTCProvider {
       return this.hub.$walletInfo.version;
     }
 
+    let info: unknown;
     try {
-      await withTimeout(
+      info = await withTimeout(
         Promise.resolve(this.hub?.$private?.getConnectWalletInfo?.()),
         ONEKEY_RPC_TIMEOUT_MS,
         () => this.timeoutError("reading its version"),
@@ -146,7 +147,11 @@ export class OneKeyProvider implements IBTCProvider {
       });
     }
 
-    return this.hub?.$walletInfo?.version;
+    // Prefer the value `getConnectWalletInfo` resolved with (a build could
+    // return the version without mutating `$walletInfo`), then fall back to the
+    // cache it repopulates — so the gate doesn't rest solely on the side effect.
+    const resolved = info as { version?: unknown; walletInfo?: { version?: unknown } } | undefined;
+    return resolved?.version ?? resolved?.walletInfo?.version ?? this.hub?.$walletInfo?.version;
   };
 
   // Gates connect on OneKey >= MIN_ONEKEY_VERSION (the floor for

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/onekey/version.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/onekey/version.ts
@@ -1,3 +1,5 @@
+import { checkMinVersion, type MinVersionCheck } from "@/core/utils/checkMinVersion";
+
 // 6.3.0 is the first OneKey app/extension release that ships
 // `deriveContextHash` (spec-conformant from the start), so it is the floor
 // for vault deposits. Source: OneKeyHQ/app-monorepo PR #11568 (merge commit
@@ -9,28 +11,7 @@
 // inpage-provider package version "2.2.69"), neither of which is the app version.
 export const MIN_ONEKEY_VERSION = "6.3.0";
 
-const MIN_ONEKEY_PARTS = MIN_ONEKEY_VERSION.split(".").map(Number) as [number, number, number];
-
-// Strict canonical semver — reject `v6.3.0`, `6.3.0-beta`, `dev`, leading
-// zeros (`06.3.0`, `6.03.0`), and any non-canonical format. The numeric
-// comparison below cannot be defeated by string collation quirks (e.g.
-// `localeCompare` ranks `"dev" > "1"`).
-const SEMVER_RE = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
-
-export type OneKeyVersionCheck = "ok" | "below" | "unparseable";
-
-/**
- * Compares a raw `$walletInfo.version` value against {@link MIN_ONEKEY_VERSION}.
- * Returns `"unparseable"` for non-string input or any string that is not
- * strict canonical `MAJOR.MINOR.PATCH` — fail-closed for fork/canary builds
- * or a `$walletInfo` cache that has not populated yet.
- */
-export function checkOneKeyVersion(raw: unknown): OneKeyVersionCheck {
-  const match = typeof raw === "string" ? SEMVER_RE.exec(raw) : null;
-  if (!match) return "unparseable";
-  const cmp =
-    Number(match[1]) - MIN_ONEKEY_PARTS[0] ||
-    Number(match[2]) - MIN_ONEKEY_PARTS[1] ||
-    Number(match[3]) - MIN_ONEKEY_PARTS[2];
-  return cmp >= 0 ? "ok" : "below";
+/** Compares a raw `$walletInfo.version` against {@link MIN_ONEKEY_VERSION}. */
+export function checkOneKeyVersion(raw: unknown): MinVersionCheck {
+  return checkMinVersion(raw, MIN_ONEKEY_VERSION);
 }

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/unisat/version.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/unisat/version.ts
@@ -1,3 +1,5 @@
+import { checkMinVersion, type MinVersionCheck } from "@/core/utils/checkMinVersion";
+
 // 1.7.14 is the first UniSat release that binds `deriveContextHash` to the
 // connected pubkey + network. Older builds derive a different hash for the
 // same inputs and would silently desync against btc-vault flows.
@@ -6,28 +8,7 @@
 // first shipped in tag extension/v1.7.14.
 export const MIN_UNISAT_VERSION = "1.7.14";
 
-const MIN_UNISAT_PARTS = MIN_UNISAT_VERSION.split(".").map(Number) as [number, number, number];
-
-// Strict canonical semver — reject `v1.7.14`, `1.7.14-beta`, `dev`, leading
-// zeros (`01.7.14`, `1.07.14`), and any non-canonical format. The numeric
-// comparison below cannot be defeated by string collation quirks (e.g.
-// `localeCompare` ranks `"dev" > "1"`).
-const SEMVER_RE = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
-
-export type UnisatVersionCheck = "ok" | "below" | "unparseable";
-
-/**
- * Compares a raw `getVersion()` value against {@link MIN_UNISAT_VERSION}.
- * Returns `"unparseable"` for non-string input or any string that is not
- * strict canonical `MAJOR.MINOR.PATCH` — fail-closed for fork/canary builds
- * that emit non-standard formats.
- */
-export function checkUnisatVersion(raw: unknown): UnisatVersionCheck {
-  const match = typeof raw === "string" ? SEMVER_RE.exec(raw) : null;
-  if (!match) return "unparseable";
-  const cmp =
-    Number(match[1]) - MIN_UNISAT_PARTS[0] ||
-    Number(match[2]) - MIN_UNISAT_PARTS[1] ||
-    Number(match[3]) - MIN_UNISAT_PARTS[2];
-  return cmp >= 0 ? "ok" : "below";
+/** Compares a raw `getVersion()` value against {@link MIN_UNISAT_VERSION}. */
+export function checkUnisatVersion(raw: unknown): MinVersionCheck {
+  return checkMinVersion(raw, MIN_UNISAT_VERSION);
 }


### PR DESCRIPTION
The OneKey version gate relied solely on getConnectWalletInfo mutating
$walletInfo, so a build that returns the version without writing it would
falsely block deposits; now also read the resolved value. Extract the
semver comparison shared with UniSat into checkMinVersion.