### PR TITLE
feat(vault): add artifact and provider-list telemetry (Phase 5) to Sentry

### DIFF
--- a/services/vault/src/hooks/deposit/__tests__/useArtifactDownload.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useArtifactDownload.test.tsx
@@ -23,6 +23,18 @@ vi.mock("@/services/artifacts", async () => {
 
 vi.mock("@/utils/artifactDownloadStorage", () => ({
   markArtifactsDownloaded: vi.fn(),
+  hasArtifactsDownloaded: vi.fn(() => false),
+}));
+
+const mockLoggerError = vi.hoisted(() => vi.fn());
+const mockLoggerEvent = vi.hoisted(() => vi.fn());
+vi.mock("@/infrastructure", () => ({
+  logger: {
+    error: mockLoggerError,
+    event: mockLoggerEvent,
+    warn: vi.fn(),
+    info: vi.fn(),
+  },
 }));
 
 vi.mock("@/hooks/deposit/depositFlowSteps/ensureAuthenticatedVpClient", () => ({
@@ -44,7 +56,10 @@ import {
   ArtifactDownloadCancelledError,
   fetchAndDownloadArtifacts,
 } from "@/services/artifacts";
-import { markArtifactsDownloaded } from "@/utils/artifactDownloadStorage";
+import {
+  hasArtifactsDownloaded,
+  markArtifactsDownloaded,
+} from "@/utils/artifactDownloadStorage";
 
 import { ensureAuthenticatedVpClient } from "../depositFlowSteps/ensureAuthenticatedVpClient";
 import { useArtifactDownload } from "../useArtifactDownload";
@@ -54,6 +69,7 @@ const ensureAuthMock = vi.mocked(ensureAuthenticatedVpClient);
 const demoEnabledMock = vi.mocked(isArtifactDownloadDemoEnabled);
 const demoFetchMock = vi.mocked(demoFetchAndDownloadArtifacts);
 const markDownloadedMock = vi.mocked(markArtifactsDownloaded);
+const hasDownloadedMock = vi.mocked(hasArtifactsDownloaded);
 
 const PROVIDER_ADDRESS = "0x1234";
 const PEGIN_TXID =
@@ -520,5 +536,162 @@ describe("useArtifactDownload — prime then fetch", () => {
     });
 
     expect(result.current.downloaded).toBe(true);
+  });
+});
+
+describe("useArtifactDownload — funnel telemetry", () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    ensureAuthMock.mockReset();
+    demoEnabledMock.mockReturnValue(false);
+    markDownloadedMock.mockReset();
+    hasDownloadedMock.mockReset();
+    hasDownloadedMock.mockReturnValue(false);
+    mockLoggerError.mockReset();
+    mockLoggerEvent.mockReset();
+    (vpTokenRegistry as unknown as { clear?: () => void }).clear?.();
+  });
+
+  it("captures a terminal download failure with the activation.artifacts stage and scrubbed vaultId", async () => {
+    seedHotCache();
+    fetchMock.mockRejectedValueOnce(new Error("HTTP error: 401 Unauthorized"));
+
+    const { result } = renderHook(() =>
+      useArtifactDownload({ vaultId: VAULT_ID, primeContext }),
+    );
+
+    await act(async () => {
+      await result.current.download(PROVIDER_ADDRESS, PEGIN_TXID, DEPOSITOR_PK);
+    });
+
+    expect(mockLoggerError).toHaveBeenCalledTimes(1);
+    const [err, ctx] = mockLoggerError.mock.calls[0];
+    expect(err).toBeInstanceOf(Error);
+    expect(ctx.tags.funnelStage).toBe("activation.artifacts");
+    expect(ctx.data.vaultId).toBe("0xde...beef");
+    expect(ctx.data.site).toBe("download");
+    expect(result.current.error).toContain("401");
+  });
+
+  it("captures a cold-cache prime failure with site prime", async () => {
+    ensureAuthMock.mockRejectedValueOnce(new Error("prime exploded"));
+
+    const { result } = renderHook(() =>
+      useArtifactDownload({ vaultId: VAULT_ID, primeContext }),
+    );
+
+    await act(async () => {
+      await result.current.download(PROVIDER_ADDRESS, PEGIN_TXID, DEPOSITOR_PK);
+    });
+
+    expect(mockLoggerError).toHaveBeenCalledTimes(1);
+    expect(mockLoggerError.mock.calls[0][1].data.site).toBe("prime");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("captures the cold-registry-without-prime-context flow bug", async () => {
+    const { result } = renderHook(() =>
+      useArtifactDownload({ vaultId: VAULT_ID, primeContext: null }),
+    );
+
+    await act(async () => {
+      await result.current.download(PROVIDER_ADDRESS, PEGIN_TXID, DEPOSITOR_PK);
+    });
+
+    expect(mockLoggerError).toHaveBeenCalledTimes(1);
+    expect(mockLoggerError.mock.calls[0][1].data.site).toBe("cold_registry");
+  });
+
+  it("does not capture a user-cancelled download", async () => {
+    seedHotCache();
+    fetchMock.mockRejectedValueOnce(new ArtifactDownloadCancelledError());
+
+    const { result } = renderHook(() =>
+      useArtifactDownload({ vaultId: VAULT_ID, primeContext }),
+    );
+
+    await act(async () => {
+      await result.current.download(PROVIDER_ADDRESS, PEGIN_TXID, DEPOSITOR_PK);
+    });
+
+    expect(mockLoggerError).not.toHaveBeenCalled();
+    expect(mockLoggerEvent).not.toHaveBeenCalled();
+  });
+
+  it("emits the downloaded milestone once, on the first real download only", async () => {
+    seedHotCache();
+    fetchMock.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() =>
+      useArtifactDownload({ vaultId: VAULT_ID, primeContext }),
+    );
+
+    await act(async () => {
+      await result.current.download(PROVIDER_ADDRESS, PEGIN_TXID, DEPOSITOR_PK);
+    });
+
+    expect(mockLoggerEvent).toHaveBeenCalledTimes(1);
+    const [name, ctx] = mockLoggerEvent.mock.calls[0];
+    expect(name).toBe("activation.artifacts.downloaded");
+    expect(ctx.vaultId).toBe("0xde...beef");
+
+    // Re-download with the gate already satisfied: no second milestone.
+    hasDownloadedMock.mockReturnValue(true);
+    await act(async () => {
+      await result.current.download(PROVIDER_ADDRESS, PEGIN_TXID, DEPOSITOR_PK);
+    });
+    expect(mockLoggerEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it("emits the stall event once after the VP reports still-processing past the threshold", async () => {
+    vi.useFakeTimers();
+    try {
+      seedHotCache();
+      fetchMock.mockRejectedValue(new Error("Invalid state PendingIngestion"));
+
+      const { result } = renderHook(() =>
+        useArtifactDownload({ vaultId: VAULT_ID, primeContext }),
+      );
+
+      let downloadPromise: Promise<void> | undefined;
+      act(() => {
+        downloadPromise = result.current.download(
+          PROVIDER_ADDRESS,
+          PEGIN_TXID,
+          DEPOSITOR_PK,
+        );
+      });
+
+      // 30 retries at the 10s interval reach the stall threshold.
+      for (let i = 0; i < 31; i++) {
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(10_000);
+        });
+      }
+
+      expect(mockLoggerEvent).toHaveBeenCalledTimes(1);
+      const [name, ctx] = mockLoggerEvent.mock.calls[0];
+      expect(name).toBe("activation.artifacts.stalled");
+      expect(ctx.level).toBe("warning");
+      expect(ctx.vaultId).toBe("0xde...beef");
+
+      // More retries past the threshold do not re-emit.
+      for (let i = 0; i < 5; i++) {
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(10_000);
+        });
+      }
+      expect(mockLoggerEvent).toHaveBeenCalledTimes(1);
+
+      act(() => {
+        result.current.cancel();
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10_000);
+        await downloadPromise;
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/services/vault/src/hooks/deposit/__tests__/useVaultProviders.test.ts
+++ b/services/vault/src/hooks/deposit/__tests__/useVaultProviders.test.ts
@@ -32,6 +32,11 @@ vi.mock("../../useDisabledVps", () => ({
   useDisabledVps: () => disabledRef.current,
 }));
 
+const mockLoggerEvent = vi.hoisted(() => vi.fn());
+vi.mock("@/infrastructure", () => ({
+  logger: { event: mockLoggerEvent, warn: vi.fn(), info: vi.fn() },
+}));
+
 vi.mock("../../useLogos", () => {
   const stableLogos = {};
   return {
@@ -126,5 +131,68 @@ describe("useVaultProviders disabled filtering", () => {
 
     const ids = result.current.allVaultProviders.map((p) => p.id);
     expect(ids).toEqual([ENABLED_ID, DISABLED_ID]);
+  });
+});
+
+describe("useVaultProviders — all-providers-disabled telemetry", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    disabledRef.current = new Set<string>();
+  });
+
+  const provider = {
+    id: "0xabcabcabcabcabcabcabcabcabcabcabcabcabca",
+    btcPubKey: "0xdeadbeef",
+  } as unknown as VaultProvider;
+
+  function mockProvidersQuery() {
+    mockedUseQuery.mockReturnValue({
+      data: { vaultProviders: [provider], vaultKeepers: [] },
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    } as never);
+  }
+
+  it("emits onboarding.providers.empty once when the proxy disabled every provider", () => {
+    mockProvidersQuery();
+    disabledRef.current = new Set([provider.id.toLowerCase()]);
+
+    // Distinct entry point per test: the once-per-application dedupe store is
+    // module-scoped and survives across tests in this file.
+    const { rerender } = renderHook(() =>
+      useVaultProviders("0xapp-all-disabled"),
+    );
+
+    expect(mockLoggerEvent).toHaveBeenCalledTimes(1);
+    const [name, ctx] = mockLoggerEvent.mock.calls[0];
+    expect(name).toBe("onboarding.providers.empty");
+    expect(ctx.reason).toBe("all_disabled");
+    expect(ctx.total).toBe(1);
+
+    // Re-renders (poll refreshes) do not re-emit.
+    rerender();
+    expect(mockLoggerEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not emit while at least one provider remains listable", () => {
+    mockProvidersQuery();
+
+    renderHook(() => useVaultProviders("0xapp-healthy"));
+
+    expect(mockLoggerEvent).not.toHaveBeenCalled();
+  });
+
+  it("does not emit when the application genuinely has no providers", () => {
+    mockedUseQuery.mockReturnValue({
+      data: { vaultProviders: [], vaultKeepers: [] },
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    } as never);
+
+    renderHook(() => useVaultProviders("0xapp-empty"));
+
+    expect(mockLoggerEvent).not.toHaveBeenCalled();
   });
 });

--- a/services/vault/src/hooks/deposit/__tests__/useVaultProviders.test.ts
+++ b/services/vault/src/hooks/deposit/__tests__/useVaultProviders.test.ts
@@ -175,6 +175,16 @@ describe("useVaultProviders — all-providers-disabled telemetry", () => {
     expect(mockLoggerEvent).toHaveBeenCalledTimes(1);
   });
 
+  it("emits once when the same application mounts with checksummed and lowercase addresses", () => {
+    mockProvidersQuery();
+    disabledRef.current = new Set([provider.id.toLowerCase()]);
+
+    renderHook(() => useVaultProviders("0xAPP-CASING"));
+    renderHook(() => useVaultProviders("0xapp-casing"));
+
+    expect(mockLoggerEvent).toHaveBeenCalledTimes(1);
+  });
+
   it("does not emit while at least one provider remains listable", () => {
     mockProvidersQuery();
 

--- a/services/vault/src/hooks/deposit/useArtifactDownload.ts
+++ b/services/vault/src/hooks/deposit/useArtifactDownload.ts
@@ -14,14 +14,32 @@ import {
   isArtifactDownloadDemoEnabled,
 } from "@/dev/demoArtifactDownload";
 import { ensureAuthenticatedVpClient } from "@/hooks/deposit/depositFlowSteps/ensureAuthenticatedVpClient";
+import { logger } from "@/infrastructure";
+import {
+  captureFunnelFailure,
+  shortId,
+  TELEMETRY_EVENT,
+  TELEMETRY_STAGE,
+} from "@/infrastructure/telemetryEvents";
 import { isPreDepositorSignaturesError } from "@/models/peginStateMachine";
 import {
   ArtifactDownloadCancelledError,
   fetchAndDownloadArtifacts,
 } from "@/services/artifacts";
-import { markArtifactsDownloaded } from "@/utils/artifactDownloadStorage";
+import {
+  hasArtifactsDownloaded,
+  markArtifactsDownloaded,
+} from "@/utils/artifactDownloadStorage";
 
 const ARTIFACT_RETRY_INTERVAL_MS = 10_000;
+
+/**
+ * "VP still processing" retries before the stall event fires — ~5 minutes at
+ * the 10s interval. The loop keeps retrying past this (the VP may genuinely
+ * still finish); the threshold only bounds how long the stall stays invisible
+ * to monitoring. Emitted once per download attempt.
+ */
+const ARTIFACT_STALL_EVENT_ATTEMPTS = 30;
 
 interface ArtifactDownloadState {
   loading: boolean;
@@ -115,6 +133,11 @@ export function useArtifactDownload(options?: {
 
       const normalizedPeginTxid = stripHexPrefix(peginTxid);
 
+      // Per-vault join key for telemetry. The collateral re-download path
+      // mounts the hook without a vaultId; the pegin txid identifies the same
+      // deposit and is public on-chain data (shortened before emission anyway).
+      const telemetryVaultId = vaultId ?? normalizedPeginTxid;
+
       // Dev/QA-only simulation of the artifact fetch (never reaches a VP),
       // so the dialogs' progress states can be exercised. Opted into via the
       // god-mode panel's "Mock artifact download" toggle; off in production
@@ -145,6 +168,17 @@ export function useArtifactDownload(options?: {
         if (demoDownload) return true;
         if (vpTokenRegistry.peek(normalizedPeginTxid)) return true;
         if (!primeContext) {
+          // A surface mounted the card without the prime inputs and the token
+          // cache is cold: every attempt is dead on arrival. A flow-wiring
+          // bug, not a user action — capture it.
+          captureFunnelFailure(
+            TELEMETRY_STAGE.ACTIVATION_ARTIFACTS,
+            new Error(
+              "Artifact download attempted with a cold token registry and no prime context",
+            ),
+            telemetryVaultId,
+            { site: "cold_registry" },
+          );
           setError(COPY.deposit.recoveryArtifacts.cannotAuthenticate);
           return false;
         }
@@ -165,6 +199,15 @@ export function useArtifactDownload(options?: {
           });
         } catch (primeErr) {
           if (isStale()) return false;
+          // Includes the on-chain prePeginTxHash mismatch guard — a potential
+          // compromised-indexer signal that must not stay UI-only. Wallet
+          // declines are filtered inside captureFunnelFailure.
+          captureFunnelFailure(
+            TELEMETRY_STAGE.ACTIVATION_ARTIFACTS,
+            primeErr,
+            telemetryVaultId,
+            { site: "prime" },
+          );
           setError(
             primeErr instanceof Error
               ? primeErr.message
@@ -218,6 +261,9 @@ export function useArtifactDownload(options?: {
         return true;
       };
 
+      let stillProcessingAttempts = 0;
+      let stallEventEmitted = false;
+
       while (true) {
         if (isStale()) return;
 
@@ -241,7 +287,17 @@ export function useArtifactDownload(options?: {
           // real vault permanently satisfies its gate with no file saved. The
           // demo still shows the downloaded UI via `downloaded: true` below.
           if (vaultId && !demoDownload) {
+            // Milestone only on the first real download — re-downloads are a
+            // routine user action, not funnel progress.
+            const firstDownload = !hasArtifactsDownloaded(vaultId);
             markArtifactsDownloaded(vaultId);
+            if (firstDownload) {
+              logger.event(TELEMETRY_EVENT.ACTIVATION_ARTIFACTS_DOWNLOADED, {
+                level: "info",
+                category: "activation",
+                vaultId: shortId(vaultId),
+              });
+            }
           }
           setState({
             ...INITIAL_STATE,
@@ -253,6 +309,19 @@ export function useArtifactDownload(options?: {
           if (isStale()) return;
 
           if (isPreDepositorSignaturesError(err)) {
+            stillProcessingAttempts += 1;
+            if (
+              !stallEventEmitted &&
+              stillProcessingAttempts >= ARTIFACT_STALL_EVENT_ATTEMPTS
+            ) {
+              stallEventEmitted = true;
+              logger.event(TELEMETRY_EVENT.ACTIVATION_ARTIFACTS_STALLED, {
+                level: "warning",
+                category: "activation",
+                vaultId: shortId(telemetryVaultId),
+                attempts: stillProcessingAttempts,
+              });
+            }
             setState((prev) => ({
               ...prev,
               progress: COPY.deposit.recoveryArtifacts.waitingForSignatures,
@@ -278,6 +347,12 @@ export function useArtifactDownload(options?: {
               }
             } catch (primeErr) {
               if (isStale()) return;
+              captureFunnelFailure(
+                TELEMETRY_STAGE.ACTIVATION_ARTIFACTS,
+                primeErr,
+                telemetryVaultId,
+                { site: "reprime" },
+              );
               setError(
                 primeErr instanceof Error
                   ? primeErr.message
@@ -288,6 +363,15 @@ export function useArtifactDownload(options?: {
           }
 
           if (isStale()) return;
+          // Terminal download failure: wire/HTTP auth rejections past the one
+          // re-prime retry, envelope-validation rejections, exhausted network
+          // retries, mid-stream failures. Cancellation returned above.
+          captureFunnelFailure(
+            TELEMETRY_STAGE.ACTIVATION_ARTIFACTS,
+            err,
+            telemetryVaultId,
+            { site: "download" },
+          );
           setError(
             err instanceof Error
               ? err.message

--- a/services/vault/src/hooks/deposit/useVaultProviders.ts
+++ b/services/vault/src/hooks/deposit/useVaultProviders.ts
@@ -18,7 +18,10 @@
  */
 
 import { useQuery } from "@tanstack/react-query";
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
+
+import { logger } from "@/infrastructure";
+import { shortId, TELEMETRY_EVENT } from "@/infrastructure/telemetryEvents";
 
 import { useAaveConfig } from "../../applications/aave/context/AaveConfigContext";
 import { fetchAppProviders } from "../../services/providers";
@@ -35,6 +38,14 @@ import { useWithLogos } from "../useWithLogos";
 const EMPTY_VAULT_PROVIDERS: VaultProvider[] = [];
 const EMPTY_VAULT_KEEPERS: VaultKeeper[] = [];
 const getProviderIdentity = (p: VaultProvider) => toIdentity(p.btcPubKey);
+
+/**
+ * Applications for which the all-providers-disabled event has already been
+ * emitted this session. Module-scoped (not per hook instance): the hook mounts
+ * in several components at once, and the systemic "picker is empty" condition
+ * must be reported once, keyed to the application — not once per mount.
+ */
+const emittedAllDisabledFor = new Set<string>();
 
 export interface UseVaultProvidersResult {
   /**
@@ -117,6 +128,26 @@ export function useVaultProviders(
       allProvidersWithLogos.filter((p) => !disabledVps.has(p.id.toLowerCase())),
     [allProvidersWithLogos, disabledVps],
   );
+
+  // Providers exist but the proxy disabled every one of them: the deposit
+  // picker renders empty and no deposit can start — a systemic outage signal,
+  // distinct from an application with no providers. Once per application per
+  // session; the picker's own empty-state copy remains the user-facing surface.
+  useEffect(() => {
+    if (!entryPoint) return;
+    if (allProvidersWithLogos.length === 0 || listableProviders.length > 0) {
+      return;
+    }
+    if (emittedAllDisabledFor.has(entryPoint)) return;
+    emittedAllDisabledFor.add(entryPoint);
+    logger.event(TELEMETRY_EVENT.ONBOARDING_PROVIDERS_EMPTY, {
+      level: "warning",
+      category: "onboarding",
+      reason: "all_disabled",
+      total: allProvidersWithLogos.length,
+      applicationId: shortId(entryPoint),
+    });
+  }, [entryPoint, allProvidersWithLogos, listableProviders]);
 
   // Find provider by address — searches ALL providers (including disabled,
   // unhealthy, and metadata-rejected) so that vault management flows (payout

--- a/services/vault/src/hooks/deposit/useVaultProviders.ts
+++ b/services/vault/src/hooks/deposit/useVaultProviders.ts
@@ -43,7 +43,9 @@ const getProviderIdentity = (p: VaultProvider) => toIdentity(p.btcPubKey);
  * Applications for which the all-providers-disabled event has already been
  * emitted this session. Module-scoped (not per hook instance): the hook mounts
  * in several components at once, and the systemic "picker is empty" condition
- * must be reported once, keyed to the application — not once per mount.
+ * must be reported once, keyed to the application — not once per mount. Keys
+ * are lowercased addresses so checksummed and lowercase mounts of the same
+ * application share one entry.
  */
 const emittedAllDisabledFor = new Set<string>();
 
@@ -138,14 +140,15 @@ export function useVaultProviders(
     if (allProvidersWithLogos.length === 0 || listableProviders.length > 0) {
       return;
     }
-    if (emittedAllDisabledFor.has(entryPoint)) return;
-    emittedAllDisabledFor.add(entryPoint);
+    const appKey = entryPoint.toLowerCase();
+    if (emittedAllDisabledFor.has(appKey)) return;
+    emittedAllDisabledFor.add(appKey);
     logger.event(TELEMETRY_EVENT.ONBOARDING_PROVIDERS_EMPTY, {
       level: "warning",
       category: "onboarding",
       reason: "all_disabled",
       total: allProvidersWithLogos.length,
-      applicationId: shortId(entryPoint),
+      applicationId: shortId(appKey),
     });
   }, [entryPoint, allProvidersWithLogos, listableProviders]);
 

--- a/services/vault/src/infrastructure/telemetryEvents.ts
+++ b/services/vault/src/infrastructure/telemetryEvents.ts
@@ -33,6 +33,12 @@ export const TELEMETRY_EVENT = {
   EXIT_REDEEM_PAYOUT_BLOCKED: "exit.redeem.payout_blocked",
   /** Pegout polling gave up (consecutive failures / unknown status / provider not found). */
   EXIT_REDEEM_PEGOUT_TIMEOUT: "exit.redeem.pegout_timeout",
+  /** Recovery artifacts downloaded for the first time — the RETRIEVE_SECRET gate is passable. */
+  ACTIVATION_ARTIFACTS_DOWNLOADED: "activation.artifacts.downloaded",
+  /** The VP kept reporting "still processing" past the stall threshold — depositor is stuck waiting. */
+  ACTIVATION_ARTIFACTS_STALLED: "activation.artifacts.stalled",
+  /** Every vault provider was filtered out of the deposit picker — deposits blocked at the top of the funnel. */
+  ONBOARDING_PROVIDERS_EMPTY: "onboarding.providers.empty",
 } as const;
 
 export type TelemetryEvent =
@@ -48,6 +54,7 @@ export type TelemetryEvent =
 export const TELEMETRY_STAGE = {
   ACTIVATION_WOTS: "activation.wots",
   ACTIVATION_PAYOUTS: "activation.payouts",
+  ACTIVATION_ARTIFACTS: "activation.artifacts",
   ACTIVATION_SECRET: "activation.secret",
   ACTIVATION_REVEAL: "activation.reveal",
 } as const;

--- a/services/vault/src/services/providers/__tests__/fetchProviders.test.ts
+++ b/services/vault/src/services/providers/__tests__/fetchProviders.test.ts
@@ -9,8 +9,9 @@ vi.mock("../../../clients/graphql", () => ({
   },
 }));
 
+const mockLoggerEvent = vi.hoisted(() => vi.fn());
 vi.mock("@/infrastructure", () => ({
-  logger: { warn: vi.fn() },
+  logger: { warn: vi.fn(), event: mockLoggerEvent },
 }));
 
 const mockRequest = vi.mocked(graphqlClient.request);
@@ -25,6 +26,76 @@ const VALID_BTC_PUBKEY_3 = "0x" + "f".repeat(66);
 
 describe("fetchProviders", () => {
   describe("fetchAppProviders", () => {
+    it("emits onboarding.providers.empty when the indexer knows providers but every row is dropped", async () => {
+      mockLoggerEvent.mockClear();
+      mockRequest.mockResolvedValueOnce({
+        vaultProviders: {
+          items: [
+            // Dropped by the null-rpcUrl filter.
+            {
+              id: VALID_ETH_ADDR_1,
+              btcPubKey: VALID_BTC_PUBKEY_1,
+              name: "a",
+              rpcUrl: null,
+              metadataStatus: null,
+              metadataRejectionReason: null,
+            },
+            // Dropped by validation (malformed id).
+            {
+              id: "not-an-address",
+              btcPubKey: VALID_BTC_PUBKEY_2,
+              name: "b",
+              rpcUrl: "https://vp.example",
+              metadataStatus: null,
+              metadataRejectionReason: null,
+            },
+          ],
+        },
+        vaultKeeperApplications: { items: [] },
+      });
+
+      const result = await fetchAppProviders(VALID_ETH_ADDR_3);
+
+      expect(result.vaultProviders).toEqual([]);
+      expect(mockLoggerEvent).toHaveBeenCalledTimes(1);
+      const [name, ctx] = mockLoggerEvent.mock.calls[0];
+      expect(name).toBe("onboarding.providers.empty");
+      expect(ctx.reason).toBe("all_rows_invalid");
+      expect(ctx.total).toBe(2);
+    });
+
+    it("does not emit onboarding.providers.empty when a provider survives filtering", async () => {
+      mockLoggerEvent.mockClear();
+      mockRequest.mockResolvedValueOnce({
+        vaultProviders: {
+          items: [
+            {
+              id: VALID_ETH_ADDR_1,
+              btcPubKey: VALID_BTC_PUBKEY_1,
+              name: "a",
+              rpcUrl: "https://vp.example",
+              metadataStatus: null,
+              metadataRejectionReason: null,
+            },
+            {
+              id: VALID_ETH_ADDR_2,
+              btcPubKey: VALID_BTC_PUBKEY_2,
+              name: "b",
+              rpcUrl: null,
+              metadataStatus: null,
+              metadataRejectionReason: null,
+            },
+          ],
+        },
+        vaultKeeperApplications: { items: [] },
+      });
+
+      const result = await fetchAppProviders(VALID_ETH_ADDR_3);
+
+      expect(result.vaultProviders).toHaveLength(1);
+      expect(mockLoggerEvent).not.toHaveBeenCalled();
+    });
+
     it("should return raw keeper items and pre-computed latest keepers", async () => {
       mockRequest.mockResolvedValueOnce({
         vaultProviders: { items: [] },

--- a/services/vault/src/services/providers/__tests__/fetchProviders.test.ts
+++ b/services/vault/src/services/providers/__tests__/fetchProviders.test.ts
@@ -62,6 +62,63 @@ describe("fetchProviders", () => {
       expect(name).toBe("onboarding.providers.empty");
       expect(ctx.reason).toBe("all_rows_invalid");
       expect(ctx.total).toBe(2);
+      expect(ctx.applicationId).toBe("0xcc...cccc");
+    });
+
+    it("does not re-emit onboarding.providers.empty on repeated fetches for the same application", async () => {
+      mockLoggerEvent.mockClear();
+      // Fresh address: the once-per-application gate is module-scoped and
+      // survives across tests in this file.
+      const appAddress = "0x" + "1".repeat(40);
+      const allInvalidResponse = {
+        vaultProviders: {
+          items: [
+            {
+              id: VALID_ETH_ADDR_1,
+              btcPubKey: VALID_BTC_PUBKEY_1,
+              name: "a",
+              rpcUrl: null,
+              metadataStatus: null,
+              metadataRejectionReason: null,
+            },
+          ],
+        },
+        vaultKeeperApplications: { items: [] },
+      };
+      mockRequest.mockResolvedValueOnce(allInvalidResponse);
+      mockRequest.mockResolvedValueOnce(allInvalidResponse);
+
+      await fetchAppProviders(appAddress);
+      await fetchAppProviders(appAddress);
+
+      expect(mockLoggerEvent).toHaveBeenCalledTimes(1);
+    });
+
+    it("treats checksummed and lowercase forms of one application as the same for the emit gate", async () => {
+      mockLoggerEvent.mockClear();
+      const appAddress = "0x" + "Ab".repeat(20);
+      const allInvalidResponse = {
+        vaultProviders: {
+          items: [
+            {
+              id: VALID_ETH_ADDR_1,
+              btcPubKey: VALID_BTC_PUBKEY_1,
+              name: "a",
+              rpcUrl: null,
+              metadataStatus: null,
+              metadataRejectionReason: null,
+            },
+          ],
+        },
+        vaultKeeperApplications: { items: [] },
+      };
+      mockRequest.mockResolvedValueOnce(allInvalidResponse);
+      mockRequest.mockResolvedValueOnce(allInvalidResponse);
+
+      await fetchAppProviders(appAddress);
+      await fetchAppProviders(appAddress.toLowerCase());
+
+      expect(mockLoggerEvent).toHaveBeenCalledTimes(1);
     });
 
     it("does not emit onboarding.providers.empty when a provider survives filtering", async () => {

--- a/services/vault/src/services/providers/fetchProviders.ts
+++ b/services/vault/src/services/providers/fetchProviders.ts
@@ -1,6 +1,7 @@
 import { gql } from "graphql-request";
 
 import { logger } from "@/infrastructure";
+import { TELEMETRY_EVENT } from "@/infrastructure/telemetryEvents";
 
 import { graphqlClient } from "../../clients/graphql";
 import type {
@@ -175,11 +176,21 @@ export async function fetchAppProviders(
     { appController: applicationEntryPoint.toLowerCase() },
   );
 
-  const vaultProviders: VaultProvider[] = response.vaultProviders.items
-    .filter(
-      (provider): provider is typeof provider & { rpcUrl: string } =>
-        provider.rpcUrl !== null,
-    )
+  const rawProviders = response.vaultProviders.items;
+  const withRpcUrl = rawProviders.filter(
+    (
+      provider,
+    ): provider is (typeof rawProviders)[number] & { rpcUrl: string } =>
+      provider.rpcUrl !== null,
+  );
+  if (withRpcUrl.length < rawProviders.length) {
+    logger.warn("Dropped vault providers with null rpcUrl from indexer", {
+      dropped: rawProviders.length - withRpcUrl.length,
+      total: rawProviders.length,
+    });
+  }
+
+  const vaultProviders: VaultProvider[] = withRpcUrl
     .filter((provider) => validateAppProvider(provider) !== null)
     .map((provider) => ({
       id: provider.id,
@@ -189,6 +200,18 @@ export async function fetchAppProviders(
       metadataStatus: normalizeMetadataStatus(provider.metadataStatus),
       metadataRejectionReason: provider.metadataRejectionReason ?? undefined,
     }));
+
+  // The indexer knows providers but every row was dropped (null rpcUrl or
+  // failed validation): a systemic schema/data regression that blocks every
+  // deposit at the picker. Distinct from a legitimately empty application.
+  if (rawProviders.length > 0 && vaultProviders.length === 0) {
+    logger.event(TELEMETRY_EVENT.ONBOARDING_PROVIDERS_EMPTY, {
+      level: "warning",
+      category: "onboarding",
+      reason: "all_rows_invalid",
+      total: rawProviders.length,
+    });
+  }
 
   const vaultKeeperItems: VaultKeeperItem[] =
     response.vaultKeeperApplications.items

--- a/services/vault/src/services/providers/fetchProviders.ts
+++ b/services/vault/src/services/providers/fetchProviders.ts
@@ -1,7 +1,7 @@
 import { gql } from "graphql-request";
 
 import { logger } from "@/infrastructure";
-import { TELEMETRY_EVENT } from "@/infrastructure/telemetryEvents";
+import { shortId, TELEMETRY_EVENT } from "@/infrastructure/telemetryEvents";
 
 import { graphqlClient } from "../../clients/graphql";
 import type {
@@ -157,6 +157,15 @@ export function getLatestVersionKeepers(
 }
 
 /**
+ * Applications (lowercased addresses) for which the all-rows-invalid event has
+ * already been emitted this session. Module-scoped for the same reason as the
+ * all-disabled gate in useVaultProviders: React Query polling re-runs
+ * fetchAppProviders, and a persistent indexer regression must be reported
+ * once per application — not once per refetch.
+ */
+const emittedAllInvalidFor = new Set<string>();
+
+/**
  * Fetches vault providers and vault keepers for a specific application.
  *
  * Note: Universal challengers are system-wide and should be fetched from
@@ -171,9 +180,10 @@ export function getLatestVersionKeepers(
 export async function fetchAppProviders(
   applicationEntryPoint: string,
 ): Promise<AppProvidersResponse> {
+  const appKey = applicationEntryPoint.toLowerCase();
   const response = await graphqlClient.request<GraphQLAppProvidersResponse>(
     GET_APP_PROVIDERS,
-    { appController: applicationEntryPoint.toLowerCase() },
+    { appController: appKey },
   );
 
   const rawProviders = response.vaultProviders.items;
@@ -204,12 +214,20 @@ export async function fetchAppProviders(
   // The indexer knows providers but every row was dropped (null rpcUrl or
   // failed validation): a systemic schema/data regression that blocks every
   // deposit at the picker. Distinct from a legitimately empty application.
-  if (rawProviders.length > 0 && vaultProviders.length === 0) {
+  // Once per application per session — React Query refetches call this on
+  // every poll, and a persistent regression must not re-count itself.
+  if (
+    rawProviders.length > 0 &&
+    vaultProviders.length === 0 &&
+    !emittedAllInvalidFor.has(appKey)
+  ) {
+    emittedAllInvalidFor.add(appKey);
     logger.event(TELEMETRY_EVENT.ONBOARDING_PROVIDERS_EMPTY, {
       level: "warning",
       category: "onboarding",
       reason: "all_rows_invalid",
       total: rawProviders.length,
+      applicationId: shortId(appKey),
     });
   }
 


### PR DESCRIPTION
## Context

Phase 5 of the Sentry funnel tracking (#2052 → #2053 → #2069 → #2091 → #2099). A 46-path coverage audit of the surfaces the funnel traverses found the **artifact pipeline** (the `RETRIEVE_SECRET` gate) and the **VP picker** were complete telemetry blind spots - 21 confirmed gaps, each verified with a full propagation trace.

## The gaps this closes

**Artifact surface - no logger existed anywhere on it.** Every failure died in `setError` as red modal text: CWT/bearer rejection of the gRPC-subject token, wire `auth_expired`/missing-bearer, HTTP 401/403, envelope-prefix validation rejections (#1943/#2020), exhausted network retries, mid-stream failures - and the on-chain `prePeginTxHash` mismatch **attack guard** firing on the artifact path, a potential compromised-indexer signal that reached only the modal.

**VP picker - silent top-of-funnel outage.** A proxy marking every provider disabled, or an indexer schema regression (null `rpcUrl` / failed validation on every row), empties the deposit picker for everyone. One of those filters had no logging of any kind.

## What it adds

| Signal | Kind | When |
| --- | --- | --- |
| `activation.artifacts` | failure capture (via `captureFunnelFailure`) | any of the four artifact failure sites (`site`: `prime` / `reprime` / `download` / `cold_registry`) |
| `activation.artifacts.downloaded` | milestone (info) | **first** real download per vault (gated on `hasArtifactsDownloaded`) |
| `activation.artifacts.stalled` | warning event | VP still reports "processing" past ~5 min (30 × 10s retries), once per attempt |
| `onboarding.providers.empty` | warning event | providers exist upstream but every row dropped - `reason`: `all_rows_invalid` (fetch) / `all_disabled` (proxy), deduped per application per session |

Design notes:
- Failure captures go through #2091's `captureFunnelFailure`, so **wallet declines are not counted** and vaultId is scrubbed; cancellation (`ArtifactDownloadCancelledError`) is never captured. The collateral re-download path (no `vaultId`) falls back to the pegin txid as the join key.
- The stall event does **not** change the retry loop's behavior - the depositor experience is identical; the stall just stops being invisible. Bounding the loop is a separate product decision.
- The milestone completes stall localization in the activation funnel: `payouts.signed → verified → artifacts.downloaded → activated`.
- `onboarding.providers.empty` distinguishes a systemic outage from a legitimately provider-less application (upstream non-empty required), and is module-deduped so multiple mounts / poll refreshes emit once.

## Testing

11 new tests: capture with stage tag + scrubbed vaultId per site, capture-vs-cancel discrimination, first-download-only milestone, stall threshold + no-re-emit via fake timers, and systemic-vs-empty provider distinction on both drop paths. Full vault suite green: **243 files, 2600 tests**. eslint clean; `tsc -p tsconfig.lib.json` clean.
