### PR TITLE
fix(ts-sdk): re-derive refund pegInAmounts and pin refund output

### DIFF
--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/refund.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/refund.test.ts
@@ -11,8 +11,18 @@
 
 import type { Network } from "@babylonlabs-io/babylon-tbv-rust-wasm";
 import * as bitcoin from "bitcoinjs-lib";
+import type { Hex } from "viem";
 import { beforeAll, describe, expect, it } from "vitest";
 
+import {
+  deriveBip86ScriptPubKeyHex,
+  stripHexPrefix,
+  uint8ArrayToHex,
+} from "../../utils/bitcoin";
+import {
+  deriveRefundPeginAmounts,
+  type RefundPrePeginContext,
+} from "../../../services/refund/buildAndBroadcastRefund";
 import { fundPeginTransaction } from "../../../utils/transaction/fundPeginTransaction";
 import { buildPrePeginPsbt, type PrePeginParams } from "../pegin";
 import { buildRefundPsbt } from "../refund";
@@ -316,6 +326,129 @@ describe("buildRefundPsbt", () => {
           hashlock: wrongHashlock,
         }),
       ).rejects.toThrow();
+    });
+  });
+
+  describe("HTLC value cross-check", () => {
+    it("rejects when pegInAmounts disagree with the funded HTLC value", async () => {
+      // Fund a Pre-PegIn with the real pegInAmounts, then reconstruct the
+      // refund template with an inflated pegInAmount (same hashlock + keys,
+      // so the HTLC *script* still matches). The HTLC script does not depend
+      // on the amount, so the script cross-check passes — only the value
+      // cross-check catches that the template's HTLC value no longer equals
+      // the funded output. This is the bug class where a caller feeds the
+      // HTLC output value (not the original peg-in amount) as pegInAmounts.
+      const { txHex, params } = await buildFundedPrePegin({
+        authAnchorHash: TEST_AUTH_ANCHOR_HASH,
+      });
+
+      await expect(
+        buildRefundPsbt({
+          prePeginParams: {
+            ...params,
+            pegInAmounts: [params.pegInAmounts[0] + 10_000n],
+          },
+          fundedPrePeginTxHex: txHex,
+          htlcVout: 0,
+          refundFee: TEST_REFUND_FEE,
+          hashlock: TEST_HASH_H,
+        }),
+      ).rejects.toThrow(/value mismatch/i);
+    });
+  });
+
+  describe("refund output pinning", () => {
+    it("pays the single refund output to the depositor's BIP-86 address", async () => {
+      // The refund must return funds to exactly one output — the depositor's
+      // own BIP-86 P2TR address derived from their key — so a malformed
+      // template can't redirect the reclaimed funds elsewhere.
+      const { txHex, params } = await buildFundedPrePegin({
+        authAnchorHash: TEST_AUTH_ANCHOR_HASH,
+      });
+
+      const { psbtHex } = await buildRefundPsbt({
+        prePeginParams: params,
+        fundedPrePeginTxHex: txHex,
+        htlcVout: 0,
+        refundFee: TEST_REFUND_FEE,
+        hashlock: TEST_HASH_H,
+      });
+
+      const psbt = bitcoin.Psbt.fromHex(psbtHex);
+      const unsigned = psbt.data.globalMap.unsignedTx.toBuffer();
+      const refundTx = bitcoin.Transaction.fromBuffer(unsigned);
+      expect(refundTx.outs.length).toBe(1);
+      const outputScript = uint8ArrayToHex(
+        new Uint8Array(refundTx.outs[0].script),
+      ).toLowerCase();
+      const expectedScript = stripHexPrefix(
+        deriveBip86ScriptPubKeyHex(TEST_KEYS.DEPOSITOR),
+      ).toLowerCase();
+      expect(outputScript).toBe(expectedScript);
+
+      // The single output returns the full HTLC value minus exactly the
+      // requested fee — no value silently burned as excess miner fee.
+      const fundedHtlcValue = BigInt(
+        bitcoin.Transaction.fromHex(txHex).outs[0].value,
+      );
+      expect(BigInt(refundTx.outs[0].value)).toBe(
+        fundedHtlcValue - TEST_REFUND_FEE,
+      );
+    });
+  });
+
+  describe("peg-in amount derivation round-trip", () => {
+    it("re-derives the original peg-in amount from the funded HTLC value (real WASM)", async () => {
+      // Keystone equality: the reserve subtracted at refund time (standalone
+      // computeMinClaimValue + computeMinPeginFee) must equal the reserve WASM
+      // baked into the HTLC value at peg-in time. Fund with a known peg-in
+      // amount, read the funded HTLC value, and prove the derivation inverts
+      // back to that exact amount — so a future WASM bump that broke the
+      // equality is caught here, not in production.
+      const { txHex, params } = await buildFundedPrePegin({
+        authAnchorHash: TEST_AUTH_ANCHOR_HASH,
+      });
+      const fundedHtlcValue = BigInt(
+        bitcoin.Transaction.fromHex(txHex).outs[0].value,
+      );
+
+      const ctx: RefundPrePeginContext = {
+        vaultProviderPubkey: params.vaultProviderPubkey,
+        vaultKeeperPubkeys: params.vaultKeeperPubkeys,
+        universalChallengerPubkeys: params.universalChallengerPubkeys,
+        timelockRefund: params.timelockRefund,
+        feeRate: params.feeRate,
+        minPeginFeeRate: params.minPeginFeeRate,
+        numLocalChallengers: params.numLocalChallengers,
+        councilQuorum: params.councilQuorum,
+        councilSize: params.councilSize,
+        network: params.network,
+      };
+
+      const derived = await deriveRefundPeginAmounts(
+        [
+          {
+            hashlock: `0x${TEST_HASH_H}` as Hex,
+            amount: fundedHtlcValue,
+            htlcVout: 0,
+          },
+        ],
+        ctx,
+      );
+      expect(derived).toEqual([TEST_AMOUNTS.PEGIN]);
+
+      // And feeding the derived amount back through the real (unmocked)
+      // builder reconstructs a template whose value cross-check passes — a
+      // legitimate refund does not throw.
+      await expect(
+        buildRefundPsbt({
+          prePeginParams: { ...params, pegInAmounts: derived },
+          fundedPrePeginTxHex: txHex,
+          htlcVout: 0,
+          refundFee: TEST_REFUND_FEE,
+          hashlock: TEST_HASH_H,
+        }),
+      ).resolves.toMatchObject({ psbtHex: expect.any(String) });
     });
   });
 });

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts
@@ -20,7 +20,13 @@ import {
 import { Buffer } from "buffer";
 import { Psbt, Transaction } from "bitcoinjs-lib";
 
-import { TAPSCRIPT_LEAF_VERSION, hexToUint8Array, uint8ArrayToHex } from "../utils/bitcoin";
+import {
+  TAPSCRIPT_LEAF_VERSION,
+  deriveBip86ScriptPubKeyHex,
+  hexToUint8Array,
+  stripHexPrefix,
+  uint8ArrayToHex,
+} from "../utils/bitcoin";
 import { normalizeAuthAnchorHash, type PrePeginParams } from "./pegin";
 
 /**
@@ -130,6 +136,12 @@ export async function buildRefundPsbt(
     const expectedHtlcScriptPubKey = unfundedTx
       .getHtlcScriptPubKey(htlcVout)
       .toLowerCase();
+    // The reconstructed template's HTLC output value at `htlcVout`,
+    // sized by WASM from the supplied `pegInAmounts` via the protocol
+    // formula `htlcValue = peginAmount + depositorClaimValue + minPeginFee`.
+    // Captured before `fromFundedTransaction` to bind it to the value the
+    // funded tx actually carries (see the cross-check below).
+    const expectedHtlcValue = unfundedTx.getHtlcValue(htlcVout);
 
     fundedTx = unfundedTx.fromFundedTransaction(fundedPrePeginTxHex);
 
@@ -167,6 +179,23 @@ export async function buildRefundPsbt(
           `template expects ${expectedHtlcScriptPubKey}, funded tx carries ` +
           `${actualHtlcScriptPubKey}. Refund refused — the (hashlocks, ` +
           `pegInAmounts) vector does not match the on-chain commitment.`,
+      );
+    }
+
+    // Value cross-check (mirrors the script check above): the template's
+    // HTLC value — derived by WASM from `pegInAmounts` via the protocol
+    // formula — must equal the value the funded tx pays at this output.
+    // A caller that hands the full HTLC output value (or any wrong amount)
+    // as `pegInAmounts` would inflate the template value and trip this
+    // guard, rather than silently signing a refund built from a template
+    // that disagrees with the on-chain commitment.
+    const actualHtlcValue = BigInt(htlcOutput.value);
+    if (actualHtlcValue !== expectedHtlcValue) {
+      throw new Error(
+        `HTLC value mismatch at vout ${htlcVout}: reconstructed template ` +
+          `expects ${expectedHtlcValue} sat, funded tx carries ` +
+          `${actualHtlcValue} sat. Refund refused — the pegInAmounts vector ` +
+          `does not match the on-chain commitment.`,
       );
     }
 
@@ -221,12 +250,52 @@ export async function buildRefundPsbt(
       tapInternalKey: Buffer.from(tapInternalPubkey),
     });
 
-    for (const output of refundTx.outs) {
-      psbt.addOutput({
-        script: output.script,
-        value: output.value,
-      });
+    // Output side: pin the single refund output to the depositor's own
+    // BIP-86 P2TR address, mirroring the input-side pinning above. WASM
+    // builds the refund output from the refund leaf's depositor key, so a
+    // correct template always pays exactly one output back to the depositor.
+    // Asserting it here means a malformed template (or a tampered WASM)
+    // cannot redirect the reclaimed funds to a script the depositor does
+    // not control.
+    if (refundTx.outs.length !== 1) {
+      throw new Error(
+        `Refund transaction must have exactly 1 output, got ${refundTx.outs.length}`,
+      );
     }
+    const refundOutput = refundTx.outs[0];
+    const expectedDepositorScriptPubKey = stripHexPrefix(
+      deriveBip86ScriptPubKeyHex(prePeginParams.depositorPubkey),
+    ).toLowerCase();
+    const actualRefundOutputScriptPubKey = uint8ArrayToHex(
+      new Uint8Array(refundOutput.script),
+    ).toLowerCase();
+    if (actualRefundOutputScriptPubKey !== expectedDepositorScriptPubKey) {
+      throw new Error(
+        `Refund output scriptPubKey ${actualRefundOutputScriptPubKey} does not ` +
+          `match the depositor's BIP-86 address ${expectedDepositorScriptPubKey}. ` +
+          `Refund refused — the reclaimed funds would not return to the depositor.`,
+      );
+    }
+
+    // Value: the single refund output must return the full HTLC value minus
+    // exactly the requested fee. The refund is 1-in/1-out (asserted above), so
+    // a value below `htlcValue - refundFee` means WASM applied a larger fee
+    // than requested — the difference would be burned as miner fee. Pin it so
+    // the depositor reclaims the expected amount, not a silently reduced one.
+    const expectedRefundOutputValue = actualHtlcValue - refundFee;
+    if (BigInt(refundOutput.value) !== expectedRefundOutputValue) {
+      throw new Error(
+        `Refund output value ${BigInt(refundOutput.value)} sat does not equal ` +
+          `the HTLC value ${actualHtlcValue} sat minus the requested fee ` +
+          `${refundFee} sat (expected ${expectedRefundOutputValue} sat). ` +
+          `Refund refused — the reclaimed amount would be burned as excess fee.`,
+      );
+    }
+
+    psbt.addOutput({
+      script: refundOutput.script,
+      value: refundOutput.value,
+    });
 
     return { psbtHex: psbt.toHex() };
   } finally {

--- a/packages/babylon-ts-sdk/src/tbv/core/services/refund/__tests__/buildAndBroadcastRefund.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/refund/__tests__/buildAndBroadcastRefund.test.ts
@@ -1,7 +1,12 @@
+import {
+  computeMinClaimValue,
+  computeMinPeginFee,
+} from "@babylonlabs-io/babylon-tbv-rust-wasm";
 import * as bitcoin from "bitcoinjs-lib";
 import type { Address, Hex } from "viem";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { deriveRefundPeginAmounts } from "../buildAndBroadcastRefund";
 import {
   BIP68NotMatureError,
   buildAndBroadcastRefund,
@@ -458,9 +463,29 @@ describe("buildAndBroadcastRefund", () => {
         HASHLOCK.slice(2),
         SIBLING_HASHLOCK.slice(2),
       ]);
+      // pegInAmounts are NOT the raw HTLC output values (100k / 200k). The
+      // orchestrator re-derives the original peg-in amount by inverting
+      // `htlcValue = peginAmount + depositorClaimValue +
+      // minPeginFee`, subtracting the (batch-constant) protocol reserve from
+      // each entry's on-chain HTLC value. Compute that reserve from the same
+      // version-pinned ctx params so the assertion tracks the WASM sizing.
+      const ctx = buildCtx();
+      const reserve =
+        (await computeMinClaimValue(
+          ctx.numLocalChallengers,
+          ctx.universalChallengerPubkeys.length,
+          ctx.councilQuorum,
+          ctx.councilSize,
+          ctx.feeRate,
+        )) +
+        (await computeMinPeginFee(
+          ctx.vaultKeeperPubkeys.length,
+          ctx.universalChallengerPubkeys.length,
+          ctx.minPeginFeeRate,
+        ));
       expect(call[0].prePeginParams.pegInAmounts).toEqual([
-        100_000n,
-        200_000n,
+        100_000n - reserve,
+        200_000n - reserve,
       ]);
       expect(call[0].htlcVout).toBe(1);
       expect(call[0].prePeginParams.authAnchorHash).toBe("cd".repeat(32));
@@ -1110,6 +1135,47 @@ describe("buildAndBroadcastRefund", () => {
         }),
       ).rejects.toThrow("cancelled");
       expect(readVault).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("deriveRefundPeginAmounts", () => {
+    it("inverts the protocol formula, subtracting the batch-constant reserve", async () => {
+      const ctx = buildCtx();
+      const reserve =
+        (await computeMinClaimValue(
+          ctx.numLocalChallengers,
+          ctx.universalChallengerPubkeys.length,
+          ctx.councilQuorum,
+          ctx.councilSize,
+          ctx.feeRate,
+        )) +
+        (await computeMinPeginFee(
+          ctx.vaultKeeperPubkeys.length,
+          ctx.universalChallengerPubkeys.length,
+          ctx.minPeginFeeRate,
+        ));
+
+      const peginAmounts = await deriveRefundPeginAmounts(
+        [
+          { hashlock: HASHLOCK, amount: 100_000n, htlcVout: 0 },
+          { hashlock: HASHLOCK, amount: 250_000n, htlcVout: 1 },
+        ],
+        ctx,
+      );
+
+      expect(peginAmounts).toEqual([100_000n - reserve, 250_000n - reserve]);
+    });
+
+    it("throws when an HTLC value does not exceed the protocol reserve", async () => {
+      // A 1-sat HTLC value cannot cover depositorClaimValue + minPeginFee, so
+      // the inverted peg-in amount would be non-positive. Fail closed rather
+      // than hand WASM a zero/negative amount.
+      await expect(
+        deriveRefundPeginAmounts(
+          [{ hashlock: HASHLOCK, amount: 1n, htlcVout: 0 }],
+          buildCtx(),
+        ),
+      ).rejects.toThrow(/non-positive/);
     });
   });
 });

--- a/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts
@@ -10,7 +10,11 @@
  * @module services/refund
  */
 
-import type { Network } from "@babylonlabs-io/babylon-tbv-rust-wasm";
+import {
+  computeMinClaimValue,
+  computeMinPeginFee,
+  type Network,
+} from "@babylonlabs-io/babylon-tbv-rust-wasm";
 import { Psbt, Transaction } from "bitcoinjs-lib";
 import type { Address, Hex } from "viem";
 
@@ -352,6 +356,58 @@ function validateRefundPrePeginContext(c: RefundPrePeginContext): void {
   }
 }
 
