### PR TITLE
fix(vault): shorten fee-rate cache window in useNetworkFees

### DIFF
--- a/services/vault/src/hooks/useNetworkFees.ts
+++ b/services/vault/src/hooks/useNetworkFees.ts
@@ -5,6 +5,15 @@ import { getMempoolApiUrl } from "../clients/btc/config";
 
 const NETWORK_FEES_KEY = "NETWORK_FEES";
 
+/**
+ * How long fetched fee rates stay fresh and how often they auto-refetch.
+ * Kept short because Bitcoin fee rates are volatile; this value is display /
+ * max-deposit only (the broadcast pegin fee uses the on-chain protocol
+ * feeRate), so a tight interval is cheap insurance with no transaction risk.
+ */
+const FEE_STALE_TIME_MS = 10_000;
+const FEE_REFETCH_INTERVAL_MS = 10_000;
+
 export interface FeeRates {
   /** Default fee rate for next-block confirmation (fastestFee from mempool) */
   defaultFeeRate: number;
@@ -18,8 +27,8 @@ export interface FeeRates {
  * Fetches Bitcoin network fee recommendations from mempool.space API.
  *
  * Returns the fastestFee rate for next-block confirmation.
- * Auto-refetches every 60 seconds with retry logic (3 attempts).
- * Globally cached - all components share the same data.
+ * Auto-refetches every 10 seconds (and on window focus) with retry logic
+ * (3 attempts). Globally cached - all components share the same data.
  *
  * @returns Fee rate with loading/error state
  */
@@ -27,8 +36,9 @@ export function useNetworkFees(): FeeRates {
   const query = useQuery({
     queryKey: [NETWORK_FEES_KEY],
     queryFn: () => getNetworkFees(getMempoolApiUrl()),
-    staleTime: 60_000,
-    refetchInterval: 60_000,
+    staleTime: FEE_STALE_TIME_MS,
+    refetchInterval: FEE_REFETCH_INTERVAL_MS,
+    refetchOnWindowFocus: true,
     retry: 3,
     retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
   });


### PR DESCRIPTION
## What

In [`services/vault/src/hooks/useNetworkFees.ts`](services/vault/src/hooks/useNetworkFees.ts) the Bitcoin fee-rate query cached data for 60 seconds (`staleTime` and `refetchInterval` both `60_000`). This PR lowers both to 10 seconds, adds `refetchOnWindowFocus: true`, and extracts the two timings into named constants (`FEE_STALE_TIME_MS`, `FEE_REFETCH_INTERVAL_MS`) so the values are documented in one place.

## Why

An audit flagged the 60-second cache: Bitcoin fee rates can move sharply within seconds during mempool congestion, so a minute-old number can be stale. Refreshing more often (and on window focus) keeps what the user sees closer to the live network.

## Important context — the audit's worst case does not actually apply here

The audit worried that a stale fee could be used to build a transaction with too low a fee, leaving it stuck in the mempool. I traced where this value is used, and that does **not** happen in our app: `useNetworkFees` only feeds **display** and the **max-deposit** estimate. The fee that actually goes into the peg-in transaction comes from the on-chain protocol parameter (`config.offchainParams.feeRate`), not from this mempool number; the withdraw flow uses `useNetworkFees` purely to show a "network fee rate" row. So no signed transaction is built from this value, and the "stuck transaction" risk doesn't reproduce. This PR is therefore a freshness/UX improvement, not a correctness fix — I kept it because it's cheap and harmless.

## Approaches considered

- **Lower `staleTime`/`refetchInterval` to 10s + `refetchOnWindowFocus`** — chosen.
- **Also re-fetch the fee right before submit** (suggested in the issue) — skipped on purpose. Since this value never feeds a transaction, an extra fetch at submit time would add complexity and an API call for no benefit.
- **Close as won't-fix** — rejected. The fix is a few lines, makes the displayed/estimated numbers fresher, and follows the audit's main recommendation, so it's worth doing.

## Why this approach

It's the smallest change that addresses the real part of the finding (fresher data) without adding machinery for a risk that doesn't exist in our flow. Pulling the timings into named constants also removes the magic numbers and documents, right next to them, that this value is display-only.

## Testing

- `pnpm --filter vault run lint` — 0 errors.
- `pnpm --filter vault run test` — full suite passes (1794 tests), confirming the consumers (`useEstimatedBtcFee`, withdraw review) still behave.

## Related

Addresses Sherlock 884