### PR TITLE
chore(vault): remove the Deposit BTC button from the navbar

### DIFF
--- a/services/vault/e2e/pages/AppShell.ts
+++ b/services/vault/e2e/pages/AppShell.ts
@@ -1,7 +1,7 @@
 /**
  * Page object for the vault dApp's persistent shell: top nav, connect
  * button, theme toggle, and the route-level entry points (Applications
- * tab, Activity tab, Deposit CTA).
+ * tab, Activity tab).
  *
  * Selectors prefer role+name with COPY constants so that copy edits
  * keep tests passing. Where a stable data-testid exists in source, it
@@ -32,21 +32,11 @@ export class AppShell {
     return this.page.getByRole("link", { name: /Activity/i });
   }
 
-  get depositCta(): Locator {
-    // The persistent "Deposit BTC" CTA rendered in RootLayout once a
-    // wallet is connected. Distinct from the in-modal "Deposit" submit.
-    return this.page.getByRole("button", { name: /^Deposit BTC$/i });
-  }
-
   async openActivity(): Promise<void> {
     await this.activityTab.click();
   }
 
   async openApplications(): Promise<void> {
     await this.applicationsTab.click();
-  }
-
-  async openDeposit(): Promise<void> {
-    await this.depositCta.click();
   }
 }

--- a/services/vault/e2e/real/actions/pegin.ts
+++ b/services/vault/e2e/real/actions/pegin.ts
@@ -52,7 +52,7 @@ import { connectWallets } from "./walletConnect";
 // a comment pointing at their `services/vault/src/copy.ts` source. Finish-line matchers below are
 // tolerant regexes instead — the activated-view copy has been observed to drift between source and the
 // deployed build, so those key on stable/actionable elements rather than exact wording.
-const DEPOSIT_BUTTON_TESTID = '[data-testid="deposit-button"]'; // header "Deposit sBTC"
+const DEPOSIT_BUTTON_TESTID = '[data-testid="deposit-button"]'; // dashboard Collateral-section "Deposit"
 const AMOUNT_PLACEHOLDER = "0"; // DepositForm amount input
 const SELECT_VP_LABEL = "Select vault provider"; // COPY.deposit.form.selectVaultProvider
 const DEPOSIT_CTA_LABEL = "Deposit"; // enabled DepositForm CTA (fluid button)

--- a/services/vault/e2e/real/actions/walletConnect.ts
+++ b/services/vault/e2e/real/actions/walletConnect.ts
@@ -5,7 +5,7 @@
  *   Connect (connect-wallet-button) → Select Bitcoin Wallet (select-bitcoin-wallet-button) →
  *   wallet-option-<id> → approve in the BTC extension popup → Select Ethereum Wallet
  *   (select-ethereum-wallet-button) → MetaMask (Reown AppKit) → approve MetaMask popup →
- *   Connect (chains-connect-button) → the deposit CTA (data-testid="deposit-button") appears.
+ *   Connect (chains-connect-button) → the dashboard deposit CTA (data-testid="deposit-button") appears.
  *
  * It assumes a pop-up approver is ALREADY installed on the context (see `approver.ts`) — the approval
  * pop-ups fire asynchronously during these clicks. Callers own the approver lifecycle so they can keep
@@ -23,7 +23,7 @@ import type { ActionContext } from "./types";
 const ETH_APPKIT_NAME: Record<EthWalletId, RegExp> = { metamask: /metamask/i };
 
 /**
- * Drive the connect flow to the connected state (the header deposit button visible). Requires an
+ * Drive the connect flow to the connected state (the dashboard deposit button visible). Requires an
  * active pop-up approver on `ctx.context`.
  */
 export async function connectWallets(ctx: ActionContext): Promise<void> {

--- a/services/vault/src/components/pages/RootLayout.tsx
+++ b/services/vault/src/components/pages/RootLayout.tsx
@@ -18,14 +18,9 @@ import { FaXTwitter } from "react-icons/fa6";
 import { NavLink, Outlet } from "react-router";
 import { twJoin } from "tailwind-merge";
 
-import { DepositButton } from "@/components/shared";
 import { PAGE_CONTENT_CLASS } from "@/components/shared/layoutClasses";
 import { CRITICAL_BANNER_SLOT_ID } from "@/components/simple/CriticalLiquidationTopBanner";
-import {
-  FeatureFlags,
-  getNetworkConfigBTC,
-  shouldDisplayTestingMsg,
-} from "@/config";
+import { FeatureFlags, shouldDisplayTestingMsg } from "@/config";
 import { useAddressScreening } from "@/context/addressScreening";
 import { useAddressType } from "@/context/addressType";
 import { useGeoFencing } from "@/context/geofencing";
@@ -42,10 +37,7 @@ import { AddressTypeBanner } from "../shared/AddressTypeBanner";
 import { DepositDisabledBanner } from "../shared/DepositDisabledBanner";
 import { GeoBlockState } from "../shared/GeoBlockState";
 import { NoticeBanner } from "../shared/NoticeBanner";
-import {
-  isDepositBlocked,
-  resolveBannerStatus,
-} from "../shared/protocolStatus";
+import { resolveBannerStatus } from "../shared/protocolStatus";
 import { ProtocolStatusBanner } from "../shared/ProtocolStatusBanner";
 import SimpleDeposit from "../simple/SimpleDeposit";
 import { Connect } from "../Wallet";
@@ -53,8 +45,6 @@ import { Connect } from "../Wallet";
 export interface RootLayoutContext {
   openDeposit: (initialAmountBtc?: string) => void;
 }
-
-const btcConfig = getNetworkConfigBTC();
 
 function MailIcon({ size = 32, title }: { size?: number; title?: string }) {
   return (
@@ -230,20 +220,6 @@ export default function RootLayout() {
           mobileNavigation={<MobileNavigation />}
           rightActions={
             <div className="flex items-center gap-4">
-              {isWalletConnected &&
-                !isDepositOpen &&
-                !isGeoBlocked &&
-                !isAddressBlocked && (
-                  <DepositButton
-                    data-testid="deposit-button"
-                    variant="outlined"
-                    rounded
-                    disabled={isDepositBlocked(gate)}
-                    onClick={() => openDeposit()}
-                  >
-                    Deposit {btcConfig.coinSymbol}
-                  </DepositButton>
-                )}
               <Connect />
               <StandardSettingsMenu theme={theme} setTheme={setTheme} />
             </div>

--- a/services/vault/src/components/simple/CollateralSection.tsx
+++ b/services/vault/src/components/simple/CollateralSection.tsx
@@ -260,6 +260,7 @@ export function CollateralSection({
         </Heading>
         <div className="flex items-center gap-2">
           <DepositButton
+            data-testid="deposit-button"
             variant="outlined"
             size="large"
             onClick={() => onDeposit()}

--- a/services/vault/src/components/simple/SimpleDeposit.tsx
+++ b/services/vault/src/components/simple/SimpleDeposit.tsx
@@ -320,6 +320,14 @@ function SimpleDepositContent({
     // dialog.
     if (isDepositBlocked(gate)) return;
 
+    // Address-screening guard on the submit path, mirroring the kill-switch guard
+    // above: the deposit entry points (Activity empty-state CTA, dashboard
+    // Collateral "Deposit" button) don't hide for a screened wallet, so a blocked
+    // address can open this dialog. The form CTA already disables ("Wallet not
+    // eligible"), but block here too so no future entry point can slip a screened
+    // wallet past. Fail closed while screening is still resolving.
+    if (isAddressBlocked || isScreeningLoading) return;
+
     // Per-position BTC Vault cap: never start a deposit that would push the
     // position past the on-chain cap, or when the cap couldn't be read (fail
     // closed) — defense-in-depth behind the disabled CTA.


### PR DESCRIPTION
<img width="1107" height="745" alt="Screenshot 2026-07-13 at 14 50 39" src="https://github.com/user-attachments/assets/885190a1-5450-46f9-8f70-ce87b0aab36b" />


Removes the persistent "Deposit BTC" call-to-action from the header's right actions in RootLayout, and cleans up the imports it left unused (DepositButton, getNetworkConfigBTC/btcConfig, isDepositBlocked).

The deposit flow's wiring is unchanged: openDeposit is still provided via the RootLayout Outlet context (reached from the Activity empty state and the dashboard liquidation banner), and SimpleDeposit + its dialog stay mounted.

One addition inside the flow: `handleDeposit` in SimpleDeposit now also blocks address-screened wallets on the submit path (mirroring the existing kill-switch guard, and failing closed while screening is still resolving). The form CTA already disables for a screened wallet ("Wallet not eligible"); this guard makes sure no current or future entry point can slip a screened wallet past it.
