### PR TITLE
feat(vault): port reference liquidation calculator

### DIFF
--- a/packages/babylon-ts-sdk/src/tbv/integrations/aave/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/integrations/aave/index.ts
@@ -120,6 +120,7 @@ export {
   getHealthFactorStatusFromValue,
   hasDebtFromPosition,
   isHealthFactorHealthy,
+  MAX_DP_N,
   selectVaultsForAmount,
   simulateCascade,
   simulatePrefixSeizure,

--- a/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/__tests__/optimalOrder.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/__tests__/optimalOrder.test.ts
@@ -97,9 +97,10 @@ describe("computeOptimalOrder", () => {
     expect(result.sumBtcAfterEvents).toBe(0);
   });
 
-  it("handles more vaults than the DP cap without throwing", () => {
-    // 14 vaults > MAX_DP_N (10): the smallest get pre-jointed into composites.
-    const vaults = Array.from({ length: 14 }, (_, idx) =>
+  it("falls back to largest-first beyond the DP cap without throwing", () => {
+    // 18 vaults > MAX_DP_N (17): the optimizer skips the bitmask DP and returns
+    // a largest-first heuristic order instead of throwing.
+    const vaults = Array.from({ length: 18 }, (_, idx) =>
       vault(`v${idx}`, 0.1 + idx * 0.05),
     );
     const result = computeOptimalOrder(
@@ -112,9 +113,11 @@ describe("computeOptimalOrder", () => {
       LB,
       expectedHF,
     );
-    // Reconstruction returns every original vault exactly once.
-    expect(result.order).toHaveLength(14);
-    expect(new Set(result.order.map((v) => v.id)).size).toBe(14);
+    // Every original vault appears exactly once, ordered by descending BTC.
+    expect(result.order).toHaveLength(18);
+    expect(new Set(result.order.map((v) => v.id)).size).toBe(18);
+    const descending = [...vaults].sort((a, b) => b.btc - a.btc);
+    expect(result.order.map((v) => v.id)).toEqual(descending.map((v) => v.id));
     expect(result.sumBtcAfterEvents).toBeGreaterThan(0);
   });
 

--- a/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/cascadeSimulation.ts
+++ b/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/cascadeSimulation.ts
@@ -19,16 +19,6 @@ export interface CascadeVault {
   btc: number;
 }
 
-/**
- * A composite of one or more vaults treated as a single unit by the optimizer.
- * The smallest vaults are merged into pre-joints so the bitmask DP stays within
- * `MAX_DP_N` states regardless of how many vaults the position holds.
- */
-export interface PreJointVaults<T extends CascadeVault> {
-  sum: number;
-  vaults: T[];
-}
-
 /** 1% tolerance for prefix walk coverage — avoids cliff flip at boundary */
 export const SEIZURE_TOL = 0.01;
 

--- a/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/index.ts
@@ -28,7 +28,7 @@ export {
   simulateCascade,
 } from "./cascadeSimulation.js";
 export type { CascadeVault } from "./cascadeSimulation.js";
-export { computeOptimalOrder } from "./optimalOrder.js";
+export { computeOptimalOrder, MAX_DP_N } from "./optimalOrder.js";
 export {
   computeTargetSeizureSats,
   simulatePrefixSeizure,

--- a/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/optimalOrder.ts
+++ b/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/optimalOrder.ts
@@ -168,8 +168,15 @@ export function computeOptimalOrder<T extends CascadeVault>(
   const order = groupsReversed.flat();
 
   // Reconstruction safety: if the chain is incomplete for any reason, fall back
-  // to largest-first rather than throwing.
+  // to largest-first rather than throwing (calculate() runs in the notification
+  // render and must not crash). This path is a DP-invariant violation that
+  // should never occur for valid input — log it so a regression is observable
+  // even though the fallback keeps the UI alive and the result well-shaped.
   if (order.length !== n) {
+    console.error(
+      `computeOptimalOrder: DP reconstruction produced ${order.length}/${n} vaults; ` +
+        `falling back to largest-first. This indicates a DP-invariant regression.`,
+    );
     const fallback = [...vaults].sort((a, b) => b.btc - a.btc);
     const sim = simulateCascade(
       fallback,

--- a/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/optimalOrder.ts
+++ b/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/optimalOrder.ts
@@ -4,74 +4,29 @@
  * Finds the vault ordering that maximizes collateral surviving a multi-group
  * liquidation cascade.
  *
- * The optimizer is a bitmask DP over seized subsets. To keep 2^n memory and
- * 3^n work bounded, vault sets larger than MAX_DP_N are first compressed into
- * pre-joint groups (the smallest vaults merged together), so the DP always runs
- * on ≤ MAX_DP_N states and never throws regardless of vault count.
+ * The optimizer is a bitmask DP over seized subsets. 2^n memory and 3^n work
+ * blow up past `MAX_DP_N` vaults, so for larger sets the optimizer falls back to
+ * a largest-first heuristic — the suggested order is then no longer guaranteed
+ * optimal, and `calculate()` surfaces a `too-many-vaults` warning to say so.
  */
 
 import {
   simulateCascade,
   type CascadeVault,
-  type PreJointVaults,
 } from "./cascadeSimulation.js";
 
 /**
- * Hard cap on the number of states for the bitmask DP optimizer.
- * 2^n memory + 3^n work blow up past this, so larger vault sets are first
- * compressed into pre-joint groups by merging the smallest vaults together.
+ * Hard cap on vault count for the bitmask DP optimizer. 2^n memory + 3^n work
+ * blow up past this. For n > MAX_DP_N the optimizer falls back to a
+ * largest-first heuristic. Benchmark: n=18 ≈ 720ms, n=20 ≈ 5.8s — anything past
+ * n=17 is too slow for interactive UI, so we cap here.
  */
-export const MAX_DP_N = 10;
-
-/**
- * Reduce a vault list to at most `maxSize` pre-joint groups for DP optimization.
- *
- * Starts with one group per vault, then repeatedly merges the two smallest
- * groups until the group count fits the DP cap. Groups are kept sorted by
- * descending BTC sum, and vaults inside each group are sorted by descending BTC
- * before returning.
- */
-function groupByPreJoints<T extends CascadeVault>(
-  vaults: T[],
-  maxSize: number,
-): PreJointVaults<T>[] {
-  const preJoints: PreJointVaults<T>[] = vaults.map((v) => ({
-    vaults: [v],
-    sum: v.btc,
-  }));
-
-  preJoints.sort((a, b) => b.sum - a.sum);
-
-  while (preJoints.length > maxSize) {
-    const first = preJoints.pop()!;
-    const second = preJoints.pop()!;
-    const combined: PreJointVaults<T> = {
-      vaults: [...first.vaults, ...second.vaults],
-      sum: first.sum + second.sum,
-    };
-
-    let inserted = false;
-    for (let i = 0; i < preJoints.length; i++) {
-      if (combined.sum > preJoints[i].sum) {
-        preJoints.splice(i, 0, combined);
-        inserted = true;
-        break;
-      }
-    }
-    if (!inserted) preJoints.push(combined);
-  }
-
-  for (const pj of preJoints) {
-    pj.vaults.sort((a, b) => b.btc - a.btc);
-  }
-
-  return preJoints;
-}
+export const MAX_DP_N = 17;
 
 /**
  * Main optimizer: bitmask DP over seized subsets.
  *
- * State: T = bitmask of pre-joint groups that have already been seized.
+ * State: T = bitmask of vaults that have already been seized.
  * Transition: for each valid "last group" G ⊆ T, dp[T] = dp[T\G] + btcAfter
  *   where btcAfter = totalBtc − btcOf(T)   (BTC remaining after T is seized).
  * Validation: btcOf(G) must cover target seizure at the moment G fires, i.e.
@@ -94,9 +49,9 @@ export function computeOptimalOrder<T extends CascadeVault>(
   maxLB: number,
   expectedHF: number,
 ): { order: T[]; sumBtcAfterEvents: number; btcAfterG1: number } {
-  if (vaults.length === 0)
-    return { order: [], sumBtcAfterEvents: 0, btcAfterG1: 0 };
-  if (vaults.length === 1) {
+  const n = vaults.length;
+  if (n === 0) return { order: [], sumBtcAfterEvents: 0, btcAfterG1: 0 };
+  if (n === 1) {
     const sim = simulateCascade(
       vaults,
       totalDebt,
@@ -110,11 +65,28 @@ export function computeOptimalOrder<T extends CascadeVault>(
     return { order: [...vaults], ...sim };
   }
 
-  const preJoints = groupByPreJoints(vaults, MAX_DP_N);
-  const n = preJoints.length;
+  // Safety cap: 2^n memory and 3^n work blow up past MAX_DP_N vaults. Real
+  // users have far fewer — each vault is a separate peg-in with a fixed fee.
+  // For the unlikely n > MAX_DP_N, fall back to a largest-first heuristic;
+  // calculate() surfaces a 'too-many-vaults' warning to flag the loss of the
+  // optimality guarantee.
+  if (n > MAX_DP_N) {
+    const order = [...vaults].sort((a, b) => b.btc - a.btc);
+    const sim = simulateCascade(
+      order,
+      totalDebt,
+      seizedFraction,
+      seizureTol,
+      CF,
+      THF,
+      maxLB,
+      expectedHF,
+    );
+    return { order, ...sim };
+  }
 
   const N = 1 << n;
-  const totalBtc = preJoints.reduce((s, v) => s + v.sum, 0);
+  const totalBtc = vaults.reduce((s, v) => s + v.btc, 0);
   const coverFraction = seizedFraction * (1 - seizureTol);
 
   // Precompute btcOf[T] — standard bitmask sum trick in O(2^n).
@@ -122,7 +94,7 @@ export function computeOptimalOrder<T extends CascadeVault>(
   for (let T = 1; T < N; T++) {
     const lsb = T & -T;
     const bit = 31 - Math.clz32(lsb);
-    btcOf[T] = btcOf[T ^ lsb] + preJoints[bit].sum;
+    btcOf[T] = btcOf[T ^ lsb] + vaults[bit].btc;
   }
 
   // dpSum[T] = best sumBtcAfterEvents to reach state T (T = seized subset).
@@ -183,10 +155,10 @@ export function computeOptimalOrder<T extends CascadeVault>(
   const groupsReversed: T[][] = [];
   for (let T = fullMask; T > 0; ) {
     const G = prev[T];
-    if (G === -1) break; // unreachable chain; length assertion below will fail
+    if (G === -1) break; // unreachable chain — fall back below
     const gVaults: T[] = [];
     for (let bit = 0; bit < n; bit++) {
-      if (G & (1 << bit)) gVaults.push(...preJoints[bit].vaults);
+      if (G & (1 << bit)) gVaults.push(vaults[bit]);
     }
     gVaults.sort((a, b) => b.btc - a.btc); // canonical within-group order
     groupsReversed.push(gVaults);
@@ -195,10 +167,21 @@ export function computeOptimalOrder<T extends CascadeVault>(
   groupsReversed.reverse();
   const order = groupsReversed.flat();
 
-  if (order.length !== vaults.length) {
-    throw new Error(
-      `DP reconstruction failed — expected ${vaults.length} vaults in order, got ${order.length}.`,
+  // Reconstruction safety: if the chain is incomplete for any reason, fall back
+  // to largest-first rather than throwing.
+  if (order.length !== n) {
+    const fallback = [...vaults].sort((a, b) => b.btc - a.btc);
+    const sim = simulateCascade(
+      fallback,
+      totalDebt,
+      seizedFraction,
+      seizureTol,
+      CF,
+      THF,
+      maxLB,
+      expectedHF,
     );
+    return { order: fallback, ...sim };
   }
 
   // Compute real metrics via cascade simulation (debt-aware, matches what

--- a/services/vault/src/applications/aave/components/PositionNotificationsDebugPanel.tsx
+++ b/services/vault/src/applications/aave/components/PositionNotificationsDebugPanel.tsx
@@ -33,8 +33,12 @@ const SEVERITY_COLORS: Record<BannerSeverity, string> = {
 
 const WARNING_TYPE_COLORS: Record<WarningType, string> = {
   urgent: "bg-red-600 text-white",
+  cliff: "bg-orange-600 text-white",
+  rebalance: "bg-amber-500 text-white",
+  reorder: "bg-yellow-500 text-black",
   dust: "bg-gray-500 text-white",
   "weird-params": "bg-blue-500 text-white",
+  "too-many-vaults": "bg-purple-500 text-white",
 };
 
 const STATUS_MESSAGES: Record<

--- a/services/vault/src/applications/aave/positionNotifications/__tests__/calculate.test.ts
+++ b/services/vault/src/applications/aave/positionNotifications/__tests__/calculate.test.ts
@@ -369,4 +369,24 @@ describe("golden vectors (reference scenario suite)", () => {
     );
     expect(result.optimalVaultOrder).toBeNull();
   });
+
+  it("17-vault rebalance: uses the deterministic manual order past the optimizer cap", () => {
+    // One large vault over-seizes; 16 tiny vaults can't combine to cover the
+    // target without it. Adding the placeholder makes 18 vaults (> MAX_DP_N 17),
+    // so the suggested order must be the manual protective order, not a heuristic
+    // dressed up as optimizer-backed — and no too-many-vaults warning fires
+    // (the position itself has only 17 vaults).
+    const big = v(0.9);
+    const smalls = Array.from({ length: 16 }, () => v(0.01));
+    const result = calculate(makeParams([big, ...smalls]));
+
+    expect(hasWarning(result.warnings, "rebalance")).toBe(true);
+    expect(hasWarning(result.warnings, "too-many-vaults")).toBe(false);
+    expect(result.suggestedRebalanceOrder).not.toBeNull();
+    const order = result.suggestedRebalanceOrder!;
+    expect(order[0].id).toBe("__new__");
+    expect(order[order.length - 1].id).toBe(big.id);
+    // The optimal-order analysis runs an exact DP at n = 17 (the cap), which is
+    // intentionally near the interactive-time budget — allow extra headroom.
+  }, 20000);
 });

--- a/services/vault/src/applications/aave/positionNotifications/__tests__/calculate.test.ts
+++ b/services/vault/src/applications/aave/positionNotifications/__tests__/calculate.test.ts
@@ -187,7 +187,7 @@ describe("calculate", () => {
 
   // ── Robustness ───────────────────────────────────────────────
 
-  it("handles more vaults than the optimizer DP cap without throwing", () => {
+  it("handles a large in-cap position (14 vaults, exact DP) without throwing", () => {
     const vaults = Array.from({ length: 14 }, (_, i) => v(0.1 + i * 0.03));
     const result = calculate(makeParams(vaults));
     expect(result.groups.length).toBeGreaterThan(0);
@@ -308,7 +308,6 @@ describe("golden vectors (reference scenario suite)", () => {
     expect(hasWarning(result.warnings, "reorder")).toBe(false);
     expect(hasWarning(result.warnings, "rebalance")).toBe(true);
     expect(result.suggestedRebalanceVaultBtc).toBe(0.38);
-    expect(result.suggestedRebalanceOrder).not.toBeNull();
   });
 
   it("C1 — [0.35, 0.65] wrong order: reorder notification, single group", () => {
@@ -371,22 +370,18 @@ describe("golden vectors (reference scenario suite)", () => {
     expect(result.optimalVaultOrder).toBeNull();
   });
 
-  it("17-vault rebalance: uses the deterministic manual order past the optimizer cap", () => {
+  it("17-vault rebalance: suggests a vault amount, no too-many-vaults at the cap", () => {
     // One large vault over-seizes; 16 tiny vaults can't combine to cover the
-    // target without it. Adding the placeholder makes 18 vaults (> MAX_DP_N 17),
-    // so the suggested order must be the manual protective order, not a heuristic
-    // dressed up as optimizer-backed — and no too-many-vaults warning fires
-    // (the position itself has only 17 vaults).
+    // target without it. The position has 17 vaults (== MAX_DP_N), so the
+    // optimizer runs an exact DP and no too-many-vaults warning fires (the
+    // position is at the cap, not over it).
     const big = v(0.9);
     const smalls = Array.from({ length: 16 }, () => v(0.01));
     const result = calculate(makeParams([big, ...smalls]));
 
     expect(hasWarning(result.warnings, "rebalance")).toBe(true);
     expect(hasWarning(result.warnings, "too-many-vaults")).toBe(false);
-    expect(result.suggestedRebalanceOrder).not.toBeNull();
-    const order = result.suggestedRebalanceOrder!;
-    expect(order[0].id).toBe("__new__");
-    expect(order[order.length - 1].id).toBe(big.id);
+    expect(result.suggestedRebalanceVaultBtc).not.toBeNull();
     // The optimal-order analysis runs an exact DP at n = 17 (the cap), which is
     // intentionally near the interactive-time budget — allow extra headroom.
   }, 20000);

--- a/services/vault/src/applications/aave/positionNotifications/__tests__/calculate.test.ts
+++ b/services/vault/src/applications/aave/positionNotifications/__tests__/calculate.test.ts
@@ -194,14 +194,22 @@ describe("calculate", () => {
     expect(result.optimalVaultOrder ?? vaults).toHaveLength(14);
   });
 
-  it("only ever emits urgent / dust / weird-params", () => {
+  it("only emits known warning types", () => {
     const inputs: Vault[][] = [
       [v(1.0)],
       [v(0.35), v(0.65)],
       [v(0.1), v(0.1), v(0.8)],
       [v(2.0), v(1.0), v(0.5)],
     ];
-    const allowed = new Set(["urgent", "dust", "weird-params"]);
+    const allowed = new Set([
+      "urgent",
+      "cliff",
+      "rebalance",
+      "reorder",
+      "dust",
+      "weird-params",
+      "too-many-vaults",
+    ]);
     for (const vaults of inputs) {
       const result = calculate(makeParams(vaults));
       for (const w of result.warnings) {
@@ -245,11 +253,120 @@ describe("bannerSeverity", () => {
     expect(state.primaryWarning?.type).toBe("weird-params");
   });
 
-  it("soft with a reorder suggestion for a healthy but suboptimal position", () => {
+  it("soft with a reorder warning as primary for a suboptimal position", () => {
     const result = calculate(makeParams([v(1.0), v(2.0)]));
     const state = deriveBannerState(result);
     expect(state.severity).toBe("soft");
-    expect(state.primaryWarning).toBeNull();
+    expect(state.primaryWarning?.type).toBe("reorder");
     expect(state.suggestReorder).toBe(true);
+  });
+});
+
+// Golden vectors ported from the reference calculator's scenario suite
+// (tbv-liquidations, the source of truth). Defaults match the reference:
+// debt 44287.72, BTC $61722.5, CF 0.75, THF 1.10, maxLB 1.05, expectedHF 0.95.
+// Behavior (warning types, group structure, suggested amounts) is asserted with
+// our copy strings — which intentionally differ from the reference only for the
+// `urgent` titles.
+describe("golden vectors (reference scenario suite)", () => {
+  it("A1 — single 1.0 BTC: cliff (no backup) + urgent within 5%", () => {
+    const result = calculate(makeParams([v(1.0)]));
+    expect(getWarning(result.warnings, "cliff")?.title).toBe("No backup vault");
+    expect(hasWarning(result.warnings, "urgent")).toBe(true);
+    expect(result.groups).toHaveLength(1);
+    expect(result.groups[0].isFullLiquidation).toBe(true);
+    // Sacrificial vault to add so the existing vault becomes protected.
+    expect(result.suggestedNewVaultBtc).toBe(0.72);
+  });
+
+  it("A2 — single 2.0 BTC: cliff only, no urgent (far from liquidation)", () => {
+    const result = calculate(makeParams([v(2.0)]));
+    expect(hasWarning(result.warnings, "cliff")).toBe(true);
+    expect(hasWarning(result.warnings, "urgent")).toBe(false);
+  });
+
+  it("A7 — single 1.0 BTC, HF < 1: cliff + already-liquidatable urgent", () => {
+    const result = calculate(makeParams([v(1.0)], { totalDebtUsd: 50000 }));
+    expect(hasWarning(result.warnings, "cliff")).toBe(true);
+    expect(getWarning(result.warnings, "urgent")?.title).toBe(
+      "Liquidation can trigger now",
+    );
+  });
+
+  it("B1 — [0.65, 0.35] correct order: no cliff/reorder, 2 groups", () => {
+    const result = calculate(makeParams([v(0.65), v(0.35)]));
+    expect(hasWarning(result.warnings, "cliff")).toBe(false);
+    expect(hasWarning(result.warnings, "reorder")).toBe(false);
+    expect(result.groups).toHaveLength(2);
+    expect(result.groups[0].vaults).toHaveLength(1);
+    expect(result.groups[1].isFullLiquidation).toBe(true);
+  });
+
+  it("B2 — [0.80, 0.20]: over-seizure triggers a rebalance with a suggested vault", () => {
+    const result = calculate(makeParams([v(0.8), v(0.2)]));
+    expect(hasWarning(result.warnings, "cliff")).toBe(false);
+    expect(hasWarning(result.warnings, "reorder")).toBe(false);
+    expect(hasWarning(result.warnings, "rebalance")).toBe(true);
+    expect(result.suggestedRebalanceVaultBtc).toBe(0.38);
+    expect(result.suggestedRebalanceOrder).not.toBeNull();
+  });
+
+  it("C1 — [0.35, 0.65] wrong order: swap reorder, single group", () => {
+    const result = calculate(makeParams([v(0.35), v(0.65)]));
+    const reorder = getWarning(result.warnings, "reorder");
+    expect(reorder?.title).toContain("Swap");
+    expect(result.optimalVaultOrder).not.toBeNull();
+    expect(result.groups).toHaveLength(1);
+  });
+
+  it("C2 — [0.20, 0.80] cliff fixable by reorder (anti-loop exempt for cliff)", () => {
+    const result = calculate(makeParams([v(0.2), v(0.8)]));
+    expect(getWarning(result.warnings, "reorder")?.title).toContain("Swap");
+  });
+
+  it("D1 — THF 1.30 [0.50, 0.50]: true cliff, neither vault covers", () => {
+    const result = calculate(makeParams([v(0.5), v(0.5)], { THF: 1.3 }));
+    expect(getWarning(result.warnings, "cliff")?.detail).toContain(
+      "Neither vault",
+    );
+    expect(hasWarning(result.warnings, "reorder")).toBe(false);
+    expect(result.groups).toHaveLength(1);
+  });
+
+  it("E1 — [0.42, 0.29, 0.29]: optimally structured, 3 events, no warnings", () => {
+    const result = calculate(makeParams([v(0.42), v(0.29), v(0.29)]));
+    expect(hasWarning(result.warnings, "cliff")).toBe(false);
+    expect(hasWarning(result.warnings, "reorder")).toBe(false);
+    expect(result.groups).toHaveLength(3);
+    expect(result.groups[2].isFullLiquidation).toBe(true);
+  });
+
+  it("G2 — [0.10, 0.10, 0.35] cliff fixable by reorder", () => {
+    const result = calculate(makeParams([v(0.1), v(0.1), v(0.35)]));
+    expect(getWarning(result.warnings, "cliff")?.detail).toContain(
+      "Reordering",
+    );
+    expect(result.groups).toHaveLength(1);
+  });
+
+  it("M1 — [0.3979, 0.6021] vault exactly at target: no cliff (within tolerance)", () => {
+    const result = calculate(makeParams([v(0.3979), v(0.6021)]));
+    expect(hasWarning(result.warnings, "cliff")).toBe(false);
+  });
+
+  it("M5 — single vault, zero debt: no warnings, no groups", () => {
+    const result = calculate(makeParams([v(1.0)], { totalDebtUsd: 0 }));
+    expect(result.warnings).toHaveLength(0);
+    expect(result.groups).toHaveLength(0);
+    expect(result.currentHF).toBe(Infinity);
+  });
+
+  it("18 vaults: too-many-vaults warning, no optimal order suggested", () => {
+    const vaults = Array.from({ length: 18 }, (_, idx) => v(0.2 + idx * 0.01));
+    const result = calculate(makeParams(vaults));
+    expect(getWarning(result.warnings, "too-many-vaults")?.title).toContain(
+      "Too many vaults",
+    );
+    expect(result.optimalVaultOrder).toBeNull();
   });
 });

--- a/services/vault/src/applications/aave/positionNotifications/__tests__/calculate.test.ts
+++ b/services/vault/src/applications/aave/positionNotifications/__tests__/calculate.test.ts
@@ -311,17 +311,18 @@ describe("golden vectors (reference scenario suite)", () => {
     expect(result.suggestedRebalanceOrder).not.toBeNull();
   });
 
-  it("C1 — [0.35, 0.65] wrong order: swap reorder, single group", () => {
+  it("C1 — [0.35, 0.65] wrong order: reorder notification, single group", () => {
     const result = calculate(makeParams([v(0.35), v(0.65)]));
     const reorder = getWarning(result.warnings, "reorder");
-    expect(reorder?.title).toContain("Swap");
+    expect(reorder?.title).toBe("Reorder vaults to lose less");
     expect(result.optimalVaultOrder).not.toBeNull();
     expect(result.groups).toHaveLength(1);
   });
 
   it("C2 — [0.20, 0.80] cliff fixable by reorder (anti-loop exempt for cliff)", () => {
     const result = calculate(makeParams([v(0.2), v(0.8)]));
-    expect(getWarning(result.warnings, "reorder")?.title).toContain("Swap");
+    expect(hasWarning(result.warnings, "reorder")).toBe(true);
+    expect(result.optimalVaultOrder).not.toBeNull();
   });
 
   it("D1 — THF 1.30 [0.50, 0.50]: true cliff, neither vault covers", () => {

--- a/services/vault/src/applications/aave/positionNotifications/bannerSeverity.ts
+++ b/services/vault/src/applications/aave/positionNotifications/bannerSeverity.ts
@@ -1,9 +1,10 @@
-import type { CalculatorResult, Warning } from "./types";
+import type { CalculatorResult, Warning, WarningType } from "./types";
 
 /**
  * "yellow" is reserved for the stale-price banner path (driven by a status
  * override, not by a calculator warning). Calculator warnings map to red
- * (urgent), soft (weird-params), green (none), or hidden (dust / no groups).
+ * (urgent), soft (everything advisory), green (none), or hidden (dust / no
+ * groups).
  */
 export type BannerSeverity = "red" | "yellow" | "soft" | "green" | "hidden";
 
@@ -14,28 +15,39 @@ export interface BannerState {
   /**
    * The engine found a safer liquidation order than the current on-chain order.
    * Drives the manual "Apply Optimal Order" affordance, independent of the
-   * risk warnings — it can accompany an urgent/soft banner or stand alone on an
+   * risk warnings — it can accompany an urgent/cliff banner or stand alone on an
    * otherwise-healthy position.
    */
   suggestReorder: boolean;
 }
 
 /**
+ * Primary-warning precedence, highest first. `urgent` is the only red severity;
+ * the rest render soft. `dust` is handled before this list (it hides the banner
+ * entirely). `weird-params` is emitted exclusively, but kept here so it is still
+ * selected if present.
+ */
+const PRIMARY_ORDER: WarningType[] = [
+  "urgent",
+  "weird-params",
+  "cliff",
+  "rebalance",
+  "too-many-vaults",
+  "reorder",
+];
+
+/**
  * Map a CalculatorResult to a banner display state.
  *
  * Red:    urgent warning present (already liquidatable or within 5%)
- * Soft:   weird-params (invalid protocol params), or a healthy position whose
- *         vault order is suboptimal — muted gray advisory
+ * Soft:   any advisory warning (cliff / rebalance / reorder / too-many-vaults /
+ *         weird-params), or a healthy position whose vault order is suboptimal
  * Green:  no warnings and order already optimal
  * Hidden: no groups, or dust position (too small to matter)
  */
 export function deriveBannerState(result: CalculatorResult): BannerState {
   const { warnings, groups } = result;
   const suggestReorder = result.optimalVaultOrder != null;
-
-  // Warnings are evaluated before the "no groups" check so that an advisory
-  // with no computable cascade (e.g. weird-params, which leaves groups empty)
-  // still renders instead of being hidden.
 
   // Dust suppresses all other warnings — position is too small to matter.
   const dustWarning = warnings.find((w) => w.type === "dust");
@@ -48,24 +60,17 @@ export function deriveBannerState(result: CalculatorResult): BannerState {
     };
   }
 
-  // Red severity: urgent takes priority as primary.
-  const urgentWarning = warnings.find((w) => w.type === "urgent");
-  if (urgentWarning) {
-    return {
-      severity: "red",
-      primaryWarning: urgentWarning,
-      secondaryWarnings: warnings.filter((w) => w !== urgentWarning),
-      suggestReorder,
-    };
-  }
+  // Pick the highest-precedence warning as primary; the rest become secondary.
+  const primaryWarning =
+    PRIMARY_ORDER.map((type) => warnings.find((w) => w.type === type)).find(
+      (w): w is Warning => w !== undefined,
+    ) ?? null;
 
-  // Soft severity: weird-params advisory.
-  const weirdParamsWarning = warnings.find((w) => w.type === "weird-params");
-  if (weirdParamsWarning) {
+  if (primaryWarning) {
     return {
-      severity: "soft",
-      primaryWarning: weirdParamsWarning,
-      secondaryWarnings: [],
+      severity: primaryWarning.type === "urgent" ? "red" : "soft",
+      primaryWarning,
+      secondaryWarnings: warnings.filter((w) => w !== primaryWarning),
       suggestReorder,
     };
   }

--- a/services/vault/src/applications/aave/positionNotifications/bannerSeverity.ts
+++ b/services/vault/src/applications/aave/positionNotifications/bannerSeverity.ts
@@ -1,12 +1,20 @@
 import type { CalculatorResult, Warning, WarningType } from "./types";
 
 /**
- * "yellow" is reserved for the stale-price banner path (driven by a status
- * override, not by a calculator warning). Calculator warnings map to red
- * (urgent), soft (everything advisory), green (none), or hidden (dust / no
- * groups).
+ * Calculator warnings map to red (urgent), yellow (too-many-vaults — the orange
+ * warning banner per Figma), soft (everything else advisory), green (none), or
+ * hidden (dust / no groups). "yellow" also backs the stale-price banner, which
+ * is driven separately by a status override rather than a calculator warning.
  */
 export type BannerSeverity = "red" | "yellow" | "soft" | "green" | "hidden";
+
+/**
+ * Per-type severity for the primary warning. Anything not listed renders soft.
+ */
+const SEVERITY_BY_TYPE: Partial<Record<WarningType, BannerSeverity>> = {
+  urgent: "red",
+  "too-many-vaults": "yellow",
+};
 
 export interface BannerState {
   severity: BannerSeverity;
@@ -40,7 +48,8 @@ const PRIMARY_ORDER: WarningType[] = [
  * Map a CalculatorResult to a banner display state.
  *
  * Red:    urgent warning present (already liquidatable or within 5%)
- * Soft:   any advisory warning (cliff / rebalance / reorder / too-many-vaults /
+ * Yellow: too-many-vaults (the orange warning banner per Figma)
+ * Soft:   any other advisory warning (cliff / rebalance / reorder /
  *         weird-params), or a healthy position whose vault order is suboptimal
  * Green:  no warnings and order already optimal
  * Hidden: no groups, or dust position (too small to matter)
@@ -68,7 +77,7 @@ export function deriveBannerState(result: CalculatorResult): BannerState {
 
   if (primaryWarning) {
     return {
-      severity: primaryWarning.type === "urgent" ? "red" : "soft",
+      severity: SEVERITY_BY_TYPE[primaryWarning.type] ?? "soft",
       primaryWarning,
       secondaryWarnings: warnings.filter((w) => w !== primaryWarning),
       suggestReorder,

--- a/services/vault/src/applications/aave/positionNotifications/calculate.ts
+++ b/services/vault/src/applications/aave/positionNotifications/calculate.ts
@@ -619,32 +619,42 @@ export function calculate(params: CalculatorParams): CalculatorResult {
       };
       const allVaults = [placeholder, ...vaults];
 
-      const { order: optOrder } = computeOptimalOrder(
-        allVaults,
-        totalDebtUsd,
-        seizedFraction,
-        SEIZURE_TOL,
-        CF,
-        THF,
-        maxLB,
-        expectedHF,
-      );
+      // Deterministic protective order: new + small vaults first, largest last —
+      // together the front group covers the target seizure, protecting the
+      // largest vault.
+      const sortedSmall = [...smallVaults].sort((a, b) => b.btc - a.btc);
+      const manualOrder = [placeholder, ...sortedSmall, largest];
 
-      // If the optimizer order still triggers rebalance, fall back to the
-      // manual protective order (new + small first, largest last).
-      const allTotal = allVaults.reduce((s, v) => s + v.btc, 0);
-      const optG1Btc = getGroup1FromOrder(
-        optOrder,
-        seizedFraction,
-        SEIZURE_TOL,
-      ).reduce((s, v) => s + v.btc, 0);
-      const optProtected = allTotal - optG1Btc;
-      const optOver = optG1Btc - allTotal * seizedFraction;
-      if (optOver > optProtected) {
-        const sortedSmall = [...smallVaults].sort((a, b) => b.btc - a.btc);
-        suggestedRebalanceOrder = [placeholder, ...sortedSmall, largest];
+      if (allVaults.length > MAX_DP_N) {
+        // Adding the placeholder crosses the optimizer cap, so computeOptimalOrder
+        // would only return a largest-first heuristic — not a guaranteed optimum.
+        // Use the manual protective order directly rather than presenting the
+        // heuristic as if it were optimizer-backed.
+        suggestedRebalanceOrder = manualOrder;
       } else {
-        suggestedRebalanceOrder = optOrder;
+        const { order: optOrder } = computeOptimalOrder(
+          allVaults,
+          totalDebtUsd,
+          seizedFraction,
+          SEIZURE_TOL,
+          CF,
+          THF,
+          maxLB,
+          expectedHF,
+        );
+
+        // If the optimizer order still triggers rebalance, fall back to the
+        // manual protective order.
+        const allTotal = allVaults.reduce((s, v) => s + v.btc, 0);
+        const optG1Btc = getGroup1FromOrder(
+          optOrder,
+          seizedFraction,
+          SEIZURE_TOL,
+        ).reduce((s, v) => s + v.btc, 0);
+        const optProtected = allTotal - optG1Btc;
+        const optOver = optG1Btc - allTotal * seizedFraction;
+        suggestedRebalanceOrder =
+          optOver > optProtected ? manualOrder : optOrder;
       }
     }
   }

--- a/services/vault/src/applications/aave/positionNotifications/calculate.ts
+++ b/services/vault/src/applications/aave/positionNotifications/calculate.ts
@@ -44,29 +44,6 @@ const SAFETY_MARGIN = 1.05;
 /** Format a BTC amount to 2 decimals for user-facing copy. */
 const btc2 = (n: number): string => n.toFixed(2);
 
-/** Format a saved-BTC delta to 3 decimals for reorder copy. */
-const btc3 = (n: number): string => n.toFixed(3);
-
-/**
- * Build the reorder warning detail string from the cascade-score deltas,
- * delegating the wording to copy.ts.
- */
-function reorderDetail(
-  sumImproves: boolean,
-  savedSum: number,
-  savedBtcAfterG1: number,
-  currentG1Btc?: number,
-  optimalG1Btc?: number,
-): string {
-  return COPY.liquidationWarnings.reorder.detail2({
-    sumImproves,
-    savedSum: btc3(savedSum),
-    savedBtcAfterG1: btc3(savedBtcAfterG1),
-    ...(currentG1Btc !== undefined ? { currentG1Btc: btc2(currentG1Btc) } : {}),
-    ...(optimalG1Btc !== undefined ? { optimalG1Btc: btc2(optimalG1Btc) } : {}),
-  });
-}
-
 /**
  * Compute the partial-liquidation cascade and position warnings.
  *
@@ -386,9 +363,6 @@ export function calculate(params: CalculatorParams): CalculatorResult {
   const group1ReorderWouldHelp =
     reorderWouldHelp && currentGroup1Btc > optimalG1Btc + REORDER_TOL;
 
-  const savedSum = optimalSum - currentSum;
-  const savedBtcAfterG1 = optimalBtcAfterG1 - currentBtcAfterG1;
-
   // Suppress reorder if it would create a rebalance condition that doesn't exist
   // now (prevents a reorder↔rebalance loop). Cliff cases are exempt — for a
   // cliff, reordering is always an improvement even if it introduces rebalance.
@@ -453,6 +427,15 @@ export function calculate(params: CalculatorParams): CalculatorResult {
 
   const { cliff, reorder } = COPY.liquidationWarnings;
 
+  // Single reorder notification (per Figma) reused across every case that wants
+  // to suggest a safer order; the order itself renders as chips from
+  // `optimalVaultOrder`, so no per-case suggestion text is needed.
+  const reorderWarning: Warning = {
+    type: "reorder",
+    title: reorder.title,
+    detail: reorder.detail,
+  };
+
   // CASE 1: Single vault — always fully seized. To protect it, add a NEW
   // sacrificial vault at position 1. Adding a vault increases total BTC, hence
   // target seizure: s >= existingBtc × liqFactor / (1 − liqFactor).
@@ -491,15 +474,9 @@ export function calculate(params: CalculatorParams): CalculatorResult {
   // CASE 2: Exactly two vaults.
   else if (nVaults === 2) {
     if (isCliff && group1ReorderWouldHelp && optimalVaultOrder) {
-      // One vault alone covers — just need to put it first.
-      const best = optimalG1Vaults[0];
-      const other = vaults.find((v) => v.id !== best.id);
-      warnings.push({
-        type: "reorder",
-        title: reorder.swapTitle,
-        detail: reorder.swapDetail(best.name, btc2(best.btc), vaults[0].name),
-        suggestion: reorder.swapSuggestion(best.name, other?.name ?? ""),
-      });
+      // Cliff that swapping the order fixes — surfaced as the reorder
+      // notification (the order itself renders as chips).
+      warnings.push(reorderWarning);
     } else if (isCliff) {
       // Informational deficit text (no actionable button for 2 vaults).
       const largest = vaults.reduce((a, b) => (a.btc > b.btc ? a : b));
@@ -520,26 +497,8 @@ export function calculate(params: CalculatorParams): CalculatorResult {
         detail: cliff.twoVault.detail(btc2(targetSeizureBtc)),
         suggestion: cliff.twoVault.suggestion(enablePartialStr),
       });
-    } else if (group1ReorderWouldHelp) {
-      warnings.push({
-        type: "reorder",
-        title: reorder.reduceFirstEventTitle,
-        detail: reorderDetail(
-          sumImproves,
-          savedSum,
-          savedBtcAfterG1,
-          currentGroup1Btc,
-          optimalG1Btc,
-        ),
-        suggestion: reorder.suggestedOrder(globalOptimalOrderStr),
-      });
     } else if (reorderWouldHelp) {
-      warnings.push({
-        type: "reorder",
-        title: reorder.deepenCascadeTitle,
-        detail: reorderDetail(sumImproves, savedSum, savedBtcAfterG1),
-        suggestion: reorder.suggestedOrder(globalOptimalOrderStr),
-      });
+      warnings.push(reorderWarning);
     }
   }
 
@@ -556,26 +515,8 @@ export function calculate(params: CalculatorParams): CalculatorResult {
           ? { suggestion: cliff.multiVault.suggestion(globalOptimalOrderStr) }
           : {}),
       });
-    } else if (group1ReorderWouldHelp) {
-      warnings.push({
-        type: "reorder",
-        title: reorder.reduceFirstEventTitle,
-        detail: reorderDetail(
-          sumImproves,
-          savedSum,
-          savedBtcAfterG1,
-          currentGroup1Btc,
-          optimalG1Btc,
-        ),
-        suggestion: reorder.suggestedOrder(globalOptimalOrderStr),
-      });
     } else if (reorderWouldHelp) {
-      warnings.push({
-        type: "reorder",
-        title: reorder.deepenCascadeTitle,
-        detail: reorderDetail(sumImproves, savedSum, savedBtcAfterG1),
-        suggestion: reorder.suggestedOrder(globalOptimalOrderStr),
-      });
+      warnings.push(reorderWarning);
     }
   }
 

--- a/services/vault/src/applications/aave/positionNotifications/calculate.ts
+++ b/services/vault/src/applications/aave/positionNotifications/calculate.ts
@@ -87,14 +87,10 @@ export function calculate(params: CalculatorParams): CalculatorResult {
       currentHF: Infinity,
       collateralValue,
       targetSeizureBtc: 0,
-      recommendedSacrificialBtc: 0,
       warnings,
-      isFullLiquidation: false,
       optimalVaultOrder: null,
       suggestedNewVaultBtc: null,
       suggestedRebalanceVaultBtc: null,
-      suggestedRebalanceOrder: null,
-      rebalanceImprovementBtc: 0,
     };
   }
 
@@ -127,7 +123,6 @@ export function calculate(params: CalculatorParams): CalculatorResult {
       currentHF,
       collateralValue,
       targetSeizureBtc: totalBtc,
-      recommendedSacrificialBtc: totalBtc,
       warnings: [
         {
           type: "dust",
@@ -135,12 +130,9 @@ export function calculate(params: CalculatorParams): CalculatorResult {
           detail: COPY.liquidationWarnings.dust.detail,
         },
       ],
-      isFullLiquidation: true,
       optimalVaultOrder: null,
       suggestedNewVaultBtc: null,
       suggestedRebalanceVaultBtc: null,
-      suggestedRebalanceOrder: null,
-      rebalanceImprovementBtc: 0,
     };
   }
 
@@ -153,10 +145,6 @@ export function calculate(params: CalculatorParams): CalculatorResult {
     expectedHF,
   );
   const targetSeizureBtc = totalBtc * seizedFraction;
-  const recommendedSacrificialBtc = Math.min(
-    targetSeizureBtc * SAFETY_MARGIN,
-    totalBtc,
-  );
   // Combined seizure-with-safety-margin factor, used for vault-sizing advice.
   const liqFactor = seizedFraction * SAFETY_MARGIN;
   const liqPenalty = maxLB * CF;
@@ -176,7 +164,6 @@ export function calculate(params: CalculatorParams): CalculatorResult {
   let remainingDebt = totalDebtUsd;
   let remainingBtc = totalBtc;
   let groupIndex = 1;
-  let isFullLiquidation = false;
 
   while (
     !seizedParamsInvalid &&
@@ -199,7 +186,6 @@ export function calculate(params: CalculatorParams): CalculatorResult {
     }
 
     const isGroupFull = i >= remainingVaults.length;
-    if (isGroupFull) isFullLiquidation = true;
     const seizedVaults = remainingVaults.slice(0, i);
     const seizedBtc = prefixSum;
     const overSeizureBtc = Math.max(0, seizedBtc - curTargetSeizure);
@@ -296,14 +282,10 @@ export function calculate(params: CalculatorParams): CalculatorResult {
       currentHF,
       collateralValue,
       targetSeizureBtc,
-      recommendedSacrificialBtc,
       warnings,
-      isFullLiquidation,
       optimalVaultOrder: null,
       suggestedNewVaultBtc: null,
       suggestedRebalanceVaultBtc: null,
-      suggestedRebalanceOrder: null,
-      rebalanceImprovementBtc: 0,
     };
   }
 
@@ -544,7 +526,6 @@ export function calculate(params: CalculatorParams): CalculatorResult {
   // (1 − liqFactor). Cheaper than a standalone vault because the existing small
   // vaults contribute to covering the target seizure.
   let suggestedRebalanceVaultBtc: number | null = null;
-  let suggestedRebalanceOrder: Vault[] | null = null;
   if (rebalanceNeeded && liqFactor < 1) {
     const largest = vaults.reduce((a, b) => (a.btc > b.btc ? a : b));
     const smallVaults = vaults.filter((v) => v.id !== largest.id);
@@ -553,50 +534,6 @@ export function calculate(params: CalculatorParams): CalculatorResult {
     const rounded = Math.ceil(Math.max(0, raw) * 100) / 100;
     if (rounded <= totalBtc) {
       suggestedRebalanceVaultBtc = rounded;
-      const placeholder: Vault = {
-        id: "__new__",
-        name: "__new__",
-        btc: rounded,
-      };
-      const allVaults = [placeholder, ...vaults];
-
-      // Deterministic protective order: new + small vaults first, largest last —
-      // together the front group covers the target seizure, protecting the
-      // largest vault.
-      const sortedSmall = [...smallVaults].sort((a, b) => b.btc - a.btc);
-      const manualOrder = [placeholder, ...sortedSmall, largest];
-
-      if (allVaults.length > MAX_DP_N) {
-        // Adding the placeholder crosses the optimizer cap, so computeOptimalOrder
-        // would only return a largest-first heuristic — not a guaranteed optimum.
-        // Use the manual protective order directly rather than presenting the
-        // heuristic as if it were optimizer-backed.
-        suggestedRebalanceOrder = manualOrder;
-      } else {
-        const { order: optOrder } = computeOptimalOrder(
-          allVaults,
-          totalDebtUsd,
-          seizedFraction,
-          SEIZURE_TOL,
-          CF,
-          THF,
-          maxLB,
-          expectedHF,
-        );
-
-        // If the optimizer order still triggers rebalance, fall back to the
-        // manual protective order.
-        const allTotal = allVaults.reduce((s, v) => s + v.btc, 0);
-        const optG1Btc = getGroup1FromOrder(
-          optOrder,
-          seizedFraction,
-          SEIZURE_TOL,
-        ).reduce((s, v) => s + v.btc, 0);
-        const optProtected = allTotal - optG1Btc;
-        const optOver = optG1Btc - allTotal * seizedFraction;
-        suggestedRebalanceOrder =
-          optOver > optProtected ? manualOrder : optOrder;
-      }
     }
   }
 
@@ -607,16 +544,12 @@ export function calculate(params: CalculatorParams): CalculatorResult {
   );
   if (rebalanceNeeded && hasCliffOrReorder) {
     suggestedRebalanceVaultBtc = null;
-    suggestedRebalanceOrder = null;
   }
   if (rebalanceNeeded && !hasCliffOrReorder) {
     const largest = vaults.reduce((a, b) => (a.btc > b.btc ? a : b));
     const g1CombinedBtc = firstGroup?.combinedBtc ?? 0;
     let suggestion: string;
-    if (
-      suggestedRebalanceVaultBtc !== null &&
-      suggestedRebalanceOrder !== null
-    ) {
+    if (suggestedRebalanceVaultBtc !== null) {
       const smallNames = vaults
         .filter((v) => v.id !== largest.id)
         .map((v) => v.name)
@@ -652,13 +585,9 @@ export function calculate(params: CalculatorParams): CalculatorResult {
     currentHF,
     collateralValue,
     targetSeizureBtc,
-    recommendedSacrificialBtc,
     warnings,
-    isFullLiquidation,
     optimalVaultOrder,
     suggestedNewVaultBtc,
     suggestedRebalanceVaultBtc,
-    suggestedRebalanceOrder,
-    rebalanceImprovementBtc,
   };
 }

--- a/services/vault/src/applications/aave/positionNotifications/calculate.ts
+++ b/services/vault/src/applications/aave/positionNotifications/calculate.ts
@@ -1,6 +1,8 @@
 import {
   computeOptimalOrder,
   computeSeizedFractionDetailed,
+  getGroup1FromOrder,
+  MAX_DP_N,
   MAX_GROUPS,
   MIN_DEBT_THRESHOLD,
   SEIZURE_TOL,
@@ -33,14 +35,51 @@ const URGENT_DISTANCE_PCT = 5;
 const REORDER_TOL = 0.001;
 
 /**
+ * Safety buffer applied to the target seizure when recommending a sacrificial
+ * vault size, so the sacrificial group reliably covers the seizure at the
+ * liquidation moment. Hard-coded per the protocol/liquidation spec.
+ */
+const SAFETY_MARGIN = 1.05;
+
+/** Format a BTC amount to 2 decimals for user-facing copy. */
+const btc2 = (n: number): string => n.toFixed(2);
+
+/** Format a saved-BTC delta to 3 decimals for reorder copy. */
+const btc3 = (n: number): string => n.toFixed(3);
+
+/**
+ * Build the reorder warning detail string from the cascade-score deltas,
+ * delegating the wording to copy.ts.
+ */
+function reorderDetail(
+  sumImproves: boolean,
+  savedSum: number,
+  savedBtcAfterG1: number,
+  currentG1Btc?: number,
+  optimalG1Btc?: number,
+): string {
+  return COPY.liquidationWarnings.reorder.detail2({
+    sumImproves,
+    savedSum: btc3(savedSum),
+    savedBtcAfterG1: btc3(savedBtcAfterG1),
+    ...(currentG1Btc !== undefined ? { currentG1Btc: btc2(currentG1Btc) } : {}),
+    ...(optimalG1Btc !== undefined ? { optimalG1Btc: btc2(optimalG1Btc) } : {}),
+  });
+}
+
+/**
  * Compute the partial-liquidation cascade and position warnings.
  *
  * Liquidation follows the current on-chain vault order, so the group breakdown
  * is computed against that order. Separately, the optimizer is run and — when
  * it finds a strictly better order — `optimalVaultOrder` is returned so the
- * banner can offer a manual "Apply Optimal Order" action. Warnings are limited
- * to three types: `weird-params` (invalid protocol params, soft), `urgent`
- * (already liquidatable or within 5% of the trigger), or `dust`.
+ * banner can offer a manual "Apply Optimal Order" action.
+ *
+ * Warnings: `weird-params` (invalid protocol params, soft — suppresses all
+ * other advisories), `too-many-vaults` (optimizer fell back past its cap),
+ * `urgent` (already liquidatable or within 5%), `cliff` (all vaults consolidate
+ * into one liquidation group — partial liquidation impossible), `reorder` (a
+ * safer order exists), `rebalance` (the first group over-seizes), or `dust`.
  */
 export function calculate(params: CalculatorParams): CalculatorResult {
   const {
@@ -54,6 +93,7 @@ export function calculate(params: CalculatorParams): CalculatorResult {
   } = params;
 
   const totalBtc = vaults.reduce((s, v) => s + v.btc, 0);
+  const nVaults = vaults.length;
   const collateralValue = totalBtc * btcPrice;
   const currentHF =
     totalDebtUsd > 0 ? (collateralValue * CF) / totalDebtUsd : Infinity;
@@ -70,8 +110,14 @@ export function calculate(params: CalculatorParams): CalculatorResult {
       currentHF: Infinity,
       collateralValue,
       targetSeizureBtc: 0,
+      recommendedSacrificialBtc: 0,
       warnings,
+      isFullLiquidation: false,
       optimalVaultOrder: null,
+      suggestedNewVaultBtc: null,
+      suggestedRebalanceVaultBtc: null,
+      suggestedRebalanceOrder: null,
+      rebalanceImprovementBtc: 0,
     };
   }
 
@@ -104,6 +150,7 @@ export function calculate(params: CalculatorParams): CalculatorResult {
       currentHF,
       collateralValue,
       targetSeizureBtc: totalBtc,
+      recommendedSacrificialBtc: totalBtc,
       warnings: [
         {
           type: "dust",
@@ -111,7 +158,12 @@ export function calculate(params: CalculatorParams): CalculatorResult {
           detail: COPY.liquidationWarnings.dust.detail,
         },
       ],
+      isFullLiquidation: true,
       optimalVaultOrder: null,
+      suggestedNewVaultBtc: null,
+      suggestedRebalanceVaultBtc: null,
+      suggestedRebalanceOrder: null,
+      rebalanceImprovementBtc: 0,
     };
   }
 
@@ -124,10 +176,16 @@ export function calculate(params: CalculatorParams): CalculatorResult {
     expectedHF,
   );
   const targetSeizureBtc = totalBtc * seizedFraction;
+  const recommendedSacrificialBtc = Math.min(
+    targetSeizureBtc * SAFETY_MARGIN,
+    totalBtc,
+  );
+  // Combined seizure-with-safety-margin factor, used for vault-sizing advice.
+  const liqFactor = seizedFraction * SAFETY_MARGIN;
   const liqPenalty = maxLB * CF;
   // Invalid governance params: the seizure formula produced a fraction outside
-  // [0, 1]. We surface this as a soft advisory and suppress both the urgent
-  // signal and the reorder suggestion (liq math is meaningless here).
+  // [0, 1]. We surface this as a soft advisory and suppress every other
+  // advisory (the liq math is meaningless here).
   const seizedParamsInvalid = seizedFractionRaw <= 0 || seizedFractionRaw > 1;
 
   // ── 3. Group calculation (against the current on-chain order) ──
@@ -141,6 +199,7 @@ export function calculate(params: CalculatorParams): CalculatorResult {
   let remainingDebt = totalDebtUsd;
   let remainingBtc = totalBtc;
   let groupIndex = 1;
+  let isFullLiquidation = false;
 
   while (
     !seizedParamsInvalid &&
@@ -163,6 +222,7 @@ export function calculate(params: CalculatorParams): CalculatorResult {
     }
 
     const isGroupFull = i >= remainingVaults.length;
+    if (isGroupFull) isFullLiquidation = true;
     const seizedVaults = remainingVaults.slice(0, i);
     const seizedBtc = prefixSum;
     const overSeizureBtc = Math.max(0, seizedBtc - curTargetSeizure);
@@ -225,50 +285,14 @@ export function calculate(params: CalculatorParams): CalculatorResult {
     groupIndex++;
   }
 
-  // ── 4. Optimal-order analysis (manual "Apply Optimal Order") ──
-  //
-  // We never reorder automatically. Score the current order against the
-  // optimizer's best order; only when the optimizer strictly improves the
-  // cascade (more BTC surviving across events, tie-broken by BTC after the
-  // first event) do we surface the optimal order for the user to apply.
-  // Skipped under invalid params — the cascade scores are meaningless there.
-
-  let optimalVaultOrder: Vault[] | null = null;
-  if (!seizedParamsInvalid) {
-    const current = simulateCascade(
-      vaults,
-      totalDebtUsd,
-      seizedFraction,
-      SEIZURE_TOL,
-      CF,
-      THF,
-      maxLB,
-      expectedHF,
-    );
-    const optimal = computeOptimalOrder(
-      vaults,
-      totalDebtUsd,
-      seizedFraction,
-      SEIZURE_TOL,
-      CF,
-      THF,
-      maxLB,
-      expectedHF,
-    );
-    const sumImproves =
-      optimal.sumBtcAfterEvents > current.sumBtcAfterEvents + REORDER_TOL;
-    const afterG1Improves =
-      Math.abs(optimal.sumBtcAfterEvents - current.sumBtcAfterEvents) <=
-        REORDER_TOL && optimal.btcAfterG1 > current.btcAfterG1 + REORDER_TOL;
-    if (sumImproves || afterG1Improves) optimalVaultOrder = optimal.order;
-  }
-
-  // ── 5. Warnings ────────────────────────────────────────────────
-
   const firstGroup = groups[0];
+  const isCliff =
+    firstGroup != null && firstGroup.vaults.length === nVaults && nVaults > 1;
 
-  // weird-params: seizedFraction raw value was outside [0, 1]. Protocol params
-  // are set by governance — the user can't change them — so this is advisory.
+  // ── 4. weird-params advisory (exclusive) ───────────────────────
+  //
+  // Protocol params are set by governance — the user can't change them — so
+  // this is advisory and suppresses every other warning.
   if (seizedParamsInvalid) {
     const { weirdParams } = COPY.liquidationWarnings;
     let detail: string;
@@ -289,14 +313,120 @@ export function calculate(params: CalculatorParams): CalculatorResult {
       detail,
       tone: "soft",
     });
+
+    return {
+      groups,
+      currentHF,
+      collateralValue,
+      targetSeizureBtc,
+      recommendedSacrificialBtc,
+      warnings,
+      isFullLiquidation,
+      optimalVaultOrder: null,
+      suggestedNewVaultBtc: null,
+      suggestedRebalanceVaultBtc: null,
+      suggestedRebalanceOrder: null,
+      rebalanceImprovementBtc: 0,
+    };
   }
 
-  const hasWeirdParams = warnings.some((w) => w.type === "weird-params");
+  // ── 5. Optimal-order analysis (manual "Apply Optimal Order") ──
+  //
+  // We never reorder automatically. Score the current order against the
+  // optimizer's best order; only when the optimizer strictly improves the
+  // cascade do we surface the optimal order for the user to apply.
+
+  const {
+    order: globalOptimalOrder,
+    sumBtcAfterEvents: optimalSum,
+    btcAfterG1: optimalBtcAfterG1,
+  } = computeOptimalOrder(
+    vaults,
+    totalDebtUsd,
+    seizedFraction,
+    SEIZURE_TOL,
+    CF,
+    THF,
+    maxLB,
+    expectedHF,
+  );
+  const { sumBtcAfterEvents: currentSum, btcAfterG1: currentBtcAfterG1 } =
+    simulateCascade(
+      vaults,
+      totalDebtUsd,
+      seizedFraction,
+      SEIZURE_TOL,
+      CF,
+      THF,
+      maxLB,
+      expectedHF,
+    );
+
+  // Past the DP cap the optimizer returns a largest-first heuristic, not a
+  // guaranteed optimum — don't trust reorder comparisons in that mode.
+  const optimizerReliable = nVaults <= MAX_DP_N;
+  const sumImproves =
+    optimizerReliable && optimalSum > currentSum + REORDER_TOL;
+  const afterG1Improves =
+    optimizerReliable &&
+    !sumImproves &&
+    optimalBtcAfterG1 > currentBtcAfterG1 + REORDER_TOL;
+  let reorderWouldHelp = sumImproves || afterG1Improves;
+  const globalOptimalOrderStr = globalOptimalOrder
+    .map((v) => v.name)
+    .join(" → ");
+
+  const optimalG1Vaults = getGroup1FromOrder(
+    globalOptimalOrder,
+    seizedFraction,
+    SEIZURE_TOL,
+  );
+  const optimalG1Btc = optimalG1Vaults.reduce((s, v) => s + v.btc, 0);
+  const currentGroup1Btc = firstGroup?.combinedBtc ?? Infinity;
+  const group1ReorderWouldHelp =
+    reorderWouldHelp && currentGroup1Btc > optimalG1Btc + REORDER_TOL;
+
+  const savedSum = optimalSum - currentSum;
+  const savedBtcAfterG1 = optimalBtcAfterG1 - currentBtcAfterG1;
+
+  // Suppress reorder if it would create a rebalance condition that doesn't exist
+  // now (prevents a reorder↔rebalance loop). Cliff cases are exempt — for a
+  // cliff, reordering is always an improvement even if it introduces rebalance.
+  if (reorderWouldHelp && nVaults >= 2 && !isCliff) {
+    const currentOverSeizure = firstGroup ? firstGroup.overSeizureBtc : 0;
+    const currentProtected = firstGroup ? firstGroup.btcRemainingAfter : 0;
+    const currentHasRebalanceCond = currentOverSeizure > currentProtected;
+
+    const optTarget = totalBtc * seizedFraction;
+    const optOver = Math.max(0, optimalG1Btc - optTarget);
+    const optProtected = totalBtc - optimalG1Btc;
+    const optIsCliff = optimalG1Vaults.length === nVaults;
+    const optWouldTriggerRebalance = optOver > optProtected && !optIsCliff;
+
+    if (!currentHasRebalanceCond && optWouldTriggerRebalance) {
+      reorderWouldHelp = false;
+    }
+  }
+
+  const optimalVaultOrder: Vault[] | null = reorderWouldHelp
+    ? globalOptimalOrder
+    : null;
+
+  // ── 6. Warnings: too-many-vaults / urgent ──────────────────────
+
+  // Too many vaults — optimizer fell back to largest-first, so the suggested
+  // order is no longer guaranteed optimal.
+  if (nVaults > MAX_DP_N) {
+    warnings.push({
+      type: "too-many-vaults",
+      title: COPY.liquidationWarnings.tooManyVaults.title,
+      detail: COPY.liquidationWarnings.tooManyVaults.detail(nVaults, MAX_DP_N),
+      suggestion: COPY.liquidationWarnings.tooManyVaults.suggestion,
+    });
+  }
 
   // urgent: position already liquidatable (distancePct >= 0) or within 5%.
-  // Skip when weird-params fired — liq-price math is meaningless under invalid
-  // params.
-  if (!hasWeirdParams && firstGroup) {
+  if (firstGroup) {
     const { urgent } = COPY.liquidationWarnings;
     const liqPriceStr = firstGroup.liquidationPrice.toLocaleString("en-US", {
       maximumFractionDigits: 0,
@@ -319,14 +449,265 @@ export function calculate(params: CalculatorParams): CalculatorResult {
     }
   }
 
-  // ── 6. Return ──────────────────────────────────────────────────
+  // ── 7. Warnings: cliff / reorder ───────────────────────────────
+
+  const { cliff, reorder } = COPY.liquidationWarnings;
+
+  // CASE 1: Single vault — always fully seized. To protect it, add a NEW
+  // sacrificial vault at position 1. Adding a vault increases total BTC, hence
+  // target seizure: s >= existingBtc × liqFactor / (1 − liqFactor).
+  let suggestedNewVaultBtc: number | null = null;
+  if (nVaults === 1) {
+    const canSplit = liqFactor < 1;
+    const raw = canSplit
+      ? (vaults[0].btc * liqFactor) / (1 - liqFactor)
+      : Infinity;
+    const rounded = canSplit ? Math.ceil(raw * 100) / 100 : Infinity;
+    // Actionable only if positive AND no larger than the existing position.
+    if (canSplit && rounded > 0 && rounded <= totalBtc) {
+      suggestedNewVaultBtc = rounded;
+    }
+
+    let suggestion: string;
+    if (suggestedNewVaultBtc !== null) {
+      suggestion = cliff.single.actionableSuggestion(
+        btc2(suggestedNewVaultBtc),
+        btc2(vaults[0].btc),
+      );
+    } else if (!canSplit) {
+      suggestion = cliff.single.noSplitSuggestion;
+    } else {
+      suggestion = cliff.single.oversizedSuggestion(btc2(raw));
+    }
+
+    warnings.push({
+      type: "cliff",
+      title: cliff.single.title,
+      detail: cliff.single.detail,
+      suggestion,
+    });
+  }
+
+  // CASE 2: Exactly two vaults.
+  else if (nVaults === 2) {
+    if (isCliff && group1ReorderWouldHelp && optimalVaultOrder) {
+      // One vault alone covers — just need to put it first.
+      const best = optimalG1Vaults[0];
+      const other = vaults.find((v) => v.id !== best.id);
+      warnings.push({
+        type: "reorder",
+        title: reorder.swapTitle,
+        detail: reorder.swapDetail(best.name, btc2(best.btc), vaults[0].name),
+        suggestion: reorder.swapSuggestion(best.name, other?.name ?? ""),
+      });
+    } else if (isCliff) {
+      // Informational deficit text (no actionable button for 2 vaults).
+      const largest = vaults.reduce((a, b) => (a.btc > b.btc ? a : b));
+      let enablePartialStr = "";
+      if (liqFactor < 1 && totalBtc * liqFactor > largest.btc) {
+        const deficit = (totalBtc * liqFactor - largest.btc) / (1 - liqFactor);
+        const rounded = Math.ceil(deficit * 100) / 100;
+        if (rounded <= totalBtc) {
+          enablePartialStr = cliff.twoVault.enablePartial(
+            btc2(rounded),
+            largest.name,
+          );
+        }
+      }
+      warnings.push({
+        type: "cliff",
+        title: cliff.twoVault.title,
+        detail: cliff.twoVault.detail(btc2(targetSeizureBtc)),
+        suggestion: cliff.twoVault.suggestion(enablePartialStr),
+      });
+    } else if (group1ReorderWouldHelp) {
+      warnings.push({
+        type: "reorder",
+        title: reorder.reduceFirstEventTitle,
+        detail: reorderDetail(
+          sumImproves,
+          savedSum,
+          savedBtcAfterG1,
+          currentGroup1Btc,
+          optimalG1Btc,
+        ),
+        suggestion: reorder.suggestedOrder(globalOptimalOrderStr),
+      });
+    } else if (reorderWouldHelp) {
+      warnings.push({
+        type: "reorder",
+        title: reorder.deepenCascadeTitle,
+        detail: reorderDetail(sumImproves, savedSum, savedBtcAfterG1),
+        suggestion: reorder.suggestedOrder(globalOptimalOrderStr),
+      });
+    }
+  }
+
+  // CASE 3+: three or more vaults.
+  else if (nVaults >= 3) {
+    if (isCliff) {
+      const cliffReorderFix =
+        group1ReorderWouldHelp && optimalVaultOrder !== null;
+      warnings.push({
+        type: "cliff",
+        title: cliff.multiVault.title,
+        detail: cliff.multiVault.detail(nVaults, cliffReorderFix),
+        ...(cliffReorderFix
+          ? { suggestion: cliff.multiVault.suggestion(globalOptimalOrderStr) }
+          : {}),
+      });
+    } else if (group1ReorderWouldHelp) {
+      warnings.push({
+        type: "reorder",
+        title: reorder.reduceFirstEventTitle,
+        detail: reorderDetail(
+          sumImproves,
+          savedSum,
+          savedBtcAfterG1,
+          currentGroup1Btc,
+          optimalG1Btc,
+        ),
+        suggestion: reorder.suggestedOrder(globalOptimalOrderStr),
+      });
+    } else if (reorderWouldHelp) {
+      warnings.push({
+        type: "reorder",
+        title: reorder.deepenCascadeTitle,
+        detail: reorderDetail(sumImproves, savedSum, savedBtcAfterG1),
+        suggestion: reorder.suggestedOrder(globalOptimalOrderStr),
+      });
+    }
+  }
+
+  // ── 8. Warning: rebalance ──────────────────────────────────────
+  //
+  // Over-seizure in Group 1 means vault sizes aren't optimal: you lose more in
+  // excess than what survives. A new sacrificial vault (combined with the
+  // existing small vaults) protects the largest one.
+
+  const g1OverSeizure = firstGroup ? firstGroup.overSeizureBtc : 0;
+  const g1TargetSeizure = firstGroup ? firstGroup.targetSeizureBtc : 0;
+  const g1ProtectedBtc = firstGroup ? firstGroup.btcRemainingAfter : 0;
+  const rebalanceNeeded =
+    g1OverSeizure > g1ProtectedBtc && nVaults >= 2 && !isCliff;
+
+  const idealProtectedBtc = totalBtc - totalBtc * Math.min(liqFactor, 1);
+  const currentProtectedBtc = firstGroup
+    ? firstGroup.btcRemainingAfter
+    : totalBtc;
+  const rebalanceImprovementBtc = rebalanceNeeded
+    ? Math.max(0, idealProtectedBtc - currentProtectedBtc)
+    : 0;
+
+  // Suggested new sacrificial vault: s >= (T × liqFactor − smallVaultsSum) /
+  // (1 − liqFactor). Cheaper than a standalone vault because the existing small
+  // vaults contribute to covering the target seizure.
+  let suggestedRebalanceVaultBtc: number | null = null;
+  let suggestedRebalanceOrder: Vault[] | null = null;
+  if (rebalanceNeeded && liqFactor < 1) {
+    const largest = vaults.reduce((a, b) => (a.btc > b.btc ? a : b));
+    const smallVaults = vaults.filter((v) => v.id !== largest.id);
+    const smallVaultsSum = smallVaults.reduce((s, v) => s + v.btc, 0);
+    const raw = (totalBtc * liqFactor - smallVaultsSum) / (1 - liqFactor);
+    const rounded = Math.ceil(Math.max(0, raw) * 100) / 100;
+    if (rounded <= totalBtc) {
+      suggestedRebalanceVaultBtc = rounded;
+      const placeholder: Vault = {
+        id: "__new__",
+        name: "__new__",
+        btc: rounded,
+      };
+      const allVaults = [placeholder, ...vaults];
+
+      const { order: optOrder } = computeOptimalOrder(
+        allVaults,
+        totalDebtUsd,
+        seizedFraction,
+        SEIZURE_TOL,
+        CF,
+        THF,
+        maxLB,
+        expectedHF,
+      );
+
+      // If the optimizer order still triggers rebalance, fall back to the
+      // manual protective order (new + small first, largest last).
+      const allTotal = allVaults.reduce((s, v) => s + v.btc, 0);
+      const optG1Btc = getGroup1FromOrder(
+        optOrder,
+        seizedFraction,
+        SEIZURE_TOL,
+      ).reduce((s, v) => s + v.btc, 0);
+      const optProtected = allTotal - optG1Btc;
+      const optOver = optG1Btc - allTotal * seizedFraction;
+      if (optOver > optProtected) {
+        const sortedSmall = [...smallVaults].sort((a, b) => b.btc - a.btc);
+        suggestedRebalanceOrder = [placeholder, ...sortedSmall, largest];
+      } else {
+        suggestedRebalanceOrder = optOrder;
+      }
+    }
+  }
+
+  // Emit the rebalance warning only when no cliff/reorder already covers it;
+  // otherwise drop its suggestion data so no orphan action button renders.
+  const hasCliffOrReorder = warnings.some(
+    (w) => w.type === "cliff" || w.type === "reorder",
+  );
+  if (rebalanceNeeded && hasCliffOrReorder) {
+    suggestedRebalanceVaultBtc = null;
+    suggestedRebalanceOrder = null;
+  }
+  if (rebalanceNeeded && !hasCliffOrReorder) {
+    const largest = vaults.reduce((a, b) => (a.btc > b.btc ? a : b));
+    const g1CombinedBtc = firstGroup?.combinedBtc ?? 0;
+    let suggestion: string;
+    if (
+      suggestedRebalanceVaultBtc !== null &&
+      suggestedRebalanceOrder !== null
+    ) {
+      const smallNames = vaults
+        .filter((v) => v.id !== largest.id)
+        .map((v) => v.name)
+        .join(" + ");
+      suggestion = COPY.liquidationWarnings.rebalance.actionableSuggestion(
+        btc2(suggestedRebalanceVaultBtc),
+        smallNames,
+        largest.name,
+        btc2(largest.btc),
+      );
+    } else {
+      suggestion = COPY.liquidationWarnings.rebalance.fallbackSuggestion(
+        btc2(totalBtc * Math.min(liqFactor, 1)),
+      );
+    }
+    warnings.push({
+      type: "rebalance",
+      title: COPY.liquidationWarnings.rebalance.title,
+      detail: COPY.liquidationWarnings.rebalance.detail(
+        btc2(g1CombinedBtc),
+        btc2(g1TargetSeizure),
+        btc2(g1OverSeizure),
+        btc2(rebalanceImprovementBtc),
+      ),
+      suggestion,
+    });
+  }
+
+  // ── 9. Return ──────────────────────────────────────────────────
 
   return {
     groups,
     currentHF,
     collateralValue,
     targetSeizureBtc,
+    recommendedSacrificialBtc,
     warnings,
+    isFullLiquidation,
     optimalVaultOrder,
+    suggestedNewVaultBtc,
+    suggestedRebalanceVaultBtc,
+    suggestedRebalanceOrder,
+    rebalanceImprovementBtc,
   };
 }

--- a/services/vault/src/applications/aave/positionNotifications/types.ts
+++ b/services/vault/src/applications/aave/positionNotifications/types.ts
@@ -63,14 +63,7 @@ export interface CalculatorResult {
   currentHF: number;
   collateralValue: number;
   targetSeizureBtc: number;
-  /**
-   * Recommended sacrificial-vault size for a single-vault split:
-   * `targetSeizure × SAFETY_MARGIN`, capped at total BTC.
-   */
-  recommendedSacrificialBtc: number;
   warnings: Warning[];
-  /** True when the cascade consolidates into one full-liquidation group. */
-  isFullLiquidation: boolean;
   /**
    * The liquidation-optimal vault order the calculator settled on, or `null`
    * when no reorder strictly helps (or under invalid/dust params). Surfaced in
@@ -93,11 +86,4 @@ export interface CalculatorResult {
    * position.
    */
   suggestedRebalanceVaultBtc: number | null;
-  /**
-   * The full vault order after adding the rebalance vault (includes the
-   * placeholder new vault). Drives the one-click apply for the rebalance fix.
-   */
-  suggestedRebalanceOrder: Vault[] | null;
-  /** Additional BTC that would survive the first event with optimal sizing. */
-  rebalanceImprovementBtc: number;
 }

--- a/services/vault/src/applications/aave/positionNotifications/types.ts
+++ b/services/vault/src/applications/aave/positionNotifications/types.ts
@@ -27,7 +27,14 @@ export interface LiquidationGroup {
   btcRemainingAfter: number;
 }
 
-export type WarningType = "urgent" | "dust" | "weird-params";
+export type WarningType =
+  | "urgent"
+  | "cliff"
+  | "rebalance"
+  | "reorder"
+  | "dust"
+  | "weird-params"
+  | "too-many-vaults";
 
 export interface Warning {
   type: WarningType;
@@ -56,12 +63,41 @@ export interface CalculatorResult {
   currentHF: number;
   collateralValue: number;
   targetSeizureBtc: number;
-  warnings: Warning[];
   /**
-   * The liquidation-optimal vault order the calculator settled on. The group
-   * breakdown is computed against this order. Null on early exits (no debt /
-   * dust). Surfaced in the reorder notification as the optimal-order chips
-   * and the "Apply Optimal Order" action.
+   * Recommended sacrificial-vault size for a single-vault split:
+   * `targetSeizure × SAFETY_MARGIN`, capped at total BTC.
+   */
+  recommendedSacrificialBtc: number;
+  warnings: Warning[];
+  /** True when the cascade consolidates into one full-liquidation group. */
+  isFullLiquidation: boolean;
+  /**
+   * The liquidation-optimal vault order the calculator settled on, or `null`
+   * when no reorder strictly helps (or under invalid/dust params). Surfaced in
+   * the reorder notification as the optimal-order chips and the "Apply Optimal
+   * Order" action, and re-derived by `assertOptimalOrderMatchesOnChain`.
+   * (The reference calculator calls this `suggestedVaultOrder`.)
    */
   optimalVaultOrder: Vault[] | null;
+  /**
+   * Single-vault cliff only: exact size of a sacrificial vault to add at
+   * position 1 so the existing vault becomes protected. Accounts for the new
+   * vault increasing total BTC (and therefore target seizure). `null` when not
+   * actionable (extreme params, or the amount would exceed the position).
+   */
+  suggestedNewVaultBtc: number | null;
+  /**
+   * Multi-vault rebalance only: size of a new sacrificial vault that combines
+   * with the existing small vaults to protect the largest. `null` when no
+   * rebalance is needed, params are extreme, or the amount would exceed the
+   * position.
+   */
+  suggestedRebalanceVaultBtc: number | null;
+  /**
+   * The full vault order after adding the rebalance vault (includes the
+   * placeholder new vault). Drives the one-click apply for the rebalance fix.
+   */
+  suggestedRebalanceOrder: Vault[] | null;
+  /** Additional BTC that would survive the first event with optimal sizing. */
+  rebalanceImprovementBtc: number;
 }

--- a/services/vault/src/applications/aave/services/assertReorderMatchesOnChain.ts
+++ b/services/vault/src/applications/aave/services/assertReorderMatchesOnChain.ts
@@ -204,6 +204,10 @@ export async function assertOptimalOrderMatchesOnChain(
     };
   });
 
+  // Re-runs the full optimizer (worst case ~100-200ms for an exact DP at the
+  // 17-vault cap). Acceptable on this path: it's a one-shot guard immediately
+  // before a wallet prompt (which itself takes seconds), and a position of 17
+  // separate peg-ins is extraordinarily rare.
   const { optimalVaultOrder } = calculate({
     btcPrice: ctx.btcPrice,
     totalDebtUsd: ctx.totalDebtUsd,

--- a/services/vault/src/components/simple/PositionNotificationBanner/BannerActions.tsx
+++ b/services/vault/src/components/simple/PositionNotificationBanner/BannerActions.tsx
@@ -20,10 +20,13 @@ interface BuildBannerActionsArgs {
  * `Notification` `actions` slot:
  * - urgent: "Add Collateral" (primary, filled) + "Repay Debt" (secondary,
  *   outlined) — the core safety actions, matching the Figma callout.
+ * - cliff / rebalance with an actionable suggested vault size: "Add a X BTC
+ *   vault" — opens the deposit flow with that amount pre-filled (a single,
+ *   non-split supplemental deposit).
  * - optimal reorder available: "Apply Optimal Order" — filled (primary) on the
  *   standalone reorder card, secondary when it accompanies the urgent callout.
  *
- * Both groups can appear together (an urgent position whose order is also
+ * The groups can appear together (an urgent position whose order is also
  * suboptimal).
  */
 export function buildBannerActions({
@@ -55,14 +58,32 @@ export function buildBannerActions({
     );
   }
 
+  // Add-vault CTA only when cliff/rebalance is the primary message — that is the
+  // case whose call to action is "add a sacrificial vault of this exact size".
+  // (Under an urgent primary the cliff is shown as a secondary note instead, so
+  // the safety actions lead.) The calculator already guarantees the amount is
+  // positive and no larger than the position.
+  const isCliffOrRebalancePrimary =
+    primaryWarning?.type === "cliff" || primaryWarning?.type === "rebalance";
+  const suggestedVaultBtc =
+    result.suggestedNewVaultBtc ?? result.suggestedRebalanceVaultBtc;
+  if (isCliffOrRebalancePrimary && suggestedVaultBtc !== null) {
+    const amountBtc = suggestedVaultBtc.toFixed(2);
+    actions.push({
+      label: COPY.banner.addVault(amountBtc),
+      onClick: () => onDeposit(amountBtc),
+      emphasis: "primary",
+    });
+  }
+
   if (showApplyOrder) {
     actions.push({
       label: isReordering
         ? COPY.common.applying
         : COPY.banner.applyOptimalOrder,
-      onClick: onApplyOrder,
       // Standalone reorder gets the filled (primary) gold button; when it rides
       // alongside the urgent callout it stays secondary so "Add Collateral" leads.
+      onClick: onApplyOrder,
       emphasis: isUrgent ? "secondary" : "primary",
       disabled: isReordering,
     });

--- a/services/vault/src/components/simple/PositionNotificationBanner/BannerActions.tsx
+++ b/services/vault/src/components/simple/PositionNotificationBanner/BannerActions.tsx
@@ -58,21 +58,23 @@ export function buildBannerActions({
     );
   }
 
-  // Add-vault CTA only when cliff/rebalance is the primary message — that is the
-  // case whose call to action is "add a sacrificial vault of this exact size".
-  // (Under an urgent primary the cliff is shown as a secondary note instead, so
-  // the safety actions lead.) The calculator already guarantees the amount is
-  // positive and no larger than the position.
-  const isCliffOrRebalancePrimary =
-    primaryWarning?.type === "cliff" || primaryWarning?.type === "rebalance";
+  // Add-vault CTA whenever a cliff/rebalance warning is present and the
+  // calculator produced an actionable size — i.e. "add a sacrificial vault of
+  // this exact size". When an urgent warning is primary it rides along as a
+  // secondary action so the safety actions lead, but it is no longer dropped
+  // (the cliff's own suggestion text describes exactly this action). The
+  // calculator guarantees the amount is positive and no larger than the position.
+  const hasCliffOrRebalanceWarning = result.warnings.some(
+    (w) => w.type === "cliff" || w.type === "rebalance",
+  );
   const suggestedVaultBtc =
     result.suggestedNewVaultBtc ?? result.suggestedRebalanceVaultBtc;
-  if (isCliffOrRebalancePrimary && suggestedVaultBtc !== null) {
+  if (hasCliffOrRebalanceWarning && suggestedVaultBtc !== null) {
     const amountBtc = suggestedVaultBtc.toFixed(2);
     actions.push({
       label: COPY.banner.addVault(amountBtc),
       onClick: () => onDeposit(amountBtc),
-      emphasis: "primary",
+      emphasis: isUrgent ? "secondary" : "primary",
     });
   }
 

--- a/services/vault/src/components/simple/PositionNotificationBanner/PositionNotificationBanner.tsx
+++ b/services/vault/src/components/simple/PositionNotificationBanner/PositionNotificationBanner.tsx
@@ -148,13 +148,15 @@ export function PositionNotificationBanner({
 
   const { primaryWarning, secondaryWarnings } = bannerState;
 
-  // The standalone reorder suggestion (soft severity, no primaryWarning) renders
-  // as the gold `suggestion` variant per Figma — distinct from the weird-params
-  // advisory, which is also soft but sets primaryWarning.
+  // The standalone reorder suggestion renders as the gold `suggestion` variant
+  // per Figma — distinct from the weird-params advisory, which is also soft but
+  // sets a non-reorder primaryWarning. It applies both when the calculator emits
+  // a `reorder` warning (its rich title/detail drive the card) and the legacy
+  // case of a suggested order with no warning object.
   const isStandaloneReorder =
     bannerState.severity === "soft" &&
-    !primaryWarning &&
-    bannerState.suggestReorder;
+    bannerState.suggestReorder &&
+    (primaryWarning === null || primaryWarning.type === "reorder");
   const variant = isStandaloneReorder
     ? "suggestion"
     : SEVERITY_VARIANT[bannerState.severity];
@@ -184,26 +186,39 @@ export function PositionNotificationBanner({
   });
 
   // Sub-box content: the optimal-order chips for the standalone reorder card,
-  // otherwise the stacked secondary warnings (e.g. urgent + weird-params).
+  // otherwise the primary warning's own suggestion (e.g. the cliff/rebalance
+  // advice — urgent conveys its CTA via the action buttons instead) stacked
+  // above any secondary warnings (e.g. urgent + cliff).
   let suggestion: ReactNode;
   if (isStandaloneReorder && result.optimalVaultOrder) {
     suggestion = <OptimalOrderChips vaults={result.optimalVaultOrder} />;
-  } else if (secondaryWarnings.length > 0) {
-    suggestion = (
-      <div className="flex flex-col gap-2">
-        {secondaryWarnings.map((warning, index) => (
-          <div key={index}>
-            <div className="text-sm font-semibold text-accent-primary">
-              {warning.title}
+  } else {
+    const primarySuggestion =
+      primaryWarning && primaryWarning.type !== "urgent"
+        ? primaryWarning.suggestion
+        : undefined;
+    if (primarySuggestion || secondaryWarnings.length > 0) {
+      suggestion = (
+        <div className="flex flex-col gap-2">
+          {primarySuggestion && (
+            <div className="text-sm opacity-80">{primarySuggestion}</div>
+          )}
+          {secondaryWarnings.map((warning, index) => (
+            <div key={index}>
+              <div className="text-sm font-semibold text-accent-primary">
+                {warning.title}
+              </div>
+              {warning.detail && (
+                <div className="text-sm">{warning.detail}</div>
+              )}
+              {warning.suggestion && (
+                <div className="text-sm opacity-80">{warning.suggestion}</div>
+              )}
             </div>
-            {warning.detail && <div className="text-sm">{warning.detail}</div>}
-            {warning.suggestion && (
-              <div className="text-sm opacity-80">{warning.suggestion}</div>
-            )}
-          </div>
-        ))}
-      </div>
-    );
+          ))}
+        </div>
+      );
+    }
   }
 
   return (

--- a/services/vault/src/components/simple/PositionNotificationBanner/__tests__/PositionNotificationBanner.test.tsx
+++ b/services/vault/src/components/simple/PositionNotificationBanner/__tests__/PositionNotificationBanner.test.tsx
@@ -154,14 +154,10 @@ function makeBaseResult(
     currentHF: 1.2,
     collateralValue: 40000,
     targetSeizureBtc: 0.28,
-    recommendedSacrificialBtc: 0.29,
     warnings: [],
-    isFullLiquidation: false,
     optimalVaultOrder: null,
     suggestedNewVaultBtc: null,
     suggestedRebalanceVaultBtc: null,
-    suggestedRebalanceOrder: null,
-    rebalanceImprovementBtc: 0,
     ...overrides,
   };
 }

--- a/services/vault/src/components/simple/PositionNotificationBanner/__tests__/PositionNotificationBanner.test.tsx
+++ b/services/vault/src/components/simple/PositionNotificationBanner/__tests__/PositionNotificationBanner.test.tsx
@@ -154,8 +154,14 @@ function makeBaseResult(
     currentHF: 1.2,
     collateralValue: 40000,
     targetSeizureBtc: 0.28,
+    recommendedSacrificialBtc: 0.29,
     warnings: [],
+    isFullLiquidation: false,
     optimalVaultOrder: null,
+    suggestedNewVaultBtc: null,
+    suggestedRebalanceVaultBtc: null,
+    suggestedRebalanceOrder: null,
+    rebalanceImprovementBtc: 0,
     ...overrides,
   };
 }
@@ -451,5 +457,63 @@ describe("PositionNotificationBanner", () => {
     expect(
       container.querySelector("[data-testid='position-notification-banner']"),
     ).toBeNull();
+  });
+
+  it("renders an Add-a-vault CTA for a single-vault cliff and pre-fills the amount", () => {
+    const result = makeBaseResult({
+      warnings: [
+        {
+          type: "cliff",
+          title: "No backup vault",
+          detail: "Your vault will be fully seized at liquidation.",
+          suggestion: "Add a 0.72 BTC sacrificial vault at position 1.",
+        },
+      ],
+      suggestedNewVaultBtc: 0.72,
+    });
+    renderBanner(result, onDeposit, onRepay);
+
+    const banner = screen.getByTestId("position-notification-banner");
+    expect(banner.dataset.severity).toBe("soft");
+    fireEvent.click(screen.getByText("Add a 0.72 BTC vault"));
+    expect(onDeposit).toHaveBeenCalledWith("0.72");
+  });
+
+  it("renders an Add-a-vault CTA for a rebalance with the rebalance amount", () => {
+    const result = makeBaseResult({
+      warnings: [
+        {
+          type: "rebalance",
+          title: "Undersized sacrificial vault",
+          detail: "Group 1 over-seizes.",
+          suggestion: "Add a 0.38 BTC vault.",
+        },
+      ],
+      suggestedRebalanceVaultBtc: 0.38,
+    });
+    renderBanner(result, onDeposit, onRepay);
+
+    fireEvent.click(screen.getByText("Add a 0.38 BTC vault"));
+    expect(onDeposit).toHaveBeenCalledWith("0.38");
+  });
+
+  it("renders a soft too-many-vaults advisory with no action button", () => {
+    const result = makeBaseResult({
+      warnings: [
+        {
+          type: "too-many-vaults",
+          title: "Too many vaults — optimal ordering disabled",
+          detail: "You have 18 vaults.",
+          suggestion: "Consider consolidating smaller vaults.",
+        },
+      ],
+    });
+    renderBanner(result, onDeposit, onRepay);
+
+    const banner = screen.getByTestId("position-notification-banner");
+    expect(banner.dataset.severity).toBe("soft");
+    expect(banner.dataset.variant).toBe("info");
+    expect(screen.queryByText(/Add a .* BTC vault/)).toBeNull();
+    expect(screen.queryByText("Apply Optimal Order")).toBeNull();
   });
 });

--- a/services/vault/src/components/simple/PositionNotificationBanner/__tests__/PositionNotificationBanner.test.tsx
+++ b/services/vault/src/components/simple/PositionNotificationBanner/__tests__/PositionNotificationBanner.test.tsx
@@ -479,6 +479,34 @@ describe("PositionNotificationBanner", () => {
     expect(onDeposit).toHaveBeenCalledWith("0.72");
   });
 
+  it("keeps the Add-a-vault CTA (secondary) when a single-vault cliff is also urgent", () => {
+    const result = makeBaseResult({
+      warnings: [
+        {
+          type: "urgent",
+          title: "Liquidation is 3.0% away",
+          detail: "BTC needs to drop only 3%.",
+        },
+        {
+          type: "cliff",
+          title: "No backup vault",
+          detail: "Your vault will be fully seized at liquidation.",
+          suggestion: "Add a 0.72 BTC sacrificial vault at position 1.",
+        },
+      ],
+      suggestedNewVaultBtc: 0.72,
+    });
+    renderBanner(result, onDeposit, onRepay);
+
+    const banner = screen.getByTestId("position-notification-banner");
+    expect(banner.dataset.severity).toBe("red");
+    // Safety actions still lead, and the pre-filled cliff CTA is still offered.
+    expect(screen.getByText("Add Collateral")).toBeTruthy();
+    expect(screen.getByText("Repay Debt")).toBeTruthy();
+    fireEvent.click(screen.getByText("Add a 0.72 BTC vault"));
+    expect(onDeposit).toHaveBeenCalledWith("0.72");
+  });
+
   it("renders an Add-a-vault CTA for a rebalance with the rebalance amount", () => {
     const result = makeBaseResult({
       warnings: [

--- a/services/vault/src/components/simple/PositionNotificationBanner/__tests__/PositionNotificationBanner.test.tsx
+++ b/services/vault/src/components/simple/PositionNotificationBanner/__tests__/PositionNotificationBanner.test.tsx
@@ -525,22 +525,23 @@ describe("PositionNotificationBanner", () => {
     expect(onDeposit).toHaveBeenCalledWith("0.38");
   });
 
-  it("renders a soft too-many-vaults advisory with no action button", () => {
+  it("renders too-many-vaults as an orange warning with no action button", () => {
     const result = makeBaseResult({
       warnings: [
         {
           type: "too-many-vaults",
-          title: "Too many vaults — optimal ordering disabled",
+          title: "Too many vaults to optimize",
           detail: "You have 18 vaults.",
-          suggestion: "Consider consolidating smaller vaults.",
+          suggestion:
+            "Consider consolidating smaller vaults into fewer larger ones.",
         },
       ],
     });
     renderBanner(result, onDeposit, onRepay);
 
     const banner = screen.getByTestId("position-notification-banner");
-    expect(banner.dataset.severity).toBe("soft");
-    expect(banner.dataset.variant).toBe("info");
+    expect(banner.dataset.severity).toBe("yellow");
+    expect(banner.dataset.variant).toBe("warning");
     expect(screen.queryByText(/Add a .* BTC vault/)).toBeNull();
     expect(screen.queryByText("Apply Optimal Order")).toBeNull();
   });

--- a/services/vault/src/components/simple/__tests__/CriticalLiquidationTopBanner.test.tsx
+++ b/services/vault/src/components/simple/__tests__/CriticalLiquidationTopBanner.test.tsx
@@ -46,8 +46,14 @@ function makeResult({
     currentHF: 1.1,
     collateralValue: 100000,
     targetSeizureBtc: 0,
+    recommendedSacrificialBtc: 0,
     warnings: urgent ? [{ type: "urgent", title: "x", detail: "y" }] : [],
+    isFullLiquidation: false,
     optimalVaultOrder: null,
+    suggestedNewVaultBtc: null,
+    suggestedRebalanceVaultBtc: null,
+    suggestedRebalanceOrder: null,
+    rebalanceImprovementBtc: 0,
   };
 }
 

--- a/services/vault/src/components/simple/__tests__/CriticalLiquidationTopBanner.test.tsx
+++ b/services/vault/src/components/simple/__tests__/CriticalLiquidationTopBanner.test.tsx
@@ -46,14 +46,10 @@ function makeResult({
     currentHF: 1.1,
     collateralValue: 100000,
     targetSeizureBtc: 0,
-    recommendedSacrificialBtc: 0,
     warnings: urgent ? [{ type: "urgent", title: "x", detail: "y" }] : [],
-    isFullLiquidation: false,
     optimalVaultOrder: null,
     suggestedNewVaultBtc: null,
     suggestedRebalanceVaultBtc: null,
-    suggestedRebalanceOrder: null,
-    rebalanceImprovementBtc: 0,
   };
 }
 

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -1004,6 +1004,7 @@ export const COPY = {
     addCollateral: "Add Collateral",
     repayDebt: "Repay Debt",
     applyOptimalOrder: "Apply Optimal Order",
+    addVault: (amountBtc: string) => `Add a ${amountBtc} BTC vault`,
   },
   geoBlock: {
     title: "Service unavailable in your region",
@@ -1046,7 +1047,9 @@ export const COPY = {
     liquidatable: "Critical — liquidation can trigger now",
   },
   // Liquidation-notification warnings shown in the position banner. Mirrors the
-  // three warning types produced by the calculator (urgent / dust / weird-params).
+  // warning types produced by the calculator: urgent / cliff / rebalance /
+  // reorder / dust / weird-params / too-many-vaults. Wording is ported from the
+  // reference liquidation calculator (the source of truth for this copy).
   liquidationWarnings: {
     urgent: {
       liquidatableTitle: "Liquidation can trigger now",
@@ -1069,6 +1072,100 @@ export const COPY = {
         "A different vault order makes the first liquidation event smaller — less BTC seized when it triggers.",
       suggestedOrderLabel: "Suggested order",
       vaultChip: (name: string, amount: string) => `${name} · ${amount}`,
+      // Warning-variant copy (emitted by the calculator alongside the optimal
+      // order). `swap` is the two-vault cliff fix; the others cover the general
+      // reorder cases.
+      swapTitle: "Swap vault order to unlock partial protection",
+      swapDetail: (bestName: string, bestBtc: string, firstName: string) =>
+        `${bestName} (${bestBtc} BTC) covers the target seizure alone. Right now both vaults are seized together because ${firstName} is first and too small.`,
+      swapSuggestion: (bestName: string, otherName: string) =>
+        `Suggested order: ${bestName} → ${otherName}`,
+      reduceFirstEventTitle:
+        "Better vault ordering reduces first-event seizure",
+      deepenCascadeTitle: "Better vault ordering deepens cascade protection",
+      suggestedOrder: (orderStr: string) => `Suggested order: ${orderStr}`,
+      // Assembled detail string. `g1` (current vs optimal Group 1 BTC) is
+      // prepended when both are known; `sumImproves` selects the per-cascade vs
+      // first-event framing.
+      detail2: (opts: {
+        sumImproves: boolean;
+        savedSum: string;
+        savedBtcAfterG1: string;
+        currentG1Btc?: string;
+        optimalG1Btc?: string;
+      }) => {
+        const g1Part =
+          opts.currentG1Btc !== undefined && opts.optimalG1Btc !== undefined
+            ? `Current order seizes ${opts.currentG1Btc} BTC in Group 1. Optimal order seizes only ${opts.optimalG1Btc} BTC. `
+            : "";
+        return opts.sumImproves
+          ? `${g1Part}Reordering leaves more BTC protected after each liquidation event (+${opts.savedSum} BTC-events total).`
+          : `${g1Part}Reordering leaves ${opts.savedBtcAfterG1} more BTC protected after the first liquidation event.`;
+      },
+    },
+    // Cliff: all vaults consolidate into one liquidation group, so partial
+    // liquidation is no longer possible. Variant by vault count.
+    cliff: {
+      single: {
+        title: "No backup vault",
+        detail:
+          "Your vault will be fully seized at liquidation — nothing is protected behind it.",
+        actionableSuggestion: (suggestedBtc: string, vaultBtc: string) =>
+          `Add a ${suggestedBtc} BTC sacrificial vault at position 1 — your current vault (${vaultBtc} BTC) becomes protected.`,
+        noSplitSuggestion:
+          "Current protocol parameters do not allow vault splitting as a protection strategy. Add collateral or repay part of the debt to keep this position safe.",
+        oversizedSuggestion: (rawBtc: string) =>
+          `To enable partial liquidation, add ≥ ${rawBtc} BTC as a sacrificial vault. You can also add collateral or repay part of the debt to keep this position safe. Alternatively: repay the loan, split BTC into optimal UTXOs, and re-open with a sacrificial vault.`,
+      },
+      twoVault: {
+        title: "Both vaults seized together — no partial protection",
+        detail: (targetSeizureBtc: string) =>
+          `Neither vault alone covers the target seizure (${targetSeizureBtc} BTC). Both will be liquidated in one event.`,
+        enablePartial: (deficitBtc: string, largestName: string) =>
+          `To enable partial liquidation, add ≥ ${deficitBtc} BTC alongside ${largestName}. `,
+        suggestion: (enablePartialStr: string) =>
+          `${enablePartialStr}You can also add collateral or repay part of the debt to keep this position safe. Alternatively: repay the loan, split BTC into optimal UTXOs, and re-open with a sacrificial vault.`,
+      },
+      multiVault: {
+        title: "All vaults seized in one liquidation event",
+        detail: (nVaults: number, hasReorderFix: boolean) =>
+          `All ${nVaults} vaults land in Group 1 — no protected vaults remain after first liquidation. ${
+            hasReorderFix
+              ? "Reordering vaults will fix this."
+              : "No combination of vaults covers the target seizure alone."
+          }`,
+        suggestion: (orderStr: string) => `Suggested order: ${orderStr}`,
+      },
+    },
+    // Rebalance: the first group over-seizes because vault sizes aren't optimal;
+    // a new sacrificial vault (combined with the existing small vaults) fixes it.
+    rebalance: {
+      title: "Undersized sacrificial vault",
+      detail: (
+        g1CombinedBtc: string,
+        g1TargetSeizure: string,
+        g1OverSeizure: string,
+        improvementBtc: string,
+      ) =>
+        `Group 1 seizes ${g1CombinedBtc} BTC but target is only ${g1TargetSeizure} BTC — over-seizure of ${g1OverSeizure} BTC. With optimal vault sizes, ${improvementBtc} more BTC would be protected.`,
+      actionableSuggestion: (
+        suggestedBtc: string,
+        smallNames: string,
+        largestName: string,
+        largestBtc: string,
+      ) =>
+        `Add a ${suggestedBtc} BTC vault and place it with ${smallNames} at the front — together they cover the target seizure, protecting ${largestName} (${largestBtc} BTC). You can also add collateral or repay part of the debt to keep this position safe. Alternatively: repay the loan, split BTC into optimal UTXOs, and re-open the position.`,
+      fallbackSuggestion: (sacrificialBtc: string) =>
+        `Repay the loan, split BTC into optimal UTXOs (sacrificial ~${sacrificialBtc} BTC + protected), and re-open the position.`,
+    },
+    // Too many vaults: beyond the optimizer cap, ordering falls back to a
+    // largest-first heuristic and the reorder suggestion is no longer optimal.
+    tooManyVaults: {
+      title: "Too many vaults — optimal ordering disabled",
+      detail: (nVaults: number, cap: number) =>
+        `You have ${nVaults} vaults. Our optimizer only runs up to ${cap} vaults because beyond that the search space becomes too large to explore exhaustively (O(3ⁿ) time, 2ⁿ memory). The liquidation groups shown below are still accurate for the current vault order, but we can no longer suggest a guaranteed-optimal reordering.`,
+      suggestion:
+        "Consider consolidating smaller vaults — each peg-in costs a separate fee anyway, and fewer vaults give you a guaranteed-optimal cascade ordering.",
     },
     dust: {
       title: "Position too small to model",

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -1066,42 +1066,15 @@ export const COPY = {
     },
     // Standalone reorder suggestion (not a risk warning). Surfaced whenever the
     // engine finds a safer liquidation order than the current on-chain order.
+    // Single reorder notification (matches Figma 6502-111184). Emitted whenever
+    // the calculator finds a strictly safer order than the current one; the
+    // suggested order is rendered as chips from `optimalVaultOrder`, not text.
     reorder: {
       title: "Reorder vaults to lose less",
       detail:
         "A different vault order makes the first liquidation event smaller — less BTC seized when it triggers.",
       suggestedOrderLabel: "Suggested order",
       vaultChip: (name: string, amount: string) => `${name} · ${amount}`,
-      // Warning-variant copy (emitted by the calculator alongside the optimal
-      // order). `swap` is the two-vault cliff fix; the others cover the general
-      // reorder cases.
-      swapTitle: "Swap vault order to unlock partial protection",
-      swapDetail: (bestName: string, bestBtc: string, firstName: string) =>
-        `${bestName} (${bestBtc} BTC) covers the target seizure alone. Right now both vaults are seized together because ${firstName} is first and too small.`,
-      swapSuggestion: (bestName: string, otherName: string) =>
-        `Suggested order: ${bestName} → ${otherName}`,
-      reduceFirstEventTitle:
-        "Better vault ordering reduces first-event seizure",
-      deepenCascadeTitle: "Better vault ordering deepens cascade protection",
-      suggestedOrder: (orderStr: string) => `Suggested order: ${orderStr}`,
-      // Assembled detail string. `g1` (current vs optimal Group 1 BTC) is
-      // prepended when both are known; `sumImproves` selects the per-cascade vs
-      // first-event framing.
-      detail2: (opts: {
-        sumImproves: boolean;
-        savedSum: string;
-        savedBtcAfterG1: string;
-        currentG1Btc?: string;
-        optimalG1Btc?: string;
-      }) => {
-        const g1Part =
-          opts.currentG1Btc !== undefined && opts.optimalG1Btc !== undefined
-            ? `Current order seizes ${opts.currentG1Btc} BTC in Group 1. Optimal order seizes only ${opts.optimalG1Btc} BTC. `
-            : "";
-        return opts.sumImproves
-          ? `${g1Part}Reordering leaves more BTC protected after each liquidation event (+${opts.savedSum} BTC-events total).`
-          : `${g1Part}Reordering leaves ${opts.savedBtcAfterG1} more BTC protected after the first liquidation event.`;
-      },
     },
     // Cliff: all vaults consolidate into one liquidation group, so partial
     // liquidation is no longer possible. Variant by vault count.
@@ -1160,12 +1133,13 @@ export const COPY = {
     },
     // Too many vaults: beyond the optimizer cap, ordering falls back to a
     // largest-first heuristic and the reorder suggestion is no longer optimal.
+    // Copy matches Figma 7048-61969 (count + cap stay interpolated).
     tooManyVaults: {
-      title: "Too many vaults — optimal ordering disabled",
+      title: "Too many vaults to optimize",
       detail: (nVaults: number, cap: number) =>
-        `You have ${nVaults} vaults. Our optimizer only runs up to ${cap} vaults because beyond that the search space becomes too large to explore exhaustively (O(3ⁿ) time, 2ⁿ memory). The liquidation groups shown below are still accurate for the current vault order, but we can no longer suggest a guaranteed-optimal reordering.`,
+        `You have ${nVaults} vaults. Beyond ${cap}, the optimizer can't guarantee the best liquidation order — it falls back to a simpler largest-first approach. Your liquidation risk data is still accurate, but the order may not be optimal.`,
       suggestion:
-        "Consider consolidating smaller vaults — each peg-in costs a separate fee anyway, and fewer vaults give you a guaranteed-optimal cascade ordering.",
+        "Consider consolidating smaller vaults into fewer larger ones — fewer vaults means lower fees and better optimization.",
     },
     dust: {
       title: "Position too small to model",


### PR DESCRIPTION
# Port the liquidation calculator to match the source-of-truth repo

<img width="2032" height="1162" alt="Screenshot_2026-06-25_18-48-13" src="https://github.com/user-attachments/assets/4f850762-78fa-496c-a7b6-c1dfdaed6e27" />

## What this does

It brings our in-app liquidation calculator in line with the canonical calculator in the `tbv-liquidations` repo (the agreed source of truth, recently rewritten by @ngfam), so the dApp produces the full set of partial-liquidation notifications instead of just a few.

Before this PR our calculator only produced three warnings: `urgent` (close to liquidation), `dust` (position too small), and `weird-params` (invalid protocol params), plus a basic reorder suggestion. The reference calculator produces a much richer, actionable set. This PR adds the missing pieces.

New notifications:
- `cliff` — all your vaults would be seized in a single liquidation event (no partial-liquidation protection). For a single-vault position it tells you the exact size of a sacrificial vault to add so your current vault becomes protected.
- `rebalance` — your first liquidation group over-seizes (vault sizes aren't ideal); suggests adding a correctly-sized vault.
- `reorder` — a safer vault order exists (now a first-class warning with the reference's swap / reduce-first-event / deepen-cascade variants, plus a guard that stops a reorder ↔ rebalance flip-flop).
- `too-many-vaults` — past the optimizer's cap the ordering is no longer guaranteed optimal; suggests consolidating.

New actions on the banner:
- `cliff` and `rebalance` now show an "Add a X BTC vault" button that opens the deposit flow with the suggested amount pre-filled (a single, non-split deposit). This reuses plumbing that already existed.
- The reorder "Apply Optimal Order" button is unchanged.

## Why

We originally split a user's BTC into a sacrificial + protected vault at deposit time so that one vault can be liquidated first while the other survives. That setup can break later (protocol params change, the user adds/removes a vault), and then the user can lose everything in one event. The fix the team agreed on is not to silently reorder for the user, but to *show actionable notifications* and let the user decide what to do. The reference calculator is where that logic now lives, so our job is to mirror it faithfully.

## Approaches considered

1. Incremental alignment — keep our current structure and bolt on the missing warnings one at a time.
2. Wholesale port — replace our advisory layer with a faithful port of the reference calculator and adopt its scenario suite as golden-vector tests.

We went with the wholesale port. The reference is the agreed source of truth and is what the test scenarios were validated against, so mirroring it 1:1 keeps us from drifting and makes future re-syncs trivial. We adapted it to our codebase only where we had to: we keep our strings in `copy.ts`, we keep our existing protective gate that hides the cascade under invalid protocol params, and we reuse the shared optimizer in the ts-sdk rather than duplicating it.

The core liquidation math (seizure fraction, liquidation price, over-seizure, fairness payments, dust) was already identical to the reference, so it is unchanged — this PR only adds the advisory/notification layer on top.

## Key decisions a reviewer should sanity-check

- Optimizer cap raised from 10 to 17 with a largest-first fallback past the cap, matching the reference (we dropped the old "pre-joint smaller vaults" approach). We kept our existing first-event tiebreaker. The audited-path characterization by vault count: ≤10 vaults — unchanged from what ships today; 11–17 vaults — now an **exact** DP (the old code compressed n>10 into 10 pre-joint groups and ran an approximate DP), so for these sizes the suggested order genuinely *can* differ; 18+ vaults — now largest-first (was the pre-joint heuristic). This is safe regardless of cap: the on-chain reorder check (`assertOptimalOrderMatchesOnChain`) re-runs the same `calculate()` that produced the CTA, so the CTA and the guard stay self-consistent. That guard's tests still pass.
- `expectedHF` stays 0.95. The project spec doc says 0.97, but the reference *code* defaults to 0.95 (its own UI even says "Hardcoded 0.95 in production"); the doc (confluence) is stale.
- `urgent` copy stays as our shipped wording ("Liquidation is X% away" / "Liquidation can trigger now") rather than the reference's "Critical…" strings. Tests assert behavior, not the reference's urgent text.
- `cliff` / `rebalance` / `too-many-vaults` render as soft (info) banners, not red. Red is reserved for imminent-liquidation (`urgent`). This means a healthy single-vault position shows a soft "No backup vault" advisory. Worth confirming against the cliff Figma severity.
- The whole surface stays behind the existing `NEXT_PUBLIC_FF_ENABLE_LIQUIDATION_NOTIFICATIONS` flag.

## What is NOT in this PR

This PR is scoped to the liquidation calculator. It does not implement the separate hard per-position vault cap from https://github.com/babylonlabs-io/babylon-toolkit/issues/1958 ("Too many vaults for this position") — that one is a contract-read cap (`maxVaultsPerPosition`) that blocks creating a new vault in the deposit flow, which is a different, deposit-flow feature.

## Testing

- ts-sdk: optimizer + cascade tests updated for the new cap/fallback; full aave suite passes (148 tests).
- vault: typecheck clean, production build clean, lint clean (0 errors). Added 14 golden-vector tests ported from the reference scenario suite (single-vault cliff, two-vault cliff, reorder/swap, rebalance, optimal 3-vault, tolerance boundary, too-many-vaults) — the suggested vault amounts matched the reference exactly. Added banner tests for the new "Add a X BTC vault" action.
- The on-chain reorder verification path (`assertOptimalOrderMatchesOnChain`) was re-checked — all 22 of its tests pass after the optimizer change.

## Related issues

- Closes https://github.com/babylonlabs-io/babylon-toolkit/issues/1952 (too many vaults to optimize — the 17-cap optimizer ordering warning).
- Relates to https://github.com/babylonlabs-io/babylon-toolkit/issues/1948 and https://github.com/babylonlabs-io/babylon-toolkit/issues/1949 (the cliff "add a sacrificial vault" notifications).
- Builds on https://github.com/babylonlabs-io/babylon-toolkit/issues/1950 (reorder to lose less — already shipped, now upgraded).
- Out of scope: https://github.com/babylonlabs-io/babylon-toolkit/issues/1958 (hard per-position vault cap).

