### PR TITLE
fix(vault): make the funnel failure captures reachable, quiet and shared

### DIFF
--- a/services/vault/src/components/deposit/PayoutSignModal/__tests__/usePayoutSigningState.test.tsx
+++ b/services/vault/src/components/deposit/PayoutSignModal/__tests__/usePayoutSigningState.test.tsx
@@ -67,7 +67,13 @@ vi.mock("../../../../utils/btc", () => ({
   },
 }));
 
-vi.mock("../../../../utils/errors/formatting", () => ({
+// Stub only the message formatter. `classifyError` stays real so the
+// user-rejection filter is exercised against genuine EIP-1193 classification
+// rather than a stub that could agree with a wrong implementation.
+vi.mock("../../../../utils/errors/formatting", async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import("../../../../utils/errors/formatting")
+  >()),
   formatPayoutSignatureError: (err: unknown) => ({
     title: "Sign Error",
     message: err instanceof Error ? err.message : String(err),
@@ -224,6 +230,26 @@ describe("usePayoutSigningState", () => {
 
       expect(mockLoggerError).not.toHaveBeenCalled();
       expect(result.current.error).toBeNull();
+    });
+
+    it("does not capture a wallet decline, but still surfaces it to the user", async () => {
+      // EIP-1193 4001 — what a wallet throws when the depositor hits Reject.
+      // Routine drop-off, not a presign failure: it must not reach Sentry and
+      // inflate the rate the activation.payouts tag alerts on.
+      const declined = Object.assign(new Error("User rejected the request"), {
+        code: 4001,
+      });
+      mockSignAndSubmitPayouts.mockRejectedValueOnce(declined);
+
+      const { result } = renderHookWithProps();
+
+      await act(async () => {
+        await result.current.handleSign();
+      });
+
+      expect(mockLoggerError).not.toHaveBeenCalled();
+      // Unlike AbortError (modal closed), the user is still here — show them why.
+      expect(result.current.error?.title).toBe("Sign Error");
     });
   });
 

--- a/services/vault/src/components/deposit/PayoutSignModal/usePayoutSigningState.ts
+++ b/services/vault/src/components/deposit/PayoutSignModal/usePayoutSigningState.ts
@@ -13,8 +13,11 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import type { Hex } from "viem";
 
 import { COPY } from "@/copy";
-import { logger } from "@/infrastructure";
-import { shortId, TELEMETRY_STAGE } from "@/infrastructure/telemetryEvents";
+import {
+  captureFunnelFailure,
+  shortId,
+  TELEMETRY_STAGE,
+} from "@/infrastructure/telemetryEvents";
 import type { PayoutSigningProgress } from "@/services/vault/vaultPayoutSignatureService";
 
 import { usePeginPolling } from "../../../context/deposit/PeginPollingContext";
@@ -308,13 +311,14 @@ export function usePayoutSigningState({
         }
         // Critical-path #3 presign failure on the resume path — previously
         // only surfaced to UI state, invisible to Sentry.
-        logger.error(err instanceof Error ? err : new Error(String(err)), {
-          tags: { funnelStage: TELEMETRY_STAGE.ACTIVATION_PAYOUTS },
-          data: {
-            vaultId: shortId(activity.id),
+        captureFunnelFailure(
+          TELEMETRY_STAGE.ACTIVATION_PAYOUTS,
+          err,
+          activity.id,
+          {
             providerId: shortId(vaultProviderAddress),
           },
-        });
+        );
         setError(formatPayoutSignatureError(err));
         setSigning(false);
       }

--- a/services/vault/src/components/simple/ResumeDepositContent.tsx
+++ b/services/vault/src/components/simple/ResumeDepositContent.tsx
@@ -45,7 +45,10 @@ import { useRequiredPrePeginDepth } from "@/hooks/deposit/useRequiredPrePeginDep
 import { useSplitVaultProgress } from "@/hooks/deposit/useSplitVaultProgress";
 import { useRunOnce } from "@/hooks/useRunOnce";
 import { logger } from "@/infrastructure";
-import { shortId, TELEMETRY_STAGE } from "@/infrastructure/telemetryEvents";
+import {
+  captureFunnelFailure,
+  TELEMETRY_STAGE,
+} from "@/infrastructure/telemetryEvents";
 import {
   ContractStatus,
   getPeginDisplayStep,
@@ -426,12 +429,8 @@ export function ResumeWotsContent({
       // so a real WOTS-submission / derivation-drift failure is worth knowing
       // even if the user has already closed the modal. Only the UI update below
       // is mount-gated. A mismatch is flagged for faceting.
-      logger.error(err instanceof Error ? err : new Error(String(err)), {
-        tags: { funnelStage: TELEMETRY_STAGE.ACTIVATION_WOTS },
-        data: {
-          vaultId: shortId(activity.id),
-          wotsMismatch: isWotsMismatchError(err),
-        },
+      captureFunnelFailure(TELEMETRY_STAGE.ACTIVATION_WOTS, err, activity.id, {
+        wotsMismatch: isWotsMismatchError(err),
       });
       if (mountedRef.current) {
         const msg =
@@ -675,10 +674,7 @@ export function ResumeActivationContent({
       // Capture regardless of mount (no abort signal on this flow). The error
       // message carries only tx hashes (regex-scrubbed) and derivation errors,
       // never secret bytes. Only the UI update below is mount-gated.
-      logger.error(err instanceof Error ? err : new Error(String(err)), {
-        tags: { funnelStage: TELEMETRY_STAGE.ACTIVATION_SECRET },
-        data: { vaultId: shortId(activity.id) },
-      });
+      captureFunnelFailure(TELEMETRY_STAGE.ACTIVATION_SECRET, err, activity.id);
       if (mountedRef.current) {
         const msg =
           err instanceof Error ? err.message : "Failed to activate BTC Vault";

--- a/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
+++ b/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
@@ -35,6 +35,19 @@ vi.mock("@/config/network", () => ({
   getETHChain: vi.fn(() => ({ id: 11155111 })),
 }));
 
+// `captureFunnelFailure` reaches the logger through this barrel, so mocking it
+// here intercepts the capture. `event` must be present: handleActivation's
+// success path calls logger.event, and omitting it would fail the happy paths.
+const mockLoggerError = vi.hoisted(() => vi.fn());
+vi.mock("@/infrastructure", () => ({
+  logger: {
+    error: mockLoggerError,
+    event: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
 vi.mock("@babylonlabs-io/ts-sdk/tbv/core", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@babylonlabs-io/ts-sdk/tbv/core")>()),
   ensureHexPrefix: vi.fn((v: string) => (v.startsWith("0x") ? v : `0x${v}`)),
@@ -944,5 +957,54 @@ describe("useVaultActions — handleActivation hashlock source", () => {
     expect(mockActivateVaultWithSecret).toHaveBeenCalledWith(
       expect.objectContaining({ hashlock: ON_CHAIN_HASHLOCK }),
     );
+  });
+
+  // handleActivation catches its own failures and never rethrows, so this catch
+  // is the only place a reveal failure is observable. A capture in a caller's
+  // catch (useActivationState) would never run.
+  it("captures an on-chain reveal failure with the activation.reveal stage and a scrubbed vaultId", async () => {
+    const reader = readerReturning({
+      depositorSignedPeginTx: "0xdeadbeef",
+      hashlock: ON_CHAIN_HASHLOCK,
+    });
+    mockGetVaultRegistryReader.mockReturnValue(reader);
+    mockActivateVaultWithSecret.mockRejectedValue(
+      new Error("execution reverted: InvalidSecret"),
+    );
+
+    const { result } = renderHook(() => useVaultActions());
+
+    await act(async () => {
+      await result.current.handleActivation(baseActivationParams);
+    });
+
+    expect(mockLoggerError).toHaveBeenCalledTimes(1);
+    const [err, ctx] = mockLoggerError.mock.calls[0];
+    expect(err).toBeInstanceOf(Error);
+    expect(ctx.tags.funnelStage).toBe("activation.reveal");
+    expect(ctx.data.vaultId).toBe("0xva...ltId");
+    expect(result.current.activationError).toContain("execution reverted");
+  });
+
+  it("does not capture a wallet decline of the activation tx, but still surfaces it", async () => {
+    const reader = readerReturning({
+      depositorSignedPeginTx: "0xdeadbeef",
+      hashlock: ON_CHAIN_HASHLOCK,
+    });
+    mockGetVaultRegistryReader.mockReturnValue(reader);
+    // EIP-1193 4001 — the depositor hit Reject in their wallet. Routine
+    // drop-off, not a reveal failure; it must not reach Sentry.
+    mockActivateVaultWithSecret.mockRejectedValue(
+      Object.assign(new Error("User rejected the request"), { code: 4001 }),
+    );
+
+    const { result } = renderHook(() => useVaultActions());
+
+    await act(async () => {
+      await result.current.handleActivation(baseActivationParams);
+    });
+
+    expect(mockLoggerError).not.toHaveBeenCalled();
+    expect(result.current.activationError).not.toBeNull();
   });
 });

--- a/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
+++ b/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
@@ -1007,4 +1007,103 @@ describe("useVaultActions — handleActivation hashlock source", () => {
     expect(mockLoggerError).not.toHaveBeenCalled();
     expect(result.current.activationError).not.toBeNull();
   });
+
+  // A pause is operator action hitting every depositor at once — capturing it
+  // would spike the exact rate the activation.reveal tag alerts on. It also
+  // keeps the two paused paths consistent: the cached-gate early return never
+  // captured, so the fresh-gate re-check must not either.
+  it("does not capture the fresh-gate pause as a reveal failure, but still surfaces it", async () => {
+    gateMock.value = { protocol: null, aave: null };
+    onChainPauseMock.value = { protocol: null, aave: "paused" };
+    const reader = readerReturning({
+      depositorSignedPeginTx: "0xdeadbeef",
+      hashlock: ON_CHAIN_HASHLOCK,
+    });
+    mockGetVaultRegistryReader.mockReturnValue(reader);
+
+    const { result } = renderHook(() => useVaultActions());
+
+    await act(async () => {
+      await result.current.handleActivation(baseActivationParams);
+    });
+
+    expect(mockLoggerError).not.toHaveBeenCalled();
+    expect(result.current.activationError).not.toBeNull();
+  });
+
+  // The retryable non-VERIFIED branch exists to absorb the indexer-lag race
+  // (indexer says VERIFIED, contract still PENDING) — a normal, self-resolving
+  // transient, not a reveal failure. The user still sees the retryable error.
+  it("does not capture the retryable non-VERIFIED status as a reveal failure", async () => {
+    const reader = readerReturning(
+      {
+        depositorSignedPeginTx: "0xdeadbeef",
+        hashlock: ON_CHAIN_HASHLOCK,
+      },
+      { status: OnChainBtcVaultStatus.PENDING },
+    );
+    mockGetVaultRegistryReader.mockReturnValue(reader);
+
+    const { result } = renderHook(() => useVaultActions());
+
+    await act(async () => {
+      await result.current.handleActivation(baseActivationParams);
+    });
+
+    expect(mockLoggerError).not.toHaveBeenCalled();
+    expect(result.current.activationError).toContain("PENDING");
+    expect(result.current.activationErrorTerminal).toBe(false);
+  });
+
+  // Mutation check on the suppression scope: EXPIRED is a genuine dead-end
+  // (retrying can't revert the status), so it must STILL be captured. Fails if
+  // the expected-interruption marker is ever set before the EXPIRED branch.
+  it("still captures the terminal EXPIRED status as a reveal failure", async () => {
+    const reader = readerReturning(
+      {
+        depositorSignedPeginTx: "0xdeadbeef",
+        hashlock: ON_CHAIN_HASHLOCK,
+      },
+      { status: OnChainBtcVaultStatus.EXPIRED },
+    );
+    mockGetVaultRegistryReader.mockReturnValue(reader);
+
+    const { result } = renderHook(() => useVaultActions());
+
+    await act(async () => {
+      await result.current.handleActivation(baseActivationParams);
+    });
+
+    expect(mockLoggerError).toHaveBeenCalledTimes(1);
+    const [, ctx] = mockLoggerError.mock.calls[0];
+    expect(ctx.tags.funnelStage).toBe("activation.reveal");
+    expect(result.current.activationErrorTerminal).toBe(true);
+  });
+
+  // Once `activateVaultWithSecret` resolves, the reveal has landed on-chain.
+  // A throw in the post-success bookkeeping (success modal, refetch, txid
+  // fallback parse) must not be captured as activation.reveal — that would
+  // report a failure for an activation that succeeded, inverting the metric.
+  it("does not capture a post-reveal bookkeeping throw once the reveal has landed on-chain", async () => {
+    const reader = readerReturning({
+      depositorSignedPeginTx: "0xdeadbeef",
+      hashlock: ON_CHAIN_HASHLOCK,
+    });
+    mockGetVaultRegistryReader.mockReturnValue(reader);
+    mockActivateVaultWithSecret.mockResolvedValue(undefined as never);
+
+    const { result } = renderHook(() => useVaultActions());
+
+    await act(async () => {
+      await result.current.handleActivation({
+        ...baseActivationParams,
+        onShowSuccessModal: vi.fn(() => {
+          throw new Error("success modal blew up");
+        }),
+      });
+    });
+
+    expect(mockActivateVaultWithSecret).toHaveBeenCalledTimes(1);
+    expect(mockLoggerError).not.toHaveBeenCalled();
+  });
 });

--- a/services/vault/src/hooks/deposit/useActivationState.ts
+++ b/services/vault/src/hooks/deposit/useActivationState.ts
@@ -10,8 +10,6 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 import { useActivatingVaults } from "@/applications/aave/context";
 import { usePeginPolling } from "@/context/deposit/PeginPollingContext";
-import { logger } from "@/infrastructure";
-import { shortId, TELEMETRY_STAGE } from "@/infrastructure/telemetryEvents";
 import { LocalStorageStatus } from "@/models/peginStateMachine";
 import { usePeginStorage } from "@/storage/usePeginStorage";
 import type { VaultActivity } from "@/types/activity";
@@ -110,11 +108,11 @@ export function useActivationState({
             setActivated(true);
           },
         });
-      } catch (err) {
-        logger.error(err instanceof Error ? err : new Error(String(err)), {
-          tags: { funnelStage: TELEMETRY_STAGE.ACTIVATION_REVEAL },
-          data: { vaultId: shortId(activity.id) },
-        });
+      } catch {
+        // Defensive. `vaultHandleActivation` reports its own failures (including
+        // the activation.reveal capture) and resolves rather than rethrowing, so
+        // this cannot fire today — it only resets local state if that contract
+        // ever changes. Capturing here instead would be dead code.
         if (mountedRef.current) setLocalActivating(false);
       }
     },

--- a/services/vault/src/hooks/deposit/useVaultActions.ts
+++ b/services/vault/src/hooks/deposit/useVaultActions.ts
@@ -33,7 +33,12 @@ import { getETHChain } from "@/config/network";
 import { COPY } from "@/copy";
 import { useProtocolGateState } from "@/hooks/useProtocolGate";
 import { logger } from "@/infrastructure";
-import { shortId, TELEMETRY_EVENT } from "@/infrastructure/telemetryEvents";
+import {
+  captureFunnelFailure,
+  shortId,
+  TELEMETRY_EVENT,
+  TELEMETRY_STAGE,
+} from "@/infrastructure/telemetryEvents";
 import {
   ActivationNotPossibleError,
   isTerminalActivationError,
@@ -503,6 +508,11 @@ export function useVaultActions(): UseVaultActionsReturn {
 
       if (mountedRef.current) setActivating(false);
     } catch (err) {
+      // Capture regardless of mount — activation has no abort signal, so a real
+      // reveal failure is worth knowing even if the modal closed mid-flight.
+      // This is the only place the error is caught: handleActivation never
+      // rethrows, so a capture in any caller's catch would be unreachable.
+      captureFunnelFailure(TELEMETRY_STAGE.ACTIVATION_REVEAL, err, vaultId);
       if (mountedRef.current) {
         const rawMessage =
           err instanceof Error ? err.message : "Failed to activate BTC Vault";

--- a/services/vault/src/hooks/deposit/useVaultActions.ts
+++ b/services/vault/src/hooks/deposit/useVaultActions.ts
@@ -397,6 +397,16 @@ export function useVaultActions(): UseVaultActionsReturn {
     setActivationError(null);
     setActivationErrorTerminal(false);
 
+    // Telemetry discriminators for the catch below. `expectedInterruption`
+    // marks the self-resolving pre-reveal states (protocol pause, the
+    // indexer-lag non-VERIFIED race) that surface to the user but are routine,
+    // not reveal failures. `revealed` flips once the secret reveal has landed
+    // on-chain — anything thrown after that is post-success bookkeeping, and
+    // capturing it as activation.reveal would report a failure for an
+    // activation that succeeded.
+    let expectedInterruption = false;
+    let revealed = false;
+
     try {
       // Read basic + protocol info in one parallel call. Indexer is
       // untrusted for signing-critical reads, so both come from on-chain.
@@ -421,6 +431,10 @@ export function useVaultActions(): UseVaultActionsReturn {
         ? composeGateState(freshPauseState)
         : gate;
       if (isActivationBlocked(effectiveGate)) {
+        // Same user-visible outcome as the cached-gate early return above —
+        // operator action, not a depositor failure, so telemetry stays quiet
+        // on both paths.
+        expectedInterruption = true;
         throw new Error(COPY.pegin.activationPaused);
       }
 
@@ -450,6 +464,11 @@ export function useVaultActions(): UseVaultActionsReturn {
         if (basicInfo.status === OnChainBtcVaultStatus.EXPIRED) {
           throw new ActivationNotPossibleError(message);
         }
+        // The retryable branch exists to absorb the indexer-lag race above;
+        // it is likely the most common landing in the catch and would inflate
+        // the activation.reveal rate. EXPIRED stays captured — a genuine
+        // dead-end, not a transient.
+        expectedInterruption = true;
         throw new Error(message);
       }
 
@@ -480,6 +499,7 @@ export function useVaultActions(): UseVaultActionsReturn {
         hashlock: ensureHexPrefix(protocolInfo.hashlock) as Hex,
         walletClient,
       });
+      revealed = true;
 
       // Cross-device resume has no `pendingPegin`; fall back to the
       // contract-authoritative signed pegin tx so the entry doesn't leak.
@@ -512,7 +532,12 @@ export function useVaultActions(): UseVaultActionsReturn {
       // reveal failure is worth knowing even if the modal closed mid-flight.
       // This is the only place the error is caught: handleActivation never
       // rethrows, so a capture in any caller's catch would be unreachable.
-      captureFunnelFailure(TELEMETRY_STAGE.ACTIVATION_REVEAL, err, vaultId);
+      // Skipped for expected pre-reveal interruptions and for anything thrown
+      // after the reveal landed on-chain — either would count a non-failure
+      // against the activation.reveal rate.
+      if (!expectedInterruption && !revealed) {
+        captureFunnelFailure(TELEMETRY_STAGE.ACTIVATION_REVEAL, err, vaultId);
+      }
       if (mountedRef.current) {
         const rawMessage =
           err instanceof Error ? err.message : "Failed to activate BTC Vault";

--- a/services/vault/src/infrastructure/telemetryEvents.ts
+++ b/services/vault/src/infrastructure/telemetryEvents.ts
@@ -8,6 +8,8 @@
  * followed by the stage and, where it adds signal, the outcome.
  */
 
+import { logger } from "@/infrastructure";
+import { classifyError } from "@/utils/errors/formatting";
 import { redactIdentifier } from "@/utils/telemetry";
 
 export const TELEMETRY_EVENT = {
@@ -40,6 +42,31 @@ export const TELEMETRY_STAGE = {
 
 export type TelemetryStage =
   (typeof TELEMETRY_STAGE)[keyof typeof TELEMETRY_STAGE];
+
+/**
+ * Capture a funnel-stage failure, with the tag schema the stage alerts facet on.
+ *
+ * A wallet decline is routine depositor drop-off, not a failure, so it is never
+ * captured — every one of these stages fronts a wallet popup, and counting
+ * cancellations would inflate the very rate these tags alert on. The caller
+ * still renders its own rejection copy; only the Sentry capture is suppressed.
+ *
+ * `vaultId` is shortened here so the per-vault join key back to the success
+ * milestones cannot be forgotten at a call site. Pass any further identifiers in
+ * `extra` already shortened via `shortId`.
+ */
+export function captureFunnelFailure(
+  stage: TelemetryStage,
+  err: unknown,
+  vaultId: string,
+  extra: Record<string, string | number | boolean> = {},
+): void {
+  if (classifyError(err) === "user-rejection") return;
+  logger.error(err instanceof Error ? err : new Error(String(err)), {
+    tags: { funnelStage: stage },
+    data: { vaultId: shortId(vaultId), ...extra },
+  });
+}
 
 /**
  * Shorten a long identifier (vaultId, provider address, txid) to `first4...last4`


### PR DESCRIPTION
## Context

Follow-up to @gbarkhatov's review on #2069, which flagged four issues in the **Phase 2** failure captures (#2053). Those merged before the review landed, so they're out of scope for Phase 3's diff — split out here as suggested.

Each is against code now in `main`. Every fix has a test verified to fail without it.

## 1. `activation.reveal` was unreachable — on-chain reveal failures reached Sentry nowhere

The capture sat in `useActivationState`'s catch, wrapped around `await vaultHandleActivation(...)`:

```ts
try {
  await vaultHandleActivation({ ... });
} catch (err) {
  logger.error(err, { tags: { funnelStage: TELEMETRY_STAGE.ACTIVATION_REVEAL }, ... });
}
```

But `useVaultActions.handleActivation` wraps its whole body in try/catch and **never rethrows** — its catch only calls `setActivationError` / `setActivationErrorTerminal` / `setActivating`. So the awaited promise resolves even when `activateVaultWithSecret` reverts, and that catch never runs. The try block contains exactly one statement, so there was no other path into it.

Net effect: a wrong secret, a passed activation deadline, or any on-chain revert during the reveal was invisible — not captured there, and not by the `activation.secret` catch either (swallowed before it).

**Fix:** emit from inside `handleActivation`'s catch, the only place the error is observable. Not by making it rethrow — two call sites depend on it resolving.

The caller's catch stays as a defensive state reset, but its dead capture is removed rather than left looking like coverage:

```ts
} catch {
  // Defensive. `vaultHandleActivation` reports its own failures (including
  // the activation.reveal capture) and resolves rather than rethrowing, so
  // this cannot fire today — it only resets local state if that contract
  // ever changes. Capturing here instead would be dead code.
  if (mountedRef.current) setLocalActivating(false);
}
```

## 2. Wallet declines were logged as `activation.*` failures

All four stages front a wallet popup, and a decline is EIP-1193 `4001` / `UserRejectedRequestError` — routine depositor drop-off, not a failure. The payouts guard only filtered `AbortError` (modal closed), which a decline is not, so it fell straight through to the capture — while `formatPayoutSignatureError` on the very next line classified that same error as a benign `user-rejection` for the UI. The two views disagreed about the same error.

**Fix:** gate every capture on `classifyError(err) !== "user-rejection"`. The UI still renders its rejection copy; only the Sentry capture is suppressed. `AbortError` keeps its separate early-return — it must also skip `setError` (the modal is gone), which the rejection path must not.

## 3. + 4. One helper instead of four copies, and `TelemetryStage` put to work

The four captures repeated the same shape, so the fixes above would have had to land four times. `captureFunnelFailure` centralizes the tag schema, the `shortId` convention on the per-vault join key, and the user-rejection filter:

```ts
export function captureFunnelFailure(
  stage: TelemetryStage,
  err: unknown,
  vaultId: string,
  extra: Record<string, string | number | boolean> = {},
): void {
  if (classifyError(err) === "user-rejection") return;
  logger.error(err instanceof Error ? err : new Error(String(err)), {
    tags: { funnelStage: stage },
    data: { vaultId: shortId(vaultId), ...extra },
  });
}
```

`vaultId` is shortened inside so the join key can't be forgotten at a call site. This also gives `TelemetryStage` a consumer — it was exported but referenced nowhere, so it's used rather than deleted (zero dead code).

It imports `logger` from the `@/infrastructure` barrel, not `./logger`, so the existing `vi.mock("@/infrastructure")` in tests still intercepts the capture. No cycle: the barrel only re-exports `logger`.

## Testing

- `useVaultActions.test.ts`: the reveal capture fires from where the error is caught, with the `activation.reveal` stage and a scrubbed vaultId; a wallet decline is suppressed but still surfaces to the user.
- `usePayoutSigningState.test.tsx`: a decline is not captured but still renders its error. The `formatting` mock now keeps the real `classifyError` via `importOriginal` and stubs only the message formatter, so the filter is exercised against genuine EIP-1193 classification rather than a stub that could agree with a wrong implementation.
- Each fix mutation-checked: removing the filter fails exactly the two decline tests; removing the reveal capture fails exactly the reveal test.
- Full vault suite green: **226 files, 2395 tests**. eslint clean; `tsc -p tsconfig.lib.json` clean.
