### PR TITLE
feat(vault): add base Banner

### DIFF
--- a/packages/babylon-core-ui/src/components/Banner/Banner.css
+++ b/packages/babylon-core-ui/src/components/Banner/Banner.css
@@ -1,0 +1,19 @@
+.bbn-banner {
+  @apply flex w-full items-center justify-center px-4 text-center text-accent-contrast;
+
+  &-content {
+    @apply flex items-center justify-center gap-4;
+  }
+
+  &-icon {
+    @apply shrink-0;
+  }
+
+  &-critical {
+    @apply bg-error-dark py-2;
+  }
+
+  &-notice {
+    @apply bg-secondary-main py-3;
+  }
+}

--- a/packages/babylon-core-ui/src/components/Banner/Banner.stories.tsx
+++ b/packages/babylon-core-ui/src/components/Banner/Banner.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { WarningIcon } from "../Icons";
+import { Text } from "../Text";
+import { Banner } from "./Banner";
+
+const meta: Meta<typeof Banner> = {
+  component: Banner,
+  title: "Components/Data Display/Indicators/Banner",
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Critical: Story = {
+  args: {
+    children: <span className="text-base font-bold leading-6 tracking-0.15">Critical — liquidation in 2.3%</span>,
+    icon: <WarningIcon color="text-accent-contrast" size={20} />,
+  },
+};
+
+export const Notice: Story = {
+  args: {
+    children: <Text variant="body2">Deposits are currently disabled while we address an issue.</Text>,
+    variant: "notice",
+  },
+};

--- a/packages/babylon-core-ui/src/components/Banner/Banner.stories.tsx
+++ b/packages/babylon-core-ui/src/components/Banner/Banner.stories.tsx
@@ -4,6 +4,9 @@ import { WarningIcon } from "../Icons";
 import { Text } from "../Text";
 import { Banner } from "./Banner";
 
+// Matches the 20px WarningFilled icon in the Figma banner (node 10088:75288).
+const BANNER_ICON_SIZE = 20;
+
 const meta: Meta<typeof Banner> = {
   component: Banner,
   title: "Components/Data Display/Indicators/Banner",
@@ -16,7 +19,7 @@ type Story = StoryObj<typeof meta>;
 export const Critical: Story = {
   args: {
     children: <span className="text-base font-bold leading-6 tracking-0.15">Critical — liquidation in 2.3%</span>,
-    icon: <WarningIcon color="text-accent-contrast" size={20} />,
+    icon: <WarningIcon color="text-accent-contrast" size={BANNER_ICON_SIZE} />,
   },
 };
 

--- a/packages/babylon-core-ui/src/components/Banner/Banner.tsx
+++ b/packages/babylon-core-ui/src/components/Banner/Banner.tsx
@@ -1,0 +1,27 @@
+import { type HTMLAttributes, type ReactNode } from "react";
+import { twJoin } from "tailwind-merge";
+
+import "./Banner.css";
+
+export type BannerVariant = "critical" | "notice";
+
+export interface BannerProps extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
+  icon?: ReactNode;
+  variant?: BannerVariant;
+}
+
+export function Banner({ children, className, icon, role, variant = "critical", ...props }: BannerProps) {
+  return (
+    <div
+      className={twJoin("bbn-banner", `bbn-banner-${variant}`, className)}
+      role={role ?? (variant === "critical" ? "alert" : "status")}
+      {...props}
+    >
+      <div className="bbn-banner-content">
+        {icon && <div className="bbn-banner-icon">{icon}</div>}
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/packages/babylon-core-ui/src/components/Banner/index.ts
+++ b/packages/babylon-core-ui/src/components/Banner/index.ts
@@ -1,0 +1,1 @@
+export { Banner, type BannerProps, type BannerVariant } from "./Banner";

--- a/packages/babylon-core-ui/src/index.tsx
+++ b/packages/babylon-core-ui/src/index.tsx
@@ -36,6 +36,7 @@ export * from "./components/Warning";
 export * from "./components/Hint";
 export * from "./components/DismissibleSubSection";
 export * from "./components/TopBanner";
+export * from "./components/Banner";
 export * from "./components/TestingBanner";
 export * from "./components/Step";
 export * from "./components/Stepper";

--- a/services/vault/src/components/pages/RootLayout.tsx
+++ b/services/vault/src/components/pages/RootLayout.tsx
@@ -13,7 +13,13 @@ import {
   useIsMobile,
 } from "@babylonlabs-io/core-ui";
 import { useTheme } from "next-themes";
-import { useCallback, useState } from "react";
+import {
+  type CSSProperties,
+  useCallback,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import { BsDiscord, BsGithub, BsLinkedin } from "react-icons/bs";
 import { FaXTwitter } from "react-icons/fa6";
 import { NavLink, Outlet, useLocation } from "react-router";
@@ -164,11 +170,22 @@ export default function RootLayout() {
 
   const isWalletConnected = btcConnected && ethConnected;
   const showAddressTypeBanner = isWalletConnected && !isSupportedAddress;
+  // Deposit kill-switch banner. Suppressed when a frozen/paused status banner is
+  // active, since that banner already explains the disabled state.
   const showDepositDisabledBanner =
     !isGeoBlocked &&
     isWalletConnected &&
     FeatureFlags.isDepositDisabled &&
     resolveBannerStatus(gate) === null;
+  // The deposit-disabled banner renders full-width above the sidebar (per Figma
+  // node 10084:28515). Measure its height and expose it as a CSS variable so the
+  // sticky v3 sidebar can offset its top/height and avoid clipping its footer.
+  // Zero when the banner is hidden, so the common case is unaffected.
+  const topBannerRef = useRef<HTMLDivElement>(null);
+  const [topBannerHeight, setTopBannerHeight] = useState(0);
+  useLayoutEffect(() => {
+    setTopBannerHeight(topBannerRef.current?.offsetHeight ?? 0);
+  }, [showDepositDisabledBanner]);
   // The disconnected dashboard landing (DisconnectedOverview / "Native Bitcoin
   // backed borrowing") is vertically centered via `my-auto` on its Container.
   // On that screen only, drop the footer's top margins (the wrapper's `mt-auto`
@@ -223,8 +240,15 @@ export default function RootLayout() {
   );
 
   return (
-    <div className="relative flex min-h-svh w-full flex-col bg-surface">
-      <DepositDisabledBanner visible={showDepositDisabledBanner} />
+    <div
+      className="relative flex min-h-svh w-full flex-col bg-surface"
+      style={
+        { "--tbv-top-banner-height": `${topBannerHeight}px` } as CSSProperties
+      }
+    >
+      <div ref={topBannerRef} className="sticky top-0 z-30">
+        <DepositDisabledBanner visible={showDepositDisabledBanner} />
+      </div>
       <div className="flex min-w-0 flex-1">
         {showV3Sidebar && <AppSidebar />}
         <div className="flex min-w-0 flex-1 flex-col">

--- a/services/vault/src/components/pages/RootLayout.tsx
+++ b/services/vault/src/components/pages/RootLayout.tsx
@@ -164,6 +164,11 @@ export default function RootLayout() {
 
   const isWalletConnected = btcConnected && ethConnected;
   const showAddressTypeBanner = isWalletConnected && !isSupportedAddress;
+  const showDepositDisabledBanner =
+    !isGeoBlocked &&
+    isWalletConnected &&
+    FeatureFlags.isDepositDisabled &&
+    resolveBannerStatus(gate) === null;
   // The disconnected dashboard landing (DisconnectedOverview / "Native Bitcoin
   // backed borrowing") is vertically centered via `my-auto` on its Container.
   // On that screen only, drop the footer's top margins (the wrapper's `mt-auto`
@@ -214,22 +219,12 @@ export default function RootLayout() {
         visible={!isGeoBlocked && isWalletConnected && isAddressBlocked}
       />
       <AddressTypeBanner visible={!isGeoBlocked && showAddressTypeBanner} />
-      {/* Deposit kill-switch banner. Suppressed when a frozen/paused status
-          banner is active, since that banner already explains the disabled
-          state. */}
-      <DepositDisabledBanner
-        visible={
-          !isGeoBlocked &&
-          isWalletConnected &&
-          FeatureFlags.isDepositDisabled &&
-          resolveBannerStatus(gate) === null
-        }
-      />
     </>
   );
 
   return (
     <div className="relative flex min-h-svh w-full flex-col bg-surface">
+      <DepositDisabledBanner visible={showDepositDisabledBanner} />
       <div className="flex min-w-0 flex-1">
         {showV3Sidebar && <AppSidebar />}
         <div className="flex min-w-0 flex-1 flex-col">

--- a/services/vault/src/components/shared/AppSidebar.tsx
+++ b/services/vault/src/components/shared/AppSidebar.tsx
@@ -81,6 +81,7 @@ function V3NavLinks() {
 export function AppSidebar() {
   return (
     <Sidebar
+      className="top-[var(--tbv-top-banner-height,0px)] h-[calc(100svh_-_var(--tbv-top-banner-height,0px))]"
       brand={<SidebarBrandLockup className="text-black dark:text-white" />}
       footer={<SidebarFooter />}
     >

--- a/services/vault/src/components/shared/DepositDisabledBanner.tsx
+++ b/services/vault/src/components/shared/DepositDisabledBanner.tsx
@@ -1,4 +1,4 @@
-import { Text } from "@babylonlabs-io/core-ui";
+import { Banner, Text } from "@babylonlabs-io/core-ui";
 
 import { COPY } from "@/copy";
 
@@ -12,8 +12,8 @@ export function DepositDisabledBanner({ visible }: DepositDisabledBannerProps) {
   }
 
   return (
-    <div className="flex flex-row items-center justify-center gap-2 bg-secondary-main px-4 py-3 text-center text-accent-contrast">
+    <Banner variant="notice">
       <Text variant="body2">{COPY.deposit.disabled.bannerMessage}</Text>
-    </div>
+    </Banner>
   );
 }

--- a/services/vault/src/components/shared/__tests__/DepositDisabledBanner.test.tsx
+++ b/services/vault/src/components/shared/__tests__/DepositDisabledBanner.test.tsx
@@ -6,9 +6,10 @@ import { COPY } from "@/copy";
 import { DepositDisabledBanner } from "../DepositDisabledBanner";
 
 describe("DepositDisabledBanner", () => {
-  it("shows the maintenance message when visible", () => {
+  it("renders the maintenance message in the notice banner", () => {
     render(<DepositDisabledBanner visible />);
 
+    expect(screen.getByRole("status")).toHaveClass("bbn-banner-notice");
     expect(
       screen.getByText(COPY.deposit.disabled.bannerMessage),
     ).toBeInTheDocument();


### PR DESCRIPTION
Add a shared full-width Banner to core-ui with critical and notice variant

## Screenshot
<img width="1457" height="351" alt="Screenshot 2026-07-17 at 18 44 34" src="https://github.com/user-attachments/assets/d27ef4c6-b2a4-4a02-bc1b-7d88c47cb90a" />
<img width="1448" height="325" alt="Screenshot 2026-07-17 at 18 44 27" src="https://github.com/user-attachments/assets/ce23b411-9e23-4e8d-bf0b-79969d920995" />
