### PR TITLE
feat(vault): show optimistic activating collateral

### DIFF
--- a/services/vault/src/applications/aave/context/ActivatingVaultsContext.tsx
+++ b/services/vault/src/applications/aave/context/ActivatingVaultsContext.tsx
@@ -39,6 +39,13 @@ const ACTIVATING_OVERRIDE_TIMEOUT_MS = 90 * 1000;
 export interface ActivatingVaultEntry {
   /** Derived vault ID: keccak256(abi.encode(peginTxHash, depositor)). */
   vaultId: Hex;
+  /**
+   * Depositor's ETH address the activation was made from. The dashboard only
+   * surfaces an entry whose address matches the currently connected wallet, so
+   * switching accounts during the optimistic window can't leak one account's
+   * activating vault onto another's dashboard.
+   */
+  depositorEthAddress?: string;
   /** Optimistic BTC amount, replaced by the indexer value on reconciliation. */
   amountBtc: number;
   /** Vault provider Ethereum address (for resolving name/icon in display). */

--- a/services/vault/src/applications/aave/context/ActivatingVaultsContext.tsx
+++ b/services/vault/src/applications/aave/context/ActivatingVaultsContext.tsx
@@ -1,0 +1,148 @@
+/**
+ * Activating Vaults Context
+ *
+ * Holds, in memory only, the vault(s) the user just activated (the activation
+ * ETH tx has confirmed) but which the Aave indexer has not yet ingested as
+ * collateral. The dashboard merges these into the collateral list as
+ * "Activating…" rows so the user sees their vault immediately, instead of an
+ * empty section (or a missing row) during the ~15s indexer gap.
+ *
+ * Deliberately NOT persisted (no localStorage): it is best-effort immediate
+ * feedback, mirroring ReorderOverrideContext. A page refresh mid-gap drops it
+ * and the dashboard falls back to indexer data. Each entry is cleared once the
+ * indexer reflects the vault (see useDashboardState) or, as a backstop, after
+ * ACTIVATING_OVERRIDE_TIMEOUT_MS.
+ */
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import type { Hex } from "viem";
+
+/**
+ * How long an in-memory activating-vault entry is held before it is
+ * auto-cleared, as a backstop in case the indexer never reflects the
+ * activation (e.g. a concurrent position change). Until then the dashboard
+ * shows the "Activating…" row; reconciliation normally clears it sooner, once
+ * the indexer catches up. 90s ≈ 3 × the 30s position poll.
+ */
+const ACTIVATING_OVERRIDE_TIMEOUT_MS = 90 * 1000;
+
+/** A just-activated vault awaiting indexer ingestion. */
+export interface ActivatingVaultEntry {
+  /** Derived vault ID: keccak256(abi.encode(peginTxHash, depositor)). */
+  vaultId: Hex;
+  /** Optimistic BTC amount, replaced by the indexer value on reconciliation. */
+  amountBtc: number;
+  /** Vault provider Ethereum address (for resolving name/icon in display). */
+  providerAddress?: string;
+}
+
+interface ActivatingVaultsContextValue {
+  /** Map of lowercased vaultId → activating entry awaiting the indexer. */
+  activatingVaults: Map<string, ActivatingVaultEntry>;
+  /** Record a just-activated vault and (re)arm its auto-clear backstop. */
+  addActivatingVault: (entry: ActivatingVaultEntry) => void;
+  /** Clear one entry (called when the indexer reconciles, or on the backstop). */
+  clearActivatingVault: (vaultId: string) => void;
+}
+
+const ActivatingVaultsContext =
+  createContext<ActivatingVaultsContextValue | null>(null);
+
+export function ActivatingVaultsProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const [activatingVaults, setActivatingVaults] = useState<
+    Map<string, ActivatingVaultEntry>
+  >(new Map());
+  const timersRef = useRef(new Map<string, ReturnType<typeof setTimeout>>());
+
+  const clearTimer = useCallback((key: string) => {
+    const timer = timersRef.current.get(key);
+    if (timer) {
+      clearTimeout(timer);
+      timersRef.current.delete(key);
+    }
+  }, []);
+
+  const clearActivatingVault = useCallback(
+    (vaultId: string) => {
+      const key = vaultId.toLowerCase();
+      clearTimer(key);
+      setActivatingVaults((prev) => {
+        if (!prev.has(key)) return prev;
+        const next = new Map(prev);
+        next.delete(key);
+        return next;
+      });
+    },
+    [clearTimer],
+  );
+
+  const addActivatingVault = useCallback(
+    (entry: ActivatingVaultEntry) => {
+      const key = entry.vaultId.toLowerCase();
+      clearTimer(key);
+      setActivatingVaults((prev) => {
+        const next = new Map(prev);
+        next.set(key, entry);
+        return next;
+      });
+      const timer = setTimeout(() => {
+        timersRef.current.delete(key);
+        setActivatingVaults((prev) => {
+          if (!prev.has(key)) return prev;
+          const next = new Map(prev);
+          next.delete(key);
+          return next;
+        });
+      }, ACTIVATING_OVERRIDE_TIMEOUT_MS);
+      timersRef.current.set(key, timer);
+    },
+    [clearTimer],
+  );
+
+  // Clean up any pending timers if the provider unmounts mid-window.
+  useEffect(() => {
+    const timers = timersRef.current;
+    return () => {
+      timers.forEach((timer) => clearTimeout(timer));
+      timers.clear();
+    };
+  }, []);
+
+  const value = useMemo(
+    () => ({ activatingVaults, addActivatingVault, clearActivatingVault }),
+    [activatingVaults, addActivatingVault, clearActivatingVault],
+  );
+
+  return (
+    <ActivatingVaultsContext.Provider value={value}>
+      {children}
+    </ActivatingVaultsContext.Provider>
+  );
+}
+
+/**
+ * Access the activating-vaults context. Must be used within an
+ * ActivatingVaultsProvider.
+ */
+export function useActivatingVaults(): ActivatingVaultsContextValue {
+  const ctx = useContext(ActivatingVaultsContext);
+  if (!ctx) {
+    throw new Error(
+      "useActivatingVaults must be used within an ActivatingVaultsProvider",
+    );
+  }
+  return ctx;
+}

