### PR TITLE
fix(vault): surface error when cap polling data goes stale

### DIFF
--- a/services/vault/src/hooks/__tests__/useApplicationCap.test.tsx
+++ b/services/vault/src/hooks/__tests__/useApplicationCap.test.tsx
@@ -1,7 +1,10 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mirrors CAP_MAX_STALE_AGE_MS (3 * 60s refetch interval) in the hook.
+const MAX_STALE_AGE_MS = 3 * 60_000;
 
 vi.mock("@/config/contracts", () => ({
   CONTRACTS: {
@@ -41,6 +44,10 @@ function buildWrapper() {
 beforeEach(() => {
   vi.clearAllMocks();
   featureFlagsMock.isVaultCapDisabled = false;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 describe("useApplicationCap", () => {
@@ -169,5 +176,112 @@ describe("useApplicationCap", () => {
     expect(result.current.error).toBeNull();
     expect(getApplicationCap).not.toHaveBeenCalled();
     expect(getApplicationUsage).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a stale error once cap data ages past the max stale age, even while a refetch is in flight", async () => {
+    // First read resolves; every later refetch hangs, so `dataUpdatedAt`
+    // freezes and `isFetching` stays true — the exact silent-RPC case.
+    let capCalls = 0;
+    vi.mocked(getApplicationCap).mockImplementation(() => {
+      capCalls += 1;
+      return capCalls === 1
+        ? Promise.resolve({ totalCapBTC: 1000n, perAddressCapBTC: 0n })
+        : new Promise(() => {});
+    });
+    vi.mocked(getApplicationUsage).mockResolvedValue({
+      totalBTC: 200n,
+      userBTC: null,
+    });
+
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const { result } = renderHook(() => useApplicationCap(), {
+      wrapper: buildWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.snapshot).not.toBeNull());
+    expect(result.current.error).toBeNull();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(MAX_STALE_AGE_MS + 1);
+    });
+    expect(result.current.error).not.toBeNull();
+    expect(result.current.error?.message).toContain("stale");
+  });
+
+  it("keeps error null while cap data refreshes within the max stale age", async () => {
+    vi.mocked(getApplicationCap).mockResolvedValue({
+      totalCapBTC: 1000n,
+      perAddressCapBTC: 0n,
+    });
+    vi.mocked(getApplicationUsage).mockResolvedValue({
+      totalBTC: 200n,
+      userBTC: null,
+    });
+
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const { result } = renderHook(() => useApplicationCap(), {
+      wrapper: buildWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.snapshot).not.toBeNull());
+
+    // Polling keeps succeeding, so `dataUpdatedAt` advances and the staleness
+    // timer never trips even well past the threshold.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(MAX_STALE_AGE_MS * 2);
+    });
+    expect(result.current.error).toBeNull();
+  });
+
+  it("does not flag stale before the first successful fetch", async () => {
+    vi.mocked(getApplicationCap).mockImplementation(
+      () => new Promise(() => {}),
+    );
+    vi.mocked(getApplicationUsage).mockImplementation(
+      () => new Promise(() => {}),
+    );
+
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const { result } = renderHook(() => useApplicationCap(), {
+      wrapper: buildWrapper(),
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(MAX_STALE_AGE_MS + 1);
+    });
+    expect(result.current.snapshot).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it("suppresses usage staleness on an uncapped deployment", async () => {
+    // Caps keep resolving (never stale); usage resolves once then hangs.
+    vi.mocked(getApplicationCap).mockResolvedValue({
+      totalCapBTC: 0n,
+      perAddressCapBTC: 0n,
+    });
+    let usageCalls = 0;
+    vi.mocked(getApplicationUsage).mockImplementation(() => {
+      usageCalls += 1;
+      return usageCalls === 1
+        ? Promise.resolve({ totalBTC: 12_345n, userBTC: null })
+        : new Promise(() => {});
+    });
+
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const { result } = renderHook(() => useApplicationCap(), {
+      wrapper: buildWrapper(),
+    });
+
+    await waitFor(() =>
+      expect(result.current.snapshot).toMatchObject({
+        hasTotalCap: false,
+        totalBTC: 12_345n,
+      }),
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(MAX_STALE_AGE_MS + 1);
+    });
+    expect(result.current.error).toBeNull();
   });
 });

--- a/services/vault/src/hooks/useApplicationCap.ts
+++ b/services/vault/src/hooks/useApplicationCap.ts
@@ -10,7 +10,7 @@
  */
 
 import { useQuery } from "@tanstack/react-query";
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import type { Address } from "viem";
 
 import {
@@ -26,11 +26,44 @@ const CAP_REFETCH_INTERVAL_MS = 60_000;
 const CAP_STALE_TIME_MS = 30_000;
 const CAP_MAX_STALE_AGE_MS = 3 * CAP_REFETCH_INTERVAL_MS;
 
+// Stable sentinel so the public `error` reference does not churn on every
+// render while stale — a consumer placing it in a dependency array must not
+// see a fresh object each render.
+const CAP_STALE_ERROR = new Error("Cap data is stale — RPC may be unavailable");
+
 export interface UseApplicationCapResult {
   snapshot: CapSnapshot | null;
   isLoading: boolean;
   error: Error | null;
   refetch: () => void;
+}
+
+/**
+ * Flips to `true` once `dataUpdatedAt` is older than `CAP_MAX_STALE_AGE_MS`,
+ * driven by a timer rather than render timing so the boundary is crossed even
+ * when polling stops producing renders. Resets to `false` only when
+ * `dataUpdatedAt` advances (a successful fetch), never merely because a fetch
+ * is in flight — keeping the gate fail-closed across refetch attempts.
+ */
+function useStaleAfterMaxAge(dataUpdatedAt: number, active: boolean): boolean {
+  const [isStale, setIsStale] = useState(false);
+
+  useEffect(() => {
+    if (!active || dataUpdatedAt === 0) {
+      setIsStale(false);
+      return;
+    }
+    const remaining = dataUpdatedAt + CAP_MAX_STALE_AGE_MS - Date.now();
+    if (remaining <= 0) {
+      setIsStale(true);
+      return;
+    }
+    setIsStale(false);
+    const timer = setTimeout(() => setIsStale(true), remaining);
+    return () => clearTimeout(timer);
+  }, [dataUpdatedAt, active]);
+
+  return isStale;
 }
 
 export function useApplicationCap(user?: string): UseApplicationCapResult {
@@ -45,6 +78,10 @@ export function useApplicationCap(user?: string): UseApplicationCapResult {
     staleTime: CAP_STALE_TIME_MS,
     refetchInterval: CAP_REFETCH_INTERVAL_MS,
     refetchOnWindowFocus: false,
+    // Surface a real error when offline instead of silently pausing refetches
+    // and serving cached cap data — the stale timer is the backstop, this is
+    // the direct signal. Matches useERC20Balance / useAaveUserPosition.
+    networkMode: "always",
     enabled,
   });
 
@@ -66,6 +103,7 @@ export function useApplicationCap(user?: string): UseApplicationCapResult {
     staleTime: CAP_STALE_TIME_MS,
     refetchInterval: CAP_REFETCH_INTERVAL_MS,
     refetchOnWindowFocus: false,
+    networkMode: "always",
     enabled: enabled && capsResolved,
   });
 
@@ -114,22 +152,13 @@ export function useApplicationCap(user?: string): UseApplicationCapResult {
   const uncappedSnapshot =
     snapshot !== null && !snapshot.hasTotalCap && !snapshot.hasPerAddressCap;
 
-  const now = Date.now();
-  const capsStale =
-    enabled &&
-    capsQuery.dataUpdatedAt > 0 &&
-    now - capsQuery.dataUpdatedAt > CAP_MAX_STALE_AGE_MS &&
-    !capsQuery.isFetching;
-  const usageStale =
-    enabled &&
-    !uncappedSnapshot &&
-    usageQuery.dataUpdatedAt > 0 &&
-    now - usageQuery.dataUpdatedAt > CAP_MAX_STALE_AGE_MS &&
-    !usageQuery.isFetching;
+  // Timer-driven so the staleness boundary trips even when polling stops
+  // producing renders. Usage staleness is suppressed on the uncapped path for
+  // the same reason its error is shielded below — it must not block deposits.
+  const capsStale = useStaleAfterMaxAge(capsQuery.dataUpdatedAt, enabled);
+  const usageStale = useStaleAfterMaxAge(usageQuery.dataUpdatedAt, enabled);
   const staleError =
-    capsStale || usageStale
-      ? new Error("Cap data is stale — RPC may be unavailable")
-      : null;
+    capsStale || (usageStale && !uncappedSnapshot) ? CAP_STALE_ERROR : null;
 
   const baseError = (
     uncappedSnapshot ? capsQuery.error : (capsQuery.error ?? usageQuery.error)

--- a/services/vault/src/hooks/useApplicationCap.ts
+++ b/services/vault/src/hooks/useApplicationCap.ts
@@ -24,6 +24,7 @@ import { computeCapSnapshot, type CapSnapshot } from "@/services/deposit";
 const APPLICATION_CAP_KEY = "applicationCap";
 const CAP_REFETCH_INTERVAL_MS = 60_000;
 const CAP_STALE_TIME_MS = 30_000;
+const CAP_MAX_STALE_AGE_MS = 3 * CAP_REFETCH_INTERVAL_MS;
 
 export interface UseApplicationCapResult {
   snapshot: CapSnapshot | null;
@@ -113,14 +114,33 @@ export function useApplicationCap(user?: string): UseApplicationCapResult {
   const uncappedSnapshot =
     snapshot !== null && !snapshot.hasTotalCap && !snapshot.hasPerAddressCap;
 
+  const now = Date.now();
+  const capsStale =
+    enabled &&
+    capsQuery.dataUpdatedAt > 0 &&
+    now - capsQuery.dataUpdatedAt > CAP_MAX_STALE_AGE_MS &&
+    !capsQuery.isFetching;
+  const usageStale =
+    enabled &&
+    !uncappedSnapshot &&
+    usageQuery.dataUpdatedAt > 0 &&
+    now - usageQuery.dataUpdatedAt > CAP_MAX_STALE_AGE_MS &&
+    !usageQuery.isFetching;
+  const staleError =
+    capsStale || usageStale
+      ? new Error("Cap data is stale — RPC may be unavailable")
+      : null;
+
+  const baseError = (
+    uncappedSnapshot ? capsQuery.error : (capsQuery.error ?? usageQuery.error)
+  ) as Error | null;
+
   return {
     snapshot,
     isLoading: uncappedSnapshot
       ? capsQuery.isLoading
       : capsQuery.isLoading || usageQuery.isLoading,
-    error: (uncappedSnapshot
-      ? capsQuery.error
-      : (capsQuery.error ?? usageQuery.error)) as Error | null,
+    error: staleError ?? baseError,
     refetch,
   };
 }


### PR DESCRIPTION
## What

Adds a dead man's switch to \`useApplicationCap\`: if cap data has not been refreshed within 3 minutes and the query is not actively fetching, the hook surfaces an error instead of silently serving stale data.

**Changed:** \`src/hooks/useApplicationCap.ts\`
- Adds \`CAP_MAX_STALE_AGE_MS = 3 * CAP_REFETCH_INTERVAL_MS\` (3 minutes)
- After each render, checks \`dataUpdatedAt\` on both the caps and usage queries
- If either is stale and not fetching, returns \`Error("Cap data is stale — RPC may be unavailable")\` as the \`error\` field

## Why

Addresses **TBV Security Report §3.4** ("Bitcoin, Ethereum, or Beacon RPC Source Fails") — "Ethereum execution RPC misses events, returns stale logs, follows the wrong finality level." Also relates to **§4.5** ("Parameter Defenses") — "Conservative supply caps on Ethereum" — and **§1.4** ("Invalid or Unbacked Vault Becomes Active") — an operator emergency-lowering the cap in response to an incident must not be silently ignored by depositors who are seeing a stale cached value.

The cap is polled every 60 seconds. If the RPC endpoint goes down silently (no error thrown, query stops retrying), the app continues serving the last known cap value indefinitely. The \`error\` returned by \`useApplicationCap\` sets \`capUnavailable: true\` in the deposit form, which already hard-rejects all deposit attempts. This change ensures a silent RPC failure eventually trips that gate.

**Timing note:** The 3-minute threshold trips approximately 3 refetch cycles after the last successful fetch (since \`dataUpdatedAt\` only advances on a successful response, not on a retry attempt). This gives the query two full missed-cycle intervals before the third cycle's absence triggers the error.

**Known limitation:** The stale check is render-driven — it re-evaluates on render, not on a dedicated timer. If polling stops producing state changes (e.g. a request that hangs indefinitely, keeping \`isFetching: true\`), the stale error may not fire until an unrelated re-render occurs. Adding a \`setTimeout\` keyed to \`dataUpdatedAt\` would make this timer-accurate; tracked as follow-up.

## Test plan
- [ ] Normal flow: cap loads, no stale error shown
- [ ] Simulate stale: disconnect network after initial load, wait 3+ minutes — confirm deposit CTA shows cap unavailable error
- [ ] Reconnect network: confirm stale error clears once the query refreshes successfully