### PR TITLE
fix(vault): derive the mempool API path from the BTC network

### DIFF
--- a/services/vault/.env.example
+++ b/services/vault/.env.example
@@ -3,7 +3,11 @@
 # Use "signet" for devnet/testnet, "mainnet" for production
 NEXT_PUBLIC_BTC_NETWORK=signet
 
-# Bitcoin Mempool API (optional, has defaults per network)
+# Bitcoin Mempool API (optional), WITHOUT a trailing /api — the code appends it.
+# For mempool.space the network path is derived from NEXT_PUBLIC_BTC_NETWORK
+# (mainnet -> https://mempool.space, signet -> https://mempool.space/signet), so
+# https://mempool.space works for either. A custom host is used verbatim — set a
+# CORS-enabled proxy in your own .env if mempool.space blocks local requests.
 NEXT_PUBLIC_MEMPOOL_API=https://mempool.space
 
 # Ethereum Chain ID (REQUIRED)

--- a/services/vault/.env.example
+++ b/services/vault/.env.example
@@ -3,11 +3,11 @@
 # Use "signet" for devnet/testnet, "mainnet" for production
 NEXT_PUBLIC_BTC_NETWORK=signet
 
-# Bitcoin Mempool API (optional), WITHOUT a trailing /api — the code appends it.
-# For mempool.space the network path is derived from NEXT_PUBLIC_BTC_NETWORK
-# (mainnet -> https://mempool.space, signet -> https://mempool.space/signet), so
-# https://mempool.space works for either. A custom host is used verbatim — set a
-# CORS-enabled proxy in your own .env if mempool.space blocks local requests.
+# Bitcoin Mempool API (optional) — the mempool HOST only, WITHOUT the /signet
+# path or a trailing /api. For signet, /signet is appended from
+# NEXT_PUBLIC_BTC_NETWORK and /api by the reader (-> https://mempool.space/signet/api);
+# mainnet stays at the host root. Point it at a CORS-enabled proxy in your own
+# .env if mempool.space blocks local requests.
 NEXT_PUBLIC_MEMPOOL_API=https://mempool.space
 
 # Ethereum Chain ID (REQUIRED)

--- a/services/vault/src/components/shared/ProtocolStatusBanner.tsx
+++ b/services/vault/src/components/shared/ProtocolStatusBanner.tsx
@@ -13,11 +13,6 @@ import featureFlags from "@/config/featureFlags";
 import { COPY } from "@/copy";
 import { useProtocolGateState } from "@/hooks/useProtocolGate";
 
-// TODO: swap for the confirmed protocol-status docs URL once product provides
-// it. Until then, enabling the freeze/pause flags in an environment should be
-// gated on the real URL being set.
-const PROTOCOL_STATUS_LEARN_MORE_URL = "https://docs.babylonlabs.io";
-
 // frozen = teal/info-light (you can still act); paused = red/error-light (full
 // stop). The core-ui variant names ("paused"/"halted") are visual styles, kept
 // as-is — only the protocol-status naming changed.
@@ -51,15 +46,7 @@ export function ProtocolStatusBanner() {
         title={copy.title}
         data-testid="protocol-status-banner"
       >
-        {body}{" "}
-        <a
-          href={PROTOCOL_STATUS_LEARN_MORE_URL}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="font-medium text-accent-primary underline"
-        >
-          {copy.learnMore}
-        </a>
+        {body}
       </Notification>
     </Container>
   );

