### PR TITLE
feat(vault): hide inscriptions toggle when wallet has none

### DIFF
--- a/packages/babylon-core-ui/src/widgets/sections/WalletMenu/WalletMenu.stories.tsx
+++ b/packages/babylon-core-ui/src/widgets/sections/WalletMenu/WalletMenu.stories.tsx
@@ -107,6 +107,67 @@ export const BtcEth: StoryObj = {
   },
 };
 
+export const BtcEthNoInscriptions: StoryObj = {
+  name: "BtcEthWalletMenu (no inscriptions — toggle hidden)",
+  render: () => {
+    const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+    const trigger = (
+      <div className="cursor-pointer">
+        <AvatarGroup max={2} variant="circular">
+          <Avatar
+            alt={mockWalletData.selectedWallets.BTC.name}
+            url={mockWalletData.selectedWallets.BTC.icon}
+            size="large"
+            className={`object-contain bg-accent-contrast box-content ${isMenuOpen ? "outline outline-[2px] outline-accent-primary" : ""}`}
+          />
+          <Avatar
+            alt={mockWalletData.selectedWallets.ETH.name}
+            url={mockWalletData.selectedWallets.ETH.icon}
+            size="large"
+            className={`object-contain bg-accent-contrast box-content ${isMenuOpen ? "outline outline-[2px] outline-accent-primary" : ""}`}
+          />
+        </AvatarGroup>
+      </div>
+    );
+
+    const customFormatBalance = (amount: number, coinSymbol: string) => {
+      return `${amount.toLocaleString(undefined, {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 8,
+      })} ${coinSymbol}`;
+    };
+
+    return (
+      <div className="space-y-4 p-4">
+        <h3 className="text-lg font-semibold">BtcEthWalletMenu - no inscriptions (toggle hidden)</h3>
+        <p className="text-sm text-gray-600 dark:text-gray-400">
+          showInscriptionsToggle=false: the "Using Inscriptions" row is omitted and the Bitcoin Public Key item takes the
+          single-item rounded-lg styling.
+        </p>
+        <BtcEthWalletMenu
+          trigger={trigger}
+          btcAddress={mockWalletData.btcAddress}
+          ethAddress={mockWalletData.ethAddress}
+          selectedWallets={mockWalletData.selectedWallets}
+          publicKeyNoCoord={mockWalletData.publicKeyNoCoord}
+          ordinalsExcluded
+          onIncludeOrdinals={() => console.log("Include ordinals")}
+          onExcludeOrdinals={() => console.log("Exclude ordinals")}
+          onDisconnect={() => console.log("Disconnect wallets")}
+          onOpenChange={setIsMenuOpen}
+          btcBalances={mockWalletData.btcBalances}
+          ethBalances={mockWalletData.ethBalances}
+          btcCoinSymbol="BTC"
+          ethCoinSymbol="ETH"
+          showInscriptionsToggle={false}
+          formatBalance={customFormatBalance}
+        />
+      </div>
+    );
+  },
+};
+
 export const BtcBaby: StoryObj = {
   name: "BtcBabyWalletMenu (Simple-staking)",
   render: () => {

--- a/packages/babylon-core-ui/src/widgets/sections/WalletMenu/presets/BtcEthWalletMenu.tsx
+++ b/packages/babylon-core-ui/src/widgets/sections/WalletMenu/presets/BtcEthWalletMenu.tsx
@@ -15,17 +15,23 @@ export interface BtcEthWalletMenuProps extends Omit<WalletMenuProps, "settingsSe
   onExcludeOrdinals: () => void;
   /** Bitcoin public key (no coordinates) */
   publicKeyNoCoord: string;
+  /**
+   * Show the "Using Inscriptions" toggle. Defaults to true. Pass false to hide
+   * it when the connected wallet has no inscription UTXOs, so users without
+   * Ordinals/Runes aren't shown a control that does nothing.
+   */
+  showInscriptionsToggle?: boolean;
 }
 
 /**
  * BtcEthWalletMenu - Wallet menu preset for Vault (BTC + ETH)
- * 
+ *
  * Features:
  * - BTC wallet card
  * - ETH wallet card
  * - Using Inscriptions toggle
  * - Bitcoin Public Key display
- * 
+ *
  * Does NOT include:
  * - Linked Wallet Stakes toggle
  */
@@ -34,6 +40,7 @@ export const BtcEthWalletMenu: React.FC<BtcEthWalletMenuProps> = ({
   onIncludeOrdinals,
   onExcludeOrdinals,
   publicKeyNoCoord,
+  showInscriptionsToggle = true,
   copy,
   ...walletMenuProps
 }) => {
@@ -42,34 +49,37 @@ export const BtcEthWalletMenu: React.FC<BtcEthWalletMenuProps> = ({
   const copyToClipboard = copy?.copyToClipboard ?? internalCopy;
 
   const settingsSection = (
-    <div className="flex flex-col w-full bg-neutral-100 rounded-lg md:bg-transparent md:border-none md:gap-8">
-      <WalletMenuSettingItem
-        icon={<ThemedIcon variant="primary" background rounded><UsingInscriptionIcon /></ThemedIcon>}
-        title="Using Inscriptions"
-        status={ordinalsExcluded ? "Off" : "On"}
-        value={!ordinalsExcluded}
-        onChange={(value) =>
-          value ? onIncludeOrdinals() : onExcludeOrdinals()
-        }
-      />
-      
+    <div className="flex w-full flex-col rounded-lg bg-neutral-100 md:gap-8 md:border-none md:bg-transparent">
+      {showInscriptionsToggle && (
+        <WalletMenuSettingItem
+          icon={
+            <ThemedIcon variant="primary" background rounded>
+              <UsingInscriptionIcon />
+            </ThemedIcon>
+          }
+          title="Using Inscriptions"
+          status={ordinalsExcluded ? "Off" : "On"}
+          value={!ordinalsExcluded}
+          onChange={(value) => (value ? onIncludeOrdinals() : onExcludeOrdinals())}
+        />
+      )}
+
       <WalletMenuInfoItem
         title="Bitcoin Public Key"
         value={publicKeyNoCoord}
         isCopied={isCopied("publicKey")}
         onCopy={() => copyToClipboard("publicKey", publicKeyNoCoord)}
-        icon={<ThemedIcon variant="primary" background rounded><BitcoinPublicKeyIcon /></ThemedIcon>}
-        className="rounded-b-lg rounded-t-none md:rounded-none"
+        icon={
+          <ThemedIcon variant="primary" background rounded>
+            <BitcoinPublicKeyIcon />
+          </ThemedIcon>
+        }
+        className={
+          showInscriptionsToggle ? "rounded-b-lg rounded-t-none md:rounded-none" : "rounded-lg md:rounded-none"
+        }
       />
     </div>
   );
 
-  return (
-    <WalletMenu
-      {...walletMenuProps}
-      copy={copy}
-      settingsSection={settingsSection}
-    />
-  );
+  return <WalletMenu {...walletMenuProps} copy={copy} settingsSection={settingsSection} />;
 };
-

--- a/services/vault/src/components/Wallet/Connect.tsx
+++ b/services/vault/src/components/Wallet/Connect.tsx
@@ -15,6 +15,7 @@ import { useMemo } from "react";
 import { useAddressScreening } from "@/context/addressScreening";
 import { useGeoFencing } from "@/context/geofencing";
 import { COPY } from "@/copy";
+import { useUTXOs } from "@/hooks/useUTXOs";
 
 import { useBTCWallet, useETHWallet } from "../../context/wallet";
 import { useAppState } from "../../state/AppState";
@@ -46,6 +47,15 @@ export const Connect: React.FC<ConnectProps> = ({ loading = false, text }) => {
     useAddressScreening();
 
   const isWalletConnected = btcConnected && ethConnected;
+
+  // Show the toggle only once detection confirms inscriptions exist. `inscriptionUTXOs`
+  // is empty while ordinals detection loads or errors, so it stays hidden then too —
+  // safe, since the toggle is a no-op when nothing is detected. `enabled` scopes this
+  // subscription to when the menu can render (the query is shared with the deposit form).
+  const { inscriptionUTXOs } = useUTXOs(btcAddress, {
+    enabled: isWalletConnected && !isGeoBlocked && !isGeoLoading,
+  });
+  const hasInscriptions = inscriptionUTXOs.length > 0;
 
   // Icon source must stay aligned with the (provider-level) connection state:
   // `selectedWallets` is volatile widget state that can lag a reconnect on
@@ -98,6 +108,7 @@ export const Connect: React.FC<ConnectProps> = ({ loading = false, text }) => {
           ordinalsExcluded={ordinalsExcluded}
           onIncludeOrdinals={includeOrdinals}
           onExcludeOrdinals={excludeOrdinals}
+          showInscriptionsToggle={hasInscriptions}
           btcCoinSymbol="BTC"
           ethCoinSymbol="ETH"
           onDisconnect={disconnect}

--- a/services/vault/src/components/Wallet/Connect.tsx
+++ b/services/vault/src/components/Wallet/Connect.tsx
@@ -20,6 +20,7 @@ import { useUTXOs } from "@/hooks/useUTXOs";
 import { useBTCWallet, useETHWallet } from "../../context/wallet";
 import { useAppState } from "../../state/AppState";
 
+import { shouldShowInscriptionsToggle } from "./inscriptionToggle";
 import { resolveDisplayWallets } from "./resolveDisplayWallets";
 
 interface ConnectProps {
@@ -48,16 +49,17 @@ export const Connect: React.FC<ConnectProps> = ({ loading = false, text }) => {
 
   const isWalletConnected = btcConnected && ethConnected;
 
-  // Show the toggle when inscriptions are detected, or when the user has opted into
-  // including them (keeps the persisted preference changeable). Hidden for the default
-  // no-inscriptions case and during ordinals loading/error (toggling is a no-op then).
+  // Scope this subscription to when the menu can render; the query is shared
+  // (same key) with the deposit form, so this only adds an observer.
   const utxoOptions = useMemo(
     () => ({ enabled: isWalletConnected && !isGeoBlocked && !isGeoLoading }),
     [isWalletConnected, isGeoBlocked, isGeoLoading],
   );
   const { inscriptionUTXOs } = useUTXOs(btcAddress, utxoOptions);
-  const shouldShowInscriptionsToggle =
-    inscriptionUTXOs.length > 0 || !ordinalsExcluded;
+  const showInscriptionsToggle = shouldShowInscriptionsToggle(
+    inscriptionUTXOs.length,
+    ordinalsExcluded,
+  );
 
   // Icon source must stay aligned with the (provider-level) connection state:
   // `selectedWallets` is volatile widget state that can lag a reconnect on
@@ -110,7 +112,7 @@ export const Connect: React.FC<ConnectProps> = ({ loading = false, text }) => {
           ordinalsExcluded={ordinalsExcluded}
           onIncludeOrdinals={includeOrdinals}
           onExcludeOrdinals={excludeOrdinals}
-          showInscriptionsToggle={shouldShowInscriptionsToggle}
+          showInscriptionsToggle={showInscriptionsToggle}
           btcCoinSymbol="BTC"
           ethCoinSymbol="ETH"
           onDisconnect={disconnect}

--- a/services/vault/src/components/Wallet/Connect.tsx
+++ b/services/vault/src/components/Wallet/Connect.tsx
@@ -49,13 +49,18 @@ export const Connect: React.FC<ConnectProps> = ({ loading = false, text }) => {
 
   const isWalletConnected = btcConnected && ethConnected;
 
+  // Single source for both the UTXO query gate and the menu render branch below.
+  const canShowWalletMenu = isWalletConnected && !isGeoBlocked && !isGeoLoading;
+
   // Scope this subscription to when the menu can render; the query is shared
   // (same key) with the deposit form, so this only adds an observer.
   const utxoOptions = useMemo(
-    () => ({ enabled: isWalletConnected && !isGeoBlocked && !isGeoLoading }),
-    [isWalletConnected, isGeoBlocked, isGeoLoading],
+    () => ({ enabled: canShowWalletMenu }),
+    [canShowWalletMenu],
   );
   const { inscriptionUTXOs } = useUTXOs(btcAddress, utxoOptions);
+  // While ordinals are loading or errored, useUTXOs reports 0 inscriptions, so
+  // the toggle stays hidden then — fine, toggling is a no-op until it resolves.
   const showInscriptionsToggle = shouldShowInscriptionsToggle(
     inscriptionUTXOs.length,
     ordinalsExcluded,
@@ -79,7 +84,7 @@ export const Connect: React.FC<ConnectProps> = ({ loading = false, text }) => {
 
   // Show BtcEthWalletMenu when wallets are connected and not geo-blocked.
   // Address-blocked users still need the menu to disconnect and try a different wallet.
-  if (isWalletConnected && !isGeoBlocked && !isGeoLoading) {
+  if (canShowWalletMenu) {
     return (
       <div className="flex flex-row items-center gap-4">
         <BtcEthWalletMenu

--- a/services/vault/src/components/Wallet/Connect.tsx
+++ b/services/vault/src/components/Wallet/Connect.tsx
@@ -48,14 +48,16 @@ export const Connect: React.FC<ConnectProps> = ({ loading = false, text }) => {
 
   const isWalletConnected = btcConnected && ethConnected;
 
-  // Show the toggle only once detection confirms inscriptions exist. `inscriptionUTXOs`
-  // is empty while ordinals detection loads or errors, so it stays hidden then too —
-  // safe, since the toggle is a no-op when nothing is detected. `enabled` scopes this
-  // subscription to when the menu can render (the query is shared with the deposit form).
-  const { inscriptionUTXOs } = useUTXOs(btcAddress, {
-    enabled: isWalletConnected && !isGeoBlocked && !isGeoLoading,
-  });
-  const hasInscriptions = inscriptionUTXOs.length > 0;
+  // Show the toggle when inscriptions are detected, or when the user has opted into
+  // including them (keeps the persisted preference changeable). Hidden for the default
+  // no-inscriptions case and during ordinals loading/error (toggling is a no-op then).
+  const utxoOptions = useMemo(
+    () => ({ enabled: isWalletConnected && !isGeoBlocked && !isGeoLoading }),
+    [isWalletConnected, isGeoBlocked, isGeoLoading],
+  );
+  const { inscriptionUTXOs } = useUTXOs(btcAddress, utxoOptions);
+  const shouldShowInscriptionsToggle =
+    inscriptionUTXOs.length > 0 || !ordinalsExcluded;
 
   // Icon source must stay aligned with the (provider-level) connection state:
   // `selectedWallets` is volatile widget state that can lag a reconnect on
@@ -108,7 +110,7 @@ export const Connect: React.FC<ConnectProps> = ({ loading = false, text }) => {
           ordinalsExcluded={ordinalsExcluded}
           onIncludeOrdinals={includeOrdinals}
           onExcludeOrdinals={excludeOrdinals}
-          showInscriptionsToggle={hasInscriptions}
+          showInscriptionsToggle={shouldShowInscriptionsToggle}
           btcCoinSymbol="BTC"
           ethCoinSymbol="ETH"
           onDisconnect={disconnect}

--- a/services/vault/src/components/Wallet/__tests__/inscriptionToggle.test.ts
+++ b/services/vault/src/components/Wallet/__tests__/inscriptionToggle.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldShowInscriptionsToggle } from "../inscriptionToggle";
+
+describe("shouldShowInscriptionsToggle", () => {
+  it("shows the toggle when the wallet holds inscriptions and they are excluded", () => {
+    expect(shouldShowInscriptionsToggle(2, true)).toBe(true);
+  });
+
+  it("shows the toggle when the wallet holds inscriptions and they are included", () => {
+    expect(shouldShowInscriptionsToggle(2, false)).toBe(true);
+  });
+
+  it("hides the toggle for the default user with no detected inscriptions", () => {
+    expect(shouldShowInscriptionsToggle(0, true)).toBe(false);
+  });
+
+  it("keeps the toggle visible when the user opted in but none are detected", () => {
+    expect(shouldShowInscriptionsToggle(0, false)).toBe(true);
+  });
+});

--- a/services/vault/src/components/Wallet/inscriptionToggle.ts
+++ b/services/vault/src/components/Wallet/inscriptionToggle.ts
@@ -1,0 +1,14 @@
+/**
+ * Whether to show the "Using Inscriptions" toggle in the wallet menu.
+ *
+ * Shown when the wallet holds inscription UTXOs, or when the user has opted into
+ * including them (so the persisted preference stays changeable). Hidden in the
+ * default no-inscriptions case — and while ordinals detection is loading or has
+ * errored, since `inscriptionCount` is 0 then and toggling is a no-op anyway.
+ */
+export function shouldShowInscriptionsToggle(
+  inscriptionCount: number,
+  ordinalsExcluded: boolean,
+): boolean {
+  return inscriptionCount > 0 || !ordinalsExcluded;
+}

--- a/services/vault/src/components/Wallet/inscriptionToggle.ts
+++ b/services/vault/src/components/Wallet/inscriptionToggle.ts
@@ -1,10 +1,10 @@
 /**
  * Whether to show the "Using Inscriptions" toggle in the wallet menu.
  *
- * Shown when the wallet holds inscription UTXOs, or when the user has opted into
- * including them (so the persisted preference stays changeable). Hidden in the
- * default no-inscriptions case — and while ordinals detection is loading or has
- * errored, since `inscriptionCount` is 0 then and toggling is a no-op anyway.
+ * Shown when the wallet holds inscription UTXOs (`inscriptionCount > 0`), or when
+ * the user has opted into including them (`!ordinalsExcluded`) so the persisted
+ * preference stays changeable. Hidden otherwise. The loading/error case maps to
+ * `inscriptionCount === 0` upstream in `useUTXOs`; see the Connect call site.
  */
 export function shouldShowInscriptionsToggle(
   inscriptionCount: number,


### PR DESCRIPTION
The "Using Inscriptions" wallet-menu toggle always rendered, showing a
no-op control to users without any Ordinals/Runes (flagged in Korea
testnet feedback). Gate it on detected inscription UTXOs via a new
optional showInscriptionsToggle prop on core-ui's BtcEthWalletMenu.