### PR TITLE
feat(vault): sign batch peg-in in one popup via native signPsbts

### DIFF
--- a/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
@@ -1152,31 +1152,7 @@ describe("useDepositFlow", () => {
   });
 
   describe("Peg-in signing progress", () => {
-    it("advances the counter to n of n by signing each peg-in tx in its own popup", async () => {
-      const { preparePeginTransaction } = vi.mocked(
-        await import("@/services/vault/vaultTransactionService"),
-      );
-      // The SDK signs the peg-in PSBTs by calling the wallet wrapper's
-      // signPsbts once; the wrapper forces per-tx signing underneath.
-      vi.mocked(preparePeginTransaction).mockImplementation(async (wallet) => {
-        await wallet.signPsbts(["psbt0", "psbt1"], [{}, {}]);
-        return MOCK_BATCH_RESULT as any;
-      });
-
-      const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
-      await executeDepositFlow(result);
-
-      await waitFor(() => {
-        expect(result.current.peginSigningProgress).toEqual({
-          completed: 2,
-          total: 2,
-        });
-      });
-      // Per-tx: the single-PSBT signer is invoked once per vault.
-      expect(MOCK_BTC_WALLET.signPsbt).toHaveBeenCalledTimes(2);
-    });
-
-    it("never uses the wallet's native batch signPsbts for peg-in, so the counter can tick", async () => {
+    it("uses the wallet's native batch signPsbts so the peg-in txs sign in one popup", async () => {
       const { preparePeginTransaction } = vi.mocked(
         await import("@/services/vault/vaultTransactionService"),
       );
@@ -1189,6 +1165,8 @@ describe("useDepositFlow", () => {
         signPsbt: nativeSignPsbt,
         signPsbts: nativeSignPsbts,
       };
+      // The SDK signs the peg-in PSBTs by calling the wallet wrapper's
+      // signPsbts once; the wrapper delegates to the native batch call.
       vi.mocked(preparePeginTransaction).mockImplementation(async (wallet) => {
         await wallet.signPsbts(["psbt0", "psbt1"], [{}, {}]);
         return MOCK_BATCH_RESULT as any;
@@ -1208,9 +1186,37 @@ describe("useDepositFlow", () => {
           total: 2,
         });
       });
-      // Peg-in is signed per-tx via signPsbt; the native batch path is unused.
-      expect(nativeSignPsbts).not.toHaveBeenCalled();
-      expect(nativeSignPsbt).toHaveBeenCalledTimes(2);
+      // One native batch call signs every peg-in tx; the per-tx signer is unused.
+      expect(nativeSignPsbts).toHaveBeenCalledTimes(1);
+      expect(nativeSignPsbts).toHaveBeenCalledWith(
+        ["psbt0", "psbt1"],
+        [{}, {}],
+      );
+      expect(nativeSignPsbt).not.toHaveBeenCalled();
+    });
+
+    it("falls back to sequential signPsbt for wallets without native batch signing, ticking the counter per tx", async () => {
+      const { preparePeginTransaction } = vi.mocked(
+        await import("@/services/vault/vaultTransactionService"),
+      );
+      // MOCK_BTC_WALLET has no signPsbts, so the SDK's signPsbtsWithFallback
+      // signs each PSBT via the wrapper's signPsbt; the counter ticks per tx.
+      vi.mocked(preparePeginTransaction).mockImplementation(async (wallet) => {
+        await wallet.signPsbt("psbt0", {});
+        await wallet.signPsbt("psbt1", {});
+        return MOCK_BATCH_RESULT as any;
+      });
+
+      const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
+      await executeDepositFlow(result);
+
+      await waitFor(() => {
+        expect(result.current.peginSigningProgress).toEqual({
+          completed: 2,
+          total: 2,
+        });
+      });
+      expect(MOCK_BTC_WALLET.signPsbt).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/services/vault/src/hooks/deposit/useDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useDepositFlow.ts
@@ -376,11 +376,11 @@ export function useDepositFlow(
         // ========================================================================
 
         setCurrentStep(DepositFlowStep.DERIVE_VAULT_SECRET);
-        // Sign each peg-in PSBT one at a time so the (x of n) sub-counter can
-        // advance per signature. A native batch signPsbts signs every tx in a
-        // single popup and returns one result, hiding intra-batch progress
-        // from the dApp — so we override signPsbts to loop signPsbt instead,
-        // trading one popup for N popups in exchange for live progress.
+        // Sign the peg-in PSBTs in a single native batch popup when the wallet
+        // supports signPsbts; the (x of n) sub-counter jumps 0 -> N around the
+        // one call. Wallets without native batch signing fall back to
+        // sequential signPsbt (via the SDK's signPsbtsWithFallback), where the
+        // per-tx wrapper ticks the counter once per signature.
         const signOnePeginPsbt: typeof confirmedBtcWallet.signPsbt = async (
           psbtHex,
           opts,
@@ -394,6 +394,21 @@ export function useDepositFlow(
           );
           return signed;
         };
+        // Native batch path: one popup; the counter jumps 0 -> N around the call.
+        const signPeginBatch: typeof confirmedBtcWallet.signPsbts = async (
+          psbtHexes,
+          opts,
+        ) => {
+          setCurrentStep(DepositFlowStep.SIGN_PEGIN_BTC);
+          setPeginSigningProgress({ completed: 0, total: psbtHexes.length });
+          const signed = await confirmedBtcWallet.signPsbts!(psbtHexes, opts);
+          setPeginSigningProgress({
+            completed: psbtHexes.length,
+            total: psbtHexes.length,
+          });
+          return signed;
+        };
+
         const phaseTrackingBtcWallet: typeof confirmedBtcWallet = {
           ...confirmedBtcWallet,
           deriveContextHash: (appName, context) => {
@@ -401,13 +416,9 @@ export function useDepositFlow(
             return confirmedBtcWallet.deriveContextHash(appName, context);
           },
           signPsbt: signOnePeginPsbt,
-          signPsbts: async (psbtHexes, opts) => {
-            const signed: string[] = [];
-            for (let i = 0; i < psbtHexes.length; i++) {
-              signed.push(await signOnePeginPsbt(psbtHexes[i], opts?.[i]));
-            }
-            return signed;
-          },
+          ...(typeof confirmedBtcWallet.signPsbts === "function"
+            ? { signPsbts: signPeginBatch }
+            : {}),
         };
 
         // No hard pre-filter. `DuplicateHashlock` on `BTCVaultRegistry`

--- a/services/vault/src/services/vault/vaultTransactionService.ts
+++ b/services/vault/src/services/vault/vaultTransactionService.ts
@@ -123,7 +123,8 @@ export interface PreparePeginResult {
  * A split (multi-vault) deposit produces one peg-in transaction per vault,
  * each signed via the wallet (one batch popup for `signPsbts`-capable
  * wallets, sequential popups otherwise). `total` is the number of peg-in
- * transactions; `completed` advances as each is signed.
+ * transactions; `completed` jumps 0 -> total for a single native batch popup,
+ * or advances per signature in the sequential fallback.
  */
 export interface PeginSigningProgress {
   /** Number of peg-in transactions signed so far. */


### PR DESCRIPTION
The bulk pre-peg-in flow looped signPsbt per vault, forcing one wallet
popup per transaction. Call the wallet's native signPsbts batch method
instead so a split deposit signs in a single popup, with a per-tx
signPsbt fallback for wallets without native batch signing.