### PR TITLE
fix(vault): validate pegInAmounts before the WASM BigUint64Array

### DIFF
--- a/packages/babylon-tbv-rust-wasm/src/index-node.ts
+++ b/packages/babylon-tbv-rust-wasm/src/index-node.ts
@@ -27,7 +27,7 @@ import type {
   ChallengeAssertConnectorParams,
   ChallengeAssertScriptInfo,
 } from "./types.js";
-import { assertWasmBigint } from "./value-guards.js";
+import { assertPositiveBigintArray, assertWasmBigint } from "./value-guards.js";
 
 /**
  * HTLC output index for single deposits.
@@ -77,7 +77,9 @@ export async function createPrePeginTransaction(
     params.vaultKeeperPubkeys,
     params.universalChallengerPubkeys,
     [...params.hashlocks],
-    new BigUint64Array(params.pegInAmounts),
+    new BigUint64Array(
+      assertPositiveBigintArray(params.pegInAmounts, "pegInAmounts"),
+    ),
     params.timelockRefund,
     params.feeRate,
     params.minPeginFeeRate,
@@ -150,7 +152,9 @@ export async function buildPeginTxFromPrePegin(
     params.vaultKeeperPubkeys,
     params.universalChallengerPubkeys,
     [...params.hashlocks],
-    new BigUint64Array(params.pegInAmounts),
+    new BigUint64Array(
+      assertPositiveBigintArray(params.pegInAmounts, "pegInAmounts"),
+    ),
     params.timelockRefund,
     params.feeRate,
     params.minPeginFeeRate,
@@ -483,6 +487,9 @@ export type {
 
 // Export constants
 export { TAP_INTERNAL_KEY, tapInternalPubkey } from "./constants.js";
+
+// Export boundary value guards (input validation for callers)
+export { assertPositiveBigintArray } from "./value-guards.js";
 
 // Re-export WASM classes (mirrors index.ts browser entry)
 export { WasmPrePeginTx, WasmPeginTx, WasmPrePeginHtlcConnector, WasmPeginPayoutConnector };

--- a/packages/babylon-tbv-rust-wasm/src/index.ts
+++ b/packages/babylon-tbv-rust-wasm/src/index.ts
@@ -7,7 +7,7 @@ import type {
   HtlcConnectorParams,
   HtlcConnectorInfo,
 } from "./types.js";
-import { assertWasmBigint } from "./value-guards.js";
+import { assertPositiveBigintArray, assertWasmBigint } from "./value-guards.js";
 
 let wasmInitialized = false;
 let wasmInitPromise: Promise<void> | null = null;
@@ -75,7 +75,9 @@ export async function createPrePeginTransaction(
     params.vaultKeeperPubkeys,
     params.universalChallengerPubkeys,
     [...params.hashlocks],
-    new BigUint64Array(params.pegInAmounts),
+    new BigUint64Array(
+      assertPositiveBigintArray(params.pegInAmounts, "pegInAmounts"),
+    ),
     params.timelockRefund,
     params.feeRate,
     params.minPeginFeeRate,
@@ -160,7 +162,9 @@ export async function buildPeginTxFromPrePegin(
     params.vaultKeeperPubkeys,
     params.universalChallengerPubkeys,
     [...params.hashlocks],
-    new BigUint64Array(params.pegInAmounts),
+    new BigUint64Array(
+      assertPositiveBigintArray(params.pegInAmounts, "pegInAmounts"),
+    ),
     params.timelockRefund,
     params.feeRate,
     params.minPeginFeeRate,
@@ -398,6 +402,9 @@ export type {
 
 // Export constants
 export { TAP_INTERNAL_KEY, tapInternalPubkey } from "./constants.js";
+
+// Export boundary value guards (input validation for callers)
+export { assertPositiveBigintArray } from "./value-guards.js";
 
 // Export payout connector utilities
 export { createPayoutConnector, getPeginPayoutScriptInfo } from "./payoutConnector.js";

--- a/packages/babylon-tbv-rust-wasm/src/value-guards.ts
+++ b/packages/babylon-tbv-rust-wasm/src/value-guards.ts
@@ -1,5 +1,6 @@
 /**
- * Runtime guards for value-bearing scalars crossing the WASM FFI boundary.
+ * Runtime guards for value-bearing scalars crossing the WASM FFI boundary,
+ * in both directions.
  *
  * wasm-bindgen returns `u64` outputs as JS `bigint`, but nothing in the type
  * system enforces the shape or sign at runtime: an ABI regression or a
@@ -7,6 +8,13 @@
  * would then flow into satoshi math unchecked. Every sat-valued WASM return
  * is funneled through {@link assertWasmBigint} so an invalid value fails loudly
  * at the seam instead of silently corrupting a transaction.
+ *
+ * The same risk exists on the way *in*: `new BigUint64Array(values)` is the
+ * only way satoshi amounts are handed to the constructor, and a runtime cast
+ * (`as readonly bigint[]`) lets a caller pass a non-bigint or non-positive
+ * element that `BigUint64Array` would either reject cryptically or, in its
+ * length-arg form, silently zero-fill. {@link assertPositiveBigintArray}
+ * validates such inputs before the typed-array construction.
  */
 
 /**
@@ -29,4 +37,43 @@ export function assertWasmBigint(value: unknown, label: string): bigint {
     );
   }
   return value;
+}
+
+/**
+ * Assert a value is a non-empty array of strictly-positive `bigint`s and return
+ * it narrowed, ready to feed into `new BigUint64Array(...)`.
+ *
+ * Input counterpart to {@link assertWasmBigint}: TypeScript types the satoshi
+ * amounts as `readonly bigint[]`, but a runtime cast bypasses that, so validate
+ * the actual values before they cross into the WASM constructor.
+ *
+ * @param values - The candidate array of satoshi amounts.
+ * @param label - Human-readable name used in the thrown error.
+ * @throws If `values` is not an array, is empty, or contains any element that is
+ *   not a `bigint` or is not strictly greater than 0.
+ */
+export function assertPositiveBigintArray(
+  values: unknown,
+  label: string,
+): bigint[] {
+  if (!Array.isArray(values)) {
+    throw new Error(
+      `${label} must be an array of positive bigints (got ${typeof values}).`,
+    );
+  }
+  if (values.length === 0) {
+    throw new Error(`${label} must not be empty.`);
+  }
+  values.forEach((value, i) => {
+    if (typeof value !== "bigint") {
+      throw new Error(
+        `${label}[${i}] must be a bigint (got ${typeof value}); ` +
+          `refusing to feed it into satoshi math.`,
+      );
+    }
+    if (value <= 0n) {
+      throw new Error(`${label}[${i}] must be > 0 (got ${value}).`);
+    }
+  });
+  return values as bigint[];
 }

