### PR TITLE
ci(vault-publish): env scoping + correlation id for orchestrated release

### DIFF
--- a/.github/workflows/service-release-vault.yml
+++ b/.github/workflows/service-release-vault.yml
@@ -61,6 +61,7 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
+      multi: ${{ steps.matrix.outputs.multi }}
     steps:
       - name: Build publish matrix
         id: matrix
@@ -84,6 +85,16 @@ jobs:
             fi
           fi
           echo "matrix={\"include\":$SELECTED}" >> "$GITHUB_OUTPUT"
+          # multi=true only when publishing more than one environment. Used to
+          # scope continue-on-error: tolerate a prod OIDC failure in the all-env
+          # run (so it can't block devnet), but fail loud when prod is the only
+          # explicitly requested environment (else a scoped prod dispatch goes
+          # green while publishing nothing).
+          if [ "$(echo "$SELECTED" | jq 'length')" -gt 1 ]; then
+            echo "multi=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "multi=false" >> "$GITHUB_OUTPUT"
+          fi
 
   s3_publish:
     needs: [lint_test, setup]
@@ -92,8 +103,11 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
 
-    # Prod environments will fail OIDC on feature branches; allow failure so devnet jobs aren't blocked
-    continue-on-error: ${{ matrix.prod == true }}
+    # Prod OIDC fails on feature branches; tolerate it ONLY in the multi-env run
+    # so it can't block devnet. When prod (vault-testnet) is the single requested
+    # environment, fail loud — otherwise a scoped prod dispatch reports success
+    # while publishing nothing.
+    continue-on-error: ${{ matrix.prod == true && needs.setup.outputs.multi == 'true' }}
     environment: ${{ matrix.environment }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/service-release-vault.yml
+++ b/.github/workflows/service-release-vault.yml
@@ -1,4 +1,5 @@
 name: vault-publish
+run-name: vault-publish${{ inputs.ENVIRONMENT != '' && inputs.ENVIRONMENT != 'all' && format(' {0}', inputs.ENVIRONMENT) || '' }} by ${{ github.actor }}${{ inputs.CORRELATION_ID != '' && format(' [{0}]', inputs.CORRELATION_ID) || '' }}
 
 on:
   push:
@@ -8,6 +9,21 @@ on:
     tags:
       - "vault/*"
   workflow_dispatch:
+    inputs:
+      ENVIRONMENT:
+        description: 'Environment to publish. "all" publishes all three (the push/tag default).'
+        required: false
+        default: all
+        type: choice
+        options:
+          - all
+          - vault-devnet
+          - vault-staging-devnet
+          - vault-testnet
+      CORRELATION_ID:
+        description: 'Opaque ID set by an orchestrating workflow (e.g. tbv-deployment unified redeploy) so it can locate this run via run-name. Empty for manual runs.'
+        required: false
+        type: string
 
 # For github OIDC authentication to AWS
 permissions:
@@ -38,20 +54,42 @@ jobs:
       - name: Build
         run: pnpm run build
 
+  # Resolve which environments this run publishes. A workflow_dispatch run may
+  # scope to a single environment (ENVIRONMENT input); push/tag runs and the
+  # "all" choice publish every environment, preserving the previous behaviour.
+  setup:
+    runs-on: ubuntu-24.04
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+      - name: Build publish matrix
+        id: matrix
+        env:
+          ENVIRONMENT: ${{ inputs.ENVIRONMENT }}
+        run: |
+          set -euo pipefail
+          ALL='[
+            {"environment":"vault-devnet","aws_account":"537927626649"},
+            {"environment":"vault-staging-devnet","aws_account":"537927626649"},
+            {"environment":"vault-testnet","aws_account":"615368094160","prod":true}
+          ]'
+          if [ -z "${ENVIRONMENT:-}" ] || [ "$ENVIRONMENT" = "all" ]; then
+            SELECTED=$(echo "$ALL" | jq -c '.')
+          else
+            SELECTED=$(echo "$ALL" | jq -c --arg e "$ENVIRONMENT" '[.[] | select(.environment == $e)]')
+            if [ "$(echo "$SELECTED" | jq 'length')" -eq 0 ]; then
+              echo "::error::Unknown ENVIRONMENT '$ENVIRONMENT'. Valid: vault-devnet, vault-staging-devnet, vault-testnet, all."
+              exit 1
+            fi
+          fi
+          echo "matrix={\"include\":$SELECTED}" >> "$GITHUB_OUTPUT"
+
   s3_publish:
-    needs: [lint_test]
+    needs: [lint_test, setup]
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - environment: vault-devnet
-            aws_account: 537927626649
-          - environment: vault-staging-devnet
-            aws_account: 537927626649
-          - environment: vault-testnet
-            aws_account: 615368094160
-            prod: true
+      matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
 
     # Prod environments will fail OIDC on feature branches; allow failure so devnet jobs aren't blocked
     continue-on-error: ${{ matrix.prod == true }}

--- a/.github/workflows/service-release-vault.yml
+++ b/.github/workflows/service-release-vault.yml
@@ -78,7 +78,8 @@ jobs:
           else
             SELECTED=$(echo "$ALL" | jq -c --arg e "$ENVIRONMENT" '[.[] | select(.environment == $e)]')
             if [ "$(echo "$SELECTED" | jq 'length')" -eq 0 ]; then
-              echo "::error::Unknown ENVIRONMENT '$ENVIRONMENT'. Valid: vault-devnet, vault-staging-devnet, vault-testnet, all."
+              VALID=$(echo "$ALL" | jq -r '[.[].environment] + ["all"] | join(", ")')
+              echo "::error::Unknown ENVIRONMENT '$ENVIRONMENT'. Valid: $VALID."
               exit 1
             fi
           fi


### PR DESCRIPTION
## What
Adds two `workflow_dispatch` inputs to `service-release-vault.yml`:
- **`ENVIRONMENT`** (choice, default `all`) — scopes the S3 publish to a single environment. `all` (and every push/tag run) publishes all three as before, via a dynamic matrix built in a new `setup` job.
- **`CORRELATION_ID`** (string) — echoed into `run-name` so an orchestrating workflow can locate this run.

## Why
The tbv-deployment unified redeploy pipeline needs to rebuild+republish the vault frontend for **one** environment after a contract redeploy (so the bundle picks up the freshly deployed addresses), without touching `vault-testnet` (prod). Today the workflow only has a static 3-env matrix and no inputs, so a dispatch rebuilds all three — unusable for a devnet-scoped redeploy.

## Behavior
- Push to `main`/`release`, tags `vault/*`, or dispatch with `ENVIRONMENT=all` → all three environments (unchanged).
- Dispatch with `ENVIRONMENT=vault-devnet` (or `vault-staging-devnet`) → that environment only; testnet is never selected.
- `CORRELATION_ID` empty (manual/push) → no bracket appended to run-name.

Companion PR: babylonlabs-io/tbv-deployment adds the `frontend-release` job that dispatches this workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)