### PR TITLE
fix(vault): persist confirmed settled refunds across reloads

### DIFF
--- a/services/vault/src/context/deposit/PeginPollingContext.tsx
+++ b/services/vault/src/context/deposit/PeginPollingContext.tsx
@@ -239,6 +239,9 @@ export function PeginPollingProvider({
             Number.isInteger(a.htlcVout)
           );
         })
+        // `htlcVout` is indexer-sourced and drives the DISPLAY poll only (a wrong
+        // vout → at worst mislabel/hide the refund, recoverable via cache TTL);
+        // the broadcast path re-reads htlcVout from chain, so no wrong tx signs.
         .map((a) => ({
           depositId: a.id,
           prePeginTxHash: a.prePeginTxHash as string,
@@ -362,6 +365,20 @@ export function PeginPollingProvider({
     });
   }, []);
 
+  // Confirmed settled refund: persist to the cache AND update the in-memory set
+  // so `refundConfirmed` flips to "Refunded" this session, not just on reload.
+  // Lowercased to match the `depositId.toLowerCase()` lookup in the poll result.
+  const addConfirmedRefund = useCallback((depositId: string) => {
+    addRefundedHtlcVaultId(depositId);
+    const key = depositId.toLowerCase();
+    setRefundedHtlcVaultIds((prev) => {
+      if (prev.has(key)) return prev;
+      const next = new Set(prev);
+      next.add(key);
+      return next;
+    });
+  }, []);
+
   // Wrapper: depositId → activity, resolve per-vault thresholds, then
   // hand off to the pure decision tree in `computeDepositPollingResult`.
   const getPollingResult = useCallback(
@@ -422,6 +439,7 @@ export function PeginPollingProvider({
       refetch: () => refetch(),
       setOptimisticStatus,
       clearOptimisticStatus,
+      addConfirmedRefund,
     }),
     [
       getPollingResult,
@@ -429,6 +447,7 @@ export function PeginPollingProvider({
       refetch,
       setOptimisticStatus,
       clearOptimisticStatus,
+      addConfirmedRefund,
     ],
   );
 

--- a/services/vault/src/hooks/deposit/useRefundState.ts
+++ b/services/vault/src/hooks/deposit/useRefundState.ts
@@ -37,7 +37,7 @@ export function useRefundState({
   const btcWalletProvider = btcConnector?.connectedWallet?.provider;
   const connectedBtcAddress = btcConnector?.connectedWallet?.account?.address;
   const { address: ethAddress } = useETHWallet();
-  const { setOptimisticStatus } = usePeginPolling();
+  const { setOptimisticStatus, addConfirmedRefund } = usePeginPolling();
   const { pendingPegins, addPendingPegin, markRefundBroadcast } =
     usePeginStorage({
       ethAddress: ethAddress ?? "",
@@ -115,9 +115,15 @@ export function useRefundState({
 
         let depositorBtcPubkey: string | undefined;
 
-        const persistRefundSuccess = (txId: string | undefined) => {
+        const persistRefundSuccess = (
+          txId: string | undefined,
+          confirmed = false,
+        ) => {
           if (txId) setRefundTxId(txId);
           setRefunding(false);
+          // Mark a confirmed (terminal) refund so the dashboard shows "Refunded"
+          // immediately this session (and across reloads), not "Refunding".
+          if (confirmed) addConfirmedRefund(vaultId);
           const refundBroadcastAt = Date.now();
           setOptimisticStatus(
             vaultId,
@@ -171,7 +177,7 @@ export function useRefundState({
             return;
           }
           if (err instanceof RefundAlreadySettledError) {
-            persistRefundSuccess(err.spendingTxid);
+            persistRefundSuccess(err.spendingTxid, err.confirmed);
             return;
           }
           logger.error(err instanceof Error ? err : new Error(String(err)), {
@@ -204,6 +210,7 @@ export function useRefundState({
       applicationEntryPoint,
       pendingPegins,
       setOptimisticStatus,
+      addConfirmedRefund,
       addPendingPegin,
       markRefundBroadcast,
     ],

--- a/services/vault/src/services/vault/__tests__/vaultRefundService.test.ts
+++ b/services/vault/src/services/vault/__tests__/vaultRefundService.test.ts
@@ -499,6 +499,31 @@ describe("vaultRefundService - adapter wiring", () => {
     ).rejects.toBeInstanceOf(RefundAlreadySettledError);
   });
 
+  it("propagates the original error when a -27 rejection's re-probe finds the HTLC still unspent", async () => {
+    // Guard passes (unspent); broadcast hits -27, but the re-probe ALSO finds
+    // the HTLC unspent (a genuine unrelated -27, or probe lag). Fail open: the
+    // original error must propagate, never be misread as already-settled.
+    (fetchHtlcSpend as Mock)
+      .mockResolvedValueOnce({ spent: false, confirmed: false })
+      .mockResolvedValueOnce({ spent: false, confirmed: false });
+    (pushTx as Mock).mockRejectedValue(
+      new Error(
+        'Failed to broadcast BTC transaction: sendrawtransaction RPC error: {"code":-27,"message":"Transaction already in block chain"}',
+      ),
+    );
+
+    const promise = buildAndBroadcastRefundTransaction({
+      vaultId: VAULT_ID,
+      depositorAddress: DEPOSITOR_ADDRESS,
+      btcWalletProvider: BTC_WALLET_PROVIDER,
+      depositorBtcPubkey: DEPOSITOR_PUBKEY,
+      feeRate: 10,
+    });
+
+    await expect(promise).rejects.toThrow(/-27|already in block chain/);
+    await expect(promise).rejects.not.toBeInstanceOf(RefundAlreadySettledError);
+  });
+
   it("does not classify a -26 broadcast rejection as already-settled (re-throws)", async () => {
     (pushTx as Mock).mockRejectedValue(
       new Error(

--- a/services/vault/src/types/peginPolling.ts
+++ b/services/vault/src/types/peginPolling.ts
@@ -62,6 +62,12 @@ export interface PeginPollingContextValue {
   ) => void;
   /** Clear optimistic status (after actual data refresh) */
   clearOptimisticStatus: (depositId: string) => void;
+  /**
+   * Mark a vault's HTLC refund as confirmed-settled: persist it to the
+   * refunded-HTLC cache AND update the in-memory set, so the dashboard shows
+   * "Refunded" immediately in-session — not only after a reload/next poll.
+   */
+  addConfirmedRefund: (depositId: string) => void;
 }
 
 /** Provider props */


### PR DESCRIPTION
## Summary
Follow-up to #1891, addressing the two review comments left unaddressed at merge.

- Persist confirmed settled refunds — the `RefundAlreadySettledError` catch in
  `useRefundState` discarded the `confirmed` flag and always wrote optimistic
  `REFUND_BROADCAST`. It now seeds `refundedHtlcCache` when confirmed, so an
  already-confirmed refund renders "Refunded" across reloads/poll gaps and
  `canRefund` stays false. (gbarkhatov + greptile P2; consumes the dead field)
- Test the fail-open backstop — a `-27` rejection whose re-probe finds the HTLC
  still unspent must propagate the original error, not `RefundAlreadySettledError`.
  (gbarkhatov)
- Note that the display poll's `htlcVout` is indexer-sourced / display-only; the
  broadcast path re-reads from chain. (gbarkhatov)

Seeding is gated strictly on an on-chain confirmed spend (`spent && status.confirmed`).