### PR TITLE
feat(wallet): remove btc from keystone connection title

### DIFF
--- a/packages/babylon-wallet-connector/src/core/wallets/btc/keystone/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/keystone/provider.ts
@@ -73,7 +73,7 @@ export class KeystoneProvider implements IBTCProvider {
       description:
         "Please scan the QR code displayed on your Keystone, Currently only the first Taproot Address will be used",
       renderInitial: {
-        walletMode: "btc",
+        walletMode: "",
         link: "",
         description: [
           `Requires Keystone firmware ${MIN_KEYSTONE_FIRMWARE_VERSION} or later.`,


### PR DESCRIPTION
- removes the `btc` from `walletMode` when connecting keystone
- pure cosmetics, affects the `title` with the current SDK
- instead of `Sync Keystone BTC` user will see `Sync Keystone`:

<img width="603" height="397" alt="Screenshot_2026-06-11_15-34-52" src="https://github.com/user-attachments/assets/24bac05e-4932-4a7b-87ee-3404c9945aba" />

Above is per @aaroninks recommendation
