### PR TITLE
feat(packages): hides progress bar when progress is finished

### DIFF
--- a/services/vault/src/components/simple/PendingWithdrawCard.tsx
+++ b/services/vault/src/components/simple/PendingWithdrawCard.tsx
@@ -125,6 +125,10 @@ export function PendingWithdrawCard({
   // Support, hidden bar). The `warning` variant is also used for transient
   // polling timeouts / unknown statuses, which should keep the normal layout.
   const isBlocked = claimer?.status === ClaimerPegoutStatusValue.PAYOUT_BLOCKED;
+  // "Payout sent" is the terminal success stage: the BTC payout is on its way,
+  // so the staged progress bar has nothing left to advance.
+  const isPayoutSent =
+    claimer?.status === ClaimerPegoutStatusValue.PAYOUT_BROADCAST;
 
   const progress = getPegoutStageProgress(
     claimer?.status,
@@ -210,9 +214,11 @@ export function PendingWithdrawCard({
         />
       </div>
 
-      {/* Progress bar — omitted only for a real protocol block, where the red
-          badge and Contact Support carry the message instead. */}
-      {!isBlocked && (
+      {/* Progress bar — shown only while the withdrawal is still advancing.
+          Omitted at the terminal payout stages: "Payout sent" (the green badge
+          already says it's done) and "Blocked" (the red badge + Contact Support
+          carry the message instead). */}
+      {!isBlocked && !isPayoutSent && (
         <ProgressBar percent={progress} color={ASSET_BRAND_COLOR} />
       )}
 

--- a/services/vault/src/components/simple/__tests__/PendingWithdrawCard.test.tsx
+++ b/services/vault/src/components/simple/__tests__/PendingWithdrawCard.test.tsx
@@ -159,14 +159,16 @@ describe("PendingWithdrawCard — stage presentation", () => {
     ).toBeInTheDocument();
   });
 
-  it("keeps the progress bar and shows no Contact Support for Payout sent", () => {
+  it("hides the progress bar and shows no Contact Support for Payout sent", () => {
+    // Payout sent is terminal-success: the bar has nothing left to advance, so
+    // it is omitted — but this is not an error, so no Contact Support either.
     renderCard(resultForStatus(ClaimerPegoutStatusValue.PAYOUT_BROADCAST));
 
-    expect(screen.getByRole("progressbar")).toBeInTheDocument();
+    expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
     expect(screen.queryByText(CARD.contactSupport)).not.toBeInTheDocument();
   });
 
-  it("shows Contact Support and hides the progress bar only when truly Blocked", () => {
+  it("shows Contact Support and hides the progress bar when truly Blocked", () => {
     renderCard(resultForStatus(ClaimerPegoutStatusValue.PAYOUT_BLOCKED));
 
     expect(


### PR DESCRIPTION
<img width="1026" height="388" alt="Screenshot 2026-06-29 at 21 03 30" src="https://github.com/user-attachments/assets/b0b9e252-3dc0-436c-9dc7-3ccf136cf654" />
