### PR TITLE
fix(vault): keep the deposit card inert while a refund is in flight

### DIFF
--- a/services/vault/src/components/simple/PendingDepositCard.tsx
+++ b/services/vault/src/components/simple/PendingDepositCard.tsx
@@ -22,7 +22,7 @@ import { DepositFlowStep } from "@/hooks/deposit/depositFlowSteps/types";
 import {
   canPerformAction,
   getPeginDisplayStep,
-  PEGIN_DISPLAY_LABELS,
+  isRefundInFlightOrSettled,
 } from "@/models/peginStateMachine";
 import { getTokenBrandColor } from "@/services/token/tokenService";
 import type { VaultProvider } from "@/types/vaultProvider";
@@ -100,12 +100,13 @@ export function PendingDepositCard({
   const isDanger = displayVariant === "danger";
   const dotColor = isDanger ? undefined : STATUS_DOT_COLORS[displayVariant];
 
-  // A refunded deposit is terminal: the card's click opens the refund modal,
-  // which has nothing left to do once the refund has settled on-chain. Drop the
-  // handler so the row isn't presented as actionable (no hover, no pointer).
-  const isRefunded = peginState.displayLabel === PEGIN_DISPLAY_LABELS.REFUNDED;
+  // The card's click opens the refund modal. Keep it inert once a refund is in
+  // flight or settled (covers our own broadcast and one the mempool probe sees
+  // from another device) — there's nothing left to do.
   const handleCardClick =
-    onCardClick && !isRefunded ? () => onCardClick(depositId) : undefined;
+    onCardClick && !isRefundInFlightOrSettled(peginState)
+      ? () => onCardClick(depositId)
+      : undefined;
 
   // The Pre-PegIn tx is on Bitcoin only once the depositor has broadcast it.
   // While the broadcast action is still pending, an explorer link would 404, so

--- a/services/vault/src/components/simple/__tests__/PendingDepositCard.test.tsx
+++ b/services/vault/src/components/simple/__tests__/PendingDepositCard.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -51,6 +51,7 @@ vi.mock("../VaultDetailCard", () => ({
       data-disabled={disabled ? "true" : "false"}
       data-disabled-tooltip={disabledTooltip ?? ""}
       data-clickable={onClick ? "true" : "false"}
+      onClick={onClick}
     >
       <div data-testid="amount-subtext">{amountSubtext}</div>
       <div data-testid="below-header">{belowHeader}</div>
@@ -276,5 +277,71 @@ describe("PendingDepositCard — payout signing step number", () => {
     expect(
       screen.getByText(COPY.deposit.steps.authenticateSession),
     ).toBeInTheDocument();
+  });
+});
+
+describe("PendingDepositCard — refunding (in-flight) cards are not clickable", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetActionStatus.mockReturnValue({ type: "noAction" });
+  });
+
+  it("is inert once a refund is in flight (Refunding)", () => {
+    // Refunding = our own broadcast OR the HTLC-spend probe seeing the refund tx
+    // in the mempool (so this also covers a refund broadcast from another
+    // device). The refund is in flight, so the card must not reopen the modal.
+    mockUseDepositPollingResult.mockReturnValue({
+      loading: false,
+      peginState: {
+        contractStatus: ContractStatus.EXPIRED,
+        displayLabel: PEGIN_DISPLAY_LABELS.REFUNDING,
+        displayVariant: "pending",
+        availableActions: [PeginAction.NONE],
+      },
+    });
+    const onCardClick = vi.fn();
+    render(
+      <PendingDepositCard
+        depositId="0xvault"
+        amount="0.05"
+        providerId="0xprovider"
+        vaultProviders={[]}
+        onCardClick={onCardClick}
+      />,
+    );
+
+    const card = screen.getByTestId("vault-detail-card");
+    expect(card).toHaveAttribute("data-clickable", "false");
+    fireEvent.click(card);
+    expect(onCardClick).not.toHaveBeenCalled();
+  });
+
+  it("stays clickable for a pending vault with no available action", () => {
+    // Pending cards open the multistepper even with no primary action; the
+    // refund gate (Refunding/Refunded only) must not touch them.
+    mockUseDepositPollingResult.mockReturnValue({
+      loading: false,
+      peginState: {
+        contractStatus: ContractStatus.PENDING,
+        displayLabel: PEGIN_DISPLAY_LABELS.PENDING,
+        displayVariant: "pending",
+        availableActions: [PeginAction.NONE],
+      },
+    });
+    const onCardClick = vi.fn();
+    render(
+      <PendingDepositCard
+        depositId="0xvault"
+        amount="0.05"
+        providerId="0xprovider"
+        vaultProviders={[]}
+        onCardClick={onCardClick}
+      />,
+    );
+
+    const card = screen.getByTestId("vault-detail-card");
+    expect(card).toHaveAttribute("data-clickable", "true");
+    fireEvent.click(card);
+    expect(onCardClick).toHaveBeenCalledWith("0xvault");
   });
 });

