### PR TITLE
feat(vault): add depositor funnel event tracking (Phase 1) to Sentry

### DIFF
--- a/services/vault/src/hooks/deposit/__tests__/useBroadcastState.test.ts
+++ b/services/vault/src/hooks/deposit/__tests__/useBroadcastState.test.ts
@@ -1,6 +1,7 @@
 import { act, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { TELEMETRY_EVENT } from "@/infrastructure/telemetryEvents";
 import { LocalStorageStatus } from "@/models/peginStateMachine";
 import type { VaultActivity } from "@/types/activity";
 
@@ -9,6 +10,9 @@ import { useBroadcastState } from "../useBroadcastState";
 const mockVaultHandleBroadcast = vi.fn();
 const mockSetOptimisticStatus = vi.fn();
 const mockUpdatePendingPeginStatus = vi.fn();
+// Hoisted: referenced inside the hoisted vi.mock("@/infrastructure") factory,
+// which runs before this module's plain const initializers.
+const mockLoggerEvent = vi.hoisted(() => vi.fn());
 
 vi.mock("../useVaultActions", () => ({
   useVaultActions: () => ({
@@ -30,7 +34,7 @@ vi.mock("@/storage/usePeginStorage", () => ({
 }));
 
 vi.mock("@/infrastructure", () => ({
-  logger: { error: vi.fn() },
+  logger: { error: vi.fn(), event: mockLoggerEvent },
 }));
 
 function activity(id: string): VaultActivity {
@@ -84,6 +88,39 @@ describe("useBroadcastState — batched broadcast", () => {
       );
     }
     expect(onSuccess).toHaveBeenCalledOnce();
+  });
+
+  it("emits a broadcast.succeeded milestone per batch sibling, not just the clicked vault", async () => {
+    // One Pre-PegIn tx confirms every sibling, so the funnel must record a
+    // broadcast milestone for each vaultId — otherwise a resumed multi-vault
+    // batch undercounts and its siblings reach activation with no broadcast.
+    mockVaultHandleBroadcast.mockImplementation(
+      async (params: { onShowSuccessModal: () => void }) => {
+        params.onShowSuccessModal();
+      },
+    );
+
+    const { result } = renderHook(() =>
+      useBroadcastState({
+        activity: activity("0xa"),
+        batchVaultIds: ["0xa", "0xb"],
+        depositorEthAddress: "0xdepositor",
+        onSuccess: vi.fn(),
+      }),
+    );
+
+    await act(async () => {
+      await result.current.handleBroadcast();
+    });
+
+    const broadcastEmits = mockLoggerEvent.mock.calls.filter(
+      ([name]) => name === TELEMETRY_EVENT.DEPOSIT_BROADCAST_SUCCEEDED,
+    );
+    expect(broadcastEmits).toHaveLength(2);
+    expect(broadcastEmits.map(([, ctx]) => ctx.vaultId)).toEqual([
+      "0xa",
+      "0xb",
+    ]);
   });
 
   it("broadcasts the shared transaction once for the whole batch", () => {

--- a/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
@@ -141,6 +141,7 @@ vi.mock("@/infrastructure", () => ({
     error: mockLoggerError,
     warn: vi.fn(),
     info: vi.fn(),
+    event: vi.fn(),
   },
 }));
 

--- a/services/vault/src/hooks/deposit/useBroadcastState.ts
+++ b/services/vault/src/hooks/deposit/useBroadcastState.ts
@@ -13,6 +13,7 @@ import { useCallback, useState } from "react";
 
 import { usePeginPolling } from "@/context/deposit/PeginPollingContext";
 import { logger } from "@/infrastructure";
+import { shortId, TELEMETRY_EVENT } from "@/infrastructure/telemetryEvents";
 import { LocalStorageStatus } from "@/models/peginStateMachine";
 import { usePeginStorage } from "@/storage/usePeginStorage";
 import type { VaultActivity } from "@/types/activity";
@@ -86,6 +87,15 @@ export function useBroadcastState({
           for (const id of batchVaultIds) {
             updatePendingPeginStatus(id, LocalStorageStatus.CONFIRMING);
             setOptimisticStatus(id, LocalStorageStatus.CONFIRMING);
+            // One broadcast confirms every sibling, so emit the milestone per
+            // vault (scalar vaultId) — matching the inline path — rather than
+            // only for the vault whose Broadcast button was clicked.
+            logger.event(TELEMETRY_EVENT.DEPOSIT_BROADCAST_SUCCEEDED, {
+              level: "info",
+              category: "deposit",
+              vaultId: shortId(id),
+              vaultCount: batchVaultIds.length,
+            });
           }
           setLocalBroadcasting(false);
           onSuccess();

--- a/services/vault/src/hooks/deposit/useDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useDepositFlow.ts
@@ -594,15 +594,21 @@ export function useDepositFlow(
             depositorBtcPubkey: batchResult.depositorBtcPubkey,
           }));
 
-        logger.event(TELEMETRY_EVENT.DEPOSIT_REGISTERED, {
-          level: "info",
-          category: "deposit",
-          batchId,
-          vaultIds: peginResults.map((r) => shortId(r.vaultId)),
-          providerId: shortId(primaryProvider),
-          ethTxHash: shortId(batchRegistration.ethTxHash),
-          vaultCount: peginResults.length,
-        });
+        // One milestone per vault (scalar vaultId) so the whole post-registration
+        // funnel — registered, broadcast, activated — joins on a single `vaultId`
+        // field. `deposit.started` stays batch-level (it fires before any vaultId
+        // exists); group the funnel by `batchId` and scale by `vaultCount`.
+        for (const peginResult of peginResults) {
+          logger.event(TELEMETRY_EVENT.DEPOSIT_REGISTERED, {
+            level: "info",
+            category: "deposit",
+            batchId,
+            vaultId: shortId(peginResult.vaultId),
+            providerId: shortId(primaryProvider),
+            ethTxHash: shortId(batchRegistration.ethTxHash),
+            vaultCount: peginResults.length,
+          });
+        }
 
         // ========================================================================
         // Step 4a: Persist pending pegins BEFORE broadcast and before any
@@ -755,14 +761,19 @@ export function useDepositFlow(
           );
         }
 
-        logger.event(TELEMETRY_EVENT.DEPOSIT_BROADCAST_SUCCEEDED, {
-          level: "info",
-          category: "deposit",
-          batchId,
-          prePeginTxid: shortId(prePeginBroadcastTxid),
-          vaultIds: peginResults.map((r) => shortId(r.vaultId)),
-          vaultCount: peginResults.length,
-        });
+        // Per vault (scalar vaultId) so each committed vault has a broadcast
+        // milestone that the per-vault stall alert can join against its
+        // activation.activated. All siblings share one Pre-PegIn tx/txid.
+        for (const peginResult of peginResults) {
+          logger.event(TELEMETRY_EVENT.DEPOSIT_BROADCAST_SUCCEEDED, {
+            level: "info",
+            category: "deposit",
+            batchId,
+            prePeginTxid: shortId(prePeginBroadcastTxid),
+            vaultId: shortId(peginResult.vaultId),
+            vaultCount: peginResults.length,
+          });
+        }
 
         // The mempool now knows our Pre-PegIn spent these outpoints, so the
         // next `/address/<addr>/utxo` fetch will exclude them. Invalidate

--- a/services/vault/src/hooks/deposit/useDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useDepositFlow.ts
@@ -43,6 +43,11 @@ import { COPY } from "@/copy";
 import { useProtocolGateState } from "@/hooks/useProtocolGate";
 import { UTXOS_QUERY_KEY } from "@/hooks/useUTXOs";
 import { logger } from "@/infrastructure";
+import {
+  amountBucket,
+  shortId,
+  TELEMETRY_EVENT,
+} from "@/infrastructure/telemetryEvents";
 import { LocalStorageStatus } from "@/models/peginStateMachine";
 import { validateMultiVaultDepositInputs } from "@/services/deposit/validations";
 import type { PayoutSigningProgress } from "@/services/vault/vaultPayoutSignatureService";
@@ -395,6 +400,17 @@ export function useDepositFlow(
         // Generate batch ID for tracking
         const batchId = uuidv4();
 
+        logger.event(TELEMETRY_EVENT.DEPOSIT_STARTED, {
+          level: "info",
+          category: "deposit",
+          batchId,
+          providerId: shortId(primaryProvider),
+          vaultCount: vaultAmounts.length,
+          amountBucket: amountBucket(
+            satoshiToBtcNumber(vaultAmounts.reduce((sum, a) => sum + a, 0n)),
+          ),
+        });
+
         // ========================================================================
         // Step 1: Get shared resources
         // ========================================================================
@@ -578,6 +594,16 @@ export function useDepositFlow(
             depositorBtcPubkey: batchResult.depositorBtcPubkey,
           }));
 
+        logger.event(TELEMETRY_EVENT.DEPOSIT_REGISTERED, {
+          level: "info",
+          category: "deposit",
+          batchId,
+          vaultIds: peginResults.map((r) => shortId(r.vaultId)),
+          providerId: shortId(primaryProvider),
+          ethTxHash: shortId(batchRegistration.ethTxHash),
+          vaultCount: peginResults.length,
+        });
+
         // ========================================================================
         // Step 4a: Persist pending pegins BEFORE broadcast and before any
         // further network calls. Saved immediately after ETH registration so
@@ -728,6 +754,15 @@ export function useDepositFlow(
             LocalStorageStatus.CONFIRMING,
           );
         }
+
+        logger.event(TELEMETRY_EVENT.DEPOSIT_BROADCAST_SUCCEEDED, {
+          level: "info",
+          category: "deposit",
+          batchId,
+          prePeginTxid: shortId(prePeginBroadcastTxid),
+          vaultIds: peginResults.map((r) => shortId(r.vaultId)),
+          vaultCount: peginResults.length,
+        });
 
         // The mempool now knows our Pre-PegIn spent these outpoints, so the
         // next `/address/<addr>/utxo` fetch will exclude them. Invalidate

--- a/services/vault/src/hooks/deposit/useVaultActions.ts
+++ b/services/vault/src/hooks/deposit/useVaultActions.ts
@@ -324,11 +324,10 @@ export function useVaultActions(): UseVaultActionsReturn {
         updatePendingPeginStatus(vaultId, nextStatus);
       }
 
-      logger.event(TELEMETRY_EVENT.DEPOSIT_BROADCAST_SUCCEEDED, {
-        level: "info",
-        category: "deposit",
-        vaultId: shortId(vaultId),
-      });
+      // The broadcast.succeeded milestone is emitted by the caller
+      // (useBroadcastState), which owns the full batchVaultIds set — one
+      // Pre-PegIn tx confirms every sibling, and this single-vault primitive
+      // cannot see them.
 
       // Show success modal and refetch
       onShowSuccessModal();

--- a/services/vault/src/hooks/deposit/useVaultActions.ts
+++ b/services/vault/src/hooks/deposit/useVaultActions.ts
@@ -32,6 +32,8 @@ import {
 import { getETHChain } from "@/config/network";
 import { COPY } from "@/copy";
 import { useProtocolGateState } from "@/hooks/useProtocolGate";
+import { logger } from "@/infrastructure";
+import { shortId, TELEMETRY_EVENT } from "@/infrastructure/telemetryEvents";
 
 import { getVaultFromChain } from "../../clients/eth-contract/btc-vault-registry/query";
 import { getOnChainPauseState } from "../../clients/eth-contract/pause-state/query";
@@ -322,6 +324,12 @@ export function useVaultActions(): UseVaultActionsReturn {
         updatePendingPeginStatus(vaultId, nextStatus);
       }
 
+      logger.event(TELEMETRY_EVENT.DEPOSIT_BROADCAST_SUCCEEDED, {
+        level: "info",
+        category: "deposit",
+        vaultId: shortId(vaultId),
+      });
+
       // Show success modal and refetch
       onShowSuccessModal();
       onRefetchActivities();
@@ -467,6 +475,12 @@ export function useVaultActions(): UseVaultActionsReturn {
       if (pendingPegin && updatePendingPeginStatus && nextStatus) {
         updatePendingPeginStatus(vaultId, nextStatus);
       }
+
+      logger.event(TELEMETRY_EVENT.ACTIVATION_ACTIVATED, {
+        level: "info",
+        category: "activation",
+        vaultId: shortId(vaultId),
+      });
 
       // Show success and refetch
       onShowSuccessModal();

--- a/services/vault/src/infrastructure/__tests__/telemetryEvents.test.ts
+++ b/services/vault/src/infrastructure/__tests__/telemetryEvents.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import { scrubString } from "../../utils/telemetry";
+import { amountBucket, shortId } from "../telemetryEvents";
+
+describe("amountBucket", () => {
+  it("buckets amounts into coarse BTC bands", () => {
+    expect(amountBucket(0.004)).toBe("<0.01");
+    expect(amountBucket(0.05)).toBe("0.01-0.1");
+    expect(amountBucket(0.5)).toBe("0.1-1");
+    expect(amountBucket(3)).toBe("1-5");
+    expect(amountBucket(9)).toBe("5+");
+  });
+
+  it("returns the lower band's label at each boundary (bands are half-open)", () => {
+    expect(amountBucket(0.01)).toBe("0.01-0.1");
+    expect(amountBucket(0.1)).toBe("0.1-1");
+    expect(amountBucket(1)).toBe("1-5");
+    expect(amountBucket(5)).toBe("5+");
+  });
+
+  it("returns 'unknown' for non-finite or negative input rather than a band", () => {
+    expect(amountBucket(NaN)).toBe("unknown");
+    expect(amountBucket(-1)).toBe("unknown");
+  });
+
+  it("never returns the raw amount", () => {
+    expect(amountBucket(1.23456789)).toBe("1-5");
+  });
+});
+
+describe("shortId", () => {
+  it("shortens a long identifier to first4...last4", () => {
+    const vaultId = "0x" + "a".repeat(64);
+    expect(shortId(vaultId)).toBe("0xaa...aaaa");
+  });
+
+  it("produces a form that survives scrubString (stays a usable join key)", () => {
+    // A raw ETH-address provider id and a raw keccak vaultId are both rewritten
+    // by scrubString; the shortened form must pass through unchanged.
+    const providerAddress = "0x742d35Cc6634C0532925a3b844Bc9e7595f2bD80";
+    const vaultId = "0x" + "b".repeat(64);
+
+    expect(scrubString(providerAddress)).toBe("[ETH_ADDR]");
+    expect(scrubString(vaultId)).toBe("[HEX_REDACTED]");
+
+    expect(scrubString(shortId(providerAddress))).toBe(
+      shortId(providerAddress),
+    );
+    expect(scrubString(shortId(vaultId))).toBe(shortId(vaultId));
+  });
+});

--- a/services/vault/src/infrastructure/telemetryEvents.ts
+++ b/services/vault/src/infrastructure/telemetryEvents.ts
@@ -1,0 +1,55 @@
+/**
+ * Sentry funnel event names and the helpers that keep depositor context safe
+ * to transmit.
+ *
+ * Event names are stable, machine-readable telemetry identifiers (not
+ * user-facing copy), so they live here rather than in copy.ts. Segments read
+ * `phase.stage.outcome`.
+ */
+
+import { redactIdentifier } from "@/utils/telemetry";
+
+export const TELEMETRY_EVENT = {
+  /** Depositor cleared every pre-flight guard; batchId minted (top of funnel). */
+  DEPOSIT_STARTED: "deposit.started",
+  /** Batch registered on Ethereum; vaultIds now exist (per-vault join point). */
+  DEPOSIT_REGISTERED: "deposit.registered",
+  /** Pre-PegIn broadcast to Bitcoin; depositor value is now committed. */
+  DEPOSIT_BROADCAST_SUCCEEDED: "deposit.broadcast.succeeded",
+  /** HTLC secret revealed on Ethereum; activation tx submitted (optimistic). */
+  ACTIVATION_ACTIVATED: "activation.activated",
+} as const;
+
+export type TelemetryEvent =
+  (typeof TELEMETRY_EVENT)[keyof typeof TELEMETRY_EVENT];
+
+/**
+ * Shorten a long identifier (vaultId, provider address, txid) to `first4...last4`
+ * before it enters event context. The embedded `...` breaks the address/hex
+ * patterns in `scrubString`, so a raw `0x`+40/64-hex id — which would otherwise
+ * be rewritten to `[ETH_ADDR]`/`[HEX_REDACTED]` and lost as a correlation key —
+ * survives scrubbing while staying a stable value to join on.
+ */
+export function shortId(value: string): string {
+  return redactIdentifier(value);
+}
+
+// Coarse BTC bands. Amounts are bucketed before emission so a depositor's exact
+// deposit size is never transmitted; the band is enough to segment the funnel.
+const BTC_BAND_SMALL = 0.01;
+const BTC_BAND_MEDIUM = 0.1;
+const BTC_BAND_LARGE = 1;
+const BTC_BAND_XLARGE = 5;
+
+/**
+ * Bucket a BTC amount into a coarse band for funnel segmentation. Never hand a
+ * raw amount to a telemetry event — the precise value is depositor-identifying.
+ */
+export function amountBucket(btc: number): string {
+  if (!Number.isFinite(btc) || btc < 0) return "unknown";
+  if (btc < BTC_BAND_SMALL) return "<0.01";
+  if (btc < BTC_BAND_MEDIUM) return "0.01-0.1";
+  if (btc < BTC_BAND_LARGE) return "0.1-1";
+  if (btc < BTC_BAND_XLARGE) return "1-5";
+  return "5+";
+}

--- a/services/vault/src/infrastructure/telemetryEvents.ts
+++ b/services/vault/src/infrastructure/telemetryEvents.ts
@@ -3,8 +3,9 @@
  * to transmit.
  *
  * Event names are stable, machine-readable telemetry identifiers (not
- * user-facing copy), so they live here rather than in copy.ts. Segments read
- * `phase.stage.outcome`.
+ * user-facing copy), so they live here rather than in copy.ts. Names are
+ * dot-delimited and lead with the funnel phase (`deposit` / `activation`),
+ * followed by the stage and, where it adds signal, the outcome.
  */
 
 import { redactIdentifier } from "@/utils/telemetry";

--- a/services/vault/src/utils/__tests__/telemetry.test.ts
+++ b/services/vault/src/utils/__tests__/telemetry.test.ts
@@ -197,6 +197,20 @@ describe("redactData", () => {
     expect(result.rpcUrl).toBeUndefined();
     expect(result.endpoint).toBeNull();
   });
+
+  it("redacts raw amounts, which the hex/address regexes cannot catch", () => {
+    const data = {
+      amountSats: 12345678n,
+      amountBtc: 1.5,
+      collateralAmount: "1,234.5",
+      vaultAmounts: [100000n, 200000n],
+    };
+    const result = redactData(data);
+    expect(result.amountSats).toBe("[REDACTED]");
+    expect(result.amountBtc).toBe("[REDACTED]");
+    expect(result.collateralAmount).toBe("[REDACTED]");
+    expect(result.vaultAmounts).toBe("[REDACTED]");
+  });
 });
 
 describe("scrubSentryEvent", () => {

--- a/services/vault/src/utils/telemetry.ts
+++ b/services/vault/src/utils/telemetry.ts
@@ -60,6 +60,15 @@ const SENSITIVE_FIELD_NAMES = new Set([
   "htlcSecretHex",
   "rpcUrl",
   "endpoint",
+  // Amounts — bucket before emitting. Raw values are depositor-identifying and,
+  // being numbers / bigints / number[], are not caught by the hex/address
+  // regexes, so the field-name denylist is their only backstop.
+  "amount",
+  "amountSats",
+  "amountBtc",
+  "collateralAmount",
+  "vaultAmounts",
+  "pegInAmounts",
 ]);
 
 const BINARY_PLACEHOLDER = "[BINARY_REDACTED]";


### PR DESCRIPTION
## Context

Part of the Sentry monitoring epic. The harness is enabled and the scrubbing is hardened; this begins the actual **funnel/event tracking**. An audit of the depositor lifecycle found there were **zero funnel success milestones** in the app - all 47 existing telemetry sinks are failure-captures or breadcrumbs, and the only `logger.event` calls anywhere were unrelated Chainlink price staleness. So there was no way to measure conversion, or to detect a deposit whose BTC is committed but never activates.

This PR is **Phase 1**: the value-at-risk spine plus the Phase 0 foundation the rest of the tracking builds on. It changes only what the app *transmits*; no product behavior changes.

## What it adds

Four scrubbed `logger.event` milestones:

| Event | When | Site |
| --- | --- | --- |
| `deposit.started` | pre-flight guards passed, `batchId` minted | `useDepositFlow.ts` |
| `deposit.registered` | ETH batch register, `vaultId`s minted (join point) | `useDepositFlow.ts` |
| `deposit.broadcast.succeeded` | Pre-PegIn broadcast to Bitcoin (**value committed**) | inline `useDepositFlow.ts` + resume `useVaultActions.ts` |
| `activation.activated` | HTLC secret revealed, activation tx submitted | `useVaultActions.ts` |

`broadcast` and `activation` are emitted at the shared `useVaultActions` / `useDepositFlow` choke points, so the inline and resume paths are each covered once (no double-count - they're mutually exclusive per deposit).

**The payoff:** primary conversion (`started → registered → broadcast.succeeded → activated`) and the value-at-risk stall alert - per `vaultId`, `broadcast.succeeded` observed with no `activation.activated` within N hours = committed BTC stalled = page.

## Phase 0 foundation (`telemetryEvents.ts`)

Two design constraints from the audit, both of which loop back to the scrubbing work:

1. **`shortId()`** emits `vaultId` / provider address / txid as `first4...last4`. A raw `vaultId` (`0x`+64hex) or provider ETH address (`0x`+40hex) would be rewritten by our own scrubber to `[HEX_REDACTED]` / `[ETH_ADDR]` and be useless as a join key; the embedded `...` dodges both regexes while staying a stable correlation id. (Tested: the shortened form survives `scrubString`.)
2. **`amountBucket()`** buckets amounts into coarse BTC bands before emission - a raw deposit amount is never transmitted. And because numbers dodge the hex/address regexes entirely, the raw amount carrier keys (`amount`, `amountSats`, `amountBtc`, `collateralAmount`, `vaultAmounts`, `pegInAmounts`) are added to the scrubber denylist as a backstop.

All event context is IDs-shortened or amount-bucketed; no raw address, pubkey, secret, txHex, or amount is emitted.

## Deliberately deferred

The polling-transition terminals - `deposit.completed` (ACTIVE-confirmed), `activation.verified`, the daemon/pegout terminal statuses - are **not** in this PR. They all need a persistent transition-diff (prev-vs-new status across poll cycles) to avoid inflating counts, so they're instrumented together in the polling layer in a follow-up, rather than bolted into a poll-driven render here. `activation.activated` (optimistic) already gives this PR's funnel a terminal and the stall alert its counterpart.

## Testing

- New `telemetryEvents.test.ts` (6 tests): amount bands + boundaries + the `shortId`-survives-`scrubString` guard.
- Amount-key redaction test added to `telemetry.test.ts`.
- Full vault suite green: **211 files, 2225 tests** (added the missing `logger.event` to the one predating mock).
- eslint clean; `tsc -p tsconfig.lib.json` clean.
