### PR TITLE
test(vault): automate a real signet peg-in end-to-end in the real-wallet E2E CLI

### DIFF
--- a/packages/babylon-wallet-connector/tests/e2e/fixtures/wallets/metamask.ts
+++ b/packages/babylon-wallet-connector/tests/e2e/fixtures/wallets/metamask.ts
@@ -100,6 +100,52 @@ async function readAddress(page: Page): Promise<string | null> {
   return truncated ? truncated[0] : null;
 }
 
+/** The auto-lock value MetaMask ships with (its Security settings show it as a word, not minutes). */
+const MM_EXPECTED_AUTO_LOCK = "Never";
+
+/**
+ * Verify MetaMask's auto-lock is "Never" so the wallet doesn't re-lock during a run (steps 4 and 14 of
+ * a peg-in are MetaMask transactions; a locked wallet stalls them). Path: account options
+ * (account-options-menu-button) → Settings (global-menu-settings) → "Security and password" → the
+ * "Auto lock" row. Fails loudly if it isn't "Never" (or the row can't be found) — that's the signal to
+ * capture MetaMask's auto-lock SETTER and switch this from a verify to a set. The per-wallet spec
+ * (test:e2e:metamask) exercises this.
+ */
+async function verifyAutoLockNever(page: Page): Promise<void> {
+  await page
+    .getByTestId("account-options-menu-button")
+    .first()
+    .click()
+    .catch(() => {});
+  await page.waitForTimeout(SETTLE.SHORT);
+  const settings = page.getByTestId("global-menu-settings").first();
+  if ((await settings.count()) === 0)
+    throw new Error(
+      "MetaMask auto-lock: Settings menu item (global-menu-settings) not found",
+    );
+  await settings.click().catch(() => {});
+  await page.waitForTimeout(SETTLE.MODAL);
+  const section = page.getByText("Security and password", { exact: true }).first();
+  if ((await section.count()) === 0)
+    throw new Error(
+      'MetaMask auto-lock: "Security and password" section not found',
+    );
+  await section.click().catch(() => {});
+  await page.waitForTimeout(SETTLE.MODAL);
+
+  const label = page.getByText("Auto lock", { exact: true }).first();
+  if ((await label.count()) === 0)
+    throw new Error('MetaMask auto-lock: "Auto lock" row not found');
+  // The row div holds the label <p> and the current-value <p> side by side; read the whole row.
+  const rowText = (await label.locator("xpath=..").innerText().catch(() => ""))
+    .replace(/\s+/g, " ")
+    .trim();
+  if (!new RegExp(MM_EXPECTED_AUTO_LOCK, "i").test(rowText))
+    throw new Error(
+      `MetaMask auto-lock: expected "${MM_EXPECTED_AUTO_LOCK}" but the Auto lock row reads "${rowText}"`,
+    );
+}
+
 /**
  * Import `mnemonic` into MetaMask, close its side panel, and return the account's Ethereum address.
  * The extension must already be loaded into `context` (see `launchWalletContext`).
@@ -203,6 +249,10 @@ export async function setupMetaMaskWallet(context: BrowserContext, mnemonic: str
   await closeSidePanel(walletPage, SIDE_PANEL_RECHECK_MS); // in case a panel re-opened
 
   const address = await readAddress(walletPage);
+
+  // Confirm auto-lock won't re-lock the wallet mid-run (expected to already be "Never").
+  await verifyAutoLockNever(walletPage);
+
   await walletPage.close().catch(() => {}); // done — the wallet persists in the profile
   if (!address) throw new Error("MetaMask: could not read an address after import");
   return address;

--- a/packages/babylon-wallet-connector/tests/e2e/fixtures/wallets/okx.ts
+++ b/packages/babylon-wallet-connector/tests/e2e/fixtures/wallets/okx.ts
@@ -140,6 +140,32 @@ async function readAddress(tab: Page): Promise<string | null> {
   return truncated;
 }
 
+/** OKX's "Never lock" auto-lock option carries this stable numeric data-value (label is localized). */
+const OKX_NEVER_LOCK_VALUE = "9999999999";
+
+/**
+ * Set OKX's wallet auto-lock to "Never lock" so it doesn't re-lock mid-run (a real peg-in takes
+ * ~30 min–2 hr and would otherwise stall at "Bitcoin wallet locked"). OKX honors direct hash-route
+ * navigation (used above for onboarding), so go straight to the auto-lock page and select the option by
+ * its language-agnostic data-value. Fails loudly if the option is missing or doesn't become active — a
+ * silent no-op reintroduces the exact lock stall this prevents; the per-wallet spec (test:e2e:okx)
+ * surfaces any OKX settings-UI drift.
+ */
+async function setNeverLock(tab: Page, origin: string): Promise<void> {
+  await tab.goto(`${origin}/home.html#/wallet-lock?pageType=AutoLock`).catch(() => {});
+  await sleep(SETTLE.MEDIUM);
+  await dismissPromoDialog(tab); // the reload can re-trigger the promo modal over the settings page
+
+  const never = tab.locator(`[data-value="${OKX_NEVER_LOCK_VALUE}"][role="radio"]`).first();
+  await never.waitFor({ state: "visible", timeout: WAIT_FOR.ELEMENT_SLOW_MS }).catch(() => {});
+  if ((await never.count()) === 0)
+    throw new Error('OKX auto-lock: "Never lock" option (data-value=9999999999) not found');
+  await never.click({ force: true, timeout: WAIT_FOR.ACTION_MS }).catch(() => {});
+  await sleep(SETTLE.SHORT);
+  if ((await never.getAttribute("aria-checked").catch(() => null)) !== "true")
+    throw new Error('OKX auto-lock: selected "Never lock" but it did not become the active option');
+}
+
 /**
  * Import `mnemonic` into OKX and return the active Bitcoin Signet taproot (`tb1p…`) address.
  * The extension must already be loaded into `context` (see `launchWalletContext`).
@@ -225,6 +251,11 @@ export async function setupOKXWallet(context: BrowserContext, mnemonic: string, 
   await switchToSignet(tab, origin);
 
   const address = await readAddress(tab);
+
+  // Keep the wallet unlocked for the length of a real peg-in run (read the address first — this
+  // navigates away from the home to the auto-lock settings page).
+  await setNeverLock(tab, origin);
+
   await closeForeignTabs(context, tab);
   await tab.close().catch(() => {}); // done — the wallet persists in the profile
 

--- a/packages/babylon-wallet-connector/tests/e2e/fixtures/wallets/onekey.ts
+++ b/packages/babylon-wallet-connector/tests/e2e/fixtures/wallets/onekey.ts
@@ -136,6 +136,43 @@ async function readAddress(tab: Page): Promise<string | null> {
   return null;
 }
 
+/** The app auto-lock value OneKey ships with (its Security screen shows a word, not a duration). */
+const ONEKEY_EXPECTED_AUTO_LOCK = "Never";
+
+/**
+ * Verify OneKey's app auto-lock is "Never" so the wallet doesn't re-lock during a run (a real peg-in
+ * takes ~30 min–2 hr and would otherwise stall at "Bitcoin wallet locked"). Path: sidebar menu
+ * (bottom-menu-container) → "Security" → the "Auto-lock" list row shows its current value. Fails loudly
+ * if it isn't "Never" (or the row can't be found) — the signal to capture OneKey's auto-lock SETTER and
+ * switch this from a verify to a set. The per-wallet spec (test:e2e:onekey) exercises this.
+ */
+async function verifyAutoLockNever(tab: Page): Promise<void> {
+  const menu = tab.locator('[data-testid="bottom-menu-container"]').first();
+  if (!(await menu.isVisible().catch(() => false)))
+    throw new Error("OneKey auto-lock: sidebar menu (bottom-menu-container) not found");
+  await menu.click({ force: true }).catch(() => {});
+  await sleep(SETTLE.MODAL);
+  await clickByText(tab, "Security");
+  await sleep(SETTLE.MEDIUM);
+
+  // The "Auto-lock" list item renders its label + current value side by side; read the whole row.
+  const row = tab
+    .locator('[data-sentry-component="TabSettingsListItem"]')
+    .filter({ hasText: "Auto-lock" })
+    .first();
+  if ((await row.count()) === 0)
+    throw new Error('OneKey auto-lock: "Auto-lock" row not found on the Security screen');
+  const rowText = (await row.innerText().catch(() => "")).replace(/\s+/g, " ").trim();
+  if (!new RegExp(ONEKEY_EXPECTED_AUTO_LOCK, "i").test(rowText))
+    throw new Error(
+      `OneKey auto-lock: expected "${ONEKEY_EXPECTED_AUTO_LOCK}" but the Auto-lock row reads "${rowText}"`,
+    );
+
+  // Return to a clean state (close the Security screen) for the next setup step.
+  await tab.locator('[data-testid="nav-header-close"]').first().click({ force: true }).catch(() => {});
+  await sleep(SETTLE.SHORT);
+}
+
 /**
  * Import `mnemonic` into OneKey and return the active Bitcoin Signet taproot (`tb1p…`) address.
  * The extension must already be loaded into `context` (see `launchWalletContext`).
@@ -194,6 +231,8 @@ export async function setupOneKeyWallet(context: BrowserContext, mnemonic: strin
   // safe: the spec asserts the returned address equals deriveSignetTaproot(mnemonic), so if OneKey ever
   // surfaced a fresh/first-unused address while multi-address is on, that assertion would fail loudly.
   const address = await readAddress(tab);
+  // Confirm OneKey's app auto-lock is "Never" so it doesn't re-lock mid-run (expected default).
+  await verifyAutoLockNever(tab);
   await disableBtcMultipleAddresses(tab);
   await closeForeignTabs(context, tab);
   await tab.close().catch(() => {}); // done — the wallet persists in the profile

--- a/packages/babylon-wallet-connector/tests/e2e/fixtures/wallets/unisat.ts
+++ b/packages/babylon-wallet-connector/tests/e2e/fixtures/wallets/unisat.ts
@@ -76,6 +76,61 @@ async function readReceiveAddress(page: Page): Promise<string | null> {
   return trunc; // fall back to the truncated on-screen value (spec compares prefix/suffix)
 }
 
+/** UniSat's longest "Automatic Lock Time" option (its dropdown tops out here). */
+const UNISAT_MAX_AUTO_LOCK = "4Hours";
+
+/** Coordinate-click a UniSat control by testid (its buttons are pointer-events:none div/span). */
+async function clickTestId(page: Page, testid: string): Promise<boolean> {
+  const box = await page
+    .locator(`[data-testid="${testid}"]`)
+    .first()
+    .boundingBox()
+    .catch(() => null);
+  if (!box) return false;
+  await page.mouse
+    .click(box.x + box.width / 2, box.y + box.height / 2)
+    .catch(() => {});
+  return true;
+}
+
+/**
+ * Raise UniSat's auto-lock timeout to its maximum (4 Hours). The default is **3 minutes**, which
+ * re-locks the wallet mid-run — a real peg-in takes ~30 min–2 hr and would otherwise stall at
+ * "Bitcoin wallet locked". Path: bottom tab Settings → Advanced (settings_advanced) → "Automatic Lock
+ * Time" → "4Hours". Fails loudly: a silent no-op reintroduces the exact lock stall this prevents, so
+ * the per-wallet spec (test:e2e:unisat) surfaces any UniSat settings-UI drift immediately.
+ */
+async function extendAutoLock(page: Page): Promise<void> {
+  // Land on the wallet home deterministically (readReceiveAddress leaves us on the Receive screen).
+  await page.goto(page.url().replace(/#.*$/, "") + "#/main").catch(() => {});
+  await page.waitForTimeout(SETTLE.MODAL);
+
+  if (!(await clickTestId(page, "tab-settings")))
+    throw new Error("UniSat auto-lock: Settings tab (tab-settings) not found");
+  await page.waitForTimeout(SETTLE.SHORT);
+  if (!(await clickTestId(page, "settings_advanced")))
+    throw new Error(
+      "UniSat auto-lock: Advanced settings (settings_advanced) not found",
+    );
+  await page.waitForTimeout(SETTLE.SHORT);
+  await tap(page, /Automatic Lock Time/i); // open the options list
+  await page.waitForTimeout(SETTLE.SHORT);
+  await tap(page, new RegExp(`^${UNISAT_MAX_AUTO_LOCK}$`)); // pick the max option
+  await page.waitForTimeout(SETTLE.MODAL);
+
+  // Verify it took: the options list closed (no "30Seconds" option visible) AND the row shows 4Hours.
+  // Checking the list closed avoids a false pass from the still-open list (which also contains "4Hours").
+  const body = (await page
+    .evaluate("document.body.innerText")
+    .catch(() => "")) as string;
+  const listClosed = !/30\s*Seconds/i.test(body);
+  const showsMax = new RegExp(UNISAT_MAX_AUTO_LOCK).test(body);
+  if (!listClosed || !showsMax)
+    throw new Error(
+      `UniSat auto-lock: expected "${UNISAT_MAX_AUTO_LOCK}" to be selected, but the setting did not update`,
+    );
+}
+
 /**
  * Import `mnemonic` into UniSat and return the active Bitcoin Signet taproot (`tb1p…`) address.
  * The extension must already be loaded into `context` (see `launchWalletContext`).
@@ -138,6 +193,9 @@ export async function setupUnisatWallet(context: BrowserContext, mnemonic: strin
   await page.waitForTimeout(SETTLE.MEDIUM);
   await switchToSignet(page);
   const address = await readReceiveAddress(page);
+
+  // Keep the wallet unlocked for the length of a real peg-in run (default auto-lock is 3 minutes).
+  await extendAutoLock(page);
 
   await page.close().catch(() => {}); // done — the wallet persists in the profile
   if (!address) throw new Error("UniSat: could not read a signet taproot address after import");

--- a/services/vault/e2e/real/actions/approver.ts
+++ b/services/vault/e2e/real/actions/approver.ts
@@ -1,0 +1,203 @@
+/**
+ * Context-level auto-approver for wallet extension pop-ups.
+ *
+ * Every wallet approval — connect, BTC PSBT signing, BTC broadcast, and MetaMask ETH transaction
+ * confirmations — opens as a separate `chrome-extension://` page in the same browser context. A single
+ * `context.on("page")` handler centers each pop-up (so a human can watch) and clicks its primary
+ * approve/confirm control across several rounds. It is deliberately generous: connect fires one pop-up,
+ * but a peg-in fires many — BTC signing pop-ups at DERIVE_VAULT_SECRET(1), SIGN_PEGIN_BTC(2),
+ * SIGN_POP(3), BROADCAST_PRE_PEGIN(5), SIGN_AUTH_ANCHOR(9), SIGN_PAYOUTS(10), SIGN_DEPOSITOR_GRAPH(11),
+ * RETRIEVE_SECRET(13), and MetaMask tx confirmations at SUBMIT_PEGIN(4) + ACTIVATE_VAULT(14) — so the
+ * same handler must cover every wallet's control shapes:
+ *   - MetaMask: real <button> matched by role name (Confirm/Approve/Next/Sign), plus stable testids
+ *     on its tx-confirm + gas screens (`confirm-footer-button`, `page-container-footer-next`).
+ *   - UniSat: styled <div preset="primary">, plus two peg-in-only shapes: the "use at your own risk"
+ *     gate on SIGN_PEGIN_BTC (a text input that must read CONFIRM before the <div preset="danger">
+ *     Confirm enables — see fillUnisatRiskGate), and the batch <div preset="primaryV2"> "Sign all N
+ *     transactions at once" on the payout/graph steps.
+ *   - OKX: OKD-styled <button data-testid="okd-button">.
+ *   - OneKey: real <button>, gated on an insecure-origin consent checkbox (see tickConsent).
+ *
+ * The handler guards everything: a pop-up that closes mid-approve (the expected outcome of approving)
+ * must never reject and crash the run.
+ */
+import type { BrowserContext, Page } from "@playwright/test";
+
+import {
+  APPROVE_CLICK_TIMEOUT_MS,
+  APPROVE_ROUND_MS,
+  APPROVE_ROUNDS,
+} from "../timing";
+import { centerWindow } from "../windowUtils";
+
+/** Accessible-name pattern for the approve/confirm/sign control across wallets. */
+const APPROVE_NAME_RX =
+  /^(connect|approve|next|confirm|sign|broadcast|got it)$/i;
+
+/** MetaMask's tx-confirm and gas/next screens expose these stable testids on the primary button. */
+const METAMASK_PRIMARY_TESTIDS = [
+  '[data-testid="confirm-footer-button"]',
+  '[data-testid="page-container-footer-next"]',
+].join(", ");
+
+/**
+ * UniSat's styled (non-<button>) approve controls, in click priority. `primaryV2` is the batch
+ * "Sign all N transactions at once" button (payout/graph steps) — preferred over the plain `primary`
+ * "(x/y) Signed" so batch signing actually completes; `okd-button` is OKX's primary control.
+ */
+const STYLED_APPROVE_SELECTORS = [
+  '[preset="primaryV2"]',
+  '[preset="primary"]',
+  'button[data-testid="okd-button"]',
+];
+
+/** UniSat's "use at your own risk" gate (SIGN_PEGIN_BTC): a danger Confirm behind a text input. */
+const UNISAT_RISK_DANGER = '[preset="danger"]';
+const UNISAT_RISK_INPUT = 'input[preset="text"]';
+/** The exact word UniSat requires typed into the risk input before its danger Confirm enables. */
+const UNISAT_RISK_CONFIRM_WORD = "CONFIRM";
+
+const readLabel = async (
+  loc: ReturnType<Page["locator"]>,
+  fallback: string,
+): Promise<string> =>
+  (await loc.textContent().catch(() => ""))?.trim() || fallback;
+
+/**
+ * Satisfy UniSat's "use at your own risk" gate on the peg-in BTC signing step: its danger Confirm
+ * stays disabled until the literal word CONFIRM is typed into the risk input. No-op on every other
+ * screen (double-gated on the danger control AND the risk input being present), and idempotent — it
+ * only types when the field isn't already CONFIRM, so re-entering it across approve rounds is safe.
+ */
+async function fillUnisatRiskGate(popup: Page): Promise<void> {
+  const danger = popup.locator(UNISAT_RISK_DANGER).first();
+  if (!(await danger.isVisible().catch(() => false))) return;
+  const input = popup.locator(UNISAT_RISK_INPUT).first();
+  if (!(await input.isVisible().catch(() => false))) return;
+  const current = (await input.inputValue().catch(() => "")) ?? "";
+  if (current.trim().toUpperCase() === UNISAT_RISK_CONFIRM_WORD) return;
+  await input.fill(UNISAT_RISK_CONFIRM_WORD).catch(() => {});
+}
+
+/**
+ * Click UniSat's / OKX's styled (non-<button>) approve control. Tries the risk-gate danger Confirm
+ * first — but only when it reads as a confirm/sign, never a destructive "reject"-style danger — then
+ * the batch and plain primary controls in {@link STYLED_APPROVE_SELECTORS}. Returns the clicked
+ * control's text, or null if none matched.
+ */
+async function clickStyledApprove(popup: Page): Promise<string | null> {
+  const danger = popup.locator(UNISAT_RISK_DANGER).first();
+  if (await danger.isVisible().catch(() => false)) {
+    const text = (await danger.textContent().catch(() => ""))?.trim() ?? "";
+    if (APPROVE_NAME_RX.test(text)) {
+      await danger.click({ force: true }).catch(() => {});
+      return text || "(danger)";
+    }
+  }
+  for (const selector of STYLED_APPROVE_SELECTORS) {
+    const control = popup.locator(selector).last();
+    if (!(await control.isVisible().catch(() => false))) continue;
+    const name = await readLabel(control, "(primary)");
+    await control.click({ force: true }).catch(() => {});
+    return name;
+  }
+  return null;
+}
+
+/**
+ * Try every known "approve/confirm" control shape inside an extension pop-up. Returns the accessible
+ * name/text of the control it clicked (so the caller can log WHAT it approved — an unexpected extra
+ * prompt should be visible in the log, not silently confirmed), or null if nothing matched.
+ */
+export async function clickApprove(popup: Page): Promise<string | null> {
+  const byRole = popup.getByRole("button", { name: APPROVE_NAME_RX }).first();
+  if (await byRole.isVisible().catch(() => false)) {
+    const name = await readLabel(byRole, "(button)");
+    // Bounded timeout: if the button is still disabled (e.g. an unticked consent checkbox), fail fast
+    // and let the next round retry after tickConsent runs, rather than blocking on the 30s default.
+    await byRole.click({ timeout: APPROVE_CLICK_TIMEOUT_MS }).catch(() => {});
+    return name;
+  }
+  const mmPrimary = popup.locator(METAMASK_PRIMARY_TESTIDS).first();
+  if (await mmPrimary.isVisible().catch(() => false)) {
+    const name = await readLabel(mmPrimary, "(metamask-primary)");
+    await mmPrimary
+      .click({ timeout: APPROVE_CLICK_TIMEOUT_MS })
+      .catch(() => {});
+    return name;
+  }
+  // UniSat / OKX styled controls. Satisfy the "use at your own risk" gate first so the danger Confirm
+  // it guards can be clicked in this same round (or the next, once UniSat enables it).
+  await fillUnisatRiskGate(popup);
+  const styled = await clickStyledApprove(popup);
+  if (styled) return styled;
+  const byText = popup.getByText(APPROVE_NAME_RX, { exact: true }).last();
+  if (await byText.isVisible().catch(() => false)) {
+    const name = await readLabel(byText, "(text)");
+    await byText.click({ force: true }).catch(() => {});
+    return name;
+  }
+  return null;
+}
+
+/**
+ * Tick the consent control that gates the approve button, if one is present. OneKey on an insecure
+ * `http://localhost` origin shows "Proceed at my own risk" and keeps Approve `aria-disabled` until it's
+ * ticked. That control is a custom element (a `div` with a stable testid, NOT a real checkbox — hence
+ * no `role="checkbox"`). We click it only while Approve is still disabled: clicking toggles it, so the
+ * `aria-disabled` gate keeps this idempotent across rounds, and it is a no-op on secure origins / other
+ * wallets that have no such gate.
+ */
+export async function tickConsent(popup: Page): Promise<void> {
+  const approve = popup.getByRole("button", { name: /^approve$/i }).first();
+  if (!(await approve.isVisible().catch(() => false))) return;
+  const gated =
+    (await approve.getAttribute("aria-disabled").catch(() => null)) === "true";
+  if (!gated) return;
+  const consent = popup
+    .locator('[data-testid="dapp-connection-continue-operate-checkbox"]')
+    .first();
+  if (await consent.isVisible().catch(() => false))
+    await consent
+      .click({ force: true, timeout: APPROVE_CLICK_TIMEOUT_MS })
+      .catch(() => {});
+}
+
+/**
+ * Center + auto-approve any extension approval pop-up that opens while installed. Returns the handler
+ * so the caller can `context.off("page", handler)` when the approval phase ends (e.g. observe mode
+ * uninstalls it after connect so the human approves the peg-in manually).
+ */
+export function installPopupApprover(
+  context: BrowserContext,
+  log: (m: string) => void,
+): (p: Page) => void {
+  const handler = (popup: Page) => {
+    // Detached listener: guard EVERYTHING — a popup that closes mid-approve must never reject and crash
+    // the process (the whole point of approving is that the popup then vanishes).
+    void (async () => {
+      try {
+        // Wait for load FIRST, then filter: extension approval windows are opened by the service
+        // worker and their URL is `about:blank` until the navigation commits — checking the URL at
+        // 'page'-event time would skip the popup permanently.
+        await popup.waitForLoadState("domcontentloaded").catch(() => {});
+        if (!popup.url().startsWith("chrome-extension://")) return;
+        await centerWindow(popup);
+        const file = popup.url().split("/").pop();
+        for (let round = 0; round < APPROVE_ROUNDS; round++) {
+          if (popup.isClosed()) break;
+          await popup.waitForTimeout(APPROVE_ROUND_MS).catch(() => {});
+          if (popup.isClosed()) break;
+          await tickConsent(popup).catch(() => {});
+          const clicked = await clickApprove(popup).catch(() => null);
+          if (!clicked) break;
+          log(`Approved "${clicked}" in wallet popup ${file}`);
+        }
+      } catch {
+        // popup vanished (approved) or navigated — nothing to do.
+      }
+    })();
+  };
+  context.on("page", handler);
+  return handler;
+}

--- a/services/vault/e2e/real/actions/approver.ts
+++ b/services/vault/e2e/real/actions/approver.ts
@@ -51,6 +51,14 @@ const STYLED_APPROVE_SELECTORS = [
   'button[data-testid="okd-button"]',
 ];
 
+/**
+ * Negative gate for styled controls: skip a `primary`/`primaryV2`/OKD control whose text is clearly a
+ * cancel/reject. A positive approve-word gate can't be used here — it would block the legitimate
+ * intermediate `"(0/5) Signed"` and batch `"Sign all N transactions at once"` controls (neither is an
+ * exact approve word) — so we only refuse the obviously-destructive labels and click the rest.
+ */
+const REJECT_NAME_RX = /^(cancel|reject|deny|back|close|no)$/i;
+
 /** UniSat's "use at your own risk" gate (SIGN_PEGIN_BTC): a danger Confirm behind a text input. */
 const UNISAT_RISK_DANGER = '[preset="danger"]';
 const UNISAT_RISK_INPUT = 'input[preset="text"]';
@@ -98,6 +106,8 @@ async function clickStyledApprove(popup: Page): Promise<string | null> {
     const control = popup.locator(selector).last();
     if (!(await control.isVisible().catch(() => false))) continue;
     const name = await readLabel(control, "(primary)");
+    // Never dismiss via a cancel/reject control styled as primary; skip it and try the next shape.
+    if (REJECT_NAME_RX.test(name)) continue;
     await control.click({ force: true }).catch(() => {});
     return name;
   }
@@ -161,6 +171,30 @@ export async function tickConsent(popup: Page): Promise<void> {
     await consent
       .click({ force: true, timeout: APPROVE_CLICK_TIMEOUT_MS })
       .catch(() => {});
+}
+
+/**
+ * One active-approval pass over the currently-open extension windows: for each `chrome-extension://`
+ * page except `mainPage`, tick any consent gate and click its approve control. Unlike
+ * `installPopupApprover` (which reacts only to NEW-window `page` events), this catches approvals
+ * rendered into a REUSED window — OKX reuses a single approval window, so a later signing prompt fires
+ * no `page` event and would otherwise never be clicked. Best-effort; never throws.
+ */
+export async function sweepApprovals(
+  context: BrowserContext,
+  mainPage: Page,
+  log: (m: string) => void,
+): Promise<void> {
+  for (const popup of context.pages()) {
+    if (popup === mainPage || !popup.url().startsWith("chrome-extension://"))
+      continue;
+    await tickConsent(popup).catch(() => {});
+    const clicked = await clickApprove(popup).catch(() => null);
+    if (clicked)
+      log(
+        `  approved "${clicked}" in ${popup.url().split("/").pop() ?? "popup"}`,
+      );
+  }
 }
 
 /**

--- a/services/vault/e2e/real/actions/connect.ts
+++ b/services/vault/e2e/real/actions/connect.ts
@@ -1,168 +1,23 @@
 /**
  * The "connect" action: drive the vault app's real wallet-connection flow and verify it.
  *
- * Flow (selectors confirmed against services/vault + core-ui source and website devnet):
- *   Connect (connect-wallet-button) → Select Bitcoin Wallet (select-bitcoin-wallet-button) →
- *   wallet-option-<id> → approve in the BTC extension popup → Select Ethereum Wallet
- *   (select-ethereum-wallet-button) → MetaMask (Reown AppKit) → approve MetaMask popup →
- *   Connect (chains-connect-button) → the deposit CTA (data-testid="deposit-button") appears.
- * Success = open the wallet menu (the avatar group) and confirm the BTC + ETH addresses each card
- * displays (a truncated "first6...last6", read straight from the DOM) match the derived addresses.
- *
- * Approval popups are extension windows — separate pages in the same context (MetaMask/UniSat/OKX use
- * `notification.html`; OneKey uses a `ConnectionModal` window). A context-level handler centers each
- * popup (for visibility) and clicks its primary approve control, which differs per wallet: MetaMask
- * and OKX use a real <button> (matched by the connect/approve/confirm role name); UniSat uses a styled
- * <div preset="primary">; OneKey uses a real <button>. A `button[data-testid="okd-button"]` fallback
- * covers OKX's OKD-styled buttons. Any `chrome-extension://` page is handled, so filenames don't matter.
+ * The connect sequence itself lives in the shared `connectWallets` helper (reused by pegin/observe);
+ * this action installs the pop-up approver, runs that sequence, and then verifies success: it opens the
+ * wallet menu (the avatar group) and confirms the BTC + ETH addresses each card displays (a truncated
+ * "first6...last6", read straight from the DOM) match the addresses derived locally from the mnemonic.
  */
-import type { BrowserContext, Page } from "@playwright/test";
+import type { Page } from "@playwright/test";
 
-import type { BtcWalletId } from "../config";
 import { addrMatches } from "../connector";
 import {
-  APPROVAL_WAIT_MS,
-  APPROVE_CLICK_TIMEOUT_MS,
-  APPROVE_ROUNDS,
-  APPROVE_ROUND_MS,
   HEADER_SETTLE_MS,
   MENU_OPEN_TIMEOUT_MS,
   STEP_TIMEOUT_MS,
 } from "../timing";
-import { centerWindow } from "../windowUtils";
 
+import { installPopupApprover } from "./approver";
 import { type Action, type ActionContext, waitSeam } from "./types";
-
-/**
- * Try every known "approve/connect" control shape inside an extension popup. Returns the accessible
- * name/text of the control it clicked (so the caller can log WHAT it approved — an unexpected extra
- * prompt should be visible in the log, not silently confirmed), or null if nothing matched.
- */
-async function clickApprove(popup: Page): Promise<string | null> {
-  const rx = /^(connect|approve|next|confirm|sign|got it)$/i;
-  const label = async (loc: ReturnType<Page["locator"]>, fallback: string) =>
-    (await loc.textContent().catch(() => ""))?.trim() || fallback;
-
-  const byRole = popup.getByRole("button", { name: rx }).first();
-  if (await byRole.isVisible().catch(() => false)) {
-    const name = await label(byRole, "(button)");
-    // Bounded timeout: if the button is still disabled (e.g. an unticked consent checkbox), fail fast
-    // and let the next round retry after tickConsent runs, rather than blocking on the 30s default.
-    await byRole.click({ timeout: APPROVE_CLICK_TIMEOUT_MS }).catch(() => {});
-    return name;
-  }
-  const primary = popup
-    .locator('[preset="primary"], button[data-testid="okd-button"]')
-    .last();
-  if (await primary.isVisible().catch(() => false)) {
-    const name = await label(primary, "(primary)");
-    await primary.click({ force: true }).catch(() => {});
-    return name;
-  }
-  const byText = popup.getByText(rx, { exact: true }).last();
-  if (await byText.isVisible().catch(() => false)) {
-    const name = await label(byText, "(text)");
-    await byText.click({ force: true }).catch(() => {});
-    return name;
-  }
-  return null;
-}
-
-/**
- * Tick the consent control that gates the approve button, if one is present. OneKey on an insecure
- * `http://localhost` origin shows "Proceed at my own risk" and keeps Approve `aria-disabled` until it's
- * ticked. That control is a custom element (a `div` with a stable testid, NOT a real checkbox — hence
- * no `role="checkbox"`). We click it only while Approve is still disabled: clicking toggles it, so the
- * `aria-disabled` gate keeps this idempotent across rounds, and it is a no-op on secure origins / other
- * wallets that have no such gate.
- */
-async function tickConsent(popup: Page): Promise<void> {
-  const approve = popup.getByRole("button", { name: /^approve$/i }).first();
-  if (!(await approve.isVisible().catch(() => false))) return;
-  const gated =
-    (await approve.getAttribute("aria-disabled").catch(() => null)) === "true";
-  if (!gated) return;
-  const consent = popup
-    .locator('[data-testid="dapp-connection-continue-operate-checkbox"]')
-    .first();
-  if (await consent.isVisible().catch(() => false))
-    await consent
-      .click({ force: true, timeout: APPROVE_CLICK_TIMEOUT_MS })
-      .catch(() => {});
-}
-
-/** Center + auto-approve any extension approval popup that opens during connect. */
-function installPopupApprover(
-  context: BrowserContext,
-  log: (m: string) => void,
-): (p: Page) => void {
-  const handler = (popup: Page) => {
-    // Detached listener: guard EVERYTHING — a popup that closes mid-approve must never reject and crash
-    // the process (the whole point of approving is that the popup then vanishes).
-    void (async () => {
-      try {
-        // Wait for load FIRST, then filter: extension approval windows are opened by the service
-        // worker and their URL is `about:blank` until the navigation commits — checking the URL at
-        // 'page'-event time would skip the popup permanently.
-        await popup.waitForLoadState("domcontentloaded").catch(() => {});
-        if (!popup.url().startsWith("chrome-extension://")) return;
-        await centerWindow(popup);
-        const file = popup.url().split("/").pop();
-        for (let round = 0; round < APPROVE_ROUNDS; round++) {
-          if (popup.isClosed()) break;
-          await popup.waitForTimeout(APPROVE_ROUND_MS).catch(() => {});
-          if (popup.isClosed()) break;
-          await tickConsent(popup).catch(() => {});
-          const clicked = await clickApprove(popup).catch(() => null);
-          if (!clicked) break;
-          log(`Approved "${clicked}" in wallet popup ${file}`);
-        }
-      } catch {
-        // popup vanished (approved) or navigated — nothing to do.
-      }
-    })();
-  };
-  context.on("page", handler);
-  return handler;
-}
-
-/**
- * Open the connected wallet menu. core-ui's `Menu` clones the trigger (the avatar group) and adds
- * `aria-haspopup="true"` + toggles `aria-expanded`, rendering the address cards in a Popover when open.
- * Click the haspopup trigger and confirm the menu opened (retry with the avatar image as a fallback).
- */
-async function openWalletMenu(
-  page: Page,
-  log: (m: string) => void,
-): Promise<void> {
-  const isOpen = () =>
-    page
-      .getByText("Bitcoin Wallet", { exact: true })
-      .first()
-      .waitFor({ state: "visible", timeout: MENU_OPEN_TIMEOUT_MS })
-      .then(() => true)
-      .catch(() => false);
-
-  // The header has TWO aria-haspopup triggers: the wallet avatar group and the settings gear. Target
-  // the avatar group specifically (it contains the wallet avatar images), not the gear.
-  const trigger = page
-    .locator('[aria-haspopup="true"]')
-    .filter({ has: page.locator("img.bbn-avatar-img") })
-    .first();
-  await trigger
-    .waitFor({ state: "visible", timeout: STEP_TIMEOUT_MS })
-    .catch(() => {});
-  await page.waitForTimeout(HEADER_SETTLE_MS); // let the header settle so the first click registers
-  await trigger.click({ force: true }).catch(() => {});
-  if (await isOpen()) return;
-
-  log("wallet menu not open — retrying the avatar trigger");
-  await page.keyboard.press("Escape").catch(() => {});
-  await trigger.click({ force: true }).catch(() => {});
-  if (await isOpen()) return;
-
-  throw new Error("Could not open the connected wallet menu");
-}
+import { connectWallets, openWalletMenu } from "./walletConnect";
 
 /**
  * Verify one chain's address in the open wallet menu. The card renders the address via core-ui's
@@ -197,54 +52,16 @@ async function verifyMenuAddress(
     );
 }
 
-const ETH_APPKIT_NAME: Record<string, RegExp> = { metamask: /metamask/i };
-
 export const connectAction: Action = {
   id: "connect",
   async run(ctx: ActionContext): Promise<void> {
     const { page, context, log } = ctx;
     const handler = installPopupApprover(context, log);
     try {
-      log("Clicking Connect");
-      await page
-        .locator('[data-testid="connect-wallet-button"]')
-        .first()
-        .click({ timeout: STEP_TIMEOUT_MS });
-
-      log(`Selecting BTC wallet: ${ctx.btc.id}`);
-      await page
-        .locator('[data-testid="select-bitcoin-wallet-button"]')
-        .click({ timeout: STEP_TIMEOUT_MS });
-      await page
-        .locator(`[data-testid="wallet-option-${ctx.btc.id as BtcWalletId}"]`)
-        .click({ timeout: STEP_TIMEOUT_MS });
-      // Wait for the BTC approval popup to be handled and the app to register the address.
-      await page.waitForTimeout(APPROVAL_WAIT_MS);
-
-      log(`Selecting ETH wallet: ${ctx.eth.id}`);
-      await page
-        .locator('[data-testid="select-ethereum-wallet-button"]')
-        .click({ timeout: STEP_TIMEOUT_MS });
-      await page
-        .getByText(ETH_APPKIT_NAME[ctx.eth.id] ?? /metamask/i, { exact: false })
-        .first()
-        .click({ timeout: STEP_TIMEOUT_MS });
-      await page.waitForTimeout(APPROVAL_WAIT_MS);
-
-      log("Finalizing (Connect)");
-      await page
-        .locator('[data-testid="chains-connect-button"]')
-        .click({ timeout: STEP_TIMEOUT_MS })
-        .catch(() => {});
-
-      log("Waiting for connected state (deposit button)");
-      await page
-        .locator('[data-testid="deposit-button"]')
-        .first()
-        .waitFor({ state: "visible", timeout: STEP_TIMEOUT_MS });
+      await connectWallets(ctx);
 
       log("Opening wallet menu to verify addresses");
-      await openWalletMenu(page, log);
+      await openWalletMenu(page, log, MENU_OPEN_TIMEOUT_MS, HEADER_SETTLE_MS);
       await verifyMenuAddress(page, "Bitcoin", ctx.btc.address, log);
       await verifyMenuAddress(page, "Ethereum", ctx.eth.address, log);
 

--- a/services/vault/e2e/real/actions/index.ts
+++ b/services/vault/e2e/real/actions/index.ts
@@ -1,12 +1,21 @@
 /**
- * Registry of implemented actions. Only `connect` runs today; the others are declared (disabled) in
- * `config.ts` for the CLI's roadmap display and will register here as they land.
+ * Registry of implemented actions: connect, observe, wallet-config, pegin, and sign-conformance. The
+ * remaining actions (borrow/repay/withdraw) are declared disabled in `config.ts` for the CLI's roadmap
+ * display and register here as they land.
  */
 import type { ActionId } from "../config";
 
 import { connectAction } from "./connect";
+import { observeAction } from "./observe";
+import { peginAction } from "./pegin";
+import { signConformanceAction } from "./signConformance";
 import type { Action } from "./types";
+import { walletConfigAction } from "./walletConfig";
 
 export const ACTIONS_BY_ID: Partial<Record<ActionId, Action>> = {
   connect: connectAction,
+  observe: observeAction,
+  "wallet-config": walletConfigAction,
+  pegin: peginAction,
+  "sign-conformance": signConformanceAction,
 };

--- a/services/vault/e2e/real/actions/observe.ts
+++ b/services/vault/e2e/real/actions/observe.ts
@@ -1,0 +1,85 @@
+/**
+ * The "observe" action: capture one human-driven, fully-recorded peg-in as ground truth.
+ *
+ * It auto-connects the wallets (approver on), then UNINSTALLS the approver and hands the browser to the
+ * human, who drives the deposit + approves every wallet pop-up themselves — so the recording reflects
+ * the true, unautomated flow. The recorder (Playwright trace + HTTP fixtures) runs the whole time. When
+ * the human confirms the peg-in is complete, it stops the recorder and writes the artifacts.
+ *
+ * This is the FIRST run for the peg-in work: the `pegin` action's selectors + step timing are written
+ * against this recording (and can be dev-looped against its replay) rather than discovered blind on a
+ * 30 min–2 hr real run. Inherently interactive — it requires a TTY.
+ */
+import { createInterface } from "node:readline/promises";
+
+import { installPopupApprover } from "./approver";
+import { startRecording } from "./recording";
+import type { Action, ActionContext } from "./types";
+import { connectWallets } from "./walletConnect";
+
+export const observeAction: Action = {
+  id: "observe",
+  async run(ctx: ActionContext): Promise<void> {
+    const { page, context, log, artifactsDir } = ctx;
+    if (!process.stdin.isTTY)
+      throw new Error(
+        "observe is interactive — run it in a terminal (a human drives the peg-in). Do not pass --yes.",
+      );
+
+    // Auto-connect with the approver, then remove it so the human approves the peg-in pop-ups manually.
+    const handler = installPopupApprover(context, log);
+    try {
+      await connectWallets(ctx);
+    } finally {
+      context.off("page", handler);
+    }
+    log(
+      "Connected. Approver uninstalled — you now drive + approve the peg-in manually.",
+    );
+
+    const recorder = await startRecording(
+      context,
+      page,
+      artifactsDir,
+      log,
+      () => "observe",
+    );
+    const rl = createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    });
+    // Flush the trace on BOTH stop paths — Enter (clean) and Ctrl-C (abort). readline's default on
+    // Ctrl-C is to emit 'pause', so without this listener a Ctrl-C would kill the process before
+    // recorder.stop() runs and trace.zip would never flush (http.jsonl is written live, so it always
+    // survives either way). Idempotent so the finally + the handler don't double-stop.
+    let stopped = false;
+    const stop = async () => {
+      if (stopped) return;
+      stopped = true;
+      await recorder.stop();
+    };
+    rl.on("SIGINT", () => {
+      log("Ctrl-C received — flushing the recording before exit…");
+      void stop().finally(() => process.exit(130));
+    });
+    try {
+      log(
+        "RECORDING. Drive the deposit in the browser: select a vault provider, enter an amount, click " +
+          "Deposit, and approve every wallet pop-up — all the way to the activated vault.",
+      );
+      log(
+        "At EACH meaningful screen (provider list, amount entered, each signing step, activated view), " +
+          "type a short label here + Enter to snapshot its DOM. Type 'done' when finished (Ctrl-C also saves).",
+      );
+      for (;;) {
+        const answer = (await rl.question("\nlabel (or 'done'): ")).trim();
+        if (answer.toLowerCase() === "done") break;
+        await recorder.snapshot(answer || "screen");
+      }
+    } finally {
+      rl.close();
+      await stop();
+    }
+    log(`Observe recording saved under ${artifactsDir}`);
+  },
+};

