### PR TITLE
feat(vault): show compact deposit summary as initial signing screen

### DIFF
--- a/services/vault/src/components/simple/DepositProgressView/DepositCardShell.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/DepositCardShell.tsx
@@ -1,0 +1,86 @@
+/**
+ * DepositCardShell
+ *
+ * Presentational chrome shared by every state of the deposit progress flow.
+ * It owns the card border, the heading + time estimate, the explanation, an
+ * optional overall progress bar, the full-bleed divider, the step/group body,
+ * and a footer region (primary CTA + optional fine print).
+ *
+ * The body is intentionally a `children` slot so the same card can host either
+ * state of the flow:
+ *   - pre-sign  → DepositSummaryCard passes the collapsed group rows
+ *   - in-flight → the live stepper passes its expanded GroupedProgress (with
+ *                 per-step detail panels), a progress bar, and the
+ *                 close-and-continue CTA + do-not-spend footnote
+ *
+ * Keeping the chrome here means the user sees one consistent card from the
+ * summary through completion — only the body and footer change per state.
+ */
+
+import { Heading, Text } from "@babylonlabs-io/core-ui";
+import type { ReactNode } from "react";
+
+import { COPY } from "@/copy";
+
+import { DEPOSIT_VIEW_MAX_WIDTH_CLASS } from "./steps";
+
+interface DepositCardShellProps {
+  /**
+   * Step/group list. Collapsed group rows in the summary state; the expanded
+   * grouped stepper (with active-step detail panels) in the live state.
+   */
+  children: ReactNode;
+  /**
+   * Footer action(s) for the current state — e.g. the "Sign" CTA on the
+   * summary, or the close-and-continue button while the flow runs.
+   */
+  footer: ReactNode;
+  /**
+   * Optional overall progress bar rendered under the explanation. Present once
+   * signing starts; omitted on the pre-sign summary.
+   */
+  progressBar?: ReactNode;
+  /**
+   * Optional fine print rendered under the footer action — e.g. the
+   * do-not-spend warning shown while the deposit is in flight.
+   */
+  footnote?: ReactNode;
+}
+
+export function DepositCardShell({
+  children,
+  footer,
+  progressBar,
+  footnote,
+}: DepositCardShellProps) {
+  return (
+    <div
+      className={`w-full ${DEPOSIT_VIEW_MAX_WIDTH_CLASS} overflow-hidden rounded-xl border border-secondary-strokeDark`}
+    >
+      <div className="px-6 pb-6 pt-6">
+        <Heading variant="h5" className="text-accent-primary">
+          {COPY.deposit.progress.heading}{" "}
+          <Text as="span" variant="body1" className="text-accent-secondary">
+            ({COPY.deposit.progress.summary.estimate})
+          </Text>
+        </Heading>
+
+        <Text variant="body2" className="mt-2 text-accent-secondary">
+          {COPY.deposit.progress.summary.description}
+        </Text>
+
+        {progressBar && <div className="mt-4">{progressBar}</div>}
+      </div>
+
+      {/* Full-bleed divider: spans the card edge-to-edge through the padding. */}
+      <div className="border-t border-secondary-strokeDark" />
+
+      <div className="px-6 py-6">{children}</div>
+
+      <div className="px-6 pb-6">
+        {footer}
+        {footnote && <div className="mt-4">{footnote}</div>}
+      </div>
+    </div>
+  );
+}