--- a/services/vault/src/models/__tests__/peginStateMachine.test.ts
+++ b/services/vault/src/models/__tests__/peginStateMachine.test.ts
@@ -10,6 +10,7 @@ import {
   getPeginDisplayStep,
   getPeginState,
   getPrimaryActionButton,
+  isRefundInFlightOrSettled,
   isVaultActivated,
   LocalStorageStatus,
   PEGIN_DISPLAY_LABELS,
@@ -559,6 +560,34 @@ describe("peginStateMachine", () => {
       expect(
         canPerformAction(state, PeginAction.SIGN_PAYOUT_TRANSACTIONS),
       ).toBe(false);
+    });
+  });
+
+  describe("isRefundInFlightOrSettled", () => {
+    it("is true while a refund is in flight (Refunding)", () => {
+      const state = getPeginState(ContractStatus.EXPIRED, {
+        canRefund: false,
+        refundSettlement: "pending",
+      });
+      expect(isRefundInFlightOrSettled(state)).toBe(true);
+    });
+
+    it("is true once a refund has settled (Refunded)", () => {
+      const state = getPeginState(ContractStatus.EXPIRED, {
+        canRefund: false,
+        refundSettlement: "confirmed",
+      });
+      expect(isRefundInFlightOrSettled(state)).toBe(true);
+    });
+
+    it("is false for a still-refundable expired vault", () => {
+      const state = getPeginState(ContractStatus.EXPIRED, { canRefund: true });
+      expect(isRefundInFlightOrSettled(state)).toBe(false);
+    });
+
+    it("is false for a pending vault", () => {
+      const state = getPeginState(ContractStatus.PENDING, {});
+      expect(isRefundInFlightOrSettled(state)).toBe(false);
     });
   });
 

--- a/services/vault/src/models/peginStateMachine.ts
+++ b/services/vault/src/models/peginStateMachine.ts
@@ -225,6 +225,19 @@ export function canPerformAction(
 }
 
 /**
+ * True when an EXPIRED vault's refund is already in flight (Refunding — our own
+ * broadcast, or an HTLC spend the mempool probe sees) or settled (Refunded).
+ * Both labels are produced only in the EXPIRED branch, so this is the
+ * display-layer signal that the refund modal has nothing left to do.
+ */
+export function isRefundInFlightOrSettled(state: PeginState): boolean {
+  return (
+    state.displayLabel === PEGIN_DISPLAY_LABELS.REFUNDING ||
+    state.displayLabel === PEGIN_DISPLAY_LABELS.REFUNDED
+  );
+}
+
+/**
  * PegIn actions a depositor can drive inline from the deposit flow.
  *
  * Excludes:


### PR DESCRIPTION
Extends #1984's refund-click gate from `Refunded` to also cover the in-flight
`Refunding` state — an expired vault whose refund was already broadcast no longer
shows a clickable card that reopens a do-nothing refund modal.

`Refunding` fires from our own broadcast OR the mempool HTLC-spend probe, so this
also catches refunds sent from another device. Extracted the check as
`isRefundInFlightOrSettled` in `peginStateMachine.ts`.

No new RPC (reads an already-computed label); both labels are EXPIRED-only so
pending/batched cards are untouched.