### PR TITLE
fix(vault): clear stale deposit warnings once the step succeeds

### DIFF
--- a/services/vault/src/components/simple/ContinuationWarnings.tsx
+++ b/services/vault/src/components/simple/ContinuationWarnings.tsx
@@ -1,0 +1,45 @@
+import { Callout } from "@babylonlabs-io/core-ui";
+
+import { usePeginPolling } from "@/context/deposit/PeginPollingContext";
+import {
+  type DepositWarning,
+  isDepositWarningResolved,
+} from "@/hooks/deposit/depositWarnings";
+
+interface ContinuationWarningsProps {
+  warnings: DepositWarning[];
+}
+
+/**
+ * Renders the deposit-flow soft warnings that are still relevant during the
+ * post-deposit continuation phase. A non-terminal per-vault warning is dropped
+ * once its vault's live `PeginState` shows it advanced past the warned stage
+ * (see {@link isDepositWarningResolved}); terminal and global warnings always
+ * show. Must render inside the continuation's `PeginPollingProvider` so it can
+ * read live per-vault state.
+ */
+export function ContinuationWarnings({ warnings }: ContinuationWarningsProps) {
+  const { getPollingResult } = usePeginPolling();
+  const visible = warnings.filter(
+    (warning) =>
+      !isDepositWarningResolved(
+        warning,
+        warning.vaultId
+          ? getPollingResult(warning.vaultId)?.peginState
+          : undefined,
+      ),
+  );
+  if (visible.length === 0) return null;
+  return (
+    <>
+      {visible.map((warning) => (
+        <Callout
+          key={`${warning.vaultId ?? "global"}:${warning.stage}`}
+          variant="warning"
+        >
+          {warning.message}
+        </Callout>
+      ))}
+    </>
+  );
+}

