### PR TITLE
feat(vault): v3 activity page

### DIFF
--- a/services/vault/src/__tests__/router.test.tsx
+++ b/services/vault/src/__tests__/router.test.tsx
@@ -51,6 +51,12 @@ vi.mock("../components/pages/not-found", () => ({
   default: () => <div data-testid="not-found" />,
 }));
 
+// The Activity page's empty state pulls in the shared EmptyState → <Connect/>
+// (heavy wallet-connector graph). Stub it so the router test stays a unit test.
+vi.mock("@/components/Wallet", () => ({
+  Connect: () => <button type="button">Connect</button>,
+}));
+
 vi.mock("../applications", () => ({
   getApplication: () => undefined,
   getApplicationMetadataByController: () => undefined,

--- a/services/vault/src/components/Activity/ActivityCard.tsx
+++ b/services/vault/src/components/Activity/ActivityCard.tsx
@@ -2,7 +2,7 @@ import { Avatar, Loader } from "@babylonlabs-io/core-ui";
 
 import { CopyableHash } from "@/components/shared/CopyableHash";
 import { COPY } from "@/copy";
-import { type ActivityLog, PENDING_DEPOSIT_TYPE } from "@/types/activityLog";
+import type { ActivityLog } from "@/types/activityLog";
 import { getExplorerTxUrl } from "@/utils/explorer";
 import { formatDateTime } from "@/utils/formatting";
 
@@ -18,9 +18,9 @@ export function ActivityCard({ row }: ActivityCardProps) {
   const showSpinner = isPending && !isExpired;
   const showHash = row.transactionHash !== "";
 
-  // PENDING_DEPOSIT_TYPE is an internal type used to keep pending peg-ins out
-  // of the filter menu; the row itself reads as a normal "Deposit" with a spinner.
-  const displayLabel = row.type === PENDING_DEPOSIT_TYPE ? "Deposit" : row.type;
+  // The type label comes from the copy catalog; "Pending Deposit" (an internal
+  // type kept out of the filter menu) reads as a normal "Deposit" with a spinner.
+  const displayLabel = COPY.activity.typeLabels[row.type];
 
   const mutedTextClass = isPending
     ? "text-accent-secondary"

--- a/services/vault/src/components/Activity/ActivityEmptyState.tsx
+++ b/services/vault/src/components/Activity/ActivityEmptyState.tsx
@@ -2,9 +2,10 @@ import { Button } from "@babylonlabs-io/core-ui";
 import { useOutletContext } from "react-router";
 
 import type { RootLayoutContext } from "@/components/pages/RootLayout";
+import { EmptyState } from "@/components/shared/EmptyState";
+import { EmptyStateIcon } from "@/components/shared/icons";
+import { FeatureFlags, getNetworkConfigBTC } from "@/config";
 import { COPY } from "@/copy";
-
-import { getNetworkConfigBTC } from "../../config";
 
 const btcConfig = getNetworkConfigBTC();
 
@@ -18,6 +19,52 @@ export function ActivityEmptyState({
   isFiltered,
 }: ActivityEmptyStateProps) {
   const { openDeposit } = useOutletContext<RootLayoutContext>();
+
+  // v3: the shared EmptyState card (document-search icon + Deposit CTA) matches
+  // the Figma "before deposit" frame. Disconnected shows the Connect control;
+  // filtered-empty stays a distinct message with no CTA. The testid is carried
+  // over so the same hook covers both UIs.
+  if (FeatureFlags.isV3UiEnabled) {
+    if (isFiltered) {
+      return (
+        <div data-testid="activity-empty-state">
+          <EmptyState
+            icon={<EmptyStateIcon />}
+            title={COPY.activity.emptyFiltered}
+            isConnected
+            withCard
+          />
+        </div>
+      );
+    }
+
+    if (!isConnected) {
+      return (
+        <div data-testid="activity-empty-state">
+          <EmptyState
+            icon={<EmptyStateIcon />}
+            title={COPY.activity.emptyDisconnected}
+            isConnected={false}
+            withCard
+          />
+        </div>
+      );
+    }
+
+    return (
+      <div data-testid="activity-empty-state">
+        <EmptyState
+          icon={<EmptyStateIcon />}
+          title={COPY.activity.emptyV3Title}
+          description={COPY.activity.emptyV3Body}
+          isConnected
+          actionLabel={COPY.overview.depositAction}
+          onAction={() => openDeposit()}
+          withCard
+        />
+      </div>
+    );
+  }
 
   if (isFiltered) {
     return (

--- a/services/vault/src/components/Activity/ActivityList.tsx
+++ b/services/vault/src/components/Activity/ActivityList.tsx
@@ -5,11 +5,51 @@ import { twJoin } from "tailwind-merge";
 import { FeatureFlags } from "@/config";
 import { COPY } from "@/copy";
 import type { ActivityRow, ActivityType } from "@/types/activityLog";
+import { formatActivityDateGroup } from "@/utils/formatting";
 
 import { ActivityCard } from "./ActivityCard";
 import { ActivityEmptyState } from "./ActivityEmptyState";
+import { ActivityRowV3 } from "./ActivityRowV3";
 import { FilterDropdown } from "./FilterDropdown";
 import { LiquidationGroupCard } from "./LiquidationGroupCard";
+
+interface ActivityDateGroup {
+  label: string;
+  rows: ActivityRow[];
+}
+
+// Buckets the (already newest-first) rows under date-group headers, preserving
+// order: each row keeps its position and groups appear in first-seen order.
+function groupByDate(
+  rows: ActivityRow[],
+  reference: Date,
+): ActivityDateGroup[] {
+  const labels = {
+    today: COPY.activity.dateToday,
+    yesterday: COPY.activity.dateYesterday,
+  };
+  const ordered: ActivityDateGroup[] = [];
+  const byLabel = new Map<string, ActivityDateGroup>();
+  for (const row of rows) {
+    const label = formatActivityDateGroup(row.date, reference, labels);
+    let group = byLabel.get(label);
+    if (!group) {
+      group = { label, rows: [] };
+      byLabel.set(label, group);
+      ordered.push(group);
+    }
+    group.rows.push(row);
+  }
+  return ordered;
+}
+
+function ActivityRow({ row }: { row: ActivityRow }) {
+  return row.kind === "liquidationGroup" ? (
+    <LiquidationGroupCard row={row} />
+  ) : (
+    <ActivityRowV3 row={row} />
+  );
+}
 
 // Single-app surface today. When multi-app ships this becomes an app picker
 // fed from the applications registry.
@@ -30,10 +70,11 @@ interface ActivityListProps {
 
 export function ActivityList({ activities, isConnected }: ActivityListProps) {
   const isMobile = useIsMobile();
+  const isV3 = FeatureFlags.isV3UiEnabled;
   // v3 desktop replaces this in-page heading with the persistent header's
   // page title; v3 mobile has no header title slot (Header only shows it on
   // desktop), so the heading must stay to avoid a page with no title at all.
-  const hideHeading = FeatureFlags.isV3UiEnabled && !isMobile;
+  const hideHeading = isV3 && !isMobile;
   const [filter, setFilter] = useState<ActivityType | null>(null);
 
   // The filter control is hidden when the wallet disconnects, so leaving the
@@ -84,8 +125,37 @@ export function ActivityList({ activities, isConnected }: ActivityListProps) {
           isConnected={isConnected}
           isFiltered={filter !== null}
         />
+      ) : isV3 ? (
+        // v3: rows grouped under date headers, each group a rounded card with
+        // divider-separated rows (matches the Figma "after deposit" frame).
+        <div className="flex flex-col gap-6">
+          {groupByDate(visible, new Date()).map((group) => (
+            <div key={group.label} className="flex flex-col gap-3">
+              <p className="text-sm leading-[1.43] tracking-[0.17px] text-accent-secondary">
+                {group.label}
+              </p>
+              <ul
+                role="list"
+                className="overflow-hidden rounded-lg bg-secondary-highlight"
+              >
+                {group.rows.map((r, index) => (
+                  <li
+                    key={r.id}
+                    className={
+                      index > 0
+                        ? "border-t border-secondary-strokeLight dark:border-secondary-strokeDark"
+                        : ""
+                    }
+                  >
+                    <ActivityRow row={r} />
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
       ) : (
-        // Scroll container: min-h keeps the card substantial when there are
+        // v2 scroll container: min-h keeps the card substantial when there are
         // only a handful of rows; max-h caps tall histories so the page never
         // grows arbitrarily. Only the row list scrolls — the title + filter
         // sit outside the container and stay pinned.

--- a/services/vault/src/components/Activity/ActivityList.tsx
+++ b/services/vault/src/components/Activity/ActivityList.tsx
@@ -4,6 +4,7 @@ import { twJoin } from "tailwind-merge";
 
 import { FeatureFlags } from "@/config";
 import { COPY } from "@/copy";
+import { useMidnightTick } from "@/hooks/useMidnightTick";
 import type { ActivityRow, ActivityType } from "@/types/activityLog";
 import { formatActivityDateGroup } from "@/utils/formatting";
 
@@ -76,6 +77,10 @@ export function ActivityList({ activities, isConnected }: ActivityListProps) {
   // desktop), so the heading must stay to avoid a page with no title at all.
   const hideHeading = isV3 && !isMobile;
   const [filter, setFilter] = useState<ActivityType | null>(null);
+
+  // Re-render at local midnight so the v3 "Today" / "Yesterday" date-group
+  // headers stay correct on a page left open overnight (the feed doesn't poll).
+  useMidnightTick();
 
   // The filter control is hidden when the wallet disconnects, so leaving the
   // selection in place would trap the user on an empty-but-filtered list with

--- a/services/vault/src/components/Activity/ActivityRowV3.tsx
+++ b/services/vault/src/components/Activity/ActivityRowV3.tsx
@@ -64,9 +64,9 @@ export function ActivityRowV3({ row }: ActivityRowV3Props) {
   const showHash = row.transactionHash !== "";
   const status = getActivityStatus(row);
 
-  // PENDING_DEPOSIT_TYPE is an internal type used to keep pending peg-ins out
-  // of the filter menu; the row itself reads as a normal "Deposit".
-  const displayLabel = row.type === PENDING_DEPOSIT_TYPE ? "Deposit" : row.type;
+  // The type column label comes from the copy catalog; "Pending Deposit" (an
+  // internal type kept out of the filter menu) maps to a normal "Deposit".
+  const displayLabel = COPY.activity.typeLabels[row.type];
 
   return (
     // A shared grid template (not content-sized flex) so every row's columns

--- a/services/vault/src/components/Activity/ActivityRowV3.tsx
+++ b/services/vault/src/components/Activity/ActivityRowV3.tsx
@@ -1,0 +1,110 @@
+/**
+ * ActivityRowV3
+ * A single row inside a v3 date-group card (behind ENABLE_V3_UI). Columns:
+ * token icon + amount, a status indicator, the transaction type, the tx-hash
+ * link/copy, and a time-only timestamp (the calendar day lives in the group
+ * header). The status is derived from the row type plus pending/expired (see
+ * `getActivityStatus`). Per-row USD value and the Withdraw button from the
+ * Figma frame are deferred (not backed by current activity data).
+ */
+
+import { Avatar } from "@babylonlabs-io/core-ui";
+
+import { CopyableHash } from "@/components/shared/CopyableHash";
+import { COPY } from "@/copy";
+import { type ActivityLog, PENDING_DEPOSIT_TYPE } from "@/types/activityLog";
+import { getExplorerTxUrl } from "@/utils/explorer";
+import { formatActivityTime } from "@/utils/formatting";
+
+interface ActivityRowV3Props {
+  row: ActivityLog;
+}
+
+/**
+ * Status dot + label for a standard activity row, from current data only:
+ * expired (red) and pending (amber) take precedence; otherwise a settled
+ * deposit's collateral is "In use" and every other settled action (borrow /
+ * repay / withdraw / redeem) is "Done" (both green). This reflects the row
+ * type, not a live collateral check. Liquidation rows render separately and
+ * never reach here.
+ */
+function getActivityStatus(row: ActivityLog): {
+  dotClass: string;
+  label: string;
+} {
+  if (row.isExpired) {
+    return { dotClass: "bg-error-main", label: COPY.activity.statusExpired };
+  }
+  if (row.isPending) {
+    return { dotClass: "bg-warning-main", label: COPY.activity.statusPending };
+  }
+  const type = row.type === PENDING_DEPOSIT_TYPE ? "Deposit" : row.type;
+  if (type === "Deposit") {
+    return { dotClass: "bg-success-main", label: COPY.activity.statusInUse };
+  }
+  return { dotClass: "bg-success-main", label: COPY.activity.statusDone };
+}
+
+function StatusIndicator({
+  dotClass,
+  label,
+}: {
+  dotClass: string;
+  label: string;
+}) {
+  return (
+    <span className="flex items-center gap-2">
+      <span className={`inline-block size-2 rounded-full ${dotClass}`} />
+      <span className="text-base text-accent-primary">{label}</span>
+    </span>
+  );
+}
+
+export function ActivityRowV3({ row }: ActivityRowV3Props) {
+  const showHash = row.transactionHash !== "";
+  const status = getActivityStatus(row);
+
+  // PENDING_DEPOSIT_TYPE is an internal type used to keep pending peg-ins out
+  // of the filter menu; the row itself reads as a normal "Deposit".
+  const displayLabel = row.type === PENDING_DEPOSIT_TYPE ? "Deposit" : row.type;
+
+  return (
+    // A shared grid template (not content-sized flex) so every row's columns
+    // line up regardless of amount length — a long "0.00705306 WBTC" no longer
+    // pushes the type/hash/time columns out of alignment with shorter rows.
+    <div className="grid grid-cols-1 gap-2 p-6 lg:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)_minmax(0,1fr)_minmax(0,1.1fr)_auto] lg:items-center lg:gap-6">
+      <div className="flex min-w-0 items-center gap-3">
+        <Avatar url={row.tokenIcon} alt={row.amount.symbol} size="medium" />
+        <span className="whitespace-nowrap text-xl text-accent-primary">
+          {row.amount.value} {row.amount.symbol}
+        </span>
+      </div>
+
+      <div className="min-w-0">
+        <StatusIndicator dotClass={status.dotClass} label={status.label} />
+      </div>
+
+      <span className="min-w-0 text-base text-accent-primary">
+        {displayLabel}
+      </span>
+
+      <div className="min-w-0">
+        {showHash ? (
+          <CopyableHash
+            hash={row.transactionHash}
+            chain={row.chain}
+            explorerUrl={getExplorerTxUrl(row.chain, row.transactionHash)}
+          />
+        ) : (
+          <span className="text-sm italic text-accent-secondary">
+            {COPY.activity.hashPending}
+          </span>
+        )}
+      </div>
+
+      <span className="whitespace-nowrap text-sm text-accent-secondary lg:justify-self-end">
+        {formatActivityTime(row.date)}
+      </span>
+    </div>
+  );
+}

--- a/services/vault/src/components/Activity/__tests__/ActivityList.test.tsx
+++ b/services/vault/src/components/Activity/__tests__/ActivityList.test.tsx
@@ -17,6 +17,12 @@ vi.mock("@/config", () => ({
   getBTCNetwork: () => "signet",
 }));
 
+// The v3 disconnected empty state renders the shared EmptyState, which mounts
+// <Connect/> (many wallet providers). Stub it so the list stays a unit test.
+vi.mock("@/components/Wallet", () => ({
+  Connect: () => <button type="button">Connect</button>,
+}));
+
 import { ActivityList } from "../ActivityList";
 
 beforeEach(() => {
@@ -229,5 +235,45 @@ describe("ActivityList", () => {
     expect(
       screen.getByRole("button", { name: /show all/i }),
     ).toBeInTheDocument();
+  });
+
+  it("v3 UI: groups rows under date-group headers (Today vs an explicit date)", () => {
+    featureFlagsMock.isV3UiEnabled = true;
+    const rows = [
+      makeRow({ id: "today", type: "Deposit", date: new Date() }),
+      makeRow({
+        id: "old",
+        type: "Borrow",
+        amount: { value: "100", symbol: "USDC" },
+        date: new Date(2025, 0, 2, 12, 0, 0),
+      }),
+    ];
+    renderList({ activities: rows, isConnected: true });
+
+    expect(screen.getByText(COPY.activity.dateToday)).toBeInTheDocument();
+    expect(screen.getByText("2025-01-02")).toBeInTheDocument();
+    expect(screen.getAllByRole("listitem")).toHaveLength(2);
+  });
+
+  it("v3 UI + connected + no activity: shows the shared empty state with a Deposit CTA", () => {
+    featureFlagsMock.isV3UiEnabled = true;
+    renderList({ activities: [], isConnected: true });
+
+    expect(screen.getByText(COPY.activity.emptyV3Title)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: COPY.overview.depositAction }),
+    ).toBeInTheDocument();
+  });
+
+  it("v3 UI + filtered to empty: distinct filtered-empty state with no CTA", () => {
+    featureFlagsMock.isV3UiEnabled = true;
+    const rows = [makeRow({ id: "a", type: "Deposit" })];
+    renderList({ activities: rows, isConnected: true });
+
+    fireEvent.click(screen.getByRole("button", { name: /show all/i }));
+    fireEvent.click(screen.getByRole("option", { name: "Borrowed" }));
+
+    expect(screen.getByText(COPY.activity.emptyFiltered)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /deposit/i })).toBeNull();
   });
 });

--- a/services/vault/src/components/Activity/__tests__/ActivityRowV3.test.tsx
+++ b/services/vault/src/components/Activity/__tests__/ActivityRowV3.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type { ActivityLog } from "@/types/activityLog";
+
+import { ActivityRowV3 } from "../ActivityRowV3";
+
+const FULL_HASH =
+  "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2";
+
+const baseRow: ActivityLog = {
+  kind: "row",
+  id: "tx-1",
+  date: new Date(2025, 8, 8, 14, 32, 7), // Sep 8, 2025 14:32:07 local
+  type: "Deposit",
+  amount: { value: "1.0", symbol: "BTC" },
+  chain: "BTC",
+  transactionHash: FULL_HASH,
+  tokenIcon: "test://btc.svg",
+};
+
+describe("ActivityRowV3", () => {
+  it("renders amount, type, tx-hash link, and a time-only timestamp", () => {
+    render(<ActivityRowV3 row={baseRow} />);
+
+    expect(screen.getByText("1.0 BTC")).toBeInTheDocument();
+    expect(screen.getByText("Deposit")).toBeInTheDocument();
+
+    const anchor = screen.getByRole("link");
+    expect(anchor).toHaveAttribute("href", expect.stringContaining(FULL_HASH));
+
+    // Time only — the calendar day lives in the group header, not the row.
+    expect(screen.getByText("14:32:07")).toBeInTheDocument();
+    expect(screen.queryByText(/2025-09-08/)).not.toBeInTheDocument();
+  });
+
+  it("shows 'In use' for a settled deposit", () => {
+    render(<ActivityRowV3 row={baseRow} />);
+
+    expect(screen.getByText("In use")).toBeInTheDocument();
+    expect(screen.queryByText("Pending")).not.toBeInTheDocument();
+    expect(screen.queryByText("Expired")).not.toBeInTheDocument();
+  });
+
+  it("shows 'Done' for a settled borrow / repay", () => {
+    render(<ActivityRowV3 row={{ ...baseRow, type: "Borrow" }} />);
+    expect(screen.getByText("Done")).toBeInTheDocument();
+
+    render(<ActivityRowV3 row={{ ...baseRow, id: "r2", type: "Repay" }} />);
+    expect(screen.getAllByText("Done").length).toBeGreaterThan(0);
+  });
+
+  it("shows a Pending status for a pending row", () => {
+    render(<ActivityRowV3 row={{ ...baseRow, isPending: true }} />);
+
+    expect(screen.getByText("Pending")).toBeInTheDocument();
+    expect(screen.queryByText("Expired")).not.toBeInTheDocument();
+  });
+
+  it("shows an Expired status for an expired row", () => {
+    render(<ActivityRowV3 row={{ ...baseRow, isExpired: true }} />);
+
+    expect(screen.getByText("Expired")).toBeInTheDocument();
+  });
+
+  it("shows Expired (not Pending) when a row is both pending and expired", () => {
+    render(
+      <ActivityRowV3 row={{ ...baseRow, isPending: true, isExpired: true }} />,
+    );
+
+    expect(screen.getByText("Expired")).toBeInTheDocument();
+    expect(screen.queryByText("Pending")).not.toBeInTheDocument();
+  });
+
+  it("renders the pending placeholder instead of a link when there is no hash", () => {
+    render(
+      <ActivityRowV3
+        row={{ ...baseRow, isPending: true, transactionHash: "" }}
+      />,
+    );
+
+    expect(screen.getByText("Pending…")).toBeInTheDocument();
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+});

--- a/services/vault/src/components/pages/__tests__/Activity.test.tsx
+++ b/services/vault/src/components/pages/__tests__/Activity.test.tsx
@@ -36,6 +36,12 @@ vi.mock("@/config", () => ({
   getBTCNetwork: () => "signet",
 }));
 
+// The v3 empty state pulls in the shared EmptyState, which mounts <Connect/>
+// (heavy wallet-connector graph). Stub it so the page stays a unit test.
+vi.mock("@/components/Wallet", () => ({
+  Connect: () => <button type="button">Connect</button>,
+}));
+
 import Activity from "../Activity";
 
 function renderActivity() {

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -36,6 +36,7 @@
 
 // Direct file import (not the barrel) so we don't pull errorMessages' siblings
 // that import this file back. errorMessages.ts is import-free, so this is safe.
+import type { ActivityType } from "@/types/activityLog";
 import { CONTRACT_ERROR_MESSAGES } from "@/utils/errors/errorMessages";
 
 // Shared strings that legitimately appear in multiple places. Hoisting them
@@ -1310,6 +1311,18 @@ export const COPY = {
       "Partially Liquidated": "Partially Liquidated",
       "Fully Liquidated": "Fully Liquidated",
     },
+    // Row type labels (the transaction-type column). Pending Deposit reads as a
+    // normal "Deposit"; keep this exhaustive with the ActivityType union.
+    typeLabels: {
+      Deposit: "Deposit",
+      Withdraw: "Withdraw",
+      Borrow: "Borrow",
+      Repay: "Repay",
+      Redeem: "Redeem",
+      "Partially Liquidated": "Partially Liquidated",
+      "Fully Liquidated": "Fully Liquidated",
+      "Pending Deposit": "Deposit",
+    } satisfies Record<ActivityType, string>,
     hashPending: "Pending…",
     expiredTooltip: "Deposit expired",
     // Labels for the two child rows nested inside a LiquidationGroupRow.

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -1321,6 +1321,19 @@ export const COPY = {
     emptyConnected: "No activity yet. Make your first deposit to get started.",
     emptyFiltered: "No activity",
     depositCta: (coinSymbol: string) => `Deposit ${coinSymbol}`,
+    // v3 activity page (behind ENABLE_V3_UI): the empty state matches the
+    // shared v3 EmptyState card; status labels are derived from the row type
+    // plus pending/expired (a deposit's collateral is "In use", every other
+    // settled action is "Done"); date-group headers label the rows by day.
+    emptyV3Title: "No activity yet",
+    emptyV3Body:
+      "Your account activity will appear here once you start using Babylon",
+    statusPending: "Pending",
+    statusExpired: "Expired",
+    statusInUse: "In use",
+    statusDone: "Done",
+    dateToday: "Today",
+    dateYesterday: "Yesterday",
   },
   banner: {
     addCollateral: "Add Collateral",

--- a/services/vault/src/hooks/__tests__/useMidnightTick.test.ts
+++ b/services/vault/src/hooks/__tests__/useMidnightTick.test.ts
@@ -1,0 +1,50 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useMidnightTick } from "../useMidnightTick";
+
+describe("useMidnightTick", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("does not tick before local midnight", () => {
+    vi.setSystemTime(new Date(2025, 8, 8, 23, 59, 59)); // Sep 8, 23:59:59 local
+    const { result } = renderHook(() => useMidnightTick());
+
+    expect(result.current).toBe(0);
+    act(() => {
+      vi.advanceTimersByTime(500); // to 23:59:59.5 — still same day
+    });
+    expect(result.current).toBe(0);
+  });
+
+  it("ticks once the clock crosses local midnight", () => {
+    vi.setSystemTime(new Date(2025, 8, 8, 23, 59, 59));
+    const { result } = renderHook(() => useMidnightTick());
+
+    act(() => {
+      vi.advanceTimersByTime(1000); // crosses into Sep 9 00:00:00
+    });
+    expect(result.current).toBe(1);
+  });
+
+  it("reschedules for the following midnight", () => {
+    vi.setSystemTime(new Date(2025, 8, 8, 23, 59, 59));
+    const { result } = renderHook(() => useMidnightTick());
+
+    act(() => {
+      vi.advanceTimersByTime(1000); // first midnight → tick 1
+    });
+    expect(result.current).toBe(1);
+
+    act(() => {
+      vi.advanceTimersByTime(24 * 60 * 60 * 1000); // a full day later
+    });
+    expect(result.current).toBe(2);
+  });
+});

--- a/services/vault/src/hooks/useMidnightTick.ts
+++ b/services/vault/src/hooks/useMidnightTick.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Forces a re-render at the next local midnight, then reschedules for each
+ * following midnight. Use it where the UI is derived from the current calendar
+ * day (e.g. the activity "Today" / "Yesterday" date-group headers): the
+ * activity feed does not poll, so an idle page would otherwise keep yesterday's
+ * labels until an unrelated render. Returns a counter that increments each
+ * midnight (usually unused — subscribing to the hook is the point).
+ */
+export function useMidnightTick(): number {
+  const [tick, setTick] = useState(0);
+
+  useEffect(() => {
+    const now = new Date();
+    const nextMidnight = new Date(
+      now.getFullYear(),
+      now.getMonth(),
+      now.getDate() + 1,
+      0,
+      0,
+      0,
+      0,
+    ).getTime();
+    const id = setTimeout(
+      () => setTick((t) => t + 1),
+      nextMidnight - now.getTime(),
+    );
+    return () => clearTimeout(id);
+  }, [tick]);
+
+  return tick;
+}

--- a/services/vault/src/utils/__tests__/formatting.test.ts
+++ b/services/vault/src/utils/__tests__/formatting.test.ts
@@ -7,6 +7,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getNetworkConfigBTC } from "@/config";
 
 import {
+  formatActivityDateGroup,
+  formatActivityTime,
   formatAmount,
   formatAprPercent,
   formatBasisPointsAsPercent,
@@ -522,5 +524,75 @@ describe("formatMeterLabel", () => {
   it("clamps out-of-range ratios before formatting", () => {
     expect(formatMeterLabel(-0.5, labels)).toBe("0% remaining");
     expect(formatMeterLabel(1.5, labels)).toBe("100% remaining");
+  });
+});
+
+describe("formatActivityTime", () => {
+  it("formats a date as zero-padded HH:mm:ss (local time)", () => {
+    expect(formatActivityTime(new Date(2025, 8, 8, 9, 5, 3))).toBe("09:05:03");
+  });
+
+  it("handles midnight and end of day", () => {
+    expect(formatActivityTime(new Date(2025, 8, 8, 0, 0, 0))).toBe("00:00:00");
+    expect(formatActivityTime(new Date(2025, 8, 8, 23, 59, 59))).toBe(
+      "23:59:59",
+    );
+  });
+});
+
+describe("formatActivityDateGroup", () => {
+  const labels = { today: "Today", yesterday: "Yesterday" };
+  // Reference "now": Sep 8, 2025, mid-afternoon (local time).
+  const reference = new Date(2025, 8, 8, 15, 30, 0);
+
+  it("labels the same calendar day 'Today' regardless of time", () => {
+    expect(
+      formatActivityDateGroup(new Date(2025, 8, 8, 0, 1, 0), reference, labels),
+    ).toBe("Today");
+    expect(
+      formatActivityDateGroup(
+        new Date(2025, 8, 8, 23, 0, 0),
+        reference,
+        labels,
+      ),
+    ).toBe("Today");
+  });
+
+  it("labels the previous calendar day 'Yesterday'", () => {
+    expect(
+      formatActivityDateGroup(
+        new Date(2025, 8, 7, 23, 0, 0),
+        reference,
+        labels,
+      ),
+    ).toBe("Yesterday");
+  });
+
+  it("labels older days with the explicit YYYY-MM-DD date", () => {
+    expect(
+      formatActivityDateGroup(
+        new Date(2025, 8, 6, 12, 0, 0),
+        reference,
+        labels,
+      ),
+    ).toBe("2025-09-06");
+    expect(
+      formatActivityDateGroup(
+        new Date(2025, 0, 2, 12, 0, 0),
+        reference,
+        labels,
+      ),
+    ).toBe("2025-01-02");
+  });
+
+  it("groups by calendar day, not elapsed 24h windows", () => {
+    // ~2 hours before the reference but on the previous calendar day → Yesterday.
+    expect(
+      formatActivityDateGroup(
+        new Date(2025, 8, 7, 23, 0, 0),
+        reference,
+        labels,
+      ),
+    ).toBe("Yesterday");
   });
 });

--- a/services/vault/src/utils/formatting.ts
+++ b/services/vault/src/utils/formatting.ts
@@ -285,6 +285,52 @@ export function formatDateTime(date: Date): string {
 }
 
 /**
+ * Format a date as "HH:mm:ss" (local time). Used by the v3 activity rows, whose
+ * calendar day lives in the group header, so only the time is shown per row.
+ * @param date - The date to format
+ * @returns Formatted time string
+ */
+export function formatActivityTime(date: Date): string {
+  const hours = String(date.getHours()).padStart(2, "0");
+  const minutes = String(date.getMinutes()).padStart(2, "0");
+  const seconds = String(date.getSeconds()).padStart(2, "0");
+
+  return `${hours}:${minutes}:${seconds}`;
+}
+
+/**
+ * Label for the v3 activity date-group header the given row belongs to:
+ * "Today" / "Yesterday" for the two most recent calendar days, else the
+ * explicit "YYYY-MM-DD". Pure and deterministic — the caller passes the
+ * reference "now" so it stays testable without touching the real clock.
+ * Grouping compares by local calendar day, not elapsed hours.
+ * @param date - The row's timestamp
+ * @param reference - The current time to compare against
+ * @param labels - Localized "Today"/"Yesterday" strings (from COPY)
+ */
+export function formatActivityDateGroup(
+  date: Date,
+  reference: Date,
+  labels: { today: string; yesterday: string },
+): string {
+  const startOfDay = (d: Date): number =>
+    new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
+
+  const MS_PER_DAY = 24 * 60 * 60 * 1000;
+  const dayDiff = Math.round(
+    (startOfDay(reference) - startOfDay(date)) / MS_PER_DAY,
+  );
+
+  if (dayDiff === 0) return labels.today;
+  if (dayDiff === 1) return labels.yesterday;
+
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+/**
  * Format a timestamp as relative time (e.g., "5 minutes ago", "2 days ago")
  * @param timestamp - Timestamp in milliseconds since epoch. Future timestamps return "just now".
  * @returns Formatted relative time string


### PR DESCRIPTION
Closes https://github.com/babylonlabs-io/babylon-toolkit/issues/2059

<img width="2032" height="1162" alt="Screenshot_2026-07-22_13-29-14" src="https://github.com/user-attachments/assets/3ad71dfa-6d17-4efa-be93-8f8eb3563929" />

<img width="2032" height="1162" alt="Screenshot_2026-07-22_13-38-30" src="https://github.com/user-attachments/assets/f0c7a59a-87d7-42ae-92aa-95fa0d08710a" />

<img width="1988" height="1118" alt="Screenshot_2026-07-22_13-34-31" src="https://github.com/user-attachments/assets/00e362f6-c982-4385-83e1-567a42026ee9" />

Mocked data with partially liquidated from v2

<img width="2032" height="1162" alt="Screenshot_2026-07-22_13-45-36" src="https://github.com/user-attachments/assets/5331cba5-4de1-48da-8808-622461a70b07" />

## What this does

Restyles the existing `/activity` page to the new v3 ("premium") look, behind the existing `NEXT_PUBLIC_FF_ENABLE_V3_UI` feature flag. With the flag off nothing changes — the same page renders exactly as it does today (v2). With the flag on, `/activity` gets the v3 treatment.

The v3 page shows, for a connected user with history:
- A **"Show all"** filter to narrow by transaction type (same options and behavior as today).
- Transactions grouped under **date headers** — "Today", "Yesterday", or an explicit date like `2025-09-08`.
- A **row per transaction** with the token icon + amount, a **status** (In use / Done / Pending / Expired), the type (Deposit / Borrow / Repay / …), a transaction-hash link with a copy button, and the time.
- **Empty / connected-empty / disconnected / loading / filtered-empty** states, all in the v3 card style.

This is a presentation change only. It reuses the exact same activity data the page already loads (`useActivitiesWithPending`) — no change to how activity is fetched, merged, ordered, or linked.

## Why

v3 is a UI restructure that gives each section of the old dashboard its own page and look. Activity is one of those pages. The rule for this rollout (the flag is being removed shortly) is the same as the earlier Loans page: **reuse the data and flows we already have, ship the restyle, and file follow-up tickets for anything that would be a big new build.**

## Approach and why we chose it

**Flag-branch the existing components instead of forking the page.** `/activity` is not flag-guarded — the same route renders in both v2 and v3 — so v2 must keep working while the flag is off (an explicit acceptance criterion). We branched the shared components on the flag (the list already did this for its heading) and added one new v3-only row component (`ActivityRowV3`) so the v2 row is left completely untouched. When the flag is deleted later, the v2 branches drop out and the v3 path becomes the only one. The alternative — a second parallel Activity page — would have duplicated the data wiring and the filter/empty-state logic for no real gain.

**Derive the status from data we already have, instead of building a new status system.** Figma shows a status on every row (In use, Done, Pending, Expired, and liquidation states). Our activity rows only carry "is it pending" and "is it expired". Rather than wire in new position/vault state, we map the status from the row type: pending → Pending, expired → Expired, a settled deposit → In use, and every other settled action (borrow / repay / withdraw / redeem) → Done. This matches the Figma vocabulary using only current data. The one trade-off: "In use" reflects the deposit action, not a live check that the collateral is still locked — a precise version is tracked in the follow-up below.

**Group by date with a small pure helper.** There was no date-grouping utility, so we added two small pure functions (`formatActivityDateGroup`, `formatActivityTime`) next to the existing date formatter and unit-tested them. Grouping keeps the existing newest-first order.

**Use a CSS grid for the row so columns line up.** A first pass used flexbox, which let a long amount (e.g. `0.00705306 WBTC`) push the later columns out of alignment with shorter rows. Switching the row to a shared grid template makes every row's columns line up regardless of amount length.

**Reuse the shared empty state.** The Figma "no activity yet" screen is exactly the shared `EmptyState` component (icon + text + orange Deposit button) already used by the v3 Loans page, so the v3 empty / disconnected / filtered states reuse it rather than the old bespoke one.

## Not included (follow-up tickets)

Some things in the Figma frame are not backed by our current activity data, so they were intentionally left out. Each is tracked as its own issue:
- **Liquidation rows** ("Partially liquidated" / "Fully liquidated" flat rows) — still render through the legacy, unrestyled liquidation card; overlaps with the separate Liquidation Dashboard work (https://github.com/babylonlabs-io/babylon-toolkit/issues/2043). Tracked in https://github.com/babylonlabs-io/babylon-toolkit/issues/2112.
- **Per-row USD value** under the amount — `ActivityLog` carries no USD; needs a price-source decision. Tracked in https://github.com/babylonlabs-io/babylon-toolkit/issues/2114.
- **Per-row Withdraw button** on expired deposits — activity rows have no per-row action today. Tracked in https://github.com/babylonlabs-io/babylon-toolkit/issues/2115.
- **A live "In use" vs "withdrawn" status** for deposits — see the status trade-off above. Tracked in https://github.com/babylonlabs-io/babylon-toolkit/issues/2116.

## Testing

- `pnpm --filter vault run lint` — clean.
- `pnpm --filter vault run test` — full suite passes; added tests for the date/time helpers, the v3 row (statuses, alignment, hash), the v3 date grouping, and the v3 empty state. (Note: `NotificationCard.test.tsx` has 3 failures that already exist on `main` and are unrelated to this change.)
- `tsc --noEmit` — clean.
- Manual, flag on: Today / Yesterday / older date groups; In use / Done / Pending / Expired statuses; filter, filtered-empty, connected-empty, disconnected, and loading states; explorer links and the copy button; light and dark themes. Flag off: v2 activity page unchanged.

Note for local runs: rebuild `core-ui` first (`pnpm --filter @babylonlabs-io/core-ui build`) so the built package is current.
