### PR TITLE
test(vault): repay E2E CLI

### DIFF
--- a/services/vault/e2e/real/actions/borrow.ts
+++ b/services/vault/e2e/real/actions/borrow.ts
@@ -27,7 +27,6 @@ import {
   fetchBorrowContext,
   fetchCollateralSats,
   fetchMaxBorrow,
-  formatBorrowAmount,
 } from "../borrowParams";
 import { formatBtc } from "../preflight";
 import {
@@ -40,6 +39,7 @@ import {
   MS_PER_SECOND,
   STEP_TIMEOUT_MS,
 } from "../timing";
+import { formatTokenAmount } from "../tokenAmount";
 
 import { installPopupApprover, sweepApprovals } from "./approver";
 import { runPeginFlow } from "./pegin";
@@ -130,17 +130,17 @@ async function resolveBorrowAmount(ctx: ActionContext): Promise<BorrowAmount> {
   // precision, which would fill 0 and stall at "Enter an amount". A zero/failed default fails loudly.
   const value =
     max.maxTokens > 0
-      ? formatBorrowAmount(
+      ? formatTokenAmount(
           max.maxTokens * CONSERVATIVE_BORROW_FRACTION,
           max.decimals,
         )
       : "0";
   if (Number(value) <= 0)
     throw new Error(
-      `borrow: the conservative default for ${token} rounds to 0 (computed max ${formatBorrowAmount(max.maxTokens, max.decimals)} ${token} is too small to borrow ${Math.round(CONSERVATIVE_BORROW_FRACTION * 100)}% of). Re-run with an explicit --borrow-amount.`,
+      `borrow: the conservative default for ${token} rounds to 0 (computed max ${formatTokenAmount(max.maxTokens, max.decimals)} ${token} is too small to borrow ${Math.round(CONSERVATIVE_BORROW_FRACTION * 100)}% of). Re-run with an explicit --borrow-amount.`,
     );
   ctx.log(
-    `Borrow amount: ${value} ${max.symbol} (~${Math.round(CONSERVATIVE_BORROW_FRACTION * 100)}% of max ${formatBorrowAmount(max.maxTokens, max.decimals)} ${max.symbol}).`,
+    `Borrow amount: ${value} ${max.symbol} (~${Math.round(CONSERVATIVE_BORROW_FRACTION * 100)}% of max ${formatTokenAmount(max.maxTokens, max.decimals)} ${max.symbol}).`,
   );
   return { mode: "amount", value };
 }

--- a/services/vault/e2e/real/actions/borrow.ts
+++ b/services/vault/e2e/real/actions/borrow.ts
@@ -44,19 +44,26 @@ import {
 import { installPopupApprover, sweepApprovals } from "./approver";
 import { runPeginFlow } from "./pegin";
 import { startRecording } from "./recording";
-import { FLUID_CTA_SELECTOR, firstByTestid } from "./selectors";
+import {
+  AMOUNT_INPUT,
+  ASSET_SELECT_TITLE,
+  DONE_BUTTON_RX,
+  firstByTestid,
+  FLUID_CTA_SELECTOR,
+  MAX_AMOUNT_KEYWORD,
+  MAX_BUTTON_RX,
+  SUCCESS_DONE_TESTID,
+  TX_FAILED_RX,
+} from "./selectors";
 import { type Action, type ActionContext } from "./types";
 import { connectWallets } from "./walletConnect";
 
 // Dashboard "Loans" section → Borrow (testid-first; the fallback matches the button only while it reads
-// exactly "Borrow", which is fine on the dashboard where the CTA isn't relabeled).
+// exactly "Borrow", which is fine on the dashboard where the CTA isn't relabeled). The shared loan-form
+// selectors (amount input, Max button, "Select asset" title, success-modal Done, tx-failed) live in
+// selectors.ts — borrow-specific ones stay here.
 const LOANS_BORROW_TESTID = '[data-testid="loans-borrow-button"]';
 const BORROW_BUTTON_RX = /^borrow$/i; // COPY.loans.borrowButton
-const ASSET_SELECT_TITLE = "Select asset"; // COPY.loans.assetSelection.title
-// Borrow form: the AmountSlider's numeric input (`inputmode="decimal"`, placeholder "0") + its Max
-// button (a <button> whose visible text is "Max"), and the fluid submit button.
-const AMOUNT_INPUT = 'input[inputmode="decimal"]';
-const MAX_BUTTON_RX = /^max$/i;
 const BORROW_SUBMIT_TESTID = '[data-testid="borrow-submit-button"]';
 const BORROW_SUBMIT_ENABLED_LABEL = "Borrow"; // COPY.loans.borrow.action (enabled state)
 // Submit labels that won't resolve by waiting — fail fast with the callout (COPY.loans.borrow.*).
@@ -79,12 +86,8 @@ const BORROW_COLLATERAL_DEPENDENT_LABELS = new Set([
 // surfaced in the fail-fast message so a blocked run says why.
 const CALLOUT_BODY_RX =
   /(minimum borrowable|maximum borrowable|available to borrow|health factor|temporarily unavailable|Price data unavailable)[^.]*\./i;
-// Success screen (testid-first; tolerant fallbacks for a pre-testid deployed build).
-const SUCCESS_DONE_TESTID = '[data-testid="loan-success-done-button"]';
-const DONE_BUTTON_RX = /^done$/i; // COPY.loans.borrowSuccess.doneButton
+// Success screen: the borrow-specific title (the shared Done testid/text + tx-failed live in selectors).
 const BORROW_SUCCESS_RX = /borrow successful/i; // COPY.loans.borrowSuccess.title
-const TX_FAILED_RX = /transaction failed/i; // COPY.common.transactionFailedTitle
-const MAX_AMOUNT_KEYWORD = "max";
 /**
  * Minimum on-chain debt rise (USD) that counts as "the borrow landed", checked after the success
  * screen. Small — a real borrow adds far more — but above float/oracle-tick noise on the existing debt.
@@ -378,7 +381,11 @@ async function assertBorrowDebtIncreased(
   );
 }
 
-/** Drive the borrow flow proper (assumes wallets connected + approver/recorder installed by the caller). */
+/**
+ * Drive the borrow flow proper (assumes wallets connected + approver/recorder installed by the caller,
+ * and collateral already present). Wrapped by `runBorrowWithOptionalPegin`, which adds the optional
+ * pegin-first phase in front.
+ */
 async function runBorrowFlow(
   ctx: ActionContext,
   onStep: (step: string) => void,
@@ -452,6 +459,34 @@ async function waitForFreshCollateral(
   );
 }
 
+/**
+ * Borrow, optionally pegging in fresh collateral first (`--pegin-first`). Assumes wallets connected +
+ * approver/recorder installed by the caller. Exported so BOTH the borrow action and the repay action
+ * (`repay --borrow-first [--pegin-first]`) run the identical "maybe peg in, then borrow" sequence — the
+ * pegin (a full `runPeginFlow`) then the baseline-relative collateral-settle wait, then the borrow. Step
+ * labels are emitted via `onStep` (the caller namespaces them for its recorder).
+ */
+export async function runBorrowWithOptionalPegin(
+  ctx: ActionContext,
+  onStep: (step: string) => void,
+): Promise<void> {
+  if (ctx.config.peginFirst) {
+    ctx.log("--pegin-first: pegging in fresh collateral before borrowing");
+    // Snapshot the on-chain collateral BEFORE the pegin so we wait for THIS pegin's vault to register —
+    // a strict increase over the baseline. That is what makes "0.01 existing + new 0.01" correct:
+    // collateral may already be > 0, so we wait for it to rise past the baseline, not merely be non-zero.
+    // A failed read → 0n baseline (worst case we wait for any collateral).
+    const baselineSats = await fetchCollateralSats(
+      ctx.config.network,
+      ctx.eth.address,
+    ).catch(() => 0n);
+    await runPeginFlow(ctx, (step) => onStep(`pegin:${step}`));
+    onStep("await-collateral");
+    await waitForFreshCollateral(ctx, baselineSats);
+  }
+  await runBorrowFlow(ctx, onStep);
+}
+
 export const borrowAction: Action = {
   id: "borrow",
   async run(ctx: ActionContext): Promise<void> {
@@ -471,26 +506,7 @@ export const borrowAction: Action = {
     try {
       await connectWallets(ctx);
 
-      if (ctx.config.peginFirst) {
-        log(
-          "Borrow --pegin-first: pegging in fresh collateral before borrowing",
-        );
-        // Snapshot the on-chain collateral BEFORE the pegin so we can wait for THIS pegin's vault to
-        // register — a strict increase over the baseline. This is what makes "0.01 existing + new 0.01"
-        // correct: collateral is already > 0, so we must wait for it to rise past the baseline, not just
-        // be non-zero. A failed read → 0n baseline (worst case we wait for any collateral).
-        const baselineSats = await fetchCollateralSats(
-          ctx.config.network,
-          ctx.eth.address,
-        ).catch(() => 0n);
-        await runPeginFlow(ctx, (step) => {
-          currentStep = `pegin:${step}`;
-        });
-        currentStep = "borrow-await-collateral";
-        await waitForFreshCollateral(ctx, baselineSats);
-      }
-
-      await runBorrowFlow(ctx, (step) => {
+      await runBorrowWithOptionalPegin(ctx, (step) => {
         currentStep = step;
       });
 

--- a/services/vault/e2e/real/actions/borrow.ts
+++ b/services/vault/e2e/real/actions/borrow.ts
@@ -46,6 +46,7 @@ import { runPeginFlow } from "./pegin";
 import { startRecording } from "./recording";
 import {
   AMOUNT_INPUT,
+  ASSET_ROW_TESTID_PREFIX,
   ASSET_SELECT_TITLE,
   DONE_BUTTON_RX,
   firstByTestid,
@@ -181,7 +182,8 @@ async function openBorrow(page: Page, log: (m: string) => void): Promise<void> {
  * needed). With no token specified, take the first asset row (testid-based; requires the testid build).
  * The modal shows "Loading assets…" until the oracle-price query resolves, so we WAIT for the row (not a
  * one-shot check) and only fail on timeout — otherwise a healthy run could race the load and see no rows.
- * Returns the symbol used, for the success log.
+ * Returns the token SYMBOL (read from the chosen row's testid, not its free-text label), used for the
+ * success log.
  */
 async function selectAsset(
   page: Page,
@@ -191,10 +193,10 @@ async function selectAsset(
   const row = token
     ? firstByTestid(
         page,
-        `[data-testid="asset-select-row-${token.toLowerCase()}"]`,
+        `[data-testid="${ASSET_ROW_TESTID_PREFIX}${token.toLowerCase()}"]`,
         page.getByRole("button").filter({ hasText: new RegExp(token, "i") }),
       )
-    : page.locator('[data-testid^="asset-select-row-"]').first();
+    : page.locator(`[data-testid^="${ASSET_ROW_TESTID_PREFIX}"]`).first();
   const appeared = await row
     .waitFor({ state: "visible", timeout: STEP_TIMEOUT_MS })
     .then(() => true)
@@ -205,12 +207,17 @@ async function selectAsset(
         ? `Borrow token "${token}" was not found in the asset picker within ${Math.round(STEP_TIMEOUT_MS / MS_PER_SECOND)}s.`
         : "No borrow token specified and no asset rows were found — re-run with --borrow-token=<symbol>.",
     );
-  const label = (await row.innerText().catch(() => ""))
-    .replace(/\s+/g, " ")
-    .trim();
+  // An explicit token wins; otherwise read the symbol from the row's testid (the no-token branch selects
+  // rows BY that prefix, so the attribute is always present on the chosen row).
+  let symbol = token;
+  if (!symbol) {
+    const testid = await row.getAttribute("data-testid").catch(() => null);
+    if (testid?.startsWith(ASSET_ROW_TESTID_PREFIX))
+      symbol = testid.slice(ASSET_ROW_TESTID_PREFIX.length);
+  }
   await row.click();
-  log(`Selected borrow token: ${token ?? label}`);
-  return token ?? label;
+  log(`Selected borrow token: ${symbol ?? "(unknown)"}`);
+  return symbol;
 }
 
 /** Enter the borrow amount: click the form's Max button, or fill the numeric input. */

--- a/services/vault/e2e/real/actions/index.ts
+++ b/services/vault/e2e/real/actions/index.ts
@@ -1,7 +1,7 @@
 /**
- * Registry of implemented actions: connect, observe, wallet-config, pegin, sign-conformance, and
- * borrow. The remaining actions (repay/withdraw) are declared disabled in `config.ts` for the CLI's
- * roadmap display and register here as they land.
+ * Registry of implemented actions: connect, observe, wallet-config, pegin, sign-conformance, borrow,
+ * and repay. The remaining action (withdraw) is declared disabled in `config.ts` for the CLI's roadmap
+ * display and registers here as it lands.
  */
 import type { ActionId } from "../config";
 
@@ -9,6 +9,7 @@ import { borrowAction } from "./borrow";
 import { connectAction } from "./connect";
 import { observeAction } from "./observe";
 import { peginAction } from "./pegin";
+import { repayAction } from "./repay";
 import { signConformanceAction } from "./signConformance";
 import type { Action } from "./types";
 import { walletConfigAction } from "./walletConfig";
@@ -20,4 +21,5 @@ export const ACTIONS_BY_ID: Partial<Record<ActionId, Action>> = {
   pegin: peginAction,
   "sign-conformance": signConformanceAction,
   borrow: borrowAction,
+  repay: repayAction,
 };

--- a/services/vault/e2e/real/actions/repay.ts
+++ b/services/vault/e2e/real/actions/repay.ts
@@ -46,6 +46,7 @@ import { runBorrowWithOptionalPegin } from "./borrow";
 import { startRecording } from "./recording";
 import {
   AMOUNT_INPUT,
+  ASSET_ROW_TESTID_PREFIX,
   ASSET_SELECT_TITLE,
   DONE_BUTTON_RX,
   firstByTestid,
@@ -154,9 +155,11 @@ async function resolveRepayAmount(
  * Open the repay flow from the dashboard: click Loans → Repay, then wait for EITHER the "Select asset"
  * picker (multiple loans) OR the repay form itself (a single loan skips the picker — see the app's
  * DashboardPage.handleRepay). Returns whether the picker appeared, so the caller knows to select an
- * asset. The Repay button only renders when the position has a loan and is enabled once connected; a
- * loan created earlier in the same session (borrow-first) takes a moment to propagate, so we poll for it
- * to enable rather than failing on the first check.
+ * asset. The Repay button is only RENDERED when the position has a loan (`{hasLoans && …}`) and is
+ * enabled once connected — so after a borrow-first the button's VISIBILITY, not just its enabled state,
+ * lags while the new loan propagates. We therefore poll for it to appear AND enable within a single
+ * window (not a short visibility wait before a long enable wait, which would abort early on a
+ * slow-to-render button).
  */
 async function openRepay(
   page: Page,
@@ -167,12 +170,12 @@ async function openRepay(
     LOANS_REPAY_TESTID,
     page.getByRole("button", { name: REPAY_BUTTON_RX }),
   );
-  await repay.waitFor({ state: "visible", timeout: STEP_TIMEOUT_MS });
   const deadline = Date.now() + REPAY_BUTTON_ENABLE_TIMEOUT_MS;
-  let enabled = await repay.isEnabled().catch(() => false);
+  let enabled = false;
   while (!enabled && Date.now() < deadline) {
-    await page.waitForTimeout(FORM_SETTLE_MS);
-    enabled = await repay.isEnabled().catch(() => false);
+    if (await repay.isVisible().catch(() => false))
+      enabled = await repay.isEnabled().catch(() => false);
+    if (!enabled) await page.waitForTimeout(FORM_SETTLE_MS);
   }
   if (!enabled)
     throw new Error(
@@ -208,7 +211,9 @@ async function openRepay(
 /**
  * Pick the debt token in the "Select asset" picker (repay mode). Prefer the per-symbol testid; fall back
  * to the row whose text contains the symbol. With no token specified, take the first row. Waits for the
- * row (the picker's rows are the user's loans, available immediately). Returns the symbol used.
+ * row (the picker's rows are the user's loans, available immediately). Returns the token SYMBOL — read
+ * from the chosen row's `data-testid` (`asset-select-row-<symbol>`), NOT its free-text label — so the
+ * caller's debt lookup (`resolveRepayAmount`) can match it against `debt.symbol`.
  */
 async function selectAsset(
   page: Page,
@@ -218,10 +223,10 @@ async function selectAsset(
   const row = token
     ? firstByTestid(
         page,
-        `[data-testid="asset-select-row-${token.toLowerCase()}"]`,
+        `[data-testid="${ASSET_ROW_TESTID_PREFIX}${token.toLowerCase()}"]`,
         page.getByRole("button").filter({ hasText: new RegExp(token, "i") }),
       )
-    : page.locator('[data-testid^="asset-select-row-"]').first();
+    : page.locator(`[data-testid^="${ASSET_ROW_TESTID_PREFIX}"]`).first();
   const appeared = await row
     .waitFor({ state: "visible", timeout: STEP_TIMEOUT_MS })
     .then(() => true)
@@ -232,12 +237,17 @@ async function selectAsset(
         ? `Repay token "${token}" was not found in the asset picker within ${Math.round(STEP_TIMEOUT_MS / MS_PER_SECOND)}s.`
         : "No repay token specified and no loan rows were found in the picker.",
     );
-  const label = (await row.innerText().catch(() => ""))
-    .replace(/\s+/g, " ")
-    .trim();
+  // An explicit token wins; otherwise read the symbol from the row's testid (the no-token branch selects
+  // rows BY that prefix, so the attribute is always present on the chosen row).
+  let symbol = token;
+  if (!symbol) {
+    const testid = await row.getAttribute("data-testid").catch(() => null);
+    if (testid?.startsWith(ASSET_ROW_TESTID_PREFIX))
+      symbol = testid.slice(ASSET_ROW_TESTID_PREFIX.length);
+  }
   await row.click();
-  log(`Selected repay token: ${token ?? label}`);
-  return token ?? label;
+  log(`Selected repay token: ${symbol ?? "(unknown)"}`);
+  return symbol;
 }
 
 /** Enter the repay amount: click the form's Max button, or fill the numeric input. */

--- a/services/vault/e2e/real/actions/repay.ts
+++ b/services/vault/e2e/real/actions/repay.ts
@@ -1,0 +1,505 @@
+/**
+ * The "repay" action: pay down (or clear) a loan drawn against a BTC-Vault position, end-to-end on real
+ * Sepolia. Two shapes, selected by the CLI:
+ *   - REUSE (default): repay a loan the depositor already holds. run.ts refuses the run before the
+ *     browser if there's no debt, so we land on the dashboard with the Repay button ready.
+ *   - BORROW-FIRST (`--borrow-first`): borrow first (the shared `runBorrowWithOptionalPegin`), then
+ *     repay that loan — all in one browser session. Adding `--pegin-first` pegs in fresh collateral
+ *     ahead of the borrow, giving the full pegin → borrow → repay lifecycle in one run.
+ *
+ * The repay flow is short but has two shapes the CLI must handle that borrow doesn't:
+ *   - A depositor with exactly ONE loan is routed straight to the repay form; only MULTIPLE loans open
+ *     the "Select asset" picker. So after clicking Repay we wait for EITHER the picker OR the form.
+ *   - Repaying can take ONE or TWO MetaMask transactions: an ERC-20 approve of the debt token to the
+ *     adapter (only when the current allowance is insufficient), then the repay. The CTA reads
+ *     "Processing…" across both; the pop-up approver confirms whatever appears.
+ *
+ * Selectors are testid-first (added to the src repay controls, mirroring borrow) with tolerant
+ * text/role/class fallbacks. No SDK / product logic is reimplemented — the amount is a best-effort
+ * default and the live form is the authoritative gate (its Max button + validation).
+ *
+ * NEVER run without an explicit go-ahead: it moves real value (a debt repayment, plus real ERC-20
+ * approval + repay gas).
+ */
+import type { BrowserContext, Locator, Page } from "@playwright/test";
+
+import { fetchBorrowContext } from "../borrowParams";
+import { type NetworkName } from "../config";
+import {
+  CONSERVATIVE_REPAY_FRACTION,
+  fetchRepayableDebts,
+  type RepayableDebt,
+} from "../repayParams";
+import {
+  FORM_SETTLE_MS,
+  MS_PER_SECOND,
+  REPAY_BUTTON_ENABLE_TIMEOUT_MS,
+  REPAY_CTA_ENABLE_TIMEOUT_MS,
+  REPAY_TX_TIMEOUT_MS,
+  REPAY_VERIFY_POLL_MS,
+  STEP_TIMEOUT_MS,
+} from "../timing";
+import { formatTokenAmount } from "../tokenAmount";
+
+import { installPopupApprover, sweepApprovals } from "./approver";
+import { runBorrowWithOptionalPegin } from "./borrow";
+import { startRecording } from "./recording";
+import {
+  AMOUNT_INPUT,
+  ASSET_SELECT_TITLE,
+  DONE_BUTTON_RX,
+  firstByTestid,
+  FLUID_CTA_SELECTOR,
+  MAX_AMOUNT_KEYWORD,
+  MAX_BUTTON_RX,
+  SUCCESS_DONE_TESTID,
+  TX_FAILED_RX,
+} from "./selectors";
+import { type Action, type ActionContext } from "./types";
+import { connectWallets } from "./walletConnect";
+
+// Dashboard "Loans" section → Repay (testid-first; the fallback matches the button only while it reads
+// exactly "Repay", which is fine on the dashboard where the CTA isn't relabeled). The shared loan-form
+// selectors (amount input — also used to detect a single-loan repay skipping the picker — Max button,
+// "Select asset" title, success-modal Done, tx-failed) live in selectors.ts; repay-specific ones here.
+const LOANS_REPAY_TESTID = '[data-testid="loans-repay-button"]';
+const REPAY_BUTTON_RX = /^repay$/i; // COPY.loans.repayButton
+const REPAY_SUBMIT_TESTID = '[data-testid="repay-submit-button"]';
+const REPAY_SUBMIT_ENABLED_LABEL = "Repay"; // COPY.loans.repay.action (enabled state)
+// Submit labels that won't resolve by waiting — fail fast with the callout (COPY.loans.repay.*).
+// "Repaying Unavailable" is protocol-gated; the rest are fixed properties of the entered amount vs the
+// wallet balance / debt, none of which change while we wait (repay has no collateral-propagation
+// transient like borrow does).
+const REPAY_INSTANT_FAIL_LABELS = new Set([
+  "Repaying Unavailable",
+  "Amount too small",
+  "Amount exceeds debt",
+  "Insufficient balance",
+]);
+// Best-effort: the repay validation/availability callout body phrases (COPY.loans.repay.*), surfaced in
+// the fail-fast message so a blocked run says why.
+const CALLOUT_BODY_RX =
+  /(cannot repay more|Minimum repayable|balance is 0|less than your debt|need more|temporarily unavailable|Couldn't (load|refresh))[^.]*\.?/i;
+// Success screen: the repay-specific title (the shared Done testid/text + tx-failed live in selectors).
+const REPAY_SUCCESS_RX = /repay successful/i; // COPY.loans.repaySuccess.title
+/**
+ * Minimum on-chain debt FALL (USD) that counts as "the repay landed", checked after the success screen.
+ * Small — even the 25% default clears far more — but above float/oracle-tick noise on the debt value.
+ */
+const DEBT_DECREASE_MIN_USD = 0.01;
+
+/** The resolved repay amount: click the form's Max button, or fill a specific token amount. */
+type RepayAmount = { mode: "max" } | { mode: "amount"; value: string };
+
+/**
+ * Resolve the amount to repay. An explicit `--repay-amount` wins (a number, or `max`). Otherwise it
+ * computes a conservative fraction of the outstanding debt, capped at the wallet's balance of the debt
+ * token so the default is always affordable. If that can't produce a positive amount (read failed, no
+ * debt for the token, zero balance, or the fraction rounds to 0 at the token's precision) it THROWS
+ * rather than silently clicking Max — a full clear is only ever done when explicitly requested via
+ * `--repay-amount=max`.
+ */
+async function resolveRepayAmount(
+  ctx: ActionContext,
+  token: string | undefined,
+): Promise<RepayAmount> {
+  const raw = ctx.config.repayAmount?.trim();
+  if (raw && raw.toLowerCase() === MAX_AMOUNT_KEYWORD) return { mode: "max" };
+  if (raw) return { mode: "amount", value: raw };
+
+  if (!token)
+    throw new Error(
+      "repay: no --repay-token resolved and no --repay-amount given — cannot compute a safe default. Re-run with --repay-token and/or --repay-amount.",
+    );
+
+  let debt: RepayableDebt | undefined;
+  try {
+    const debts = await fetchRepayableDebts(
+      ctx.config.network,
+      ctx.eth.address,
+    );
+    debt = debts.find((d) => d.symbol.toLowerCase() === token.toLowerCase());
+  } catch (error) {
+    throw new Error(
+      `repay: could not read the outstanding ${token} debt (${error instanceof Error ? error.message : error}) — refusing to guess an amount. Re-run with an explicit --repay-amount (or --repay-amount=max).`,
+    );
+  }
+  if (!debt)
+    throw new Error(
+      `repay: this position has no outstanding ${token} debt to repay. Re-run with a token you owe on, or --repay-amount.`,
+    );
+  if (debt.balanceTokens <= 0)
+    throw new Error(
+      `repay: your wallet holds 0 ${token} — you need ${token} to repay this debt (${debt.debtTokens} ${token} outstanding). Acquire some first.`,
+    );
+
+  // Cap the conservative fraction at the wallet balance so the default never trips "Insufficient
+  // balance"; format (floored) to the token's precision.
+  const target = Math.min(
+    debt.debtTokens * CONSERVATIVE_REPAY_FRACTION,
+    debt.balanceTokens,
+  );
+  const value = formatTokenAmount(target, debt.decimals);
+  if (Number(value) <= 0)
+    throw new Error(
+      `repay: the conservative default for ${token} rounds to 0 (outstanding debt ${debt.debtTokens} ${token}, wallet balance ${debt.balanceTokens} ${token}). Re-run with an explicit --repay-amount.`,
+    );
+  ctx.log(
+    `Repay amount: ${value} ${debt.symbol} (~${Math.round(CONSERVATIVE_REPAY_FRACTION * 100)}% of ${debt.debtTokens} ${debt.symbol} debt; wallet holds ${debt.balanceTokens} ${debt.symbol}).`,
+  );
+  return { mode: "amount", value };
+}
+
+/**
+ * Open the repay flow from the dashboard: click Loans → Repay, then wait for EITHER the "Select asset"
+ * picker (multiple loans) OR the repay form itself (a single loan skips the picker — see the app's
+ * DashboardPage.handleRepay). Returns whether the picker appeared, so the caller knows to select an
+ * asset. The Repay button only renders when the position has a loan and is enabled once connected; a
+ * loan created earlier in the same session (borrow-first) takes a moment to propagate, so we poll for it
+ * to enable rather than failing on the first check.
+ */
+async function openRepay(
+  page: Page,
+  log: (m: string) => void,
+): Promise<{ pickerOpened: boolean }> {
+  const repay = firstByTestid(
+    page,
+    LOANS_REPAY_TESTID,
+    page.getByRole("button", { name: REPAY_BUTTON_RX }),
+  );
+  await repay.waitFor({ state: "visible", timeout: STEP_TIMEOUT_MS });
+  const deadline = Date.now() + REPAY_BUTTON_ENABLE_TIMEOUT_MS;
+  let enabled = await repay.isEnabled().catch(() => false);
+  while (!enabled && Date.now() < deadline) {
+    await page.waitForTimeout(FORM_SETTLE_MS);
+    enabled = await repay.isEnabled().catch(() => false);
+  }
+  if (!enabled)
+    throw new Error(
+      `The dashboard Repay button stayed disabled/absent for ${Math.round(REPAY_BUTTON_ENABLE_TIMEOUT_MS / MS_PER_SECOND)}s — this position has no loan to repay.`,
+    );
+  log("Opening the repay flow (Loans → Repay)");
+  await repay.click();
+
+  // Race the two possible landings. The picker is identified by its "Select asset" title; the repay form
+  // by its numeric amount input (present on the form, absent on the dashboard) — a more specific signal
+  // than the generic fluid CTA, so a stray dashboard fluid button can't be mistaken for the form.
+  const pickerTitle = page
+    .getByText(ASSET_SELECT_TITLE, { exact: true })
+    .first();
+  const amountInput = page.locator(AMOUNT_INPUT).first();
+  const landDeadline = Date.now() + STEP_TIMEOUT_MS;
+  while (Date.now() < landDeadline) {
+    if (await pickerTitle.isVisible().catch(() => false)) {
+      log("Asset picker opened (multiple loans) — selecting the debt token");
+      return { pickerOpened: true };
+    }
+    if (await amountInput.isVisible().catch(() => false)) {
+      log("Routed straight to the repay form (single loan)");
+      return { pickerOpened: false };
+    }
+    await page.waitForTimeout(FORM_SETTLE_MS);
+  }
+  throw new Error(
+    `Repay: after clicking Repay, neither the asset picker nor the repay form appeared within ${Math.round(STEP_TIMEOUT_MS / MS_PER_SECOND)}s.`,
+  );
+}
+
+/**
+ * Pick the debt token in the "Select asset" picker (repay mode). Prefer the per-symbol testid; fall back
+ * to the row whose text contains the symbol. With no token specified, take the first row. Waits for the
+ * row (the picker's rows are the user's loans, available immediately). Returns the symbol used.
+ */
+async function selectAsset(
+  page: Page,
+  log: (m: string) => void,
+  token: string | undefined,
+): Promise<string | undefined> {
+  const row = token
+    ? firstByTestid(
+        page,
+        `[data-testid="asset-select-row-${token.toLowerCase()}"]`,
+        page.getByRole("button").filter({ hasText: new RegExp(token, "i") }),
+      )
+    : page.locator('[data-testid^="asset-select-row-"]').first();
+  const appeared = await row
+    .waitFor({ state: "visible", timeout: STEP_TIMEOUT_MS })
+    .then(() => true)
+    .catch(() => false);
+  if (!appeared)
+    throw new Error(
+      token
+        ? `Repay token "${token}" was not found in the asset picker within ${Math.round(STEP_TIMEOUT_MS / MS_PER_SECOND)}s.`
+        : "No repay token specified and no loan rows were found in the picker.",
+    );
+  const label = (await row.innerText().catch(() => ""))
+    .replace(/\s+/g, " ")
+    .trim();
+  await row.click();
+  log(`Selected repay token: ${token ?? label}`);
+  return token ?? label;
+}
+
+/** Enter the repay amount: click the form's Max button, or fill the numeric input. */
+async function fillRepayAmount(
+  page: Page,
+  log: (m: string) => void,
+  amount: RepayAmount,
+): Promise<void> {
+  if (amount.mode === "max") {
+    log("Repay amount: Max (clicking the form's Max button)");
+    const max = page.getByRole("button", { name: MAX_BUTTON_RX }).first();
+    await max.waitFor({ state: "visible", timeout: STEP_TIMEOUT_MS });
+    await max.click();
+  } else {
+    log(`Entering repay amount: ${amount.value}`);
+    const input = page.locator(AMOUNT_INPUT).first();
+    await input.waitFor({ state: "visible", timeout: STEP_TIMEOUT_MS });
+    await input.fill(amount.value);
+  }
+  await page.waitForTimeout(FORM_SETTLE_MS);
+}
+
+/** Best-effort: read the repay validation/availability callout body so a blocked run explains why. */
+async function readCalloutText(page: Page): Promise<string> {
+  const callout = page.getByText(CALLOUT_BODY_RX).first();
+  if (!(await callout.isVisible().catch(() => false))) return "";
+  return (await callout.innerText().catch(() => ""))
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * Wait for the fluid submit button to become the enabled "Repay". It settles through "Enter an amount"
+ * while the wallet balance + debt load; we key on the stable label-independent control (testid, else the
+ * fluid-button class) and read its text each tick, logging changes. An instant-fail label (protocol
+ * paused, amount too small, over debt, insufficient balance) throws immediately with the callout — none
+ * of these self-resolve by waiting, unlike borrow's collateral-dependent labels.
+ */
+async function waitForRepayCta(
+  page: Page,
+  log: (m: string) => void,
+): Promise<Locator> {
+  const cta = firstByTestid(
+    page,
+    REPAY_SUBMIT_TESTID,
+    page.locator(FLUID_CTA_SELECTOR),
+  );
+  const deadline = Date.now() + REPAY_CTA_ENABLE_TIMEOUT_MS;
+  let lastLabel = "";
+  while (Date.now() < deadline) {
+    const label = ((await cta.textContent().catch(() => "")) ?? "").trim();
+    if (label && label !== lastLabel) {
+      log(`Repay CTA: "${label}"`);
+      lastLabel = label;
+    }
+    if (REPAY_INSTANT_FAIL_LABELS.has(label)) {
+      const callout = await readCalloutText(page);
+      throw new Error(
+        `Repay blocked at the form: "${label}"${callout ? ` — ${callout}` : ""}`,
+      );
+    }
+    if (
+      label === REPAY_SUBMIT_ENABLED_LABEL &&
+      (await cta.isEnabled().catch(() => false))
+    )
+      return cta;
+    await page.waitForTimeout(FORM_SETTLE_MS);
+  }
+  const callout = await readCalloutText(page);
+  throw new Error(
+    `Repay CTA did not become the enabled "${REPAY_SUBMIT_ENABLED_LABEL}" within ${REPAY_CTA_ENABLE_TIMEOUT_MS}ms (last label: "${lastLabel}")${callout ? ` — ${callout}` : ""}.`,
+  );
+}
+
+/**
+ * After submitting, actively approve the MetaMask pop-up(s) — repay can be ONE tx (repay) or TWO (an
+ * ERC-20 approve of the debt token, then the repay) depending on the current allowance; the CTA reads
+ * "Processing…" across both and the approver's sweep confirms whichever appear. Wait for the "Repay
+ * successful" screen, then click Done. Fails fast if the form surfaces a "Transaction failed" callout.
+ */
+async function confirmRepaySuccess(
+  page: Page,
+  context: BrowserContext,
+  log: (m: string) => void,
+  symbol: string | undefined,
+): Promise<void> {
+  // Success is gated ONLY on markers specific to the loan-success screen — the "Repay successful" title
+  // or the `loan-success-done-button` testid. NOT the generic "Done" role: borrow/deposit/withdraw
+  // modals also have Done buttons, so keying on any Done could report a false success. The generic-role
+  // done is only the click TARGET (via firstByTestid), used after success is confirmed.
+  const successTitle = page.getByText(REPAY_SUCCESS_RX).first();
+  const successDone = page.locator(SUCCESS_DONE_TESTID).first();
+  const doneButton = firstByTestid(
+    page,
+    SUCCESS_DONE_TESTID,
+    page.getByRole("button", { name: DONE_BUTTON_RX }),
+  );
+  const txFailed = page.getByText(TX_FAILED_RX).first();
+  const deadline = Date.now() + REPAY_TX_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    await sweepApprovals(context, page, log);
+
+    if (
+      (await successTitle.isVisible().catch(() => false)) ||
+      (await successDone.isVisible().catch(() => false))
+    ) {
+      log(`✅ Repay successful${symbol ? ` (${symbol})` : ""} — clicking Done`);
+      await doneButton.click({ timeout: STEP_TIMEOUT_MS }).catch(() => {});
+      return;
+    }
+    if (await txFailed.isVisible().catch(() => false)) {
+      const detail = await readCalloutText(page);
+      throw new Error(
+        `Repay transaction failed${detail ? ` — ${detail}` : ""}. See trace.zip + the failure screenshot.`,
+      );
+    }
+    await page.waitForTimeout(FORM_SETTLE_MS);
+  }
+  throw new Error(
+    `Repay did not reach the "Repay successful" screen within ${REPAY_TX_TIMEOUT_MS}ms — a MetaMask transaction (approve and/or repay) may not have confirmed. See trace.zip + the failure screenshot.`,
+  );
+}
+
+/**
+ * After the success screen, verify on-chain that the position's debt actually fell — the UI "Repay
+ * successful" alone doesn't prove funds moved. Polls `fetchBorrowContext` (on-chain `getUserAccountData`)
+ * until the debt drops below the pre-repay baseline (inverse of borrow's debt-rose check). Skipped (with
+ * a warning) only if the pre-repay baseline couldn't be read — never silently passes.
+ */
+async function assertRepayDebtDecreased(
+  ctx: ActionContext,
+  debtBeforeUsd: number | null,
+): Promise<void> {
+  if (debtBeforeUsd == null) {
+    ctx.log(
+      "⚠️ Skipping the on-chain debt check — couldn't read the pre-repay debt to compare against.",
+    );
+    return;
+  }
+  const deadline = Date.now() + REPAY_TX_TIMEOUT_MS;
+  let lastUsd = debtBeforeUsd;
+  while (Date.now() < deadline) {
+    const context = await fetchBorrowContext(
+      ctx.config.network,
+      ctx.eth.address,
+    ).catch(() => null);
+    if (context) {
+      lastUsd = context.currentDebtUsd;
+      if (lastUsd < debtBeforeUsd - DEBT_DECREASE_MIN_USD) {
+        ctx.log(
+          `✅ On-chain debt fell: $${debtBeforeUsd.toFixed(2)} → $${lastUsd.toFixed(2)}.`,
+        );
+        return;
+      }
+    }
+    await ctx.page.waitForTimeout(REPAY_VERIFY_POLL_MS);
+  }
+  throw new Error(
+    `Repay reached the success screen but on-chain debt did not fall within ${Math.round(REPAY_TX_TIMEOUT_MS / MS_PER_SECOND)}s (before $${debtBeforeUsd.toFixed(2)}, last $${lastUsd.toFixed(2)}) — the position doesn't reflect the repayment.`,
+  );
+}
+
+/** Read the position's current on-chain debt (USD), for the pre/post repay comparison. */
+async function readDebtUsd(
+  network: NetworkName,
+  ethAddress: string,
+): Promise<number | null> {
+  return fetchBorrowContext(network, ethAddress)
+    .then((c) => c.currentDebtUsd)
+    .catch(() => null);
+}
+
+/** Drive the repay flow proper (assumes wallets connected + approver/recorder installed by the caller). */
+export async function runRepayFlow(
+  ctx: ActionContext,
+  onStep: (step: string) => void,
+): Promise<void> {
+  const { page, context, log } = ctx;
+  // Repay the explicit token, else (borrow-first) the token we just borrowed, else let the picker/form
+  // decide (a single loan needs no token).
+  const token =
+    ctx.config.repayToken?.trim() ||
+    ctx.config.borrowToken?.trim() ||
+    undefined;
+
+  onStep("repay-open");
+  const { pickerOpened } = await openRepay(page, log);
+
+  let symbol = token;
+  if (pickerOpened) {
+    onStep("repay-select-asset");
+    symbol = await selectAsset(page, log, token);
+  }
+
+  onStep("repay-form");
+  // Snapshot the on-chain debt BEFORE submitting so we can assert it fell afterwards (a real-data
+  // post-condition on top of the UI success screen).
+  const debtBeforeUsd = await readDebtUsd(ctx.config.network, ctx.eth.address);
+  const amount = await resolveRepayAmount(ctx, symbol);
+  await fillRepayAmount(page, log, amount);
+  const cta = await waitForRepayCta(page, log);
+
+  onStep("repay-submit");
+  log(
+    "Repay CTA enabled — submitting (the approver will confirm the MetaMask approve/repay tx(s))",
+  );
+  await cta.click();
+
+  await confirmRepaySuccess(page, context, log, symbol);
+
+  onStep("repay-verify");
+  await assertRepayDebtDecreased(ctx, debtBeforeUsd);
+}
+
+export const repayAction: Action = {
+  id: "repay",
+  async run(ctx: ActionContext): Promise<void> {
+    const { page, context, log, artifactsDir } = ctx;
+
+    const handler = installPopupApprover(context, log);
+    let currentStep = "connect";
+    const recorder = await startRecording(
+      context,
+      page,
+      artifactsDir,
+      log,
+      () => currentStep,
+    );
+    try {
+      await connectWallets(ctx);
+
+      if (ctx.config.borrowFirst) {
+        log(
+          "Repay --borrow-first: borrowing before repaying" +
+            (ctx.config.peginFirst
+              ? " (pegging in fresh collateral first)"
+              : ""),
+        );
+        // The borrow leg is a hard prerequisite: if it fails (e.g. the pegin/borrow tx reverts or the
+        // wallet RPC errors), there is no new loan to repay, so STOP here — never fall through to the
+        // repay. runBorrowWithOptionalPegin throws on any pegin/borrow failure; we catch only to log the
+        // skip intent, then rethrow so the run aborts (repay is never attempted).
+        try {
+          await runBorrowWithOptionalPegin(ctx, (step) => {
+            currentStep = `borrow:${step}`;
+          });
+        } catch (error) {
+          log(
+            "❌ Borrow leg failed — stopping the run and SKIPPING repay (no new loan was created to repay).",
+          );
+          throw error;
+        }
+      }
+
+      await runRepayFlow(ctx, (step) => {
+        currentStep = step;
+      });
+
+      log("✅ Repay complete.");
+    } finally {
+      await recorder.stop();
+      context.off("page", handler);
+    }
+  },
+};

--- a/services/vault/e2e/real/actions/selectors.ts
+++ b/services/vault/e2e/real/actions/selectors.ts
@@ -36,6 +36,9 @@ export function firstByTestid(
 /** The "Select asset" picker title (COPY.loans.assetSelection.title). Borrow always shows it; repay only
  *  when the position has multiple loans (a single loan routes straight to the form). */
 export const ASSET_SELECT_TITLE = "Select asset";
+/** Per-row testid prefix in the "Select asset" picker: `asset-select-row-<symbol-lowercase>`. Used both
+ *  to target a row by token and to read the token symbol back out of the chosen row's `data-testid`. */
+export const ASSET_ROW_TESTID_PREFIX = "asset-select-row-";
 /** The AmountSlider's numeric input (`inputmode="decimal"`, placeholder "0"). */
 export const AMOUNT_INPUT = 'input[inputmode="decimal"]';
 /** The AmountSlider's "Max" button (a <button> whose visible text is "Max"). */

--- a/services/vault/e2e/real/actions/selectors.ts
+++ b/services/vault/e2e/real/actions/selectors.ts
@@ -26,3 +26,25 @@ export function firstByTestid(
 ): Locator {
   return page.locator(testid).or(fallback).first();
 }
+
+// ── Shared loan-form (Borrow / Repay) selectors ─────────────────────────────────
+// The borrow and repay flows drive the SAME components — the `AmountSlider` (numeric input + Max
+// button), the "Select asset" picker, and the one `LoanSuccessModal` — so these live here rather than
+// being duplicated verbatim in both actions. The parts that genuinely differ (submit testid, success
+// title, CTA label taxonomy) stay local to each action.
+
+/** The "Select asset" picker title (COPY.loans.assetSelection.title). Borrow always shows it; repay only
+ *  when the position has multiple loans (a single loan routes straight to the form). */
+export const ASSET_SELECT_TITLE = "Select asset";
+/** The AmountSlider's numeric input (`inputmode="decimal"`, placeholder "0"). */
+export const AMOUNT_INPUT = 'input[inputmode="decimal"]';
+/** The AmountSlider's "Max" button (a <button> whose visible text is "Max"). */
+export const MAX_BUTTON_RX = /^max$/i;
+/** The CLI amount keyword meaning "click the form's Max button" (`--borrow-amount`/`--repay-amount=max`). */
+export const MAX_AMOUNT_KEYWORD = "max";
+/** LoanSuccessModal's Done button testid (the borrow + repay variants share the modal). */
+export const SUCCESS_DONE_TESTID = '[data-testid="loan-success-done-button"]';
+/** LoanSuccessModal's Done button text (COPY.loans.*Success.doneButton) — the tolerant click fallback. */
+export const DONE_BUTTON_RX = /^done$/i;
+/** The tx-failure callout title (COPY.common.transactionFailedTitle) shown when a borrow/repay tx fails. */
+export const TX_FAILED_RX = /transaction failed/i;

--- a/services/vault/e2e/real/actions/walletConnect.ts
+++ b/services/vault/e2e/real/actions/walletConnect.ts
@@ -15,8 +15,15 @@
 import type { Page } from "@playwright/test";
 
 import type { BtcWalletId, EthWalletId } from "../config";
-import { APPROVAL_WAIT_MS, STEP_TIMEOUT_MS } from "../timing";
+import {
+  APPROVAL_WAIT_MS,
+  CONNECT_STATE_POLL_MS,
+  CONNECT_STATE_TIMEOUT_MS,
+  MS_PER_SECOND,
+  STEP_TIMEOUT_MS,
+} from "../timing";
 
+import { sweepApprovals } from "./approver";
 import type { ActionContext } from "./types";
 
 /** The Reown AppKit list entry to click per ETH wallet. */
@@ -27,7 +34,7 @@ const ETH_APPKIT_NAME: Record<EthWalletId, RegExp> = { metamask: /metamask/i };
  * active pop-up approver on `ctx.context`.
  */
 export async function connectWallets(ctx: ActionContext): Promise<void> {
-  const { page, log } = ctx;
+  const { page, context, log } = ctx;
 
   log("Clicking Connect");
   await page
@@ -62,10 +69,22 @@ export async function connectWallets(ctx: ActionContext): Promise<void> {
     .catch(() => {});
 
   log("Waiting for connected state (deposit button)");
-  await page
-    .locator('[data-testid="deposit-button"]')
-    .first()
-    .waitFor({ state: "visible", timeout: STEP_TIMEOUT_MS });
+  // Poll for the connected state while actively sweeping approval popups. MetaMask can insert an EXTRA
+  // approval AFTER the initial connect — a "Review permissions / Use your enabled networks" prompt whose
+  // Confirm (page-container-footer-next) must be clicked before the app flips to connected. That prompt
+  // can land after the popup approver's per-window rounds have ended (or in a reused window that fires no
+  // 'page' event), so a one-shot waitFor would just time out with it hanging. Sweeping each tick clicks
+  // it (clickApprove already matches that Confirm), the same way the borrow/repay confirm loops do.
+  const deposit = page.locator('[data-testid="deposit-button"]').first();
+  const deadline = Date.now() + CONNECT_STATE_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    if (await deposit.isVisible().catch(() => false)) return;
+    await sweepApprovals(context, page, log);
+    await page.waitForTimeout(CONNECT_STATE_POLL_MS);
+  }
+  throw new Error(
+    `connect: the connected state (deposit button) did not appear within ${Math.round(CONNECT_STATE_TIMEOUT_MS / MS_PER_SECOND)}s — a wallet approval popup (e.g. MetaMask "Review permissions") may be unconfirmed.`,
+  );
 }
 
 /**

--- a/services/vault/e2e/real/borrowParams.ts
+++ b/services/vault/e2e/real/borrowParams.ts
@@ -38,6 +38,7 @@ import {
   resolveCoreSpoke,
   resolveNetworkContracts,
 } from "./networkContracts";
+import { formatTokenAmount } from "./tokenAmount";
 
 /**
  * Default borrow = this fraction of the computed max, keeping the health factor well above the
@@ -49,18 +50,11 @@ export const CONSERVATIVE_BORROW_FRACTION = 0.25;
 /** The Aave oracle reports USD prices scaled by 1e8. */
 const ORACLE_PRICE_SCALE = 1e8;
 
-/** Cap the borrow-form input at this many decimal places (USDC/USDT are 6) — enough for any test amount. */
-const MAX_INPUT_DECIMALS = 6;
-
 /**
- * Format a token amount for the borrow form's numeric input: floored (never rounded up, so a computed
- * default can't drift above the max) to min(decimals, MAX_INPUT_DECIMALS) places, then trimmed.
+ * Format a token amount for the borrow form's numeric input — the shared floored formatter (see
+ * tokenAmount.ts). Kept as a named re-export so the borrow action's import is unchanged.
  */
-export function formatBorrowAmount(amount: number, decimals: number): string {
-  const places = Math.min(decimals, MAX_INPUT_DECIMALS);
-  const scale = 10 ** places;
-  return (Math.floor(amount * scale) / scale).toString();
-}
+export const formatBorrowAmount = formatTokenAmount;
 
 /** A borrowable token as offered in the CLI menu / used to drive the asset picker. */
 export interface BorrowReserve {
@@ -179,9 +173,10 @@ export async function fetchBorrowableReserves(
 /**
  * Shared prelude for every position-derived read: resolve the network's adapter + a Sepolia client,
  * then read the depositor's on-chain adapter position (`null` when none exists yet). `getPosition` maps
- * the ETH address to the Aave proxy — the app's `useAaveUserPosition` does the same.
+ * the ETH address to the Aave proxy — the app's `useAaveUserPosition` does the same. Exported so the
+ * repay pre-flight (repayParams.ts) reuses the same proxy/client resolution.
  */
-async function openPosition(
+export async function openPosition(
   network: NetworkName,
   ethAddress: string,
 ): Promise<{

--- a/services/vault/e2e/real/borrowParams.ts
+++ b/services/vault/e2e/real/borrowParams.ts
@@ -38,7 +38,6 @@ import {
   resolveCoreSpoke,
   resolveNetworkContracts,
 } from "./networkContracts";
-import { formatTokenAmount } from "./tokenAmount";
 
 /**
  * Default borrow = this fraction of the computed max, keeping the health factor well above the
@@ -50,13 +49,7 @@ export const CONSERVATIVE_BORROW_FRACTION = 0.25;
 /** The Aave oracle reports USD prices scaled by 1e8. */
 const ORACLE_PRICE_SCALE = 1e8;
 
-/**
- * Format a token amount for the borrow form's numeric input — the shared floored formatter (see
- * tokenAmount.ts). Kept as a named re-export so the borrow action's import is unchanged.
- */
-export const formatBorrowAmount = formatTokenAmount;
-
-/** A borrowable token as offered in the CLI menu / used to drive the asset picker. */
+/** A reserve token as offered in the CLI menu / used to drive the asset picker. */
 export interface BorrowReserve {
   symbol: string;
   name: string;
@@ -124,12 +117,18 @@ interface AaveAppConfigResponse {
 }
 
 /**
- * Read the vBTC reserve id + the borrowable-token list from the indexer — a raw-string mirror of the
- * app's `fetchAaveAppConfig`: keep only reserves that are `borrowable && !paused && !frozen`, are not
- * the vBTC collateral reserve, and carry token metadata (mirrors the app's `mapReserveConfig` null-skip).
+ * Read the vBTC reserve id + two reserve lists from the indexer — a raw-string mirror of the app's
+ * `fetchAaveAppConfig` (services/vault/src/applications/aave/services/fetchConfig.ts):
+ *   - `all`        — every non-vBTC reserve that carries token metadata, with NO borrowable/paused/frozen
+ *                    filter (the app's `allBorrowReserves`). The REPAY path uses this so debt on a
+ *                    reserve that was borrowable at borrow-time but has since been paused/frozen still
+ *                    surfaces.
+ *   - `borrowable` — the `borrowable && !paused && !frozen` subset (the app's `borrowableReserves`), what
+ *                    the BORROW path offers.
  */
 async function fetchAaveReserveConfig(graphqlEndpoint: string): Promise<{
   vaultBtcReserveId: bigint;
+  all: BorrowReserve[];
   borrowable: BorrowReserve[];
 }> {
   const client = createGraphQLClient(graphqlEndpoint);
@@ -137,28 +136,31 @@ async function fetchAaveReserveConfig(graphqlEndpoint: string): Promise<{
     await client.request<AaveAppConfigResponse>(GET_AAVE_APP_CONFIG);
   if (!response.aaveConfig)
     throw new Error(
-      `No aaveConfig from the indexer at ${graphqlEndpoint} — cannot resolve borrowable reserves.`,
+      `No aaveConfig from the indexer at ${graphqlEndpoint} — cannot resolve reserves.`,
     );
   const vaultBtcReserveId = BigInt(response.aaveConfig.vaultBtcReserveId);
 
-  const borrowable = response.aaveReserves.items
-    .filter(
-      (r) =>
-        r.borrowable &&
-        !r.paused &&
-        !r.frozen &&
-        BigInt(r.id) !== vaultBtcReserveId &&
-        r.underlyingToken != null,
-    )
-    .map((r) => ({
-      symbol: r.underlyingToken!.symbol,
-      name: r.underlyingToken!.name,
-      reserveId: BigInt(r.id),
-      tokenAddress: r.underlyingToken!.address,
-      decimals: r.underlyingToken!.decimals,
-    }));
+  const toReserve = (
+    r: AaveAppConfigResponse["aaveReserves"]["items"][number],
+  ): BorrowReserve => ({
+    symbol: r.underlyingToken!.symbol,
+    name: r.underlyingToken!.name,
+    reserveId: BigInt(r.id),
+    tokenAddress: r.underlyingToken!.address,
+    decimals: r.underlyingToken!.decimals,
+  });
 
-  return { vaultBtcReserveId, borrowable };
+  // All non-vBTC reserves carrying token metadata (the app's `allBorrowReserves`); the borrowable subset
+  // filters this further, mirroring the app's `borrowableReserves = allBorrowReserves.filter(...)`.
+  const nonVbtc = response.aaveReserves.items.filter(
+    (r) => BigInt(r.id) !== vaultBtcReserveId && r.underlyingToken != null,
+  );
+  const all = nonVbtc.map(toReserve);
+  const borrowable = nonVbtc
+    .filter((r) => r.borrowable && !r.paused && !r.frozen)
+    .map(toReserve);
+
+  return { vaultBtcReserveId, all, borrowable };
 }
 
 /** Fetch the borrowable-token list for `network` (for the CLI's asset menu + the browser asset picker). */
@@ -168,6 +170,19 @@ export async function fetchBorrowableReserves(
   const { graphqlEndpoint } = resolveNetworkContracts(network);
   const { borrowable } = await fetchAaveReserveConfig(graphqlEndpoint);
   return borrowable;
+}
+
+/**
+ * Fetch ALL non-vBTC reserves for `network` (the app's `allBorrowReserves`, no borrowable/paused/frozen
+ * filter). The repay pre-flight iterates these to find the user's debts — a loan can sit on a reserve
+ * that has since been paused/frozen, which `fetchBorrowableReserves` would drop.
+ */
+export async function fetchAllReserves(
+  network: NetworkName,
+): Promise<BorrowReserve[]> {
+  const { graphqlEndpoint } = resolveNetworkContracts(network);
+  const { all } = await fetchAaveReserveConfig(graphqlEndpoint);
+  return all;
 }
 
 /**

--- a/services/vault/e2e/real/cli.ts
+++ b/services/vault/e2e/real/cli.ts
@@ -14,6 +14,11 @@
  * Borrow accepts `--pegin-first` (peg in fresh collateral before borrowing — then also honors the pegin
  * extras above), `--borrow-token=<symbol>` (from the live borrowable list; default = first), and
  * `--borrow-amount=<n>|max` (default = a conservative fraction of the computed max, resolved in run.ts).
+ *
+ * Repay accepts `--borrow-first` (borrow against existing collateral, then repay the new loan — then
+ * also honors the borrow extras above), `--repay-token=<symbol>` (from the depositor's outstanding
+ * loans; default = the sole loan, or the borrowed token under --borrow-first) and `--repay-amount=<n>|max`
+ * (`max` clicks the form's Max for a full clear; default = a conservative fraction of the debt).
  */
 import { createInterface, type Interface } from "node:readline/promises";
 
@@ -30,12 +35,15 @@ import {
   type RunConfig,
   type Target,
 } from "./config";
+import { deriveEthAddress } from "./connector";
 import {
   fetchMinDepositBtc,
   fetchMinDepositForSplitBtc,
   fetchProviders,
 } from "./peginParams";
+import { fetchRepayableDebts } from "./repayParams";
 import { runE2E } from "./run";
+import { loadWalletSecrets } from "./secrets";
 import { MS_PER_SECOND } from "./timing";
 
 interface Choice<T extends string> {
@@ -245,11 +253,29 @@ async function resolveConfig(
       delayMs = Math.max(0, Math.round((Number(raw) || 0) * MS_PER_SECOND));
     }
 
-    // Borrow only: peg in first, or borrow against existing collateral? Resolved early because it
-    // decides whether the pegin extras below are collected (a `--pegin-first` borrow performs a pegin
-    // before borrowing). `--pegin-first` wins; else prompt (default = reuse existing collateral).
+    // Repay: borrow first (then repay the new loan), or repay an existing loan? Resolved BEFORE the
+    // pegin/collateral choice below because it decides whether a borrow (and thus a possible pegin)
+    // happens at all. `--borrow-first` wins; else prompt (default = repay an existing loan).
+    let borrowFirst = false;
+    if (action === "repay") {
+      if (flags["borrow-first"] !== undefined) {
+        borrowFirst = flagBool(flags["borrow-first"]);
+      } else if (interactive) {
+        borrowFirst =
+          (await select<"existing" | "borrow">(rl, "What to repay", [
+            { value: "existing", label: "Repay an existing loan" },
+            { value: "borrow", label: "Borrow first, then repay it" },
+          ])) === "borrow";
+      }
+    }
+
+    // Peg in first, or borrow against existing collateral? Applies to any run that borrows — a `borrow`
+    // run, or a `repay --borrow-first` run. Resolved early because it decides whether the pegin extras
+    // below are collected. `--pegin-first` wins; else prompt (default = reuse existing collateral).
+    const willBorrow =
+      action === "borrow" || (action === "repay" && borrowFirst);
     let peginFirst = false;
-    if (action === "borrow") {
+    if (willBorrow) {
       if (flags["pegin-first"] !== undefined) {
         peginFirst = flagBool(flags["pegin-first"]);
       } else if (interactive) {
@@ -266,9 +292,9 @@ async function resolveConfig(
 
     // Pegin extras. A flag always wins; otherwise fetch the network's real values (like the balance
     // pre-flight) and offer them as defaults — amount ⇒ minimum, provider ⇒ first available. Collected
-    // for a `pegin` run AND for a `borrow --pegin-first` run (which pegs in before borrowing).
-    const needsPeginParams =
-      action === "pegin" || (action === "borrow" && peginFirst);
+    // for a `pegin` run AND for any pegin-first borrow (`borrow --pegin-first` or
+    // `repay --borrow-first --pegin-first`, which peg in before borrowing).
+    const needsPeginParams = action === "pegin" || (willBorrow && peginFirst);
 
     // Split: `--split` wins; else prompt (default = single vault). Resolved first because the deposit
     // minimum depends on it — a two-vault split needs a larger deposit than a single vault.
@@ -362,10 +388,11 @@ async function resolveConfig(
       }
     }
 
-    // Borrow extras: token (from the live borrowable list) + an explicit amount passthrough. The amount
+    // Borrow extras: token (from the live borrowable list) + an explicit amount passthrough. Collected
+    // for any run that borrows (`willBorrow`: a `borrow` run, or a `repay --borrow-first` run). The amount
     // DEFAULT (a conservative fraction of the max) needs the depositor's ETH address, which isn't known
-    // until wallet import — so it's resolved later in run.ts; here we only carry an explicit
-    // --borrow-amount (a number, or "max" for the form's Max button) through.
+    // until wallet import — so it's resolved later; here we only carry an explicit --borrow-amount
+    // (a number, or "max" for the form's Max button) through.
     let borrowToken =
       typeof flags["borrow-token"] === "string"
         ? flags["borrow-token"]
@@ -381,7 +408,7 @@ async function resolveConfig(
           `--borrow-amount must be a positive number of tokens or "max" (got "${borrowAmount}")`,
         );
     }
-    if (action === "borrow") {
+    if (willBorrow) {
       // Fetch the live borrowable list up front so we can VALIDATE an explicit --borrow-token before a
       // (possibly funded, pegin-first) run — an unselectable token would otherwise only surface after
       // the peg-in, wasting it. When the token isn't given, pick from the list (menu / first).
@@ -416,6 +443,74 @@ async function resolveConfig(
       }
     }
 
+    // Repay extras: token (from the depositor's outstanding loans) + an explicit amount passthrough.
+    // Mirrors borrow: the amount DEFAULT (a conservative fraction of the debt) needs the ETH address, so
+    // it's resolved later in the action; here we only carry an explicit --repay-amount through.
+    let repayToken =
+      typeof flags["repay-token"] === "string"
+        ? flags["repay-token"]
+        : undefined;
+    const repayAmount =
+      typeof flags["repay-amount"] === "string"
+        ? flags["repay-amount"]
+        : undefined;
+    if (repayAmount !== undefined && repayAmount.toLowerCase() !== "max") {
+      const parsed = Number(repayAmount);
+      if (!Number.isFinite(parsed) || parsed <= 0)
+        throw new Error(
+          `--repay-amount must be a positive number of tokens or "max" (got "${repayAmount}")`,
+        );
+    }
+    if (action === "repay" && !borrowFirst) {
+      // Fetch the depositor's outstanding loans up front so an explicit --repay-token is VALIDATED
+      // before the run, and so an unspecified token can be picked from the list (menu / sole loan).
+      // Skipped for --borrow-first: the loan is created during the run, so `repayToken` defaults to the
+      // borrowed token (below) rather than being validated against the current (pre-borrow) loans.
+      // Unlike borrow's address-independent reserve list, the loans are position-specific, so we derive
+      // the ETH address from the wallet mnemonic (the same derivation the balance pre-flight uses) — the
+      // real run in run.ts re-derives it as ground truth. Best-effort: any read/derivation failure warns
+      // and skips validation (the disabled Repay button + form validation still gate the run).
+      const debts = await (async () =>
+        fetchRepayableDebts(
+          network,
+          deriveEthAddress(loadWalletSecrets().mnemonic),
+        ))().catch((error) => {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `\nCould not fetch outstanding loans (${error instanceof Error ? error.message : error}); skipping token validation — the repay form will gate it.`,
+        );
+        return [];
+      });
+      if (repayToken !== undefined) {
+        const match = debts.find(
+          (d) => d.symbol.toLowerCase() === repayToken!.toLowerCase(),
+        );
+        if (debts.length > 0 && !match)
+          throw new Error(
+            `--repay-token "${repayToken}" is not an outstanding loan on ${network} (you owe on: ${debts.map((d) => d.symbol).join(", ") || "nothing"}).`,
+          );
+        // Canonicalize to the reserve's exact symbol casing when we could validate it.
+        if (match) repayToken = match.symbol;
+      } else if (debts.length > 0) {
+        repayToken =
+          debts.length === 1
+            ? debts[0].symbol
+            : interactive
+              ? await select(
+                  rl,
+                  "Repay token",
+                  debts.map((d) => ({
+                    value: d.symbol,
+                    label: `${d.symbol} — ${d.debtTokens} owed`,
+                  })),
+                )
+              : debts[0].symbol;
+      }
+    }
+    // For `repay --borrow-first`, repay the token we just borrowed unless the user overrode --repay-token.
+    if (action === "repay" && borrowFirst && repayToken === undefined)
+      repayToken = borrowToken;
+
     // Sign-conformance extra: explicit fixtures file (else the action auto-detects the newest pegin's).
     const fixturesPath =
       typeof flags.fixtures === "string" ? flags.fixtures : undefined;
@@ -435,6 +530,9 @@ async function resolveConfig(
       peginFirst,
       borrowToken,
       borrowAmount,
+      borrowFirst,
+      repayToken,
+      repayAmount,
     };
   } finally {
     rl.close();

--- a/services/vault/e2e/real/cli.ts
+++ b/services/vault/e2e/real/cli.ts
@@ -2,9 +2,14 @@
  * Interactive (and flag-driven) entry for the real-wallet E2E runner.
  *
  * Uses Node's built-in `node:readline/promises` (numbered-choice prompts) — no third-party prompt
- * dependency. Every prompt can be pre-supplied as a flag for non-interactive / programmatic runs:
+ * dependency. Launch it via the package script (from the repo root):
  *
- *   pnpm exec tsx e2e/real/cli.ts --target=website --network=devnet --btc=unisat --eth=metamask \
+ *   pnpm --filter vault run e2e:cli               # interactive menu (prompts for every choice)
+ *
+ * Every prompt can be pre-supplied as a flag for a non-interactive / programmatic run (flags forward
+ * through the script — no `--` separator needed):
+ *
+ *   pnpm --filter vault run e2e:cli --target=website --network=devnet --btc=unisat --eth=metamask \
  *     --action=connect [--data=real] [--delay=0] [--yes]
  *
  * Pegin accepts two optional extras: `--amount=<btc>` and `--vp=<name>`. When omitted, the CLI fetches

--- a/services/vault/e2e/real/config.ts
+++ b/services/vault/e2e/real/config.ts
@@ -114,7 +114,7 @@ export const ACTIONS: ActionOption[] = [
     enabled: true,
   },
   { id: "borrow", label: "Borrow", enabled: true },
-  { id: "repay", label: "Repay", enabled: false },
+  { id: "repay", label: "Repay", enabled: true },
   { id: "withdraw", label: "Withdraw", enabled: false },
 ];
 
@@ -148,6 +148,18 @@ export interface RunConfig {
    * the CLI defaults to a conservative fraction of the computed max (see borrowParams).
    */
   borrowAmount?: string;
+  /**
+   * Repay only: borrow first (`--borrow-first`), then repay in the same run. When set, the borrow extras
+   * (`borrowToken`/`borrowAmount`) drive that borrow, and `repayToken` defaults to the borrowed token.
+   */
+  borrowFirst?: boolean;
+  /** Repay only: token symbol to repay (`--repay-token`); defaults to the sole/first outstanding loan. */
+  repayToken?: string;
+  /**
+   * Repay only: token amount to repay (`--repay-amount`, or `max` for the form's Max — a full clear).
+   * When absent the CLI defaults to a conservative fraction of the outstanding debt (see repayParams).
+   */
+  repayAmount?: string;
 }
 
 /** Resolve the target URL a run should open. */

--- a/services/vault/e2e/real/repayParams.ts
+++ b/services/vault/e2e/real/repayParams.ts
@@ -1,0 +1,97 @@
+/**
+ * Repay-parameter pre-flight: read which reserves the depositor currently owes on, each one's debt (in
+ * token units, incl. accrued interest) and the wallet's balance of that token — the SAME sources the
+ * web app's Repay form uses — so the CLI can offer a token menu, validate `--repay-token`, and size a
+ * safe default amount before launching the browser.
+ *
+ * Reuses the borrow pre-flight's on-chain plumbing (no duplication): `fetchBorrowableReserves` for the
+ * reserve list (you can only owe on a borrowable reserve), `openPosition` for the proxy/client, and
+ * `resolveCoreSpoke` for the spoke. Per reserve it reads the SDK's `getUserTotalDebt` and a direct viem
+ * `balanceOf`. The aggregate USD debt used by the run.ts no-debt gate + the action's "debt fell"
+ * assertion comes from the existing `fetchBorrowContext` — this file stays token-level.
+ *
+ * Everything here is a best-effort ESTIMATE for a menu default / affordability heads-up — NEVER a hard
+ * gate. The live repay form (its Max button + validation) is the authoritative, position-aware limit.
+ */
+import { getUserTotalDebt } from "@babylonlabs-io/ts-sdk/tbv/integrations/aave";
+import { type Address, erc20Abi, formatUnits } from "viem";
+
+import { fetchBorrowableReserves, openPosition } from "./borrowParams";
+import { type NetworkName } from "./config";
+import { resolveCoreSpoke } from "./networkContracts";
+
+/**
+ * Default repay = this fraction of the outstanding debt, keeping the repay partial (always affordable
+ * from the borrowed principal, and leaving the loan open so the test is repeatable). A full clear stays
+ * reachable via `--repay-amount=max` and the form's Max button.
+ */
+export const CONSERVATIVE_REPAY_FRACTION = 0.25;
+
+/** A reserve the depositor currently owes on — offered in the CLI menu / used to drive the repay form. */
+export interface RepayableDebt {
+  symbol: string;
+  name: string;
+  reserveId: bigint;
+  tokenAddress: string;
+  /** Token (underlying) decimals — what the repay amount is parsed against. */
+  decimals: number;
+  /** Outstanding debt in token units (incl. accrued interest), from `getUserTotalDebt`. */
+  debtTokens: number;
+  /** Wallet balance of the debt token, in token units — for the affordability heads-up + amount cap. */
+  balanceTokens: number;
+}
+
+/** Convert a raw on-chain token amount (smallest unit) to a decimal token count for display/sizing —
+ *  via viem's `formatUnits` (no hand-rolled `10 ** decimals`). */
+function rawToTokens(raw: bigint, decimals: number): number {
+  return Number(formatUnits(raw, decimals));
+}
+
+/**
+ * Read the reserves this position currently owes on (debt > 0), each with its debt + the wallet's token
+ * balance. Iterates the borrowable reserves (the only ones a position can owe on) and reads on-chain
+ * `getUserTotalDebt(spoke, reserveId, proxy)` + `balanceOf(wallet)` per reserve. Returns an empty list
+ * when there's no position (nothing borrowed yet) — the run.ts pre-flight turns that into a clear "no
+ * debt to repay" error.
+ */
+export async function fetchRepayableDebts(
+  network: NetworkName,
+  ethAddress: string,
+): Promise<RepayableDebt[]> {
+  const reserves = await fetchBorrowableReserves(network);
+  const { client, appController, position } = await openPosition(
+    network,
+    ethAddress,
+  );
+  if (!position) return [];
+
+  const spoke = await resolveCoreSpoke(client, appController);
+  const proxy = position.proxyContract;
+
+  const debts: RepayableDebt[] = [];
+  for (const reserve of reserves) {
+    const debtRaw = await getUserTotalDebt(
+      client,
+      spoke,
+      reserve.reserveId,
+      proxy,
+    );
+    if (debtRaw <= 0n) continue;
+    const balanceRaw = await client.readContract({
+      address: reserve.tokenAddress as Address,
+      abi: erc20Abi,
+      functionName: "balanceOf",
+      args: [ethAddress as Address],
+    });
+    debts.push({
+      symbol: reserve.symbol,
+      name: reserve.name,
+      reserveId: reserve.reserveId,
+      tokenAddress: reserve.tokenAddress,
+      decimals: reserve.decimals,
+      debtTokens: rawToTokens(debtRaw, reserve.decimals),
+      balanceTokens: rawToTokens(balanceRaw, reserve.decimals),
+    });
+  }
+  return debts;
+}

--- a/services/vault/e2e/real/repayParams.ts
+++ b/services/vault/e2e/real/repayParams.ts
@@ -4,10 +4,11 @@
  * web app's Repay form uses — so the CLI can offer a token menu, validate `--repay-token`, and size a
  * safe default amount before launching the browser.
  *
- * Reuses the borrow pre-flight's on-chain plumbing (no duplication): `fetchBorrowableReserves` for the
- * reserve list (you can only owe on a borrowable reserve), `openPosition` for the proxy/client, and
- * `resolveCoreSpoke` for the spoke. Per reserve it reads the SDK's `getUserTotalDebt` and a direct viem
- * `balanceOf`. The aggregate USD debt used by the run.ts no-debt gate + the action's "debt fell"
+ * Reuses the borrow pre-flight's on-chain plumbing (no duplication): `fetchAllReserves` for the reserve
+ * list (ALL non-vBTC reserves — matching the app's `allBorrowReserves` — NOT the borrowable subset, so a
+ * loan on a reserve that has since been paused/frozen still surfaces), `openPosition` for the proxy/client,
+ * and `resolveCoreSpoke` for the spoke. Per reserve it reads the SDK's `getUserTotalDebt` and a direct
+ * viem `balanceOf`. The aggregate USD debt used by the run.ts no-debt gate + the action's "debt fell"
  * assertion comes from the existing `fetchBorrowContext` — this file stays token-level.
  *
  * Everything here is a best-effort ESTIMATE for a menu default / affordability heads-up — NEVER a hard
@@ -16,7 +17,7 @@
 import { getUserTotalDebt } from "@babylonlabs-io/ts-sdk/tbv/integrations/aave";
 import { type Address, erc20Abi, formatUnits } from "viem";
 
-import { fetchBorrowableReserves, openPosition } from "./borrowParams";
+import { fetchAllReserves, openPosition } from "./borrowParams";
 import { type NetworkName } from "./config";
 import { resolveCoreSpoke } from "./networkContracts";
 
@@ -49,16 +50,17 @@ function rawToTokens(raw: bigint, decimals: number): number {
 
 /**
  * Read the reserves this position currently owes on (debt > 0), each with its debt + the wallet's token
- * balance. Iterates the borrowable reserves (the only ones a position can owe on) and reads on-chain
- * `getUserTotalDebt(spoke, reserveId, proxy)` + `balanceOf(wallet)` per reserve. Returns an empty list
- * when there's no position (nothing borrowed yet) — the run.ts pre-flight turns that into a clear "no
- * debt to repay" error.
+ * balance. Iterates ALL non-vBTC reserves (`fetchAllReserves` — matching the app's `allBorrowReserves`,
+ * not just the currently-borrowable subset, so a loan on a reserve that has since been paused/frozen is
+ * still discovered) and reads on-chain `getUserTotalDebt(spoke, reserveId, proxy)` + `balanceOf(wallet)`
+ * per reserve. Returns an empty list when there's no position (nothing borrowed yet) — the run.ts
+ * pre-flight turns that into a clear "no debt to repay" error.
  */
 export async function fetchRepayableDebts(
   network: NetworkName,
   ethAddress: string,
 ): Promise<RepayableDebt[]> {
-  const reserves = await fetchBorrowableReserves(network);
+  const reserves = await fetchAllReserves(network);
   const { client, appController, position } = await openPosition(
     network,
     ethAddress,

--- a/services/vault/e2e/real/run.ts
+++ b/services/vault/e2e/real/run.ts
@@ -92,11 +92,14 @@ export async function runE2E(config: RunConfig): Promise<void> {
     // browser deposit and refuse if the deposit (2 vaults for a split, else 1) would exceed it — so a
     // doomed pegin never launches. A fetch failure is non-fatal: the form's own gate backstops it (see
     // pegin.ts), so we warn and proceed rather than block on a transient read error.
-    // A `borrow --pegin-first` run performs a pegin too, so it's subject to the same cap.
-    if (
-      config.action === "pegin" ||
-      (config.action === "borrow" && config.peginFirst)
-    ) {
+    // Any pegin-first run performs a pegin too (`borrow --pegin-first` or
+    // `repay --borrow-first --pegin-first`), so it's subject to the same cap.
+    const willBorrow =
+      config.action === "borrow" ||
+      (config.action === "repay" && config.borrowFirst);
+    const willPegin =
+      config.action === "pegin" || (willBorrow && config.peginFirst);
+    if (willPegin) {
       const cap = await fetchVaultCountCap(
         config.network,
         balances.eth.address,
@@ -119,13 +122,14 @@ export async function runE2E(config: RunConfig): Promise<void> {
       }
     }
 
-    // Borrow pre-flight (reuse-collateral only). Read the position from real data (contract + indexer)
-    // and refuse a doomed run BEFORE the browser if there's no borrowable collateral. A `--pegin-first`
-    // run has no collateral yet (it pegs in during the run), so this gate is skipped for it. A fetch
-    // failure is non-fatal: the disabled Borrow button + the form's validation backstop it (see
-    // actions/borrow.ts), so we warn. The borrow amount (a conservative fraction of the max) is resolved
-    // inside the action, which also has the ETH address and logs the real-data max it picked from.
-    if (config.action === "borrow" && !config.peginFirst) {
+    // Collateral pre-flight (any run that BORROWS against existing collateral: a `borrow` run, or a
+    // `repay --borrow-first` run — both draw a loan before doing anything else). Read the position from
+    // real data and refuse a doomed run BEFORE the browser if there's no borrowable collateral. A
+    // `--pegin-first` run has no collateral yet (it pegs in during the run), so this gate is skipped for
+    // it. A fetch failure is non-fatal: the disabled Borrow button + the form's validation backstop it,
+    // so we warn. The borrow amount (a conservative fraction of the max) is resolved inside the action.
+    const borrowsAgainstExistingCollateral = willBorrow && !config.peginFirst;
+    if (borrowsAgainstExistingCollateral) {
       const borrowContext = await fetchBorrowContext(
         config.network,
         balances.eth.address,
@@ -142,6 +146,32 @@ export async function runE2E(config: RunConfig): Promise<void> {
           );
         artifacts.log(
           `Borrow collateral: $${borrowContext.collateralUsd.toFixed(2)} (current debt $${borrowContext.currentDebtUsd.toFixed(2)}).`,
+        );
+      }
+    }
+
+    // Repay pre-flight (repay an EXISTING loan — not `--borrow-first`, which creates the loan during the
+    // run). Read the position from real data and refuse a doomed run BEFORE the browser if there's no
+    // debt to repay. A fetch failure is non-fatal: the disabled Repay button + the form's validation
+    // backstop it, so we warn. The repay amount (a conservative fraction of the debt) is resolved inside
+    // the action, which has the ETH address and logs it.
+    if (config.action === "repay" && !config.borrowFirst) {
+      const repayContext = await fetchBorrowContext(
+        config.network,
+        balances.eth.address,
+      ).catch((error) => {
+        artifacts.log(
+          `⚠️ Could not pre-check repay debt (${error instanceof Error ? error.message : error}); the form will gate it.`,
+        );
+        return undefined;
+      });
+      if (repayContext) {
+        if (repayContext.currentDebtUsd <= 0)
+          throw new Error(
+            "No debt to repay: this position holds no outstanding loan. Borrow first (--borrow-first), or repay with a different ETH account that has a loan.",
+          );
+        artifacts.log(
+          `Repay debt: current debt $${repayContext.currentDebtUsd.toFixed(2)} (collateral $${repayContext.collateralUsd.toFixed(2)}).`,
         );
       }
     }

--- a/services/vault/e2e/real/timing.ts
+++ b/services/vault/e2e/real/timing.ts
@@ -17,6 +17,17 @@ export const HEADER_SETTLE_MS = 1_500;
 /** Let an extension approval popup be handled + the address register in the app. */
 export const APPROVAL_WAIT_MS = 6_000;
 
+/**
+ * The connected state (the header "deposit" CTA) to appear after finalizing the connect. Generous
+ * because MetaMask can insert an EXTRA approval after the initial connect — a "Review permissions / Use
+ * your enabled networks" prompt — which must be confirmed before the app flips to connected. We poll +
+ * sweep approvals across this window so that late/reused-window prompt is clicked (a single one-shot
+ * waitFor would just time out with the prompt left hanging).
+ */
+export const CONNECT_STATE_TIMEOUT_MS = 60_000;
+/** Poll cadence for the connected-state wait (each tick re-sweeps any open approval popup). */
+export const CONNECT_STATE_POLL_MS = 1_500;
+
 /** Auto-approve loop over an extension popup (MetaMask needs multiple rounds). */
 export const APPROVE_ROUNDS = 6;
 export const APPROVE_ROUND_MS = 1_500;
@@ -94,6 +105,31 @@ export const BORROW_CTA_ENABLE_TIMEOUT_MS = 150_000;
  * a stuck tx fails the run (trace captured) instead of hanging.
  */
 export const BORROW_TX_TIMEOUT_MS = 90_000;
+
+// ── repay ─────────────────────────────────────────────────────────────────────
+/**
+ * The dashboard "Repay" button to become visible + enabled. It only renders when `hasLoans` and is
+ * enabled once connected; a loan created earlier in the SAME session (borrow-first) takes a moment to
+ * propagate into that read, so we poll rather than fail on the first check. A reuse run's loan is
+ * already on-chain, so the button is ready almost immediately.
+ */
+export const REPAY_BUTTON_ENABLE_TIMEOUT_MS = 180_000;
+/**
+ * The repay form's submit button to become the enabled "Repay" after entering an amount — it settles
+ * through "Enter an amount" while the wallet balance + debt load (and, for a Max intent, a submit-time
+ * refetch). No collateral-propagation transient (unlike borrow), so shorter; a genuinely-blocked amount
+ * surfaces its instant-fail label (e.g. "Amount exceeds debt") well within this.
+ */
+export const REPAY_CTA_ENABLE_TIMEOUT_MS = 90_000;
+/**
+ * The repay transaction(s) to confirm on Sepolia. Unlike borrow this can be TWO sequential txs — an
+ * ERC-20 approve of the debt token to the adapter (only when the current allowance is insufficient),
+ * then the repay — with the CTA reading "Processing…" across both. Longer than the borrow budget to
+ * absorb two confirmations; a stuck tx fails the run (trace captured) instead of hanging.
+ */
+export const REPAY_TX_TIMEOUT_MS = 120_000;
+/** Poll cadence for the on-chain "debt fell" post-condition check after the success screen. */
+export const REPAY_VERIFY_POLL_MS = 3_000;
 
 // ── sign-conformance (per-wallet signing replay) ─────────────────────────────
 /**

--- a/services/vault/e2e/real/tokenAmount.ts
+++ b/services/vault/e2e/real/tokenAmount.ts
@@ -1,0 +1,20 @@
+/**
+ * Shared token-amount formatting for the borrow/repay form inputs. Both actions fill a numeric amount
+ * into an `AmountSlider` (`inputmode="decimal"`) and must never drift ABOVE the intended value — a
+ * borrow default above the max stalls at "Amount exceeds maximum", a repay default above the debt at
+ * "Amount exceeds debt". So the value is FLOORED (never rounded up) to the token's precision, capped at
+ * MAX_INPUT_DECIMALS (USDC/USDT are 6), then trimmed.
+ */
+
+/** Cap the form input at this many decimal places (USDC/USDT are 6) — enough for any test amount. */
+export const MAX_INPUT_DECIMALS = 6;
+
+/**
+ * Format a token amount for a form's numeric input: floored to min(decimals, MAX_INPUT_DECIMALS) places
+ * (never rounded up, so a computed default can't drift above the max/debt), then trimmed.
+ */
+export function formatTokenAmount(amount: number, decimals: number): string {
+  const places = Math.min(decimals, MAX_INPUT_DECIMALS);
+  const scale = 10 ** places;
+  return (Math.floor(amount * scale) / scale).toString();
+}

--- a/services/vault/src/applications/aave/components/LoanCard/Repay/index.tsx
+++ b/services/vault/src/applications/aave/components/LoanCard/Repay/index.tsx
@@ -394,6 +394,7 @@ export function Repay() {
         }
         onClick={handleRepay}
         className="mt-6"
+        data-testid="repay-submit-button"
       >
         {repayBlocked
           ? COPY.loans.repay.unavailable

--- a/services/vault/src/components/simple/LoansSection.tsx
+++ b/services/vault/src/components/simple/LoansSection.tsx
@@ -83,6 +83,7 @@ export function LoansSection({
               onClick={onRepay}
               className="rounded-full"
               disabled={!isConnected}
+              data-testid="loans-repay-button"
             >
               {COPY.loans.repayButton}
             </Button>


### PR DESCRIPTION
# Repay action for the real-wallet E2E CLI (step 6)

Closes https://github.com/babylonlabs-io/babylon-toolkit/issues/2048

## What this does

Adds a `repay` action to the real-wallet end-to-end CLI (`services/vault/e2e/real/`) — the tool that drives the vault dApp with real Chrome wallet extensions (signet BTC + Sepolia ETH) through the depositor lifecycle. With repay landed, the CLI now covers the whole journey a real depositor takes: **pegin → borrow → repay**.

You run it with one command. Three shapes, picked by flags:

- `--action=repay` — repay a loan you already have.
- `--action=repay --borrow-first` — borrow against collateral you already have, then repay it, in one browser session.
- `--action=repay --borrow-first --pegin-first` — peg in fresh BTC collateral, borrow against it, then repay — the full lifecycle in one run.

By default it repays a conservative 25% of the debt (a partial repay that always fits your wallet balance and leaves the loan open, so the test can be re-run). `--repay-amount=max` clears the loan in full by clicking the form's own "Max" button, and `--repay-amount=<n>` repays an exact amount.

## Why

The CLI already did connect, pegin, split-pegin, and borrow (https://github.com/babylonlabs-io/babylon-toolkit/pull/2033). Repay was the missing piece to exercise the full depositor lifecycle against real wallets and real chains — so we can prove, end to end, that a user can borrow against their BTC Vault and pay it back, with the debt change confirmed on-chain (not just from the UI saying "success").

## How it works (and the two things repay does that borrow doesn't)

The action drives the live UI only — it never rebuilds transactions or reimplements protocol logic. It reads the depositor's on-chain debt (via the SDK) to size a safe default amount, fills the form, and lets the live form's own validation be the authority. After the success screen it re-reads the on-chain debt and asserts it actually fell.

Two behaviours are specific to repay and are handled explicitly:

- **A single loan skips the asset picker.** With one loan the dApp routes straight to the repay form; only with multiple loans does the "Select asset" screen appear. The action waits for whichever shows up.
- **Repay can be one or two wallet transactions.** Repaying pulls the debt token from your wallet, so it first needs an ERC-20 approval — but only when the current allowance is too low. So sometimes it's just the repay (1 pop-up), sometimes approve-then-repay (2 pop-ups). The pop-up approver confirms whichever appear; we never hard-assume a fixed number.

## Approach — and why this one

**Reuse over rebuild.** Rather than write a second copy of the borrow flow for the `--borrow-first` case, we extracted the borrow flow's "optionally peg in, then borrow" sequence into a single shared function that both the borrow action and the repay action call. So `repay --borrow-first --pegin-first` runs the exact same pegin + borrow path we already proved for borrow — no duplication, and the pegin logic has one home. In the same spirit, repay reuses the borrow pre-flight's on-chain reads (reserve list, position, Core Spoke) and the SDK's debt read, and the UI selectors shared by both forms (amount input, Max button, "Select asset" picker, success modal) were moved into one shared module instead of being copied into each action.

**Conservative default, explicit full-clear.** We considered defaulting to a full repay, but a full clear depends on the wallet holding at least the accrued debt and can leave interest "dust" otherwise. A 25% partial repay is always affordable and repeatable, so it's the default; a full clear is available on demand via `--repay-amount=max`, which clicks the form's real Max button (the app then repays debt + a tiny buffer and refunds the excess, so there's no dust when the balance covers it).

**Fail loud, never guess.** If the debt read fails, or the amount would round to zero, the action throws instead of silently doing something surprising. And if the borrow leg of a `--borrow-first` run fails, the run stops before the repay (there's no new loan to repay) with a clear message.

## Two robustness fixes included (help every action, not just repay)

- **Connect approval sweep.** MetaMask sometimes shows an extra "Review permissions / Use your enabled networks" prompt after connecting. The connect step now sweeps and confirms approval pop-ups while it waits for the connected state, so that prompt no longer hangs the run. This benefits connect, pegin, borrow, and repay alike.
- **Borrow-fail guard.** A `--borrow-first` run that hits a failed borrow (e.g. a transient wallet/RPC error) now stops cleanly before the repay, instead of falling through.

## How to test

Run the CLI via its package script (from the repo root). With no flags it drops into an interactive menu; flags make it non-interactive. Localhost against devnet (real signet + Sepolia, real funds — needs a funded wallet):

```
pnpm --filter vault run e2e:cli --target=localhost --network=devnet \
  --btc=unisat --eth=metamask --action=repay --data=real --borrow-first --yes
```

Drop `--borrow-first` to repay an existing loan; add `--pegin-first` for the full pegin → borrow → repay; add `--repay-amount=max` to clear a loan in full. `pnpm --filter vault run e2e:cli` with no flags launches the interactive menu.

Verified live on devnet, each confirmed on-chain: repay-only ($111.81 → $83.86 and a full Max clear $132.67 → $0.00); borrow + repay in one session ($83.86 → $176.89 → $132.67, plus $0 → $114 → $0); and the full pegin → borrow → repay (peg in 0.01 sBTC, borrow $0 → $227.72, repay → $170.79). Existing pegin (single + split) and borrow still pass; `pnpm exec eslint` and `pnpm exec tsc` are clean.

## Files

- New: `e2e/real/repayParams.ts` (on-chain debt/balance reads), `e2e/real/actions/repay.ts` (the action), `e2e/real/tokenAmount.ts` (shared amount formatter).
- Changed: `e2e/real/actions/borrow.ts` (extracted the shared pegin-first-then-borrow function), `actions/index.ts`, `actions/selectors.ts` (shared loan-form selectors), `actions/walletConnect.ts` (connect approval sweep), `borrowParams.ts`, `cli.ts`, `config.ts`, `run.ts`, `timing.ts`.
- Two `data-testid`s added to the repay controls in `services/vault/src` (`loans-repay-button`, `repay-submit-button`).
