### PR TITLE
feat(vault): add security headers and extract process polyfill

### DIFF
--- a/services/vault/eslint.config.js
+++ b/services/vault/eslint.config.js
@@ -27,6 +27,7 @@ export default tseslint.config(
       "postcss.config.cjs",
       "prettier.config.cjs",
       "scripts",
+      "public",
     ],
   },
   importPlugin.flatConfigs.recommended,

--- a/services/vault/index.html
+++ b/services/vault/index.html
@@ -26,16 +26,11 @@
     <meta name="twitter:image:width" content="2048" />
     <meta name="twitter:image:height" content="1170" />
     <meta name="version" content="%NEXT_PUBLIC_COMMIT_HASH%" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; connect-src 'self' https: http: wss: ws:; img-src 'self' data: https: blob:; style-src 'self' 'unsafe-inline'; font-src 'self' data: https:; object-src 'none'; base-uri 'self'; worker-src 'self' blob:;" />
+    <meta name="referrer" content="strict-origin-when-cross-origin" />
     <title>Babylon - Vault</title>
 
-    <!-- Polyfill for Node.js process global (required for @reown/appkit-adapter-bitcoin) -->
-    <script>
-      window.process = window.process || {
-        version: "",
-        browser: true,
-        env: {},
-      };
-    </script>
+    <script src="/process-polyfill.js"></script>
   </head>
 
   <body>

--- a/services/vault/index.html
+++ b/services/vault/index.html
@@ -26,7 +26,7 @@
     <meta name="twitter:image:width" content="2048" />
     <meta name="twitter:image:height" content="1170" />
     <meta name="version" content="%NEXT_PUBLIC_COMMIT_HASH%" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; connect-src 'self' https: http: wss: ws:; img-src 'self' data: https: blob:; style-src 'self' 'unsafe-inline'; font-src 'self' data: https:; object-src 'none'; base-uri 'self'; worker-src 'self' blob:;" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; connect-src 'self' https: http: wss: ws:; img-src 'self' data: https: blob:; style-src 'self' 'unsafe-inline'; font-src 'self' data: https:; object-src 'none'; base-uri 'self'; worker-src 'self' blob:; frame-src 'self' https://verify.walletconnect.com https://verify.walletconnect.org https://secure.walletconnect.com https://secure.walletconnect.org;" />
     <meta name="referrer" content="strict-origin-when-cross-origin" />
     <title>Babylon - Vault</title>
 

--- a/services/vault/public/process-polyfill.js
+++ b/services/vault/public/process-polyfill.js
@@ -1,0 +1,1 @@
+window.process = window.process || { version: "", browser: true, env: {} };

