### PR TITLE
fix(ts-sdk): floor the depositors payout output

### DIFF
--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/payout.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/payout.test.ts
@@ -1125,3 +1125,123 @@ describe("buildPayoutPsbt — implicit-fee bound (value-burn variant)", () => {
     ).rejects.toThrow(/outputs \(200000 sats\) exceed inputs/);
   });
 });
+
+/**
+ * The coarse 10%-of-inputs fee cap leaves room to shave a large deposit's
+ * payout output and burn the difference as fee. The explicit depositor-payout
+ * lower bound floors outs[0] at `peginValue − maxCommission − anchorDust −
+ * MAX_PAYOUT_IMPLICIT_FEE_SATS`. The fixtures use a large pegin so the absolute
+ * fee backstop (2_000_000 sats) is the binding constraint while the 10% cap
+ * still passes.
+ */
+describe("buildPayoutPsbt — depositor-payout lower bound", () => {
+  beforeAll(async () => {
+    await initializeWasmForTests();
+  });
+
+  // 30_000_000 pegin + 1_000 assert = 30_001_000 inputs (10% cap = 3_000_100).
+  // VP-claimer floor = 30_000_000 − 1_500_000 (max commission @ 500 bps) − 546
+  // − 2_000_000 = 26_499_454.
+  const LARGE_PEGIN_VALUE = 30_000_000;
+  const SMALL_ASSERT_VALUE = 1_000;
+
+  function highValuePeginTxHex(): string {
+    const tx = new Transaction();
+    tx.addInput(NULL_TXID, 0xffffffff, SEQUENCE_MAX);
+    tx.addOutput(createDummyP2TR(), LARGE_PEGIN_VALUE);
+    return tx.toHex();
+  }
+
+  function smallAssertTxHex(): string {
+    const tx = new Transaction();
+    tx.addInput(DUMMY_TXID_2, 0xffffffff, SEQUENCE_MAX);
+    tx.addOutput(createDummyP2WPKH("c"), SMALL_ASSERT_VALUE);
+    return tx.toHex();
+  }
+
+  function payoutTxHexWith(
+    peginTxHex: string,
+    assertTxHex: string,
+    outputs: { script: Buffer; value: number }[],
+  ): string {
+    const peginTx = Transaction.fromHex(peginTxHex);
+    const assertTx = Transaction.fromHex(assertTxHex);
+    const tx = new Transaction();
+    tx.addInput(Buffer.from(peginTx.getId(), "hex").reverse(), 0, SEQUENCE_MAX);
+    tx.addInput(Buffer.from(assertTx.getId(), "hex").reverse(), 0, SEQUENCE_MAX);
+    for (const out of outputs) tx.addOutput(out.script, out.value);
+    return tx.toHex();
+  }
+
+  function baseParams(overrides: Partial<PayoutParams>): PayoutParams {
+    return {
+      payoutTxHex: "",
+      peginTxHex: "",
+      assertTxHex: "",
+      depositorBtcPubkey: TEST_KEYS.DEPOSITOR,
+      vaultProviderBtcPubkey: TEST_KEYS.VAULT_PROVIDER,
+      vaultKeeperBtcPubkeys: [TEST_KEYS.VAULT_KEEPER_1],
+      universalChallengerBtcPubkeys: [TEST_KEYS.UNIVERSAL_CHALLENGER_1],
+      timelockPegin: 100,
+      network: "signet" as Network,
+      claimerBtcPubkey: TEST_KEYS.VAULT_PROVIDER,
+      registeredPayoutScriptPubKey: REGISTERED_PAYOUT_SCRIPT_HEX,
+      commissionBps: TEST_COMMISSION_BPS,
+      ...overrides,
+    };
+  }
+
+  it("VP-claimer: rejects a deflated payout below the floor even within the 10% fee cap", async () => {
+    // outs[0] 26_000_000 < floor 26_499_454; implicit fee 2_500_454 < 10% cap
+    // 3_000_100, so only the lower bound trips.
+    const peginTxHex = highValuePeginTxHex();
+    const assertTxHex = smallAssertTxHex();
+    const payoutTxHex = payoutTxHexWith(peginTxHex, assertTxHex, [
+      { script: createDummyP2WPKH("a"), value: 26_000_000 },
+      { script: createDummyP2WPKH("e"), value: 1_500_000 },
+      { script: createDummyP2WPKH("c"), value: PAYOUT_ANCHOR_DUST_SATS },
+    ]);
+    await expect(
+      buildPayoutPsbt(baseParams({ payoutTxHex, peginTxHex, assertTxHex })),
+    ).rejects.toThrow(
+      /output 0 value 26000000 sats is below the minimum depositor payout 26499454 sats/,
+    );
+  });
+
+  it("VP-claimer: accepts a large payout that pays the depositor above the floor", async () => {
+    // outs[0] 28_995_454 >= floor; commission 1_000_000 <= cap; fee 5_000.
+    const peginTxHex = highValuePeginTxHex();
+    const assertTxHex = smallAssertTxHex();
+    const payoutTxHex = payoutTxHexWith(peginTxHex, assertTxHex, [
+      { script: createDummyP2WPKH("a"), value: 28_995_454 },
+      { script: createDummyP2WPKH("e"), value: 1_000_000 },
+      { script: createDummyP2WPKH("c"), value: PAYOUT_ANCHOR_DUST_SATS },
+    ]);
+    await expect(
+      buildPayoutPsbt(baseParams({ payoutTxHex, peginTxHex, assertTxHex })),
+    ).resolves.toBeDefined();
+  });
+
+  it("depositor-as-claimer: floors outs[0] with a zero commission allowance", async () => {
+    // No commission output, so floor = 30_000_000 − 0 − 546 − 2_000_000 =
+    // 27_999_454. outs[0] 27_500_000 trips it; fee 2_500_454 < 10% cap.
+    const peginTxHex = highValuePeginTxHex();
+    const assertTxHex = smallAssertTxHex();
+    const payoutTxHex = payoutTxHexWith(peginTxHex, assertTxHex, [
+      { script: createDummyP2WPKH("a"), value: 27_500_000 },
+      { script: createDummyP2WPKH("c"), value: PAYOUT_ANCHOR_DUST_SATS },
+    ]);
+    await expect(
+      buildPayoutPsbt(
+        baseParams({
+          payoutTxHex,
+          peginTxHex,
+          assertTxHex,
+          claimerBtcPubkey: TEST_KEYS.DEPOSITOR,
+        }),
+      ),
+    ).rejects.toThrow(
+      /output 0 value 27500000 sats is below the minimum depositor payout 27999454 sats/,
+    );
+  });
+});

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts
@@ -55,6 +55,33 @@ const MAX_PAYOUT_FEE_FRACTION_NUMERATOR = 10;
 const MAX_PAYOUT_FEE_FRACTION_DENOMINATOR = 100;
 
 /**
+ * Generous ceiling on a payout transaction's virtual size (vbytes). The payout
+ * is a fixed 2-input (PegIn + Assert) / 2-or-3-output taproot transaction whose
+ * real vsize is ~300-400 vB; this bound is deliberately loose. Not a protocol
+ * parameter — paired with {@link MAX_PAYOUT_FEE_RATE_SAT_PER_VB} only to derive
+ * an absolute fee backstop.
+ */
+const MAX_PAYOUT_TX_VBYTES = 1_000;
+
+/**
+ * Backstop fee rate (sat/vB), set far above any realistic Bitcoin fee rate so a
+ * legitimate payout fee can never reach the derived ceiling. Not a protocol
+ * parameter.
+ */
+const MAX_PAYOUT_FEE_RATE_SAT_PER_VB = 2_000;
+
+/**
+ * Absolute ceiling (sats) on a payout's implicit fee, used as the fee allowance
+ * in the depositor-payout lower bound. No legitimate payout pays this much fee,
+ * so any output deflation that pushes the implied fee above it is a VP burning
+ * the depositor's value. For large deposits this is far tighter than the coarse
+ * {@link MAX_PAYOUT_FEE_FRACTION_NUMERATOR}/{@link MAX_PAYOUT_FEE_FRACTION_DENOMINATOR}
+ * input fraction, which remains the binding cap for small deposits.
+ */
+const MAX_PAYOUT_IMPLICIT_FEE_SATS =
+  MAX_PAYOUT_TX_VBYTES * MAX_PAYOUT_FEE_RATE_SAT_PER_VB;
+
+/**
  * Parameters for building an unsigned Payout PSBT
  *
  * Payout is used in the challenge path after Assert, when the claimer proves validity.
@@ -166,6 +193,8 @@ export interface PayoutPsbtResult {
  * @throws If `claimerBtcPubkey` is not VP, depositor, or a registered VK
  * @throws If payout output count, outs[0] script, outs[last] anchor value, or
  *   (VP-claimer) outs[1] commission cap do not match the protocol layout
+ * @throws If outs[0] value is below the depositor-payout lower bound
+ *   `peginValue − maxCommission − anchorDust − {@link MAX_PAYOUT_IMPLICIT_FEE_SATS}`
  * @throws If `commissionBps` is not a non-negative integer below 10_000
  */
 export async function buildPayoutPsbt(
@@ -353,6 +382,11 @@ export async function buildPayoutPsbt(
  * `floor(peginValue × commissionBps / 10_000)`. Canonical layouts: VP-claimer
  * = [payout, commission, anchor]; depositor/VK-claimer = [payout, anchor].
  *
+ * Also floors the depositor payout: `outs[0].value` must be at least
+ * `peginValue − maxCommission − anchorDust − {@link MAX_PAYOUT_IMPLICIT_FEE_SATS}`,
+ * blocking a VP that deflates the depositor's output and burns the difference
+ * as an implausibly large fee.
+ *
  * `outs[1].script` and `outs[last].script` are intentionally not pinned: the
  * value pins above bound depositor exposure regardless of where those outputs
  * are sent, so the value pins — not script pins — are load-bearing.
@@ -436,6 +470,10 @@ function assertPayoutOutputLayout(args: {
     );
   }
 
+  // Maximum value a VP may legitimately remove from the depositor's output as
+  // commission: the per-role cap (0 for non-VP claimers, which carry no
+  // commission output). Reused below to floor the depositor payout.
+  let maxCommissionSats = 0;
   if (role === "vp-claimer") {
     // Structural guard only — a non-negative integer below the bps
     // denominator, so the cap math `floor(peginValue * bps / 10_000)` is
@@ -451,7 +489,7 @@ function assertPayoutOutputLayout(args: {
           `[0, ${MAX_VP_COMMISSION_BPS_EXCLUSIVE}), got ${commissionBps}`,
       );
     }
-    const maxCommissionSats = Math.floor(
+    maxCommissionSats = Math.floor(
       (peginValueSats * commissionBps) / MAX_VP_COMMISSION_BPS_EXCLUSIVE,
     );
     if (payoutTx.outs[1].value > maxCommissionSats) {
@@ -461,6 +499,35 @@ function assertPayoutOutputLayout(args: {
           `(${commissionBps} bps of peginValue=${peginValueSats})`,
       );
     }
+  }
+
+  // Explicit depositor-payout lower bound. The
+  // pins above constrain where value goes; this floors how much the depositor
+  // must *receive* at outs[0]. The depositor must keep at least the pegin value
+  // minus the most a VP may legitimately remove — the commission cap, the CPFP
+  // anchor, and a hard fee backstop.
+  //
+  // Conservative on every term — input 1's value (>= 0) is ignored, the
+  // commission *cap* is used rather than the actual commission, and the anchor
+  // is its pinned dust value — so for any legitimate payout
+  // `outs[0] = (peginValue + input1) - commission - anchor - fee` is provably
+  // >= this floor (a real payout fee is far below MAX_PAYOUT_IMPLICIT_FEE_SATS).
+  // It only rejects a VP that deflates the depositor output and burns the
+  // difference as an implausibly large fee; for large deposits it binds tighter
+  // than the coarse input-fraction fee cap in `buildPayoutPsbt`.
+  const minDepositorPayoutSats =
+    peginValueSats -
+    maxCommissionSats -
+    PAYOUT_ANCHOR_DUST_SATS -
+    MAX_PAYOUT_IMPLICIT_FEE_SATS;
+  if (payoutTx.outs[0].value < minDepositorPayoutSats) {
+    throw new Error(
+      `Payout output 0 value ${payoutTx.outs[0].value} sats is below the ` +
+        `minimum depositor payout ${minDepositorPayoutSats} sats ` +
+        `(peginValue ${peginValueSats} - maxCommission ${maxCommissionSats} - ` +
+        `anchor ${PAYOUT_ANCHOR_DUST_SATS} - maxFee ${MAX_PAYOUT_IMPLICIT_FEE_SATS}); ` +
+        `refusing to sign a payout that underpays the depositor.`,
+    );
   }
 }
 


### PR DESCRIPTION
## What this does

This adds one new safety check to the payout transaction builder: the depositor's payout output (`outs[0]`) must be at least the amount they are owed, allowing for a small fee. If a payout would pay the depositor too little, we refuse to sign it.

## Background

When a vault is redeemed through the payout path, the vault provider (VP) builds the payout transaction and the depositor pre-signs it. The depositor's money comes out at output 0. We already verify a lot about that transaction (added in [#1699](https://github.com/babylonlabs-io/babylon-toolkit/pull/1699)): the number of outputs, that output 0 pays the depositor's registered address, that the VP commission output is within its cap, that the CPFP anchor output is exactly the dust value, and that the total fee (inputs minus outputs) is at most 10% of the inputs.

## The problem

That 10% fee cap is loose. A real Bitcoin payout fee is only a few thousand sats, but the check allows up to 10% of the input value to disappear as miner fee. So for a large deposit, a VP could shrink the depositor's output and "burn" up to ~10% of the deposit as fee, and every existing check would still pass. The depositor would silently receive up to ~10% less than they should.

This is not theft — the burned sats go to miners, not the VP — it is griefing or a bug, and the loss is bounded, so it is low severity. It is the leftover ("residual") of `Coinspect finding TRV-033 / Sherlock 841`; the main fix already shipped in [#1699](https://github.com/babylonlabs-io/babylon-toolkit/pull/1699), and this closes the gap that was left.

## What we changed

We added an explicit lower bound on the depositor's payout output, right next to the other per-role output checks: `outs[0].value >= peginValue − maxCommission − anchorDust − maxFee`.

`maxFee` is an absolute backstop of `1000 vB × 2000 sat/vB = 2,000,000 sats`, set far above any realistic payout fee.

We kept the existing 10%-of-inputs fee cap, so small deposits are still protected by it; the absolute backstop only becomes the tighter limit for large deposits.

We added tests: a payout that stays under the 10% fee cap but still underpays output 0 now fails; a large, legitimate payout still passes; and the same check works when the depositor is the claimer (no commission output).

## Approaches we considered

1. The literal formula the auditor suggested — `outs[0] >= peginValue − maxCommission − anchorDust`, with no fee term. Rejected: it ignores the payout fee, so it would reject legitimate payouts and could block a real redemption.
2. Just tightening the existing 10% fraction. Rejected: a percentage is the wrong tool — for a small deposit a normal fee is already a large fraction of the value, so a tighter percentage would reject legitimate small-deposit payouts.
3. (Chosen) An explicit floor with an absolute fee backstop. Every term in the floor is deliberately conservative (we ignore the second input's value, use the commission cap instead of the actual commission, and use the pinned anchor value), so it can be proven to never reject a legitimate payout, while still bounding a large deposit's worst-case loss far more tightly than 10%.

## Why we chose this

The worst thing this check could do is wrongly block a legitimate redemption and leave a depositor unable to get their funds — which is worse than the bounded griefing it prevents. So we picked the option that is mathematically guaranteed not to false-positive: a real payout fee is nowhere near 2,000,000 sats, so a legitimate payout always passes, while for large deposits the depositor's worst-case loss is now capped at roughly 0.02 BTC instead of ~10% of the deposit.

The 2,000,000-sat backstop is intentionally generous to guarantee availability. Because the risk is bounded, low-likelihood griefing (not theft), we favor never blocking a redemption over shrinking the window further. A future pass can lower it if we want it stricter.