### PR TITLE
fix(vault): move payout-sent withdrawals to a Withdrawals section

### DIFF
--- a/services/vault/src/components/simple/DashboardPage.tsx
+++ b/services/vault/src/components/simple/DashboardPage.tsx
@@ -109,20 +109,21 @@ export function DashboardPage() {
   // A "Payout sent" withdrawal is terminal success — the depositor's BTC is on
   // its way — so it belongs under "Withdrawals", not "Pending Withdrawals".
   // Everything still advancing (incl. the "Blocked" error state) stays pending.
-  const isPayoutSent = useCallback(
-    (vaultId: string) =>
-      pegoutStatuses.get(vaultId)?.response?.claimer?.status ===
-      ClaimerPegoutStatusValue.PAYOUT_BROADCAST,
-    [pegoutStatuses],
-  );
-  const inProgressWithdrawVaults = useMemo(
-    () => pendingWithdrawVaults.filter((vault) => !isPayoutSent(vault.id)),
-    [pendingWithdrawVaults, isPayoutSent],
-  );
-  const completedWithdrawVaults = useMemo(
-    () => pendingWithdrawVaults.filter((vault) => isPayoutSent(vault.id)),
-    [pendingWithdrawVaults, isPayoutSent],
-  );
+  const { inProgressWithdrawVaults, completedWithdrawVaults } = useMemo(() => {
+    const inProgressWithdrawVaults: typeof pendingWithdrawVaults = [];
+    const completedWithdrawVaults: typeof pendingWithdrawVaults = [];
+    for (const vault of pendingWithdrawVaults) {
+      const payoutSent =
+        pegoutStatuses.get(vault.id)?.response?.claimer?.status ===
+        ClaimerPegoutStatusValue.PAYOUT_BROADCAST;
+      if (payoutSent) {
+        completedWithdrawVaults.push(vault);
+      } else {
+        inProgressWithdrawVaults.push(vault);
+      }
+    }
+    return { inProgressWithdrawVaults, completedWithdrawVaults };
+  }, [pendingWithdrawVaults, pegoutStatuses]);
 
   // Sync pending vault operations (add/withdraw) with indexer data
   useSyncPendingVaults(aaveVaults);

--- a/services/vault/src/components/simple/DashboardPage.tsx
+++ b/services/vault/src/components/simple/DashboardPage.tsx
@@ -5,7 +5,7 @@
  */
 
 import { Container } from "@babylonlabs-io/core-ui";
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useNavigate, useOutletContext } from "react-router";
 
 import { AssetSelectionModal } from "@/applications/aave/components/AssetSelectionModal";
@@ -28,6 +28,7 @@ import { useApplicationCap } from "@/hooks/useApplicationCap";
 import { useDashboardState } from "@/hooks/useDashboardState";
 import { usePegoutPolling } from "@/hooks/usePegoutPolling";
 import { usePrices } from "@/hooks/usePrices";
+import { ClaimerPegoutStatusValue } from "@/models/pegoutStateMachine";
 import {
   formatBtcAmount,
   formatLiquidationDistancePercent,
@@ -101,10 +102,27 @@ export function DashboardPage() {
     redeemedVaults,
   });
 
-  // Every redeemed vault shows its staged progress, including the terminal
-  // "Payout sent" and "Blocked" states. A vault drops off naturally once it
-  // leaves the redeemed set on-chain (payout settles / vault closes).
+  // Every redeemed vault shows its staged progress until it leaves the redeemed
+  // set on-chain (payout settles / vault closes).
   const pendingWithdrawVaults = redeemedVaults;
+
+  // A "Payout sent" withdrawal is terminal success — the depositor's BTC is on
+  // its way — so it belongs under "Withdrawals", not "Pending Withdrawals".
+  // Everything still advancing (incl. the "Blocked" error state) stays pending.
+  const isPayoutSent = useCallback(
+    (vaultId: string) =>
+      pegoutStatuses.get(vaultId)?.response?.claimer?.status ===
+      ClaimerPegoutStatusValue.PAYOUT_BROADCAST,
+    [pegoutStatuses],
+  );
+  const inProgressWithdrawVaults = useMemo(
+    () => pendingWithdrawVaults.filter((vault) => !isPayoutSent(vault.id)),
+    [pendingWithdrawVaults, isPayoutSent],
+  );
+  const completedWithdrawVaults = useMemo(
+    () => pendingWithdrawVaults.filter((vault) => isPayoutSent(vault.id)),
+    [pendingWithdrawVaults, isPayoutSent],
+  );
 
   // Sync pending vault operations (add/withdraw) with indexer data
   useSyncPendingVaults(aaveVaults);
