### PR TITLE
feat(toolkit): cross-check wasm-returned pegin values before signing

### DIFF
--- a/packages/babylon-tbv-rust-wasm/src/index-node.ts
+++ b/packages/babylon-tbv-rust-wasm/src/index-node.ts
@@ -171,7 +171,7 @@ export async function buildPeginTxFromPrePegin(
       txHex: peginTx.toHex(),
       txid: peginTx.getTxid(),
       vaultScriptPubKey: peginTx.getVaultScriptPubKey(),
-      vaultValue: peginTx.getVaultValue(),
+      vaultValue: assertWasmBigint(peginTx.getVaultValue(), "vaultValue"),
     };
   } finally {
     peginTx?.free();
@@ -216,16 +216,20 @@ export async function computeMinClaimValue(
   feeRate: bigint,
 ): Promise<bigint> {
   await initWasm();
-  return assertWasmBigint(
-    wasmComputeMinClaimValue(
-      numLocalChallengers,
-      numUniversalChallengers,
-      councilQuorum,
-      councilSize,
-      feeRate,
-    ),
-    "minClaimValue",
-  );
+  try {
+    return assertWasmBigint(
+      wasmComputeMinClaimValue(
+        numLocalChallengers,
+        numUniversalChallengers,
+        councilQuorum,
+        councilSize,
+        feeRate,
+      ),
+      "minClaimValue",
+    );
+  } catch (err) {
+    throw toError(err, "computeMinClaimValue");
+  }
 }
 
 export async function computeMinPeginFee(
@@ -234,10 +238,14 @@ export async function computeMinPeginFee(
   minPeginFeeRate: bigint,
 ): Promise<bigint> {
   await initWasm();
-  return assertWasmBigint(
-    wasmComputeMinPeginFee(numVks, numUcs, minPeginFeeRate),
-    "minPeginFee",
-  );
+  try {
+    return assertWasmBigint(
+      wasmComputeMinPeginFee(numVks, numUcs, minPeginFeeRate),
+      "minPeginFee",
+    );
+  } catch (err) {
+    throw toError(err, "computeMinPeginFee");
+  }
 }
 
 export async function createPayoutConnector(

--- a/packages/babylon-tbv-rust-wasm/src/index-node.ts
+++ b/packages/babylon-tbv-rust-wasm/src/index-node.ts
@@ -27,6 +27,7 @@ import type {
   ChallengeAssertConnectorParams,
   ChallengeAssertScriptInfo,
 } from "./types.js";
+import { assertWasmBigint } from "./value-guards.js";
 
 /**
  * HTLC output index for single deposits.
@@ -95,10 +96,12 @@ export async function createPrePeginTransaction(
     const peginAmounts: bigint[] = [];
 
     for (let i = 0; i < numHtlcs; i++) {
-      htlcValues.push(tx.getHtlcValue(i));
+      htlcValues.push(assertWasmBigint(tx.getHtlcValue(i), `htlcValue[${i}]`));
       htlcScriptPubKeys.push(tx.getHtlcScriptPubKey(i));
       htlcAddresses.push(tx.getHtlcAddress(i));
-      peginAmounts.push(tx.getPeginAmountAt(i));
+      peginAmounts.push(
+        assertWasmBigint(tx.getPeginAmountAt(i), `peginAmount[${i}]`),
+      );
     }
 
     return {
@@ -108,7 +111,10 @@ export async function createPrePeginTransaction(
       htlcScriptPubKeys,
       htlcAddresses,
       peginAmounts,
-      depositorClaimValue: tx.getDepositorClaimValue(),
+      depositorClaimValue: assertWasmBigint(
+        tx.getDepositorClaimValue(),
+        "depositorClaimValue",
+      ),
     };
   } finally {
     tx.free();
@@ -210,12 +216,15 @@ export async function computeMinClaimValue(
   feeRate: bigint,
 ): Promise<bigint> {
   await initWasm();
-  return wasmComputeMinClaimValue(
-    numLocalChallengers,
-    numUniversalChallengers,
-    councilQuorum,
-    councilSize,
-    feeRate,
+  return assertWasmBigint(
+    wasmComputeMinClaimValue(
+      numLocalChallengers,
+      numUniversalChallengers,
+      councilQuorum,
+      councilSize,
+      feeRate,
+    ),
+    "minClaimValue",
   );
 }
 
@@ -225,7 +234,10 @@ export async function computeMinPeginFee(
   minPeginFeeRate: bigint,
 ): Promise<bigint> {
   await initWasm();
-  return wasmComputeMinPeginFee(numVks, numUcs, minPeginFeeRate);
+  return assertWasmBigint(
+    wasmComputeMinPeginFee(numVks, numUcs, minPeginFeeRate),
+    "minPeginFee",
+  );
 }
 
 export async function createPayoutConnector(

--- a/packages/babylon-tbv-rust-wasm/src/index.ts
+++ b/packages/babylon-tbv-rust-wasm/src/index.ts
@@ -181,7 +181,7 @@ export async function buildPeginTxFromPrePegin(
       txHex: peginTx.toHex(),
       txid: peginTx.getTxid(),
       vaultScriptPubKey: peginTx.getVaultScriptPubKey(),
-      vaultValue: peginTx.getVaultValue(),
+      vaultValue: assertWasmBigint(peginTx.getVaultValue(), "vaultValue"),
     };
   } finally {
     peginTx?.free();
@@ -242,16 +242,20 @@ export async function computeMinClaimValue(
   feeRate: bigint,
 ): Promise<bigint> {
   await initWasm();
-  return assertWasmBigint(
-    wasmComputeMinClaimValue(
-      numLocalChallengers,
-      numUniversalChallengers,
-      councilQuorum,
-      councilSize,
-      feeRate,
-    ),
-    "minClaimValue",
-  );
+  try {
+    return assertWasmBigint(
+      wasmComputeMinClaimValue(
+        numLocalChallengers,
+        numUniversalChallengers,
+        councilQuorum,
+        councilSize,
+        feeRate,
+      ),
+      "minClaimValue",
+    );
+  } catch (err) {
+    throw toError(err, "computeMinClaimValue");
+  }
 }
 
 /**
@@ -270,10 +274,14 @@ export async function computeMinPeginFee(
   minPeginFeeRate: bigint,
 ): Promise<bigint> {
   await initWasm();
-  return assertWasmBigint(
-    wasmComputeMinPeginFee(numVks, numUcs, minPeginFeeRate),
-    "minPeginFee",
-  );
+  try {
+    return assertWasmBigint(
+      wasmComputeMinPeginFee(numVks, numUcs, minPeginFeeRate),
+      "minPeginFee",
+    );
+  } catch (err) {
+    throw toError(err, "computeMinPeginFee");
+  }
 }
 
 // wasm-bindgen rethrows Rust `JsValue::from_str(...)` errors as bare strings,

--- a/packages/babylon-tbv-rust-wasm/src/index.ts
+++ b/packages/babylon-tbv-rust-wasm/src/index.ts
@@ -7,6 +7,7 @@ import type {
   HtlcConnectorParams,
   HtlcConnectorInfo,
 } from "./types.js";
+import { assertWasmBigint } from "./value-guards.js";
 
 let wasmInitialized = false;
 let wasmInitPromise: Promise<void> | null = null;
@@ -93,10 +94,12 @@ export async function createPrePeginTransaction(
     const peginAmounts: bigint[] = [];
 
     for (let i = 0; i < numHtlcs; i++) {
-      htlcValues.push(tx.getHtlcValue(i));
+      htlcValues.push(assertWasmBigint(tx.getHtlcValue(i), `htlcValue[${i}]`));
       htlcScriptPubKeys.push(tx.getHtlcScriptPubKey(i));
       htlcAddresses.push(tx.getHtlcAddress(i));
-      peginAmounts.push(tx.getPeginAmountAt(i));
+      peginAmounts.push(
+        assertWasmBigint(tx.getPeginAmountAt(i), `peginAmount[${i}]`),
+      );
     }
 
     return {
@@ -106,7 +109,10 @@ export async function createPrePeginTransaction(
       htlcScriptPubKeys,
       htlcAddresses,
       peginAmounts,
-      depositorClaimValue: tx.getDepositorClaimValue(),
+      depositorClaimValue: assertWasmBigint(
+        tx.getDepositorClaimValue(),
+        "depositorClaimValue",
+      ),
     };
   } finally {
     tx.free();
@@ -236,12 +242,15 @@ export async function computeMinClaimValue(
   feeRate: bigint,
 ): Promise<bigint> {
   await initWasm();
-  return wasmComputeMinClaimValue(
-    numLocalChallengers,
-    numUniversalChallengers,
-    councilQuorum,
-    councilSize,
-    feeRate,
+  return assertWasmBigint(
+    wasmComputeMinClaimValue(
+      numLocalChallengers,
+      numUniversalChallengers,
+      councilQuorum,
+      councilSize,
+      feeRate,
+    ),
+    "minClaimValue",
   );
 }
 
@@ -261,7 +270,10 @@ export async function computeMinPeginFee(
   minPeginFeeRate: bigint,
 ): Promise<bigint> {
   await initWasm();
-  return wasmComputeMinPeginFee(numVks, numUcs, minPeginFeeRate);
+  return assertWasmBigint(
+    wasmComputeMinPeginFee(numVks, numUcs, minPeginFeeRate),
+    "minPeginFee",
+  );
 }
 
 // wasm-bindgen rethrows Rust `JsValue::from_str(...)` errors as bare strings,

--- a/packages/babylon-tbv-rust-wasm/src/value-guards.ts
+++ b/packages/babylon-tbv-rust-wasm/src/value-guards.ts
@@ -1,0 +1,32 @@
+/**
+ * Runtime guards for value-bearing scalars crossing the WASM FFI boundary.
+ *
+ * wasm-bindgen returns `u64` outputs as JS `bigint`, but nothing in the type
+ * system enforces the shape or sign at runtime: an ABI regression or a
+ * doctored binary could hand back a non-bigint or a non-positive value that
+ * would then flow into satoshi math unchecked. Every sat-valued WASM return
+ * is funneled through {@link assertWasmBigint} so an invalid value fails loudly
+ * at the seam instead of silently corrupting a transaction.
+ */
+
+/**
+ * Assert a WASM-returned value is a positive `bigint` and return it narrowed.
+ *
+ * @param value - The raw value returned across the WASM boundary.
+ * @param label - Human-readable name used in the thrown error.
+ * @throws If `value` is not a `bigint`, or is not strictly greater than 0.
+ */
+export function assertWasmBigint(value: unknown, label: string): bigint {
+  if (typeof value !== "bigint") {
+    throw new Error(
+      `WASM returned a non-bigint ${label} (got ${typeof value}); ` +
+        `refusing to use it in satoshi math.`,
+    );
+  }
+  if (value <= 0n) {
+    throw new Error(
+      `WASM returned a non-positive ${label} (${value}); expected > 0.`,
+    );
+  }
+  return value;
+}

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/assertWasmPeginSizing.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/assertWasmPeginSizing.test.ts
@@ -18,7 +18,10 @@ vi.mock("@babylonlabs-io/babylon-tbv-rust-wasm", () => ({
   computeMinClaimValue: computeMinClaimValueMock,
 }));
 
-import { assertWasmPeginSizing } from "../assertWasmPeginSizing";
+import {
+  assertEncodedHtlcOutputsMatch,
+  assertWasmPeginSizing,
+} from "../assertWasmPeginSizing";
 import type { PrePeginParams } from "../pegin";
 
 const CLAIM_VALUE = 5_000n;
@@ -211,5 +214,66 @@ describe("assertWasmPeginSizing", () => {
         ),
       ).rejects.toThrow(/HTLC\[1\].*exceeds the plausibility cap/);
     });
+  });
+});
+
+describe("assertEncodedHtlcOutputsMatch", () => {
+  const SCRIPT_A = "5120" + "11".repeat(32);
+  const SCRIPT_B = "5120" + "22".repeat(32);
+  const OP_RETURN_SCRIPT = "6a20" + "ab".repeat(32);
+  const ANCHOR_SCRIPT = "51024e73";
+
+  // HTLC outputs first (vouts 0..N-1), then optional OP_RETURN, then CPFP
+  // anchor — mirroring the WASM layout.
+  function htlcOutput(value: bigint, scriptHex: string) {
+    return { value: Number(value), script: Buffer.from(scriptHex, "hex") };
+  }
+
+  it("passes when encoded HTLC outputs match the validated metadata", () => {
+    const outputs = [
+      htlcOutput(105_000n, SCRIPT_A),
+      htlcOutput(255_000n, SCRIPT_B),
+      htlcOutput(0n, OP_RETURN_SCRIPT),
+      htlcOutput(330n, ANCHOR_SCRIPT),
+    ];
+    expect(() =>
+      assertEncodedHtlcOutputsMatch(
+        outputs,
+        [105_000n, 255_000n],
+        [SCRIPT_A, SCRIPT_B],
+      ),
+    ).not.toThrow();
+  });
+
+  it("throws when an encoded HTLC output value differs from htlcValues", () => {
+    const outputs = [
+      htlcOutput(105_000n, SCRIPT_A),
+      htlcOutput(254_999n, SCRIPT_B),
+    ];
+    expect(() =>
+      assertEncodedHtlcOutputsMatch(
+        outputs,
+        [105_000n, 255_000n],
+        [SCRIPT_A, SCRIPT_B],
+      ),
+    ).toThrow(/output\[1\] value 254999 does not match the cross-checked htlcValue 255000/);
+  });
+
+  it("throws when an encoded HTLC scriptPubKey differs from htlcScriptPubKeys", () => {
+    const outputs = [htlcOutput(105_000n, SCRIPT_B)];
+    expect(() =>
+      assertEncodedHtlcOutputsMatch(outputs, [105_000n], [SCRIPT_A]),
+    ).toThrow(/output\[0\] scriptPubKey .* does not match the cross-checked htlcScriptPubKey/);
+  });
+
+  it("throws when the encoded tx has fewer outputs than validated HTLCs", () => {
+    const outputs = [htlcOutput(105_000n, SCRIPT_A)];
+    expect(() =>
+      assertEncodedHtlcOutputsMatch(
+        outputs,
+        [105_000n, 255_000n],
+        [SCRIPT_A, SCRIPT_B],
+      ),
+    ).toThrow(/has 1 output\(s\), fewer than the 2 HTLC output\(s\)/);
   });
 });

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/assertWasmPeginSizing.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/assertWasmPeginSizing.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Tests for assertWasmPeginSizing — the cross-check that guards every
+ * value-bearing field WASM returns from createPrePeginTransaction before it
+ * feeds a signed tx or the on-chain PegIn registration (CLAUDE.md #1).
+ */
+
+import type {
+  Network,
+  PrePeginResult,
+} from "@babylonlabs-io/babylon-tbv-rust-wasm";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { computeMinClaimValueMock } = vi.hoisted(() => ({
+  computeMinClaimValueMock: vi.fn(),
+}));
+
+vi.mock("@babylonlabs-io/babylon-tbv-rust-wasm", () => ({
+  computeMinClaimValue: computeMinClaimValueMock,
+}));
+
+import { assertWasmPeginSizing } from "../assertWasmPeginSizing";
+import type { PrePeginParams } from "../pegin";
+
+const CLAIM_VALUE = 5_000n;
+const PEGIN_AMOUNT = 100_000n;
+const PEGIN_FEE = 1_000n;
+// makeParams uses minPeginFeeRate = 10n, so the plausibility cap is
+// 10 × MAX_REASONABLE_PEGIN_VBYTES (100_000) = 1_000_000 sat.
+const FEE_PLAUSIBILITY_CAP = 1_000_000n;
+
+function makeParams(overrides?: Partial<PrePeginParams>): PrePeginParams {
+  return {
+    depositorPubkey: "aa".repeat(32),
+    vaultProviderPubkey: "bb".repeat(32),
+    vaultKeeperPubkeys: ["cc".repeat(32)],
+    universalChallengerPubkeys: ["dd".repeat(32)],
+    hashlocks: ["ab".repeat(32)],
+    timelockRefund: 50,
+    pegInAmounts: [PEGIN_AMOUNT],
+    feeRate: 10n,
+    minPeginFeeRate: 10n,
+    numLocalChallengers: 1,
+    councilQuorum: 2,
+    councilSize: 3,
+    network: "signet" as Network,
+    ...overrides,
+  };
+}
+
+function makeResult(overrides?: Partial<PrePeginResult>): PrePeginResult {
+  return {
+    txHex: "00",
+    txid: "ff".repeat(32),
+    htlcValues: [PEGIN_AMOUNT + CLAIM_VALUE + PEGIN_FEE],
+    htlcScriptPubKeys: ["5120" + "11".repeat(32)],
+    htlcAddresses: ["tb1pexampleaddress"],
+    peginAmounts: [PEGIN_AMOUNT],
+    depositorClaimValue: CLAIM_VALUE,
+    ...overrides,
+  };
+}
+
+describe("assertWasmPeginSizing", () => {
+  beforeEach(() => {
+    computeMinClaimValueMock.mockReset();
+    computeMinClaimValueMock.mockResolvedValue(CLAIM_VALUE);
+  });
+
+  it("resolves without throwing for a valid single-vault result", async () => {
+    await expect(
+      assertWasmPeginSizing(makeResult(), makeParams()),
+    ).resolves.toBeUndefined();
+  });
+
+  it("throws when htlcValues length does not match the request", async () => {
+    await expect(
+      assertWasmPeginSizing(
+        makeResult({
+          htlcValues: [
+            PEGIN_AMOUNT + CLAIM_VALUE + PEGIN_FEE,
+            PEGIN_AMOUNT + CLAIM_VALUE + PEGIN_FEE,
+          ],
+        }),
+        makeParams(),
+      ),
+    ).rejects.toThrow(/expected 1 .one per requested deposit/);
+  });
+
+  it("throws when parallel array lengths disagree", async () => {
+    await expect(
+      assertWasmPeginSizing(makeResult({ peginAmounts: [] }), makeParams()),
+    ).rejects.toThrow(/mismatched array lengths/);
+  });
+
+  it("throws when depositorClaimValue is non-positive", async () => {
+    await expect(
+      assertWasmPeginSizing(
+        makeResult({ depositorClaimValue: 0n }),
+        makeParams(),
+      ),
+    ).rejects.toThrow(/non-positive depositorClaimValue/);
+  });
+
+  it("throws when depositorClaimValue disagrees with computeMinClaimValue", async () => {
+    computeMinClaimValueMock.mockResolvedValue(CLAIM_VALUE + 1n);
+    await expect(
+      assertWasmPeginSizing(makeResult(), makeParams()),
+    ).rejects.toThrow(/does not match the independently computed/);
+  });
+
+  it("throws when peginAmount does not echo the requested amount", async () => {
+    await expect(
+      assertWasmPeginSizing(
+        makeResult({
+          peginAmounts: [PEGIN_AMOUNT - 1n],
+          // keep htlcValue consistent so the amount check is what trips
+          htlcValues: [PEGIN_AMOUNT - 1n + CLAIM_VALUE + PEGIN_FEE],
+        }),
+        makeParams(),
+      ),
+    ).rejects.toThrow(/does not match the requested amount/);
+  });
+
+  it("throws when htlcValue does not strictly cover amount + claim + fee", async () => {
+    await expect(
+      assertWasmPeginSizing(
+        // implied fee == 0
+        makeResult({ htlcValues: [PEGIN_AMOUNT + CLAIM_VALUE] }),
+        makeParams(),
+      ),
+    ).rejects.toThrow(/does not strictly cover/);
+  });
+
+  it("throws when the implied PegIn fee exceeds the plausibility cap", async () => {
+    await expect(
+      assertWasmPeginSizing(
+        makeResult({
+          htlcValues: [
+            PEGIN_AMOUNT + CLAIM_VALUE + FEE_PLAUSIBILITY_CAP + 1n,
+          ],
+        }),
+        makeParams(),
+      ),
+    ).rejects.toThrow(/exceeds the plausibility cap/);
+  });
+
+  it("accepts an implied fee exactly at the plausibility cap", async () => {
+    await expect(
+      assertWasmPeginSizing(
+        makeResult({
+          htlcValues: [PEGIN_AMOUNT + CLAIM_VALUE + FEE_PLAUSIBILITY_CAP],
+        }),
+        makeParams(),
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  describe("two-vault batch (overlapping inputs, distinct keys)", () => {
+    const PEGIN_A = 100_000n;
+    const PEGIN_B = 250_000n;
+
+    function makeTwoVaultParams(): PrePeginParams {
+      return makeParams({
+        hashlocks: ["ab".repeat(32), "cd".repeat(32)],
+        pegInAmounts: [PEGIN_A, PEGIN_B],
+      });
+    }
+
+    function makeTwoVaultResult(
+      overrides?: Partial<PrePeginResult>,
+    ): PrePeginResult {
+      return makeResult({
+        htlcValues: [
+          PEGIN_A + CLAIM_VALUE + PEGIN_FEE,
+          PEGIN_B + CLAIM_VALUE + PEGIN_FEE,
+        ],
+        htlcScriptPubKeys: ["5120" + "11".repeat(32), "5120" + "22".repeat(32)],
+        htlcAddresses: ["tb1pvaulta", "tb1pvaultb"],
+        peginAmounts: [PEGIN_A, PEGIN_B],
+        ...overrides,
+      });
+    }
+
+    it("resolves for a valid two-vault result", async () => {
+      await expect(
+        assertWasmPeginSizing(makeTwoVaultResult(), makeTwoVaultParams()),
+      ).resolves.toBeUndefined();
+    });
+
+    it("catches a tampered second-vault peginAmount", async () => {
+      await expect(
+        assertWasmPeginSizing(
+          makeTwoVaultResult({
+            peginAmounts: [PEGIN_A, PEGIN_B - 10_000n],
+          }),
+          makeTwoVaultParams(),
+        ),
+      ).rejects.toThrow(/peginAmount\[1\].*does not match the requested amount/);
+    });
+
+    it("catches a grossly inflated second-vault htlcValue", async () => {
+      await expect(
+        assertWasmPeginSizing(
+          makeTwoVaultResult({
+            htlcValues: [
+              PEGIN_A + CLAIM_VALUE + PEGIN_FEE,
+              PEGIN_B + CLAIM_VALUE + FEE_PLAUSIBILITY_CAP + 1n,
+            ],
+          }),
+          makeTwoVaultParams(),
+        ),
+      ).rejects.toThrow(/HTLC\[1\].*exceeds the plausibility cap/);
+    });
+  });
+});

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/assertWasmPeginSizing.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/assertWasmPeginSizing.ts
@@ -1,0 +1,154 @@
+/**
+ * Cross-check the values WASM returns from `createPrePeginTransaction`
+ * against independently-known expectations before they feed a signed
+ * Bitcoin transaction or the on-chain PegIn registration.
+ *
+ * CLAUDE.md critical path #1: the Rust/WASM layer computes
+ * `htlcValue = peginAmount + depositorClaimValue + minPeginFee` internally
+ * and JS receives the outputs with no runtime validation. A doctored or
+ * buggy binary that returns a different `peginAmount`, an out-of-formula
+ * `htlcValue`, or a wrong `depositorClaimValue` would otherwise be committed
+ * verbatim — taxing the depositor or starving the downstream tx graph of fees.
+ *
+ * @module primitives/psbt/assertWasmPeginSizing
+ */
+
+import {
+  computeMinClaimValue,
+  type PrePeginResult,
+} from "@babylonlabs-io/babylon-tbv-rust-wasm";
+
+import { MAX_REASONABLE_PEGIN_VBYTES } from "../../utils/fee/constants";
+
+import type { PrePeginParams } from "./pegin";
+
+/**
+ * Assert the WASM Pre-PegIn sizing result is internally consistent and
+ * matches what the caller requested.
+ *
+ * The strong checks are pure-JS and fully independent of the WASM binary:
+ * the per-HTLC `peginAmount` must equal the requested amount, array lengths
+ * must match, and every value must be positive. The implied PegIn fee
+ * (`htlcValue - peginAmount - depositorClaimValue`) is bounded by
+ * plausibility rather than recomputed exactly, because JS↔Rust vbyte parity
+ * is not a cross-stack guarantee (see {@link MAX_REASONABLE_PEGIN_VBYTES}).
+ * The `depositorClaimValue` cross-check against `computeMinClaimValue` is a
+ * WASM-vs-WASM consistency check (a different entry point), not an
+ * independent one.
+ *
+ * @param result - The result returned by `createPrePeginTransaction`.
+ * @param params - The parameters that were passed to build it.
+ * @throws If any value is missing, non-positive, mismatched against the
+ *   request, or outside the protocol formula / plausibility bounds.
+ */
+export async function assertWasmPeginSizing(
+  result: PrePeginResult,
+  params: PrePeginParams,
+): Promise<void> {
+  const expectedCount = params.pegInAmounts.length;
+
+  // Count: every parallel array must carry exactly one entry per requested
+  // deposit, otherwise the per-HTLC indexing downstream is meaningless.
+  if (result.htlcValues.length !== expectedCount) {
+    throw new Error(
+      `WASM Pre-PegIn returned ${result.htlcValues.length} HTLC value(s), ` +
+        `expected ${expectedCount} (one per requested deposit).`,
+    );
+  }
+  if (
+    result.peginAmounts.length !== expectedCount ||
+    result.htlcScriptPubKeys.length !== expectedCount ||
+    result.htlcAddresses.length !== expectedCount
+  ) {
+    throw new Error(
+      `WASM Pre-PegIn returned mismatched array lengths ` +
+        `(htlcValues=${result.htlcValues.length}, ` +
+        `peginAmounts=${result.peginAmounts.length}, ` +
+        `htlcScriptPubKeys=${result.htlcScriptPubKeys.length}, ` +
+        `htlcAddresses=${result.htlcAddresses.length}); ` +
+        `expected ${expectedCount} each.`,
+    );
+  }
+
+  // depositorClaimValue: positivity + WASM-vs-WASM consistency. Sized by the
+  // tx-graph `feeRate` (see PrePeginParams.feeRate), so the standalone
+  // `computeMinClaimValue` must reproduce the constructor's internal value.
+  if (result.depositorClaimValue <= 0n) {
+    throw new Error(
+      `WASM Pre-PegIn returned non-positive depositorClaimValue ` +
+        `${result.depositorClaimValue}; expected > 0.`,
+    );
+  }
+  const expectedClaimValue = await computeMinClaimValue(
+    params.numLocalChallengers,
+    params.universalChallengerPubkeys.length,
+    params.councilQuorum,
+    params.councilSize,
+    params.feeRate,
+  );
+  if (result.depositorClaimValue !== expectedClaimValue) {
+    throw new Error(
+      `WASM Pre-PegIn depositorClaimValue ${result.depositorClaimValue} does ` +
+        `not match the independently computed minimum claim value ` +
+        `${expectedClaimValue} (numLocalChallengers=${params.numLocalChallengers}, ` +
+        `numUniversalChallengers=${params.universalChallengerPubkeys.length}, ` +
+        `councilQuorum=${params.councilQuorum}, councilSize=${params.councilSize}, ` +
+        `feeRate=${params.feeRate}).`,
+    );
+  }
+
+  const maxImpliedFee = params.minPeginFeeRate * MAX_REASONABLE_PEGIN_VBYTES;
+
+  for (let i = 0; i < expectedCount; i++) {
+    const requested = params.pegInAmounts[i];
+    const peginAmount = result.peginAmounts[i];
+    const htlcValue = result.htlcValues[i];
+
+    // Amount echo (strongest, fully independent): the recorded pegin amount
+    // must equal exactly what the caller requested. A mismatch is the
+    // WASM-tax attack — the contract would record a doctored amount while the
+    // depositor's wallet funds the original, and the difference is a
+    // WASM-controlled tax.
+    if (peginAmount !== requested) {
+      throw new Error(
+        `WASM Pre-PegIn peginAmount[${i}] ${peginAmount} does not match the ` +
+          `requested amount ${requested}; refusing to build a tx whose ` +
+          `recorded amount differs from the depositor's request.`,
+      );
+    }
+    if (peginAmount <= 0n) {
+      throw new Error(
+        `WASM Pre-PegIn peginAmount[${i}] is non-positive (${peginAmount}); ` +
+          `expected > 0.`,
+      );
+    }
+    if (htlcValue <= 0n) {
+      throw new Error(
+        `WASM Pre-PegIn htlcValue[${i}] is non-positive (${htlcValue}); ` +
+          `expected > 0.`,
+      );
+    }
+
+    // Formula: htlcValue = peginAmount + depositorClaimValue + minPeginFee.
+    // The implied fee must be strictly positive (the HTLC must reserve a real
+    // PegIn fee) and within the plausibility bound.
+    const impliedFee = htlcValue - peginAmount - result.depositorClaimValue;
+    if (impliedFee <= 0n) {
+      throw new Error(
+        `WASM Pre-PegIn htlcValue[${i}] ${htlcValue} does not strictly cover ` +
+          `peginAmount ${peginAmount} + depositorClaimValue ` +
+          `${result.depositorClaimValue} + a PegIn fee (implied fee ` +
+          `${impliedFee}).`,
+      );
+    }
+    if (impliedFee > maxImpliedFee) {
+      throw new Error(
+        `WASM Pre-PegIn implied PegIn fee for HTLC[${i}] (${impliedFee} sat) ` +
+          `exceeds the plausibility cap ${maxImpliedFee} sat ` +
+          `(minPeginFeeRate=${params.minPeginFeeRate} × ` +
+          `${MAX_REASONABLE_PEGIN_VBYTES} vbytes); htlcValue ${htlcValue} ` +
+          `appears grossly inflated.`,
+      );
+    }
+  }
+}

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/assertWasmPeginSizing.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/assertWasmPeginSizing.ts
@@ -19,6 +19,7 @@ import {
 } from "@babylonlabs-io/babylon-tbv-rust-wasm";
 
 import { MAX_REASONABLE_PEGIN_VBYTES } from "../../utils/fee/constants";
+import type { ParsedOutput } from "../../utils/transaction/fundPeginTransaction";
 
 import type { PrePeginParams } from "./pegin";
 
@@ -148,6 +149,61 @@ export async function assertWasmPeginSizing(
           `(minPeginFeeRate=${params.minPeginFeeRate} × ` +
           `${MAX_REASONABLE_PEGIN_VBYTES} vbytes); htlcValue ${htlcValue} ` +
           `appears grossly inflated.`,
+      );
+    }
+  }
+}
+
+/**
+ * Bind the validated metadata to the bytes that actually get funded and
+ * signed.
+ *
+ * `assertWasmPeginSizing` proves the WASM *metadata* (`htlcValues`,
+ * `htlcScriptPubKeys`) matches the request and the protocol formula — but the
+ * transaction the depositor funds and signs is `result.txHex`. If the encoded
+ * tx carried a different HTLC output value or script than the metadata, the
+ * depositor would fund a transaction whose real outputs differ from the values
+ * that were cross-checked. This closes that final link: the encoded HTLC
+ * outputs must equal the validated metadata.
+ *
+ * The WASM lays out HTLC outputs first (vouts `0..N-1`), then the optional
+ * auth-anchor OP_RETURN, then the CPFP anchor — so we only compare the first
+ * `htlcValues.length` outputs.
+ *
+ * @param outputs - Outputs parsed from the unfunded Pre-PegIn tx hex.
+ * @param htlcValues - The (already value-validated) per-HTLC values.
+ * @param htlcScriptPubKeys - The per-HTLC scriptPubKeys (hex).
+ * @throws If the encoded outputs are too few, or any HTLC output's value or
+ *   scriptPubKey disagrees with the validated metadata.
+ */
+export function assertEncodedHtlcOutputsMatch(
+  outputs: readonly ParsedOutput[],
+  htlcValues: readonly bigint[],
+  htlcScriptPubKeys: readonly string[],
+): void {
+  if (outputs.length < htlcValues.length) {
+    throw new Error(
+      `Encoded Pre-PegIn tx has ${outputs.length} output(s), fewer than the ` +
+        `${htlcValues.length} HTLC output(s) the cross-check validated.`,
+    );
+  }
+
+  for (let i = 0; i < htlcValues.length; i++) {
+    const encodedValue = BigInt(outputs[i].value);
+    if (encodedValue !== htlcValues[i]) {
+      throw new Error(
+        `Encoded Pre-PegIn HTLC output[${i}] value ${encodedValue} does not ` +
+          `match the cross-checked htlcValue ${htlcValues[i]}; the funded/signed ` +
+          `tx would not pay the validated amount.`,
+      );
+    }
+
+    const encodedScript = outputs[i].script.toString("hex").toLowerCase();
+    const expectedScript = htlcScriptPubKeys[i].toLowerCase();
+    if (encodedScript !== expectedScript) {
+      throw new Error(
+        `Encoded Pre-PegIn HTLC output[${i}] scriptPubKey ${encodedScript} does ` +
+          `not match the cross-checked htlcScriptPubKey ${expectedScript}.`,
       );
     }
   }

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts
@@ -22,7 +22,10 @@ import {
 
 import { parseUnfundedWasmTransaction } from "../../utils/transaction/fundPeginTransaction";
 
-import { assertWasmPeginSizing } from "./assertWasmPeginSizing";
+import {
+  assertEncodedHtlcOutputsMatch,
+  assertWasmPeginSizing,
+} from "./assertWasmPeginSizing";
 
 /**
  * Parameters for building an unfunded Pre-PegIn PSBT
@@ -177,6 +180,17 @@ export async function buildPrePeginPsbt(
   // (HTLCs + optional OP_RETURN + CPFP anchor). This is the amount
   // UTXOs must cover before adding network fees.
   const parsed = parseUnfundedWasmTransaction(result.txHex);
+
+  // Bind the validated metadata to the bytes that get funded and signed:
+  // the encoded HTLC outputs must carry exactly the values/scripts the
+  // cross-check above validated. Otherwise a tx whose real outputs differ
+  // from the checked metadata could still be funded and signed.
+  assertEncodedHtlcOutputsMatch(
+    parsed.outputs,
+    result.htlcValues,
+    result.htlcScriptPubKeys,
+  );
+
   const totalOutputValue = parsed.outputs.reduce(
     (sum, o) => sum + BigInt(o.value),
     0n,

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts
@@ -22,6 +22,8 @@ import {
 
 import { parseUnfundedWasmTransaction } from "../../utils/transaction/fundPeginTransaction";
 
+import { assertWasmPeginSizing } from "./assertWasmPeginSizing";
+
 /**
  * Parameters for building an unfunded Pre-PegIn PSBT
  */
@@ -164,6 +166,12 @@ export async function buildPrePeginPsbt(
     network: params.network,
     authAnchorHash,
   });
+
+  // CLAUDE.md critical path #1: the WASM outputs reach JS with no runtime
+  // validation. Cross-check every value-bearing field against the request
+  // and the protocol formula before it can feed a signed tx or the on-chain
+  // PegIn registration. Both the sizing and commit passes route through here.
+  await assertWasmPeginSizing(result, params);
 
   // Parse the unfunded tx to sum all output values
   // (HTLCs + optional OP_RETURN + CPFP anchor). This is the amount

--- a/packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts
@@ -100,3 +100,20 @@ export function peginOutputCount(
  * catching catastrophic wallet-side overpayment.
  */
 export const SPLIT_TX_FEE_SAFETY_MULTIPLIER = 5;
+
+/**
+ * Upper bound (vbytes) used to plausibility-check the implied per-HTLC
+ * PegIn fee returned by WASM: `htlcValue - peginAmount - depositorClaimValue`.
+ *
+ * The WASM sizes the PegIn fee internally as `minPeginFeeRate × peginTxVsize`.
+ * We do not reproduce the exact Rust vsize model here — JS↔Rust vbyte parity
+ * is explicitly NOT a cross-stack guarantee (see `peginFeeMath.ts`), so an
+ * exact recompute would false-positive on valid deposits. Instead we bound
+ * the implied fee by the largest vsize any *standard, relayable* Bitcoin
+ * transaction can have: 100,000 vbytes (400,000 weight units, the consensus
+ * tx-weight limit). A PegIn is a single transaction, so its real vsize is far
+ * below this; an implied fee above `minPeginFeeRate × MAX_REASONABLE_PEGIN_VBYTES`
+ * therefore signals a grossly inflated `htlcValue` (excess sats that would be
+ * locked irrecoverably in the HTLC), not legitimate sizing.
+ */
+export const MAX_REASONABLE_PEGIN_VBYTES = 100_000n;

--- a/packages/babylon-ts-sdk/src/tbv/core/utils/transaction/fundPeginTransaction.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/utils/transaction/fundPeginTransaction.ts
@@ -34,7 +34,7 @@ export interface FundPeginTransactionParams {
 }
 
 /** A single parsed output from the unfunded WASM transaction */
-interface ParsedOutput {
+export interface ParsedOutput {
   value: number;
   script: Buffer;
 }

--- a/services/vault/src/components/simple/DepositForm.tsx
+++ b/services/vault/src/components/simple/DepositForm.tsx
@@ -91,6 +91,12 @@ interface DepositFormProps {
   isLoadingFee: boolean;
   feeError: string | null;
   depositorClaimValue?: bigint;
+  /**
+   * Terminal failure from the `computeMinClaimValue` WASM query. CTA surfaces
+   * this as "Fee estimate unavailable" instead of an indefinite loading
+   * state. Null while the query is healthy.
+   */
+  depositorClaimValueError: Error | null;
   isDepositDisabled: boolean;
   isGeoBlocked: boolean;
   isAddressBlocked: boolean;
@@ -170,6 +176,7 @@ export function DepositForm({
   isLoadingFee,
   feeError,
   depositorClaimValue,
+  depositorClaimValueError,
   isDepositDisabled,
   isGeoBlocked,
   isAddressBlocked,
@@ -276,6 +283,7 @@ export function DepositForm({
     capUnavailable,
     minPeginFee,
     minPeginFeeError,
+    depositorClaimValueError,
     btcBalance,
     estimatedFeeSats: estimatedFeeSats ?? undefined,
     depositorClaimValue,

--- a/services/vault/src/components/simple/SimpleDeposit.tsx
+++ b/services/vault/src/components/simple/SimpleDeposit.tsx
@@ -119,6 +119,7 @@ function SimpleDepositContent({
     isSplitLoading,
     splitRatioLabel,
     depositorClaimValue,
+    depositorClaimValueError,
     ordinalsCheckPending,
     validateForm,
     resetForm,
@@ -368,6 +369,7 @@ function SimpleDepositContent({
                 }
                 isWalletConnected={isWalletConnected}
                 depositorClaimValue={totalDepositorClaimValue}
+                depositorClaimValueError={depositorClaimValueError}
                 estimatedFeeSats={estimatedFeeSats}
                 estimatedFeeRate={estimatedFeeRate}
                 isLoadingFee={isLoadingFee}

--- a/services/vault/src/hooks/deposit/useDepositPageForm.ts
+++ b/services/vault/src/hooks/deposit/useDepositPageForm.ts
@@ -157,6 +157,14 @@ export interface UseDepositPageFormResult {
   splitRatioLabel: string | null;
   /** Depositor claim value computed from WASM (VK/UC counts + fee). undefined while loading. */
   depositorClaimValue: bigint | undefined;
+  /**
+   * Terminal failure from the `computeMinClaimValue` WASM query (init
+   * failure, unsupported signer count, or a guard-rejected non-positive
+   * return). Surfaced separately from the undefined "still loading" state so
+   * the CTA reports an actionable error instead of getting stuck
+   * indefinitely on "Calculating fees...".
+   */
+  depositorClaimValueError: Error | null;
 
   validateForm: () => boolean;
   validateAmountOnBlur: () => void;
@@ -382,28 +390,29 @@ export function useDepositPageForm(): UseDepositPageFormResult {
     }
   }, [selectedVpBtcPubkey, vaultKeeperBtcPubkeys, depositorBtcPubkey]);
 
-  const { data: depositorClaimValue } = useQuery({
-    queryKey: [
-      "depositorClaimValue",
-      numLocalChallengers,
-      latestUniversalChallengers.length,
-      config.offchainParams.councilQuorum,
-      config.offchainParams.securityCouncilKeys.length,
-      String(config.offchainParams.feeRate),
-    ],
-    queryFn: () =>
-      computeMinClaimValue(
-        numLocalChallengers!,
+  const { data: depositorClaimValue, error: depositorClaimValueError } =
+    useQuery({
+      queryKey: [
+        "depositorClaimValue",
+        numLocalChallengers,
         latestUniversalChallengers.length,
         config.offchainParams.councilQuorum,
         config.offchainParams.securityCouncilKeys.length,
-        config.offchainParams.feeRate,
-      ),
-    enabled:
-      latestUniversalChallengers.length > 0 && numLocalChallengers != null,
-    staleTime: STALE_TIME_MS,
-    refetchOnWindowFocus: false,
-  });
+        String(config.offchainParams.feeRate),
+      ],
+      queryFn: () =>
+        computeMinClaimValue(
+          numLocalChallengers!,
+          latestUniversalChallengers.length,
+          config.offchainParams.councilQuorum,
+          config.offchainParams.securityCouncilKeys.length,
+          config.offchainParams.feeRate,
+        ),
+      enabled:
+        latestUniversalChallengers.length > 0 && numLocalChallengers != null,
+      staleTime: STALE_TIME_MS,
+      refetchOnWindowFocus: false,
+    });
 
   // Exact per-HTLC PegIn (activation) fee the depositor must reserve inside
   // each HTLC value. Sourced from the WASM (`compute_min_pegin_fee` in
@@ -630,6 +639,10 @@ export function useDepositPageForm(): UseDepositPageFormResult {
     vaultAmounts: splitVaultAmounts,
     isSplitLoading,
     depositorClaimValue,
+    depositorClaimValueError:
+      depositorClaimValueError instanceof Error
+        ? depositorClaimValueError
+        : null,
     splitRatioLabel,
     validateForm,
     validateAmountOnBlur,

--- a/services/vault/src/hooks/deposit/useDepositPageForm.ts
+++ b/services/vault/src/hooks/deposit/useDepositPageForm.ts
@@ -50,6 +50,18 @@ const STALE_TIME_MS = 5 * 60 * 1000;
  */
 const PRE_PEGIN_SAFETY_BUFFER_SATS = 3_000n;
 
+/**
+ * Normalize a React Query failure into `Error | null`. wasm-bindgen can reject
+ * with a bare string, so a plain `instanceof Error` filter would silently drop
+ * the failure and leave the CTA stuck on "Calculating fees..." instead of
+ * surfacing the terminal fee-error state. Coerce any non-null, non-Error value
+ * into an `Error` so the failure is always preserved.
+ */
+function toError(value: unknown): Error | null {
+  if (value == null) return null;
+  return value instanceof Error ? value : new Error(String(value));
+}
+
 export interface DepositPageFormData {
   amountBtc: string;
   selectedProvider: string;
@@ -630,8 +642,7 @@ export function useDepositPageForm(): UseDepositPageFormResult {
     effectiveRemaining: capSnapshot?.effectiveRemaining ?? null,
     capUnavailable: capError !== null,
     minPeginFee: minPeginFee ?? null,
-    minPeginFeeError:
-      minPeginFeeError instanceof Error ? minPeginFeeError : null,
+    minPeginFeeError: toError(minPeginFeeError),
     ordinalsCheckPending,
     isPartialLiquidation,
     setIsPartialLiquidation,
@@ -639,10 +650,7 @@ export function useDepositPageForm(): UseDepositPageFormResult {
     vaultAmounts: splitVaultAmounts,
     isSplitLoading,
     depositorClaimValue,
-    depositorClaimValueError:
-      depositorClaimValueError instanceof Error
-        ? depositorClaimValueError
-        : null,
+    depositorClaimValueError: toError(depositorClaimValueError),
     splitRatioLabel,
     validateForm,
     validateAmountOnBlur,

--- a/services/vault/src/services/deposit/__tests__/validations.test.ts
+++ b/services/vault/src/services/deposit/__tests__/validations.test.ts
@@ -300,6 +300,7 @@ describe("Deposit Validations", () => {
       capUnavailable: false,
       minPeginFee: 500n,
       minPeginFeeError: null,
+      depositorClaimValueError: null,
     };
 
     it("returns enabled 'Deposit' when all conditions are met", () => {
@@ -775,6 +776,17 @@ describe("Deposit Validations", () => {
         minPeginFeeError: new Error("boom"),
       });
       expect(result.label).toBe("Fee estimate unavailable");
+    });
+
+    it("disables with 'Fee estimate unavailable' when depositorClaimValue query errored", () => {
+      const result = getDepositCtaState({
+        ...readyParams,
+        depositorClaimValueError: new Error("WASM init failed"),
+      });
+      expect(result).toEqual({
+        disabled: true,
+        label: "Fee estimate unavailable",
+      });
     });
   });
 

--- a/services/vault/src/services/deposit/validations.ts
+++ b/services/vault/src/services/deposit/validations.ts
@@ -150,6 +150,13 @@ export interface DepositCtaParams extends DepositFormValidityParams {
    * indefinitely on "Calculating fees...".
    */
   minPeginFeeError: Error | null;
+  /**
+   * Terminal failure from the `computeMinClaimValue` WASM query. Same purpose
+   * as {@link minPeginFeeError}: without it a query rejection would leave the
+   * CTA stuck on "Calculating fees..." (the depositorClaimValue == null gate)
+   * with no error or retry signal.
+   */
+  depositorClaimValueError: Error | null;
 }
 
 export interface DepositCtaState {
@@ -350,7 +357,11 @@ export function getDepositCtaState(params: DepositCtaParams): DepositCtaState {
   // loading" gate below. Without this branch a query rejection (WASM init
   // failure, unsupported signer count) would leave the CTA stuck on
   // "Calculating fees..." with no error or retry signal.
-  if (params.amountSats > 0n && params.minPeginFeeError !== null) {
+  if (
+    params.amountSats > 0n &&
+    (params.minPeginFeeError !== null ||
+      params.depositorClaimValueError !== null)
+  ) {
     return { disabled: true, label: "Fee estimate unavailable" };
   }
 


### PR DESCRIPTION
## What this does

When a depositor starts a peg-in, the Rust/WASM layer computes the satoshi values for the transaction: how much goes into each HTLC output (`htlcValue`), how much the depositor pegs in (`peginAmount`), and the depositor's recovery-path budget (`depositorClaimValue`). The contract is `htlcValue = peginAmount + depositorClaimValue + minPeginFee`. Until now, JavaScript took those numbers and used them directly — to build the Bitcoin transaction the user signs and to register the peg-in on-chain — without ever checking them. This PR adds that check.

## Why it matters

These values move real money and the transaction is irreversible once broadcast. If the WASM ever returned a wrong number — whether from an honest bug or a tampered binary — nothing would have caught it:

- A wrong `peginAmount` (different from what the user asked for) means the contract records one amount while the user's wallet funds another. The difference is a silent tax the user can't see.
- An `htlcValue` that's too small means the downstream transactions can't pay their fees, so the user's funds sit stuck until the refund timelock.
- An `htlcValue` that's too large means extra sats are locked in the HTLC and can't be recovered.

This is one of the codebase's flagged critical paths (WASM value boundary), so "the code compiled and tests passed" is not enough — a wrong value here ships silently.

## What we changed

1. **A cross-check at the single choke point.** Every peg-in (both the sizing pass and the commit pass) goes through one function, `buildPrePeginPsbt`. We added a new helper, `assertWasmPeginSizing`, that runs there right after the WASM call and validates every value before anything downstream can use it. Putting it in one place means we can't accidentally miss a path.

2. **The checks themselves**, strongest first:
   - The recorded `peginAmount` for each vault must exactly equal what the user requested. This is pure JavaScript and does not trust the WASM at all — it's the main defense against the "silent tax" case.
   - The number of returned values must match the number of deposits requested, and every value must be positive.
   - The implied fee (`htlcValue − peginAmount − depositorClaimValue`) must be positive and within a sane upper bound.
   - The `depositorClaimValue` is cross-checked against a second WASM entry point as a consistency check.

3. **A cheap guard right at the WASM boundary** (closes 877). Before any value leaves the WASM wrapper, we confirm it's actually a positive `bigint`. This catches a broken value at the exact seam instead of letting it travel into satoshi math.

4. **A UI fix that falls out of the above.** The deposit form reads two of these WASM values to show the "Max" deposit amount. Now that a bad value throws instead of silently returning zero, the form could otherwise get stuck on "Calculating fees…" forever. We surface that failure as an error state — exactly the way the form already handles the sister value (`minPeginFee`).

## Approaches we considered for the fee check

The amount and count checks are easy: they're pure JavaScript and fully independent of the WASM. The only real decision was how strict to be on the **fee** portion of `htlcValue`.

- **Option A — exact match.** Recompute the expected fee and require `htlcValue` to equal `peginAmount + depositorClaimValue + fee` exactly.
- **Option B — bounded plausibility (chosen).** Require the implied fee to be positive and below a generous ceiling.

We chose **Option B**. The exact-match option sounds safer but is actually fragile: the codebase already documents that the JavaScript and Rust fee-size calculations are *not* guaranteed to produce byte-identical vbyte numbers. An exact check would then reject perfectly valid deposits — a worse outcome than the bug we're fixing, because it blocks real users. The bound we use is the maximum size any standard Bitcoin transaction can have, so it never trips on a legitimate peg-in but still catches a grossly inflated value. The amount-echo check (which *is* exact and independent) already fully protects the user's deposit amount, so the fee only needs a plausibility guard, not a precise one.

## Scope

We did the full fix (the SDK cross-check) plus the cheap boundary guard 877 in one PR, since they guard the same boundary and one subsumes the other.

## Testing

- New unit tests for the cross-check, one per failure path, including a two-vault batch that proves a tampered second-vault amount or value is caught.
- New test for the form's error gate.
- Existing peg-in and `PeginManager` suites run real WASM through the new check and all pass — confirming valid deposits are not falsely rejected.
- All packages: ts-sdk (1281 tests), vault (1798 tests) green; lint and type-check clean across ts-sdk, the WASM package, and vault.

## Reviewer notes

This touches a critical value path, so please review with two sets of eyes. The two spots worth a closer look against the Rust reference (`btc-vault`):

- the upper-bound constant used for the fee plausibility check, and
- the assumption that the standalone claim-value computation reproduces the constructor's internal one (so the consistency check can never false-positive).

Closes 869 and 877 from Sherlock.