### PR TITLE
fix(vault): gate Activate when the activation deadline has passed

### DIFF
--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/peginState.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/peginState.test.ts
@@ -4,6 +4,7 @@ import {
   canPerformAction,
   ContractStatus,
   getPeginProtocolState,
+  isActivationDeadlinePassedOnChain,
   PeginAction,
 } from "../peginState";
 
@@ -162,6 +163,41 @@ describe("peginProtocolState", () => {
       const state = getPeginProtocolState(ContractStatus.ACTIVE);
       expect(
         canPerformAction(state, PeginAction.SIGN_PAYOUT_TRANSACTIONS),
+      ).toBe(false);
+    });
+  });
+
+  // ==========================================================================
+  // isActivationDeadlinePassedOnChain — mirrors the contract's strict '>'
+  // ==========================================================================
+  describe("isActivationDeadlinePassedOnChain", () => {
+    it("treats the boundary block (current == created + timeout) as NOT expired", () => {
+      expect(
+        isActivationDeadlinePassedOnChain({
+          currentBlock: 1100n,
+          createdAtBlock: 1000n,
+          pegInActivationTimeout: 100n,
+        }),
+      ).toBe(false);
+    });
+
+    it("treats one block past the boundary as expired", () => {
+      expect(
+        isActivationDeadlinePassedOnChain({
+          currentBlock: 1101n,
+          createdAtBlock: 1000n,
+          pegInActivationTimeout: 100n,
+        }),
+      ).toBe(true);
+    });
+
+    it("treats a block below the boundary as NOT expired", () => {
+      expect(
+        isActivationDeadlinePassedOnChain({
+          currentBlock: 1050n,
+          createdAtBlock: 1000n,
+          pegInActivationTimeout: 100n,
+        }),
       ).toBe(false);
     });
   });

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/index.ts
@@ -27,6 +27,7 @@ export {
   PeginAction,
   canPerformAction,
   getPeginProtocolState,
+  isActivationDeadlinePassedOnChain,
   type ExpirationReason,
   type GetPeginProtocolStateOptions,
   type PeginProtocolState,

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts
@@ -196,3 +196,22 @@ export function canPerformAction(
 ): boolean {
   return state.availableActions.includes(action);
 }
+
+// ============================================================================
+// Activation deadline
+// ============================================================================
+
+/**
+ * Whether a vault's on-chain activation window has closed. Mirrors the
+ * BTCVaultRegistry check that reverts `ActivationDeadlineExpired`:
+ * `block.number > createdAt + pegInActivationTimeout` — strict `>`, so a
+ * boundary-equal block is NOT expired. All values are Ethereum block numbers.
+ */
+export function isActivationDeadlinePassedOnChain(params: {
+  currentBlock: bigint;
+  createdAtBlock: bigint;
+  pegInActivationTimeout: bigint;
+}): boolean {
+  const { currentBlock, createdAtBlock, pegInActivationTimeout } = params;
+  return currentBlock > createdAtBlock + pegInActivationTimeout;
+}

--- a/services/vault/src/components/simple/ResumeDepositContent.tsx
+++ b/services/vault/src/components/simple/ResumeDepositContent.tsx
@@ -577,6 +577,7 @@ export function ResumeActivationContent({
     activating,
     activated,
     error: activationError,
+    errorTerminal,
     handleActivation,
   } = useActivationState({
     activity,
@@ -685,6 +686,9 @@ export function ResumeActivationContent({
   useRunOnce(handleSubmit, !btcWalletProvider || Boolean(connectedBtcAddress));
 
   const error = localError ?? activationError;
+  // Terminal only applies to the activation failure (deadline passed), never a
+  // local pre-flight error — which localError would override via `??` above.
+  const isTerminal = localError == null && errorTerminal;
 
   // Track the live contract status so an activation completed elsewhere
   // (another tab, a previous session) still lands on the success terminal
@@ -718,7 +722,13 @@ export function ResumeActivationContent({
   return (
     <DepositProgressView
       currentStep={renderStep}
-      error={error ? mapDepositError(error) : null}
+      error={
+        error
+          ? isTerminal
+            ? COPY.deposit.errors.activationDeadlinePassed
+            : mapDepositError(error)
+          : null
+      }
       isComplete={derived.isComplete}
       isProcessing={derived.isProcessing}
       canClose={derived.canClose}
@@ -729,7 +739,7 @@ export function ResumeActivationContent({
       currentVaultIndex={currentVaultIndex}
       perVaultSteps={perVaultSteps}
       onClose={onClose}
-      onRetry={error ? handleSubmit : undefined}
+      onRetry={error && !isTerminal ? handleSubmit : undefined}
       offchainParamsVersion={activity.offchainParamsVersion}
     />
   );

--- a/services/vault/src/components/simple/__tests__/ResumeDepositContent.test.tsx
+++ b/services/vault/src/components/simple/__tests__/ResumeDepositContent.test.tsx
@@ -11,6 +11,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { getVaultRegistryReader } from "@/clients/eth-contract/sdk-readers";
 import { usePayoutSigningState } from "@/components/deposit/PayoutSignModal/usePayoutSigningState";
+import { COPY } from "@/copy";
 import { useActivationState } from "@/hooks/deposit/useActivationState";
 import type { VaultActivity } from "@/types/activity";
 
@@ -199,6 +200,7 @@ vi.mock("../DepositProgressView", () => ({
     isProcessing,
     terminalMessage,
     canContinueInBackground,
+    onRetry,
   }: {
     currentStep?: string;
     error?: { title: string; body: string } | null;
@@ -206,10 +208,13 @@ vi.mock("../DepositProgressView", () => ({
     isProcessing?: boolean;
     terminalMessage?: string | null;
     canContinueInBackground?: boolean;
+    onRetry?: () => void;
   }) => (
     <div data-testid="progress-view">
       <span data-testid="step">{String(currentStep)}</span>
       <span data-testid="error">{error?.body ?? ""}</span>
+      <span data-testid="error-title">{error?.title ?? ""}</span>
+      <span data-testid="has-retry">{String(!!onRetry)}</span>
       <span data-testid="complete">{String(!!isComplete)}</span>
       <span data-testid="processing">{String(!!isProcessing)}</span>
       <span data-testid="terminal">{terminalMessage ?? ""}</span>
@@ -582,5 +587,46 @@ describe("ResumeActivationContent — activated success terminal", () => {
     // ACTIVATE_VAULT
     await waitFor(() => expect(getByTestId("step").textContent).toBe("14"));
     expect(queryByTestId("vault-activated-view")).toBeNull();
+  });
+
+  it("shows the deadline-passed copy and suppresses Retry on a terminal failure", async () => {
+    vi.mocked(useActivationState).mockReturnValue({
+      activating: false,
+      activated: false,
+      error: "The activation deadline has passed.",
+      errorTerminal: true,
+      handleActivation: mockHandleActivation,
+    });
+
+    const { getByTestId } = renderActivation();
+
+    await waitFor(() =>
+      expect(getByTestId("error-title").textContent).toBe(
+        COPY.deposit.errors.activationDeadlinePassed.title,
+      ),
+    );
+    expect(getByTestId("error").textContent).toBe(
+      COPY.deposit.errors.activationDeadlinePassed.body,
+    );
+    expect(getByTestId("has-retry").textContent).toBe("false");
+  });
+
+  it("keeps Retry and the generic mapping for a non-terminal failure", async () => {
+    vi.mocked(useActivationState).mockReturnValue({
+      activating: false,
+      activated: false,
+      error: "Some transient RPC error",
+      errorTerminal: false,
+      handleActivation: mockHandleActivation,
+    });
+
+    const { getByTestId } = renderActivation();
+
+    await waitFor(() =>
+      expect(getByTestId("has-retry").textContent).toBe("true"),
+    );
+    expect(getByTestId("error-title").textContent).not.toBe(
+      COPY.deposit.errors.activationDeadlinePassed.title,
+    );
   });
 });

--- a/services/vault/src/components/simple/__tests__/ResumeDepositContent.test.tsx
+++ b/services/vault/src/components/simple/__tests__/ResumeDepositContent.test.tsx
@@ -136,6 +136,7 @@ vi.mock("@/hooks/deposit/useActivationState", () => ({
     activating: false,
     activated: false,
     error: null,
+    errorTerminal: false,
     handleActivation: mockHandleActivation,
   })),
 }));
@@ -529,6 +530,7 @@ describe("ResumeActivationContent — activated success terminal", () => {
       activating: false,
       activated: true,
       error: null,
+      errorTerminal: false,
       handleActivation: mockHandleActivation,
     });
     mockUseDepositPollingResult.mockReturnValue({
@@ -548,6 +550,7 @@ describe("ResumeActivationContent — activated success terminal", () => {
       activating: false,
       activated: false,
       error: null,
+      errorTerminal: false,
       handleActivation: mockHandleActivation,
     });
     mockUseDepositPollingResult.mockReturnValue({
@@ -567,6 +570,7 @@ describe("ResumeActivationContent — activated success terminal", () => {
       activating: true,
       activated: false,
       error: null,
+      errorTerminal: false,
       handleActivation: mockHandleActivation,
     });
     mockUseDepositPollingResult.mockReturnValue({

--- a/services/vault/src/context/deposit/PeginPollingContext.tsx
+++ b/services/vault/src/context/deposit/PeginPollingContext.tsx
@@ -25,6 +25,7 @@ import { useDemoDeposit } from "@/dev/demoDeposit";
 import { usePeginPollingQuery } from "../../hooks/deposit/usePeginPollingQuery";
 import { useRequiredPrePeginDepthResolver } from "../../hooks/deposit/useRequiredPrePeginDepth";
 import { useSigningRequiredNotifications } from "../../hooks/deposit/useSigningRequiredNotifications";
+import { useActivationDeadlineGate } from "../../hooks/useActivationDeadlineGate";
 import { useBtcHtlcRefundStatus } from "../../hooks/useBtcHtlcRefundStatus";
 import { useBtcMempoolConfirmations } from "../../hooks/useBtcMempoolConfirmations";
 import {
@@ -149,7 +150,13 @@ export function PeginPollingProvider({
   // VP activation tx, absent during PENDING). PENDING gates on min-depth;
   // EXPIRED gates on `tRefund` for the Refund action. Each has its own
   // cache (depth/maturity never rewinds → drop cached txids from polling).
-  const { getOffchainParamsByVersion } = useProtocolParamsContext();
+  const { config, getOffchainParamsByVersion } = useProtocolParamsContext();
+  // Tiered (Tier-1 estimate → Tier-2 chain confirm) activation-deadline gate.
+  // Lowercased ids of VERIFIED vaults confirmed past their activation window.
+  const activationDeadlinePassedIds = useActivationDeadlineGate(
+    activities,
+    config.pegInActivationTimeout,
+  );
   const [confirmedTxids, setConfirmedTxids] = useState<Set<string>>(
     loadConfirmedPrePeginTxids,
   );
@@ -401,6 +408,9 @@ export function PeginPollingProvider({
         refundedHtlcVaultIds,
         requiredDepth: getRequiredPrePeginDepth(activity),
         refundTimelock,
+        activationDeadlinePassed: activationDeadlinePassedIds.has(
+          activity.id.toLowerCase(),
+        ),
         isLoading,
         optimisticStatuses,
         optimisticRefundBroadcastAt,
@@ -422,6 +432,7 @@ export function PeginPollingProvider({
       refundedHtlcVaultIds,
       getRequiredPrePeginDepth,
       getOffchainParamsByVersion,
+      activationDeadlinePassedIds,
       isLoading,
       optimisticStatuses,
       optimisticRefundBroadcastAt,

--- a/services/vault/src/context/deposit/__tests__/PeginPollingContext.test.tsx
+++ b/services/vault/src/context/deposit/__tests__/PeginPollingContext.test.tsx
@@ -62,6 +62,18 @@ vi.mock("../../../hooks/useBtcHtlcRefundStatus", () => ({
   useBtcHtlcRefundStatus: () => mockUseBtcHtlcRefundStatus(),
 }));
 
+// Activation-deadline gate uses react-query + chain reads — stub so the
+// provider renders in isolation. Default: nothing gated. Tests can inject a
+// gated vault id via `mockReturnValue`.
+const { mockUseActivationDeadlineGate } = vi.hoisted(() => ({
+  mockUseActivationDeadlineGate: vi.fn<() => ReadonlySet<string>>(
+    () => new Set<string>(),
+  ),
+}));
+vi.mock("../../../hooks/useActivationDeadlineGate", () => ({
+  useActivationDeadlineGate: () => mockUseActivationDeadlineGate(),
+}));
+
 const mockVersionedParams = new Map<number, { tRefund: number }>();
 
 vi.mock("../../ProtocolParamsContext", () => ({

--- a/services/vault/src/context/deposit/__tests__/computeDepositPollingResult.test.ts
+++ b/services/vault/src/context/deposit/__tests__/computeDepositPollingResult.test.ts
@@ -51,6 +51,7 @@ function makeInputs(
     refundedHtlcVaultIds: new Set(),
     requiredDepth: 6,
     refundTimelock: 10,
+    activationDeadlinePassed: false,
     isLoading: false,
     optimisticStatuses: new Map(),
     optimisticRefundBroadcastAt: new Map(),
@@ -101,5 +102,41 @@ describe("computeDepositPollingResult — refund settlement", () => {
     );
     expect(result.peginState.availableActions).toEqual([PeginAction.NONE]);
     expect(result.peginState.displayLabel).toBe(PEGIN_DISPLAY_LABELS.REFUNDED);
+  });
+});
+
+describe("computeDepositPollingResult — activation deadline gate", () => {
+  function makeVerifiedActivity(): VaultActivity {
+    return {
+      ...makeExpiredActivity(),
+      displayLabel: PEGIN_DISPLAY_LABELS.READY_TO_ACTIVATE,
+      contractStatus: ContractStatus.VERIFIED,
+    };
+  }
+
+  it("gates Activate to expired when the deadline is confirmed passed", () => {
+    const result = computeDepositPollingResult(
+      makeInputs({
+        activity: makeVerifiedActivity(),
+        activationDeadlinePassed: true,
+      }),
+    );
+    expect(result.peginState.availableActions).toEqual([PeginAction.NONE]);
+    expect(result.peginState.displayLabel).toBe(PEGIN_DISPLAY_LABELS.EXPIRED);
+  });
+
+  it("leaves Activate available when the deadline has not passed", () => {
+    const result = computeDepositPollingResult(
+      makeInputs({
+        activity: makeVerifiedActivity(),
+        activationDeadlinePassed: false,
+      }),
+    );
+    expect(result.peginState.availableActions).toContain(
+      PeginAction.ACTIVATE_VAULT,
+    );
+    expect(result.peginState.displayLabel).toBe(
+      PEGIN_DISPLAY_LABELS.READY_TO_ACTIVATE,
+    );
   });
 });

--- a/services/vault/src/context/deposit/computeDepositPollingResult.ts
+++ b/services/vault/src/context/deposit/computeDepositPollingResult.ts
@@ -69,6 +69,12 @@ export interface DepositPollingInputs {
   requiredDepth: number;
   /** Per-vault `tRefund`; `undefined` collapses maturity to `unknown`. */
   refundTimelock: number | undefined;
+  /**
+   * VERIFIED only: confirmed (Tier-2 chain read) past the on-chain activation
+   * deadline. Gates the Activate CTA. Defaults false (fail-safe) when not a
+   * suspect, the RPC failed, or the vault isn't on chain yet.
+   */
+  activationDeadlinePassed: boolean;
   isLoading: boolean;
   optimisticStatuses: Map<string, LocalStorageStatus>;
   optimisticRefundBroadcastAt: Map<string, number>;
@@ -92,6 +98,7 @@ export function computeDepositPollingResult(
     refundedHtlcVaultIds,
     requiredDepth,
     refundTimelock,
+    activationDeadlinePassed,
     isLoading,
     optimisticStatuses,
     optimisticRefundBroadcastAt,
@@ -203,6 +210,7 @@ export function computeDepositPollingResult(
     prePeginBroadcastSeen,
     expirationReason: activity.expirationReason,
     expiredAt: activity.expiredAt,
+    activationDeadlinePassed,
     canRefund,
     refundMaturityState,
     refundMaturesInBlocks,

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -624,6 +624,10 @@ export const COPY = {
         title: TRANSACTION_FAILED_TITLE,
         body: "Your wallet doesn't have enough ETH to cover the network fee. Add more ETH and retry the transaction.",
       },
+      activationDeadlinePassed: {
+        title: "Activation deadline passed",
+        body: "The activation window has closed and this BTC Vault can no longer be activated. You can reclaim your BTC through the refund flow once it becomes available.",
+      },
       signingRejected: {
         title: "Signing rejected",
         body: "You rejected the request in your wallet. Click Retry to approve it and continue.",

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -34,6 +34,10 @@
  *   surrounding screen rather than imposing a single rule.
  */
 
+// Direct file import (not the barrel) so we don't pull errorMessages' siblings
+// that import this file back. errorMessages.ts is import-free, so this is safe.
+import { CONTRACT_ERROR_MESSAGES } from "@/utils/errors/errorMessages";
+
 // Shared strings that legitimately appear in multiple places. Hoisting them
 // here prevents wording drift if one site is later reworded but the other is
 // missed.
@@ -628,7 +632,9 @@ export const COPY = {
       },
       activationDeadlinePassed: {
         title: "Activation deadline passed",
-        body: "The activation window has closed and this BTC Vault can no longer be activated. You can reclaim your BTC through the refund flow once it becomes available.",
+        // Reuse the canonical ABI-keyed message so this terminal callout can't
+        // drift from the ActivationDeadlineExpired contract-error string.
+        body: `${CONTRACT_ERROR_MESSAGES.ActivationDeadlineExpired} You can reclaim your BTC through the refund flow once it becomes available.`,
       },
       signingRejected: {
         title: "Signing rejected",

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -607,6 +607,8 @@ export const COPY = {
       // broadcast, so no funds are locked and the user can retry once it resumes.
       protocolPaused:
         "New deposits are temporarily disabled while the protocol is frozen or paused. No Bitcoin was sent — please try again once it resumes.",
+      cannotActivateInState: (state: string) =>
+        `Cannot activate: BTC Vault is in ${state} state. Activation is only valid when VERIFIED.`,
       chainSwitchRequired: (network: string) =>
         `Please switch to ${network} in your wallet`,
       ethereumMainnet: "Ethereum Mainnet",

--- a/services/vault/src/hooks/__tests__/useActivationDeadlineGate.test.ts
+++ b/services/vault/src/hooks/__tests__/useActivationDeadlineGate.test.ts
@@ -1,12 +1,32 @@
-import { describe, expect, it } from "vitest";
+import { OnChainBtcVaultStatus } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { zeroAddress } from "viem";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { ethClient } from "@/clients/eth-contract/client";
+import { getVaultRegistryReader } from "@/clients/eth-contract/sdk-readers";
 import {
   ContractStatus,
   PEGIN_DISPLAY_LABELS,
 } from "@/models/peginStateMachine";
 import type { VaultActivity } from "@/types/activity";
 
-import { getActivationDeadlineSuspects } from "../useActivationDeadlineGate";
+import {
+  getActivationDeadlineSuspects,
+  useActivationDeadlineGate,
+} from "../useActivationDeadlineGate";
+
+vi.mock("@/clients/eth-contract/client", () => ({
+  ethClient: { getPublicClient: vi.fn() },
+}));
+vi.mock("@/clients/eth-contract/sdk-readers", () => ({
+  getVaultRegistryReader: vi.fn(),
+}));
+
+const mockGetBlockNumber = vi.fn();
+const mockGetVaultBasicInfo = vi.fn();
 
 const TIMEOUT = 100n; // blocks
 // 12s slots → 100 blocks ≈ 1200s. Anchor "now" 2000s after creation so the
@@ -15,6 +35,13 @@ const TIMEOUT = 100n; // blocks
 const CREATED_MS = 1_000_000;
 const NOW_PAST_MS = CREATED_MS + 2_000_000;
 const NOW_WITHIN_MS = CREATED_MS + 60_000;
+
+// On-chain blocks for Tier-2: createdAt 1000 + timeout 100 → deadline block 1100.
+const CREATED_AT_BLOCK = 1_000n;
+const BLOCK_PAST_DEADLINE = 2_000n; // > 1100 → expired
+const BLOCK_WITHIN_WINDOW = 1_050n; // <= 1100 → not expired
+// A non-zero registered depositor so the zero-record guard doesn't skip it.
+const REGISTERED_DEPOSITOR = "0x00000000000000000000000000000000000000a1";
 
 function makeActivity(overrides: Partial<VaultActivity> = {}): VaultActivity {
   return {
@@ -29,6 +56,36 @@ function makeActivity(overrides: Partial<VaultActivity> = {}): VaultActivity {
     ...overrides,
   };
 }
+
+function makeBasicInfo(overrides: Record<string, unknown> = {}) {
+  return {
+    depositor: REGISTERED_DEPOSITOR,
+    createdAt: CREATED_AT_BLOCK,
+    status: OnChainBtcVaultStatus.VERIFIED,
+    ...overrides,
+  };
+}
+
+function queryWrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return createElement(QueryClientProvider, { client }, children);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(ethClient.getPublicClient).mockReturnValue({
+    getBlockNumber: mockGetBlockNumber,
+  } as unknown as ReturnType<typeof ethClient.getPublicClient>);
+  vi.mocked(getVaultRegistryReader).mockReturnValue({
+    getVaultBasicInfo: mockGetVaultBasicInfo,
+  } as unknown as ReturnType<typeof getVaultRegistryReader>);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
 
 describe("getActivationDeadlineSuspects", () => {
   it("flags a VERIFIED vault whose estimate is past the window", () => {
@@ -64,5 +121,95 @@ describe("getActivationDeadlineSuspects", () => {
         NOW_PAST_MS,
       ),
     ).toEqual([]);
+  });
+});
+
+describe("useActivationDeadlineGate (Tier-2 on-chain confirm)", () => {
+  it("gates a suspect confirmed past the deadline on chain", async () => {
+    mockGetBlockNumber.mockResolvedValue(BLOCK_PAST_DEADLINE);
+    mockGetVaultBasicInfo.mockResolvedValue(makeBasicInfo());
+    const activity = makeActivity();
+
+    const { result } = renderHook(
+      () => useActivationDeadlineGate([activity], TIMEOUT),
+      { wrapper: queryWrapper },
+    );
+
+    await waitFor(() =>
+      expect(result.current.has(activity.id.toLowerCase())).toBe(true),
+    );
+  });
+
+  it("does not gate when the chain no longer reports VERIFIED", async () => {
+    // Stale indexer VERIFIED row, but on chain the vault is already ACTIVE.
+    mockGetBlockNumber.mockResolvedValue(BLOCK_PAST_DEADLINE);
+    mockGetVaultBasicInfo.mockResolvedValue(
+      makeBasicInfo({ status: OnChainBtcVaultStatus.ACTIVE }),
+    );
+    const activity = makeActivity();
+
+    const { result } = renderHook(
+      () => useActivationDeadlineGate([activity], TIMEOUT),
+      { wrapper: queryWrapper },
+    );
+
+    await waitFor(() => expect(mockGetVaultBasicInfo).toHaveBeenCalled());
+    expect(result.current.has(activity.id.toLowerCase())).toBe(false);
+  });
+
+  it("does not gate a suspect still within the window on chain", async () => {
+    mockGetBlockNumber.mockResolvedValue(BLOCK_WITHIN_WINDOW);
+    mockGetVaultBasicInfo.mockResolvedValue(makeBasicInfo());
+    const activity = makeActivity();
+
+    const { result } = renderHook(
+      () => useActivationDeadlineGate([activity], TIMEOUT),
+      { wrapper: queryWrapper },
+    );
+
+    await waitFor(() => expect(mockGetVaultBasicInfo).toHaveBeenCalled());
+    expect(result.current.has(activity.id.toLowerCase())).toBe(false);
+  });
+
+  it("fails open (gates nothing) when the chain read throws", async () => {
+    mockGetBlockNumber.mockResolvedValue(BLOCK_PAST_DEADLINE);
+    mockGetVaultBasicInfo.mockRejectedValue(new Error("rpc down"));
+    const activity = makeActivity();
+
+    const { result } = renderHook(
+      () => useActivationDeadlineGate([activity], TIMEOUT),
+      { wrapper: queryWrapper },
+    );
+
+    await waitFor(() => expect(mockGetVaultBasicInfo).toHaveBeenCalled());
+    expect(result.current.size).toBe(0);
+  });
+
+  it("does not gate an unregistered (zero-address) record", async () => {
+    mockGetBlockNumber.mockResolvedValue(BLOCK_PAST_DEADLINE);
+    mockGetVaultBasicInfo.mockResolvedValue(
+      makeBasicInfo({ depositor: zeroAddress, createdAt: 0n }),
+    );
+    const activity = makeActivity();
+
+    const { result } = renderHook(
+      () => useActivationDeadlineGate([activity], TIMEOUT),
+      { wrapper: queryWrapper },
+    );
+
+    await waitFor(() => expect(mockGetVaultBasicInfo).toHaveBeenCalled());
+    expect(result.current.has(activity.id.toLowerCase())).toBe(false);
+  });
+
+  it("skips the chain read entirely when there are no Tier-1 suspects", () => {
+    const within = makeActivity({ timestamp: Date.now() });
+
+    const { result } = renderHook(
+      () => useActivationDeadlineGate([within], TIMEOUT),
+      { wrapper: queryWrapper },
+    );
+
+    expect(result.current.size).toBe(0);
+    expect(mockGetVaultBasicInfo).not.toHaveBeenCalled();
   });
 });

--- a/services/vault/src/hooks/__tests__/useActivationDeadlineGate.test.ts
+++ b/services/vault/src/hooks/__tests__/useActivationDeadlineGate.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ContractStatus,
+  PEGIN_DISPLAY_LABELS,
+} from "@/models/peginStateMachine";
+import type { VaultActivity } from "@/types/activity";
+
+import { getActivationDeadlineSuspects } from "../useActivationDeadlineGate";
+
+const TIMEOUT = 100n; // blocks
+// 12s slots → 100 blocks ≈ 1200s. Anchor "now" 2000s after creation so the
+// cheap estimate is well past the window; 60s after creation so it is well
+// within it.
+const CREATED_MS = 1_000_000;
+const NOW_PAST_MS = CREATED_MS + 2_000_000;
+const NOW_WITHIN_MS = CREATED_MS + 60_000;
+
+function makeActivity(overrides: Partial<VaultActivity> = {}): VaultActivity {
+  return {
+    id: `0x${"11".repeat(32)}`,
+    collateral: { amount: "1", symbol: "BTC" },
+    providers: [],
+    displayLabel: PEGIN_DISPLAY_LABELS.READY_TO_ACTIVATE,
+    unsignedPrePeginTx: "00",
+    depositorWotsPkHash: `0x${"00".repeat(32)}`,
+    contractStatus: ContractStatus.VERIFIED,
+    timestamp: CREATED_MS,
+    ...overrides,
+  };
+}
+
+describe("getActivationDeadlineSuspects", () => {
+  it("flags a VERIFIED vault whose estimate is past the window", () => {
+    const suspects = getActivationDeadlineSuspects(
+      [makeActivity()],
+      TIMEOUT,
+      NOW_PAST_MS,
+    );
+    expect(suspects).toEqual([makeActivity().id]);
+  });
+
+  it("does not flag a VERIFIED vault still well within the window", () => {
+    expect(
+      getActivationDeadlineSuspects([makeActivity()], TIMEOUT, NOW_WITHIN_MS),
+    ).toEqual([]);
+  });
+
+  it("ignores non-VERIFIED vaults even if the estimate is past the window", () => {
+    expect(
+      getActivationDeadlineSuspects(
+        [makeActivity({ contractStatus: ContractStatus.ACTIVE })],
+        TIMEOUT,
+        NOW_PAST_MS,
+      ),
+    ).toEqual([]);
+  });
+
+  it("does not flag a vault with no indexer timestamp (fail-safe)", () => {
+    expect(
+      getActivationDeadlineSuspects(
+        [makeActivity({ timestamp: undefined })],
+        TIMEOUT,
+        NOW_PAST_MS,
+      ),
+    ).toEqual([]);
+  });
+});

--- a/services/vault/src/hooks/__tests__/useActivationDeadlineGate.test.ts
+++ b/services/vault/src/hooks/__tests__/useActivationDeadlineGate.test.ts
@@ -1,12 +1,15 @@
 import { OnChainBtcVaultStatus } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { createElement, type ReactNode } from "react";
 import { zeroAddress } from "viem";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ethClient } from "@/clients/eth-contract/client";
-import { getVaultRegistryReader } from "@/clients/eth-contract/sdk-readers";
+import {
+  getProtocolParamsReader,
+  getVaultRegistryReader,
+} from "@/clients/eth-contract/sdk-readers";
 import {
   ContractStatus,
   PEGIN_DISPLAY_LABELS,
@@ -23,10 +26,12 @@ vi.mock("@/clients/eth-contract/client", () => ({
 }));
 vi.mock("@/clients/eth-contract/sdk-readers", () => ({
   getVaultRegistryReader: vi.fn(),
+  getProtocolParamsReader: vi.fn(),
 }));
 
 const mockGetBlockNumber = vi.fn();
 const mockGetVaultBasicInfo = vi.fn();
+const mockGetTBVProtocolParams = vi.fn();
 
 const TIMEOUT = 100n; // blocks
 // 12s slots → 100 blocks ≈ 1200s. Anchor "now" 2000s after creation so the
@@ -81,6 +86,14 @@ beforeEach(() => {
   vi.mocked(getVaultRegistryReader).mockReturnValue({
     getVaultBasicInfo: mockGetVaultBasicInfo,
   } as unknown as ReturnType<typeof getVaultRegistryReader>);
+  // Tier-2 reads the timeout from chain; default it to agree with the cached
+  // copy unless a test deliberately diverges them.
+  mockGetTBVProtocolParams.mockResolvedValue({
+    pegInActivationTimeout: TIMEOUT,
+  });
+  vi.mocked(getProtocolParamsReader).mockResolvedValue({
+    getTBVProtocolParams: mockGetTBVProtocolParams,
+  } as unknown as Awaited<ReturnType<typeof getProtocolParamsReader>>);
 });
 
 afterEach(() => {
@@ -138,6 +151,80 @@ describe("useActivationDeadlineGate (Tier-2 on-chain confirm)", () => {
     await waitFor(() =>
       expect(result.current.has(activity.id.toLowerCase())).toBe(true),
     );
+  });
+
+  it("does not gate when the live on-chain timeout is longer than the cached one", async () => {
+    // Governance raised the timeout (100 → 200) after this tab cached it. At
+    // createdAt+150 the vault is expired under the stale value, live under the
+    // real one — gating here would lock out an activation the chain accepts.
+    mockGetBlockNumber.mockResolvedValue(CREATED_AT_BLOCK + 150n);
+    mockGetVaultBasicInfo.mockResolvedValue(makeBasicInfo());
+    mockGetTBVProtocolParams.mockResolvedValue({
+      pegInActivationTimeout: 200n,
+    });
+    const activity = makeActivity();
+
+    const { result } = renderHook(
+      // Stale cached timeout, as the provider had it at page load.
+      () => useActivationDeadlineGate([activity], TIMEOUT),
+      { wrapper: queryWrapper },
+    );
+
+    await waitFor(() => expect(mockGetVaultBasicInfo).toHaveBeenCalled());
+    expect(result.current.has(activity.id.toLowerCase())).toBe(false);
+  });
+
+  it("gates on the live on-chain timeout even when the cached one is too large", async () => {
+    // Mirror case: governance shortened the window, so the vault IS expired.
+    mockGetBlockNumber.mockResolvedValue(CREATED_AT_BLOCK + 150n);
+    mockGetVaultBasicInfo.mockResolvedValue(makeBasicInfo());
+    mockGetTBVProtocolParams.mockResolvedValue({
+      pegInActivationTimeout: 100n,
+    });
+    const activity = makeActivity();
+
+    const { result } = renderHook(
+      // Cached value is generous enough that Tier-1 still suspects it.
+      () => useActivationDeadlineGate([activity], 200n),
+      { wrapper: queryWrapper },
+    );
+
+    await waitFor(() =>
+      expect(result.current.has(activity.id.toLowerCase())).toBe(true),
+    );
+  });
+
+  it("fails open when the chain reports no activation timeout", async () => {
+    mockGetBlockNumber.mockResolvedValue(BLOCK_PAST_DEADLINE);
+    mockGetVaultBasicInfo.mockResolvedValue(makeBasicInfo());
+    mockGetTBVProtocolParams.mockResolvedValue({ pegInActivationTimeout: 0n });
+    const activity = makeActivity();
+
+    const { result } = renderHook(
+      () => useActivationDeadlineGate([activity], TIMEOUT),
+      { wrapper: queryWrapper },
+    );
+
+    await waitFor(() => expect(mockGetTBVProtocolParams).toHaveBeenCalled());
+    expect(result.current.size).toBe(0);
+  });
+
+  it("fails open when the live timeout read throws (never gates on stale data)", async () => {
+    // A block/params read failure must return an empty set, not reject — a
+    // rejection would let React Query keep a prior gated set on a background
+    // refetch, holding a vault gated through a governance-raise + RPC outage.
+    mockGetBlockNumber.mockResolvedValue(BLOCK_PAST_DEADLINE);
+    mockGetVaultBasicInfo.mockResolvedValue(makeBasicInfo());
+    mockGetTBVProtocolParams.mockRejectedValue(new Error("params rpc down"));
+    const activity = makeActivity();
+
+    const { result } = renderHook(
+      () => useActivationDeadlineGate([activity], TIMEOUT),
+      { wrapper: queryWrapper },
+    );
+
+    await waitFor(() => expect(mockGetTBVProtocolParams).toHaveBeenCalled());
+    expect(result.current.size).toBe(0);
   });
 
   it("does not gate when the chain no longer reports VERIFIED", async () => {
@@ -211,5 +298,46 @@ describe("useActivationDeadlineGate (Tier-2 on-chain confirm)", () => {
 
     expect(result.current.size).toBe(0);
     expect(mockGetVaultBasicInfo).not.toHaveBeenCalled();
+  });
+});
+
+describe("useActivationDeadlineGate (Tier-1 clock)", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("re-evaluates as time passes, even when the activities array keeps a stable identity", async () => {
+    // Structural sharing hands back the same `activities` reference for an idle
+    // vault, so a clock read keyed only on it would pin to mount time forever.
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW_WITHIN_MS);
+    mockGetBlockNumber.mockResolvedValue(BLOCK_PAST_DEADLINE);
+    mockGetVaultBasicInfo.mockResolvedValue(makeBasicInfo());
+
+    // One array, one identity — never replaced.
+    const activities = [makeActivity()];
+
+    const { result } = renderHook(
+      () => useActivationDeadlineGate(activities, TIMEOUT),
+      { wrapper: queryWrapper },
+    );
+
+    // Inside the window: no suspects, so Tier-2 never runs.
+    expect(mockGetVaultBasicInfo).not.toHaveBeenCalled();
+    expect(result.current.size).toBe(0);
+
+    // Deadline crosses while the tab sits idle; only the clock can notice.
+    await act(async () => {
+      vi.setSystemTime(NOW_PAST_MS);
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+    // Timers are frozen, so `waitFor` can't settle — drive the microtasks.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    // The tick re-ran Tier-1, enabling the Tier-2 read. Before the fix: never.
+    expect(mockGetVaultBasicInfo).toHaveBeenCalled();
+    expect(result.current.has(activities[0].id.toLowerCase())).toBe(true);
   });
 });

--- a/services/vault/src/hooks/deposit/useActivationState.ts
+++ b/services/vault/src/hooks/deposit/useActivationState.ts
@@ -32,6 +32,8 @@ export interface UseActivationStateResult {
   activated: boolean;
   /** Error message if activation failed */
   error: string | null;
+  /** True when the error is terminal (activation deadline passed) — no Retry. */
+  errorTerminal: boolean;
   /** Handler to initiate activation with the user-entered secret */
   handleActivation: (secretHex: string) => Promise<void>;
 }
@@ -43,6 +45,7 @@ export function useActivationState({
   const {
     activating: vaultActivating,
     activationError,
+    activationErrorTerminal,
     handleActivation: vaultHandleActivation,
   } = useVaultActions();
   const [localActivating, setLocalActivating] = useState(false);
@@ -130,6 +133,7 @@ export function useActivationState({
     activating: isActivating,
     activated,
     error: activationError,
+    errorTerminal: activationErrorTerminal,
     handleActivation,
   };
 }

--- a/services/vault/src/hooks/deposit/useVaultActions.ts
+++ b/services/vault/src/hooks/deposit/useVaultActions.ts
@@ -435,7 +435,7 @@ export function useVaultActions(): UseVaultActionsReturn {
         const label =
           OnChainBtcVaultStatus[basicInfo.status] ??
           `UNKNOWN(${basicInfo.status})`;
-        const message = `Cannot activate: BTC Vault is in ${label} state. Activation is only valid when VERIFIED.`;
+        const message = COPY.deposit.errors.cannotActivateInState(label);
         // EXPIRED is terminal — retrying can't revert the status to VERIFIED.
         // Other non-VERIFIED states (e.g. still-PENDING verification) stay
         // retryable, so only EXPIRED suppresses Retry.

--- a/services/vault/src/hooks/deposit/useVaultActions.ts
+++ b/services/vault/src/hooks/deposit/useVaultActions.ts
@@ -34,6 +34,10 @@ import { COPY } from "@/copy";
 import { useProtocolGateState } from "@/hooks/useProtocolGate";
 import { logger } from "@/infrastructure";
 import { shortId, TELEMETRY_EVENT } from "@/infrastructure/telemetryEvents";
+import {
+  ActivationNotPossibleError,
+  isTerminalActivationError,
+} from "@/utils/errors";
 
 import { getVaultFromChain } from "../../clients/eth-contract/btc-vault-registry/query";
 import { getOnChainPauseState } from "../../clients/eth-contract/pause-state/query";
@@ -99,6 +103,8 @@ export interface UseVaultActionsReturn {
   // Activation state
   activating: boolean;
   activationError: string | null;
+  /** True when the activation failure is terminal (deadline passed) — no Retry. */
+  activationErrorTerminal: boolean;
   handleActivation: (params: ActivateVaultParams) => Promise<void>;
 }
 
@@ -115,6 +121,7 @@ export function useVaultActions(): UseVaultActionsReturn {
   // Activation state
   const [activating, setActivating] = useState(false);
   const [activationError, setActivationError] = useState<string | null>(null);
+  const [activationErrorTerminal, setActivationErrorTerminal] = useState(false);
 
   // Track mount: both handleBroadcast and handleActivation await slow
   // on-chain work and then setState. The consumer (Resume*Content inside
@@ -380,6 +387,7 @@ export function useVaultActions(): UseVaultActionsReturn {
 
     setActivating(true);
     setActivationError(null);
+    setActivationErrorTerminal(false);
 
     try {
       // Read basic + protocol info in one parallel call. Indexer is
@@ -427,9 +435,14 @@ export function useVaultActions(): UseVaultActionsReturn {
         const label =
           OnChainBtcVaultStatus[basicInfo.status] ??
           `UNKNOWN(${basicInfo.status})`;
-        throw new Error(
-          `Cannot activate: BTC Vault is in ${label} state. Activation is only valid when VERIFIED.`,
-        );
+        const message = `Cannot activate: BTC Vault is in ${label} state. Activation is only valid when VERIFIED.`;
+        // EXPIRED is terminal — retrying can't revert the status to VERIFIED.
+        // Other non-VERIFIED states (e.g. still-PENDING verification) stay
+        // retryable, so only EXPIRED suppresses Retry.
+        if (basicInfo.status === OnChainBtcVaultStatus.EXPIRED) {
+          throw new ActivationNotPossibleError(message);
+        }
+        throw new Error(message);
       }
 
       // Validate secret against hashlock before sending ETH tx.
@@ -496,6 +509,9 @@ export function useVaultActions(): UseVaultActionsReturn {
           ? "BTC Vault not found. The BTC Vault ID may be invalid."
           : rawMessage;
         setActivationError(errorMessage);
+        // Classify from the typed error before it is flattened to a string — a
+        // passed deadline or an already-EXPIRED vault is terminal (no Retry).
+        setActivationErrorTerminal(isTerminalActivationError(err));
         setActivating(false);
       }
     }
@@ -507,6 +523,7 @@ export function useVaultActions(): UseVaultActionsReturn {
     handleBroadcast,
     activating,
     activationError,
+    activationErrorTerminal,
     handleActivation,
   };
 }

--- a/services/vault/src/hooks/useActivationDeadlineGate.ts
+++ b/services/vault/src/hooks/useActivationDeadlineGate.ts
@@ -9,6 +9,7 @@
 // Only a confirmed TRUE gates the Activate CTA. Any RPC error, missing param, or
 // vault-not-yet-on-chain leaves the vault ungated (fail-safe).
 
+import { OnChainBtcVaultStatus } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
 import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
 import { type Hex, zeroAddress } from "viem";
@@ -123,6 +124,10 @@ export function useActivationDeadlineGate(
         const { id, info } = entry;
         // Unregistered / zero record → can't trust createdAt; don't gate.
         if (info.depositor === zeroAddress || info.createdAt === 0n) continue;
+        // Gate only vaults the chain still reports VERIFIED. A stale indexer
+        // VERIFIED row for an already-ACTIVE/REDEEMED/EXPIRED vault must not be
+        // badged Expired from the deadline alone.
+        if (info.status !== OnChainBtcVaultStatus.VERIFIED) continue;
         if (
           isActivationDeadlinePassedOnChain({
             currentBlock,

--- a/services/vault/src/hooks/useActivationDeadlineGate.ts
+++ b/services/vault/src/hooks/useActivationDeadlineGate.ts
@@ -10,6 +10,7 @@
 // vault-not-yet-on-chain leaves the vault ungated (fail-safe).
 
 import { OnChainBtcVaultStatus } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
+import { isActivationDeadlinePassedOnChain } from "@babylonlabs-io/ts-sdk/tbv/core/services";
 import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
 import { type Hex, zeroAddress } from "viem";
@@ -18,10 +19,7 @@ import { ethClient } from "@/clients/eth-contract/client";
 import { getVaultRegistryReader } from "@/clients/eth-contract/sdk-readers";
 import { ContractStatus } from "@/models/peginStateMachine";
 import type { VaultActivity } from "@/types/activity";
-import {
-  estimateActivationDeadlineLikelyPassed,
-  isActivationDeadlinePassedOnChain,
-} from "@/utils/activationDeadline";
+import { estimateActivationDeadlineLikelyPassed } from "@/utils/activationDeadline";
 
 const ACTIVATION_DEADLINE_QUERY_KEY = "activationDeadlineOnChain";
 // Refresh on the dashboard cadence; the gate moves slowly (deadline is measured

--- a/services/vault/src/hooks/useActivationDeadlineGate.ts
+++ b/services/vault/src/hooks/useActivationDeadlineGate.ts
@@ -1,0 +1,157 @@
+// Tiered activation-deadline gate for VERIFIED vaults (UX only — the contract
+// is the real gate and reverts ActivationDeadlineExpired).
+//
+// Tier 1 (no RPC): the indexer createdAt timestamp + slot time give an UPPER
+// bound on elapsed blocks; only vaults the cheap estimate flags as MAYBE past
+// the window are escalated.
+// Tier 2 (suspects only): one current-block read per refresh + each suspect's
+// authoritative on-chain createdAt block, then `isActivationDeadlinePassedOnChain`.
+// Only a confirmed TRUE gates the Activate CTA. Any RPC error, missing param, or
+// vault-not-yet-on-chain leaves the vault ungated (fail-safe).
+
+import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+import { type Hex, zeroAddress } from "viem";
+
+import { ethClient } from "@/clients/eth-contract/client";
+import { getVaultRegistryReader } from "@/clients/eth-contract/sdk-readers";
+import { ContractStatus } from "@/models/peginStateMachine";
+import type { VaultActivity } from "@/types/activity";
+import {
+  estimateActivationDeadlineLikelyPassed,
+  isActivationDeadlinePassedOnChain,
+} from "@/utils/activationDeadline";
+
+const ACTIVATION_DEADLINE_QUERY_KEY = "activationDeadlineOnChain";
+// Refresh on the dashboard cadence; the gate moves slowly (deadline is measured
+// in blocks) so a once-a-minute confirm is ample.
+const POLL_INTERVAL_MS = 60 * 1000;
+// Just under the poll interval so refocus/remount doesn't double-fetch.
+const STALE_TIME_MS = 55 * 1000;
+
+const EMPTY_SET: ReadonlySet<string> = new Set();
+
+/**
+ * Tier-1 suspects: VERIFIED vaults whose cheap, no-RPC estimate says the
+ * activation window MAY have closed. A vault with no indexer timestamp can't be
+ * estimated, so it is not flagged (fail-safe — left activatable).
+ */
+export function getActivationDeadlineSuspects(
+  activities: VaultActivity[],
+  pegInActivationTimeout: bigint,
+  nowMs: number,
+): Hex[] {
+  const suspects: Hex[] = [];
+  for (const activity of activities) {
+    if ((activity.contractStatus ?? 0) !== ContractStatus.VERIFIED) continue;
+    if (activity.timestamp === undefined) continue;
+    if (
+      estimateActivationDeadlineLikelyPassed({
+        createdAtMs: activity.timestamp,
+        nowMs,
+        pegInActivationTimeout,
+      })
+    ) {
+      suspects.push(activity.id);
+    }
+  }
+  return suspects;
+}
+
+/**
+ * Lowercased ids of VERIFIED vaults confirmed (on chain) past their activation
+ * deadline. An absent id means "not gated" — the set is empty until a Tier-2
+ * read confirms, and stays empty on any RPC error or missing param (fail-safe).
+ */
+export function useActivationDeadlineGate(
+  activities: VaultActivity[],
+  pegInActivationTimeout: bigint | undefined,
+): ReadonlySet<string> {
+  // Tier 1: cheap suspect filter. Recomputes when activities refresh (the
+  // dashboard re-polls the indexer), advancing the `Date.now()` anchor.
+  const suspectIds = useMemo(() => {
+    if (!pegInActivationTimeout) return [];
+    return getActivationDeadlineSuspects(
+      activities,
+      pegInActivationTimeout,
+      Date.now(),
+    ).sort();
+  }, [activities, pegInActivationTimeout]);
+
+  // Timeout is part of the key: a governance change to pegInActivationTimeout
+  // must invalidate any cached on-chain confirmation computed under the old one.
+  const queryKey = useMemo(
+    () =>
+      [
+        ACTIVATION_DEADLINE_QUERY_KEY,
+        pegInActivationTimeout?.toString() ?? "none",
+        suspectIds.join(","),
+      ] as const,
+    [pegInActivationTimeout, suspectIds],
+  );
+
+  const query = useQuery({
+    queryKey,
+    enabled: suspectIds.length > 0 && pegInActivationTimeout !== undefined,
+    refetchInterval: POLL_INTERVAL_MS,
+    staleTime: STALE_TIME_MS,
+    // No placeholderData: when the suspect set or timeout changes the key, the
+    // gate must FAIL OPEN (no data → nothing gated) until Tier-2 reconfirms,
+    // rather than carry a confirmation computed under the old inputs — which
+    // could briefly lock out a now-valid vault. Background refetches on an
+    // unchanged key keep their data, so steady-state gating doesn't flicker.
+    queryFn: async (): Promise<Set<string>> => {
+      // Re-checked so the closure can't gate on a missing param.
+      if (!pegInActivationTimeout) return new Set();
+      const reader = getVaultRegistryReader();
+      // One current-block read per refresh, shared by every suspect.
+      const currentBlock = await ethClient.getPublicClient().getBlockNumber();
+      // Parallel reads coalesce into one Multicall3 round-trip (client batch).
+      const infos = await Promise.all(
+        suspectIds.map(async (id) => {
+          try {
+            return { id, info: await reader.getVaultBasicInfo(id) };
+          } catch {
+            // Vault not yet on chain / transient RPC error → don't gate.
+            return null;
+          }
+        }),
+      );
+      const passed = new Set<string>();
+      for (const entry of infos) {
+        if (!entry) continue;
+        const { id, info } = entry;
+        // Unregistered / zero record → can't trust createdAt; don't gate.
+        if (info.depositor === zeroAddress || info.createdAt === 0n) continue;
+        if (
+          isActivationDeadlinePassedOnChain({
+            currentBlock,
+            createdAtBlock: info.createdAt,
+            pegInActivationTimeout,
+          })
+        ) {
+          passed.add(id.toLowerCase());
+        }
+      }
+      return passed;
+    },
+  });
+
+  // Invariant guard: gate only vaults that are STILL current Tier-1 suspects.
+  // A vault Tier-1 no longer flags is definitely within the window (the estimate
+  // is an upper bound on elapsed blocks), so intersecting with the live suspect
+  // set ensures a confirmation can never outlive Tier-1 suspicion — e.g. data
+  // React Query retains for a key while the query is disabled.
+  const confirmed = query.data;
+  return useMemo(() => {
+    if (!confirmed || confirmed.size === 0 || suspectIds.length === 0) {
+      return EMPTY_SET;
+    }
+    const currentSuspects = new Set(suspectIds.map((id) => id.toLowerCase()));
+    const gated = new Set<string>();
+    for (const id of confirmed) {
+      if (currentSuspects.has(id)) gated.add(id);
+    }
+    return gated;
+  }, [confirmed, suspectIds]);
+}

--- a/services/vault/src/hooks/useActivationDeadlineGate.ts
+++ b/services/vault/src/hooks/useActivationDeadlineGate.ts
@@ -4,19 +4,21 @@
 // Tier 1 (no RPC): the indexer createdAt timestamp + slot time give an UPPER
 // bound on elapsed blocks; only vaults the cheap estimate flags as MAYBE past
 // the window are escalated.
-// Tier 2 (suspects only): one current-block read per refresh + each suspect's
-// authoritative on-chain createdAt block, then `isActivationDeadlinePassedOnChain`.
-// Only a confirmed TRUE gates the Activate CTA. Any RPC error, missing param, or
-// vault-not-yet-on-chain leaves the vault ungated (fail-safe).
+// Tier 2 (suspects only): every input — current block, live timeout, on-chain
+// createdAt — is read from chain, so the gate can never be stricter than the
+// contract. Only a confirmed TRUE gates Activate; any error leaves it ungated.
 
 import { OnChainBtcVaultStatus } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
 import { isActivationDeadlinePassedOnChain } from "@babylonlabs-io/ts-sdk/tbv/core/services";
 import { useQuery } from "@tanstack/react-query";
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { type Hex, zeroAddress } from "viem";
 
 import { ethClient } from "@/clients/eth-contract/client";
-import { getVaultRegistryReader } from "@/clients/eth-contract/sdk-readers";
+import {
+  getProtocolParamsReader,
+  getVaultRegistryReader,
+} from "@/clients/eth-contract/sdk-readers";
 import { ContractStatus } from "@/models/peginStateMachine";
 import type { VaultActivity } from "@/types/activity";
 import { estimateActivationDeadlineLikelyPassed } from "@/utils/activationDeadline";
@@ -27,6 +29,9 @@ const ACTIVATION_DEADLINE_QUERY_KEY = "activationDeadlineOnChain";
 const POLL_INTERVAL_MS = 60 * 1000;
 // Just under the poll interval so refocus/remount doesn't double-fetch.
 const STALE_TIME_MS = 55 * 1000;
+// Tier-1's `now` must advance on a clock, not on data identity: an idle VERIFIED
+// vault's payload stops changing, so `activities` keeps a stable reference.
+const TIER1_CLOCK_TICK_MS = POLL_INTERVAL_MS;
 
 const EMPTY_SET: ReadonlySet<string> = new Set();
 
@@ -66,16 +71,31 @@ export function useActivationDeadlineGate(
   activities: VaultActivity[],
   pegInActivationTimeout: bigint | undefined,
 ): ReadonlySet<string> {
-  // Tier 1: cheap suspect filter. Recomputes when activities refresh (the
-  // dashboard re-polls the indexer), advancing the `Date.now()` anchor.
-  const suspectIds = useMemo(() => {
-    if (!pegInActivationTimeout) return [];
+  const [nowMs, setNowMs] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNowMs(Date.now()), TIER1_CLOCK_TICK_MS);
+    return () => clearInterval(id);
+  }, []);
+
+  // Tier 1: cheap suspect filter on the CACHED timeout — fine because Tier-2
+  // re-checks every suspect against the live value; a stale cache only ever
+  // under-suspects (fail-open), never gates. Joined so an unchanged suspect set
+  // keeps a stable identity across clock ticks (no downstream re-render storm).
+  const suspectKey = useMemo(() => {
+    if (!pegInActivationTimeout) return "";
     return getActivationDeadlineSuspects(
       activities,
       pegInActivationTimeout,
-      Date.now(),
-    ).sort();
-  }, [activities, pegInActivationTimeout]);
+      nowMs,
+    )
+      .sort()
+      .join(",");
+  }, [activities, pegInActivationTimeout, nowMs]);
+
+  const suspectIds = useMemo(
+    () => (suspectKey ? (suspectKey.split(",") as Hex[]) : []),
+    [suspectKey],
+  );
 
   // Timeout is part of the key: a governance change to pegInActivationTimeout
   // must invalidate any cached on-chain confirmation computed under the old one.
@@ -84,9 +104,9 @@ export function useActivationDeadlineGate(
       [
         ACTIVATION_DEADLINE_QUERY_KEY,
         pegInActivationTimeout?.toString() ?? "none",
-        suspectIds.join(","),
+        suspectKey,
       ] as const,
-    [pegInActivationTimeout, suspectIds],
+    [pegInActivationTimeout, suspectKey],
   );
 
   const query = useQuery({
@@ -100,43 +120,56 @@ export function useActivationDeadlineGate(
     // could briefly lock out a now-valid vault. Background refetches on an
     // unchanged key keep their data, so steady-state gating doesn't flicker.
     queryFn: async (): Promise<Set<string>> => {
-      // Re-checked so the closure can't gate on a missing param.
-      if (!pegInActivationTimeout) return new Set();
-      const reader = getVaultRegistryReader();
-      // One current-block read per refresh, shared by every suspect.
-      const currentBlock = await ethClient.getPublicClient().getBlockNumber();
-      // Parallel reads coalesce into one Multicall3 round-trip (client batch).
-      const infos = await Promise.all(
-        suspectIds.map(async (id) => {
-          try {
-            return { id, info: await reader.getVaultBasicInfo(id) };
-          } catch {
-            // Vault not yet on chain / transient RPC error → don't gate.
-            return null;
+      try {
+        const reader = getVaultRegistryReader();
+        const paramsReader = await getProtocolParamsReader();
+        // The timeout is governance-mutable and the registry reads it live, so a
+        // page-load-cached copy could gate a vault the contract would accept.
+        const [currentBlock, tbvParams] = await Promise.all([
+          ethClient.getPublicClient().getBlockNumber(),
+          paramsReader.getTBVProtocolParams(),
+        ]);
+        const liveActivationTimeout = tbvParams.pegInActivationTimeout;
+        if (!liveActivationTimeout) return new Set();
+        // The per-suspect reads coalesce into one Multicall3 round-trip (client
+        // batch); the block/params reads above are a separate round-trip.
+        const infos = await Promise.all(
+          suspectIds.map(async (id) => {
+            try {
+              return { id, info: await reader.getVaultBasicInfo(id) };
+            } catch {
+              // Vault not yet on chain / transient RPC error → don't gate.
+              return null;
+            }
+          }),
+        );
+        const passed = new Set<string>();
+        for (const entry of infos) {
+          if (!entry) continue;
+          const { id, info } = entry;
+          // Unregistered / zero record → can't trust createdAt; don't gate.
+          if (info.depositor === zeroAddress || info.createdAt === 0n) continue;
+          // Gate only vaults the chain still reports VERIFIED. A stale indexer
+          // VERIFIED row for an already-ACTIVE/REDEEMED/EXPIRED vault must not be
+          // badged Expired from the deadline alone.
+          if (info.status !== OnChainBtcVaultStatus.VERIFIED) continue;
+          if (
+            isActivationDeadlinePassedOnChain({
+              currentBlock,
+              createdAtBlock: info.createdAt,
+              pegInActivationTimeout: liveActivationTimeout,
+            })
+          ) {
+            passed.add(id.toLowerCase());
           }
-        }),
-      );
-      const passed = new Set<string>();
-      for (const entry of infos) {
-        if (!entry) continue;
-        const { id, info } = entry;
-        // Unregistered / zero record → can't trust createdAt; don't gate.
-        if (info.depositor === zeroAddress || info.createdAt === 0n) continue;
-        // Gate only vaults the chain still reports VERIFIED. A stale indexer
-        // VERIFIED row for an already-ACTIVE/REDEEMED/EXPIRED vault must not be
-        // badged Expired from the deadline alone.
-        if (info.status !== OnChainBtcVaultStatus.VERIFIED) continue;
-        if (
-          isActivationDeadlinePassedOnChain({
-            currentBlock,
-            createdAtBlock: info.createdAt,
-            pegInActivationTimeout,
-          })
-        ) {
-          passed.add(id.toLowerCase());
         }
+        return passed;
+      } catch {
+        // Block/params read failed. Reject would let React Query retain the
+        // prior (possibly stale) gated set on a background refetch; return empty
+        // so any read failure fails OPEN, never gating a now-valid vault.
+        return new Set();
       }
-      return passed;
     },
   });
 

--- a/services/vault/src/models/__tests__/peginStateMachine.test.ts
+++ b/services/vault/src/models/__tests__/peginStateMachine.test.ts
@@ -264,6 +264,28 @@ describe("peginStateMachine", () => {
       expect(state.displayLabel).toBe(PEGIN_DISPLAY_LABELS.PROCESSING);
       expect(state.availableActions).toEqual([PeginAction.NONE]);
     });
+
+    it("gates Activate as expired when the activation deadline passed on-chain", () => {
+      const state = getPeginState(ContractStatus.VERIFIED, {
+        activationDeadlinePassed: true,
+      });
+      expect(state.availableActions).toEqual([PeginAction.NONE]);
+      expect(state.availableActions).not.toContain(PeginAction.ACTIVATE_VAULT);
+      expect(state.displayLabel).toBe(PEGIN_DISPLAY_LABELS.EXPIRED);
+      expect(state.displayVariant).toBe("warning");
+      expect(state.message).toContain("not activated in time");
+      expect(getPrimaryActionButton(state)).toBeNull();
+      // warning variant → no progress step
+      expect(getPeginDisplayStep(state)).toBeNull();
+    });
+
+    it("keeps Activate available when the deadline has not passed", () => {
+      const state = getPeginState(ContractStatus.VERIFIED, {
+        activationDeadlinePassed: false,
+      });
+      expect(state.availableActions).toContain(PeginAction.ACTIVATE_VAULT);
+      expect(state.displayLabel).toBe(PEGIN_DISPLAY_LABELS.READY_TO_ACTIVATE);
+    });
   });
 
   // ==========================================================================

--- a/services/vault/src/models/peginStateMachine.ts
+++ b/services/vault/src/models/peginStateMachine.ts
@@ -137,6 +137,14 @@ export interface GetPeginStateOptions {
   expirationReason?: ExpirationReason;
   expiredAt?: number;
   /**
+   * VERIFIED only: the on-chain activation window has closed
+   * (`block.number > createdAt + pegInActivationTimeout`), so
+   * `activateVaultWithSecret` would revert ActivationDeadlineExpired.
+   * Confirmed by an authoritative chain read; a UX-only gate that strips
+   * ACTIVATE_VAULT and flips the badge to Expired. Fail-safe default: false.
+   */
+  activationDeadlinePassed?: boolean;
+  /**
    * True only when the deposit can be refunded *now*: the Pre-PegIn tx
    * exists AND the HTLC CSV timelock (`tRefund`) has elapsed. The
    * frontend computes this composite — the SDK-level protocol state
@@ -368,7 +376,16 @@ export function getPeginState(
           (a) => a !== SdkPeginAction.SIGN_AND_BROADCAST_TO_BITCOIN,
         )
       : sdkActions;
-  const actions = mapActions(chainAdjustedActions);
+  // VERIFIED past its on-chain activation deadline: the contract would revert
+  // ActivationDeadlineExpired, so strip the now-futile Activate action. UX only
+  // — confirmed by an authoritative chain read; missing/error data leaves the
+  // action in place (fail-safe). Mirrors the broadcast filter above.
+  const deadlineAdjustedActions =
+    contractStatus === ContractStatus.VERIFIED &&
+    options.activationDeadlinePassed === true
+      ? chainAdjustedActions.filter((a) => a !== SdkPeginAction.ACTIVATE_VAULT)
+      : chainAdjustedActions;
+  const actions = mapActions(deadlineAdjustedActions);
   const display = getDisplay(contractStatus, actions, options);
 
   return {
@@ -575,6 +592,16 @@ function getDisplay(
         displayLabel: PEGIN_DISPLAY_LABELS.PROCESSING,
         displayVariant: "pending",
         message: COPY.pegin.messages.activationSubmitted,
+      };
+    }
+    // Activation window closed on-chain — present as terminal-expired in place
+    // (the indexer flips to EXPIRED later). `warning` variant also suppresses
+    // the progress step via getPeginDisplayStep.
+    if (options.activationDeadlinePassed) {
+      return {
+        displayLabel: PEGIN_DISPLAY_LABELS.EXPIRED,
+        displayVariant: "warning",
+        message: buildExpiredMessage("activation_timeout", expiredAt),
       };
     }
     return {

--- a/services/vault/src/utils/__tests__/activationDeadline.test.ts
+++ b/services/vault/src/utils/__tests__/activationDeadline.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ETH_SLOT_SECONDS,
+  estimateActivationDeadlineLikelyPassed,
+  isActivationDeadlinePassedOnChain,
+} from "../activationDeadline";
+
+describe("isActivationDeadlinePassedOnChain", () => {
+  it("treats the boundary block (current == created + timeout) as NOT expired", () => {
+    expect(
+      isActivationDeadlinePassedOnChain({
+        currentBlock: 1100n,
+        createdAtBlock: 1000n,
+        pegInActivationTimeout: 100n,
+      }),
+    ).toBe(false);
+  });
+
+  it("treats one block past the boundary as expired", () => {
+    expect(
+      isActivationDeadlinePassedOnChain({
+        currentBlock: 1101n,
+        createdAtBlock: 1000n,
+        pegInActivationTimeout: 100n,
+      }),
+    ).toBe(true);
+  });
+
+  it("treats a block below the boundary as NOT expired", () => {
+    expect(
+      isActivationDeadlinePassedOnChain({
+        currentBlock: 1050n,
+        createdAtBlock: 1000n,
+        pegInActivationTimeout: 100n,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("estimateActivationDeadlineLikelyPassed", () => {
+  it("returns false when well within the window", () => {
+    // 120s elapsed at 12s/slot = 10 blocks, far below the 100-block timeout.
+    expect(
+      estimateActivationDeadlineLikelyPassed({
+        createdAtMs: 1_000_000,
+        nowMs: 1_120_000,
+        pegInActivationTimeout: 100n,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true when the estimate is past the window", () => {
+    // 1320s elapsed at 12s/slot = 110 blocks, above the 100-block timeout.
+    expect(
+      estimateActivationDeadlineLikelyPassed({
+        createdAtMs: 1_000_000,
+        nowMs: 2_320_000,
+        pegInActivationTimeout: 100n,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false at exactly one block under the threshold", () => {
+    // 1188s elapsed at 12s/slot = 99 blocks, one below the 100-block timeout.
+    expect(
+      estimateActivationDeadlineLikelyPassed({
+        createdAtMs: 1_000_000,
+        nowMs: 2_188_000,
+        pegInActivationTimeout: 100n,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true at exactly the threshold", () => {
+    // 1200s elapsed at 12s/slot = 100 blocks, equal to the 100-block timeout.
+    expect(
+      estimateActivationDeadlineLikelyPassed({
+        createdAtMs: 1_000_000,
+        nowMs: 2_200_000,
+        pegInActivationTimeout: 100n,
+      }),
+    ).toBe(true);
+  });
+
+  it("treats negative elapsed time (createdAtMs in the future) as not passed", () => {
+    expect(
+      estimateActivationDeadlineLikelyPassed({
+        createdAtMs: 2_000_000,
+        nowMs: 1_000_000,
+        pegInActivationTimeout: 100n,
+      }),
+    ).toBe(false);
+  });
+
+  it("honors a slotSeconds override", () => {
+    // 600s elapsed at 6s/slot = 100 blocks, reaching the 100-block timeout.
+    expect(
+      estimateActivationDeadlineLikelyPassed({
+        createdAtMs: 1_000_000,
+        nowMs: 1_600_000,
+        pegInActivationTimeout: 100n,
+        slotSeconds: 6,
+      }),
+    ).toBe(true);
+
+    // Same 600s elapsed at the 12s default = 50 blocks, below the timeout.
+    expect(
+      estimateActivationDeadlineLikelyPassed({
+        createdAtMs: 1_000_000,
+        nowMs: 1_600_000,
+        pegInActivationTimeout: 100n,
+      }),
+    ).toBe(false);
+  });
+
+  it("exposes the Ethereum slot time as a 12s constant", () => {
+    expect(ETH_SLOT_SECONDS).toBe(12);
+  });
+});

--- a/services/vault/src/utils/__tests__/activationDeadline.test.ts
+++ b/services/vault/src/utils/__tests__/activationDeadline.test.ts
@@ -3,40 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   ETH_SLOT_SECONDS,
   estimateActivationDeadlineLikelyPassed,
-  isActivationDeadlinePassedOnChain,
 } from "../activationDeadline";
-
-describe("isActivationDeadlinePassedOnChain", () => {
-  it("treats the boundary block (current == created + timeout) as NOT expired", () => {
-    expect(
-      isActivationDeadlinePassedOnChain({
-        currentBlock: 1100n,
-        createdAtBlock: 1000n,
-        pegInActivationTimeout: 100n,
-      }),
-    ).toBe(false);
-  });
-
-  it("treats one block past the boundary as expired", () => {
-    expect(
-      isActivationDeadlinePassedOnChain({
-        currentBlock: 1101n,
-        createdAtBlock: 1000n,
-        pegInActivationTimeout: 100n,
-      }),
-    ).toBe(true);
-  });
-
-  it("treats a block below the boundary as NOT expired", () => {
-    expect(
-      isActivationDeadlinePassedOnChain({
-        currentBlock: 1050n,
-        createdAtBlock: 1000n,
-        pegInActivationTimeout: 100n,
-      }),
-    ).toBe(false);
-  });
-});
 
 describe("estimateActivationDeadlineLikelyPassed", () => {
   it("returns false when well within the window", () => {

--- a/services/vault/src/utils/__tests__/activationDeadline.test.ts
+++ b/services/vault/src/utils/__tests__/activationDeadline.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  ETH_SLOT_SECONDS,
-  estimateActivationDeadlineLikelyPassed,
-} from "../activationDeadline";
+import { estimateActivationDeadlineLikelyPassed } from "../activationDeadline";
 
 describe("estimateActivationDeadlineLikelyPassed", () => {
   it("returns false when well within the window", () => {
@@ -81,7 +78,26 @@ describe("estimateActivationDeadlineLikelyPassed", () => {
     ).toBe(false);
   });
 
-  it("exposes the Ethereum slot time as a 12s constant", () => {
-    expect(ETH_SLOT_SECONDS).toBe(12);
+  it("defaults to the fastest realistic cadence, so it over-counts elapsed blocks and never misses an expiry", () => {
+    // 12s is the slot floor — real slots can only be slower — so the block
+    // estimate is an upper bound. 1200s at 12s = 100 blocks, reaching the timeout.
+    expect(
+      estimateActivationDeadlineLikelyPassed({
+        createdAtMs: 0,
+        nowMs: 1_200_000,
+        pegInActivationTimeout: 100n,
+      }),
+    ).toBe(true);
+
+    // Same wall time at a slower cadence is only 80 blocks, so a `false` means
+    // "definitely inside the window", not "probably".
+    expect(
+      estimateActivationDeadlineLikelyPassed({
+        createdAtMs: 0,
+        nowMs: 1_200_000,
+        pegInActivationTimeout: 100n,
+        slotSeconds: 15,
+      }),
+    ).toBe(false);
   });
 });

--- a/services/vault/src/utils/activationDeadline.ts
+++ b/services/vault/src/utils/activationDeadline.ts
@@ -3,15 +3,9 @@ export const ETH_SLOT_SECONDS = 12;
 
 const MILLISECONDS_PER_SECOND = 1000;
 
-/** Authoritative on-chain check: matches the contract's strict '>', so a boundary-equal block is NOT expired. */
-export function isActivationDeadlinePassedOnChain(params: {
-  currentBlock: bigint;
-  createdAtBlock: bigint;
-  pegInActivationTimeout: bigint;
-}): boolean {
-  const { currentBlock, createdAtBlock, pegInActivationTimeout } = params;
-  return currentBlock > createdAtBlock + pegInActivationTimeout;
-}
+// The authoritative on-chain check (currentBlock > createdAt + timeout) lives
+// in the SDK (`@babylonlabs-io/ts-sdk/tbv/core/services` → peginState) so the
+// contract-mirror rule stays co-located with its inputs and the ABI error.
 
 /**
  * Cheap, no-RPC first pass. Uses slot time as a fixed cadence to estimate elapsed blocks.

--- a/services/vault/src/utils/activationDeadline.ts
+++ b/services/vault/src/utils/activationDeadline.ts
@@ -1,0 +1,49 @@
+// Ethereum L1 consensus slot time; missed slots only make real intervals >= 12s, so 12s yields a safe UPPER bound on elapsed blocks.
+export const ETH_SLOT_SECONDS = 12;
+
+const MILLISECONDS_PER_SECOND = 1000;
+const NO_ELAPSED_BLOCKS = 0;
+
+/** Authoritative on-chain check: matches the contract's strict '>', so a boundary-equal block is NOT expired. */
+export function isActivationDeadlinePassedOnChain(params: {
+  currentBlock: bigint;
+  createdAtBlock: bigint;
+  pegInActivationTimeout: bigint;
+}): boolean {
+  const { currentBlock, createdAtBlock, pegInActivationTimeout } = params;
+  return currentBlock > createdAtBlock + pegInActivationTimeout;
+}
+
+/**
+ * Cheap, no-RPC first pass. Uses slot time as a fixed cadence to estimate elapsed blocks.
+ * Because missed slots only stretch real intervals beyond slotSeconds, this is an UPPER bound on
+ * real elapsed blocks: returning false means DEFINITELY still within the window (safe to allow
+ * Activate with no RPC); returning true means MAYBE expired and must be confirmed on chain.
+ */
+export function estimateActivationDeadlineLikelyPassed(params: {
+  createdAtMs: number;
+  nowMs: number;
+  pegInActivationTimeout: bigint;
+  slotSeconds?: number;
+}): boolean {
+  const {
+    createdAtMs,
+    nowMs,
+    pegInActivationTimeout,
+    slotSeconds = ETH_SLOT_SECONDS,
+  } = params;
+
+  const elapsedMs = nowMs - createdAtMs;
+  // Clock skew / future createdAtMs: treat as no time elapsed -> definitely within window.
+  if (elapsedMs <= 0) {
+    return false;
+  }
+
+  const estimatedElapsedBlocks = Math.floor(
+    elapsedMs / MILLISECONDS_PER_SECOND / slotSeconds,
+  );
+  return (
+    Math.max(estimatedElapsedBlocks, NO_ELAPSED_BLOCKS) >=
+    Number(pegInActivationTimeout)
+  );
+}

--- a/services/vault/src/utils/activationDeadline.ts
+++ b/services/vault/src/utils/activationDeadline.ts
@@ -2,7 +2,6 @@
 export const ETH_SLOT_SECONDS = 12;
 
 const MILLISECONDS_PER_SECOND = 1000;
-const NO_ELAPSED_BLOCKS = 0;
 
 /** Authoritative on-chain check: matches the contract's strict '>', so a boundary-equal block is NOT expired. */
 export function isActivationDeadlinePassedOnChain(params: {
@@ -39,11 +38,10 @@ export function estimateActivationDeadlineLikelyPassed(params: {
     return false;
   }
 
-  const estimatedElapsedBlocks = Math.floor(
-    elapsedMs / MILLISECONDS_PER_SECOND / slotSeconds,
+  // elapsedMs > 0 here, so the floor is already >= 0. Compare in bigint (the
+  // timeout is a uint256) to avoid precision loss for very large values.
+  const estimatedElapsedBlocks = BigInt(
+    Math.floor(elapsedMs / MILLISECONDS_PER_SECOND / slotSeconds),
   );
-  return (
-    Math.max(estimatedElapsedBlocks, NO_ELAPSED_BLOCKS) >=
-    Number(pegInActivationTimeout)
-  );
+  return estimatedElapsedBlocks >= pegInActivationTimeout;
 }

--- a/services/vault/src/utils/activationDeadline.ts
+++ b/services/vault/src/utils/activationDeadline.ts
@@ -1,5 +1,5 @@
 // Ethereum L1 consensus slot time; missed slots only make real intervals >= 12s, so 12s yields a safe UPPER bound on elapsed blocks.
-export const ETH_SLOT_SECONDS = 12;
+const ETH_SLOT_SECONDS = 12;
 
 const MILLISECONDS_PER_SECOND = 1000;
 

--- a/services/vault/src/utils/errors/__tests__/contract.test.ts
+++ b/services/vault/src/utils/errors/__tests__/contract.test.ts
@@ -6,8 +6,13 @@ import { AaveIntegrationAdapterABI } from "@babylonlabs-io/ts-sdk/tbv/integratio
 import { type Abi, encodeErrorResult } from "viem";
 import { describe, expect, it } from "vitest";
 
-import { mapViemErrorToContractError } from "../contract";
-import { ErrorCode } from "../types";
+import {
+  ACTIVATION_DEADLINE_EXPIRED_REASON,
+  isActivationDeadlineExpiredError,
+  isTerminalActivationError,
+  mapViemErrorToContractError,
+} from "../contract";
+import { ActivationNotPossibleError, ContractError, ErrorCode } from "../types";
 
 // Test ABI with custom errors
 const TEST_ABI: Abi = [
@@ -448,6 +453,89 @@ describe("Contract Error Mapping", () => {
       );
 
       expect(result.cause).toBe(originalError);
+    });
+  });
+
+  describe("isActivationDeadlineExpiredError", () => {
+    it("returns true for the decoded ActivationDeadlineExpired revert", () => {
+      const data = encodeErrorResult({
+        abi: TEST_ABI,
+        errorName: "ActivationDeadlineExpired",
+      });
+      const mapped = mapViemErrorToContractError(
+        { message: "execution reverted", data },
+        "activate",
+        [TEST_ABI],
+      );
+
+      expect(mapped.reason).toBe(ACTIVATION_DEADLINE_EXPIRED_REASON);
+      expect(isActivationDeadlineExpiredError(mapped)).toBe(true);
+    });
+
+    it("returns false for a different contract revert", () => {
+      const data = encodeErrorResult({
+        abi: TEST_ABI,
+        errorName: "PositionNotFound",
+      });
+      const mapped = mapViemErrorToContractError(
+        { message: "execution reverted", data },
+        "activate",
+        [TEST_ABI],
+      );
+
+      expect(isActivationDeadlineExpiredError(mapped)).toBe(false);
+    });
+
+    it("returns false for a ContractError without the deadline reason", () => {
+      const err = new ContractError(
+        "nope",
+        ErrorCode.CONTRACT_REVERT,
+        undefined,
+        "SomethingElse",
+      );
+
+      expect(isActivationDeadlineExpiredError(err)).toBe(false);
+    });
+
+    it("returns false for a plain Error, the message string, or null", () => {
+      expect(isActivationDeadlineExpiredError(new Error("boom"))).toBe(false);
+      expect(
+        isActivationDeadlineExpiredError(
+          "The activation deadline has passed. The BTC Vault can no longer be activated.",
+        ),
+      ).toBe(false);
+      expect(isActivationDeadlineExpiredError(null)).toBe(false);
+    });
+  });
+
+  describe("isTerminalActivationError", () => {
+    it("returns true for the deadline-expired contract revert", () => {
+      const data = encodeErrorResult({
+        abi: TEST_ABI,
+        errorName: "ActivationDeadlineExpired",
+      });
+      const mapped = mapViemErrorToContractError(
+        { message: "execution reverted", data },
+        "activate",
+        [TEST_ABI],
+      );
+
+      expect(isTerminalActivationError(mapped)).toBe(true);
+    });
+
+    it("returns true for an ActivationNotPossibleError (e.g. already EXPIRED)", () => {
+      const err = new ActivationNotPossibleError(
+        "Cannot activate: BTC Vault is in EXPIRED state.",
+      );
+
+      expect(isTerminalActivationError(err)).toBe(true);
+    });
+
+    it("returns false for a retryable plain Error and null", () => {
+      expect(
+        isTerminalActivationError(new Error("Cannot activate: ... PENDING")),
+      ).toBe(false);
+      expect(isTerminalActivationError(null)).toBe(false);
     });
   });
 });

--- a/services/vault/src/utils/errors/contract.ts
+++ b/services/vault/src/utils/errors/contract.ts
@@ -9,7 +9,7 @@ import { type Abi, type Hash, decodeErrorResult } from "viem";
 
 import { COMMON_ERROR_ABI } from "./commonErrorAbi";
 import { CONTRACT_ERROR_MESSAGES } from "./errorMessages";
-import { ContractError, ErrorCode } from "./types";
+import { ActivationNotPossibleError, ContractError, ErrorCode } from "./types";
 
 /** Minimum length of a revert hex payload: `0x` + a 4-byte (8 hex char) selector. */
 const SELECTOR_HEX_MIN_LENGTH = 10;
@@ -338,4 +338,35 @@ export function mapViemErrorToContractError(
   return new ContractError(finalMessage, code, transactionHash, reason, {
     cause: error,
   });
+}
+
+/**
+ * ABI error name from BTCVaultRegistry, surfaced as `ContractError.reason` when
+ * `activateVaultWithSecret` is called after the activation window closed
+ * (contract check `block.number > createdAt + pegInActivationTimeout`).
+ */
+export const ACTIVATION_DEADLINE_EXPIRED_REASON = "ActivationDeadlineExpired";
+
+/**
+ * True when an activation failure is the terminal ActivationDeadlineExpired
+ * revert. Retrying re-runs the identical revert, so the UI must offer Close,
+ * not Retry.
+ */
+export function isActivationDeadlineExpiredError(err: unknown): boolean {
+  return (
+    err instanceof ContractError &&
+    err.reason === ACTIVATION_DEADLINE_EXPIRED_REASON
+  );
+}
+
+/**
+ * True when an activation failure is terminal — retrying would re-run the same
+ * failing path. Covers the on-chain deadline revert and the pre-flight
+ * "vault not in an activatable state" guard. The UI offers Close, not Retry.
+ */
+export function isTerminalActivationError(err: unknown): boolean {
+  return (
+    isActivationDeadlineExpiredError(err) ||
+    err instanceof ActivationNotPossibleError
+  );
 }

--- a/services/vault/src/utils/errors/types.ts
+++ b/services/vault/src/utils/errors/types.ts
@@ -109,6 +109,18 @@ export class WalletError extends Error {
   }
 }
 
+/**
+ * Thrown by the activation pre-flight when the vault's on-chain status makes
+ * activation impossible (e.g. already EXPIRED). Terminal — retrying cannot
+ * revert the status to VERIFIED, so the UI suppresses Retry.
+ */
+export class ActivationNotPossibleError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ActivationNotPossibleError";
+  }
+}
+
 export const isError451 = (error: unknown): boolean => {
   if (!error || typeof error !== "object") {
     return false;


### PR DESCRIPTION
A vault's activation deadline is enforced only by the BTCVaultRegistry contract
(`block.number > createdAt + pegInActivationTimeout` reverts
`ActivationDeadlineExpired`). The indexer only flips a vault VERIFIED→EXPIRED when
someone calls the permissionless `reportExpiredPegins`, which can lag
indefinitely — so the dashboard kept offering "Activate" on vaults already past
their deadline, and the resulting revert left a "Retry" that re-ran the same
failing call forever.