### PR TITLE
feat(vault): pass the Sentry tunnel URL through to CI builds

### DIFF
--- a/.github/workflows/service-release-vault.yml
+++ b/.github/workflows/service-release-vault.yml
@@ -193,7 +193,6 @@ jobs:
           # Misc
           NEXT_PUBLIC_DISPLAY_TESTING_MESSAGES: ${{ vars.NEXT_PUBLIC_DISPLAY_TESTING_MESSAGES }}
           NEXT_PUBLIC_NOTICE_BANNER_MESSAGE: ${{ vars.NEXT_PUBLIC_NOTICE_BANNER_MESSAGE }}
-          NEXT_PUBLIC_REPLAYS_RATE: ${{ vars.NEXT_PUBLIC_REPLAYS_RATE }}
 
       - name: Copy all index.html to fix path for activity, app/aave
         run: |

--- a/.github/workflows/service-release-vault.yml
+++ b/.github/workflows/service-release-vault.yml
@@ -169,6 +169,9 @@ jobs:
           SENTRY_DIST: ${{ github.run_id }}
           SENTRY_ENVIRONMENT: ${{ matrix.environment }}
           NEXT_PUBLIC_SENTRY_DSN: ${{ vars.NEXT_PUBLIC_SENTRY_DSN }}
+          # Proxies Sentry events through our own host. Unset, events go directly to
+          # Sentry's ingest host, which the CDN's connect-src does not allow.
+          NEXT_PUBLIC_SENTRY_TUNNEL_URL: ${{ vars.NEXT_PUBLIC_SENTRY_TUNNEL_URL }}
           NEXT_PUBLIC_RELEASE_ID: ${{ github.sha }}
           NEXT_PUBLIC_DIST_ID: ${{ github.run_id }}
           NEXT_PUBLIC_SENTRY_ENVIRONMENT: ${{ matrix.environment }}


### PR DESCRIPTION
## What

Passes `NEXT_PUBLIC_SENTRY_TUNNEL_URL` through to the vault build in CI. No-op until the matching GitHub variable is set.

Also drops `NEXT_PUBLIC_REPLAYS_RATE` from the same block, per @jrwbabylonlab's review.

## Why

Sentry currently transmits **nothing** from testnet. The DSN is configured, but the CDN's `connect-src` allowlist contains no Sentry host, so every event is blocked by CSP before it leaves the browser.

The fix is to route events through the sidecar's Sentry tunnel (per the team's service split, Sentry proxying lives in `babylon-sidecar-api`):

- babylonlabs-io/babylon-sidecar-api#39 — multi-project tunnel support (routes by the envelope's own DSN, allowlisted)
- babylonlabs-io/babylon-dapp-deployment#313 — adds the vault DSN to the testnet sidecar's allowlist

`sentry.client.config.ts` has supported a tunnel since #2028:

```ts
const tunnelUrl = process.env.NEXT_PUBLIC_SENTRY_TUNNEL_URL;
...
...(tunnelUrl ? { tunnel: tunnelUrl } : {}),
```

but the variable was never plumbed through the release workflow, so setting it in GitHub would have silently done nothing — the same class of failure that kept Sentry dark in the first place (the env-var mismatch behind #2028).

The tunnel URL stays an explicit variable rather than being derived from another service's URL, per the note in `sentry.client.config.ts` that it is "deliberately independent of the (logo) sidecar so that unrelated infrastructure can never silently disable telemetry again" — the dependency on the sidecar host is now a deliberate, visible config value, not an implicit coupling.

## Dropping `NEXT_PUBLIC_REPLAYS_RATE`

Confirmed dead for the vault: a repo-wide grep finds no consumer anywhere under `services/vault`. #2028 (`36c156594`) removed `replayIntegration` from `sentry.client.config.ts`, and its only remaining mentions there are the comment explaining why Session Replay is off:

> replay envelopes bypass `beforeSend`/`scrubSentryEvent`, and `maskAllText`/`maskAllInputs` do not mask request URLs or `href` attributes (the app renders the depositor's BTC address in both — the screening request URL and explorer `/address/<addr>` links)

So the variable is not merely unused — it advertises a knob that would be a privacy regression to turn without a replay-side redaction hook first. Removing it keeps the workflow honest about what the vault build actually reads.

`services/simple-staking` still consumes it (via `service-release-simple-staking.yml` and its own `constants.ts`); that injection is untouched.

## Verification

Built the vault with the variable set to the planned value, and confirmed it reaches the emitted bundle:

```js
tunnelUrl="https://sidecar-api.testnet.babylonlabs.io/sentry-tunnel"
```

Built again with the variable empty (what CI produces while the GitHub variable is unset): `tunnelUrl` is absent from the bundle entirely, so `Sentry.init` omits `tunnel` and behaviour is unchanged. This PR is inert until the variable is set.

The workflow YAML still parses after the removal, and the `Build project` step's env block resolves to 45 keys with `NEXT_PUBLIC_REPLAYS_RATE` gone and `NEXT_PUBLIC_SENTRY_TUNNEL_URL` present.

## Sequencing (this PR can merge any time; the variable must wait)

1. babylon-sidecar-api#39 merged and deployed to testnet.
2. babylon-dapp-deployment#313 merged, with `VAULT_SENTRY_DSN` set in its `testnet` environment.
3. The vault CSP `connect-src` gains `https://sidecar-api.testnet.babylonlabs.io` (edge config — requested from infra; only utils-api hosts are allowlisted today).
4. Then set `NEXT_PUBLIC_SENTRY_TUNNEL_URL=https://sidecar-api.testnet.babylonlabs.io/sentry-tunnel` in the `vault-testnet` environment. It is a variable, not a secret.
5. Verify by sending a test event and confirming it lands in the vault Sentry project.

Setting the variable before steps 1–3 would make events POST into a 404/CSP block and be dropped silently by the SDK's transport — worse than today, where the block is at least visible in DevTools.
