### PR TITLE
fix(vault): tighten index.html meta CSP

### DIFF
--- a/services/vault/index.html
+++ b/services/vault/index.html
@@ -26,7 +26,10 @@
     <meta name="twitter:image:width" content="2048" />
     <meta name="twitter:image:height" content="1170" />
     <meta name="version" content="%NEXT_PUBLIC_COMMIT_HASH%" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; connect-src 'self' https: http: wss: ws:; img-src 'self' data: https: blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https:; object-src 'none'; base-uri 'self'; worker-src 'self' blob:; frame-src 'self' https://verify.walletconnect.com https://verify.walletconnect.org https://secure.walletconnect.com https://secure.walletconnect.org;" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; connect-src 'self' https: wss: http://localhost:* ws://localhost:*; img-src 'self' data: https: blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com https://fonts.reown.com; object-src 'none'; base-uri 'self'; form-action 'self'; worker-src 'self' blob:; frame-src 'self' https://verify.walletconnect.com https://verify.walletconnect.org https://secure.walletconnect.org;"
+    />
     <meta name="referrer" content="strict-origin-when-cross-origin" />
     <title>Babylon - Vault</title>
 

--- a/services/vault/src/config/env.ts
+++ b/services/vault/src/config/env.ts
@@ -227,7 +227,7 @@ function validateEnvVars(): EnvValidationResult {
   // the blocking error modal.
   const FALLBACK_ETH_CHAIN_ID: EthChainId = ETH_SEPOLIA_CHAIN_ID;
   const FALLBACK_BTC_NETWORK: BtcNetworkName = "signet";
-  const FALLBACK_RPC_URL = "http://invalid.local";
+  const FALLBACK_RPC_URL = "https://invalid.local";
   try {
     configureBabylonConfig({
       ethChainId,

--- a/services/vault/vite.config.ts
+++ b/services/vault/vite.config.ts
@@ -17,6 +17,12 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 // injects, which has no 'unsafe-inline'/nonce and would white-screen `pnpm dev`. The meta CSP
 // does not govern that preamble because Vite injects it above the meta tag, and a meta policy
 // only applies to content that follows it.
+//
+// The meta CSP's connect-src carve-outs `http://localhost:*` and `ws://localhost:*` are
+// load-bearing for dev, not leftovers: ws://localhost is the Vite HMR websocket (a page's
+// 'self' does not reliably match the ws: scheme), and http://localhost:<port> covers the
+// cross-port Playwright mock servers (playwright.config.ts). Removing them breaks HMR and
+// the e2e suite with silent CSP blocks, not build errors.
 const SECURITY_HEADERS = {
   "X-Content-Type-Options": "nosniff",
   "X-Frame-Options": "DENY",


### PR DESCRIPTION
## Summary

Follow-up to #1859. An external audit finding ("No Content-Security-Policy delivered from the client") was filed against a pre-#1859 snapshot; the meta CSP already ships, but several directives were effectively unbounded. This PR tightens them. The meta tag is the only CSP on mainnet and localhost (the edge CSP currently covers testnet only), so the wildcards were load-bearing there.

## Changes

- **connect-src**: drops blanket `http:` / `ws:` (any host was previously reachable over plaintext). Keeps `https:` / `wss:` - vault-provider proxy, RPC, mempool, indexer, and Sentry hosts differ per environment and mainnet hosts are not visible from the repo - plus explicit `http://localhost:*` and `ws://localhost:*` carve-outs. The carve-outs are load-bearing: Vite HMR's websocket and the cross-port Playwright mock servers (see the new comment in `vite.config.ts`).
- **font-src**: pins the `https:` wildcard to the only two font hosts in the built bundle: `fonts.gstatic.com` (Poppins via the Tomo SDK import) and `fonts.reown.com` (AppKit KHTeka). Keeps `data:` for the BaseSans font the Coinbase/Base wallet SDK injects.
- **frame-src**: removes `secure.walletconnect.com` - both installed `@reown/appkit-wallet` trees (1.7.8, 1.8.12) hardcode only `https://secure.walletconnect.org/sdk`; the `.com` host appears nowhere in the built bundle.
- **form-action 'self'** (new): closes the one exfiltration channel the old policy left fully open (an injected `<form action=...>`); all forms in the bundle omit `action` and preventDefault, so `'self'` is a no-op for legitimate flows.
- **env.ts**: the intentional dead-endpoint sentinel `FALLBACK_RPC_URL` is now `https://invalid.local` so it stays within `connect-src https:` and fails as a clean network error instead of a CSP violation.

## Deliberately not tightened

- `img-src https:` stays: the sidecar `/logo` endpoint returns arbitrary https logo URLs with no host validation, so any pin would silently degrade provider logos. Needs an infra commitment to a fixed logo host list first.
- Per-environment `connect-src` host allowlists via the `%VAR%` templating `index.html` already uses are feasible but deferred: mainnet hosts exist only as GitHub environment vars, and three build paths (lint_test, PR verify, local `pnpm build`) run without endpoint env vars and would fail closed. Best done together with edge/meta CSP convergence.

## Verification

- Typecheck, eslint, prettier pass.
- Full vitest suite: 2598 passed.
- Playwright e2e ran the app in Chromium under the new policy: 15/19 passed; the 4 failures reproduce identically on clean `main` (local `.env` files leak into the "missing configuration" webServer) and are unrelated to this change.

## Maintenance note

The `frame-src` and `font-src` pins are version-coupled to `@reown/appkit*`: on any AppKit bump, re-grep the built assets for `secure.walletconnect` / `verify.walletconnect` and `https://fonts.` before shipping.
