### PR TITLE
feat(vault): add on-chain funnel terminals (Phase 3) to Sentry

### DIFF
--- a/services/vault/src/context/deposit/PeginPollingContext.tsx
+++ b/services/vault/src/context/deposit/PeginPollingContext.tsx
@@ -21,6 +21,8 @@ import {
 } from "react";
 
 import { useDemoDeposit } from "@/dev/demoDeposit";
+import { logger } from "@/infrastructure";
+import { shortId } from "@/infrastructure/telemetryEvents";
 
 import { usePeginPollingQuery } from "../../hooks/deposit/usePeginPollingQuery";
 import { useRequiredPrePeginDepthResolver } from "../../hooks/deposit/useRequiredPrePeginDepth";
@@ -55,6 +57,10 @@ import { isVaultOwnedByWallet } from "../../utils/vaultWarnings";
 import { useProtocolParamsContext } from "../ProtocolParamsContext";
 
 import { computeDepositPollingResult } from "./computeDepositPollingResult";
+import {
+  collectTerminalMilestones,
+  getSharedTerminalMilestoneTracking,
+} from "./terminalMilestones";
 
 /** React Query namespace for the Pre-PegIn confirmation poller. */
 const PREPEGIN_CONFIRMATIONS_QUERY_KEY = "prePeginMempoolConfirmations";
@@ -338,6 +344,28 @@ export function PeginPollingProvider({
       return next;
     });
   }, [htlcRefundByDepositId, refundedHtlcVaultIds]);
