### PR TITLE
feat(vault): derive the deposit time estimate from on-chain depth

### DIFF
--- a/services/vault/src/components/simple/DepositProgressView/DepositCardShell.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/DepositCardShell.tsx
@@ -21,7 +21,10 @@ import { Heading, Text } from "@babylonlabs-io/core-ui";
 import type { ReactNode } from "react";
 
 import { COPY } from "@/copy";
+import { useRequiredPrePeginDepth } from "@/hooks/deposit/useRequiredPrePeginDepth";
+import { formatDurationShort } from "@/utils/formatting";
 
+import { computeTotalEstimateMinutes } from "./btcConfirmationProgress";
 import { DEPOSIT_VIEW_MAX_WIDTH_CLASS } from "./layout";
 
 interface DepositCardShellProps {
@@ -45,6 +48,12 @@ interface DepositCardShellProps {
    * do-not-spend warning shown while the deposit is in flight.
    */
   footnote?: ReactNode;
+  /**
+   * The deposit's registered offchain-params version, so the header estimate
+   * uses the same pinned confirmation depth the flow actually gates on.
+   * Omitted pre-sign, where no version is registered yet → latest params.
+   */
+  offchainParamsVersion?: number;
 }
 
 export function DepositCardShell({
@@ -52,7 +61,11 @@ export function DepositCardShell({
   footer,
   progressBar,
   footnote,
+  offchainParamsVersion,
 }: DepositCardShellProps) {
+  const requiredDepth = useRequiredPrePeginDepth(offchainParamsVersion);
+  const estimateMinutes = computeTotalEstimateMinutes(requiredDepth);
+
   return (
     <div
       // Cap the card height to the viewport and lay it out as a column so the
@@ -64,7 +77,11 @@ export function DepositCardShell({
         <Heading variant="h5" className="text-accent-primary">
           {COPY.deposit.progress.heading}{" "}
           <Text as="span" variant="body1" className="text-accent-secondary">
-            ({COPY.deposit.progress.summary.estimate})
+            (
+            {COPY.deposit.progress.summary.estimate(
+              formatDurationShort(estimateMinutes),
+            )}
+            )
           </Text>
         </Heading>
 

--- a/services/vault/src/components/simple/DepositProgressView/DepositProgressView.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/DepositProgressView.tsx
@@ -109,6 +109,12 @@ export interface DepositProgressViewProps {
    * there.
    */
   btcConfirmationDetail?: BtcConfirmationDetailData | null;
+  /**
+   * The deposit's registered offchain-params version. Keeps the header's
+   * total-duration estimate on the same pinned confirmation depth the flow
+   * gates on. Omit pre-sign (no registered version yet) → latest params.
+   */
+  offchainParamsVersion?: number;
 }
 
 /**
@@ -168,6 +174,7 @@ export function DepositProgressView(props: DepositProgressViewProps) {
     terminalMessage,
     onRetry,
     btcConfirmationDetail,
+    offchainParamsVersion,
     started = true,
     onSign,
   } = props;
@@ -249,6 +256,7 @@ export function DepositProgressView(props: DepositProgressViewProps) {
 
   return (
     <DepositCardShell
+      offchainParamsVersion={offchainParamsVersion}
       progressBar={
         showOverallProgress ? (
           <ProgressBar

--- a/services/vault/src/components/simple/DepositProgressView/__tests__/DepositCardShell.test.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/__tests__/DepositCardShell.test.tsx
@@ -1,11 +1,33 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { COPY } from "@/copy";
 
 import { DepositCardShell } from "../DepositCardShell";
 
+const protocolParamsMock = vi.hoisted(() => ({
+  minPrepeginDepth: 6,
+  depthByVersion: {} as Record<number, number>,
+}));
+
+vi.mock("@/context/ProtocolParamsContext", () => ({
+  useProtocolParamsContext: () => ({
+    config: {
+      offchainParams: { minPrepeginDepth: protocolParamsMock.minPrepeginDepth },
+    },
+    getOffchainParamsByVersion: (version: number) =>
+      version in protocolParamsMock.depthByVersion
+        ? { minPrepeginDepth: protocolParamsMock.depthByVersion[version] }
+        : undefined,
+  }),
+}));
+
 describe("DepositCardShell", () => {
+  beforeEach(() => {
+    protocolParamsMock.minPrepeginDepth = 6;
+    protocolParamsMock.depthByVersion = {};
+  });
+
   it("renders the shared heading, estimate, and explanation across states", () => {
     render(
       <DepositCardShell footer={<button type="button">cta</button>}>
@@ -14,12 +36,51 @@ describe("DepositCardShell", () => {
     );
 
     expect(screen.getByText(COPY.deposit.progress.heading)).toBeTruthy();
-    expect(
-      screen.getByText(`(${COPY.deposit.progress.summary.estimate})`),
-    ).toBeTruthy();
+    // depth 6 × 10 min + 10 min pipeline overhead = 70 min
+    expect(screen.getByText("(~70 min)")).toBeTruthy();
     expect(
       screen.getByText(COPY.deposit.progress.summary.description),
     ).toBeTruthy();
+  });
+
+  it("derives an hours estimate on high-depth networks (testnet, depth 12)", () => {
+    protocolParamsMock.minPrepeginDepth = 12;
+    render(
+      <DepositCardShell footer={<button type="button">cta</button>}>
+        <div>body</div>
+      </DepositCardShell>,
+    );
+
+    // depth 12 × 10 min + 10 min overhead = 130 min → rounded to hours
+    expect(screen.getByText("(~2 h)")).toBeTruthy();
+  });
+
+  it("shows a minutes estimate on low-depth networks (devnet, depth 2)", () => {
+    protocolParamsMock.minPrepeginDepth = 2;
+    render(
+      <DepositCardShell footer={<button type="button">cta</button>}>
+        <div>body</div>
+      </DepositCardShell>,
+    );
+
+    // depth 2 × 10 min + 10 min overhead = 30 min
+    expect(screen.getByText("(~30 min)")).toBeTruthy();
+  });
+
+  it("uses the deposit's pinned params version over the latest depth", () => {
+    protocolParamsMock.minPrepeginDepth = 12; // latest — would read "~2 h"
+    protocolParamsMock.depthByVersion = { 3: 6 }; // version the deposit registered
+    render(
+      <DepositCardShell
+        footer={<button type="button">cta</button>}
+        offchainParamsVersion={3}
+      >
+        <div>body</div>
+      </DepositCardShell>,
+    );
+
+    // pinned depth 6 × 10 min + 10 min overhead = 70 min
+    expect(screen.getByText("(~70 min)")).toBeTruthy();
   });
 
   it("renders the body and footer slots", () => {

--- a/services/vault/src/components/simple/DepositProgressView/__tests__/DepositProgressView.test.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/__tests__/DepositProgressView.test.tsx
@@ -19,6 +19,7 @@ vi.mock("../BtcConfirmationDetailContainer", () => ({
 vi.mock("@/context/ProtocolParamsContext", () => ({
   useProtocolParamsContext: () => ({
     config: { offchainParams: { minPrepeginDepth: 6 } },
+    getOffchainParamsByVersion: () => undefined,
   }),
 }));
 

--- a/services/vault/src/components/simple/DepositProgressView/__tests__/DepositProgressView.test.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/__tests__/DepositProgressView.test.tsx
@@ -14,6 +14,14 @@ vi.mock("../BtcConfirmationDetailContainer", () => ({
   ),
 }));
 
+// DepositCardShell derives the header estimate from the on-chain confirmation
+// depth; the estimate itself is covered in DepositCardShell.test.tsx.
+vi.mock("@/context/ProtocolParamsContext", () => ({
+  useProtocolParamsContext: () => ({
+    config: { offchainParams: { minPrepeginDepth: 6 } },
+  }),
+}));
+
 // DepositProgressView self-sources the BTC wallet-lock state to render its
 // unlock notice and pre-sign unlock CTA. Drive it through a mutable mock;
 // default unlocked.

--- a/services/vault/src/components/simple/DepositProgressView/__tests__/btcConfirmationProgress.test.ts
+++ b/services/vault/src/components/simple/DepositProgressView/__tests__/btcConfirmationProgress.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   computeConfirmations,
   computeRemainingEstimateMinutes,
+  computeTotalEstimateMinutes,
 } from "../btcConfirmationProgress";
 
 describe("computeConfirmations", () => {
@@ -50,5 +51,16 @@ describe("computeRemainingEstimateMinutes", () => {
 
   it("returns null when confirmations exceed the required depth", () => {
     expect(computeRemainingEstimateMinutes(8, 6)).toBeNull();
+  });
+});
+
+describe("computeTotalEstimateMinutes", () => {
+  it("adds the pipeline overhead to ten minutes per required block", () => {
+    expect(computeTotalEstimateMinutes(6)).toBe(70);
+  });
+
+  it("scales with the on-chain confirmation depth", () => {
+    expect(computeTotalEstimateMinutes(2)).toBe(30);
+    expect(computeTotalEstimateMinutes(12)).toBe(130);
   });
 });

--- a/services/vault/src/components/simple/DepositProgressView/btcConfirmationProgress.ts
+++ b/services/vault/src/components/simple/DepositProgressView/btcConfirmationProgress.ts
@@ -1,14 +1,19 @@
 /**
- * Pure helpers for the "Awaiting Bitcoin confirmation" detail panel.
+ * Pure helpers for the deposit-progress duration estimates: the "Awaiting
+ * Bitcoin confirmation" detail panel's counter and the card header's total.
  *
  * The deposit waits for the Pre-PegIn tx to reach the protocol-mandated
  * confirmation depth (`minPrepeginDepth`, on-chain offchain param). These
- * helpers turn raw mempool data + that depth into the counter and estimate
- * the panel renders — no countdown, since block arrivals are not schedulable.
+ * helpers turn raw mempool data + that depth into the counter and estimates
+ * the card renders — no countdown, since block arrivals are not schedulable.
  */
 
-/** Bitcoin difficulty retargeting aims for one block every 10 minutes. */
-const AVG_BTC_BLOCK_MINUTES = 10;
+import { BTC_BLOCK_TIME_MINS } from "@/constants";
+
+// Machine-paced pegin overhead beyond BTC confirmations: ACK round, two ETH
+// txs, indexer surfacing, and poll quantization. BTC depth accrues in
+// parallel with the VP pipeline, so it is an additive allowance, not a sum.
+const DEPOSIT_PIPELINE_OVERHEAD_MINS = 10;
 
 /**
  * Confirmation count for a transaction given the current chain tip.
@@ -35,5 +40,15 @@ export function computeRemainingEstimateMinutes(
   requiredDepth: number,
 ): number | null {
   if (confirmations >= requiredDepth) return null;
-  return (requiredDepth - confirmations) * AVG_BTC_BLOCK_MINUTES;
+  return (requiredDepth - confirmations) * BTC_BLOCK_TIME_MINS;
+}
+
+/**
+ * Estimated machine-paced total for the whole deposit flow, shown in the card
+ * header. BTC confirmations dominate by design and accrue in parallel with
+ * the VP pipeline, so it's depth × block time plus a fixed overhead
+ * allowance. User-paced signing steps are excluded.
+ */
+export function computeTotalEstimateMinutes(requiredDepth: number): number {
+  return requiredDepth * BTC_BLOCK_TIME_MINS + DEPOSIT_PIPELINE_OVERHEAD_MINS;
 }

--- a/services/vault/src/components/simple/PostDepositContinuationView.tsx
+++ b/services/vault/src/components/simple/PostDepositContinuationView.tsx
@@ -3,9 +3,9 @@ import { useNavigate } from "react-router";
 import type { Address, Hex } from "viem";
 
 import { usePeginPolling } from "@/context/deposit/PeginPollingContext";
-import { useProtocolParamsContext } from "@/context/ProtocolParamsContext";
 import { COPY } from "@/copy";
 import { DepositFlowStep } from "@/hooks/deposit/depositFlowSteps";
+import { useRequiredPrePeginDepth } from "@/hooks/deposit/useRequiredPrePeginDepth";
 import { deriveSplitVaultProgress } from "@/hooks/deposit/useSplitVaultProgress";
 import {
   getPeginDisplayStep,
@@ -52,6 +52,7 @@ function StatusView({
   vaultCount = 1,
   currentVaultIndex = null,
   perVaultSteps,
+  offchainParamsVersion,
 }: {
   currentStep: DepositFlowStep;
   onClose: () => void;
@@ -64,6 +65,7 @@ function StatusView({
   vaultCount?: number;
   currentVaultIndex?: number | null;
   perVaultSteps?: DepositFlowStep[];
+  offchainParamsVersion?: number;
 }) {
   return (
     <DepositProgressView
@@ -81,6 +83,7 @@ function StatusView({
       onClose={onClose}
       successMessage={successMessage}
       btcConfirmationDetail={btcConfirmationDetail}
+      offchainParamsVersion={offchainParamsVersion}
     />
   );
 }
@@ -93,7 +96,6 @@ export function PostDepositContinuationView({
   onClose,
 }: PostDepositContinuationViewProps) {
   const { refetch, getPollingResult } = usePeginPolling();
-  const { config, getOffchainParamsByVersion } = useProtocolParamsContext();
   const navigate = useNavigate();
 
   const handleGoToDashboard = useCallback(() => {
@@ -161,6 +163,11 @@ export function PostDepositContinuationView({
 
   // Hoisted above the early returns to satisfy Rules of Hooks. When no
   // vault is selected, showBtcDepthPanel is false and the hook no-ops.
+  // requiredDepth pinned to the deposit's registered offchain-params version
+  // (matches PeginPollingContext.getRequiredPrePeginDepth).
+  const requiredDepth = useRequiredPrePeginDepth(
+    activity?.offchainParamsVersion,
+  );
   const peginState = pollingResult?.peginState;
   const waitStep = peginState
     ? (getPeginDisplayStep(peginState) ?? DepositFlowStep.ACTIVATE_VAULT)
@@ -331,13 +338,6 @@ export function PostDepositContinuationView({
     );
   }
 
-  // requiredDepth pinned to the deposit's registered offchain-params version
-  // (matches PeginPollingContext.getRequiredPrePeginDepth).
-  const requiredDepth =
-    (activity?.offchainParamsVersion !== undefined
-      ? getOffchainParamsByVersion(activity.offchainParamsVersion)
-          ?.minPrepeginDepth
-      : undefined) ?? config.offchainParams.minPrepeginDepth;
   const btcConfirmationDetail: BtcConfirmationDetailData | null =
     showBtcDepthPanel && activity?.prePeginTxHash
       ? {
@@ -368,6 +368,7 @@ export function PostDepositContinuationView({
       canContinueInBackground
       onClose={onClose}
       btcConfirmationDetail={btcConfirmationDetail}
+      offchainParamsVersion={activity?.offchainParamsVersion}
     />
   );
 }

--- a/services/vault/src/components/simple/PostDepositContinuationView.tsx
+++ b/services/vault/src/components/simple/PostDepositContinuationView.tsx
@@ -163,8 +163,7 @@ export function PostDepositContinuationView({
 
   // Hoisted above the early returns to satisfy Rules of Hooks. When no
   // vault is selected, showBtcDepthPanel is false and the hook no-ops.
-  // requiredDepth pinned to the deposit's registered offchain-params version
-  // (matches PeginPollingContext.getRequiredPrePeginDepth).
+  // requiredDepth pinned to the deposit's registered offchain-params version.
   const requiredDepth = useRequiredPrePeginDepth(
     activity?.offchainParamsVersion,
   );
@@ -249,6 +248,11 @@ export function PostDepositContinuationView({
       pollingResults.every((result) => isVaultActivated(result?.peginState));
 
     if (hasMissingOrLoadingVault || !allVaultsActivated) {
+      // Batch siblings share their registration-time params version (one
+      // registration tx for the whole batch), so any sibling is representative.
+      const batchParamsVersion = activities.find(
+        (a) => a.offchainParamsVersion !== undefined,
+      )?.offchainParamsVersion;
       return (
         <StatusView
           currentStep={DepositFlowStep.AWAIT_BTC_CONFIRMATION}
@@ -258,6 +262,7 @@ export function PostDepositContinuationView({
           vaultCount={vaultCount}
           currentVaultIndex={null}
           perVaultSteps={perVaultSteps}
+          offchainParamsVersion={batchParamsVersion}
         />
       );
     }

--- a/services/vault/src/components/simple/ResumeDepositContent.tsx
+++ b/services/vault/src/components/simple/ResumeDepositContent.tsx
@@ -32,7 +32,6 @@ import { getVaultRegistryReader } from "@/clients/eth-contract/sdk-readers";
 import { computeDepositDerivedState } from "@/components/deposit/DepositSignModal/depositStepHelpers";
 import { usePayoutSigningState } from "@/components/deposit/PayoutSignModal/usePayoutSigningState";
 import { useDepositPollingResult } from "@/context/deposit/PeginPollingContext";
-import { useProtocolParamsContext } from "@/context/ProtocolParamsContext";
 import { COPY } from "@/copy";
 import {
   DepositFlowStep,
@@ -42,6 +41,7 @@ import { submitWotsPublicKey } from "@/hooks/deposit/depositFlowSteps/wotsSubmis
 import { useActivationState } from "@/hooks/deposit/useActivationState";
 import { useBroadcastState } from "@/hooks/deposit/useBroadcastState";
 import { useReleaseVpTokenOnUnmount } from "@/hooks/deposit/useReleaseVpTokenOnUnmount";
+import { useRequiredPrePeginDepth } from "@/hooks/deposit/useRequiredPrePeginDepth";
 import { useSplitVaultProgress } from "@/hooks/deposit/useSplitVaultProgress";
 import { useRunOnce } from "@/hooks/useRunOnce";
 import { logger } from "@/infrastructure";
@@ -138,6 +138,7 @@ export function ResumeSignContent({
   return (
     <DepositProgressView
       currentStep={renderStep}
+      offchainParamsVersion={activity.offchainParamsVersion}
       // usePayoutSigningState already produces structured { title, message }
       // errors with actionable guard titles (missing/mismatched payout address,
       // wallet liveness, etc.). Pass them through directly so the callout keeps
@@ -223,6 +224,7 @@ export function ResumeBroadcastContent({
   return (
     <DepositProgressView
       currentStep={DepositFlowStep.BROADCAST_PRE_PEGIN}
+      offchainParamsVersion={activity.offchainParamsVersion}
       error={error ? mapDepositError(error) : null}
       isComplete={derived.isComplete}
       isProcessing={derived.isProcessing}
@@ -488,14 +490,9 @@ export function ResumeWotsContent({
     error != null,
   );
 
-  // requiredDepth is pinned to the version this deposit registered against
-  // (matches PeginPollingContext.getRequiredPrePeginDepth).
-  const { config, getOffchainParamsByVersion } = useProtocolParamsContext();
-  const requiredDepth =
-    (activity.offchainParamsVersion !== undefined
-      ? getOffchainParamsByVersion(activity.offchainParamsVersion)
-          ?.minPrepeginDepth
-      : undefined) ?? config.offchainParams.minPrepeginDepth;
+  const requiredDepth = useRequiredPrePeginDepth(
+    activity.offchainParamsVersion,
+  );
   const showBtcDepthPanel =
     renderStep === DepositFlowStep.AWAIT_PAYOUT_TRANSACTIONS &&
     Boolean(activity.prePeginTxHash);
@@ -527,6 +524,7 @@ export function ResumeWotsContent({
       onClose={onClose}
       onRetry={error ? handleSubmit : undefined}
       btcConfirmationDetail={btcConfirmationDetail}
+      offchainParamsVersion={activity.offchainParamsVersion}
     />
   );
 }
@@ -732,6 +730,7 @@ export function ResumeActivationContent({
       perVaultSteps={perVaultSteps}
       onClose={onClose}
       onRetry={error ? handleSubmit : undefined}
+      offchainParamsVersion={activity.offchainParamsVersion}
     />
   );
 }

--- a/services/vault/src/components/simple/__tests__/PostDepositContinuationView.test.tsx
+++ b/services/vault/src/components/simple/__tests__/PostDepositContinuationView.test.tsx
@@ -195,6 +195,7 @@ vi.mock("../DepositProgressView", () => ({
     perVaultSteps,
     successMessage,
     onClose,
+    offchainParamsVersion,
   }: {
     currentStep: string;
     error?: { title: string; body: string } | null;
@@ -202,6 +203,7 @@ vi.mock("../DepositProgressView", () => ({
     perVaultSteps?: string[];
     successMessage?: string;
     onClose: () => void;
+    offchainParamsVersion?: number;
   }) => (
     <div data-testid="progress-view">
       <span data-testid="step">{String(currentStep)}</span>
@@ -211,6 +213,9 @@ vi.mock("../DepositProgressView", () => ({
         {JSON.stringify(perVaultSteps ?? [])}
       </span>
       <span data-testid="success-message">{successMessage ?? ""}</span>
+      <span data-testid="offchain-params-version">
+        {String(offchainParamsVersion)}
+      </span>
       <button type="button" data-testid="progress-close" onClick={onClose}>
         close
       </button>
@@ -780,6 +785,24 @@ describe("PostDepositContinuationView", () => {
     expect(queryByTestId("payout")).toBeNull();
     expect(queryByTestId("activate")).toBeNull();
     expect(getByTestId("progress-view")).not.toBeNull();
+  });
+
+  it("pins the aggregate loading view's estimate to the batch's registered params version", () => {
+    // No polling results yet → the multi-vault AWAIT_BTC_CONFIRMATION
+    // aggregate renders while results load.
+    mockGetPollingResult.mockReturnValue(undefined);
+
+    const { getByTestId } = renderView({
+      vaultIds: ["0xvault0" as Hex, "0xvault1" as Hex],
+      activities: [
+        { ...activityWithId("0xvault0"), offchainParamsVersion: 3 },
+        { ...activityWithId("0xvault1"), offchainParamsVersion: 3 },
+      ],
+    });
+    expect(getByTestId("step").textContent).toBe(
+      String(DepositFlowStep.AWAIT_BTC_CONFIRMATION),
+    );
+    expect(getByTestId("offchain-params-version").textContent).toBe("3");
   });
 
   it("surfaces the warning once no other vault is actionable", () => {

--- a/services/vault/src/context/deposit/PeginPollingContext.tsx
+++ b/services/vault/src/context/deposit/PeginPollingContext.tsx
@@ -23,6 +23,7 @@ import {
 import { useDemoDeposit } from "@/dev/demoDeposit";
 
 import { usePeginPollingQuery } from "../../hooks/deposit/usePeginPollingQuery";
+import { useRequiredPrePeginDepthResolver } from "../../hooks/deposit/useRequiredPrePeginDepth";
 import { useSigningRequiredNotifications } from "../../hooks/deposit/useSigningRequiredNotifications";
 import { useBtcHtlcRefundStatus } from "../../hooks/useBtcHtlcRefundStatus";
 import { useBtcMempoolConfirmations } from "../../hooks/useBtcMempoolConfirmations";
@@ -148,7 +149,7 @@ export function PeginPollingProvider({
   // VP activation tx, absent during PENDING). PENDING gates on min-depth;
   // EXPIRED gates on `tRefund` for the Refund action. Each has its own
   // cache (depth/maturity never rewinds → drop cached txids from polling).
-  const { config, getOffchainParamsByVersion } = useProtocolParamsContext();
+  const { getOffchainParamsByVersion } = useProtocolParamsContext();
   const [confirmedTxids, setConfirmedTxids] = useState<Set<string>>(
     loadConfirmedPrePeginTxids,
   );
@@ -165,17 +166,11 @@ export function PeginPollingProvider({
     loadRefundedHtlcVaultIds,
   );
 
+  const resolveRequiredPrePeginDepth = useRequiredPrePeginDepthResolver();
   const getRequiredPrePeginDepth = useCallback(
-    (activity: VaultActivity): number => {
-      const versioned =
-        activity.offchainParamsVersion !== undefined
-          ? getOffchainParamsByVersion(activity.offchainParamsVersion)
-          : undefined;
-      return (
-        versioned?.minPrepeginDepth ?? config.offchainParams.minPrepeginDepth
-      );
-    },
-    [getOffchainParamsByVersion, config.offchainParams.minPrepeginDepth],
+    (activity: VaultActivity): number =>
+      resolveRequiredPrePeginDepth(activity.offchainParamsVersion),
+    [resolveRequiredPrePeginDepth],
   );
 
   // Optimistic overrides (set immediately on user action) take precedence

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -312,10 +312,10 @@ export const COPY = {
     progress: {
       heading: "Deposit Progress",
       // Pre-sign summary card shown before the flow starts: an estimated total
-      // duration suffixed to the heading plus a short explanation of the
-      // grouped signature counts.
+      // duration suffixed to the heading (derived from the on-chain
+      // confirmation depth) plus a short explanation of the grouped counts.
       summary: {
-        estimate: "~60 min",
+        estimate: (duration: string) => `~${duration}`,
         description:
           "Each step is divided into several wallet signature confirmations. The progress counter shows how many are completed. Your Bitcoin will only be locked once the BTC Vault is activated.",
       },

--- a/services/vault/src/hooks/deposit/useRequiredPrePeginDepth.ts
+++ b/services/vault/src/hooks/deposit/useRequiredPrePeginDepth.ts
@@ -1,18 +1,30 @@
+import { useCallback } from "react";
+
 import { useProtocolParamsContext } from "@/context/ProtocolParamsContext";
 
 /**
- * Required Pre-PegIn confirmation depth (`minPrepeginDepth`), pinned to the
- * deposit's registered offchain-params version when given — matching
- * `PeginPollingContext.getRequiredPrePeginDepth` — or the latest version
- * otherwise (pre-sign, where the deposit has no registered version yet).
+ * Stable resolver for the required Pre-PegIn confirmation depth
+ * (`minPrepeginDepth`): pinned to the deposit's registered offchain-params
+ * version when given, or the latest version otherwise (pre-sign, where the
+ * deposit has no registered version yet). Single source of this rule — also
+ * consumed by `PeginPollingContext.getRequiredPrePeginDepth`.
  */
+export function useRequiredPrePeginDepthResolver(): (
+  offchainParamsVersion?: number,
+) => number {
+  const { config, getOffchainParamsByVersion } = useProtocolParamsContext();
+  return useCallback(
+    (offchainParamsVersion?: number) =>
+      (offchainParamsVersion !== undefined
+        ? getOffchainParamsByVersion(offchainParamsVersion)?.minPrepeginDepth
+        : undefined) ?? config.offchainParams.minPrepeginDepth,
+    [getOffchainParamsByVersion, config.offchainParams.minPrepeginDepth],
+  );
+}
+
+/** Required Pre-PegIn depth for one deposit (see the resolver above). */
 export function useRequiredPrePeginDepth(
   offchainParamsVersion?: number,
 ): number {
-  const { config, getOffchainParamsByVersion } = useProtocolParamsContext();
-  return (
-    (offchainParamsVersion !== undefined
-      ? getOffchainParamsByVersion(offchainParamsVersion)?.minPrepeginDepth
-      : undefined) ?? config.offchainParams.minPrepeginDepth
-  );
+  return useRequiredPrePeginDepthResolver()(offchainParamsVersion);
 }

--- a/services/vault/src/hooks/deposit/useRequiredPrePeginDepth.ts
+++ b/services/vault/src/hooks/deposit/useRequiredPrePeginDepth.ts
@@ -1,0 +1,18 @@
+import { useProtocolParamsContext } from "@/context/ProtocolParamsContext";
+
+/**
+ * Required Pre-PegIn confirmation depth (`minPrepeginDepth`), pinned to the
+ * deposit's registered offchain-params version when given — matching
+ * `PeginPollingContext.getRequiredPrePeginDepth` — or the latest version
+ * otherwise (pre-sign, where the deposit has no registered version yet).
+ */
+export function useRequiredPrePeginDepth(
+  offchainParamsVersion?: number,
+): number {
+  const { config, getOffchainParamsByVersion } = useProtocolParamsContext();
+  return (
+    (offchainParamsVersion !== undefined
+      ? getOffchainParamsByVersion(offchainParamsVersion)?.minPrepeginDepth
+      : undefined) ?? config.offchainParams.minPrepeginDepth
+  );
+}

--- a/services/vault/src/utils/__tests__/formatting.test.ts
+++ b/services/vault/src/utils/__tests__/formatting.test.ts
@@ -15,6 +15,7 @@ import {
   formatCompactUsd,
   formatDateTime,
   formatDuration,
+  formatDurationShort,
   formatLiquidationDistancePercent,
   formatLLTV,
   formatOrdinal,
@@ -496,6 +497,21 @@ describe("Formatting Utilities", () => {
 
     it("formats a 91-block assert timelock (~15h) in hours", () => {
       expect(formatDuration(91 * 10)).toBe("15 hours");
+    });
+  });
+
+  describe("formatDurationShort", () => {
+    it("rounds sub-90-minute durations to 5-minute steps", () => {
+      expect(formatDurationShort(30)).toBe("30 min");
+      expect(formatDurationShort(68)).toBe("70 min");
+      expect(formatDurationShort(84)).toBe("85 min");
+    });
+
+    it("switches to half-hour-rounded hours from 90 minutes", () => {
+      expect(formatDurationShort(89)).toBe("1.5 h"); // rounds to 90 → hours
+      expect(formatDurationShort(100)).toBe("1.5 h");
+      expect(formatDurationShort(130)).toBe("2 h");
+      expect(formatDurationShort(170)).toBe("3 h");
     });
   });
 });

--- a/services/vault/src/utils/formatting.ts
+++ b/services/vault/src/utils/formatting.ts
@@ -347,6 +347,9 @@ export function formatDurationShort(totalMinutes: number): string {
   if (roundedMinutes < SHORT_DURATION_HOURS_FROM_MINS) {
     return `${roundedMinutes} min`;
   }
+  // Hours deliberately re-round from the raw value — snapping twice compounds
+  // error (103 min is nearest 1.5 h, but 103→105 would round to 2 h) — while
+  // the snapped branch base is what keeps "90 min" from ever rendering.
   const halfHours = Math.round(totalMinutes / SHORT_DURATION_HALF_HOUR_MINS);
   return `${halfHours / 2} h`;
 }

--- a/services/vault/src/utils/formatting.ts
+++ b/services/vault/src/utils/formatting.ts
@@ -332,6 +332,25 @@ export function formatDuration(totalMinutes: number): string {
   return pluralizeUnit(Math.round(totalMinutes / MINS_PER_DAY), "day");
 }
 
+/** Below this (after rounding), a short duration reads better in minutes. */
+const SHORT_DURATION_HOURS_FROM_MINS = 90;
+/** Minute estimates snap to 5-minute steps; hour estimates to half hours. */
+const SHORT_DURATION_MINUTE_STEP = 5;
+const SHORT_DURATION_HALF_HOUR_MINS = 30;
+
+/** Compact approximate duration for headline estimates: "70 min", "1.5 h",
+ *  "2 h". Rounds to 5-minute steps under 90 minutes, half hours above. */
+export function formatDurationShort(totalMinutes: number): string {
+  const roundedMinutes =
+    Math.round(totalMinutes / SHORT_DURATION_MINUTE_STEP) *
+    SHORT_DURATION_MINUTE_STEP;
+  if (roundedMinutes < SHORT_DURATION_HOURS_FROM_MINS) {
+    return `${roundedMinutes} min`;
+  }
+  const halfHours = Math.round(totalMinutes / SHORT_DURATION_HALF_HOUR_MINS);
+  return `${halfHours / 2} h`;
+}
+
 /**
  * Format a 1-based position as an ordinal string (1st, 2nd, 3rd, 4th, etc.)
  * @param n - 1-based position number


### PR DESCRIPTION
The Deposit Progress header hardcoded "~60 min" while the in-flow
counter computed minPrepeginDepth × 10 min from chain params — on
testnet (depth 12) the same card showed 60 and 120 min. Compute the
header from the deposit's pinned depth plus a fixed pipeline allowance.