### PR TITLE
feat(vault): add action CTA to pending deposit cards

### DIFF
--- a/services/vault/src/components/simple/BatchedDepositGroup.tsx
+++ b/services/vault/src/components/simple/BatchedDepositGroup.tsx
@@ -15,6 +15,7 @@
 import { Button } from "@babylonlabs-io/core-ui";
 
 import {
+  type ActionButton,
   getActionStatus,
   PeginAction,
 } from "@/components/deposit/actionStatus";
@@ -63,6 +64,26 @@ export function BatchedDepositGroup({
       status.action.action === PeginAction.SIGN_AND_BROADCAST_TO_BITCOIN
     );
   });
+
+  // Once the shared broadcast is done, a sibling may still need a per-vault
+  // step (submit key / sign payouts / activate). Surface a single group CTA so
+  // the depositor always has an explicit "continue" affordance — it opens the
+  // batch multistepper, which drives every remaining step. Broadcast keeps its
+  // own dedicated button (a distinct handler); the two are mutually exclusive.
+  // Split siblings normally advance together, so the first one still needing a
+  // step labels the batch.
+  let continueAction: ActionButton | undefined;
+  if (!broadcastTarget) {
+    for (const activity of activities) {
+      const result = getPollingResult(activity.id);
+      if (!result) continue;
+      const status = getActionStatus(result);
+      if (status.type === "available") {
+        continueAction = status.action;
+        break;
+      }
+    }
+  }
 
   // Display-only header total. `formatBtcAmount` rounds to 8 dp, so float-sum
   // drift never surfaces. Do NOT copy this parseFloat-sum into any commitment,
