### PR TITLE
feat(vault): align reorder notification

### DIFF
--- a/services/vault/src/components/simple/PositionNotificationBanner/BannerActions.tsx
+++ b/services/vault/src/components/simple/PositionNotificationBanner/BannerActions.tsx
@@ -20,8 +20,8 @@ interface BuildBannerActionsArgs {
  * `Notification` `actions` slot:
  * - urgent: "Add Collateral" (primary, filled) + "Repay Debt" (secondary,
  *   outlined) — the core safety actions, matching the Figma callout.
- * - suggested reorder available: "Apply Suggested Order" (secondary) — manual
- *   approve.
+ * - suggested reorder available: "Apply Optimal Order" — filled (primary) on the
+ *   standalone reorder card, secondary when it accompanies the urgent callout.
  *
  * Both groups can appear together (an urgent position whose order is also
  * suboptimal).
@@ -59,9 +59,11 @@ export function buildBannerActions({
     actions.push({
       label: isReordering
         ? COPY.common.applying
-        : COPY.banner.applySuggestedOrder,
+        : COPY.banner.applyOptimalOrder,
       onClick: onApplyOrder,
-      emphasis: "secondary",
+      // Standalone reorder gets the filled (primary) gold button; when it rides
+      // alongside the urgent callout it stays secondary so "Add Collateral" leads.
+      emphasis: isUrgent ? "secondary" : "primary",
       disabled: isReordering,
     });
   }

--- a/services/vault/src/components/simple/PositionNotificationBanner/PositionNotificationBanner.tsx
+++ b/services/vault/src/components/simple/PositionNotificationBanner/PositionNotificationBanner.tsx
@@ -3,7 +3,7 @@ import {
   type NotificationVariant,
 } from "@babylonlabs-io/core-ui";
 import { useQueryClient } from "@tanstack/react-query";
-import { useCallback, useState } from "react";
+import { useCallback, useState, type ReactNode } from "react";
 import type { Address, Hex } from "viem";
 import { useAccount } from "wagmi";
 
@@ -30,6 +30,7 @@ import {
   STALE_PRICE_BANNER_DETAIL,
   STALE_PRICE_BANNER_TITLE,
 } from "./constants";
+import { SuggestedOrderChips } from "./SuggestedOrderChips";
 
 const TEST_ID = "position-notification-banner";
 
@@ -146,7 +147,17 @@ export function PositionNotificationBanner({
   if (isWeirdParamsAdvisory && isWeirdParamsDismissed) return null;
 
   const { primaryWarning, secondaryWarnings } = bannerState;
-  const variant = SEVERITY_VARIANT[bannerState.severity];
+
+  // The standalone reorder suggestion (soft severity, no primaryWarning) renders
+  // as the gold `suggestion` variant per Figma — distinct from the weird-params
+  // advisory, which is also soft but sets primaryWarning.
+  const isStandaloneReorder =
+    bannerState.severity === "soft" &&
+    !primaryWarning &&
+    bannerState.suggestReorder;
+  const variant = isStandaloneReorder
+    ? "suggestion"
+    : SEVERITY_VARIANT[bannerState.severity];
 
   // Primary content: green standalone copy / risk warning / standalone reorder.
   let title: string;
@@ -172,33 +183,38 @@ export function PositionNotificationBanner({
     isReordering,
   });
 
+  // Sub-box content: the suggested-order chips for the standalone reorder card,
+  // otherwise the stacked secondary warnings (e.g. urgent + weird-params).
+  let suggestion: ReactNode;
+  if (isStandaloneReorder && result.suggestedVaultOrder) {
+    suggestion = <SuggestedOrderChips vaults={result.suggestedVaultOrder} />;
+  } else if (secondaryWarnings.length > 0) {
+    suggestion = (
+      <div className="flex flex-col gap-2">
+        {secondaryWarnings.map((warning, index) => (
+          <div key={index}>
+            <div className="text-sm font-semibold text-accent-primary">
+              {warning.title}
+            </div>
+            {warning.detail && <div className="text-sm">{warning.detail}</div>}
+            {warning.suggestion && (
+              <div className="text-sm opacity-80">{warning.suggestion}</div>
+            )}
+          </div>
+        ))}
+      </div>
+    );
+  }
+
   return (
     <>
       <Notification
         variant={variant}
         title={title}
+        icon={isStandaloneReorder ? null : undefined}
         actions={actions.length > 0 ? actions : undefined}
-        suggestion={
-          secondaryWarnings.length > 0 ? (
-            <div className="flex flex-col gap-2">
-              {secondaryWarnings.map((warning, index) => (
-                <div key={index}>
-                  <div className="text-sm font-semibold text-accent-primary">
-                    {warning.title}
-                  </div>
-                  {warning.detail && (
-                    <div className="text-sm">{warning.detail}</div>
-                  )}
-                  {warning.suggestion && (
-                    <div className="text-sm opacity-80">
-                      {warning.suggestion}
-                    </div>
-                  )}
-                </div>
-              ))}
-            </div>
-          ) : undefined
-        }
+        actionsPlacement={isStandaloneReorder ? "below" : "inline"}
+        suggestion={suggestion}
         onClose={isWeirdParamsAdvisory ? handleDismissWeirdParams : undefined}
         data-testid={TEST_ID}
         data-severity={bannerState.severity}

--- a/services/vault/src/components/simple/PositionNotificationBanner/SuggestedOrderChips.tsx
+++ b/services/vault/src/components/simple/PositionNotificationBanner/SuggestedOrderChips.tsx
@@ -1,0 +1,45 @@
+import { Fragment } from "react";
+
+import type { Vault } from "@/applications/aave/positionNotifications";
+import { COPY } from "@/copy";
+import { formatBtcAmount } from "@/utils/formatting";
+
+// Figma shows the suggested-order chips with two-decimal BTC amounts
+// (e.g. "0.60 BTC"); formatBtcAmount still supplies the network coin suffix.
+const CHIP_BTC_DECIMALS = 2;
+
+interface SuggestedOrderChipsProps {
+  vaults: Vault[];
+}
+
+/**
+ * The "SUGGESTED ORDER" sub-box of the reorder notification
+ * a label above a wrapped row of vault pills joined by arrows,
+ * read left-to-right as the order the apply action would submit.
+ */
+export function SuggestedOrderChips({ vaults }: SuggestedOrderChipsProps) {
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="text-xs uppercase tracking-[0.4px] text-accent-secondary">
+        {COPY.liquidationWarnings.reorder.suggestedOrderLabel}
+      </div>
+      <div className="flex flex-wrap items-center gap-2">
+        {vaults.map((vault, index) => (
+          <Fragment key={vault.id}>
+            {index > 0 && (
+              <span aria-hidden="true" className="text-accent-secondary">
+                →
+              </span>
+            )}
+            <span className="rounded-full bg-secondary-highlight px-3 py-1 text-sm text-accent-primary">
+              {COPY.liquidationWarnings.reorder.vaultChip(
+                vault.name,
+                formatBtcAmount(vault.btc, CHIP_BTC_DECIMALS),
+              )}
+            </span>
+          </Fragment>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/services/vault/src/components/simple/PositionNotificationBanner/SuggestedOrderChips.tsx
+++ b/services/vault/src/components/simple/PositionNotificationBanner/SuggestedOrderChips.tsx
@@ -4,10 +4,6 @@ import type { Vault } from "@/applications/aave/positionNotifications";
 import { COPY } from "@/copy";
 import { formatBtcAmount } from "@/utils/formatting";
 
-// Figma shows the suggested-order chips with two-decimal BTC amounts
-// (e.g. "0.60 BTC"); formatBtcAmount still supplies the network coin suffix.
-const CHIP_BTC_DECIMALS = 2;
-
 interface SuggestedOrderChipsProps {
   vaults: Vault[];
 }
@@ -34,7 +30,7 @@ export function SuggestedOrderChips({ vaults }: SuggestedOrderChipsProps) {
             <span className="rounded-full bg-secondary-highlight px-3 py-1 text-sm text-accent-primary">
               {COPY.liquidationWarnings.reorder.vaultChip(
                 vault.name,
-                formatBtcAmount(vault.btc, CHIP_BTC_DECIMALS),
+                formatBtcAmount(vault.btc),
               )}
             </span>
           </Fragment>

--- a/services/vault/src/components/simple/PositionNotificationBanner/__tests__/PositionNotificationBanner.test.tsx
+++ b/services/vault/src/components/simple/PositionNotificationBanner/__tests__/PositionNotificationBanner.test.tsx
@@ -218,7 +218,7 @@ describe("PositionNotificationBanner", () => {
     expect(banner.dataset.severity).toBe("green");
     expect(banner.dataset.variant).toBe("success");
     expect(screen.getByText("Position optimally structured")).toBeTruthy();
-    expect(screen.queryByText("Apply Suggested Order")).toBeNull();
+    expect(screen.queryByText("Apply Optimal Order")).toBeNull();
   });
 
   it("renders red banner with Add Collateral + Repay Debt for an urgent warning", () => {
@@ -238,7 +238,7 @@ describe("PositionNotificationBanner", () => {
     expect(banner.dataset.variant).toBe("error");
     expect(screen.getByText("Add Collateral")).toBeTruthy();
     expect(screen.getByText("Repay Debt")).toBeTruthy();
-    expect(screen.queryByText("Apply Suggested Order")).toBeNull();
+    expect(screen.queryByText("Apply Optimal Order")).toBeNull();
   });
 
   it("renders soft banner for a weird-params advisory with no actions", () => {
@@ -259,7 +259,7 @@ describe("PositionNotificationBanner", () => {
     expect(banner.dataset.variant).toBe("info");
     expect(screen.getByText("Protocol parameters don't compute")).toBeTruthy();
     expect(screen.queryByText("Add Collateral")).toBeNull();
-    expect(screen.queryByText("Apply Suggested Order")).toBeNull();
+    expect(screen.queryByText("Apply Optimal Order")).toBeNull();
   });
 
   it("hides the weird-params advisory after its dismiss control is clicked", () => {
@@ -306,22 +306,26 @@ describe("PositionNotificationBanner", () => {
     ).toBeNull();
   });
 
-  it("renders soft reorder note + Apply Suggested Order for a healthy but suboptimal position", () => {
+  it("renders the gold reorder suggestion with a chip row + Apply Optimal Order for a healthy but suboptimal position", () => {
     const result = makeBaseResult({ suggestedVaultOrder: SUGGESTED_ORDER });
     renderBanner(result, onDeposit, onRepay);
 
     const banner = screen.getByTestId("position-notification-banner");
     expect(banner.dataset.severity).toBe("soft");
-    expect(
-      screen.getByText("BTC Vaults aren't in the safest liquidation order"),
-    ).toBeTruthy();
-    expect(screen.getByText("Apply Suggested Order")).toBeTruthy();
+    // Standalone reorder uses the gold `suggestion` variant, not blue `info`.
+    expect(banner.dataset.variant).toBe("suggestion");
+    expect(screen.getByText("Reorder vaults to lose less")).toBeTruthy();
+    // Suggested-order chip row renders each vault in order.
+    expect(screen.getByText("Suggested order")).toBeTruthy();
+    expect(screen.getByText(/Vault 2 ·/)).toBeTruthy();
+    expect(screen.getByText(/Vault 1 ·/)).toBeTruthy();
+    expect(screen.getByText("Apply Optimal Order")).toBeTruthy();
     // Reorder-only — no collateral/repay actions.
     expect(screen.queryByText("Add Collateral")).toBeNull();
     expect(screen.queryByText("Repay Debt")).toBeNull();
   });
 
-  it("shows Add Collateral, Repay Debt and Apply Suggested Order when urgent + suboptimal", () => {
+  it("shows Add Collateral, Repay Debt and Apply Optimal Order when urgent + suboptimal", () => {
     const result = makeBaseResult({
       warnings: [
         { type: "urgent", title: "Liquidation is 4.3% away", detail: "..." },
@@ -332,7 +336,7 @@ describe("PositionNotificationBanner", () => {
 
     expect(screen.getByText("Add Collateral")).toBeTruthy();
     expect(screen.getByText("Repay Debt")).toBeTruthy();
-    expect(screen.getByText("Apply Suggested Order")).toBeTruthy();
+    expect(screen.getByText("Apply Optimal Order")).toBeTruthy();
   });
 
   it("calls onDeposit when Add Collateral is clicked", () => {
@@ -355,11 +359,11 @@ describe("PositionNotificationBanner", () => {
     expect(onRepay).toHaveBeenCalled();
   });
 
-  it("calls executeReorder with vault IDs and verification context when Apply Suggested Order is clicked", () => {
+  it("calls executeReorder with vault IDs and verification context when Apply Optimal Order is clicked", () => {
     const result = makeBaseResult({ suggestedVaultOrder: SUGGESTED_ORDER });
     renderBanner(result, onDeposit, onRepay);
 
-    fireEvent.click(screen.getByText("Apply Suggested Order"));
+    fireEvent.click(screen.getByText("Apply Optimal Order"));
     expect(mockExecuteReorder).toHaveBeenCalledWith(["0xabc", "0xdef"], {
       suggestedOrderContext: mockReorderVerificationContext,
     });
@@ -375,7 +379,7 @@ describe("PositionNotificationBanner", () => {
     const result = makeBaseResult({ suggestedVaultOrder: SUGGESTED_ORDER });
     renderBanner(result, onDeposit, onRepay);
 
-    fireEvent.click(screen.getByText("Apply Suggested Order"));
+    fireEvent.click(screen.getByText("Apply Optimal Order"));
     expect(mockExecuteReorder).not.toHaveBeenCalled();
   });
 
@@ -429,7 +433,7 @@ describe("PositionNotificationBanner", () => {
 
     expect(screen.queryByText("Add Collateral")).toBeNull();
     expect(screen.queryByText("Repay Debt")).toBeNull();
-    expect(screen.queryByText("Apply Suggested Order")).toBeNull();
+    expect(screen.queryByText("Apply Optimal Order")).toBeNull();
   });
 
   it("renders nothing for dust (hidden severity)", () => {

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -938,7 +938,7 @@ export const COPY = {
   activity: {
     pageTitle: "Activity",
     filterAll: "Show all",
-    // Visible filter options in dropdown order (matches Figma node 6602-64485).
+    // Visible filter options in dropdown order
     // Redeem / Pending Deposit rows still render but are not filterable —
     // they don't appear here on purpose.
     filterTypes: {
@@ -964,7 +964,7 @@ export const COPY = {
   banner: {
     addCollateral: "Add Collateral",
     repayDebt: "Repay Debt",
-    applySuggestedOrder: "Apply Suggested Order",
+    applyOptimalOrder: "Apply Optimal Order",
   },
   geoBlock: {
     title: "Service unavailable in your region",
@@ -1025,9 +1025,11 @@ export const COPY = {
     // Standalone reorder suggestion (not a risk warning). Surfaced whenever the
     // engine finds a safer liquidation order than the current on-chain order.
     reorder: {
-      title: "BTC Vaults aren't in the safest liquidation order",
+      title: "Reorder vaults to lose less",
       detail:
-        "Reordering puts a smaller BTC Vault first so less collateral is seized in the first liquidation event. Apply the suggested order to improve your partial-liquidation protection.",
+        "A different vault order makes the first liquidation event smaller — less BTC seized when it triggers.",
+      suggestedOrderLabel: "Suggested order",
+      vaultChip: (name: string, amount: string) => `${name} · ${amount}`,
     },
     dust: {
       title: "Position too small to model",


### PR DESCRIPTION

<img width="2032" height="1162" alt="Screenshot_2026-06-24_23-59-40" src="https://github.com/user-attachments/assets/6612527b-ee92-475a-8a76-14ffddd59c53" />

<img width="1031" height="286" alt="Screenshot_2026-06-24_23-59-45" src="https://github.com/user-attachments/assets/4e4f33a2-412e-4079-bacb-cc701284411b" />

<img width="1035" height="329" alt="Screenshot_2026-06-25_00-02-06" src="https://github.com/user-attachments/assets/825f67e3-e510-4cd1-99db-69d40426a515" />

<img width="2032" height="1162" alt="Screenshot_2026-06-25_00-02-13" src="https://github.com/user-attachments/assets/1ccbae76-6a82-496b-b897-17e99d137247" />

<img width="2032" height="1162" alt="Screenshot_2026-06-25_00-02-38" src="https://github.com/user-attachments/assets/be4b7d50-47c1-4c80-a59b-712c1db56bfe" />

<img width="1032" height="164" alt="Screenshot_2026-06-25_00-02-47" src="https://github.com/user-attachments/assets/f9fa13c8-c4ff-487f-9516-ab6eea7786d2" />

# "Reorder vaults to lose less" notification — gold suggestion variant + suggested-order chips

Closes https://github.com/babylonlabs-io/babylon-toolkit/issues/1950

## What this PR does

It aligns the existing reorder suggestion (the banner that appears when your BTC Vaults aren't in the safest liquidation order) to its Figma design. Three visible changes:

1. New title and body copy: **"Reorder vaults to lose less"** + "A different vault order makes the first liquidation event smaller — less BTC seized when it triggers."
2. A new **SUGGESTED ORDER** row of pill chips that shows the recommended order, e.g. `Vault 2 · 0.45 sBTC → Vault 1 · 0.6 sBTC`.
3. The notification now uses the **gold "suggestion" style** (gold accent, no icon, a filled gold **"Apply Optimal Order"** button below) instead of the plain blue informational style it had before.

The underlying logic (detecting a better order and applying it) already existed — this PR is purely the visual + copy alignment on top of it.

## Why

The reorder suggestion was already functional but didn't match Figma: it rendered as a blue info box with a secondary button and no visual of the suggested order. The current Figma (notification node `6502-111184`) shows it as a distinct gold "suggestion" card with the order spelled out as chips and a filled gold action button. Two things are worth calling out:

- The core-ui `Notification` component already had a **`suggestion` (gold) variant that nothing used** — this reorder card is its intended home, so we're finally wiring it up rather than inventing anything new.
- Showing the actual suggested order (the chips) makes the suggestion concrete: the user can see exactly what "apply" will do before clicking.

## Approaches and decisions

**Match the live Figma, not the old ticket text.** The tracking issue described an older design (blue box, "Apply Suggested Order"). The current Figma had moved on (gold card, "Apply Optimal Order", no icon). We chose to match the **live Figma** since it's the source of truth and the team cares about pixel fidelity. (Confirmed this direction before implementing.)

**Scope the new look to the standalone reorder only.** The same banner component also renders the urgent (red) liquidation callout. We detect the standalone reorder case precisely — soft severity, no risk warning, but a better order exists — and only that case gets the gold variant, the dropped icon, the chip row, and the filled button. The red urgent banner is untouched. This keeps the change surgical and avoids regressing the urgent callout.

**Reuse instead of rebuild.** We reused the core-ui `Notification` `suggestion` variant, its `actions`/`actionsPlacement`/`icon`/`suggestion` slots, the existing apply-reorder action, and the existing `formatBtcAmount` helper for the chip amounts. The only new piece is a small presentational `SuggestedOrderChips` component for the pill row.

**Button label.** Figma renames the action to **"Apply Optimal Order"**. This label is shared with the rare case where the urgent banner also offers a reorder, so we renamed it in one place (`COPY.banner`) — it reads the same in both spots, which is correct since it's the same action.

**Button emphasis.** On the standalone reorder card the button is the primary (filled gold) action. When the same reorder action rides alongside the urgent banner, it stays secondary so "Add Collateral" remains the lead action. One small conditional drives this.

## Files changed

- `services/vault/src/copy.ts` — new title/body copy, a `Suggested order` label, a chip formatter, and renamed `applySuggestedOrder` → `applyOptimalOrder` ("Apply Optimal Order").
- `services/vault/src/components/simple/PositionNotificationBanner/SuggestedOrderChips.tsx` — new: the SUGGESTED ORDER label + pill row.
- `services/vault/src/components/simple/PositionNotificationBanner/PositionNotificationBanner.tsx` — render the standalone reorder as the gold `suggestion` variant, drop the icon, place the button below, show the chip row.
- `services/vault/src/components/simple/PositionNotificationBanner/BannerActions.tsx` — primary (filled) button on the standalone reorder, secondary alongside urgent; new label.
- `services/vault/src/components/simple/PositionNotificationBanner/__tests__/PositionNotificationBanner.test.tsx` — assert the gold variant, the chip row, and the new copy/label.

## How to test (reproduce the UI)

Open the **Position Notifications Debug Panel** on the dashboard, turn on **Manual Mode**. The panel feeds the live dashboard banner, so look at the **main banner above the panel** (the panel's own gray "Banner: SOFT" box is just its internal readout, not the styled card).

### Gold reorder card (the standalone suggestion)

| Field | Value |
|---|---|
| BTC Price ($) | 61722.5 |
| Total Debt ($) | 30000 |
| CF | 0.75 |
| THF | 1.1 |
| LB (maxLB) | 1.05 |
| Expected HF | 0.95 |
| Vault 1 | 0.6 |
| Vault 2 | 0.45 |

Why these: each liquidation event seizes ~`0.40 × total ≈ 0.42 BTC`. With the current order (`Vault 1` 0.6 first) the first event over-seizes by ~0.18 BTC; putting the smaller `Vault 2` (0.45) first over-seizes only ~0.03 BTC, so the optimizer suggests the swap. The low debt keeps liquidation ~30%+ away, so it stays a calm advisory (no red urgent), which renders as the **gold "Reorder vaults to lose less"** card with the chip row and the gold **Apply Optimal Order** button. (Note: the default vaults `0.65 / 0.35` produce no suggestion, because 0.35 is below the seizure target — big-first is already optimal there.)

### Red urgent banner that also shows "Apply Optimal Order"

Same as above, but set **Total Debt ($) = 47000** (keep vaults `0.6 / 0.45`).

This pushes the first liquidation event to ~3.3% away (under the 5% urgent threshold), so the banner turns **red/urgent** while the suboptimal order still stands. You'll see **Add Collateral** (filled) + **Repay Debt** + **Apply Optimal Order** (secondary) together — confirming the renamed label in its second home, with no gold styling or chip row on the urgent banner. (Safe window for "approaching" urgent here is roughly $46,200–$48,600; above that it flips to the "liquidation can trigger now" copy.)

## Notes for reviewers

- This is visual/copy alignment only — no change to the reorder detection or apply logic.
- No core-ui changes; we consume the existing (previously unused) `suggestion` variant.
- Relates to https://github.com/babylonlabs-io/babylon-toolkit/issues/1955 (the Notification primitive + banner migration this builds on).