--- a/packages/babylon-tbv-rust-wasm/src/value-guards.ts
+++ b/packages/babylon-tbv-rust-wasm/src/value-guards.ts
@@ -17,6 +17,9 @@
  * validates such inputs before the typed-array construction.
  */
 
+/** Largest value BigUint64Array stores without wrapping mod 2^64 (2^64 − 1). */
+const U64_MAX = (1n << 64n) - 1n;
+
 /**
  * Assert a WASM-returned value is a positive `bigint` and return it narrowed.
  *
@@ -50,7 +53,8 @@ export function assertWasmBigint(value: unknown, label: string): bigint {
  * @param values - The candidate array of satoshi amounts.
  * @param label - Human-readable name used in the thrown error.
  * @throws If `values` is not an array, is empty, or contains any element that is
- *   not a `bigint` or is not strictly greater than 0.
+ *   not a `bigint`, is not strictly greater than 0, or exceeds the u64 maximum
+ *   (which `BigUint64Array` would otherwise wrap mod 2^64).
  */
 export function assertPositiveBigintArray(
   values: unknown,
@@ -73,6 +77,12 @@ export function assertPositiveBigintArray(
     }
     if (value <= 0n) {
       throw new Error(`${label}[${i}] must be > 0 (got ${value}).`);
+    }
+    if (value > U64_MAX) {
+      throw new Error(
+        `${label}[${i}] must fit in a u64 (got ${value}); ` +
+          `refusing to feed it into satoshi math.`,
+      );
     }
   });
   return values as bigint[];

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/pegin.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/pegin.test.ts
@@ -472,6 +472,22 @@ describe("buildPrePeginPsbt", () => {
         ),
       ).rejects.toThrow();
     });
+
+    it("rejects a non-positive pegInAmount before WASM construction", async () => {
+      await expect(
+        buildPrePeginPsbt(makePrePeginParams({ pegInAmounts: [0n] })),
+      ).rejects.toThrow(/pegInAmounts\[0\] must be > 0/);
+    });
+
+    it("rejects a non-bigint pegInAmount that bypassed the type check", async () => {
+      await expect(
+        buildPrePeginPsbt(
+          makePrePeginParams({
+            pegInAmounts: [100_000 as unknown as bigint],
+          }),
+        ),
+      ).rejects.toThrow(/pegInAmounts\[0\] must be a bigint \(got number\)/);
+    });
   });
 });
 
