### PR TITLE
fix(vault): align user-facing copy with terminology style guide

### DIFF
--- a/services/vault/src/applications/aave/positionNotifications/__tests__/calculate.test.ts
+++ b/services/vault/src/applications/aave/positionNotifications/__tests__/calculate.test.ts
@@ -291,7 +291,7 @@ describe("golden vectors (reference scenario suite)", () => {
     // existing vault becomes protected.
     expect(result.suggestedNewVaultBtc).toBe(0.72);
     expect(getWarning(result.warnings, "cliff")?.suggestion).toContain(
-      "0.72 BTC sacrificial vault creates a buffer",
+      "sacrificial 0.72 BTC Vault creates a buffer",
     );
   });
 
@@ -356,7 +356,7 @@ describe("golden vectors (reference scenario suite)", () => {
   it("C1 — [0.35, 0.65] wrong order: reorder notification, single group", () => {
     const result = calculate(makeParams([v(0.35), v(0.65)]));
     const reorder = getWarning(result.warnings, "reorder");
-    expect(reorder?.title).toBe("Reorder vaults to lose less");
+    expect(reorder?.title).toBe("Reorder BTC Vaults to lose less");
     expect(result.optimalVaultOrder).not.toBeNull();
     expect(result.groups).toHaveLength(1);
   });
@@ -372,7 +372,7 @@ describe("golden vectors (reference scenario suite)", () => {
     const cliff = getWarning(result.warnings, "cliff");
     expect(cliff?.title).toBe("First liquidation takes everything");
     // The deficit detail moved into the suggestion now that the body is shared.
-    expect(cliff?.suggestion).toContain("Neither vault");
+    expect(cliff?.suggestion).toContain("Neither BTC Vault");
     expect(hasWarning(result.warnings, "reorder")).toBe(false);
     expect(result.groups).toHaveLength(1);
   });
@@ -409,7 +409,7 @@ describe("golden vectors (reference scenario suite)", () => {
     const vaults = Array.from({ length: 18 }, (_, idx) => v(0.2 + idx * 0.01));
     const result = calculate(makeParams(vaults));
     expect(getWarning(result.warnings, "too-many-vaults")?.title).toContain(
-      "Too many vaults",
+      "Too many BTC Vaults",
     );
     expect(result.optimalVaultOrder).toBeNull();
   });

--- a/services/vault/src/components/deposit/PayoutSignModal/__tests__/usePayoutSigningState.test.tsx
+++ b/services/vault/src/components/deposit/PayoutSignModal/__tests__/usePayoutSigningState.test.tsx
@@ -327,7 +327,7 @@ describe("usePayoutSigningState", () => {
         await result.current.handleSign();
       });
 
-      expect(result.current.error?.title).toBe("Provider not found");
+      expect(result.current.error?.title).toBe("Vault provider not found");
       expect(mockSignAndSubmitPayouts).not.toHaveBeenCalled();
     });
 
@@ -356,7 +356,7 @@ describe("usePayoutSigningState", () => {
         await result.current.handleSign();
       });
 
-      expect(result.current.error?.title).toBe("Provider not assigned");
+      expect(result.current.error?.title).toBe("Vault provider not assigned");
       expect(mockSignAndSubmitPayouts).not.toHaveBeenCalled();
     });
 

