### PR TITLE
fix(sdk): enforce ChallengeAssert connector count

### DIFF
--- a/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/__tests__/validators.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/__tests__/validators.test.ts
@@ -216,6 +216,7 @@ describe("VP Response Validators", () => {
       nopayout_psbt: "cHNidA==",
       challenge_assert_connectors: [
         { wots_pks_json: "{}", gc_wots_keys_json: "{}" },
+        { wots_pks_json: "{}", gc_wots_keys_json: "{}" },
       ],
       output_label_hashes: ["aabb"],
     };
@@ -373,6 +374,66 @@ describe("VP Response Validators", () => {
           },
         }),
       ).toThrow(VpResponseValidationError);
+    });
+
+    it("rejects too few challenge_assert_connectors", () => {
+      expect(() =>
+        validateRequestDepositorPresignTransactionsResponse({
+          txs: [],
+          depositor_graph: {
+            ...validDepositorGraph,
+            challenger_presign_data: [
+              {
+                ...validChallengerPresignData,
+                challenge_assert_connectors: [
+                  { wots_pks_json: "{}", gc_wots_keys_json: "{}" },
+                ],
+              },
+            ],
+          },
+        }),
+      ).toThrow(VpResponseValidationError);
+    });
+
+    it("rejects too many challenge_assert_connectors", () => {
+      expect(() =>
+        validateRequestDepositorPresignTransactionsResponse({
+          txs: [],
+          depositor_graph: {
+            ...validDepositorGraph,
+            challenger_presign_data: [
+              {
+                ...validChallengerPresignData,
+                challenge_assert_connectors: [
+                  { wots_pks_json: "{}", gc_wots_keys_json: "{}" },
+                  { wots_pks_json: "{}", gc_wots_keys_json: "{}" },
+                  { wots_pks_json: "{}", gc_wots_keys_json: "{}" },
+                ],
+              },
+            ],
+          },
+        }),
+      ).toThrow(VpResponseValidationError);
+    });
+
+    it("accepts exactly two challenge_assert_connectors", () => {
+      expect(() =>
+        validateRequestDepositorPresignTransactionsResponse({
+          txs: [],
+          depositor_graph: {
+            ...validDepositorGraph,
+            challenger_presign_data: [
+              {
+                ...validChallengerPresignData,
+                challenge_assert_connectors: [
+                  { wots_pks_json: "{}", gc_wots_keys_json: "{}" },
+                  { wots_pks_json: "{}", gc_wots_keys_json: "{}" },
+                ],
+              },
+            ],
+          },
+        }),
+      ).not.toThrow();
     });
 
     it("rejects non-array output_label_hashes", () => {

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/validators.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/validators.ts
@@ -9,6 +9,7 @@
  * construction. Only `progress.presigning` sub-fields are checked.
  */
 
+import { CHALLENGE_ASSERT_CONNECTORS_PER_CHALLENGER } from "../../primitives/psbt/constants";
 import {
   COMPRESSED_PUBKEY_HEX_LEN,
   X_ONLY_PUBKEY_HEX_LEN,
@@ -300,6 +301,15 @@ function validatePresignDataPerChallenger(value: unknown, field: string): void {
   if (!Array.isArray(d.challenge_assert_connectors)) {
     throw new VpResponseValidationError(
       `VP response validation failed: "${field}.challenge_assert_connectors" must be an array`,
+    );
+  }
+
+  if (
+    d.challenge_assert_connectors.length !==
+    CHALLENGE_ASSERT_CONNECTORS_PER_CHALLENGER
+  ) {
+    throw new VpResponseValidationError(
+      `VP response validation failed: "${field}.challenge_assert_connectors" must have exactly ${CHALLENGE_ASSERT_CONNECTORS_PER_CHALLENGER} entries, got ${d.challenge_assert_connectors.length}`,
     );
   }
 

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/challengeAssert.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/challengeAssert.ts
@@ -2,13 +2,14 @@
  * ChallengeAssert PSBT Builder
  *
  * Builds an unsigned PSBT for a ChallengeAssert transaction
- * (depositor-as-claimer path, per challenger). The ChallengeAssert tx has
- * NUM_UTXOS_FOR_CHALLENGE_ASSERT (3) inputs, each spending a different Assert
- * output segment. The depositor signs ALL inputs, each with its own taproot
- * script derived from the per-segment connector params.
+ * (depositor-as-claimer path, per challenger). ChallengeAssert is split across
+ * two single-input transactions — ChallengeAssertX (spends the challenger's
+ * ConnectorX Assert output) and ChallengeAssertY (spends ConnectorY). This
+ * builder handles one such transaction; the depositor signs every input, each
+ * with its own taproot script derived from that input's connector params.
  *
  * @module primitives/psbt/challengeAssert
- * @see btc-vault crates/vault/docs/btc-transactions-spec.md — ChallengeAssert connector (NUM_UTXOS_FOR_CHALLENGE_ASSERT=3)
+ * @see btc-vault crates/vault/docs/btc-transactions-spec.md — ChallengeAssertX / ChallengeAssertY
  */
 
 import {
@@ -41,10 +42,10 @@ export interface ChallengeAssertParams {
 /**
  * Build unsigned ChallengeAssert PSBT.
  *
- * The ChallengeAssert transaction has 3 inputs (one per Assert output segment).
- * Each input has its own taproot script derived from its connector params.
- * The depositor signs all inputs. Every prevout is derived from the
- * authoritative Assert transaction, never trusted from external input.
+ * Each input has its own taproot script derived from its connector params; the
+ * number of connector params must match the transaction's input count. The
+ * depositor signs all inputs. Every prevout is derived from the authoritative
+ * Assert transaction, never trusted from external input.
  *
  * @param params - ChallengeAssert parameters
  * @returns Unsigned PSBT hex ready for signing

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/constants.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/constants.ts
@@ -36,6 +36,15 @@ export const VP_CLAIMER_PAYOUT_OUTPUT_COUNT = 3;
 export const NON_VP_CLAIMER_PAYOUT_OUTPUT_COUNT = 2;
 
 /**
+ * ChallengeAssert connectors the VP returns per challenger: one for the
+ * ChallengeAssertX transaction and one for ChallengeAssertY — two single-input
+ * transactions, not a single multi-input one. This is a per-challenger array
+ * cardinality, NOT a count of inputs in one transaction.
+ * @see btc-vault crates/vault/docs/btc-transactions-spec.md (ChallengeAssertX / ChallengeAssertY)
+ */
+export const CHALLENGE_ASSERT_CONNECTORS_PER_CHALLENGER = 2;
+
+/**
  * Exclusive upper bound on VP commission (bps), and the bps denominator for
  * `floor(peginValue * bps / 10_000)`. Matches `BTCVaultRegistry._validateCommission`
  * (`commissionBps >= 10000` reverts). The minimum is version-locked


### PR DESCRIPTION
Closes [#912](https://github.com/sherlock-audit/2026-05-babylon-fe-indexer-monitor-utils-proxy-may-11th-2026/issues/912).

## What this does

When the vault provider (VP) returns presign data for a deposit, each challenger entry includes a `challenge_assert_connectors` array. The validator already checked that this is an array and that each element has the right shape, but it never checked **how many** entries there are. This PR adds that missing count check: each challenger must return exactly the protocol-defined number of connectors, or the whole response is rejected at the validation boundary with a clear error.

## Why it matters

The VP is an external, untrusted party, and this is one of the codebase's flagged critical paths (depositor-graph presigning). A malformed or malicious response with the wrong number of connectors used to pass validation and only surface later as a confusing failure deeper in the signing code. Catching it early, at the RPC boundary, turns a hard-to-diagnose downstream error into an obvious, actionable one.

## Important: the audit's recommended number was wrong

The Sherlock issue recommended asserting `length === 3` and introducing a constant `NUM_UTXOS_FOR_CHALLENGE_ASSERT = 3`. We verified this against the actual protocol source — the btc-vault commit our WASM is pinned to (`BTC_VAULT_COMMIT = 63ab9e8d`) — and found the recommendation is incorrect:

- ChallengeAssert is **two separate single-input transactions** (ChallengeAssertX and ChallengeAssertY), not one transaction with 3 inputs. The VP builds the connectors as exactly **2 entries per challenger** (one for X, one for Y) — see `vaultd/src/rpc/server/vault_provider.rs` at the pinned commit.
- The name `NUM_UTXOS_FOR_CHALLENGE_ASSERT` does not exist anywhere in btc-vault. The only "3" on our side was **stale, incorrect comments** in `challengeAssert.ts` that wrongly described a 3-input transaction — and those comments are almost certainly what led the auditor to the wrong number.

So we implemented the auditor's **intent** (enforce the connector count at the validator) with the **correct value (2)**, and fixed the misleading comments at the same time.

## What changed

- `primitives/psbt/constants.ts` — added an exported constant `CHALLENGE_ASSERT_CONNECTORS_PER_CHALLENGER = 2`, alongside the other protocol-count constants, with a comment explaining it is one connector per ChallengeAssert transaction (X and Y). We deliberately did **not** reuse the misleading `NUM_UTXOS_FOR_CHALLENGE_ASSERT` name.
- `clients/vault-provider/validators.ts` — imported the constant and added a length check in `validatePresignDataPerChallenger`, right after the existing "is it an array" check and before the per-element loop, throwing the existing `VpResponseValidationError` with an actionable detail (expected vs actual count).
- `primitives/psbt/challengeAssert.ts` — corrected the stale comments to describe the real two-single-input-transaction (X/Y) model. The existing runtime check there (connector params must match the transaction's input count) was already correct and is left as-is.
- `clients/vault-provider/__tests__/validators.test.ts` — updated the shared valid fixture to use 2 connectors (so existing "accepts a valid response" tests still pass) and added three tests: rejects too few, rejects too many, accepts exactly two.

## Approaches we considered

- **Option A — assert the correct count (2) at the validator (chosen).** Honors the auditor's intent (validate the array cardinality at the untrusted boundary) using the value verified against the pinned protocol, and fixes the stale comments that caused the confusion.
- **Option B — document-and-defer.** The field is currently validated but not consumed by signing (`signDepositorGraph` reads the X/Y transactions and the NoPayout PSBT, not the connectors; `buildChallengeAssertPsbt` is unused). We could have just fixed the comments and replied to the auditor. Rejected because validating an untrusted VP response strictly is cheap, correct defense-in-depth, and closes the ticket concretely rather than leaving it open.
- **Option C — the literal `=== 3` from the issue.** Rejected: it is provably wrong against the pinned protocol, would reject valid VP responses, and would break the project's own test fixtures.

## Why this approach

It is the smallest change that closes the issue **correctly**: one named constant as the single source of truth, one length check at the exact boundary where untrusted data enters, with the protocol-verified value — plus a cleanup of the comments that misstated the protocol. Valid responses are unaffected; malformed ones now fail fast with a clear message.

## Out of scope (flagged for follow-up, not fixed here)

- `challenge_assert_connectors` is validated but not yet consumed by signing, and `buildChallengeAssertPsbt` is currently unused — a separate decision (wire it up or remove it).
- `output_label_hashes` in the same validator has a similar missing-count check, but per the spec that array scales with the challenger count, so a fixed-count check there would be wrong. Noted only.