### PR TITLE
feat(vault): critical near-liquidation top banner

### DIFF
--- a/packages/babylon-core-ui/src/components/TopBanner/TopBanner.stories.tsx
+++ b/packages/babylon-core-ui/src/components/TopBanner/TopBanner.stories.tsx
@@ -56,3 +56,13 @@ export const Hidden: Story = {
     onDismiss: () => console.log("Banner dismissed"),
   },
 };
+
+// Omitting `onDismiss` renders a non-dismissible banner (no close button) — e.g.
+// a critical alert the user must not be able to hide.
+export const NonDismissible: Story = {
+  args: {
+    visible: true,
+    message: "Critical — liquidation in 4.3%",
+    onClick: () => console.log("Banner clicked"),
+  },
+};

--- a/packages/babylon-core-ui/src/components/TopBanner/TopBanner.stories.tsx
+++ b/packages/babylon-core-ui/src/components/TopBanner/TopBanner.stories.tsx
@@ -57,12 +57,13 @@ export const Hidden: Story = {
   },
 };
 
-// Omitting `onDismiss` renders a non-dismissible banner (no close button) — e.g.
-// a critical alert the user must not be able to hide.
-export const NonDismissible: Story = {
+// A non-interactive alert: no `onDismiss` (no close button) and no `onClick`, so
+// it isn't a focusable/clickable button. `role="alert"` lets assistive tech
+// announce it — e.g. a critical warning the user must not be able to hide.
+export const NonDismissibleAlert: Story = {
   args: {
     visible: true,
     message: "Critical — liquidation in 4.3%",
-    onClick: () => console.log("Banner clicked"),
+    role: "alert",
   },
 };

--- a/packages/babylon-core-ui/src/components/TopBanner/TopBanner.tsx
+++ b/packages/babylon-core-ui/src/components/TopBanner/TopBanner.tsx
@@ -30,6 +30,13 @@ export interface TopBannerProps {
    * Optional custom icon
    */
   icon?: React.ReactNode;
+  /**
+   * Optional ARIA role for the banner wrapper. Use for a non-interactive banner
+   * that should still be announced — e.g. `"alert"` for a critical warning. When
+   * omitted, a clickable banner is exposed as a `button` and a non-clickable one
+   * carries no role.
+   */
+  role?: React.AriaRole;
 }
 
 export const TopBanner = ({
@@ -39,6 +46,7 @@ export const TopBanner = ({
   onDismiss,
   className,
   icon,
+  role,
 }: TopBannerProps) => {
   if (!visible) {
     return null;
@@ -59,7 +67,7 @@ export const TopBanner = ({
         className,
       )}
       onClick={onClick}
-      role={isClickable ? "button" : undefined}
+      role={role ?? (isClickable ? "button" : undefined)}
       tabIndex={isClickable ? 0 : undefined}
     >
       <div className="bbn-top-banner-content">

--- a/packages/babylon-core-ui/src/components/TopBanner/TopBanner.tsx
+++ b/packages/babylon-core-ui/src/components/TopBanner/TopBanner.tsx
@@ -13,13 +13,15 @@ export interface TopBannerProps {
    */
   message: string;
   /**
-   * Callback when banner is clicked
+   * Callback when banner is clicked. Omit for a non-interactive banner — the
+   * banner then drops its `button` role and pointer affordance.
    */
-  onClick: () => void;
+  onClick?: () => void;
   /**
-   * Callback when banner is dismissed
+   * Callback when banner is dismissed. Omit to render a non-dismissible banner
+   * (no close button) — e.g. a critical alert the user must not be able to hide.
    */
-  onDismiss: () => void;
+  onDismiss?: () => void;
   /**
    * Optional custom className
    */
@@ -44,15 +46,21 @@ export const TopBanner = ({
 
   const handleDismiss = (e: React.MouseEvent) => {
     e.stopPropagation();
-    onDismiss();
+    onDismiss?.();
   };
+
+  const isClickable = Boolean(onClick);
 
   return (
     <div
-      className={twJoin("bbn-top-banner", className)}
+      className={twJoin(
+        "bbn-top-banner",
+        !isClickable && "!cursor-default",
+        className,
+      )}
       onClick={onClick}
-      role="button"
-      tabIndex={0}
+      role={isClickable ? "button" : undefined}
+      tabIndex={isClickable ? 0 : undefined}
     >
       <div className="bbn-top-banner-content">
         {icon}
@@ -60,14 +68,16 @@ export const TopBanner = ({
           {message}
         </Text>
       </div>
-      <button
-        onClick={handleDismiss}
-        className="bbn-top-banner-dismiss-btn"
-        aria-label="Dismiss banner"
-        type="button"
-      >
-        <CloseIcon size={16} className="bbn-top-banner-dismiss-icon" />
-      </button>
+      {onDismiss && (
+        <button
+          onClick={handleDismiss}
+          className="bbn-top-banner-dismiss-btn"
+          aria-label="Dismiss banner"
+          type="button"
+        >
+          <CloseIcon size={16} className="bbn-top-banner-dismiss-icon" />
+        </button>
+      )}
     </div>
   );
 };

--- a/services/vault/src/components/pages/RootLayout.tsx
+++ b/services/vault/src/components/pages/RootLayout.tsx
@@ -18,6 +18,7 @@ import { twJoin } from "tailwind-merge";
 
 import { DepositButton } from "@/components/shared";
 import { PAGE_CONTENT_CLASS } from "@/components/shared/layoutClasses";
+import { CRITICAL_BANNER_SLOT_ID } from "@/components/simple/CriticalLiquidationTopBanner";
 import {
   FeatureFlags,
   getNetworkConfigBTC,
@@ -121,6 +122,10 @@ export default function RootLayout() {
   return (
     <div className="relative h-full min-h-svh w-full bg-surface">
       <div className="flex min-h-svh flex-col">
+        {/* Portal target for the critical near-liquidation banner. Owned by the
+            dashboard (where the Aave data + debug override live) but portaled
+            here so it renders above the header, atop the operational banners. */}
+        <div id={CRITICAL_BANNER_SLOT_ID} />
         <TestingBanner visible={shouldDisplayTestingMsg()} />
         <AddressScreeningBanner
           visible={!isGeoBlocked && isWalletConnected && isAddressBlocked}

--- a/services/vault/src/components/simple/CriticalLiquidationTopBanner/CriticalLiquidationTopBanner.tsx
+++ b/services/vault/src/components/simple/CriticalLiquidationTopBanner/CriticalLiquidationTopBanner.tsx
@@ -23,18 +23,17 @@ interface CriticalLiquidationTopBannerProps {
    * shows only when this resolves to a `red` (urgent) banner severity.
    */
   result: CalculatorResult | null;
-  /** Scroll the detailed position banner into view when the strip is clicked. */
-  onShowDetails: () => void;
 }
 
 /**
  * Full-width critical (near-liquidation) banner shown above the header when the
- * position is at `red` severity. Non-dismissible by design — an imminent
- * liquidation warning the user must not be able to hide.
+ * position is at `red` severity. A non-interactive `role="alert"` so assistive
+ * tech announces it; non-dismissible by design — an imminent liquidation warning
+ * the user must not be able to hide. The actionable Add Collateral / Repay Debt
+ * controls live on the detailed position banner below.
  */
 export function CriticalLiquidationTopBanner({
   result,
-  onShowDetails,
 }: CriticalLiquidationTopBannerProps) {
   // The portal target lives in RootLayout (mounted before this component);
   // resolve it on mount so we can portal into it once available.
@@ -63,8 +62,8 @@ export function CriticalLiquidationTopBanner({
   return createPortal(
     <TopBanner
       visible
+      role="alert"
       message={message}
-      onClick={onShowDetails}
       icon={<IoWarning size={20} className="shrink-0 text-white" />}
       // error-dark (#C62828) matches the Figma critical-banner fill; force white
       // text over it (the base banner message defaults to accent-primary) and a

--- a/services/vault/src/components/simple/CriticalLiquidationTopBanner/CriticalLiquidationTopBanner.tsx
+++ b/services/vault/src/components/simple/CriticalLiquidationTopBanner/CriticalLiquidationTopBanner.tsx
@@ -1,0 +1,76 @@
+import { TopBanner } from "@babylonlabs-io/core-ui";
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import { IoWarning } from "react-icons/io5";
+
+import {
+  deriveBannerState,
+  type CalculatorResult,
+} from "@/applications/aave/positionNotifications";
+import { COPY } from "@/copy";
+import { formatLiquidationDistancePercent } from "@/utils/formatting";
+
+/**
+ * DOM id of the slot RootLayout renders above the header. This banner portals
+ * into it so a dashboard-scoped component (which has the Aave providers + the
+ * debug override) can render visually above the app header.
+ */
+export const CRITICAL_BANNER_SLOT_ID = "critical-liquidation-banner-slot";
+
+interface CriticalLiquidationTopBannerProps {
+  /**
+   * Effective position-notification result (debug override ?? live). The banner
+   * shows only when this resolves to a `red` (urgent) banner severity.
+   */
+  result: CalculatorResult | null;
+  /** Scroll the detailed position banner into view when the strip is clicked. */
+  onShowDetails: () => void;
+}
+
+/**
+ * Full-width critical (near-liquidation) banner shown above the header when the
+ * position is at `red` severity. Non-dismissible by design — an imminent
+ * liquidation warning the user must not be able to hide.
+ */
+export function CriticalLiquidationTopBanner({
+  result,
+  onShowDetails,
+}: CriticalLiquidationTopBannerProps) {
+  // The portal target lives in RootLayout (mounted before this component);
+  // resolve it on mount so we can portal into it once available.
+  const [slot, setSlot] = useState<HTMLElement | null>(null);
+  useEffect(() => {
+    setSlot(document.getElementById(CRITICAL_BANNER_SLOT_ID));
+  }, []);
+
+  const bannerState = result ? deriveBannerState(result) : null;
+  const firstGroup = result?.groups[0] ?? null;
+
+  if (!slot || bannerState?.severity !== "red" || !firstGroup) {
+    return null;
+  }
+
+  // distancePct is negative while approaching liquidation and >= 0 once the
+  // position is already liquidatable (same sign convention the dashboard gauge
+  // uses), so negate it before formatting the remaining buffer.
+  const message =
+    firstGroup.distancePct >= 0
+      ? COPY.topBanner.liquidatable
+      : COPY.topBanner.critical(
+          formatLiquidationDistancePercent(-firstGroup.distancePct),
+        );
+
+  return createPortal(
+    <TopBanner
+      visible
+      message={message}
+      onClick={onShowDetails}
+      icon={<IoWarning size={20} className="shrink-0 text-white" />}
+      // error-dark (#C62828) matches the Figma critical-banner fill; force white
+      // text over it (the base banner message defaults to accent-primary) and a
+      // slim strip (40px tall, 8px vertical padding) to match the design.
+      className="!h-10 bg-error-dark !py-2 [&_.bbn-top-banner-message]:!font-semibold [&_.bbn-top-banner-message]:!text-white"
+    />,
+    slot,
+  );
+}

--- a/services/vault/src/components/simple/CriticalLiquidationTopBanner/index.ts
+++ b/services/vault/src/components/simple/CriticalLiquidationTopBanner/index.ts
@@ -1,0 +1,4 @@
+export {
+  CRITICAL_BANNER_SLOT_ID,
+  CriticalLiquidationTopBanner,
+} from "./CriticalLiquidationTopBanner";

--- a/services/vault/src/components/simple/DashboardPage.tsx
+++ b/services/vault/src/components/simple/DashboardPage.tsx
@@ -36,6 +36,7 @@ import {
 } from "@/utils/formatting";
 
 import { CollateralSection } from "./CollateralSection";
+import { CriticalLiquidationTopBanner } from "./CriticalLiquidationTopBanner";
 import { DisconnectedOverview } from "./DisconnectedOverview";
 import { LoansSection } from "./LoansSection";
 import { OverviewSection } from "./OverviewSection";
@@ -88,6 +89,10 @@ export function DashboardPage() {
   const liquidationNotificationsEnabled =
     featureFlags.isLiquidationNotificationsEnabled;
 
+  // Feed the critical top banner the same debug-aware result the mid-page banner
+  // uses: the debug override when set, otherwise the live calculation.
+  const criticalBannerResult = debugResultOverride ?? positionNotifications;
+
   const { vaults: aaveVaults, redeemedVaults } = useAaveVaults(
     isConnected ? address : undefined,
   );
@@ -136,6 +141,12 @@ export function DashboardPage() {
   const pctToLiquidation = firstLiquidationGroup
     ? formatLiquidationDistancePercent(-firstLiquidationGroup.distancePct)
     : COPY.common.emptyValue;
+
+  const scrollToPositionBanner = useCallback(() => {
+    document
+      .querySelector('[data-testid="position-notification-banner"]')
+      ?.scrollIntoView({ behavior: "smooth", block: "center" });
+  }, []);
 
   const handleOpenWithdraw = useCallback(() => {
     setIsWithdrawOpen(true);
@@ -193,6 +204,13 @@ export function DashboardPage() {
           btcPrice={btcPrice}
           pctToLiquidation={pctToLiquidation}
         />
+
+        {liquidationNotificationsEnabled && (
+          <CriticalLiquidationTopBanner
+            result={criticalBannerResult}
+            onShowDetails={scrollToPositionBanner}
+          />
+        )}
 
         {liquidationNotificationsEnabled && (
           <PositionNotificationBanner

--- a/services/vault/src/components/simple/DashboardPage.tsx
+++ b/services/vault/src/components/simple/DashboardPage.tsx
@@ -142,12 +142,6 @@ export function DashboardPage() {
     ? formatLiquidationDistancePercent(-firstLiquidationGroup.distancePct)
     : COPY.common.emptyValue;
 
-  const scrollToPositionBanner = useCallback(() => {
-    document
-      .querySelector('[data-testid="position-notification-banner"]')
-      ?.scrollIntoView({ behavior: "smooth", block: "center" });
-  }, []);
-
   const handleOpenWithdraw = useCallback(() => {
     setIsWithdrawOpen(true);
   }, []);
@@ -206,10 +200,7 @@ export function DashboardPage() {
         />
 
         {liquidationNotificationsEnabled && (
-          <CriticalLiquidationTopBanner
-            result={criticalBannerResult}
-            onShowDetails={scrollToPositionBanner}
-          />
+          <CriticalLiquidationTopBanner result={criticalBannerResult} />
         )}
 
         {liquidationNotificationsEnabled && (

--- a/services/vault/src/components/simple/__tests__/CriticalLiquidationTopBanner.test.tsx
+++ b/services/vault/src/components/simple/__tests__/CriticalLiquidationTopBanner.test.tsx
@@ -66,7 +66,6 @@ describe("CriticalLiquidationTopBanner", () => {
     render(
       <CriticalLiquidationTopBanner
         result={makeResult({ distancePct: -4.3, urgent: true })}
-        onShowDetails={() => {}}
       />,
     );
 
@@ -75,11 +74,20 @@ describe("CriticalLiquidationTopBanner", () => {
     ).toBeInTheDocument();
   });
 
+  it("exposes the banner as an alert for assistive tech", () => {
+    render(
+      <CriticalLiquidationTopBanner
+        result={makeResult({ distancePct: -4.3, urgent: true })}
+      />,
+    );
+
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+  });
+
   it("shows the imminent message when already liquidatable (distancePct >= 0)", () => {
     render(
       <CriticalLiquidationTopBanner
         result={makeResult({ distancePct: 1.2, urgent: true })}
-        onShowDetails={() => {}}
       />,
     );
 
@@ -92,7 +100,6 @@ describe("CriticalLiquidationTopBanner", () => {
     render(
       <CriticalLiquidationTopBanner
         result={makeResult({ distancePct: -30, urgent: false })}
-        onShowDetails={() => {}}
       />,
     );
 
@@ -103,7 +110,6 @@ describe("CriticalLiquidationTopBanner", () => {
     render(
       <CriticalLiquidationTopBanner
         result={makeResult({ distancePct: -4.3, urgent: true })}
-        onShowDetails={() => {}}
       />,
     );
 

--- a/services/vault/src/components/simple/__tests__/CriticalLiquidationTopBanner.test.tsx
+++ b/services/vault/src/components/simple/__tests__/CriticalLiquidationTopBanner.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * Tests for the critical near-liquidation top banner: it surfaces only at `red`
+ * severity, picks the approaching-vs-liquidatable copy from the first group's
+ * distance-to-liquidation, and is non-dismissible (no close button).
+ */
+
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { CalculatorResult } from "@/applications/aave/positionNotifications";
+
+import {
+  CRITICAL_BANNER_SLOT_ID,
+  CriticalLiquidationTopBanner,
+} from "../CriticalLiquidationTopBanner";
+
+// Minimal CalculatorResult: deriveBannerState keys severity off `warnings`
+// (an "urgent" warning ⇒ red) while the banner reads `groups[0].distancePct`.
+function makeResult({
+  distancePct,
+  urgent,
+}: {
+  distancePct: number;
+  urgent: boolean;
+}): CalculatorResult {
+  return {
+    groups: [
+      {
+        index: 0,
+        vaults: [],
+        combinedBtc: 1,
+        liquidationPrice: 80621,
+        distancePct,
+        targetSeizureBtc: 0,
+        overSeizureBtc: 0,
+        isFullLiquidation: false,
+        debtToRepay: 0,
+        liquidatorProfitUsd: 0,
+        debtRepaid: 0,
+        fairnessDebtRepay: 0,
+        fairnessPaymentUsd: 0,
+        debtRemainingAfter: 0,
+        btcRemainingAfter: 0,
+      },
+    ],
+    currentHF: 1.1,
+    collateralValue: 100000,
+    targetSeizureBtc: 0,
+    warnings: urgent ? [{ type: "urgent", title: "x", detail: "y" }] : [],
+    suggestedVaultOrder: null,
+  };
+}
+
+describe("CriticalLiquidationTopBanner", () => {
+  beforeEach(() => {
+    const slot = document.createElement("div");
+    slot.id = CRITICAL_BANNER_SLOT_ID;
+    document.body.appendChild(slot);
+  });
+
+  afterEach(() => {
+    document.getElementById(CRITICAL_BANNER_SLOT_ID)?.remove();
+  });
+
+  it("shows the remaining distance when approaching liquidation (negative distancePct)", () => {
+    render(
+      <CriticalLiquidationTopBanner
+        result={makeResult({ distancePct: -4.3, urgent: true })}
+        onShowDetails={() => {}}
+      />,
+    );
+
+    expect(
+      screen.getByText("Critical — liquidation in 4.3%"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the imminent message when already liquidatable (distancePct >= 0)", () => {
+    render(
+      <CriticalLiquidationTopBanner
+        result={makeResult({ distancePct: 1.2, urgent: true })}
+        onShowDetails={() => {}}
+      />,
+    );
+
+    expect(
+      screen.getByText("Critical — liquidation can trigger now"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders nothing when severity is not red", () => {
+    render(
+      <CriticalLiquidationTopBanner
+        result={makeResult({ distancePct: -30, urgent: false })}
+        onShowDetails={() => {}}
+      />,
+    );
+
+    expect(screen.queryByText(/Critical —/)).not.toBeInTheDocument();
+  });
+
+  it("is non-dismissible — renders no close button", () => {
+    render(
+      <CriticalLiquidationTopBanner
+        result={makeResult({ distancePct: -4.3, urgent: true })}
+        onShowDetails={() => {}}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Dismiss banner" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -968,6 +968,14 @@ export const COPY = {
       tooltip: "Bonus percentage awarded to liquidators on seized collateral.",
     },
   },
+  // Full-width critical banner rendered above the header when the position is at
+  // imminent liquidation risk (red severity). The warning glyph is supplied via
+  // the banner's icon slot, not the message string.
+  topBanner: {
+    critical: (distancePct: string) =>
+      `Critical — liquidation in ${distancePct}`,
+    liquidatable: "Critical — liquidation can trigger now",
+  },
   // Liquidation-notification warnings shown in the position banner. Mirrors the
   // three warning types produced by the calculator (urgent / dust / weird-params).
   liquidationWarnings: {


### PR DESCRIPTION
Closes https://github.com/babylonlabs-io/babylon-toolkit/issues/1946

<img width="1071" height="1162" alt="Screenshot_2026-06-24_16-38-53" src="https://github.com/user-attachments/assets/8d3d8f60-eb04-4205-8a52-45d5ad1679de" />

<img width="1071" height="1162" alt="Screenshot_2026-06-24_16-38-46" src="https://github.com/user-attachments/assets/f0c2bb60-5818-4987-942d-b9c8066b2a31" />

## What this does

Adds a full-width red banner above the app header that warns the user when their position is close to liquidation — for example "⚠ Critical — liquidation in 4.3%". It only appears when the position is at critical (red) risk, and it cannot be dismissed while critical.

## Why

When a position is near liquidation the user can lose BTC, so this warning needs to be impossible to miss. The existing position notification lives in the middle of the dashboard, below the fold; this banner puts the same critical signal at the very top of the screen where the user sees it immediately. It is the first item in the notification design set.

## Scope (important for the reviewer)

The Figma "URGENT" screen shows two things: the top red strip (this PR) and a detailed callout box ("Liquidation is 4.3% away" with Add Collateral / Repay Debt buttons). Those are two separate issues. This PR only builds the top red strip. The detailed callout already exists in code today and its Figma restyle is tracked separately in https://github.com/babylonlabs-io/babylon-toolkit/issues/1947 — it is not touched here.

## How it works

The banner reuses the data the dashboard already computes (`usePositionNotifications` → `deriveBannerState`). When the severity is "red" it reads the distance-to-liquidation and renders the strip; otherwise it renders nothing. The text and percentage stay in sync with the existing mid-page banner because both read the exact same severity source.

## The main design decision (and why)

The banner has to appear above the header, but the data it needs (the Aave position providers) only exists inside the dashboard route, lower in the tree. So a component placed at the header level cannot read that data directly. We considered two approaches:

- Approach A (chosen): keep the banner owned by the dashboard (where the data and the debug override already live) and "portal" its output up into a small slot rendered above the header. No provider changes, no second data fetch, and it automatically works with the existing debug panel because it shares the same override the mid-page banner uses.
- Approach B (rejected): move the Aave providers and a new shared notifications context above the header so a header-level component could fetch the data itself. This is cleaner in theory (single source of truth) but it changes how those providers mount for the whole app and touches the router — more risk and a bigger change than this banner warrants.

We chose A because it is the smallest, lowest-risk change and it keeps the debug panel working out of the box, which was an explicit requirement.

## Notable detail: non-dismissible

Per design, the user must not be able to hide an imminent-liquidation warning, so the banner has no close button. The shared core-ui `TopBanner` previously always rendered a close button, so it was changed to make the close (and click) optional. This is backward compatible — the only other user of `TopBanner` still passes those callbacks and keeps its close button.

## Changes

- `packages/babylon-core-ui` — `TopBanner`: `onDismiss` and `onClick` are now optional; the close button renders only when `onDismiss` is provided. Added a story for the non-dismissible variant.
- `services/vault` — new `CriticalLiquidationTopBanner` component that portals the red strip above the header and shows only at red severity.
- `services/vault` — `RootLayout`: added the portal slot at the top of the banner stack.
- `services/vault` — `DashboardPage`: feeds the banner the same debug-aware result as the existing banner, plus a click handler that scrolls down to the detailed notification.
- `services/vault` — `copy.ts`: added the banner strings.
- Tests for the new component.

## How to test it

Run the vault app with `NEXT_PUBLIC_FF_ENABLE_LIQUIDATION_NOTIFICATIONS=true` and `NEXT_PUBLIC_FF_POSITION_DEBUG_PANEL=true`. Open the debug panel, switch to manual mode, and push the position into the red (near-liquidation) range. You should see the red strip appear above the header (with no close button) at the same time as the existing mid-page banner, both showing the same percentage. Move the position back out of the red range and both disappear.

## Related

- Depends conceptually on the shared notification primitive in https://github.com/babylonlabs-io/babylon-toolkit/issues/1955
- Pairs with the detailed callout restyle in https://github.com/babylonlabs-io/babylon-toolkit/issues/1947
