### PR TITLE
feat(vault): v3 loans page

### DIFF
--- a/services/vault/src/__tests__/router.test.tsx
+++ b/services/vault/src/__tests__/router.test.tsx
@@ -5,7 +5,7 @@
  *    useAaveConfig() through useActivities(). If the route element loses its
  *    AaveConfigProvider wrapper, the page throws synchronously on mount.
  * 2. The reserve detail is an overlay: v2 uses `/?reserve=<id>&tab=<tab>` over the
- *    dashboard, v3 uses `/loans?reserve=<id>&tab=<tab>` over the loans placeholder.
+ *    dashboard, v3 uses `/loans?reserve=<id>&tab=<tab>` over the loans page.
  *    Both are gated by pathname to prevent wrong-base rendering. The dashboard
  *    stays mounted in v2 so opening the overlay never blanks the page.
  * 3. /vaults, /loans, and /liquidations are reachable only when ENABLE_V3_UI
@@ -83,6 +83,7 @@ vi.mock("@/context/wallet", () => ({
 
 const DASHBOARD_TESTID = "dashboard";
 const RESERVE_DETAIL_TESTID = "reserve-detail";
+const LOANS_TESTID = "loans-page";
 
 vi.mock("../components/simple/DashboardPage", () => ({
   DashboardPage: () => {
@@ -98,6 +99,10 @@ vi.mock("../components/simple/DashboardPage", () => ({
       />
     );
   },
+}));
+
+vi.mock("../components/pages/Loans", () => ({
+  default: () => <div data-testid={LOANS_TESTID} />,
 }));
 
 vi.mock("../applications/aave/components/Detail", () => ({
@@ -242,7 +247,7 @@ describe("Router — new v3 placeholder routes", () => {
     },
   );
 
-  it.each(["/vaults", "/loans", "/liquidations"])(
+  it.each(["/vaults", "/liquidations"])(
     "renders a placeholder at %s when the flag is on, not the dashboard",
     async (path) => {
       setV3Flag("true");
@@ -257,6 +262,17 @@ describe("Router — new v3 placeholder routes", () => {
       ).not.toBeInTheDocument();
     },
   );
+
+  it("renders the Loans page at /loans when the flag is on, not the dashboard or a placeholder", async () => {
+    setV3Flag("true");
+    renderAt("/loans");
+
+    await waitFor(() => {
+      expect(screen.getByTestId(LOANS_TESTID)).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("v3-placeholder")).not.toBeInTheDocument();
+    expect(screen.queryByTestId(DASHBOARD_TESTID)).not.toBeInTheDocument();
+  });
 
   it.each(["/app/aave/reserve/usdc/borrow", "/vaults/details"])(
     "rejects the nested path %s",

--- a/services/vault/src/applications/aave/constants.ts
+++ b/services/vault/src/applications/aave/constants.ts
@@ -120,6 +120,16 @@ export const NEAR_ZERO_DEBT_RELATIVE_THRESHOLD = 0.005;
 export const NEAR_ZERO_DEBT_RELATIVE_CAP_USD = 5;
 
 /**
+ * Threshold (in USD) at or above which the position is considered to have
+ * borrow headroom. Remaining capacity below one cent is a float / health-factor
+ * dust residual (the capacity display rounds it to "$0.00"), so a fully-borrowed
+ * position is treated as having no headroom and the Borrow CTA is disabled —
+ * we don't open a borrow flow the user can't complete. Matches the design,
+ * which shows Borrow disabled at $0 capacity.
+ */
+export const MIN_BORROWABLE_USD = 0.01;
+
+/**
  * Loan tab identifiers
  * Used for URL params and tab switching
  */

--- a/services/vault/src/applications/aave/hooks/index.ts
+++ b/services/vault/src/applications/aave/hooks/index.ts
@@ -30,6 +30,7 @@ export {
   type UseAaveUserPositionResult,
 } from "./useAaveUserPosition";
 export { useAaveVaults, type UseAaveVaultsResult } from "./useAaveVaults";
+export { useActiveLoans, type ActiveLoanRow } from "./useActiveLoans";
 export {
   useBorrowTransaction,
   type UseBorrowTransactionResult,

--- a/services/vault/src/applications/aave/hooks/useAaveBorrowedAssets.ts
+++ b/services/vault/src/applications/aave/hooks/useAaveBorrowedAssets.ts
@@ -27,6 +27,9 @@ import { useAaveBorrowAprs } from "./useAaveBorrowAprs";
  * Borrowed asset for display
  */
 export interface BorrowedAsset {
+  /** Reserve ID (`reserveId.toString()`), the key for per-reserve reads such as
+   *  liquidity/utilization in `useAaveReserveLiquidity`. */
+  reserveId: string;
   /** Token symbol */
   symbol: string;
   /** Full token name (e.g. "USD Coin"); falls back to the symbol. */
@@ -131,7 +134,14 @@ function transformToBorrowedAsset(
   const borrowRate =
     aprPercent != null ? formatAprPercent(aprPercent) : undefined;
 
-  return { symbol, name, amount, icon, borrowRate };
+  return {
+    reserveId: reserve.reserveId.toString(),
+    symbol,
+    name,
+    amount,
+    icon,
+    borrowRate,
+  };
 }
 
 /**

--- a/services/vault/src/applications/aave/hooks/useActiveLoans.ts
+++ b/services/vault/src/applications/aave/hooks/useActiveLoans.ts
@@ -1,0 +1,52 @@
+/**
+ * Merges each borrowed asset with its live per-reserve liquidity/utilization,
+ * for the v3 Loans page "Active Loans" rows. Reuses the reserve `reserveId`
+ * carried on each `BorrowedAsset` to look up the batched Hub reads from
+ * `useAaveReserveLiquidity` — no separate debt derivation.
+ */
+
+import { useMemo } from "react";
+
+import { useAaveConfig } from "../context";
+
+import type { BorrowedAsset } from "./useAaveBorrowedAssets";
+import { useAaveReserveLiquidity } from "./useAaveReserveLiquidity";
+
+export interface ActiveLoanRow extends BorrowedAsset {
+  /** Borrowable liquidity remaining in token units; null while loading/failed. */
+  availableLiquidity: number | null;
+  /** Utilization in basis points; null at 0 supply or while loading/failed. */
+  utilizationBps: number | null;
+}
+
+export function useActiveLoans(
+  borrowedAssets: BorrowedAsset[],
+): ActiveLoanRow[] {
+  const { allBorrowReserves } = useAaveConfig();
+
+  // The reserve configs behind the current debt, needed for the batched
+  // liquidity read (keyed by hub/assetId/decimals inside the hook).
+  const borrowedReserves = useMemo(() => {
+    const borrowedIds = new Set(borrowedAssets.map((a) => a.reserveId));
+    return allBorrowReserves.filter((r) =>
+      borrowedIds.has(r.reserveId.toString()),
+    );
+  }, [allBorrowReserves, borrowedAssets]);
+
+  const { liquidityByReserveId } = useAaveReserveLiquidity({
+    reserves: borrowedReserves,
+  });
+
+  return useMemo(
+    () =>
+      borrowedAssets.map((asset) => {
+        const liquidity = liquidityByReserveId[asset.reserveId] ?? null;
+        return {
+          ...asset,
+          availableLiquidity: liquidity?.availableLiquidity ?? null,
+          utilizationBps: liquidity?.utilizationBps ?? null,
+        };
+      }),
+    [borrowedAssets, liquidityByReserveId],
+  );
+}

--- a/services/vault/src/applications/aave/hooks/useActiveLoans.ts
+++ b/services/vault/src/applications/aave/hooks/useActiveLoans.ts
@@ -17,12 +17,19 @@ export interface ActiveLoanRow extends BorrowedAsset {
   availableLiquidity: number | null;
   /** Utilization in basis points; null at 0 supply or while loading/failed. */
   utilizationBps: number | null;
+  /**
+   * Whether more can be borrowed from this reserve. Debt surfaces here for the
+   * full reserve set (so repay always works), but a reserve that is
+   * frozen/paused/un-borrowable is absent from `borrowableReserves` — its
+   * Borrow action would dead-end in the reserve-detail form, so gate on this.
+   */
+  isBorrowable: boolean;
 }
 
 export function useActiveLoans(
   borrowedAssets: BorrowedAsset[],
 ): ActiveLoanRow[] {
-  const { allBorrowReserves } = useAaveConfig();
+  const { allBorrowReserves, borrowableReserves } = useAaveConfig();
 
   // The reserve configs behind the current debt, needed for the batched
   // liquidity read (keyed by hub/assetId/decimals inside the hook).
@@ -37,6 +44,13 @@ export function useActiveLoans(
     reserves: borrowedReserves,
   });
 
+  // Reserves that still accept new borrows (the same set the borrow asset
+  // picker offers); debt in any other reserve is repay-only.
+  const borrowableReserveIds = useMemo(
+    () => new Set(borrowableReserves.map((r) => r.reserveId.toString())),
+    [borrowableReserves],
+  );
+
   return useMemo(
     () =>
       borrowedAssets.map((asset) => {
@@ -45,8 +59,9 @@ export function useActiveLoans(
           ...asset,
           availableLiquidity: liquidity?.availableLiquidity ?? null,
           utilizationBps: liquidity?.utilizationBps ?? null,
+          isBorrowable: borrowableReserveIds.has(asset.reserveId),
         };
       }),
-    [borrowedAssets, liquidityByReserveId],
+    [borrowedAssets, liquidityByReserveId, borrowableReserveIds],
   );
 }

--- a/services/vault/src/components/pages/Loans.tsx
+++ b/services/vault/src/components/pages/Loans.tsx
@@ -1,0 +1,121 @@
+/**
+ * Loans page (v3)
+ * Dedicated `/loans` route: borrow-capacity + health-factor summary and the
+ * list of active loans, reusing the existing Aave data hooks and the
+ * reserve-detail borrow/repay overlay (route-driven via `?reserve=&tab=`).
+ */
+
+import { Container } from "@babylonlabs-io/core-ui";
+import { useOutletContext } from "react-router";
+
+import { AssetSelectionModal } from "@/applications/aave/components/AssetSelectionModal";
+import { LOAN_TAB } from "@/applications/aave/constants";
+import { useActiveLoans } from "@/applications/aave/hooks";
+import type { RootLayoutContext } from "@/components/pages/RootLayout";
+import { EmptyState, EmptyStateIcon } from "@/components/shared";
+import { PAGE_CONTENT_CLASS } from "@/components/shared/layoutClasses";
+import { useConnection, useETHWallet } from "@/context/wallet";
+import { COPY } from "@/copy";
+import { useDashboardState } from "@/hooks/useDashboardState";
+import { useLoanActions } from "@/hooks/useLoanActions";
+import { formatUsdValue } from "@/utils/formatting";
+
+import { ActiveLoansList } from "../simple/ActiveLoansList";
+import { LoansSummary } from "../simple/LoansSummary";
+
+export default function Loans() {
+  const { openDeposit } = useOutletContext<RootLayoutContext>();
+  const { address } = useETHWallet();
+  const { isConnected } = useConnection();
+
+  const {
+    debtValueUsd,
+    maxTotalDebtUsd,
+    availableToBorrowUsd,
+    canBorrow,
+    healthFactor,
+    healthFactorStatus,
+    borrowedAssets,
+    hasLoans,
+    hasCollateral,
+    selectableBorrowedAssets,
+    isBorrowCapacityLoading,
+    borrowCapacityError,
+  } = useDashboardState(isConnected ? address : undefined);
+
+  const { openBorrowPicker, openRepay, goToReserve, assetModalProps } =
+    useLoanActions({ borrowedAssets, selectableBorrowedAssets });
+
+  const activeLoans = useActiveLoans(borrowedAssets);
+
+  // A borrow position exists once there is collateral to borrow against (or an
+  // active loan). With collateral but no debt yet, the summary still renders so
+  // the depositor can borrow via its Borrow action — mirroring the v2 Loans
+  // section, whose Borrow button was enabled whenever collateral was present.
+  const hasPosition = hasCollateral || hasLoans;
+
+  // Nothing to borrow against yet: prompt to deposit collateral first (or to
+  // connect a wallet when disconnected).
+  if (!isConnected || !hasPosition) {
+    return (
+      <Container className={`${PAGE_CONTENT_CLASS} pb-6`}>
+        <EmptyState
+          icon={<EmptyStateIcon />}
+          title={COPY.loans.noActiveLoans.title}
+          description={COPY.loans.noActiveLoans.body}
+          isConnected={isConnected}
+          actionLabel={COPY.overview.depositAction}
+          onAction={() => openDeposit()}
+          withCard
+        />
+      </Container>
+    );
+  }
+
+  const availableMeterPercent =
+    maxTotalDebtUsd > 0 ? availableToBorrowUsd / maxTotalDebtUsd : 0;
+  const borrowedMeterPercent =
+    maxTotalDebtUsd > 0 ? debtValueUsd / maxTotalDebtUsd : 0;
+
+  return (
+    <Container className={`${PAGE_CONTENT_CLASS} pb-6`}>
+      <div className="space-y-6">
+        <LoansSummary
+          availableToBorrow={formatUsdValue(availableToBorrowUsd)}
+          availableMeterPercent={availableMeterPercent}
+          totalBorrowed={formatUsdValue(debtValueUsd)}
+          borrowedMeterPercent={borrowedMeterPercent}
+          borrowCapacityLoading={isBorrowCapacityLoading}
+          borrowCapacityError={borrowCapacityError}
+          healthFactor={healthFactor}
+          healthFactorStatus={healthFactorStatus}
+          onBorrow={openBorrowPicker}
+          onRepay={openRepay}
+          canBorrow={canBorrow}
+          canRepay={hasLoans}
+        />
+
+        {hasLoans ? (
+          <ActiveLoansList
+            rows={activeLoans}
+            canBorrow={canBorrow}
+            onBorrow={(symbol) => goToReserve(symbol, LOAN_TAB.BORROW)}
+            onRepay={(symbol) => goToReserve(symbol, LOAN_TAB.REPAY)}
+          />
+        ) : (
+          // Has collateral but no borrows yet: the Borrow action lives in the
+          // summary above; this just labels the empty active-loans area.
+          <EmptyState
+            icon={<EmptyStateIcon />}
+            title={COPY.loans.noActiveLoans.title}
+            description={COPY.loans.noActiveLoans.body}
+            isConnected
+            withCard
+          />
+        )}
+      </div>
+
+      <AssetSelectionModal {...assetModalProps} />
+    </Container>
+  );
+}

--- a/services/vault/src/components/pages/Loans.tsx
+++ b/services/vault/src/components/pages/Loans.tsx
@@ -5,7 +5,7 @@
  * reserve-detail borrow/repay overlay (route-driven via `?reserve=&tab=`).
  */
 
-import { Container } from "@babylonlabs-io/core-ui";
+import { Container, Loader } from "@babylonlabs-io/core-ui";
 import { useOutletContext } from "react-router";
 
 import { AssetSelectionModal } from "@/applications/aave/components/AssetSelectionModal";
@@ -41,6 +41,7 @@ export default function Loans() {
     selectableBorrowedAssets,
     isBorrowCapacityLoading,
     borrowCapacityError,
+    isLoading,
   } = useDashboardState(isConnected ? address : undefined);
 
   const { openBorrowPicker, openRepay, goToReserve, assetModalProps } =
@@ -53,6 +54,19 @@ export default function Loans() {
   // the depositor can borrow via its Borrow action — mirroring the v2 Loans
   // section, whose Borrow button was enabled whenever collateral was present.
   const hasPosition = hasCollateral || hasLoans;
+
+  // Position is still loading for a connected wallet: hold on a spinner rather
+  // than flashing the full-page "deposit" empty state before the summary lands
+  // (hasCollateral/hasLoans are false until the position resolves).
+  if (isConnected && isLoading) {
+    return (
+      <Container className={`${PAGE_CONTENT_CLASS} pb-6`}>
+        <div className="flex items-center justify-center py-12">
+          <Loader />
+        </div>
+      </Container>
+    );
+  }
 
   // Nothing to borrow against yet: prompt to deposit collateral first (or to
   // connect a wallet when disconnected).

--- a/services/vault/src/components/pages/__tests__/Loans.test.tsx
+++ b/services/vault/src/components/pages/__tests__/Loans.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * Loans page loading/gating tests.
+ *
+ * Locks in that a connected depositor whose position is still loading sees a
+ * spinner — not the full-page "deposit" empty state — so the deposit CTA can't
+ * flash before the summary lands on a hard refresh. Disconnected still shows
+ * the connect prompt immediately.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const useConnectionMock = vi.fn();
+const useETHWalletMock = vi.fn();
+const useDashboardStateMock = vi.fn();
+
+vi.mock("@/context/wallet", () => ({
+  useConnection: () => useConnectionMock(),
+  useETHWallet: () => useETHWalletMock(),
+}));
+
+vi.mock("@/hooks/useDashboardState", () => ({
+  useDashboardState: () => useDashboardStateMock(),
+}));
+
+vi.mock("@/hooks/useLoanActions", () => ({
+  useLoanActions: () => ({
+    openBorrowPicker: vi.fn(),
+    openRepay: vi.fn(),
+    goToReserve: vi.fn(),
+    assetModalProps: {
+      isOpen: false,
+      onClose: vi.fn(),
+      onSelectAsset: vi.fn(),
+      mode: "borrow",
+      assets: undefined,
+    },
+  }),
+}));
+
+vi.mock("@/applications/aave/hooks", () => ({
+  useActiveLoans: () => [],
+}));
+
+vi.mock("react-router", () => ({
+  useOutletContext: () => ({ openDeposit: vi.fn() }),
+}));
+
+vi.mock("@/applications/aave/components/AssetSelectionModal", () => ({
+  AssetSelectionModal: () => null,
+}));
+
+vi.mock("@/components/shared", () => ({
+  EmptyState: ({ isConnected }: { isConnected?: boolean }) => (
+    <div
+      data-testid="loans-empty-state"
+      data-connected={String(Boolean(isConnected))}
+    />
+  ),
+  EmptyStateIcon: () => null,
+}));
+
+vi.mock("../../simple/LoansSummary", () => ({
+  LoansSummary: () => <div data-testid="loans-summary" />,
+}));
+
+vi.mock("../../simple/ActiveLoansList", () => ({
+  ActiveLoansList: () => <div data-testid="active-loans-list" />,
+}));
+
+import Loans from "../Loans";
+
+const CONNECTED_LOADED = {
+  debtValueUsd: 0,
+  maxTotalDebtUsd: 0,
+  availableToBorrowUsd: 0,
+  canBorrow: false,
+  healthFactor: 0,
+  healthFactorStatus: "safe",
+  borrowedAssets: [],
+  hasLoans: false,
+  hasCollateral: true,
+  selectableBorrowedAssets: [],
+  isBorrowCapacityLoading: false,
+  borrowCapacityError: null,
+  isLoading: false,
+};
+
+describe("Loans page — loading gate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows a spinner (not the deposit CTA) while a connected depositor's position loads", () => {
+    useConnectionMock.mockReturnValue({ isConnected: true });
+    useETHWalletMock.mockReturnValue({ address: "0xabc" });
+    useDashboardStateMock.mockReturnValue({
+      ...CONNECTED_LOADED,
+      hasCollateral: false,
+      isLoading: true,
+    });
+
+    const { container } = render(<Loans />);
+
+    expect(container.querySelector("svg")).toBeInTheDocument();
+    expect(screen.queryByTestId("loans-empty-state")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("loans-summary")).not.toBeInTheDocument();
+  });
+
+  it("shows the disconnected empty state (no spinner) when disconnected", () => {
+    useConnectionMock.mockReturnValue({ isConnected: false });
+    useETHWalletMock.mockReturnValue({ address: undefined });
+    useDashboardStateMock.mockReturnValue({
+      ...CONNECTED_LOADED,
+      hasCollateral: false,
+      isLoading: false,
+    });
+
+    const { container } = render(<Loans />);
+
+    expect(screen.getByTestId("loans-empty-state")).toHaveAttribute(
+      "data-connected",
+      "false",
+    );
+    expect(container.querySelector("svg")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("loans-summary")).not.toBeInTheDocument();
+  });
+
+  it("renders the summary once a connected depositor with collateral has loaded", () => {
+    useConnectionMock.mockReturnValue({ isConnected: true });
+    useETHWalletMock.mockReturnValue({ address: "0xabc" });
+    useDashboardStateMock.mockReturnValue(CONNECTED_LOADED);
+
+    render(<Loans />);
+
+    expect(screen.getByTestId("loans-summary")).toBeInTheDocument();
+  });
+});

--- a/services/vault/src/components/shared/EmptyState.tsx
+++ b/services/vault/src/components/shared/EmptyState.tsx
@@ -4,15 +4,19 @@
  * or empty data states with customizable content
  */
 
-import { Avatar, Button, Card, SubSection } from "@babylonlabs-io/core-ui";
+import { Avatar, Button, Card } from "@babylonlabs-io/core-ui";
+import type { ReactNode } from "react";
 
 import { Connect } from "@/components/Wallet";
 
 interface EmptyStateProps {
-  /** Avatar image URL */
-  avatarUrl: string;
+  /** Avatar image URL. Ignored when `icon` is provided. */
+  avatarUrl?: string;
   /** Avatar alt text */
-  avatarAlt: string;
+  avatarAlt?: string;
+  /** Custom illustration rendered instead of the circular avatar (e.g. a line
+   *  icon from the v3 designs). Takes precedence over `avatarUrl`. */
+  icon?: ReactNode;
   /** Primary text/title */
   title: string;
   /** Secondary text/description (optional) */
@@ -30,6 +34,7 @@ interface EmptyStateProps {
 export function EmptyState({
   avatarUrl,
   avatarAlt,
+  icon,
   title,
   description,
   isConnected = false,
@@ -37,46 +42,58 @@ export function EmptyState({
   onAction,
   withCard = false,
 }: EmptyStateProps) {
+  // A single centered surface. When `withCard` is set, the `Card` below is the
+  // only surface — the content sits directly on it (no inner panel), matching
+  // the v3 empty-state design.
   const content = (
-    <SubSection className="w-full py-28">
-      <div className="flex flex-col items-center justify-center gap-2">
-        {/* Avatar/Logo */}
+    <div className="flex w-full flex-col items-center justify-center gap-2 py-16">
+      {/* Illustration: custom icon node when provided, else the avatar image */}
+      {icon ? (
+        <div className="mb-2">{icon}</div>
+      ) : (
         <Avatar
           url={avatarUrl}
           alt={avatarAlt}
           size="xlarge"
           className="mb-2 h-[100px] w-[100px]"
         />
+      )}
 
-        {/* Primary Text */}
-        <p className="text-xl text-accent-primary">{title}</p>
+      {/* Primary Text */}
+      <p className="text-xl text-accent-primary">{title}</p>
 
-        {/* Secondary Text */}
-        {description && (
-          <p className="text-sm text-accent-secondary">{description}</p>
+      {/* Secondary Text */}
+      {description && (
+        <p className="text-sm text-accent-secondary">{description}</p>
+      )}
+
+      {/* Action Button */}
+      <div className="mt-8">
+        {isConnected ? (
+          actionLabel &&
+          onAction && (
+            <Button
+              // The brand orange CTA is core-ui's `secondary` color
+              // (`bg-secondary-main`) — the same the ConnectButton uses.
+              // `primary` (`bg-primary-light`) is the blue, not what we want here.
+              variant="contained"
+              color="secondary"
+              size="medium"
+              // Invoked with no arguments on purpose: callers pass handlers
+              // that take optional parameters (e.g. `openDeposit(amountBtc?)`),
+              // and forwarding the click event would land a MouseEvent in that
+              // parameter. TypeScript can't catch it — a zero-arg signature is
+              // assignable to onClick's.
+              onClick={() => onAction()}
+            >
+              {actionLabel}
+            </Button>
+          )
+        ) : (
+          <Connect />
         )}
-
-        {/* Action Button */}
-        <div className="mt-8">
-          {isConnected ? (
-            actionLabel &&
-            onAction && (
-              <Button
-                variant="contained"
-                color="primary"
-                size="medium"
-                onClick={onAction}
-                className="!bg-white !text-black hover:!bg-gray-100"
-              >
-                {actionLabel}
-              </Button>
-            )
-          ) : (
-            <Connect />
-          )}
-        </div>
       </div>
-    </SubSection>
+    </div>
   );
 
   if (withCard) {

--- a/services/vault/src/components/shared/__tests__/EmptyState.test.tsx
+++ b/services/vault/src/components/shared/__tests__/EmptyState.test.tsx
@@ -1,0 +1,74 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/components/Wallet", () => ({
+  Connect: () => <button type="button">Connect</button>,
+}));
+
+// Import after mocks
+import { EmptyState } from "../EmptyState";
+
+describe("EmptyState", () => {
+  it("invokes onAction with no arguments when the action button is clicked", () => {
+    // Callers pass handlers with optional parameters (e.g.
+    // `openDeposit(initialAmountBtc?: string)`). Forwarding the click event
+    // would put a MouseEvent in that parameter and crash downstream consumers.
+    const onAction = vi.fn();
+
+    render(
+      <EmptyState
+        avatarUrl="/images/btc.svg"
+        avatarAlt="BTC"
+        title="No active loans"
+        isConnected
+        actionLabel="Deposit"
+        onAction={onAction}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Deposit" }));
+
+    expect(onAction).toHaveBeenCalledTimes(1);
+    expect(onAction).toHaveBeenCalledWith();
+  });
+
+  it("renders the connected action button as the brand orange (secondary) CTA", () => {
+    // core-ui `contained secondary` (`bg-secondary-main`) is the brand orange
+    // used by the ConnectButton; `primary` is the blue. The Deposit CTA must be
+    // orange, matching the v3 design.
+    render(
+      <EmptyState
+        avatarUrl="/images/btc.svg"
+        avatarAlt="BTC"
+        title="No active loans"
+        isConnected
+        actionLabel="Deposit"
+        onAction={vi.fn()}
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: "Deposit" });
+    expect(button.className).toContain("bbn-btn-secondary");
+    expect(button.className).not.toContain("bbn-btn-primary");
+  });
+
+  it("renders the connect prompt instead of the action button when disconnected", () => {
+    const onAction = vi.fn();
+
+    render(
+      <EmptyState
+        avatarUrl="/images/btc.svg"
+        avatarAlt="BTC"
+        title="No active loans"
+        isConnected={false}
+        actionLabel="Deposit"
+        onAction={onAction}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Connect" })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Deposit" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/services/vault/src/components/shared/icons/EmptyStateIcon.tsx
+++ b/services/vault/src/components/shared/icons/EmptyStateIcon.tsx
@@ -1,0 +1,60 @@
+/**
+ * EmptyStateIcon
+ * Document-with-magnifier line illustration used by the v3 empty states
+ * (Loans / Activity "nothing here yet"). Strokes use `currentColor` so the
+ * color follows the surrounding text color in both themes.
+ */
+
+interface EmptyStateIconProps {
+  className?: string;
+}
+
+export function EmptyStateIcon({ className = "" }: EmptyStateIconProps) {
+  return (
+    <svg
+      width="72"
+      height="78"
+      viewBox="0 0 72 78"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={`text-accent-secondary ${className}`}
+      aria-hidden="true"
+    >
+      {/* Document sheet with a folded top-right corner */}
+      <path
+        d="M12 3H41L59 21V63C59 65.2091 57.2091 67 55 67H12C9.79086 67 8 65.2091 8 63V7C8 4.79086 9.79086 3 12 3Z"
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M41 3V19C41 20.1046 41.8954 21 43 21H59"
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinejoin="round"
+      />
+      {/* Text lines */}
+      <path
+        d="M18 31H40M18 40H34"
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+      />
+      {/* Magnifier at the lower-right */}
+      <circle
+        cx="47"
+        cy="52"
+        r="14"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2.5"
+      />
+      <path
+        d="M57.5 62.5L66 71"
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}

--- a/services/vault/src/components/shared/icons/index.tsx
+++ b/services/vault/src/components/shared/icons/index.tsx
@@ -1,1 +1,2 @@
+export { EmptyStateIcon } from "./EmptyStateIcon";
 export { HeartIcon } from "./HeartIcon";

--- a/services/vault/src/components/shared/index.ts
+++ b/services/vault/src/components/shared/index.ts
@@ -7,4 +7,4 @@ export {
   HealthFactorGauge,
   type HealthFactorGaugeStat,
 } from "./HealthFactorGauge";
-export { HeartIcon } from "./icons";
+export { EmptyStateIcon, HeartIcon } from "./icons";

--- a/services/vault/src/components/simple/ActiveLoansList.tsx
+++ b/services/vault/src/components/simple/ActiveLoansList.tsx
@@ -117,7 +117,7 @@ export function ActiveLoansList({
                 <RowActionButton
                   label={COPY.loans.borrowButton}
                   onClick={() => onBorrow(row.symbol)}
-                  disabled={!canBorrow}
+                  disabled={!canBorrow || !row.isBorrowable}
                 />
                 <RowActionButton
                   label={COPY.loans.repayButton}

--- a/services/vault/src/components/simple/ActiveLoansList.tsx
+++ b/services/vault/src/components/simple/ActiveLoansList.tsx
@@ -1,0 +1,133 @@
+/**
+ * ActiveLoansList Component
+ * v3 Loans page "Active Loans (N)" section: one row per borrowed asset showing
+ * amount, live Borrow APR, available liquidity and utilization, with per-asset
+ * Borrow / Repay entry points into the existing reserve-detail overlay.
+ */
+
+import { Avatar, Heading } from "@babylonlabs-io/core-ui";
+
+import type { ActiveLoanRow } from "@/applications/aave/hooks";
+import { COPY } from "@/copy";
+import {
+  formatBasisPointsAsPercent,
+  formatCompactTokenAmount,
+} from "@/utils/formatting";
+
+interface ActiveLoansListProps {
+  rows: ActiveLoanRow[];
+  /** Whether there is remaining borrow capacity (disables per-row Borrow at 0). */
+  canBorrow: boolean;
+  onBorrow: (symbol: string) => void;
+  onRepay: (symbol: string) => void;
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex min-w-[120px] flex-col gap-1">
+      <span className="text-sm leading-[1.43] tracking-[0.17px] text-accent-secondary">
+        {label}
+      </span>
+      <span className="text-base leading-[1.5] tracking-[0.15px] text-accent-primary">
+        {value}
+      </span>
+    </div>
+  );
+}
+
+// Filled action button matching the summary's Borrow/Repay (see
+// PositionStatCards' StatSection button) so both button groups look identical,
+// per the v3 design.
+function RowActionButton({
+  label,
+  onClick,
+  disabled,
+}: {
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className="flex h-10 items-center justify-center rounded-lg bg-secondary-strokeLight px-6 text-base leading-[1.5] tracking-[0.15px] text-accent-primary transition-[filter] enabled:hover:brightness-110 disabled:cursor-not-allowed disabled:text-accent-disabled"
+    >
+      {label}
+    </button>
+  );
+}
+
+export function ActiveLoansList({
+  rows,
+  canBorrow,
+  onBorrow,
+  onRepay,
+}: ActiveLoansListProps) {
+  return (
+    <div className="w-full space-y-4">
+      <Heading variant="h6" as="h2" className="font-normal text-accent-primary">
+        {COPY.loans.activeLoansHeading(rows.length)}
+      </Heading>
+
+      <div className="overflow-hidden rounded-lg bg-secondary-highlight">
+        {rows.map((row, index) => {
+          const availableLiquidity =
+            row.availableLiquidity !== null
+              ? `${formatCompactTokenAmount(row.availableLiquidity)} ${row.symbol}`
+              : COPY.common.emptyValue;
+          const utilization =
+            row.utilizationBps !== null
+              ? formatBasisPointsAsPercent(row.utilizationBps)
+              : COPY.common.emptyValue;
+
+          return (
+            <div
+              key={row.reserveId}
+              className={`flex flex-col gap-4 p-6 lg:flex-row lg:items-center lg:justify-between ${
+                index > 0
+                  ? "border-t border-secondary-strokeLight dark:border-secondary-strokeDark"
+                  : ""
+              }`}
+            >
+              <div className="flex shrink-0 items-center gap-2 lg:min-w-[200px]">
+                <Avatar url={row.icon} alt={row.symbol} size="medium" />
+                <span className="whitespace-nowrap text-xl text-accent-primary">
+                  {row.amount} {row.symbol}
+                </span>
+              </div>
+
+              <div className="flex flex-wrap gap-6 lg:flex-1 lg:justify-start">
+                <Metric
+                  label={COPY.loans.borrowRateLabel}
+                  value={row.borrowRate ?? COPY.common.emptyValue}
+                />
+                <Metric
+                  label={COPY.loans.availableLiquidityLabel}
+                  value={availableLiquidity}
+                />
+                <Metric
+                  label={COPY.loans.utilizationLabel}
+                  value={utilization}
+                />
+              </div>
+
+              <div className="flex flex-shrink-0 gap-3">
+                <RowActionButton
+                  label={COPY.loans.borrowButton}
+                  onClick={() => onBorrow(row.symbol)}
+                  disabled={!canBorrow}
+                />
+                <RowActionButton
+                  label={COPY.loans.repayButton}
+                  onClick={() => onRepay(row.symbol)}
+                />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/services/vault/src/components/simple/DashboardPage.tsx
+++ b/services/vault/src/components/simple/DashboardPage.tsx
@@ -6,14 +6,12 @@
 
 import { Container } from "@babylonlabs-io/core-ui";
 import { lazy, Suspense, useCallback, useMemo, useState } from "react";
-import { useNavigate, useOutletContext } from "react-router";
+import { useOutletContext } from "react-router";
 
 import { AssetSelectionModal } from "@/applications/aave/components/AssetSelectionModal";
-import { LOAN_TAB, type LoanTab } from "@/applications/aave/constants";
 import { useSyncPendingVaults } from "@/applications/aave/context";
 import { useAaveVaults } from "@/applications/aave/hooks";
 import { usePositionNotifications } from "@/applications/aave/hooks/usePositionNotifications";
-import type { Asset } from "@/applications/aave/types";
 import type { RootLayoutContext } from "@/components/pages/RootLayout";
 import { PAGE_CONTENT_CLASS } from "@/components/shared/layoutClasses";
 import featureFlags from "@/config/featureFlags";
@@ -24,10 +22,10 @@ import { useDebugPositionOverride } from "@/dev/debugPositionStore";
 import { useDemoCollateral, useDemoWithdrawal } from "@/dev/demoDeposit";
 import { useApplicationCap } from "@/hooks/useApplicationCap";
 import { useDashboardState } from "@/hooks/useDashboardState";
+import { useLoanActions } from "@/hooks/useLoanActions";
 import { usePegoutPolling } from "@/hooks/usePegoutPolling";
 import { usePrices } from "@/hooks/usePrices";
 import { ClaimerPegoutStatusValue } from "@/models/pegoutStateMachine";
-import { getReserveDetailRoute } from "@/routes";
 import {
   formatBasisPointsAsPercent,
   formatBtcAmount,
@@ -59,17 +57,12 @@ const GodModePanel = import.meta.env.DEV
   : null;
 
 export function DashboardPage() {
-  const navigate = useNavigate();
   const { openDeposit } = useOutletContext<RootLayoutContext>();
   const { address } = useETHWallet();
   const { isConnected } = useConnection();
 
   const [isWithdrawOpen, setIsWithdrawOpen] = useState(false);
   const [selectedVaultIds, setSelectedVaultIds] = useState<string[]>([]);
-  const [isAssetModalOpen, setIsAssetModalOpen] = useState(false);
-  const [assetModalMode, setAssetModalMode] = useState<LoanTab>(
-    LOAN_TAB.BORROW,
-  );
 
   // Dev-only banner override driven by the position-notifications section of
   // the god-mode panel (see debugPositionStore). Always null in production, so
@@ -83,6 +76,7 @@ export function DashboardPage() {
     debtValueUsd,
     maxTotalDebtUsd,
     availableToBorrowUsd,
+    canBorrow,
     collateralFactorBps,
     healthFactor,
     healthFactorStatus,
@@ -95,6 +89,11 @@ export function DashboardPage() {
     isBorrowCapacityLoading,
     borrowCapacityError,
   } = useDashboardState(isConnected ? address : undefined);
+
+  const { openBorrowPicker, openRepay, assetModalProps } = useLoanActions({
+    borrowedAssets,
+    selectableBorrowedAssets,
+  });
 
   const { snapshot: capSnapshot, isLoading: isCapLoading } = useApplicationCap(
     isConnected ? address : undefined,
@@ -260,37 +259,6 @@ export function DashboardPage() {
     setSelectedVaultIds([]);
   }, []);
 
-  const handleBorrow = () => {
-    setAssetModalMode(LOAN_TAB.BORROW);
-    setIsAssetModalOpen(true);
-  };
-
-  const handleRepay = () => {
-    if (borrowedAssets.length === 1) {
-      const assetSymbol = borrowedAssets[0].symbol;
-      navigate(
-        getReserveDetailRoute(
-          assetSymbol,
-          LOAN_TAB.REPAY,
-          featureFlags.isV3UiEnabled,
-        ),
-      );
-      return;
-    }
-    setAssetModalMode(LOAN_TAB.REPAY);
-    setIsAssetModalOpen(true);
-  };
-
-  const handleSelectAsset = (assetSymbol: string) => {
-    navigate(
-      getReserveDetailRoute(
-        assetSymbol,
-        assetModalMode,
-        featureFlags.isV3UiEnabled,
-      ),
-    );
-  };
-
   // Dev/QA god-mode admin panel (NEXT_PUBLIC_FF_GOD_MODE_PANEL). Floats over
   // the page and drives the demo items rendered in the real sections below.
   // Stripped from production builds and never active there (see GodModePanel).
@@ -347,7 +315,7 @@ export function DashboardPage() {
           <PositionNotificationBanner
             connectedAddress={address}
             onDeposit={openDeposit}
-            onRepay={handleRepay}
+            onRepay={openRepay}
             result={debugResultOverride ?? undefined}
             statusOverride={debugStatusOverride ?? undefined}
           />
@@ -369,9 +337,9 @@ export function DashboardPage() {
             borrowCapacityError={borrowCapacityError}
             borrowedMeterPercent={borrowedMeterPercent}
             onDeposit={openDeposit}
-            onBorrow={handleBorrow}
-            onRepay={handleRepay}
-            canBorrow={availableToBorrowUsd > 0}
+            onBorrow={openBorrowPicker}
+            onRepay={openRepay}
+            canBorrow={canBorrow}
             canRepay={hasLoans}
           />
         )}
@@ -424,8 +392,8 @@ export function DashboardPage() {
               hasCollateral={hasCollateral}
               isConnected={isConnected}
               borrowedAssets={borrowedAssets}
-              onBorrow={handleBorrow}
-              onRepay={handleRepay}
+              onBorrow={openBorrowPicker}
+              onRepay={openRepay}
             />
           </>
         )}
@@ -450,17 +418,7 @@ export function DashboardPage() {
       />
 
       {/* Asset Selection Modal for Borrow/Repay */}
-      <AssetSelectionModal
-        isOpen={isAssetModalOpen}
-        onClose={() => setIsAssetModalOpen(false)}
-        onSelectAsset={handleSelectAsset}
-        mode={assetModalMode}
-        assets={
-          assetModalMode === LOAN_TAB.REPAY
-            ? (selectableBorrowedAssets as Asset[])
-            : undefined
-        }
-      />
+      <AssetSelectionModal {...assetModalProps} />
 
       {godModePanel}
     </Container>

--- a/services/vault/src/components/simple/LoansSummary.tsx
+++ b/services/vault/src/components/simple/LoansSummary.tsx
@@ -1,0 +1,89 @@
+/**
+ * LoansSummary Component
+ * v3 Loans page summary trio: Available to Borrow · Total Borrowed · Health
+ * Factor. Reuses the shared PositionStatCards primitive and the borrow-capacity
+ * card builder (same cards the Overview position summary uses); the health-factor
+ * card is an action-less variant with a color-coded value + heart.
+ */
+
+import {
+  formatHealthFactor,
+  getHealthFactorColor,
+  type HealthFactorStatus,
+} from "@/applications/aave/utils";
+import { HeartIcon } from "@/components/shared";
+import { COPY } from "@/copy";
+
+import {
+  buildBorrowCapacityCards,
+  PositionStatCards,
+} from "./PositionStatCards";
+
+interface LoansSummaryProps {
+  availableToBorrow: string;
+  availableMeterPercent: number;
+  totalBorrowed: string;
+  borrowedMeterPercent: number;
+  borrowCapacityLoading: boolean;
+  borrowCapacityError: Error | null;
+  healthFactor: number | null;
+  healthFactorStatus: HealthFactorStatus;
+  onBorrow: () => void;
+  onRepay: () => void;
+  canBorrow: boolean;
+  canRepay: boolean;
+}
+
+export function LoansSummary({
+  availableToBorrow,
+  availableMeterPercent,
+  totalBorrowed,
+  borrowedMeterPercent,
+  borrowCapacityLoading,
+  borrowCapacityError,
+  healthFactor,
+  healthFactorStatus,
+  onBorrow,
+  onRepay,
+  canBorrow,
+  canRepay,
+}: LoansSummaryProps) {
+  const healthFactorColor = getHealthFactorColor(healthFactorStatus);
+  const healthFactorText =
+    healthFactor !== null
+      ? formatHealthFactor(healthFactor)
+      : COPY.common.emptyValue;
+
+  const cards = [
+    ...buildBorrowCapacityCards({
+      availableToBorrow,
+      availableMeterPercent,
+      totalBorrowed,
+      borrowedMeterPercent,
+      borrowCapacityLoading,
+      borrowCapacityError,
+      onBorrow,
+      onRepay,
+      canBorrow,
+      canRepay,
+      borrowTestId: "loans-borrow-button",
+      repayTestId: "loans-repay-button",
+    }),
+    {
+      label: COPY.loans.healthFactorLabel,
+      tooltip: COPY.loans.healthFactorTooltip,
+      value: healthFactorText,
+      valueNode: (
+        <>
+          <span style={{ color: healthFactorColor }}>{healthFactorText}</span>
+          {healthFactor !== null && (
+            <HeartIcon color={healthFactorColor} className="size-6" />
+          )}
+        </>
+      ),
+      caption: COPY.loans.healthFactorCaption,
+    },
+  ];
+
+  return <PositionStatCards cards={cards} />;
+}

--- a/services/vault/src/components/simple/OverviewSection.tsx
+++ b/services/vault/src/components/simple/OverviewSection.tsx
@@ -23,7 +23,11 @@ import {
 import { FeatureFlags } from "@/config";
 import { COPY } from "@/copy";
 
-import { PositionStatCards, type PositionStatCard } from "./PositionStatCards";
+import {
+  buildBorrowCapacityCards,
+  PositionStatCards,
+  type PositionStatCard,
+} from "./PositionStatCards";
 
 interface OverviewSectionProps {
   healthFactor: number | null;
@@ -115,14 +119,8 @@ export function OverviewSection({
     [liquidationPrice, btcPrice, pctToLiquidation],
   );
 
-  const statCards: PositionStatCard[] = useMemo(() => {
-    const clampPct = (ratio: number) =>
-      Math.round(Math.min(1, Math.max(0, ratio)) * 100);
-    const availablePercent = clampPct(availableMeterPercent);
-    const borrowedPercent = clampPct(borrowedMeterPercent);
-    const capacityUnavailable =
-      borrowCapacityLoading || borrowCapacityError != null;
-    return [
+  const statCards: PositionStatCard[] = useMemo(
+    () => [
       {
         label: COPY.overview.totalCollateralValueLabel,
         tooltip: COPY.overview.totalCollateralValueTooltip,
@@ -132,70 +130,35 @@ export function OverviewSection({
         onAction: onDeposit,
         actionDisabled: false,
       },
-      {
-        label: COPY.overview.availableToBorrowLabel,
-        value: borrowCapacityLoading
-          ? COPY.common.loading
-          : borrowCapacityError
-            ? COPY.common.emptyValue
-            : availableToBorrow,
-        meter: capacityUnavailable
-          ? undefined
-          : {
-              percent: availableMeterPercent,
-              label:
-                availableMeterPercent > 0 &&
-                availableMeterPercent < 1 &&
-                availablePercent === 100
-                  ? COPY.overview.availableMeterNearFullLabel
-                  : availableMeterPercent > 0 &&
-                      availableMeterPercent < 1 &&
-                      availablePercent === 0
-                    ? COPY.overview.availableMeterBelowOneLabel
-                    : COPY.overview.availableMeterLabel(availablePercent),
-            },
-        actionLabel: COPY.overview.borrowAction,
-        onAction: onBorrow,
-        actionDisabled: !canBorrow,
-      },
-      {
-        label: COPY.overview.totalBorrowedLabel,
-        value: totalBorrowed,
-        meter: capacityUnavailable
-          ? undefined
-          : {
-              percent: borrowedMeterPercent,
-              label:
-                borrowedMeterPercent > 0 &&
-                borrowedMeterPercent < 1 &&
-                borrowedPercent === 0
-                  ? COPY.overview.borrowedMeterBelowOneLabel
-                  : borrowedMeterPercent > 0 &&
-                      borrowedMeterPercent < 1 &&
-                      borrowedPercent === 100
-                    ? COPY.overview.borrowedMeterNearFullLabel
-                    : COPY.overview.borrowedMeterLabel(borrowedPercent),
-            },
-        actionLabel: COPY.overview.repayAction,
-        onAction: onRepay,
-        actionDisabled: !canRepay,
-      },
-    ];
-  }, [
-    totalCollateralValue,
-    collateralBtc,
-    onDeposit,
-    availableToBorrow,
-    availableMeterPercent,
-    borrowCapacityLoading,
-    borrowCapacityError,
-    onBorrow,
-    canBorrow,
-    totalBorrowed,
-    borrowedMeterPercent,
-    onRepay,
-    canRepay,
-  ]);
+      ...buildBorrowCapacityCards({
+        availableToBorrow,
+        availableMeterPercent,
+        totalBorrowed,
+        borrowedMeterPercent,
+        borrowCapacityLoading,
+        borrowCapacityError,
+        onBorrow,
+        onRepay,
+        canBorrow,
+        canRepay,
+      }),
+    ],
+    [
+      totalCollateralValue,
+      collateralBtc,
+      onDeposit,
+      availableToBorrow,
+      availableMeterPercent,
+      borrowCapacityLoading,
+      borrowCapacityError,
+      onBorrow,
+      canBorrow,
+      totalBorrowed,
+      borrowedMeterPercent,
+      onRepay,
+      canRepay,
+    ],
+  );
 
   return (
     <div className="w-full space-y-6">

--- a/services/vault/src/components/simple/PositionStatCards.tsx
+++ b/services/vault/src/components/simple/PositionStatCards.tsx
@@ -1,18 +1,27 @@
 import { Hint, InfoIcon } from "@babylonlabs-io/core-ui";
-import { Fragment } from "react";
+import { Fragment, type ReactNode } from "react";
+
+import { COPY } from "@/copy";
+import { formatMeterLabel } from "@/utils/formatting";
 
 export interface PositionStatCard {
   label: string;
   tooltip?: string;
   value: string;
+  /** Custom value rendering (e.g. colored health factor + heart). Overrides
+   *  `value` when set; `value` is still used for accessibility fallbacks. */
+  valueNode?: ReactNode;
   caption?: string;
   meter?: {
     percent: number;
     label: string;
   };
-  actionLabel: string;
-  onAction: () => void;
-  actionDisabled: boolean;
+  /** Action button. Omit all three to render a card with no button. */
+  actionLabel?: string;
+  onAction?: () => void;
+  actionDisabled?: boolean;
+  /** Optional test hook for the action button (E2E real-wallet CLI). */
+  actionTestId?: string;
 }
 
 function StatMeter({
@@ -48,6 +57,7 @@ function StatMeter({
 }
 
 function StatSection({ card }: { card: PositionStatCard }) {
+  const hasAction = card.actionLabel != null && card.onAction != null;
   return (
     <div className="flex flex-1 items-center justify-between gap-4">
       <div className="flex flex-col gap-3">
@@ -64,8 +74,8 @@ function StatSection({ card }: { card: PositionStatCard }) {
           )}
         </div>
 
-        <span className="text-xl leading-[1.6] tracking-[0.15px] text-accent-primary">
-          {card.value}
+        <span className="flex items-center gap-2 text-xl leading-[1.6] tracking-[0.15px] text-accent-primary">
+          {card.valueNode ?? card.value}
         </span>
 
         {card.meter ? (
@@ -81,14 +91,17 @@ function StatSection({ card }: { card: PositionStatCard }) {
         ) : null}
       </div>
 
-      <button
-        type="button"
-        onClick={() => card.onAction()}
-        disabled={card.actionDisabled}
-        className="flex h-10 w-[120px] shrink-0 items-center justify-center rounded-lg bg-secondary-strokeLight text-base leading-[1.5] tracking-[0.15px] text-accent-primary transition-[filter] enabled:hover:brightness-110 disabled:cursor-not-allowed disabled:text-accent-disabled"
-      >
-        {card.actionLabel}
-      </button>
+      {hasAction && (
+        <button
+          type="button"
+          onClick={() => card.onAction?.()}
+          disabled={card.actionDisabled}
+          data-testid={card.actionTestId}
+          className="flex h-10 w-[120px] shrink-0 items-center justify-center rounded-lg bg-secondary-strokeLight text-base leading-[1.5] tracking-[0.15px] text-accent-primary transition-[filter] enabled:hover:brightness-110 disabled:cursor-not-allowed disabled:text-accent-disabled"
+        >
+          {card.actionLabel}
+        </button>
+      )}
     </div>
   );
 }
@@ -108,4 +121,86 @@ export function PositionStatCards({ cards }: { cards: PositionStatCard[] }) {
       </div>
     </div>
   );
+}
+
+/**
+ * Builds the two borrow-capacity summary cards — "Available to borrow" and
+ * "Total borrowed" — shared by the Overview position summary and the Loans
+ * page. Keeps the meter-label branching (near-full / below-one) single-sourced.
+ */
+export function buildBorrowCapacityCards({
+  availableToBorrow,
+  availableMeterPercent,
+  totalBorrowed,
+  borrowedMeterPercent,
+  borrowCapacityLoading,
+  borrowCapacityError,
+  onBorrow,
+  onRepay,
+  canBorrow,
+  canRepay,
+  borrowTestId,
+  repayTestId,
+}: {
+  availableToBorrow: string;
+  availableMeterPercent: number;
+  totalBorrowed: string;
+  borrowedMeterPercent: number;
+  borrowCapacityLoading: boolean;
+  borrowCapacityError: Error | null;
+  onBorrow: () => void;
+  onRepay: () => void;
+  canBorrow: boolean;
+  canRepay: boolean;
+  /** Optional E2E test hooks for the borrow / repay action buttons. */
+  borrowTestId?: string;
+  repayTestId?: string;
+}): PositionStatCard[] {
+  const capacityUnavailable =
+    borrowCapacityLoading || borrowCapacityError != null;
+
+  const availableValue = borrowCapacityLoading
+    ? COPY.common.loading
+    : borrowCapacityError
+      ? COPY.common.emptyValue
+      : availableToBorrow;
+
+  return [
+    {
+      label: COPY.overview.availableToBorrowLabel,
+      value: availableValue,
+      meter: capacityUnavailable
+        ? undefined
+        : {
+            percent: availableMeterPercent,
+            label: formatMeterLabel(availableMeterPercent, {
+              belowOne: COPY.overview.availableMeterBelowOneLabel,
+              nearFull: COPY.overview.availableMeterNearFullLabel,
+              exact: COPY.overview.availableMeterLabel,
+            }),
+          },
+      actionLabel: COPY.overview.borrowAction,
+      onAction: onBorrow,
+      actionDisabled: !canBorrow,
+      actionTestId: borrowTestId,
+    },
+    {
+      label: COPY.overview.totalBorrowedLabel,
+      value: totalBorrowed,
+      meter: capacityUnavailable
+        ? undefined
+        : {
+            percent: borrowedMeterPercent,
+            label: formatMeterLabel(borrowedMeterPercent, {
+              belowOne: COPY.overview.borrowedMeterBelowOneLabel,
+              nearFull: COPY.overview.borrowedMeterNearFullLabel,
+              exact: COPY.overview.borrowedMeterLabel,
+            }),
+          },
+      actionLabel: COPY.overview.repayAction,
+      onAction: onRepay,
+      actionDisabled: !canRepay,
+      actionTestId: repayTestId,
+    },
+  ];
 }

--- a/services/vault/src/components/simple/__tests__/ActiveLoansList.test.tsx
+++ b/services/vault/src/components/simple/__tests__/ActiveLoansList.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { ActiveLoanRow } from "@/applications/aave/hooks";
+
+import { ActiveLoansList } from "../ActiveLoansList";
+
+function makeRow(overrides: Partial<ActiveLoanRow> = {}): ActiveLoanRow {
+  return {
+    reserveId: "1",
+    symbol: "USDC",
+    name: "USD Coin",
+    amount: "1.00",
+    icon: "https://example.com/usdc.svg",
+    borrowRate: "5.861%",
+    availableLiquidity: 1000,
+    utilizationBps: 5000,
+    isBorrowable: true,
+    ...overrides,
+  };
+}
+
+describe("ActiveLoansList — per-row Borrow gating", () => {
+  it("disables the Borrow button for a non-borrowable reserve while keeping Repay enabled", () => {
+    render(
+      <ActiveLoansList
+        rows={[makeRow({ isBorrowable: false })]}
+        canBorrow
+        onBorrow={vi.fn()}
+        onRepay={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Borrow" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Repay" })).toBeEnabled();
+  });
+
+  it("enables the Borrow button for a borrowable reserve when capacity remains", () => {
+    render(
+      <ActiveLoansList
+        rows={[makeRow({ isBorrowable: true })]}
+        canBorrow
+        onBorrow={vi.fn()}
+        onRepay={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Borrow" })).toBeEnabled();
+  });
+
+  it("disables the Borrow button when there is no borrow capacity, even for a borrowable reserve", () => {
+    render(
+      <ActiveLoansList
+        rows={[makeRow({ isBorrowable: true })]}
+        canBorrow={false}
+        onBorrow={vi.fn()}
+        onRepay={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Borrow" })).toBeDisabled();
+  });
+});

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -994,6 +994,16 @@ export const COPY = {
     heading: "Loans",
     borrowButton: "Borrow",
     repayButton: "Repay",
+    // v3 Loans page: "Active Loans (N)" section heading.
+    activeLoansHeading: (count: number) => `Active Loans (${count})`,
+    // v3 Loans page empty state (connected, no debt).
+    noActiveLoans: {
+      title: "No active loans",
+      body: "You haven't borrowed any assets yet",
+    },
+    // v3 Loans summary — caption under the health-factor value.
+    healthFactorCaption:
+      "When the ratio falls below 1.0, liquidation may occur.",
     // Live drawn borrow rate for the asset (Aave Hub), no compounding applied —
     // an APR, the same figure the asset picker labels "Borrow APR". One number,
     // one label.

--- a/services/vault/src/hooks/__tests__/useDashboardState.test.ts
+++ b/services/vault/src/hooks/__tests__/useDashboardState.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   BPS_SCALE,
+  MIN_BORROWABLE_USD,
   MIN_HEALTH_FACTOR_FOR_BORROW,
 } from "@/applications/aave/constants";
 
@@ -293,5 +294,52 @@ describe("useDashboardState", () => {
     const { result } = renderHook(() => useDashboardState("0xabc"));
 
     expect(result.current.borrowCapacityError).toBe(mockSplitError);
+  });
+
+  // Max total debt for the shared collateral/split fixture below.
+  const fixtureMaxTotalDebtUsd =
+    (10000 * Math.round(0.8 * BPS_SCALE)) /
+    BPS_SCALE /
+    MIN_HEALTH_FACTOR_FOR_BORROW;
+
+  it("disables borrow when remaining capacity is sub-cent dust (fully borrowed)", () => {
+    mockCollateralBtc = 1;
+    mockCollateralValueUsd = 10000;
+    mockSplitParams = { THF: 1.1, CF: 0.8, LB: 1.05 };
+    // Borrowed to within a fraction of a cent of the max — the float/HF-buffer
+    // residual a fully-borrowed position leaves behind.
+    mockDebtValueUsd = fixtureMaxTotalDebtUsd - 0.003;
+
+    const { result } = renderHook(() => useDashboardState("0xabc"));
+
+    expect(result.current.availableToBorrowUsd).toBeLessThan(
+      MIN_BORROWABLE_USD,
+    );
+    expect(result.current.canBorrow).toBe(false);
+  });
+
+  it("enables borrow when there is at least a cent of capacity", () => {
+    mockCollateralBtc = 1;
+    mockCollateralValueUsd = 10000;
+    mockSplitParams = { THF: 1.1, CF: 0.8, LB: 1.05 };
+    mockDebtValueUsd = fixtureMaxTotalDebtUsd - 50;
+
+    const { result } = renderHook(() => useDashboardState("0xabc"));
+
+    expect(result.current.availableToBorrowUsd).toBeGreaterThan(
+      MIN_BORROWABLE_USD,
+    );
+    expect(result.current.canBorrow).toBe(true);
+  });
+
+  it("disables borrow while split params are unavailable (zero capacity)", () => {
+    mockCollateralBtc = 1;
+    mockCollateralValueUsd = 10000;
+    mockDebtValueUsd = 0;
+    mockSplitParams = null;
+
+    const { result } = renderHook(() => useDashboardState("0xabc"));
+
+    expect(result.current.canBorrow).toBe(false);
   });
 });

--- a/services/vault/src/hooks/useDashboardState.ts
+++ b/services/vault/src/hooks/useDashboardState.ts
@@ -6,7 +6,7 @@
 
 import { useEffect, useMemo } from "react";
 
-import { BPS_SCALE } from "@/applications/aave/constants";
+import { BPS_SCALE, MIN_BORROWABLE_USD } from "@/applications/aave/constants";
 import {
   useActivatingVaults,
   useReorderOverride,
@@ -59,6 +59,12 @@ export function useDashboardState(connectedAddress: string | undefined) {
     currentDebtUsd: debtValueUsd,
     liquidationThresholdBps,
   });
+
+  // Borrow is offered only with at least a cent of headroom. A fully-borrowed
+  // position leaves sub-cent dust here (float / HF buffer), which must not
+  // enable the Borrow CTA. While capacity is loading/errored this is 0 → false,
+  // the safe default.
+  const canBorrow = availableToBorrowUsd >= MIN_BORROWABLE_USD;
 
   const { findProvider } = useVaultProviders();
   const { reorderedOrder, clearReorderedOrder } = useReorderOverride();
@@ -180,6 +186,7 @@ export function useDashboardState(connectedAddress: string | undefined) {
     debtValueUsd,
     maxTotalDebtUsd,
     availableToBorrowUsd,
+    canBorrow,
     collateralFactorBps: splitParams ? liquidationThresholdBps : null,
     isBorrowCapacityLoading,
     borrowCapacityError,

--- a/services/vault/src/hooks/useLoanActions.ts
+++ b/services/vault/src/hooks/useLoanActions.ts
@@ -8,9 +8,10 @@
  * `AaveOverlayLayout`.
  */
 
-import { useCallback, useMemo, useState } from "react";
+import { type ComponentProps, useCallback, useMemo, useState } from "react";
 import { useNavigate } from "react-router";
 
+import { AssetSelectionModal } from "@/applications/aave/components/AssetSelectionModal";
 import { LOAN_TAB, type LoanTab } from "@/applications/aave/constants";
 import type { Asset } from "@/applications/aave/types";
 import featureFlags from "@/config/featureFlags";
@@ -23,13 +24,9 @@ interface UseLoanActionsProps {
   selectableBorrowedAssets: Asset[];
 }
 
-export interface AssetSelectionModalProps {
-  isOpen: boolean;
-  onClose: () => void;
-  onSelectAsset: (assetSymbol: string) => void;
-  mode: LoanTab;
-  assets: Asset[] | undefined;
-}
+// Typed against the modal's real props so the two can't drift; spread onto
+// `<AssetSelectionModal {...assetModalProps} />` by the consuming pages.
+type AssetSelectionModalProps = ComponentProps<typeof AssetSelectionModal>;
 
 export function useLoanActions({
   borrowedAssets,

--- a/services/vault/src/hooks/useLoanActions.ts
+++ b/services/vault/src/hooks/useLoanActions.ts
@@ -1,0 +1,96 @@
+/**
+ * useLoanActions hook
+ * Owns the borrow/repay entry-point orchestration shared by the v2 dashboard
+ * and the v3 Loans page: the asset-selection modal state, opening borrow/repay
+ * pickers (with the single-borrowed-asset direct-navigation shortcut), and
+ * direct navigation to a reserve's detail overlay. The overlay itself is
+ * route-driven (`?reserve=<symbol>&tab=<borrow|repay>`), rendered by
+ * `AaveOverlayLayout`.
+ */
+
+import { useCallback, useMemo, useState } from "react";
+import { useNavigate } from "react-router";
+
+import { LOAN_TAB, type LoanTab } from "@/applications/aave/constants";
+import type { Asset } from "@/applications/aave/types";
+import featureFlags from "@/config/featureFlags";
+import { getReserveDetailRoute } from "@/routes";
+
+interface UseLoanActionsProps {
+  /** Borrowed assets (used to resolve the single-asset repay shortcut). */
+  borrowedAssets: { symbol: string }[];
+  /** Borrowed assets shaped for the repay-mode asset picker. */
+  selectableBorrowedAssets: Asset[];
+}
+
+export interface AssetSelectionModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSelectAsset: (assetSymbol: string) => void;
+  mode: LoanTab;
+  assets: Asset[] | undefined;
+}
+
+export function useLoanActions({
+  borrowedAssets,
+  selectableBorrowedAssets,
+}: UseLoanActionsProps) {
+  const navigate = useNavigate();
+  const isV3 = featureFlags.isV3UiEnabled;
+
+  const [isAssetModalOpen, setIsAssetModalOpen] = useState(false);
+  const [assetModalMode, setAssetModalMode] = useState<LoanTab>(
+    LOAN_TAB.BORROW,
+  );
+
+  const goToReserve = useCallback(
+    (assetSymbol: string, tab: LoanTab) => {
+      navigate(getReserveDetailRoute(assetSymbol, tab, isV3));
+    },
+    [navigate, isV3],
+  );
+
+  const openBorrowPicker = useCallback(() => {
+    setAssetModalMode(LOAN_TAB.BORROW);
+    setIsAssetModalOpen(true);
+  }, []);
+
+  const openRepay = useCallback(() => {
+    // A single borrowed asset has no choice to make — skip the picker and open
+    // its repay overlay directly.
+    if (borrowedAssets.length === 1) {
+      goToReserve(borrowedAssets[0].symbol, LOAN_TAB.REPAY);
+      return;
+    }
+    setAssetModalMode(LOAN_TAB.REPAY);
+    setIsAssetModalOpen(true);
+  }, [borrowedAssets, goToReserve]);
+
+  const handleSelectAsset = useCallback(
+    (assetSymbol: string) => {
+      goToReserve(assetSymbol, assetModalMode);
+    },
+    [goToReserve, assetModalMode],
+  );
+
+  const assetModalProps: AssetSelectionModalProps = useMemo(
+    () => ({
+      isOpen: isAssetModalOpen,
+      onClose: () => setIsAssetModalOpen(false),
+      onSelectAsset: handleSelectAsset,
+      mode: assetModalMode,
+      assets:
+        assetModalMode === LOAN_TAB.REPAY
+          ? selectableBorrowedAssets
+          : undefined,
+    }),
+    [
+      isAssetModalOpen,
+      handleSelectAsset,
+      assetModalMode,
+      selectableBorrowedAssets,
+    ],
+  );
+
+  return { openBorrowPicker, openRepay, goToReserve, assetModalProps };
+}

--- a/services/vault/src/router.tsx
+++ b/services/vault/src/router.tsx
@@ -32,6 +32,7 @@ import {
 import { lazyWithRetry } from "./utils/lazyWithRetry";
 
 const Activity = lazyWithRetry(() => import("./components/pages/Activity"));
+const LoansPage = lazyWithRetry(() => import("./components/pages/Loans"));
 const DashboardPage = lazyWithRetry(() =>
   import("./components/simple/DashboardPage").then((m) => ({
     default: m.DashboardPage,
@@ -115,7 +116,18 @@ export const Router = () => (
     <Route element={<RootLayout />}>
       <Route element={<AaveOverlayLayout />}>
         <Route path={ROUTES.OVERVIEW} element={<DashboardPage />} />
-        <Route path={ROUTES.LOANS} element={<V3Placeholder />} />
+        <Route
+          path={ROUTES.LOANS}
+          element={
+            featureFlags.isV3UiEnabled ? (
+              <Suspense fallback={<RouteFallback />}>
+                <LoansPage />
+              </Suspense>
+            ) : (
+              <Navigate to={ROUTES.OVERVIEW} replace />
+            )
+          }
+        />
       </Route>
       <Route path={ROUTES.VAULTS} element={<V3Placeholder />} />
       <Route path={ROUTES.LIQUIDATIONS} element={<V3Placeholder />} />

--- a/services/vault/src/utils/__tests__/formatting.test.ts
+++ b/services/vault/src/utils/__tests__/formatting.test.ts
@@ -17,6 +17,7 @@ import {
   formatDuration,
   formatDurationShort,
   formatLiquidationDistancePercent,
+  formatMeterLabel,
   formatOrdinal,
   formatProviderDisplayName,
   formatTimeAgo,
@@ -488,5 +489,38 @@ describe("Formatting Utilities", () => {
       expect(formatDurationShort(130)).toBe("2 h");
       expect(formatDurationShort(170)).toBe("3 h");
     });
+  });
+});
+
+describe("formatMeterLabel", () => {
+  const labels = {
+    belowOne: "<1% remaining",
+    nearFull: ">99% remaining",
+    exact: (percent: number) => `${percent}% remaining`,
+  };
+
+  it("returns the exact rounded percentage for a mid-range ratio", () => {
+    expect(formatMeterLabel(0.5, labels)).toBe("50% remaining");
+  });
+
+  it("shows the below-one label when a non-zero ratio rounds down to 0%", () => {
+    expect(formatMeterLabel(0.003, labels)).toBe("<1% remaining");
+  });
+
+  it("shows the near-full label when a below-full ratio rounds up to 100%", () => {
+    expect(formatMeterLabel(0.997, labels)).toBe(">99% remaining");
+  });
+
+  it("uses the exact label (not below-one) at exactly 0", () => {
+    expect(formatMeterLabel(0, labels)).toBe("0% remaining");
+  });
+
+  it("uses the exact label (not near-full) at exactly 1", () => {
+    expect(formatMeterLabel(1, labels)).toBe("100% remaining");
+  });
+
+  it("clamps out-of-range ratios before formatting", () => {
+    expect(formatMeterLabel(-0.5, labels)).toBe("0% remaining");
+    expect(formatMeterLabel(1.5, labels)).toBe("100% remaining");
   });
 });

--- a/services/vault/src/utils/formatting.ts
+++ b/services/vault/src/utils/formatting.ts
@@ -247,6 +247,28 @@ export function formatDisplayAmount(
 }
 
 /**
+ * Label for a progress meter whose fill is a 0–1 ratio, guarding the two
+ * rounding edges so the text can't contradict a partial bar:
+ *  - a non-zero ratio that rounds down to 0%   → `belowOne` (e.g. "<1% …")
+ *  - a below-full ratio that rounds up to 100%  → `nearFull` (e.g. ">99% …")
+ *  - otherwise the exact rounded percentage.
+ */
+export function formatMeterLabel(
+  ratio: number,
+  labels: {
+    belowOne: string;
+    nearFull: string;
+    exact: (percent: number) => string;
+  },
+): string {
+  const percent = Math.round(Math.min(1, Math.max(0, ratio)) * 100);
+  const isPartial = ratio > 0 && ratio < 1;
+  if (isPartial && percent === 0) return labels.belowOne;
+  if (isPartial && percent === 100) return labels.nearFull;
+  return labels.exact(percent);
+}
+
+/**
  * Format a date as "YYYY-MM-DD HH:mm:ss"
  * @param date - The date to format
  * @returns Formatted date string


### PR DESCRIPTION
Closes https://github.com/babylonlabs-io/babylon-toolkit/issues/2042

<img width="2032" height="1162" alt="Screenshot_2026-07-21_19-00-28" src="https://github.com/user-attachments/assets/dc1c9cb8-b6e4-4e4c-af1a-dfcb64e5a1f6" />

---

## What this does

Adds the new "Loans" page for the v3 (premium) UI at `/loans`, behind the existing `NEXT_PUBLIC_FF_ENABLE_V3_UI` feature flag. With the flag off nothing changes (the page redirects to the v2 dashboard); with it on, the sidebar shows a dedicated Loans page.

The page shows, for a connected depositor with collateral:
- A summary card with **Available to Borrow**, **Total Borrowed**, and **Health Factor**.
- An **Active Loans** list (one row per borrowed asset) with the live Borrow APR, available liquidity, and utilization, plus per-asset Borrow / Repay buttons.
- An empty state when there are no active loans yet.

Borrowing and repaying happen through the **exact same flow the v2 app already uses** — the asset-selection modal and the reserve-detail overlay — so no borrow/repay logic was rewritten.

## Why

v3 is a UI restructure that splits the old single-page dashboard into separate pages. The Loans section needed its own page. The guiding rule for this rollout (the flag is being removed shortly) was: **reuse what already works, ship it raw, and file follow-up tickets for anything that would be a big new build.**

## Approach and why we chose it

**Reuse the existing borrow/repay engine instead of rebuilding it.** The `/loans` route already sits under the layout that renders the Aave reserve-detail overlay (driven by `?reserve=&tab=` in the URL), so we mounted the real page there and pointed the Borrow/Repay buttons at the existing asset-selection modal and overlay. The alternative — rebuilding the borrow/repay UI for v3 — was rejected: it would duplicate value-moving code, add risk, and take far longer than the flag timeline allows.

**Show the summary and a Borrow entry whenever the user has collateral (matches v2).** In v2 the Loans section always offered a Borrow button once you had a pegin. Our first version gated the whole page on "already has debt", which meant a depositor with collateral but no loan saw only a "Deposit" prompt and could not borrow. We fixed this so the page keys off "has a position" (collateral or loans), restoring the v2 behavior.

**Disable Borrow when there is effectively no capacity left.** A fully-borrowed position leaves a sub-cent dust residual, so a naive `available > 0` check kept the Borrow buttons enabled at "$0.00 available". We added a small named threshold (`MIN_BORROWABLE_USD`) and compute a single `canBorrow` in one place (`useDashboardState`) that both the Loans page and the Overview page use, so the Borrow buttons disable when the position is maxed out — matching the design.

**Reuse and extend shared UI instead of one-off components.** The summary reuses the same stat-card component the v3 Overview uses (we extracted the two shared "borrow capacity" cards so both pages build them the same way and added a no-button health-factor variant). The empty state reuses the shared `EmptyState` component, which we improved (optional custom icon, a single card surface, and the brand-orange primary button) — this also cleans up the one other place that component is used.

**Small shared hooks for the wiring.** `useLoanActions` holds the borrow/repay button orchestration (shared with the dashboard so it is not duplicated) and `useActiveLoans` merges each borrowed asset with its live liquidity/utilization.

## Not included (follow-up tickets)

- **Borrow-market asset-detail page with historical APY / utilization charts** — the per-asset "borrow market" screens with graphs and a date selector. This does not exist in v2 and is a substantial new build, so it was left out of this raw rollout. Tracked in https://github.com/babylonlabs-io/babylon-toolkit/issues/2098 <- cc @jeremy-babylonlabs you need to think who should take this ticket
- **Loan amount precision** — active-loan amounts show the exact on-chain debt at full token precision (e.g. `1.000002 USDC`) while the summary shows rounded USD. This is pre-existing behavior in both v2 and v3; whether to round the display is tracked (with implementation notes) in https://github.com/babylonlabs-io/babylon-toolkit/issues/2097 <- @jeremy-babylonlabs this is present in v2

## Testing

- `pnpm --filter vault run lint` — clean.
- `pnpm --filter vault run test` — full suite passes (added tests for the empty state, the `canBorrow` threshold, and the `/loans` route).
- `tsc --noEmit` — clean.
- Manual, flag on: empty / connected-no-loans / active-loans states; borrow and repay through the reserve-detail overlay; Borrow disabled when fully borrowed; light and dark themes. Flag off: v2 dashboard unchanged, `/loans` redirects.

Note for local runs: rebuild `core-ui` first (`pnpm --filter @babylonlabs-io/core-ui build`) so the built package is current.
