### PR TITLE
fix(vault): stop re-broadcasting an already-settled refund

### DIFF
--- a/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/__tests__/mempoolApi.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/__tests__/mempoolApi.test.ts
@@ -13,6 +13,7 @@ import {
   getAddressTxs,
   getAddressUtxos,
   getNetworkFees,
+  getOutspend,
   getTipHeight,
   getTxHex,
   getTxInfo,
@@ -380,6 +381,49 @@ describe("scriptPubKey format validation", () => {
     );
     const result = await getUtxoInfo(VALID_TXID, 0, API_URL);
     expect(result.scriptPubKey).toBe("76a914abcdef88ac");
+  });
+});
+
+describe("getOutspend", () => {
+  it("returns spent:false for an unspent output", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ spent: false }));
+    const result = await getOutspend(VALID_TXID, 0, API_URL);
+    expect(result.spent).toBe(false);
+    expect(result.txid).toBeUndefined();
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${API_URL}/tx/${VALID_TXID}/outspend/0`,
+      expect.anything(),
+    );
+  });
+
+  it("returns the spending tx details for a spent output", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        spent: true,
+        txid: VALID_TXID_2,
+        vin: 0,
+        status: { confirmed: true, block_height: 308289 },
+      }),
+    );
+    const result = await getOutspend(VALID_TXID, 2, API_URL);
+    expect(result.spent).toBe(true);
+    expect(result.txid).toBe(VALID_TXID_2);
+    expect(result.status?.confirmed).toBe(true);
+    expect(result.status?.block_height).toBe(308289);
+  });
+
+  it("rejects an invalid txid before fetching", async () => {
+    await expect(getOutspend("bad-txid", 0, API_URL)).rejects.toThrow(
+      /Invalid transaction ID format/,
+    );
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("rejects a negative vout before fetching", async () => {
+    await expect(getOutspend(VALID_TXID, -1, API_URL)).rejects.toThrow(
+      /Invalid vout -1/,
+    );
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/index.ts
@@ -11,6 +11,7 @@ export {
   getAddressUtxos,
   getMempoolApiUrl,
   getNetworkFees,
+  getOutspend,
   getTipHeight,
   getTxHex,
   getTxInfo,
@@ -24,6 +25,7 @@ export type { AddressTx } from "./mempoolApi";
 export type {
   MempoolUTXO,
   NetworkFees,
+  OutspendStatus,
   TxInfo,
   TxInput,
   TxOutput,

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts
@@ -14,7 +14,13 @@ import {
   TXID_RE,
 } from "../../utils/validation";
 
-import type { MempoolUTXO, NetworkFees, TxInfo, UtxoInfo } from "./types";
+import type {
+  MempoolUTXO,
+  NetworkFees,
+  OutspendStatus,
+  TxInfo,
+  UtxoInfo,
+} from "./types";
 
 /** Maximum valid satoshi value: 21 million BTC × 10^8 sats/BTC */
 const MAX_SATOSHIS = 21_000_000 * 1e8;
@@ -228,6 +234,31 @@ export async function getTipHeight(apiUrl: string): Promise<number> {
     );
   }
   return Number.parseInt(trimmed, 10);
+}
+
+/**
+ * Get the spend status of a specific transaction output.
+ *
+ * Calls the esplora-compatible `GET /tx/{txid}/outspend/{vout}` endpoint
+ * (mempool.space backend, mempool/electrs `rest.rs`). Returns
+ * `{ spent: false }` for an unspent output, or
+ * `{ spent: true, txid, vin, status }` when the output has been spent.
+ *
+ * @param txid - The transaction id whose output is being checked (no 0x prefix)
+ * @param vout - The output index
+ * @param apiUrl - Mempool API base URL
+ * @returns The output's spend status
+ */
+export async function getOutspend(
+  txid: string,
+  vout: number,
+  apiUrl: string,
+): Promise<OutspendStatus> {
+  assertValidTxid(txid);
+  if (!isValidVout(vout)) {
+    throw new Error(`Invalid vout ${vout} for transaction ${txid}`);
+  }
+  return fetchApi<OutspendStatus>(`${apiUrl}/tx/${txid}/outspend/${vout}`);
 }
 
 /**

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts
@@ -182,7 +182,7 @@ export async function pushTx(txHex: string, apiUrl: string): Promise<string> {
       let message: string | undefined;
       try {
         const errorJson = JSON.parse(errorText);
-        message = errorJson.message;
+        message = errorJson.message ?? errorJson.error;
       } catch {
         // Not JSON, use raw text
         message = errorText;

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts
@@ -59,6 +59,27 @@ export interface TxStatus {
 }
 
 /**
+ * Spend status of a single transaction output, from the esplora-compatible
+ * `GET /tx/{txid}/outspend/{vout}` endpoint served by the mempool.space
+ * backend.
+ *
+ * Source: mempool/electrs `src/rest.rs` `SpendingValue` — an unspent output
+ * serializes as `{ "spent": false }` (the optional fields use
+ * `skip_serializing_if`); a spent output serializes as
+ * `{ "spent": true, "txid", "vin", "status" }`.
+ */
+export interface OutspendStatus {
+  /** True when the output has been spent (mempool or a block). */
+  spent: boolean;
+  /** Spending transaction id; present only when `spent`. */
+  txid?: string;
+  /** Input index within the spending tx; present only when `spent`. */
+  vin?: number;
+  /** Confirmation status of the spending tx; present only when `spent`. */
+  status?: TxStatus;
+}
+
+/**
  * Full transaction info from mempool API.
  */
 export interface TxInfo {

--- a/services/vault/src/clients/btc/outspend.ts
+++ b/services/vault/src/clients/btc/outspend.ts
@@ -1,0 +1,40 @@
+/**
+ * Mempool-API helper that reports whether a Pre-PegIn HTLC output has been
+ * spent (i.e. the depositor's CSV refund has landed). A pure BTC refund emits
+ * no Ethereum event, so neither the indexer nor the BTC monitor sees it today —
+ * the frontend reads the spend status directly from the esplora-compatible
+ * `outspend` endpoint.
+ */
+
+import { stripHexPrefix } from "@babylonlabs-io/ts-sdk/tbv/core";
+import { getOutspend } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
+
+export interface HtlcSpend {
+  /** True when the HTLC output has been spent (in the mempool or a block). */
+  spent: boolean;
+  /** True only when the spending tx is confirmed in a block. */
+  confirmed: boolean;
+  /** Spending (refund) transaction id, when spent. */
+  spendingTxid?: string;
+}
+
+/**
+ * Returns the spend status of a vault's HTLC output `(prePeginTxHash,
+ * htlcVout)`. Callers handle errors (404, 429, network blips) at their layer.
+ */
+export async function fetchHtlcSpend(
+  prePeginTxHash: string,
+  htlcVout: number,
+  apiUrl: string,
+): Promise<HtlcSpend> {
+  const res = await getOutspend(
+    stripHexPrefix(prePeginTxHash),
+    htlcVout,
+    apiUrl,
+  );
+  return {
+    spent: res.spent === true,
+    confirmed: res.spent === true && res.status?.confirmed === true,
+    spendingTxid: res.txid,
+  };
+}

--- a/services/vault/src/context/deposit/PeginPollingContext.tsx
+++ b/services/vault/src/context/deposit/PeginPollingContext.tsx
@@ -21,6 +21,7 @@ import {
 } from "react";
 
 import { usePeginPollingQuery } from "../../hooks/deposit/usePeginPollingQuery";
+import { useBtcHtlcRefundStatus } from "../../hooks/useBtcHtlcRefundStatus";
 import { useBtcMempoolConfirmations } from "../../hooks/useBtcMempoolConfirmations";
 import {
   ContractStatus,
@@ -34,6 +35,10 @@ import {
   addMatureRefundTxid,
   loadMatureRefundTxids,
 } from "../../storage/matureRefundCache";
+import {
+  addRefundedHtlcVaultId,
+  loadRefundedHtlcVaultIds,
+} from "../../storage/refundedHtlcCache";
 import type { VaultActivity } from "../../types/activity";
 import type {
   DepositPollingResult,
@@ -48,6 +53,9 @@ import { computeDepositPollingResult } from "./computeDepositPollingResult";
 
 /** React Query namespace for the Pre-PegIn confirmation poller. */
 const PREPEGIN_CONFIRMATIONS_QUERY_KEY = "prePeginMempoolConfirmations";
+
+/** React Query namespace for the EXPIRED-vault HTLC refund-spend poller. */
+const HTLC_REFUND_QUERY_KEY = "htlcRefundOutspend";
 
 /**
  * Whether a vault's localStorage status puts it in the window where the
@@ -142,6 +150,12 @@ export function PeginPollingProvider({
   const [matureRefundTxids, setMatureRefundTxids] = useState<Set<string>>(
     loadMatureRefundTxids,
   );
+  // EXPIRED vaults whose HTLC spend confirmed (refund landed). A confirmed
+  // spend is terminal, so — like the caches above — drop the vault from the
+  // poll set and keep rendering "Refunded" without re-probing.
+  const [refundedHtlcVaultIds, setRefundedHtlcVaultIds] = useState<Set<string>>(
+    loadRefundedHtlcVaultIds,
+  );
 
   const getRequiredPrePeginDepth = useCallback(
     (activity: VaultActivity): number => {
@@ -207,6 +221,36 @@ export function PeginPollingProvider({
       PREPEGIN_CONFIRMATIONS_QUERY_KEY,
     );
 
+  // Probe whether each EXPIRED+owned vault's HTLC output is already spent
+  // (refund landed). A pure BTC refund emits no Ethereum event, so the indexer
+  // never sees it — read it from Bitcoin directly. Drop vaults already known
+  // refunded (confirmed-spend cache) from the set.
+  const htlcRefundOutpoints = useMemo(
+    () =>
+      activities
+        .filter((a) => {
+          if (!isVaultOwnedByWallet(a.depositorBtcPubkey, btcPublicKey))
+            return false;
+          if ((a.contractStatus ?? 0) !== ContractStatus.EXPIRED) return false;
+          if (refundedHtlcVaultIds.has(a.id.toLowerCase())) return false;
+          return (
+            !!a.prePeginTxHash &&
+            a.htlcVout !== undefined &&
+            Number.isInteger(a.htlcVout)
+          );
+        })
+        .map((a) => ({
+          depositId: a.id,
+          prePeginTxHash: a.prePeginTxHash as string,
+          htlcVout: a.htlcVout as number,
+        })),
+    [activities, btcPublicKey, refundedHtlcVaultIds],
+  );
+  const { refundByDepositId: htlcRefundByDepositId } = useBtcHtlcRefundStatus(
+    htlcRefundOutpoints,
+    HTLC_REFUND_QUERY_KEY,
+  );
+
   // Persist newly-confirmed observations and drop them from the next
   // poll set. Side effects sit outside the updater so StrictMode's
   // double-invoke doesn't double-write; the early return prevents
@@ -261,6 +305,26 @@ export function PeginPollingProvider({
     matureRefundTxids,
     getOffchainParamsByVersion,
   ]);
+
+  // Persist vaults whose HTLC spend has confirmed and drop them from the next
+  // poll set. Only confirmed spends are cached (a mempool-only spend can still
+  // be replaced/reorged); the live map drives the transient "Refunding" state.
+  useEffect(() => {
+    if (htlcRefundByDepositId.size === 0) return;
+    const newlyRefunded: string[] = [];
+    for (const [depositId, spend] of htlcRefundByDepositId) {
+      if (spend.confirmed && !refundedHtlcVaultIds.has(depositId)) {
+        newlyRefunded.push(depositId);
+      }
+    }
+    if (newlyRefunded.length === 0) return;
+    newlyRefunded.forEach(addRefundedHtlcVaultId);
+    setRefundedHtlcVaultIds((prev) => {
+      const next = new Set(prev);
+      newlyRefunded.forEach((id) => next.add(id));
+      return next;
+    });
+  }, [htlcRefundByDepositId, refundedHtlcVaultIds]);
 
   // Optimistic status handlers
   const setOptimisticStatus = useCallback(
@@ -320,6 +384,8 @@ export function PeginPollingProvider({
         prePeginConfirmationsByTxid,
         confirmedTxids,
         matureRefundTxids,
+        htlcRefundByDepositId,
+        refundedHtlcVaultIds,
         requiredDepth: getRequiredPrePeginDepth(activity),
         refundTimelock,
         isLoading,
@@ -338,6 +404,8 @@ export function PeginPollingProvider({
       prePeginConfirmationsByTxid,
       confirmedTxids,
       matureRefundTxids,
+      htlcRefundByDepositId,
+      refundedHtlcVaultIds,
       getRequiredPrePeginDepth,
       getOffchainParamsByVersion,
       isLoading,

--- a/services/vault/src/context/deposit/__tests__/PeginPollingContext.test.tsx
+++ b/services/vault/src/context/deposit/__tests__/PeginPollingContext.test.tsx
@@ -45,6 +45,23 @@ vi.mock("../../../hooks/useBtcMempoolConfirmations", () => ({
     mockUseBtcMempoolConfirmations(txids),
 }));
 
+// EXPIRED-vault HTLC refund-spend poller — stub so the provider renders
+// without a real QueryClient. Default: nothing spent. Tests can inject a
+// spent/confirmed entry via `mockReturnValue`.
+const { mockUseBtcHtlcRefundStatus } = vi.hoisted(() => ({
+  mockUseBtcHtlcRefundStatus: vi.fn<
+    () => {
+      refundByDepositId: Map<
+        string,
+        { spent: boolean; confirmed: boolean; spendingTxid?: string }
+      >;
+    }
+  >(() => ({ refundByDepositId: new Map() })),
+}));
+vi.mock("../../../hooks/useBtcHtlcRefundStatus", () => ({
+  useBtcHtlcRefundStatus: () => mockUseBtcHtlcRefundStatus(),
+}));
+
 const mockVersionedParams = new Map<number, { tRefund: number }>();
 
 vi.mock("../../ProtocolParamsContext", () => ({
@@ -97,6 +114,10 @@ describe("PeginPollingContext", () => {
     // `mockReturnValue` to inject a depth-reached entry.
     mockUseBtcMempoolConfirmations.mockReturnValue({
       confirmationsByTxid: new Map<string, number>(),
+    });
+    mockUseBtcHtlcRefundStatus.mockReset();
+    mockUseBtcHtlcRefundStatus.mockReturnValue({
+      refundByDepositId: new Map(),
     });
     mockVersionedParams.clear();
     // The persistent confirmed-txid cache leaks across tests otherwise.
@@ -621,6 +642,26 @@ describe("PeginPollingContext", () => {
       PeginAction.REFUND_HTLC,
     ]);
     expect(status?.peginState.refundMaturityState).toBe("mature");
+  });
+
+  it("EXPIRED: hides the refund action and shows Refunded when the HTLC spend has confirmed", () => {
+    mockVersionedParams.set(3, { tRefund: 144 });
+    mockUseBtcMempoolConfirmations.mockReturnValue({
+      confirmationsByTxid: new Map([[PRE_PEGIN_TXID_HEX, 144]]),
+    });
+    // Chain ground truth: the HTLC output was already spent (refund landed
+    // and confirmed) — the dashboard must not re-offer a doomed refund.
+    mockUseBtcHtlcRefundStatus.mockReturnValue({
+      refundByDepositId: new Map([
+        [ACTIVITY_ID.toLowerCase(), { spent: true, confirmed: true }],
+      ]),
+    });
+
+    const { result } = renderExpired();
+    const status = result.current.getPollingResult(ACTIVITY_ID);
+
+    expect(status?.peginState.availableActions).toEqual([PeginAction.NONE]);
+    expect(status?.peginState.displayLabel).toBe(PEGIN_DISPLAY_LABELS.REFUNDED);
   });
 
   it("EXPIRED: never marks mature when the per-deposit tRefund is unknown (no fallback to latest)", () => {

--- a/services/vault/src/context/deposit/__tests__/computeDepositPollingResult.test.ts
+++ b/services/vault/src/context/deposit/__tests__/computeDepositPollingResult.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  computeDepositPollingResult,
+  type DepositPollingInputs,
+} from "@/context/deposit/computeDepositPollingResult";
+import {
+  ContractStatus,
+  PEGIN_DISPLAY_LABELS,
+  PeginAction,
+} from "@/models/peginStateMachine";
+import type { VaultActivity } from "@/types/activity";
+import { canonicalizeTxid } from "@/utils/txid";
+
+const VAULT_ID = `0x${"11".repeat(32)}` as const;
+const PREPEGIN_TX = `0x${"ab".repeat(32)}` as const;
+const PUBKEY = "ab".repeat(32);
+// matureRefundTxids keys off the canonical (lowercased, no-0x) Pre-PegIn txid.
+const CANONICAL_PREPEGIN = canonicalizeTxid(PREPEGIN_TX) as string;
+
+function makeExpiredActivity(): VaultActivity {
+  return {
+    id: VAULT_ID,
+    collateral: { amount: "1", symbol: "BTC" },
+    providers: [],
+    displayLabel: PEGIN_DISPLAY_LABELS.EXPIRED,
+    unsignedPrePeginTx: "00",
+    depositorWotsPkHash: `0x${"00".repeat(32)}`,
+    prePeginTxHash: PREPEGIN_TX,
+    contractStatus: ContractStatus.EXPIRED,
+    depositorBtcPubkey: PUBKEY,
+    htlcVout: 0,
+  };
+}
+
+function makeInputs(
+  overrides: Partial<DepositPollingInputs> = {},
+): DepositPollingInputs {
+  return {
+    activity: makeExpiredActivity(),
+    pendingPegins: [],
+    pendingDepositorSignatures: undefined,
+    errors: undefined,
+    needsWotsKey: undefined,
+    pendingIngestion: undefined,
+    prePeginConfirmationsByTxid: new Map(),
+    confirmedTxids: new Set(),
+    // Cached-mature → refundMaturityState "mature" without needing live confs.
+    matureRefundTxids: new Set([CANONICAL_PREPEGIN]),
+    htlcRefundByDepositId: new Map(),
+    refundedHtlcVaultIds: new Set(),
+    requiredDepth: 6,
+    refundTimelock: 10,
+    isLoading: false,
+    optimisticStatuses: new Map(),
+    optimisticRefundBroadcastAt: new Map(),
+    btcPublicKey: PUBKEY,
+    ...overrides,
+  };
+}
+
+describe("computeDepositPollingResult — refund settlement", () => {
+  it("offers the refund action for a mature EXPIRED vault whose HTLC is unspent", () => {
+    const result = computeDepositPollingResult(makeInputs());
+    expect(result.peginState.availableActions).toContain(
+      PeginAction.REFUND_HTLC,
+    );
+    expect(result.peginState.displayLabel).toBe(PEGIN_DISPLAY_LABELS.EXPIRED);
+  });
+
+  it("hides the refund action and shows Refunded once the HTLC spend confirms", () => {
+    const result = computeDepositPollingResult(
+      makeInputs({
+        htlcRefundByDepositId: new Map([
+          [VAULT_ID.toLowerCase(), { spent: true, confirmed: true }],
+        ]),
+      }),
+    );
+    expect(result.peginState.availableActions).toEqual([PeginAction.NONE]);
+    expect(result.peginState.displayLabel).toBe(PEGIN_DISPLAY_LABELS.REFUNDED);
+  });
+
+  it("shows Refunding while the HTLC spend is seen but unconfirmed", () => {
+    const result = computeDepositPollingResult(
+      makeInputs({
+        htlcRefundByDepositId: new Map([
+          [VAULT_ID.toLowerCase(), { spent: true, confirmed: false }],
+        ]),
+      }),
+    );
+    expect(result.peginState.availableActions).toEqual([PeginAction.NONE]);
+    expect(result.peginState.displayLabel).toBe(PEGIN_DISPLAY_LABELS.REFUNDING);
+  });
+
+  it("treats a cached confirmed-refund as settled even when the live poll is empty", () => {
+    const result = computeDepositPollingResult(
+      makeInputs({
+        htlcRefundByDepositId: new Map(),
+        refundedHtlcVaultIds: new Set([VAULT_ID.toLowerCase()]),
+      }),
+    );
+    expect(result.peginState.availableActions).toEqual([PeginAction.NONE]);
+    expect(result.peginState.displayLabel).toBe(PEGIN_DISPLAY_LABELS.REFUNDED);
+  });
+});

--- a/services/vault/src/context/deposit/computeDepositPollingResult.ts
+++ b/services/vault/src/context/deposit/computeDepositPollingResult.ts
@@ -4,6 +4,7 @@
  * the rules — so the decision tree is testable without a React render.
  */
 
+import type { HtlcSpend } from "../../clients/btc/outspend";
 import {
   ContractStatus,
   getPeginState,
@@ -53,6 +54,17 @@ export interface DepositPollingInputs {
   prePeginConfirmationsByTxid: Map<string, number>;
   confirmedTxids: Set<string>;
   matureRefundTxids: Set<string>;
+  /**
+   * Live HTLC spend status keyed by lowercased vault id, from the EXPIRED
+   * `outspend` poll. A spent HTLC means the refund already landed.
+   */
+  htlcRefundByDepositId: Map<string, HtlcSpend>;
+  /**
+   * Lowercased vault ids whose HTLC spend confirmed (cached; dropped from the
+   * live poll). OR'd with the live map so a confirmed refund stays settled
+   * after the txid leaves the poll set.
+   */
+  refundedHtlcVaultIds: Set<string>;
   /** Per-vault min depth, pre-resolved from `offchainParamsVersion`. */
   requiredDepth: number;
   /** Per-vault `tRefund`; `undefined` collapses maturity to `unknown`. */
@@ -76,6 +88,8 @@ export function computeDepositPollingResult(
     prePeginConfirmationsByTxid,
     confirmedTxids,
     matureRefundTxids,
+    htlcRefundByDepositId,
+    refundedHtlcVaultIds,
     requiredDepth,
     refundTimelock,
     isLoading,
@@ -84,6 +98,7 @@ export function computeDepositPollingResult(
     btcPublicKey,
   } = inputs;
   const depositId = activity.id;
+  const depositIdKey = depositId.toLowerCase();
   const contractStatus = (activity.contractStatus ?? 0) as ContractStatus;
   const localStatus = resolveLocalStatus(
     depositId,
@@ -156,10 +171,27 @@ export function computeDepositPollingResult(
     }
   }
 
+  // Chain ground truth: has the HTLC output already been spent (refund landed)?
+  // Cached confirmed-refunds OR the live poll. A confirmed spend is terminal;
+  // a spent-but-unconfirmed one is a pending refund. Either way the refund is
+  // no longer available — re-broadcasting would hit Bitcoin's -27/-25.
+  const liveRefund = htlcRefundByDepositId.get(depositIdKey);
+  const refundConfirmed =
+    refundedHtlcVaultIds.has(depositIdKey) || liveRefund?.confirmed === true;
+  const refundPending = !refundConfirmed && liveRefund?.spent === true;
+  const refundSettlement: "confirmed" | "pending" | undefined = refundConfirmed
+    ? "confirmed"
+    : refundPending
+      ? "pending"
+      : undefined;
+
   // FE-composite: SDK only checks "have unsigned hex?"; we also gate on
-  // CSV maturity so the button never shows for a deposit Bitcoin would reject.
+  // CSV maturity so the button never shows for a deposit Bitcoin would reject,
+  // and on the HTLC not already being spent (settled refund).
   const canRefund =
-    !!activity.unsignedPrePeginTx && refundMaturityState === "mature";
+    !!activity.unsignedPrePeginTx &&
+    refundMaturityState === "mature" &&
+    refundSettlement === undefined;
 
   const peginState = getPeginState(contractStatus, {
     localStatus,
@@ -174,6 +206,7 @@ export function computeDepositPollingResult(
     canRefund,
     refundMaturityState,
     refundMaturesInBlocks,
+    refundSettlement,
     vpTerminalError,
     refundBroadcastAt,
   });

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -62,6 +62,7 @@ export const COPY = {
       LIQUIDATED: "Liquidated",
       EXPIRED: "Expired",
       REFUNDING: "Refunding",
+      REFUNDED: "Refunded",
       FAILED: "Failed",
       INVALID: "Invalid",
       UNKNOWN: "Unknown",
@@ -106,6 +107,8 @@ export const COPY = {
         "This BTC Vault was liquidated. The collateral was seized to cover unpaid debt.",
       refundBroadcast:
         "Refund transaction has been broadcast to Bitcoin. Waiting for on-chain confirmation...",
+      refundComplete:
+        "Your refund has been confirmed on Bitcoin. The locked BTC has returned to your wallet.",
       refundMaturing: (blocks: number, hours: number) =>
         `Refund claimable in ~${blocks} Bitcoin ${blocks === 1 ? "block" : "blocks"} (~${hours}h).`,
       refundMaturingUnknown: "Checking when your refund will be claimable...",

--- a/services/vault/src/hooks/deposit/useRefundState.ts
+++ b/services/vault/src/hooks/deposit/useRefundState.ts
@@ -113,50 +113,22 @@ export function useRefundState({
         abortRef.current?.abort();
         abortRef.current = new AbortController();
 
-        try {
-          // The wallet may have locked since the refund modal opened;
-          // `getPublicKeyHex()` below is cached and would not reveal it. Probe
-          // with a round-trip first so a locked wallet fails fast with an
-          // actionable error instead of a silent no-op at signing time.
-          await verifyBtcWalletLiveness(
-            btcWalletProvider,
-            connectedBtcAddress,
-            {
-              probeConnection: shouldProbeWalletLiveness(
-                btcConnector?.connectedWallet?.id,
-              ),
-            },
-          );
+        let depositorBtcPubkey: string | undefined;
 
-          // Fetch the pubkey live from the wallet (not from storage). The
-          // wallet's signPsbt signInputs[].publicKey requires the wallet's
-          // native format (typically compressed 33-byte sec1), and the
-          // stored activity holds the canonical x-only form used for
-          // on-chain/indexer identification.
-          const depositorBtcPubkey = await btcWalletProvider.getPublicKeyHex();
-          const txId = await buildAndBroadcastRefundTransaction({
-            vaultId,
-            depositorAddress: ethAddress as Address,
-            btcWalletProvider,
-            depositorBtcPubkey,
-            feeRate,
-            signal: abortRef.current.signal,
-          });
-          setRefundTxId(txId);
+        const persistRefundSuccess = (txId: string | undefined) => {
+          if (txId) setRefundTxId(txId);
           setRefunding(false);
-
           const refundBroadcastAt = Date.now();
           setOptimisticStatus(
             vaultId,
             LocalStorageStatus.REFUND_BROADCAST,
             refundBroadcastAt,
           );
-
           if (ethAddress && peginTxHash && unsignedPrePeginTx) {
             const existing = pendingPegins.find((p) => p.id === vaultId);
             if (existing) {
               markRefundBroadcast(vaultId, refundBroadcastAt);
-            } else {
+            } else if (depositorBtcPubkey) {
               addPendingPegin({
                 id: vaultId,
                 peginTxHash,
@@ -170,23 +142,36 @@ export function useRefundState({
               });
             }
           }
+        };
+
+        try {
+          await verifyBtcWalletLiveness(
+            btcWalletProvider,
+            connectedBtcAddress,
+            {
+              probeConnection: shouldProbeWalletLiveness(
+                btcConnector?.connectedWallet?.id,
+              ),
+            },
+          );
+
+          depositorBtcPubkey = await btcWalletProvider.getPublicKeyHex();
+          const txId = await buildAndBroadcastRefundTransaction({
+            vaultId,
+            depositorAddress: ethAddress as Address,
+            btcWalletProvider,
+            depositorBtcPubkey,
+            feeRate,
+            signal: abortRef.current.signal,
+          });
+          persistRefundSuccess(txId);
         } catch (err) {
           if (err instanceof Error && err.name === "AbortError") {
             setRefunding(false);
             return;
           }
-          // The HTLC output was already spent — the refund already landed
-          // (often from another device/session). This is success, not a
-          // retryable failure: show the existing refund tx and mark the
-          // optimistic REFUND_BROADCAST state so the action stops re-offering.
           if (err instanceof RefundAlreadySettledError) {
-            if (err.spendingTxid) setRefundTxId(err.spendingTxid);
-            setRefunding(false);
-            setOptimisticStatus(
-              vaultId,
-              LocalStorageStatus.REFUND_BROADCAST,
-              Date.now(),
-            );
+            persistRefundSuccess(err.spendingTxid);
             return;
           }
           logger.error(err instanceof Error ? err : new Error(String(err)), {

--- a/services/vault/src/hooks/deposit/useRefundState.ts
+++ b/services/vault/src/hooks/deposit/useRefundState.ts
@@ -6,7 +6,10 @@ import { usePeginPolling } from "@/context/deposit/PeginPollingContext";
 import { useETHWallet } from "@/context/wallet";
 import { logger } from "@/infrastructure";
 import { LocalStorageStatus } from "@/models/peginStateMachine";
-import { buildAndBroadcastRefundTransaction } from "@/services/vault/vaultRefundService";
+import {
+  buildAndBroadcastRefundTransaction,
+  RefundAlreadySettledError,
+} from "@/services/vault/vaultRefundService";
 import { usePeginStorage } from "@/storage/usePeginStorage";
 import type { VaultActivity } from "@/types/activity";
 import {
@@ -170,6 +173,20 @@ export function useRefundState({
         } catch (err) {
           if (err instanceof Error && err.name === "AbortError") {
             setRefunding(false);
+            return;
+          }
+          // The HTLC output was already spent — the refund already landed
+          // (often from another device/session). This is success, not a
+          // retryable failure: show the existing refund tx and mark the
+          // optimistic REFUND_BROADCAST state so the action stops re-offering.
+          if (err instanceof RefundAlreadySettledError) {
+            if (err.spendingTxid) setRefundTxId(err.spendingTxid);
+            setRefunding(false);
+            setOptimisticStatus(
+              vaultId,
+              LocalStorageStatus.REFUND_BROADCAST,
+              Date.now(),
+            );
             return;
           }
           logger.error(err instanceof Error ? err : new Error(String(err)), {

--- a/services/vault/src/hooks/useBtcHtlcRefundStatus.ts
+++ b/services/vault/src/hooks/useBtcHtlcRefundStatus.ts
@@ -1,0 +1,105 @@
+// Centralized poller for whether each EXPIRED vault's Pre-PegIn HTLC output
+// has been spent (the depositor's CSV refund). Mirrors
+// `useBtcMempoolConfirmations`: one batched query, concurrency-capped against
+// the public mempool.space rate limit, keyed by vault id (siblings of a
+// batched Pre-PegIn share a txid but own distinct HTLC outputs).
+
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMemo } from "react";
+
+import { getMempoolApiUrl } from "@/clients/btc/config";
+import { fetchHtlcSpend, type HtlcSpend } from "@/clients/btc/outspend";
+import { mapWithConcurrency } from "@/utils/concurrency";
+
+// 60s tick mirrors the confirmation poller — a refund confirms on a ~10-min
+// block, so a minute of latency is immaterial while halving requests.
+const POLL_INTERVAL_MS = 60 * 1000;
+// Just under the poll interval so refocus/remount doesn't double-fetch.
+const STALE_TIME_MS = 55 * 1000;
+// Cap concurrency — the public mempool.space endpoint rate-limits (429s).
+const MAX_CONCURRENT_REQUESTS = 4;
+
+/** One vault's HTLC outpoint to probe for a refund spend. */
+export interface HtlcRefundOutpoint {
+  /** Vault id (the result map's key). */
+  depositId: string;
+  /** Pre-PegIn tx hash funding the HTLC output. */
+  prePeginTxHash: string;
+  /** Index of this vault's HTLC output in the Pre-PegIn tx. */
+  htlcVout: number;
+}
+
+export interface BtcHtlcRefundStatusResult {
+  /** Vault id (lowercased) → HTLC spend status. Missing = not yet polled. */
+  refundByDepositId: Map<string, HtlcSpend>;
+}
+
+export function useBtcHtlcRefundStatus(
+  outpoints: ReadonlyArray<HtlcRefundOutpoint>,
+  queryKeyRoot: string,
+): BtcHtlcRefundStatusResult {
+  const queryClient = useQueryClient();
+
+  // Dedupe by vault id and sort so list churn / reordering doesn't refetch.
+  const stable = useMemo(() => {
+    const map = new Map<string, HtlcRefundOutpoint>();
+    for (const o of outpoints) {
+      if (!o.depositId || !o.prePeginTxHash) continue;
+      if (!Number.isInteger(o.htlcVout) || o.htlcVout < 0) continue;
+      const depositId = o.depositId.toLowerCase();
+      map.set(depositId, { ...o, depositId });
+    }
+    return Array.from(map.values()).sort((a, b) =>
+      a.depositId.localeCompare(b.depositId),
+    );
+  }, [outpoints]);
+
+  const enabled = stable.length > 0;
+  const queryKey = useMemo(
+    () =>
+      [
+        queryKeyRoot,
+        stable.map((o) => `${o.depositId}:${o.htlcVout}`).join(","),
+      ] as const,
+    [queryKeyRoot, stable],
+  );
+
+  const query = useQuery({
+    queryKey,
+    enabled,
+    refetchInterval: POLL_INTERVAL_MS,
+    staleTime: STALE_TIME_MS,
+    // Keep the prior batch across queryKey changes so list churn doesn't
+    // flicker a known status back to "unknown" until the next fetch lands.
+    placeholderData: (prev) => prev,
+    queryFn: async () => {
+      const apiUrl = getMempoolApiUrl();
+      // Carry prior known status forward on per-vault error so a transient
+      // 429/network blip doesn't drop a row for one cycle.
+      const prior =
+        queryClient.getQueryData<Map<string, HtlcSpend>>(queryKey) ?? new Map();
+      const entries = await mapWithConcurrency(
+        stable,
+        MAX_CONCURRENT_REQUESTS,
+        async (o): Promise<[string, HtlcSpend] | null> => {
+          try {
+            const spend = await fetchHtlcSpend(
+              o.prePeginTxHash,
+              o.htlcVout,
+              apiUrl,
+            );
+            return [o.depositId, spend];
+          } catch {
+            const priorSpend = prior.get(o.depositId);
+            return priorSpend !== undefined ? [o.depositId, priorSpend] : null;
+          }
+        },
+      );
+      return new Map<string, HtlcSpend>(
+        entries.filter((e): e is [string, HtlcSpend] => e !== null),
+      );
+    },
+  });
+
+  return { refundByDepositId: query.data ?? new Map() };
+}

--- a/services/vault/src/hooks/useBtcMempoolConfirmations.ts
+++ b/services/vault/src/hooks/useBtcMempoolConfirmations.ts
@@ -7,6 +7,7 @@ import { useMemo } from "react";
 
 import { getMempoolApiUrl } from "@/clients/btc/config";
 import { fetchConfirmations } from "@/clients/btc/confirmations";
+import { mapWithConcurrency } from "@/utils/concurrency";
 import { canonicalizeTxid } from "@/utils/txid";
 
 // 60s tick catches each ~10-min block within a minute while halving requests.
@@ -19,28 +20,6 @@ const MAX_CONCURRENT_REQUESTS = 4;
 export interface BtcMempoolConfirmationsResult {
   /** Canonical (lowercased, no 0x) txid → confirmation count. Missing = unknown. */
   confirmationsByTxid: Map<string, number>;
-}
-
-// Run `task` over items with at most `concurrency` in flight; preserves order.
-async function mapWithConcurrency<T, R>(
-  items: ReadonlyArray<T>,
-  concurrency: number,
-  task: (item: T) => Promise<R>,
-): Promise<R[]> {
-  const results = new Array<R>(items.length);
-  let nextIndex = 0;
-  const workers = Array.from(
-    { length: Math.min(concurrency, items.length) },
-    async () => {
-      while (true) {
-        const i = nextIndex++;
-        if (i >= items.length) return;
-        results[i] = await task(items[i]);
-      }
-    },
-  );
-  await Promise.all(workers);
-  return results;
 }
 
 export function useBtcMempoolConfirmations(

--- a/services/vault/src/models/__tests__/peginStateMachine.test.ts
+++ b/services/vault/src/models/__tests__/peginStateMachine.test.ts
@@ -451,6 +451,37 @@ describe("peginStateMachine", () => {
       expect(state.displayLabel).toBe(PEGIN_DISPLAY_LABELS.EXPIRED);
     });
 
+    it("shows Refunded (terminal, no action) when the HTLC spend has confirmed", () => {
+      const state = getPeginState(ContractStatus.EXPIRED, {
+        canRefund: false,
+        refundSettlement: "confirmed",
+      });
+      expect(state.displayLabel).toBe(PEGIN_DISPLAY_LABELS.REFUNDED);
+      expect(state.displayVariant).toBe("inactive");
+      expect(state.availableActions).toEqual([PeginAction.NONE]);
+    });
+
+    it("shows Refunding when the HTLC spend is seen but not yet confirmed", () => {
+      const state = getPeginState(ContractStatus.EXPIRED, {
+        canRefund: false,
+        refundSettlement: "pending",
+      });
+      expect(state.displayLabel).toBe(PEGIN_DISPLAY_LABELS.REFUNDING);
+      expect(state.displayVariant).toBe("pending");
+    });
+
+    it("chain-confirmed refund overrides a stale REFUND_BROADCAST optimistic state", () => {
+      const now = 1_700_000_000_000;
+      const state = getPeginState(ContractStatus.EXPIRED, {
+        canRefund: false,
+        refundSettlement: "confirmed",
+        localStatus: LocalStorageStatus.REFUND_BROADCAST,
+        refundBroadcastAt: now - 60_000,
+        now,
+      });
+      expect(state.displayLabel).toBe(PEGIN_DISPLAY_LABELS.REFUNDED);
+    });
+
     it("surfaces a CSV-maturing countdown when refund timelock has not elapsed", () => {
       const state = getPeginState(ContractStatus.EXPIRED, {
         expirationReason: "ack_timeout",

--- a/services/vault/src/models/peginStateMachine.ts
+++ b/services/vault/src/models/peginStateMachine.ts
@@ -151,6 +151,14 @@ export interface GetPeginStateOptions {
   refundMaturityState?: RefundMaturityState;
   /** Blocks remaining until CSV maturity; set only when `maturing`. */
   refundMaturesInBlocks?: number;
+  /**
+   * Chain-derived refund settlement for an EXPIRED vault, from probing the
+   * HTLC outpoint's spend status. `confirmed` = the refund landed in a block
+   * (terminal); `pending` = the refund is in the mempool. Overrides the
+   * localStorage REFUND_BROADCAST optimistic state (chain is ground truth);
+   * paired with `canRefund=false` so a settled refund can't be re-broadcast.
+   */
+  refundSettlement?: "confirmed" | "pending";
   vpTerminalError?: string;
   /**
    * `Date.now()` value captured when the refund tx was broadcast. Anchors
@@ -546,6 +554,23 @@ function getDisplay(
   }
 
   if (contractStatus === ContractStatus.EXPIRED) {
+    // Chain ground truth: the HTLC output is already spent. Overrides the
+    // localStorage optimistic state and (with `canRefund=false`) stops the
+    // dashboard re-offering a refund that Bitcoin would reject.
+    if (options.refundSettlement === "confirmed") {
+      return {
+        displayLabel: PEGIN_DISPLAY_LABELS.REFUNDED,
+        displayVariant: "inactive",
+        message: COPY.pegin.messages.refundComplete,
+      };
+    }
+    if (options.refundSettlement === "pending") {
+      return {
+        displayLabel: PEGIN_DISPLAY_LABELS.REFUNDING,
+        displayVariant: "pending",
+        message: COPY.pegin.messages.refundBroadcast,
+      };
+    }
     if (
       localStatus === LocalStorageStatus.REFUND_BROADCAST &&
       isRefundBroadcastWithinTtl(refundBroadcastAt, now)

--- a/services/vault/src/services/vault/__tests__/vaultRefundService.test.ts
+++ b/services/vault/src/services/vault/__tests__/vaultRefundService.test.ts
@@ -28,6 +28,10 @@ vi.mock("../../../clients/btc/config", () => ({
   getMempoolApiUrl: vi.fn().mockReturnValue("https://mempool.space/api"),
 }));
 
+vi.mock("../../../clients/btc/outspend", () => ({
+  fetchHtlcSpend: vi.fn(),
+}));
+
 vi.mock("@babylonlabs-io/ts-sdk/tbv/core/utils", () => ({
   calculateBtcTxHash: vi.fn(() => "0xmatching_pre_pegin_hash"),
 }));
@@ -84,12 +88,14 @@ import {
   type Mock,
 } from "vitest";
 
+import { fetchHtlcSpend } from "../../../clients/btc/outspend";
 import { getVaultFromChain } from "../../../clients/eth-contract/btc-vault-registry/query";
 import { fetchVaultProviderById } from "../fetchVaultProviders";
 import { fetchVaultIdsByDepositor, fetchVaultRefundData } from "../fetchVaults";
 import {
   buildAndBroadcastRefundTransaction,
   getRefundPreview,
+  RefundAlreadySettledError,
 } from "../vaultRefundService";
 
 const VAULT_ID = "0xvaultid" as `0x${string}`;
@@ -141,6 +147,13 @@ const mockFetch = vi.fn();
 beforeEach(() => {
   vi.stubGlobal("fetch", mockFetch);
   mockFetch.mockResolvedValue({ status: 200 });
+  // Default: HTLC output unspent, so the refund proceeds normally. Individual
+  // tests override to exercise the already-settled path. `clearAllMocks` (used
+  // per-describe) preserves this implementation.
+  (fetchHtlcSpend as Mock).mockResolvedValue({
+    spent: false,
+    confirmed: false,
+  });
 });
 
 afterEach(() => {
@@ -433,6 +446,76 @@ describe("vaultRefundService - adapter wiring", () => {
 
     expect(observed).toEqual({ txId: "broadcast_txid" });
     expect(txId).toBe("broadcast_txid");
+  });
+
+  it("throws RefundAlreadySettledError (before signing) when the HTLC is already spent", async () => {
+    (fetchHtlcSpend as Mock).mockResolvedValue({
+      spent: true,
+      confirmed: true,
+      spendingTxid: "existing_refund_txid",
+    });
+
+    const promise = buildAndBroadcastRefundTransaction({
+      vaultId: VAULT_ID,
+      depositorAddress: DEPOSITOR_ADDRESS,
+      btcWalletProvider: BTC_WALLET_PROVIDER,
+      depositorBtcPubkey: DEPOSITOR_PUBKEY,
+      feeRate: 10,
+    });
+
+    await expect(promise).rejects.toBeInstanceOf(RefundAlreadySettledError);
+    await expect(promise).rejects.toMatchObject({
+      spendingTxid: "existing_refund_txid",
+      confirmed: true,
+    });
+    // Guard fires before the wallet popup — never builds/signs/broadcasts.
+    expect(mockBuildAndBroadcastRefund).not.toHaveBeenCalled();
+  });
+
+  it("classifies a -27 broadcast rejection as already-settled when the re-probe finds the HTLC spent", async () => {
+    // Guard passes (unspent), then the broadcast races a confirmed refund:
+    // bitcoind returns -27, the re-probe finds the HTLC spent → success.
+    (fetchHtlcSpend as Mock)
+      .mockResolvedValueOnce({ spent: false, confirmed: false })
+      .mockResolvedValueOnce({
+        spent: true,
+        confirmed: true,
+        spendingTxid: "raced_refund_txid",
+      });
+    (pushTx as Mock).mockRejectedValue(
+      new Error(
+        'Failed to broadcast BTC transaction: sendrawtransaction RPC error: {"code":-27,"message":"Transaction already in block chain"}',
+      ),
+    );
+
+    await expect(
+      buildAndBroadcastRefundTransaction({
+        vaultId: VAULT_ID,
+        depositorAddress: DEPOSITOR_ADDRESS,
+        btcWalletProvider: BTC_WALLET_PROVIDER,
+        depositorBtcPubkey: DEPOSITOR_PUBKEY,
+        feeRate: 10,
+      }),
+    ).rejects.toBeInstanceOf(RefundAlreadySettledError);
+  });
+
+  it("does not classify a -26 broadcast rejection as already-settled (re-throws)", async () => {
+    (pushTx as Mock).mockRejectedValue(
+      new Error(
+        'Failed to broadcast BTC transaction: sendrawtransaction RPC error: {"code":-26,"message":"min relay fee not met"}',
+      ),
+    );
+
+    const promise = buildAndBroadcastRefundTransaction({
+      vaultId: VAULT_ID,
+      depositorAddress: DEPOSITOR_ADDRESS,
+      btcWalletProvider: BTC_WALLET_PROVIDER,
+      depositorBtcPubkey: DEPOSITOR_PUBKEY,
+      feeRate: 10,
+    });
+
+    await expect(promise).rejects.toThrow(/-26|min relay fee/);
+    await expect(promise).rejects.not.toBeInstanceOf(RefundAlreadySettledError);
   });
 });
 

--- a/services/vault/src/services/vault/vaultRefundService.ts
+++ b/services/vault/src/services/vault/vaultRefundService.ts
@@ -29,6 +29,7 @@ import { calculateBtcTxHash } from "@babylonlabs-io/ts-sdk/tbv/core/utils";
 import type { Address, Hex } from "viem";
 
 import { getMempoolApiUrl } from "../../clients/btc/config";
+import { fetchHtlcSpend } from "../../clients/btc/outspend";
 import { getVaultFromChain } from "../../clients/eth-contract/btc-vault-registry/query";
 import {
   getProtocolParamsReader,
@@ -387,6 +388,36 @@ async function readPrePeginContext(
 }
 
 /**
+ * Thrown when the refund cannot proceed because the vault's HTLC output is
+ * already spent — the depositor's refund has already landed, often from
+ * another device or session. Carries the spending (refund) txid so the UI can
+ * show success instead of a doomed retry. A pure BTC refund emits no Ethereum
+ * event, so this is detected by probing the HTLC outpoint's spend status, not
+ * from the indexer.
+ */
+export class RefundAlreadySettledError extends Error {
+  /** The transaction that already spent the HTLC output, when known. */
+  public readonly spendingTxid?: string;
+  /** True when that spending tx is confirmed in a block. */
+  public readonly confirmed: boolean;
+
+  constructor(spendingTxid: string | undefined, confirmed: boolean) {
+    super("Refund already settled: the HTLC output has already been spent.");
+    this.name = "RefundAlreadySettledError";
+    this.spendingTxid = spendingTxid;
+    this.confirmed = confirmed;
+  }
+}
+
+// bitcoind sendrawtransaction rejection codes that mean "this refund already
+// happened", relayed verbatim by mempool.space as `...RPC error: {"code":-N,...}`.
+// -27 = RPC_VERIFY_ALREADY_IN_UTXO_SET (the tx is already confirmed); -25 =
+// missing/already-spent inputs (the HTLC was already spent). Verified against
+// bitcoin/bitcoin src/rpc/protocol.h + src/node/transaction.cpp.
+const ALREADY_IN_CHAIN_CODE_RE = /"code"\s*:\s*-27\b/;
+const MISSING_OR_SPENT_INPUTS_CODE_RE = /"code"\s*:\s*-25\b/;
+
+/**
  * Build, sign, and broadcast a refund transaction for an expired vault.
  *
  * The broadcast will be rejected by the Bitcoin network if timelockRefund
@@ -394,6 +425,7 @@ async function readPrePeginContext(
  * in that case the SDK throws {@link BIP68NotMatureError}.
  *
  * @returns The broadcasted refund transaction ID
+ * @throws {@link RefundAlreadySettledError} if the HTLC output is already spent
  * @throws If vault data is missing or the broadcast fails
  */
 export async function buildAndBroadcastRefundTransaction(
@@ -425,6 +457,25 @@ export async function buildAndBroadcastRefundTransaction(
     throw new Error(COPY.deposit.refundNotBroadcast.broadcastGuardError);
   }
 
+  // The Pre-PegIn exists, but its HTLC output may already be spent — the refund
+  // already landed (e.g. from another device/session). The refund tx is
+  // deterministic, so re-broadcasting hits bitcoind -27 (already in chain) or
+  // -25 (input already spent); surface the existing refund as success instead
+  // of a doomed retry. On-chain `htlcVout` (never the indexer's) keys the
+  // probe. Fail-open: a flaky probe must not block a legitimate refund — the
+  // broadcast-time classification below is the backstop.
+  const htlcSpend = await fetchHtlcSpend(
+    target.onChainVault.prePeginTxHash,
+    target.onChainVault.htlcVout,
+    mempoolApiUrl,
+  ).catch(() => undefined);
+  if (htlcSpend?.spent) {
+    throw new RefundAlreadySettledError(
+      htlcSpend.spendingTxid,
+      htlcSpend.confirmed,
+    );
+  }
+
   // Override indexer-provided depositor pubkey with the caller's wallet key —
   // the wallet is the authoritative source for the depositor's signing key.
   const { txId } = await buildAndBroadcastRefund({
@@ -437,9 +488,33 @@ export async function buildAndBroadcastRefundTransaction(
     feeRate,
     signPsbt: (psbtHex, options) =>
       btcWalletProvider.signPsbt(psbtHex, options),
-    broadcastTx: async (signedTxHex) => ({
-      txId: await pushTx(signedTxHex, mempoolApiUrl),
-    }),
+    broadcastTx: async (signedTxHex) => {
+      try {
+        return { txId: await pushTx(signedTxHex, mempoolApiUrl) };
+      } catch (err) {
+        // Race: the HTLC was spent between the guard above and this broadcast.
+        // On bitcoind -27/-25, re-probe the outpoint; if spent, the refund is
+        // already done — report success rather than a retryable failure.
+        const message = err instanceof Error ? err.message : String(err);
+        if (
+          ALREADY_IN_CHAIN_CODE_RE.test(message) ||
+          MISSING_OR_SPENT_INPUTS_CODE_RE.test(message)
+        ) {
+          const spend = await fetchHtlcSpend(
+            target.onChainVault.prePeginTxHash,
+            target.onChainVault.htlcVout,
+            mempoolApiUrl,
+          ).catch(() => undefined);
+          if (spend?.spent) {
+            throw new RefundAlreadySettledError(
+              spend.spendingTxid,
+              spend.confirmed,
+            );
+          }
+        }
+        throw err;
+      }
+    },
     signal,
   });
 

--- a/services/vault/src/storage/refundedHtlcCache.ts
+++ b/services/vault/src/storage/refundedHtlcCache.ts
@@ -1,0 +1,68 @@
+/**
+ * Persistent cache of vault ids whose Pre-PegIn HTLC output has been observed
+ * spent-and-confirmed on Bitcoin (i.e. the depositor's refund landed). A
+ * confirmed spend is terminal, so once cached the dashboard stops polling the
+ * `outspend` endpoint for that vault and keeps rendering "Refunded".
+ *
+ * Keyed by vault id (not Pre-PegIn txid): batched siblings share one Pre-PegIn
+ * tx but each owns a distinct HTLC output, so one sibling can be refunded while
+ * another is not. Sibling of `matureRefundCache` (CSV maturity, keyed by txid).
+ */
+
+import { getBTCNetwork } from "@/config";
+
+const STORAGE_KEY = `tbv-refunded-htlc-${getBTCNetwork()}`;
+// TTL only matters on fresh page loads (in-session the `Set` lives in memory).
+// 1h bounds blast radius for any buggy entry; a reorg that un-spends a
+// confirmed refund re-surfaces within a poll cycle after expiry.
+const CACHE_TTL_MS = 60 * 60 * 1000;
+
+function readMap(): Record<string, number> {
+  try {
+    const parsed = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "{}");
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, number>)
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+function writeMap(map: Record<string, number>): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(map));
+  } catch {
+    /* quota / disabled — non-fatal */
+  }
+}
+
+function pruneExpired(
+  map: Record<string, number>,
+  now: number,
+): Record<string, number> {
+  const cutoff = now - CACHE_TTL_MS;
+  const out: Record<string, number> = {};
+  for (const [vaultId, ts] of Object.entries(map)) {
+    if (ts > cutoff) out[vaultId] = ts;
+  }
+  return out;
+}
+
+export function loadRefundedHtlcVaultIds(): Set<string> {
+  const map = readMap();
+  const pruned = pruneExpired(map, Date.now());
+  if (Object.keys(pruned).length !== Object.keys(map).length) {
+    writeMap(pruned);
+  }
+  return new Set(Object.keys(pruned));
+}
+
+export function addRefundedHtlcVaultId(vaultId: string): void {
+  if (!vaultId) return;
+  const key = vaultId.toLowerCase();
+  const now = Date.now();
+  const map = pruneExpired(readMap(), now);
+  if (map[key] !== undefined) return;
+  map[key] = now;
+  writeMap(map);
+}

--- a/services/vault/src/types/activity.ts
+++ b/services/vault/src/types/activity.ts
@@ -115,6 +115,13 @@ export interface VaultActivity {
   /** Unsigned pre-pegin transaction hex (spends depositor's UTXOs — used for UTXO validation and refund) */
   unsignedPrePeginTx: string;
 
+  /**
+   * Index of this vault's HTLC output in the Pre-PegIn tx. Indexer-provided;
+   * used (display-only) to probe whether the HTLC has already been refunded.
+   * The signing/broadcast path re-reads it from chain, never from here.
+   */
+  htlcVout?: number;
+
   /** Depositor-specified BTC payout address (raw scriptPubKey hex from indexer) */
   depositorPayoutBtcAddress?: Hex;
 

--- a/services/vault/src/utils/concurrency.ts
+++ b/services/vault/src/utils/concurrency.ts
@@ -1,0 +1,25 @@
+/**
+ * Run `task` over `items` with at most `concurrency` in flight; preserves
+ * input order in the result array. Shared by the mempool batch pollers so
+ * the public mempool.space endpoint's rate limit (429s) is respected.
+ */
+export async function mapWithConcurrency<T, R>(
+  items: ReadonlyArray<T>,
+  concurrency: number,
+  task: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+  const workers = Array.from(
+    { length: Math.min(concurrency, items.length) },
+    async () => {
+      while (true) {
+        const i = nextIndex++;
+        if (i >= items.length) return;
+        results[i] = await task(items[i]);
+      }
+    },
+  );
+  await Promise.all(workers);
+  return results;
+}

--- a/services/vault/src/utils/vaultTransformers.ts
+++ b/services/vault/src/utils/vaultTransformers.ts
@@ -82,6 +82,7 @@ export function transformVaultToActivity(vault: Vault): VaultActivity {
     depositorBtcPubkey: vault.depositorBtcPubkey,
     depositorSignedPeginTx: vault.depositorSignedPeginTx,
     unsignedPrePeginTx: vault.unsignedPrePeginTx,
+    htlcVout: vault.htlcVout,
     depositorPayoutBtcAddress: vault.depositorPayoutBtcAddress,
     depositorWotsPkHash: vault.depositorWotsPkHash,
     expiredAt: vault.expiredAt,


### PR DESCRIPTION
A confirmed or in-flight Pre-PegIn refund surfaced as "Failed to broadcast"
with a Retry that re-broadcast the same deterministic tx forever (bitcoind
-27/-25): the guard checked Pre-PegIn existence, not whether the HTLC output
was still unspent, and a pure BTC refund emits no on-chain event so the
indexer never sees it. Detect the spend via the mempool outspend endpoint.