### PR TITLE
fix(vault): enable Sentry in deployed builds, close binary redaction hole

### DIFF
--- a/services/vault/playwright.config.ts
+++ b/services/vault/playwright.config.ts
@@ -24,7 +24,9 @@ const MOCK_ENV_VARS = {
   NEXT_PUBLIC_MEMPOOL_API: "http://localhost:9996/mempool",
   NEXT_PUBLIC_REOWN_PROJECT_ID: "test-project-id-12345",
   NEXT_PUBLIC_SENTRY_DSN: "https://test@o12345.ingest.sentry.io/12345",
-  NEXT_PUBLIC_SIDECAR_API_URL: "http://localhost:8092",
+  // Route events through a tunnel so SentryInterceptor (which intercepts **/sentry-tunnel)
+  // captures them. The DSN alone enables Sentry; this only changes where events are POSTed.
+  NEXT_PUBLIC_SENTRY_TUNNEL_URL: "http://localhost:8092/sentry-tunnel",
   NEXT_PUBLIC_SENTRY_ENVIRONMENT: "e2e-test",
   // Gate that the page-side `getInjectedWallets()` helper reads to
   // decide whether to surface `window.__BABYLON_E2E_WALLETS__`.

--- a/services/vault/playwright.config.ts
+++ b/services/vault/playwright.config.ts
@@ -72,6 +72,12 @@ export default defineConfig({
       url: `http://localhost:${PORT_MISSING_ENV}`,
       timeout: 120_000,
       reuseExistingServer: true,
+      // This "missing configuration" server inherits the parent shell. Force the Sentry DSN
+      // empty so a developer's exported NEXT_PUBLIC_SENTRY_DSN can't enable Sentry here and
+      // transmit to a real project — the enable gate is DSN-only.
+      env: {
+        NEXT_PUBLIC_SENTRY_DSN: "",
+      },
     },
     {
       command: `pnpm exec vite --port ${PORT_FULL_ENV}`,

--- a/services/vault/sentry.client.config.ts
+++ b/services/vault/sentry.client.config.ts
@@ -13,7 +13,6 @@ import * as Sentry from "@sentry/react";
 import { v4 as uuidv4 } from "uuid";
 
 import { getCommitHash } from "@/config";
-import { REPLAYS_ON_ERROR_RATE } from "@/constants";
 import { redactData, scrubSentryEvent, scrubString } from "@/utils/telemetry";
 
 const SENTRY_DEVICE_ID_KEY = "sentry_device_id";
@@ -27,16 +26,32 @@ const sentryDsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
 const tunnelUrl = process.env.NEXT_PUBLIC_SENTRY_TUNNEL_URL;
 const sentryEnabled = Boolean(sentryDsn);
 
-// This environment variable is provided in the CI; its absence means a local build.
+// These environment variables are provided by CI; their absence means a local build.
 const LOCAL_ENVIRONMENT = "local";
+const LOCAL_RELEASE = "local-dev";
 const sentryEnvironment =
   process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT ?? LOCAL_ENVIRONMENT;
+const sentryRelease = process.env.NEXT_PUBLIC_RELEASE_ID ?? LOCAL_RELEASE;
+// A deployed build is detected by its CI-injected release id (github.sha), NOT by the Sentry
+// env vars — those are exactly what a broken env-injection step might drop, and the warning
+// must survive that. RELEASE_ID comes from the github context, so it is still present even if
+// the DSN and environment vars are both dropped.
+const isDeployedBuild = sentryRelease !== LOCAL_RELEASE;
 
-// A deployed build with Sentry off is a defect that reports nothing — including its own
-// silence. Say so at boot. Local builds legitimately run without a DSN, so stay quiet there.
-if (!sentryEnabled && sentryEnvironment !== LOCAL_ENVIRONMENT) {
+// Warn on any telemetry misconfiguration a deployed build should never ship with. Local builds
+// legitimately run without a DSN, so the "off" case stays quiet there.
+if (isDeployedBuild && !sentryEnabled) {
+  // Deployed build, telemetry off: reports nothing, including its own silence — regardless of
+  // whether the environment var was also dropped (which would resolve environment to "local").
   console.warn(
-    `[sentry] disabled in "${sentryEnvironment}" — no events will be transmitted. Missing: NEXT_PUBLIC_SENTRY_DSN`,
+    `[sentry] disabled in a deployed build (env "${sentryEnvironment}") — no events will be transmitted. Missing: NEXT_PUBLIC_SENTRY_DSN`,
+  );
+} else if (sentryEnabled && sentryEnvironment === LOCAL_ENVIRONMENT) {
+  // Enabled but tagged "local": either a deployed build that forgot
+  // NEXT_PUBLIC_SENTRY_ENVIRONMENT (events mislabeled, likely filtered out) or a local build
+  // with a stray DSN (transmitting a developer's session). Neither is intended.
+  console.warn(
+    `[sentry] enabled but environment is "local" — deployed builds must set NEXT_PUBLIC_SENTRY_ENVIRONMENT; a local build should unset NEXT_PUBLIC_SENTRY_DSN.`,
   );
 }
 
@@ -53,27 +68,19 @@ Sentry.init({
 
   // Ensure this release ID matches the one used during 'vite build' for source map uploads
   // It's passed via NEXT_PUBLIC_RELEASE_ID in the build environment (e.g., GitHub Actions)
-  release: process.env.NEXT_PUBLIC_RELEASE_ID ?? "local-dev",
+  release: sentryRelease,
 
   // Ensure this dist ID matches the one used during 'vite build' for source map uploads
   // It's passed via NEXT_PUBLIC_DIST_ID in the build environment (e.g., GitHub Actions)
   dist: process.env.NEXT_PUBLIC_DIST_ID ?? "local",
 
-  // Adjust this value in production, or use tracesSampler for greater control
-  tracesSampleRate: 1,
-  tracesSampler: (samplingContext) => {
-    const hasErrorTag = samplingContext.tags?.error === "true";
-
-    // Only sample at 100% if it's an error transaction with the error tag
-    if (hasErrorTag) {
-      return 1.0;
-    }
-
-    // Default sampling rate for everything else
-    return 0.01;
-  },
-
-  enableTracing: true,
+  // Performance tracing is intentionally OFF. beforeSend (and thus scrubSentryEvent) runs
+  // only on error/message events, never on transaction envelopes — those need a separate
+  // beforeSendTransaction hook. With browserTracingIntegration, auto-instrumented fetch spans
+  // carry full request URLs, and this app fetches `${UTILS_API_URL}/address/screening?address=
+  // <btc-addr>`, so the depositor's address would transmit unredacted. No tracesSampleRate and
+  // no browserTracingIntegration => no transactions are created. Restore tracing together with
+  // a transaction-side URL scrubber (planned for the SDK-upgrade PR).
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
@@ -88,19 +95,13 @@ Sentry.init({
     return breadcrumb;
   },
 
-  replaysOnErrorSampleRate: REPLAYS_ON_ERROR_RATE,
-
-  replaysSessionSampleRate: 0,
-
-  integrations: [
-    Sentry.replayIntegration({
-      maskAllText: true,
-      maskAllInputs: true,
-      blockAllMedia: true,
-    }),
-    // Browser tracing for performance monitoring and React component annotation
-    Sentry.browserTracingIntegration(),
-  ],
+  // Session Replay is intentionally OFF for the same reason: replay envelopes bypass
+  // beforeSend/scrubSentryEvent, and maskAllText/maskAllInputs do not mask request URLs or
+  // href attributes (the app renders the depositor's BTC address in both — the screening
+  // request URL and explorer /address/<addr> links). Leaving out replayIntegration keeps only
+  // Sentry's default integrations (error handlers, breadcrumbs), which carry no address data
+  // that scrubSentryEvent does not already cover. Restore replay only with a replay-side
+  // redaction hook (URL + href masking).
 
   beforeSend(event, hint) {
     event.extra = {

--- a/services/vault/sentry.client.config.ts
+++ b/services/vault/sentry.client.config.ts
@@ -18,22 +18,38 @@ import { redactData, scrubSentryEvent, scrubString } from "@/utils/telemetry";
 
 const SENTRY_DEVICE_ID_KEY = "sentry_device_id";
 
+const sentryDsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
+
+// Telemetry is gated on the DSN alone. Events go directly to Sentry unless a tunnel is
+// configured. A tunnel proxies events through our own host to dodge ad-blockers; it is an
+// optimization, not a requirement, and is deliberately independent of the (logo) sidecar so
+// that unrelated infrastructure can never silently disable telemetry again.
+const tunnelUrl = process.env.NEXT_PUBLIC_SENTRY_TUNNEL_URL;
+const sentryEnabled = Boolean(sentryDsn);
+
+// This environment variable is provided in the CI; its absence means a local build.
+const LOCAL_ENVIRONMENT = "local";
+const sentryEnvironment =
+  process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT ?? LOCAL_ENVIRONMENT;
+
+// A deployed build with Sentry off is a defect that reports nothing — including its own
+// silence. Say so at boot. Local builds legitimately run without a DSN, so stay quiet there.
+if (!sentryEnabled && sentryEnvironment !== LOCAL_ENVIRONMENT) {
+  console.warn(
+    `[sentry] disabled in "${sentryEnvironment}" — no events will be transmitted. Missing: NEXT_PUBLIC_SENTRY_DSN`,
+  );
+}
+
 Sentry.init({
-  enabled: Boolean(
-    process.env.NEXT_PUBLIC_SIDECAR_API_URL &&
-      process.env.NEXT_PUBLIC_SENTRY_DSN,
-  ),
+  enabled: sentryEnabled,
   // This is pointing to the DSN (Data Source Name) for the Sentry project
-  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+  dsn: sentryDsn,
 
-  // Tunnel endpoint for proxying Sentry events through our own server
-  // This helps avoid ad-blockers and CSP issues
-  tunnel: process.env.NEXT_PUBLIC_SIDECAR_API_URL
-    ? `${process.env.NEXT_PUBLIC_SIDECAR_API_URL}/sentry-tunnel`
-    : "http://localhost:8092/sentry-tunnel",
+  // Tunnel endpoint for proxying Sentry events through our own host (ad-blocker/CSP
+  // resistance). Omitted when unset so events go directly to Sentry.
+  ...(tunnelUrl ? { tunnel: tunnelUrl } : {}),
 
-  // This environment variable is provided in the CI
-  environment: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT ?? "local",
+  environment: sentryEnvironment,
 
   // Ensure this release ID matches the one used during 'vite build' for source map uploads
   // It's passed via NEXT_PUBLIC_RELEASE_ID in the build environment (e.g., GitHub Actions)

--- a/services/vault/src/constants.ts
+++ b/services/vault/src/constants.ts
@@ -14,11 +14,6 @@ export const MAX_PENDING_DURATION = 24 * 60 * 60 * 1000; // 24 hours - cleanup s
 // Pending collateral storage constants
 export const PENDING_COLLATERAL_KEY_PREFIX = "vault-pending-collateral";
 
-// Sentry replay sampling rate (5% by default)
-export const REPLAYS_ON_ERROR_RATE = Number.parseFloat(
-  process.env.NEXT_PUBLIC_REPLAYS_RATE ?? "0.05",
-);
-
 // External links surfaced on the pending-withdraw card.
 // Support points to the Babylon Discord invite (confirmed).
 // TODO(product): swap in the exact withdrawal-latency doc page once confirmed.

--- a/services/vault/src/utils/__tests__/telemetry.test.ts
+++ b/services/vault/src/utils/__tests__/telemetry.test.ts
@@ -164,7 +164,7 @@ describe("redactData", () => {
   it("replaces a Uint8Array secret instead of spreading its bytes", () => {
     const data = { htlcSecretHex: new Uint8Array([222, 173, 190, 239]) };
     const result = redactData(data);
-    expect(result.htlcSecretHex).toBe("[REDACTED]");
+    expect(result.htlcSecretHex).toBe("[BINARY_REDACTED]");
   });
 
   it("replaces a binary buffer held under a non-sensitive key", () => {
@@ -179,10 +179,10 @@ describe("redactData", () => {
     expect(result.chunks).toEqual(["[BINARY_REDACTED]", "plain text"]);
   });
 
-  it("replaces a raw ArrayBuffer", () => {
-    const data = { seed: new ArrayBuffer(8) };
+  it("replaces a raw ArrayBuffer under a non-sensitive key", () => {
+    const data = { payload: new ArrayBuffer(8) };
     const result = redactData(data);
-    expect(result.seed).toBe("[REDACTED]");
+    expect(result.payload).toBe("[BINARY_REDACTED]");
   });
 
   it("redacts a bigint held under a sensitive key", () => {

--- a/services/vault/src/utils/__tests__/telemetry.test.ts
+++ b/services/vault/src/utils/__tests__/telemetry.test.ts
@@ -160,6 +160,43 @@ describe("redactData", () => {
     expect(result.publicKey).toBe("[REDACTED]");
     expect(result.secretHex).toBe("[REDACTED]");
   });
+
+  it("replaces a Uint8Array secret instead of spreading its bytes", () => {
+    const data = { htlcSecretHex: new Uint8Array([222, 173, 190, 239]) };
+    const result = redactData(data);
+    expect(result.htlcSecretHex).toBe("[REDACTED]");
+  });
+
+  it("replaces a binary buffer held under a non-sensitive key", () => {
+    const data = { payload: new Uint8Array([1, 2, 3]) };
+    const result = redactData(data);
+    expect(result.payload).toBe("[BINARY_REDACTED]");
+  });
+
+  it("replaces a binary buffer nested inside an array", () => {
+    const data = { chunks: [new Uint8Array([7, 8]), "plain text"] };
+    const result = redactData(data);
+    expect(result.chunks).toEqual(["[BINARY_REDACTED]", "plain text"]);
+  });
+
+  it("replaces a raw ArrayBuffer", () => {
+    const data = { seed: new ArrayBuffer(8) };
+    const result = redactData(data);
+    expect(result.seed).toBe("[REDACTED]");
+  });
+
+  it("redacts a bigint held under a sensitive key", () => {
+    const data = { publicKey: 123456789n };
+    const result = redactData(data);
+    expect(result.publicKey).toBe("[REDACTED]");
+  });
+
+  it("passes through an absent sensitive field rather than claiming it was redacted", () => {
+    const data = { rpcUrl: undefined, endpoint: null };
+    const result = redactData(data);
+    expect(result.rpcUrl).toBeUndefined();
+    expect(result.endpoint).toBeNull();
+  });
 });
 
 describe("scrubSentryEvent", () => {

--- a/services/vault/src/utils/telemetry.ts
+++ b/services/vault/src/utils/telemetry.ts
@@ -80,6 +80,9 @@ function isBinary(value: unknown): boolean {
  */
 function redactSensitiveValue(value: unknown): unknown {
   if (value === null || value === undefined) return value;
+  // Preserve the "this was binary" signal for the fields most likely to hold raw secret
+  // material, rather than collapsing it into the generic [REDACTED].
+  if (isBinary(value)) return BINARY_PLACEHOLDER;
   if (typeof value === "string") return redactIdentifier(value, true);
   return REDACTED_PLACEHOLDER;
 }

--- a/services/vault/src/utils/telemetry.ts
+++ b/services/vault/src/utils/telemetry.ts
@@ -1,6 +1,7 @@
 import type { Event as SentryEvent } from "@sentry/react";
 
 const REDACTED_IDENTIFIER_VISIBLE_CHARS = 4;
+const REDACTED_PLACEHOLDER = "[REDACTED]";
 
 /**
  * Redact a known-sensitive identifier to "first4...last4" format.
@@ -8,7 +9,7 @@ const REDACTED_IDENTIFIER_VISIBLE_CHARS = 4;
  */
 export function redactIdentifier(value: string, forceRedact = false): string {
   if (value.length <= REDACTED_IDENTIFIER_VISIBLE_CHARS * 2) {
-    return forceRedact ? "[REDACTED]" : value;
+    return forceRedact ? REDACTED_PLACEHOLDER : value;
   }
   const head = value.slice(0, REDACTED_IDENTIFIER_VISIBLE_CHARS);
   const tail = value.slice(-REDACTED_IDENTIFIER_VISIBLE_CHARS);
@@ -61,9 +62,33 @@ const SENSITIVE_FIELD_NAMES = new Set([
   "endpoint",
 ]);
 
+const BINARY_PLACEHOLDER = "[BINARY_REDACTED]";
+
+/**
+ * Binary buffers hold raw secret material (WOTS seeds, HTLC preimages, signatures).
+ * They are not strings, so no regex matches them, and Object.entries would spread a
+ * Uint8Array into { 0: 222, 1: 173, ... } — leaking every byte as a plain number.
+ */
+function isBinary(value: unknown): boolean {
+  return ArrayBuffer.isView(value) || value instanceof ArrayBuffer;
+}
+
+/**
+ * Redact a value held under a known-sensitive key, whatever its type. Absent values are
+ * passed through: reporting "[REDACTED]" for a field that was never set would send a
+ * debugger looking for a value that does not exist.
+ */
+function redactSensitiveValue(value: unknown): unknown {
+  if (value === null || value === undefined) return value;
+  if (typeof value === "string") return redactIdentifier(value, true);
+  return REDACTED_PLACEHOLDER;
+}
+
 /**
  * Recursively redact sensitive fields in a data object.
- * - Fields in SENSITIVE_FIELD_NAMES get identifier-level redaction (first4...last4)
+ * - Fields in SENSITIVE_FIELD_NAMES are redacted whatever their type: strings get
+ *   identifier-level redaction (first4...last4), everything else becomes [REDACTED]
+ * - Binary buffers are replaced wholesale, at any depth
  * - All other string values get regex scrubbing for address/hex patterns
  */
 export function redactData<T>(obj: T): T {
@@ -71,6 +96,10 @@ export function redactData<T>(obj: T): T {
 
   if (typeof obj === "string") {
     return scrubString(obj) as T;
+  }
+
+  if (isBinary(obj)) {
+    return BINARY_PLACEHOLDER as T;
   }
 
   if (Array.isArray(obj)) {
@@ -85,8 +114,8 @@ export function redactData<T>(obj: T): T {
   if (typeof obj === "object") {
     const result: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
-      if (SENSITIVE_FIELD_NAMES.has(key) && typeof value === "string") {
-        result[key] = redactIdentifier(value, true);
+      if (SENSITIVE_FIELD_NAMES.has(key)) {
+        result[key] = redactSensitiveValue(value);
       } else {
         result[key] = redactData(value);
       }


### PR DESCRIPTION
> [!IMPORTANT]
> This makes the vault *able* to send Sentry events; it sends nothing until `NEXT_PUBLIC_SENTRY_DSN` is set on the vault environments. See _Before this does anything_ (in progress).

## Sentry has never transmitted an event from any deployed vault environment

Two independent failures, both addressed here.

**1. The enable gate read a variable no vault build sets.** `sentry.client.config.ts` gated `enabled` on `NEXT_PUBLIC_SIDECAR_API_URL`, but the vault build only ever sets `NEXT_PUBLIC_TBV_SIDECAR_API_URL` (the `TBV_` infix). The un-prefixed name is simple-staking's — removed from the vault workflow in `d200616f6` (#662), a month *before* the Sentry harness landed (`af8055829`, #867). Vite substitutes the missing var to `undefined`, so `enabled` was `false` in every deployed build. It failed silently, and the e2e specs hid it by setting the un-prefixed name (Sentry enabled in tests, disabled in prod — inverted).

**2. No DSN is set on the vault environments.** Verified via the GitHub API: `NEXT_PUBLIC_SENTRY_DSN` is unset on `vault-devnet`, `vault-staging-devnet`, and `vault-testnet` (only the `mainnet` env, which Genesis deploys to, has one). Being wired now.

## What this PR does

- **Gate on the DSN alone.** `enabled = Boolean(NEXT_PUBLIC_SENTRY_DSN)`. Events go **directly to Sentry**. A tunnel — which proxies events through our own host to dodge ad-blockers — moved to a dedicated, optional `NEXT_PUBLIC_SENTRY_TUNNEL_URL` (unset for now). Telemetry no longer depends on the logo sidecar (`NEXT_PUBLIC_TBV_SIDECAR_API_URL`), whose host has no `/sentry-tunnel` route anyway (returns 404 — verified), so unrelated infrastructure can never silently disable telemetry again. **No sidecar/devops work is required to start receiving data.**
- **Boot warning** when a deployed build (detected by its CI-injected `NEXT_PUBLIC_RELEASE_ID`, which survives a broken env-var injection) initializes with Sentry off, *or* is enabled but tagged `"local"` — catching a deploy that dropped the DSN and/or `NEXT_PUBLIC_SENTRY_ENVIRONMENT`, or a local build transmitting on a stray DSN. This is what would have caught the original bug on day one.
- **Session Replay and performance tracing disabled.** Both send envelopes that never pass through `beforeSend`/`scrubSentryEvent`: replay bypasses it entirely, and tracing/transaction envelopes need a separate `beforeSendTransaction` hook that doesn't exist. `maskAllText` doesn't cover request URLs or `href` attributes, and auto-instrumented fetch spans carry full URLs — both of which include the depositor's BTC address (the address-screening request URL `?address=<addr>` and explorer `/address/<addr>` links). So both paths would reach Sentry unredacted. Error/message events (which *do* go through the scrubber) still flow. Restore replay and tracing with their respective redaction hooks (the tracing one alongside the SDK-upgrade PR).
- **Playwright env** aligned with the deployed gate; the "missing config" e2e server forces the DSN empty so a developer's shell DSN can't make it transmit.
- **PII fix**, found while auditing the scrubber. `redactData` only redacted sensitive fields when `typeof value === "string"`. Secret material here is usually a `Uint8Array` (WOTS seeds, HTLC preimages, signatures) — under `seed`/`htlcSecretHex` it skipped redaction, and `Object.entries` spread it byte-by-byte into `{0:222,1:173,...}`, leaking every byte. Now: sensitive keys are redacted regardless of type, binary buffers are replaced at any depth, absent values pass through. Harmless only because Sentry was off; goes live the moment it turns on, so it belongs here. **+6 tests.**

## Verification

Driven in a real browser against a **production build** (not just unit tests):

| Build | Env (production-shaped) | Result |
|---|---|---|
| `main` | only `NEXT_PUBLIC_TBV_SIDECAR_API_URL` set | no envelope — Sentry disabled |
| this branch, DSN only, no tunnel | `NEXT_PUBLIC_SENTRY_DSN` set | `POST https://<dsn-host>/api/<id>/envelope/`, `sentry_client=sentry.javascript.react/8.33.0` |

- `tsc -p tsconfig.lib.json` clean, `eslint` clean, `pnpm --filter vault test` — 204 files / 2181 passed.
- `e2e/catastrophic-errors.spec.ts` "should send Sentry event" specs pass. (Two unrelated specs in that file fail identically on `main` — a plain-`vite` server that loads a local `.env`, and "Application Paused"; not touched here.)

## Deferred: the SDK 8→10 upgrade

`Sentry.metrics.*` (for the funnel/analytics work) requires `@sentry/react ≥ 10.25`. The repo enforces a **single `@sentry/react` version across the monorepo** (syncpack), so bumping the vault forces simple-staking (Genesis — live, transmitting) to move in lockstep. That's out of scope for "enable vault telemetry" and belongs in its own coordinated PR with Genesis tested. This PR stays on `8.33.0`.

## Before this does anything

An admin sets the DSN on the vault environments — as a **Variable** (the workflow reads `vars.NEXT_PUBLIC_SENTRY_DSN`; it's a public `NEXT_PUBLIC_` client DSN, not a secret), one value on all three:

```bash
gh variable set NEXT_PUBLIC_SENTRY_DSN --repo babylonlabs-io/babylon-toolkit --env vault-devnet         --body "<tbv-dsn>"
gh variable set NEXT_PUBLIC_SENTRY_DSN --repo babylonlabs-io/babylon-toolkit --env vault-staging-devnet --body "<tbv-dsn>"
gh variable set NEXT_PUBLIC_SENTRY_DSN --repo babylonlabs-io/babylon-toolkit --env vault-testnet        --body "<tbv-dsn>"
```

One `tbv` project, filtered by the `environment` tag. Split out `tbv-mainnet` when vault mainnet exists — the boundary Genesis draws.

## For reviewers — two deploy-time judgment calls

- **Direct egress.** This is the first direct third-party telemetry egress from the wallet app: with no tunnel set, the browser POSTs error/message/breadcrumb envelopes straight to the Sentry ingest host. All of those go through `beforeSend`/`scrubSentryEvent`; the two paths that bypass the scrubber (replay, tracing) are disabled, so nothing unscrubbed leaves. Worth conscious acceptance, and noting the DSN's data region.
- **CSP.** No Content-Security-Policy exists in-repo, so nothing blocks the ingest host here — but if the *deploy* sets a `connect-src`, it must include the Sentry ingest host, or events silently die (the exact failure this PR fixes). Verify at deploy time.

## Rollout

Turning Sentry on for the first time makes one untested thing live: `queryClient.ts` reports every failed query after 3 retries (the vault polls, so a degraded RPC could be noisy). Suggest deploying to **`vault-devnet` only** first, watching volume for a day, then promoting.

## Not in this PR (follow-ups)

The "events" PR: funnel milestones + `Sentry.metrics.*` (needs the SDK upgrade above), the swallowed catches in `useVaultActions` (a wrong HTLC secret currently reports nothing — CLAUDE.md critical path), dependency-outage detectors, wallet user context.

This PR touches no CLAUDE.md critical path.
