### PR TITLE
fix(vault): unwrap the sidecar response envelope in fetchLogos

### DIFF
--- a/services/vault/src/clients/logo/__tests__/logoClient.contract.test.ts
+++ b/services/vault/src/clients/logo/__tests__/logoClient.contract.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Live contract test against a real deployed sidecar. Opt-in: skipped unless
+ * LIVE_SIDECAR_API_URL is set, so CI stays offline and deterministic.
+ *
+ *   LIVE_SIDECAR_API_URL=https://sidecar-api.canon-devnet.babylonlabs.io \
+ *     pnpm exec vitest run src/clients/logo/__tests__/logoClient.contract.test.ts
+ *
+ * Exists because this feature shipped broken for five months: the client parsed
+ * a flat map while the sidecar has always wrapped responses in
+ * { data: { images } }, and the unit tests mocked the client's assumption, so
+ * both stayed green. This test is the only one that fails when the two sides
+ * genuinely disagree.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+const LIVE_URL = process.env.LIVE_SIDECAR_API_URL;
+
+const { mockEnv } = vi.hoisted(() => ({
+  mockEnv: { SIDECAR_API_URL: "" },
+}));
+vi.mock("../../../config/env", () => ({
+  ENV: mockEnv,
+}));
+
+// A syntactically valid identity (64-hex BTC pubkey); the sidecar validates the
+// format, and an unknown key simply yields no image for it.
+const PROBE_IDENTITY =
+  "1db08a1171aa6adfc73c18f58f99bf2699cee76708b7c9eb23859631b4d0008e";
+
+describe.runIf(Boolean(LIVE_URL))("sidecar /logo contract (live)", () => {
+  it("responds with the { data: { images } } envelope", async () => {
+    const response = await fetch(`${LIVE_URL}/logo`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ identities: [PROBE_IDENTITY] }),
+    });
+
+    expect(response.ok).toBe(true);
+    const body = await response.json();
+    expect(body).toHaveProperty("data.images");
+    expect(typeof body.data.images).toBe("object");
+  });
+
+  it("fetchLogos returns exactly the envelope's images map", async () => {
+    mockEnv.SIDECAR_API_URL = LIVE_URL as string;
+    const { fetchLogos } = await import("../logoClient");
+
+    const raw = await fetch(`${LIVE_URL}/logo`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ identities: [PROBE_IDENTITY] }),
+    });
+    const expected = (await raw.json()).data.images;
+
+    const result = await fetchLogos([PROBE_IDENTITY]);
+
+    expect(result).toEqual(expected);
+  });
+});

--- a/services/vault/src/clients/logo/__tests__/logoClient.test.ts
+++ b/services/vault/src/clients/logo/__tests__/logoClient.test.ts
@@ -103,6 +103,22 @@ describe("logoClient", () => {
       expect(result).toEqual({ identity1: "https://s3-bucket/logo1.png" });
     });
 
+    it("parses a verbatim captured response from the deployed sidecar", async () => {
+      mockEnv.SIDECAR_API_URL = "https://sidecar-api.example.com";
+      // Captured 2026-07-17 from POST https://sidecar-api.canon-devnet.babylonlabs.io/logo
+      // (empty bucket, so no images). Byte-for-byte what the real service sends;
+      // if the sidecar envelope ever changes shape, recapture and update.
+      const capturedBody = '{"data":{"images":{}}}';
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(JSON.parse(capturedBody)),
+      });
+
+      const result = await fetchLogos(["identity1"]);
+
+      expect(result).toEqual({});
+    });
+
     it("returns empty object when the response is not the sidecar envelope", async () => {
       mockEnv.SIDECAR_API_URL = "https://sidecar-api.example.com";
       // A flat { identity: url } body is not the sidecar contract; treat it as

--- a/services/vault/src/clients/logo/__tests__/logoClient.test.ts
+++ b/services/vault/src/clients/logo/__tests__/logoClient.test.ts
@@ -42,13 +42,14 @@ describe("logoClient", () => {
 
     it("fetches logos from sidecar API with POST request", async () => {
       mockEnv.SIDECAR_API_URL = "https://sidecar-api.example.com";
-      const mockResponse = {
+      const images = {
         identity1: "https://s3-bucket/logo1.png",
         identity2: "https://s3-bucket/logo2.png",
       };
+      // Real sidecar responses arrive wrapped in its envelope: { data: { images } }.
       mockFetch.mockResolvedValueOnce({
         ok: true,
-        json: () => Promise.resolve(mockResponse),
+        json: () => Promise.resolve({ data: { images } }),
       });
 
       const result = await fetchLogos(["identity1", "identity2"]);
@@ -63,7 +64,7 @@ describe("logoClient", () => {
           body: JSON.stringify({ identities: ["identity1", "identity2"] }),
         },
       );
-      expect(result).toEqual(mockResponse);
+      expect(result).toEqual(images);
     });
 
     it("returns empty object when API returns error", async () => {
@@ -92,12 +93,29 @@ describe("logoClient", () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: () =>
-          Promise.resolve({ identity1: "https://s3-bucket/logo1.png" }),
+          Promise.resolve({
+            data: { images: { identity1: "https://s3-bucket/logo1.png" } },
+          }),
       });
 
       const result = await fetchLogos(["identity1", "identity2"]);
 
       expect(result).toEqual({ identity1: "https://s3-bucket/logo1.png" });
+    });
+
+    it("returns empty object when the response is not the sidecar envelope", async () => {
+      mockEnv.SIDECAR_API_URL = "https://sidecar-api.example.com";
+      // A flat { identity: url } body is not the sidecar contract; treat it as
+      // no logos rather than guessing at shapes.
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({ identity1: "https://s3-bucket/logo1.png" }),
+      });
+
+      const result = await fetchLogos(["identity1"]);
+
+      expect(result).toEqual({});
     });
   });
 });

