### PR TITLE
feat(vault): drop the rebalance

### DIFF
--- a/services/vault/src/applications/aave/components/PositionNotificationsDebugPanel.tsx
+++ b/services/vault/src/applications/aave/components/PositionNotificationsDebugPanel.tsx
@@ -34,7 +34,6 @@ const SEVERITY_COLORS: Record<BannerSeverity, string> = {
 const WARNING_TYPE_COLORS: Record<WarningType, string> = {
   urgent: "bg-red-600 text-white",
   cliff: "bg-orange-600 text-white",
-  rebalance: "bg-amber-500 text-white",
   reorder: "bg-yellow-500 text-black",
   dust: "bg-gray-500 text-white",
   "weird-params": "bg-blue-500 text-white",

--- a/services/vault/src/applications/aave/positionNotifications/__tests__/calculate.test.ts
+++ b/services/vault/src/applications/aave/positionNotifications/__tests__/calculate.test.ts
@@ -204,7 +204,6 @@ describe("calculate", () => {
     const allowed = new Set([
       "urgent",
       "cliff",
-      "rebalance",
       "reorder",
       "dust",
       "weird-params",
@@ -345,12 +344,13 @@ describe("golden vectors (reference scenario suite)", () => {
     expect(result.groups[1].isFullLiquidation).toBe(true);
   });
 
-  it("B2 — [0.80, 0.20]: over-seizure triggers a rebalance with a suggested vault", () => {
+  it("B2 — [0.80, 0.20]: over-seizure is no longer surfaced (rebalance dropped)", () => {
+    // The first group over-seizes, but with the "Undersized sacrificial vault"
+    // (rebalance) notification removed there is no actionable cliff/reorder
+    // warning for this shape — the position is left un-notified by design.
     const result = calculate(makeParams([v(0.8), v(0.2)]));
     expect(hasWarning(result.warnings, "cliff")).toBe(false);
     expect(hasWarning(result.warnings, "reorder")).toBe(false);
-    expect(hasWarning(result.warnings, "rebalance")).toBe(true);
-    expect(result.suggestedRebalanceVaultBtc).toBe(0.38);
   });
 
   it("C1 — [0.35, 0.65] wrong order: reorder notification, single group", () => {
@@ -414,18 +414,15 @@ describe("golden vectors (reference scenario suite)", () => {
     expect(result.optimalVaultOrder).toBeNull();
   });
 
-  it("17-vault rebalance: suggests a vault amount, no too-many-vaults at the cap", () => {
-    // One large vault over-seizes; 16 tiny vaults can't combine to cover the
-    // target without it. The position has 17 vaults (== MAX_DP_N), so the
-    // optimizer runs an exact DP and no too-many-vaults warning fires (the
-    // position is at the cap, not over it).
+  it("17 vaults at the cap: no too-many-vaults warning (== MAX_DP_N)", () => {
+    // The position has 17 vaults (== MAX_DP_N), so the optimizer runs an exact
+    // DP and does NOT fall back — no too-many-vaults warning fires (the position
+    // is at the cap, not over it).
     const big = v(0.9);
     const smalls = Array.from({ length: 16 }, () => v(0.01));
     const result = calculate(makeParams([big, ...smalls]));
 
-    expect(hasWarning(result.warnings, "rebalance")).toBe(true);
     expect(hasWarning(result.warnings, "too-many-vaults")).toBe(false);
-    expect(result.suggestedRebalanceVaultBtc).not.toBeNull();
     // The optimal-order analysis runs an exact DP at n = 17 (the cap), which is
     // intentionally near the interactive-time budget — allow extra headroom.
   }, 20000);

--- a/services/vault/src/applications/aave/positionNotifications/bannerSeverity.ts
+++ b/services/vault/src/applications/aave/positionNotifications/bannerSeverity.ts
@@ -43,7 +43,6 @@ const PRIMARY_ORDER: WarningType[] = [
   "urgent",
   "weird-params",
   "cliff",
-  "rebalance",
   "too-many-vaults",
   "reorder",
 ];
@@ -53,7 +52,7 @@ const PRIMARY_ORDER: WarningType[] = [
  *
  * Red:    urgent warning present (already liquidatable or within 5%)
  * Yellow: cliff or too-many-vaults (the orange warning banner per Figma)
- * Soft:   any other advisory warning (rebalance / reorder / weird-params), or a
+ * Soft:   any other advisory warning (reorder / weird-params), or a
  *         healthy position whose vault order is suboptimal
  * Green:  no warnings and order already optimal
  * Hidden: no groups

--- a/services/vault/src/applications/aave/positionNotifications/calculate.ts
+++ b/services/vault/src/applications/aave/positionNotifications/calculate.ts
@@ -56,7 +56,7 @@ const btc2 = (n: number): string => n.toFixed(2);
  * other advisories), `too-many-vaults` (optimizer fell back past its cap),
  * `urgent` (already liquidatable or within 5%), `cliff` (all vaults consolidate
  * into one liquidation group — partial liquidation impossible), `reorder` (a
- * safer order exists), `rebalance` (the first group over-seizes), or `dust`.
+ * safer order exists), or `dust`.
  */
 export function calculate(params: CalculatorParams): CalculatorResult {
   const {
@@ -90,7 +90,6 @@ export function calculate(params: CalculatorParams): CalculatorResult {
       warnings,
       optimalVaultOrder: null,
       suggestedNewVaultBtc: null,
-      suggestedRebalanceVaultBtc: null,
     };
   }
 
@@ -132,7 +131,6 @@ export function calculate(params: CalculatorParams): CalculatorResult {
       ],
       optimalVaultOrder: null,
       suggestedNewVaultBtc: null,
-      suggestedRebalanceVaultBtc: null,
     };
   }
 
@@ -285,7 +283,6 @@ export function calculate(params: CalculatorParams): CalculatorResult {
       warnings,
       optimalVaultOrder: null,
       suggestedNewVaultBtc: null,
-      suggestedRebalanceVaultBtc: null,
     };
   }
 
@@ -345,21 +342,23 @@ export function calculate(params: CalculatorParams): CalculatorResult {
   const group1ReorderWouldHelp =
     reorderWouldHelp && currentGroup1Btc > optimalG1Btc + REORDER_TOL;
 
-  // Suppress reorder if it would create a rebalance condition that doesn't exist
-  // now (prevents a reorder↔rebalance loop). Cliff cases are exempt — for a
-  // cliff, reordering is always an improvement even if it introduces rebalance.
+  // Don't suggest a reorder that would newly introduce an over-seizure
+  // condition (Group 1 loses more in excess than it protects) that the current
+  // order doesn't already have — a reorder should never make the position
+  // worse. Cliff cases are exempt: for a cliff, reordering is always an
+  // improvement even if the result over-seizes.
   if (reorderWouldHelp && nVaults >= 2 && !isCliff) {
     const currentOverSeizure = firstGroup ? firstGroup.overSeizureBtc : 0;
     const currentProtected = firstGroup ? firstGroup.btcRemainingAfter : 0;
-    const currentHasRebalanceCond = currentOverSeizure > currentProtected;
+    const currentHasOverSeizure = currentOverSeizure > currentProtected;
 
     const optTarget = totalBtc * seizedFraction;
     const optOver = Math.max(0, optimalG1Btc - optTarget);
     const optProtected = totalBtc - optimalG1Btc;
     const optIsCliff = optimalG1Vaults.length === nVaults;
-    const optWouldTriggerRebalance = optOver > optProtected && !optIsCliff;
+    const optWouldOverSeize = optOver > optProtected && !optIsCliff;
 
-    if (!currentHasRebalanceCond && optWouldTriggerRebalance) {
+    if (!currentHasOverSeizure && optWouldOverSeize) {
       reorderWouldHelp = false;
     }
   }
@@ -526,83 +525,7 @@ export function calculate(params: CalculatorParams): CalculatorResult {
     }
   }
 
-  // ── 8. Warning: rebalance ──────────────────────────────────────
-  //
-  // Over-seizure in Group 1 means vault sizes aren't optimal: you lose more in
-  // excess than what survives. A new sacrificial vault (combined with the
-  // existing small vaults) protects the largest one.
-
-  const g1OverSeizure = firstGroup ? firstGroup.overSeizureBtc : 0;
-  const g1TargetSeizure = firstGroup ? firstGroup.targetSeizureBtc : 0;
-  const g1ProtectedBtc = firstGroup ? firstGroup.btcRemainingAfter : 0;
-  const rebalanceNeeded =
-    g1OverSeizure > g1ProtectedBtc && nVaults >= 2 && !isCliff;
-
-  const idealProtectedBtc = totalBtc - totalBtc * Math.min(liqFactor, 1);
-  const currentProtectedBtc = firstGroup
-    ? firstGroup.btcRemainingAfter
-    : totalBtc;
-  const rebalanceImprovementBtc = rebalanceNeeded
-    ? Math.max(0, idealProtectedBtc - currentProtectedBtc)
-    : 0;
-
-  // Suggested new sacrificial vault: s >= (T × liqFactor − smallVaultsSum) /
-  // (1 − liqFactor). Cheaper than a standalone vault because the existing small
-  // vaults contribute to covering the target seizure.
-  let suggestedRebalanceVaultBtc: number | null = null;
-  if (rebalanceNeeded && liqFactor < 1) {
-    const largest = vaults.reduce((a, b) => (a.btc > b.btc ? a : b));
-    const smallVaults = vaults.filter((v) => v.id !== largest.id);
-    const smallVaultsSum = smallVaults.reduce((s, v) => s + v.btc, 0);
-    const raw = (totalBtc * liqFactor - smallVaultsSum) / (1 - liqFactor);
-    const rounded = Math.ceil(Math.max(0, raw) * 100) / 100;
-    if (rounded <= totalBtc) {
-      suggestedRebalanceVaultBtc = rounded;
-    }
-  }
-
-  // Emit the rebalance warning only when no cliff/reorder already covers it;
-  // otherwise drop its suggestion data so no orphan action button renders.
-  const hasCliffOrReorder = warnings.some(
-    (w) => w.type === "cliff" || w.type === "reorder",
-  );
-  if (rebalanceNeeded && hasCliffOrReorder) {
-    suggestedRebalanceVaultBtc = null;
-  }
-  if (rebalanceNeeded && !hasCliffOrReorder) {
-    const largest = vaults.reduce((a, b) => (a.btc > b.btc ? a : b));
-    const g1CombinedBtc = firstGroup?.combinedBtc ?? 0;
-    let suggestion: string;
-    if (suggestedRebalanceVaultBtc !== null) {
-      const smallNames = vaults
-        .filter((v) => v.id !== largest.id)
-        .map((v) => v.name)
-        .join(" + ");
-      suggestion = COPY.liquidationWarnings.rebalance.actionableSuggestion(
-        btc2(suggestedRebalanceVaultBtc),
-        smallNames,
-        largest.name,
-        btc2(largest.btc),
-      );
-    } else {
-      suggestion = COPY.liquidationWarnings.rebalance.fallbackSuggestion(
-        btc2(totalBtc * Math.min(liqFactor, 1)),
-      );
-    }
-    warnings.push({
-      type: "rebalance",
-      title: COPY.liquidationWarnings.rebalance.title,
-      detail: COPY.liquidationWarnings.rebalance.detail(
-        btc2(g1CombinedBtc),
-        btc2(g1TargetSeizure),
-        btc2(g1OverSeizure),
-        btc2(rebalanceImprovementBtc),
-      ),
-      suggestion,
-    });
-  }
-
-  // ── 9. Return ──────────────────────────────────────────────────
+  // ── 8. Return ──────────────────────────────────────────────────
 
   return {
     groups,
@@ -612,6 +535,5 @@ export function calculate(params: CalculatorParams): CalculatorResult {
     warnings,
     optimalVaultOrder,
     suggestedNewVaultBtc,
-    suggestedRebalanceVaultBtc,
   };
 }

--- a/services/vault/src/applications/aave/positionNotifications/types.ts
+++ b/services/vault/src/applications/aave/positionNotifications/types.ts
@@ -30,7 +30,6 @@ export interface LiquidationGroup {
 export type WarningType =
   | "urgent"
   | "cliff"
-  | "rebalance"
   | "reorder"
   | "dust"
   | "weird-params"
@@ -79,11 +78,4 @@ export interface CalculatorResult {
    * actionable (extreme params, or the amount would exceed the position).
    */
   suggestedNewVaultBtc: number | null;
-  /**
-   * Multi-vault rebalance only: size of a new sacrificial vault that combines
-   * with the existing small vaults to protect the largest. `null` when no
-   * rebalance is needed, params are extreme, or the amount would exceed the
-   * position.
-   */
-  suggestedRebalanceVaultBtc: number | null;
 }

--- a/services/vault/src/applications/aave/services/__tests__/assertReorderMatchesOnChain.test.ts
+++ b/services/vault/src/applications/aave/services/__tests__/assertReorderMatchesOnChain.test.ts
@@ -10,7 +10,7 @@
  * notification calculator with on-chain amounts and blocks submissions
  * whose ordering disagrees (the same-set tamper attack), whose vaults
  * are inactive or bound to a different application, or whose trusted
- * calculator would not have suggested a reorder at all (rebalance
+ * calculator would not have suggested a reorder at all (over-seizure
  * suppression).
  */
 

--- a/services/vault/src/applications/aave/services/assertReorderMatchesOnChain.ts
+++ b/services/vault/src/applications/aave/services/assertReorderMatchesOnChain.ts
@@ -136,8 +136,9 @@ export async function assertReorderMembership(
  * notification calculator would have suggested.
  *
  * Re-runs the full `calculate(...)` pipeline (not just `computeOptimalOrder`)
- * so that suppression rules — e.g. when an optimal reorder would create a
- * rebalance condition the user currently doesn't have — are honored. A
+ * so that suppression rules — e.g. when an optimal reorder would newly
+ * introduce an over-seizure condition the user currently doesn't have — are
+ * honored. A
  * malicious indexer can otherwise fabricate a CTA whose submitted order
  * equals `computeOptimalOrder(trusted).order` even though the trusted
  * calculator would have returned `optimalVaultOrder: null`.

--- a/services/vault/src/components/simple/PositionNotificationBanner/BannerActions.tsx
+++ b/services/vault/src/components/simple/PositionNotificationBanner/BannerActions.tsx
@@ -29,9 +29,6 @@ interface BuildBannerActionsArgs {
  * - cliff with an affordable sacrificial size: "Add sacrificial vault" (generic
  *   label per Figma; the amount lives in the suggestion text) — opens the
  *   deposit flow with that amount pre-filled.
- * - rebalance with an actionable suggested vault size: "Add a X BTC vault" —
- *   opens the deposit flow with that amount pre-filled (a single, non-split
- *   supplemental deposit).
  * - optimal reorder available: "Apply Optimal Order" — filled (primary) on the
  *   standalone reorder card, secondary when it accompanies the urgent callout.
  *
@@ -75,26 +72,17 @@ export function buildBannerActions({
     );
   }
 
-  // Add-vault CTA whenever a cliff/rebalance warning is present and the
-  // calculator produced an actionable size — i.e. "add a sacrificial vault of
-  // this exact size". When an urgent warning is primary it rides along as a
-  // secondary action so the safety actions lead, but it is no longer dropped
-  // (the warning's own suggestion text describes exactly this action). The
-  // calculator guarantees the amount is positive and no larger than the position.
-  // The cliff path uses the generic "Add sacrificial vault" label (amount in the
-  // suggestion text per Figma); rebalance keeps the amount on the button.
-  const hasCliffOrRebalanceWarning = result.warnings.some(
-    (w) => w.type === "cliff" || w.type === "rebalance",
-  );
-  const isCliffSacrificial = result.suggestedNewVaultBtc !== null;
-  const suggestedVaultBtc =
-    result.suggestedNewVaultBtc ?? result.suggestedRebalanceVaultBtc;
-  if (hasCliffOrRebalanceWarning && suggestedVaultBtc !== null) {
-    const amountBtc = suggestedVaultBtc.toFixed(2);
+  // Add-sacrificial-vault CTA on a cliff when the calculator produced an
+  // actionable size — "add a sacrificial vault of this exact size". When an
+  // urgent warning is primary it rides along as a secondary action so the
+  // safety actions lead. The calculator guarantees the amount is positive and
+  // no larger than the position. Generic "Add sacrificial vault" label (the
+  // amount lives in the suggestion text per Figma).
+  const hasCliffWarning = result.warnings.some((w) => w.type === "cliff");
+  if (hasCliffWarning && result.suggestedNewVaultBtc !== null) {
+    const amountBtc = result.suggestedNewVaultBtc.toFixed(2);
     actions.push({
-      label: isCliffSacrificial
-        ? COPY.banner.addSacrificialVault
-        : COPY.banner.addVault(amountBtc),
+      label: COPY.banner.addSacrificialVault,
       onClick: () => onDeposit(amountBtc),
       emphasis: isUrgent ? "secondary" : "primary",
       // Adding a vault is a deposit — blocked under a protocol Freeze/Pause.

--- a/services/vault/src/components/simple/PositionNotificationBanner/PositionNotificationBanner.tsx
+++ b/services/vault/src/components/simple/PositionNotificationBanner/PositionNotificationBanner.tsx
@@ -233,9 +233,9 @@ export function PositionNotificationBanner({
   });
 
   // Sub-box content: the optimal-order chips for the standalone reorder card,
-  // otherwise the primary warning's own suggestion (e.g. the cliff/rebalance
-  // advice — urgent conveys its CTA via the action buttons instead) stacked
-  // above any secondary warnings (e.g. urgent + cliff).
+  // otherwise the primary warning's own suggestion (e.g. the cliff advice —
+  // urgent conveys its CTA via the action buttons instead) stacked above any
+  // secondary warnings (e.g. urgent + cliff).
   let suggestion: ReactNode;
   if (isStandaloneReorder && result.optimalVaultOrder) {
     suggestion = <OptimalOrderChips vaults={result.optimalVaultOrder} />;

--- a/services/vault/src/components/simple/PositionNotificationBanner/__tests__/BannerActions.test.ts
+++ b/services/vault/src/components/simple/PositionNotificationBanner/__tests__/BannerActions.test.ts
@@ -22,7 +22,6 @@ function makeResult(
       { id: "0xdef", name: "Vault 1", btc: 0.1 },
     ],
     suggestedNewVaultBtc: null,
-    suggestedRebalanceVaultBtc: null,
     ...overrides,
   };
 }

--- a/services/vault/src/components/simple/PositionNotificationBanner/__tests__/PositionNotificationBanner.test.tsx
+++ b/services/vault/src/components/simple/PositionNotificationBanner/__tests__/PositionNotificationBanner.test.tsx
@@ -160,7 +160,6 @@ function makeBaseResult(
     warnings: [],
     optimalVaultOrder: null,
     suggestedNewVaultBtc: null,
-    suggestedRebalanceVaultBtc: null,
     ...overrides,
   };
 }
@@ -662,24 +661,6 @@ describe("PositionNotificationBanner", () => {
     expect(screen.getByText("Repay Debt")).toBeTruthy();
     fireEvent.click(screen.getByText("Add sacrificial BTC Vault"));
     expect(onDeposit).toHaveBeenCalledWith("0.72");
-  });
-
-  it("renders an Add-a-vault CTA for a rebalance with the rebalance amount", () => {
-    const result = makeBaseResult({
-      warnings: [
-        {
-          type: "rebalance",
-          title: "Undersized sacrificial BTC Vault",
-          detail: "Group 1 over-seizes.",
-          suggestion: "Add a 0.38 BTC Vault.",
-        },
-      ],
-      suggestedRebalanceVaultBtc: 0.38,
-    });
-    renderBanner(result, onDeposit, onRepay);
-
-    fireEvent.click(screen.getByText("Add a 0.38 BTC Vault"));
-    expect(onDeposit).toHaveBeenCalledWith("0.38");
   });
 
   it("renders too-many-vaults as an orange warning with no action button", () => {

--- a/services/vault/src/components/simple/__tests__/CriticalLiquidationTopBanner.test.tsx
+++ b/services/vault/src/components/simple/__tests__/CriticalLiquidationTopBanner.test.tsx
@@ -49,7 +49,6 @@ function makeResult({
     warnings: urgent ? [{ type: "urgent", title: "x", detail: "y" }] : [],
     optimalVaultOrder: null,
     suggestedNewVaultBtc: null,
-    suggestedRebalanceVaultBtc: null,
   };
 }
 

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -1120,7 +1120,6 @@ export const COPY = {
     addCollateral: "Add Collateral",
     repayDebt: "Repay Debt",
     applyOptimalOrder: "Apply Optimal Order",
-    addVault: (amountBtc: string) => `Add a ${amountBtc} BTC Vault`,
     addSacrificialVault: "Add sacrificial BTC Vault",
   },
   geoBlock: {
@@ -1192,9 +1191,9 @@ export const COPY = {
     liquidatable: "Critical — liquidation can trigger now",
   },
   // Liquidation-notification warnings shown in the position banner. Mirrors the
-  // warning types produced by the calculator: urgent / cliff / rebalance /
-  // reorder / dust / weird-params / too-many-vaults. Wording is ported from the
-  // reference liquidation calculator (the source of truth for this copy).
+  // warning types produced by the calculator: urgent / cliff / reorder / dust /
+  // weird-params / too-many-vaults. Wording is ported from the reference
+  // liquidation calculator (the source of truth for this copy).
   liquidationWarnings: {
     urgent: {
       liquidatableTitle: "Liquidation can trigger now",
@@ -1265,27 +1264,6 @@ export const COPY = {
             ? `All ${nVaults} BTC Vaults land in the first liquidation group. Reordering BTC Vaults will fix this — suggested order: ${orderStr}.`
             : `All ${nVaults} BTC Vaults land in the first liquidation group, and no combination of BTC Vaults covers the target seizure alone. Add collateral or repay part of the debt to keep this position safe.`,
       },
-    },
-    // Rebalance: the first group over-seizes because vault sizes aren't optimal;
-    // a new sacrificial vault (combined with the existing small vaults) fixes it.
-    rebalance: {
-      title: "Undersized sacrificial BTC Vault",
-      detail: (
-        g1CombinedBtc: string,
-        g1TargetSeizure: string,
-        g1OverSeizure: string,
-        improvementBtc: string,
-      ) =>
-        `Group 1 seizes ${g1CombinedBtc} BTC but target is only ${g1TargetSeizure} BTC — over-seizure of ${g1OverSeizure} BTC. With optimal BTC Vault sizes, ${improvementBtc} more BTC would be protected.`,
-      actionableSuggestion: (
-        suggestedBtc: string,
-        smallNames: string,
-        largestName: string,
-        largestBtc: string,
-      ) =>
-        `Add a ${suggestedBtc} BTC Vault and place it with ${smallNames} at the front — together they cover the target seizure, protecting ${largestName} (${largestBtc} BTC). You can also add collateral or repay part of the debt to keep this position safe. Alternatively: repay the loan, split BTC into optimal UTXOs, and re-open the position.`,
-      fallbackSuggestion: (sacrificialBtc: string) =>
-        `Repay the loan, split BTC into optimal UTXOs (sacrificial ~${sacrificialBtc} BTC + protected), and re-open the position.`,
     },
     // Too many vaults: beyond the optimizer cap, ordering falls back to a
     // largest-first heuristic and the reorder suggestion is no longer optimal.


### PR DESCRIPTION
# Drop the "Undersized sacrificial vault" (rebalance) notification

Closes https://github.com/babylonlabs-io/babylon-toolkit/issues/1971

## What this does

Removes the `rebalance` liquidation notification (shown as "Undersized sacrificial vault") from the position-notification calculator and UI. It was live behind the existing liquidation-notifications feature flag, using placeholder developer copy.

## Why

This notification only ever existed in the `tbv-liquidations` reference calculator we ported from. It has **no Figma design**, it's **not in the simplified product spec**, and it conceptually overlaps the cliff/reorder notifications. Product made the call to drop it. Leaving it in means shipping an undesigned notification with dev copy, so it needs to be removed rather than left behind the flag.

## Approaches considered, and what we chose

**Spec it vs. remove it.** The two options were: (a) design a Figma frame for it and keep it, or (b) remove it. Product chose remove, so this PR deletes it. The reference calculator stays the source of truth for the liquidation *math*; Figma/product decides what we actually *show* — and this one isn't shown.

**The subtle part — two different things are named "rebalance".** There's the user-facing rebalance *warning* (the notification), and there's a small internal *reorder guard* that uses an "over-seizure" condition to avoid suggesting a vault reorder that would make the position worse. Only the first is being dropped. I removed the warning and everything that feeds it, but kept the reorder guard (it's about reorder quality, not this notification) and just renamed its wording away from "rebalance" so the code isn't misleading.

**Delete the dead helpers too.** Removing the warning left a copy string and a result field with no remaining users. Per the repo's no-dead-code rule I deleted those as well (the calculator result no longer carries `suggestedRebalanceVaultBtc`, and the banner's "Add a X BTC vault" label is gone — the cliff path uses "Add sacrificial vault").

## Changes

- `positionNotifications/types.ts` — removed `"rebalance"` from the warning types and the `suggestedRebalanceVaultBtc` result field.
- `positionNotifications/calculate.ts` — deleted the whole rebalance-warning section; kept and reworded the internal over-seizure reorder guard.
- `copy.ts` — removed the rebalance copy block and the now-unused "Add a X BTC vault" label.
- `bannerSeverity.ts`, `BannerActions.tsx`, the debug panel, and a few comments — dropped the rebalance references; the add-a-vault CTA is now cliff-only.
- Tests — removed the rebalance-specific tests/fixtures and updated the calculator tests to the new behavior (see below).

## Behavior change to be aware of

A position whose first liquidation group over-seizes because of sub-optimal vault sizes — e.g. `[0.80, 0.20]` — now shows **no** notification, because rebalance was the only warning that covered that shape. That's the intended tradeoff of dropping it. Everything else (urgent, cliff, reorder, dust, too-many-vaults) is unchanged.

## How to verify

- tsc, lint (0 errors — same warning baseline as `main`), and the full vault test suite pass (2113 tests).
- Manually (debug panel with the liquidation-notifications flag on, Manual Mode): an `[0.80, 0.20]` position no longer shows "Undersized sacrificial vault"; cliff / reorder / dust / urgent / too-many-vaults still behave, and the cliff "Add sacrificial vault" CTA still works.
