### PR TITLE
fix(ts-sdk): pass peg-in principal as refund pegInAmounts

### DIFF
--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/refund.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/refund.test.ts
@@ -19,10 +19,6 @@ import {
   stripHexPrefix,
   uint8ArrayToHex,
 } from "../../utils/bitcoin";
-import {
-  deriveRefundPeginAmounts,
-  type RefundPrePeginContext,
-} from "../../../services/refund/buildAndBroadcastRefund";
 import { fundPeginTransaction } from "../../../utils/transaction/fundPeginTransaction";
 import { buildPrePeginPsbt, type PrePeginParams } from "../pegin";
 import { buildRefundPsbt } from "../refund";
@@ -397,52 +393,21 @@ describe("buildRefundPsbt", () => {
     });
   });
 
-  describe("peg-in amount derivation round-trip", () => {
-    it("re-derives the original peg-in amount from the funded HTLC value (real WASM)", async () => {
-      // Keystone equality: the reserve subtracted at refund time (standalone
-      // computeMinClaimValue + computeMinPeginFee) must equal the reserve WASM
-      // baked into the HTLC value at peg-in time. Fund with a known peg-in
-      // amount, read the funded HTLC value, and prove the derivation inverts
-      // back to that exact amount — so a future WASM bump that broke the
-      // equality is caught here, not in production.
+  describe("peg-in amount round-trip (real WASM)", () => {
+    it("reconstructs the funded HTLC value from the peg-in principal", async () => {
+      // The refund passes the on-chain `amount` (the peg-in principal) as
+      // pegInAmounts; WASM adds depositorClaimValue + minPeginFee back to size
+      // the HTLC output, which must equal the funded tx value. Funding with a
+      // peg-in amount and refunding with that same amount must pass the value
+      // cross-check — so a future WASM bump that changed the reserve sizing is
+      // caught here, not in production.
       const { txHex, params } = await buildFundedPrePegin({
         authAnchorHash: TEST_AUTH_ANCHOR_HASH,
       });
-      const fundedHtlcValue = BigInt(
-        bitcoin.Transaction.fromHex(txHex).outs[0].value,
-      );
 
-      const ctx: RefundPrePeginContext = {
-        vaultProviderPubkey: params.vaultProviderPubkey,
-        vaultKeeperPubkeys: params.vaultKeeperPubkeys,
-        universalChallengerPubkeys: params.universalChallengerPubkeys,
-        timelockRefund: params.timelockRefund,
-        feeRate: params.feeRate,
-        minPeginFeeRate: params.minPeginFeeRate,
-        numLocalChallengers: params.numLocalChallengers,
-        councilQuorum: params.councilQuorum,
-        councilSize: params.councilSize,
-        network: params.network,
-      };
-
-      const derived = await deriveRefundPeginAmounts(
-        [
-          {
-            hashlock: `0x${TEST_HASH_H}` as Hex,
-            amount: fundedHtlcValue,
-            htlcVout: 0,
-          },
-        ],
-        ctx,
-      );
-      expect(derived).toEqual([TEST_AMOUNTS.PEGIN]);
-
-      // And feeding the derived amount back through the real (unmocked)
-      // builder reconstructs a template whose value cross-check passes — a
-      // legitimate refund does not throw.
       await expect(
         buildRefundPsbt({
-          prePeginParams: { ...params, pegInAmounts: derived },
+          prePeginParams: params,
           fundedPrePeginTxHex: txHex,
           htlcVout: 0,
           refundFee: TEST_REFUND_FEE,

--- a/packages/babylon-ts-sdk/src/tbv/core/services/refund/__tests__/buildAndBroadcastRefund.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/refund/__tests__/buildAndBroadcastRefund.test.ts
@@ -1,12 +1,7 @@
-import {
-  computeMinClaimValue,
-  computeMinPeginFee,
-} from "@babylonlabs-io/babylon-tbv-rust-wasm";
 import * as bitcoin from "bitcoinjs-lib";
 import type { Address, Hex } from "viem";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { deriveRefundPeginAmounts } from "../buildAndBroadcastRefund";
 import {
   BIP68NotMatureError,
   buildAndBroadcastRefund,
@@ -471,30 +466,11 @@ describe("buildAndBroadcastRefund", () => {
         HASHLOCK.slice(2),
         SIBLING_HASHLOCK.slice(2),
       ]);
-      // pegInAmounts are NOT the raw HTLC output values (100k / 200k). The
-      // orchestrator re-derives the original peg-in amount by inverting
-      // `htlcValue = peginAmount + depositorClaimValue +
-      // minPeginFee`, subtracting the (batch-constant) protocol reserve from
-      // each entry's on-chain HTLC value. Compute that reserve from the same
-      // version-pinned ctx params so the assertion tracks the WASM sizing.
-      const ctx = buildCtx();
-      const reserve =
-        (await computeMinClaimValue(
-          ctx.numLocalChallengers,
-          ctx.universalChallengerPubkeys.length,
-          ctx.councilQuorum,
-          ctx.councilSize,
-          ctx.feeRate,
-        )) +
-        (await computeMinPeginFee(
-          ctx.vaultKeeperPubkeys.length,
-          ctx.universalChallengerPubkeys.length,
-          ctx.minPeginFeeRate,
-        ));
-      expect(call[0].prePeginParams.pegInAmounts).toEqual([
-        100_000n - reserve,
-        200_000n - reserve,
-      ]);
+      // pegInAmounts ARE the raw on-chain `amount` values: `amount` is the
+      // peg-in principal (BTCVaultRegistry "amount of BTC being pegged in"),
+      // which is exactly what the WASM template expects — it adds
+      // depositorClaimValue + minPeginFee to size the HTLC output.
+      expect(call[0].prePeginParams.pegInAmounts).toEqual([100_000n, 200_000n]);
       expect(call[0].htlcVout).toBe(1);
       expect(call[0].prePeginParams.authAnchorHash).toBe("cd".repeat(32));
     });
@@ -1148,44 +1124,4 @@ describe("buildAndBroadcastRefund", () => {
     });
   });
 
-  describe("deriveRefundPeginAmounts", () => {
-    it("inverts the protocol formula, subtracting the batch-constant reserve", async () => {
-      const ctx = buildCtx();
-      const reserve =
-        (await computeMinClaimValue(
-          ctx.numLocalChallengers,
-          ctx.universalChallengerPubkeys.length,
-          ctx.councilQuorum,
-          ctx.councilSize,
-          ctx.feeRate,
-        )) +
-        (await computeMinPeginFee(
-          ctx.vaultKeeperPubkeys.length,
-          ctx.universalChallengerPubkeys.length,
-          ctx.minPeginFeeRate,
-        ));
-
-      const peginAmounts = await deriveRefundPeginAmounts(
-        [
-          { hashlock: HASHLOCK, amount: 100_000n, htlcVout: 0 },
-          { hashlock: HASHLOCK, amount: 250_000n, htlcVout: 1 },
-        ],
-        ctx,
-      );
-
-      expect(peginAmounts).toEqual([100_000n - reserve, 250_000n - reserve]);
-    });
-
-    it("throws when an HTLC value does not exceed the protocol reserve", async () => {
-      // A 1-sat HTLC value cannot cover depositorClaimValue + minPeginFee, so
-      // the inverted peg-in amount would be non-positive. Fail closed rather
-      // than hand WASM a zero/negative amount.
-      await expect(
-        deriveRefundPeginAmounts(
-          [{ hashlock: HASHLOCK, amount: 1n, htlcVout: 0 }],
-          buildCtx(),
-        ),
-      ).rejects.toThrow(/non-positive/);
-    });
-  });
 });

--- a/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts
@@ -10,11 +10,7 @@
  * @module services/refund
  */
 
-import {
-  computeMinClaimValue,
-  computeMinPeginFee,
-  type Network,
-} from "@babylonlabs-io/babylon-tbv-rust-wasm";
+import type { Network } from "@babylonlabs-io/babylon-tbv-rust-wasm";
 import { Psbt, Transaction } from "bitcoinjs-lib";
 import type { Address, Hex } from "viem";
 
@@ -116,7 +112,12 @@ function assertBytes32(value: string, label: string): void {
 export interface VaultBatchEntry {
   /** SHA-256 hashlock commitment for this vault (bytes32, 0x-prefixed). */
   hashlock: Hex;
-  /** HTLC output value in satoshis for this vault. */
+  /**
+   * On-chain peg-in principal in satoshis (BTCVaultRegistry `amount`), NOT the
+   * HTLC output value. The funded HTLC output is this + depositorClaimValue +
+   * minPeginFee; WASM adds that reserve back, so this is what `pegInAmounts`
+   * takes verbatim.
+   */
   amount: bigint;
   /** Index of this vault's HTLC output in the funded Pre-PegIn tx. */
   htlcVout: number;
@@ -143,7 +144,10 @@ export interface VaultRefundData {
   universalChallengersVersion: number;
   vaultProvider: Address;
   applicationEntryPoint: Address;
-  /** Pre-PegIn HTLC output value in satoshis. */
+  /**
+   * On-chain peg-in principal in satoshis (BTCVaultRegistry `amount`), NOT the
+   * HTLC output value (which is this + depositorClaimValue + minPeginFee).
+   */
   amount: bigint;
   /**
    * Funded, pre-witness Pre-PegIn transaction hex. 0x prefix optional.
@@ -357,58 +361,6 @@ function validateRefundPrePeginContext(c: RefundPrePeginContext): void {
   }
 }
 
-/**
- * Re-derive each HTLC's original peg-in amount from its on-chain HTLC output
- * value, inverting the protocol formula
- * `htlcValue = peginAmount + depositorClaimValue + minPeginFee`.
- *
- * The original peg-in amount is not persisted anywhere — only the HTLC output
- * value (`batch[i].amount`) survives on-chain. WASM refund template
- * reconstruction needs the *peg-in amount*, not the HTLC value: feeding the
- * HTLC value would size the template's HTLC output above what the funded tx
- * carries, and `buildRefundPsbt`'s value cross-check would refuse the refund.
- *
- * `depositorClaimValue` and `minPeginFee` are constant across the batch
- * (fixed by the version-pinned protocol params in {@link ctx}), so they are
- * computed once via the same WASM entry points the peg-in path uses, then
- * subtracted from every entry's value. The subtraction is the inverse of the
- * sizing WASM performs internally; `buildRefundPsbt` then re-binds the result
- * to the funded tx bytes, so a wrong derivation fails closed rather than
- * signing a mis-sized refund.
- */
-export async function deriveRefundPeginAmounts(
-  batch: ReadonlyArray<VaultBatchEntry>,
-  ctx: RefundPrePeginContext,
-): Promise<bigint[]> {
-  const depositorClaimValue = await computeMinClaimValue(
-    ctx.numLocalChallengers,
-    ctx.universalChallengerPubkeys.length,
-    ctx.councilQuorum,
-    ctx.councilSize,
-    ctx.feeRate,
-  );
-  const minPeginFee = await computeMinPeginFee(
-    ctx.vaultKeeperPubkeys.length,
-    ctx.universalChallengerPubkeys.length,
-    ctx.minPeginFeeRate,
-  );
-  const reserved = depositorClaimValue + minPeginFee;
-
-  return batch.map((entry, i) => {
-    const peginAmount = entry.amount - reserved;
-    if (peginAmount <= 0n) {
-      throw new Error(
-        `Re-derived peginAmount for batch[${i}] is non-positive ` +
-          `(${peginAmount}): HTLC value ${entry.amount} does not exceed ` +
-          `depositorClaimValue ${depositorClaimValue} + minPeginFee ` +
-          `${minPeginFee}. Refusing to build a refund from an inconsistent ` +
-          `(amount, protocol params) pair.`,
-      );
-    }
-    return peginAmount;
-  });
-}
-
 function finalizeAndExtract(signedPsbtHex: string): string {
   const psbt = Psbt.fromHex(signedPsbtHex);
   try {
@@ -546,15 +498,6 @@ export async function buildAndBroadcastRefund<
     );
   }
 
-  // Re-derive the original peg-in amounts from the on-chain HTLC values.
-  // `batch[i].amount` is the HTLC *output* value, not the peg-in amount the
-  // WASM template constructor expects; feeding it verbatim mis-sizes the
-  // template. The derivation is bound back to the funded tx bytes by
-  // `buildRefundPsbt`'s value cross-check, so an inconsistent result fails
-  // closed instead of producing a mis-sized refund.
-  const refundPeginAmounts = await deriveRefundPeginAmounts(vault.batch, ctx);
-  signal?.throwIfAborted();
-
   const { psbtHex } = await buildRefundPsbt({
     prePeginParams: {
       depositorPubkey: xOnlyDepositorPubkey,
@@ -564,7 +507,12 @@ export async function buildAndBroadcastRefund<
         ctx.universalChallengerPubkeys.map(stripHexPrefix),
       hashlocks: vault.batch.map((b) => stripHexPrefix(b.hashlock)),
       timelockRefund: ctx.timelockRefund,
-      pegInAmounts: refundPeginAmounts,
+      // `b.amount` is the on-chain peg-in principal (BTCVaultRegistry "amount of
+      // BTC being pegged in"), which is exactly what the WASM template expects:
+      // it adds depositorClaimValue + minPeginFee to size the HTLC output.
+      // buildRefundPsbt's value cross-check then asserts the reconstructed HTLC
+      // value equals the funded tx, failing closed on any mismatch.
+      pegInAmounts: vault.batch.map((b) => b.amount),
       feeRate: ctx.feeRate,
       minPeginFeeRate: ctx.minPeginFeeRate,
       numLocalChallengers: ctx.numLocalChallengers,


### PR DESCRIPTION
Restores the **refund path** for expired vaults. Every expired-vault refund was
failing with `HTLC value mismatch at vout 0: reconstructed template expects … sat,
funded tx carries … sat. Refund refused`. This passes the on-chain peg-in amount
straight into the WASM refund template instead of subtracting a reserve from it
first, which is what the template actually expects.

It reverts **only** the `deriveRefundPeginAmounts` re-derivation that PR #1877 added,
and **keeps** that PR's two security guards intact (see "Security" below).