+/**
+ * Re-derive each HTLC's original peg-in amount from its on-chain HTLC output
+ * value, inverting the protocol formula
+ * `htlcValue = peginAmount + depositorClaimValue + minPeginFee`.
+ *
+ * The original peg-in amount is not persisted anywhere — only the HTLC output
+ * value (`batch[i].amount`) survives on-chain. WASM refund template
+ * reconstruction needs the *peg-in amount*, not the HTLC value: feeding the
+ * HTLC value would size the template's HTLC output above what the funded tx
+ * carries, and `buildRefundPsbt`'s value cross-check would refuse the refund.
+ *
+ * `depositorClaimValue` and `minPeginFee` are constant across the batch
+ * (fixed by the version-pinned protocol params in {@link ctx}), so they are
+ * computed once via the same WASM entry points the peg-in path uses, then
+ * subtracted from every entry's value. The subtraction is the inverse of the
+ * sizing WASM performs internally; `buildRefundPsbt` then re-binds the result
+ * to the funded tx bytes, so a wrong derivation fails closed rather than
+ * signing a mis-sized refund.
+ */
+export async function deriveRefundPeginAmounts(
+  batch: ReadonlyArray<VaultBatchEntry>,
+  ctx: RefundPrePeginContext,
+): Promise<bigint[]> {
+  const depositorClaimValue = await computeMinClaimValue(
+    ctx.numLocalChallengers,
+    ctx.universalChallengerPubkeys.length,
+    ctx.councilQuorum,
+    ctx.councilSize,
+    ctx.feeRate,
+  );
+  const minPeginFee = await computeMinPeginFee(
+    ctx.vaultKeeperPubkeys.length,
+    ctx.universalChallengerPubkeys.length,
+    ctx.minPeginFeeRate,
+  );
+  const reserved = depositorClaimValue + minPeginFee;
+
+  return batch.map((entry, i) => {
+    const peginAmount = entry.amount - reserved;
+    if (peginAmount <= 0n) {
+      throw new Error(
+        `Re-derived peginAmount for batch[${i}] is non-positive ` +
+          `(${peginAmount}): HTLC value ${entry.amount} does not exceed ` +
+          `depositorClaimValue ${depositorClaimValue} + minPeginFee ` +
+          `${minPeginFee}. Refusing to build a refund from an inconsistent ` +
+          `(amount, protocol params) pair.`,
+      );
+    }
+    return peginAmount;
+  });
+}
+
 function finalizeAndExtract(signedPsbtHex: string): string {
   const psbt = Psbt.fromHex(signedPsbtHex);
   try {
@@ -489,6 +545,15 @@ export async function buildAndBroadcastRefund<
     );
   }
 
