### PR TITLE
feat(sdk): route single-PSBT signing to signPsbt for all wallets

### DIFF
--- a/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
@@ -626,8 +626,9 @@ export class PeginManager {
   /**
    * Prepare a peg-in: sizing pass → vault-root derivation (one wallet
    * popup) → per-vault WOTS / hashlock derivation → commit pass with
-   * batch PSBT signing (one popup). Returns broadcast-ready txs, the
-   * pubkey snapshot, and the sensitive derived material.
+   * PSBT signing (signPsbt for a single vault, one batch popup for a
+   * split). Returns broadcast-ready txs, the pubkey snapshot, and the
+   * sensitive derived material.
    *
    * @throws If the wallet rejects, insufficient funds, or an internal
    *         invariant violation.

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PeginManager.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PeginManager.test.ts
@@ -252,16 +252,17 @@ describe("PeginManager", () => {
   });
 
   describe("preparePegin", () => {
-    it("passes the wallet's raw (compressed) pubkey to signPsbts", async () => {
+    it("passes the wallet's raw (compressed) pubkey to signPsbt (single-vault pegin)", async () => {
       // Regression: taproot signPsbt expects the wallet's native format
       // on signInputs[].publicKey (UniSat/OKX/OneKey reject x-only with
-      // "invalid public key in toSignInput").
+      // "invalid public key in toSignInput"). A single-vault pegin is one
+      // PSBT, so signPsbtsWithFallback routes it to signPsbt.
       const compressedPubkey = `02${TEST_KEYS.DEPOSITOR}`;
       const btcWallet = new MockBitcoinWallet({
         publicKeyHex: compressedPubkey,
       });
       const ethWallet = new MockEthereumWallet();
-      const signPsbtsSpy = vi.spyOn(btcWallet, "signPsbts");
+      const signPsbtSpy = vi.spyOn(btcWallet, "signPsbt");
 
       const manager = new PeginManager({
         btcNetwork: "signet",
@@ -278,9 +279,9 @@ describe("PeginManager", () => {
         ...BASE_PREPARE_PEGIN_PARAMS,
       });
 
-      expect(signPsbtsSpy).toHaveBeenCalled();
-      const signOptions = signPsbtsSpy.mock.calls[0][1];
-      const publicKey = signOptions?.[0]?.signInputs?.[0]?.publicKey;
+      expect(signPsbtSpy).toHaveBeenCalled();
+      const signOptions = signPsbtSpy.mock.calls[0][1];
+      const publicKey = signOptions?.signInputs?.[0]?.publicKey;
       expect(publicKey).toBe(compressedPubkey);
     });
 

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/__tests__/signPsbtsWithFallback.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/__tests__/signPsbtsWithFallback.test.ts
@@ -18,6 +18,24 @@ function makeWallet(overrides: Partial<BitcoinWallet> = {}): BitcoinWallet {
 }
 
 describe("signPsbtsWithFallback", () => {
+  it("routes a single PSBT to signPsbt, never the batch endpoint", async () => {
+    // Generic (all-wallet) behavior: a lone PSBT must not hit signPsbts, even
+    // when the wallet supports batch signing.
+    const signPsbts = vi.fn<NonNullable<BitcoinWallet["signPsbts"]>>();
+    const signPsbt = vi
+      .fn<BitcoinWallet["signPsbt"]>()
+      .mockResolvedValue("signed-a");
+    const wallet = makeWallet({ signPsbts, signPsbt });
+    const opts: SignPsbtOptions[] = [{ autoFinalized: false }];
+
+    const out = await signPsbtsWithFallback(wallet, ["a"], opts);
+
+    expect(out).toEqual(["signed-a"]);
+    expect(signPsbt).toHaveBeenCalledTimes(1);
+    expect(signPsbt).toHaveBeenCalledWith("a", opts[0]);
+    expect(signPsbts).not.toHaveBeenCalled();
+  });
+
   it("uses native batch signing when wallet.signPsbts is a function", async () => {
     const signPsbts = vi
       .fn<NonNullable<BitcoinWallet["signPsbts"]>>()
@@ -90,13 +108,19 @@ describe("signPsbtsWithFallback", () => {
   });
 
   it("propagates errors from the batch path", async () => {
+    // Two PSBTs so the batch endpoint is exercised (a single PSBT routes to
+    // signPsbt instead).
     const signPsbts = vi
       .fn<NonNullable<BitcoinWallet["signPsbts"]>>()
       .mockRejectedValue(new Error("user rejected"));
     const wallet = makeWallet({ signPsbts });
 
     await expect(
-      signPsbtsWithFallback(wallet, ["a"], [{ autoFinalized: false }]),
+      signPsbtsWithFallback(
+        wallet,
+        ["a", "b"],
+        [{ autoFinalized: false }, { autoFinalized: false }],
+      ),
     ).rejects.toThrow("user rejected");
   });
 

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/signPsbtsWithFallback.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/signPsbtsWithFallback.ts
@@ -1,6 +1,7 @@
 /**
- * Batch-sign helper that prefers native `signPsbts` and falls back to
- * sequential `signPsbt` for wallets that don't implement batch signing.
+ * Wallet-signing helper that routes a lone PSBT to `signPsbt`, prefers native
+ * `signPsbts` for real batches, and falls back to sequential `signPsbt` for
+ * wallets that don't implement batch signing.
  *
  * @module managers/pegin/signPsbtsWithFallback
  */
@@ -11,19 +12,27 @@ import type {
 } from "../../../../shared/wallets";
 
 /**
- * Sign multiple PSBTs against a wallet. Wallets exposing native batch
- * signing (e.g. UniSat) sign all PSBTs in a single interaction; others
- * (Ledger, AppKit) loop `signPsbt` internally, so the popup UX depends
- * on the wallet adapter.
+ * Sign one or more PSBTs against a wallet.
  *
- * @throws If `signPsbts` returns a different number of signed PSBTs
+ * A single PSBT is always signed via `signPsbt`, never the batch endpoint: it's
+ * one wallet interaction either way, and `signPsbt` is the universally-required
+ * wallet method (batch `signPsbts` is optional), so single-sign is the portable
+ * choice — some integrations (notably MPC / institutional wallets) prefer it.
+ * For a real batch (>1), wallets exposing native `signPsbts` (e.g. UniSat) sign
+ * in one interaction; others loop `signPsbt`.
+ *
+ * @throws If native `signPsbts` returns a different number of signed PSBTs
  *         than were submitted.
  */
 export async function signPsbtsWithFallback(
   wallet: BitcoinWallet,
   psbtsHexes: string[],
-  options: SignPsbtOptions[],
+  options?: SignPsbtOptions[],
 ): Promise<string[]> {
+  if (psbtsHexes.length === 1) {
+    return [await wallet.signPsbt(psbtsHexes[0], options?.[0])];
+  }
+
   if (typeof wallet.signPsbts === "function") {
     const signedPsbts = await wallet.signPsbts(psbtsHexes, options);
     if (signedPsbts.length !== psbtsHexes.length) {
@@ -36,8 +45,7 @@ export async function signPsbtsWithFallback(
 
   const signedPsbts: string[] = [];
   for (let i = 0; i < psbtsHexes.length; i++) {
-    const signed = await wallet.signPsbt(psbtsHexes[i], options[i]);
-    signedPsbts.push(signed);
+    signedPsbts.push(await wallet.signPsbt(psbtsHexes[i], options?.[i]));
   }
   return signedPsbts;
 }

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/signDepositorGraph.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/signDepositorGraph.test.ts
@@ -638,7 +638,7 @@ describe("signDepositorGraph", () => {
         btcWallet: wallet,
         signingContext: createSigningContext(),
       }),
-    ).rejects.toThrow("expected 3");
+    ).rejects.toThrow(/expected 3/i);
   });
 
   it("strips 0x prefix from depositor pubkey", async () => {

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts
@@ -44,6 +44,7 @@ import {
   extractPayoutSignature,
 } from "../../primitives/psbt/payout";
 import { assertScriptPathSchnorrSignature } from "../../primitives/psbt/verifyScriptPathSchnorrSignature";
+import { signPsbtsWithFallback } from "../../managers/pegin/signPsbtsWithFallback";
 import {
   stripHexPrefix,
   uint8ArrayToHex,
@@ -481,26 +482,6 @@ function extractDepositorGraphSignatures(
   };
 }
 
-/**
- * Sign multiple PSBTs, using batch signing when the wallet supports it.
- * Falls back to sequential `signPsbt` calls for wallets without `signPsbts`.
- */
-async function signPsbtsWithFallback(
-  wallet: BitcoinWallet,
-  psbtHexes: string[],
-  options?: SignPsbtOptions[],
-): Promise<string[]> {
-  if (typeof wallet.signPsbts === "function") {
-    return wallet.signPsbts(psbtHexes, options);
-  }
-
-  const signed: string[] = [];
-  for (let i = 0; i < psbtHexes.length; i++) {
-    signed.push(await wallet.signPsbt(psbtHexes[i], options?.[i]));
-  }
-  return signed;
-}
-
 // ============================================================================
 // Main entry point
 // ============================================================================
@@ -598,17 +579,13 @@ export async function signDepositorGraph(
     );
 
   // 2. Sign all PSBTs (batch when supported, sequential fallback for mobile)
+  // signPsbtsWithFallback guarantees one signed PSBT per input (or throws), so
+  // no separate arity check is needed here.
   const signedPsbtHexes = await signPsbtsWithFallback(
     btcWallet,
     psbtHexes,
     signOptions,
   );
-
-  if (signedPsbtHexes.length !== psbtHexes.length) {
-    throw new Error(
-      `Wallet returned ${signedPsbtHexes.length} signed PSBTs, expected ${psbtHexes.length}`,
-    );
-  }
 
   // 3. Pair requested with signed and extract signatures
   const psbtPairs: PsbtPair[] = psbtHexes.map((requestedPsbtHex, i) => ({

--- a/packages/babylon-ts-sdk/src/testing/MockBitcoinWallet.ts
+++ b/packages/babylon-ts-sdk/src/testing/MockBitcoinWallet.ts
@@ -86,7 +86,10 @@ export class MockBitcoinWallet implements BitcoinWallet {
     return this.config.address;
   }
 
-  async signPsbt(psbtHex: string): Promise<string> {
+  async signPsbt(
+    psbtHex: string,
+    _options?: SignPsbtOptions,
+  ): Promise<string> {
     if (this.config.shouldFailSigning) {
       throw new Error("Mock signing failed");
     }

--- a/services/vault/src/hooks/deposit/useDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useDepositFlow.ts
@@ -423,11 +423,11 @@ export function useDepositFlow(
         // ========================================================================
 
         setCurrentStep(DepositFlowStep.DERIVE_VAULT_SECRET);
-        // Sign the peg-in PSBTs in a single native batch popup when the wallet
-        // supports signPsbts; the (x of n) sub-counter jumps 0 -> N around the
-        // one call. Wallets without native batch signing fall back to
-        // sequential signPsbt (via the SDK's signPsbtsWithFallback), where the
-        // per-tx wrapper ticks the counter once per signature.
+        // A single peg-in PSBT signs via signPsbt (the SDK's
+        // signPsbtsWithFallback routes lone PSBTs there), ticking the counter
+        // once. Multi-vault: one native batch popup when the wallet supports
+        // signPsbts — the (x of n) sub-counter jumps 0 -> N around the one
+        // call — else sequential signPsbt ticks it per signature.
         const signOnePeginPsbt: typeof confirmedBtcWallet.signPsbt = async (
           psbtHex,
           opts,

--- a/services/vault/src/services/vault/vaultTransactionService.ts
+++ b/services/vault/src/services/vault/vaultTransactionService.ts
@@ -112,11 +112,12 @@ export interface PreparePeginResult {
 /**
  * Detailed progress for peg-in BTC transaction signing (used by UI layer).
  *
- * A split (multi-vault) deposit produces one peg-in transaction per vault,
- * each signed via the wallet (one batch popup for `signPsbts`-capable
- * wallets, sequential popups otherwise). `total` is the number of peg-in
- * transactions; `completed` jumps 0 -> total for a single native batch popup,
- * or advances per signature in the sequential fallback.
+ * A split (multi-vault) deposit produces one peg-in transaction per vault.
+ * A lone peg-in signs via `signPsbt` (`completed` ticks 0 -> 1); a multi-vault
+ * batch signs in one native popup for `signPsbts`-capable wallets (`completed`
+ * jumps 0 -> total around the one call) or sequential popups otherwise
+ * (`completed` advances per signature). `total` is the number of peg-in
+ * transactions.
  */
 export interface PeginSigningProgress {
   /** Number of peg-in transactions signed so far. */


### PR DESCRIPTION
Requested by the Utila integration but implemented generically: when there is
only one PSBT to sign, call `signPsbt` instead of the batch `signPsbts` API —
for every wallet, at the SDK chokepoint all vault signing flows through
(`signPsbtsWithFallback`).

- **Single PSBT → `signPsbt`.** One wallet interaction either way; `signPsbt`
is the universally-required `BitcoinWallet` method (batch `signPsbts` is the
optional one), so single-sign is the portable choice — some integrations
(notably MPC / institutional wallets) prefer it. The per-PSBT options entry
is threaded (`options?.[0]`), so the signature produced is identical to a
1-element batch. Real batches (>1) are unchanged: native `signPsbts` when
available, sequential `signPsbt` otherwise.
- **De-dup.** `signDepositorGraph` had its own private copy of
`signPsbtsWithFallback` (without the arity check); it now imports the
canonical helper. Its downstream arity check is removed as redundant — the
canonical guarantees one signed PSBT per input or throws, which is what
`PeginManager` already relies on, so enforcement is now in exactly one place.
- Comments that described the old routing ("single native batch popup" for a
single-vault pegin) updated in `useDepositFlow`, `vaultTransactionService`,
and the `preparePegin` docstring.