### PR TITLE
fix(vault): scrub vault-secret carrier keys by name in Sentry telemetry

### DIFF
--- a/services/vault/src/utils/__tests__/telemetry.test.ts
+++ b/services/vault/src/utils/__tests__/telemetry.test.ts
@@ -199,6 +199,79 @@ describe("redactData", () => {
   });
 });
 
+describe("redactData — vault-secret carrier keys", () => {
+  it("redacts the auth-anchor hex by field name, not just by regex length", () => {
+    const data = { authAnchorHex: "deadbeef".repeat(8) };
+    const result = redactData(data);
+    expect(result.authAnchorHex).toBe("dead...beef");
+  });
+
+  it("redacts the activation secret regardless of length", () => {
+    const data = { secret: "0x1234" };
+    const result = redactData(data);
+    expect(result.secret).toBe("[REDACTED]");
+  });
+
+  it("redacts the plural htlcSecretHexes array carrier that regex length would miss element-by-element", () => {
+    const data = { htlcSecretHexes: ["ab".repeat(32), "cd".repeat(32)] };
+    const result = redactData(data);
+    expect(result.htlcSecretHexes).toBe("[REDACTED]");
+  });
+
+  it("redacts a depositor pubkey alias not previously in the denylist", () => {
+    const data = { depositorBtcPubkeyRaw: "a".repeat(66) };
+    const result = redactData(data);
+    expect(result.depositorBtcPubkeyRaw).toBe("aaaa...aaaa");
+  });
+
+  it("redacts a vault root held as a Uint8Array under a named carrier key", () => {
+    const data = { vaultRoot: new Uint8Array(32).fill(255) };
+    const result = redactData(data);
+    expect(result.vaultRoot).toBe("[BINARY_REDACTED]");
+  });
+});
+
+describe("redactData — byte-valued number[] handling", () => {
+  it("redacts a 32-byte number[] that isBinary misses", () => {
+    const data = { payload: Array.from(new Uint8Array(32).fill(222)) };
+    const result = redactData(data);
+    expect(result.payload).toBe("[BINARY_REDACTED]");
+  });
+
+  it("redacts each inner byte array of a number[][] (Array.from WOTS terminals)", () => {
+    const data = {
+      perVaultWotsKeys: [
+        Array.from(new Uint8Array(20).fill(1)),
+        Array.from(new Uint8Array(20).fill(2)),
+      ],
+    };
+    const result = redactData(data);
+    expect(result.perVaultWotsKeys).toEqual([
+      "[BINARY_REDACTED]",
+      "[BINARY_REDACTED]",
+    ]);
+  });
+
+  it("redacts a byte-valued number[] held under a sensitive key with the binary signal", () => {
+    const data = { secretBytes: Array.from(new Uint8Array(32).fill(7)) };
+    const result = redactData(data);
+    expect(result.secretBytes).toBe("[BINARY_REDACTED]");
+  });
+
+  it("leaves a short numeric array (fee rates) readable", () => {
+    const data = { feeRates: [1, 2, 5, 10] };
+    const result = redactData(data);
+    expect(result.feeRates).toEqual([1, 2, 5, 10]);
+  });
+
+  it("leaves a long array of non-byte numbers (block heights) readable", () => {
+    const heights = Array.from({ length: 20 }, (_, i) => 840000 + i);
+    const data = { blockHeights: heights };
+    const result = redactData(data);
+    expect(result.blockHeights).toEqual(heights);
+  });
+});
+
 describe("scrubSentryEvent", () => {
   it("scrubs exception values", () => {
     const event: SentryEvent = {

--- a/services/vault/src/utils/telemetry.ts
+++ b/services/vault/src/utils/telemetry.ts
@@ -42,27 +42,65 @@ export function scrubString(value: string): string {
 }
 
 const SENSITIVE_FIELD_NAMES = new Set([
+  // Chain addresses.
   "address",
   "btcAddress",
   "ethAddress",
   "babylonAddress",
   "bech32Address",
+  // Depositor public keys — semi-sensitive via linkability; the x-only key is
+  // committed inside vaultContext (the deriveContextHash input).
   "publicKey",
   "pubKey",
   "userPublicKey",
   "depositorBtcPubkey",
+  "depositorBtcPubkeyRaw",
+  "depositorBtcPubkeyXOnly",
+  "depositorPubkey",
+  "verifiedBtcPubkeyRaw",
+  "verifiedDepositorBtcPubkeyRaw",
+  "signerXOnlyPubkeyHex",
+  "publicKeyNoCoord",
+  // Transactions.
   "txHash",
   "txHex",
   "peginTxHash",
   "rawTx",
+  // Vault-secret material derived from deriveContextHash (derive-vault-secrets.md).
+  // Listed under the exact keys these values travel on so scrubbing never depends
+  // on a value happening to be 64+ hex — a rename, truncation, or re-encoding by a
+  // future refactor must not silently defeat redaction.
   "seed",
+  "wotsSeed",
+  "secret",
   "secretHex",
+  "secretBytes",
   "htlcSecretHex",
+  "htlcSecretHexes",
+  "authAnchorHex",
+  "authAnchorBytes",
+  "auth_anchor",
+  "root",
+  "rootHex",
+  "rootDerivation",
+  "vaultRoot",
+  "contextHash",
+  "vaultContext",
+  "contextHex",
+  // Infrastructure.
   "rpcUrl",
   "endpoint",
 ]);
 
 const BINARY_PLACEHOLDER = "[BINARY_REDACTED]";
+
+/**
+ * Minimum length at which a plain number[] is treated as raw binary. 16 bytes
+ * (128 bits) is the smallest cryptographic secret size; shorter numeric arrays
+ * are far more likely to be genuine debugging data (fee rates, vault indices,
+ * counts) than key material, so they are left readable.
+ */
+const MIN_BYTE_ARRAY_LENGTH = 16;
 
 /**
  * Binary buffers hold raw secret material (WOTS seeds, HTLC preimages, signatures).
@@ -74,6 +112,28 @@ function isBinary(value: unknown): boolean {
 }
 
 /**
+ * A byte buffer in disguise: a plain number[] whose every element is an integer
+ * in 0..255. isBinary misses it (ArrayBuffer.isView is false for plain arrays),
+ * so without this check redactData would recurse and keep every byte as a plain
+ * number — leaking secret material that was converted via Array.from(uint8Array)
+ * (the WOTS terminals are already stored exactly this way). Applied at the
+ * MIN_BYTE_ARRAY_LENGTH floor so short numeric arrays stay readable.
+ */
+function isByteArray(value: unknown): boolean {
+  return (
+    Array.isArray(value) &&
+    value.length >= MIN_BYTE_ARRAY_LENGTH &&
+    value.every(
+      (element) =>
+        typeof element === "number" &&
+        Number.isInteger(element) &&
+        element >= 0 &&
+        element <= 255,
+    )
+  );
+}
+
+/**
  * Redact a value held under a known-sensitive key, whatever its type. Absent values are
  * passed through: reporting "[REDACTED]" for a field that was never set would send a
  * debugger looking for a value that does not exist.
@@ -82,7 +142,7 @@ function redactSensitiveValue(value: unknown): unknown {
   if (value === null || value === undefined) return value;
   // Preserve the "this was binary" signal for the fields most likely to hold raw secret
   // material, rather than collapsing it into the generic [REDACTED].
-  if (isBinary(value)) return BINARY_PLACEHOLDER;
+  if (isBinary(value) || isByteArray(value)) return BINARY_PLACEHOLDER;
   if (typeof value === "string") return redactIdentifier(value, true);
   return REDACTED_PLACEHOLDER;
 }
@@ -90,8 +150,9 @@ function redactSensitiveValue(value: unknown): unknown {
 /**
  * Recursively redact sensitive fields in a data object.
  * - Fields in SENSITIVE_FIELD_NAMES are redacted whatever their type: strings get
- *   identifier-level redaction (first4...last4), everything else becomes [REDACTED]
- * - Binary buffers are replaced wholesale, at any depth
+ *   identifier-level redaction (first4...last4), binary/byte-array values become
+ *   [BINARY_REDACTED], everything else becomes [REDACTED]
+ * - Binary buffers and byte-valued number[]s are replaced wholesale, at any depth
  * - All other string values get regex scrubbing for address/hex patterns
  */
 export function redactData<T>(obj: T): T {
@@ -101,7 +162,7 @@ export function redactData<T>(obj: T): T {
     return scrubString(obj) as T;
   }
 
-  if (isBinary(obj)) {
+  if (isBinary(obj) || isByteArray(obj)) {
     return BINARY_PLACEHOLDER as T;
   }
 

--- a/services/vault/src/utils/telemetry.ts
+++ b/services/vault/src/utils/telemetry.ts
@@ -80,7 +80,6 @@ const SENSITIVE_FIELD_NAMES = new Set([
   "authAnchorHex",
   "authAnchorBytes",
   "auth_anchor",
-  "root",
   "rootHex",
   "rootDerivation",
   "vaultRoot",


### PR DESCRIPTION
## Context

Continuation of the merged `fix/vault-sentry-enable-gate` work. A review note on the TBV dApp monitoring flagged that Sentry must not leak the semi-sensitive material derived via `deriveContextHash` (vault root, WOTS seed/keys, HTLC hashlock secret, auth-anchor preimage) - the data that should be held only by depositors.

## What I checked

Audited the full Sentry pipeline against the actual scrubbing in `telemetry.ts` and `sentry.client.config.ts`: every explicit `logger.*` sink, the default auto-capture integrations (global handlers, breadcrumbs, linked errors, http context) with tracing/replay off, and every representation of each secret across the derivation pipeline.

**Conclusion: no reachable leak today.** The truly-private material is held only as `Uint8Array` locals, zeroed with `.fill(0)`, and never placed on a serializable object; the binary check would catch it anyway. The live hex secrets never reach a sink.

## Why this PR, given there's no live bug

The protection was holding by coincidence, not by design:

- The live HTLC hashlock (`htlcSecretHexes`) and auth-anchor (`authAnchorHex`) hex are scrubbed **only** because they happen to be exactly 64 hex chars and the length-based regex catches them. The field-name denylist - the intended primary defense - never lists those keys. A rename, truncation, or re-encoding silently defeats redaction.
- Secrets converted to a plain `number[]` via `Array.from` bypass the `ArrayBuffer`-only binary check. This shape is **already live** in the code (`Array.from` on the WOTS terminals in `blockDerivation.ts`); only the sensitivity of what currently flows through it saves us.

The failure mode is silent and irreversible - user secret material at a third party, with no error and no failing test. This change is cheap insurance against that: one file plus tests. It is hardening, not a fix for an active vulnerability.

## What this changes

1. Adds the real carrier field names to `SENSITIVE_FIELD_NAMES` so redaction fires on the key, not on a value coincidentally looking like a hash.
2. Detects a byte-valued `number[]` (>=16 bytes, all `0..255`) and redacts it as binary. A length floor keeps genuine debugging arrays (fee rates, vault indices, counts) readable - see the guard tests.
3. 10 regression tests covering both, including over-redaction guards.

No change to what transmits today; latent gaps only.

## Deliberately out of scope

- The `.slice(0, 8)` truncated-hex fragments in the SDK's `tokenRegistry.ts` error messages: audited and refuted as a secret leak (the branch carrying secret-derived bytes cannot fire for a fixed `peginTxid` under deterministic derivation; the reachable branches carry only public on-chain keys).
- Re-enabling performance tracing / session replay: still correctly off; both would bypass this scrubbing and carry the depositor BTC address in request URLs / hrefs.

## Testing

- `pnpm --filter vault exec vitest run src/utils/__tests__/telemetry.test.ts` - 47 passed (10 new)
- eslint clean; `tsc -p tsconfig.lib.json` clean

Addresses the review note flagging Sentry secret-leak risk on the TBV dApp monitoring.
