### PR TITLE
test(vault): borrow E2E CLI

### DIFF
--- a/services/vault/e2e/real/actions/borrow.ts
+++ b/services/vault/e2e/real/actions/borrow.ts
@@ -1,0 +1,433 @@
+/**
+ * The "borrow" action: draw a borrowable token (Aave-style) against an activated BTC-Vault position,
+ * end-to-end on real Sepolia. Two shapes, selected by the CLI:
+ *   - REUSE (default): borrow against the depositor's existing collateral. run.ts already refused the
+ *     run before the browser if there's no active collateral (fetchBorrowContext), so we land on the
+ *     dashboard with the Borrow button enabled.
+ *   - PEGIN-FIRST (`--pegin-first`): peg in fresh collateral first (the shared `runPeginFlow`, which
+ *     ends on the dashboard with an active vault), then borrow — all in one browser session.
+ *
+ * The borrow flow itself is short and has NO multi-minute on-chain gates (unlike pegin): open Loans →
+ * Borrow, pick the token in the "Select asset" modal, enter the amount (a conservative fraction of the
+ * real-data max, or the form's Max), submit, and approve the single MetaMask transaction. Then the
+ * "Borrow successful" screen confirms it.
+ *
+ * Selectors are testid-first (added to the src borrow controls, mirroring `activate-vault-button`) with
+ * tolerant text/role/class fallbacks so a deployed build that predates the testids still works. No SDK
+ * / product logic is reimplemented — the amount is a best-effort default and the live form is the
+ * authoritative gate (its Max button + validation).
+ *
+ * NEVER run without an explicit go-ahead: it moves real value (a borrow draw, plus a full pegin when
+ * `--pegin-first`).
+ */
+import type { BrowserContext, Locator, Page } from "@playwright/test";
+
+import {
+  CONSERVATIVE_BORROW_FRACTION,
+  fetchCollateralSats,
+  fetchMaxBorrow,
+  formatBorrowAmount,
+} from "../borrowParams";
+import { formatBtc } from "../preflight";
+import {
+  BORROW_BUTTON_ENABLE_TIMEOUT_MS,
+  BORROW_CTA_ENABLE_TIMEOUT_MS,
+  BORROW_TX_TIMEOUT_MS,
+  FORM_SETTLE_MS,
+  FRESH_COLLATERAL_POLL_MS,
+  FRESH_COLLATERAL_TIMEOUT_MS,
+  MS_PER_SECOND,
+  STEP_TIMEOUT_MS,
+} from "../timing";
+
+import { installPopupApprover, sweepApprovals } from "./approver";
+import { runPeginFlow } from "./pegin";
+import { startRecording } from "./recording";
+import { FLUID_CTA_SELECTOR, firstByTestid } from "./selectors";
+import { type Action, type ActionContext } from "./types";
+import { connectWallets } from "./walletConnect";
+
+// Dashboard "Loans" section → Borrow (testid-first; the fallback matches the button only while it reads
+// exactly "Borrow", which is fine on the dashboard where the CTA isn't relabeled).
+const LOANS_BORROW_TESTID = '[data-testid="loans-borrow-button"]';
+const BORROW_BUTTON_RX = /^borrow$/i; // COPY.loans.borrowButton
+const ASSET_SELECT_TITLE = "Select asset"; // COPY.loans.assetSelection.title
+// Borrow form: the AmountSlider's numeric input (`inputmode="decimal"`, placeholder "0") + its Max
+// button (a <button> whose visible text is "Max"), and the fluid submit button.
+const AMOUNT_INPUT = 'input[inputmode="decimal"]';
+const MAX_BUTTON_RX = /^max$/i;
+const BORROW_SUBMIT_TESTID = '[data-testid="borrow-submit-button"]';
+const BORROW_SUBMIT_ENABLED_LABEL = "Borrow"; // COPY.loans.borrow.action (enabled state)
+// Submit labels that won't resolve by waiting — fail fast with the callout (COPY.loans.borrow.*).
+// "Borrowing Unavailable" is protocol-gated; "Amount too small" / "…exceeds available liquidity" are
+// fixed properties of the entered amount + reserve, not of how much collateral has propagated.
+const BORROW_INSTANT_FAIL_LABELS = new Set([
+  "Borrowing Unavailable",
+  "Amount too small",
+  "Amount exceeds available liquidity",
+]);
+// Labels that depend on the position's collateral and so can be TRANSIENT right after a pegin-first
+// activation — the borrow form's max/health-factor grow as the just-activated vault propagates into
+// its on-chain position read. We poll through these (not instant-fail) and only surface them if they
+// persist to the enable deadline (COPY.loans.borrow.*).
+const BORROW_COLLATERAL_DEPENDENT_LABELS = new Set([
+  "Amount exceeds maximum",
+  "Health factor too low",
+]);
+// Best-effort: the validation callout body phrases (COPY.loans.validation.*) + the availability ones,
+// surfaced in the fail-fast message so a blocked run says why.
+const CALLOUT_BODY_RX =
+  /(minimum borrowable|maximum borrowable|available to borrow|health factor|temporarily unavailable|Price data unavailable)[^.]*\./i;
+// Success screen (testid-first; tolerant fallbacks for a pre-testid deployed build).
+const SUCCESS_DONE_TESTID = '[data-testid="loan-success-done-button"]';
+const DONE_BUTTON_RX = /^done$/i; // COPY.loans.borrowSuccess.doneButton
+const BORROW_SUCCESS_RX = /borrow successful/i; // COPY.loans.borrowSuccess.title
+const TX_FAILED_RX = /transaction failed/i; // COPY.common.transactionFailedTitle
+const MAX_AMOUNT_KEYWORD = "max";
+
+/** The resolved borrow amount: click the form's Max button, or fill a specific token amount. */
+type BorrowAmount = { mode: "max" } | { mode: "amount"; value: string };
+
+/**
+ * Resolve the amount to borrow. An explicit `--borrow-amount` wins (a number, or `max`). Otherwise it
+ * computes a conservative fraction of the real-data max — this runs after any pegin-first pegin has
+ * activated, so fresh collateral is already readable — falling back to the form's Max if that read is
+ * zero or fails. The live form stays the authoritative gate either way.
+ */
+async function resolveBorrowAmount(ctx: ActionContext): Promise<BorrowAmount> {
+  const raw = ctx.config.borrowAmount?.trim();
+  if (raw && raw.toLowerCase() === MAX_AMOUNT_KEYWORD) return { mode: "max" };
+  if (raw) return { mode: "amount", value: raw };
+
+  // No explicit amount → compute a conservative fraction of the real-data max. This runs AFTER any
+  // pegin-first pegin has activated, so the fresh collateral is already on-chain and readable here
+  // (getPosition/getUserAccountData are on-chain, not indexer). Falls back to the form's Max only if
+  // the read is zero (indexer/state lag) or fails — the form stays the authoritative gate either way.
+  const token = ctx.config.borrowToken?.trim();
+  if (!token) return { mode: "max" };
+  try {
+    const max = await fetchMaxBorrow(
+      ctx.config.network,
+      ctx.eth.address,
+      token,
+    );
+    if (max.maxTokens > 0) {
+      const value = formatBorrowAmount(
+        max.maxTokens * CONSERVATIVE_BORROW_FRACTION,
+        max.decimals,
+      );
+      ctx.log(
+        `Borrow amount: ${value} ${max.symbol} (~${Math.round(CONSERVATIVE_BORROW_FRACTION * 100)}% of max ${formatBorrowAmount(max.maxTokens, max.decimals)} ${max.symbol}).`,
+      );
+      return { mode: "amount", value };
+    }
+    ctx.log(
+      `⚠️ Computed max borrow for ${token} is 0 — using the form's Max (it will gate the amount).`,
+    );
+  } catch (error) {
+    ctx.log(
+      `⚠️ Could not compute a conservative default (${error instanceof Error ? error.message : error}); using the form's Max.`,
+    );
+  }
+  return { mode: "max" };
+}
+
+/** Open the borrow flow from the dashboard: click Loans → Borrow, wait for the "Select asset" modal. */
+async function openBorrow(page: Page, log: (m: string) => void): Promise<void> {
+  const borrow = firstByTestid(
+    page,
+    LOANS_BORROW_TESTID,
+    page.getByRole("button", { name: BORROW_BUTTON_RX }),
+  );
+  await borrow.waitFor({ state: "visible", timeout: STEP_TIMEOUT_MS });
+  // The button is gated on `hasCollateral` (collateral > 0). A JUST-activated vault (pegin-first) takes
+  // a moment to propagate into the app's position read, so the button can be briefly disabled right
+  // after "Go to Dashboard". Poll for it to enable rather than failing on the first check; only treat a
+  // persistently-disabled button as "no collateral". (A reuse run already passed run.ts's collateral
+  // gate, so its button is enabled almost immediately.)
+  const deadline = Date.now() + BORROW_BUTTON_ENABLE_TIMEOUT_MS;
+  let enabled = await borrow.isEnabled().catch(() => false);
+  while (!enabled && Date.now() < deadline) {
+    await page.waitForTimeout(FORM_SETTLE_MS);
+    enabled = await borrow.isEnabled().catch(() => false);
+  }
+  if (!enabled)
+    throw new Error(
+      `The dashboard Borrow button stayed disabled for ${Math.round(BORROW_BUTTON_ENABLE_TIMEOUT_MS / MS_PER_SECOND)}s — this position has no active BTC Vault collateral to borrow against. Peg in first (or re-run with --pegin-first).`,
+    );
+  log("Opening the borrow flow (Loans → Borrow)");
+  await borrow.click();
+  await page
+    .getByText(ASSET_SELECT_TITLE, { exact: true })
+    .first()
+    .waitFor({ state: "visible", timeout: STEP_TIMEOUT_MS });
+}
+
+/**
+ * Pick the borrow token in the "Select asset" modal. Prefer the per-symbol testid; fall back to the row
+ * whose text contains the symbol (case-insensitive — symbols are alphanumeric so no regex escaping is
+ * needed). With no token specified, take the first asset row (testid-based; requires the testid build).
+ * Returns the symbol used, for the success log.
+ */
+async function selectAsset(
+  page: Page,
+  log: (m: string) => void,
+  token: string | undefined,
+): Promise<string | undefined> {
+  const row = token
+    ? firstByTestid(
+        page,
+        `[data-testid="asset-select-row-${token.toLowerCase()}"]`,
+        page.getByRole("button").filter({ hasText: new RegExp(token, "i") }),
+      )
+    : page.locator('[data-testid^="asset-select-row-"]').first();
+  if (!(await row.isVisible().catch(() => false)))
+    throw new Error(
+      token
+        ? `Borrow token "${token}" was not found in the asset picker.`
+        : "No borrow token specified and no asset rows were found — re-run with --borrow-token=<symbol>.",
+    );
+  const label = (await row.innerText().catch(() => ""))
+    .replace(/\s+/g, " ")
+    .trim();
+  await row.click();
+  log(`Selected borrow token: ${token ?? label}`);
+  return token ?? label;
+}
+
+/** Enter the borrow amount: click the form's Max button, or fill the numeric input. */
+async function fillBorrowAmount(
+  page: Page,
+  log: (m: string) => void,
+  amount: BorrowAmount,
+): Promise<void> {
+  if (amount.mode === "max") {
+    log("Borrow amount: Max (clicking the form's Max button)");
+    const max = page.getByRole("button", { name: MAX_BUTTON_RX }).first();
+    await max.waitFor({ state: "visible", timeout: STEP_TIMEOUT_MS });
+    await max.click();
+  } else {
+    log(`Entering borrow amount: ${amount.value}`);
+    const input = page.locator(AMOUNT_INPUT).first();
+    await input.waitFor({ state: "visible", timeout: STEP_TIMEOUT_MS });
+    await input.fill(amount.value);
+  }
+  await page.waitForTimeout(FORM_SETTLE_MS);
+}
+
+/** Best-effort: read the validation/availability callout body so a blocked run explains why. */
+async function readCalloutText(page: Page): Promise<string> {
+  const callout = page.getByText(CALLOUT_BODY_RX).first();
+  if (!(await callout.isVisible().catch(() => false))) return "";
+  return (await callout.innerText().catch(() => ""))
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * Wait for the fluid submit button to become the enabled "Borrow". It relabels through "Enter an
+ * amount" / "Refreshing position…" while the price + position settle; we key on the stable
+ * label-independent control (testid, else the fluid-button class) and read its text each tick, logging
+ * changes. An instant-fail label (protocol paused, amount too small, over reserve liquidity) throws
+ * immediately with the callout. A collateral-dependent label ("Amount exceeds maximum" / "Health factor
+ * too low") is treated as possibly-TRANSIENT — right after a pegin-first activation the form's max grows
+ * as the new vault propagates — so we keep polling and only surface it if it persists to the deadline.
+ */
+async function waitForBorrowCta(
+  page: Page,
+  log: (m: string) => void,
+): Promise<Locator> {
+  const cta = firstByTestid(
+    page,
+    BORROW_SUBMIT_TESTID,
+    page.locator(FLUID_CTA_SELECTOR),
+  );
+  const deadline = Date.now() + BORROW_CTA_ENABLE_TIMEOUT_MS;
+  let lastLabel = "";
+  while (Date.now() < deadline) {
+    const label = ((await cta.textContent().catch(() => "")) ?? "").trim();
+    if (label && label !== lastLabel) {
+      log(`Borrow CTA: "${label}"`);
+      lastLabel = label;
+    }
+    if (BORROW_INSTANT_FAIL_LABELS.has(label)) {
+      const callout = await readCalloutText(page);
+      throw new Error(
+        `Borrow blocked at the form: "${label}"${callout ? ` — ${callout}` : ""}`,
+      );
+    }
+    if (
+      label === BORROW_SUBMIT_ENABLED_LABEL &&
+      (await cta.isEnabled().catch(() => false))
+    )
+      return cta;
+    await page.waitForTimeout(FORM_SETTLE_MS);
+  }
+  // Deadline: surface the terminal label + callout. A persistent collateral-dependent label here means
+  // the amount genuinely exceeds the (fully-propagated) position's capacity — not a transient.
+  const callout = await readCalloutText(page);
+  const stuck = BORROW_COLLATERAL_DEPENDENT_LABELS.has(lastLabel)
+    ? ` — the amount still exceeds this position's capacity after waiting for collateral to settle`
+    : "";
+  throw new Error(
+    `Borrow CTA did not become the enabled "${BORROW_SUBMIT_ENABLED_LABEL}" within ${BORROW_CTA_ENABLE_TIMEOUT_MS}ms (last label: "${lastLabel}")${stuck}${callout ? ` — ${callout}` : ""}.`,
+  );
+}
+
+/**
+ * After submitting, actively approve the MetaMask pop-up (the borrow is one ETH tx — the reused OKX-style
+ * window needs the active sweep; MetaMask fires its own event too) and wait for the "Borrow successful"
+ * screen, then click Done. Fails fast if the form surfaces a "Transaction failed" callout.
+ */
+async function confirmBorrowSuccess(
+  page: Page,
+  context: BrowserContext,
+  log: (m: string) => void,
+  symbol: string | undefined,
+): Promise<void> {
+  const done = firstByTestid(
+    page,
+    SUCCESS_DONE_TESTID,
+    page.getByRole("button", { name: DONE_BUTTON_RX }),
+  );
+  const success = page.getByText(BORROW_SUCCESS_RX).first();
+  const txFailed = page.getByText(TX_FAILED_RX).first();
+  const deadline = Date.now() + BORROW_TX_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    await sweepApprovals(context, page, log);
+
+    if (
+      (await success.isVisible().catch(() => false)) ||
+      (await done.isVisible().catch(() => false))
+    ) {
+      log(
+        `✅ Borrow successful${symbol ? ` (${symbol})` : ""} — clicking Done`,
+      );
+      await done.click({ timeout: STEP_TIMEOUT_MS }).catch(() => {});
+      return;
+    }
+    if (await txFailed.isVisible().catch(() => false)) {
+      const detail = await readCalloutText(page);
+      throw new Error(
+        `Borrow transaction failed${detail ? ` — ${detail}` : ""}. See trace.zip + the failure screenshot.`,
+      );
+    }
+    await page.waitForTimeout(FORM_SETTLE_MS);
+  }
+  throw new Error(
+    `Borrow did not reach the "Borrow successful" screen within ${BORROW_TX_TIMEOUT_MS}ms — the MetaMask transaction may not have confirmed. See trace.zip + the failure screenshot.`,
+  );
+}
+
+/** Drive the borrow flow proper (assumes wallets connected + approver/recorder installed by the caller). */
+async function runBorrowFlow(
+  ctx: ActionContext,
+  onStep: (step: string) => void,
+): Promise<void> {
+  const { page, context, log } = ctx;
+  const token = ctx.config.borrowToken?.trim() || undefined;
+
+  onStep("borrow-open");
+  await openBorrow(page, log);
+
+  onStep("borrow-select-asset");
+  const symbol = await selectAsset(page, log, token);
+
+  onStep("borrow-form");
+  const amount = await resolveBorrowAmount(ctx);
+  await fillBorrowAmount(page, log, amount);
+  const cta = await waitForBorrowCta(page, log);
+
+  onStep("borrow-submit");
+  log(
+    "Borrow CTA enabled — submitting (the approver will confirm the MetaMask tx)",
+  );
+  await cta.click();
+
+  await confirmBorrowSuccess(page, context, log, symbol);
+}
+
+/**
+ * pegin-first only: wait for the just-activated vault's collateral to register on-chain BEFORE
+ * borrowing. The vault is shown active optimistically, but the borrow max is derived from the on-chain
+ * position, which lags — so borrowing immediately (especially an amount sized for the new collateral)
+ * would be rejected as over-max. We poll the adapter position's BTC collateral (sats — exact and
+ * price-independent) until it rises STRICTLY above the pre-pegin baseline, i.e. the new vault (fresh, or
+ * a second vault added to an existing position) has been counted. Non-fatal on timeout: the borrow
+ * form's own CTA wait still gates the amount, so this is an explicit + logged settle, not a hard gate.
+ */
+async function waitForFreshCollateral(
+  ctx: ActionContext,
+  baselineSats: bigint,
+): Promise<void> {
+  ctx.log(
+    `Waiting for the new collateral to register on-chain (baseline ${formatBtc(baselineSats)})…`,
+  );
+  const deadline = Date.now() + FRESH_COLLATERAL_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const sats = await fetchCollateralSats(
+      ctx.config.network,
+      ctx.eth.address,
+    ).catch(() => null);
+    if (sats != null && sats > baselineSats) {
+      ctx.log(
+        `✅ New collateral registered on-chain: ${formatBtc(baselineSats)} → ${formatBtc(sats)}.`,
+      );
+      return;
+    }
+    await ctx.page.waitForTimeout(FRESH_COLLATERAL_POLL_MS);
+  }
+  ctx.log(
+    `⚠️ New collateral hadn't registered on-chain within ${Math.round(FRESH_COLLATERAL_TIMEOUT_MS / MS_PER_SECOND)}s — proceeding; the borrow form's CTA wait will gate the amount.`,
+  );
+}
+
+export const borrowAction: Action = {
+  id: "borrow",
+  async run(ctx: ActionContext): Promise<void> {
+    const { page, context, log, artifactsDir } = ctx;
+
+    // One approver + one recorder for the WHOLE run — including the optional pegin phase — so a
+    // pegin-first borrow keeps a single set across both (see runPeginFlow's contract).
+    const handler = installPopupApprover(context, log);
+    let currentStep = "connect";
+    const recorder = await startRecording(
+      context,
+      page,
+      artifactsDir,
+      log,
+      () => currentStep,
+    );
+    try {
+      await connectWallets(ctx);
+
+      if (ctx.config.peginFirst) {
+        log(
+          "Borrow --pegin-first: pegging in fresh collateral before borrowing",
+        );
+        // Snapshot the on-chain collateral BEFORE the pegin so we can wait for THIS pegin's vault to
+        // register — a strict increase over the baseline. This is what makes "0.01 existing + new 0.01"
+        // correct: collateral is already > 0, so we must wait for it to rise past the baseline, not just
+        // be non-zero. A failed read → 0n baseline (worst case we wait for any collateral).
+        const baselineSats = await fetchCollateralSats(
+          ctx.config.network,
+          ctx.eth.address,
+        ).catch(() => 0n);
+        await runPeginFlow(ctx, (step) => {
+          currentStep = `pegin:${step}`;
+        });
+        currentStep = "borrow-await-collateral";
+        await waitForFreshCollateral(ctx, baselineSats);
+      }
+
+      await runBorrowFlow(ctx, (step) => {
+        currentStep = step;
+      });
+
+      log("✅ Borrow complete.");
+    } finally {
+      await recorder.stop();
+      context.off("page", handler);
+    }
+  },
+};