--- a/services/vault/src/build/__tests__/sriPlugin.test.ts
+++ b/services/vault/src/build/__tests__/sriPlugin.test.ts
@@ -1,0 +1,143 @@
+// @vitest-environment node
+// Vite's build pipeline (esbuild) cannot run under jsdom — it swaps the global
+// Uint8Array/TextEncoder and breaks esbuild's realm check.
+import { createHash } from "node:crypto";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { build, type Plugin } from "vite";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { sriPlugin } from "../sriPlugin";
+
+function sha384(content: Buffer): string {
+  return `sha384-${createHash("sha384").update(content).digest("base64")}`;
+}
+
+// Rewrites the entry chunk in a `generateBundle` hook — i.e. AFTER any earlier
+// hook would have seen the chunk's code. This reproduces the real failure class
+// that broke the app: the bytes Vite finally writes to disk differ from the
+// in-memory `chunk.code` an earlier hook hashed, leaving a stale integrity hash.
+function rewriteEntryChunkPlugin(): Plugin {
+  return {
+    name: "rewrite-entry-chunk",
+    apply: "build",
+    generateBundle(_options, bundle) {
+      for (const chunk of Object.values(bundle)) {
+        if (chunk.type === "chunk" && chunk.isEntry) {
+          chunk.code += "\n/* rewritten after hashing */\n";
+        }
+      }
+    },
+  };
+}
+
+describe("sriPlugin", () => {
+  let root = "";
+
+  afterEach(() => {
+    if (root) rmSync(root, { recursive: true, force: true });
+    root = "";
+  });
+
+  // Builds a tiny fixture app with the SRI plugin into a temp dir and returns
+  // the output dir. The entry statically imports a sibling forced into its own
+  // chunk, so the built HTML carries a script, a module entry, and a preload.
+  async function buildFixture(
+    indexHtml: string,
+    extraPlugins: Plugin[] = [],
+  ): Promise<string> {
+    // realpath: macOS tmpdir is a /var -> /private/var symlink, and a root that
+    // mismatches the resolved HTML path makes Vite emit an invalid output name.
+    root = realpathSync(mkdtempSync(join(tmpdir(), "sri-test-")));
+    mkdirSync(join(root, "public"));
+    writeFileSync(
+      join(root, "public", "process-polyfill.js"),
+      "window.process = window.process || {};\n",
+    );
+    writeFileSync(join(root, "sibling.ts"), "export const answer = 42;\n");
+    writeFileSync(
+      join(root, "main.ts"),
+      'import { answer } from "./sibling";\ndocument.title = String(answer);\n',
+    );
+    writeFileSync(join(root, "index.html"), indexHtml);
+
+    const outDir = join(root, "dist");
+    await build({
+      root,
+      configFile: false,
+      logLevel: "silent",
+      plugins: [sriPlugin(), ...extraPlugins],
+      build: {
+        outDir,
+        sourcemap: true,
+        rollupOptions: {
+          output: {
+            manualChunks: (id: string) =>
+              id.includes("sibling") ? "sibling" : undefined,
+          },
+        },
+      },
+    });
+    return outDir;
+  }
+
+  const VALID_HTML = `<!doctype html>
+<html>
+  <head>
+    <script src="/process-polyfill.js"></script>
+  </head>
+  <body>
+    <script type="module" src="/main.ts"></script>
+  </body>
+</html>
+`;
+
+  it("injects integrity matching the bytes on disk, even when a later build hook rewrites the entry chunk", async () => {
+    const outDir = await buildFixture(VALID_HTML, [rewriteEntryChunkPlugin()]);
+    const html = readFileSync(join(outDir, "index.html"), "utf8");
+
+    const refs = [
+      ...html.matchAll(
+        /(?:src|href)="(\/[^"]+\.js)"\s+integrity="(sha384-[A-Za-z0-9+/=]+)"/g,
+      ),
+    ];
+
+    // At minimum the public polyfill and the hashed entry chunk are protected.
+    expect(refs.length).toBeGreaterThanOrEqual(2);
+    // The hashed entry module must carry an integrity attribute — the asset that
+    // broke when hashing in-memory chunk code instead of the final disk bytes.
+    expect(html).toMatch(
+      /<script type="module" src="\/assets\/[^"]+\.js" integrity="sha384-/,
+    );
+
+    for (const [, path, injected] of refs) {
+      const actual = sha384(readFileSync(join(outDir, path.slice(1))));
+      expect(actual, `integrity mismatch for ${path}`).toBe(injected);
+    }
+  });
+
+  it("throws during build when a local script cannot be given an integrity hash", async () => {
+    const htmlWithUnresolvableScript = `<!doctype html>
+<html>
+  <head>
+    <script src="/missing.js"></script>
+  </head>
+  <body>
+    <script type="module" src="/main.ts"></script>
+  </body>
+</html>
+`;
+
+    await expect(buildFixture(htmlWithUnresolvableScript)).rejects.toThrow(
+      /missing integrity attribute/,
+    );
+  });
+});

