### PR TITLE
feat(wallet): always enable OKX and gate it on version >= 4.5.0

### DIFF
--- a/packages/babylon-wallet-connector/src/core/wallets/btc/okx/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/okx/provider.ts
@@ -2,9 +2,11 @@ import { isAccountChangeEvent, DISCONNECT_EVENT, removeProviderListener } from "
 import type { BTCConfig, InscriptionIdentifier, SignPsbtOptions, WalletInfo } from "@/core/types";
 import { IBTCProvider, Network } from "@/core/types";
 import { mapSignInputsToToSignInputs } from "@/core/utils/psbtOptionsMapper";
+import { withTimeout } from "@/core/utils/withTimeout";
 import { ERROR_CODES, WalletError, isUserRejectionMessage } from "@/error";
 
 import logo from "./logo.svg";
+import { MIN_OKX_VERSION, checkOKXVersion } from "./version";
 
 const PROVIDER_NAMES = {
   [Network.MAINNET]: "bitcoin",
@@ -14,8 +16,13 @@ const PROVIDER_NAMES = {
 
 export const WALLET_PROVIDER_NAME = "OKX";
 
+// Bound the version read so a locked/asleep extension fails recoverably, not hangs.
+const OKX_RPC_TIMEOUT_MS = 10_000;
+
 export class OKXProvider implements IBTCProvider {
   private provider: any;
+  // Root `okxwallet` (getVersion lives here); `this.provider` is the per-chain provider.
+  private wallet: any;
   private walletInfo: WalletInfo | undefined;
   private config: BTCConfig;
 
@@ -31,6 +38,8 @@ export class OKXProvider implements IBTCProvider {
       });
     }
 
+    this.wallet = wallet;
+
     const providerName = PROVIDER_NAMES[config.network];
 
     if (!providerName) {
@@ -45,6 +54,9 @@ export class OKXProvider implements IBTCProvider {
   }
 
   connectWallet = async (): Promise<void> => {
+    // Fail fast on an out-of-date OKX here, not at deposit time.
+    await this.ensureSupportedVersion();
+
     let result;
     try {
       result = await this.provider.connect();
@@ -78,6 +90,57 @@ export class OKXProvider implements IBTCProvider {
         wallet: WALLET_PROVIDER_NAME,
       });
     }
+  };
+
+  private timeoutError = (operation: string): WalletError =>
+    new WalletError({
+      code: ERROR_CODES.CONNECTION_FAILED,
+      message: `OKX Wallet did not respond while ${operation}. Open the extension to confirm it is unlocked, then try again.`,
+      wallet: WALLET_PROVIDER_NAME,
+    });
+
+  // Gate connect on OKX >= MIN_OKX_VERSION (deriveContextHash support).
+  // Fail closed on a missing / unreadable / non-canonical version.
+  private ensureSupportedVersion = async (): Promise<void> => {
+    if (typeof this.wallet.getVersion !== "function") {
+      throw new WalletError({
+        code: ERROR_CODES.INCOMPATIBLE_WALLET_VERSION,
+        message: `Your OKX Wallet extension is out of date. Please update to version ${MIN_OKX_VERSION} or later and try again.`,
+        wallet: WALLET_PROVIDER_NAME,
+      });
+    }
+
+    let raw: unknown;
+    try {
+      raw = await withTimeout(this.wallet.getVersion(), OKX_RPC_TIMEOUT_MS, () =>
+        this.timeoutError("reading its version"),
+      );
+    } catch (error) {
+      throw new WalletError({
+        code: ERROR_CODES.CONNECTION_FAILED,
+        message: (error as Error)?.message || "Failed to read OKX Wallet version",
+        wallet: WALLET_PROVIDER_NAME,
+      });
+    }
+
+    const result = checkOKXVersion(raw);
+    if (result === "ok") return;
+
+    if (result === "below") {
+      throw new WalletError({
+        code: ERROR_CODES.INCOMPATIBLE_WALLET_VERSION,
+        message: `Your OKX Wallet extension is out of date (${raw}). Please update to version ${MIN_OKX_VERSION} or later and try again.`,
+        wallet: WALLET_PROVIDER_NAME,
+        version: raw as string,
+      });
+    }
+
+    // Non-canonical version (fork/canary): fail closed without claiming "out of date".
+    throw new WalletError({
+      code: ERROR_CODES.INCOMPATIBLE_WALLET_VERSION,
+      message: `Unable to verify your OKX Wallet version${typeof raw === "string" ? ` (got "${raw}")` : ""}. Please install the official OKX Wallet ${MIN_OKX_VERSION} or later and try again.`,
+      wallet: WALLET_PROVIDER_NAME,
+    });
   };
 
   getAddress = async (): Promise<string> => {

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/okx/version.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/okx/version.ts
@@ -1,0 +1,12 @@
+import { checkMinVersion, type MinVersionCheck } from "@/core/utils/checkMinVersion";
+
+// Floor for `deriveContextHash`, which vault deposits require; older OKX can't
+// deposit. Verified: OKX 4.5.0 is the first version where
+// `okxwallet.bitcoin.deriveContextHash` is present. Compared via
+// checkMinVersion (strict semver), never a string `<` (the #740 Immunefi bug).
+export const MIN_OKX_VERSION = "4.5.0";
+
+/** Compares a raw OKX `getVersion()` value against {@link MIN_OKX_VERSION}. */
+export function checkOKXVersion(raw: unknown): MinVersionCheck {
+  return checkMinVersion(raw, MIN_OKX_VERSION);
+}

--- a/packages/babylon-wallet-connector/tests/unit/okxVersion.test.ts
+++ b/packages/babylon-wallet-connector/tests/unit/okxVersion.test.ts
@@ -1,0 +1,87 @@
+import { expect, test } from "@playwright/test";
+
+import { checkOKXVersion } from "../../src/core/wallets/btc/okx/version";
+
+test.describe("checkOKXVersion — OKX extension version gate (MIN = 4.5.0)", () => {
+  test("returns 'ok' for the exact minimum '4.5.0'", () => {
+    expect(checkOKXVersion("4.5.0")).toBe("ok");
+  });
+
+  test("returns 'ok' for a higher patch '4.5.1'", () => {
+    expect(checkOKXVersion("4.5.1")).toBe("ok");
+  });
+
+  test("returns 'ok' for a higher minor '4.6.0'", () => {
+    expect(checkOKXVersion("4.6.0")).toBe("ok");
+  });
+
+  test("returns 'ok' for a higher major '5.0.0'", () => {
+    expect(checkOKXVersion("5.0.0")).toBe("ok");
+  });
+
+  test("returns 'ok' for '4.10.0' — numeric comparison, not string collation", () => {
+    expect(checkOKXVersion("4.10.0")).toBe("ok");
+  });
+
+  test("returns 'below' for the previous patch '4.4.99'", () => {
+    expect(checkOKXVersion("4.4.99")).toBe("below");
+  });
+
+  test("returns 'below' for an older minor '4.4.0'", () => {
+    expect(checkOKXVersion("4.4.0")).toBe("below");
+  });
+
+  test("returns 'below' for an older major '3.54.12'", () => {
+    expect(checkOKXVersion("3.54.12")).toBe("below");
+  });
+
+  // Non-canonical strings must NOT parse as 'ok'/'below'; they get a distinct
+  // "unable to verify" prompt downstream.
+  test("returns 'unparseable' for a v-prefixed version 'v4.5.0'", () => {
+    expect(checkOKXVersion("v4.5.0")).toBe("unparseable");
+  });
+
+  test("returns 'unparseable' for a prerelease suffix '4.5.0-beta'", () => {
+    expect(checkOKXVersion("4.5.0-beta")).toBe("unparseable");
+  });
+
+  test("returns 'unparseable' for a build-metadata suffix '4.5.0+abc'", () => {
+    expect(checkOKXVersion("4.5.0+abc")).toBe("unparseable");
+  });
+
+  test("returns 'unparseable' for a four-part version '4.5.0.123'", () => {
+    expect(checkOKXVersion("4.5.0.123")).toBe("unparseable");
+  });
+
+  test("returns 'unparseable' for a non-numeric tag 'dev'", () => {
+    expect(checkOKXVersion("dev")).toBe("unparseable");
+  });
+
+  test("returns 'unparseable' for a two-part string '4.5'", () => {
+    expect(checkOKXVersion("4.5")).toBe("unparseable");
+  });
+
+  test("returns 'unparseable' for the empty string", () => {
+    expect(checkOKXVersion("")).toBe("unparseable");
+  });
+
+  test("returns 'unparseable' for undefined (provider returns nothing)", () => {
+    expect(checkOKXVersion(undefined)).toBe("unparseable");
+  });
+
+  test("returns 'unparseable' for a non-string value (number)", () => {
+    expect(checkOKXVersion(4.5)).toBe("unparseable");
+  });
+
+  test("returns 'unparseable' for a leading-zero major '04.5.0'", () => {
+    expect(checkOKXVersion("04.5.0")).toBe("unparseable");
+  });
+
+  test("returns 'unparseable' for a leading-zero minor '4.05.0'", () => {
+    expect(checkOKXVersion("4.05.0")).toBe("unparseable");
+  });
+
+  test("returns 'unparseable' for a leading-zero patch '4.5.01'", () => {
+    expect(checkOKXVersion("4.5.01")).toBe("unparseable");
+  });
+});

--- a/services/vault/src/context/wallet/VaultWalletConnectionProvider.tsx
+++ b/services/vault/src/context/wallet/VaultWalletConnectionProvider.tsx
@@ -21,14 +21,10 @@ import featureFlags from "@/config/featureFlags";
 import { getNetworkConfigETH } from "@/config/network";
 import { logger } from "@/infrastructure";
 
-// Vault deposits require the connected BTC wallet to implement the
-// `deriveContextHash` API (see docs/specs/derive-context-hash.md). UniSat
-// and OneKey are always enabled. Additional wallets (e.g. okx, utila) can
-// be opted in per environment via NEXT_PUBLIC_TBV_EXTRA_BTC_WALLETS (a
-// comma-separated list of wallet IDs). Each non-conforming adapter still
-// throws `WALLET_METHOD_NOT_SUPPORTED` at the connector layer; this list
-// keeps them out of the connection UI so users don't pick something that
-// can't complete a deposit.
+// Vault deposits need the BTC wallet's `deriveContextHash` (docs/specs/derive-context-hash.md).
+// UniSat/OneKey/OKX are always enabled (OKX self-gates on version >= 4.5.0 at the connector).
+// Other wallets (e.g. utila) opt in per env via NEXT_PUBLIC_TBV_EXTRA_BTC_WALLETS; this list
+// keeps non-conforming adapters out of the connect UI.
 const ALWAYS_DISABLED_WALLETS: string[] = [
   APPKIT_BTC_CONNECTOR_ID,
   "injectable",
@@ -36,7 +32,7 @@ const ALWAYS_DISABLED_WALLETS: string[] = [
   "ledger_btc_v2",
 ];
 
-const OPT_IN_WALLETS = ["okx", "utila"];
+const OPT_IN_WALLETS = ["utila"];
 
 const DISABLED_WALLETS: string[] = [
   ...ALWAYS_DISABLED_WALLETS,


### PR DESCRIPTION
- Remove OKX from the vault's opt-in wallet list so it's always shown
  (only utila stays behind NEXT_PUBLIC_TBV_EXTRA_BTC_WALLETS).
- Add a connect-time minimum-version gate (>= 4.5.0) in the wallet-connector
  OKX provider, mirroring the audited UniSat/OneKey pattern: reads root
  okxwallet.getVersion() via withTimeout, compares with checkMinVersion
  (strict semver — not the string compare removed in #740), and fails closed
  on a missing / unreadable / non-canonical version.
- Add okxVersion.test.ts (20 cases, parity with unisat/onekey).