--- a/services/vault/e2e/real/actions/observe.ts
+++ b/services/vault/e2e/real/actions/observe.ts
@@ -37,12 +37,14 @@ export const observeAction: Action = {
       "Connected. Approver uninstalled — you now drive + approve the peg-in manually.",
     );
 
+    // Observe exists to build the per-wallet signing fixtures, so it opts into the signing capture.
     const recorder = await startRecording(
       context,
       page,
       artifactsDir,
       log,
       () => "observe",
+      { captureSigning: true },
     );
     const rl = createInterface({
       input: process.stdin,

--- a/services/vault/e2e/real/actions/pegin.ts
+++ b/services/vault/e2e/real/actions/pegin.ts
@@ -1,0 +1,380 @@
+/**
+ * The "pegin" action: drive a real signet + Sepolia peg-in end-to-end, from the deposit form through
+ * all 15 `DepositFlowStep` steps to an active, borrowable vault on the dashboard.
+ *
+ * The work splits cleanly in two:
+ *   - DAPP actions (this file drives them on `ctx.page`): open the deposit form, enter the amount,
+ *     select a vault provider, submit, click "Sign Transaction" to start signing, then — mid-flow —
+ *     acknowledge + "Activate Vault", "Skip" the artifact download, and finally "Go to Dashboard".
+ *   - WALLET actions (the shared pop-up approver handles them on the chrome-extension pop-ups): the 8
+ *     UniSat BTC signing prompts and the 2 MetaMask ETH transactions. The approver is installed for
+ *     the WHOLE run (unlike observe, which uninstalls it) so every pop-up auto-approves.
+ *
+ * The 15-step machine is walked by AWAITING UI transitions (the `role="progressbar"` and the active
+ * step's `aria-label="Step N active"`), never fixed sleeps, and tolerates the multi-minute on-chain
+ * gates (Pre-PegIn inclusion, WOTS, payout) via a generous overall budget with no short per-step
+ * timeout. The whole run is recorded (trace + HTTP fixtures) so a 30 min–2 hr flow is debuggable
+ * offline instead of re-run blind.
+ *
+ * Selectors + copy strings below were verified against a real observe recording AND the React
+ * components (DepositForm, VaultProviderSelector, DepositProgressView, ActivateConfirmationModal,
+ * InStepArtifactCallout, VaultActivatedView, CollateralSection/CollateralVaultItem). No product/SDK
+ * code is reimplemented — this only drives the UI; the frozen critical paths stay owned by the app.
+ *
+ * NEVER run without an explicit go-ahead: it spends real signet BTC + Sepolia ETH and is not
+ * idempotent (a crash after the Pre-PegIn broadcast leaves an on-chain in-flight deposit).
+ */
+import type { Locator, Page } from "@playwright/test";
+
+import {
+  DASHBOARD_VAULT_TIMEOUT_MS,
+  DEPOSIT_CTA_ENABLE_TIMEOUT_MS,
+  FORM_SETTLE_MS,
+  PEGIN_POLL_INTERVAL_MS,
+  PEGIN_STEP_MACHINE_BUDGET_MS,
+  PROVIDER_LIST_TIMEOUT_MS,
+  STEP_TIMEOUT_MS,
+} from "../timing";
+
+import { installPopupApprover } from "./approver";
+import { startRecording } from "./recording";
+import { type Action, type ActionContext } from "./types";
+import { connectWallets } from "./walletConnect";
+
+/** Default deposit size in BTC when `--amount` isn't supplied (small, well above the protocol min). */
+const DEFAULT_PEGIN_AMOUNT_BTC = "0.01";
+
+// Form-phase matchers use exact copy strings (verified against the deployed build the run drives) with
+// a comment pointing at their `services/vault/src/copy.ts` source. Finish-line matchers below are
+// tolerant regexes instead — the activated-view copy has been observed to drift between source and the
+// deployed build, so those key on stable/actionable elements rather than exact wording.
+const DEPOSIT_BUTTON_TESTID = '[data-testid="deposit-button"]'; // header "Deposit sBTC"
+const AMOUNT_PLACEHOLDER = "0"; // DepositForm amount input
+const SELECT_VP_LABEL = "Select vault provider"; // COPY.deposit.form.selectVaultProvider
+const DEPOSIT_CTA_LABEL = "Deposit"; // enabled DepositForm CTA (fluid button)
+const SIGN_TRANSACTION_LABEL = "Sign Transaction"; // COPY.deposit.progress.buttons.signTransaction
+const ACTIVATE_VAULT_LABEL = "Activate Vault"; // COPY.deposit.activateConfirmation.activateButton
+const RISK_ACK_LABEL =
+  "I understand the risks of continuing without the artifacts."; // riskAcknowledgement
+const SKIP_LABEL = "Skip"; // COPY.deposit.inStepArtifact.skip
+// Finish-line matchers are tolerant regexes, NOT exact strings: the deployed build's copy can drift
+// from local source (e.g. the heading renders "Vault activated" on devnet vs "BTC Vault activated" in
+// copy.ts), and we key on the stable actionable control (the "Go to Dashboard" button) rather than the
+// heading text so a wording tweak can't strand the run at the activated screen.
+const GO_TO_DASHBOARD_RX = /go to dashboard/i; // COPY.deposit.vaultActivatedSuccess.goToDashboard
+const VAULT_OPTIONS_RX = /vault options/i; // CollateralSection ExpandMenuButton aria-label ("[BTC ]Vault options")
+const VAULT_CARD_TESTID = '[data-testid="vault-card"]'; // CollateralVaultItem VaultCardShell (stable testid)
+
+/**
+ * Fill the deposit form (amount → provider → submit). The form has almost no testids, so selectors
+ * are copy/role-driven and were verified against the real DOM. Returns once the deposit progress view
+ * has opened (the fluid CTA click transitions to it).
+ */
+async function fillDepositForm(
+  page: Page,
+  log: (m: string) => void,
+  amountBtc: string,
+  provider: string | undefined,
+): Promise<void> {
+  log(
+    `Opening deposit form (amount ${amountBtc} sBTC, provider ${provider ?? "first available"})`,
+  );
+  await page
+    .locator(DEPOSIT_BUTTON_TESTID)
+    .first()
+    .click({ timeout: STEP_TIMEOUT_MS });
+
+  const amount = page.getByPlaceholder(AMOUNT_PLACEHOLDER).first();
+  await amount.waitFor({ state: "visible", timeout: STEP_TIMEOUT_MS });
+  await amount.fill(amountBtc);
+  await page.waitForTimeout(FORM_SETTLE_MS);
+
+  await selectVaultProvider(page, log, provider);
+
+  const cta = await waitForDepositCta(page, log);
+  log("Deposit CTA enabled — submitting the form");
+  await cta.click();
+}
+
+/**
+ * Expand the provider accordion and select a provider row. Rows are `<button aria-pressed>`; the
+ * unavailable ones carry the `disabled` attr (metadata-rejected VPs), so we only ever pick a
+ * `:not([disabled])` row. Selecting collapses the accordion (the row then detaches), so selection is
+ * NOT re-read from the row's `aria-pressed`; it's confirmed downstream by the CTA becoming "Deposit".
+ */
+async function selectVaultProvider(
+  page: Page,
+  log: (m: string) => void,
+  provider: string | undefined,
+): Promise<void> {
+  await page
+    .getByRole("button", { name: SELECT_VP_LABEL })
+    .first()
+    .click({ timeout: STEP_TIMEOUT_MS });
+
+  const selectableRows = page.locator("button[aria-pressed]:not([disabled])");
+  await selectableRows
+    .first()
+    .waitFor({ state: "visible", timeout: PROVIDER_LIST_TIMEOUT_MS });
+
+  const row = provider
+    ? selectableRows.filter({ hasText: provider }).first()
+    : selectableRows.first();
+  if (!(await row.isVisible().catch(() => false)))
+    throw new Error(
+      provider
+        ? `Vault provider "${provider}" is not present or is unavailable in the picker`
+        : "No selectable vault provider in the picker",
+    );
+
+  const name = (await row.innerText().catch(() => ""))
+    .replace(/\s+/g, " ")
+    .trim();
+  await row.click();
+  log(`Selected vault provider: ${name || provider || "first available"}`);
+}
+
+/**
+ * Wait for the fluid form CTA to become the enabled "Deposit". It relabels as the form validates and
+ * estimates fees ("Enter an amount" → "Select a vault provider" → "Calculating fees…" → "Checking for
+ * inscriptions…" → "Deposit"), and is `disabled` throughout — so we wait for BOTH the exact "Deposit"
+ * label AND enabled, logging each label change (this doubles as the fee-estimation progress log).
+ */
+async function waitForDepositCta(
+  page: Page,
+  log: (m: string) => void,
+): Promise<Locator> {
+  const cta = page.locator("button.bbn-btn-fluid").first();
+  const deadline = Date.now() + DEPOSIT_CTA_ENABLE_TIMEOUT_MS;
+  let lastLabel = "";
+  while (Date.now() < deadline) {
+    const label = (await cta.textContent().catch(() => ""))?.trim() ?? "";
+    if (label && label !== lastLabel) {
+      log(`Deposit CTA: "${label}"`);
+      lastLabel = label;
+    }
+    if (
+      label === DEPOSIT_CTA_LABEL &&
+      (await cta.isEnabled().catch(() => false))
+    )
+      return cta;
+    await page.waitForTimeout(FORM_SETTLE_MS);
+  }
+  throw new Error(
+    `Deposit CTA did not become enabled "${DEPOSIT_CTA_LABEL}" within ${DEPOSIT_CTA_ENABLE_TIMEOUT_MS}ms (last label: "${lastLabel}")`,
+  );
+}
+
+/** Click the single "Sign Transaction" start button that kicks off the whole signing sequence. */
+async function startSigning(
+  page: Page,
+  log: (m: string) => void,
+): Promise<void> {
+  const signButton = page
+    .getByRole("button", { name: SIGN_TRANSACTION_LABEL, exact: true })
+    .first();
+  await signButton.waitFor({ state: "visible", timeout: STEP_TIMEOUT_MS });
+  log(
+    "Deposit progress open — starting the signing sequence (Sign Transaction)",
+  );
+  await signButton.click();
+}
+
+/** True once the terminal activated view is showing — detected by its "Go to Dashboard" button. */
+function activatedViewReached(page: Page): Promise<boolean> {
+  return page
+    .getByRole("button", { name: GO_TO_DASHBOARD_RX })
+    .first()
+    .isVisible()
+    .catch(() => false);
+}
+
+/**
+ * Handle the `ActivateConfirmationModal` if it's showing: acknowledge the risk (we skip the artifact
+ * download) then click "Activate Vault". The checkbox toggles on each click, so acknowledgement is
+ * idempotent — only ticked when currently unchecked. Returns true once Activate Vault was clicked.
+ */
+async function handleActivateConfirmation(
+  page: Page,
+  log: (m: string) => void,
+): Promise<boolean> {
+  const activate = page
+    .getByRole("button", { name: ACTIVATE_VAULT_LABEL, exact: true })
+    .first();
+  if (!(await activate.isVisible().catch(() => false))) return false;
+
+  const checkbox = page.locator('[data-testid="checkbox-input"]').first();
+  if (
+    (await checkbox.count().catch(() => 0)) > 0 &&
+    !(await checkbox.isChecked().catch(() => false))
+  ) {
+    // Toggle via the label (the native input is a visually-hidden switcher); only when unchecked so
+    // repeated polls don't flip it back off.
+    const label = page.getByText(RISK_ACK_LABEL, { exact: true }).first();
+    if (await label.isVisible().catch(() => false)) {
+      await label.click().catch(() => {});
+    } else {
+      await checkbox.check({ force: true }).catch(() => {});
+    }
+  }
+
+  if (!(await activate.isEnabled().catch(() => false))) return false;
+  log("Activate confirmation: risk acknowledged → clicking Activate Vault");
+  await activate.click().catch(() => {});
+  return true;
+}
+
+/** Click "Skip" on the in-step artifact callout (proceed without downloading recovery artifacts). */
+async function handleArtifactSkip(
+  page: Page,
+  log: (m: string) => void,
+): Promise<boolean> {
+  const skip = page
+    .getByRole("button", { name: SKIP_LABEL, exact: true })
+    .first();
+  if (!(await skip.isVisible().catch(() => false))) return false;
+  log("Artifact step: Skip (continue without downloading recovery artifacts)");
+  await skip.click().catch(() => {});
+  return true;
+}
+
+/** Read the active step for the run log: "Step N active (P%)" from the stepper + progress bar. */
+async function readActiveStep(page: Page): Promise<string> {
+  const active = page.locator('[aria-label$="active"]').first();
+  const label = await active.getAttribute("aria-label").catch(() => null);
+  const bar = page.locator('[role="progressbar"]').first();
+  const percent = await bar.getAttribute("aria-valuenow").catch(() => null);
+  if (!label && percent === null) return "";
+  return `${label ?? "Step ?"} (${percent ?? "?"}%)`;
+}
+
+/**
+ * Walk the 15-step signing machine to the activated vault. The pop-up approver auto-approves every
+ * wallet prompt asynchronously; this loop only drives the two dapp-page gates the approver can't reach
+ * (Activate Vault + Skip) and follows the progress UI, logging each transition, until the terminal
+ * heading appears. `onStep` tags the recorder's HTTP fixtures with the current step.
+ */
+async function walkStepMachine(
+  page: Page,
+  log: (m: string) => void,
+  onStep: (step: string) => void,
+): Promise<void> {
+  const deadline = Date.now() + PEGIN_STEP_MACHINE_BUDGET_MS;
+  let lastStep = "";
+  let activated = false;
+  let skipped = false;
+
+  while (Date.now() < deadline) {
+    if (await activatedViewReached(page)) return;
+
+    // Two dapp-page interactions the wallet pop-up approver can't perform.
+    if (!activated) activated = await handleActivateConfirmation(page, log);
+    if (activated && !skipped) skipped = await handleArtifactSkip(page, log);
+
+    const step = await readActiveStep(page);
+    if (step && step !== lastStep) {
+      lastStep = step;
+      onStep(step);
+      log(`Step machine → ${step}`);
+    }
+    await page.waitForTimeout(PEGIN_POLL_INTERVAL_MS);
+  }
+  throw new Error(
+    `Peg-in did not reach the activated view (no "Go to Dashboard" button) within the step-machine budget — see trace.zip + the failure screenshot`,
+  );
+}
+
+/**
+ * Finish line: click "Go to Dashboard", then best-effort confirm the vault landed as collateral. The
+ * activated view is the definitive success signal (we're only here because its "Go to Dashboard"
+ * button appeared); the dashboard card is a secondary check, so a copy/layout drift on the dashboard
+ * is logged as a warning rather than hanging or failing an otherwise-successful peg-in.
+ */
+async function assertActivatedAndOnDashboard(
+  page: Page,
+  log: (m: string) => void,
+  amountBtc: string,
+): Promise<void> {
+  log("✅ Activated view reached — clicking Go to Dashboard");
+  await page
+    .getByRole("button", { name: GO_TO_DASHBOARD_RX })
+    .first()
+    .click({ timeout: STEP_TIMEOUT_MS });
+
+  // The freshly activated vault surfaces as collateral behind the per-vault options expander (its
+  // label may render "BTC Vault options" or "Vault options" depending on the build). Bounded waits so
+  // a dashboard drift can never hang the run.
+  const options = page.getByRole("button", { name: VAULT_OPTIONS_RX }).first();
+  const optionsShown = await options
+    .waitFor({ state: "visible", timeout: DASHBOARD_VAULT_TIMEOUT_MS })
+    .then(() => true)
+    .catch(() => false);
+  if (!optionsShown) {
+    log(
+      "⚠️ Dashboard collateral controls not found within the wait — activation succeeded; skipping the card cross-check.",
+    );
+    return;
+  }
+
+  const card = page.locator(VAULT_CARD_TESTID).first();
+  if (!(await card.isVisible().catch(() => false))) {
+    await options.click().catch(() => {}); // expand the collateral panel
+    await card
+      .waitFor({ state: "visible", timeout: STEP_TIMEOUT_MS })
+      .catch(() => {});
+  }
+  const cardText = (await card.innerText().catch(() => ""))
+    .replace(/\s+/g, " ")
+    .trim();
+  if (cardText.includes(amountBtc))
+    log(
+      `Dashboard shows the activated vault as collateral (${amountBtc} sBTC).`,
+    );
+  else
+    log(
+      `⚠️ Dashboard vault card did not clearly show "${amountBtc}" (card: "${cardText.slice(0, 120)}") — activation still succeeded.`,
+    );
+}
+
+export const peginAction: Action = {
+  id: "pegin",
+  async run(ctx: ActionContext): Promise<void> {
+    const { page, context, log, artifactsDir } = ctx;
+    const amountBtc = (
+      ctx.config.peginAmountBtc ?? DEFAULT_PEGIN_AMOUNT_BTC
+    ).trim();
+    const provider = ctx.config.peginProvider?.trim() || undefined;
+
+    // Approver stays installed for the whole run (auto-approves every wallet pop-up).
+    const handler = installPopupApprover(context, log);
+    let currentStep = "connect";
+    const recorder = await startRecording(
+      context,
+      page,
+      artifactsDir,
+      log,
+      () => currentStep,
+    );
+    try {
+      await connectWallets(ctx);
+
+      currentStep = "deposit-form";
+      await fillDepositForm(page, log, amountBtc, provider);
+
+      currentStep = "sign-transaction";
+      await startSigning(page, log);
+
+      currentStep = "step-machine";
+      await walkStepMachine(page, log, (step) => {
+        currentStep = step;
+      });
+
+      currentStep = "finish";
+      await assertActivatedAndOnDashboard(page, log, amountBtc);
+      log("✅ Pegin complete: BTC Vault activated and shown on the dashboard.");
+    } finally {
+      await recorder.stop();
+      context.off("page", handler);
+    }
+  },
+};

--- a/services/vault/e2e/real/actions/pegin.ts
+++ b/services/vault/e2e/real/actions/pegin.ts
@@ -382,7 +382,9 @@ async function assertActivatedAndOnDashboard(
     : null;
   const byAmount = cards
     .filter({
-      hasText: new RegExp(`${amountBtc.replace(/\./g, "\\.")}\\s*sBTC`),
+      hasText: new RegExp(
+        `${amountBtc.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*sBTC`,
+      ),
     })
     .first();
 

--- a/services/vault/e2e/real/actions/pegin.ts
+++ b/services/vault/e2e/real/actions/pegin.ts
@@ -235,6 +235,28 @@ async function handleArtifactSkip(
   return true;
 }
 
+/**
+ * Capture this deposit's Pre-PegIn txid from the progress view. Explorer links render as
+ * `<host>/tx/<txid>` anchors (CopyableHash); the depositor broadcasts + links the Pre-PegIn early in
+ * the flow (well before the VP broadcasts the peg-in), so the first BTC txid to appear is this run's
+ * Pre-PegIn. Used to pin the dashboard cross-check to THIS run's vault — a returning depositor's
+ * dashboard lists several. Scans hrefs Node-side (no page-context function) and skips ETH links: an
+ * ETH `/tx/0x…` hash never matches the 64-hex-no-0x BTC pattern.
+ */
+async function readPrePeginTxid(page: Page): Promise<string | undefined> {
+  const links = page.locator('a[href*="/tx/"]');
+  const count = await links.count().catch(() => 0);
+  for (let i = 0; i < count; i++) {
+    const href = await links
+      .nth(i)
+      .getAttribute("href")
+      .catch(() => null);
+    const match = href?.match(/\/tx\/([0-9a-fA-F]{64})(?:$|[/?#])/);
+    if (match) return match[1].toLowerCase();
+  }
+  return undefined;
+}
+
 /** Read the active step for the run log: "Step N active (P%)" from the stepper + progress bar. */
 async function readActiveStep(page: Page): Promise<string> {
   const active = page.locator('[aria-label$="active"]').first();
@@ -252,20 +274,24 @@ async function readActiveStep(page: Page): Promise<string> {
  * prompt fires no `page` event and would otherwise never be clicked. This loop also drives the two
  * dapp-page gates the approver can't reach (Activate Vault + Skip) and follows the progress UI, logging
  * each transition, until the terminal view appears. `onStep` tags the recorder's HTTP fixtures.
+ *
+ * Returns this run's Pre-PegIn txid (captured once, as soon as the progress view links it) so the
+ * finish-line check can target THIS run's vault card among a returning depositor's several.
  */
 async function walkStepMachine(
   page: Page,
   context: BrowserContext,
   log: (m: string) => void,
   onStep: (step: string) => void,
-): Promise<void> {
+): Promise<string | undefined> {
   const deadline = Date.now() + PEGIN_STEP_MACHINE_BUDGET_MS;
   let lastStep = "";
   let activated = false;
   let skipped = false;
+  let prePeginTxid: string | undefined;
 
   while (Date.now() < deadline) {
-    if (await activatedViewReached(page)) return;
+    if (await activatedViewReached(page)) return prePeginTxid;
 
     // Actively approve any reused wallet window (OKX) that the event approver can't see.
     await sweepApprovals(context, page, log);
@@ -273,6 +299,13 @@ async function walkStepMachine(
     // Two dapp-page interactions the wallet pop-up approver can't perform.
     if (!activated) activated = await handleActivateConfirmation(page, log);
     if (activated && !skipped) skipped = await handleArtifactSkip(page, log);
+
+    // Capture the Pre-PegIn txid once, the first tick the progress view links it.
+    if (!prePeginTxid) {
+      prePeginTxid = await readPrePeginTxid(page);
+      if (prePeginTxid)
+        log(`Captured this run's Pre-PegIn txid: ${prePeginTxid}`);
+    }
 
     const step = await readActiveStep(page);
     if (step && step !== lastStep) {
@@ -297,6 +330,7 @@ async function assertActivatedAndOnDashboard(
   page: Page,
   log: (m: string) => void,
   amountBtc: string,
+  prePeginTxid: string | undefined,
 ): Promise<void> {
   log("✅ Activated view reached — clicking Go to Dashboard");
   await page
@@ -319,23 +353,59 @@ async function assertActivatedAndOnDashboard(
     return;
   }
 
-  const card = page.locator(VAULT_CARD_TESTID).first();
-  if (!(await card.isVisible().catch(() => false))) {
-    await options.click().catch(() => {}); // expand the collateral panel
-    await card
+  // Expand the collateral panel so the vault cards render.
+  const cards = page.locator(VAULT_CARD_TESTID);
+  if (
+    !(await cards
+      .first()
+      .isVisible()
+      .catch(() => false))
+  ) {
+    await options.click().catch(() => {});
+    await cards
+      .first()
       .waitFor({ state: "visible", timeout: STEP_TIMEOUT_MS })
       .catch(() => {});
   }
+
+  // A returning depositor's dashboard lists several vault cards, so `.first()` is not necessarily the
+  // one this run created — matching the first card against the requested amount produced a false
+  // mismatch warning against an older vault. Prefer THIS run's Pre-PegIn txid captured mid-flow: the
+  // card links it in its "TX Hash" row (PeginTxHashRow, linkPrePegin default) as `<a href=".../tx/…">`.
+  // But that row is indexer-sourced, and for a JUST-activated vault the indexer commonly lags the click
+  // to the dashboard — the fresh card shows its amount (from activation state) before its tx-hash row
+  // populates. So the amount match is the expected, immediately-authoritative identifier for a fresh
+  // vault; the txid match engages once the indexer has caught up (e.g. an already-indexed vault). First
+  // card is the last resort when neither is captured.
+  const byTxid = prePeginTxid
+    ? cards.filter({ has: page.locator(`a[href*="${prePeginTxid}"]`) }).first()
+    : null;
+  const byAmount = cards
+    .filter({
+      hasText: new RegExp(`${amountBtc.replace(/\./g, "\\.")}\\s*sBTC`),
+    })
+    .first();
+
+  let card = cards.first();
+  let matchedBy = "first card (fallback)";
+  if (byTxid && (await byTxid.isVisible().catch(() => false))) {
+    card = byTxid;
+    matchedBy = `Pre-PegIn txid ${prePeginTxid?.slice(0, 8)}…`;
+  } else if (await byAmount.isVisible().catch(() => false)) {
+    card = byAmount;
+    matchedBy = `amount ${amountBtc}`;
+  }
+
   const cardText = (await card.innerText().catch(() => ""))
     .replace(/\s+/g, " ")
     .trim();
   if (cardText.includes(amountBtc))
     log(
-      `Dashboard shows the activated vault as collateral (${amountBtc} sBTC).`,
+      `Dashboard shows this run's vault as collateral (${amountBtc} sBTC, matched by ${matchedBy}).`,
     );
   else
     log(
-      `⚠️ Dashboard vault card did not clearly show "${amountBtc}" (card: "${cardText.slice(0, 120)}") — activation still succeeded.`,
+      `⚠️ Dashboard vault card did not clearly show "${amountBtc}" (matched by ${matchedBy}; card: "${cardText.slice(0, 120)}") — activation still succeeded.`,
     );
 }
 
@@ -375,12 +445,12 @@ export const peginAction: Action = {
       await startSigning(page, log);
 
       currentStep = "step-machine";
-      await walkStepMachine(page, context, log, (step) => {
+      const prePeginTxid = await walkStepMachine(page, context, log, (step) => {
         currentStep = step;
       });
 
       currentStep = "finish";
-      await assertActivatedAndOnDashboard(page, log, amountBtc);
+      await assertActivatedAndOnDashboard(page, log, amountBtc, prePeginTxid);
       log("✅ Pegin complete: BTC Vault activated and shown on the dashboard.");
     } finally {
       await recorder.stop();

--- a/services/vault/e2e/real/actions/pegin.ts
+++ b/services/vault/e2e/real/actions/pegin.ts
@@ -24,7 +24,7 @@
  * NEVER run without an explicit go-ahead: it spends real signet BTC + Sepolia ETH and is not
  * idempotent (a crash after the Pre-PegIn broadcast leaves an on-chain in-flight deposit).
  */
-import type { Locator, Page } from "@playwright/test";
+import type { BrowserContext, Locator, Page } from "@playwright/test";
 
 import {
   DASHBOARD_VAULT_TIMEOUT_MS,
@@ -36,13 +36,10 @@ import {
   STEP_TIMEOUT_MS,
 } from "../timing";
 
-import { installPopupApprover } from "./approver";
+import { installPopupApprover, sweepApprovals } from "./approver";
 import { startRecording } from "./recording";
 import { type Action, type ActionContext } from "./types";
 import { connectWallets } from "./walletConnect";
-
-/** Default deposit size in BTC when `--amount` isn't supplied (small, well above the protocol min). */
-const DEFAULT_PEGIN_AMOUNT_BTC = "0.01";
 
 // Form-phase matchers use exact copy strings (verified against the deployed build the run drives) with
 // a comment pointing at their `services/vault/src/copy.ts` source. Finish-line matchers below are
@@ -249,13 +246,16 @@ async function readActiveStep(page: Page): Promise<string> {
 }
 
 /**
- * Walk the 15-step signing machine to the activated vault. The pop-up approver auto-approves every
- * wallet prompt asynchronously; this loop only drives the two dapp-page gates the approver can't reach
- * (Activate Vault + Skip) and follows the progress UI, logging each transition, until the terminal
- * heading appears. `onStep` tags the recorder's HTTP fixtures with the current step.
+ * Walk the 15-step signing machine to the activated vault. Two approval mechanisms run in parallel:
+ * the event-driven `installPopupApprover` (for NEW wallet windows) and, each tick, an active
+ * `sweepApprovals` pass over already-open windows — OKX reuses one approval window, so a later signing
+ * prompt fires no `page` event and would otherwise never be clicked. This loop also drives the two
+ * dapp-page gates the approver can't reach (Activate Vault + Skip) and follows the progress UI, logging
+ * each transition, until the terminal view appears. `onStep` tags the recorder's HTTP fixtures.
  */
 async function walkStepMachine(
   page: Page,
+  context: BrowserContext,
   log: (m: string) => void,
   onStep: (step: string) => void,
 ): Promise<void> {
@@ -266,6 +266,9 @@ async function walkStepMachine(
 
   while (Date.now() < deadline) {
     if (await activatedViewReached(page)) return;
+
+    // Actively approve any reused wallet window (OKX) that the event approver can't see.
+    await sweepApprovals(context, page, log);
 
     // Two dapp-page interactions the wallet pop-up approver can't perform.
     if (!activated) activated = await handleActivateConfirmation(page, log);
@@ -340,14 +343,21 @@ export const peginAction: Action = {
   id: "pegin",
   async run(ctx: ActionContext): Promise<void> {
     const { page, context, log, artifactsDir } = ctx;
-    const amountBtc = (
-      ctx.config.peginAmountBtc ?? DEFAULT_PEGIN_AMOUNT_BTC
-    ).trim();
+    // Amount is resolved by the CLI to the fetched protocol minimum (or --amount). If it's unresolved
+    // — the min-fetch failed non-interactively and no --amount was given — fail loudly rather than
+    // silently depositing a stale hardcoded amount (CLAUDE.md: no silent fallbacks on critical paths).
+    const amountBtc = ctx.config.peginAmountBtc?.trim();
+    if (!amountBtc)
+      throw new Error(
+        "pegin: no deposit amount resolved — the minimum-deposit fetch failed and no --amount was given. Re-run with --amount=<btc>, or against a reachable network.",
+      );
     const provider = ctx.config.peginProvider?.trim() || undefined;
 
     // Approver stays installed for the whole run (auto-approves every wallet pop-up).
     const handler = installPopupApprover(context, log);
     let currentStep = "connect";
+    // No signing capture for pegin: the sign-conformance fixtures come from the `observe` run, and a
+    // pegin doesn't need signing.jsonl — keeping it off shrinks the sensitive-artifact surface.
     const recorder = await startRecording(
       context,
       page,
@@ -365,7 +375,7 @@ export const peginAction: Action = {
       await startSigning(page, log);
 
       currentStep = "step-machine";
-      await walkStepMachine(page, log, (step) => {
+      await walkStepMachine(page, context, log, (step) => {
         currentStep = step;
       });
 

--- a/services/vault/e2e/real/actions/recording.ts
+++ b/services/vault/e2e/real/actions/recording.ts
@@ -203,6 +203,11 @@ function declaredSize(response: Response): number | null {
  * Start recording. `currentStep` is sampled per captured response so each fixture line is tagged with
  * the step it belongs to (a step index/label for pegin; an elapsed marker for the human-driven observe
  * run). Returns a `Recorder` whose `stop()` the caller MUST invoke (in a finally) to flush the trace.
+ *
+ * `captureSigning` (default off) enables layer 3 — the wallet signing capture. It's OPT-IN because it
+ * writes real (testnet) message/psbt/psbts fixtures; only the `observe` run (which exists to build the
+ * conformance fixtures) turns it on. A plain peg-in leaves it off to keep the sensitive-artifact
+ * surface minimal. These are testnet artifacts with no key material, and `artifacts/` is gitignored.
  */
 export async function startRecording(
   context: BrowserContext,
@@ -210,6 +215,7 @@ export async function startRecording(
   dir: string,
   log: (m: string) => void,
   currentStep: () => string = () => "",
+  { captureSigning = false }: { captureSigning?: boolean } = {},
 ): Promise<Recorder> {
   const recordingDir = join(dir, "recording");
   mkdirSync(recordingDir, { recursive: true });
@@ -221,9 +227,14 @@ export async function startRecording(
     .start({ screenshots: true, snapshots: true, sources: true })
     .catch((e) => log(`recorder: tracing.start failed (non-fatal): ${e}`));
 
-  // Layer 3: wrap the injected wallet provider's signing methods (read-through) to save the real
-  // message/psbt/psbts fixtures for per-wallet conformance tests.
-  await installSigningCapture(page, signingLog, log);
+  // Layer 3 (opt-in): wrap the injected wallet provider's signing methods (read-through) to save the
+  // real message/psbt/psbts fixtures for per-wallet conformance tests.
+  if (captureSigning) {
+    log(
+      "⚠️ signing capture ON → recording/signing.jsonl will hold real testnet message/psbt/psbts + signatures (no keys). Gitignored; don't share broadly.",
+    );
+    await installSigningCapture(page, signingLog, log);
+  }
 
   const onResponse = (response: Response) => {
     void (async () => {

--- a/services/vault/e2e/real/actions/recording.ts
+++ b/services/vault/e2e/real/actions/recording.ts
@@ -1,0 +1,283 @@
+/**
+ * Run recorder — captures the ground truth of a peg-in so a run can be reproduced/inspected offline
+ * (and, later, replayed as a mock without the multi-minute waits) instead of re-driving a 30 min–2 hr
+ * real flow blind. Three layers:
+ *
+ *  1. Playwright trace (`trace.zip`) — per-action DOM snapshots + screenshots + full network, browsable
+ *     in the Playwright trace viewer. The primary "what did the UI actually look like at step N" tool.
+ *  2. Programmatic HTTP capture (`recording/http.jsonl`) — one JSON line per app fetch/XHR
+ *     (request + response body/status), tagged with the current step. This is the machine-readable
+ *     fixture the future `--data=mock` replay consumes; the VP daemon's `PendingIngestion → … →
+ *     Activated` progression is reconstructable from the ordered `batchGetPeginStatus` responses here.
+ *  3. Wallet signing capture (`recording/signing.jsonl`) — one JSON line per BTC-wallet signing call
+ *     (`signMessage` / `signPsbt` / `signPsbts`): its arguments (message, PSBT hex, PSBT-array) and the
+ *     returned signature. These calls go through the injected wallet provider (`window.unisat`, …), NOT
+ *     over HTTP, so the HTTP layer never sees them. Because every wallet imports the SAME mnemonic (=
+ *     same BTC key), these fixtures are re-signable by another wallet — so one UniSat peg-in yields the
+ *     exact message/psbt/psbts inputs a focused OKX / OneKey signing-conformance test can replay,
+ *     rather than driving a full peg-in per wallet. Capture is a READ-THROUGH wrapper: it always
+ *     delegates to the real provider method untouched, so it can never alter or block signing.
+ *
+ * Only the dapp page's fetch/XHR is captured for layer 2: the four external boundaries (VP proxy
+ * JSON-RPC, indexer GraphQL, Bitcoin mempool REST, Ethereum RPC reads) are all initiated by the dapp
+ * page. The ETH write broadcast goes through MetaMask's own provider (not the page) and is
+ * intentionally NOT captured — it is the one boundary a page-level recorder / `page.route` mock cannot
+ * see.
+ *
+ * Security: the mnemonic never crosses the network, so it cannot appear here; wallet seed screens occur
+ * during import, before recording starts. VP `Authorization: Bearer` tokens are session-scoped and kept
+ * for replay fidelity.
+ */
+import type { BrowserContext, Page, Response } from "@playwright/test";
+import { appendFileSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+/** Skip capturing bodies larger than this (e.g. the ~450MB artifact blob) — record metadata only. */
+const MAX_CAPTURED_BODY_BYTES = 512 * 1024;
+/** Only these resource types are app IO worth recording (skip document/script/img/css/font/etc.). */
+const CAPTURED_RESOURCE_TYPES = new Set(["fetch", "xhr"]);
+
+export interface Recorder {
+  /**
+   * Capture the CURRENT screen as queryable DOM (`<seq>-<label>.html`) + a screenshot
+   * (`<seq>-<label>.png`) under `recording/`. Playwright's own trace only snapshots DOM around actions
+   * IT performs, so a human-driven observe run yields screenshots but no queryable DOM — this fills that
+   * gap: the human snapshots each meaningful screen so `pegin.ts` selectors are written against real DOM.
+   */
+  snapshot(label: string): Promise<void>;
+  /** Stop capture and flush the trace to `<dir>/trace.zip`. Best-effort; never throws. */
+  stop(): Promise<void>;
+}
+
+/** Filesystem-safe, ordered snapshot basename, e.g. `03-select-provider`. */
+export function snapshotName(seq: number, label: string): string {
+  const slug =
+    label
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, 40) || "screen";
+  return `${String(seq).padStart(2, "0")}-${slug}`;
+}
+
+/**
+ * Append a free-form note (the full line the human typed) to `<dir>/notes.md`, correlated to a snapshot
+ * by its basename. Lets the label stay a short filename slug while preserving any extra detail the
+ * human wants to attach (e.g. "clicked the gear → Security, auto-lock dropdown here") verbatim.
+ */
+export function appendNote(
+  dir: string,
+  name: string,
+  note: string,
+  log: (m: string) => void,
+): void {
+  if (!note.trim()) return;
+  appendFileSync(join(dir, "notes.md"), `- **${name}** — ${note.trim()}\n`);
+  log(`note → ${name}: ${note.trim()}`);
+}
+
+/**
+ * Write one screen as queryable DOM (`<dir>/<name>.html`) + a full-page screenshot (`<dir>/<name>.png`).
+ * Best-effort; never throws. Shared by the observe recorder and the wallet-config helper.
+ */
+export async function captureSnapshot(
+  page: Page,
+  dir: string,
+  name: string,
+  log: (m: string) => void,
+): Promise<void> {
+  const base = join(dir, name);
+  const html = await page.content().catch(() => null);
+  if (html !== null) writeFileSync(`${base}.html`, html);
+  await page
+    .screenshot({ path: `${base}.png`, fullPage: true })
+    .catch(() => {});
+  log(`snapshot → ${base}.{html,png}`);
+}
+
+/**
+ * Page-side source for the signing capture (layer 3), wrapping the BTC-wallet provider's signing
+ * methods. It is a raw STRING on purpose: passing a TS function to `page.evaluate` / `addInitScript`
+ * makes tsx/esbuild inject its `__name` keepNames helper into the serialized body, which is undefined
+ * in the browser page (`ReferenceError: __name is not defined`) — a string literal is never
+ * transformed, so it runs verbatim. Read-through: each wrapper awaits and returns the REAL method's
+ * result and only records in a `finally`, so a fault can never alter or block a signature. Re-scans on
+ * an interval so a provider injected/replaced after page load (e.g. post-connect) is still hooked.
+ *
+ * References only `window` + the exposed `__peginRecordSigning` binding; self-contained (no closures).
+ */
+const SIGNING_CAPTURE_SOURCE = `(() => {
+  if (window.__peginSigningHooked) return;
+  window.__peginSigningHooked = true;
+  var METHODS = ["signMessage", "signPsbt", "signPsbts"];
+  var PATHS = ["unisat","okxwallet.bitcoin","okxwallet.bitcoinSignet","okxwallet.bitcoinTestnet","$onekey.btc","onekey.btc","bitcoin"];
+  function safe(value) {
+    if (value === null || typeof value === "string" || typeof value === "number" || typeof value === "boolean") return value;
+    try { return JSON.parse(JSON.stringify(value)); } catch (e) { return String(value); }
+  }
+  function emit(entry) {
+    try { if (window.__peginRecordSigning) window.__peginRecordSigning(JSON.stringify(entry)); } catch (e) {}
+  }
+  function resolve(path) {
+    var node = window;
+    var parts = path.split(".");
+    for (var i = 0; i < parts.length; i++) {
+      if (node == null || typeof node !== "object") return undefined;
+      node = node[parts[i]];
+    }
+    return node && typeof node === "object" ? node : undefined;
+  }
+  function wrap(provider, name) {
+    if (!provider) return;
+    for (var i = 0; i < METHODS.length; i++) {
+      var method = METHODS[i];
+      var fn = provider[method];
+      if (typeof fn !== "function" || fn.__peginWrapped) continue;
+      (function (m, original) {
+        var wrapped = async function () {
+          var args = Array.prototype.slice.call(arguments);
+          var result, error, hasError = false;
+          try { result = await original.apply(this, args); return result; }
+          catch (e) { error = e; hasError = true; throw e; }
+          finally {
+            emit({
+              t: new Date().toISOString(),
+              provider: name,
+              method: m,
+              args: args.map(safe),
+              result: hasError ? undefined : safe(result),
+              error: hasError ? String(error) : undefined
+            });
+          }
+        };
+        wrapped.__peginWrapped = true;
+        try { provider[m] = wrapped; } catch (e) {}
+      })(method, fn);
+    }
+  }
+  function scan() { for (var i = 0; i < PATHS.length; i++) wrap(resolve(PATHS[i]), PATHS[i]); }
+  scan();
+  setInterval(scan, 500);
+})()`;
+
+/**
+ * Install the read-through signing capture (layer 3): expose a Node sink the page calls, then inject
+ * the wrapper into BOTH the current page and every future navigation. Best-effort — a failure here is
+ * logged and skipped, never fatal to the run (the peg-in matters more than the fixture).
+ */
+async function installSigningCapture(
+  page: Page,
+  signingLog: string,
+  log: (m: string) => void,
+): Promise<void> {
+  try {
+    await page.exposeFunction("__peginRecordSigning", (json: string) => {
+      appendFileSync(signingLog, json + "\n");
+    });
+    // addInitScript for future navigations; evaluate for the already-loaded current page. Both take
+    // the raw string so esbuild can't inject its `__name` helper (see SIGNING_CAPTURE_SOURCE).
+    await page.addInitScript({ content: SIGNING_CAPTURE_SOURCE });
+    await page.evaluate(SIGNING_CAPTURE_SOURCE);
+    log(`Signing capture → ${signingLog}`);
+  } catch (e) {
+    log(`recorder: signing capture install failed (non-fatal): ${e}`);
+  }
+}
+
+/** Whether a captured response body is textual (JSON/text) and safe to store verbatim. */
+function isTextBody(response: Response): boolean {
+  const type = (response.headers()["content-type"] ?? "").toLowerCase();
+  return type.includes("json") || type.includes("text");
+}
+
+/** Declared body size from content-length, or null when the header is absent. */
+function declaredSize(response: Response): number | null {
+  const raw = response.headers()["content-length"];
+  if (!raw) return null;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * Start recording. `currentStep` is sampled per captured response so each fixture line is tagged with
+ * the step it belongs to (a step index/label for pegin; an elapsed marker for the human-driven observe
+ * run). Returns a `Recorder` whose `stop()` the caller MUST invoke (in a finally) to flush the trace.
+ */
+export async function startRecording(
+  context: BrowserContext,
+  page: Page,
+  dir: string,
+  log: (m: string) => void,
+  currentStep: () => string = () => "",
+): Promise<Recorder> {
+  const recordingDir = join(dir, "recording");
+  mkdirSync(recordingDir, { recursive: true });
+  const httpLog = join(recordingDir, "http.jsonl");
+  const signingLog = join(recordingDir, "signing.jsonl");
+  const tracePath = join(dir, "trace.zip");
+
+  await context.tracing
+    .start({ screenshots: true, snapshots: true, sources: true })
+    .catch((e) => log(`recorder: tracing.start failed (non-fatal): ${e}`));
+
+  // Layer 3: wrap the injected wallet provider's signing methods (read-through) to save the real
+  // message/psbt/psbts fixtures for per-wallet conformance tests.
+  await installSigningCapture(page, signingLog, log);
+
+  const onResponse = (response: Response) => {
+    void (async () => {
+      try {
+        const request = response.request();
+        if (!CAPTURED_RESOURCE_TYPES.has(request.resourceType())) return;
+
+        const size = declaredSize(response);
+        const tooBig = size !== null && size > MAX_CAPTURED_BODY_BYTES;
+        let body: string | { truncated: true; size: number | null } | null =
+          null;
+        if (tooBig) {
+          body = { truncated: true, size };
+        } else if (isTextBody(response)) {
+          const text = await response.text().catch(() => null);
+          body =
+            text !== null && text.length > MAX_CAPTURED_BODY_BYTES
+              ? { truncated: true, size: text.length }
+              : text;
+        }
+
+        const entry = {
+          t: new Date().toISOString(),
+          step: currentStep(),
+          method: request.method(),
+          url: response.url(),
+          status: response.status(),
+          reqBody: request.postData() ?? undefined,
+          resBody: body ?? undefined,
+        };
+        appendFileSync(httpLog, JSON.stringify(entry) + "\n");
+      } catch {
+        // A response can be superseded/aborted before its body resolves — skip it, never crash the run.
+      }
+    })();
+  };
+
+  page.on("response", onResponse);
+  log(`Recording → trace ${tracePath} + fixtures ${httpLog}`);
+
+  let snapshotSeq = 0;
+  return {
+    snapshot: async (label: string) => {
+      snapshotSeq += 1;
+      const name = snapshotName(snapshotSeq, label);
+      await captureSnapshot(page, recordingDir, name, log);
+      appendNote(recordingDir, name, label, log);
+    },
+    stop: async () => {
+      page.off("response", onResponse);
+      await context.tracing
+        .stop({ path: tracePath })
+        .catch((e) => log(`recorder: tracing.stop failed (non-fatal): ${e}`));
+      log(`Recording stopped → ${tracePath}`);
+    },
+  };
+}

--- a/services/vault/e2e/real/actions/signConformance.ts
+++ b/services/vault/e2e/real/actions/signConformance.ts
@@ -1,0 +1,358 @@
+/**
+ * The "sign-conformance" action: replay the REAL signing fixtures captured from a UniSat peg-in
+ * (`recording/signing.jsonl`) into ANOTHER BTC wallet (e.g. OKX) and assert each call produces a
+ * signature — WITHOUT driving a full 30 min–2 hr peg-in per wallet.
+ *
+ * This works because every wallet imports the SAME mnemonic → same BTC key → same signet taproot
+ * address, so the captured PSBTs' inputs (and the `toSignInputs[].publicKey`) belong to this wallet
+ * too, and the captured `options` are already at the injected-provider boundary — the exact shape
+ * OKX's `signPsbt(hex, {autoFinalized, toSignInputs})` / `signPsbts` / `signMessage(msg, type)` expect.
+ * It signs but never broadcasts, so no funds move.
+ *
+ * Approvals are driven ACTIVELY: for each call we poll every open `chrome-extension://` window and
+ * click its approve control until the call resolves. This is deliberately NOT the new-window-event
+ * approver used elsewhere — OKX reuses ONE persistent approval window (and parses PSBTs for a few
+ * seconds before its Confirm appears), so an event-driven approver misses approvals after the first.
+ */
+import type { BrowserContext, Page } from "@playwright/test";
+import { readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+import type { BtcWalletId } from "../config";
+import {
+  APPROVE_ROUND_MS,
+  POPUP_OPEN_WAIT_MS,
+  POST_CONNECT_SETTLE_MS,
+  SIGN_CALL_TIMEOUT_MS,
+} from "../timing";
+
+import { clickApprove, tickConsent } from "./approver";
+import { type Action, type ActionContext } from "./types";
+
+/** The signing methods we replay (the three the dapp uses on the BTC wallet). */
+const SIGNING_METHODS = ["signMessage", "signPsbt", "signPsbts"] as const;
+type SigningMethod = (typeof SIGNING_METHODS)[number];
+
+/** One captured signing call to replay. */
+interface Fixture {
+  method: SigningMethod;
+  args: unknown[];
+}
+
+/**
+ * Injected-provider path per BTC wallet (the object that actually exposes signMessage/signPsbt/…).
+ * OKX namespaces per chain (`bitcoinSignet` for signet); UniSat is flat. A wallet not listed here
+ * errors clearly rather than being guessed at.
+ */
+const PROVIDER_PATH: Partial<Record<BtcWalletId, string>> = {
+  unisat: "unisat",
+  okx: "okxwallet.bitcoinSignet",
+};
+
+/** Newest sibling `*-pegin/recording/signing.jsonl`, or the explicit `--fixtures` path. */
+function resolveFixturesPath(
+  artifactsDir: string,
+  explicit: string | undefined,
+): string {
+  if (explicit) return explicit;
+  const artifactsRoot = dirname(artifactsDir);
+  const peginRuns = readdirSync(artifactsRoot)
+    .filter((name) => name.endsWith("-pegin"))
+    .sort()
+    .reverse();
+  for (const run of peginRuns) {
+    const candidate = join(artifactsRoot, run, "recording", "signing.jsonl");
+    try {
+      readFileSync(candidate);
+      return candidate;
+    } catch {
+      // no signing.jsonl in this run — try the next.
+    }
+  }
+  throw new Error(
+    `No signing fixtures found. Pass --fixtures=<path to signing.jsonl>, or run a pegin first (looked under ${artifactsRoot}/*-pegin/recording/signing.jsonl).`,
+  );
+}
+
+/** Parse signing.jsonl into replayable fixtures (skip errored + non-signing entries). */
+function loadFixtures(path: string, log: (m: string) => void): Fixture[] {
+  const fixtures: Fixture[] = [];
+  for (const line of readFileSync(path, "utf8").split("\n")) {
+    if (!line.trim()) continue;
+    const entry = JSON.parse(line) as {
+      method?: string;
+      args?: unknown[];
+      error?: string;
+    };
+    if (entry.error) continue;
+    if (!SIGNING_METHODS.includes(entry.method as SigningMethod)) continue;
+    if (!Array.isArray(entry.args)) continue;
+    fixtures.push({ method: entry.method as SigningMethod, args: entry.args });
+  }
+  log(`Loaded ${fixtures.length} signing fixtures from ${path}`);
+  return fixtures;
+}
+
+/** The depositor pubkey the fixtures were built for — used to warn on an account/network mismatch. */
+function fixturePublicKey(fixtures: Fixture[]): string | undefined {
+  for (const f of fixtures) {
+    const opts =
+      f.method === "signPsbts" ? (f.args[1] as unknown[])?.[0] : f.args[1];
+    const toSign = (opts as { toSignInputs?: { publicKey?: string }[] })
+      ?.toSignInputs;
+    if (toSign?.[0]?.publicKey) return toSign[0].publicKey;
+  }
+  return undefined;
+}
+
+/** Human-readable one-liner for a fixture (no raw hex spam). */
+function describeFixture(f: Fixture): string {
+  const a0 = f.args[0];
+  if (f.method === "signMessage")
+    return `signMessage type=${JSON.stringify(f.args[1])} (${String(a0).length} chars)`;
+  if (f.method === "signPsbt")
+    return `signPsbt (${String(a0).length}-char psbt)`;
+  return `signPsbts (${Array.isArray(a0) ? a0.length : "?"} psbts)`;
+}
+
+/** Whether a returned signature has the right SHAPE for the method (non-empty / right arity). */
+function isValidResult(
+  method: SigningMethod,
+  result: unknown,
+  args: unknown[],
+): boolean {
+  if (method === "signPsbts") {
+    const expected = Array.isArray(args[0]) ? args[0].length : -1;
+    return (
+      Array.isArray(result) &&
+      result.length === expected &&
+      result.every((r) => typeof r === "string" && r.length > 0)
+    );
+  }
+  return typeof result === "string" && result.length > 0;
+}
+
+function summarizeResult(result: unknown): string {
+  if (Array.isArray(result))
+    return `array[${result.length}] (elem0 ${String(result[0] ?? "").length} chars)`;
+  return `string ${String(result ?? "").length} chars`;
+}
+
+/** Reject if `promise` doesn't settle within `ms` (an approval that never resolved). */
+function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  label: string,
+): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<T>((_, reject) =>
+      setTimeout(
+        () =>
+          reject(
+            new Error(
+              `${label} did not resolve within ${ms}ms (not confirmed?)`,
+            ),
+          ),
+        ms,
+      ),
+    ),
+  ]);
+}
+
+/**
+ * Call a wallet provider method (or `__connect`) in the page and return its result. Anonymous arrow
+ * with no nested named declarations — safe to pass to `page.evaluate` (a named/nested function would
+ * be rewritten with esbuild's `__name` helper, which is undefined in the browser page).
+ */
+function callProvider(
+  page: Page,
+  providerPath: string,
+  method: string,
+  args: unknown[],
+): Promise<unknown> {
+  return page.evaluate(
+    async ({ providerPath, method, args }) => {
+      let provider: unknown = window;
+      for (const key of providerPath.split(".")) {
+        provider =
+          provider == null
+            ? provider
+            : (provider as Record<string, unknown>)[key];
+      }
+      if (provider == null)
+        throw new Error(`provider not found at window.${providerPath}`);
+      const p = provider as Record<
+        string,
+        (...a: unknown[]) => Promise<unknown>
+      >;
+      if (method === "__connect") {
+        if (typeof p.connect === "function") return await p.connect();
+        if (typeof p.requestAccounts === "function")
+          return await p.requestAccounts();
+        throw new Error(
+          "provider exposes neither connect() nor requestAccounts()",
+        );
+      }
+      if (typeof p[method] !== "function")
+        throw new Error(`provider has no method ${method}`);
+      return await p[method](...args);
+    },
+    { providerPath, method, args },
+  );
+}
+
+/** Close any leftover extension pop-ups so a failed call can't leak a modal into the next one. */
+async function closeStrayPopups(
+  context: BrowserContext,
+  mainPage: Page,
+): Promise<void> {
+  for (const pg of context.pages()) {
+    if (pg !== mainPage && pg.url().startsWith("chrome-extension://"))
+      await pg.close().catch(() => {});
+  }
+}
+
+/**
+ * Drive approvals for an in-flight provider call: poll every open extension window and click its
+ * approve control each round until `isStopped()` (the call settled). Handles OKX's reused approval
+ * window (no new-`page` event) and its multi-second PSBT parse (the Confirm appears late — polling
+ * simply clicks it once it's live). Best-effort; never throws.
+ */
+async function driveApprovals(
+  context: BrowserContext,
+  mainPage: Page,
+  isStopped: () => boolean,
+  log: (m: string) => void,
+): Promise<void> {
+  // Let the approval UI render (OKX parses PSBTs first) before the first pass.
+  await mainPage.waitForTimeout(POPUP_OPEN_WAIT_MS).catch(() => {});
+  while (!isStopped()) {
+    for (const pg of context.pages()) {
+      if (pg === mainPage || !pg.url().startsWith("chrome-extension://"))
+        continue;
+      await tickConsent(pg).catch(() => {});
+      const clicked = await clickApprove(pg).catch(() => null);
+      if (clicked)
+        log(
+          `  approved "${clicked}" in ${pg.url().split("/").pop() ?? "popup"}`,
+        );
+    }
+    await mainPage.waitForTimeout(APPROVE_ROUND_MS).catch(() => {});
+  }
+}
+
+/** Run one provider call while actively driving its approvals; returns the call's result. */
+async function callWithApprovals(
+  context: BrowserContext,
+  page: Page,
+  label: string,
+  call: Promise<unknown>,
+  log: (m: string) => void,
+): Promise<unknown> {
+  const settled = withTimeout(call, SIGN_CALL_TIMEOUT_MS, label);
+  let stopped = false;
+  const driver = driveApprovals(context, page, () => stopped, log);
+  try {
+    return await settled;
+  } finally {
+    stopped = true;
+    await driver;
+  }
+}
+
+interface FixtureResult {
+  label: string;
+  method: SigningMethod;
+  ok: boolean;
+  detail: string;
+}
+
+export const signConformanceAction: Action = {
+  id: "sign-conformance",
+  async run(ctx: ActionContext): Promise<void> {
+    const { page, context, log, artifactsDir, config } = ctx;
+    const btcId = ctx.btc.id;
+    const providerPath = PROVIDER_PATH[btcId];
+    if (!providerPath)
+      throw new Error(
+        `sign-conformance: injected-provider path not defined for "${btcId}" (supported: ${Object.keys(PROVIDER_PATH).join(", ")}).`,
+      );
+
+    const fixtures = loadFixtures(
+      resolveFixturesPath(artifactsDir, config.fixturesPath),
+      log,
+    );
+    if (fixtures.length === 0)
+      throw new Error(
+        "sign-conformance: no replayable signing fixtures found.",
+      );
+
+    // Establish the wallet↔page connection (its approval is driven like any other call).
+    log(`Connecting ${btcId} via window.${providerPath}`);
+    const connection = (await callWithApprovals(
+      context,
+      page,
+      "connect",
+      callProvider(page, providerPath, "__connect", []),
+      log,
+    )) as { address?: string; compressedPublicKey?: string } | string[];
+    log(`Connected: ${JSON.stringify(connection).slice(0, 200)}`);
+
+    // Warn early if the connected account can't own the fixtures' inputs (wrong network/address) —
+    // signing would then fail for a reason unrelated to the wallet's approval UI.
+    const expectedPk = fixturePublicKey(fixtures);
+    const connectedPk = Array.isArray(connection)
+      ? undefined
+      : connection.compressedPublicKey;
+    if (expectedPk && connectedPk && connectedPk !== expectedPk)
+      log(
+        `⚠️ connected pubkey ${connectedPk} ≠ fixture pubkey ${expectedPk} — the wallet is on a different account/network; signing will likely fail`,
+      );
+
+    // Let the dapp finish any post-connection navigation before driving provider calls, so an
+    // in-flight signing evaluate isn't destroyed mid-call by a late SPA route change.
+    await page.waitForTimeout(POST_CONNECT_SETTLE_MS);
+
+    const results: FixtureResult[] = [];
+    for (let i = 0; i < fixtures.length; i++) {
+      const f = fixtures[i];
+      const label = `${String(i + 1).padStart(2, "0")}-${f.method}`;
+      log(`\n▶ ${label}: ${describeFixture(f)}`);
+      try {
+        const result = await callWithApprovals(
+          context,
+          page,
+          label,
+          callProvider(page, providerPath, f.method, f.args),
+          log,
+        );
+        const ok = isValidResult(f.method, result, f.args);
+        const detail = summarizeResult(result);
+        log(
+          ok
+            ? `  ✅ signed → ${detail}`
+            : `  ⚠️ returned but wrong shape → ${detail}`,
+        );
+        results.push({ label, method: f.method, ok, detail });
+      } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        log(`  ❌ ${detail}`);
+        results.push({ label, method: f.method, ok: false, detail });
+        await closeStrayPopups(context, page);
+      }
+    }
+
+    writeFileSync(
+      join(artifactsDir, "conformance-results.json"),
+      JSON.stringify({ wallet: btcId, providerPath, results }, null, 2),
+    );
+    const passed = results.filter((r) => r.ok).length;
+    log(`\nSign-conformance (${btcId}): ${passed}/${results.length} signed.`);
+    if (passed !== results.length)
+      throw new Error(
+        `sign-conformance: ${results.length - passed}/${results.length} fixture(s) failed for ${btcId}.`,
+      );
+    log(`✅ ${btcId} signed every fixture shape (message + psbt + psbts).`);
+  },
+};

--- a/services/vault/e2e/real/actions/signConformance.ts
+++ b/services/vault/e2e/real/actions/signConformance.ts
@@ -26,7 +26,7 @@ import {
   SIGN_CALL_TIMEOUT_MS,
 } from "../timing";
 
-import { clickApprove, tickConsent } from "./approver";
+import { sweepApprovals } from "./approver";
 import { type Action, type ActionContext } from "./types";
 
 /** The signing methods we replay (the three the dapp uses on the BTC wallet). */
@@ -228,16 +228,7 @@ async function driveApprovals(
   // Let the approval UI render (OKX parses PSBTs first) before the first pass.
   await mainPage.waitForTimeout(POPUP_OPEN_WAIT_MS).catch(() => {});
   while (!isStopped()) {
-    for (const pg of context.pages()) {
-      if (pg === mainPage || !pg.url().startsWith("chrome-extension://"))
-        continue;
-      await tickConsent(pg).catch(() => {});
-      const clicked = await clickApprove(pg).catch(() => null);
-      if (clicked)
-        log(
-          `  approved "${clicked}" in ${pg.url().split("/").pop() ?? "popup"}`,
-        );
-    }
+    await sweepApprovals(context, mainPage, log);
     await mainPage.waitForTimeout(APPROVE_ROUND_MS).catch(() => {});
   }
 }

--- a/services/vault/e2e/real/actions/walletConfig.ts
+++ b/services/vault/e2e/real/actions/walletConfig.ts
@@ -1,0 +1,108 @@
+/**
+ * The "wallet-config" action: capture where each wallet's auto-lock / lock-timeout setting lives, so
+ * that setting can be automated in the importers (a wallet that locks mid-run — MetaMask/UniSat/OKX/
+ * OneKey all auto-lock after a few minutes — stalls the peg-in at "wallet locked", see the deposit
+ * progress view). It imports the chosen BTC wallet + MetaMask (done by the run orchestrator before this
+ * action), re-opens each wallet's extension UI in its own tab, and drops into a snapshot loop: you
+ * navigate to the lock setting and type a label + Enter; it dumps the DOM + a screenshot of whichever
+ * wallet tab is frontmost, so the settings path can be encoded per wallet.
+ *
+ * Inherently interactive — it requires a TTY. It does not touch the dapp page.
+ */
+import type { Page } from "@playwright/test";
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { createInterface } from "node:readline/promises";
+
+import type { BtcWalletId, EthWalletId } from "../config";
+import { EXTENSION_CHROME_STORE_IDS, runtimeExtensionId } from "../connector";
+
+import { appendNote, captureSnapshot, snapshotName } from "./recording";
+import type { Action, ActionContext } from "./types";
+
+/** Store id + home path (the URL that opens the unlocked wallet UI) per wallet. */
+const WALLET_UI: Record<
+  BtcWalletId | EthWalletId,
+  { storeId: string; homePath: string }
+> = {
+  unisat: {
+    storeId: EXTENSION_CHROME_STORE_IDS.UNISAT,
+    homePath: "index.html",
+  },
+  okx: { storeId: EXTENSION_CHROME_STORE_IDS.OKX, homePath: "home.html#/" },
+  onekey: {
+    storeId: EXTENSION_CHROME_STORE_IDS.ONEKEY,
+    homePath: "ui-expand-tab.html",
+  },
+  metamask: {
+    storeId: EXTENSION_CHROME_STORE_IDS.METAMASK,
+    homePath: "home.html#/",
+  },
+};
+
+interface WalletTab {
+  id: BtcWalletId | EthWalletId;
+  tab: Page;
+}
+
+/** Open a wallet's extension UI in a fresh tab. */
+async function openWalletUi(
+  ctx: ActionContext,
+  id: BtcWalletId | EthWalletId,
+): Promise<WalletTab> {
+  const { storeId, homePath } = WALLET_UI[id];
+  const url = `chrome-extension://${runtimeExtensionId(storeId)}/${homePath}`;
+  const tab = await ctx.context.newPage();
+  await tab.goto(url).catch(() => {});
+  await tab.waitForLoadState("domcontentloaded").catch(() => {});
+  ctx.log(`Opened ${id} wallet UI: ${url}`);
+  return { id, tab };
+}
+
+export const walletConfigAction: Action = {
+  id: "wallet-config",
+  async run(ctx: ActionContext): Promise<void> {
+    if (!process.stdin.isTTY)
+      throw new Error(
+        "wallet-config is interactive — run it in a terminal (you navigate the wallet settings). Do not pass --yes.",
+      );
+
+    const dir = join(ctx.artifactsDir, "wallet-config");
+    mkdirSync(dir, { recursive: true });
+    const tabs: WalletTab[] = [
+      await openWalletUi(ctx, ctx.btc.id),
+      await openWalletUi(ctx, ctx.eth.id),
+    ];
+
+    const rl = createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    });
+    let seq = 0;
+    try {
+      ctx.log(
+        "Navigate to the auto-lock / lock-timeout setting in a wallet (unlock it first if needed), then " +
+          "type a note + Enter. Both wallet tabs are snapshotted each time (whichever you edited is " +
+          "captured either way — alt-tabbing to this terminal backgrounds the browser, so 'which tab is " +
+          "frontmost' is unreliable). The note is saved verbatim to notes.md. Type 'done' to finish.",
+      );
+      for (;;) {
+        const note = (await rl.question("\nnote (or 'done'): ")).trim();
+        if (note.toLowerCase() === "done") break;
+        for (const t of tabs) {
+          if (t.tab.isClosed()) continue; // don't write phantom snapshots for a tab you've closed
+          seq += 1;
+          // Append the wallet id AFTER the slug so it survives the 40-char truncation (a long note
+          // would otherwise swallow it, leaving unisat/metamask indistinguishable by filename).
+          const name = `${snapshotName(seq, note)}-${t.id}`;
+          await captureSnapshot(t.tab, dir, name, ctx.log);
+          appendNote(dir, name, `[${t.id}] ${note}`, ctx.log);
+        }
+      }
+    } finally {
+      rl.close();
+      for (const { tab } of tabs) await tab.close().catch(() => {});
+    }
+    ctx.log(`Wallet-config snapshots saved under ${dir}`);
+  },
+};

--- a/services/vault/e2e/real/actions/walletConnect.ts
+++ b/services/vault/e2e/real/actions/walletConnect.ts
@@ -1,0 +1,109 @@
+/**
+ * The shared wallet-connection sequence, reused by every action that needs a connected app
+ * (`connect`, `pegin`, `observe`). It drives the vault app's connect flow up to the connected state:
+ *
+ *   Connect (connect-wallet-button) → Select Bitcoin Wallet (select-bitcoin-wallet-button) →
+ *   wallet-option-<id> → approve in the BTC extension popup → Select Ethereum Wallet
+ *   (select-ethereum-wallet-button) → MetaMask (Reown AppKit) → approve MetaMask popup →
+ *   Connect (chains-connect-button) → the deposit CTA (data-testid="deposit-button") appears.
+ *
+ * It assumes a pop-up approver is ALREADY installed on the context (see `approver.ts`) — the approval
+ * pop-ups fire asynchronously during these clicks. Callers own the approver lifecycle so they can keep
+ * it running afterwards (pegin) or uninstall it (observe, where the human then drives the peg-in).
+ * Address verification is NOT done here — that is the `connect` action's own success check.
+ */
+import type { Page } from "@playwright/test";
+
+import type { BtcWalletId, EthWalletId } from "../config";
+import { APPROVAL_WAIT_MS, STEP_TIMEOUT_MS } from "../timing";
+
+import type { ActionContext } from "./types";
+
+/** The Reown AppKit list entry to click per ETH wallet. */
+const ETH_APPKIT_NAME: Record<EthWalletId, RegExp> = { metamask: /metamask/i };
+
+/**
+ * Drive the connect flow to the connected state (the header deposit button visible). Requires an
+ * active pop-up approver on `ctx.context`.
+ */
+export async function connectWallets(ctx: ActionContext): Promise<void> {
+  const { page, log } = ctx;
+
+  log("Clicking Connect");
+  await page
+    .locator('[data-testid="connect-wallet-button"]')
+    .first()
+    .click({ timeout: STEP_TIMEOUT_MS });
+
+  log(`Selecting BTC wallet: ${ctx.btc.id}`);
+  await page
+    .locator('[data-testid="select-bitcoin-wallet-button"]')
+    .click({ timeout: STEP_TIMEOUT_MS });
+  await page
+    .locator(`[data-testid="wallet-option-${ctx.btc.id as BtcWalletId}"]`)
+    .click({ timeout: STEP_TIMEOUT_MS });
+  // Wait for the BTC approval popup to be handled and the app to register the address.
+  await page.waitForTimeout(APPROVAL_WAIT_MS);
+
+  log(`Selecting ETH wallet: ${ctx.eth.id}`);
+  await page
+    .locator('[data-testid="select-ethereum-wallet-button"]')
+    .click({ timeout: STEP_TIMEOUT_MS });
+  await page
+    .getByText(ETH_APPKIT_NAME[ctx.eth.id] ?? /metamask/i, { exact: false })
+    .first()
+    .click({ timeout: STEP_TIMEOUT_MS });
+  await page.waitForTimeout(APPROVAL_WAIT_MS);
+
+  log("Finalizing (Connect)");
+  await page
+    .locator('[data-testid="chains-connect-button"]')
+    .click({ timeout: STEP_TIMEOUT_MS })
+    .catch(() => {});
+
+  log("Waiting for connected state (deposit button)");
+  await page
+    .locator('[data-testid="deposit-button"]')
+    .first()
+    .waitFor({ state: "visible", timeout: STEP_TIMEOUT_MS });
+}
+
+/**
+ * Open the connected wallet menu. core-ui's `Menu` clones the trigger (the avatar group) and adds
+ * `aria-haspopup="true"` + toggles `aria-expanded`, rendering the address cards in a Popover when open.
+ * Click the haspopup trigger and confirm the menu opened (retry with the avatar image as a fallback).
+ */
+export async function openWalletMenu(
+  page: Page,
+  log: (m: string) => void,
+  menuOpenTimeoutMs: number,
+  headerSettleMs: number,
+): Promise<void> {
+  const isOpen = () =>
+    page
+      .getByText("Bitcoin Wallet", { exact: true })
+      .first()
+      .waitFor({ state: "visible", timeout: menuOpenTimeoutMs })
+      .then(() => true)
+      .catch(() => false);
+
+  // The header has TWO aria-haspopup triggers: the wallet avatar group and the settings gear. Target
+  // the avatar group specifically (it contains the wallet avatar images), not the gear.
+  const trigger = page
+    .locator('[aria-haspopup="true"]')
+    .filter({ has: page.locator("img.bbn-avatar-img") })
+    .first();
+  await trigger
+    .waitFor({ state: "visible", timeout: STEP_TIMEOUT_MS })
+    .catch(() => {});
+  await page.waitForTimeout(headerSettleMs); // let the header settle so the first click registers
+  await trigger.click({ force: true }).catch(() => {});
+  if (await isOpen()) return;
+
+  log("wallet menu not open — retrying the avatar trigger");
+  await page.keyboard.press("Escape").catch(() => {});
+  await trigger.click({ force: true }).catch(() => {});
+  if (await isOpen()) return;
+
+  throw new Error("Could not open the connected wallet menu");
+}

--- a/services/vault/e2e/real/cli.ts
+++ b/services/vault/e2e/real/cli.ts
@@ -7,7 +7,9 @@
  *   pnpm exec tsx e2e/real/cli.ts --target=website --network=devnet --btc=unisat --eth=metamask \
  *     --action=connect [--data=real] [--delay=0] [--yes]
  *
- * Only `connect` + `real` are implemented; other actions and mock mode show as disabled.
+ * Pegin accepts two optional extras: `--amount=<btc>` and `--vp=<name>`. When omitted, the CLI fetches
+ * the network's real values (protocol minimum deposit + provider list) and offers them as defaults —
+ * amount ⇒ minimum, provider ⇒ first available — prompting interactively. Mock mode shows as disabled.
  */
 import { createInterface, type Interface } from "node:readline/promises";
 
@@ -23,6 +25,7 @@ import {
   type RunConfig,
   type Target,
 } from "./config";
+import { fetchMinDepositBtc, fetchProviders } from "./peginParams";
 import { runE2E } from "./run";
 
 const MS_PER_SECOND = 1000;
@@ -120,8 +123,11 @@ async function resolveConfig(
   // Valid values derived from config so the flag validator can't drift from the interactive menu.
   const TARGETS: readonly Target[] = ["website", "localhost"];
   const NETWORKS_LIST: readonly NetworkName[] = ["devnet", "testnet"];
-  const BTC_IDS = BTC_WALLETS.map((w) => w.id);
-  const ETH_IDS = ETH_WALLETS.map((w) => w.id);
+  // Only enabled wallets are selectable (disabled ones — e.g. OneKey — are hidden + rejected).
+  const enabledBtcWallets = BTC_WALLETS.filter((w) => w.enabled);
+  const enabledEthWallets = ETH_WALLETS.filter((w) => w.enabled);
+  const BTC_IDS = enabledBtcWallets.map((w) => w.id);
+  const ETH_IDS = enabledEthWallets.map((w) => w.id);
   const ACTION_IDS = ACTIONS.map((a) => a.id);
 
   /**
@@ -170,7 +176,7 @@ async function resolveConfig(
         select<BtcWalletId>(
           rl,
           "3. BTC wallet",
-          BTC_WALLETS.map((w) => ({ value: w.id, label: w.label })),
+          enabledBtcWallets.map((w) => ({ value: w.id, label: w.label })),
         ),
       "btc",
     );
@@ -182,7 +188,7 @@ async function resolveConfig(
         select<EthWalletId>(
           rl,
           "4. ETH wallet",
-          ETH_WALLETS.map((w) => ({ value: w.id, label: w.label })),
+          enabledEthWallets.map((w) => ({ value: w.id, label: w.label })),
         ),
       "eth",
     );
@@ -231,6 +237,66 @@ async function resolveConfig(
       delayMs = Math.max(0, Math.round((Number(raw) || 0) * MS_PER_SECOND));
     }
 
+    // Pegin extras. A flag always wins; otherwise, for the pegin action, fetch the network's real
+    // values (like the balance pre-flight) and offer them as defaults — amount ⇒ protocol minimum,
+    // provider ⇒ first available — prompting interactively when there's a TTY.
+    let peginAmountBtc =
+      typeof flags.amount === "string" ? flags.amount : undefined;
+    if (peginAmountBtc !== undefined) {
+      const parsed = Number(peginAmountBtc);
+      if (!Number.isFinite(parsed) || parsed <= 0)
+        throw new Error(
+          `--amount must be a positive number of BTC (got "${peginAmountBtc}")`,
+        );
+    }
+    let peginProvider = typeof flags.vp === "string" ? flags.vp : undefined;
+
+    if (action === "pegin") {
+      // Amount: default to the fetched protocol minimum for this network (unless --amount given).
+      if (peginAmountBtc === undefined) {
+        const minBtc = await fetchMinDepositBtc(network).catch((error) => {
+          // eslint-disable-next-line no-console
+          console.warn(
+            `\nCould not fetch the minimum deposit (${error instanceof Error ? error.message : error}); the run will fall back to the form's minimum.`,
+          );
+          return undefined;
+        });
+        if (interactive) {
+          const hint = minBtc
+            ? `${minBtc} = protocol minimum`
+            : "protocol minimum";
+          const raw = (
+            await rl.question(`\nPegin amount in BTC [${hint}]: `)
+          ).trim();
+          peginAmountBtc = raw || minBtc;
+        } else {
+          peginAmountBtc = minBtc; // non-interactive: use the fetched minimum
+        }
+      }
+
+      // Provider: interactive menu from the live list (default = first available); --vp overrides.
+      if (peginProvider === undefined && interactive) {
+        const providers = await fetchProviders(network).catch((error) => {
+          // eslint-disable-next-line no-console
+          console.warn(
+            `\nCould not fetch providers (${error instanceof Error ? error.message : error}); the run will pick the first available.`,
+          );
+          return [];
+        });
+        const available = providers.filter((p) => p.available);
+        if (available.length > 0)
+          peginProvider = await select(
+            rl,
+            "Vault provider",
+            available.map((p) => ({ value: p.name, label: p.name })),
+          );
+      }
+    }
+
+    // Sign-conformance extra: explicit fixtures file (else the action auto-detects the newest pegin's).
+    const fixturesPath =
+      typeof flags.fixtures === "string" ? flags.fixtures : undefined;
+
     return {
       target,
       network,
@@ -239,6 +305,9 @@ async function resolveConfig(
       action,
       dataMode,
       delayMs,
+      peginAmountBtc,
+      peginProvider,
+      fixturesPath,
     };
   } finally {
     rl.close();

--- a/services/vault/e2e/real/config.ts
+++ b/services/vault/e2e/real/config.ts
@@ -1,9 +1,9 @@
 /**
  * Static configuration + run-config types for the real-wallet E2E CLI.
  *
- * Only `connect` (action) and `real` (data mode) are implemented today; the other actions and mock
- * mode are declared here as disabled so the CLI can show the roadmap and so the shape is ready to
- * extend (see `actions/index.ts`).
+ * The `connect`, `observe`, `wallet-config`, and `pegin` actions are implemented (all `real` data
+ * mode); the remaining actions and mock mode are declared here as disabled so the CLI can show the
+ * roadmap and so the shape is ready to extend (see `actions/index.ts`).
  */
 import type { SupportedWallet } from "./connector";
 
@@ -12,7 +12,15 @@ export type NetworkName = "devnet" | "testnet";
 export type BtcWalletId = "unisat" | "okx" | "onekey";
 export type EthWalletId = "metamask";
 export type DataMode = "real" | "mock";
-export type ActionId = "connect" | "pegin" | "borrow" | "repay" | "withdraw";
+export type ActionId =
+  | "connect"
+  | "observe"
+  | "wallet-config"
+  | "pegin"
+  | "sign-conformance"
+  | "borrow"
+  | "repay"
+  | "withdraw";
 
 /** Maps our lowercase wallet ids to the connector's SupportedWallet keys. */
 export const BTC_WALLET_TO_CONNECTOR: Record<BtcWalletId, SupportedWallet> = {
@@ -34,6 +42,12 @@ export interface NetworkConfig {
   /** Sepolia RPC + chain id used for the ETH balance pre-flight. */
   sepoliaRpcUrl: string;
   ethChainId: number;
+  /**
+   * Vite mode whose env the app resolves for this network (`pnpm dev` ⇒ `development`, `dev:testnet`
+   * ⇒ `dev-testnet`). The pegin pre-flight loads the contract addresses + endpoints from that mode's
+   * env (see peginParams.ts) rather than hardcoding them — they rotate via `scripts/sync-env.mjs`.
+   */
+  viteMode: string;
 }
 
 const SIGNET_MEMPOOL = "https://mempool.space/signet/api";
@@ -47,6 +61,7 @@ export const NETWORKS: Record<NetworkName, NetworkConfig> = {
     mempoolApiBase: SIGNET_MEMPOOL,
     sepoliaRpcUrl: SEPOLIA_RPC,
     ethChainId: SEPOLIA_CHAIN_ID,
+    viteMode: "development",
   },
   testnet: {
     websiteUrl: "https://btc-vaults.testnet.babylonlabs.io/",
@@ -54,22 +69,28 @@ export const NETWORKS: Record<NetworkName, NetworkConfig> = {
     mempoolApiBase: SIGNET_MEMPOOL,
     sepoliaRpcUrl: SEPOLIA_RPC,
     ethChainId: SEPOLIA_CHAIN_ID,
+    viteMode: "dev-testnet",
   },
 };
 
 export interface WalletOption<T extends string> {
   id: T;
   label: string;
+  /** Selectable in the CLI. Disabled wallets stay fully wired (importer + connector map) for an
+   *  easy re-enable, but are hidden from the menu and rejected as a flag value. */
+  enabled: boolean;
 }
 
 export const BTC_WALLETS: WalletOption<BtcWalletId>[] = [
-  { id: "unisat", label: "UniSat" },
-  { id: "okx", label: "OKX" },
-  { id: "onekey", label: "OneKey" },
+  { id: "unisat", label: "UniSat", enabled: true },
+  { id: "okx", label: "OKX", enabled: true },
+  // OneKey does not currently sign `signPsbts` correctly (batch payout/graph signing). Disabled until
+  // OneKey fixes it upstream; the importer + connector mapping remain so re-enabling is `enabled: true`.
+  { id: "onekey", label: "OneKey", enabled: false },
 ];
 
 export const ETH_WALLETS: WalletOption<EthWalletId>[] = [
-  { id: "metamask", label: "MetaMask" },
+  { id: "metamask", label: "MetaMask", enabled: true },
 ];
 
 export interface ActionOption {
@@ -80,7 +101,18 @@ export interface ActionOption {
 
 export const ACTIONS: ActionOption[] = [
   { id: "connect", label: "Connect", enabled: true },
-  { id: "pegin", label: "Pegin", enabled: false },
+  { id: "observe", label: "Observe (record a manual peg-in)", enabled: true },
+  {
+    id: "wallet-config",
+    label: "Wallet config (snapshot lock settings)",
+    enabled: true,
+  },
+  { id: "pegin", label: "Pegin", enabled: true },
+  {
+    id: "sign-conformance",
+    label: "Sign conformance (replay captured signing into this wallet)",
+    enabled: true,
+  },
   { id: "borrow", label: "Borrow", enabled: false },
   { id: "repay", label: "Repay", enabled: false },
   { id: "withdraw", label: "Withdraw", enabled: false },
@@ -96,6 +128,12 @@ export interface RunConfig {
   dataMode: DataMode;
   /** Artificial per-"wait" delay, in ms (mock-only; no-op for real connect). */
   delayMs: number;
+  /** Pegin only: BTC amount to deposit (`--amount`); the action defaults it when absent. */
+  peginAmountBtc?: string;
+  /** Pegin only: vault provider name to select (`--vp`); defaults to the first available. */
+  peginProvider?: string;
+  /** Sign-conformance only: path to a `signing.jsonl` (`--fixtures`); defaults to the newest pegin's. */
+  fixturesPath?: string;
 }
 
 /** Resolve the target URL a run should open. */

--- a/services/vault/e2e/real/connector.ts
+++ b/services/vault/e2e/real/connector.ts
@@ -14,6 +14,8 @@ export { setupMetaMaskWallet } from "../../../../packages/babylon-wallet-connect
 export { setupOKXWallet } from "../../../../packages/babylon-wallet-connector/tests/e2e/fixtures/wallets/okx";
 export { setupOneKeyWallet } from "../../../../packages/babylon-wallet-connector/tests/e2e/fixtures/wallets/onekey";
 export { setupUnisatWallet } from "../../../../packages/babylon-wallet-connector/tests/e2e/fixtures/wallets/unisat";
+export { EXTENSION_CHROME_STORE_IDS } from "../../../../packages/babylon-wallet-connector/tests/e2e/setup/downloadExtensions";
 export { deriveEthAddress } from "../../../../packages/babylon-wallet-connector/tests/e2e/setup/eth";
 export { deriveSignetTaproot } from "../../../../packages/babylon-wallet-connector/tests/e2e/setup/taproot";
+export { runtimeExtensionId } from "../../../../packages/babylon-wallet-connector/tests/e2e/utils/extensionId";
 export { addrMatches } from "../../../../packages/babylon-wallet-connector/tests/e2e/utils/walletUi";

--- a/services/vault/e2e/real/peginParams.ts
+++ b/services/vault/e2e/real/peginParams.ts
@@ -1,0 +1,128 @@
+/**
+ * Pegin-parameter pre-flight: fetch the protocol minimum deposit + the vault-provider list for the
+ * selected network — the SAME sources the web app uses — so the CLI can offer them as defaults
+ * (minimum amount, first provider) before launching the browser, network-scoped (devnet vs testnet).
+ *
+ *  - Minimum deposit: the ProtocolParams contract, read via the SDK's `ViemProtocolParamsReader`
+ *    (addresses resolved off the network's BTCVaultRegistry) — identical to the app's
+ *    `getPegInConfiguration().minimumPegInAmount`. Reused (not reimplemented) so it can't drift.
+ *  - Providers: the indexer GraphQL `GetAppProviders` query, filtered by the app controller.
+ *
+ * The contract addresses + endpoints are NOT hardcoded — they rotate (via `scripts/sync-env.mjs`) and
+ * differ per network. We resolve them exactly as the app does at runtime: Vite's `loadEnv` for the
+ * network's mode (devnet ⇒ `development`, testnet ⇒ `dev-testnet`), which layers `.env` (sync-env's
+ * output) + `.env.local` + `.env.<mode>` with the same precedence Vite gives the running dapp.
+ */
+import {
+  resolveProtocolAddresses,
+  ViemProtocolParamsReader,
+} from "@babylonlabs-io/ts-sdk/tbv/core/clients";
+import { gql, GraphQLClient } from "graphql-request";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createPublicClient, http, type Address } from "viem";
+import { sepolia } from "viem/chains";
+import { loadEnv } from "vite";
+
+import { NETWORKS, type NetworkName } from "./config";
+
+const SATS_PER_BTC = 100_000_000n;
+
+/** The vault service root (holds .env / .env.local / .env.dev-testnet), relative to this file. */
+const VAULT_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+/** A vault provider as offered in the CLI menu. `available` mirrors the app's metadata gating. */
+export interface ProviderChoice {
+  id: string;
+  name: string;
+  available: boolean;
+}
+
+interface NetworkContracts {
+  registry: Address;
+  appController: string;
+  graphqlEndpoint: string;
+  ethRpcUrl: string;
+}
+
+/**
+ * Resolve the network's contract addresses + endpoints from the app's env, exactly as the running
+ * dapp does — so a `sync-env.mjs` rotation is picked up automatically instead of going stale.
+ */
+function resolveNetworkContracts(network: NetworkName): NetworkContracts {
+  const env = loadEnv(NETWORKS[network].viteMode, VAULT_ROOT, "NEXT_PUBLIC_");
+  const registry = env.NEXT_PUBLIC_TBV_BTC_VAULT_REGISTRY;
+  const appController = env.NEXT_PUBLIC_TBV_AAVE_ADAPTER;
+  const graphqlEndpoint = env.NEXT_PUBLIC_TBV_GRAPHQL_ENDPOINT;
+  const ethRpcUrl = env.NEXT_PUBLIC_ETH_RPC_URL;
+  if (!registry || !appController || !graphqlEndpoint || !ethRpcUrl)
+    throw new Error(
+      `Missing NEXT_PUBLIC_TBV_* env for ${network} (Vite mode "${NETWORKS[network].viteMode}", dir ${VAULT_ROOT}). Run 'pnpm --filter vault sync-env' or check .env / .env.dev-testnet.`,
+    );
+  return {
+    registry: registry as Address,
+    appController,
+    graphqlEndpoint,
+    ethRpcUrl,
+  };
+}
+
+/** Format satoshis as a trimmed BTC decimal string (e.g. 1_000_000n → "0.01"), for the amount input. */
+function satsToBtc(sats: bigint): string {
+  const whole = sats / SATS_PER_BTC;
+  const frac = sats % SATS_PER_BTC;
+  if (frac === 0n) return whole.toString();
+  const fracStr = frac.toString().padStart(8, "0").replace(/0+$/, "");
+  return `${whole}.${fracStr}`;
+}
+
+/** Fetch the protocol minimum pegin amount for `network`, formatted as a BTC string. */
+export async function fetchMinDepositBtc(
+  network: NetworkName,
+): Promise<string> {
+  const { registry, ethRpcUrl } = resolveNetworkContracts(network);
+  const client = createPublicClient({
+    chain: sepolia,
+    transport: http(ethRpcUrl),
+  });
+  const addresses = await resolveProtocolAddresses(client, registry);
+  const reader = new ViemProtocolParamsReader(client, addresses.protocolParams);
+  const config = await reader.getPegInConfiguration();
+  return satsToBtc(config.minimumPegInAmount);
+}
+
+const GET_APP_PROVIDERS = gql`
+  query GetAppProviders($appController: String!) {
+    vaultProviders(where: { applicationEntryPoint: $appController }) {
+      items {
+        id
+        name
+        metadataStatus
+      }
+    }
+  }
+`;
+
+interface AppProvidersResponse {
+  vaultProviders: {
+    items: { id: string; name: string | null; metadataStatus: string | null }[];
+  };
+}
+
+/** Fetch the app's vault providers for `network` from the indexer GraphQL. */
+export async function fetchProviders(
+  network: NetworkName,
+): Promise<ProviderChoice[]> {
+  const { graphqlEndpoint, appController } = resolveNetworkContracts(network);
+  const client = new GraphQLClient(graphqlEndpoint);
+  const response = await client.request<AppProvidersResponse>(
+    GET_APP_PROVIDERS,
+    { appController },
+  );
+  return response.vaultProviders.items.map((p) => ({
+    id: p.id,
+    name: p.name ?? p.id,
+    // The app treats a null / "ok" metadataStatus as usable and any other value (rejected) as not.
+    available: p.metadataStatus == null || p.metadataStatus === "ok",
+  }));
+}

--- a/services/vault/e2e/real/peginParams.ts
+++ b/services/vault/e2e/real/peginParams.ts
@@ -31,6 +31,9 @@ const SATS_PER_BTC = 100_000_000n;
 /** The vault service root (holds .env / .env.local / .env.dev-testnet), relative to this file. */
 const VAULT_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 
+/** Networks whose resolved env we've already surfaced, so we log it once per process (not per call). */
+const loggedNetworks = new Set<NetworkName>();
+
 /** A vault provider as offered in the CLI menu. `available` mirrors the app's metadata gating. */
 export interface ProviderChoice {
   id: string;
@@ -59,6 +62,24 @@ function resolveNetworkContracts(network: NetworkName): NetworkContracts {
     throw new Error(
       `Missing NEXT_PUBLIC_TBV_* env for ${network} (Vite mode "${NETWORKS[network].viteMode}", dir ${VAULT_ROOT}). Run 'pnpm --filter vault sync-env' or check .env / .env.dev-testnet.`,
     );
+
+  // Surface which network's values were resolved (once per process), and warn loudly if they look
+  // like they came from another network — `loadEnv` merges shared `.env` under the mode file, so a key
+  // missing from `.env.<mode>` would silently inherit e.g. devnet's value. The endpoint host naming
+  // (…vault-devnet… / …testnet…) is a cheap cross-check for that footgun.
+  if (!loggedNetworks.has(network)) {
+    loggedNetworks.add(network);
+    // eslint-disable-next-line no-console
+    console.log(
+      `[pegin-params] ${network}: registry ${registry}, graphql ${graphqlEndpoint}`,
+    );
+    if (!graphqlEndpoint.includes(network))
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[pegin-params] ⚠️ ${network}: GraphQL endpoint "${graphqlEndpoint}" does not mention "${network}" — env may be resolving another network's values (a key missing from .env.${NETWORKS[network].viteMode}?).`,
+      );
+  }
+
   return {
     registry: registry as Address,
     appController,

--- a/services/vault/e2e/real/timing.ts
+++ b/services/vault/e2e/real/timing.ts
@@ -23,3 +23,46 @@ export const APPROVE_ROUND_MS = 1_500;
  * is unticked — fails fast and the next round retries, instead of blocking the whole loop.
  */
 export const APPROVE_CLICK_TIMEOUT_MS = 3_000;
+
+// ── pegin: deposit form ──────────────────────────────────────────────────────
+/** Let the deposit form recompute (fees, validation) after each input; also the CTA-poll cadence. */
+export const FORM_SETTLE_MS = 1_000;
+/** The vault-provider list to render after expanding the accordion. */
+export const PROVIDER_LIST_TIMEOUT_MS = 15_000;
+/**
+ * The form CTA to become the enabled "Deposit" — it relabels through "Enter an amount" → "Select a
+ * vault provider" → "Calculating fees…" → "Checking for inscriptions…" as fee estimation + the
+ * inscription check complete, so this must outlast those async passes.
+ */
+export const DEPOSIT_CTA_ENABLE_TIMEOUT_MS = 90_000;
+
+// ── pegin: step machine ──────────────────────────────────────────────────────
+/**
+ * Overall budget for the 15-step signing machine. It spans multiple on-chain gates — Pre-PegIn
+ * inclusion (~10 min/block), the WOTS-key gate (~20 min), and the payout gate (~3 min) — so a real
+ * peg-in runs 30 min–2 hr. Budgeted generously; the action imposes NO short per-step timeout.
+ */
+export const PEGIN_STEP_MACHINE_BUDGET_MS = 2.5 * 60 * 60 * 1_000;
+/** How often to poll the progress UI (advance the step log, handle the Activate/Skip dapp gates). */
+export const PEGIN_POLL_INTERVAL_MS = 3_000;
+/**
+ * The activated vault to surface as collateral on the dashboard after "Go to Dashboard" — it appears
+ * optimistically ("Activating collateral…") but can lag the indexer catching up.
+ */
+export const DASHBOARD_VAULT_TIMEOUT_MS = 60_000;
+
+// ── sign-conformance (per-wallet signing replay) ─────────────────────────────
+/**
+ * Budget for one signing call to resolve (popup open → approver confirms → signature returned). A
+ * `signPsbts` of 9 can fan out to several sequential pop-ups, so this is generous; a stuck call fails
+ * the fixture (its pop-up DOM is already snapshotted) instead of hanging the run.
+ */
+export const SIGN_CALL_TIMEOUT_MS = 90_000;
+/**
+ * Wait for a wallet's approval UI to render before the first approve attempt. OKX parses the PSBT(s)
+ * before showing its Confirm — unlike UniSat, which is instant — so this must be generous (the active
+ * approval driver then keeps polling, so a slower render is still handled up to SIGN_CALL_TIMEOUT_MS).
+ */
+export const POPUP_OPEN_WAIT_MS = 5_000;
+/** Let the dapp settle any post-connection navigation before driving direct provider sign calls. */
+export const POST_CONNECT_SETTLE_MS = 5_000;


### PR DESCRIPTION
Closes https://github.com/babylonlabs-io/babylon-toolkit/issues/2006

## What this PR does

This adds the ability to drive a **real** BTC peg-in from start to finish using real browser wallet extensions, inside the existing real-wallet E2E CLI (`services/vault/e2e/real/`). Before this PR the CLI could only connect wallets; now it can complete the whole deposit journey — lock BTC on signet, sign everything, and end up with an activated vault on the dashboard — the way a real user would, with no mocking.

Concretely:

- **New `pegin` action** — runs a full single-vault peg-in end-to-end: connect wallets → fill the deposit form (amount + vault provider) → walk all 15 deposit-flow steps → finish at the activated vault on the dashboard. Auto-approves every wallet pop-up along the way (the BTC signing prompts and the two MetaMask transactions). Verified green end-to-end with UniSat on devnet.
- **New `sign-conformance` action** — replays the exact `signMessage` / `signPsbt` / `signPsbts` calls a real peg-in made into a *different* wallet, and checks each one produces a signature. This validates a new wallet's signing in ~3 minutes instead of running a full 30 min–2 hr peg-in. Used it to confirm OKX signs everything correctly (5/5).
- **New `observe` and `wallet-config` helper actions** — `observe` records one human-driven peg-in as ground truth (so the automation is written against a real recording, not guessed); `wallet-config` snapshots each wallet's settings UI (used to figure out the auto-lock controls).
- **Broadened the pop-up approver** — it now handles MetaMask transaction confirmations, UniSat's "type CONFIRM to continue" risk gate, and the batch "Sign all N transactions at once" button, across many rounds.
- **Recording layer** — every run can capture a Playwright trace, the network calls, and (new) the real wallet signing inputs/outputs (`signing.jsonl`) — the fixtures the `sign-conformance` action replays.
- **Deposit amount + provider are fetched live** — when you run `pegin`, the CLI fetches the protocol minimum deposit (from the on-chain ProtocolParams contract, via the SDK reader) and the vault-provider list (from the indexer GraphQL) for the chosen network, and offers them as defaults (amount = minimum, provider = first). You can override with `--amount` / `--vp`. The contract addresses and endpoints are read from the app's own env per network (via Vite `loadEnv`), so they are never hardcoded and can't go stale when they rotate.
- **Wallet auto-lock hardening** — each wallet's auto-lock timeout is raised/verified in the connector importers so a wallet can't lock itself in the middle of a 30 min–2 hr run.
- **OneKey disabled in the CLI** — OneKey does not currently sign `signPsbts` correctly, so it's turned off in the wallet list (and rejected as a flag value). It stays fully wired so re-enabling is a one-line change once OneKey fixes it upstream.

## Why

The real user journey that actually moves value — locking BTC to mint a borrowable vault — was only ever tested by hand. A real peg-in is 15 steps across ~30 min–2 hr (Bitcoin confirmations, a 20-min WOTS gate, a 3-min payout gate, VP/council signing, on-chain activation), so manual testing is slow, fragile, and rarely repeated across wallets. Driving the *real* extensions against the *real* dApp catches the bugs that mocked tests miss — wallet API drift, per-wallet signing quirks, contract/endpoint changes — because nothing is faked.

## Approaches we considered, and why we chose this one

- **Observe-first + record, vs blind automation.** A real peg-in spends real (test) funds and isn't cheaply repeatable, so guessing selectors blind would burn funds and time discovering a wrong click at step 8. We instead record one human-driven peg-in as ground truth and write the automation against that recording. Chosen because it makes the expensive path deterministic to build.
- **`sign-conformance` replay, vs a full peg-in per wallet.** Every wallet imports the same seed, so the same BTC key signs — which means the PSBTs one wallet signed are re-signable by any other wallet. We capture the real signing calls once and replay them into OKX/OneKey to check their signing in minutes, instead of a 30 min–2 hr peg-in each. Chosen because it cuts per-wallet validation from hours to minutes.
- **Active-poll approver for signing, vs event-driven.** OKX reuses a single approval window and parses PSBTs for a few seconds before showing its Confirm button, so an event-driven approver (which reacts only when a *new* window opens) missed reused-window approvals and stalled. The `sign-conformance` action instead polls every open wallet window and clicks Confirm once it's live. Chosen because it's robust to how a wallet actually surfaces approvals.
- **Fetch params from the app's env, vs hardcoding them.** The deposit minimum and vault-provider list differ per network, and the contract addresses rotate (via `scripts/sync-env.mjs`). Hardcoding them would silently go stale. We resolve them exactly as the running dApp does — Vite `loadEnv` for the network's mode — so the CLI always tracks the app. Chosen after hardcoded addresses were caught as a drift risk in review.
- **Tolerant finish-line matching, vs exact copy strings.** The deployed build's copy can differ from the source (we hit this: the activated screen renders "Vault activated" on devnet but "BTC Vault activated" in source). So we key the finish on the stable actionable control (the "Go to Dashboard" button) with tolerant matching, not exact heading text. Chosen so a copy tweak can't strand a run at the final screen.

## What's verified

- UniSat single-vault peg-in: completed end-to-end on devnet (website target).
- OKX `sign-conformance`: 5/5 (message, psbt, psbts × 1/5/9).
- Wallet auto-lock: the four per-wallet importer specs pass headed.
- Live param fetch: devnet and testnet each return the correct minimum + provider list.
- Lint and type-check pass across `services/vault/e2e/real`.

## Known limitations / follow-ups

- The `pegin` action still uses the event-driven approver (not the active-poll one from `sign-conformance`). It handled OKX fine in practice, but OKX's reused-window/parse-delay *could* flake on the batch steps; porting the active driver into the pegin approver is a fast-follow. UniSat is the fully proven pegin path.
- No resume: a run that dies after the Pre-PegIn broadcast leaves an in-flight on-chain deposit that must be resumed by hand, not restarted.
- **Two-vault (split) peg-in is the next task**, tracked in https://github.com/babylonlabs-io/babylon-toolkit/issues/2011 (details in `markdown/ai/4 - multi pegin.md`).

## Where to look

- CLI: `services/vault/e2e/real/` — `actions/{pegin,signConformance,observe,walletConfig,connect,walletConnect,approver,recording}.ts`, `peginParams.ts`, `cli.ts`, `config.ts`, `timing.ts`.
- Wallet auto-lock: `packages/babylon-wallet-connector/tests/e2e/fixtures/wallets/{unisat,metamask,okx,onekey}.ts`.
- Design docs: `markdown/ai/3 - real pegin.md` (this work) and `markdown/ai/4 - multi pegin.md` (next).

## How to run

Single-vault peg-in (real funds, ~30 min–2 hr, headed):

`pnpm exec tsx services/vault/e2e/real/cli.ts --target=website --network=devnet --btc=unisat --eth=metamask --action=pegin --data=real --yes`

Validate a wallet's signing without a peg-in (~3 min, headed):

`pnpm exec tsx services/vault/e2e/real/cli.ts --target=website --network=devnet --btc=okx --eth=metamask --action=sign-conformance --data=real --yes`