--- a/services/vault/src/build/sriPlugin.ts
+++ b/services/vault/src/build/sriPlugin.ts
@@ -1,0 +1,82 @@
+import { createHash } from "node:crypto";
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import type { Plugin } from "vite";
+
+const SRI_HASH_PREFIX = "sha384-";
+
+function computeSriHash(content: Buffer): string {
+  return `${SRI_HASH_PREFIX}${createHash("sha384").update(content).digest("base64")}`;
+}
+
+function stripCrossorigin(attrs: string): string {
+  return attrs.replace(/\s*crossorigin(?:="[^"]*")?/g, "");
+}
+
+/**
+ * Adds Subresource Integrity (`integrity` + `crossorigin`) attributes to every
+ * local script/module-preload in the built `index.html`, and fails the build if
+ * any local JS script is left unprotected.
+ *
+ * Hashes are computed from the bytes Vite actually writes to disk. The in-memory
+ * `chunk.code` exposed during `generateBundle` does not match the final entry
+ * chunk, whose sibling-chunk import references are rewritten afterwards — a stale
+ * hash there makes the browser reject the entry script and blank the app.
+ */
+export function sriPlugin(): Plugin {
+  let outDir = "";
+  function resolveIntegrity(urlPath: string): string | undefined {
+    if (!outDir) return undefined;
+    const fileName = urlPath.replace(/^\//, "");
+    try {
+      return computeSriHash(readFileSync(resolve(outDir, fileName)));
+    } catch {
+      return undefined;
+    }
+  }
+  return {
+    name: "sri",
+    apply: "build",
+    configResolved(config) {
+      outDir = resolve(config.root, config.build.outDir);
+    },
+    closeBundle() {
+      if (!outDir) return;
+      const htmlPath = resolve(outDir, "index.html");
+      let html: string;
+      try {
+        html = readFileSync(htmlPath, "utf8");
+      } catch {
+        return;
+      }
+      const patched = html
+        .replace(
+          /<script ([^>]*?)src="([^"]+)"([^>]*?)>/g,
+          (match, before, src, after) => {
+            const integrity = resolveIntegrity(src);
+            if (!integrity) return match;
+            return `<script ${stripCrossorigin(before)}src="${src}" integrity="${integrity}" crossorigin="anonymous"${stripCrossorigin(after)}>`;
+          },
+        )
+        .replace(
+          /<link ([^>]*?)href="([^"]+\.js)"([^>]*?)>/g,
+          (match, before, href, after) => {
+            const integrity = resolveIntegrity(href);
+            if (!integrity) return match;
+            return `<link ${stripCrossorigin(before)}href="${href}" integrity="${integrity}" crossorigin="anonymous"${stripCrossorigin(after)}>`;
+          },
+        );
+
+      const unprotected = [
+        ...patched.matchAll(/<script [^>]*?src="(\/[^"]+\.js)"[^>]*>/g),
+      ].filter((m) => !m[0].includes(`integrity="${SRI_HASH_PREFIX}`));
+      if (unprotected.length > 0) {
+        throw new Error(
+          `SRI plugin: ${unprotected.length} local JS script(s) missing integrity attribute: ${unprotected.map((m) => m[1]).join(", ")}`,
+        );
+      }
+
+      writeFileSync(htmlPath, patched);
+    },
+  };
+}