+  // Re-derive the original peg-in amounts from the on-chain HTLC values.
+  // `batch[i].amount` is the HTLC *output* value, not the peg-in amount the
+  // WASM template constructor expects; feeding it verbatim mis-sizes the
+  // template. The derivation is bound back to the funded tx bytes by
+  // `buildRefundPsbt`'s value cross-check, so an inconsistent result fails
+  // closed instead of producing a mis-sized refund.
+  const refundPeginAmounts = await deriveRefundPeginAmounts(vault.batch, ctx);
+  signal?.throwIfAborted();
+
   const { psbtHex } = await buildRefundPsbt({
     prePeginParams: {
       depositorPubkey: xOnlyDepositorPubkey,
@@ -498,7 +563,7 @@ export async function buildAndBroadcastRefund<
         ctx.universalChallengerPubkeys.map(stripHexPrefix),
       hashlocks: vault.batch.map((b) => stripHexPrefix(b.hashlock)),
       timelockRefund: ctx.timelockRefund,
-      pegInAmounts: vault.batch.map((b) => b.amount),
+      pegInAmounts: refundPeginAmounts,
       feeRate: ctx.feeRate,
       minPeginFeeRate: ctx.minPeginFeeRate,
       numLocalChallengers: ctx.numLocalChallengers,


### PR DESCRIPTION
## What this does

This hardens the **refund path** — the flow a depositor uses to reclaim their BTC when a Pre-PegIn expires and they need to get their money back. It fixes two audit findings from Sherlock 908 and 870.

## Why it matters

The refund is recovery material: if it's built wrong, the worst case is a depositor who cannot get their own BTC back (a stuck deposit), or who gets back less than they should (funds quietly burned as extra miner fee). None of this is theft, but it is exactly the kind of silent value bug the critical-path rules exist to catch. Before this change the refund code trusted values from WASM and the indexer without checking them against the actual on-chain transaction.

## Background (one minute of context)

When a deposit is created, WASM sizes each HTLC output using a fixed protocol formula: `htlcValue = peginAmount + depositorClaimValue + minPeginFee`. In plain terms, the on-chain HTLC output holds the depositor's deposit **plus** a reserve the protocol needs for the downstream transactions. Only that final `htlcValue` is recorded on-chain — the original deposit amount is not stored anywhere.

## The two bugs and the fixes

### 908 — the refund fed the wrong amount into WASM

The refund builder was passing the on-chain HTLC output value (`htlcValue`) where WASM expects the original deposit amount (`peginAmount`). It also re-checked the HTLC *script* against the funded transaction but never the *value*. So a wrong amount could slip through and, in the worst case, produce a refund the depositor cannot use.

Fix:
- We re-derive the original deposit amount by inverting the formula: `peginAmount = htlcValue − depositorClaimValue − minPeginFee`, using the exact same WASM helpers (`computeMinClaimValue`, `computeMinPeginFee`) that the deposit path already uses, so the two can't drift apart.
- We added a **value cross-check** in the PSBT builder: the value WASM derives for the rebuilt HTLC must equal the value the funded transaction actually carries. If they disagree, we refuse to build the refund instead of signing a mis-sized one.

### 870 — the refund output was copied from WASM without checking it

The builder copied whatever output WASM produced straight into the PSBT. It never confirmed the refund actually returns the funds to the depositor, or that the amount is right.

Fix — we now pin the output the same way the input side is already pinned:
- exactly **one** output,
- its script must equal the **depositor's own** BIP-86 address (derived from the depositor's key, matching the Rust reference and mirroring the existing payout-output check),
- its value must equal `htlcValue − requestedFee` (so nothing is silently burned as excess fee).

## Approach — and why this one

The hard part of 908 is that the original deposit amount is not stored anywhere; only the final on-chain HTLC value survives. There were two ways to get it back:

1. **Store the original amount in the indexer** and read it at refund time.
2. **Re-derive it on the fly** by inverting the protocol formula from the on-chain value.

We chose option 2 because it needs no new data source, can't go stale, and reuses the exact same WASM functions the deposit flow uses — so the math at refund time is guaranteed to match the math at deposit time. To make this safe, the re-derived value is always **bound back to the real funded-transaction bytes** by the value cross-check: if the derivation were ever wrong, the refund fails loudly and signs nothing, rather than producing a bad transaction. This "fail closed" behavior is the right trade-off for a recovery path — refusing to act is always safer than acting incorrectly with someone's BTC.

For 870 we didn't invent anything new: we mirrored the checks that already exist on the input side of the refund and on the payout output, so the output is now fully pinned (count, script, value).

## Note on a related finding

While doing this I confirmed the closely related finding **Sherlock 869 / Coinspect TRV-034** (cross-checking WASM-returned values on the *deposit* path) is **already resolved** in `main` by an earlier change (`assertWasmPeginSizing` + `assertEncodedHtlcOutputsMatch`). This PR closes the matching gap on the *refund* path.

## Testing

- New unit tests cover: a wrong amount is rejected by the value cross-check; the refund output is pinned to the depositor's address and to `htlcValue − fee`; the non-positive guard on the re-derivation; and a **real-WASM round-trip** that proves re-deriving from a funded HTLC value returns the exact original deposit amount (so a future WASM change that broke this would be caught in CI, not in production).
- An existing test that encoded the old (buggy) behavior was updated to assert the corrected re-derivation.
- Full SDK suite green (1295 tests), lint clean, type-check clean.