### PR TITLE
fix(vault): don't claim 'Insufficient balance' before balance loads

### DIFF
--- a/services/vault/src/applications/aave/components/LoanCard/Repay/hooks/__tests__/validateRepayAction.test.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Repay/hooks/__tests__/validateRepayAction.test.ts
@@ -115,6 +115,22 @@ describe("validateRepayAction", () => {
       const result = validateRepayAction(0, 0, 0, 0, 8);
       expect(result.buttonText).toBe("Enter an amount");
     });
+
+    it("does not classify an unknown (undefined) balance as a real zero", () => {
+      // The Repay component passes `undefined` while the balance is still
+      // loading/errored, so outstanding debt must NOT render "Insufficient
+      // balance" before the balance is actually known.
+      const result = validateRepayAction(
+        0,
+        0,
+        0.00000003,
+        undefined,
+        8,
+        "WBTC",
+      );
+      expect(result.buttonText).toBe("Enter an amount");
+      expect(result.errorMessage).toBeNull();
+    });
   });
 
   describe("balance below debt (dust partial repay)", () => {

--- a/services/vault/src/applications/aave/components/LoanCard/Repay/index.tsx
+++ b/services/vault/src/applications/aave/components/LoanCard/Repay/index.tsx
@@ -109,7 +109,10 @@ export function Repay() {
       repayAmount,
       maxRepayAmount,
       currentDebtAmount,
-      userTokenBalance,
+      // Treat the balance as unknown until it's loaded so a loading/errored 0
+      // isn't classified as a real zero balance — which would render the CTA as
+      // "Insufficient balance" for a wallet that may actually hold tokens.
+      balanceKnown ? userTokenBalance : undefined,
       displayDecimals,
       assetConfig.symbol,
     );


### PR DESCRIPTION
Follow-up to #1881 (Aave repay dust / zero-balance hardening). It addresses a
review comment on that PR that wasn't included before it merged: the repay CTA
can render **"Insufficient balance"** for a wallet that actually holds tokens,
during the brief window while the balance is still loading (or if the balance
fetch errored).