### PR TITLE
fix(vault): surface the pending wallet approval on resume WOTS submit

### DIFF
--- a/services/vault/src/components/simple/DepositProgressView/DepositProgressView.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/DepositProgressView.tsx
@@ -110,6 +110,12 @@ export interface DepositProgressViewProps {
    */
   btcConfirmationDetail?: BtcConfirmationDetailData | null;
   /**
+   * Hint rendered under the active SUBMIT_WOTS_KEYS step. Resume passes it
+   * because its cold path fires a wallet approval the step copy doesn't
+   * mention — and some extensions queue that approval without a popup.
+   */
+  wotsApprovalHint?: string | null;
+  /**
    * The deposit's registered offchain-params version. Keeps the header's
    * total-duration estimate on the same pinned confirmation depth the flow
    * gates on. Omit pre-sign (no registered version yet) → latest params.
@@ -127,12 +133,36 @@ export interface DepositProgressViewProps {
 function resolveActiveStepDetail(params: {
   currentStep: DepositFlowStep;
   btcConfirmationDetail: BtcConfirmationDetailData | null | undefined;
+  wotsApprovalHint?: string | null;
   /** Stack the panel's rows — used for the narrow split-deposit columns. */
   stacked?: boolean;
+  /**
+   * In split layouts, whether this column is the vault the flow is currently
+   * driving. The WOTS hint only belongs under that vault — sibling columns
+   * parked on the same step are not awaiting this modal's wallet approval.
+   */
+  isActiveVault?: boolean;
 }): ReactNode {
-  const { currentStep, btcConfirmationDetail, stacked } = params;
+  const {
+    currentStep,
+    btcConfirmationDetail,
+    wotsApprovalHint,
+    stacked,
+    isActiveVault,
+  } = params;
   if (currentStep === DepositFlowStep.SIGN_PEGIN_BTC) {
     return <PeginFeeWarning />;
+  }
+  if (
+    currentStep === DepositFlowStep.SUBMIT_WOTS_KEYS &&
+    wotsApprovalHint &&
+    isActiveVault !== false
+  ) {
+    return (
+      <Text as="p" variant="body2" className="mt-3 text-accent-secondary">
+        {wotsApprovalHint}
+      </Text>
+    );
   }
   if (
     currentStep === DepositFlowStep.AWAIT_PAYOUT_TRANSACTIONS &&
@@ -174,6 +204,7 @@ export function DepositProgressView(props: DepositProgressViewProps) {
     terminalMessage,
     onRetry,
     btcConfirmationDetail,
+    wotsApprovalHint,
     offchainParamsVersion,
     started = true,
     onSign,
@@ -238,6 +269,7 @@ export function DepositProgressView(props: DepositProgressViewProps) {
   const activeStepDetail = resolveActiveStepDetail({
     currentStep,
     btcConfirmationDetail,
+    wotsApprovalHint,
   });
 
   // Split columns resolve the detail from each column's OWN step (so two
@@ -245,13 +277,18 @@ export function DepositProgressView(props: DepositProgressViewProps) {
   // columns each show their own). Rendered stacked because the columns are
   // narrow. The single-column path keeps the inline `activeStepDetail` above.
   const renderStepDetail = useCallback(
-    (step: DepositFlowStep, opts: { stacked: boolean }): ReactNode =>
+    (
+      step: DepositFlowStep,
+      opts: { stacked: boolean; isActiveVault?: boolean },
+    ): ReactNode =>
       resolveActiveStepDetail({
         currentStep: step,
         btcConfirmationDetail,
+        wotsApprovalHint,
         stacked: opts.stacked,
+        isActiveVault: opts.isActiveVault,
       }),
-    [btcConfirmationDetail],
+    [btcConfirmationDetail, wotsApprovalHint],
   );
 
   return (

--- a/services/vault/src/components/simple/DepositProgressView/SplitGroupedProgress.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/SplitGroupedProgress.tsx
@@ -45,7 +45,7 @@ interface SplitGroupedProgressProps {
    */
   renderStepDetail?: (
     step: DepositFlowStep,
-    opts: { stacked: boolean },
+    opts: { stacked: boolean; isActiveVault?: boolean },
   ) => ReactNode;
   /**
    * Per-vault raw steps (resume path), indexed to match the columns. When
@@ -176,6 +176,7 @@ export function SplitGroupedProgress({
               }
               activeStepDetail={renderStepDetail?.(vaultRawStep, {
                 stacked: true,
+                isActiveVault: vaultIndex === currentVaultIndex,
               })}
             />
           );

--- a/services/vault/src/components/simple/DepositProgressView/__tests__/DepositProgressView.test.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/__tests__/DepositProgressView.test.tsx
@@ -706,4 +706,69 @@ describe("DepositProgressView", () => {
       expect(onSign).not.toHaveBeenCalled();
     });
   });
+
+  describe("WOTS wallet-approval hint", () => {
+    it("renders the hint under the active WOTS step when provided", () => {
+      render(
+        <DepositProgressView
+          {...baseProps}
+          currentStep={DepositFlowStep.SUBMIT_WOTS_KEYS}
+          wotsApprovalHint={COPY.deposit.resume.wotsWalletApprovalHint}
+        />,
+      );
+
+      expect(
+        screen.getByText(COPY.deposit.resume.wotsWalletApprovalHint),
+      ).toBeInTheDocument();
+    });
+
+    it("does not render the hint at a non-WOTS step", () => {
+      render(
+        <DepositProgressView
+          {...baseProps}
+          currentStep={DepositFlowStep.SIGN_PEGIN_BTC}
+          wotsApprovalHint={COPY.deposit.resume.wotsWalletApprovalHint}
+        />,
+      );
+
+      expect(
+        screen.queryByText(COPY.deposit.resume.wotsWalletApprovalHint),
+      ).not.toBeInTheDocument();
+    });
+
+    it("does not render the hint when the WOTS step failed", () => {
+      render(
+        <DepositProgressView
+          {...baseProps}
+          currentStep={DepositFlowStep.SUBMIT_WOTS_KEYS}
+          error={{ title: "Transaction failed", body: "boom" }}
+          wotsApprovalHint={COPY.deposit.resume.wotsWalletApprovalHint}
+        />,
+      );
+
+      expect(
+        screen.queryByText(COPY.deposit.resume.wotsWalletApprovalHint),
+      ).not.toBeInTheDocument();
+    });
+
+    it("shows the hint only under the active vault's column in a split deposit", () => {
+      render(
+        <DepositProgressView
+          {...baseProps}
+          currentStep={DepositFlowStep.SUBMIT_WOTS_KEYS}
+          vaultCount={2}
+          currentVaultIndex={0}
+          perVaultSteps={[
+            DepositFlowStep.SUBMIT_WOTS_KEYS,
+            DepositFlowStep.SUBMIT_WOTS_KEYS,
+          ]}
+          wotsApprovalHint={COPY.deposit.resume.wotsWalletApprovalHint}
+        />,
+      );
+
+      expect(
+        screen.getAllByText(COPY.deposit.resume.wotsWalletApprovalHint),
+      ).toHaveLength(1);
+    });
+  });
 });

--- a/services/vault/src/components/simple/ResumeDepositContent.tsx
+++ b/services/vault/src/components/simple/ResumeDepositContent.tsx
@@ -535,6 +535,7 @@ export function ResumeWotsContent({
       onClose={onClose}
       onRetry={error ? handleSubmit : undefined}
       btcConfirmationDetail={btcConfirmationDetail}
+      wotsApprovalHint={COPY.deposit.resume.wotsWalletApprovalHint}
       offchainParamsVersion={activity.offchainParamsVersion}
     />
   );

--- a/services/vault/src/components/simple/__tests__/PostDepositContinuationView.test.tsx
+++ b/services/vault/src/components/simple/__tests__/PostDepositContinuationView.test.tsx
@@ -173,6 +173,15 @@ vi.mock("@/copy", () => ({
         },
       },
     },
+    // depositErrors.ts (imported transitively here) matches liveness copy.
+    wallet: {
+      liveness: {
+        errorTitle: "Wallet not responding",
+        unresponsive: "Your BTC wallet is not responding.",
+        emptyAddress: "Your BTC wallet did not return an address.",
+        addressMismatch: "Wrong wallet account connected.",
+      },
+    },
     common: {
       somethingWentWrong: { body: "Please close this and try again." },
       // formatting.ts builds FRIENDLY_MESSAGES from these at module load, and

--- a/services/vault/src/components/simple/__tests__/ResumeDepositContent.test.tsx
+++ b/services/vault/src/components/simple/__tests__/ResumeDepositContent.test.tsx
@@ -203,6 +203,7 @@ vi.mock("../DepositProgressView", () => ({
     terminalMessage,
     canContinueInBackground,
     onRetry,
+    wotsApprovalHint,
   }: {
     currentStep?: string;
     error?: { title: string; body: string } | null;
@@ -211,8 +212,10 @@ vi.mock("../DepositProgressView", () => ({
     terminalMessage?: string | null;
     canContinueInBackground?: boolean;
     onRetry?: () => void;
+    wotsApprovalHint?: string | null;
   }) => (
     <div data-testid="progress-view">
+      <span data-testid="wots-hint">{wotsApprovalHint ?? ""}</span>
       <span data-testid="step">{String(currentStep)}</span>
       <span data-testid="error">{error?.body ?? ""}</span>
       <span data-testid="error-title">{error?.title ?? ""}</span>
@@ -327,6 +330,28 @@ describe("ResumeWotsContent — Pre-PegIn tx hash trust boundary", () => {
       expect(mockDeriveVaultRoot).toHaveBeenCalledTimes(1);
     });
     expect(mockParseFundingOutpointsFromTx).toHaveBeenCalledWith("0xindexertx");
+  });
+
+  it("passes the wallet-approval hint to the progress view", async () => {
+    mockCalculateBtcTxHash.mockReturnValue(ON_CHAIN_HASH);
+    mockGetVaultRegistryReader.mockReturnValue(readerWith(ON_CHAIN_HASH));
+    mockDeriveVaultRoot.mockResolvedValue(new Uint8Array(32));
+
+    const { getByTestId } = render(
+      <ResumeWotsContent
+        activity={baseActivity}
+        onClose={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    );
+
+    expect(getByTestId("wots-hint").textContent).toBe(
+      COPY.deposit.resume.wotsWalletApprovalHint,
+    );
+
+    await waitFor(() => {
+      expect(mockDeriveVaultRoot).toHaveBeenCalledTimes(1);
+    });
   });
 });
 

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -585,6 +585,10 @@ export const COPY = {
       readyToActivateMessage:
         "Your payout transactions are signed and verified. Your BTC Vault is ready to activate.",
       wotsMismatchError: WRONG_WALLET_BODY,
+      // Resume's cold path fires a wallet approval the WOTS step copy doesn't
+      // mention, and some extensions queue it without surfacing a popup.
+      wotsWalletApprovalHint:
+        "You may be asked to approve a request in your BTC wallet. If no approval window appears, open your wallet extension.",
     },
     warnings: {
       depositRecordNotSaved:

--- a/services/vault/src/utils/errors/__tests__/depositErrors.test.ts
+++ b/services/vault/src/utils/errors/__tests__/depositErrors.test.ts
@@ -48,6 +48,21 @@ describe("mapDepositError", () => {
     expect(result.body).toContain("hasn't ingested");
   });
 
+  it("maps a BTC wallet liveness failure to the wallet-not-responding callout", () => {
+    const err = new Error(COPY.wallet.liveness.unresponsive);
+    expect(mapDepositError(err)).toEqual({
+      title: COPY.wallet.liveness.errorTitle,
+      body: COPY.wallet.liveness.unresponsive,
+    });
+  });
+
+  it("maps a liveness address mismatch surfaced as a plain string", () => {
+    expect(mapDepositError(COPY.wallet.liveness.addressMismatch)).toEqual({
+      title: COPY.wallet.liveness.errorTitle,
+      body: COPY.wallet.liveness.addressMismatch,
+    });
+  });
+
   it("maps a registered-version mismatch to the version-changed callout", () => {
     const err = new Error("on-chain version differs");
     err.name = "RegisteredVaultVersionMismatchError";

--- a/services/vault/src/utils/errors/depositErrors.ts
+++ b/services/vault/src/utils/errors/depositErrors.ts
@@ -51,6 +51,13 @@ export interface DepositErrorContent {
 
 const ERRORS = COPY.deposit.errors;
 
+/** BtcWalletLivenessError bodies, matched (lowercased) by bucket 5b. */
+const LIVENESS_BODIES = [
+  COPY.wallet.liveness.unresponsive,
+  COPY.wallet.liveness.emptyAddress,
+  COPY.wallet.liveness.addressMismatch,
+];
+
 /**
  * Thrown by the deposit flow when the selected vault provider's commission
  * never loaded, so it can't be quoted as `maxAcceptableCommissionBps`. Used as
@@ -152,6 +159,16 @@ export function mapDepositError(err: unknown): DepositErrorContent {
     msg.includes("failed to get wallet client")
   ) {
     return ERRORS.walletNotConnected;
+  }
+
+  // 5b. BTC wallet liveness-probe failures. Resume surfaces stringify the
+  // BtcWalletLivenessError, so match the copy strings and keep the matched
+  // (actionable) body under the liveness title instead of the generic one.
+  const livenessBody = LIVENESS_BODIES.find((body) =>
+    msg.includes(body.toLowerCase()),
+  );
+  if (livenessBody) {
+    return { title: COPY.wallet.liveness.errorTitle, body: livenessBody };
   }
 
   // 6. Wallet signing rejection. The coded path (step 1) misses rejections that


### PR DESCRIPTION
1. A hint under the active "Submit WOTS key" step: *"You may be asked to
 approve a request in your BTC wallet. If no approval window appears,
 open your wallet extension."* Rendered through the existing
 per-step detail seam, so it auto-suppresses on error, on other steps,
 and (in split deposits) on sibling vault columns.
2. BTC-wallet liveness-probe failures are now titled **"Wallet not
 responding"** with the actionable body preserved, instead of the
 generic "Transaction failed".