### PR TITLE
feat(vault): wire reserve available liquidity and utilization

### DIFF
--- a/services/vault/src/applications/aave/clients/__tests__/aaveHub.test.ts
+++ b/services/vault/src/applications/aave/clients/__tests__/aaveHub.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const multicall = vi.fn();
+vi.mock("../../../../clients/eth-contract/client", () => ({
+  ethClient: { getPublicClient: () => ({ multicall }) },
+}));
+
+// aaveHub.ts also re-exports an SDK rate read; stub the SDK so the module loads
+// without pulling the real package into the test.
+vi.mock("@babylonlabs-io/ts-sdk/tbv/integrations/aave", () => ({
+  getAssetDrawnRatesSafe: vi.fn(),
+}));
+
+import { getAssetLiquiditiesSafe } from "../aaveHub";
+
+const HUB = "0x0000000000000000000000000000000000000003" as const;
+
+describe("getAssetLiquiditiesSafe", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("pairs liquidity + owed per asset into one result", async () => {
+    multicall.mockResolvedValueOnce([
+      { status: "success", result: 100n },
+      { status: "success", result: 30n },
+      { status: "success", result: 500n },
+      { status: "success", result: 0n },
+    ]);
+
+    const out = await getAssetLiquiditiesSafe([
+      { hub: HUB, assetId: 1 },
+      { hub: HUB, assetId: 2 },
+    ]);
+
+    expect(out).toEqual([
+      {
+        hub: HUB,
+        assetId: 1,
+        availableLiquidityRaw: 100n,
+        totalOwedRaw: 30n,
+        error: null,
+      },
+      {
+        hub: HUB,
+        assetId: 2,
+        availableLiquidityRaw: 500n,
+        totalOwedRaw: 0n,
+        error: null,
+      },
+    ]);
+  });
+
+  it("nulls an asset whole when either leg reverts (no half-read)", async () => {
+    multicall.mockResolvedValueOnce([
+      { status: "success", result: 100n },
+      { status: "failure", error: new Error("owed reverted") },
+    ]);
+
+    const [result] = await getAssetLiquiditiesSafe([{ hub: HUB, assetId: 1 }]);
+
+    expect(result.availableLiquidityRaw).toBeNull();
+    expect(result.totalOwedRaw).toBeNull();
+    expect(result.error).toBeInstanceOf(Error);
+  });
+
+  it("marks every asset failed on a network-level multicall throw", async () => {
+    multicall.mockRejectedValueOnce(new Error("RPC down"));
+
+    const out = await getAssetLiquiditiesSafe([
+      { hub: HUB, assetId: 1 },
+      { hub: HUB, assetId: 2 },
+    ]);
+
+    expect(out).toHaveLength(2);
+    for (const result of out) {
+      expect(result.availableLiquidityRaw).toBeNull();
+      expect(result.totalOwedRaw).toBeNull();
+      expect(result.error).toBeInstanceOf(Error);
+    }
+  });
+
+  it("skips the multicall entirely for an empty request list", async () => {
+    expect(await getAssetLiquiditiesSafe([])).toEqual([]);
+    expect(multicall).not.toHaveBeenCalled();
+  });
+});

--- a/services/vault/src/applications/aave/clients/aaveHub.ts
+++ b/services/vault/src/applications/aave/clients/aaveHub.ts
@@ -1,10 +1,11 @@
-/** Vault-side wrapper that injects `ethClient` into the SDK Hub reads. */
+/** Vault-side access to the Aave v4 Hub reads. */
 
 import {
   getAssetDrawnRatesSafe as sdkGetAssetDrawnRatesSafe,
   type AssetDrawnRateRequest,
   type AssetDrawnRateResult,
 } from "@babylonlabs-io/ts-sdk/tbv/integrations/aave";
+import type { Abi, Address } from "viem";
 
 import { ethClient } from "../../../clients/eth-contract/client";
 
@@ -15,3 +16,118 @@ export async function getAssetDrawnRatesSafe(
 }
 
 export type { AssetDrawnRateRequest, AssetDrawnRateResult };
