### PR TITLE
feat(vault): gate the v3 UI behind an ENABLE_V3_UI feature flag

### DIFF
--- a/services/vault/.env.example
+++ b/services/vault/.env.example
@@ -65,6 +65,10 @@ NEXT_PUBLIC_REOWN_PROJECT_ID=your-reown-project-id-here
 # NEXT_PUBLIC_FF_PROTOCOL_PAUSED=true
 # Optional override for the frozen/paused banner body text; leave unset to use the default per-status copy.
 # NEXT_PUBLIC_PROTOCOL_STATUS_MESSAGE=
+# Switches the app to the v3 sidebar shell and its per-page routes. Off (the default) keeps today's v2
+# header + top-nav dashboard, with the v3-only routes unreachable. Temporary scaffolding for the v3
+# rebuild — removed together with the v2 shell once v3 becomes the default.
+# NEXT_PUBLIC_FF_ENABLE_V3_UI=true
 # Freeform notice banner shown at the top of the app (e.g. for intermittent
 # peg-in errors or degraded service). Leave blank to hide. Independent of
 # NEXT_PUBLIC_FF_DISABLE_DEPOSIT — a notice can be shown while deposits stay on.

--- a/services/vault/src/__tests__/router.test.tsx
+++ b/services/vault/src/__tests__/router.test.tsx
@@ -7,6 +7,8 @@
  * 2. The reserve detail (/app/aave/reserve/:reserveId) is an overlay on top of
  *    the dashboard, not a sibling route that replaces it. The dashboard must
  *    stay mounted underneath so opening the overlay never blanks the page.
+ * 3. The v3-only sections are reachable only when ENABLE_V3_UI is on. With the
+ *    flag off a direct load of one of them redirects to the v2 dashboard.
  *
  * These tests lock in that wiring so a future router refactor can't silently
  * regress it.
@@ -16,7 +18,21 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { MemoryRouter, Outlet } from "react-router";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const featureFlagsState = vi.hoisted(() => ({ isV3UiEnabled: false }));
+
+vi.mock("@/config/featureFlags", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/config/featureFlags")>();
+  return {
+    default: Object.create(actual.default, {
+      isV3UiEnabled: {
+        get: () => featureFlagsState.isV3UiEnabled,
+        enumerable: true,
+      },
+    }),
+  };
+});
 
 vi.mock("../components/pages/RootLayout", () => ({
   default: () => <Outlet context={{ openDeposit: () => {} }} />,
@@ -182,4 +198,55 @@ describe("Router — reserve detail is an overlay over the persistent dashboard"
       "borrow",
     );
   });
+});
+
+describe("Router — v3-only routes are gated on the ENABLE_V3_UI flag", () => {
+  const V3_ROUTE_PATHS = ["vaults", "loans", "liquidations"];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    featureFlagsState.isV3UiEnabled = false;
+  });
+
+  afterEach(() => {
+    featureFlagsState.isV3UiEnabled = false;
+  });
+
+  it.each(V3_ROUTE_PATHS)(
+    "redirects a direct load of /%s to the v2 dashboard while the flag is off",
+    async (path) => {
+      await renderAt(`/${path}`);
+
+      await waitFor(() => {
+        expect(screen.getByText(DASHBOARD_MARKER)).toBeInTheDocument();
+      });
+      expect(screen.queryByText("Page not found")).not.toBeInTheDocument();
+    },
+  );
+
+  it.each(V3_ROUTE_PATHS)(
+    "redirects a deep link under /%s, not just the section root",
+    async (path) => {
+      await renderAt(`/${path}/some-deep-link`);
+
+      await waitFor(() => {
+        expect(screen.getByText(DASHBOARD_MARKER)).toBeInTheDocument();
+      });
+      expect(screen.queryByText("Page not found")).not.toBeInTheDocument();
+    },
+  );
+
+  it.each(V3_ROUTE_PATHS)(
+    "stops redirecting /%s to the dashboard once the flag is on",
+    async (path) => {
+      featureFlagsState.isV3UiEnabled = true;
+
+      await renderAt(`/${path}`);
+
+      await waitFor(() => {
+        expect(screen.getByText("Page not found")).toBeInTheDocument();
+      });
+      expect(screen.queryByText(DASHBOARD_MARKER)).not.toBeInTheDocument();
+    },
+  );
 });

