### PR TITLE
fix(vault): make unowned vault cards inert, not just dimmed

### DIFF
--- a/services/vault/src/components/simple/BatchedDepositGroup.tsx
+++ b/services/vault/src/components/simple/BatchedDepositGroup.tsx
@@ -73,10 +73,19 @@ export function BatchedDepositGroup({
   );
   const btcSymbol = getNetworkConfigBTC().coinSymbol;
 
+  // A batch whose vaults belong to a different wallet is inert, same as a single
+  // unowned card: every sibling already dims + shows the switch-wallet tooltip,
+  // and opening the multistepper would only auto-fire an action that fails its
+  // on-chain checks. Siblings share one depositor, so ownership is all-or-none.
+  const groupUnowned = activities.some((activity) => {
+    const result = getPollingResult(activity.id);
+    return result ? getActionStatus(result).type === "disabled" : false;
+  });
+
   // One click anywhere on the group opens the batch-level multistepper.
   // Clicks landing on a button or anchor inside (Copy, explorer link,
   // hoisted broadcast button, per-vault action) preserve their own behaviour.
-  const clickable = Boolean(onGroupClick);
+  const clickable = Boolean(onGroupClick) && !groupUnowned;
   const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
     if (!clickable || isInteractiveEventTarget(event)) return;
     onGroupClick?.(activities[0].id);

--- a/services/vault/src/components/simple/VaultCardShell.tsx
+++ b/services/vault/src/components/simple/VaultCardShell.tsx
@@ -51,11 +51,11 @@ export function VaultCardShell({
 }: VaultCardShellProps) {
   const tooltipId = useId();
   const tooltipActive = Boolean(disabled && disabledTooltip);
-  // A `disabled` card (e.g. wallet-ownership mismatch) is still clickable —
-  // opening the multistepper as a read-only view lets the user see where the
-  // deposit is even when they can't currently act on it. The dim + tooltip
-  // already communicate that actions are blocked.
-  const clickable = Boolean(onClick);
+  // A `disabled` card (wallet-ownership mismatch) is inert: it isn't yours, and
+  // opening the multistepper would auto-fire an action signed by the wrong
+  // wallet that can only fail its on-chain checks. Block the click entirely; the
+  // dim + tooltip already say "switch to the owning wallet."
+  const clickable = Boolean(onClick) && !disabled;
 
   // Clicks/keys on buttons or anchors inside the card (Copy / explorer link /
   // action button) preserve their own behaviour rather than open the card

--- a/services/vault/src/components/simple/__tests__/BatchedDepositGroup.test.tsx
+++ b/services/vault/src/components/simple/__tests__/BatchedDepositGroup.test.tsx
@@ -128,6 +128,46 @@ describe("BatchedDepositGroup", () => {
     expect(screen.getAllByTestId("deposit-card")).toHaveLength(2);
   });
 
+  it("opens the batch multistepper when an owned group body is clicked", () => {
+    mockGetActionStatus.mockReturnValue(NO_ACTION);
+    const onGroupClick = vi.fn();
+    render(
+      <BatchedDepositGroup
+        activities={[activity("0xa"), activity("0xb")]}
+        vaultProviders={[]}
+        onBroadcastClick={vi.fn()}
+        onGroupClick={onGroupClick}
+      />,
+    );
+
+    fireEvent.click(screen.getByText(COPY.pegin.batchedDeposit.groupLabel));
+    // The handler receives the first sibling's id as the batch representative.
+    expect(onGroupClick).toHaveBeenCalledWith("0xa");
+  });
+
+  it("is inert when the batch belongs to a different wallet", () => {
+    // Ownership mismatch → getActionStatus returns `disabled` for the siblings.
+    mockGetActionStatus.mockReturnValue({
+      type: "disabled",
+      tooltip: "Switch to the owning wallet",
+    } satisfies ActionStatus);
+    const onGroupClick = vi.fn();
+    render(
+      <BatchedDepositGroup
+        activities={[activity("0xa"), activity("0xb")]}
+        vaultProviders={[]}
+        onBroadcastClick={vi.fn()}
+        onGroupClick={onGroupClick}
+      />,
+    );
+
+    fireEvent.click(screen.getByText(COPY.pegin.batchedDeposit.groupLabel));
+    expect(onGroupClick).not.toHaveBeenCalled();
+    // No button semantics on the wrapper, and no hoisted broadcast button
+    // (an unowned sibling is `disabled`, never `available`).
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
   it("renders a total of all sibling amounts in the group header", () => {
     mockGetActionStatus.mockReturnValue(NO_ACTION);
     const a = activity("0xa");

--- a/services/vault/src/components/simple/__tests__/VaultCardShell.test.tsx
+++ b/services/vault/src/components/simple/__tests__/VaultCardShell.test.tsx
@@ -90,4 +90,33 @@ describe("VaultCardShell — card-as-button routing", () => {
     expect(shell).not.toHaveAttribute("role");
     expect(shell).not.toHaveAttribute("tabindex");
   });
+
+  it("is inert when disabled even with an onClick — but still shows the tooltip", () => {
+    // Wallet-ownership mismatch: the card dims and explains itself, but must not
+    // open the multistepper (that would auto-sign with the wrong wallet).
+    render(
+      <VaultCardShell
+        testId="shell"
+        disabled
+        disabledTooltip="Switch to the owning wallet"
+        onClick={onClick}
+      >
+        <span data-testid="plain">0.05 BTC</span>
+      </VaultCardShell>,
+    );
+    const shell = screen.getByTestId("shell");
+
+    fireEvent.click(screen.getByTestId("plain"));
+    fireEvent.keyDown(shell, { key: "Enter" });
+    fireEvent.keyDown(shell, { key: " " });
+    expect(onClick).not.toHaveBeenCalled();
+
+    expect(shell).not.toHaveAttribute("role");
+    expect(shell).not.toHaveAttribute("tabindex");
+    // Dim + tooltip still communicate why the card is inert.
+    expect(shell).toHaveAttribute(
+      "data-tooltip-content",
+      "Switch to the owning wallet",
+    );
+  });
 });


### PR DESCRIPTION
A vault card greys out (dim + "switch to the owning wallet" tooltip) when the
connected BTC account's pubkey differs from the vault's depositor pubkey — e.g.
you created the vault with pubkey A, then switched BTC accounts to pubkey B.

Previously that disabled card was **still clickable**. Clicking opened the deposit
multistepper, which has no ownership gate and **auto-fires the pending action
(broadcast / submit WOTS / sign payout / activate) with the currently-connected
wallet B** via `useRunOnce`. Every path then fails its on-chain check (payout
address mismatch, WOTS-hash mismatch, hashlock mismatch, unsignable inputs), but
the user still gets an unexpected wallet prompt followed by an error.

This makes unowned cards fully inert. The dim + tooltip already communicate the
state; there's nothing actionable behind the click.