### PR TITLE
fix(vault): verify vBTC reserve ID on-chain to block indexer poisoning

### DIFF
--- a/packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/abis/AaveIntegrationAdapter.abi.json
+++ b/packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/abis/AaveIntegrationAdapter.abi.json
@@ -78,7 +78,7 @@
   },
   {
     "type": "function",
-    "name": "BTC_VAULT_CORE_VAULT_BTC_RESERVE_ID",
+    "name": "VAULT_BTC_RESERVE_ID",
     "inputs": [],
     "outputs": [
       {
@@ -91,7 +91,7 @@
   },
   {
     "type": "function",
-    "name": "BTC_VAULT_CORE_WBTC_RESERVE_ID",
+    "name": "WBTC_RESERVE_ID",
     "inputs": [],
     "outputs": [
       {

--- a/services/vault/src/applications/aave/clients/transaction.ts
+++ b/services/vault/src/applications/aave/clients/transaction.ts
@@ -50,11 +50,11 @@ export async function getCoreSpokeAddress(
 /**
  * Read the vBTC reserve ID from the controller contract.
  *
- * BTC_VAULT_CORE_VAULT_BTC_RESERVE_ID is an immutable property on the
- * AaveIntegrationAdapter. Reading it on-chain from the trusted adapter
- * guarantees the reserve ID is not influenced by untrusted external sources
- * (e.g. GraphQL indexer), which would otherwise be able to point collateral
- * and liquidation math at the wrong reserve.
+ * VAULT_BTC_RESERVE_ID is an immutable property on the AaveIntegrationAdapter.
+ * Reading it on-chain from the trusted adapter guarantees the reserve ID is not
+ * influenced by untrusted external sources (e.g. GraphQL indexer), which would
+ * otherwise be able to point collateral and liquidation math at the wrong
+ * reserve.
  *
  * @param controllerAddress - Trusted AaveIntegrationAdapter address
  * @returns vBTC reserve ID on the Core Spoke
@@ -66,7 +66,7 @@ export async function getVaultBtcReserveId(
   return publicClient.readContract({
     address: controllerAddress,
     abi: AaveIntegrationAdapterABI,
-    functionName: "BTC_VAULT_CORE_VAULT_BTC_RESERVE_ID",
+    functionName: "VAULT_BTC_RESERVE_ID",
     args: [],
   }) as Promise<bigint>;
 }

--- a/services/vault/src/applications/aave/clients/transaction.ts
+++ b/services/vault/src/applications/aave/clients/transaction.ts
@@ -48,6 +48,30 @@ export async function getCoreSpokeAddress(
 }
 
 /**
+ * Read the vBTC reserve ID from the controller contract.
+ *
+ * BTC_VAULT_CORE_VAULT_BTC_RESERVE_ID is an immutable property on the
+ * AaveIntegrationAdapter. Reading it on-chain from the trusted adapter
+ * guarantees the reserve ID is not influenced by untrusted external sources
+ * (e.g. GraphQL indexer), which would otherwise be able to point collateral
+ * and liquidation math at the wrong reserve.
+ *
+ * @param controllerAddress - Trusted AaveIntegrationAdapter address
+ * @returns vBTC reserve ID on the Core Spoke
+ */
+export async function getVaultBtcReserveId(
+  controllerAddress: Address,
+): Promise<bigint> {
+  const publicClient = ethClient.getPublicClient();
+  return publicClient.readContract({
+    address: controllerAddress,
+    abi: AaveIntegrationAdapterABI,
+    functionName: "BTC_VAULT_CORE_VAULT_BTC_RESERVE_ID",
+    args: [],
+  }) as Promise<bigint>;
+}
+
+/**
  * Simulate a transaction to catch errors before sending
  *
  * Uses eth_call to simulate the transaction against current blockchain state.

--- a/services/vault/src/applications/aave/services/__tests__/fetchConfig.test.ts
+++ b/services/vault/src/applications/aave/services/__tests__/fetchConfig.test.ts
@@ -9,6 +9,7 @@ vi.mock("../../../../clients/graphql", () => ({
 
 vi.mock("../../clients/transaction", () => ({
   getCoreSpokeAddress: vi.fn(),
+  getVaultBtcReserveId: vi.fn(),
 }));
 
 vi.mock("../../config", () => ({
@@ -16,12 +17,16 @@ vi.mock("../../config", () => ({
 }));
 
 import { graphqlClient } from "../../../../clients/graphql";
-import { getCoreSpokeAddress } from "../../clients/transaction";
+import {
+  getCoreSpokeAddress,
+  getVaultBtcReserveId,
+} from "../../clients/transaction";
 import { getAaveAdapterAddress } from "../../config";
 import { fetchAaveAppConfig } from "../fetchConfig";
 
 const mockRequest = vi.mocked(graphqlClient.request);
 const mockGetCoreSpokeAddress = vi.mocked(getCoreSpokeAddress);
+const mockGetVaultBtcReserveId = vi.mocked(getVaultBtcReserveId);
 const mockGetAaveAdapterAddress = vi.mocked(getAaveAdapterAddress);
 
 const ENV_ADAPTER = "0x1111111111111111111111111111111111111111" as Address;
@@ -32,14 +37,17 @@ const BTC_VAULT_REGISTRY = "0x5555555555555555555555555555555555555555";
 const VBTC_TOKEN = "0x6666666666666666666666666666666666666666";
 const USDC_TOKEN = "0x7777777777777777777777777777777777777777";
 
-function makeResponse(adapterAddress: Address = ENV_ADAPTER) {
+function makeResponse(
+  adapterAddress: Address = ENV_ADAPTER,
+  vaultBtcReserveId = "1",
+) {
   return {
     aaveConfig: {
       id: 1,
       adapterAddress,
       vaultBtcAddress: VAULT_BTC,
       btcVaultRegistryAddress: BTC_VAULT_REGISTRY,
-      vaultBtcReserveId: "1",
+      vaultBtcReserveId,
     },
     aaveReserves: {
       items: [
@@ -91,6 +99,7 @@ describe("fetchAaveAppConfig", () => {
     vi.clearAllMocks();
     mockGetAaveAdapterAddress.mockReturnValue(ENV_ADAPTER);
     mockGetCoreSpokeAddress.mockResolvedValue(CORE_SPOKE);
+    mockGetVaultBtcReserveId.mockResolvedValue(1n);
   });
 
   it("resolves the Core Spoke from the env-pinned adapter when the indexer agrees", async () => {
@@ -129,6 +138,7 @@ describe("fetchAaveAppConfig", () => {
     );
 
     expect(mockGetCoreSpokeAddress).not.toHaveBeenCalled();
+    expect(mockGetVaultBtcReserveId).not.toHaveBeenCalled();
   });
 
   it("returns null when the indexer has no Aave config", async () => {
@@ -139,5 +149,34 @@ describe("fetchAaveAppConfig", () => {
 
     await expect(fetchAaveAppConfig()).resolves.toBeNull();
     expect(mockGetCoreSpokeAddress).not.toHaveBeenCalled();
+  });
+
+  it("resolves the vBTC reserve ID on-chain when the indexer agrees", async () => {
+    mockGetVaultBtcReserveId.mockResolvedValue(1n);
+    mockRequest.mockResolvedValueOnce(makeResponse(ENV_ADAPTER, "1"));
+
+    const result = await fetchAaveAppConfig();
+
+    expect(mockGetVaultBtcReserveId).toHaveBeenCalledWith(ENV_ADAPTER);
+    expect(result?.config.vaultBtcReserveId).toBe(1n);
+    expect(result?.vbtcReserve?.reserveId).toBe(1n);
+  });
+
+  it("fails closed when the indexer reserve ID differs from the on-chain adapter", async () => {
+    mockGetVaultBtcReserveId.mockResolvedValue(1n);
+    mockRequest.mockResolvedValueOnce(makeResponse(ENV_ADAPTER, "2"));
+
+    await expect(fetchAaveAppConfig()).rejects.toThrow(
+      "Aave vBTC reserve ID mismatch: indexer returned 2, expected 1",
+    );
+  });
+
+  it("fails closed when the on-chain reserve ID read fails", async () => {
+    mockGetVaultBtcReserveId.mockRejectedValueOnce(new Error("rpc down"));
+    mockRequest.mockResolvedValueOnce(makeResponse());
+
+    await expect(fetchAaveAppConfig()).rejects.toThrow(
+      `Failed to resolve vBTC reserve ID from adapter ${ENV_ADAPTER}`,
+    );
   });
 });

--- a/services/vault/src/applications/aave/services/fetchConfig.ts
+++ b/services/vault/src/applications/aave/services/fetchConfig.ts
@@ -9,7 +9,10 @@ import { gql } from "graphql-request";
 import type { Address } from "viem";
 
 import { graphqlClient } from "../../../clients/graphql";
-import { getCoreSpokeAddress } from "../clients/transaction";
+import {
+  getCoreSpokeAddress,
+  getVaultBtcReserveId,
+} from "../clients/transaction";
 import { getAaveAdapterAddress } from "../config";
 
 /**
@@ -208,8 +211,6 @@ export async function fetchAaveAppConfig(): Promise<AaveAppConfig | null> {
     return null;
   }
 
-  const vbtcReserveId = BigInt(response.aaveConfig.vaultBtcReserveId);
-
   const adapterAddress = getAaveAdapterAddress();
   const indexedAdapterAddress = response.aaveConfig.adapterAddress as Address;
   if (indexedAdapterAddress.toLowerCase() !== adapterAddress.toLowerCase()) {
@@ -229,6 +230,27 @@ export async function fetchAaveAppConfig(): Promise<AaveAppConfig | null> {
       { cause: error },
     );
   }
+
+  // Resolve the vBTC reserve ID on-chain from the env-pinned adapter and treat
+  // the immutable getter as the source of truth. The GraphQL value is only a
+  // mirror to cross-check: a compromised indexer could otherwise point split /
+  // liquidation math at a different reserve while keeping the adapter address
+  // equal. Fail closed on disagreement or read failure.
+  let onChainReserveId: bigint;
+  try {
+    onChainReserveId = await getVaultBtcReserveId(adapterAddress);
+  } catch (error) {
+    throw new Error(
+      `Failed to resolve vBTC reserve ID from adapter ${adapterAddress}`,
+      { cause: error },
+    );
+  }
+  if (onChainReserveId !== BigInt(response.aaveConfig.vaultBtcReserveId)) {
+    throw new Error(
+      `Aave vBTC reserve ID mismatch: indexer returned ${response.aaveConfig.vaultBtcReserveId}, expected ${onChainReserveId}`,
+    );
+  }
+  const vbtcReserveId = onChainReserveId;
 
   const config: AaveConfig = {
     adapterAddress,


### PR DESCRIPTION
## What this changes

The vault app used to trust the GraphQL indexer for the vBTC reserve ID — the number that tells the app which reserve is our Bitcoin collateral. This PR stops trusting the indexer for that number and reads it directly from the immutable on-chain getter on the env-pinned adapter, then fails closed if the on-chain value and the indexer value disagree (or if the read fails).

## Why it matters

The vBTC reserve ID feeds the whole borrow side: borrow capacity, projected health factor, liquidation guidance, and the collateral split math. A compromised indexer (keeping the adapter address equal to the real env-pinned adapter) could swap that ID for a different reserve with friendlier collateral settings, making the UI show an inflated borrow limit and a safer-looking health factor than reality. On-chain simulation only enforces the protocol's hard liquidation floor, so the inflated UI buffer was never actually checked — a user could borrow far closer to liquidation than the screen suggests. Security review finding F9: https://github.com/babylonlabs-io/baby-auditor/issues/38

## How

- New `getVaultBtcReserveId(adapter)` reads `VAULT_BTC_RESERVE_ID` on-chain — a near-copy of the existing `getCoreSpokeAddress` / `BTC_VAULT_CORE_SPOKE` pattern in the same file.
- In `fetchAaveAppConfig`, after the existing adapter-address check, read the reserve ID on-chain, throw if the read fails, and throw if it does not equal the indexer value. The on-chain value is then used everywhere (config, vBTC reserve lookup, borrowable-reserve filtering). This is the single funnel all consumers read from, so one check protects split params, health factor, position, and reorder math.
- Any throw surfaces through the existing `AaveConfigContext` "Something went wrong / Retry" panel, before any borrow/split/reorder child mounts — a poisoned value can never reach the math.

## ABI name correction (included in this PR)

While validating, we found the bundled ts-sdk ABI carried a fabricated getter name `BTC_VAULT_CORE_VAULT_BTC_RESERVE_ID` that does not exist on the deployed contract — the v4 adapter declares it as `VAULT_BTC_RESERVE_ID`. Calling the wrong name reverted, which briefly looked like a missing on-chain getter. It was a frontend ABI bug: this PR corrects both reserve-id entries in `AaveIntegrationAdapter.abi.json` to the real contract names. There is no contracts-team dependency and no deployment blocker — verified on-chain (Sepolia adapter `0x31BC43cab2d91b3016BeE8e9Fc1194D46D7b0590`): `VAULT_BTC_RESERVE_ID()` returns `3`, `WBTC_RESERVE_ID()` returns `2`.

## Files

- `packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/abis/AaveIntegrationAdapter.abi.json` — correct the two reserve-id getter names (`VAULT_BTC_RESERVE_ID`, `WBTC_RESERVE_ID`)
- `services/vault/src/applications/aave/clients/transaction.ts` — `getVaultBtcReserveId`
- `services/vault/src/applications/aave/services/fetchConfig.ts` — on-chain read + fail-closed assert
- `services/vault/src/applications/aave/services/__tests__/fetchConfig.test.ts` — agreement / mismatch-throws / read-failure-throws / precedence

## Testing

- Unit: `fetchConfig.test.ts` — 7 passing (3 original + 4 new). Lint and typecheck clean.
- On-chain: `cast call 0x31BC43… "VAULT_BTC_RESERVE_ID()(uint256)"` → `3`.
- In-app (Sepolia): Loans and Activity load; console confirmed `on-chain=3 indexer=3 → verified OK`.

## How to test manually

- Open Loans and Activity — both should load with health factor and borrow limits rendered (no retry panel).
- Borrow a small amount against vBTC collateral, then repay it. On the happy path (on-chain reserve ID equals the indexer's) behavior is identical to before — this change is transparent unless the indexer disagrees with the chain, in which case the Aave surface intentionally hard-blocks.

## Critical path

This touches inputs to collateral and liquidation math, so it is strict by design: no silent fallback, no defaulting to the indexer value on read failure. Both a read failure and a mismatch throw.

## Follow-ups (out of scope)

- `WBTC_RESERVE_ID` verification (the name is corrected in the ABI here but not consumed yet).
- The bundled `AaveIntegrationAdapter.abi.json` is a stale hand-merged superset predating the v4 contract split (`AaveAdapter` + `AaveAdapterConfig`); regenerating/reconciling it from the v4 compiled artifacts is worth a separate task.

Closes https://github.com/babylonlabs-io/baby-auditor/issues/38