+
+/**
+ * Minimal Hub ABI for the two reserve-total reads. The SDK's `AaveHub.abi.json`
+ * is the rate-read subset (`getAssetDrawnRate` only), so — matching the
+ * cap-policy reader's self-contained-fragment pattern — the liquidity reads are
+ * kept app-side rather than widening the shared SDK ABI for one display surface.
+ */
+const HUB_LIQUIDITY_ABI = [
+  {
+    type: "function",
+    name: "getAssetLiquidity",
+    stateMutability: "view",
+    inputs: [{ name: "assetId", type: "uint256" }],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "getAssetTotalOwed",
+    stateMutability: "view",
+    inputs: [{ name: "assetId", type: "uint256" }],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+] as const;
+
+/** Identifies one Hub asset to read reserve totals for. */
+export interface AssetLiquidityRequest {
+  /** Hub contract address (from the reserve's `hub` field). */
+  hub: Address;
+  /** Asset identifier on that Hub (from the reserve's `assetId` field). */
+  assetId: number;
+}
+
+export interface AssetLiquidityResult {
+  hub: Address;
+  assetId: number;
+  /** Borrowable liquidity remaining (token units), or null on revert. */
+  availableLiquidityRaw: bigint | null;
+  /** Total borrowed: drawn + premium (token units), or null on revert. */
+  totalOwedRaw: bigint | null;
+  error: Error | null;
+}
+
+/**
+ * Per-asset isolated read of available liquidity and total owed for display
+ * lists (one bad asset ≠ whole list blank). One multicall round-trip pairs
+ * `getAssetLiquidity` + `getAssetTotalOwed` per asset with `allowFailure: true`.
+ * Both legs are required to derive available liquidity and utilization, so if
+ * either reverts the asset is nulled whole (no half-read figure). A
+ * network-level multicall failure marks every asset failed rather than throwing
+ * — callers (display hooks) rely on always getting a per-asset result array.
+ */
+export async function getAssetLiquiditiesSafe(
+  requests: AssetLiquidityRequest[],
+): Promise<AssetLiquidityResult[]> {
+  if (requests.length === 0) return [];
+
+  const publicClient = ethClient.getPublicClient();
+
+  let results;
+  try {
+    results = await publicClient.multicall({
+      contracts: requests.flatMap(({ hub, assetId }) => [
+        {
+          address: hub,
+          abi: HUB_LIQUIDITY_ABI as Abi,
+          functionName: "getAssetLiquidity" as const,
+          args: [BigInt(assetId)] as const,
+        },
+        {
+          address: hub,
+          abi: HUB_LIQUIDITY_ABI as Abi,
+          functionName: "getAssetTotalOwed" as const,
+          args: [BigInt(assetId)] as const,
+        },
+      ]),
+      allowFailure: true,
+    });
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    return requests.map(({ hub, assetId }) => ({
+      hub,
+      assetId,
+      availableLiquidityRaw: null,
+      totalOwedRaw: null,
+      error,
+    }));
+  }
+
+  return requests.map(({ hub, assetId }, i): AssetLiquidityResult => {
+    const liquidity = results[i * 2];
+    const owed = results[i * 2 + 1];
+    if (liquidity.status !== "success" || owed.status !== "success") {
+      const failed =
+        liquidity.status !== "success" ? liquidity.error : owed.error;
+      const error =
+        failed instanceof Error
+          ? failed
+          : new Error(String(failed ?? "Hub reserve-total read reverted"));
+      return {
+        hub,
+        assetId,
+        availableLiquidityRaw: null,
+        totalOwedRaw: null,
+        error,
+      };
+    }
+    return {
+      hub,
+      assetId,
+      availableLiquidityRaw: liquidity.result as bigint,
+      totalOwedRaw: owed.result as bigint,
+      error: null,
+    };
+  });
+}

--- a/services/vault/src/applications/aave/components/AssetSelectionModal/AssetSelectionModal.tsx
+++ b/services/vault/src/applications/aave/components/AssetSelectionModal/AssetSelectionModal.tsx
@@ -16,11 +16,19 @@ import {
   getCurrencyIconWithFallback,
   getTokenByAddress,
 } from "@/services/token/tokenService";
-import { formatAprPercent, formatPriceUsd } from "@/utils/formatting";
+import {
+  formatAprPercent,
+  formatCompactTokenAmount,
+  formatPriceUsd,
+} from "@/utils/formatting";
 
 import { LOAN_TAB, type LoanTab } from "../../constants";
 import { useAaveConfig } from "../../context";
-import { useAaveBorrowAprs, useAaveReservesPrices } from "../../hooks";
+import {
+  useAaveBorrowAprs,
+  useAaveReserveLiquidity,
+  useAaveReservesPrices,
+} from "../../hooks";
 import type { Asset } from "../../types";
 
 interface AssetSelectionModalProps {
@@ -44,6 +52,8 @@ interface AssetRow {
   icon?: string;
   /** Formatted price string, or the empty placeholder when unavailable. */
   priceLabel: string;
+  /** Formatted available liquidity (borrow mode only); undefined hides the cell. */
+  availableLabel?: string;
   /** Formatted borrow APR (borrow mode only); undefined hides the cell. */
   aprLabel?: string;
 }
@@ -73,6 +83,10 @@ export function AssetSelectionModal({
   );
   // Borrow APR is borrow-only; skip the read entirely in repay mode.
   const { aprPercentByReserveId } = useAaveBorrowAprs({
+    reserves: isRepay ? [] : borrowableReserves,
+  });
+  // Available liquidity is borrow-only too (the column is hidden in repay).
+  const { liquidityByReserveId } = useAaveReserveLiquidity({
     reserves: isRepay ? [] : borrowableReserves,
   });
 
@@ -111,6 +125,7 @@ export function AssetSelectionModal({
       const reserveKey = reserve.reserveId.toString();
       const priceUsd = pricesByReserveId[reserveKey] ?? undefined;
       const aprPercent = aprPercentByReserveId[reserveKey];
+      const liquidity = liquidityByReserveId[reserveKey];
       return {
         key: reserveKey,
         symbol: reserve.token.symbol,
@@ -118,6 +133,10 @@ export function AssetSelectionModal({
         icon: getTokenByAddress(reserve.token.address)?.icon,
         priceLabel:
           priceUsd != null ? formatPriceUsd(priceUsd) : COPY.common.emptyValue,
+        availableLabel:
+          liquidity == null
+            ? COPY.common.emptyValue
+            : `${formatCompactTokenAmount(liquidity.availableLiquidity)} ${reserve.token.symbol}`,
         aprLabel:
           aprPercent == null
             ? COPY.common.emptyValue
@@ -129,6 +148,7 @@ export function AssetSelectionModal({
     borrowableReserves,
     pricesByReserveId,
     aprPercentByReserveId,
+    liquidityByReserveId,
     priceBySymbol,
   ]);
 
@@ -205,7 +225,7 @@ export function AssetSelectionModal({
                 </span>
                 {!isRepay && (
                   <>
-                    <span className="flex-1">{COPY.common.emptyValue}</span>
+                    <span className="flex-1">{row.availableLabel}</span>
                     <span className="flex-1">{row.aprLabel}</span>
                   </>
                 )}

--- a/services/vault/src/applications/aave/components/AssetSelectionModal/__tests__/AssetSelectionModal.test.tsx
+++ b/services/vault/src/applications/aave/components/AssetSelectionModal/__tests__/AssetSelectionModal.test.tsx
@@ -28,12 +28,17 @@ vi.mock("@babylonlabs-io/core-ui", () => ({
 const borrowableReserves = [
   {
     reserveId: 1n,
-    token: { symbol: "USDC", name: "USD Coin", address: "0xusdc" },
+    token: { symbol: "USDC", name: "USD Coin", address: "0xusdc", decimals: 6 },
     reserve: { hub: "0xhub", assetId: 1 },
   },
   {
     reserveId: 2n,
-    token: { symbol: "WBTC", name: "Wrapped BTC", address: "0xwbtc" },
+    token: {
+      symbol: "WBTC",
+      name: "Wrapped BTC",
+      address: "0xwbtc",
+      decimals: 8,
+    },
     reserve: { hub: "0xhub", assetId: 2 },
   },
 ];
@@ -52,6 +57,14 @@ vi.mock("../../../hooks", () => ({
   }),
   useAaveBorrowAprs: () => ({
     aprPercentByReserveId: { "1": 3.5, "2": 2.2 },
+  }),
+  useAaveReserveLiquidity: () => ({
+    liquidityByReserveId: {
+      // Below 1,000 → shown in full.
+      "1": { availableLiquidity: 500.25, utilizationBps: 2500 },
+      // Large figure → compact K/M/B notation.
+      "2": { availableLiquidity: 1234567, utilizationBps: 6000 },
+    },
   }),
 }));
 
@@ -79,6 +92,10 @@ describe("AssetSelectionModal", () => {
     expect(screen.getByText("USD Coin")).toBeInTheDocument();
     expect(screen.getByText("3.5%")).toBeInTheDocument();
     expect(screen.getByText("2.2%")).toBeInTheDocument();
+    // Available liquidity renders with the asset symbol: small amounts in full,
+    // large amounts in compact K/M/B notation.
+    expect(screen.getByText("500.25 USDC")).toBeInTheDocument();
+    expect(screen.getByText("1.23M WBTC")).toBeInTheDocument();
   });
 
   it("hides the Available and Borrow APR columns in repay mode", () => {

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/BorrowMetricsCard/BorrowMetricsCard.tsx
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/BorrowMetricsCard/BorrowMetricsCard.tsx
@@ -8,8 +8,17 @@ import { HeartIcon } from "@/components/shared";
 import { COPY } from "@/copy";
 
 interface BorrowMetricsCardProps {
+  /** Formatted current available liquidity, or "–". */
+  availableLiquidity: string;
+  /**
+   * Formatted post-borrow available liquidity. When set, the row shows
+   * `current → projected`; omit it to show the current value alone.
+   */
+  availableLiquidityProjected?: string;
   /** Formatted current borrow APR (live from the Aave Hub), or "–". */
   borrowApr: string;
+  /** Formatted utilization percentage (borrowed / supplied), or "–". */
+  utilization: string;
   healthFactor: string;
   healthFactorValue: number;
   healthFactorOriginal?: string;
@@ -20,14 +29,18 @@ const ROW_CLASS = "flex w-full items-center justify-between text-sm";
 const DIVIDER_CLASS = "h-px w-full bg-secondary-strokeLight";
 
 /**
- * Borrow metrics card. Borrow APR shows the live current rate (Aave Hub drawn
- * rate); Health factor uses its real projected value. Available liquidity and
- * Utilization have no frontend data source yet, so they render the empty
- * placeholder ("–") rather than a fabricated figure — a follow-up PR wires
- * those (and the projected post-borrow rate) once the reserve totals are read.
+ * Borrow metrics card. Borrow APR, Available liquidity, and Utilization all
+ * show live values read from the Aave Hub for the selected reserve; Health
+ * factor uses its real projected value. Each figure falls back to the empty
+ * placeholder ("–") while its read is loading or unavailable rather than
+ * rendering a fabricated value. (The projected post-borrow rate is not a simple
+ * read, so only the current borrow APR is shown.)
  */
 export function BorrowMetricsCard({
+  availableLiquidity,
+  availableLiquidityProjected,
   borrowApr,
+  utilization,
   healthFactor,
   healthFactorValue,
   healthFactorOriginal,
@@ -49,7 +62,15 @@ export function BorrowMetricsCard({
         <span className="text-accent-secondary">
           {COPY.loans.availableLiquidityLabel}
         </span>
-        <span className="text-accent-primary">{COPY.common.emptyValue}</span>
+        {availableLiquidityProjected ? (
+          <span className="flex items-center gap-2 text-accent-primary">
+            <span className="text-accent-secondary">{availableLiquidity}</span>
+            <span className="text-accent-secondary">→</span>
+            <span>{availableLiquidityProjected}</span>
+          </span>
+        ) : (
+          <span className="text-accent-primary">{availableLiquidity}</span>
+        )}
       </div>
 
       <div className={DIVIDER_CLASS} />
@@ -67,7 +88,7 @@ export function BorrowMetricsCard({
           {COPY.loans.utilizationLabel}
           <Hint tooltip={COPY.loans.utilizationTooltip} />
         </div>
-        <span className="text-accent-primary">{COPY.common.emptyValue}</span>
+        <span className="text-accent-primary">{utilization}</span>
       </div>
 
       <div className={DIVIDER_CLASS} />

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/BorrowMetricsCard/BorrowMetricsCard.tsx
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/BorrowMetricsCard/BorrowMetricsCard.tsx
@@ -65,7 +65,9 @@ export function BorrowMetricsCard({
         {availableLiquidityProjected ? (
           <span className="flex items-center gap-2 text-accent-primary">
             <span className="text-accent-secondary">{availableLiquidity}</span>
-            <span className="text-accent-secondary">→</span>
+            <span className="text-accent-secondary">
+              {COPY.common.valueTransitionArrow}
+            </span>
             <span>{availableLiquidityProjected}</span>
           </span>
         ) : (
@@ -105,7 +107,9 @@ export function BorrowMetricsCard({
                 <HeartIcon color={originalColor} />
                 {healthFactorOriginal}
               </span>
-              <span className="text-accent-secondary">→</span>
+              <span className="text-accent-secondary">
+                {COPY.common.valueTransitionArrow}
+              </span>
               <span className="flex items-center gap-1">
                 <HeartIcon color={color} />
                 {healthFactor}

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/BorrowMetricsCard/__tests__/BorrowMetricsCard.test.tsx
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/BorrowMetricsCard/__tests__/BorrowMetricsCard.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * BorrowMetricsCard — Available liquidity before → after projection.
+ *
+ * Locks in that the row shows the post-borrow figure as `current → projected`
+ * when a projection is supplied (mirroring the health-factor row), and the
+ * current value alone otherwise.
+ */
+
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { BorrowMetricsCard } from "../BorrowMetricsCard";
+
+vi.mock("@babylonlabs-io/core-ui", () => ({
+  SubSection: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Hint: () => null,
+}));
+
+vi.mock("@/components/shared", () => ({
+  HeartIcon: () => null,
+}));
+
+const baseProps = {
+  availableLiquidity: "45.2K",
+  borrowApr: "3.7%",
+  utilization: "25%",
+  healthFactor: "2.10",
+  healthFactorValue: 2.1,
+};
+
+describe("BorrowMetricsCard", () => {
+  it("shows available liquidity as current → projected when a projection is given", () => {
+    render(
+      <BorrowMetricsCard {...baseProps} availableLiquidityProjected="0 USDT" />,
+    );
+
+    expect(screen.getByText("45.2K")).toBeInTheDocument();
+    expect(screen.getByText("→")).toBeInTheDocument();
+    expect(screen.getByText("0 USDT")).toBeInTheDocument();
+  });
+
+  it("shows only the current available liquidity when no projection is given", () => {
+    render(
+      <BorrowMetricsCard {...baseProps} availableLiquidity="45.2K USDT" />,
+    );
+
+    expect(screen.getByText("45.2K USDT")).toBeInTheDocument();
+    expect(screen.queryByText("→")).not.toBeInTheDocument();
+  });
+});

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/__tests__/validateBorrowAction.test.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/__tests__/validateBorrowAction.test.ts
@@ -65,6 +65,26 @@ describe("validateBorrowAction", () => {
     });
   });
 
+  it("disables with the liquidity message when the cap is the reserve's available liquidity", () => {
+    // limitedByLiquidity=true → distinct copy explaining the market is the limit.
+    const result = validateBorrowAction(
+      6000,
+      2.0,
+      5000,
+      6,
+      "USDC",
+      false,
+      true,
+    );
+
+    expect(result).toEqual({
+      isDisabled: true,
+      buttonText: "Amount exceeds available liquidity",
+      errorMessage:
+        "Only 5,000 USDC is available to borrow from this market right now. Enter a lower amount and try again.",
+    });
+  });
+
   it("disables with 'Health factor too low' when HF is below minimum", () => {
     const result = validateBorrowAction(8000, 1.0, 10000, 6, "USDC");
 

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/validateBorrowAction.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/validateBorrowAction.ts
@@ -26,10 +26,14 @@ export interface BorrowValidationResult {
  *
  * @param borrowAmount - Amount user wants to borrow
  * @param projectedHealthFactor - Health factor after the borrow
- * @param maxBorrowAmount - Maximum borrowable amount based on collateral and debt
+ * @param maxBorrowAmount - Effective maximum borrowable amount (collateral- and
+ *   debt-based, already capped by available reserve liquidity when known)
  * @param tokenDecimals - Native token decimals (e.g., 8 for WBTC, 6 for USDC, 18 for ETH)
  * @param symbol - Token symbol, shown in the error description (e.g. "DAI")
  * @param isPositionDataStale - Whether position data may be outdated
+ * @param limitedByLiquidity - Whether `maxBorrowAmount` is bound by the
+ *   reserve's available liquidity (vs the user's collateral). Selects the
+ *   "exceeds available liquidity" message over the generic "exceeds maximum".
  * @returns Validation result with disabled state, button text, and error message
  */
 export function validateBorrowAction(
@@ -39,6 +43,7 @@ export function validateBorrowAction(
   tokenDecimals: number,
   symbol: string,
   isPositionDataStale = false,
+  limitedByLiquidity = false,
 ): BorrowValidationResult {
   if (isPositionDataStale) {
     return {
@@ -77,14 +82,21 @@ export function validateBorrowAction(
   }
 
   if (borrowAmount > maxBorrowAmount) {
-    return {
-      isDisabled: true,
-      buttonText: COPY.loans.borrow.amountExceedsMax,
-      errorMessage: COPY.loans.validation.maxBorrow(
-        formatDisplayAmount(maxBorrowAmount, displayDecimals),
-        symbol,
-      ),
-    };
+    const formattedMax = formatDisplayAmount(maxBorrowAmount, displayDecimals);
+    return limitedByLiquidity
+      ? {
+          isDisabled: true,
+          buttonText: COPY.loans.borrow.amountExceedsLiquidity,
+          errorMessage: COPY.loans.validation.exceedsLiquidity(
+            formattedMax,
+            symbol,
+          ),
+        }
+      : {
+          isDisabled: true,
+          buttonText: COPY.loans.borrow.amountExceedsMax,
+          errorMessage: COPY.loans.validation.maxBorrow(formattedMax, symbol),
+        };
   }
 
   // Block borrow if health factor would be too low

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/index.tsx
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/index.tsx
@@ -86,6 +86,26 @@ export function Borrow() {
       tokenDecimals: selectedReserve.token.decimals,
     });
 
+  // Live available liquidity for the selected reserve (Aave Hub reserve totals);
+  // also drives the metrics card below. Falls back to "–" while loading/failed.
+  const { liquidityByReserveId } = useAaveReserveLiquidity({
+    reserves: [selectedReserve],
+  });
+  const reserveLiquidity =
+    liquidityByReserveId[selectedReserve.reserveId.toString()];
+
+  // You can't borrow more than the reserve holds, so cap the collateral-based
+  // max by available liquidity when it's known. Additive: when the read is
+  // loading or failed (reserveLiquidity == null) the cap is skipped, so a
+  // best-effort display read can never block an otherwise-fundable borrow.
+  const limitedByLiquidity =
+    reserveLiquidity != null &&
+    reserveLiquidity.availableLiquidity < maxBorrowAmount;
+  const effectiveMaxBorrowAmount =
+    reserveLiquidity == null
+      ? maxBorrowAmount
+      : Math.min(maxBorrowAmount, reserveLiquidity.availableLiquidity);
+
   // Reset the entered amount whenever the borrow asset changes. The form is no
   // longer remounted on switch (see `useAaveReservePrice` keepPreviousData), so
   // clear the amount and the last failed-tx error explicitly — both belong to
@@ -125,17 +145,20 @@ export function Borrow() {
   const { isDisabled, buttonText, errorMessage } = validateBorrowAction(
     borrowAmount,
     metrics.healthFactorValue,
-    maxBorrowAmount,
+    effectiveMaxBorrowAmount,
     selectedReserve.token.decimals,
     assetConfig.symbol,
     isPositionDataStale,
+    limitedByLiquidity,
   );
 
   // Cosmetic minimum only — keeps the slider track from rendering at zero
   // width when there is nothing to borrow. The "Max" label and the slider's
-  // accept range use the real `maxBorrowAmount` so the UI doesn't advertise
-  // a value that validation will reject.
-  const sliderTrackMax = maxBorrowAmount > 0 ? maxBorrowAmount : MIN_SLIDER_MAX;
+  // accept range use `effectiveMaxBorrowAmount` so the UI doesn't advertise a
+  // value (beyond collateral capacity or available liquidity) that validation
+  // will reject.
+  const sliderTrackMax =
+    effectiveMaxBorrowAmount > 0 ? effectiveMaxBorrowAmount : MIN_SLIDER_MAX;
   const displayDecimals = Math.min(
     selectedReserve.token.decimals,
     SAFE_TOFIXED_PRECISION,
@@ -158,13 +181,6 @@ export function Borrow() {
       ? COPY.common.emptyValue
       : formatAprPercent(borrowAprPercent);
 
-  // Live available liquidity + utilization for the selected reserve (Aave Hub
-  // reserve totals). Each falls back to "–" while loading or on a failed read.
-  const { liquidityByReserveId } = useAaveReserveLiquidity({
-    reserves: [selectedReserve],
-  });
-  const reserveLiquidity =
-    liquidityByReserveId[selectedReserve.reserveId.toString()];
   // Borrowing draws the entered amount from the reserve, so the row shows the
   // current liquidity reducing to the post-borrow figure (current → projected),
   // mirroring the health-factor row. The arrow only appears once an amount is
@@ -284,12 +300,12 @@ export function Borrow() {
                     : COPY.common.emptyValue,
             }}
             onMaxClick={() => {
-              if (isPriceReady) handleAmountChange(maxBorrowAmount);
+              if (isPriceReady) handleAmountChange(effectiveMaxBorrowAmount);
             }}
             rightField={{
               label: COPY.loans.availableLabel,
               value: isPriceReady
-                ? `${formatTokenAmount(maxBorrowAmount, displayDecimals)} ${assetConfig.symbol}`
+                ? `${formatTokenAmount(effectiveMaxBorrowAmount, displayDecimals)} ${assetConfig.symbol}`
                 : COPY.common.emptyValue,
             }}
             maxPosition="right"

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/index.tsx
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/index.tsx
@@ -52,6 +52,14 @@ import { useBorrowState } from "./hooks/useBorrowState";
 import { validateBorrowAction } from "./hooks/validateBorrowAction";
 import { validateBorrowPreSign } from "./hooks/validateBorrowPreSign";
 
+/**
+ * Borrow at most this fraction of a reserve's available liquidity. The small
+ * margin keeps "Max" from advertising the exact remaining amount — borrowing
+ * the reserve down to zero can revert under some pool configs, so leaving a
+ * sliver avoids a fail-at-Max edge while the on-chain draw stays the backstop.
+ */
+const MAX_BORROWABLE_LIQUIDITY_FRACTION = 0.999;
+
 export function Borrow() {
   const {
     collateralValueUsd,
@@ -95,16 +103,16 @@ export function Borrow() {
     liquidityByReserveId[selectedReserve.reserveId.toString()];
 
   // You can't borrow more than the reserve holds, so cap the collateral-based
-  // max by available liquidity when it's known. Additive: when the read is
-  // loading or failed (reserveLiquidity == null) the cap is skipped, so a
-  // best-effort display read can never block an otherwise-fundable borrow.
-  const limitedByLiquidity =
-    reserveLiquidity != null &&
-    reserveLiquidity.availableLiquidity < maxBorrowAmount;
-  const effectiveMaxBorrowAmount =
+  // max by available liquidity (less a safety margin) when it's known. Additive:
+  // when the read is loading or failed (reserveLiquidity == null) the cap is
+  // skipped, so a best-effort display read can never block an otherwise-fundable
+  // borrow.
+  const liquidityCap =
     reserveLiquidity == null
-      ? maxBorrowAmount
-      : Math.min(maxBorrowAmount, reserveLiquidity.availableLiquidity);
+      ? Infinity
+      : reserveLiquidity.availableLiquidity * MAX_BORROWABLE_LIQUIDITY_FRACTION;
+  const effectiveMaxBorrowAmount = Math.min(maxBorrowAmount, liquidityCap);
+  const limitedByLiquidity = effectiveMaxBorrowAmount < maxBorrowAmount;
 
   // Reset the entered amount whenever the borrow asset changes. The form is no
   // longer remounted on switch (see `useAaveReservePrice` keepPreviousData), so

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/index.tsx
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/index.tsx
@@ -25,6 +25,8 @@ import {
 } from "../../../../../services/token";
 import {
   formatAprPercent,
+  formatBasisPointsAsPercent,
+  formatCompactTokenAmount,
   formatTokenAmount,
   formatUsdValue,
 } from "../../../../../utils/formatting";
@@ -36,7 +38,11 @@ import {
   SAFE_TOFIXED_PRECISION,
 } from "../../../constants";
 import { useAaveConfig } from "../../../context";
-import { useAaveBorrowAprs, useBorrowTransaction } from "../../../hooks";
+import {
+  useAaveBorrowAprs,
+  useAaveReserveLiquidity,
+  useBorrowTransaction,
+} from "../../../hooks";
 import { AssetPill } from "../../AssetPill";
 import { useLoanContext } from "../../context/LoanContext";
 
@@ -141,7 +147,7 @@ export function Borrow() {
 
   // Live current borrow APR for the selected reserve (Aave Hub drawn rate).
   // The projected post-borrow rate isn't a simple read, so only "current"
-  // shows real data; the other metric rows remain placeholders ("–").
+  // shows real data.
   const { aprPercentByReserveId } = useAaveBorrowAprs({
     reserves: [selectedReserve],
   });
@@ -151,6 +157,32 @@ export function Borrow() {
     borrowAprPercent == null
       ? COPY.common.emptyValue
       : formatAprPercent(borrowAprPercent);
+
+  // Live available liquidity + utilization for the selected reserve (Aave Hub
+  // reserve totals). Each falls back to "–" while loading or on a failed read.
+  const { liquidityByReserveId } = useAaveReserveLiquidity({
+    reserves: [selectedReserve],
+  });
+  const reserveLiquidity =
+    liquidityByReserveId[selectedReserve.reserveId.toString()];
+  // Borrowing draws the entered amount from the reserve, so the row shows the
+  // current liquidity reducing to the post-borrow figure (current → projected),
+  // mirroring the health-factor row. The arrow only appears once an amount is
+  // entered; the symbol is shown once, on whichever value is the last shown.
+  const availableLiquidityProjectedDisplay =
+    reserveLiquidity == null || !hasProjection
+      ? undefined
+      : `${formatCompactTokenAmount(Math.max(0, reserveLiquidity.availableLiquidity - borrowAmount))} ${assetConfig.symbol}`;
+  const availableLiquidityDisplay =
+    reserveLiquidity == null
+      ? COPY.common.emptyValue
+      : availableLiquidityProjectedDisplay
+        ? formatCompactTokenAmount(reserveLiquidity.availableLiquidity)
+        : `${formatCompactTokenAmount(reserveLiquidity.availableLiquidity)} ${assetConfig.symbol}`;
+  const utilizationDisplay =
+    reserveLiquidity?.utilizationBps == null
+      ? COPY.common.emptyValue
+      : formatBasisPointsAsPercent(reserveLiquidity.utilizationBps);
 
   const projectedHealthStatus = getHealthFactorStatusFromValue(
     metrics.healthFactorValue,
@@ -283,7 +315,10 @@ export function Borrow() {
 
         {/* Borrow Metrics */}
         <BorrowMetricsCard
+          availableLiquidity={availableLiquidityDisplay}
+          availableLiquidityProjected={availableLiquidityProjectedDisplay}
           borrowApr={borrowAprDisplay}
+          utilization={utilizationDisplay}
           healthFactor={metrics.healthFactor}
           healthFactorValue={metrics.healthFactorValue}
           healthFactorOriginal={metrics.healthFactorOriginal}

--- a/services/vault/src/applications/aave/hooks/__tests__/useAaveReserveLiquidity.test.tsx
+++ b/services/vault/src/applications/aave/hooks/__tests__/useAaveReserveLiquidity.test.tsx
@@ -1,0 +1,172 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../clients/aaveHub", () => ({
+  getAssetLiquiditiesSafe: vi.fn(),
+}));
+
+import { getAssetLiquiditiesSafe } from "../../clients/aaveHub";
+import type { AaveReserveConfig } from "../../services/fetchConfig";
+import { useAaveReserveLiquidity } from "../useAaveReserveLiquidity";
+
+const HUB = "0x0000000000000000000000000000000000000003" as const;
+
+function makeReserve(reserveId: bigint, assetId: number): AaveReserveConfig {
+  return {
+    reserveId,
+    reserve: {
+      underlying: "0x0000000000000000000000000000000000000010",
+      hub: HUB,
+      assetId,
+      decimals: 6,
+      dynamicConfigKey: 0,
+      paused: false,
+      frozen: false,
+      borrowable: true,
+      collateralRisk: 0,
+      collateralFactor: 8000,
+    },
+    token: {
+      address: "0x0000000000000000000000000000000000000010",
+      symbol: "USDC",
+      name: "USD Coin",
+      decimals: 6,
+    },
+  };
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe("useAaveReserveLiquidity", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("converts base units to token units and derives bps utilization", async () => {
+    // 6-decimal token: 75 available + 25 owed → 75 token units, 25% utilization.
+    vi.mocked(getAssetLiquiditiesSafe).mockResolvedValueOnce([
+      {
+        hub: HUB,
+        assetId: 0,
+        availableLiquidityRaw: 75_000_000n,
+        totalOwedRaw: 25_000_000n,
+        error: null,
+      },
+    ]);
+
+    const { result } = renderHook(
+      () => useAaveReserveLiquidity({ reserves: [makeReserve(1n, 0)] }),
+      { wrapper },
+    );
+
+    await waitFor(() =>
+      expect(result.current.liquidityByReserveId["1"]).not.toBeUndefined(),
+    );
+    expect(result.current.liquidityByReserveId["1"]).toEqual({
+      availableLiquidity: 75,
+      utilizationBps: 2500,
+    });
+  });
+
+  it("reports null utilization when the reserve has no supplied liquidity", async () => {
+    vi.mocked(getAssetLiquiditiesSafe).mockResolvedValueOnce([
+      {
+        hub: HUB,
+        assetId: 0,
+        availableLiquidityRaw: 0n,
+        totalOwedRaw: 0n,
+        error: null,
+      },
+    ]);
+
+    const { result } = renderHook(
+      () => useAaveReserveLiquidity({ reserves: [makeReserve(1n, 0)] }),
+      { wrapper },
+    );
+
+    await waitFor(() =>
+      expect(result.current.liquidityByReserveId["1"]).not.toBeUndefined(),
+    );
+    expect(result.current.liquidityByReserveId["1"]).toEqual({
+      availableLiquidity: 0,
+      utilizationBps: null,
+    });
+  });
+
+  it("nulls a reserve whose read failed", async () => {
+    vi.mocked(getAssetLiquiditiesSafe).mockResolvedValueOnce([
+      {
+        hub: HUB,
+        assetId: 0,
+        availableLiquidityRaw: null,
+        totalOwedRaw: null,
+        error: new Error("reverted"),
+      },
+    ]);
+
+    const { result } = renderHook(
+      () => useAaveReserveLiquidity({ reserves: [makeReserve(1n, 0)] }),
+      { wrapper },
+    );
+
+    await waitFor(() =>
+      expect(Object.keys(result.current.liquidityByReserveId)).toHaveLength(1),
+    );
+    expect(result.current.liquidityByReserveId["1"]).toBeNull();
+  });
+
+  it("is disabled when reserves is empty", () => {
+    const { result } = renderHook(
+      () => useAaveReserveLiquidity({ reserves: [] }),
+      { wrapper },
+    );
+    expect(result.current.liquidityByReserveId).toEqual({});
+    expect(result.current.isLoading).toBe(false);
+    expect(getAssetLiquiditiesSafe).not.toHaveBeenCalled();
+  });
+
+  it("clears stale liquidity after a refetch fails", async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    vi.mocked(getAssetLiquiditiesSafe)
+      .mockResolvedValueOnce([
+        {
+          hub: HUB,
+          assetId: 0,
+          availableLiquidityRaw: 75_000_000n,
+          totalOwedRaw: 25_000_000n,
+          error: null,
+        },
+      ])
+      .mockRejectedValueOnce(new Error("RPC failure"));
+
+    const wrapperWithClient = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+
+    const { result } = renderHook(
+      () => useAaveReserveLiquidity({ reserves: [makeReserve(1n, 0)] }),
+      { wrapper: wrapperWithClient },
+    );
+
+    await waitFor(() =>
+      expect(result.current.liquidityByReserveId["1"]).toEqual({
+        availableLiquidity: 75,
+        utilizationBps: 2500,
+      }),
+    );
+
+    await client.refetchQueries({ queryKey: ["aaveReserveLiquidity"] });
+
+    await waitFor(() => expect(result.current.error).toBeInstanceOf(Error));
+    expect(result.current.liquidityByReserveId).toEqual({});
+  });
+});

--- a/services/vault/src/applications/aave/hooks/index.ts
+++ b/services/vault/src/applications/aave/hooks/index.ts
@@ -12,6 +12,11 @@ export {
   type UseAaveOracleAddressResult,
 } from "./useAaveOracleAddress";
 export {
+  useAaveReserveLiquidity,
+  type ReserveLiquidity,
+  type UseAaveReserveLiquidityResult,
+} from "./useAaveReserveLiquidity";
+export {
   useAaveReservePrice,
   type UseAaveReservePriceResult,
 } from "./useAaveReservePrice";

--- a/services/vault/src/applications/aave/hooks/useAaveReserveLiquidity.ts
+++ b/services/vault/src/applications/aave/hooks/useAaveReserveLiquidity.ts
@@ -90,6 +90,9 @@ export function useAaveReserveLiquidity({
         }
         const suppliedRaw = availableLiquidityRaw + totalOwedRaw;
         out[key] = {
+          // The Hub reports liquidity and owed in the reserve's underlying-token
+          // base units, so convert with the token's decimals — the same scale
+          // the borrow amount and the rest of the borrow flow already use.
           availableLiquidity: Number(
             formatUnits(availableLiquidityRaw, reserve.token.decimals),
           ),

--- a/services/vault/src/applications/aave/hooks/useAaveReserveLiquidity.ts
+++ b/services/vault/src/applications/aave/hooks/useAaveReserveLiquidity.ts
@@ -1,0 +1,117 @@
+/**
+ * Batched per-reserve liquidity read from the Aave v4 Hub. Returns
+ * `Record<reserveId.toString(), ReserveLiquidity | null>` with available
+ * liquidity in token units and utilization in basis points. A reserve is
+ * `null` when its read failed (callers render the empty placeholder).
+ *
+ * Read from the Hub (keyed by `hub`/`assetId`), not the Spoke: the Core Spoke
+ * supplies vBTC collateral, not the borrowed asset, so its reserve totals are
+ * spoke-local. The Hub holds the shared market — the same place the borrow APR
+ * is read — so utilization here stays consistent with the displayed rate.
+ *
+ * Wallet-less: reads go through the app's public RPC client, so this works on
+ * disconnected surfaces (e.g. the asset picker).
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+import { formatUnits } from "viem";
+
+import { getAssetLiquiditiesSafe } from "../clients/aaveHub";
+import type { AaveReserveConfig } from "../services/fetchConfig";
+
+const QUERY_KEY = "aaveReserveLiquidity";
+const ONE_MINUTE_MS = 60 * 1000;
+/** 100% expressed in basis points (1 bps = 0.01%). */
+const BPS_SCALE = 10_000n;
+
+export interface ReserveLiquidity {
+  /**
+   * Borrowable liquidity remaining, in whole token units. Consumed for compact
+   * display and for projecting the post-borrow figure (`available - amount`),
+   * so a `number` is the convenient form; the compact display rounds anyway, so
+   * the `Number()` conversion's loss of sub-display precision is immaterial.
+   */
+  availableLiquidity: number;
+  /**
+   * Utilization (borrowed / supplied) in basis points, or null when the
+   * reserve has no supplied liquidity (utilization is undefined at 0 supply).
+   */
+  utilizationBps: number | null;
+}
+
+export interface UseAaveReserveLiquidityResult {
+  /** Liquidity per reserve ID; null when that reserve's read failed. */
+  liquidityByReserveId: Record<string, ReserveLiquidity | null>;
+  isLoading: boolean;
+  error: Error | null;
+}
+
+export function useAaveReserveLiquidity({
+  reserves,
+}: {
+  reserves: AaveReserveConfig[];
+}): UseAaveReserveLiquidityResult {
+  // Stable cache key regardless of input order. Includes the Hub asset
+  // (`hub`/`assetId`) each total is read from, not just the reserve ID, so a
+  // config refresh that repoints a reserve busts the cache instead of serving
+  // totals fetched for the old asset. Also includes `decimals`, since the
+  // cached value is token-unit-converted with it — a corrected decimal must
+  // recompute rather than reuse the old conversion.
+  const reserveAssetsKey = useMemo(
+    () =>
+      reserves
+        .map(
+          (r) =>
+            `${r.reserveId.toString()}:${r.reserve.hub.toLowerCase()}:${r.reserve.assetId}:${r.token.decimals}`,
+        )
+        .sort()
+        .join(","),
+    [reserves],
+  );
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: [QUERY_KEY, reserveAssetsKey],
+    queryFn: async () => {
+      const results = await getAssetLiquiditiesSafe(
+        reserves.map((r) => ({
+          hub: r.reserve.hub,
+          assetId: r.reserve.assetId,
+        })),
+      );
+      const out: Record<string, ReserveLiquidity | null> = {};
+      results.forEach((result, i) => {
+        const reserve = reserves[i];
+        const key = reserve.reserveId.toString();
+        const { availableLiquidityRaw, totalOwedRaw } = result;
+        if (availableLiquidityRaw == null || totalOwedRaw == null) {
+          out[key] = null;
+          return;
+        }
+        const suppliedRaw = availableLiquidityRaw + totalOwedRaw;
+        out[key] = {
+          availableLiquidity: Number(
+            formatUnits(availableLiquidityRaw, reserve.token.decimals),
+          ),
+          // Utilization stays in bigint until the final ratio so a large
+          // supplied total can't overflow the intermediate product.
+          utilizationBps:
+            suppliedRaw === 0n
+              ? null
+              : Number((totalOwedRaw * BPS_SCALE) / suppliedRaw),
+        };
+      });
+      return out;
+    },
+    enabled: reserves.length > 0,
+    staleTime: ONE_MINUTE_MS,
+    refetchInterval: ONE_MINUTE_MS,
+  });
+
+  // Same stale-data guard as useAaveBorrowAprs: clear `data` on error.
+  return {
+    liquidityByReserveId: error ? {} : (data ?? {}),
+    isLoading: reserves.length > 0 && isLoading,
+    error: (error as Error | null) ?? null,
+  };
+}

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -742,6 +742,7 @@ export const COPY = {
       refreshingPosition: "Refreshing position...",
       amountTooSmall: "Amount too small",
       amountExceedsMax: "Amount exceeds maximum",
+      amountExceedsLiquidity: "Amount exceeds available liquidity",
       healthFactorTooLow: "Health factor too low",
     },
     // Borrow validation-error descriptions (the Callout title comes from the
@@ -751,6 +752,8 @@ export const COPY = {
         `The minimum borrowable amount is ${min}. Enter a higher amount and try again.`,
       maxBorrow: (max: string, symbol: string) =>
         `The maximum borrowable amount is ${max} ${symbol}. Enter a lower amount and try again.`,
+      exceedsLiquidity: (available: string, symbol: string) =>
+        `Only ${available} ${symbol} is available to borrow from this market right now. Enter a lower amount and try again.`,
       healthFactorTooLow: (min: number) =>
         `Borrowing this amount would drop your health factor below ${min}, risking liquidation. Reduce the amount and try again.`,
     },

--- a/services/vault/src/utils/__tests__/formatting.test.ts
+++ b/services/vault/src/utils/__tests__/formatting.test.ts
@@ -11,6 +11,7 @@ import {
   formatAprPercent,
   formatBasisPointsAsPercent,
   formatBtcAmount,
+  formatCompactTokenAmount,
   formatCompactUsd,
   formatDateTime,
   formatDuration,
@@ -446,6 +447,25 @@ describe("Formatting Utilities", () => {
   // ~5-day wait reads as "5 days", not "114 hours". Thresholds are on the raw
   // minutes (< 60 minutes, < 1440 hours, else days); the value within the unit
   // is rounded to the nearest whole.
+  describe("formatCompactTokenAmount", () => {
+    it("collapses thousands and up into K/M/B suffixes", () => {
+      expect(formatCompactTokenAmount(45200)).toBe("45.2K");
+      expect(formatCompactTokenAmount(1234567)).toBe("1.23M");
+      expect(formatCompactTokenAmount(1500000000)).toBe("1.5B");
+    });
+
+    it("shows amounts below one thousand in full, grouped, up to two decimals", () => {
+      expect(formatCompactTokenAmount(999)).toBe("999");
+      expect(formatCompactTokenAmount(500.25)).toBe("500.25");
+      expect(formatCompactTokenAmount(2.5)).toBe("2.5");
+    });
+
+    it("returns '0' for zero or negative input", () => {
+      expect(formatCompactTokenAmount(0)).toBe("0");
+      expect(formatCompactTokenAmount(-5)).toBe("0");
+    });
+  });
+
   describe("formatDuration", () => {
     it("shows 'less than a minute' at or below zero", () => {
       expect(formatDuration(0)).toBe("less than a minute");

--- a/services/vault/src/utils/__tests__/formatting.test.ts
+++ b/services/vault/src/utils/__tests__/formatting.test.ts
@@ -464,6 +464,13 @@ describe("Formatting Utilities", () => {
       expect(formatCompactTokenAmount(0)).toBe("0");
       expect(formatCompactTokenAmount(-5)).toBe("0");
     });
+
+    it("rounds to two decimals before the compact threshold so the boundary is consistent", () => {
+      // 999.995 rounds up to 1,000 → compact "1K", not the full "1,000".
+      expect(formatCompactTokenAmount(999.995)).toBe("1K");
+      // Just under the rounding boundary stays in full form.
+      expect(formatCompactTokenAmount(999.99)).toBe("999.99");
+    });
   });
 
   describe("formatDuration", () => {

--- a/services/vault/src/utils/formatting.ts
+++ b/services/vault/src/utils/formatting.ts
@@ -387,11 +387,15 @@ const COMPACT_NOTATION_THRESHOLD = 1000;
  */
 export function formatCompactTokenAmount(amount: number): string {
   if (amount <= 0) return "0";
-  if (amount >= COMPACT_NOTATION_THRESHOLD) {
+  // Round to the two decimals shown before testing the compact threshold, so a
+  // value that rounds up to 1,000 (e.g. 999.995) renders as "1K" rather than
+  // the full "1,000" — keeping the boundary consistent and not overstating.
+  const rounded = Number(amount.toFixed(2));
+  if (rounded >= COMPACT_NOTATION_THRESHOLD) {
     return new Intl.NumberFormat("en-US", {
       notation: "compact",
       maximumFractionDigits: 2,
-    }).format(amount);
+    }).format(rounded);
   }
   return formatAmount(amount, 2);
 }

--- a/services/vault/src/utils/formatting.ts
+++ b/services/vault/src/utils/formatting.ts
@@ -371,3 +371,27 @@ export function formatTokenAmount(amount: number, maxDecimals = 6): string {
   }
   return trimmed;
 }
+
+/** At/above this magnitude a token amount renders in compact K/M/B notation. */
+const COMPACT_NOTATION_THRESHOLD = 1000;
+
+/**
+ * Format a token amount for compact display. Figures of one thousand or more
+ * collapse to grouped magnitude suffixes (45_200 → "45.2K", 1_234_567 →
+ * "1.23M", 1.5e9 → "1.5B"); smaller amounts render in full (grouped, up to two
+ * decimals). The token symbol, if any, is appended by the caller. Returns "0"
+ * for zero or negative input.
+ *
+ * Sibling of `formatCompactUsd` for bare token quantities (no "$" prefix,
+ * uppercase suffix).
+ */
+export function formatCompactTokenAmount(amount: number): string {
+  if (amount <= 0) return "0";
+  if (amount >= COMPACT_NOTATION_THRESHOLD) {
+    return new Intl.NumberFormat("en-US", {
+      notation: "compact",
+      maximumFractionDigits: 2,
+    }).format(amount);
+  }
+  return formatAmount(amount, 2);
+}


### PR DESCRIPTION
## Summary

Wires the reserve-level **Available liquidity** and **Utilization** figures
into the borrow flow. They previously rendered `–` with no data source; this
reads them live from the Aave Hub.

Closes #1887

## What changed

- **Data source — Aave Hub (keyed by `assetId`), not the Spoke.** The Core
  Spoke supplies vBTC collateral, not the borrowed asset, so its per-reserve
  totals are spoke-local and would misreport. The Hub holds the shared market
  and is also where the borrow APR is read, so Utilization stays consistent
  with the displayed rate. Per reserve we read `getAssetLiquidity` (available)
  and `getAssetTotalOwed` (borrowed) in one fault-isolated multicall;
  Utilization = `borrowed / (available + borrowed)`.
- **App-side read.** The Hub liquidity read lives in the vault's
  `clients/eth-contract`-style layer (a minimal local ABI fragment), matching
  the existing cap-policy / chainlink readers, rather than widening the shared
  ts-sdk for one display surface.
- **Surfaces.** Borrow metrics card (Available liquidity + Utilization) and the
  asset-picker per-asset Available column. Each falls back to the empty
  placeholder while the read is loading or unavailable — no fabricated figures.
- **Before → after.** Available liquidity projects `current → post-borrow`
  once an amount is entered (it draws from the reserve), mirroring the
  health-factor row.
- **Compact display.** Large amounts render as `K`/`M`/`B` via a new
  `formatCompactTokenAmount` (token sibling of `formatCompactUsd`).
- Repay has no reserve-liquidity figure, and the asset picker already hides the
  Available column in repay mode, so nothing changes there.

## Testing

- Unit: `formatCompactTokenAmount`, the Hub liquidity multicall (success /
  half-success → null reserve / network failure), the `useAaveReserveLiquidity`
  hook (token-unit conversion, zero-supply, failed read, stale-clear), the
  asset-picker Available column, and the borrow-card `current → projected` row.
- `pnpm run lint` and `pnpm exec tsc --noEmit -p tsconfig.lib.json` clean.

## Screenshots
<img width="2912" height="1804" alt="image" src="https://github.com/user-attachments/assets/51381bc6-6f4e-416a-b9a8-56a41def2ca2" />
<img width="2912" height="1804" alt="image" src="https://github.com/user-attachments/assets/644487f0-81f6-4819-8a43-4f5ebdb2c0ea" />

