### PR TITLE
fix(vault): bind and disclose VP commission before deposit

### DIFF
--- a/services/vault/src/components/simple/DepositFeesBreakdown.tsx
+++ b/services/vault/src/components/simple/DepositFeesBreakdown.tsx
@@ -1,11 +1,23 @@
 import { Hint } from "@babylonlabs-io/core-ui";
 import { useMemo } from "react";
 
+import { COPY } from "@/copy";
 import { satoshiToBtcNumber } from "@/utils/btcConversion";
-import { formatBtcAmount } from "@/utils/formatting";
+import {
+  formatBasisPointsAsPercent,
+  formatBtcAmount,
+} from "@/utils/formatting";
 
 const TRANSACTION_RESERVE_TOOLTIP =
   "A small portion of your deposit is reserved in a dedicated output to fund a future protocol claim transaction. It remains locked until claim conditions are met and is returned to you if unused.";
+
+const FORM_COPY = COPY.deposit.form;
+
+/** Basis-points denominator: 10_000 bps = 100%. */
+const BPS_DENOMINATOR = 10_000n;
+
+/** Placeholder shown for a fee line whose value isn't known yet. */
+const METRIC_PLACEHOLDER = "--";
 
 interface DepositFeesBreakdownProps {
   depositorClaimValue?: bigint;
@@ -14,6 +26,10 @@ interface DepositFeesBreakdownProps {
   protocolFeeAmount: string;
   protocolFeePrice: string;
   protocolFeeIsError: boolean;
+  /** Entered deposit amount (satoshis) — base for the commission/net figures. */
+  amountSats: bigint;
+  /** VP commission (bps) for the selected provider; undefined while loading. */
+  commissionBps?: number;
 }
 
 interface FeeLineProps {
@@ -63,12 +79,19 @@ export function DepositFeesBreakdown({
   protocolFeeAmount,
   protocolFeePrice,
   protocolFeeIsError,
+  amountSats,
+  commissionBps,
 }: DepositFeesBreakdownProps) {
-  const transactionReserve = useMemo(() => {
-    if (depositorClaimValue === undefined) {
-      return { amount: "--", price: "" };
+  // Format a satoshi value as a BTC amount plus an optional "($X USD)" suffix,
+  // matching the existing fee-line presentation. `null` sats render as the
+  // metric placeholder (value not yet known).
+  const formatSatsLine = (
+    sats: bigint | null,
+  ): { amount: string; price: string } => {
+    if (sats === null) {
+      return { amount: METRIC_PLACEHOLDER, price: "" };
     }
-    const btc = satoshiToBtcNumber(depositorClaimValue);
+    const btc = satoshiToBtcNumber(sats);
     const hasPrice = !hasPriceFetchError && btcPrice > 0;
     const price = hasPrice
       ? `($${(btc * btcPrice).toLocaleString("en-US", {
@@ -77,7 +100,32 @@ export function DepositFeesBreakdown({
         })} USD)`
       : "";
     return { amount: formatBtcAmount(btc), price };
-  }, [depositorClaimValue, btcPrice, hasPriceFetchError]);
+  };
+
+  const transactionReserve = formatSatsLine(
+    depositorClaimValue === undefined ? null : depositorClaimValue,
+  );
+
+  // VP commission is floor(amount * bps / 10_000), deducted from the payout.
+  // Net payout is the deposit minus that commission. Both are unknown until the
+  // commission loads, so they show the placeholder until then.
+  const { commissionSats, netPayoutSats } = useMemo(() => {
+    if (commissionBps === undefined) {
+      return { commissionSats: null, netPayoutSats: null };
+    }
+    const commission = (amountSats * BigInt(commissionBps)) / BPS_DENOMINATOR;
+    return {
+      commissionSats: commission,
+      netPayoutSats: amountSats - commission,
+    };
+  }, [amountSats, commissionBps]);
+
+  const commission = formatSatsLine(commissionSats);
+  const netPayout = formatSatsLine(netPayoutSats);
+  const commissionLabel =
+    commissionBps === undefined
+      ? FORM_COPY.vpCommissionLabel
+      : `${FORM_COPY.vpCommissionLabel} (${formatBasisPointsAsPercent(commissionBps)})`;
 
   return (
     <div className="flex flex-col gap-2">
@@ -92,6 +140,18 @@ export function DepositFeesBreakdown({
         amount={protocolFeeAmount}
         amountIsError={protocolFeeIsError}
         price={protocolFeePrice}
+      />
+      <FeeLine
+        label={commissionLabel}
+        tooltip={FORM_COPY.vpCommissionTooltip}
+        amount={commission.amount}
+        price={commission.price}
+      />
+      <FeeLine
+        label={FORM_COPY.netPayoutLabel}
+        tooltip={FORM_COPY.netPayoutTooltip}
+        amount={netPayout.amount}
+        price={netPayout.price}
       />
     </div>
   );

--- a/services/vault/src/components/simple/DepositFeesBreakdown.tsx
+++ b/services/vault/src/components/simple/DepositFeesBreakdown.tsx
@@ -26,10 +26,15 @@ interface DepositFeesBreakdownProps {
   protocolFeeAmount: string;
   protocolFeePrice: string;
   protocolFeeIsError: boolean;
-  /** Entered deposit amount (satoshis) — base for the commission/net figures. */
+  /** Entered deposit amount (satoshis) — base for the net-payout figure. */
   amountSats: bigint;
   /** VP commission (bps) for the selected provider; undefined while loading. */
   commissionBps?: number;
+  /**
+   * Full HTLC output values the protocol charges commission on, one per vault.
+   * `undefined` while the reserve / PegIn-fee inputs are still loading.
+   */
+  commissionHtlcValues?: readonly bigint[];
 }
 
 interface FeeLineProps {
@@ -81,6 +86,7 @@ export function DepositFeesBreakdown({
   protocolFeeIsError,
   amountSats,
   commissionBps,
+  commissionHtlcValues,
 }: DepositFeesBreakdownProps) {
   // Format a satoshi value as a BTC amount plus an optional "($X USD)" suffix,
   // matching the existing fee-line presentation. `null` sats render as the
@@ -106,19 +112,28 @@ export function DepositFeesBreakdown({
     depositorClaimValue === undefined ? null : depositorClaimValue,
   );
 
-  // VP commission is floor(amount * bps / 10_000), deducted from the payout.
-  // Net payout is the deposit minus that commission. Both are unknown until the
-  // commission loads, so they show the placeholder until then.
+  // The protocol charges commission on the full HTLC output value
+  // (`htlcValue = deposit + depositorClaimValue + minPeginFee`), not on the
+  // entered deposit alone — see `payout.ts` (commission cap on
+  // `peginPrevOut.value`). For split deposits, each HTLC is floored
+  // independently by the payout cap, so mirror that rather than flooring the
+  // summed value once. Net payout is the deposit minus that commission.
+  // All inputs must be known to size the HTLC values, so the lines show the
+  // placeholder until the commission, reserve, and PegIn fee have all loaded.
   const { commissionSats, netPayoutSats } = useMemo(() => {
-    if (commissionBps === undefined) {
+    if (commissionBps === undefined || commissionHtlcValues === undefined) {
       return { commissionSats: null, netPayoutSats: null };
     }
-    const commission = (amountSats * BigInt(commissionBps)) / BPS_DENOMINATOR;
+    const bps = BigInt(commissionBps);
+    const commission = commissionHtlcValues.reduce(
+      (total, htlcValue) => total + (htlcValue * bps) / BPS_DENOMINATOR,
+      0n,
+    );
     return {
       commissionSats: commission,
       netPayoutSats: amountSats - commission,
     };
-  }, [amountSats, commissionBps]);
+  }, [amountSats, commissionHtlcValues, commissionBps]);
 
   const commission = formatSatsLine(commissionSats);
   const netPayout = formatSatsLine(netPayoutSats);

--- a/services/vault/src/components/simple/DepositForm.tsx
+++ b/services/vault/src/components/simple/DepositForm.tsx
@@ -92,6 +92,12 @@ interface DepositFormProps {
   feeError: string | null;
   depositorClaimValue?: bigint;
   /**
+   * Full HTLC output values the protocol charges commission on, one per vault.
+   * Used by the fee breakdown so split deposits floor commission per HTLC.
+   * `undefined` while the per-vault reserve / PegIn fee is still loading.
+   */
+  commissionHtlcValues?: readonly bigint[];
+  /**
    * Terminal failure from the `computeMinClaimValue` WASM query. CTA surfaces
    * this as "Fee estimate unavailable" instead of an indefinite loading
    * state. Null while the query is healthy.
@@ -176,6 +182,7 @@ export function DepositForm({
   isLoadingFee,
   feeError,
   depositorClaimValue,
+  commissionHtlcValues,
   depositorClaimValueError,
   isDepositDisabled,
   isGeoBlocked,
@@ -422,6 +429,7 @@ export function DepositForm({
         protocolFeeIsError={protocolFeeIsError}
         amountSats={amountSats}
         commissionBps={selectedProviderCommissionBps}
+        commissionHtlcValues={commissionHtlcValues}
       />
 
       {/* Protocol & risk parameters */}

--- a/services/vault/src/components/simple/DepositForm.tsx
+++ b/services/vault/src/components/simple/DepositForm.tsx
@@ -265,6 +265,15 @@ export function DepositForm({
 
   const selectedApp = applications.find((a) => a.id === selectedApplication);
 
+  // Commission (bps) shown for the selected provider. Drives the fee breakdown
+  // and gates the CTA: a selected provider whose commission hasn't loaded
+  // cannot be quoted, so the deposit must wait for it.
+  const selectedProviderCommissionBps = providers.find(
+    (provider) => provider.id === selectedProvider,
+  )?.commissionBps;
+  const commissionUnavailable =
+    !!selectedProvider && selectedProviderCommissionBps === undefined;
+
   const hasAmount = !!amount && amount !== "0";
   const isFeeError = hasAmount && !isLoadingFee && !!feeError;
   const feeDisabled =
@@ -292,6 +301,7 @@ export function DepositForm({
     isAddressBlocked,
     isWalletConnected,
     hasProvider: !!selectedProvider,
+    commissionUnavailable,
     isFeeError,
     feeError,
     feeDisabled,
@@ -410,6 +420,8 @@ export function DepositForm({
         protocolFeeAmount={protocolFeeAmount}
         protocolFeePrice={protocolFeePrice}
         protocolFeeIsError={protocolFeeIsError}
+        amountSats={amountSats}
+        commissionBps={selectedProviderCommissionBps}
       />
 
       {/* Protocol & risk parameters */}

--- a/services/vault/src/components/simple/DepositSignContent.tsx
+++ b/services/vault/src/components/simple/DepositSignContent.tsx
@@ -27,6 +27,8 @@ interface DepositSignContentProps {
   depositorEthAddress: Address | undefined;
   selectedApplication: string;
   selectedProviders: string[];
+  /** VP commission (bps) shown to the depositor for the primary provider. */
+  quotedCommissionBps: number | undefined;
   vaultProviderBtcPubkey: string;
   vaultKeeperBtcPubkeys: string[];
   universalChallengerBtcPubkeys: string[];

--- a/services/vault/src/components/simple/SimpleDeposit.tsx
+++ b/services/vault/src/components/simple/SimpleDeposit.tsx
@@ -144,6 +144,17 @@ function SimpleDepositContent({
       ? depositorClaimValue * BigInt(depositBatchSize)
       : undefined;
 
+  // Full HTLC output values the protocol charges commission on. `amountSats`
+  // is the total deposit, while split deposits are charged per HTLC/payout, so
+  // keep the per-vault values distinct to preserve each floor operation.
+  const commissionHtlcValues =
+    depositorClaimValue !== undefined && minPeginFee != null
+      ? (isPartialLiquidation && vaultAmounts
+          ? vaultAmounts
+          : [amountSats]
+        ).map((vaultAmount) => vaultAmount + depositorClaimValue + minPeginFee)
+      : undefined;
+
   // Live commission (bps) for the selected provider, read from the current
   // providers list. Captured into the deposit snapshot at commit time
   // (`handleDeposit`) so the value the signing flow binds is exactly what the
@@ -382,6 +393,7 @@ function SimpleDepositContent({
                 }
                 isWalletConnected={isWalletConnected}
                 depositorClaimValue={totalDepositorClaimValue}
+                commissionHtlcValues={commissionHtlcValues}
                 depositorClaimValueError={depositorClaimValueError}
                 estimatedFeeSats={estimatedFeeSats}
                 estimatedFeeRate={estimatedFeeRate}

--- a/services/vault/src/components/simple/SimpleDeposit.tsx
+++ b/services/vault/src/components/simple/SimpleDeposit.tsx
@@ -144,6 +144,13 @@ function SimpleDepositContent({
       ? depositorClaimValue * BigInt(depositBatchSize)
       : undefined;
 
+  // Commission (bps) the depositor was shown for the selected provider. Passed
+  // into the deposit flow as the quote that bounds `maxAcceptableCommissionBps`
+  // on-chain; `undefined` while it loads or if the read failed.
+  const selectedProviderCommissionBps = providers.find(
+    (provider) => provider.id === formData.selectedProvider,
+  )?.commissionBps;
+
   const {
     depositStep,
     depositAmount,
@@ -407,6 +414,7 @@ function SimpleDepositContent({
               depositorEthAddress={ethAddress}
               selectedApplication={selectedApplication}
               selectedProviders={selectedProviders}
+              quotedCommissionBps={selectedProviderCommissionBps}
               vaultProviderBtcPubkey={selectedProviderBtcPubkey}
               vaultKeeperBtcPubkeys={vaultKeeperBtcPubkeys}
               universalChallengerBtcPubkeys={universalChallengerBtcPubkeys}

--- a/services/vault/src/components/simple/SimpleDeposit.tsx
+++ b/services/vault/src/components/simple/SimpleDeposit.tsx
@@ -144,9 +144,11 @@ function SimpleDepositContent({
       ? depositorClaimValue * BigInt(depositBatchSize)
       : undefined;
 
-  // Commission (bps) the depositor was shown for the selected provider. Passed
-  // into the deposit flow as the quote that bounds `maxAcceptableCommissionBps`
-  // on-chain; `undefined` while it loads or if the read failed.
+  // Live commission (bps) for the selected provider, read from the current
+  // providers list. Captured into the deposit snapshot at commit time
+  // (`handleDeposit`) so the value the signing flow binds is exactly what the
+  // depositor reviewed — not a value a background refetch changed afterwards.
+  // `undefined` while it loads or if the read failed.
   const selectedProviderCommissionBps = providers.find(
     (provider) => provider.id === formData.selectedProvider,
   )?.commissionBps;
@@ -156,6 +158,7 @@ function SimpleDepositContent({
     depositAmount,
     selectedApplication,
     selectedProviders,
+    quotedCommissionBps,
     feeRate,
     btcWalletProvider,
     ethAddress,
@@ -322,9 +325,12 @@ function SimpleDepositContent({
       shouldSplit && vaultAmounts ? [...vaultAmounts] : [amountSats];
     setOverlappingPendingVaultCount(runOverlapCheck(effectiveVaultAmounts));
 
-    setDepositData(amountSats, effectiveSelectedApplication, [
-      formData.selectedProvider,
-    ]);
+    setDepositData(
+      amountSats,
+      effectiveSelectedApplication,
+      [formData.selectedProvider],
+      selectedProviderCommissionBps,
+    );
     setFeeRate(estimatedFeeRate);
     setIsSplitDeposit(shouldSplit);
     if (shouldSplit && vaultAmounts) {
@@ -414,7 +420,7 @@ function SimpleDepositContent({
               depositorEthAddress={ethAddress}
               selectedApplication={selectedApplication}
               selectedProviders={selectedProviders}
-              quotedCommissionBps={selectedProviderCommissionBps}
+              quotedCommissionBps={quotedCommissionBps}
               vaultProviderBtcPubkey={selectedProviderBtcPubkey}
               vaultKeeperBtcPubkeys={vaultKeeperBtcPubkeys}
               universalChallengerBtcPubkeys={universalChallengerBtcPubkeys}

--- a/services/vault/src/components/simple/__tests__/DepositFeesBreakdown.test.tsx
+++ b/services/vault/src/components/simple/__tests__/DepositFeesBreakdown.test.tsx
@@ -1,8 +1,9 @@
 /**
  * Tests for the deposit fee breakdown's VP-commission and net-payout lines
  * (the disclosure half of TRV-032). They pin the depositor-facing numbers:
- * the commission percent, the commission deducted from the deposit, and the
- * resulting net payout — and the placeholder shown before the commission loads.
+ * the commission percent, the commission charged (on the full HTLC value, not
+ * the entered amount), and the resulting net payout — plus the placeholder
+ * shown before the inputs that size the HTLC value have loaded.
  */
 
 import { render, screen } from "@testing-library/react";
@@ -11,7 +12,6 @@ import { describe, expect, it } from "vitest";
 import { DepositFeesBreakdown } from "../DepositFeesBreakdown";
 
 const baseProps = {
-  depositorClaimValue: 5000n,
   btcPrice: 0,
   hasPriceFetchError: false,
   protocolFeeAmount: "0.0001 BTC",
@@ -20,20 +20,24 @@ const baseProps = {
 };
 
 describe("DepositFeesBreakdown commission disclosure", () => {
-  it("shows the commission percent, commission amount, and net payout", () => {
-    // 1 BTC deposit at 250 bps (2.5%): commission 0.025 BTC, net 0.975 BTC.
+  it("charges commission on the HTLC value (deposit + reserve + pegin fee), not the deposit alone", () => {
+    // htlcValue = 1.00 + 0.03 + 0.01 = 1.04 BTC. At 2.5%, commission =
+    // floor(1.04 × 2.5%) = 0.026 — distinct from the deposit-only 0.025, which
+    // proves the HTLC-value basis. Net payout = deposit − commission = 0.974.
     render(
       <DepositFeesBreakdown
         {...baseProps}
         amountSats={100_000_000n}
+        depositorClaimValue={3_000_000n}
+        commissionHtlcValues={[104_000_000n]}
         commissionBps={250}
       />,
     );
 
     expect(screen.getByText("VP commission (2.5%)")).toBeInTheDocument();
     expect(screen.getByText("Net payout")).toBeInTheDocument();
-    expect(screen.getByText(/0\.025/)).toBeInTheDocument();
-    expect(screen.getByText(/0\.975/)).toBeInTheDocument();
+    expect(screen.getByText(/0\.026/)).toBeInTheDocument();
+    expect(screen.getByText(/0\.974/)).toBeInTheDocument();
   });
 
   it("shows the placeholder and no percent while the commission is unavailable", () => {
@@ -41,6 +45,8 @@ describe("DepositFeesBreakdown commission disclosure", () => {
       <DepositFeesBreakdown
         {...baseProps}
         amountSats={100_000_000n}
+        depositorClaimValue={3_000_000n}
+        commissionHtlcValues={[104_000_000n]}
         commissionBps={undefined}
       />,
     );
@@ -50,5 +56,39 @@ describe("DepositFeesBreakdown commission disclosure", () => {
     expect(screen.queryByText(/VP commission \(/)).not.toBeInTheDocument();
     // Both the commission and net-payout cells render the "--" placeholder.
     expect(screen.getAllByText("--").length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("shows the placeholder until the HTLC values have loaded", () => {
+    render(
+      <DepositFeesBreakdown
+        {...baseProps}
+        amountSats={100_000_000n}
+        depositorClaimValue={3_000_000n}
+        commissionHtlcValues={undefined}
+        commissionBps={250}
+      />,
+    );
+
+    // Percent is still shown (it's just the bps), but the sats can't be sized
+    // without the pegin fee, so commission and net payout stay as "--".
+    expect(screen.getByText("VP commission (2.5%)")).toBeInTheDocument();
+    expect(screen.getAllByText("--").length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("floors commission per HTLC for split deposits", () => {
+    render(
+      <DepositFeesBreakdown
+        {...baseProps}
+        amountSats={10n}
+        depositorClaimValue={0n}
+        commissionHtlcValues={[5n, 5n]}
+        commissionBps={5000}
+      />,
+    );
+
+    // floor(5 * 50%) + floor(5 * 50%) = 4 sats. A single floor on the summed
+    // value would produce 5 sats, which is not the per-HTLC protocol cap.
+    expect(screen.getByText(/0\.00000004/)).toBeInTheDocument();
+    expect(screen.getByText(/0\.00000006/)).toBeInTheDocument();
   });
 });

--- a/services/vault/src/components/simple/__tests__/DepositFeesBreakdown.test.tsx
+++ b/services/vault/src/components/simple/__tests__/DepositFeesBreakdown.test.tsx
@@ -1,0 +1,54 @@
+/**
+ * Tests for the deposit fee breakdown's VP-commission and net-payout lines
+ * (the disclosure half of TRV-032). They pin the depositor-facing numbers:
+ * the commission percent, the commission deducted from the deposit, and the
+ * resulting net payout — and the placeholder shown before the commission loads.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { DepositFeesBreakdown } from "../DepositFeesBreakdown";
+
+const baseProps = {
+  depositorClaimValue: 5000n,
+  btcPrice: 0,
+  hasPriceFetchError: false,
+  protocolFeeAmount: "0.0001 BTC",
+  protocolFeePrice: "",
+  protocolFeeIsError: false,
+};
+
+describe("DepositFeesBreakdown commission disclosure", () => {
+  it("shows the commission percent, commission amount, and net payout", () => {
+    // 1 BTC deposit at 250 bps (2.5%): commission 0.025 BTC, net 0.975 BTC.
+    render(
+      <DepositFeesBreakdown
+        {...baseProps}
+        amountSats={100_000_000n}
+        commissionBps={250}
+      />,
+    );
+
+    expect(screen.getByText("VP commission (2.5%)")).toBeInTheDocument();
+    expect(screen.getByText("Net payout")).toBeInTheDocument();
+    expect(screen.getByText(/0\.025/)).toBeInTheDocument();
+    expect(screen.getByText(/0\.975/)).toBeInTheDocument();
+  });
+
+  it("shows the placeholder and no percent while the commission is unavailable", () => {
+    render(
+      <DepositFeesBreakdown
+        {...baseProps}
+        amountSats={100_000_000n}
+        commissionBps={undefined}
+      />,
+    );
+
+    // Label has no percent suffix when the commission hasn't loaded.
+    expect(screen.getByText("VP commission")).toBeInTheDocument();
+    expect(screen.queryByText(/VP commission \(/)).not.toBeInTheDocument();
+    // Both the commission and net-payout cells render the "--" placeholder.
+    expect(screen.getAllByText("--").length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/services/vault/src/components/simple/__tests__/DepositSignContent.test.tsx
+++ b/services/vault/src/components/simple/__tests__/DepositSignContent.test.tsx
@@ -52,6 +52,7 @@ function renderContent(
       depositorEthAddress={"0xeth" as Address}
       selectedApplication="0xapp"
       selectedProviders={["0xprovider"]}
+      quotedCommissionBps={250}
       vaultProviderBtcPubkey="0xvp"
       vaultKeeperBtcPubkeys={["0xkeeper"]}
       universalChallengerBtcPubkeys={["0xchallenger"]}

--- a/services/vault/src/context/deposit/DepositState.tsx
+++ b/services/vault/src/context/deposit/DepositState.tsx
@@ -21,6 +21,15 @@ interface DepositStateContext {
   amount: bigint;
   selectedApplication: string;
   selectedProviders: string[];
+  /**
+   * VP commission (bps) the depositor was shown for the primary provider,
+   * frozen at commit time. Bounds `maxAcceptableCommissionBps` in the signing
+   * flow, so it must be snapshotted with the rest of the deposit data rather
+   * than re-read live — otherwise a background commission refetch between
+   * review and signing could bind a value the depositor never saw.
+   * `undefined` if the commission had not loaded at commit time.
+   */
+  quotedCommissionBps: number | undefined;
   feeRate: number;
   processing: boolean;
   isSplitDeposit: boolean;
@@ -30,6 +39,7 @@ interface DepositStateContext {
     amount: bigint,
     application: string,
     providers: string[],
+    quotedCommissionBps: number | undefined,
   ) => void;
   setFeeRate: (feeRate: number) => void;
   setProcessing: (processing: boolean) => void;
@@ -44,6 +54,7 @@ const { StateProvider, useState: useDepositState } =
     amount: 0n,
     selectedApplication: "",
     selectedProviders: [],
+    quotedCommissionBps: undefined,
     feeRate: 0,
     processing: false,
     isSplitDeposit: false,
@@ -62,6 +73,9 @@ export function DepositState({ children }: PropsWithChildren) {
   const [amount, setAmount] = useState<bigint>(0n);
   const [selectedApplication, setSelectedApplication] = useState("");
   const [selectedProviders, setSelectedProviders] = useState<string[]>([]);
+  const [quotedCommissionBps, setQuotedCommissionBps] = useState<
+    number | undefined
+  >(undefined);
   const [feeRate, setFeeRate] = useState(0);
   const [processing, setProcessing] = useState(false);
   const [isSplitDeposit, setIsSplitDeposit] = useState(false);
@@ -74,10 +88,16 @@ export function DepositState({ children }: PropsWithChildren) {
   }, []);
 
   const setDepositData = useCallback(
-    (newAmount: bigint, application: string, providers: string[]) => {
+    (
+      newAmount: bigint,
+      application: string,
+      providers: string[],
+      commissionBps: number | undefined,
+    ) => {
       setAmount(newAmount);
       setSelectedApplication(application);
       setSelectedProviders(providers);
+      setQuotedCommissionBps(commissionBps);
     },
     [],
   );
@@ -91,6 +111,7 @@ export function DepositState({ children }: PropsWithChildren) {
     setAmount(0n);
     setSelectedApplication("");
     setSelectedProviders([]);
+    setQuotedCommissionBps(undefined);
     setFeeRate(0);
     setProcessing(false);
     setIsSplitDeposit(false);
@@ -103,6 +124,7 @@ export function DepositState({ children }: PropsWithChildren) {
       amount,
       selectedApplication,
       selectedProviders,
+      quotedCommissionBps,
       feeRate,
       processing,
       isSplitDeposit,
@@ -120,6 +142,7 @@ export function DepositState({ children }: PropsWithChildren) {
       amount,
       selectedApplication,
       selectedProviders,
+      quotedCommissionBps,
       feeRate,
       processing,
       isSplitDeposit,

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -351,6 +351,15 @@ export const COPY = {
       // Per-provider metric labels shown in the picker.
       providerCommissionLabel: "Commission",
       providerActiveLabel: "Total locked",
+      // Fee-breakdown lines (DepositFeesBreakdown) shown before the user
+      // submits. The commission label appends the percent, e.g. "VP commission
+      // (2.50%)"; net payout is the deposit minus that commission.
+      vpCommissionLabel: "VP commission",
+      vpCommissionTooltip:
+        "The vault provider's fee, deducted from your payout when you redeem. Set by the provider and shown here before you deposit.",
+      netPayoutLabel: "Net payout",
+      netPayoutTooltip:
+        "What you receive at payout: your deposit minus the vault provider's commission.",
       // Placeholder while a metric (commission, active BTC) is loading or
       // could not be fetched.
       providerMetricPlaceholder: "—",
@@ -442,6 +451,14 @@ export const COPY = {
       wrongWalletAccount: {
         title: "Wrong wallet account",
         body: WRONG_WALLET_BODY,
+      },
+      commissionChanged: {
+        title: "Commission changed",
+        body: "The vault provider raised its commission since you selected it. Please refresh to see the new commission and start the deposit again.",
+      },
+      commissionUnavailable: {
+        title: "Commission unavailable",
+        body: "We couldn't confirm the vault provider's commission. Please refresh and try again before depositing.",
       },
       // Vault-provider JSON-RPC error copy, consumed by `mapVpRpcError`
       // (utils/errors/formatting.ts). Title + message are both user-facing.

--- a/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
@@ -244,6 +244,7 @@ const MOCK_PARAMS = {
   depositorEthAddress: "0xEthAddress123" as Address,
   selectedApplication: "0xAppController",
   selectedProviders: ["0xProvider123"],
+  quotedCommissionBps: 250,
   vaultProviderBtcPubkey: "ab".repeat(32),
   vaultKeeperBtcPubkeys: ["keeper1pubkey"],
   universalChallengerBtcPubkeys: ["uc1pubkey"],
@@ -466,6 +467,9 @@ describe("useDepositFlow", () => {
         expect(callArgs?.vaultProviderAddress).toBe("0xProvider123");
         expect(callArgs?.unsignedPrePeginTx).toBe("batchFundedPrePeginHex");
         expect(callArgs?.requests).toHaveLength(2);
+        // The commission the depositor saw is forwarded as the quote that
+        // bounds maxAcceptableCommissionBps on-chain.
+        expect(callArgs?.quotedCommissionBps).toBe(250);
 
         // First vault: htlcVout = 0
         expect(callArgs?.requests[0]).toEqual(
@@ -1316,6 +1320,24 @@ describe("useDepositFlow", () => {
         expect(result.current.error?.body).toContain("Insufficient funds");
         expect(result.current.processing).toBe(false);
       });
+    });
+
+    it("refuses to submit and never prepares the pegin when the commission is unavailable", async () => {
+      const { preparePeginTransaction } = vi.mocked(
+        await import("@/services/vault/vaultTransactionService"),
+      );
+
+      const { result } = renderHook(() =>
+        useDepositFlow({ ...MOCK_PARAMS, quotedCommissionBps: undefined }),
+      );
+      await executeDepositFlow(result);
+
+      await waitFor(() => {
+        expect(result.current.error?.title).toBe("Commission unavailable");
+        expect(result.current.processing).toBe(false);
+      });
+      // The guard fires before any BTC is committed.
+      expect(preparePeginTransaction).not.toHaveBeenCalled();
     });
   });
 });

--- a/services/vault/src/hooks/deposit/depositFlowSteps/ethereumSubmit.ts
+++ b/services/vault/src/hooks/deposit/depositFlowSteps/ethereumSubmit.ts
@@ -93,6 +93,7 @@ export async function registerPeginBatchAndWait(
     unsignedPrePeginTx,
     requests,
     popSignature,
+    quotedCommissionBps,
   } = params;
 
   const result = await registerPeginBatchOnChain(
@@ -103,6 +104,7 @@ export async function registerPeginBatchAndWait(
       unsignedPrePeginTx,
       requests,
       popSignature,
+      quotedCommissionBps,
     },
   );
 

--- a/services/vault/src/hooks/deposit/depositFlowSteps/types.ts
+++ b/services/vault/src/hooks/deposit/depositFlowSteps/types.ts
@@ -110,6 +110,12 @@ export interface PeginBatchRegisterParams {
   }>;
   /** Proof of possession from signProofOfPossession. */
   popSignature: PopSignature;
+  /**
+   * VP commission (bps) the depositor was shown at provider selection. Bounds
+   * `maxAcceptableCommissionBps` so registration is rejected if the on-chain
+   * commission drifted upward beyond the SDK's headroom since the quote.
+   */
+  quotedCommissionBps: number;
 }
 
 export interface PeginBatchRegisterResult {

--- a/services/vault/src/hooks/deposit/useDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useDepositFlow.ts
@@ -65,7 +65,11 @@ import {
   verifyBtcWalletLiveness,
 } from "@/utils/btc";
 import { satoshiToBtcNumber } from "@/utils/btcConversion";
-import { mapDepositError, type DepositErrorContent } from "@/utils/errors";
+import {
+  COMMISSION_UNAVAILABLE_ERROR,
+  mapDepositError,
+  type DepositErrorContent,
+} from "@/utils/errors";
 import { formatBtcValue } from "@/utils/formatting";
 import { getVpProxyUrl } from "@/utils/rpc";
 
@@ -102,6 +106,13 @@ export interface UseDepositFlowParams {
   selectedApplication: string;
   /** Selected vault provider addresses */
   selectedProviders: string[];
+  /**
+   * VP commission (bps) shown to the depositor at provider selection, for the
+   * primary provider (`selectedProviders[0]`). `undefined` while the on-chain
+   * commission is still loading or failed to fetch — the flow refuses to submit
+   * in that state rather than binding to an unquoted value.
+   */
+  quotedCommissionBps: number | undefined;
   /** Vault provider BTC public key (x-only, 64 hex chars) */
   vaultProviderBtcPubkey: string;
   /** Vault keeper BTC public keys */
@@ -200,6 +211,7 @@ export function useDepositFlow(
     depositorEthAddress,
     selectedApplication,
     selectedProviders,
+    quotedCommissionBps,
     vaultProviderBtcPubkey,
     vaultKeeperBtcPubkeys,
     universalChallengerBtcPubkeys,
@@ -361,6 +373,14 @@ export function useDepositFlow(
         // Extract primary provider (current implementation supports single provider only)
         const primaryProvider = selectedProviders[0] as Address;
 
+        // The VP commission the depositor was shown must be known before we
+        // bind it on-chain. If it never loaded, refuse to submit rather than
+        // letting the SDK bind `maxAcceptableCommissionBps` to an unquoted
+        // fresh read — that is the silent-overcharge path TRV-032 describes.
+        if (quotedCommissionBps === undefined) {
+          throw new Error(COMMISSION_UNAVAILABLE_ERROR);
+        }
+
         // Generate batch ID for tracking
         const batchId = uuidv4();
 
@@ -519,6 +539,7 @@ export function useDepositFlow(
           unsignedPrePeginTx: batchResult.fundedPrePeginTxHex,
           requests: batchRequests,
           popSignature,
+          quotedCommissionBps,
         });
 
         // 3f. Build pegin results from batch response
@@ -1143,6 +1164,7 @@ export function useDepositFlow(
       depositorEthAddress,
       selectedApplication,
       selectedProviders,
+      quotedCommissionBps,
       vaultProviderBtcPubkey,
       vaultKeeperBtcPubkeys,
       universalChallengerBtcPubkeys,

--- a/services/vault/src/hooks/deposit/useDepositPageFlow.ts
+++ b/services/vault/src/hooks/deposit/useDepositPageFlow.ts
@@ -28,6 +28,8 @@ export interface UseDepositPageFlowResult {
   depositAmount: bigint;
   selectedApplication: string;
   selectedProviders: string[];
+  /** VP commission (bps) frozen at commit time; `undefined` if it hadn't loaded. */
+  quotedCommissionBps: number | undefined;
   feeRate: number;
 
   // Wallet data
@@ -48,6 +50,7 @@ export interface UseDepositPageFlowResult {
     amountSats: bigint,
     application: string,
     providers: string[],
+    quotedCommissionBps: number | undefined,
   ) => void;
   confirmReview: (feeRate: number) => void;
   resetDeposit: () => void;
@@ -65,6 +68,7 @@ export interface UseDepositPageFlowResult {
     amount: bigint,
     application: string,
     providers: string[],
+    quotedCommissionBps: number | undefined,
   ) => void;
   setFeeRate: (feeRate: number) => void;
 }
@@ -84,6 +88,7 @@ export function useDepositPageFlow(): UseDepositPageFlowResult {
     amount: depositAmount,
     selectedApplication,
     selectedProviders,
+    quotedCommissionBps,
     feeRate,
     goToStep,
     setDepositData,
@@ -147,8 +152,9 @@ export function useDepositPageFlow(): UseDepositPageFlowResult {
     amountSats: bigint,
     application: string,
     providers: string[],
+    commissionBps: number | undefined,
   ) => {
-    setDepositData(amountSats, application, providers);
+    setDepositData(amountSats, application, providers, commissionBps);
     goToStep(DepositStep.REVIEW);
   };
 
@@ -166,6 +172,7 @@ export function useDepositPageFlow(): UseDepositPageFlowResult {
     depositAmount,
     selectedApplication,
     selectedProviders,
+    quotedCommissionBps,
     feeRate,
     btcWalletProvider,
     ethAddress,

--- a/services/vault/src/services/deposit/__tests__/validations.test.ts
+++ b/services/vault/src/services/deposit/__tests__/validations.test.ts
@@ -289,6 +289,7 @@ describe("Deposit Validations", () => {
       isAddressBlocked: false,
       isWalletConnected: true,
       hasProvider: true,
+      commissionUnavailable: false,
       isFeeError: false,
       feeError: null,
       feeDisabled: false,
@@ -399,6 +400,26 @@ describe("Deposit Validations", () => {
         disabled: true,
         label: "Select a vault provider",
       });
+    });
+
+    it("blocks with 'Loading commission...' when the selected provider commission is unavailable", () => {
+      const result = getDepositCtaState({
+        ...readyParams,
+        commissionUnavailable: true,
+      });
+      expect(result).toEqual({
+        disabled: true,
+        label: "Loading commission...",
+      });
+    });
+
+    it("prioritizes 'Select a vault provider' over the commission gate", () => {
+      const result = getDepositCtaState({
+        ...readyParams,
+        hasProvider: false,
+        commissionUnavailable: true,
+      });
+      expect(result.label).toBe("Select a vault provider");
     });
 
     it("returns fee error message when fee estimation fails", () => {

--- a/services/vault/src/services/deposit/__tests__/validations.test.ts
+++ b/services/vault/src/services/deposit/__tests__/validations.test.ts
@@ -422,6 +422,17 @@ describe("Deposit Validations", () => {
       expect(result.label).toBe("Select a vault provider");
     });
 
+    it("prioritizes amount guidance over the commission gate", () => {
+      // Below-minimum amount with the commission still loading: the actionable
+      // "Minimum" guidance should win, not "Loading commission...".
+      const result = getDepositCtaState({
+        ...readyParams,
+        amountSats: 5000n,
+        commissionUnavailable: true,
+      });
+      expect(result.label).toContain("Minimum");
+    });
+
     it("returns fee error message when fee estimation fails", () => {
       const result = getDepositCtaState({
         ...readyParams,

--- a/services/vault/src/services/deposit/validations.ts
+++ b/services/vault/src/services/deposit/validations.ts
@@ -100,6 +100,14 @@ export interface DepositCtaParams extends DepositFormValidityParams {
   isAddressBlocked: boolean;
   isWalletConnected: boolean;
   hasProvider: boolean;
+  /**
+   * True when a provider is selected but its on-chain commission hasn't loaded
+   * (still fetching or the read failed). The deposit binds this commission as
+   * the quote that bounds `maxAcceptableCommissionBps` on-chain, so submitting
+   * without a known value risks the silent-overcharge path: block until it is
+   * available rather than letting the flow bind to an unquoted fresh read.
+   */
+  commissionUnavailable: boolean;
   isFeeError: boolean;
   feeError: string | null;
   feeDisabled: boolean;
@@ -351,6 +359,12 @@ export function getDepositCtaState(params: DepositCtaParams): DepositCtaState {
 
   if (!params.hasProvider) {
     return { disabled: true, label: "Select a vault provider" };
+  }
+
+  // A provider is selected but its commission hasn't loaded. The deposit can't
+  // bind a commission it hasn't read, so block until it is available.
+  if (params.commissionUnavailable) {
+    return { disabled: true, label: "Loading commission..." };
   }
 
   // Surface a terminal `computeMinPeginFee` failure ahead of the "still

--- a/services/vault/src/services/deposit/validations.ts
+++ b/services/vault/src/services/deposit/validations.ts
@@ -361,12 +361,6 @@ export function getDepositCtaState(params: DepositCtaParams): DepositCtaState {
     return { disabled: true, label: "Select a vault provider" };
   }
 
-  // A provider is selected but its commission hasn't loaded. The deposit can't
-  // bind a commission it hasn't read, so block until it is available.
-  if (params.commissionUnavailable) {
-    return { disabled: true, label: "Loading commission..." };
-  }
-
   // Surface a terminal `computeMinPeginFee` failure ahead of the "still
   // loading" gate below. Without this branch a query rejection (WASM init
   // failure, unsupported signer count) would leave the CTA stuck on
@@ -391,6 +385,14 @@ export function getDepositCtaState(params: DepositCtaParams): DepositCtaState {
   const amountLabel = getDepositButtonLabel(params);
   if (amountLabel !== "Deposit") {
     return { disabled: true, label: amountLabel };
+  }
+
+  // The amount is valid and a provider is selected, but its commission hasn't
+  // loaded. The deposit binds this commission as the quote, so block until it
+  // is known — checked after the amount guidance so "Enter an amount" /
+  // "Minimum" isn't preempted by a transient commission load.
+  if (params.commissionUnavailable) {
+    return { disabled: true, label: "Loading commission..." };
   }
 
   if (params.ordinalsCheckPending) {

--- a/services/vault/src/services/vault/vaultTransactionService.ts
+++ b/services/vault/src/services/vault/vaultTransactionService.ts
@@ -144,6 +144,15 @@ export interface RegisterPeginBatchOnChainParams {
   requests: BatchPeginRequestItem[];
   /** Proof of possession from signProofOfPossession(). */
   popSignature: PopSignature;
+  /**
+   * VP commission (bps) the depositor was shown at provider selection.
+   * Forwarded to the SDK as the quote that bounds `maxAcceptableCommissionBps`
+   * on-chain: if the on-chain commission has drifted upward beyond the SDK's
+   * allowed headroom between the quote and submit, registration is rejected
+   * instead of silently binding to the new higher value. See
+   * `PeginManager.resolveMaxAcceptableCommissionBps`.
+   */
+  quotedCommissionBps: number;
 }
 
 /**
@@ -254,6 +263,7 @@ export async function registerPeginBatchOnChain(
     unsignedPrePeginTx: params.unsignedPrePeginTx,
     requests: params.requests,
     popSignature: params.popSignature,
+    quotedCommissionBps: params.quotedCommissionBps,
   });
 
   return {

--- a/services/vault/src/utils/errors/__tests__/depositErrors.test.ts
+++ b/services/vault/src/utils/errors/__tests__/depositErrors.test.ts
@@ -13,7 +13,10 @@ import { describe, expect, it } from "vitest";
 
 import { COPY } from "@/copy";
 
-import { mapDepositError } from "../depositErrors";
+import {
+  COMMISSION_UNAVAILABLE_ERROR,
+  mapDepositError,
+} from "../depositErrors";
 
 const ERRORS = COPY.deposit.errors;
 
@@ -56,6 +59,20 @@ describe("mapDepositError", () => {
       "BTC wallet account changed during deposit flow. Please restart.",
     );
     expect(mapDepositError(err)).toEqual(ERRORS.walletAccountChanged);
+  });
+
+  it("maps the SDK commission-drift error to the commission-changed callout", () => {
+    const err = new Error(
+      "Vault provider commission changed since quote: quoted 250 bps, " +
+        "chain currently reports 9999 bps (allowed drift 25 bps). " +
+        "Please refresh to see the new commission and try again.",
+    );
+    expect(mapDepositError(err)).toEqual(ERRORS.commissionChanged);
+  });
+
+  it("maps the commission-unavailable guard to the commission-unavailable callout", () => {
+    const err = new Error(COMMISSION_UNAVAILABLE_ERROR);
+    expect(mapDepositError(err)).toEqual(ERRORS.commissionUnavailable);
   });
 
   it("maps an insufficient-ETH gas error to the insufficient-ETH callout", () => {

--- a/services/vault/src/utils/errors/depositErrors.ts
+++ b/services/vault/src/utils/errors/depositErrors.ts
@@ -52,6 +52,15 @@ export interface DepositErrorContent {
 const ERRORS = COPY.deposit.errors;
 
 /**
+ * Thrown by the deposit flow when the selected vault provider's commission
+ * never loaded, so it can't be quoted as `maxAcceptableCommissionBps`. Used as
+ * the matchable marker for the friendly `commissionUnavailable` mapping; the
+ * flow refuses to submit unbound rather than risk the silent-overcharge path.
+ */
+export const COMMISSION_UNAVAILABLE_ERROR =
+  "Vault provider commission unavailable at submit";
+
+/**
  * Extract a lowercase message from an unknown error for substring matching.
  * Includes viem's `shortMessage` (often where "insufficient funds" lives)
  * alongside the standard `message`.
@@ -107,6 +116,18 @@ export function mapDepositError(err: unknown): DepositErrorContent {
     msg.includes("wots public key hash does not match")
   ) {
     return ERRORS.wrongWalletAccount;
+  }
+
+  // 4c. VP commission drift / unavailability. The SDK throws "...commission
+  // changed since quote..." when the on-chain commission rose above the quoted
+  // value plus headroom; the flow throws COMMISSION_UNAVAILABLE_ERROR when the
+  // commission never loaded. Both are recoverable by refreshing, so they get
+  // their own titles instead of the generic fallback.
+  if (msg.includes("commission changed since quote")) {
+    return ERRORS.commissionChanged;
+  }
+  if (msg.includes(COMMISSION_UNAVAILABLE_ERROR.toLowerCase())) {
+    return ERRORS.commissionUnavailable;
   }
 
   // 5. Wallet not connected / wallet client unavailable. Checked before the


### PR DESCRIPTION
# Disclose and enforce the vault provider commission (Coinspect TRV-032)

## The problem in plain words

Every vault provider (VP) charges a commission that is taken out of the depositor's payout. The audit found that a depositor could be charged a commission far higher than the one they were shown — in the worst case up to ~99.99% of their deposit — without ever seeing it. So someone could deposit expecting a 2.5% fee and silently get back almost nothing.

Two things were missing on `main`:

- The commission was shown in the provider picker, but nowhere on the review/submit screen — so it was easy to miss.
- More importantly, the commission the depositor *saw* was never tied to the commission they *actually paid*. The SDK already had a guard built for exactly this (it throws if the on-chain commission rose too far above a quoted value), but the app never passed the quoted value — so the guard was effectively dead code. The app just read whatever the on-chain commission happened to be at submit time and locked that in. A VP could raise its commission in the gap between the depositor viewing the picker and clicking submit, and it would go through silently.

## What we did

This PR has two parts. Part A is the real protection; Part B is the disclosure.

**Part A — Bind the commission the depositor saw (the security fix).** We pass the commission shown for the selected provider into the deposit flow as the "quote". This turns on the SDK's existing drift check: if the on-chain commission has risen more than the allowed headroom (25 bps) above what the depositor was shown, the deposit fails *before* any Bitcoin is signed, with a clear "Commission changed — please refresh" message. We also refuse to submit at all if the commission never loaded (instead of silently binding to an unknown value), and we disable the deposit button in that state. Both error cases are mapped to friendly, actionable messages.

**Part B — Show the commission and net payout before submit (the disclosure fix).** We added two lines to the deposit fee breakdown: the VP commission (as a percentage and a BTC/USD amount) and the resulting net payout (deposit minus commission). Now the depositor sees exactly what the provider will take and what they will get back, before they commit.

## Approaches we considered

- **Disclosure only (show the commission in the UI).** This is what the audit's wording literally suggested and what an earlier triage note assumed was the only gap. We rejected it as the *sole* fix: showing a number doesn't stop a malicious VP, because a user might not notice it changed. It's good defense-in-depth, but not a real control.
- **Enforcement only (turn on the drift check).** This closes the actual security hole, but leaves the commission still hidden on the review screen, so it only partially answers the finding.
- **Both, enforcement first (chosen).** We did the binding check *and* the disclosure. Enforcement is the guarantee; disclosure is the human-visible confirmation. Together they fully answer both of the audit's recommendations.

We also chose to put the disclosure on the **deposit review screen** rather than the later payout-signing step (which is where the audit text literally pointed). Reason: the deposit-review screen is where the amount is already known and where the money is actually committed on-chain. By the time the payout is signed, the commission is already locked in, so re-showing it there would be too late to matter and would need extra plumbing.

One deliberate belt-and-suspenders choice: we both disable the deposit button while the commission is loading *and* keep a hard error throw in the flow. The throw is the real guarantee; the disabled button is nicer UX. If the commission read is flaky, the throw is recoverable ("refresh and try again") rather than a permanent block.

## Why this is safe

The protection chain, end to end: the picker reads the commission → we pass it as the quote → the SDK binds it to `maxAcceptableCommissionBps` on-chain → the contract rejects any commission above that ceiling → the payout transaction caps the commission output. Nothing the VP returns is trusted blindly; the value the depositor saw is what bounds what they can be charged.

<img width="568" height="666" alt="Screenshot_2026-06-10_14-49-23" src="https://github.com/user-attachments/assets/38cd4535-bd86-4b6c-8327-4da936083601" />

<img width="583" height="877" alt="Screenshot_2026-06-10_15-02-37" src="https://github.com/user-attachments/assets/afadb2dc-48d0-46e3-8cb5-3678f6df8980" />

<img width="575" height="856" alt="Screenshot_2026-06-10_15-03-40" src="https://github.com/user-attachments/assets/2e254ac4-f8af-48e6-9efb-32d69d5314ad" />

