### PR TITLE
fix(vault): align the vault-activated success screen with the design

### DIFF
--- a/services/vault/src/components/simple/VaultActivatedView.tsx
+++ b/services/vault/src/components/simple/VaultActivatedView.tsx
@@ -7,7 +7,6 @@
  */
 
 import { Button, Heading, Text } from "@babylonlabs-io/core-ui";
-import { IoCheckmarkSharp } from "react-icons/io5";
 
 import { COPY } from "@/copy";
 
@@ -22,14 +21,33 @@ export function VaultActivatedView({
 }: VaultActivatedViewProps) {
   return (
     <div
-      className={`w-full ${DEPOSIT_VIEW_MAX_WIDTH_CLASS} overflow-hidden rounded-xl border border-secondary-strokeDark px-6 pb-6 pt-10`}
+      className={`w-full ${DEPOSIT_VIEW_MAX_WIDTH_CLASS} overflow-hidden rounded-2xl border border-secondary-strokeLight bg-primary-contrast px-6 pb-6 pt-10`}
     >
-      <div className="flex flex-col items-center gap-6 pb-10 text-center">
-        <div className="flex h-20 w-20 items-center justify-center rounded-full border-2 border-accent-primary">
-          <IoCheckmarkSharp size={40} className="text-accent-primary" />
-        </div>
-        <div className="flex flex-col items-center gap-2">
-          <Heading variant="h5" className="text-accent-primary">
+      <div className="flex flex-col items-center gap-10 pb-10 text-center">
+        <svg
+          width="92"
+          height="92"
+          viewBox="0 0 92 92"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          className="text-black dark:text-white"
+          aria-hidden="true"
+        >
+          <path
+            d="M23.5 48.6417L40.3755 65.1235L73 32.4995"
+            stroke="currentColor"
+            strokeWidth="2"
+          />
+          <circle
+            cx="46"
+            cy="46"
+            r="45"
+            stroke="currentColor"
+            strokeWidth="2"
+          />
+        </svg>
+        <div className="flex flex-col items-center gap-4">
+          <Heading variant="h4" className="text-black dark:text-white">
             {COPY.deposit.vaultActivatedSuccess.heading}
           </Heading>
           <Text variant="body1" className="text-accent-secondary">

--- a/services/vault/src/components/simple/__tests__/PostDepositContinuationView.test.tsx
+++ b/services/vault/src/components/simple/__tests__/PostDepositContinuationView.test.tsx
@@ -147,8 +147,8 @@ vi.mock("@/copy", () => ({
         activationSuccessMessagePlural: "Your BTC Vaults have been activated.",
       },
       vaultActivatedSuccess: {
-        heading: "BTC Vault activated",
-        body: "Your BTC Vault is now active and ready for borrowing.",
+        heading: "Vault activated",
+        body: "Your vault is now active and ready for borrowing.",
         goToDashboard: "Go to Dashboard",
       },
       errors: {
@@ -411,7 +411,7 @@ describe("PostDepositContinuationView", () => {
     // With no vault left to continue, the modal lands on the activated success
     // screen (replacing the progress view) rather than parking on a generic
     // "awaiting confirmation" step.
-    expect(getByText("BTC Vault activated")).toBeInTheDocument();
+    expect(getByText("Vault activated")).toBeInTheDocument();
     expect(getByText("Go to Dashboard")).toBeInTheDocument();
     // The deposit progress view is replaced, not layered behind.
     expect(queryByTestId("step")).toBeNull();
@@ -437,7 +437,7 @@ describe("PostDepositContinuationView", () => {
     });
 
     // No candidate vault remains → the single activated success screen shows.
-    expect(getByText("BTC Vault activated")).toBeInTheDocument();
+    expect(getByText("Vault activated")).toBeInTheDocument();
     expect(getByText("Go to Dashboard")).toBeInTheDocument();
     expect(queryByTestId("step")).toBeNull();
   });

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -425,8 +425,8 @@ export const COPY = {
       continueButton: "Continue",
     },
     vaultActivatedSuccess: {
-      heading: "BTC Vault activated",
-      body: "Your BTC Vault is now active and ready for borrowing.",
+      heading: "Vault activated",
+      body: "Your vault is now active and ready for borrowing.",
       goToDashboard: "Go to Dashboard",
     },
     recoveryArtifacts: {


### PR DESCRIPTION

<img width="564" height="398" alt="Screenshot 2026-07-06 at 17 59 58" src="https://github.com/user-attachments/assets/3ba375f0-d42d-474c-95cf-88197b77fe03" />
<img width="572" height="409" alt="Screenshot 2026-07-06 at 17 59 51" src="https://github.com/user-attachments/assets/429f8016-c268-4ae1-8297-6873124bca60" />


- Copy: "Vault activated" / "Your vault is now active and ready for borrowing." (drops the "BTC" qualifier per the updated design).
- Card uses the bg-primary-contrast surface, a 16px radius and a subtle stroke so the border reads in dark mode; 34px (h4) heading with the design's spacing.
- Replaces the checkmark with the design's circle+tick SVG.
- Heading and icon use text-black dark:text-white to match the design in both themes.