### PR TITLE
fix(wallet-connector): route single-PSBT signPsbts through signPsbt f…

### DIFF
--- a/packages/babylon-wallet-connector/src/core/wallets/btc/onekey/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/onekey/provider.ts
@@ -251,6 +251,12 @@ export class OneKeyProvider implements IBTCProvider {
       });
     }
 
+    // OneKey renders a blank popup for signPsbts with a single-element
+    // array. Route through signPsbt instead.
+    if (psbtsHexes.length === 1) {
+      return [await this.signPsbt(psbtsHexes[0], options?.[0])];
+    }
+
     // If options provided, map them to OneKey format
     if (options && options.length > 0) {
       const onekeyOptions = options.map((opt) => {


### PR DESCRIPTION
- OneKey shows a blank popup when `signPsbts` is called with a single-element
  array (e.g. single-vault deposit), introduced by #1875 which routes all
  peg-in signing through native `signPsbts`.
- Fix lives entirely in `OneKeyProvider.signPsbts`: a single-element array is
  delegated to `signPsbt`, which OneKey renders correctly. The fix sits at the
  single chokepoint all batch flows pass through, so no SDK-level guards are
  needed.