### PR TITLE
feat(vault): make "protocol parameters don't compute" notification dismissable

### DIFF
--- a/packages/babylon-core-ui/src/components/Notification/Notification.tsx
+++ b/packages/babylon-core-ui/src/components/Notification/Notification.tsx
@@ -114,6 +114,10 @@ const VARIANT_ACCENT: Record<NotificationVariant, VariantAccent> = {
 
 const ICON_SIZE = 24;
 
+// Figma's close (X) is a 14px mark centered in a 24px frame; our CloseIcon glyph
+// is full-bleed (no internal padding), so render it at 14 to match the visible X.
+const CLOSE_ICON_SIZE = 14;
+
 const DEFAULT_ICON: Record<NotificationVariant, ComponentType<IconProps>> = {
   error: WarningIcon,
   warning: InfoIcon,
@@ -236,7 +240,7 @@ export function Notification({
           aria-label="Dismiss notification"
           className="-mr-1 -mt-1 flex shrink-0 items-center justify-center rounded p-1 text-accent-secondary transition-colors hover:text-accent-primary"
         >
-          <CloseIcon size={14} />
+          <CloseIcon size={CLOSE_ICON_SIZE} />
         </button>
       )}
     </div>

--- a/packages/babylon-core-ui/src/components/Notification/Notification.tsx
+++ b/packages/babylon-core-ui/src/components/Notification/Notification.tsx
@@ -236,7 +236,7 @@ export function Notification({
           aria-label="Dismiss notification"
           className="-mr-1 -mt-1 flex shrink-0 items-center justify-center rounded p-1 text-accent-secondary transition-colors hover:text-accent-primary"
         >
-          <CloseIcon size={20} />
+          <CloseIcon size={14} />
         </button>
       )}
     </div>

--- a/services/vault/src/components/simple/PositionNotificationBanner/PositionNotificationBanner.tsx
+++ b/services/vault/src/components/simple/PositionNotificationBanner/PositionNotificationBanner.tsx
@@ -78,6 +78,7 @@ export function PositionNotificationBanner({
   const { executeReorder, isProcessing: isReordering } = useReorderVaults();
   const { applyReorderedOrder } = useReorderOverride();
   const [isReorderSuccess, setIsReorderSuccess] = useState(false);
+  const [isWeirdParamsDismissed, setIsWeirdParamsDismissed] = useState(false);
   const queryClient = useQueryClient();
   const { address } = useAccount();
 
@@ -90,6 +91,10 @@ export function PositionNotificationBanner({
       invalidateVaultQueries(queryClient, address as Address);
     }
   }, [address, queryClient]);
+
+  const handleDismissWeirdParams = useCallback(() => {
+    setIsWeirdParamsDismissed(true);
+  }, []);
 
   const handleApplyOrder = useCallback(async () => {
     if (!result?.suggestedVaultOrder || !reorderVerificationContext) return;
@@ -131,6 +136,14 @@ export function PositionNotificationBanner({
   const bannerState = deriveBannerState(result);
 
   if (bannerState.severity === "hidden") return null;
+
+  // Only the weird-params advisory is dismissible (informational, no required
+  // action). The standalone reorder suggestion is also `soft` but has a null
+  // primaryWarning, so it is intentionally excluded.
+  const isWeirdParamsAdvisory =
+    bannerState.severity === "soft" &&
+    bannerState.primaryWarning?.type === "weird-params";
+  if (isWeirdParamsAdvisory && isWeirdParamsDismissed) return null;
 
   const { primaryWarning, secondaryWarnings } = bannerState;
   const variant = SEVERITY_VARIANT[bannerState.severity];
@@ -186,6 +199,7 @@ export function PositionNotificationBanner({
             </div>
           ) : undefined
         }
+        onClose={isWeirdParamsAdvisory ? handleDismissWeirdParams : undefined}
         data-testid={TEST_ID}
         data-severity={bannerState.severity}
       >

--- a/services/vault/src/components/simple/PositionNotificationBanner/__tests__/PositionNotificationBanner.test.tsx
+++ b/services/vault/src/components/simple/PositionNotificationBanner/__tests__/PositionNotificationBanner.test.tsx
@@ -52,6 +52,14 @@ vi.mock("@babylonlabs-io/core-ui", () => ({
         <div>{props.title as ReactNode}</div>
         <div>{props.children as ReactNode}</div>
         {props.suggestion ? <div>{props.suggestion as ReactNode}</div> : null}
+        {props.onClose ? (
+          <button
+            aria-label="Dismiss notification"
+            onClick={props.onClose as () => void}
+          >
+            dismiss
+          </button>
+        ) : null}
         {actions.map((action, index) => (
           <button
             key={index}
@@ -252,6 +260,50 @@ describe("PositionNotificationBanner", () => {
     expect(screen.getByText("Protocol parameters don't compute")).toBeTruthy();
     expect(screen.queryByText("Add Collateral")).toBeNull();
     expect(screen.queryByText("Apply Suggested Order")).toBeNull();
+  });
+
+  it("hides the weird-params advisory after its dismiss control is clicked", () => {
+    const result = makeBaseResult({
+      warnings: [
+        {
+          type: "weird-params",
+          title: "Protocol parameters don't compute",
+          detail: "THF must be greater than expected HF.",
+          tone: "soft",
+        },
+      ],
+    });
+    renderBanner(result, onDeposit, onRepay);
+
+    expect(screen.getByTestId("position-notification-banner")).toBeTruthy();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Dismiss notification" }),
+    );
+
+    expect(screen.queryByTestId("position-notification-banner")).toBeNull();
+  });
+
+  it("does not render a dismiss control on the urgent banner", () => {
+    const result = makeBaseResult({
+      warnings: [
+        { type: "urgent", title: "Liquidation is 3.0% away", detail: "..." },
+      ],
+    });
+    renderBanner(result, onDeposit, onRepay);
+
+    expect(
+      screen.queryByRole("button", { name: "Dismiss notification" }),
+    ).toBeNull();
+  });
+
+  it("does not render a dismiss control on the reorder suggestion", () => {
+    const result = makeBaseResult({ suggestedVaultOrder: SUGGESTED_ORDER });
+    renderBanner(result, onDeposit, onRepay);
+
+    expect(
+      screen.queryByRole("button", { name: "Dismiss notification" }),
+    ).toBeNull();
   });
 
   it("renders soft reorder note + Apply Suggested Order for a healthy but suboptimal position", () => {


### PR DESCRIPTION

<img width="2032" height="1162" alt="Screenshot_2026-06-24_19-43-25" src="https://github.com/user-attachments/assets/d8baa663-6d47-4812-9e16-815e3795775a" />

<img width="2032" height="1162" alt="Screenshot_2026-06-24_19-43-48" src="https://github.com/user-attachments/assets/721c7dd7-19ae-4f38-b27b-4f56c9875872" />

<img width="2032" height="1162" alt="Screenshot_2026-06-24_19-44-36" src="https://github.com/user-attachments/assets/684c0a41-7cbf-4f91-806e-48c2406778c0" />

# Make the "Protocol parameters don't compute" notification dismissible (info) + fix the close-icon size

Closes https://github.com/babylonlabs-io/babylon-toolkit/issues/1957

## What this PR does

It finishes aligning the "Protocol parameters don't compute" advisory (the `weird-params` warning) to its Figma design. Two things change:

1. The notification is now **dismissible** — it shows an X in the top-right, and clicking it hides the notification for the rest of the session.
2. The shared notification's **close (X) icon is smaller**, matching Figma (it was rendering noticeably too big/heavy).

Everything else about this notification was already correct before this PR: the warning logic, the wording, and the blue **info** styling all landed when `PositionNotificationBanner` was migrated onto the shared `Notification` component in https://github.com/babylonlabs-io/babylon-toolkit/pull/1961. This PR is the small remaining gap on top of that.

## Why

The Figma design for this notification (and the issue) asks for an informational, **dismissible** notification. It's purely advisory — it tells the user the protocol's liquidation parameters are in a combination where the math is undefined, and there's nothing the user can do about it (those values are set by governance). Because it requires no action, the user should be able to close it. Our version was missing that X, and once we added it we noticed the shared X icon was visibly larger than the Figma design, so we corrected that too.

## How it works

- The dismiss is **session-local**: closing it hides it until the page reloads. If the parameters still don't compute after a reload, the notification comes back. We chose this over remembering the dismissal permanently because the message reflects live on-chain state — we don't want to permanently hide a condition that is still true.
- Only **this** advisory gets the X. The urgent (red) liquidation banner and the "apply suggested order" suggestion are intentionally **not** dismissible — they're either safety-critical or actionable, so hiding them would be wrong. We scope the X precisely to the weird-params advisory and nothing else.

## Approaches considered

**Where to add the dismiss.** The shared `Notification` component already renders an X whenever it's given an `onClose` handler. So we didn't build any new dismiss UI — we just pass `onClose` for this one notification. Simpler and consistent with the design system.

**How to remember the dismissal.** Options were (a) session-local hide, or (b) persist it across reloads (e.g. local storage). We picked (a) — session-local — because the notification describes a live protocol condition; persisting could hide a problem that's still present after a refresh. Less code, and safer.

**Which notifications can be dismissed.** Options were (a) only this advisory, or (b) every info/soft notification. We picked (a). The other soft notification in the same banner is the "apply suggested order" suggestion, which is actionable — letting users X it away would hide a useful action. So the X is limited to the weird-params advisory.

**The close-icon size.** The X lives in the shared `Notification` component, not in this banner. It was hardcoded to `size={20}`, and our close-icon SVG fills its whole box edge-to-edge, so it painted a 20px X. Figma's close icon is a 14px X centered inside a 24px frame. We changed the shared component to `size={14}` to match. Since this notification is currently the only place in the app that shows a dismiss X, this change affects exactly this one icon and nothing else on screen. The alternative — leaving the shared component alone and filing a separate change — would have left the X oversized until that landed, so we folded the one-line fix into this PR.

## How to test (reproduce the UI)

Use the **Position Notifications Debug Panel** on the dashboard (Manual Mode). Change these three fields and leave everything else as the defaults:

| Field | Value |
|---|---|
| CF | 0,85 |
| THF | 1,05 |
| LB (maxLB) | 1,30 |

Keep BTC Price, Total Debt, Expected HF (`0,95`), and both vaults exactly as they are.

**Why these:** `maxLB × CF = 1.30 × 0.85 = 1.105`, and `THF = 1.05`, so `THF − liqPenalty = 1.05 − 1.105 = −0.055 ≤ 0`. That hits the `causeLiqPenalty` branch, which renders the Figma copy verbatim:

> **Protocol parameters don't compute**
> maxLB × CF = 1.105, but it must be less than THF (1.05). At this combination the liquidation formula becomes undefined (division by a non-positive number).

You should see a blue **info** notification with that text and a small X in the top-right. Click the X — the notification disappears for the session.

**Optional — the sibling cause text.** To see the `causeThfTooLow` variant (same info notification, different cause line), set `CF 0,75 · LB 1,05 · THF 0,90` (keep Expected HF `0,95`). That keeps `THF − liqPenalty > 0` but makes `THF ≤ expectedHF`, producing: *"THF (0.9) must be greater than expected HF (0.95) — otherwise liquidation has no valid target."* — also dismissible.

**Also confirm the scope:** the red urgent banner and the "Apply Suggested Order" suggestion should show **no** X.

## Files changed

- `services/vault/src/components/simple/PositionNotificationBanner/PositionNotificationBanner.tsx` — pass `onClose` for the weird-params advisory only; session-local hide.
- `services/vault/src/components/simple/PositionNotificationBanner/__tests__/PositionNotificationBanner.test.tsx` — tests: the advisory hides on dismiss; the urgent banner and the reorder suggestion have no X.
- `packages/babylon-core-ui/src/components/Notification/Notification.tsx` — shared close icon `size={20}` → `size={14}` (Figma-accurate).

## Notes for reviewers

- This touches the shared `core-ui` `Notification` component (from https://github.com/babylonlabs-io/babylon-toolkit/pull/1956) with a one-line icon-size change. This notification is its only dismiss-X consumer today, so the blast radius is just this icon.
- No new user-facing copy — the wording already existed and already matches Figma.
- Relates to https://github.com/babylonlabs-io/babylon-toolkit/issues/1955.

## Verification

- `pnpm --filter @babylonlabs-io/core-ui run build` — rebuilds the shared package (the vault imports it from `dist/`).
- `pnpm --filter vault run build` — passes.
- `pnpm --filter vault run test` — 1954 passed, 4 skipped.
- `pnpm --filter vault run lint` — 0 errors.
