### PR TITLE
feat(vault): add daemon and pegout terminal events (Phase 4) to Sentry

### DIFF
--- a/services/vault/src/context/deposit/PeginPollingContext.tsx
+++ b/services/vault/src/context/deposit/PeginPollingContext.tsx
@@ -22,7 +22,7 @@ import {
 
 import { useDemoDeposit } from "@/dev/demoDeposit";
 import { logger } from "@/infrastructure";
-import { shortId } from "@/infrastructure/telemetryEvents";
+import { shortId, TELEMETRY_EVENT } from "@/infrastructure/telemetryEvents";
 
 import { usePeginPollingQuery } from "../../hooks/deposit/usePeginPollingQuery";
 import { useRequiredPrePeginDepthResolver } from "../../hooks/deposit/useRequiredPrePeginDepth";
@@ -57,6 +57,10 @@ import { isVaultOwnedByWallet } from "../../utils/vaultWarnings";
 import { useProtocolParamsContext } from "../ProtocolParamsContext";
 
 import { computeDepositPollingResult } from "./computeDepositPollingResult";
+import {
+  collectDaemonTerminalEvents,
+  getSharedDaemonTerminalTracking,
+} from "./daemonTerminalEvents";
 import {
   collectTerminalMilestones,
   getSharedTerminalMilestoneTracking,
@@ -146,6 +150,7 @@ export function PeginPollingProvider({
     pendingDepositorSignatures,
     isLoading,
     refetch,
+    depositsToPoll,
   } = usePeginPollingQuery({
     activities,
     pendingPegins,
@@ -366,6 +371,28 @@ export function PeginPollingProvider({
       });
     }
   }, [activities]);
+
+  // Emit activation.daemon.terminal once per (vault, daemonStatus) as the VP
+  // daemon reports a terminal drop (Expired / AmlRejected / ...). These states
+  // stop polling and previously transmitted nothing — a rejected deposit was
+  // invisible. Same seeding rule and shared-store rationale as the milestone
+  // effect above; gated on `errors` so it only runs once a poll has resolved.
+  useEffect(() => {
+    if (!errors) return;
+    const terminalEvents = collectDaemonTerminalEvents(
+      depositsToPoll.map((deposit) => deposit.activity.id),
+      errors,
+      getSharedDaemonTerminalTracking(),
+    );
+    for (const terminal of terminalEvents) {
+      logger.event(TELEMETRY_EVENT.ACTIVATION_DAEMON_TERMINAL, {
+        level: "warning",
+        category: "activation",
+        vaultId: shortId(terminal.vaultId),
+        daemonStatus: terminal.daemonStatus,
+      });
+    }
+  }, [errors, depositsToPoll]);
 
   // Optimistic status handlers
   const setOptimisticStatus = useCallback(

--- a/services/vault/src/context/deposit/PeginPollingContext.tsx
+++ b/services/vault/src/context/deposit/PeginPollingContext.tsx
@@ -144,13 +144,13 @@ export function PeginPollingProvider({
 
   // Use the polling query hook
   const {
+    polledIds,
     errors,
     needsWotsKey,
     pendingIngestion,
     pendingDepositorSignatures,
     isLoading,
     refetch,
-    depositsToPoll,
   } = usePeginPollingQuery({
     activities,
     pendingPegins,
@@ -376,11 +376,16 @@ export function PeginPollingProvider({
   // daemon reports a terminal drop (Expired / AmlRejected / ...). These states
   // stop polling and previously transmitted nothing — a rejected deposit was
   // invisible. Same seeding rule and shared-store rationale as the milestone
-  // effect above; gated on `errors` so it only runs once a poll has resolved.
+  // effect above; runs only once a poll has resolved. `polledIds` is captured
+  // inside the queryFn, so ids and errors are always the same poll's snapshot —
+  // pairing the live `depositsToPoll` memo with `errors` instead would, under
+  // `keepPreviousData`, seed new vaults (wallet switch, late-arriving
+  // activities) against a stale map and later emit their pre-existing
+  // terminals as fresh transitions.
   useEffect(() => {
-    if (!errors) return;
+    if (!polledIds || !errors) return;
     const terminalEvents = collectDaemonTerminalEvents(
-      depositsToPoll.map((deposit) => deposit.activity.id),
+      polledIds,
       errors,
       getSharedDaemonTerminalTracking(),
     );
@@ -392,7 +397,7 @@ export function PeginPollingProvider({
         daemonStatus: terminal.daemonStatus,
       });
     }
-  }, [errors, depositsToPoll]);
+  }, [polledIds, errors]);
 
   // Optimistic status handlers
   const setOptimisticStatus = useCallback(

--- a/services/vault/src/context/deposit/__tests__/PeginPollingContext.test.tsx
+++ b/services/vault/src/context/deposit/__tests__/PeginPollingContext.test.tsx
@@ -14,13 +14,13 @@ import type { VaultActivity } from "../../../types/activity";
 import { PeginPollingProvider, usePeginPolling } from "../PeginPollingContext";
 
 const mockQueryResult = {
+  polledIds: undefined as string[] | undefined,
   errors: undefined as Map<string, Error> | undefined,
   needsWotsKey: undefined as Set<string> | undefined,
   pendingIngestion: undefined as Set<string> | undefined,
   pendingDepositorSignatures: undefined as Set<string> | undefined,
   isLoading: false,
   refetch: vi.fn(),
-  depositsToPoll: [],
 };
 
 vi.mock("../../../hooks/deposit/usePeginPollingQuery", () => ({

--- a/services/vault/src/context/deposit/__tests__/daemonTerminalEmission.test.tsx
+++ b/services/vault/src/context/deposit/__tests__/daemonTerminalEmission.test.tsx
@@ -1,0 +1,196 @@
+import { DaemonStatus } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
+import { render } from "@testing-library/react";
+import type { Hex } from "viem";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  ContractStatus,
+  PEGIN_DISPLAY_LABELS,
+} from "../../../models/peginStateMachine";
+import type { VaultActivity } from "../../../types/activity";
+import { TerminalPeginPollingError } from "../../../utils/peginPolling";
+import { resetSharedDaemonTerminalTracking } from "../daemonTerminalEvents";
+import { PeginPollingProvider } from "../PeginPollingContext";
+
+// Mutable polling-query state read by the mock below, so each rerender can
+// observe a different resolved poll. `polledIds` and `errors` are served as
+// one snapshot, mirroring the real hook's PollingQueryData contract — the
+// hook result carries no other id source, so the daemon-terminal effect can
+// only classify from this snapshot (never from the provider's live
+// `activities`, which the cases below keep disjoint from the polled ids by
+// never marking the activity terminal).
+const { pollingQueryState } = vi.hoisted(() => ({
+  pollingQueryState: {
+    polledIds: undefined as string[] | undefined,
+    errors: undefined as Map<string, Error> | undefined,
+  },
+}));
+
+vi.mock("../../../hooks/deposit/usePeginPollingQuery", () => ({
+  usePeginPollingQuery: () => ({
+    polledIds: pollingQueryState.polledIds,
+    errors: pollingQueryState.errors,
+    needsWotsKey: undefined,
+    pendingIngestion: undefined,
+    pendingDepositorSignatures: undefined,
+    isLoading: false,
+    refetch: vi.fn(),
+  }),
+}));
+
+// The hooks below reach for react-query / chain reads / ProtocolParams. Stub
+// them so the provider renders in isolation — this file only exercises the
+// daemon-terminal effect. Mirrors the stubs in terminalMilestoneEmission.
+vi.mock("../../../hooks/useBtcMempoolConfirmations", () => ({
+  useBtcMempoolConfirmations: () => ({ confirmationsByTxid: new Map() }),
+}));
+
+vi.mock("../../../hooks/useBtcHtlcRefundStatus", () => ({
+  useBtcHtlcRefundStatus: () => ({ refundByDepositId: new Map() }),
+}));
+
+vi.mock("../../../hooks/useActivationDeadlineGate", () => ({
+  useActivationDeadlineGate: () => new Set<string>(),
+}));
+
+vi.mock("../../ProtocolParamsContext", () => ({
+  useProtocolParamsContext: () => ({
+    config: { offchainParams: { minPrepeginDepth: 6 } },
+    getOffchainParamsByVersion: () => undefined,
+  }),
+}));
+
+const { mockEvent } = vi.hoisted(() => ({ mockEvent: vi.fn() }));
+vi.mock("@/infrastructure", () => ({
+  logger: { event: mockEvent, error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+// Long enough for shortId to shorten; distinct head/tail pin the redaction.
+const VAULT_ID = `0x11${"ab".repeat(29)}2222` as Hex;
+const BTC_PUBKEY = "ab".repeat(32);
+
+function pendingActivity(): VaultActivity {
+  return {
+    id: VAULT_ID,
+    collateral: { amount: "0.1", symbol: "BTC" },
+    providers: [{ id: "0xprovider" }],
+    peginTxHash: VAULT_ID,
+    contractStatus: ContractStatus.PENDING,
+    isInUse: false,
+    displayLabel: PEGIN_DISPLAY_LABELS.PENDING,
+    depositorBtcPubkey: BTC_PUBKEY,
+    unsignedPrePeginTx: "0xdeadbeef",
+    depositorPayoutBtcAddress: "0xpayoutscript" as Hex,
+    depositorWotsPkHash: "0xwotsh",
+  };
+}
+
+function terminalErrors(status: DaemonStatus): Map<string, Error> {
+  return new Map([
+    [VAULT_ID, new TerminalPeginPollingError(status, "terminal")],
+  ]);
+}
+
+const Tree = () => (
+  <PeginPollingProvider
+    activities={[pendingActivity()]}
+    pendingPegins={[]}
+    btcPublicKey={BTC_PUBKEY}
+  >
+    <div />
+  </PeginPollingProvider>
+);
+
+describe("daemon terminal emission through the polling provider", () => {
+  beforeEach(() => {
+    mockEvent.mockClear();
+    pollingQueryState.polledIds = undefined;
+    pollingQueryState.errors = undefined;
+    // The tracking store is app-scoped and outlives any provider, so it also
+    // outlives a test case. Without this reset a later case starts with the
+    // vault already seen and silently observes nothing.
+    resetSharedDaemonTerminalTracking();
+  });
+
+  it("emits a warning with the shortened vaultId when a healthy vault turns terminal", () => {
+    pollingQueryState.polledIds = [VAULT_ID];
+    pollingQueryState.errors = new Map();
+    const { rerender } = render(<Tree />);
+    expect(mockEvent).not.toHaveBeenCalled();
+
+    pollingQueryState.errors = terminalErrors(DaemonStatus.AML_REJECTED);
+    rerender(<Tree />);
+
+    expect(mockEvent).toHaveBeenCalledTimes(1);
+    expect(mockEvent).toHaveBeenCalledWith("activation.daemon.terminal", {
+      level: "warning",
+      category: "activation",
+      vaultId: "0x11...2222",
+      daemonStatus: DaemonStatus.AML_REJECTED,
+    });
+
+    // The sticky terminal re-observed on the next poll — no re-emit, because
+    // the shared store already holds the (vault, status) pair.
+    pollingQueryState.errors = terminalErrors(DaemonStatus.AML_REJECTED);
+    rerender(<Tree />);
+    expect(mockEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it("seeds a vault already terminal on its first resolved poll without emitting", () => {
+    pollingQueryState.polledIds = [VAULT_ID];
+    pollingQueryState.errors = terminalErrors(DaemonStatus.EXPIRED);
+    const { rerender } = render(<Tree />);
+
+    pollingQueryState.errors = terminalErrors(DaemonStatus.EXPIRED);
+    rerender(<Tree />);
+    expect(mockEvent).not.toHaveBeenCalled();
+
+    // A real progression past the seeded status still emits.
+    pollingQueryState.errors = terminalErrors(DaemonStatus.EXPIRED_CLEANED_UP);
+    rerender(<Tree />);
+    expect(mockEvent).toHaveBeenCalledTimes(1);
+    expect(mockEvent).toHaveBeenCalledWith(
+      "activation.daemon.terminal",
+      expect.objectContaining({
+        daemonStatus: DaemonStatus.EXPIRED_CLEANED_UP,
+      }),
+    );
+  });
+
+  it("observes nothing before the first poll resolves, then seeds from the resolved snapshot", () => {
+    const { rerender } = render(<Tree />);
+    expect(mockEvent).not.toHaveBeenCalled();
+
+    // First RESOLVED observation arrives already terminal: seed, don't emit.
+    pollingQueryState.polledIds = [VAULT_ID];
+    pollingQueryState.errors = terminalErrors(DaemonStatus.INGESTION_REJECTED);
+    rerender(<Tree />);
+    expect(mockEvent).not.toHaveBeenCalled();
+  });
+
+  it("emits once when co-mounted providers observe the same transition", () => {
+    const NestedTree = () => (
+      <PeginPollingProvider
+        activities={[pendingActivity()]}
+        pendingPegins={[]}
+        btcPublicKey={BTC_PUBKEY}
+      >
+        <PeginPollingProvider
+          activities={[pendingActivity()]}
+          pendingPegins={[]}
+          btcPublicKey={BTC_PUBKEY}
+        >
+          <div />
+        </PeginPollingProvider>
+      </PeginPollingProvider>
+    );
+
+    pollingQueryState.polledIds = [VAULT_ID];
+    pollingQueryState.errors = new Map();
+    const { rerender } = render(<NestedTree />);
+
+    pollingQueryState.errors = terminalErrors(DaemonStatus.AML_REJECTED);
+    rerender(<NestedTree />);
+    expect(mockEvent).toHaveBeenCalledTimes(1);
+  });
+});

--- a/services/vault/src/context/deposit/__tests__/daemonTerminalEvents.test.ts
+++ b/services/vault/src/context/deposit/__tests__/daemonTerminalEvents.test.ts
@@ -68,4 +68,40 @@ describe("collectDaemonTerminalEvents", () => {
     const errors = new Map([["0xa", new Error("Provider unreachable")]]);
     expect(collectDaemonTerminalEvents(["0xa"], errors, tracking)).toEqual([]);
   });
+
+  it("does not seed from a connectivity-errored first poll, so a prior-session terminal stays suppressed", () => {
+    const tracking = createDaemonTerminalTracking();
+
+    // First poll after reload fails to reach the provider: not an observation.
+    const unreachable = new Map([["0xold", new Error("Provider unreachable")]]);
+    expect(
+      collectDaemonTerminalEvents(["0xold"], unreachable, tracking),
+    ).toEqual([]);
+
+    // Next poll succeeds and reports the prior-session drop: this is the first
+    // genuine observation, so it seeds without emitting.
+    const errors = new Map([["0xold", terminalError(DaemonStatus.EXPIRED)]]);
+    expect(collectDaemonTerminalEvents(["0xold"], errors, tracking)).toEqual(
+      [],
+    );
+    expect(collectDaemonTerminalEvents(["0xold"], errors, tracking)).toEqual(
+      [],
+    );
+  });
+
+  it("still emits a genuine transition after an initial connectivity error", () => {
+    const tracking = createDaemonTerminalTracking();
+
+    const unreachable = new Map([["0xa", new Error("Provider unreachable")]]);
+    collectDaemonTerminalEvents(["0xa"], unreachable, tracking);
+
+    // First genuine observation is healthy — seeds.
+    collectDaemonTerminalEvents(["0xa"], new Map(), tracking);
+
+    // The in-session drop that follows emits.
+    const errors = new Map([["0xa", terminalError(DaemonStatus.AML_REJECTED)]]);
+    expect(collectDaemonTerminalEvents(["0xa"], errors, tracking)).toEqual([
+      { vaultId: "0xa", daemonStatus: DaemonStatus.AML_REJECTED },
+    ]);
+  });
 });

--- a/services/vault/src/context/deposit/__tests__/daemonTerminalEvents.test.ts
+++ b/services/vault/src/context/deposit/__tests__/daemonTerminalEvents.test.ts
@@ -1,0 +1,71 @@
+import { DaemonStatus } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
+import { describe, expect, it } from "vitest";
+
+import { TerminalPeginPollingError } from "../../../utils/peginPolling";
+import {
+  collectDaemonTerminalEvents,
+  createDaemonTerminalTracking,
+} from "../daemonTerminalEvents";
+
+const terminalError = (status: DaemonStatus) =>
+  new TerminalPeginPollingError(status, "terminal");
+
+describe("collectDaemonTerminalEvents", () => {
+  it("emits once when a seen vault transitions to a terminal daemon status", () => {
+    const tracking = createDaemonTerminalTracking();
+
+    // First poll: healthy (no error) — marks the vault seen, emits nothing.
+    expect(collectDaemonTerminalEvents(["0xa"], new Map(), tracking)).toEqual(
+      [],
+    );
+
+    // VP reports AmlRejected — emits once.
+    const errors = new Map([["0xa", terminalError(DaemonStatus.AML_REJECTED)]]);
+    expect(collectDaemonTerminalEvents(["0xa"], errors, tracking)).toEqual([
+      { vaultId: "0xa", daemonStatus: DaemonStatus.AML_REJECTED },
+    ]);
+
+    // Sticky terminal error re-observed every poll — no re-emit.
+    expect(collectDaemonTerminalEvents(["0xa"], errors, tracking)).toEqual([]);
+  });
+
+  it("seeds a vault already terminal at first observation without emitting (no page-load burst)", () => {
+    const tracking = createDaemonTerminalTracking();
+    const errors = new Map([["0xold", terminalError(DaemonStatus.EXPIRED)]]);
+
+    expect(collectDaemonTerminalEvents(["0xold"], errors, tracking)).toEqual(
+      [],
+    );
+    expect(collectDaemonTerminalEvents(["0xold"], errors, tracking)).toEqual(
+      [],
+    );
+  });
+
+  it("emits each distinct terminal status once as a vault progresses Expired -> ExpiredCleanedUp", () => {
+    const tracking = createDaemonTerminalTracking();
+    collectDaemonTerminalEvents(["0xa"], new Map(), tracking);
+
+    const expired = new Map([["0xa", terminalError(DaemonStatus.EXPIRED)]]);
+    expect(collectDaemonTerminalEvents(["0xa"], expired, tracking)).toEqual([
+      { vaultId: "0xa", daemonStatus: DaemonStatus.EXPIRED },
+    ]);
+
+    const cleanedUp = new Map([
+      ["0xa", terminalError(DaemonStatus.EXPIRED_CLEANED_UP)],
+    ]);
+    expect(collectDaemonTerminalEvents(["0xa"], cleanedUp, tracking)).toEqual([
+      { vaultId: "0xa", daemonStatus: DaemonStatus.EXPIRED_CLEANED_UP },
+    ]);
+    expect(collectDaemonTerminalEvents(["0xa"], cleanedUp, tracking)).toEqual(
+      [],
+    );
+  });
+
+  it("ignores non-terminal errors (provider connectivity) entirely", () => {
+    const tracking = createDaemonTerminalTracking();
+    collectDaemonTerminalEvents(["0xa"], new Map(), tracking);
+
+    const errors = new Map([["0xa", new Error("Provider unreachable")]]);
+    expect(collectDaemonTerminalEvents(["0xa"], errors, tracking)).toEqual([]);
+  });
+});

--- a/services/vault/src/context/deposit/__tests__/terminalMilestoneEmission.test.tsx
+++ b/services/vault/src/context/deposit/__tests__/terminalMilestoneEmission.test.tsx
@@ -12,13 +12,13 @@ import { resetSharedTerminalMilestoneTracking } from "../terminalMilestones";
 
 vi.mock("../../../hooks/deposit/usePeginPollingQuery", () => ({
   usePeginPollingQuery: () => ({
+    polledIds: undefined,
     errors: undefined,
     needsWotsKey: undefined,
     pendingIngestion: undefined,
     pendingDepositorSignatures: undefined,
     isLoading: false,
     refetch: vi.fn(),
-    depositsToPoll: [],
   }),
 }));
 

--- a/services/vault/src/context/deposit/daemonTerminalEvents.ts
+++ b/services/vault/src/context/deposit/daemonTerminalEvents.ts
@@ -1,0 +1,97 @@
+/**
+ * Pure transition detector for `activation.daemon.terminal` — a VP daemon
+ * terminal drop (Expired / AmlRejected / IngestionRejected / ...) observed by
+ * the pegin polling loop. These states stop polling and previously transmitted
+ * nothing, so a rejected deposit was invisible to monitoring.
+ *
+ * Same emission discipline as `terminalMilestones`:
+ *  - A vault is SEEDED on the first poll observation that includes it: if it is
+ *    already terminal then (a prior-session drop rediscovered on reload), it is
+ *    marked emitted WITHOUT emitting, so a dashboard load never emits a burst.
+ *  - Thereafter, each distinct terminal daemonStatus emits once per vault —
+ *    keyed per status, so a real Expired → ExpiredCleanedUp progression yields
+ *    both signals.
+ *
+ * Seeding is keyed to the POLLED set, not the errors map: a vault only enters
+ * the errors map once it errors, so its first appearance there would always
+ * look pre-existing and nothing would ever emit.
+ */
+
+import { TerminalPeginPollingError } from "../../utils/peginPolling";
+
+export interface DaemonTerminalTracking {
+  /** Vaults observed in at least one poll result (drives seeding). */
+  seen: Set<string>;
+  /** Emitted `${vaultId}:${daemonStatus}` pairs. */
+  emitted: Set<string>;
+}
+
+export interface DaemonTerminalEvent {
+  /** Raw vaultId; the caller shortens it before it enters event context. */
+  vaultId: string;
+  /** VP daemon status name (e.g. "Expired", "AmlRejected") — safe to emit. */
+  daemonStatus: string;
+}
+
+export function createDaemonTerminalTracking(): DaemonTerminalTracking {
+  return { seen: new Set(), emitted: new Set() };
+}
+
+/**
+ * App-scoped tracking shared by every mounted `PeginPollingProvider`, for the
+ * same reason `terminalMilestones` shares its store: several providers can
+ * observe the same vault at once, and the once-per-transition guarantee must
+ * key to the vault, not to a provider instance. In-memory by design — a reload
+ * resets it so the seeding rule re-suppresses prior-session terminals.
+ */
+const sharedTracking = createDaemonTerminalTracking();
+
+export function getSharedDaemonTerminalTracking(): DaemonTerminalTracking {
+  return sharedTracking;
+}
+
+/**
+ * Test-only reset: the shared store outlives any single provider, so cases
+ * asserting emissions must start from a clean slate.
+ */
+export function resetSharedDaemonTerminalTracking(): void {
+  sharedTracking.seen.clear();
+  sharedTracking.emitted.clear();
+}
+
+/**
+ * Return the daemon-terminal events to emit for this poll, mutating `tracking`
+ * so each (vault, status) pair fires at most once. `polledIds` is the set of
+ * deposits the poll observed; `errors` is the per-deposit error map from the
+ * same poll (non-terminal entries are ignored).
+ */
+export function collectDaemonTerminalEvents(
+  polledIds: readonly string[],
+  errors: ReadonlyMap<string, Error>,
+  tracking: DaemonTerminalTracking,
+): DaemonTerminalEvent[] {
+  const out: DaemonTerminalEvent[] = [];
+
+  for (const vaultId of polledIds) {
+    const error = errors.get(vaultId);
+    const daemonStatus =
+      error instanceof TerminalPeginPollingError ? error.daemonStatus : null;
+
+    if (!tracking.seen.has(vaultId)) {
+      tracking.seen.add(vaultId);
+      // First observation: seed a pre-existing terminal without emitting.
+      if (daemonStatus !== null) {
+        tracking.emitted.add(`${vaultId}:${daemonStatus}`);
+      }
+      continue;
+    }
+
+    if (daemonStatus === null) continue;
+    const key = `${vaultId}:${daemonStatus}`;
+    if (tracking.emitted.has(key)) continue;
+    tracking.emitted.add(key);
+    out.push({ vaultId, daemonStatus });
+  }
+
+  return out;
+}

--- a/services/vault/src/context/deposit/daemonTerminalEvents.ts
+++ b/services/vault/src/context/deposit/daemonTerminalEvents.ts
@@ -15,7 +15,16 @@
  * Seeding is keyed to the POLLED set, not the errors map: a vault only enters
  * the errors map once it errors, so its first appearance there would always
  * look pre-existing and nothing would ever emit.
+ *
+ * A polled id whose errors entry is a plain (non-terminal) Error is a FAILED
+ * observation — provider unreachable, entry omitted or duplicated — so the
+ * poll learned nothing about that vault. It neither seeds nor emits; seeding
+ * waits for a poll that genuinely observes the vault, otherwise a
+ * connectivity blip on the first poll after reload would mis-seed the vault
+ * as healthy and its prior-session terminal would emit as a fresh warning.
  */
+
+import type { DaemonStatus } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
 
 import { TerminalPeginPollingError } from "../../utils/peginPolling";
 
@@ -30,7 +39,7 @@ export interface DaemonTerminalEvent {
   /** Raw vaultId; the caller shortens it before it enters event context. */
   vaultId: string;
   /** VP daemon status name (e.g. "Expired", "AmlRejected") — safe to emit. */
-  daemonStatus: string;
+  daemonStatus: DaemonStatus;
 }
 
 export function createDaemonTerminalTracking(): DaemonTerminalTracking {
@@ -63,7 +72,10 @@ export function resetSharedDaemonTerminalTracking(): void {
  * Return the daemon-terminal events to emit for this poll, mutating `tracking`
  * so each (vault, status) pair fires at most once. `polledIds` is the set of
  * deposits the poll observed; `errors` is the per-deposit error map from the
- * same poll (non-terminal entries are ignored).
+ * SAME resolved poll (non-terminal entries are ignored). Pairing ids and
+ * errors from different polls breaks seeding: a vault new to the id set would
+ * be seeded as healthy against a map that could not contain it, and its
+ * pre-existing terminal would then emit as a fresh transition.
  */
 export function collectDaemonTerminalEvents(
   polledIds: readonly string[],
@@ -76,6 +88,10 @@ export function collectDaemonTerminalEvents(
     const error = errors.get(vaultId);
     const daemonStatus =
       error instanceof TerminalPeginPollingError ? error.daemonStatus : null;
+
+    // Plain error = failed observation: the poll learned nothing about this
+    // vault, so skip it entirely — in particular it must not seed as healthy.
+    if (error !== undefined && daemonStatus === null) continue;
 
     if (!tracking.seen.has(vaultId)) {
       tracking.seen.add(vaultId);

--- a/services/vault/src/hooks/__tests__/pegoutTerminalEmission.test.tsx
+++ b/services/vault/src/hooks/__tests__/pegoutTerminalEmission.test.tsx
@@ -1,0 +1,203 @@
+import type { GetPegoutStatusResponse } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { PropsWithChildren } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { RedeemedVaultInfo } from "@/applications/aave/hooks/useAaveVaults";
+import {
+  ClaimerPegoutStatusValue,
+  PEGOUT_MAX_CONSECUTIVE_FAILURES,
+} from "@/models/pegoutStateMachine";
+
+import { resetSharedPegoutTerminalTracking } from "../pegoutTerminalEvents";
+import { usePegoutPolling } from "../usePegoutPolling";
+
+/**
+ * What the next poll cycle should feed every vault: a per-item envelope, or
+ * "batch_error" to fail the whole provider batch (drives the
+ * consecutive-failures give-up path).
+ */
+type PollScript =
+  | { error: string | null; result: GetPegoutStatusResponse | null }
+  | "batch_error";
+
+const { pollScript, mockEvent } = vi.hoisted(() => ({
+  pollScript: { current: undefined as PollScript | undefined },
+  mockEvent: vi.fn(),
+}));
+
+// Replace the SDK's batch poller so each poll cycle serves the scripted
+// envelope without touching the network; everything downstream of it —
+// counters, give-up thresholds, the emission effect — runs for real.
+vi.mock("@babylonlabs-io/ts-sdk/tbv/core/clients", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@babylonlabs-io/ts-sdk/tbv/core/clients")
+    >();
+  return {
+    ...actual,
+    batchPollByProvider: async (opts: {
+      items: { vault: { id: string } }[];
+      onItem: (
+        item: { vault: { id: string } },
+        envelope: {
+          error: string | null;
+          result: GetPegoutStatusResponse | null;
+        },
+      ) => void;
+      onWholeBatchError: (
+        chunk: { vault: { id: string } }[],
+        error: unknown,
+      ) => void;
+    }) => {
+      const script = pollScript.current;
+      if (script === undefined) {
+        throw new Error("pollScript.current not set before a poll cycle");
+      }
+      if (script === "batch_error") {
+        opts.onWholeBatchError(opts.items, new Error("provider down"));
+        return;
+      }
+      for (const item of opts.items) {
+        opts.onItem(item, script);
+      }
+    },
+  };
+});
+
+// The provider client is only dereferenced inside the (mocked-away) batch
+// poller, so a stub satisfies the hook.
+vi.mock("@/utils/rpc", () => ({
+  createVpClient: () => ({}),
+}));
+
+vi.mock("@/infrastructure", () => ({
+  logger: { event: mockEvent, error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+// The hook pins per-query retry options (3 retries, 5s delay), which beat any
+// QueryClient default and would stretch a throwing queryFn (e.g. the
+// unset-script guard above) into an opaque test timeout — zero them so a
+// scripting mistake fails fast instead.
+vi.mock("@/config/polling", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/config/polling")>();
+  return { ...actual, POLLING_RETRY_COUNT: 0, POLLING_RETRY_DELAY_MS: 0 };
+});
+
+// Long enough for shortId to shorten; distinct head/tail pin the redaction.
+const VAULT_ID = `0x22${"cd".repeat(29)}9999`;
+
+const VAULT: RedeemedVaultInfo = {
+  id: VAULT_ID,
+  peginTxHash: `0x${"cd".repeat(32)}`,
+  amountBtc: 0.1,
+  providerName: "provider",
+  vaultProviderAddress: `0x${"ef".repeat(20)}`,
+  createdAt: 1700000000000,
+  offchainParamsVersion: 0,
+};
+
+function statusEnvelope(claimerStatus: string): PollScript {
+  return {
+    error: null,
+    result: {
+      found: true,
+      claimer: { status: claimerStatus },
+    } as GetPegoutStatusResponse,
+  };
+}
+
+function renderPolling() {
+  const queryClient = new QueryClient();
+  const wrapper = ({ children }: PropsWithChildren) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  const rendered = renderHook(
+    () => usePegoutPolling({ redeemedVaults: [VAULT] }),
+    { wrapper },
+  );
+  const pollAgain = async () => {
+    await act(async () => {
+      await queryClient.refetchQueries();
+      // The observer notification for the refreshed data lands a tick after
+      // the refetch promise resolves — flush it so assertions that follow
+      // (including negative ones) observe the post-poll render.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  };
+  return { ...rendered, pollAgain };
+}
+
+describe("pegout terminal emission through usePegoutPolling", () => {
+  beforeEach(() => {
+    mockEvent.mockClear();
+    pollScript.current = undefined;
+    // The tracking store is module-scoped and outlives the hook, so it also
+    // outlives a test case. Without this reset a later case starts with the
+    // vault already seen and silently observes nothing.
+    resetSharedPegoutTerminalTracking();
+  });
+
+  it("emits payout_broadcast once, without a timeoutReason key, when a polled vault reaches it", async () => {
+    pollScript.current = statusEnvelope(
+      ClaimerPegoutStatusValue.CLAIM_BROADCAST,
+    );
+    const { result, pollAgain } = renderPolling();
+    await waitFor(() => expect(result.current.pegoutStatuses.size).toBe(1));
+    expect(mockEvent).not.toHaveBeenCalled();
+
+    pollScript.current = statusEnvelope(
+      ClaimerPegoutStatusValue.PAYOUT_BROADCAST,
+    );
+    await pollAgain();
+
+    expect(mockEvent).toHaveBeenCalledTimes(1);
+    // Pins level/category and the shortened vaultId.
+    expect(mockEvent).toHaveBeenCalledWith("exit.redeem.payout_broadcast", {
+      level: "info",
+      category: "exit",
+      vaultId: "0x22...9999",
+    });
+    // toEqual-style matching treats `{ timeoutReason: undefined }` as equal to
+    // the object above, so pin the key's ABSENCE separately — this is what
+    // fails if the conditional spread regresses to an unconditional one.
+    expect(mockEvent.mock.calls[0][1]).not.toHaveProperty("timeoutReason");
+
+    // Sticky terminal re-observed — the shared store suppresses a re-emit.
+    await pollAgain();
+    expect(mockEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it("seeds a vault already terminal on its first poll without emitting", async () => {
+    pollScript.current = statusEnvelope(
+      ClaimerPegoutStatusValue.PAYOUT_BROADCAST,
+    );
+    const { result, pollAgain } = renderPolling();
+    await waitFor(() => expect(result.current.pegoutStatuses.size).toBe(1));
+
+    await pollAgain();
+    expect(mockEvent).not.toHaveBeenCalled();
+  });
+
+  it("emits pegout_timeout with the consecutive_failures facet after polling gives up", async () => {
+    pollScript.current = statusEnvelope(
+      ClaimerPegoutStatusValue.CLAIM_BROADCAST,
+    );
+    const { result, pollAgain } = renderPolling();
+    await waitFor(() => expect(result.current.pegoutStatuses.size).toBe(1));
+
+    pollScript.current = "batch_error";
+    for (let i = 0; i < PEGOUT_MAX_CONSECUTIVE_FAILURES; i++) {
+      await pollAgain();
+    }
+
+    expect(mockEvent).toHaveBeenCalledTimes(1);
+    expect(mockEvent).toHaveBeenCalledWith("exit.redeem.pegout_timeout", {
+      level: "warning",
+      category: "exit",
+      vaultId: "0x22...9999",
+      timeoutReason: "consecutive_failures",
+    });
+  });
+});

--- a/services/vault/src/hooks/__tests__/pegoutTerminalEvents.test.ts
+++ b/services/vault/src/hooks/__tests__/pegoutTerminalEvents.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ClaimerPegoutStatusValue,
+  getPegoutDisplayState,
+  TIMED_OUT_STATE,
+} from "../../models/pegoutStateMachine";
+import {
+  collectPegoutTerminalEvents,
+  createPegoutTerminalTracking,
+} from "../pegoutTerminalEvents";
+import type { PegoutPollingResult } from "../usePegoutPolling";
+
+function resultWithStatus(claimerStatus: string): PegoutPollingResult {
+  return {
+    displayState: getPegoutDisplayState(claimerStatus, true),
+    response: {
+      found: true,
+      claimer: { status: claimerStatus },
+    } as PegoutPollingResult["response"],
+  };
+}
+
+const IN_PROGRESS = resultWithStatus(ClaimerPegoutStatusValue.CLAIM_BROADCAST);
+
+describe("collectPegoutTerminalEvents", () => {
+  it("emits the payout_broadcast success terminal once when a seen vault reaches it", () => {
+    const tracking = createPegoutTerminalTracking();
+
+    // First poll: in progress — marks seen, emits nothing.
+    expect(
+      collectPegoutTerminalEvents(new Map([["0xa", IN_PROGRESS]]), tracking),
+    ).toEqual([]);
+
+    const broadcast = new Map([
+      ["0xa", resultWithStatus(ClaimerPegoutStatusValue.PAYOUT_BROADCAST)],
+    ]);
+    expect(collectPegoutTerminalEvents(broadcast, tracking)).toEqual([
+      {
+        event: "exit.redeem.payout_broadcast",
+        level: "info",
+        vaultId: "0xa",
+      },
+    ]);
+
+    // Terminal status re-observed — no re-emit.
+    expect(collectPegoutTerminalEvents(broadcast, tracking)).toEqual([]);
+  });
+
+  it("emits payout_blocked as a warning terminal", () => {
+    const tracking = createPegoutTerminalTracking();
+    collectPegoutTerminalEvents(new Map([["0xa", IN_PROGRESS]]), tracking);
+
+    const blocked = new Map([
+      ["0xa", resultWithStatus(ClaimerPegoutStatusValue.PAYOUT_BLOCKED)],
+    ]);
+    expect(collectPegoutTerminalEvents(blocked, tracking)).toEqual([
+      {
+        event: "exit.redeem.payout_blocked",
+        level: "warning",
+        vaultId: "0xa",
+      },
+    ]);
+  });
+
+  it("emits pegout_timeout with the give-up reason", () => {
+    const tracking = createPegoutTerminalTracking();
+    collectPegoutTerminalEvents(new Map([["0xa", IN_PROGRESS]]), tracking);
+
+    const timedOut = new Map<string, PegoutPollingResult>([
+      [
+        "0xa",
+        {
+          displayState: TIMED_OUT_STATE,
+          timeoutReason: "consecutive_failures",
+        },
+      ],
+    ]);
+    expect(collectPegoutTerminalEvents(timedOut, tracking)).toEqual([
+      {
+        event: "exit.redeem.pegout_timeout",
+        level: "warning",
+        vaultId: "0xa",
+        timeoutReason: "consecutive_failures",
+      },
+    ]);
+    expect(collectPegoutTerminalEvents(timedOut, tracking)).toEqual([]);
+  });
+
+  it("seeds a vault already terminal at first observation without emitting (no page-load burst)", () => {
+    const tracking = createPegoutTerminalTracking();
+    const broadcast = new Map([
+      ["0xold", resultWithStatus(ClaimerPegoutStatusValue.PAYOUT_BROADCAST)],
+    ]);
+
+    expect(collectPegoutTerminalEvents(broadcast, tracking)).toEqual([]);
+    expect(collectPegoutTerminalEvents(broadcast, tracking)).toEqual([]);
+  });
+
+  it("still emits the success terminal after a timeout if a later poll recovers", () => {
+    const tracking = createPegoutTerminalTracking();
+    collectPegoutTerminalEvents(new Map([["0xa", IN_PROGRESS]]), tracking);
+
+    const timedOut = new Map<string, PegoutPollingResult>([
+      [
+        "0xa",
+        { displayState: TIMED_OUT_STATE, timeoutReason: "unknown_status" },
+      ],
+    ]);
+    collectPegoutTerminalEvents(timedOut, tracking);
+
+    const broadcast = new Map([
+      ["0xa", resultWithStatus(ClaimerPegoutStatusValue.PAYOUT_BROADCAST)],
+    ]);
+    expect(collectPegoutTerminalEvents(broadcast, tracking)).toEqual([
+      {
+        event: "exit.redeem.payout_broadcast",
+        level: "info",
+        vaultId: "0xa",
+      },
+    ]);
+  });
+});

--- a/services/vault/src/hooks/__tests__/pegoutTerminalEvents.test.ts
+++ b/services/vault/src/hooks/__tests__/pegoutTerminalEvents.test.ts
@@ -87,6 +87,43 @@ describe("collectPegoutTerminalEvents", () => {
     expect(collectPegoutTerminalEvents(timedOut, tracking)).toEqual([]);
   });
 
+  it("emits a second timeout that fires down a different give-up path, but not the same one", () => {
+    const tracking = createPegoutTerminalTracking();
+    collectPegoutTerminalEvents(new Map([["0xa", IN_PROGRESS]]), tracking);
+
+    const failures = new Map<string, PegoutPollingResult>([
+      [
+        "0xa",
+        {
+          displayState: TIMED_OUT_STATE,
+          timeoutReason: "consecutive_failures",
+        },
+      ],
+    ]);
+    expect(collectPegoutTerminalEvents(failures, tracking)).toHaveLength(1);
+
+    // Recovers, then gives up again — this time on unknown statuses.
+    collectPegoutTerminalEvents(new Map([["0xa", IN_PROGRESS]]), tracking);
+    const unknown = new Map<string, PegoutPollingResult>([
+      [
+        "0xa",
+        { displayState: TIMED_OUT_STATE, timeoutReason: "unknown_status" },
+      ],
+    ]);
+    expect(collectPegoutTerminalEvents(unknown, tracking)).toEqual([
+      {
+        event: "exit.redeem.pegout_timeout",
+        level: "warning",
+        vaultId: "0xa",
+        timeoutReason: "unknown_status",
+      },
+    ]);
+
+    // A repeat of an already-emitted reason stays deduped.
+    collectPegoutTerminalEvents(new Map([["0xa", IN_PROGRESS]]), tracking);
+    expect(collectPegoutTerminalEvents(unknown, tracking)).toEqual([]);
+  });
+
   it("seeds a vault already terminal at first observation without emitting (no page-load burst)", () => {
     const tracking = createPegoutTerminalTracking();
     const broadcast = new Map([
@@ -95,6 +132,49 @@ describe("collectPegoutTerminalEvents", () => {
 
     expect(collectPegoutTerminalEvents(broadcast, tracking)).toEqual([]);
     expect(collectPegoutTerminalEvents(broadcast, tracking)).toEqual([]);
+  });
+
+  it("does not seed from a failure-shaped first poll, so a prior-session terminal stays suppressed", () => {
+    const tracking = createPegoutTerminalTracking();
+
+    // First poll after reload fails (applyPegoutFailure shape: no response,
+    // no give-up reason): not an observation.
+    const failed = new Map<string, PegoutPollingResult>([
+      ["0xold", { displayState: getPegoutDisplayState(undefined, false) }],
+    ]);
+    expect(collectPegoutTerminalEvents(failed, tracking)).toEqual([]);
+
+    // Next poll succeeds and reports the prior-session terminal: first genuine
+    // observation, so it seeds without emitting.
+    const broadcast = new Map([
+      ["0xold", resultWithStatus(ClaimerPegoutStatusValue.PAYOUT_BROADCAST)],
+    ]);
+    expect(collectPegoutTerminalEvents(broadcast, tracking)).toEqual([]);
+    expect(collectPegoutTerminalEvents(broadcast, tracking)).toEqual([]);
+  });
+
+  it("still emits a genuine transition after an initial failure-shaped poll", () => {
+    const tracking = createPegoutTerminalTracking();
+
+    const failed = new Map<string, PegoutPollingResult>([
+      ["0xa", { displayState: getPegoutDisplayState(undefined, false) }],
+    ]);
+    collectPegoutTerminalEvents(failed, tracking);
+
+    // First genuine observation is in progress — seeds.
+    collectPegoutTerminalEvents(new Map([["0xa", IN_PROGRESS]]), tracking);
+
+    // The in-session terminal that follows emits.
+    const broadcast = new Map([
+      ["0xa", resultWithStatus(ClaimerPegoutStatusValue.PAYOUT_BROADCAST)],
+    ]);
+    expect(collectPegoutTerminalEvents(broadcast, tracking)).toEqual([
+      {
+        event: "exit.redeem.payout_broadcast",
+        level: "info",
+        vaultId: "0xa",
+      },
+    ]);
   });
 
   it("still emits the success terminal after a timeout if a later poll recovers", () => {

--- a/services/vault/src/hooks/deposit/usePeginPollingQuery.ts
+++ b/services/vault/src/hooks/deposit/usePeginPollingQuery.ts
@@ -50,6 +50,15 @@ interface UsePeginPollingQueryParams {
 
 /** Result from polling query */
 interface PollingQueryData {
+  /**
+   * DepositIds this poll actually observed — captured inside the queryFn so it
+   * is always the same snapshot as `errors`. Consumers that diff terminal
+   * transitions (daemon-terminal seeding) must read this, not the live
+   * `depositsToPoll` memo: under `keepPreviousData` a query-key change serves
+   * the previous poll's data, and pairing it with a fresher id set would seed
+   * new vaults against an errors map that could not contain them.
+   */
+  polledIds: string[];
   /** Map of depositId -> error (for deposits with provider connectivity issues) */
   errors: Map<string, Error>;
   /** Set of depositIds where vault provider needs the depositor's WOTS key */
@@ -61,6 +70,8 @@ interface PollingQueryData {
 }
 
 interface UsePeginPollingQueryResult {
+  /** DepositIds observed by the resolved poll — same snapshot as `errors`. */
+  polledIds: string[] | undefined;
   /** Map of depositId -> error */
   errors: Map<string, Error> | undefined;
   /** Set of depositIds needing WOTS key submission */
@@ -73,8 +84,6 @@ interface UsePeginPollingQueryResult {
   isLoading: boolean;
   /** Trigger manual refetch */
   refetch: () => void;
-  /** Deposits that are being polled */
-  depositsToPoll: DepositToPoll[];
 }
 
 /**
@@ -337,6 +346,7 @@ export function usePeginPollingQuery({
 
       if (!currentBtcPubKey || currentDeposits.length === 0) {
         return {
+          polledIds: [],
           errors: new Map<string, Error>(),
           needsWotsKey: new Set<string>(),
           pendingIngestion: new Set<string>(),
@@ -367,6 +377,7 @@ export function usePeginPollingQuery({
 
       await Promise.all(fetchPromises);
       return {
+        polledIds: currentDeposits.map((d) => d.activity.id),
         errors,
         needsWotsKey,
         pendingIngestion,
@@ -412,12 +423,12 @@ export function usePeginPollingQuery({
   }, [isEnabled, refetch]);
 
   return {
+    polledIds: data?.polledIds,
     errors: data?.errors,
     needsWotsKey: data?.needsWotsKey,
     pendingIngestion: data?.pendingIngestion,
     pendingDepositorSignatures: data?.pendingDepositorSignatures,
     isLoading,
     refetch,
-    depositsToPoll,
   };
 }

--- a/services/vault/src/hooks/pegoutTerminalEvents.ts
+++ b/services/vault/src/hooks/pegoutTerminalEvents.ts
@@ -1,0 +1,139 @@
+/**
+ * Pure transition detector for the redemption (pegout) terminals observed by
+ * `usePegoutPolling`: `exit.redeem.payout_broadcast` (BTC returned to the
+ * depositor — the redemption success terminal), `exit.redeem.payout_blocked`
+ * (claim/assert on-chain but the payout is blocked), and
+ * `exit.redeem.pegout_timeout` (polling gave up). All three previously
+ * surfaced only as breadcrumbs, which transmit nothing on their own — a stuck
+ * or blocked redemption was invisible to monitoring.
+ *
+ * Same emission discipline as `terminalMilestones`:
+ *  - A vault is SEEDED on its first appearance in the results map: if it is
+ *    already terminal then (a prior-session terminal re-observed on reload), it
+ *    is marked emitted WITHOUT emitting.
+ *  - Thereafter each terminal kind emits once per vault. Kinds are keyed
+ *    independently, so a vault that times out and later (after a manual
+ *    refetch) reaches payout_broadcast still emits the success terminal.
+ */
+
+import {
+  TELEMETRY_EVENT,
+  type TelemetryEvent,
+} from "../infrastructure/telemetryEvents";
+import { ClaimerPegoutStatusValue } from "../models/pegoutStateMachine";
+
+import type { PegoutPollingResult } from "./usePegoutPolling";
+
+export interface PegoutTerminalTracking {
+  /** Vaults observed in at least one results map (drives seeding). */
+  seen: Set<string>;
+  /** Emitted `${vaultId}:${kind}` pairs. */
+  emitted: Set<string>;
+}
+
+export interface PegoutTerminalEvent {
+  event: TelemetryEvent;
+  level: "info" | "warning";
+  /** Raw vaultId; the caller shortens it before it enters event context. */
+  vaultId: string;
+  /** Only set for pegout_timeout — which give-up path fired. */
+  timeoutReason?: string;
+}
+
+export function createPegoutTerminalTracking(): PegoutTerminalTracking {
+  return { seen: new Set(), emitted: new Set() };
+}
+
+/**
+ * Module-scoped tracking. `usePegoutPolling` mounts once (DashboardPage), but
+ * the once-per-transition guarantee is keyed to the vault id rather than a hook
+ * instance so a remount (route change, StrictMode) cannot re-emit. In-memory by
+ * design — a reload resets it so seeding re-suppresses prior-session terminals.
+ */
+const sharedTracking = createPegoutTerminalTracking();
+
+export function getSharedPegoutTerminalTracking(): PegoutTerminalTracking {
+  return sharedTracking;
+}
+
+/**
+ * Test-only reset: the shared store outlives the hook, so cases asserting
+ * emissions must start from a clean slate.
+ */
+export function resetSharedPegoutTerminalTracking(): void {
+  sharedTracking.seen.clear();
+  sharedTracking.emitted.clear();
+}
+
+interface ClassifiedTerminal {
+  kind: string;
+  event: TelemetryEvent;
+  level: "info" | "warning";
+  timeoutReason?: string;
+}
+
+function classifyTerminal(
+  result: PegoutPollingResult,
+): ClassifiedTerminal | null {
+  if (result.timeoutReason !== undefined) {
+    return {
+      kind: "timeout",
+      event: TELEMETRY_EVENT.EXIT_REDEEM_PEGOUT_TIMEOUT,
+      level: "warning",
+      timeoutReason: result.timeoutReason,
+    };
+  }
+  const claimerStatus = result.response?.claimer?.status;
+  if (claimerStatus === ClaimerPegoutStatusValue.PAYOUT_BROADCAST) {
+    return {
+      kind: "payout_broadcast",
+      event: TELEMETRY_EVENT.EXIT_REDEEM_PAYOUT_BROADCAST,
+      level: "info",
+    };
+  }
+  if (claimerStatus === ClaimerPegoutStatusValue.PAYOUT_BLOCKED) {
+    return {
+      kind: "payout_blocked",
+      event: TELEMETRY_EVENT.EXIT_REDEEM_PAYOUT_BLOCKED,
+      level: "warning",
+    };
+  }
+  return null;
+}
+
+/**
+ * Return the pegout-terminal events to emit for this poll, mutating `tracking`
+ * so each (vault, kind) pair fires at most once.
+ */
+export function collectPegoutTerminalEvents(
+  results: ReadonlyMap<string, PegoutPollingResult>,
+  tracking: PegoutTerminalTracking,
+): PegoutTerminalEvent[] {
+  const out: PegoutTerminalEvent[] = [];
+
+  for (const [vaultId, result] of results) {
+    const terminal = classifyTerminal(result);
+
+    if (!tracking.seen.has(vaultId)) {
+      tracking.seen.add(vaultId);
+      // First observation: seed a pre-existing terminal without emitting.
+      if (terminal) tracking.emitted.add(`${vaultId}:${terminal.kind}`);
+      continue;
+    }
+
+    if (!terminal) continue;
+    const key = `${vaultId}:${terminal.kind}`;
+    if (tracking.emitted.has(key)) continue;
+    tracking.emitted.add(key);
+    out.push({
+      event: terminal.event,
+      level: terminal.level,
+      vaultId,
+      ...(terminal.timeoutReason !== undefined
+        ? { timeoutReason: terminal.timeoutReason }
+        : {}),
+    });
+  }
+
+  return out;
+}

--- a/services/vault/src/hooks/pegoutTerminalEvents.ts
+++ b/services/vault/src/hooks/pegoutTerminalEvents.ts
@@ -14,6 +14,16 @@
  *  - Thereafter each terminal kind emits once per vault. Kinds are keyed
  *    independently, so a vault that times out and later (after a manual
  *    refetch) reaches payout_broadcast still emits the success terminal.
+ *    Timeouts are additionally keyed per give-up reason — mirroring the
+ *    per-status keying in `daemonTerminalEvents` — so a vault that times out,
+ *    recovers, and later times out down a different give-up path emits the
+ *    new reason instead of being swallowed by the first.
+ *  - A failure-shaped result (no response, no give-up reason — the shape
+ *    `applyPegoutFailure` and the provider-not-found path record before the
+ *    give-up threshold) is a FAILED observation: the poll learned nothing
+ *    about the vault, so it neither seeds nor emits. Otherwise a provider
+ *    blip on the first poll after reload would mis-seed the vault as
+ *    non-terminal and its prior-session terminal would emit as fresh.
  */
 
 import {
@@ -37,7 +47,7 @@ export interface PegoutTerminalEvent {
   /** Raw vaultId; the caller shortens it before it enters event context. */
   vaultId: string;
   /** Only set for pegout_timeout — which give-up path fired. */
-  timeoutReason?: string;
+  timeoutReason?: PegoutPollingResult["timeoutReason"];
 }
 
 export function createPegoutTerminalTracking(): PegoutTerminalTracking {
@@ -69,7 +79,7 @@ interface ClassifiedTerminal {
   kind: string;
   event: TelemetryEvent;
   level: "info" | "warning";
-  timeoutReason?: string;
+  timeoutReason?: PegoutPollingResult["timeoutReason"];
 }
 
 function classifyTerminal(
@@ -77,7 +87,8 @@ function classifyTerminal(
 ): ClassifiedTerminal | null {
   if (result.timeoutReason !== undefined) {
     return {
-      kind: "timeout",
+      // Reason-suffixed so each distinct give-up path dedups independently.
+      kind: `timeout:${result.timeoutReason}`,
       event: TELEMETRY_EVENT.EXIT_REDEEM_PEGOUT_TIMEOUT,
       level: "warning",
       timeoutReason: result.timeoutReason,
@@ -112,6 +123,14 @@ export function collectPegoutTerminalEvents(
   const out: PegoutTerminalEvent[] = [];
 
   for (const [vaultId, result] of results) {
+    // Failure shape = failed observation: the poll learned nothing about this
+    // vault, so skip it entirely — in particular it must not seed. Every
+    // genuinely observed status carries `response`; every give-up carries
+    // `timeoutReason`.
+    if (result.response === undefined && result.timeoutReason === undefined) {
+      continue;
+    }
+
     const terminal = classifyTerminal(result);
 
     if (!tracking.seen.has(vaultId)) {

--- a/services/vault/src/hooks/usePegoutPolling.ts
+++ b/services/vault/src/hooks/usePegoutPolling.ts
@@ -24,6 +24,7 @@ import {
   POLLING_RETRY_DELAY_MS,
 } from "@/config/polling";
 import { logger } from "@/infrastructure";
+import { shortId } from "@/infrastructure/telemetryEvents";
 import {
   getPegoutDisplayState,
   isPegoutEffectivelyTerminal,
@@ -35,9 +36,19 @@ import {
 } from "@/models/pegoutStateMachine";
 import { createVpClient } from "@/utils/rpc";
 
+import {
+  collectPegoutTerminalEvents,
+  getSharedPegoutTerminalTracking,
+} from "./pegoutTerminalEvents";
+
 export interface PegoutPollingResult {
   displayState: PegoutDisplayState;
   response?: GetPegoutStatusResponse;
+  /** Set when polling gave up on this vault — which give-up path fired. */
+  timeoutReason?:
+    | "consecutive_failures"
+    | "unknown_status"
+    | "provider_not_found";
 }
 
 interface VaultToPoll {
@@ -147,7 +158,10 @@ function applyPegoutFailure(
     logger.warn(
       `Pegout polling for ${vaultId} timed out after ${newFailures} consecutive failures`,
     );
-    results.set(vaultId, { displayState: TIMED_OUT_STATE });
+    results.set(vaultId, {
+      displayState: TIMED_OUT_STATE,
+      timeoutReason: "consecutive_failures",
+    });
   } else {
     results.set(vaultId, {
       displayState: getPegoutDisplayState(undefined, false),
@@ -175,7 +189,11 @@ function applyPegoutResult(
       logger.warn(
         `Pegout polling for ${vaultId} timed out after ${newUnknown} consecutive unknown status polls (last status: "${claimerStatus ?? ""}")`,
       );
-      results.set(vaultId, { displayState: TIMED_OUT_STATE, response });
+      results.set(vaultId, {
+        displayState: TIMED_OUT_STATE,
+        response,
+        timeoutReason: "unknown_status",
+      });
       return;
     }
   } else {
@@ -253,7 +271,10 @@ export function usePegoutPolling({
             logger.warn(
               `Pegout polling for ${vault.id} timed out: provider not found after ${newFailures} consecutive polls`,
             );
-            results.set(vault.id, { displayState: TIMED_OUT_STATE });
+            results.set(vault.id, {
+              displayState: TIMED_OUT_STATE,
+              timeoutReason: "provider_not_found",
+            });
           } else {
             results.set(vault.id, {
               displayState: getPegoutDisplayState(undefined, false),
@@ -287,6 +308,28 @@ export function usePegoutPolling({
     retryDelay: POLLING_RETRY_DELAY_MS,
     placeholderData: keepPreviousData,
   });
+
+  // Emit the redemption terminals — payout_broadcast / payout_blocked /
+  // pegout_timeout — once per (vault, kind) as results transition. The detector
+  // seeds already-terminal vaults on first observation, so a dashboard load
+  // never emits a burst for prior-session terminals.
+  useEffect(() => {
+    if (!data) return;
+    const events = collectPegoutTerminalEvents(
+      data,
+      getSharedPegoutTerminalTracking(),
+    );
+    for (const event of events) {
+      logger.event(event.event, {
+        level: event.level,
+        category: "exit",
+        vaultId: shortId(event.vaultId),
+        ...(event.timeoutReason !== undefined
+          ? { timeoutReason: event.timeoutReason }
+          : {}),
+      });
+    }
+  }, [data]);
 
   const pegoutStatuses = useMemo(() => {
     if (!data) return new Map<string, PegoutPollingResult>();

--- a/services/vault/src/infrastructure/telemetryEvents.ts
+++ b/services/vault/src/infrastructure/telemetryEvents.ts
@@ -23,6 +23,14 @@ export const TELEMETRY_EVENT = {
   ACTIVATION_VERIFIED: "activation.verified",
   /** Vault confirmed ACTIVE on-chain — funnel terminal / primary conversion. */
   DEPOSIT_COMPLETED: "deposit.completed",
+  /** VP daemon reported a terminal drop (Expired / AmlRejected / ...) — the deposit leaves the funnel. */
+  ACTIVATION_DAEMON_TERMINAL: "activation.daemon.terminal",
+  /** Redemption terminal success — the BTC payout tx is broadcast to the depositor. */
+  EXIT_REDEEM_PAYOUT_BROADCAST: "exit.redeem.payout_broadcast",
+  /** Redemption blocked terminal — claim/assert on-chain but the BTC payout is blocked. */
+  EXIT_REDEEM_PAYOUT_BLOCKED: "exit.redeem.payout_blocked",
+  /** Pegout polling gave up (consecutive failures / unknown status / provider not found). */
+  EXIT_REDEEM_PEGOUT_TIMEOUT: "exit.redeem.pegout_timeout",
 } as const;
 
 export type TelemetryEvent =

--- a/services/vault/src/infrastructure/telemetryEvents.ts
+++ b/services/vault/src/infrastructure/telemetryEvents.ts
@@ -4,8 +4,8 @@
  *
  * Event names are stable, machine-readable telemetry identifiers (not
  * user-facing copy), so they live here rather than in copy.ts. Names are
- * dot-delimited and lead with the funnel phase (`deposit` / `activation`),
- * followed by the stage and, where it adds signal, the outcome.
+ * dot-delimited and lead with the funnel phase (`deposit` / `activation` /
+ * `exit`), followed by the stage and, where it adds signal, the outcome.
  */
 
 import { redactIdentifier } from "@/utils/telemetry";


### PR DESCRIPTION
## Context

Phase 4 of the Sentry funnel tracking (#2052 → #2053 → #2069 → #2091). This closes the remaining **silent-drop blind spots**: a deposit the VP daemon terminally rejects, and a redemption that completes, blocks, or stalls, all stopped polling and transmitted **nothing** - invisible to monitoring.

Based directly on `main` (all prior phases merged).

## What it adds

Four events, per-vault with a scalar `vaultId`, all transition-diffed with the discipline Phase 3 established (pure collector + shared in-memory tracking + thin effect; already-terminal vaults are **seeded** on first observation, so a dashboard load never emits a burst for prior-session terminals):

| Event | Level | When | Facet |
| --- | --- | --- | --- |
| `activation.daemon.terminal` | warning | VP daemon reports a terminal drop | `daemonStatus` (Expired / AmlRejected / IngestionRejected / InvalidSigInContract / ExpiredCleanedUp / ExpiredInClaim) |
| `exit.redeem.payout_broadcast` | info | Redemption success terminal - BTC payout broadcast | - |
| `exit.redeem.payout_blocked` | warning | Claim/assert on-chain but payout blocked | - |
| `exit.redeem.pegout_timeout` | warning | Pegout polling gave up | `timeoutReason` (consecutive_failures / unknown_status / provider_not_found) |

**Alerts these enable:** AML/ingestion rejection spike faceted by `daemonStatus` (VP or compliance pipeline regression), stuck-redemption page (`pegout_timeout` rate + `payout_blocked`), and the redemption success terminal for eventual initiated→broadcast conversion.

## Design notes

- **Daemon-terminal seeding keys off the *polled set*, not the errors map.** A vault only enters the errors map once it errors - so its first appearance there would always look pre-existing and nothing would ever emit. The collector takes the polled ids as the observation universe and the errors map as the classification source.
- **Dedup is per (vault, status/kind), not per vault.** A real `Expired → ExpiredCleanedUp` progression yields both signals, and a timed-out pegout that later recovers to `payout_broadcast` still emits the success terminal.
- `PegoutPollingResult` gains an optional `timeoutReason`, set at the three existing give-up sites - so the collector classifies from data instead of reference-comparing `TIMED_OUT_STATE`, and the reason becomes a Sentry facet for free. Additive; no display behavior changes.
- Non-terminal errors (provider connectivity) are ignored entirely - they're transient and already breadcrumbed.

## Testing

- `daemonTerminalEvents.test.ts` (4): healthy→terminal emits once; already-terminal-at-first-observation seeds silently; `Expired → ExpiredCleanedUp` emits both; connectivity errors never emit.
- `pegoutTerminalEvents.test.ts` (5): each terminal kind emits once with the right level/facet; no-burst seeding; timeout→recovery still emits the success terminal.
- Full vault suite green: **234 files, 2436 tests**. eslint clean; `tsc -p tsconfig.lib.json` clean (after the documented core-ui/ts-sdk `dist` rebuild).

## Review follow-ups (728ec508)

- **Atomic polled-id snapshot.** `PollingQueryData` now carries `polledIds`, captured inside the queryFn, and the daemon-terminal effect collects from `data.polledIds` + `data.errors` - always the same resolved poll, so a wallet switch or late-arriving activities under `keepPreviousData` can no longer seed new vaults against a stale errors map. The hook's returned `depositsToPoll` lost its last consumer and was removed.
- **Failed observations no longer seed.** Found while testing the above - a second route to the prior-session burst with zero snapshot tearing: a vault whose first observation is a failed poll (plain connectivity `Error` on the pegin side; a result with no `response` and no `timeoutReason` on the pegout side) was seeded as "seen healthy" even though the poll learned nothing, so its prior-session terminal emitted as fresh on the next successful poll. Both collectors now skip failed observations entirely; seeding waits for a genuinely observed status.
- **Emission-level integration tests.** `daemonTerminalEmission.test.tsx` (4) mounts the real provider (incl. co-mounted providers); `pegoutTerminalEmission.test.tsx` (3) drives the real `usePegoutPolling` through react-query with only the SDK batch poller mocked. Both consume the `resetShared*` exports in `beforeEach` and pin the effect wiring: the `polledIds` id source, resolved-poll guards, `shortId`, level/category, and `timeoutReason` absence on non-timeout payloads.
- **Timeouts dedup per give-up reason** (`timeout:<reason>`), mirroring the daemon side's per-status keying - a re-timeout down a different give-up path emits the new reason; a repeat of the same reason stays deduped. Collector unit tests grew to 6 (daemon) and 8 (pegout).
- Types: `daemonStatus` is `DaemonStatus`; `timeoutReason` keeps its three-literal union. Telemetry header now lists `exit` as a funnel phase.

## Remaining backlog (Phase 5)

`activation.wots.submitted` / `activation.payouts.signed` (need transition-based emission at the localStorage status advance - the SDK calls are idempotent, so emit-on-resolution would double-count on resume), `exit.redeem.initiated` (completes the redemption conversion pair), and the `depositStep` tag on the inline outer catch.

