### PR TITLE
fix(vault): show asset brand color on Aave loan card sliders

### DIFF
--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/index.tsx
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/index.tsx
@@ -145,7 +145,7 @@ export function Borrow() {
             sliderStep={sliderTrackMax / 1000}
             sliderSteps={[]}
             onSliderChange={setBorrowAmount}
-            sliderVariant="rainbow"
+            sliderVariant="primary"
             leftField={{
               value:
                 borrowAmount === 0

--- a/services/vault/src/applications/aave/components/LoanCard/Repay/index.tsx
+++ b/services/vault/src/applications/aave/components/LoanCard/Repay/index.tsx
@@ -186,7 +186,7 @@ export function Repay() {
             sliderStep={sliderTrackMax / SLIDER_STEP_COUNT}
             sliderSteps={[]}
             onSliderChange={setRepayAmountSlider}
-            sliderVariant="rainbow"
+            sliderVariant="primary"
             leftField={{
               value:
                 repayAmount === 0


### PR DESCRIPTION
closes #1852

The Borrow and Repay loan cards passed sliderActiveColor but forced sliderVariant="rainbow", which paints a fixed green-to-red gradient and ignores the active color. Switch to the primary variant so the slider track renders the asset brand color.