@@ -627,6 +643,24 @@ describe("buildPeginTxFromFundedPrePegin", () => {
       });
 
       expect(result1.vaultScriptPubKey).not.toBe(result2.vaultScriptPubKey);
+    });
+  });
+
+  describe("Error handling", () => {
+    // The reconstruction path has no assertWasmPeginSizing amount-echo backstop,
+    // so the input guard at the BigUint64Array construction is its only defense
+    // against a bad pegInAmount.
+    it("rejects a non-positive pegInAmount during reconstruction", async () => {
+      const { txHex } = await buildFundedPrePeginTxHex();
+
+      await expect(
+        buildPeginTxFromFundedPrePegin({
+          prePeginParams: makePrePeginParams({ pegInAmounts: [0n] }),
+          timelockPegin: TEST_TIMELOCK_PEGIN,
+          fundedPrePeginTxHex: txHex,
+          htlcVout: 0,
+        }),
+      ).rejects.toThrow(/pegInAmounts\[0\] must be > 0/);
     });
   });
 });

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/peginAmountsGuard.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/peginAmountsGuard.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Tests for assertPositiveBigintArray — the input guard that validates satoshi
+ * amounts before they are handed to `new BigUint64Array(...)` at the WASM
+ * boundary (CLAUDE.md #1). TypeScript types these as `readonly bigint[]`, but a
+ * runtime cast bypasses that, so the values are checked at runtime.
+ */
+
+import { assertPositiveBigintArray } from "@babylonlabs-io/babylon-tbv-rust-wasm";
+import { describe, expect, it } from "vitest";
+
+describe("assertPositiveBigintArray", () => {
+  it("returns the array narrowed when every element is a positive bigint", () => {
+    const input = [1n, 100_000n, 42n];
+    expect(assertPositiveBigintArray(input, "pegInAmounts")).toBe(input);
+  });
+
+  it("throws when the value is not an array", () => {
+    expect(() =>
+      assertPositiveBigintArray(123n as unknown, "pegInAmounts"),
+    ).toThrow(/pegInAmounts must be an array of positive bigints/);
+  });
+
+  it("throws when the array is empty", () => {
+    expect(() => assertPositiveBigintArray([], "pegInAmounts")).toThrow(
+      /pegInAmounts must not be empty/,
+    );
+  });
+
+  it("throws when an element is not a bigint", () => {
+    expect(() =>
+      assertPositiveBigintArray(
+        [1n, 2 as unknown as bigint] as unknown,
+        "pegInAmounts",
+      ),
+    ).toThrow(/pegInAmounts\[1\] must be a bigint \(got number\)/);
+  });
+
+  it("throws when an element is zero", () => {
+    expect(() => assertPositiveBigintArray([0n], "pegInAmounts")).toThrow(
+      /pegInAmounts\[0\] must be > 0 \(got 0\)/,
+    );
+  });
+
+  it("throws when an element is negative", () => {
+    expect(() => assertPositiveBigintArray([1n, -5n], "pegInAmounts")).toThrow(
+      /pegInAmounts\[1\] must be > 0 \(got -5\)/,
+    );
+  });
+});

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/peginAmountsGuard.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/peginAmountsGuard.test.ts
@@ -46,4 +46,16 @@ describe("assertPositiveBigintArray", () => {
       /pegInAmounts\[1\] must be > 0 \(got -5\)/,
     );
   });
+
+  it("throws when an element exceeds the u64 maximum", () => {
+    // Without this bound BigUint64Array would wrap 2^64 to 0 (silent corruption).
+    expect(() =>
+      assertPositiveBigintArray([1n << 64n], "pegInAmounts"),
+    ).toThrow(/pegInAmounts\[0\] must fit in a u64/);
+  });
+
+  it("accepts the u64 maximum", () => {
+    const max = (1n << 64n) - 1n;
+    expect(assertPositiveBigintArray([max], "pegInAmounts")).toEqual([max]);
+  });
 });

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/refund.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/refund.test.ts
@@ -451,4 +451,23 @@ describe("buildRefundPsbt", () => {
       ).resolves.toMatchObject({ psbtHex: expect.any(String) });
     });
   });