@@ -154,7 +175,7 @@ export function BatchedDepositGroup({
         <div className="mt-3">
           <Button
             variant="contained"
-            color="primary"
+            color="secondary"
             className="w-full"
             onClick={() => onBroadcastClick(broadcastTarget.id)}
           >
@@ -163,6 +184,18 @@ export function BatchedDepositGroup({
           <span className="mt-2 block text-center text-xs text-accent-secondary">
             {COPY.pegin.batchedDeposit.broadcastHelper}
           </span>
+        </div>
+      )}
+      {continueAction && onGroupClick && (
+        <div className="mt-3">
+          <Button
+            variant="contained"
+            color="secondary"
+            className="w-full"
+            onClick={() => onGroupClick(activities[0].id)}
+          >
+            {continueAction.label}
+          </Button>
         </div>
       )}
     </div>

--- a/services/vault/src/components/simple/PendingDepositCard.tsx
+++ b/services/vault/src/components/simple/PendingDepositCard.tsx
@@ -4,12 +4,21 @@
  * Renders a single pending deposit as a bordered sub-card within the
  * expanded summary card. Uses VaultDetailCard for the common layout.
  *
- * The card itself is the action surface: when an `onCardClick` is wired
- * (pending list) or the parent batched-group wrapper is clickable, that
- * click opens the deposit multistepper modal which owns every per-vault
- * flow (broadcast, WOTS, sign, activate, artifact download). The card no
- * longer renders its own per-action button.
+ * The card body is an action surface: when an `onCardClick` is wired
+ * (single pending list / expired list), clicking it opens the deposit
+ * multistepper (or the refund modal for expired cards) which owns every
+ * per-vault flow (broadcast, WOTS, sign, activate, refund, artifact
+ * download).
+ *
+ * When the deposit has an available next action, the card also surfaces an
+ * explicit CTA button for it: the orange primary CTA for forward actions
+ * (broadcast / sign / activate …) and a lower-emphasis outlined button for
+ * the HTLC refund on expired deposits. The button runs the same handler as
+ * the card body. Batched siblings have no `onCardClick` (the group wrapper
+ * owns the click and hoists the shared broadcast), so they render no CTA.
  */
+
+import { Button } from "@babylonlabs-io/core-ui";
 
 import {
   getActionStatus,
@@ -92,9 +101,9 @@ export function PendingDepositCard({
 
   const { loading, peginState, prePeginConfirmations, requiredPrePeginDepth } =
     pollingResult;
-  // `getActionStatus` still drives the disabled-with-tooltip state for
-  // wallet-ownership mismatch. Action triggering itself is no longer the
-  // card's job — the parent's click handler owns that.
+  // `getActionStatus` drives both the disabled-with-tooltip state (wallet-
+  // ownership mismatch) and the CTA below. Executing the action stays the
+  // parent's job — the CTA and the card body both route to its click handler.
   const status = getActionStatus(pollingResult);
   const { displayVariant } = peginState;
   const isDanger = displayVariant === "danger";
@@ -133,6 +142,33 @@ export function PendingDepositCard({
   const provider = vaultProviders.find((vp) => vp.id === providerId);
   const providerName =
     provider?.name ?? `Provider ${truncateAddress(providerId)}`;
+
+  // Surface the available next action as an explicit CTA on cards that own a
+  // click handler (single pending + expired; batched siblings defer to the
+  // group). Only an `available` status is actionable — disabled (ownership
+  // mismatch) and noAction render no button. The HTLC refund reads as a
+  // lower-emphasis outlined button; every forward action uses the orange
+  // primary CTA. The button runs the same handler as the card body and is
+  // excluded from the body click by isInteractiveEventTarget.
+  const actionCta =
+    status.type === "available" && handleCardClick ? (
+      <Button
+        variant={
+          status.action.action === PeginAction.REFUND_HTLC
+            ? "outlined"
+            : "contained"
+        }
+        color={
+          status.action.action === PeginAction.REFUND_HTLC
+            ? "primary"
+            : "secondary"
+        }
+        className="w-full"
+        onClick={handleCardClick}
+      >
+        {status.action.label}
+      </Button>
+    ) : undefined;
 
   return (
     <VaultDetailCard
@@ -190,6 +226,7 @@ export function PendingDepositCard({
           />
         )
       }
+      action={actionCta}
     />
   );
 }

--- a/services/vault/src/components/simple/__tests__/BatchedDepositGroup.test.tsx
+++ b/services/vault/src/components/simple/__tests__/BatchedDepositGroup.test.tsx
@@ -128,6 +128,36 @@ describe("BatchedDepositGroup", () => {
     expect(screen.getAllByTestId("deposit-card")).toHaveLength(2);
   });
 
+  it("surfaces a group CTA that opens the multistepper once a sibling needs a post-broadcast step", () => {
+    // Broadcast done; a sibling now needs to activate. The batch shows one
+    // orange CTA routing through onGroupClick to the batch multistepper.
+    mockGetActionStatus.mockReturnValue({
+      type: "available",
+      action: {
+        action: PeginAction.ACTIVATE_VAULT,
+        label: COPY.pegin.primaryAction.ACTIVATE_VAULT,
+      },
+    } satisfies ActionStatus);
+    const onGroupClick = vi.fn();
+    render(
+      <BatchedDepositGroup
+        activities={[activity("0xa"), activity("0xb")]}
+        vaultProviders={[]}
+        onBroadcastClick={vi.fn()}
+        onGroupClick={onGroupClick}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: /broadcast pre-pegin/i }),
+    ).not.toBeInTheDocument();
+    const cta = screen.getByRole("button", {
+      name: COPY.pegin.primaryAction.ACTIVATE_VAULT,
+    });
+    fireEvent.click(cta);
+    expect(onGroupClick).toHaveBeenCalledWith("0xa");
+  });
+
   it("opens the batch multistepper when an owned group body is clicked", () => {
     mockGetActionStatus.mockReturnValue(NO_ACTION);
     const onGroupClick = vi.fn();

--- a/services/vault/src/components/simple/__tests__/PendingDepositCard.test.tsx
+++ b/services/vault/src/components/simple/__tests__/PendingDepositCard.test.tsx
@@ -32,6 +32,7 @@ vi.mock("@/components/deposit/actionStatus", async (importOriginal) => {
 // test can assert what was passed in.
 vi.mock("../VaultDetailCard", () => ({
   VaultDetailCard: ({
+    action,
     amountSubtext,
     belowHeader,
     disabled,
@@ -39,6 +40,7 @@ vi.mock("../VaultDetailCard", () => ({
     onClick,
     txHashRow,
   }: {
+    action?: ReactNode;
     amountSubtext?: ReactNode;
     belowHeader?: ReactNode;
     disabled?: boolean;
@@ -56,6 +58,7 @@ vi.mock("../VaultDetailCard", () => ({
       <div data-testid="amount-subtext">{amountSubtext}</div>
       <div data-testid="below-header">{belowHeader}</div>
       <div data-testid="tx-hash-row">{txHashRow}</div>
+      <div data-testid="action-slot">{action}</div>
     </div>
   ),
   VaultStatusBadge: () => <div data-testid="status-badge" />,
@@ -128,9 +131,9 @@ describe("PendingDepositCard — disabled (ownership mismatch) surface", () => {
   });
 
   it("dims the card and surfaces the tooltip when the action is disabled", () => {
-    // Wallet-ownership mismatch: the card has no in-card action button
-    // anymore (clicking the card opens the multistepper), so the visual
-    // signal is dimming + a hover tooltip.
+    // Wallet-ownership mismatch: a disabled card renders no CTA button — the
+    // visual signal is dimming + a hover tooltip (the CTA is reserved for an
+    // `available` action).
     const TOOLTIP =
       "This BTC Vault was created with a different BTC public key (bcc5...f21c). Switch to that wallet to perform actions.";
     mockGetActionStatus.mockReturnValue({
@@ -343,5 +346,155 @@ describe("PendingDepositCard — refunding (in-flight) cards are not clickable",
     expect(card).toHaveAttribute("data-clickable", "true");
     fireEvent.click(card);
     expect(onCardClick).toHaveBeenCalledWith("0xvault");
+  });
+});
+
+describe("PendingDepositCard — action CTA button", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseDepositPollingResult.mockReturnValue({
+      loading: false,
+      peginState: {
+        contractStatus: ContractStatus.VERIFIED,
+        displayLabel: PEGIN_DISPLAY_LABELS.READY_TO_ACTIVATE,
+        displayVariant: "pending",
+        availableActions: [PeginAction.ACTIVATE_VAULT],
+      },
+    });
+  });
+
+  it("renders the orange CTA for an available forward action and routes its click to the card handler", () => {
+    mockGetActionStatus.mockReturnValue({
+      type: "available",
+      action: {
+        action: PeginAction.ACTIVATE_VAULT,
+        label: COPY.pegin.primaryAction.ACTIVATE_VAULT,
+      },
+    });
+    const onCardClick = vi.fn();
+    render(
+      <PendingDepositCard
+        depositId="0xvault"
+        amount="0.05"
+        providerId="0xprovider"
+        vaultProviders={[]}
+        onCardClick={onCardClick}
+      />,
+    );
+
+    const button = screen.getByRole("button", {
+      name: COPY.pegin.primaryAction.ACTIVATE_VAULT,
+    });
+    // The orange CTA is the contained/secondary button (secondary.main is the
+    // brand orange in this theme).
+    expect(button.className).toContain("bbn-btn-contained");
+    expect(button.className).toContain("bbn-btn-secondary");
+    fireEvent.click(button);
+    expect(onCardClick).toHaveBeenCalledWith("0xvault");
+  });
+
+  it("renders the HTLC refund as a lower-emphasis outlined button", () => {
+    mockUseDepositPollingResult.mockReturnValue({
+      loading: false,
+      peginState: {
+        contractStatus: ContractStatus.EXPIRED,
+        displayLabel: PEGIN_DISPLAY_LABELS.EXPIRED,
+        displayVariant: "warning",
+        availableActions: [PeginAction.REFUND_HTLC],
+      },
+    });
+    mockGetActionStatus.mockReturnValue({
+      type: "available",
+      action: {
+        action: PeginAction.REFUND_HTLC,
+        label: COPY.pegin.primaryAction.REFUND_HTLC,
+      },
+    });
+    render(
+      <PendingDepositCard
+        depositId="0xvault"
+        amount="0.05"
+        providerId="0xprovider"
+        vaultProviders={[]}
+        onCardClick={vi.fn()}
+      />,
+    );
+
+    const button = screen.getByRole("button", {
+      name: COPY.pegin.primaryAction.REFUND_HTLC,
+    });
+    expect(button.className).toContain("bbn-btn-outlined");
+  });
+
+  it("renders no CTA when there is no available action", () => {
+    mockGetActionStatus.mockReturnValue({ type: "noAction" });
+    render(
+      <PendingDepositCard
+        depositId="0xvault"
+        amount="0.05"
+        providerId="0xprovider"
+        vaultProviders={[]}
+        onCardClick={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", {
+        name: COPY.pegin.primaryAction.ACTIVATE_VAULT,
+      }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders no CTA for a batched sibling with no card handler", () => {
+    // Batched siblings have no `onCardClick` — the group wrapper owns the click
+    // and hoists the shared broadcast, so the inner card stays CTA-free even
+    // when an action is available.
+    mockGetActionStatus.mockReturnValue({
+      type: "available",
+      action: {
+        action: PeginAction.ACTIVATE_VAULT,
+        label: COPY.pegin.primaryAction.ACTIVATE_VAULT,
+      },
+    });
+    render(
+      <PendingDepositCard
+        depositId="0xvault"
+        amount="0.05"
+        providerId="0xprovider"
+        vaultProviders={[]}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", {
+        name: COPY.pegin.primaryAction.ACTIVATE_VAULT,
+      }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders no CTA when the action is disabled by an ownership mismatch", () => {
+    mockGetActionStatus.mockReturnValue({
+      type: "disabled",
+      action: {
+        action: PeginAction.ACTIVATE_VAULT,
+        label: COPY.pegin.primaryAction.ACTIVATE_VAULT,
+      },
+      tooltip: "Switch to the owning wallet",
+    });
+    render(
+      <PendingDepositCard
+        depositId="0xvault"
+        amount="0.05"
+        providerId="0xprovider"
+        vaultProviders={[]}
+        onCardClick={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", {
+        name: COPY.pegin.primaryAction.ACTIVATE_VAULT,
+      }),
+    ).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Show an explicit call-to-action on each pending/expired deposit card when the user has a next step: an orange primary CTA for forward actions (broadcast, submit key, sign, activate) and a lower-emphasis outlined button for the HTLC refund. The batched-group hoisted broadcast/continue CTA is aligned to the same orange. No CTA is shown for waiting states or when the vault belongs to a different wallet.