### PR TITLE
test(vault): add two-vault (split) peg-in to the real-wallet E2E CLI

### DIFF
--- a/services/vault/e2e/real/actions/pegin.ts
+++ b/services/vault/e2e/real/actions/pegin.ts
@@ -6,9 +6,15 @@
  *   - DAPP actions (this file drives them on `ctx.page`): open the deposit form, enter the amount,
  *     select a vault provider, submit, click "Sign Transaction" to start signing, then — mid-flow —
  *     acknowledge + "Activate Vault", "Skip" the artifact download, and finally "Go to Dashboard".
- *   - WALLET actions (the shared pop-up approver handles them on the chrome-extension pop-ups): the 8
- *     UniSat BTC signing prompts and the 2 MetaMask ETH transactions. The approver is installed for
+ *   - WALLET actions (the shared pop-up approver handles them on the chrome-extension pop-ups): the
+ *     UniSat BTC signing prompts and the MetaMask ETH transactions. The approver is installed for
  *     the WHOLE run (unlike observe, which uninstalls it) so every pop-up auto-approves.
+ *
+ * With `--split` (`ctx.config.split`) the same flow runs a TWO-VAULT split deposit: the form's
+ * "Two-vault split" option is selected (one provider, two HTLC outputs), and from the per-vault phase
+ * the progress view fans into two columns — so there are more signing pop-ups and TWO Activate-Vault
+ * ETH txs. The step machine handles both (the approver + re-armed Activate/Skip gates), and finishes
+ * only when both columns reach the shared activated view.
  *
  * The 15-step machine is walked by AWAITING UI transitions (the `role="progressbar"` and the active
  * step's `aria-label="Step N active"`), never fixed sleeps, and tolerates the multi-minute on-chain
@@ -33,6 +39,7 @@ import {
   PEGIN_POLL_INTERVAL_MS,
   PEGIN_STEP_MACHINE_BUDGET_MS,
   PROVIDER_LIST_TIMEOUT_MS,
+  SPLIT_ALLOCATION_TIMEOUT_MS,
   STEP_TIMEOUT_MS,
 } from "../timing";
 
@@ -50,7 +57,20 @@ const AMOUNT_PLACEHOLDER = "0"; // DepositForm amount input
 const SELECT_VP_LABEL = "Select vault provider"; // COPY.deposit.form.selectVaultProvider
 const DEPOSIT_CTA_LABEL = "Deposit"; // enabled DepositForm CTA (fluid button)
 const SIGN_TRANSACTION_LABEL = "Sign Transaction"; // COPY.deposit.progress.buttons.signTransaction
-const ACTIVATE_VAULT_LABEL = "Activate Vault"; // COPY.deposit.activateConfirmation.activateButton
+// The activation modal's confirm button. Selected testid-first (stable + text-independent) with a
+// tolerant-text fallback: the button copy drifts (COPY.deposit.activateConfirmation.activateButton
+// renders "Activate vault", lowercase v — an exact string silently stalled the run here), and the
+// data-testid isn't on the deployed build until it ships, so the fallback carries the current build.
+const ACTIVATE_VAULT_TESTID = '[data-testid="activate-vault-button"]';
+const ACTIVATE_VAULT_RX = /activate vault/i; // COPY.deposit.activateConfirmation.activateButton
+
+/** The activation modal's confirm button — testid if present (future-proof), else tolerant wording. */
+function activateButton(page: Page): Locator {
+  return page
+    .locator(ACTIVATE_VAULT_TESTID)
+    .or(page.getByRole("button", { name: ACTIVATE_VAULT_RX }))
+    .first();
+}
 const RISK_ACK_LABEL =
   "I understand the risks of continuing without the artifacts."; // riskAcknowledgement
 const SKIP_LABEL = "Skip"; // COPY.deposit.inStepArtifact.skip
@@ -61,6 +81,11 @@ const SKIP_LABEL = "Skip"; // COPY.deposit.inStepArtifact.skip
 const GO_TO_DASHBOARD_RX = /go to dashboard/i; // COPY.deposit.vaultActivatedSuccess.goToDashboard
 const VAULT_OPTIONS_RX = /vault options/i; // CollateralSection ExpandMenuButton aria-label ("[BTC ]Vault options")
 const VAULT_CARD_TESTID = '[data-testid="vault-card"]'; // CollateralVaultItem VaultCardShell (stable testid)
+// Two-vault split: the UtxoSplitSelector is an Accordion with NO testids (rows are `role="button"`
+// divs), so it's driven by role + visible text. The selector header shows "Do not split" while
+// single-vault (the default) and relabels to the split option once enabled.
+const DO_NOT_SPLIT_TEXT = "Do not split"; // COPY.deposit.form.doNotSplit
+const TWO_VAULT_SPLIT_RX = /Two-vault split/; // COPY.deposit.form.splitOptionLabel / TWO_VAULT_SPLIT_NAME
 
 /**
  * Fill the deposit form (amount → provider → submit). The form has almost no testids, so selectors
@@ -72,9 +97,10 @@ async function fillDepositForm(
   log: (m: string) => void,
   amountBtc: string,
   provider: string | undefined,
+  split: boolean,
 ): Promise<void> {
   log(
-    `Opening deposit form (amount ${amountBtc} sBTC, provider ${provider ?? "first available"})`,
+    `Opening deposit form (${split ? "two-vault split, " : ""}amount ${amountBtc} sBTC, provider ${provider ?? "first available"})`,
   );
   await page
     .locator(DEPOSIT_BUTTON_TESTID)
@@ -86,11 +112,83 @@ async function fillDepositForm(
   await amount.fill(amountBtc);
   await page.waitForTimeout(FORM_SETTLE_MS);
 
+  if (split) await enableTwoVaultSplit(page, log, amountBtc);
+
   await selectVaultProvider(page, log, provider);
 
   const cta = await waitForDepositCta(page, log);
   log("Deposit CTA enabled — submitting the form");
   await cta.click();
+}
+
+/**
+ * Switch the deposit into a two-vault split. Expand the `UtxoSplitSelector` (its header shows the
+ * current choice — "Do not split" while single-vault), wait for the "Two-vault split" row to leave its
+ * `aria-disabled` state (it stays disabled while the allocation computes and whenever the amount is
+ * below the split minimum), then select it. If it never enables, the amount is below the form's split
+ * minimum — surface the form's own `role="status"` threshold hint and fail loudly rather than silently
+ * fall back to a single vault (real funds; never guess an amount).
+ */
+async function enableTwoVaultSplit(
+  page: Page,
+  log: (m: string) => void,
+  amountBtc: string,
+): Promise<void> {
+  log("Enabling two-vault split");
+  const splitRow = page
+    .getByRole("button", { name: TWO_VAULT_SPLIT_RX })
+    .first();
+
+  // Expand the selector if the option rows aren't visible yet (collapsed header shows "Do not split").
+  if (!(await splitRow.isVisible().catch(() => false))) {
+    const header = page
+      .getByRole("button", { name: DO_NOT_SPLIT_TEXT })
+      .first();
+    if (await header.isVisible().catch(() => false))
+      await header.click().catch(() => {});
+  }
+  await splitRow.waitFor({ state: "visible", timeout: STEP_TIMEOUT_MS });
+
+  // Poll for the row to leave aria-disabled (allocation resolved AND amount clears the split minimum).
+  const deadline = Date.now() + SPLIT_ALLOCATION_TIMEOUT_MS;
+  let disabled = await splitRow.getAttribute("aria-disabled").catch(() => null);
+  while (disabled === "true" && Date.now() < deadline) {
+    await page.waitForTimeout(FORM_SETTLE_MS);
+    disabled = await splitRow.getAttribute("aria-disabled").catch(() => null);
+  }
+  if (disabled === "true") {
+    const hint = (
+      await page
+        .getByRole("status")
+        .first()
+        .innerText()
+        .catch(() => "")
+    )
+      .replace(/\s+/g, " ")
+      .trim();
+    throw new Error(
+      `Two-vault split stayed unavailable for ${amountBtc} sBTC — the form keeps it disabled${hint ? ` ("${hint}")` : ""}. Increase --amount above the split minimum.`,
+    );
+  }
+
+  await splitRow.click();
+  await page.waitForTimeout(FORM_SETTLE_MS);
+
+  // Confirm the split took: the selector header relabels to the split option ("Two-vault split - <ratio>").
+  const selectedLabel = (
+    await page
+      .getByRole("button", { name: TWO_VAULT_SPLIT_RX })
+      .first()
+      .innerText()
+      .catch(() => "")
+  )
+    .replace(/\s+/g, " ")
+    .trim();
+  log(
+    selectedLabel
+      ? `Two-vault split selected: "${selectedLabel}"`
+      : "⚠️ Clicked the two-vault split row but could not confirm the split label.",
+  );
 }
 
 /**
@@ -195,9 +293,7 @@ async function handleActivateConfirmation(
   page: Page,
   log: (m: string) => void,
 ): Promise<boolean> {
-  const activate = page
-    .getByRole("button", { name: ACTIVATE_VAULT_LABEL, exact: true })
-    .first();
+  const activate = activateButton(page);
   if (!(await activate.isVisible().catch(() => false))) return false;
 
   const checkbox = page.locator('[data-testid="checkbox-input"]').first();
@@ -257,14 +353,28 @@ async function readPrePeginTxid(page: Page): Promise<string | undefined> {
   return undefined;
 }
 
-/** Read the active step for the run log: "Step N active (P%)" from the stepper + progress bar. */
+/**
+ * Read the active step(s) for the run log: "Step N active (P%)" from the stepper + progress bar. In a
+ * two-vault split the progress view shows two per-vault columns, each emitting its own
+ * `aria-label="Step N active"` (the columns carry no distinguishing testid), so we collect ALL active
+ * labels — the two lanes advance independently and may sit on different steps. The single progressbar
+ * reflects the aggregate (slowest lane).
+ */
 async function readActiveStep(page: Page): Promise<string> {
-  const active = page.locator('[aria-label$="active"]').first();
-  const label = await active.getAttribute("aria-label").catch(() => null);
+  const actives = page.locator('[aria-label$="active"]');
+  const count = await actives.count().catch(() => 0);
+  const labels: string[] = [];
+  for (let i = 0; i < count; i++) {
+    const label = await actives
+      .nth(i)
+      .getAttribute("aria-label")
+      .catch(() => null);
+    if (label && !labels.includes(label)) labels.push(label);
+  }
   const bar = page.locator('[role="progressbar"]').first();
   const percent = await bar.getAttribute("aria-valuenow").catch(() => null);
-  if (!label && percent === null) return "";
-  return `${label ?? "Step ?"} (${percent ?? "?"}%)`;
+  if (labels.length === 0 && percent === null) return "";
+  return `${labels.length ? labels.join(", ") : "Step ?"} (${percent ?? "?"}%)`;
 }
 
 /**
@@ -286,8 +396,12 @@ async function walkStepMachine(
 ): Promise<string | undefined> {
   const deadline = Date.now() + PEGIN_STEP_MACHINE_BUDGET_MS;
   let lastStep = "";
-  let activated = false;
-  let skipped = false;
+  // Per-appearance guards (NOT one-shot): a two-vault split has TWO activations, so the Activate modal
+  // and the artifact-Skip callout can each appear twice. We click once per appearance and re-arm when
+  // the control disappears — handling both vaults without double-clicking a single modal (which could
+  // fire a duplicate ETH tx).
+  let activateClickedThisModal = false;
+  let skipClickedThisCallout = false;
   let prePeginTxid: string | undefined;
 
   while (Date.now() < deadline) {
@@ -296,9 +410,28 @@ async function walkStepMachine(
     // Actively approve any reused wallet window (OKX) that the event approver can't see.
     await sweepApprovals(context, page, log);
 
-    // Two dapp-page interactions the wallet pop-up approver can't perform.
-    if (!activated) activated = await handleActivateConfirmation(page, log);
-    if (activated && !skipped) skipped = await handleArtifactSkip(page, log);
+    // Two dapp-page interactions the wallet pop-up approver can't perform, each re-armed per appearance.
+    const activateVisible = await activateButton(page)
+      .isVisible()
+      .catch(() => false);
+    if (activateVisible) {
+      if (!activateClickedThisModal)
+        activateClickedThisModal = await handleActivateConfirmation(page, log);
+    } else {
+      activateClickedThisModal = false;
+    }
+
+    const skipVisible = await page
+      .getByRole("button", { name: SKIP_LABEL, exact: true })
+      .first()
+      .isVisible()
+      .catch(() => false);
+    if (skipVisible) {
+      if (!skipClickedThisCallout)
+        skipClickedThisCallout = await handleArtifactSkip(page, log);
+    } else {
+      skipClickedThisCallout = false;
+    }
 
     // Capture the Pre-PegIn txid once, the first tick the progress view links it.
     if (!prePeginTxid) {
@@ -331,6 +464,7 @@ async function assertActivatedAndOnDashboard(
   log: (m: string) => void,
   amountBtc: string,
   prePeginTxid: string | undefined,
+  expectedVaults: number,
 ): Promise<void> {
   log("✅ Activated view reached — clicking Go to Dashboard");
   await page
@@ -366,6 +500,40 @@ async function assertActivatedAndOnDashboard(
       .first()
       .waitFor({ state: "visible", timeout: STEP_TIMEOUT_MS })
       .catch(() => {});
+  }
+
+  // Two-vault split: both fresh cards share THIS run's single (batched) Pre-PegIn txid, and each shows
+  // its own split sub-amount (not the full requested amount), so the single-vault amount cross-check
+  // below doesn't apply. The indexer commonly lags a just-activated vault's tx-hash row, so a miss here
+  // is logged (not failed) — the activated view we came from is the real signal that BOTH vaults
+  // activated (its "Go to Dashboard" only appears once every lane completes).
+  if (expectedVaults > 1) {
+    // Both fresh split cards share this run's Pre-PegIn txid, but the indexer commonly lags a
+    // just-activated vault's tx-hash row — so poll (bounded) for both cards to link the txid rather
+    // than snapshotting once and warning on a transient 1/2.
+    const matchingCards = () =>
+      prePeginTxid
+        ? cards
+            .filter({ has: page.locator(`a[href*="${prePeginTxid}"]`) })
+            .count()
+            .catch(() => 0)
+        : Promise.resolve(0);
+    let matched = await matchingCards();
+    const deadline = Date.now() + DASHBOARD_VAULT_TIMEOUT_MS;
+    while (matched < expectedVaults && Date.now() < deadline) {
+      await page.waitForTimeout(PEGIN_POLL_INTERVAL_MS);
+      matched = await matchingCards();
+    }
+    const total = await cards.count().catch(() => 0);
+    if (matched >= expectedVaults)
+      log(
+        `Dashboard shows ${matched} split vaults for this run (matched by Pre-PegIn txid ${prePeginTxid?.slice(0, 8)}…).`,
+      );
+    else
+      log(
+        `⚠️ Dashboard matched ${matched}/${expectedVaults} split vaults by Pre-PegIn txid within the wait (${total} cards total) — activation succeeded; the indexer may still be catching up to the fresh vaults' tx-hash rows.`,
+      );
+    return;
   }
 
   // A returning depositor's dashboard lists several vault cards, so `.first()` is not necessarily the
@@ -424,6 +592,7 @@ export const peginAction: Action = {
         "pegin: no deposit amount resolved — the minimum-deposit fetch failed and no --amount was given. Re-run with --amount=<btc>, or against a reachable network.",
       );
     const provider = ctx.config.peginProvider?.trim() || undefined;
+    const split = ctx.config.split ?? false;
 
     // Approver stays installed for the whole run (auto-approves every wallet pop-up).
     const handler = installPopupApprover(context, log);
@@ -441,7 +610,7 @@ export const peginAction: Action = {
       await connectWallets(ctx);
 
       currentStep = "deposit-form";
-      await fillDepositForm(page, log, amountBtc, provider);
+      await fillDepositForm(page, log, amountBtc, provider, split);
 
       currentStep = "sign-transaction";
       await startSigning(page, log);
@@ -452,8 +621,16 @@ export const peginAction: Action = {
       });
 
       currentStep = "finish";
-      await assertActivatedAndOnDashboard(page, log, amountBtc, prePeginTxid);
-      log("✅ Pegin complete: BTC Vault activated and shown on the dashboard.");
+      await assertActivatedAndOnDashboard(
+        page,
+        log,
+        amountBtc,
+        prePeginTxid,
+        split ? 2 : 1,
+      );
+      log(
+        `✅ Pegin complete: ${split ? "two BTC Vaults" : "BTC Vault"} activated and shown on the dashboard.`,
+      );
     } finally {
       await recorder.stop();
       context.off("page", handler);

--- a/services/vault/e2e/real/actions/pegin.ts
+++ b/services/vault/e2e/real/actions/pegin.ts
@@ -387,11 +387,18 @@ async function readActiveStep(page: Page): Promise<string> {
  *
  * Returns this run's Pre-PegIn txid (captured once, as soon as the progress view links it) so the
  * finish-line check can target THIS run's vault card among a returning depositor's several.
+ *
+ * `expectedVaults` (1, or 2 for a split) gates the finish: the terminal "Go to Dashboard" view is
+ * accepted only once we've driven that many activations. The app renders a TRANSIENT per-vault
+ * "Go to Dashboard" (scoped to a single vault) that can appear after just one split vault activates —
+ * so keying on that button alone could finish a split at 1/2. Counting the activations WE drove ties
+ * completion to "both vaults activated", which is exactly what we did.
  */
 async function walkStepMachine(
   page: Page,
   context: BrowserContext,
   log: (m: string) => void,
+  expectedVaults: number,
   onStep: (step: string) => void,
 ): Promise<string | undefined> {
   const deadline = Date.now() + PEGIN_STEP_MACHINE_BUDGET_MS;
@@ -402,10 +409,17 @@ async function walkStepMachine(
   // fire a duplicate ETH tx).
   let activateClickedThisModal = false;
   let skipClickedThisCallout = false;
+  // Count the activations we've driven; the finish gate needs `expectedVaults` of them (see below).
+  let activationCount = 0;
   let prePeginTxid: string | undefined;
 
   while (Date.now() < deadline) {
-    if (await activatedViewReached(page)) return prePeginTxid;
+    // Finish only when the activated view is up AND we've driven every expected activation. The second
+    // clause rejects the transient per-vault "Go to Dashboard" that can flash after just one split
+    // vault activates, before the sibling is done. Single-vault (expectedVaults=1) is satisfied by the
+    // one activation this fresh deposit always performs.
+    if ((await activatedViewReached(page)) && activationCount >= expectedVaults)
+      return prePeginTxid;
 
     // Actively approve any reused wallet window (OKX) that the event approver can't see.
     await sweepApprovals(context, page, log);
@@ -415,8 +429,10 @@ async function walkStepMachine(
       .isVisible()
       .catch(() => false);
     if (activateVisible) {
-      if (!activateClickedThisModal)
+      if (!activateClickedThisModal) {
         activateClickedThisModal = await handleActivateConfirmation(page, log);
+        if (activateClickedThisModal) activationCount += 1;
+      }
     } else {
       activateClickedThisModal = false;
     }
@@ -504,9 +520,10 @@ async function assertActivatedAndOnDashboard(
 
   // Two-vault split: both fresh cards share THIS run's single (batched) Pre-PegIn txid, and each shows
   // its own split sub-amount (not the full requested amount), so the single-vault amount cross-check
-  // below doesn't apply. The indexer commonly lags a just-activated vault's tx-hash row, so a miss here
-  // is logged (not failed) — the activated view we came from is the real signal that BOTH vaults
-  // activated (its "Go to Dashboard" only appears once every lane completes).
+  // below doesn't apply. "Both vaults activated" is already guaranteed upstream — walkStepMachine only
+  // finishes once it has driven both activations — so this dashboard count is a SOFT secondary
+  // confirmation: the indexer commonly lags a just-activated vault's tx-hash row, so a miss is logged
+  // (not failed) rather than turning indexer lag into a false failure on a real-funds run.
   if (expectedVaults > 1) {
     // Both fresh split cards share this run's Pre-PegIn txid, but the indexer commonly lags a
     // just-activated vault's tx-hash row — so poll (bounded) for both cards to link the txid rather
@@ -616,9 +633,15 @@ export const peginAction: Action = {
       await startSigning(page, log);
 
       currentStep = "step-machine";
-      const prePeginTxid = await walkStepMachine(page, context, log, (step) => {
-        currentStep = step;
-      });
+      const prePeginTxid = await walkStepMachine(
+        page,
+        context,
+        log,
+        split ? 2 : 1,
+        (step) => {
+          currentStep = step;
+        },
+      );
 
       currentStep = "finish";
       await assertActivatedAndOnDashboard(

--- a/services/vault/e2e/real/cli.ts
+++ b/services/vault/e2e/real/cli.ts
@@ -25,7 +25,11 @@ import {
   type RunConfig,
   type Target,
 } from "./config";
-import { fetchMinDepositBtc, fetchProviders } from "./peginParams";
+import {
+  fetchMinDepositBtc,
+  fetchMinDepositForSplitBtc,
+  fetchProviders,
+} from "./peginParams";
 import { runE2E } from "./run";
 
 const MS_PER_SECOND = 1000;
@@ -240,6 +244,22 @@ async function resolveConfig(
     // Pegin extras. A flag always wins; otherwise, for the pegin action, fetch the network's real
     // values (like the balance pre-flight) and offer them as defaults — amount ⇒ protocol minimum,
     // provider ⇒ first available — prompting interactively when there's a TTY.
+
+    // Split (pegin only): `--split` wins; else prompt (default = single vault). Resolved first because
+    // the deposit minimum depends on it — a two-vault split needs a larger deposit than a single vault.
+    let split = false;
+    if (action === "pegin") {
+      if (flags.split !== undefined) {
+        split = flagBool(flags.split);
+      } else if (interactive) {
+        split =
+          (await select<"single" | "split">(rl, "Deposit type", [
+            { value: "single", label: "Single-vault deposit" },
+            { value: "split", label: "Two-vault split deposit" },
+          ])) === "split";
+      }
+    }
+
     let peginAmountBtc =
       typeof flags.amount === "string" ? flags.amount : undefined;
     if (peginAmountBtc !== undefined) {
@@ -252,19 +272,22 @@ async function resolveConfig(
     let peginProvider = typeof flags.vp === "string" ? flags.vp : undefined;
 
     if (action === "pegin") {
-      // Amount: default to the fetched protocol minimum for this network (unless --amount given).
+      // The deposit minimum depends on the deposit type: the single-vault protocol minimum, or the
+      // (larger) two-vault split minimum computed from Aave risk params + the SDK split math.
+      const fetchMin = split ? fetchMinDepositForSplitBtc : fetchMinDepositBtc;
+      const minLabel = split ? "two-vault split minimum" : "protocol minimum";
+
+      // Amount: default to the fetched minimum for this network + deposit type (unless --amount given).
       if (peginAmountBtc === undefined) {
-        const minBtc = await fetchMinDepositBtc(network).catch((error) => {
+        const minBtc = await fetchMin(network).catch((error) => {
           // eslint-disable-next-line no-console
           console.warn(
-            `\nCould not fetch the minimum deposit (${error instanceof Error ? error.message : error}); the run will fall back to the form's minimum.`,
+            `\nCould not fetch the ${minLabel} (${error instanceof Error ? error.message : error}); the run will fall back to the form's minimum.`,
           );
           return undefined;
         });
         if (interactive) {
-          const hint = minBtc
-            ? `${minBtc} = protocol minimum`
-            : "protocol minimum";
+          const hint = minBtc ? `${minBtc} = ${minLabel}` : minLabel;
           const raw = (
             await rl.question(`\nPegin amount in BTC [${hint}]: `)
           ).trim();
@@ -272,6 +295,16 @@ async function resolveConfig(
         } else {
           peginAmountBtc = minBtc; // non-interactive: use the fetched minimum
         }
+      } else if (split) {
+        // --amount was given with --split: guard it against the fetched split minimum before launching
+        // the browser (the form is the ultimate gate; this is a fast, actionable pre-flight fail).
+        const minBtc = await fetchMinDepositForSplitBtc(network).catch(
+          () => undefined,
+        );
+        if (minBtc !== undefined && Number(peginAmountBtc) < Number(minBtc))
+          throw new Error(
+            `--amount ${peginAmountBtc} is below the two-vault split minimum ${minBtc} sBTC for ${network}. Increase --amount to at least ${minBtc}, or drop --split.`,
+          );
       }
 
       // Provider: interactive menu from the live list (default = first available); --vp overrides.
@@ -307,6 +340,7 @@ async function resolveConfig(
       delayMs,
       peginAmountBtc,
       peginProvider,
+      split,
       fixturesPath,
     };
   } finally {

--- a/services/vault/e2e/real/cli.ts
+++ b/services/vault/e2e/real/cli.ts
@@ -296,14 +296,25 @@ async function resolveConfig(
           peginAmountBtc = minBtc; // non-interactive: use the fetched minimum
         }
       } else if (split) {
-        // --amount was given with --split: guard it against the fetched split minimum before launching
-        // the browser (the form is the ultimate gate; this is a fast, actionable pre-flight fail).
+        // --amount was given with --split: a best-effort pre-flight heads-up, NOT a hard gate. The
+        // estimate uses the reserve's current dynamic config key (not the depositor's position key), so
+        // it can differ slightly from the form — the live form is the authoritative, position-aware gate
+        // and fails loudly at the split selector within ~30-60s if the amount is truly too low. So we
+        // WARN rather than throw: an approximate estimate must never wrongly reject a valid run, and a
+        // failed fetch must not silently skip the heads-up.
         const minBtc = await fetchMinDepositForSplitBtc(network).catch(
-          () => undefined,
+          (error) => {
+            // eslint-disable-next-line no-console
+            console.warn(
+              `\n⚠️ Could not fetch the two-vault split minimum (${error instanceof Error ? error.message : error}); skipping the pre-flight amount check — the form will gate it.`,
+            );
+            return undefined;
+          },
         );
         if (minBtc !== undefined && Number(peginAmountBtc) < Number(minBtc))
-          throw new Error(
-            `--amount ${peginAmountBtc} is below the two-vault split minimum ${minBtc} sBTC for ${network}. Increase --amount to at least ${minBtc}, or drop --split.`,
+          // eslint-disable-next-line no-console
+          console.warn(
+            `\n⚠️ --amount ${peginAmountBtc} looks below the two-vault split minimum (~${minBtc} sBTC estimated for ${network}); the form will confirm the exact position-aware threshold and stop the run there if it's genuinely too low.`,
           );
       }
 

--- a/services/vault/e2e/real/config.ts
+++ b/services/vault/e2e/real/config.ts
@@ -132,6 +132,8 @@ export interface RunConfig {
   peginAmountBtc?: string;
   /** Pegin only: vault provider name to select (`--vp`); defaults to the first available. */
   peginProvider?: string;
+  /** Pegin only: run a two-vault (split) deposit (`--split`) instead of a single vault. */
+  split?: boolean;
   /** Sign-conformance only: path to a `signing.jsonl` (`--fixtures`); defaults to the newest pegin's. */
   fixturesPath?: string;
 }

--- a/services/vault/e2e/real/peginParams.ts
+++ b/services/vault/e2e/real/peginParams.ts
@@ -17,16 +17,39 @@ import {
   resolveProtocolAddresses,
   ViemProtocolParamsReader,
 } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
+import {
+  AaveIntegrationAdapterABI,
+  BPS_SCALE,
+  computeMinDepositForSplit,
+  computeSeizedFraction,
+  getDynamicReserveConfig,
+  getReserve,
+  getTargetHealthFactor,
+  wadToNumber,
+} from "@babylonlabs-io/ts-sdk/tbv/integrations/aave";
 import { gql, GraphQLClient } from "graphql-request";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { createPublicClient, http, type Address } from "viem";
+import {
+  createPublicClient,
+  http,
+  type Address,
+  type PublicClient,
+} from "viem";
 import { sepolia } from "viem/chains";
 import { loadEnv } from "vite";
 
 import { NETWORKS, type NetworkName } from "./config";
 
 const SATS_PER_BTC = 100_000_000n;
+
+// Two-vault split risk constants — mirror `services/vault/src/applications/aave/constants.ts`
+// (EXPECTED_HEALTH_FACTOR_AT_LIQUIDATION, VAULT_SPLIT_SAFETY_MARGIN). They feed the SDK split math
+// exactly as the app's `useOptimalSplit` does, so the fetched split minimum matches the form.
+const EXPECTED_HEALTH_FACTOR_AT_LIQUIDATION = 0.95;
+const VAULT_SPLIT_SAFETY_MARGIN = 1.05;
+/** The immutable Core Spoke getter on the AaveIntegrationAdapter (read on-chain, never trusted from GraphQL). */
+const CORE_SPOKE_FN = "BTC_VAULT_CORE_SPOKE";
 
 /** The vault service root (holds .env / .env.local / .env.dev-testnet), relative to this file. */
 const VAULT_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
@@ -97,19 +120,116 @@ function satsToBtc(sats: bigint): string {
   return `${whole}.${fracStr}`;
 }
 
+/** A Sepolia public client for the network's ETH RPC (the same reads the app performs). */
+function createEthClient(ethRpcUrl: string): PublicClient {
+  return createPublicClient({
+    chain: sepolia,
+    transport: http(ethRpcUrl),
+  }) as PublicClient;
+}
+
+/**
+ * Read the peg-in configuration from the ProtocolParams contract via the SDK reader (addresses
+ * resolved off the network's BTCVaultRegistry) — identical to the app's `getPegInConfiguration()`.
+ * Shared by the single-vault minimum and the two-vault split minimum so neither can drift.
+ */
+async function getPegInConfig(client: PublicClient, registry: Address) {
+  const addresses = await resolveProtocolAddresses(client, registry);
+  const reader = new ViemProtocolParamsReader(client, addresses.protocolParams);
+  return reader.getPegInConfiguration();
+}
+
 /** Fetch the protocol minimum pegin amount for `network`, formatted as a BTC string. */
 export async function fetchMinDepositBtc(
   network: NetworkName,
 ): Promise<string> {
   const { registry, ethRpcUrl } = resolveNetworkContracts(network);
-  const client = createPublicClient({
-    chain: sepolia,
-    transport: http(ethRpcUrl),
-  });
-  const addresses = await resolveProtocolAddresses(client, registry);
-  const reader = new ViemProtocolParamsReader(client, addresses.protocolParams);
-  const config = await reader.getPegInConfiguration();
+  const client = createEthClient(ethRpcUrl);
+  const config = await getPegInConfig(client, registry);
   return satsToBtc(config.minimumPegInAmount);
+}
+
+const GET_VBTC_RESERVE_ID = gql`
+  query GetVaultBtcReserveId {
+    aaveConfig(id: 1) {
+      vaultBtcReserveId
+    }
+  }
+`;
+
+interface VbtcReserveIdResponse {
+  aaveConfig: { vaultBtcReserveId: string } | null;
+}
+
+/**
+ * Fetch the minimum deposit required to enable a TWO-VAULT split for `network`, formatted as a BTC
+ * string — the same value the deposit form shows in its "increase your deposit to at least X sBTC"
+ * hint. This is NOT a plain protocol param: it mirrors the app's `useOptimalSplit` / `useVaultSplitParams`
+ * chain — `minPegin` from ProtocolParams, plus the Aave Core Spoke risk params (THF/CF/LB) — fed through
+ * the SDK's `computeSeizedFraction` + `computeMinDepositForSplit` (the frozen split math is NOT
+ * reimplemented). It uses the reserve's current `dynamicConfigKey` (the no-position baseline); a wallet
+ * with an existing position may see a slightly different threshold, so the live form stays authoritative.
+ */
+export async function fetchMinDepositForSplitBtc(
+  network: NetworkName,
+): Promise<string> {
+  const { registry, appController, graphqlEndpoint, ethRpcUrl } =
+    resolveNetworkContracts(network);
+  const client = createEthClient(ethRpcUrl);
+
+  // Single-vault minimum (minPegin) — the same read fetchMinDepositBtc uses.
+  const peginConfig = await getPegInConfig(client, registry);
+  const minPegin = peginConfig.minimumPegInAmount;
+
+  // Resolve the Core Spoke on-chain from the env-pinned adapter (mirrors the app's getCoreSpokeAddress —
+  // never trust a GraphQL-supplied spoke), and the vBTC reserve id from the indexer's singleton config.
+  const spokeAddress = (await client.readContract({
+    address: appController as Address,
+    abi: AaveIntegrationAdapterABI,
+    functionName: CORE_SPOKE_FN,
+    args: [],
+  })) as Address;
+
+  const gqlClient = new GraphQLClient(graphqlEndpoint);
+  const { aaveConfig } =
+    await gqlClient.request<VbtcReserveIdResponse>(GET_VBTC_RESERVE_ID);
+  if (!aaveConfig)
+    throw new Error(
+      `No aaveConfig from the indexer at ${graphqlEndpoint} — cannot resolve the vBTC reserve id for the split minimum.`,
+    );
+  const reserveId = BigInt(aaveConfig.vaultBtcReserveId);
+
+  // Aave risk params from the spoke, using the reserve's current dynamicConfigKey (no-position baseline).
+  const { dynamicConfigKey } = await getReserve(
+    client,
+    spokeAddress,
+    reserveId,
+  );
+  const [thfWad, dynamicConfig] = await Promise.all([
+    getTargetHealthFactor(client, spokeAddress),
+    getDynamicReserveConfig(client, spokeAddress, reserveId, dynamicConfigKey),
+  ]);
+  const THF = wadToNumber(thfWad);
+  const CF = Number(dynamicConfig.collateralFactor) / BPS_SCALE;
+  const LB = Number(dynamicConfig.maxLiquidationBonus) / BPS_SCALE;
+
+  // SDK split math, identical to useOptimalSplit: seized fraction → minimum deposit for a split.
+  const seizedFraction = computeSeizedFraction(
+    CF,
+    LB,
+    THF,
+    EXPECTED_HEALTH_FACTOR_AT_LIQUIDATION,
+  );
+  const minSplitSats = computeMinDepositForSplit({
+    minPegin,
+    seizedFraction,
+    safetyMargin: VAULT_SPLIT_SAFETY_MARGIN,
+  });
+  if (minSplitSats <= 0n)
+    throw new Error(
+      `Computed split minimum is ${minSplitSats} sats (seizedFraction ${seizedFraction}, CF ${CF}, LB ${LB}, THF ${THF}) — two-vault split is not available for this reserve.`,
+    );
+  return satsToBtc(minSplitSats);
 }
 
 const GET_APP_PROVIDERS = gql`

--- a/services/vault/e2e/real/peginParams.ts
+++ b/services/vault/e2e/real/peginParams.ts
@@ -167,8 +167,11 @@ interface VbtcReserveIdResponse {
  * hint. This is NOT a plain protocol param: it mirrors the app's `useOptimalSplit` / `useVaultSplitParams`
  * chain — `minPegin` from ProtocolParams, plus the Aave Core Spoke risk params (THF/CF/LB) — fed through
  * the SDK's `computeSeizedFraction` + `computeMinDepositForSplit` (the frozen split math is NOT
- * reimplemented). It uses the reserve's current `dynamicConfigKey` (the no-position baseline); a wallet
- * with an existing position may see a slightly different threshold, so the live form stays authoritative.
+ * reimplemented). It uses the reserve's current `dynamicConfigKey` (the no-position baseline), so a
+ * depositor with an existing position opened under a since-rotated config may see a slightly different
+ * threshold. Treat the result as a best-effort ESTIMATE for defaults/warnings — NEVER a hard gate: the
+ * live deposit form (read by the pegin action's split selector) is the authoritative, position-aware
+ * minimum and is what actually blocks a too-low split.
  */
 export async function fetchMinDepositForSplitBtc(
   network: NetworkName,

--- a/services/vault/e2e/real/timing.ts
+++ b/services/vault/e2e/real/timing.ts
@@ -35,6 +35,13 @@ export const PROVIDER_LIST_TIMEOUT_MS = 15_000;
  * inscription check complete, so this must outlast those async passes.
  */
 export const DEPOSIT_CTA_ENABLE_TIMEOUT_MS = 90_000;
+/**
+ * The two-vault split option to become selectable after entering a split-eligible amount: the form
+ * fetches Aave risk params + runs the allocation ("Computing allocation…") before the "Two-vault split"
+ * row flips from `aria-disabled` to enabled. Generous so a slow risk-param fetch isn't mistaken for a
+ * too-low amount (which is a hard fail).
+ */
+export const SPLIT_ALLOCATION_TIMEOUT_MS = 30_000;
 
 // ── pegin: step machine ──────────────────────────────────────────────────────
 /**

--- a/services/vault/src/components/simple/ActivateConfirmationModal.tsx
+++ b/services/vault/src/components/simple/ActivateConfirmationModal.tsx
@@ -194,6 +194,7 @@ export function ActivateConfirmationModal({
           className="h-10 flex-1"
           onClick={onConfirm}
           disabled={!canActivate}
+          data-testid="activate-vault-button"
         >
           {COPY.deposit.activateConfirmation.activateButton}
         </Button>


### PR DESCRIPTION
# Two-vault (split) peg-in in the real-wallet E2E CLI

Closes https://github.com/babylonlabs-io/babylon-toolkit/issues/2011

## What this does

The vault app lets a depositor split one BTC deposit across **two** vaults (the UI calls it "Two-vault split"). The real-wallet E2E CLI (`services/vault/e2e/real/`) could already drive a real single-vault peg-in end-to-end with actual browser wallet extensions; this PR extends the same `pegin` action so one command can run a **two-vault split** peg-in end-to-end and finish with **two active vaults** on the dashboard.

Run it with the new `--split` flag, e.g. `--action=pegin --split --amount=0.04`.

## Why

We want automated, real-wallet confidence that the split deposit flow actually works — form → signing → per-vault steps → activation → dashboard — not just unit-tested in isolation. A split deposit is more complex than a single one (larger minimum, two per-vault progress lanes, more wallet pop-ups, two on-chain activations), so it's exactly the kind of flow that benefits from an end-to-end check with real UniSat/OKX + MetaMask.

## What changed

- New `--split` flag + an interactive "Deposit type" prompt, threaded through `RunConfig` (`config.ts`, `cli.ts`).
- New `fetchMinDepositForSplitBtc(network)` (`peginParams.ts`) that computes the split minimum the same way the app does, so the CLI can default/validate the amount before the browser opens.
- The `pegin` action (`actions/pegin.ts`) now: selects the "Two-vault split" option in the deposit form, tracks **both** per-vault progress columns, handles **both** vault activations, and asserts **two** vault cards on the dashboard.
- A small robustness fix to the activate step after the button copy drifted (see "Activate button" below), including one tiny production change: a `data-testid` on the activate button in `ActivateConfirmationModal.tsx`.

## Key thing to know: a split uses ONE provider, not two

The "second vault" is a second HTLC output under the **same** selected vault provider — the split only produces two per-vault **amounts** (e.g. a 26/74 split), not two providers. So provider selection is unchanged; only the output count and the per-vault progress differ. The transaction sizing itself stays owned by the SDK (the frozen `vaultSplit.ts` critical path) — the CLI only drives the UI and never recomputes values.

## Approaches we considered

### 1. Where to get the split minimum (the ~0.038 sBTC threshold)

The form only lets you enable a split above a minimum deposit. That minimum is **not** a plain protocol constant — it's derived from Aave risk parameters (target health factor, collateral factor, liquidation bonus) read from the Core Spoke contract, fed through the SDK's split math, and it's position-dependent.

- **Option A — read it from the live form.** The form already shows the exact threshold in its "increase your deposit to at least X sBTC" hint. Simple, always authoritative, but only available after the browser is open.
- **Option B — compute it in Node up front**, mirroring the app's `useOptimalSplit` / `useVaultSplitParams` hooks, so the CLI can offer it as a default and reject a too-low `--amount` before launching the browser.

**We did both.** The Node compute gives a fast, browser-free default and pre-flight guard; the live form stays the final gate (it's authoritative for a wallet that already has a position). We verified the Node value matches the form exactly (both produced `0.03838384` on devnet). This reuses the SDK's split functions rather than reimplementing the math, so it can't silently drift from the app.

### 2. How to select the "Activate vault" button (it broke mid-run)

The first split run stalled at the very last step: the activate button's text had drifted from `Activate Vault` to `Activate vault`, and our matcher was an exact, case-sensitive string, so it silently never clicked.

- **Exact text** — what we had; fragile, breaks on any wording/casing change.
- **Position (e.g. "the 2nd button")** — survives text changes but breaks if button order or an added close icon changes.
- **`data-testid`** — text-independent and robust, but a testid added here won't exist on the already-deployed site until it redeploys.

**We chose a `data-testid` plus a tolerant-text fallback** (`data-testid="activate-vault-button"`, else a case-insensitive `/activate vault/i`). This works against today's deployed build via the fallback and becomes bulletproof once the testid ships — the best of both, and it's the same "prefer a stable hook, tolerate copy drift" pattern the rest of this file already uses for its finish-line matchers.

### 3. Handling two activations

A split has two activation modals (one per vault). We made the activate/skip handling **re-entrant** — it clicks once per appearance and re-arms when the modal closes — so both vaults get activated without double-clicking a single modal (which could fire a duplicate transaction). We also made the two-vault dashboard check **poll** for both cards, because the indexer briefly lags a freshly activated vault's tx-hash link.

## How it was verified

- `eslint` + `tsc` clean; the Node split-minimum matches the form's displayed value exactly.
- **Real funded peg-ins on devnet (signet BTC + Sepolia ETH):**
  - **UniSat** — full split run reached both activations and two vaults (this run surfaced the activate-button drift; that's now fixed).
  - **OKX** — full split run against local source with the fix, **fully hands-off**: both vaults auto-activated and the dashboard matched **2/2**.
- Single-vault `pegin` is unchanged — every split path is guarded by the `--split` flag.

## Notes

- Building on the single-vault foundation from https://github.com/babylonlabs-io/babylon-toolkit/pull/2012.
- These runs use real testnet funds and take ~30 min–2 hr; they're run on demand, not in CI.
- OneKey stays disabled in the CLI until its `signPsbts` is fixed upstream (unchanged here).