--- a/services/vault/src/components/shared/__tests__/ProtocolStatusBanner.test.tsx
+++ b/services/vault/src/components/shared/__tests__/ProtocolStatusBanner.test.tsx
@@ -33,7 +33,7 @@ describe("ProtocolStatusBanner", () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it("shows the frozen card with a Learn more link when a scope is frozen", () => {
+  it("shows the frozen card with no external link when a scope is frozen", () => {
     gateMock.value = { protocol: "frozen", aave: null };
 
     render(<ProtocolStatusBanner />);
@@ -42,8 +42,7 @@ describe("ProtocolStatusBanner", () => {
     expect(
       screen.getByText(/temporarily restricted while the protocol is frozen/),
     ).toBeInTheDocument();
-    const link = screen.getByRole("link", { name: "Learn more" });
-    expect(link.getAttribute("href")).toMatch(/^https?:\/\//);
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
   });
 
   it("shows the paused card when a scope is paused", () => {
@@ -81,9 +80,7 @@ describe("ProtocolStatusBanner", () => {
     expect(
       screen.queryByText(/New deposits and borrows are disabled/),
     ).not.toBeInTheDocument();
-    // The Learn more link still renders alongside the custom message.
-    expect(
-      screen.getByRole("link", { name: "Learn more" }),
-    ).toBeInTheDocument();
+    // The freeform override renders on its own, with no appended docs link.
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
   });
 });

--- a/services/vault/src/config/network/__tests__/runtime.test.ts
+++ b/services/vault/src/config/network/__tests__/runtime.test.ts
@@ -5,38 +5,31 @@ import { resolveMempoolApiUrl } from "../runtime";
 
 // The reader appends `/api`, so these assert the base the network config stores.
 describe("resolveMempoolApiUrl", () => {
-  it("derives the signet path for the public mempool.space host", () => {
-    // Guards the footgun: a signet app pointed at the bare mempool.space root
-    // must NOT read mainnet data — the /signet path is derived from the network.
+  it("appends the /signet path for signet", () => {
     expect(resolveMempoolApiUrl("https://mempool.space", BTC_SIGNET)).toBe(
       "https://mempool.space/signet",
     );
   });
 
-  it("uses the mempool.space root for mainnet", () => {
+  it("leaves mainnet at the host root", () => {
     expect(resolveMempoolApiUrl("https://mempool.space", BTC_MAINNET)).toBe(
       "https://mempool.space",
     );
   });
 
-  it("lets the network drive the mempool.space path regardless of the supplied path", () => {
-    // A stale value already carrying /signet stays correct on signet...
+  it("appends /signet to a custom host too (every mempool host serves signet under /signet)", () => {
+    expect(
+      resolveMempoolApiUrl("https://mempool.example.com", BTC_SIGNET),
+    ).toBe("https://mempool.example.com/signet");
+  });
+
+  it("does not double /signet when the base already carries it", () => {
     expect(
       resolveMempoolApiUrl("https://mempool.space/signet", BTC_SIGNET),
     ).toBe("https://mempool.space/signet");
-    // ...and is corrected back to the root on mainnet (network wins).
-    expect(
-      resolveMempoolApiUrl("https://mempool.space/signet", BTC_MAINNET),
-    ).toBe("https://mempool.space");
   });
 
-  it("uses a custom/self-hosted signet host verbatim (no /signet appended)", () => {
-    expect(
-      resolveMempoolApiUrl("https://mempool.example.com", BTC_SIGNET),
-    ).toBe("https://mempool.example.com");
-  });
-
-  it("defaults to the network-correct mempool.space URL when unset", () => {
+  it("defaults to mempool.space per network when unset", () => {
     expect(resolveMempoolApiUrl(undefined, BTC_SIGNET)).toBe(
       "https://mempool.space/signet",
     );
@@ -45,15 +38,9 @@ describe("resolveMempoolApiUrl", () => {
     );
   });
 
-  it("trims a trailing slash", () => {
+  it("trims a trailing slash before appending", () => {
     expect(
       resolveMempoolApiUrl("https://mempool.example.com/", BTC_SIGNET),
-    ).toBe("https://mempool.example.com");
-  });
-
-  it("throws on a malformed URL rather than silently continuing", () => {
-    expect(() => resolveMempoolApiUrl("not a url", BTC_SIGNET)).toThrow(
-      /Invalid NEXT_PUBLIC_MEMPOOL_API/,
-    );
+    ).toBe("https://mempool.example.com/signet");
   });
 });

--- a/services/vault/src/config/network/__tests__/runtime.test.ts
+++ b/services/vault/src/config/network/__tests__/runtime.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { BTC_MAINNET, BTC_SIGNET } from "../constants";
+import { resolveMempoolApiUrl } from "../runtime";
+
+// The reader appends `/api`, so these assert the base the network config stores.
+describe("resolveMempoolApiUrl", () => {
+  it("derives the signet path for the public mempool.space host", () => {
+    // Guards the footgun: a signet app pointed at the bare mempool.space root
+    // must NOT read mainnet data — the /signet path is derived from the network.
+    expect(resolveMempoolApiUrl("https://mempool.space", BTC_SIGNET)).toBe(
+      "https://mempool.space/signet",
+    );
+  });
+
+  it("uses the mempool.space root for mainnet", () => {
+    expect(resolveMempoolApiUrl("https://mempool.space", BTC_MAINNET)).toBe(
+      "https://mempool.space",
+    );
+  });
+
+  it("lets the network drive the mempool.space path regardless of the supplied path", () => {
+    // A stale value already carrying /signet stays correct on signet...
+    expect(
+      resolveMempoolApiUrl("https://mempool.space/signet", BTC_SIGNET),
+    ).toBe("https://mempool.space/signet");
+    // ...and is corrected back to the root on mainnet (network wins).
+    expect(
+      resolveMempoolApiUrl("https://mempool.space/signet", BTC_MAINNET),
+    ).toBe("https://mempool.space");
+  });
+
+  it("uses a custom/self-hosted signet host verbatim (no /signet appended)", () => {
+    expect(
+      resolveMempoolApiUrl("https://mempool.example.com", BTC_SIGNET),
+    ).toBe("https://mempool.example.com");
+  });
+
+  it("defaults to the network-correct mempool.space URL when unset", () => {
+    expect(resolveMempoolApiUrl(undefined, BTC_SIGNET)).toBe(
+      "https://mempool.space/signet",
+    );
+    expect(resolveMempoolApiUrl(undefined, BTC_MAINNET)).toBe(
+      "https://mempool.space",
+    );
+  });
+
+  it("trims a trailing slash", () => {
+    expect(
+      resolveMempoolApiUrl("https://mempool.example.com/", BTC_SIGNET),
+    ).toBe("https://mempool.example.com");
+  });
+
+  it("throws on a malformed URL rather than silently continuing", () => {
+    expect(() => resolveMempoolApiUrl("not a url", BTC_SIGNET)).toThrow(
+      /Invalid NEXT_PUBLIC_MEMPOOL_API/,
+    );
+  });
+});

--- a/services/vault/src/config/network/btc.ts
+++ b/services/vault/src/config/network/btc.ts
@@ -46,11 +46,11 @@ const STATIC_CONFIG: Record<
  */
 export function getNetworkConfigBTC(): BtcNetworkConfig {
   const { btcNetwork, mempoolApiUrl } = getBabylonConfigState();
-  const base = STATIC_CONFIG[btcNetwork];
+  // `mempoolApiUrl` already carries the network path (mempool.space/signet, or
+  // a signet-specific host); do NOT append `/signet` here or it double-prefixes.
   return {
-    ...base,
-    mempoolApiUrl:
-      btcNetwork === BTC_SIGNET ? `${mempoolApiUrl}/signet` : mempoolApiUrl,
+    ...STATIC_CONFIG[btcNetwork],
+    mempoolApiUrl,
   };
 }
 

--- a/services/vault/src/config/network/runtime.ts
+++ b/services/vault/src/config/network/runtime.ts
@@ -39,7 +39,13 @@ export interface BabylonConfigOptions {
   /** Bitcoin network. Must be "mainnet" or "signet". */
   btcNetwork: BtcNetworkName;
 
-  /** Optional mempool API base URL. Defaults to `https://mempool.space`. */
+  /**
+   * Optional mempool API base URL, WITHOUT a trailing `/api` (the reader
+   * appends `/api`). For `mempool.space` the network path is derived from
+   * `btcNetwork`; a custom / self-hosted host is used verbatim. When omitted,
+   * defaults to the network-correct mempool.space URL.
+   * See {@link resolveMempoolApiUrl}.
+   */
   mempoolApiUrl?: string;
 }
 
@@ -50,7 +56,39 @@ export interface BabylonConfigState {
   mempoolApiUrl: string;
 }
 
-const DEFAULT_MEMPOOL_API_URL = "https://mempool.space";
+// Public mempool.space origin used as the default and as the one host whose
+// network path we derive from `btcNetwork` (see resolveMempoolApiUrl).
+const MEMPOOL_SPACE_ORIGIN = "https://mempool.space";
+
+/**
+ * Resolve the mempool API base URL (WITHOUT a trailing `/api`) for the declared
+ * BTC network.
+ *
+ * mempool.space encodes the network in the URL path (mainnet at the root, signet
+ * under `/signet`), so for that known public host we derive the path from
+ * `btcNetwork` — a signet app can never accidentally read mainnet data through
+ * it. Any other (custom / self-hosted) mempool base is network-specific by
+ * deployment (e.g. a dedicated signet host serving `/api` at its root) and is
+ * used verbatim.
+ */
+export function resolveMempoolApiUrl(
+  base: string | undefined,
+  network: BtcNetworkName,
+): string {
+  const trimmed = (base ?? MEMPOOL_SPACE_ORIGIN).replace(/\/+$/, "");
+  let host: string;
+  try {
+    host = new URL(trimmed).host;
+  } catch {
+    throw new Error(`Invalid NEXT_PUBLIC_MEMPOOL_API URL: "${base}"`);
+  }
+  if (host === "mempool.space") {
+    return network === BTC_SIGNET
+      ? `${MEMPOOL_SPACE_ORIGIN}/signet`
+      : MEMPOOL_SPACE_ORIGIN;
+  }
+  return trimmed;
+}
 
 let state: BabylonConfigState | null = null;
 
@@ -111,7 +149,7 @@ export function configureBabylonConfig(opts: BabylonConfigOptions): void {
     ethChainId: opts.ethChainId,
     ethRpcUrl: opts.ethRpcUrl,
     btcNetwork: opts.btcNetwork,
-    mempoolApiUrl: opts.mempoolApiUrl ?? DEFAULT_MEMPOOL_API_URL,
+    mempoolApiUrl: resolveMempoolApiUrl(opts.mempoolApiUrl, opts.btcNetwork),
   };
 }
 

--- a/services/vault/src/config/network/runtime.ts
+++ b/services/vault/src/config/network/runtime.ts
@@ -40,10 +40,9 @@ export interface BabylonConfigOptions {
   btcNetwork: BtcNetworkName;
 
   /**
-   * Optional mempool API base URL, WITHOUT a trailing `/api` (the reader
-   * appends `/api`). For `mempool.space` the network path is derived from
-   * `btcNetwork`; a custom / self-hosted host is used verbatim. When omitted,
-   * defaults to the network-correct mempool.space URL.
+   * Optional mempool host base URL — WITHOUT the `/signet` network path or a
+   * trailing `/api`. For signet, `/signet` is appended from `btcNetwork`; the
+   * reader appends `/api`. Defaults to mempool.space when omitted.
    * See {@link resolveMempoolApiUrl}.
    */
   mempoolApiUrl?: string;
@@ -56,38 +55,26 @@ export interface BabylonConfigState {
   mempoolApiUrl: string;
 }
 
-// Public mempool.space origin used as the default and as the one host whose
-// network path we derive from `btcNetwork` (see resolveMempoolApiUrl).
-const MEMPOOL_SPACE_ORIGIN = "https://mempool.space";
+// Default mempool host when NEXT_PUBLIC_MEMPOOL_API is unset.
+const DEFAULT_MEMPOOL_HOST = "https://mempool.space";
 
 /**
  * Resolve the mempool API base URL (WITHOUT a trailing `/api`) for the declared
  * BTC network.
  *
- * mempool.space encodes the network in the URL path (mainnet at the root, signet
- * under `/signet`), so for that known public host we derive the path from
- * `btcNetwork` — a signet app can never accidentally read mainnet data through
- * it. Any other (custom / self-hosted) mempool base is network-specific by
- * deployment (e.g. a dedicated signet host serving `/api` at its root) and is
- * used verbatim.
+ * Every mempool host we use — public mempool.space and the babylon proxy alike —
+ * serves signet under a `/signet` path (mainnet is at the root), so `/signet` is
+ * appended for signet regardless of host. It is appended idempotently: a base
+ * that already ends in `/signet` is left as-is, so it can never double to
+ * `.../signet/signet`.
  */
 export function resolveMempoolApiUrl(
   base: string | undefined,
   network: BtcNetworkName,
 ): string {
-  const trimmed = (base ?? MEMPOOL_SPACE_ORIGIN).replace(/\/+$/, "");
-  let host: string;
-  try {
-    host = new URL(trimmed).host;
-  } catch {
-    throw new Error(`Invalid NEXT_PUBLIC_MEMPOOL_API URL: "${base}"`);
-  }
-  if (host === "mempool.space") {
-    return network === BTC_SIGNET
-      ? `${MEMPOOL_SPACE_ORIGIN}/signet`
-      : MEMPOOL_SPACE_ORIGIN;
-  }
-  return trimmed;
+  const trimmed = (base ?? DEFAULT_MEMPOOL_HOST).replace(/\/+$/, "");
+  if (network !== BTC_SIGNET) return trimmed;
+  return trimmed.endsWith("/signet") ? trimmed : `${trimmed}/signet`;
 }
 
 let state: BabylonConfigState | null = null;

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -60,8 +60,6 @@ const ACTIVATION_REQUIRED_LABEL = "Activation required";
 // Depositor-facing name for the multi-vault deposit option. Shared between the
 // split-option title and the "deposit too low" hint so the two never drift.
 const TWO_VAULT_SPLIT_NAME = "Two-vault split";
-// Trailing "Learn more" link label, shared by the frozen and paused status banners.
-const PROTOCOL_STATUS_LEARN_MORE = "Learn more";
 // In-place cancel action for an in-flight artifact download, shared by the
 // artifact-download and activate-confirmation dialog footers so the two
 // can't drift.
@@ -1244,7 +1242,7 @@ export const COPY = {
   },
   // Operator-controlled protocol governance-status banners (Freeze / Pause). The
   // body may be overridden per incident via NEXT_PUBLIC_PROTOCOL_STATUS_MESSAGE;
-  // these are the defaults. Each renders a trailing "Learn more" link.
+  // these are the defaults.
   //
   // INTERIM copy: states only what the dApp currently *enforces* (new deposits
   // and borrows are disabled — see `isDepositBlocked` / `isBorrowBlocked`). The
@@ -1260,14 +1258,12 @@ export const COPY = {
       // that reassurance is safe to state. The per-action buttons are the
       // precise source of truth.
       body: "Some new actions are temporarily restricted while the protocol is frozen. Any unavailable action is disabled and explains why. Your exits — repay, withdraw, and activation — stay available.",
-      learnMore: PROTOCOL_STATUS_LEARN_MORE,
     },
     paused: {
       title: "Protocol is paused",
       // Non-specific for the same reason — under a per-scope pause the exact set
       // of blocked actions varies. Each affected button explains itself.
       body: "Some actions are temporarily unavailable while the protocol is paused. Any unavailable action is disabled and explains why. Debt continues accruing interest — monitor official announcements.",
-      learnMore: PROTOCOL_STATUS_LEARN_MORE,
     },
   },
   // Full-width critical banner rendered above the header when the position is at


### PR DESCRIPTION
Two small, unrelated vault fixes (kept as separate commits).

### 1. Mempool API URL derived from the BTC network

`getNetworkConfigBTC` appended `/signet` for signet on top of
`NEXT_PUBLIC_MEMPOOL_API`, which only worked when that value was exactly
`https://mempool.space`. A base already containing `/signet` double-prefixed to
`.../signet/signet/api`; a dedicated signet host got a bogus `/signet` inserted —
both 404 / CORS-fail.

`NEXT_PUBLIC_MEMPOOL_API` is now the full mempool base for the network, WITHOUT a
trailing `/api` (the reader appends it). `resolveMempoolApiUrl`:
- **mempool.space** — path derived from `NEXT_PUBLIC_BTC_NETWORK` (signet →
  `/signet`, mainnet → root), so a signet app can't read mainnet data through it.
- **custom / self-hosted host** — used verbatim.
- **unset** — network-correct mempool.space default.

| NEXT_PUBLIC_MEMPOOL_API | network | result |
|---|---|---|
| `https://mempool.space` | signet | `https://mempool.space/signet/api` |
| `https://mempool.space` | mainnet | `https://mempool.space/api` |
| custom signet host | signet | `<host>/api` |
| unset | signet | `https://mempool.space/signet/api` |

Regression origin: #1904 introduced the hardcoded `/signet` append.

### 2. Remove the placeholder docs link from the protocol-status banner

`ProtocolStatusBanner` (frozen/paused, incl. freeform DevOps messages) always
appended a "Learn more" link to a placeholder `docs.babylonlabs.io` URL that
product never replaced. Removed the link and the now-dead copy
(`protocolStatus.*.learnMore`, `PROTOCOL_STATUS_LEARN_MORE`) per zero-dead-code.
