### PR TITLE
feat(core-ui): add esc to close support for all modals

### DIFF
--- a/packages/babylon-core-ui/src/components/Dialog/Dialog.tsx
+++ b/packages/babylon-core-ui/src/components/Dialog/Dialog.tsx
@@ -11,6 +11,7 @@ export interface DialogProps extends DetailedHTMLProps<HTMLAttributes<HTMLDivEle
   hasBackdrop?: boolean;
   backdropClassName?: string;
   dialogClassName?: string;
+  disableEscapeClose?: boolean;
 }
 
 export const Dialog = ({
@@ -21,9 +22,10 @@ export const Dialog = ({
   hasBackdrop = true,
   backdropClassName,
   dialogClassName,
+  disableEscapeClose,
   ...restProps
 }: DialogProps) => {
-  const { mounted, unmount } = useModalManager({ open });
+  const { mounted, unmount } = useModalManager({ open, onClose, disableEscapeClose });
 
   return (
     <Portal mounted={mounted}>

--- a/packages/babylon-core-ui/src/components/Dialog/FullScreenDialog.tsx
+++ b/packages/babylon-core-ui/src/components/Dialog/FullScreenDialog.tsx
@@ -9,10 +9,18 @@ import { CloseIcon } from "@/components/Icons";
 export interface FullScreenDialogProps extends DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> {
   open?: boolean;
   onClose?: () => void;
+  disableEscapeClose?: boolean;
 }
 
-export const FullScreenDialog = ({ children, open = false, className, onClose, ...restProps }: FullScreenDialogProps) => {
-  const { mounted, unmount } = useModalManager({ open });
+export const FullScreenDialog = ({
+  children,
+  open = false,
+  className,
+  onClose,
+  disableEscapeClose,
+  ...restProps
+}: FullScreenDialogProps) => {
+  const { mounted, unmount } = useModalManager({ open, onClose, disableEscapeClose });
 
   return (
     <Portal mounted={mounted}>

--- a/packages/babylon-core-ui/src/components/Dialog/MobileDialog.tsx
+++ b/packages/babylon-core-ui/src/components/Dialog/MobileDialog.tsx
@@ -9,10 +9,18 @@ import { CloseIcon } from "@/components/Icons";
 export interface MobileDialogProps extends DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> {
   open?: boolean;
   onClose?: () => void;
+  disableEscapeClose?: boolean;
 }
 
-export const MobileDialog = ({ children, open = false, className, onClose, ...restProps }: MobileDialogProps) => {
-  const { mounted, unmount } = useModalManager({ open });
+export const MobileDialog = ({
+  children,
+  open = false,
+  className,
+  onClose,
+  disableEscapeClose,
+  ...restProps
+}: MobileDialogProps) => {
+  const { mounted, unmount } = useModalManager({ open, onClose, disableEscapeClose });
 
   return (
     <Portal mounted={mounted}>

--- a/packages/babylon-core-ui/src/components/Form/SelectWithIcon.tsx
+++ b/packages/babylon-core-ui/src/components/Form/SelectWithIcon.tsx
@@ -166,8 +166,8 @@ export const SelectWithIcon = forwardRef<HTMLDivElement, SelectWithIconProps>(
             break;
 
           case "Escape":
-            event.preventDefault();
             if (isOpen) {
+              event.preventDefault();
               setIsOpen(false);
             }
             break;

--- a/packages/babylon-core-ui/src/context/Dialog.context.tsx
+++ b/packages/babylon-core-ui/src/context/Dialog.context.tsx
@@ -4,6 +4,7 @@ import { toPixels } from "@/utils/css";
 const ESCAPE_KEY = "Escape";
 
 export interface DialogOptions {
+  open: boolean;
   visible: boolean;
   onClose?: () => void;
   disableEscapeClose?: boolean;
@@ -53,7 +54,7 @@ export function ScrollLocker({ children }: PropsWithChildren) {
 
       let topmost: DialogEntry | undefined;
       for (const entry of entriesRef.current.values()) {
-        if (!entry.visible) continue;
+        if (!entry.open) continue;
         if (!topmost || entry.order > topmost.order) topmost = entry;
       }
 
@@ -77,12 +78,12 @@ export function ScrollLocker({ children }: PropsWithChildren) {
     });
   }, []);
 
-  const updateDialog = useCallback((id: string, { visible, onClose, disableEscapeClose }: DialogOptions) => {
+  const updateDialog = useCallback((id: string, { open, visible, onClose, disableEscapeClose }: DialogOptions) => {
     const previous = entriesRef.current.get(id);
     const wasVisible = previous?.visible ?? false;
     const order = visible && !wasVisible ? (orderRef.current += 1) : (previous?.order ?? 0);
 
-    entriesRef.current.set(id, { visible, onClose, disableEscapeClose, order });
+    entriesRef.current.set(id, { open, visible, onClose, disableEscapeClose, order });
 
     if (wasVisible === visible) return;
 

--- a/packages/babylon-core-ui/src/context/Dialog.context.tsx
+++ b/packages/babylon-core-ui/src/context/Dialog.context.tsx
@@ -1,19 +1,34 @@
-import { type PropsWithChildren, createContext, useState, useMemo, useCallback, useEffect } from "react";
+import { type PropsWithChildren, createContext, useState, useMemo, useCallback, useEffect, useRef } from "react";
 import { toPixels } from "@/utils/css";
 
-interface DialogContext {
-  removeDialog: (id: string, value?: boolean) => void;
-  updateDialog: (id: string, value: boolean) => void;
+const ESCAPE_KEY = "Escape";
+
+export interface DialogOptions {
+  visible: boolean;
+  onClose?: () => void;
+  disableEscapeClose?: boolean;
 }
 
-export const DialogContext = createContext<DialogContext>({
+interface DialogEntry extends DialogOptions {
+  order: number;
+}
+
+interface DialogContextValue {
+  removeDialog: (id: string) => void;
+  updateDialog: (id: string, options: DialogOptions) => void;
+}
+
+export const DialogContext = createContext<DialogContextValue>({
   removeDialog: () => null,
   updateDialog: () => null,
 });
 
 export function ScrollLocker({ children }: PropsWithChildren) {
-  const [dialogs, setDialogs] = useState<Record<string, boolean>>({});
-  const bodyLocked = useMemo(() => Object.values(dialogs).some((v) => v), [dialogs]);
+  const [visibleIds, setVisibleIds] = useState<Record<string, true>>({});
+  const entriesRef = useRef<Map<string, DialogEntry>>(new Map());
+  const orderRef = useRef(0);
+
+  const bodyLocked = useMemo(() => Object.keys(visibleIds).length > 0, [visibleIds]);
 
   useEffect(
     function lockBody() {
@@ -32,12 +47,52 @@ export function ScrollLocker({ children }: PropsWithChildren) {
     [bodyLocked],
   );
 
-  const removeDialog = useCallback((id: string) => {
-    setDialogs((state) => (Reflect.deleteProperty(state, id) ? { ...state } : state));
+  useEffect(function closeTopmostOnEscape() {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== ESCAPE_KEY || event.defaultPrevented) return;
+
+      let topmost: DialogEntry | undefined;
+      for (const entry of entriesRef.current.values()) {
+        if (!entry.visible) continue;
+        if (!topmost || entry.order > topmost.order) topmost = entry;
+      }
+
+      if (topmost?.onClose && !topmost.disableEscapeClose) {
+        event.preventDefault();
+        topmost.onClose();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
   }, []);
 
-  const updateDialog = useCallback((id: string, value: boolean) => {
-    setDialogs((state) => ({ ...state, [id]: value }));
+  const removeDialog = useCallback((id: string) => {
+    entriesRef.current.delete(id);
+    setVisibleIds((state) => {
+      if (!(id in state)) return state;
+      const next = { ...state };
+      delete next[id];
+      return next;
+    });
+  }, []);
+
+  const updateDialog = useCallback((id: string, { visible, onClose, disableEscapeClose }: DialogOptions) => {
+    const previous = entriesRef.current.get(id);
+    const wasVisible = previous?.visible ?? false;
+    const order = visible && !wasVisible ? (orderRef.current += 1) : (previous?.order ?? 0);
+
+    entriesRef.current.set(id, { visible, onClose, disableEscapeClose, order });
+
+    if (wasVisible === visible) return;
+
+    setVisibleIds((state) => {
+      if (visible) return { ...state, [id]: true };
+      if (!(id in state)) return state;
+      const next = { ...state };
+      delete next[id];
+      return next;
+    });
   }, []);
 
   const value = useMemo(() => ({ removeDialog, updateDialog }), [removeDialog, updateDialog]);

--- a/packages/babylon-core-ui/src/hooks/useModalManager.ts
+++ b/packages/babylon-core-ui/src/hooks/useModalManager.ts
@@ -22,8 +22,8 @@ export function useModalManager({ open = false, onClose, disableEscapeClose }: O
   );
 
   useEffect(() => {
-    updateDialog(modalId, { visible, onClose, disableEscapeClose });
-  }, [modalId, visible, onClose, disableEscapeClose, updateDialog]);
+    updateDialog(modalId, { open, visible, onClose, disableEscapeClose });
+  }, [modalId, open, visible, onClose, disableEscapeClose, updateDialog]);
 
   useEffect(() => {
     if (open) {

--- a/packages/babylon-core-ui/src/hooks/useModalManager.ts
+++ b/packages/babylon-core-ui/src/hooks/useModalManager.ts
@@ -3,10 +3,12 @@ import { useCallback, useContext, useEffect, useId, useState } from "react";
 
 interface Options {
   open?: boolean;
+  onClose?: () => void;
+  disableEscapeClose?: boolean;
   unmountOnClose?: boolean;
 }
 
-export function useModalManager({ open = false }: Options = {}) {
+export function useModalManager({ open = false, onClose, disableEscapeClose }: Options = {}) {
   const modalId = useId();
   const [mounted, setMounted] = useState(open);
   const { updateDialog, removeDialog } = useContext(DialogContext);
@@ -20,8 +22,8 @@ export function useModalManager({ open = false }: Options = {}) {
   );
 
   useEffect(() => {
-    updateDialog(modalId, visible);
-  }, [modalId, visible, updateDialog]);
+    updateDialog(modalId, { visible, onClose, disableEscapeClose });
+  }, [modalId, visible, onClose, disableEscapeClose, updateDialog]);
 
   useEffect(() => {
     if (open) {

--- a/packages/babylon-wallet-connector/src/components/WalletProvider/components/WalletDialog.tsx
+++ b/packages/babylon-wallet-connector/src/components/WalletProvider/components/WalletDialog.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useEffect, useRef } from "react";
 
 import { ResponsiveDialog } from "@/components/ResponsiveDialog/ResponsiveDialog";
 import { useChainProviders } from "@/context/Chain.context";
@@ -29,6 +29,23 @@ export function WalletDialog({ persistent, storage, config, onError, simplifiedT
   const { connect, disconnect } = useWalletConnectors({ persistent, accountStorage: storage, onError });
   const { disconnect: disconnectAll } = useWalletConnect();
 
+  const disconnectTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  const clearDisconnectTimer = useCallback(() => {
+    if (disconnectTimerRef.current !== undefined) {
+      clearTimeout(disconnectTimerRef.current);
+      disconnectTimerRef.current = undefined;
+    }
+  }, []);
+
+  useEffect(() => {
+    if (visible) {
+      clearDisconnectTimer();
+    }
+  }, [visible, clearDisconnectTimer]);
+
+  useEffect(() => clearDisconnectTimer, [clearDisconnectTimer]);
+
   const handleAccepTermsOfService = useCallback(() => {
     displayChains?.();
   }, [displayChains]);
@@ -45,9 +62,10 @@ export function WalletDialog({ persistent, storage, config, onError, simplifiedT
   const handleClose = useCallback(() => {
     close?.();
     if (!confirmed) {
-      setTimeout(disconnectAll, ANIMATION_DELAY);
+      clearDisconnectTimer();
+      disconnectTimerRef.current = setTimeout(disconnectAll, ANIMATION_DELAY);
     }
-  }, [close, disconnectAll, confirmed]);
+  }, [close, disconnectAll, confirmed, clearDisconnectTimer]);
 
   const handleConfirm = useCallback(() => {
     confirm?.();

--- a/services/vault/vite.config.ts
+++ b/services/vault/vite.config.ts
@@ -23,6 +23,7 @@ const enableSentryPlugin =
 // https://vite.dev/config/
 export default defineConfig({
   resolve: {
+    dedupe: ["@babylonlabs-io/core-ui", "react", "react-dom"],
     alias: {
       // Provide empty stubs for Node.js-only modules
       ws: resolve(__dirname, "src/stubs/ws.ts"),
@@ -34,6 +35,7 @@ export default defineConfig({
       "bitcoinjs-lib",
       "@bitcoin-js/tiny-secp256k1-asmjs",
       "@babylonlabs-io/wallet-connector",
+      "@babylonlabs-io/core-ui",
     ],
   },
   build: {


### PR DESCRIPTION
Add a centralized esc handler in the `ScrollLocker` `DialogContext` so every modal built on the core-ui Dialog/MobileDialog/FullScreenDialog primitives closes on Escape, with no call-site changes. Only the topmost visible dialog closes; modals without an onClose (mid-transaction) are exempt, and a new disableEscapeClose prop opts a dialog out.

- core-ui: track per-dialog onClose/visibility/order and close the topmost dialog on Escape; respect event.defaultPrevented so inner controls win
- SelectWithIcon: only consume Escape when its dropdown is open so a closed select no longer swallows the modal-close key
- vault: dedupe core-ui in Vite dev (optimizeDeps.include + resolve.dedupe) so the wallet-connector dialog shares the app's DialogContext
- wallet-connector: cancel the pending disconnect timer when the wallet dialog reopens, fixing it auto-closing after a quick close/reopen