+
+  // Emit the on-chain funnel terminals — activation.verified and
+  // deposit.completed — once per vault as its contractStatus transitions. The
+  // detector seeds already-terminal vaults on first observation, so a dashboard
+  // load never emits a burst for prior-session completions. Tracking is
+  // app-scoped rather than per-provider: the continuation modal mounts a second
+  // provider over the same vault, and per-instance tracking would count every
+  // terminal twice. It is a plain module store, not state — emitting telemetry
+  // must not trigger a re-render.
+  useEffect(() => {
+    const milestones = collectTerminalMilestones(
+      activities,
+      getSharedTerminalMilestoneTracking(),
+    );
+    for (const milestone of milestones) {
+      logger.event(milestone.event, {
+        level: "info",
+        category: milestone.category,
+        vaultId: shortId(milestone.vaultId),
+      });
+    }
+  }, [activities]);
 
   // Optimistic status handlers
   const setOptimisticStatus = useCallback(

--- a/services/vault/src/context/deposit/__tests__/terminalMilestoneEmission.test.tsx
+++ b/services/vault/src/context/deposit/__tests__/terminalMilestoneEmission.test.tsx
@@ -1,0 +1,154 @@
+import { render } from "@testing-library/react";
+import type { Hex } from "viem";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  ContractStatus,
+  PEGIN_DISPLAY_LABELS,
+} from "../../../models/peginStateMachine";
+import type { VaultActivity } from "../../../types/activity";
+import { PeginPollingProvider } from "../PeginPollingContext";
+import { resetSharedTerminalMilestoneTracking } from "../terminalMilestones";
+
+vi.mock("../../../hooks/deposit/usePeginPollingQuery", () => ({
+  usePeginPollingQuery: () => ({
+    errors: undefined,
+    needsWotsKey: undefined,
+    pendingIngestion: undefined,
+    pendingDepositorSignatures: undefined,
+    isLoading: false,
+    refetch: vi.fn(),
+    depositsToPoll: [],
+  }),
+}));
+
+// The hooks below reach for react-query / chain reads / ProtocolParams. Stub
+// them so the provider renders in isolation — this file only exercises the
+// milestone effect. Mirrors the stubs in PeginPollingContext.test.tsx.
+vi.mock("../../../hooks/useBtcMempoolConfirmations", () => ({
+  useBtcMempoolConfirmations: () => ({ confirmationsByTxid: new Map() }),
+}));
+
+vi.mock("../../../hooks/useBtcHtlcRefundStatus", () => ({
+  useBtcHtlcRefundStatus: () => ({ refundByDepositId: new Map() }),
+}));
+
+vi.mock("../../../hooks/useActivationDeadlineGate", () => ({
+  useActivationDeadlineGate: () => new Set<string>(),
+}));
+
+vi.mock("../../ProtocolParamsContext", () => ({
+  useProtocolParamsContext: () => ({
+    config: { offchainParams: { minPrepeginDepth: 6 } },
+    getOffchainParamsByVersion: () => undefined,
+  }),
+}));
+
+const { mockEvent } = vi.hoisted(() => ({ mockEvent: vi.fn() }));
+vi.mock("@/infrastructure", () => ({
+  logger: { event: mockEvent, error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+const ACTIVITY_ID = "0xpegin" as Hex;
+const BTC_PUBKEY = "ab".repeat(32);
+
+function activityAt(contractStatus: ContractStatus): VaultActivity {
+  return {
+    id: ACTIVITY_ID,
+    collateral: { amount: "0.1", symbol: "BTC" },
+    providers: [{ id: "0xprovider" }],
+    peginTxHash: ACTIVITY_ID,
+    contractStatus,
+    isInUse: false,
+    displayLabel: PEGIN_DISPLAY_LABELS.PENDING,
+    depositorBtcPubkey: BTC_PUBKEY,
+    unsignedPrePeginTx: "0xdeadbeef",
+    depositorPayoutBtcAddress: "0xpayoutscript" as Hex,
+    depositorWotsPkHash: "0xwotsh",
+  };
+}
+
+function emittedEventNames(): string[] {
+  return mockEvent.mock.calls.map((call) => call[0] as string);
+}
+
+describe("terminal milestone emission across co-mounted providers", () => {
+  beforeEach(() => {
+    mockEvent.mockClear();
+    // The tracking store is app-scoped and outlives any provider, so it also
+    // outlives a test case. Without this reset a later case starts with the
+    // vault already seen and silently observes nothing.
+    resetSharedTerminalMilestoneTracking();
+  });
+
+  it("emits each terminal once when the continuation modal nests a second provider over the same vault", () => {
+    const Tree = ({ status }: { status: ContractStatus }) => (
+      <PeginPollingProvider
+        activities={[activityAt(status)]}
+        pendingPegins={[]}
+        btcPublicKey={BTC_PUBKEY}
+      >
+        <PeginPollingProvider
+          activities={[activityAt(status)]}
+          pendingPegins={[]}
+          btcPublicKey={BTC_PUBKEY}
+        >
+          <div />
+        </PeginPollingProvider>
+      </PeginPollingProvider>
+    );
+
+    const { rerender } = render(<Tree status={ContractStatus.PENDING} />);
+    rerender(<Tree status={ContractStatus.VERIFIED} />);
+    rerender(<Tree status={ContractStatus.ACTIVE} />);
+
+    expect(emittedEventNames()).toEqual([
+      "activation.verified",
+      "deposit.completed",
+    ]);
+  });
+
+  it("emits each terminal once when the dashboard and root-layout providers are siblings over the same vault", () => {
+    const Tree = ({ status }: { status: ContractStatus }) => (
+      <>
+        <PeginPollingProvider
+          activities={[activityAt(status)]}
+          pendingPegins={[]}
+          btcPublicKey={BTC_PUBKEY}
+        >
+          <div />
+        </PeginPollingProvider>
+        <PeginPollingProvider
+          activities={[activityAt(status)]}
+          pendingPegins={[]}
+          btcPublicKey={BTC_PUBKEY}
+        >
+          <div />
+        </PeginPollingProvider>
+      </>
+    );
+
+    const { rerender } = render(<Tree status={ContractStatus.PENDING} />);
+    rerender(<Tree status={ContractStatus.VERIFIED} />);
+    rerender(<Tree status={ContractStatus.ACTIVE} />);
+
+    expect(emittedEventNames()).toEqual([
+      "activation.verified",
+      "deposit.completed",
+    ]);
+  });
+
+  it("emits nothing for a vault already ACTIVE on its first observation", () => {
+    render(
+      <PeginPollingProvider
+        activities={[activityAt(ContractStatus.ACTIVE)]}
+        pendingPegins={[]}
+        btcPublicKey={BTC_PUBKEY}
+      >
+        <div />
+      </PeginPollingProvider>,
+    );
+
+    expect(emittedEventNames()).toEqual([]);
+  });
+});

--- a/services/vault/src/context/deposit/__tests__/terminalMilestones.test.ts
+++ b/services/vault/src/context/deposit/__tests__/terminalMilestones.test.ts
@@ -1,0 +1,279 @@
+import { describe, expect, it } from "vitest";
+
+import { ContractStatus } from "../../../models/peginStateMachine";
+import {
+  collectTerminalMilestones,
+  createTerminalMilestoneTracking,
+} from "../terminalMilestones";
+
+const activity = (id: string, contractStatus: number) => ({
+  id,
+  contractStatus,
+});
+
+// What the usePeginStorage merge fabricates for a pegin the indexer has not
+// returned yet: a synthetic PENDING that was never observed on-chain.
+const localOnly = (id: string) => ({
+  id,
+  contractStatus: ContractStatus.PENDING,
+  isPending: true,
+});
+
+describe("collectTerminalMilestones", () => {
+  it("emits activation.verified then deposit.completed as one vault transitions across polls", () => {
+    const tracking = createTerminalMilestoneTracking();
+
+    // First observation as PENDING seeds nothing and emits nothing.
+    expect(
+      collectTerminalMilestones(
+        [activity("0xa", ContractStatus.PENDING)],
+        tracking,
+      ),
+    ).toEqual([]);
+
+    // Transition to VERIFIED emits activation.verified once.
+    expect(
+      collectTerminalMilestones(
+        [activity("0xa", ContractStatus.VERIFIED)],
+        tracking,
+      ),
+    ).toEqual([
+      { event: "activation.verified", category: "activation", vaultId: "0xa" },
+    ]);
+
+    // Still VERIFIED next poll — no re-emit.
+    expect(
+      collectTerminalMilestones(
+        [activity("0xa", ContractStatus.VERIFIED)],
+        tracking,
+      ),
+    ).toEqual([]);
+
+    // Transition to ACTIVE emits deposit.completed once.
+    expect(
+      collectTerminalMilestones(
+        [activity("0xa", ContractStatus.ACTIVE)],
+        tracking,
+      ),
+    ).toEqual([
+      { event: "deposit.completed", category: "deposit", vaultId: "0xa" },
+    ]);
+
+    // Still ACTIVE — no re-emit.
+    expect(
+      collectTerminalMilestones(
+        [activity("0xa", ContractStatus.ACTIVE)],
+        tracking,
+      ),
+    ).toEqual([]);
+  });
+
+  it("seeds already-terminal vaults on first observation without emitting (no page-load burst)", () => {
+    const tracking = createTerminalMilestoneTracking();
+
+    // A dashboard load where the vault is already ACTIVE must NOT emit.
+    expect(
+      collectTerminalMilestones(
+        [activity("0xold", ContractStatus.ACTIVE)],
+        tracking,
+      ),
+    ).toEqual([]);
+
+    // And never emits on subsequent polls either.
+    expect(
+      collectTerminalMilestones(
+        [activity("0xold", ContractStatus.ACTIVE)],
+        tracking,
+      ),
+    ).toEqual([]);
+  });
+
+  it("emits both milestones once when a seen vault jumps straight to ACTIVE", () => {
+    const tracking = createTerminalMilestoneTracking();
+    collectTerminalMilestones(
+      [activity("0xb", ContractStatus.PENDING)],
+      tracking,
+    );
+
+    // PENDING -> ACTIVE in one step still yields verified AND completed once each.
+    expect(
+      collectTerminalMilestones(
+        [activity("0xb", ContractStatus.ACTIVE)],
+        tracking,
+      ),
+    ).toEqual([
+      { event: "activation.verified", category: "activation", vaultId: "0xb" },
+      { event: "deposit.completed", category: "deposit", vaultId: "0xb" },
+    ]);
+  });
+
+  it("emits both milestones once when a seen vault jumps straight to REDEEMED", () => {
+    const tracking = createTerminalMilestoneTracking();
+    collectTerminalMilestones(
+      [activity("0xc", ContractStatus.PENDING)],
+      tracking,
+    );
+
+    // PENDING -> REDEEMED (already redeemed by the time we observe it) still
+    // yields verified AND completed once each, same as reaching ACTIVE.
+    expect(
+      collectTerminalMilestones(
+        [activity("0xc", ContractStatus.REDEEMED)],
+        tracking,
+      ),
+    ).toEqual([
+      { event: "activation.verified", category: "activation", vaultId: "0xc" },
+      { event: "deposit.completed", category: "deposit", vaultId: "0xc" },
+    ]);
+
+    // Still REDEEMED — no re-emit.
+    expect(
+      collectTerminalMilestones(
+        [activity("0xc", ContractStatus.REDEEMED)],
+        tracking,
+      ),
+    ).toEqual([]);
+  });
+
+  it("defers seeding while contractStatus is missing, so a vault first classified as ACTIVE does not emit", () => {
+    const tracking = createTerminalMilestoneTracking();
+
+    // No status: the field is optional, and reading it as PENDING would seed the
+    // vault at a state it was never observed in. Must not seed or emit.
+    expect(collectTerminalMilestones([{ id: "0xd" }], tracking)).toEqual([]);
+
+    // Status arrives and the vault was already ACTIVE: this is its first real
+    // observation, so it seeds silently instead of emitting a spurious milestone.
+    expect(
+      collectTerminalMilestones(
+        [activity("0xd", ContractStatus.ACTIVE)],
+        tracking,
+      ),
+    ).toEqual([]);
+  });
+
+  it("emits both milestones once when a seen vault jumps straight to LIQUIDATED", () => {
+    const tracking = createTerminalMilestoneTracking();
+    collectTerminalMilestones(
+      [activity("0xe", ContractStatus.PENDING)],
+      tracking,
+    );
+
+    // A liquidated vault necessarily activated first, so it converted: both
+    // milestones still owe an emission, same as reaching ACTIVE.
+    expect(
+      collectTerminalMilestones(
+        [activity("0xe", ContractStatus.LIQUIDATED)],
+        tracking,
+      ),
+    ).toEqual([
+      { event: "activation.verified", category: "activation", vaultId: "0xe" },
+      { event: "deposit.completed", category: "deposit", vaultId: "0xe" },
+    ]);
+  });
+
+  it("emits nothing for a vault that expires without activating", () => {
+    const tracking = createTerminalMilestoneTracking();
+    collectTerminalMilestones(
+      [activity("0xf", ContractStatus.PENDING)],
+      tracking,
+    );
+
+    // EXPIRED is a pre-activation abort, not a conversion.
+    expect(
+      collectTerminalMilestones(
+        [activity("0xf", ContractStatus.EXPIRED)],
+        tracking,
+      ),
+    ).toEqual([]);
+  });
+
+  it("does not seed from a localStorage-only row, so a vault that activated between sessions emits nothing", () => {
+    const tracking = createTerminalMilestoneTracking();
+
+    // Cold load: the indexer has not answered yet, so the merge fabricates a
+    // PENDING row from localStorage. Seeding from it would classify the vault as
+    // first seen at PENDING.
+    expect(collectTerminalMilestones([localOnly("0xg")], tracking)).toEqual([]);
+
+    // The indexer resolves and the vault was already ACTIVE — it activated while
+    // the user was away. That is a prior-session transition: seed, don't emit.
+    expect(
+      collectTerminalMilestones(
+        [activity("0xg", ContractStatus.ACTIVE)],
+        tracking,
+      ),
+    ).toEqual([]);
+  });
+
+  it("does not seed from a localStorage-only row when the indexer first reports VERIFIED", () => {
+    const tracking = createTerminalMilestoneTracking();
+
+    expect(collectTerminalMilestones([localOnly("0xh")], tracking)).toEqual([]);
+
+    // The repeating false positive this guards: without it the fabricated PENDING
+    // seeds the vault, and every later poll at VERIFIED looks like a live
+    // transition worth an activation.verified.
+    expect(
+      collectTerminalMilestones(
+        [activity("0xh", ContractStatus.VERIFIED)],
+        tracking,
+      ),
+    ).toEqual([]);
+    expect(
+      collectTerminalMilestones(
+        [activity("0xh", ContractStatus.VERIFIED)],
+        tracking,
+      ),
+    ).toEqual([]);
+  });
+
+  it("still emits for a deposit made in this session, once the indexer picks it up", () => {
+    const tracking = createTerminalMilestoneTracking();
+
+    // A fresh deposit is localStorage-only at first — skipped, not suppressed.
+    collectTerminalMilestones([localOnly("0xi")], tracking);
+
+    // The indexer picks it up at PENDING: this is its first real observation.
+    collectTerminalMilestones(
+      [activity("0xi", ContractStatus.PENDING)],
+      tracking,
+    );
+
+    // The transition is now observed in-session and emits normally.
+    expect(
+      collectTerminalMilestones(
+        [activity("0xi", ContractStatus.ACTIVE)],
+        tracking,
+      ),
+    ).toEqual([
+      { event: "activation.verified", category: "activation", vaultId: "0xi" },
+      { event: "deposit.completed", category: "deposit", vaultId: "0xi" },
+    ]);
+  });
+
+  it("tracks each vault in a multi-vault batch independently", () => {
+    const tracking = createTerminalMilestoneTracking();
+    collectTerminalMilestones(
+      [
+        activity("0xa", ContractStatus.PENDING),
+        activity("0xb", ContractStatus.PENDING),
+      ],
+      tracking,
+    );
+
+    const emitted = collectTerminalMilestones(
+      [
+        activity("0xa", ContractStatus.VERIFIED),
+        activity("0xb", ContractStatus.ACTIVE),
+      ],
+      tracking,
+    );
+
+    expect(emitted).toEqual([
+      { event: "activation.verified", category: "activation", vaultId: "0xa" },
+      { event: "activation.verified", category: "activation", vaultId: "0xb" },
+      { event: "deposit.completed", category: "deposit", vaultId: "0xb" },
+    ]);
+  });
+});

--- a/services/vault/src/context/deposit/terminalMilestones.ts
+++ b/services/vault/src/context/deposit/terminalMilestones.ts
@@ -1,0 +1,153 @@
+/**
+ * Pure transition detector for the on-chain deposit-funnel terminals emitted
+ * from the polling context: `activation.verified` (VP verified the presigned
+ * payouts) and `deposit.completed` (vault ACTIVE — funnel terminal).
+ *
+ * Emission must be per-vault and once-per-transition. Two rules make that hold
+ * against a poll loop that re-runs every cycle:
+ *  - A vault is SEEDED on its first indexer-sourced observation: if it is
+ *    already at/past a milestone then (a prior-session completion, or a resumed
+ *    deposit), it is marked emitted WITHOUT emitting, so a page load never emits
+ *    a burst. localStorage-only rows are skipped outright — their status is
+ *    fabricated, not observed.
+ *  - Thereafter a milestone emits once, the first cycle a seen vault is observed
+ *    to have reached that state, and never again.
+ */
+
+import {
+  TELEMETRY_EVENT,
+  type TelemetryEvent,
+} from "../../infrastructure/telemetryEvents";
+import { ContractStatus } from "../../models/peginStateMachine";
+
+export interface TerminalMilestoneTracking {
+  /** Vaults observed at least once (drives first-observation seeding). */
+  seen: Set<string>;
+  emittedVerified: Set<string>;
+  emittedCompleted: Set<string>;
+}
+
+export interface TerminalMilestone {
+  event: TelemetryEvent;
+  category: "activation" | "deposit";
+  /** Raw vaultId; the caller shortens it before it enters event context. */
+  vaultId: string;
+}
+
+export function createTerminalMilestoneTracking(): TerminalMilestoneTracking {
+  return {
+    seen: new Set(),
+    emittedVerified: new Set(),
+    emittedCompleted: new Set(),
+  };
+}
+
+/**
+ * App-scoped tracking shared by every mounted `PeginPollingProvider`.
+ *
+ * Several providers observe the same vault at once: the dashboard section polls
+ * every activity, while the continuation modal mounts its own provider scoped to
+ * the viewed batch — nested inside that section, or as a sibling under the root
+ * layout. Per-provider tracking emits each terminal once per provider, so the
+ * once-per-vault guarantee is keyed to the vault id here rather than to a
+ * provider instance, and holds however many providers are mounted.
+ *
+ * In-memory by design: a reload must reset it, so that the seeding rule above
+ * re-suppresses prior-session completions rather than replaying them.
+ */
+const sharedTracking = createTerminalMilestoneTracking();
+
+export function getSharedTerminalMilestoneTracking(): TerminalMilestoneTracking {
+  return sharedTracking;
+}
+
+/**
+ * Test-only reset: the shared store outlives any single provider, so cases
+ * asserting emissions must start from a clean slate.
+ */
+export function resetSharedTerminalMilestoneTracking(): void {
+  sharedTracking.seen.clear();
+  sharedTracking.emittedVerified.clear();
+  sharedTracking.emittedCompleted.clear();
+}
+
+interface StatusBearingActivity {
+  id: string;
+  contractStatus?: number;
+  /** True on localStorage-only rows the indexer has not returned yet. */
+  isPending?: boolean;
+}
+
+/**
+ * Terminal statuses only reachable from ACTIVE: a vault must have activated to
+ * be redeemed, liquidated (collateral seized against a debt) or withdrawn. A
+ * liquidated vault still converted — it activated first — so it counts. EXPIRED
+ * and INVALID are pre-activation aborts and never do. Mirrors the contract
+ * statuses of `isVaultPastActivation`, minus its optimistic localStorage branch:
+ * an on-chain milestone must be decided from chain truth alone.
+ */
+function hasReachedActive(status: ContractStatus): boolean {
+  return (
+    status === ContractStatus.ACTIVE ||
+    status === ContractStatus.REDEEMED ||
+    status === ContractStatus.LIQUIDATED ||
+    status === ContractStatus.DEPOSITOR_WITHDRAWN
+  );
+}
+
+/**
+ * Return the milestones to emit for this poll, mutating `tracking` so each fires
+ * at most once per vault. Any status implying the vault reached ACTIVE counts as
+ * both "reached verified" and "reached completed", and VERIFIED counts as
+ * reached-verified — so a vault that jumps straight past VERIFIED between polls
+ * still yields both milestones once.
+ */
+export function collectTerminalMilestones(
+  activities: readonly StatusBearingActivity[],
+  tracking: TerminalMilestoneTracking,
+): TerminalMilestone[] {
+  const out: TerminalMilestone[] = [];
+
+  for (const activity of activities) {
+    // Classify a vault only from an indexer-sourced status. A localStorage-only
+    // row carries a fabricated PENDING (`isPending: true` — see the merge in
+    // usePeginStorage) and exists only until the indexer returns the vault.
+    // Seeding from it would mark an already-terminal vault as first seen at
+    // PENDING, then emit a spurious milestone one poll later for a transition
+    // that happened in a previous session. The `contractStatus` half is
+    // defensive: no caller reaches it today, but the field is optional and the
+    // cast below would otherwise read `undefined` as PENDING (0).
+    if (activity.isPending || activity.contractStatus === undefined) continue;
+    const status = activity.contractStatus as ContractStatus;
+    const reachedCompleted = hasReachedActive(status);
+    const reachedVerified =
+      status === ContractStatus.VERIFIED || reachedCompleted;
+
+    if (!tracking.seen.has(activity.id)) {
+      tracking.seen.add(activity.id);
+      // First observation: seed pre-existing terminal state without emitting.
+      if (reachedVerified) tracking.emittedVerified.add(activity.id);
+      if (reachedCompleted) tracking.emittedCompleted.add(activity.id);
+      continue;
+    }
+
+    if (reachedVerified && !tracking.emittedVerified.has(activity.id)) {
+      tracking.emittedVerified.add(activity.id);
+      out.push({
+        event: TELEMETRY_EVENT.ACTIVATION_VERIFIED,
+        category: "activation",
+        vaultId: activity.id,
+      });
+    }
+    if (reachedCompleted && !tracking.emittedCompleted.has(activity.id)) {
+      tracking.emittedCompleted.add(activity.id);
+      out.push({
+        event: TELEMETRY_EVENT.DEPOSIT_COMPLETED,
+        category: "deposit",
+        vaultId: activity.id,
+      });
+    }
+  }
+
+  return out;
+}

--- a/services/vault/src/infrastructure/telemetryEvents.ts
+++ b/services/vault/src/infrastructure/telemetryEvents.ts
@@ -19,6 +19,10 @@ export const TELEMETRY_EVENT = {
   DEPOSIT_BROADCAST_SUCCEEDED: "deposit.broadcast.succeeded",
   /** HTLC secret revealed on Ethereum; activation tx submitted (optimistic). */
   ACTIVATION_ACTIVATED: "activation.activated",
+  /** VP verified the depositor's presigned payouts on-chain (contractStatus VERIFIED). */
+  ACTIVATION_VERIFIED: "activation.verified",
+  /** Vault confirmed ACTIVE on-chain — funnel terminal / primary conversion. */
+  DEPOSIT_COMPLETED: "deposit.completed",
 } as const;
 
 export type TelemetryEvent =


### PR DESCRIPTION
## Context

Phase 3 of the Sentry funnel tracking. Phase 1 (#2052) added the success spine, Phase 2 (#2053) the failure side. This PR adds the two **on-chain terminal milestones** that close the deposit funnel.

> **Rebased onto `main` now that Phase 2 has merged.** The diff was previously showing Phase 2's files as if they were new — the branch was stacked and its merge-base was still Phase 1. It is now Phase-3-only: 4 files.

## What it adds

Emitted from `PeginPollingContext` as each vault's `contractStatus` transitions, per-vault with a scalar `vaultId`:

| Event | When |
| --- | --- |
| `activation.verified` | `contractStatus` VERIFIED - VP verified the presigned payouts |
| `deposit.completed` | `contractStatus` ACTIVE - **the true conversion terminal** (promised since Phase 1) |

This completes the primary funnel (`started → registered → broadcast.succeeded → activated → completed`) and lets `activation.verified` split the value-at-risk stall alert into VP-side (verified absent) vs depositor-side.

## The transition-diff problem, and how it's handled

The polling loop re-runs every cycle, so a naive emit-on-observe would (a) fire repeatedly for a vault sitting in a terminal state and (b) emit a **burst** on any dashboard load full of already-completed deposits. Two rules make emission per-vault and once-per-transition:

- **Seed on first observation.** The first time a vault is seen, if it's already at/past a milestone (a prior-session completion or a resumed deposit), it's marked emitted *without* emitting. So a page load never bursts.
- **Emit once thereafter**, the first cycle a *seen* vault is observed to have reached that state, then never again.

The detection is a **pure function** (`collectTerminalMilestones` in `terminalMilestones.ts`) - so the transition logic is unit-tested directly, not through the React tree.

## Review fixes since the last round

Thanks @gbarkhatov and @jrwbabylonlab — all three findings against Phase 3's own code were real. Each fix has a test that was verified to fail without it.

**1. Double-emit through co-mounted providers** (@gbarkhatov). Confirmed, and worse than reported. Tracking was a per-provider `useRef`, but several providers observe the same vault at once, so each emitted its own copy — the headline conversion metric counted twice on the normal completion path. Reproduced by mounting two real providers and counting `logger.event` calls: `["activation.verified", "activation.verified", "deposit.completed", "deposit.completed"]`.

There are three co-mount paths, and the third rules out the cheaper fix:

- `PendingDepositSection` → `PostDepositContinuationContent` mounts a second provider (nested).
- `PendingDepositSection` → `PendingDepositModals` → `SimpleDeposit` → `DepositSignContent` (nested).
- `RootLayout` renders `<Outlet/>` (→ dashboard) and `<SimpleDeposit>` as **siblings** — neither is an ancestor of the other, so "only emit in the outermost provider" would leave both self-identifying as outermost and both still emitting.

So tracking is now an **app-scoped module store keyed by vaultId**, which holds however many providers are mounted. It stays in-memory deliberately: a reload must reset it, so the seeding rule re-suppresses prior-session completions rather than replaying them. Regression test covers the nested path, the sibling path, and seeding.

**2. Seeding from localStorage-only rows** (@jrwbabylonlab). Confirmed — this was the sharpest catch, and it defeated the very burst-suppression the seeding rule exists for. `contractStatus` is never actually `undefined` in the real pipeline: the `usePeginStorage` merge fabricates a synthetic `PENDING` with `isPending: true` for rows the indexer hasn't returned. On a cold load with a stale pending row, the tracker seeded from that fabricated PENDING, then emitted both terminals one poll later for a transition that happened entirely while the user was away.

Milestones are now decided from an indexer-sourced status only (`isPending` rows are skipped). The `contractStatus === undefined` half of the guard stays as type-level narrowing for the optional field — with its comment corrected, since it was advertising itself as a load-in-progress guard it never was. Both halves have their own test; the `isPending` half has two.

**3. LIQUIDATED / DEPOSITOR_WITHDRAWN** (@gbarkhatov). Included. The right model is "terminal statuses that imply the vault reached ACTIVE" — a liquidated vault *did* convert, it activated first — which is exactly the contract-status set of the existing `isVaultPastActivation`, so `hasReachedActive` mirrors it rather than inventing a set. EXPIRED and INVALID are pre-activation aborts and still count for nothing; there's a test pinning that too.

**Not taken:**

- *Lazy `useRef` init* (@gbarkhatov, optional): moot — fix #1 removes the ref entirely.
- *Documenting slow registration as a seeding trigger* (@gbarkhatov, non-blocking): the header comment already names the two real triggers ("a prior-session completion, or a resumed deposit"). A vault can't realistically first appear already VERIFIED — the depositor must broadcast BTC and wait for confirmations first, which is what makes registration→activities latency a non-issue here. Adding it would make an accurate comment wrong.
- *Phase 2's failure-capture issues* (@gbarkhatov #2–#5): real, but they're against code that merged in #2053 and is no longer in this diff. Split into a follow-up as you suggested — see the linked PR.

**Known limitation** (unchanged): tracking is session-scoped, so a transition that happened entirely while the user was away is treated as pre-existing and not emitted. Acceptable for a first cut — it avoids localStorage persistence and the historical-burst problem.

## Deliberately deferred to Phase 4

The remaining transition-sensitive events: `activation.wots.submitted` / `payouts.signed` (localStorage status advance), `activation.daemon.terminal` (VP daemon terminal statuses), and the exit/redemption pegout terminals.

## Testing

- `terminalMilestones.test.ts` (11): the verified→completed sequence, no-burst seeding, fast PENDING→ACTIVE and →REDEEMED jumps, →LIQUIDATED, EXPIRED emitting nothing, the missing-status guard, the two localStorage-only seeding cases, in-session emission surviving the guard, and per-vault independence in a batch.
- `terminalMilestoneEmission.test.tsx` (3): once-per-vault emission across nested and sibling providers, and no emission for an already-ACTIVE vault.
- Each fix mutation-checked: reverting it fails exactly its own tests and nothing else.
- Full vault suite green: **228 files, 2406 tests**. eslint clean; `tsc -p tsconfig.lib.json` clean.
