### PR TITLE
fix(vault): proxy sidecar API through the dev server

### DIFF
--- a/services/vault/.env.example
+++ b/services/vault/.env.example
@@ -43,6 +43,14 @@ NEXT_PUBLIC_REOWN_PROJECT_ID=your-reown-project-id-here
 # sidecar host for that environment.
 # NEXT_PUBLIC_TBV_SIDECAR_API_URL=
 
+# Local development only. The sidecar sends no CORS headers for http://localhost, so
+# calling it directly from `pnpm dev` fails preflight and logos stay blank. Set
+# SIDECAR_PROXY_TARGET to the sidecar host and NEXT_PUBLIC_TBV_SIDECAR_API_URL to the dev
+# server's /sidecar prefix, and the dev server proxies the call so it stays same-origin.
+# Leave both unset to call the sidecar directly (the deployed behaviour).
+# SIDECAR_PROXY_TARGET=https://sidecar-api.<env>.babylonlabs.io
+# NEXT_PUBLIC_TBV_SIDECAR_API_URL=http://localhost:5173/sidecar
+
 # Feature Flags (all default to disabled; set to "true" to enable)
 # Kill-switch for the vault supply-cap UI (dashboard section + deposit-form validation).
 # When enabled, the CapPolicy contract is never read. Vault cap is on by default.

--- a/services/vault/vite.config.ts
+++ b/services/vault/vite.config.ts
@@ -2,7 +2,7 @@ import { sentryVitePlugin } from "@sentry/vite-plugin";
 import react from "@vitejs/plugin-react";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import EnvironmentPlugin from "vite-plugin-environment";
 import { nodePolyfills } from "vite-plugin-node-polyfills";
 import tsconfigPaths from "vite-tsconfig-paths";
@@ -24,6 +24,33 @@ const SECURITY_HEADERS = {
   "Permissions-Policy": "camera=(), microphone=(), geolocation=()",
 };
 
+// Dev-server-only proxy for the sidecar API. The sidecar sends no
+// Access-Control-Allow-Origin for http://localhost, so the browser's preflight of
+// POST /logo (Content-Type: application/json) fails and provider logos never load.
+// Routing the call through the dev server keeps it same-origin, so no preflight happens.
+// Set SIDECAR_PROXY_TARGET to the sidecar host and point
+// NEXT_PUBLIC_TBV_SIDECAR_API_URL at this prefix to use it; unset, the proxy is skipped
+// and the app calls the sidecar directly, as it does in deployed builds.
+const SIDECAR_PROXY_PATH = "/sidecar";
+// .env is not loaded into process.env for this config module, so read it directly. The
+// mode only selects extra .env.[mode] files; plain .env is always read.
+const { SIDECAR_PROXY_TARGET: sidecarProxyTarget } = loadEnv(
+  process.env.NODE_ENV ?? "development",
+  __dirname,
+  "SIDECAR_",
+);
+
+const sidecarProxy = sidecarProxyTarget
+  ? {
+      [SIDECAR_PROXY_PATH]: {
+        target: sidecarProxyTarget,
+        changeOrigin: true,
+        rewrite: (path: string) =>
+          path.replace(new RegExp(`^${SIDECAR_PROXY_PATH}`), ""),
+      },
+    }
+  : undefined;
+
 const isSentryDisabled =
   process.env.NEXT_BUILD_E2E || process.env.DISABLE_SENTRY === "true";
 