--- a/services/vault/src/components/shared/AddressScreeningBanner.tsx
+++ b/services/vault/src/components/shared/AddressScreeningBanner.tsx
@@ -19,8 +19,8 @@ export function AddressScreeningBanner({
         <Text variant="body1">
           <strong>Wallet not eligible</strong>
           <br />
-          This wallet is not eligible to use the vault. Please review the Terms
-          of Use or contact support if you believe this is an error.
+          This wallet is not eligible to use the BTC Vault. Please review the
+          Terms of Use or contact support if you believe this is an error.
         </Text>
       </div>
     </div>

--- a/services/vault/src/components/shared/__tests__/ExplorerLink.test.tsx
+++ b/services/vault/src/components/shared/__tests__/ExplorerLink.test.tsx
@@ -8,11 +8,13 @@ describe("ExplorerLink", () => {
     render(
       <ExplorerLink
         href="https://explorer.test/vault/0xabc"
-        label="View vault on explorer"
+        label="View BTC Vault on explorer"
       />,
     );
 
-    const link = screen.getByRole("link", { name: "View vault on explorer" });
+    const link = screen.getByRole("link", {
+      name: "View BTC Vault on explorer",
+    });
     expect(link).toHaveAttribute("href", "https://explorer.test/vault/0xabc");
     expect(link).toHaveAttribute("target", "_blank");
     expect(link).toHaveAttribute("rel", "noopener noreferrer");
@@ -20,7 +22,7 @@ describe("ExplorerLink", () => {
 
   it("renders nothing when href is undefined (no link when explorer is unconfigured)", () => {
     const { container } = render(
-      <ExplorerLink label="View vault on explorer" />,
+      <ExplorerLink label="View BTC Vault on explorer" />,
     );
 
     expect(container).toBeEmptyDOMElement();

--- a/services/vault/src/components/simple/PositionNotificationBanner/__tests__/PositionNotificationBanner.test.tsx
+++ b/services/vault/src/components/simple/PositionNotificationBanner/__tests__/PositionNotificationBanner.test.tsx
@@ -327,7 +327,7 @@ describe("PositionNotificationBanner", () => {
     expect(banner.dataset.severity).toBe("soft");
     // Standalone reorder uses the gold `suggestion` variant, not blue `info`.
     expect(banner.dataset.variant).toBe("suggestion");
-    expect(screen.getByText("Reorder vaults to lose less")).toBeTruthy();
+    expect(screen.getByText("Reorder BTC Vaults to lose less")).toBeTruthy();
     // Optimal-order chip row renders each vault in order.
     expect(screen.getByText("Suggested order")).toBeTruthy();
     expect(screen.getByText(/Vault 2 ·/)).toBeTruthy();
@@ -487,7 +487,7 @@ describe("PositionNotificationBanner", () => {
       warnings: [
         {
           type: "dust",
-          title: "Position too small for vault analysis",
+          title: "Position too small for BTC Vault analysis",
           detail:
             "Below $1,000 the cascade simplifies — all vaults are shown as one liquidation event.",
         },
@@ -499,7 +499,7 @@ describe("PositionNotificationBanner", () => {
     expect(banner.dataset.severity).toBe("soft");
     expect(banner.dataset.variant).toBe("info");
     expect(
-      screen.getByText("Position too small for vault analysis"),
+      screen.getByText("Position too small for BTC Vault analysis"),
     ).toBeTruthy();
     expect(screen.queryByText("Add Collateral")).toBeNull();
     expect(screen.queryByText("Apply Optimal Order")).toBeNull();
@@ -513,7 +513,7 @@ describe("PositionNotificationBanner", () => {
       warnings: [
         {
           type: "dust",
-          title: "Position too small for vault analysis",
+          title: "Position too small for BTC Vault analysis",
           detail:
             "Below $1,000 the cascade simplifies — all vaults are shown as one liquidation event.",
         },
@@ -565,7 +565,7 @@ describe("PositionNotificationBanner", () => {
       warnings: [
         {
           type: "dust",
-          title: "Position too small for vault analysis",
+          title: "Position too small for BTC Vault analysis",
           detail:
             "Below $1,000 the cascade simplifies — all vaults are shown as one liquidation event.",
         },
@@ -582,16 +582,16 @@ describe("PositionNotificationBanner", () => {
     expect(screen.queryByTestId("position-notification-banner")).toBeNull();
   });
 
-  it("renders an orange cliff with the generic 'Add sacrificial vault' CTA and pre-fills the amount", () => {
+  it("renders an orange cliff with the generic 'Add sacrificial BTC Vault' CTA and pre-fills the amount", () => {
     const result = makeBaseResult({
       warnings: [
         {
           type: "cliff",
           title: "First liquidation takes everything",
           detail:
-            "With your current vaults, a single liquidation event seizes all your BTC — nothing remains protected behind it.",
+            "With your current BTC Vaults, a single liquidation event seizes all your BTC — nothing remains protected behind it.",
           suggestion:
-            "Adding a 0.72 BTC sacrificial vault creates a buffer — it gets liquidated first, your existing BTC survives.",
+            "Adding a sacrificial 0.72 BTC Vault creates a buffer — it gets liquidated first, your existing BTC survives.",
         },
       ],
       suggestedNewVaultBtc: 0.72,
@@ -605,7 +605,7 @@ describe("PositionNotificationBanner", () => {
     expect(screen.getByTestId("suggestion-info-icon")).toBeTruthy();
     expect(screen.queryByText("Suggestion")).toBeNull();
     // Generic label per Figma; the amount lives in the suggestion text.
-    fireEvent.click(screen.getByText("Add sacrificial vault"));
+    fireEvent.click(screen.getByText("Add sacrificial BTC Vault"));
     expect(onDeposit).toHaveBeenCalledWith("0.72");
   });
 
@@ -616,9 +616,9 @@ describe("PositionNotificationBanner", () => {
           type: "cliff",
           title: "First liquidation takes everything",
           detail:
-            "With your current vaults, a single liquidation event seizes all your BTC — nothing remains protected behind it.",
+            "With your current BTC Vaults, a single liquidation event seizes all your BTC — nothing remains protected behind it.",
           suggestion:
-            "To enable partial liquidation, withdraw your 2.00 BTC and re-deposit as two smaller vaults: 1.28 BTC sacrificial + 0.72 BTC protected. Alternatively: add collateral or repay debt to manage the liquidation.",
+            "To enable partial liquidation, withdraw your 2.00 BTC and re-deposit as two smaller BTC Vaults: 1.28 BTC sacrificial + 0.72 BTC protected. Alternatively: add collateral or repay debt to manage the liquidation.",
         },
       ],
       // No affordable add → no CTA, "SUGGESTION"-labelled box.
@@ -631,7 +631,7 @@ describe("PositionNotificationBanner", () => {
     expect(banner.dataset.variant).toBe("warning");
     expect(screen.getByText("Suggestion")).toBeTruthy();
     expect(screen.queryByTestId("suggestion-info-icon")).toBeNull();
-    expect(screen.queryByText("Add sacrificial vault")).toBeNull();
+    expect(screen.queryByText("Add sacrificial BTC Vault")).toBeNull();
   });
 
   it("keeps the sacrificial CTA (secondary) when a single-vault cliff is also urgent", () => {
@@ -646,9 +646,9 @@ describe("PositionNotificationBanner", () => {
           type: "cliff",
           title: "First liquidation takes everything",
           detail:
-            "With your current vaults, a single liquidation event seizes all your BTC — nothing remains protected behind it.",
+            "With your current BTC Vaults, a single liquidation event seizes all your BTC — nothing remains protected behind it.",
           suggestion:
-            "Adding a 0.72 BTC sacrificial vault creates a buffer — it gets liquidated first, your existing BTC survives.",
+            "Adding a sacrificial 0.72 BTC Vault creates a buffer — it gets liquidated first, your existing BTC survives.",
         },
       ],
       suggestedNewVaultBtc: 0.72,
@@ -660,7 +660,7 @@ describe("PositionNotificationBanner", () => {
     // Safety actions still lead, and the pre-filled cliff CTA is still offered.
     expect(screen.getByText("Add Collateral")).toBeTruthy();
     expect(screen.getByText("Repay Debt")).toBeTruthy();
-    fireEvent.click(screen.getByText("Add sacrificial vault"));
+    fireEvent.click(screen.getByText("Add sacrificial BTC Vault"));
     expect(onDeposit).toHaveBeenCalledWith("0.72");
   });
 
@@ -669,16 +669,16 @@ describe("PositionNotificationBanner", () => {
       warnings: [
         {
           type: "rebalance",
-          title: "Undersized sacrificial vault",
+          title: "Undersized sacrificial BTC Vault",
           detail: "Group 1 over-seizes.",
-          suggestion: "Add a 0.38 BTC vault.",
+          suggestion: "Add a 0.38 BTC Vault.",
         },
       ],
       suggestedRebalanceVaultBtc: 0.38,
     });
     renderBanner(result, onDeposit, onRepay);
 
-    fireEvent.click(screen.getByText("Add a 0.38 BTC vault"));
+    fireEvent.click(screen.getByText("Add a 0.38 BTC Vault"));
     expect(onDeposit).toHaveBeenCalledWith("0.38");
   });
 
@@ -687,7 +687,7 @@ describe("PositionNotificationBanner", () => {
       warnings: [
         {
           type: "too-many-vaults",
-          title: "Too many vaults to optimize",
+          title: "Too many BTC Vaults to optimize",
           detail: "You have 18 vaults.",
           suggestion:
             "Consider consolidating smaller vaults into fewer larger ones.",
@@ -699,7 +699,7 @@ describe("PositionNotificationBanner", () => {
     const banner = screen.getByTestId("position-notification-banner");
     expect(banner.dataset.severity).toBe("yellow");
     expect(banner.dataset.variant).toBe("warning");
-    expect(screen.queryByText(/Add a .* BTC vault/)).toBeNull();
+    expect(screen.queryByText(/Add a .* BTC Vault/)).toBeNull();
     expect(screen.queryByText("Apply Optimal Order")).toBeNull();
   });
 });

--- a/services/vault/src/components/simple/ResumeDepositContent.tsx
+++ b/services/vault/src/components/simple/ResumeDepositContent.tsx
@@ -304,11 +304,11 @@ export function ResumeWotsContent({
     try {
       const peginTxHash = activity.peginTxHash ?? null;
       if (!peginTxHash) {
-        throw new Error("Missing pegin transaction hash");
+        throw new Error("Missing peg-in transaction hash");
       }
       if (!activity.unsignedPrePeginTx) {
         throw new Error(
-          "Missing pre-pegin transaction; cannot recover WOTS seed inputs",
+          "Missing Pre-Pegin transaction; cannot recover WOTS seed inputs",
         );
       }
 
@@ -597,7 +597,7 @@ export function ResumeActivationContent({
     }
     if (!activity.unsignedPrePeginTx) {
       setLocalError(
-        "Missing pre-pegin transaction; cannot recover HTLC secret",
+        "Missing Pre-Pegin transaction; cannot recover HTLC secret",
       );
       setLoading(false);
       return;

--- a/services/vault/src/components/simple/__tests__/MaxVaultsNotification.test.tsx
+++ b/services/vault/src/components/simple/__tests__/MaxVaultsNotification.test.tsx
@@ -21,7 +21,7 @@ describe("MaxVaultsNotification", () => {
 
     render(<MaxVaultsNotification connectedAddress="0xuser" />);
 
-    expect(screen.getByText("Maximum vaults reached")).toBeInTheDocument();
+    expect(screen.getByText("Maximum BTC Vaults reached")).toBeInTheDocument();
     expect(
       screen.getByText(/maximum number of BTC Vaults \(10\)/),
     ).toBeInTheDocument();

--- a/services/vault/src/components/simple/__tests__/PostDepositContinuationView.test.tsx
+++ b/services/vault/src/components/simple/__tests__/PostDepositContinuationView.test.tsx
@@ -147,8 +147,8 @@ vi.mock("@/copy", () => ({
         activationSuccessMessagePlural: "Your BTC Vaults have been activated.",
       },
       vaultActivatedSuccess: {
-        heading: "Vault activated",
-        body: "Your vault is now active and ready for borrowing.",
+        heading: "BTC Vault activated",
+        body: "Your BTC Vault is now active and ready for borrowing.",
         goToDashboard: "Go to Dashboard",
       },
       errors: {
@@ -411,7 +411,7 @@ describe("PostDepositContinuationView", () => {
     // With no vault left to continue, the modal lands on the activated success
     // screen (replacing the progress view) rather than parking on a generic
     // "awaiting confirmation" step.
-    expect(getByText("Vault activated")).toBeInTheDocument();
+    expect(getByText("BTC Vault activated")).toBeInTheDocument();
     expect(getByText("Go to Dashboard")).toBeInTheDocument();
     // The deposit progress view is replaced, not layered behind.
     expect(queryByTestId("step")).toBeNull();
@@ -437,7 +437,7 @@ describe("PostDepositContinuationView", () => {
     });
 
     // No candidate vault remains → the single activated success screen shows.
-    expect(getByText("Vault activated")).toBeInTheDocument();
+    expect(getByText("BTC Vault activated")).toBeInTheDocument();
     expect(getByText("Go to Dashboard")).toBeInTheDocument();
     expect(queryByTestId("step")).toBeNull();
   });

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -146,7 +146,7 @@ export const COPY = {
     },
     statusErrors: {
       expired:
-        "This deposit has expired. You may still reclaim within the grace window — see refund options.",
+        "This deposit has expired. You may still refund within the grace window.",
       expiredCleanedUp:
         "This deposit expired and the grace window has elapsed. No further action is possible.",
       expiredInClaim: "Deposit expired; claim transaction has been broadcast",
@@ -202,9 +202,9 @@ export const COPY = {
     },
     maxVaultsReached: {
       cta: "Maximum BTC Vaults reached",
-      unavailableCta: "Unable to verify vault count — please try again",
+      unavailableCta: "Unable to verify BTC Vault count — please try again",
       splitUnavailable: (used: number, cap: number) =>
-        `${used} of ${cap} vaults used. Vault split unavailable.`,
+        `${used} of ${cap} BTC Vaults used. BTC Vault split unavailable.`,
     },
     steps: {
       generateSecret: "Generate secret for the deposit",
@@ -222,7 +222,7 @@ export const COPY = {
       awaitVpVerification: "Awaiting vault provider verification",
       retrieveSecret: "Retrieve secret",
       revealSecret: "Sign and broadcast ETH activation transaction",
-      awaitActivationConfirmation: "Awaiting vault activation confirmation",
+      awaitActivationConfirmation: "Awaiting BTC Vault activation confirmation",
       peginFeeWarning: "Expect a high transaction fee for security reasons",
       signingCounter: (completed: number, total: number) =>
         `(${completed} of ${total})`,
@@ -280,7 +280,7 @@ export const COPY = {
       registerDeposit: "Register deposit",
       signWots: "Set up claim",
       signPayout: "Sign payout",
-      activateVault: "Activate vault",
+      activateVault: "Activate BTC Vault",
       stepCounter: (completed: number, total: number) =>
         `${completed}/${total}`,
     },
@@ -304,7 +304,7 @@ export const COPY = {
       summary: {
         estimate: "~60 min",
         description:
-          "Each step is divided into several wallet signature confirmations. The progress counter shows how many are completed. Your Bitcoin will only be locked once the vault is activated.",
+          "Each step is divided into several wallet signature confirmations. The progress counter shows how many are completed. Your Bitcoin will only be locked once the BTC Vault is activated.",
       },
       stepsCompleted: (completed: number, total: number) =>
         `${completed} of ${total} steps completed`,
@@ -365,8 +365,8 @@ export const COPY = {
       doneButton: "Done",
     },
     refundSuccess: {
-      heading: "Expired vault withdrawal broadcast",
-      body: "Your expired vault withdrawal transaction has been broadcast successfully.",
+      heading: "Expired BTC Vault withdrawal broadcast",
+      body: "Your expired BTC Vault withdrawal transaction has been broadcast successfully.",
       viewExplorerButton: "View on blockchain explorer",
       doneButton: "Done",
       doNotSpendWarning: (symbol: string) =>
@@ -425,8 +425,8 @@ export const COPY = {
       continueButton: "Continue",
     },
     vaultActivatedSuccess: {
-      heading: "Vault activated",
-      body: "Your vault is now active and ready for borrowing.",
+      heading: "BTC Vault activated",
+      body: "Your BTC Vault is now active and ready for borrowing.",
       goToDashboard: "Go to Dashboard",
     },
     recoveryArtifacts: {
@@ -458,7 +458,7 @@ export const COPY = {
         "Only balances confirmed in a Bitcoin block are shown here. This amount is still waiting to confirm.",
       doNotSplit: "Do not split",
       selectVaultProvider: "Select vault provider",
-      providerSelectDescription: "Choose a provider to secure your BTC",
+      providerSelectDescription: "Choose a vault provider to secure your BTC",
       providerSelectEmpty: "No vault providers available at this time.",
       providerStatusUnavailable: "Unavailable",
       // Status label for a vault provider that has recently been unreachable
@@ -466,7 +466,7 @@ export const COPY = {
       providerStatusUnhealthy: "Recently unreachable",
       // Tooltip on an unhealthy provider, explaining it stays selectable.
       providerUnhealthyReason:
-        "This provider has recently been unreachable. You can still select it, but the deposit may need a retry.",
+        "This vault provider has recently been unreachable. You can still select it, but the deposit may need a retry.",
       // Divider label above the group of unhealthy / rejected providers.
       providerGroupUnavailableLabel: "Limited availability",
       // Per-provider metric labels shown in the picker.
@@ -477,7 +477,7 @@ export const COPY = {
       // (2.50%)"; net payout is the deposit minus that commission.
       vpCommissionLabel: "VP commission",
       vpCommissionTooltip:
-        "The vault provider's fee, deducted from your payout when you redeem. Set by the provider and shown here before you deposit.",
+        "The vault provider's fee, deducted from your payout when you redeem. Set by the vault provider and shown here before you deposit.",
       netPayoutLabel: "Net payout",
       netPayoutTooltip:
         "What you receive at payout: your deposit minus the vault provider's commission.",
@@ -508,7 +508,7 @@ export const COPY = {
         minimum: `at least ${minBtc}`,
       }),
       splitOptionDescription:
-        "Split your Bitcoin into two vaults to enable partial liquidation.",
+        "Split your BTC into two BTC Vaults to enable partial liquidation.",
       noSplitOptionDescription:
         "Your BTC will be deposited into a single BTC Vault.",
       // "Learn more here." link appended to the split-option description in
@@ -630,7 +630,7 @@ export const COPY = {
             "The vault provider took too long to respond. Please try again.",
         },
         providerNotFound: {
-          title: "Provider not found",
+          title: "Vault provider not found",
           message:
             "The vault provider could not be found in the on-chain registry. It may have been deregistered.",
         },
@@ -640,12 +640,12 @@ export const COPY = {
             "Unable to connect to the vault provider. Please check your connection and try again.",
         },
         providerTimeout: {
-          title: "Provider timeout",
+          title: "Vault provider timeout",
           message:
             "The vault provider took too long to respond. Please try again later.",
         },
         providerUnavailable: {
-          title: "Provider unavailable",
+          title: "Vault provider unavailable",
           message:
             "The vault provider is temporarily unreachable. Please try again later.",
         },
@@ -678,12 +678,12 @@ export const COPY = {
           "The payout address from the indexer does not match your connected wallet. This may indicate a data integrity issue. Please verify your wallet connection.",
       },
       providerNotAssigned: {
-        title: "Provider not assigned",
+        title: "Vault provider not assigned",
         message:
           "No vault provider is associated with this deposit. Please wait for indexer sync and try again.",
       },
       providerNotFound: {
-        title: "Provider not found",
+        title: "Vault provider not found",
         message: "Vault provider not found.",
       },
       walletNotConnected: {
@@ -793,12 +793,12 @@ export const COPY = {
   // NEXT_PUBLIC_TBV_VP_EXPLORER_URL is set; icon links use these as the
   // accessible name + tooltip.
   explorer: {
-    vaultLinkLabel: "View vault on explorer",
+    vaultLinkLabel: "View BTC Vault on explorer",
     providerLinkLabel: "View vault provider on explorer",
     // Callout under the Protocol Cap section. `calloutLinkText` renders as the
     // anchor to the explorer home; `callout` is the plain lead-in.
     callout:
-      "Explore vault activity, liquidity metrics, and protocol statistics in the",
+      "Explore BTC Vault activity, liquidity metrics, and protocol statistics in the",
     calloutLinkText: "BTC Trustless Vault Explorer",
   },
   withdraw: {
@@ -807,7 +807,7 @@ export const COPY = {
     modal: {
       title: "Withdraw",
       subtitle:
-        "Choose the collateral you want to withdraw. Remaining vaults will move up in priority order.",
+        "Choose the collateral you want to withdraw. Remaining BTC Vaults will move up in priority order.",
       confirmButton: "Withdraw",
       confirmButtonWithAmount: (amount: string) => `Withdraw ${amount}`,
     },
@@ -1120,8 +1120,8 @@ export const COPY = {
     addCollateral: "Add Collateral",
     repayDebt: "Repay Debt",
     applyOptimalOrder: "Apply Optimal Order",
-    addVault: (amountBtc: string) => `Add a ${amountBtc} BTC vault`,
-    addSacrificialVault: "Add sacrificial vault",
+    addVault: (amountBtc: string) => `Add a ${amountBtc} BTC Vault`,
+    addSacrificialVault: "Add sacrificial BTC Vault",
   },
   geoBlock: {
     title: "Service unavailable in your region",
@@ -1215,9 +1215,9 @@ export const COPY = {
     // the calculator finds a strictly safer order than the current one; the
     // suggested order is rendered as chips from `optimalVaultOrder`, not text.
     reorder: {
-      title: "Reorder vaults to lose less",
+      title: "Reorder BTC Vaults to lose less",
       detail:
-        "A different vault order makes the first liquidation event smaller — less BTC seized when it triggers.",
+        "A different BTC Vault order makes the first liquidation event smaller — less BTC seized when it triggers.",
       suggestedOrderLabel: "Suggested order",
       vaultChip: (name: string, amount: string) => `${name} · ${amount}`,
     },
@@ -1227,14 +1227,14 @@ export const COPY = {
     // what action is feasible.
     cliff: {
       title: "First liquidation takes everything",
-      body: "With your current vaults, a single liquidation event seizes all your BTC — nothing remains protected behind it.",
+      body: "With your current BTC Vaults, a single liquidation event seizes all your BTC — nothing remains protected behind it.",
       // Header shown above the suggestion text when there is no actionable CTA
       // (the withdraw/re-deposit and multi-vault cases). Rendered uppercase.
       suggestionLabel: "Suggestion",
       // Variant A (#1948): an affordable sacrificial vault buffers the existing
       // position. The amount lives here; the CTA label stays generic.
       addSacrificialSuggestion: (sacrificialBtc: string) =>
-        `Adding a ${sacrificialBtc} BTC sacrificial vault creates a buffer — it gets liquidated first, your existing BTC survives.`,
+        `Adding a sacrificial ${sacrificialBtc} BTC Vault creates a buffer — it gets liquidated first, your existing BTC survives.`,
       // Variant B (#1949): the single vault is too large to buffer cheaply —
       // withdraw it and re-deposit as two smaller vaults instead.
       withdrawResplitSuggestion: (
@@ -1242,10 +1242,10 @@ export const COPY = {
         sacrificialBtc: string,
         protectedBtc: string,
       ) =>
-        `To enable partial liquidation, withdraw your ${withdrawBtc} BTC and re-deposit as two smaller vaults: ${sacrificialBtc} BTC sacrificial + ${protectedBtc} BTC protected. Alternatively: add collateral or repay debt to manage the liquidation.`,
+        `To enable partial liquidation, withdraw your ${withdrawBtc} BTC and re-deposit as two smaller BTC Vaults: ${sacrificialBtc} BTC sacrificial + ${protectedBtc} BTC protected. Alternatively: add collateral or repay debt to manage the liquidation.`,
       // Protocol params disallow splitting entirely — no re-split is possible.
       noSplitSuggestion:
-        "Current protocol parameters do not allow vault splitting as a protection strategy. Add collateral or repay part of the debt to keep this position safe.",
+        "Current protocol parameters do not allow BTC Vault splitting as a protection strategy. Add collateral or repay part of the debt to keep this position safe.",
       // 2-vault / 3+ cliffs share the title/body/severity but keep their
       // structural suggestion, since "re-deposit as two smaller vaults" doesn't
       // apply when you already hold multiple vaults.
@@ -1253,7 +1253,7 @@ export const COPY = {
         enablePartial: (deficitBtc: string, largestName: string) =>
           `To enable partial liquidation, add ≥ ${deficitBtc} BTC alongside ${largestName}. `,
         suggestion: (targetSeizureBtc: string, enablePartialStr: string) =>
-          `Neither vault alone covers the target seizure (${targetSeizureBtc} BTC). ${enablePartialStr}You can also add collateral or repay part of the debt to keep this position safe. Alternatively: repay the loan, split BTC into optimal UTXOs, and re-open with a sacrificial vault.`,
+          `Neither BTC Vault alone covers the target seizure (${targetSeizureBtc} BTC). ${enablePartialStr}You can also add collateral or repay part of the debt to keep this position safe. Alternatively: repay the loan, split BTC into optimal UTXOs, and re-open with a sacrificial BTC Vault.`,
       },
       multiVault: {
         suggestion: (
@@ -1262,28 +1262,28 @@ export const COPY = {
           orderStr: string,
         ) =>
           hasReorderFix
-            ? `All ${nVaults} vaults land in the first liquidation group. Reordering vaults will fix this — suggested order: ${orderStr}.`
-            : `All ${nVaults} vaults land in the first liquidation group, and no combination of vaults covers the target seizure alone. Add collateral or repay part of the debt to keep this position safe.`,
+            ? `All ${nVaults} BTC Vaults land in the first liquidation group. Reordering BTC Vaults will fix this — suggested order: ${orderStr}.`
+            : `All ${nVaults} BTC Vaults land in the first liquidation group, and no combination of BTC Vaults covers the target seizure alone. Add collateral or repay part of the debt to keep this position safe.`,
       },
     },
     // Rebalance: the first group over-seizes because vault sizes aren't optimal;
     // a new sacrificial vault (combined with the existing small vaults) fixes it.
     rebalance: {
-      title: "Undersized sacrificial vault",
+      title: "Undersized sacrificial BTC Vault",
       detail: (
         g1CombinedBtc: string,
         g1TargetSeizure: string,
         g1OverSeizure: string,
         improvementBtc: string,
       ) =>
-        `Group 1 seizes ${g1CombinedBtc} BTC but target is only ${g1TargetSeizure} BTC — over-seizure of ${g1OverSeizure} BTC. With optimal vault sizes, ${improvementBtc} more BTC would be protected.`,
+        `Group 1 seizes ${g1CombinedBtc} BTC but target is only ${g1TargetSeizure} BTC — over-seizure of ${g1OverSeizure} BTC. With optimal BTC Vault sizes, ${improvementBtc} more BTC would be protected.`,
       actionableSuggestion: (
         suggestedBtc: string,
         smallNames: string,
         largestName: string,
         largestBtc: string,
       ) =>
-        `Add a ${suggestedBtc} BTC vault and place it with ${smallNames} at the front — together they cover the target seizure, protecting ${largestName} (${largestBtc} BTC). You can also add collateral or repay part of the debt to keep this position safe. Alternatively: repay the loan, split BTC into optimal UTXOs, and re-open the position.`,
+        `Add a ${suggestedBtc} BTC Vault and place it with ${smallNames} at the front — together they cover the target seizure, protecting ${largestName} (${largestBtc} BTC). You can also add collateral or repay part of the debt to keep this position safe. Alternatively: repay the loan, split BTC into optimal UTXOs, and re-open the position.`,
       fallbackSuggestion: (sacrificialBtc: string) =>
         `Repay the loan, split BTC into optimal UTXOs (sacrificial ~${sacrificialBtc} BTC + protected), and re-open the position.`,
     },
@@ -1291,21 +1291,21 @@ export const COPY = {
     // largest-first heuristic and the reorder suggestion is no longer optimal.
     // Copy matches Figma 7048-61969 (count + cap stay interpolated).
     tooManyVaults: {
-      title: "Too many vaults to optimize",
+      title: "Too many BTC Vaults to optimize",
       detail: (nVaults: number, cap: number) =>
-        `You have ${nVaults} vaults. Beyond ${cap}, the optimizer can't guarantee the best liquidation order — it falls back to a simpler largest-first approach. Your liquidation risk data is still accurate, but the order may not be optimal.`,
+        `You have ${nVaults} BTC Vaults. Beyond ${cap}, the optimizer can't guarantee the best liquidation order — it falls back to a simpler largest-first approach. Your liquidation risk data is still accurate, but the order may not be optimal.`,
       suggestion:
-        "Consider consolidating smaller vaults into fewer larger ones — fewer vaults means lower fees and better optimization.",
+        "Consider consolidating smaller BTC Vaults into fewer larger ones — fewer BTC Vaults means lower fees and better optimization.",
     },
     maxVaults: {
-      title: "Maximum vaults reached",
+      title: "Maximum BTC Vaults reached",
       detail: (cap: number) =>
         `This position already has the maximum number of BTC Vaults (${cap}).`,
     },
     dust: {
-      title: "Position too small for vault analysis",
+      title: "Position too small for BTC Vault analysis",
       detail:
-        "Below $1,000 the cascade simplifies — all vaults are shown as one liquidation event. Small positions don't have meaningful multi-event behavior.",
+        "Below $1,000 the cascade simplifies — all BTC Vaults are shown as one liquidation event. Small positions don't have meaningful multi-event behavior.",
     },
     weirdParams: {
       title: "Protocol parameters don't compute",

--- a/services/vault/src/services/deposit/__tests__/validations.test.ts
+++ b/services/vault/src/services/deposit/__tests__/validations.test.ts
@@ -607,7 +607,7 @@ describe("Deposit Validations", () => {
       });
       expect(result).toEqual({
         disabled: true,
-        label: "Vault size exceeds remaining capacity (0.005 BTC)",
+        label: "BTC Vault size exceeds remaining capacity (0.005 BTC)",
       });
     });
 
@@ -657,7 +657,7 @@ describe("Deposit Validations", () => {
       });
     });
 
-    it("returns 'Vault size exceeds remaining capacity' when amount > effectiveRemaining", () => {
+    it("returns 'BTC Vault size exceeds remaining capacity' when amount > effectiveRemaining", () => {
       // Amount + fee + claim (806_000) still fits readyParams.btcBalance
       // (1_000_000), so this test isolates the cap branch from the balance
       // check. effectiveRemaining 500_000 sats = "0.005" via
@@ -669,7 +669,7 @@ describe("Deposit Validations", () => {
       });
       expect(result).toEqual({
         disabled: true,
-        label: "Vault size exceeds remaining capacity (0.005 BTC)",
+        label: "BTC Vault size exceeds remaining capacity (0.005 BTC)",
       });
     });
 

--- a/services/vault/src/services/deposit/validations.ts
+++ b/services/vault/src/services/deposit/validations.ts
@@ -348,7 +348,7 @@ export function getDepositCtaState(params: DepositCtaParams): DepositCtaState {
   ) {
     return {
       disabled: true,
-      label: `Vault size exceeds remaining capacity (${formatSatoshisToBtc(params.effectiveRemaining)} BTC)`,
+      label: `BTC Vault size exceeds remaining capacity (${formatSatoshisToBtc(params.effectiveRemaining)} BTC)`,
     };
   }
 

--- a/services/vault/src/utils/errors/errorMessages.ts
+++ b/services/vault/src/utils/errors/errorMessages.ts
@@ -224,7 +224,7 @@ export const CONTRACT_ERROR_MESSAGES: Record<string, string> = {
   BlocklistedVaultKeeper:
     "This vault keeper has been blocklisted and cannot perform this action.",
   PostExpiryGraceWindowElapsed:
-    "The grace window to reclaim this expired BTC Vault has elapsed.",
+    "The grace window to refund this expired BTC Vault has elapsed.",
   BtcKeyAlreadyRegistered: "This Bitcoin public key is already registered.",
   CommissionAboveMaximum:
     "The proposed commission exceeds the protocol maximum.",

--- a/services/vault/src/utils/errors/formatting.ts
+++ b/services/vault/src/utils/errors/formatting.ts
@@ -341,7 +341,7 @@ export function formatPayoutSignatureError(error: unknown): {
   if (error instanceof Error) {
     if (error.message.includes("Vault provider not found")) {
       return {
-        title: "Provider not found",
+        title: "Vault provider not found",
         message:
           "The vault provider for this deposit could not be found. Please contact support.",
       };

--- a/services/vault/src/utils/vaultProviderStatus.ts
+++ b/services/vault/src/utils/vaultProviderStatus.ts
@@ -15,14 +15,14 @@ const REASON_BY_STATUS: Record<
   Exclude<VaultProviderMetadataStatus, "ok">,
   string
 > = {
-  missing: "This provider has no RPC URL configured.",
-  invalid_url: "This provider's RPC URL is not a valid URL.",
+  missing: "This vault provider has no RPC URL configured.",
+  invalid_url: "This vault provider's RPC URL is not a valid URL.",
   unsupported_scheme:
-    "This provider's RPC URL uses an unsupported scheme (only http/https are accepted).",
+    "This vault provider's RPC URL uses an unsupported scheme (only http/https are accepted).",
   private_host:
-    "This provider's RPC URL points to a private or internal address that the proxy will reject.",
+    "This vault provider's RPC URL points to a private or internal address that the proxy will reject.",
   ipv6_literal_unsupported:
-    "This provider's RPC URL uses an IPv6 literal host that the proxy does not support.",
+    "This vault provider's RPC URL uses an IPv6 literal host that the proxy does not support.",
 };
 
 /**


### PR DESCRIPTION
- Replaces all bare "vault"/"vaults" with "BTC Vault"/"BTC Vaults" in user-facing
strings across copy.ts, AddressScreeningBanner, validations.ts, notification
banners, and liquidation warning copy (~30 instances)
- Replaces bare "provider" with "vault provider" in copy.ts, vaultProviderStatus.ts,
and formatting.ts (~12 instances)
- Eliminates "reclaim" as a third synonym for the expired-deposit refund flow,
standardizing on "refund" (copy.ts, errorMessages.ts)
- Fixes "pegin" → "peg-in" and "pre-pegin" → "Pre-Pegin" in thrown error strings
(ResumeDepositContent.tsx)
- Aligns "Bitcoin" vs "BTC" in adjacent split-option descriptions