--- a/services/vault/e2e/real/actions/borrow.ts
+++ b/services/vault/e2e/real/actions/borrow.ts
@@ -24,6 +24,7 @@ import type { BrowserContext, Locator, Page } from "@playwright/test";
 
 import {
   CONSERVATIVE_BORROW_FRACTION,
+  fetchBorrowContext,
   fetchCollateralSats,
   fetchMaxBorrow,
   formatBorrowAmount,
@@ -84,6 +85,11 @@ const DONE_BUTTON_RX = /^done$/i; // COPY.loans.borrowSuccess.doneButton
 const BORROW_SUCCESS_RX = /borrow successful/i; // COPY.loans.borrowSuccess.title
 const TX_FAILED_RX = /transaction failed/i; // COPY.common.transactionFailedTitle
 const MAX_AMOUNT_KEYWORD = "max";
+/**
+ * Minimum on-chain debt rise (USD) that counts as "the borrow landed", checked after the success
+ * screen. Small — a real borrow adds far more — but above float/oracle-tick noise on the existing debt.
+ */
+const DEBT_INCREASE_MIN_USD = 0.01;
 
 /** The resolved borrow amount: click the form's Max button, or fill a specific token amount. */
 type BorrowAmount = { mode: "max" } | { mode: "amount"; value: string };
@@ -91,45 +97,48 @@ type BorrowAmount = { mode: "max" } | { mode: "amount"; value: string };
 /**
  * Resolve the amount to borrow. An explicit `--borrow-amount` wins (a number, or `max`). Otherwise it
  * computes a conservative fraction of the real-data max — this runs after any pegin-first pegin has
- * activated, so fresh collateral is already readable — falling back to the form's Max if that read is
- * zero or fails. The live form stays the authoritative gate either way.
+ * activated, so fresh collateral is already readable. If that computation can't produce a positive
+ * amount (read failed, max is 0, or the fraction rounds to 0 at the token's precision) it THROWS rather
+ * than silently borrowing the form's full Max — full-max is only ever used when explicitly requested
+ * via `--borrow-amount=max`, so a failed read can't pin the health factor at the liquidation edge.
  */
 async function resolveBorrowAmount(ctx: ActionContext): Promise<BorrowAmount> {
   const raw = ctx.config.borrowAmount?.trim();
   if (raw && raw.toLowerCase() === MAX_AMOUNT_KEYWORD) return { mode: "max" };
   if (raw) return { mode: "amount", value: raw };
 
-  // No explicit amount → compute a conservative fraction of the real-data max. This runs AFTER any
-  // pegin-first pegin has activated, so the fresh collateral is already on-chain and readable here
-  // (getPosition/getUserAccountData are on-chain, not indexer). Falls back to the form's Max only if
-  // the read is zero (indexer/state lag) or fails — the form stays the authoritative gate either way.
   const token = ctx.config.borrowToken?.trim();
-  if (!token) return { mode: "max" };
+  if (!token)
+    throw new Error(
+      "borrow: no --borrow-token resolved and no --borrow-amount given — cannot compute a safe default. Re-run with --borrow-token and/or --borrow-amount.",
+    );
+
+  let max;
   try {
-    const max = await fetchMaxBorrow(
-      ctx.config.network,
-      ctx.eth.address,
-      token,
-    );
-    if (max.maxTokens > 0) {
-      const value = formatBorrowAmount(
-        max.maxTokens * CONSERVATIVE_BORROW_FRACTION,
-        max.decimals,
-      );
-      ctx.log(
-        `Borrow amount: ${value} ${max.symbol} (~${Math.round(CONSERVATIVE_BORROW_FRACTION * 100)}% of max ${formatBorrowAmount(max.maxTokens, max.decimals)} ${max.symbol}).`,
-      );
-      return { mode: "amount", value };
-    }
-    ctx.log(
-      `⚠️ Computed max borrow for ${token} is 0 — using the form's Max (it will gate the amount).`,
-    );
+    max = await fetchMaxBorrow(ctx.config.network, ctx.eth.address, token);
   } catch (error) {
-    ctx.log(
-      `⚠️ Could not compute a conservative default (${error instanceof Error ? error.message : error}); using the form's Max.`,
+    throw new Error(
+      `borrow: could not compute the max borrow for ${token} (${error instanceof Error ? error.message : error}) — refusing to guess an amount. Re-run with an explicit --borrow-amount (or --borrow-amount=max).`,
     );
   }
-  return { mode: "max" };
+
+  // Guard on the FORMATTED value, not raw maxTokens: 25% of a tiny max can floor to "0" at the token's
+  // precision, which would fill 0 and stall at "Enter an amount". A zero/failed default fails loudly.
+  const value =
+    max.maxTokens > 0
+      ? formatBorrowAmount(
+          max.maxTokens * CONSERVATIVE_BORROW_FRACTION,
+          max.decimals,
+        )
+      : "0";
+  if (Number(value) <= 0)
+    throw new Error(
+      `borrow: the conservative default for ${token} rounds to 0 (computed max ${formatBorrowAmount(max.maxTokens, max.decimals)} ${token} is too small to borrow ${Math.round(CONSERVATIVE_BORROW_FRACTION * 100)}% of). Re-run with an explicit --borrow-amount.`,
+    );
+  ctx.log(
+    `Borrow amount: ${value} ${max.symbol} (~${Math.round(CONSERVATIVE_BORROW_FRACTION * 100)}% of max ${formatBorrowAmount(max.maxTokens, max.decimals)} ${max.symbol}).`,
+  );
+  return { mode: "amount", value };
 }
 
 /** Open the borrow flow from the dashboard: click Loans → Borrow, wait for the "Select asset" modal. */
@@ -167,6 +176,8 @@ async function openBorrow(page: Page, log: (m: string) => void): Promise<void> {
  * Pick the borrow token in the "Select asset" modal. Prefer the per-symbol testid; fall back to the row
  * whose text contains the symbol (case-insensitive — symbols are alphanumeric so no regex escaping is
  * needed). With no token specified, take the first asset row (testid-based; requires the testid build).
+ * The modal shows "Loading assets…" until the oracle-price query resolves, so we WAIT for the row (not a
+ * one-shot check) and only fail on timeout — otherwise a healthy run could race the load and see no rows.
  * Returns the symbol used, for the success log.
  */
 async function selectAsset(
@@ -181,10 +192,14 @@ async function selectAsset(
         page.getByRole("button").filter({ hasText: new RegExp(token, "i") }),
       )
     : page.locator('[data-testid^="asset-select-row-"]').first();
-  if (!(await row.isVisible().catch(() => false)))
+  const appeared = await row
+    .waitFor({ state: "visible", timeout: STEP_TIMEOUT_MS })
+    .then(() => true)
+    .catch(() => false);
+  if (!appeared)
     throw new Error(
       token
-        ? `Borrow token "${token}" was not found in the asset picker.`
+        ? `Borrow token "${token}" was not found in the asset picker within ${Math.round(STEP_TIMEOUT_MS / MS_PER_SECOND)}s.`
         : "No borrow token specified and no asset rows were found — re-run with --borrow-token=<symbol>.",
     );
   const label = (await row.innerText().catch(() => ""))
@@ -285,25 +300,30 @@ async function confirmBorrowSuccess(
   log: (m: string) => void,
   symbol: string | undefined,
 ): Promise<void> {
-  const done = firstByTestid(
+  // Success is gated ONLY on markers specific to the borrow-success screen — the "Borrow successful"
+  // title or the `loan-success-done-button` testid. NOT the generic "Done" role: deposit/withdraw/repay
+  // modals also have Done buttons, so keying on any Done could report a false success. The generic-role
+  // done is only the click TARGET (via firstByTestid), used after success is confirmed.
+  const successTitle = page.getByText(BORROW_SUCCESS_RX).first();
+  const successDone = page.locator(SUCCESS_DONE_TESTID).first();
+  const doneButton = firstByTestid(
     page,
     SUCCESS_DONE_TESTID,
     page.getByRole("button", { name: DONE_BUTTON_RX }),
   );
-  const success = page.getByText(BORROW_SUCCESS_RX).first();
   const txFailed = page.getByText(TX_FAILED_RX).first();
   const deadline = Date.now() + BORROW_TX_TIMEOUT_MS;
   while (Date.now() < deadline) {
     await sweepApprovals(context, page, log);
 
     if (
-      (await success.isVisible().catch(() => false)) ||
-      (await done.isVisible().catch(() => false))
+      (await successTitle.isVisible().catch(() => false)) ||
+      (await successDone.isVisible().catch(() => false))
     ) {
       log(
         `✅ Borrow successful${symbol ? ` (${symbol})` : ""} — clicking Done`,
       );
-      await done.click({ timeout: STEP_TIMEOUT_MS }).catch(() => {});
+      await doneButton.click({ timeout: STEP_TIMEOUT_MS }).catch(() => {});
       return;
     }
     if (await txFailed.isVisible().catch(() => false)) {
@@ -316,6 +336,45 @@ async function confirmBorrowSuccess(
   }
   throw new Error(
     `Borrow did not reach the "Borrow successful" screen within ${BORROW_TX_TIMEOUT_MS}ms — the MetaMask transaction may not have confirmed. See trace.zip + the failure screenshot.`,
+  );
+}
+
+/**
+ * After the success screen, verify on-chain that the position's debt actually rose — the UI "Borrow
+ * successful" alone doesn't prove funds moved. Polls `fetchBorrowContext` (on-chain `getUserAccountData`)
+ * until the debt exceeds the pre-borrow baseline. Same baseline pattern as `waitForFreshCollateral`.
+ * Skipped (with a warning) only if the pre-borrow baseline couldn't be read — never silently passes.
+ */
+async function assertBorrowDebtIncreased(
+  ctx: ActionContext,
+  debtBeforeUsd: number | null,
+): Promise<void> {
+  if (debtBeforeUsd == null) {
+    ctx.log(
+      "⚠️ Skipping the on-chain debt check — couldn't read the pre-borrow debt to compare against.",
+    );
+    return;
+  }
+  const deadline = Date.now() + BORROW_TX_TIMEOUT_MS;
+  let lastUsd = debtBeforeUsd;
+  while (Date.now() < deadline) {
+    const context = await fetchBorrowContext(
+      ctx.config.network,
+      ctx.eth.address,
+    ).catch(() => null);
+    if (context) {
+      lastUsd = context.currentDebtUsd;
+      if (lastUsd > debtBeforeUsd + DEBT_INCREASE_MIN_USD) {
+        ctx.log(
+          `✅ On-chain debt rose: $${debtBeforeUsd.toFixed(2)} → $${lastUsd.toFixed(2)}.`,
+        );
+        return;
+      }
+    }
+    await ctx.page.waitForTimeout(FRESH_COLLATERAL_POLL_MS);
+  }
+  throw new Error(
+    `Borrow reached the success screen but on-chain debt did not rise within ${Math.round(BORROW_TX_TIMEOUT_MS / MS_PER_SECOND)}s (before $${debtBeforeUsd.toFixed(2)}, last $${lastUsd.toFixed(2)}) — the position doesn't reflect the new debt.`,
   );
 }
 
@@ -334,6 +393,14 @@ async function runBorrowFlow(
   const symbol = await selectAsset(page, log, token);
 
   onStep("borrow-form");
+  // Snapshot the on-chain debt BEFORE submitting so we can assert it rose afterwards (a real-data
+  // post-condition on top of the UI success screen).
+  const debtBeforeUsd = await fetchBorrowContext(
+    ctx.config.network,
+    ctx.eth.address,
+  )
+    .then((c) => c.currentDebtUsd)
+    .catch(() => null);
   const amount = await resolveBorrowAmount(ctx);
   await fillBorrowAmount(page, log, amount);
   const cta = await waitForBorrowCta(page, log);
@@ -345,6 +412,9 @@ async function runBorrowFlow(
   await cta.click();
 
   await confirmBorrowSuccess(page, context, log, symbol);
+
+  onStep("borrow-verify");
+  await assertBorrowDebtIncreased(ctx, debtBeforeUsd);
 }
 
 /**

--- a/services/vault/e2e/real/actions/index.ts
+++ b/services/vault/e2e/real/actions/index.ts
@@ -1,10 +1,11 @@
 /**
- * Registry of implemented actions: connect, observe, wallet-config, pegin, and sign-conformance. The
- * remaining actions (borrow/repay/withdraw) are declared disabled in `config.ts` for the CLI's roadmap
- * display and register here as they land.
+ * Registry of implemented actions: connect, observe, wallet-config, pegin, sign-conformance, and
+ * borrow. The remaining actions (repay/withdraw) are declared disabled in `config.ts` for the CLI's
+ * roadmap display and register here as they land.
  */
 import type { ActionId } from "../config";
 
+import { borrowAction } from "./borrow";
 import { connectAction } from "./connect";
 import { observeAction } from "./observe";
 import { peginAction } from "./pegin";
@@ -18,4 +19,5 @@ export const ACTIONS_BY_ID: Partial<Record<ActionId, Action>> = {
   "wallet-config": walletConfigAction,
   pegin: peginAction,
   "sign-conformance": signConformanceAction,
+  borrow: borrowAction,
 };

--- a/services/vault/e2e/real/actions/pegin.ts
+++ b/services/vault/e2e/real/actions/pegin.ts
@@ -45,6 +45,7 @@ import {
 
 import { installPopupApprover, sweepApprovals } from "./approver";
 import { startRecording } from "./recording";
+import { FLUID_CTA_SELECTOR, firstByTestid } from "./selectors";
 import { type Action, type ActionContext } from "./types";
 import { connectWallets } from "./walletConnect";
 
@@ -56,6 +57,11 @@ const DEPOSIT_BUTTON_TESTID = '[data-testid="deposit-button"]'; // header "Depos
 const AMOUNT_PLACEHOLDER = "0"; // DepositForm amount input
 const SELECT_VP_LABEL = "Select vault provider"; // COPY.deposit.form.selectVaultProvider
 const DEPOSIT_CTA_LABEL = "Deposit"; // enabled DepositForm CTA (fluid button)
+// The fluid CTA also renders these at-cap states (COPY.deposit.maxVaultsReached) — detect them so an
+// at-cap position fails fast with a clear message instead of hitting the 90s CTA-enable timeout.
+const MAX_VAULTS_CTA_LABEL = "Maximum BTC Vaults reached"; // COPY.deposit.maxVaultsReached.cta
+const VAULT_COUNT_UNAVAILABLE_CTA_LABEL =
+  "Unable to verify BTC Vault count — please try again"; // COPY.deposit.maxVaultsReached.unavailableCta
 const SIGN_TRANSACTION_LABEL = "Sign Transaction"; // COPY.deposit.progress.buttons.signTransaction
 // The activation modal's confirm button. Selected testid-first (stable + text-independent) with a
 // tolerant-text fallback: the button copy drifts (COPY.deposit.activateConfirmation.activateButton
@@ -66,10 +72,11 @@ const ACTIVATE_VAULT_RX = /activate vault/i; // COPY.deposit.activateConfirmatio
 
 /** The activation modal's confirm button — testid if present (future-proof), else tolerant wording. */
 function activateButton(page: Page): Locator {
-  return page
-    .locator(ACTIVATE_VAULT_TESTID)
-    .or(page.getByRole("button", { name: ACTIVATE_VAULT_RX }))
-    .first();
+  return firstByTestid(
+    page,
+    ACTIVATE_VAULT_TESTID,
+    page.getByRole("button", { name: ACTIVATE_VAULT_RX }),
+  );
 }
 const RISK_ACK_LABEL =
   "I understand the risks of continuing without the artifacts."; // riskAcknowledgement
@@ -239,7 +246,7 @@ async function waitForDepositCta(
   page: Page,
   log: (m: string) => void,
 ): Promise<Locator> {
-  const cta = page.locator("button.bbn-btn-fluid").first();
+  const cta = page.locator(FLUID_CTA_SELECTOR).first();
   const deadline = Date.now() + DEPOSIT_CTA_ENABLE_TIMEOUT_MS;
   let lastLabel = "";
   while (Date.now() < deadline) {
@@ -248,6 +255,17 @@ async function waitForDepositCta(
       log(`Deposit CTA: "${label}"`);
       lastLabel = label;
     }
+    // The position is at its BTC-Vault cap (or the count couldn't be verified) — the form blocks the
+    // deposit here. Fail fast with a clear message instead of waiting out the CTA-enable timeout. This
+    // is the authoritative gate (the run.ts pre-flight is only a best-effort early check).
+    if (label === MAX_VAULTS_CTA_LABEL)
+      throw new Error(
+        "Maximum BTC Vaults reached — the deposit form is blocking new peg-ins for this position (its BTC-Vault cap is full). Redeem/withdraw a vault or use a different ETH account.",
+      );
+    if (label === VAULT_COUNT_UNAVAILABLE_CTA_LABEL)
+      throw new Error(
+        "The deposit form could not verify this position's BTC-Vault count and is blocking the deposit — retry once the cap read recovers.",
+      );
     if (
       label === DEPOSIT_CTA_LABEL &&
       (await cta.isEnabled().catch(() => false))
@@ -377,6 +395,36 @@ async function readActiveStep(page: Page): Promise<string> {
   return `${labels.length ? labels.join(", ") : "Step ?"} (${percent ?? "?"}%)`;
 }
 
+// The per-vault "WOTS key submission skipped" warning the app shows when the vault provider isn't ready
+// for WOTS-key submission before the readiness timeout (COPY.deposit.warnings.wotsReadinessTimeout /
+// wotsReadinessTerminal). A skipped vault is dropped from payout signing + activation and can NEVER
+// reach the activated view — so it's a hard dead-end for that vault, not a transient. Both variants
+// share this "Vault N: WOTS key submission skipped" prefix; the capture group is the vault number.
+const WOTS_SKIP_RX = /Vault\s+(\d+):\s*WOTS key submission skipped/i;
+
+/**
+ * Count DISTINCT per-vault WOTS-key-submission-skip banners on the progress view. Deduped by the vault
+ * number so a banner matched via nested elements (or re-rendered) isn't double-counted; a copy drift
+ * that breaks the "Vault N:" prefix simply yields 0 (we degrade to the normal budget wait, never a
+ * false abort). Used by walkStepMachine to fail fast when every expected vault has been skipped.
+ */
+async function countWotsSkippedVaults(page: Page): Promise<number> {
+  const banners = page.getByText(/WOTS key submission skipped/i);
+  const count = await banners.count().catch(() => 0);
+  const vaults = new Set<string>();
+  for (let i = 0; i < count; i++) {
+    const text = (
+      await banners
+        .nth(i)
+        .innerText()
+        .catch(() => "")
+    ).replace(/\s+/g, " ");
+    const match = text.match(WOTS_SKIP_RX);
+    if (match) vaults.add(match[1]);
+  }
+  return vaults.size;
+}
+
 /**
  * Walk the 15-step signing machine to the activated vault. Two approval mechanisms run in parallel:
  * the event-driven `installPopupApprover` (for NEW wallet windows) and, each tick, an active
@@ -420,6 +468,21 @@ async function walkStepMachine(
     // one activation this fresh deposit always performs.
     if ((await activatedViewReached(page)) && activationCount >= expectedVaults)
       return prePeginTxid;
+
+    // Fast-fail on a vault-provider readiness dead-end. If the VP never became ready for WOTS-key
+    // submission, the app skips that vault and it can never activate. Once EVERY expected vault is
+    // skipped there is no route to the activated view — abort now (with a clear, VP-attributed message)
+    // instead of polling out the multi-hour budget. A split where only one sibling is skipped keeps
+    // going (skipped < expectedVaults), matching the app, which continues the ready sibling.
+    const skippedVaults = await countWotsSkippedVaults(page);
+    if (skippedVaults >= expectedVaults)
+      throw new Error(
+        `Vault-provider readiness timeout: the vault provider did not become ready for WOTS-key ` +
+          `submission, so ${skippedVaults === 1 ? "the vault was" : `all ${skippedVaults} vaults were`} ` +
+          `skipped and cannot activate. This is a vault-provider availability issue (not the CLI) — ` +
+          `retry once the provider is healthy. The Pre-PegIn is already broadcast, so the deposit can ` +
+          `be resumed later rather than re-pegged.`,
+      );
 
     // Actively approve any reused wallet window (OKX) that the event approver can't see.
     await sweepApprovals(context, page, log);
@@ -596,20 +659,61 @@ async function assertActivatedAndOnDashboard(
     );
 }
 
+/**
+ * The pegin flow proper: deposit form → "Sign Transaction" → the 15-step signing machine → activated
+ * vault on the dashboard. Assumes the caller has ALREADY connected the wallets and installed the
+ * pop-up approver + recorder for the run (so a composite like `borrow --pegin-first` keeps a single
+ * approver/recorder across both phases). `onStep` tags the recorder's HTTP fixtures with the current
+ * phase and is forwarded into the step machine. Shared by the `pegin` action and `borrow --pegin-first`.
+ */
+export async function runPeginFlow(
+  ctx: ActionContext,
+  onStep: (step: string) => void,
+): Promise<void> {
+  const { page, context, log } = ctx;
+  // Amount is resolved by the CLI to the fetched protocol minimum (or --amount). If it's unresolved
+  // — the min-fetch failed non-interactively and no --amount was given — fail loudly rather than
+  // silently depositing a stale hardcoded amount (CLAUDE.md: no silent fallbacks on critical paths).
+  const amountBtc = ctx.config.peginAmountBtc?.trim();
+  if (!amountBtc)
+    throw new Error(
+      "pegin: no deposit amount resolved — the minimum-deposit fetch failed and no --amount was given. Re-run with --amount=<btc>, or against a reachable network.",
+    );
+  const provider = ctx.config.peginProvider?.trim() || undefined;
+  const split = ctx.config.split ?? false;
+
+  onStep("deposit-form");
+  await fillDepositForm(page, log, amountBtc, provider, split);
+
+  onStep("sign-transaction");
+  await startSigning(page, log);
+
+  onStep("step-machine");
+  const prePeginTxid = await walkStepMachine(
+    page,
+    context,
+    log,
+    split ? 2 : 1,
+    onStep,
+  );
+
+  onStep("finish");
+  await assertActivatedAndOnDashboard(
+    page,
+    log,
+    amountBtc,
+    prePeginTxid,
+    split ? 2 : 1,
+  );
+  log(
+    `✅ Pegin complete: ${split ? "two BTC Vaults" : "BTC Vault"} activated and shown on the dashboard.`,
+  );
+}
+
 export const peginAction: Action = {
   id: "pegin",
   async run(ctx: ActionContext): Promise<void> {
     const { page, context, log, artifactsDir } = ctx;
-    // Amount is resolved by the CLI to the fetched protocol minimum (or --amount). If it's unresolved
-    // — the min-fetch failed non-interactively and no --amount was given — fail loudly rather than
-    // silently depositing a stale hardcoded amount (CLAUDE.md: no silent fallbacks on critical paths).
-    const amountBtc = ctx.config.peginAmountBtc?.trim();
-    if (!amountBtc)
-      throw new Error(
-        "pegin: no deposit amount resolved — the minimum-deposit fetch failed and no --amount was given. Re-run with --amount=<btc>, or against a reachable network.",
-      );
-    const provider = ctx.config.peginProvider?.trim() || undefined;
-    const split = ctx.config.split ?? false;
 
     // Approver stays installed for the whole run (auto-approves every wallet pop-up).
     const handler = installPopupApprover(context, log);
@@ -625,35 +729,9 @@ export const peginAction: Action = {
     );
     try {
       await connectWallets(ctx);
-
-      currentStep = "deposit-form";
-      await fillDepositForm(page, log, amountBtc, provider, split);
-
-      currentStep = "sign-transaction";
-      await startSigning(page, log);
-
-      currentStep = "step-machine";
-      const prePeginTxid = await walkStepMachine(
-        page,
-        context,
-        log,
-        split ? 2 : 1,
-        (step) => {
-          currentStep = step;
-        },
-      );
-
-      currentStep = "finish";
-      await assertActivatedAndOnDashboard(
-        page,
-        log,
-        amountBtc,
-        prePeginTxid,
-        split ? 2 : 1,
-      );
-      log(
-        `✅ Pegin complete: ${split ? "two BTC Vaults" : "BTC Vault"} activated and shown on the dashboard.`,
-      );
+      await runPeginFlow(ctx, (step) => {
+        currentStep = step;
+      });
     } finally {
       await recorder.stop();
       context.off("page", handler);

--- a/services/vault/e2e/real/actions/pegin.ts
+++ b/services/vault/e2e/real/actions/pegin.ts
@@ -470,18 +470,20 @@ async function walkStepMachine(
       return prePeginTxid;
 
     // Fast-fail on a vault-provider readiness dead-end. If the VP never became ready for WOTS-key
-    // submission, the app skips that vault and it can never activate. Once EVERY expected vault is
-    // skipped there is no route to the activated view — abort now (with a clear, VP-attributed message)
-    // instead of polling out the multi-hour budget. A split where only one sibling is skipped keeps
-    // going (skipped < expectedVaults), matching the app, which continues the ready sibling.
+    // submission, the app skips that vault and it can never activate — so the finish gate
+    // (`activationCount >= expectedVaults`) becomes unreachable. Abort once there's no route left to a
+    // full completion: at least one vault was skipped AND every non-skipped vault has already activated
+    // (`activationCount >= expectedVaults - skippedVaults`). This covers both a fully-skipped deposit
+    // (single vault, or all split vaults) and a PARTIAL split (one sibling skipped, the other activated)
+    // — the latter would otherwise burn the entire multi-hour budget, the exact slow failure this guards.
     const skippedVaults = await countWotsSkippedVaults(page);
-    if (skippedVaults >= expectedVaults)
+    if (skippedVaults > 0 && activationCount >= expectedVaults - skippedVaults)
       throw new Error(
-        `Vault-provider readiness timeout: the vault provider did not become ready for WOTS-key ` +
-          `submission, so ${skippedVaults === 1 ? "the vault was" : `all ${skippedVaults} vaults were`} ` +
-          `skipped and cannot activate. This is a vault-provider availability issue (not the CLI) — ` +
-          `retry once the provider is healthy. The Pre-PegIn is already broadcast, so the deposit can ` +
-          `be resumed later rather than re-pegged.`,
+        `Vault-provider readiness timeout: ${skippedVaults} of ${expectedVaults} vault(s) were skipped ` +
+          `for WOTS-key submission and cannot activate` +
+          `${activationCount > 0 ? ` (the other ${activationCount} activated)` : ""}. This is a ` +
+          `vault-provider availability issue (not the CLI) — retry once the provider is healthy. The ` +
+          `Pre-PegIn is already broadcast, so the deposit can be resumed later rather than re-pegged.`,
       );
 
     // Actively approve any reused wallet window (OKX) that the event approver can't see.

--- a/services/vault/e2e/real/actions/selectors.ts
+++ b/services/vault/e2e/real/actions/selectors.ts
@@ -1,0 +1,24 @@
+/**
+ * Shared Playwright selector helpers for the dapp-driving actions (pegin, borrow, …).
+ */
+import type { Locator, Page } from "@playwright/test";
+
+/**
+ * The core-ui fluid `Button`'s stable class — the primary CTA in both the deposit and borrow forms.
+ * Used to locate that button independently of its (label-dependent) accessible name.
+ */
+export const FLUID_CTA_SELECTOR = "button.bbn-btn-fluid";
+
+/**
+ * Locate a control testid-first with a tolerant fallback: prefer the stable `data-testid` (added to the
+ * src controls), else a pre-built role/text/css `Locator` for a deployed build that predates the testid.
+ * `.first()` guards against duplicates. The fallback is a `Locator` (not a name) because it differs per
+ * site — `getByRole({name})`, `getByRole().filter({hasText})`, or a raw `page.locator(...)`.
+ */
+export function firstByTestid(
+  page: Page,
+  testid: string,
+  fallback: Locator,
+): Locator {
+  return page.locator(testid).or(fallback).first();
+}

--- a/services/vault/e2e/real/actions/selectors.ts
+++ b/services/vault/e2e/real/actions/selectors.ts
@@ -10,10 +10,14 @@ import type { Locator, Page } from "@playwright/test";
 export const FLUID_CTA_SELECTOR = "button.bbn-btn-fluid";
 
 /**
- * Locate a control testid-first with a tolerant fallback: prefer the stable `data-testid` (added to the
- * src controls), else a pre-built role/text/css `Locator` for a deployed build that predates the testid.
- * `.first()` guards against duplicates. The fallback is a `Locator` (not a name) because it differs per
- * site — `getByRole({name})`, `getByRole().filter({hasText})`, or a raw `page.locator(...)`.
+ * Locate a control by its `data-testid` OR a tolerant fallback `Locator`, resolving to the FIRST match
+ * in DOM order (`.or()` is a match-either union, not a testid priority). This works because the testid
+ * (added to the src controls) and the fallback target the SAME control: on the current build both match
+ * that one element; on a deployed build that predates the testid, only the fallback matches — either way
+ * it resolves to that control. Keep each fallback tightly scoped to its own control so a broad fallback
+ * can't match an earlier, unrelated element and win the `.first()`. The fallback is a `Locator` (not a
+ * name) because it differs per site — `getByRole({name})`, `getByRole().filter({hasText})`, or a raw
+ * `page.locator(...)`.
  */
 export function firstByTestid(
   page: Page,

--- a/services/vault/e2e/real/borrowParams.ts
+++ b/services/vault/e2e/real/borrowParams.ts
@@ -1,0 +1,388 @@
+/**
+ * Borrow-parameter pre-flight: read the borrowable-token list, the depositor's collateral/debt, and a
+ * best-effort max-borrow estimate for the selected network — the SAME sources the web app uses — so
+ * the CLI can offer a token menu + a safe default amount before launching the browser.
+ *
+ * This mirrors the app's `useAaveReserveDetail` chain in Node against pure SDK reads (each takes a viem
+ * client; nothing here reimplements a frozen/critical path):
+ *   - Borrowable reserves: the indexer GraphQL `GetAaveAppConfig` (a raw-string mirror of
+ *     `fetchAaveAppConfig`), filtered `borrowable && !paused && !frozen && id !== vBTC`.
+ *   - Collateral/debt: on-chain `getPosition` (ETH addr → proxy) + `getUserAccountData` (aggregate).
+ *   - Max borrow: `calculateMaxBorrowTokens`'s formula (helper is app-side; `BPS_SCALE` +
+ *     `MIN_HEALTH_FACTOR_FOR_BORROW` are SDK-exported), fed the vBTC liquidation threshold + oracle price.
+ *
+ * Everything here is a best-effort ESTIMATE for a menu default / a "no collateral" heads-up — NEVER a
+ * hard gate. The live borrow form (its Max button + validation) is the authoritative, position-aware
+ * limit and is what actually blocks a too-large or uncollateralised borrow.
+ */
+import {
+  aaveRayValueToUsd,
+  aaveValueToUsd,
+  BPS_SCALE,
+  getDynamicReserveConfig,
+  getOracleAddress,
+  getPosition,
+  getReserve,
+  getReservesPrices,
+  getUserAccountData,
+  getUserPosition,
+  MIN_HEALTH_FACTOR_FOR_BORROW,
+} from "@babylonlabs-io/ts-sdk/tbv/integrations/aave";
+import { gql } from "graphql-request";
+import { type Address, type PublicClient, zeroAddress } from "viem";
+
+import { type NetworkName } from "./config";
+import {
+  createEthClient,
+  createGraphQLClient,
+  resolveCoreSpoke,
+  resolveNetworkContracts,
+} from "./networkContracts";
+
+/**
+ * Default borrow = this fraction of the computed max, keeping the health factor well above the
+ * MIN_HEALTH_FACTOR_FOR_BORROW (1.05) liquidation edge for a repeatable real-money test. The full max
+ * stays reachable via `--borrow-amount` (or `--borrow-amount=max`) and the form's Max button.
+ */
+export const CONSERVATIVE_BORROW_FRACTION = 0.25;
+
+/** The Aave oracle reports USD prices scaled by 1e8. */
+const ORACLE_PRICE_SCALE = 1e8;
+
+/** Cap the borrow-form input at this many decimal places (USDC/USDT are 6) — enough for any test amount. */
+const MAX_INPUT_DECIMALS = 6;
+
+/**
+ * Format a token amount for the borrow form's numeric input: floored (never rounded up, so a computed
+ * default can't drift above the max) to min(decimals, MAX_INPUT_DECIMALS) places, then trimmed.
+ */
+export function formatBorrowAmount(amount: number, decimals: number): string {
+  const places = Math.min(decimals, MAX_INPUT_DECIMALS);
+  const scale = 10 ** places;
+  return (Math.floor(amount * scale) / scale).toString();
+}
+
+/** A borrowable token as offered in the CLI menu / used to drive the asset picker. */
+export interface BorrowReserve {
+  symbol: string;
+  name: string;
+  reserveId: bigint;
+  tokenAddress: string;
+  /** Token (underlying) decimals — what the borrow amount is parsed against. */
+  decimals: number;
+}
+
+/** The depositor's aggregate Aave position (collateral + debt). */
+export interface BorrowContext {
+  /** True when the position currently holds borrowable collateral (`totalCollateralBTC > 0`) — the same
+   *  condition that enables the dashboard's Borrow button (`hasCollateral = collateralBtc > 0`). */
+  hasCollateral: boolean;
+  collateralUsd: number;
+  currentDebtUsd: number;
+  /** The Aave proxy that keys all spoke reads (zero address string when no position exists yet). */
+  proxy: string;
+}
+
+/** A best-effort max-borrow estimate for one token. */
+export interface MaxBorrow {
+  symbol: string;
+  decimals: number;
+  /** Max tokens borrowable while keeping HF ≥ MIN_HEALTH_FACTOR_FOR_BORROW (0 when no collateral). */
+  maxTokens: number;
+  /** Oracle USD price of the token (0 when unavailable / no position). */
+  tokenPriceUsd: number;
+  collateralUsd: number;
+  currentDebtUsd: number;
+  hasCollateral: boolean;
+}
+
+const GET_AAVE_APP_CONFIG = gql`
+  query GetAaveAppConfig {
+    aaveConfig(id: 1) {
+      vaultBtcReserveId
+    }
+    aaveReserves {
+      items {
+        id
+        paused
+        frozen
+        borrowable
+        underlyingToken {
+          address
+          symbol
+          name
+          decimals
+        }
+      }
+    }
+  }
+`;
+
+interface AaveAppConfigResponse {
+  aaveConfig: { vaultBtcReserveId: string } | null;
+  aaveReserves: {
+    items: {
+      id: string;
+      paused: boolean;
+      frozen: boolean;
+      borrowable: boolean;
+      underlyingToken: {
+        address: string;
+        symbol: string;
+        name: string;
+        decimals: number;
+      } | null;
+    }[];
+  };
+}
+
+/**
+ * Read the vBTC reserve id + the borrowable-token list from the indexer — a raw-string mirror of the
+ * app's `fetchAaveAppConfig`: keep only reserves that are `borrowable && !paused && !frozen`, are not
+ * the vBTC collateral reserve, and carry token metadata (mirrors the app's `mapReserveConfig` null-skip).
+ */
+async function fetchAaveReserveConfig(graphqlEndpoint: string): Promise<{
+  vaultBtcReserveId: bigint;
+  borrowable: BorrowReserve[];
+}> {
+  const client = createGraphQLClient(graphqlEndpoint);
+  const response =
+    await client.request<AaveAppConfigResponse>(GET_AAVE_APP_CONFIG);
+  if (!response.aaveConfig)
+    throw new Error(
+      `No aaveConfig from the indexer at ${graphqlEndpoint} — cannot resolve borrowable reserves.`,
+    );
+  const vaultBtcReserveId = BigInt(response.aaveConfig.vaultBtcReserveId);
+
+  const borrowable = response.aaveReserves.items
+    .filter(
+      (r) =>
+        r.borrowable &&
+        !r.paused &&
+        !r.frozen &&
+        BigInt(r.id) !== vaultBtcReserveId &&
+        r.underlyingToken != null,
+    )
+    .map((r) => ({
+      symbol: r.underlyingToken!.symbol,
+      name: r.underlyingToken!.name,
+      reserveId: BigInt(r.id),
+      tokenAddress: r.underlyingToken!.address,
+      decimals: r.underlyingToken!.decimals,
+    }));
+
+  return { vaultBtcReserveId, borrowable };
+}
+
+/** Fetch the borrowable-token list for `network` (for the CLI's asset menu + the browser asset picker). */
+export async function fetchBorrowableReserves(
+  network: NetworkName,
+): Promise<BorrowReserve[]> {
+  const { graphqlEndpoint } = resolveNetworkContracts(network);
+  const { borrowable } = await fetchAaveReserveConfig(graphqlEndpoint);
+  return borrowable;
+}
+
+/**
+ * Shared prelude for every position-derived read: resolve the network's adapter + a Sepolia client,
+ * then read the depositor's on-chain adapter position (`null` when none exists yet). `getPosition` maps
+ * the ETH address to the Aave proxy — the app's `useAaveUserPosition` does the same.
+ */
+async function openPosition(
+  network: NetworkName,
+  ethAddress: string,
+): Promise<{
+  client: PublicClient;
+  appController: string;
+  position: Awaited<ReturnType<typeof getPosition>>;
+}> {
+  const { appController, ethRpcUrl } = resolveNetworkContracts(network);
+  const client = createEthClient(ethRpcUrl);
+  const position = await getPosition(
+    client,
+    appController as Address,
+    ethAddress as Address,
+  );
+  return { client, appController, position };
+}
+
+/**
+ * The proxy's aggregate collateral + debt in USD, via the Core Spoke's account data. Returns the spoke
+ * too so a caller needing further spoke reads (e.g. the max-borrow risk params) reuses it instead of
+ * re-resolving.
+ */
+async function readAccountUsd(
+  client: PublicClient,
+  appController: string,
+  proxy: Address,
+): Promise<{ spoke: Address; collateralUsd: number; currentDebtUsd: number }> {
+  const spoke = await resolveCoreSpoke(client, appController);
+  const accountData = await getUserAccountData(client, spoke, proxy);
+  return {
+    spoke,
+    collateralUsd: aaveValueToUsd(accountData.totalCollateralValue),
+    currentDebtUsd: aaveRayValueToUsd(accountData.totalDebtValueRay),
+  };
+}
+
+/**
+ * Read the depositor's aggregate collateral + debt on `network`, mirroring the app's
+ * `useAaveUserPosition`. `hasCollateral` uses `totalCollateralBTC > 0` — the same condition the
+ * dashboard's Borrow button enables on. Returns a zero/`hasCollateral:false` context when the position
+ * doesn't exist yet.
+ */
+export async function fetchBorrowContext(
+  network: NetworkName,
+  ethAddress: string,
+): Promise<BorrowContext> {
+  const { client, appController, position } = await openPosition(
+    network,
+    ethAddress,
+  );
+  if (!position || position.totalCollateralBTC <= 0n)
+    return {
+      hasCollateral: false,
+      collateralUsd: 0,
+      currentDebtUsd: 0,
+      proxy: position?.proxyContract ?? zeroAddress,
+    };
+
+  const { collateralUsd, currentDebtUsd } = await readAccountUsd(
+    client,
+    appController,
+    position.proxyContract,
+  );
+  return {
+    hasCollateral: true,
+    collateralUsd,
+    currentDebtUsd,
+    proxy: position.proxyContract,
+  };
+}
+
+/**
+ * Read just the depositor's on-chain BTC collateral (in sats) from the adapter position. This is the
+ * exact, PRICE-INDEPENDENT quantity that rises the moment a vault is registered as collateral — unlike
+ * the USD collateral value (oracle-priced, so it drifts with BTC price between reads). Lighter than
+ * `fetchBorrowContext` (a single `getPosition` read, no spoke/account-data), so it's cheap to poll for
+ * the post-activation collateral-settle wait (see the borrow action). Returns 0n when no position
+ * exists yet (e.g. a first-ever vault, before activation creates the position).
+ */
+export async function fetchCollateralSats(
+  network: NetworkName,
+  ethAddress: string,
+): Promise<bigint> {
+  const { position } = await openPosition(network, ethAddress);
+  return position?.totalCollateralBTC ?? 0n;
+}
+
+/**
+ * Max tokens borrowable while keeping health factor ≥ MIN_HEALTH_FACTOR_FOR_BORROW — the exact formula
+ * of the app's `calculateMaxBorrowTokens` (the helper itself is app-side, but `BPS_SCALE` +
+ * `MIN_HEALTH_FACTOR_FOR_BORROW` are SDK-exported). Not floored to token precision here — the caller
+ * applies the conservative fraction + formatting.
+ *
+ * KEEP IN SYNC with src/applications/aave/components/LoanCard/Borrow/hooks/calculateMaxBorrowTokens.ts.
+ * Reimplemented (not imported) because there's no SDK equivalent and the e2e layer intentionally does
+ * not import from `src/` (see the file header) — this comment is the maintenance contract.
+ */
+function computeMaxBorrowTokens(
+  collateralUsd: number,
+  currentDebtUsd: number,
+  liquidationThresholdBps: number,
+  tokenPriceUsd: number,
+): number {
+  if (tokenPriceUsd <= 0) return 0;
+  const maxTotalDebtUsd =
+    (collateralUsd * liquidationThresholdBps) /
+    BPS_SCALE /
+    MIN_HEALTH_FACTOR_FOR_BORROW;
+  const maxAdditionalBorrowUsd = maxTotalDebtUsd - currentDebtUsd;
+  return Math.max(0, maxAdditionalBorrowUsd / tokenPriceUsd);
+}
+
+/**
+ * Best-effort max-borrow estimate for one token on `network`, mirroring the app's borrow-form chain:
+ * collateral/debt from the position, the vBTC reserve's liquidation threshold (the depositor's stored
+ * `dynamicConfigKey` when a position exists, else the reserve's current key — matches the app), and the
+ * token's oracle price. Returns `maxTokens: 0` / `hasCollateral: false` when there's no collateral yet.
+ * Estimate only — the form's Max is authoritative.
+ */
+export async function fetchMaxBorrow(
+  network: NetworkName,
+  ethAddress: string,
+  symbol: string,
+): Promise<MaxBorrow> {
+  const { graphqlEndpoint } = resolveNetworkContracts(network);
+  const { vaultBtcReserveId, borrowable } =
+    await fetchAaveReserveConfig(graphqlEndpoint);
+  const reserve = borrowable.find(
+    (r) => r.symbol.toLowerCase() === symbol.toLowerCase(),
+  );
+  if (!reserve)
+    throw new Error(
+      `Token "${symbol}" is not a borrowable reserve on ${network} (available: ${borrowable.map((r) => r.symbol).join(", ")}).`,
+    );
+
+  const { client, appController, position } = await openPosition(
+    network,
+    ethAddress,
+  );
+  if (!position || position.totalCollateralBTC <= 0n)
+    return {
+      symbol: reserve.symbol,
+      decimals: reserve.decimals,
+      maxTokens: 0,
+      tokenPriceUsd: 0,
+      collateralUsd: 0,
+      currentDebtUsd: 0,
+      hasCollateral: false,
+    };
+
+  const { spoke, collateralUsd, currentDebtUsd } = await readAccountUsd(
+    client,
+    appController,
+    position.proxyContract,
+  );
+
+  // Liquidation threshold from the vBTC reserve's dynamic config, keyed by the depositor's stored
+  // `dynamicConfigKey` when the position has one (else the reserve's current key) — matches the app's
+  // useVaultSplitParams. A missing user position falls back to the reserve baseline.
+  const userVbtcPosition = await getUserPosition(
+    client,
+    spoke,
+    vaultBtcReserveId,
+    position.proxyContract,
+  ).catch(() => null);
+  const vbtcReserve = await getReserve(client, spoke, vaultBtcReserveId);
+  const dynamicConfigKey =
+    userVbtcPosition?.dynamicConfigKey ?? vbtcReserve.dynamicConfigKey;
+  const dynamicConfig = await getDynamicReserveConfig(
+    client,
+    spoke,
+    vaultBtcReserveId,
+    dynamicConfigKey,
+  );
+  const liquidationThresholdBps = Number(dynamicConfig.collateralFactor);
+
+  const oracle = await getOracleAddress(client, spoke);
+  const priceRaw = (
+    await getReservesPrices(client, oracle, [reserve.reserveId])
+  )[0];
+  const tokenPriceUsd = Number(priceRaw) / ORACLE_PRICE_SCALE;
+
+  return {
+    symbol: reserve.symbol,
+    decimals: reserve.decimals,
+    maxTokens: computeMaxBorrowTokens(
+      collateralUsd,
+      currentDebtUsd,
+      liquidationThresholdBps,
+      tokenPriceUsd,
+    ),
+    tokenPriceUsd,
+    collateralUsd,
+    currentDebtUsd,
+    hasCollateral: true,
+  };
+}

--- a/services/vault/e2e/real/borrowParams.ts
+++ b/services/vault/e2e/real/borrowParams.ts
@@ -29,7 +29,7 @@ import {
   MIN_HEALTH_FACTOR_FOR_BORROW,
 } from "@babylonlabs-io/ts-sdk/tbv/integrations/aave";
 import { gql } from "graphql-request";
-import { type Address, type PublicClient, zeroAddress } from "viem";
+import { type Address, type PublicClient } from "viem";
 
 import { type NetworkName } from "./config";
 import {
@@ -79,8 +79,6 @@ export interface BorrowContext {
   hasCollateral: boolean;
   collateralUsd: number;
   currentDebtUsd: number;
-  /** The Aave proxy that keys all spoke reads (zero address string when no position exists yet). */
-  proxy: string;
 }
 
 /** A best-effort max-borrow estimate for one token. */
@@ -89,11 +87,6 @@ export interface MaxBorrow {
   decimals: number;
   /** Max tokens borrowable while keeping HF ≥ MIN_HEALTH_FACTOR_FOR_BORROW (0 when no collateral). */
   maxTokens: number;
-  /** Oracle USD price of the token (0 when unavailable / no position). */
-  tokenPriceUsd: number;
-  collateralUsd: number;
-  currentDebtUsd: number;
-  hasCollateral: boolean;
 }
 
 const GET_AAVE_APP_CONFIG = gql`
@@ -240,24 +233,14 @@ export async function fetchBorrowContext(
     ethAddress,
   );
   if (!position || position.totalCollateralBTC <= 0n)
-    return {
-      hasCollateral: false,
-      collateralUsd: 0,
-      currentDebtUsd: 0,
-      proxy: position?.proxyContract ?? zeroAddress,
-    };
+    return { hasCollateral: false, collateralUsd: 0, currentDebtUsd: 0 };
 
   const { collateralUsd, currentDebtUsd } = await readAccountUsd(
     client,
     appController,
     position.proxyContract,
   );
-  return {
-    hasCollateral: true,
-    collateralUsd,
-    currentDebtUsd,
-    proxy: position.proxyContract,
-  };
+  return { hasCollateral: true, collateralUsd, currentDebtUsd };
 }
 
 /**
@@ -305,8 +288,8 @@ function computeMaxBorrowTokens(
  * Best-effort max-borrow estimate for one token on `network`, mirroring the app's borrow-form chain:
  * collateral/debt from the position, the vBTC reserve's liquidation threshold (the depositor's stored
  * `dynamicConfigKey` when a position exists, else the reserve's current key — matches the app), and the
- * token's oracle price. Returns `maxTokens: 0` / `hasCollateral: false` when there's no collateral yet.
- * Estimate only — the form's Max is authoritative.
+ * token's oracle price. Returns `maxTokens: 0` when there's no collateral yet. Estimate only — the
+ * form's Max is authoritative.
  */
 export async function fetchMaxBorrow(
   network: NetworkName,
@@ -329,15 +312,7 @@ export async function fetchMaxBorrow(
     ethAddress,
   );
   if (!position || position.totalCollateralBTC <= 0n)
-    return {
-      symbol: reserve.symbol,
-      decimals: reserve.decimals,
-      maxTokens: 0,
-      tokenPriceUsd: 0,
-      collateralUsd: 0,
-      currentDebtUsd: 0,
-      hasCollateral: false,
-    };
+    return { symbol: reserve.symbol, decimals: reserve.decimals, maxTokens: 0 };
 
   const { spoke, collateralUsd, currentDebtUsd } = await readAccountUsd(
     client,
@@ -380,9 +355,5 @@ export async function fetchMaxBorrow(
       liquidationThresholdBps,
       tokenPriceUsd,
     ),
-    tokenPriceUsd,
-    collateralUsd,
-    currentDebtUsd,
-    hasCollateral: true,
   };
 }

--- a/services/vault/e2e/real/cli.ts
+++ b/services/vault/e2e/real/cli.ts
@@ -381,15 +381,28 @@ async function resolveConfig(
           `--borrow-amount must be a positive number of tokens or "max" (got "${borrowAmount}")`,
         );
     }
-    if (action === "borrow" && borrowToken === undefined) {
+    if (action === "borrow") {
+      // Fetch the live borrowable list up front so we can VALIDATE an explicit --borrow-token before a
+      // (possibly funded, pegin-first) run — an unselectable token would otherwise only surface after
+      // the peg-in, wasting it. When the token isn't given, pick from the list (menu / first).
       const reserves = await fetchBorrowableReserves(network).catch((error) => {
         // eslint-disable-next-line no-console
         console.warn(
-          `\nCould not fetch borrowable tokens (${error instanceof Error ? error.message : error}); the run will pick the first available in the asset picker.`,
+          `\nCould not fetch borrowable tokens (${error instanceof Error ? error.message : error}); skipping token validation — the borrow form will gate it.`,
         );
         return [];
       });
-      if (reserves.length > 0)
+      if (borrowToken !== undefined) {
+        const match = reserves.find(
+          (r) => r.symbol.toLowerCase() === borrowToken!.toLowerCase(),
+        );
+        if (reserves.length > 0 && !match)
+          throw new Error(
+            `--borrow-token "${borrowToken}" is not a borrowable reserve on ${network} (available: ${reserves.map((r) => r.symbol).join(", ")}).`,
+          );
+        // Canonicalize to the reserve's exact symbol casing when we could validate it.
+        if (match) borrowToken = match.symbol;
+      } else if (reserves.length > 0) {
         borrowToken = interactive
           ? await select(
               rl,
@@ -400,6 +413,7 @@ async function resolveConfig(
               })),
             )
           : reserves[0].symbol;
+      }
     }
 
     // Sign-conformance extra: explicit fixtures file (else the action auto-detects the newest pegin's).

--- a/services/vault/e2e/real/cli.ts
+++ b/services/vault/e2e/real/cli.ts
@@ -10,9 +10,14 @@
  * Pegin accepts two optional extras: `--amount=<btc>` and `--vp=<name>`. When omitted, the CLI fetches
  * the network's real values (protocol minimum deposit + provider list) and offers them as defaults —
  * amount ⇒ minimum, provider ⇒ first available — prompting interactively. Mock mode shows as disabled.
+ *
+ * Borrow accepts `--pegin-first` (peg in fresh collateral before borrowing — then also honors the pegin
+ * extras above), `--borrow-token=<symbol>` (from the live borrowable list; default = first), and
+ * `--borrow-amount=<n>|max` (default = a conservative fraction of the computed max, resolved in run.ts).
  */
 import { createInterface, type Interface } from "node:readline/promises";
 
+import { fetchBorrowableReserves } from "./borrowParams";
 import {
   ACTIONS,
   BTC_WALLETS,
@@ -31,8 +36,7 @@ import {
   fetchProviders,
 } from "./peginParams";
 import { runE2E } from "./run";
-
-const MS_PER_SECOND = 1000;
+import { MS_PER_SECOND } from "./timing";
 
 interface Choice<T extends string> {
   value: T;
@@ -241,14 +245,35 @@ async function resolveConfig(
       delayMs = Math.max(0, Math.round((Number(raw) || 0) * MS_PER_SECOND));
     }
 
-    // Pegin extras. A flag always wins; otherwise, for the pegin action, fetch the network's real
-    // values (like the balance pre-flight) and offer them as defaults — amount ⇒ protocol minimum,
-    // provider ⇒ first available — prompting interactively when there's a TTY.
+    // Borrow only: peg in first, or borrow against existing collateral? Resolved early because it
+    // decides whether the pegin extras below are collected (a `--pegin-first` borrow performs a pegin
+    // before borrowing). `--pegin-first` wins; else prompt (default = reuse existing collateral).
+    let peginFirst = false;
+    if (action === "borrow") {
+      if (flags["pegin-first"] !== undefined) {
+        peginFirst = flagBool(flags["pegin-first"]);
+      } else if (interactive) {
+        peginFirst =
+          (await select<"reuse" | "pegin">(rl, "Collateral for the borrow", [
+            {
+              value: "reuse",
+              label: "Borrow against existing BTC Vaults (collateral)",
+            },
+            { value: "pegin", label: "Peg in first, then borrow" },
+          ])) === "pegin";
+      }
+    }
 
-    // Split (pegin only): `--split` wins; else prompt (default = single vault). Resolved first because
-    // the deposit minimum depends on it — a two-vault split needs a larger deposit than a single vault.
+    // Pegin extras. A flag always wins; otherwise fetch the network's real values (like the balance
+    // pre-flight) and offer them as defaults — amount ⇒ minimum, provider ⇒ first available. Collected
+    // for a `pegin` run AND for a `borrow --pegin-first` run (which pegs in before borrowing).
+    const needsPeginParams =
+      action === "pegin" || (action === "borrow" && peginFirst);
+
+    // Split: `--split` wins; else prompt (default = single vault). Resolved first because the deposit
+    // minimum depends on it — a two-vault split needs a larger deposit than a single vault.
     let split = false;
-    if (action === "pegin") {
+    if (needsPeginParams) {
       if (flags.split !== undefined) {
         split = flagBool(flags.split);
       } else if (interactive) {
@@ -271,7 +296,7 @@ async function resolveConfig(
     }
     let peginProvider = typeof flags.vp === "string" ? flags.vp : undefined;
 
-    if (action === "pegin") {
+    if (needsPeginParams) {
       // The deposit minimum depends on the deposit type: the single-vault protocol minimum, or the
       // (larger) two-vault split minimum computed from Aave risk params + the SDK split math.
       const fetchMin = split ? fetchMinDepositForSplitBtc : fetchMinDepositBtc;
@@ -337,6 +362,46 @@ async function resolveConfig(
       }
     }
 
+    // Borrow extras: token (from the live borrowable list) + an explicit amount passthrough. The amount
+    // DEFAULT (a conservative fraction of the max) needs the depositor's ETH address, which isn't known
+    // until wallet import — so it's resolved later in run.ts; here we only carry an explicit
+    // --borrow-amount (a number, or "max" for the form's Max button) through.
+    let borrowToken =
+      typeof flags["borrow-token"] === "string"
+        ? flags["borrow-token"]
+        : undefined;
+    const borrowAmount =
+      typeof flags["borrow-amount"] === "string"
+        ? flags["borrow-amount"]
+        : undefined;
+    if (borrowAmount !== undefined && borrowAmount.toLowerCase() !== "max") {
+      const parsed = Number(borrowAmount);
+      if (!Number.isFinite(parsed) || parsed <= 0)
+        throw new Error(
+          `--borrow-amount must be a positive number of tokens or "max" (got "${borrowAmount}")`,
+        );
+    }
+    if (action === "borrow" && borrowToken === undefined) {
+      const reserves = await fetchBorrowableReserves(network).catch((error) => {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `\nCould not fetch borrowable tokens (${error instanceof Error ? error.message : error}); the run will pick the first available in the asset picker.`,
+        );
+        return [];
+      });
+      if (reserves.length > 0)
+        borrowToken = interactive
+          ? await select(
+              rl,
+              "Borrow token",
+              reserves.map((r) => ({
+                value: r.symbol,
+                label: `${r.symbol} — ${r.name}`,
+              })),
+            )
+          : reserves[0].symbol;
+    }
+
     // Sign-conformance extra: explicit fixtures file (else the action auto-detects the newest pegin's).
     const fixturesPath =
       typeof flags.fixtures === "string" ? flags.fixtures : undefined;
@@ -353,6 +418,9 @@ async function resolveConfig(
       peginProvider,
       split,
       fixturesPath,
+      peginFirst,
+      borrowToken,
+      borrowAmount,
     };
   } finally {
     rl.close();

--- a/services/vault/e2e/real/config.ts
+++ b/services/vault/e2e/real/config.ts
@@ -113,7 +113,7 @@ export const ACTIONS: ActionOption[] = [
     label: "Sign conformance (replay captured signing into this wallet)",
     enabled: true,
   },
-  { id: "borrow", label: "Borrow", enabled: false },
+  { id: "borrow", label: "Borrow", enabled: true },
   { id: "repay", label: "Repay", enabled: false },
   { id: "withdraw", label: "Withdraw", enabled: false },
 ];
@@ -136,6 +136,18 @@ export interface RunConfig {
   split?: boolean;
   /** Sign-conformance only: path to a `signing.jsonl` (`--fixtures`); defaults to the newest pegin's. */
   fixturesPath?: string;
+  /**
+   * Borrow only: peg in first (`--pegin-first`), then borrow against the fresh collateral in the same
+   * run. When set, the pegin extras above (`peginAmountBtc`/`peginProvider`/`split`) drive that pegin.
+   */
+  peginFirst?: boolean;
+  /** Borrow only: token symbol to borrow (`--borrow-token`); defaults to the first borrowable reserve. */
+  borrowToken?: string;
+  /**
+   * Borrow only: token amount to borrow (`--borrow-amount`, or `max` for the form's Max). When absent
+   * the CLI defaults to a conservative fraction of the computed max (see borrowParams).
+   */
+  borrowAmount?: string;
 }
 
 /** Resolve the target URL a run should open. */

--- a/services/vault/e2e/real/networkContracts.ts
+++ b/services/vault/e2e/real/networkContracts.ts
@@ -136,9 +136,11 @@ interface VbtcReserveIdResponse {
 }
 
 /**
- * Read the vBTC (collateral) reserve id from the indexer's singleton `aaveConfig`. Shared by the pegin
- * split-minimum and the borrow reserve list so the `aaveConfig(id:1)` key + null contract live in one
- * place. Callers that also need the reserve list add `aaveReserves` to their own query.
+ * Read the vBTC (collateral) reserve id from the indexer's singleton `aaveConfig`. Used by the pegin
+ * split-minimum (`peginParams.fetchMinDepositForSplitBtc`). Note: `borrowParams.fetchAaveReserveConfig`
+ * does NOT call this — it reads the id as part of one combined query (`aaveConfig` + `aaveReserves` in a
+ * single round-trip), the right trade-off there; this just centralizes the `aaveConfig(id:1)` key + null
+ * contract for the pegin path.
  */
 export async function fetchVbtcReserveId(
   graphqlEndpoint: string,

--- a/services/vault/e2e/real/networkContracts.ts
+++ b/services/vault/e2e/real/networkContracts.ts
@@ -1,0 +1,155 @@
+/**
+ * Shared network-contract resolution for the real-wallet E2E pre-flights (pegin + borrow).
+ *
+ * The contract addresses + endpoints are NOT hardcoded — they rotate (via `scripts/sync-env.mjs`) and
+ * differ per network. We resolve them exactly as the app does at runtime: Vite's `loadEnv` for the
+ * network's mode (devnet ⇒ `development`, testnet ⇒ `dev-testnet`), which layers `.env` (sync-env's
+ * output) + `.env.local` + `.env.<mode>` with the same precedence Vite gives the running dapp.
+ *
+ * Extracted from peginParams.ts so the borrow pre-flight (borrowParams.ts) reuses the identical
+ * resolution + Sepolia client + Core-Spoke read rather than duplicating (and drifting from) it.
+ */
+import { AaveIntegrationAdapterABI } from "@babylonlabs-io/ts-sdk/tbv/integrations/aave";
+import { gql, GraphQLClient } from "graphql-request";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  createPublicClient,
+  http,
+  type Address,
+  type PublicClient,
+} from "viem";
+import { sepolia } from "viem/chains";
+import { loadEnv } from "vite";
+
+import { NETWORKS, type NetworkName } from "./config";
+
+/** The immutable Core Spoke getter on the AaveIntegrationAdapter (read on-chain, never trusted from GraphQL). */
+const CORE_SPOKE_FN = "BTC_VAULT_CORE_SPOKE";
+
+/** The vault service root (holds .env / .env.local / .env.dev-testnet), relative to this file. */
+const VAULT_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+/** Networks whose resolved env we've already surfaced, so we log it once per process (not per call). */
+const loggedNetworks = new Set<NetworkName>();
+
+export interface NetworkContracts {
+  registry: Address;
+  /** AaveIntegrationAdapter (app controller) — NEXT_PUBLIC_TBV_AAVE_ADAPTER. Also the Core-Spoke source. */
+  appController: string;
+  graphqlEndpoint: string;
+  ethRpcUrl: string;
+  /** AaveAdapterConfig — holds the per-position size params (maxVaultsPerPosition). */
+  aaveAdapterConfig: Address;
+}
+
+/**
+ * Resolve the network's contract addresses + endpoints from the app's env, exactly as the running
+ * dapp does — so a `sync-env.mjs` rotation is picked up automatically instead of going stale.
+ */
+export function resolveNetworkContracts(
+  network: NetworkName,
+): NetworkContracts {
+  const env = loadEnv(NETWORKS[network].viteMode, VAULT_ROOT, "NEXT_PUBLIC_");
+  const registry = env.NEXT_PUBLIC_TBV_BTC_VAULT_REGISTRY;
+  const appController = env.NEXT_PUBLIC_TBV_AAVE_ADAPTER;
+  const graphqlEndpoint = env.NEXT_PUBLIC_TBV_GRAPHQL_ENDPOINT;
+  const ethRpcUrl = env.NEXT_PUBLIC_ETH_RPC_URL;
+  const aaveAdapterConfig = env.NEXT_PUBLIC_TBV_AAVE_ADAPTER_CONFIG;
+  if (
+    !registry ||
+    !appController ||
+    !graphqlEndpoint ||
+    !ethRpcUrl ||
+    !aaveAdapterConfig
+  )
+    throw new Error(
+      `Missing NEXT_PUBLIC_TBV_* env for ${network} (Vite mode "${NETWORKS[network].viteMode}", dir ${VAULT_ROOT}). Run 'pnpm --filter vault sync-env' or check .env / .env.dev-testnet.`,
+    );
+
+  // Surface which network's values were resolved (once per process), and warn loudly if they look
+  // like they came from another network — `loadEnv` merges shared `.env` under the mode file, so a key
+  // missing from `.env.<mode>` would silently inherit e.g. devnet's value. The endpoint host naming
+  // (…vault-devnet… / …testnet…) is a cheap cross-check for that footgun.
+  if (!loggedNetworks.has(network)) {
+    loggedNetworks.add(network);
+    // eslint-disable-next-line no-console
+    console.log(
+      `[network-contracts] ${network}: registry ${registry}, graphql ${graphqlEndpoint}`,
+    );
+    if (!graphqlEndpoint.includes(network))
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[network-contracts] ⚠️ ${network}: GraphQL endpoint "${graphqlEndpoint}" does not mention "${network}" — env may be resolving another network's values (a key missing from .env.${NETWORKS[network].viteMode}?).`,
+      );
+  }
+
+  return {
+    registry: registry as Address,
+    appController,
+    graphqlEndpoint,
+    ethRpcUrl,
+    aaveAdapterConfig: aaveAdapterConfig as Address,
+  };
+}
+
+/** A Sepolia public client for the network's ETH RPC (the same reads the app performs). */
+export function createEthClient(ethRpcUrl: string): PublicClient {
+  return createPublicClient({
+    chain: sepolia,
+    transport: http(ethRpcUrl),
+  }) as PublicClient;
+}
+
+/**
+ * Resolve the Aave Core Spoke on-chain from the env-pinned adapter (mirrors the app's
+ * getCoreSpokeAddress — never trust a GraphQL-supplied spoke). Every spoke read (risk params, account
+ * data, oracle) hangs off this address.
+ */
+export async function resolveCoreSpoke(
+  client: PublicClient,
+  appController: string,
+): Promise<Address> {
+  return (await client.readContract({
+    address: appController as Address,
+    abi: AaveIntegrationAdapterABI,
+    functionName: CORE_SPOKE_FN,
+    args: [],
+  })) as Address;
+}
+
+/** An indexer GraphQL client for the network's endpoint — one place to add default headers/timeouts. */
+export function createGraphQLClient(graphqlEndpoint: string): GraphQLClient {
+  return new GraphQLClient(graphqlEndpoint);
+}
+
+const GET_VBTC_RESERVE_ID = gql`
+  query GetVaultBtcReserveId {
+    aaveConfig(id: 1) {
+      vaultBtcReserveId
+    }
+  }
+`;
+
+interface VbtcReserveIdResponse {
+  aaveConfig: { vaultBtcReserveId: string } | null;
+}
+
+/**
+ * Read the vBTC (collateral) reserve id from the indexer's singleton `aaveConfig`. Shared by the pegin
+ * split-minimum and the borrow reserve list so the `aaveConfig(id:1)` key + null contract live in one
+ * place. Callers that also need the reserve list add `aaveReserves` to their own query.
+ */
+export async function fetchVbtcReserveId(
+  graphqlEndpoint: string,
+): Promise<bigint> {
+  const { aaveConfig } =
+    await createGraphQLClient(graphqlEndpoint).request<VbtcReserveIdResponse>(
+      GET_VBTC_RESERVE_ID,
+    );
+  if (!aaveConfig)
+    throw new Error(
+      `No aaveConfig from the indexer at ${graphqlEndpoint} — cannot resolve the vBTC reserve id.`,
+    );
+  return BigInt(aaveConfig.vaultBtcReserveId);
+}

--- a/services/vault/e2e/real/peginParams.ts
+++ b/services/vault/e2e/real/peginParams.ts
@@ -276,6 +276,7 @@ export async function fetchVaultCountCap(
   const adapter = appController.toLowerCase();
   let currentCount = 0;
   let after: string | null = null;
+  let exhausted = false;
   for (let pageIndex = 0; pageIndex < MAX_VAULT_PAGES; pageIndex++) {
     const page: VaultStatusPage = after
       ? await gqlClient.request(GET_DEPOSITOR_VAULT_STATUSES_NEXT, {
@@ -293,10 +294,25 @@ export async function fetchVaultCountCap(
         item.applicationEntryPoint.toLowerCase() === adapter
       )
         currentCount++;
-    if (!page.vaults.pageInfo.hasNextPage) break;
+    if (!page.vaults.pageInfo.hasNextPage) {
+      exhausted = true;
+      break;
+    }
     after = page.vaults.pageInfo.endCursor;
-    if (!after) break;
+    if (!after) {
+      exhausted = true;
+      break;
+    }
   }
+
+  // Fail CLOSED (like the app's fetchVaultsByDepositor) if the depositor's vaults didn't fit in
+  // MAX_VAULT_PAGES: returning a partial count would UNDERCOUNT occupied slots and could let a
+  // cap-exceeding peg-in through. The caller (run.ts) treats a throw as non-fatal → warn + let the form
+  // gate, so this never blocks a legit run — it just refuses to under-report.
+  if (!exhausted)
+    throw new Error(
+      `fetchVaultCountCap: depositor ${depositor} has more than ${MAX_VAULT_PAGES * VAULTS_PAGE_SIZE} vaults — refusing to return a partial (undercounted) slot count.`,
+    );
 
   return { maxVaults, currentCount };
 }

--- a/services/vault/e2e/real/peginParams.ts
+++ b/services/vault/e2e/real/peginParams.ts
@@ -8,54 +8,44 @@
  *    `getPegInConfiguration().minimumPegInAmount`. Reused (not reimplemented) so it can't drift.
  *  - Providers: the indexer GraphQL `GetAppProviders` query, filtered by the app controller.
  *
- * The contract addresses + endpoints are NOT hardcoded — they rotate (via `scripts/sync-env.mjs`) and
- * differ per network. We resolve them exactly as the app does at runtime: Vite's `loadEnv` for the
- * network's mode (devnet ⇒ `development`, testnet ⇒ `dev-testnet`), which layers `.env` (sync-env's
- * output) + `.env.local` + `.env.<mode>` with the same precedence Vite gives the running dapp.
+ * Contract addresses + endpoints are resolved per-network from the app's env via `networkContracts.ts`
+ * (shared with the borrow pre-flight) — never hardcoded, so a `sync-env.mjs` rotation is picked up.
  */
 import {
   resolveProtocolAddresses,
   ViemProtocolParamsReader,
 } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
 import {
-  AaveIntegrationAdapterABI,
   BPS_SCALE,
   computeMinDepositForSplit,
   computeSeizedFraction,
   getDynamicReserveConfig,
+  getPositionSizeParams,
   getReserve,
   getTargetHealthFactor,
   wadToNumber,
 } from "@babylonlabs-io/ts-sdk/tbv/integrations/aave";
-import { gql, GraphQLClient } from "graphql-request";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
-import {
-  createPublicClient,
-  http,
-  type Address,
-  type PublicClient,
-} from "viem";
-import { sepolia } from "viem/chains";
-import { loadEnv } from "vite";
+import { gql } from "graphql-request";
+import { type Address, type PublicClient } from "viem";
 
-import { NETWORKS, type NetworkName } from "./config";
+import { type NetworkName } from "./config";
+import {
+  createEthClient,
+  createGraphQLClient,
+  fetchVbtcReserveId,
+  resolveCoreSpoke,
+  resolveNetworkContracts,
+} from "./networkContracts";
 
 const SATS_PER_BTC = 100_000_000n;
+/** BTC has 8 decimal places (1 BTC = 1e8 sats) — the fractional width for the amount string. */
+const BTC_DECIMALS = 8;
 
 // Two-vault split risk constants — mirror `services/vault/src/applications/aave/constants.ts`
 // (EXPECTED_HEALTH_FACTOR_AT_LIQUIDATION, VAULT_SPLIT_SAFETY_MARGIN). They feed the SDK split math
 // exactly as the app's `useOptimalSplit` does, so the fetched split minimum matches the form.
 const EXPECTED_HEALTH_FACTOR_AT_LIQUIDATION = 0.95;
 const VAULT_SPLIT_SAFETY_MARGIN = 1.05;
-/** The immutable Core Spoke getter on the AaveIntegrationAdapter (read on-chain, never trusted from GraphQL). */
-const CORE_SPOKE_FN = "BTC_VAULT_CORE_SPOKE";
-
-/** The vault service root (holds .env / .env.local / .env.dev-testnet), relative to this file. */
-const VAULT_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
-
-/** Networks whose resolved env we've already surfaced, so we log it once per process (not per call). */
-const loggedNetworks = new Set<NetworkName>();
 
 /** A vault provider as offered in the CLI menu. `available` mirrors the app's metadata gating. */
 export interface ProviderChoice {
@@ -64,68 +54,16 @@ export interface ProviderChoice {
   available: boolean;
 }
 
-interface NetworkContracts {
-  registry: Address;
-  appController: string;
-  graphqlEndpoint: string;
-  ethRpcUrl: string;
-}
-
-/**
- * Resolve the network's contract addresses + endpoints from the app's env, exactly as the running
- * dapp does — so a `sync-env.mjs` rotation is picked up automatically instead of going stale.
- */
-function resolveNetworkContracts(network: NetworkName): NetworkContracts {
-  const env = loadEnv(NETWORKS[network].viteMode, VAULT_ROOT, "NEXT_PUBLIC_");
-  const registry = env.NEXT_PUBLIC_TBV_BTC_VAULT_REGISTRY;
-  const appController = env.NEXT_PUBLIC_TBV_AAVE_ADAPTER;
-  const graphqlEndpoint = env.NEXT_PUBLIC_TBV_GRAPHQL_ENDPOINT;
-  const ethRpcUrl = env.NEXT_PUBLIC_ETH_RPC_URL;
-  if (!registry || !appController || !graphqlEndpoint || !ethRpcUrl)
-    throw new Error(
-      `Missing NEXT_PUBLIC_TBV_* env for ${network} (Vite mode "${NETWORKS[network].viteMode}", dir ${VAULT_ROOT}). Run 'pnpm --filter vault sync-env' or check .env / .env.dev-testnet.`,
-    );
-
-  // Surface which network's values were resolved (once per process), and warn loudly if they look
-  // like they came from another network — `loadEnv` merges shared `.env` under the mode file, so a key
-  // missing from `.env.<mode>` would silently inherit e.g. devnet's value. The endpoint host naming
-  // (…vault-devnet… / …testnet…) is a cheap cross-check for that footgun.
-  if (!loggedNetworks.has(network)) {
-    loggedNetworks.add(network);
-    // eslint-disable-next-line no-console
-    console.log(
-      `[pegin-params] ${network}: registry ${registry}, graphql ${graphqlEndpoint}`,
-    );
-    if (!graphqlEndpoint.includes(network))
-      // eslint-disable-next-line no-console
-      console.warn(
-        `[pegin-params] ⚠️ ${network}: GraphQL endpoint "${graphqlEndpoint}" does not mention "${network}" — env may be resolving another network's values (a key missing from .env.${NETWORKS[network].viteMode}?).`,
-      );
-  }
-
-  return {
-    registry: registry as Address,
-    appController,
-    graphqlEndpoint,
-    ethRpcUrl,
-  };
-}
-
 /** Format satoshis as a trimmed BTC decimal string (e.g. 1_000_000n → "0.01"), for the amount input. */
 function satsToBtc(sats: bigint): string {
   const whole = sats / SATS_PER_BTC;
   const frac = sats % SATS_PER_BTC;
   if (frac === 0n) return whole.toString();
-  const fracStr = frac.toString().padStart(8, "0").replace(/0+$/, "");
+  const fracStr = frac
+    .toString()
+    .padStart(BTC_DECIMALS, "0")
+    .replace(/0+$/, "");
   return `${whole}.${fracStr}`;
-}
-
-/** A Sepolia public client for the network's ETH RPC (the same reads the app performs). */
-function createEthClient(ethRpcUrl: string): PublicClient {
-  return createPublicClient({
-    chain: sepolia,
-    transport: http(ethRpcUrl),
-  }) as PublicClient;
 }
 
 /**
@@ -147,18 +85,6 @@ export async function fetchMinDepositBtc(
   const client = createEthClient(ethRpcUrl);
   const config = await getPegInConfig(client, registry);
   return satsToBtc(config.minimumPegInAmount);
-}
-
-const GET_VBTC_RESERVE_ID = gql`
-  query GetVaultBtcReserveId {
-    aaveConfig(id: 1) {
-      vaultBtcReserveId
-    }
-  }
-`;
-
-interface VbtcReserveIdResponse {
-  aaveConfig: { vaultBtcReserveId: string } | null;
 }
 
 /**
@@ -186,21 +112,8 @@ export async function fetchMinDepositForSplitBtc(
 
   // Resolve the Core Spoke on-chain from the env-pinned adapter (mirrors the app's getCoreSpokeAddress —
   // never trust a GraphQL-supplied spoke), and the vBTC reserve id from the indexer's singleton config.
-  const spokeAddress = (await client.readContract({
-    address: appController as Address,
-    abi: AaveIntegrationAdapterABI,
-    functionName: CORE_SPOKE_FN,
-    args: [],
-  })) as Address;
-
-  const gqlClient = new GraphQLClient(graphqlEndpoint);
-  const { aaveConfig } =
-    await gqlClient.request<VbtcReserveIdResponse>(GET_VBTC_RESERVE_ID);
-  if (!aaveConfig)
-    throw new Error(
-      `No aaveConfig from the indexer at ${graphqlEndpoint} — cannot resolve the vBTC reserve id for the split minimum.`,
-    );
-  const reserveId = BigInt(aaveConfig.vaultBtcReserveId);
+  const spokeAddress = await resolveCoreSpoke(client, appController);
+  const reserveId = await fetchVbtcReserveId(graphqlEndpoint);
 
   // Aave risk params from the spoke, using the reserve's current dynamicConfigKey (no-position baseline).
   const { dynamicConfigKey } = await getReserve(
@@ -258,7 +171,7 @@ export async function fetchProviders(
   network: NetworkName,
 ): Promise<ProviderChoice[]> {
   const { graphqlEndpoint, appController } = resolveNetworkContracts(network);
-  const client = new GraphQLClient(graphqlEndpoint);
+  const client = createGraphQLClient(graphqlEndpoint);
   const response = await client.request<AppProvidersResponse>(
     GET_APP_PROVIDERS,
     { appController },
@@ -269,4 +182,121 @@ export async function fetchProviders(
     // The app treats a null / "ok" metadataStatus as usable and any other value (rejected) as not.
     available: p.metadataStatus == null || p.metadataStatus === "ok",
   }));
+}
+
+/**
+ * Raw indexer vault statuses that occupy a per-position cap slot — the raw-string equivalent of the
+ * app's `countCollateralizableVaults` (ContractStatus ACTIVE|PENDING|VERIFIED): "available" → ACTIVE,
+ * "pending"/"signatures_collected" → PENDING, "verified" → VERIFIED. Terminal states (redeemed,
+ * liquidated, expired, invalid, depositor_withdrawn) free the slot and are NOT counted. Kept as raw
+ * strings so we count off the indexer directly without importing the app's status enums.
+ */
+const CAP_SLOT_STATUSES = new Set([
+  "available",
+  "pending",
+  "signatures_collected",
+  "verified",
+]);
+/** Ponder's max page size + a runaway-cursor backstop, mirroring the app's fetchVaultsByDepositor. */
+const VAULTS_PAGE_SIZE = 1000;
+const MAX_VAULT_PAGES = 50;
+
+const GET_DEPOSITOR_VAULT_STATUSES_FIRST = gql`
+  query GetDepositorVaultStatusesFirst($depositor: String!, $limit: Int!) {
+    vaults(where: { depositor: $depositor }, limit: $limit) {
+      items {
+        status
+        applicationEntryPoint
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+`;
+
+const GET_DEPOSITOR_VAULT_STATUSES_NEXT = gql`
+  query GetDepositorVaultStatusesNext(
+    $depositor: String!
+    $limit: Int!
+    $after: String!
+  ) {
+    vaults(where: { depositor: $depositor }, limit: $limit, after: $after) {
+      items {
+        status
+        applicationEntryPoint
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+`;
+
+interface VaultStatusPage {
+  vaults: {
+    items: { status: string; applicationEntryPoint: string }[];
+    pageInfo: { hasNextPage: boolean; endCursor: string | null };
+  };
+}
+
+export interface VaultCountCap {
+  /** On-chain per-position BTC Vault cap. 0 means unlimited (the adapter only enforces a cap > 0). */
+  maxVaults: number;
+  /** This depositor's vaults under the app that currently occupy a cap slot. */
+  currentCount: number;
+}
+
+/**
+ * Read the per-position BTC-Vault cap and the depositor's current occupied-slot count, mirroring the
+ * app's `useVaultCountCap`: the cap from `getPositionSizeParams(AaveAdapterConfig).maxVaultsPerPosition`
+ * (on-chain), and the count from the indexer — this depositor's vaults filtered to the collateralizable
+ * statuses under this app's controller (a conservative superset that includes in-flight PENDING/VERIFIED,
+ * so it over-counts rather than under-counts, matching the app). Paginated like the app so a high-volume
+ * depositor isn't silently truncated.
+ */
+export async function fetchVaultCountCap(
+  network: NetworkName,
+  depositorEthAddress: string,
+): Promise<VaultCountCap> {
+  const { appController, graphqlEndpoint, ethRpcUrl, aaveAdapterConfig } =
+    resolveNetworkContracts(network);
+
+  const client = createEthClient(ethRpcUrl);
+  const { maxVaultsPerPosition } = await getPositionSizeParams(
+    client,
+    aaveAdapterConfig,
+  );
+  const maxVaults = Number(maxVaultsPerPosition);
+
+  const gqlClient = createGraphQLClient(graphqlEndpoint);
+  const depositor = depositorEthAddress.toLowerCase();
+  const adapter = appController.toLowerCase();
+  let currentCount = 0;
+  let after: string | null = null;
+  for (let pageIndex = 0; pageIndex < MAX_VAULT_PAGES; pageIndex++) {
+    const page: VaultStatusPage = after
+      ? await gqlClient.request(GET_DEPOSITOR_VAULT_STATUSES_NEXT, {
+          depositor,
+          limit: VAULTS_PAGE_SIZE,
+          after,
+        })
+      : await gqlClient.request(GET_DEPOSITOR_VAULT_STATUSES_FIRST, {
+          depositor,
+          limit: VAULTS_PAGE_SIZE,
+        });
+    for (const item of page.vaults.items)
+      if (
+        CAP_SLOT_STATUSES.has(item.status) &&
+        item.applicationEntryPoint.toLowerCase() === adapter
+      )
+        currentCount++;
+    if (!page.vaults.pageInfo.hasNextPage) break;
+    after = page.vaults.pageInfo.endCursor;
+    if (!after) break;
+  }
+
+  return { maxVaults, currentCount };
 }

--- a/services/vault/e2e/real/run.ts
+++ b/services/vault/e2e/real/run.ts
@@ -6,6 +6,7 @@
  */
 import { ACTIONS_BY_ID } from "./actions";
 import { createArtifacts } from "./artifacts";
+import { fetchBorrowContext } from "./borrowParams";
 import {
   BTC_WALLET_TO_CONNECTOR,
   ETH_WALLET_TO_CONNECTOR,
@@ -15,6 +16,7 @@ import {
 } from "./config";
 import { launchWalletContext } from "./connector";
 import { ensureDevServer, type DevServerHandle } from "./devServer";
+import { fetchVaultCountCap } from "./peginParams";
 import {
   balanceWarnings,
   checkBalances,
@@ -83,6 +85,66 @@ export async function runE2E(config: RunConfig): Promise<void> {
     );
     for (const warning of balanceWarnings(balances))
       artifacts.log(`BALANCE WARNING: ${warning}`);
+
+    // Max-BTC-Vaults pre-flight (pegin only). A position has an on-chain cap on how many BTC Vaults it
+    // can hold; the app blocks the deposit ("Maximum BTC Vaults reached") once full. Read the cap +
+    // this depositor's current occupied-slot count from real data (contract + indexer) BEFORE the
+    // browser deposit and refuse if the deposit (2 vaults for a split, else 1) would exceed it — so a
+    // doomed pegin never launches. A fetch failure is non-fatal: the form's own gate backstops it (see
+    // pegin.ts), so we warn and proceed rather than block on a transient read error.
+    // A `borrow --pegin-first` run performs a pegin too, so it's subject to the same cap.
+    if (
+      config.action === "pegin" ||
+      (config.action === "borrow" && config.peginFirst)
+    ) {
+      const cap = await fetchVaultCountCap(
+        config.network,
+        balances.eth.address,
+      ).catch((error) => {
+        artifacts.log(
+          `⚠️ Could not pre-check the BTC-Vault count cap (${error instanceof Error ? error.message : error}); the form will gate it.`,
+        );
+        return undefined;
+      });
+      if (cap) {
+        const needed = config.split ? 2 : 1;
+        if (cap.maxVaults > 0 && cap.currentCount + needed > cap.maxVaults)
+          throw new Error(
+            `Maximum BTC Vaults reached: this position already holds ${cap.currentCount} of ${cap.maxVaults} BTC Vaults` +
+              `${config.split ? " and a two-vault split needs 2 free slots" : ""}. Redeem/withdraw a vault or use a different ETH account before pegging in.`,
+          );
+        artifacts.log(
+          `Vault-count cap: ${cap.currentCount}/${cap.maxVaults === 0 ? "∞ (unlimited)" : cap.maxVaults} slots used (this deposit needs ${needed}).`,
+        );
+      }
+    }
+
+    // Borrow pre-flight (reuse-collateral only). Read the position from real data (contract + indexer)
+    // and refuse a doomed run BEFORE the browser if there's no borrowable collateral. A `--pegin-first`
+    // run has no collateral yet (it pegs in during the run), so this gate is skipped for it. A fetch
+    // failure is non-fatal: the disabled Borrow button + the form's validation backstop it (see
+    // actions/borrow.ts), so we warn. The borrow amount (a conservative fraction of the max) is resolved
+    // inside the action, which also has the ETH address and logs the real-data max it picked from.
+    if (config.action === "borrow" && !config.peginFirst) {
+      const borrowContext = await fetchBorrowContext(
+        config.network,
+        balances.eth.address,
+      ).catch((error) => {
+        artifacts.log(
+          `⚠️ Could not pre-check borrow collateral (${error instanceof Error ? error.message : error}); the form will gate it.`,
+        );
+        return undefined;
+      });
+      if (borrowContext) {
+        if (!borrowContext.hasCollateral)
+          throw new Error(
+            "No collateral to borrow against: this position holds no active BTC Vaults. Peg in first, or re-run with --pegin-first (or borrow with a different ETH account that has collateral).",
+          );
+        artifacts.log(
+          `Borrow collateral: $${borrowContext.collateralUsd.toFixed(2)} (current debt $${borrowContext.currentDebtUsd.toFixed(2)}).`,
+        );
+      }
+    }
 
     artifacts.writeNetworkState({
       config,

--- a/services/vault/e2e/real/timing.ts
+++ b/services/vault/e2e/real/timing.ts
@@ -4,6 +4,9 @@
  * lengthening a settle is safe, shortening risks flakiness.
  */
 
+/** Milliseconds per second — for converting a `*_MS` budget to seconds in a user-facing message. */
+export const MS_PER_SECOND = 1000;
+
 /** A dapp step: click a control / wait for an element to appear on the vault UI. */
 export const STEP_TIMEOUT_MS = 30_000;
 /** The wallet menu content to render after clicking the avatar-group trigger. */
@@ -57,6 +60,40 @@ export const PEGIN_POLL_INTERVAL_MS = 3_000;
  * optimistically ("Activating collateral…") but can lag the indexer catching up.
  */
 export const DASHBOARD_VAULT_TIMEOUT_MS = 60_000;
+
+// ── borrow ────────────────────────────────────────────────────────────────────
+/**
+ * The dashboard "Borrow" button to become enabled after landing on the dashboard. It's gated on
+ * `hasCollateral` (the position's on-chain collateral > 0); a JUST-activated vault (pegin-first) takes
+ * a little time to propagate into that read, so the button can be briefly disabled right after
+ * "Go to Dashboard". Generous so a fresh activation isn't mistaken for "no collateral" (a hard fail);
+ * a reuse run already had its collateral gated by run.ts, so the button is enabled well within this.
+ */
+export const BORROW_BUTTON_ENABLE_TIMEOUT_MS = 180_000;
+/**
+ * After a pegin-first activation, how long to wait for the freshly-activated vault's collateral to
+ * register on-chain (the adapter position's BTC amount rising above the pre-pegin baseline) before
+ * entering the borrow amount. Activation confirms on Sepolia in seconds and `getPosition` reads that
+ * on-chain state directly, so this is usually quick; generous to absorb a slow read. Non-fatal on
+ * timeout — the borrow form's own CTA wait still gates the amount.
+ */
+export const FRESH_COLLATERAL_TIMEOUT_MS = 180_000;
+/** Poll cadence for the post-activation collateral-settle wait (a light on-chain `getPosition` read). */
+export const FRESH_COLLATERAL_POLL_MS = 3_000;
+/**
+ * The borrow form's submit button to become the enabled "Borrow" after entering an amount — it relabels
+ * through "Enter an amount" / "Refreshing position…" while the oracle price + position settle. Generous
+ * because in a pegin-first run the just-activated vault's collateral has to propagate into the form's
+ * on-chain position read before a larger amount clears the max ("Amount exceeds maximum" is transient
+ * until then). A genuinely-too-large amount fails at this deadline with the form's callout.
+ */
+export const BORROW_CTA_ENABLE_TIMEOUT_MS = 150_000;
+/**
+ * One borrow ETH transaction to confirm on Sepolia (approver confirms the MetaMask pop-up → the app
+ * shows the "Borrow successful" screen). A single draw with no ERC-20 approval, so a minute is ample;
+ * a stuck tx fails the run (trace captured) instead of hanging.
+ */
+export const BORROW_TX_TIMEOUT_MS = 90_000;
 
 // ── sign-conformance (per-wallet signing replay) ─────────────────────────────
 /**

--- a/services/vault/src/applications/aave/components/AssetSelectionModal/AssetSelectionModal.tsx
+++ b/services/vault/src/applications/aave/components/AssetSelectionModal/AssetSelectionModal.tsx
@@ -201,6 +201,7 @@ export function AssetSelectionModal({
               key={row.key}
               onClick={() => handleAssetClick(row.symbol)}
               className="flex w-full cursor-pointer items-center rounded-xl bg-secondary-highlight p-4 text-left transition-colors hover:bg-secondary-strokeLight dark:bg-primary-main dark:hover:bg-secondary-strokeDark"
+              data-testid={`asset-select-row-${row.symbol.toLowerCase()}`}
             >
               <div className={ASSET_COL_CLASS}>
                 <Avatar

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/index.tsx
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/index.tsx
@@ -381,6 +381,7 @@ export function Borrow() {
         }
         onClick={handleBorrow}
         className="mt-2 disabled:!bg-accent-disabled disabled:!opacity-100"
+        data-testid="borrow-submit-button"
       >
         {getBorrowButtonText()}
       </Button>

--- a/services/vault/src/applications/aave/components/LoanCard/LoanSuccessModal.tsx
+++ b/services/vault/src/applications/aave/components/LoanCard/LoanSuccessModal.tsx
@@ -79,6 +79,7 @@ export function LoanSuccessModal({
           size="large"
           fluid
           onClick={onDone}
+          data-testid="loan-success-done-button"
         >
           {copy.doneButton}
         </Button>

--- a/services/vault/src/components/simple/LoansSection.tsx
+++ b/services/vault/src/components/simple/LoansSection.tsx
@@ -71,6 +71,7 @@ export function LoansSection({
             onClick={onBorrow}
             className="rounded-full"
             disabled={!isConnected || !hasCollateral}
+            data-testid="loans-borrow-button"
           >
             {COPY.loans.borrowButton}
           </Button>


### PR DESCRIPTION
Closes https://github.com/babylonlabs-io/babylon-toolkit/issues/2032

## What this PR does

Adds a `borrow` action to the real-wallet E2E CLI (`services/vault/e2e/real/`) — the next step of the depositor lifecycle after connect and pegin. It drives the vault dApp with real wallet extensions (UniSat + MetaMask) on real testnets (signet BTC + Sepolia ETH) to borrow a token (USDC / USDT / WBTC) against an activated BTC-Vault position, end-to-end, and finishes at the "Borrow successful" screen.

The borrow runs in one of two shapes, chosen by the CLI:

- **Reuse existing collateral** (default): borrow against vaults the depositor already has. Before opening the browser, a pre-flight reads the position from real on-chain + indexer data and refuses the run early if there is no collateral to borrow against.
- **Pegin-first** (`--pegin-first`): peg in a fresh vault first (reusing the existing pegin flow), then borrow — all in one browser session. This works both for a brand-new position and for adding another vault to an existing one.

You pick the token with `--borrow-token` (defaults to the first borrowable one) and the amount with `--borrow-amount` (`--borrow-amount=max` uses the form's Max button). When you don't pass an amount, the CLI reads the real max from chain data and borrows a conservative fraction of it so the position stays well clear of liquidation.

Alongside borrow, this PR adds a few things that the borrow flow needed or that harden the existing pegin (all in the same E2E CLI):

- **"Maximum BTC Vaults reached" guard** — a pegin is refused early when the position is already at its on-chain per-position vault cap, instead of launching a deposit that the app would block anyway.
- **Vault-provider readiness fast-fail** — if the vault provider isn't ready for the WOTS key step in time (usually because a Bitcoin block is slow), the pegin now stops in at most ~20 minutes with a clear "this is a vault-provider issue, not the CLI" message, instead of hanging for the full 2.5-hour budget.
- **Wait for fresh collateral before borrowing** — after a pegin-first activation, the app shows the new vault as active immediately (optimistically), but the amount you can borrow is read from the on-chain position, which lags by a variable 15–30+ seconds. So the CLI now waits for the new collateral to actually register on chain before it enters the borrow amount. It waits for the collateral to rise *above what was there before*, so adding a second vault to an existing position is handled correctly (not just "collateral > 0").
- **Shared plumbing + cleanup** — network/env resolution, the Sepolia and GraphQL clients, and the vBTC-reserve-id read are now shared between the pegin and borrow pre-flights (`networkContracts.ts`) instead of duplicated, and a handful of stable `data-testid`s were added to the borrow controls in `services/vault/src` so the test can target them without depending on button text.

## Why

The E2E CLI is being grown one depositor step at a time (connect → pegin → borrow → repay → withdraw) so we can drive and verify each real flow unattended. Borrow is the next step. The extra guards exist because both of them showed up as real failure modes while testing borrow on devnet: a position at its vault cap, and a pegin that couldn't finish because the vault provider wasn't ready — both of which used to fail slowly and confusingly.

## Approaches, and why we chose them

- **The CLI re-derives a little app logic against the SDK instead of importing the app's React code.** The CLI is a separate Node runtime — it can't cleanly import the app's hooks, `@/` aliases, or single-environment singletons. So for anything that must match the app exactly (protocol minimums, the borrowable-token list, the max-borrow math) it calls the same pure SDK functions the app calls, and only re-implements the small glue (a couple of GraphQL queries and the max-borrow formula, both commented as "keep in sync"). Crucially, all of these are treated as *best-effort defaults*: the live form (its Max button and validation) is always the authoritative gate, so any small drift in the CLI's estimate can never cause a wrong borrow — the form catches it.

- **Conservative default borrow amount, not Max.** Borrowing the maximum drives the health factor right to the liquidation edge, which is risky and not repeatable for a test. So the default is a safe fraction of the max; Max is still reachable explicitly.

- **Support both reuse and pegin-first rather than only one.** Reuse is fast and cheap to run repeatedly (no new pegin); pegin-first proves the whole composite works from nothing. Keeping both means we can iterate quickly on the borrow UI (reuse) and still validate the full path (pegin-first).

- **Wait on the on-chain collateral amount, in sats, not the USD value.** The USD collateral value moves with the oracle price between reads, so a "did it go up?" check on USD would need a fuzzy threshold. The BTC amount in sats only changes when a vault is actually registered as collateral, so waiting for a strict increase there is exact and price-independent.

- **Testid-first selectors with a tolerant fallback.** The borrow UI had no stable test hooks, and button text drifts between the source and the deployed build (this already bit us once). So the test prefers a `data-testid` (added in this PR) and falls back to role/text/class for a build that predates the testid — the same pattern the pegin flow already uses.

## How it was validated

Run end-to-end on devnet with real funds, confirmed on-chain each time:

- Reuse borrow against existing collateral — debt appeared on-chain.
- Pegin-first with a fresh vault — full pegin → activation → borrow, debt confirmed.
- Pegin-first adding a *second* vault, borrowing an amount that only clears against the *combined* collateral — proving the new vault's collateral is actually counted (the borrow was briefly rejected as "exceeds maximum" until the second vault registered, then went through).
- The vault-provider fast-fail was also exercised (a slow Bitcoin block) and aborted cleanly in ~20 minutes.

Existing single-vault and split pegins still pass — no regression. `pnpm exec eslint e2e/real` and `pnpm exec tsc --noEmit -p tsconfig.e2e.json` are clean.

## Note for reviewers

This branch bundles the borrow feature with the two pegin guards and the shared-plumbing cleanup described above — they landed together because borrow depended on them. Everything is test tooling under `services/vault/e2e/real/` plus four one-line `data-testid` additions in `services/vault/src`; no product or protocol logic is changed.