### PR TITLE
feat(vault): show projected post-borrow rate in borrow metrics card

### DIFF
--- a/services/vault/src/applications/aave/clients/__tests__/aaveHub.test.ts
+++ b/services/vault/src/applications/aave/clients/__tests__/aaveHub.test.ts
@@ -125,7 +125,12 @@ function modelRateRay(liquidity: bigint, drawn: bigint, swept: bigint): bigint {
  * it is handed, so the test verifies the projection the reader builds.
  */
 function setupHub(
-  totals: { liquidity: bigint; drawn: bigint; swept: bigint },
+  totals: {
+    liquidity: bigint;
+    drawn: bigint;
+    swept: bigint;
+    deficitRay?: bigint;
+  },
   opts: { totalsRevert?: boolean; currentRevert?: boolean } = {},
 ) {
   multicall.mockImplementation(
@@ -135,13 +140,14 @@ function setupHub(
       contracts: { functionName: string; args: unknown[] }[];
     }) => {
       if (contracts[0].functionName !== "calculateInterestRate") {
-        // Round 1: asset totals + config.
+        // Round 1: asset totals + deficit + config.
         return [
           opts.totalsRevert
             ? { status: "failure", error: new Error("reverted") }
             : { status: "success", result: totals.liquidity },
           { status: "success", result: [totals.drawn, 0n] },
           { status: "success", result: totals.swept },
+          { status: "success", result: totals.deficitRay ?? 0n },
           { status: "success", result: { irStrategy: IRM } },
         ];
       }
@@ -206,6 +212,32 @@ describe("getProjectedBorrowAprPercentsSafe", () => {
     // [assetId, liquidity, drawn, deficit, swept]
     expect(currentArgs).toEqual([5n, 600n, 400n, 0n, 7n]);
     expect(projectedArgs).toEqual([5n, 450n, 550n, 0n, 7n]);
+  });
+
+  it("passes the live deficit (RAY ceil-divided to asset units) to both calls", async () => {
+    // 2.5 RAY -> ceil(2.5) = 3 asset units.
+    setupHub({
+      liquidity: 600n,
+      drawn: 400n,
+      swept: 0n,
+      deficitRay: 2n * 10n ** 27n + 1n,
+    });
+
+    await getProjectedBorrowAprPercentsSafe({
+      hub: HUB,
+      assetId: 5,
+      borrowAmountRaw: 100n,
+    });
+
+    const rateCall = multicall.mock.calls.find(
+      (c) => c[0].contracts[0].functionName === "calculateInterestRate",
+    )!;
+    const [currentArgs, projectedArgs] = rateCall[0].contracts.map(
+      (c: { args: unknown[] }) => c.args,
+    );
+    // deficit (index 3) is identical for both legs — a borrow doesn't change it.
+    expect(currentArgs[3]).toBe(3n);
+    expect(projectedArgs[3]).toBe(3n);
   });
 
   it("crosses the optimal kink into the steep slope as utilization rises", async () => {

--- a/services/vault/src/applications/aave/clients/__tests__/aaveHub.test.ts
+++ b/services/vault/src/applications/aave/clients/__tests__/aaveHub.test.ts
@@ -1,5 +1,13 @@
+import type { Address } from "viem";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import {
+  getAssetLiquiditiesSafe,
+  getProjectedBorrowAprPercentsSafe,
+} from "../aaveHub";
+
+// vitest hoists vi.mock above imports; the factory closes over `multicall`,
+// which is initialized before the mocked module is first imported.
 const multicall = vi.fn();
 vi.mock("../../../../clients/eth-contract/client", () => ({
   ethClient: { getPublicClient: () => ({ multicall }) },
@@ -11,9 +19,9 @@ vi.mock("@babylonlabs-io/ts-sdk/tbv/integrations/aave", () => ({
   getAssetDrawnRatesSafe: vi.fn(),
 }));
 
-import { getAssetLiquiditiesSafe } from "../aaveHub";
-
-const HUB = "0x0000000000000000000000000000000000000003" as const;
+const HUB = "0x0000000000000000000000000000000000000003" as Address;
+const IRM = "0x0000000000000000000000000000000000000004" as Address;
+const RAY = 10n ** 27n;
 
 describe("getAssetLiquiditiesSafe", () => {
   beforeEach(() => {
@@ -83,5 +91,206 @@ describe("getAssetLiquiditiesSafe", () => {
   it("skips the multicall entirely for an empty request list", async () => {
     expect(await getAssetLiquiditiesSafe([])).toEqual([]);
     expect(multicall).not.toHaveBeenCalled();
+  });
+});
+
+const PARAMS = {
+  optimalUsage: 0.9,
+  baseRate: 0.0, // 0%
+  growthBefore: 0.04, // +4% across [0, optimal]
+  growthAfter: 0.6, // +60% across [optimal, 100%]
+};
+
+/**
+ * Faithful float port of the on-chain kinked rate model
+ * (AssetInterestRateStrategy.calculateInterestRate), used to give the mocked
+ * Hub a realistic rate curve. Usage is `drawn / (liquidity + drawn + swept)`.
+ */
+function modelRateRay(liquidity: bigint, drawn: bigint, swept: bigint): bigint {
+  const denom = liquidity + drawn + swept;
+  const usage = denom === 0n ? 0 : Number(drawn) / Number(denom);
+  const { optimalUsage, baseRate, growthBefore, growthAfter } = PARAMS;
+  const rate =
+    usage <= optimalUsage
+      ? baseRate + (growthBefore * usage) / optimalUsage
+      : baseRate +
+        growthBefore +
+        (growthAfter * (usage - optimalUsage)) / (1 - optimalUsage);
+  return BigInt(Math.round(rate * Number(RAY)));
+}
+
+/**
+ * Mock Hub: round 1 returns the asset totals + strategy address; round 2
+ * answers `calculateInterestRate` from whatever (liquidity, drawn, swept) args
+ * it is handed, so the test verifies the projection the reader builds.
+ */
+function setupHub(
+  totals: { liquidity: bigint; drawn: bigint; swept: bigint },
+  opts: { totalsRevert?: boolean; currentRevert?: boolean } = {},
+) {
+  multicall.mockImplementation(
+    async ({
+      contracts,
+    }: {
+      contracts: { functionName: string; args: unknown[] }[];
+    }) => {
+      if (contracts[0].functionName !== "calculateInterestRate") {
+        // Round 1: asset totals + config.
+        return [
+          opts.totalsRevert
+            ? { status: "failure", error: new Error("reverted") }
+            : { status: "success", result: totals.liquidity },
+          { status: "success", result: [totals.drawn, 0n] },
+          { status: "success", result: totals.swept },
+          { status: "success", result: { irStrategy: IRM } },
+        ];
+      }
+      // Round 2: rate at each (liquidity, drawn, swept) tuple.
+      return contracts.map((c, i) => {
+        if (opts.currentRevert && i === 0) {
+          return { status: "failure", error: new Error("reverted") };
+        }
+        const [, liquidity, drawn, , swept] = c.args as [
+          bigint,
+          bigint,
+          bigint,
+          bigint,
+          bigint,
+        ];
+        return {
+          status: "success",
+          result: modelRateRay(liquidity, drawn, swept),
+        };
+      });
+    },
+  );
+}
+
+describe("getProjectedBorrowAprPercentsSafe", () => {
+  beforeEach(() => {
+    multicall.mockReset();
+  });
+
+  it("returns the current rate and a higher projected rate after the borrow", async () => {
+    setupHub({ liquidity: 600n, drawn: 400n, swept: 0n });
+
+    const out = await getProjectedBorrowAprPercentsSafe({
+      hub: HUB,
+      assetId: 5,
+      borrowAmountRaw: 200n,
+    });
+
+    // Current usage 400/1000 = 0.40 (below optimal): 0.40/0.90 * 4% ≈ 1.778%.
+    expect(out.currentPercent).toBeCloseTo(0.04 * (0.4 / 0.9) * 100, 6);
+    // Post-borrow usage 600/1000 = 0.60: 0.60/0.90 * 4% ≈ 2.667%.
+    expect(out.projectedPercent).toBeCloseTo(0.04 * (0.6 / 0.9) * 100, 6);
+    expect(out.projectedPercent!).toBeGreaterThan(out.currentPercent!);
+    expect(out.error).toBeNull();
+  });
+
+  it("projects from post-borrow totals: drawn + amount, liquidity - amount", async () => {
+    setupHub({ liquidity: 600n, drawn: 400n, swept: 7n });
+
+    await getProjectedBorrowAprPercentsSafe({
+      hub: HUB,
+      assetId: 5,
+      borrowAmountRaw: 150n,
+    });
+
+    const rateCall = multicall.mock.calls.find(
+      (c) => c[0].contracts[0].functionName === "calculateInterestRate",
+    )!;
+    const [currentArgs, projectedArgs] = rateCall[0].contracts.map(
+      (c: { args: unknown[] }) => c.args,
+    );
+    // [assetId, liquidity, drawn, deficit, swept]
+    expect(currentArgs).toEqual([5n, 600n, 400n, 0n, 7n]);
+    expect(projectedArgs).toEqual([5n, 450n, 550n, 0n, 7n]);
+  });
+
+  it("crosses the optimal kink into the steep slope as utilization rises", async () => {
+    // Current usage 0.80 (below optimal 0.90); borrowing pushes it to 0.95.
+    setupHub({ liquidity: 200n, drawn: 800n, swept: 0n });
+
+    const out = await getProjectedBorrowAprPercentsSafe({
+      hub: HUB,
+      assetId: 5,
+      borrowAmountRaw: 150n,
+    });
+
+    expect(out.currentPercent).toBeCloseTo(0.04 * (0.8 / 0.9) * 100, 6);
+    // 0.95 > 0.90: base + growthBefore + growthAfter*(0.05/0.10) = 4% + 30%.
+    expect(out.projectedPercent).toBeCloseTo((0.04 + 0.6 * 0.5) * 100, 6);
+  });
+
+  it("caps the moved amount at available liquidity when the borrow exceeds it", async () => {
+    setupHub({ liquidity: 100n, drawn: 900n, swept: 0n });
+
+    const out = await getProjectedBorrowAprPercentsSafe({
+      hub: HUB,
+      assetId: 5,
+      borrowAmountRaw: 500n, // > liquidity
+    });
+
+    const rateCall = multicall.mock.calls.find(
+      (c) => c[0].contracts[0].functionName === "calculateInterestRate",
+    )!;
+    const projectedArgs = rateCall[0].contracts[1].args;
+    // The move is capped at liquidity (100): liquidity -> 0, drawn 900 -> 1000.
+    // The denominator (liquidity + drawn + swept = 1000) stays invariant.
+    expect(projectedArgs).toEqual([5n, 0n, 1000n, 0n, 0n]);
+    expect(out.projectedPercent).not.toBeNull();
+  });
+
+  it("returns nulls without issuing the rate call when the totals read reverts", async () => {
+    setupHub(
+      { liquidity: 600n, drawn: 400n, swept: 0n },
+      { totalsRevert: true },
+    );
+
+    const out = await getProjectedBorrowAprPercentsSafe({
+      hub: HUB,
+      assetId: 5,
+      borrowAmountRaw: 100n,
+    });
+
+    expect(out).toEqual({
+      currentPercent: null,
+      projectedPercent: null,
+      error: expect.any(Error),
+    });
+    // Only the totals multicall ran; no rate multicall.
+    expect(multicall).toHaveBeenCalledTimes(1);
+  });
+
+  it("nulls only the leg whose strategy call reverts", async () => {
+    setupHub(
+      { liquidity: 600n, drawn: 400n, swept: 0n },
+      { currentRevert: true },
+    );
+
+    const out = await getProjectedBorrowAprPercentsSafe({
+      hub: HUB,
+      assetId: 5,
+      borrowAmountRaw: 100n,
+    });
+
+    expect(out.currentPercent).toBeNull();
+    expect(out.projectedPercent).not.toBeNull();
+    expect(out.error).toBeNull();
+  });
+
+  it("never throws on a network-level multicall failure", async () => {
+    multicall.mockRejectedValue(new Error("RPC timeout"));
+
+    const out = await getProjectedBorrowAprPercentsSafe({
+      hub: HUB,
+      assetId: 5,
+      borrowAmountRaw: 100n,
+    });
+
+    expect(out.currentPercent).toBeNull();
+    expect(out.projectedPercent).toBeNull();
+    expect(out.error).toBeInstanceOf(Error);
   });
 });

--- a/services/vault/src/applications/aave/clients/aaveHub.ts
+++ b/services/vault/src/applications/aave/clients/aaveHub.ts
@@ -26,6 +26,11 @@ function rateRayToPercent(rateRay: bigint): number {
   return (Number(rateRay) / Number(RAY)) * PERCENT_SCALE;
 }
 
+/** Ceil-divides a RAY-scaled value down to asset units (Aave's `fromRayUp`). */
+function ceilDivRay(valueRay: bigint): bigint {
+  return (valueRay + RAY - 1n) / RAY;
+}
+
 /**
  * Minimal Hub ABI for the two reserve-total reads. The SDK's `AaveHub.abi.json`
  * is the rate-read subset (`getAssetDrawnRate` only), so — matching the
@@ -82,6 +87,13 @@ const HUB_RATE_ABI = [
   {
     type: "function",
     name: "getAssetSwept",
+    stateMutability: "view",
+    inputs: [{ name: "assetId", type: "uint256" }],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "getAssetDeficitRay",
     stateMutability: "view",
     inputs: [{ name: "assetId", type: "uint256" }],
     outputs: [{ name: "", type: "uint256" }],
@@ -256,10 +268,12 @@ const NULL_PROJECTION = {
  *
  * Both endpoints are read from the same strategy view so the current -> projected
  * delta is exact and monotonic. A new borrow of `borrowAmountRaw` moves that
- * amount from `liquidity` to `drawn` (`deficit` is unused by the curve, passed
- * as 0). Reads are isolated with `allowFailure`: any revert (e.g. an asset with
- * no strategy configured) returns nulls rather than throwing, since callers are
- * display surfaces that fall back to a placeholder.
+ * amount from `liquidity` to `drawn`; `deficit` is passed through to both calls
+ * exactly as the Hub feeds it (a borrow doesn't change it), so the figures match
+ * the Hub even for a strategy that uses deficit or an asset with bad debt. Reads
+ * are isolated with `allowFailure`: any revert (e.g. an asset with no strategy
+ * configured) returns nulls rather than throwing, since callers are display
+ * surfaces that fall back to a placeholder.
  */
 export async function getProjectedBorrowAprPercentsSafe({
   hub,
@@ -294,6 +308,12 @@ export async function getProjectedBorrowAprPercentsSafe({
         {
           address: hub,
           abi: HUB_RATE_ABI as Abi,
+          functionName: "getAssetDeficitRay" as const,
+          args: [assetIdArg] as const,
+        },
+        {
+          address: hub,
+          abi: HUB_RATE_ABI as Abi,
           functionName: "getAssetConfig" as const,
           args: [assetIdArg] as const,
         },
@@ -307,11 +327,12 @@ export async function getProjectedBorrowAprPercentsSafe({
     };
   }
 
-  const [liquidityCall, owedCall, sweptCall, configCall] = totals;
+  const [liquidityCall, owedCall, sweptCall, deficitCall, configCall] = totals;
   if (
     liquidityCall.status !== "success" ||
     owedCall.status !== "success" ||
     sweptCall.status !== "success" ||
+    deficitCall.status !== "success" ||
     configCall.status !== "success"
   ) {
     return {
@@ -324,6 +345,9 @@ export async function getProjectedBorrowAprPercentsSafe({
   // getAssetOwed returns [drawn, premium]; the strategy curve uses `drawn`.
   const drawn = (owedCall.result as readonly bigint[])[0];
   const swept = sweptCall.result as bigint;
+  // The strategy takes the deficit in asset units; the Hub stores it RAY-scaled
+  // and feeds `deficitRay.fromRayUp()` (ceil-divide by RAY) into the rate call.
+  const deficit = ceilDivRay(deficitCall.result as bigint);
   const { irStrategy } = configCall.result as { irStrategy: Address };
 
   // Borrowing moves the drawn amount out of liquidity, so the denominator
@@ -344,7 +368,7 @@ export async function getProjectedBorrowAprPercentsSafe({
           address: irStrategy,
           abi: IR_STRATEGY_ABI as Abi,
           functionName: "calculateInterestRate" as const,
-          args: [assetIdArg, liquidity, drawn, 0n, swept] as const,
+          args: [assetIdArg, liquidity, drawn, deficit, swept] as const,
         },
         {
           address: irStrategy,
@@ -354,7 +378,7 @@ export async function getProjectedBorrowAprPercentsSafe({
             assetIdArg,
             projectedLiquidity,
             projectedDrawn,
-            0n,
+            deficit,
             swept,
           ] as const,
         },

--- a/services/vault/src/applications/aave/clients/aaveHub.ts
+++ b/services/vault/src/applications/aave/clients/aaveHub.ts
@@ -266,8 +266,12 @@ const NULL_PROJECTION = {
  *   rate = irStrategy.calculateInterestRate(assetId, liquidity, drawn, _, swept)
  *   utilization = drawn / (liquidity + drawn + swept)
  *
- * Both endpoints are read from the same strategy view so the current -> projected
- * delta is exact and monotonic. A new borrow of `borrowAmountRaw` moves that
+ * The current-rate leg is bit-identical to the Hub's own `getAssetDrawnRate`
+ * (Aave v4 `AssetLogic.getDrawnRate` calls the same strategy with these exact
+ * totals), so it matches the rate shown by the landing card and asset-selection
+ * modal. Both endpoints are read from one totals snapshot fed to the same
+ * strategy view, so the current -> projected delta stays exact and monotonic
+ * regardless of block skew. A new borrow of `borrowAmountRaw` moves that
  * amount from `liquidity` to `drawn`; `deficit` is passed through to both calls
  * exactly as the Hub feeds it (a borrow doesn't change it), so the figures match
  * the Hub even for a strategy that uses deficit or an asset with bad debt. Reads

--- a/services/vault/src/applications/aave/clients/aaveHub.ts
+++ b/services/vault/src/applications/aave/clients/aaveHub.ts
@@ -17,6 +17,15 @@ export async function getAssetDrawnRatesSafe(
 
 export type { AssetDrawnRateRequest, AssetDrawnRateResult };
 
+/** RAY fixed-point scale Aave uses for rates (1e27 = 100%). */
+const RAY = 10n ** 27n;
+const PERCENT_SCALE = 100;
+
+/** Converts a RAY-scaled rate to a percent number (e.g. 3.7 for 3.7%). */
+function rateRayToPercent(rateRay: bigint): number {
+  return (Number(rateRay) / Number(RAY)) * PERCENT_SCALE;
+}
+
 /**
  * Minimal Hub ABI for the two reserve-total reads. The SDK's `AaveHub.abi.json`
  * is the rate-read subset (`getAssetDrawnRate` only), so — matching the
@@ -36,6 +45,79 @@ const HUB_LIQUIDITY_ABI = [
     name: "getAssetTotalOwed",
     stateMutability: "view",
     inputs: [{ name: "assetId", type: "uint256" }],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+] as const;
+
+/**
+ * Minimal Hub + interest-rate-strategy ABI for the projected-rate read. The
+ * SDK's `AaveHub.abi.json` is the rate-read subset (`getAssetDrawnRate` only),
+ * so — matching the cap-policy reader's self-contained-fragment pattern — these
+ * reads are kept app-side rather than widening the shared SDK ABI for one
+ * display surface.
+ *
+ * The Hub feeds the strategy the same totals it uses on-chain
+ * (`AssetLogic.getDrawnRate`): `getAssetOwed` returns `[drawn, premium]` and
+ * the curve's utilization is `drawn / (liquidity + drawn + swept)`. The
+ * strategy address comes from `getAssetConfig`.
+ */
+const HUB_RATE_ABI = [
+  {
+    type: "function",
+    name: "getAssetLiquidity",
+    stateMutability: "view",
+    inputs: [{ name: "assetId", type: "uint256" }],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "getAssetOwed",
+    stateMutability: "view",
+    inputs: [{ name: "assetId", type: "uint256" }],
+    outputs: [
+      { name: "drawn", type: "uint256" },
+      { name: "premium", type: "uint256" },
+    ],
+  },
+  {
+    type: "function",
+    name: "getAssetSwept",
+    stateMutability: "view",
+    inputs: [{ name: "assetId", type: "uint256" }],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "getAssetConfig",
+    stateMutability: "view",
+    inputs: [{ name: "assetId", type: "uint256" }],
+    outputs: [
+      {
+        name: "",
+        type: "tuple",
+        components: [
+          { name: "feeReceiver", type: "address" },
+          { name: "liquidityFee", type: "uint16" },
+          { name: "irStrategy", type: "address" },
+          { name: "reinvestmentController", type: "address" },
+        ],
+      },
+    ],
+  },
+] as const;
+
+const IR_STRATEGY_ABI = [
+  {
+    type: "function",
+    name: "calculateInterestRate",
+    stateMutability: "view",
+    inputs: [
+      { name: "assetId", type: "uint256" },
+      { name: "liquidity", type: "uint256" },
+      { name: "drawn", type: "uint256" },
+      { name: "deficit", type: "uint256" },
+      { name: "swept", type: "uint256" },
+    ],
     outputs: [{ name: "", type: "uint256" }],
   },
 ] as const;
@@ -130,4 +212,172 @@ export async function getAssetLiquiditiesSafe(
       error: null,
     };
   });
+}
+
+/** Identifies one Hub asset and the borrow size to project the rate for. */
+export interface ProjectedBorrowAprRequest {
+  /** Hub contract address (from the reserve's `hub` field). */
+  hub: Address;
+  /** Asset identifier on that Hub (from the reserve's `assetId` field). */
+  assetId: number;
+  /**
+   * Borrow amount in the asset's smallest units (raw, decimals already
+   * applied). Drawing this amount moves it from `liquidity` into `drawn`,
+   * raising utilization and so the rate. `0n` yields `projectedPercent`
+   * equal to `currentPercent`.
+   */
+  borrowAmountRaw: bigint;
+}
+
+export interface ProjectedBorrowAprResult {
+  /** Current borrow APR percent at the live utilization, or null on revert. */
+  currentPercent: number | null;
+  /**
+   * Borrow APR percent at the post-borrow utilization, or null on revert.
+   * Never below `currentPercent`: borrowing only raises utilization.
+   */
+  projectedPercent: number | null;
+  error: Error | null;
+}
+
+const NULL_PROJECTION = {
+  currentPercent: null,
+  projectedPercent: null,
+} as const;
+
+/**
+ * Computes the current and post-borrow borrow APR for one Hub asset using the
+ * asset's on-chain interest-rate strategy — no off-chain reimplementation of
+ * the rate curve. The rate is a pure function of the asset totals the Hub
+ * itself feeds the strategy:
+ *
+ *   rate = irStrategy.calculateInterestRate(assetId, liquidity, drawn, _, swept)
+ *   utilization = drawn / (liquidity + drawn + swept)
+ *
+ * Both endpoints are read from the same strategy view so the current -> projected
+ * delta is exact and monotonic. A new borrow of `borrowAmountRaw` moves that
+ * amount from `liquidity` to `drawn` (`deficit` is unused by the curve, passed
+ * as 0). Reads are isolated with `allowFailure`: any revert (e.g. an asset with
+ * no strategy configured) returns nulls rather than throwing, since callers are
+ * display surfaces that fall back to a placeholder.
+ */
+export async function getProjectedBorrowAprPercentsSafe({
+  hub,
+  assetId,
+  borrowAmountRaw,
+}: ProjectedBorrowAprRequest): Promise<ProjectedBorrowAprResult> {
+  const publicClient = ethClient.getPublicClient();
+  const assetIdArg = BigInt(assetId);
+
+  let totals;
+  try {
+    totals = await publicClient.multicall({
+      contracts: [
+        {
+          address: hub,
+          abi: HUB_RATE_ABI as Abi,
+          functionName: "getAssetLiquidity" as const,
+          args: [assetIdArg] as const,
+        },
+        {
+          address: hub,
+          abi: HUB_RATE_ABI as Abi,
+          functionName: "getAssetOwed" as const,
+          args: [assetIdArg] as const,
+        },
+        {
+          address: hub,
+          abi: HUB_RATE_ABI as Abi,
+          functionName: "getAssetSwept" as const,
+          args: [assetIdArg] as const,
+        },
+        {
+          address: hub,
+          abi: HUB_RATE_ABI as Abi,
+          functionName: "getAssetConfig" as const,
+          args: [assetIdArg] as const,
+        },
+      ],
+      allowFailure: true,
+    });
+  } catch (err) {
+    return {
+      ...NULL_PROJECTION,
+      error: err instanceof Error ? err : new Error(String(err)),
+    };
+  }
+
+  const [liquidityCall, owedCall, sweptCall, configCall] = totals;
+  if (
+    liquidityCall.status !== "success" ||
+    owedCall.status !== "success" ||
+    sweptCall.status !== "success" ||
+    configCall.status !== "success"
+  ) {
+    return {
+      ...NULL_PROJECTION,
+      error: new Error("Hub asset totals read reverted"),
+    };
+  }
+
+  const liquidity = liquidityCall.result as bigint;
+  // getAssetOwed returns [drawn, premium]; the strategy curve uses `drawn`.
+  const drawn = (owedCall.result as readonly bigint[])[0];
+  const swept = sweptCall.result as bigint;
+  const { irStrategy } = configCall.result as { irStrategy: Address };
+
+  // Borrowing moves the drawn amount out of liquidity, so the denominator
+  // (liquidity + drawn + swept) is invariant. A borrow can't exceed available
+  // liquidity, so cap the moved amount at `liquidity`: an oversized entry
+  // saturates the projection at draining the reserve rather than inventing
+  // liquidity (which would inflate the denominator and understate the rate).
+  const effectiveBorrowRaw =
+    borrowAmountRaw > liquidity ? liquidity : borrowAmountRaw;
+  const projectedLiquidity = liquidity - effectiveBorrowRaw;
+  const projectedDrawn = drawn + effectiveBorrowRaw;
+
+  let rates;
+  try {
+    rates = await publicClient.multicall({
+      contracts: [
+        {
+          address: irStrategy,
+          abi: IR_STRATEGY_ABI as Abi,
+          functionName: "calculateInterestRate" as const,
+          args: [assetIdArg, liquidity, drawn, 0n, swept] as const,
+        },
+        {
+          address: irStrategy,
+          abi: IR_STRATEGY_ABI as Abi,
+          functionName: "calculateInterestRate" as const,
+          args: [
+            assetIdArg,
+            projectedLiquidity,
+            projectedDrawn,
+            0n,
+            swept,
+          ] as const,
+        },
+      ],
+      allowFailure: true,
+    });
+  } catch (err) {
+    return {
+      ...NULL_PROJECTION,
+      error: err instanceof Error ? err : new Error(String(err)),
+    };
+  }
+
+  const [currentCall, projectedCall] = rates;
+  return {
+    currentPercent:
+      currentCall.status === "success"
+        ? rateRayToPercent(currentCall.result as bigint)
+        : null,
+    projectedPercent:
+      projectedCall.status === "success"
+        ? rateRayToPercent(projectedCall.result as bigint)
+        : null,
+    error: null,
+  };
 }

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/BorrowMetricsCard/BorrowMetricsCard.tsx
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/BorrowMetricsCard/BorrowMetricsCard.tsx
@@ -92,7 +92,9 @@ export function BorrowMetricsCard({
         {borrowAprProjected ? (
           <span className="flex items-center gap-2 text-accent-primary">
             <span className="text-accent-secondary">{borrowApr}</span>
-            <span className="text-accent-secondary">→</span>
+            <span className="text-accent-secondary">
+              {COPY.common.valueTransitionArrow}
+            </span>
             <span>{borrowAprProjected}</span>
           </span>
         ) : (

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/BorrowMetricsCard/BorrowMetricsCard.tsx
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/BorrowMetricsCard/BorrowMetricsCard.tsx
@@ -17,6 +17,11 @@ interface BorrowMetricsCardProps {
   availableLiquidityProjected?: string;
   /** Formatted current borrow APR (live from the Aave Hub), or "–". */
   borrowApr: string;
+  /**
+   * Formatted post-borrow borrow APR. When set, the row shows
+   * `current → projected`; omit it to show the current value alone.
+   */
+  borrowAprProjected?: string;
   /** Formatted utilization percentage (borrowed / supplied), or "–". */
   utilization: string;
   healthFactor: string;
@@ -30,16 +35,18 @@ const DIVIDER_CLASS = "h-px w-full bg-secondary-strokeLight";
 
 /**
  * Borrow metrics card. Borrow APR, Available liquidity, and Utilization all
- * show live values read from the Aave Hub for the selected reserve; Health
- * factor uses its real projected value. Each figure falls back to the empty
- * placeholder ("–") while its read is loading or unavailable rather than
- * rendering a fabricated value. (The projected post-borrow rate is not a simple
- * read, so only the current borrow APR is shown.)
+ * show live values read from the Aave Hub for the selected reserve, and Health
+ * factor uses its real projected value. Once an amount is entered, the Borrow
+ * APR and Available liquidity rows render `current → projected` (the new borrow
+ * raises the reserve's utilization), as does Health factor. Each figure falls
+ * back to the empty placeholder ("–") while its read is loading or unavailable
+ * rather than rendering a fabricated value.
  */
 export function BorrowMetricsCard({
   availableLiquidity,
   availableLiquidityProjected,
   borrowApr,
+  borrowAprProjected,
   utilization,
   healthFactor,
   healthFactorValue,
@@ -82,7 +89,15 @@ export function BorrowMetricsCard({
           {COPY.loans.borrowRateLabel}
           <Hint tooltip={COPY.loans.borrowAprTooltip} />
         </div>
-        <span className="text-accent-primary">{borrowApr}</span>
+        {borrowAprProjected ? (
+          <span className="flex items-center gap-2 text-accent-primary">
+            <span className="text-accent-secondary">{borrowApr}</span>
+            <span className="text-accent-secondary">→</span>
+            <span>{borrowAprProjected}</span>
+          </span>
+        ) : (
+          <span className="text-accent-primary">{borrowApr}</span>
+        )}
       </div>
 
       <div className={ROW_CLASS}>

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/BorrowMetricsCard/__tests__/BorrowMetricsCard.test.tsx
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/BorrowMetricsCard/__tests__/BorrowMetricsCard.test.tsx
@@ -1,35 +1,34 @@
 /**
- * BorrowMetricsCard — Available liquidity before → after projection.
- *
- * Locks in that the row shows the post-borrow figure as `current → projected`
- * when a projection is supplied (mirroring the health-factor row), and the
- * current value alone otherwise.
+ * BorrowMetricsCard — the Available liquidity and Borrow APR rows each render
+ * `current → projected` when a projection is supplied (mirroring the
+ * health-factor row), and the current value alone otherwise.
  */
 
 import { render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
 
-import { BorrowMetricsCard } from "../BorrowMetricsCard";
-
+// Component tests mock core-ui (its dist isn't built in the test run).
 vi.mock("@babylonlabs-io/core-ui", () => ({
-  SubSection: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   Hint: () => null,
+  SubSection: ({ children }: { children: ReactNode }) => <div>{children}</div>,
 }));
 
 vi.mock("@/components/shared", () => ({
-  HeartIcon: () => null,
+  HeartIcon: () => <span data-testid="heart-icon" />,
 }));
+
+import { BorrowMetricsCard } from "../BorrowMetricsCard";
 
 const baseProps = {
   availableLiquidity: "45.2K",
-  borrowApr: "3.7%",
+  borrowApr: "3.70%",
   utilization: "25%",
   healthFactor: "2.10",
   healthFactorValue: 2.1,
 };
 
-describe("BorrowMetricsCard", () => {
+describe("BorrowMetricsCard available liquidity row", () => {
   it("shows available liquidity as current → projected when a projection is given", () => {
     render(
       <BorrowMetricsCard {...baseProps} availableLiquidityProjected="0 USDT" />,
@@ -47,5 +46,24 @@ describe("BorrowMetricsCard", () => {
 
     expect(screen.getByText("45.2K USDT")).toBeInTheDocument();
     expect(screen.queryByText("→")).not.toBeInTheDocument();
+  });
+});
+
+describe("BorrowMetricsCard borrow APR row", () => {
+  it("shows the current APR alone when no projection is provided", () => {
+    render(<BorrowMetricsCard {...baseProps} />);
+
+    expect(screen.getByText("3.70%")).toBeInTheDocument();
+    // No transition arrow without a projected value (health factor row also
+    // has none here since healthFactorOriginal is unset).
+    expect(screen.queryByText("→")).not.toBeInTheDocument();
+  });
+
+  it("shows current → projected when a projected APR is provided", () => {
+    render(<BorrowMetricsCard {...baseProps} borrowAprProjected="4.20%" />);
+
+    expect(screen.getByText("3.70%")).toBeInTheDocument();
+    expect(screen.getByText("4.20%")).toBeInTheDocument();
+    expect(screen.getByText("→")).toBeInTheDocument();
   });
 });

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/index.tsx
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/index.tsx
@@ -39,9 +39,9 @@ import {
 } from "../../../constants";
 import { useAaveConfig } from "../../../context";
 import {
-  useAaveBorrowAprs,
   useAaveReserveLiquidity,
   useBorrowTransaction,
+  useProjectedBorrowApr,
 } from "../../../hooks";
 import { AssetPill } from "../../AssetPill";
 import { useLoanContext } from "../../context/LoanContext";
@@ -176,18 +176,26 @@ export function Borrow() {
 
   const { borrowableReserves } = useAaveConfig();
 
-  // Live current borrow APR for the selected reserve (Aave Hub drawn rate).
-  // The projected post-borrow rate isn't a simple read, so only "current"
-  // shows real data.
-  const { aprPercentByReserveId } = useAaveBorrowAprs({
-    reserves: [selectedReserve],
-  });
-  const borrowAprPercent =
-    aprPercentByReserveId[selectedReserve.reserveId.toString()];
+  // Current and projected borrow APR for the selected reserve, both evaluated
+  // from the Hub asset's on-chain interest-rate strategy so the entered amount's
+  // effect on utilization is exact. The projected figure is shown only once an
+  // amount raises the rate enough to differ from the current after formatting.
+  const { currentPercent: borrowAprPercent, projectedPercent } =
+    useProjectedBorrowApr({ reserve: selectedReserve, borrowAmount });
   const borrowAprDisplay =
     borrowAprPercent == null
       ? COPY.common.emptyValue
       : formatAprPercent(borrowAprPercent);
+  const borrowAprProjectedDisplay =
+    hasProjection && borrowAprPercent != null && projectedPercent != null
+      ? formatAprPercent(projectedPercent)
+      : undefined;
+  // Suppress the arrow when the projection rounds to the current value (e.g.
+  // a tiny amount, or the debounced amount has not yet caught up to the input).
+  const borrowAprProjected =
+    borrowAprProjectedDisplay && borrowAprProjectedDisplay !== borrowAprDisplay
+      ? borrowAprProjectedDisplay
+      : undefined;
 
   // Borrowing draws the entered amount from the reserve, so the row shows the
   // current liquidity reducing to the post-borrow figure (current → projected),
@@ -342,6 +350,7 @@ export function Borrow() {
           availableLiquidity={availableLiquidityDisplay}
           availableLiquidityProjected={availableLiquidityProjectedDisplay}
           borrowApr={borrowAprDisplay}
+          borrowAprProjected={borrowAprProjected}
           utilization={utilizationDisplay}
           healthFactor={metrics.healthFactor}
           healthFactorValue={metrics.healthFactorValue}

--- a/services/vault/src/applications/aave/hooks/__tests__/useProjectedBorrowApr.test.tsx
+++ b/services/vault/src/applications/aave/hooks/__tests__/useProjectedBorrowApr.test.tsx
@@ -1,0 +1,192 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../clients/aaveHub", () => ({
+  getProjectedBorrowAprPercentsSafe: vi.fn(),
+}));
+
+import { getProjectedBorrowAprPercentsSafe } from "../../clients/aaveHub";
+import type { AaveReserveConfig } from "../../services/fetchConfig";
+import { useProjectedBorrowApr } from "../useProjectedBorrowApr";
+
+const HUB = "0x0000000000000000000000000000000000000003" as const;
+
+function makeReserve(decimals: number, assetId = 0): AaveReserveConfig {
+  return {
+    reserveId: 1n,
+    reserve: {
+      underlying: "0x0000000000000000000000000000000000000010",
+      hub: HUB,
+      assetId,
+      decimals,
+      dynamicConfigKey: 0,
+      paused: false,
+      frozen: false,
+      borrowable: true,
+      collateralRisk: 0,
+      collateralFactor: 8000,
+    },
+    token: {
+      address: "0x0000000000000000000000000000000000000010",
+      symbol: "USDT",
+      name: "Tether USD",
+      decimals,
+    },
+  };
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe("useProjectedBorrowApr", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the current and projected percents from the reader", async () => {
+    vi.mocked(getProjectedBorrowAprPercentsSafe).mockResolvedValue({
+      currentPercent: 3.7,
+      projectedPercent: 4.2,
+      error: null,
+    });
+
+    const { result } = renderHook(
+      () =>
+        useProjectedBorrowApr({ reserve: makeReserve(6), borrowAmount: 100 }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.currentPercent).toBe(3.7));
+    expect(result.current.projectedPercent).toBe(4.2);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("scales the entered amount to the token's smallest units", async () => {
+    vi.mocked(getProjectedBorrowAprPercentsSafe).mockResolvedValue({
+      currentPercent: 1,
+      projectedPercent: 1,
+      error: null,
+    });
+
+    renderHook(
+      () =>
+        useProjectedBorrowApr({ reserve: makeReserve(6), borrowAmount: 100.5 }),
+      { wrapper },
+    );
+
+    await waitFor(() =>
+      expect(getProjectedBorrowAprPercentsSafe).toHaveBeenCalledWith({
+        hub: HUB,
+        assetId: 0,
+        borrowAmountRaw: 100_500_000n, // 100.5 * 1e6
+      }),
+    );
+  });
+
+  it("surfaces the reader's non-throwing error while nulling the figures", async () => {
+    vi.mocked(getProjectedBorrowAprPercentsSafe).mockResolvedValue({
+      currentPercent: null,
+      projectedPercent: null,
+      error: new Error("Hub asset totals read reverted"),
+    });
+
+    const { result } = renderHook(
+      () => useProjectedBorrowApr({ reserve: makeReserve(6), borrowAmount: 0 }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.error).toBeInstanceOf(Error));
+    expect(result.current.currentPercent).toBeNull();
+    expect(result.current.projectedPercent).toBeNull();
+  });
+
+  it("does not surface the previous reserve's APR while the new reserve loads", async () => {
+    let resolveB: (value: {
+      currentPercent: number | null;
+      projectedPercent: number | null;
+      error: Error | null;
+    }) => void = () => {};
+    vi.mocked(getProjectedBorrowAprPercentsSafe)
+      .mockResolvedValueOnce({
+        currentPercent: 3.7,
+        projectedPercent: 3.7,
+        error: null,
+      })
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveB = resolve;
+        }),
+      );
+
+    const { result, rerender } = renderHook(
+      ({ reserve }) => useProjectedBorrowApr({ reserve, borrowAmount: 0 }),
+      { wrapper, initialProps: { reserve: makeReserve(6, 1) } },
+    );
+    await waitFor(() => expect(result.current.currentPercent).toBe(3.7));
+
+    // Switch to a different reserve whose read is still in flight.
+    rerender({ reserve: makeReserve(6, 2) });
+    // The stale 3.7 from reserve 1 must not carry over to reserve 2.
+    await waitFor(() => expect(result.current.currentPercent).toBeNull());
+
+    resolveB({ currentPercent: 9.9, projectedPercent: 9.9, error: null });
+    await waitFor(() => expect(result.current.currentPercent).toBe(9.9));
+  });
+
+  describe("debounces amount edits before the on-chain read", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("waits for the amount to settle before reading the new projection", async () => {
+      vi.mocked(getProjectedBorrowAprPercentsSafe).mockResolvedValue({
+        currentPercent: 3.7,
+        projectedPercent: 3.7,
+        error: null,
+      });
+
+      const { rerender } = renderHook(
+        ({ amount }) =>
+          useProjectedBorrowApr({
+            reserve: makeReserve(6),
+            borrowAmount: amount,
+          }),
+        { wrapper, initialProps: { amount: 0 } },
+      );
+
+      // Initial value reads immediately (no settle needed for the current rate).
+      expect(getProjectedBorrowAprPercentsSafe).toHaveBeenLastCalledWith({
+        hub: HUB,
+        assetId: 0,
+        borrowAmountRaw: 0n,
+      });
+
+      rerender({ amount: 50 });
+      // Before the debounce elapses, no read for the new amount.
+      expect(getProjectedBorrowAprPercentsSafe).not.toHaveBeenCalledWith({
+        hub: HUB,
+        assetId: 0,
+        borrowAmountRaw: 50_000_000n,
+      });
+
+      await act(async () => {
+        vi.advanceTimersByTime(300);
+      });
+
+      expect(getProjectedBorrowAprPercentsSafe).toHaveBeenLastCalledWith({
+        hub: HUB,
+        assetId: 0,
+        borrowAmountRaw: 50_000_000n,
+      });
+    });
+  });
+});

--- a/services/vault/src/applications/aave/hooks/__tests__/useProjectedBorrowApr.test.tsx
+++ b/services/vault/src/applications/aave/hooks/__tests__/useProjectedBorrowApr.test.tsx
@@ -106,6 +106,45 @@ describe("useProjectedBorrowApr", () => {
     expect(result.current.projectedPercent).toBeNull();
   });
 
+  it("withholds the projected rate while showing placeholder data for a stale amount", async () => {
+    let resolveSecond: (value: {
+      currentPercent: number | null;
+      projectedPercent: number | null;
+      error: Error | null;
+    }) => void = () => {};
+    vi.mocked(getProjectedBorrowAprPercentsSafe)
+      .mockResolvedValueOnce({
+        currentPercent: 3.7,
+        projectedPercent: 3.7,
+        error: null,
+      })
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveSecond = resolve;
+        }),
+      );
+
+    const { result, rerender } = renderHook(
+      ({ amount }) =>
+        useProjectedBorrowApr({
+          reserve: makeReserve(6, 1),
+          borrowAmount: amount,
+        }),
+      { wrapper, initialProps: { amount: 0 } },
+    );
+    await waitFor(() => expect(result.current.projectedPercent).toBe(3.7));
+
+    // Change the amount (same reserve): the read for the new amount is in flight,
+    // so the hook shows placeholder data. The current rate (amount-independent)
+    // is retained, but the stale projection must be withheld.
+    rerender({ amount: 100 });
+    await waitFor(() => expect(result.current.projectedPercent).toBeNull());
+    expect(result.current.currentPercent).toBe(3.7);
+
+    resolveSecond({ currentPercent: 3.7, projectedPercent: 5.2, error: null });
+    await waitFor(() => expect(result.current.projectedPercent).toBe(5.2));
+  });
+
   it("does not surface the previous reserve's APR while the new reserve loads", async () => {
     let resolveB: (value: {
       currentPercent: number | null;

--- a/services/vault/src/applications/aave/hooks/index.ts
+++ b/services/vault/src/applications/aave/hooks/index.ts
@@ -40,6 +40,10 @@ export {
   type UsePositionNotificationsResult,
 } from "./usePositionNotifications";
 export {
+  useProjectedBorrowApr,
+  type UseProjectedBorrowAprResult,
+} from "./useProjectedBorrowApr";
+export {
   useReorderVaults,
   type UseReorderVaultsResult,
 } from "./useReorderVaults";

--- a/services/vault/src/applications/aave/hooks/useProjectedBorrowApr.ts
+++ b/services/vault/src/applications/aave/hooks/useProjectedBorrowApr.ts
@@ -8,8 +8,10 @@
  *
  * The entered amount is debounced before it reaches the query key: the slider
  * fires continuously while dragging, and each distinct amount is its own
- * on-chain read. `keepPreviousData` holds the last figures during a refetch so
- * the row doesn't blank between keystrokes.
+ * on-chain read. `placeholderData` keeps the previous reserve's figures during a
+ * refetch so the current rate doesn't blank between edits; the amount-specific
+ * `projectedPercent` is withheld while showing placeholder data so a stale
+ * projection is never labeled as the new amount's.
  *
  * Wallet-less: reads go through the app's public RPC client.
  */
@@ -69,7 +71,7 @@ export function useProjectedBorrowApr({
   const { hub, assetId } = reserve.reserve;
   const hubKey = hub.toLowerCase();
 
-  const { data, isLoading, error } = useQuery({
+  const { data, isLoading, error, isPlaceholderData } = useQuery({
     queryKey: [QUERY_KEY, hubKey, assetId, borrowAmountRaw.toString()],
     queryFn: () =>
       getProjectedBorrowAprPercentsSafe({ hub, assetId, borrowAmountRaw }),
@@ -87,10 +89,15 @@ export function useProjectedBorrowApr({
   });
 
   // Surface the SDK-style error from a non-throwing read while still falling
-  // back to nulls, so callers render the empty placeholder.
+  // back to nulls, so callers render the empty placeholder. The current rate is
+  // amount-independent so placeholder data is fine, but the projected rate is
+  // amount-specific: withhold it while showing a placeholder (it was computed
+  // for the previous amount) so the row never labels a stale projection.
   return {
     currentPercent: data?.currentPercent ?? null,
-    projectedPercent: data?.projectedPercent ?? null,
+    projectedPercent: isPlaceholderData
+      ? null
+      : (data?.projectedPercent ?? null),
     isLoading,
     error: (error as Error | null) ?? data?.error ?? null,
   };

--- a/services/vault/src/applications/aave/hooks/useProjectedBorrowApr.ts
+++ b/services/vault/src/applications/aave/hooks/useProjectedBorrowApr.ts
@@ -1,0 +1,97 @@
+/**
+ * Current and projected (post-borrow) borrow APR for the selected reserve.
+ *
+ * The borrow APR is a function of the Hub asset's utilization, which a new
+ * borrow raises. Both endpoints are read from the asset's on-chain interest-rate
+ * strategy (see `getProjectedBorrowAprPercentsSafe`) so the `current -> projected`
+ * delta is exact rather than a frontend re-derivation of the rate curve.
+ *
+ * The entered amount is debounced before it reaches the query key: the slider
+ * fires continuously while dragging, and each distinct amount is its own
+ * on-chain read. `keepPreviousData` holds the last figures during a refetch so
+ * the row doesn't blank between keystrokes.
+ *
+ * Wallet-less: reads go through the app's public RPC client.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+import { parseUnits } from "viem";
+
+import { getProjectedBorrowAprPercentsSafe } from "../clients/aaveHub";
+import { SAFE_TOFIXED_PRECISION } from "../constants";
+import type { AaveReserveConfig } from "../services/fetchConfig";
+
+const QUERY_KEY = "aaveProjectedBorrowApr";
+const ONE_MINUTE_MS = 60 * 1000;
+/** Settle time before an edited amount triggers a fresh on-chain read. */
+const AMOUNT_DEBOUNCE_MS = 300;
+
+export interface UseProjectedBorrowAprResult {
+  /** Current borrow APR percent, or null while loading/unavailable. */
+  currentPercent: number | null;
+  /** Post-borrow borrow APR percent, or null while loading/unavailable. */
+  projectedPercent: number | null;
+  isLoading: boolean;
+  error: Error | null;
+}
+
+export function useProjectedBorrowApr({
+  reserve,
+  borrowAmount,
+}: {
+  reserve: AaveReserveConfig;
+  borrowAmount: number;
+}): UseProjectedBorrowAprResult {
+  // Debounce the entered amount so dragging the slider doesn't issue an
+  // on-chain read per tick. The current rate (amount 0) needs no settling, so
+  // seed with the live value and only delay subsequent edits.
+  const [debouncedAmount, setDebouncedAmount] = useState(borrowAmount);
+  useEffect(() => {
+    const timeout = setTimeout(
+      () => setDebouncedAmount(borrowAmount),
+      AMOUNT_DEBOUNCE_MS,
+    );
+    return () => clearTimeout(timeout);
+  }, [borrowAmount]);
+
+  const { decimals } = reserve.token;
+  // Clamp toFixed precision to SAFE_TOFIXED_PRECISION to avoid IEEE 754
+  // artifacts, mirroring the borrow-tx conversion; the projection only needs
+  // display-grade precision regardless.
+  const borrowAmountRaw = parseUnits(
+    Math.max(debouncedAmount, 0).toFixed(
+      Math.min(decimals, SAFE_TOFIXED_PRECISION),
+    ),
+    decimals,
+  );
+
+  const { hub, assetId } = reserve.reserve;
+  const hubKey = hub.toLowerCase();
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: [QUERY_KEY, hubKey, assetId, borrowAmountRaw.toString()],
+    queryFn: () =>
+      getProjectedBorrowAprPercentsSafe({ hub, assetId, borrowAmountRaw }),
+    // Hold the last figures across amount edits (the slider settles between
+    // reads) so the row doesn't blank, but NOT across a reserve switch — the
+    // new reserve must not briefly display the previous reserve's APR.
+    placeholderData: (previous, previousQuery) => {
+      const previousKey = previousQuery?.queryKey;
+      return previousKey?.[1] === hubKey && previousKey?.[2] === assetId
+        ? previous
+        : undefined;
+    },
+    staleTime: ONE_MINUTE_MS,
+    refetchInterval: ONE_MINUTE_MS,
+  });
+
+  // Surface the SDK-style error from a non-throwing read while still falling
+  // back to nulls, so callers render the empty placeholder.
+  return {
+    currentPercent: data?.currentPercent ?? null,
+    projectedPercent: data?.projectedPercent ?? null,
+    isLoading,
+    error: (error as Error | null) ?? data?.error ?? null,
+  };
+}


### PR DESCRIPTION
## Summary

Wires the **projected post-borrow APR** into the borrow flow. The borrow metrics
card previously showed only the current Borrow APR; it now renders
`current → projected` once an amount is entered, mirroring the health-factor row.

Closes #1888

## What changed

- **Rate read — Aave Hub interest-rate strategy, computed on-chain.** A new
  borrow raises the reserve's utilization, which changes the rate. Rather than
  re-deriving the kinked rate curve in the frontend (a subtly-wrong APR is worse
  than `–` on this surface), both endpoints are read from the asset's on-chain
  strategy via `calculateInterestRate`. Per asset we read the Hub totals
  (`getAssetLiquidity`, `getAssetOwed`, `getAssetSwept`, `getAssetConfig`) then
  evaluate the strategy at the current and post-borrow utilization. The borrow
  moves `min(amount, liquidity)` from `liquidity` to `drawn`, so the denominator
  `liquidity + drawn + swept` stays invariant and the delta is exact and
  monotonic.
- **App-side read.** Kept in the vault's `clients/aaveHub.ts` with a minimal
  local ABI fragment, matching the existing Hub readers, rather than widening the
  shared ts-sdk for one display surface.
- **Surface.** Borrow metrics card "Borrow APR" row shows `current → projected`
  when an amount is entered, the current value alone otherwise, and the empty
  placeholder while the read is loading or unavailable — no fabricated figures.
  The arrow is suppressed when the projection rounds to the current value.
- **Hook.** `useProjectedBorrowApr` reads for the selected reserve, debounces the
  entered amount (the slider fires continuously), and scopes `placeholderData`
  so a reserve switch does not briefly display the previous reserve's APR.
- Available liquidity and Utilization remain `–` here; those reserve totals are a
  separate read (tracked in #1887).

## Testing

- Unit: the Hub projection read (current/projected from the strategy curve,
  post-borrow totals, the over-liquidity cap, per-leg and network failure → `–`),
  the `useProjectedBorrowApr` hook (token-unit conversion, debounce, reserve-switch
  staleness), and the borrow-card `current → projected` row.
- `pnpm run lint`, `pnpm exec tsc --noEmit -p tsconfig.lib.json`, and the affected
  vitest suites pass.
