### PR TITLE
feat(vault): add subresource integrity hashes to built script assets

### DIFF
--- a/services/vault/vite.config.ts
+++ b/services/vault/vite.config.ts
@@ -1,13 +1,54 @@
 import { sentryVitePlugin } from "@sentry/vite-plugin";
 import react from "@vitejs/plugin-react";
+import { createHash } from "node:crypto";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { defineConfig } from "vite";
+import { defineConfig, type Plugin } from "vite";
 import EnvironmentPlugin from "vite-plugin-environment";
 import { nodePolyfills } from "vite-plugin-node-polyfills";
 import tsconfigPaths from "vite-tsconfig-paths";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function sriPlugin(): Plugin {
+  const assetHashes = new Map<string, string>();
+  return {
+    name: "sri",
+    apply: "build",
+    generateBundle(_options, bundle) {
+      for (const [fileName, chunk] of Object.entries(bundle)) {
+        const content = chunk.type === "chunk" ? chunk.code : chunk.source;
+        const contentBuffer =
+          typeof content === "string" ? Buffer.from(content) : content;
+        const hash = createHash("sha384")
+          .update(contentBuffer)
+          .digest("base64");
+        assetHashes.set(fileName, `sha384-${hash}`);
+      }
+    },
+    transformIndexHtml(html) {
+      return html
+        .replace(
+          /<script ([^>]*?)src="([^"]+)"([^>]*?)>/g,
+          (_match, before, src, after) => {
+            const fileName = src.replace(/^\//, "");
+            const integrity = assetHashes.get(fileName);
+            if (!integrity) return _match;
+            return `<script ${before}src="${src}" integrity="${integrity}" crossorigin="anonymous"${after}>`;
+          },
+        )
+        .replace(
+          /<link ([^>]*?)href="([^"]+\.js)"([^>]*?)>/g,
+          (_match, before, href, after) => {
+            const fileName = href.replace(/^\//, "");
+            const integrity = assetHashes.get(fileName);
+            if (!integrity) return _match;
+            return `<link ${before}href="${href}" integrity="${integrity}" crossorigin="anonymous"${after}>`;
+          },
+        );
+    },
+  };
+}
 
 const isSentryDisabled =
   process.env.NEXT_BUILD_E2E || process.env.DISABLE_SENTRY === "true";
