### PR TITLE
feat(vault): surface position too small

### DIFF
--- a/services/vault/src/applications/aave/positionNotifications/__tests__/calculate.test.ts
+++ b/services/vault/src/applications/aave/positionNotifications/__tests__/calculate.test.ts
@@ -234,11 +234,12 @@ describe("bannerSeverity", () => {
     expect(state.primaryWarning?.type).toBe("urgent");
   });
 
-  it("hidden for dust", () => {
+  it("soft (info) for dust — suppresses other warnings", () => {
     const result = calculate(makeParams([v(0.5)], { totalDebtUsd: 500 }));
     const state = deriveBannerState(result);
-    expect(state.severity).toBe("hidden");
+    expect(state.severity).toBe("soft");
     expect(state.primaryWarning?.type).toBe("dust");
+    expect(state.secondaryWarnings).toHaveLength(0);
   });
 
   it("hidden when there are no groups (zero debt)", () => {

--- a/services/vault/src/applications/aave/positionNotifications/bannerSeverity.ts
+++ b/services/vault/src/applications/aave/positionNotifications/bannerSeverity.ts
@@ -2,10 +2,10 @@ import type { CalculatorResult, Warning, WarningType } from "./types";
 
 /**
  * Calculator warnings map to red (urgent), yellow (cliff / too-many-vaults — the
- * orange warning banner per Figma), soft (everything else advisory), green
- * (none), or hidden (dust / no groups). "yellow" also backs the stale-price
- * banner, which is driven separately by a status override rather than a
- * calculator warning.
+ * orange warning banner per Figma), soft (everything else advisory, including the
+ * dismissible dust notice), green (none), or hidden (no groups). "yellow" also
+ * backs the stale-price banner, which is driven separately by a status override
+ * rather than a calculator warning.
  */
 export type BannerSeverity = "red" | "yellow" | "soft" | "green" | "hidden";
 
@@ -35,9 +35,9 @@ export interface BannerState {
 
 /**
  * Primary-warning precedence, highest first. `urgent` is the only red severity;
- * the rest render soft. `dust` is handled before this list (it hides the banner
- * entirely). `weird-params` is emitted exclusively, but kept here so it is still
- * selected if present.
+ * the rest render soft. `dust` is handled before this list — it surfaces as a
+ * soft advisory that suppresses every other warning. `weird-params` is emitted
+ * exclusively, but kept here so it is still selected if present.
  */
 const PRIMARY_ORDER: WarningType[] = [
   "urgent",
@@ -56,17 +56,18 @@ const PRIMARY_ORDER: WarningType[] = [
  * Soft:   any other advisory warning (rebalance / reorder / weird-params), or a
  *         healthy position whose vault order is suboptimal
  * Green:  no warnings and order already optimal
- * Hidden: no groups, or dust position (too small to matter)
+ * Hidden: no groups
  */
 export function deriveBannerState(result: CalculatorResult): BannerState {
   const { warnings, groups } = result;
   const suggestReorder = result.optimalVaultOrder != null;
 
-  // Dust suppresses all other warnings — position is too small to matter.
+  // Dust suppresses all other warnings — a sub-$1k position has no meaningful
+  // multi-event cascade. It still surfaces as a dismissible soft advisory.
   const dustWarning = warnings.find((w) => w.type === "dust");
   if (dustWarning) {
     return {
-      severity: "hidden",
+      severity: "soft",
       primaryWarning: dustWarning,
       secondaryWarnings: [],
       suggestReorder: false,

--- a/services/vault/src/components/simple/DashboardPage.tsx
+++ b/services/vault/src/components/simple/DashboardPage.tsx
@@ -190,16 +190,9 @@ export function DashboardPage() {
       <div className="space-y-10">
         <SupplyCapSection snapshot={capSnapshot} isLoading={isCapLoading} />
 
-        <OverviewSection
-          healthFactor={healthFactor}
-          healthFactorStatus={healthFactorStatus}
-          totalCollateralValue={totalCollateralValue}
-          totalBorrowed={totalBorrowed}
-          liquidationPrice={liquidationPrice}
-          btcPrice={btcPrice}
-          pctToLiquidation={pctToLiquidation}
-        />
-
+        {/* Notifications sit between the supply cap and Overview per Figma
+            (frame 6508-114810). The critical top banner, the max-vaults notice,
+            and the cascade banner share this slot. */}
         {liquidationNotificationsEnabled && (
           <CriticalLiquidationTopBanner result={criticalBannerResult} />
         )}
@@ -219,6 +212,16 @@ export function DashboardPage() {
             statusOverride={debugStatusOverride ?? undefined}
           />
         )}
+
+        <OverviewSection
+          healthFactor={healthFactor}
+          healthFactorStatus={healthFactorStatus}
+          totalCollateralValue={totalCollateralValue}
+          totalBorrowed={totalBorrowed}
+          liquidationPrice={liquidationPrice}
+          btcPrice={btcPrice}
+          pctToLiquidation={pctToLiquidation}
+        />
 
         <PendingDepositSection />
 

--- a/services/vault/src/components/simple/PositionNotificationBanner/PositionNotificationBanner.tsx
+++ b/services/vault/src/components/simple/PositionNotificationBanner/PositionNotificationBanner.tsx
@@ -18,6 +18,7 @@ import {
   deriveBannerState,
   type BannerSeverity,
   type CalculatorResult,
+  type WarningType,
 } from "@/applications/aave/positionNotifications";
 import { COPY } from "@/copy";
 import { invalidateVaultQueries } from "@/utils/queryKeys";
@@ -82,7 +83,9 @@ export function PositionNotificationBanner({
   const { executeReorder, isProcessing: isReordering } = useReorderVaults();
   const { applyReorderedOrder } = useReorderOverride();
   const [isReorderSuccess, setIsReorderSuccess] = useState(false);
-  const [isAdvisoryDismissed, setIsAdvisoryDismissed] = useState(false);
+  const [dismissedAdvisories, setDismissedAdvisories] = useState<
+    Set<WarningType>
+  >(() => new Set());
   const queryClient = useQueryClient();
   const { address } = useAccount();
 
@@ -96,8 +99,8 @@ export function PositionNotificationBanner({
     }
   }, [address, queryClient]);
 
-  const handleDismissAdvisory = useCallback(() => {
-    setIsAdvisoryDismissed(true);
+  const handleDismissAdvisory = useCallback((type: WarningType) => {
+    setDismissedAdvisories((prev) => new Set(prev).add(type));
   }, []);
 
   const handleApplyOrder = useCallback(async () => {
@@ -156,13 +159,21 @@ export function PositionNotificationBanner({
   if (bannerState.severity === "hidden") return null;
 
   // The weird-params and dust advisories are dismissible (informational, no
-  // required action). The standalone reorder suggestion is also `soft` but has a
-  // null primaryWarning, so it is intentionally excluded.
-  const isDismissibleAdvisory =
+  // required action). Dismissal is tracked per warning type so closing one never
+  // hides the other if the position later transitions between them. The
+  // standalone reorder suggestion is also `soft` but has a null primaryWarning,
+  // so it is intentionally excluded.
+  const primaryWarningType = bannerState.primaryWarning?.type;
+  const dismissibleAdvisoryType =
     bannerState.severity === "soft" &&
-    (bannerState.primaryWarning?.type === "weird-params" ||
-      bannerState.primaryWarning?.type === "dust");
-  if (isDismissibleAdvisory && isAdvisoryDismissed) return null;
+    (primaryWarningType === "weird-params" || primaryWarningType === "dust")
+      ? primaryWarningType
+      : null;
+  if (
+    dismissibleAdvisoryType &&
+    dismissedAdvisories.has(dismissibleAdvisoryType)
+  )
+    return null;
 
   const { primaryWarning, secondaryWarnings } = bannerState;
 
@@ -287,7 +298,11 @@ export function PositionNotificationBanner({
           isStandaloneReorder || isCliffPrimary ? "below" : "inline"
         }
         suggestion={suggestion}
-        onClose={isDismissibleAdvisory ? handleDismissAdvisory : undefined}
+        onClose={
+          dismissibleAdvisoryType
+            ? () => handleDismissAdvisory(dismissibleAdvisoryType)
+            : undefined
+        }
         data-testid={TEST_ID}
         data-severity={bannerState.severity}
       >

--- a/services/vault/src/components/simple/PositionNotificationBanner/PositionNotificationBanner.tsx
+++ b/services/vault/src/components/simple/PositionNotificationBanner/PositionNotificationBanner.tsx
@@ -82,7 +82,7 @@ export function PositionNotificationBanner({
   const { executeReorder, isProcessing: isReordering } = useReorderVaults();
   const { applyReorderedOrder } = useReorderOverride();
   const [isReorderSuccess, setIsReorderSuccess] = useState(false);
-  const [isWeirdParamsDismissed, setIsWeirdParamsDismissed] = useState(false);
+  const [isAdvisoryDismissed, setIsAdvisoryDismissed] = useState(false);
   const queryClient = useQueryClient();
   const { address } = useAccount();
 
@@ -96,8 +96,8 @@ export function PositionNotificationBanner({
     }
   }, [address, queryClient]);
 
-  const handleDismissWeirdParams = useCallback(() => {
-    setIsWeirdParamsDismissed(true);
+  const handleDismissAdvisory = useCallback(() => {
+    setIsAdvisoryDismissed(true);
   }, []);
 
   const handleApplyOrder = useCallback(async () => {
@@ -155,13 +155,14 @@ export function PositionNotificationBanner({
 
   if (bannerState.severity === "hidden") return null;
 
-  // Only the weird-params advisory is dismissible (informational, no required
-  // action). The standalone reorder suggestion is also `soft` but has a null
-  // primaryWarning, so it is intentionally excluded.
-  const isWeirdParamsAdvisory =
+  // The weird-params and dust advisories are dismissible (informational, no
+  // required action). The standalone reorder suggestion is also `soft` but has a
+  // null primaryWarning, so it is intentionally excluded.
+  const isDismissibleAdvisory =
     bannerState.severity === "soft" &&
-    bannerState.primaryWarning?.type === "weird-params";
-  if (isWeirdParamsAdvisory && isWeirdParamsDismissed) return null;
+    (bannerState.primaryWarning?.type === "weird-params" ||
+      bannerState.primaryWarning?.type === "dust");
+  if (isDismissibleAdvisory && isAdvisoryDismissed) return null;
 
   const { primaryWarning, secondaryWarnings } = bannerState;
 
@@ -286,7 +287,7 @@ export function PositionNotificationBanner({
           isStandaloneReorder || isCliffPrimary ? "below" : "inline"
         }
         suggestion={suggestion}
-        onClose={isWeirdParamsAdvisory ? handleDismissWeirdParams : undefined}
+        onClose={isDismissibleAdvisory ? handleDismissAdvisory : undefined}
         data-testid={TEST_ID}
         data-severity={bannerState.severity}
       >

--- a/services/vault/src/components/simple/PositionNotificationBanner/__tests__/PositionNotificationBanner.test.tsx
+++ b/services/vault/src/components/simple/PositionNotificationBanner/__tests__/PositionNotificationBanner.test.tsx
@@ -482,21 +482,49 @@ describe("PositionNotificationBanner", () => {
     vi.useRealTimers();
   });
 
-  it("renders nothing for dust (hidden severity)", () => {
+  it("renders the dust notice as a soft (info) banner with no actions", () => {
     const result = makeBaseResult({
       warnings: [
         {
           type: "dust",
-          title: "Position too small to model",
-          detail: "Too small for analysis.",
+          title: "Position too small for vault analysis",
+          detail:
+            "Below $1,000 the cascade simplifies — all vaults are shown as one liquidation event.",
         },
       ],
     });
-    const { container } = renderBanner(result, onDeposit, onRepay);
+    renderBanner(result, onDeposit, onRepay);
 
+    const banner = screen.getByTestId("position-notification-banner");
+    expect(banner.dataset.severity).toBe("soft");
+    expect(banner.dataset.variant).toBe("info");
     expect(
-      container.querySelector("[data-testid='position-notification-banner']"),
-    ).toBeNull();
+      screen.getByText("Position too small for vault analysis"),
+    ).toBeTruthy();
+    expect(screen.queryByText("Add Collateral")).toBeNull();
+    expect(screen.queryByText("Apply Optimal Order")).toBeNull();
+  });
+
+  it("hides the dust notice after its dismiss control is clicked", () => {
+    const result = makeBaseResult({
+      warnings: [
+        {
+          type: "dust",
+          title: "Position too small for vault analysis",
+          detail:
+            "Below $1,000 the cascade simplifies — all vaults are shown as one liquidation event.",
+        },
+      ],
+    });
+    renderBanner(result, onDeposit, onRepay);
+
+    expect(screen.getByTestId("position-notification-banner")).toBeTruthy();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Dismiss notification" }),
+    );
+
+    expect(screen.queryByTestId("position-notification-banner")).toBeNull();
   });
 
   it("renders an orange cliff with the generic 'Add sacrificial vault' CTA and pre-fills the amount", () => {

--- a/services/vault/src/components/simple/PositionNotificationBanner/__tests__/PositionNotificationBanner.test.tsx
+++ b/services/vault/src/components/simple/PositionNotificationBanner/__tests__/PositionNotificationBanner.test.tsx
@@ -505,6 +505,61 @@ describe("PositionNotificationBanner", () => {
     expect(screen.queryByText("Apply Optimal Order")).toBeNull();
   });
 
+  it("keeps a later weird-params advisory visible after the dust notice was dismissed", () => {
+    // Dismissal is per warning type: dismissing dust must not suppress a
+    // different advisory the position later transitions into while mounted.
+    const queryClient = makeQueryClient();
+    const dust = makeBaseResult({
+      warnings: [
+        {
+          type: "dust",
+          title: "Position too small for vault analysis",
+          detail:
+            "Below $1,000 the cascade simplifies — all vaults are shown as one liquidation event.",
+        },
+      ],
+    });
+    const weirdParams = makeBaseResult({
+      warnings: [
+        {
+          type: "weird-params",
+          title: "Protocol parameters don't compute",
+          detail: "THF must be greater than expected HF.",
+          tone: "soft",
+        },
+      ],
+    });
+
+    const { rerender } = render(
+      <QueryClientProvider client={queryClient}>
+        <PositionNotificationBanner
+          result={dust}
+          onDeposit={onDeposit}
+          onRepay={onRepay}
+        />
+      </QueryClientProvider>,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Dismiss notification" }),
+    );
+    expect(screen.queryByTestId("position-notification-banner")).toBeNull();
+
+    // Same mounted banner, position now reads as a weird-params advisory.
+    rerender(
+      <QueryClientProvider client={queryClient}>
+        <PositionNotificationBanner
+          result={weirdParams}
+          onDeposit={onDeposit}
+          onRepay={onRepay}
+        />
+      </QueryClientProvider>,
+    );
+
+    expect(screen.getByTestId("position-notification-banner")).toBeTruthy();
+    expect(screen.getByText("Protocol parameters don't compute")).toBeTruthy();
+  });
+
   it("hides the dust notice after its dismiss control is clicked", () => {
     const result = makeBaseResult({
       warnings: [

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -1201,9 +1201,9 @@ export const COPY = {
         `This position already has the maximum number of BTC Vaults (${cap}).`,
     },
     dust: {
-      title: "Position too small to model",
+      title: "Position too small for vault analysis",
       detail:
-        "Below $1,000 the cascade simplifies — all BTC Vaults are shown as one liquidation event. Small positions don't have meaningful multi-event behavior.",
+        "Below $1,000 the cascade simplifies — all vaults are shown as one liquidation event. Small positions don't have meaningful multi-event behavior.",
     },
     weirdParams: {
       title: "Protocol parameters don't compute",


### PR DESCRIPTION
# Surface the "Position too small" (dust) notification per Figma

Closes https://github.com/babylonlabs-io/babylon-toolkit/issues/1951

## What this does

When a position is very small (under $1,000 of debt or collateral), the app already figures out that it's a "dust" position — but it never showed that to the user. The notification was calculated and then hidden. This PR makes it visible, as Figma designed it: a dismissible blue info banner.

It also fixes where the notification block sits on the dashboard. Figma places notifications above the Overview section (right under Vault Cap), but our code rendered them below Overview. This PR moves them up to match the design.

## Why

Two reasons. First, hiding the dust notice meant a user with a tiny position got no explanation for why their liquidation breakdown looks collapsed into a single event — Figma explicitly designed a notice for this, so we should show it. Second, the notification was appearing in the wrong place on the page compared to the design.

## The dust notification

It shows up for positions under $1,000 (debt or collateral). It's informational only — a small position has no meaningful step-by-step liquidation cascade, so all vaults are treated as one event. Because it's only informational, it's dismissible (an X in the corner), exactly like the existing "Protocol parameters don't compute" notice.

The final result matches the Figma frame: blue info style, an "i" icon, the title "Position too small for vault analysis", a short explanation, and a dismiss X. No buttons, no extra suggestion box.

## How it was built, and the approaches considered

The dust notice was already being produced by the calculator and was already in the copy file — it was just being forced to a "hidden" state and stripped of any way to dismiss it. So most of the work was unhiding it and reusing what's already there rather than building anything new.

For surfacing it, there were two ways to go. One: keep it hidden and only change the copy (the minimal change, but it ignores the design). Two: follow Figma and actually show it. We chose to follow Figma, because the design clearly drew a full, surfaced, dismissible notification — the intent is to show it.

For the dismiss behavior, there were also two ways. One: add a new, dust-specific piece of dismiss logic. Two: reuse the dismiss logic that already exists for the "Protocol parameters don't compute" advisory, since dust behaves identically (informational, no action, can be closed). We chose to reuse it and made that one path cover both notices, so there's no duplicated logic.

## Changes

- The banner severity logic no longer hides dust — it now renders it as the blue info style (the same style other informational advisories use). Its existing behavior of suppressing other warnings (because a tiny position has nothing else meaningful to say) is kept.
- The banner component's dismiss handling was generalized from "only the protocol-params advisory" to "the protocol-params advisory and dust", since they share the exact same dismiss behavior.
- The copy was aligned to Figma: the title became "Position too small for vault analysis", and one word in the body was adjusted so it matches the design word-for-word.
- The dashboard layout was changed so the notification block (the critical top banner, the max-vaults notice, and this cascade banner) renders above the Overview section instead of below it, matching the Figma dashboard layout. This applies to every notification type, not just dust.
- Tests were updated to reflect that dust now shows (instead of being hidden) and can be dismissed.

## Scope notes

The notification only appears where it already did — it's still behind the existing liquidation-notifications feature flag. No shared component library changes, and no change to the liquidation math; the calculator already produced this notice.

## How to verify

- Typecheck, tests, and lint all pass (lint unchanged from the baseline: 0 errors).
- Manually: turn on the position debug panel and the liquidation-notifications flag, switch the debug panel to Manual Mode, and set a position under $1,000 (for example one 0.5 BTC vault with a $500 debt). You should see the blue "Position too small for vault analysis" banner, with a working dismiss X, sitting above the Overview section