--- a/services/vault/src/applications/aave/context/__tests__/ActivatingVaultsContext.test.tsx
+++ b/services/vault/src/applications/aave/context/__tests__/ActivatingVaultsContext.test.tsx
@@ -1,0 +1,102 @@
+import { act, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  ActivatingVaultsProvider,
+  useActivatingVaults,
+} from "../ActivatingVaultsContext";
+
+const VAULT_A = ("0x" + "a".repeat(64)) as `0x${string}`;
+const VAULT_B = ("0x" + "b".repeat(64)) as `0x${string}`;
+// The provider auto-clears each entry after 90s (its internal backstop).
+const OVERRIDE_TIMEOUT_MS = 90 * 1000;
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <ActivatingVaultsProvider>{children}</ActivatingVaultsProvider>;
+}
+
+describe("ActivatingVaultsContext", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("starts with no activating vaults", () => {
+    const { result } = renderHook(() => useActivatingVaults(), { wrapper });
+    expect(result.current.activatingVaults.size).toBe(0);
+  });
+
+  it("addActivatingVault records an entry keyed by lowercased vaultId", () => {
+    const { result } = renderHook(() => useActivatingVaults(), { wrapper });
+    act(() =>
+      result.current.addActivatingVault({ vaultId: VAULT_A, amountBtc: 1 }),
+    );
+    expect(result.current.activatingVaults.get(VAULT_A.toLowerCase())).toEqual({
+      vaultId: VAULT_A,
+      amountBtc: 1,
+    });
+  });
+
+  it("clearActivatingVault removes a single entry (case-insensitive)", () => {
+    const { result } = renderHook(() => useActivatingVaults(), { wrapper });
+    act(() => {
+      result.current.addActivatingVault({ vaultId: VAULT_A, amountBtc: 1 });
+      result.current.addActivatingVault({ vaultId: VAULT_B, amountBtc: 2 });
+    });
+    act(() => result.current.clearActivatingVault(VAULT_A.toUpperCase()));
+    expect(result.current.activatingVaults.has(VAULT_A.toLowerCase())).toBe(
+      false,
+    );
+    expect(result.current.activatingVaults.has(VAULT_B.toLowerCase())).toBe(
+      true,
+    );
+  });
+
+  it("auto-clears an entry after the backstop timeout", () => {
+    const { result } = renderHook(() => useActivatingVaults(), { wrapper });
+    act(() =>
+      result.current.addActivatingVault({ vaultId: VAULT_A, amountBtc: 1 }),
+    );
+
+    act(() => vi.advanceTimersByTime(OVERRIDE_TIMEOUT_MS - 1));
+    expect(result.current.activatingVaults.size).toBe(1);
+
+    act(() => vi.advanceTimersByTime(1));
+    expect(result.current.activatingVaults.size).toBe(0);
+  });
+
+  it("throws when used outside the provider", () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    expect(() => renderHook(() => useActivatingVaults())).toThrow(
+      /within an ActivatingVaultsProvider/,
+    );
+    consoleError.mockRestore();
+  });
+
+  it("shares state across consumers under one provider (writer → reader boundary)", () => {
+    // Guards the provider-boundary wiring: a writer (addActivatingVault) and a
+    // separate reader must see the same state when both sit under a single
+    // ActivatingVaultsProvider — the bug class this provider placement avoids.
+    const { result } = renderHook(
+      () => ({ writer: useActivatingVaults(), reader: useActivatingVaults() }),
+      { wrapper },
+    );
+
+    act(() =>
+      result.current.writer.addActivatingVault({
+        vaultId: VAULT_A,
+        amountBtc: 3,
+      }),
+    );
+
+    expect(
+      result.current.reader.activatingVaults.get(VAULT_A.toLowerCase()),
+    ).toEqual({ vaultId: VAULT_A, amountBtc: 3 });
+  });
+});

