### PR TITLE
fix(vault): show the vaults empty state while a deposit is pending

### DIFF
--- a/services/vault/src/components/pages/VaultsPage.tsx
+++ b/services/vault/src/components/pages/VaultsPage.tsx
@@ -15,7 +15,6 @@ import { useOutletContext } from "react-router";
 import type { Address } from "viem";
 
 import type { RootLayoutContext } from "@/components/pages/RootLayout";
-import { DepositButton, EmptyState } from "@/components/shared";
 import { PAGE_CONTENT_CLASS } from "@/components/shared/layoutClasses";
 import {
   isDepositBlocked,
@@ -28,6 +27,7 @@ import {
 } from "@/components/simple/ReorderVaults";
 import WithdrawFlow from "@/components/simple/WithdrawFlow";
 import { VaultsActiveSection } from "@/components/vaults/VaultsActiveSection";
+import { VaultsEmptyState } from "@/components/vaults/VaultsEmptyState";
 import { VaultsLifecycleSections } from "@/components/vaults/VaultsLifecycleSections";
 import { VaultsSummaryCard } from "@/components/vaults/VaultsSummaryCard";
 import { FeatureFlags } from "@/config";
@@ -39,8 +39,6 @@ import { useProtocolGateState } from "@/hooks/useProtocolGate";
 import { useVaultsPageData } from "@/hooks/useVaultsPageData";
 import { useVaultsPageEmptiness } from "@/hooks/useVaultsPageEmptiness";
 import { invalidateVaultQueries, vaultOrderQueryKey } from "@/utils/queryKeys";
-
-const EMPTY_ILLUSTRATION_SRC = "/images/vaults-empty.svg";
 
 // Dev-only god-mode panel, lazily imported behind `import.meta.env.DEV` so its
 // code is dropped from production builds entirely (same pattern as
@@ -86,6 +84,16 @@ export default function VaultsPage() {
   const [isReorderSuccess, setIsReorderSuccess] = useState(false);
 
   const isDepositsPaused = FeatureFlags.isDepositDisabled;
+
+  const renderEmptyState = (withCard: boolean) => (
+    <VaultsEmptyState
+      isConnected={isConnected}
+      isDepositsPaused={isDepositsPaused}
+      isDepositDisabled={isDepositBlocked(gate)}
+      onDeposit={() => openDeposit()}
+      withCard={withCard}
+    />
+  );
 
   const reorderableVaults = useMemo(
     () => rawCollateralVaults.filter((vault) => !vault.isActivating),
@@ -147,6 +155,10 @@ export default function VaultsPage() {
           vaults={displayVaults}
           onWithdraw={handleWithdrawRow}
           isWithdrawDisabled={isWithdrawBlocked(gate)}
+          // Pending deposits keep the page populated while the vault list is
+          // still empty — the section shows the empty state until the deposit
+          // confirms and activates.
+          emptyState={renderEmptyState(true)}
         />
       </VaultsLifecycleSections>
     </div>
@@ -173,44 +185,7 @@ export default function VaultsPage() {
       );
     }
     if (!isEmpty) return populatedBody;
-    return (
-      <EmptyState
-        icon={
-          <img
-            src={EMPTY_ILLUSTRATION_SRC}
-            alt=""
-            className="h-[100px] w-[94px]"
-          />
-        }
-        title={
-          isDepositsPaused
-            ? COPY.deposit.disabled.title
-            : COPY.vaults.empty.title
-        }
-        description={
-          isDepositsPaused
-            ? COPY.deposit.disabled.description
-            : COPY.vaults.empty.description
-        }
-        descriptionVariant="wide"
-        isConnected={isConnected}
-        action={
-          <DepositButton
-            // This control's data-testid is a real-wallet E2E hook
-            // (e2e/real/actions/walletConnect.ts, e2e/real/actions/pegin.ts)
-            // — carry it over if you move or rename the element.
-            data-testid="deposit-button"
-            variant="contained"
-            color="secondary"
-            size="medium"
-            onClick={() => openDeposit()}
-            disabled={isDepositBlocked(gate)}
-          >
-            {COPY.vaults.empty.depositAction}
-          </DepositButton>
-        }
-      />
-    );
+    return renderEmptyState(false);
   };
 
   // Dev/QA god-mode panel (same gate and pattern as DashboardPage) so demo

--- a/services/vault/src/components/vaults/VaultsActiveSection.tsx
+++ b/services/vault/src/components/vaults/VaultsActiveSection.tsx
@@ -10,6 +10,7 @@
  */
 
 import { Heading, Loader } from "@babylonlabs-io/core-ui";
+import type { ReactNode } from "react";
 
 import { ApplicationLogo } from "@/components/ApplicationLogo";
 import { NEUTRAL_ROW_BUTTON_CLASS } from "@/components/shared/buttonClasses";
@@ -23,6 +24,9 @@ interface VaultsActiveSectionProps {
   vaults: CollateralVaultEntry[];
   onWithdraw: (vaultId: string) => void;
   isWithdrawDisabled: boolean;
+  /** Shown under a plain "Vaults" heading while no vault is active yet —
+   *  the page reaches this section with pending deposits only. */
+  emptyState?: ReactNode;
 }
 
 function ActiveVaultRow({
@@ -128,8 +132,23 @@ export function VaultsActiveSection({
   vaults,
   onWithdraw,
   isWithdrawDisabled,
+  emptyState,
 }: VaultsActiveSectionProps) {
-  if (vaults.length === 0) return null;
+  if (vaults.length === 0) {
+    if (!emptyState) return null;
+    return (
+      <section className="w-full space-y-3">
+        <Heading
+          variant="h6"
+          as="h2"
+          className="font-normal text-accent-primary"
+        >
+          {COPY.vaults.sections.vaultsTitle}
+        </Heading>
+        {emptyState}
+      </section>
+    );
+  }
 
   return (
     <section className="w-full space-y-3">

--- a/services/vault/src/components/vaults/VaultsEmptyState.tsx
+++ b/services/vault/src/components/vaults/VaultsEmptyState.tsx
@@ -1,0 +1,78 @@
+/**
+ * VaultsEmptyState — the "Your BTC Vaults will appear here" prompt.
+ *
+ * Two placements share it: the whole-page state when the account has nothing
+ * at all, and the Vaults section when a deposit is still pending — a pending
+ * deposit is not yet a vault, so the list below it stays empty until the
+ * deposit confirms and activates.
+ */
+
+import type { ReactNode } from "react";
+
+import { DepositButton, EmptyState } from "@/components/shared";
+import { COPY } from "@/copy";
+
+const EMPTY_ILLUSTRATION_SRC = "/images/vaults-empty.svg";
+
+interface VaultsEmptyStateProps {
+  isConnected: boolean;
+  /** Deposits kill-switch — swaps in the paused copy. */
+  isDepositsPaused: boolean;
+  isDepositDisabled: boolean;
+  onDeposit: () => void;
+  /** Render on the page's card surface — the section placement sits on its
+   *  own panel, matching the summary card and the lifecycle rows. */
+  withCard?: boolean;
+}
+
+/** Same surface as the summary card and the lifecycle rows, at the empty
+ *  state's larger 16px radius. */
+const CARD_CLASS =
+  "w-full rounded-2xl border border-secondary-strokeLight bg-secondary-highlight dark:bg-[#202020]";
+
+export function VaultsEmptyState({
+  isConnected,
+  isDepositsPaused,
+  isDepositDisabled,
+  onDeposit,
+  withCard = false,
+}: VaultsEmptyStateProps): ReactNode {
+  const emptyState = (
+    <EmptyState
+      icon={
+        <img
+          src={EMPTY_ILLUSTRATION_SRC}
+          alt=""
+          className="h-[100px] w-[94px]"
+        />
+      }
+      title={
+        isDepositsPaused ? COPY.deposit.disabled.title : COPY.vaults.empty.title
+      }
+      description={
+        isDepositsPaused
+          ? COPY.deposit.disabled.description
+          : COPY.vaults.empty.description
+      }
+      descriptionVariant="wide"
+      isConnected={isConnected}
+      action={
+        <DepositButton
+          // This control's data-testid is a real-wallet E2E hook
+          // (e2e/real/actions/walletConnect.ts, e2e/real/actions/pegin.ts)
+          // — carry it over if you move or rename the element.
+          data-testid="deposit-button"
+          variant="contained"
+          color="secondary"
+          size="medium"
+          onClick={onDeposit}
+          disabled={isDepositDisabled}
+        >
+          {COPY.vaults.empty.depositAction}
+        </DepositButton>
+      }
+    />
+  );
+
+  return withCard ? <div className={CARD_CLASS}>{emptyState}</div> : emptyState;
+}

--- a/services/vault/src/components/vaults/__tests__/VaultsActiveSection.test.tsx
+++ b/services/vault/src/components/vaults/__tests__/VaultsActiveSection.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { VaultsActiveSection } from "@/components/vaults/VaultsActiveSection";
+import { COPY } from "@/copy";
+import type { CollateralVaultEntry } from "@/types/collateral";
+
+const activeVault: CollateralVaultEntry = {
+  id: "vault-1",
+  vaultId: "0xvault1",
+  amountBtc: 1,
+  addedAt: 1_700_000_000,
+  liquidationIndex: 0,
+  inUse: true,
+  providerAddress: "0x2222222222222222222222222222222222222222",
+  providerName: "Atlas Custody",
+  peginTxHash: "a1b2c3",
+};
+
+describe("VaultsActiveSection", () => {
+  it("shows the empty state under a Vaults heading while no vault is active", () => {
+    render(
+      <VaultsActiveSection
+        vaults={[]}
+        onWithdraw={vi.fn()}
+        isWithdrawDisabled={false}
+        emptyState={<div data-testid="vaults-empty-state" />}
+      />,
+    );
+
+    expect(
+      screen.getByText(COPY.vaults.sections.vaultsTitle),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("vaults-empty-state")).toBeInTheDocument();
+  });
+
+  it("renders the vault rows instead of the empty state once a vault is active", () => {
+    render(
+      <VaultsActiveSection
+        vaults={[activeVault]}
+        onWithdraw={vi.fn()}
+        isWithdrawDisabled={false}
+        emptyState={<div data-testid="vaults-empty-state" />}
+      />,
+    );
+
+    expect(screen.queryByTestId("vaults-empty-state")).not.toBeInTheDocument();
+    expect(
+      screen.getByText(COPY.vaults.sections.activeVaultsTitle, {
+        exact: false,
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(COPY.pegin.labels.IN_USE)).toBeInTheDocument();
+  });
+
+  it("renders nothing when there is no vault and no empty state to show", () => {
+    const { container } = render(
+      <VaultsActiveSection
+        vaults={[]}
+        onWithdraw={vi.fn()}
+        isWithdrawDisabled={false}
+      />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -1320,6 +1320,9 @@ export const COPY = {
     },
     sections: {
       pendingDepositsTitle: "Pending Deposit",
+      // Heading over the vaults list before any vault is active — the count
+      // is dropped while the section only holds the empty state.
+      vaultsTitle: "Vaults",
       activeVaultsTitle: "Active Vaults",
       inactiveVaultsTitle: "Inactive Vaults",
       count: (count: number) => `(${count})`,


### PR DESCRIPTION
A pending deposit kept the /vaults page in its populated layout, and VaultsActiveSection rendered nothing with zero vaults — so the Vaults section disappeared entirely instead of showing the empty state.

The section now renders a "Vaults" heading with the empty-state card until a vault confirms and activates, at which point it switches back to the "Active Vaults (n)" rows. The prompt itself moves into VaultsEmptyState, shared by the page-level and section placements.

## Screenshot

<img width="1449" height="859" alt="Screenshot 2026-07-23 at 18 22 32" src="https://github.com/user-attachments/assets/ca139598-522a-42ec-946b-a64bb17b371f" />
