### PR TITLE
fix(wasm): replace deprecated substr with slice in hexToBytes

### DIFF
--- a/packages/babylon-tbv-rust-wasm/src/index.ts
+++ b/packages/babylon-tbv-rust-wasm/src/index.ts
@@ -354,7 +354,7 @@ function hexToBytes(hex: string): Uint8Array {
   }
   const bytes = new Uint8Array(clean.length / 2);
   for (let i = 0; i < bytes.length; i++) {
-    bytes[i] = parseInt(clean.substr(i * 2, 2), 16);
+    bytes[i] = parseInt(clean.slice(i * 2, i * 2 + 2), 16);
   }
   return bytes;
 }


### PR DESCRIPTION
## What

In [`packages/babylon-tbv-rust-wasm/src/index.ts`](packages/babylon-tbv-rust-wasm/src/index.ts), the `hexToBytes` helper parsed each byte with `clean.substr(i * 2, 2)`. This PR swaps that single call for `clean.slice(i * 2, i * 2 + 2)`. Nothing else changes.

## Why

`String.prototype.substr` is a deprecated/legacy JavaScript method. It still works in every engine today, but it is marked for eventual removal and lint/security tooling flags it. There is no bug today — this is a hygiene fix so the code keeps working on future runtimes and stops tripping the linter.

## The two argument styles (and why they're equivalent here)

`substr(start, length)` takes a start index and a **length**, while `slice(start, end)` takes a start index and an **end** index. For a fixed length of 2 starting at `i * 2`, the matching `slice` end is `i * 2 + 2`. So `substr(i * 2, 2)` and `slice(i * 2, i * 2 + 2)` read exactly the same 2 characters and produce identical output. The input is also already validated just above (even length + hex-only characters), so there are no edge cases where the two would diverge.

## Approach considered

- `slice(i * 2, i * 2 + 2)` — chosen.
- `substring(i * 2, i * 2 + 2)` — also valid, but `slice` is the standard replacement recommended in the issue, and the same function already uses `slice` one line up (`hex.slice(2)` to strip the `0x` prefix). Matching the existing style keeps the file consistent.

## Why this approach

It is the smallest possible change, it is behaviour-identical, and it lines up with code that is already in the file. Because the output is provably the same, no test changes were needed.

## Testing

- `pnpm --filter @babylonlabs-io/babylon-tbv-rust-wasm run lint` — clean.
- The vault test suite still passes (`pnpm --filter vault run test`), confirming nothing downstream of `hexToBytes` shifted.