### PR TITLE
fix(vault): make the Aave repay flow tolerant of lagging RPC backends

### DIFF
--- a/services/vault/e2e/real/actions/repay.ts
+++ b/services/vault/e2e/real/actions/repay.ts
@@ -10,10 +10,11 @@
  * The repay flow is short but has two shapes the CLI must handle that borrow doesn't:
  *   - A depositor with exactly ONE loan is routed straight to the repay form; only MULTIPLE loans open
  *     the "Select asset" picker. So after clicking Repay we wait for EITHER the picker OR the form.
- *   - Repaying can take ONE to THREE MetaMask transactions (rarely FOUR): an ERC-20 approve of the
- *     debt token to the adapter (only when the current allowance is insufficient; USDT-style tokens
- *     add a reset-to-zero first), then the repay — and the stale-RPC retry can force one extra
- *     approve. The CTA reads "Processing…" throughout; the pop-up approver confirms whatever appears.
+ *   - Repaying can take ONE to THREE MetaMask transactions: an ERC-20 approve of the debt token to
+ *     the adapter (only when the current allowance is insufficient; USDT-style tokens add a
+ *     reset-to-zero first), then the repay. The stale-RPC retry's forced approve only fires when no
+ *     initial approve ran, so three is the ceiling either way. The CTA reads "Processing…"
+ *     throughout; the pop-up approver confirms whatever appears.
  *
  * Selectors are testid-first (added to the src repay controls, mirroring borrow) with tolerant
  * text/role/class fallbacks. No SDK / product logic is reimplemented — the amount is a best-effort

--- a/services/vault/e2e/real/actions/repay.ts
+++ b/services/vault/e2e/real/actions/repay.ts
@@ -10,9 +10,10 @@
  * The repay flow is short but has two shapes the CLI must handle that borrow doesn't:
  *   - A depositor with exactly ONE loan is routed straight to the repay form; only MULTIPLE loans open
  *     the "Select asset" picker. So after clicking Repay we wait for EITHER the picker OR the form.
- *   - Repaying can take ONE or TWO MetaMask transactions: an ERC-20 approve of the debt token to the
- *     adapter (only when the current allowance is insufficient), then the repay. The CTA reads
- *     "Processing…" across both; the pop-up approver confirms whatever appears.
+ *   - Repaying can take ONE to THREE MetaMask transactions (rarely FOUR): an ERC-20 approve of the
+ *     debt token to the adapter (only when the current allowance is insufficient; USDT-style tokens
+ *     add a reset-to-zero first), then the repay — and the stale-RPC retry can force one extra
+ *     approve. The CTA reads "Processing…" throughout; the pop-up approver confirms whatever appears.
  *
  * Selectors are testid-first (added to the src repay controls, mirroring borrow) with tolerant
  * text/role/class fallbacks. No SDK / product logic is reimplemented — the amount is a best-effort

--- a/services/vault/src/applications/aave/clients/__tests__/transaction.test.ts
+++ b/services/vault/src/applications/aave/clients/__tests__/transaction.test.ts
@@ -1,0 +1,91 @@
+import { encodeErrorResult } from "viem";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  ContractError,
+  ErrorCode,
+  isSimulationPhaseError,
+} from "@/utils/errors";
+
+const { mockPublicClient } = vi.hoisted(() => ({
+  mockPublicClient: {
+    call: vi.fn(),
+    getTransaction: vi.fn(),
+  },
+}));
+
+vi.mock("../../../../clients/eth-contract/client", () => ({
+  ethClient: { getPublicClient: () => mockPublicClient },
+}));
+
+vi.mock("@/config/network", () => ({
+  getETHChain: () => ({ id: 1 }),
+}));
+
+import { repayToCorePosition } from "../transaction";
+
+const ERC20_INSUFFICIENT_ALLOWANCE_ABI = [
+  {
+    type: "error",
+    name: "ERC20InsufficientAllowance",
+    inputs: [
+      { name: "spender", type: "address" },
+      { name: "allowance", type: "uint256" },
+      { name: "needed", type: "uint256" },
+    ],
+  },
+] as const;
+
+const walletClient = {
+  chain: { id: 1 },
+  account: { address: "0x2000000000000000000000000000000000000002" },
+  sendTransaction: vi.fn(),
+} as any;
+
+const repayCall = () =>
+  repayToCorePosition(
+    walletClient,
+    { id: 1 } as any,
+    "0x3000000000000000000000000000000000000003",
+    "0x2000000000000000000000000000000000000002",
+    0n,
+    3n,
+  );
+
+describe("executeTx simulation-phase tagging (via repayToCorePosition)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("tags a simulation allowance revert and decodes its reason — the exact shape the repay retry keys on", async () => {
+    // An eth_call revert carrying the OZ-v5 custom error data, as a
+    // JSON-RPC-shaped error object with the revert hex on `data`.
+    const revertData = encodeErrorResult({
+      abi: ERC20_INSUFFICIENT_ALLOWANCE_ABI,
+      errorName: "ERC20InsufficientAllowance",
+      args: ["0x3000000000000000000000000000000000000003", 2n, 3n],
+    });
+    mockPublicClient.call.mockRejectedValue(
+      Object.assign(new Error("execution reverted"), { data: revertData }),
+    );
+
+    const thrown = await repayCall().catch((e: unknown) => e);
+
+    expect(thrown).toBeInstanceOf(ContractError);
+    expect(isSimulationPhaseError(thrown)).toBe(true);
+    expect((thrown as ContractError).code).toBe(ErrorCode.CONTRACT_REVERT);
+    expect((thrown as ContractError).reason).toBe("ERC20InsufficientAllowance");
+    // Nothing was signed or broadcast.
+    expect(walletClient.sendTransaction).not.toHaveBeenCalled();
+  });
+
+  it("does not tag a post-simulation send failure", async () => {
+    mockPublicClient.call.mockResolvedValue({});
+    walletClient.sendTransaction.mockRejectedValue(new Error("nonce too low"));
+
+    const thrown = await repayCall().catch((e: unknown) => e);
+
+    expect(thrown).toBeInstanceOf(ContractError);
+    expect(isSimulationPhaseError(thrown)).toBe(false);
+  });
+});

