### PR TITLE
feat(ts-sdk): verify VP CWT bearer tokens, not just the wire envelope

### DIFF
--- a/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/__tests__/cborDecode.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/__tests__/cborDecode.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CborDecodeError,
+  CborReader,
+  type CborTagged,
+  decodeCbor,
+} from "../cborDecode";
+
+function bytes(...values: number[]): Uint8Array {
+  return Uint8Array.from(values);
+}
+
+describe("decodeCbor", () => {
+  it("decodes small unsigned integers inline", () => {
+    expect(decodeCbor(bytes(0x00))).toBe(0);
+    expect(decodeCbor(bytes(0x17))).toBe(23);
+  });
+
+  it("decodes multi-byte unsigned integers (1/2/4 byte arguments)", () => {
+    expect(decodeCbor(bytes(0x18, 0x18))).toBe(24);
+    expect(decodeCbor(bytes(0x19, 0x01, 0x00))).toBe(256);
+    expect(decodeCbor(bytes(0x1a, 0x65, 0x53, 0xf1, 0x00))).toBe(1_700_000_000);
+  });
+
+  it("decodes negative integers", () => {
+    // 0x20 = -1, 0x37 = -24, 0x38 0x2e = -47 (the ES256K alg id).
+    expect(decodeCbor(bytes(0x20))).toBe(-1);
+    expect(decodeCbor(bytes(0x37))).toBe(-24);
+    expect(decodeCbor(bytes(0x38, 0x2e))).toBe(-47);
+  });
+
+  it("decodes byte strings as raw bytes", () => {
+    expect(decodeCbor(bytes(0x43, 0x01, 0x02, 0x03))).toEqual(
+      bytes(0x01, 0x02, 0x03),
+    );
+  });
+
+  it("decodes text strings as UTF-8", () => {
+    // 0x6a + "Signature1"
+    const sig = bytes(0x6a, ...new TextEncoder().encode("Signature1"));
+    expect(decodeCbor(sig)).toBe("Signature1");
+  });
+
+  it("decodes arrays", () => {
+    expect(decodeCbor(bytes(0x83, 0x01, 0x02, 0x03))).toEqual([1, 2, 3]);
+  });
+
+  it("decodes maps with integer keys", () => {
+    // {1: 2, 3: 4}
+    const map = decodeCbor(bytes(0xa2, 0x01, 0x02, 0x03, 0x04));
+    expect(map).toBeInstanceOf(Map);
+    expect((map as Map<number, number>).get(1)).toBe(2);
+    expect((map as Map<number, number>).get(3)).toBe(4);
+  });
+
+  it("decodes tagged values", () => {
+    // tag(18) wrapping uint 5
+    const tagged = decodeCbor(bytes(0xd2, 0x05)) as CborTagged;
+    expect(tagged.tag).toBe(18);
+    expect(tagged.value).toBe(5);
+  });
+
+  it("rejects indefinite-length encodings", () => {
+    // 0x5f = indefinite-length byte string.
+    expect(() => decodeCbor(bytes(0x5f))).toThrow(CborDecodeError);
+  });
+
+  it("rejects reserved additional-info values", () => {
+    // 0x1c = major 0, additional info 28 (reserved).
+    expect(() => decodeCbor(bytes(0x1c))).toThrow(CborDecodeError);
+  });
+
+  it("rejects input that ends mid-item", () => {
+    // Array of 2 declared, only 1 element present.
+    expect(() => decodeCbor(bytes(0x82, 0x01))).toThrow(CborDecodeError);
+  });
+
+  it("rejects a byte string whose length overruns the buffer", () => {
+    expect(() => decodeCbor(bytes(0x43, 0x01))).toThrow(CborDecodeError);
+  });
+});
+
+describe("CborReader", () => {
+  it("advances pos so callers can slice an item's exact encoded bytes", () => {
+    // [protected-bstr h'a0', uint 7]
+    const buf = bytes(0x82, 0x41, 0xa0, 0x07);
+    const reader = new CborReader(buf);
+    reader.readHead(); // array header
+
+    const start = reader.pos;
+    const content = reader.readByteString();
+    const encoded = buf.subarray(start, reader.pos);
+
+    expect(content).toEqual(bytes(0xa0));
+    expect(encoded).toEqual(bytes(0x41, 0xa0)); // head + content
+    expect(reader.readValue()).toBe(7);
+  });
+
+  it("readByteString throws on a non-byte-string item", () => {
+    expect(() => new CborReader(bytes(0x07)).readByteString()).toThrow(
+      CborDecodeError,
+    );
+  });
+});

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/__tests__/cborDecode.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/__tests__/cborDecode.test.ts
@@ -79,6 +79,35 @@ describe("decodeCbor", () => {
   it("rejects a byte string whose length overruns the buffer", () => {
     expect(() => decodeCbor(bytes(0x43, 0x01))).toThrow(CborDecodeError);
   });
+
+  it("rejects trailing bytes after the top-level item", () => {
+    // uint 0 (0x00) fully decodes; the second 0x00 is a stray trailing
+    // byte the strict top-level decoder must reject.
+    expect(() => decodeCbor(bytes(0x00, 0x00))).toThrow(CborDecodeError);
+  });
+
+  it("rejects nesting deeper than the recursion cap", () => {
+    // 300 levels of array(1) nesting (0x81 = array of one element) wrapping
+    // a final uint 0, exceeding the 256 cap. A deeply-nested blob from a
+    // malicious VP must be rejected with a CborDecodeError, not crash the
+    // decoder with a native stack overflow before the signature is checked.
+    const deeplyNested = new Uint8Array(301).fill(0x81);
+    deeplyNested[300] = 0x00;
+    expect(() => decodeCbor(deeplyNested)).toThrow(CborDecodeError);
+  });
+
+  it("decodes nesting up to the recursion cap", () => {
+    // 200 levels stays under the cap and decodes to the innermost value.
+    const depth = 200;
+    const nested = new Uint8Array(depth + 1).fill(0x81);
+    nested[depth] = 0x07;
+    let value = decodeCbor(nested);
+    for (let i = 0; i < depth; i++) {
+      expect(Array.isArray(value)).toBe(true);
+      value = (value as unknown[])[0] as typeof value;
+    }
+    expect(value).toBe(7);
+  });
 });
 
 describe("CborReader", () => {

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/__tests__/createAuthenticatedVpClient.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/__tests__/createAuthenticatedVpClient.test.ts
@@ -22,6 +22,7 @@ const PEGIN_TXID = "a".repeat(64);
 const AUTH_ANCHOR = "b".repeat(64);
 const PINNED_PUBKEY =
   "ab".repeat(32) as unknown as OnChainBtcPubkey;
+const DEPOSITOR_PUBKEY = "cd".repeat(32);
 
 describe("createAuthenticatedVpClient", () => {
   beforeEach(() => {
@@ -39,6 +40,7 @@ describe("createAuthenticatedVpClient", () => {
       peginTxid: PEGIN_TXID,
       authAnchorHex: AUTH_ANCHOR,
       pinnedServerPubkey: PINNED_PUBKEY,
+      depositorBtcPubkey: DEPOSITOR_PUBKEY,
     });
     const firstProvider = vpTokenRegistry.peek(PEGIN_TXID);
     expect(firstProvider).toBeDefined();
@@ -48,6 +50,7 @@ describe("createAuthenticatedVpClient", () => {
       peginTxid: PEGIN_TXID,
       authAnchorHex: AUTH_ANCHOR,
       pinnedServerPubkey: PINNED_PUBKEY,
+      depositorBtcPubkey: DEPOSITOR_PUBKEY,
     });
     expect(vpTokenRegistry.peek(PEGIN_TXID)).toBe(firstProvider);
   });
@@ -67,6 +70,7 @@ describe("createAuthenticatedVpClient", () => {
       peginTxid: PEGIN_TXID,
       authAnchorHex: AUTH_ANCHOR,
       pinnedServerPubkey: PINNED_PUBKEY,
+      depositorBtcPubkey: DEPOSITOR_PUBKEY,
     });
 
     await client.getPeginStatus({ pegin_txid: PEGIN_TXID }).catch(() => {

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/__tests__/goldenVectors.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/__tests__/goldenVectors.ts
@@ -50,3 +50,48 @@ export const GOLDEN_PAYLOAD_HEX =
 /** 64-byte BIP-322 Schnorr signature for the above payload + signing key. */
 export const GOLDEN_SIGNATURE_HEX =
   "89c7473a2b4128f7c015272d535c535d7508b8ca9d9a06e4863d7da4cea8feb99fc20f9cbbb49f67594a81fdd31406f9654e4964b9176e8d47259a0fbc322fdf";
+
+/*
+ * --- CWT bearer-token golden vectors ---
+ *
+ * Real ES256K COSE Sign1 CWT tokens produced by the btc-vault Rust
+ * reference (`crates/btc-auth/src/token_signer.rs::build_cose_sign1_token`
+ * + `coset::cwt::ClaimsSetBuilder`). They are signed by the **same**
+ * ephemeral key as {@link GOLDEN_EPHEMERAL_PUBKEY_COMPRESSED} (seed 42)
+ * and carry {@link GOLDEN_SIGNING_KEY_XONLY} (seed 7) as their `iss`, so
+ * a token verifies against the server-identity golden above as one
+ * consistent issuance.
+ *
+ * Reproduce: add a temporary `#[test]` to that module that builds a
+ * COSE Sign1 over a `ClaimsSetBuilder` payload with the seed-42 signing
+ * key, iss = seed-7 x-only, aud = seed-99 x-only, and prints the
+ * base64url token. Run with
+ * `cargo test -p btc-auth --lib --features test-utils <test> -- --nocapture`,
+ * then revert.
+ *
+ * Claims (all three tokens): iss = GOLDEN_SIGNING_KEY_XONLY,
+ * aud = GOLDEN_CWT_AUDIENCE_XONLY, iat = nbf = GOLDEN_CWT_NBF.
+ */
+
+/** Depositor x-only pubkey carried in the `aud` claim (seed 99). */
+export const GOLDEN_CWT_AUDIENCE_XONLY =
+  "4f401063cc0f559467937a3fad43929058922478886f70505e7d29569af2ab5e";
+
+/** `iat`/`nbf` of every CWT golden token. */
+export const GOLDEN_CWT_NBF = 1_699_996_000;
+/** `exp` of the normal-lifetime tokens. ≤ GOLDEN_EXPIRES_AT (server-identity expiry). */
+export const GOLDEN_CWT_EXP = 1_699_999_000;
+/** `exp` of the short-lifetime token used to exercise refresh-on-skew. */
+export const GOLDEN_CWT_SHORT_EXP = 1_699_996_440;
+
+/** JSON-RPC-subject token (`sub` = "vaultd-jsonrpc"), exp = GOLDEN_CWT_EXP. */
+export const GOLDEN_CWT_TOKEN_JSONRPC =
+  "0oREoQE4LqBYu6cBeEA0OTE2NGEwMmFjODFiNDJjYzRkY2RlN2E4MzExYmVjZjU2ODg2ODUwZjA2M2E4NmM2NmFmZWY1YzhhZTA3NzhjAm52YXVsdGQtanNvbnJwYwN4QDRmNDAxMDYzY2MwZjU1OTQ2NzkzN2EzZmFkNDM5MjkwNTg5MjI0Nzg4ODZmNzA1MDVlN2QyOTU2OWFmMmFiNWUEGmVT7RgFGmVT4WAGGmVT4WAHUKurq6urq6urq6urq6urq6tYQFYf_JPwc-IvtuwABdhlKk78PWG0KS2u30pRQ2U1CE4GHGrfmcLIrhZsoDifabPwgtcMLTuDEUHLGJM5dOC_Bi8";
+
+/** Same issuance shape but short-lived (exp = GOLDEN_CWT_SHORT_EXP). */
+export const GOLDEN_CWT_TOKEN_JSONRPC_SHORT =
+  "0oREoQE4LqBYu6cBeEA0OTE2NGEwMmFjODFiNDJjYzRkY2RlN2E4MzExYmVjZjU2ODg2ODUwZjA2M2E4NmM2NmFmZWY1YzhhZTA3NzhjAm52YXVsdGQtanNvbnJwYwN4QDRmNDAxMDYzY2MwZjU1OTQ2NzkzN2EzZmFkNDM5MjkwNTg5MjI0Nzg4ODZmNzA1MDVlN2QyOTU2OWFmMmFiNWUEGmVT4xgFGmVT4WAGGmVT4WAHUM3Nzc3Nzc3Nzc3Nzc3Nzc1YQDayqqB4bTlHAaFOwyNcAMIEpiBW5GrgnkarO0yJ7bnkHjsmHlFcA9XDFupahH9wIQMGN8R6FVDax52MdYdg3Wc";
+
+/** gRPC-subject token (`sub` = "vaultd-grpc"), exp = GOLDEN_CWT_EXP. */
+export const GOLDEN_CWT_TOKEN_GRPC =
+  "0oREoQE4LqBYuKcBeEA0OTE2NGEwMmFjODFiNDJjYzRkY2RlN2E4MzExYmVjZjU2ODg2ODUwZjA2M2E4NmM2NmFmZWY1YzhhZTA3NzhjAmt2YXVsdGQtZ3JwYwN4QDRmNDAxMDYzY2MwZjU1OTQ2NzkzN2EzZmFkNDM5MjkwNTg5MjI0Nzg4ODZmNzA1MDVlN2QyOTU2OWFmMmFiNWUEGmVT7RgFGmVT4WAGGmVT4WAHUO_v7-_v7-_v7-_v7-_v7-9YQJhF3CJH5sFKdi7jwGeqVxErk95edujMvMVF6JiU-Io6cbBBbcJtHWZPF_Cc3_SIlAO6s6Oi9N6u0XUOPQf5ZW8";

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/__tests__/mintTestCwt.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/__tests__/mintTestCwt.ts
@@ -1,0 +1,165 @@
+/**
+ * Test-only minter for ES256K COSE Sign1 CWT bearer tokens.
+ *
+ * The genuine golden vectors in {@link ./goldenVectors} are signed by the
+ * Rust issuer's key, so they can only exercise the *happy* path and the
+ * checks that run before signature verification. The claim-rejection
+ * paths (`invalid_claims` for a malformed `aud`, `iat > exp`, an empty
+ * `cti`, …) run only *after* the COSE signature verifies, so reaching
+ * them needs a token signed over deliberately-bad claims.
+ *
+ * This helper signs tokens with a test-controlled key and hands the
+ * matching ephemeral pubkey to the verifier, so any claim combination can
+ * be minted with a signature that genuinely verifies. It builds the same
+ * COSE_Sign1 byte layout the verifier reads — tag(18), 4-element array,
+ * protected-header byte string, empty unprotected map, payload byte
+ * string, and the 64-byte compact signature.
+ *
+ * @module tbv/core/clients/vault-provider/auth/__tests__/mintTestCwt
+ */
+
+import * as ecc from "@bitcoin-js/tiny-secp256k1-asmjs";
+import { sha256 } from "@noble/hashes/sha2.js";
+
+/** Deterministic, non-zero test scalar — valid private key, not a secret. */
+const TEST_PRIVATE_KEY = new Uint8Array(32).fill(0x11);
+
+/** Compressed ephemeral pubkey matching {@link TEST_PRIVATE_KEY}. */
+export const MINT_EPHEMERAL_PUBKEY_COMPRESSED = (() => {
+  const point = ecc.pointFromScalar(TEST_PRIVATE_KEY, true);
+  if (!point) throw new Error("mintTestCwt: invalid test private key");
+  return Buffer.from(point).toString("hex");
+})();
+
+/** COSE algorithm id for ES256K (the value the verifier requires). */
+export const ALG_ES256K = -47;
+
+function cborHead(major: number, arg: number): Uint8Array {
+  const tag = (major & 0x07) << 5;
+  if (arg < 24) return Uint8Array.of(tag | arg);
+  if (arg < 0x100) return Uint8Array.of(tag | 24, arg);
+  if (arg < 0x10000) return Uint8Array.of(tag | 25, (arg >> 8) & 0xff, arg & 0xff);
+  return Uint8Array.of(
+    tag | 26,
+    (arg >>> 24) & 0xff,
+    (arg >> 16) & 0xff,
+    (arg >> 8) & 0xff,
+    arg & 0xff,
+  );
+}
+
+function concat(...parts: Uint8Array[]): Uint8Array {
+  const total = parts.reduce((sum, part) => sum + part.length, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const part of parts) {
+    out.set(part, offset);
+    offset += part.length;
+  }
+  return out;
+}
+
+/** CBOR unsigned integer (major 0). */
+function uint(n: number): Uint8Array {
+  return cborHead(0, n);
+}
+
+/** CBOR negative integer (major 1): encodes -1 - arg. */
+function nint(n: number): Uint8Array {
+  return cborHead(1, -1 - n);
+}
+
+/** CBOR byte string (major 2). */
+function bstr(bytes: Uint8Array): Uint8Array {
+  return concat(cborHead(2, bytes.length), bytes);
+}
+
+/** CBOR text string (major 3). */
+function tstr(text: string): Uint8Array {
+  const bytes = new TextEncoder().encode(text);
+  return concat(cborHead(3, bytes.length), bytes);
+}
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  return Buffer.from(bytes)
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+export interface MintCwtOptions {
+  alg?: number;
+  iss: string;
+  sub: string;
+  aud: string;
+  exp: number;
+  nbf: number;
+  iat: number;
+  /** `cti` bytes; defaults to a single non-zero byte. */
+  cti?: Uint8Array;
+  /**
+   * Override the signature length. The genuine signature is always
+   * computed; when set, it is truncated/padded to this length so the
+   * verifier's structural length check can be exercised.
+   */
+  sigLenOverride?: number;
+}
+
+/** Build a base64url COSE Sign1 CWT signed with the test ephemeral key. */
+export function mintTestCwt(opts: MintCwtOptions): string {
+  const protectedContent = concat(
+    cborHead(5, 1), // map(1)
+    uint(1), // COSE header label: alg
+    nint(opts.alg ?? ALG_ES256K),
+  );
+
+  const cti = opts.cti ?? Uint8Array.of(0x01);
+  const payloadContent = concat(
+    cborHead(5, 7), // map(7) — the seven registered CWT claims
+    uint(1),
+    tstr(opts.iss),
+    uint(2),
+    tstr(opts.sub),
+    uint(3),
+    tstr(opts.aud),
+    uint(4),
+    uint(opts.exp),
+    uint(5),
+    uint(opts.nbf),
+    uint(6),
+    uint(opts.iat),
+    uint(7),
+    bstr(cti),
+  );
+
+  const protectedBstr = bstr(protectedContent);
+  const payloadBstr = bstr(payloadContent);
+
+  // Sig_structure (RFC 8152 §4.4): array(4) of ["Signature1", protected,
+  // external_aad = h'', payload], matching the verifier's reconstruction.
+  const sigStructure = concat(
+    Uint8Array.of(0x84),
+    tstr("Signature1"),
+    protectedBstr,
+    Uint8Array.of(0x40), // empty external_aad byte string
+    payloadBstr,
+  );
+  const digest = sha256(sigStructure);
+  let signature = ecc.sign(digest, TEST_PRIVATE_KEY);
+  if (opts.sigLenOverride !== undefined) {
+    const resized = new Uint8Array(opts.sigLenOverride);
+    resized.set(signature.subarray(0, opts.sigLenOverride));
+    signature = resized;
+  }
+
+  const token = concat(
+    cborHead(6, 18), // tag(18) — COSE_Sign1
+    Uint8Array.of(0x84), // array(4)
+    protectedBstr,
+    Uint8Array.of(0xa0), // unprotected: empty map
+    payloadBstr,
+    bstr(signature),
+  );
+  return base64UrlEncode(token);
+}

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/__tests__/tokenProvider.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/__tests__/tokenProvider.test.ts
@@ -8,6 +8,12 @@ import {
 } from "../tokenProvider";
 
 import {
+  GOLDEN_CWT_AUDIENCE_XONLY,
+  GOLDEN_CWT_EXP,
+  GOLDEN_CWT_SHORT_EXP,
+  GOLDEN_CWT_TOKEN_GRPC,
+  GOLDEN_CWT_TOKEN_JSONRPC,
+  GOLDEN_CWT_TOKEN_JSONRPC_SHORT,
   GOLDEN_EPHEMERAL_PUBKEY_COMPRESSED,
   GOLDEN_EXPIRES_AT,
   GOLDEN_SIGNATURE_HEX,
@@ -43,8 +49,11 @@ function buildResponse(
   overrides: Partial<CreateDepositorTokenResponse> = {},
 ): CreateDepositorTokenResponse {
   return {
-    token: "test-token",
-    expires_at: NOW + 300,
+    // A genuine Rust-issued CWT whose iss/ephemeral match the server
+    // identity fixtures below and whose exp equals `expires_at`, so the
+    // provider's new CWT verification accepts it on the happy path.
+    token: GOLDEN_CWT_TOKEN_JSONRPC,
+    expires_at: GOLDEN_CWT_EXP,
     server_identity: {
       server_pubkey: PINNED_PUBKEY,
       ephemeral_pubkey: GOLDEN_EPHEMERAL_PUBKEY_COMPRESSED,
@@ -88,6 +97,7 @@ describe("VpTokenProvider", () => {
       peginTxid: PEGIN_TXID,
       authAnchorHex: AUTH_ANCHOR,
       pinnedServerPubkey: PINNED_PUBKEY,
+      expectedAudienceXOnlyPubkey: GOLDEN_CWT_AUDIENCE_XONLY,
       authGatedMethods: new Set([
         "vaultProvider_submitDepositorWotsKey",
         "auth_createDepositorToken",
@@ -107,6 +117,7 @@ describe("VpTokenProvider", () => {
       peginTxid: PEGIN_TXID,
       authAnchorHex: AUTH_ANCHOR,
       pinnedServerPubkey: PINNED_PUBKEY,
+      expectedAudienceXOnlyPubkey: GOLDEN_CWT_AUDIENCE_XONLY,
       authGatedMethods: AUTH_GATED_METHODS,
       grpcGatedMethods: new Set(),
       now: () => NOW,
@@ -125,6 +136,7 @@ describe("VpTokenProvider", () => {
       peginTxid: PEGIN_TXID,
       authAnchorHex: AUTH_ANCHOR,
       pinnedServerPubkey: PINNED_PUBKEY,
+      expectedAudienceXOnlyPubkey: GOLDEN_CWT_AUDIENCE_XONLY,
       authGatedMethods: AUTH_GATED_METHODS,
       grpcGatedMethods: new Set(),
       now: () => NOW,
@@ -133,13 +145,13 @@ describe("VpTokenProvider", () => {
     const first = await provider.getToken(
       "vaultProvider_submitDepositorWotsKey",
     );
-    expect(first).toBe("test-token");
+    expect(first).toBe(GOLDEN_CWT_TOKEN_JSONRPC);
 
     // No fetch mock was queued for a second call — cache must serve this.
     const second = await provider.getToken(
       "vaultProvider_submitDepositorWotsKey",
     );
-    expect(second).toBe("test-token");
+    expect(second).toBe(GOLDEN_CWT_TOKEN_JSONRPC);
     expect(
       (global.fetch as unknown as { mock: { calls: unknown[][] } }).mock.calls
         .length,
@@ -147,17 +159,11 @@ describe("VpTokenProvider", () => {
   });
 
   it("re-acquires after invalidate()", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi
-        .fn()
-        .mockResolvedValueOnce(
-          createJsonRpcSuccessResponse(buildResponse({ token: "token-1" })),
-        )
-        .mockResolvedValueOnce(
-          createJsonRpcSuccessResponse(buildResponse({ token: "token-2" }), 2),
-        ),
-    );
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(createJsonRpcSuccessResponse(buildResponse()))
+      .mockResolvedValueOnce(createJsonRpcSuccessResponse(buildResponse(), 2));
+    vi.stubGlobal("fetch", mockFetch);
 
     const client = createClient();
     const provider = new VpTokenProvider({
@@ -165,6 +171,7 @@ describe("VpTokenProvider", () => {
       peginTxid: PEGIN_TXID,
       authAnchorHex: AUTH_ANCHOR,
       pinnedServerPubkey: PINNED_PUBKEY,
+      expectedAudienceXOnlyPubkey: GOLDEN_CWT_AUDIENCE_XONLY,
       authGatedMethods: AUTH_GATED_METHODS,
       grpcGatedMethods: new Set(),
       now: () => NOW,
@@ -173,14 +180,17 @@ describe("VpTokenProvider", () => {
     const first = await provider.getToken(
       "vaultProvider_submitDepositorWotsKey",
     );
-    expect(first).toBe("token-1");
+    expect(first).toBe(GOLDEN_CWT_TOKEN_JSONRPC);
 
     provider.invalidate();
 
+    // After invalidate the cache is empty, so this must hit the network
+    // again rather than serve the evicted token.
     const second = await provider.getToken(
       "vaultProvider_submitDepositorWotsKey",
     );
-    expect(second).toBe("token-2");
+    expect(second).toBe(GOLDEN_CWT_TOKEN_JSONRPC);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
   });
 
   it("refreshes when cached token is within refreshSkewSecs of expiry", async () => {
@@ -190,14 +200,15 @@ describe("VpTokenProvider", () => {
         .fn()
         .mockResolvedValueOnce(
           createJsonRpcSuccessResponse(
+            // Short-lived token: exp = GOLDEN_CWT_SHORT_EXP = NOW + 40.
             buildResponse({
-              token: "token-1",
-              expires_at: NOW + 40, // close to now
+              token: GOLDEN_CWT_TOKEN_JSONRPC_SHORT,
+              expires_at: GOLDEN_CWT_SHORT_EXP,
             }),
           ),
         )
         .mockResolvedValueOnce(
-          createJsonRpcSuccessResponse(buildResponse({ token: "token-2" }), 2),
+          createJsonRpcSuccessResponse(buildResponse(), 2),
         ),
     );
 
@@ -208,6 +219,7 @@ describe("VpTokenProvider", () => {
       peginTxid: PEGIN_TXID,
       authAnchorHex: AUTH_ANCHOR,
       pinnedServerPubkey: PINNED_PUBKEY,
+      expectedAudienceXOnlyPubkey: GOLDEN_CWT_AUDIENCE_XONLY,
       authGatedMethods: AUTH_GATED_METHODS,
       grpcGatedMethods: new Set(),
       refreshSkewSecs: 30,
@@ -217,7 +229,7 @@ describe("VpTokenProvider", () => {
     const first = await provider.getToken(
       "vaultProvider_submitDepositorWotsKey",
     );
-    expect(first).toBe("token-1");
+    expect(first).toBe(GOLDEN_CWT_TOKEN_JSONRPC_SHORT);
 
     // Advance clock past (expires_at - skew) = NOW + 10
     fakeNow = NOW + 11;
@@ -225,7 +237,7 @@ describe("VpTokenProvider", () => {
     const second = await provider.getToken(
       "vaultProvider_submitDepositorWotsKey",
     );
-    expect(second).toBe("token-2");
+    expect(second).toBe(GOLDEN_CWT_TOKEN_JSONRPC);
   });
 
   it("propagates server-identity errors from acquire", async () => {
@@ -246,6 +258,7 @@ describe("VpTokenProvider", () => {
       peginTxid: PEGIN_TXID,
       authAnchorHex: AUTH_ANCHOR,
       pinnedServerPubkey: PINNED_PUBKEY,
+      expectedAudienceXOnlyPubkey: GOLDEN_CWT_AUDIENCE_XONLY,
       authGatedMethods: AUTH_GATED_METHODS,
       grpcGatedMethods: new Set(),
       now: () => NOW,
@@ -268,6 +281,7 @@ describe("VpTokenProvider", () => {
       peginTxid: PEGIN_TXID,
       authAnchorHex: AUTH_ANCHOR,
       pinnedServerPubkey: PINNED_PUBKEY,
+      expectedAudienceXOnlyPubkey: GOLDEN_CWT_AUDIENCE_XONLY,
       authGatedMethods: AUTH_GATED_METHODS,
       grpcGatedMethods: new Set(),
       now: () => NOW,
@@ -279,9 +293,9 @@ describe("VpTokenProvider", () => {
       provider.getToken("vaultProvider_submitDepositorWotsKey"),
     ]);
 
-    expect(a).toBe("test-token");
-    expect(b).toBe("test-token");
-    expect(c).toBe("test-token");
+    expect(a).toBe(GOLDEN_CWT_TOKEN_JSONRPC);
+    expect(b).toBe(GOLDEN_CWT_TOKEN_JSONRPC);
+    expect(c).toBe(GOLDEN_CWT_TOKEN_JSONRPC);
     expect(mockFetch).toHaveBeenCalledOnce();
   });
 
@@ -311,10 +325,7 @@ describe("VpTokenProvider", () => {
         )
         // Second acquire: server returns a valid response.
         .mockResolvedValueOnce(
-          createJsonRpcSuccessResponse(
-            buildResponse({ token: "recovery-token" }),
-            2,
-          ),
+          createJsonRpcSuccessResponse(buildResponse(), 2),
         ),
     );
 
@@ -324,6 +335,7 @@ describe("VpTokenProvider", () => {
       peginTxid: PEGIN_TXID,
       authAnchorHex: AUTH_ANCHOR,
       pinnedServerPubkey: PINNED_PUBKEY,
+      expectedAudienceXOnlyPubkey: GOLDEN_CWT_AUDIENCE_XONLY,
       authGatedMethods: AUTH_GATED_METHODS,
       grpcGatedMethods: new Set(),
       now: () => NOW,
@@ -343,7 +355,7 @@ describe("VpTokenProvider", () => {
     const recovered = await provider.getToken(
       "vaultProvider_submitDepositorWotsKey",
     );
-    expect(recovered).toBe("recovery-token");
+    expect(recovered).toBe(GOLDEN_CWT_TOKEN_JSONRPC);
   });
 
   // Strictly mid-await invalidate. The earlier test sequences
@@ -366,7 +378,7 @@ describe("VpTokenProvider", () => {
         .fn()
         .mockReturnValueOnce(firstResponse)
         .mockResolvedValueOnce(
-          createJsonRpcSuccessResponse(buildResponse({ token: "after-race" })),
+          createJsonRpcSuccessResponse(buildResponse()),
         ),
     );
 
@@ -376,6 +388,7 @@ describe("VpTokenProvider", () => {
       peginTxid: PEGIN_TXID,
       authAnchorHex: AUTH_ANCHOR,
       pinnedServerPubkey: PINNED_PUBKEY,
+      expectedAudienceXOnlyPubkey: GOLDEN_CWT_AUDIENCE_XONLY,
       authGatedMethods: AUTH_GATED_METHODS,
       grpcGatedMethods: new Set(),
       now: () => NOW,
@@ -403,7 +416,7 @@ describe("VpTokenProvider", () => {
     const recovered = await provider.getToken(
       "vaultProvider_submitDepositorWotsKey",
     );
-    expect(recovered).toBe("after-race");
+    expect(recovered).toBe(GOLDEN_CWT_TOKEN_JSONRPC);
   });
 
   // --- gRPC bootstrap path ---
@@ -412,7 +425,9 @@ describe("VpTokenProvider", () => {
     const mockFetch = vi
       .fn()
       .mockResolvedValueOnce(
-        createJsonRpcSuccessResponse(buildResponse({ token: "grpc-token" })),
+        createJsonRpcSuccessResponse(
+          buildResponse({ token: GOLDEN_CWT_TOKEN_GRPC }),
+        ),
       );
     vi.stubGlobal("fetch", mockFetch);
 
@@ -422,6 +437,7 @@ describe("VpTokenProvider", () => {
       peginTxid: PEGIN_TXID,
       authAnchorHex: AUTH_ANCHOR,
       pinnedServerPubkey: PINNED_PUBKEY,
+      expectedAudienceXOnlyPubkey: GOLDEN_CWT_AUDIENCE_XONLY,
       authGatedMethods: AUTH_GATED_METHODS,
       grpcGatedMethods: GRPC_GATED_METHODS,
       now: () => NOW,
@@ -430,7 +446,7 @@ describe("VpTokenProvider", () => {
     const token = await provider.getToken(
       "vaultProvider_requestDepositorClaimerArtifacts",
     );
-    expect(token).toBe("grpc-token");
+    expect(token).toBe(GOLDEN_CWT_TOKEN_GRPC);
 
     // The bootstrap RPC must be the gRPC variant — bearer subject is what
     // distinguishes the two paths server-side.
@@ -443,12 +459,10 @@ describe("VpTokenProvider", () => {
   it("caches jsonrpc and grpc tokens in independent slots", async () => {
     const mockFetch = vi
       .fn()
-      .mockResolvedValueOnce(
-        createJsonRpcSuccessResponse(buildResponse({ token: "jsonrpc-token" })),
-      )
+      .mockResolvedValueOnce(createJsonRpcSuccessResponse(buildResponse()))
       .mockResolvedValueOnce(
         createJsonRpcSuccessResponse(
-          buildResponse({ token: "grpc-token" }),
+          buildResponse({ token: GOLDEN_CWT_TOKEN_GRPC }),
           2,
         ),
       );
@@ -460,6 +474,7 @@ describe("VpTokenProvider", () => {
       peginTxid: PEGIN_TXID,
       authAnchorHex: AUTH_ANCHOR,
       pinnedServerPubkey: PINNED_PUBKEY,
+      expectedAudienceXOnlyPubkey: GOLDEN_CWT_AUDIENCE_XONLY,
       authGatedMethods: AUTH_GATED_METHODS,
       grpcGatedMethods: GRPC_GATED_METHODS,
       now: () => NOW,
@@ -471,8 +486,8 @@ describe("VpTokenProvider", () => {
     const grpcToken = await provider.getToken(
       "vaultProvider_requestDepositorClaimerArtifacts",
     );
-    expect(jsonRpcToken).toBe("jsonrpc-token");
-    expect(grpcToken).toBe("grpc-token");
+    expect(jsonRpcToken).toBe(GOLDEN_CWT_TOKEN_JSONRPC);
+    expect(grpcToken).toBe(GOLDEN_CWT_TOKEN_GRPC);
     expect(mockFetch).toHaveBeenCalledTimes(2);
 
     // Re-asking for each must hit cache (no third fetch).
@@ -482,25 +497,29 @@ describe("VpTokenProvider", () => {
     const grpcAgain = await provider.getToken(
       "vaultProvider_requestDepositorClaimerArtifacts",
     );
-    expect(jsonRpcAgain).toBe("jsonrpc-token");
-    expect(grpcAgain).toBe("grpc-token");
+    expect(jsonRpcAgain).toBe(GOLDEN_CWT_TOKEN_JSONRPC);
+    expect(grpcAgain).toBe(GOLDEN_CWT_TOKEN_GRPC);
     expect(mockFetch).toHaveBeenCalledTimes(2);
   });
 
   it("invalidate() clears both slots", async () => {
     const mockFetch = vi
       .fn()
+      .mockResolvedValueOnce(createJsonRpcSuccessResponse(buildResponse()))
       .mockResolvedValueOnce(
-        createJsonRpcSuccessResponse(buildResponse({ token: "jsonrpc-1" })),
+        createJsonRpcSuccessResponse(
+          buildResponse({ token: GOLDEN_CWT_TOKEN_GRPC }),
+          2,
+        ),
       )
       .mockResolvedValueOnce(
-        createJsonRpcSuccessResponse(buildResponse({ token: "grpc-1" }), 2),
+        createJsonRpcSuccessResponse(buildResponse(), 3),
       )
       .mockResolvedValueOnce(
-        createJsonRpcSuccessResponse(buildResponse({ token: "jsonrpc-2" }), 3),
-      )
-      .mockResolvedValueOnce(
-        createJsonRpcSuccessResponse(buildResponse({ token: "grpc-2" }), 4),
+        createJsonRpcSuccessResponse(
+          buildResponse({ token: GOLDEN_CWT_TOKEN_GRPC }),
+          4,
+        ),
       );
     vi.stubGlobal("fetch", mockFetch);
 
@@ -510,6 +529,7 @@ describe("VpTokenProvider", () => {
       peginTxid: PEGIN_TXID,
       authAnchorHex: AUTH_ANCHOR,
       pinnedServerPubkey: PINNED_PUBKEY,
+      expectedAudienceXOnlyPubkey: GOLDEN_CWT_AUDIENCE_XONLY,
       authGatedMethods: AUTH_GATED_METHODS,
       grpcGatedMethods: GRPC_GATED_METHODS,
       now: () => NOW,
@@ -517,21 +537,22 @@ describe("VpTokenProvider", () => {
 
     expect(
       await provider.getToken("vaultProvider_submitDepositorWotsKey"),
-    ).toBe("jsonrpc-1");
+    ).toBe(GOLDEN_CWT_TOKEN_JSONRPC);
     expect(
       await provider.getToken("vaultProvider_requestDepositorClaimerArtifacts"),
-    ).toBe("grpc-1");
+    ).toBe(GOLDEN_CWT_TOKEN_GRPC);
 
     // One invalidate must evict both slots (the client doesn't tell us
-    // which subject expired, so we stay correct by clearing both).
+    // which subject expired, so we stay correct by clearing both). Each
+    // re-acquire hits the network again (4 fetches total).
     provider.invalidate();
 
     expect(
       await provider.getToken("vaultProvider_submitDepositorWotsKey"),
-    ).toBe("jsonrpc-2");
+    ).toBe(GOLDEN_CWT_TOKEN_JSONRPC);
     expect(
       await provider.getToken("vaultProvider_requestDepositorClaimerArtifacts"),
-    ).toBe("grpc-2");
+    ).toBe(GOLDEN_CWT_TOKEN_GRPC);
     expect(mockFetch).toHaveBeenCalledTimes(4);
   });
 
@@ -543,6 +564,7 @@ describe("VpTokenProvider", () => {
       peginTxid: PEGIN_TXID,
       authAnchorHex: AUTH_ANCHOR,
       pinnedServerPubkey: PINNED_PUBKEY,
+      expectedAudienceXOnlyPubkey: GOLDEN_CWT_AUDIENCE_XONLY,
       authGatedMethods: AUTH_GATED_METHODS,
       grpcGatedMethods: new Set([
         "vaultProvider_requestDepositorClaimerArtifacts",

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/__tests__/tokenProvider.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/__tests__/tokenProvider.test.ts
@@ -6,6 +6,7 @@ import {
   type CreateDepositorTokenResponse,
   VpTokenProvider,
 } from "../tokenProvider";
+import { CwtVerificationError } from "../verifyDepositorCwt";
 
 import {
   GOLDEN_CWT_AUDIENCE_XONLY,
@@ -238,6 +239,52 @@ describe("VpTokenProvider", () => {
       "vaultProvider_submitDepositorWotsKey",
     );
     expect(second).toBe(GOLDEN_CWT_TOKEN_JSONRPC);
+  });
+
+  it("throws and does not cache when the wire token fails CWT verification", async () => {
+    // A response whose server_identity proof is genuine but whose bearer
+    // token has been tampered with: the COSE signature no longer verifies,
+    // so acquire must throw and leave the cache empty (the bad token never
+    // reaches a downstream authenticated call). The next acquire re-fetches.
+    const tamperedIndex = GOLDEN_CWT_TOKEN_JSONRPC.length - 10;
+    const tamperedChar =
+      GOLDEN_CWT_TOKEN_JSONRPC[tamperedIndex] === "A" ? "B" : "A";
+    const tamperedToken =
+      GOLDEN_CWT_TOKEN_JSONRPC.slice(0, tamperedIndex) +
+      tamperedChar +
+      GOLDEN_CWT_TOKEN_JSONRPC.slice(tamperedIndex + 1);
+
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        createJsonRpcSuccessResponse(buildResponse({ token: tamperedToken })),
+      )
+      .mockResolvedValueOnce(createJsonRpcSuccessResponse(buildResponse(), 2));
+    vi.stubGlobal("fetch", mockFetch);
+
+    const client = createClient();
+    const provider = new VpTokenProvider({
+      client,
+      peginTxid: PEGIN_TXID,
+      authAnchorHex: AUTH_ANCHOR,
+      pinnedServerPubkey: PINNED_PUBKEY,
+      expectedAudienceXOnlyPubkey: GOLDEN_CWT_AUDIENCE_XONLY,
+      authGatedMethods: AUTH_GATED_METHODS,
+      grpcGatedMethods: new Set(),
+      now: () => NOW,
+    });
+
+    await expect(
+      provider.getToken("vaultProvider_submitDepositorWotsKey"),
+    ).rejects.toBeInstanceOf(CwtVerificationError);
+
+    // Cache stayed empty — the next acquire must hit the network again and
+    // serve the now-valid token rather than a cached tampered one.
+    const recovered = await provider.getToken(
+      "vaultProvider_submitDepositorWotsKey",
+    );
+    expect(recovered).toBe(GOLDEN_CWT_TOKEN_JSONRPC);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
   });
 
   it("propagates server-identity errors from acquire", async () => {

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/__tests__/tokenRegistry.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/__tests__/tokenRegistry.test.ts
@@ -9,17 +9,23 @@ import {
 } from "../tokenRegistry";
 
 import {
+  GOLDEN_CWT_AUDIENCE_XONLY,
   GOLDEN_SIGNING_KEY_XONLY,
 } from "./goldenVectors";
 
 // The gating tests drive a real `getToken` acquire, which verifies the
-// server-identity proof. That check is exercised exhaustively in
-// serverIdentity / tokenProvider specs; here we only care which
-// bootstrap method the registry-built provider calls, so stub it out to
-// stay independent of the golden proof's wall-clock.
+// server-identity proof and the issued CWT. Both checks are exercised
+// exhaustively in serverIdentity / tokenProvider / verifyDepositorCwt
+// specs; here we only care which bootstrap method the registry-built
+// provider calls, so stub them out to stay independent of the golden
+// fixtures' wall-clock and token bytes.
 vi.mock("../serverIdentity", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../serverIdentity")>()),
   verifyServerIdentity: vi.fn(),
+}));
+vi.mock("../verifyDepositorCwt", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../verifyDepositorCwt")>()),
+  verifyDepositorCwt: vi.fn(),
 }));
 
 const PEGIN_TXID_A = "a".repeat(64);
@@ -51,6 +57,7 @@ function buildInput(
     peginTxid: PEGIN_TXID_A,
     authAnchorHex: AUTH_ANCHOR_HEX,
     pinnedServerPubkey: PINNED_PUBKEY,
+    expectedAudienceXOnlyPubkey: GOLDEN_CWT_AUDIENCE_XONLY,
     ...overrides,
   };
 }
@@ -112,6 +119,20 @@ describe("VpTokenRegistry", () => {
         buildInput({ pinnedServerPubkey: ALT_PINNED_PUBKEY }),
       ),
     ).toThrow(/already bound to pinnedServerPubkey/);
+  });
+
+  it("throws on getOrCreate with the same peginTxid but a different expectedAudienceXOnlyPubkey", () => {
+    // The token's CWT `aud` is bound to the depositor; a second caller
+    // disagreeing on the depositor pubkey must fail loud rather than
+    // share a provider that would reject the issued token's audience.
+    registry.getOrCreate(
+      buildInput({ expectedAudienceXOnlyPubkey: GOLDEN_CWT_AUDIENCE_XONLY }),
+    );
+    expect(() =>
+      registry.getOrCreate(
+        buildInput({ expectedAudienceXOnlyPubkey: "f".repeat(64) }),
+      ),
+    ).toThrow(/already bound to expectedAudienceXOnlyPubkey/);
   });
 
   it("throws on getOrCreate reuse with a different enableGrpcArtifactAuth", () => {

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/__tests__/verifyDepositorCwt.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/__tests__/verifyDepositorCwt.test.ts
@@ -21,6 +21,12 @@ import {
   GOLDEN_EXPIRES_AT,
   GOLDEN_SIGNING_KEY_XONLY,
 } from "./goldenVectors";
+import {
+  ALG_ES256K,
+  MINT_EPHEMERAL_PUBKEY_COMPRESSED,
+  type MintCwtOptions,
+  mintTestCwt,
+} from "./mintTestCwt";
 
 // Wall clock chosen between the tokens' nbf (GOLDEN_CWT_NBF) and exp
 // (GOLDEN_CWT_EXP), and within the server identity's lifetime.
@@ -184,6 +190,114 @@ describe("verifyDepositorCwt", () => {
     expectReason(
       baseInput({ expectedIssuerXOnlyPubkey: "xyz" }),
       "invalid_input",
+    );
+  });
+});
+
+// The genuine golden tokens are signed by the Rust issuer's key, so they
+// can only reach the checks that run *before* signature verification.
+// These cases mint a token with a test signing key (and hand the verifier
+// the matching ephemeral pubkey) so the signature genuinely verifies and
+// the post-signature claim-rejection paths become reachable.
+describe("verifyDepositorCwt — crafted negative tokens", () => {
+  const MINT_ISS = GOLDEN_SIGNING_KEY_XONLY;
+  const MINT_AUD = GOLDEN_CWT_AUDIENCE_XONLY;
+  const MINT_NOW = 1_700_000_000;
+  /** COSE alg id for ES256 (secp256r1) — a valid alg, but not the ES256K we pin. */
+  const ALG_ES256 = -7;
+
+  function mintedInput(
+    claims: Partial<MintCwtOptions> = {},
+  ): VerifyDepositorCwtInput {
+    const exp = claims.exp ?? MINT_NOW + 1000;
+    const token = mintTestCwt({
+      alg: ALG_ES256K,
+      iss: MINT_ISS,
+      sub: CWT_SUBJECT_JSONRPC,
+      aud: MINT_AUD,
+      exp,
+      nbf: MINT_NOW - 1000,
+      iat: MINT_NOW - 1000,
+      ...claims,
+    });
+    return {
+      token,
+      ephemeralPubkeyHex: MINT_EPHEMERAL_PUBKEY_COMPRESSED,
+      expectedIssuerXOnlyPubkey: MINT_ISS,
+      expectedSubject: CWT_SUBJECT_JSONRPC,
+      expectedAudienceXOnlyPubkey: MINT_AUD,
+      responseExpiresAt: exp,
+      serverIdentityExpiresAt: exp,
+      now: MINT_NOW,
+    };
+  }
+
+  it("accepts a token minted with the test signing key (minter sanity)", () => {
+    const claims = verifyDepositorCwt(mintedInput());
+    expect(claims.audience).toBe(MINT_AUD);
+    expect(claims.subject).toBe(CWT_SUBJECT_JSONRPC);
+  });
+
+  it("rejects a token whose protected header pins a non-ES256K algorithm", () => {
+    expectReason(mintedInput({ alg: ALG_ES256 }), "unexpected_algorithm");
+  });
+
+  it("rejects a token whose signature is not 64 bytes", () => {
+    expectReason(mintedInput({ sigLenOverride: 63 }), "invalid_token_structure");
+  });
+
+  it("rejects a token whose aud is not a 32-byte x-only pubkey", () => {
+    expectReason(mintedInput({ aud: "not-a-pubkey" }), "invalid_claims");
+  });
+
+  it("rejects a token whose iat is after its exp", () => {
+    expectReason(
+      mintedInput({ exp: MINT_NOW + 1000, iat: MINT_NOW + 1001 }),
+      "invalid_claims",
+    );
+  });
+
+  it("rejects a token issued in the future (iat > now)", () => {
+    expectReason(mintedInput({ iat: MINT_NOW + 1 }), "invalid_claims");
+  });
+
+  it("rejects a token with an empty cti", () => {
+    expectReason(mintedInput({ cti: new Uint8Array(0) }), "invalid_claims");
+  });
+
+  it("rejects a token with trailing bytes after the COSE Sign1 structure", () => {
+    // Append a stray byte to an otherwise-valid minted token. base64url of
+    // the extra byte decodes to trailing bytes the verifier must reject.
+    const valid = mintTestCwt({
+      alg: ALG_ES256K,
+      iss: MINT_ISS,
+      sub: CWT_SUBJECT_JSONRPC,
+      aud: MINT_AUD,
+      exp: MINT_NOW + 1000,
+      nbf: MINT_NOW - 1000,
+      iat: MINT_NOW - 1000,
+    });
+    const tokenBytes = Buffer.from(
+      valid.replace(/-/g, "+").replace(/_/g, "/"),
+      "base64",
+    );
+    const withTrailer = Buffer.concat([tokenBytes, Buffer.of(0x00)])
+      .toString("base64")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+    expectReason(
+      {
+        token: withTrailer,
+        ephemeralPubkeyHex: MINT_EPHEMERAL_PUBKEY_COMPRESSED,
+        expectedIssuerXOnlyPubkey: MINT_ISS,
+        expectedSubject: CWT_SUBJECT_JSONRPC,
+        expectedAudienceXOnlyPubkey: MINT_AUD,
+        responseExpiresAt: MINT_NOW + 1000,
+        serverIdentityExpiresAt: MINT_NOW + 1000,
+        now: MINT_NOW,
+      },
+      "invalid_token_structure",
     );
   });
 });

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/__tests__/verifyDepositorCwt.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/__tests__/verifyDepositorCwt.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CWT_SUBJECT_GRPC,
+  CWT_SUBJECT_JSONRPC,
+  type CwtVerificationReason,
+  CwtVerificationError,
+  type VerifyDepositorCwtInput,
+  verifyDepositorCwt,
+} from "../verifyDepositorCwt";
+
+import {
+  GOLDEN_CWT_AUDIENCE_XONLY,
+  GOLDEN_CWT_EXP,
+  GOLDEN_CWT_NBF,
+  GOLDEN_CWT_SHORT_EXP,
+  GOLDEN_CWT_TOKEN_GRPC,
+  GOLDEN_CWT_TOKEN_JSONRPC,
+  GOLDEN_CWT_TOKEN_JSONRPC_SHORT,
+  GOLDEN_EPHEMERAL_PUBKEY_COMPRESSED,
+  GOLDEN_EXPIRES_AT,
+  GOLDEN_SIGNING_KEY_XONLY,
+} from "./goldenVectors";
+
+// Wall clock chosen between the tokens' nbf (GOLDEN_CWT_NBF) and exp
+// (GOLDEN_CWT_EXP), and within the server identity's lifetime.
+const NOW = 1_699_997_000;
+
+function baseInput(
+  overrides: Partial<VerifyDepositorCwtInput> = {},
+): VerifyDepositorCwtInput {
+  return {
+    token: GOLDEN_CWT_TOKEN_JSONRPC,
+    ephemeralPubkeyHex: GOLDEN_EPHEMERAL_PUBKEY_COMPRESSED,
+    expectedIssuerXOnlyPubkey: GOLDEN_SIGNING_KEY_XONLY,
+    expectedSubject: CWT_SUBJECT_JSONRPC,
+    expectedAudienceXOnlyPubkey: GOLDEN_CWT_AUDIENCE_XONLY,
+    responseExpiresAt: GOLDEN_CWT_EXP,
+    serverIdentityExpiresAt: GOLDEN_EXPIRES_AT,
+    now: NOW,
+    ...overrides,
+  };
+}
+
+function expectReason(
+  input: VerifyDepositorCwtInput,
+  reason: CwtVerificationReason,
+): void {
+  try {
+    verifyDepositorCwt(input);
+  } catch (error) {
+    expect(error).toBeInstanceOf(CwtVerificationError);
+    expect((error as CwtVerificationError).reason).toBe(reason);
+    return;
+  }
+  throw new Error(`expected verifyDepositorCwt to throw ${reason}`);
+}
+
+describe("verifyDepositorCwt", () => {
+  it("verifies a genuine JSON-RPC-subject token and returns its claims", () => {
+    const claims = verifyDepositorCwt(baseInput());
+
+    expect(claims.issuer.toLowerCase()).toBe(GOLDEN_SIGNING_KEY_XONLY);
+    expect(claims.subject).toBe(CWT_SUBJECT_JSONRPC);
+    expect(claims.audience).toBe(GOLDEN_CWT_AUDIENCE_XONLY);
+    expect(claims.expiresAt).toBe(GOLDEN_CWT_EXP);
+    expect(claims.notBefore).toBe(GOLDEN_CWT_NBF);
+    expect(claims.issuedAt).toBe(GOLDEN_CWT_NBF);
+  });
+
+  it("verifies a genuine gRPC-subject token", () => {
+    const claims = verifyDepositorCwt(
+      baseInput({
+        token: GOLDEN_CWT_TOKEN_GRPC,
+        expectedSubject: CWT_SUBJECT_GRPC,
+      }),
+    );
+    expect(claims.subject).toBe(CWT_SUBJECT_GRPC);
+  });
+
+  it("rejects a token whose signature has been tampered with", () => {
+    // Flip one base64url char well inside the trailing COSE signature
+    // (the final char carries non-significant bits, so avoid it).
+    const index = GOLDEN_CWT_TOKEN_JSONRPC.length - 10;
+    const original = GOLDEN_CWT_TOKEN_JSONRPC[index];
+    const replacement = original === "A" ? "B" : "A";
+    const tampered =
+      GOLDEN_CWT_TOKEN_JSONRPC.slice(0, index) +
+      replacement +
+      GOLDEN_CWT_TOKEN_JSONRPC.slice(index + 1);
+    expect(tampered).not.toBe(GOLDEN_CWT_TOKEN_JSONRPC);
+    expectReason(
+      baseInput({ token: tampered }),
+      "signature_verification_failed",
+    );
+  });
+
+  it("rejects a token verified against the wrong ephemeral key", () => {
+    // Same x-coordinate, flipped parity prefix → a different valid point.
+    const wrongEphemeral =
+      "03" + GOLDEN_EPHEMERAL_PUBKEY_COMPRESSED.slice(2);
+    expectReason(
+      baseInput({ ephemeralPubkeyHex: wrongEphemeral }),
+      "signature_verification_failed",
+    );
+  });
+
+  it("rejects a token whose issuer is not the pinned server pubkey", () => {
+    expectReason(
+      baseInput({ expectedIssuerXOnlyPubkey: "a".repeat(64) }),
+      "issuer_mismatch",
+    );
+  });
+
+  it("rejects a JSON-RPC token presented for the gRPC subject", () => {
+    expectReason(
+      baseInput({ expectedSubject: CWT_SUBJECT_GRPC }),
+      "subject_mismatch",
+    );
+  });
+
+  it("rejects a token minted for a different depositor", () => {
+    expectReason(
+      baseInput({ expectedAudienceXOnlyPubkey: "b".repeat(64) }),
+      "audience_mismatch",
+    );
+  });
+
+  it("rejects a token that is not yet valid", () => {
+    expectReason(baseInput({ now: GOLDEN_CWT_NBF - 1 }), "token_not_yet_valid");
+  });
+
+  it("rejects an expired token", () => {
+    expectReason(baseInput({ now: GOLDEN_CWT_EXP }), "token_expired");
+  });
+
+  it("rejects when the wire expires_at disagrees with the token exp", () => {
+    expectReason(
+      baseInput({ responseExpiresAt: GOLDEN_CWT_EXP + 1 }),
+      "expiry_mismatch",
+    );
+  });
+
+  it("rejects when the server identity expires before the token", () => {
+    expectReason(
+      baseInput({ serverIdentityExpiresAt: GOLDEN_CWT_EXP - 1 }),
+      "server_identity_expires_before_token",
+    );
+  });
+
+  it("verifies the short-lived token only within its window", () => {
+    const claims = verifyDepositorCwt(
+      baseInput({
+        token: GOLDEN_CWT_TOKEN_JSONRPC_SHORT,
+        responseExpiresAt: GOLDEN_CWT_SHORT_EXP,
+        now: GOLDEN_CWT_SHORT_EXP - 1,
+      }),
+    );
+    expect(claims.expiresAt).toBe(GOLDEN_CWT_SHORT_EXP);
+
+    expectReason(
+      baseInput({
+        token: GOLDEN_CWT_TOKEN_JSONRPC_SHORT,
+        responseExpiresAt: GOLDEN_CWT_SHORT_EXP,
+        now: GOLDEN_CWT_SHORT_EXP,
+      }),
+      "token_expired",
+    );
+  });
+
+  it("rejects a structurally invalid token", () => {
+    // Valid base64url, but the bytes are not a COSE Sign1 tagged value.
+    expectReason(baseInput({ token: "AA" }), "invalid_token_structure");
+  });
+
+  it("rejects a token with invalid base64url characters", () => {
+    expectReason(
+      baseInput({ token: "not valid base64url!!" }),
+      "invalid_token_structure",
+    );
+  });
+
+  it("rejects a malformed expected issuer pubkey", () => {
+    expectReason(
+      baseInput({ expectedIssuerXOnlyPubkey: "xyz" }),
+      "invalid_input",
+    );
+  });
+});

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/cborDecode.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/cborDecode.ts
@@ -42,6 +42,16 @@ const SIMPLE_FALSE = 20;
 const SIMPLE_TRUE = 21;
 const SIMPLE_NULL = 22;
 
+/**
+ * Maximum CBOR nesting depth. Mirrors the issuer's recursion cap (256 in
+ * btc-vault's `ciborium` stack). The COSE protected header is decoded
+ * *before* the signature is verified, so without this bound a
+ * malicious/MITM'd VP could send a deeply-nested blob and crash token
+ * acquisition with an uncatchable stack overflow. Far below the JS call
+ * stack limit, so it converts that DoS into a catchable decode error.
+ */
+const MAX_NESTING_DEPTH = 256;
+
 /** A decoded CBOR data item. Maps preserve key insertion order. */
 export type CborValue =
   | number
@@ -150,8 +160,19 @@ export class CborReader {
     return this.readBytes(head.arg);
   }
 
-  /** Read the next complete data item as a decoded {@link CborValue}. */
-  readValue(): CborValue {
+  /**
+   * Read the next complete data item as a decoded {@link CborValue}.
+   *
+   * `depth` tracks the current nesting level so a deeply-nested blob is
+   * rejected with a {@link CborDecodeError} rather than overflowing the
+   * native call stack (see {@link MAX_NESTING_DEPTH}).
+   */
+  readValue(depth = 0): CborValue {
+    if (depth > MAX_NESTING_DEPTH) {
+      throw new CborDecodeError(
+        `nesting exceeds maximum depth ${MAX_NESTING_DEPTH}`,
+      );
+    }
     const head = this.readHead();
     switch (head.major) {
       case MAJOR_UNSIGNED_INT:
@@ -168,21 +189,21 @@ export class CborReader {
       case MAJOR_ARRAY: {
         const items: CborValue[] = [];
         for (let i = 0; i < head.arg; i++) {
-          items.push(this.readValue());
+          items.push(this.readValue(depth + 1));
         }
         return items;
       }
       case MAJOR_MAP: {
         const map = new Map<CborValue, CborValue>();
         for (let i = 0; i < head.arg; i++) {
-          const key = this.readValue();
-          const value = this.readValue();
+          const key = this.readValue(depth + 1);
+          const value = this.readValue(depth + 1);
           map.set(key, value);
         }
         return map;
       }
       case MAJOR_TAG:
-        return { tag: head.arg, value: this.readValue() };
+        return { tag: head.arg, value: this.readValue(depth + 1) };
       case MAJOR_SIMPLE:
         if (head.arg === SIMPLE_FALSE) return false;
         if (head.arg === SIMPLE_TRUE) return true;
@@ -196,7 +217,20 @@ export class CborReader {
   }
 }
 
-/** Decode a single CBOR item from `bytes`. Trailing bytes are ignored. */
+/**
+ * Decode a single CBOR item from `bytes`, rejecting any trailing bytes.
+ *
+ * Used to parse the COSE protected header and CWT claims set — both are
+ * exactly one top-level item, so a valid prefix followed by extra bytes
+ * is a malformed structure, not a benign tail. Strict consumption keeps
+ * the parser from silently accepting a token a stricter CWT/COSE
+ * consumer would interpret differently.
+ */
 export function decodeCbor(bytes: Uint8Array): CborValue {
-  return new CborReader(bytes).readValue();
+  const reader = new CborReader(bytes);
+  const value = reader.readValue();
+  if (reader.pos !== bytes.length) {
+    throw new CborDecodeError("trailing bytes after top-level item");
+  }
+  return value;
 }

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/cborDecode.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/cborDecode.ts
@@ -1,0 +1,202 @@
+/**
+ * Minimal CBOR decoder — the read-side counterpart to {@link ./cbor}.
+ *
+ * Decodes only the subset needed to verify a vault-provider CWT bearer
+ * token (RFC 8392) wrapped in a COSE Sign1 envelope (RFC 8152): tagged
+ * values, definite-length arrays and maps, byte/text strings, and
+ * unsigned/negative integers. Indefinite-length items, floats, and
+ * big-number tags are intentionally rejected — the issuer
+ * (btc-vault's `coset`/`ciborium` stack) never emits them for this
+ * shape, so accepting them would only widen the parser's attack
+ * surface.
+ *
+ * The decoder is a cursor over a single buffer. {@link CborReader.pos}
+ * is public so callers can slice the exact encoded byte range of an
+ * item (head + content) — required to reconstruct the COSE
+ * `Sig_structure` byte-for-byte from the token's own protected-header
+ * and payload byte strings.
+ *
+ * @module tbv/core/clients/vault-provider/auth/cborDecode
+ */
+
+/** CBOR major types (the high 3 bits of the initial byte). */
+const MAJOR_UNSIGNED_INT = 0;
+const MAJOR_NEGATIVE_INT = 1;
+const MAJOR_BYTE_STRING = 2;
+const MAJOR_TEXT_STRING = 3;
+const MAJOR_ARRAY = 4;
+const MAJOR_MAP = 5;
+const MAJOR_TAG = 6;
+const MAJOR_SIMPLE = 7;
+
+/**
+ * Smallest additional-info value that introduces a multi-byte argument
+ * (24 ⇒ 1 byte, 25 ⇒ 2, 26 ⇒ 4, 27 ⇒ 8 — i.e. `1 << (info - 24)`).
+ */
+const ARG_IN_NEXT_1_BYTE = 24;
+/** Additional-info ≥ this (28..31) is reserved/indefinite — unsupported. */
+const ARG_RESERVED_MIN = 28;
+
+/** Major-7 simple values we accept. */
+const SIMPLE_FALSE = 20;
+const SIMPLE_TRUE = 21;
+const SIMPLE_NULL = 22;
+
+/** A decoded CBOR data item. Maps preserve key insertion order. */
+export type CborValue =
+  | number
+  | bigint
+  | string
+  | Uint8Array
+  | boolean
+  | null
+  | CborValue[]
+  | Map<CborValue, CborValue>
+  | CborTagged;
+
+/** A CBOR tagged value (major type 6). */
+export interface CborTagged {
+  tag: number;
+  value: CborValue;
+}
+
+/** Parsed initial-byte header: major type plus its decoded argument. */
+export interface CborHead {
+  major: number;
+  /** The header argument (length, value, tag number, …) as a number. */
+  arg: number;
+}
+
+export class CborDecodeError extends Error {
+  constructor(message: string) {
+    super(`CBOR decode: ${message}`);
+    this.name = "CborDecodeError";
+  }
+}
+
+/**
+ * Cursor-based reader over a CBOR buffer. Not reusable across buffers —
+ * construct one per decode.
+ */
+export class CborReader {
+  readonly buf: Uint8Array;
+  /** Current read offset. Public so callers can slice encoded sub-ranges. */
+  pos = 0;
+
+  constructor(buf: Uint8Array) {
+    this.buf = buf;
+  }
+
+  private nextByte(): number {
+    if (this.pos >= this.buf.length) {
+      throw new CborDecodeError("unexpected end of input");
+    }
+    return this.buf[this.pos++];
+  }
+
+  /**
+   * Read an initial byte and its argument. Rejects indefinite-length
+   * and reserved additional-info encodings. Arguments wider than
+   * {@link Number.MAX_SAFE_INTEGER} are rejected — none of the token's
+   * lengths, tags, or timestamps approach that bound.
+   */
+  readHead(): CborHead {
+    const initial = this.nextByte();
+    const major = initial >> 5;
+    const info = initial & 0x1f;
+
+    if (info < ARG_IN_NEXT_1_BYTE) {
+      return { major, arg: info };
+    }
+    if (info >= ARG_RESERVED_MIN) {
+      throw new CborDecodeError(
+        `unsupported additional info ${info} (indefinite-length or reserved)`,
+      );
+    }
+
+    const byteCount = 1 << (info - ARG_IN_NEXT_1_BYTE);
+
+    let value = 0n;
+    for (let i = 0; i < byteCount; i++) {
+      value = (value << 8n) | BigInt(this.nextByte());
+    }
+    if (value > BigInt(Number.MAX_SAFE_INTEGER)) {
+      throw new CborDecodeError(`argument ${value} exceeds safe integer range`);
+    }
+    return { major, arg: Number(value) };
+  }
+
+  /** Read `length` raw bytes as a sub-array view into the backing buffer. */
+  private readBytes(length: number): Uint8Array {
+    if (this.pos + length > this.buf.length) {
+      throw new CborDecodeError("length overruns end of input");
+    }
+    const slice = this.buf.subarray(this.pos, this.pos + length);
+    this.pos += length;
+    return slice;
+  }
+
+  /**
+   * Read a byte string (major type 2), returning its content bytes.
+   * Throws if the next item is not a byte string.
+   */
+  readByteString(): Uint8Array {
+    const head = this.readHead();
+    if (head.major !== MAJOR_BYTE_STRING) {
+      throw new CborDecodeError(
+        `expected byte string (major ${MAJOR_BYTE_STRING}), got major ${head.major}`,
+      );
+    }
+    return this.readBytes(head.arg);
+  }
+
+  /** Read the next complete data item as a decoded {@link CborValue}. */
+  readValue(): CborValue {
+    const head = this.readHead();
+    switch (head.major) {
+      case MAJOR_UNSIGNED_INT:
+        return head.arg;
+      case MAJOR_NEGATIVE_INT:
+        // RFC 8949 §3.1: the encoded argument n represents -1 - n.
+        return -1 - head.arg;
+      case MAJOR_BYTE_STRING:
+        return this.readBytes(head.arg);
+      case MAJOR_TEXT_STRING:
+        return new TextDecoder("utf-8", { fatal: true }).decode(
+          this.readBytes(head.arg),
+        );
+      case MAJOR_ARRAY: {
+        const items: CborValue[] = [];
+        for (let i = 0; i < head.arg; i++) {
+          items.push(this.readValue());
+        }
+        return items;
+      }
+      case MAJOR_MAP: {
+        const map = new Map<CborValue, CborValue>();
+        for (let i = 0; i < head.arg; i++) {
+          const key = this.readValue();
+          const value = this.readValue();
+          map.set(key, value);
+        }
+        return map;
+      }
+      case MAJOR_TAG:
+        return { tag: head.arg, value: this.readValue() };
+      case MAJOR_SIMPLE:
+        if (head.arg === SIMPLE_FALSE) return false;
+        if (head.arg === SIMPLE_TRUE) return true;
+        if (head.arg === SIMPLE_NULL) return null;
+        throw new CborDecodeError(
+          `unsupported simple/float value ${head.arg}`,
+        );
+      default:
+        throw new CborDecodeError(`unsupported major type ${head.major}`);
+    }
+  }
+}
+
+/** Decode a single CBOR item from `bytes`. Trailing bytes are ignored. */
+export function decodeCbor(bytes: Uint8Array): CborValue {
+  return new CborReader(bytes).readValue();
+}

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/createAuthenticatedVpClient.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/createAuthenticatedVpClient.ts
@@ -8,6 +8,7 @@
  * @module tbv/core/clients/vault-provider/auth/createAuthenticatedVpClient
  */
 
+import { processPublicKeyToXOnly } from "../../../primitives/utils/bitcoin";
 import type { OnChainBtcPubkey } from "../../eth/types";
 import {
   VaultProviderRpcClient,
@@ -26,6 +27,11 @@ export interface AuthenticatedVpClientConfig {
   authAnchorHex: string;
   /** On-chain VP pubkey, branded so it can only come from the registry reader. */
   pinnedServerPubkey: OnChainBtcPubkey;
+  /**
+   * Depositor BTC pubkey (x-only or compressed hex). Normalized to
+   * x-only and asserted against every issued token's CWT `aud` claim.
+   */
+  depositorBtcPubkey: string;
   /**
    * Opt into gRPC-subject auth for the artifact stream. Defaults to
    * `false` (JSON-RPC bearer). Only enable against a proxy running with
@@ -49,6 +55,9 @@ export function createAuthenticatedVpClient(
     peginTxid: config.peginTxid,
     authAnchorHex: config.authAnchorHex,
     pinnedServerPubkey: config.pinnedServerPubkey,
+    expectedAudienceXOnlyPubkey: processPublicKeyToXOnly(
+      config.depositorBtcPubkey,
+    ),
     enableGrpcArtifactAuth: config.enableGrpcArtifactAuth,
   });
 

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/primeVpAuth.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/primeVpAuth.ts
@@ -7,6 +7,7 @@
  * @module tbv/core/clients/vault-provider/auth/primeVpAuth
  */
 
+import { processPublicKeyToXOnly } from "../../../primitives/utils/bitcoin";
 import type { OnChainBtcPubkey } from "../../eth/types";
 
 import { buildInnerTokenClient } from "./innerTokenClient";
@@ -17,6 +18,11 @@ export interface PrimeVpAuthInput {
   peginTxid: string;
   authAnchorHex: string;
   pinnedServerPubkey: OnChainBtcPubkey;
+  /**
+   * Depositor BTC pubkey (x-only or compressed hex). Normalized to
+   * x-only and asserted against every issued token's CWT `aud` claim.
+   */
+  depositorBtcPubkey: string;
   /** Optional headers forwarded to the inner token client (e.g. gateway auth). */
   headers?: Record<string, string>;
   /**
@@ -35,6 +41,9 @@ export function primeVpTokenRegistry(input: PrimeVpAuthInput): void {
     peginTxid: input.peginTxid,
     authAnchorHex: input.authAnchorHex,
     pinnedServerPubkey: input.pinnedServerPubkey,
+    expectedAudienceXOnlyPubkey: processPublicKeyToXOnly(
+      input.depositorBtcPubkey,
+    ),
     enableGrpcArtifactAuth: input.enableGrpcArtifactAuth,
   });
 }

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/tokenProvider.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/tokenProvider.ts
@@ -36,6 +36,11 @@ import {
   type ServerIdentityResponse,
   verifyServerIdentity,
 } from "./serverIdentity";
+import {
+  CWT_SUBJECT_GRPC,
+  CWT_SUBJECT_JSONRPC,
+  verifyDepositorCwt,
+} from "./verifyDepositorCwt";
 
 /**
  * Maximum reasonable `expires_at` value (seconds since epoch). Guards
@@ -71,6 +76,13 @@ export interface VpTokenProviderConfig {
   authAnchorHex: string;
   /** Pinned VP pubkey from the on-chain registry; branded so indexer mirrors can't substitute. */
   pinnedServerPubkey: OnChainBtcPubkey;
+  /**
+   * Depositor x-only pubkey (32-byte hex). Asserted against every
+   * issued token's CWT `aud` claim so a token minted for a different
+   * depositor — or mis-issued by a buggy/compromised VP — is rejected
+   * before it can authenticate a mutation.
+   */
+  expectedAudienceXOnlyPubkey: string;
   /**
    * Methods that need a JSON-RPC-subject bearer (minted via
    * `auth_createDepositorToken`). Forwarded over plain HTTP JSON-RPC by
@@ -111,6 +123,7 @@ export class VpTokenProvider implements BearerTokenProvider {
   private readonly peginTxid: string;
   private readonly authAnchorHex: string;
   private readonly pinnedServerPubkey: OnChainBtcPubkey;
+  private readonly expectedAudienceXOnlyPubkey: string;
   private readonly authGatedMethods: ReadonlySet<string>;
   private readonly grpcGatedMethods: ReadonlySet<string>;
   private readonly refreshSkewSecs: number;
@@ -128,6 +141,7 @@ export class VpTokenProvider implements BearerTokenProvider {
     this.peginTxid = config.peginTxid;
     this.authAnchorHex = config.authAnchorHex;
     this.pinnedServerPubkey = config.pinnedServerPubkey;
+    this.expectedAudienceXOnlyPubkey = config.expectedAudienceXOnlyPubkey;
     this.authGatedMethods = config.authGatedMethods;
     this.grpcGatedMethods = config.grpcGatedMethods;
     this.refreshSkewSecs = config.refreshSkewSecs ?? DEFAULT_REFRESH_SKEW_SECS;
@@ -252,6 +266,24 @@ export class VpTokenProvider implements BearerTokenProvider {
             `VpTokenProvider: invalid expires_at in acquire response (got ${JSON.stringify(response.expires_at)}; must be a safe integer in (${now}, ${MAX_EXPIRES_AT_SECS}])`,
           );
         }
+
+        // Cryptographically verify the token itself — not just the wire
+        // envelope. The COSE Sign1 signature is checked against the
+        // (server-identity-verified) ephemeral key, and the inner CWT
+        // claims are bound to this depositor (`aud`), this VP (`iss`),
+        // and this subject. Without this the bearer is an opaque blob the
+        // FE would attach to mutations on the VP's word alone.
+        verifyDepositorCwt({
+          token: response.token,
+          ephemeralPubkeyHex: response.server_identity.ephemeral_pubkey,
+          expectedIssuerXOnlyPubkey: this.pinnedServerPubkey,
+          expectedSubject:
+            subject === "grpc" ? CWT_SUBJECT_GRPC : CWT_SUBJECT_JSONRPC,
+          expectedAudienceXOnlyPubkey: this.expectedAudienceXOnlyPubkey,
+          responseExpiresAt: response.expires_at,
+          serverIdentityExpiresAt: response.server_identity.expires_at,
+          now,
+        });
 
         const fresh: CachedToken = {
           token: response.token,

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/tokenRegistry.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/tokenRegistry.ts
@@ -17,6 +17,8 @@ export interface VpTokenRegistryInput {
   peginTxid: string;
   authAnchorHex: string;
   pinnedServerPubkey: OnChainBtcPubkey;
+  /** Depositor x-only pubkey (32-byte hex), asserted against each token's CWT `aud`. */
+  expectedAudienceXOnlyPubkey: string;
   /**
    * Opt into gRPC-subject auth for {@link GRPC_AUTH_GATED_METHODS}
    * (currently the artifact stream). Defaults to `false`: those methods
@@ -32,6 +34,7 @@ interface RegistryEntry {
   provider: VpTokenProvider;
   authAnchorHex: string;
   pinnedServerPubkey: OnChainBtcPubkey;
+  expectedAudienceXOnlyPubkey: string;
   /** Resolved (defaulted) gRPC-auth gating the provider was built with. */
   enableGrpcArtifactAuth: boolean;
 }
@@ -68,6 +71,14 @@ export class VpTokenRegistry {
           `VpTokenRegistry: peginTxid ${input.peginTxid} already bound to pinnedServerPubkey ${existing.pinnedServerPubkey.slice(0, 8)}…; got ${input.pinnedServerPubkey.slice(0, 8)}…`,
         );
       }
+      if (
+        existing.expectedAudienceXOnlyPubkey !==
+        input.expectedAudienceXOnlyPubkey
+      ) {
+        throw new Error(
+          `VpTokenRegistry: peginTxid ${input.peginTxid} already bound to expectedAudienceXOnlyPubkey ${existing.expectedAudienceXOnlyPubkey.slice(0, 8)}…; got ${input.expectedAudienceXOnlyPubkey.slice(0, 8)}…`,
+        );
+      }
       // The provider's gated-method sets are fixed at construction, so a
       // later caller asking for a different subject can't be honoured by
       // the cached instance. Fail loudly rather than silently serve the
@@ -89,6 +100,7 @@ export class VpTokenRegistry {
       peginTxid: input.peginTxid,
       authAnchorHex: input.authAnchorHex,
       pinnedServerPubkey: input.pinnedServerPubkey,
+      expectedAudienceXOnlyPubkey: input.expectedAudienceXOnlyPubkey,
       authGatedMethods: useGrpcAuth
         ? AUTH_GATED_METHODS
         : new Set([...AUTH_GATED_METHODS, ...GRPC_AUTH_GATED_METHODS]),
@@ -98,6 +110,7 @@ export class VpTokenRegistry {
       provider,
       authAnchorHex: input.authAnchorHex,
       pinnedServerPubkey: input.pinnedServerPubkey,
+      expectedAudienceXOnlyPubkey: input.expectedAudienceXOnlyPubkey,
       enableGrpcArtifactAuth: useGrpcAuth,
     });
     return provider;

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/verifyDepositorCwt.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/verifyDepositorCwt.ts
@@ -1,0 +1,515 @@
+/**
+ * Verify a vault-provider CWT bearer token (RFC 8392) wrapped in a
+ * COSE Sign1 envelope (RFC 8152), signed with ES256K by the VP's
+ * ephemeral token-signing key.
+ *
+ * This is the TypeScript port of the btc-vault Rust client verifier
+ * (`crates/btc-auth/src/client.rs::validate_token_with_public_key_at_time`
+ * plus the response cross-checks from `verify_token_response_at_time`).
+ * The FE previously verified only the server-identity proof
+ * ({@link ./serverIdentity}) and treated the token itself as an opaque
+ * blob; this closes that gap by cryptographically verifying the token
+ * and binding its claims to the expected issuer, subject, and depositor.
+ *
+ * Trust chain: {@link ./serverIdentity} first proves the
+ * `ephemeral_pubkey` is attested by the on-chain-pinned server key.
+ * This function then verifies the token's COSE signature against that
+ * same ephemeral key, so a token that decodes and verifies here is one
+ * the pinned VP actually issued.
+ *
+ * The byte-level expectations (COSE tag, ES256K alg id, Sig_structure
+ * layout, CWT registered-claim keys) mirror the issuer's `coset` stack
+ * and are pinned by the golden-vector test against a real Rust-issued
+ * token.
+ *
+ * @module tbv/core/clients/vault-provider/auth/verifyDepositorCwt
+ */
+
+import * as ecc from "@bitcoin-js/tiny-secp256k1-asmjs";
+import { sha256 } from "@noble/hashes/sha2.js";
+
+import {
+  COMPRESSED_PUBKEY_HEX_LEN,
+  hexToUint8Array,
+  stripHexPrefix,
+  X_ONLY_PUBKEY_HEX_LEN,
+} from "../../../primitives/utils/bitcoin";
+import { HEX_RE } from "../../../utils/validation";
+
+import { CborReader, decodeCbor } from "./cborDecode";
+
+/** CWT `sub` value for JSON-RPC-subject tokens (`auth_createDepositorToken`). */
+export const CWT_SUBJECT_JSONRPC = "vaultd-jsonrpc";
+/** CWT `sub` value for gRPC-subject tokens (`auth_createDepositorTokenGrpc`). */
+export const CWT_SUBJECT_GRPC = "vaultd-grpc";
+
+/** CBOR tag wrapping a COSE_Sign1 structure (RFC 8152 §2). */
+const COSE_SIGN1_TAG = 18;
+/** A COSE_Sign1 is a 4-element array: [protected, unprotected, payload, signature]. */
+const COSE_SIGN1_ARRAY_LEN = 4;
+/** COSE algorithm id for ES256K (ECDSA w/ secp256k1 + SHA-256), RFC 8812. */
+const COSE_ALG_ES256K = -47;
+/** COSE header label for the algorithm (RFC 8152 §3.1). */
+const COSE_HEADER_LABEL_ALG = 1;
+/** ECDSA signature length in COSE compact (r‖s) form. */
+const ECDSA_COMPACT_SIG_LEN = 64;
+
+/** CBOR major-type 4 (array) high bits, for the Sig_structure header. */
+const CBOR_ARRAY_HEAD = 0x80;
+/** CBOR major-type 3 (text string) high bits, for the context string head. */
+const CBOR_TEXT_STRING_HEAD = 0x60;
+/** CBOR encoding of an empty byte string (major type 2, length 0). */
+const CBOR_EMPTY_BYTE_STRING = 0x40;
+
+/** CWT registered claim keys (RFC 8392 §4 / IANA CWT registry). */
+const CWT_CLAIM_ISS = 1;
+const CWT_CLAIM_SUB = 2;
+const CWT_CLAIM_AUD = 3;
+const CWT_CLAIM_EXP = 4;
+const CWT_CLAIM_NBF = 5;
+const CWT_CLAIM_IAT = 6;
+const CWT_CLAIM_CTI = 7;
+
+/**
+ * Context string for a COSE_Sign1 Sig_structure (RFC 8152 §4.4). 10
+ * bytes, so it encodes with a single-byte CBOR text-string head.
+ */
+const SIG_STRUCTURE_CONTEXT = new TextEncoder().encode("Signature1");
+
+export type CwtVerificationReason =
+  | "invalid_input"
+  | "invalid_token_structure"
+  | "unexpected_algorithm"
+  | "signature_verification_failed"
+  | "invalid_claims"
+  | "issuer_mismatch"
+  | "subject_mismatch"
+  | "audience_mismatch"
+  | "token_not_yet_valid"
+  | "token_expired"
+  | "expiry_mismatch"
+  | "server_identity_expires_before_token";
+
+export class CwtVerificationError extends Error {
+  constructor(
+    message: string,
+    public readonly reason: CwtVerificationReason,
+  ) {
+    super(message);
+    this.name = "CwtVerificationError";
+  }
+}
+
+export interface VerifyDepositorCwtInput {
+  /** Base64url (no padding) COSE Sign1 token from `auth_createDepositorToken`. */
+  token: string;
+  /**
+   * VP ephemeral token-signing pubkey (33-byte compressed hex) from the
+   * bundled `server_identity` proof — MUST already be verified by
+   * {@link verifyServerIdentity} before being passed here.
+   */
+  ephemeralPubkeyHex: string;
+  /** Pinned VP persistent x-only pubkey (on-chain). Asserted against the token `iss`. */
+  expectedIssuerXOnlyPubkey: string;
+  /** Expected `sub` — {@link CWT_SUBJECT_JSONRPC} or {@link CWT_SUBJECT_GRPC}. */
+  expectedSubject: string;
+  /** Depositor x-only pubkey. Asserted against the token `aud`. */
+  expectedAudienceXOnlyPubkey: string;
+  /** Outer wire `expires_at`. Must equal the token's `exp` exactly. */
+  responseExpiresAt: number;
+  /** `server_identity.expires_at`. Must be ≥ the token's `exp`. */
+  serverIdentityExpiresAt: number;
+  /** Current Unix time (seconds). Injected for testability. */
+  now: number;
+}
+
+export interface VerifiedCwtClaims {
+  issuer: string;
+  subject: string;
+  audience: string;
+  expiresAt: number;
+  notBefore: number;
+  issuedAt: number;
+}
+
+/**
+ * Verify a depositor CWT and return its claims, or throw
+ * {@link CwtVerificationError}.
+ *
+ * Steps (matching the Rust reference):
+ *   1. Decode the COSE Sign1 envelope and assert the protected header
+ *      pins ES256K.
+ *   2. Verify the ECDSA signature over the reconstructed Sig_structure
+ *      against the (already server-identity-verified) ephemeral key.
+ *   3. Decode the CWT claims and assert `iss`/`sub`/`aud` bindings,
+ *      `nbf`/`exp` validity, `cti` presence, and the outer-vs-inner
+ *      expiry cross-checks.
+ */
+export function verifyDepositorCwt(
+  input: VerifyDepositorCwtInput,
+): VerifiedCwtClaims {
+  const expectedIssuer = normalizeXOnly(
+    input.expectedIssuerXOnlyPubkey,
+    "expectedIssuerXOnlyPubkey",
+  );
+  const expectedAudience = normalizeXOnly(
+    input.expectedAudienceXOnlyPubkey,
+    "expectedAudienceXOnlyPubkey",
+  );
+  const ephemeral = decodeCompressedPubkey(input.ephemeralPubkeyHex);
+
+  const tokenBytes = base64UrlToBytes(input.token);
+
+  // --- 1. COSE Sign1 structural decode -------------------------------
+  // Capture the exact encoded byte ranges of the protected header and
+  // payload so the Sig_structure can be rebuilt byte-for-byte from the
+  // token's own bytes (any re-encoding risks a non-canonical mismatch).
+  const reader = new CborReader(tokenBytes);
+  const tag = reader.readHead();
+  if (tag.major !== 6 || tag.arg !== COSE_SIGN1_TAG) {
+    throw new CwtVerificationError(
+      `token is not a COSE Sign1 tagged value (tag ${COSE_SIGN1_TAG})`,
+      "invalid_token_structure",
+    );
+  }
+  const array = reader.readHead();
+  if (array.major !== 4 || array.arg !== COSE_SIGN1_ARRAY_LEN) {
+    throw new CwtVerificationError(
+      `COSE Sign1 must be a ${COSE_SIGN1_ARRAY_LEN}-element array`,
+      "invalid_token_structure",
+    );
+  }
+
+  const protectedStart = reader.pos;
+  const protectedContent = reader.readByteString();
+  const protectedBstr = tokenBytes.subarray(protectedStart, reader.pos);
+
+  // Unprotected header map: present in the envelope but unused here.
+  reader.readValue();
+
+  const payloadStart = reader.pos;
+  const payloadContent = reader.readByteString();
+  const payloadBstr = tokenBytes.subarray(payloadStart, reader.pos);
+
+  const signature = reader.readByteString();
+  if (signature.length !== ECDSA_COMPACT_SIG_LEN) {
+    throw new CwtVerificationError(
+      `COSE signature must be ${ECDSA_COMPACT_SIG_LEN} bytes, got ${signature.length}`,
+      "invalid_token_structure",
+    );
+  }
+
+  // --- 2a. Algorithm pin --------------------------------------------
+  const alg = readProtectedAlgorithm(protectedContent);
+  if (alg !== COSE_ALG_ES256K) {
+    throw new CwtVerificationError(
+      `unexpected COSE algorithm ${alg} (expected ES256K ${COSE_ALG_ES256K})`,
+      "unexpected_algorithm",
+    );
+  }
+
+  // --- 2b. Signature verification -----------------------------------
+  const sigStructure = buildSigStructure(protectedBstr, payloadBstr);
+  const digest = sha256(sigStructure);
+  // strict = true enforces low-S, matching libsecp256k1's `verify_ecdsa`.
+  if (!ecc.verify(digest, ephemeral, signature, true)) {
+    throw new CwtVerificationError(
+      "COSE signature does not verify against the server's ephemeral key",
+      "signature_verification_failed",
+    );
+  }
+
+  // --- 3. Claims -----------------------------------------------------
+  const claims = decodeClaims(payloadContent);
+
+  const audience = claims.audience.toLowerCase();
+  if (audience.length !== X_ONLY_PUBKEY_HEX_LEN || !HEX_RE.test(audience)) {
+    throw new CwtVerificationError(
+      "token `aud` is not a 32-byte x-only pubkey hex",
+      "invalid_claims",
+    );
+  }
+  if (claims.issuedAt > claims.expiresAt) {
+    throw new CwtVerificationError(
+      `token iat (${claims.issuedAt}) is after exp (${claims.expiresAt})`,
+      "invalid_claims",
+    );
+  }
+
+  if (claims.issuer.toLowerCase() !== expectedIssuer) {
+    throw new CwtVerificationError(
+      `token issuer does not match pinned server pubkey: expected ${expectedIssuer}, got ${claims.issuer.toLowerCase()}`,
+      "issuer_mismatch",
+    );
+  }
+  if (claims.subject !== input.expectedSubject) {
+    throw new CwtVerificationError(
+      `token subject mismatch: expected ${input.expectedSubject}, got ${claims.subject}`,
+      "subject_mismatch",
+    );
+  }
+  if (audience !== expectedAudience) {
+    throw new CwtVerificationError(
+      `token audience does not match depositor pubkey: expected ${expectedAudience}, got ${audience}`,
+      "audience_mismatch",
+    );
+  }
+  if (claims.notBefore > input.now) {
+    throw new CwtVerificationError(
+      `token not yet valid: nbf ${claims.notBefore} > now ${input.now}`,
+      "token_not_yet_valid",
+    );
+  }
+  if (claims.expiresAt <= input.now) {
+    throw new CwtVerificationError(
+      `token expired: exp ${claims.expiresAt} <= now ${input.now}`,
+      "token_expired",
+    );
+  }
+  if (input.responseExpiresAt !== claims.expiresAt) {
+    throw new CwtVerificationError(
+      `response expires_at (${input.responseExpiresAt}) does not equal token exp (${claims.expiresAt})`,
+      "expiry_mismatch",
+    );
+  }
+  if (input.serverIdentityExpiresAt < claims.expiresAt) {
+    throw new CwtVerificationError(
+      `server identity expires (${input.serverIdentityExpiresAt}) before token exp (${claims.expiresAt})`,
+      "server_identity_expires_before_token",
+    );
+  }
+
+  return {
+    issuer: claims.issuer,
+    subject: claims.subject,
+    audience,
+    expiresAt: claims.expiresAt,
+    notBefore: claims.notBefore,
+    issuedAt: claims.issuedAt,
+  };
+}
+
+/** Read the algorithm label from the COSE protected-header byte string. */
+function readProtectedAlgorithm(protectedContent: Uint8Array): number {
+  if (protectedContent.length === 0) {
+    throw new CwtVerificationError(
+      "empty COSE protected header (no algorithm)",
+      "unexpected_algorithm",
+    );
+  }
+  const header = decodeCbor(protectedContent);
+  if (!(header instanceof Map)) {
+    throw new CwtVerificationError(
+      "COSE protected header is not a map",
+      "invalid_token_structure",
+    );
+  }
+  const alg = header.get(COSE_HEADER_LABEL_ALG);
+  if (typeof alg !== "number") {
+    throw new CwtVerificationError(
+      "COSE protected header missing integer algorithm label",
+      "unexpected_algorithm",
+    );
+  }
+  return alg;
+}
+
+/**
+ * Rebuild the COSE_Sign1 Sig_structure (RFC 8152 §4.4):
+ *
+ *   [ "Signature1", body_protected (bstr), external_aad = h'' , payload (bstr) ]
+ *
+ * `body_protected` and `payload` are spliced verbatim from the token's
+ * own encoded byte strings, so the result is byte-identical to what the
+ * issuer signed regardless of CBOR canonicalization choices.
+ */
+function buildSigStructure(
+  protectedBstr: Uint8Array,
+  payloadBstr: Uint8Array,
+): Uint8Array {
+  return concatBytes(
+    Uint8Array.of(CBOR_ARRAY_HEAD | COSE_SIGN1_ARRAY_LEN),
+    Uint8Array.of(CBOR_TEXT_STRING_HEAD | SIG_STRUCTURE_CONTEXT.length),
+    SIG_STRUCTURE_CONTEXT,
+    protectedBstr,
+    Uint8Array.of(CBOR_EMPTY_BYTE_STRING),
+    payloadBstr,
+  );
+}
+
+interface DecodedClaims {
+  issuer: string;
+  subject: string;
+  audience: string;
+  expiresAt: number;
+  notBefore: number;
+  issuedAt: number;
+}
+
+/** Decode and type-check the CWT registered claims from the payload. */
+function decodeClaims(payloadContent: Uint8Array): DecodedClaims {
+  const root = decodeCbor(payloadContent);
+  if (!(root instanceof Map)) {
+    throw new CwtVerificationError(
+      "CWT claims root is not a map",
+      "invalid_claims",
+    );
+  }
+  const cti = requireBytes(root, CWT_CLAIM_CTI, "cti");
+  if (cti.length === 0) {
+    throw new CwtVerificationError("token cti is empty", "invalid_claims");
+  }
+  return {
+    issuer: requireString(root, CWT_CLAIM_ISS, "iss"),
+    subject: requireString(root, CWT_CLAIM_SUB, "sub"),
+    audience: requireString(root, CWT_CLAIM_AUD, "aud"),
+    expiresAt: requireTimestamp(root, CWT_CLAIM_EXP, "exp"),
+    notBefore: requireTimestamp(root, CWT_CLAIM_NBF, "nbf"),
+    issuedAt: requireTimestamp(root, CWT_CLAIM_IAT, "iat"),
+  };
+}
+
+function requireString(
+  claims: Map<unknown, unknown>,
+  key: number,
+  name: string,
+): string {
+  const value = claims.get(key);
+  if (typeof value !== "string") {
+    throw new CwtVerificationError(
+      `token claim ${name} is missing or not a text string`,
+      "invalid_claims",
+    );
+  }
+  return value;
+}
+
+function requireBytes(
+  claims: Map<unknown, unknown>,
+  key: number,
+  name: string,
+): Uint8Array {
+  const value = claims.get(key);
+  if (!(value instanceof Uint8Array)) {
+    throw new CwtVerificationError(
+      `token claim ${name} is missing or not a byte string`,
+      "invalid_claims",
+    );
+  }
+  return value;
+}
+
+function requireTimestamp(
+  claims: Map<unknown, unknown>,
+  key: number,
+  name: string,
+): number {
+  const value = claims.get(key);
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
+    throw new CwtVerificationError(
+      `token claim ${name} is missing or not a non-negative integer timestamp`,
+      "invalid_claims",
+    );
+  }
+  return value;
+}
+
+/** Validate and normalize a 32-byte x-only pubkey to lowercase hex. */
+function normalizeXOnly(pubkey: string, label: string): string {
+  const normalized = stripHexPrefix(pubkey).toLowerCase();
+  if (normalized.length !== X_ONLY_PUBKEY_HEX_LEN || !HEX_RE.test(normalized)) {
+    throw new CwtVerificationError(
+      `${label} must be 32-byte x-only hex; got ${normalized.length} chars`,
+      "invalid_input",
+    );
+  }
+  return normalized;
+}
+
+/** Validate a 33-byte compressed pubkey hex and return its bytes. */
+function decodeCompressedPubkey(pubkeyHex: string): Uint8Array {
+  const normalized = stripHexPrefix(pubkeyHex).toLowerCase();
+  const prefix = normalized.slice(0, 2);
+  if (
+    normalized.length !== COMPRESSED_PUBKEY_HEX_LEN ||
+    !HEX_RE.test(normalized) ||
+    (prefix !== "02" && prefix !== "03")
+  ) {
+    throw new CwtVerificationError(
+      "ephemeralPubkeyHex must be 33-byte compressed pubkey hex (prefix 02/03)",
+      "invalid_input",
+    );
+  }
+  return hexToUint8Array(normalized);
+}
+
+const B64URL_LOOKUP = (() => {
+  const table = new Int16Array(128).fill(-1);
+  const alphabet =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+  for (let i = 0; i < alphabet.length; i++) {
+    table[alphabet.charCodeAt(i)] = i;
+  }
+  return table;
+})();
+
+/** Decode a base64url (no-padding) string to bytes. */
+function base64UrlToBytes(input: string): Uint8Array {
+  const len = input.length;
+  const fullGroups = Math.floor(len / 4);
+  const remainder = len % 4;
+  if (remainder === 1) {
+    throw new CwtVerificationError(
+      "invalid base64url length",
+      "invalid_token_structure",
+    );
+  }
+  const outLen = fullGroups * 3 + (remainder === 0 ? 0 : remainder - 1);
+  const out = new Uint8Array(outLen);
+
+  const sextet = (charCode: number): number => {
+    const value = charCode < 128 ? B64URL_LOOKUP[charCode] : -1;
+    if (value < 0) {
+      throw new CwtVerificationError(
+        "invalid base64url character",
+        "invalid_token_structure",
+      );
+    }
+    return value;
+  };
+
+  let inPos = 0;
+  let outPos = 0;
+  for (let g = 0; g < fullGroups; g++) {
+    const a = sextet(input.charCodeAt(inPos++));
+    const b = sextet(input.charCodeAt(inPos++));
+    const c = sextet(input.charCodeAt(inPos++));
+    const d = sextet(input.charCodeAt(inPos++));
+    out[outPos++] = (a << 2) | (b >> 4);
+    out[outPos++] = ((b & 0x0f) << 4) | (c >> 2);
+    out[outPos++] = ((c & 0x03) << 6) | d;
+  }
+  if (remainder === 2) {
+    const a = sextet(input.charCodeAt(inPos++));
+    const b = sextet(input.charCodeAt(inPos++));
+    out[outPos++] = (a << 2) | (b >> 4);
+  } else if (remainder === 3) {
+    const a = sextet(input.charCodeAt(inPos++));
+    const b = sextet(input.charCodeAt(inPos++));
+    const c = sextet(input.charCodeAt(inPos++));
+    out[outPos++] = (a << 2) | (b >> 4);
+    out[outPos++] = ((b & 0x0f) << 4) | (c >> 2);
+  }
+  return out;
+}
+
+function concatBytes(...parts: Uint8Array[]): Uint8Array {
+  const total = parts.reduce((sum, part) => sum + part.length, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const part of parts) {
+    out.set(part, offset);
+    offset += part.length;
+  }
+  return out;
+}

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/verifyDepositorCwt.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/verifyDepositorCwt.ts
@@ -198,6 +198,15 @@ export function verifyDepositorCwt(
       "invalid_token_structure",
     );
   }
+  // Reject anything after the COSE_Sign1 structure. The bearer we verify
+  // must be the exact bytes attached to authenticated calls; a stricter
+  // CWT/COSE consumer could interpret trailing bytes differently.
+  if (reader.pos !== tokenBytes.length) {
+    throw new CwtVerificationError(
+      "COSE Sign1 token has trailing bytes after the signature",
+      "invalid_token_structure",
+    );
+  }
 
   // --- 2a. Algorithm pin --------------------------------------------
   const alg = readProtectedAlgorithm(protectedContent);
@@ -258,6 +267,17 @@ export function verifyDepositorCwt(
     throw new CwtVerificationError(
       `token not yet valid: nbf ${claims.notBefore} > now ${input.now}`,
       "token_not_yet_valid",
+    );
+  }
+  // Reject tokens stamped in the future. The Rust reference enforces
+  // `iat <= now`; the golden tokens have iat == nbf so the `nbf` check
+  // above covers it there, but checking iat explicitly matches the
+  // reference exactly (and catches a token with nbf in the past but iat
+  // in the future).
+  if (claims.issuedAt > input.now) {
+    throw new CwtVerificationError(
+      `token issued in the future: iat ${claims.issuedAt} > now ${input.now}`,
+      "invalid_claims",
     );
   }
   if (claims.expiresAt <= input.now) {

--- a/services/vault/src/components/simple/ResumeDepositContent.tsx
+++ b/services/vault/src/components/simple/ResumeDepositContent.tsx
@@ -401,6 +401,7 @@ export function ResumeWotsContent({
           peginTxid: primedTxid,
           authAnchorHex,
           pinnedServerPubkey,
+          depositorBtcPubkey,
           enableGrpcArtifactAuth: featureFlags.isGrpcArtifactsEnabled,
         });
         trackPrimedTxid(primedTxid);

--- a/services/vault/src/hooks/deposit/__tests__/useArtifactDownload.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useArtifactDownload.test.tsx
@@ -53,6 +53,7 @@ function seedHotCache(): void {
     pinnedServerPubkey: "ab".repeat(32) as unknown as Parameters<
       typeof createAuthenticatedVpClient
     >[0]["pinnedServerPubkey"],
+    depositorBtcPubkey: DEPOSITOR_PK,
   });
 }
 

--- a/services/vault/src/hooks/deposit/depositFlowSteps/ensureAuthenticatedVpClient.ts
+++ b/services/vault/src/hooks/deposit/depositFlowSteps/ensureAuthenticatedVpClient.ts
@@ -100,6 +100,7 @@ export async function ensureAuthenticatedVpClient(
       peginTxid,
       authAnchorHex,
       pinnedServerPubkey,
+      depositorBtcPubkey: params.depositorBtcPubkey,
       enableGrpcArtifactAuth: featureFlags.isGrpcArtifactsEnabled,
     });
   } finally {

--- a/services/vault/src/hooks/deposit/useDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useDepositFlow.ts
@@ -749,6 +749,7 @@ export function useDepositFlow(
               peginTxid,
               authAnchorHex,
               pinnedServerPubkey,
+              depositorBtcPubkey: batchResult.depositorBtcPubkey,
               enableGrpcArtifactAuth: featureFlags.isGrpcArtifactsEnabled,
             });
             primedRegistryTxids.push(peginTxid);


### PR DESCRIPTION
Issue: https://github.com/sherlock-audit/2026-05-babylon-fe-indexer-monitor-utils-proxy-may-11th-2026/issues/852