### PR TITLE
refactor(vault): rename suggested order to optimal

### DIFF
--- a/packages/babylon-core-ui/src/components/Notification/Notification.stories.tsx
+++ b/packages/babylon-core-ui/src/components/Notification/Notification.stories.tsx
@@ -130,7 +130,7 @@ export const SuggestionBelowActions: Story = {
     ),
     actionsPlacement: "below",
     actions: [
-      { label: "Apply Suggested Order", emphasis: "primary", onClick: () => {} },
+      { label: "Apply Optimal Order", emphasis: "primary", onClick: () => {} },
     ],
   },
 };

--- a/services/vault/src/applications/aave/components/PositionNotificationsDebugPanel.tsx
+++ b/services/vault/src/applications/aave/components/PositionNotificationsDebugPanel.tsx
@@ -227,14 +227,14 @@ function ResultPanel({ result }: { result: CalculatorResult }) {
         </details>
       )}
 
-      {/* Suggested order (manual "Apply Suggested Order") */}
-      {result.suggestedVaultOrder && (
+      {/* Suggested order (manual "Apply Optimal Order") */}
+      {result.optimalVaultOrder && (
         <details open>
           <summary className="cursor-pointer font-medium">Suggestions</summary>
           <div className="mt-2 space-y-2 text-sm">
             <VaultOrderDisplay
               label="Suggested order"
-              vaults={result.suggestedVaultOrder}
+              vaults={result.optimalVaultOrder}
             />
           </div>
         </details>

--- a/services/vault/src/applications/aave/hooks/__tests__/useReorderVaults.test.tsx
+++ b/services/vault/src/applications/aave/hooks/__tests__/useReorderVaults.test.tsx
@@ -49,7 +49,7 @@ vi.mock("../../config", () => ({
 
 const mockAssertMembership = vi.fn();
 const mockAssertBaseline = vi.fn();
-const mockAssertSuggestedOrder = vi.fn();
+const mockAssertOptimalOrder = vi.fn();
 const mockReorderVaultOrder = vi.fn();
 
 const { FakePositionChangedError } = vi.hoisted(() => {
@@ -64,8 +64,8 @@ vi.mock("../../services", () => ({
   assertReorderMembership: (...args: unknown[]) =>
     mockAssertMembership(...args),
   assertReorderBaseline: (...args: unknown[]) => mockAssertBaseline(...args),
-  assertSuggestedOrderMatchesOnChain: (...args: unknown[]) =>
-    mockAssertSuggestedOrder(...args),
+  assertOptimalOrderMatchesOnChain: (...args: unknown[]) =>
+    mockAssertOptimalOrder(...args),
   reorderVaultOrder: (...args: unknown[]) => mockReorderVaultOrder(...args),
 }));
 
@@ -102,7 +102,7 @@ describe("useReorderVaults — on-chain integrity guards", () => {
     // submits — individual tests can override.
     mockAssertMembership.mockResolvedValue([VAULT_A, VAULT_B]);
     mockAssertBaseline.mockReturnValue(undefined);
-    mockAssertSuggestedOrder.mockResolvedValue(undefined);
+    mockAssertOptimalOrder.mockResolvedValue(undefined);
     mockReorderVaultOrder.mockResolvedValue({
       transactionHash: "0xtx",
     });
@@ -139,14 +139,14 @@ describe("useReorderVaults — on-chain integrity guards", () => {
     expect(mockHandleError).toHaveBeenCalled();
   });
 
-  it("runs the optimal-order recompute only when suggestedOrderContext is provided", async () => {
+  it("runs the optimal-order recompute only when optimalOrderContext is provided", async () => {
     const { result } = renderHook(() => useReorderVaults());
 
     await act(async () => {
       await result.current.executeReorder([VAULT_A, VAULT_B]);
     });
 
-    expect(mockAssertSuggestedOrder).not.toHaveBeenCalled();
+    expect(mockAssertOptimalOrder).not.toHaveBeenCalled();
     expect(mockReorderVaultOrder).toHaveBeenCalledTimes(1);
   });
 
@@ -159,11 +159,11 @@ describe("useReorderVaults — on-chain integrity guards", () => {
 
     await act(async () => {
       await result.current.executeReorder([VAULT_B, VAULT_A], {
-        suggestedOrderContext: CTX,
+        optimalOrderContext: CTX,
       });
     });
 
-    expect(mockAssertSuggestedOrder).toHaveBeenCalledWith(
+    expect(mockAssertOptimalOrder).toHaveBeenCalledWith(
       [VAULT_B, VAULT_A],
       [VAULT_A, VAULT_B],
       "0xaaaa000000000000000000000000000000000ada",
@@ -173,14 +173,14 @@ describe("useReorderVaults — on-chain integrity guards", () => {
   });
 
   it("blocks the reorder tx when the optimal-order recompute rejects", async () => {
-    mockAssertSuggestedOrder.mockRejectedValue(new Error("order mismatch"));
+    mockAssertOptimalOrder.mockRejectedValue(new Error("order mismatch"));
 
     const { result } = renderHook(() => useReorderVaults());
 
     let resolved: boolean | undefined;
     await act(async () => {
       resolved = await result.current.executeReorder([VAULT_A, VAULT_B], {
-        suggestedOrderContext: CTX,
+        optimalOrderContext: CTX,
       });
     });
 

--- a/services/vault/src/applications/aave/hooks/useReorderVaults.ts
+++ b/services/vault/src/applications/aave/hooks/useReorderVaults.ts
@@ -21,9 +21,9 @@ import {
 import { getAaveAdapterAddress } from "../config";
 import {
   PositionChangedError,
+  assertOptimalOrderMatchesOnChain,
   assertReorderBaseline,
   assertReorderMembership,
-  assertSuggestedOrderMatchesOnChain,
   reorderVaultOrder,
   type ReorderVerificationContext,
 } from "../services";
@@ -35,7 +35,7 @@ export interface ExecuteReorderOptions {
    * sign if the result diverges from the submitted permutation. Manual
    * drag-and-drop reorders omit this so users can pick non-optimal orders.
    */
-  suggestedOrderContext?: ReorderVerificationContext;
+  optimalOrderContext?: ReorderVerificationContext;
   /**
    * The on-chain vault ordering the caller observed at the time it built
    * the submission (e.g. the modal-open snapshot). When provided, the hook
@@ -107,12 +107,12 @@ export function useReorderVaults(): UseReorderVaultsResult {
           );
         }
 
-        if (options?.suggestedOrderContext) {
-          await assertSuggestedOrderMatchesOnChain(
+        if (options?.optimalOrderContext) {
+          await assertOptimalOrderMatchesOnChain(
             permutedVaultIds,
             currentVaultIds,
             adapterAddress,
-            options.suggestedOrderContext,
+            options.optimalOrderContext,
           );
         }
 

--- a/services/vault/src/applications/aave/positionNotifications/__tests__/calculate.test.ts
+++ b/services/vault/src/applications/aave/positionNotifications/__tests__/calculate.test.ts
@@ -92,7 +92,7 @@ describe("calculate", () => {
     expect(result.warnings).toHaveLength(0);
     expect(result.groups).toHaveLength(0);
     expect(result.currentHF).toBe(Infinity);
-    expect(result.suggestedVaultOrder).toBeNull();
+    expect(result.optimalVaultOrder).toBeNull();
   });
 
   it("dust — debt under $1k — single dust warning, one full-liquidation group", () => {
@@ -101,7 +101,7 @@ describe("calculate", () => {
     expect(result.warnings[0].type).toBe("dust");
     expect(result.groups).toHaveLength(1);
     expect(result.groups[0].isFullLiquidation).toBe(true);
-    expect(result.suggestedVaultOrder).toBeNull();
+    expect(result.optimalVaultOrder).toBeNull();
   });
 
   it("dust — collateral under $1k", () => {
@@ -157,7 +157,7 @@ describe("calculate", () => {
     // but invalid params (THF <= expectedHF) suppress the suggestion.
     const result = calculate(makeParams([v(0.35), v(0.65)], { THF: 0.9 }));
     expect(hasWarning(result.warnings, "weird-params")).toBe(true);
-    expect(result.suggestedVaultOrder).toBeNull();
+    expect(result.optimalVaultOrder).toBeNull();
   });
 
   // ── Group breakdown uses the current on-chain order ──────────
@@ -165,24 +165,24 @@ describe("calculate", () => {
   it("group breakdown follows the current order, not the optimal one", () => {
     // [0.35, 0.65] in this order: 0.35 alone can't cover the target, so both
     // vaults are seized together in one event (a worse outcome the user keeps
-    // until they apply the suggested order).
+    // until they apply the optimal order).
     const result = calculate(makeParams([v(0.35), v(0.65)]));
     expect(result.groups).toHaveLength(1);
     expect(result.groups[0].vaults).toHaveLength(2);
   });
 
-  // ── Suggested order ──────────────────────────────────────────
+  // ── Optimal order ──────────────────────────────────────────
 
   it("suggests a better order when the current order is suboptimal", () => {
     const result = calculate(makeParams([v(0.35), v(0.65)]));
-    expect(result.suggestedVaultOrder).not.toBeNull();
+    expect(result.optimalVaultOrder).not.toBeNull();
     // Largest vault first protects more collateral.
-    expect(result.suggestedVaultOrder![0].btc).toBeCloseTo(0.65, 2);
+    expect(result.optimalVaultOrder![0].btc).toBeCloseTo(0.65, 2);
   });
 
   it("suggests nothing when the current order is already optimal", () => {
     const result = calculate(makeParams([v(0.65), v(0.35)]));
-    expect(result.suggestedVaultOrder).toBeNull();
+    expect(result.optimalVaultOrder).toBeNull();
   });
 
   // ── Robustness ───────────────────────────────────────────────
@@ -191,7 +191,7 @@ describe("calculate", () => {
     const vaults = Array.from({ length: 14 }, (_, i) => v(0.1 + i * 0.03));
     const result = calculate(makeParams(vaults));
     expect(result.groups.length).toBeGreaterThan(0);
-    expect(result.suggestedVaultOrder ?? vaults).toHaveLength(14);
+    expect(result.optimalVaultOrder ?? vaults).toHaveLength(14);
   });
 
   it("only ever emits urgent / dust / weird-params", () => {

--- a/services/vault/src/applications/aave/positionNotifications/bannerSeverity.ts
+++ b/services/vault/src/applications/aave/positionNotifications/bannerSeverity.ts
@@ -13,7 +13,7 @@ export interface BannerState {
   secondaryWarnings: Warning[];
   /**
    * The engine found a safer liquidation order than the current on-chain order.
-   * Drives the manual "Apply Suggested Order" affordance, independent of the
+   * Drives the manual "Apply Optimal Order" affordance, independent of the
    * risk warnings — it can accompany an urgent/soft banner or stand alone on an
    * otherwise-healthy position.
    */
@@ -31,7 +31,7 @@ export interface BannerState {
  */
 export function deriveBannerState(result: CalculatorResult): BannerState {
   const { warnings, groups } = result;
-  const suggestReorder = result.suggestedVaultOrder != null;
+  const suggestReorder = result.optimalVaultOrder != null;
 
   // Warnings are evaluated before the "no groups" check so that an advisory
   // with no computable cascade (e.g. weird-params, which leaves groups empty)

--- a/services/vault/src/applications/aave/positionNotifications/calculate.ts
+++ b/services/vault/src/applications/aave/positionNotifications/calculate.ts
@@ -37,8 +37,8 @@ const REORDER_TOL = 0.001;
  *
  * Liquidation follows the current on-chain vault order, so the group breakdown
  * is computed against that order. Separately, the optimizer is run and — when
- * it finds a strictly better order — `suggestedVaultOrder` is returned so the
- * banner can offer a manual "Apply Suggested Order" action. Warnings are limited
+ * it finds a strictly better order — `optimalVaultOrder` is returned so the
+ * banner can offer a manual "Apply Optimal Order" action. Warnings are limited
  * to three types: `weird-params` (invalid protocol params, soft), `urgent`
  * (already liquidatable or within 5% of the trigger), or `dust`.
  */
@@ -71,7 +71,7 @@ export function calculate(params: CalculatorParams): CalculatorResult {
       collateralValue,
       targetSeizureBtc: 0,
       warnings,
-      suggestedVaultOrder: null,
+      optimalVaultOrder: null,
     };
   }
 
@@ -111,7 +111,7 @@ export function calculate(params: CalculatorParams): CalculatorResult {
           detail: COPY.liquidationWarnings.dust.detail,
         },
       ],
-      suggestedVaultOrder: null,
+      optimalVaultOrder: null,
     };
   }
 
@@ -225,15 +225,15 @@ export function calculate(params: CalculatorParams): CalculatorResult {
     groupIndex++;
   }
 
-  // ── 4. Optimal-order analysis (manual "Apply Suggested Order") ──
+  // ── 4. Optimal-order analysis (manual "Apply Optimal Order") ──
   //
   // We never reorder automatically. Score the current order against the
   // optimizer's best order; only when the optimizer strictly improves the
   // cascade (more BTC surviving across events, tie-broken by BTC after the
-  // first event) do we surface a suggested order for the user to apply.
+  // first event) do we surface the optimal order for the user to apply.
   // Skipped under invalid params — the cascade scores are meaningless there.
 
-  let suggestedVaultOrder: Vault[] | null = null;
+  let optimalVaultOrder: Vault[] | null = null;
   if (!seizedParamsInvalid) {
     const current = simulateCascade(
       vaults,
@@ -260,7 +260,7 @@ export function calculate(params: CalculatorParams): CalculatorResult {
     const afterG1Improves =
       Math.abs(optimal.sumBtcAfterEvents - current.sumBtcAfterEvents) <=
         REORDER_TOL && optimal.btcAfterG1 > current.btcAfterG1 + REORDER_TOL;
-    if (sumImproves || afterG1Improves) suggestedVaultOrder = optimal.order;
+    if (sumImproves || afterG1Improves) optimalVaultOrder = optimal.order;
   }
 
   // ── 5. Warnings ────────────────────────────────────────────────
@@ -327,6 +327,6 @@ export function calculate(params: CalculatorParams): CalculatorResult {
     collateralValue,
     targetSeizureBtc,
     warnings,
-    suggestedVaultOrder,
+    optimalVaultOrder,
   };
 }

--- a/services/vault/src/applications/aave/positionNotifications/types.ts
+++ b/services/vault/src/applications/aave/positionNotifications/types.ts
@@ -60,8 +60,8 @@ export interface CalculatorResult {
   /**
    * The liquidation-optimal vault order the calculator settled on. The group
    * breakdown is computed against this order. Null on early exits (no debt /
-   * dust). Not surfaced in the banner yet — consumed by the (deferred)
-   * auto-reorder-on-EVM-action flow.
+   * dust). Surfaced in the reorder notification as the optimal-order chips
+   * and the "Apply Optimal Order" action.
    */
-  suggestedVaultOrder: Vault[] | null;
+  optimalVaultOrder: Vault[] | null;
 }

--- a/services/vault/src/applications/aave/services/__tests__/assertReorderMatchesOnChain.test.ts
+++ b/services/vault/src/applications/aave/services/__tests__/assertReorderMatchesOnChain.test.ts
@@ -6,7 +6,7 @@
  * Returns the current on-chain ordering so Guard B can feed it into the
  * calculator.
  *
- * Guard B — `assertSuggestedOrderMatchesOnChain`: re-runs the full
+ * Guard B — `assertOptimalOrderMatchesOnChain`: re-runs the full
  * notification calculator with on-chain amounts and blocks submissions
  * whose ordering disagrees (the same-set tamper attack), whose vaults
  * are inactive or bound to a different application, or whose trusted
@@ -21,12 +21,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getBtcVaultBasicInfoFromChain } from "@/clients/eth-contract/btc-vault-registry/query";
 
 import {
+  OptimalReorderMismatchError,
   PositionChangedError,
   ReorderMembershipMismatchError,
-  SuggestedReorderMismatchError,
+  assertOptimalOrderMatchesOnChain,
   assertReorderBaseline,
   assertReorderMembership,
-  assertSuggestedOrderMatchesOnChain,
   type ReorderVerificationContext,
 } from "../assertReorderMatchesOnChain";
 
@@ -67,7 +67,7 @@ const VAULT_C =
  * High-debt context where the optimizer prefers concentrating seizure on
  * the larger vault first ([A=0.6, B=0.1] → suggested [A, B]). Current
  * order in tests is [B, A] so `calculate()` will surface a non-null
- * `suggestedVaultOrder = [A, B]`.
+ * `optimalVaultOrder = [A, B]`.
  */
 const CONTEXT_BASE: ReorderVerificationContext = {
   CF: 0.7,
@@ -181,12 +181,12 @@ describe("assertReorderMembership", () => {
   });
 });
 
-describe("assertSuggestedOrderMatchesOnChain", () => {
+describe("assertOptimalOrderMatchesOnChain", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("resolves when the submission equals the calculator's suggested order under on-chain amounts", async () => {
+  it("resolves when the submission equals the calculator's optimal order under on-chain amounts", async () => {
     // Current order [B, A] is suboptimal (smaller-first cliff). Calculator
     // suggests [A, B] (larger-first). Submission matches.
     mockGetBtcVaultBasicInfo.mockResolvedValue(
@@ -197,7 +197,7 @@ describe("assertSuggestedOrderMatchesOnChain", () => {
     );
 
     await expect(
-      assertSuggestedOrderMatchesOnChain(
+      assertOptimalOrderMatchesOnChain(
         [VAULT_A, VAULT_B],
         [VAULT_B, VAULT_A],
         ADAPTER,
@@ -218,17 +218,17 @@ describe("assertSuggestedOrderMatchesOnChain", () => {
     );
 
     await expect(
-      assertSuggestedOrderMatchesOnChain(
+      assertOptimalOrderMatchesOnChain(
         [VAULT_B, VAULT_A],
         [VAULT_B, VAULT_A],
         ADAPTER,
         CONTEXT_BASE,
       ),
-    ).rejects.toBeInstanceOf(SuggestedReorderMismatchError);
+    ).rejects.toBeInstanceOf(OptimalReorderMismatchError);
   });
 
   it("rejects when the trusted calculator would not have suggested a reorder (no debt)", async () => {
-    // No-debt scenario → calculator returns early with suggestedVaultOrder: null.
+    // No-debt scenario → calculator returns early with optimalVaultOrder: null.
     // Indexer would have fabricated a CTA; Guard B refuses.
     mockGetBtcVaultBasicInfo.mockResolvedValue(
       basicInfoMap([
@@ -238,13 +238,13 @@ describe("assertSuggestedOrderMatchesOnChain", () => {
     );
 
     await expect(
-      assertSuggestedOrderMatchesOnChain(
+      assertOptimalOrderMatchesOnChain(
         [VAULT_A, VAULT_B],
         [VAULT_B, VAULT_A],
         ADAPTER,
         { ...CONTEXT_BASE, totalDebtUsd: 0 },
       ),
-    ).rejects.toBeInstanceOf(SuggestedReorderMismatchError);
+    ).rejects.toBeInstanceOf(OptimalReorderMismatchError);
   });
 
   it("rejects when the current ordering is already optimal (calculator returns null)", async () => {
@@ -259,13 +259,13 @@ describe("assertSuggestedOrderMatchesOnChain", () => {
     );
 
     await expect(
-      assertSuggestedOrderMatchesOnChain(
+      assertOptimalOrderMatchesOnChain(
         [VAULT_B, VAULT_A],
         [VAULT_A, VAULT_B],
         ADAPTER,
         CONTEXT_BASE,
       ),
-    ).rejects.toBeInstanceOf(SuggestedReorderMismatchError);
+    ).rejects.toBeInstanceOf(OptimalReorderMismatchError);
   });
 
   it("rejects when any vault is not in ACTIVE status", async () => {
@@ -284,13 +284,13 @@ describe("assertSuggestedOrderMatchesOnChain", () => {
     );
 
     await expect(
-      assertSuggestedOrderMatchesOnChain(
+      assertOptimalOrderMatchesOnChain(
         [VAULT_A, VAULT_B],
         [VAULT_B, VAULT_A],
         ADAPTER,
         CONTEXT_BASE,
       ),
-    ).rejects.toBeInstanceOf(SuggestedReorderMismatchError);
+    ).rejects.toBeInstanceOf(OptimalReorderMismatchError);
   });
 
   it("rejects when a vault's applicationEntryPoint differs from the trusted adapter", async () => {
@@ -302,13 +302,13 @@ describe("assertSuggestedOrderMatchesOnChain", () => {
     );
 
     await expect(
-      assertSuggestedOrderMatchesOnChain(
+      assertOptimalOrderMatchesOnChain(
         [VAULT_A, VAULT_B],
         [VAULT_B, VAULT_A],
         ADAPTER,
         CONTEXT_BASE,
       ),
-    ).rejects.toBeInstanceOf(SuggestedReorderMismatchError);
+    ).rejects.toBeInstanceOf(OptimalReorderMismatchError);
   });
 
   it("matches applicationEntryPoint case-insensitively", async () => {
@@ -320,7 +320,7 @@ describe("assertSuggestedOrderMatchesOnChain", () => {
     );
 
     await expect(
-      assertSuggestedOrderMatchesOnChain(
+      assertOptimalOrderMatchesOnChain(
         [VAULT_A, VAULT_B],
         [VAULT_B, VAULT_A],
         ADAPTER,
@@ -338,7 +338,7 @@ describe("assertSuggestedOrderMatchesOnChain", () => {
     );
 
     await expect(
-      assertSuggestedOrderMatchesOnChain(
+      assertOptimalOrderMatchesOnChain(
         [VAULT_A.toUpperCase() as Hex, VAULT_B],
         [VAULT_B, VAULT_A],
         ADAPTER,
@@ -349,8 +349,8 @@ describe("assertSuggestedOrderMatchesOnChain", () => {
 
   it("rejects empty submissions", async () => {
     await expect(
-      assertSuggestedOrderMatchesOnChain([], [], ADAPTER, CONTEXT_BASE),
-    ).rejects.toBeInstanceOf(SuggestedReorderMismatchError);
+      assertOptimalOrderMatchesOnChain([], [], ADAPTER, CONTEXT_BASE),
+    ).rejects.toBeInstanceOf(OptimalReorderMismatchError);
     expect(mockGetBtcVaultBasicInfo).not.toHaveBeenCalled();
   });
 
@@ -360,7 +360,7 @@ describe("assertSuggestedOrderMatchesOnChain", () => {
     );
 
     await expect(
-      assertSuggestedOrderMatchesOnChain(
+      assertOptimalOrderMatchesOnChain(
         [VAULT_A, VAULT_B],
         [VAULT_B, VAULT_A],
         ADAPTER,
@@ -369,19 +369,19 @@ describe("assertSuggestedOrderMatchesOnChain", () => {
     ).rejects.toThrow("vault not registered on-chain");
   });
 
-  it("throws SuggestedReorderMismatchError when the registry omits a vault from its response", async () => {
+  it("throws OptimalReorderMismatchError when the registry omits a vault from its response", async () => {
     mockGetBtcVaultBasicInfo.mockResolvedValue(
       basicInfoMap([[VAULT_A, activeInfo(60_000_000n)]]),
     );
 
     await expect(
-      assertSuggestedOrderMatchesOnChain(
+      assertOptimalOrderMatchesOnChain(
         [VAULT_A, VAULT_B],
         [VAULT_B, VAULT_A],
         ADAPTER,
         CONTEXT_BASE,
       ),
-    ).rejects.toBeInstanceOf(SuggestedReorderMismatchError);
+    ).rejects.toBeInstanceOf(OptimalReorderMismatchError);
   });
 });
 

--- a/services/vault/src/applications/aave/services/assertReorderMatchesOnChain.ts
+++ b/services/vault/src/applications/aave/services/assertReorderMatchesOnChain.ts
@@ -14,12 +14,12 @@
  *   from the env-pinned adapter and refuses if the submitted multiset
  *   disagrees with the on-chain set.
  *
- * - `assertSuggestedOrderMatchesOnChain` re-fetches per-vault basic info
+ * - `assertOptimalOrderMatchesOnChain` re-fetches per-vault basic info
  *   from `BTCVaultRegistry.getBtcVaultBasicInfo` (amount, status,
  *   applicationEntryPoint), re-runs the full `calculate(...)` pipeline
  *   with on-chain amounts, and refuses if any per-vault status /
  *   application check fails or if the trusted calculator's
- *   `suggestedVaultOrder` does not equal the submission (including the
+ *   `optimalVaultOrder` does not equal the submission (including the
  *   case where the trusted calculator would have suggested no reorder at
  *   all). Only called when the caller is the auto-suggested CTA — manual
  *   drag-and-drop reorders intentionally skip this guard so the user can
@@ -40,8 +40,8 @@ export class ReorderMembershipMismatchError extends Error {
   readonly code = "REORDER_MEMBERSHIP_MISMATCH";
 }
 
-export class SuggestedReorderMismatchError extends Error {
-  readonly code = "SUGGESTED_REORDER_MISMATCH";
+export class OptimalReorderMismatchError extends Error {
+  readonly code = "OPTIMAL_REORDER_MISMATCH";
 }
 
 export class PositionChangedError extends Error {
@@ -49,7 +49,7 @@ export class PositionChangedError extends Error {
 }
 
 /**
- * Trusted calculator inputs for the suggested-order recompute. All values
+ * Trusted calculator inputs for the optimal-order recompute. All values
  * must be on-chain-anchored — the whole point of the guard is to refuse
  * recomputes against indexer-supplied inputs.
  *
@@ -140,7 +140,7 @@ export async function assertReorderMembership(
  * rebalance condition the user currently doesn't have — are honored. A
  * malicious indexer can otherwise fabricate a CTA whose submitted order
  * equals `computeOptimalOrder(trusted).order` even though the trusted
- * calculator would have returned `suggestedVaultOrder: null`.
+ * calculator would have returned `optimalVaultOrder: null`.
  *
  * The calculator needs the **current** on-chain ordering as its `vaults`
  * input so it can decide whether a reorder helps relative to that
@@ -159,18 +159,18 @@ export async function assertReorderMembership(
  *   `AaveIntegrationAdapter.getPosition(user).vaultIds`. Used as the
  *   `vaults` input to `calculate(...)` so the suppression rules see the
  *   user's actual current ordering.
- * @throws {SuggestedReorderMismatchError} when any per-vault check fails,
- *   the trusted calculator suggests no reorder, or the suggested order
+ * @throws {OptimalReorderMismatchError} when any per-vault check fails,
+ *   the trusted calculator suggests no reorder, or the optimal order
  *   does not equal the submission.
  */
-export async function assertSuggestedOrderMatchesOnChain(
+export async function assertOptimalOrderMatchesOnChain(
   submittedVaultIds: readonly Hex[],
   currentVaultIds: readonly Hex[],
   trustedAdapterAddress: Address,
   ctx: ReorderVerificationContext,
 ): Promise<void> {
   if (submittedVaultIds.length === 0) {
-    throw new SuggestedReorderMismatchError(
+    throw new OptimalReorderMismatchError(
       "Reorder submission is empty — refusing to sign.",
     );
   }
@@ -180,12 +180,12 @@ export async function assertSuggestedOrderMatchesOnChain(
   const vaults: Vault[] = currentVaultIds.map((id, i) => {
     const info = basicInfo.get(lower(id) as Hex);
     if (info === undefined) {
-      throw new SuggestedReorderMismatchError(
+      throw new OptimalReorderMismatchError(
         `On-chain basic info for vault ${id} not returned by registry multicall.`,
       );
     }
     if (info.status !== ContractStatus.ACTIVE) {
-      throw new SuggestedReorderMismatchError(
+      throw new OptimalReorderMismatchError(
         `Vault ${id} has on-chain status ${info.status}, expected ACTIVE (${ContractStatus.ACTIVE}). Refusing to recompute reorder against a non-active vault.`,
       );
     }
@@ -193,7 +193,7 @@ export async function assertSuggestedOrderMatchesOnChain(
       info.applicationEntryPoint.toLowerCase() !==
       trustedAdapterAddress.toLowerCase()
     ) {
-      throw new SuggestedReorderMismatchError(
+      throw new OptimalReorderMismatchError(
         `Vault ${id} is bound to application ${info.applicationEntryPoint}, expected the env-pinned Aave adapter ${trustedAdapterAddress}.`,
       );
     }
@@ -204,7 +204,7 @@ export async function assertSuggestedOrderMatchesOnChain(
     };
   });
 
-  const { suggestedVaultOrder } = calculate({
+  const { optimalVaultOrder } = calculate({
     btcPrice: ctx.btcPrice,
     totalDebtUsd: ctx.totalDebtUsd,
     vaults,
@@ -214,17 +214,17 @@ export async function assertSuggestedOrderMatchesOnChain(
     ...(ctx.expectedHF !== undefined ? { expectedHF: ctx.expectedHF } : {}),
   });
 
-  if (suggestedVaultOrder === null) {
-    throw new SuggestedReorderMismatchError(
+  if (optimalVaultOrder === null) {
+    throw new OptimalReorderMismatchError(
       "Trusted calculator would not have suggested a reorder under on-chain amounts. Aborting to avoid signing an indexer-fabricated CTA.",
     );
   }
 
-  const expectedOrder = suggestedVaultOrder.map((v) => v.id as Hex);
+  const expectedOrder = optimalVaultOrder.map((v) => v.id as Hex);
 
   if (!sameOrderedSequence(submittedVaultIds, expectedOrder)) {
-    throw new SuggestedReorderMismatchError(
-      "Suggested reorder does not match the calculator's output under on-chain amounts. Aborting to avoid signing an indexer-steered permutation.",
+    throw new OptimalReorderMismatchError(
+      "Optimal reorder does not match the calculator's output under on-chain amounts. Aborting to avoid signing an indexer-steered permutation.",
     );
   }
 }

--- a/services/vault/src/applications/aave/services/index.ts
+++ b/services/vault/src/applications/aave/services/index.ts
@@ -34,9 +34,9 @@ export {
 // On-chain integrity guards
 export {
   PositionChangedError,
+  assertOptimalOrderMatchesOnChain,
   assertReorderBaseline,
   assertReorderMembership,
-  assertSuggestedOrderMatchesOnChain,
   type ReorderVerificationContext,
 } from "./assertReorderMatchesOnChain";
 export {

--- a/services/vault/src/components/simple/PositionNotificationBanner/BannerActions.tsx
+++ b/services/vault/src/components/simple/PositionNotificationBanner/BannerActions.tsx
@@ -20,7 +20,7 @@ interface BuildBannerActionsArgs {
  * `Notification` `actions` slot:
  * - urgent: "Add Collateral" (primary, filled) + "Repay Debt" (secondary,
  *   outlined) — the core safety actions, matching the Figma callout.
- * - suggested reorder available: "Apply Optimal Order" — filled (primary) on the
+ * - optimal reorder available: "Apply Optimal Order" — filled (primary) on the
  *   standalone reorder card, secondary when it accompanies the urgent callout.
  *
  * Both groups can appear together (an urgent position whose order is also
@@ -36,7 +36,7 @@ export function buildBannerActions({
 }: BuildBannerActionsArgs): NotificationAction[] {
   const { primaryWarning, suggestReorder } = bannerState;
   const isUrgent = primaryWarning?.type === "urgent";
-  const showApplyOrder = suggestReorder && result.suggestedVaultOrder !== null;
+  const showApplyOrder = suggestReorder && result.optimalVaultOrder !== null;
 
   const actions: NotificationAction[] = [];
 

--- a/services/vault/src/components/simple/PositionNotificationBanner/OptimalOrderChips.tsx
+++ b/services/vault/src/components/simple/PositionNotificationBanner/OptimalOrderChips.tsx
@@ -4,7 +4,7 @@ import type { Vault } from "@/applications/aave/positionNotifications";
 import { COPY } from "@/copy";
 import { formatBtcAmount } from "@/utils/formatting";
 
-interface SuggestedOrderChipsProps {
+interface OptimalOrderChipsProps {
   vaults: Vault[];
 }
 
@@ -13,7 +13,7 @@ interface SuggestedOrderChipsProps {
  * a label above a wrapped row of vault pills joined by arrows,
  * read left-to-right as the order the apply action would submit.
  */
-export function SuggestedOrderChips({ vaults }: SuggestedOrderChipsProps) {
+export function OptimalOrderChips({ vaults }: OptimalOrderChipsProps) {
   return (
     <div className="flex flex-col gap-2">
       <div className="text-xs uppercase tracking-[0.4px] text-accent-secondary">

--- a/services/vault/src/components/simple/PositionNotificationBanner/PositionNotificationBanner.tsx
+++ b/services/vault/src/components/simple/PositionNotificationBanner/PositionNotificationBanner.tsx
@@ -30,7 +30,7 @@ import {
   STALE_PRICE_BANNER_DETAIL,
   STALE_PRICE_BANNER_TITLE,
 } from "./constants";
-import { SuggestedOrderChips } from "./SuggestedOrderChips";
+import { OptimalOrderChips } from "./OptimalOrderChips";
 
 const TEST_ID = "position-notification-banner";
 
@@ -98,10 +98,10 @@ export function PositionNotificationBanner({
   }, []);
 
   const handleApplyOrder = useCallback(async () => {
-    if (!result?.suggestedVaultOrder || !reorderVerificationContext) return;
-    const vaultIds = result.suggestedVaultOrder.map((v) => v.id as Hex);
+    if (!result?.optimalVaultOrder || !reorderVerificationContext) return;
+    const vaultIds = result.optimalVaultOrder.map((v) => v.id as Hex);
     const success = await executeReorder(vaultIds, {
-      suggestedOrderContext: reorderVerificationContext,
+      optimalOrderContext: reorderVerificationContext,
     });
     if (success) {
       // Show the just-submitted order immediately; the indexer catches up later.
@@ -183,11 +183,11 @@ export function PositionNotificationBanner({
     isReordering,
   });
 
-  // Sub-box content: the suggested-order chips for the standalone reorder card,
+  // Sub-box content: the optimal-order chips for the standalone reorder card,
   // otherwise the stacked secondary warnings (e.g. urgent + weird-params).
   let suggestion: ReactNode;
-  if (isStandaloneReorder && result.suggestedVaultOrder) {
-    suggestion = <SuggestedOrderChips vaults={result.suggestedVaultOrder} />;
+  if (isStandaloneReorder && result.optimalVaultOrder) {
+    suggestion = <OptimalOrderChips vaults={result.optimalVaultOrder} />;
   } else if (secondaryWarnings.length > 0) {
     suggestion = (
       <div className="flex flex-col gap-2">

--- a/services/vault/src/components/simple/PositionNotificationBanner/__tests__/PositionNotificationBanner.test.tsx
+++ b/services/vault/src/components/simple/PositionNotificationBanner/__tests__/PositionNotificationBanner.test.tsx
@@ -155,12 +155,12 @@ function makeBaseResult(
     collateralValue: 40000,
     targetSeizureBtc: 0.28,
     warnings: [],
-    suggestedVaultOrder: null,
+    optimalVaultOrder: null,
     ...overrides,
   };
 }
 
-const SUGGESTED_ORDER = [
+const OPTIMAL_ORDER = [
   { id: "0xabc", name: "Vault 2", btc: 0.6 },
   { id: "0xdef", name: "Vault 1", btc: 0.1 },
 ];
@@ -298,7 +298,7 @@ describe("PositionNotificationBanner", () => {
   });
 
   it("does not render a dismiss control on the reorder suggestion", () => {
-    const result = makeBaseResult({ suggestedVaultOrder: SUGGESTED_ORDER });
+    const result = makeBaseResult({ optimalVaultOrder: OPTIMAL_ORDER });
     renderBanner(result, onDeposit, onRepay);
 
     expect(
@@ -307,7 +307,7 @@ describe("PositionNotificationBanner", () => {
   });
 
   it("renders the gold reorder suggestion with a chip row + Apply Optimal Order for a healthy but suboptimal position", () => {
-    const result = makeBaseResult({ suggestedVaultOrder: SUGGESTED_ORDER });
+    const result = makeBaseResult({ optimalVaultOrder: OPTIMAL_ORDER });
     renderBanner(result, onDeposit, onRepay);
 
     const banner = screen.getByTestId("position-notification-banner");
@@ -315,7 +315,7 @@ describe("PositionNotificationBanner", () => {
     // Standalone reorder uses the gold `suggestion` variant, not blue `info`.
     expect(banner.dataset.variant).toBe("suggestion");
     expect(screen.getByText("Reorder vaults to lose less")).toBeTruthy();
-    // Suggested-order chip row renders each vault in order.
+    // Optimal-order chip row renders each vault in order.
     expect(screen.getByText("Suggested order")).toBeTruthy();
     expect(screen.getByText(/Vault 2 ·/)).toBeTruthy();
     expect(screen.getByText(/Vault 1 ·/)).toBeTruthy();
@@ -330,7 +330,7 @@ describe("PositionNotificationBanner", () => {
       warnings: [
         { type: "urgent", title: "Liquidation is 4.3% away", detail: "..." },
       ],
-      suggestedVaultOrder: SUGGESTED_ORDER,
+      optimalVaultOrder: OPTIMAL_ORDER,
     });
     renderBanner(result, onDeposit, onRepay);
 
@@ -360,12 +360,12 @@ describe("PositionNotificationBanner", () => {
   });
 
   it("calls executeReorder with vault IDs and verification context when Apply Optimal Order is clicked", () => {
-    const result = makeBaseResult({ suggestedVaultOrder: SUGGESTED_ORDER });
+    const result = makeBaseResult({ optimalVaultOrder: OPTIMAL_ORDER });
     renderBanner(result, onDeposit, onRepay);
 
     fireEvent.click(screen.getByText("Apply Optimal Order"));
     expect(mockExecuteReorder).toHaveBeenCalledWith(["0xabc", "0xdef"], {
-      suggestedOrderContext: mockReorderVerificationContext,
+      optimalOrderContext: mockReorderVerificationContext,
     });
   });
 
@@ -376,7 +376,7 @@ describe("PositionNotificationBanner", () => {
       isLoading: false,
       reorderVerificationContext: null,
     });
-    const result = makeBaseResult({ suggestedVaultOrder: SUGGESTED_ORDER });
+    const result = makeBaseResult({ optimalVaultOrder: OPTIMAL_ORDER });
     renderBanner(result, onDeposit, onRepay);
 
     fireEvent.click(screen.getByText("Apply Optimal Order"));

--- a/services/vault/src/components/simple/__tests__/CriticalLiquidationTopBanner.test.tsx
+++ b/services/vault/src/components/simple/__tests__/CriticalLiquidationTopBanner.test.tsx
@@ -47,7 +47,7 @@ function makeResult({
     collateralValue: 100000,
     targetSeizureBtc: 0,
     warnings: urgent ? [{ type: "urgent", title: "x", detail: "y" }] : [],
-    suggestedVaultOrder: null,
+    optimalVaultOrder: null,
   };
 }
 


### PR DESCRIPTION
# Reorder notification: align internal naming to "optimal" + fix stale "Apply Suggested Order" references

Resolves the review comment on https://github.com/babylonlabs-io/babylon-toolkit/pull/1965: https://github.com/babylonlabs-io/babylon-toolkit/pull/1965#discussion_r3471381495

Follow-up to https://github.com/babylonlabs-io/babylon-toolkit/pull/1965 (the reorder notification), which renamed the button to "Apply Optimal Order" but left a few stale references and inconsistent internal naming behind.

## What this PR does

Two related cleanups, no behavior change:

1. **Fixes the stale references the reviewer flagged.** A handful of comments still quoted the old "Apply Suggested Order" button label, and one JSDoc said the suggested order "isn't surfaced in the banner yet" — which is no longer true (it now drives the chip row + button). It also updates the Storybook story that mirrors this exact card (the reviewer thought it was unrelated; it actually models our reorder notification 1:1, so its button label was stale too).
2. **Aligns the internal code naming to "optimal".** The optimizer computes the *optimal* vault order, so the code now calls it that consistently: the `optimalVaultOrder` field, the `OptimalOrderChips` component, the reorder-verification helper and its error type, and the related comments/test names.

## Why

After #1965 the codebase was half-and-half: the user-facing button said "Apply Optimal Order", but the field, component, security-check function, error class, and many comments still said "suggested". That mismatch is confusing to read and easy to grep wrong. Unifying the internal naming on "optimal" (what the optimizer actually produces) makes the feature consistent end-to-end.

## The one subtlety: the visible label stays "Suggested order"

The on-screen sub-box label is **"SUGGESTED ORDER"**, and that is intentional — the live Figma (notification node `6502-111184`) deliberately uses "Suggested order" for the box label and "Apply Optimal Order" only for the button. So we **kept the visible label as "Suggested order"** (it matches Figma) and only changed the code that names the order. If you see "Suggested order" still rendered in the UI, that's correct and matches design.

To keep this coherent we drew one line:
- **The order itself** (a noun) → renamed to "optimal" everywhere in code: `optimalVaultOrder`, `OptimalOrderChips`, `optimalOrderContext`, `assertOptimalOrderMatchesOnChain`, `OptimalReorderMismatchError`.
- **The act of suggesting** (a verb) → kept as "suggest": we still *suggest* the optimal order to the user, so phrases like "suggest a reorder", "would have suggested a reorder", the `suggestReorder` flag, and "auto-suggested CTA" stay. Renaming those to "optimal" would read wrong.
- **The visible label** → stays "Suggested order" (Figma).

## Approaches and decisions

**Match Figma for the visible label, not blanket find-replace.** A naive "replace every 'suggested' with 'optimal'" would have changed the on-screen label and diverged from Figma. We confirmed the live Figma still shows "Suggested order" for the box label and scoped the rename to code only.

**Include the Storybook story.** The reviewer suggested leaving the Storybook reference, but on inspection that story (`SuggestionBelowActions`) is a faithful mock of this card — same gold variant, title, body, and chips — so its "Apply Suggested Order" button was stale for the same reason. Updated it so the story keeps documenting the real card. (Happy to revert if you'd rather freeze that story.)

**Rename the security-path API too.** The reorder-verification function and its error type (`assertSuggestedOrderMatchesOnChain` / `SuggestedReorderMismatchError`) live on the path that guards against an indexer-steered reorder before signing. We renamed them to `assertOptimalOrderMatchesOnChain` / `OptimalReorderMismatchError` for consistency. This is a pure rename — no logic change — and the existing `instanceof` tests cover it. We also confirmed the error `code` string isn't referenced anywhere else before changing it, so no telemetry/error-mapping breaks.

## Files changed (high level)

- `positionNotifications/` — `types.ts` (`optimalVaultOrder` field + JSDoc), `calculate.ts`, `bannerSeverity.ts`, and tests.
- `PositionNotificationBanner/` — `OptimalOrderChips.tsx` (renamed from `SuggestedOrderChips.tsx`), `PositionNotificationBanner.tsx`, `BannerActions.tsx`, and tests.
- `services/assertReorderMatchesOnChain.ts` + `services/index.ts` + `hooks/useReorderVaults.ts` — renamed function/error/context, message, and `@throws` doc, plus their tests.
- `applications/aave/components/PositionNotificationsDebugPanel.tsx` — comment + field access.
- `packages/babylon-core-ui/.../Notification.stories.tsx` — Storybook button label.

The user-facing `COPY.liquidationWarnings.reorder.suggestedOrderLabel = "Suggested order"` is intentionally unchanged.

## How to verify (optional)

Nothing visual changed, but if you want to confirm the card still works: open the dashboard debug panel (Manual Mode) with a healthy-but-suboptimal position — e.g. BTC `61722.5`, Debt `30000`, CF `0.75`, THF `1.1`, LB `1.05`, Expected HF `0.95`, vaults `0.6` and `0.45`. You should still see the gold "Reorder vaults to lose less" card, the "SUGGESTED ORDER" chips, and the "Apply Optimal Order" button.
