### PR TITLE
feat(vault): add v3 position summary overview (#2035)

### DIFF
--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/calculateMaxBorrowTokens.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/calculateMaxBorrowTokens.ts
@@ -1,8 +1,5 @@
-import {
-  BPS_SCALE,
-  MIN_HEALTH_FACTOR_FOR_BORROW,
-  SAFE_TOFIXED_PRECISION,
-} from "../../../../constants";
+import { SAFE_TOFIXED_PRECISION } from "../../../../constants";
+import { calculateBorrowCapacityUsd } from "../../../../utils/borrowCapacity";
 
 export interface CalculateMaxBorrowTokensParams {
   /** Collateral value in USD (from Aave oracle) */
@@ -49,12 +46,12 @@ export function calculateMaxBorrowTokens({
     return 0;
   }
 
-  const maxTotalDebtUsd =
-    (collateralValueUsd * liquidationThresholdBps) /
-    BPS_SCALE /
-    MIN_HEALTH_FACTOR_FOR_BORROW;
-  const maxAdditionalBorrowUsd = maxTotalDebtUsd - currentDebtUsd;
-  const maxBorrowTokens = maxAdditionalBorrowUsd / tokenPriceUsd;
+  const { availableToBorrowUsd } = calculateBorrowCapacityUsd({
+    collateralValueUsd,
+    currentDebtUsd,
+    liquidationThresholdBps,
+  });
+  const maxBorrowTokens = availableToBorrowUsd / tokenPriceUsd;
   const floorDecimals = Math.min(tokenDecimals, SAFE_TOFIXED_PRECISION);
   const scale = 10 ** floorDecimals;
   return Math.floor(Math.max(0, maxBorrowTokens) * scale) / scale;

--- a/services/vault/src/applications/aave/utils/__tests__/borrowCapacity.test.ts
+++ b/services/vault/src/applications/aave/utils/__tests__/borrowCapacity.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import { BPS_SCALE, MIN_HEALTH_FACTOR_FOR_BORROW } from "../../constants";
+import { calculateBorrowCapacityUsd } from "../borrowCapacity";
+
+describe("calculateBorrowCapacityUsd", () => {
+  it("computes max total debt and available borrow from collateral and LT", () => {
+    const result = calculateBorrowCapacityUsd({
+      collateralValueUsd: 10000,
+      currentDebtUsd: 2000,
+      liquidationThresholdBps: 8000,
+    });
+
+    const expectedMaxTotalDebtUsd =
+      (10000 * 8000) / BPS_SCALE / MIN_HEALTH_FACTOR_FOR_BORROW;
+    expect(result.maxTotalDebtUsd).toBe(expectedMaxTotalDebtUsd);
+    expect(result.availableToBorrowUsd).toBe(expectedMaxTotalDebtUsd - 2000);
+  });
+
+  it("clamps availableToBorrowUsd to 0 when debt exceeds capacity", () => {
+    const result = calculateBorrowCapacityUsd({
+      collateralValueUsd: 10000,
+      currentDebtUsd: 100000,
+      liquidationThresholdBps: 8000,
+    });
+
+    const expectedMaxTotalDebtUsd =
+      (10000 * 8000) / BPS_SCALE / MIN_HEALTH_FACTOR_FOR_BORROW;
+    expect(result.maxTotalDebtUsd).toBe(expectedMaxTotalDebtUsd);
+    expect(result.availableToBorrowUsd).toBe(0);
+  });
+
+  it("returns zero capacity when collateral is zero", () => {
+    const result = calculateBorrowCapacityUsd({
+      collateralValueUsd: 0,
+      currentDebtUsd: 0,
+      liquidationThresholdBps: 8000,
+    });
+
+    expect(result.maxTotalDebtUsd).toBe(0);
+    expect(result.availableToBorrowUsd).toBe(0);
+  });
+
+  it("returns zero capacity when liquidation threshold is 0 (split params not loaded)", () => {
+    const result = calculateBorrowCapacityUsd({
+      collateralValueUsd: 10000,
+      currentDebtUsd: 0,
+      liquidationThresholdBps: 0,
+    });
+
+    expect(result.maxTotalDebtUsd).toBe(0);
+    expect(result.availableToBorrowUsd).toBe(0);
+  });
+
+  it("respects a different liquidation threshold (7500 BPS)", () => {
+    const result = calculateBorrowCapacityUsd({
+      collateralValueUsd: 10000,
+      currentDebtUsd: 0,
+      liquidationThresholdBps: 7500,
+    });
+
+    const expectedMaxTotalDebtUsd =
+      (10000 * 7500) / BPS_SCALE / MIN_HEALTH_FACTOR_FOR_BORROW;
+    expect(result.maxTotalDebtUsd).toBe(expectedMaxTotalDebtUsd);
+    expect(result.availableToBorrowUsd).toBe(expectedMaxTotalDebtUsd);
+  });
+});

--- a/services/vault/src/applications/aave/utils/borrowCapacity.ts
+++ b/services/vault/src/applications/aave/utils/borrowCapacity.ts
@@ -1,0 +1,27 @@
+import { BPS_SCALE, MIN_HEALTH_FACTOR_FOR_BORROW } from "../constants";
+
+export interface BorrowCapacityUsdParams {
+  collateralValueUsd: number;
+  currentDebtUsd: number;
+  liquidationThresholdBps: number;
+}
+
+export interface BorrowCapacityUsd {
+  maxTotalDebtUsd: number;
+  availableToBorrowUsd: number;
+}
+
+export function calculateBorrowCapacityUsd({
+  collateralValueUsd,
+  currentDebtUsd,
+  liquidationThresholdBps,
+}: BorrowCapacityUsdParams): BorrowCapacityUsd {
+  const maxTotalDebtUsd =
+    (collateralValueUsd * liquidationThresholdBps) /
+    BPS_SCALE /
+    MIN_HEALTH_FACTOR_FOR_BORROW;
+  return {
+    maxTotalDebtUsd,
+    availableToBorrowUsd: Math.max(0, maxTotalDebtUsd - currentDebtUsd),
+  };
+}

--- a/services/vault/src/applications/aave/utils/index.ts
+++ b/services/vault/src/applications/aave/utils/index.ts
@@ -54,3 +54,10 @@ export type {
   AssertCfUnchangedDeps,
   AssertCfUnchangedResult,
 } from "./assertCfUnchanged";
+
+export { calculateBorrowCapacityUsd } from "./borrowCapacity";
+
+export type {
+  BorrowCapacityUsd,
+  BorrowCapacityUsdParams,
+} from "./borrowCapacity";

--- a/services/vault/src/components/simple/DashboardPage.tsx
+++ b/services/vault/src/components/simple/DashboardPage.tsx
@@ -90,6 +90,7 @@ export function DashboardPage() {
     collateralVaults,
     selectableBorrowedAssets,
     isBorrowCapacityLoading,
+    borrowCapacityError,
   } = useDashboardState(isConnected ? address : undefined);
 
   const { snapshot: capSnapshot, isLoading: isCapLoading } = useApplicationCap(
@@ -352,7 +353,8 @@ export function DashboardPage() {
             availableToBorrow={availableToBorrow}
             collateralBtc={collateralBtcText}
             availableMeterPercent={availableMeterPercent}
-            availableLoading={isBorrowCapacityLoading}
+            borrowCapacityLoading={isBorrowCapacityLoading}
+            borrowCapacityError={borrowCapacityError}
             borrowedMeterPercent={borrowedMeterPercent}
             onDeposit={openDeposit}
             onBorrow={handleBorrow}

--- a/services/vault/src/components/simple/DashboardPage.tsx
+++ b/services/vault/src/components/simple/DashboardPage.tsx
@@ -89,6 +89,7 @@ export function DashboardPage() {
     hasDisplayCollateral,
     collateralVaults,
     selectableBorrowedAssets,
+    isBorrowCapacityLoading,
   } = useDashboardState(isConnected ? address : undefined);
 
   const { snapshot: capSnapshot, isLoading: isCapLoading } = useApplicationCap(
@@ -351,6 +352,7 @@ export function DashboardPage() {
             availableToBorrow={availableToBorrow}
             collateralBtc={collateralBtcText}
             availableMeterPercent={availableMeterPercent}
+            availableLoading={isBorrowCapacityLoading}
             borrowedMeterPercent={borrowedMeterPercent}
             onDeposit={openDeposit}
             onBorrow={handleBorrow}

--- a/services/vault/src/components/simple/DashboardPage.tsx
+++ b/services/vault/src/components/simple/DashboardPage.tsx
@@ -79,6 +79,8 @@ export function DashboardPage() {
     displayCollateralBtc,
     collateralValueUsd,
     debtValueUsd,
+    maxTotalDebtUsd,
+    availableToBorrowUsd,
     healthFactor,
     healthFactorStatus,
     borrowedAssets,
@@ -191,12 +193,20 @@ export function DashboardPage() {
   // Format display values
   const totalCollateralValue = formatUsdValue(collateralValueUsd);
   const totalBorrowed = formatUsdValue(debtValueUsd);
+  const availableToBorrow = formatUsdValue(availableToBorrowUsd);
+  const collateralBtcText = formatBtcAmount(collateralBtc);
   // The Overview is purely a financial summary: an empty position renders every
   // row as a placeholder ("Health factor –", "$0 USD", "$0 USD"), so suppress
   // the whole panel until there is real collateral or debt to summarize. Gate on
   // the financial flags (not the display ones) so an optimistic "activating"
   // vault, whose values are still $0, doesn't surface an empty panel.
   const hasOverviewData = hasCollateral || hasLoans;
+  const showOverview = featureFlags.isV3UiEnabled || hasOverviewData;
+
+  const availableMeterPercent =
+    maxTotalDebtUsd > 0 ? availableToBorrowUsd / maxTotalDebtUsd : 0;
+  const borrowedMeterPercent =
+    maxTotalDebtUsd > 0 ? debtValueUsd / maxTotalDebtUsd : 0;
 
   // Liquidation-risk gauge stats. Liquidation price and distance-to-liquidation
   // come from the first group of the position cascade (the price at which the
@@ -302,7 +312,9 @@ export function DashboardPage() {
   return (
     <Container className={`${PAGE_CONTENT_CLASS} pb-6`}>
       <div className="space-y-10">
-        <SupplyCapSection snapshot={capSnapshot} isLoading={isCapLoading} />
+        {!featureFlags.isV3UiEnabled && (
+          <SupplyCapSection snapshot={capSnapshot} isLoading={isCapLoading} />
+        )}
 
         {/* Notifications sit between the supply cap and Overview per Figma
             (frame 6508-114810). The critical top banner, the max-vaults notice,
@@ -327,7 +339,7 @@ export function DashboardPage() {
           />
         )}
 
-        {hasOverviewData && (
+        {showOverview && (
           <OverviewSection
             healthFactor={healthFactor}
             healthFactorStatus={healthFactorStatus}
@@ -336,43 +348,56 @@ export function DashboardPage() {
             liquidationPrice={liquidationPrice}
             btcPrice={btcPrice}
             pctToLiquidation={pctToLiquidation}
+            availableToBorrow={availableToBorrow}
+            collateralBtc={collateralBtcText}
+            availableMeterPercent={availableMeterPercent}
+            borrowedMeterPercent={borrowedMeterPercent}
+            onDeposit={openDeposit}
+            onBorrow={handleBorrow}
+            onRepay={handleRepay}
+            canBorrow={availableToBorrowUsd > 0}
+            canRepay={hasLoans}
           />
         )}
 
-        <PendingDepositSection />
+        {!featureFlags.isV3UiEnabled && (
+          <>
+            <PendingDepositSection />
 
-        <PendingWithdrawSection
-          pendingWithdrawVaults={inProgressWithdrawVaults}
-          pegoutStatuses={withdrawPegoutStatuses}
-        />
+            <PendingWithdrawSection
+              pendingWithdrawVaults={inProgressWithdrawVaults}
+              pegoutStatuses={withdrawPegoutStatuses}
+            />
 
-        <PendingWithdrawSection
-          title={COPY.pegout.section.completedTitle}
-          pendingWithdrawVaults={completedWithdrawVaults}
-          pegoutStatuses={withdrawPegoutStatuses}
-        />
+            <PendingWithdrawSection
+              title={COPY.pegout.section.completedTitle}
+              pendingWithdrawVaults={completedWithdrawVaults}
+              pegoutStatuses={withdrawPegoutStatuses}
+            />
 
-        <CollateralSection
-          totalAmountBtc={totalAmountBtcShown}
-          collateralVaults={collateralVaultsWithDemo}
-          hasCollateral={showCollateral}
-          isConnected={isConnected}
-          collateralBtc={collateralBtc}
-          currentHealthFactor={healthFactor}
-          selectedVaultIds={selectedVaultIds}
-          onSelectedVaultIdsChange={setSelectedVaultIds}
-          onWithdraw={handleOpenWithdraw}
-          onDeposit={openDeposit}
-        />
+            <CollateralSection
+              totalAmountBtc={totalAmountBtcShown}
+              collateralVaults={collateralVaultsWithDemo}
+              hasCollateral={showCollateral}
+              isConnected={isConnected}
+              collateralBtc={collateralBtc}
+              currentHealthFactor={healthFactor}
+              selectedVaultIds={selectedVaultIds}
+              onSelectedVaultIdsChange={setSelectedVaultIds}
+              onWithdraw={handleOpenWithdraw}
+              onDeposit={openDeposit}
+            />
 
-        <LoansSection
-          hasLoans={hasLoans}
-          hasCollateral={hasCollateral}
-          isConnected={isConnected}
-          borrowedAssets={borrowedAssets}
-          onBorrow={handleBorrow}
-          onRepay={handleRepay}
-        />
+            <LoansSection
+              hasLoans={hasLoans}
+              hasCollateral={hasCollateral}
+              isConnected={isConnected}
+              borrowedAssets={borrowedAssets}
+              onBorrow={handleBorrow}
+              onRepay={handleRepay}
+            />
+          </>
+        )}
       </div>
 
       {/* Withdraw Flow.

--- a/services/vault/src/components/simple/OverviewSection.tsx
+++ b/services/vault/src/components/simple/OverviewSection.tsx
@@ -36,8 +36,9 @@ interface OverviewSectionProps {
   availableToBorrow: string;
   collateralBtc: string;
   availableMeterPercent: number;
-  availableLoading: boolean;
   borrowedMeterPercent: number;
+  borrowCapacityLoading: boolean;
+  borrowCapacityError: Error | null;
   onDeposit: () => void;
   onBorrow: () => void;
   onRepay: () => void;
@@ -84,8 +85,9 @@ export function OverviewSection({
   availableToBorrow,
   collateralBtc,
   availableMeterPercent,
-  availableLoading,
   borrowedMeterPercent,
+  borrowCapacityLoading,
+  borrowCapacityError,
   onDeposit,
   onBorrow,
   onRepay,
@@ -116,6 +118,8 @@ export function OverviewSection({
   const statCards: PositionStatCard[] = useMemo(() => {
     const clampPct = (ratio: number) =>
       Math.round(Math.min(1, Math.max(0, ratio)) * 100);
+    const capacityUnavailable =
+      borrowCapacityLoading || borrowCapacityError != null;
     return [
       {
         label: COPY.overview.totalCollateralValueLabel,
@@ -128,8 +132,12 @@ export function OverviewSection({
       },
       {
         label: COPY.overview.availableToBorrowLabel,
-        value: availableLoading ? COPY.common.loading : availableToBorrow,
-        meter: availableLoading
+        value: borrowCapacityLoading
+          ? COPY.common.loading
+          : borrowCapacityError
+            ? COPY.common.emptyValue
+            : availableToBorrow,
+        meter: capacityUnavailable
           ? undefined
           : {
               percent: availableMeterPercent,
@@ -144,12 +152,14 @@ export function OverviewSection({
       {
         label: COPY.overview.totalBorrowedLabel,
         value: totalBorrowed,
-        meter: {
-          percent: borrowedMeterPercent,
-          label: COPY.overview.borrowedMeterLabel(
-            clampPct(borrowedMeterPercent),
-          ),
-        },
+        meter: capacityUnavailable
+          ? undefined
+          : {
+              percent: borrowedMeterPercent,
+              label: COPY.overview.borrowedMeterLabel(
+                clampPct(borrowedMeterPercent),
+              ),
+            },
         actionLabel: COPY.overview.repayAction,
         onAction: onRepay,
         actionDisabled: !canRepay,
@@ -161,7 +171,8 @@ export function OverviewSection({
     onDeposit,
     availableToBorrow,
     availableMeterPercent,
-    availableLoading,
+    borrowCapacityLoading,
+    borrowCapacityError,
     onBorrow,
     canBorrow,
     totalBorrowed,

--- a/services/vault/src/components/simple/OverviewSection.tsx
+++ b/services/vault/src/components/simple/OverviewSection.tsx
@@ -17,11 +17,13 @@ import {
 } from "@/applications/aave/utils";
 import {
   HealthFactorGauge,
-  type HealthFactorGaugeStat,
   HeartIcon,
+  type HealthFactorGaugeStat,
 } from "@/components/shared";
 import { FeatureFlags } from "@/config";
 import { COPY } from "@/copy";
+
+import { PositionStatCards, type PositionStatCard } from "./PositionStatCards";
 
 interface OverviewSectionProps {
   healthFactor: number | null;
@@ -31,6 +33,15 @@ interface OverviewSectionProps {
   liquidationPrice: string;
   btcPrice: string;
   pctToLiquidation: string;
+  availableToBorrow: string;
+  collateralBtc: string;
+  availableMeterPercent: number;
+  borrowedMeterPercent: number;
+  onDeposit: () => void;
+  onBorrow: () => void;
+  onRepay: () => void;
+  canBorrow: boolean;
+  canRepay: boolean;
 }
 
 interface OverviewRowProps {
@@ -69,6 +80,15 @@ export function OverviewSection({
   liquidationPrice,
   btcPrice,
   pctToLiquidation,
+  availableToBorrow,
+  collateralBtc,
+  availableMeterPercent,
+  borrowedMeterPercent,
+  onDeposit,
+  onBorrow,
+  onRepay,
+  canBorrow,
+  canRepay,
 }: OverviewSectionProps) {
   const isMobile = useIsMobile();
   // v3 desktop replaces this in-page heading with the persistent header's
@@ -91,6 +111,60 @@ export function OverviewSection({
     [liquidationPrice, btcPrice, pctToLiquidation],
   );
 
+  const statCards: PositionStatCard[] = useMemo(() => {
+    const clampPct = (ratio: number) =>
+      Math.round(Math.min(1, Math.max(0, ratio)) * 100);
+    return [
+      {
+        label: COPY.overview.totalCollateralValueLabel,
+        tooltip: COPY.overview.totalCollateralValueTooltip,
+        value: totalCollateralValue,
+        caption: collateralBtc,
+        actionLabel: COPY.overview.depositAction,
+        onAction: onDeposit,
+        actionDisabled: false,
+      },
+      {
+        label: COPY.overview.availableToBorrowLabel,
+        value: availableToBorrow,
+        meter: {
+          percent: availableMeterPercent,
+          label: COPY.overview.availableMeterLabel(
+            clampPct(availableMeterPercent),
+          ),
+        },
+        actionLabel: COPY.overview.borrowAction,
+        onAction: onBorrow,
+        actionDisabled: !canBorrow,
+      },
+      {
+        label: COPY.overview.totalBorrowedLabel,
+        value: totalBorrowed,
+        meter: {
+          percent: borrowedMeterPercent,
+          label: COPY.overview.borrowedMeterLabel(
+            clampPct(borrowedMeterPercent),
+          ),
+        },
+        actionLabel: COPY.overview.repayAction,
+        onAction: onRepay,
+        actionDisabled: !canRepay,
+      },
+    ];
+  }, [
+    totalCollateralValue,
+    collateralBtc,
+    onDeposit,
+    availableToBorrow,
+    availableMeterPercent,
+    onBorrow,
+    canBorrow,
+    totalBorrowed,
+    borrowedMeterPercent,
+    onRepay,
+    canRepay,
+  ]);
+
   return (
     <div className="w-full space-y-6">
       {!hideHeading && (
@@ -105,46 +179,59 @@ export function OverviewSection({
         </div>
       )}
 
-      <div className="w-full rounded-2xl bg-secondary-highlight p-6">
-        <div className="space-y-4">
-          {/* Liquidation-risk gauge with stats */}
-          {showHealthFactor && (
-            <HealthFactorGauge
-              value={healthFactor}
-              status={healthFactorStatus}
-              stats={gaugeStats}
-            />
-          )}
-
-          {/* Health Factor Row */}
-          <OverviewRow
-            label={COPY.overview.healthFactorLabel}
-            tooltip={COPY.overview.healthFactorTooltip}
+      {FeatureFlags.isV3UiEnabled ? (
+        <div className="space-y-2">
+          <Heading
+            variant="h6"
+            as="h2"
+            className="font-normal text-accent-primary"
           >
-            {showHealthFactor ? (
-              <>
-                <HeartIcon color={healthFactorColor} />
-                {healthFactorFormatted}
-              </>
-            ) : (
-              COPY.common.emptyValue
-            )}
-          </OverviewRow>
-
-          {/* Total Collateral Value Row */}
-          <OverviewRow
-            label={COPY.overview.totalCollateralValueLabel}
-            tooltip={COPY.overview.totalCollateralValueTooltip}
-          >
-            {totalCollateralValue}
-          </OverviewRow>
-
-          {/* Total Borrowed Row */}
-          <OverviewRow label={COPY.overview.totalBorrowedLabel}>
-            {totalBorrowed}
-          </OverviewRow>
+            {COPY.overview.positionTitle}
+          </Heading>
+          <PositionStatCards cards={statCards} />
         </div>
-      </div>
+      ) : (
+        <div className="w-full rounded-2xl bg-secondary-highlight p-6">
+          <div className="space-y-4">
+            {/* Liquidation-risk gauge with stats */}
+            {showHealthFactor && (
+              <HealthFactorGauge
+                value={healthFactor}
+                status={healthFactorStatus}
+                stats={gaugeStats}
+              />
+            )}
+
+            {/* Health Factor Row */}
+            <OverviewRow
+              label={COPY.overview.healthFactorLabel}
+              tooltip={COPY.overview.healthFactorTooltip}
+            >
+              {showHealthFactor ? (
+                <>
+                  <HeartIcon color={healthFactorColor} />
+                  {healthFactorFormatted}
+                </>
+              ) : (
+                COPY.common.emptyValue
+              )}
+            </OverviewRow>
+
+            {/* Total Collateral Value Row */}
+            <OverviewRow
+              label={COPY.overview.totalCollateralValueLabel}
+              tooltip={COPY.overview.totalCollateralValueTooltip}
+            >
+              {totalCollateralValue}
+            </OverviewRow>
+
+            {/* Total Borrowed Row */}
+            <OverviewRow label={COPY.overview.totalBorrowedLabel}>
+              {totalBorrowed}
+            </OverviewRow>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/services/vault/src/components/simple/OverviewSection.tsx
+++ b/services/vault/src/components/simple/OverviewSection.tsx
@@ -36,6 +36,7 @@ interface OverviewSectionProps {
   availableToBorrow: string;
   collateralBtc: string;
   availableMeterPercent: number;
+  availableLoading: boolean;
   borrowedMeterPercent: number;
   onDeposit: () => void;
   onBorrow: () => void;
@@ -83,6 +84,7 @@ export function OverviewSection({
   availableToBorrow,
   collateralBtc,
   availableMeterPercent,
+  availableLoading,
   borrowedMeterPercent,
   onDeposit,
   onBorrow,
@@ -126,13 +128,15 @@ export function OverviewSection({
       },
       {
         label: COPY.overview.availableToBorrowLabel,
-        value: availableToBorrow,
-        meter: {
-          percent: availableMeterPercent,
-          label: COPY.overview.availableMeterLabel(
-            clampPct(availableMeterPercent),
-          ),
-        },
+        value: availableLoading ? COPY.common.loading : availableToBorrow,
+        meter: availableLoading
+          ? undefined
+          : {
+              percent: availableMeterPercent,
+              label: COPY.overview.availableMeterLabel(
+                clampPct(availableMeterPercent),
+              ),
+            },
         actionLabel: COPY.overview.borrowAction,
         onAction: onBorrow,
         actionDisabled: !canBorrow,
@@ -157,6 +161,7 @@ export function OverviewSection({
     onDeposit,
     availableToBorrow,
     availableMeterPercent,
+    availableLoading,
     onBorrow,
     canBorrow,
     totalBorrowed,

--- a/services/vault/src/components/simple/PositionStatCards.tsx
+++ b/services/vault/src/components/simple/PositionStatCards.tsx
@@ -95,7 +95,7 @@ function StatSection({ card }: { card: PositionStatCard }) {
 
 export function PositionStatCards({ cards }: { cards: PositionStatCard[] }) {
   return (
-    <div className="rounded-lg bg-secondary-highlight p-6 dark:bg-[#202020]">
+    <div className="rounded-lg bg-secondary-highlight p-6">
       <div className="flex flex-col gap-6 xl:flex-row xl:items-stretch">
         {cards.map((card, index) => (
           <Fragment key={card.label}>

--- a/services/vault/src/components/simple/PositionStatCards.tsx
+++ b/services/vault/src/components/simple/PositionStatCards.tsx
@@ -36,7 +36,7 @@ function StatMeter({
         className="h-1 w-[68px] overflow-hidden rounded-full bg-secondary-strokeLight"
       >
         <div
-          className="h-full rounded-full bg-secondary-main transition-[width] duration-300"
+          className="h-full rounded-full bg-secondary-main"
           style={{ width: `${clamped * 100}%` }}
         />
       </div>

--- a/services/vault/src/components/simple/PositionStatCards.tsx
+++ b/services/vault/src/components/simple/PositionStatCards.tsx
@@ -1,0 +1,111 @@
+import { Hint, InfoIcon } from "@babylonlabs-io/core-ui";
+import { Fragment } from "react";
+
+export interface PositionStatCard {
+  label: string;
+  tooltip?: string;
+  value: string;
+  caption?: string;
+  meter?: {
+    percent: number;
+    label: string;
+  };
+  actionLabel: string;
+  onAction: () => void;
+  actionDisabled: boolean;
+}
+
+function StatMeter({
+  percent,
+  label,
+  ariaLabel,
+}: {
+  percent: number;
+  label: string;
+  ariaLabel: string;
+}) {
+  const clamped = Math.max(0, Math.min(1, percent));
+  return (
+    <div className="flex items-center gap-2">
+      <div
+        role="progressbar"
+        aria-label={ariaLabel}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={Math.round(clamped * 100)}
+        className="h-1 w-[68px] overflow-hidden rounded-full bg-secondary-strokeLight"
+      >
+        <div
+          className="h-full rounded-full bg-secondary-main transition-[width] duration-300"
+          style={{ width: `${clamped * 100}%` }}
+        />
+      </div>
+      <span className="whitespace-nowrap text-xs leading-[1.66] tracking-[0.4px] text-accent-primary">
+        {label}
+      </span>
+    </div>
+  );
+}
+
+function StatSection({ card }: { card: PositionStatCard }) {
+  return (
+    <div className="flex flex-1 items-center justify-between gap-4">
+      <div className="flex flex-col gap-3">
+        <div className="flex items-center gap-1 text-sm leading-[1.43] tracking-[0.17px] text-accent-secondary">
+          {card.tooltip ? (
+            <Hint
+              tooltip={card.tooltip}
+              icon={<InfoIcon size={16} className="text-accent-secondary" />}
+            >
+              <span className="text-accent-secondary">{card.label}</span>
+            </Hint>
+          ) : (
+            card.label
+          )}
+        </div>
+
+        <span className="text-xl leading-[1.6] tracking-[0.15px] text-accent-primary">
+          {card.value}
+        </span>
+
+        {card.meter ? (
+          <StatMeter
+            percent={card.meter.percent}
+            label={card.meter.label}
+            ariaLabel={card.label}
+          />
+        ) : card.caption ? (
+          <span className="text-sm leading-[1.43] tracking-[0.17px] text-accent-secondary">
+            {card.caption}
+          </span>
+        ) : null}
+      </div>
+
+      <button
+        type="button"
+        onClick={() => card.onAction()}
+        disabled={card.actionDisabled}
+        className="flex h-10 w-[120px] shrink-0 items-center justify-center rounded-lg bg-secondary-strokeLight text-base leading-[1.5] tracking-[0.15px] text-accent-primary transition-[filter] enabled:hover:brightness-110 disabled:cursor-not-allowed disabled:text-accent-disabled"
+      >
+        {card.actionLabel}
+      </button>
+    </div>
+  );
+}
+
+export function PositionStatCards({ cards }: { cards: PositionStatCard[] }) {
+  return (
+    <div className="rounded-lg bg-secondary-highlight p-6 dark:bg-[#202020]">
+      <div className="flex flex-col gap-6 xl:flex-row xl:items-stretch">
+        {cards.map((card, index) => (
+          <Fragment key={card.label}>
+            {index > 0 && (
+              <div className="h-px w-full self-center bg-secondary-strokeLight xl:h-16 xl:w-px" />
+            )}
+            <StatSection card={card} />
+          </Fragment>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/services/vault/src/components/simple/__tests__/DashboardPage.test.tsx
+++ b/services/vault/src/components/simple/__tests__/DashboardPage.test.tsx
@@ -1,0 +1,148 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DashboardPage } from "../DashboardPage";
+
+const featureFlagsMock = vi.hoisted(() => ({
+  isV3UiEnabled: false,
+  isLiquidationNotificationsEnabled: false,
+  isGodModePanelEnabled: false,
+  isPositionDebugPanelEnabled: false,
+}));
+
+vi.mock("@/config/featureFlags", () => ({ default: featureFlagsMock }));
+
+vi.mock("react-router", () => ({
+  useNavigate: () => vi.fn(),
+  useOutletContext: () => ({ openDeposit: vi.fn() }),
+}));
+
+vi.mock("@/context/wallet", () => ({
+  useConnection: () => ({ isConnected: true }),
+  useETHWallet: () => ({ address: "0xabc" }),
+}));
+
+vi.mock("@/hooks/useDashboardState", () => ({
+  useDashboardState: () => ({
+    collateralBtc: 0,
+    displayCollateralBtc: 0,
+    collateralValueUsd: 0,
+    debtValueUsd: 0,
+    maxTotalDebtUsd: 0,
+    availableToBorrowUsd: 0,
+    healthFactor: 0,
+    healthFactorStatus: "safe",
+    borrowedAssets: [],
+    hasLoans: true,
+    hasCollateral: true,
+    hasDisplayCollateral: true,
+    collateralVaults: [],
+    selectableBorrowedAssets: [],
+    isLoading: false,
+  }),
+}));
+
+vi.mock("@/hooks/useApplicationCap", () => ({
+  useApplicationCap: () => ({ snapshot: null, isLoading: false }),
+}));
+
+vi.mock("@/hooks/usePegoutPolling", () => ({
+  usePegoutPolling: () => ({ pegoutStatuses: new Map() }),
+}));
+
+vi.mock("@/hooks/usePrices", () => ({
+  usePrices: () => ({ prices: {}, metadata: {} }),
+}));
+
+vi.mock("@/dev/debugPositionStore", () => ({
+  useDebugPositionOverride: () => ({ result: null, status: null }),
+}));
+
+vi.mock("@/dev/demoDeposit", () => ({
+  useDemoCollateral: () => null,
+  useDemoWithdrawal: () => null,
+}));
+
+vi.mock("@/applications/aave/context", () => ({
+  useSyncPendingVaults: () => undefined,
+}));
+
+vi.mock("@/applications/aave/hooks", () => ({
+  useAaveVaults: () => ({ vaults: [], redeemedVaults: [] }),
+}));
+
+vi.mock("@/applications/aave/hooks/usePositionNotifications", () => ({
+  usePositionNotifications: () => ({ result: null }),
+}));
+
+vi.mock("@/applications/aave/components/AssetSelectionModal", () => ({
+  AssetSelectionModal: () => null,
+}));
+
+vi.mock("../OverviewSection", () => ({
+  OverviewSection: () => <div data-testid="overview-section" />,
+}));
+vi.mock("../CollateralSection", () => ({
+  CollateralSection: () => <div data-testid="collateral-section" />,
+}));
+vi.mock("../LoansSection", () => ({
+  LoansSection: () => <div data-testid="loans-section" />,
+}));
+vi.mock("../SupplyCapSection", () => ({
+  SupplyCapSection: () => <div data-testid="supply-cap" />,
+}));
+vi.mock("../MaxVaultsNotification", () => ({
+  MaxVaultsNotification: () => <div data-testid="max-vaults" />,
+}));
+vi.mock("../PendingDepositSection", () => ({
+  PendingDepositSection: () => <div data-testid="pending-deposits" />,
+}));
+vi.mock("../PendingWithdrawSection", () => ({
+  PendingWithdrawSection: () => <div data-testid="pending-withdrawals" />,
+}));
+vi.mock("../PositionNotificationBanner", () => ({
+  PositionNotificationBanner: () => <div data-testid="position-banner" />,
+}));
+vi.mock("../CriticalLiquidationTopBanner", () => ({
+  CriticalLiquidationTopBanner: () => <div data-testid="critical-banner" />,
+}));
+vi.mock("../DisconnectedOverview", () => ({
+  DisconnectedOverview: () => null,
+}));
+vi.mock("../WithdrawFlow", () => ({ default: () => null }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  featureFlagsMock.isV3UiEnabled = false;
+  featureFlagsMock.isLiquidationNotificationsEnabled = false;
+});
+
+describe("DashboardPage v3 composition", () => {
+  it("renders every legacy section when the v3 flag is off", () => {
+    render(<DashboardPage />);
+
+    expect(screen.getByTestId("collateral-section")).toBeInTheDocument();
+    expect(screen.getByTestId("loans-section")).toBeInTheDocument();
+    expect(screen.getByTestId("supply-cap")).toBeInTheDocument();
+    expect(screen.getByTestId("pending-deposits")).toBeInTheDocument();
+    expect(screen.getAllByTestId("pending-withdrawals")).toHaveLength(2);
+  });
+
+  it("shows only the overview summary in v3, hiding cap, pending, collateral, and loans while keeping safety notifications", () => {
+    featureFlagsMock.isV3UiEnabled = true;
+    featureFlagsMock.isLiquidationNotificationsEnabled = true;
+
+    render(<DashboardPage />);
+
+    expect(screen.getByTestId("overview-section")).toBeInTheDocument();
+    expect(screen.getByTestId("max-vaults")).toBeInTheDocument();
+    expect(screen.getByTestId("critical-banner")).toBeInTheDocument();
+    expect(screen.getByTestId("position-banner")).toBeInTheDocument();
+
+    expect(screen.queryByTestId("collateral-section")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("loans-section")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("supply-cap")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("pending-deposits")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("pending-withdrawals")).not.toBeInTheDocument();
+  });
+});

--- a/services/vault/src/components/simple/__tests__/DashboardPage.test.tsx
+++ b/services/vault/src/components/simple/__tests__/DashboardPage.test.tsx
@@ -31,6 +31,7 @@ vi.mock("@/hooks/useDashboardState", () => ({
     maxTotalDebtUsd: 0,
     availableToBorrowUsd: 0,
     isBorrowCapacityLoading: false,
+    borrowCapacityError: null,
     healthFactor: 0,
     healthFactorStatus: "safe",
     borrowedAssets: [],

--- a/services/vault/src/components/simple/__tests__/DashboardPage.test.tsx
+++ b/services/vault/src/components/simple/__tests__/DashboardPage.test.tsx
@@ -30,6 +30,7 @@ vi.mock("@/hooks/useDashboardState", () => ({
     debtValueUsd: 0,
     maxTotalDebtUsd: 0,
     availableToBorrowUsd: 0,
+    isBorrowCapacityLoading: false,
     healthFactor: 0,
     healthFactorStatus: "safe",
     borrowedAssets: [],

--- a/services/vault/src/components/simple/__tests__/OverviewSection.test.tsx
+++ b/services/vault/src/components/simple/__tests__/OverviewSection.test.tsx
@@ -37,6 +37,7 @@ function renderSection(overrides: Record<string, unknown> = {}) {
       availableToBorrow="$5,000"
       collateralBtc="0.5 BTC"
       availableMeterPercent={0.75}
+      availableLoading={false}
       borrowedMeterPercent={0.25}
       onDeposit={onDeposit}
       onBorrow={onBorrow}
@@ -138,6 +139,22 @@ describe("OverviewSection", () => {
         }),
       ).not.toBeInTheDocument();
       expect(screen.getByText("0.5 BTC")).toBeInTheDocument();
+    });
+
+    it("shows a loading placeholder for available-to-borrow and no meter while borrow capacity loads", () => {
+      renderSection({ availableLoading: true });
+
+      expect(screen.getByText(COPY.common.loading)).toBeInTheDocument();
+      expect(
+        screen.queryByRole("progressbar", {
+          name: COPY.overview.availableToBorrowLabel,
+        }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByRole("progressbar", {
+          name: COPY.overview.totalBorrowedLabel,
+        }),
+      ).toBeInTheDocument();
     });
   });
 

--- a/services/vault/src/components/simple/__tests__/OverviewSection.test.tsx
+++ b/services/vault/src/components/simple/__tests__/OverviewSection.test.tsx
@@ -37,7 +37,8 @@ function renderSection(overrides: Record<string, unknown> = {}) {
       availableToBorrow="$5,000"
       collateralBtc="0.5 BTC"
       availableMeterPercent={0.75}
-      availableLoading={false}
+      borrowCapacityLoading={false}
+      borrowCapacityError={null}
       borrowedMeterPercent={0.25}
       onDeposit={onDeposit}
       onBorrow={onBorrow}
@@ -141,8 +142,8 @@ describe("OverviewSection", () => {
       expect(screen.getByText("0.5 BTC")).toBeInTheDocument();
     });
 
-    it("shows a loading placeholder for available-to-borrow and no meter while borrow capacity loads", () => {
-      renderSection({ availableLoading: true });
+    it("shows a loading placeholder and hides both meters while borrow capacity loads", () => {
+      renderSection({ borrowCapacityLoading: true });
 
       expect(screen.getByText(COPY.common.loading)).toBeInTheDocument();
       expect(
@@ -151,10 +152,28 @@ describe("OverviewSection", () => {
         }),
       ).not.toBeInTheDocument();
       expect(
-        screen.getByRole("progressbar", {
+        screen.queryByRole("progressbar", {
           name: COPY.overview.totalBorrowedLabel,
         }),
-      ).toBeInTheDocument();
+      ).not.toBeInTheDocument();
+      expect(screen.getByText("$2,000")).toBeInTheDocument();
+    });
+
+    it("shows an empty placeholder for available and hides both meters when borrow capacity errors", () => {
+      renderSection({ borrowCapacityError: new Error("split params failed") });
+
+      expect(screen.getByText(COPY.common.emptyValue)).toBeInTheDocument();
+      expect(
+        screen.queryByRole("progressbar", {
+          name: COPY.overview.availableToBorrowLabel,
+        }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("progressbar", {
+          name: COPY.overview.totalBorrowedLabel,
+        }),
+      ).not.toBeInTheDocument();
+      expect(screen.getByText("$2,000")).toBeInTheDocument();
     });
   });
 

--- a/services/vault/src/components/simple/__tests__/OverviewSection.test.tsx
+++ b/services/vault/src/components/simple/__tests__/OverviewSection.test.tsx
@@ -1,0 +1,169 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { COPY } from "@/copy";
+
+import { OverviewSection } from "../OverviewSection";
+
+const featureFlagsMock = vi.hoisted(() => ({
+  isV3UiEnabled: false,
+}));
+
+vi.mock("@/config", () => ({
+  FeatureFlags: featureFlagsMock,
+  getNetworkConfigBTC: () => ({ coinSymbol: "sBTC" }),
+  getBTCNetwork: () => "signet",
+}));
+
+vi.mock("@/components/shared", () => ({
+  HealthFactorGauge: () => <div data-testid="health-factor-gauge" />,
+  HeartIcon: () => null,
+}));
+
+const onDeposit = vi.fn();
+const onBorrow = vi.fn();
+const onRepay = vi.fn();
+
+function renderSection(overrides: Record<string, unknown> = {}) {
+  return render(
+    <OverviewSection
+      healthFactor={2}
+      healthFactorStatus="safe"
+      totalCollateralValue="$10,000"
+      totalBorrowed="$2,000"
+      liquidationPrice="$40,000"
+      btcPrice="$60,000"
+      pctToLiquidation="30%"
+      availableToBorrow="$5,000"
+      collateralBtc="0.5 BTC"
+      availableMeterPercent={0.75}
+      borrowedMeterPercent={0.25}
+      onDeposit={onDeposit}
+      onBorrow={onBorrow}
+      onRepay={onRepay}
+      canBorrow={true}
+      canRepay={true}
+      {...overrides}
+    />,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  featureFlagsMock.isV3UiEnabled = false;
+});
+
+describe("OverviewSection", () => {
+  describe("v3 flag on: position summary cards", () => {
+    beforeEach(() => {
+      featureFlagsMock.isV3UiEnabled = true;
+    });
+
+    it("renders the three stat values and their action buttons", () => {
+      renderSection();
+
+      expect(screen.getByText("$10,000")).toBeInTheDocument();
+      expect(screen.getByText("$5,000")).toBeInTheDocument();
+      expect(screen.getByText("$2,000")).toBeInTheDocument();
+      expect(screen.getByText(COPY.overview.positionTitle)).toBeInTheDocument();
+      expect(screen.getByText("0.5 BTC")).toBeInTheDocument();
+
+      expect(
+        screen.getByRole("button", { name: COPY.overview.depositAction }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: COPY.overview.borrowAction }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: COPY.overview.repayAction }),
+      ).toBeInTheDocument();
+    });
+
+    it("fires the matching callback when each action is clicked", () => {
+      renderSection();
+
+      fireEvent.click(
+        screen.getByRole("button", { name: COPY.overview.depositAction }),
+      );
+      fireEvent.click(
+        screen.getByRole("button", { name: COPY.overview.borrowAction }),
+      );
+      fireEvent.click(
+        screen.getByRole("button", { name: COPY.overview.repayAction }),
+      );
+
+      expect(onDeposit).toHaveBeenCalledTimes(1);
+      expect(onDeposit).toHaveBeenCalledWith();
+      expect(onBorrow).toHaveBeenCalledTimes(1);
+      expect(onRepay).toHaveBeenCalledTimes(1);
+    });
+
+    it("disables Borrow and Repay when the position cannot act, Deposit stays enabled", () => {
+      renderSection({ canBorrow: false, canRepay: false });
+
+      expect(
+        screen.getByRole("button", { name: COPY.overview.depositAction }),
+      ).toBeEnabled();
+      expect(
+        screen.getByRole("button", { name: COPY.overview.borrowAction }),
+      ).toBeDisabled();
+      expect(
+        screen.getByRole("button", { name: COPY.overview.repayAction }),
+      ).toBeDisabled();
+    });
+
+    it("exposes the available and borrowed meters as named progressbars, and shows the collateral BTC caption instead of a meter", () => {
+      renderSection();
+
+      expect(
+        screen.getByRole("progressbar", {
+          name: COPY.overview.availableToBorrowLabel,
+        }),
+      ).toHaveAttribute("aria-valuenow", "75");
+      expect(
+        screen.getByRole("progressbar", {
+          name: COPY.overview.totalBorrowedLabel,
+        }),
+      ).toHaveAttribute("aria-valuenow", "25");
+      expect(
+        screen.getByText(COPY.overview.availableMeterLabel(75)),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(COPY.overview.borrowedMeterLabel(25)),
+      ).toBeInTheDocument();
+
+      expect(
+        screen.queryByRole("progressbar", {
+          name: COPY.overview.totalCollateralValueLabel,
+        }),
+      ).not.toBeInTheDocument();
+      expect(screen.getByText("0.5 BTC")).toBeInTheDocument();
+    });
+  });
+
+  describe("v2 flag off: legacy overview rows", () => {
+    it("renders the gauge and the three legacy rows, and no stat-card action buttons", () => {
+      renderSection();
+
+      expect(screen.getByTestId("health-factor-gauge")).toBeInTheDocument();
+      expect(
+        screen.getByText(COPY.overview.healthFactorLabel),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(COPY.overview.totalCollateralValueLabel),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(COPY.overview.totalBorrowedLabel),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: COPY.overview.depositAction }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: COPY.overview.borrowAction }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: COPY.overview.repayAction }),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -1109,6 +1109,7 @@ export const COPY = {
   },
   overview: {
     heading: "Overview",
+    positionTitle: "Position",
     healthFactorLabel: "Health factor",
     healthFactorTooltip:
       "Your position's safety margin. If it falls below 1.0, your collateral can be liquidated.",
@@ -1118,8 +1119,14 @@ export const COPY = {
     liquidationRiskLabel: "Liquidation Risk",
     totalCollateralValueLabel: "Total collateral value",
     totalCollateralValueTooltip:
-      "The current USD value of all Bitcoin collateral backing your loans.",
+      "The total value of assets used as collateral.",
     totalBorrowedLabel: "Total borrowed",
+    availableToBorrowLabel: "Available to borrow",
+    depositAction: "Deposit",
+    borrowAction: "Borrow",
+    repayAction: "Repay",
+    availableMeterLabel: (percent: number) => `${percent}% remaining`,
+    borrowedMeterLabel: (percent: number) => `${percent}% borrowed`,
     liquidationPriceLabel: "Liquidation price",
     btcPriceLabel: "BTC price",
     pctToLiquidationLabel: "% to liquidation",

--- a/services/vault/src/hooks/__tests__/useDashboardState.test.ts
+++ b/services/vault/src/hooks/__tests__/useDashboardState.test.ts
@@ -27,6 +27,7 @@ let mockCollateralBtc = 0;
 let mockCollateralValueUsd = 0;
 let mockDebtValueUsd = 0;
 let mockSplitParams: { THF: number; CF: number; LB: number } | null = null;
+let mockSplitLoading = false;
 let mockReorderedOrder: readonly `0x${string}`[] | null = null;
 let mockActivatingVaults = new Map<string, ActivatingEntry>();
 const mockClearReorderedOrder = vi.fn();
@@ -61,7 +62,7 @@ vi.mock("@/applications/aave/hooks", () => ({
   }),
   useVaultSplitParams: () => ({
     params: mockSplitParams,
-    isLoading: false,
+    isLoading: mockSplitLoading,
     error: null,
     refetch: async () => mockSplitParams,
   }),
@@ -103,6 +104,7 @@ describe("useDashboardState", () => {
     mockCollateralValueUsd = 0;
     mockDebtValueUsd = 0;
     mockSplitParams = null;
+    mockSplitLoading = false;
     mockReorderedOrder = null;
     mockActivatingVaults = new Map();
   });
@@ -273,5 +275,13 @@ describe("useDashboardState", () => {
 
     expect(result.current.maxTotalDebtUsd).toBe(0);
     expect(result.current.availableToBorrowUsd).toBe(0);
+  });
+
+  it("forwards the split-params loading state as isBorrowCapacityLoading", () => {
+    mockSplitLoading = true;
+
+    const { result } = renderHook(() => useDashboardState("0xabc"));
+
+    expect(result.current.isBorrowCapacityLoading).toBe(true);
   });
 });

--- a/services/vault/src/hooks/__tests__/useDashboardState.test.ts
+++ b/services/vault/src/hooks/__tests__/useDashboardState.test.ts
@@ -28,6 +28,7 @@ let mockCollateralValueUsd = 0;
 let mockDebtValueUsd = 0;
 let mockSplitParams: { THF: number; CF: number; LB: number } | null = null;
 let mockSplitLoading = false;
+let mockSplitError: Error | null = null;
 let mockReorderedOrder: readonly `0x${string}`[] | null = null;
 let mockActivatingVaults = new Map<string, ActivatingEntry>();
 const mockClearReorderedOrder = vi.fn();
@@ -63,7 +64,7 @@ vi.mock("@/applications/aave/hooks", () => ({
   useVaultSplitParams: () => ({
     params: mockSplitParams,
     isLoading: mockSplitLoading,
-    error: null,
+    error: mockSplitError,
     refetch: async () => mockSplitParams,
   }),
 }));
@@ -105,6 +106,7 @@ describe("useDashboardState", () => {
     mockDebtValueUsd = 0;
     mockSplitParams = null;
     mockSplitLoading = false;
+    mockSplitError = null;
     mockReorderedOrder = null;
     mockActivatingVaults = new Map();
   });
@@ -283,5 +285,13 @@ describe("useDashboardState", () => {
     const { result } = renderHook(() => useDashboardState("0xabc"));
 
     expect(result.current.isBorrowCapacityLoading).toBe(true);
+  });
+
+  it("forwards the split-params error as borrowCapacityError", () => {
+    mockSplitError = new Error("split params failed");
+
+    const { result } = renderHook(() => useDashboardState("0xabc"));
+
+    expect(result.current.borrowCapacityError).toBe(mockSplitError);
   });
 });

--- a/services/vault/src/hooks/__tests__/useDashboardState.test.ts
+++ b/services/vault/src/hooks/__tests__/useDashboardState.test.ts
@@ -1,6 +1,11 @@
 import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import {
+  BPS_SCALE,
+  MIN_HEALTH_FACTOR_FOR_BORROW,
+} from "@/applications/aave/constants";
+
 import { useDashboardState } from "../useDashboardState";
 
 const stableFindProvider = vi.fn(() => undefined);
@@ -19,6 +24,9 @@ type ActivatingEntry = {
 // Mutable state read by the hoisted mocks below.
 let mockCollaterals: unknown[] | null = null;
 let mockCollateralBtc = 0;
+let mockCollateralValueUsd = 0;
+let mockDebtValueUsd = 0;
+let mockSplitParams: { THF: number; CF: number; LB: number } | null = null;
 let mockReorderedOrder: readonly `0x${string}`[] | null = null;
 let mockActivatingVaults = new Map<string, ActivatingEntry>();
 const mockClearReorderedOrder = vi.fn();
@@ -41,8 +49,8 @@ vi.mock("@/applications/aave/hooks", () => ({
   useAaveUserPosition: () => ({
     position: mockCollaterals ? { collaterals: mockCollaterals } : null,
     collateralBtc: mockCollateralBtc,
-    collateralValueUsd: 0,
-    debtValueUsd: 0,
+    collateralValueUsd: mockCollateralValueUsd,
+    debtValueUsd: mockDebtValueUsd,
     healthFactor: null,
     healthFactorStatus: null,
     isLoading: false,
@@ -50,6 +58,12 @@ vi.mock("@/applications/aave/hooks", () => ({
   useAaveBorrowedAssets: () => ({
     borrowedAssets: [],
     hasLoans: false,
+  }),
+  useVaultSplitParams: () => ({
+    params: mockSplitParams,
+    isLoading: false,
+    error: null,
+    refetch: async () => mockSplitParams,
   }),
 }));
 
@@ -86,6 +100,9 @@ describe("useDashboardState", () => {
     vi.clearAllMocks();
     mockCollaterals = null;
     mockCollateralBtc = 0;
+    mockCollateralValueUsd = 0;
+    mockDebtValueUsd = 0;
+    mockSplitParams = null;
     mockReorderedOrder = null;
     mockActivatingVaults = new Map();
   });
@@ -226,5 +243,35 @@ describe("useDashboardState", () => {
     expect(result.current.collateralVaults).toHaveLength(0);
     expect(result.current.displayCollateralBtc).toBe(0);
     expect(result.current.hasDisplayCollateral).toBe(false);
+  });
+
+  it("derives borrow capacity from collateral, debt, and split params", () => {
+    mockCollateralBtc = 1;
+    mockCollateralValueUsd = 10000;
+    mockDebtValueUsd = 2000;
+    mockSplitParams = { THF: 1.1, CF: 0.8, LB: 1.05 };
+
+    const { result } = renderHook(() => useDashboardState("0xabc"));
+
+    const expectedMaxTotalDebtUsd =
+      (10000 * Math.round(0.8 * BPS_SCALE)) /
+      BPS_SCALE /
+      MIN_HEALTH_FACTOR_FOR_BORROW;
+    expect(result.current.maxTotalDebtUsd).toBe(expectedMaxTotalDebtUsd);
+    expect(result.current.availableToBorrowUsd).toBe(
+      expectedMaxTotalDebtUsd - 2000,
+    );
+  });
+
+  it("reports zero borrow capacity while split params are unavailable", () => {
+    mockCollateralBtc = 1;
+    mockCollateralValueUsd = 10000;
+    mockDebtValueUsd = 0;
+    mockSplitParams = null;
+
+    const { result } = renderHook(() => useDashboardState("0xabc"));
+
+    expect(result.current.maxTotalDebtUsd).toBe(0);
+    expect(result.current.availableToBorrowUsd).toBe(0);
   });
 });

--- a/services/vault/src/hooks/useDashboardState.ts
+++ b/services/vault/src/hooks/useDashboardState.ts
@@ -46,8 +46,11 @@ export function useDashboardState(connectedAddress: string | undefined) {
     debtValueUsd,
   });
 
-  const { params: splitParams, isLoading: isBorrowCapacityLoading } =
-    useVaultSplitParams(connectedAddress);
+  const {
+    params: splitParams,
+    isLoading: isBorrowCapacityLoading,
+    error: borrowCapacityError,
+  } = useVaultSplitParams(connectedAddress);
   const liquidationThresholdBps = splitParams
     ? Math.round(splitParams.CF * BPS_SCALE)
     : 0;
@@ -178,6 +181,7 @@ export function useDashboardState(connectedAddress: string | undefined) {
     maxTotalDebtUsd,
     availableToBorrowUsd,
     isBorrowCapacityLoading,
+    borrowCapacityError,
     healthFactor,
     healthFactorStatus,
     borrowedAssets,

--- a/services/vault/src/hooks/useDashboardState.ts
+++ b/services/vault/src/hooks/useDashboardState.ts
@@ -46,7 +46,8 @@ export function useDashboardState(connectedAddress: string | undefined) {
     debtValueUsd,
   });
 
-  const { params: splitParams } = useVaultSplitParams(connectedAddress);
+  const { params: splitParams, isLoading: isBorrowCapacityLoading } =
+    useVaultSplitParams(connectedAddress);
   const liquidationThresholdBps = splitParams
     ? Math.round(splitParams.CF * BPS_SCALE)
     : 0;
@@ -176,6 +177,7 @@ export function useDashboardState(connectedAddress: string | undefined) {
     debtValueUsd,
     maxTotalDebtUsd,
     availableToBorrowUsd,
+    isBorrowCapacityLoading,
     healthFactor,
     healthFactorStatus,
     borrowedAssets,

--- a/services/vault/src/hooks/useDashboardState.ts
+++ b/services/vault/src/hooks/useDashboardState.ts
@@ -6,6 +6,7 @@
 
 import { useEffect, useMemo } from "react";
 
+import { BPS_SCALE } from "@/applications/aave/constants";
 import {
   useActivatingVaults,
   useReorderOverride,
@@ -13,8 +14,10 @@ import {
 import {
   useAaveBorrowedAssets,
   useAaveUserPosition,
+  useVaultSplitParams,
 } from "@/applications/aave/hooks";
 import type { Asset } from "@/applications/aave/types";
+import { calculateBorrowCapacityUsd } from "@/applications/aave/utils";
 import { useVaultProviders } from "@/hooks/deposit/useVaultProviders";
 import type { CollateralVaultEntry } from "@/types/collateral";
 import { truncateHash } from "@/utils/addressUtils";
@@ -41,6 +44,16 @@ export function useDashboardState(connectedAddress: string | undefined) {
   const { borrowedAssets, hasLoans } = useAaveBorrowedAssets({
     position,
     debtValueUsd,
+  });
+
+  const { params: splitParams } = useVaultSplitParams(connectedAddress);
+  const liquidationThresholdBps = splitParams
+    ? Math.round(splitParams.CF * BPS_SCALE)
+    : 0;
+  const { maxTotalDebtUsd, availableToBorrowUsd } = calculateBorrowCapacityUsd({
+    collateralValueUsd,
+    currentDebtUsd: debtValueUsd,
+    liquidationThresholdBps,
   });
 
   const { findProvider } = useVaultProviders();
@@ -161,6 +174,8 @@ export function useDashboardState(connectedAddress: string | undefined) {
     displayCollateralBtc,
     collateralValueUsd,
     debtValueUsd,
+    maxTotalDebtUsd,
+    availableToBorrowUsd,
     healthFactor,
     healthFactorStatus,
     borrowedAssets,


### PR DESCRIPTION
Replace OverviewSection's v2 gauge+rows with a single "Position" summary card.

The v3 Overview now shows only this summary plus safety notifications; the legacy supply-cap, pending deposit/withdrawal, collateral, and loans sections are hidden.

Available-to-borrow capacity is derived via a shared `calculateBorrowCapacityUsd` helper so the dashboard and the Borrow form can't drift.

Closes #2035

## Screenshot
<img width="2762" height="1700" alt="image" src="https://github.com/user-attachments/assets/d1488e5c-b9cf-410f-823c-0ad2a655c65e" />
