### PR TITLE
feat(vault): liquidation callout via the Notification primitive

### DIFF
--- a/services/vault/src/components/simple/PositionNotificationBanner/BannerActions.tsx
+++ b/services/vault/src/components/simple/PositionNotificationBanner/BannerActions.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@babylonlabs-io/core-ui";
+import type { NotificationAction } from "@babylonlabs-io/core-ui";
 
 import type {
   BannerState,
@@ -6,7 +6,7 @@ import type {
 } from "@/applications/aave/positionNotifications";
 import { COPY } from "@/copy";
 
-interface BannerActionsProps {
+interface BuildBannerActionsArgs {
   result: CalculatorResult;
   bannerState: BannerState;
   onDeposit: (initialAmountBtc?: string) => void;
@@ -16,51 +16,55 @@ interface BannerActionsProps {
 }
 
 /**
- * Renders the manual actions for the position banner:
- * - urgent: "Add Collateral" + "Repay Debt" (core safety actions)
- * - suggested reorder available: "Apply Suggested Order" (manual approve)
+ * Build the manual action pills for the position banner, fed to the core-ui
+ * `Notification` `actions` slot:
+ * - urgent: "Add Collateral" (primary, filled) + "Repay Debt" (secondary,
+ *   outlined) — the core safety actions, matching the Figma callout.
+ * - suggested reorder available: "Apply Suggested Order" (secondary) — manual
+ *   approve.
  *
- * Both can appear together (urgent position whose order is also suboptimal).
+ * Both groups can appear together (an urgent position whose order is also
+ * suboptimal).
  */
-export function BannerActions({
+export function buildBannerActions({
   result,
   bannerState,
   onDeposit,
   onRepay,
   onApplyOrder,
   isReordering,
-}: BannerActionsProps) {
+}: BuildBannerActionsArgs): NotificationAction[] {
   const { primaryWarning, suggestReorder } = bannerState;
-
   const isUrgent = primaryWarning?.type === "urgent";
   const showApplyOrder = suggestReorder && result.suggestedVaultOrder !== null;
 
-  if (!isUrgent && !showApplyOrder) return null;
+  const actions: NotificationAction[] = [];
 
-  return (
-    <div className="mt-3 flex items-center gap-2">
-      {isUrgent && (
-        <>
-          <Button variant="outlined" size="small" onClick={() => onDeposit()}>
-            {COPY.banner.addCollateral}
-          </Button>
-          <Button variant="outlined" size="small" onClick={onRepay}>
-            {COPY.banner.repayDebt}
-          </Button>
-        </>
-      )}
-      {showApplyOrder && (
-        <Button
-          variant="outlined"
-          size="small"
-          onClick={onApplyOrder}
-          disabled={isReordering}
-        >
-          {isReordering
-            ? COPY.common.applying
-            : COPY.banner.applySuggestedOrder}
-        </Button>
-      )}
-    </div>
-  );
+  if (isUrgent) {
+    actions.push(
+      {
+        label: COPY.banner.addCollateral,
+        onClick: () => onDeposit(),
+        emphasis: "primary",
+      },
+      {
+        label: COPY.banner.repayDebt,
+        onClick: onRepay,
+        emphasis: "secondary",
+      },
+    );
+  }
+
+  if (showApplyOrder) {
+    actions.push({
+      label: isReordering
+        ? COPY.common.applying
+        : COPY.banner.applySuggestedOrder,
+      onClick: onApplyOrder,
+      emphasis: "secondary",
+      disabled: isReordering,
+    });
+  }
+
+  return actions;
 }

--- a/services/vault/src/components/simple/PositionNotificationBanner/PositionNotificationBanner.tsx
+++ b/services/vault/src/components/simple/PositionNotificationBanner/PositionNotificationBanner.tsx
@@ -1,4 +1,7 @@
-import { Text } from "@babylonlabs-io/core-ui";
+import {
+  Notification,
+  type NotificationVariant,
+} from "@babylonlabs-io/core-ui";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useState } from "react";
 import type { Address, Hex } from "viem";
@@ -12,6 +15,7 @@ import {
 import { useReorderVaults } from "@/applications/aave/hooks/useReorderVaults";
 import {
   deriveBannerState,
+  type BannerSeverity,
   type CalculatorResult,
 } from "@/applications/aave/positionNotifications";
 import { COPY } from "@/copy";
@@ -19,14 +23,30 @@ import { invalidateVaultQueries } from "@/utils/queryKeys";
 
 import { ReorderSuccessModal } from "../ReorderVaults";
 
-import { BannerActions } from "./BannerActions";
+import { buildBannerActions } from "./BannerActions";
 import {
   GREEN_BANNER_DETAIL,
   GREEN_BANNER_TITLE,
-  SEVERITY_STYLES,
   STALE_PRICE_BANNER_DETAIL,
   STALE_PRICE_BANNER_TITLE,
 } from "./constants";
+
+const TEST_ID = "position-notification-banner";
+
+// Map the calculator's banner severity to a core-ui Notification variant. `red`
+// is the urgent Figma callout (error), `soft` advisories render as info, `green`
+// as success. `yellow` only arises from the stale-price status path (handled
+// separately below with an early return) — mapped here so the index is total
+// over every non-`hidden` severity. `hidden` renders nothing.
+const SEVERITY_VARIANT: Record<
+  Exclude<BannerSeverity, "hidden">,
+  NotificationVariant
+> = {
+  red: "error",
+  yellow: "warning",
+  soft: "info",
+  green: "success",
+};
 
 interface PositionNotificationBannerProps {
   connectedAddress?: string;
@@ -86,22 +106,17 @@ export function PositionNotificationBanner({
 
   const effectiveStatus = statusOverride ?? status;
 
-  // Stale-price: show yellow warning regardless of result
+  // Stale-price: warning notification regardless of result.
   if (effectiveStatus === "stale-price") {
     return (
-      <div
-        className={`rounded-lg p-4 ${SEVERITY_STYLES.yellow}`}
-        role="status"
-        data-testid="position-notification-banner"
+      <Notification
+        variant="warning"
+        title={STALE_PRICE_BANNER_TITLE}
+        data-testid={TEST_ID}
         data-severity="yellow"
       >
-        <Text variant="body2" className="text-sm font-semibold">
-          {STALE_PRICE_BANNER_TITLE}
-        </Text>
-        <Text variant="body2" className="mt-1 text-sm opacity-80">
-          {STALE_PRICE_BANNER_DETAIL}
-        </Text>
-      </div>
+        {STALE_PRICE_BANNER_DETAIL}
+      </Notification>
     );
   }
 
@@ -117,88 +132,65 @@ export function PositionNotificationBanner({
 
   if (bannerState.severity === "hidden") return null;
 
-  const isGreen = bannerState.severity === "green";
+  const { primaryWarning, secondaryWarnings } = bannerState;
+  const variant = SEVERITY_VARIANT[bannerState.severity];
+
+  // Primary content: green standalone copy / risk warning / standalone reorder.
+  let title: string;
+  let detail: string;
+  if (bannerState.severity === "green") {
+    title = GREEN_BANNER_TITLE;
+    detail = GREEN_BANNER_DETAIL;
+  } else if (primaryWarning) {
+    title = primaryWarning.title;
+    detail = primaryWarning.detail;
+  } else {
+    // Soft severity with no warning = standalone reorder suggestion.
+    title = COPY.liquidationWarnings.reorder.title;
+    detail = COPY.liquidationWarnings.reorder.detail;
+  }
+
+  const actions = buildBannerActions({
+    result,
+    bannerState,
+    onDeposit,
+    onRepay,
+    onApplyOrder: handleApplyOrder,
+    isReordering,
+  });
 
   return (
     <>
-      <div
-        className={`rounded-lg p-4 ${SEVERITY_STYLES[bannerState.severity]}`}
-        role="status"
-        data-testid="position-notification-banner"
+      <Notification
+        variant={variant}
+        title={title}
+        actions={actions.length > 0 ? actions : undefined}
+        suggestion={
+          secondaryWarnings.length > 0 ? (
+            <div className="flex flex-col gap-2">
+              {secondaryWarnings.map((warning, index) => (
+                <div key={index}>
+                  <div className="text-sm font-semibold text-accent-primary">
+                    {warning.title}
+                  </div>
+                  {warning.detail && (
+                    <div className="text-sm">{warning.detail}</div>
+                  )}
+                  {warning.suggestion && (
+                    <div className="text-sm opacity-80">
+                      {warning.suggestion}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          ) : undefined
+        }
+        data-testid={TEST_ID}
         data-severity={bannerState.severity}
       >
-        {/* Primary content: green / risk warning / standalone reorder note */}
-        {isGreen ? (
-          <div>
-            <Text variant="body2" className="text-sm font-semibold">
-              {GREEN_BANNER_TITLE}
-            </Text>
-            <Text variant="body2" className="mt-1 text-sm opacity-80">
-              {GREEN_BANNER_DETAIL}
-            </Text>
-          </div>
-        ) : bannerState.primaryWarning ? (
-          <div>
-            <Text variant="body2" className="text-sm font-semibold">
-              {bannerState.primaryWarning.title}
-            </Text>
-            <Text variant="body2" className="mt-1 text-sm">
-              {bannerState.primaryWarning.detail}
-            </Text>
-            {bannerState.primaryWarning.suggestion && (
-              <Text variant="body2" className="mt-1 text-sm opacity-80">
-                {bannerState.primaryWarning.suggestion}
-              </Text>
-            )}
-          </div>
-        ) : (
-          bannerState.suggestReorder && (
-            <div>
-              <Text variant="body2" className="text-sm font-semibold">
-                {COPY.liquidationWarnings.reorder.title}
-              </Text>
-              <Text variant="body2" className="mt-1 text-sm opacity-80">
-                {COPY.liquidationWarnings.reorder.detail}
-              </Text>
-            </div>
-          )
-        )}
-
-        {/* Secondary warnings */}
-        {bannerState.secondaryWarnings.length > 0 && (
-          <div className="border-current/20 mt-3 space-y-2 border-t pt-3">
-            {bannerState.secondaryWarnings.map((w, i) => (
-              <div key={i}>
-                <Text variant="body2" className="text-sm font-semibold">
-                  {w.title}
-                </Text>
-                {w.detail && (
-                  <Text variant="body2" className="mt-1 text-sm">
-                    {w.detail}
-                  </Text>
-                )}
-                {w.suggestion && (
-                  <Text variant="body2" className="mt-1 text-sm opacity-80">
-                    {w.suggestion}
-                  </Text>
-                )}
-              </div>
-            ))}
-          </div>
-        )}
-
-        {/* Action buttons */}
-        {!isGreen && (
-          <BannerActions
-            result={result}
-            bannerState={bannerState}
-            onDeposit={onDeposit}
-            onRepay={onRepay}
-            onApplyOrder={handleApplyOrder}
-            isReordering={isReordering}
-          />
-        )}
-      </div>
+        {detail}
+      </Notification>
 
       <ReorderSuccessModal
         isOpen={isReorderSuccess}

--- a/services/vault/src/components/simple/PositionNotificationBanner/__tests__/PositionNotificationBanner.test.tsx
+++ b/services/vault/src/components/simple/PositionNotificationBanner/__tests__/PositionNotificationBanner.test.tsx
@@ -32,15 +32,37 @@ vi.mock("@/clients/eth-contract/client", () => ({
   ethClient: { readContract: vi.fn(), getTransactionReceipt: vi.fn() },
 }));
 
-// Mock core-ui to avoid ESM transformation issues in test environment
+// Mock core-ui Notification to avoid ESM transformation issues in the test
+// environment. Render the pieces the banner assertions depend on: title, body,
+// the suggestion sub-box, and the action pills (label + onClick + disabled),
+// and surface variant/severity as data-attributes.
 vi.mock("@babylonlabs-io/core-ui", () => ({
-  Text: (props: Record<string, unknown>) => {
-    const { children, ...rest } = props;
-    return <span {...rest}>{children as ReactNode}</span>;
-  },
-  Button: (props: Record<string, unknown>) => {
-    const { children, ...rest } = props;
-    return <button {...rest}>{children as ReactNode}</button>;
+  Notification: (props: Record<string, unknown>) => {
+    const actions = (props.actions ?? []) as Array<{
+      label: ReactNode;
+      onClick: () => void;
+      disabled?: boolean;
+    }>;
+    return (
+      <div
+        data-testid={props["data-testid"] as string}
+        data-severity={props["data-severity"] as string}
+        data-variant={props.variant as string}
+      >
+        <div>{props.title as ReactNode}</div>
+        <div>{props.children as ReactNode}</div>
+        {props.suggestion ? <div>{props.suggestion as ReactNode}</div> : null}
+        {actions.map((action, index) => (
+          <button
+            key={index}
+            onClick={action.onClick}
+            disabled={action.disabled}
+          >
+            {action.label}
+          </button>
+        ))}
+      </div>
+    );
   },
 }));
 
@@ -186,6 +208,7 @@ describe("PositionNotificationBanner", () => {
     renderBanner(makeBaseResult(), onDeposit, onRepay);
     const banner = screen.getByTestId("position-notification-banner");
     expect(banner.dataset.severity).toBe("green");
+    expect(banner.dataset.variant).toBe("success");
     expect(screen.getByText("Position optimally structured")).toBeTruthy();
     expect(screen.queryByText("Apply Suggested Order")).toBeNull();
   });
@@ -204,6 +227,7 @@ describe("PositionNotificationBanner", () => {
 
     const banner = screen.getByTestId("position-notification-banner");
     expect(banner.dataset.severity).toBe("red");
+    expect(banner.dataset.variant).toBe("error");
     expect(screen.getByText("Add Collateral")).toBeTruthy();
     expect(screen.getByText("Repay Debt")).toBeTruthy();
     expect(screen.queryByText("Apply Suggested Order")).toBeNull();
@@ -224,6 +248,7 @@ describe("PositionNotificationBanner", () => {
 
     const banner = screen.getByTestId("position-notification-banner");
     expect(banner.dataset.severity).toBe("soft");
+    expect(banner.dataset.variant).toBe("info");
     expect(screen.getByText("Protocol parameters don't compute")).toBeTruthy();
     expect(screen.queryByText("Add Collateral")).toBeNull();
     expect(screen.queryByText("Apply Suggested Order")).toBeNull();
@@ -333,6 +358,7 @@ describe("PositionNotificationBanner", () => {
 
     const banner = screen.getByTestId("position-notification-banner");
     expect(banner.dataset.severity).toBe("yellow");
+    expect(banner.dataset.variant).toBe("warning");
     expect(
       screen.getByText("Position notifications temporarily unavailable"),
     ).toBeTruthy();

--- a/services/vault/src/components/simple/PositionNotificationBanner/constants.ts
+++ b/services/vault/src/components/simple/PositionNotificationBanner/constants.ts
@@ -1,17 +1,3 @@
-import type { BannerSeverity } from "@/applications/aave/positionNotifications";
-
-export const SEVERITY_STYLES: Record<BannerSeverity, string> = {
-  red: "border-2 border-red-500 bg-red-50 text-red-900 dark:bg-red-950/30 dark:text-red-200",
-  yellow:
-    "border-2 border-yellow-500 bg-yellow-50 text-yellow-900 dark:bg-yellow-950/30 dark:text-yellow-200",
-  green:
-    "border-2 border-green-500 bg-green-50 text-green-900 dark:bg-green-950/30 dark:text-green-200",
-  // Muted advisory tone for soft warnings (weird-params): protocol params are
-  // governance-set, so this is informational rather than actionable.
-  soft: "border border-gray-300 bg-gray-50 text-gray-600 dark:border-gray-700 dark:bg-gray-900/30 dark:text-gray-400",
-  hidden: "",
-};
-
 export const GREEN_BANNER_TITLE = "Position optimally structured";
 export const GREEN_BANNER_DETAIL =
   "BTC Vault ordering is correct and partial liquidation is enabled.";


### PR DESCRIPTION
Closes https://github.com/babylonlabs-io/babylon-toolkit/issues/1947

<img width="2032" height="1162" alt="Screenshot_2026-06-24_18-19-14" src="https://github.com/user-attachments/assets/3cac1034-3942-47a3-b536-3b55c4a7e4a1" />

<img width="2032" height="1162" alt="Screenshot_2026-06-24_18-20-18" src="https://github.com/user-attachments/assets/97bf5215-b892-43da-95cf-70cae63187bc" />

## What this does

Restyles the position notification banner (the "Liquidation is 4.3% away" callout with the Add Collateral / Repay Debt buttons) to match the Figma, by rendering it through the shared core-ui `Notification` component instead of its own hand-rolled box.

## Why

The banner currently builds its own colored box with a local `SEVERITY_STYLES` map and plain buttons. The Figma for the urgent callout is exactly the design-system `Notification` (red left-accent bar, red tint, warning icon, title + detail, and inline action pills). So instead of re-styling the bespoke box to look like the primitive, we make the banner consume the primitive. This also completes the migration described in https://github.com/babylonlabs-io/babylon-toolkit/issues/1955 — the new `Notification` primitive shipped in https://github.com/babylonlabs-io/babylon-toolkit/pull/1956, but the vault banner was never moved onto it. This PR does that.

## The approaches we considered

- Approach A (chosen): consume the existing core-ui `Notification` primitive. Map each banner severity to a `Notification` variant (urgent → error, soft advisory → info, healthy → success, stale price → warning), pass the title/detail as its content, and pass the buttons through its `actions` slot. The Figma callout maps one-to-one onto the `error` variant, so almost no custom styling is needed.
- Approach B (rejected): keep the bespoke box and just re-skin `SEVERITY_STYLES` and the buttons to look like the Figma. Rejected because it duplicates what the primitive already does, keeps dead styling around, and would drift from the design system over time (two places to keep in sync).

We chose A because it deletes code instead of adding it, removes the duplicated styling (`SEVERITY_STYLES` is gone), keeps every severity consistent with the design system, and matches the Figma for free.

## What changed

- `PositionNotificationBanner.tsx` — now renders a single core-ui `Notification`. A small severity → variant map drives the styling; title/detail become the notification content; secondary warnings (rare) render in its nested "suggestion" sub-box; the stale-price and dust/hidden cases are preserved.
- `BannerActions.tsx` — changed from a component that rendered `<Button>`s into a `buildBannerActions()` helper that returns the structured action list the `Notification` expects. Add Collateral is the primary (filled) pill; Repay Debt and Apply Suggested Order are secondary (outlined) — matching the Figma.
- `constants.ts` — removed `SEVERITY_STYLES` (now unused). No remaining references.
- Tests — updated to mock the `Notification` primitive and assert the severity → variant mapping; all existing behavior (severities, actions, clicks, secondary warnings, stale-price, dust-hidden) is still covered.

## One intentional behavior change

In the urgent callout we no longer show the extra suggestion line ("Add collateral or repay part of the debt…"). The Add Collateral / Repay Debt buttons already say that, and the Figma drops the line. No user-facing copy was added or removed in `copy.ts`.

## Scope and dependencies

This PR only touches the position notification banner. It is independent of the top critical banner (https://github.com/babylonlabs-io/babylon-toolkit/issues/1946 / PR https://github.com/babylonlabs-io/babylon-toolkit/pull/1960) — different files, no overlap. It depends only on the `Notification` primitive, which is already on `main`. The branch was cut from `main` and rebased after PR #1960 merged.

## How to test it

Run the vault app with `NEXT_PUBLIC_FF_ENABLE_LIQUIDATION_NOTIFICATIONS=true` (and `NEXT_PUBLIC_FF_POSITION_DEBUG_PANEL=true` to drive states). Use the debug panel to push the position into the urgent range — the callout should render as the red `Notification` (left accent, red tint, warning icon, title + detail) with Add Collateral (filled) and Repay Debt (outlined) pills. Check the other states too: healthy → green/success, suboptimal order → info with "Apply Suggested Order", stale price → warning, dust → nothing.

## Verification

Full vault build passes (`tsc -p tsconfig.lib.json` + vite build); vault typecheck passes; lint is clean on all changed files; the banner test suite passes (14 tests) and the full vault test suite passes.
