### PR TITLE
feat(wallet): keystone additions

### DIFF
--- a/packages/babylon-wallet-connector/src/core/wallets/btc/keystone/connectedKeyPath.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/keystone/connectedKeyPath.ts
@@ -1,0 +1,12 @@
+/**
+ * The connected Keystone key is the first receive leaf of the Taproot account:
+ * `${accountPath}/0/0`. This leaf — not the bare account path — is the key used
+ * for the address, PSBT signing, and message signing, and it is the
+ * `connectedPubkey` the deriveContextHash spec binds into the HKDF `info`
+ * (docs/specs/derive-context-hash.md §2.2).
+ *
+ * Centralizing it here keeps the `/0/0` leaf invariant in one tested place so a
+ * refactor can't silently drop the suffix and regress to deriving against the
+ * account path.
+ */
+export const connectedLeafKeyPath = (accountPath: string): string => `${accountPath}/0/0`;

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/keystone/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/keystone/provider.ts
@@ -19,11 +19,7 @@ import {
   isValidContextHashOutput,
 } from "@/core/wallets/btc/keystone/contextHashOutput";
 import { signingProgressLabel } from "@/core/wallets/btc/keystone/signingProgress";
-import {
-  expectedTaprootCoinType,
-  findTaprootAccount,
-  getCoinType,
-} from "@/core/wallets/btc/keystone/taprootAccount";
+import { expectedTaprootCoinType, findTaprootAccount, getCoinType } from "@/core/wallets/btc/keystone/taprootAccount";
 import { ERROR_CODES, WalletError } from "@/error";
 
 import logo from "./logo.svg";
