### PR TITLE
fix(wallet): ignore OneKey's window.unisat impersonation

### DIFF
--- a/packages/babylon-wallet-connector/src/core/index.ts
+++ b/packages/babylon-wallet-connector/src/core/index.ts
@@ -92,7 +92,10 @@ export const createWalletConnector = async <N extends string, P extends IProvide
   );
   const connector = new WalletConnector(metadata.chain, metadata.name, metadata.icon, filteredWallets, config);
 
-  const shouldAutoReconnect = metadata.chain !== "ETH" && connectedWalletId && wallets.some((wallet) => wallet.id === connectedWalletId);
+  const shouldAutoReconnect =
+    metadata.chain !== "ETH" &&
+    connectedWalletId &&
+    wallets.some((wallet) => wallet.id === connectedWalletId && wallet.installed);
 
   if (shouldAutoReconnect) {
     // Fire-and-forget: do NOT await the reconnect handshake. Awaiting it here

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/unisat/index.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/unisat/index.ts
@@ -8,7 +8,16 @@ const metadata: WalletMetadata<IBTCProvider, BTCConfig> = {
   name: WALLET_PROVIDER_NAME,
   icon: logo,
   docs: "https://unisat.io/download",
-  wallet: (context) => context.unisat_wallet ?? context.unisat,
+  wallet: (context) => {
+    // Prefer real UniSat's own `unisat_wallet` namespace, else `window.unisat`.
+    // OneKey injects `window.unisat` (a ProviderBtc with `isOneKey === true`)
+    // impersonating UniSat; skip any provider flagged `isOneKey` so the phantom
+    // UniSat entry isn't treated as installed (OneKey is reachable via its own
+    // `$onekey` entry), otherwise its getVersion() "1.4.10" fails our >= 1.7.14
+    // UniSat version gate.
+    const provider = context.unisat_wallet ?? context.unisat;
+    return provider && !provider.isOneKey ? provider : undefined;
+  },
   createProvider: (wallet, config) => new UnisatProvider(wallet, config),
   networks: [Network.MAINNET, Network.SIGNET],
 };


### PR DESCRIPTION
## Summary

A user with **only OneKey installed** saw a broken **UniSat** wallet tile that, on
click, failed with *"Your UniSat Wallet extension is out of date (1.4.10). Please
update to version 1.7.14 or later."*

OneKey injects `window.unisat` — a `ProviderBtc` with `isOneKey === true` and
`getVersion()` hardcoded to `"1.4.10"` — impersonating UniSat. Our UniSat adapter
picked that up as a real UniSat provider, so the depositor version gate
(`>= 1.7.14`) ran against OneKey and always failed. There is no UniSat to update.

Verified from OneKey source (`OneKeyHQ/cross-inpage-provider`,
`injectWeb3Provider.ts:273` → `defineWindowProperty('unisat', btc)`;
`ProviderBtc.ts` → `isOneKey = true`, `getVersion()` → `"1.4.10"`). OneKey injects
**only** `window.unisat`, never `window.unisat_wallet` (0 source hits).