--- a/services/vault/src/applications/aave/clients/__tests__/transaction.test.ts
+++ b/services/vault/src/applications/aave/clients/__tests__/transaction.test.ts
@@ -10,7 +10,6 @@ import {
 const { mockPublicClient } = vi.hoisted(() => ({
   mockPublicClient: {
     call: vi.fn(),
-    getTransaction: vi.fn(),
   },
 }));
 

--- a/services/vault/src/applications/aave/clients/transaction.ts
+++ b/services/vault/src/applications/aave/clients/transaction.ts
@@ -23,7 +23,10 @@ import {
   throwRevertError,
   type TransactionResult,
 } from "../../../clients/eth-contract/transactionFactory";
-import { mapViemErrorToContractError } from "../../../utils/errors";
+import {
+  mapViemErrorToContractError,
+  tagSimulationPhase,
+} from "../../../utils/errors";
 
 /**
  * Read the Core Spoke address from the controller contract.
@@ -103,7 +106,18 @@ async function executeTx(
   try {
     // Pre-flight simulation - catches errors before user signs
     await simulateTx(to, data, account);
+  } catch (error) {
+    // Tagged so callers can safely auto-retry: nothing was signed or sent,
+    // and the failure may be a lagging RPC backend, not the chain.
+    throw tagSimulationPhase(
+      mapViemErrorToContractError(error, errorContext, [
+        AaveIntegrationAdapterABI,
+        BTCVaultRegistryABI,
+      ]),
+    );
+  }
 
+  try {
     // Simulation passed, now send the actual transaction
     const hash = await walletClient.sendTransaction({
       to,

--- a/services/vault/src/applications/aave/hooks/useRepayTransaction.ts
+++ b/services/vault/src/applications/aave/hooks/useRepayTransaction.ts
@@ -183,6 +183,7 @@ export function useRepayTransaction({
           reserve.reserveId,
           reserve.token.address,
           proxyContract as Address,
+          reserve.token,
         );
       } else if (mode === "max-capped") {
         // max-capped requires the caller-supplied exact bigint. The float
@@ -203,6 +204,7 @@ export function useRepayTransaction({
           reserve.reserveId,
           reserve.token.address,
           repayAmountRaw,
+          reserve.token,
         );
       } else {
         // partial path: convert the user-typed float to bigint. Float rounding
@@ -229,6 +231,7 @@ export function useRepayTransaction({
           reserve.reserveId,
           reserve.token.address,
           amountBigInt,
+          reserve.token,
         );
       }
 

--- a/services/vault/src/applications/aave/services/__tests__/positionTransactions.test.ts
+++ b/services/vault/src/applications/aave/services/__tests__/positionTransactions.test.ts
@@ -57,6 +57,8 @@ vi.mock("@/infrastructure", () => ({
   logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), event: vi.fn() },
 }));
 
+import { logger } from "@/infrastructure";
+
 import {
   ContractError,
   ErrorCode,
@@ -721,10 +723,11 @@ describe("positionTransactions", () => {
       const amount = 1000000n;
       const FOREIGN_TOKEN = "0x9000000000000000000000000000000000000009";
       const OTHER_SPENDER = "0x4000000000000000000000000000000000000004";
-      // A Safe-style batched receipt: a foreign token's Approval, an
-      // ERC-721-shaped Approval (3 indexed topics, empty data), a
-      // wrong-spender Approval, then two matching logs where only the LAST
-      // reflects the final state.
+      const OTHER_OWNER = "0x5000000000000000000000000000000000000005";
+      // A Safe-style batched receipt. Hostile sufficient-value logs sit both
+      // BEFORE and AFTER the matching pair: dropping any filter predicate
+      // (token, owner, spender) makes a trailing hostile log the last match
+      // and flips this test's outcome — each predicate is load-bearing.
       const erc721StyleLog = {
         address: TOKEN,
         topics: [
@@ -755,6 +758,25 @@ describe("positionTransactions", () => {
             },
             approvalLog(amount),
             approvalLog(amount - 1n),
+            { ...approvalLog(amount * 10n), address: FOREIGN_TOKEN },
+            {
+              address: TOKEN,
+              topics: encodeEventTopics({
+                abi: APPROVAL_EVENT_ABI,
+                eventName: "Approval",
+                args: { owner: OWNER, spender: OTHER_SPENDER },
+              }),
+              data: numberToHex(amount * 10n, { size: 32 }),
+            },
+            {
+              address: TOKEN,
+              topics: encodeEventTopics({
+                abi: APPROVAL_EVENT_ABI,
+                eventName: "Approval",
+                args: { owner: OTHER_OWNER, spender: ADAPTER },
+              }),
+              data: numberToHex(amount * 10n, { size: 32 }),
+            },
           ],
         },
       });
@@ -856,6 +878,8 @@ describe("positionTransactions", () => {
 
         expect(mockRepayToCorePosition).toHaveBeenCalledTimes(2);
         expect(mockApproveERC20).not.toHaveBeenCalled();
+        // Each absorbed retry is observable — the rescue must not be silent.
+        expect(logger.warn).toHaveBeenCalledTimes(1);
       } finally {
         vi.useRealTimers();
       }

--- a/services/vault/src/applications/aave/services/__tests__/positionTransactions.test.ts
+++ b/services/vault/src/applications/aave/services/__tests__/positionTransactions.test.ts
@@ -53,6 +53,10 @@ vi.mock("../../config", () => ({
   getAaveAdapterAddress: vi.fn(() => "0xadapter"),
 }));
 
+vi.mock("@/infrastructure", () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), event: vi.fn() },
+}));
+
 import {
   ContractError,
   ErrorCode,
@@ -122,6 +126,9 @@ describe("positionTransactions", () => {
     mockRepayToCorePosition.mockResolvedValue(mockTxResult);
     mockWithdrawCollaterals.mockResolvedValue(mockTxResult);
     mockGetCoreSpokeAddress.mockResolvedValue("0xspoke");
+    // vi.clearAllMocks does not clear mockReturnValue overrides; pin the
+    // default so per-describe overrides can't leak into later suites.
+    (getAaveAdapterAddress as Mock).mockReturnValue("0xadapter");
   });
 
   // ============================================================================
@@ -709,6 +716,102 @@ describe("positionTransactions", () => {
       expect(mockGetERC20Allowance).toHaveBeenCalledTimes(1);
       expect(mockRepayToCorePosition).not.toHaveBeenCalled();
     });
+
+    it("ignores foreign and mismatched logs and verifies from the LAST matching Approval", async () => {
+      const amount = 1000000n;
+      const FOREIGN_TOKEN = "0x9000000000000000000000000000000000000009";
+      const OTHER_SPENDER = "0x4000000000000000000000000000000000000004";
+      // A Safe-style batched receipt: a foreign token's Approval, an
+      // ERC-721-shaped Approval (3 indexed topics, empty data), a
+      // wrong-spender Approval, then two matching logs where only the LAST
+      // reflects the final state.
+      const erc721StyleLog = {
+        address: TOKEN,
+        topics: [
+          ...encodeEventTopics({
+            abi: APPROVAL_EVENT_ABI,
+            eventName: "Approval",
+            args: { owner: OWNER, spender: ADAPTER },
+          }),
+          numberToHex(7n, { size: 32 }),
+        ],
+        data: "0x",
+      };
+      mockApproveERC20.mockResolvedValue({
+        transactionHash: "0xhash",
+        receipt: {
+          status: "success",
+          logs: [
+            { ...approvalLog(amount * 10n), address: FOREIGN_TOKEN },
+            erc721StyleLog,
+            {
+              address: TOKEN,
+              topics: encodeEventTopics({
+                abi: APPROVAL_EVENT_ABI,
+                eventName: "Approval",
+                args: { owner: OWNER, spender: OTHER_SPENDER },
+              }),
+              data: numberToHex(amount * 10n, { size: 32 }),
+            },
+            approvalLog(amount),
+            approvalLog(amount - 1n),
+          ],
+        },
+      });
+
+      await expect(
+        repayPartial(
+          ownerWallet,
+          mockChain,
+          1n,
+          TOKEN as any,
+          amount,
+          mockToken,
+        ),
+      ).rejects.toThrow(/approved a lower amount than required/i);
+
+      // Verified from the last MATCHING log (amount - 1n), not the foreign,
+      // ERC-721-shaped, wrong-spender, or earlier sufficient logs.
+      expect(mockRepayToCorePosition).not.toHaveBeenCalled();
+      expect(mockGetERC20Allowance).toHaveBeenCalledTimes(1);
+    });
+
+    it("recovers when the fallback allowance re-read succeeds on a later attempt", async () => {
+      vi.useFakeTimers();
+      try {
+        const amount = 1000000n;
+        // No Approval event in the receipt (e.g. wallet-replaced tx) and the
+        // first verification read is still stale; the second sees the value.
+        mockApproveERC20.mockResolvedValue({
+          transactionHash: "0xhash",
+          receipt: { status: "success", logs: [] },
+        });
+        mockGetERC20Allowance.mockReset();
+        mockGetERC20Allowance
+          .mockResolvedValueOnce(0n) // pre-approve short-circuit check
+          .mockResolvedValueOnce(0n) // verification attempt 1 (stale)
+          .mockResolvedValue(amount); // verification attempt 2
+
+        const result = repayPartial(
+          ownerWallet,
+          mockChain,
+          1n,
+          TOKEN as any,
+          amount,
+          mockToken,
+        );
+        const assertion = expect(result).resolves.toMatchObject({
+          transactionHash: "0xhash",
+        });
+        await vi.runAllTimersAsync();
+        await assertion;
+
+        expect(mockGetERC20Allowance).toHaveBeenCalledTimes(3);
+        expect(mockRepayToCorePosition).toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 
   // ============================================================================
@@ -817,12 +920,12 @@ describe("positionTransactions", () => {
       expect(mockRepayToCorePosition).toHaveBeenCalledTimes(1);
     });
 
-    it("gives up after the retry budget when the approve was already sent", async () => {
+    it("gives up after three attempts when the approve was already sent", async () => {
       vi.useFakeTimers();
       try {
         // Allowance starts short, so ensureAllowance sends the approve; a
-        // forced re-approve could not change anything, so after the plain
-        // retry the error propagates.
+        // forced re-approve could not change anything, so the third attempt
+        // is a plain re-simulation and then the error propagates.
         mockRepayToCorePosition.mockRejectedValue(staleSimulationError());
 
         const result = repayPartial(
@@ -837,8 +940,56 @@ describe("positionTransactions", () => {
         await vi.runAllTimersAsync();
         await assertion;
 
-        expect(mockRepayToCorePosition).toHaveBeenCalledTimes(2);
+        expect(mockRepayToCorePosition).toHaveBeenCalledTimes(3);
         expect(mockApproveERC20).toHaveBeenCalledTimes(1);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("forces the balance-cap approve amount for repayMaxCapped on the short-circuit path", async () => {
+      vi.useFakeTimers();
+      try {
+        const balanceAmount = 1500000n;
+        setSimulatedAllowance(balanceAmount);
+        mockRepayToCorePosition
+          .mockRejectedValueOnce(staleSimulationError())
+          .mockRejectedValueOnce(staleSimulationError())
+          .mockResolvedValue(mockTxResult);
+
+        const result = repayMaxCapped(
+          mockWalletClient,
+          mockChain,
+          1n,
+          "0xtoken" as any,
+          balanceAmount,
+          mockToken,
+        );
+        const assertion = expect(result).resolves.toMatchObject({
+          transactionHash: "0xhash",
+        });
+        await vi.runAllTimersAsync();
+        await assertion;
+
+        // The forced approve re-approves the balance cap, not maxUint256.
+        expect(mockApproveERC20).toHaveBeenCalledTimes(1);
+        expect(mockApproveERC20).toHaveBeenCalledWith(
+          mockWalletClient,
+          mockChain,
+          "0xtoken",
+          "0xadapter",
+          balanceAmount,
+        );
+        expect(mockRepayToCorePosition).toHaveBeenCalledTimes(3);
+        // Every attempt sends the repay-all sentinel.
+        expect(mockRepayToCorePosition).toHaveBeenLastCalledWith(
+          mockWalletClient,
+          mockChain,
+          "0xadapter",
+          "0xuser",
+          1n,
+          maxUint256,
+        );
       } finally {
         vi.useRealTimers();
       }

--- a/services/vault/src/applications/aave/services/__tests__/positionTransactions.test.ts
+++ b/services/vault/src/applications/aave/services/__tests__/positionTransactions.test.ts
@@ -2,8 +2,8 @@
  * Tests for Aave position transactions.
  */
 
-import { maxUint256 } from "viem";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { encodeEventTopics, maxUint256, numberToHex } from "viem";
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
 
 // Hoist mock functions so they can be used in vi.mock factories
 const {
@@ -53,6 +53,12 @@ vi.mock("../../config", () => ({
   getAaveAdapterAddress: vi.fn(() => "0xadapter"),
 }));
 
+import {
+  ContractError,
+  ErrorCode,
+  tagSimulationPhase,
+} from "../../../../utils/errors";
+import { getAaveAdapterAddress } from "../../config";
 import { FULL_REPAY_BUFFER_DIVISOR } from "../../constants";
 import {
   borrow,
@@ -70,15 +76,21 @@ describe("positionTransactions", () => {
 
   const mockChain = { id: 1 } as any;
 
+  const mockToken = { symbol: "USDC", decimals: 6 };
+
+  // `logs: []` routes ensureAllowance's verification to the fallback
+  // allowance re-read (no Approval event to parse); event-path behavior is
+  // covered by the dedicated approval-verification tests below.
   const mockTxResult = {
     transactionHash: "0xhash",
-    receipt: { status: "success" },
+    receipt: { status: "success", logs: [] },
   };
 
   // Shared mutable allowance state — simulates the on-chain allowance moving
-  // from its starting value to the just-approved amount. `ensureAllowance`
-  // verifies the post-approve allowance, so the mock must reflect that
-  // transition or every test would throw "Approval did not take effect".
+  // from its starting value to the just-approved amount. The fallback
+  // verification re-reads it (the shared mock receipt has no Approval event),
+  // so the mock must reflect that transition or every test would throw the
+  // approval-not-confirmed error.
   let simulatedAllowance: bigint;
 
   /**
@@ -207,6 +219,7 @@ describe("positionTransactions", () => {
         1n,
         "0xtoken" as any,
         amount,
+        mockToken,
       );
 
       // Should check allowance against the pinned adapter address
@@ -239,6 +252,7 @@ describe("positionTransactions", () => {
         1n,
         "0xtoken" as any,
         amount,
+        mockToken,
       );
 
       expect(mockApproveERC20).not.toHaveBeenCalled();
@@ -249,7 +263,14 @@ describe("positionTransactions", () => {
       const noAccountWallet = { account: undefined } as any;
 
       await expect(
-        repayPartial(noAccountWallet, mockChain, 1n, "0xtoken" as any, 1000n),
+        repayPartial(
+          noAccountWallet,
+          mockChain,
+          1n,
+          "0xtoken" as any,
+          1000n,
+          mockToken,
+        ),
       ).rejects.toThrow("Wallet address not available");
     });
   });
@@ -270,6 +291,7 @@ describe("positionTransactions", () => {
         1n,
         "0xtoken" as any,
         balanceAmount,
+        mockToken,
       );
 
       // Approve exactly the cap (the user's balance), not cap × (1+buffer).
@@ -303,6 +325,7 @@ describe("positionTransactions", () => {
         1n,
         "0xtoken" as any,
         balanceAmount,
+        mockToken,
       );
 
       expect(mockApproveERC20).not.toHaveBeenCalled();
@@ -318,6 +341,7 @@ describe("positionTransactions", () => {
         1n,
         "0xtoken" as any,
         1_000_000n,
+        mockToken,
       );
 
       expect(mockGetUserTotalDebt).not.toHaveBeenCalled();
@@ -325,7 +349,14 @@ describe("positionTransactions", () => {
 
     it("should throw error when balanceAmount is 0", async () => {
       await expect(
-        repayMaxCapped(mockWalletClient, mockChain, 1n, "0xtoken" as any, 0n),
+        repayMaxCapped(
+          mockWalletClient,
+          mockChain,
+          1n,
+          "0xtoken" as any,
+          0n,
+          mockToken,
+        ),
       ).rejects.toThrow("Repay amount must be greater than 0");
     });
 
@@ -339,6 +370,7 @@ describe("positionTransactions", () => {
           1n,
           "0xtoken" as any,
           1_000n,
+          mockToken,
         ),
       ).rejects.toThrow("Wallet address not available");
     });
@@ -368,6 +400,7 @@ describe("positionTransactions", () => {
         1n,
         "0xtoken" as any,
         "0xproxy" as any,
+        mockToken,
       );
 
       // Verify approval is for exact amount, not MAX_UINT256, to the pinned adapter address
@@ -387,6 +420,7 @@ describe("positionTransactions", () => {
         1n,
         "0xtoken" as any,
         "0xproxy" as any,
+        mockToken,
       );
 
       expect(mockGetUserTotalDebt).toHaveBeenCalledWith(
@@ -408,6 +442,7 @@ describe("positionTransactions", () => {
         1n,
         "0xtoken" as any,
         "0xproxy" as any,
+        mockToken,
       );
 
       expect(mockApproveERC20).not.toHaveBeenCalled();
@@ -423,6 +458,7 @@ describe("positionTransactions", () => {
           1n,
           "0xtoken" as any,
           "0xproxy" as any,
+          mockToken,
         ),
       ).rejects.toThrow("No debt to repay");
     });
@@ -437,34 +473,45 @@ describe("positionTransactions", () => {
           1n,
           "0xtoken" as any,
           "0xproxy" as any,
+          mockToken,
         ),
       ).rejects.toThrow(
         "insufficient balance to fully repay: not enough stablecoin to cover the debt plus interest",
       );
     });
 
-    it("throws when post-approve allowance verification fails (RPC lag defense)", async () => {
-      // Override the global simulation: approveERC20 succeeds but the
-      // on-chain allowance state doesn't update — this is what a stale RPC
-      // response (the bug we're defending against) looks like to the caller.
-      // ensureAllowance should catch it pre-broadcast and surface a clear
-      // error instead of letting the user sign a doomed repay tx.
-      mockApproveERC20.mockReset();
-      mockApproveERC20.mockResolvedValue(mockTxResult);
+    it("throws when the fallback allowance verification exhausts its retries", async () => {
+      // approveERC20 succeeds but its receipt carries no Approval event and
+      // every allowance read keeps returning the stale pre-approve value —
+      // the flow retries the read a bounded number of times, then surfaces a
+      // clear error instead of letting the user sign a doomed repay tx.
+      vi.useFakeTimers();
+      try {
+        mockApproveERC20.mockReset();
+        mockApproveERC20.mockResolvedValue(mockTxResult);
 
-      await expect(
-        repayFull(
+        const result = repayFull(
           mockWalletClient,
           mockChain,
           1n,
           "0xtoken" as any,
           "0xproxy" as any,
-        ),
-      ).rejects.toThrow(/Approval did not take effect/);
+          mockToken,
+        );
+        const assertion = expect(result).rejects.toThrow(
+          /approval could not be confirmed/i,
+        );
+        await vi.runAllTimersAsync();
+        await assertion;
 
-      // Crucially, the repay was never broadcast — the user would have signed
-      // a doomed tx if we'd skipped the verification.
-      expect(mockRepayToCorePosition).not.toHaveBeenCalled();
+        // Bounded budget: 1 short-circuit read + exactly 3 verification reads.
+        expect(mockGetERC20Allowance).toHaveBeenCalledTimes(4);
+        // Crucially, the repay was never broadcast — the user would have
+        // signed a doomed tx if we'd skipped the verification.
+        expect(mockRepayToCorePosition).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it("should throw error when wallet has no account", async () => {
@@ -477,6 +524,7 @@ describe("positionTransactions", () => {
           1n,
           "0xtoken" as any,
           "0xproxy" as any,
+          mockToken,
         ),
       ).rejects.toThrow("Wallet address not available");
     });
@@ -496,6 +544,7 @@ describe("positionTransactions", () => {
           1n,
           "0xtoken" as any,
           "0xproxy" as any,
+          mockToken,
         );
       };
 
@@ -576,6 +625,223 @@ describe("positionTransactions", () => {
         vaultIds,
       );
       expect(result.transactionHash).toBe("0xhash");
+    });
+  });
+
+  // ============================================================================
+  // approval verification from the approve receipt's Approval event
+  // ============================================================================
+  describe("receipt-event approval verification", () => {
+    const TOKEN = "0x1000000000000000000000000000000000000001";
+    const OWNER = "0x2000000000000000000000000000000000000002";
+    const ADAPTER = "0x3000000000000000000000000000000000000003";
+
+    const APPROVAL_EVENT_ABI = [
+      {
+        type: "event",
+        name: "Approval",
+        inputs: [
+          { indexed: true, name: "owner", type: "address" },
+          { indexed: true, name: "spender", type: "address" },
+          { indexed: false, name: "value", type: "uint256" },
+        ],
+      },
+    ] as const;
+
+    const approvalLog = (value: bigint) => ({
+      address: TOKEN,
+      topics: encodeEventTopics({
+        abi: APPROVAL_EVENT_ABI,
+        eventName: "Approval",
+        args: { owner: OWNER, spender: ADAPTER },
+      }),
+      data: numberToHex(value, { size: 32 }),
+    });
+
+    const ownerWallet = { account: { address: OWNER } } as any;
+
+    beforeEach(() => {
+      (getAaveAdapterAddress as Mock).mockReturnValue(ADAPTER);
+      mockGetERC20Balance.mockResolvedValue(2000000n);
+    });
+
+    it("verifies from the receipt's Approval event without re-reading allowance", async () => {
+      const amount = 1000000n;
+      mockApproveERC20.mockResolvedValue({
+        transactionHash: "0xhash",
+        receipt: { status: "success", logs: [approvalLog(amount)] },
+      });
+
+      await repayPartial(
+        ownerWallet,
+        mockChain,
+        1n,
+        TOKEN as any,
+        amount,
+        mockToken,
+      );
+
+      // Exactly one allowance read: the pre-approve short-circuit check.
+      // The verification came from the receipt, immune to stale RPC reads.
+      expect(mockGetERC20Allowance).toHaveBeenCalledTimes(1);
+      expect(mockRepayToCorePosition).toHaveBeenCalled();
+    });
+
+    it("rejects without retries when the approved value is below the requirement", async () => {
+      // e.g. the user edited the wallet's spending cap below the repay amount.
+      const amount = 1000000n;
+      mockApproveERC20.mockResolvedValue({
+        transactionHash: "0xhash",
+        receipt: { status: "success", logs: [approvalLog(amount - 1n)] },
+      });
+
+      await expect(
+        repayPartial(
+          ownerWallet,
+          mockChain,
+          1n,
+          TOKEN as any,
+          amount,
+          mockToken,
+        ),
+      ).rejects.toThrow(/approved a lower amount than required/i);
+
+      expect(mockGetERC20Allowance).toHaveBeenCalledTimes(1);
+      expect(mockRepayToCorePosition).not.toHaveBeenCalled();
+    });
+  });
+
+  // ============================================================================
+  // stale-simulation repay retry
+  // ============================================================================
+  describe("stale-simulation repay retry", () => {
+    const staleSimulationError = () =>
+      tagSimulationPhase(
+        new ContractError(
+          "execution reverted",
+          ErrorCode.CONTRACT_REVERT,
+          undefined,
+          "ERC20InsufficientAllowance",
+        ),
+      );
+
+    beforeEach(() => {
+      mockGetERC20Balance.mockResolvedValue(2000000n);
+    });
+
+    it("retries once after a stale simulation revert when the approve was short-circuited", async () => {
+      vi.useFakeTimers();
+      try {
+        setSimulatedAllowance(2000000n);
+        mockRepayToCorePosition
+          .mockRejectedValueOnce(staleSimulationError())
+          .mockResolvedValue(mockTxResult);
+
+        const result = repayPartial(
+          mockWalletClient,
+          mockChain,
+          1n,
+          "0xtoken" as any,
+          1000000n,
+          mockToken,
+        );
+        const assertion = expect(result).resolves.toMatchObject({
+          transactionHash: "0xhash",
+        });
+        await vi.runAllTimersAsync();
+        await assertion;
+
+        expect(mockRepayToCorePosition).toHaveBeenCalledTimes(2);
+        expect(mockApproveERC20).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("forces an approve after a second stale failure on the short-circuit path", async () => {
+      vi.useFakeTimers();
+      try {
+        // The stale-HIGH read scenario: the short-circuit saw enough
+        // allowance, but the chain disagrees on every simulation.
+        setSimulatedAllowance(2000000n);
+        mockRepayToCorePosition
+          .mockRejectedValueOnce(staleSimulationError())
+          .mockRejectedValueOnce(staleSimulationError())
+          .mockResolvedValue(mockTxResult);
+
+        const result = repayPartial(
+          mockWalletClient,
+          mockChain,
+          1n,
+          "0xtoken" as any,
+          1000000n,
+          mockToken,
+        );
+        const assertion = expect(result).resolves.toMatchObject({
+          transactionHash: "0xhash",
+        });
+        await vi.runAllTimersAsync();
+        await assertion;
+
+        expect(mockRepayToCorePosition).toHaveBeenCalledTimes(3);
+        expect(mockApproveERC20).toHaveBeenCalledTimes(1);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("does not retry a mined allowance revert", async () => {
+      setSimulatedAllowance(2000000n);
+      // Same decoded reason but NOT simulation-tagged: the tx was broadcast
+      // and reverted on-chain. Auto-retrying would re-prompt the wallet.
+      mockRepayToCorePosition.mockRejectedValue(
+        new ContractError(
+          "execution reverted",
+          ErrorCode.CONTRACT_REVERT,
+          undefined,
+          "ERC20InsufficientAllowance",
+        ),
+      );
+
+      await expect(
+        repayPartial(
+          mockWalletClient,
+          mockChain,
+          1n,
+          "0xtoken" as any,
+          1000000n,
+          mockToken,
+        ),
+      ).rejects.toThrow("execution reverted");
+
+      expect(mockRepayToCorePosition).toHaveBeenCalledTimes(1);
+    });
+
+    it("gives up after the retry budget when the approve was already sent", async () => {
+      vi.useFakeTimers();
+      try {
+        // Allowance starts short, so ensureAllowance sends the approve; a
+        // forced re-approve could not change anything, so after the plain
+        // retry the error propagates.
+        mockRepayToCorePosition.mockRejectedValue(staleSimulationError());
+
+        const result = repayPartial(
+          mockWalletClient,
+          mockChain,
+          1n,
+          "0xtoken" as any,
+          1000000n,
+          mockToken,
+        );
+        const assertion = expect(result).rejects.toThrow("execution reverted");
+        await vi.runAllTimersAsync();
+        await assertion;
+
+        expect(mockRepayToCorePosition).toHaveBeenCalledTimes(2);
+        expect(mockApproveERC20).toHaveBeenCalledTimes(1);
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 });

--- a/services/vault/src/applications/aave/services/positionTransactions.ts
+++ b/services/vault/src/applications/aave/services/positionTransactions.ts
@@ -16,6 +16,7 @@ import type {
 import { formatUnits, isAddressEqual, maxUint256, parseEventLogs } from "viem";
 
 import { COPY } from "@/copy";
+import { logger } from "@/infrastructure";
 
 import { ERC20 } from "../../../clients/eth-contract";
 import { ErrorCode, isSimulationPhaseError } from "../../../utils/errors";
@@ -253,11 +254,13 @@ function isStaleAllowanceSimulationError(err: unknown): boolean {
 }
 
 /**
- * Run the repay, absorbing stale-backend allowance reverts at simulation: one
- * plain delayed retry first; if the approve was short-circuited (a stale HIGH
- * allowance read can skip a genuinely needed approve), force the approve
- * before the final attempt. Mined reverts and all other errors propagate
- * untouched — auto-retrying a broadcast tx would re-prompt the wallet.
+ * Run the repay, absorbing stale-backend allowance reverts at simulation:
+ * three attempts with catch-up delays on every path. When the approve was
+ * short-circuited (a stale HIGH allowance read can skip a genuinely needed
+ * approve), the second failure forces the approve before the last attempt; a
+ * receipt-verified approve can't be improved on, so that path just
+ * re-simulates. Mined reverts and all other errors propagate untouched —
+ * auto-retrying a broadcast tx would re-prompt the wallet.
  * Note: repayMaxCapped can revert here legitimately (accrued interest pushed
  * debt past the approved balance cap); the retries just delay that error.
  */
@@ -272,18 +275,21 @@ async function repayWithStaleSimulationRetry(params: {
     return await execute();
   } catch (firstError) {
     if (!isStaleAllowanceSimulationError(firstError)) throw firstError;
+    logger.warn("Repay simulation saw a stale allowance; retrying", {
+      data: { attempt: 1, approveSent },
+    });
     await wait(REPAY_STALE_SIM_RETRY_DELAY_MS);
   }
 
   try {
     return await execute();
   } catch (secondError) {
-    if (!isStaleAllowanceSimulationError(secondError) || approveSent) {
-      throw secondError;
-    }
-    // Approve was skipped on a possibly stale-high read; force it once, then
-    // give the backends the same catch-up window before the final attempt.
-    await forceApprove();
+    if (!isStaleAllowanceSimulationError(secondError)) throw secondError;
+    logger.warn("Repay simulation saw a stale allowance; retrying", {
+      data: { attempt: 2, approveSent },
+    });
+    // Approve was skipped on a possibly stale-high read; force it once.
+    if (!approveSent) await forceApprove();
     await wait(REPAY_STALE_SIM_RETRY_DELAY_MS);
   }
 

--- a/services/vault/src/applications/aave/services/positionTransactions.ts
+++ b/services/vault/src/applications/aave/services/positionTransactions.ts
@@ -262,7 +262,9 @@ function isStaleAllowanceSimulationError(err: unknown): boolean {
  * re-simulates. Mined reverts and all other errors propagate untouched —
  * auto-retrying a broadcast tx would re-prompt the wallet.
  * Note: repayMaxCapped can revert here legitimately (accrued interest pushed
- * debt past the approved balance cap); the retries just delay that error.
+ * debt past the approved balance cap); indistinguishable from staleness, so
+ * the retries delay that error and the short-circuit branch spends one no-op
+ * forceApprove prompt (plus its gas) before it surfaces — consciously accepted.
  */
 async function repayWithStaleSimulationRetry(params: {
   execute: () => Promise<RepayResult>;

--- a/services/vault/src/applications/aave/services/positionTransactions.ts
+++ b/services/vault/src/applications/aave/services/positionTransactions.ts
@@ -13,9 +13,12 @@ import type {
   TransactionReceipt,
   WalletClient,
 } from "viem";
-import { maxUint256 } from "viem";
+import { formatUnits, isAddressEqual, maxUint256, parseEventLogs } from "viem";
+
+import { COPY } from "@/copy";
 
 import { ERC20 } from "../../../clients/eth-contract";
+import { ErrorCode, isSimulationPhaseError } from "../../../utils/errors";
 import { AaveAdapterTx, AaveSpoke } from "../clients";
 import { getAaveAdapterAddress } from "../config";
 import { FULL_REPAY_BUFFER_DIVISOR } from "../constants";
@@ -95,13 +98,118 @@ export async function repay(
   };
 }
 
+/** Display metadata for the debt token, used only in error copy. */
+interface TokenDisplay {
+  symbol: string;
+  decimals: number;
+}
+
+type RepayResult = { transactionHash: Hash; receipt: TransactionReceipt };
+
+/** Bounded fallback verification when the approve receipt has no usable Approval event. */
+const ALLOWANCE_VERIFY_ATTEMPTS = 3;
+const ALLOWANCE_VERIFY_RETRY_DELAY_MS = 2000;
+
+/** Delay before retrying a repay whose simulation hit a stale backend. */
+const REPAY_STALE_SIM_RETRY_DELAY_MS = 3000;
+
+/** Decoded reason for the OZ allowance revert (always in COMMON_ERROR_ABI). */
+const ERC20_INSUFFICIENT_ALLOWANCE_REASON = "ERC20InsufficientAllowance";
+
+/** Approval event ABI for parsing the approve receipt's logs. */
+const ERC20_APPROVAL_EVENT_ABI = [
+  {
+    type: "event",
+    name: "Approval",
+    inputs: [
+      { indexed: true, name: "owner", type: "address" },
+      { indexed: true, name: "spender", type: "address" },
+      { indexed: false, name: "value", type: "uint256" },
+    ],
+  },
+] as const;
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function formatTokenAmount(amount: bigint, token: TokenDisplay): string {
+  return `${formatUnits(amount, token.decimals)} ${token.symbol}`;
+}
+
 /**
- * Approve if needed, then verify the approval landed on-chain.
- *
- * We've seen the subsequent repay tx revert with `ERC20InsufficientAllowance`
- * after the approve receipt returned cleanly — the public RPC can briefly
- * serve pre-block state, so the next tx executes against a stale allowance.
- * Re-reading turns a revert-after-signing into a pre-broadcast error.
+ * Send the approval and verify it from its own mined receipt's Approval event
+ * — the receipt is chain truth for this tx, immune to a load-balanced RPC
+ * serving pre-block state on a follow-up read. The read-based fallback covers
+ * receipts without a matching event: wallet-replaced txs (cancel / speed-up
+ * resolve to the replacement's receipt) and tokens that don't emit Approval.
+ */
+async function approveAndVerify(
+  walletClient: WalletClient,
+  chain: Chain,
+  tokenAddress: Address,
+  ownerAddress: Address,
+  spenderAddress: Address,
+  requiredAmount: bigint,
+  token: TokenDisplay,
+): Promise<void> {
+  const { receipt } = await ERC20.approveERC20(
+    walletClient,
+    chain,
+    tokenAddress,
+    spenderAddress,
+    requiredAmount,
+  );
+
+  const approvalLogs = parseEventLogs({
+    abi: ERC20_APPROVAL_EVENT_ABI,
+    logs: receipt.logs,
+    eventName: "Approval",
+  });
+  // Last match wins: a Safe batch execution can carry sibling Approval logs.
+  const matched = approvalLogs
+    .filter(
+      (log) =>
+        isAddressEqual(log.address, tokenAddress) &&
+        isAddressEqual(log.args.owner, ownerAddress) &&
+        isAddressEqual(log.args.spender, spenderAddress),
+    )
+    .at(-1);
+
+  if (matched) {
+    if (matched.args.value >= requiredAmount) return;
+    // Deterministic shortfall — e.g. the user edited the wallet's spending
+    // cap below what the repay needs. No retry can fix it.
+    throw new Error(
+      COPY.loans.repay.approvalBelowRequired(
+        formatTokenAmount(requiredAmount, token),
+        formatTokenAmount(matched.args.value, token),
+      ),
+    );
+  }
+
+  let observed = 0n;
+  for (let attempt = 0; attempt < ALLOWANCE_VERIFY_ATTEMPTS; attempt++) {
+    if (attempt > 0) await wait(ALLOWANCE_VERIFY_RETRY_DELAY_MS);
+    observed = await ERC20.getERC20Allowance(
+      tokenAddress,
+      ownerAddress,
+      spenderAddress,
+    );
+    if (observed >= requiredAmount) return;
+  }
+  throw new Error(
+    COPY.loans.repay.approvalNotConfirmed(
+      formatTokenAmount(requiredAmount, token),
+      formatTokenAmount(observed, token),
+    ),
+  );
+}
+
+/**
+ * Ensure the adapter can pull `requiredAmount`, approving when the current
+ * allowance is short. Returns whether an approve was actually sent so the
+ * repay retry can force one if the short-circuit read turns out stale.
  */
 async function ensureAllowance(
   walletClient: WalletClient,
@@ -110,32 +218,76 @@ async function ensureAllowance(
   ownerAddress: Address,
   spenderAddress: Address,
   requiredAmount: bigint,
-): Promise<void> {
+  token: TokenDisplay,
+): Promise<{ approveSent: boolean }> {
   const currentAllowance = await ERC20.getERC20Allowance(
     tokenAddress,
     ownerAddress,
     spenderAddress,
   );
-  if (currentAllowance >= requiredAmount) return;
+  if (currentAllowance >= requiredAmount) return { approveSent: false };
 
-  await ERC20.approveERC20(
+  await approveAndVerify(
     walletClient,
     chain,
     tokenAddress,
-    spenderAddress,
-    requiredAmount,
-  );
-
-  const verifiedAllowance = await ERC20.getERC20Allowance(
-    tokenAddress,
     ownerAddress,
     spenderAddress,
+    requiredAmount,
+    token,
   );
-  if (verifiedAllowance < requiredAmount) {
-    throw new Error(
-      `Approval did not take effect on-chain (expected at least ${requiredAmount}, got ${verifiedAllowance}). This is usually a transient RPC lag — please refresh the page and try again.`,
-    );
+  return { approveSent: true };
+}
+
+/**
+ * True for an ERC20InsufficientAllowance raised at pre-flight simulation:
+ * nothing was signed or broadcast, so with a receipt-verified approval it can
+ * only mean the simulating backend has not caught up to the approve block.
+ */
+function isStaleAllowanceSimulationError(err: unknown): boolean {
+  return (
+    isSimulationPhaseError(err) &&
+    err.code === ErrorCode.CONTRACT_REVERT &&
+    err.reason === ERC20_INSUFFICIENT_ALLOWANCE_REASON
+  );
+}
+
+/**
+ * Run the repay, absorbing stale-backend allowance reverts at simulation: one
+ * plain delayed retry first; if the approve was short-circuited (a stale HIGH
+ * allowance read can skip a genuinely needed approve), force the approve
+ * before the final attempt. Mined reverts and all other errors propagate
+ * untouched — auto-retrying a broadcast tx would re-prompt the wallet.
+ * Note: repayMaxCapped can revert here legitimately (accrued interest pushed
+ * debt past the approved balance cap); the retries just delay that error.
+ */
+async function repayWithStaleSimulationRetry(params: {
+  execute: () => Promise<RepayResult>;
+  approveSent: boolean;
+  forceApprove: () => Promise<void>;
+}): Promise<RepayResult> {
+  const { execute, approveSent, forceApprove } = params;
+
+  try {
+    return await execute();
+  } catch (firstError) {
+    if (!isStaleAllowanceSimulationError(firstError)) throw firstError;
+    await wait(REPAY_STALE_SIM_RETRY_DELAY_MS);
   }
+
+  try {
+    return await execute();
+  } catch (secondError) {
+    if (!isStaleAllowanceSimulationError(secondError) || approveSent) {
+      throw secondError;
+    }
+    // Approve was skipped on a possibly stale-high read; force it once, then
+    // give the backends the same catch-up window before the final attempt.
+    await forceApprove();
+    await wait(REPAY_STALE_SIM_RETRY_DELAY_MS);
+  }
+
+  return execute();
 }
 
 /**
@@ -157,6 +309,7 @@ export async function repayPartial(
   debtReserveId: bigint,
   tokenAddress: Address,
   amount: bigint,
+  token: TokenDisplay,
 ): Promise<{ transactionHash: Hash; receipt: TransactionReceipt }> {
   const userAddress = walletClient.account?.address;
   if (!userAddress) {
@@ -172,16 +325,31 @@ export async function repayPartial(
     );
   }
 
-  await ensureAllowance(
+  const { approveSent } = await ensureAllowance(
     walletClient,
     chain,
     tokenAddress,
     userAddress,
     adapterAddress,
     amount,
+    token,
   );
 
-  return repay(walletClient, chain, userAddress, debtReserveId, amount);
+  return repayWithStaleSimulationRetry({
+    execute: () =>
+      repay(walletClient, chain, userAddress, debtReserveId, amount),
+    approveSent,
+    forceApprove: () =>
+      approveAndVerify(
+        walletClient,
+        chain,
+        tokenAddress,
+        userAddress,
+        adapterAddress,
+        amount,
+        token,
+      ),
+  });
 }
 
 /**
@@ -199,6 +367,7 @@ export async function repayMaxCapped(
   debtReserveId: bigint,
   tokenAddress: Address,
   balanceAmount: bigint,
+  token: TokenDisplay,
 ): Promise<{ transactionHash: Hash; receipt: TransactionReceipt }> {
   const userAddress = walletClient.account?.address;
   if (!userAddress) {
@@ -211,16 +380,31 @@ export async function repayMaxCapped(
 
   const adapterAddress = getAaveAdapterAddress();
 
-  await ensureAllowance(
+  const { approveSent } = await ensureAllowance(
     walletClient,
     chain,
     tokenAddress,
     userAddress,
     adapterAddress,
     balanceAmount,
+    token,
   );
 
-  return repay(walletClient, chain, userAddress, debtReserveId, maxUint256);
+  return repayWithStaleSimulationRetry({
+    execute: () =>
+      repay(walletClient, chain, userAddress, debtReserveId, maxUint256),
+    approveSent,
+    forceApprove: () =>
+      approveAndVerify(
+        walletClient,
+        chain,
+        tokenAddress,
+        userAddress,
+        adapterAddress,
+        balanceAmount,
+        token,
+      ),
+  });
 }
 
 /**
@@ -246,6 +430,7 @@ export async function repayFull(
   debtReserveId: bigint,
   tokenAddress: Address,
   proxyContract: Address,
+  token: TokenDisplay,
 ): Promise<{ transactionHash: Hash; receipt: TransactionReceipt }> {
   const userAddress = walletClient.account?.address;
   if (!userAddress) {
@@ -279,16 +464,31 @@ export async function repayFull(
     );
   }
 
-  await ensureAllowance(
+  const { approveSent } = await ensureAllowance(
     walletClient,
     chain,
     tokenAddress,
     userAddress,
     adapterAddress,
     amountToRepay,
+    token,
   );
 
-  return repay(walletClient, chain, userAddress, debtReserveId, amountToRepay);
+  return repayWithStaleSimulationRetry({
+    execute: () =>
+      repay(walletClient, chain, userAddress, debtReserveId, amountToRepay),
+    approveSent,
+    forceApprove: () =>
+      approveAndVerify(
+        walletClient,
+        chain,
+        tokenAddress,
+        userAddress,
+        adapterAddress,
+        amountToRepay,
+        token,
+      ),
+  });
 }
 
 /**

--- a/services/vault/src/applications/aave/services/positionTransactions.ts
+++ b/services/vault/src/applications/aave/services/positionTransactions.ts
@@ -263,8 +263,9 @@ function isStaleAllowanceSimulationError(err: unknown): boolean {
  * auto-retrying a broadcast tx would re-prompt the wallet.
  * Note: repayMaxCapped can revert here legitimately (accrued interest pushed
  * debt past the approved balance cap); indistinguishable from staleness, so
- * the retries delay that error and the short-circuit branch spends one no-op
- * forceApprove prompt (plus its gas) before it surfaces — consciously accepted.
+ * the retries delay that error and the short-circuit branch spends a no-op
+ * forceApprove — one prompt plus gas, two for USDT-style tokens — before it
+ * surfaces. Consciously accepted.
  */
 async function repayWithStaleSimulationRetry(params: {
   execute: () => Promise<RepayResult>;

--- a/services/vault/src/clients/eth-contract/__tests__/transactionFactory.test.ts
+++ b/services/vault/src/clients/eth-contract/__tests__/transactionFactory.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ContractError, isSimulationPhaseError } from "@/utils/errors";
+
+const { mockPublicClient, mockWaitReceipt } = vi.hoisted(() => ({
+  mockPublicClient: {
+    simulateContract: vi.fn(),
+    call: vi.fn(),
+    getTransaction: vi.fn(),
+  },
+  mockWaitReceipt: vi.fn(),
+}));
+
+vi.mock("../client", () => ({
+  ethClient: { getPublicClient: () => mockPublicClient },
+}));
+
+vi.mock("@/config/network", () => ({
+  getETHChain: () => ({ id: 1 }),
+}));
+
+vi.mock("@/infrastructure", () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), event: vi.fn() },
+}));
+
+vi.mock("@babylonlabs-io/ts-sdk/tbv/core/utils", () => ({
+  waitForTransactionReceiptSmartAware: (...args: unknown[]) =>
+    mockWaitReceipt(...args),
+}));
+
+import { executeWrite } from "../transactionFactory";
+
+const APPROVE_ABI = [
+  {
+    type: "function",
+    name: "approve",
+    inputs: [
+      { name: "spender", type: "address" },
+      { name: "amount", type: "uint256" },
+    ],
+    outputs: [{ name: "", type: "bool" }],
+    stateMutability: "nonpayable",
+  },
+] as const;
+
+const walletClient = {
+  chain: { id: 1 },
+  account: { address: "0x2000000000000000000000000000000000000002" },
+  writeContract: vi.fn(),
+} as any;
+
+const write = () =>
+  executeWrite({
+    walletClient,
+    chain: { id: 1 } as any,
+    address: "0x1000000000000000000000000000000000000001",
+    abi: APPROVE_ABI,
+    functionName: "approve",
+    args: ["0x3000000000000000000000000000000000000003", 1n],
+    errorContext: "approve ERC20",
+  });
+
+describe("executeWrite simulation-phase tagging", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("tags a pre-flight simulation failure as simulation-phase", async () => {
+    mockPublicClient.simulateContract.mockRejectedValue(
+      new Error("execution reverted"),
+    );
+
+    const thrown = await write().catch((e: unknown) => e);
+
+    expect(thrown).toBeInstanceOf(ContractError);
+    expect(isSimulationPhaseError(thrown)).toBe(true);
+    // Nothing was signed or broadcast.
+    expect(walletClient.writeContract).not.toHaveBeenCalled();
+  });
+
+  it("does not tag a post-simulation send failure", async () => {
+    mockPublicClient.simulateContract.mockResolvedValue({});
+    walletClient.writeContract.mockRejectedValue(new Error("nonce too low"));
+
+    const thrown = await write().catch((e: unknown) => e);
+
+    expect(thrown).toBeInstanceOf(ContractError);
+    expect(isSimulationPhaseError(thrown)).toBe(false);
+  });
+
+  it("does not tag a mined revert surfaced via receipt replay", async () => {
+    mockPublicClient.simulateContract.mockResolvedValue({});
+    walletClient.writeContract.mockResolvedValue("0xhash");
+    mockWaitReceipt.mockResolvedValue({
+      status: "reverted",
+      gasUsed: 10n,
+      blockNumber: 5n,
+      transactionHash: "0xabc",
+      logs: [],
+    });
+    mockPublicClient.getTransaction.mockResolvedValue({ gas: 1000n });
+    // The replay call rethrows the on-chain revert for decoding.
+    mockPublicClient.call.mockRejectedValue(new Error("execution reverted"));
+
+    const thrown = await write().catch((e: unknown) => e);
+
+    expect(thrown).toBeInstanceOf(ContractError);
+    expect(isSimulationPhaseError(thrown)).toBe(false);
+  });
+});

--- a/services/vault/src/clients/eth-contract/erc20/__tests__/transaction.test.ts
+++ b/services/vault/src/clients/eth-contract/erc20/__tests__/transaction.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { ContractError, ErrorCode } from "@/utils/errors";
+import { ContractError, ErrorCode, tagSimulationPhase } from "@/utils/errors";
 
 const mockExecuteWrite = vi.fn();
 
@@ -8,13 +8,24 @@ vi.mock("@/clients/eth-contract/transactionFactory", () => ({
   executeWrite: (...args: unknown[]) => mockExecuteWrite(...args),
 }));
 
+const mockGetERC20Allowance = vi.fn();
+
+vi.mock("@/clients/eth-contract/erc20/query", () => ({
+  getERC20Allowance: (...args: unknown[]) => mockGetERC20Allowance(...args),
+}));
+
+vi.mock("@/infrastructure", () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), event: vi.fn() },
+}));
+
 import { approveERC20 } from "../transaction";
 
 const TOKEN_ADDRESS = "0xTokenAddress" as `0x${string}`;
 const SPENDER_ADDRESS = "0xSpenderAddress" as `0x${string}`;
+const OWNER_ADDRESS = "0xOwnerAddress" as `0x${string}`;
 
 const mockWalletClient = {
-  account: { address: "0xOwnerAddress" },
+  account: { address: OWNER_ADDRESS },
 } as Parameters<typeof approveERC20>[0];
 
 const mockChain = { id: 1, name: "Ethereum" } as Parameters<
@@ -23,16 +34,19 @@ const mockChain = { id: 1, name: "Ethereum" } as Parameters<
 
 const txResult = { transactionHash: "0xhash", receipt: {} };
 
-/** The shape executeWrite throws for a USDT-style non-zero→non-zero revert. */
-const approveRevert = () =>
-  new ContractError("approve reverted", ErrorCode.CONTRACT_REVERT);
+/** The shape executeWrite throws for a USDT-style pre-broadcast revert. */
+const simulationRevert = () =>
+  tagSimulationPhase(
+    new ContractError("approve reverted", ErrorCode.CONTRACT_REVERT),
+  );
 
 describe("approveERC20", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetERC20Allowance.mockResolvedValue(500n);
   });
 
-  it("sends a single approve for a standard token — no zero-reset", async () => {
+  it("sends a single approve for a standard token — no zero-reset, no allowance read", async () => {
     mockExecuteWrite.mockResolvedValue(txResult);
 
     await approveERC20(
@@ -50,11 +64,12 @@ describe("approveERC20", () => {
         errorContext: "approve ERC20",
       }),
     );
+    expect(mockGetERC20Allowance).not.toHaveBeenCalled();
   });
 
-  it("falls back to reset-then-approve when the direct approve reverts", async () => {
+  it("falls back to reset-then-approve on a simulation revert with a non-zero allowance", async () => {
     mockExecuteWrite
-      .mockRejectedValueOnce(approveRevert())
+      .mockRejectedValueOnce(simulationRevert())
       .mockResolvedValue(txResult);
 
     await approveERC20(
@@ -65,7 +80,19 @@ describe("approveERC20", () => {
       1000n,
     );
 
+    expect(mockGetERC20Allowance).toHaveBeenCalledWith(
+      TOKEN_ADDRESS,
+      OWNER_ADDRESS,
+      SPENDER_ADDRESS,
+    );
     expect(mockExecuteWrite).toHaveBeenCalledTimes(3);
+    expect(mockExecuteWrite).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        args: [SPENDER_ADDRESS, 1000n],
+        errorContext: "approve ERC20",
+      }),
+    );
     expect(mockExecuteWrite).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({
@@ -80,6 +107,46 @@ describe("approveERC20", () => {
         errorContext: "approve ERC20",
       }),
     );
+  });
+
+  it("rethrows a simulation revert without the fallback when the allowance is zero", async () => {
+    // The zero-first quirk needs a non-zero allowance; this revert has some
+    // other cause and the reset could clear nothing but still prompt.
+    mockGetERC20Allowance.mockResolvedValue(0n);
+    mockExecuteWrite.mockRejectedValue(simulationRevert());
+
+    await expect(
+      approveERC20(
+        mockWalletClient,
+        mockChain,
+        TOKEN_ADDRESS,
+        SPENDER_ADDRESS,
+        1000n,
+      ),
+    ).rejects.toThrow("approve reverted");
+
+    expect(mockExecuteWrite).toHaveBeenCalledTimes(1);
+  });
+
+  it("rethrows a mined (untagged) revert without the fallback", async () => {
+    // The tx was broadcast and reverted on-chain — gas was burned; auto-firing
+    // a reset prompt on top would surprise the user.
+    mockExecuteWrite.mockRejectedValue(
+      new ContractError("approve reverted", ErrorCode.CONTRACT_REVERT),
+    );
+
+    await expect(
+      approveERC20(
+        mockWalletClient,
+        mockChain,
+        TOKEN_ADDRESS,
+        SPENDER_ADDRESS,
+        1000n,
+      ),
+    ).rejects.toThrow("approve reverted");
+
+    expect(mockExecuteWrite).toHaveBeenCalledTimes(1);
+    expect(mockGetERC20Allowance).not.toHaveBeenCalled();
   });
 
   it("rethrows a user rejection without attempting the zero-reset", async () => {
@@ -122,5 +189,25 @@ describe("approveERC20", () => {
     ).rejects.toThrow("rpc timeout");
 
     expect(mockExecuteWrite).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces a failure of the fallback's reset step", async () => {
+    mockExecuteWrite
+      .mockRejectedValueOnce(simulationRevert())
+      .mockRejectedValueOnce(
+        new ContractError("reset reverted", ErrorCode.CONTRACT_REVERT),
+      );
+
+    await expect(
+      approveERC20(
+        mockWalletClient,
+        mockChain,
+        TOKEN_ADDRESS,
+        SPENDER_ADDRESS,
+        1000n,
+      ),
+    ).rejects.toThrow("reset reverted");
+
+    expect(mockExecuteWrite).toHaveBeenCalledTimes(2);
   });
 });

--- a/services/vault/src/clients/eth-contract/erc20/__tests__/transaction.test.ts
+++ b/services/vault/src/clients/eth-contract/erc20/__tests__/transaction.test.ts
@@ -1,10 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const mockGetERC20Allowance = vi.fn();
-
-vi.mock("@/clients/eth-contract/erc20/query", () => ({
-  getERC20Allowance: (...args: unknown[]) => mockGetERC20Allowance(...args),
-}));
+import { ContractError, ErrorCode } from "@/utils/errors";
 
 const mockExecuteWrite = vi.fn();
 
@@ -16,27 +12,28 @@ import { approveERC20 } from "../transaction";
 
 const TOKEN_ADDRESS = "0xTokenAddress" as `0x${string}`;
 const SPENDER_ADDRESS = "0xSpenderAddress" as `0x${string}`;
-const OWNER_ADDRESS = "0xOwnerAddress" as `0x${string}`;
 
 const mockWalletClient = {
-  account: { address: OWNER_ADDRESS },
+  account: { address: "0xOwnerAddress" },
 } as Parameters<typeof approveERC20>[0];
 
 const mockChain = { id: 1, name: "Ethereum" } as Parameters<
   typeof approveERC20
 >[1];
 
+const txResult = { transactionHash: "0xhash", receipt: {} };
+
+/** The shape executeWrite throws for a USDT-style non-zero→non-zero revert. */
+const approveRevert = () =>
+  new ContractError("approve reverted", ErrorCode.CONTRACT_REVERT);
+
 describe("approveERC20", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("approves directly when current allowance is zero", async () => {
-    mockGetERC20Allowance.mockResolvedValue(0n);
-    mockExecuteWrite.mockResolvedValue({
-      transactionHash: "0xhash",
-      receipt: {},
-    });
+  it("sends a single approve for a standard token — no zero-reset", async () => {
+    mockExecuteWrite.mockResolvedValue(txResult);
 
     await approveERC20(
       mockWalletClient,
@@ -55,12 +52,10 @@ describe("approveERC20", () => {
     );
   });
 
-  it("resets allowance to zero before approving when current allowance is non-zero", async () => {
-    mockGetERC20Allowance.mockResolvedValue(500n);
-    mockExecuteWrite.mockResolvedValue({
-      transactionHash: "0xhash",
-      receipt: {},
-    });
+  it("falls back to reset-then-approve when the direct approve reverts", async () => {
+    mockExecuteWrite
+      .mockRejectedValueOnce(approveRevert())
+      .mockResolvedValue(txResult);
 
     await approveERC20(
       mockWalletClient,
@@ -70,16 +65,16 @@ describe("approveERC20", () => {
       1000n,
     );
 
-    expect(mockExecuteWrite).toHaveBeenCalledTimes(2);
+    expect(mockExecuteWrite).toHaveBeenCalledTimes(3);
     expect(mockExecuteWrite).toHaveBeenNthCalledWith(
-      1,
+      2,
       expect.objectContaining({
         args: [SPENDER_ADDRESS, 0n],
         errorContext: "reset ERC20 approval to zero",
       }),
     );
     expect(mockExecuteWrite).toHaveBeenNthCalledWith(
-      2,
+      3,
       expect.objectContaining({
         args: [SPENDER_ADDRESS, 1000n],
         errorContext: "approve ERC20",
@@ -87,65 +82,45 @@ describe("approveERC20", () => {
     );
   });
 
-  it("throws when wallet account is not available", async () => {
-    const noAccountWallet = { account: undefined } as Parameters<
-      typeof approveERC20
-    >[0];
+  it("rethrows a user rejection without attempting the zero-reset", async () => {
+    // EIP-1193 user rejection surfaced through the mapped error's cause chain.
+    const rejection = new ContractError(
+      "approve failed",
+      ErrorCode.CONTRACT_REVERT,
+      undefined,
+      undefined,
+      { cause: { code: 4001, message: "User rejected the request." } },
+    );
+    mockExecuteWrite.mockRejectedValue(rejection);
 
     await expect(
       approveERC20(
-        noAccountWallet,
+        mockWalletClient,
         mockChain,
         TOKEN_ADDRESS,
         SPENDER_ADDRESS,
         1000n,
       ),
-    ).rejects.toThrow("Wallet account not available for ERC20 approval");
-  });
-
-  it("revokes with a single transaction when amount is zero and allowance is non-zero", async () => {
-    mockGetERC20Allowance.mockResolvedValue(500n);
-    mockExecuteWrite.mockResolvedValue({
-      transactionHash: "0xhash",
-      receipt: {},
-    });
-
-    await approveERC20(
-      mockWalletClient,
-      mockChain,
-      TOKEN_ADDRESS,
-      SPENDER_ADDRESS,
-      0n,
-    );
+    ).rejects.toThrow("approve failed");
 
     expect(mockExecuteWrite).toHaveBeenCalledTimes(1);
-    expect(mockExecuteWrite).toHaveBeenCalledWith(
-      expect.objectContaining({
-        args: [SPENDER_ADDRESS, 0n],
-        errorContext: "approve ERC20",
-      }),
-    );
   });
 
-  it("reads allowance for the correct owner, token, and spender", async () => {
-    mockGetERC20Allowance.mockResolvedValue(0n);
-    mockExecuteWrite.mockResolvedValue({
-      transactionHash: "0xhash",
-      receipt: {},
-    });
-
-    await approveERC20(
-      mockWalletClient,
-      mockChain,
-      TOKEN_ADDRESS,
-      SPENDER_ADDRESS,
-      1000n,
+  it("rethrows non-revert failures (e.g. network) without attempting the zero-reset", async () => {
+    mockExecuteWrite.mockRejectedValue(
+      new ContractError("rpc timeout", ErrorCode.CONTRACT_EXECUTION_FAILED),
     );
 
-    expect(mockGetERC20Allowance).toHaveBeenCalledWith(
-      TOKEN_ADDRESS,
-      OWNER_ADDRESS,
-      SPENDER_ADDRESS,
-    );
+    await expect(
+      approveERC20(
+        mockWalletClient,
+        mockChain,
+        TOKEN_ADDRESS,
+        SPENDER_ADDRESS,
+        1000n,
+      ),
+    ).rejects.toThrow("rpc timeout");
+
+    expect(mockExecuteWrite).toHaveBeenCalledTimes(1);
   });
 });

--- a/services/vault/src/clients/eth-contract/erc20/__tests__/transaction.test.ts
+++ b/services/vault/src/clients/eth-contract/erc20/__tests__/transaction.test.ts
@@ -128,6 +128,25 @@ describe("approveERC20", () => {
     expect(mockExecuteWrite).toHaveBeenCalledTimes(1);
   });
 
+  it("rethrows the original revert when the fallback's allowance read fails", async () => {
+    // A failed read leaves the non-zero-allowance condition unproven; the
+    // read error must not mask the approve revert that triggered the path.
+    mockGetERC20Allowance.mockRejectedValue(new Error("rpc unreachable"));
+    mockExecuteWrite.mockRejectedValue(simulationRevert());
+
+    await expect(
+      approveERC20(
+        mockWalletClient,
+        mockChain,
+        TOKEN_ADDRESS,
+        SPENDER_ADDRESS,
+        1000n,
+      ),
+    ).rejects.toThrow("approve reverted");
+
+    expect(mockExecuteWrite).toHaveBeenCalledTimes(1);
+  });
+
   it("rethrows a mined (untagged) revert without the fallback", async () => {
     // The tx was broadcast and reverted on-chain — gas was burned; auto-firing
     // a reset prompt on top would surprise the user.

--- a/services/vault/src/clients/eth-contract/erc20/transaction.ts
+++ b/services/vault/src/clients/eth-contract/erc20/transaction.ts
@@ -80,15 +80,17 @@ export async function approveERC20(
     }
     // The quirk only exists for non-zero → non-zero approvals: with a zero
     // allowance the revert has some other cause — surface the original error
-    // instead of firing a pointless reset prompt. Failure-path-only read.
+    // instead of firing a pointless reset prompt. Failure-path-only read; if
+    // the read itself fails the condition is unproven, so the original revert
+    // (not the read error) surfaces.
     const ownerAddress = walletClient.account?.address;
     if (!ownerAddress) throw error;
     const currentAllowance = await getERC20Allowance(
       tokenAddress,
       ownerAddress,
       spenderAddress,
-    );
-    if (currentAllowance === 0n) throw error;
+    ).catch(() => null);
+    if (currentAllowance === null || currentAllowance === 0n) throw error;
     logger.warn("Direct ERC20 approve reverted; using zero-first fallback", {
       data: { tokenAddress },
     });

--- a/services/vault/src/clients/eth-contract/erc20/transaction.ts
+++ b/services/vault/src/clients/eth-contract/erc20/transaction.ts
@@ -4,8 +4,16 @@
 
 import { type Address, type Chain, type WalletClient } from "viem";
 
-import { classifyError, ContractError, ErrorCode } from "../../../utils/errors";
+import { logger } from "@/infrastructure";
+
+import {
+  classifyError,
+  ErrorCode,
+  isSimulationPhaseError,
+} from "../../../utils/errors";
 import { executeWrite, type TransactionResult } from "../transactionFactory";
+
+import { getERC20Allowance } from "./query";
 
 /**
  * Standard ERC20 ABI for approve function
@@ -26,12 +34,14 @@ const ERC20_APPROVE_ABI = [
 /**
  * Approve ERC20 token spending.
  *
- * Attempts the target approval directly. USDT-like tokens revert when approve
- * is called with a non-zero amount while the current allowance is also
- * non-zero; `executeWrite` pre-simulates, so that revert surfaces before any
- * wallet prompt, and only then do we fall back to reset-to-zero + approve.
- * Standard tokens get a single prompt and never see the reset (which wallets
- * label "revoke approval").
+ * Attempts the target approval directly, falling back to reset-to-zero +
+ * approve only when the failure is consistent with the USDT zero-first quirk
+ * (a non-zero approve over a non-zero allowance reverts): the revert must be
+ * raised at pre-flight simulation (nothing signed, no gas burned) and the
+ * current allowance must be non-zero. Standard tokens get a single prompt and
+ * never see the reset (which wallets label "revoke approval"); every other
+ * failure — user rejection, network error, mined revert, zero-allowance
+ * revert — surfaces unchanged.
  */
 export async function approveERC20(
   walletClient: WalletClient,
@@ -59,15 +69,29 @@ export async function approveERC20(
     if (classifyError(error) === "user-rejection") {
       throw error;
     }
-    // Only a revert suggests the zero-first requirement. Anything else
-    // (network failure, timeout, chain guard) is not a token quirk — rethrow
-    // rather than firing a surprise reset approval.
+    // Only a pre-broadcast simulation revert can indicate the zero-first
+    // quirk; a mined revert already cost gas and must surface as-is, and
+    // non-revert failures (network, timeout) are not token quirks.
     if (
-      !(error instanceof ContractError) ||
+      !isSimulationPhaseError(error) ||
       error.code !== ErrorCode.CONTRACT_REVERT
     ) {
       throw error;
     }
+    // The quirk only exists for non-zero → non-zero approvals: with a zero
+    // allowance the revert has some other cause — surface the original error
+    // instead of firing a pointless reset prompt. Failure-path-only read.
+    const ownerAddress = walletClient.account?.address;
+    if (!ownerAddress) throw error;
+    const currentAllowance = await getERC20Allowance(
+      tokenAddress,
+      ownerAddress,
+      spenderAddress,
+    );
+    if (currentAllowance === 0n) throw error;
+    logger.warn("Direct ERC20 approve reverted; using zero-first fallback", {
+      data: { tokenAddress },
+    });
   }
 
   await executeWrite({

--- a/services/vault/src/clients/eth-contract/erc20/transaction.ts
+++ b/services/vault/src/clients/eth-contract/erc20/transaction.ts
@@ -4,9 +4,8 @@
 
 import { type Address, type Chain, type WalletClient } from "viem";
 
+import { classifyError, ContractError, ErrorCode } from "../../../utils/errors";
 import { executeWrite, type TransactionResult } from "../transactionFactory";
-
-import { getERC20Allowance } from "./query";
 
 /**
  * Standard ERC20 ABI for approve function
@@ -27,9 +26,12 @@ const ERC20_APPROVE_ABI = [
 /**
  * Approve ERC20 token spending.
  *
- * USDT-like tokens revert if approve is called with a non-zero amount when the
- * current allowance is also non-zero. This function resets the allowance to zero
- * first when necessary, making it safe for all ERC-20 tokens.
+ * Attempts the target approval directly. USDT-like tokens revert when approve
+ * is called with a non-zero amount while the current allowance is also
+ * non-zero; `executeWrite` pre-simulates, so that revert surfaces before any
+ * wallet prompt, and only then do we fall back to reset-to-zero + approve.
+ * Standard tokens get a single prompt and never see the reset (which wallets
+ * label "revoke approval").
  */
 export async function approveERC20(
   walletClient: WalletClient,
@@ -38,38 +40,44 @@ export async function approveERC20(
   spenderAddress: Address,
   amount: bigint,
 ): Promise<TransactionResult> {
-  const ownerAddress = walletClient.account?.address;
-  if (!ownerAddress) {
-    throw new Error("Wallet account not available for ERC20 approval");
-  }
-
-  const currentAllowance = await getERC20Allowance(
-    tokenAddress,
-    ownerAddress,
-    spenderAddress,
-  );
-
-  // USDT-like tokens revert if approve is called with a non-zero amount
-  // when the current allowance is also non-zero. Reset to zero first.
-  if (currentAllowance !== 0n && amount !== 0n) {
-    await executeWrite({
-      walletClient,
-      chain,
-      address: tokenAddress,
-      abi: ERC20_APPROVE_ABI,
-      functionName: "approve",
-      args: [spenderAddress, 0n],
-      errorContext: "reset ERC20 approval to zero",
-    });
-  }
-
-  return executeWrite({
+  const approveArgs = {
     walletClient,
     chain,
     address: tokenAddress,
     abi: ERC20_APPROVE_ABI,
-    functionName: "approve",
-    args: [spenderAddress, amount],
+    functionName: "approve" as const,
     errorContext: "approve ERC20",
+  };
+
+  try {
+    return await executeWrite({
+      ...approveArgs,
+      args: [spenderAddress, amount],
+    });
+  } catch (error) {
+    // A user rejection is final — never follow it with more prompts.
+    if (classifyError(error) === "user-rejection") {
+      throw error;
+    }
+    // Only a revert suggests the zero-first requirement. Anything else
+    // (network failure, timeout, chain guard) is not a token quirk — rethrow
+    // rather than firing a surprise reset approval.
+    if (
+      !(error instanceof ContractError) ||
+      error.code !== ErrorCode.CONTRACT_REVERT
+    ) {
+      throw error;
+    }
+  }
+
+  await executeWrite({
+    ...approveArgs,
+    args: [spenderAddress, 0n],
+    errorContext: "reset ERC20 approval to zero",
+  });
+
+  return executeWrite({
+    ...approveArgs,
+    args: [spenderAddress, amount],
   });
 }

--- a/services/vault/src/clients/eth-contract/transactionFactory.ts
+++ b/services/vault/src/clients/eth-contract/transactionFactory.ts
@@ -20,7 +20,10 @@ import {
 import { getETHChain } from "@/config/network";
 import { logger } from "@/infrastructure";
 
-import { mapViemErrorToContractError } from "../../utils/errors";
+import {
+  mapViemErrorToContractError,
+  tagSimulationPhase,
+} from "../../utils/errors";
 
 import { ethClient } from "./client";
 
@@ -100,7 +103,18 @@ export async function executeWrite(
       args,
       account,
     });
+  } catch (error) {
+    // Tagged so callers can safely auto-retry: nothing was signed or sent,
+    // and the failure may be a lagging RPC backend, not the chain.
+    throw tagSimulationPhase(
+      mapViemErrorToContractError(error, errorContext, [
+        abi as Abi,
+        ...(errorAbis ?? []),
+      ]),
+    );
+  }
 
+  try {
     // Simulation passed, now send the actual transaction
     const hash = await walletClient.writeContract({
       address,

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -1121,6 +1121,12 @@ export const COPY = {
       // Shown when the wallet balance query fails so the user isn't left with a
       // disabled repay button and no explanation.
       balanceLoadError: "Couldn't load your balance. Please try again.",
+      // Post-approve verification failures. Wording must avoid the substrings
+      // getEnhancedErrorMessage rewrites (see utils/errors/contract.ts).
+      approvalNotConfirmed: (required: string, observed: string) =>
+        `Token approval could not be confirmed on-chain (required ${required}, last read ${observed}). The network may be briefly out of sync — please try again.`,
+      approvalBelowRequired: (required: string, approved: string) =>
+        `The wallet approved a lower amount than required (required ${required}, approved ${approved}). Please retry and approve the full amount.`,
       // Submit-time (Max intent) balance/debt refetch failure.
       refetchError: "Couldn't refresh balance/debt — please try again.",
     },

--- a/services/vault/src/utils/errors/__tests__/contract.test.ts
+++ b/services/vault/src/utils/errors/__tests__/contract.test.ts
@@ -6,6 +6,8 @@ import { AaveIntegrationAdapterABI } from "@babylonlabs-io/ts-sdk/tbv/integratio
 import { type Abi, encodeErrorResult } from "viem";
 import { describe, expect, it } from "vitest";
 
+import { COPY } from "@/copy";
+
 import {
   ACTIVATION_DEADLINE_EXPIRED_REASON,
   isActivationDeadlineExpiredError,
@@ -536,6 +538,26 @@ describe("Contract Error Mapping", () => {
         isTerminalActivationError(new Error("Cannot activate: ... PENDING")),
       ).toBe(false);
       expect(isTerminalActivationError(null)).toBe(false);
+    });
+  });
+
+  describe("repay approval copy survives message rewriting", () => {
+    // getEnhancedErrorMessage substring-rewrites messages containing e.g.
+    // "not enough" / "insufficient liquidity" / "paused"; the approval copy
+    // is worded to dodge those rules — pin that property here.
+    it("preserves the approval-not-confirmed copy under the Repay mapping", () => {
+      const body = COPY.loans.repay.approvalNotConfirmed(
+        "3 USDC",
+        "0.000002 USDC",
+      );
+      const mapped = mapViemErrorToContractError(new Error(body), "Repay");
+      expect(mapped.message).toBe(`Repay failed: ${body}`);
+    });
+
+    it("preserves the approval-below-required copy under the Repay mapping", () => {
+      const body = COPY.loans.repay.approvalBelowRequired("3 USDC", "2 USDC");
+      const mapped = mapViemErrorToContractError(new Error(body), "Repay");
+      expect(mapped.message).toBe(`Repay failed: ${body}`);
     });
   });
 });

--- a/services/vault/src/utils/errors/contract.ts
+++ b/services/vault/src/utils/errors/contract.ts
@@ -340,6 +340,34 @@ export function mapViemErrorToContractError(
   });
 }
 
+/** Context marker for errors raised during pre-flight simulation. */
+const SIMULATION_PHASE = "simulation";
+
+/**
+ * Mark a mapped error as raised during pre-flight simulation — nothing was
+ * signed or broadcast. Retry logic must only auto-retry these: the same error
+ * from a mined revert means the chain itself rejected the call.
+ */
+export function tagSimulationPhase(err: ContractError): ContractError {
+  return new ContractError(
+    err.message,
+    err.code,
+    err.transactionHash,
+    err.reason,
+    {
+      cause: err.cause,
+      context: { ...err.context, phase: SIMULATION_PHASE },
+    },
+  );
+}
+
+/** True when the error was raised at simulation time (see tagSimulationPhase). */
+export function isSimulationPhaseError(err: unknown): err is ContractError {
+  return (
+    err instanceof ContractError && err.context?.phase === SIMULATION_PHASE
+  );
+}
+
 /**
  * ABI error name from BTCVaultRegistry, surfaced as `ContractError.reason` when
  * `activateVaultWithSecret` is called after the activation window closed


### PR DESCRIPTION
1. **Approvals are verified from the approve tx's own receipt** (its
 `Approval` event, last matching log) instead of a follow-up allowance
 read that can hit a lagging backend. A bounded re-read remains as
 fallback for receipts without a matching event (wallet cancel/speed-up
 replacements, non-emitting tokens). A wallet-edited spending cap below
 the required amount gets its own accurate error.
2. **Repay retries only provably pre-broadcast failures.** Errors raised at
 pre-flight simulation are tagged; a simulation-phase
 `ERC20InsufficientAllowance` gets up to three attempts with catch-up
 delays on every path. When the approve was short-circuited by the
 allowance pre-check, the second failure forces a fresh approve before
 the last attempt. Mined reverts never auto-retry (no second wallet
 prompt, no double gas), and each absorbed retry logs a warning so
 rescued flows stay visible in monitoring.
3. **`approveERC20` is attempt-first**: single prompt for standard tokens.
 The `approve(0)` reset (shown by wallets as "revoke approval") fires
 only when the direct approve reverts at pre-broadcast simulation AND
 the current allowance is non-zero — the USDT zero-first signature.
 User rejections, network errors, and mined reverts rethrow immediately,
 and if the gate's own allowance read fails, the original revert
 surfaces rather than the read error.
4. Approval-verification errors are humanized (token units, not raw wei)
 and live in `copy.ts`, worded to survive the error-message rewriter.