+
+  describe("pegInAmounts input guard", () => {
+    // Refund reconstruction builds the WASM template from pegInAmounts with no
+    // amount-echo backstop, so the input guard at the BigUint64Array
+    // construction is the only check on these values.
+    it("rejects a non-positive pegInAmount", async () => {
+      const { txHex, params } = await buildFundedPrePegin();
+
+      await expect(
+        buildRefundPsbt({
+          prePeginParams: { ...params, pegInAmounts: [0n] },
+          fundedPrePeginTxHex: txHex,
+          htlcVout: 0,
+          refundFee: TEST_REFUND_FEE,
+          hashlock: TEST_HASH_H,
+        }),
+      ).rejects.toThrow(/pegInAmounts\[0\] must be > 0/);
+    });
+  });
 });

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts
@@ -12,6 +12,7 @@
  */
 
 import {
+  assertPositiveBigintArray,
   getPrePeginHtlcConnectorInfo,
   initWasm,
   tapInternalPubkey,
@@ -112,7 +113,9 @@ export async function buildRefundPsbt(
     prePeginParams.vaultKeeperPubkeys,
     prePeginParams.universalChallengerPubkeys,
     [...prePeginParams.hashlocks],
-    new BigUint64Array(prePeginParams.pegInAmounts),
+    new BigUint64Array(
+      assertPositiveBigintArray(prePeginParams.pegInAmounts, "pegInAmounts"),
+    ),
     prePeginParams.timelockRefund,
     prePeginParams.feeRate,
     prePeginParams.minPeginFeeRate,


### PR DESCRIPTION
Additions to [#877](https://github.com/sherlock-audit/2026-05-babylon-fe-indexer-monitor-utils-proxy-may-11th-2026/issues/877).

## What this does

When we build a peg-in, refund, or peg-in reconstruction, the satoshi amounts are handed to the Rust/WASM layer through `new BigUint64Array(params.pegInAmounts)`. This PR adds a small runtime check, `assertPositiveBigintArray`, that runs right before that construction at every call site. It confirms the amounts are a non-empty array of `bigint` values that are all greater than zero, and throws a clear error if not.

## Why it matters

TypeScript already types these amounts as `bigint[]`, but that check only exists at compile time. A runtime cast (`as readonly bigint[]`) silently turns it off, so a buggy caller could pass the wrong kind of value and it would slip straight into money math. Depending on the bad value, `BigUint64Array` either throws a confusing low-level error or, in one edge case, quietly fills the array with zeros — which would build a zero-value vault that a depositor could sign. We want this to fail loudly and early, at the exact seam, with a message that says what was wrong.

A previous PR, [#1866](https://github.com/babylonlabs-io/babylon-toolkit/pull/1866), was tagged as closing this issue, but it only added checks on the values coming *out* of WASM (`assertWasmBigint` and `assertWasmPeginSizing`). The amount-echo check in that PR happens to catch the peg-in *creation* path by accident, but it does not run on the *reconstruction* path (`buildPeginTxFromFundedPrePegin`) or the *refund* path (`buildRefundPsbt`). So the input check that the issue actually asked for was still missing on two of the three paths. This PR adds it everywhere.

## What changed

- New guard `assertPositiveBigintArray(values, label)` in [packages/babylon-tbv-rust-wasm/src/value-guards.ts](packages/babylon-tbv-rust-wasm/src/value-guards.ts). It is the input counterpart to the existing output guard `assertWasmBigint` and lives in the same file.
- The guard is exported from the WASM package's public entry point so the SDK can reuse the exact same function (one source of truth, no copy-paste).
- Wired in at all five `BigUint64Array` construction sites: `createPrePeginTransaction` and `buildPeginTxFromPrePegin` in both the browser ([index.ts](packages/babylon-tbv-rust-wasm/src/index.ts)) and node ([index-node.ts](packages/babylon-tbv-rust-wasm/src/index-node.ts)) entry points, and the refund reconstruction in [refund.ts](packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts).
- Tests: a unit test for the guard itself (one case per failure plus the happy path), and "wiring" tests on the peg-in, reconstruction, and refund paths that feed a deliberately bad amount (using the same cast that defeats the type system) and confirm each path now rejects it.

## Approaches we considered

- Option A — validate the input at each call site, right before the typed array is built (chosen). This is exactly what the issue recommends, it is cheap, and it puts the check at the one seam every amount must pass through, so no path can be missed.
- Option B — rely on the existing output checks from [#1866](https://github.com/babylonlabs-io/babylon-toolkit/pull/1866). Rejected: those run after the WASM call and only fully cover the creation path; the reconstruction and refund paths have no equivalent backstop, so a bad input there would not be caught at the boundary.
- Option C — duplicate a small check inside each file. Rejected: the SDK and the WASM package would drift over time. Exporting one shared function keeps the behaviour identical everywhere, and the dependency direction is correct (the SDK already depends on the WASM package).

## Why this approach

It is the smallest change that actually closes the gap. One shared, well-tested function, called at the exact point where untrusted JS values cross into satoshi math, on every path — creation, reconstruction, and refund. Valid deposits are unaffected (real amounts are always positive bigints), and a bad value now fails immediately with a readable message instead of corrupting a transaction.
