### PR TITLE
test(vault): e2e resume, self-provisioning setup, 24 words support

### DIFF
--- a/packages/babylon-wallet-connector/tests/e2e/fixtures/wallets/okx.ts
+++ b/packages/babylon-wallet-connector/tests/e2e/fixtures/wallets/okx.ts
@@ -60,6 +60,18 @@ async function clickPrimaryButton(frame: Frame): Promise<void> {
 }
 
 /**
+ * Switch OKX's seed grid to `count` words. OKX renders in the OS locale, so we drive the phrase-length
+ * selector structurally (never by the visible "N words" label): open the `okd-select-text` control, then
+ * pick the option carrying `data-e2e-okd-select-option-value="<count>"` (e.g. 12 or 24).
+ */
+async function selectOkxSeedWordCount(frame: Frame, count: number): Promise<void> {
+  await frame.locator('[data-testid="okd-select-text"]').first().click({ force: true }).catch(() => {});
+  await sleep(SETTLE.SHORT);
+  await frame.locator(`[data-e2e-okd-select-option-value="${count}"]`).first().click({ force: true }).catch(() => {});
+  await sleep(SETTLE.MODAL);
+}
+
+/**
  * OKX intermittently shows a promo/warning modal over the home (e.g. the OKT-Network shutdown notice).
  * Its overlay blocks the settings/network/copy controls, so close it if present. Best-effort no-op when
  * absent. NOTE: this uses OKX's generic dialog close-icon testid (the network selector shares it), so
@@ -197,8 +209,20 @@ export async function setupOKXWallet(context: BrowserContext, mnemonic: string, 
   const seedFrame = sesFrame(tab, "import");
   if (!seedFrame) throw new Error("OKX: seed-entry iframe (ses.html) not found");
   const words = mnemonic.trim().split(/\s+/).filter(Boolean);
-  const boxes = seedFrame.locator('input[data-testid="import-seed-phrase-or-private-key-page-seed-phrase-input"]');
+  let boxes = seedFrame.locator('input[data-testid="import-seed-phrase-or-private-key-page-seed-phrase-input"]');
   await boxes.first().waitFor({ state: "visible", timeout: WAIT_FOR.ELEMENT_SLOW_MS }).catch(() => {});
+  // The seed screen defaults to a 12-input grid with a phrase-length selector; a 24-word phrase needs
+  // it switched first, or the extra words are dropped. OKX renders in the OS locale, so we NEVER match
+  // the visible "N words" text — we drive the selector by its language-agnostic data attributes.
+  if ((await boxes.count()) !== words.length) {
+    await selectOkxSeedWordCount(seedFrame, words.length);
+    boxes = seedFrame.locator('input[data-testid="import-seed-phrase-or-private-key-page-seed-phrase-input"]');
+  }
+  const boxCount = await boxes.count();
+  if (boxCount < words.length)
+    throw new Error(
+      `OKX: seed grid shows ${boxCount} inputs but the phrase has ${words.length} words — the phrase-length selector (okd-select-text) did not switch. OKX's import UI likely changed; re-derive selectOkxSeedWordCount (okx.ts).`,
+    );
   for (let i = 0; i < words.length; i++) {
     await boxes.nth(i).click().catch(() => {});
     await boxes.nth(i).fill(words[i]).catch(() => {});

--- a/packages/babylon-wallet-connector/tests/e2e/fixtures/wallets/onekey.ts
+++ b/packages/babylon-wallet-connector/tests/e2e/fixtures/wallets/onekey.ts
@@ -10,9 +10,10 @@
  *    is on — `connectWallet` throws "requires single address mode" — so we disable it after import.
  *  - Onboarding runs in the full-page tab `ui-expand-tab.html`; OneKey renders it in English already,
  *    so there's no in-app language switch (unlike OKX). We still drive by `data-testid` where possible.
- *  - The 12 seed inputs (`phrase-input-index0..11`) each show an autocomplete popup and do NOT
- *    auto-advance, so typing word-by-word is fragile. OneKey fans a single paste across all 12 fields,
- *    so we write the phrase to the clipboard and paste into box 0, then clear the clipboard.
+ *  - The seed inputs (`phrase-input-index0..`) each show an autocomplete popup and do NOT auto-advance,
+ *    so typing word-by-word is fragile. OneKey fans a single paste across all fields and auto-expands the
+ *    grid to the phrase length (12 or 24 words), so we write the phrase to the clipboard and paste into
+ *    box 0, then clear the clipboard — no word-count selector needed.
  *  - After the passcode screen OneKey shows "Your wallet is ready" (→ Enter wallet) and then a
  *    referral-code modal (→ Skip) before landing on the wallet home.
  *  - The network selector trigger (the chain-icon cluster, "+16", next to "Account #1") carries no
@@ -197,7 +198,9 @@ export async function setupOneKeyWallet(context: BrowserContext, mnemonic: strin
   await clickByTestId(tab, "onboarding-create-or-import-wallet-option-phraseOrPrivateKey-btn");
   await sleep(SETTLE.MEDIUM);
 
-  // Fill the 12 seed words by pasting into box 0 (OneKey fans it across all inputs); clear the clipboard.
+  // Fill the seed words by pasting into box 0 — OneKey fans the paste across all inputs and auto-expands
+  // the grid to match the phrase length (12 or 24 words), so no word-count switch is needed; then clear
+  // the clipboard.
   const seedBox = tab.locator('[data-testid="phrase-input-index0"]').first();
   await seedBox.waitFor({ state: "visible", timeout: WAIT_FOR.ELEMENT_SLOW_MS }).catch(() => {});
   await tab.evaluate((m) => navigator.clipboard.writeText(m).catch(() => {}), mnemonic.trim()).catch(() => {});

--- a/packages/babylon-wallet-connector/tests/e2e/fixtures/wallets/unisat.ts
+++ b/packages/babylon-wallet-connector/tests/e2e/fixtures/wallets/unisat.ts
@@ -39,6 +39,25 @@ async function dismissModals(page: Page): Promise<void> {
   }
 }
 
+/**
+ * Switch UniSat's restore-screen seed grid to `count` words. The screen defaults to a 12-input grid and
+ * exposes a word-count selector, but its options are bare <span>s with no testid/role/class — so we
+ * can't target them structurally. The option LABEL always contains the count as digits, though ("24
+ * words" / "24 слова" / "24 词"), so we match the DIGITS — which are the same in every UI language — and
+ * exclude the numbered seed-row labels ("24."). Picking the option resizes the grid.
+ */
+async function selectSeedWordCount(page: Page, count: number): Promise<void> {
+  // \b<count>\b not followed by a "." (so a "24." row label can't match), anywhere in the label.
+  const target = new RegExp(`\\b${count}\\b(?!\\.)`);
+  const option = page.getByText(target).first();
+  await option.click({ force: true }).catch(() => {});
+  await page.waitForTimeout(SETTLE.SHORT);
+  if ((await page.locator("input:visible, textarea:visible").count()) >= count) return;
+  // Fallback: the selector may be a closed dropdown — click it again after a settle to open + pick.
+  await option.click({ force: true }).catch(() => {});
+  await page.waitForTimeout(SETTLE.SHORT);
+}
+
 /** Switch the network to Bitcoin Signet: pill → expand "Bitcoin Testnet" → "Bitcoin Signet". */
 async function switchToSignet(page: Page): Promise<void> {
   await dismissModals(page);
@@ -164,16 +183,21 @@ export async function setupUnisatWallet(context: BrowserContext, mnemonic: strin
   // Seed-entry screen — type each word with real key events.
   await page.waitForTimeout(SETTLE.BRIEF);
   const words = mnemonic.trim().split(/\s+/).filter(Boolean);
-  const seedInputs = page.locator("input:visible, textarea:visible");
+  // The restore screen defaults to a 12-input grid with a "<n> words" selector. A 24-word phrase needs
+  // the grid switched to 24 first, or the extra words are dropped — so match the grid to the phrase.
+  let seedInputs = page.locator("input:visible, textarea:visible");
+  if ((await seedInputs.count()) !== words.length) {
+    await selectSeedWordCount(page, words.length);
+    seedInputs = page.locator("input:visible, textarea:visible");
+  }
   const seedCount = await seedInputs.count();
-  if (seedCount >= words.length) {
-    for (let i = 0; i < words.length; i++) {
-      await seedInputs.nth(i).click();
-      await seedInputs.nth(i).pressSequentially(words[i], { delay: TYPE_DELAY_MS });
-    }
-  } else {
-    await seedInputs.first().click();
-    await seedInputs.first().fill(mnemonic.trim());
+  if (seedCount < words.length)
+    throw new Error(
+      `UniSat: seed grid shows ${seedCount} inputs but the phrase has ${words.length} words — the word-count selector did not switch. Its restore UI likely changed; re-derive selectSeedWordCount (unisat.ts).`,
+    );
+  for (let i = 0; i < words.length; i++) {
+    await seedInputs.nth(i).click();
+    await seedInputs.nth(i).pressSequentially(words[i], { delay: TYPE_DELAY_MS });
   }
   await page.waitForTimeout(SETTLE.BRIEF);
   await advance(page, /continue|import|next|confirm/i);

--- a/services/vault/e2e/real/actions/index.ts
+++ b/services/vault/e2e/real/actions/index.ts
@@ -1,6 +1,6 @@
 /**
  * Registry of implemented actions: connect, observe, wallet-config, pegin, sign-conformance, borrow,
- * repay, and withdraw.
+ * repay, withdraw, and resume.
  */
 import type { ActionId } from "../config";
 
@@ -9,6 +9,7 @@ import { connectAction } from "./connect";
 import { observeAction } from "./observe";
 import { peginAction } from "./pegin";
 import { repayAction } from "./repay";
+import { resumeAction } from "./resume";
 import { signConformanceAction } from "./signConformance";
 import type { Action } from "./types";
 import { walletConfigAction } from "./walletConfig";
@@ -23,4 +24,5 @@ export const ACTIONS_BY_ID: Partial<Record<ActionId, Action>> = {
   borrow: borrowAction,
   repay: repayAction,
   withdraw: withdrawAction,
+  resume: resumeAction,
 };

--- a/services/vault/e2e/real/actions/pegin.ts
+++ b/services/vault/e2e/real/actions/pegin.ts
@@ -30,23 +30,20 @@
  * NEVER run without an explicit go-ahead: it spends real signet BTC + Sepolia ETH and is not
  * idempotent (a crash after the Pre-PegIn broadcast leaves an on-chain in-flight deposit).
  */
-import type { BrowserContext, Locator, Page } from "@playwright/test";
+import type { Locator, Page } from "@playwright/test";
 
 import {
-  DASHBOARD_VAULT_TIMEOUT_MS,
   DEPOSIT_CTA_ENABLE_TIMEOUT_MS,
   FORM_SETTLE_MS,
-  PEGIN_POLL_INTERVAL_MS,
-  PEGIN_STEP_MACHINE_BUDGET_MS,
-  PEGIN_TX_FAILURE_RETRY_LIMIT,
   PROVIDER_LIST_TIMEOUT_MS,
   SPLIT_ALLOCATION_TIMEOUT_MS,
   STEP_TIMEOUT_MS,
 } from "../timing";
 
-import { installPopupApprover, sweepApprovals } from "./approver";
+import { installPopupApprover } from "./approver";
 import { startRecording } from "./recording";
-import { FLUID_CTA_SELECTOR, firstByTestid } from "./selectors";
+import { FLUID_CTA_SELECTOR } from "./selectors";
+import { assertActivatedAndOnDashboard, walkStepMachine } from "./stepMachine";
 import { type Action, type ActionContext } from "./types";
 import { connectWallets } from "./walletConnect";
 
@@ -64,39 +61,6 @@ const MAX_VAULTS_CTA_LABEL = "Maximum BTC Vaults reached"; // COPY.deposit.maxVa
 const VAULT_COUNT_UNAVAILABLE_CTA_LABEL =
   "Unable to verify BTC Vault count — please try again"; // COPY.deposit.maxVaultsReached.unavailableCta
 const SIGN_TRANSACTION_LABEL = "Sign Transaction"; // COPY.deposit.progress.buttons.signTransaction
-// The activation modal's confirm button. Selected testid-first (stable + text-independent) with a
-// tolerant-text fallback: the button copy drifts (COPY.deposit.activateConfirmation.activateButton
-// renders "Activate vault", lowercase v — an exact string silently stalled the run here), and the
-// data-testid isn't on the deployed build until it ships, so the fallback carries the current build.
-const ACTIVATE_VAULT_TESTID = '[data-testid="activate-vault-button"]';
-const ACTIVATE_VAULT_RX = /activate vault/i; // COPY.deposit.activateConfirmation.activateButton
-
-/** The activation modal's confirm button — testid if present (future-proof), else tolerant wording. */
-function activateButton(page: Page): Locator {
-  return firstByTestid(
-    page,
-    ACTIVATE_VAULT_TESTID,
-    page.getByRole("button", { name: ACTIVATE_VAULT_RX }),
-  );
-}
-const RISK_ACK_LABEL =
-  "I understand the risks of continuing without the artifacts."; // riskAcknowledgement
-const SKIP_LABEL = "Skip"; // COPY.deposit.inStepArtifact.skip
-// The DepositProgressView's recoverable-error CTA: the fluid submit relabels to "Retry" (and calls
-// `onRetry`) whenever a step tx fails with a retryable error (COPY.deposit.progress.buttons.retry). It's
-// only rendered in that error state — during signing the CTA is "Sign Transaction"/processing/"Done" —
-// so its visible text is a safe, state-specific target (mirrors how the Activate/Skip gates are matched).
-const RETRY_BUTTON_RX = /^retry$/i; // COPY.deposit.progress.buttons.retry
-function retryButton(page: Page): Locator {
-  return page.getByRole("button", { name: RETRY_BUTTON_RX }).first();
-}
-// Finish-line matchers are tolerant regexes, NOT exact strings: the deployed build's copy can drift
-// from local source (e.g. the heading renders "Vault activated" on devnet vs "BTC Vault activated" in
-// copy.ts), and we key on the stable actionable control (the "Go to Dashboard" button) rather than the
-// heading text so a wording tweak can't strand the run at the activated screen.
-const GO_TO_DASHBOARD_RX = /go to dashboard/i; // COPY.deposit.vaultActivatedSuccess.goToDashboard
-const VAULT_OPTIONS_RX = /vault options/i; // CollateralSection ExpandMenuButton aria-label ("[BTC ]Vault options")
-const VAULT_CARD_TESTID = '[data-testid="vault-card"]'; // CollateralVaultItem VaultCardShell (stable testid)
 // Two-vault split: the UtxoSplitSelector is an Accordion with NO testids (rows are `role="button"`
 // divs), so it's driven by role + visible text. The selector header shows "Do not split" while
 // single-vault (the default) and relabels to the split option once enabled.
@@ -108,7 +72,7 @@ const TWO_VAULT_SPLIT_RX = /Two-vault split/; // COPY.deposit.form.splitOptionLa
  * are copy/role-driven and were verified against the real DOM. Returns once the deposit progress view
  * has opened (the fluid CTA click transitions to it).
  */
-async function fillDepositForm(
+export async function fillDepositForm(
   page: Page,
   log: (m: string) => void,
   amountBtc: string,
@@ -288,7 +252,7 @@ async function waitForDepositCta(
 }
 
 /** Click the single "Sign Transaction" start button that kicks off the whole signing sequence. */
-async function startSigning(
+export async function startSigning(
   page: Page,
   log: (m: string) => void,
 ): Promise<void> {
@@ -300,408 +264,6 @@ async function startSigning(
     "Deposit progress open — starting the signing sequence (Sign Transaction)",
   );
   await signButton.click();
-}
-
-/** True once the terminal activated view is showing — detected by its "Go to Dashboard" button. */
-function activatedViewReached(page: Page): Promise<boolean> {
-  return page
-    .getByRole("button", { name: GO_TO_DASHBOARD_RX })
-    .first()
-    .isVisible()
-    .catch(() => false);
-}
-
-/**
- * Handle the `ActivateConfirmationModal` if it's showing: acknowledge the risk (we skip the artifact
- * download) then click "Activate Vault". The checkbox toggles on each click, so acknowledgement is
- * idempotent — only ticked when currently unchecked. Returns true once Activate Vault was clicked.
- */
-async function handleActivateConfirmation(
-  page: Page,
-  log: (m: string) => void,
-): Promise<boolean> {
-  const activate = activateButton(page);
-  if (!(await activate.isVisible().catch(() => false))) return false;
-
-  const checkbox = page.locator('[data-testid="checkbox-input"]').first();
-  if (
-    (await checkbox.count().catch(() => 0)) > 0 &&
-    !(await checkbox.isChecked().catch(() => false))
-  ) {
-    // Toggle via the label (the native input is a visually-hidden switcher); only when unchecked so
-    // repeated polls don't flip it back off.
-    const label = page.getByText(RISK_ACK_LABEL, { exact: true }).first();
-    if (await label.isVisible().catch(() => false)) {
-      await label.click().catch(() => {});
-    } else {
-      await checkbox.check({ force: true }).catch(() => {});
-    }
-  }
-
-  if (!(await activate.isEnabled().catch(() => false))) return false;
-  log("Activate confirmation: risk acknowledged → clicking Activate Vault");
-  await activate.click().catch(() => {});
-  return true;
-}
-
-/** Click "Skip" on the in-step artifact callout (proceed without downloading recovery artifacts). */
-async function handleArtifactSkip(
-  page: Page,
-  log: (m: string) => void,
-): Promise<boolean> {
-  const skip = page
-    .getByRole("button", { name: SKIP_LABEL, exact: true })
-    .first();
-  if (!(await skip.isVisible().catch(() => false))) return false;
-  log("Artifact step: Skip (continue without downloading recovery artifacts)");
-  await skip.click().catch(() => {});
-  return true;
-}
-
-/**
- * Capture this deposit's Pre-PegIn txid from the progress view. Explorer links render as
- * `<host>/tx/<txid>` anchors (CopyableHash); the depositor broadcasts + links the Pre-PegIn early in
- * the flow (well before the VP broadcasts the peg-in), so the first BTC txid to appear is this run's
- * Pre-PegIn. Used to pin the dashboard cross-check to THIS run's vault — a returning depositor's
- * dashboard lists several. Scans hrefs Node-side (no page-context function) and skips ETH links: an
- * ETH `/tx/0x…` hash never matches the 64-hex-no-0x BTC pattern.
- */
-async function readPrePeginTxid(page: Page): Promise<string | undefined> {
-  const links = page.locator('a[href*="/tx/"]');
-  const count = await links.count().catch(() => 0);
-  for (let i = 0; i < count; i++) {
-    const href = await links
-      .nth(i)
-      .getAttribute("href")
-      .catch(() => null);
-    const match = href?.match(/\/tx\/([0-9a-fA-F]{64})(?:$|[/?#])/);
-    if (match) return match[1].toLowerCase();
-  }
-  return undefined;
-}
-
-/**
- * Read the active step(s) for the run log: "Step N active (P%)" from the stepper + progress bar. In a
- * two-vault split the progress view shows two per-vault columns, each emitting its own
- * `aria-label="Step N active"` (the columns carry no distinguishing testid), so we collect ALL active
- * labels — the two lanes advance independently and may sit on different steps. The single progressbar
- * reflects the aggregate (slowest lane).
- */
-async function readActiveStep(page: Page): Promise<string> {
-  const actives = page.locator('[aria-label$="active"]');
-  const count = await actives.count().catch(() => 0);
-  const labels: string[] = [];
-  for (let i = 0; i < count; i++) {
-    const label = await actives
-      .nth(i)
-      .getAttribute("aria-label")
-      .catch(() => null);
-    if (label && !labels.includes(label)) labels.push(label);
-  }
-  const bar = page.locator('[role="progressbar"]').first();
-  const percent = await bar.getAttribute("aria-valuenow").catch(() => null);
-  if (labels.length === 0 && percent === null) return "";
-  return `${labels.length ? labels.join(", ") : "Step ?"} (${percent ?? "?"}%)`;
-}
-
-// The per-vault "WOTS key submission skipped" warning the app shows when the vault provider isn't ready
-// for WOTS-key submission before the readiness timeout (COPY.deposit.warnings.wotsReadinessTimeout /
-// wotsReadinessTerminal). A skipped vault is dropped from payout signing + activation and can NEVER
-// reach the activated view — so it's a hard dead-end for that vault, not a transient. Both variants
-// share this "Vault N: WOTS key submission skipped" prefix; the capture group is the vault number.
-const WOTS_SKIP_RX = /Vault\s+(\d+):\s*WOTS key submission skipped/i;
-
-/**
- * Count DISTINCT per-vault WOTS-key-submission-skip banners on the progress view. Deduped by the vault
- * number so a banner matched via nested elements (or re-rendered) isn't double-counted; a copy drift
- * that breaks the "Vault N:" prefix simply yields 0 (we degrade to the normal budget wait, never a
- * false abort). Used by walkStepMachine to fail fast when every expected vault has been skipped.
- */
-async function countWotsSkippedVaults(page: Page): Promise<number> {
-  const banners = page.getByText(/WOTS key submission skipped/i);
-  const count = await banners.count().catch(() => 0);
-  const vaults = new Set<string>();
-  for (let i = 0; i < count; i++) {
-    const text = (
-      await banners
-        .nth(i)
-        .innerText()
-        .catch(() => "")
-    ).replace(/\s+/g, " ");
-    const match = text.match(WOTS_SKIP_RX);
-    if (match) vaults.add(match[1]);
-  }
-  return vaults.size;
-}
-
-/**
- * Walk the 15-step signing machine to the activated vault. Two approval mechanisms run in parallel:
- * the event-driven `installPopupApprover` (for NEW wallet windows) and, each tick, an active
- * `sweepApprovals` pass over already-open windows — OKX reuses one approval window, so a later signing
- * prompt fires no `page` event and would otherwise never be clicked. This loop also drives the two
- * dapp-page gates the approver can't reach (Activate Vault + Skip) and follows the progress UI, logging
- * each transition, until the terminal view appears. `onStep` tags the recorder's HTTP fixtures.
- *
- * Returns this run's Pre-PegIn txid (captured once, as soon as the progress view links it) so the
- * finish-line check can target THIS run's vault card among a returning depositor's several.
- *
- * `expectedVaults` (1, or 2 for a split) gates the finish: the terminal "Go to Dashboard" view is
- * accepted only once we've driven that many activations. The app renders a TRANSIENT per-vault
- * "Go to Dashboard" (scoped to a single vault) that can appear after just one split vault activates —
- * so keying on that button alone could finish a split at 1/2. Counting the activations WE drove ties
- * completion to "both vaults activated", which is exactly what we did.
- */
-async function walkStepMachine(
-  page: Page,
-  context: BrowserContext,
-  log: (m: string) => void,
-  expectedVaults: number,
-  onStep: (step: string) => void,
-): Promise<string | undefined> {
-  const deadline = Date.now() + PEGIN_STEP_MACHINE_BUDGET_MS;
-  let lastStep = "";
-  // Per-appearance guards (NOT one-shot): a two-vault split has TWO activations, so the Activate modal
-  // and the artifact-Skip callout can each appear twice. We click once per appearance and re-arm when
-  // the control disappears — handling both vaults without double-clicking a single modal (which could
-  // fire a duplicate ETH tx).
-  let activateClickedThisModal = false;
-  let skipClickedThisCallout = false;
-  // A recoverable "Transaction failed → Retry" state (e.g. the intermittent public-Sepolia RPC
-  // gas-estimation flake that nulls a tx's `gasLimit`). Re-armed per appearance like the gates above,
-  // and capped at PEGIN_TX_FAILURE_RETRY_LIMIT total so a genuinely-failing tx aborts instead of looping.
-  let retryClickedThisCallout = false;
-  let txRetryCount = 0;
-  // Count the activations we've driven; the finish gate needs `expectedVaults` of them (see below).
-  let activationCount = 0;
-  let prePeginTxid: string | undefined;
-
-  while (Date.now() < deadline) {
-    // Finish only when the activated view is up AND we've driven every expected activation. The second
-    // clause rejects the transient per-vault "Go to Dashboard" that can flash after just one split
-    // vault activates, before the sibling is done. Single-vault (expectedVaults=1) is satisfied by the
-    // one activation this fresh deposit always performs.
-    if ((await activatedViewReached(page)) && activationCount >= expectedVaults)
-      return prePeginTxid;
-
-    // Fast-fail on a vault-provider readiness dead-end. If the VP never became ready for WOTS-key
-    // submission, the app skips that vault and it can never activate — so the finish gate
-    // (`activationCount >= expectedVaults`) becomes unreachable. Abort once there's no route left to a
-    // full completion: at least one vault was skipped AND every non-skipped vault has already activated
-    // (`activationCount >= expectedVaults - skippedVaults`). This covers both a fully-skipped deposit
-    // (single vault, or all split vaults) and a PARTIAL split (one sibling skipped, the other activated)
-    // — the latter would otherwise burn the entire multi-hour budget, the exact slow failure this guards.
-    const skippedVaults = await countWotsSkippedVaults(page);
-    if (skippedVaults > 0 && activationCount >= expectedVaults - skippedVaults)
-      throw new Error(
-        `Vault-provider readiness timeout: ${skippedVaults} of ${expectedVaults} vault(s) were skipped ` +
-          `for WOTS-key submission and cannot activate` +
-          `${activationCount > 0 ? ` (the other ${activationCount} activated)` : ""}. This is a ` +
-          `vault-provider availability issue (not the CLI) — retry once the provider is healthy. The ` +
-          `Pre-PegIn is already broadcast, so the deposit can be resumed later rather than re-pegged.`,
-      );
-
-    // Actively approve any reused wallet window (OKX) that the event approver can't see.
-    await sweepApprovals(context, page, log);
-
-    // Two dapp-page interactions the wallet pop-up approver can't perform, each re-armed per appearance.
-    const activateVisible = await activateButton(page)
-      .isVisible()
-      .catch(() => false);
-    if (activateVisible) {
-      if (!activateClickedThisModal) {
-        activateClickedThisModal = await handleActivateConfirmation(page, log);
-        if (activateClickedThisModal) activationCount += 1;
-      }
-    } else {
-      activateClickedThisModal = false;
-    }
-
-    const skipVisible = await page
-      .getByRole("button", { name: SKIP_LABEL, exact: true })
-      .first()
-      .isVisible()
-      .catch(() => false);
-    if (skipVisible) {
-      if (!skipClickedThisCallout)
-        skipClickedThisCallout = await handleArtifactSkip(page, log);
-    } else {
-      skipClickedThisCallout = false;
-    }
-
-    // Recover from a transient, app-retryable step-tx failure (e.g. the public-Sepolia RPC returning a
-    // null gasLimit on an activation tx): the progress view shows a "Transaction failed" callout with a
-    // Retry button that a human would just click. Click it — re-armed per appearance, capped at
-    // PEGIN_TX_FAILURE_RETRY_LIMIT so a persistently-failing tx aborts with the callout instead of
-    // spinning to the budget deadline. sweepApprovals (above) + the event approver confirm the wallet
-    // pop-up the retried tx re-opens. This does NOT touch `activationCount`: Retry re-runs the pending tx
-    // on the progress view, not the Activate modal, so a recovered activation stays counted exactly once.
-    const retryVisible = await retryButton(page)
-      .isVisible()
-      .catch(() => false);
-    if (retryVisible) {
-      if (!retryClickedThisCallout) {
-        if (txRetryCount >= PEGIN_TX_FAILURE_RETRY_LIMIT)
-          throw new Error(
-            `A step-machine transaction kept failing after ${PEGIN_TX_FAILURE_RETRY_LIMIT} retries — see the "Transaction failed" callout (a persistent RPC/gas-estimation or contract error, not a transient flake). trace.zip + the failure screenshot are captured.`,
-          );
-        txRetryCount += 1;
-        log(
-          `⚠️ Step-machine transaction failed — clicking Retry (${txRetryCount}/${PEGIN_TX_FAILURE_RETRY_LIMIT}) to recover from a transient tx/RPC failure`,
-        );
-        await retryButton(page)
-          .click({ timeout: STEP_TIMEOUT_MS })
-          .catch(() => {});
-        retryClickedThisCallout = true;
-      }
-    } else {
-      retryClickedThisCallout = false;
-    }
-
-    // Capture the Pre-PegIn txid once, the first tick the progress view links it.
-    if (!prePeginTxid) {
-      prePeginTxid = await readPrePeginTxid(page);
-      if (prePeginTxid)
-        log(`Captured this run's Pre-PegIn txid: ${prePeginTxid}`);
-    }
-
-    const step = await readActiveStep(page);
-    if (step && step !== lastStep) {
-      lastStep = step;
-      onStep(step);
-      log(`Step machine → ${step}`);
-    }
-    await page.waitForTimeout(PEGIN_POLL_INTERVAL_MS);
-  }
-  throw new Error(
-    `Peg-in did not reach the activated view (no "Go to Dashboard" button) within the step-machine budget — see trace.zip + the failure screenshot`,
-  );
-}
-
-/**
- * Finish line: click "Go to Dashboard", then best-effort confirm the vault landed as collateral. The
- * activated view is the definitive success signal (we're only here because its "Go to Dashboard"
- * button appeared); the dashboard card is a secondary check, so a copy/layout drift on the dashboard
- * is logged as a warning rather than hanging or failing an otherwise-successful peg-in.
- */
-async function assertActivatedAndOnDashboard(
-  page: Page,
-  log: (m: string) => void,
-  amountBtc: string,
-  prePeginTxid: string | undefined,
-  expectedVaults: number,
-): Promise<void> {
-  log("✅ Activated view reached — clicking Go to Dashboard");
-  await page
-    .getByRole("button", { name: GO_TO_DASHBOARD_RX })
-    .first()
-    .click({ timeout: STEP_TIMEOUT_MS });
-
-  // The freshly activated vault surfaces as collateral behind the per-vault options expander (its
-  // label may render "BTC Vault options" or "Vault options" depending on the build). Bounded waits so
-  // a dashboard drift can never hang the run.
-  const options = page.getByRole("button", { name: VAULT_OPTIONS_RX }).first();
-  const optionsShown = await options
-    .waitFor({ state: "visible", timeout: DASHBOARD_VAULT_TIMEOUT_MS })
-    .then(() => true)
-    .catch(() => false);
-  if (!optionsShown) {
-    log(
-      "⚠️ Dashboard collateral controls not found within the wait — activation succeeded; skipping the card cross-check.",
-    );
-    return;
-  }
-
-  // Expand the collateral panel so the vault cards render.
-  const cards = page.locator(VAULT_CARD_TESTID);
-  if (
-    !(await cards
-      .first()
-      .isVisible()
-      .catch(() => false))
-  ) {
-    await options.click().catch(() => {});
-    await cards
-      .first()
-      .waitFor({ state: "visible", timeout: STEP_TIMEOUT_MS })
-      .catch(() => {});
-  }
-
-  // Two-vault split: both fresh cards share THIS run's single (batched) Pre-PegIn txid, and each shows
-  // its own split sub-amount (not the full requested amount), so the single-vault amount cross-check
-  // below doesn't apply. "Both vaults activated" is already guaranteed upstream — walkStepMachine only
-  // finishes once it has driven both activations — so this dashboard count is a SOFT secondary
-  // confirmation: the indexer commonly lags a just-activated vault's tx-hash row, so a miss is logged
-  // (not failed) rather than turning indexer lag into a false failure on a real-funds run.
-  if (expectedVaults > 1) {
-    // Both fresh split cards share this run's Pre-PegIn txid, but the indexer commonly lags a
-    // just-activated vault's tx-hash row — so poll (bounded) for both cards to link the txid rather
-    // than snapshotting once and warning on a transient 1/2.
-    const matchingCards = () =>
-      prePeginTxid
-        ? cards
-            .filter({ has: page.locator(`a[href*="${prePeginTxid}"]`) })
-            .count()
-            .catch(() => 0)
-        : Promise.resolve(0);
-    let matched = await matchingCards();
-    const deadline = Date.now() + DASHBOARD_VAULT_TIMEOUT_MS;
-    while (matched < expectedVaults && Date.now() < deadline) {
-      await page.waitForTimeout(PEGIN_POLL_INTERVAL_MS);
-      matched = await matchingCards();
-    }
-    const total = await cards.count().catch(() => 0);
-    if (matched >= expectedVaults)
-      log(
-        `Dashboard shows ${matched} split vaults for this run (matched by Pre-PegIn txid ${prePeginTxid?.slice(0, 8)}…).`,
-      );
-    else
-      log(
-        `⚠️ Dashboard matched ${matched}/${expectedVaults} split vaults by Pre-PegIn txid within the wait (${total} cards total) — activation succeeded; the indexer may still be catching up to the fresh vaults' tx-hash rows.`,
-      );
-    return;
-  }
-
-  // A returning depositor's dashboard lists several vault cards, so `.first()` is not necessarily the
-  // one this run created — matching the first card against the requested amount produced a false
-  // mismatch warning against an older vault. Prefer THIS run's Pre-PegIn txid captured mid-flow: the
-  // card links it in its "TX Hash" row (PeginTxHashRow, linkPrePegin default) as `<a href=".../tx/…">`.
-  // But that row is indexer-sourced, and for a JUST-activated vault the indexer commonly lags the click
-  // to the dashboard — the fresh card shows its amount (from activation state) before its tx-hash row
-  // populates. So the amount match is the expected, immediately-authoritative identifier for a fresh
-  // vault; the txid match engages once the indexer has caught up (e.g. an already-indexed vault). First
-  // card is the last resort when neither is captured.
-  const byTxid = prePeginTxid
-    ? cards.filter({ has: page.locator(`a[href*="${prePeginTxid}"]`) }).first()
-    : null;
-  const byAmount = cards
-    .filter({
-      hasText: new RegExp(
-        `${amountBtc.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*sBTC`,
-      ),
-    })
-    .first();
-
-  let card = cards.first();
-  let matchedBy = "first card (fallback)";
-  if (byTxid && (await byTxid.isVisible().catch(() => false))) {
-    card = byTxid;
-    matchedBy = `Pre-PegIn txid ${prePeginTxid?.slice(0, 8)}…`;
-  } else if (await byAmount.isVisible().catch(() => false)) {
-    card = byAmount;
-    matchedBy = `amount ${amountBtc}`;
-  }
-
-  const cardText = (await card.innerText().catch(() => ""))
-    .replace(/\s+/g, " ")
-    .trim();
-  if (cardText.includes(amountBtc))
-    log(
-      `Dashboard shows this run's vault as collateral (${amountBtc} sBTC, matched by ${matchedBy}).`,
-    );
-  else
-    log(
-      `⚠️ Dashboard vault card did not clearly show "${amountBtc}" (matched by ${matchedBy}; card: "${cardText.slice(0, 120)}") — activation still succeeded.`,
-    );
 }
 
 /**

--- a/services/vault/e2e/real/actions/resume.ts
+++ b/services/vault/e2e/real/actions/resume.ts
@@ -1,0 +1,314 @@
+/**
+ * The "resume" action: recover an interrupted peg-in from the dashboard's Pending Deposits UI and drive
+ * it through to an activated vault.
+ *
+ * A real peg-in spans 30 min–2 hr and the app is built to survive interruption: once the Pre-PegIn is
+ * broadcast the deposit is on-chain, and the dashboard resurfaces it under "Pending Deposits" with a
+ * resume action (Submit WOTS Key → Sign Payouts → Activate) driven from live vault-provider state. This
+ * action opens that pending card and hands off to the SAME `walkStepMachine` the `pegin` action uses —
+ * the resume flow renders the IDENTICAL `DepositProgressView` stepper — so the walk, the Activate-Vault
+ * gate, and the activated-view finish line are shared, not reimplemented.
+ *
+ * Two shapes:
+ *   - default: resume an ALREADY-pending deposit (by `--txid`, else the first actionable card).
+ *   - `--interrupt-fresh`: peg in a fresh deposit, interrupt it right after Pre-PegIn broadcast (reload
+ *     the page to a cold state), then resume it from the dashboard — a fully self-contained run.
+ *
+ * Cold-resume specifics: unlike the happy path (which holds the vault root in memory), the dashboard
+ * resume RE-DERIVES the vault root from the BTC wallet — a `deriveContextHash` approval dialog — to
+ * recompute the WOTS keys and verify them against the on-chain hash. That dialog is the same one normal
+ * peg-in step 1 (DERIVE_VAULT_SECRET) fires, so the shared pop-up approver already handles it; the
+ * resume steps otherwise auto-fire on mount, so the only dapp-page interactions are the pending-card
+ * click, the Activate gate, and "Go to Dashboard" — all owned by `walkStepMachine`.
+ *
+ * NEVER run `--interrupt-fresh` without an explicit go-ahead: it spends real signet BTC + Sepolia ETH.
+ */
+import type { Page } from "@playwright/test";
+
+import {
+  CONNECT_STATE_POLL_MS,
+  CONNECT_STATE_TIMEOUT_MS,
+  RESUME_ACTIONABLE_TIMEOUT_MS,
+  RESUME_CARD_APPEAR_TIMEOUT_MS,
+  RESUME_POLL_INTERVAL_MS,
+  STEP_TIMEOUT_MS,
+} from "../timing";
+
+import { installPopupApprover, sweepApprovals } from "./approver";
+import { fillDepositForm, startSigning } from "./pegin";
+import { startRecording } from "./recording";
+import {
+  assertActivatedAndOnDashboard,
+  walkStepMachine,
+  walkUntilPrePeginBroadcast,
+} from "./stepMachine";
+import { type Action, type ActionContext } from "./types";
+import { connectWallets } from "./walletConnect";
+
+const DEPOSIT_BUTTON_TESTID = '[data-testid="deposit-button"]'; // connected-state signal (dashboard)
+const CONNECT_BUTTON_TESTID = '[data-testid="connect-wallet-button"]'; // shown when disconnected
+// PendingDepositSection's ExpandMenuButton — the pending list (and each card's resume CTA) lives behind
+// it (aria-label="Pending deposit details"). The button is only rendered when a pending deposit exists,
+// so its presence doubles as "there is something to resume".
+const PENDING_EXPAND_RX = /pending deposit details/i;
+// Added to services/vault/src for this action (see PendingDepositCard.tsx): the card root carries the
+// deposit's Pre-PegIn txid (its tx-hash row links it), and the resume CTA renders ONLY once the deposit
+// is actionable — so waiting for the CTA is waiting for vault-provider readiness.
+const PENDING_CARD_TESTID = '[data-testid="pending-deposit-card"]';
+const PENDING_RESUME_CTA_TESTID = '[data-testid="pending-deposit-resume-cta"]';
+
+/** Normalize a Pre-PegIn txid flag to the bare lowercase hex the card's explorer href contains. */
+function normalizeTxid(txid: string | undefined): string | undefined {
+  const hex = txid?.trim().replace(/^0x/i, "").toLowerCase();
+  return hex && /^[0-9a-f]{64}$/.test(hex) ? hex : undefined;
+}
+
+/**
+ * After the interrupt reload, make sure the app is connected before we look for the pending card (the
+ * pending list reads the connected ETH address). wagmi/AppKit usually auto-reconnects on reload (the
+ * deposit button reappears with no pop-up); if instead the Connect button is shown, re-run the connect
+ * flow. Neither appearing is left to the pending-card wait to surface a clearer error.
+ */
+async function ensureConnected(ctx: ActionContext): Promise<void> {
+  const { page, context, log } = ctx;
+  const deposit = page.locator(DEPOSIT_BUTTON_TESTID).first();
+  const connect = page.locator(CONNECT_BUTTON_TESTID).first();
+  const deadline = Date.now() + CONNECT_STATE_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    if (await deposit.isVisible().catch(() => false)) return; // auto-reconnected
+    // Only click Connect once it's actually ENABLED. Right after the reload the app re-hydrates and the
+    // Connect button renders visible-but-DISABLED for a beat while wagmi/AppKit auto-reconnects; clicking
+    // that transient disabled button just times out (it detaches the instant the connected state swaps
+    // in). Waiting instead lets the auto-reconnect win and the deposit button appear above.
+    if (
+      (await connect.isVisible().catch(() => false)) &&
+      (await connect.isEnabled().catch(() => false))
+    ) {
+      log("Reconnecting wallets after the interrupt reload");
+      await connectWallets(ctx);
+      return;
+    }
+    await sweepApprovals(context, page, log);
+    await page.waitForTimeout(CONNECT_STATE_POLL_MS);
+  }
+  log(
+    "⚠️ After reload neither the connected state nor a Connect button appeared within the wait — proceeding; the pending-deposit wait will surface any connection issue.",
+  );
+}
+
+/** Expand the Pending Deposits section if its cards aren't visible yet (the CTA lives behind it). */
+async function ensurePendingExpanded(
+  page: Page,
+  log: (m: string) => void,
+): Promise<void> {
+  if (
+    await page
+      .locator(PENDING_CARD_TESTID)
+      .first()
+      .isVisible()
+      .catch(() => false)
+  )
+    return;
+  const expander = page
+    .getByRole("button", { name: PENDING_EXPAND_RX })
+    .first();
+  if (await expander.isVisible().catch(() => false)) {
+    log("Expanding the Pending Deposits section");
+    await expander.click().catch(() => {});
+  }
+}
+
+/** A concise snapshot of the target pending card's state, for a heads-up log while waiting. */
+async function readPendingCardState(
+  page: Page,
+  txid: string | undefined,
+): Promise<string> {
+  const card = txid
+    ? page
+        .locator(PENDING_CARD_TESTID)
+        .filter({ has: page.locator(`a[href*="${txid}"]`) })
+        .first()
+    : page.locator(PENDING_CARD_TESTID).first();
+  return (await card.innerText().catch(() => ""))
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 80);
+}
+
+/**
+ * Open the target pending deposit's resume flow: wait for the pending section, expand it, wait for the
+ * deposit to become actionable (its resume CTA renders only then — gated on the VP reaching the next
+ * step, which for a just-confirmed Pre-PegIn waits on signet block time), then click the CTA to open the
+ * continuation view. Targets the `--txid` card when given (its tx-hash row links the Pre-PegIn), else the
+ * first actionable card.
+ */
+async function openPendingDeposit(
+  ctx: ActionContext,
+  txid: string | undefined,
+): Promise<void> {
+  const { page, context, log } = ctx;
+
+  // 1. Wait for the pending section (the expander is only rendered when a deposit is pending).
+  const expander = page
+    .getByRole("button", { name: PENDING_EXPAND_RX })
+    .first();
+  const appearDeadline = Date.now() + RESUME_CARD_APPEAR_TIMEOUT_MS;
+  while (Date.now() < appearDeadline) {
+    if (await expander.isVisible().catch(() => false)) break;
+    await sweepApprovals(context, page, log);
+    await page.waitForTimeout(RESUME_POLL_INTERVAL_MS);
+  }
+  if (!(await expander.isVisible().catch(() => false)))
+    throw new Error(
+      "resume: no pending deposit found on the dashboard to resume. Peg in and interrupt one first (or re-run with --interrupt-fresh), or resume with an ETH account that has an in-flight deposit.",
+    );
+
+  await ensurePendingExpanded(page, log);
+
+  // 2. The resume CTA — scoped to the --txid card when given, else the first actionable card.
+  const cta = txid
+    ? page
+        .locator(PENDING_CARD_TESTID)
+        .filter({ has: page.locator(`a[href*="${txid}"]`) })
+        .locator(PENDING_RESUME_CTA_TESTID)
+        .first()
+    : page.locator(PENDING_RESUME_CTA_TESTID).first();
+
+  // 3. Wait for it to become actionable — can be long (VP must ingest the confirmed Pre-PegIn).
+  log(
+    txid
+      ? `Waiting for pending deposit ${txid.slice(0, 8)}… to become resumable (vault-provider readiness)…`
+      : "Waiting for a pending deposit to become resumable (vault-provider readiness)…",
+  );
+  const actionableDeadline = Date.now() + RESUME_ACTIONABLE_TIMEOUT_MS;
+  let lastState = "";
+  while (Date.now() < actionableDeadline) {
+    await ensurePendingExpanded(page, log);
+    if (await cta.isVisible().catch(() => false)) break;
+    const state = await readPendingCardState(page, txid);
+    if (state && state !== lastState) {
+      lastState = state;
+      log(`Pending deposit → ${state}`);
+    }
+    await sweepApprovals(context, page, log);
+    await page.waitForTimeout(RESUME_POLL_INTERVAL_MS);
+  }
+  if (!(await cta.isVisible().catch(() => false)))
+    throw new Error(
+      "resume: the pending deposit never became resumable within the budget — the vault provider may not have ingested the confirmed Pre-PegIn (signet confirmation delay / VP availability), or the deposit hit a terminal state. Retry once the card shows a resume action.",
+    );
+
+  const label = (await cta.innerText().catch(() => ""))
+    .replace(/\s+/g, " ")
+    .trim();
+  log(`Resuming pending deposit — clicking "${label || "resume"}"`);
+  await cta.click({ timeout: STEP_TIMEOUT_MS });
+}
+
+/**
+ * `--interrupt-fresh`: peg in a fresh deposit only as far as the Pre-PegIn broadcast, then reload the
+ * page to a cold state so the deposit must be resumed from the dashboard (the realistic "closed the tab,
+ * came back later" scenario). Reuses the pegin form + signing helpers and the shared broadcast walk.
+ */
+async function peginUntilInterrupt(
+  ctx: ActionContext,
+  onStep: (step: string) => void,
+): Promise<void> {
+  const { page, context, log } = ctx;
+  const amountBtc = ctx.config.peginAmountBtc?.trim();
+  if (!amountBtc)
+    throw new Error(
+      "resume --interrupt-fresh: no deposit amount resolved — the minimum-deposit fetch failed and no --amount was given. Re-run with --amount=<btc>, or against a reachable network.",
+    );
+  const provider = ctx.config.peginProvider?.trim() || undefined;
+  const split = ctx.config.split ?? false;
+
+  log(
+    "--interrupt-fresh: pegging in a fresh deposit, to interrupt after Pre-PegIn broadcast and resume it",
+  );
+  onStep("deposit-form");
+  await fillDepositForm(page, log, amountBtc, provider, split);
+
+  onStep("sign-transaction");
+  await startSigning(page, log);
+
+  onStep("until-broadcast");
+  const txid = await walkUntilPrePeginBroadcast(page, context, log, onStep);
+
+  log(
+    `Interrupting after Pre-PegIn broadcast (txid ${txid}) — reloading the page to a cold state.`,
+  );
+  onStep("reload");
+  await page.reload({ waitUntil: "domcontentloaded" });
+  await ensureConnected(ctx);
+}
+
+/**
+ * Resume the pending deposit through to activation: open its resume flow, then hand off to the shared
+ * step machine (WOTS → Sign → Activate → Go to Dashboard) and the dashboard collateral cross-check.
+ */
+async function runResumeFlow(
+  ctx: ActionContext,
+  onStep: (step: string) => void,
+): Promise<void> {
+  const { page, context, log } = ctx;
+
+  onStep("open-pending-deposit");
+  await openPendingDeposit(ctx, normalizeTxid(ctx.config.resumeTxid));
+
+  onStep("resume-step-machine");
+  const expectedVaults = ctx.config.split ? 2 : 1;
+  const prePeginTxid = await walkStepMachine(
+    page,
+    context,
+    log,
+    expectedVaults,
+    onStep,
+  );
+
+  onStep("finish");
+  // The resume flow doesn't always know the original deposit amount (a plain resume of a pre-existing
+  // deposit), so the dashboard cross-check runs by Pre-PegIn txid; --interrupt-fresh does pass the amount.
+  await assertActivatedAndOnDashboard(
+    page,
+    log,
+    ctx.config.peginAmountBtc,
+    prePeginTxid,
+    expectedVaults,
+  );
+  log(
+    "✅ Resume complete: the interrupted deposit reached an activated vault on the dashboard.",
+  );
+}
+
+export const resumeAction: Action = {
+  id: "resume",
+  async run(ctx: ActionContext): Promise<void> {
+    const { page, context, log, artifactsDir } = ctx;
+
+    // Approver stays installed for the whole run (auto-approves every wallet pop-up, incl. the
+    // cold-resume `deriveContextHash` vault-root dialog).
+    const handler = installPopupApprover(context, log);
+    let currentStep = "connect";
+    const recorder = await startRecording(
+      context,
+      page,
+      artifactsDir,
+      log,
+      () => currentStep,
+    );
+    try {
+      await connectWallets(ctx);
+      if (ctx.config.interruptFresh)
+        await peginUntilInterrupt(ctx, (step) => {
+          currentStep = step;
+        });
+      await runResumeFlow(ctx, (step) => {
+        currentStep = step;
+      });
+    } finally {
+      await recorder.stop();
+      context.off("page", handler);
+    }
+  },
+};

--- a/services/vault/e2e/real/actions/resume.ts
+++ b/services/vault/e2e/real/actions/resume.ts
@@ -209,11 +209,15 @@ async function openPendingDeposit(
  * `--interrupt-fresh`: peg in a fresh deposit only as far as the Pre-PegIn broadcast, then reload the
  * page to a cold state so the deposit must be resumed from the dashboard (the realistic "closed the tab,
  * came back later" scenario). Reuses the pegin form + signing helpers and the shared broadcast walk.
+ *
+ * Returns the fresh Pre-PegIn txid so the caller can target exactly THIS deposit when resuming — without
+ * it the resume would fall back to the first actionable pending card and could pick up an unrelated
+ * deposit (the dashboard commonly lists several in flight).
  */
 async function peginUntilInterrupt(
   ctx: ActionContext,
   onStep: (step: string) => void,
-): Promise<void> {
+): Promise<string> {
   const { page, context, log } = ctx;
   const amountBtc = ctx.config.peginAmountBtc?.trim();
   if (!amountBtc)
@@ -241,20 +245,28 @@ async function peginUntilInterrupt(
   onStep("reload");
   await page.reload({ waitUntil: "domcontentloaded" });
   await ensureConnected(ctx);
+  return txid;
 }
 
 /**
  * Resume the pending deposit through to activation: open its resume flow, then hand off to the shared
  * step machine (WOTS → Sign → Activate → Go to Dashboard) and the dashboard collateral cross-check.
+ *
+ * `targetTxid` (the just-created deposit's Pre-PegIn txid under `--interrupt-fresh`) takes precedence
+ * over `--txid`; when neither is set, `openPendingDeposit` falls back to the first actionable card.
  */
 async function runResumeFlow(
   ctx: ActionContext,
   onStep: (step: string) => void,
+  targetTxid?: string,
 ): Promise<void> {
   const { page, context, log } = ctx;
 
   onStep("open-pending-deposit");
-  await openPendingDeposit(ctx, normalizeTxid(ctx.config.resumeTxid));
+  await openPendingDeposit(
+    ctx,
+    normalizeTxid(targetTxid ?? ctx.config.resumeTxid),
+  );
 
   onStep("resume-step-machine");
   const expectedVaults = ctx.config.split ? 2 : 1;
@@ -299,13 +311,20 @@ export const resumeAction: Action = {
     );
     try {
       await connectWallets(ctx);
-      if (ctx.config.interruptFresh)
-        await peginUntilInterrupt(ctx, (step) => {
+      // --interrupt-fresh pegs in a new deposit and returns its Pre-PegIn txid so the resume targets
+      // exactly that card (not the first actionable one, which could be an unrelated pending deposit).
+      const freshTxid = ctx.config.interruptFresh
+        ? await peginUntilInterrupt(ctx, (step) => {
+            currentStep = step;
+          })
+        : undefined;
+      await runResumeFlow(
+        ctx,
+        (step) => {
           currentStep = step;
-        });
-      await runResumeFlow(ctx, (step) => {
-        currentStep = step;
-      });
+        },
+        freshTxid,
+      );
     } finally {
       await recorder.stop();
       context.off("page", handler);

--- a/services/vault/e2e/real/actions/resume.ts
+++ b/services/vault/e2e/real/actions/resume.ts
@@ -96,25 +96,22 @@ async function ensureConnected(ctx: ActionContext): Promise<void> {
   );
 }
 
-/** Expand the Pending Deposits section if its cards aren't visible yet (the CTA lives behind it). */
+/**
+ * Expand the Pending Deposits section if it's collapsed (the deposit cards + their CTAs live behind it).
+ * Idempotent: the ExpandMenuButton reflects state via `aria-expanded`, so we match it ONLY while
+ * collapsed (`expanded: false`) and click once. Clicking unconditionally on every poll would toggle the
+ * section open→closed and race the CTA click against a collapsing panel (landing on the wrong deposit).
+ */
 async function ensurePendingExpanded(
   page: Page,
   log: (m: string) => void,
 ): Promise<void> {
-  if (
-    await page
-      .locator(PENDING_CARD_TESTID)
-      .first()
-      .isVisible()
-      .catch(() => false)
-  )
-    return;
-  const expander = page
-    .getByRole("button", { name: PENDING_EXPAND_RX })
+  const collapsedToggle = page
+    .getByRole("button", { name: PENDING_EXPAND_RX, expanded: false })
     .first();
-  if (await expander.isVisible().catch(() => false)) {
+  if (await collapsedToggle.isVisible().catch(() => false)) {
     log("Expanding the Pending Deposits section");
-    await expander.click().catch(() => {});
+    await collapsedToggle.click().catch(() => {});
   }
 }
 
@@ -165,16 +162,28 @@ async function openPendingDeposit(
 
   await ensurePendingExpanded(page, log);
 
-  // 2. The resume CTA — scoped to the --txid card when given, else the first actionable card.
-  const cta = txid
+  // 2. The resume CTA. A single deposit exposes the CTA inside its own pending-deposit-card; a
+  //    batched/split deposit renders ONE group-level CTA (Broadcast / Continue / Activate) as a sibling
+  //    of its cards, inside the group's role=button wrapper. Both carry the same resume-cta testid, so we
+  //    scope one locator to the card and one to the wrapper (each filtered to the --txid deposit, else the
+  //    first actionable), and click whichever is present.
+  const txidHref = txid ? `a[href*="${txid}"]` : undefined;
+  const singleCta = txidHref
     ? page
         .locator(PENDING_CARD_TESTID)
-        .filter({ has: page.locator(`a[href*="${txid}"]`) })
+        .filter({ has: page.locator(txidHref) })
+        .locator(PENDING_RESUME_CTA_TESTID)
+        .first()
+    : page.locator(PENDING_RESUME_CTA_TESTID).first();
+  const batchedCta = txidHref
+    ? page
+        .locator('[role="button"]')
+        .filter({ has: page.locator(txidHref) })
         .locator(PENDING_RESUME_CTA_TESTID)
         .first()
     : page.locator(PENDING_RESUME_CTA_TESTID).first();
 
-  // 3. Wait for it to become actionable — can be long (VP must ingest the confirmed Pre-PegIn).
+  // 3. Wait for either to become actionable — can be long (VP must ingest the confirmed Pre-PegIn).
   log(
     txid
       ? `Waiting for pending deposit ${txid.slice(0, 8)}… to become resumable (vault-provider readiness)…`
@@ -184,7 +193,8 @@ async function openPendingDeposit(
   let lastState = "";
   while (Date.now() < actionableDeadline) {
     await ensurePendingExpanded(page, log);
-    if (await cta.isVisible().catch(() => false)) break;
+    if (await singleCta.isVisible().catch(() => false)) break;
+    if (await batchedCta.isVisible().catch(() => false)) break;
     const state = await readPendingCardState(page, txid);
     if (state && state !== lastState) {
       lastState = state;
@@ -193,6 +203,9 @@ async function openPendingDeposit(
     await sweepApprovals(context, page, log);
     await page.waitForTimeout(RESUME_POLL_INTERVAL_MS);
   }
+  const cta = (await singleCta.isVisible().catch(() => false))
+    ? singleCta
+    : batchedCta;
   if (!(await cta.isVisible().catch(() => false)))
     throw new Error(
       "resume: the pending deposit never became resumable within the budget — the vault provider may not have ingested the confirmed Pre-PegIn (signet confirmation delay / VP availability), or the deposit hit a terminal state. Retry once the card shows a resume action.",
@@ -200,9 +213,13 @@ async function openPendingDeposit(
 
   const label = (await cta.innerText().catch(() => ""))
     .replace(/\s+/g, " ")
-    .trim();
+    .trim()
+    .slice(0, 40);
   log(`Resuming pending deposit — clicking "${label || "resume"}"`);
-  await cta.click({ timeout: STEP_TIMEOUT_MS });
+  // `force`: a batched deposit's group is a role=button wrapper whose card children overlap the CTA's
+  // click point (the app's known "card-as-button" nesting), so the strict pointer-intercept check fails
+  // even though the CTA is the right, visible element; clicking it still fires the same group action.
+  await cta.click({ timeout: STEP_TIMEOUT_MS, force: true });
 }
 
 /**
@@ -228,7 +245,7 @@ async function peginUntilInterrupt(
   const split = ctx.config.split ?? false;
 
   log(
-    "--interrupt-fresh: pegging in a fresh deposit, to interrupt after Pre-PegIn broadcast and resume it",
+    "Pegging in a fresh deposit, to interrupt right after the Pre-PegIn broadcast",
   );
   onStep("deposit-form");
   await fillDepositForm(page, log, amountBtc, provider, split);
@@ -262,11 +279,14 @@ async function runResumeFlow(
 ): Promise<void> {
   const { page, context, log } = ctx;
 
+  // The deposit we're resuming (a fresh interrupt txid wins over --txid). Used BOTH to target the card
+  // AND as the ground-truth Pre-PegIn for the dashboard cross-check: walkStepMachine re-reads the first
+  // on-page /tx link, which in a resume is the dashboard *behind* the continuation view — a DIFFERENT
+  // deposit — so we prefer this known txid and only fall back to the read one (first-actionable resume).
+  const knownTxid = normalizeTxid(targetTxid ?? ctx.config.resumeTxid);
+
   onStep("open-pending-deposit");
-  await openPendingDeposit(
-    ctx,
-    normalizeTxid(targetTxid ?? ctx.config.resumeTxid),
-  );
+  await openPendingDeposit(ctx, knownTxid);
 
   onStep("resume-step-machine");
   const expectedVaults = ctx.config.split ? 2 : 1;
@@ -285,7 +305,7 @@ async function runResumeFlow(
     page,
     log,
     ctx.config.peginAmountBtc,
-    prePeginTxid,
+    knownTxid ?? prePeginTxid,
     expectedVaults,
   );
   log(
@@ -311,13 +331,21 @@ export const resumeAction: Action = {
     );
     try {
       await connectWallets(ctx);
-      // --interrupt-fresh pegs in a new deposit and returns its Pre-PegIn txid so the resume targets
-      // exactly that card (not the first actionable one, which could be an unrelated pending deposit).
-      const freshTxid = ctx.config.interruptFresh
-        ? await peginUntilInterrupt(ctx, (step) => {
-            currentStep = step;
-          })
-        : undefined;
+      // --interrupt-fresh / --interrupt-only peg in a new deposit and return its Pre-PegIn txid; fresh
+      // then resumes it (targeting exactly that card, not the first actionable one), while only stops
+      // here so the deposit can be resumed later in stages (manual on-chain checkpoints between).
+      const freshTxid =
+        ctx.config.interruptFresh || ctx.config.interruptOnly
+          ? await peginUntilInterrupt(ctx, (step) => {
+              currentStep = step;
+            })
+          : undefined;
+      if (ctx.config.interruptOnly) {
+        log(
+          `--interrupt-only: fresh deposit broadcast + interrupted (Pre-PegIn ${freshTxid}). Stopping before resume. Verify on-chain until it shows "Submit WOTS Key", then run: --action=resume --txid=${freshTxid}${ctx.config.split ? " --split" : ""}`,
+        );
+        return;
+      }
       await runResumeFlow(
         ctx,
         (step) => {

--- a/services/vault/e2e/real/actions/stepMachine.ts
+++ b/services/vault/e2e/real/actions/stepMachine.ts
@@ -1,0 +1,527 @@
+/**
+ * The shared peg-in signing step-machine + activated-view finish line, driven purely by AWAITING UI
+ * transitions (the `role="progressbar"` and each active step's `aria-label="Step N active"`), never
+ * fixed sleeps. Extracted from the `pegin` action so both `pegin` (form → sign → walk) and `resume`
+ * (dashboard pending card → walk) share ONE implementation of the 15-step `DepositProgressView` walk,
+ * the Activate-Vault / artifact-Skip dapp gates, the transient-tx Retry gate, the WOTS-skip fast-fail,
+ * and the dashboard collateral cross-check.
+ *
+ * The resume flow renders the IDENTICAL `DepositProgressView` stepper as the initial deposit, so the
+ * walk works unchanged for both. The artifact-Skip gate is re-armed per appearance and simply never
+ * fires in resume (that flow shows no Skip button) — it is optional, never required.
+ *
+ * No product/SDK code is reimplemented here; this only drives the UI. Wallet pop-ups (BTC signing,
+ * the `deriveContextHash` vault-root dialog, MetaMask txs) are auto-approved by the shared pop-up
+ * approver — the event-driven `installPopupApprover` plus the per-tick `sweepApprovals` this walk runs.
+ */
+import type { BrowserContext, Locator, Page } from "@playwright/test";
+
+import {
+  DASHBOARD_VAULT_TIMEOUT_MS,
+  PEGIN_POLL_INTERVAL_MS,
+  PEGIN_STEP_MACHINE_BUDGET_MS,
+  PEGIN_TX_FAILURE_RETRY_LIMIT,
+  STEP_TIMEOUT_MS,
+} from "../timing";
+
+import { sweepApprovals } from "./approver";
+import { firstByTestid } from "./selectors";
+
+// The activation modal's confirm button. Selected testid-first (stable + text-independent) with a
+// tolerant-text fallback: the button copy drifts (COPY.deposit.activateConfirmation.activateButton
+// renders "Activate vault", lowercase v — an exact string silently stalled the run here), and the
+// data-testid isn't on the deployed build until it ships, so the fallback carries the current build.
+const ACTIVATE_VAULT_TESTID = '[data-testid="activate-vault-button"]';
+const ACTIVATE_VAULT_RX = /activate vault/i; // COPY.deposit.activateConfirmation.activateButton
+
+/** The activation modal's confirm button — testid if present (future-proof), else tolerant wording. */
+function activateButton(page: Page): Locator {
+  return firstByTestid(
+    page,
+    ACTIVATE_VAULT_TESTID,
+    page.getByRole("button", { name: ACTIVATE_VAULT_RX }),
+  );
+}
+const RISK_ACK_LABEL =
+  "I understand the risks of continuing without the artifacts."; // riskAcknowledgement
+const SKIP_LABEL = "Skip"; // COPY.deposit.inStepArtifact.skip
+// The DepositProgressView's recoverable-error CTA: the fluid submit relabels to "Retry" (and calls
+// `onRetry`) whenever a step tx fails with a retryable error (COPY.deposit.progress.buttons.retry). It's
+// only rendered in that error state — during signing the CTA is "Sign Transaction"/processing/"Done" —
+// so its visible text is a safe, state-specific target (mirrors how the Activate/Skip gates are matched).
+const RETRY_BUTTON_RX = /^retry$/i; // COPY.deposit.progress.buttons.retry
+function retryButton(page: Page): Locator {
+  return page.getByRole("button", { name: RETRY_BUTTON_RX }).first();
+}
+// Finish-line matchers are tolerant regexes, NOT exact strings: the deployed build's copy can drift
+// from local source (e.g. the heading renders "Vault activated" on devnet vs "BTC Vault activated" in
+// copy.ts), and we key on the stable actionable control (the "Go to Dashboard" button) rather than the
+// heading text so a wording tweak can't strand the run at the activated screen.
+const GO_TO_DASHBOARD_RX = /go to dashboard/i; // COPY.deposit.vaultActivatedSuccess.goToDashboard
+const VAULT_OPTIONS_RX = /vault options/i; // CollateralSection ExpandMenuButton aria-label ("[BTC ]Vault options")
+const VAULT_CARD_TESTID = '[data-testid="vault-card"]'; // CollateralVaultItem VaultCardShell (stable testid)
+
+/** True once the terminal activated view is showing — detected by its "Go to Dashboard" button. */
+function activatedViewReached(page: Page): Promise<boolean> {
+  return page
+    .getByRole("button", { name: GO_TO_DASHBOARD_RX })
+    .first()
+    .isVisible()
+    .catch(() => false);
+}
+
+/**
+ * Handle the `ActivateConfirmationModal` if it's showing: acknowledge the risk (we skip the artifact
+ * download) then click "Activate Vault". The checkbox toggles on each click, so acknowledgement is
+ * idempotent — only ticked when currently unchecked. Returns true once Activate Vault was clicked.
+ */
+async function handleActivateConfirmation(
+  page: Page,
+  log: (m: string) => void,
+): Promise<boolean> {
+  const activate = activateButton(page);
+  if (!(await activate.isVisible().catch(() => false))) return false;
+
+  const checkbox = page.locator('[data-testid="checkbox-input"]').first();
+  if (
+    (await checkbox.count().catch(() => 0)) > 0 &&
+    !(await checkbox.isChecked().catch(() => false))
+  ) {
+    // Toggle via the label (the native input is a visually-hidden switcher); only when unchecked so
+    // repeated polls don't flip it back off.
+    const label = page.getByText(RISK_ACK_LABEL, { exact: true }).first();
+    if (await label.isVisible().catch(() => false)) {
+      await label.click().catch(() => {});
+    } else {
+      await checkbox.check({ force: true }).catch(() => {});
+    }
+  }
+
+  if (!(await activate.isEnabled().catch(() => false))) return false;
+  log("Activate confirmation: risk acknowledged → clicking Activate Vault");
+  await activate.click().catch(() => {});
+  return true;
+}
+
+/** Click "Skip" on the in-step artifact callout (proceed without downloading recovery artifacts). */
+async function handleArtifactSkip(
+  page: Page,
+  log: (m: string) => void,
+): Promise<boolean> {
+  const skip = page
+    .getByRole("button", { name: SKIP_LABEL, exact: true })
+    .first();
+  if (!(await skip.isVisible().catch(() => false))) return false;
+  log("Artifact step: Skip (continue without downloading recovery artifacts)");
+  await skip.click().catch(() => {});
+  return true;
+}
+
+/**
+ * Capture this deposit's Pre-PegIn txid from the progress view. Explorer links render as
+ * `<host>/tx/<txid>` anchors (CopyableHash); the depositor broadcasts + links the Pre-PegIn early in
+ * the flow (well before the VP broadcasts the peg-in), so the first BTC txid to appear is this run's
+ * Pre-PegIn. Used to pin the dashboard cross-check to THIS run's vault — a returning depositor's
+ * dashboard lists several. Scans hrefs Node-side (no page-context function) and skips ETH links: an
+ * ETH `/tx/0x…` hash never matches the 64-hex-no-0x BTC pattern.
+ */
+export async function readPrePeginTxid(
+  page: Page,
+): Promise<string | undefined> {
+  const links = page.locator('a[href*="/tx/"]');
+  const count = await links.count().catch(() => 0);
+  for (let i = 0; i < count; i++) {
+    const href = await links
+      .nth(i)
+      .getAttribute("href")
+      .catch(() => null);
+    const match = href?.match(/\/tx\/([0-9a-fA-F]{64})(?:$|[/?#])/);
+    if (match) return match[1].toLowerCase();
+  }
+  return undefined;
+}
+
+/**
+ * Read the active step(s) for the run log: "Step N active (P%)" from the stepper + progress bar. In a
+ * two-vault split the progress view shows two per-vault columns, each emitting its own
+ * `aria-label="Step N active"` (the columns carry no distinguishing testid), so we collect ALL active
+ * labels — the two lanes advance independently and may sit on different steps. The single progressbar
+ * reflects the aggregate (slowest lane).
+ */
+export async function readActiveStep(page: Page): Promise<string> {
+  const actives = page.locator('[aria-label$="active"]');
+  const count = await actives.count().catch(() => 0);
+  const labels: string[] = [];
+  for (let i = 0; i < count; i++) {
+    const label = await actives
+      .nth(i)
+      .getAttribute("aria-label")
+      .catch(() => null);
+    if (label && !labels.includes(label)) labels.push(label);
+  }
+  const bar = page.locator('[role="progressbar"]').first();
+  const percent = await bar.getAttribute("aria-valuenow").catch(() => null);
+  if (labels.length === 0 && percent === null) return "";
+  return `${labels.length ? labels.join(", ") : "Step ?"} (${percent ?? "?"}%)`;
+}
+
+// The per-vault "WOTS key submission skipped" warning the app shows when the vault provider isn't ready
+// for WOTS-key submission before the readiness timeout (COPY.deposit.warnings.wotsReadinessTimeout /
+// wotsReadinessTerminal). A skipped vault is dropped from payout signing + activation and can NEVER
+// reach the activated view — so it's a hard dead-end for that vault, not a transient. Both variants
+// share this "Vault N: WOTS key submission skipped" prefix; the capture group is the vault number.
+const WOTS_SKIP_RX = /Vault\s+(\d+):\s*WOTS key submission skipped/i;
+
+/**
+ * Count DISTINCT per-vault WOTS-key-submission-skip banners on the progress view. Deduped by the vault
+ * number so a banner matched via nested elements (or re-rendered) isn't double-counted; a copy drift
+ * that breaks the "Vault N:" prefix simply yields 0 (we degrade to the normal budget wait, never a
+ * false abort). Used by walkStepMachine to fail fast when every expected vault has been skipped.
+ */
+async function countWotsSkippedVaults(page: Page): Promise<number> {
+  const banners = page.getByText(/WOTS key submission skipped/i);
+  const count = await banners.count().catch(() => 0);
+  const vaults = new Set<string>();
+  for (let i = 0; i < count; i++) {
+    const text = (
+      await banners
+        .nth(i)
+        .innerText()
+        .catch(() => "")
+    ).replace(/\s+/g, " ");
+    const match = text.match(WOTS_SKIP_RX);
+    if (match) vaults.add(match[1]);
+  }
+  return vaults.size;
+}
+
+/**
+ * Walk the 15-step signing machine to the activated vault. Two approval mechanisms run in parallel:
+ * the event-driven `installPopupApprover` (for NEW wallet windows) and, each tick, an active
+ * `sweepApprovals` pass over already-open windows — OKX reuses one approval window, so a later signing
+ * prompt fires no `page` event and would otherwise never be clicked. This loop also drives the two
+ * dapp-page gates the approver can't reach (Activate Vault + Skip) and follows the progress UI, logging
+ * each transition, until the terminal view appears. `onStep` tags the recorder's HTTP fixtures.
+ *
+ * Returns this run's Pre-PegIn txid (captured once, as soon as the progress view links it) so the
+ * finish-line check can target THIS run's vault card among a returning depositor's several.
+ *
+ * `expectedVaults` (1, or 2 for a split) gates the finish: the terminal "Go to Dashboard" view is
+ * accepted only once we've driven that many activations. The app renders a TRANSIENT per-vault
+ * "Go to Dashboard" (scoped to a single vault) that can appear after just one split vault activates —
+ * so keying on that button alone could finish a split at 1/2. Counting the activations WE drove ties
+ * completion to "both vaults activated", which is exactly what we did.
+ */
+export async function walkStepMachine(
+  page: Page,
+  context: BrowserContext,
+  log: (m: string) => void,
+  expectedVaults: number,
+  onStep: (step: string) => void,
+): Promise<string | undefined> {
+  const deadline = Date.now() + PEGIN_STEP_MACHINE_BUDGET_MS;
+  let lastStep = "";
+  // Per-appearance guards (NOT one-shot): a two-vault split has TWO activations, so the Activate modal
+  // and the artifact-Skip callout can each appear twice. We click once per appearance and re-arm when
+  // the control disappears — handling both vaults without double-clicking a single modal (which could
+  // fire a duplicate ETH tx).
+  let activateClickedThisModal = false;
+  let skipClickedThisCallout = false;
+  // A recoverable "Transaction failed → Retry" state (e.g. the intermittent public-Sepolia RPC
+  // gas-estimation flake that nulls a tx's `gasLimit`). Re-armed per appearance like the gates above,
+  // and capped at PEGIN_TX_FAILURE_RETRY_LIMIT total so a genuinely-failing tx aborts instead of looping.
+  let retryClickedThisCallout = false;
+  let txRetryCount = 0;
+  // Count the activations we've driven; the finish gate needs `expectedVaults` of them (see below).
+  let activationCount = 0;
+  let prePeginTxid: string | undefined;
+
+  while (Date.now() < deadline) {
+    // Finish only when the activated view is up AND we've driven every expected activation. The second
+    // clause rejects the transient per-vault "Go to Dashboard" that can flash after just one split
+    // vault activates, before the sibling is done. Single-vault (expectedVaults=1) is satisfied by the
+    // one activation this fresh deposit always performs.
+    if ((await activatedViewReached(page)) && activationCount >= expectedVaults)
+      return prePeginTxid;
+
+    // Fast-fail on a vault-provider readiness dead-end. If the VP never became ready for WOTS-key
+    // submission, the app skips that vault and it can never activate — so the finish gate
+    // (`activationCount >= expectedVaults`) becomes unreachable. Abort once there's no route left to a
+    // full completion: at least one vault was skipped AND every non-skipped vault has already activated
+    // (`activationCount >= expectedVaults - skippedVaults`). This covers both a fully-skipped deposit
+    // (single vault, or all split vaults) and a PARTIAL split (one sibling skipped, the other activated)
+    // — the latter would otherwise burn the entire multi-hour budget, the exact slow failure this guards.
+    const skippedVaults = await countWotsSkippedVaults(page);
+    if (skippedVaults > 0 && activationCount >= expectedVaults - skippedVaults)
+      throw new Error(
+        `Vault-provider readiness timeout: ${skippedVaults} of ${expectedVaults} vault(s) were skipped ` +
+          `for WOTS-key submission and cannot activate` +
+          `${activationCount > 0 ? ` (the other ${activationCount} activated)` : ""}. This is a ` +
+          `vault-provider availability issue (not the CLI) — retry once the provider is healthy. The ` +
+          `Pre-PegIn is already broadcast, so the deposit can be resumed later rather than re-pegged.`,
+      );
+
+    // Actively approve any reused wallet window (OKX) that the event approver can't see.
+    await sweepApprovals(context, page, log);
+
+    // Two dapp-page interactions the wallet pop-up approver can't perform, each re-armed per appearance.
+    const activateVisible = await activateButton(page)
+      .isVisible()
+      .catch(() => false);
+    if (activateVisible) {
+      if (!activateClickedThisModal) {
+        activateClickedThisModal = await handleActivateConfirmation(page, log);
+        if (activateClickedThisModal) activationCount += 1;
+      }
+    } else {
+      activateClickedThisModal = false;
+    }
+
+    const skipVisible = await page
+      .getByRole("button", { name: SKIP_LABEL, exact: true })
+      .first()
+      .isVisible()
+      .catch(() => false);
+    if (skipVisible) {
+      if (!skipClickedThisCallout)
+        skipClickedThisCallout = await handleArtifactSkip(page, log);
+    } else {
+      skipClickedThisCallout = false;
+    }
+
+    // Recover from a transient, app-retryable step-tx failure (e.g. the public-Sepolia RPC returning a
+    // null gasLimit on an activation tx): the progress view shows a "Transaction failed" callout with a
+    // Retry button that a human would just click. Click it — re-armed per appearance, capped at
+    // PEGIN_TX_FAILURE_RETRY_LIMIT so a persistently-failing tx aborts with the callout instead of
+    // spinning to the budget deadline. sweepApprovals (above) + the event approver confirm the wallet
+    // pop-up the retried tx re-opens. This does NOT touch `activationCount`: Retry re-runs the pending tx
+    // on the progress view, not the Activate modal, so a recovered activation stays counted exactly once.
+    const retryVisible = await retryButton(page)
+      .isVisible()
+      .catch(() => false);
+    if (retryVisible) {
+      if (!retryClickedThisCallout) {
+        if (txRetryCount >= PEGIN_TX_FAILURE_RETRY_LIMIT)
+          throw new Error(
+            `A step-machine transaction kept failing after ${PEGIN_TX_FAILURE_RETRY_LIMIT} retries — see the "Transaction failed" callout (a persistent RPC/gas-estimation or contract error, not a transient flake). trace.zip + the failure screenshot are captured.`,
+          );
+        txRetryCount += 1;
+        log(
+          `⚠️ Step-machine transaction failed — clicking Retry (${txRetryCount}/${PEGIN_TX_FAILURE_RETRY_LIMIT}) to recover from a transient tx/RPC failure`,
+        );
+        await retryButton(page)
+          .click({ timeout: STEP_TIMEOUT_MS })
+          .catch(() => {});
+        retryClickedThisCallout = true;
+      }
+    } else {
+      retryClickedThisCallout = false;
+    }
+
+    // Capture the Pre-PegIn txid once, the first tick the progress view links it.
+    if (!prePeginTxid) {
+      prePeginTxid = await readPrePeginTxid(page);
+      if (prePeginTxid)
+        log(`Captured this run's Pre-PegIn txid: ${prePeginTxid}`);
+    }
+
+    const step = await readActiveStep(page);
+    if (step && step !== lastStep) {
+      lastStep = step;
+      onStep(step);
+      log(`Step machine → ${step}`);
+    }
+    await page.waitForTimeout(PEGIN_POLL_INTERVAL_MS);
+  }
+  throw new Error(
+    `Peg-in did not reach the activated view (no "Go to Dashboard" button) within the step-machine budget — see trace.zip + the failure screenshot`,
+  );
+}
+
+/**
+ * Drive the signing sequence only up to the Pre-PegIn broadcast and return its txid. Used by the
+ * `resume` action's `--interrupt-fresh` path to reach an on-chain, resumable deposit, which it then
+ * reloads (cold) to resume from the dashboard. Before broadcast the only wallet pop-ups are BTC signing
+ * (derive secret / sign PSBT / sign PoP) and the SUBMIT_PEGIN ETH tx — all handled by the approver +
+ * this loop's `sweepApprovals`; no Activate/Skip/Retry dapp gates fire yet. The Pre-PegIn txid link
+ * appears only once the app has signed AND broadcast it, so capturing it is the post-broadcast signal;
+ * we keep sweeping for a short settle afterwards so any final broadcast pop-up is confirmed before the
+ * caller reloads.
+ */
+export async function walkUntilPrePeginBroadcast(
+  page: Page,
+  context: BrowserContext,
+  log: (m: string) => void,
+  onStep: (step: string) => void,
+): Promise<string> {
+  const deadline = Date.now() + PEGIN_STEP_MACHINE_BUDGET_MS;
+  let lastStep = "";
+  while (Date.now() < deadline) {
+    await sweepApprovals(context, page, log);
+
+    const txid = await readPrePeginTxid(page);
+    if (txid) {
+      log(`Pre-PegIn broadcast — captured txid ${txid}`);
+      // Short settle: keep confirming pop-ups for a few ticks so the broadcast call fully lands before
+      // the caller reloads the page (reloading mid-broadcast could drop the mempool submission).
+      for (let i = 0; i < BROADCAST_SETTLE_TICKS; i++) {
+        await sweepApprovals(context, page, log);
+        await page.waitForTimeout(PEGIN_POLL_INTERVAL_MS);
+      }
+      return txid;
+    }
+
+    const step = await readActiveStep(page);
+    if (step && step !== lastStep) {
+      lastStep = step;
+      onStep(step);
+      log(`Step machine → ${step}`);
+    }
+    await page.waitForTimeout(PEGIN_POLL_INTERVAL_MS);
+  }
+  throw new Error(
+    "Pre-PegIn was not broadcast (no BTC txid linked in the progress view) within the step-machine budget — see trace.zip",
+  );
+}
+
+/** Ticks (× PEGIN_POLL_INTERVAL_MS) to keep sweeping pop-ups after the Pre-PegIn txid appears, so the
+ *  broadcast call lands before an interrupt reload. */
+const BROADCAST_SETTLE_TICKS = 3;
+
+/**
+ * Finish line: click "Go to Dashboard", then best-effort confirm the vault landed as collateral. The
+ * activated view is the definitive success signal (we're only here because its "Go to Dashboard"
+ * button appeared); the dashboard card is a secondary check, so a copy/layout drift on the dashboard
+ * is logged as a warning rather than hanging or failing an otherwise-successful peg-in.
+ *
+ * `amountBtc` may be undefined (the resume flow doesn't know the original deposit amount) — the
+ * amount cross-check is then skipped and the txid / first-card path is used instead.
+ */
+export async function assertActivatedAndOnDashboard(
+  page: Page,
+  log: (m: string) => void,
+  amountBtc: string | undefined,
+  prePeginTxid: string | undefined,
+  expectedVaults: number,
+): Promise<void> {
+  log("✅ Activated view reached — clicking Go to Dashboard");
+  await page
+    .getByRole("button", { name: GO_TO_DASHBOARD_RX })
+    .first()
+    .click({ timeout: STEP_TIMEOUT_MS });
+
+  // The freshly activated vault surfaces as collateral behind the per-vault options expander (its
+  // label may render "BTC Vault options" or "Vault options" depending on the build). Bounded waits so
+  // a dashboard drift can never hang the run.
+  const options = page.getByRole("button", { name: VAULT_OPTIONS_RX }).first();
+  const optionsShown = await options
+    .waitFor({ state: "visible", timeout: DASHBOARD_VAULT_TIMEOUT_MS })
+    .then(() => true)
+    .catch(() => false);
+  if (!optionsShown) {
+    log(
+      "⚠️ Dashboard collateral controls not found within the wait — activation succeeded; skipping the card cross-check.",
+    );
+    return;
+  }
+
+  // Expand the collateral panel so the vault cards render.
+  const cards = page.locator(VAULT_CARD_TESTID);
+  if (
+    !(await cards
+      .first()
+      .isVisible()
+      .catch(() => false))
+  ) {
+    await options.click().catch(() => {});
+    await cards
+      .first()
+      .waitFor({ state: "visible", timeout: STEP_TIMEOUT_MS })
+      .catch(() => {});
+  }
+
+  // Two-vault split: both fresh cards share THIS run's single (batched) Pre-PegIn txid, and each shows
+  // its own split sub-amount (not the full requested amount), so the single-vault amount cross-check
+  // below doesn't apply. "Both vaults activated" is already guaranteed upstream — walkStepMachine only
+  // finishes once it has driven both activations — so this dashboard count is a SOFT secondary
+  // confirmation: the indexer commonly lags a just-activated vault's tx-hash row, so a miss is logged
+  // (not failed) rather than turning indexer lag into a false failure on a real-funds run.
+  if (expectedVaults > 1) {
+    // Both fresh split cards share this run's Pre-PegIn txid, but the indexer commonly lags a
+    // just-activated vault's tx-hash row — so poll (bounded) for both cards to link the txid rather
+    // than snapshotting once and warning on a transient 1/2.
+    const matchingCards = () =>
+      prePeginTxid
+        ? cards
+            .filter({ has: page.locator(`a[href*="${prePeginTxid}"]`) })
+            .count()
+            .catch(() => 0)
+        : Promise.resolve(0);
+    let matched = await matchingCards();
+    const deadline = Date.now() + DASHBOARD_VAULT_TIMEOUT_MS;
+    while (matched < expectedVaults && Date.now() < deadline) {
+      await page.waitForTimeout(PEGIN_POLL_INTERVAL_MS);
+      matched = await matchingCards();
+    }
+    const total = await cards.count().catch(() => 0);
+    if (matched >= expectedVaults)
+      log(
+        `Dashboard shows ${matched} split vaults for this run (matched by Pre-PegIn txid ${prePeginTxid?.slice(0, 8)}…).`,
+      );
+    else
+      log(
+        `⚠️ Dashboard matched ${matched}/${expectedVaults} split vaults by Pre-PegIn txid within the wait (${total} cards total) — activation succeeded; the indexer may still be catching up to the fresh vaults' tx-hash rows.`,
+      );
+    return;
+  }
+
+  // A returning depositor's dashboard lists several vault cards, so `.first()` is not necessarily the
+  // one this run created — matching the first card against the requested amount produced a false
+  // mismatch warning against an older vault. Prefer THIS run's Pre-PegIn txid captured mid-flow: the
+  // card links it in its "TX Hash" row (PeginTxHashRow, linkPrePegin default) as `<a href=".../tx/…">`.
+  // But that row is indexer-sourced, and for a JUST-activated vault the indexer commonly lags the click
+  // to the dashboard — the fresh card shows its amount (from activation state) before its tx-hash row
+  // populates. So the amount match is the expected, immediately-authoritative identifier for a fresh
+  // vault; the txid match engages once the indexer has caught up (e.g. an already-indexed vault). First
+  // card is the last resort when neither is captured.
+  const byTxid = prePeginTxid
+    ? cards.filter({ has: page.locator(`a[href*="${prePeginTxid}"]`) }).first()
+    : null;
+  const byAmount = amountBtc
+    ? cards
+        .filter({
+          hasText: new RegExp(
+            `${amountBtc.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*sBTC`,
+          ),
+        })
+        .first()
+    : null;
+
+  let card = cards.first();
+  let matchedBy = "first card (fallback)";
+  if (byTxid && (await byTxid.isVisible().catch(() => false))) {
+    card = byTxid;
+    matchedBy = `Pre-PegIn txid ${prePeginTxid?.slice(0, 8)}…`;
+  } else if (byAmount && (await byAmount.isVisible().catch(() => false))) {
+    card = byAmount;
+    matchedBy = `amount ${amountBtc}`;
+  }
+
+  const cardText = (await card.innerText().catch(() => ""))
+    .replace(/\s+/g, " ")
+    .trim();
+  // With no known amount (resume), reaching the activated view + a rendered collateral card is the
+  // success signal; the amount-substring assertion only applies when the caller passed an amount.
+  if (!amountBtc)
+    log(
+      `Dashboard shows the resumed vault as collateral (matched by ${matchedBy}).`,
+    );
+  else if (cardText.includes(amountBtc))
+    log(
+      `Dashboard shows this run's vault as collateral (${amountBtc} sBTC, matched by ${matchedBy}).`,
+    );
+  else
+    log(
+      `⚠️ Dashboard vault card did not clearly show "${amountBtc}" (matched by ${matchedBy}; card: "${cardText.slice(0, 120)}") — activation still succeeded.`,
+    );
+}

--- a/services/vault/e2e/real/actions/stepMachine.ts
+++ b/services/vault/e2e/real/actions/stepMachine.ts
@@ -125,9 +125,7 @@ async function handleArtifactSkip(
  * dashboard lists several. Scans hrefs Node-side (no page-context function) and skips ETH links: an
  * ETH `/tx/0x…` hash never matches the 64-hex-no-0x BTC pattern.
  */
-export async function readPrePeginTxid(
-  page: Page,
-): Promise<string | undefined> {
+async function readPrePeginTxid(page: Page): Promise<string | undefined> {
   const links = page.locator('a[href*="/tx/"]');
   const count = await links.count().catch(() => 0);
   for (let i = 0; i < count; i++) {
@@ -148,7 +146,7 @@ export async function readPrePeginTxid(
  * labels — the two lanes advance independently and may sit on different steps. The single progressbar
  * reflects the aggregate (slowest lane).
  */
-export async function readActiveStep(page: Page): Promise<string> {
+async function readActiveStep(page: Page): Promise<string> {
   const actives = page.locator('[aria-label$="active"]');
   const count = await actives.count().catch(() => 0);
   const labels: string[] = [];
@@ -338,6 +336,10 @@ export async function walkStepMachine(
   );
 }
 
+/** Ticks (× PEGIN_POLL_INTERVAL_MS) to keep sweeping pop-ups after the Pre-PegIn txid appears, so the
+ *  broadcast call lands before an interrupt reload. */
+const BROADCAST_SETTLE_TICKS = 3;
+
 /**
  * Drive the signing sequence only up to the Pre-PegIn broadcast and return its txid. Used by the
  * `resume` action's `--interrupt-fresh` path to reach an on-chain, resumable deposit, which it then
@@ -383,10 +385,6 @@ export async function walkUntilPrePeginBroadcast(
     "Pre-PegIn was not broadcast (no BTC txid linked in the progress view) within the step-machine budget — see trace.zip",
   );
 }
-
-/** Ticks (× PEGIN_POLL_INTERVAL_MS) to keep sweeping pop-ups after the Pre-PegIn txid appears, so the
- *  broadcast call lands before an interrupt reload. */
-const BROADCAST_SETTLE_TICKS = 3;
 
 /**
  * Finish line: click "Go to Dashboard", then best-effort confirm the vault landed as collateral. The

--- a/services/vault/e2e/real/cli.ts
+++ b/services/vault/e2e/real/cli.ts
@@ -41,6 +41,9 @@
  * Payouts → Activate). By default it resumes an already-pending deposit (`--txid=<prePeginTxid>` targets a
  * specific one, else the first actionable); `--interrupt-fresh` pegs in a fresh deposit, reloads after
  * Pre-PegIn broadcast, and resumes it — a self-contained run (then also honors the pegin extras above).
+ * `--interrupt-only` pegs in + broadcasts a fresh deposit then STOPS (no resume), printing its Pre-PegIn
+ * txid — for staged manual verification: let it reach "Submit WOTS Key" on-chain, then re-run with
+ * `--txid=<that txid>` to resume it in steps.
  */
 import { createInterface, type Interface } from "node:readline/promises";
 
@@ -342,6 +345,10 @@ async function resolveConfig(
     // pegin params below. `--txid` targets a specific pending deposit when several are in flight.
     const interruptFresh =
       action === "resume" && flagBool(flags["interrupt-fresh"]);
+    // `--interrupt-only`: peg in a fresh deposit + broadcast, then STOP (no resume) — for staged manual
+    // verification. Also pegs in, so it needs the pegin params below.
+    const interruptOnly =
+      action === "resume" && flagBool(flags["interrupt-only"]);
     const resumeTxid =
       action === "resume" && typeof flags.txid === "string"
         ? flags.txid
@@ -354,7 +361,7 @@ async function resolveConfig(
     const needsPeginParams =
       action === "pegin" ||
       (willBorrow && peginFirst) ||
-      (action === "resume" && interruptFresh);
+      (action === "resume" && (interruptFresh || interruptOnly));
 
     // Split: `--split` wins; else prompt (default = single vault). Resolved first because the deposit
     // minimum depends on it — a two-vault split needs a larger deposit than a single vault.
@@ -370,6 +377,16 @@ async function resolveConfig(
           ])) === "split";
       }
     }
+    // A plain resume (no --interrupt-fresh) of a batched/split deposit still needs --split so the step
+    // machine and the dashboard cross-check expect the right vault count — the block above only resolves
+    // it for pegin-bearing runs (a plain resume fetches no pegin params), yet real dashboards are batched.
+    if (
+      action === "resume" &&
+      !interruptFresh &&
+      !interruptOnly &&
+      flags.split !== undefined
+    )
+      split = flagBool(flags.split);
 
     let peginAmountBtc =
       typeof flags.amount === "string" ? flags.amount : undefined;
@@ -614,6 +631,7 @@ async function resolveConfig(
       withdrawAll,
       resumeTxid,
       interruptFresh,
+      interruptOnly,
     };
   } finally {
     rl.close();

--- a/services/vault/e2e/real/cli.ts
+++ b/services/vault/e2e/real/cli.ts
@@ -6,6 +6,10 @@
  *
  *   pnpm --filter vault run e2e:cli               # interactive menu (prompts for every choice)
  *
+ * On a clean checkout this is the only command needed: the run self-provisions before launching the
+ * browser — it installs Playwright's Chromium if missing and downloads/updates the wallet extensions
+ * (see `provision.ts`), so no separate `playwright install` / `extensions:download` step is required.
+ *
  * Every prompt can be pre-supplied as a flag for a non-interactive / programmatic run (flags forward
  * through the script — no `--` separator needed):
  *
@@ -32,6 +36,11 @@
  * pegs in fresh collateral (honoring the pegin extras, incl. `--split`) then borrows + repays — the full
  * pegin → borrow → repay → withdraw cycle. `--withdraw-all` releases every selectable vault (default = a
  * single vault, keeping the position alive).
+ *
+ * Resume recovers an interrupted peg-in from the dashboard's Pending Deposits UI (Submit WOTS Key → Sign
+ * Payouts → Activate). By default it resumes an already-pending deposit (`--txid=<prePeginTxid>` targets a
+ * specific one, else the first actionable); `--interrupt-fresh` pegs in a fresh deposit, reloads after
+ * Pre-PegIn broadcast, and resumes it — a self-contained run (then also honors the pegin extras above).
  */
 import { createInterface, type Interface } from "node:readline/promises";
 
@@ -328,11 +337,24 @@ async function resolveConfig(
       }
     }
 
+    // Resume extras (resume-only). `--interrupt-fresh` makes the run self-contained: peg in a fresh
+    // deposit, interrupt it after Pre-PegIn broadcast, then resume from the dashboard — so it needs the
+    // pegin params below. `--txid` targets a specific pending deposit when several are in flight.
+    const interruptFresh =
+      action === "resume" && flagBool(flags["interrupt-fresh"]);
+    const resumeTxid =
+      action === "resume" && typeof flags.txid === "string"
+        ? flags.txid
+        : undefined;
+
     // Pegin extras. A flag always wins; otherwise fetch the network's real values (like the balance
     // pre-flight) and offer them as defaults — amount ⇒ minimum, provider ⇒ first available. Collected
-    // for a `pegin` run AND for any pegin-first borrow (`borrow --pegin-first` or
-    // `repay --borrow-first --pegin-first`, which peg in before borrowing).
-    const needsPeginParams = action === "pegin" || (willBorrow && peginFirst);
+    // for a `pegin` run, any pegin-first borrow (`borrow --pegin-first` or
+    // `repay --borrow-first --pegin-first`), AND `resume --interrupt-fresh` (which pegs in then resumes).
+    const needsPeginParams =
+      action === "pegin" ||
+      (willBorrow && peginFirst) ||
+      (action === "resume" && interruptFresh);
 
     // Split: `--split` wins; else prompt (default = single vault). Resolved first because the deposit
     // minimum depends on it — a two-vault split needs a larger deposit than a single vault.
@@ -590,6 +612,8 @@ async function resolveConfig(
       repayAmount,
       repayFirst,
       withdrawAll,
+      resumeTxid,
+      interruptFresh,
     };
   } finally {
     rl.close();

--- a/services/vault/e2e/real/config.ts
+++ b/services/vault/e2e/real/config.ts
@@ -185,6 +185,12 @@ export interface RunConfig {
    * When absent, resume expects an already-pending deposit to be present.
    */
   interruptFresh?: boolean;
+  /**
+   * Resume only: peg in a fresh deposit and interrupt it after Pre-PegIn broadcast (`--interrupt-only`),
+   * then STOP without resuming — leaving the deposit pending on the dashboard so it can be resumed later
+   * in stages (verify on-chain it reaches "Submit WOTS Key", then re-run with `--txid=<its Pre-PegIn>`).
+   */
+  interruptOnly?: boolean;
 }
 
 /** Resolve the target URL a run should open. */

--- a/services/vault/e2e/real/config.ts
+++ b/services/vault/e2e/real/config.ts
@@ -20,7 +20,8 @@ export type ActionId =
   | "sign-conformance"
   | "borrow"
   | "repay"
-  | "withdraw";
+  | "withdraw"
+  | "resume";
 
 /** Maps our lowercase wallet ids to the connector's SupportedWallet keys. */
 export const BTC_WALLET_TO_CONNECTOR: Record<BtcWalletId, SupportedWallet> = {
@@ -116,6 +117,7 @@ export const ACTIONS: ActionOption[] = [
   { id: "borrow", label: "Borrow", enabled: true },
   { id: "repay", label: "Repay", enabled: true },
   { id: "withdraw", label: "Withdraw", enabled: true },
+  { id: "resume", label: "Resume (an interrupted peg-in)", enabled: true },
 ];
 
 /** A fully-resolved run: what the user chose (interactively or via flags). */
@@ -171,6 +173,18 @@ export interface RunConfig {
    * withdrawable one. Default (absent) withdraws a single vault, keeping the position alive for reuse.
    */
   withdrawAll?: boolean;
+  /**
+   * Resume only: target a specific in-flight deposit by its Pre-PegIn txid (`--txid`) when several are
+   * pending (e.g. a split's two vaults share one Pre-PegIn). When absent, the first actionable pending
+   * deposit on the dashboard is resumed.
+   */
+  resumeTxid?: string;
+  /**
+   * Resume only: peg in a fresh deposit and interrupt it after Pre-PegIn broadcast (`--interrupt-fresh`),
+   * reloading the page to a cold state, then resume it from the dashboard — a fully self-contained run.
+   * When absent, resume expects an already-pending deposit to be present.
+   */
+  interruptFresh?: boolean;
 }
 
 /** Resolve the target URL a run should open. */

--- a/services/vault/e2e/real/connector.ts
+++ b/services/vault/e2e/real/connector.ts
@@ -14,7 +14,12 @@ export { setupMetaMaskWallet } from "../../../../packages/babylon-wallet-connect
 export { setupOKXWallet } from "../../../../packages/babylon-wallet-connector/tests/e2e/fixtures/wallets/okx";
 export { setupOneKeyWallet } from "../../../../packages/babylon-wallet-connector/tests/e2e/fixtures/wallets/onekey";
 export { setupUnisatWallet } from "../../../../packages/babylon-wallet-connector/tests/e2e/fixtures/wallets/unisat";
-export { EXTENSION_CHROME_STORE_IDS } from "../../../../packages/babylon-wallet-connector/tests/e2e/setup/downloadExtensions";
+export {
+  EXTENSIONS,
+  EXTENSION_CHROME_STORE_IDS,
+  downloadExtension,
+  getExtensionPath,
+} from "../../../../packages/babylon-wallet-connector/tests/e2e/setup/downloadExtensions";
 export { deriveEthAddress } from "../../../../packages/babylon-wallet-connector/tests/e2e/setup/eth";
 export { deriveSignetTaproot } from "../../../../packages/babylon-wallet-connector/tests/e2e/setup/taproot";
 export { runtimeExtensionId } from "../../../../packages/babylon-wallet-connector/tests/e2e/utils/extensionId";

--- a/services/vault/e2e/real/provision.ts
+++ b/services/vault/e2e/real/provision.ts
@@ -1,0 +1,100 @@
+/**
+ * Zero-setup bootstrap for the real-wallet E2E CLI.
+ *
+ * A fresh checkout has neither Playwright's Chromium browser installed nor the wallet extensions
+ * downloaded, so a run would die inside `launchWalletContext` with an opaque browser-launch error, or
+ * with `getExtensionPath`'s "Extensions directory … does not exist. Run 'npm run extensions:download'".
+ * This module makes both self-provisioning so a single `pnpm --filter vault run e2e:cli` works on a
+ * clean machine — no separate `playwright install` / `extensions:download` steps for engineers to run.
+ *
+ * Both checks are idempotent and fast when already provisioned, so they run on every invocation. The
+ * extension check also picks up a newer published version (the downloader skips a version already on
+ * disk) and degrades gracefully to the on-disk copy when the update check can't reach the network.
+ */
+import { chromium } from "@playwright/test";
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+
+import {
+  downloadExtension,
+  EXTENSION_CHROME_STORE_IDS,
+  EXTENSIONS,
+  getExtensionPath,
+  type SupportedWallet,
+} from "./connector";
+
+/** True when the given wallet extension is already downloaded + unpacked on disk. */
+function hasExtension(storeId: string): boolean {
+  try {
+    getExtensionPath(storeId);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Install Playwright's Chromium build if it isn't already present. `launchWalletContext` launches with
+ * `channel: "chromium"`, which needs the browser that `playwright install chromium` provides — absent
+ * it, the launch fails with a raw "Executable doesn't exist" error pointing engineers at a bare
+ * `playwright install`. We probe the expected executable path (Playwright returns it whether or not the
+ * binary is present) and install only when it's missing, so provisioned machines pay nothing.
+ */
+function ensurePlaywrightChromium(log: (m: string) => void): void {
+  if (existsSync(chromium.executablePath())) return;
+  log(
+    "Playwright Chromium not found — installing it (one-time, a few minutes)…",
+  );
+  execFileSync("pnpm", ["exec", "playwright", "install", "chromium"], {
+    stdio: "inherit",
+  });
+  log("Playwright Chromium installed.");
+}
+
+/**
+ * Ensure each wallet extension this run uses is downloaded + unpacked, checking for a newer published
+ * version each run (the downloader is a no-op when that exact version is already on disk). When the
+ * update check can't reach the Chrome Web Store, fall back to the on-disk copy if we have one, and only
+ * fail hard when the extension is genuinely missing and can't be fetched.
+ */
+async function ensureExtensions(
+  wallets: SupportedWallet[],
+  log: (m: string) => void,
+): Promise<void> {
+  for (const wallet of wallets) {
+    const storeId = EXTENSION_CHROME_STORE_IDS[wallet];
+    const config = EXTENSIONS.find((extension) => extension.id === storeId);
+    if (!config)
+      throw new Error(
+        `No extension is configured for wallet "${wallet}" (store id ${storeId}).`,
+      );
+    const present = hasExtension(storeId);
+    try {
+      await downloadExtension(config);
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      if (present) {
+        log(
+          `⚠️ Could not check the ${config.name} extension for updates (${reason}); using the copy on disk.`,
+        );
+      } else {
+        throw new Error(
+          `Failed to download the ${config.name} wallet extension (${reason}). ` +
+            "Check your network connection and re-run.",
+        );
+      }
+    }
+  }
+}
+
+/**
+ * Provision the two runtime prerequisites (Playwright Chromium + the wallet extensions this run needs)
+ * so a clean checkout can run the CLI with one command. Call once before launching the browser context.
+ */
+export async function provisionRuntime(
+  wallets: SupportedWallet[],
+  log: (m: string) => void,
+): Promise<void> {
+  ensurePlaywrightChromium(log);
+  await ensureExtensions(wallets, log);
+}

--- a/services/vault/e2e/real/run.ts
+++ b/services/vault/e2e/real/run.ts
@@ -23,6 +23,7 @@ import {
   formatBtc,
   formatEth,
 } from "./preflight";
+import { provisionRuntime } from "./provision";
 import { loadWalletSecrets } from "./secrets";
 import { importWallets } from "./wallets";
 import { maximizeWindow } from "./windowUtils";
@@ -45,6 +46,10 @@ export async function runE2E(config: RunConfig): Promise<void> {
 
   const btcKey = BTC_WALLET_TO_CONNECTOR[config.btcWallet];
   const ethKey = ETH_WALLET_TO_CONNECTOR[config.ethWallet];
+
+  // Self-provision the runtime prerequisites (Playwright Chromium + the two wallet extensions) so a
+  // clean checkout runs with one command — must happen before launchWalletContext, which needs both.
+  await provisionRuntime([btcKey, ethKey], artifacts.log);
 
   let devServer: DevServerHandle | undefined;
   const context = await launchWalletContext([btcKey, ethKey], {
@@ -100,7 +105,9 @@ export async function runE2E(config: RunConfig): Promise<void> {
       ((config.action === "repay" || config.action === "withdraw") &&
         config.borrowFirst);
     const willPegin =
-      config.action === "pegin" || (willBorrow && config.peginFirst);
+      config.action === "pegin" ||
+      (willBorrow && config.peginFirst) ||
+      (config.action === "resume" && config.interruptFresh);
     if (willPegin) {
       const cap = await fetchVaultCountCap(
         config.network,

--- a/services/vault/e2e/real/run.ts
+++ b/services/vault/e2e/real/run.ts
@@ -107,7 +107,8 @@ export async function runE2E(config: RunConfig): Promise<void> {
     const willPegin =
       config.action === "pegin" ||
       (willBorrow && config.peginFirst) ||
-      (config.action === "resume" && config.interruptFresh);
+      (config.action === "resume" &&
+        (config.interruptFresh || config.interruptOnly));
     if (willPegin) {
       const cap = await fetchVaultCountCap(
         config.network,

--- a/services/vault/e2e/real/timing.ts
+++ b/services/vault/e2e/real/timing.ts
@@ -164,6 +164,23 @@ export const WITHDRAW_TX_TIMEOUT_MS = 90_000;
 /** Poll cadence for the post-withdraw on-chain collateral-fell check (a light `getPosition` read). */
 export const WITHDRAW_VERIFY_POLL_MS = 3_000;
 
+// ── resume (recover an interrupted peg-in from the dashboard) ────────────────────
+/**
+ * After landing on the dashboard, how long to wait for a resumable pending-deposit card to appear. A
+ * same-tab storage event + the indexer poll surface it quickly, so this is short — its absence means
+ * there is nothing to resume (a clear fail), not a slow read.
+ */
+export const RESUME_CARD_APPEAR_TIMEOUT_MS = 60_000;
+/**
+ * How long to wait for a pending deposit to become ACTIONABLE (its resume CTA rendered). This can be
+ * LONG: the vault provider must ingest the confirmed Pre-PegIn before "Submit WOTS Key" appears, and the
+ * Pre-PegIn's Bitcoin confirmation is subject to signet block time (observed up to ~1 h). Budgeted like
+ * the step machine so a slow-but-healthy signet confirmation isn't mistaken for a dead deposit.
+ */
+export const RESUME_ACTIONABLE_TIMEOUT_MS = PEGIN_STEP_MACHINE_BUDGET_MS;
+/** Poll cadence while waiting for the pending card to appear / become actionable (sweeps pop-ups too). */
+export const RESUME_POLL_INTERVAL_MS = 5_000;
+
 // ── sign-conformance (per-wallet signing replay) ─────────────────────────────
 /**
  * Budget for one signing call to resolve (popup open → approver confirms → signature returned). A

--- a/services/vault/src/components/simple/BatchedDepositGroup.tsx
+++ b/services/vault/src/components/simple/BatchedDepositGroup.tsx
@@ -177,6 +177,8 @@ export function BatchedDepositGroup({
             variant="contained"
             color="secondary"
             className="w-full"
+            // E2E: the batched deposit's group-level resume action (consumed by e2e/real/actions/resume.ts).
+            data-testid="pending-deposit-resume-cta"
             onClick={() => onBroadcastClick(broadcastTarget.id)}
           >
             {COPY.pegin.primaryAction.SIGN_AND_BROADCAST_TO_BITCOIN}
@@ -192,6 +194,8 @@ export function BatchedDepositGroup({
             variant="contained"
             color="secondary"
             className="w-full"
+            // E2E: the batched deposit's group-level resume action (consumed by e2e/real/actions/resume.ts).
+            data-testid="pending-deposit-resume-cta"
             onClick={() => onGroupClick(activities[0].id)}
           >
             {continueAction.label}

--- a/services/vault/src/components/simple/PendingDepositCard.tsx
+++ b/services/vault/src/components/simple/PendingDepositCard.tsx
@@ -161,6 +161,9 @@ export function PendingDepositCard({
   // excluded from the body click by isInteractiveEventTarget.
   const actionCta =
     status.type === "available" && handleCardClick ? (
+      // data-testid consumed by the real-wallet E2E CLI resume action
+      // (services/vault/e2e/real/actions/resume.ts): it appears only once the deposit is actionable, so
+      // it doubles as the "resumable now" signal the CLI waits for before opening the resume flow.
       <Button
         variant={
           status.action.action === PeginAction.REFUND_HTLC
@@ -174,6 +177,7 @@ export function PendingDepositCard({
         }
         className="w-full"
         onClick={handleCardClick}
+        data-testid="pending-deposit-resume-cta"
       >
         {status.action.label}
       </Button>
@@ -181,6 +185,10 @@ export function PendingDepositCard({
 
   return (
     <VaultDetailCard
+      // data-testid consumed by the real-wallet E2E CLI resume action
+      // (services/vault/e2e/real/actions/resume.ts) to scope a specific pending deposit by its Pre-PegIn
+      // txid (the card's tx-hash row links it) when several are in flight.
+      testId="pending-deposit-card"
       amountBtc={parseFloat(amount || "0")}
       timestamp={timestamp}
       onClick={handleCardClick}

--- a/services/vault/src/components/simple/VaultDetailCard.tsx
+++ b/services/vault/src/components/simple/VaultDetailCard.tsx
@@ -99,6 +99,8 @@ interface VaultDetailCardProps {
   /** Optional click handler invoked when the card body (not an inner button
    *  or link) is clicked. Used to open the deposit multistepper. */
   onClick?: () => void;
+  /** Optional stable `data-testid` for the card root (forwarded to VaultCardShell). */
+  testId?: string;
 }
 
 export function VaultDetailCard({
@@ -120,6 +122,7 @@ export function VaultDetailCard({
   disabledTooltip,
   payoutBtcAddress,
   onClick,
+  testId,
 }: VaultDetailCardProps) {
   const relativeTime = useRelativeTime(timestamp);
 
@@ -128,6 +131,7 @@ export function VaultDetailCard({
       disabled={disabled}
       disabledTooltip={disabledTooltip}
       onClick={onClick}
+      testId={testId}
     >
       {/* BTC icon + amount (+ optional subtext), optional header-end content */}
       <div className="flex items-start justify-between gap-2">


### PR DESCRIPTION
# Real-wallet E2E CLI: resume an interrupted peg-in, one-command setup, and 24-word wallets

## What this PR does

This PR adds three things to the real-wallet E2E CLI (`services/vault/e2e/real/`), which drives the depositor lifecycle with real browser wallets: (1) a new `resume` action that recovers a peg-in that was interrupted (page refreshed, or the peg-in modal closed), (2) automatic setup so a fresh checkout can run with a single command, and (3) support for 24-word seed phrases when importing wallets.

Closes [#2070](https://github.com/babylonlabs-io/babylon-toolkit/issues/2070).

## Why

A real peg-in takes 30 minutes to a couple of hours and the app is built to survive interruption: once the Pre-PegIn is broadcast the deposit is on-chain, and if you refresh or close the tab the dashboard resurfaces it with a "resume" flow (Submit WOTS → Sign Payouts → Activate). Until now the CLI could only drive a peg-in start-to-finish inside one modal in one session, so it could never test that resume path — the last gap in the lifecycle coverage. On top of that, other engineers who tried to run the CLI hit two setup papercuts (missing wallet extensions, and Playwright's browser not installed), and one engineer's wallet uses a 24-word phrase, which the importer silently got wrong. This PR closes all three.

## 1. Resume an interrupted peg-in

The new `resume` action opens the interrupted deposit from the dashboard's Pending Deposits list and drives it the rest of the way to an activated vault. It has two modes: by default it resumes a deposit that is already pending (optionally targeted with `--txid=<prePeginTxid>`); with `--interrupt-fresh` it is fully self-contained — it pegs in a new deposit, interrupts it right after the Pre-PegIn broadcast (reloads the page to a truly cold state), then resumes it.

Approach and why: the dashboard's resume screens reuse the exact same progress stepper as a normal peg-in, so instead of writing a second driver we extracted the shared step-machine core (`walkStepMachine`, `assertActivatedAndOnDashboard`, and their helpers) out of `pegin.ts` into a new `stepMachine.ts`, and both `pegin` and `resume` now import it. This keeps a single source of truth for "walk the stepper" and means the peg-in path is a pure move with no behaviour change. The one genuinely new thing on a cold resume is that the app re-derives the vault secret (`deriveContextHash` → WOTS) after the reload; the existing pop-up approver already handles that dialog (it is the same one peg-in step 1 shows), so no approver changes were needed. We also added a few load-bearing `data-testid`s to the pending-deposit resume UI so the CLI can find and click the resume controls.

While verifying `--interrupt-fresh` we found and fixed a real bug: right after the reload the app re-hydrates and the "Connect" button briefly renders visible-but-disabled while it auto-reconnects; the reconnect helper was clicking that disabled button and timing out. It now waits for the app to auto-reconnect or for the button to actually be enabled before clicking.

## 2. One-command setup (auto-provisioning)

The CLI now provisions its own prerequisites before launching the browser: **_it installs Playwright's Chromium if it is missing_**, and **_downloads (and updates) the wallet extensions the run needs_**. So a new engineer can clone, `pnpm i && pnpm run build`, and then just run `pnpm --filter vault run e2e:cli` — no separate `playwright install` and no `extensions:download` step.

Approach and why: this lives in a small new `provision.ts` called at the top of the run. It reuses the wallet-connector's existing download primitives rather than reimplementing them (it only adds the "check what's missing and fetch it" orchestration). Both checks are fast no-ops when everything is already present, so provisioned machines pay nothing. We considered making the update check opt-in behind a flag, but the team chose to always check-and-update every run so wallets stay fresh; the extension check degrades gracefully to the on-disk copy if it can't reach the network, and only fails hard when an extension is genuinely missing.

## 3. 24-word mnemonic support

Wallet import now works with 24-word seed phrases, not just 12, across UniSat, OKX, OneKey and MetaMask. Previously the importers assumed a 12-input seed grid, so a 24-word phrase either lost its extra words or got dumped whole into the first box — importing the wrong wallet.

Approach and why: MetaMask and OneKey already handle any length (MetaMask uses a single text box, OneKey fans a paste across the grid and auto-expands it), so they needed no change. UniSat and OKX default to a 12-box grid with a word-count selector that must be switched first. The important constraint here was raised in review: selectors must not depend on the visible wording, because colleagues run their OS in different languages (Russian, Chinese, English) and OKX in particular renders in the OS language, not English. So for OKX we drive the selector by its stable structural data attributes, and for UniSat — whose options are bare spans with no attributes — we match on the digits in the label ("24"), which are identical in every language. This is why the fix does not simply match the text "24 words".

## How it was verified

Auto-provisioning was tested by actually removing each prerequisite and re-running: with Chromium deleted the run re-installed it and continued; with a wallet extension deleted the run re-downloaded and unpacked it. 24-word support was verified by importing a throwaway 24-word phrase into each of the four wallets and confirming the derived address matches the expected one; 12-word imports were re-checked for all four to make sure nothing regressed. The resume flow was driven live on devnet through connect → detect the pending deposit → cold WOTS re-derivation → the progress stepper, and the `--interrupt-fresh` path was driven through peg-in → Pre-PegIn broadcast → interrupt/reload → reconnect. The peg-in path itself was exercised (form → sign → broadcast a real Pre-PegIn) through the refactored code, so this PR does not change peg-in behaviour, and none of the value-critical files were touched.

## Known limitation

Count not observe one fully green resume run all the way to on-chain activation, because the devnet vault provider is currently stalling every deposit at "Step 8 — prepare claim and payout transactions" (multiple deposits have been stuck there for days, and a fresh Pre-PegIn that is already confirmed on signet still isn't advanced). That is a provider/infra issue, not this code — a normal uninterrupted peg-in stalls at the same step right now — and it has been reported to DevOps. Every individual step of the resume path has been exercised; the moment the provider is healthy, a single `resume` run should close that last gap.
