### PR TITLE
fix(wallet-connector): disable Base Account SDK telemetry injection

### DIFF
--- a/packages/babylon-wallet-connector/src/core/wallets/appkit/appKitModal.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/appkit/appKitModal.ts
@@ -5,6 +5,7 @@ import { bitcoin, bitcoinSignet } from "@reown/appkit/networks";
 import { createAppKit } from "@reown/appkit/react";
 import { http, type Chain } from "viem";
 import { cookieStorage, createStorage } from "wagmi";
+import { baseAccount } from "wagmi/connectors";
 
 import { setSharedBtcAppKitConfig } from "../btc/appkit/sharedConfig";
 import { setSharedWagmiConfig } from "../eth/appkit/sharedConfig";
@@ -104,11 +105,15 @@ export function initializeAppKitModal(config: AppKitModalConfig) {
     // wagmi falls back to viem's bundled public RPC (e.g. sepolia.drpc.org)
     // which doesn't see contracts on private/devnet deployments.
     const ethRpcUrl = config.eth.chain.rpcUrls.default.http[0];
+    // Supply the Base Account connector ourselves so AppKit skips constructing
+    // its own default one. Its default enables the Base Account SDK's telemetry,
+    // which injects an inline analytics script into the page.
     wagmiAdapter = new WagmiAdapter({
       networks: ethNetworks,
       projectId,
       ssr: false,
       storage,
+      connectors: [baseAccount({ preference: { telemetry: false } })],
       transports: {
         [config.eth.chain.id]: http(ethRpcUrl),
       },


### PR DESCRIPTION
## What

Supplies the `baseAccount` wagmi connector explicitly with `preference: { telemetry: false }`, so the Base Account SDK never injects its inline analytics script.

## Why

Since the CSP shipped (#1859), every page load logs three of these:

```
Executing inline script violates the following Content Security Policy directive 'script-src 'self' 'wasm-unsafe-eval''.
Either the 'unsafe-inline' keyword, a hash ('sha256-NzvNrqk5jB9YZATwo5BF4JoRlJ02HsnFikbKXgEPdaQ='), or a nonce ('nonce-...') is required.
    at initCCA.js:12
```

`initCCA.js` is Coinbase Client Analytics, vendored inside `@base-org/account`. It reaches us transitively: our `WagmiAdapter` → `@reown/appkit-adapter-wagmi` → `@wagmi/connectors` `baseAccount` → `createBaseAccountSDK()`. The SDK builds a `<script>` whose `textContent` is a bundled Amplitude library and appends it to `document.head`, which would report a persistent device ID to `https://cca-lite.coinbase.com`. The CSP blocks it, so the console fills with violations on every load.

The block itself is harmless (the SDK guards on `if (window.ClientAnalytics)` and no-ops), but the noise buries real errors, and the telemetry is something we don't want running regardless.

## How

`@reown/appkit-adapter-wagmi` only constructs its own default `baseAccount()` connector when our wagmi config doesn't already provide one:

```js
// @reown/appkit-adapter-wagmi/dist/esm/src/utils/helpers.js
if (baseAccount && !connectors.some(c => c.id === 'baseAccount')) {
  return baseAccount();   // default — telemetry on
}
```

So passing our own connector through `WagmiAdapter`'s `connectors` option preempts the default. The preference then flows through to the SDK's opt-out:

```js
// @base-org/account/dist/interface/builder/core/createBaseAccountSDK.js
if (options.preference.telemetry !== false) {
  void loadTelemetryScript();   // skipped
}
```

`telemetry?: boolean` is a documented, first-class field on the SDK's `Preference` type — not a workaround.

## Why not the alternatives

- **Allowlisting the `sha256-...` hash in the CSP** — the hash is of the SDK's bundled telemetry script and rotates on every release (including silent transitive bumps), so it would re-break unpredictably. It would also re-enable the tracking the CSP is currently stopping.
- **`'unsafe-inline'` in `script-src`** — removes the policy's main protection against injected inline scripts.
- **`enableCoinbase: false`** — drops Coinbase Wallet support entirely.

## Verification

- `pnpm --filter @babylonlabs-io/wallet-connector build` — typechecks and builds clean.
- `pnpm --filter @babylonlabs-io/wallet-connector lint` — 0 errors.
- Confirmed in the built bundle that `connectors: [baseAccount({ preference: { telemetry: !1 } })]` is emitted, that the bundled connector carries `id: "baseAccount"` (so AppKit's check matches it), and that the SDK's `i.preference.telemetry !== !1 && cs()` guard therefore skips the injection.

Still worth a manual check on a preview: connect with Base Account / Coinbase Wallet and confirm the wallet still lists and connects, since we now supply the connector AppKit used to build.
