### PR TITLE
fix(vault): validate ETH address and BTC pubkey fields from GraphQL responses

### DIFF
--- a/services/vault/src/services/applications/__tests__/fetchApplications.test.ts
+++ b/services/vault/src/services/applications/__tests__/fetchApplications.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { graphqlClient } from "../../../clients/graphql";
+import { fetchApplications } from "../fetchApplications";
+
+vi.mock("../../../clients/graphql", () => ({
+  graphqlClient: {
+    request: vi.fn(),
+  },
+}));
+
+vi.mock("@/infrastructure", () => ({
+  logger: { warn: vi.fn() },
+}));
+
+vi.mock("../../../applications", () => ({
+  getApplicationMetadataByController: vi.fn((id: string) => {
+    if (id === VALID_ETH_ADDR_WITH_METADATA) {
+      return {
+        name: "Test App",
+        type: "aave",
+        description: "A test app",
+        logoUrl: "https://example.com/logo.png",
+        websiteUrl: "https://example.com",
+      };
+    }
+    return undefined;
+  }),
+}));
+
+const mockRequest = vi.mocked(graphqlClient.request);
+
+const VALID_ETH_ADDR_WITH_METADATA = "0x" + "a".repeat(40);
+const VALID_ETH_ADDR_NO_METADATA = "0x" + "b".repeat(40);
+
+const BASE_APP = {
+  registeredAt: "2024-01-01T00:00:00Z",
+  blockNumber: "100",
+  transactionHash: "0x" + "f".repeat(64),
+};
+
+describe("fetchApplications", () => {
+  it("returns apps that have registry metadata", async () => {
+    mockRequest.mockResolvedValueOnce({
+      applications: {
+        items: [
+          { id: VALID_ETH_ADDR_WITH_METADATA, name: "Indexer Name", ...BASE_APP },
+        ],
+      },
+    });
+
+    const result = await fetchApplications();
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe(VALID_ETH_ADDR_WITH_METADATA);
+    expect(result[0].name).toBe("Indexer Name");
+  });
+
+  it("skips apps with no registry metadata", async () => {
+    mockRequest.mockResolvedValueOnce({
+      applications: {
+        items: [
+          { id: VALID_ETH_ADDR_NO_METADATA, name: null, ...BASE_APP },
+        ],
+      },
+    });
+
+    const result = await fetchApplications();
+
+    expect(result).toHaveLength(0);
+  });
+
+  it("skips an app with an invalid ETH address and warns", async () => {
+    mockRequest.mockResolvedValueOnce({
+      applications: {
+        items: [
+          { id: "not-an-address", name: null, ...BASE_APP },
+          { id: VALID_ETH_ADDR_WITH_METADATA, name: "Good App", ...BASE_APP },
+        ],
+      },
+    });
+
+    const { logger } = await import("@/infrastructure");
+    const result = await fetchApplications();
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe(VALID_ETH_ADDR_WITH_METADATA);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("invalid id"),
+    );
+  });
+
+  it("falls back to registry name when indexer name is null", async () => {
+    mockRequest.mockResolvedValueOnce({
+      applications: {
+        items: [
+          { id: VALID_ETH_ADDR_WITH_METADATA, name: null, ...BASE_APP },
+        ],
+      },
+    });
+
+    const result = await fetchApplications();
+
+    expect(result[0].name).toBe("Test App");
+  });
+});

--- a/services/vault/src/services/applications/fetchApplications.ts
+++ b/services/vault/src/services/applications/fetchApplications.ts
@@ -5,6 +5,7 @@ import { logger } from "@/infrastructure";
 import { getApplicationMetadataByController } from "../../applications";
 import { graphqlClient } from "../../clients/graphql";
 import type { Application } from "../../types/application";
