### PR TITLE
feat(core-ui): add Notification severity primitive

### DIFF
--- a/packages/babylon-core-ui/src/components/Notification/Notification.stories.tsx
+++ b/packages/babylon-core-ui/src/components/Notification/Notification.stories.tsx
@@ -45,8 +45,8 @@ export const ErrorInlineActions: Story = {
     children:
       "BTC has dropped below your liquidation price ($88,400). Anyone can liquidate your position at any moment.",
     actions: [
-      { label: "Add Collateral", emphasis: "primary" },
-      { label: "Repay Debt", emphasis: "secondary" },
+      { label: "Add Collateral", emphasis: "primary", onClick: () => {} },
+      { label: "Repay Debt", emphasis: "secondary", onClick: () => {} },
     ],
   },
 };
@@ -129,7 +129,9 @@ export const SuggestionBelowActions: Story = {
       </>
     ),
     actionsPlacement: "below",
-    actions: [{ label: "Apply Suggested Order", emphasis: "primary" }],
+    actions: [
+      { label: "Apply Suggested Order", emphasis: "primary", onClick: () => {} },
+    ],
   },
 };
 

--- a/packages/babylon-core-ui/src/components/Notification/Notification.stories.tsx
+++ b/packages/babylon-core-ui/src/components/Notification/Notification.stories.tsx
@@ -1,0 +1,170 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { Text } from "../Text";
+
+import { Notification } from "./Notification";
+
+const meta: Meta<typeof Notification> = {
+  title: "Components/Data Display/Indicators/Notification",
+  component: Notification,
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: 760 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const SuggestionLabel = ({ children }: { children: string }) => (
+  <Text
+    variant="caption"
+    as="div"
+    className="uppercase tracking-0.4 text-accent-secondary"
+  >
+    {children}
+  </Text>
+);
+
+const OrderChip = ({ children }: { children: string }) => (
+  <span className="rounded-full bg-secondary-highlight px-3 py-1 text-accent-primary">
+    {children}
+  </span>
+);
+
+/** Critical severity with inline, severity-colored action pills (Figma: "Liquidation can trigger now"). */
+export const ErrorInlineActions: Story = {
+  args: {
+    variant: "error",
+    title: "Liquidation can trigger right now",
+    children:
+      "BTC has dropped below your liquidation price ($88,400). Anyone can liquidate your position at any moment.",
+    actions: [
+      { label: "Add Collateral", emphasis: "primary" },
+      { label: "Repay Debt", emphasis: "secondary" },
+    ],
+  },
+};
+
+/** Info notification with a dismiss control (Figma: "Position too small"). */
+export const InfoDismissible: Story = {
+  args: {
+    variant: "info",
+    title: "Position too small for vault analysis",
+    children: "Collateral or debt below $1,000",
+    onClose: () => {},
+  },
+};
+
+/** Soft-pause uses the teal `paused` variant (Figma: "Protocol is soft-paused"). */
+export const Paused: Story = {
+  args: {
+    variant: "paused",
+    title: "Protocol is soft-paused",
+    children: (
+      <>
+        New deposits, borrows, and withdrawals are disabled. You can{" "}
+        <u>still repay debt</u> — liquidations remain active. <u>Learn more</u>
+      </>
+    ),
+  },
+};
+
+/** Warning with an icon, a plain suggestion box, and a close control. */
+export const WarningWithSuggestion: Story = {
+  args: {
+    variant: "warning",
+    title: "Too many vaults to optimize",
+    children:
+      "You have 18 vaults. Beyond 17, the optimizer can't guarantee the best liquidation order — it falls back to a simpler largest-first approach. Your liquidation risk data is still accurate, but the order may not be optimal.",
+    suggestion:
+      "Consider consolidating smaller vaults into fewer larger ones — fewer vaults means lower fees and better optimization.",
+    onClose: () => {},
+  },
+};
+
+/** No icon chip + labeled suggestion box (Figma: "First liquidation takes everything"). */
+export const WarningNoIconWithLabel: Story = {
+  args: {
+    variant: "warning",
+    icon: null,
+    title: "First liquidation takes everything",
+    children:
+      "With your current vaults, a single liquidation event seizes all your BTC — nothing remains protected behind it.",
+    suggestion: (
+      <>
+        <SuggestionLabel>Suggestion</SuggestionLabel>
+        <Text variant="body2" as="div" className="text-accent-secondary">
+          To enable partial liquidation, withdraw your 0.70 BTC and re-deposit as
+          two smaller vaults: 0.40 BTC sacrificial + 0.30 BTC protected.
+        </Text>
+      </>
+    ),
+  },
+};
+
+/** Suggestion box with custom content + a severity-colored action below (Figma: "Reorder vaults"). */
+export const SuggestionBelowActions: Story = {
+  args: {
+    variant: "suggestion",
+    icon: null,
+    title: "Reorder vaults to lose less",
+    children:
+      "A different vault order makes the first liquidation event smaller — less BTC seized when it triggers.",
+    suggestion: (
+      <>
+        <SuggestionLabel>Suggested order</SuggestionLabel>
+        <div className="flex flex-wrap items-center gap-2">
+          <OrderChip>Vault 3 · 0.60 BTC</OrderChip>
+          <span className="text-accent-secondary">→</span>
+          <OrderChip>Vault 1 · 0.10 BTC</OrderChip>
+          <span className="text-accent-secondary">→</span>
+          <OrderChip>Vault 2 · 0.30 BTC</OrderChip>
+        </div>
+      </>
+    ),
+    actionsPlacement: "below",
+    actions: [{ label: "Apply Suggested Order", emphasis: "primary" }],
+  },
+};
+
+/** Success variant (not in Figma; included for completeness). */
+export const Success: Story = {
+  args: {
+    variant: "success",
+    title: "Position optimally structured",
+    children:
+      "BTC Vault ordering is correct and partial liquidation is enabled.",
+  },
+};
+
+/** Every severity, stacked, to compare accent treatments (note the error tint). */
+export const AllVariants: Story = {
+  render: () => (
+    <div className="flex flex-col gap-4">
+      <Notification variant="error" title="Error">
+        Critical, immediate-action notification.
+      </Notification>
+      <Notification variant="warning" title="Warning">
+        Something needs attention soon.
+      </Notification>
+      <Notification variant="info" title="Info">
+        Neutral, informational message.
+      </Notification>
+      <Notification variant="success" title="Success">
+        An action completed successfully.
+      </Notification>
+      <Notification variant="paused" title="Paused">
+        A soft, lower-urgency status update.
+      </Notification>
+      <Notification variant="suggestion" title="Suggestion">
+        An optional optimization the user can take.
+      </Notification>
+    </div>
+  ),
+};

--- a/packages/babylon-core-ui/src/components/Notification/Notification.tsx
+++ b/packages/babylon-core-ui/src/components/Notification/Notification.tsx
@@ -14,6 +14,13 @@ import {
 } from "../Icons";
 import { Text } from "../Text";
 
+import {
+  type NotificationAction,
+  NotificationActionButton,
+} from "./NotificationActionButton";
+
+export type { NotificationAction } from "./NotificationActionButton";
+
 export type NotificationVariant =
   | "error"
   | "warning"
@@ -23,17 +30,6 @@ export type NotificationVariant =
   | "suggestion";
 
 export type NotificationActionsPlacement = "inline" | "below";
-
-export interface NotificationAction {
-  label: ReactNode;
-  onClick?: () => void;
-  /**
-   * `primary` = filled with the variant accent color; `secondary` = outlined.
-   * Defaults to `primary`.
-   */
-  emphasis?: "primary" | "secondary";
-  disabled?: boolean;
-}
 
 export interface NotificationProps
   extends Omit<HTMLAttributes<HTMLDivElement>, "title"> {
@@ -127,31 +123,9 @@ const DEFAULT_ICON: Record<NotificationVariant, ComponentType<IconProps>> = {
   suggestion: InfoIcon,
 };
 
-const ACTION_BASE =
-  "rounded-full px-4 py-2 text-sm transition-colors disabled:cursor-not-allowed disabled:opacity-50";
-
-function ActionButton({
-  action,
-  accent,
-}: {
-  action: NotificationAction;
-  accent: VariantAccent;
-}) {
-  const { label, emphasis = "primary", onClick, disabled } = action;
-  const styles =
-    emphasis === "primary"
-      ? twMerge(ACTION_BASE, accent.accentBg, accent.onAccent, "hover:opacity-90")
-      : twMerge(
-          ACTION_BASE,
-          "border border-secondary-strokeLight text-accent-primary hover:bg-neutral-200",
-        );
-
-  return (
-    <button type="button" onClick={onClick} disabled={disabled} className={styles}>
-      {label}
-    </button>
-  );
-}
+// React drops `false`/`null`/`undefined`, but `0` and `""` are valid content —
+// gate optional slots on absence, not truthiness, so they are not swallowed.
+const isPresent = (node: ReactNode): boolean => node != null && node !== false;
 
 export function Notification({
   variant,
@@ -186,7 +160,12 @@ export function Notification({
   const alignClass = centerAlign ? "items-center" : "items-start";
 
   const actionButtons = actions?.map((action, index) => (
-    <ActionButton key={index} action={action} accent={accent} />
+    <NotificationActionButton
+      key={index}
+      action={action}
+      accentBg={accent.accentBg}
+      onAccent={accent.onAccent}
+    />
   ));
 
   return (
@@ -216,12 +195,12 @@ export function Notification({
 
         <div className="flex min-w-0 flex-1 flex-col gap-4">
           <div className="flex min-w-0 flex-col gap-1">
-            {title && (
+            {isPresent(title) && (
               <div className="break-words text-xl font-bold tracking-0.15 text-accent-primary">
                 {title}
               </div>
             )}
-            {children && (
+            {isPresent(children) && (
               <Text
                 as="div"
                 variant="body2"
@@ -232,7 +211,7 @@ export function Notification({
             )}
           </div>
 
-          {suggestion && (
+          {isPresent(suggestion) && (
             <div className="flex w-full flex-col gap-2 rounded-lg bg-neutral-200 p-4 text-accent-secondary">
               {suggestion}
             </div>

--- a/packages/babylon-core-ui/src/components/Notification/Notification.tsx
+++ b/packages/babylon-core-ui/src/components/Notification/Notification.tsx
@@ -1,0 +1,265 @@
+import {
+  type ComponentType,
+  type HTMLAttributes,
+  type ReactNode,
+} from "react";
+import { twMerge } from "tailwind-merge";
+
+import {
+  CheckIcon,
+  CloseIcon,
+  type IconProps,
+  InfoIcon,
+  WarningIcon,
+} from "../Icons";
+import { Text } from "../Text";
+
+export type NotificationVariant =
+  | "error"
+  | "warning"
+  | "info"
+  | "success"
+  | "paused"
+  | "suggestion";
+
+export type NotificationActionsPlacement = "inline" | "below";
+
+export interface NotificationAction {
+  label: ReactNode;
+  onClick?: () => void;
+  /**
+   * `primary` = filled with the variant accent color; `secondary` = outlined.
+   * Defaults to `primary`.
+   */
+  emphasis?: "primary" | "secondary";
+  disabled?: boolean;
+}
+
+export interface NotificationProps
+  extends Omit<HTMLAttributes<HTMLDivElement>, "title"> {
+  /** Severity — drives the left accent bar, icon chip, tint, and default icon. */
+  variant: NotificationVariant;
+  title?: ReactNode;
+  /** Description body. */
+  children?: ReactNode;
+  /** `undefined` shows the variant default icon; `null` hides the icon chip. */
+  icon?: ReactNode | null;
+  /** Action buttons — rendered as severity-aware pills. */
+  actions?: NotificationAction[];
+  /** `inline` = same row, right-aligned; `below` = stacked under the body. */
+  actionsPlacement?: NotificationActionsPlacement;
+  /** Nested sub-box rendered below the body (e.g. a suggestion/details panel). */
+  suggestion?: ReactNode;
+  /** When provided, renders a dismiss (X) control. */
+  onClose?: () => void;
+}
+
+// Gold has no core-ui theme token, so the "suggestion" variant uses a one-off
+// accent (Figma #ffb300). Kept as named constants because Tailwind needs the
+// arbitrary-value class strings to appear literally at build time.
+const SUGGESTION_BORDER = "border-[#ffb300]";
+const SUGGESTION_ACCENT_BG = "bg-[#ffb300]";
+
+// Text/icon color sitting on top of the accent: white on the dark/saturated
+// variants, dark on the light gold "suggestion" accent.
+const ON_DARK_ACCENT = "text-accent-contrast";
+const ON_LIGHT_ACCENT = "text-primary-main";
+
+interface VariantAccent {
+  /** Left accent bar color. */
+  border: string;
+  /** Background of the icon chip and of primary action buttons. */
+  accentBg: string;
+  /** Foreground color that sits on `accentBg`. */
+  onAccent: string;
+  /** Optional severity tint layered over the neutral card background. */
+  tint: string;
+}
+
+const VARIANT_ACCENT: Record<NotificationVariant, VariantAccent> = {
+  error: {
+    border: "border-error-main",
+    accentBg: "bg-error-main",
+    onAccent: ON_DARK_ACCENT,
+    // High-urgency variant gets a subtle red wash over the neutral card.
+    tint: "bg-gradient-to-r from-error-main/[0.06] to-error-main/[0.06]",
+  },
+  warning: {
+    border: "border-warning-main",
+    accentBg: "bg-warning-main",
+    onAccent: ON_DARK_ACCENT,
+    tint: "",
+  },
+  info: {
+    border: "border-info-main",
+    accentBg: "bg-info-main",
+    onAccent: ON_DARK_ACCENT,
+    tint: "",
+  },
+  success: {
+    border: "border-success-main",
+    accentBg: "bg-success-main",
+    onAccent: ON_DARK_ACCENT,
+    tint: "",
+  },
+  paused: {
+    border: "border-info-light",
+    accentBg: "bg-info-light",
+    onAccent: ON_DARK_ACCENT,
+    tint: "",
+  },
+  suggestion: {
+    border: SUGGESTION_BORDER,
+    accentBg: SUGGESTION_ACCENT_BG,
+    onAccent: ON_LIGHT_ACCENT,
+    tint: "",
+  },
+};
+
+const ICON_SIZE = 24;
+
+const DEFAULT_ICON: Record<NotificationVariant, ComponentType<IconProps>> = {
+  error: WarningIcon,
+  warning: InfoIcon,
+  info: InfoIcon,
+  success: CheckIcon,
+  paused: InfoIcon,
+  suggestion: InfoIcon,
+};
+
+const ACTION_BASE =
+  "rounded-full px-4 py-2 text-sm transition-colors disabled:cursor-not-allowed disabled:opacity-50";
+
+function ActionButton({
+  action,
+  accent,
+}: {
+  action: NotificationAction;
+  accent: VariantAccent;
+}) {
+  const { label, emphasis = "primary", onClick, disabled } = action;
+  const styles =
+    emphasis === "primary"
+      ? twMerge(ACTION_BASE, accent.accentBg, accent.onAccent, "hover:opacity-90")
+      : twMerge(
+          ACTION_BASE,
+          "border border-secondary-strokeLight text-accent-primary hover:bg-neutral-200",
+        );
+
+  return (
+    <button type="button" onClick={onClick} disabled={disabled} className={styles}>
+      {label}
+    </button>
+  );
+}
+
+export function Notification({
+  variant,
+  title,
+  icon,
+  actions,
+  actionsPlacement = "inline",
+  suggestion,
+  onClose,
+  className,
+  children,
+  role,
+  ...rest
+}: NotificationProps) {
+  const accent = VARIANT_ACCENT[variant];
+  const resolvedRole = role ?? (variant === "error" ? "alert" : "status");
+
+  const DefaultIcon = DEFAULT_ICON[variant];
+  const iconNode =
+    icon === null ? null : (
+      (icon ?? <DefaultIcon size={ICON_SIZE} color={accent.onAccent} />)
+    );
+
+  const hasActions = Boolean(actions && actions.length > 0);
+  const hasInlineActions = hasActions && actionsPlacement === "inline";
+  const hasBelowActions = hasActions && actionsPlacement === "below";
+
+  // Vertically center only in the simple inline case (icon + text + actions on
+  // one row); any stacked content — a suggestion box or a top-right close —
+  // top-aligns so the icon and close control sit at the top.
+  const centerAlign = hasInlineActions && !suggestion && !onClose;
+  const alignClass = centerAlign ? "items-center" : "items-start";
+
+  const actionButtons = actions?.map((action, index) => (
+    <ActionButton key={index} action={action} accent={accent} />
+  ));
+
+  return (
+    <div
+      role={resolvedRole}
+      className={twMerge(
+        "flex w-full gap-6 rounded-lg border-l-4 bg-secondary-highlight p-6",
+        accent.tint,
+        accent.border,
+        alignClass,
+        className,
+      )}
+      {...rest}
+    >
+      <div className={twMerge("flex min-w-0 flex-1 gap-4", alignClass)}>
+        {iconNode && (
+          <div
+            aria-hidden="true"
+            className={twMerge(
+              "flex shrink-0 items-center justify-center rounded-lg p-2.5",
+              accent.accentBg,
+            )}
+          >
+            {iconNode}
+          </div>
+        )}
+
+        <div className="flex min-w-0 flex-1 flex-col gap-4">
+          <div className="flex min-w-0 flex-col gap-1">
+            {title && (
+              <div className="break-words text-xl font-bold tracking-0.15 text-accent-primary">
+                {title}
+              </div>
+            )}
+            {children && (
+              <Text
+                as="div"
+                variant="body2"
+                className="break-words text-accent-secondary"
+              >
+                {children}
+              </Text>
+            )}
+          </div>
+
+          {suggestion && (
+            <div className="flex w-full flex-col gap-2 rounded-lg bg-neutral-200 p-4 text-accent-secondary">
+              {suggestion}
+            </div>
+          )}
+
+          {hasBelowActions && (
+            <div className="flex flex-wrap items-center gap-2">{actionButtons}</div>
+          )}
+        </div>
+      </div>
+
+      {hasInlineActions && (
+        <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
+          {actionButtons}
+        </div>
+      )}
+
+      {onClose && (
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Dismiss notification"
+          className="-mr-1 -mt-1 flex shrink-0 items-center justify-center rounded p-1 text-accent-secondary transition-colors hover:text-accent-primary"
+        >
+          <CloseIcon size={20} />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/packages/babylon-core-ui/src/components/Notification/NotificationActionButton.tsx
+++ b/packages/babylon-core-ui/src/components/Notification/NotificationActionButton.tsx
@@ -1,0 +1,51 @@
+import { type ReactNode } from "react";
+import { twMerge } from "tailwind-merge";
+
+export interface NotificationAction {
+  label: ReactNode;
+  /** Required so an action pill always does something when activated. */
+  onClick: () => void;
+  /**
+   * `primary` = filled with the variant accent color; `secondary` = outlined.
+   * Defaults to `primary`.
+   */
+  emphasis?: "primary" | "secondary";
+  disabled?: boolean;
+}
+
+const ACTION_BASE =
+  "rounded-full px-4 py-2 text-sm transition-colors disabled:cursor-not-allowed disabled:opacity-50";
+
+export interface NotificationActionButtonProps {
+  action: NotificationAction;
+  /** Background applied to a `primary` action (the variant accent). */
+  accentBg: string;
+  /** Foreground that sits on `accentBg` for a `primary` action. */
+  onAccent: string;
+}
+
+export function NotificationActionButton({
+  action,
+  accentBg,
+  onAccent,
+}: NotificationActionButtonProps) {
+  const { label, emphasis = "primary", onClick, disabled } = action;
+  const styles =
+    emphasis === "primary"
+      ? twMerge(ACTION_BASE, accentBg, onAccent, "hover:opacity-90")
+      : twMerge(
+          ACTION_BASE,
+          "border border-secondary-strokeLight text-accent-primary hover:bg-neutral-200",
+        );
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className={styles}
+    >
+      {label}
+    </button>
+  );
+}

--- a/packages/babylon-core-ui/src/components/Notification/index.ts
+++ b/packages/babylon-core-ui/src/components/Notification/index.ts
@@ -1,0 +1,7 @@
+export { Notification } from "./Notification";
+export type {
+  NotificationProps,
+  NotificationVariant,
+  NotificationAction,
+  NotificationActionsPlacement,
+} from "./Notification";

--- a/packages/babylon-core-ui/src/index.tsx
+++ b/packages/babylon-core-ui/src/index.tsx
@@ -31,6 +31,7 @@ export * from "./components/DisplayHash";
 export * from "./components/Copy";
 export * from "./components/Icons";
 export * from "./components/Callout";
+export * from "./components/Notification";
 export * from "./components/Warning";
 export * from "./components/Hint";
 export * from "./components/DismissibleSubSection";


### PR DESCRIPTION
Add a dashboard-level Notification component: left severity accent bar, icon chip, title/description, optional suggestion sub-box, optional dismiss control, and severity-aware action pills.

Variants: error (with subtle red tint), warning, info, success, paused (teal), and suggestion (gold). Actions are passed as a structured NotificationAction[] and rendered as primary (accent-filled) or secondary (outlined) pills, so consumers never hand-style severity colors. Storybook stories cover every severity and slot combination.

## Screenshot

<img width="1154" height="871" alt="Screenshot 2026-06-24 at 18 16 27" src="https://github.com/user-attachments/assets/6a81931f-a5e7-4471-8c6f-9edcfc5792c4" />
