### PR TITLE
fix(vault): verify wallet-returned Schnorr signatures vs sighash (#842)

### DIFF
--- a/packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts
@@ -14,18 +14,19 @@
  * @module managers/PayoutManager
  */
 
-import type {
-  BitcoinWallet,
-  SignPsbtOptions,
-} from "../../../shared/wallets";
-import { createTaprootScriptPathSignOptions } from "../utils/signing";
+import type { BitcoinWallet, SignPsbtOptions } from "../../../shared/wallets";
 import {
   assertPsbtUnsignedTxMatches,
+  assertScriptPathSchnorrSignature,
   buildPayoutPsbt,
   extractPayoutSignature,
   validateWalletPubkey,
   type Network,
 } from "../primitives";
+import { createTaprootScriptPathSignOptions } from "../utils/signing";
+
+/** Payout PSBTs are signed by the depositor on input 0 (Taproot script-path). */
+const PAYOUT_SIGNED_INPUT_INDEX = 0;
 
 /**
  * Configuration for the PayoutManager.
@@ -233,6 +234,14 @@ export class PayoutManager {
 
     // Extract Schnorr signature
     const signature = extractPayoutSignature(signedPsbtHex, depositorPubkey);
+    // Critical Path #7: verify the signature against a sighash recomputed from
+    // the PSBT we built, not the wallet-returned one.
+    assertScriptPathSchnorrSignature({
+      requestedPsbtHex: payoutPsbt.psbtHex,
+      signatureHex: signature,
+      signerXOnlyPubkeyHex: depositorPubkey,
+      inputIndex: PAYOUT_SIGNED_INPUT_INDEX,
+    });
 
     return {
       signature,
@@ -267,9 +276,7 @@ export class PayoutManager {
    * @throws Error if wallet doesn't support batch signing
    * @throws Error if any signing operation fails
    */
-  async signPayoutTransactionsBatch(
-    transactions: SignPayoutParams[],
-  ): Promise<
+  async signPayoutTransactionsBatch(transactions: SignPayoutParams[]): Promise<
     Array<{
       payoutSignature: string;
       depositorBtcPubkey: string;
@@ -346,6 +353,12 @@ export class PayoutManager {
         signedPsbts[i],
         depositorPubkey,
       );
+      assertScriptPathSchnorrSignature({
+        requestedPsbtHex: psbtsToSign[i],
+        signatureHex: payoutSignature,
+        signerXOnlyPubkeyHex: depositorPubkey,
+        inputIndex: PAYOUT_SIGNED_INPUT_INDEX,
+      });
 
       results.push({
         payoutSignature,
@@ -355,5 +368,4 @@ export class PayoutManager {
 
     return results;
   }
-
 }

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
@@ -24,13 +24,6 @@ import { Psbt, Transaction } from "bitcoinjs-lib";
 import { Buffer } from "buffer";
 
 import {
-  assertAuthAnchorOpReturn,
-  expandPerVaultSecrets,
-  normalizePopSignature,
-  normalizeXOnlyPubkey,
-  signPsbtsWithFallback,
-} from "./pegin";
-import {
   encodeFunctionData,
   isAddressEqual,
   zeroAddress,
@@ -40,22 +33,34 @@ import {
   type PublicClient,
   type WalletClient,
 } from "viem";
+import {
+  assertAuthAnchorOpReturn,
+  expandPerVaultSecrets,
+  normalizePopSignature,
+  normalizeXOnlyPubkey,
+  signPsbtsWithFallback,
+} from "./pegin";
 
-import type { BitcoinWallet, Hash, SignPsbtOptions } from "../../../shared/wallets";
-import type { WotsBlockPublicKey } from "../clients/vault-provider/types";
+import type {
+  BitcoinWallet,
+  Hash,
+  SignPsbtOptions,
+} from "../../../shared/wallets";
 import { ViemVaultRegistryReader } from "../clients/eth";
-import { type UtxoInfo, getUtxoInfo, pushTx } from "../clients/mempool";
+import { getUtxoInfo, pushTx, type UtxoInfo } from "../clients/mempool";
+import type { WotsBlockPublicKey } from "../clients/vault-provider/types";
 import { BTCVaultRegistryABI, handleContractError } from "../contracts";
 import {
   assertPsbtUnsignedTxMatches,
-  buildPrePeginPsbt,
-  buildPeginTxFromFundedPrePegin,
+  assertScriptPathSchnorrSignature,
   buildPeginInputPsbt,
+  buildPeginTxFromFundedPrePegin,
+  buildPrePeginPsbt,
+  deriveVaultId,
   extractPeginInputSignature,
   finalizePeginInputPsbt,
-  deriveVaultId,
-  type PrePeginParams,
   type Network,
+  type PrePeginParams,
 } from "../primitives";
 import {
   ensureHexPrefix,
@@ -70,11 +75,11 @@ import {
   fundPeginTransaction,
   getNetwork,
   getPsbtInputFields,
+  MAX_REASONABLE_FEE_SATS,
   peginOutputCount,
   selectUtxosForPegin,
-  type UTXO,
-  MAX_REASONABLE_FEE_SATS,
   waitForTransactionReceiptSmartAware,
+  type UTXO,
 } from "../utils";
 import { createTaprootScriptPathSignOptions } from "../utils/signing";
 import {
@@ -334,7 +339,6 @@ export interface PreparePeginResult {
   derivedSecrets: PreparePeginDerivedSecrets;
 }
 
-
 /**
  * Parameters for signing and broadcasting a transaction.
  */
@@ -507,7 +511,6 @@ export interface RegisterPeginBatchResult {
   vaults: BatchPeginResultItem[];
 }
 
-
 /**
  * Detect a P2WPKH (Native SegWit) bech32 address for the configured network,
  * used purely for diagnostic routing. Distinguishes P2WPKH (witness v0,
@@ -541,7 +544,9 @@ function isP2wpkhAddressForNetwork(address: string, network: Network): boolean {
 function resolveUtxoInfo(
   txid: string,
   vout: number,
-  localPrevouts: Record<string, { scriptPubKey: string; value: number }> | undefined,
+  localPrevouts:
+    | Record<string, { scriptPubKey: string; value: number }>
+    | undefined,
   apiUrl: string,
 ): Promise<UtxoInfo> {
   const local = localPrevouts?.[`${txid}:${vout}`];
@@ -619,9 +624,7 @@ export class PeginManager {
    * @throws If the wallet rejects, insufficient funds, or an internal
    *         invariant violation.
    */
-  async preparePegin(
-    params: PreparePeginParams,
-  ): Promise<PreparePeginResult> {
+  async preparePegin(params: PreparePeginParams): Promise<PreparePeginResult> {
     if (params.amounts.length === 0) {
       throw new Error("amounts must contain at least one entry");
     }
@@ -629,8 +632,7 @@ export class PeginManager {
     // Raw form for `signInputs[].publicKey` (UniSat/OKX/OneKey reject
     // x-only); x-only form for protocol/HTLC use. One snapshot binds
     // sizing, root derivation, and PSBT signing to one identity.
-    const depositorBtcPubkeyRaw =
-      await this.config.btcWallet.getPublicKeyHex();
+    const depositorBtcPubkeyRaw = await this.config.btcWallet.getPublicKeyHex();
     const depositorBtcPubkey = normalizeXOnlyPubkey(depositorBtcPubkeyRaw);
 
     // Pre-PegIn change pays back to the depositor. The wallet will sign
@@ -845,8 +847,11 @@ export class PeginManager {
       );
     }
 
-    const vaultProviderBtcPubkey = stripHexPrefix(params.vaultProviderBtcPubkey);
-    const vaultKeeperBtcPubkeys = params.vaultKeeperBtcPubkeys.map(stripHexPrefix);
+    const vaultProviderBtcPubkey = stripHexPrefix(
+      params.vaultProviderBtcPubkey,
+    );
+    const vaultKeeperBtcPubkeys =
+      params.vaultKeeperBtcPubkeys.map(stripHexPrefix);
     const universalChallengerBtcPubkeys =
       params.universalChallengerBtcPubkeys.map(stripHexPrefix);
     const numLocalChallengers = vaultKeeperBtcPubkeys.length;
@@ -879,7 +884,9 @@ export class PeginManager {
       network,
     });
 
-    const prePeginTxid = stripHexPrefix(calculateBtcTxHash(fundedPrePeginTxHex));
+    const prePeginTxid = stripHexPrefix(
+      calculateBtcTxHash(fundedPrePeginTxHex),
+    );
 
     const peginTxResults: Array<{
       txHex: string;
@@ -933,6 +940,15 @@ export class PeginManager {
         signedPsbts[i],
         depositorBtcPubkey,
       );
+      // Critical Path #7: verify the depositor's script-path signature against a
+      // sighash recomputed from the PSBT we built (psbtsToSign[i]) before the
+      // signed tx is finalized and broadcast. The PegIn input is signed on input 0.
+      assertScriptPathSchnorrSignature({
+        requestedPsbtHex: psbtsToSign[i],
+        signatureHex: peginInputSignature,
+        signerXOnlyPubkeyHex: depositorBtcPubkey,
+        inputIndex: 0,
+      });
 
       const depositorSignedPeginTxHex = finalizePeginInputPsbt(signedPsbts[i]);
 
@@ -952,7 +968,6 @@ export class PeginManager {
       perVault,
     };
   }
-
 
   /**
    * Signs and broadcasts a funded peg-in transaction to the Bitcoin network.
@@ -1141,7 +1156,9 @@ export class PeginManager {
       throw new Error("Ethereum wallet account not found");
     }
     const depositorEthAddress = this.config.ethWallet.account.address;
-    if (!isAddressEqual(popSignature.depositorEthAddress, depositorEthAddress)) {
+    if (
+      !isAddressEqual(popSignature.depositorEthAddress, depositorEthAddress)
+    ) {
       throw new Error(
         `Proof of possession was signed for ${popSignature.depositorEthAddress} ` +
           `but the Ethereum wallet is currently connected to ${depositorEthAddress}. ` +
@@ -1156,7 +1173,9 @@ export class PeginManager {
     const btcPopSignature = popSignature.btcPopSignature;
 
     // Step 2: Format parameters for contract call
-    const depositorBtcPubkeyHex = ensureHexPrefix(popSignature.depositorBtcPubkey);
+    const depositorBtcPubkeyHex = ensureHexPrefix(
+      popSignature.depositorBtcPubkey,
+    );
     const unsignedPrePeginTxHex = ensureHexPrefix(unsignedPrePeginTx);
     const depositorSignedPeginTxHex = ensureHexPrefix(depositorSignedPeginTx);
 
@@ -1317,7 +1336,9 @@ export class PeginManager {
       throw new Error("Ethereum wallet account not found");
     }
     const depositorEthAddress = this.config.ethWallet.account.address;
-    if (!isAddressEqual(popSignature.depositorEthAddress, depositorEthAddress)) {
+    if (
+      !isAddressEqual(popSignature.depositorEthAddress, depositorEthAddress)
+    ) {
       throw new Error(
         `Proof of possession was signed for ${popSignature.depositorEthAddress} ` +
           `but the Ethereum wallet is currently connected to ${depositorEthAddress}. ` +
@@ -1775,8 +1796,13 @@ export interface EstimateSubmitPeginRequestBatchGasParams {
 export async function estimateSubmitPeginRequestBatchGas(
   params: EstimateSubmitPeginRequestBatchGasParams,
 ): Promise<bigint> {
-  const { publicClient, btcVaultRegistry, depositorEthAddress, vaultProvider, batchSize } =
-    params;
+  const {
+    publicClient,
+    btcVaultRegistry,
+    depositorEthAddress,
+    vaultProvider,
+    batchSize,
+  } = params;
 
   if (batchSize <= 0) {
     throw new Error(

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PayoutManager.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PayoutManager.test.ts
@@ -27,6 +27,15 @@ import { initializeWasmForTests } from "../../primitives/psbt/__tests__/helpers"
 import { PAYOUT_ANCHOR_DUST_SATS } from "../../primitives/psbt/constants";
 import { PayoutManager, type PayoutManagerConfig } from "../PayoutManager";
 
+// These tests inject synthetic signatures into otherwise-real payout PSBTs to
+// exercise orchestration and output validation. BIP-340 signature verification
+// is a separate concern with its own dedicated real-PSBT tests
+// (primitives/psbt/__tests__/verifyScriptPathSchnorrSignature.test.ts), so it is
+// stubbed here to let the synthetic fixtures through.
+vi.mock("../../primitives/psbt/verifyScriptPathSchnorrSignature", () => ({
+  assertScriptPathSchnorrSignature: vi.fn(),
+}));
+
 // Test constants - use valid secp256k1 x-only public keys
 const TEST_KEYS = {
   DEPOSITOR: "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
@@ -192,8 +201,7 @@ describe("PayoutManager", () => {
 
           return psbtsHexes.map((psbtHex, index) => {
             const psbt = Psbt.fromHex(psbtHex);
-            const signature =
-              index === 0 ? payoutSignature1 : payoutSignature2;
+            const signature = index === 0 ? payoutSignature1 : payoutSignature2;
 
             psbt.data.inputs[0].tapScriptSig = [
               {
@@ -415,9 +423,7 @@ describe("PayoutManager", () => {
             commissionBps: 500,
           },
         ]),
-      ).rejects.toThrow(
-        "Expected 2 signed PSBTs but received 1",
-      );
+      ).rejects.toThrow("Expected 2 signed PSBTs but received 1");
     });
 
     it("should throw error when wallet returns more PSBTs than expected", async () => {
@@ -492,9 +498,7 @@ describe("PayoutManager", () => {
             commissionBps: 500,
           },
         ]),
-      ).rejects.toThrow(
-        "Expected 2 signed PSBTs but received 3",
-      );
+      ).rejects.toThrow("Expected 2 signed PSBTs but received 3");
     });
   });
 

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PeginManager.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PeginManager.test.ts
@@ -7,7 +7,6 @@
 
 import * as bitcoin from "bitcoinjs-lib";
 import { Buffer } from "buffer";
-import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import {
   decodeFunctionData,
   zeroAddress,
@@ -15,11 +14,9 @@ import {
   type Chain,
   type PublicClient,
 } from "viem";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
-import {
-  MockBitcoinWallet,
-  MockEthereumWallet,
-} from "../../../../testing";
+import { MockBitcoinWallet, MockEthereumWallet } from "../../../../testing";
 import { MEMPOOL_API_URLS } from "../../clients/mempool";
 import { BTCVaultRegistryABI } from "../../contracts";
 import {
@@ -42,11 +39,11 @@ vi.mock("../../primitives/psbt/peginInput", async (importOriginal) => {
     await importOriginal<typeof import("../../primitives/psbt/peginInput")>();
   return {
     ...actual,
-    buildPeginInputPsbt: vi
-      .fn()
-      .mockResolvedValue({ psbtHex: "deadbeef" }),
+    buildPeginInputPsbt: vi.fn().mockResolvedValue({ psbtHex: "deadbeef" }),
     extractPeginInputSignature: vi.fn().mockReturnValue("a".repeat(128)),
-    finalizePeginInputPsbt: vi.fn().mockReturnValue("mock-depositor-signed-pegin-tx"),
+    finalizePeginInputPsbt: vi
+      .fn()
+      .mockReturnValue("mock-depositor-signed-pegin-tx"),
   };
 });
 
@@ -64,6 +61,13 @@ vi.mock(
     };
   },
 );
+
+// Schnorr-signature verification needs a real PSBT + real signature, which the
+// mock wallet cannot produce. It is verified in its own dedicated real-PSBT
+// tests (primitives/psbt/__tests__/verifyScriptPathSchnorrSignature.test.ts).
+vi.mock("../../primitives/psbt/verifyScriptPathSchnorrSignature", () => ({
+  assertScriptPathSchnorrSignature: vi.fn(),
+}));
 
 // Test chain configuration (minimal viem Chain)
 const TEST_CHAIN: Chain = {
@@ -102,8 +106,7 @@ const TEST_PUBLIC_CLIENT = {
 
 // Test constants - use valid secp256k1 x-only public keys
 const TEST_KEYS = {
-  DEPOSITOR:
-    "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+  DEPOSITOR: "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
   VAULT_PROVIDER:
     "c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5",
   VAULT_KEEPER_1:
@@ -139,21 +142,24 @@ const TEST_UTXOS: UTXO[] = [
     vout: 0,
     value: 800_000,
     scriptPubKey:
-      "5120" + "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+      "5120" +
+      "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
   },
   {
     txid: "0000000000000000000000000000000000000000000000000000000000000002",
     vout: 0,
     value: 800_000,
     scriptPubKey:
-      "5120" + "c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5",
+      "5120" +
+      "c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5",
   },
   {
     txid: "0000000000000000000000000000000000000000000000000000000000000003",
     vout: 1,
     value: 800_000,
     scriptPubKey:
-      "5120" + "f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9",
+      "5120" +
+      "f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9",
   },
 ];
 
@@ -431,9 +437,7 @@ describe("PeginManager", () => {
       expect(result.derivedSecrets.htlcSecretHexes[0]).toMatch(
         /^[0-9a-f]{64}$/,
       );
-      expect(result.derivedSecrets.wotsPkHashes[0]).toMatch(
-        /^0x[0-9a-f]{64}$/,
-      );
+      expect(result.derivedSecrets.wotsPkHashes[0]).toMatch(/^0x[0-9a-f]{64}$/);
       expect(result.derivedSecrets.authAnchorHex).toMatch(/^[0-9a-f]{64}$/);
 
       // Pubkey snapshot returned at top level (safe to persist).
@@ -494,7 +498,10 @@ describe("PeginManager", () => {
       const result = await manager.preparePegin({
         amounts: [TEST_AMOUNTS.PEGIN],
         ...BASE_PREPARE_PEGIN_PARAMS,
-        vaultKeeperBtcPubkeys: [TEST_KEYS.VAULT_KEEPER_1, TEST_KEYS.VAULT_KEEPER_2],
+        vaultKeeperBtcPubkeys: [
+          TEST_KEYS.VAULT_KEEPER_1,
+          TEST_KEYS.VAULT_KEEPER_2,
+        ],
       });
 
       expect(result.transaction.fundedPrePeginTxHex.length).toBeGreaterThan(0);
@@ -756,9 +763,7 @@ describe("PeginManager", () => {
       const btcWallet = new MockBitcoinWallet({
         publicKeyHex: TEST_KEYS.DEPOSITOR,
       });
-      vi.spyOn(btcWallet, "signMessage").mockResolvedValueOnce(
-        "0xDEADBEEF",
-      );
+      vi.spyOn(btcWallet, "signMessage").mockResolvedValueOnce("0xDEADBEEF");
       const ethWallet = new MockEthereumWallet();
 
       const manager = new PeginManager({
@@ -792,9 +797,7 @@ describe("PeginManager", () => {
         mempoolApiUrl: MEMPOOL_API_URLS.signet,
       });
 
-      await expect(manager.signProofOfPossession()).rejects.toThrow(
-        /empty/i,
-      );
+      await expect(manager.signProofOfPossession()).rejects.toThrow(/empty/i);
     });
 
     it("rejects a malformed (non-canonical) base64 signature", async () => {
@@ -815,9 +818,7 @@ describe("PeginManager", () => {
         mempoolApiUrl: MEMPOOL_API_URLS.signet,
       });
 
-      await expect(manager.signProofOfPossession()).rejects.toThrow(
-        /base64/i,
-      );
+      await expect(manager.signProofOfPossession()).rejects.toThrow(/base64/i);
     });
 
     it("rejects a malformed hex signature", async () => {
@@ -837,9 +838,7 @@ describe("PeginManager", () => {
         mempoolApiUrl: MEMPOOL_API_URLS.signet,
       });
 
-      await expect(manager.signProofOfPossession()).rejects.toThrow(
-        /hex/i,
-      );
+      await expect(manager.signProofOfPossession()).rejects.toThrow(/hex/i);
     });
 
     it("treats unprefixed hex-looking output as hex, not base64", async () => {
@@ -957,8 +956,7 @@ describe("PeginManager", () => {
         vaultProvider: TEST_CONTRACT_ADDRESS,
         hashlock: MOCK_HASHLOCK,
         htlcVout: 0,
-        depositorPayoutBtcAddress:
-          TEST_PAYOUT_ADDRESS,
+        depositorPayoutBtcAddress: TEST_PAYOUT_ADDRESS,
         depositorWotsPkHash: MOCK_WOTS_PK_HASH,
         popSignature,
       });
@@ -989,8 +987,7 @@ describe("PeginManager", () => {
           vaultProvider: TEST_CONTRACT_ADDRESS,
           hashlock: MOCK_HASHLOCK,
           htlcVout: 0,
-          depositorPayoutBtcAddress:
-            TEST_PAYOUT_ADDRESS,
+          depositorPayoutBtcAddress: TEST_PAYOUT_ADDRESS,
           depositorWotsPkHash: MOCK_WOTS_PK_HASH,
           popSignature,
         }),
@@ -998,8 +995,7 @@ describe("PeginManager", () => {
     });
 
     it("should throw when BTC wallet is connected to a different pubkey than the PoP", async () => {
-      const { manager, btcWallet, popSignature } =
-        await makeManagerWithPop();
+      const { manager, btcWallet, popSignature } = await makeManagerWithPop();
       // Simulate BTC wallet swap between signing PoP and submitting.
       vi.spyOn(btcWallet, "getPublicKeyHex").mockResolvedValue(
         TEST_KEYS.VAULT_KEEPER_1,
@@ -1012,8 +1008,7 @@ describe("PeginManager", () => {
           vaultProvider: TEST_CONTRACT_ADDRESS,
           hashlock: MOCK_HASHLOCK,
           htlcVout: 0,
-          depositorPayoutBtcAddress:
-            TEST_PAYOUT_ADDRESS,
+          depositorPayoutBtcAddress: TEST_PAYOUT_ADDRESS,
           depositorWotsPkHash: MOCK_WOTS_PK_HASH,
           popSignature,
         }),
@@ -1047,8 +1042,7 @@ describe("PeginManager", () => {
           vaultProvider: TEST_CONTRACT_ADDRESS,
           hashlock: MOCK_HASHLOCK,
           htlcVout: 0,
-          depositorPayoutBtcAddress:
-            TEST_PAYOUT_ADDRESS,
+          depositorPayoutBtcAddress: TEST_PAYOUT_ADDRESS,
           depositorWotsPkHash: MOCK_WOTS_PK_HASH,
           popSignature,
         }),
@@ -1065,8 +1059,7 @@ describe("PeginManager", () => {
         vaultProvider: TEST_CONTRACT_ADDRESS,
         hashlock: MOCK_HASHLOCK,
         htlcVout: 0,
-        depositorPayoutBtcAddress:
-          TEST_PAYOUT_ADDRESS,
+        depositorPayoutBtcAddress: TEST_PAYOUT_ADDRESS,
         depositorWotsPkHash: MOCK_WOTS_PK_HASH,
         popSignature,
       });
@@ -1079,8 +1072,7 @@ describe("PeginManager", () => {
         vaultProvider: TEST_CONTRACT_ADDRESS,
         hashlock: MOCK_HASHLOCK,
         htlcVout: 0,
-        depositorPayoutBtcAddress:
-          TEST_PAYOUT_ADDRESS,
+        depositorPayoutBtcAddress: TEST_PAYOUT_ADDRESS,
         depositorWotsPkHash: MOCK_WOTS_PK_HASH,
         popSignature,
       });
@@ -1088,7 +1080,9 @@ describe("PeginManager", () => {
     });
 
     it("should throw when transaction receipt status is reverted", async () => {
-      vi.mocked(TEST_PUBLIC_CLIENT.waitForTransactionReceipt).mockResolvedValueOnce({
+      vi.mocked(
+        TEST_PUBLIC_CLIENT.waitForTransactionReceipt,
+      ).mockResolvedValueOnce({
         status: "reverted",
         transactionHash: `0x${"ab".repeat(32)}`,
       } as never);
@@ -1102,8 +1096,7 @@ describe("PeginManager", () => {
           vaultProvider: TEST_CONTRACT_ADDRESS,
           hashlock: MOCK_HASHLOCK,
           htlcVout: 0,
-          depositorPayoutBtcAddress:
-            TEST_PAYOUT_ADDRESS,
+          depositorPayoutBtcAddress: TEST_PAYOUT_ADDRESS,
           depositorWotsPkHash: MOCK_WOTS_PK_HASH,
           popSignature,
         }),
@@ -1113,9 +1106,11 @@ describe("PeginManager", () => {
     describe("resolveMaxAcceptableCommissionBps (boundary cases)", () => {
       // The shared TEST_PUBLIC_CLIENT.readContract mock is reset to its
       // default after each case so per-test overrides don't leak.
-      const DEFAULT_READ_CONTRACT_IMPL = (
-        { functionName }: { functionName: string },
-      ) => {
+      const DEFAULT_READ_CONTRACT_IMPL = ({
+        functionName,
+      }: {
+        functionName: string;
+      }) => {
         if (functionName === "getPegInFee") return Promise.resolve(0n);
         if (functionName === "getVaultProviderCommission")
           return Promise.resolve(0);
@@ -1222,7 +1217,6 @@ describe("PeginManager", () => {
           }),
         ).rejects.toThrow(/commission changed since quote/);
       });
-
     });
   });
 
@@ -1231,8 +1225,7 @@ describe("PeginManager", () => {
     const baseRequest = {
       depositorSignedPeginTx: MOCK_DEPOSITOR_SIGNED_PEGIN_TX,
       hashlock: MOCK_HASHLOCK,
-      depositorPayoutBtcAddress:
-        TEST_PAYOUT_ADDRESS,
+      depositorPayoutBtcAddress: TEST_PAYOUT_ADDRESS,
       depositorWotsPkHash: MOCK_WOTS_PK_HASH,
     } as const;
 
@@ -1356,7 +1349,6 @@ describe("PeginManager", () => {
       // Depositor BTC pubkey comes from PopSignature, not per-request.
       expect(sentData).toContain(popSignature.depositorBtcPubkey);
     });
-
   });
 
   describe("signAndBroadcast", () => {
@@ -1646,7 +1638,9 @@ describe("PeginManager", () => {
         ...BASE_PREPARE_PEGIN_PARAMS,
       });
 
-      const tx = bitcoin.Transaction.fromHex(result.transaction.fundedPrePeginTxHex);
+      const tx = bitcoin.Transaction.fromHex(
+        result.transaction.fundedPrePeginTxHex,
+      );
       const opReturnVout = 2; // vault outputs at 0, 1; OP_RETURN at vaultCount
       const script = tx.outs[opReturnVout].script;
 
@@ -1951,9 +1945,7 @@ describe("PeginManager", () => {
             depositorWotsPkHash: MOCK_WOTS_PK_HASH,
             popSignature,
           }),
-        ).rejects.toThrow(
-          /P2WPKH .* x-only public key.*Use a P2TR/i,
-        );
+        ).rejects.toThrow(/P2WPKH .* x-only public key.*Use a P2TR/i);
       }
     });
 

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/index.ts
@@ -78,11 +78,16 @@
 export { computeNumLocalChallengers } from "./challengers";
 
 // Core types and functions from WASM package
-export type { Network } from "@babylonlabs-io/babylon-tbv-rust-wasm";
 export {
   computeMinClaimValue,
   computeMinPeginFee,
   deriveVaultId,
+} from "@babylonlabs-io/babylon-tbv-rust-wasm";
+export type {
+  AssertPayoutNoPayoutConnectorParams,
+  ChallengeAssertConnectorParams,
+  Network,
+  PayoutConnectorParams,
 } from "@babylonlabs-io/babylon-tbv-rust-wasm";
 
 /**
@@ -93,22 +98,24 @@ export {
  * Derive with `deriveVaultId(peginTxHash, depositorAddress)`.
  */
 export type VaultId = `0x${string}`;
-export type {
-  AssertPayoutNoPayoutConnectorParams,
-  ChallengeAssertConnectorParams,
-  PayoutConnectorParams,
-} from "@babylonlabs-io/babylon-tbv-rust-wasm";
 
 // PSBT builders
-export { buildPrePeginPsbt, buildPeginTxFromFundedPrePegin } from "./psbt/pegin";
+export {
+  buildPeginTxFromFundedPrePegin,
+  buildPrePeginPsbt,
+} from "./psbt/pegin";
 export type {
-  PrePeginParams,
-  PrePeginPsbtResult,
   BuildPeginTxParams,
   PeginTxResult,
+  PrePeginParams,
+  PrePeginPsbtResult,
 } from "./psbt/pegin";
 
-export { buildPeginInputPsbt, extractPeginInputSignature, finalizePeginInputPsbt } from "./psbt/peginInput";
+export {
+  buildPeginInputPsbt,
+  extractPeginInputSignature,
+  finalizePeginInputPsbt,
+} from "./psbt/peginInput";
 export type {
   BuildPeginInputPsbtParams,
   BuildPeginInputPsbtResult,
@@ -124,10 +131,13 @@ export { buildPayoutPsbt, extractPayoutSignature } from "./psbt/payout";
 export type { PayoutParams, PayoutPsbtResult } from "./psbt/payout";
 
 export {
-  assertPsbtUnsignedTxMatches,
   PsbtSubstitutionError,
+  assertPsbtUnsignedTxMatches,
 } from "./psbt/assertPsbtUnsignedTxMatches";
 export type { AssertPsbtUnsignedTxMatchesParams } from "./psbt/assertPsbtUnsignedTxMatches";
+
+export { assertScriptPathSchnorrSignature } from "./psbt/verifyScriptPathSchnorrSignature";
+export type { VerifyScriptPathSchnorrSignatureParams } from "./psbt/verifyScriptPathSchnorrSignature";
 
 export { buildDepositorPayoutPsbt } from "./psbt/depositorPayout";
 export type { DepositorPayoutParams } from "./psbt/depositorPayout";
@@ -147,12 +157,12 @@ export {
   deriveBip86ScriptPubKeyHex,
   deriveNativeSegwitAddress,
   deriveTaprootAddress,
+  ensureHexPrefix,
+  formatSatoshisToBtc,
   getSortedXOnlyPubkeys,
   hexToUint8Array,
   isAddressFromPublicKey,
   isValidHex,
-  ensureHexPrefix,
-  formatSatoshisToBtc,
   processPublicKeyToXOnly,
   stripHexPrefix,
   toXOnly,

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/verifyScriptPathSchnorrSignature.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/verifyScriptPathSchnorrSignature.test.ts
@@ -1,0 +1,319 @@
+/**
+ * Tests for assertScriptPathSchnorrSignature — BIP-340 verification of a
+ * wallet-returned Taproot script-path signature against an independently
+ * recomputed sighash (Critical Path #7).
+ *
+ * The positive cases build a PSBT exactly as the SDK does (witnessUtxo on every
+ * input, one tapLeafScript on the signed input), compute the real BIP-341
+ * script-path sighash, and sign it with a test key. The negative cases model the
+ * threat scenarios the guard exists for: a tweaked/wrong-key signature, a tampered
+ * signature, and a wallet that keeps the unsigned tx but substitutes prevout
+ * metadata.
+ */
+
+import { Buffer } from "buffer";
+
+import * as ecc from "@bitcoin-js/tiny-secp256k1-asmjs";
+import { sha256 } from "@noble/hashes/sha2.js";
+import { Psbt, Transaction } from "bitcoinjs-lib";
+import { describe, expect, it } from "vitest";
+
+import { TAPSCRIPT_LEAF_VERSION } from "../../utils/bitcoin";
+import { assertScriptPathSchnorrSignature } from "../verifyScriptPathSchnorrSignature";
+import { DUMMY_TXID_1, NULL_TXID } from "./constants";
+
+// Deterministic test private keys (valid secp256k1 scalars).
+const SIGNER_PRIV = Buffer.alloc(32, 1);
+const OTHER_PRIV = Buffer.alloc(32, 7);
+
+function xOnlyHex(priv: Buffer): string {
+  const xOnly = ecc.xOnlyPointFromScalar(priv);
+  return Buffer.from(xOnly).toString("hex");
+}
+
+/** BIP-340 tagged hash, matching the helper and bip322Verify.ts. */
+function taggedHash(tag: string, data: Uint8Array): Uint8Array {
+  const tagHash = sha256(new TextEncoder().encode(tag));
+  const preimage = new Uint8Array(tagHash.length * 2 + data.length);
+  preimage.set(tagHash, 0);
+  preimage.set(tagHash, tagHash.length);
+  preimage.set(data, tagHash.length * 2);
+  return sha256(preimage);
+}
+
+/** A realistic single-key tapscript leaf: `<32-byte pubkey> OP_CHECKSIG`. */
+function checksigLeafScript(signerXOnly: string): Buffer {
+  return Buffer.concat([
+    Buffer.from([0x20]),
+    Buffer.from(signerXOnly, "hex"),
+    Buffer.from([0xac]),
+  ]);
+}
+
+interface BuildPsbtArgs {
+  signerXOnly: string;
+  input0Value: number;
+  input1Value: number;
+}
+
+/**
+ * Build a two-input payout-shaped PSBT: input 0 is the depositor's script-path
+ * input (witnessUtxo + one tapLeafScript), input 1 carries witnessUtxo only.
+ */
+function buildSignablePsbt({
+  signerXOnly,
+  input0Value,
+  input1Value,
+}: BuildPsbtArgs): string {
+  const leafScript = checksigLeafScript(signerXOnly);
+  const psbt = new Psbt();
+  psbt.addInput({
+    hash: NULL_TXID,
+    index: 0,
+    witnessUtxo: {
+      script: Buffer.from(`5120${signerXOnly}`, "hex"),
+      value: input0Value,
+    },
+    tapLeafScript: [
+      {
+        leafVersion: TAPSCRIPT_LEAF_VERSION,
+        script: leafScript,
+        controlBlock: Buffer.concat([
+          Buffer.from([TAPSCRIPT_LEAF_VERSION]),
+          Buffer.alloc(32, 2),
+        ]),
+      },
+    ],
+    tapInternalKey: Buffer.alloc(32, 3),
+  });
+  psbt.addInput({
+    hash: DUMMY_TXID_1,
+    index: 1,
+    witnessUtxo: {
+      script: Buffer.from("0014" + "ab".repeat(20), "hex"),
+      value: input1Value,
+    },
+  });
+  psbt.addOutput({
+    script: Buffer.from(`5120${signerXOnly}`, "hex"),
+    value: input0Value + input1Value - 1000,
+  });
+  return psbt.toHex();
+}
+
+/**
+ * Reconstruct the unsigned tx from `psbtHex`, compute the BIP-341 script-path
+ * sighash for input 0, and sign it with `priv`. Returns the 64-byte sig as hex.
+ * `prevoutValues` lets a test sign over deliberately wrong prevout amounts.
+ */
+function signInput0(
+  psbtHex: string,
+  priv: Buffer,
+  prevoutValues?: number[],
+): string {
+  const psbt = Psbt.fromHex(psbtHex);
+  const leaf = psbt.data.inputs[0].tapLeafScript![0];
+  const leafHash = taggedHash(
+    "TapLeaf",
+    Buffer.concat([
+      Buffer.from([leaf.leafVersion]),
+      Buffer.from([leaf.script.length]),
+      leaf.script,
+    ]),
+  );
+
+  const prevOutScripts = psbt.data.inputs.map((i) => i.witnessUtxo!.script);
+  const values =
+    prevoutValues ?? psbt.data.inputs.map((i) => i.witnessUtxo!.value);
+
+  const tx = new Transaction();
+  tx.version = psbt.version;
+  tx.locktime = psbt.locktime;
+  for (const input of psbt.txInputs) {
+    tx.addInput(input.hash, input.index, input.sequence);
+  }
+  for (const output of psbt.txOutputs) {
+    tx.addOutput(output.script, output.value);
+  }
+
+  const sighash = tx.hashForWitnessV1(
+    0,
+    prevOutScripts,
+    values,
+    Transaction.SIGHASH_DEFAULT,
+    Buffer.from(leafHash),
+  );
+  return Buffer.from(ecc.signSchnorr(sighash, priv)).toString("hex");
+}
+
+describe("assertScriptPathSchnorrSignature", () => {
+  const signerXOnly = xOnlyHex(SIGNER_PRIV);
+
+  it("accepts a valid script-path signature over the requested PSBT", () => {
+    const psbtHex = buildSignablePsbt({
+      signerXOnly,
+      input0Value: 100_000,
+      input1Value: 50_000,
+    });
+    const signatureHex = signInput0(psbtHex, SIGNER_PRIV);
+
+    expect(() =>
+      assertScriptPathSchnorrSignature({
+        requestedPsbtHex: psbtHex,
+        signatureHex,
+        signerXOnlyPubkeyHex: signerXOnly,
+        inputIndex: 0,
+      }),
+    ).not.toThrow();
+  });
+
+  it("rejects a signature by a different key (wrong/tweaked signer)", () => {
+    const psbtHex = buildSignablePsbt({
+      signerXOnly,
+      input0Value: 100_000,
+      input1Value: 50_000,
+    });
+    // Sign the correct sighash but with a different private key — models a wallet
+    // that signed with the tweaked key instead of the untweaked script-path key.
+    const signatureHex = signInput0(psbtHex, OTHER_PRIV);
+
+    expect(() =>
+      assertScriptPathSchnorrSignature({
+        requestedPsbtHex: psbtHex,
+        signatureHex,
+        signerXOnlyPubkeyHex: signerXOnly,
+        inputIndex: 0,
+      }),
+    ).toThrow(/does not verify/);
+  });
+
+  it("rejects a tampered (flipped-byte) signature stub", () => {
+    const psbtHex = buildSignablePsbt({
+      signerXOnly,
+      input0Value: 100_000,
+      input1Value: 50_000,
+    });
+    const valid = signInput0(psbtHex, SIGNER_PRIV);
+    const tamperedBytes = Buffer.from(valid, "hex");
+    tamperedBytes[0] ^= 0xff;
+    const signatureHex = tamperedBytes.toString("hex");
+
+    expect(() =>
+      assertScriptPathSchnorrSignature({
+        requestedPsbtHex: psbtHex,
+        signatureHex,
+        signerXOnlyPubkeyHex: signerXOnly,
+        inputIndex: 0,
+      }),
+    ).toThrow(/does not verify/);
+  });
+
+  it("rejects a signature made over substituted prevout amounts", () => {
+    const psbtHex = buildSignablePsbt({
+      signerXOnly,
+      input0Value: 100_000,
+      input1Value: 50_000,
+    });
+    // Wallet signs over the same unsigned tx but different prevout values. Verifying
+    // against the requested PSBT's real prevouts must reject — this is why the guard
+    // uses the locally-built PSBT, not the wallet-returned metadata.
+    const signatureHex = signInput0(psbtHex, SIGNER_PRIV, [999_999, 50_000]);
+
+    expect(() =>
+      assertScriptPathSchnorrSignature({
+        requestedPsbtHex: psbtHex,
+        signatureHex,
+        signerXOnlyPubkeyHex: signerXOnly,
+        inputIndex: 0,
+      }),
+    ).toThrow(/does not verify/);
+  });
+
+  it("throws when an input lacks witnessUtxo (cannot recompute sighash)", () => {
+    const psbt = new Psbt();
+    psbt.addInput({
+      hash: NULL_TXID,
+      index: 0,
+      tapLeafScript: [
+        {
+          leafVersion: TAPSCRIPT_LEAF_VERSION,
+          script: checksigLeafScript(signerXOnly),
+          controlBlock: Buffer.alloc(33, 0xc0),
+        },
+      ],
+    });
+    psbt.addOutput({
+      script: Buffer.from(`5120${signerXOnly}`, "hex"),
+      value: 1_000,
+    });
+
+    expect(() =>
+      assertScriptPathSchnorrSignature({
+        requestedPsbtHex: psbt.toHex(),
+        signatureHex: "00".repeat(64),
+        signerXOnlyPubkeyHex: signerXOnly,
+        inputIndex: 0,
+      }),
+    ).toThrow(/no witnessUtxo/);
+  });
+
+  it("throws when the signed input has no tapLeafScript", () => {
+    const psbt = new Psbt();
+    psbt.addInput({
+      hash: NULL_TXID,
+      index: 0,
+      witnessUtxo: {
+        script: Buffer.from(`5120${signerXOnly}`, "hex"),
+        value: 100_000,
+      },
+    });
+    psbt.addOutput({
+      script: Buffer.from(`5120${signerXOnly}`, "hex"),
+      value: 99_000,
+    });
+
+    expect(() =>
+      assertScriptPathSchnorrSignature({
+        requestedPsbtHex: psbt.toHex(),
+        signatureHex: "00".repeat(64),
+        signerXOnlyPubkeyHex: signerXOnly,
+        inputIndex: 0,
+      }),
+    ).toThrow(/exactly one tapLeafScript/);
+  });
+
+  it("throws on a signature of the wrong length", () => {
+    const psbtHex = buildSignablePsbt({
+      signerXOnly,
+      input0Value: 100_000,
+      input1Value: 50_000,
+    });
+
+    expect(() =>
+      assertScriptPathSchnorrSignature({
+        requestedPsbtHex: psbtHex,
+        signatureHex: "00".repeat(63),
+        signerXOnlyPubkeyHex: signerXOnly,
+        inputIndex: 0,
+      }),
+    ).toThrow(/must be 128 hex chars/);
+  });
+
+  it("throws when the input index is out of range", () => {
+    const psbtHex = buildSignablePsbt({
+      signerXOnly,
+      input0Value: 100_000,
+      input1Value: 50_000,
+    });
+    const signatureHex = signInput0(psbtHex, SIGNER_PRIV);
+
+    expect(() =>
+      assertScriptPathSchnorrSignature({
+        requestedPsbtHex: psbtHex,
+        signatureHex,
+        signerXOnlyPubkeyHex: signerXOnly,
+        inputIndex: 5,
+      }),
+    ).toThrow(/out of range/);
+  });
+});

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyScriptPathSchnorrSignature.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyScriptPathSchnorrSignature.ts
@@ -1,0 +1,225 @@
+/**
+ * Independent BIP-340 verification of a wallet-returned Taproot script-path
+ * Schnorr signature against an independently-recomputed sighash.
+ *
+ * Critical Path #7 (CLAUDE.md): the SDK requests script-path signatures with
+ * `useTweakedSigner: false, autoFinalized: false`. Wallet support for the
+ * untweaked-key flag is inconsistent — older OKX / mobile bridges silently sign
+ * with the *tweaked* key, Keystone ignores the flag — and a compromised
+ * extension can stuff a 64-byte stub into `tapScriptSig`. A bad signature that
+ * the SDK forwards is only caught on broadcast; in the worst case it passes the
+ * VP off-chain but Bitcoin rejects it, leaving the depositor's BTC locked in the
+ * HTLC until `timelockRefund` matures. This guard rejects such signatures before
+ * they are trusted.
+ *
+ * Why verify against the *locally-built* PSBT, not the wallet-returned one:
+ * `assertPsbtUnsignedTxMatches` pins the unsigned transaction but deliberately
+ * skips per-input metadata (`witnessUtxo`, `tapLeafScript`). A malicious wallet
+ * could rewrite those consistently in the returned PSBT so a wrong-message
+ * signature self-validates. The trusted prevout scripts/values and leaf script
+ * therefore come from the PSBT we built ourselves (derived from on-chain / WASM
+ * sources); only the 64-byte signature comes from the wallet.
+ *
+ * Reuses the exact primitives `bip322Verify.ts` already depends on — no new
+ * dependency:
+ *   - `@bitcoin-js/tiny-secp256k1-asmjs` → `verifySchnorr`
+ *   - `bitcoinjs-lib` → `Transaction.hashForWitnessV1`
+ *   - `@noble/hashes/sha2` → BIP-340 tagged hash for the TapLeaf hash
+ *
+ * @module tbv/core/primitives/psbt/verifyScriptPathSchnorrSignature
+ */
+
+import * as ecc from "@bitcoin-js/tiny-secp256k1-asmjs";
+import { Psbt, Transaction } from "bitcoinjs-lib";
+
+import { sha256 } from "@noble/hashes/sha2.js";
+import { Buffer } from "buffer";
+
+import {
+  SCHNORR_SIG_HEX_LEN,
+  TAPSCRIPT_LEAF_VERSION,
+  X_ONLY_PUBKEY_HEX_LEN,
+  hexToUint8Array,
+  stripHexPrefix,
+} from "../utils/bitcoin";
+
+/** BIP-341 tag for the TapLeaf hash. */
+const TAPLEAF_TAG = "TapLeaf";
+
+/**
+ * BIP-340 tagged hash: `SHA256( SHA256(tag) || SHA256(tag) || data )`.
+ */
+function taggedHash(tag: string, data: Uint8Array): Uint8Array {
+  const tagHash = sha256(new TextEncoder().encode(tag));
+  const preimage = new Uint8Array(tagHash.length * 2 + data.length);
+  preimage.set(tagHash, 0);
+  preimage.set(tagHash, tagHash.length);
+  preimage.set(data, tagHash.length * 2);
+  return sha256(preimage);
+}
+
+/**
+ * Encode a length as a Bitcoin CompactSize (varint). Tapscript leaf scripts can
+ * exceed 252 bytes (WOTS scripts), so the multi-byte forms are required, not
+ * just the single-byte fast path.
+ */
+function encodeCompactSize(n: number): Buffer {
+  if (n < 0xfd) {
+    return Buffer.from([n]);
+  }
+  if (n <= 0xffff) {
+    const buf = Buffer.allocUnsafe(3);
+    buf.writeUInt8(0xfd, 0);
+    buf.writeUInt16LE(n, 1);
+    return buf;
+  }
+  if (n <= 0xffffffff) {
+    const buf = Buffer.allocUnsafe(5);
+    buf.writeUInt8(0xfe, 0);
+    buf.writeUInt32LE(n, 1);
+    return buf;
+  }
+  throw new Error(`Script too large to encode as CompactSize: ${n} bytes`);
+}
+
+/**
+ * Compute the BIP-341 TapLeaf hash for a tapscript leaf:
+ * `tagged_hash("TapLeaf", leaf_version || compact_size(script) || script)`.
+ */
+function computeTapLeafHash(
+  leafVersion: number,
+  script: Uint8Array,
+): Uint8Array {
+  const preimage = Buffer.concat([
+    Buffer.from([leafVersion]),
+    encodeCompactSize(script.length),
+    Buffer.from(script),
+  ]);
+  return taggedHash(TAPLEAF_TAG, preimage);
+}
+
+export interface VerifyScriptPathSchnorrSignatureParams {
+  /**
+   * Hex of the PSBT we built locally and sent to the wallet (the trusted
+   * source of prevout scripts/values and the leaf script). NOT the
+   * wallet-returned PSBT.
+   */
+  requestedPsbtHex: string;
+  /** The 64-byte Schnorr signature extracted from the wallet's response (128 hex chars). */
+  signatureHex: string;
+  /** X-only public key (64 hex chars) the wallet signed the script-path leaf with. */
+  signerXOnlyPubkeyHex: string;
+  /** Index of the input the signature is for. */
+  inputIndex: number;
+}
+
+/**
+ * Assert that `signatureHex` is a valid BIP-340 Schnorr signature by the
+ * `signerXOnlyPubkeyHex` key over the Taproot script-path sighash of
+ * `requestedPsbtHex` input `inputIndex` (SIGHASH_DEFAULT).
+ *
+ * @throws If the requested PSBT is malformed, lacks the prevout/leaf data needed
+ *         to recompute the sighash, or the signature does not verify.
+ */
+export function assertScriptPathSchnorrSignature(
+  params: VerifyScriptPathSchnorrSignatureParams,
+): void {
+  const { requestedPsbtHex, signatureHex, signerXOnlyPubkeyHex, inputIndex } =
+    params;
+
+  const signatureRaw = stripHexPrefix(signatureHex);
+  if (signatureRaw.length !== SCHNORR_SIG_HEX_LEN) {
+    throw new Error(
+      `Schnorr signature for input ${inputIndex} must be ${SCHNORR_SIG_HEX_LEN} hex chars ` +
+        `(64 bytes), got ${signatureRaw.length}.`,
+    );
+  }
+
+  const signerXOnly = stripHexPrefix(signerXOnlyPubkeyHex);
+  if (signerXOnly.length !== X_ONLY_PUBKEY_HEX_LEN) {
+    throw new Error(
+      `Signer x-only pubkey for input ${inputIndex} must be ${X_ONLY_PUBKEY_HEX_LEN} hex chars ` +
+        `(32 bytes), got ${signerXOnly.length}.`,
+    );
+  }
+
+  const psbt = Psbt.fromHex(requestedPsbtHex);
+
+  if (inputIndex < 0 || inputIndex >= psbt.data.inputs.length) {
+    throw new Error(
+      `Input index ${inputIndex} out of range (${psbt.data.inputs.length} inputs).`,
+    );
+  }
+
+  // Taproot's sighash commits to every input's prevout (script + value), so all
+  // inputs must carry a witnessUtxo. A missing one is a build error, not a
+  // value we can default — fail loudly.
+  const prevOutScripts: Buffer[] = [];
+  const values: number[] = [];
+  for (let i = 0; i < psbt.data.inputs.length; i++) {
+    const witnessUtxo = psbt.data.inputs[i].witnessUtxo;
+    if (!witnessUtxo) {
+      throw new Error(
+        `Cannot verify signature: input ${i} of the requested PSBT has no witnessUtxo ` +
+          `(required to recompute the Taproot sighash).`,
+      );
+    }
+    prevOutScripts.push(witnessUtxo.script);
+    values.push(witnessUtxo.value);
+  }
+
+  // The signed input must expose exactly one tapLeafScript — the leaf the
+  // depositor signs. Zero means we sent the wrong PSBT; more than one means an
+  // ambiguous spend path we never construct for a single-signature input.
+  const tapLeafScripts = psbt.data.inputs[inputIndex].tapLeafScript;
+  if (!tapLeafScripts || tapLeafScripts.length !== 1) {
+    throw new Error(
+      `Cannot verify signature: input ${inputIndex} of the requested PSBT must have exactly ` +
+        `one tapLeafScript, got ${tapLeafScripts?.length ?? 0}.`,
+    );
+  }
+  const leaf = tapLeafScripts[0];
+  if (leaf.leafVersion !== TAPSCRIPT_LEAF_VERSION) {
+    throw new Error(
+      `Cannot verify signature: input ${inputIndex} tapLeafScript has leaf version ` +
+        `0x${leaf.leafVersion.toString(16)}, expected 0x${TAPSCRIPT_LEAF_VERSION.toString(16)}.`,
+    );
+  }
+
+  const leafHash = computeTapLeafHash(leaf.leafVersion, leaf.script);
+
+  // Reconstruct the unsigned transaction from the requested PSBT using only
+  // public bitcoinjs-lib API (same pattern as bip322Verify.ts), then compute the
+  // BIP-341 script-path sighash with SIGHASH_DEFAULT.
+  const tx = new Transaction();
+  tx.version = psbt.version;
+  tx.locktime = psbt.locktime;
+  for (const input of psbt.txInputs) {
+    tx.addInput(input.hash, input.index, input.sequence);
+  }
+  for (const output of psbt.txOutputs) {
+    tx.addOutput(output.script, output.value);
+  }
+
+  const sighash = tx.hashForWitnessV1(
+    inputIndex,
+    prevOutScripts,
+    values,
+    Transaction.SIGHASH_DEFAULT,
+    Buffer.from(leafHash),
+  );
+
+  const isValid = ecc.verifySchnorr(
+    sighash,
+    hexToUint8Array(signerXOnly),
+    hexToUint8Array(signatureRaw),
+  );
+
+  if (!isValid) {
+    throw new Error(
+      `Schnorr signature for input ${inputIndex} (signer ${signerXOnly}) does not verify ` +
+        `against the expected Taproot script-path sighash. The wallet may have signed with ` +
+        `the tweaked key, signed a different transaction, or returned an invalid signature.`,
+    );
+  }
+}

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyScriptPathSchnorrSignature.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyScriptPathSchnorrSignature.ts
@@ -23,16 +23,14 @@
  * Reuses the exact primitives `bip322Verify.ts` already depends on — no new
  * dependency:
  *   - `@bitcoin-js/tiny-secp256k1-asmjs` → `verifySchnorr`
- *   - `bitcoinjs-lib` → `Transaction.hashForWitnessV1`
- *   - `@noble/hashes/sha2` → BIP-340 tagged hash for the TapLeaf hash
+ *   - `bitcoinjs-lib` → `Transaction.hashForWitnessV1`, `crypto.taggedHash` (TapLeaf hash)
  *
  * @module tbv/core/primitives/psbt/verifyScriptPathSchnorrSignature
  */
 
 import * as ecc from "@bitcoin-js/tiny-secp256k1-asmjs";
-import { Psbt, Transaction } from "bitcoinjs-lib";
+import { Psbt, Transaction, crypto as bcrypto } from "bitcoinjs-lib";
 
-import { sha256 } from "@noble/hashes/sha2.js";
 import { Buffer } from "buffer";
 
 import {
@@ -43,20 +41,12 @@ import {
   stripHexPrefix,
 } from "../utils/bitcoin";
 
-/** BIP-341 tag for the TapLeaf hash. */
-const TAPLEAF_TAG = "TapLeaf";
-
-/**
- * BIP-340 tagged hash: `SHA256( SHA256(tag) || SHA256(tag) || data )`.
- */
-function taggedHash(tag: string, data: Uint8Array): Uint8Array {
-  const tagHash = sha256(new TextEncoder().encode(tag));
-  const preimage = new Uint8Array(tagHash.length * 2 + data.length);
-  preimage.set(tagHash, 0);
-  preimage.set(tagHash, tagHash.length);
-  preimage.set(data, tagHash.length * 2);
-  return sha256(preimage);
-}
+// Bitcoin CompactSize (varint) prefix markers — values fixed by the protocol.
+// https://developer.bitcoin.org/reference/transactions.html#compactsize-unsigned-integers
+const COMPACT_SIZE_UINT16_PREFIX = 0xfd; // value in [0xfd, 0xffff] → 0xfd + uint16 LE
+const COMPACT_SIZE_UINT32_PREFIX = 0xfe; // value in [0x10000, 0xffffffff] → 0xfe + uint32 LE
+const COMPACT_SIZE_UINT16_MAX = 0xffff;
+const COMPACT_SIZE_UINT32_MAX = 0xffffffff;
 
 /**
  * Encode a length as a Bitcoin CompactSize (varint). Tapscript leaf scripts can
@@ -64,38 +54,36 @@ function taggedHash(tag: string, data: Uint8Array): Uint8Array {
  * just the single-byte fast path.
  */
 function encodeCompactSize(n: number): Buffer {
-  if (n < 0xfd) {
+  if (n < COMPACT_SIZE_UINT16_PREFIX) {
     return Buffer.from([n]);
   }
-  if (n <= 0xffff) {
-    const buf = Buffer.allocUnsafe(3);
-    buf.writeUInt8(0xfd, 0);
-    buf.writeUInt16LE(n, 1);
-    return buf;
+  if (n <= COMPACT_SIZE_UINT16_MAX) {
+    const value = Buffer.alloc(2); // uint16, little-endian
+    value.writeUInt16LE(n);
+    return Buffer.concat([Buffer.from([COMPACT_SIZE_UINT16_PREFIX]), value]);
   }
-  if (n <= 0xffffffff) {
-    const buf = Buffer.allocUnsafe(5);
-    buf.writeUInt8(0xfe, 0);
-    buf.writeUInt32LE(n, 1);
-    return buf;
+  if (n <= COMPACT_SIZE_UINT32_MAX) {
+    const value = Buffer.alloc(4); // uint32, little-endian
+    value.writeUInt32LE(n);
+    return Buffer.concat([Buffer.from([COMPACT_SIZE_UINT32_PREFIX]), value]);
   }
   throw new Error(`Script too large to encode as CompactSize: ${n} bytes`);
 }
+
+/** BIP-341 tag for the TapLeaf hash. */
+const TAPLEAF_TAG = "TapLeaf";
 
 /**
  * Compute the BIP-341 TapLeaf hash for a tapscript leaf:
  * `tagged_hash("TapLeaf", leaf_version || compact_size(script) || script)`.
  */
-function computeTapLeafHash(
-  leafVersion: number,
-  script: Uint8Array,
-): Uint8Array {
+function computeTapLeafHash(leafVersion: number, script: Uint8Array): Buffer {
   const preimage = Buffer.concat([
     Buffer.from([leafVersion]),
     encodeCompactSize(script.length),
     Buffer.from(script),
   ]);
-  return taggedHash(TAPLEAF_TAG, preimage);
+  return bcrypto.taggedHash(TAPLEAF_TAG, preimage);
 }
 
 export interface VerifyScriptPathSchnorrSignatureParams {
@@ -206,7 +194,7 @@ export function assertScriptPathSchnorrSignature(
     prevOutScripts,
     values,
     Transaction.SIGHASH_DEFAULT,
-    Buffer.from(leafHash),
+    leafHash,
   );
 
   const isValid = ecc.verifySchnorr(

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/signDepositorGraph.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/signDepositorGraph.test.ts
@@ -73,10 +73,11 @@ vi.mock("bitcoinjs-lib", () => ({
 
 vi.mock("../../../primitives/utils/bitcoin", () => ({
   stripHexPrefix: (s: string) => (s.startsWith("0x") ? s.slice(2) : s),
-  uint8ArrayToHex: (bytes: Uint8Array) =>
-    Buffer.from(bytes).toString("hex"),
+  uint8ArrayToHex: (bytes: Uint8Array) => Buffer.from(bytes).toString("hex"),
   validateWalletPubkey: (walletRaw: string, expectedDepositor: string) => {
-    const stripped = walletRaw.startsWith("0x") ? walletRaw.slice(2) : walletRaw;
+    const stripped = walletRaw.startsWith("0x")
+      ? walletRaw.slice(2)
+      : walletRaw;
     const walletXOnly = stripped.length === 66 ? stripped.slice(2) : stripped;
     if (walletXOnly.toLowerCase() !== expectedDepositor.toLowerCase()) {
       throw new Error(
@@ -108,6 +109,13 @@ vi.mock("../../../utils/signing", () => ({
 // dedicated tests against real PSBTs in primitives/psbt/__tests__/.
 vi.mock("../../../primitives/psbt/assertPsbtUnsignedTxMatches", () => ({
   assertPsbtUnsignedTxMatches: vi.fn(),
+}));
+
+// Same rationale for the Schnorr-signature verification guard: it needs real
+// PSBTs + real signatures, which it gets in its own dedicated unit tests
+// (primitives/psbt/__tests__/verifyScriptPathSchnorrSignature.test.ts).
+vi.mock("../../../primitives/psbt/verifyScriptPathSchnorrSignature", () => ({
+  assertScriptPathSchnorrSignature: vi.fn(),
 }));
 
 // ---------------------------------------------------------------------------
@@ -280,9 +288,7 @@ function createSigningContext(
 describe("signDepositorGraph", () => {
   it("rebuilds the payout PSBT locally from authoritative connector params", async () => {
     registerStandardMocks([CHALLENGER_A, CHALLENGER_B]);
-    const { buildPayoutPsbt } = await import(
-      "../../../primitives/psbt/payout"
-    );
+    const { buildPayoutPsbt } = await import("../../../primitives/psbt/payout");
     const builder = vi.mocked(buildPayoutPsbt);
     builder.mockClear();
 
@@ -648,9 +654,7 @@ describe("signDepositorGraph", () => {
 
   it("propagates payout build errors and never reaches the wallet", async () => {
     registerStandardMocks([CHALLENGER_A, CHALLENGER_B]);
-    const { buildPayoutPsbt } = await import(
-      "../../../primitives/psbt/payout"
-    );
+    const { buildPayoutPsbt } = await import("../../../primitives/psbt/payout");
     vi.mocked(buildPayoutPsbt).mockImplementationOnce(async () => {
       throw new Error(
         "Payout transaction output 0 does not pay the expected scriptPubKey for role depositor-as-claimer",
@@ -734,7 +738,9 @@ describe("signDepositorGraph", () => {
         }),
       }),
     ).rejects.toThrow(
-      new RegExp(`challenger set does not match expected.*missing.*${UC_PUBKEY}`),
+      new RegExp(
+        `challenger set does not match expected.*missing.*${UC_PUBKEY}`,
+      ),
     );
 
     expect(wallet.signPsbts).not.toHaveBeenCalled();

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts
@@ -21,7 +21,10 @@
 import { type Network } from "@babylonlabs-io/babylon-tbv-rust-wasm";
 import { Transaction } from "bitcoinjs-lib";
 
-import type { BitcoinWallet, SignPsbtOptions } from "../../../../shared/wallets/interfaces";
+import type {
+  BitcoinWallet,
+  SignPsbtOptions,
+} from "../../../../shared/wallets/interfaces";
 import type {
   DepositorAsClaimerPresignatures,
   DepositorGraphTransactions,
@@ -40,6 +43,7 @@ import {
   buildPayoutPsbt,
   extractPayoutSignature,
 } from "../../primitives/psbt/payout";
+import { assertScriptPathSchnorrSignature } from "../../primitives/psbt/verifyScriptPathSchnorrSignature";
 import {
   stripHexPrefix,
   uint8ArrayToHex,
@@ -432,20 +436,38 @@ function extractDepositorGraphSignatures(
   // Set up by `collectDepositorGraphPsbts` (payout pushed first, then each
   // nopayout). A future refactor that reorders the array would silently
   // extract the wrong signature for the wrong slot — Critical Path #3.
+  // Payout and every NoPayout PSBT are signed on input 0 (depositor script-path).
+  const DEPOSITOR_SIGNED_INPUT_INDEX = 0;
+
   assertPsbtUnsignedTxMatches(psbtPairs[0]);
   const payoutSignature = extractPayoutSignature(
     psbtPairs[0].returnedPsbtHex,
     depositorPubkey,
   );
+  // Critical Path #7: verify the wallet's signature against a sighash recomputed
+  // from the PSBT we built (psbtPairs[0].requestedPsbtHex), not the returned one.
+  assertScriptPathSchnorrSignature({
+    requestedPsbtHex: psbtPairs[0].requestedPsbtHex,
+    signatureHex: payoutSignature,
+    signerXOnlyPubkeyHex: depositorPubkey,
+    inputIndex: DEPOSITOR_SIGNED_INPUT_INDEX,
+  });
 
   const perChallenger: Record<string, DepositorPreSigsPerChallenger> = {};
   for (const entry of challengerEntries) {
     assertPsbtUnsignedTxMatches(psbtPairs[entry.noPayoutIdx]);
+    const nopayoutSignature = extractPayoutSignature(
+      psbtPairs[entry.noPayoutIdx].returnedPsbtHex,
+      depositorPubkey,
+    );
+    assertScriptPathSchnorrSignature({
+      requestedPsbtHex: psbtPairs[entry.noPayoutIdx].requestedPsbtHex,
+      signatureHex: nopayoutSignature,
+      signerXOnlyPubkeyHex: depositorPubkey,
+      inputIndex: DEPOSITOR_SIGNED_INPUT_INDEX,
+    });
     perChallenger[entry.challengerPubkey] = {
-      nopayout_signature: extractPayoutSignature(
-        psbtPairs[entry.noPayoutIdx].returnedPsbtHex,
-        depositorPubkey,
-      ),
+      nopayout_signature: nopayoutSignature,
     };
   }
 

--- a/packages/babylon-ts-sdk/src/tbv/core/services/refund/__tests__/buildAndBroadcastRefund.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/refund/__tests__/buildAndBroadcastRefund.test.ts
@@ -23,9 +23,7 @@ import {
 // we can assert the orchestration contract (call order, arg passing, fee
 // math, error mapping) without needing WASM or a funded Pre-PegIn vector.
 vi.mock("../../../primitives/psbt/refund", () => ({
-  buildRefundPsbt: vi
-    .fn()
-    .mockResolvedValue({ psbtHex: "70736274ff01mock" }),
+  buildRefundPsbt: vi.fn().mockResolvedValue({ psbtHex: "70736274ff01mock" }),
 }));
 
 // Mocked: bitcoinjs-lib is mocked below, real helper would fail to parse.
@@ -42,6 +40,18 @@ vi.mock(
     };
   },
 );
+
+// The refund path extracts the depositor's signature and verifies it against a
+// recomputed sighash before broadcasting. Both need real PSBTs, which this suite
+// deliberately stubs (Psbt.fromHex is mocked below). Signature verification has
+// its own dedicated real-PSBT tests; here we stub the extractor and the guard so
+// the broadcast-orchestration assertions can run against the mock PSBT.
+vi.mock("../../../primitives/psbt/payout", () => ({
+  extractPayoutSignature: vi.fn(() => "ab".repeat(64)),
+}));
+vi.mock("../../../primitives/psbt/verifyScriptPathSchnorrSignature", () => ({
+  assertScriptPathSchnorrSignature: vi.fn(),
+}));
 
 // Finalize + extract uses bitcoinjs-lib. We stub Psbt.fromHex to return an
 // object with controllable `finalizeAllInputs` / `extractTransaction`.
@@ -64,8 +74,8 @@ vi.mock("bitcoinjs-lib", async (importOriginal) => {
   };
 });
 
-import { buildRefundPsbt } from "../../../primitives/psbt/refund";
 import { Psbt } from "bitcoinjs-lib";
+import { buildRefundPsbt } from "../../../primitives/psbt/refund";
 
 const mockedBuildRefundPsbt = vi.mocked(buildRefundPsbt);
 const mockedFromHex = vi.mocked(Psbt.fromHex);
@@ -346,9 +356,7 @@ describe("buildAndBroadcastRefund", () => {
     expect(call[0].prePeginParams.universalChallengerPubkeys).toEqual([
       UC_PUBKEY,
     ]);
-    expect(call[0].prePeginParams.hashlocks).toEqual([
-      HASHLOCK.slice(2),
-    ]);
+    expect(call[0].prePeginParams.hashlocks).toEqual([HASHLOCK.slice(2)]);
     // The top-level `hashlock` param on buildRefundPsbt is documented as
     // "no 0x prefix" and feeds the WASM HTLC connector derivation. A
     // prefixed value here would derive the wrong refund leaf and yield an
@@ -512,7 +520,9 @@ describe("buildAndBroadcastRefund", () => {
           signPsbt,
           broadcastTx,
         }),
-      ).rejects.toThrow(/Auth-anchor OP_RETURN at vout 2 does not match batch size/);
+      ).rejects.toThrow(
+        /Auth-anchor OP_RETURN at vout 2 does not match batch size/,
+      );
 
       expect(mockedBuildRefundPsbt).not.toHaveBeenCalled();
       expect(broadcastTx).not.toHaveBeenCalled();
@@ -548,7 +558,9 @@ describe("buildAndBroadcastRefund", () => {
           signPsbt,
           broadcastTx,
         }),
-      ).rejects.toThrow(/Funded Pre-PegIn tx has 1 outputs but batch requires at least 3/);
+      ).rejects.toThrow(
+        /Funded Pre-PegIn tx has 1 outputs but batch requires at least 3/,
+      );
       expect(mockedBuildRefundPsbt).not.toHaveBeenCalled();
     });
   });
@@ -569,9 +581,7 @@ describe("buildAndBroadcastRefund", () => {
     });
 
     it("rejects vault with non-bytes32 hashlock", async () => {
-      readVault.mockResolvedValue(
-        buildVault({ hashlock: "0xaa" as Hex }),
-      );
+      readVault.mockResolvedValue(buildVault({ hashlock: "0xaa" as Hex }));
 
       await expect(
         buildAndBroadcastRefund({
@@ -681,7 +691,9 @@ describe("buildAndBroadcastRefund", () => {
           signPsbt,
           broadcastTx,
         }),
-      ).rejects.toThrow(/batch\[0\]\.hashlock .* does not match target hashlock/);
+      ).rejects.toThrow(
+        /batch\[0\]\.hashlock .* does not match target hashlock/,
+      );
     });
 
     it("rejects when the target amount does not match its batch entry", async () => {
@@ -706,9 +718,7 @@ describe("buildAndBroadcastRefund", () => {
     });
 
     it("rejects an empty batch", async () => {
-      readVault.mockResolvedValue(
-        buildVault({ batch: [] as never }),
-      );
+      readVault.mockResolvedValue(buildVault({ batch: [] as never }));
 
       await expect(
         buildAndBroadcastRefund({
@@ -881,9 +891,7 @@ describe("buildAndBroadcastRefund", () => {
     });
 
     it("rejects zero or negative timelockRefund", async () => {
-      readPrePeginContext.mockResolvedValue(
-        buildCtx({ timelockRefund: 0 }),
-      );
+      readPrePeginContext.mockResolvedValue(buildCtx({ timelockRefund: 0 }));
 
       await expect(
         buildAndBroadcastRefund({
@@ -957,7 +965,9 @@ describe("buildAndBroadcastRefund", () => {
     it("allows refund at exactly the rate cap when the vault is large enough to clear the fraction cap", async () => {
       // refundFee at rate cap = REFUND_MAX_FEE_RATE_SATS_VB * REFUND_VSIZE.
       // Pick vault.amount such that fraction cap >= refundFee.
-      const refundFeeAtRateCap = BigInt(REFUND_MAX_FEE_RATE_SATS_VB * REFUND_VSIZE);
+      const refundFeeAtRateCap = BigInt(
+        REFUND_MAX_FEE_RATE_SATS_VB * REFUND_VSIZE,
+      );
       const minVaultAmount =
         (refundFeeAtRateCap * REFUND_MAX_FEE_FRACTION_DENOMINATOR) /
         REFUND_MAX_FEE_FRACTION_NUMERATOR;

--- a/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts
@@ -21,7 +21,9 @@ import type { Address, Hex } from "viem";
 import type { SignPsbtOptions } from "../../../../shared/wallets/interfaces/BitcoinWallet";
 import { findAuthAnchorOpReturn } from "../../managers/pegin";
 import { assertPsbtUnsignedTxMatches } from "../../primitives/psbt/assertPsbtUnsignedTxMatches";
+import { extractPayoutSignature } from "../../primitives/psbt/payout";
 import { buildRefundPsbt } from "../../primitives/psbt/refund";
+import { assertScriptPathSchnorrSignature } from "../../primitives/psbt/verifyScriptPathSchnorrSignature";
 import {
   processPublicKeyToXOnly,
   stripHexPrefix,
@@ -190,9 +192,8 @@ export interface BtcBroadcastResult {
   txId: string;
 }
 
-export type BtcBroadcaster<
-  R extends BtcBroadcastResult = BtcBroadcastResult,
-> = (signedTxHex: string) => Promise<R>;
+export type BtcBroadcaster<R extends BtcBroadcastResult = BtcBroadcastResult> =
+  (signedTxHex: string) => Promise<R>;
 
 export type RefundPsbtSigner = (
   psbtHex: string,
@@ -294,7 +295,10 @@ function validateVaultRefundData(v: VaultRefundData): void {
     v.universalChallengersVersion,
     "universalChallengersVersion",
   );
-  if (typeof v.unsignedPrePeginTxHex !== "string" || v.unsignedPrePeginTxHex.length === 0) {
+  if (
+    typeof v.unsignedPrePeginTxHex !== "string" ||
+    v.unsignedPrePeginTxHex.length === 0
+  ) {
     throw new Error("unsignedPrePeginTxHex must be a non-empty hex string");
   }
   if (!BTC_HEX_BYTES_RE.test(v.unsignedPrePeginTxHex)) {
@@ -337,10 +341,7 @@ function validateRefundPrePeginContext(c: RefundPrePeginContext): void {
       `minPeginFeeRate must be a positive bigint, got ${c.minPeginFeeRate}`,
     );
   }
-  if (
-    !Number.isInteger(c.numLocalChallengers) ||
-    c.numLocalChallengers < 0
-  ) {
+  if (!Number.isInteger(c.numLocalChallengers) || c.numLocalChallengers < 0) {
     throw new Error("numLocalChallengers must be a non-negative integer");
   }
   if (
@@ -592,6 +593,22 @@ export async function buildAndBroadcastRefund<
   assertPsbtUnsignedTxMatches({
     requestedPsbtHex: psbtHex,
     returnedPsbtHex: signedPsbtHex,
+  });
+
+  // Critical Path #7: verify the depositor's script-path signature against a
+  // sighash recomputed from the PSBT we built before finalizing and broadcasting.
+  // The refund spends a single input (the HTLC output) on input 0.
+  const REFUND_SIGNED_INPUT_INDEX = 0;
+  const refundSignature = extractPayoutSignature(
+    signedPsbtHex,
+    xOnlyDepositorPubkey,
+    REFUND_SIGNED_INPUT_INDEX,
+  );
+  assertScriptPathSchnorrSignature({
+    requestedPsbtHex: psbtHex,
+    signatureHex: refundSignature,
+    signerXOnlyPubkeyHex: xOnlyDepositorPubkey,
+    inputIndex: REFUND_SIGNED_INPUT_INDEX,
   });
 
   const signedTxHex = finalizeAndExtract(signedPsbtHex);


### PR DESCRIPTION
# Verify wallet-returned Schnorr signatures before trusting them

Closes [#842](https://github.com/sherlock-audit/2026-05-babylon-fe-indexer-monitor-utils-proxy-may-11th-2026/issues/842)

## What this changes

The SDK asks the user's Bitcoin wallet to sign Taproot **script-path** transactions (pegin, payout, per-challenger NoPayout, refund). Until now it took the 64-byte signature the wallet handed back, checked only its length, and forwarded or broadcast it. This PR adds a step that actually verifies each signature is valid before we rely on it. If the signature doesn't check out, we throw with a clear error instead of moving on.

## Why

For these spends we sign with non-standard wallet options (`useTweakedSigner: false`, `autoFinalized: false`). Wallet support for that flag is inconsistent — some older OKX / mobile builds quietly sign with the wrong (tweaked) key, Keystone ignores the flag, and a compromised browser extension can stuff in a fake 64-byte signature. In all of these cases the SDK currently believes the wallet succeeded. The bad signature is only caught much later, on Bitcoin broadcast. Worst case for a pegin: it passes the vault provider off-chain but Bitcoin rejects it, the Pre-PegIn never confirms, and the depositor's BTC is stuck in the HTLC until the refund timelock matures. This is also one of the "critical paths" our own `CLAUDE.md` calls out (path #7): every signature produced with these flags must be validated against the expected sighash, not trusted because the wallet returned success.

## How it works

New helper [`assertScriptPathSchnorrSignature`](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyScriptPathSchnorrSignature.ts) re-computes the BIP-341 sighash for the signed input and runs a BIP-340 (`verifySchnorr`) check. It is wired in right after we extract the signature at every depositor signing site: payout + per-challenger NoPayout in `signDepositorGraph.ts`, the pegin input in `PeginManager.ts`, the refund in `buildAndBroadcastRefund.ts`, and the VP/VK payout paths in `PayoutManager.ts`.

The important detail: it verifies against the PSBT **we built locally**, not the one the wallet sent back. We already pin the unsigned transaction (via `assertPsbtUnsignedTxMatches`), but that check deliberately ignores per-input data like prevout amounts and the leaf script. If we trusted the returned PSBT's copy of that data, a malicious wallet could rewrite it to be self-consistent and a wrong-message signature would "pass". Our locally-built PSBT comes from on-chain / WASM-derived data, so it's the trustworthy source for the prevouts and leaf script; only the 64-byte signature itself comes from the wallet.

## Approaches considered

**A. Verify against the wallet-returned PSBT** (e.g. bitcoinjs `validateSignaturesOfInput`). Less code, but it only protects against honest wallet bugs, not a malicious one that rewrites the input metadata consistently — so it doesn't fully cover the threat. Rejected.

**B. Verify against our locally-built PSBT — chosen.** Slightly more code (re-derive the leaf hash and sighash ourselves), but it binds the signature to the transaction *we* intend to sign, which is exactly the defense the audit and `CLAUDE.md` ask for. It reuses the same crypto libraries the existing server-identity verifier (`bip322Verify.ts`) already depends on, so it adds **no new dependency** (the issue suggested pulling in `@noble/curves`, which turned out to be unnecessary).

**C. Bury the check inside the extractor.** The extractor only receives the returned PSBT, so it can't reach the trusted local PSBT. Keeping extraction and verification as separate steps at the call site (where both PSBTs are in scope) is cleaner. Rejected.

## Scope

All depositor script-path signing sites are covered: pegin input, payout, per-challenger NoPayout, refund, and the VP/VK payout paths. `buildDepositorPayoutPsbt` / `buildChallengeAssertPsbt` are not wired to any wallet-signing flow, so they need no guard.

## Tests

New dedicated suite [`verifyScriptPathSchnorrSignature.test.ts`](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/verifyScriptPathSchnorrSignature.test.ts) (8 cases): a valid signature passes; a wrong/tweaked-key signature is rejected; a tampered stub is rejected; a signature made over substituted prevout amounts is rejected (proves the check is bound to our PSBT, not the wallet's); and the input-shape guards (missing witnessUtxo, missing/duplicate leaf script, bad length, out-of-range index) throw.

The orchestration tests (`PeginManager`, `PayoutManager`, `signDepositorGraph`, refund) feed synthetic/mock PSBTs, so they stub the new guard the same way they already stub `assertPsbtUnsignedTxMatches` — the guard's real behavior lives in the dedicated suite above.