+import { ETH_ADDRESS_PATTERN } from "../../utils/validation";
 
 /**
  * GraphQL response shape for applications query
@@ -49,6 +50,12 @@ export async function fetchApplications(): Promise<Application[]> {
 
   return data.applications.items
     .map((app): Application | null => {
+      if (!ETH_ADDRESS_PATTERN.test(app.id)) {
+        logger.warn(
+          `[fetchApplications] Skipping application with invalid id: "${String(app.id).slice(0, 20)}"`,
+        );
+        return null;
+      }
       const metadata = getApplicationMetadataByController(app.id);
       if (!metadata) {
         logger.warn(

--- a/services/vault/src/services/providers/__tests__/fetchUniversalChallengers.test.ts
+++ b/services/vault/src/services/providers/__tests__/fetchUniversalChallengers.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { graphqlClient } from "../../../clients/graphql";
+import { fetchAllUniversalChallengers } from "../fetchUniversalChallengers";
+
+vi.mock("../../../clients/graphql", () => ({
+  graphqlClient: {
+    request: vi.fn(),
+  },
+}));
+
+vi.mock("@/infrastructure", () => ({
+  logger: { warn: vi.fn() },
+}));
+
+const mockRequest = vi.mocked(graphqlClient.request);
+
+const VALID_ETH_ADDR_1 = "0x" + "a".repeat(40);
+const VALID_ETH_ADDR_2 = "0x" + "b".repeat(40);
+const VALID_BTC_PUBKEY_1 = "0x" + "d".repeat(64);
+const VALID_BTC_PUBKEY_2 = "0x" + "e".repeat(64);
+
+describe("fetchUniversalChallengers", () => {
+  describe("fetchAllUniversalChallengers", () => {
+    it("groups challengers by version and returns the latest version number", async () => {
+      mockRequest.mockResolvedValueOnce({
+        universalChallengerVersions: {
+          items: [
+            {
+              version: 1,
+              challengerInfo: { id: VALID_ETH_ADDR_1, btcPubKey: VALID_BTC_PUBKEY_1 },
+            },
+            {
+              version: 2,
+              challengerInfo: { id: VALID_ETH_ADDR_2, btcPubKey: VALID_BTC_PUBKEY_2 },
+            },
+            {
+              version: 2,
+              challengerInfo: { id: VALID_ETH_ADDR_1, btcPubKey: VALID_BTC_PUBKEY_1 },
+            },
+          ],
+        },
+      });
+
+      const result = await fetchAllUniversalChallengers();
+
+      expect(result.latestVersion).toBe(2);
+      expect(result.byVersion.get(1)).toHaveLength(1);
+      expect(result.byVersion.get(2)).toHaveLength(2);
+      expect(result.byVersion.get(1)?.[0]).toEqual({
+        id: VALID_ETH_ADDR_1,
+        btcPubKey: VALID_BTC_PUBKEY_1,
+      });
+    });
+
+    it("skips a challenger with an invalid ETH address and warns", async () => {
+      mockRequest.mockResolvedValueOnce({
+        universalChallengerVersions: {
+          items: [
+            {
+              version: 1,
+              challengerInfo: { id: "not-an-address", btcPubKey: VALID_BTC_PUBKEY_1 },
+            },
+            {
+              version: 1,
+              challengerInfo: { id: VALID_ETH_ADDR_1, btcPubKey: VALID_BTC_PUBKEY_1 },
+            },
+          ],
+        },
+      });
+
+      const { logger } = await import("@/infrastructure");
+      const result = await fetchAllUniversalChallengers();
+
+      expect(result.byVersion.get(1)).toHaveLength(1);
+      expect(result.byVersion.get(1)?.[0].id).toBe(VALID_ETH_ADDR_1);
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("invalid id"),
+      );
+    });
+
+    it("skips a challenger with an invalid BTC pubkey and warns", async () => {
+      mockRequest.mockResolvedValueOnce({
+        universalChallengerVersions: {
+          items: [
+            {
+              version: 1,
+              challengerInfo: { id: VALID_ETH_ADDR_1, btcPubKey: "not-a-pubkey" },
+            },
+            {
+              version: 1,
+              challengerInfo: { id: VALID_ETH_ADDR_2, btcPubKey: VALID_BTC_PUBKEY_2 },
+            },
+          ],
+        },
+      });
+
+      const { logger } = await import("@/infrastructure");
+      const result = await fetchAllUniversalChallengers();
+
+      expect(result.byVersion.get(1)).toHaveLength(1);
+      expect(result.byVersion.get(1)?.[0].btcPubKey).toBe(VALID_BTC_PUBKEY_2);
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("invalid btcPubKey"),
+      );
+    });
+
+    it("returns empty byVersion and latestVersion 0 when all items fail validation", async () => {
+      mockRequest.mockResolvedValueOnce({
+        universalChallengerVersions: {
+          items: [
+            { version: 1, challengerInfo: { id: "bad-addr", btcPubKey: "bad-key" } },
+          ],
+        },
+      });
+
+      const result = await fetchAllUniversalChallengers();
+
+      expect(result.byVersion.size).toBe(0);
+      expect(result.latestVersion).toBe(0);
+    });
+
+    it("returns empty byVersion and latestVersion 0 when items array is empty", async () => {
+      mockRequest.mockResolvedValueOnce({
+        universalChallengerVersions: { items: [] },
+      });
+
+      const result = await fetchAllUniversalChallengers();
+
+      expect(result.byVersion.size).toBe(0);
+      expect(result.latestVersion).toBe(0);
+    });
+  });
+});

--- a/services/vault/src/services/providers/fetchUniversalChallengers.ts
+++ b/services/vault/src/services/providers/fetchUniversalChallengers.ts
@@ -1,7 +1,13 @@
 import { gql } from "graphql-request";
 
+import { logger } from "@/infrastructure";
+
 import { graphqlClient } from "../../clients/graphql";
 import type { UniversalChallenger } from "../../types/vaultProvider";
+import {
+  BTC_PUBKEY_HEX_PATTERN,
+  ETH_ADDRESS_PATTERN,
+} from "../../utils/validation";
 
 /** GraphQL response for universal challengers query */
 interface GraphQLUniversalChallengersResponse {
@@ -30,6 +36,27 @@ const GET_UNIVERSAL_CHALLENGERS = gql`
   }
 `;
 
+type RawChallengerItem =
+  GraphQLUniversalChallengersResponse["universalChallengerVersions"]["items"][number];
+
+function validateChallengerItem(
+  item: RawChallengerItem,
+): RawChallengerItem | null {
+  if (!ETH_ADDRESS_PATTERN.test(item.challengerInfo.id)) {
+    logger.warn(
+      `[fetchUniversalChallengers] Skipping challenger with invalid id: "${String(item.challengerInfo.id).slice(0, 20)}"`,
+    );
+    return null;
+  }
+  if (!BTC_PUBKEY_HEX_PATTERN.test(item.challengerInfo.btcPubKey)) {
+    logger.warn(
+      `[fetchUniversalChallengers] Skipping challenger ${item.challengerInfo.id}: invalid btcPubKey format`,
+    );
+    return null;
+  }
+  return item;
+}
+
 /** Result from fetchAllUniversalChallengers */
 export interface UniversalChallengersData {
   /** All challengers grouped by version */
@@ -57,7 +84,10 @@ export async function fetchAllUniversalChallengers(): Promise<UniversalChallenge
       GET_UNIVERSAL_CHALLENGERS,
     );
 
-  const items = response.universalChallengerVersions.items;
+  const rawItems = response.universalChallengerVersions.items;
+  const items = rawItems
+    .map(validateChallengerItem)
+    .filter((item): item is RawChallengerItem => item !== null);
 
   if (items.length === 0) {
     return { byVersion: new Map(), latestVersion: 0 };


### PR DESCRIPTION
## What

Adds field-level validation to the two GraphQL queries that were previously missing it — universal challengers and applications — using the same patterns already applied to \`fetchProviders\` and \`fetchVaults\`.

**Changed:**
- \`src/services/providers/fetchUniversalChallengers.ts\` — validates \`challengerInfo.id\` against \`ETH_ADDRESS_PATTERN\` and \`challengerInfo.btcPubKey\` against \`BTC_PUBKEY_HEX_PATTERN\`; skips invalid items with \`logger.warn\`
- \`src/services/applications/fetchApplications.ts\` — validates \`app.id\` against \`ETH_ADDRESS_PATTERN\` before the registry lookup; skips invalid items with \`logger.warn\`

## Why

Addresses **TBV Security Report §1.3** ("Malicious Claimer Receives BTC") — "Challenger daemons lack the graph, BABE setup, challenger signatures, or proof verification data needed to challenge" — and **§1.8** ("Transaction Graph Is Invalid or Spendable Outside Intended Paths") — "Artifacts from different vaults, claimers, challengers, or BABE sessions are mixed."

Also relates to CLAUDE.md critical path §3 (presigning depositor-graph transactions): the depositor-graph signer asserts the VP-returned challenger set equals \`local ∪ universal\`. A corrupted universal-challenger set from an indexer bug or compromised GraphQL response would cause this assertion to throw at signing (fail-closed), but catching the corruption earlier provides a clearer error signal.

**Scope and defense-in-depth note:** This is a **fail-fast syntactic validation** at the indexer boundary, not the primary security control:
- Universal-challenger BTC keys are byte-cross-checked against on-chain data at deposit via \`validateOnChainParticipantKeys\`
- At presigning, \`vaultPayoutSignatureService\` re-sources challenger keys directly from chain
- A valid-format-but-semantically-wrong pubkey is caught by those on-chain checks, not here

This layer catches syntactically malformed data early (before it reaches signing), consistent with the existing pattern in \`fetchProviders.ts\` and \`fetchVaults.ts\`.

## Test plan
- [ ] App loads normally with valid indexer data
- [ ] Confirm \`logger.warn\` fires when a challenger or application with an invalid id is returned