### PR TITLE
feat(vault): in-page disabled-deposit state and oversized-amount guard

### DIFF
--- a/services/vault/src/applications/aave/hooks/__tests__/useOptimalSplit.test.tsx
+++ b/services/vault/src/applications/aave/hooks/__tests__/useOptimalSplit.test.tsx
@@ -71,13 +71,13 @@ describe("useOptimalSplit", () => {
     expect(result.current.sacrificialVault).toBe(0n);
   });
 
-  it("surfaces an explicit error for an oversized amount instead of zeroing", () => {
-    // 21,000,001 BTC in sats — above Bitcoin's max supply, so invalid input.
+  it("returns an empty result without throwing for an oversized amount", () => {
+    // Above Bitcoin's max supply (21M BTC) — would trip the SDK's
+    // assertSafePrecision guard (RangeError); the hook must bail safely.
     const { result } = renderHook(() =>
       useOptimalSplit(2_100_000_100_000_000n),
     );
 
-    expect(result.current.error).toBeInstanceOf(RangeError);
     expect(result.current.canSplit).toBe(false);
     expect(result.current.sacrificialVault).toBe(0n);
     expect(result.current.protectedVault).toBe(0n);

--- a/services/vault/src/applications/aave/hooks/__tests__/useOptimalSplit.test.tsx
+++ b/services/vault/src/applications/aave/hooks/__tests__/useOptimalSplit.test.tsx
@@ -71,6 +71,18 @@ describe("useOptimalSplit", () => {
     expect(result.current.sacrificialVault).toBe(0n);
   });
 
+  it("surfaces an explicit error for an oversized amount instead of zeroing", () => {
+    // 21,000,001 BTC in sats — above Bitcoin's max supply, so invalid input.
+    const { result } = renderHook(() =>
+      useOptimalSplit(2_100_000_100_000_000n),
+    );
+
+    expect(result.current.error).toBeInstanceOf(RangeError);
+    expect(result.current.canSplit).toBe(false);
+    expect(result.current.sacrificialVault).toBe(0n);
+    expect(result.current.protectedVault).toBe(0n);
+  });
+
   it("returns canSplit: false when params errored", () => {
     mockUseVaultSplitParams.mockReturnValue({
       params: null,

--- a/services/vault/src/applications/aave/hooks/useOptimalSplit.ts
+++ b/services/vault/src/applications/aave/hooks/useOptimalSplit.ts
@@ -37,6 +37,12 @@ export interface UseOptimalSplitResult {
   error: Error | null;
 }
 
+// Bitcoin's fixed maximum supply in satoshis (21,000,000 BTC × 1e8). Any
+// amount above this is invalid input and would trip the SDK's
+// assertSafePrecision guard (RangeError). Bail to the empty result so the
+// form's amount validation can surface the error instead of crashing.
+const MAX_PLAUSIBLE_DEPOSIT_SATS = 2_100_000_000_000_000n;
+
 const EMPTY_RESULT: Omit<UseOptimalSplitResult, "isLoading" | "error"> = {
   sacrificialVault: 0n,
   protectedVault: 0n,
@@ -53,7 +59,7 @@ export function useOptimalSplit(
   const { minDeposit } = useProtocolParamsContext();
 
   const result = useMemo(() => {
-    if (!params || totalBtc <= 0n) {
+    if (!params || totalBtc <= 0n || totalBtc > MAX_PLAUSIBLE_DEPOSIT_SATS) {
       return EMPTY_RESULT;
     }
 

--- a/services/vault/src/applications/aave/hooks/useOptimalSplit.ts
+++ b/services/vault/src/applications/aave/hooks/useOptimalSplit.ts
@@ -37,10 +37,11 @@ export interface UseOptimalSplitResult {
   error: Error | null;
 }
 
-// Bitcoin's fixed maximum supply in satoshis (21,000,000 BTC × 1e8). Any
-// amount above this is invalid input and would trip the SDK's
-// assertSafePrecision guard (RangeError). We reject it with an explicit error
-// rather than computing the split or returning a silent zero result.
+// Bitcoin's fixed maximum supply in satoshis (21,000,000 BTC × 1e8). A larger
+// "amount" can't be a real deposit and would trip the SDK's assertSafePrecision
+// guard (RangeError) mid-render. This is a defensive crash-guard only — the
+// oversized amount is rejected for the user with an explicit message by the
+// form's balance/max validation (getDepositCtaState), so we just bail here.
 const MAX_PLAUSIBLE_DEPOSIT_SATS = 2_100_000_000_000_000n;
 
 const EMPTY_RESULT: Omit<UseOptimalSplitResult, "isLoading" | "error"> = {
@@ -58,21 +59,9 @@ export function useOptimalSplit(
   const { params, isLoading, error } = useVaultSplitParams(connectedAddress);
   const { minDeposit } = useProtocolParamsContext();
 
-  const { result, amountError } = useMemo(() => {
-    // An oversized amount is invalid input, not a no-split: surface an explicit
-    // error instead of a zeroed result that downstream split planning can't
-    // distinguish from a normal empty/no-split state.
-    if (totalBtc > MAX_PLAUSIBLE_DEPOSIT_SATS) {
-      return {
-        result: EMPTY_RESULT,
-        amountError: new RangeError(
-          "Deposit amount exceeds the maximum supported value.",
-        ),
-      };
-    }
-
-    if (!params || totalBtc <= 0n) {
-      return { result: EMPTY_RESULT, amountError: null };
+  const result = useMemo(() => {
+    if (!params || totalBtc <= 0n || totalBtc > MAX_PLAUSIBLE_DEPOSIT_SATS) {
+      return EMPTY_RESULT;
     }
 
     const { THF, CF, LB } = params;
@@ -95,22 +84,17 @@ export function useOptimalSplit(
     const canSplit = minDepositForSplit > 0n && totalBtc >= minDepositForSplit;
 
     return {
-      result: {
-        sacrificialVault: split.sacrificialVault,
-        protectedVault: split.protectedVault,
-        seizedFraction: split.seizedFraction,
-        canSplit,
-        minDepositForSplit,
-      },
-      amountError: null,
+      sacrificialVault: split.sacrificialVault,
+      protectedVault: split.protectedVault,
+      seizedFraction: split.seizedFraction,
+      canSplit,
+      minDepositForSplit,
     };
   }, [params, totalBtc, minDeposit]);
 
   return {
     ...result,
     isLoading,
-    // Surface oversized-amount errors alongside param-fetch errors so an
-    // invalid amount isn't masked as a valid empty result.
-    error: error ?? amountError,
+    error,
   };
 }

--- a/services/vault/src/applications/aave/hooks/useOptimalSplit.ts
+++ b/services/vault/src/applications/aave/hooks/useOptimalSplit.ts
@@ -37,11 +37,8 @@ export interface UseOptimalSplitResult {
   error: Error | null;
 }
 
-// Bitcoin's fixed maximum supply in satoshis (21,000,000 BTC × 1e8). A larger
-// "amount" can't be a real deposit and would trip the SDK's assertSafePrecision
-// guard (RangeError) mid-render. This is a defensive crash-guard only — the
-// oversized amount is rejected for the user with an explicit message by the
-// form's balance/max validation (getDepositCtaState), so we just bail here.
+// Bitcoin's max supply in satoshis (21M BTC). Larger amounts would trip the
+// SDK's precision guard, so bail before computing the split.
 const MAX_PLAUSIBLE_DEPOSIT_SATS = 2_100_000_000_000_000n;
 
 const EMPTY_RESULT: Omit<UseOptimalSplitResult, "isLoading" | "error"> = {

--- a/services/vault/src/applications/aave/hooks/useOptimalSplit.ts
+++ b/services/vault/src/applications/aave/hooks/useOptimalSplit.ts
@@ -39,8 +39,8 @@ export interface UseOptimalSplitResult {
 
 // Bitcoin's fixed maximum supply in satoshis (21,000,000 BTC × 1e8). Any
 // amount above this is invalid input and would trip the SDK's
-// assertSafePrecision guard (RangeError). Bail to the empty result so the
-// form's amount validation can surface the error instead of crashing.
+// assertSafePrecision guard (RangeError). We reject it with an explicit error
+// rather than computing the split or returning a silent zero result.
 const MAX_PLAUSIBLE_DEPOSIT_SATS = 2_100_000_000_000_000n;
 
 const EMPTY_RESULT: Omit<UseOptimalSplitResult, "isLoading" | "error"> = {
@@ -58,9 +58,21 @@ export function useOptimalSplit(
   const { params, isLoading, error } = useVaultSplitParams(connectedAddress);
   const { minDeposit } = useProtocolParamsContext();
 
-  const result = useMemo(() => {
-    if (!params || totalBtc <= 0n || totalBtc > MAX_PLAUSIBLE_DEPOSIT_SATS) {
-      return EMPTY_RESULT;
+  const { result, amountError } = useMemo(() => {
+    // An oversized amount is invalid input, not a no-split: surface an explicit
+    // error instead of a zeroed result that downstream split planning can't
+    // distinguish from a normal empty/no-split state.
+    if (totalBtc > MAX_PLAUSIBLE_DEPOSIT_SATS) {
+      return {
+        result: EMPTY_RESULT,
+        amountError: new RangeError(
+          "Deposit amount exceeds the maximum supported value.",
+        ),
+      };
+    }
+
+    if (!params || totalBtc <= 0n) {
+      return { result: EMPTY_RESULT, amountError: null };
     }
 
     const { THF, CF, LB } = params;
@@ -83,17 +95,22 @@ export function useOptimalSplit(
     const canSplit = minDepositForSplit > 0n && totalBtc >= minDepositForSplit;
 
     return {
-      sacrificialVault: split.sacrificialVault,
-      protectedVault: split.protectedVault,
-      seizedFraction: split.seizedFraction,
-      canSplit,
-      minDepositForSplit,
+      result: {
+        sacrificialVault: split.sacrificialVault,
+        protectedVault: split.protectedVault,
+        seizedFraction: split.seizedFraction,
+        canSplit,
+        minDepositForSplit,
+      },
+      amountError: null,
     };
   }, [params, totalBtc, minDeposit]);
 
   return {
     ...result,
     isLoading,
-    error,
+    // Surface oversized-amount errors alongside param-fetch errors so an
+    // invalid amount isn't masked as a valid empty result.
+    error: error ?? amountError,
   };
 }

--- a/services/vault/src/components/pages/RootLayout.tsx
+++ b/services/vault/src/components/pages/RootLayout.tsx
@@ -18,7 +18,11 @@ import { twJoin } from "tailwind-merge";
 
 import { DepositButton } from "@/components/shared";
 import { PAGE_CONTENT_CLASS } from "@/components/shared/layoutClasses";
-import { getNetworkConfigBTC, shouldDisplayTestingMsg } from "@/config";
+import {
+  FeatureFlags,
+  getNetworkConfigBTC,
+  shouldDisplayTestingMsg,
+} from "@/config";
 import { useAddressScreening } from "@/context/addressScreening";
 import { useAddressType } from "@/context/addressType";
 import { useGeoFencing } from "@/context/geofencing";
@@ -28,6 +32,7 @@ import { AaveConfigProvider } from "../../applications/aave/context";
 import { useBTCWallet, useETHWallet } from "../../context/wallet";
 import { AddressScreeningBanner } from "../shared/AddressScreeningBanner";
 import { AddressTypeBanner } from "../shared/AddressTypeBanner";
+import { DepositDisabledBanner } from "../shared/DepositDisabledBanner";
 import { GeoBlockState } from "../shared/GeoBlockState";
 import SimpleDeposit from "../simple/SimpleDeposit";
 import { Connect } from "../Wallet";
@@ -118,6 +123,11 @@ export default function RootLayout() {
           visible={!isGeoBlocked && isWalletConnected && isAddressBlocked}
         />
         <AddressTypeBanner visible={!isGeoBlocked && showAddressTypeBanner} />
+        <DepositDisabledBanner
+          visible={
+            !isGeoBlocked && isWalletConnected && FeatureFlags.isDepositDisabled
+          }
+        />
         <Header
           size="md"
           // `!max-w-` overrides the `container` class's 2xl breakpoint max-width
@@ -149,6 +159,7 @@ export default function RootLayout() {
                   <DepositButton
                     variant="outlined"
                     rounded
+                    disabled={FeatureFlags.isDepositDisabled}
                     onClick={() => openDeposit()}
                   >
                     Deposit {btcConfig.coinSymbol}

--- a/services/vault/src/components/shared/DepositDisabledBanner.tsx
+++ b/services/vault/src/components/shared/DepositDisabledBanner.tsx
@@ -1,0 +1,19 @@
+import { Text } from "@babylonlabs-io/core-ui";
+
+import { COPY } from "@/copy";
+
+interface DepositDisabledBannerProps {
+  visible: boolean;
+}
+
+export function DepositDisabledBanner({ visible }: DepositDisabledBannerProps) {
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-row items-center justify-center gap-2 bg-secondary-main px-4 py-3 text-center text-accent-contrast">
+      <Text variant="body2">{COPY.deposit.disabled.bannerMessage}</Text>
+    </div>
+  );
+}

--- a/services/vault/src/components/simple/CollateralSection.tsx
+++ b/services/vault/src/components/simple/CollateralSection.tsx
@@ -6,6 +6,7 @@
 import { Avatar, Button, Card } from "@babylonlabs-io/core-ui";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useMemo, useState } from "react";
+import { twJoin } from "tailwind-merge";
 import { isHex, type Address, type Hex } from "viem";
 import { useAccount } from "wagmi";
 
@@ -273,11 +274,10 @@ export function CollateralSection({
               url={btcConfig.icon}
               alt={btcConfig.coinSymbol}
               size="xlarge"
-              className={
-                FeatureFlags.isDepositDisabled
-                  ? "mb-4 h-[100px] w-[100px] grayscale"
-                  : "mb-4 h-[100px] w-[100px]"
-              }
+              className={twJoin(
+                "mb-4 h-[100px] w-[100px]",
+                FeatureFlags.isDepositDisabled && "grayscale",
+              )}
             />
             <p className="text-[20px] text-accent-primary">
               {FeatureFlags.isDepositDisabled

--- a/services/vault/src/components/simple/CollateralSection.tsx
+++ b/services/vault/src/components/simple/CollateralSection.tsx
@@ -27,7 +27,7 @@ import {
   CARD_DARK_BG_CLASS,
   SUMMARY_CARD_CLASS,
 } from "@/components/shared/layoutClasses";
-import { getNetworkConfigBTC } from "@/config";
+import { FeatureFlags, getNetworkConfigBTC } from "@/config";
 import { COPY } from "@/copy";
 import { useVaultProviders } from "@/hooks/deposit/useVaultProviders";
 import { logger } from "@/infrastructure";
@@ -219,7 +219,7 @@ export function CollateralSection({
             variant="outlined"
             size="large"
             onClick={() => onDeposit()}
-            disabled={!isConnected}
+            disabled={!isConnected || FeatureFlags.isDepositDisabled}
             className="rounded-full"
           >
             Deposit
@@ -273,13 +273,21 @@ export function CollateralSection({
               url={btcConfig.icon}
               alt={btcConfig.coinSymbol}
               size="xlarge"
-              className="mb-4 h-[100px] w-[100px]"
+              className={
+                FeatureFlags.isDepositDisabled
+                  ? "mb-4 h-[100px] w-[100px] grayscale"
+                  : "mb-4 h-[100px] w-[100px]"
+              }
             />
             <p className="text-[20px] text-accent-primary">
-              {COPY.collateral.empty.title}
+              {FeatureFlags.isDepositDisabled
+                ? COPY.deposit.disabled.title
+                : COPY.collateral.empty.title}
             </p>
             <p className="text-[16px] text-accent-secondary">
-              {COPY.collateral.empty.body(btcConfig.coinSymbol)}
+              {FeatureFlags.isDepositDisabled
+                ? COPY.deposit.disabled.description
+                : COPY.collateral.empty.body(btcConfig.coinSymbol)}
             </p>
           </div>
         </Card>

--- a/services/vault/src/components/simple/DepositForm.tsx
+++ b/services/vault/src/components/simple/DepositForm.tsx
@@ -103,6 +103,7 @@ interface DepositFormProps {
    * state. Null while the query is healthy.
    */
   depositorClaimValueError: Error | null;
+  isDepositDisabled: boolean;
   isGeoBlocked: boolean;
   isAddressBlocked: boolean;
   onDeposit: () => void;
@@ -183,6 +184,7 @@ export function DepositForm({
   depositorClaimValue,
   commissionHtlcValues,
   depositorClaimValueError,
+  isDepositDisabled,
   isGeoBlocked,
   isAddressBlocked,
   onDeposit,
@@ -301,6 +303,7 @@ export function DepositForm({
     btcBalance,
     estimatedFeeSats: estimatedFeeSats ?? undefined,
     depositorClaimValue,
+    isDepositDisabled,
     isGeoBlocked,
     isAddressBlocked,
     isWalletConnected,

--- a/services/vault/src/components/simple/DepositForm.tsx
+++ b/services/vault/src/components/simple/DepositForm.tsx
@@ -103,7 +103,6 @@ interface DepositFormProps {
    * state. Null while the query is healthy.
    */
   depositorClaimValueError: Error | null;
-  isDepositDisabled: boolean;
   isGeoBlocked: boolean;
   isAddressBlocked: boolean;
   onDeposit: () => void;
@@ -184,7 +183,6 @@ export function DepositForm({
   depositorClaimValue,
   commissionHtlcValues,
   depositorClaimValueError,
-  isDepositDisabled,
   isGeoBlocked,
   isAddressBlocked,
   onDeposit,
@@ -303,7 +301,6 @@ export function DepositForm({
     btcBalance,
     estimatedFeeSats: estimatedFeeSats ?? undefined,
     depositorClaimValue,
-    isDepositDisabled,
     isGeoBlocked,
     isAddressBlocked,
     isWalletConnected,

--- a/services/vault/src/components/simple/SimpleDeposit.tsx
+++ b/services/vault/src/components/simple/SimpleDeposit.tsx
@@ -283,6 +283,11 @@ function SimpleDepositContent({
   };
 
   const handleDeposit = async () => {
+    // Kill-switch guard on the submit path: blocks the deposit flow even if a
+    // deposit entry point that bypasses the disabled buttons (e.g. the Activity
+    // empty-state CTA or the urgent Add Collateral banner) opens this dialog.
+    if (FeatureFlags.isDepositDisabled) return;
+
     // The CTA doubles as the recovery action when the wallet-liveness probe
     // has failed: clicking it re-runs the underlying provider's connect flow
     // (which triggers the wallet's unlock/re-authorization prompt) instead of
@@ -399,6 +404,7 @@ function SimpleDepositContent({
                 estimatedFeeRate={estimatedFeeRate}
                 isLoadingFee={isLoadingFee}
                 feeError={feeError}
+                isDepositDisabled={FeatureFlags.isDepositDisabled}
                 isGeoBlocked={isGeoBlocked || isGeoLoading}
                 isAddressBlocked={isAddressBlocked || isScreeningLoading}
                 onDeposit={handleDeposit}

--- a/services/vault/src/components/simple/SimpleDeposit.tsx
+++ b/services/vault/src/components/simple/SimpleDeposit.tsx
@@ -399,7 +399,6 @@ function SimpleDepositContent({
                 estimatedFeeRate={estimatedFeeRate}
                 isLoadingFee={isLoadingFee}
                 feeError={feeError}
-                isDepositDisabled={FeatureFlags.isDepositDisabled}
                 isGeoBlocked={isGeoBlocked || isGeoLoading}
                 isAddressBlocked={isAddressBlocked || isScreeningLoading}
                 onDeposit={handleDeposit}

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -167,6 +167,12 @@ export const COPY = {
     },
   },
   deposit: {
+    disabled: {
+      title: "Deposits temporarily unavailable",
+      description: "Deposits are currently disabled. Please try again later.",
+      bannerMessage:
+        "Deposits are currently disabled while we address an issue.",
+    },
     steps: {
       generateSecret: "Generate secret for the deposit",
       signPeginBtc: "Sign the peg-in BTC transaction",

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -171,7 +171,7 @@ export const COPY = {
       title: "Deposits temporarily unavailable",
       description: "Deposits are currently disabled. Please try again later.",
       bannerMessage:
-        "Deposits are currently disabled while we address an issue.",
+        "New deposits are paused for maintenance and will resume shortly.",
     },
     steps: {
       generateSecret: "Generate secret for the deposit",

--- a/services/vault/src/services/deposit/__tests__/validations.test.ts
+++ b/services/vault/src/services/deposit/__tests__/validations.test.ts
@@ -284,7 +284,6 @@ describe("Deposit Validations", () => {
       btcBalance: 1000000n,
       estimatedFeeSats: 1000n,
       depositorClaimValue: 5000n,
-      isDepositDisabled: false,
       isGeoBlocked: false,
       isAddressBlocked: false,
       isWalletConnected: true,
@@ -307,17 +306,6 @@ describe("Deposit Validations", () => {
     it("returns enabled 'Deposit' when all conditions are met", () => {
       const result = getDepositCtaState(readyParams);
       expect(result).toEqual({ disabled: false, label: "Deposit" });
-    });
-
-    it("returns 'Depositing Unavailable' when deposits are disabled", () => {
-      const result = getDepositCtaState({
-        ...readyParams,
-        isDepositDisabled: true,
-      });
-      expect(result).toEqual({
-        disabled: true,
-        label: "Depositing Unavailable",
-      });
     });
 
     it("returns geo-blocked message when geo-blocked", () => {
@@ -496,15 +484,6 @@ describe("Deposit Validations", () => {
         disabled: true,
         label: "Insufficient balance",
       });
-    });
-
-    it("prioritizes deposit-disabled over geo-blocked", () => {
-      const result = getDepositCtaState({
-        ...readyParams,
-        isDepositDisabled: true,
-        isGeoBlocked: true,
-      });
-      expect(result.label).toBe("Depositing Unavailable");
     });
 
     it("prioritizes geo-blocked over wallet-not-connected", () => {

--- a/services/vault/src/services/deposit/__tests__/validations.test.ts
+++ b/services/vault/src/services/deposit/__tests__/validations.test.ts
@@ -284,6 +284,7 @@ describe("Deposit Validations", () => {
       btcBalance: 1000000n,
       estimatedFeeSats: 1000n,
       depositorClaimValue: 5000n,
+      isDepositDisabled: false,
       isGeoBlocked: false,
       isAddressBlocked: false,
       isWalletConnected: true,
@@ -306,6 +307,26 @@ describe("Deposit Validations", () => {
     it("returns enabled 'Deposit' when all conditions are met", () => {
       const result = getDepositCtaState(readyParams);
       expect(result).toEqual({ disabled: false, label: "Deposit" });
+    });
+
+    it("returns disabled 'Deposits unavailable' when deposits are disabled", () => {
+      const result = getDepositCtaState({
+        ...readyParams,
+        isDepositDisabled: true,
+      });
+      expect(result).toEqual({
+        disabled: true,
+        label: "Deposits unavailable",
+      });
+    });
+
+    it("prioritizes deposit-disabled over geo-blocked", () => {
+      const result = getDepositCtaState({
+        ...readyParams,
+        isDepositDisabled: true,
+        isGeoBlocked: true,
+      });
+      expect(result.label).toBe("Deposits unavailable");
     });
 
     it("returns geo-blocked message when geo-blocked", () => {

--- a/services/vault/src/services/deposit/validations.ts
+++ b/services/vault/src/services/deposit/validations.ts
@@ -95,7 +95,6 @@ export function validateMultiVaultDepositInputs(
 // ---------------------------------------------------------------------------
 
 export interface DepositCtaParams extends DepositFormValidityParams {
-  isDepositDisabled: boolean;
   isGeoBlocked: boolean;
   isAddressBlocked: boolean;
   isWalletConnected: boolean;
@@ -267,10 +266,6 @@ export function getDepositButtonLabel(
 }
 
 export function getDepositCtaState(params: DepositCtaParams): DepositCtaState {
-  if (params.isDepositDisabled) {
-    return { disabled: true, label: "Depositing Unavailable" };
-  }
-
   if (params.isGeoBlocked) {
     return { disabled: true, label: "Service unavailable in your region" };
   }

--- a/services/vault/src/services/deposit/validations.ts
+++ b/services/vault/src/services/deposit/validations.ts
@@ -95,6 +95,8 @@ export function validateMultiVaultDepositInputs(
 // ---------------------------------------------------------------------------
 
 export interface DepositCtaParams extends DepositFormValidityParams {
+  /** DISABLE_DEPOSIT kill-switch — blocks the CTA at every deposit entry point. */
+  isDepositDisabled: boolean;
   isGeoBlocked: boolean;
   isAddressBlocked: boolean;
   isWalletConnected: boolean;
@@ -266,6 +268,10 @@ export function getDepositButtonLabel(
 }
 
 export function getDepositCtaState(params: DepositCtaParams): DepositCtaState {
+  if (params.isDepositDisabled) {
+    return { disabled: true, label: "Deposits unavailable" };
+  }
+
   if (params.isGeoBlocked) {
     return { disabled: true, label: "Service unavailable in your region" };
   }


### PR DESCRIPTION
Behind the DISABLE_DEPOSIT flag, replace the bare "Depositing Unavailable" CTA with an in-page disabled experience: an orange top banner, disabled Deposit buttons (header and Collateral section), and a grayed-out BTC logo empty state with explanatory copy.

## Screenshot
<img width="1105" height="469" alt="Screenshot 2026-06-22 at 19 39 26" src="https://github.com/user-attachments/assets/71314156-c7ee-4d71-b2e9-7a496a5dc140" />

<img width="1450" height="698" alt="Screenshot 2026-06-22 at 19 39 33" src="https://github.com/user-attachments/assets/22d44e63-c6b3-464d-bc4c-8fcaf5169e6d" />