--- a/services/vault/src/applications/aave/context/index.ts
+++ b/services/vault/src/applications/aave/context/index.ts
@@ -1,5 +1,10 @@
 export { AaveConfigProvider, useAaveConfig } from "./AaveConfigContext";
 export {
+  ActivatingVaultsProvider,
+  useActivatingVaults,
+  type ActivatingVaultEntry,
+} from "./ActivatingVaultsContext";
+export {
   PendingVaultsProvider,
   usePendingVaults,
   useSyncPendingVaults,

--- a/services/vault/src/components/pages/RootLayout.tsx
+++ b/services/vault/src/components/pages/RootLayout.tsx
@@ -28,7 +28,10 @@ import { useAddressType } from "@/context/addressType";
 import { useGeoFencing } from "@/context/geofencing";
 import { COPY } from "@/copy";
 
-import { AaveConfigProvider } from "../../applications/aave/context";
+import {
+  AaveConfigProvider,
+  ActivatingVaultsProvider,
+} from "../../applications/aave/context";
 import { useBTCWallet, useETHWallet } from "../../context/wallet";
 import { AddressScreeningBanner } from "../shared/AddressScreeningBanner";
 import { AddressTypeBanner } from "../shared/AddressTypeBanner";
@@ -178,7 +181,7 @@ export default function RootLayout() {
         ) : isGeoBlocked ? (
           <GeoBlockState />
         ) : (
-          <>
+          <ActivatingVaultsProvider>
             <Outlet
               context={
                 {
@@ -214,7 +217,7 @@ export default function RootLayout() {
                 initialAmountBtc={initialDepositAmountBtc}
               />
             </AaveConfigProvider>
-          </>
+          </ActivatingVaultsProvider>
         )}
         <div className="mt-auto">
           {/* `[&>div]:!max-w-[1400px]` caps the Footer's inner Container at

--- a/services/vault/src/components/simple/CollateralExpandedContent.tsx
+++ b/services/vault/src/components/simple/CollateralExpandedContent.tsx
@@ -52,6 +52,7 @@ export function CollateralExpandedContent({
               vaultId={vault.vaultId}
               amountBtc={vault.amountBtc}
               inUse={vault.inUse}
+              isActivating={vault.isActivating}
               providerName={vault.providerName}
               providerIconUrl={vault.providerIconUrl}
               providerAddress={vault.providerAddress}

--- a/services/vault/src/components/simple/CollateralSection.tsx
+++ b/services/vault/src/components/simple/CollateralSection.tsx
@@ -144,10 +144,15 @@ export function CollateralSection({
   }, [hasWithdrawableVault, wouldBreachHF, effectiveSelectedVaultIds.length]);
 
   // Optimistic "activating" rows have no indexed liquidation order yet and
-  // can't participate in a reorder, so they don't count toward the threshold.
+  // aren't on-chain collateral, so they must not enter the reorder path (gate,
+  // gas estimate, or the signed permutation). This single derived list drives
+  // both the gate and the modal data so the two can't drift apart.
   const hasActivatingVault = collateralVaults.some((v) => v.isActivating);
-  const canReorder =
-    collateralVaults.filter((v) => !v.isActivating).length >= 2;
+  const reorderableVaults = useMemo(
+    () => collateralVaults.filter((v) => !v.isActivating),
+    [collateralVaults],
+  );
+  const canReorder = reorderableVaults.length >= 2;
 
   const handleToggleVaultSelect = useCallback(
     (vaultId: string) => {
@@ -323,7 +328,7 @@ export function CollateralSection({
       <ReorderVaultsModal
         isOpen={isReorderOpen}
         onClose={() => setIsReorderOpen(false)}
-        vaults={collateralVaults}
+        vaults={reorderableVaults}
         onSuccess={() => setIsReorderSuccess(true)}
       />
 

--- a/services/vault/src/components/simple/CollateralSection.tsx
+++ b/services/vault/src/components/simple/CollateralSection.tsx
@@ -3,7 +3,7 @@
  * Displays collateral with an expandable view showing individual peg-in vaults.
  */
 
-import { Avatar, Button, Card, Heading } from "@babylonlabs-io/core-ui";
+import { Avatar, Button, Card, Heading, Loader } from "@babylonlabs-io/core-ui";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useMemo, useState } from "react";
 import { twJoin } from "tailwind-merge";
@@ -143,7 +143,11 @@ export function CollateralSection({
     return undefined;
   }, [hasWithdrawableVault, wouldBreachHF, effectiveSelectedVaultIds.length]);
 
-  const canReorder = collateralVaults.length >= 2;
+  // Optimistic "activating" rows have no indexed liquidation order yet and
+  // can't participate in a reorder, so they don't count toward the threshold.
+  const hasActivatingVault = collateralVaults.some((v) => v.isActivating);
+  const canReorder =
+    collateralVaults.filter((v) => !v.isActivating).length >= 2;
 
   const handleToggleVaultSelect = useCallback(
     (vaultId: string) => {
@@ -239,9 +243,21 @@ export function CollateralSection({
                 alt={btcConfig.coinSymbol}
                 size="medium"
               />
-              <span className="text-xl text-accent-primary">
-                {totalAmountBtc}
-              </span>
+              <div className="flex flex-col">
+                <div className="flex items-center gap-2">
+                  <span className="text-xl text-accent-primary">
+                    {totalAmountBtc}
+                  </span>
+                  {hasActivatingVault && (
+                    <Loader size={16} className="text-accent-secondary" />
+                  )}
+                </div>
+                {hasActivatingVault && (
+                  <span className="text-sm text-accent-secondary">
+                    {COPY.collateral.activating}
+                  </span>
+                )}
+              </div>
             </div>
             <ExpandMenuButton
               isExpanded={isExpanded}

--- a/services/vault/src/components/simple/CollateralVaultItem.tsx
+++ b/services/vault/src/components/simple/CollateralVaultItem.tsx
@@ -116,29 +116,36 @@ export function CollateralVaultItem({
         />
       )}
 
-      {/* Vault Provider row */}
-      <VaultCardRow label="Vault provider">
-        <span className="inline-flex items-center gap-1.5">
-          <Hint
-            tooltip={truncateAddress(providerAddress)}
-            attachToChildren
-            placement="left"
-            className="text-sm text-accent-primary"
-          >
-            <span className="inline-flex items-center gap-1.5">
-              {providerIconUrl && (
-                <Avatar url={providerIconUrl} alt={providerName} size="tiny" />
-              )}
-              {providerName}
-            </span>
-          </Hint>
-          <ExplorerLink
-            href={getVpExplorerProviderUrl(providerAddress)}
-            label={COPY.explorer.providerLinkLabel}
-            size={14}
-          />
-        </span>
-      </VaultCardRow>
+      {/* Vault Provider row — hidden while activating: indexed provider
+          metadata may be incomplete on the transient row. */}
+      {!isActivating && (
+        <VaultCardRow label="Vault provider">
+          <span className="inline-flex items-center gap-1.5">
+            <Hint
+              tooltip={truncateAddress(providerAddress)}
+              attachToChildren
+              placement="left"
+              className="text-sm text-accent-primary"
+            >
+              <span className="inline-flex items-center gap-1.5">
+                {providerIconUrl && (
+                  <Avatar
+                    url={providerIconUrl}
+                    alt={providerName}
+                    size="tiny"
+                  />
+                )}
+                {providerName}
+              </span>
+            </Hint>
+            <ExplorerLink
+              href={getVpExplorerProviderUrl(providerAddress)}
+              label={COPY.explorer.providerLinkLabel}
+              size={14}
+            />
+          </span>
+        </VaultCardRow>
+      )}
 
       {/* Status row */}
       <VaultCardRow label="Status">

--- a/services/vault/src/components/simple/CollateralVaultItem.tsx
+++ b/services/vault/src/components/simple/CollateralVaultItem.tsx
@@ -8,6 +8,7 @@ import {
   Button,
   Checkbox,
   Hint,
+  Loader,
   StatusBadge,
 } from "@babylonlabs-io/core-ui";
 
@@ -30,6 +31,12 @@ interface CollateralVaultItemProps {
   vaultId: string;
   amountBtc: number;
   inUse: boolean;
+  /**
+   * Optimistic row shown right after the activation ETH tx, before the indexer
+   * ingests the vault. Suppresses every action/field that needs indexed
+   * metadata and shows an "Activating collateral…" status instead.
+   */
+  isActivating?: boolean;
   providerName: string;
   providerIconUrl?: string;
   /** Vault provider Ethereum address, shown on hover over the provider label */
@@ -49,6 +56,7 @@ export function CollateralVaultItem({
   vaultId,
   amountBtc,
   inUse,
+  isActivating = false,
   providerName,
   providerIconUrl,
   providerAddress,
@@ -60,7 +68,7 @@ export function CollateralVaultItem({
   onToggleSelect,
   onArtifactDownload,
 }: CollateralVaultItemProps) {
-  const canInteract = selectable || selected;
+  const canInteract = (selectable || selected) && !isActivating;
   const handleToggle = () => {
     if (canInteract) onToggleSelect(vaultId);
   };
@@ -78,10 +86,13 @@ export function CollateralVaultItem({
           <span className="text-xl font-medium text-accent-primary">
             {formatBtcAmount(amountBtc)}
           </span>
-          <ExplorerLink
-            href={getVpExplorerVaultUrl(vaultId)}
-            label={COPY.explorer.vaultLinkLabel}
-          />
+          {/* The vault explorer may 404 until the indexer ingests it. */}
+          {!isActivating && (
+            <ExplorerLink
+              href={getVpExplorerVaultUrl(vaultId)}
+              label={COPY.explorer.vaultLinkLabel}
+            />
+          )}
         </div>
         <div onClick={(e: React.MouseEvent) => e.stopPropagation()}>
           <Checkbox
@@ -95,12 +106,15 @@ export function CollateralVaultItem({
       </div>
 
       {/* Transaction hash row — Pegin + Pre-Pegin. The vault is active here, so
-          both txs are on Bitcoin and link to the explorer. */}
-      <PeginTxHashRow
-        peginTxHash={peginTxHash}
-        prePeginTxHash={prePeginTxHash}
-        linkPegin
-      />
+          both txs are on Bitcoin and link to the explorer. Hidden while
+          activating: the indexed tx hashes aren't available yet. */}
+      {!isActivating && (
+        <PeginTxHashRow
+          peginTxHash={peginTxHash}
+          prePeginTxHash={prePeginTxHash}
+          linkPegin
+        />
+      )}
 
       {/* Vault Provider row */}
       <VaultCardRow label="Vault provider">
@@ -128,14 +142,23 @@ export function CollateralVaultItem({
 
       {/* Status row */}
       <VaultCardRow label="Status">
-        <StatusBadge
-          status={inUse ? "active" : "inactive"}
-          label={inUse ? COPY.pegin.labels.IN_USE : COPY.pegin.labels.AVAILABLE}
-        />
+        {isActivating ? (
+          <span className="inline-flex items-center gap-1.5 text-sm text-accent-secondary">
+            <Loader size={16} className="text-accent-secondary" />
+            {COPY.collateral.activating}
+          </span>
+        ) : (
+          <StatusBadge
+            status={inUse ? "active" : "inactive"}
+            label={
+              inUse ? COPY.pegin.labels.IN_USE : COPY.pegin.labels.AVAILABLE
+            }
+          />
+        )}
       </VaultCardRow>
 
-      {/* Liquidation Order row */}
-      {liquidationIndex !== undefined && (
+      {/* Liquidation Order row — hidden while activating (no indexed order). */}
+      {!isActivating && liquidationIndex !== undefined && (
         <VaultCardRow label="Liquidation Order">
           <span className="text-sm text-accent-primary">
             {formatOrdinal(liquidationIndex + 1)}
@@ -143,7 +166,7 @@ export function CollateralVaultItem({
         </VaultCardRow>
       )}
 
-      {onArtifactDownload && (
+      {!isActivating && onArtifactDownload && (
         <Button
           variant="outlined"
           color="secondary"

--- a/services/vault/src/components/simple/DashboardPage.tsx
+++ b/services/vault/src/components/simple/DashboardPage.tsx
@@ -63,6 +63,7 @@ export function DashboardPage() {
   );
   const {
     collateralBtc,
+    displayCollateralBtc,
     collateralValueUsd,
     debtValueUsd,
     healthFactor,
@@ -70,6 +71,7 @@ export function DashboardPage() {
     borrowedAssets,
     hasLoans,
     hasCollateral,
+    hasDisplayCollateral,
     collateralVaults,
     selectableBorrowedAssets,
   } = useDashboardState(isConnected ? address : undefined);
@@ -104,7 +106,9 @@ export function DashboardPage() {
   // Format display values
   const totalCollateralValue = formatUsdValue(collateralValueUsd);
   const totalBorrowed = formatUsdValue(debtValueUsd);
-  const totalAmountBtc = formatBtcAmount(collateralBtc);
+  // Display total includes optimistic "activating" vaults; the financial
+  // `collateralBtc` (passed separately for the position snapshot) stays pure.
+  const totalAmountBtc = formatBtcAmount(displayCollateralBtc);
 
   // Liquidation-risk gauge stats. Liquidation price and distance-to-liquidation
   // come from the first group of the position cascade (the price at which the
@@ -210,7 +214,7 @@ export function DashboardPage() {
         <CollateralSection
           totalAmountBtc={totalAmountBtc}
           collateralVaults={collateralVaults}
-          hasCollateral={hasCollateral}
+          hasCollateral={hasDisplayCollateral}
           isConnected={isConnected}
           collateralBtc={collateralBtc}
           currentHealthFactor={healthFactor}

--- a/services/vault/src/components/simple/__tests__/CollateralSection.test.tsx
+++ b/services/vault/src/components/simple/__tests__/CollateralSection.test.tsx
@@ -1,0 +1,155 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { CollateralVaultEntry } from "@/types/collateral";
+
+// Capture the `vaults` prop handed to the reorder modal so we can assert the
+// optimistic "activating" row never enters the reorder path (gas estimate +
+// executeReorder inputs), only the display list.
+let reorderModalVaults: CollateralVaultEntry[] | null = null;
+vi.mock("../ReorderVaults", () => ({
+  ReorderVaultsModal: (props: { vaults: CollateralVaultEntry[] }) => {
+    reorderModalVaults = props.vaults;
+    return null;
+  },
+  ReorderSuccessModal: () => null,
+}));
+
+// Capture the `vaults` prop handed to the expanded list — the activating row
+// SHOULD still be displayed there.
+let expandedVaults: CollateralVaultEntry[] | null = null;
+vi.mock("../CollateralExpandedContent", () => ({
+  CollateralExpandedContent: (props: { vaults: CollateralVaultEntry[] }) => {
+    expandedVaults = props.vaults;
+    return null;
+  },
+}));
+
+vi.mock("@/components/deposit/ArtifactDownloadModal", () => ({
+  ArtifactDownloadModal: () => null,
+}));
+
+vi.mock("@/components/shared", () => ({
+  DepositButton: ({ children }: { children: React.ReactNode }) => (
+    <button>{children}</button>
+  ),
+  ExpandMenuButton: ({ onToggle }: { onToggle: () => void }) => (
+    <button data-testid="expand-toggle" onClick={onToggle}>
+      expand
+    </button>
+  ),
+}));
+
+vi.mock("@/config", () => ({
+  getNetworkConfigBTC: () => ({ icon: "/btc.svg", coinSymbol: "sBTC" }),
+  FeatureFlags: { isDepositDisabled: false },
+}));
+
+vi.mock("wagmi", () => ({
+  useAccount: () => ({ address: "0xabc" }),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+
+vi.mock("@/hooks/deposit/useVaultProviders", () => ({
+  useVaultProviders: () => ({ findProvider: () => undefined }),
+}));
+
+vi.mock("@/applications/aave/utils", () => ({
+  canWithdrawAnyVault: () => false,
+  computeProjectedHealthFactor: () => null,
+  getEffectiveVaultSelection: () => ({
+    selectedVaultIds: [],
+    selectedVaults: [],
+  }),
+  getWithdrawHfWarningState: () => ({ wouldBreachHF: false }),
+  isVaultIndividuallyWithdrawable: () => false,
+}));
+
+vi.mock("@/applications/aave/constants", () => ({
+  WITHDRAW_HF_BLOCK_THRESHOLD: 1.1,
+}));
+
+import { CollateralSection } from "../CollateralSection";
+
+const VAULT_A = ("0x" + "a".repeat(64)) as `0x${string}`;
+const VAULT_B = ("0x" + "b".repeat(64)) as `0x${string}`;
+const VAULT_C = ("0x" + "c".repeat(64)) as `0x${string}`;
+
+function entry(
+  vaultId: `0x${string}`,
+  overrides: Partial<CollateralVaultEntry> = {},
+): CollateralVaultEntry {
+  return {
+    id: `entry-${vaultId}`,
+    vaultId,
+    amountBtc: 1,
+    addedAt: 0,
+    inUse: true,
+    providerAddress: "0xprovider",
+    providerName: "VP",
+    liquidationIndex: 0,
+    ...overrides,
+  };
+}
+
+function renderSection(collateralVaults: CollateralVaultEntry[]) {
+  return render(
+    <CollateralSection
+      totalAmountBtc="3 sBTC"
+      collateralVaults={collateralVaults}
+      hasCollateral
+      isConnected
+      collateralBtc={2}
+      currentHealthFactor={null}
+      selectedVaultIds={[]}
+      onSelectedVaultIdsChange={vi.fn()}
+      onWithdraw={vi.fn()}
+      onDeposit={vi.fn()}
+    />,
+  );
+}
+
+describe("CollateralSection reorder input", () => {
+  beforeEach(() => {
+    reorderModalVaults = null;
+    expandedVaults = null;
+  });
+
+  it("excludes optimistic activating vaults from the reorder modal data", () => {
+    renderSection([
+      entry(VAULT_A, { liquidationIndex: 0 }),
+      entry(VAULT_B, { liquidationIndex: 1 }),
+      entry(VAULT_C, {
+        inUse: false,
+        isActivating: true,
+        liquidationIndex: Number.MAX_SAFE_INTEGER,
+      }),
+    ]);
+
+    // The reorder modal only sees indexer-confirmed vaults.
+    expect(reorderModalVaults?.map((v) => v.vaultId)).toEqual([
+      VAULT_A,
+      VAULT_B,
+    ]);
+  });
+
+  it("still displays the activating vault in the expanded collateral list", () => {
+    renderSection([
+      entry(VAULT_A, { liquidationIndex: 0 }),
+      entry(VAULT_B, { liquidationIndex: 1 }),
+      entry(VAULT_C, { inUse: false, isActivating: true }),
+    ]);
+
+    // Expand to mount the list.
+    fireEvent.click(screen.getByTestId("expand-toggle"));
+
+    expect(expandedVaults?.map((v) => v.vaultId)).toEqual([
+      VAULT_A,
+      VAULT_B,
+      VAULT_C,
+    ]);
+  });
+});

--- a/services/vault/src/components/simple/__tests__/CollateralVaultItem.test.tsx
+++ b/services/vault/src/components/simple/__tests__/CollateralVaultItem.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { COPY } from "@/copy";
+
+// The `@/components/shared` barrel drags in deps vitest can't transform; stub
+// the only export this component uses so the test stays focused on the item.
+vi.mock("@/components/shared", () => ({
+  ExplorerLink: () => null,
+}));
+
+import { CollateralVaultItem } from "../CollateralVaultItem";
+
+const VAULT_ID = "0x" + "a".repeat(64);
+
+const baseProps = {
+  vaultId: VAULT_ID,
+  amountBtc: 1,
+  providerName: "Provider X",
+  providerAddress: "0x" + "b".repeat(40),
+  selected: false,
+  selectable: false,
+  onToggleSelect: vi.fn(),
+};
+
+describe("CollateralVaultItem", () => {
+  it("shows the activating status with a disabled checkbox and no actions", () => {
+    render(
+      <CollateralVaultItem
+        {...baseProps}
+        inUse={false}
+        isActivating
+        onArtifactDownload={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(COPY.collateral.activating)).toBeInTheDocument();
+    // The indexed status badge is replaced by the activating indicator.
+    expect(
+      screen.queryByText(COPY.pegin.labels.IN_USE),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(COPY.pegin.labels.AVAILABLE),
+    ).not.toBeInTheDocument();
+    // Indexed-metadata actions are suppressed.
+    expect(screen.getByRole("checkbox")).toBeDisabled();
+    expect(
+      screen.queryByRole("button", { name: /download artifacts/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Liquidation Order")).not.toBeInTheDocument();
+  });
+
+  it("shows the normal status badge when not activating", () => {
+    render(<CollateralVaultItem {...baseProps} inUse={true} selectable />);
+
+    expect(screen.getByText(COPY.pegin.labels.IN_USE)).toBeInTheDocument();
+    expect(
+      screen.queryByText(COPY.collateral.activating),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/services/vault/src/components/simple/__tests__/CollateralVaultItem.test.tsx
+++ b/services/vault/src/components/simple/__tests__/CollateralVaultItem.test.tsx
@@ -48,14 +48,18 @@ describe("CollateralVaultItem", () => {
       screen.queryByRole("button", { name: /download artifacts/i }),
     ).not.toBeInTheDocument();
     expect(screen.queryByText("Liquidation Order")).not.toBeInTheDocument();
+    // Provider row is suppressed while activating (indexed metadata may be
+    // incomplete on the transient row).
+    expect(screen.queryByText("Vault provider")).not.toBeInTheDocument();
   });
 
-  it("shows the normal status badge when not activating", () => {
+  it("shows the normal status badge and provider row when not activating", () => {
     render(<CollateralVaultItem {...baseProps} inUse={true} selectable />);
 
     expect(screen.getByText(COPY.pegin.labels.IN_USE)).toBeInTheDocument();
     expect(
       screen.queryByText(COPY.collateral.activating),
     ).not.toBeInTheDocument();
+    expect(screen.getByText("Vault provider")).toBeInTheDocument();
   });
 });

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -630,6 +630,9 @@ export const COPY = {
     releaseHfBreachTooltip: (threshold: number) =>
       `This selection would drop your health factor below ${threshold.toFixed(1)} and be rejected on-chain. Reduce the selection or repay debt first.`,
     uncapped: "Uncapped",
+    // Shown on an optimistic collateral row right after the activation ETH tx,
+    // while the indexer catches up and the vault becomes "In use".
+    activating: "Activating collateral...",
     empty: {
       title: "Deposit Bitcoin to get started",
       body: (symbol: string) =>

--- a/services/vault/src/hooks/__tests__/useDashboardState.test.ts
+++ b/services/vault/src/hooks/__tests__/useDashboardState.test.ts
@@ -11,6 +11,7 @@ const VAULT_C = ("0x" + "c".repeat(64)) as `0x${string}`;
 
 type ActivatingEntry = {
   vaultId: `0x${string}`;
+  depositorEthAddress?: string;
   amountBtc: number;
   providerAddress?: string;
 };
@@ -164,7 +165,10 @@ describe("useDashboardState", () => {
   it("appends an optimistic activating row when the vault is not yet indexed", () => {
     mockCollaterals = null; // empty position (first deposit)
     mockActivatingVaults = new Map([
-      [VAULT_A.toLowerCase(), { vaultId: VAULT_A, amountBtc: 1 }],
+      [
+        VAULT_A.toLowerCase(),
+        { vaultId: VAULT_A, depositorEthAddress: "0xabc", amountBtc: 1 },
+      ],
     ]);
 
     const { result } = renderHook(() => useDashboardState("0xabc"));
@@ -190,7 +194,10 @@ describe("useDashboardState", () => {
     mockCollateralBtc = 1;
     mockCollaterals = [collateral(VAULT_A, 0)];
     mockActivatingVaults = new Map([
-      [VAULT_A.toLowerCase(), { vaultId: VAULT_A, amountBtc: 1 }],
+      [
+        VAULT_A.toLowerCase(),
+        { vaultId: VAULT_A, depositorEthAddress: "0xabc", amountBtc: 1 },
+      ],
     ]);
 
     const { result } = renderHook(() => useDashboardState("0xabc"));
@@ -202,5 +209,22 @@ describe("useDashboardState", () => {
     expect(mockClearActivatingVault).toHaveBeenCalledWith(VAULT_A);
     // Display total is not double-counted.
     expect(result.current.displayCollateralBtc).toBe(1);
+  });
+
+  it("does not surface an activating vault belonging to a different connected address", () => {
+    mockCollaterals = null;
+    // Entry was recorded while a different wallet was connected.
+    mockActivatingVaults = new Map([
+      [
+        VAULT_A.toLowerCase(),
+        { vaultId: VAULT_A, depositorEthAddress: "0xother", amountBtc: 1 },
+      ],
+    ]);
+
+    const { result } = renderHook(() => useDashboardState("0xabc"));
+
+    expect(result.current.collateralVaults).toHaveLength(0);
+    expect(result.current.displayCollateralBtc).toBe(0);
+    expect(result.current.hasDisplayCollateral).toBe(false);
   });
 });

--- a/services/vault/src/hooks/__tests__/useDashboardState.test.ts
+++ b/services/vault/src/hooks/__tests__/useDashboardState.test.ts
@@ -9,10 +9,19 @@ const VAULT_A = ("0x" + "a".repeat(64)) as `0x${string}`;
 const VAULT_B = ("0x" + "b".repeat(64)) as `0x${string}`;
 const VAULT_C = ("0x" + "c".repeat(64)) as `0x${string}`;
 
+type ActivatingEntry = {
+  vaultId: `0x${string}`;
+  amountBtc: number;
+  providerAddress?: string;
+};
+
 // Mutable state read by the hoisted mocks below.
 let mockCollaterals: unknown[] | null = null;
+let mockCollateralBtc = 0;
 let mockReorderedOrder: readonly `0x${string}`[] | null = null;
+let mockActivatingVaults = new Map<string, ActivatingEntry>();
 const mockClearReorderedOrder = vi.fn();
+const mockClearActivatingVault = vi.fn();
 
 vi.mock("@/applications/aave/context", () => ({
   useReorderOverride: () => ({
@@ -20,12 +29,17 @@ vi.mock("@/applications/aave/context", () => ({
     applyReorderedOrder: vi.fn(),
     clearReorderedOrder: mockClearReorderedOrder,
   }),
+  useActivatingVaults: () => ({
+    activatingVaults: mockActivatingVaults,
+    addActivatingVault: vi.fn(),
+    clearActivatingVault: mockClearActivatingVault,
+  }),
 }));
 
 vi.mock("@/applications/aave/hooks", () => ({
   useAaveUserPosition: () => ({
     position: mockCollaterals ? { collaterals: mockCollaterals } : null,
-    collateralBtc: 0,
+    collateralBtc: mockCollateralBtc,
     collateralValueUsd: 0,
     debtValueUsd: 0,
     healthFactor: null,
@@ -70,7 +84,9 @@ describe("useDashboardState", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockCollaterals = null;
+    mockCollateralBtc = 0;
     mockReorderedOrder = null;
+    mockActivatingVaults = new Map();
   });
 
   it("returns a stable collateralVaults reference across re-renders when position?.collaterals is undefined", () => {
@@ -143,5 +159,48 @@ describe("useDashboardState", () => {
       VAULT_B,
     ]);
     expect(mockClearReorderedOrder).toHaveBeenCalled();
+  });
+
+  it("appends an optimistic activating row when the vault is not yet indexed", () => {
+    mockCollaterals = null; // empty position (first deposit)
+    mockActivatingVaults = new Map([
+      [VAULT_A.toLowerCase(), { vaultId: VAULT_A, amountBtc: 1 }],
+    ]);
+
+    const { result } = renderHook(() => useDashboardState("0xabc"));
+
+    expect(result.current.collateralVaults).toHaveLength(1);
+    expect(result.current.collateralVaults[0]).toMatchObject({
+      vaultId: VAULT_A,
+      amountBtc: 1,
+      isActivating: true,
+      inUse: false,
+    });
+    // Display total + display gate reflect the optimistic vault, while the
+    // financial collateralBtc and the action-gating hasCollateral stay
+    // indexer-pure (so Borrow can't be unlocked before collateral exists).
+    expect(result.current.displayCollateralBtc).toBe(1);
+    expect(result.current.collateralBtc).toBe(0);
+    expect(result.current.hasDisplayCollateral).toBe(true);
+    expect(result.current.hasCollateral).toBe(false);
+    expect(mockClearActivatingVault).not.toHaveBeenCalled();
+  });
+
+  it("drops the activating override and does not duplicate once the indexer reflects the vault", () => {
+    mockCollateralBtc = 1;
+    mockCollaterals = [collateral(VAULT_A, 0)];
+    mockActivatingVaults = new Map([
+      [VAULT_A.toLowerCase(), { vaultId: VAULT_A, amountBtc: 1 }],
+    ]);
+
+    const { result } = renderHook(() => useDashboardState("0xabc"));
+
+    // Only the indexer row remains — no duplicate optimistic row.
+    expect(vaultIds(result.current.collateralVaults)).toEqual([VAULT_A]);
+    expect(result.current.collateralVaults[0].isActivating).toBeUndefined();
+    // Reconciliation clears the now-indexed activating entry.
+    expect(mockClearActivatingVault).toHaveBeenCalledWith(VAULT_A);
+    // Display total is not double-counted.
+    expect(result.current.displayCollateralBtc).toBe(1);
   });
 });

--- a/services/vault/src/hooks/deposit/useActivationState.ts
+++ b/services/vault/src/hooks/deposit/useActivationState.ts
@@ -95,6 +95,7 @@ export function useActivationState({
             if (Number.isFinite(amountBtc) && amountBtc > 0) {
               addActivatingVault({
                 vaultId: activity.id,
+                depositorEthAddress,
                 amountBtc,
                 providerAddress: activity.providers[0]?.id,
               });

--- a/services/vault/src/hooks/deposit/useActivationState.ts
+++ b/services/vault/src/hooks/deposit/useActivationState.ts
@@ -8,6 +8,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 
+import { useActivatingVaults } from "@/applications/aave/context";
 import { usePeginPolling } from "@/context/deposit/PeginPollingContext";
 import { logger } from "@/infrastructure";
 import { LocalStorageStatus } from "@/models/peginStateMachine";
@@ -60,6 +61,7 @@ export function useActivationState({
   }, []);
 
   const { setOptimisticStatus } = usePeginPolling();
+  const { addActivatingVault } = useActivatingVaults();
   const { pendingPegins, updatePendingPeginStatus } = usePeginStorage({
     ethAddress: depositorEthAddress,
     confirmedPegins: EMPTY_CONFIRMED,
@@ -83,6 +85,20 @@ export function useActivationState({
           onShowSuccessModal: () => {
             if (!mountedRef.current) return;
             setOptimisticStatus(activity.id, LocalStorageStatus.CONFIRMED);
+            // Optimistically surface the just-activated vault in the dashboard
+            // Collateral section while the Aave indexer catches up (~15s gap).
+            // Skip a bogus row if the amount can't be parsed to a positive BTC
+            // value — the indexer-driven row will still appear within seconds.
+            const amountBtc = parseFloat(
+              activity.collateral.amount.replace(/,/g, ""),
+            );
+            if (Number.isFinite(amountBtc) && amountBtc > 0) {
+              addActivatingVault({
+                vaultId: activity.id,
+                amountBtc,
+                providerAddress: activity.providers[0]?.id,
+              });
+            }
             setLocalActivating(false);
             setActivated(true);
           },
@@ -101,6 +117,7 @@ export function useActivationState({
       updatePendingPeginStatus,
       vaultHandleActivation,
       setOptimisticStatus,
+      addActivatingVault,
     ],
   );
 

--- a/services/vault/src/hooks/useDashboardState.ts
+++ b/services/vault/src/hooks/useDashboardState.ts
@@ -6,7 +6,10 @@
 
 import { useEffect, useMemo } from "react";
 
-import { useReorderOverride } from "@/applications/aave/context";
+import {
+  useActivatingVaults,
+  useReorderOverride,
+} from "@/applications/aave/context";
 import {
   useAaveBorrowedAssets,
   useAaveUserPosition,
@@ -14,6 +17,7 @@ import {
 import type { Asset } from "@/applications/aave/types";
 import { useVaultProviders } from "@/hooks/deposit/useVaultProviders";
 import type { CollateralVaultEntry } from "@/types/collateral";
+import { truncateHash } from "@/utils/addressUtils";
 import { toCollateralVaultEntries } from "@/utils/collateral";
 import {
   isReorderOverrideReconciled,
@@ -41,8 +45,8 @@ export function useDashboardState(connectedAddress: string | undefined) {
 
   const { findProvider } = useVaultProviders();
   const { reorderedOrder, clearReorderedOrder } = useReorderOverride();
+  const { activatingVaults, clearActivatingVault } = useActivatingVaults();
 
-  const hasCollateral = collateralBtc > 0;
   const hasDebt = debtValueUsd > 0;
 
   // Raw indexer entries (liquidationIndex straight from the indexer). These
@@ -56,14 +60,46 @@ export function useDashboardState(connectedAddress: string | undefined) {
     [position?.collaterals, findProvider],
   );
 
+  // Optimistic "Activating…" rows: just-activated vaults the indexer hasn't
+  // ingested yet. Excludes any vault already present in the indexer entries so
+  // we never duplicate a row once it lands.
+  const activatingEntries = useMemo((): CollateralVaultEntry[] => {
+    if (activatingVaults.size === 0) return [];
+    const indexedIds = new Set(
+      rawCollateralVaults.map((v) => v.vaultId.toLowerCase()),
+    );
+    return Array.from(activatingVaults.values())
+      .filter((entry) => !indexedIds.has(entry.vaultId.toLowerCase()))
+      .map((entry): CollateralVaultEntry => {
+        const provider = findProvider?.(entry.providerAddress ?? "");
+        return {
+          id: `activating-${entry.vaultId}`,
+          vaultId: entry.vaultId,
+          amountBtc: entry.amountBtc,
+          addedAt: 0,
+          inUse: false,
+          isActivating: true,
+          providerAddress: entry.providerAddress ?? "",
+          providerName:
+            provider?.name ?? truncateHash(entry.providerAddress ?? ""),
+          providerIconUrl: provider?.iconUrl,
+          // No indexed liquidation order yet; sentinel keeps it last if sorted.
+          liquidationIndex: Number.MAX_SAFE_INTEGER,
+        };
+      });
+  }, [activatingVaults, rawCollateralVaults, findProvider]);
+
   // Displayed entries. Normally indexer-ordered; right after a reorder,
   // `reorderedOrder` holds the submitted order so the new order (and each row's
   // ordinal) shows immediately. Falls back to indexer ordering once the
-  // override no longer matches the vault set.
+  // override no longer matches the vault set. Optimistic activating rows are
+  // appended last, until the indexer reflects them.
   const collateralVaults = useMemo(
-    (): CollateralVaultEntry[] =>
-      sortByReorderedOverride(rawCollateralVaults, reorderedOrder),
-    [rawCollateralVaults, reorderedOrder],
+    (): CollateralVaultEntry[] => [
+      ...sortByReorderedOverride(rawCollateralVaults, reorderedOrder),
+      ...activatingEntries,
+    ],
+    [rawCollateralVaults, reorderedOrder, activatingEntries],
   );
 
   // Drop the override once the indexer reflects the reordered sequence (or the
@@ -75,6 +111,36 @@ export function useDashboardState(connectedAddress: string | undefined) {
       clearReorderedOrder();
     }
   }, [rawCollateralVaults, reorderedOrder, clearReorderedOrder]);
+
+  // Drop each activating override once the indexer reflects that vault, so the
+  // optimistic row hands off to the real indexer-driven row without duplicating.
+  useEffect(() => {
+    if (activatingVaults.size === 0) return;
+    const indexedIds = new Set(
+      rawCollateralVaults.map((v) => v.vaultId.toLowerCase()),
+    );
+    for (const entry of activatingVaults.values()) {
+      if (indexedIds.has(entry.vaultId.toLowerCase())) {
+        clearActivatingVault(entry.vaultId);
+      }
+    }
+  }, [rawCollateralVaults, activatingVaults, clearActivatingVault]);
+
+  // Display-only BTC total: indexer collateral plus optimistic activating
+  // amounts. The financial `collateralBtc` (health factor / withdraw math)
+  // stays indexer/oracle-pure and is returned unchanged below.
+  const displayCollateralBtc =
+    collateralBtc +
+    activatingEntries.reduce((sum, entry) => sum + entry.amountBtc, 0);
+
+  // Financial gate — drives action-enabling (e.g. Borrow). Indexer-pure: an
+  // optimistic activating row must NOT unlock financial actions before the
+  // collateral actually exists on-chain.
+  const hasCollateral = collateralBtc > 0;
+  // Display gate — drives the Collateral section's summary-vs-empty rendering,
+  // so the just-activated vault shows during the indexer gap.
+  const hasDisplayCollateral =
+    collateralBtc > 0 || activatingEntries.length > 0;
 
   // Transform borrowed assets for the asset selection modal
   const selectableBorrowedAssets = useMemo(
@@ -89,6 +155,7 @@ export function useDashboardState(connectedAddress: string | undefined) {
 
   return {
     collateralBtc,
+    displayCollateralBtc,
     collateralValueUsd,
     debtValueUsd,
     healthFactor,
@@ -96,6 +163,7 @@ export function useDashboardState(connectedAddress: string | undefined) {
     borrowedAssets,
     hasLoans,
     hasCollateral,
+    hasDisplayCollateral,
     hasDebt,
     collateralVaults,
     selectableBorrowedAssets,

--- a/services/vault/src/hooks/useDashboardState.ts
+++ b/services/vault/src/hooks/useDashboardState.ts
@@ -62,14 +62,19 @@ export function useDashboardState(connectedAddress: string | undefined) {
 
   // Optimistic "Activating…" rows: just-activated vaults the indexer hasn't
   // ingested yet. Excludes any vault already present in the indexer entries so
-  // we never duplicate a row once it lands.
+  // we never duplicate a row once it lands, and any entry that belongs to a
+  // different depositor address so switching wallets during the optimistic
+  // window can't leak one account's activating vault onto another's dashboard.
   const activatingEntries = useMemo((): CollateralVaultEntry[] => {
     if (activatingVaults.size === 0) return [];
+    const connected = connectedAddress?.toLowerCase();
     const indexedIds = new Set(
       rawCollateralVaults.map((v) => v.vaultId.toLowerCase()),
     );
+    if (!connected) return [];
     return Array.from(activatingVaults.values())
       .filter((entry) => !indexedIds.has(entry.vaultId.toLowerCase()))
+      .filter((entry) => entry.depositorEthAddress?.toLowerCase() === connected)
       .map((entry): CollateralVaultEntry => {
         const provider = findProvider?.(entry.providerAddress ?? "");
         return {
@@ -87,7 +92,7 @@ export function useDashboardState(connectedAddress: string | undefined) {
           liquidationIndex: Number.MAX_SAFE_INTEGER,
         };
       });
-  }, [activatingVaults, rawCollateralVaults, findProvider]);
+  }, [activatingVaults, rawCollateralVaults, findProvider, connectedAddress]);
 
   // Displayed entries. Normally indexer-ordered; right after a reorder,
   // `reorderedOrder` holds the submitted order so the new order (and each row's

--- a/services/vault/src/types/collateral.ts
+++ b/services/vault/src/types/collateral.ts
@@ -21,6 +21,14 @@ export interface CollateralVaultEntry {
   addedAt: number;
   /** Whether the vault is currently in use as collateral */
   inUse: boolean;
+  /**
+   * True for an optimistic row shown right after the activation ETH tx, while
+   * the Aave indexer has not yet ingested the vault as collateral. Such a row
+   * has no indexed metadata (provider/tx hashes/liquidation order may be
+   * placeholders) and is not selectable/withdrawable. Cleared once the indexer
+   * reflects the vault. See ActivatingVaultsContext.
+   */
+  isActivating?: boolean;
   /** Vault provider Ethereum address */
   providerAddress: string;
   /** Vault provider display name */


### PR DESCRIPTION
## What

When a user finishes the activation Ethereum transaction, their vault is now shown immediately in the dashboard's Collateral section as a row reading "Activating collateral…" with a spinner, instead of nothing. Once the indexer catches up (~15s later) the row reconciles into the normal "In use" collateral row automatically.

## Why

Activation supplies the vault as collateral on-chain right away, but the Collateral section is driven entirely by the Aave indexer, which takes ~15 seconds to ingest the event. During that window the just-activated vault was missing from the list — and for a first deposit the section even showed the empty "Deposit Bitcoin to get started" state. Users thought their activation had failed and panicked. This change closes that perception gap.

## How it works

We added a small in-memory store (`ActivatingVaultsContext`) that records a vault the moment its activation tx succeeds (vault id, amount, provider). The dashboard merges any such vault that the indexer hasn't returned yet into the Collateral list as an optimistic "activating" row. As soon as the indexer reports that vault, the optimistic entry is dropped (so there's never a duplicate), with a 90-second safety timeout as a backstop in case the indexer never reflects it.

This mirrors a pattern the codebase already uses for the post-reorder display (`ReorderOverrideContext`): show the expected state immediately, then hand off to the indexer once it agrees.

## Approaches considered

- **Reuse the existing `PendingVaultsContext`.** It already tracks "submitted but not yet indexed" vaults and reconciles on "In use". We didn't reuse it because its "add" path is currently unused, it stores only vault ids (no amount/provider, so there'd be nothing to display), and its provider is mounted too low in the tree to see the deposit modal. Adapting it would have meant relocating the provider and extending its storage model — more invasive than a small purpose-built context.
- **A new parallel context (chosen).** It carries exactly the display data we need and slots into the established reorder-override pattern, so it's small, self-contained, and easy to reason about.

## Safety boundary (important for review)

This is a display-only change. The financial value `collateralBtc` — which drives health factor, withdraw eligibility, and other money math — stays sourced purely from the indexer/oracle and is never inflated by the optimistic row.

We deliberately split the collateral flags so the optimistic state can't unlock a financial action: `hasCollateral` (gates the Borrow button) remains indexer-pure, while a new `hasDisplayCollateral` (gates only the Collateral section's rendering) accounts for activating vaults. The optimistic row is also not selectable or withdrawable, and it hides every field that depends on indexed metadata (tx hashes, liquidation order, artifacts, vault explorer link).

## Provider placement (key wiring detail)

The activation flow runs inside the deposit modal, which is rendered both under the dashboard and as a sibling of the dashboard at the `RootLayout` level. The new provider is therefore mounted in `RootLayout` wrapping both the routed page and the deposit modal, so the modal can write the activating state and the dashboard can read it.

## Testing

- Unit tests for the context (state, single-entry clear, 90s backstop, used-outside-provider guard, and writer→reader sharing under one provider).
- Unit tests for the dashboard merge/reconcile: an activating vault not yet indexed is appended and counted in the display total; once the indexer reflects it, the optimistic entry is cleared and not duplicated; and the financial `hasCollateral` stays `false` while `hasDisplayCollateral` is `true`.
- A component test for the activating row (shows "Activating collateral…", disables the checkbox, hides artifacts/liquidation order).
- Full suite: lint clean (no new errors), typecheck clean, all vault tests pass.

## Manual verification

1. Run a deposit through to activation on an empty position.
2. Right after the activation tx confirms (before the indexer poll), the Collateral section shows the amount + spinner + "Activating collateral…" instead of the empty state.
3. Within ~15–30s the row reconciles to the normal "In use" row with no flicker or duplicate.
4. Confirm the Borrow button stays disabled until the indexer reports the collateral.