### PR TITLE
feat(vault): show god mode panel on v3 Activity and Loans pages

### DIFF
--- a/services/vault/src/components/pages/Activity.tsx
+++ b/services/vault/src/components/pages/Activity.tsx
@@ -1,10 +1,21 @@
 import { Container, Loader } from "@babylonlabs-io/core-ui";
+import { lazy, Suspense } from "react";
 import type { Hex } from "viem";
+
+import { FeatureFlags } from "@/config";
 
 import { useConnection, useETHWallet } from "../../context/wallet";
 import { useActivitiesWithPending } from "../../hooks/useActivitiesWithPending";
 import { ActivityList } from "../Activity";
 import { PAGE_CONTENT_CLASS } from "../shared/layoutClasses";
+
+// Dev-only god-mode panel, lazily imported behind `import.meta.env.DEV` so its
+// code is dropped from production builds entirely (same pattern as VaultsPage).
+const GodModePanel = import.meta.env.DEV
+  ? lazy(() =>
+      import("@/dev/GodModePanel").then((m) => ({ default: m.GodModePanel })),
+    )
+  : null;
 
 export default function Activity() {
   const { address } = useETHWallet();
@@ -12,6 +23,18 @@ export default function Activity() {
   const { data: activities, isLoading } = useActivitiesWithPending(
     isConnected ? (address as Hex) : undefined,
   );
+
+  const isDevToolingEnabled =
+    import.meta.env.DEV && FeatureFlags.isGodModePanelEnabled;
+
+  // Dev/QA god-mode panel (same gate and pattern as VaultsPage) so demo items
+  // can be injected without navigating back to the Vaults page.
+  const godModePanel =
+    isDevToolingEnabled && GodModePanel ? (
+      <Suspense fallback={null}>
+        <GodModePanel />
+      </Suspense>
+    ) : null;
 
   return (
     <Container
@@ -30,6 +53,7 @@ export default function Activity() {
           />
         )}
       </div>
+      {godModePanel}
     </Container>
   );
 }

--- a/services/vault/src/components/pages/Loans.tsx
+++ b/services/vault/src/components/pages/Loans.tsx
@@ -6,6 +6,7 @@
  */
 
 import { Container, Loader } from "@babylonlabs-io/core-ui";
+import { lazy, Suspense } from "react";
 import { useOutletContext } from "react-router";
 
 import { AssetSelectionModal } from "@/applications/aave/components/AssetSelectionModal";
@@ -14,6 +15,7 @@ import { useActiveLoans } from "@/applications/aave/hooks";
 import type { RootLayoutContext } from "@/components/pages/RootLayout";
 import { EmptyState, EmptyStateIcon } from "@/components/shared";
 import { PAGE_CONTENT_CLASS } from "@/components/shared/layoutClasses";
+import { FeatureFlags } from "@/config";
 import { useConnection, useETHWallet } from "@/context/wallet";
 import { COPY } from "@/copy";
 import { useDashboardState } from "@/hooks/useDashboardState";
@@ -22,6 +24,14 @@ import { formatUsdValue } from "@/utils/formatting";
 
 import { ActiveLoansList } from "../simple/ActiveLoansList";
 import { LoansSummary } from "../simple/LoansSummary";
+
+// Dev-only god-mode panel, lazily imported behind `import.meta.env.DEV` so its
+// code is dropped from production builds entirely (same pattern as VaultsPage).
+const GodModePanel = import.meta.env.DEV
+  ? lazy(() =>
+      import("@/dev/GodModePanel").then((m) => ({ default: m.GodModePanel })),
+    )
+  : null;
 
 export default function Loans() {
   const { openDeposit } = useOutletContext<RootLayoutContext>();
@@ -49,6 +59,19 @@ export default function Loans() {
 
   const activeLoans = useActiveLoans(borrowedAssets);
 
+  const isDevToolingEnabled =
+    import.meta.env.DEV && FeatureFlags.isGodModePanelEnabled;
+
+  // Dev/QA god-mode panel (same gate and pattern as VaultsPage). Rendered in
+  // every return branch below so it stays reachable while the position loads or
+  // when the page is in its disconnected/empty state.
+  const godModePanel =
+    isDevToolingEnabled && GodModePanel ? (
+      <Suspense fallback={null}>
+        <GodModePanel />
+      </Suspense>
+    ) : null;
+
   // A borrow position exists once there is collateral to borrow against (or an
   // active loan). With collateral but no debt yet, the summary still renders so
   // the depositor can borrow via its Borrow action — mirroring the v2 Loans
@@ -64,6 +87,7 @@ export default function Loans() {
         <div className="flex items-center justify-center py-12">
           <Loader />
         </div>
+        {godModePanel}
       </Container>
     );
   }
@@ -82,6 +106,7 @@ export default function Loans() {
           onAction={() => openDeposit()}
           withCard
         />
+        {godModePanel}
       </Container>
     );
   }
@@ -130,6 +155,7 @@ export default function Loans() {
       </div>
 
       <AssetSelectionModal {...assetModalProps} />
+      {godModePanel}
     </Container>
   );
 }


### PR DESCRIPTION
# Show the god mode panel on the v3 Activity and Loans pages

## What we did

Made the dev/QA "god mode" panel available on the v3 `/activity` and `/loans` routes. Previously it only showed up on the v1 Dashboard and the v3 Vaults page, so if you were on Activity or Loans you had to navigate away to reach it.

## Why

The god mode panel is a dev-only floating tool for exercising UI states (for example, injecting a demo deposit). It is gated behind `import.meta.env.DEV` and the `NEXT_PUBLIC_FF_GOD_MODE_PANEL` feature flag, so it never ships to real users. Having it on every v3 page means QA and developers can toggle demo state from wherever they are, instead of jumping back to the Vaults page.

## How it works

The panel is lazily imported behind `import.meta.env.DEV`, so in a production build it compiles to `null` and the bundler drops the code entirely. At runtime it only renders when both `import.meta.env.DEV` is true and the `NEXT_PUBLIC_FF_GOD_MODE_PANEL` flag is set. This is the exact same pattern already used on the Vaults page, so the two new pages just reuse it. The panel itself is `position: fixed`, so where it sits in the page markup does not matter visually.

On the Loans page there are three render paths (loading spinner, disconnected/empty state, and the main content). We render the panel in all three so it stays reachable in every state — including before a position loads or when the wallet is disconnected — because the demo tooling is useful regardless of wallet state.

## Approaches considered

1. **Mount it once in the shared v3 layout (`RootLayout`).** One line, available on every route automatically. We did not take this because the existing codebase already mounts the panel per page (Dashboard and Vaults each do their own mount), and the request was specifically to add it to Activity and Loans — not to every current and future route. Per-page mounting keeps the behaviour explicit and consistent with what is already there.

2. **Mount it per page on Activity and Loans (chosen).** Slightly more code (a few lines per file), but it matches the established pattern, keeps each page in control of whether it shows the panel, and does not silently opt in routes we were not asked to touch.

## Testing

- Lint and TypeScript checks pass on both changed files.
- Existing `Activity` and `Loans` page tests pass.
- Manual: with `NEXT_PUBLIC_FF_GOD_MODE_PANEL=true` in a dev build, the floating panel appears on `/activity` and `/loans` and behaves the same as on `/vaults`. A production build does not include it.