--- a/services/vault/src/components/simple/DepositProgressView/DepositProgressView.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/DepositProgressView.tsx
@@ -33,6 +33,7 @@ import { ProviderWaitDetail } from "./ProviderWaitDetail";
 import { SplitGroupedProgress } from "./SplitGroupedProgress";
 import {
   buildStepItems,
+  DEPOSIT_VIEW_MAX_WIDTH_CLASS,
   getStepFillPercent,
   getVisualStep,
   STEP_GROUPS,
@@ -222,7 +223,7 @@ export function DepositProgressView(props: DepositProgressViewProps) {
   );
 
   return (
-    <div className="w-full max-w-[520px]">
+    <div className={`w-full ${DEPOSIT_VIEW_MAX_WIDTH_CLASS}`}>
       <Heading variant="h5" className="text-accent-primary">
         {COPY.deposit.progress.heading}
       </Heading>

--- a/services/vault/src/components/simple/DepositProgressView/DepositSummaryCard.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/DepositSummaryCard.tsx
@@ -15,21 +15,25 @@ import { Button, Heading, Text } from "@babylonlabs-io/core-ui";
 import { COPY } from "@/copy";
 
 import { StepConnector } from "./StepConnector";
-import { STEP_GROUPS } from "./steps";
+import { DEPOSIT_VIEW_MAX_WIDTH_CLASS, STEP_GROUPS } from "./steps";
 
 interface DepositSummaryCardProps {
   /** Starts the deposit flow; the parent then swaps in DepositProgressView. */
   onSign: () => void;
 }
 
-export function DepositSummaryCard({ onSign }: DepositSummaryCardProps) {
-  const groups = STEP_GROUPS.map((group) => ({
-    title: group.title,
-    total: group.endStep - group.startStep + 1,
-  }));
+// Hoisted: derived purely from the static STEP_GROUPS, so the same array
+// instance is reused across renders (no per-render allocation).
+const SUMMARY_GROUPS = STEP_GROUPS.map((group) => ({
+  title: group.title,
+  total: group.endStep - group.startStep + 1,
+}));
 
+export function DepositSummaryCard({ onSign }: DepositSummaryCardProps) {
   return (
-    <div className="w-full max-w-[520px] overflow-hidden rounded-xl border border-secondary-strokeDark">
+    <div
+      className={`w-full ${DEPOSIT_VIEW_MAX_WIDTH_CLASS} overflow-hidden rounded-xl border border-secondary-strokeDark`}
+    >
       <div className="px-6 pt-6">
         <Heading variant="h5" className="text-accent-primary">
           {COPY.deposit.progress.heading}{" "}
@@ -47,7 +51,7 @@ export function DepositSummaryCard({ onSign }: DepositSummaryCardProps) {
       <div className="border-t border-secondary-strokeDark" />
 
       <div className="flex flex-col px-6 pt-6">
-        {groups.map((group, index) => (
+        {SUMMARY_GROUPS.map((group, index) => (
           <div key={group.title} className="flex flex-col">
             <div className="flex items-center gap-3">
               <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border-2 border-secondary-strokeDark">
@@ -70,7 +74,7 @@ export function DepositSummaryCard({ onSign }: DepositSummaryCardProps) {
                 {COPY.deposit.groups.stepCounter(0, group.total)}
               </Text>
             </div>
-            {index < groups.length - 1 && <StepConnector />}
+            {index < SUMMARY_GROUPS.length - 1 && <StepConnector />}
           </div>
         ))}
       </div>

--- a/services/vault/src/components/simple/DepositProgressView/DepositSummaryCard.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/DepositSummaryCard.tsx
@@ -1,0 +1,90 @@
+/**
+ * DepositSummaryCard
+ *
+ * Pre-sign intro screen for the deposit flow. Renders a compact summary of the
+ * four step groups (collapsed, each showing its signature count) before the
+ * user starts signing. Clicking "Sign" begins the flow, after which
+ * DepositProgressView takes over with the live stepper.
+ *
+ * Counts are derived from STEP_GROUPS (the same source the live stepper uses),
+ * so the summary stays in lock-step with the real group sizes.
+ */
+
+import { Button, Heading, Text } from "@babylonlabs-io/core-ui";
+
+import { COPY } from "@/copy";
+
+import { StepConnector } from "./StepConnector";
+import { STEP_GROUPS } from "./steps";
+
+interface DepositSummaryCardProps {
+  /** Starts the deposit flow; the parent then swaps in DepositProgressView. */
+  onSign: () => void;
+}
+
+export function DepositSummaryCard({ onSign }: DepositSummaryCardProps) {
+  const groups = STEP_GROUPS.map((group) => ({
+    title: group.title,
+    total: group.endStep - group.startStep + 1,
+  }));
+
+  return (
+    <div className="w-full max-w-[520px] overflow-hidden rounded-xl border border-secondary-strokeDark">
+      <div className="px-6 pt-6">
+        <Heading variant="h5" className="text-accent-primary">
+          {COPY.deposit.progress.heading}{" "}
+          <Text as="span" variant="body1" className="text-accent-secondary">
+            ({COPY.deposit.progress.summary.estimate})
+          </Text>
+        </Heading>
+
+        <Text variant="body2" className="mb-6 mt-2 text-accent-secondary">
+          {COPY.deposit.progress.summary.description}
+        </Text>
+      </div>
+
+      {/* Full-bleed divider: spans the card edge-to-edge through the padding. */}
+      <div className="border-t border-secondary-strokeDark" />
+
+      <div className="flex flex-col px-6 pt-6">
+        {groups.map((group, index) => (
+          <div key={group.title} className="flex flex-col">
+            <div className="flex items-center gap-3">
+              <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border-2 border-secondary-strokeDark">
+                <Text
+                  as="span"
+                  variant="body2"
+                  className="font-medium text-accent-secondary"
+                >
+                  {index + 1}
+                </Text>
+              </div>
+              <Text
+                as="span"
+                variant="body1"
+                className="flex-1 font-medium text-accent-primary"
+              >
+                {group.title}
+              </Text>
+              <Text as="span" variant="body2" className="text-accent-secondary">
+                {COPY.deposit.groups.stepCounter(0, group.total)}
+              </Text>
+            </div>
+            {index < groups.length - 1 && <StepConnector />}
+          </div>
+        ))}
+      </div>
+
+      <div className="px-6 pb-6 pt-6">
+        <Button
+          variant="contained"
+          color="secondary"
+          className="w-full"
+          onClick={onSign}
+        >
+          {COPY.deposit.progress.buttons.sign}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/services/vault/src/components/simple/DepositProgressView/DepositSummaryCard.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/DepositSummaryCard.tsx
@@ -1,21 +1,23 @@
 /**
  * DepositSummaryCard
  *
- * Pre-sign intro screen for the deposit flow. Renders a compact summary of the
- * four step groups (collapsed, each showing its signature count) before the
- * user starts signing. Clicking "Sign" begins the flow, after which
- * DepositProgressView takes over with the live stepper.
+ * Pre-sign intro state of the deposit flow. Renders inside the shared
+ * DepositCardShell, supplying the collapsed group list (each group with its
+ * signature count) as the body and a single "Sign" CTA as the footer. Clicking
+ * "Sign" begins the flow, after which the live stepper renders the expanded
+ * groups inside the same shell.
  *
  * Counts are derived from STEP_GROUPS (the same source the live stepper uses),
  * so the summary stays in lock-step with the real group sizes.
  */
 
-import { Button, Heading, Text } from "@babylonlabs-io/core-ui";
+import { Button, Text } from "@babylonlabs-io/core-ui";
 
 import { COPY } from "@/copy";
 
+import { DepositCardShell } from "./DepositCardShell";
 import { StepConnector } from "./StepConnector";
-import { DEPOSIT_VIEW_MAX_WIDTH_CLASS, STEP_GROUPS } from "./steps";
+import { STEP_GROUPS } from "./steps";
 
 interface DepositSummaryCardProps {
   /** Starts the deposit flow; the parent then swaps in DepositProgressView. */
@@ -31,26 +33,19 @@ const SUMMARY_GROUPS = STEP_GROUPS.map((group) => ({
 
 export function DepositSummaryCard({ onSign }: DepositSummaryCardProps) {
   return (
-    <div
-      className={`w-full ${DEPOSIT_VIEW_MAX_WIDTH_CLASS} overflow-hidden rounded-xl border border-secondary-strokeDark`}
+    <DepositCardShell
+      footer={
+        <Button
+          variant="contained"
+          color="secondary"
+          className="w-full"
+          onClick={onSign}
+        >
+          {COPY.deposit.progress.buttons.sign}
+        </Button>
+      }
     >
-      <div className="px-6 pt-6">
-        <Heading variant="h5" className="text-accent-primary">
-          {COPY.deposit.progress.heading}{" "}
-          <Text as="span" variant="body1" className="text-accent-secondary">
-            ({COPY.deposit.progress.summary.estimate})
-          </Text>
-        </Heading>
-
-        <Text variant="body2" className="mb-6 mt-2 text-accent-secondary">
-          {COPY.deposit.progress.summary.description}
-        </Text>
-      </div>
-
-      {/* Full-bleed divider: spans the card edge-to-edge through the padding. */}
-      <div className="border-t border-secondary-strokeDark" />
-
-      <div className="flex flex-col px-6 pt-6">
+      <div className="flex flex-col">
         {SUMMARY_GROUPS.map((group, index) => (
           <div key={group.title} className="flex flex-col">
             <div className="flex items-center gap-3">
@@ -78,17 +73,6 @@ export function DepositSummaryCard({ onSign }: DepositSummaryCardProps) {
           </div>
         ))}
       </div>
-
-      <div className="px-6 pb-6 pt-6">
-        <Button
-          variant="contained"
-          color="secondary"
-          className="w-full"
-          onClick={onSign}
-        >
-          {COPY.deposit.progress.buttons.sign}
-        </Button>
-      </div>
-    </div>
+    </DepositCardShell>
   );
 }

--- a/services/vault/src/components/simple/DepositProgressView/__tests__/DepositCardShell.test.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/__tests__/DepositCardShell.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { COPY } from "@/copy";
+
+import { DepositCardShell } from "../DepositCardShell";
+
+describe("DepositCardShell", () => {
+  it("renders the shared heading, estimate, and explanation across states", () => {
+    render(
+      <DepositCardShell footer={<button type="button">cta</button>}>
+        <div>body</div>
+      </DepositCardShell>,
+    );
+
+    expect(screen.getByText(COPY.deposit.progress.heading)).toBeTruthy();
+    expect(
+      screen.getByText(`(${COPY.deposit.progress.summary.estimate})`),
+    ).toBeTruthy();
+    expect(
+      screen.getByText(COPY.deposit.progress.summary.description),
+    ).toBeTruthy();
+  });
+
+  it("renders the body and footer slots", () => {
+    render(
+      <DepositCardShell footer={<div data-testid="footer">footer</div>}>
+        <div data-testid="body">body</div>
+      </DepositCardShell>,
+    );
+
+    expect(screen.getByTestId("body")).toBeTruthy();
+    expect(screen.getByTestId("footer")).toBeTruthy();
+  });
+
+  it("omits the progress bar and footnote when not provided (summary state)", () => {
+    render(
+      <DepositCardShell footer={<button type="button">cta</button>}>
+        <div>body</div>
+      </DepositCardShell>,
+    );
+
+    expect(screen.queryByTestId("progress-bar")).toBeNull();
+    expect(screen.queryByTestId("footnote")).toBeNull();
+  });
+
+  it("renders the progress bar and footnote when provided (in-flight state)", () => {
+    render(
+      <DepositCardShell
+        footer={<button type="button">cta</button>}
+        progressBar={<div data-testid="progress-bar" />}
+        footnote={<div data-testid="footnote" />}
+      >
+        <div>body</div>
+      </DepositCardShell>,
+    );
+
+    expect(screen.getByTestId("progress-bar")).toBeTruthy();
+    expect(screen.getByTestId("footnote")).toBeTruthy();
+  });
+});

--- a/services/vault/src/components/simple/DepositProgressView/__tests__/DepositSummaryCard.test.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/__tests__/DepositSummaryCard.test.tsx
@@ -1,0 +1,43 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { COPY } from "@/copy";
+
+import { DepositSummaryCard } from "../DepositSummaryCard";
+
+describe("DepositSummaryCard", () => {
+  it("renders the heading with the estimated duration", () => {
+    render(<DepositSummaryCard onSign={vi.fn()} />);
+
+    expect(screen.getByText(COPY.deposit.progress.heading)).toBeTruthy();
+    expect(
+      screen.getByText(`(${COPY.deposit.progress.summary.estimate})`),
+    ).toBeTruthy();
+  });
+
+  it("lists the four step groups with their signature counts", () => {
+    render(<DepositSummaryCard onSign={vi.fn()} />);
+
+    // Counts mirror STEP_GROUPS: register(6), claim(2), payout(4), activate(3).
+    expect(screen.getByText(COPY.deposit.groups.registerDeposit)).toBeTruthy();
+    expect(screen.getByText("0/6")).toBeTruthy();
+    expect(screen.getByText(COPY.deposit.groups.signWots)).toBeTruthy();
+    expect(screen.getByText("0/2")).toBeTruthy();
+    expect(screen.getByText(COPY.deposit.groups.signPayout)).toBeTruthy();
+    expect(screen.getByText("0/4")).toBeTruthy();
+    expect(screen.getByText(COPY.deposit.groups.activateVault)).toBeTruthy();
+    // Activate vault stays at 0/3 — the Figma 0/4 counter is the stale side.
+    expect(screen.getByText("0/3")).toBeTruthy();
+  });
+
+  it("calls onSign when the Sign button is clicked", () => {
+    const onSign = vi.fn();
+    render(<DepositSummaryCard onSign={onSign} />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: COPY.deposit.progress.buttons.sign }),
+    );
+
+    expect(onSign).toHaveBeenCalledTimes(1);
+  });
+});

--- a/services/vault/src/components/simple/DepositProgressView/index.ts
+++ b/services/vault/src/components/simple/DepositProgressView/index.ts
@@ -3,3 +3,4 @@ export {
   type BtcConfirmationDetailData,
   type DepositProgressViewProps,
 } from "./DepositProgressView";
+export { DepositSummaryCard } from "./DepositSummaryCard";

--- a/services/vault/src/components/simple/DepositProgressView/index.ts
+++ b/services/vault/src/components/simple/DepositProgressView/index.ts
@@ -1,3 +1,4 @@
+export { DepositCardShell } from "./DepositCardShell";
 export {
   DepositProgressView,
   type BtcConfirmationDetailData,

--- a/services/vault/src/components/simple/DepositProgressView/steps.ts
+++ b/services/vault/src/components/simple/DepositProgressView/steps.ts
@@ -51,6 +51,13 @@ export function buildStepItems(
 export const TOTAL_VISUAL_STEPS = buildStepItems(null).length;
 
 /**
+ * Shared max-width for the deposit progress surfaces. Both the live stepper
+ * (DepositProgressView) and the pre-sign summary (DepositSummaryCard) use this
+ * so the two screens stay the same width across the Sign transition.
+ */
+export const DEPOSIT_VIEW_MAX_WIDTH_CLASS = "max-w-[520px]";
+
+/**
  * Logical groupings of the deposit flow. Each group covers a contiguous,
  * inclusive range of 1-based visual step numbers (the same numbering produced
  * by {@link getVisualStep}). The grouped progress UI expands only the group

--- a/services/vault/src/components/simple/DepositSignContent.tsx
+++ b/services/vault/src/components/simple/DepositSignContent.tsx
@@ -15,9 +15,8 @@ import type { Address, Hex } from "viem";
 import { computeDepositDerivedState } from "@/components/deposit/DepositSignModal/depositStepHelpers";
 import { COPY } from "@/copy";
 import { useDepositFlow } from "@/hooks/deposit/useDepositFlow";
-import { useRunOnce } from "@/hooks/useRunOnce";
 
-import { DepositProgressView } from "./DepositProgressView";
+import { DepositProgressView, DepositSummaryCard } from "./DepositProgressView";
 import { PostDepositContinuationContent } from "./PostDepositContinuationContent";
 
 interface DepositSignContentProps {
@@ -67,6 +66,11 @@ export function DepositSignContent({
     Hex[] | null
   >(null);
 
+  // The flow no longer auto-starts on mount: the initial screen is a compact
+  // summary card and the depositor begins signing by clicking "Sign". Once
+  // started, the live stepper (DepositProgressView) takes over.
+  const [started, setStarted] = useState(false);
+
   const startFlow = useCallback(async () => {
     const result = await executeDeposit();
     if (result) {
@@ -75,7 +79,10 @@ export function DepositSignContent({
     }
   }, [executeDeposit, onRefetchActivities]);
 
-  useRunOnce(startFlow);
+  const handleSign = useCallback(() => {
+    setStarted(true);
+    void startFlow();
+  }, [startFlow]);
 
   // Derived state
   const { isComplete, canClose, isProcessing, canContinueInBackground } =
@@ -122,6 +129,17 @@ export function DepositSignContent({
       {warning}
     </Callout>
   ));
+
+  // Initial screen: compact summary card with a single "Sign" CTA. The flow
+  // only begins once the depositor clicks Sign (see `handleSign`).
+  if (!started) {
+    return (
+      <>
+        {banner}
+        <DepositSummaryCard onSign={handleSign} />
+      </>
+    );
+  }
 
   if (
     continuationVaultIds &&

--- a/services/vault/src/components/simple/DepositSignContent.tsx
+++ b/services/vault/src/components/simple/DepositSignContent.tsx
@@ -9,7 +9,7 @@
 
 import { Callout } from "@babylonlabs-io/core-ui";
 import type { BitcoinWallet } from "@babylonlabs-io/ts-sdk/shared";
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import type { Address, Hex } from "viem";
 
 import { computeDepositDerivedState } from "@/components/deposit/DepositSignModal/depositStepHelpers";
@@ -79,7 +79,16 @@ export function DepositSignContent({
     }
   }, [executeDeposit, onRefetchActivities]);
 
+  // `executeDeposit` broadcasts BTC and has no internal re-entrancy guard, and
+  // dropping `useRunOnce` removed its exactly-once protection. A fast double
+  // click on Sign fires `handleSign` twice before the `started` re-render
+  // unmounts the button, which would start (and broadcast) the deposit twice.
+  // This ref restores the exactly-once guarantee regardless of click cadence.
+  const hasStartedRef = useRef(false);
+
   const handleSign = useCallback(() => {
+    if (hasStartedRef.current) return;
+    hasStartedRef.current = true;
     setStarted(true);
     void startFlow();
   }, [startFlow]);

--- a/services/vault/src/components/simple/__tests__/DepositSignContent.test.tsx
+++ b/services/vault/src/components/simple/__tests__/DepositSignContent.test.tsx
@@ -1,11 +1,15 @@
 import type { BitcoinWallet } from "@babylonlabs-io/ts-sdk/shared";
-import { fireEvent, render } from "@testing-library/react";
+import { act, fireEvent, render } from "@testing-library/react";
 import type { Address } from "viem";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { DepositSignContent } from "../DepositSignContent";
 
 const mockExecuteDeposit = vi.hoisted(() => vi.fn());
+// Captures the latest `onSign` handed to the summary card so a test can invoke
+// it twice synchronously — the real double-click race that happens before the
+// `started` re-render unmounts the Sign button.
+const signHolder = vi.hoisted(() => ({ onSign: null as null | (() => void) }));
 
 vi.mock("@/hooks/deposit/useDepositFlow", () => ({
   useDepositFlow: () => ({
@@ -39,11 +43,14 @@ vi.mock("../PostDepositContinuationContent", () => ({
 
 vi.mock("../DepositProgressView", () => ({
   DepositProgressView: () => <div data-testid="progress" />,
-  DepositSummaryCard: ({ onSign }: { onSign: () => void }) => (
-    <button type="button" data-testid="summary-sign" onClick={onSign}>
-      Sign
-    </button>
-  ),
+  DepositSummaryCard: ({ onSign }: { onSign: () => void }) => {
+    signHolder.onSign = onSign;
+    return (
+      <button type="button" data-testid="summary-sign" onClick={onSign}>
+        Sign
+      </button>
+    );
+  },
 }));
 
 function renderContent(
@@ -86,6 +93,21 @@ describe("DepositSignContent", () => {
 
     expect(mockExecuteDeposit).toHaveBeenCalledTimes(1);
     expect(getByTestId("progress")).toBeTruthy();
+  });
+
+  it("starts the deposit at most once even when Sign fires twice synchronously", () => {
+    mockExecuteDeposit.mockResolvedValue(null);
+
+    renderContent();
+
+    // Two clicks landing in the same tick, before the `started` re-render can
+    // unmount the Sign button — the double-broadcast race the ref guards.
+    act(() => {
+      signHolder.onSign?.();
+      signHolder.onSign?.();
+    });
+
+    expect(mockExecuteDeposit).toHaveBeenCalledTimes(1);
   });
 
   it("switches to the continuation view once the deposit returns pegins", async () => {

--- a/services/vault/src/components/simple/__tests__/DepositSignContent.test.tsx
+++ b/services/vault/src/components/simple/__tests__/DepositSignContent.test.tsx
@@ -1,5 +1,5 @@
 import type { BitcoinWallet } from "@babylonlabs-io/ts-sdk/shared";
-import { render } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 import type { Address } from "viem";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -39,6 +39,11 @@ vi.mock("../PostDepositContinuationContent", () => ({
 
 vi.mock("../DepositProgressView", () => ({
   DepositProgressView: () => <div data-testid="progress" />,
+  DepositSummaryCard: ({ onSign }: { onSign: () => void }) => (
+    <button type="button" data-testid="summary-sign" onClick={onSign}>
+      Sign
+    </button>
+  ),
 }));
 
 function renderContent(
@@ -67,6 +72,22 @@ describe("DepositSignContent", () => {
     vi.clearAllMocks();
   });
 
+  it("shows the summary card first and only starts the flow on Sign", () => {
+    mockExecuteDeposit.mockResolvedValue(null);
+
+    const { getByTestId, queryByTestId } = renderContent();
+
+    // Initial screen is the summary card; the flow has not started.
+    expect(getByTestId("summary-sign")).toBeTruthy();
+    expect(queryByTestId("progress")).toBeNull();
+    expect(mockExecuteDeposit).not.toHaveBeenCalled();
+
+    fireEvent.click(getByTestId("summary-sign"));
+
+    expect(mockExecuteDeposit).toHaveBeenCalledTimes(1);
+    expect(getByTestId("progress")).toBeTruthy();
+  });
+
   it("switches to the continuation view once the deposit returns pegins", async () => {
     mockExecuteDeposit.mockResolvedValue({
       pegins: [{ vaultId: "0xv0" }, { vaultId: "0xv1" }],
@@ -74,7 +95,11 @@ describe("DepositSignContent", () => {
     });
     const onRefetchActivities = vi.fn().mockResolvedValue(undefined);
 
-    const { findByTestId } = renderContent({ onRefetchActivities });
+    const { findByTestId, getByTestId } = renderContent({
+      onRefetchActivities,
+    });
+
+    fireEvent.click(getByTestId("summary-sign"));
 
     const continuation = await findByTestId("continuation");
     expect(continuation.getAttribute("data-count")).toBe("2");
@@ -84,7 +109,9 @@ describe("DepositSignContent", () => {
   it("stays on the progress view when the deposit returns null", async () => {
     mockExecuteDeposit.mockResolvedValue(null);
 
-    const { findByTestId, queryByTestId } = renderContent();
+    const { findByTestId, getByTestId, queryByTestId } = renderContent();
+
+    fireEvent.click(getByTestId("summary-sign"));
 
     await findByTestId("progress");
     expect(queryByTestId("continuation")).toBeNull();

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -209,6 +209,14 @@ export const COPY = {
     },
     progress: {
       heading: "Deposit Progress",
+      // Pre-sign summary card shown before the flow starts: an estimated total
+      // duration suffixed to the heading plus a short explanation of the
+      // grouped signature counts.
+      summary: {
+        estimate: "~60 min",
+        description:
+          "Each step is divided into several wallet signature confirmations. The progress counter shows how many are completed. Your Bitcoin will only be locked once the vault is activated.",
+      },
       stepsCompleted: (completed: number, total: number) =>
         `${completed} of ${total} steps completed`,
       // Inline prefix for the pending-deposit card's active-step label


### PR DESCRIPTION
The deposit signing modal previously auto-started the flow on mount and rendered the fully-expanded step list immediately. 

The flow now starts only when the depositor clicks Sign, after which the existing live stepper renders unchanged.

closes #1906

## Screenshot
<img width="823" height="672" alt="Screenshot 2026-06-22 at 16 02 01" src="https://github.com/user-attachments/assets/fd31fdaf-36af-4490-8444-c44321fdbeb6" />
