### PR TITLE
feat(vault): show page title in v3 header instead of nav

### DIFF
--- a/services/vault/src/components/Activity/ActivityList.tsx
+++ b/services/vault/src/components/Activity/ActivityList.tsx
@@ -1,6 +1,8 @@
 import { Avatar, Heading } from "@babylonlabs-io/core-ui";
 import { useEffect, useState } from "react";
+import { twJoin } from "tailwind-merge";
 
+import { FeatureFlags } from "@/config";
 import { COPY } from "@/copy";
 import type { ActivityRow, ActivityType } from "@/types/activityLog";
 
@@ -42,26 +44,35 @@ export function ActivityList({ activities, isConnected }: ActivityListProps) {
 
   return (
     <div className="flex flex-col gap-6">
-      <div className="flex items-center justify-between gap-4">
-        <Heading
-          variant="h5"
-          as="h2"
-          className="font-normal text-accent-primary"
+      {(!FeatureFlags.isV3UiEnabled || isConnected) && (
+        <div
+          className={twJoin(
+            "flex items-center gap-4",
+            FeatureFlags.isV3UiEnabled ? "justify-end" : "justify-between",
+          )}
         >
-          {COPY.activity.pageTitle}
-        </Heading>
-        {isConnected && (
-          <div className="flex items-center gap-4">
-            <Avatar url={AAVE_LOGO_URL} alt="Aave" size="small" />
-            <FilterDropdown
-              value={filter}
-              placeholder={COPY.activity.filterAll}
-              options={FILTER_OPTIONS}
-              onChange={setFilter}
-            />
-          </div>
-        )}
-      </div>
+          {!FeatureFlags.isV3UiEnabled && (
+            <Heading
+              variant="h5"
+              as="h2"
+              className="font-normal text-accent-primary"
+            >
+              {COPY.activity.pageTitle}
+            </Heading>
+          )}
+          {isConnected && (
+            <div className="flex items-center gap-4">
+              <Avatar url={AAVE_LOGO_URL} alt="Aave" size="small" />
+              <FilterDropdown
+                value={filter}
+                placeholder={COPY.activity.filterAll}
+                options={FILTER_OPTIONS}
+                onChange={setFilter}
+              />
+            </div>
+          )}
+        </div>
+      )}
 
       {visible.length === 0 ? (
         <ActivityEmptyState

--- a/services/vault/src/components/Activity/__tests__/ActivityList.test.tsx
+++ b/services/vault/src/components/Activity/__tests__/ActivityList.test.tsx
@@ -1,9 +1,31 @@
 import { fireEvent, render, screen, within } from "@testing-library/react";
 import { MemoryRouter, Outlet, Route, Routes } from "react-router";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { ActivityLog } from "../../../types/activityLog";
+import { COPY } from "@/copy";
+import type { ActivityLog } from "@/types/activityLog";
+
+const featureFlagsMock = vi.hoisted(() => ({
+  isV3UiEnabled: false,
+}));
+
+// Local override of the global `@/config` mock (src/test/setup.ts) — that
+// default doesn't export `FeatureFlags`, and `isV3UiEnabled` must be
+// flippable per test case. Same pattern as RootLayout.test.tsx.
+// `getBTCNetwork` is also required here: ActivityCard/LiquidationGroupCard
+// resolve explorer links via `@/utils/explorer`, which reads it off this
+// same barrel.
+vi.mock("@/config", () => ({
+  FeatureFlags: featureFlagsMock,
+  getNetworkConfigBTC: () => ({ coinSymbol: "sBTC" }),
+  getBTCNetwork: () => "signet",
+}));
+
 import { ActivityList } from "../ActivityList";
+
+beforeEach(() => {
+  featureFlagsMock.isV3UiEnabled = false;
+});
 
 const makeRow = (overrides: Partial<ActivityLog>): ActivityLog => ({
   kind: "row",
@@ -160,6 +182,38 @@ describe("ActivityList", () => {
 
     expect(
       screen.getByText(/connect your wallet to view your activity/i),
+    ).toBeInTheDocument();
+  });
+
+  it("v3 UI + disconnected: renders no in-page heading and no avatar/filter row", () => {
+    featureFlagsMock.isV3UiEnabled = true;
+    renderList({ activities: [], isConnected: false });
+
+    expect(
+      screen.queryByRole("heading", { name: COPY.activity.pageTitle }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByAltText("Aave")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /show all/i }),
+    ).not.toBeInTheDocument();
+    // The persistent app header owns the title in v3; the disconnected
+    // empty state below must still render on its own.
+    expect(
+      screen.getByText(/connect your wallet to view your activity/i),
+    ).toBeInTheDocument();
+  });
+
+  it("v3 UI + connected: renders no in-page heading but keeps the avatar and filter dropdown", () => {
+    featureFlagsMock.isV3UiEnabled = true;
+    const rows = [makeRow({ id: "a", type: "Deposit" })];
+    renderList({ activities: rows, isConnected: true });
+
+    expect(
+      screen.queryByRole("heading", { name: COPY.activity.pageTitle }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByAltText("Aave")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /show all/i }),
     ).toBeInTheDocument();
   });
 });

--- a/services/vault/src/components/pages/RootLayout.tsx
+++ b/services/vault/src/components/pages/RootLayout.tsx
@@ -2,6 +2,7 @@ import {
   Footer,
   FullScreenDialog,
   Header,
+  Heading,
   Loader,
   MobileLogo,
   Nav,
@@ -35,6 +36,7 @@ import { useAddressScreening } from "@/context/addressScreening";
 import { useAddressType } from "@/context/addressType";
 import { useGeoFencing } from "@/context/geofencing";
 import { COPY } from "@/copy";
+import { usePageTitle } from "@/hooks/usePageTitle";
 import { useProtocolGateState } from "@/hooks/useProtocolGate";
 
 import {
@@ -46,6 +48,7 @@ import { AddressScreeningBanner } from "../shared/AddressScreeningBanner";
 import { AddressTypeBanner } from "../shared/AddressTypeBanner";
 import { DepositDisabledBanner } from "../shared/DepositDisabledBanner";
 import { GeoBlockState } from "../shared/GeoBlockState";
+import { NetworkBadge } from "../shared/NetworkBadge";
 import { NoticeBanner } from "../shared/NoticeBanner";
 import {
   isDepositBlocked,
@@ -155,6 +158,7 @@ export default function RootLayout() {
   const { isBlocked: isAddressBlocked } = useAddressScreening();
   const { isSupportedAddress } = useAddressType();
   const isMobileView = useIsMobile();
+  const pageTitle = usePageTitle();
   const showV3Sidebar = FeatureFlags.isV3UiEnabled && !isMobileView;
 
   const isWalletConnected = btcConnected && ethConnected;
@@ -228,11 +232,27 @@ export default function RootLayout() {
           {showV3Sidebar && banners}
           <Header
             size="md"
+            // v3 owns its own vertical rhythm via each page's content
+            // padding (matches Figma: no gap between the header's bottom
+            // border and the content start). v2 keeps the default mb-20.
+            className={FeatureFlags.isV3UiEnabled ? "mb-0" : undefined}
             // `PAGE_CONTENT_CLASS` carries `!max-w-[1080px]`, overriding the
             // `container` width core-ui's Header applies by default so the navbar
             // shares the same 1080px content box as the page body and footer.
             containerClassName={PAGE_CONTENT_CLASS}
-            logo={<BrandLockup />}
+            logo={
+              FeatureFlags.isV3UiEnabled ? (
+                <Heading
+                  variant="h5"
+                  as="h1"
+                  className="font-normal text-accent-primary"
+                >
+                  {pageTitle}
+                </Heading>
+              ) : (
+                <BrandLockup />
+              )
+            }
             mobileLogo={
               <div className="[&_svg]:!text-secondary-main dark:[&_svg]:!text-accent-primary">
                 <MobileLogo />
@@ -250,6 +270,7 @@ export default function RootLayout() {
             }
             rightActions={
               <div className="flex items-center gap-4">
+                {FeatureFlags.isV3UiEnabled && <NetworkBadge />}
                 {isWalletConnected &&
                   !isDepositOpen &&
                   !isGeoBlocked &&

--- a/services/vault/src/components/pages/__tests__/Activity.test.tsx
+++ b/services/vault/src/components/pages/__tests__/Activity.test.tsx
@@ -26,6 +26,22 @@ vi.mock("../../../hooks/useActivitiesWithPending", () => ({
   useActivitiesWithPending: (arg: unknown) => useActivitiesWithPendingMock(arg),
 }));
 
+const featureFlagsMock = vi.hoisted(() => ({
+  isV3UiEnabled: false,
+}));
+
+// Local override of the global `@/config` mock (src/test/setup.ts) — that
+// default doesn't export `FeatureFlags`, which `ActivityList` (rendered
+// here via the `Activity` page) reads. Same pattern as RootLayout.test.tsx.
+// `getBTCNetwork` is also required here: ActivityCard/LiquidationGroupCard
+// resolve explorer links via `@/utils/explorer`, which reads it off this
+// same barrel.
+vi.mock("@/config", () => ({
+  FeatureFlags: featureFlagsMock,
+  getNetworkConfigBTC: () => ({ coinSymbol: "sBTC" }),
+  getBTCNetwork: () => "signet",
+}));
+
 import Activity from "../Activity";
 
 function renderActivity() {
@@ -43,6 +59,7 @@ function renderActivity() {
 describe("Activity page — wallet gating", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    featureFlagsMock.isV3UiEnabled = false;
     useActivitiesWithPendingMock.mockReturnValue({
       data: [],
       isLoading: false,

--- a/services/vault/src/components/pages/__tests__/RootLayout.test.tsx
+++ b/services/vault/src/components/pages/__tests__/RootLayout.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * RootLayout header wiring tests.
+ *
+ * The `Header`'s `logo` slot and `rightActions` NetworkBadge are both gated
+ * on `FeatureFlags.isV3UiEnabled`:
+ * - v2 (flag off, today's production path): `logo` is the v2 `BrandLockup`
+ *   mark, no page-title heading, no NetworkBadge.
+ * - v3 (flag on): `logo` is the current page title (`usePageTitle()`) as an
+ *   `<h1>`, and `rightActions` gains a leading `NetworkBadge` (visible only
+ *   on non-mainnet networks).
+ *
+ * These are locked in here since no other test exercises the real
+ * (unmocked) RootLayout — `src/__tests__/router.test.tsx` mocks it away
+ * entirely — and the v2 path is what ships to production today.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { COPY } from "@/copy";
+
+const featureFlagsMock = vi.hoisted(() => ({
+  isV3UiEnabled: false,
+  noticeBannerMessage: undefined as string | undefined,
+  isDepositDisabled: false,
+}));
+
+const networkMock = vi.hoisted(() => ({ value: "mainnet" }));
+
+// Local override of the global `@/config` mock (src/test/setup.ts) — that
+// default doesn't export `FeatureFlags` or `shouldDisplayTestingMsg`, and
+// `isV3UiEnabled` must be flippable per test case.
+vi.mock("@/config", () => ({
+  FeatureFlags: featureFlagsMock,
+  getNetworkConfigBTC: () => ({ coinSymbol: "sBTC" }),
+  getBTCNetwork: () => networkMock.value,
+  shouldDisplayTestingMsg: () => false,
+}));
+
+// A plain useContext consumer with no Provider mounted always sees the
+// context's default value in RTL — `@/context/addressScreening` and
+// `@/context/addressType` are left unmocked for exactly that reason. But
+// `@/context/geofencing`'s own module (GeoFencingProvider.tsx, which also
+// hosts the `useGeoFencing` export consumed here) imports `@/config/wagmi`
+// at module scope, which imports `@babylonlabs-io/wallet-connector` — and
+// that package's build cannot be transformed by Vitest in this workspace
+// (see the wallet-connector mock below), so the real module can't even be
+// loaded, not just "unsafe to render". Mocked here to return the exact same
+// default the real context has (`isLoading: true`, so RootLayout stays on
+// its Loader branch and the content-branch providers/components below it —
+// AaveConfigProvider, ActivatingVaultsProvider, SimpleDeposit, GeoBlockState,
+// ProtocolStatusBanner — never mount, matching the real unmocked behavior).
+vi.mock("@/context/geofencing", () => ({
+  useGeoFencing: () => ({ isGeoBlocked: false, isLoading: true }),
+}));
+
+vi.mock("@/context/wallet", () => ({
+  useBTCWallet: () => ({ connected: false }),
+  useETHWallet: () => ({ connected: false }),
+}));
+
+vi.mock("@/components/Wallet", () => ({
+  Connect: () => <div data-testid="connect-stub" />,
+}));
+
+// `@babylonlabs-io/wallet-connector`'s build also can't be transformed by
+// Vitest in this workspace (every existing test touching it — e.g.
+// NetworkBadge.test.tsx, useDepositFlow.test.tsx — fully mocks the package
+// rather than partially merging with the real one via `importOriginal`).
+// `Network` is the only export RootLayout's real (unmocked) tree still
+// needs — NetworkBadge imports it directly, and NetworkBadge is real here
+// since it's under test.
+vi.mock("@babylonlabs-io/wallet-connector", () => ({
+  Network: { MAINNET: "mainnet", SIGNET: "signet", TESTNET: "testnet" },
+}));
+
+// SimpleDeposit never mounts in any case below (RootLayout stays on its
+// Loader branch — see the geofencing mock above), but it's still imported
+// unconditionally at module scope. Its own import graph (DepositForm,
+// DepositSignContent, ResumeDepositContent, and a dozen `hooks/deposit/*`
+// files) directly imports several more `@babylonlabs-io/wallet-connector`
+// exports (useChainConnector, getSharedWagmiConfig, isUserRejectionMessage,
+// …) that the mock above doesn't provide. Stubbing the dead subtree here is
+// far more targeted than growing the wallet-connector mock to satisfy code
+// that never executes.
+vi.mock("@/components/simple/SimpleDeposit", () => ({
+  default: () => null,
+}));
+
+vi.mock("@babylonlabs-io/core-ui", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@babylonlabs-io/core-ui")>();
+  return {
+    ...actual,
+    StandardSettingsMenu: () => <div data-testid="settings-menu-stub" />,
+  };
+});
+
+import RootLayout from "../RootLayout";
+
+function renderRootLayout() {
+  return render(
+    <MemoryRouter initialEntries={["/"]}>
+      <RootLayout />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  featureFlagsMock.isV3UiEnabled = false;
+  featureFlagsMock.noticeBannerMessage = undefined;
+  featureFlagsMock.isDepositDisabled = false;
+  networkMock.value = "mainnet";
+});
+
+describe("RootLayout — header wiring", () => {
+  it("v2 (flag off): shows BrandLockup, no page-title heading, no NetworkBadge", () => {
+    featureFlagsMock.isV3UiEnabled = false;
+
+    renderRootLayout();
+
+    // BrandLockup renders SmallLogo + a divider + the Aave wordmark image —
+    // the alt text is the stable, concrete marker (see AppSidebar.tsx).
+    expect(screen.getByAltText("Aave")).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { level: 1 })).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(COPY.header.networkBadge),
+    ).not.toBeInTheDocument();
+  });
+
+  it("v3 flag on, mainnet: shows the page-title h1, no BrandLockup, no NetworkBadge", () => {
+    featureFlagsMock.isV3UiEnabled = true;
+    networkMock.value = "mainnet";
+
+    renderRootLayout();
+
+    const heading = screen.getByRole("heading", { level: 1 });
+    expect(heading).toHaveTextContent(COPY.nav.overview);
+    // The logo slot is replaced, not just hidden behind the title.
+    expect(screen.queryByAltText("Aave")).not.toBeInTheDocument();
+    // Mainnet: NetworkBadge renders null.
+    expect(
+      screen.queryByText(COPY.header.networkBadge),
+    ).not.toBeInTheDocument();
+  });
+
+  it("v3 flag on, signet: shows the page-title h1 and the NetworkBadge", () => {
+    featureFlagsMock.isV3UiEnabled = true;
+    networkMock.value = "signet";
+
+    renderRootLayout();
+
+    const heading = screen.getByRole("heading", { level: 1 });
+    expect(heading).toHaveTextContent(COPY.nav.overview);
+    // Proves the NetworkBadge wiring reaches the DOM under realistic v3
+    // conditions, not just that the JSX slot is reachable.
+    expect(screen.getByText(COPY.header.networkBadge)).toBeInTheDocument();
+  });
+});

--- a/services/vault/src/components/shared/AppSidebar.tsx
+++ b/services/vault/src/components/shared/AppSidebar.tsx
@@ -23,8 +23,9 @@ import { COPY } from "@/copy";
 
 // Header's own brand mark (unchanged v2 lockup: SmallLogo + divider + Aave
 // wordmark) — kept separate from `SidebarBrandLockup` (the exact Figma
-// sidebar asset). Header still renders this in both v2 and v3 until the
-// page-title header rebuild (#2016) removes it.
+// sidebar asset). Only rendered in v2; the v3 header shows the page title
+// instead (see RootLayout's `logo` prop), since the sidebar already carries
+// the brand.
 export function BrandLockup() {
   return (
     <div className="flex items-center gap-3">

--- a/services/vault/src/components/shared/NetworkBadge.tsx
+++ b/services/vault/src/components/shared/NetworkBadge.tsx
@@ -1,0 +1,26 @@
+import { Text } from "@babylonlabs-io/core-ui";
+import { Network } from "@babylonlabs-io/wallet-connector";
+
+import { getBTCNetwork } from "@/config";
+import { COPY } from "@/copy";
+
+// Mirrors simple-staking's NetworkBadge convention (services/simple-staking/
+// src/ui/common/components/NetworkBadge/NetworkBadge.tsx): shown only on
+// non-production networks, hidden entirely on mainnet.
+const NON_MAINNET_NETWORKS: readonly Network[] = [
+  Network.SIGNET,
+  Network.TESTNET,
+];
+
+/** v3 header network indicator — the Figma "Testnet" chip (node 10084:22952). */
+export function NetworkBadge() {
+  if (!NON_MAINNET_NETWORKS.includes(getBTCNetwork())) return null;
+
+  return (
+    <span className="flex items-center rounded-full bg-secondary-highlight px-2.5 py-1">
+      <Text as="span" variant="caption" className="text-warning-main">
+        {COPY.header.networkBadge}
+      </Text>
+    </span>
+  );
+}

--- a/services/vault/src/components/shared/__tests__/NetworkBadge.test.tsx
+++ b/services/vault/src/components/shared/__tests__/NetworkBadge.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { COPY } from "@/copy";
+
+vi.mock("@babylonlabs-io/wallet-connector", () => ({
+  Network: {
+    MAINNET: "mainnet",
+    SIGNET: "signet",
+    TESTNET: "testnet",
+  },
+}));
+
+const mockGetBTCNetwork = vi.fn(() => "signet");
+vi.mock("@/config", () => ({
+  getBTCNetwork: () => mockGetBTCNetwork(),
+}));
+
+// Import after mocks
+import { NetworkBadge } from "../NetworkBadge";
+
+describe("NetworkBadge", () => {
+  it("renders nothing on mainnet", () => {
+    mockGetBTCNetwork.mockReturnValue("mainnet");
+
+    const { container } = render(<NetworkBadge />);
+
+    expect(
+      screen.queryByText(COPY.header.networkBadge),
+    ).not.toBeInTheDocument();
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the badge on signet", () => {
+    mockGetBTCNetwork.mockReturnValue("signet");
+
+    render(<NetworkBadge />);
+
+    expect(screen.getByText(COPY.header.networkBadge)).toBeInTheDocument();
+  });
+
+  it("renders the badge on testnet", () => {
+    mockGetBTCNetwork.mockReturnValue("testnet");
+
+    render(<NetworkBadge />);
+
+    expect(screen.getByText(COPY.header.networkBadge)).toBeInTheDocument();
+  });
+});

--- a/services/vault/src/components/simple/OverviewSection.tsx
+++ b/services/vault/src/components/simple/OverviewSection.tsx
@@ -20,6 +20,7 @@ import {
   type HealthFactorGaugeStat,
   HeartIcon,
 } from "@/components/shared";
+import { FeatureFlags } from "@/config";
 import { COPY } from "@/copy";
 
 interface OverviewSectionProps {
@@ -87,15 +88,17 @@ export function OverviewSection({
 
   return (
     <div className="w-full space-y-6">
-      <div className="flex items-center justify-between">
-        <Heading
-          variant="h5"
-          as="h2"
-          className="font-normal text-accent-primary"
-        >
-          {COPY.overview.heading}
-        </Heading>
-      </div>
+      {!FeatureFlags.isV3UiEnabled && (
+        <div className="flex items-center justify-between">
+          <Heading
+            variant="h5"
+            as="h2"
+            className="font-normal text-accent-primary"
+          >
+            {COPY.overview.heading}
+          </Heading>
+        </div>
+      )}
 
       <div className="w-full rounded-2xl bg-secondary-highlight p-6">
         <div className="space-y-4">

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -1099,6 +1099,12 @@ export const COPY = {
     termsOfUse: "Terms of Use",
     privacyPolicy: "Privacy Policy",
   },
+  // v3 page-title header (services/vault/src/components/pages/RootLayout.tsx).
+  header: {
+    // Network indicator chip, shown only on non-production networks (see
+    // components/shared/NetworkBadge.tsx).
+    networkBadge: "Testnet",
+  },
   overview: {
     heading: "Overview",
     healthFactorLabel: "Health factor",

--- a/services/vault/src/hooks/__tests__/usePageTitle.test.ts
+++ b/services/vault/src/hooks/__tests__/usePageTitle.test.ts
@@ -1,0 +1,83 @@
+import { act, renderHook } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { MemoryRouter, useNavigate } from "react-router";
+import { describe, expect, it } from "vitest";
+
+import { COPY } from "@/copy";
+
+import { usePageTitle } from "../usePageTitle";
+
+function renderAtPath(path: string) {
+  function wrapper({ children }: { children: ReactNode }) {
+    return createElement(MemoryRouter, { initialEntries: [path] }, children);
+  }
+  return renderHook(() => usePageTitle(), { wrapper });
+}
+
+describe("usePageTitle", () => {
+  it("resolves the root dashboard path to the overview title", () => {
+    const { result } = renderAtPath("/");
+    expect(result.current).toBe(COPY.nav.overview);
+  });
+
+  it.each([
+    ["/activity", COPY.nav.activity],
+    ["/vaults", COPY.nav.vaults],
+    ["/loans", COPY.nav.loans],
+    ["/liquidations", COPY.nav.liquidations],
+    ["/explore", COPY.nav.explore],
+  ])("resolves exact path %s to its section title", (path, title) => {
+    const { result } = renderAtPath(path);
+    expect(result.current).toBe(title);
+  });
+
+  it.each([
+    ["/activity/0xabc123", COPY.nav.activity],
+    ["/vaults/some-vault-id", COPY.nav.vaults],
+    ["/loans/loan-42", COPY.nav.loans],
+    ["/liquidations/liq-1", COPY.nav.liquidations],
+    ["/explore/details", COPY.nav.explore],
+  ])(
+    "resolves nested sub-route %s to its parent section's title",
+    (path, title) => {
+      const { result } = renderAtPath(path);
+      expect(result.current).toBe(title);
+    },
+  );
+
+  it.each(["/vaultsfoo", "/loansxyz", "/activityhistory"])(
+    "does not match a path that merely shares a prefix's characters (%s falls back to overview)",
+    (path) => {
+      const { result } = renderAtPath(path);
+      expect(result.current).toBe(COPY.nav.overview);
+    },
+  );
+
+  it("falls back to the overview title for the AAVE reserve-detail overlay route", () => {
+    const { result } = renderAtPath("/app/aave/reserve/abc/borrow");
+    expect(result.current).toBe(COPY.nav.overview);
+  });
+
+  it("falls back to the overview title for an unknown/404-ish path", () => {
+    const { result } = renderAtPath("/some-random-path");
+    expect(result.current).toBe(COPY.nav.overview);
+  });
+
+  it("updates the title on an already-mounted tree when navigating, without remounting", () => {
+    function wrapper({ children }: { children: ReactNode }) {
+      return createElement(MemoryRouter, { initialEntries: ["/"] }, children);
+    }
+    const { result } = renderHook(
+      () => ({ title: usePageTitle(), navigate: useNavigate() }),
+      { wrapper },
+    );
+
+    expect(result.current.title).toBe(COPY.nav.overview);
+
+    act(() => {
+      result.current.navigate("/activity");
+    });
+
+    expect(result.current.title).toBe(COPY.nav.activity);
+  });
+});

--- a/services/vault/src/hooks/usePageTitle.ts
+++ b/services/vault/src/hooks/usePageTitle.ts
@@ -1,0 +1,28 @@
+import { useLocation } from "react-router";
+
+import { COPY } from "@/copy";
+
+// Longest-prefix match against the v3 sidebar's routes (see
+// components/shared/AppSidebar.tsx's `V3_NAV_GROUPS`), so a path the sidebar
+// treats as "Vaults" (etc.) shows that same title in the header. Anything
+// that doesn't match — the root dashboard and its AAVE reserve-detail
+// overlay routes (`/app/aave/reserve/:id/...`) — is the Overview page, so
+// it's the fallback rather than a listed prefix.
+const ROUTE_TITLES: readonly (readonly [path: string, title: string])[] = [
+  ["/activity", COPY.nav.activity],
+  ["/vaults", COPY.nav.vaults],
+  ["/loans", COPY.nav.loans],
+  ["/liquidations", COPY.nav.liquidations],
+  ["/explore", COPY.nav.explore],
+];
+
+/** Current page title for the v3 header, driven by the active route. */
+export function usePageTitle(): string {
+  const { pathname } = useLocation();
+  // Segment-boundary match — mirrors react-router's `NavLink` (used by
+  // AppSidebar's nav links), so `/vaults` matches but `/vaultsfoo` doesn't.
+  const match = ROUTE_TITLES.find(
+    ([path]) => pathname === path || pathname.startsWith(`${path}/`),
+  );
+  return match ? match[1] : COPY.nav.overview;
+}


### PR DESCRIPTION
<img width="2912" height="1736" alt="image" src="https://github.com/user-attachments/assets/670ce19b-c709-4760-98fe-4b4fd878825f" />

Add a per-page title to the v3 header, driven by the active route, replacing the header's logo/nav slot. usePageTitle() maps the current pathname to the matching sidebar section's title (Overview, Vaults, Loans, Activity, Liquidations, Explore), falling back to Overview for the root dashboard and its AAVE reserve-detail overlay routes. Matching is segment-boundary aware (mirrors react-router's NavLink), so a route like /vaultsfoo doesn't false-match /vaults.

Add a NetworkBadge chip to the header's right actions (Figma's "Testnet" pill), shown only on non-mainnet networks — mirrors simple-staking's existing NetworkBadge convention. Connect, StandardSettingsMenu, and the Deposit action are unchanged.

Drop the v3 header's own brand logo (BrandLockup), which duplicated the sidebar's brand lockup — a known limitation called out in PR #2023 (left sidebar navigation rail). v2 is untouched: same BrandLockup, same nav, no NetworkBadge.

Also gate OverviewSection's and ActivityList's own in-page headings behind !FeatureFlags.isV3UiEnabled: both duplicated the new header title in v3 (confirmed live — Activity showed "Activity" twice in the disconnected state). ActivityList's row also hosts the Aave avatar + FilterDropdown when connected, so its fix keeps that row rendering (right-aligned, no heading) whenever connected, and drops the row entirely when disconnected to avoid an empty-row gap.

Zero out the v3 header's bottom margin (mb-20 -> mb-0): it left a large gap between the title and page content, confirmed live. v2 keeps the default margin.

Refs #2016