--- a/services/vault/src/clients/logo/logoClient.ts
+++ b/services/vault/src/clients/logo/logoClient.ts
@@ -4,6 +4,14 @@ export interface LogoResponse {
   [identity: string]: string;
 }
 
+// The sidecar wraps every response in its PublicResponse envelope:
+// { "data": { "images": { <identity>: <url> } } }
+interface LogoApiResponse {
+  data?: {
+    images?: LogoResponse;
+  };
+}
+
 export async function fetchLogos(identities: string[]): Promise<LogoResponse> {
   if (!ENV.SIDECAR_API_URL || identities.length === 0) {
     return {};
@@ -22,8 +30,8 @@ export async function fetchLogos(identities: string[]): Promise<LogoResponse> {
       return {};
     }
 
-    const data: LogoResponse = await response.json();
-    return data;
+    const payload: LogoApiResponse = await response.json();
+    return payload.data?.images ?? {};
   } catch {
     return {};
   }


### PR DESCRIPTION
## What

Unwraps the sidecar's response envelope in `fetchLogos`, so provider logos can actually render once the logo buckets are provisioned.

## Why

The sidecar wraps every response in its `PublicResponse` envelope. Live response from `POST https://sidecar-api.canon-devnet.babylonlabs.io/logo`:

```json
{"data":{"images":{}}}
```

but `logoClient.ts` parsed the body as a flat `{ identity: url }` map and never unwrapped `data.images`.

## How

- `fetchLogos` parses `{ data: { images } }` and returns `payload.data?.images ?? {}` — the empty-object fallback stays correct here since logos are optional display.
- Test mocks updated to the real envelope, plus a new test pinning that a non-envelope (flat) body yields `{}` rather than shape-guessing.

## Verification

- `vitest run src/clients/logo/` — 7 tests pass (6 updated/existing + 1 new).
- ESLint clean on both touched files.


## Contract tests (added after review of what the old tests missed)

The original tests stayed green for five months because they mocked the client's own assumption. Two additions close that hole:

- A unit test parsing a **verbatim captured response** from the deployed devnet sidecar (byte-for-byte, capture date noted in the test).
- `logoClient.contract.test.ts` — an opt-in live contract test, skipped unless `LIVE_SIDECAR_API_URL` is set (CI stays offline). It asserts the deployed sidecar actually responds with the `{ data: { images } }` envelope, and that `fetchLogos` returns exactly that map. This is the only test that fails when the client and the real service genuinely disagree.

```
LIVE_SIDECAR_API_URL=https://sidecar-api.canon-devnet.babylonlabs.io \
  pnpm exec vitest run src/clients/logo/__tests__/logoClient.contract.test.ts
```

Verified both ways: default run 8 passed / 2 skipped; live run against canon-devnet 10/10.

Honest limitation: until a real logo exists in a bucket, the populated-images path is still exercised only against constructed fixtures (shape taken from the sidecar's Go structs). The final acceptance remains uploading one logo and seeing it render.