@@ -52,6 +93,7 @@ export default defineConfig({
     },
   },
   plugins: [
+    sriPlugin(),
     react(),
     tsconfigPaths({
       projects: [resolve(__dirname, "./tsconfig.lib.json")],

--- a/services/vault/vite.config.ts
+++ b/services/vault/vite.config.ts
@@ -10,6 +10,12 @@ import tsconfigPaths from "vite-tsconfig-paths";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
+const SRI_HASH_PREFIX = "sha384-";
+
+function stripCrossorigin(attrs: string): string {
+  return attrs.replace(/\s*crossorigin(?:="[^"]*")?/g, "");
+}
+
 function sriPlugin(): Plugin {
   const assetHashes = new Map<string, string>();
   return {
@@ -23,18 +29,18 @@ function sriPlugin(): Plugin {
         const hash = createHash("sha384")
           .update(contentBuffer)
           .digest("base64");
-        assetHashes.set(fileName, `sha384-${hash}`);
+        assetHashes.set(fileName, `${SRI_HASH_PREFIX}${hash}`);
       }
     },
     transformIndexHtml(html) {
-      return html
+      const patched = html
         .replace(
           /<script ([^>]*?)src="([^"]+)"([^>]*?)>/g,
           (_match, before, src, after) => {
             const fileName = src.replace(/^\//, "");
             const integrity = assetHashes.get(fileName);
             if (!integrity) return _match;
-            return `<script ${before}src="${src}" integrity="${integrity}" crossorigin="anonymous"${after}>`;
+            return `<script ${stripCrossorigin(before)}src="${src}" integrity="${integrity}" crossorigin="anonymous"${stripCrossorigin(after)}>`;
           },
         )
         .replace(
@@ -43,9 +49,20 @@ function sriPlugin(): Plugin {
             const fileName = href.replace(/^\//, "");
             const integrity = assetHashes.get(fileName);
             if (!integrity) return _match;
-            return `<link ${before}href="${href}" integrity="${integrity}" crossorigin="anonymous"${after}>`;
+            return `<link ${stripCrossorigin(before)}href="${href}" integrity="${integrity}" crossorigin="anonymous"${stripCrossorigin(after)}>`;
           },
         );
+
+      const unprotected = [
+        ...patched.matchAll(/<script [^>]*?src="(\/[^"]+\.js)"[^>]*>/g),
+      ].filter((m) => !m[0].includes(`integrity="${SRI_HASH_PREFIX}`));
+      if (unprotected.length > 0) {
+        throw new Error(
+          `SRI plugin: ${unprotected.length} local JS script(s) missing integrity attribute: ${unprotected.map((m) => m[1]).join(", ")}`,
+        );
+      }
+
+      return patched;
     },
   };
 }


### PR DESCRIPTION
## What

Adds a Vite build plugin that computes SHA-384 hashes of output chunks and injects `integrity` and `crossorigin="anonymous"` attributes into the emitted `index.html`.

**Changed:** `vite.config.ts` — adds `sriPlugin()` (runs only during `build`, not `dev`)

## Coverage — what this actually protects

SRI delivered through HTML attributes can only cover tags that exist in `index.html`. That is a **structural limit of the mechanism**, not a TODO:

| Asset | Protected? | Why |
| --- | --- | --- |
| Entry chunk (`<script type="module">`) | ✅ Yes | referenced in `index.html` |
| Eager `modulepreload` links | ✅ Yes | referenced in `index.html` |
| Lazy route chunks (`import()` via `__vitePreload`) | ❌ No | loaded by native `import()` at runtime; the browser provides no way to attach `integrity` to a dynamic module import |
| WASM module (`instantiate`/`fetch`) | ❌ No | fetched as a binary, not a `<script>`; no integrity attribute exists for it |

The unprotected set is the larger one, and it includes the **lazy-loaded deposit/signing UI** — i.e. the code the §1.7 threat (patched JS → PSBT exfiltration) cares about most. This PR protects the app shell and fails the build loud if that protection regresses; it does **not** protect the signing-path chunks. See the follow-up below for the control that does.

## Before merge — required verification

- [ ] **Build with Sentry enabled (`SENTRY_AUTH_TOKEN` set) and confirm `dist/index.html` hashes still validate in a browser.** This is the one way this PR could ship a broken prod: hashes are computed in `generateBundle`, so if the Sentry plugin mutates chunk bytes *after* that hook, every script fails SRI in production → blank app. Sentry is expected to inject debug IDs in `renderChunk` (before `generateBundle`), so this should be fine — but it must be confirmed on a real Sentry build before merging.
- [x] Production `base` is the default `/` (verified — no override in `vite.config.ts` or the release workflow), so the plugin's leading-slash path matching does not silently no-op in prod.

## Follow-up — the complete tamper-detection control (infra)

HTML SRI cannot cover lazy chunks or WASM. The deploy pipeline **already produces a per-file `sha256` manifest of the entire `dist/`** (`*-files-checksum.txt`, uploaded to the checksum bucket in `service-release-vault.yml`). The complete defense against a compromised CDN / patched static hosting is to **verify that manifest at the serving/edge layer (or on tarball extract)** — that covers every file, including the signing-path chunks and the WASM binary that attribute-SRI can't reach.

- [ ] Verify the existing `sha256` checksum manifest at the edge / on deploy, covering all assets (tracked as infra, outside this repo).

## Why

Addresses **TBV Security Report §3.6** ("Public Endpoint, Metadata, Auth, or Network Boundary Fails") — the supply-chain scenario where a compromised CDN, storage-bucket MITM, or patched static hosting silently delivers modified JavaScript. Also relates to **§1.7** ("Key, Metadata, Endpoint, or Authority Compromise") — for a wallet-signing DeFi app, patched JS is a direct path to signed-PSBT exfiltration or fund redirection.

With `integrity` attributes in place, the browser refuses to execute any **entry/preload** script whose content does not match the hash baked into the HTML at build time. Treat this PR as a scoped first layer (the shell), complemented by the infra manifest follow-up (everything else).

## Implementation notes

- **Plugin ordering:** `sriPlugin()` is listed first so its `generateBundle` hook populates `assetHashes` before Vite's internal `build-html` plugin runs `transformIndexHtml`. It must also run before any plugin that mutates chunk bytes after hashing — which is the substance of the Sentry verification above.
- **Fail-loud:** the build throws if any local `<script src="/…js">` in `index.html` ends up without an `integrity` attribute, so a future refactor can't silently drop entry-script protection. (Note: this guard covers `index.html` scripts only — it does not and cannot assert coverage of the lazy chunks above.)

## Test plan
- [ ] `pnpm --filter vault run build` — inspect `dist/index.html` and confirm `<script>` tags have `integrity="sha384-..."` and `crossorigin="anonymous"`
- [ ] Manually corrupt a byte in a built JS file and confirm the browser console shows an SRI integrity error and refuses to load the script
- [ ] Sentry-enabled build verification (see "Before merge" above)