@@ -226,7 +244,13 @@ export function DashboardPage() {
         <PendingDepositSection />
 
         <PendingWithdrawSection
-          pendingWithdrawVaults={pendingWithdrawVaults}
+          pendingWithdrawVaults={inProgressWithdrawVaults}
+          pegoutStatuses={pegoutStatuses}
+        />
+
+        <PendingWithdrawSection
+          title={COPY.pegout.section.completedTitle}
+          pendingWithdrawVaults={completedWithdrawVaults}
           pegoutStatuses={pegoutStatuses}
         />
 

--- a/services/vault/src/components/simple/PendingWithdrawSection.tsx
+++ b/services/vault/src/components/simple/PendingWithdrawSection.tsx
@@ -13,6 +13,7 @@ import type { RedeemedVaultInfo } from "@/applications/aave/hooks/useAaveVaults"
 import { ExpandMenuButton } from "@/components/shared";
 import { SUMMARY_CARD_CLASS } from "@/components/shared/layoutClasses";
 import { getNetworkConfigBTC } from "@/config";
+import { COPY } from "@/copy";
 import { useBtcMempoolConfirmations } from "@/hooks/useBtcMempoolConfirmations";
 import { useOffchainParams } from "@/hooks/useOffchainParams";
 import type { PegoutPollingResult } from "@/hooks/usePegoutPolling";
@@ -33,6 +34,9 @@ const ASSERT_CONFIRMATIONS_QUERY_KEY = "assertMempoolConfirmations";
 interface PendingWithdrawSectionProps {
   pendingWithdrawVaults: RedeemedVaultInfo[];
   pegoutStatuses: Map<string, PegoutPollingResult>;
+  /** Section heading. Defaults to the "Pending Withdrawals" copy; the
+   *  completed (payout-sent) section passes the "Withdrawals" copy. */
+  title?: string;
 }
 
 export function PendingWithdrawSection(props: PendingWithdrawSectionProps) {
@@ -43,6 +47,7 @@ export function PendingWithdrawSection(props: PendingWithdrawSectionProps) {
 function PendingWithdrawSectionContent({
   pendingWithdrawVaults,
   pegoutStatuses,
+  title = COPY.pegout.section.pendingTitle,
 }: PendingWithdrawSectionProps) {
   const [isExpanded, setIsExpanded] = useState(false);
   // Non-blocking: the withdrawal status (tx hash, Blocked → Contact Support,
@@ -96,7 +101,7 @@ function PendingWithdrawSectionContent({
           as="h2"
           className="font-normal text-accent-primary"
         >
-          Pending Withdrawals ({count})
+          {title} ({count})
         </Heading>
         {anyInProgress && (
           <div className="h-[18px] w-[18px] animate-spin rounded-full border-2 border-accent-primary border-t-transparent" />
@@ -119,7 +124,7 @@ function PendingWithdrawSectionContent({
           <ExpandMenuButton
             isExpanded={isExpanded}
             onToggle={() => setIsExpanded((prev) => !prev)}
-            aria-label="Pending withdrawal details"
+            aria-label={COPY.pegout.section.detailsAria}
           />
         </div>
 

--- a/services/vault/src/components/simple/PendingWithdrawSection.tsx
+++ b/services/vault/src/components/simple/PendingWithdrawSection.tsx
@@ -124,7 +124,7 @@ function PendingWithdrawSectionContent({
           <ExpandMenuButton
             isExpanded={isExpanded}
             onToggle={() => setIsExpanded((prev) => !prev)}
-            aria-label={COPY.pegout.section.detailsAria}
+            aria-label={COPY.pegout.section.detailsAria(title)}
           />
         </div>
 

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -814,7 +814,10 @@ export const COPY = {
     section: {
       pendingTitle: "Pending Withdrawals",
       completedTitle: "Withdrawals",
-      detailsAria: "Withdrawal details",
+      // Derived from the section title so each section's expand button is
+      // distinctly labelled ("Pending Withdrawals details" vs "Withdrawals
+      // details") when both render at once.
+      detailsAria: (title: string) => `${title} details`,
     },
     // Staged pending-withdraw card (Submitted → … → Payout sent / Blocked).
     card: {

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -808,6 +808,14 @@ export const COPY = {
       unknownMessage: (status: string) =>
         `Unknown status: ${status}. Please contact support.`,
     },
+    // Dashboard section headings. A "Payout sent" withdrawal is terminal
+    // success, so it moves out of "Pending Withdrawals" into a plain
+    // "Withdrawals" section while it lingers in the redeemed set.
+    section: {
+      pendingTitle: "Pending Withdrawals",
+      completedTitle: "Withdrawals",
+      detailsAria: "Withdrawal details",
+    },
     // Staged pending-withdraw card (Submitted → … → Payout sent / Blocked).
     card: {
       // When the withdrawal was initiated (the VP's claimer-record timestamp).


### PR DESCRIPTION
A withdrawal whose pegout status is PAYOUT_BROADCAST is terminal success, so it no longer sits under Pending Withdrawals. Partition the redeemed vaults and render payout-sent ones under a separate Withdrawals section; everything still progressing (incl. the Blocked error state) stays pending. PendingWithdrawSection takes a title prop (default Pending Withdrawals).