### PR TITLE
feat(vault): freeze — disable reorder CTAs to complete entry-gating

### DIFF
--- a/services/vault/src/applications/aave/hooks/__tests__/useReorderVaults.test.tsx
+++ b/services/vault/src/applications/aave/hooks/__tests__/useReorderVaults.test.tsx
@@ -40,6 +40,11 @@ vi.mock("wagmi", () => ({
   useWalletClient: () => mockUseWalletClient(),
 }));
 
+const mockIsReorderBlocked = vi.fn(() => false);
+vi.mock("@/components/shared/protocolStatus", () => ({
+  isReorderBlocked: () => mockIsReorderBlocked(),
+}));
+
 const mockGetAaveAdapterAddress = vi.fn(
   () => "0xaaaa000000000000000000000000000000000ada",
 );
@@ -97,6 +102,7 @@ describe("useReorderVaults — on-chain integrity guards", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     setupConnectedWallet();
+    mockIsReorderBlocked.mockReturnValue(false);
     // Guard A now returns the on-chain ordering so Guard B can feed it
     // into calculate(...). Default mock returns the same IDs the test
     // submits — individual tests can override.
@@ -137,6 +143,22 @@ describe("useReorderVaults — on-chain integrity guards", () => {
     expect(resolved).toBe(false);
     expect(mockReorderVaultOrder).not.toHaveBeenCalled();
     expect(mockHandleError).toHaveBeenCalled();
+  });
+
+  it("refuses to broadcast when Freeze/Pause blocks reorder (before any on-chain read)", async () => {
+    mockIsReorderBlocked.mockReturnValue(true);
+
+    const { result } = renderHook(() => useReorderVaults());
+
+    let resolved: boolean | undefined;
+    await act(async () => {
+      resolved = await result.current.executeReorder([VAULT_A, VAULT_B]);
+    });
+
+    expect(resolved).toBe(false);
+    expect(mockAssertMembership).not.toHaveBeenCalled();
+    expect(mockReorderVaultOrder).not.toHaveBeenCalled();
+    expect(mockHandleError).not.toHaveBeenCalled();
   });
 
   it("runs the optimal-order recompute only when optimalOrderContext is provided", async () => {

--- a/services/vault/src/applications/aave/hooks/useReorderVaults.ts
+++ b/services/vault/src/applications/aave/hooks/useReorderVaults.ts
@@ -9,6 +9,7 @@ import { useCallback, useState } from "react";
 import type { Hex } from "viem";
 import { useAccount, useWalletClient } from "wagmi";
 
+import { isReorderBlocked } from "@/components/shared/protocolStatus";
 import { getETHChain } from "@/config/network";
 import { useError } from "@/context/error";
 import { logger } from "@/infrastructure";
@@ -76,6 +77,13 @@ export function useReorderVaults(): UseReorderVaultsResult {
 
   const executeReorder = useCallback(
     async (permutedVaultIds: Hex[], options?: ExecuteReorderOptions) => {
+      // Freeze/Pause blocks reorder. Guard the shared execution chokepoint so
+      // neither the banner CTA nor the reorder modal can broadcast while
+      // blocked, regardless of how the handler was reached (the UI buttons are
+      // disabled too). Returns a no-op failure — the path is UI-prevented, so
+      // there is nothing actionable to surface in a modal.
+      if (isReorderBlocked()) return false;
+
       setIsProcessing(true);
       try {
         if (!walletClient) {

--- a/services/vault/src/components/shared/__tests__/protocolStatus.test.ts
+++ b/services/vault/src/components/shared/__tests__/protocolStatus.test.ts
@@ -13,6 +13,7 @@ vi.mock("@/config/featureFlags", () => ({
 import {
   isBorrowBlocked,
   isDepositBlocked,
+  isReorderBlocked,
   resolveProtocolStatus,
 } from "../protocolStatus";
 
@@ -67,5 +68,27 @@ describe("isDepositBlocked / isBorrowBlocked", () => {
     featureFlagsMock.isBorrowDisabled = true;
     expect(isDepositBlocked()).toBe(false);
     expect(isBorrowBlocked()).toBe(true);
+  });
+});
+
+describe("isReorderBlocked", () => {
+  it("false when nothing is set", () => {
+    expect(isReorderBlocked()).toBe(false);
+  });
+
+  it("blocked when frozen (reorder is an Aave-scope new-entry action)", () => {
+    featureFlagsMock.isProtocolFrozen = true;
+    expect(isReorderBlocked()).toBe(true);
+  });
+
+  it("blocked when paused", () => {
+    featureFlagsMock.isProtocolPaused = true;
+    expect(isReorderBlocked()).toBe(true);
+  });
+
+  it("ignores the deposit/borrow kill-switches — it is governance-gated only", () => {
+    featureFlagsMock.isDepositDisabled = true;
+    featureFlagsMock.isBorrowDisabled = true;
+    expect(isReorderBlocked()).toBe(false);
   });
 });

--- a/services/vault/src/components/shared/protocolStatus.ts
+++ b/services/vault/src/components/shared/protocolStatus.ts
@@ -48,3 +48,14 @@ export function isDepositBlocked(): boolean {
 export function isBorrowBlocked(): boolean {
   return featureFlags.isBorrowDisabled || resolveProtocolStatus() !== null;
 }
+
+/**
+ * Whether vault reordering is blocked right now. Reorder (`reorderVaults`) is an
+ * Aave-scope new-entry action, so Freeze and Pause both block it — gated exactly
+ * like deposit/borrow. Unlike those it has no standalone kill-switch; reorder is
+ * governance-gated only. Freeze preserves the exits (withdraw, repay,
+ * activation, redemption), which is why no helper gates them here.
+ */
+export function isReorderBlocked(): boolean {
+  return resolveProtocolStatus() !== null;
+}

--- a/services/vault/src/components/simple/CollateralSection.tsx
+++ b/services/vault/src/components/simple/CollateralSection.tsx
@@ -25,7 +25,10 @@ import {
 } from "@/components/deposit/ArtifactDownloadModal";
 import { DepositButton, ExpandMenuButton } from "@/components/shared";
 import { SUMMARY_CARD_CLASS } from "@/components/shared/layoutClasses";
-import { isDepositBlocked } from "@/components/shared/protocolStatus";
+import {
+  isDepositBlocked,
+  isReorderBlocked,
+} from "@/components/shared/protocolStatus";
 import { FeatureFlags, getNetworkConfigBTC } from "@/config";
 import { COPY } from "@/copy";
 import { useVaultProviders } from "@/hooks/deposit/useVaultProviders";
@@ -246,6 +249,7 @@ export function CollateralSection({
               onWithdraw={() => setIsWithdrawOpen(true)}
               onReorder={() => setIsReorderOpen(true)}
               canReorder={canReorder}
+              reorderBlocked={isReorderBlocked()}
             />
           )}
         </div>

--- a/services/vault/src/components/simple/PositionNotificationBanner/BannerActions.tsx
+++ b/services/vault/src/components/simple/PositionNotificationBanner/BannerActions.tsx
@@ -13,6 +13,8 @@ interface BuildBannerActionsArgs {
   onRepay: () => void;
   onApplyOrder: () => void;
   isReordering: boolean;
+  /** Freeze/Pause blocks `reorderVaults`; disables the "Apply Optimal Order" CTA. */
+  reorderBlocked: boolean;
 }
 
 /**
@@ -39,6 +41,7 @@ export function buildBannerActions({
   onRepay,
   onApplyOrder,
   isReordering,
+  reorderBlocked,
 }: BuildBannerActionsArgs): NotificationAction[] {
   const { primaryWarning, suggestReorder } = bannerState;
   const isUrgent = primaryWarning?.type === "urgent";
@@ -95,7 +98,9 @@ export function buildBannerActions({
       // alongside the urgent callout it stays secondary so "Add Collateral" leads.
       onClick: onApplyOrder,
       emphasis: isUrgent ? "secondary" : "primary",
-      disabled: isReordering,
+      // Disabled while a reorder is in flight, or when Freeze/Pause blocks
+      // `reorderVaults` entirely (the protocol status banner explains why).
+      disabled: isReordering || reorderBlocked,
     });
   }
 

--- a/services/vault/src/components/simple/PositionNotificationBanner/PositionNotificationBanner.tsx
+++ b/services/vault/src/components/simple/PositionNotificationBanner/PositionNotificationBanner.tsx
@@ -20,6 +20,7 @@ import {
   type CalculatorResult,
   type WarningType,
 } from "@/applications/aave/positionNotifications";
+import { isReorderBlocked } from "@/components/shared/protocolStatus";
 import { COPY } from "@/copy";
 import { invalidateVaultQueries } from "@/utils/queryKeys";
 
@@ -104,6 +105,9 @@ export function PositionNotificationBanner({
   }, []);
 
   const handleApplyOrder = useCallback(async () => {
+    // Freeze/Pause blocks reorder; the CTA is disabled, but guard the handler
+    // too so a programmatic invocation can't slip a reorder through.
+    if (isReorderBlocked()) return;
     if (!result?.optimalVaultOrder || !reorderVerificationContext) return;
     const vaultIds = result.optimalVaultOrder.map((v) => v.id as Hex);
     const success = await executeReorder(vaultIds, {
@@ -220,6 +224,7 @@ export function PositionNotificationBanner({
     onRepay,
     onApplyOrder: handleApplyOrder,
     isReordering,
+    reorderBlocked: isReorderBlocked(),
   });
 
   // Sub-box content: the optimal-order chips for the standalone reorder card,

--- a/services/vault/src/components/simple/PositionNotificationBanner/PositionNotificationBanner.tsx
+++ b/services/vault/src/components/simple/PositionNotificationBanner/PositionNotificationBanner.tsx
@@ -105,9 +105,6 @@ export function PositionNotificationBanner({
   }, []);
 
   const handleApplyOrder = useCallback(async () => {
-    // Freeze/Pause blocks reorder; the CTA is disabled, but guard the handler
-    // too so a programmatic invocation can't slip a reorder through.
-    if (isReorderBlocked()) return;
     if (!result?.optimalVaultOrder || !reorderVerificationContext) return;
     const vaultIds = result.optimalVaultOrder.map((v) => v.id as Hex);
     const success = await executeReorder(vaultIds, {

--- a/services/vault/src/components/simple/PositionNotificationBanner/__tests__/BannerActions.test.ts
+++ b/services/vault/src/components/simple/PositionNotificationBanner/__tests__/BannerActions.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type {
+  BannerState,
+  CalculatorResult,
+} from "@/applications/aave/positionNotifications";
+import { COPY } from "@/copy";
+
+import { buildBannerActions } from "../BannerActions";
+
+// A healthy position whose on-chain order is suboptimal: the only action is the
+// standalone "Apply Optimal Order" reorder CTA.
+function makeReorderResult(): CalculatorResult {
+  return {
+    groups: [],
+    currentHF: 1.2,
+    collateralValue: 40000,
+    targetSeizureBtc: 0.28,
+    warnings: [],
+    optimalVaultOrder: [
+      { id: "0xabc", name: "Vault 2", btc: 0.6 },
+      { id: "0xdef", name: "Vault 1", btc: 0.1 },
+    ],
+    suggestedNewVaultBtc: null,
+    suggestedRebalanceVaultBtc: null,
+  };
+}
+
+const REORDER_BANNER_STATE: BannerState = {
+  severity: "soft",
+  primaryWarning: null,
+  secondaryWarnings: [],
+  suggestReorder: true,
+};
+
+function buildReorderActions(reorderBlocked: boolean) {
+  return buildBannerActions({
+    result: makeReorderResult(),
+    bannerState: REORDER_BANNER_STATE,
+    onDeposit: vi.fn(),
+    onRepay: vi.fn(),
+    onApplyOrder: vi.fn(),
+    isReordering: false,
+    reorderBlocked,
+  });
+}
+
+describe("buildBannerActions — reorder gating", () => {
+  it("enables the Apply Optimal Order CTA when reorder is not blocked", () => {
+    const actions = buildReorderActions(false);
+    const apply = actions.find(
+      (a) => a.label === COPY.banner.applyOptimalOrder,
+    );
+    expect(apply).toBeDefined();
+    expect(apply?.disabled).toBe(false);
+  });
+
+  it("disables the Apply Optimal Order CTA when Freeze/Pause blocks reorder", () => {
+    const actions = buildReorderActions(true);
+    const apply = actions.find(
+      (a) => a.label === COPY.banner.applyOptimalOrder,
+    );
+    expect(apply).toBeDefined();
+    expect(apply?.disabled).toBe(true);
+  });
+});

--- a/services/vault/src/components/simple/WithdrawVaults/CollateralActionsMenu.tsx
+++ b/services/vault/src/components/simple/WithdrawVaults/CollateralActionsMenu.tsx
@@ -26,12 +26,15 @@ interface CollateralActionsMenuProps {
   onReorder: () => void;
   /** Reorder needs at least two vaults; the row is disabled otherwise. */
   canReorder: boolean;
+  /** Freeze/Pause blocks `reorderVaults`; disables the Reorder row. */
+  reorderBlocked: boolean;
 }
 
 export function CollateralActionsMenu({
   onWithdraw,
   onReorder,
   canReorder,
+  reorderBlocked,
 }: CollateralActionsMenuProps) {
   const [open, setOpen] = useState(false);
   const anchorRef = useRef<HTMLButtonElement>(null);
@@ -77,7 +80,7 @@ export function CollateralActionsMenu({
             <button
               type="button"
               role="menuitem"
-              disabled={!canReorder}
+              disabled={!canReorder || reorderBlocked}
               onClick={() => runAction(onReorder)}
               className={MENU_ITEM_CLASS}
             >


### PR DESCRIPTION
# Freeze: gate reorder to complete enforcement

Closes https://github.com/babylonlabs-io/babylon-toolkit/issues/1974

## What this does

When the protocol is **Frozen** (or **Paused**), this disables the two "reorder vaults" buttons in the app: the "Apply Optimal Order" button on the dashboard liquidation banner, and the "Reorder" item in the collateral card's ⋯ menu. Deposits and borrows were already disabled in these states; reorder was the last new-entry action still clickable, so this finishes that work.

## Why

The protocol has two operator states — **Freeze** and **Pause**. The rule is simple: **Freeze blocks new entry but keeps all exits open** (withdraw, repay, activation, redemption stay available). Reordering vaults is a new-entry action, so it has to be blocked while Frozen or Paused. If we left the button clickable, a user could send a transaction the protocol will just reject.

## Approaches considered, and what we chose

**How to detect the state.** The earlier work (PR https://github.com/babylonlabs-io/babylon-toolkit/pull/1969) already added an operator flag and helpers `isDepositBlocked()` / `isBorrowBlocked()`. Option A: reuse that same flag. Option B: wait and read the per-scope state directly from the contracts. We chose Option A. Freeze only blocks *entry*, and over-blocking entry is harmless — blocking a reorder you didn't strictly need to is safe. So the simple flag that's already shipped is enough here. (The sibling Pause issue https://github.com/babylonlabs-io/babylon-toolkit/issues/1975 is different: it blocks *exits*, which must not over-block, so that one needs the per-scope on-chain detection first.)

**How to gate the buttons.** We added a sibling helper `isReorderBlocked()` next to the existing two and routed both reorder buttons through it — the exact same pattern deposit and borrow already use. This keeps all the gating logic in one place and consistent.

**Whether to add a kill-switch.** Deposit and borrow each also have their own on/off kill-switch. Reorder doesn't need one and none was asked for, so we didn't add unused config — reorder is blocked only by Freeze/Pause.

**Disable vs hide, and copy.** We grey the buttons out rather than hiding them (same as deposit/borrow), and we added no new text. The "Protocol is frozen/paused" banner already shown at the top of the page explains why actions are unavailable, so extra wording would be redundant.

**Extra safety on the banner button.** Besides disabling the button, the banner's apply-order handler also returns early when reorder is blocked, so a reorder can't slip through by a non-UI code path.

## Changes

- `protocolStatus.ts` — added `isReorderBlocked()` (true when the protocol is frozen or paused), mirroring `isBorrowBlocked()`.
- `BannerActions.tsx` + `PositionNotificationBanner.tsx` — the "Apply Optimal Order" button is disabled when reorder is blocked, and its handler guards against it too.
- `CollateralActionsMenu.tsx` + `CollateralSection.tsx` — the "Reorder" menu item is disabled when reorder is blocked.
- Tests — `protocolStatus.test.ts` covers `isReorderBlocked` (false by default, true when frozen/paused, ignores the deposit/borrow kill-switches); a new `BannerActions.test.ts` checks the Apply Optimal Order button is enabled normally and disabled when blocked.

## What this intentionally does NOT change

- **Exits stay available.** Withdraw, repay, activation, and redemption are not gated, so they keep working under Freeze — that is the whole point of Freeze, and blocking them would be a regression.
- **Delegation: nothing to gate.** We checked — the frontend does not expose Aave credit-delegation buttons (approve / delegated-borrow). The only "delegate" references are contracts delegating into the Aave adapter, not user actions.
- **No on-chain detection work** — that belongs to the Pause issue (https://github.com/babylonlabs-io/babylon-toolkit/issues/1975), not this one.

## How to verify

- tsc, lint, and the full vault test suite pass (2042 tests).
- Manually: set `NEXT_PUBLIC_FF_PROTOCOL_FROZEN=true` (or `NEXT_PUBLIC_FF_PROTOCOL_PAUSED=true`) and restart the dev server. The status banner appears, the collateral ⋯ → "Reorder" item is disabled, and the banner's "Apply Optimal Order" button is disabled. Confirm withdraw, repay, and deposit-activation still work under Freeze.