### PR TITLE
test(vault): withdraw E2E CLI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,6 +234,12 @@ These paths handle irreversible value movement. An AI-generated mistake here is 
 - **Components**: One component per file. File name matches component name.
 - **After changes**: Check for comments/docs that reference old behavior and update them.
 
+## E2E TEST HOOKS (`data-testid`)
+
+- Some `data-testid` attributes in `services/vault/src` are consumed by the real-wallet E2E CLI (`services/vault/e2e/real/`) to drive the depositor lifecycle (pegin / borrow / repay / withdraw). They are load-bearing test infrastructure, not decoration.
+- **If you move, rename, or re-implement an element that carries such a `data-testid`, carry the testid over to the equivalent control** — never silently drop it. Removing one breaks the E2E run with no compile error.
+- These sites are flagged with an inline comment pointing at the consuming action file; keep that comment attached to the testid.
+
 <!-- nx configuration start-->
 <!-- Leave the start & end comments to automatically receive updates. -->
 

--- a/services/vault/e2e/real/actions/index.ts
+++ b/services/vault/e2e/real/actions/index.ts
@@ -1,7 +1,6 @@
 /**
  * Registry of implemented actions: connect, observe, wallet-config, pegin, sign-conformance, borrow,
- * and repay. The remaining action (withdraw) is declared disabled in `config.ts` for the CLI's roadmap
- * display and registers here as it lands.
+ * repay, and withdraw.
  */
 import type { ActionId } from "../config";
 
@@ -13,6 +12,7 @@ import { repayAction } from "./repay";
 import { signConformanceAction } from "./signConformance";
 import type { Action } from "./types";
 import { walletConfigAction } from "./walletConfig";