--- a/services/vault/src/config/featureFlags.ts
+++ b/services/vault/src/config/featureFlags.ts
@@ -157,6 +157,24 @@ export default {
   },
 
   /**
+   * ENABLE_V3_UI feature flag
+   *
+   * Purpose: Switches the app shell from today's v2 header + top-nav +
+   * single-page dashboard over to the v3 sidebar shell and its per-page routes.
+   * Why needed: v3 is a full UI restructure landing incrementally across many
+   * PRs. The flag keeps `main` shipping v2 while v3 is built, and lets the flag
+   * be turned on per environment (devnet → testnet → mainnet) without a code
+   * change.
+   * Unlike the DISABLE_DEPOSIT / PROTOCOL_PAUSED kill-switches, this is
+   * temporary scaffolding: it is deleted together with the v2 shell once v3
+   * becomes the default.
+   * Default: false (the v2 shell renders unless explicitly set to "true")
+   */
+  get isV3UiEnabled() {
+    return process.env.NEXT_PUBLIC_FF_ENABLE_V3_UI === "true";
+  },
+
+  /**
    * NOTICE_BANNER_MESSAGE config
    *
    * Purpose: Operator-controlled freeform banner shown at the top of the app

--- a/services/vault/src/router.tsx
+++ b/services/vault/src/router.tsx
@@ -2,6 +2,8 @@ import { Loader } from "@babylonlabs-io/core-ui";
 import { Suspense, useEffect, type ComponentType } from "react";
 import { Navigate, Outlet, Route, Routes } from "react-router";
 
+import featureFlags from "@/config/featureFlags";
+
 import { getAllApplications } from "./applications";
 import { AAVE_APP_ID } from "./applications/aave/config";
 import { LOAN_TAB } from "./applications/aave/constants";
@@ -28,6 +30,9 @@ const importAaveReserveDetail = () =>
 const AaveReserveDetail = lazyWithRetry(() =>
   importAaveReserveDetail().then((m) => ({ default: m.AaveReserveDetail })),
 );
+
+// Guarded as whole subtrees, so a v3 deep link redirects rather than 404s.
+const V3_ROUTE_PATHS = ["vaults", "loans", "liquidations"] as const;
 
 const RouteFallback = () => (
   <div className="flex min-h-[50vh] items-center justify-center">
@@ -128,6 +133,14 @@ export const Router = () => {
           );
         })}
       </Route>
+      {!featureFlags.isV3UiEnabled &&
+        V3_ROUTE_PATHS.map((path) => (
+          <Route
+            key={path}
+            path={`${path}/*`}
+            element={<Navigate to="/" replace />}
+          />
+        ))}
       <Route path="*" element={<NotFound />} />
     </Routes>
   );


### PR DESCRIPTION
Add the isV3UiEnabled getter (NEXT_PUBLIC_FF_ENABLE_V3_UI) following the existing opt-in convention, and guard the v3-only sections at the router so they are unreachable while the flag is off.

The v3 sections are guarded as whole subtrees (`vaults/*` rather than `vaults`), so a direct load or a stale deep link redirects to the v2 dashboard instead of falling through to the 404 route once the nested v3 routes land.

Unlike the DISABLE_DEPOSIT / PROTOCOL_PAUSED kill-switches this flag is temporary scaffolding: it keeps main shipping the v2 dashboard while v3 lands incrementally, and is removed together with the v2 shell once v3 becomes the default.

The v3 shell and its pages are out of scope here and land behind this flag in the follow-up issues.

Closes #2014