### PR TITLE
fix(vault): restore footer horizontal padding to align with page chrome

### DIFF
--- a/services/vault/src/components/pages/RootLayout.tsx
+++ b/services/vault/src/components/pages/RootLayout.tsx
@@ -209,13 +209,17 @@ export default function RootLayout() {
           {/* `[&>div]:!max-w-[1400px]` caps the Footer's inner Container at
               1400px, overriding the `container` class's 1536px max-width at
               the 2xl breakpoint so the footer aligns with the navbar.
+              `[&>div]:!px-5` restores the 20px horizontal inset that core-ui's
+              Container drops at the `sm` breakpoint (`sm:px-0`), matching the
+              navbar/page `PAGE_CONTENT_CLASS` padding so the footer content
+              lines up with the rest of the page chrome.
               `!bg-secondary-main` + `before:!bg-secondary-main` swap the light-
               mode background (and its decorative top-edge pseudo) from the
               default teal to brand orange; dark mode keeps `primary-main`. */}
           <Footer
             socialLinks={DEFAULT_SOCIAL_LINKS}
             copyrightYear={new Date().getFullYear()}
-            className="!bg-secondary-main before:!bg-secondary-main dark:!bg-primary-main dark:before:!bg-primary-main [&>div]:!max-w-[1400px]"
+            className="!bg-secondary-main before:!bg-secondary-main dark:!bg-primary-main dark:before:!bg-primary-main [&>div]:!max-w-[1400px] [&>div]:!px-5"
           />
         </div>
       </div>


### PR DESCRIPTION
The footer's inner Container was capped at max-w-[1400px] to match the navbar but kept core-ui Container's default px-4 sm:px-0, dropping its horizontal inset at the sm breakpoint. 

