### PR TITLE
feat(vault): pause per-scope on-chain detection and gate all exits

### DIFF
--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/index.tsx
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/index.tsx
@@ -19,6 +19,7 @@ import { useEffect } from "react";
 import { getHealthFactorStatusFromValue } from "@/applications/aave/utils";
 import { isBorrowBlocked } from "@/components/shared/protocolStatus";
 import { COPY } from "@/copy";
+import { useProtocolGateState } from "@/hooks/useProtocolGate";
 
 import {
   getCurrencyIconWithFallback,
@@ -62,6 +63,7 @@ import { validateBorrowPreSign } from "./hooks/validateBorrowPreSign";
 const MAX_BORROWABLE_LIQUIDITY_FRACTION = 0.999;
 
 export function Borrow() {
+  const gate = useProtocolGateState();
   const {
     collateralValueUsd,
     totalDebtValueUsd,
@@ -244,7 +246,7 @@ export function Borrow() {
   };
 
   const getBorrowButtonText = () => {
-    if (isBorrowBlocked()) return COPY.loans.borrow.unavailable;
+    if (isBorrowBlocked(gate)) return COPY.loans.borrow.unavailable;
     if (isProcessing) return COPY.loans.borrow.processing;
     return buttonText;
   };
@@ -264,7 +266,7 @@ export function Borrow() {
           title: COPY.loans.transactionFailedTitle,
           body: txError,
         }
-      : isBorrowBlocked()
+      : isBorrowBlocked(gate)
         ? { variant: "warning", body: COPY.loans.borrowingUnavailable }
         : tokenPriceUsd == null || oracleAddress == null
           ? { variant: "warning", body: COPY.loans.priceUnavailable }
@@ -373,7 +375,7 @@ export function Borrow() {
         disabled={
           isDisabled ||
           isProcessing ||
-          isBorrowBlocked() ||
+          isBorrowBlocked(gate) ||
           !isPriceReady ||
           oracleAddress == null
         }

--- a/services/vault/src/applications/aave/components/LoanCard/Repay/index.tsx
+++ b/services/vault/src/applications/aave/components/LoanCard/Repay/index.tsx
@@ -274,16 +274,18 @@ export function Repay() {
             title: COPY.loans.transactionFailedTitle,
             body: txError,
           }
-        : refetchError
-          ? { variant: "warning", body: refetchError }
-          : // Only when NO balance ever loaded (first load failed). A
-            // background-refetch blip keeps the last good balance, so it must
-            // not surface a load error or block repay.
-            !hasBalanceData && balanceError != null
-            ? { variant: "warning", body: COPY.loans.repay.balanceLoadError }
-            : balanceKnown && warningMessage
-              ? { variant: "warning", body: warningMessage }
-              : null;
+        : repayBlocked
+          ? { variant: "warning", body: COPY.loans.repayingUnavailable }
+          : refetchError
+            ? { variant: "warning", body: refetchError }
+            : // Only when NO balance ever loaded (first load failed). A
+              // background-refetch blip keeps the last good balance, so it must
+              // not surface a load error or block repay.
+              !hasBalanceData && balanceError != null
+              ? { variant: "warning", body: COPY.loans.repay.balanceLoadError }
+              : balanceKnown && warningMessage
+                ? { variant: "warning", body: warningMessage }
+                : null;
 
   return (
     <div>
@@ -393,9 +395,11 @@ export function Repay() {
         onClick={handleRepay}
         className="mt-6"
       >
-        {isProcessing || isSubmitting
-          ? COPY.loans.repay.processing
-          : buttonText}
+        {repayBlocked
+          ? COPY.loans.repay.unavailable
+          : isProcessing || isSubmitting
+            ? COPY.loans.repay.processing
+            : buttonText}
       </Button>
 
       {/* Single status callout (validation / transaction / balance warning) */}

--- a/services/vault/src/applications/aave/components/LoanCard/Repay/index.tsx
+++ b/services/vault/src/applications/aave/components/LoanCard/Repay/index.tsx
@@ -14,9 +14,11 @@ import {
 } from "@babylonlabs-io/core-ui";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
+import { isRepayBlocked } from "@/components/shared/protocolStatus";
 import { useETHWallet } from "@/context/wallet";
 import { COPY } from "@/copy";
 import { useERC20Balance } from "@/hooks";
+import { useProtocolGateState } from "@/hooks/useProtocolGate";
 
 import {
   getCurrencyIconWithFallback,
@@ -51,6 +53,8 @@ import { validateRepayPreSign } from "./hooks/validateRepayPreSign";
 import { RepayDetailsCard } from "./RepayDetailsCard";
 
 export function Repay() {
+  const gate = useProtocolGateState();
+  const repayBlocked = isRepayBlocked(gate);
   const {
     collateralValueUsd,
     currentDebtAmount,
@@ -379,7 +383,13 @@ export function Repay() {
         color="secondary"
         size="large"
         fluid
-        disabled={isDisabled || isProcessing || isSubmitting || !balanceKnown}
+        disabled={
+          isDisabled ||
+          isProcessing ||
+          isSubmitting ||
+          !balanceKnown ||
+          repayBlocked
+        }
         onClick={handleRepay}
         className="mt-6"
       >

--- a/services/vault/src/applications/aave/hooks/__tests__/useBorrowTransaction.test.tsx
+++ b/services/vault/src/applications/aave/hooks/__tests__/useBorrowTransaction.test.tsx
@@ -1,0 +1,64 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockBorrow = vi.fn();
+const mockAssertReserve = vi.fn();
+vi.mock("../../services", () => ({
+  borrow: (...a: unknown[]) => mockBorrow(...a),
+  assertReserveMatchesOnChain: (...a: unknown[]) => mockAssertReserve(...a),
+  ReserveMismatchError: class ReserveMismatchError extends Error {},
+}));
+
+vi.mock("../../config", () => ({
+  getAaveAdapterAddress: () => "0xadapter",
+}));
+
+vi.mock("@/clients/eth-contract", () => ({
+  ERC20: { getERC20Decimals: vi.fn() },
+}));
+
+vi.mock("@/infrastructure", () => ({
+  logger: { error: vi.fn() },
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+
+vi.mock("wagmi", () => ({
+  useWalletClient: () => ({ data: { account: { address: "0xuser" } } }),
+  useAccount: () => ({ address: "0xuser" }),
+}));
+
+// Local override of the global gate mock so we can drive a paused aave scope.
+const gateMock = vi.hoisted(() => ({
+  value: { protocol: null as string | null, aave: null as string | null },
+}));
+vi.mock("@/hooks/useProtocolGate", () => ({
+  useProtocolGateState: () => gateMock.value,
+}));
+
+import { useBorrowTransaction } from "../useBorrowTransaction";
+
+const RESERVE = {} as never;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  gateMock.value = { protocol: null, aave: null };
+});
+
+describe("useBorrowTransaction — pause gating", () => {
+  it("refuses to broadcast when an aave Freeze/Pause blocks borrow (before any on-chain read)", async () => {
+    gateMock.value = { protocol: null, aave: "paused" };
+    const { result } = renderHook(() => useBorrowTransaction());
+
+    let resolved: boolean | undefined;
+    await act(async () => {
+      resolved = await result.current.executeBorrow(100, RESERVE);
+    });
+
+    expect(resolved).toBe(false);
+    expect(mockAssertReserve).not.toHaveBeenCalled();
+    expect(mockBorrow).not.toHaveBeenCalled();
+  });
+});

--- a/services/vault/src/applications/aave/hooks/__tests__/useRepayTransaction.test.tsx
+++ b/services/vault/src/applications/aave/hooks/__tests__/useRepayTransaction.test.tsx
@@ -1,0 +1,90 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockAssertReserve = vi.fn();
+const mockRepayFull = vi.fn();
+const mockRepayPartial = vi.fn();
+const mockRepayMaxCapped = vi.fn();
+vi.mock("../../services", () => ({
+  assertReserveMatchesOnChain: (...a: unknown[]) => mockAssertReserve(...a),
+  repayFull: (...a: unknown[]) => mockRepayFull(...a),
+  repayPartial: (...a: unknown[]) => mockRepayPartial(...a),
+  repayMaxCapped: (...a: unknown[]) => mockRepayMaxCapped(...a),
+  ReserveMismatchError: class ReserveMismatchError extends Error {},
+}));
+
+vi.mock("../../config", () => ({
+  getAaveAdapterAddress: () => "0xadapter",
+}));
+
+vi.mock("@/clients/eth-contract", () => ({
+  ERC20: { getERC20Decimals: vi.fn() },
+}));
+
+vi.mock("@/infrastructure", () => ({
+  logger: { error: vi.fn() },
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+
+vi.mock("wagmi", () => ({
+  useWalletClient: () => ({ data: { account: { address: "0xuser" } } }),
+  useAccount: () => ({ address: "0xuser" }),
+}));
+
+// Local override of the global gate mock so we can drive a paused scope.
+const gateMock = vi.hoisted(() => ({
+  value: { protocol: null as string | null, aave: null as string | null },
+}));
+vi.mock("@/hooks/useProtocolGate", () => ({
+  useProtocolGateState: () => gateMock.value,
+}));
+
+import { useRepayTransaction } from "../useRepayTransaction";
+
+const RESERVE = {
+  reserveId: "r1",
+  token: { address: "0xtoken", decimals: 6, symbol: "USDC" },
+} as never;
+
+function setup() {
+  return renderHook(() => useRepayTransaction({ proxyContract: "0xproxy" }));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  gateMock.value = { protocol: null, aave: null };
+});
+
+describe("useRepayTransaction — pause gating (aave-scope only)", () => {
+  it("returns false without any on-chain read when the aave scope is paused", async () => {
+    gateMock.value = { protocol: null, aave: "paused" };
+    const { result } = setup();
+
+    let resolved: boolean | undefined;
+    await act(async () => {
+      resolved = await result.current.executeRepay(100, RESERVE);
+    });
+
+    expect(resolved).toBe(false);
+    expect(mockAssertReserve).not.toHaveBeenCalled();
+    expect(mockRepayFull).not.toHaveBeenCalled();
+  });
+
+  it("PROCEEDS under a protocol-only pause — repay must stay available so a near-liquidation user can de-risk", async () => {
+    // protocol paused, aave normal → repay is NOT blocked. Stop the flow at the
+    // reserve check (rejected stub) and assert it was reached, proving the gate
+    // let execution through. A mis-wire to isWithdrawBlocked would block here.
+    gateMock.value = { protocol: "paused", aave: null };
+    mockAssertReserve.mockRejectedValueOnce(new Error("stub reserve"));
+    const { result } = setup();
+
+    await act(async () => {
+      await result.current.executeRepay(100, RESERVE);
+    });
+
+    expect(mockAssertReserve).toHaveBeenCalledTimes(1);
+  });
+});

--- a/services/vault/src/applications/aave/hooks/useBorrowTransaction.ts
+++ b/services/vault/src/applications/aave/hooks/useBorrowTransaction.ts
@@ -9,7 +9,9 @@ import { parseUnits } from "viem";
 import { useAccount, useWalletClient } from "wagmi";
 
 import { ERC20 } from "@/clients/eth-contract";
+import { isBorrowBlocked } from "@/components/shared/protocolStatus";
 import { getETHChain } from "@/config/network";
+import { useProtocolGateState } from "@/hooks/useProtocolGate";
 import { logger } from "@/infrastructure";
 import {
   ErrorCode,
@@ -55,6 +57,7 @@ export function useBorrowTransaction(): UseBorrowTransactionResult {
   const { address } = useAccount();
   const queryClient = useQueryClient();
   const chain = getETHChain();
+  const gate = useProtocolGateState();
 
   const clearError = useCallback(() => setError(null), []);
 
@@ -64,6 +67,11 @@ export function useBorrowTransaction(): UseBorrowTransactionResult {
     preSignValidation?: () => Promise<void>,
   ) => {
     if (borrowAmount <= 0) return false;
+
+    // Borrow is an aave-scope ENTRY action: Freeze or Pause blocks it. Guard the
+    // execution chokepoint behind the disabled button so a programmatic call
+    // can't broadcast while blocked.
+    if (isBorrowBlocked(gate)) return false;
 
     setError(null);
     setIsProcessing(true);

--- a/services/vault/src/applications/aave/hooks/useReorderVaults.ts
+++ b/services/vault/src/applications/aave/hooks/useReorderVaults.ts
@@ -12,6 +12,7 @@ import { useAccount, useWalletClient } from "wagmi";
 import { isReorderBlocked } from "@/components/shared/protocolStatus";
 import { getETHChain } from "@/config/network";
 import { useError } from "@/context/error";
+import { useProtocolGateState } from "@/hooks/useProtocolGate";
 import { logger } from "@/infrastructure";
 import {
   ErrorCode,
@@ -74,15 +75,16 @@ export function useReorderVaults(): UseReorderVaultsResult {
   const { data: walletClient } = useWalletClient();
   const { address } = useAccount();
   const { handleError } = useError();
+  const gate = useProtocolGateState();
 
   const executeReorder = useCallback(
     async (permutedVaultIds: Hex[], options?: ExecuteReorderOptions) => {
-      // Freeze/Pause blocks reorder. Guard the shared execution chokepoint so
-      // neither the banner CTA nor the reorder modal can broadcast while
-      // blocked, regardless of how the handler was reached (the UI buttons are
-      // disabled too). Returns a no-op failure — the path is UI-prevented, so
-      // there is nothing actionable to surface in a modal.
-      if (isReorderBlocked()) return false;
+      // Reorder is an aave-scope entry action: Freeze or Pause blocks it. Guard
+      // the shared execution chokepoint so neither the banner CTA nor the
+      // reorder modal can broadcast while blocked, regardless of how the handler
+      // was reached (the UI buttons are disabled too). Returns a no-op failure —
+      // the path is UI-prevented, so there is nothing actionable to surface.
+      if (isReorderBlocked(gate)) return false;
 
       setIsProcessing(true);
       try {
@@ -154,7 +156,7 @@ export function useReorderVaults(): UseReorderVaultsResult {
         setIsProcessing(false);
       }
     },
-    [walletClient, address, handleError],
+    [walletClient, address, handleError, gate],
   );
 
   return {

--- a/services/vault/src/applications/aave/hooks/useRepayTransaction.ts
+++ b/services/vault/src/applications/aave/hooks/useRepayTransaction.ts
@@ -12,7 +12,9 @@ import { parseUnits } from "viem";
 import { useAccount, useWalletClient } from "wagmi";
 
 import { ERC20 } from "@/clients/eth-contract";
+import { isRepayBlocked } from "@/components/shared/protocolStatus";
 import { getETHChain } from "@/config/network";
+import { useProtocolGateState } from "@/hooks/useProtocolGate";
 import { logger } from "@/infrastructure";
 import {
   ErrorCode,
@@ -111,6 +113,7 @@ export function useRepayTransaction({
   const { address } = useAccount();
   const queryClient = useQueryClient();
   const chain = getETHChain();
+  const gate = useProtocolGateState();
 
   const clearError = useCallback(() => setError(null), []);
 
@@ -123,6 +126,10 @@ export function useRepayTransaction({
     const { preSignValidation, repayAmountRaw } = options;
 
     if (repayAmount <= 0) return false;
+
+    // Repay is an aave-scope EXIT: blocked only by an aave Pause (not a protocol
+    // pause, and never by Freeze). Guard the chokepoint behind the disabled button.
+    if (isRepayBlocked(gate)) return false;
 
     setError(null);
     setIsProcessing(true);

--- a/services/vault/src/applications/aave/hooks/useWithdrawCollateralTransaction.ts
+++ b/services/vault/src/applications/aave/hooks/useWithdrawCollateralTransaction.ts
@@ -10,8 +10,10 @@ import { useCallback, useState } from "react";
 import type { Address, Hex } from "viem";
 import { useAccount, useWalletClient } from "wagmi";
 
+import { isWithdrawBlocked } from "@/components/shared/protocolStatus";
 import { getETHChain } from "@/config/network";
 import { useError } from "@/context/error";
+import { useProtocolGateState } from "@/hooks/useProtocolGate";
 import { logger } from "@/infrastructure";
 import {
   ErrorCode,
@@ -49,9 +51,16 @@ export function useWithdrawCollateralTransaction(): UseWithdrawCollateralTransac
   const queryClient = useQueryClient();
   const { handleError } = useError();
   const { markVaultsAsPending } = usePendingVaults();
+  const gate = useProtocolGateState();
 
   const executeWithdraw = useCallback(
     async (vaultIds: string[]) => {
+      // Withdraw is an EXIT: blocked only when either scope is paused (Freeze
+      // preserves exits). Guard the execution chokepoint so a pause that lands
+      // mid-session can't broadcast even if a modal was already open; the menu
+      // item is disabled too.
+      if (isWithdrawBlocked(gate)) return false;
+
       setIsProcessing(true);
       try {
         // Validate wallet connection
@@ -109,7 +118,14 @@ export function useWithdrawCollateralTransaction(): UseWithdrawCollateralTransac
         setIsProcessing(false);
       }
     },
-    [walletClient, address, queryClient, handleError, markVaultsAsPending],
+    [
+      walletClient,
+      address,
+      queryClient,
+      handleError,
+      markVaultsAsPending,
+      gate,
+    ],
   );
 
   return {

--- a/services/vault/src/clients/eth-contract/pause-state/__tests__/query.test.ts
+++ b/services/vault/src/clients/eth-contract/pause-state/__tests__/query.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+
+const mockMulticall = vi.fn();
+vi.mock("../../client", () => ({
+  ethClient: { getPublicClient: () => ({ multicall: mockMulticall }) },
+}));
+
+vi.mock("@/config/contracts", () => ({
+  CONTRACTS: {
+    BTC_VAULT_REGISTRY: "0x0000000000000000000000000000000000000001",
+    AAVE_ADAPTER: "0x0000000000000000000000000000000000000002",
+  },
+}));
+
+vi.mock("@babylonlabs-io/ts-sdk/tbv/integrations/aave", () => ({
+  AaveIntegrationAdapterABI: [],
+}));
+
+import { getOnChainPauseState } from "../query";
+
+describe("getOnChainPauseState — PauseState enum mapping", () => {
+  it("maps 0 / 1 / 2 to null / frozen / paused, per scope (protocol, aave)", async () => {
+    mockMulticall.mockResolvedValueOnce([0, 0]);
+    await expect(getOnChainPauseState()).resolves.toEqual({
+      protocol: null,
+      aave: null,
+    });
+
+    mockMulticall.mockResolvedValueOnce([1, 2]);
+    await expect(getOnChainPauseState()).resolves.toEqual({
+      protocol: "frozen",
+      aave: "paused",
+    });
+
+    mockMulticall.mockResolvedValueOnce([2, 1]);
+    await expect(getOnChainPauseState()).resolves.toEqual({
+      protocol: "paused",
+      aave: "frozen",
+    });
+  });
+
+  it("throws on an unrecognized enum value instead of defaulting to unpaused", async () => {
+    mockMulticall.mockResolvedValueOnce([3, 0]);
+    await expect(getOnChainPauseState()).rejects.toThrow(
+      /Unknown ITBVPausable\.PauseState value: 3/,
+    );
+  });
+});

--- a/services/vault/src/clients/eth-contract/pause-state/__tests__/query.test.ts
+++ b/services/vault/src/clients/eth-contract/pause-state/__tests__/query.test.ts
@@ -39,10 +39,18 @@ describe("getOnChainPauseState — PauseState enum mapping", () => {
     });
   });
 
-  it("throws on an unrecognized enum value instead of defaulting to unpaused", async () => {
+  it("maps an unrecognized enum value to 'paused' (fail closed, not open)", async () => {
+    // A future/unknown PauseState must NOT collapse to null (which would leave
+    // actions open). It maps to the most-restrictive status for that scope.
     mockMulticall.mockResolvedValueOnce([3, 0]);
-    await expect(getOnChainPauseState()).rejects.toThrow(
-      /Unknown ITBVPausable\.PauseState value: 3/,
-    );
+    await expect(getOnChainPauseState()).resolves.toEqual({
+      protocol: "paused",
+      aave: null,
+    });
+  });
+
+  it("propagates a reverted read (so the hook can fail open on an RPC error)", async () => {
+    mockMulticall.mockRejectedValueOnce(new Error("execution reverted"));
+    await expect(getOnChainPauseState()).rejects.toThrow(/reverted/);
   });
 });

--- a/services/vault/src/clients/eth-contract/pause-state/query.ts
+++ b/services/vault/src/clients/eth-contract/pause-state/query.ts
@@ -36,8 +36,7 @@ const REGISTRY_PAUSE_STATE_ABI = [
 // Confirmed against the upstream Solidity `ITBVPausable.sol`:
 //   enum PauseState { None, Frozen, Paused }  // 0, 1, 2
 // (`freeze() -> Frozen`, `pause() -> Paused`; both contracts the FE reads
-// inherit `TBVPausableUpg`). Unknown values still THROW rather than defaulting
-// to "unpaused" (no silent fallback that could mask a future enum change).
+// inherit `TBVPausableUpg`).
 const PAUSE_STATE = {
   /** Normal operation. */
   NONE: 0,
@@ -47,6 +46,13 @@ const PAUSE_STATE = {
   PAUSED: 2,
 } as const;
 
+// An unrecognized enum value means the on-chain contract is in a state this
+// build does not model (e.g. a future `PauseState` was added). Treat it as the
+// MOST RESTRICTIVE status ("paused") — fail CLOSED — rather than mapping it to
+// `null`, which would leave actions open during a state we don't understand.
+// This is deliberately different from a genuine read failure (a reverted
+// multicall throws and the React-Query hook fails OPEN, so an RPC blip never
+// traps a user mid-exit).
 function mapPauseState(raw: number): ScopeStatus {
   switch (raw) {
     case PAUSE_STATE.NONE:
@@ -56,17 +62,16 @@ function mapPauseState(raw: number): ScopeStatus {
     case PAUSE_STATE.PAUSED:
       return "paused";
     default:
-      throw new Error(
-        `Unknown ITBVPausable.PauseState value: ${raw}. The on-chain enum may have changed — update the pause-state mapping.`,
-      );
+      return "paused";
   }
 }
 
 /**
  * Read both scopes' pause state in a single multicall round-trip. Throws on a
- * reverted read or an unrecognized enum value; the caller decides how to fall
- * back (the React-Query hook treats a throw as "unknown" and defers to the
- * operator-flag override).
+ * reverted read (the React-Query hook then fails OPEN, deferring to the
+ * operator-flag override so an RPC blip never traps a user mid-exit). An
+ * unrecognized enum value does NOT throw — it maps to "paused" (fail closed),
+ * see `mapPauseState`.
  */
 export async function getOnChainPauseState(): Promise<ProtocolGateState> {
   const publicClient = ethClient.getPublicClient();

--- a/services/vault/src/clients/eth-contract/pause-state/query.ts
+++ b/services/vault/src/clients/eth-contract/pause-state/query.ts
@@ -1,0 +1,95 @@
+/**
+ * Per-scope on-chain pause/freeze detection.
+ *
+ * Reads `pauseState()` from the two governance scopes:
+ * - protocol scope: `BTCVaultRegistry` (uses a self-contained ABI fragment —
+ *   the bundled registry ABI in `@babylonlabs-io/ts-sdk/tbv/core` is the
+ *   signing subset and does not expose this getter).
+ * - aave scope: `AaveIntegrationAdapter` (the SDK ABI already exposes it).
+ *
+ * Both return the on-chain `ITBVPausable.PauseState` enum (a `uint8`).
+ */
+
+import { AaveIntegrationAdapterABI } from "@babylonlabs-io/ts-sdk/tbv/integrations/aave";
+
+import type {
+  ProtocolGateState,
+  ScopeStatus,
+} from "@/components/shared/protocolStatus";
+import { CONTRACTS } from "@/config/contracts";
+
+import { ethClient } from "../client";
+
+/** Single-function ABI for `BTCVaultRegistry.pauseState()`. */
+const REGISTRY_PAUSE_STATE_ABI = [
+  {
+    type: "function",
+    name: "pauseState",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "uint8" }],
+  },
+] as const;
+
+// VALUE-CRITICAL: this uint8 -> status mapping gates the exit path, so a wrong
+// ordering would mis-gate (e.g. leave exits open during a real pause).
+// Confirmed against the upstream Solidity `ITBVPausable.sol`:
+//   enum PauseState { None, Frozen, Paused }  // 0, 1, 2
+// (`freeze() -> Frozen`, `pause() -> Paused`; both contracts the FE reads
+// inherit `TBVPausableUpg`). Unknown values still THROW rather than defaulting
+// to "unpaused" (no silent fallback that could mask a future enum change).
+const PAUSE_STATE = {
+  /** Normal operation. */
+  NONE: 0,
+  /** Frozen — blocks new entry, preserves exits. */
+  FROZEN: 1,
+  /** Fully paused — full stop. */
+  PAUSED: 2,
+} as const;
+
+function mapPauseState(raw: number): ScopeStatus {
+  switch (raw) {
+    case PAUSE_STATE.NONE:
+      return null;
+    case PAUSE_STATE.FROZEN:
+      return "frozen";
+    case PAUSE_STATE.PAUSED:
+      return "paused";
+    default:
+      throw new Error(
+        `Unknown ITBVPausable.PauseState value: ${raw}. The on-chain enum may have changed — update the pause-state mapping.`,
+      );
+  }
+}
+
+/**
+ * Read both scopes' pause state in a single multicall round-trip. Throws on a
+ * reverted read or an unrecognized enum value; the caller decides how to fall
+ * back (the React-Query hook treats a throw as "unknown" and defers to the
+ * operator-flag override).
+ */
+export async function getOnChainPauseState(): Promise<ProtocolGateState> {
+  const publicClient = ethClient.getPublicClient();
+
+  const [protocolRaw, aaveRaw] = (await publicClient.multicall({
+    contracts: [
+      {
+        address: CONTRACTS.BTC_VAULT_REGISTRY,
+        abi: REGISTRY_PAUSE_STATE_ABI,
+        functionName: "pauseState",
+      },
+      {
+        address: CONTRACTS.AAVE_ADAPTER,
+        abi: AaveIntegrationAdapterABI,
+        functionName: "pauseState",
+        args: [],
+      },
+    ],
+    allowFailure: false,
+  })) as [number, number];
+
+  return {
+    protocol: mapPauseState(Number(protocolRaw)),
+    aave: mapPauseState(Number(aaveRaw)),
+  };
+}

--- a/services/vault/src/components/pages/RootLayout.tsx
+++ b/services/vault/src/components/pages/RootLayout.tsx
@@ -28,6 +28,7 @@ import { useAddressScreening } from "@/context/addressScreening";
 import { useAddressType } from "@/context/addressType";
 import { useGeoFencing } from "@/context/geofencing";
 import { COPY } from "@/copy";
+import { useProtocolGateState } from "@/hooks/useProtocolGate";
 
 import {
   AaveConfigProvider,
@@ -41,7 +42,7 @@ import { GeoBlockState } from "../shared/GeoBlockState";
 import { NoticeBanner } from "../shared/NoticeBanner";
 import {
   isDepositBlocked,
-  resolveProtocolStatus,
+  resolveBannerStatus,
 } from "../shared/protocolStatus";
 import { ProtocolStatusBanner } from "../shared/ProtocolStatusBanner";
 import SimpleDeposit from "../simple/SimpleDeposit";
@@ -101,6 +102,7 @@ function MobileNavigation() {
 }
 
 export default function RootLayout() {
+  const gate = useProtocolGateState();
   const { theme, setTheme } = useTheme();
   const { connected: btcConnected } = useBTCWallet();
   const { connected: ethConnected } = useETHWallet();
@@ -153,7 +155,7 @@ export default function RootLayout() {
             !isGeoBlocked &&
             isWalletConnected &&
             FeatureFlags.isDepositDisabled &&
-            resolveProtocolStatus() === null
+            resolveBannerStatus(gate) === null
           }
         />
         <Header
@@ -187,7 +189,7 @@ export default function RootLayout() {
                   <DepositButton
                     variant="outlined"
                     rounded
-                    disabled={isDepositBlocked()}
+                    disabled={isDepositBlocked(gate)}
                     onClick={() => openDeposit()}
                   >
                     Deposit {btcConfig.coinSymbol}

--- a/services/vault/src/components/shared/ProtocolStatusBanner.tsx
+++ b/services/vault/src/components/shared/ProtocolStatusBanner.tsx
@@ -7,10 +7,11 @@ import {
 import { PAGE_CONTENT_CLASS } from "@/components/shared/layoutClasses";
 import {
   type ProtocolStatus,
-  resolveProtocolStatus,
+  resolveBannerStatus,
 } from "@/components/shared/protocolStatus";
 import featureFlags from "@/config/featureFlags";
 import { COPY } from "@/copy";
+import { useProtocolGateState } from "@/hooks/useProtocolGate";
 
 // TODO: swap for the confirmed protocol-status docs URL once product provides
 // it. Until then, enabling the freeze/pause flags in an environment should be
@@ -32,7 +33,8 @@ const STATUS_VARIANT: Record<ProtocolStatus, NotificationVariant> = {
  * shows.
  */
 export function ProtocolStatusBanner() {
-  const status = resolveProtocolStatus();
+  const gate = useProtocolGateState();
+  const status = resolveBannerStatus(gate);
   if (!status) {
     return null;
   }

--- a/services/vault/src/components/shared/__tests__/ProtocolStatusBanner.test.tsx
+++ b/services/vault/src/components/shared/__tests__/ProtocolStatusBanner.test.tsx
@@ -2,30 +2,39 @@ import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const featureFlagsMock = vi.hoisted(() => ({
-  isProtocolFrozen: false,
-  isProtocolPaused: false,
   protocolStatusMessage: undefined as string | undefined,
 }));
 vi.mock("@/config/featureFlags", () => ({
   default: featureFlagsMock,
 }));
 
+// The banner derives its status from the composed gate state, so drive the gate
+// directly here (overriding the unblocked default from the global test setup).
+const gateMock = vi.hoisted(() => ({
+  value: { protocol: null, aave: null } as {
+    protocol: string | null;
+    aave: string | null;
+  },
+}));
+vi.mock("@/hooks/useProtocolGate", () => ({
+  useProtocolGateState: () => gateMock.value,
+}));
+
 import { ProtocolStatusBanner } from "../ProtocolStatusBanner";
 
 beforeEach(() => {
-  featureFlagsMock.isProtocolFrozen = false;
-  featureFlagsMock.isProtocolPaused = false;
   featureFlagsMock.protocolStatusMessage = undefined;
+  gateMock.value = { protocol: null, aave: null };
 });
 
 describe("ProtocolStatusBanner", () => {
-  it("renders nothing when no status flag is set", () => {
+  it("renders nothing when no scope has a status", () => {
     const { container } = render(<ProtocolStatusBanner />);
     expect(container).toBeEmptyDOMElement();
   });
 
-  it("shows the frozen card with a Learn more link when frozen", () => {
-    featureFlagsMock.isProtocolFrozen = true;
+  it("shows the frozen card with a Learn more link when a scope is frozen", () => {
+    gateMock.value = { protocol: "frozen", aave: null };
 
     render(<ProtocolStatusBanner />);
 
@@ -37,8 +46,8 @@ describe("ProtocolStatusBanner", () => {
     expect(link.getAttribute("href")).toMatch(/^https?:\/\//);
   });
 
-  it("shows the paused card when paused", () => {
-    featureFlagsMock.isProtocolPaused = true;
+  it("shows the paused card when a scope is paused", () => {
+    gateMock.value = { protocol: "paused", aave: null };
 
     render(<ProtocolStatusBanner />);
 
@@ -51,9 +60,8 @@ describe("ProtocolStatusBanner", () => {
     expect(screen.getByRole("alert")).toBeInTheDocument();
   });
 
-  it("shows the paused card when both flags are set (pause wins)", () => {
-    featureFlagsMock.isProtocolFrozen = true;
-    featureFlagsMock.isProtocolPaused = true;
+  it("summarizes the most severe scope (pause wins over a concurrent freeze)", () => {
+    gateMock.value = { protocol: "frozen", aave: "paused" };
 
     render(<ProtocolStatusBanner />);
 
@@ -62,7 +70,7 @@ describe("ProtocolStatusBanner", () => {
   });
 
   it("overrides the body with NEXT_PUBLIC_PROTOCOL_STATUS_MESSAGE when set", () => {
-    featureFlagsMock.isProtocolFrozen = true;
+    gateMock.value = { protocol: "frozen", aave: null };
     featureFlagsMock.protocolStatusMessage = "Maintenance until 14:00 UTC.";
 
     render(<ProtocolStatusBanner />);

--- a/services/vault/src/components/shared/__tests__/ProtocolStatusBanner.test.tsx
+++ b/services/vault/src/components/shared/__tests__/ProtocolStatusBanner.test.tsx
@@ -40,7 +40,7 @@ describe("ProtocolStatusBanner", () => {
 
     expect(screen.getByText("Protocol is frozen")).toBeInTheDocument();
     expect(
-      screen.getByText(/New deposits and borrows are disabled/),
+      screen.getByText(/temporarily restricted while the protocol is frozen/),
     ).toBeInTheDocument();
     const link = screen.getByRole("link", { name: "Learn more" });
     expect(link.getAttribute("href")).toMatch(/^https?:\/\//);

--- a/services/vault/src/components/shared/__tests__/protocolStatus.test.ts
+++ b/services/vault/src/components/shared/__tests__/protocolStatus.test.ts
@@ -11,11 +11,25 @@ vi.mock("@/config/featureFlags", () => ({
 }));
 
 import {
+  composeGateState,
+  isActivationBlocked,
   isBorrowBlocked,
   isDepositBlocked,
   isReorderBlocked,
-  resolveProtocolStatus,
+  isRepayBlocked,
+  isWithdrawBlocked,
+  maxSeverity,
+  resolveBannerStatus,
+  type ProtocolGateState,
+  type ScopeStatus,
 } from "../protocolStatus";
+
+function gate(
+  protocol: ScopeStatus,
+  aave: ScopeStatus = null,
+): ProtocolGateState {
+  return { protocol, aave };
+}
 
 beforeEach(() => {
   featureFlagsMock.isProtocolFrozen = false;
@@ -24,71 +38,115 @@ beforeEach(() => {
   featureFlagsMock.isBorrowDisabled = false;
 });
 
-describe("resolveProtocolStatus", () => {
-  it("returns null when no status flag is set", () => {
-    expect(resolveProtocolStatus()).toBeNull();
-  });
-
-  it("returns 'frozen' when only frozen", () => {
-    featureFlagsMock.isProtocolFrozen = true;
-    expect(resolveProtocolStatus()).toBe("frozen");
-  });
-
-  it("returns 'paused' when paused (wins over frozen)", () => {
-    featureFlagsMock.isProtocolFrozen = true;
-    featureFlagsMock.isProtocolPaused = true;
-    expect(resolveProtocolStatus()).toBe("paused");
+describe("maxSeverity", () => {
+  it("ranks paused > frozen > null", () => {
+    expect(maxSeverity("frozen", "paused")).toBe("paused");
+    expect(maxSeverity("frozen", null)).toBe("frozen");
+    expect(maxSeverity(null, null)).toBeNull();
   });
 });
 
-describe("isDepositBlocked / isBorrowBlocked", () => {
-  it("both false when nothing is set", () => {
-    expect(isDepositBlocked()).toBe(false);
-    expect(isBorrowBlocked()).toBe(false);
+describe("composeGateState — operator override", () => {
+  it("uses the on-chain status when no operator flag is set", () => {
+    expect(composeGateState({ protocol: "paused", aave: null })).toEqual({
+      protocol: "paused",
+      aave: null,
+    });
   });
 
-  it("both blocked when frozen", () => {
-    featureFlagsMock.isProtocolFrozen = true;
-    expect(isDepositBlocked()).toBe(true);
-    expect(isBorrowBlocked()).toBe(true);
-  });
-
-  it("both blocked when paused", () => {
+  it("falls back to the operator flag when on-chain is null (e.g. read failed)", () => {
     featureFlagsMock.isProtocolPaused = true;
-    expect(isDepositBlocked()).toBe(true);
-    expect(isBorrowBlocked()).toBe(true);
+    expect(composeGateState(null)).toEqual({
+      protocol: "paused",
+      aave: "paused",
+    });
   });
 
-  it("respects the standalone DISABLE_DEPOSIT / DISABLE_BORROW kill-switches independently", () => {
+  it("takes the more severe of on-chain and operator per scope", () => {
+    featureFlagsMock.isProtocolFrozen = true; // global frozen override
+    expect(composeGateState({ protocol: null, aave: "paused" })).toEqual({
+      protocol: "frozen",
+      aave: "paused",
+    });
+  });
+
+  it("does not block exits on a failed read unless an operator flag is set", () => {
+    // on-chain null (read failed) + no operator flag → nothing blocked.
+    const g = composeGateState(null);
+    expect(isWithdrawBlocked(g)).toBe(false);
+    expect(isRepayBlocked(g)).toBe(false);
+    expect(isActivationBlocked(g)).toBe(false);
+  });
+});
+
+describe("entry gating — blocks on any non-null status for its scope", () => {
+  it("deposit is protocol-scope (frozen OR paused)", () => {
+    expect(isDepositBlocked(gate(null))).toBe(false);
+    expect(isDepositBlocked(gate("frozen"))).toBe(true);
+    expect(isDepositBlocked(gate("paused"))).toBe(true);
+    // An aave-scope status does NOT block deposit.
+    expect(isDepositBlocked(gate(null, "paused"))).toBe(false);
+  });
+
+  it("borrow is aave-scope (frozen OR paused)", () => {
+    expect(isBorrowBlocked(gate(null, null))).toBe(false);
+    expect(isBorrowBlocked(gate(null, "frozen"))).toBe(true);
+    expect(isBorrowBlocked(gate(null, "paused"))).toBe(true);
+    // A protocol-scope status does NOT block borrow.
+    expect(isBorrowBlocked(gate("paused", null))).toBe(false);
+  });
+
+  it("reorder is aave-scope (frozen OR paused)", () => {
+    expect(isReorderBlocked(gate(null, null))).toBe(false);
+    expect(isReorderBlocked(gate(null, "frozen"))).toBe(true);
+    expect(isReorderBlocked(gate(null, "paused"))).toBe(true);
+    expect(isReorderBlocked(gate("paused", null))).toBe(false);
+  });
+
+  it("honors the standalone DISABLE_DEPOSIT / DISABLE_BORROW kill-switches", () => {
     featureFlagsMock.isDepositDisabled = true;
-    expect(isDepositBlocked()).toBe(true);
-    expect(isBorrowBlocked()).toBe(false);
+    expect(isDepositBlocked(gate(null, null))).toBe(true);
+    expect(isBorrowBlocked(gate(null, null))).toBe(false);
 
     featureFlagsMock.isDepositDisabled = false;
     featureFlagsMock.isBorrowDisabled = true;
-    expect(isDepositBlocked()).toBe(false);
-    expect(isBorrowBlocked()).toBe(true);
+    expect(isBorrowBlocked(gate(null, null))).toBe(true);
+    expect(isDepositBlocked(gate(null, null))).toBe(false);
   });
 });
 
-describe("isReorderBlocked", () => {
-  it("false when nothing is set", () => {
-    expect(isReorderBlocked()).toBe(false);
+describe("exit gating — blocks only on PAUSE (Freeze preserves exits)", () => {
+  it("Freeze never blocks any exit", () => {
+    const frozen = gate("frozen", "frozen");
+    expect(isWithdrawBlocked(frozen)).toBe(false);
+    expect(isActivationBlocked(frozen)).toBe(false);
+    expect(isRepayBlocked(frozen)).toBe(false);
   });
 
-  it("blocked when frozen (reorder is an Aave-scope new-entry action)", () => {
-    featureFlagsMock.isProtocolFrozen = true;
-    expect(isReorderBlocked()).toBe(true);
+  it("withdraw is blocked if EITHER scope is paused", () => {
+    expect(isWithdrawBlocked(gate(null, null))).toBe(false);
+    expect(isWithdrawBlocked(gate("paused", null))).toBe(true);
+    expect(isWithdrawBlocked(gate(null, "paused"))).toBe(true);
   });
 
-  it("blocked when paused", () => {
-    featureFlagsMock.isProtocolPaused = true;
-    expect(isReorderBlocked()).toBe(true);
+  it("activation is blocked if EITHER scope is paused", () => {
+    expect(isActivationBlocked(gate(null, null))).toBe(false);
+    expect(isActivationBlocked(gate("paused", null))).toBe(true);
+    expect(isActivationBlocked(gate(null, "paused"))).toBe(true);
   });
 
-  it("ignores the deposit/borrow kill-switches — it is governance-gated only", () => {
-    featureFlagsMock.isDepositDisabled = true;
-    featureFlagsMock.isBorrowDisabled = true;
-    expect(isReorderBlocked()).toBe(false);
+  it("repay is blocked ONLY by an aave pause (not a protocol pause)", () => {
+    expect(isRepayBlocked(gate(null, null))).toBe(false);
+    expect(isRepayBlocked(gate(null, "paused"))).toBe(true);
+    // Protocol-only pause must keep repay available — the user can still de-risk.
+    expect(isRepayBlocked(gate("paused", null))).toBe(false);
+  });
+});
+
+describe("resolveBannerStatus", () => {
+  it("summarizes the most severe scope status", () => {
+    expect(resolveBannerStatus(gate(null, null))).toBeNull();
+    expect(resolveBannerStatus(gate("frozen", null))).toBe("frozen");
+    expect(resolveBannerStatus(gate("frozen", "paused"))).toBe("paused");
   });
 });

--- a/services/vault/src/components/shared/protocolStatus.ts
+++ b/services/vault/src/components/shared/protocolStatus.ts
@@ -1,61 +1,105 @@
 import featureFlags from "@/config/featureFlags";
 
 /**
- * Protocol governance status, using the Aave-aligned naming (Freeze / Pause):
- * - "frozen": blocks new entry (deposits, borrows, …) but preserves exits.
- * - "paused": full stop.
+ * Governance status of a single scope, using the Aave-aligned naming:
+ * - "frozen": blocks new ENTRY (deposit/borrow/reorder) but preserves EXITS.
+ * - "paused": full stop — also blocks exits (withdraw/repay/activation).
+ * - null:    normal operation.
+ *
+ * The protocol has two independent scopes, each with its own status:
+ * - protocol scope: `BTCVaultRegistry` — governs pegin/deposit + activation.
+ * - aave scope:     `AaveIntegrationAdapter` — governs borrow/reorder/repay.
  *
  * See the governance spec for the per-operation matrix:
  * https://babylonlabs.atlassian.net/wiki/spaces/BABYLON/pages/398655537
  */
-export type ProtocolStatus = "frozen" | "paused";
+export type ScopeStatus = "frozen" | "paused" | null;
 
-/**
- * Resolves the active protocol status from the operator feature flags.
- *
- * Operator-controlled and flag-driven for now: each contract does expose its
- * Frozen/Paused state (and Frozen/Paused events) on-chain, but we intentionally
- * drive the banner from an operator flag rather than reading them — wiring the
- * on-chain detection is the follow-up. Pause wins over freeze when both are set.
- * Shared by the status banner and by RootLayout (which suppresses the
- * deposit-disabled banner while a status banner is showing).
- */
-export function resolveProtocolStatus(): ProtocolStatus | null {
-  if (featureFlags.isProtocolPaused) {
-    return "paused";
-  }
-  if (featureFlags.isProtocolFrozen) {
-    return "frozen";
-  }
+/** Non-null scope status — the two states the status banner renders. */
+export type ProtocolStatus = Exclude<ScopeStatus, null>;
+
+/** Per-scope governance status snapshot. */
+export interface ProtocolGateState {
+  protocol: ScopeStatus;
+  aave: ScopeStatus;
+}
+
+/** The more severe of two scope statuses (paused > frozen > null). */
+export function maxSeverity(a: ScopeStatus, b: ScopeStatus): ScopeStatus {
+  if (a === "paused" || b === "paused") return "paused";
+  if (a === "frozen" || b === "frozen") return "frozen";
   return null;
 }
 
 /**
- * Whether new deposits are blocked right now — either by the DISABLE_DEPOSIT
- * kill-switch or because the protocol is frozen or paused (both block new
- * entry). Routing the deposit CTAs through this makes the status actually
- * enforce, so the banner reflects reality instead of just describing it.
+ * The operator-flag status. Operator flags are a global manual override (a
+ * DevOps "big red button") applied to BOTH scopes — the interim control that
+ * predates on-chain detection. Pause wins over freeze.
  */
-export function isDepositBlocked(): boolean {
-  return featureFlags.isDepositDisabled || resolveProtocolStatus() !== null;
+function operatorScopeStatus(): ScopeStatus {
+  if (featureFlags.isProtocolPaused) return "paused";
+  if (featureFlags.isProtocolFrozen) return "frozen";
+  return null;
 }
 
 /**
- * Whether new borrows are blocked right now — either by the DISABLE_BORROW
- * kill-switch or because the protocol is frozen or paused (both block new
- * borrows).
+ * Compose the effective per-scope gate state from the on-chain reads and the
+ * operator-flag override, taking the more severe of the two per scope.
+ *
+ * On-chain `null` means either "scope is healthy" or "read unavailable" — both
+ * collapse to the operator-flag value here. This gives the safe default for
+ * EXITS: a failed RPC read never blocks an exit on its own (it would only be
+ * blocked if the operator explicitly set the pause flag). Over-blocking an exit
+ * traps users, so exits fail open; entries can still be operator-blocked.
  */
-export function isBorrowBlocked(): boolean {
-  return featureFlags.isBorrowDisabled || resolveProtocolStatus() !== null;
+export function composeGateState(
+  onChain: ProtocolGateState | null,
+): ProtocolGateState {
+  const operator = operatorScopeStatus();
+  return {
+    protocol: maxSeverity(onChain?.protocol ?? null, operator),
+    aave: maxSeverity(onChain?.aave ?? null, operator),
+  };
 }
 
-/**
- * Whether vault reordering is blocked right now. Reorder (`reorderVaults`) is an
- * Aave-scope new-entry action, so Freeze and Pause both block it — gated exactly
- * like deposit/borrow. Unlike those it has no standalone kill-switch; reorder is
- * governance-gated only. Freeze preserves the exits (withdraw, repay,
- * activation, redemption), which is why no helper gates them here.
- */
-export function isReorderBlocked(): boolean {
-  return resolveProtocolStatus() !== null;
+/** The status the banner summarizes — the most severe across both scopes. */
+export function resolveBannerStatus(gate: ProtocolGateState): ScopeStatus {
+  return maxSeverity(gate.protocol, gate.aave);
+}
+
+// ── Per-action gating predicates ───────────────────────────────────────────
+// Pure functions of the gate state (plus the standalone kill-switches). Each
+// implements one row of the governance matrix. ENTRY actions block on any
+// non-null status for their scope; EXIT actions block only on "paused" (Freeze
+// preserves exits). Scope accuracy matters: e.g. repay must stay available
+// under a protocol-only pause, so it checks the aave scope only.
+
+/** Deposit (pegin) is a protocol-scope ENTRY action. */
+export function isDepositBlocked(gate: ProtocolGateState): boolean {
+  return featureFlags.isDepositDisabled || gate.protocol !== null;
+}
+
+/** Borrow is an aave-scope ENTRY action. */
+export function isBorrowBlocked(gate: ProtocolGateState): boolean {
+  return featureFlags.isBorrowDisabled || gate.aave !== null;
+}
+
+/** Reorder is an aave-scope ENTRY action. */
+export function isReorderBlocked(gate: ProtocolGateState): boolean {
+  return gate.aave !== null;
+}
+
+/** Withdraw (+redeem) is an EXIT blocked if EITHER scope is paused. */
+export function isWithdrawBlocked(gate: ProtocolGateState): boolean {
+  return gate.protocol === "paused" || gate.aave === "paused";
+}
+
+/** Activation is an EXIT blocked if EITHER scope is paused (preserved under freeze). */
+export function isActivationBlocked(gate: ProtocolGateState): boolean {
+  return gate.protocol === "paused" || gate.aave === "paused";
+}
+
+/** Repay is an aave-scope EXIT blocked ONLY by an aave pause (not protocol). */
+export function isRepayBlocked(gate: ProtocolGateState): boolean {
+  return gate.aave === "paused";
 }

--- a/services/vault/src/components/simple/ActivateConfirmationModal.tsx
+++ b/services/vault/src/components/simple/ActivateConfirmationModal.tsx
@@ -13,7 +13,9 @@ import {
   RecoveryArtifactsCard,
   type RecoveryArtifactsCardHandle,
 } from "@/components/deposit/RecoveryArtifactsCard";
+import { isActivationBlocked } from "@/components/shared/protocolStatus";
 import { COPY } from "@/copy";
+import { useProtocolGateState } from "@/hooks/useProtocolGate";
 import { hasArtifactsDownloaded } from "@/utils/artifactDownloadStorage";
 
 interface ActivateConfirmationModalProps {
@@ -64,7 +66,9 @@ export function ActivateConfirmationModal({
   };
 
   const canRenderCard = Boolean(providerAddress && peginTxid && depositorPk);
-  const canActivate = downloaded || acknowledged;
+  const gate = useProtocolGateState();
+  const canActivate =
+    (downloaded || acknowledged) && !isActivationBlocked(gate);
 
   return (
     <ResponsiveDialog

--- a/services/vault/src/components/simple/CollateralSection.tsx
+++ b/services/vault/src/components/simple/CollateralSection.tsx
@@ -28,10 +28,12 @@ import { SUMMARY_CARD_CLASS } from "@/components/shared/layoutClasses";
 import {
   isDepositBlocked,
   isReorderBlocked,
+  isWithdrawBlocked,
 } from "@/components/shared/protocolStatus";
 import { FeatureFlags, getNetworkConfigBTC } from "@/config";
 import { COPY } from "@/copy";
 import { useVaultProviders } from "@/hooks/deposit/useVaultProviders";
+import { useProtocolGateState } from "@/hooks/useProtocolGate";
 import { logger } from "@/infrastructure";
 import type { CollateralVaultEntry } from "@/types/collateral";
 import { invalidateVaultQueries } from "@/utils/queryKeys";
@@ -84,6 +86,7 @@ export function CollateralSection({
   const [isReorderOpen, setIsReorderOpen] = useState(false);
   const [isReorderSuccess, setIsReorderSuccess] = useState(false);
   const { findProvider } = useVaultProviders();
+  const gate = useProtocolGateState();
   const queryClient = useQueryClient();
   const { address } = useAccount();
 
@@ -239,7 +242,7 @@ export function CollateralSection({
             variant="outlined"
             size="large"
             onClick={() => onDeposit()}
-            disabled={!isConnected || isDepositBlocked()}
+            disabled={!isConnected || isDepositBlocked(gate)}
             className="rounded-full"
           >
             Deposit
@@ -249,7 +252,8 @@ export function CollateralSection({
               onWithdraw={() => setIsWithdrawOpen(true)}
               onReorder={() => setIsReorderOpen(true)}
               canReorder={canReorder}
-              reorderBlocked={isReorderBlocked()}
+              reorderBlocked={isReorderBlocked(gate)}
+              withdrawBlocked={isWithdrawBlocked(gate)}
             />
           )}
         </div>

--- a/services/vault/src/components/simple/PositionNotificationBanner/BannerActions.tsx
+++ b/services/vault/src/components/simple/PositionNotificationBanner/BannerActions.tsx
@@ -15,6 +15,10 @@ interface BuildBannerActionsArgs {
   isReordering: boolean;
   /** Freeze/Pause blocks `reorderVaults`; disables the "Apply Optimal Order" CTA. */
   reorderBlocked: boolean;
+  /** Protocol Freeze/Pause blocks new deposits; disables the add-collateral / add-vault CTAs. */
+  depositBlocked: boolean;
+  /** An aave Pause blocks repay; disables the "Repay Debt" CTA. */
+  repayBlocked: boolean;
 }
 
 /**
@@ -42,6 +46,8 @@ export function buildBannerActions({
   onApplyOrder,
   isReordering,
   reorderBlocked,
+  depositBlocked,
+  repayBlocked,
 }: BuildBannerActionsArgs): NotificationAction[] {
   const { primaryWarning, suggestReorder } = bannerState;
   const isUrgent = primaryWarning?.type === "urgent";
@@ -55,11 +61,16 @@ export function buildBannerActions({
         label: COPY.banner.addCollateral,
         onClick: () => onDeposit(),
         emphasis: "primary",
+        // Adding collateral is a deposit (protocol-scope entry) — blocked under
+        // a protocol Freeze/Pause. The status banner explains why.
+        disabled: depositBlocked,
       },
       {
         label: COPY.banner.repayDebt,
         onClick: onRepay,
         emphasis: "secondary",
+        // Repay is blocked only by an aave Pause (preserved under Freeze).
+        disabled: repayBlocked,
       },
     );
   }
@@ -86,6 +97,8 @@ export function buildBannerActions({
         : COPY.banner.addVault(amountBtc),
       onClick: () => onDeposit(amountBtc),
       emphasis: isUrgent ? "secondary" : "primary",
+      // Adding a vault is a deposit — blocked under a protocol Freeze/Pause.
+      disabled: depositBlocked,
     });
   }
 

--- a/services/vault/src/components/simple/PositionNotificationBanner/PositionNotificationBanner.tsx
+++ b/services/vault/src/components/simple/PositionNotificationBanner/PositionNotificationBanner.tsx
@@ -20,8 +20,13 @@ import {
   type CalculatorResult,
   type WarningType,
 } from "@/applications/aave/positionNotifications";
-import { isReorderBlocked } from "@/components/shared/protocolStatus";
+import {
+  isDepositBlocked,
+  isReorderBlocked,
+  isRepayBlocked,
+} from "@/components/shared/protocolStatus";
 import { COPY } from "@/copy";
+import { useProtocolGateState } from "@/hooks/useProtocolGate";
 import { invalidateVaultQueries } from "@/utils/queryKeys";
 
 import { ReorderSuccessModal } from "../ReorderVaults";
@@ -81,6 +86,7 @@ export function PositionNotificationBanner({
   const hasOverride = resultOverride !== undefined;
   const result = hasOverride ? resultOverride : hookResult;
 
+  const gate = useProtocolGateState();
   const { executeReorder, isProcessing: isReordering } = useReorderVaults();
   const { applyReorderedOrder } = useReorderOverride();
   const [isReorderSuccess, setIsReorderSuccess] = useState(false);
@@ -221,7 +227,9 @@ export function PositionNotificationBanner({
     onRepay,
     onApplyOrder: handleApplyOrder,
     isReordering,
-    reorderBlocked: isReorderBlocked(),
+    reorderBlocked: isReorderBlocked(gate),
+    depositBlocked: isDepositBlocked(gate),
+    repayBlocked: isRepayBlocked(gate),
   });
 
   // Sub-box content: the optimal-order chips for the standalone reorder card,

--- a/services/vault/src/components/simple/PositionNotificationBanner/__tests__/BannerActions.test.ts
+++ b/services/vault/src/components/simple/PositionNotificationBanner/__tests__/BannerActions.test.ts
@@ -8,9 +8,9 @@ import { COPY } from "@/copy";
 
 import { buildBannerActions } from "../BannerActions";
 
-// A healthy position whose on-chain order is suboptimal: the only action is the
-// standalone "Apply Optimal Order" reorder CTA.
-function makeReorderResult(): CalculatorResult {
+function makeResult(
+  overrides: Partial<CalculatorResult> = {},
+): CalculatorResult {
   return {
     groups: [],
     currentHF: 1.2,
@@ -23,9 +23,36 @@ function makeReorderResult(): CalculatorResult {
     ],
     suggestedNewVaultBtc: null,
     suggestedRebalanceVaultBtc: null,
+    ...overrides,
   };
 }
 
+interface GateOpts {
+  reorderBlocked?: boolean;
+  depositBlocked?: boolean;
+  repayBlocked?: boolean;
+}
+
+function build(
+  bannerState: BannerState,
+  result: CalculatorResult,
+  gate: GateOpts = {},
+) {
+  return buildBannerActions({
+    result,
+    bannerState,
+    onDeposit: vi.fn(),
+    onRepay: vi.fn(),
+    onApplyOrder: vi.fn(),
+    isReordering: false,
+    reorderBlocked: gate.reorderBlocked ?? false,
+    depositBlocked: gate.depositBlocked ?? false,
+    repayBlocked: gate.repayBlocked ?? false,
+  });
+}
+
+// A healthy position whose on-chain order is suboptimal: the only action is the
+// standalone "Apply Optimal Order" reorder CTA.
 const REORDER_BANNER_STATE: BannerState = {
   severity: "soft",
   primaryWarning: null,
@@ -33,34 +60,106 @@ const REORDER_BANNER_STATE: BannerState = {
   suggestReorder: true,
 };
 
-function buildReorderActions(reorderBlocked: boolean) {
-  return buildBannerActions({
-    result: makeReorderResult(),
-    bannerState: REORDER_BANNER_STATE,
-    onDeposit: vi.fn(),
-    onRepay: vi.fn(),
-    onApplyOrder: vi.fn(),
-    isReordering: false,
-    reorderBlocked,
-  });
-}
+// An urgent (near-liquidation) position: shows "Add Collateral" + "Repay Debt".
+const URGENT_BANNER_STATE: BannerState = {
+  severity: "red",
+  primaryWarning: {
+    type: "urgent",
+    title: "Liquidation can trigger now",
+    detail: "…",
+  },
+  secondaryWarnings: [],
+  suggestReorder: false,
+};
 
 describe("buildBannerActions — reorder gating", () => {
   it("enables the Apply Optimal Order CTA when reorder is not blocked", () => {
-    const actions = buildReorderActions(false);
+    const actions = build(REORDER_BANNER_STATE, makeResult());
     const apply = actions.find(
       (a) => a.label === COPY.banner.applyOptimalOrder,
     );
-    expect(apply).toBeDefined();
     expect(apply?.disabled).toBe(false);
   });
 
   it("disables the Apply Optimal Order CTA when Freeze/Pause blocks reorder", () => {
-    const actions = buildReorderActions(true);
+    const actions = build(REORDER_BANNER_STATE, makeResult(), {
+      reorderBlocked: true,
+    });
     const apply = actions.find(
       (a) => a.label === COPY.banner.applyOptimalOrder,
     );
-    expect(apply).toBeDefined();
     expect(apply?.disabled).toBe(true);
+  });
+});
+
+describe("buildBannerActions — urgent CTA gating", () => {
+  it("leaves Add Collateral and Repay Debt enabled when nothing is blocked", () => {
+    const actions = build(URGENT_BANNER_STATE, makeResult());
+    expect(
+      actions.find((a) => a.label === COPY.banner.addCollateral)?.disabled,
+    ).toBe(false);
+    expect(
+      actions.find((a) => a.label === COPY.banner.repayDebt)?.disabled,
+    ).toBe(false);
+  });
+
+  it("disables Add Collateral when deposits are blocked (protocol Freeze/Pause)", () => {
+    const actions = build(URGENT_BANNER_STATE, makeResult(), {
+      depositBlocked: true,
+    });
+    expect(
+      actions.find((a) => a.label === COPY.banner.addCollateral)?.disabled,
+    ).toBe(true);
+    // Repay is independent — an aave pause, not a deposit block, gates it.
+    expect(
+      actions.find((a) => a.label === COPY.banner.repayDebt)?.disabled,
+    ).toBe(false);
+  });
+
+  it("disables Repay Debt when repay is blocked (aave Pause)", () => {
+    const actions = build(URGENT_BANNER_STATE, makeResult(), {
+      repayBlocked: true,
+    });
+    expect(
+      actions.find((a) => a.label === COPY.banner.repayDebt)?.disabled,
+    ).toBe(true);
+    expect(
+      actions.find((a) => a.label === COPY.banner.addCollateral)?.disabled,
+    ).toBe(false);
+  });
+
+  it("disables the cliff Add-sacrificial-vault CTA when deposits are blocked", () => {
+    const cliffState: BannerState = {
+      severity: "yellow",
+      primaryWarning: {
+        type: "cliff",
+        title: "First liquidation takes everything",
+        detail: "…",
+      },
+      secondaryWarnings: [],
+      suggestReorder: false,
+    };
+    const cliffResult = makeResult({
+      warnings: [
+        {
+          type: "cliff",
+          title: "First liquidation takes everything",
+          detail: "…",
+        },
+      ],
+      suggestedNewVaultBtc: 0.14,
+    });
+
+    expect(
+      build(cliffState, cliffResult).find(
+        (a) => a.label === COPY.banner.addSacrificialVault,
+      )?.disabled,
+    ).toBe(false);
+
+    expect(
+      build(cliffState, cliffResult, { depositBlocked: true }).find(
+        (a) => a.label === COPY.banner.addSacrificialVault,
+      )?.disabled,
+    ).toBe(true);
   });
 });

--- a/services/vault/src/components/simple/SimpleDeposit.tsx
+++ b/services/vault/src/components/simple/SimpleDeposit.tsx
@@ -14,6 +14,7 @@ import { useDepositPeginFee } from "@/hooks/deposit/useDepositPeginFee";
 import { useDialogStep } from "@/hooks/deposit/useDialogStep";
 import { usePendingVaultOverlapCheck } from "@/hooks/deposit/usePendingVaultOverlapCheck";
 import { useProtocolFeeRows } from "@/hooks/useProtocolFeeRows";
+import { useProtocolGateState } from "@/hooks/useProtocolGate";
 import { useVaultCountCap } from "@/hooks/useVaultCountCap";
 import { resolveVaultCapState } from "@/services/deposit/vaultCap";
 import type { VaultActivity } from "@/types/activity";
@@ -74,6 +75,7 @@ function SimpleDepositContent({
   onClose,
   initialAmountBtc,
 }: SimpleDepositBaseProps) {
+  const gate = useProtocolGateState();
   const { isGeoBlocked, isLoading: isGeoLoading } = useGeoFencing();
   const { isBlocked: isAddressBlocked, isLoading: isScreeningLoading } =
     useAddressScreening();
@@ -313,7 +315,7 @@ function SimpleDepositContent({
     // if a deposit entry point that bypasses the disabled buttons (e.g. the
     // Activity empty-state CTA or the urgent Add Collateral banner) opens this
     // dialog.
-    if (isDepositBlocked()) return;
+    if (isDepositBlocked(gate)) return;
 
     // Per-position BTC Vault cap: never start a deposit that would push the
     // position past the on-chain cap, or when the cap couldn't be read (fail
@@ -455,7 +457,7 @@ function SimpleDepositContent({
                   isReconnectingWallet,
                 }}
                 gatingState={{
-                  isDepositDisabled: isDepositBlocked(),
+                  isDepositDisabled: isDepositBlocked(gate),
                   isGeoBlocked: isGeoBlocked || isGeoLoading,
                   isAddressBlocked: isAddressBlocked || isScreeningLoading,
                   ordinalsCheckPending,

--- a/services/vault/src/components/simple/WithdrawVaults/CollateralActionsMenu.tsx
+++ b/services/vault/src/components/simple/WithdrawVaults/CollateralActionsMenu.tsx
@@ -28,6 +28,8 @@ interface CollateralActionsMenuProps {
   canReorder: boolean;
   /** Freeze/Pause blocks `reorderVaults`; disables the Reorder row. */
   reorderBlocked: boolean;
+  /** Pause (either scope) blocks withdrawal; disables the Withdraw row. */
+  withdrawBlocked: boolean;
 }
 
 export function CollateralActionsMenu({
@@ -35,6 +37,7 @@ export function CollateralActionsMenu({
   onReorder,
   canReorder,
   reorderBlocked,
+  withdrawBlocked,
 }: CollateralActionsMenuProps) {
   const [open, setOpen] = useState(false);
   const anchorRef = useRef<HTMLButtonElement>(null);
@@ -70,6 +73,7 @@ export function CollateralActionsMenu({
             <button
               type="button"
               role="menuitem"
+              disabled={withdrawBlocked}
               onClick={() => runAction(onWithdraw)}
               className={MENU_ITEM_CLASS}
             >

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -856,6 +856,11 @@ export const COPY = {
       "Borrowing is temporarily unavailable. Please check back later.",
     priceUnavailable:
       "Price data unavailable. Borrowing is temporarily disabled.",
+    // Shown on the Repay tab when repay is blocked by a protocol pause (not a
+    // technical/user error), so a user near liquidation knows it's governance,
+    // not a bug. Repay is gated only by an aave-scope pause.
+    repayingUnavailable:
+      "Repaying is temporarily unavailable while the protocol is paused. It will resume once the pause is lifted.",
     // Borrow tab — action-button labels (also used as the status-callout title).
     borrow: {
       action: "Borrow",
@@ -911,6 +916,8 @@ export const COPY = {
     repay: {
       action: "Repay",
       processing: "Processing...",
+      // Action-button label when repay is blocked by a protocol pause.
+      unavailable: "Repaying Unavailable",
       enterAmount: "Enter an amount",
       amountTooSmall: "Amount too small",
       amountExceedsDebt: "Amount exceeds debt",

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -84,6 +84,11 @@ export const COPY = {
     },
     // Row label for the vault creation time (rendered as relative time).
     createdLabel: "Created",
+    // Shown if activation is attempted while the protocol is paused — surfaced
+    // as the activation error so the spinner clears and the user understands
+    // it's a governance pause (not a failed secret). Activation resumes on unpause.
+    activationPaused:
+      "Activation is paused by a protocol governance action. Your BTC Vault stays safe — activation will resume once the pause is lifted.",
     messages: {
       payoutSignaturesSubmitted:
         "Payout signatures submitted. Vault provider is verifying and collecting acknowledgments...",
@@ -483,6 +488,11 @@ export const COPY = {
     errors: {
       invalidSecret:
         "Invalid secret: SHA256(secret) does not match the BTC Vault's hashlock. Please check your secret and try again.",
+      // Surfaced if deposit execution is reached while the protocol is frozen or
+      // paused — aborted up front, before the on-chain registration and the BTC
+      // broadcast, so no funds are locked and the user can retry once it resumes.
+      protocolPaused:
+        "New deposits are temporarily disabled while the protocol is frozen or paused. No Bitcoin was sent — please try again once it resumes.",
       chainSwitchRequired: (network: string) =>
         `Please switch to ${network} in your wallet`,
       ethereumMainnet: "Ethereum Mainnet",
@@ -1079,12 +1089,19 @@ export const COPY = {
   protocolStatus: {
     frozen: {
       title: "Protocol is frozen",
-      body: "New deposits and borrows are disabled. You can still repay debt — liquidations remain active.",
+      // Non-specific about which actions: gating is per-scope, so naming
+      // "deposits and borrows" can be inaccurate (e.g. an aave-only freeze
+      // leaves deposits working). Exits are always preserved under a freeze, so
+      // that reassurance is safe to state. The per-action buttons are the
+      // precise source of truth.
+      body: "Some new actions are temporarily restricted while the protocol is frozen. Any unavailable action is disabled and explains why. Your exits — repay, withdraw, and activation — stay available.",
       learnMore: PROTOCOL_STATUS_LEARN_MORE,
     },
     paused: {
       title: "Protocol is paused",
-      body: "New deposits and borrows are disabled. Debt continues accruing interest. Monitor official announcements.",
+      // Non-specific for the same reason — under a per-scope pause the exact set
+      // of blocked actions varies. Each affected button explains itself.
+      body: "Some actions are temporarily unavailable while the protocol is paused. Any unavailable action is disabled and explains why. Debt continues accruing interest — monitor official announcements.",
       learnMore: PROTOCOL_STATUS_LEARN_MORE,
     },
   },

--- a/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
@@ -37,6 +37,14 @@ vi.mock("@babylonlabs-io/wallet-connector", () => ({
   useChainConnector: vi.fn(),
 }));
 
+// Local override of the global gate mock so we can drive a frozen/paused scope.
+const depositGateMock = vi.hoisted(() => ({
+  value: { protocol: null as string | null, aave: null as string | null },
+}));
+vi.mock("@/hooks/useProtocolGate", () => ({
+  useProtocolGateState: () => depositGateMock.value,
+}));
+
 // Avoid threading a real QueryClientProvider through every renderHook —
 // `useDepositFlow` only uses the client to invalidate the UTXO query
 // after broadcast; a stub is sufficient for adapter-wiring tests.
@@ -368,7 +376,40 @@ async function setupDefaultMocks() {
 describe("useDepositFlow", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
+    depositGateMock.value = { protocol: null, aave: null };
     await setupDefaultMocks();
+  });
+
+  describe("Protocol pause gating", () => {
+    it("aborts before any side effect when the protocol is frozen/paused", async () => {
+      depositGateMock.value = { protocol: "paused", aave: null };
+
+      const { preparePeginTransaction } = vi.mocked(
+        await import("@/services/vault/vaultTransactionService"),
+      );
+      const { registerPeginBatchAndWait } = vi.mocked(
+        await import("../depositFlowSteps"),
+      );
+      const { broadcastPrePeginTransaction } = vi.mocked(
+        await import("@/services/vault/vaultPeginBroadcastService"),
+      );
+
+      const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
+
+      let resolved: unknown;
+      await act(async () => {
+        resolved = await result.current.executeDeposit();
+      });
+
+      expect(resolved).toBeNull();
+      expect(result.current.error?.body).toBe(
+        COPY.deposit.errors.protocolPaused,
+      );
+      // No BTC was sent and nothing was registered — aborted up front.
+      expect(preparePeginTransaction).not.toHaveBeenCalled();
+      expect(registerPeginBatchAndWait).not.toHaveBeenCalled();
+      expect(broadcastPrePeginTransaction).not.toHaveBeenCalled();
+    });
   });
 
   describe("Batch Pre-PegIn Creation", () => {

--- a/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
+++ b/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
@@ -60,6 +60,19 @@ vi.mock("@/clients/eth-contract/btc-vault-registry/query", () => ({
   ),
 }));
 
+// Fresh on-chain pause read used by the activation preflight. Holder so tests
+// can simulate a pause landing in the stale-gate window (cached gate unblocked,
+// fresh read paused). Defaults unblocked.
+const onChainPauseMock = vi.hoisted(() => ({
+  value: { protocol: null, aave: null } as {
+    protocol: string | null;
+    aave: string | null;
+  } | null,
+}));
+vi.mock("@/clients/eth-contract/pause-state/query", () => ({
+  getOnChainPauseState: () => Promise.resolve(onChainPauseMock.value),
+}));
+
 vi.mock("@babylonlabs-io/wallet-connector", () => ({
   getSharedWagmiConfig: vi.fn(() => ({})),
   useChainConnector: vi.fn(() => ({
@@ -720,6 +733,7 @@ describe("useVaultActions — handleActivation hashlock source", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     gateMock.value = { protocol: null, aave: null };
+    onChainPauseMock.value = { protocol: null, aave: null };
   });
 
   it("does not reveal the secret on-chain when a scope is paused", async () => {
@@ -740,6 +754,27 @@ describe("useVaultActions — handleActivation hashlock source", () => {
 
     expect(reader.getVaultData).not.toHaveBeenCalled();
     expect(mockActivateVaultWithSecret).not.toHaveBeenCalled();
+  });
+
+  it("re-checks pause on-chain before revealing the secret (catches a pause in the stale-gate window)", async () => {
+    // Cached gate is unblocked, but a FRESH read shows a pause landed while the
+    // user sat on the activate screen. The secret must not reach the tx.
+    gateMock.value = { protocol: null, aave: null };
+    onChainPauseMock.value = { protocol: null, aave: "paused" };
+    const reader = readerReturning({
+      depositorSignedPeginTx: "0xdeadbeef",
+      hashlock: ON_CHAIN_HASHLOCK,
+    });
+    mockGetVaultRegistryReader.mockReturnValue(reader);
+
+    const { result } = renderHook(() => useVaultActions());
+
+    await act(async () => {
+      await result.current.handleActivation(baseActivationParams);
+    });
+
+    expect(mockActivateVaultWithSecret).not.toHaveBeenCalled();
+    expect(result.current.activationError).not.toBeNull();
   });
 
   it("uses the on-chain hashlock and never reads the indexer hashlock", async () => {

--- a/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
+++ b/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
@@ -22,6 +22,15 @@ const mockCalculateBtcTxHash = vi.hoisted(() =>
   vi.fn(() => "0xmatching_pre_pegin_hash"),
 );
 
+// Local override of the global gate mock so we can drive a paused scope. Plain
+// holder (not vi.fn) so `vi.clearAllMocks()` can't reset it; defaults unblocked.
+const gateMock = vi.hoisted(() => ({
+  value: { protocol: null as string | null, aave: null as string | null },
+}));
+vi.mock("@/hooks/useProtocolGate", () => ({
+  useProtocolGateState: () => gateMock.value,
+}));
+
 vi.mock("@/config/network", () => ({
   getETHChain: vi.fn(() => ({ id: 11155111 })),
 }));
@@ -710,6 +719,27 @@ describe("useVaultActions — handleActivation hashlock source", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    gateMock.value = { protocol: null, aave: null };
+  });
+
+  it("does not reveal the secret on-chain when a scope is paused", async () => {
+    // Activation is an EXIT blocked under Pause (either scope). The guard must
+    // short-circuit before any on-chain read or the secret-revealing tx.
+    gateMock.value = { protocol: null, aave: "paused" };
+    const reader = readerReturning({
+      depositorSignedPeginTx: "0xdeadbeef",
+      hashlock: ON_CHAIN_HASHLOCK,
+    });
+    mockGetVaultRegistryReader.mockReturnValue(reader);
+
+    const { result } = renderHook(() => useVaultActions());
+
+    await act(async () => {
+      await result.current.handleActivation(baseActivationParams);
+    });
+
+    expect(reader.getVaultData).not.toHaveBeenCalled();
+    expect(mockActivateVaultWithSecret).not.toHaveBeenCalled();
   });
 
   it("uses the on-chain hashlock and never reads the indexer hashlock", async () => {

--- a/services/vault/src/hooks/deposit/useDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useDepositFlow.ts
@@ -37,9 +37,11 @@ import {
   getVaultKeeperReader,
   getVaultRegistryReader,
 } from "@/clients/eth-contract/sdk-readers";
+import { isDepositBlocked } from "@/components/shared/protocolStatus";
 import featureFlags from "@/config/featureFlags";
 import { useProtocolParamsContext } from "@/context/ProtocolParamsContext";
 import { COPY } from "@/copy";
+import { useProtocolGateState } from "@/hooks/useProtocolGate";
 import { UTXOS_QUERY_KEY } from "@/hooks/useUTXOs";
 import { logger } from "@/infrastructure";
 import { LocalStorageStatus } from "@/models/peginStateMachine";
@@ -278,6 +280,7 @@ export function useDepositFlow(
   const { btcAddress, spendableUTXOs, isUTXOsLoading, utxoError } =
     useBtcWalletState();
   const queryClient = useQueryClient();
+  const gate = useProtocolGateState();
   const { findProvider } = useVaultProviders(selectedApplication);
   const { config, timelockPegin, timelockRefund, minDeposit, maxDeposit } =
     useProtocolParamsContext();
@@ -313,6 +316,15 @@ export function useDepositFlow(
       const primedRegistryTxids: string[] = [];
 
       try {
+        // Deposit (pegin) is a protocol-scope ENTRY action. The dialog-open is
+        // gated and the on-chain register below is contract-enforced
+        // (`whenNotFrozen`), but guard the execution path too: abort cleanly
+        // here — before the wallet popup and the doomed on-chain register —
+        // rather than letting it revert, if the protocol is frozen/paused.
+        if (isDepositBlocked(gate)) {
+          throw new Error(COPY.deposit.errors.protocolPaused);
+        }
+
         // ========================================================================
         // Step 0: Validation
         // ========================================================================
@@ -1182,6 +1194,7 @@ export function useDepositFlow(
         abortControllerRef.current = null;
       }
     }, [
+      gate,
       vaultAmounts,
       mempoolFeeRate,
       btcWalletProvider,

--- a/services/vault/src/hooks/deposit/useVaultActions.ts
+++ b/services/vault/src/hooks/deposit/useVaultActions.ts
@@ -25,12 +25,16 @@ import { useEffect, useRef, useState } from "react";
 import type { Hex } from "viem";
 import { getWalletClient, switchChain } from "wagmi/actions";
 
-import { isActivationBlocked } from "@/components/shared/protocolStatus";
+import {
+  composeGateState,
+  isActivationBlocked,
+} from "@/components/shared/protocolStatus";
 import { getETHChain } from "@/config/network";
 import { COPY } from "@/copy";
 import { useProtocolGateState } from "@/hooks/useProtocolGate";
 
 import { getVaultFromChain } from "../../clients/eth-contract/btc-vault-registry/query";
+import { getOnChainPauseState } from "../../clients/eth-contract/pause-state/query";
 import { getVaultRegistryReader } from "../../clients/eth-contract/sdk-readers";
 import {
   ContractStatus,
@@ -349,8 +353,13 @@ export function useVaultActions(): UseVaultActionsReturn {
     // Activation is an EXIT blocked under Pause (either scope); preserved under
     // Freeze (time-critical — a depositor with BTC locked must still activate).
     // Guard the chokepoint behind the disabled Activate button; never reveal the
-    // secret on-chain while paused.
-    if (isActivationBlocked(gate)) return;
+    // secret on-chain while paused. Surface a paused error (rather than a silent
+    // return) so the caller's spinner clears via `!activationError` and the user
+    // gets feedback. A fresh on-chain re-check below closes the stale-gate window.
+    if (isActivationBlocked(gate)) {
+      setActivationError(COPY.pegin.activationPaused);
+      return;
+    }
 
     const {
       vaultId,
@@ -374,8 +383,23 @@ export function useVaultActions(): UseVaultActionsReturn {
       // status check and the contract write (the actual TOCTOU window
       // for the secret-leak failure mode this hook guards against).
       const reader = getVaultRegistryReader();
-      const { basic: basicInfo, protocol: protocolInfo } =
-        await reader.getVaultData(vaultId);
+      // Read the vault data AND a FRESH pause state in parallel. The cached
+      // `gate` can be ~20s stale; the secret must never reach `activateVault`
+      // calldata if the protocol paused in that window. A failed pause read
+      // falls back to the cached gate (activation is time-critical — an RPC
+      // blip must not trap a depositor whose activation deadline is near).
+      const [{ basic: basicInfo, protocol: protocolInfo }, freshPauseState] =
+        await Promise.all([
+          reader.getVaultData(vaultId),
+          getOnChainPauseState().catch(() => null),
+        ]);
+
+      const effectiveGate = freshPauseState
+        ? composeGateState(freshPauseState)
+        : gate;
+      if (isActivationBlocked(effectiveGate)) {
+        throw new Error(COPY.pegin.activationPaused);
+      }
 
       if (!protocolInfo.hashlock || protocolInfo.hashlock === "0x") {
         throw new Error(

--- a/services/vault/src/hooks/deposit/useVaultActions.ts
+++ b/services/vault/src/hooks/deposit/useVaultActions.ts
@@ -25,8 +25,10 @@ import { useEffect, useRef, useState } from "react";
 import type { Hex } from "viem";
 import { getWalletClient, switchChain } from "wagmi/actions";
 
+import { isActivationBlocked } from "@/components/shared/protocolStatus";
 import { getETHChain } from "@/config/network";
 import { COPY } from "@/copy";
+import { useProtocolGateState } from "@/hooks/useProtocolGate";
 
 import { getVaultFromChain } from "../../clients/eth-contract/btc-vault-registry/query";
 import { getVaultRegistryReader } from "../../clients/eth-contract/sdk-readers";
@@ -98,6 +100,8 @@ export interface UseVaultActionsReturn {
  * Custom hook for vault actions (broadcast)
  */
 export function useVaultActions(): UseVaultActionsReturn {
+  const gate = useProtocolGateState();
+
   // Broadcast state
   const [broadcasting, setBroadcasting] = useState(false);
   const [broadcastError, setBroadcastError] = useState<string | null>(null);
@@ -342,6 +346,12 @@ export function useVaultActions(): UseVaultActionsReturn {
    * Handle vault activation — reveal HTLC secret on Ethereum
    */
   const handleActivation = async (params: ActivateVaultParams) => {
+    // Activation is an EXIT blocked under Pause (either scope); preserved under
+    // Freeze (time-critical — a depositor with BTC locked must still activate).
+    // Guard the chokepoint behind the disabled Activate button; never reveal the
+    // secret on-chain while paused.
+    if (isActivationBlocked(gate)) return;
+
     const {
       vaultId,
       secretHex,

--- a/services/vault/src/hooks/useProtocolGate.ts
+++ b/services/vault/src/hooks/useProtocolGate.ts
@@ -1,0 +1,79 @@
+/**
+ * Per-scope protocol gate state — composes the on-chain `pauseState()` reads
+ * with the operator-flag override and exposes per-action gating booleans.
+ *
+ * Components read `useGating()` to disable CTAs; transaction hooks read
+ * `useProtocolGateState()` and pass the snapshot to the matching
+ * `is*Blocked(gate)` predicate at their execution chokepoint.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+
+import { getOnChainPauseState } from "@/clients/eth-contract/pause-state/query";
+import {
+  composeGateState,
+  isActivationBlocked,
+  isBorrowBlocked,
+  isDepositBlocked,
+  isReorderBlocked,
+  isRepayBlocked,
+  isWithdrawBlocked,
+  type ProtocolGateState,
+} from "@/components/shared/protocolStatus";
+
+const PAUSE_STATE_QUERY_KEY = "protocolPauseState";
+// Freeze is high-frequency / transient — Risk Stewards can freeze/unfreeze in
+// seconds — so poll briskly and keep the data fresh.
+const PAUSE_STATE_REFETCH_INTERVAL_MS = 20_000;
+const PAUSE_STATE_STALE_TIME_MS = 10_000;
+
+/**
+ * Raw on-chain pause-state query. `data` is undefined while loading or after a
+ * failed/unrecognized read; callers fall back to the operator-flag override.
+ */
+export function useProtocolPauseStatus() {
+  return useQuery({
+    queryKey: [PAUSE_STATE_QUERY_KEY],
+    queryFn: getOnChainPauseState,
+    refetchInterval: PAUSE_STATE_REFETCH_INTERVAL_MS,
+    staleTime: PAUSE_STATE_STALE_TIME_MS,
+    networkMode: "always",
+  });
+}
+
+/**
+ * The effective per-scope gate state: on-chain reads composed with the operator
+ * flags (more severe wins). While loading or on a read failure, on-chain is
+ * treated as `null`, so the state falls back to the operator-flag value — exits
+ * stay available unless an operator explicitly paused.
+ */
+export function useProtocolGateState(): ProtocolGateState {
+  const { data } = useProtocolPauseStatus();
+  return useMemo(() => composeGateState(data ?? null), [data]);
+}
+
+export interface GatingFlags {
+  depositBlocked: boolean;
+  borrowBlocked: boolean;
+  reorderBlocked: boolean;
+  withdrawBlocked: boolean;
+  repayBlocked: boolean;
+  activationBlocked: boolean;
+}
+
+/** Derived per-action booleans for disabling CTAs in components. */
+export function useGating(): GatingFlags {
+  const gate = useProtocolGateState();
+  return useMemo(
+    () => ({
+      depositBlocked: isDepositBlocked(gate),
+      borrowBlocked: isBorrowBlocked(gate),
+      reorderBlocked: isReorderBlocked(gate),
+      withdrawBlocked: isWithdrawBlocked(gate),
+      repayBlocked: isRepayBlocked(gate),
+      activationBlocked: isActivationBlocked(gate),
+    }),
+    [gate],
+  );
+}

--- a/services/vault/src/hooks/useProtocolGate.ts
+++ b/services/vault/src/hooks/useProtocolGate.ts
@@ -1,10 +1,10 @@
 /**
  * Per-scope protocol gate state — composes the on-chain `pauseState()` reads
- * with the operator-flag override and exposes per-action gating booleans.
+ * with the operator-flag override.
  *
- * Components read `useGating()` to disable CTAs; transaction hooks read
- * `useProtocolGateState()` and pass the snapshot to the matching
- * `is*Blocked(gate)` predicate at their execution chokepoint.
+ * Consumers call `useProtocolGateState()` for the snapshot and pass it to the
+ * matching `is*Blocked(gate)` predicate from `protocolStatus`: components use it
+ * to disable CTAs; transaction hooks guard their execution chokepoint with it.
  */
 
 import { useQuery } from "@tanstack/react-query";
@@ -13,12 +13,6 @@ import { useMemo } from "react";
 import { getOnChainPauseState } from "@/clients/eth-contract/pause-state/query";
 import {
   composeGateState,
-  isActivationBlocked,
-  isBorrowBlocked,
-  isDepositBlocked,
-  isReorderBlocked,
-  isRepayBlocked,
-  isWithdrawBlocked,
   type ProtocolGateState,
 } from "@/components/shared/protocolStatus";
 
@@ -50,30 +44,13 @@ export function useProtocolPauseStatus() {
  */
 export function useProtocolGateState(): ProtocolGateState {
   const { data } = useProtocolPauseStatus();
-  return useMemo(() => composeGateState(data ?? null), [data]);
-}
-
-export interface GatingFlags {
-  depositBlocked: boolean;
-  borrowBlocked: boolean;
-  reorderBlocked: boolean;
-  withdrawBlocked: boolean;
-  repayBlocked: boolean;
-  activationBlocked: boolean;
-}
-
-/** Derived per-action booleans for disabling CTAs in components. */
-export function useGating(): GatingFlags {
-  const gate = useProtocolGateState();
-  return useMemo(
-    () => ({
-      depositBlocked: isDepositBlocked(gate),
-      borrowBlocked: isBorrowBlocked(gate),
-      reorderBlocked: isReorderBlocked(gate),
-      withdrawBlocked: isWithdrawBlocked(gate),
-      repayBlocked: isRepayBlocked(gate),
-      activationBlocked: isActivationBlocked(gate),
-    }),
-    [gate],
-  );
+  // Depend on the primitive scope values (not the `data` object) so the gate
+  // keeps a stable reference across polls when the status is unchanged — this
+  // avoids churning the `useCallback`s in the tx hooks that consume it. Operator
+  // flags are env-static, so these two values are the only dynamic inputs to
+  // `composeGateState` (passing `{ protocol: null, aave: null }` is equivalent
+  // to passing `null` — it collapses to the operator-flag value).
+  const protocol = data?.protocol ?? null;
+  const aave = data?.aave ?? null;
+  return useMemo(() => composeGateState({ protocol, aave }), [protocol, aave]);
 }

--- a/services/vault/src/hooks/useProtocolGate.ts
+++ b/services/vault/src/hooks/useProtocolGate.ts
@@ -24,7 +24,9 @@ const PAUSE_STATE_STALE_TIME_MS = 10_000;
 
 /**
  * Raw on-chain pause-state query. `data` is undefined while loading or after a
- * failed/unrecognized read; callers fall back to the operator-flag override.
+ * failed (reverted) read; callers fall back to the operator-flag override. An
+ * unrecognized enum value does NOT land here — it maps to "paused" (fail
+ * closed) in `mapPauseState`, so it arrives as real data.
  */
 export function useProtocolPauseStatus() {
   return useQuery({

--- a/services/vault/src/test/setup.ts
+++ b/services/vault/src/test/setup.ts
@@ -63,6 +63,25 @@ vi.mock("@/config/network", () => ({
   BTC_SIGNET: "signet",
 }));
 
+// Default-mock the protocol gate hooks. They wrap a React-Query on-chain read,
+// which the many incidental consumers (deposit/borrow/withdraw/repay/activation
+// components and tx hooks) would otherwise require a QueryClient for. The
+// default is an unblocked gate; gating-specific tests override `useProtocolGate`
+// locally with their own `vi.mock` to drive a frozen/paused scope. Plain
+// functions (not vi.fn) so `vi.clearAllMocks()` can't reset them to undefined.
+vi.mock("@/hooks/useProtocolGate", () => ({
+  useProtocolPauseStatus: () => ({ data: undefined, isError: false }),
+  useProtocolGateState: () => ({ protocol: null, aave: null }),
+  useGating: () => ({
+    depositBlocked: false,
+    borrowBlocked: false,
+    reorderBlocked: false,
+    withdrawBlocked: false,
+    repayBlocked: false,
+    activationBlocked: false,
+  }),
+}));
+
 // Mock the WASM module to avoid syntax errors in tests
 vi.mock("@/utils/btc/wasm", () => ({
   initWasm: vi.fn(),

--- a/services/vault/src/test/setup.ts
+++ b/services/vault/src/test/setup.ts
@@ -72,14 +72,6 @@ vi.mock("@/config/network", () => ({
 vi.mock("@/hooks/useProtocolGate", () => ({
   useProtocolPauseStatus: () => ({ data: undefined, isError: false }),
   useProtocolGateState: () => ({ protocol: null, aave: null }),
-  useGating: () => ({
-    depositBlocked: false,
-    borrowBlocked: false,
-    reorderBlocked: false,
-    withdrawBlocked: false,
-    repayBlocked: false,
-    activationBlocked: false,
-  }),
 }));
 
 // Mock the WASM module to avoid syntax errors in tests


### PR DESCRIPTION
# Pause: per-scope detection and exit gating

Closes https://github.com/babylonlabs-io/babylon-toolkit/issues/1975

## What this does

When the protocol is **Paused**, this disables every depositor action that changes on-chain state — deposit, borrow, reorder, withdraw, repay, and activation — while leaving the recovery paths (BTC refund, recovery-artifact download) working. Freeze keeps doing what it did before: it blocks new entry (deposit/borrow/reorder) but leaves exits open. To do this correctly the app now reads the real pause/freeze state from the contracts, per scope, instead of relying only on a single operator flag.

## Why

The protocol has two independent "scopes" — the core protocol (`BTCVaultRegistry`) and the Aave integration (`AaveIntegrationAdapter`) — and each can be Frozen or Paused on its own. The rules differ by action: withdrawing and activating are blocked if **either** scope is paused; repaying is blocked **only** by an Aave pause; depositing depends **only** on the protocol scope. A single global flag can't express this — and getting it wrong is harmful: if we blocked repay during a protocol-only pause, we'd stop a user from reducing their debt exactly when they need to. So scope-accurate state is required, not optional.

## Approaches considered, and what we chose

**How to know the pause state.** Option A: keep using the single operator flag. Option B: read the real per-scope state from the contracts. We chose B because exit-gating must be scope-accurate (Option A would over-block). Both contracts expose a `pauseState()` view; the Aave one was already in our bundled ABI, and the protocol one needed a tiny ABI fragment added. We kept the operator flag as a **manual override on top** of the on-chain reads (a DevOps "big red button"), which also serves as the safe fallback while the read is loading or if it fails.

**Sync helpers vs a reactive hook.** The old gating helpers were plain no-argument functions. Since the state now comes from an async contract read, we made the helpers **pure functions of a passed-in state object** (easy to unit-test against the full rules matrix) and added a small React-Query hook that supplies that state. Components call `useProtocolGateState()` and pass the snapshot to the matching `is*Blocked(gate)` predicate to disable buttons; transaction hooks read the same state and guard their execution chokepoint — the same disable-the-button-plus-guard-the-handler pattern we already use for reorder.

**Fail-open for exits.** If the on-chain read fails (e.g. a brief RPC hiccup), exits are **not** blocked — only the operator flag can block them. Over-blocking an exit traps users, so exits fail open; entries can still be operator-blocked.

**Enum mapping safety.** The contract returns a numeric `PauseState` enum. The number→meaning mapping (`0 = normal, 1 = frozen, 2 = paused`) is **confirmed against the contract source** (`ITBVPausable.sol`: `enum PauseState { None, Frozen, Paused }`). To guard a future enum change, an unrecognized value **throws** instead of defaulting to "not paused".

## Changes

- New `clients/eth-contract/pause-state/query.ts` — reads `pauseState()` from both contracts in one multicall and maps it to a per-scope status (throws on an unknown value).
- New `hooks/useProtocolGate.ts` — `useProtocolPauseStatus` (polls the read) and `useProtocolGateState` (composes the on-chain reads with the operator flag).
- `components/shared/protocolStatus.ts` — refactored to per-scope: status types, `composeGateState`, and pure `is*Blocked(gate)` predicates for deposit/borrow/reorder/withdraw/repay/activation, plus `resolveBannerStatus`.
- Wired the gating: re-scoped deposit (protocol) and borrow/reorder (aave); added withdraw, repay (aave-pause only), and activation gating at both the button and the transaction chokepoint. Every state-changing action — deposit, borrow, reorder, withdraw, repay, activation — guards its execution path, not just its button. The position-notification banner CTAs (Add Collateral / Add vault / Repay Debt) are gated too. The status banner reflects the real per-scope state.
- Repay shows an explanatory label + callout when blocked by a pause (mirroring Borrow), so a user near liquidation sees that it's a governance pause, not a silently greyed-out button.
- Tests — the full rules matrix as pure-function tests, the enum mapping (including throw-on-unknown), the activation guard (never reveals the secret while paused), the borrow guard, and the banner CTA gating. A default unblocked gate is mocked in the test setup so unrelated tests don't need a query client.

## What this intentionally does NOT change

- **Recovery stays available** under Pause: BTC refund, WOTS self-claim, artifact download, and expired-pegin cleanup are not gated.
- No change to the actual transaction-building or value logic; this only decides when a CTA is allowed to run.

## How to verify

- tsc, lint (0 errors), and the full vault test suite pass (2056 tests).
- Manually, with no chain needed: set `NEXT_PUBLIC_FF_PROTOCOL_PAUSED=true` and restart — deposit, borrow, reorder, withdraw, repay, and activation are all disabled, and refund/artifact recovery still works. Set `NEXT_PUBLIC_FF_PROTOCOL_FROZEN=true` instead — only deposit/borrow/reorder are disabled; withdraw, repay, and activation stay enabled. On a testnet whose contracts report a real `pauseState()`, the on-chain read drives the gating per scope.