--- a/services/vault/src/components/simple/DepositSignContent.tsx
+++ b/services/vault/src/components/simple/DepositSignContent.tsx
@@ -116,10 +116,16 @@ export function DepositSignContent({
     );
   // Soft deposit-flow warnings from `useDepositFlow`: recoverable issues such
   // as local persistence failures or per-vault WOTS/payout steps that were
-  // skipped/failed while the rest of the split deposit kept moving.
+  // skipped/failed while the rest of the split deposit kept moving. Rendered
+  // unfiltered here: in-progress warnings are final-by-construction (no resume
+  // has happened, and there is no polling context to filter against). The
+  // continuation branch filters stale ones via `ContinuationWarnings`.
   const warningCallouts = lastWarnings.map((warning) => (
-    <Callout key={warning} variant="warning">
-      {warning}
+    <Callout
+      key={`${warning.vaultId ?? "global"}:${warning.stage}`}
+      variant="warning"
+    >
+      {warning.message}
     </Callout>
   ));
 
@@ -131,10 +137,10 @@ export function DepositSignContent({
     return (
       <>
         {banner}
-        {warningCallouts}
         <PostDepositContinuationContent
           vaultIds={continuationVaultIds}
           depositorEthAddress={flowParams.depositorEthAddress}
+          warnings={lastWarnings}
           onClose={onClose}
         />
       </>

--- a/services/vault/src/components/simple/PostDepositContinuationContent.tsx
+++ b/services/vault/src/components/simple/PostDepositContinuationContent.tsx
@@ -3,20 +3,28 @@ import type { Address, Hex } from "viem";
 
 import { PeginPollingProvider } from "@/context/deposit/PeginPollingContext";
 import { useBTCWallet } from "@/context/wallet";
+import type { DepositWarning } from "@/hooks/deposit/depositWarnings";
 import { useBtcPublicKey } from "@/hooks/useBtcPublicKey";
 import { useVaultDeposits } from "@/hooks/useVaultDeposits";
 
+import { ContinuationWarnings } from "./ContinuationWarnings";
 import { PostDepositContinuationView } from "./PostDepositContinuationView";
 
 interface PostDepositContinuationContentProps {
   vaultIds: Hex[];
   depositorEthAddress: Address;
+  /**
+   * Soft warnings carried over from the live deposit run. Absent on the
+   * resume-from-pending-card path, which has no in-flight warnings.
+   */
+  warnings?: DepositWarning[];
   onClose: () => void;
 }
 
 export function PostDepositContinuationContent({
   vaultIds,
   depositorEthAddress,
+  warnings = [],
   onClose,
 }: PostDepositContinuationContentProps) {
   const { connected: btcConnected } = useBTCWallet();
@@ -37,6 +45,7 @@ export function PostDepositContinuationContent({
       pendingPegins={scoped.pendingPegins}
       btcPublicKey={btcPublicKey}
     >
+      <ContinuationWarnings warnings={warnings} />
       <PostDepositContinuationView
         vaultIds={vaultIds}
         activities={scoped.activities}

--- a/services/vault/src/components/simple/__tests__/ContinuationWarnings.test.tsx
+++ b/services/vault/src/components/simple/__tests__/ContinuationWarnings.test.tsx
@@ -1,0 +1,125 @@
+import { render, screen } from "@testing-library/react";
+import type { Hex } from "viem";
+import { describe, expect, it, vi } from "vitest";
+
+import type { DepositWarning } from "@/hooks/deposit/depositWarnings";
+import { ContractStatus, getPeginState } from "@/models/peginStateMachine";
+
+import { ContinuationWarnings } from "../ContinuationWarnings";
+
+const { mockGetPollingResult } = vi.hoisted(() => ({
+  mockGetPollingResult: vi.fn(),
+}));
+vi.mock("@/context/deposit/PeginPollingContext", () => ({
+  usePeginPolling: () => ({ getPollingResult: mockGetPollingResult }),
+}));
+
+const VAULT_ID = "0xvault1" as Hex;
+
+const WOTS_WARNING: DepositWarning = {
+  vaultId: VAULT_ID,
+  stage: "wots",
+  terminal: false,
+  message: "Vault 1: WOTS key submission skipped",
+};
+
+describe("ContinuationWarnings", () => {
+  it("shows a non-terminal warning while its vault still owes the step", () => {
+    mockGetPollingResult.mockReturnValue({
+      peginState: getPeginState(ContractStatus.PENDING, { needsWotsKey: true }),
+    });
+    render(<ContinuationWarnings warnings={[WOTS_WARNING]} />);
+    expect(screen.getByText(WOTS_WARNING.message)).toBeInTheDocument();
+  });
+
+  it("keeps the warning while the VP poll is still loading (empty actions)", () => {
+    // Regression: the loading window returns a defined state with no actions —
+    // that must NOT be read as "advanced past WOTS".
+    mockGetPollingResult.mockReturnValue({
+      peginState: getPeginState(ContractStatus.PENDING, {}),
+    });
+    render(<ContinuationWarnings warnings={[WOTS_WARNING]} />);
+    expect(screen.getByText(WOTS_WARNING.message)).toBeInTheDocument();
+  });
+
+  it("hides the warning once its vault advanced past the warned stage", () => {
+    mockGetPollingResult.mockReturnValue({
+      peginState: getPeginState(ContractStatus.PENDING, {
+        transactionsReady: true,
+      }),
+    });
+    render(<ContinuationWarnings warnings={[WOTS_WARNING]} />);
+    expect(screen.queryByText(WOTS_WARNING.message)).not.toBeInTheDocument();
+  });
+
+  it("always shows a terminal warning regardless of live state", () => {
+    mockGetPollingResult.mockReturnValue({
+      peginState: getPeginState(ContractStatus.VERIFIED, {}),
+    });
+    const terminal: DepositWarning = {
+      ...WOTS_WARNING,
+      terminal: true,
+      message: "Vault 1: cannot continue",
+    };
+    render(<ContinuationWarnings warnings={[terminal]} />);
+    expect(screen.getByText(terminal.message)).toBeInTheDocument();
+  });
+
+  it("resolves each warning against its OWN vault's live state", () => {
+    const resolvedWots: DepositWarning = {
+      vaultId: "0xvaultA" as Hex,
+      stage: "wots",
+      terminal: false,
+      message: "Vault A: WOTS skipped",
+    };
+    const owedPayout: DepositWarning = {
+      vaultId: "0xvaultB" as Hex,
+      stage: "payout",
+      terminal: false,
+      message: "Vault B: payout signing failed",
+    };
+    const terminalWarning: DepositWarning = {
+      vaultId: "0xvaultC" as Hex,
+      stage: "wots",
+      terminal: true,
+      message: "Vault C: cannot continue",
+    };
+    // Per-vault routing: A is fully advanced (resolves), B still owes payout
+    // signing (kept), C is terminal (always shown). The states differ per vault,
+    // so a wrong-vault lookup would flip B's assertion.
+    mockGetPollingResult.mockImplementation((id: string) => {
+      if (id === resolvedWots.vaultId) {
+        return { peginState: getPeginState(ContractStatus.VERIFIED, {}) };
+      }
+      if (id === owedPayout.vaultId) {
+        return {
+          peginState: getPeginState(ContractStatus.PENDING, {
+            transactionsReady: true,
+          }),
+        };
+      }
+      return undefined;
+    });
+
+    render(
+      <ContinuationWarnings
+        warnings={[resolvedWots, owedPayout, terminalWarning]}
+      />,
+    );
+
+    expect(screen.queryByText(resolvedWots.message)).not.toBeInTheDocument();
+    expect(screen.getByText(owedPayout.message)).toBeInTheDocument();
+    expect(screen.getByText(terminalWarning.message)).toBeInTheDocument();
+  });
+
+  it("always shows a global persistence warning with no live state", () => {
+    mockGetPollingResult.mockReturnValue(undefined);
+    const persistence: DepositWarning = {
+      stage: "persistence",
+      terminal: true,
+      message: "Could not save a local copy of this deposit",
+    };
+    render(<ContinuationWarnings warnings={[persistence]} />);
+    expect(screen.getByText(persistence.message)).toBeInTheDocument();
+  });
+});

--- a/services/vault/src/hooks/deposit/__tests__/depositWarnings.test.ts
+++ b/services/vault/src/hooks/deposit/__tests__/depositWarnings.test.ts
@@ -1,0 +1,124 @@
+import type { Hex } from "viem";
+import { describe, expect, it } from "vitest";
+
+import {
+  ContractStatus,
+  getPeginState,
+  LocalStorageStatus,
+} from "@/models/peginStateMachine";
+
+import {
+  type DepositWarning,
+  isDepositWarningResolved,
+} from "../depositWarnings";
+
+const VAULT_ID = "0xvault" as Hex;
+
+function wotsWarning(overrides: Partial<DepositWarning> = {}): DepositWarning {
+  return {
+    vaultId: VAULT_ID,
+    stage: "wots",
+    terminal: false,
+    message: "Vault 1: WOTS skipped",
+    ...overrides,
+  };
+}
+
+function payoutWarning(
+  overrides: Partial<DepositWarning> = {},
+): DepositWarning {
+  return {
+    vaultId: VAULT_ID,
+    stage: "payout",
+    terminal: false,
+    message: "Vault 1: payout signing failed",
+    ...overrides,
+  };
+}
+
+describe("isDepositWarningResolved", () => {
+  it("keeps a WOTS warning while the VP poll is still loading (no signals)", () => {
+    // The crux of the fix: an empty action set during the loading / pre-VP
+    // window must NOT read as "advanced past WOTS".
+    const state = getPeginState(ContractStatus.PENDING, {});
+    expect(isDepositWarningResolved(wotsWarning(), state)).toBe(false);
+  });
+
+  it("keeps a WOTS warning while the vault still owes its WOTS key", () => {
+    const state = getPeginState(ContractStatus.PENDING, { needsWotsKey: true });
+    expect(isDepositWarningResolved(wotsWarning(), state)).toBe(false);
+  });
+
+  it("resolves a WOTS warning once payouts are ready (past WOTS)", () => {
+    const state = getPeginState(ContractStatus.PENDING, {
+      transactionsReady: true,
+    });
+    expect(isDepositWarningResolved(wotsWarning(), state)).toBe(true);
+  });
+
+  it("keeps a payout warning while payouts are still awaiting signing", () => {
+    const state = getPeginState(ContractStatus.PENDING, {
+      transactionsReady: true,
+    });
+    expect(isDepositWarningResolved(payoutWarning(), state)).toBe(false);
+  });
+
+  it("resolves wots but keeps payout while the VP is preparing payouts", () => {
+    // awaitingPayoutPrep: VP has ingested and accepted the WOTS key but the
+    // payout package is not ready yet — the window straddling both thresholds.
+    const state = getPeginState(ContractStatus.PENDING, {
+      pendingIngestion: false,
+    });
+    expect(isDepositWarningResolved(wotsWarning(), state)).toBe(true);
+    expect(isDepositWarningResolved(payoutWarning(), state)).toBe(false);
+  });
+
+  it("resolves a payout warning once payouts have been signed", () => {
+    const state = getPeginState(ContractStatus.PENDING, {
+      localStatus: LocalStorageStatus.PAYOUT_SIGNED,
+    });
+    expect(isDepositWarningResolved(payoutWarning(), state)).toBe(true);
+  });
+
+  it("resolves both stages once the vault reaches VERIFIED", () => {
+    const state = getPeginState(ContractStatus.VERIFIED, {});
+    expect(isDepositWarningResolved(wotsWarning(), state)).toBe(true);
+    expect(isDepositWarningResolved(payoutWarning(), state)).toBe(true);
+  });
+
+  it("resolves a stale warning once the vault is terminal (expired)", () => {
+    const state = getPeginState(ContractStatus.EXPIRED, {});
+    expect(isDepositWarningResolved(wotsWarning(), state)).toBe(true);
+    expect(isDepositWarningResolved(payoutWarning(), state)).toBe(true);
+  });
+
+  it("never resolves a terminal warning, even when the vault advanced", () => {
+    const state = getPeginState(ContractStatus.PENDING, {
+      transactionsReady: true,
+    });
+    expect(
+      isDepositWarningResolved(wotsWarning({ terminal: true }), state),
+    ).toBe(false);
+  });
+
+  it("never resolves a global persistence warning", () => {
+    const warning: DepositWarning = {
+      stage: "persistence",
+      terminal: true,
+      message: "Could not save a local copy",
+    };
+    const state = getPeginState(ContractStatus.VERIFIED, {});
+    expect(isDepositWarningResolved(warning, state)).toBe(false);
+  });
+
+  it("keeps the warning when live state is unknown (no optimistic clearing)", () => {
+    expect(isDepositWarningResolved(wotsWarning(), undefined)).toBe(false);
+  });
+
+  it("keeps a per-vault warning that carries no vaultId", () => {
+    const state = getPeginState(ContractStatus.VERIFIED, {});
+    expect(
+      isDepositWarningResolved(wotsWarning({ vaultId: undefined }), state),
+    ).toBe(false);
+  });
+});

--- a/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
@@ -787,7 +787,9 @@ describe("useDepositFlow", () => {
       // Flow should complete with warnings, not error
       expect(depositResult).not.toBeNull();
       expect(depositResult?.warnings).toHaveLength(1);
-      expect(depositResult?.warnings?.[0]).toContain("Payout signing failed");
+      expect(depositResult?.warnings?.[0]?.message).toContain(
+        "Payout signing failed",
+      );
 
       // Second vault should still attempt
       expect(signAndSubmitPayouts).toHaveBeenCalledTimes(2);
@@ -814,7 +816,7 @@ describe("useDepositFlow", () => {
 
       expect(depositResult).not.toBeNull();
       expect(depositResult?.warnings).toHaveLength(1);
-      expect(depositResult?.warnings?.[0]).toContain(
+      expect(depositResult?.warnings?.[0]?.message).toContain(
         "WOTS key submission failed",
       );
 
@@ -876,9 +878,11 @@ describe("useDepositFlow", () => {
       expect(depositResult).not.toBeNull();
       expect(result.current.lastWarnings).toEqual(
         expect.arrayContaining([
-          expect.stringContaining(
-            "Vault 1: WOTS key submission skipped - vault provider was not ready",
-          ),
+          expect.objectContaining({
+            message: expect.stringContaining(
+              "Vault 1: WOTS key submission skipped - vault provider was not ready",
+            ),
+          }),
         ]),
       );
       expect(submitWotsPublicKey).toHaveBeenCalledTimes(1);
@@ -913,9 +917,11 @@ describe("useDepositFlow", () => {
       expect(depositResult).not.toBeNull();
       expect(result.current.lastWarnings).toEqual(
         expect.arrayContaining([
-          expect.stringContaining(
-            "Vault 1: WOTS key submission skipped - vault provider reported this BTC Vault cannot continue",
-          ),
+          expect.objectContaining({
+            message: expect.stringContaining(
+              "Vault 1: WOTS key submission skipped - vault provider reported this BTC Vault cannot continue",
+            ),
+          }),
         ]),
       );
       expect(submitWotsPublicKey).toHaveBeenCalledTimes(1);
@@ -945,7 +951,9 @@ describe("useDepositFlow", () => {
       expect(signAndSubmitPayouts).not.toHaveBeenCalled();
       expect(result.current.lastWarnings).not.toEqual(
         expect.arrayContaining([
-          expect.stringContaining("Payout signing failed"),
+          expect.objectContaining({
+            message: expect.stringContaining("Payout signing failed"),
+          }),
         ]),
       );
       expect(result.current.perVaultSteps).toEqual([
@@ -996,7 +1004,9 @@ describe("useDepositFlow", () => {
       expect(signAndSubmitPayouts).toHaveBeenCalledTimes(2);
       expect(result.current.lastWarnings).not.toEqual(
         expect.arrayContaining([
-          expect.stringContaining("Payout signing failed"),
+          expect.objectContaining({
+            message: expect.stringContaining("Payout signing failed"),
+          }),
         ]),
       );
       expect(result.current.perVaultSteps).toEqual([
@@ -1247,7 +1257,7 @@ describe("useDepositFlow", () => {
       expect(result.current.error).toBeFalsy();
       expect(
         result.current.lastWarnings.some((w) =>
-          w.includes("couldn't save a local copy"),
+          w.message.includes("couldn't save a local copy"),
         ),
       ).toBe(true);
     });
@@ -1304,7 +1314,7 @@ describe("useDepositFlow", () => {
       // error must still be visible.
       expect(
         result.current.lastWarnings.some((w) =>
-          w.includes("couldn't save a local copy"),
+          w.message.includes("couldn't save a local copy"),
         ),
       ).toBe(true);
     });

--- a/services/vault/src/hooks/deposit/depositWarnings.ts
+++ b/services/vault/src/hooks/deposit/depositWarnings.ts
@@ -1,0 +1,75 @@
+/**
+ * Structured soft warnings surfaced by the deposit flow, plus the rule for
+ * when a non-terminal one becomes stale.
+ *
+ * Warnings used to be opaque strings appended to a list that only reset on a
+ * fresh `executeDeposit` run — so a recoverable per-vault warning (e.g. a WOTS
+ * readiness timeout) kept showing an orange alert even after the user resumed
+ * and the step succeeded. Tagging each warning with the vault and the stage it
+ * came from lets the continuation view drop it once that vault's live
+ * `PeginState` shows it advanced past the warned stage.
+ *
+ * @module hooks/deposit/depositWarnings
+ */
+
+import type { Hex } from "viem";
+
+import { DepositFlowStep } from "@/hooks/deposit/depositFlowSteps/types";
+import {
+  getPeginDisplayStep,
+  type PeginState,
+} from "@/models/peginStateMachine";
+
+export type DepositWarningStage = "wots" | "payout" | "persistence";
+
+export interface DepositWarning {
+  /** Vault this warning is about; undefined for global (non-per-vault) warnings. */
+  vaultId?: Hex;
+  /** Which flow stage produced the warning. */
+  stage: DepositWarningStage;
+  /**
+   * Terminal warnings describe a dead-end the continuation can never clear
+   * (an expired vault or a terminal VP failure), so they always render.
+   */
+  terminal: boolean;
+  /** Pre-rendered, copy.ts-authored message. */
+  message: string;
+}
+
+/**
+ * Whether a non-terminal per-vault warning is now stale because its vault
+ * advanced past the stage it warned about.
+ *
+ * Forward-only: resolution is driven by the vault's position in the ordered
+ * deposit flow (`getPeginDisplayStep`, the same mapping the progress bar uses),
+ * never by the absence of the warned action. That action is also absent while
+ * the VP poll is still loading and before the VP asks for the key, so keying on
+ * absence would hide a step the user still owes. A `null` step means the vault
+ * is terminal / expired / already activated, where the warned step is moot, so
+ * that resolves too.
+ *
+ * Terminal and global (`persistence`) warnings, and an unknown live state,
+ * never resolve.
+ */
+export function isDepositWarningResolved(
+  warning: DepositWarning,
+  peginState: PeginState | undefined,
+): boolean {
+  if (warning.terminal || warning.stage === "persistence" || !warning.vaultId) {
+    return false;
+  }
+  if (!peginState) return false;
+
+  // VP daemon ordering (btc-vault PegInStatus): WOTS (PendingDepositorWotsPK)
+  // precedes payout signing (PendingDepositorSignatures), and the step enum
+  // mirrors that order — a strictly-greater step means the stage is done.
+  const step = getPeginDisplayStep(peginState);
+  if (step === null) return true;
+  if (warning.stage === "wots") {
+    return step > DepositFlowStep.SUBMIT_WOTS_KEYS;
+  }
+  if (warning.stage === "payout") {
+    return step > DepositFlowStep.SIGN_DEPOSITOR_GRAPH;
+  }
+  return false;
+}

--- a/services/vault/src/hooks/deposit/useDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useDepositFlow.ts
@@ -86,6 +86,7 @@ import {
   waitForWotsReadiness,
   type DepositUtxo,
 } from "./depositFlowSteps";
+import type { DepositWarning } from "./depositWarnings";
 import { useBtcWalletState } from "./useBtcWalletState";
 import { useVaultProviders } from "./useVaultProviders";
 
@@ -135,12 +136,13 @@ export interface UseDepositFlowReturn {
   /** Mapped error content (title + body) if any step failed */
   error: DepositErrorContent | null;
   /**
-   * Soft warnings accumulated by the most recent flow (e.g. "couldn't save a
-   * local copy" when the deposit registered on-chain but `addPendingPegin`
-   * failed). Empty until the flow finishes or errors out; persists for the
-   * UI to surface until the next run starts.
+   * Structured soft warnings from the most recent flow (e.g. a per-vault WOTS
+   * readiness timeout, or "couldn't save a local copy"). Empty until the flow
+   * finishes or errors out. Non-terminal per-vault warnings are dropped by the
+   * continuation view once their vault advances past the warned stage — see
+   * {@link DepositWarning}.
    */
-  lastWarnings: string[];
+  lastWarnings: DepositWarning[];
   /** Whether currently waiting for external action (e.g., wallet signature) */
   isWaiting: boolean;
   /** Payout signing progress (X of Y signings) */
@@ -192,8 +194,8 @@ export interface MultiVaultDepositResult {
   pegins: PeginCreationResult[];
   /** Batch ID linking the vaults */
   batchId: string;
-  /** Warning messages for recoverable per-vault failures. */
-  warnings?: string[];
+  /** Structured warnings for recoverable/terminal per-vault failures. */
+  warnings?: DepositWarning[];
 }
 
 // ============================================================================
@@ -232,7 +234,7 @@ export function useDepositFlow(
   // failures, localStorage write failures, etc.). Exposed so the UI can
   // surface them after completion — these are informational, the flow
   // itself doesn't abort on them.
-  const [lastWarnings, setLastWarnings] = useState<string[]>([]);
+  const [lastWarnings, setLastWarnings] = useState<DepositWarning[]>([]);
   const [payoutSigningProgress, setPayoutSigningProgress] =
     useState<PayoutSigningProgress | null>(null);
   const [peginSigningProgress, setPeginSigningProgress] =
@@ -300,8 +302,8 @@ export function useDepositFlow(
       );
 
       // Track background operation failures
-      const warnings: string[] = [];
-      const recordWarning = (warning: string) => {
+      const warnings: DepositWarning[] = [];
+      const recordWarning = (warning: DepositWarning) => {
         warnings.push(warning);
         setLastWarnings([...warnings]);
       };
@@ -644,10 +646,12 @@ export function useDepositFlow(
                 data: { vaultId: peginResult.vaultId },
               },
             );
-            if (
-              !warnings.includes(COPY.deposit.warnings.depositRecordNotSaved)
-            ) {
-              recordWarning(COPY.deposit.warnings.depositRecordNotSaved);
+            if (!warnings.some((w) => w.stage === "persistence")) {
+              recordWarning({
+                stage: "persistence",
+                terminal: true,
+                message: COPY.deposit.warnings.depositRecordNotSaved,
+              });
             }
           }
         }
@@ -880,15 +884,18 @@ export function useDepositFlow(
           signal.throwIfAborted();
 
           if (!readyVaultIds.has(result.vaultId)) {
-            recordWarning(
-              terminalVaultIds.has(result.vaultId)
+            recordWarning({
+              vaultId: result.vaultId,
+              stage: "wots",
+              terminal: terminalVaultIds.has(result.vaultId),
+              message: terminalVaultIds.has(result.vaultId)
                 ? COPY.deposit.warnings.wotsReadinessTerminal(
                     result.vaultIndex + 1,
                   )
                 : COPY.deposit.warnings.wotsReadinessTimeout(
                     result.vaultIndex + 1,
                   ),
-            );
+            });
             wotsFailedVaultIds.add(result.vaultId);
             continue;
           }
@@ -944,12 +951,15 @@ export function useDepositFlow(
 
               const errorMsg =
                 error instanceof Error ? error.message : String(error);
-              recordWarning(
-                COPY.deposit.warnings.wotsSubmissionFailed(
+              recordWarning({
+                vaultId: result.vaultId,
+                stage: "wots",
+                terminal: false,
+                message: COPY.deposit.warnings.wotsSubmissionFailed(
                   result.vaultIndex + 1,
                   errorMsg,
                 ),
-              );
+              });
               logger.error(
                 error instanceof Error ? error : new Error(String(error)),
                 {
@@ -1011,11 +1021,14 @@ export function useDepositFlow(
 
           if (!payoutReadyVaultIds.has(result.vaultId)) {
             if (payoutTerminalVaultIds.has(result.vaultId)) {
-              recordWarning(
-                COPY.deposit.warnings.payoutReadinessTerminal(
+              recordWarning({
+                vaultId: result.vaultId,
+                stage: "payout",
+                terminal: true,
+                message: COPY.deposit.warnings.payoutReadinessTerminal(
                   result.vaultIndex + 1,
                 ),
-              );
+              });
             }
             setPerVaultSteps((prev) =>
               prev.map((step, index) =>
@@ -1083,12 +1096,15 @@ export function useDepositFlow(
 
             const errorMsg =
               error instanceof Error ? error.message : String(error);
-            recordWarning(
-              COPY.deposit.warnings.payoutSigningFailed(
+            recordWarning({
+              vaultId: result.vaultId,
+              stage: "payout",
+              terminal: false,
+              message: COPY.deposit.warnings.payoutSigningFailed(
                 result.vaultIndex + 1,
                 errorMsg,
               ),
-            );
+            });
             logger.error(
               error instanceof Error ? error : new Error(String(error)),
               {


### PR DESCRIPTION
Deposit-flow warnings were append-only, reset only at executeDeposit start,
so a recoverable per-vault warning (e.g. a WOTS-readiness timeout) kept
showing a stale orange alert after the user resumed and completed the step.
Resolve non-terminal warnings off the vault's live position in the flow.