### PR TITLE
fix(vault): v3 deposit flow polish and shared modal shell

### DIFF
--- a/services/vault/src/applications/aave/components/Detail/index.tsx
+++ b/services/vault/src/applications/aave/components/Detail/index.tsx
@@ -1,8 +1,8 @@
-import { FullScreenDialog } from "@babylonlabs-io/core-ui";
 import { useState } from "react";
 import { useNavigate } from "react-router";
 
 import { EmptyState } from "@/components/shared";
+import { V3ModalShell } from "@/components/shared/V3ModalShell";
 import { FeatureFlags, getNetworkConfigBTC } from "@/config";
 import { useConnection, useETHWallet } from "@/context/wallet";
 import { getReserveDetailBaseRoute } from "@/routes";
@@ -161,17 +161,17 @@ export function AaveReserveDetail({
 
   return (
     <>
-      <FullScreenDialog
+      <V3ModalShell
         open={!showSuccess}
         // Withholding `onClose` hides the close button and no-ops the backdrop
         // click; `disableEscapeClose` covers the ESC key — together they lock
         // all three dismiss paths while a tx is in flight.
         onClose={isTxInFlight ? undefined : handleClose}
         disableEscapeClose={isTxInFlight}
-        className="items-center justify-center p-6"
+        contentClassName="max-w-[520px]"
       >
-        <div className="mx-auto w-full max-w-[520px]">{renderContent()}</div>
-      </FullScreenDialog>
+        {renderContent()}
+      </V3ModalShell>
 
       {selectedReserve && assetConfig && (
         <>

--- a/services/vault/src/components/ApplicationLogo.tsx
+++ b/services/vault/src/components/ApplicationLogo.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 interface ApplicationLogoProps {
   logoUrl: string | null;
   name: string;
-  size?: "xs" | "small" | "large";
+  size?: "xs" | "sm" | "small" | "large";
   shape?: "circle" | "rounded";
 }
 
@@ -13,8 +13,19 @@ const SIZE_CLASSES: Record<
   string
 > = {
   xs: "h-4 w-4",
+  sm: "h-6 w-6",
   small: "h-8 w-8",
   large: "h-10 w-10",
+};
+
+const FALLBACK_TEXT_CLASSES: Record<
+  NonNullable<ApplicationLogoProps["size"]>,
+  string
+> = {
+  xs: "text-[10px]",
+  sm: "text-xs",
+  small: "text-base",
+  large: "text-base",
 };
 
 export function ApplicationLogo({
@@ -35,7 +46,7 @@ export function ApplicationLogo({
       >
         <Text
           as="span"
-          className={`font-medium text-accent-contrast ${size === "xs" ? "text-[10px]" : "text-base"}`}
+          className={`font-medium text-accent-contrast ${FALLBACK_TEXT_CLASSES[size]}`}
         >
           {name.charAt(0).toUpperCase()}
         </Text>

--- a/services/vault/src/components/shared/ListRow.tsx
+++ b/services/vault/src/components/shared/ListRow.tsx
@@ -1,0 +1,52 @@
+/**
+ * Shared row primitives for the v3 list surfaces (Active Vaults, Active
+ * Loans). Both pages render the same row: a bordered 8px-radius card with a
+ * leading asset block, fixed-width label/value metrics, and trailing action
+ * buttons. Keeping the chrome here stops the two lists drifting apart.
+ *
+ * Not a core-ui component: the pattern is vault-app specific and core-ui has
+ * no card variant with this border/background pair.
+ */
+
+import type { ReactNode } from "react";
+
+/** Bordered row card shared by the vault and loan lists. */
+export function ListRowCard({
+  children,
+  testId,
+}: {
+  children: ReactNode;
+  testId?: string;
+}) {
+  return (
+    <div
+      data-testid={testId}
+      className="flex w-full flex-wrap items-center gap-x-4 gap-y-3 rounded-lg border border-secondary-strokeLight bg-secondary-highlight p-4 dark:bg-[#202020]"
+    >
+      {children}
+    </div>
+  );
+}
+
+/** Label over value, on the fixed column width the rows align to. */
+export function ListRowMetric({
+  label,
+  value,
+}: {
+  label: string;
+  value: string;
+}) {
+  return (
+    // Flexes rather than pinning the design's 190px: at the app's container
+    // width three fixed columns plus the asset block and two action buttons
+    // overflow, wrapping the buttons onto a second line.
+    <div className="flex min-w-[120px] flex-1 flex-col">
+      <span className="text-xs leading-[1.4] tracking-[0.4px] text-accent-secondary">
+        {label}
+      </span>
+      <span className="text-sm leading-[1.43] tracking-[0.17px] text-accent-primary">
+        {value}
+      </span>
+    </div>
+  );
+}

--- a/services/vault/src/components/shared/V3ModalShell.tsx
+++ b/services/vault/src/components/shared/V3ModalShell.tsx
@@ -1,0 +1,117 @@
+/**
+ * Shared full-screen modal shell for the v3 flows.
+ *
+ * Every v3 overlay (deposit, borrow/repay, reorder, withdraw, and their
+ * success screens) renders through this so they share one header: a close
+ * button on the left and the network chip + settings menu on the right, both
+ * aligned to the same content column the page uses. The card itself is
+ * centered and capped at `contentClassName`.
+ *
+ * Pre-v3 it falls back to the plain centered `FullScreenDialog` those flows
+ * used before, so the v2 look is unchanged.
+ */
+
+import {
+  FullScreenDialog,
+  StandardSettingsMenu,
+} from "@babylonlabs-io/core-ui";
+import { useTheme } from "next-themes";
+import type { ReactNode } from "react";
+import { IoArrowBack, IoClose } from "react-icons/io5";
+import { twJoin } from "tailwind-merge";
+
+import { NetworkBadge } from "@/components/shared/NetworkBadge";
+import { PAGE_CONTENT_CLASS } from "@/components/shared/layoutClasses";
+import { FeatureFlags } from "@/config";
+import { COPY } from "@/copy";
+
+interface V3ModalShellProps {
+  open: boolean;
+  /** Omit to lock dismissal (e.g. while a tx is in flight). */
+  onClose?: () => void;
+  /** When set, the top-left control is a back arrow instead of a close X. */
+  onBack?: () => void;
+  disableEscapeClose?: boolean;
+  /** Max-width (and any extra layout) for the centered card. */
+  contentClassName?: string;
+  children: ReactNode;
+}
+
+export function V3ModalShell({
+  open,
+  onClose,
+  onBack,
+  disableEscapeClose,
+  contentClassName,
+  children,
+}: V3ModalShellProps) {
+  const { theme, setTheme } = useTheme();
+
+  if (!FeatureFlags.isV3UiEnabled) {
+    return (
+      <FullScreenDialog
+        open={open}
+        onClose={onClose}
+        onBack={onBack}
+        disableEscapeClose={disableEscapeClose}
+        className="items-center justify-center p-6"
+      >
+        <div className={twJoin("mx-auto w-full", contentClassName)}>
+          {children}
+        </div>
+      </FullScreenDialog>
+    );
+  }
+
+  return (
+    <FullScreenDialog
+      open={open}
+      onClose={onClose}
+      onBack={onBack}
+      disableEscapeClose={disableEscapeClose}
+      // The shell renders its own header aligned to the page column, so hide
+      // FullScreenDialog's fixed built-in close/back button (onClose is still
+      // wired for backdrop + Escape dismissal).
+      closeButtonClassName="!hidden"
+    >
+      {/* Header row: close/back on the left, network + settings on the right,
+          both on the page's content column so the modal chrome lines up with
+          the page underneath. */}
+      <div
+        className={`mx-auto flex w-full items-center justify-between py-4 ${PAGE_CONTENT_CLASS}`}
+      >
+        {onBack ? (
+          <button
+            type="button"
+            onClick={onBack}
+            aria-label={COPY.common.back}
+            className="flex size-10 items-center justify-center text-accent-primary"
+          >
+            <IoArrowBack size={20} />
+          </button>
+        ) : onClose ? (
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label={COPY.common.close}
+            className="flex size-10 items-center justify-center text-accent-primary"
+          >
+            <IoClose size={24} />
+          </button>
+        ) : (
+          <span className="size-10" />
+        )}
+        <div className="flex items-center gap-4">
+          <NetworkBadge />
+          <StandardSettingsMenu theme={theme} setTheme={setTheme} />
+        </div>
+      </div>
+
+      <div className="flex flex-1 items-center justify-center px-6 pb-6">
+        <div className={twJoin("mx-auto w-full", contentClassName)}>
+          {children}
+        </div>
+      </div>
+    </FullScreenDialog>
+  );
+}

--- a/services/vault/src/components/shared/V3ModalShell.tsx
+++ b/services/vault/src/components/shared/V3ModalShell.tsx
@@ -17,7 +17,7 @@ import {
 } from "@babylonlabs-io/core-ui";
 import { useTheme } from "next-themes";
 import type { ReactNode } from "react";
-import { IoArrowBack, IoClose } from "react-icons/io5";
+import { IoClose } from "react-icons/io5";
 import { twJoin } from "tailwind-merge";
 
 import { NetworkBadge } from "@/components/shared/NetworkBadge";
@@ -29,8 +29,6 @@ interface V3ModalShellProps {
   open: boolean;
   /** Omit to lock dismissal (e.g. while a tx is in flight). */
   onClose?: () => void;
-  /** When set, the top-left control is a back arrow instead of a close X. */
-  onBack?: () => void;
   disableEscapeClose?: boolean;
   /** Max-width (and any extra layout) for the centered card. */
   contentClassName?: string;
@@ -40,7 +38,6 @@ interface V3ModalShellProps {
 export function V3ModalShell({
   open,
   onClose,
-  onBack,
   disableEscapeClose,
   contentClassName,
   children,
@@ -52,7 +49,6 @@ export function V3ModalShell({
       <FullScreenDialog
         open={open}
         onClose={onClose}
-        onBack={onBack}
         disableEscapeClose={disableEscapeClose}
         className="items-center justify-center p-6"
       >
@@ -67,29 +63,19 @@ export function V3ModalShell({
     <FullScreenDialog
       open={open}
       onClose={onClose}
-      onBack={onBack}
       disableEscapeClose={disableEscapeClose}
       // The shell renders its own header aligned to the page column, so hide
       // FullScreenDialog's fixed built-in close/back button (onClose is still
       // wired for backdrop + Escape dismissal).
       closeButtonClassName="!hidden"
     >
-      {/* Header row: close/back on the left, network + settings on the right,
-          both on the page's content column so the modal chrome lines up with
-          the page underneath. */}
+      {/* Header row: close on the left, network + settings on the right, both
+          on the page's content column so the modal chrome lines up with the
+          page underneath. */}
       <div
         className={`mx-auto flex w-full items-center justify-between py-4 ${PAGE_CONTENT_CLASS}`}
       >
-        {onBack ? (
-          <button
-            type="button"
-            onClick={onBack}
-            aria-label={COPY.common.back}
-            className="flex size-10 items-center justify-center text-accent-primary"
-          >
-            <IoArrowBack size={20} />
-          </button>
-        ) : onClose ? (
+        {onClose ? (
           <button
             type="button"
             onClick={onClose}

--- a/services/vault/src/components/simple/ActiveLoansList.tsx
+++ b/services/vault/src/components/simple/ActiveLoansList.tsx
@@ -8,6 +8,8 @@
 import { Avatar, Heading } from "@babylonlabs-io/core-ui";
 
 import type { ActiveLoanRow } from "@/applications/aave/hooks";
+import { ListRowCard, ListRowMetric } from "@/components/shared/ListRow";
+import { NEUTRAL_ROW_BUTTON_CLASS } from "@/components/shared/buttonClasses";
 import { COPY } from "@/copy";
 import {
   formatBasisPointsAsPercent,
@@ -22,43 +24,6 @@ interface ActiveLoansListProps {
   onRepay: (symbol: string) => void;
 }
 
-function Metric({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="flex min-w-[120px] flex-col gap-1">
-      <span className="text-sm leading-[1.43] tracking-[0.17px] text-accent-secondary">
-        {label}
-      </span>
-      <span className="text-base leading-[1.5] tracking-[0.15px] text-accent-primary">
-        {value}
-      </span>
-    </div>
-  );
-}
-
-// Filled action button matching the summary's Borrow/Repay (see
-// PositionStatCards' StatSection button) so both button groups look identical,
-// per the v3 design.
-function RowActionButton({
-  label,
-  onClick,
-  disabled,
-}: {
-  label: string;
-  onClick: () => void;
-  disabled?: boolean;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      disabled={disabled}
-      className="flex h-10 items-center justify-center rounded-lg bg-secondary-strokeLight px-6 text-base leading-[1.5] tracking-[0.15px] text-accent-primary transition-[filter] enabled:hover:brightness-110 disabled:cursor-not-allowed disabled:text-accent-disabled"
-    >
-      {label}
-    </button>
-  );
-}
-
 export function ActiveLoansList({
   rows,
   canBorrow,
@@ -71,8 +36,8 @@ export function ActiveLoansList({
         {COPY.loans.activeLoansHeading(rows.length)}
       </Heading>
 
-      <div className="overflow-hidden rounded-lg bg-secondary-highlight">
-        {rows.map((row, index) => {
+      <div className="flex flex-col gap-2">
+        {rows.map((row) => {
           const availableLiquidity =
             row.availableLiquidity !== null
               ? `${formatCompactTokenAmount(row.availableLiquidity)} ${row.symbol}`
@@ -83,48 +48,45 @@ export function ActiveLoansList({
               : COPY.common.emptyValue;
 
           return (
-            <div
-              key={row.reserveId}
-              className={`flex flex-col gap-4 p-6 lg:flex-row lg:items-center lg:justify-between ${
-                index > 0
-                  ? "border-t border-secondary-strokeLight dark:border-secondary-strokeDark"
-                  : ""
-              }`}
-            >
-              <div className="flex shrink-0 items-center gap-2 lg:min-w-[200px]">
+            <ListRowCard key={row.reserveId}>
+              <div className="flex w-[200px] shrink-0 items-center gap-2">
                 <Avatar url={row.icon} alt={row.symbol} size="medium" />
-                <span className="whitespace-nowrap text-xl text-accent-primary">
+                <span className="truncate text-base leading-[1.5] tracking-[0.15px] text-accent-primary">
                   {row.amount} {row.symbol}
                 </span>
               </div>
 
-              <div className="flex flex-wrap gap-6 lg:flex-1 lg:justify-start">
-                <Metric
-                  label={COPY.loans.borrowRateLabel}
-                  value={row.borrowRate ?? COPY.common.emptyValue}
-                />
-                <Metric
-                  label={COPY.loans.availableLiquidityLabel}
-                  value={availableLiquidity}
-                />
-                <Metric
-                  label={COPY.loans.utilizationLabel}
-                  value={utilization}
-                />
-              </div>
+              <ListRowMetric
+                label={COPY.loans.borrowRateLabel}
+                value={row.borrowRate ?? COPY.common.emptyValue}
+              />
+              <ListRowMetric
+                label={COPY.loans.availableLiquidityLabel}
+                value={availableLiquidity}
+              />
+              <ListRowMetric
+                label={COPY.loans.utilizationLabel}
+                value={utilization}
+              />
 
-              <div className="flex flex-shrink-0 gap-3">
-                <RowActionButton
-                  label={COPY.loans.borrowButton}
+              <div className="ml-auto flex shrink-0 gap-2">
+                <button
+                  type="button"
                   onClick={() => onBorrow(row.symbol)}
                   disabled={!canBorrow || !row.isBorrowable}
-                />
-                <RowActionButton
-                  label={COPY.loans.repayButton}
+                  className={NEUTRAL_ROW_BUTTON_CLASS}
+                >
+                  {COPY.loans.borrowButton}
+                </button>
+                <button
+                  type="button"
                   onClick={() => onRepay(row.symbol)}
-                />
+                  className={NEUTRAL_ROW_BUTTON_CLASS}
+                >
+                  {COPY.loans.repayButton}
+                </button>
               </div>
-            </div>
+            </ListRowCard>
           );
         })}
       </div>

--- a/services/vault/src/components/simple/DepositForm.tsx
+++ b/services/vault/src/components/simple/DepositForm.tsx
@@ -4,7 +4,7 @@ import { IoInformationCircle } from "react-icons/io5";
 
 import { ApplicationLogo } from "@/components/ApplicationLogo";
 import { DepositButton } from "@/components/shared";
-import { getNetworkConfigBTC } from "@/config";
+import { FeatureFlags, getNetworkConfigBTC } from "@/config";
 import { COPY } from "@/copy";
 import { depositService } from "@/services/deposit";
 import type { VaultProviderListItem } from "@/types/vaultProvider";
@@ -18,9 +18,22 @@ import {
   UtxoSplitSelector,
   type TwoVaultSplitProps,
 } from "./UtxoSplitSelector";
+import { UtxoSplitSelectorV3 } from "./UtxoSplitSelectorV3";
 import { VaultProviderSelector } from "./VaultProviderSelector";
+import {
+  VaultProviderSelectorV3,
+  type VaultProviderSelectorProps,
+} from "./VaultProviderSelectorV3";
 
 const btcConfig = getNetworkConfigBTC();
+
+// v3 deposit CTA: accent-primary (#CE6533) enabled, stroke-primary (#5A5A5A)
+// disabled, 8px radius. core-ui's contained/primary button is slate blue with a
+// 30%-opacity disabled state, so both states are overridden here rather than in
+// the shared component. Undefined pre-v3, which leaves the core-ui styling.
+const V3_CTA_CLASSES = FeatureFlags.isV3UiEnabled
+  ? "!rounded-lg !bg-secondary-main disabled:!bg-secondary-strokeDark disabled:!opacity-100"
+  : undefined;
 
 interface Application {
   id: string;
@@ -263,6 +276,14 @@ export function DepositForm({
   const setPanelExpanded =
     (panel: "split" | "provider") => (expanded: boolean) =>
       setOpenPanel(expanded ? panel : null);
+  const providerSelectorProps: VaultProviderSelectorProps = {
+    providers,
+    isLoadingProviders,
+    selectedProvider,
+    onProviderSelect,
+    expanded: openPanel === "provider",
+    onExpandedChange: setPanelExpanded("provider"),
+  };
   // The depositable max is unknown until the fee estimate, UTXOs, and the
   // on-chain supply cap resolve. Until then we never fall back to the raw
   // balance, which would let the user select an amount above the real cap that
@@ -331,6 +352,12 @@ export function DepositForm({
   ) : null;
 
   const selectedApp = applications.find((a) => a.id === selectedApplication);
+
+  const maxTooltip = hasUnconfirmedBalanceOnly
+    ? undefined
+    : COPY.deposit.form.maxTooltip({
+        hasSupplyCap: effectiveRemaining !== null,
+      });
 
   // Commission (bps) shown for the selected provider. Drives the fee breakdown
   // and gates the CTA: a selected provider whose commission hasn't loaded
@@ -411,29 +438,43 @@ export function DepositForm({
             )
           }
           sliderVariant="primary"
-          leftField={{
-            label: COPY.deposit.form.maxLabel,
-            value: maxDepositLabel,
-            // Mention the supply cap only when one exists for this user.
-            // `effectiveRemaining` is null both when no cap applies and while
-            // the cap read is loading; either way we omit the cap clause
-            // until we know it's a real constraint.
-            //
-            // Drop the Max tooltip while the pending-confirmation note is shown
-            // so the row carries a single info icon (the pending one) rather
-            // than two competing tooltips.
-            tooltip: hasUnconfirmedBalanceOnly
-              ? undefined
-              : COPY.deposit.form.maxTooltip({
-                  hasSupplyCap: effectiveRemaining !== null,
-                }),
-          }}
-          rightField={{
-            value: !hasAmount
-              ? (pendingConfirmationField ?? COPY.common.zeroUsdValue)
-              : usdValue,
-          }}
-          maxPosition="left"
+          // v3 mirrors the Figma row: USD value on the left, balance + Max
+          // pill on the right. v2 keeps the Max-pill-first layout.
+          leftField={
+            FeatureFlags.isV3UiEnabled
+              ? {
+                  value: !hasAmount
+                    ? (pendingConfirmationField ?? COPY.common.zeroUsdValue)
+                    : usdValue,
+                }
+              : {
+                  label: COPY.deposit.form.maxLabel,
+                  value: maxDepositLabel,
+                  // Mention the supply cap only when one exists for this user.
+                  // `effectiveRemaining` is null both when no cap applies and
+                  // while the cap read is loading; either way we omit the cap
+                  // clause until we know it's a real constraint.
+                  //
+                  // Drop the Max tooltip while the pending-confirmation note is
+                  // shown so the row carries a single info icon (the pending
+                  // one) rather than two competing tooltips.
+                  tooltip: maxTooltip,
+                }
+          }
+          rightField={
+            FeatureFlags.isV3UiEnabled
+              ? {
+                  label: COPY.deposit.form.balanceLabel,
+                  value: maxDepositLabel,
+                  tooltip: maxTooltip,
+                }
+              : {
+                  value: !hasAmount
+                    ? (pendingConfirmationField ?? COPY.common.zeroUsdValue)
+                    : usdValue,
+                }
+          }
+          maxPosition={FeatureFlags.isV3UiEnabled ? "right" : "left"}
           onMaxClick={onMaxClick}
           inputClassName="h-10 w-auto rounded-lg bg-primary-contrast px-4 [field-sizing:content]"
         />
@@ -485,16 +526,24 @@ export function DepositForm({
         )}
       </Card>
 
-      {twoVaultSplit && (
-        <UtxoSplitSelector
-          twoVaultSplit={twoVaultSplit}
-          expanded={openPanel === "split"}
-          onExpandedChange={setPanelExpanded("split")}
-        />
-      )}
+      {twoVaultSplit &&
+        (FeatureFlags.isV3UiEnabled ? (
+          <UtxoSplitSelectorV3
+            twoVaultSplit={twoVaultSplit}
+            expanded={openPanel === "split"}
+            onExpandedChange={setPanelExpanded("split")}
+          />
+        ) : (
+          <UtxoSplitSelector
+            twoVaultSplit={twoVaultSplit}
+            expanded={openPanel === "split"}
+            onExpandedChange={setPanelExpanded("split")}
+          />
+        ))}
 
-      {/* Aave app */}
-      {selectedApp && (
+      {/* Aave app. v3 shows the application logo in the page header instead
+          (see SimpleDeposit), so this row is v2-only. */}
+      {!FeatureFlags.isV3UiEnabled && selectedApp && (
         <Card variant="filled" className="flex items-center gap-3 !rounded-lg">
           <ApplicationLogo
             logoUrl={selectedApp.logoUrl}
@@ -507,14 +556,11 @@ export function DepositForm({
         </Card>
       )}
 
-      <VaultProviderSelector
-        providers={providers}
-        isLoadingProviders={isLoadingProviders}
-        selectedProvider={selectedProvider}
-        onProviderSelect={onProviderSelect}
-        expanded={openPanel === "provider"}
-        onExpandedChange={setPanelExpanded("provider")}
-      />
+      {FeatureFlags.isV3UiEnabled ? (
+        <VaultProviderSelectorV3 {...providerSelectorProps} />
+      ) : (
+        <VaultProviderSelector {...providerSelectorProps} />
+      )}
 
       {/* CTA button. A locked wallet shows no inline message — the relabeled CTA
           ("Unlock wallet") is the affordance. A liveness failure still surfaces
@@ -531,6 +577,7 @@ export function DepositForm({
         color="primary"
         size="large"
         fluid
+        className={V3_CTA_CLASSES}
         disabled={
           cta.disabled ||
           isVerifyingWallet ||

--- a/services/vault/src/components/simple/DepositProgressView/layout.ts
+++ b/services/vault/src/components/simple/DepositProgressView/layout.ts
@@ -4,9 +4,15 @@
  * COPY tree) so a component can pin its width without pulling that in.
  */
 
+import { FeatureFlags } from "@/config";
+
 /**
  * Shared max-width for the deposit progress surfaces. The live stepper
  * (DepositProgressView) and the activated success screen use this so the card
  * stays the same width across the flow.
  */
-export const DEPOSIT_VIEW_MAX_WIDTH_CLASS = "max-w-[520px]";
+export const DEPOSIT_VIEW_MAX_WIDTH_CLASS = FeatureFlags.isV3UiEnabled
+  ? // v3: 612px card = 564px content + 24px padding either side, so the
+    // stepper content lines up with the deposit form.
+    "max-w-[612px]"
+  : "max-w-[520px]";

--- a/services/vault/src/components/simple/FeesSection.tsx
+++ b/services/vault/src/components/simple/FeesSection.tsx
@@ -5,7 +5,7 @@ import {
   Hint,
 } from "@babylonlabs-io/core-ui";
 import { type ReactNode, useId, useState } from "react";
-import { IoChevronUp } from "react-icons/io5";
+import { IoAdd, IoChevronUp, IoRemove } from "react-icons/io5";
 
 import { FeatureFlags } from "@/config";
 import { COPY } from "@/copy";
@@ -43,7 +43,10 @@ function FeesSectionV3({ rows }: FeesSectionProps) {
   const panelId = useId();
 
   return (
-    <div className="border-t border-secondary-strokeLight pt-4">
+    <Accordion
+      expanded={expanded}
+      className="border-t border-secondary-strokeLight pt-4"
+    >
       <button
         type="button"
         aria-expanded={expanded}
@@ -54,14 +57,20 @@ function FeesSectionV3({ rows }: FeesSectionProps) {
         <span className="text-sm text-accent-primary">
           {COPY.protocolFees.sectionTitle}
         </span>
-        <IoChevronUp
-          className={`text-secondary-strokeDark transition-transform ${expanded ? "" : "rotate-180"}`}
-        />
+        <span className="flex size-6 shrink-0 items-center justify-center rounded bg-neutral-200 text-accent-primary">
+          {expanded ? <IoRemove size={16} /> : <IoAdd size={16} />}
+        </span>
       </button>
-      <div id={panelId} hidden={!expanded} className="flex flex-col gap-2 pt-3">
-        <FeeRows rows={rows} />
+      {/* AccordionDetails carries the shared dropdown motion (height +
+          opacity/translate from the `--motion-*` tokens) and owns the
+          collapsed visibility, so the panel animates like every other
+          expandable instead of snapping open. */}
+      <div id={panelId}>
+        <AccordionDetails className="flex flex-col gap-2 pt-3">
+          <FeeRows rows={rows} />
+        </AccordionDetails>
       </div>
-    </div>
+    </Accordion>
   );
 }
 

--- a/services/vault/src/components/simple/ReorderVaults/ReorderSuccessModal.tsx
+++ b/services/vault/src/components/simple/ReorderVaults/ReorderSuccessModal.tsx
@@ -1,10 +1,7 @@
-import {
-  Button,
-  DialogBody,
-  DialogFooter,
-  DialogHeader,
-  ResponsiveDialog,
-} from "@babylonlabs-io/core-ui";
+import { Button } from "@babylonlabs-io/core-ui";
+
+import { V3ModalShell } from "@/components/shared/V3ModalShell";
+import { COPY } from "@/copy";
 
 import { REORDER_SUCCESS_TEXT, REORDER_SUCCESS_TITLE } from "./constants";
 import { ReorderSuccessIcon } from "./ReorderSuccessIcon";
@@ -19,15 +16,21 @@ export function ReorderSuccessModal({
   onClose,
 }: ReorderSuccessModalProps) {
   return (
-    <ResponsiveDialog open={isOpen} onClose={onClose}>
-      <DialogHeader title={REORDER_SUCCESS_TITLE} onClose={onClose} />
-      <DialogBody>
-        <ReorderSuccessIcon className="mx-auto my-3 text-accent-primary" />
-        <p className="py-3 text-center text-accent-secondary">
-          {REORDER_SUCCESS_TEXT}
-        </p>
-      </DialogBody>
-      <DialogFooter>
+    <V3ModalShell
+      open={isOpen}
+      onClose={onClose}
+      contentClassName="max-w-[564px]"
+    >
+      <div className="flex w-full flex-col items-center gap-10 rounded-2xl border border-secondary-strokeLight bg-primary-contrast px-6 pb-6 pt-10">
+        <ReorderSuccessIcon className="text-accent-primary" />
+        <div className="flex w-full flex-col items-center gap-4 text-center">
+          <h2 className="text-[34px] leading-[1.235] tracking-[0.25px] text-accent-primary">
+            {REORDER_SUCCESS_TITLE}
+          </h2>
+          <p className="text-xl leading-[1.6] tracking-[0.15px] text-accent-secondary">
+            {REORDER_SUCCESS_TEXT}
+          </p>
+        </div>
         <Button
           variant="contained"
           color="secondary"
@@ -35,9 +38,9 @@ export function ReorderSuccessModal({
           fluid
           onClick={onClose}
         >
-          Done
+          {COPY.reorder.doneButton}
         </Button>
-      </DialogFooter>
-    </ResponsiveDialog>
+      </div>
+    </V3ModalShell>
   );
 }

--- a/services/vault/src/components/simple/ReorderVaults/ReorderSuccessModal.tsx
+++ b/services/vault/src/components/simple/ReorderVaults/ReorderSuccessModal.tsx
@@ -1,9 +1,15 @@
-import { Button } from "@babylonlabs-io/core-ui";
+import {
+  Button,
+  DialogBody,
+  DialogFooter,
+  DialogHeader,
+  ResponsiveDialog,
+} from "@babylonlabs-io/core-ui";
 
 import { V3ModalShell } from "@/components/shared/V3ModalShell";
+import { FeatureFlags } from "@/config";
 import { COPY } from "@/copy";
 
-import { REORDER_SUCCESS_TEXT, REORDER_SUCCESS_TITLE } from "./constants";
 import { ReorderSuccessIcon } from "./ReorderSuccessIcon";
 
 interface ReorderSuccessModalProps {
@@ -15,6 +21,33 @@ export function ReorderSuccessModal({
   isOpen,
   onClose,
 }: ReorderSuccessModalProps) {
+  // v2 keeps the ResponsiveDialog bottom-sheet; only v3 uses the full-screen
+  // shell + centered card.
+  if (!FeatureFlags.isV3UiEnabled) {
+    return (
+      <ResponsiveDialog open={isOpen} onClose={onClose}>
+        <DialogHeader title={COPY.reorder.successTitle} onClose={onClose} />
+        <DialogBody>
+          <ReorderSuccessIcon className="mx-auto my-3 text-accent-primary" />
+          <p className="py-3 text-center text-accent-secondary">
+            {COPY.reorder.successText}
+          </p>
+        </DialogBody>
+        <DialogFooter>
+          <Button
+            variant="contained"
+            color="secondary"
+            size="large"
+            fluid
+            onClick={onClose}
+          >
+            {COPY.reorder.doneButton}
+          </Button>
+        </DialogFooter>
+      </ResponsiveDialog>
+    );
+  }
+
   return (
     <V3ModalShell
       open={isOpen}
@@ -25,10 +58,10 @@ export function ReorderSuccessModal({
         <ReorderSuccessIcon className="text-accent-primary" />
         <div className="flex w-full flex-col items-center gap-4 text-center">
           <h2 className="text-[34px] leading-[1.235] tracking-[0.25px] text-accent-primary">
-            {REORDER_SUCCESS_TITLE}
+            {COPY.reorder.successTitle}
           </h2>
           <p className="text-xl leading-[1.6] tracking-[0.15px] text-accent-secondary">
-            {REORDER_SUCCESS_TEXT}
+            {COPY.reorder.successText}
           </p>
         </div>
         <Button

--- a/services/vault/src/components/simple/ReorderVaults/ReorderVaultsModal.tsx
+++ b/services/vault/src/components/simple/ReorderVaults/ReorderVaultsModal.tsx
@@ -1,10 +1,4 @@
-import {
-  Button,
-  Callout,
-  FullScreenDialog,
-  Heading,
-  Text,
-} from "@babylonlabs-io/core-ui";
+import { Button, Callout, Heading, Text } from "@babylonlabs-io/core-ui";
 import {
   closestCenter,
   DndContext,
@@ -25,6 +19,7 @@ import {
 import type { Hex } from "viem";
 
 import { useReorderOverride } from "@/applications/aave/context";
+import { V3ModalShell } from "@/components/shared/V3ModalShell";
 import { COPY } from "@/copy";
 import type { CollateralVaultEntry } from "@/types/collateral";
 
@@ -89,12 +84,12 @@ export function ReorderVaultsModal({
   };
 
   return (
-    <FullScreenDialog
+    <V3ModalShell
       open={isOpen}
       onClose={handleClose}
-      className="items-center justify-center p-6"
+      contentClassName="max-w-[564px]"
     >
-      <div className="mx-auto flex w-full max-w-[564px] flex-col gap-4">
+      <div className="flex w-full flex-col gap-4">
         <div className="flex flex-col gap-2">
           <Heading
             variant="h5"
@@ -171,6 +166,6 @@ export function ReorderVaultsModal({
           </div>
         </div>
       </div>
-    </FullScreenDialog>
+    </V3ModalShell>
   );
 }

--- a/services/vault/src/components/simple/ReorderVaults/constants.ts
+++ b/services/vault/src/components/simple/ReorderVaults/constants.ts
@@ -6,9 +6,4 @@ export const REORDER_MODAL_SUBTITLE =
 export const REORDER_INFO_TEXT =
   "BTC Vaults are liquidated in order from first to last. Place your smallest BTC Vault first so it acts as a sacrificial buffer. If your largest BTC Vault is first, it will be seized before smaller ones, resulting in a greater loss.";
 
-export const REORDER_SUCCESS_TITLE = "BTC Vault order updated";
-
-export const REORDER_SUCCESS_TEXT =
-  "The liquidation order of your BTC Vaults has been updated.";
-
 export const NETWORK_FEE_LABEL = "Ethereum network fee";

--- a/services/vault/src/components/simple/RiskSection/railLayout.ts
+++ b/services/vault/src/components/simple/RiskSection/railLayout.ts
@@ -43,8 +43,10 @@ export interface RailLayout {
 
 const MARKER_EDGE_MARGIN_PCT = 1.5;
 const MAX_TICKS = 8;
-const GRADIENT_AMBER_OFFSET = 22;
-const GRADIENT_GREEN_OFFSET = 45;
+// Over the rail, red ends at the current-price marker, amber peaks ~21
+// points later, green runs to the end.
+const GRADIENT_AMBER_OFFSET = 21;
+const GRADIENT_GREEN_STOP = 100;
 
 function isUsablePrice(price: number | null): price is number {
   return price !== null && isFinite(price) && price > 0;
@@ -110,14 +112,16 @@ export function computeRailLayout(
   const currentPct = toPct(currentPriceUsd);
   const liquidationPct = hasLiquidation ? toPct(liquidationPriceUsd) : null;
 
+  // The red→amber hand-off sits ON the current-price marker, so the colour
+  // under the dot is the colour the dot's ring reports. Anchoring on the
+  // midpoint instead left the marker sitting in the red band while it was
+  // rendered green.
   let gradient: string | null = null;
   if (liquidationPct !== null) {
-    const midpoint = (liquidationPct + currentPct) / 2;
-    const amber = Math.min(midpoint + GRADIENT_AMBER_OFFSET, 100);
-    const green = Math.min(midpoint + GRADIENT_GREEN_OFFSET, 100);
+    const amber = Math.min(currentPct + GRADIENT_AMBER_OFFSET, 100);
     gradient =
-      `linear-gradient(90deg, rgb(var(--risk-red)) ${midpoint}%, ` +
-      `rgb(var(--risk-amber)) ${amber}%, rgb(var(--risk-green)) ${green}%)`;
+      `linear-gradient(90deg, rgb(var(--risk-red)) ${currentPct}%, ` +
+      `rgb(var(--risk-amber)) ${amber}%, rgb(var(--risk-green)) ${GRADIENT_GREEN_STOP}%)`;
   }
 
   return { lo, hi, ticks, currentPct, liquidationPct, gradient };

--- a/services/vault/src/components/simple/SimpleDeposit.tsx
+++ b/services/vault/src/components/simple/SimpleDeposit.tsx
@@ -1,9 +1,11 @@
-import { FullScreenDialog, Heading } from "@babylonlabs-io/core-ui";
+import { Heading } from "@babylonlabs-io/core-ui";
 import { useChainConnector } from "@babylonlabs-io/wallet-connector";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { Address } from "viem";
 
+import { ApplicationLogo } from "@/components/ApplicationLogo";
 import { isDepositBlocked } from "@/components/shared/protocolStatus";
+import { V3ModalShell } from "@/components/shared/V3ModalShell";
 import { FeatureFlags } from "@/config";
 import { useAddressScreening } from "@/context/addressScreening";
 import { useGeoFencing } from "@/context/geofencing";
@@ -438,18 +440,28 @@ function SimpleDepositContent({
   };
 
   const showForm = !renderedStep || renderedStep === DepositStep.FORM;
+  const headerApp = FeatureFlags.isV3UiEnabled
+    ? applications.find((a) => a.id === effectiveSelectedApplication)
+    : undefined;
   const stepKey = renderedStep ?? "form";
 
   return (
-    <FullScreenDialog
-      open={open}
-      onClose={onClose}
-      className="items-center justify-center p-6"
-    >
+    <V3ModalShell open={open} onClose={onClose}>
       <FadeTransition stepKey={stepKey}>
         {showForm && (
           <div className="mx-auto w-full max-w-[564px]">
-            <Heading variant="h5">Deposit</Heading>
+            {/* v3 puts the target application's logo in the header row
+                instead of a separate app card inside the form. */}
+            <div className="flex items-center justify-between gap-2">
+              <Heading variant="h5">Deposit</Heading>
+              {headerApp && (
+                <ApplicationLogo
+                  logoUrl={headerApp.logoUrl}
+                  name={headerApp.name}
+                  size="small"
+                />
+              )}
+            </div>
             <div className="mt-4">
               <DepositForm
                 amountState={{
@@ -563,7 +575,7 @@ function SimpleDepositContent({
           </div>
         )}
       </FadeTransition>
-    </FullScreenDialog>
+    </V3ModalShell>
   );
 }
 
@@ -579,21 +591,19 @@ export default function SimpleDeposit(props: SimpleDepositProps) {
   if (resumeMode) {
     return (
       <ProtocolParamsProvider>
-        <FullScreenDialog
+        <V3ModalShell
           open={open}
           onClose={onClose}
-          className="items-center justify-center p-6"
+          contentClassName="max-w-[520px]"
         >
-          <div className="mx-auto w-full max-w-[520px]">
-            <ResumeBroadcastContent
-              activity={props.activity}
-              batchVaultIds={props.batchVaultIds}
-              depositorEthAddress={props.depositorEthAddress}
-              onClose={onClose}
-              onSuccess={props.onResumeSuccess}
-            />
-          </div>
-        </FullScreenDialog>
+          <ResumeBroadcastContent
+            activity={props.activity}
+            batchVaultIds={props.batchVaultIds}
+            depositorEthAddress={props.depositorEthAddress}
+            onClose={onClose}
+            onSuccess={props.onResumeSuccess}
+          />
+        </V3ModalShell>
       </ProtocolParamsProvider>
     );
   }

--- a/services/vault/src/components/simple/UtxoSplitSelectorV3.tsx
+++ b/services/vault/src/components/simple/UtxoSplitSelectorV3.tsx
@@ -4,6 +4,10 @@ import { IoCheckmark, IoChevronUp } from "react-icons/io5";
 import { TWO_VAULT_SPLIT_DOCS_URL } from "@/constants";
 import { COPY } from "@/copy";
 
+/**
+ * Split state driving the picker. Declared here (rather than imported from the
+ * v2 file) so the v2 selector can be deleted whole when ENABLE_V3_UI retires.
+ */
 export interface TwoVaultSplitProps {
   isEnabled: boolean;
   onChange: (checked: boolean) => void;
@@ -14,24 +18,31 @@ export interface TwoVaultSplitProps {
   isSplitAmountTooLow: boolean;
 }
 
-interface UtxoSplitSelectorProps {
+export interface UtxoSplitSelectorProps {
   twoVaultSplit: TwoVaultSplitProps;
   expanded: boolean;
   onExpandedChange: (expanded: boolean) => void;
 }
 
-export function UtxoSplitSelector({
+const FORM_COPY = COPY.deposit.form;
+
+export function UtxoSplitSelectorV3({
   twoVaultSplit,
   expanded,
   onExpandedChange,
 }: UtxoSplitSelectorProps) {
   const splitDisabled = !twoVaultSplit.canSplit || twoVaultSplit.isLoading;
 
+  // Picking an option collapses the panel, matching the vault provider picker.
+  const select = (enabled: boolean) => {
+    twoVaultSplit.onChange(enabled);
+    onExpandedChange(false);
+  };
   const handleSelectSplit = () => {
     if (splitDisabled) return;
-    twoVaultSplit.onChange(true);
+    select(true);
   };
-  const handleSelectNoSplit = () => twoVaultSplit.onChange(false);
+  const handleSelectNoSplit = () => select(false);
 
   const splitTitleColor = twoVaultSplit.isEnabled
     ? "text-accent-primary"
@@ -39,6 +50,12 @@ export function UtxoSplitSelector({
   const noSplitTitleColor = twoVaultSplit.isEnabled
     ? "text-accent-secondary"
     : "text-accent-primary";
+
+  // Selected option is filled; the unselected one keeps the same padding so
+  // the two rows stay aligned. The card clips the corners, so the top option
+  // can never show bottom corners (and vice versa).
+  const optionBox = (selected: boolean) =>
+    `p-4${selected ? " bg-primary-contrast" : ""}`;
 
   return (
     <Accordion expanded={expanded}>
@@ -51,15 +68,13 @@ export function UtxoSplitSelector({
           <span className="text-sm text-accent-primary">
             {twoVaultSplit.isEnabled ? (
               <>
-                {COPY.deposit.form.splitOptionLabel(
-                  twoVaultSplit.splitRatioLabel,
-                )}{" "}
+                {FORM_COPY.splitOptionLabel(twoVaultSplit.splitRatioLabel)}{" "}
                 <span className="text-accent-secondary">
-                  {COPY.deposit.form.splitOptionRecommended}
+                  {FORM_COPY.splitOptionRecommended}
                 </span>
               </>
             ) : (
-              COPY.deposit.form.doNotSplit
+              FORM_COPY.doNotSplit
             )}
           </span>
           <IoChevronUp
@@ -71,13 +86,13 @@ export function UtxoSplitSelector({
       <AccordionDetails className="pt-4">
         <Card
           variant="default"
-          className="flex w-full flex-col gap-6 !rounded-lg !bg-primary-contrast !py-4"
+          className="flex w-full flex-col overflow-hidden !rounded-lg !bg-transparent !p-0"
         >
           <div
             role="button"
             tabIndex={splitDisabled ? -1 : 0}
             aria-disabled={splitDisabled}
-            className={`flex w-full items-start justify-between gap-3 text-left ${splitDisabled ? "cursor-not-allowed opacity-50" : "cursor-pointer"}`}
+            className={`flex w-full items-start justify-between gap-3 text-left ${splitDisabled ? "cursor-not-allowed opacity-50" : "cursor-pointer"} ${optionBox(twoVaultSplit.isEnabled)}`}
             onClick={handleSelectSplit}
             onKeyDown={(event) => {
               if (event.key === "Enter" || event.key === " ") {
@@ -88,15 +103,13 @@ export function UtxoSplitSelector({
           >
             <span className="flex flex-col gap-1">
               <span className={`text-sm ${splitTitleColor}`}>
-                {COPY.deposit.form.splitOptionLabel(
-                  twoVaultSplit.splitRatioLabel,
-                )}{" "}
+                {FORM_COPY.splitOptionLabel(twoVaultSplit.splitRatioLabel)}{" "}
                 <span className="text-accent-secondary">
-                  {COPY.deposit.form.splitOptionRecommended}
+                  {FORM_COPY.splitOptionRecommended}
                 </span>
               </span>
               <span className="text-xs text-accent-secondary">
-                {COPY.deposit.form.splitOptionDescription}{" "}
+                {FORM_COPY.splitOptionDescription}{" "}
                 <a
                   href={TWO_VAULT_SPLIT_DOCS_URL}
                   target="_blank"
@@ -104,7 +117,7 @@ export function UtxoSplitSelector({
                   className="text-secondary-main underline"
                   onClick={(event) => event.stopPropagation()}
                 >
-                  {COPY.deposit.form.learnMore}
+                  {FORM_COPY.learnMore}
                 </a>
               </span>
             </span>
@@ -116,7 +129,7 @@ export function UtxoSplitSelector({
           <div
             role="button"
             tabIndex={0}
-            className="flex w-full cursor-pointer items-start justify-between gap-3 text-left"
+            className={`flex w-full cursor-pointer items-start justify-between gap-3 text-left ${optionBox(!twoVaultSplit.isEnabled)}`}
             onClick={handleSelectNoSplit}
             onKeyDown={(event) => {
               if (event.key === "Enter" || event.key === " ") {
@@ -127,10 +140,10 @@ export function UtxoSplitSelector({
           >
             <span className="flex flex-col gap-1">
               <span className={`text-sm ${noSplitTitleColor}`}>
-                {COPY.deposit.form.doNotSplit}
+                {FORM_COPY.doNotSplit}
               </span>
               <span className="text-xs text-accent-secondary">
-                {COPY.deposit.form.noSplitOptionDescription}
+                {FORM_COPY.noSplitOptionDescription}
               </span>
             </span>
             {!twoVaultSplit.isEnabled && (
@@ -139,8 +152,8 @@ export function UtxoSplitSelector({
           </div>
 
           {twoVaultSplit.isLoading && (
-            <span className="text-xs text-accent-secondary">
-              {COPY.deposit.form.computingAllocation}
+            <span className="px-4 pb-4 text-xs text-accent-secondary">
+              {FORM_COPY.computingAllocation}
             </span>
           )}
         </Card>

--- a/services/vault/src/components/simple/VaultProviderSelector.tsx
+++ b/services/vault/src/components/simple/VaultProviderSelector.tsx
@@ -16,16 +16,11 @@ import {
 } from "@/utils/formatting";
 import { isProblematicVaultProvider } from "@/utils/sortVaultProviders";
 
-const FORM_COPY = COPY.deposit.form;
+// Props live in the v3 file so this whole file can be deleted when
+// ENABLE_V3_UI retires.
+import type { VaultProviderSelectorProps } from "./VaultProviderSelectorV3";
 
-interface VaultProviderSelectorProps {
-  providers: VaultProviderListItem[];
-  isLoadingProviders: boolean;
-  selectedProvider: string;
-  onProviderSelect: (providerId: string) => void;
-  expanded: boolean;
-  onExpandedChange: (expanded: boolean) => void;
-}
+const FORM_COPY = COPY.deposit.form;
 
 /**
  * Status line text for a problematic provider row. Healthy providers don't

--- a/services/vault/src/components/simple/VaultProviderSelectorV3.tsx
+++ b/services/vault/src/components/simple/VaultProviderSelectorV3.tsx
@@ -1,0 +1,239 @@
+import {
+  Accordion,
+  AccordionDetails,
+  Card,
+  Loader,
+} from "@babylonlabs-io/core-ui";
+import { IoCheckmarkCircle, IoChevronUp, IoWarning } from "react-icons/io5";
+
+import { ApplicationLogo } from "@/components/ApplicationLogo";
+import { VAULT_PROVIDER_DOCS_URL } from "@/constants";
+import { COPY } from "@/copy";
+import type { VaultProviderListItem } from "@/types/vaultProvider";
+import {
+  formatBasisPointsAsPercent,
+  formatBtcFromSats,
+  formatTimeAgo,
+} from "@/utils/formatting";
+import { isProblematicVaultProvider } from "@/utils/sortVaultProviders";
+
+const FORM_COPY = COPY.deposit.form;
+
+/**
+ * Props for both the v2 (`VaultProviderSelector`) and v3 pickers. Declared
+ * here so the v2 file can be deleted whole when ENABLE_V3_UI retires.
+ */
+export interface VaultProviderSelectorProps {
+  providers: VaultProviderListItem[];
+  isLoadingProviders: boolean;
+  selectedProvider: string;
+  onProviderSelect: (providerId: string) => void;
+  expanded: boolean;
+  onExpandedChange: (expanded: boolean) => void;
+}
+
+/**
+ * Status line under a provider name: the rejection / unhealthy reason for a
+ * problematic provider, otherwise "Active".
+ */
+function statusLabel(provider: VaultProviderListItem): string {
+  if (provider.unavailable) {
+    return provider.unavailableReason ?? FORM_COPY.providerStatusUnavailable;
+  }
+  if (provider.unhealthy) {
+    return FORM_COPY.providerStatusUnhealthy;
+  }
+  return FORM_COPY.providerStatusActive;
+}
+
+/** Commission metric value, with a placeholder while it loads / on failure. */
+function commissionValue(provider: VaultProviderListItem): string {
+  return provider.commissionBps === undefined
+    ? FORM_COPY.providerMetricPlaceholder
+    : formatBasisPointsAsPercent(provider.commissionBps);
+}
+
+/** Active-BTC metric value, with a placeholder while it loads / on failure. */
+function activeBtcValue(provider: VaultProviderListItem): string {
+  return provider.totalActiveSats === undefined
+    ? FORM_COPY.providerMetricPlaceholder
+    : formatBtcFromSats(provider.totalActiveSats);
+}
+
+/** Relative time of the VP's latest activated vault; placeholder if none. */
+function lastDepositValue(provider: VaultProviderListItem): string {
+  return provider.lastSuccessfulPeginAt === undefined
+    ? FORM_COPY.providerMetricPlaceholder
+    : formatTimeAgo(provider.lastSuccessfulPeginAt);
+}
+
+/** One right-hand metric column of a provider row: value over label. */
+function metricColumn(value: string, label: string) {
+  return (
+    <span className="flex min-w-[60px] flex-col justify-center whitespace-nowrap">
+      <span className="text-xs text-accent-primary">{value}</span>
+      <span className="text-[8px] text-accent-secondary">{label}</span>
+    </span>
+  );
+}
+
+export function VaultProviderSelectorV3({
+  providers,
+  isLoadingProviders,
+  selectedProvider,
+  onProviderSelect,
+  expanded,
+  onExpandedChange,
+}: VaultProviderSelectorProps) {
+  const selectedProviderData = providers.find((p) => p.id === selectedProvider);
+  const headerLabel =
+    selectedProviderData?.name ?? FORM_COPY.selectVaultProvider;
+
+  // `providers` arrives pre-sorted (healthy first, problematic last), so the
+  // first problematic entry marks where the "currently unavailable" group
+  // starts. A divider is only meaningful when healthy providers precede it.
+  const firstProblematicIndex = providers.findIndex(isProblematicVaultProvider);
+
+  return (
+    <Accordion expanded={expanded}>
+      <Card variant="filled" className="!rounded-lg !p-0">
+        <button
+          type="button"
+          className="flex w-full items-center justify-between px-6 py-4"
+          onClick={() => onExpandedChange(!expanded)}
+        >
+          <span
+            className={`text-sm ${selectedProviderData ? "text-accent-primary" : "text-accent-secondary"}`}
+          >
+            {headerLabel}
+          </span>
+          <IoChevronUp
+            className={`text-accent-primary transition-transform ${expanded ? "" : "rotate-180"}`}
+          />
+        </button>
+      </Card>
+
+      <AccordionDetails className="pt-4">
+        <Card
+          variant="default"
+          className="flex w-full flex-col gap-4 !rounded-lg !bg-primary-contrast !py-4"
+        >
+          {/* The "choose a provider" prompt only makes sense when there is
+              something to choose. Hidden in the empty state (e.g. every VP
+              disabled) so it doesn't contradict the empty message below. */}
+          {(isLoadingProviders || providers.length > 0) && (
+            <span className="flex flex-col">
+              <span className="text-sm text-accent-secondary">
+                {FORM_COPY.providerSelectDescriptionV3}
+                <a
+                  href={VAULT_PROVIDER_DOCS_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-secondary-main underline"
+                >
+                  {FORM_COPY.providerSelectDescriptionLink}
+                </a>
+              </span>
+              <span className="text-xs text-accent-secondary">
+                {FORM_COPY.providerSortNote}
+              </span>
+            </span>
+          )}
+
+          {isLoadingProviders ? (
+            <div className="flex items-center justify-center py-2">
+              <Loader size={24} className="text-primary-main" />
+            </div>
+          ) : providers.length === 0 ? (
+            <p className="text-sm text-accent-secondary">
+              {FORM_COPY.providerSelectEmpty}
+            </p>
+          ) : (
+            providers.map((provider, index) => {
+              const isSelected = provider.id === selectedProvider;
+              const problematic = isProblematicVaultProvider(provider);
+              // Runtime-unhealthy VPs stay selectable (health can recover);
+              // metadata-rejected VPs do not.
+              const isDisabled = provider.unavailable;
+              const handleSelect = () => {
+                if (isDisabled) return;
+                onProviderSelect(provider.id);
+                onExpandedChange(false);
+              };
+              return (
+                <div key={provider.id} className="flex flex-col gap-4">
+                  {index === firstProblematicIndex && index > 0 && (
+                    <div className="h-px w-full bg-secondary-strokeLight" />
+                  )}
+                  {/* The whole row is the selection control; the metrics are
+                      fixed columns on the right. Rows carry no selected
+                      styling — picking one collapses the panel and the
+                      collapsed header names the chosen provider. */}
+                  <button
+                    type="button"
+                    disabled={isDisabled}
+                    onClick={handleSelect}
+                    aria-pressed={isSelected}
+                    className={`-mx-2 flex w-[calc(100%+1rem)] items-center justify-between gap-4 rounded-md px-2 py-2 text-left ${isDisabled ? "cursor-not-allowed opacity-50" : "cursor-pointer"}`}
+                  >
+                    <span className="flex items-center gap-2">
+                      {/* Avatar carries a status badge: a check for a healthy
+                          provider, a warning for an unreachable / rejected
+                          one. The badge sits on the card background so it
+                          punches out of the avatar edge. */}
+                      <span className="relative shrink-0">
+                        <ApplicationLogo
+                          logoUrl={provider.iconUrl ?? null}
+                          name={provider.name}
+                          size="sm"
+                        />
+                        <span className="absolute -bottom-0.5 -right-0.5 flex size-3 items-center justify-center rounded-full bg-primary-contrast">
+                          {problematic ? (
+                            <IoWarning
+                              className="text-error-main"
+                              size={10}
+                              title={statusLabel(provider)}
+                            />
+                          ) : (
+                            <IoCheckmarkCircle
+                              className="text-success-bright"
+                              size={12}
+                            />
+                          )}
+                        </span>
+                      </span>
+                      <span className="flex flex-col justify-center">
+                        <span className="text-sm text-accent-primary">
+                          {provider.name}
+                        </span>
+                        <span
+                          className={`text-[10px] ${problematic ? "text-error-main" : "text-success-bright"}`}
+                        >
+                          {statusLabel(provider)}
+                        </span>
+                      </span>
+                    </span>
+                    <span className="flex items-center gap-4">
+                      {metricColumn(
+                        commissionValue(provider),
+                        FORM_COPY.providerCommissionLabel,
+                      )}
+                      {metricColumn(
+                        activeBtcValue(provider),
+                        FORM_COPY.providerActiveBtcLabel,
+                      )}
+                      {metricColumn(
+                        lastDepositValue(provider),
+                        FORM_COPY.providerLastDepositLabel,
+                      )}
+                    </span>
+                  </button>
+                </div>
+              );
+            })
+          )}
+        </Card>
+      </AccordionDetails>
+    </Accordion>
+  );
+}

--- a/services/vault/src/components/simple/VaultProviderSelectorV3.tsx
+++ b/services/vault/src/components/simple/VaultProviderSelectorV3.tsx
@@ -7,6 +7,7 @@ import {
 import { IoCheckmarkCircle, IoChevronUp, IoWarning } from "react-icons/io5";
 
 import { ApplicationLogo } from "@/components/ApplicationLogo";
+import { ExplorerLink } from "@/components/shared";
 import { VAULT_PROVIDER_DOCS_URL } from "@/constants";
 import { COPY } from "@/copy";
 import type { VaultProviderListItem } from "@/types/vaultProvider";
@@ -170,69 +171,79 @@ export function VaultProviderSelectorV3({
                   {index === firstProblematicIndex && index > 0 && (
                     <div className="h-px w-full bg-secondary-strokeLight" />
                   )}
-                  {/* The whole row is the selection control; the metrics are
-                      fixed columns on the right. Rows carry no selected
-                      styling — picking one collapses the panel and the
-                      collapsed header names the chosen provider. */}
-                  <button
-                    type="button"
-                    disabled={isDisabled}
-                    onClick={handleSelect}
-                    aria-pressed={isSelected}
-                    className={`-mx-2 flex w-[calc(100%+1rem)] items-center justify-between gap-4 rounded-md px-2 py-2 text-left ${isDisabled ? "cursor-not-allowed opacity-50" : "cursor-pointer"}`}
-                  >
-                    <span className="flex items-center gap-2">
-                      {/* Avatar carries a status badge: a check for a healthy
+                  {/* Row is a flex container holding two SIBLING controls: the
+                      selection button and (when configured) the explorer link,
+                      so the link isn't nested inside another interactive
+                      element. Rows carry no selected styling — picking one
+                      collapses the panel and the collapsed header names the
+                      chosen provider. */}
+                  <div className="-mx-2 flex w-[calc(100%+1rem)] items-center gap-2 rounded-md px-2 py-2">
+                    <button
+                      type="button"
+                      disabled={isDisabled}
+                      onClick={handleSelect}
+                      aria-pressed={isSelected}
+                      className={`flex flex-1 items-center justify-between gap-4 text-left ${isDisabled ? "cursor-not-allowed opacity-50" : "cursor-pointer"}`}
+                    >
+                      <span className="flex items-center gap-2">
+                        {/* Avatar carries a status badge: a check for a healthy
                           provider, a warning for an unreachable / rejected
                           one. The badge sits on the card background so it
                           punches out of the avatar edge. */}
-                      <span className="relative shrink-0">
-                        <ApplicationLogo
-                          logoUrl={provider.iconUrl ?? null}
-                          name={provider.name}
-                          size="sm"
-                        />
-                        <span className="absolute -bottom-0.5 -right-0.5 flex size-3 items-center justify-center rounded-full bg-primary-contrast">
-                          {problematic ? (
-                            <IoWarning
-                              className="text-error-main"
-                              size={10}
-                              title={statusLabel(provider)}
-                            />
-                          ) : (
-                            <IoCheckmarkCircle
-                              className="text-success-bright"
-                              size={12}
-                            />
-                          )}
+                        <span className="relative shrink-0">
+                          <ApplicationLogo
+                            logoUrl={provider.iconUrl ?? null}
+                            name={provider.name}
+                            size="sm"
+                          />
+                          <span className="absolute -bottom-0.5 -right-0.5 flex size-3 items-center justify-center rounded-full bg-primary-contrast">
+                            {problematic ? (
+                              <IoWarning
+                                className="text-error-main"
+                                size={10}
+                                title={statusLabel(provider)}
+                              />
+                            ) : (
+                              <IoCheckmarkCircle
+                                className="text-success-bright"
+                                size={12}
+                              />
+                            )}
+                          </span>
+                        </span>
+                        <span className="flex flex-col justify-center">
+                          <span className="text-sm text-accent-primary">
+                            {provider.name}
+                          </span>
+                          <span
+                            className={`text-[10px] ${problematic ? "text-error-main" : "text-success-bright"}`}
+                          >
+                            {statusLabel(provider)}
+                          </span>
                         </span>
                       </span>
-                      <span className="flex flex-col justify-center">
-                        <span className="text-sm text-accent-primary">
-                          {provider.name}
-                        </span>
-                        <span
-                          className={`text-[10px] ${problematic ? "text-error-main" : "text-success-bright"}`}
-                        >
-                          {statusLabel(provider)}
-                        </span>
+                      <span className="flex items-center gap-4">
+                        {metricColumn(
+                          commissionValue(provider),
+                          FORM_COPY.providerCommissionLabel,
+                        )}
+                        {metricColumn(
+                          activeBtcValue(provider),
+                          FORM_COPY.providerActiveBtcLabel,
+                        )}
+                        {metricColumn(
+                          lastDepositValue(provider),
+                          FORM_COPY.providerLastDepositLabel,
+                        )}
                       </span>
-                    </span>
-                    <span className="flex items-center gap-4">
-                      {metricColumn(
-                        commissionValue(provider),
-                        FORM_COPY.providerCommissionLabel,
-                      )}
-                      {metricColumn(
-                        activeBtcValue(provider),
-                        FORM_COPY.providerActiveBtcLabel,
-                      )}
-                      {metricColumn(
-                        lastDepositValue(provider),
-                        FORM_COPY.providerLastDepositLabel,
-                      )}
-                    </span>
-                  </button>
+                    </button>
+                    {provider.explorerUrl && (
+                      <ExplorerLink
+                        href={provider.explorerUrl}
+                        label={FORM_COPY.providerExplorerLinkLabel}
+                      />
+                    )}
+                  </div>
                 </div>
               );
             })

--- a/services/vault/src/components/simple/VaultProviderSelectorV3.tsx
+++ b/services/vault/src/components/simple/VaultProviderSelectorV3.tsx
@@ -125,14 +125,19 @@ export function VaultProviderSelectorV3({
             <span className="flex flex-col">
               <span className="text-sm text-accent-secondary">
                 {FORM_COPY.providerSelectDescriptionV3}
-                <a
-                  href={VAULT_PROVIDER_DOCS_URL}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-secondary-main underline"
-                >
-                  {FORM_COPY.providerSelectDescriptionLink}
-                </a>
+                {VAULT_PROVIDER_DOCS_URL && (
+                  <>
+                    {FORM_COPY.providerSelectDescriptionDocs}
+                    <a
+                      href={VAULT_PROVIDER_DOCS_URL}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-secondary-main underline"
+                    >
+                      {FORM_COPY.providerSelectDescriptionLink}
+                    </a>
+                  </>
+                )}
               </span>
               <span className="text-xs text-accent-secondary">
                 {FORM_COPY.providerSortNote}

--- a/services/vault/src/components/simple/WithdrawFlow/index.tsx
+++ b/services/vault/src/components/simple/WithdrawFlow/index.tsx
@@ -1,4 +1,3 @@
-import { FullScreenDialog } from "@babylonlabs-io/core-ui";
 import { useCallback, useMemo, useState } from "react";
 
 import { useWithdrawCollateralTransaction } from "@/applications/aave/hooks/useWithdrawCollateralTransaction";
@@ -7,6 +6,7 @@ import {
   getEffectiveVaultSelection,
   getUniquePayoutAddresses,
 } from "@/applications/aave/utils";
+import { V3ModalShell } from "@/components/shared/V3ModalShell";
 import {
   ProtocolParamsProvider,
   useProtocolParamsContext,
@@ -137,11 +137,7 @@ function WithdrawFlowContent({
   ]);
 
   return (
-    <FullScreenDialog
-      open={open}
-      onClose={onClose}
-      className="items-center justify-center p-6"
-    >
+    <V3ModalShell open={open} onClose={onClose}>
       <FadeTransition stepKey={renderedStep}>
         {renderedStep === WithdrawStep.REVIEW && (
           <div className="mx-auto w-full max-w-[612px]">
@@ -168,7 +164,7 @@ function WithdrawFlowContent({
           </div>
         )}
       </FadeTransition>
-    </FullScreenDialog>
+    </V3ModalShell>
   );
 }
 

--- a/services/vault/src/components/simple/WithdrawVaults/WithdrawVaultsModal.tsx
+++ b/services/vault/src/components/simple/WithdrawVaults/WithdrawVaultsModal.tsx
@@ -5,13 +5,9 @@
  * withdrawal flow.
  */
 
-import {
-  Button,
-  FullScreenDialog,
-  Heading,
-  Text,
-} from "@babylonlabs-io/core-ui";
+import { Button, Heading, Text } from "@babylonlabs-io/core-ui";
 
+import { V3ModalShell } from "@/components/shared/V3ModalShell";
 import { COPY } from "@/copy";
 import type { CollateralVaultEntry } from "@/types/collateral";
 import { formatBtcAmount } from "@/utils/formatting";
@@ -52,12 +48,12 @@ export function WithdrawVaultsModal({
     : COPY.withdraw.modal.confirmButton;
 
   return (
-    <FullScreenDialog
+    <V3ModalShell
       open={isOpen}
       onClose={onClose}
-      className="items-center justify-center p-6"
+      contentClassName="max-w-[564px]"
     >
-      <div className="mx-auto flex w-full max-w-[564px] flex-col gap-4">
+      <div className="flex w-full flex-col gap-4">
         <div className="flex flex-col gap-2">
           <Heading
             variant="h5"
@@ -111,6 +107,6 @@ export function WithdrawVaultsModal({
           )}
         </div>
       </div>
-    </FullScreenDialog>
+    </V3ModalShell>
   );
 }

--- a/services/vault/src/components/simple/__tests__/FeesSection.test.tsx
+++ b/services/vault/src/components/simple/__tests__/FeesSection.test.tsx
@@ -70,5 +70,22 @@ describe("FeesSection", () => {
       expect(screen.getByText("Min deposit")).toBeVisible();
       expect(screen.getByText("Collateral Factor")).toBeVisible();
     });
+
+    it("keeps the collapsed panel out of the layout at zero height", () => {
+      render(<FeesSection rows={rows} />);
+
+      const toggle = screen.getByRole("button", {
+        name: /Protocol Parameters/,
+      });
+      const panel = document.getElementById(
+        toggle.getAttribute("aria-controls") as string,
+      ) as HTMLElement;
+      const details = panel.firstElementChild as HTMLElement;
+
+      expect(details).toHaveStyle({ height: "0px", visibility: "hidden" });
+
+      fireEvent.click(toggle);
+      expect(details).toHaveStyle({ visibility: "visible" });
+    });
   });
 });

--- a/services/vault/src/components/simple/__tests__/UtxoSplitSelectorV3.test.tsx
+++ b/services/vault/src/components/simple/__tests__/UtxoSplitSelectorV3.test.tsx
@@ -4,9 +4,9 @@ import { describe, expect, it, vi } from "vitest";
 import { COPY } from "@/copy";
 
 import {
-  UtxoSplitSelector,
+  UtxoSplitSelectorV3,
   type TwoVaultSplitProps,
-} from "../UtxoSplitSelector";
+} from "../UtxoSplitSelectorV3";
 
 function baseSplit(
   overrides: Partial<TwoVaultSplitProps> = {},
@@ -35,10 +35,10 @@ function noSplitRow() {
     .closest('[role="button"]') as HTMLElement;
 }
 
-describe("UtxoSplitSelector", () => {
+describe("UtxoSplitSelectorV3", () => {
   it("renders both split options when expanded", () => {
     render(
-      <UtxoSplitSelector
+      <UtxoSplitSelectorV3
         twoVaultSplit={baseSplit()}
         expanded
         onExpandedChange={vi.fn()}
@@ -52,7 +52,7 @@ describe("UtxoSplitSelector", () => {
   it("selects the two-vault split when its row is chosen", () => {
     const onChange = vi.fn();
     render(
-      <UtxoSplitSelector
+      <UtxoSplitSelectorV3
         twoVaultSplit={baseSplit({ onChange })}
         expanded
         onExpandedChange={vi.fn()}
@@ -66,7 +66,7 @@ describe("UtxoSplitSelector", () => {
   it("selects no-split when its row is chosen", () => {
     const onChange = vi.fn();
     render(
-      <UtxoSplitSelector
+      <UtxoSplitSelectorV3
         twoVaultSplit={baseSplit({ isEnabled: true, onChange })}
         expanded
         onExpandedChange={vi.fn()}
@@ -77,13 +77,32 @@ describe("UtxoSplitSelector", () => {
     expect(onChange).toHaveBeenCalledWith(false);
   });
 
+  it("collapses the panel after an option is selected", () => {
+    const onExpandedChange = vi.fn();
+    render(
+      <UtxoSplitSelectorV3
+        twoVaultSplit={baseSplit()}
+        expanded
+        onExpandedChange={onExpandedChange}
+      />,
+    );
+
+    fireEvent.click(splitRow());
+    expect(onExpandedChange).toHaveBeenCalledWith(false);
+
+    onExpandedChange.mockClear();
+    fireEvent.click(noSplitRow());
+    expect(onExpandedChange).toHaveBeenCalledWith(false);
+  });
+
   it("keeps the split option unavailable (aria-disabled) and unselectable when it cannot split", () => {
     const onChange = vi.fn();
+    const onExpandedChange = vi.fn();
     render(
-      <UtxoSplitSelector
+      <UtxoSplitSelectorV3
         twoVaultSplit={baseSplit({ canSplit: false, onChange })}
         expanded
-        onExpandedChange={vi.fn()}
+        onExpandedChange={onExpandedChange}
       />,
     );
 
@@ -91,5 +110,7 @@ describe("UtxoSplitSelector", () => {
     expect(row).toHaveAttribute("aria-disabled", "true");
     fireEvent.click(row);
     expect(onChange).not.toHaveBeenCalledWith(true);
+    // A rejected selection must not collapse the panel either.
+    expect(onExpandedChange).not.toHaveBeenCalled();
   });
 });

--- a/services/vault/src/components/vaults/VaultsActiveSection.tsx
+++ b/services/vault/src/components/vaults/VaultsActiveSection.tsx
@@ -14,6 +14,7 @@ import { Heading, Loader } from "@babylonlabs-io/core-ui";
 import { ApplicationLogo } from "@/components/ApplicationLogo";
 import { NEUTRAL_ROW_BUTTON_CLASS } from "@/components/shared/buttonClasses";
 import { CopyableHash } from "@/components/shared/CopyableHash";
+import { ListRowCard } from "@/components/shared/ListRow";
 import { COPY } from "@/copy";
 import type { CollateralVaultEntry } from "@/types/collateral";
 import { getBtcExplorerTxUrl } from "@/utils/explorer";
@@ -39,7 +40,7 @@ function ActiveVaultRow({
   const hash = vault.peginTxHash ?? vault.prePeginTxHash;
 
   return (
-    <div className="flex w-full flex-wrap items-center gap-x-4 gap-y-3 rounded-lg border border-secondary-strokeLight bg-secondary-highlight p-4 dark:bg-[#202020]">
+    <ListRowCard>
       {/* Amount + liquidation ordinal */}
       <div className="flex w-[180px] shrink-0 items-center gap-2">
         <ApplicationLogo
@@ -120,7 +121,7 @@ function ActiveVaultRow({
       >
         {COPY.vaults.actions.withdraw}
       </button>
-    </div>
+    </ListRowCard>
   );
 }
 

--- a/services/vault/src/components/vaults/VaultsSummaryCard.tsx
+++ b/services/vault/src/components/vaults/VaultsSummaryCard.tsx
@@ -2,20 +2,23 @@
  * VaultsSummaryCard — the v3 /vaults summary strip (issue #2041).
  *
  * Three panes: total collateral value + Deposit, active-vault count with the
- * liquidation-order sequence + Reorder, and the health factor. Purely
- * presentational — all values arrive formatted from useVaultsPageData.
+ * liquidation-order sequence + Reorder, and the health factor. Renders through
+ * the shared `PositionStatCards` primitive so this strip stays identical to the
+ * Overview and Loans summaries. Purely presentational — all values arrive
+ * formatted from useVaultsPageData.
  */
 
-import { Hint, InfoIcon } from "@babylonlabs-io/core-ui";
 import type { HealthFactorStatus } from "@babylonlabs-io/ts-sdk/tbv/integrations/aave";
-import type { ReactNode } from "react";
 
 import {
   formatHealthFactor,
   getHealthFactorColor,
 } from "@/applications/aave/utils";
 import { HeartIcon } from "@/components/shared";
-import { NEUTRAL_BUTTON_CLASS } from "@/components/shared/buttonClasses";
+import {
+  PositionStatCards,
+  type PositionStatCard,
+} from "@/components/simple/PositionStatCards";
 import { COPY } from "@/copy";
 
 interface VaultsSummaryCardProps {
@@ -31,52 +34,6 @@ interface VaultsSummaryCardProps {
   isReorderDisabled: boolean;
 }
 
-function StatLabel({ label, tooltip }: { label: string; tooltip?: string }) {
-  return (
-    <span className="flex items-center gap-1 whitespace-nowrap text-sm leading-[1.43] tracking-[0.17px] text-accent-secondary">
-      {tooltip ? (
-        <Hint
-          tooltip={tooltip}
-          icon={<InfoIcon size={16} className="text-accent-secondary" />}
-        >
-          {label}
-        </Hint>
-      ) : (
-        label
-      )}
-    </span>
-  );
-}
-
-function StatPane({
-  label,
-  tooltip,
-  value,
-  caption,
-  action,
-}: {
-  label: string;
-  tooltip?: string;
-  value: ReactNode;
-  caption: ReactNode;
-  action?: ReactNode;
-}) {
-  return (
-    <div className="flex min-w-0 flex-1 items-center justify-between gap-4">
-      <div className="flex h-[88px] min-w-0 flex-col justify-between">
-        <StatLabel label={label} tooltip={tooltip} />
-        <span className="text-xl leading-8 tracking-[0.15px] text-accent-primary">
-          {value}
-        </span>
-        <span className="truncate text-sm leading-[1.43] tracking-[0.17px] text-accent-secondary">
-          {caption}
-        </span>
-      </div>
-      {action}
-    </div>
-  );
-}
-
 export function VaultsSummaryCard({
   totalCollateralBtc,
   totalCollateralUsd,
@@ -90,67 +47,47 @@ export function VaultsSummaryCard({
   isReorderDisabled,
 }: VaultsSummaryCardProps) {
   const healthFactorColor = getHealthFactorColor(healthFactorStatus);
+  const healthFactorText = formatHealthFactor(healthFactor);
 
-  return (
-    <section className="flex w-full flex-col gap-6 rounded-lg border border-secondary-strokeLight bg-secondary-highlight p-6 dark:bg-[#202020] xl:flex-row xl:items-stretch">
-      <StatPane
-        label={COPY.vaults.summary.totalCollateralLabel}
-        tooltip={COPY.overview.totalCollateralValueTooltip}
-        value={totalCollateralBtc}
-        caption={totalCollateralUsd}
-        action={
-          <button
-            type="button"
-            onClick={onDeposit}
-            disabled={isDepositDisabled}
-            className={NEUTRAL_BUTTON_CLASS}
-            // This control's data-testid is a real-wallet E2E hook
-            // (e2e/real/actions/walletConnect.ts, e2e/real/actions/pegin.ts)
-            // — it takes over from the empty state's Deposit button once
-            // vaults exist. Carry it over if you move or rename the element.
-            data-testid="deposit-button"
-          >
-            {COPY.vaults.empty.depositAction}
-          </button>
-        }
-      />
-
-      <div className="h-px w-full bg-secondary-strokeLight xl:h-auto xl:w-px xl:self-stretch" />
-
-      <StatPane
-        label={COPY.vaults.summary.activeVaultsLabel}
-        value={COPY.vaults.summary.vaultCount(activeVaultsCount)}
-        caption={liquidationOrder ?? ""}
-        action={
-          <button
-            type="button"
-            onClick={onReorder}
-            disabled={isReorderDisabled}
-            className={NEUTRAL_BUTTON_CLASS}
-          >
-            {COPY.vaults.actions.reorder}
-          </button>
-        }
-      />
-
-      <div className="h-px w-full bg-secondary-strokeLight xl:h-auto xl:w-px xl:self-stretch" />
-
-      <div className="flex h-[88px] w-full shrink-0 flex-col justify-between xl:w-[324px]">
-        <StatLabel
-          label={COPY.vaults.summary.healthFactorLabel}
-          tooltip={COPY.overview.healthFactorTooltip}
-        />
+  const cards: PositionStatCard[] = [
+    {
+      label: COPY.vaults.summary.totalCollateralLabel,
+      tooltip: COPY.overview.totalCollateralValueTooltip,
+      value: totalCollateralBtc,
+      caption: totalCollateralUsd,
+      actionLabel: COPY.vaults.empty.depositAction,
+      onAction: onDeposit,
+      actionDisabled: isDepositDisabled,
+      // This control's data-testid is a real-wallet E2E hook
+      // (e2e/real/actions/walletConnect.ts, e2e/real/actions/pegin.ts) — it
+      // takes over from the empty state's Deposit button once vaults exist.
+      // Carry it over if you move or rename the element.
+      actionTestId: "deposit-button",
+    },
+    {
+      label: COPY.vaults.summary.activeVaultsLabel,
+      value: COPY.vaults.summary.vaultCount(activeVaultsCount),
+      caption: liquidationOrder ?? undefined,
+      actionLabel: COPY.vaults.actions.reorder,
+      onAction: onReorder,
+      actionDisabled: isReorderDisabled,
+    },
+    {
+      label: COPY.vaults.summary.healthFactorLabel,
+      tooltip: COPY.overview.healthFactorTooltip,
+      value: healthFactorText,
+      valueNode: (
         <span
-          className="flex items-center gap-2 text-xl leading-8 tracking-[0.15px]"
+          className="flex items-center gap-2"
           style={{ color: healthFactorColor }}
         >
-          {formatHealthFactor(healthFactor)}
+          {healthFactorText}
           <HeartIcon color={healthFactorColor} className="size-6" />
         </span>
-        <span className="text-xs leading-[1.66] tracking-[0.4px] text-accent-secondary">
-          {COPY.vaults.summary.healthFactorCaption}
-        </span>
-      </div>
-    </section>
-  );
+      ),
+      caption: COPY.vaults.summary.healthFactorCaption,
+    },
+  ];
+
+  return <PositionStatCards cards={cards} />;
 }

--- a/services/vault/src/constants.ts
+++ b/services/vault/src/constants.ts
@@ -25,6 +25,10 @@ export const SUPPORT_URL = "https://discord.com/invite/babylonglobal";
 export const TWO_VAULT_SPLIT_DOCS_URL =
   "https://docs.babylonlabs.io/trustless-bitcoin-vault/use-for-lending/create-a-vault/#step-1-decide-how-to-split-your-btc";
 
+// Vault provider docs link, surfaced from the v3 provider picker intro.
+// TODO(product): swap in the exact vault-provider page once confirmed.
+export const VAULT_PROVIDER_DOCS_URL = "https://docs.babylonlabs.io";
+
 // Bitcoin protocol constants
 export const BTC_BLOCK_TIME_MINS = 10;
 export const MINS_PER_HOUR = 60;

--- a/services/vault/src/constants.ts
+++ b/services/vault/src/constants.ts
@@ -25,9 +25,12 @@ export const SUPPORT_URL = "https://discord.com/invite/babylonglobal";
 export const TWO_VAULT_SPLIT_DOCS_URL =
   "https://docs.babylonlabs.io/trustless-bitcoin-vault/use-for-lending/create-a-vault/#step-1-decide-how-to-split-your-btc";
 
-// Vault provider docs link, surfaced from the v3 provider picker intro.
-// TODO(product): swap in the exact vault-provider page once confirmed.
-export const VAULT_PROVIDER_DOCS_URL = "https://docs.babylonlabs.io";
+// Vault provider docs link, surfaced from the v3 provider picker intro. Null
+// until the exact "learn about / create your own vault provider" page exists;
+// the picker hides the link (and its clause) while this is null rather than
+// pointing the "create your own" copy at a placeholder page.
+// TODO(product): set the real vault-provider docs URL, then the link renders.
+export const VAULT_PROVIDER_DOCS_URL: string | null = null;
 
 // Bitcoin protocol constants
 export const BTC_BLOCK_TIME_MINS = 10;

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -506,6 +506,9 @@ export const COPY = {
       // Amount-input left-field label; the slider renders its Max button when
       // this reads "max" (case-insensitive), so keep the value as "Max".
       maxLabel: "Max",
+      // v3 amount row: the depositable maximum is labelled as the balance,
+      // with `maxTooltip` explaining the fee buffer / cap adjustments.
+      balanceLabel: "Balance",
       maxTooltip: (opts: { hasSupplyCap: boolean }) =>
         opts.hasSupplyCap
           ? "Reserves a fee buffer, excludes inscription UTXOs, and stays within the supply cap."
@@ -517,6 +520,14 @@ export const COPY = {
       doNotSplit: "Do not split",
       selectVaultProvider: "Select vault provider",
       providerSelectDescription: "Choose a vault provider to secure your BTC",
+      // v3 picker intro: the sentence above renders as a lead-in to
+      // `providerSelectDescriptionLink`, which links out to the vault
+      // provider docs.
+      providerSelectDescriptionV3:
+        "Choose a vault provider to assist with your vault maintenance. For more information about vault provider or to create your own, ",
+      providerSelectDescriptionLink: "please go here.",
+      // Sub-line under the v3 intro, describing the picker's ordering.
+      providerSortNote: "Sorted by most recent deposit",
       providerSelectEmpty: "No vault providers available at this time.",
       providerStatusUnavailable: "Unavailable",
       // Status label for a vault provider that has recently been unreachable
@@ -530,6 +541,12 @@ export const COPY = {
       // Per-provider metric labels shown in the picker.
       providerCommissionLabel: "Commission",
       providerActiveLabel: "Total locked",
+      // v3 picker column labels + healthy-provider status line. The v3 rows
+      // are a metric table, so the labels sit under their values instead of
+      // reading as a sentence.
+      providerActiveBtcLabel: "Active BTC",
+      providerLastDepositLabel: "Last deposit",
+      providerStatusActive: "Active",
       // Fee-breakdown lines (DepositFeesBreakdown) shown before the user
       // submits. The commission label appends the percent, e.g. "VP commission
       // (2.50%)"; net payout is the deposit minus that commission.
@@ -781,6 +798,9 @@ export const COPY = {
     // Separator between a metric's current and projected value (before → after).
     valueTransitionArrow: "→",
     loading: "Loading...",
+    // Accessible labels for the shared v3 modal header controls.
+    close: "Close",
+    back: "Back",
     confirming: "Confirming...",
     applying: "Applying...",
     checking: "Checking...",
@@ -1418,6 +1438,7 @@ export const COPY = {
   },
   reorder: {
     confirmButton: "Confirm",
+    doneButton: "Done",
   },
   protocolFees: {
     sectionTitle: "Protocol Parameters",

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -520,11 +520,13 @@ export const COPY = {
       doNotSplit: "Do not split",
       selectVaultProvider: "Select vault provider",
       providerSelectDescription: "Choose a vault provider to secure your BTC",
-      // v3 picker intro: the sentence above renders as a lead-in to
-      // `providerSelectDescriptionLink`, which links out to the vault
-      // provider docs.
+      // v3 picker intro. The docs clause + link is appended only when a vault
+      // provider docs URL is configured (see VAULT_PROVIDER_DOCS_URL); the
+      // lead-in sentence stands alone otherwise.
       providerSelectDescriptionV3:
-        "Choose a vault provider to assist with your vault maintenance. For more information about vault provider or to create your own, ",
+        "Choose a vault provider to assist with your vault maintenance.",
+      providerSelectDescriptionDocs:
+        " For more information about vault provider or to create your own, ",
       providerSelectDescriptionLink: "please go here.",
       // Sub-line under the v3 intro, describing the picker's ordering.
       providerSortNote: "Sorted by most recent deposit",
@@ -798,9 +800,8 @@ export const COPY = {
     // Separator between a metric's current and projected value (before → after).
     valueTransitionArrow: "→",
     loading: "Loading...",
-    // Accessible labels for the shared v3 modal header controls.
+    // Accessible label for the shared v3 modal header close control.
     close: "Close",
-    back: "Back",
     confirming: "Confirming...",
     applying: "Applying...",
     checking: "Checking...",
@@ -1439,6 +1440,8 @@ export const COPY = {
   reorder: {
     confirmButton: "Confirm",
     doneButton: "Done",
+    successTitle: "BTC Vault order updated",
+    successText: "The liquidation order of your BTC Vaults has been updated.",
   },
   protocolFees: {
     sectionTitle: "Protocol Parameters",


### PR DESCRIPTION
- Split UtxoSplitSelector and VaultProviderSelector into dedicated v3 components (own files, gated once in DepositForm) instead of inline flag branches; both v3 pickers auto-collapse on select.
- VaultProviderSelector v3: match the design row (avatar status badge, metric columns, docs intro), drop the blue selected tint and checkmark.
- Provider/loan/vault lists share ListRow and the row button classes; VaultsSummaryCard now renders through PositionStatCards like the Overview and Loans summaries.
- FeesSection v3 disclosure animates via the shared Accordion motion and uses a boxed plus/minus toggle.
- Deposit form: app logo in the modal header, corrected amount-row fields, accent-primary CTA with stroke-primary disabled state.
- Deposit stepper width matches the design (612px).
- Fix the health-factor rail gradient so the current-price marker sits on the red-to-amber hand-off.
- Add a shared V3ModalShell (close left, network and settings right on the page column) and route deposit, borrow/repay, reorder, withdraw and the redesigned reorder-success modal through it.