+import { withdrawAction } from "./withdraw";
 
 export const ACTIONS_BY_ID: Partial<Record<ActionId, Action>> = {
   connect: connectAction,
@@ -22,4 +22,5 @@ export const ACTIONS_BY_ID: Partial<Record<ActionId, Action>> = {
   "sign-conformance": signConformanceAction,
   borrow: borrowAction,
   repay: repayAction,
+  withdraw: withdrawAction,
 };

--- a/services/vault/e2e/real/actions/pegin.ts
+++ b/services/vault/e2e/real/actions/pegin.ts
@@ -38,6 +38,7 @@ import {
   FORM_SETTLE_MS,
   PEGIN_POLL_INTERVAL_MS,
   PEGIN_STEP_MACHINE_BUDGET_MS,
+  PEGIN_TX_FAILURE_RETRY_LIMIT,
   PROVIDER_LIST_TIMEOUT_MS,
   SPLIT_ALLOCATION_TIMEOUT_MS,
   STEP_TIMEOUT_MS,
@@ -81,6 +82,14 @@ function activateButton(page: Page): Locator {
 const RISK_ACK_LABEL =
   "I understand the risks of continuing without the artifacts."; // riskAcknowledgement
 const SKIP_LABEL = "Skip"; // COPY.deposit.inStepArtifact.skip
+// The DepositProgressView's recoverable-error CTA: the fluid submit relabels to "Retry" (and calls
+// `onRetry`) whenever a step tx fails with a retryable error (COPY.deposit.progress.buttons.retry). It's
+// only rendered in that error state — during signing the CTA is "Sign Transaction"/processing/"Done" —
+// so its visible text is a safe, state-specific target (mirrors how the Activate/Skip gates are matched).
+const RETRY_BUTTON_RX = /^retry$/i; // COPY.deposit.progress.buttons.retry
+function retryButton(page: Page): Locator {
+  return page.getByRole("button", { name: RETRY_BUTTON_RX }).first();
+}
 // Finish-line matchers are tolerant regexes, NOT exact strings: the deployed build's copy can drift
 // from local source (e.g. the heading renders "Vault activated" on devnet vs "BTC Vault activated" in
 // copy.ts), and we key on the stable actionable control (the "Go to Dashboard" button) rather than the
@@ -457,6 +466,11 @@ async function walkStepMachine(
   // fire a duplicate ETH tx).
   let activateClickedThisModal = false;
   let skipClickedThisCallout = false;
+  // A recoverable "Transaction failed → Retry" state (e.g. the intermittent public-Sepolia RPC
+  // gas-estimation flake that nulls a tx's `gasLimit`). Re-armed per appearance like the gates above,
+  // and capped at PEGIN_TX_FAILURE_RETRY_LIMIT total so a genuinely-failing tx aborts instead of looping.
+  let retryClickedThisCallout = false;
+  let txRetryCount = 0;
   // Count the activations we've driven; the finish gate needs `expectedVaults` of them (see below).
   let activationCount = 0;
   let prePeginTxid: string | undefined;
@@ -512,6 +526,35 @@ async function walkStepMachine(
         skipClickedThisCallout = await handleArtifactSkip(page, log);
     } else {
       skipClickedThisCallout = false;
+    }
+
+    // Recover from a transient, app-retryable step-tx failure (e.g. the public-Sepolia RPC returning a
+    // null gasLimit on an activation tx): the progress view shows a "Transaction failed" callout with a
+    // Retry button that a human would just click. Click it — re-armed per appearance, capped at
+    // PEGIN_TX_FAILURE_RETRY_LIMIT so a persistently-failing tx aborts with the callout instead of
+    // spinning to the budget deadline. sweepApprovals (above) + the event approver confirm the wallet
+    // pop-up the retried tx re-opens. This does NOT touch `activationCount`: Retry re-runs the pending tx
+    // on the progress view, not the Activate modal, so a recovered activation stays counted exactly once.
+    const retryVisible = await retryButton(page)
+      .isVisible()
+      .catch(() => false);
+    if (retryVisible) {
+      if (!retryClickedThisCallout) {
+        if (txRetryCount >= PEGIN_TX_FAILURE_RETRY_LIMIT)
+          throw new Error(
+            `A step-machine transaction kept failing after ${PEGIN_TX_FAILURE_RETRY_LIMIT} retries — see the "Transaction failed" callout (a persistent RPC/gas-estimation or contract error, not a transient flake). trace.zip + the failure screenshot are captured.`,
+          );
+        txRetryCount += 1;
+        log(
+          `⚠️ Step-machine transaction failed — clicking Retry (${txRetryCount}/${PEGIN_TX_FAILURE_RETRY_LIMIT}) to recover from a transient tx/RPC failure`,
+        );
+        await retryButton(page)
+          .click({ timeout: STEP_TIMEOUT_MS })
+          .catch(() => {});
+        retryClickedThisCallout = true;
+      }
+    } else {
+      retryClickedThisCallout = false;
     }
 
     // Capture the Pre-PegIn txid once, the first tick the progress view links it.

--- a/services/vault/e2e/real/actions/withdraw.ts
+++ b/services/vault/e2e/real/actions/withdraw.ts
@@ -1,0 +1,472 @@
+/**
+ * The "withdraw" action: release active BTC-Vault collateral back to the depositor, end-to-end on real
+ * Sepolia. Withdraw is the lifecycle exit — it submits a SINGLE on-chain `withdrawCollaterals(vaultIds)`
+ * transaction (one MetaMask pop-up, NO Bitcoin signing); the vault provider then drives the Bitcoin
+ * claim → challenge → payout off-chain and the vault surfaces under "Pending Withdrawals".
+ *
+ * Shapes, selected by the CLI (the prerequisite legs run before the withdraw, each guarded so a failed
+ * leg aborts the run rather than withdrawing against a half-built position):
+ *   - AS-IS (default): withdraw against the current position. A vault is withdrawable while the projected
+ *     health factor after removing it stays ≥ 1.0 — so with NO debt every active vault is freely
+ *     withdrawable (mirrors src/applications/aave/utils/withdrawEligibility.ts). When the position still
+ *     carries debt, some/all vaults may be HF-gated; the modal's per-vault checkbox + the Review screen's
+ *     HF gate enforce that, and we surface it rather than guessing.
+ *   - REPAY-FIRST (`--repay-first`): repay the outstanding debt in full (the shared `runRepayFlow` with
+ *     the amount forced to Max), then withdraw — clearing the HF gate so collateral releases cleanly.
+ *   - BORROW-FIRST (`--borrow-first`): borrow (the shared `runBorrowWithOptionalPegin`), then repay that
+ *     loan in full, then withdraw — all in one session.
+ *   - PEGIN-FIRST (`--pegin-first`): peg in fresh collateral (optionally `--split` for two vaults) ahead
+ *     of the borrow, giving the full pegin → borrow → repay → withdraw lifecycle. The CLI's flag cascade
+ *     (`--pegin-first ⟹ --borrow-first ⟹ --repay-first`) sets these, so this action just runs whichever
+ *     legs are enabled in order.
+ *
+ * Click path (all modal-driven — unlike repay there is no route change):
+ *   Collateral "⋯" menu → "Withdraw" → selection modal (checkbox list of vaults) → "Withdraw {amount}"
+ *   → Review ("Confirm") → one MetaMask tx → "Withdrawal initiated" → "Done".
+ *
+ * Default selection is ONE vault (the first withdrawable), keeping the position alive for reuse;
+ * `--withdraw-all` ticks every selectable vault. Selectors are testid-first (added to the src withdraw
+ * controls, mirroring borrow/repay) with tolerant role/text fallbacks. No SDK / product logic is
+ * reimplemented — the live modal + Review HF gate are authoritative.
+ *
+ * NEVER run without an explicit go-ahead: it moves real value (releases BTC collateral + real withdraw gas).
+ */
+import type { BrowserContext, Page } from "@playwright/test";
+
+import { fetchCollateralSats } from "../borrowParams";
+import { formatBtc } from "../preflight";
+import {
+  FORM_SETTLE_MS,
+  MS_PER_SECOND,
+  STEP_TIMEOUT_MS,
+  WITHDRAW_CTA_ENABLE_TIMEOUT_MS,
+  WITHDRAW_MENU_TIMEOUT_MS,
+  WITHDRAW_MODAL_TIMEOUT_MS,
+  WITHDRAW_TX_TIMEOUT_MS,
+  WITHDRAW_VERIFY_POLL_MS,
+} from "../timing";
+
+import { installPopupApprover, sweepApprovals } from "./approver";
+import { runBorrowWithOptionalPegin } from "./borrow";
+import { startRecording } from "./recording";
+import { runRepayFlow } from "./repay";
+import { DONE_BUTTON_RX, firstByTestid, TX_FAILED_RX } from "./selectors";
+import { type Action, type ActionContext } from "./types";
+import { connectWallets } from "./walletConnect";
+
+// ── Withdraw selectors (testid-first; tolerant role/text fallbacks) ──────────────
+// Collateral summary card → "⋯" overflow menu (aria-label COPY.collateral.menu.triggerLabel).
+const COLLATERAL_ACTIONS_TESTID = '[data-testid="collateral-actions-button"]';
+const COLLATERAL_ACTIONS_RX = /collateral options/i;
+// The "Withdraw" item inside the "⋯" menu (COPY.collateral.menu.withdraw). Disabled only when the
+// protocol has paused withdrawals.
+const WITHDRAW_MENU_TESTID = '[data-testid="collateral-withdraw-button"]';
+const WITHDRAW_MENU_RX = /^withdraw$/i;
+// Per-vault selection row in the modal: `withdraw-vault-row-<vaultId>`, each with a trailing checkbox.
+const VAULT_ROW_TESTID_PREFIX = "withdraw-vault-row-";
+const VAULT_ROW_SELECTOR = `[data-testid^="${VAULT_ROW_TESTID_PREFIX}"]`;
+// The core-ui Checkbox renders a real <input type="checkbox">; it's `disabled` when the vault is not
+// selectable (not in use, or HF-gated), which is exactly how we tell a withdrawable vault apart.
+const VAULT_CHECKBOX_SELECTOR = 'input[type="checkbox"]';
+// The selection modal's "Withdraw {amount}" confirm (COPY.withdraw.modal.confirmButton*).
+const MODAL_CONFIRM_TESTID = '[data-testid="withdraw-modal-confirm-button"]';
+// The Review screen's "Confirm" submit + its blocking HF warning + the reason shown when confirm is off.
+const REVIEW_CONFIRM_TESTID = '[data-testid="withdraw-confirm-button"]';
+const HF_BLOCK_TESTID = '[data-testid="withdraw-hf-block-warning"]';
+const DISABLED_REASON_TESTID = '[data-testid="withdraw-disabled-reason"]';
+// Success screen: "Withdrawal initiated" (COPY.withdraw.initiated.title) + its Done button. Both are
+// unique to the withdraw progress view (not the shared LoanSuccessModal), so either safely marks success.
+const WITHDRAW_DONE_TESTID = '[data-testid="withdraw-done-button"]';
+const WITHDRAW_INITIATED_RX = /withdrawal initiated/i;
+
+/** Short form of a bytes32 vaultId for logs (e.g. `0x1234abcd…`). */
+function shortenVaultId(id: string): string {
+  return id.length > 12 ? `${id.slice(0, 10)}…` : id;
+}
+
+/**
+ * Open the withdraw flow from the dashboard: click the Collateral "⋯" menu, then its "Withdraw" item,
+ * and wait for the selection modal. The "⋯" trigger is only rendered when the position holds collateral,
+ * so we poll for it to appear AND enable within one window (not a short visibility wait before a long
+ * enable wait, which would abort early on a slow-to-render menu).
+ */
+async function openWithdraw(
+  page: Page,
+  log: (m: string) => void,
+): Promise<void> {
+  const trigger = firstByTestid(
+    page,
+    COLLATERAL_ACTIONS_TESTID,
+    page.getByRole("button", { name: COLLATERAL_ACTIONS_RX }),
+  );
+  const deadline = Date.now() + WITHDRAW_MENU_TIMEOUT_MS;
+  let ready = false;
+  while (!ready && Date.now() < deadline) {
+    if (await trigger.isVisible().catch(() => false))
+      ready = await trigger.isEnabled().catch(() => false);
+    if (!ready) await page.waitForTimeout(FORM_SETTLE_MS);
+  }
+  if (!ready)
+    throw new Error(
+      `The Collateral "⋯" actions menu stayed absent/disabled for ${Math.round(WITHDRAW_MENU_TIMEOUT_MS / MS_PER_SECOND)}s — this position has no active collateral to withdraw.`,
+    );
+  log('Opening the withdraw flow (Collateral → "⋯" → Withdraw)');
+  await trigger.click();
+
+  const menuItem = firstByTestid(
+    page,
+    WITHDRAW_MENU_TESTID,
+    page.getByRole("menuitem", { name: WITHDRAW_MENU_RX }),
+  );
+  await menuItem.waitFor({ state: "visible", timeout: STEP_TIMEOUT_MS });
+  if (!(await menuItem.isEnabled().catch(() => false)))
+    throw new Error(
+      "The Withdraw menu item is disabled — withdrawals are paused by the protocol right now.",
+    );
+  await menuItem.click();
+
+  const confirm = page.locator(MODAL_CONFIRM_TESTID).first();
+  const appeared = await confirm
+    .waitFor({ state: "visible", timeout: WITHDRAW_MODAL_TIMEOUT_MS })
+    .then(() => true)
+    .catch(() => false);
+  if (!appeared)
+    throw new Error(
+      `The withdraw selection modal did not open within ${Math.round(WITHDRAW_MODAL_TIMEOUT_MS / MS_PER_SECOND)}s after clicking Withdraw.`,
+    );
+  log("Withdraw selection modal opened");
+}
+
+/** Index of the first row with an enabled (selectable) checkbox, or -1 if none. */
+async function findSelectableRow(
+  rows: ReturnType<Page["locator"]>,
+  count: number,
+): Promise<number> {
+  for (let i = 0; i < count; i++) {
+    if (
+      await rows
+        .nth(i)
+        .locator(VAULT_CHECKBOX_SELECTOR)
+        .isEnabled()
+        .catch(() => false)
+    )
+      return i;
+  }
+  return -1;
+}
+
+/**
+ * Tick the vault checkbox(es) in the selection modal. A row's checkbox is `disabled` unless the vault is
+ * selectable (in use AND withdrawable without breaching HF) — the same eligibility the modal enforces —
+ * so we skip disabled rows. Default selects the FIRST selectable vault (keeps the position alive);
+ * `all` ticks every selectable one. Returns the selected `vaultId`s (read from the row testids). THROWS
+ * when nothing is selectable (all HF-gated or none in use).
+ *
+ * Polls for a selectable row first: after a chained `--repay-first` the app's position/HF read can lag
+ * the on-chain debt clear by a poll cycle, briefly leaving every vault HF-gated — so we wait for one to
+ * become selectable rather than mistaking that transient for "nothing withdrawable".
+ */
+async function selectVaults(
+  page: Page,
+  log: (m: string) => void,
+  all: boolean,
+): Promise<string[]> {
+  const rows = page.locator(VAULT_ROW_SELECTOR);
+  const deadline = Date.now() + WITHDRAW_CTA_ENABLE_TIMEOUT_MS;
+  let count = 0;
+  let firstSelectable = -1;
+  while (Date.now() < deadline) {
+    count = await rows.count();
+    if (count > 0) {
+      firstSelectable = await findSelectableRow(rows, count);
+      if (firstSelectable >= 0) break;
+    }
+    await page.waitForTimeout(FORM_SETTLE_MS);
+  }
+  if (count === 0)
+    throw new Error(
+      "The withdraw modal showed no vault rows — this position has nothing to withdraw.",
+    );
+  if (firstSelectable < 0)
+    throw new Error(
+      `No withdrawable vault in the modal after ${Math.round(WITHDRAW_CTA_ENABLE_TIMEOUT_MS / MS_PER_SECOND)}s (${count} shown — all are health-factor-gated or not in use). Repay outstanding debt first so collateral can be released.`,
+    );
+
+  const selectedIds: string[] = [];
+  for (let i = firstSelectable; i < count; i++) {
+    const row = rows.nth(i);
+    const checkbox = row.locator(VAULT_CHECKBOX_SELECTOR);
+    if (!(await checkbox.isEnabled().catch(() => false))) continue; // not selectable
+    // The input is visually replaced by an SVG (zero-size), so bypass actionability with force; check()
+    // is idempotent (ensures the box ends up ticked).
+    await checkbox.check({ force: true });
+    const testid = await row.getAttribute("data-testid").catch(() => null);
+    if (testid?.startsWith(VAULT_ROW_TESTID_PREFIX))
+      selectedIds.push(testid.slice(VAULT_ROW_TESTID_PREFIX.length));
+    if (!all) break;
+  }
+
+  log(
+    `Selected ${selectedIds.length} vault(s) to withdraw: ${selectedIds.map(shortenVaultId).join(", ")}`,
+  );
+  return selectedIds;
+}
+
+/**
+ * Click the selection modal's "Withdraw {amount}" confirm once it enables (a selection is made and the
+ * projected HF holds). On timeout, surface the modal's own disabled reason so a blocked run explains why.
+ */
+async function confirmSelection(
+  page: Page,
+  log: (m: string) => void,
+): Promise<void> {
+  const confirm = page.locator(MODAL_CONFIRM_TESTID).first();
+  const deadline = Date.now() + WITHDRAW_CTA_ENABLE_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    if (await confirm.isEnabled().catch(() => false)) {
+      log("Confirming the vault selection");
+      await confirm.click();
+      return;
+    }
+    await page.waitForTimeout(FORM_SETTLE_MS);
+  }
+  const reason = (
+    await page
+      .locator(DISABLED_REASON_TESTID)
+      .first()
+      .innerText()
+      .catch(() => "")
+  )
+    .replace(/\s+/g, " ")
+    .trim();
+  throw new Error(
+    `The withdraw modal's confirm button stayed disabled for ${Math.round(WITHDRAW_CTA_ENABLE_TIMEOUT_MS / MS_PER_SECOND)}s${reason ? ` — ${reason}` : ""}.`,
+  );
+}
+
+/**
+ * On the Review screen, wait for the "Confirm" submit to enable and click it. Fails fast if the blocking
+ * HF warning is present (the withdrawal would drop the health factor below the on-chain minimum) — that
+ * won't self-resolve by waiting.
+ */
+async function submitReview(
+  page: Page,
+  log: (m: string) => void,
+): Promise<void> {
+  const confirm = page.locator(REVIEW_CONFIRM_TESTID).first();
+  const hfBlock = page.locator(HF_BLOCK_TESTID).first();
+  const appeared = await confirm
+    .waitFor({ state: "visible", timeout: STEP_TIMEOUT_MS })
+    .then(() => true)
+    .catch(() => false);
+  if (!appeared)
+    throw new Error(
+      `The withdraw review screen did not appear within ${Math.round(STEP_TIMEOUT_MS / MS_PER_SECOND)}s after confirming the selection.`,
+    );
+
+  const deadline = Date.now() + WITHDRAW_CTA_ENABLE_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    if (await hfBlock.isVisible().catch(() => false))
+      throw new Error(
+        "Withdraw blocked on the review screen: this withdrawal would drop the health factor below the on-chain minimum. Repay debt or withdraw fewer vaults.",
+      );
+    if (await confirm.isEnabled().catch(() => false)) {
+      log(
+        "Review confirmed — submitting the withdraw transaction (the approver will confirm the MetaMask tx)",
+      );
+      await confirm.click();
+      return;
+    }
+    await page.waitForTimeout(FORM_SETTLE_MS);
+  }
+  throw new Error(
+    `The withdraw review's Confirm button stayed disabled for ${Math.round(WITHDRAW_CTA_ENABLE_TIMEOUT_MS / MS_PER_SECOND)}s.`,
+  );
+}
+
+/**
+ * After submitting, actively approve the single MetaMask withdraw pop-up (the approver's sweep confirms
+ * whatever appears), then wait for the "Withdrawal initiated" screen and click Done. Fails fast if the
+ * form surfaces a "Transaction failed" callout. Success is keyed ONLY on withdraw-specific markers (the
+ * "Withdrawal initiated" title or the `withdraw-done-button` testid); the generic Done role is only the
+ * click target after success is confirmed.
+ */
+async function confirmWithdrawSuccess(
+  page: Page,
+  context: BrowserContext,
+  log: (m: string) => void,
+): Promise<void> {
+  const initiated = page.getByText(WITHDRAW_INITIATED_RX).first();
+  const doneVisible = page.locator(WITHDRAW_DONE_TESTID).first();
+  const done = firstByTestid(
+    page,
+    WITHDRAW_DONE_TESTID,
+    page.getByRole("button", { name: DONE_BUTTON_RX }),
+  );
+  const txFailed = page.getByText(TX_FAILED_RX).first();
+  const deadline = Date.now() + WITHDRAW_TX_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    await sweepApprovals(context, page, log);
+
+    if (
+      (await initiated.isVisible().catch(() => false)) ||
+      (await doneVisible.isVisible().catch(() => false))
+    ) {
+      log("✅ Withdrawal initiated — clicking Done");
+      await done.click({ timeout: STEP_TIMEOUT_MS }).catch(() => {});
+      return;
+    }
+    if (await txFailed.isVisible().catch(() => false))
+      throw new Error(
+        "Withdraw transaction failed. See trace.zip + the failure screenshot.",
+      );
+    await page.waitForTimeout(FORM_SETTLE_MS);
+  }
+  throw new Error(
+    `Withdraw did not reach the "Withdrawal initiated" screen within ${Math.round(WITHDRAW_TX_TIMEOUT_MS / MS_PER_SECOND)}s — the MetaMask withdraw transaction may not have confirmed. See trace.zip + the failure screenshot.`,
+  );
+}
+
+/**
+ * After the success screen, verify on-chain that the position's collateral actually fell — the UI
+ * "Withdrawal initiated" alone doesn't prove the vault left the position. Polls `fetchCollateralSats`
+ * (on-chain `getPosition.totalCollateralBTC`) until it drops below the pre-withdraw baseline (inverse of
+ * borrow's collateral-rose wait). Never silently passes; throws if collateral doesn't move.
+ */
+async function assertCollateralDecreased(
+  ctx: ActionContext,
+  beforeSats: bigint,
+): Promise<void> {
+  const deadline = Date.now() + WITHDRAW_TX_TIMEOUT_MS;
+  let lastSats = beforeSats;
+  while (Date.now() < deadline) {
+    const sats = await fetchCollateralSats(
+      ctx.config.network,
+      ctx.eth.address,
+    ).catch(() => null);
+    if (sats != null) {
+      lastSats = sats;
+      if (sats < beforeSats) {
+        ctx.log(
+          `✅ On-chain collateral fell: ${formatBtc(beforeSats)} → ${formatBtc(sats)}.`,
+        );
+        return;
+      }
+    }
+    await ctx.page.waitForTimeout(WITHDRAW_VERIFY_POLL_MS);
+  }
+  throw new Error(
+    `Withdraw reached the success screen but on-chain collateral did not fall within ${Math.round(WITHDRAW_TX_TIMEOUT_MS / MS_PER_SECOND)}s (before ${formatBtc(beforeSats)}, last ${formatBtc(lastSats)}) — the position doesn't reflect the withdrawal.`,
+  );
+}
+
+/** Drive the withdraw flow proper (assumes wallets connected + approver/recorder installed by the caller). */
+export async function runWithdrawFlow(
+  ctx: ActionContext,
+  onStep: (step: string) => void,
+): Promise<void> {
+  const { page, context, log } = ctx;
+
+  onStep("withdraw-open");
+  await openWithdraw(page, log);
+
+  onStep("withdraw-select");
+  const selectedIds = await selectVaults(
+    page,
+    log,
+    ctx.config.withdrawAll === true,
+  );
+
+  // Snapshot on-chain collateral BEFORE submitting so we can assert it fell afterwards (a real-data
+  // post-condition on top of the UI success screen).
+  const collateralBeforeSats = await fetchCollateralSats(
+    ctx.config.network,
+    ctx.eth.address,
+  ).catch(() => null);
+
+  onStep("withdraw-modal-confirm");
+  await confirmSelection(page, log);
+
+  onStep("withdraw-review");
+  await submitReview(page, log);
+
+  await confirmWithdrawSuccess(page, context, log);
+
+  onStep("withdraw-verify");
+  if (collateralBeforeSats == null)
+    log(
+      "⚠️ Skipping the on-chain collateral check — couldn't read the pre-withdraw collateral to compare against.",
+    );
+  else await assertCollateralDecreased(ctx, collateralBeforeSats);
+
+  log(`Withdraw released ${selectedIds.length} vault(s).`);
+}
+
+export const withdrawAction: Action = {
+  id: "withdraw",
+  async run(ctx: ActionContext): Promise<void> {
+    const { page, context, log, artifactsDir } = ctx;
+
+    const handler = installPopupApprover(context, log);
+    let currentStep = "connect";
+    const recorder = await startRecording(
+      context,
+      page,
+      artifactsDir,
+      log,
+      () => currentStep,
+    );
+    try {
+      await connectWallets(ctx);
+
+      if (ctx.config.borrowFirst) {
+        log(
+          "Withdraw --borrow-first: borrowing before repay + withdraw" +
+            (ctx.config.peginFirst
+              ? " (pegging in fresh collateral first)"
+              : ""),
+        );
+        // The borrow (+ optional pegin) leg is a hard prerequisite: if it fails there is no new loan /
+        // collateral to unwind, so STOP — never fall through to repay + withdraw. runBorrowWithOptionalPegin
+        // throws on any pegin/borrow failure; we catch only to log the skip intent, then rethrow.
+        try {
+          await runBorrowWithOptionalPegin(ctx, (step) => {
+            currentStep = `borrow:${step}`;
+          });
+        } catch (error) {
+          log(
+            "❌ Borrow leg failed — stopping the run and SKIPPING repay + withdraw (no new loan/collateral to unwind).",
+          );
+          throw error;
+        }
+      }
+
+      if (ctx.config.repayFirst) {
+        log(
+          "Withdraw --repay-first: repaying the outstanding debt in full before withdrawing",
+        );
+        // The repay leg is a hard prerequisite: if it fails, the debt isn't cleared and the collateral
+        // stays health-factor-gated, so STOP here — never fall through to the withdraw. runRepayFlow
+        // throws on any repay failure; we catch only to log the skip intent, then rethrow.
+        try {
+          await runRepayFlow(ctx, (step) => {
+            currentStep = `repay:${step}`;
+          });
+        } catch (error) {
+          log(
+            "❌ Repay leg failed — stopping the run and SKIPPING withdraw (debt not cleared; collateral would be health-factor-gated).",
+          );
+          throw error;
+        }
+      }
+
+      await runWithdrawFlow(ctx, (step) => {
+        currentStep = step;
+      });
+      log("✅ Withdraw complete.");
+    } finally {
+      await recorder.stop();
+      context.off("page", handler);
+    }
+  },
+};

--- a/services/vault/e2e/real/actions/withdraw.ts
+++ b/services/vault/e2e/real/actions/withdraw.ts
@@ -79,9 +79,16 @@ const DISABLED_REASON_TESTID = '[data-testid="withdraw-disabled-reason"]';
 const WITHDRAW_DONE_TESTID = '[data-testid="withdraw-done-button"]';
 const WITHDRAW_INITIATED_RX = /withdrawal initiated/i;
 
+/** vaultId log form: keep the first N chars (0x + 8 hex), then elide the rest with "…". */
+const VAULT_ID_LOG_PREFIX_LEN = 10;
+/** Only shorten a vaultId longer than this — a short/blank id logs whole. */
+const VAULT_ID_LOG_MIN_LEN = 12;
+
 /** Short form of a bytes32 vaultId for logs (e.g. `0x1234abcd…`). */
 function shortenVaultId(id: string): string {
-  return id.length > 12 ? `${id.slice(0, 10)}…` : id;
+  return id.length > VAULT_ID_LOG_MIN_LEN
+    ? `${id.slice(0, VAULT_ID_LOG_PREFIX_LEN)}…`
+    : id;
 }
 
 /**

--- a/services/vault/e2e/real/cli.ts
+++ b/services/vault/e2e/real/cli.ts
@@ -24,6 +24,14 @@
  * also honors the borrow extras above), `--repay-token=<symbol>` (from the depositor's outstanding
  * loans; default = the sole loan, or the borrowed token under --borrow-first) and `--repay-amount=<n>|max`
  * (`max` clicks the form's Max for a full clear; default = a conservative fraction of the debt).
+ *
+ * Withdraw releases active BTC-Vault collateral (a single on-chain tx; the vault provider drives the
+ * Bitcoin payout afterward). It chains prerequisite legs via the cascade `--pegin-first ⟹ --borrow-first
+ * ⟹ --repay-first` (a deeper flag implies the shallower legs): `--repay-first` repays outstanding debt in
+ * full first; `--borrow-first` borrows (honoring the borrow extras) then repays that loan; `--pegin-first`
+ * pegs in fresh collateral (honoring the pegin extras, incl. `--split`) then borrows + repays — the full
+ * pegin → borrow → repay → withdraw cycle. `--withdraw-all` releases every selectable vault (default = a
+ * single vault, keeping the position alive).
  */
 import { createInterface, type Interface } from "node:readline/promises";
 
@@ -258,11 +266,19 @@ async function resolveConfig(
       delayMs = Math.max(0, Math.round((Number(raw) || 0) * MS_PER_SECOND));
     }
 
-    // Repay: borrow first (then repay the new loan), or repay an existing loan? Resolved BEFORE the
-    // pegin/collateral choice below because it decides whether a borrow (and thus a possible pegin)
-    // happens at all. `--borrow-first` wins; else prompt (default = repay an existing loan).
+    // ── Prerequisite legs (which actions run before the primary one) ──────────────
+    // `borrowFirst`/`peginFirst`/`repayFirst` gate the pegin + borrow extras below and the run.ts
+    // pre-flights. Resolved BEFORE those because they decide whether a borrow (and thus a possible pegin,
+    // and the loan-token lookup) happens at all.
+    //   repay:    --borrow-first (borrow a new loan, then repay it), optionally with --pegin-first.
+    //   withdraw: cascade --pegin-first ⟹ --borrow-first ⟹ --repay-first — a deeper flag implies every
+    //             shallower leg (pegin → borrow → repay → withdraw).
     let borrowFirst = false;
+    let peginFirst = false;
+    let repayFirst = false;
+
     if (action === "repay") {
+      // borrow-first: flag wins, else prompt (default = repay an existing loan).
       if (flags["borrow-first"] !== undefined) {
         borrowFirst = flagBool(flags["borrow-first"]);
       } else if (interactive) {
@@ -274,13 +290,30 @@ async function resolveConfig(
       }
     }
 
-    // Peg in first, or borrow against existing collateral? Applies to any run that borrows — a `borrow`
-    // run, or a `repay --borrow-first` run. Resolved early because it decides whether the pegin extras
-    // below are collected. `--pegin-first` wins; else prompt (default = reuse existing collateral).
+    if (action === "withdraw") {
+      // Cascade: a flag at any depth implies every shallower leg.
+      peginFirst = flagBool(flags["pegin-first"]);
+      borrowFirst = flagBool(flags["borrow-first"]) || peginFirst;
+      repayFirst = flagBool(flags["repay-first"]) || borrowFirst;
+      // No chain flag → offer the common repay-first choice interactively (deeper chains are flag-only).
+      if (!repayFirst && interactive)
+        repayFirst =
+          (await select<"asis" | "repay">(rl, "Withdraw collateral", [
+            { value: "asis", label: "Withdraw against the current position" },
+            {
+              value: "repay",
+              label: "Repay outstanding debt first, then withdraw",
+            },
+          ])) === "repay";
+    }
+
+    // Peg in first, or borrow against existing collateral? Applies to any run that draws a loan — a
+    // `borrow` run, or a `repay`/`withdraw` with --borrow-first. Withdraw already resolved `peginFirst`
+    // above via the cascade; borrow/repay resolve it here (flag wins, else prompt, default = reuse).
     const willBorrow =
-      action === "borrow" || (action === "repay" && borrowFirst);
-    let peginFirst = false;
-    if (willBorrow) {
+      action === "borrow" ||
+      ((action === "repay" || action === "withdraw") && borrowFirst);
+    if (willBorrow && action !== "withdraw") {
       if (flags["pegin-first"] !== undefined) {
         peginFirst = flagBool(flags["pegin-first"]);
       } else if (interactive) {
@@ -394,7 +427,7 @@ async function resolveConfig(
     }
 
     // Borrow extras: token (from the live borrowable list) + an explicit amount passthrough. Collected
-    // for any run that borrows (`willBorrow`: a `borrow` run, or a `repay --borrow-first` run). The amount
+    // for any run that borrows (`willBorrow`: a `borrow` run, or a `repay`/`withdraw` --borrow-first). The amount
     // DEFAULT (a conservative fraction of the max) needs the depositor's ETH address, which isn't known
     // until wallet import — so it's resolved later; here we only carry an explicit --borrow-amount
     // (a number, or "max" for the form's Max button) through.
@@ -455,7 +488,7 @@ async function resolveConfig(
       typeof flags["repay-token"] === "string"
         ? flags["repay-token"]
         : undefined;
-    const repayAmount =
+    let repayAmount =
       typeof flags["repay-amount"] === "string"
         ? flags["repay-amount"]
         : undefined;
@@ -466,11 +499,19 @@ async function resolveConfig(
           `--repay-amount must be a positive number of tokens or "max" (got "${repayAmount}")`,
         );
     }
-    if (action === "repay" && !borrowFirst) {
+    // Withdraw with any repay leg clears the debt in full by default so collateral is no longer health-
+    // factor-gated (an explicit --repay-amount still wins if a partial repay + withdraw is intended).
+    if (action === "withdraw" && repayFirst && repayAmount === undefined)
+      repayAmount = "max";
+    // Resolve/validate the loan token for any run that repays an EXISTING loan: `repay` or `withdraw
+    // --repay-first`. Excludes --borrow-first (repay OR withdraw), whose loan is created during the run —
+    // that case defaults `repayToken` to the borrowed token below instead.
+    const resolveExistingLoanToken =
+      (action === "repay" && !borrowFirst) ||
+      (action === "withdraw" && repayFirst && !borrowFirst);
+    if (resolveExistingLoanToken) {
       // Fetch the depositor's outstanding loans up front so an explicit --repay-token is VALIDATED
       // before the run, and so an unspecified token can be picked from the list (menu / sole loan).
-      // Skipped for --borrow-first: the loan is created during the run, so `repayToken` defaults to the
-      // borrowed token (below) rather than being validated against the current (pre-borrow) loans.
       // Unlike borrow's address-independent reserve list, the loans are position-specific, so we derive
       // the ETH address from the wallet mnemonic (the same derivation the balance pre-flight uses) — the
       // real run in run.ts re-derives it as ground truth. Best-effort: any read/derivation failure warns
@@ -512,13 +553,22 @@ async function resolveConfig(
               : debts[0].symbol;
       }
     }
-    // For `repay --borrow-first`, repay the token we just borrowed unless the user overrode --repay-token.
-    if (action === "repay" && borrowFirst && repayToken === undefined)
+    // For a --borrow-first run (`repay` or `withdraw`), repay the token we just borrowed unless the user
+    // overrode --repay-token.
+    if (
+      (action === "repay" || action === "withdraw") &&
+      borrowFirst &&
+      repayToken === undefined
+    )
       repayToken = borrowToken;
 
     // Sign-conformance extra: explicit fixtures file (else the action auto-detects the newest pegin's).
     const fixturesPath =
       typeof flags.fixtures === "string" ? flags.fixtures : undefined;
+
+    // Withdraw extra: release every selectable vault (default = a single vault, keeping the position alive).
+    const withdrawAll =
+      action === "withdraw" && flagBool(flags["withdraw-all"]);
 
     return {
       target,
@@ -538,6 +588,8 @@ async function resolveConfig(
       borrowFirst,
       repayToken,
       repayAmount,
+      repayFirst,
+      withdrawAll,
     };
   } finally {
     rl.close();

--- a/services/vault/e2e/real/config.ts
+++ b/services/vault/e2e/real/config.ts
@@ -115,7 +115,7 @@ export const ACTIONS: ActionOption[] = [
   },
   { id: "borrow", label: "Borrow", enabled: true },
   { id: "repay", label: "Repay", enabled: true },
-  { id: "withdraw", label: "Withdraw", enabled: false },
+  { id: "withdraw", label: "Withdraw", enabled: true },
 ];
 
 /** A fully-resolved run: what the user chose (interactively or via flags). */
@@ -160,6 +160,17 @@ export interface RunConfig {
    * When absent the CLI defaults to a conservative fraction of the outstanding debt (see repayParams).
    */
   repayAmount?: string;
+  /**
+   * Withdraw only: repay the outstanding debt in full (`--repay-first`) before withdrawing, so collateral
+   * is no longer health-factor-gated. When set, the repay leg reuses the repay flow with `repayAmount`
+   * forced to `max`; `repayToken` defaults to the sole/first outstanding loan.
+   */
+  repayFirst?: boolean;
+  /**
+   * Withdraw only: release every selectable vault (`--withdraw-all`) instead of just the first
+   * withdrawable one. Default (absent) withdraws a single vault, keeping the position alive for reuse.
+   */
+  withdrawAll?: boolean;
 }
 
 /** Resolve the target URL a run should open. */

--- a/services/vault/e2e/real/run.ts
+++ b/services/vault/e2e/real/run.ts
@@ -26,6 +26,7 @@ import {
 import { loadWalletSecrets } from "./secrets";
 import { importWallets } from "./wallets";
 import { maximizeWindow } from "./windowUtils";
+import { fetchWithdrawContext } from "./withdrawParams";
 
 export async function runE2E(config: RunConfig): Promise<void> {
   const action = ACTIONS_BY_ID[config.action];
@@ -96,7 +97,8 @@ export async function runE2E(config: RunConfig): Promise<void> {
     // `repay --borrow-first --pegin-first`), so it's subject to the same cap.
     const willBorrow =
       config.action === "borrow" ||
-      (config.action === "repay" && config.borrowFirst);
+      ((config.action === "repay" || config.action === "withdraw") &&
+        config.borrowFirst);
     const willPegin =
       config.action === "pegin" || (willBorrow && config.peginFirst);
     if (willPegin) {
@@ -172,6 +174,56 @@ export async function runE2E(config: RunConfig): Promise<void> {
           );
         artifacts.log(
           `Repay debt: current debt $${repayContext.currentDebtUsd.toFixed(2)} (collateral $${repayContext.collateralUsd.toFixed(2)}).`,
+        );
+      }
+    }
+
+    // Withdraw pre-flight (withdraw run, EXCEPT --pegin-first — which pegs in the collateral DURING the
+    // run, so there's nothing to read yet; the max-vault cap gate above covers that pegin). Read the
+    // position from real data and refuse a doomed run BEFORE the browser if there's no active collateral
+    // to release. A fetch failure is non-fatal: the absent "⋯" menu + the modal's per-vault eligibility
+    // backstop it, so we warn. The debt handling depends on the chain: --borrow-first creates the debt
+    // during the run (nothing to require here); --repay-first needs an EXISTING debt to clear; a plain
+    // withdraw with lingering debt is only HF-gated (a heads-up, not a hard block). Which vault(s) to
+    // release is resolved inside the action.
+    if (config.action === "withdraw" && !config.peginFirst) {
+      const withdrawContext = await fetchWithdrawContext(
+        config.network,
+        balances.eth.address,
+      ).catch((error) => {
+        artifacts.log(
+          `⚠️ Could not pre-check withdraw collateral (${error instanceof Error ? error.message : error}); the form will gate it.`,
+        );
+        return undefined;
+      });
+      if (withdrawContext) {
+        if (!withdrawContext.hasCollateral)
+          throw new Error(
+            "No collateral to withdraw: this position holds no active BTC Vaults. Peg in (and activate) first, re-run with --pegin-first, or withdraw with a different ETH account that has collateral.",
+          );
+        if (config.borrowFirst) {
+          // The borrow leg creates the debt during the run (collateral already gated above + by the borrow
+          // collateral pre-flight); the repay leg then clears it before withdrawing.
+          artifacts.log(
+            "Withdraw --borrow-first: will borrow, repay in full, then release collateral.",
+          );
+        } else if (config.repayFirst) {
+          // --repay-first clears an EXISTING debt during the run. Refuse if there's nothing to repay — the
+          // repay leg would fail on an absent Repay button; run plain withdraw instead.
+          if (!withdrawContext.hasDebt)
+            throw new Error(
+              "Withdraw --repay-first: this position has no outstanding debt to repay. Re-run without --repay-first (plain --action=withdraw).",
+            );
+          artifacts.log(
+            `Withdraw --repay-first: will clear $${withdrawContext.currentDebtUsd.toFixed(2)} debt, then release collateral.`,
+          );
+        } else if (withdrawContext.hasDebt) {
+          artifacts.log(
+            `⚠️ Position carries $${withdrawContext.currentDebtUsd.toFixed(2)} debt — withdraw is health-factor-gated, so some/all vaults may not be selectable. Re-run with --repay-first for a clean release.`,
+          );
+        }
+        artifacts.log(
+          `Withdraw collateral: ${withdrawContext.vaultCount} vault(s), ${withdrawContext.collateralSats} sats.`,
         );
       }
     }

--- a/services/vault/e2e/real/timing.ts
+++ b/services/vault/e2e/real/timing.ts
@@ -67,6 +67,14 @@ export const PEGIN_STEP_MACHINE_BUDGET_MS = 2.5 * 60 * 60 * 1_000;
 /** How often to poll the progress UI (advance the step log, handle the Activate/Skip dapp gates). */
 export const PEGIN_POLL_INTERVAL_MS = 3_000;
 /**
+ * How many times to click a step-machine "Transaction failed → Retry" before giving up. A recoverable
+ * failure here is almost always the intermittent public-Sepolia RPC gas-estimation flake (a null
+ * `gasLimit` on an activation/step tx), which clears on a retry — the app offers a Retry button for
+ * exactly this. A genuinely-failing tx exhausts these retries and the run aborts with the callout
+ * instead of spinning to the multi-hour step-machine budget.
+ */
+export const PEGIN_TX_FAILURE_RETRY_LIMIT = 3;
+/**
  * The activated vault to surface as collateral on the dashboard after "Go to Dashboard" — it appears
  * optimistically ("Activating collateral…") but can lag the indexer catching up.
  */
@@ -130,6 +138,31 @@ export const REPAY_CTA_ENABLE_TIMEOUT_MS = 90_000;
 export const REPAY_TX_TIMEOUT_MS = 120_000;
 /** Poll cadence for the on-chain "debt fell" post-condition check after the success screen. */
 export const REPAY_VERIFY_POLL_MS = 3_000;
+
+// ── withdraw ───────────────────────────────────────────────────────────────────
+/**
+ * The Collateral "⋯" actions menu to appear + enable on the dashboard. It's only RENDERED when the
+ * position holds collateral, so after a chained repay/borrow it can lag while the position settles;
+ * generous so a slow-to-render menu isn't mistaken for "no collateral" (a hard fail).
+ */
+export const WITHDRAW_MENU_TIMEOUT_MS = 30_000;
+/** The withdraw selection modal to render after clicking the "Withdraw" menu item. */
+export const WITHDRAW_MODAL_TIMEOUT_MS = 15_000;
+/**
+ * A withdraw CTA (the modal's "Withdraw {amount}" confirm, then the Review "Confirm") to enable after a
+ * selection is made — the Review screen recomputes the projected health factor + fees first. Generous so
+ * a slow risk-param read isn't mistaken for a blocked withdrawal; a genuine HF breach fails fast via the
+ * block warning.
+ */
+export const WITHDRAW_CTA_ENABLE_TIMEOUT_MS = 90_000;
+/**
+ * The single withdraw ETH transaction to confirm on Sepolia (the approver confirms the MetaMask pop-up →
+ * the app shows "Withdrawal initiated"). One tx, so a minute-plus is ample; a stuck tx fails the run
+ * (trace captured) instead of hanging. Reused as the on-chain collateral-fell verification budget.
+ */
+export const WITHDRAW_TX_TIMEOUT_MS = 90_000;
+/** Poll cadence for the post-withdraw on-chain collateral-fell check (a light `getPosition` read). */
+export const WITHDRAW_VERIFY_POLL_MS = 3_000;
 
 // ── sign-conformance (per-wallet signing replay) ─────────────────────────────
 /**

--- a/services/vault/e2e/real/withdrawParams.ts
+++ b/services/vault/e2e/real/withdrawParams.ts
@@ -1,0 +1,60 @@
+/**
+ * Withdraw-parameter pre-flight: read the depositor's active BTC-Vault collateral + outstanding debt for
+ * the selected network — the SAME on-chain sources the web app uses — so the CLI can refuse a doomed
+ * withdraw (no collateral) and warn when debt would health-factor-gate the release, before launching the
+ * browser.
+ *
+ * Withdraw releases collateral via a single on-chain `withdrawCollaterals(vaultIds)` tx (no BTC signing;
+ * the vault provider drives the Bitcoin payout off-chain afterward). A vault is withdrawable while the
+ * projected health factor stays ≥ 1.0 — so with NO debt every active vault is freely withdrawable
+ * (mirrors src/applications/aave/utils/withdrawEligibility.ts). This read is best-effort: the live
+ * Withdraw modal (its per-vault checkbox eligibility + the Review HF gate) is authoritative.
+ */
+import { fetchBorrowContext, openPosition } from "./borrowParams";
+import { type NetworkName } from "./config";
+
+/** The depositor's withdraw-relevant on-chain state (active collateral + debt). */
+export interface WithdrawContext {
+  /** True when the position holds active BTC-Vault collateral (`totalCollateralBTC > 0`) — the same
+   *  condition that makes the Collateral "⋯" → Withdraw menu meaningful. */
+  hasCollateral: boolean;
+  /** On-chain BTC collateral in sats (`getPosition.totalCollateralBTC`); falls after a withdraw. */
+  collateralSats: bigint;
+  /** Number of active BTC Vaults in the position (each a selectable row in the Withdraw modal). */
+  vaultCount: number;
+  /** True when the position carries outstanding debt — withdraw is then HF-gated (repay first to clear). */
+  hasDebt: boolean;
+  /** Aggregate outstanding debt in USD (0 when none). */
+  currentDebtUsd: number;
+}
+
+/**
+ * Read the depositor's active collateral + debt on `network`. Uses the same on-chain reads as the
+ * borrow/repay pre-flights (`openPosition` for the vault list + sats, `fetchBorrowContext` for the
+ * aggregate debt). Returns a `hasCollateral:false` context when the position doesn't exist / holds no
+ * collateral. THROWS on a genuine read failure rather than defaulting (the caller treats this as best-
+ * effort and warns).
+ */
+export async function fetchWithdrawContext(
+  network: NetworkName,
+  ethAddress: string,
+): Promise<WithdrawContext> {
+  const { position } = await openPosition(network, ethAddress);
+  if (!position || position.totalCollateralBTC <= 0n)
+    return {
+      hasCollateral: false,
+      collateralSats: 0n,
+      vaultCount: 0,
+      hasDebt: false,
+      currentDebtUsd: 0,
+    };
+
+  const { currentDebtUsd } = await fetchBorrowContext(network, ethAddress);
+  return {
+    hasCollateral: true,
+    collateralSats: position.totalCollateralBTC,
+    vaultCount: position.vaultIds.length,
+    hasDebt: currentDebtUsd > 0,
+    currentDebtUsd,
+  };
+}

--- a/services/vault/src/components/simple/WithdrawFlow/WithdrawProgressView.tsx
+++ b/services/vault/src/components/simple/WithdrawFlow/WithdrawProgressView.tsx
@@ -55,11 +55,13 @@ export function WithdrawProgressView({
           </Text>
         </div>
 
+        {/* This control's data-testid is a real-wallet E2E hook (e2e/real/actions/withdraw.ts) — carry it over if you move or rename the element. */}
         <Button
           variant="contained"
           color="secondary"
           className="w-full"
           onClick={onClose}
+          data-testid="withdraw-done-button"
         >
           {copy.doneButton}
         </Button>

--- a/services/vault/src/components/simple/WithdrawFlow/WithdrawReviewContent.tsx
+++ b/services/vault/src/components/simple/WithdrawFlow/WithdrawReviewContent.tsx
@@ -208,12 +208,14 @@ export function WithdrawReviewContent({
             </Text>
           )}
 
+          {/* This control's data-testid is a real-wallet E2E hook (e2e/real/actions/withdraw.ts) — carry it over if you move or rename the element. */}
           <Button
             variant="contained"
             color="secondary"
             className="w-full"
             disabled={isProcessing || wouldBreachHF}
             onClick={onConfirm}
+            data-testid="withdraw-confirm-button"
           >
             {isProcessing ? (
               <span className="flex items-center justify-center gap-2">

--- a/services/vault/src/components/simple/WithdrawVaults/CollateralActionsMenu.tsx
+++ b/services/vault/src/components/simple/WithdrawVaults/CollateralActionsMenu.tsx
@@ -49,6 +49,7 @@ export function CollateralActionsMenu({
 
   return (
     <>
+      {/* This control's data-testid is a real-wallet E2E hook (e2e/real/actions/withdraw.ts) — carry it over if you move or rename the element. */}
       <button
         ref={anchorRef}
         type="button"
@@ -56,6 +57,7 @@ export function CollateralActionsMenu({
         aria-haspopup="menu"
         aria-expanded={open}
         aria-label={COPY.collateral.menu.triggerLabel}
+        data-testid="collateral-actions-button"
         className={TRIGGER_CLASS}
       >
         <MdMoreHoriz size={MENU_ICON_SIZE} />
@@ -70,11 +72,13 @@ export function CollateralActionsMenu({
       >
         <ul role="menu" className="flex flex-col">
           <li role="none">
+            {/* This control's data-testid is a real-wallet E2E hook (e2e/real/actions/withdraw.ts) — carry it over if you move or rename the element. */}
             <button
               type="button"
               role="menuitem"
               disabled={withdrawBlocked}
               onClick={() => runAction(onWithdraw)}
+              data-testid="collateral-withdraw-button"
               className={MENU_ITEM_CLASS}
             >
               {COPY.collateral.menu.withdraw}

--- a/services/vault/src/components/simple/WithdrawVaults/WithdrawVaultItem.tsx
+++ b/services/vault/src/components/simple/WithdrawVaults/WithdrawVaultItem.tsx
@@ -35,7 +35,11 @@ export function WithdrawVaultItem({
   };
 
   return (
-    <div className="flex items-center justify-between rounded-lg bg-primary-contrast px-6 py-4">
+    // This row's data-testid is a real-wallet E2E hook (e2e/real/actions/withdraw.ts) — carry it over if you move or rename the element.
+    <div
+      className="flex items-center justify-between rounded-lg bg-primary-contrast px-6 py-4"
+      data-testid={`withdraw-vault-row-${vaultId}`}
+    >
       <div className="flex items-center gap-2">
         <Avatar url={btcConfig.icon} alt={btcConfig.coinSymbol} size="medium" />
         <span className="text-xl text-accent-primary">

--- a/services/vault/src/components/simple/WithdrawVaults/WithdrawVaultsModal.tsx
+++ b/services/vault/src/components/simple/WithdrawVaults/WithdrawVaultsModal.tsx
@@ -88,6 +88,7 @@ export function WithdrawVaultsModal({
             ))}
           </div>
 
+          {/* This control's data-testid is a real-wallet E2E hook (e2e/real/actions/withdraw.ts) — carry it over if you move or rename the element. */}
           <Button
             variant="contained"
             color="secondary"
@@ -95,6 +96,7 @@ export function WithdrawVaultsModal({
             fluid
             onClick={onConfirm}
             disabled={!canWithdraw || !hasSelection}
+            data-testid="withdraw-modal-confirm-button"
           >
             {withdrawLabel}
           </Button>


### PR DESCRIPTION
# Add `withdraw` to the real-wallet E2E CLI (lifecycle step 7)

Closes https://github.com/babylonlabs-io/babylon-toolkit/issues/2054

## What this adds

This adds the final step of the depositor lifecycle to our real-wallet end-to-end CLI (`services/vault/e2e/real/`): **withdraw**, which releases a BTC-Vault's collateral back to the depositor. The CLI already drives connect → pegin → borrow → repay against real Chrome wallet extensions (signet BTC + Sepolia ETH); this wires up the exit, so the tool can now run the whole journey and unwind it.

Withdraw in the app is a single Ethereum transaction (`withdrawCollaterals`) — there is no Bitcoin signature from the depositor; the vault provider does the Bitcoin payout off-chain afterward. So the CLI drives one MetaMask confirmation and then checks on-chain that the collateral actually left the position.

## Why

Withdraw was the last untested leg of the lifecycle (step-7 issue https://github.com/babylonlabs-io/babylon-toolkit/issues/2054, part of the withdrawal / redemption e2e coverage tracked in https://github.com/babylonlabs-io/babylon-toolkit/issues/1596). Having it in the CLI means we can run a full, real-money happy path — peg in, borrow, repay, and withdraw everything back — unattended, and catch regressions in the withdraw UI or the underlying contract calls before they reach users.

## The four ways to run it

Because you can't always withdraw straight away (a vault backing a loan is locked until the debt is repaid, and you can't borrow without collateral), the CLI supports four "how deep to start" runs. Each is one flag:

- `--action=withdraw` — withdraw against the current position (no debt).
- `--action=withdraw --repay-first` — repay the outstanding debt in full, then withdraw.
- `--action=withdraw --borrow-first` — borrow, repay that loan in full, then withdraw.
- `--action=withdraw --pegin-first [--split]` — peg in fresh collateral (optionally a two-vault split), then borrow, repay, and withdraw — the full cycle.

By default it releases **one** vault (keeping the position alive for the next test); `--withdraw-all` releases every eligible vault.

## How it works (and the approaches we weighed)

**Approach 1 — reuse the existing action, or build a standalone one?** We mirrored the existing repay/borrow action instead of writing withdraw from scratch. The connect flow, the wallet-popup approver, the pegin step machine, the borrow and repay flows, and the on-chain read helpers already exist and are battle-tested from the borrow (step 5) and repay (step 6) work (https://github.com/babylonlabs-io/babylon-toolkit/issues/2048). The new `withdraw` action calls straight into those (`runBorrowWithOptionalPegin`, `runRepayFlow`, `fetchCollateralSats`, the shared selectors, the approver). This keeps the change small and the whole CLI consistent, and it means the prerequisite legs are already proven.

**Approach 2 — independent flags, or a cascade?** We chose a cascade: `--pegin-first` implies `--borrow-first` implies `--repay-first`. This matches reality — you cannot withdraw a vault that is backing a loan until the debt is cleared (the app's health-factor gate), and you cannot borrow without collateral. The legs are naturally nested, so a cascade maps one-to-one onto the real user journeys and rules out nonsensical combinations. The alternative (three independent flags) would let a user ask for impossible states.

**Approach 3 — how much to repay in the chained runs?** The repay leg is forced to **Max** (full clear). Withdraw only lets a vault out while the health factor stays safe, so fully clearing the debt is the clean, deterministic path — every eligible vault becomes withdrawable once debt is zero.

**Approach 4 — target the UI by visible text, or by test IDs?** We target buttons by `data-testid` first, with a tolerant text/role fallback. Text-only selectors break whenever copy changes; test IDs are stable. This required adding a handful of `data-testid`s to the withdraw components (see below).

**Pre-flight checks are best-effort, not the source of truth.** Before opening the browser the CLI reads the position on-chain and refuses only genuinely-doomed runs (nothing to withdraw, or `--repay-first` with no debt). For everything else it warns and lets the live form be the authority, because the on-chain read can lag and the app's own gates are what actually protect the user. After the transaction, though, we verify on-chain that collateral truly fell — not just that the UI showed a success screen.

## Also included: an activation Retry gate for the peg-in step machine

While testing the full `--pegin-first` cycle, the vault-activation transaction hit a transient failure from the public Sepolia RPC (a gas-estimation glitch: "Cannot destructure property 'gasLimit'"). The app handles this gracefully — it shows a **Retry** button — but our automation didn't click it, so the run stalled. We added a small, bounded gate to the step machine that clicks that Retry button (up to 3 times) to recover exactly like a human would, then gives up with a clear error if it keeps failing. We deliberately click the app's own Retry (which re-runs just the failed activation) rather than restarting the whole peg-in, which would needlessly re-broadcast the Bitcoin deposit.

## Frontend changes (test hooks only)

Five `data-testid`s were added to the withdraw UI (the "⋯" collateral menu, the Withdraw menu item, the per-vault row, the modal confirm, the review confirm, and the done button). These are test hooks only — no behavior or copy changes. Each has a short comment pointing at the CLI that consumes it, and there's a new note in `CLAUDE.md` so that anyone refactoring these components knows to carry the test ID over rather than drop it.

## Testing

All four runs were verified live on devnet with real funds (signet BTC + Sepolia ETH), every leg confirmed on-chain (collateral rising/falling, debt rising/falling — read straight from the contract, not just the UI):

- withdraw: collateral 0.02 → 0.01 sBTC.
- repay + withdraw: debt $116 → $0, collateral 0.01 → 0.00.
- pegin (split) + borrow + repay + withdraw: two vaults pegged in, borrow $448, repay to $0, withdraw releasing collateral.
- borrow + repay + withdraw (reusing a leftover vault): borrow $331, repay to $0, collateral → 0.00.
- full single-vault cycle (pegin → borrow → repay → withdraw): 0 → 0.01 sBTC, borrow $116, repay to $0, withdraw → 0.

`pnpm --filter vault run lint` and the e2e type-check pass. The E2E CLI stays dependency-free (Node built-ins + `tsx`) and never reimplements SDK logic — it drives the UI and reads position state through the existing SDK helpers.