@@ -80,7 +76,7 @@ export class KeystoneProvider implements IBTCProvider {
         walletMode: "btc",
         link: "",
         description: [
-          `Requires Keystone firmware ${MIN_KEYSTONE_FIRMWARE_VERSION} or later for vault deposits.`,
+          `Requires Keystone firmware ${MIN_KEYSTONE_FIRMWARE_VERSION} or later.`,
           "1. Turn on your Keystone 3.",
           "2. Click connect software wallet and select Bitcoin Wallets.",
           '3. Press the "Sync Keystone" button and scan the QR Code displayed on your Keystone hardware wallet',

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/keystone/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/keystone/provider.ts
@@ -13,12 +13,17 @@ import { IBTCProvider, Network } from "@/core/types";
 import BIP322 from "@/core/utils/bip322";
 import { generateP2TRAddressFromXpub, toNetwork } from "@/core/utils/wallet";
 import { canonicalNetworkName } from "@/core/wallets/btc/keystone/canonicalNetworkName";
+import { connectedLeafKeyPath } from "@/core/wallets/btc/keystone/connectedKeyPath";
 import {
   CONTEXT_HASH_OUTPUT_HEX_LENGTH,
   isValidContextHashOutput,
 } from "@/core/wallets/btc/keystone/contextHashOutput";
 import { signingProgressLabel } from "@/core/wallets/btc/keystone/signingProgress";
-import { findTaprootAccount } from "@/core/wallets/btc/keystone/taprootAccount";
+import {
+  expectedTaprootCoinType,
+  findTaprootAccount,
+  getCoinType,
+} from "@/core/wallets/btc/keystone/taprootAccount";
 import { ERROR_CODES, WalletError } from "@/error";
 
 import logo from "./logo.svg";
@@ -33,6 +38,15 @@ type KeystoneWalletInfo = {
 };
 
 export const WALLET_PROVIDER_NAME = "Keystone";
+
+/**
+ * Minimum Keystone firmware that ships the `deriveContextHash` UR type (the
+ * firmware paired with keystone-sdk 0.12.x). The airgapped QR sync exposes no
+ * firmware/device version, so we cannot detect or gate it programmatically the
+ * way software wallets gate their injected version — it is surfaced as a hint in
+ * the connect dialog instead. Confirm the exact version with Keystone before release.
+ */
+const MIN_KEYSTONE_FIRMWARE_VERSION = "2.4.5";
 
 export class KeystoneProvider implements IBTCProvider {
   private keystoneWalletInfo: KeystoneWalletInfo | undefined;
@@ -66,6 +80,7 @@ export class KeystoneProvider implements IBTCProvider {
         walletMode: "btc",
         link: "",
         description: [
+          `Requires Keystone firmware ${MIN_KEYSTONE_FIRMWARE_VERSION} or later for vault deposits.`,
           "1. Turn on your Keystone 3.",
           "2. Click connect software wallet and select Bitcoin Wallets.",
           '3. Press the "Sync Keystone" button and scan the QR Code displayed on your Keystone hardware wallet',
@@ -102,8 +117,8 @@ export class KeystoneProvider implements IBTCProvider {
     // software wallets. For signet, the Keystone must run the separate BTC-only
     // firmware with Signet mode connection enabled (coin_type 1') to derive the
     // same key as software wallets like UniSat; otherwise the keys differ even
-    // for the same seed. This is intentionally not hard-enforced here (signet is
-    // dev-only).
+    // for the same seed. This is intentionally not hard-enforced (signet is
+    // dev-only) — a console warning below flags the mismatch.
     const taprootAccount = findTaprootAccount(accountData.keys);
 
     if (!taprootAccount?.extendedPublicKey)
@@ -114,6 +129,21 @@ export class KeystoneProvider implements IBTCProvider {
       });
 
     const xpub = taprootAccount.extendedPublicKey;
+
+    // Dev signal: if the device's exported coin_type doesn't match the app
+    // network (e.g. mainnet-firmware Keystone connected on signet), the derived
+    // keys won't match software wallets for the same seed and surface later as a
+    // confusing "different BTC public key" error. Only fires on a mismatch
+    // (never on a correct mainnet setup), so it's effectively signet/dev-only.
+    const exportedCoinType = getCoinType(taprootAccount.path);
+    const expectedCoinType = expectedTaprootCoinType(this.config.network);
+    if (exportedCoinType !== expectedCoinType) {
+      console.warn(
+        `[Keystone] exported coin_type ${exportedCoinType} but ${this.config.network} expects ` +
+          `${expectedCoinType}; derived keys will not match software wallets for the same seed. ` +
+          `Use a Keystone firmware/mode whose network matches the app.`,
+      );
+    }
 
     this.keystoneWalletInfo = {
       mfp: accountData.masterFingerprint,
@@ -259,7 +289,7 @@ export class KeystoneProvider implements IBTCProvider {
   };
 
   signMessageECDSA = async (message: string): Promise<string> => {
-    if (!this.keystoneWalletInfo?.address || !this.keystoneWalletInfo?.publicKeyHex) {
+    if (!this.keystoneWalletInfo?.address || !this.keystoneWalletInfo?.publicKeyHex || !this.keystoneWalletInfo?.path) {
       throw new WalletError({
         code: ERROR_CODES.WALLET_NOT_CONNECTED,
         message: "Keystone Wallet not connected",
@@ -273,7 +303,7 @@ export class KeystoneProvider implements IBTCProvider {
       dataType: KeystoneBitcoinSDK.DataType.message,
       accounts: [
         {
-          path: `${this.keystoneWalletInfo.path}/0/0`,
+          path: connectedLeafKeyPath(this.keystoneWalletInfo.path),
           xfp: `${this.keystoneWalletInfo.mfp}`,
           address: this.keystoneWalletInfo.address,
         },
@@ -372,7 +402,7 @@ export class KeystoneProvider implements IBTCProvider {
 
     const bip32Derivation = {
       masterFingerprint: Buffer.from(this.keystoneWalletInfo.mfp, "hex"),
-      path: `${this.keystoneWalletInfo.path}/0/0`,
+      path: connectedLeafKeyPath(this.keystoneWalletInfo.path),
       pubkey: Buffer.from(this.keystoneWalletInfo.publicKeyHex, "hex"),
     };
 
@@ -401,11 +431,10 @@ export class KeystoneProvider implements IBTCProvider {
       });
     }
 
-    // Bind the derivation to the exact connected key — the first Taproot leaf
-    // `${path}/0/0` that this provider uses for address generation, PSBT
-    // signing, and message signing. That leaf key is the `connectedPubkey` the
-    // spec injects into the HKDF `info` (docs/specs/derive-context-hash.md §2.2).
-    const keyPath = `${this.keystoneWalletInfo.path}/0/0`;
+    // Bind to the connected leaf key — the `connectedPubkey` the spec injects
+    // into the HKDF `info` (docs/specs/derive-context-hash.md §2.2). See
+    // connectedLeafKeyPath for why this must be the `/0/0` leaf, not the account path.
+    const keyPath = connectedLeafKeyPath(this.keystoneWalletInfo.path);
 
     const ur = this.dataSdk.generateDeriveContextHashCall({
       appName,

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/keystone/taprootAccount.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/keystone/taprootAccount.ts
@@ -1,5 +1,16 @@
+import { Network } from "@/core/types";
+
 /** BIP86 Taproot purpose (the first hardened component of `m/86'/…`). */
 const TAPROOT_PURPOSE = 86;
+
+/** BIP-44 coin_type the connected Keystone account should use per network (0 mainnet, 1 test/signet). */
+const TAPROOT_COIN_TYPE: Record<Network, number> = {
+  [Network.MAINNET]: 0,
+  [Network.TESTNET]: 1,
+  [Network.SIGNET]: 1,
+};
+
+export const expectedTaprootCoinType = (network: Network): number => TAPROOT_COIN_TYPE[network];
 
 /**
  * Rewrites the `h` hardened marker to the apostrophe form (`86h` → `86'`).
@@ -13,6 +24,9 @@ const TAPROOT_PURPOSE = 86;
 const normalizeHardenedPath = (path: string): string => path.replace(/h(?=\/|$)/g, "'");
 
 const purposeOf = (path: string): number => parseInt(normalizeHardenedPath(path).split("/")[1], 10);
+
+/** Parses the BIP-44 coin_type (third path component) from a derivation path, e.g. `m/86'/1'/0'` → 1. */
+export const getCoinType = (path: string): number => parseInt(normalizeHardenedPath(path).split("/")[2], 10);
 
 /**
  * Finds the Taproot (BIP86, purpose `86'`) account in a parsed Keystone export

--- a/packages/babylon-wallet-connector/tests/unit/keystoneCoinType.test.ts
+++ b/packages/babylon-wallet-connector/tests/unit/keystoneCoinType.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Unit tests for the Keystone coin_type helpers used to warn when the device's
+ * exported coin_type doesn't match the app network (the signet "different BTC
+ * public key" footgun).
+ */
+import { expect, test } from "@playwright/test";
+
+import { Network } from "../../src/core/types";
+import { expectedTaprootCoinType, getCoinType } from "../../src/core/wallets/btc/keystone/taprootAccount";
+
+test.describe("expectedTaprootCoinType — coin_type per app network", () => {
+  test("mainnet expects coin_type 0", () => {
+    expect(expectedTaprootCoinType(Network.MAINNET)).toBe(0);
+  });
+
+  test("testnet and signet expect coin_type 1", () => {
+    expect(expectedTaprootCoinType(Network.TESTNET)).toBe(1);
+    expect(expectedTaprootCoinType(Network.SIGNET)).toBe(1);
+  });
+});
+
+test.describe("getCoinType — parses coin_type from a derivation path", () => {
+  test("reads the coin_type component", () => {
+    expect(getCoinType("m/86'/0'/0'")).toBe(0);
+    expect(getCoinType("m/86'/1'/0'")).toBe(1);
+  });
+
+  test("tolerates the 'h' hardened marker", () => {
+    expect(getCoinType("m/86h/1h/0h")).toBe(1);
+  });
+});

--- a/packages/babylon-wallet-connector/tests/unit/keystoneConnectedKeyPath.test.ts
+++ b/packages/babylon-wallet-connector/tests/unit/keystoneConnectedKeyPath.test.ts
@@ -1,0 +1,24 @@
+/**
+ * Unit tests for the Keystone connected-leaf key path. This is the load-bearing
+ * value handed to deriveContextHash / signing: it MUST be the `/0/0` receive
+ * leaf, not the bare account path (using the account path was the bug fixed vs
+ * PR #1834). Pinning it here stops a refactor from silently dropping `/0/0`.
+ */
+import { expect, test } from "@playwright/test";
+
+import { connectedLeafKeyPath } from "../../src/core/wallets/btc/keystone/connectedKeyPath";
+
+test.describe("connectedLeafKeyPath — appends the /0/0 receive leaf", () => {
+  test("appends /0/0 to a mainnet Taproot account path", () => {
+    expect(connectedLeafKeyPath("m/86'/0'/0'")).toBe("m/86'/0'/0'/0/0");
+  });
+
+  test("appends /0/0 to a testnet/signet Taproot account path", () => {
+    expect(connectedLeafKeyPath("m/86'/1'/0'")).toBe("m/86'/1'/0'/0/0");
+  });
+
+  test("does not return the bare account path", () => {
+    const accountPath = "m/86'/0'/0'";
+    expect(connectedLeafKeyPath(accountPath)).not.toBe(accountPath);
+  });
+});


### PR DESCRIPTION
## What this PR does

Three small, non-blocking follow-ups from the review of the merged Keystone vault PR (https://github.com/babylonlabs-io/babylon-toolkit/pull/1837):

- Adds a minimum-firmware hint to the Keystone connect dialog, since we can't detect the device firmware version to gate on it.
- Extracts the "connected leaf key path" into a tested helper so a future refactor can't silently break the derivation.
- Adds a developer console warning when the Keystone-exported coin_type doesn't match the app's network (the confusing signet case).

## Why, and the approach for each

### 1. Firmware-version hint (instead of a hard version gate)

`deriveContextHash` only exists in newer Keystone firmware (the firmware paired with `@keystonehq/keystone-sdk` 0.12.x). The other two wallets that implement `deriveContextHash` (UniSat, OneKey) refuse to connect on old versions and show an "incompatible version" message up front. **We can't do the same for Keystone**: it's an air-gapped QR wallet, and the connection QR (the crypto-account sync) carries no firmware or device version — there is simply nothing to read. This was confirmed with Keystone's team, whose recommendation was to show a hint in the connect UI.

So instead of a programmatic gate, we add a line to the connect dialog — "Requires Keystone firmware 2.4.5 or later for vault deposits." — and keep the version in a named constant (`MIN_KEYSTONE_FIRMWARE_VERSION`) with a comment explaining why it can't be enforced in code. A user on older firmware will still fail when they reach the context-hash QR step, but now they have an up-front heads-up. (The exact minimum version should be confirmed with Keystone before merge.)

<img width="2032" height="1162" alt="Screenshot_2026-06-09_12-38-32" src="https://github.com/user-attachments/assets/9572f142-18b1-4eff-be74-e3e4f92426d2" />

### 2. Test the leaf key path (protect against re-introducing an old bug)

The single most important line in the Keystone `deriveContextHash` is the one that builds the derivation path: it must use the first receive leaf `m/86'/.../0/0`, not the bare account path `m/86'/...`. That leaf is the public key the spec binds the derived secret to, and it's the same key Keystone uses for its address and signing. An earlier version (https://github.com/babylonlabs-io/babylon-toolkit/pull/1834) from Aaron had the bug of using the account path, which derives a different key. Until now nothing tested this, so a refactor could quietly drop the `/0/0` and bring the bug back with no test failing.

Approach: pull that one-liner into a tiny pure helper, `connectedLeafKeyPath(accountPath)`, and route every place that needs the leaf (the context-hash call, PSBT signing, message signing) through it. Then a unit test pins that it always appends `/0/0` and never returns the bare account path. We extract a helper rather than test the provider directly because the provider module imports an SVG logo that the unit-test runner can't load — which is the same reason the other Keystone logic already lives in small tested helpers.

### 3. Developer warning on a signet coin_type mismatch

On signet, a Keystone running standard mainnet firmware exports mainnet keys (coin_type `0'`), while software wallets like UniSat use testnet keys (coin_type `1'`). Same seed, different key — so if you create a vault with Keystone and then switch to a software wallet (or vice versa), you hit a confusing "different BTC public key" error with no explanation. This only affects signet (a dev network); on mainnet everyone uses coin_type `0'`, so there's no mismatch. We intentionally do not block this, because signet is dev-only and a hard check could break the dev flow.

Approach: a non-throwing `console.warn` at connect time when the exported coin_type doesn't match the network the app is configured for. It only fires on the exact mismatch that causes the bug, and never on a correct mainnet setup, so it's effectively a signet-only developer signal — exactly what the reviewer asked for. The coin_type comparison is done with two small tested helpers (`expectedTaprootCoinType`, `getCoinType`).

## Incidental fix

Routing message signing through the strict `connectedLeafKeyPath` helper surfaced that `signMessageECDSA` didn't guard against a missing derivation path (the old inline string silently accepted `undefined`). Added `path` to that method's "wallet not connected" check.
