### PR TITLE
fix(vault): allow Google Fonts stylesheets in the CSP style-src

### DIFF
--- a/services/vault/index.html
+++ b/services/vault/index.html
@@ -26,7 +26,7 @@
     <meta name="twitter:image:width" content="2048" />
     <meta name="twitter:image:height" content="1170" />
     <meta name="version" content="%NEXT_PUBLIC_COMMIT_HASH%" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; connect-src 'self' https: http: wss: ws:; img-src 'self' data: https: blob:; style-src 'self' 'unsafe-inline'; font-src 'self' data: https:; object-src 'none'; base-uri 'self'; worker-src 'self' blob:; frame-src 'self' https://verify.walletconnect.com https://verify.walletconnect.org https://secure.walletconnect.com https://secure.walletconnect.org;" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; connect-src 'self' https: http: wss: ws:; img-src 'self' data: https: blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https:; object-src 'none'; base-uri 'self'; worker-src 'self' blob:; frame-src 'self' https://verify.walletconnect.com https://verify.walletconnect.org https://secure.walletconnect.com https://secure.walletconnect.org;" />
     <meta name="referrer" content="strict-origin-when-cross-origin" />
     <title>Babylon - Vault</title>
 


### PR DESCRIPTION
## What

Adds `https://fonts.googleapis.com` to the `style-src` directive of the CSP meta tag introduced in #1859. One-token change, everything else in the policy is untouched.

## Why

Since #1859 the console shows `Loading the stylesheet 'https://fonts.googleapis.com/css2?family=Poppins...' violates the following Content Security Policy directive: "style-src 'self' 'unsafe-inline'"`.

The blocked stylesheet is injected by `@tomo-inc/wallet-connect-sdk@1.0.0`: line 1 of its shipped `dist/style.css` is `@import "https://fonts.googleapis.com/css2?family=Poppins..."`. It reaches the app unconditionally on every page load:

- `packages/babylon-wallet-connector/src/context/TomoProvider.tsx` imports `@tomo-inc/wallet-connect-sdk/style.css`
- the `@import` survives into the built `wallet-connector.css`
- `services/vault/src/globals.css` imports the wallet-connector stylesheet

The SDK exposes no flag to disable the font injection, and remote `@import`s hoist to the top of the bundled sheet (hence the `(index):1` attribution in the console).

The same token also covers two conditional Google Fonts injectors in the wallet dependency tree that would surface later: `@reown/appkit-ui` (Inter, WalletConnect QR modal path) and `@sats-connect/ui` (DM Sans, BTC wallet selector). Font binaries come from `fonts.gstatic.com`, already allowed by `font-src 'self' data: https:`.

An audit of all external origins used at runtime (stylesheets, scripts, iframes, workers, connect endpoints) found nothing else in the active production bundle that the merged policy blocks.
