### PR TITLE
fix(refund): stop HTLC value mismatch crash

### DIFF
--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/refund.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/refund.test.ts
@@ -11,7 +11,6 @@
 
 import type { Network } from "@babylonlabs-io/babylon-tbv-rust-wasm";
 import * as bitcoin from "bitcoinjs-lib";
-import type { Hex } from "viem";
 import { beforeAll, describe, expect, it } from "vitest";
 
 import {
@@ -19,10 +18,6 @@ import {
   stripHexPrefix,
   uint8ArrayToHex,
 } from "../../utils/bitcoin";
-import {
-  deriveRefundPeginAmounts,
-  type RefundPrePeginContext,
-} from "../../../services/refund/buildAndBroadcastRefund";
 import { fundPeginTransaction } from "../../../utils/transaction/fundPeginTransaction";
 import { buildPrePeginPsbt, type PrePeginParams } from "../pegin";
 import { buildRefundPsbt } from "../refund";
@@ -397,52 +392,22 @@ describe("buildRefundPsbt", () => {
     });
   });
 
-  describe("peg-in amount derivation round-trip", () => {
-    it("re-derives the original peg-in amount from the funded HTLC value (real WASM)", async () => {
-      // Keystone equality: the reserve subtracted at refund time (standalone
-      // computeMinClaimValue + computeMinPeginFee) must equal the reserve WASM
-      // baked into the HTLC value at peg-in time. Fund with a known peg-in
-      // amount, read the funded HTLC value, and prove the derivation inverts
-      // back to that exact amount — so a future WASM bump that broke the
-      // equality is caught here, not in production.
+  describe("peg-in amount pass-through", () => {
+    it("passes the on-chain peg-in amount straight through and the value cross-check accepts it (real WASM)", async () => {
+      // `batch[i].amount` is the on-chain vault deposit (peg-in) amount, which
+      // is exactly what WASM's `pegInAmounts` expects: WASM re-adds the protocol
+      // reserve (`depositorClaimValue + minPeginFee`) internally when it sizes
+      // the HTLC output, so the template's HTLC value equals the funded tx's
+      // output and `buildRefundPsbt`'s value cross-check passes. Fund with a
+      // known peg-in amount and prove the unmodified amount reconstructs a
+      // template the cross-check accepts — a legitimate refund does not throw.
       const { txHex, params } = await buildFundedPrePegin({
         authAnchorHash: TEST_AUTH_ANCHOR_HASH,
       });
-      const fundedHtlcValue = BigInt(
-        bitcoin.Transaction.fromHex(txHex).outs[0].value,
-      );
 
-      const ctx: RefundPrePeginContext = {
-        vaultProviderPubkey: params.vaultProviderPubkey,
-        vaultKeeperPubkeys: params.vaultKeeperPubkeys,
-        universalChallengerPubkeys: params.universalChallengerPubkeys,
-        timelockRefund: params.timelockRefund,
-        feeRate: params.feeRate,
-        minPeginFeeRate: params.minPeginFeeRate,
-        numLocalChallengers: params.numLocalChallengers,
-        councilQuorum: params.councilQuorum,
-        councilSize: params.councilSize,
-        network: params.network,
-      };
-
-      const derived = await deriveRefundPeginAmounts(
-        [
-          {
-            hashlock: `0x${TEST_HASH_H}` as Hex,
-            amount: fundedHtlcValue,
-            htlcVout: 0,
-          },
-        ],
-        ctx,
-      );
-      expect(derived).toEqual([TEST_AMOUNTS.PEGIN]);
-
-      // And feeding the derived amount back through the real (unmocked)
-      // builder reconstructs a template whose value cross-check passes — a
-      // legitimate refund does not throw.
       await expect(
         buildRefundPsbt({
-          prePeginParams: { ...params, pegInAmounts: derived },
+          prePeginParams: { ...params, pegInAmounts: [TEST_AMOUNTS.PEGIN] },
           fundedPrePeginTxHex: txHex,
           htlcVout: 0,
           refundFee: TEST_REFUND_FEE,

--- a/packages/babylon-ts-sdk/src/tbv/core/services/refund/__tests__/buildAndBroadcastRefund.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/refund/__tests__/buildAndBroadcastRefund.test.ts
@@ -1,12 +1,7 @@
-import {
-  computeMinClaimValue,
-  computeMinPeginFee,
-} from "@babylonlabs-io/babylon-tbv-rust-wasm";
 import * as bitcoin from "bitcoinjs-lib";
 import type { Address, Hex } from "viem";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { deriveRefundPeginAmounts } from "../buildAndBroadcastRefund";
 import {
   BIP68NotMatureError,
   buildAndBroadcastRefund,
@@ -471,30 +466,11 @@ describe("buildAndBroadcastRefund", () => {
         HASHLOCK.slice(2),
         SIBLING_HASHLOCK.slice(2),
       ]);
-      // pegInAmounts are NOT the raw HTLC output values (100k / 200k). The
-      // orchestrator re-derives the original peg-in amount by inverting
-      // `htlcValue = peginAmount + depositorClaimValue +
-      // minPeginFee`, subtracting the (batch-constant) protocol reserve from
-      // each entry's on-chain HTLC value. Compute that reserve from the same
-      // version-pinned ctx params so the assertion tracks the WASM sizing.
-      const ctx = buildCtx();
-      const reserve =
-        (await computeMinClaimValue(
-          ctx.numLocalChallengers,
-          ctx.universalChallengerPubkeys.length,
-          ctx.councilQuorum,
-          ctx.councilSize,
-          ctx.feeRate,
-        )) +
-        (await computeMinPeginFee(
-          ctx.vaultKeeperPubkeys.length,
-          ctx.universalChallengerPubkeys.length,
-          ctx.minPeginFeeRate,
-        ));
-      expect(call[0].prePeginParams.pegInAmounts).toEqual([
-        100_000n - reserve,
-        200_000n - reserve,
-      ]);
+      // pegInAmounts are the on-chain vault deposit (peg-in) amounts passed
+      // straight through from `batch[i].amount` — WASM re-adds the protocol
+      // reserve (`depositorClaimValue + minPeginFee`) internally when it sizes
+      // the HTLC output, so the orchestrator must not pre-subtract it.
+      expect(call[0].prePeginParams.pegInAmounts).toEqual([100_000n, 200_000n]);
       expect(call[0].htlcVout).toBe(1);
       expect(call[0].prePeginParams.authAnchorHash).toBe("cd".repeat(32));
     });
@@ -1145,47 +1121,6 @@ describe("buildAndBroadcastRefund", () => {
         }),
       ).rejects.toThrow("cancelled");
       expect(readVault).not.toHaveBeenCalled();
-    });
-  });
-
-  describe("deriveRefundPeginAmounts", () => {
-    it("inverts the protocol formula, subtracting the batch-constant reserve", async () => {
-      const ctx = buildCtx();
-      const reserve =
-        (await computeMinClaimValue(
-          ctx.numLocalChallengers,
-          ctx.universalChallengerPubkeys.length,
-          ctx.councilQuorum,
-          ctx.councilSize,
-          ctx.feeRate,
-        )) +
-        (await computeMinPeginFee(
-          ctx.vaultKeeperPubkeys.length,
-          ctx.universalChallengerPubkeys.length,
-          ctx.minPeginFeeRate,
-        ));
-
-      const peginAmounts = await deriveRefundPeginAmounts(
-        [
-          { hashlock: HASHLOCK, amount: 100_000n, htlcVout: 0 },
-          { hashlock: HASHLOCK, amount: 250_000n, htlcVout: 1 },
-        ],
-        ctx,
-      );
-
-      expect(peginAmounts).toEqual([100_000n - reserve, 250_000n - reserve]);
-    });
-
-    it("throws when an HTLC value does not exceed the protocol reserve", async () => {
-      // A 1-sat HTLC value cannot cover depositorClaimValue + minPeginFee, so
-      // the inverted peg-in amount would be non-positive. Fail closed rather
-      // than hand WASM a zero/negative amount.
-      await expect(
-        deriveRefundPeginAmounts(
-          [{ hashlock: HASHLOCK, amount: 1n, htlcVout: 0 }],
-          buildCtx(),
-        ),
-      ).rejects.toThrow(/non-positive/);
     });
   });
 });

--- a/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts
@@ -10,11 +10,7 @@
  * @module services/refund
  */
 
-import {
-  computeMinClaimValue,
-  computeMinPeginFee,
-  type Network,
-} from "@babylonlabs-io/babylon-tbv-rust-wasm";
+import type { Network } from "@babylonlabs-io/babylon-tbv-rust-wasm";
 import { Psbt, Transaction } from "bitcoinjs-lib";
 import type { Address, Hex } from "viem";
 
@@ -116,7 +112,13 @@ function assertBytes32(value: string, label: string): void {
 export interface VaultBatchEntry {
   /** SHA-256 hashlock commitment for this vault (bytes32, 0x-prefixed). */
   hashlock: Hex;
-  /** HTLC output value in satoshis for this vault. */
+  /**
+   * Vault deposit (peg-in) amount in satoshis — the on-chain contract's
+   * `amount` field. This is the peg-in amount WASM expects in `pegInAmounts`,
+   * NOT the funded HTLC output value (which is `amount + depositorClaimValue +
+   * minPeginFee`). WASM re-adds that reserve internally when it sizes the HTLC
+   * output, so this value is passed straight through.
+   */
   amount: bigint;
   /** Index of this vault's HTLC output in the funded Pre-PegIn tx. */
   htlcVout: number;
@@ -143,7 +145,7 @@ export interface VaultRefundData {
   universalChallengersVersion: number;
   vaultProvider: Address;
   applicationEntryPoint: Address;
-  /** Pre-PegIn HTLC output value in satoshis. */
+  /** Vault deposit (peg-in) amount in satoshis — the on-chain `amount` field. */
   amount: bigint;
   /**
    * Funded, pre-witness Pre-PegIn transaction hex. 0x prefix optional.
@@ -357,58 +359,6 @@ function validateRefundPrePeginContext(c: RefundPrePeginContext): void {
   }
 }
 
-/**
- * Re-derive each HTLC's original peg-in amount from its on-chain HTLC output
- * value, inverting the protocol formula
- * `htlcValue = peginAmount + depositorClaimValue + minPeginFee`.
- *
- * The original peg-in amount is not persisted anywhere — only the HTLC output
- * value (`batch[i].amount`) survives on-chain. WASM refund template
- * reconstruction needs the *peg-in amount*, not the HTLC value: feeding the
- * HTLC value would size the template's HTLC output above what the funded tx
- * carries, and `buildRefundPsbt`'s value cross-check would refuse the refund.
- *
- * `depositorClaimValue` and `minPeginFee` are constant across the batch
- * (fixed by the version-pinned protocol params in {@link ctx}), so they are
- * computed once via the same WASM entry points the peg-in path uses, then
- * subtracted from every entry's value. The subtraction is the inverse of the
- * sizing WASM performs internally; `buildRefundPsbt` then re-binds the result
- * to the funded tx bytes, so a wrong derivation fails closed rather than
- * signing a mis-sized refund.
- */
-export async function deriveRefundPeginAmounts(
-  batch: ReadonlyArray<VaultBatchEntry>,
-  ctx: RefundPrePeginContext,
-): Promise<bigint[]> {
-  const depositorClaimValue = await computeMinClaimValue(
-    ctx.numLocalChallengers,
-    ctx.universalChallengerPubkeys.length,
-    ctx.councilQuorum,
-    ctx.councilSize,
-    ctx.feeRate,
-  );
-  const minPeginFee = await computeMinPeginFee(
-    ctx.vaultKeeperPubkeys.length,
-    ctx.universalChallengerPubkeys.length,
-    ctx.minPeginFeeRate,
-  );
-  const reserved = depositorClaimValue + minPeginFee;
-
-  return batch.map((entry, i) => {
-    const peginAmount = entry.amount - reserved;
-    if (peginAmount <= 0n) {
-      throw new Error(
-        `Re-derived peginAmount for batch[${i}] is non-positive ` +
-          `(${peginAmount}): HTLC value ${entry.amount} does not exceed ` +
-          `depositorClaimValue ${depositorClaimValue} + minPeginFee ` +
-          `${minPeginFee}. Refusing to build a refund from an inconsistent ` +
-          `(amount, protocol params) pair.`,
-      );
-    }
-    return peginAmount;
-  });
-}
-
 function finalizeAndExtract(signedPsbtHex: string): string {
   const psbt = Psbt.fromHex(signedPsbtHex);
   try {
@@ -546,15 +496,6 @@ export async function buildAndBroadcastRefund<
     );
   }
 
-  // Re-derive the original peg-in amounts from the on-chain HTLC values.
-  // `batch[i].amount` is the HTLC *output* value, not the peg-in amount the
-  // WASM template constructor expects; feeding it verbatim mis-sizes the
-  // template. The derivation is bound back to the funded tx bytes by
-  // `buildRefundPsbt`'s value cross-check, so an inconsistent result fails
-  // closed instead of producing a mis-sized refund.
-  const refundPeginAmounts = await deriveRefundPeginAmounts(vault.batch, ctx);
-  signal?.throwIfAborted();
-
   const { psbtHex } = await buildRefundPsbt({
     prePeginParams: {
       depositorPubkey: xOnlyDepositorPubkey,
@@ -564,7 +505,13 @@ export async function buildAndBroadcastRefund<
         ctx.universalChallengerPubkeys.map(stripHexPrefix),
       hashlocks: vault.batch.map((b) => stripHexPrefix(b.hashlock)),
       timelockRefund: ctx.timelockRefund,
-      pegInAmounts: refundPeginAmounts,
+      // `batch[i].amount` is the on-chain vault deposit (peg-in) amount, which
+      // is exactly what WASM's `pegInAmounts` expects — it re-adds the protocol
+      // reserve (`depositorClaimValue + minPeginFee`) internally when sizing the
+      // HTLC output. `buildRefundPsbt`'s value cross-check then binds the result
+      // to the funded tx bytes, refusing the refund if the template's HTLC value
+      // disagrees with the on-chain commitment.
+      pegInAmounts: vault.batch.map((b) => b.amount),
       feeRate: ctx.feeRate,
       minPeginFeeRate: ctx.minPeginFeeRate,
       numLocalChallengers: ctx.numLocalChallengers,

--- a/services/vault/src/components/deposit/RefundModal/RefundReviewContent.tsx
+++ b/services/vault/src/components/deposit/RefundModal/RefundReviewContent.tsx
@@ -26,7 +26,14 @@ import { FeeRateField } from "./FeeRateField";
 const DUST_LIMIT_SATS = 546n;
 
 interface RefundReviewContentProps {
+  /** Amount reclaimed by the refund (funded HTLC value); drives the display. */
   amountSats: bigint | null;
+  /**
+   * Deposit amount the SDK's fee-fraction cap is computed against. Mirror it
+   * here (not {@link amountSats}) so the UI cap matches the SDK and never lets
+   * the user confirm a fee the SDK is about to reject.
+   */
+  feeCapBasisSats: bigint | null;
   defaultFeeRateSatsVb: number | null;
   previewError: string | null;
   refunding: boolean;
@@ -36,6 +43,7 @@ interface RefundReviewContentProps {
 
 export function RefundReviewContent({
   amountSats,
+  feeCapBasisSats,
   defaultFeeRateSatsVb,
   previewError,
   refunding,
@@ -95,8 +103,8 @@ export function RefundReviewContent({
   const exceedsRateCap =
     feeRate !== null && feeRate > REFUND_MAX_FEE_RATE_SATS_VB;
   const maxFeeByFractionSats =
-    amountSats !== null
-      ? (amountSats * REFUND_MAX_FEE_FRACTION_NUMERATOR) /
+    feeCapBasisSats !== null
+      ? (feeCapBasisSats * REFUND_MAX_FEE_FRACTION_NUMERATOR) /
         REFUND_MAX_FEE_FRACTION_DENOMINATOR
       : null;
   const exceedsFractionCap =
@@ -115,9 +123,14 @@ export function RefundReviewContent({
     !usingFallback;
 
   const feeCapMessage = exceedsRateCap
-    ? `Network fee rate exceeds the safety cap of ${REFUND_MAX_FEE_RATE_SATS_VB} sat/vB. Lower the fee rate to continue.`
+    ? COPY.deposit.refundReview.feeRateCapError(REFUND_MAX_FEE_RATE_SATS_VB)
     : exceedsFractionCap
-      ? `Network fee exceeds ${(REFUND_MAX_FEE_FRACTION_NUMERATOR * 100n) / REFUND_MAX_FEE_FRACTION_DENOMINATOR}% of the refund amount. Lower the fee rate to continue.`
+      ? COPY.deposit.refundReview.feeFractionCapError(
+          Number(
+            (REFUND_MAX_FEE_FRACTION_NUMERATOR * 100n) /
+              REFUND_MAX_FEE_FRACTION_DENOMINATOR,
+          ),
+        )
       : null;
 
   const handleConfirmClick = () => {

--- a/services/vault/src/components/deposit/RefundModal/__tests__/RefundModal.test.tsx
+++ b/services/vault/src/components/deposit/RefundModal/__tests__/RefundModal.test.tsx
@@ -17,6 +17,7 @@ vi.mock("@/services/vault/vaultRefundService", async (importOriginal) => {
     ...actual,
     getRefundPreview: vi.fn(async () => ({
       amountSats: 1_000_000n,
+      feeCapBasisSats: 1_000_000n,
       halfHourFeeSatsVb: 5,
       prePeginOnChain: true,
     })),
@@ -84,6 +85,7 @@ describe("RefundModal", () => {
   it("disables Confirm and shows the rate-cap banner when mempool returns a malicious fee rate", async () => {
     vi.mocked(getRefundPreview).mockResolvedValueOnce({
       amountSats: 100_000_000n,
+      feeCapBasisSats: 100_000_000n,
       halfHourFeeSatsVb: 10_000,
       prePeginOnChain: true,
     });
@@ -133,6 +135,7 @@ describe("RefundModal", () => {
     // exists to spend, so the modal must not offer the refund form.
     vi.mocked(getRefundPreview).mockResolvedValueOnce({
       amountSats: 1_000_000n,
+      feeCapBasisSats: 1_000_000n,
       halfHourFeeSatsVb: 5,
       prePeginOnChain: false,
     });
@@ -161,12 +164,15 @@ describe("RefundModal", () => {
     expect(onClose).toHaveBeenCalled();
   });
 
-  it("disables Confirm and shows the fraction-cap banner for a small vault at a within-rate-cap fee", async () => {
-    // Small vault where rate is below the per-vbyte ceiling but absolute
-    // fee still consumes more than 10% of vault.amount.
-    // 100k-sat vault, halfHourFee=100 sat/vB → fee=16_000 > 10% of 100k.
+  it("caps the fee against the deposit basis, not the larger refund amount, for a small vault", async () => {
+    // The cap mirrors the SDK, which keys off the deposit amount
+    // (feeCapBasisSats), not the funded HTLC value shown as amountSats.
+    // halfHourFee=100 sat/vB → fee=16_000. That is > 10% of the 100k deposit
+    // basis (10_000) so the banner must show, yet < 10% of the 200k funded
+    // amount (20_000) — so a cap keyed off amountSats would wrongly pass.
     vi.mocked(getRefundPreview).mockResolvedValueOnce({
-      amountSats: 100_000n,
+      amountSats: 200_000n,
+      feeCapBasisSats: 100_000n,
       halfHourFeeSatsVb: 100,
       prePeginOnChain: true,
     });
@@ -183,7 +189,7 @@ describe("RefundModal", () => {
     );
 
     expect(
-      await screen.findByText(/exceeds 10% of the refund amount/i),
+      await screen.findByText(/exceeds the 10% refund safety cap/i),
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /confirm/i })).toBeDisabled();
   });

--- a/services/vault/src/components/deposit/RefundModal/index.tsx
+++ b/services/vault/src/components/deposit/RefundModal/index.tsx
@@ -104,6 +104,7 @@ export function RefundModal({
     >
       <RefundReviewContent
         amountSats={previewQuery.data?.amountSats ?? null}
+        feeCapBasisSats={previewQuery.data?.feeCapBasisSats ?? null}
         defaultFeeRateSatsVb={previewQuery.data?.halfHourFeeSatsVb ?? null}
         previewError={previewError}
         refunding={refunding}

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -295,6 +295,14 @@ export const COPY = {
         "Could not fetch the mempool fee rate. The minimum relay fee may not get your refund confirmed. Set a fee rate above to continue.",
       dustError:
         "Network fee is too high — your refund would be below the Bitcoin dust limit. Lower the fee rate to continue.",
+      feeRateCapError: (maxRateSatsVb: number) =>
+        `Network fee rate exceeds the safety cap of ${maxRateSatsVb} sat/vB. Lower the fee rate to continue.`,
+      // The cap is a percentage of the vault deposit (the SDK's basis), not of
+      // the larger refund amount shown above — so frame it as the safety cap
+      // rather than "% of the refund amount", which would contradict the
+      // displayed figure.
+      feeFractionCapError: (percent: number) =>
+        `Network fee exceeds the ${percent}% refund safety cap. Lower the fee rate to continue.`,
       retryButton: "Retry",
       confirmButton: "Confirm",
     },

--- a/services/vault/src/services/vault/__tests__/vaultRefundService.test.ts
+++ b/services/vault/src/services/vault/__tests__/vaultRefundService.test.ts
@@ -78,6 +78,7 @@ vi.mock("../fetchVaults", () => ({
 
 import { getNetworkFees, pushTx } from "@babylonlabs-io/ts-sdk/tbv/core";
 import { calculateBtcTxHash } from "@babylonlabs-io/ts-sdk/tbv/core/utils";
+import * as bitcoin from "bitcoinjs-lib";
 import {
   afterEach,
   beforeEach,
@@ -129,8 +130,22 @@ const VP_BTC_PUBKEY_X_ONLY = "f".repeat(64);
 const VAULT_PROVIDER = { btcPubKey: `0x${VP_BTC_PUBKEY_X_ONLY}` };
 const VAULT_KEEPERS = [{ btcPubKey: "vk1" }, { btcPubKey: "vk2" }];
 const UNIVERSAL_CHALLENGERS = [{ btcPubKey: "uc1" }];
+// Funded Pre-PegIn tx whose HTLC output (vout 0, matching ON_CHAIN_VAULT
+// .htlcVout) carries the deposit amount (100_000) PLUS the protocol reserve.
+// The refund preview must report this funded value — what the depositor
+// actually reclaims — not the bare on-chain deposit amount.
+const FUNDED_HTLC_VALUE_SATS = 133_668n; // 100_000 deposit + 33_668 reserve
+const FUNDED_PRE_PEGIN_TX_HEX = (() => {
+  const tx = new bitcoin.Transaction();
+  tx.addInput(Buffer.alloc(32, 0), 0);
+  tx.addOutput(
+    Buffer.from(`0014${"bb".repeat(20)}`, "hex"),
+    Number(FUNDED_HTLC_VALUE_SATS),
+  );
+  return tx.toHex();
+})();
 const INDEXER_VAULT = {
-  unsignedPrePeginTx: "0xrawtx",
+  unsignedPrePeginTx: `0x${FUNDED_PRE_PEGIN_TX_HEX}`,
   depositorBtcPubkey: "indexer_depositor_pubkey",
 };
 const BTC_WALLET_PROVIDER = {
@@ -553,9 +568,15 @@ describe("getRefundPreview", () => {
     mockFetch.mockResolvedValue({ status: 200 });
   });
 
-  it("returns the on-chain HTLC amount and mempool halfHourFee", async () => {
+  it("returns the funded HTLC value (deposit + reserve) as the refund amount, with the deposit amount as the fee-cap basis", async () => {
     const preview = await getRefundPreview(VAULT_ID);
-    expect(preview.amountSats).toBe(ON_CHAIN_VAULT.amount);
+    // The reclaimed amount is the funded HTLC output value, not the bare
+    // on-chain deposit amount — the reserve returns to the depositor.
+    expect(preview.amountSats).toBe(FUNDED_HTLC_VALUE_SATS);
+    expect(preview.amountSats).not.toBe(ON_CHAIN_VAULT.amount);
+    // The SDK caps the fee against the deposit amount; the preview surfaces it
+    // separately so the UI cap mirrors the SDK exactly.
+    expect(preview.feeCapBasisSats).toBe(ON_CHAIN_VAULT.amount);
     expect(preview.halfHourFeeSatsVb).toBe(7);
     expect(preview.prePeginOnChain).toBe(true);
   });
@@ -572,7 +593,7 @@ describe("getRefundPreview", () => {
       new Error("mempool unreachable"),
     );
     const preview = await getRefundPreview(VAULT_ID);
-    expect(preview.amountSats).toBe(ON_CHAIN_VAULT.amount);
+    expect(preview.amountSats).toBe(FUNDED_HTLC_VALUE_SATS);
     expect(preview.halfHourFeeSatsVb).toBeNull();
   });
 

--- a/services/vault/src/services/vault/vaultRefundService.ts
+++ b/services/vault/src/services/vault/vaultRefundService.ts
@@ -26,6 +26,7 @@ import {
   type VaultRefundData,
 } from "@babylonlabs-io/ts-sdk/tbv/core/services";
 import { calculateBtcTxHash } from "@babylonlabs-io/ts-sdk/tbv/core/utils";
+import { Transaction } from "bitcoinjs-lib";
 import type { Address, Hex } from "viem";
 
 import { getMempoolApiUrl } from "../../clients/btc/config";
@@ -63,7 +64,27 @@ export interface BroadcastRefundParams {
 }
 
 export interface RefundPreview {
+  /**
+   * The amount actually reclaimed by the refund: the funded HTLC output value
+   * at `htlcVout` in the on-chain Pre-PegIn tx. This is the vault deposit
+   * amount PLUS the protocol reserve (`depositorClaimValue + minPeginFee`)
+   * that peg-in baked into the HTLC output — the depositor reclaims all of it
+   * (minus the network fee) because activation never spent the reserve. NOT
+   * the bare on-chain `amount` field, which is only the deposit amount. The
+   * broadcast path pins the refund output to exactly this value minus the fee
+   * (see `buildRefundPsbt`), so the preview must show the same figure.
+   */
   amountSats: bigint;
+  /**
+   * The deposit amount (`amount` field) the SDK's fee-fraction safety cap is
+   * computed against (`buildAndBroadcastRefund` caps the refund fee at a
+   * fraction of `vault.amount`). The review UI mirrors that cap to avoid
+   * letting the user confirm a fee the SDK is about to reject — so it must
+   * use this deposit-amount basis, not the larger `amountSats`, otherwise the
+   * mirror drifts (notably for small vaults where the reserve is a large
+   * fraction of the deposit).
+   */
+  feeCapBasisSats: bigint;
   /**
    * Mempool's halfHourFee, or null if the fee endpoint failed. Vault data
    * loads independently — a fee fetch failure must not block the refund.
@@ -121,6 +142,30 @@ async function isPrePeginOnChain(
   }
 }
 
+/**
+ * Read the funded HTLC output value (satoshis) the refund will reclaim — the
+ * output at `htlcVout` in the funded Pre-PegIn tx. This is the deposit amount
+ * plus the protocol reserve peg-in baked into the HTLC; it is the value the
+ * broadcast path pins the refund output to (minus the fee). The funded tx hex
+ * is authenticated against the on-chain `prePeginTxHash` in
+ * {@link readTargetVault} before it reaches here.
+ */
+function readFundedHtlcValueSats(
+  fundedTxHex: string,
+  htlcVout: number,
+): bigint {
+  const fundedTx = Transaction.fromHex(stripHexPrefix(fundedTxHex));
+  const htlcOutput = fundedTx.outs[htlcVout];
+  if (!htlcOutput) {
+    throw new Error(
+      `Funded Pre-PegIn tx has no output at htlcVout ${htlcVout} ` +
+        `(it has ${fundedTx.outs.length} outputs). Cannot preview the ` +
+        `refund amount.`,
+    );
+  }
+  return BigInt(htlcOutput.value);
+}
+
 export async function getRefundPreview(vaultId: Hex): Promise<RefundPreview> {
   const mempoolApiUrl = getMempoolApiUrl();
   // The fee fetch doesn't depend on vault data — start it now so it overlaps
@@ -133,7 +178,16 @@ export async function getRefundPreview(vaultId: Hex): Promise<RefundPreview> {
     isPrePeginOnChain(target.onChainVault.prePeginTxHash, mempoolApiUrl),
   ]);
   return {
-    amountSats: target.onChainVault.amount,
+    // Reclaimed amount = the funded HTLC output value, not the bare deposit
+    // `amount`. The reserve peg-in baked into the HTLC returns to the
+    // depositor since activation never spent it.
+    amountSats: readFundedHtlcValueSats(
+      target.unsignedPrePeginTx,
+      target.onChainVault.htlcVout,
+    ),
+    // The SDK caps the refund fee against the deposit amount; mirror that
+    // basis in the UI cap so the two never disagree.
+    feeCapBasisSats: target.onChainVault.amount,
     halfHourFeeSatsVb:
       feeRecommendation && feeRecommendation.halfHourFee > 0
         ? feeRecommendation.halfHourFee


### PR DESCRIPTION
## What this fixes

Refunds of expired deposits were failing with this error, and the user could not get their BTC back:

> HTLC value mismatch at vout 0: reconstructed template expects 1690667 sat, funded tx carries 1724335 sat. Refund refused — the pegInAmounts vector does not match the on-chain commitment.

This PR makes refunds work again, and also fixes the refund preview screen so it shows the amount the depositor actually gets back.

## Background: how a refund is built

When someone deposits, we lock BTC in an HTLC output on Bitcoin. The value sitting in that HTLC output is `deposit amount + a protocol reserve` (the reserve = `depositorClaimValue + minPeginFee`, money set aside to cover later steps). To build a refund, our WASM code rebuilds a copy of that original transaction "template" and checks that the value it computes matches the value actually sitting on-chain. If they don't match, it refuses to sign — this is a safety check so we never sign a refund that disagrees with what's really on Bitcoin.

## What was going wrong

A recent change (https://github.com/babylonlabs-io/babylon-toolkit/pull/1877) added two things to the refund path: (1) a re-derivation of the "peg-in amount" and (2) the value cross-check above.

The re-derivation assumed the on-chain `amount` field was the **full HTLC output value**, so it subtracted the reserve from it to get the peg-in amount. But `amount` from the contract is already the **deposit (peg-in) amount** — the reserve was never in it. So the code subtracted the reserve one time too many. The rebuilt template then came out exactly one reserve too small, and the new cross-check correctly rejected it.

## The fix

### 1. SDK — stop the crash (the important part)

- Removed the wrong re-derivation (`deriveRefundPeginAmounts`).
- We now pass the contract `amount` straight through as `pegInAmounts` again — which is exactly what WASM expects, because WASM adds the reserve back internally. This restores the behavior from before https://github.com/babylonlabs-io/babylon-toolkit/pull/1877.
- We **kept** the value cross-check and the output safety checks added by that PR. They were never the bug — the cross-check did its job by catching the mis-sized template. With correct inputs it now passes.
- Fixed the misleading code comment that called `amount` the "HTLC output value" (that wrong label is what caused the bug in the first place).

### 2. Vault UI — show the real refund amount

The refund preview was showing the bare **deposit amount**, but the refund actually returns the **full HTLC value** (deposit + reserve) minus the network fee. So users were being shown less than they really get back.

- The preview now reads the real HTLC output value straight from the funded transaction (the same value the broadcast code pays out), so "Refund Amount" and "You'll receive" are correct.
- The refund fee safety cap (max 10%) still uses the **deposit amount**, to exactly match what the SDK enforces. We pass this as a separate `feeCapBasisSats` value so the UI and SDK never disagree (important for small vaults, where the reserve is a big share of the deposit).
- Updated the fee-cap warning text so it no longer says "10% of the refund amount" (which would now be misleading), and moved both fee-cap messages into `copy.ts` per our copy rules.

## Approaches we considered

1. **Pass the deposit amount through and keep the cross-check (chosen).** Smallest, safest change. It treats the on-chain value as the source of truth, keeps the new safety checks, and simply stops doing the wrong subtraction. This is what the data clearly pointed to.
2. **Drop the value cross-check entirely.** Rejected. The check is a useful guardrail and was correctly catching the problem — removing it would hide future bugs instead of fixing this one.
3. **Keep the re-derivation but fix the reserve math.** Rejected. There was no reserve math to "fix" — the input was already the peg-in amount, so any subtraction is wrong. Re-deriving a value we already have just adds fragility.

For the UI fee cap, we considered changing the SDK to cap against the full HTLC value (so the UI could use one number for everything). We did **not** do this here, because that changes a refund-fee safety guard on a critical path and should be a deliberate, separately-reviewed decision. It's noted as a possible follow-up.
