### PR TITLE
feat(vault): align cliff liquidation notification to Figma and smooth the stale price banner

### DIFF
--- a/services/vault/src/applications/aave/positionNotifications/__tests__/calculate.test.ts
+++ b/services/vault/src/applications/aave/positionNotifications/__tests__/calculate.test.ts
@@ -246,6 +246,15 @@ describe("bannerSeverity", () => {
     expect(deriveBannerState(result).severity).toBe("hidden");
   });
 
+  it("yellow (orange) when a cliff is the primary warning", () => {
+    // Single 2.0 BTC vault: cliff but far from liquidation (no urgent), so the
+    // cliff is primary and renders as the orange warning per Figma.
+    const result = calculate(makeParams([v(2.0)]));
+    const state = deriveBannerState(result);
+    expect(state.primaryWarning?.type).toBe("cliff");
+    expect(state.severity).toBe("yellow");
+  });
+
   it("soft for a weird-params advisory", () => {
     const result = calculate(makeParams([v(1.0)], { THF: 0.9 }));
     const state = deriveBannerState(result);
@@ -269,14 +278,32 @@ describe("bannerSeverity", () => {
 // our copy strings — which intentionally differ from the reference only for the
 // `urgent` titles.
 describe("golden vectors (reference scenario suite)", () => {
-  it("A1 — single 1.0 BTC: cliff (no backup) + urgent within 5%", () => {
+  it("A1 — single 1.0 BTC: affordable cliff (add sacrificial) + urgent within 5%", () => {
     const result = calculate(makeParams([v(1.0)]));
-    expect(getWarning(result.warnings, "cliff")?.title).toBe("No backup vault");
+    expect(getWarning(result.warnings, "cliff")?.title).toBe(
+      "First liquidation takes everything",
+    );
     expect(hasWarning(result.warnings, "urgent")).toBe(true);
     expect(result.groups).toHaveLength(1);
     expect(result.groups[0].isFullLiquidation).toBe(true);
-    // Sacrificial vault to add so the existing vault becomes protected.
+    // Affordable add (≤ position) → Variant A: sacrificial vault to add so the
+    // existing vault becomes protected.
     expect(result.suggestedNewVaultBtc).toBe(0.72);
+    expect(getWarning(result.warnings, "cliff")?.suggestion).toContain(
+      "0.72 BTC sacrificial vault creates a buffer",
+    );
+  });
+
+  it("A8 — single 2.0 BTC, THF 1.40: oversized cliff → withdraw & re-deposit (Variant B)", () => {
+    const result = calculate(makeParams([v(2.0)], { THF: 1.4 }));
+    const cliff = getWarning(result.warnings, "cliff");
+    expect(cliff?.title).toBe("First liquidation takes everything");
+    // The needed add exceeds the position, so there is no actionable CTA; the
+    // fix is to withdraw and re-split. sacrificial + protected === withdraw.
+    expect(result.suggestedNewVaultBtc).toBeNull();
+    expect(cliff?.suggestion).toContain("withdraw your 2.00 BTC");
+    expect(cliff?.suggestion).toContain("1.28 BTC sacrificial");
+    expect(cliff?.suggestion).toContain("0.72 BTC protected");
   });
 
   it("A2 — single 2.0 BTC: cliff only, no urgent (far from liquidation)", () => {
@@ -326,9 +353,10 @@ describe("golden vectors (reference scenario suite)", () => {
 
   it("D1 — THF 1.30 [0.50, 0.50]: true cliff, neither vault covers", () => {
     const result = calculate(makeParams([v(0.5), v(0.5)], { THF: 1.3 }));
-    expect(getWarning(result.warnings, "cliff")?.detail).toContain(
-      "Neither vault",
-    );
+    const cliff = getWarning(result.warnings, "cliff");
+    expect(cliff?.title).toBe("First liquidation takes everything");
+    // The deficit detail moved into the suggestion now that the body is shared.
+    expect(cliff?.suggestion).toContain("Neither vault");
     expect(hasWarning(result.warnings, "reorder")).toBe(false);
     expect(result.groups).toHaveLength(1);
   });
@@ -343,9 +371,9 @@ describe("golden vectors (reference scenario suite)", () => {
 
   it("G2 — [0.10, 0.10, 0.35] cliff fixable by reorder", () => {
     const result = calculate(makeParams([v(0.1), v(0.1), v(0.35)]));
-    expect(getWarning(result.warnings, "cliff")?.detail).toContain(
-      "Reordering",
-    );
+    const cliff = getWarning(result.warnings, "cliff");
+    expect(cliff?.title).toBe("First liquidation takes everything");
+    expect(cliff?.suggestion).toContain("Reordering");
     expect(result.groups).toHaveLength(1);
   });
 

--- a/services/vault/src/applications/aave/positionNotifications/__tests__/calculate.test.ts
+++ b/services/vault/src/applications/aave/positionNotifications/__tests__/calculate.test.ts
@@ -306,6 +306,21 @@ describe("golden vectors (reference scenario suite)", () => {
     expect(cliff?.suggestion).toContain("0.72 BTC protected");
   });
 
+  it("A9 — non-cent-aligned vault: the three re-deposit amounts reconcile", () => {
+    // 1.045 BTC at THF 1.40 rendered an infeasible "1.04 → 0.67 + 0.38" (= 1.05)
+    // before the withdraw was snapped to cents; the parts must sum to withdraw.
+    const result = calculate(makeParams([v(1.045)], { THF: 1.4 }));
+    const suggestion = getWarning(result.warnings, "cliff")?.suggestion ?? "";
+    const match = suggestion.match(
+      /withdraw your ([\d.]+) BTC.*?([\d.]+) BTC sacrificial \+ ([\d.]+) BTC protected/,
+    );
+    expect(match).not.toBeNull();
+    const [, withdraw, sacrificial, protectedAmt] = match!;
+    expect(
+      (parseFloat(sacrificial) + parseFloat(protectedAmt)).toFixed(2),
+    ).toBe(parseFloat(withdraw).toFixed(2));
+  });
+
   it("A2 — single 2.0 BTC: cliff only, no urgent (far from liquidation)", () => {
     const result = calculate(makeParams([v(2.0)]));
     expect(hasWarning(result.warnings, "cliff")).toBe(true);

--- a/services/vault/src/applications/aave/positionNotifications/bannerSeverity.ts
+++ b/services/vault/src/applications/aave/positionNotifications/bannerSeverity.ts
@@ -1,18 +1,22 @@
 import type { CalculatorResult, Warning, WarningType } from "./types";
 
 /**
- * Calculator warnings map to red (urgent), yellow (too-many-vaults — the orange
- * warning banner per Figma), soft (everything else advisory), green (none), or
- * hidden (dust / no groups). "yellow" also backs the stale-price banner, which
- * is driven separately by a status override rather than a calculator warning.
+ * Calculator warnings map to red (urgent), yellow (cliff / too-many-vaults — the
+ * orange warning banner per Figma), soft (everything else advisory), green
+ * (none), or hidden (dust / no groups). "yellow" also backs the stale-price
+ * banner, which is driven separately by a status override rather than a
+ * calculator warning.
  */
 export type BannerSeverity = "red" | "yellow" | "soft" | "green" | "hidden";
 
 /**
  * Per-type severity for the primary warning. Anything not listed renders soft.
+ * `cliff` is orange per Figma ("First liquidation takes everything"); it only
+ * surfaces as the primary banner when no `urgent` (red) warning is present.
  */
 const SEVERITY_BY_TYPE: Partial<Record<WarningType, BannerSeverity>> = {
   urgent: "red",
+  cliff: "yellow",
   "too-many-vaults": "yellow",
 };
 
@@ -48,9 +52,9 @@ const PRIMARY_ORDER: WarningType[] = [
  * Map a CalculatorResult to a banner display state.
  *
  * Red:    urgent warning present (already liquidatable or within 5%)
- * Yellow: too-many-vaults (the orange warning banner per Figma)
- * Soft:   any other advisory warning (cliff / rebalance / reorder /
- *         weird-params), or a healthy position whose vault order is suboptimal
+ * Yellow: cliff or too-many-vaults (the orange warning banner per Figma)
+ * Soft:   any other advisory warning (rebalance / reorder / weird-params), or a
+ *         healthy position whose vault order is suboptimal
  * Green:  no warnings and order already optimal
  * Hidden: no groups, or dust position (too small to matter)
  */

--- a/services/vault/src/applications/aave/positionNotifications/calculate.ts
+++ b/services/vault/src/applications/aave/positionNotifications/calculate.ts
@@ -418,9 +418,12 @@ export function calculate(params: CalculatorParams): CalculatorResult {
     detail: reorder.detail,
   };
 
-  // CASE 1: Single vault — always fully seized. To protect it, add a NEW
-  // sacrificial vault at position 1. Adding a vault increases total BTC, hence
-  // target seizure: s >= existingBtc × liqFactor / (1 − liqFactor).
+  // CASE 1: Single vault — always fully seized. Two Figma variants share the
+  // title/body and differ only by which fix is feasible:
+  //  • Affordable add (CLIFF A, #1948): a sacrificial vault smaller than the
+  //    position buffers it. s >= existingBtc × liqFactor / (1 − liqFactor).
+  //  • Oversized (CLIFF B, #1949): that add would exceed the position, so the
+  //    fix is to withdraw and re-deposit the same BTC as two smaller vaults.
   let suggestedNewVaultBtc: number | null = null;
   if (nVaults === 1) {
     const canSplit = liqFactor < 1;
@@ -435,25 +438,37 @@ export function calculate(params: CalculatorParams): CalculatorResult {
 
     let suggestion: string;
     if (suggestedNewVaultBtc !== null) {
-      suggestion = cliff.single.actionableSuggestion(
-        btc2(suggestedNewVaultBtc),
-        btc2(vaults[0].btc),
-      );
-    } else if (!canSplit) {
-      suggestion = cliff.single.noSplitSuggestion;
+      // Variant A — affordable sacrificial add; the CTA carries the action.
+      suggestion = cliff.addSacrificialSuggestion(btc2(suggestedNewVaultBtc));
     } else {
-      suggestion = cliff.single.oversizedSuggestion(btc2(raw));
+      // Variant B — re-split the existing vault. seizedFraction depends only on
+      // CF/maxLB/THF, so re-splitting the same total is valid; size the
+      // sacrificial to cover the seizure first and protect the remainder.
+      const withdrawBtc = vaults[0].btc;
+      const sacrificialBtc = Math.ceil(withdrawBtc * liqFactor * 100) / 100;
+      const protectedBtc =
+        Math.round((withdrawBtc - sacrificialBtc) * 100) / 100;
+      if (canSplit && protectedBtc > 0) {
+        suggestion = cliff.withdrawResplitSuggestion(
+          btc2(withdrawBtc),
+          btc2(sacrificialBtc),
+          btc2(protectedBtc),
+        );
+      } else {
+        // Splitting disallowed or the re-split degenerates — fall back.
+        suggestion = cliff.noSplitSuggestion;
+      }
     }
 
     warnings.push({
       type: "cliff",
-      title: cliff.single.title,
-      detail: cliff.single.detail,
+      title: cliff.title,
+      detail: cliff.body,
       suggestion,
     });
   }
 
-  // CASE 2: Exactly two vaults.
+  // CASE 2: Exactly two vaults — shared shell, keep the structural suggestion.
   else if (nVaults === 2) {
     if (isCliff && group1ReorderWouldHelp && optimalVaultOrder) {
       // Cliff that swapping the order fixes — surfaced as the reorder
@@ -475,27 +490,32 @@ export function calculate(params: CalculatorParams): CalculatorResult {
       }
       warnings.push({
         type: "cliff",
-        title: cliff.twoVault.title,
-        detail: cliff.twoVault.detail(btc2(targetSeizureBtc)),
-        suggestion: cliff.twoVault.suggestion(enablePartialStr),
+        title: cliff.title,
+        detail: cliff.body,
+        suggestion: cliff.twoVault.suggestion(
+          btc2(targetSeizureBtc),
+          enablePartialStr,
+        ),
       });
     } else if (reorderWouldHelp) {
       warnings.push(reorderWarning);
     }
   }
 
-  // CASE 3+: three or more vaults.
+  // CASE 3+: three or more vaults — shared shell, keep the structural suggestion.
   else if (nVaults >= 3) {
     if (isCliff) {
       const cliffReorderFix =
         group1ReorderWouldHelp && optimalVaultOrder !== null;
       warnings.push({
         type: "cliff",
-        title: cliff.multiVault.title,
-        detail: cliff.multiVault.detail(nVaults, cliffReorderFix),
-        ...(cliffReorderFix
-          ? { suggestion: cliff.multiVault.suggestion(globalOptimalOrderStr) }
-          : {}),
+        title: cliff.title,
+        detail: cliff.body,
+        suggestion: cliff.multiVault.suggestion(
+          nVaults,
+          cliffReorderFix,
+          globalOptimalOrderStr,
+        ),
       });
     } else if (reorderWouldHelp) {
       warnings.push(reorderWarning);

--- a/services/vault/src/applications/aave/positionNotifications/calculate.ts
+++ b/services/vault/src/applications/aave/positionNotifications/calculate.ts
@@ -444,7 +444,11 @@ export function calculate(params: CalculatorParams): CalculatorResult {
       // Variant B — re-split the existing vault. seizedFraction depends only on
       // CF/maxLB/THF, so re-splitting the same total is valid; size the
       // sacrificial to cover the seizure first and protect the remainder.
-      const withdrawBtc = vaults[0].btc;
+      // Snap the withdraw to cents first so the three displayed amounts
+      // reconcile exactly: sacrificial (ceil) + protected (remainder) ===
+      // withdraw. Deriving the parts from a full-precision withdraw lets the
+      // cent-rounded parts sum to more than the (also-rounded) withdraw.
+      const withdrawBtc = Math.round(vaults[0].btc * 100) / 100;
       const sacrificialBtc = Math.ceil(withdrawBtc * liqFactor * 100) / 100;
       const protectedBtc =
         Math.round((withdrawBtc - sacrificialBtc) * 100) / 100;

--- a/services/vault/src/components/simple/PositionNotificationBanner/BannerActions.tsx
+++ b/services/vault/src/components/simple/PositionNotificationBanner/BannerActions.tsx
@@ -20,9 +20,12 @@ interface BuildBannerActionsArgs {
  * `Notification` `actions` slot:
  * - urgent: "Add Collateral" (primary, filled) + "Repay Debt" (secondary,
  *   outlined) — the core safety actions, matching the Figma callout.
- * - cliff / rebalance with an actionable suggested vault size: "Add a X BTC
- *   vault" — opens the deposit flow with that amount pre-filled (a single,
- *   non-split supplemental deposit).
+ * - cliff with an affordable sacrificial size: "Add sacrificial vault" (generic
+ *   label per Figma; the amount lives in the suggestion text) — opens the
+ *   deposit flow with that amount pre-filled.
+ * - rebalance with an actionable suggested vault size: "Add a X BTC vault" —
+ *   opens the deposit flow with that amount pre-filled (a single, non-split
+ *   supplemental deposit).
  * - optimal reorder available: "Apply Optimal Order" — filled (primary) on the
  *   standalone reorder card, secondary when it accompanies the urgent callout.
  *
@@ -62,17 +65,22 @@ export function buildBannerActions({
   // calculator produced an actionable size — i.e. "add a sacrificial vault of
   // this exact size". When an urgent warning is primary it rides along as a
   // secondary action so the safety actions lead, but it is no longer dropped
-  // (the cliff's own suggestion text describes exactly this action). The
+  // (the warning's own suggestion text describes exactly this action). The
   // calculator guarantees the amount is positive and no larger than the position.
+  // The cliff path uses the generic "Add sacrificial vault" label (amount in the
+  // suggestion text per Figma); rebalance keeps the amount on the button.
   const hasCliffOrRebalanceWarning = result.warnings.some(
     (w) => w.type === "cliff" || w.type === "rebalance",
   );
+  const isCliffSacrificial = result.suggestedNewVaultBtc !== null;
   const suggestedVaultBtc =
     result.suggestedNewVaultBtc ?? result.suggestedRebalanceVaultBtc;
   if (hasCliffOrRebalanceWarning && suggestedVaultBtc !== null) {
     const amountBtc = suggestedVaultBtc.toFixed(2);
     actions.push({
-      label: COPY.banner.addVault(amountBtc),
+      label: isCliffSacrificial
+        ? COPY.banner.addSacrificialVault
+        : COPY.banner.addVault(amountBtc),
       onClick: () => onDeposit(amountBtc),
       emphasis: isUrgent ? "secondary" : "primary",
     });

--- a/services/vault/src/components/simple/PositionNotificationBanner/PositionNotificationBanner.tsx
+++ b/services/vault/src/components/simple/PositionNotificationBanner/PositionNotificationBanner.tsx
@@ -1,4 +1,5 @@
 import {
+  InfoIcon,
   Notification,
   type NotificationVariant,
 } from "@babylonlabs-io/core-ui";
@@ -28,9 +29,11 @@ import {
   GREEN_BANNER_DETAIL,
   GREEN_BANNER_TITLE,
   STALE_PRICE_BANNER_DETAIL,
+  STALE_PRICE_BANNER_GRACE_MS,
   STALE_PRICE_BANNER_TITLE,
 } from "./constants";
 import { OptimalOrderChips } from "./OptimalOrderChips";
+import { useSustainedFlag } from "./useSustainedFlag";
 
 const TEST_ID = "position-notification-banner";
 
@@ -112,18 +115,32 @@ export function PositionNotificationBanner({
 
   const effectiveStatus = statusOverride ?? status;
 
-  // Stale-price: warning notification regardless of result.
+  // The live feed already auto-refetches (faster while unhealthy); "stale" means
+  // the on-chain oracle's own timestamp is old, which a refetch can't fix. Defer
+  // the banner past a grace window so a transient blip doesn't flash it. A debug
+  // override (statusOverride) shows immediately for testing.
+  const isLiveStalePrice =
+    statusOverride === undefined && status === "stale-price";
+  const staleBannerReady = useSustainedFlag(
+    isLiveStalePrice,
+    STALE_PRICE_BANNER_GRACE_MS,
+  );
+
   if (effectiveStatus === "stale-price") {
-    return (
-      <Notification
-        variant="warning"
-        title={STALE_PRICE_BANNER_TITLE}
-        data-testid={TEST_ID}
-        data-severity="yellow"
-      >
-        {STALE_PRICE_BANNER_DETAIL}
-      </Notification>
-    );
+    if (statusOverride === "stale-price" || staleBannerReady) {
+      return (
+        <Notification
+          variant="warning"
+          title={STALE_PRICE_BANNER_TITLE}
+          data-testid={TEST_ID}
+          data-severity="yellow"
+        >
+          {STALE_PRICE_BANNER_DETAIL}
+        </Notification>
+      );
+    }
+    // Within the grace window: render nothing (no stale price is ever used).
+    return null;
   }
 
   // When no override, respect loading states
@@ -161,6 +178,14 @@ export function PositionNotificationBanner({
     ? "suggestion"
     : SEVERITY_VARIANT[bannerState.severity];
 
+  // The cliff ("First liquidation takes everything") renders as a vertical card
+  // per Figma: no title icon-chip, the CTA stacked below, and its suggestion box
+  // styled by feasibility — an info-icon row when an affordable sacrificial add
+  // exists (#1948), otherwise a "SUGGESTION"-labelled block (#1949 / multi-vault).
+  const isCliffPrimary = primaryWarning?.type === "cliff";
+  const cliffHasAffordableAdd =
+    isCliffPrimary && result.suggestedNewVaultBtc !== null;
+
   // Primary content: green standalone copy / risk warning / standalone reorder.
   let title: string;
   let detail: string;
@@ -197,12 +222,41 @@ export function PositionNotificationBanner({
       primaryWarning && primaryWarning.type !== "urgent"
         ? primaryWarning.suggestion
         : undefined;
-    if (primarySuggestion || secondaryWarnings.length > 0) {
+
+    let primarySuggestionNode: ReactNode = null;
+    if (primarySuggestion) {
+      if (cliffHasAffordableAdd) {
+        // #1948 — affordable add: info-icon row, no label (Figma CLIFF A).
+        primarySuggestionNode = (
+          <div className="flex items-start gap-3">
+            <InfoIcon
+              size={16}
+              className="mt-0.5 shrink-0 text-accent-primary"
+            />
+            <div className="text-sm">{primarySuggestion}</div>
+          </div>
+        );
+      } else if (isCliffPrimary) {
+        // #1949 / multi-vault — no CTA: "SUGGESTION" label, no icon (Figma CLIFF B).
+        primarySuggestionNode = (
+          <div className="flex flex-col gap-1">
+            <div className="tracking-wider text-xs font-medium uppercase text-accent-secondary">
+              {COPY.liquidationWarnings.cliff.suggestionLabel}
+            </div>
+            <div className="text-sm">{primarySuggestion}</div>
+          </div>
+        );
+      } else {
+        primarySuggestionNode = (
+          <div className="text-sm opacity-80">{primarySuggestion}</div>
+        );
+      }
+    }
+
+    if (primarySuggestionNode || secondaryWarnings.length > 0) {
       suggestion = (
         <div className="flex flex-col gap-2">
-          {primarySuggestion && (
-            <div className="text-sm opacity-80">{primarySuggestion}</div>
-          )}
+          {primarySuggestionNode}
           {secondaryWarnings.map((warning, index) => (
             <div key={index}>
               <div className="text-sm font-semibold text-accent-primary">
@@ -226,9 +280,11 @@ export function PositionNotificationBanner({
       <Notification
         variant={variant}
         title={title}
-        icon={isStandaloneReorder ? null : undefined}
+        icon={isStandaloneReorder || isCliffPrimary ? null : undefined}
         actions={actions.length > 0 ? actions : undefined}
-        actionsPlacement={isStandaloneReorder ? "below" : "inline"}
+        actionsPlacement={
+          isStandaloneReorder || isCliffPrimary ? "below" : "inline"
+        }
         suggestion={suggestion}
         onClose={isWeirdParamsAdvisory ? handleDismissWeirdParams : undefined}
         data-testid={TEST_ID}

--- a/services/vault/src/components/simple/PositionNotificationBanner/__tests__/PositionNotificationBanner.test.tsx
+++ b/services/vault/src/components/simple/PositionNotificationBanner/__tests__/PositionNotificationBanner.test.tsx
@@ -1,10 +1,12 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { PositionNotificationsStatus } from "@/applications/aave/hooks/usePositionNotifications";
 import type { CalculatorResult } from "@/applications/aave/positionNotifications";
 
+import { STALE_PRICE_BANNER_GRACE_MS } from "../constants";
 import { PositionNotificationBanner } from "../PositionNotificationBanner";
 
 // ---------------------------------------------------------------------------
@@ -37,6 +39,7 @@ vi.mock("@/clients/eth-contract/client", () => ({
 // the suggestion sub-box, and the action pills (label + onClick + disabled),
 // and surface variant/severity as data-attributes.
 vi.mock("@babylonlabs-io/core-ui", () => ({
+  InfoIcon: () => <span data-testid="suggestion-info-icon" />,
   Notification: (props: Record<string, unknown>) => {
     const actions = (props.actions ?? []) as Array<{
       label: ReactNode;
@@ -109,7 +112,7 @@ const mockReorderVerificationContext = {
 
 const mockUsePositionNotifications = vi.fn(() => ({
   result: null,
-  status: "ready" as const,
+  status: "ready" as PositionNotificationsStatus,
   isLoading: false,
   reorderVerificationContext: mockReorderVerificationContext as
     | typeof mockReorderVerificationContext
@@ -207,6 +210,14 @@ describe("PositionNotificationBanner", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // Reset the live status to "ready" so a per-test override (e.g. stale-price)
+    // doesn't leak into other tests.
+    mockUsePositionNotifications.mockReturnValue({
+      result: null,
+      status: "ready",
+      isLoading: false,
+      reorderVerificationContext: mockReorderVerificationContext,
+    });
   });
 
   it("renders nothing when result is null", () => {
@@ -438,6 +449,39 @@ describe("PositionNotificationBanner", () => {
     expect(screen.queryByText("Apply Optimal Order")).toBeNull();
   });
 
+  it("defers the live stale-price banner until the grace window elapses", () => {
+    vi.useFakeTimers();
+    // Live feed (no debug override) reports stale price.
+    mockUsePositionNotifications.mockReturnValue({
+      result: null,
+      status: "stale-price",
+      isLoading: false,
+      reorderVerificationContext: null,
+    });
+
+    render(
+      <Wrapper>
+        <PositionNotificationBanner onDeposit={onDeposit} onRepay={onRepay} />
+      </Wrapper>,
+    );
+
+    // Within the grace window: nothing shown (no banner, no stale price used).
+    expect(
+      screen.queryByText("Position notifications temporarily unavailable"),
+    ).toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(STALE_PRICE_BANNER_GRACE_MS);
+    });
+
+    // Condition persisted past the window → banner surfaces.
+    expect(
+      screen.getByText("Position notifications temporarily unavailable"),
+    ).toBeTruthy();
+
+    vi.useRealTimers();
+  });
+
   it("renders nothing for dust (hidden severity)", () => {
     const result = makeBaseResult({
       warnings: [
@@ -455,14 +499,16 @@ describe("PositionNotificationBanner", () => {
     ).toBeNull();
   });
 
-  it("renders an Add-a-vault CTA for a single-vault cliff and pre-fills the amount", () => {
+  it("renders an orange cliff with the generic 'Add sacrificial vault' CTA and pre-fills the amount", () => {
     const result = makeBaseResult({
       warnings: [
         {
           type: "cliff",
-          title: "No backup vault",
-          detail: "Your vault will be fully seized at liquidation.",
-          suggestion: "Add a 0.72 BTC sacrificial vault at position 1.",
+          title: "First liquidation takes everything",
+          detail:
+            "With your current vaults, a single liquidation event seizes all your BTC — nothing remains protected behind it.",
+          suggestion:
+            "Adding a 0.72 BTC sacrificial vault creates a buffer — it gets liquidated first, your existing BTC survives.",
         },
       ],
       suggestedNewVaultBtc: 0.72,
@@ -470,12 +516,42 @@ describe("PositionNotificationBanner", () => {
     renderBanner(result, onDeposit, onRepay);
 
     const banner = screen.getByTestId("position-notification-banner");
-    expect(banner.dataset.severity).toBe("soft");
-    fireEvent.click(screen.getByText("Add a 0.72 BTC vault"));
+    expect(banner.dataset.severity).toBe("yellow");
+    expect(banner.dataset.variant).toBe("warning");
+    // Affordable cliff (CLIFF A): info-icon suggestion box, no "Suggestion" label.
+    expect(screen.getByTestId("suggestion-info-icon")).toBeTruthy();
+    expect(screen.queryByText("Suggestion")).toBeNull();
+    // Generic label per Figma; the amount lives in the suggestion text.
+    fireEvent.click(screen.getByText("Add sacrificial vault"));
     expect(onDeposit).toHaveBeenCalledWith("0.72");
   });
 
-  it("keeps the Add-a-vault CTA (secondary) when a single-vault cliff is also urgent", () => {
+  it("renders an unaffordable cliff (CLIFF B) with a SUGGESTION label and no CTA", () => {
+    const result = makeBaseResult({
+      warnings: [
+        {
+          type: "cliff",
+          title: "First liquidation takes everything",
+          detail:
+            "With your current vaults, a single liquidation event seizes all your BTC — nothing remains protected behind it.",
+          suggestion:
+            "To enable partial liquidation, withdraw your 2.00 BTC and re-deposit as two smaller vaults: 1.28 BTC sacrificial + 0.72 BTC protected. Alternatively: add collateral or repay debt to manage the liquidation.",
+        },
+      ],
+      // No affordable add → no CTA, "SUGGESTION"-labelled box.
+      suggestedNewVaultBtc: null,
+    });
+    renderBanner(result, onDeposit, onRepay);
+
+    const banner = screen.getByTestId("position-notification-banner");
+    expect(banner.dataset.severity).toBe("yellow");
+    expect(banner.dataset.variant).toBe("warning");
+    expect(screen.getByText("Suggestion")).toBeTruthy();
+    expect(screen.queryByTestId("suggestion-info-icon")).toBeNull();
+    expect(screen.queryByText("Add sacrificial vault")).toBeNull();
+  });
+
+  it("keeps the sacrificial CTA (secondary) when a single-vault cliff is also urgent", () => {
     const result = makeBaseResult({
       warnings: [
         {
@@ -485,9 +561,11 @@ describe("PositionNotificationBanner", () => {
         },
         {
           type: "cliff",
-          title: "No backup vault",
-          detail: "Your vault will be fully seized at liquidation.",
-          suggestion: "Add a 0.72 BTC sacrificial vault at position 1.",
+          title: "First liquidation takes everything",
+          detail:
+            "With your current vaults, a single liquidation event seizes all your BTC — nothing remains protected behind it.",
+          suggestion:
+            "Adding a 0.72 BTC sacrificial vault creates a buffer — it gets liquidated first, your existing BTC survives.",
         },
       ],
       suggestedNewVaultBtc: 0.72,
@@ -499,7 +577,7 @@ describe("PositionNotificationBanner", () => {
     // Safety actions still lead, and the pre-filled cliff CTA is still offered.
     expect(screen.getByText("Add Collateral")).toBeTruthy();
     expect(screen.getByText("Repay Debt")).toBeTruthy();
-    fireEvent.click(screen.getByText("Add a 0.72 BTC vault"));
+    fireEvent.click(screen.getByText("Add sacrificial vault"));
     expect(onDeposit).toHaveBeenCalledWith("0.72");
   });
 

--- a/services/vault/src/components/simple/PositionNotificationBanner/__tests__/useSustainedFlag.test.tsx
+++ b/services/vault/src/components/simple/PositionNotificationBanner/__tests__/useSustainedFlag.test.tsx
@@ -1,0 +1,67 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useSustainedFlag } from "../useSustainedFlag";
+
+const DELAY = 60_000;
+
+describe("useSustainedFlag", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("stays false until the active condition has persisted for the delay", () => {
+    const { result } = renderHook(() => useSustainedFlag(true, DELAY));
+    expect(result.current).toBe(false);
+
+    act(() => {
+      vi.advanceTimersByTime(DELAY - 1);
+    });
+    expect(result.current).toBe(false);
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it("is always false while inactive", () => {
+    const { result } = renderHook(() => useSustainedFlag(false, DELAY));
+    act(() => {
+      vi.advanceTimersByTime(DELAY * 2);
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it("resets the timer when the condition clears before the delay", () => {
+    const { result, rerender } = renderHook(
+      ({ active }) => useSustainedFlag(active, DELAY),
+      { initialProps: { active: true } },
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(DELAY - 5_000);
+    });
+    expect(result.current).toBe(false);
+
+    // Condition clears (e.g. a transient blip recovered) — timer resets.
+    rerender({ active: false });
+    expect(result.current).toBe(false);
+
+    // Becomes active again: the full delay must elapse afresh.
+    rerender({ active: true });
+    act(() => {
+      vi.advanceTimersByTime(DELAY - 1);
+    });
+    expect(result.current).toBe(false);
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(result.current).toBe(true);
+  });
+});

--- a/services/vault/src/components/simple/PositionNotificationBanner/constants.ts
+++ b/services/vault/src/components/simple/PositionNotificationBanner/constants.ts
@@ -6,3 +6,12 @@ export const STALE_PRICE_BANNER_TITLE =
   "Position notifications temporarily unavailable";
 export const STALE_PRICE_BANNER_DETAIL =
   "BTC price data is stale or unavailable. Notifications will resume when fresh price data is available.";
+
+/**
+ * Grace window before the live stale-price banner appears. The price query
+ * polls faster while unhealthy, so a transient blip clears well within this
+ * window and never surfaces the banner; a genuinely stale on-chain feed
+ * surfaces it after the delay. Notifications stay hidden meanwhile — no stale
+ * price is ever fed into the calculation.
+ */
+export const STALE_PRICE_BANNER_GRACE_MS = 60 * 1000;

--- a/services/vault/src/components/simple/PositionNotificationBanner/useSustainedFlag.ts
+++ b/services/vault/src/components/simple/PositionNotificationBanner/useSustainedFlag.ts
@@ -1,0 +1,38 @@
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * Returns `true` only once `active` has stayed `true` continuously for
+ * `delayMs`. Any flip back to `false` resets the timer.
+ *
+ * Used to defer the stale-price banner: a transient blip (a single failed RPC
+ * read, or the brief gap before a faster poll lands) clears within the window
+ * and never surfaces the banner, while a genuinely stale on-chain feed surfaces
+ * it after the delay.
+ */
+export function useSustainedFlag(active: boolean, delayMs: number): boolean {
+  const [reached, setReached] = useState(false);
+  const activeSinceRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!active) {
+      activeSinceRef.current = null;
+      setReached(false);
+      return;
+    }
+
+    if (activeSinceRef.current === null) {
+      activeSinceRef.current = Date.now();
+    }
+
+    const remaining = delayMs - (Date.now() - activeSinceRef.current);
+    if (remaining <= 0) {
+      setReached(true);
+      return;
+    }
+
+    const timer = setTimeout(() => setReached(true), remaining);
+    return () => clearTimeout(timer);
+  }, [active, delayMs]);
+
+  return active && reached;
+}

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -1026,6 +1026,7 @@ export const COPY = {
     repayDebt: "Repay Debt",
     applyOptimalOrder: "Apply Optimal Order",
     addVault: (amountBtc: string) => `Add a ${amountBtc} BTC vault`,
+    addSacrificialVault: "Add sacrificial vault",
   },
   geoBlock: {
     title: "Service unavailable in your region",
@@ -1119,37 +1120,48 @@ export const COPY = {
       vaultChip: (name: string, amount: string) => `${name} · ${amount}`,
     },
     // Cliff: all vaults consolidate into one liquidation group, so partial
-    // liquidation is no longer possible. Variant by vault count.
+    // liquidation is no longer possible. One Figma title/body across every case
+    // (CLIFF A 6502-110902 / CLIFF B 7064-77201); only the suggestion varies by
+    // what action is feasible.
     cliff: {
-      single: {
-        title: "No backup vault",
-        detail:
-          "Your vault will be fully seized at liquidation — nothing is protected behind it.",
-        actionableSuggestion: (suggestedBtc: string, vaultBtc: string) =>
-          `Add a ${suggestedBtc} BTC sacrificial vault at position 1 — your current vault (${vaultBtc} BTC) becomes protected.`,
-        noSplitSuggestion:
-          "Current protocol parameters do not allow vault splitting as a protection strategy. Add collateral or repay part of the debt to keep this position safe.",
-        oversizedSuggestion: (rawBtc: string) =>
-          `To enable partial liquidation, add ≥ ${rawBtc} BTC as a sacrificial vault. You can also add collateral or repay part of the debt to keep this position safe. Alternatively: repay the loan, split BTC into optimal UTXOs, and re-open with a sacrificial vault.`,
-      },
+      title: "First liquidation takes everything",
+      body: "With your current vaults, a single liquidation event seizes all your BTC — nothing remains protected behind it.",
+      // Header shown above the suggestion text when there is no actionable CTA
+      // (the withdraw/re-deposit and multi-vault cases). Rendered uppercase.
+      suggestionLabel: "Suggestion",
+      // Variant A (#1948): an affordable sacrificial vault buffers the existing
+      // position. The amount lives here; the CTA label stays generic.
+      addSacrificialSuggestion: (sacrificialBtc: string) =>
+        `Adding a ${sacrificialBtc} BTC sacrificial vault creates a buffer — it gets liquidated first, your existing BTC survives.`,
+      // Variant B (#1949): the single vault is too large to buffer cheaply —
+      // withdraw it and re-deposit as two smaller vaults instead.
+      withdrawResplitSuggestion: (
+        withdrawBtc: string,
+        sacrificialBtc: string,
+        protectedBtc: string,
+      ) =>
+        `To enable partial liquidation, withdraw your ${withdrawBtc} BTC and re-deposit as two smaller vaults: ${sacrificialBtc} BTC sacrificial + ${protectedBtc} BTC protected. Alternatively: add collateral or repay debt to manage the liquidation.`,
+      // Protocol params disallow splitting entirely — no re-split is possible.
+      noSplitSuggestion:
+        "Current protocol parameters do not allow vault splitting as a protection strategy. Add collateral or repay part of the debt to keep this position safe.",
+      // 2-vault / 3+ cliffs share the title/body/severity but keep their
+      // structural suggestion, since "re-deposit as two smaller vaults" doesn't
+      // apply when you already hold multiple vaults.
       twoVault: {
-        title: "Both vaults seized together — no partial protection",
-        detail: (targetSeizureBtc: string) =>
-          `Neither vault alone covers the target seizure (${targetSeizureBtc} BTC). Both will be liquidated in one event.`,
         enablePartial: (deficitBtc: string, largestName: string) =>
           `To enable partial liquidation, add ≥ ${deficitBtc} BTC alongside ${largestName}. `,
-        suggestion: (enablePartialStr: string) =>
-          `${enablePartialStr}You can also add collateral or repay part of the debt to keep this position safe. Alternatively: repay the loan, split BTC into optimal UTXOs, and re-open with a sacrificial vault.`,
+        suggestion: (targetSeizureBtc: string, enablePartialStr: string) =>
+          `Neither vault alone covers the target seizure (${targetSeizureBtc} BTC). ${enablePartialStr}You can also add collateral or repay part of the debt to keep this position safe. Alternatively: repay the loan, split BTC into optimal UTXOs, and re-open with a sacrificial vault.`,
       },
       multiVault: {
-        title: "All vaults seized in one liquidation event",
-        detail: (nVaults: number, hasReorderFix: boolean) =>
-          `All ${nVaults} vaults land in Group 1 — no protected vaults remain after first liquidation. ${
-            hasReorderFix
-              ? "Reordering vaults will fix this."
-              : "No combination of vaults covers the target seizure alone."
-          }`,
-        suggestion: (orderStr: string) => `Suggested order: ${orderStr}`,
+        suggestion: (
+          nVaults: number,
+          hasReorderFix: boolean,
+          orderStr: string,
+        ) =>
+          hasReorderFix
+            ? `All ${nVaults} vaults land in the first liquidation group. Reordering vaults will fix this — suggested order: ${orderStr}.`
+            : `All ${nVaults} vaults land in the first liquidation group, and no combination of vaults covers the target seizure alone. Add collateral or repay part of the debt to keep this position safe.`,
       },
     },
     // Rebalance: the first group over-seizes because vault sizes aren't optimal;

--- a/services/vault/src/hooks/__tests__/priceHealth.test.ts
+++ b/services/vault/src/hooks/__tests__/priceHealth.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import type { PriceMetadata } from "@/clients/eth-contract/chainlink";
+
+import { hasUnhealthyPrice } from "../priceHealth";
+
+const fresh: PriceMetadata = {
+  isStale: false,
+  ageSeconds: 30,
+  fetchFailed: false,
+};
+const stale: PriceMetadata = {
+  isStale: true,
+  ageSeconds: 7200,
+  fetchFailed: false,
+};
+const failed: PriceMetadata = {
+  isStale: false,
+  ageSeconds: 0,
+  fetchFailed: true,
+};
+
+describe("hasUnhealthyPrice", () => {
+  it("is false when metadata is undefined (not yet loaded)", () => {
+    expect(hasUnhealthyPrice(undefined)).toBe(false);
+  });
+
+  it("is false when every price is fresh", () => {
+    expect(hasUnhealthyPrice({ BTC: fresh, ETH: fresh })).toBe(false);
+  });
+
+  it("is true when any price is stale", () => {
+    expect(hasUnhealthyPrice({ BTC: stale, ETH: fresh })).toBe(true);
+  });
+
+  it("is true when any price fetch failed", () => {
+    expect(hasUnhealthyPrice({ BTC: fresh, ETH: failed })).toBe(true);
+  });
+});

--- a/services/vault/src/hooks/priceHealth.ts
+++ b/services/vault/src/hooks/priceHealth.ts
@@ -1,0 +1,14 @@
+import type { PriceMetadata } from "@/clients/eth-contract/chainlink";
+
+/**
+ * True when any token's price is stale or its last fetch failed. Drives the
+ * faster price-refetch cadence while unhealthy. Kept dependency-free (only the
+ * erased `PriceMetadata` type) so it can be unit-tested without loading the
+ * chainlink client.
+ */
+export function hasUnhealthyPrice(
+  metadata: Record<string, PriceMetadata> | undefined,
+): boolean {
+  if (!metadata) return false;
+  return Object.values(metadata).some((m) => m.isStale || m.fetchFailed);
+}

--- a/services/vault/src/hooks/usePrices.ts
+++ b/services/vault/src/hooks/usePrices.ts
@@ -13,8 +13,20 @@ import {
   type PriceMetadata,
 } from "@/clients/eth-contract/chainlink";
 
+import { hasUnhealthyPrice } from "./priceHealth";
+
 const PRICES_QUERY_KEY = "prices";
 const ONE_MINUTE = 60 * 1000;
+/** Poll cadence while every price is fresh. */
+const HEALTHY_REFETCH_INTERVAL = ONE_MINUTE;
+/**
+ * Faster cadence while any price is stale or its fetch failed, so a recovered
+ * feed (or a recovered RPC) is picked up within seconds instead of up to a
+ * minute. Staleness is the on-chain oracle's own `updatedAt` age, so polling
+ * faster cannot force a stale feed fresh — it only shortens the lag once the
+ * feed (or the RPC) actually recovers.
+ */
+const UNHEALTHY_REFETCH_INTERVAL = 15 * 1000;
 
 const SUPPORTED_TOKENS = ["BTC", "ETH", "USDC", "USDT", "DAI"];
 
@@ -45,7 +57,14 @@ export function usePrices(): UsePricesResult {
     queryKey: [PRICES_QUERY_KEY, "chainlink"],
     queryFn: () => getTokenPrices(SUPPORTED_TOKENS),
     staleTime: ONE_MINUTE,
-    refetchInterval: ONE_MINUTE,
+    // Poll faster while unhealthy so a recovered feed/RPC clears sooner, and
+    // re-check on tab focus / network reconnect.
+    refetchInterval: (query) =>
+      hasUnhealthyPrice(query.state.data?.metadata)
+        ? UNHEALTHY_REFETCH_INTERVAL
+        : HEALTHY_REFETCH_INTERVAL,
+    refetchOnWindowFocus: true,
+    refetchOnReconnect: true,
     retry: 2,
   });
 


### PR DESCRIPTION
# Cliff liquidation notification (Figma alignment) + stale-price banner UX

<img width="2032" height="1162" alt="Screenshot_2026-06-26_18-03-41" src="https://github.com/user-attachments/assets/c1a5afc3-cfa7-42c0-b992-b4585a2d1515" />

<img width="2032" height="1162" alt="Screenshot_2026-06-26_18-03-54" src="https://github.com/user-attachments/assets/d04b8179-3586-4798-8467-efa0700bf0ea" />

<img width="2032" height="1162" alt="Screenshot_2026-06-26_18-05-23" src="https://github.com/user-attachments/assets/c20e4b1a-4916-4c37-ac0e-efe421f97879" />

<img width="2032" height="1162" alt="Screenshot_2026-06-26_18-05-39" src="https://github.com/user-attachments/assets/102b6f11-355b-406a-9bb5-7ff91752ed8a" />

## Summary

This PR does two related things on the dashboard's position-notifications surface. First, it makes the "first liquidation takes everything" (cliff) notification match the Figma design — the wording, the orange severity, the two variants, and the card layout. Second, it stops the "Position notifications temporarily unavailable" (stale BTC price) banner from flashing for brief hiccups, and makes it recover faster. The notification math itself was already shipped earlier in https://github.com/babylonlabs-io/babylon-toolkit/pull/1970 using developer placeholder copy; this PR is the design alignment plus a UX fix.

---

## Part 1 — Cliff notification matches Figma

### What it looked like before

The cliff notification was working but used the reference repo's developer wording ("No backup vault" / "Both vaults seized together…"), rendered grey/soft, split its message by how many vaults you had (1 / 2 / 3+), and laid the action button out to the right of the text.

### What it looks like now

One title and body for every cliff case — "First liquidation takes everything" — rendered in the orange warning style. The message is now split by what you can actually do about it, which is what the two Figma frames show: if adding a small "sacrificial" vault is affordable, you get that suggestion plus an "Add sacrificial vault" button; if it isn't (your one vault is too big), you instead get guidance to withdraw and re-deposit as two smaller vaults, with the three amounts spelled out (withdraw / sacrificial / protected). The card is also laid out top-to-bottom per Figma: no icon chip next to the title, the button stacked below the box, an info "i" icon inside the affordable suggestion box, and a "SUGGESTION" label inside the unaffordable one.

### Approaches considered, and why we chose this one

- **Split the message by vault count (what existed) vs. by what the user can do (chosen).** Figma only draws two cliff frames, and they differ by the available action, not by a vault count. We re-mapped the existing logic onto those two action-based variants so the UI matches the design and reads as advice, not as an internal classification.
- **Ship [#1949](https://github.com/babylonlabs-io/babylon-toolkit/issues/1949) alone vs. ship [#1948](https://github.com/babylonlabs-io/babylon-toolkit/issues/1948) and [#1949](https://github.com/babylonlabs-io/babylon-toolkit/issues/1949) together (chosen).** They are two render variants of the same warning — same title, same body, same severity, emitted from the same place in the code. Doing them separately would mean editing the exact same lines twice, so they ship as one change.
- **Put the amount on the button vs. in the suggestion text (chosen).** Figma uses a plain "Add sacrificial vault" button with the amount in the sentence above it. We matched Figma; the button still pre-fills the deposit with the computed amount when clicked.
- **Change the shared component vs. keep it app-side (chosen).** The new layout (button below, no title icon, an icon/label inside the suggestion box) is all achievable with options the shared Notification component already exposes, plus passing our own content into the suggestion box. So we changed nothing in the shared component — which means zero risk to every other notification that uses it.
- **Multi-vault cliffs (2 and 3+ vaults).** Figma only specifies the single-vault story. For genuine multi-vault cliffs we apply the shared shell (same orange title and body) but keep their existing, accurate guidance text, because "withdraw and re-deposit as two smaller vaults" is wrong when you already hold several vaults.

Closes https://github.com/babylonlabs-io/babylon-toolkit/issues/1948
Closes https://github.com/babylonlabs-io/babylon-toolkit/issues/1949

---

## Part 2 — Stale-price banner no longer flashes, and recovers faster

### The problem

Sometimes the dashboard shows "Position notifications temporarily unavailable — BTC price data is stale or unavailable," and refreshing the page doesn't help. The reason is that "stale" is decided by the on-chain Chainlink oracle's own last-updated timestamp (older than 1 hour), not by our cache being old. We already auto-refetch the price every 60 seconds, but re-reading a stale feed — or reloading the page — returns the same old timestamp, so the banner can't be refreshed away. It's mostly a devnet/testnet artifact, because that price feed updates infrequently; on mainnet BTC updates every few minutes.

### What we changed

- **Don't flash the banner for brief blips.** The live banner now only appears after the stale/failed condition has persisted for a grace window (60 seconds). A one-off failed read, or the short gap before a fresh poll lands, clears within that window and never shows the banner. During the grace window we show nothing — and importantly, we never feed a stale price into the liquidation math.
- **Recover faster.** While the price is stale or failing, we poll every 15 seconds instead of 60, and we also re-check when you switch back to the tab or your network reconnects. So once the feed (or the connection) recovers, the banner clears in seconds instead of up to a minute.

### Approaches considered, and why we chose this one

- **"Just refetch harder" — rejected as a fix on its own.** We already poll automatically; the staleness is on the oracle's side, so no amount of refetching makes a genuinely stale feed fresh. We kept faster polling only as a way to recover sooner once the feed actually updates.
- **Loosen the 1-hour staleness threshold — deliberately not done.** Using an older price in the liquidation calculation is exactly what that guard prevents, so we left it untouched. This change only affects when the UI banner appears, never whether stale data is used.
- **Show the banner only after N retries (chosen, as a time-based grace window).** This is what the grace window is: ride out transient problems, and only inform the user once the condition is real and sustained.

This part is a UX fix with no tracking issue; it was added on this branch because it touches the same banner.

---

## Testing

- New and updated unit tests: the cliff copy/severity and the two variants, the affordable vs. unaffordable suggestion box (info icon vs. "SUGGESTION" label), the grace-window hook (timer and reset behavior), the price-health helper, and the banner deferring the live stale-price banner until the window elapses.
- Full vault test suite passes (868 tests), typecheck is clean, and lint reports 0 errors.
- Manually verified each cliff variant and the stale-price behavior via the dashboard debug panel.
