### PR TITLE
fix(vault): surface deposit fee/wallet failures instead of spinning

### DIFF
--- a/services/vault/src/components/simple/PostDepositContinuationContent.tsx
+++ b/services/vault/src/components/simple/PostDepositContinuationContent.tsx
@@ -28,7 +28,7 @@ export function PostDepositContinuationContent({
   onClose,
 }: PostDepositContinuationContentProps) {
   const { connected: btcConnected } = useBTCWallet();
-  const btcPublicKey = useBtcPublicKey(btcConnected);
+  const { publicKey: btcPublicKey } = useBtcPublicKey(btcConnected);
   const { activities, pendingPegins } = useVaultDeposits(depositorEthAddress);
 
   const scoped = useMemo(() => {

--- a/services/vault/src/components/simple/SimpleDeposit.tsx
+++ b/services/vault/src/components/simple/SimpleDeposit.tsx
@@ -9,6 +9,7 @@ import { useAddressScreening } from "@/context/addressScreening";
 import { useGeoFencing } from "@/context/geofencing";
 import { ProtocolParamsProvider } from "@/context/ProtocolParamsContext";
 import { useBTCWallet, useETHWallet } from "@/context/wallet";
+import { COPY } from "@/copy";
 import { useBtcWalletState } from "@/hooks/deposit/useBtcWalletState";
 import { useDepositPeginFee } from "@/hooks/deposit/useDepositPeginFee";
 import { useDialogStep } from "@/hooks/deposit/useDialogStep";
@@ -130,6 +131,8 @@ function SimpleDepositContent({
     isSplitAmountTooLow,
     depositorClaimValue,
     depositorClaimValueError,
+    btcPublicKeyError,
+    refetchBtcPublicKey,
     ordinalsCheckPending,
     validateForm,
     resetForm,
@@ -301,6 +304,10 @@ function SimpleDepositContent({
     try {
       await reconnectBtcWallet();
       setWalletConnectionError(null);
+      // reconnect() re-auths the raw provider without emitting a connector
+      // event, so re-read the public key explicitly to clear a stuck
+      // btcPublicKeyError once the wallet is unlocked again.
+      refetchBtcPublicKey();
     } catch {
       // The underlying provider throws dev-facing strings (e.g. "BTC wallet
       // provider returned an empty address"). Surface a single polished
@@ -331,7 +338,7 @@ function SimpleDepositContent({
     // (which triggers the wallet's unlock/re-authorization prompt) instead of
     // attempting another deposit. The deposit attempt itself is only retried
     // once the user successfully reconnects and the error/lock state clears.
-    if (walletConnectionError || isBtcWalletLocked) {
+    if (walletConnectionError || isBtcWalletLocked || btcPublicKeyError) {
       await handleReconnectWallet();
       return;
     }
@@ -461,8 +468,14 @@ function SimpleDepositContent({
                   // of showing a red inline string; a liveness failure keeps its
                   // detail message.
                   hasWalletConnectionError:
-                    Boolean(walletConnectionError) || isBtcWalletLocked,
-                  walletConnectionErrorMessage: walletConnectionError,
+                    Boolean(walletConnectionError) ||
+                    isBtcWalletLocked ||
+                    btcPublicKeyError !== null,
+                  walletConnectionErrorMessage:
+                    walletConnectionError ??
+                    (btcPublicKeyError
+                      ? COPY.wallet.publicKeyUnavailable
+                      : null),
                   isWalletLocked: isBtcWalletLocked,
                   isVerifyingWallet,
                   isReconnectingWallet,

--- a/services/vault/src/components/simple/SimpleDeposit.tsx
+++ b/services/vault/src/components/simple/SimpleDeposit.tsx
@@ -306,8 +306,10 @@ function SimpleDepositContent({
       setWalletConnectionError(null);
       // reconnect() re-auths the raw provider without emitting a connector
       // event, so re-read the public key explicitly to clear a stuck
-      // btcPublicKeyError once the wallet is unlocked again.
-      refetchBtcPublicKey();
+      // btcPublicKeyError once the wallet is unlocked again. Awaited so the
+      // reconnecting state holds until the key is fresh — otherwise the CTA
+      // briefly looks actionable while still showing the stale failure.
+      await refetchBtcPublicKey();
     } catch {
       // The underlying provider throws dev-facing strings (e.g. "BTC wallet
       // provider returned an empty address"). Surface a single polished

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -811,6 +811,8 @@ export const COPY = {
       unlockButton: "Unlock wallet",
       unlocking: "Unlocking wallet...",
     },
+    publicKeyUnavailable:
+      "Your BTC wallet did not return a public key. Please reconnect your wallet and try again.",
   },
   collateral: {
     releaseDisabledTooltip:

--- a/services/vault/src/hooks/__tests__/useBtcPublicKey.test.tsx
+++ b/services/vault/src/hooks/__tests__/useBtcPublicKey.test.tsx
@@ -1,0 +1,82 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useBtcPublicKey } from "../useBtcPublicKey";
+
+const mockGetPublicKeyHex = vi.hoisted(() => vi.fn());
+// Stable connector instance, mirroring the real provider context (which keeps
+// the same connector object across reconnects and only bumps its map).
+const mockConnector = vi.hoisted(() => ({
+  connectedWallet: { provider: { getPublicKeyHex: mockGetPublicKeyHex } },
+}));
+
+vi.mock("@babylonlabs-io/wallet-connector", () => ({
+  useChainConnector: () => mockConnector,
+}));
+
+vi.mock("@babylonlabs-io/ts-sdk/tbv/core", () => ({
+  // Fixed x-only output with 0x prefix so the strip behavior is observable.
+  processPublicKeyToXOnly: () => `0x${"ab".repeat(32)}`,
+}));
+
+vi.mock("@/infrastructure", () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+describe("useBtcPublicKey", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the x-only key without the 0x prefix once the wallet responds", async () => {
+    mockGetPublicKeyHex.mockResolvedValue(`02${"ab".repeat(32)}`);
+
+    const { result } = renderHook(() => useBtcPublicKey(true));
+
+    await waitFor(() => {
+      expect(result.current.publicKey).toBe("ab".repeat(32));
+    });
+    expect(result.current.error).toBeNull();
+  });
+
+  it("surfaces a terminal error when the wallet public-key read fails", async () => {
+    mockGetPublicKeyHex.mockRejectedValue(new Error("wallet locked"));
+
+    const { result } = renderHook(() => useBtcPublicKey(true));
+
+    await waitFor(() => {
+      expect(result.current.error?.message).toBe("wallet locked");
+    });
+    expect(result.current.publicKey).toBeUndefined();
+  });
+
+  it("refetch() re-reads and clears the error after a reconnect unlocks the wallet", async () => {
+    mockGetPublicKeyHex.mockRejectedValueOnce(new Error("wallet locked"));
+    mockGetPublicKeyHex.mockResolvedValue(`02${"ab".repeat(32)}`);
+
+    const { result } = renderHook(() => useBtcPublicKey(true));
+    await waitFor(() => {
+      expect(result.current.error).not.toBeNull();
+    });
+
+    // The user reconnects/unlocks; the CTA handler calls refetch().
+    act(() => {
+      result.current.refetch();
+    });
+
+    await waitFor(() => {
+      expect(result.current.publicKey).toBe("ab".repeat(32));
+    });
+    expect(result.current.error).toBeNull();
+  });
+
+  it("stays empty without error while the wallet is disconnected", async () => {
+    const { result } = renderHook(() => useBtcPublicKey(false));
+
+    await waitFor(() => {
+      expect(result.current.publicKey).toBeUndefined();
+      expect(result.current.error).toBeNull();
+    });
+    expect(mockGetPublicKeyHex).not.toHaveBeenCalled();
+  });
+});

--- a/services/vault/src/hooks/__tests__/useBtcPublicKey.test.tsx
+++ b/services/vault/src/hooks/__tests__/useBtcPublicKey.test.tsx
@@ -59,14 +59,39 @@ describe("useBtcPublicKey", () => {
       expect(result.current.error).not.toBeNull();
     });
 
-    // The user reconnects/unlocks; the CTA handler calls refetch().
-    act(() => {
-      result.current.refetch();
+    // The user reconnects/unlocks; the CTA handler awaits refetch().
+    await act(async () => {
+      await result.current.refetch();
     });
 
-    await waitFor(() => {
-      expect(result.current.publicKey).toBe("ab".repeat(32));
+    expect(result.current.publicKey).toBe("ab".repeat(32));
+    expect(result.current.error).toBeNull();
+  });
+
+  it("does not let a stale mount read clobber a fresher refetch result", async () => {
+    // Mount read: still pending (wallet locked, slow), will ultimately fail.
+    let rejectMountRead!: (e: Error) => void;
+    const mountRead = new Promise<string>((_, reject) => {
+      rejectMountRead = reject;
     });
+    mockGetPublicKeyHex
+      .mockReturnValueOnce(mountRead) // mount read — hangs
+      .mockResolvedValue(`02${"ab".repeat(32)}`); // refetch — fresh key
+
+    const { result } = renderHook(() => useBtcPublicKey(true));
+
+    // Reconnect fires refetch while the mount read is still in flight; it wins.
+    await act(async () => {
+      await result.current.refetch();
+    });
+    expect(result.current.publicKey).toBe("ab".repeat(32));
+
+    // The stale mount read finally fails — it must NOT overwrite the fresh key.
+    await act(async () => {
+      rejectMountRead(new Error("wallet locked"));
+      await mountRead.catch(() => undefined);
+    });
+    expect(result.current.publicKey).toBe("ab".repeat(32));
     expect(result.current.error).toBeNull();
   });
 

--- a/services/vault/src/hooks/__tests__/usePendingDeposits.test.tsx
+++ b/services/vault/src/hooks/__tests__/usePendingDeposits.test.tsx
@@ -22,7 +22,11 @@ vi.mock("@/context/wallet", () => ({
 }));
 
 vi.mock("@/hooks/useBtcPublicKey", () => ({
-  useBtcPublicKey: vi.fn(() => "btcpubkey123"),
+  useBtcPublicKey: vi.fn(() => ({
+    publicKey: "btcpubkey123",
+    error: null,
+    refetch: vi.fn(),
+  })),
 }));
 
 const mockActivities = vi.fn((): any[] => []);

--- a/services/vault/src/hooks/deposit/__tests__/useDepositPageForm.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useDepositPageForm.test.tsx
@@ -1,7 +1,7 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock env before importing modules that use it
 vi.mock("@/config/env", () => ({
@@ -70,10 +70,12 @@ vi.mock("../../../applications/aave/context", () => ({
 }));
 
 import { useApplications } from "../../useApplications";
+import { useBtcPublicKey } from "../../useBtcPublicKey";
 import { useUTXOs } from "../../useUTXOs";
 import { useAllocationPlanning } from "../useAllocationPlanning";
 import { useDepositPageForm } from "../useDepositPageForm";
 import { useEstimatedBtcFee } from "../useEstimatedBtcFee";
+import { useVaultProviders } from "../useVaultProviders";
 
 vi.mock("@babylonlabs-io/ts-sdk/tbv/core", () => ({
   computeNumLocalChallengers: vi.fn(() => 2),
@@ -87,9 +89,11 @@ vi.mock("@babylonlabs-io/ts-sdk/tbv/core", () => ({
 }));
 
 vi.mock("@/hooks/useBtcPublicKey", () => ({
-  useBtcPublicKey: vi.fn(
-    () => "aa".repeat(32), // 64-char mock x-only pubkey
-  ),
+  useBtcPublicKey: vi.fn(() => ({
+    publicKey: "aa".repeat(32), // 64-char mock x-only pubkey
+    error: null,
+    refetch: vi.fn(),
+  })),
 }));
 
 vi.mock("../../../context/ProtocolParamsContext", () => ({
@@ -1046,6 +1050,79 @@ describe("useDepositPageForm", () => {
         expect(result.current.canSplit).toBe(false);
       });
       expect(result.current.maxDepositSats).toBe(760_000n);
+    });
+  });
+
+  describe("silent stall surfacing", () => {
+    afterEach(() => {
+      // Restore module-level defaults — the suite's beforeEach doesn't reset
+      // these two mocks, so overrides here must not leak into later tests.
+      vi.mocked(useVaultProviders).mockReturnValue({
+        allVaultProviders: [
+          {
+            id: "0x1234567890abcdef1234567890abcdef12345678",
+            btcPubKey: "pubkey1",
+          },
+          {
+            id: "0xabcdef1234567890abcdef1234567890abcdef12",
+            btcPubKey: "pubkey2",
+          },
+        ],
+        unhealthyVpIds: new Set<string>(),
+        vaultKeepers: [{ btcPubKey: "0xVaultKeeperKey1" }],
+        loading: false,
+      } as unknown as ReturnType<typeof useVaultProviders>);
+      vi.mocked(useBtcPublicKey).mockReturnValue({
+        publicKey: "aa".repeat(32),
+        error: null,
+        refetch: vi.fn(),
+      });
+    });
+
+    it("surfaces a terminal minPeginFee error when the settled registry has providers but no keepers", () => {
+      vi.mocked(useVaultProviders).mockReturnValue({
+        allVaultProviders: [
+          {
+            id: "0x1234567890abcdef1234567890abcdef12345678",
+            btcPubKey: "pubkey1",
+          },
+        ],
+        unhealthyVpIds: new Set<string>(),
+        vaultKeepers: [],
+        loading: false,
+      } as unknown as ReturnType<typeof useVaultProviders>);
+
+      const { result } = renderHook(() => useDepositPageForm(), { wrapper });
+
+      // Zero keeper pubkeys can never enable the minPeginFee query — the hook
+      // must report a terminal error so the CTA doesn't spin forever.
+      expect(result.current.minPeginFeeError).not.toBeNull();
+    });
+
+    it("keeps minPeginFeeError null while the registry is still loading", () => {
+      vi.mocked(useVaultProviders).mockReturnValue({
+        allVaultProviders: [],
+        unhealthyVpIds: new Set<string>(),
+        vaultKeepers: [],
+        loading: true,
+      } as unknown as ReturnType<typeof useVaultProviders>);
+
+      const { result } = renderHook(() => useDepositPageForm(), { wrapper });
+
+      expect(result.current.minPeginFeeError).toBeNull();
+    });
+
+    it("exposes the wallet public-key read failure", () => {
+      const walletError = new Error("wallet unresponsive");
+      vi.mocked(useBtcPublicKey).mockReturnValue({
+        publicKey: undefined,
+        error: walletError,
+        refetch: vi.fn(),
+      });
+
+      const { result } = renderHook(() => useDepositPageForm(), { wrapper });
+
+      expect(result.current.btcPublicKeyError).toBe(walletError);
     });
   });
 });

--- a/services/vault/src/hooks/deposit/useDepositPageForm.ts
+++ b/services/vault/src/hooks/deposit/useDepositPageForm.ts
@@ -128,6 +128,14 @@ export interface UseDepositPageFormResult {
   isLoadingFee: boolean;
   feeError: string | null;
   maxDepositSats: bigint | null;
+  /**
+   * Terminal wallet public-key read failure. Without it the depositor pubkey
+   * silently stays undefined, permanently disabling the claim-value query —
+   * consumers must promote it to the wallet-reconnect recovery surface.
+   */
+  btcPublicKeyError: Error | null;
+  /** Re-read the wallet public key — call after a successful reconnect. */
+  refetchBtcPublicKey: () => void;
 
   /**
    * Remaining application supply cap in satoshis. Null = no cap applies, or
@@ -195,7 +203,11 @@ export interface UseDepositPageFormResult {
 export function useDepositPageForm(): UseDepositPageFormResult {
   const { address: btcAddress, connected: btcConnected } = useBTCWallet();
   const { isConnected: isWalletConnected } = useConnection();
-  const depositorBtcPubkey = useBtcPublicKey(btcConnected);
+  const {
+    publicKey: depositorBtcPubkey,
+    error: btcPublicKeyError,
+    refetch: refetchBtcPublicKey,
+  } = useBtcPublicKey(btcConnected);
   const { config, latestUniversalChallengers } = useProtocolParamsContext();
   const { config: aaveConfig } = useAaveConfig();
   const btcPriceUSD = usePrice("BTC");
@@ -290,6 +302,18 @@ export function useDepositPageForm(): UseDepositPageFormResult {
   const vaultKeeperBtcPubkeys = useMemo(
     () => vaultKeepers.map((vk) => vk.btcPubKey),
     [vaultKeepers],
+  );
+  // A settled registry with selectable providers but zero keepers can never
+  // enable the minPeginFee query — surface the stall as a terminal error
+  // instead of letting the CTA spin on "Calculating fees..." forever.
+  const keeperSetError = useMemo(
+    () =>
+      !isLoadingRegistry &&
+      rawProviders.length > 0 &&
+      vaultKeeperBtcPubkeys.length === 0
+        ? new Error("No vault keepers registered for the application")
+        : null,
+    [isLoadingRegistry, rawProviders.length, vaultKeeperBtcPubkeys.length],
   );
 
   const { address: ethAddress } = useETHWallet();
@@ -661,11 +685,13 @@ export function useDepositPageForm(): UseDepositPageFormResult {
     estimatedFeeRate,
     isLoadingFee,
     feeError,
+    btcPublicKeyError,
+    refetchBtcPublicKey,
     maxDepositSats: adjustedMaxDepositSats,
     effectiveRemaining: capSnapshot?.effectiveRemaining ?? null,
     capUnavailable: capError !== null,
     minPeginFee: minPeginFee ?? null,
-    minPeginFeeError: toError(minPeginFeeError),
+    minPeginFeeError: toError(minPeginFeeError) ?? keeperSetError,
     ordinalsCheckPending,
     isTwoVaultSplit,
     setIsTwoVaultSplit,

--- a/services/vault/src/hooks/deposit/useDepositPageForm.ts
+++ b/services/vault/src/hooks/deposit/useDepositPageForm.ts
@@ -134,8 +134,11 @@ export interface UseDepositPageFormResult {
    * consumers must promote it to the wallet-reconnect recovery surface.
    */
   btcPublicKeyError: Error | null;
-  /** Re-read the wallet public key — call after a successful reconnect. */
-  refetchBtcPublicKey: () => void;
+  /**
+   * Re-read the wallet public key — call (and await) after a successful
+   * reconnect so the reconnecting state holds until the key is fresh.
+   */
+  refetchBtcPublicKey: () => Promise<void>;
 
   /**
    * Remaining application supply cap in satoshis. Null = no cap applies, or

--- a/services/vault/src/hooks/useBtcPublicKey.ts
+++ b/services/vault/src/hooks/useBtcPublicKey.ts
@@ -1,10 +1,10 @@
 import { processPublicKeyToXOnly } from "@babylonlabs-io/ts-sdk/tbv/core";
 import { useChainConnector } from "@babylonlabs-io/wallet-connector";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { logger } from "@/infrastructure";
 
-export interface UseBtcPublicKeyResult {
+interface BtcPublicKeyState {
   /**
    * X-only public key (32 bytes, 64 hex chars, no 0x prefix), suitable for
    * vault provider RPC calls. `undefined` while disconnected, still fetching,
@@ -17,13 +17,19 @@ export interface UseBtcPublicKeyResult {
    * instead of waiting forever on an undefined key.
    */
   error: Error | null;
+}
+
+export interface UseBtcPublicKeyResult extends BtcPublicKeyState {
   /**
-   * Force a re-read of the public key. Call after the user reconnects/unlocks
-   * the wallet: the reconnect CTA drives `BTCWalletProvider.reconnect()`, which
-   * re-auths the raw provider WITHOUT emitting a connector event or changing
-   * this hook's deps, so recovery from a stuck `error` needs an explicit nudge.
+   * Re-read the public key, resolving once the read settles. Call after the
+   * user reconnects/unlocks the wallet: the reconnect CTA drives
+   * `BTCWalletProvider.reconnect()`, which re-auths the raw provider WITHOUT
+   * emitting a connector event or changing this hook's deps, so recovery from
+   * a stuck `error` needs an explicit nudge. Awaiting it lets the caller hold
+   * its "reconnecting" state until `error` is fresh, avoiding a window where
+   * the CTA looks actionable while still showing the stale failure.
    */
-  refetch: () => void;
+  refetch: () => Promise<void>;
 }
 
 /**
@@ -33,44 +39,50 @@ export interface UseBtcPublicKeyResult {
  */
 export function useBtcPublicKey(btcConnected: boolean): UseBtcPublicKeyResult {
   const btcConnector = useChainConnector("BTC");
-  const [result, setResult] = useState<{
-    publicKey: string | undefined;
-    error: Error | null;
-  }>({ publicKey: undefined, error: null });
-  const [refetchNonce, setRefetchNonce] = useState(0);
-  const refetch = useCallback(() => setRefetchNonce((n) => n + 1), []);
+  const [result, setResult] = useState<BtcPublicKeyState>({
+    publicKey: undefined,
+    error: null,
+  });
+  // Generation guard: only the most recent read commits. Without it a slow
+  // in-flight mount read (started while the wallet was locked) could settle
+  // AFTER a successful reconnect refetch and clobber the fresh key with a
+  // stale error — reintroducing the stuck-CTA state this hook exists to avoid.
+  const genRef = useRef(0);
+
+  // Pure read — resolves the current key state without committing, so the
+  // mount effect and the imperative refetch share one code path.
+  const readPublicKey = useCallback(async (): Promise<BtcPublicKeyState> => {
+    if (!btcConnected || !btcConnector?.connectedWallet?.provider) {
+      return { publicKey: undefined, error: null };
+    }
+    try {
+      const publicKeyHex =
+        await btcConnector.connectedWallet.provider.getPublicKeyHex();
+      const xOnlyKey = processPublicKeyToXOnly(publicKeyHex);
+      // Strip 0x prefix for RPC calls (32-byte x-only, 64 chars)
+      const keyWithoutPrefix = xOnlyKey.startsWith("0x")
+        ? xOnlyKey.slice(2)
+        : xOnlyKey;
+      return { publicKey: keyWithoutPrefix, error: null };
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      logger.error(error, {
+        data: { context: "Failed to get BTC public key" },
+      });
+      return { publicKey: undefined, error };
+    }
+  }, [btcConnected, btcConnector]);
+
+  const refetch = useCallback(async () => {
+    const gen = ++genRef.current;
+    const next = await readPublicKey();
+    // Drop a read superseded by a newer one (mount read vs. refetch).
+    if (gen === genRef.current) setResult(next);
+  }, [readPublicKey]);
 
   useEffect(() => {
-    let cancelled = false;
-    const fetchBtcPublicKey = async () => {
-      if (btcConnected && btcConnector?.connectedWallet?.provider) {
-        try {
-          const publicKeyHex =
-            await btcConnector.connectedWallet.provider.getPublicKeyHex();
-          const xOnlyKey = processPublicKeyToXOnly(publicKeyHex);
-          // Strip 0x prefix for RPC calls (32-byte x-only, 64 chars)
-          const keyWithoutPrefix = xOnlyKey.startsWith("0x")
-            ? xOnlyKey.slice(2)
-            : xOnlyKey;
-          if (!cancelled) {
-            setResult({ publicKey: keyWithoutPrefix, error: null });
-          }
-        } catch (err) {
-          const error = err instanceof Error ? err : new Error(String(err));
-          logger.error(error, {
-            data: { context: "Failed to get BTC public key" },
-          });
-          if (!cancelled) setResult({ publicKey: undefined, error });
-        }
-      } else if (!cancelled) {
-        setResult({ publicKey: undefined, error: null });
-      }
-    };
-    fetchBtcPublicKey();
-    return () => {
-      cancelled = true;
-    };
-  }, [btcConnected, btcConnector, refetchNonce]);
+    refetch();
+  }, [refetch]);
 
   return { ...result, refetch };
 }

--- a/services/vault/src/hooks/useBtcPublicKey.ts
+++ b/services/vault/src/hooks/useBtcPublicKey.ts
@@ -1,23 +1,47 @@
 import { processPublicKeyToXOnly } from "@babylonlabs-io/ts-sdk/tbv/core";
 import { useChainConnector } from "@babylonlabs-io/wallet-connector";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { logger } from "@/infrastructure";
 
+export interface UseBtcPublicKeyResult {
+  /**
+   * X-only public key (32 bytes, 64 hex chars, no 0x prefix), suitable for
+   * vault provider RPC calls. `undefined` while disconnected, still fetching,
+   * or after a failed wallet read.
+   */
+  publicKey: string | undefined;
+  /**
+   * Terminal wallet read failure (`getPublicKeyHex` threw — e.g. a locked or
+   * unresponsive extension). Surfaced so callers can prompt a reconnect
+   * instead of waiting forever on an undefined key.
+   */
+  error: Error | null;
+  /**
+   * Force a re-read of the public key. Call after the user reconnects/unlocks
+   * the wallet: the reconnect CTA drives `BTCWalletProvider.reconnect()`, which
+   * re-auths the raw provider WITHOUT emitting a connector event or changing
+   * this hook's deps, so recovery from a stuck `error` needs an explicit nudge.
+   */
+  refetch: () => void;
+}
+
 /**
- * Hook to fetch and manage BTC public key from wallet
- *
- * Returns the x-only public key (32 bytes, 64 hex chars) without 0x prefix,
- * suitable for use in vault provider RPC calls.
+ * Hook to fetch and manage the BTC public key from the connected wallet.
  *
  * @param btcConnected - Whether BTC wallet is connected
- * @returns BTC public key (x-only, 64 hex chars, no 0x prefix) or undefined
  */
-export function useBtcPublicKey(btcConnected: boolean): string | undefined {
+export function useBtcPublicKey(btcConnected: boolean): UseBtcPublicKeyResult {
   const btcConnector = useChainConnector("BTC");
-  const [btcPublicKey, setBtcPublicKey] = useState<string | undefined>();
+  const [result, setResult] = useState<{
+    publicKey: string | undefined;
+    error: Error | null;
+  }>({ publicKey: undefined, error: null });
+  const [refetchNonce, setRefetchNonce] = useState(0);
+  const refetch = useCallback(() => setRefetchNonce((n) => n + 1), []);
 
   useEffect(() => {
+    let cancelled = false;
     const fetchBtcPublicKey = async () => {
       if (btcConnected && btcConnector?.connectedWallet?.provider) {
         try {
@@ -28,19 +52,25 @@ export function useBtcPublicKey(btcConnected: boolean): string | undefined {
           const keyWithoutPrefix = xOnlyKey.startsWith("0x")
             ? xOnlyKey.slice(2)
             : xOnlyKey;
-          setBtcPublicKey(keyWithoutPrefix);
+          if (!cancelled) {
+            setResult({ publicKey: keyWithoutPrefix, error: null });
+          }
         } catch (err) {
-          logger.error(err instanceof Error ? err : new Error(String(err)), {
+          const error = err instanceof Error ? err : new Error(String(err));
+          logger.error(error, {
             data: { context: "Failed to get BTC public key" },
           });
-          setBtcPublicKey(undefined);
+          if (!cancelled) setResult({ publicKey: undefined, error });
         }
-      } else {
-        setBtcPublicKey(undefined);
+      } else if (!cancelled) {
+        setResult({ publicKey: undefined, error: null });
       }
     };
     fetchBtcPublicKey();
-  }, [btcConnected, btcConnector]);
+    return () => {
+      cancelled = true;
+    };
+  }, [btcConnected, btcConnector, refetchNonce]);
 
-  return btcPublicKey;
+  return { ...result, refetch };
 }

--- a/services/vault/src/hooks/usePendingDeposits.ts
+++ b/services/vault/src/hooks/usePendingDeposits.ts
@@ -27,7 +27,7 @@ import { ContractStatus } from "@/models/peginStateMachine";
 export function usePendingDeposits() {
   const { connected: btcConnected, address: btcAddress } = useBTCWallet();
   const { address: ethAddress } = useETHWallet();
-  const btcPublicKey = useBtcPublicKey(btcConnected);
+  const { publicKey: btcPublicKey } = useBtcPublicKey(btcConnected);
 
   const { activities, pendingPegins, refetchActivities } = useVaultDeposits(
     ethAddress as Address | undefined,

--- a/services/vault/src/services/deposit/__tests__/validations.test.ts
+++ b/services/vault/src/services/deposit/__tests__/validations.test.ts
@@ -475,6 +475,36 @@ describe("Deposit Validations", () => {
       });
     });
 
+    it("surfaces the fee error when the fee value is absent (real failure shape)", () => {
+      // In production a failed estimate always has estimatedFeeSats missing
+      // (useEstimatedBtcFee pairs every error with fee: null), so the error
+      // must win over the null-fee "Calculating fees..." label.
+      const result = getDepositCtaState({
+        ...readyParams,
+        estimatedFeeSats: undefined,
+        isFeeError: true,
+        feeError: "Unable to fetch network fee rates",
+      });
+      expect(result).toEqual({
+        disabled: true,
+        label: "Unable to fetch network fee rates",
+      });
+    });
+
+    it("prefers 'No available balance' over a fee error when the wallet is empty", () => {
+      const result = getDepositCtaState({
+        ...readyParams,
+        btcBalance: 0n,
+        estimatedFeeSats: undefined,
+        isFeeError: true,
+        feeError: "Unable to fetch network fee rates",
+      });
+      expect(result).toEqual({
+        disabled: true,
+        label: "No available balance",
+      });
+    });
+
     it("returns 'Calculating fees...' when fee is loading", () => {
       const result = getDepositCtaState({
         ...readyParams,

--- a/services/vault/src/services/deposit/validations.ts
+++ b/services/vault/src/services/deposit/validations.ts
@@ -391,6 +391,18 @@ export function getDepositCtaState(params: DepositCtaParams): DepositCtaState {
     return { disabled: true, label: "Calculating fees..." };
   }
 
+  // Surface a terminal network-fee failure before `getDepositButtonLabel`:
+  // a failed estimate also has `estimatedFeeSats` absent, so the null-fee
+  // "Calculating fees..." label would otherwise shadow the error forever.
+  // Skip when there's no balance — "No available balance" is more actionable
+  // than a fee error the user can't act on anyway.
+  if (params.btcBalance > 0n && params.isFeeError) {
+    return {
+      disabled: true,
+      label: params.feeError ?? "Fee estimate unavailable",
+    };
+  }
+
   const amountLabel = getDepositButtonLabel(params);
   if (amountLabel !== "Deposit") {
     return { disabled: true, label: amountLabel };
@@ -406,13 +418,6 @@ export function getDepositCtaState(params: DepositCtaParams): DepositCtaState {
 
   if (params.ordinalsCheckPending) {
     return { disabled: true, label: "Checking for inscriptions..." };
-  }
-
-  if (params.isFeeError) {
-    return {
-      disabled: true,
-      label: params.feeError ?? "Fee estimate unavailable",
-    };
   }
 
   if (params.feeDisabled) {


### PR DESCRIPTION
The deposit form's CTA showed "Calculating fees..." indefinitely whenever an
upstream dependency failed, giving the user no indication anything was wrong.
This fixes three independent silent-forever paths so each failure surfaces an
actionable message or recovery CTA.

- **Network fee-rate failure** (`validations.ts`): `getDepositCtaState` returned
the null-fee "Calculating fees..." label before the `isFeeError` branch could
ever run, making that branch dead code — every fee error also has `fee === null`.
Moved the fee-error check ahead of the null-fee label so a failed estimate shows
its message; removed the now-duplicate later block. Guarded on `btcBalance > 0n`
so "No available balance" still wins for an empty wallet.
- **Silent wallet public-key failure** (`useBtcPublicKey.ts`): the hook swallowed
`getPublicKeyHex()` errors and left the key `undefined`, permanently disabling
the downstream claim-value query. It now returns `{ publicKey, error, refetch }`;
the error promotes the CTA to the existing "Reconnect Wallet" recovery action,
and `refetch()` (called after a successful reconnect) clears it deterministically.
- **Keeper-less registry** (`useDepositPageForm.ts`): a settled registry with
providers but zero vault keepers could never enable the `minPeginFee` query.
Now surfaced as a terminal `minPeginFeeError` instead of an infinite spinner.

Note: the trigger that exposed this (a WAF 403 on the signet mempool fees
endpoint) is an infra/region issue — this change makes the app *report* the
failure rather than fixing the endpoint.


<img width="939" height="878" alt="image" src="https://github.com/user-attachments/assets/5f148f8e-bbe1-4e26-96c3-b6275a5ee05a" />