--- a/services/vault/src/build/sriPlugin.ts
+++ b/services/vault/src/build/sriPlugin.ts
@@ -26,7 +26,6 @@ function stripCrossorigin(attrs: string): string {
 export function sriPlugin(): Plugin {
   let outDir = "";
   function resolveIntegrity(urlPath: string): string | undefined {
-    if (!outDir) return undefined;
     const fileName = urlPath.replace(/^\//, "");
     try {
       return computeSriHash(readFileSync(resolve(outDir, fileName)));
@@ -41,7 +40,6 @@ export function sriPlugin(): Plugin {
       outDir = resolve(config.root, config.build.outDir);
     },
     closeBundle() {
-      if (!outDir) return;
       const htmlPath = resolve(outDir, "index.html");
       let html: string;
       try {

--- a/services/vault/src/test/setup.ts
+++ b/services/vault/src/test/setup.ts
@@ -75,20 +75,22 @@ vi.mock("@/utils/btc/wasm", () => ({
   }),
 }));
 
-// Mock window.matchMedia
-Object.defineProperty(window, "matchMedia", {
-  writable: true,
-  value: vi.fn().mockImplementation((query) => ({
-    matches: false,
-    media: query,
-    onchange: null,
-    addListener: vi.fn(),
-    removeListener: vi.fn(),
-    addEventListener: vi.fn(),
-    removeEventListener: vi.fn(),
-    dispatchEvent: vi.fn(),
-  })),
-});
+// Mock window.matchMedia (jsdom-only; skipped in the node test environment)
+if (typeof window !== "undefined") {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
 
 // Mock IntersectionObserver
 global.IntersectionObserver = vi.fn().mockImplementation(() => ({

--- a/services/vault/vite.config.ts
+++ b/services/vault/vite.config.ts
@@ -1,6 +1,7 @@
 import { sentryVitePlugin } from "@sentry/vite-plugin";
 import react from "@vitejs/plugin-react";
 import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { defineConfig, type Plugin } from "vite";
@@ -10,7 +11,21 @@ import tsconfigPaths from "vite-tsconfig-paths";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
+const SECURITY_HEADERS = {
+  "Content-Security-Policy":
+    "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; connect-src 'self' https: http: wss: ws:; img-src 'self' data: https: blob:; style-src 'self' 'unsafe-inline'; font-src 'self' data: https:; object-src 'none'; base-uri 'self'; worker-src 'self' blob:;",
+  "X-Content-Type-Options": "nosniff",
+  "X-Frame-Options": "DENY",
+  "Referrer-Policy": "strict-origin-when-cross-origin",
+  "Permissions-Policy": "camera=(), microphone=(), geolocation=()",
+};
+
 const SRI_HASH_PREFIX = "sha384-";
+const PUBLIC_DIR = resolve(__dirname, "public");
+
+function computeSriHash(content: Buffer): string {
+  return `${SRI_HASH_PREFIX}${createHash("sha384").update(content).digest("base64")}`;
+}
 
 function stripCrossorigin(attrs: string): string {
   return attrs.replace(/\s*crossorigin(?:="[^"]*")?/g, "");
@@ -18,6 +33,17 @@ function stripCrossorigin(attrs: string): string {
 
 function sriPlugin(): Plugin {
   const assetHashes = new Map<string, string>();
+  // Static assets served from `public/` are copied verbatim and never enter the
+  // Rollup bundle, so hash them on demand from disk when referenced in the HTML.
+  function resolveIntegrity(fileName: string): string | undefined {
+    const bundled = assetHashes.get(fileName);
+    if (bundled) return bundled;
+    try {
+      return computeSriHash(readFileSync(resolve(PUBLIC_DIR, fileName)));
+    } catch {
+      return undefined;
+    }
+  }
   return {
     name: "sri",
     apply: "build",
@@ -26,10 +52,7 @@ function sriPlugin(): Plugin {
         const content = chunk.type === "chunk" ? chunk.code : chunk.source;
         const contentBuffer =
           typeof content === "string" ? Buffer.from(content) : content;
-        const hash = createHash("sha384")
-          .update(contentBuffer)
-          .digest("base64");
-        assetHashes.set(fileName, `${SRI_HASH_PREFIX}${hash}`);
+        assetHashes.set(fileName, computeSriHash(contentBuffer));
       }
     },
     transformIndexHtml(html) {
@@ -38,7 +61,7 @@ function sriPlugin(): Plugin {
           /<script ([^>]*?)src="([^"]+)"([^>]*?)>/g,
           (_match, before, src, after) => {
             const fileName = src.replace(/^\//, "");
-            const integrity = assetHashes.get(fileName);
+            const integrity = resolveIntegrity(fileName);
             if (!integrity) return _match;
             return `<script ${stripCrossorigin(before)}src="${src}" integrity="${integrity}" crossorigin="anonymous"${stripCrossorigin(after)}>`;
           },
@@ -80,6 +103,9 @@ const enableSentryPlugin =
 
 // https://vite.dev/config/
 export default defineConfig({
+  server: {
+    headers: SECURITY_HEADERS,
+  },
   resolve: {
     dedupe: ["@babylonlabs-io/core-ui", "react", "react-dom"],
     alias: {

--- a/services/vault/vite.config.ts
+++ b/services/vault/vite.config.ts
@@ -1,13 +1,12 @@
 import { sentryVitePlugin } from "@sentry/vite-plugin";
 import react from "@vitejs/plugin-react";
-import { createHash } from "node:crypto";
-import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { defineConfig, type Plugin } from "vite";
+import { defineConfig } from "vite";
 import EnvironmentPlugin from "vite-plugin-environment";
 import { nodePolyfills } from "vite-plugin-node-polyfills";
 import tsconfigPaths from "vite-tsconfig-paths";
+import { sriPlugin } from "./src/build/sriPlugin";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -19,76 +18,6 @@ const SECURITY_HEADERS = {
   "Referrer-Policy": "strict-origin-when-cross-origin",
   "Permissions-Policy": "camera=(), microphone=(), geolocation=()",
 };
-
-const SRI_HASH_PREFIX = "sha384-";
-const PUBLIC_DIR = resolve(__dirname, "public");
-
-function computeSriHash(content: Buffer): string {
-  return `${SRI_HASH_PREFIX}${createHash("sha384").update(content).digest("base64")}`;
-}
-
-function stripCrossorigin(attrs: string): string {
-  return attrs.replace(/\s*crossorigin(?:="[^"]*")?/g, "");
-}
-
-function sriPlugin(): Plugin {
-  const assetHashes = new Map<string, string>();
-  // Static assets served from `public/` are copied verbatim and never enter the
-  // Rollup bundle, so hash them on demand from disk when referenced in the HTML.
-  function resolveIntegrity(fileName: string): string | undefined {
-    const bundled = assetHashes.get(fileName);
-    if (bundled) return bundled;
-    try {
-      return computeSriHash(readFileSync(resolve(PUBLIC_DIR, fileName)));
-    } catch {
-      return undefined;
-    }
-  }
-  return {
-    name: "sri",
-    apply: "build",
-    generateBundle(_options, bundle) {
-      for (const [fileName, chunk] of Object.entries(bundle)) {
-        const content = chunk.type === "chunk" ? chunk.code : chunk.source;
-        const contentBuffer =
-          typeof content === "string" ? Buffer.from(content) : content;
-        assetHashes.set(fileName, computeSriHash(contentBuffer));
-      }
-    },
-    transformIndexHtml(html) {
-      const patched = html
-        .replace(
-          /<script ([^>]*?)src="([^"]+)"([^>]*?)>/g,
-          (_match, before, src, after) => {
-            const fileName = src.replace(/^\//, "");
-            const integrity = resolveIntegrity(fileName);
-            if (!integrity) return _match;
-            return `<script ${stripCrossorigin(before)}src="${src}" integrity="${integrity}" crossorigin="anonymous"${stripCrossorigin(after)}>`;
-          },
-        )
-        .replace(
-          /<link ([^>]*?)href="([^"]+\.js)"([^>]*?)>/g,
-          (_match, before, href, after) => {
-            const fileName = href.replace(/^\//, "");
-            const integrity = assetHashes.get(fileName);
-            if (!integrity) return _match;
-            return `<link ${stripCrossorigin(before)}href="${href}" integrity="${integrity}" crossorigin="anonymous"${stripCrossorigin(after)}>`;
-          },
-        );
-
-      const unprotected = [
-        ...patched.matchAll(/<script [^>]*?src="(\/[^"]+\.js)"[^>]*>/g),
-      ].filter((m) => !m[0].includes(`integrity="${SRI_HASH_PREFIX}`));
-      if (unprotected.length > 0) {
-        throw new Error(
-          `SRI plugin: ${unprotected.length} local JS script(s) missing integrity attribute: ${unprotected.map((m) => m[1]).join(", ")}`,
-        );
-      }
-
-      return patched;
-    },
-  };
-}
 
 const isSentryDisabled =
   process.env.NEXT_BUILD_E2E || process.env.DISABLE_SENTRY === "true";

--- a/services/vault/vite.config.ts
+++ b/services/vault/vite.config.ts
@@ -10,9 +10,14 @@ import { sriPlugin } from "./src/build/sriPlugin";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
+// Dev/preview-server response headers only. The Content-Security-Policy is deliberately NOT
+// set here: it lives solely in the index.html <meta> tag (the single source of truth that
+// also ships to the static S3/CDN prod build). Delivering the same CSP as a dev-server header
+// additionally governs the inline React Fast Refresh preamble that @vitejs/plugin-react
+// injects, which has no 'unsafe-inline'/nonce and would white-screen `pnpm dev`. The meta CSP
+// does not govern that preamble because Vite injects it above the meta tag, and a meta policy
+// only applies to content that follows it.
 const SECURITY_HEADERS = {
-  "Content-Security-Policy":
-    "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; connect-src 'self' https: http: wss: ws:; img-src 'self' data: https: blob:; style-src 'self' 'unsafe-inline'; font-src 'self' data: https:; object-src 'none'; base-uri 'self'; worker-src 'self' blob:;",
   "X-Content-Type-Options": "nosniff",
   "X-Frame-Options": "DENY",
   "Referrer-Policy": "strict-origin-when-cross-origin",


### PR DESCRIPTION
## What

Adds a Content-Security-Policy meta tag, Subresource Integrity on the built entry scripts, and dev/preview-server response headers to the Vite-based vault app, and eliminates the one inline script that was blocking a strict CSP.

**Changes:**
- `index.html` — adds a `Content-Security-Policy` meta tag (`wasm-unsafe-eval` for WASM, `worker-src 'self' blob:` for Sentry Replay's worker, `frame-src` for the WalletConnect/AppKit verify + secure iframes, `http:`/`ws:` in `connect-src` for local and e2e), plus `Referrer-Policy`
- `public/process-polyfill.js` — extracts the `window.process` polyfill from an inline `<script>` into a static file so no inline scripts remain
- `src/build/sriPlugin.ts` — build plugin that adds Subresource Integrity (`integrity` + `crossorigin`) to every local entry script / module-preload in the built `index.html`, hashing the bytes Vite writes to disk, and **fails the build** if any local JS is left unprotected
- `vite.config.ts` — adds dev/preview-server `SECURITY_HEADERS` (`X-Frame-Options: DENY`, `X-Content-Type-Options`, `Referrer-Policy`, `Permissions-Policy`) and wires the SRI plugin. The CSP is **not** duplicated here — the `index.html` meta tag is the single source of truth (a header CSP would also govern React Fast Refresh's inline preamble and white-screen `pnpm dev`)
- `eslint.config.js` — excludes `public/` from linting (static assets are not TypeScript)

## What this PR protects in production vs. not

The vault app is built to static files, archived, and uploaded to S3, then served by a CDN (see `service-release-vault.yml`). There is **no application server in production** — so only protections baked into the bundle reach real users:

| Protection | Reaches production? | How |
| --- | --- | --- |
| Content-Security-Policy | ✅ Yes | `<meta>` tag in `index.html` (ships in the bundle) |
| Referrer-Policy | ✅ Yes | `<meta name="referrer">` in `index.html` |
| `X-Frame-Options: DENY` | ❌ No | only sent by the Vite dev/preview server |
| `X-Content-Type-Options: nosniff` | ❌ No | header-only; `<meta http-equiv>` form is a spec no-op |
| `Permissions-Policy` | ❌ No | only sent by the Vite dev/preview server |
| CSP `frame-ancestors` | ❌ No | header-only; ignored when delivered via `<meta>` |

The `SECURITY_HEADERS` block in `vite.config.ts` applies **only to the Vite dev/preview server** and is there to keep local development consistent — it never reaches deployed users. The meta-tag CSP is the only header-equivalent this PR delivers to production.

## Follow-up required (separate, infra) — production HTTP headers

The header-only protections above must be configured at the **serving/CDN layer** (CloudFront response-headers policy, or nginx if fronted by it), which lives outside this repo. This is the change that actually closes clickjacking + MIME-sniffing in production:

- [ ] Add a CloudFront **Response Headers Policy** (or nginx `add_header`) on the vault distribution with:
  - `Content-Security-Policy` — same policy as the meta tag, **plus** `frame-ancestors 'none'` (only enforceable as a header)
  - `X-Frame-Options: DENY`
  - `X-Content-Type-Options: nosniff`
  - `Referrer-Policy: strict-origin-when-cross-origin`
  - `Permissions-Policy: camera=(), microphone=(), geolocation=()`
- [ ] Once the header-delivered CSP is in place, treat the CDN policy as the source of truth and keep the `index.html` meta CSP in sync (or drop the meta copy to avoid drift).

This PR is intentionally scoped to the frontend bundle; the infra change is tracked as the follow-up above.

## Why

Addresses **TBV Security Report §3.6** ("Public Endpoint, Metadata, Auth, or Network Boundary Fails") — specifically the risk that overly permissive content policies allow injected scripts to exfiltrate wallet state or redirect signing flows. Also relates to **§1.7** ("Key, Metadata, Endpoint, or Authority Compromise") — an XSS vector in a DeFi app that handles wallet signing is a direct path to key leakage or manipulated ACK submissions.

Specific mitigations this PR establishes (all production-effective via the meta CSP):
- No `unsafe-inline` — injected inline scripts are blocked by the browser
- `object-src: none` — closes the Flash/plugin attack surface
- `wasm-unsafe-eval` — explicitly scoped to allow the WASM module without opening `unsafe-eval` broadly
- `worker-src 'self' blob:` — allows Sentry Replay's compression worker without a wildcard
- `frame-src` pinned to the WalletConnect/AppKit `verify` + `secure` hosts — allows the anti-phishing Verify attestation and email/social-login iframe without a wildcard, per Reown's CSP guidance
- **Subresource Integrity** on the entry scripts — a tampered entry bundle (e.g. an S3/CDN compromise) is rejected by the browser

Note: `Permissions-Policy` (restricting camera/mic/geolocation) is dev/preview-only until the infra follow-up lands.

## Out of scope
- **SRI now covers** the built `index.html` entry script and module-preload links (via `sriPlugin`). Runtime-loaded dynamic route chunks and the WASM module are not referenced from `index.html`, so they fall outside this HTML-based SRI — that remains follow-up (see PR #1862).

## Test plan
- [ ] `pnpm --filter vault run dev` — check browser DevTools Network tab for response headers on the dev server
- [ ] `pnpm --filter vault run build` — verify `dist/index.html` contains the CSP meta tag and `<script src="/process-polyfill.js">` with no inline scripts
- [ ] Open the app in browser, confirm no CSP violations in the console
- [ ] Confirm e2e / local HTTP endpoints are not blocked by the updated `connect-src`