@@ -39,6 +66,7 @@ const enableSentryPlugin =
 export default defineConfig({
   server: {
     headers: SECURITY_HEADERS,
+    proxy: sidecarProxy,
   },
   resolve: {
     dedupe: ["@babylonlabs-io/core-ui", "react", "react-dom"],

--- a/services/vault/vite.config.ts
+++ b/services/vault/vite.config.ts
@@ -32,24 +32,21 @@ const SECURITY_HEADERS = {
 // NEXT_PUBLIC_TBV_SIDECAR_API_URL at this prefix to use it; unset, the proxy is skipped
 // and the app calls the sidecar directly, as it does in deployed builds.
 const SIDECAR_PROXY_PATH = "/sidecar";
-// .env is not loaded into process.env for this config module, so read it directly. The
-// mode only selects extra .env.[mode] files; plain .env is always read.
-const { SIDECAR_PROXY_TARGET: sidecarProxyTarget } = loadEnv(
-  process.env.NODE_ENV ?? "development",
-  __dirname,
-  "SIDECAR_",
-);
 
-const sidecarProxy = sidecarProxyTarget
-  ? {
-      [SIDECAR_PROXY_PATH]: {
-        target: sidecarProxyTarget,
-        changeOrigin: true,
-        rewrite: (path: string) =>
-          path.replace(new RegExp(`^${SIDECAR_PROXY_PATH}`), ""),
-      },
-    }
-  : undefined;
+// .env files are not loaded into process.env for this config module, so read them
+// directly. The mode must come from Vite rather than NODE_ENV, or `vite --mode
+// dev-testnet` would miss the .env.dev-testnet override.
+function resolveSidecarProxy(mode: string) {
+  const { SIDECAR_PROXY_TARGET: target } = loadEnv(mode, __dirname, "SIDECAR_");
+  if (!target) return undefined;
+  return {
+    [SIDECAR_PROXY_PATH]: {
+      target,
+      changeOrigin: true,
+      rewrite: (path: string) => path.slice(SIDECAR_PROXY_PATH.length),
+    },
+  };
+}
 
 const isSentryDisabled =
   process.env.NEXT_BUILD_E2E || process.env.DISABLE_SENTRY === "true";
@@ -63,10 +60,10 @@ const enableSentryPlugin =
   );
 
 // https://vite.dev/config/
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
   server: {
     headers: SECURITY_HEADERS,
-    proxy: sidecarProxy,
+    proxy: resolveSidecarProxy(mode),
   },
   resolve: {
     dedupe: ["@babylonlabs-io/core-ui", "react", "react-dom"],
@@ -143,4 +140,4 @@ export default defineConfig({
     ),
     "process.env.NEXT_TELEMETRY_DISABLED": JSON.stringify("1"),
   },
-});
+}));


### PR DESCRIPTION
## What

Adds an opt-in dev-server proxy for the sidecar API, so provider logos load on `pnpm dev`. Dev-only — deployed builds are unaffected.

## Why

On localhost the console shows:

```
Access to fetch at 'https://sidecar-api.<env>.babylonlabs.io/logo' from origin 'http://localhost:5173'
has been blocked by CORS policy: Response to preflight request doesn't pass access control check:
No 'Access-Control-Allow-Origin' header is present on the requested resource.
POST https://sidecar-api.<env>.babylonlabs.io/logo net::ERR_FAILED     logoClient.ts:13
```

`fetchLogos` POSTs with `Content-Type: application/json`, which is not a CORS-safelisted value, so the browser preflights. The sidecar answers `OPTIONS` with `405` and no `Access-Control-Allow-Origin`, so the request never happens and provider logos stay blank locally. `fetchLogos` swallows it (`catch { return {}; }`), so nothing breaks — it's just a dead feature and a red console error in dev.

Allowing `http://localhost` in the sidecar's CORS was rejected (correctly — it's a shared deployed API), so this fixes it on our side instead: route the call through the Vite dev server, which makes it same-origin and skips the preflight entirely.

## How

Opt-in via `SIDECAR_PROXY_TARGET`. When unset the proxy isn't registered at all and the app calls the sidecar directly, which is exactly what deployed builds do — so this cannot affect production.

To use it locally:

```
SIDECAR_PROXY_TARGET=https://sidecar-api.<env>.babylonlabs.io
NEXT_PUBLIC_TBV_SIDECAR_API_URL=http://localhost:5173/sidecar
```

The target is read with Vite's `loadEnv` rather than `process.env`, because Vite does not populate `process.env` from `.env` files for the config module itself — reading `process.env.SIDECAR_PROXY_TARGET` there silently yields `undefined` and the proxy never registers.

`NEXT_PUBLIC_TBV_SIDECAR_API_URL` stays an absolute URL because `parseOptionalUrl` in `config/env.ts` requires an `http(s)` scheme and is shared by four other settings; relaxing it to accept a relative path was out of scope for a dev-only fix.

## Verification

Ran the dev server against the real canon-devnet sidecar:

- Direct `OPTIONS` preflight to the sidecar → `405`, no `Access-Control-Allow-Origin` (reproduces the reported failure).
- Proxied `POST http://localhost:5173/sidecar/logo` with the target set in `.env` only → `200 {"data":{"images":{}}}`, matching a direct server-side `POST`.
- With `SIDECAR_PROXY_TARGET` unset → dev server boots normally and `/sidecar` is not proxied (the deployed code path).
- `pnpm --filter vault lint` → 0 errors.
