### PR TITLE
fix(wallet-connector): loop signPsbt when Utila omits batch signing

### DIFF
--- a/packages/babylon-wallet-connector/src/core/wallets/btc/utila/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/utila/provider.ts
@@ -18,11 +18,11 @@ const UTILA_PROMPT_TIMEOUT_MS = 60_000;
 
 /**
  * Utila is an MPC wallet that injects an `IBTCProvider`-compatible object at
- * `window.utila.bitcoin` (see docs/vault-integration-guide.md — it implements
- * the documented Bitcoin Wallet Interface directly). Unlike the UniSat/OneKey
- * adapters there is no request-shape translation; this adapter forwards each
- * method through and adds the connection guards + deriveContextHash error
- * mapping the dApp expects.
+ * `window.utila.bitcoin`, targeting Babylon's Bitcoin Wallet Interface
+ * (docs/vault-integration-guide.md). Most methods forward straight through with
+ * connection guards + deriveContextHash error mapping. `signPsbts` is the
+ * exception: Utila does not implement batch signing, so the adapter falls back
+ * to looping `signPsbt` (confirmed with the Utila team).
  *
  * Its `deriveContextHash` is MPC-based, not HD/HKDF — cross-wallet portability
  * is not provided, which the spec permits for non-HD wallets (the dApp only
@@ -166,6 +166,16 @@ export class UtilaProvider implements IBTCProvider {
         message: "psbts hexes are required and must be a non-empty array",
         wallet: WALLET_PROVIDER_NAME,
       });
+    }
+
+    // Batch signing is STRONGLY RECOMMENDED, not required. If Utila's injected
+    // provider omits signPsbts, sign each PSBT sequentially via signPsbt.
+    if (typeof this.provider.signPsbts !== "function") {
+      const signedPsbts: string[] = [];
+      for (let i = 0; i < psbtsHexes.length; i++) {
+        signedPsbts.push(await this.signPsbt(psbtsHexes[i], options?.[i]));
+      }
+      return signedPsbts;
     }
 
     try {


### PR DESCRIPTION
## Summary

`UtilaProvider.signPsbts` called `this.provider.signPsbts(...)` on the injected
`window.utila.bitcoin` object without checking the method exists. Utila's MPC
wallet does not implement batch signing yet (their Vault integration is still in
progress on their side), so that call throws `TypeError: signPsbts is not a
function`. The Utila team asked us to fall back to singular `signPsbt`.

This adds a presence guard that loops `signPsbt` when `signPsbts` is absent,
mirroring the existing `deriveContextHash` guard in the same adapter. Batch
signing is "STRONGLY RECOMMENDED, not required" per the integration guide, and
the sequential fallback is already the documented degradation path.

## Why the guard has to live in the adapter

The SDK-layer `signPsbtsWithFallback` already checks `typeof wallet.signPsbts
=== "function"` — but `wallet` there is the `UtilaProvider` instance, which
always defines `signPsbts` as a class method, so that check is always true for
Utila. The only place that can see whether the *underlying* injected provider
supports batch signing is the adapter itself.

## Changes
- Guard `typeof this.provider.signPsbts !== "function"` in
  `UtilaProvider.signPsbts`; loop `this.signPsbt` (keeps per-call connection
  guards + error mapping) with `options?.[i]` aligned to `psbtsHexes[i]`.
- Update the adapter's header comment, which incorrectly claimed Utila forwards
  every method through / fully implements the interface.a