### PR TITLE
feat(vault): god-mode  improvement for the v3 Loans and Activity

### DIFF
--- a/services/vault/eslint.config.js
+++ b/services/vault/eslint.config.js
@@ -149,6 +149,9 @@ export default tseslint.config(
       "**/__tests__/**",
       "**/*.test.{ts,tsx}",
       // Sanctioned seams that legitimately mount / inject the dev tooling.
+      // The single god-mode mount: the route layout that wraps Overview /
+      // Vaults / Loans loads `dev/GodModeMount` behind `import.meta.env.DEV`.
+      "src/router.tsx",
       "src/components/simple/DashboardPage.tsx",
       // v3 /vaults (#2041): mounts the god-mode panel, routes to the populated
       // layout under demo injection, and merges demo collateral / routes demo
@@ -157,6 +160,13 @@ export default tseslint.config(
       "src/components/pages/VaultsPage.tsx",
       "src/components/vaults/VaultsLifecycleSections.tsx",
       "src/hooks/useVaultsPageData.ts",
+      // v3 /loans: merges demo loan rows into the Active Loans list, routes to
+      // the populated layout under demo injection, and applies the god-mode
+      // health-factor / borrow-capacity summary overrides. Mirrors VaultsPage.
+      "src/components/pages/Loans.tsx",
+      // v3 /activity: merges demo activity rows into the feed (display-only —
+      // never polled, never written to the pending-activity storage).
+      "src/hooks/useActivitiesWithPending.ts",
       "src/hooks/usePendingDeposits.ts",
       "src/context/deposit/PeginPollingContext.tsx",
       // God-mode simulated-activation walk: routes demo card clicks to the

--- a/services/vault/src/applications/aave/hooks/useActiveLoans.ts
+++ b/services/vault/src/applications/aave/hooks/useActiveLoans.ts
@@ -24,6 +24,12 @@ export interface ActiveLoanRow extends BorrowedAsset {
    * Borrow action would dead-end in the reserve-detail form, so gate on this.
    */
   isBorrowable: boolean;
+  /**
+   * God-mode demo row (dev only, never set on a real row): renders like a real
+   * loan but its `reserveId`/`symbol` resolve to no reserve, so ActiveLoansList
+   * disables both of its actions. Keeps a mock out of the borrow/repay overlay.
+   */
+  displayOnly?: boolean;
 }
 
 export function useActiveLoans(

--- a/services/vault/src/components/pages/Activity.tsx
+++ b/services/vault/src/components/pages/Activity.tsx
@@ -1,40 +1,20 @@
 import { Container, Loader } from "@babylonlabs-io/core-ui";
-import { lazy, Suspense } from "react";
 import type { Hex } from "viem";
-
-import { FeatureFlags } from "@/config";
 
 import { useConnection, useETHWallet } from "../../context/wallet";
 import { useActivitiesWithPending } from "../../hooks/useActivitiesWithPending";
 import { ActivityList } from "../Activity";
 import { PAGE_CONTENT_CLASS } from "../shared/layoutClasses";
 
-// Dev-only god-mode panel, lazily imported behind `import.meta.env.DEV` so its
-// code is dropped from production builds entirely (same pattern as VaultsPage).
-const GodModePanel = import.meta.env.DEV
-  ? lazy(() =>
-      import("@/dev/GodModePanel").then((m) => ({ default: m.GodModePanel })),
-    )
-  : null;
-
 export default function Activity() {
   const { address } = useETHWallet();
   const { isConnected } = useConnection();
+  // God-mode demo rows are merged in by this hook (dev only), so the feed can
+  // be exercised without a wallet or an indexed history. The panel itself is
+  // mounted once by the route (see dev/GodModeMount), not per page.
   const { data: activities, isLoading } = useActivitiesWithPending(
     isConnected ? (address as Hex) : undefined,
   );
-
-  const isDevToolingEnabled =
-    import.meta.env.DEV && FeatureFlags.isGodModePanelEnabled;
-
-  // Dev/QA god-mode panel (same gate and pattern as VaultsPage) so demo items
-  // can be injected without navigating back to the Vaults page.
-  const godModePanel =
-    isDevToolingEnabled && GodModePanel ? (
-      <Suspense fallback={null}>
-        <GodModePanel />
-      </Suspense>
-    ) : null;
 
   return (
     <Container
@@ -53,7 +33,6 @@ export default function Activity() {
           />
         )}
       </div>
-      {godModePanel}
     </Container>
   );
 }

--- a/services/vault/src/components/pages/Loans.tsx
+++ b/services/vault/src/components/pages/Loans.tsx
@@ -6,32 +6,29 @@
  */
 
 import { Container, Loader } from "@babylonlabs-io/core-ui";
-import { lazy, Suspense } from "react";
+import { useMemo } from "react";
 import { useOutletContext } from "react-router";
 
 import { AssetSelectionModal } from "@/applications/aave/components/AssetSelectionModal";
 import { LOAN_TAB } from "@/applications/aave/constants";
 import { useActiveLoans } from "@/applications/aave/hooks";
+import { getHealthFactorStatusFromValue } from "@/applications/aave/utils";
 import type { RootLayoutContext } from "@/components/pages/RootLayout";
 import { EmptyState, EmptyStateIcon } from "@/components/shared";
 import { PAGE_CONTENT_CLASS } from "@/components/shared/layoutClasses";
-import { FeatureFlags } from "@/config";
 import { useConnection, useETHWallet } from "@/context/wallet";
 import { COPY } from "@/copy";
+import {
+  useDebugBorrowCapacity,
+  useDebugHealthFactorOverride,
+} from "@/dev/debugPositionStore";
+import { useDemoLoan } from "@/dev/demoDeposit";
 import { useDashboardState } from "@/hooks/useDashboardState";
 import { useLoanActions } from "@/hooks/useLoanActions";
 import { formatUsdValue } from "@/utils/formatting";
 
 import { ActiveLoansList } from "../simple/ActiveLoansList";
 import { LoansSummary } from "../simple/LoansSummary";
-
-// Dev-only god-mode panel, lazily imported behind `import.meta.env.DEV` so its
-// code is dropped from production builds entirely (same pattern as VaultsPage).
-const GodModePanel = import.meta.env.DEV
-  ? lazy(() =>
-      import("@/dev/GodModePanel").then((m) => ({ default: m.GodModePanel })),
-    )
-  : null;
 
 export default function Loans() {
   const { openDeposit } = useOutletContext<RootLayoutContext>();
@@ -59,42 +56,63 @@ export default function Loans() {
 
   const activeLoans = useActiveLoans(borrowedAssets);
 
-  const isDevToolingEnabled =
-    import.meta.env.DEV && FeatureFlags.isGodModePanelEnabled;
+  // God-mode demo loans (dev only; null unless the panel's "Inject demo" toggle
+  // is on). Merged into the rendered rows — real rows dropped when `hideReal`
+  // is set — so the Loans page can be exercised without a borrow position, or
+  // a wallet. Every mock row is `displayOnly`, so ActiveLoansList disables its
+  // actions and the real borrow/repay flows never see one. Inert in production.
+  const demoLoans = useDemoLoan();
+  const displayLoans = useMemo(() => {
+    if (!demoLoans) return activeLoans;
+    return [...demoLoans.rows, ...(demoLoans.hideReal ? [] : activeLoans)];
+  }, [activeLoans, demoLoans]);
+  const demoAffectsLoans =
+    demoLoans !== null && (demoLoans.rows.length > 0 || demoLoans.hideReal);
 
-  // Dev/QA god-mode panel (same gate and pattern as VaultsPage). Rendered in
-  // every return branch below so it stays reachable while the position loads or
-  // when the page is in its disconnected/empty state.
-  const godModePanel =
-    isDevToolingEnabled && GodModePanel ? (
-      <Suspense fallback={null}>
-        <GodModePanel />
-      </Suspense>
-    ) : null;
+  // God-mode summary overrides (dev only; null unless the panel forces them).
+  // The health-factor STATUS is derived from the forced value with the real
+  // banding function, so a forced card can't drift from production. Both are
+  // compile-time null in production builds.
+  const healthFactorOverride = useDebugHealthFactorOverride();
+  const borrowCapacityOverride = useDebugBorrowCapacity();
+  const shownHealthFactor = healthFactorOverride ?? healthFactor;
+  const shownHealthFactorStatus =
+    healthFactorOverride !== null
+      ? getHealthFactorStatusFromValue(healthFactorOverride)
+      : healthFactorStatus;
+  const shownCapacityLoading =
+    borrowCapacityOverride?.loading || isBorrowCapacityLoading;
+  const shownCapacityError =
+    borrowCapacityOverride?.error ?? borrowCapacityError;
+  // A forced summary state is as much a reason to render the page as a mock
+  // row is — otherwise setting one on an empty position shows nothing.
+  const godModeAffectsPage =
+    demoAffectsLoans ||
+    healthFactorOverride !== null ||
+    borrowCapacityOverride !== null;
 
   // A borrow position exists once there is collateral to borrow against (or an
   // active loan). With collateral but no debt yet, the summary still renders so
   // the depositor can borrow via its Borrow action — mirroring the v2 Loans
   // section, whose Borrow button was enabled whenever collateral was present.
-  const hasPosition = hasCollateral || hasLoans;
+  const hasPosition = hasCollateral || hasLoans || godModeAffectsPage;
 
   // Position is still loading for a connected wallet: hold on a spinner rather
   // than flashing the full-page "deposit" empty state before the summary lands
   // (hasCollateral/hasLoans are false until the position resolves).
-  if (isConnected && isLoading) {
+  if (isConnected && isLoading && !godModeAffectsPage) {
     return (
       <Container className={`${PAGE_CONTENT_CLASS} pb-6`}>
         <div className="flex items-center justify-center py-12">
           <Loader />
         </div>
-        {godModePanel}
       </Container>
     );
   }
 
   // Nothing to borrow against yet: prompt to deposit collateral first (or to
   // connect a wallet when disconnected).
-  if (!isConnected || !hasPosition) {
+  if (!hasPosition || (!isConnected && !godModeAffectsPage)) {
     return (
       <Container className={`${PAGE_CONTENT_CLASS} pb-6`}>
         <EmptyState
@@ -106,15 +124,24 @@ export default function Loans() {
           onAction={() => openDeposit()}
           withCard
         />
-        {godModePanel}
       </Container>
     );
   }
 
+  // Display-only totals: when the demo changes the rendered rows, the summary
+  // must total what is on screen — otherwise it reads "$0 borrowed" above a mock
+  // row. With no real borrow capacity to scale against (the usual demo case:
+  // no position at all), the mock debt itself becomes the meter's denominator,
+  // so the bar reads fully-borrowed rather than empty. The values passed to the
+  // borrow/repay actions stay demo-unaware.
+  const shownDebtUsd = demoAffectsLoans
+    ? (demoLoans?.debtUsd ?? 0) + (demoLoans?.hideReal ? 0 : debtValueUsd)
+    : debtValueUsd;
+  const meterBaseUsd = maxTotalDebtUsd > 0 ? maxTotalDebtUsd : shownDebtUsd;
   const availableMeterPercent =
-    maxTotalDebtUsd > 0 ? availableToBorrowUsd / maxTotalDebtUsd : 0;
+    meterBaseUsd > 0 ? availableToBorrowUsd / meterBaseUsd : 0;
   const borrowedMeterPercent =
-    maxTotalDebtUsd > 0 ? debtValueUsd / maxTotalDebtUsd : 0;
+    meterBaseUsd > 0 ? shownDebtUsd / meterBaseUsd : 0;
 
   return (
     <Container className={`${PAGE_CONTENT_CLASS} pb-6`}>
@@ -122,21 +149,25 @@ export default function Loans() {
         <LoansSummary
           availableToBorrow={formatUsdValue(availableToBorrowUsd)}
           availableMeterPercent={availableMeterPercent}
-          totalBorrowed={formatUsdValue(debtValueUsd)}
+          totalBorrowed={formatUsdValue(shownDebtUsd)}
           borrowedMeterPercent={borrowedMeterPercent}
-          borrowCapacityLoading={isBorrowCapacityLoading}
-          borrowCapacityError={borrowCapacityError}
-          healthFactor={healthFactor}
-          healthFactorStatus={healthFactorStatus}
+          borrowCapacityLoading={shownCapacityLoading}
+          borrowCapacityError={shownCapacityError}
+          healthFactor={shownHealthFactor}
+          healthFactorStatus={shownHealthFactorStatus}
           onBorrow={openBorrowPicker}
           onRepay={openRepay}
           canBorrow={canBorrow}
           canRepay={hasLoans}
         />
 
-        {hasLoans ? (
+        {/* `hasLoans` (debt in USD), not `displayLoans.length`: the two can
+            disagree — dust debt, or a reserve with a debt position whose USD
+            value reads 0 — and the real page's choice here must not shift. The
+            demo only ever adds a reason to render the list. */}
+        {hasLoans || demoAffectsLoans ? (
           <ActiveLoansList
-            rows={activeLoans}
+            rows={displayLoans}
             canBorrow={canBorrow}
             onBorrow={(symbol) => goToReserve(symbol, LOAN_TAB.BORROW)}
             onRepay={(symbol) => goToReserve(symbol, LOAN_TAB.REPAY)}
@@ -155,7 +186,6 @@ export default function Loans() {
       </div>
 
       <AssetSelectionModal {...assetModalProps} />
-      {godModePanel}
     </Container>
   );
 }

--- a/services/vault/src/components/pages/Loans.tsx
+++ b/services/vault/src/components/pages/Loans.tsx
@@ -80,10 +80,15 @@ export default function Loans() {
     healthFactorOverride !== null
       ? getHealthFactorStatusFromValue(healthFactorOverride)
       : healthFactorStatus;
-  const shownCapacityLoading =
-    borrowCapacityOverride?.loading || isBorrowCapacityLoading;
-  const shownCapacityError =
-    borrowCapacityOverride?.error ?? borrowCapacityError;
+  // A forced state REPLACES the live one wholesale — combining them field by
+  // field would leave "Error" showing the live loader (or "Loading" showing a
+  // live error), i.e. never actually render the state that was forced.
+  const shownCapacityLoading = borrowCapacityOverride
+    ? borrowCapacityOverride.loading
+    : isBorrowCapacityLoading;
+  const shownCapacityError = borrowCapacityOverride
+    ? borrowCapacityOverride.error
+    : borrowCapacityError;
   // A forced summary state is as much a reason to render the page as a mock
   // row is — otherwise setting one on an empty position shows nothing.
   const godModeAffectsPage =

--- a/services/vault/src/components/pages/VaultsPage.tsx
+++ b/services/vault/src/components/pages/VaultsPage.tsx
@@ -10,7 +10,7 @@
 
 import { Container, Loader, Notification } from "@babylonlabs-io/core-ui";
 import { useQueryClient } from "@tanstack/react-query";
-import { lazy, Suspense, useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useOutletContext } from "react-router";
 import type { Address } from "viem";
 
@@ -41,15 +41,6 @@ import { useVaultsPageEmptiness } from "@/hooks/useVaultsPageEmptiness";
 import { invalidateVaultQueries, vaultOrderQueryKey } from "@/utils/queryKeys";
 
 const EMPTY_ILLUSTRATION_SRC = "/images/vaults-empty.svg";
-
-// Dev-only god-mode panel, lazily imported behind `import.meta.env.DEV` so its
-// code is dropped from production builds entirely (same pattern as
-// DashboardPage).
-const GodModePanel = import.meta.env.DEV
-  ? lazy(() =>
-      import("@/dev/GodModePanel").then((m) => ({ default: m.GodModePanel })),
-    )
-  : null;
 
 export default function VaultsPage() {
   const { openDeposit } = useOutletContext<RootLayoutContext>();
@@ -110,6 +101,8 @@ export default function VaultsPage() {
     }
   }, [address, queryClient]);
 
+  // The god-mode panel itself is mounted once by the route layout (see
+  // dev/GodModeMount); this only gates the demo-driven body below.
   const isDevToolingEnabled =
     import.meta.env.DEV && FeatureFlags.isGodModePanelEnabled;
 
@@ -213,19 +206,9 @@ export default function VaultsPage() {
     );
   };
 
-  // Dev/QA god-mode panel (same gate and pattern as DashboardPage) so demo
-  // items can be injected from this page without navigating to Overview.
-  const godModePanel =
-    isDevToolingEnabled && GodModePanel ? (
-      <Suspense fallback={null}>
-        <GodModePanel />
-      </Suspense>
-    ) : null;
-
   return (
     <Container as="main" className={`${PAGE_CONTENT_CLASS} pb-6`}>
       {renderBody()}
-      {godModePanel}
 
       <WithdrawFlow
         open={withdrawVaultIds !== null}

--- a/services/vault/src/components/pages/__tests__/Loans.test.tsx
+++ b/services/vault/src/components/pages/__tests__/Loans.test.tsx
@@ -5,6 +5,10 @@
  * spinner — not the full-page "deposit" empty state — so the deposit CTA can't
  * flash before the summary lands on a hard refresh. Disconnected still shows
  * the connect prompt immediately.
+ *
+ * Also covers the god-mode demo path: injected mock loans route the page to the
+ * populated layout even with no wallet and no position, which is the only way
+ * to review the Loans page states.
  */
 
 import { render, screen } from "@testing-library/react";
@@ -13,6 +17,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const useConnectionMock = vi.fn();
 const useETHWalletMock = vi.fn();
 const useDashboardStateMock = vi.fn();
+const useDemoLoanMock = vi.fn();
 
 vi.mock("@/context/wallet", () => ({
   useConnection: () => useConnectionMock(),
@@ -40,6 +45,10 @@ vi.mock("@/hooks/useLoanActions", () => ({
 
 vi.mock("@/applications/aave/hooks", () => ({
   useActiveLoans: () => [],
+}));
+
+vi.mock("@/dev/demoDeposit", () => ({
+  useDemoLoan: () => useDemoLoanMock(),
 }));
 
 vi.mock("react-router", () => ({
@@ -86,9 +95,23 @@ const CONNECTED_LOADED = {
   isLoading: false,
 };
 
+const DEMO_LOAN_ROW = {
+  reserveId: "demo-reserve-1",
+  symbol: "USDC",
+  name: "USDC",
+  amount: "1500",
+  icon: "",
+  borrowRate: "5.861%",
+  availableLiquidity: 1_250_000,
+  utilizationBps: 6420,
+  isBorrowable: true,
+  displayOnly: true,
+};
+
 describe("Loans page — loading gate", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    useDemoLoanMock.mockReturnValue(null);
   });
 
   it("shows a spinner (not the deposit CTA) while a connected depositor's position loads", () => {
@@ -124,6 +147,40 @@ describe("Loans page — loading gate", () => {
     );
     expect(container.querySelector("svg")).not.toBeInTheDocument();
     expect(screen.queryByTestId("loans-summary")).not.toBeInTheDocument();
+  });
+
+  it("renders injected god-mode loans while disconnected, instead of the empty state", () => {
+    useConnectionMock.mockReturnValue({ isConnected: false });
+    useETHWalletMock.mockReturnValue({ address: undefined });
+    useDashboardStateMock.mockReturnValue({
+      ...CONNECTED_LOADED,
+      hasCollateral: false,
+    });
+    useDemoLoanMock.mockReturnValue({
+      rows: [DEMO_LOAN_ROW],
+      debtUsd: 1500,
+      hideReal: false,
+    });
+
+    render(<Loans />);
+
+    expect(screen.getByTestId("active-loans-list")).toBeInTheDocument();
+    expect(screen.getByTestId("loans-summary")).toBeInTheDocument();
+    expect(screen.queryByTestId("loans-empty-state")).not.toBeInTheDocument();
+  });
+
+  it("keeps the empty state when the demo is on but has no loan mocks", () => {
+    useConnectionMock.mockReturnValue({ isConnected: false });
+    useETHWalletMock.mockReturnValue({ address: undefined });
+    useDashboardStateMock.mockReturnValue({
+      ...CONNECTED_LOADED,
+      hasCollateral: false,
+    });
+    useDemoLoanMock.mockReturnValue({ rows: [], debtUsd: 0, hideReal: false });
+
+    render(<Loans />);
+
+    expect(screen.getByTestId("loans-empty-state")).toBeInTheDocument();
   });
 
   it("renders the summary once a connected depositor with collateral has loaded", () => {

--- a/services/vault/src/components/pages/__tests__/Loans.test.tsx
+++ b/services/vault/src/components/pages/__tests__/Loans.test.tsx
@@ -18,6 +18,8 @@ const useConnectionMock = vi.fn();
 const useETHWalletMock = vi.fn();
 const useDashboardStateMock = vi.fn();
 const useDemoLoanMock = vi.fn();
+const useDebugHealthFactorOverrideMock = vi.fn();
+const useDebugBorrowCapacityMock = vi.fn();
 
 vi.mock("@/context/wallet", () => ({
   useConnection: () => useConnectionMock(),
@@ -51,6 +53,11 @@ vi.mock("@/dev/demoDeposit", () => ({
   useDemoLoan: () => useDemoLoanMock(),
 }));
 
+vi.mock("@/dev/debugPositionStore", () => ({
+  useDebugHealthFactorOverride: () => useDebugHealthFactorOverrideMock(),
+  useDebugBorrowCapacity: () => useDebugBorrowCapacityMock(),
+}));
+
 vi.mock("react-router", () => ({
   useOutletContext: () => ({ openDeposit: vi.fn() }),
 }));
@@ -70,7 +77,25 @@ vi.mock("@/components/shared", () => ({
 }));
 
 vi.mock("../../simple/LoansSummary", () => ({
-  LoansSummary: () => <div data-testid="loans-summary" />,
+  LoansSummary: ({
+    borrowCapacityLoading,
+    borrowCapacityError,
+    healthFactor,
+    healthFactorStatus,
+  }: {
+    borrowCapacityLoading: boolean;
+    borrowCapacityError: Error | null;
+    healthFactor: number | null;
+    healthFactorStatus: string;
+  }) => (
+    <div
+      data-testid="loans-summary"
+      data-capacity-loading={String(borrowCapacityLoading)}
+      data-capacity-error={String(Boolean(borrowCapacityError))}
+      data-health-factor={String(healthFactor)}
+      data-health-factor-status={healthFactorStatus}
+    />
+  ),
 }));
 
 vi.mock("../../simple/ActiveLoansList", () => ({
@@ -112,6 +137,8 @@ describe("Loans page — loading gate", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     useDemoLoanMock.mockReturnValue(null);
+    useDebugHealthFactorOverrideMock.mockReturnValue(null);
+    useDebugBorrowCapacityMock.mockReturnValue(null);
   });
 
   it("shows a spinner (not the deposit CTA) while a connected depositor's position loads", () => {
@@ -191,5 +218,83 @@ describe("Loans page — loading gate", () => {
     render(<Loans />);
 
     expect(screen.getByTestId("loans-summary")).toBeInTheDocument();
+  });
+});
+
+describe("Loans page — god-mode summary overrides", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useDemoLoanMock.mockReturnValue(null);
+    useDebugHealthFactorOverrideMock.mockReturnValue(null);
+    useDebugBorrowCapacityMock.mockReturnValue(null);
+    useConnectionMock.mockReturnValue({ isConnected: true });
+    useETHWalletMock.mockReturnValue({ address: "0xabc" });
+  });
+
+  // A forced state must REPLACE the live one: merging them field by field left
+  // "Error" rendering the live loader, so the forced state never showed.
+  it("shows the forced capacity error even while the live read is loading", () => {
+    useDashboardStateMock.mockReturnValue({
+      ...CONNECTED_LOADED,
+      isBorrowCapacityLoading: true,
+    });
+    useDebugBorrowCapacityMock.mockReturnValue({
+      loading: false,
+      error: new Error("forced"),
+    });
+
+    render(<Loans />);
+
+    const summary = screen.getByTestId("loans-summary");
+    expect(summary).toHaveAttribute("data-capacity-loading", "false");
+    expect(summary).toHaveAttribute("data-capacity-error", "true");
+  });
+
+  it("shows the forced loading state even while the live read has failed", () => {
+    useDashboardStateMock.mockReturnValue({
+      ...CONNECTED_LOADED,
+      borrowCapacityError: new Error("live failure"),
+    });
+    useDebugBorrowCapacityMock.mockReturnValue({ loading: true, error: null });
+
+    render(<Loans />);
+
+    const summary = screen.getByTestId("loans-summary");
+    expect(summary).toHaveAttribute("data-capacity-loading", "true");
+    expect(summary).toHaveAttribute("data-capacity-error", "false");
+  });
+
+  it("bands the forced health factor with the production rule", () => {
+    useDashboardStateMock.mockReturnValue({
+      ...CONNECTED_LOADED,
+      healthFactor: 5,
+      healthFactorStatus: "safe",
+    });
+    useDebugHealthFactorOverrideMock.mockReturnValue(0.95);
+
+    render(<Loans />);
+
+    const summary = screen.getByTestId("loans-summary");
+    expect(summary).toHaveAttribute("data-health-factor", "0.95");
+    expect(summary).toHaveAttribute("data-health-factor-status", "danger");
+  });
+
+  it("renders the summary from an override alone, with no position and no mocks", () => {
+    useConnectionMock.mockReturnValue({ isConnected: false });
+    useETHWalletMock.mockReturnValue({ address: undefined });
+    useDashboardStateMock.mockReturnValue({
+      ...CONNECTED_LOADED,
+      hasCollateral: false,
+    });
+    useDebugHealthFactorOverrideMock.mockReturnValue(1.25);
+
+    render(<Loans />);
+
+    // The summary only exists in the populated layout, so its presence is what
+    // proves the override routed past the full-page empty state. (The inner
+    // "no active loans" placeholder still renders below it — there are no rows
+    // — and shares the same stub, so it can't be asserted on separately here.)
+    expect(screen.getByTestId("loans-summary")).toBeInTheDocument();
+    expect(screen.queryByTestId("active-loans-list")).not.toBeInTheDocument();
   });
 });

--- a/services/vault/src/components/simple/ActiveLoansList.tsx
+++ b/services/vault/src/components/simple/ActiveLoansList.tsx
@@ -69,11 +69,15 @@ export function ActiveLoansList({
                 value={utilization}
               />
 
+              {/* A god-mode demo row (`displayOnly`) is a preview of the row
+                  layout only — its symbol resolves to no reserve, so both
+                  actions stay disabled rather than dead-ending in (or worse,
+                  colliding with) the real borrow/repay overlay. */}
               <div className="ml-auto flex shrink-0 gap-2">
                 <button
                   type="button"
                   onClick={() => onBorrow(row.symbol)}
-                  disabled={!canBorrow || !row.isBorrowable}
+                  disabled={!canBorrow || !row.isBorrowable || row.displayOnly}
                   className={NEUTRAL_ROW_BUTTON_CLASS}
                 >
                   {COPY.loans.borrowButton}
@@ -81,6 +85,7 @@ export function ActiveLoansList({
                 <button
                   type="button"
                   onClick={() => onRepay(row.symbol)}
+                  disabled={row.displayOnly}
                   className={NEUTRAL_ROW_BUTTON_CLASS}
                 >
                   {COPY.loans.repayButton}

--- a/services/vault/src/components/simple/DashboardPage.tsx
+++ b/services/vault/src/components/simple/DashboardPage.tsx
@@ -5,7 +5,7 @@
  */
 
 import { Container } from "@babylonlabs-io/core-ui";
-import { lazy, Suspense, useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useOutletContext } from "react-router";
 
 import { AssetSelectionModal } from "@/applications/aave/components/AssetSelectionModal";
@@ -17,8 +17,6 @@ import { PAGE_CONTENT_CLASS } from "@/components/shared/layoutClasses";
 import featureFlags from "@/config/featureFlags";
 import { useConnection, useETHWallet } from "@/context/wallet";
 import { COPY } from "@/copy";
-import { LiquidationAnalysisDebugPanel } from "@/dev/LiquidationAnalysisDebugPanel";
-import { PositionNotificationsDebugPanel } from "@/dev/PositionNotificationsDebugPanel";
 import {
   useDebugManualMode,
   useDebugManualParams,
@@ -56,15 +54,6 @@ import { PositionNotificationBanner } from "./PositionNotificationBanner";
 import { RiskSection } from "./RiskSection";
 import { SupplyCapSection } from "./SupplyCapSection";
 import WithdrawFlow from "./WithdrawFlow";
-
-// Dev-only god-mode panel, lazily imported behind `import.meta.env.DEV` so its
-// code is dropped from production builds entirely (the dynamic import sits in a
-// dead branch that the bundler eliminates).
-const GodModePanel = import.meta.env.DEV
-  ? lazy(() =>
-      import("@/dev/GodModePanel").then((m) => ({ default: m.GodModePanel })),
-    )
-  : null;
 
 export function DashboardPage() {
   const { openDeposit } = useOutletContext<RootLayoutContext>();
@@ -308,27 +297,6 @@ export function DashboardPage() {
     />
   ) : null;
 
-  // Dev/QA god-mode admin panel (NEXT_PUBLIC_FF_GOD_MODE_PANEL). Floats over
-  // the page and drives the demo items rendered in the real sections below.
-  // Stripped from production builds and never active there (see GodModePanel).
-  // The position-notifications debug controls live inside the god-mode panel as
-  // a section (gated by their own flag), so there's one integrated debug
-  // surface rather than a separate panel on the page.
-  const godModePanel =
-    import.meta.env.DEV &&
-    GodModePanel &&
-    featureFlags.isGodModePanelEnabled ? (
-      <Suspense fallback={null}>
-        <GodModePanel>
-          {featureFlags.isV3UiEnabled && <LiquidationAnalysisDebugPanel />}
-          {liquidationNotificationsEnabled &&
-            featureFlags.isPositionDebugPanelEnabled && (
-              <PositionNotificationsDebugPanel />
-            )}
-        </GodModePanel>
-      </Suspense>
-    ) : null;
-
   if (!isConnected) {
     return (
       // `my-auto` completes the Container's built-in `mx-auto` to a full
@@ -336,7 +304,6 @@ export function DashboardPage() {
       // the remaining viewport height.
       <Container className={`${PAGE_CONTENT_CLASS} my-auto pb-6`}>
         <DisconnectedOverview capSnapshot={capSnapshot} />
-        {godModePanel}
       </Container>
     );
   }
@@ -473,8 +440,6 @@ export function DashboardPage() {
 
       {/* Asset Selection Modal for Borrow/Repay */}
       <AssetSelectionModal {...assetModalProps} />
-
-      {godModePanel}
     </Container>
   );
 }

--- a/services/vault/src/components/simple/__tests__/ActiveLoansList.test.tsx
+++ b/services/vault/src/components/simple/__tests__/ActiveLoansList.test.tsx
@@ -60,4 +60,22 @@ describe("ActiveLoansList — per-row Borrow gating", () => {
 
     expect(screen.getByRole("button", { name: "Borrow" })).toBeDisabled();
   });
+
+  // A `displayOnly` row is a god-mode demo mock: its symbol resolves to no
+  // reserve, so neither action may reach the real borrow/repay overlay.
+  it("disables both actions for a display-only (god-mode demo) row", () => {
+    const onBorrow = vi.fn();
+    const onRepay = vi.fn();
+    render(
+      <ActiveLoansList
+        rows={[makeRow({ isBorrowable: true, displayOnly: true })]}
+        canBorrow
+        onBorrow={onBorrow}
+        onRepay={onRepay}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Borrow" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Repay" })).toBeDisabled();
+  });
 });

--- a/services/vault/src/dev/GodModeMount.tsx
+++ b/services/vault/src/dev/GodModeMount.tsx
@@ -1,0 +1,36 @@
+/**
+ * The single god-mode mount point (dev / QA only).
+ *
+ * The panel used to be mounted per page (Overview, then Vaults), which meant
+ * the v3 tabs that came later — Loans above all — had no panel at all, and the
+ * debug sections below only ever existed on Overview. It is now rendered by the
+ * route layout that wraps Overview / Vaults / Loans, and by the Activity route
+ * (see router.tsx), so every tab gets the same controls and the panel keeps its
+ * open/dragged/popped-out state while navigating within a subtree. The mock
+ * list itself lives in a module store, so it survives any navigation.
+ *
+ * It is mounted per subtree rather than in RootLayout because the
+ * position-notifications section reads the Aave providers (config / reorder /
+ * activating vaults) that only those subtrees mount.
+ *
+ * Everything here is behind `import.meta.env.DEV` at the import site, so this
+ * module and its whole dev subtree are dropped from production builds.
+ */
+
+import featureFlags from "@/config/featureFlags";
+
+import { GodModePanel } from "./GodModePanel";
+import { LiquidationAnalysisDebugPanel } from "./LiquidationAnalysisDebugPanel";
+import { PositionNotificationsDebugPanel } from "./PositionNotificationsDebugPanel";
+
+export function GodModeMount() {
+  return (
+    <GodModePanel>
+      {featureFlags.isV3UiEnabled && <LiquidationAnalysisDebugPanel />}
+      {featureFlags.isLiquidationNotificationsEnabled &&
+        featureFlags.isPositionDebugPanelEnabled && (
+          <PositionNotificationsDebugPanel />
+        )}
+    </GodModePanel>
+  );
+}

--- a/services/vault/src/dev/GodModePanel.tsx
+++ b/services/vault/src/dev/GodModePanel.tsx
@@ -46,6 +46,7 @@ import {
 } from "./demoArtifactDownload";
 import {
   addDemoItem,
+  amountUnitFor,
   type DemoCta,
   type DemoItem,
   type DemoType,
@@ -79,12 +80,6 @@ const TYPE_LABELS: Record<DemoType, string> = {
   loan: "Loan",
   activity: "Activity",
 };
-
-/** Unit a mock item's amount is denominated in: BTC everywhere except loans,
- *  whose amount is the borrowed stablecoin. */
-function amountUnit(type: DemoType): string {
-  return type === "loan" ? "USDC" : "BTC";
-}
 
 const CTA_BADGE: Record<DemoCta, { label: string; className: string }> = {
   primary: { label: "Orange CTA", className: "bg-orange-500 text-white" },
@@ -257,7 +252,7 @@ function ItemRow({ item, index }: { item: DemoItem; index: number }) {
       </div>
 
       <label className="flex items-center justify-between gap-2 text-xs">
-        <span>Amount ({amountUnit(item.type)})</span>
+        <span>Amount ({amountUnitFor(item)})</span>
         <input
           type="number"
           min="0"
@@ -265,7 +260,7 @@ function ItemRow({ item, index }: { item: DemoItem; index: number }) {
           value={item.amount}
           onChange={(e) => setDemoItemAmount(item.key, e.target.value)}
           className="w-28 rounded border border-zinc-600 bg-zinc-800 px-2 py-1 text-xs"
-          aria-label={`Mock ${position} amount (${amountUnit(item.type)})`}
+          aria-label={`Mock ${position} amount (${amountUnitFor(item)})`}
         />
       </label>
 

--- a/services/vault/src/dev/GodModePanel.tsx
+++ b/services/vault/src/dev/GodModePanel.tsx
@@ -7,8 +7,9 @@
  * app — no cross-window plumbing).
  *
  * It is a controller only: it never renders the cards itself. It manages a list
- * of mock items (each a deposit / withdrawal / collateral at some state) that
- * render inside the REAL dashboard sections (see demoDeposit.ts).
+ * of mock items (each a deposit / withdrawal / collateral / loan at some state)
+ * that render inside the REAL dashboard, vaults and loans sections (see
+ * demoDeposit.ts). It is mounted once for those routes (see dev/GodModeMount).
  *
  * Chrome is intentionally theme-independent (fixed zinc colors) and inline, not
  * routed through copy.ts — none of it is shown to depositors.
@@ -28,8 +29,14 @@ import type { ProtocolStatus } from "@/components/shared/protocolStatus";
 
 import {
   DEBUG_FORCED_MAX_VAULTS,
+  DEBUG_HEALTH_FACTORS,
+  type DebugBorrowCapacityState,
+  setDebugBorrowCapacityStateOverride,
+  setDebugHealthFactorOverride,
   setDebugMaxVaultsOverride,
   setDebugProtocolStatusOverride,
+  useDebugBorrowCapacityStateOverride,
+  useDebugHealthFactorOverride,
   useDebugMaxVaultsOverride,
   useDebugProtocolStatusOverride,
 } from "./debugPositionStore";
@@ -58,12 +65,26 @@ import {
   useDemoHideReal,
   useDemoItems,
 } from "./demoDeposit";
+import {
+  PANEL_BUTTON_CLASS,
+  PANEL_SECTION_CLASS,
+  PANEL_SECTION_TITLE_CLASS,
+  panelSegmentClass,
+} from "./panelChrome";
 
 const TYPE_LABELS: Record<DemoType, string> = {
   deposit: "Deposit",
   withdrawal: "Withdrawal",
   collateral: "Collateral",
+  loan: "Loan",
+  activity: "Activity",
 };
+
+/** Unit a mock item's amount is denominated in: BTC everywhere except loans,
+ *  whose amount is the borrowed stablecoin. */
+function amountUnit(type: DemoType): string {
+  return type === "loan" ? "USDC" : "BTC";
+}
 
 const CTA_BADGE: Record<DemoCta, { label: string; className: string }> = {
   primary: { label: "Orange CTA", className: "bg-orange-500 text-white" },
@@ -73,9 +94,6 @@ const CTA_BADGE: Record<DemoCta, { label: string; className: string }> = {
   },
   none: { label: "No CTA", className: "bg-zinc-700 text-zinc-300" },
 };
-
-const CONTROL_BUTTON_CLASS =
-  "rounded border border-zinc-600 px-2 py-1 text-xs disabled:opacity-40";
 
 /**
  * Deposit "mode" segments over the flat DEPOSIT_SCENARIOS list. The mode select
@@ -130,7 +148,7 @@ function ItemRow({ item, index }: { item: DemoItem; index: number }) {
   const clampLocal = (next: number) => Math.min(count - 1, Math.max(0, next));
 
   return (
-    <div className="space-y-2 rounded-lg border border-zinc-700/60 p-2">
+    <div className={`space-y-2 ${PANEL_SECTION_CLASS}`}>
       <div className="flex items-center justify-between gap-2">
         <select
           value={item.type}
@@ -158,7 +176,7 @@ function ItemRow({ item, index }: { item: DemoItem; index: number }) {
           <button
             type="button"
             onClick={() => removeDemoItem(item.key)}
-            className={CONTROL_BUTTON_CLASS}
+            className={PANEL_BUTTON_CLASS}
             aria-label={`Remove mock ${position}`}
           >
             ✕
@@ -200,7 +218,7 @@ function ItemRow({ item, index }: { item: DemoItem; index: number }) {
             setDemoItemState(item.key, offset + clampLocal(localIndex - 1))
           }
           disabled={localIndex === 0}
-          className={CONTROL_BUTTON_CLASS}
+          className={PANEL_BUTTON_CLASS}
         >
           Prev
         </button>
@@ -222,7 +240,7 @@ function ItemRow({ item, index }: { item: DemoItem; index: number }) {
             setDemoItemState(item.key, offset + clampLocal(localIndex + 1))
           }
           disabled={localIndex === count - 1}
-          className={CONTROL_BUTTON_CLASS}
+          className={PANEL_BUTTON_CLASS}
         >
           Next
         </button>
@@ -239,7 +257,7 @@ function ItemRow({ item, index }: { item: DemoItem; index: number }) {
       </div>
 
       <label className="flex items-center justify-between gap-2 text-xs">
-        <span>Amount (BTC)</span>
+        <span>Amount ({amountUnit(item.type)})</span>
         <input
           type="number"
           min="0"
@@ -247,7 +265,7 @@ function ItemRow({ item, index }: { item: DemoItem; index: number }) {
           value={item.amount}
           onChange={(e) => setDemoItemAmount(item.key, e.target.value)}
           className="w-28 rounded border border-zinc-600 bg-zinc-800 px-2 py-1 text-xs"
-          aria-label={`Mock ${position} amount (BTC)`}
+          aria-label={`Mock ${position} amount (${amountUnit(item.type)})`}
         />
       </label>
 
@@ -334,20 +352,14 @@ function ThemeControls() {
   const { theme, setTheme } = useTheme();
   return (
     <div className="space-y-2">
-      <div className="tracking-wide text-xs font-semibold uppercase text-zinc-400">
-        Theme
-      </div>
+      <div className={PANEL_SECTION_TITLE_CLASS}>Theme</div>
       <div className="flex gap-2">
         {THEME_OPTIONS.map((option) => (
           <button
             key={option}
             type="button"
             onClick={() => setTheme(option)}
-            className={`flex-1 rounded border px-2 py-1 text-xs capitalize ${
-              theme === option
-                ? "border-orange-500 bg-orange-500/20 text-white"
-                : "border-zinc-600 text-zinc-300"
-            }`}
+            className={`${panelSegmentClass(theme === option)} capitalize`}
           >
             {option}
           </button>
@@ -387,11 +399,7 @@ function SegmentButton({
     <button
       type="button"
       onClick={onClick}
-      className={`flex-1 rounded border px-2 py-1 text-xs ${
-        active
-          ? "border-orange-500 bg-orange-500/20 text-white"
-          : "border-zinc-600 text-zinc-300"
-      }`}
+      className={panelSegmentClass(active)}
     >
       {label}
     </button>
@@ -404,9 +412,7 @@ function NotificationOverrideControls() {
 
   return (
     <div className="space-y-2">
-      <div className="tracking-wide text-xs font-semibold uppercase text-zinc-400">
-        Notifications
-      </div>
+      <div className={PANEL_SECTION_TITLE_CLASS}>Notifications</div>
 
       <label className="flex cursor-pointer items-center justify-between gap-2 text-sm">
         <span>Maximum vaults reached</span>
@@ -445,15 +451,76 @@ function NotificationOverrideControls() {
   );
 }
 
+/**
+ * Loans-summary overrides (v3 /loans). The row list is driven by "Loan" mocks
+ * in the Mocks section; these two cover the summary states a real position
+ * can't be talked into on demand — a health factor in each band, and the
+ * borrow-capacity cards while their read is loading or has failed.
+ */
+const BORROW_CAPACITY_LABELS: Record<DebugBorrowCapacityState, string> = {
+  loading: "Loading",
+  error: "Error",
+};
+
+function LoansOverrideControls() {
+  const healthFactorOverride = useDebugHealthFactorOverride();
+  const borrowCapacityOverride = useDebugBorrowCapacityStateOverride();
+
+  return (
+    <div className="space-y-2">
+      <div className={PANEL_SECTION_TITLE_CLASS}>Loans summary</div>
+
+      <div className="space-y-1">
+        <div className="text-xs text-zinc-400">Health factor</div>
+        <div className="flex gap-2">
+          <SegmentButton
+            label="Live"
+            active={healthFactorOverride === null}
+            onClick={() => setDebugHealthFactorOverride(null)}
+          />
+          {DEBUG_HEALTH_FACTORS.map(({ value, label }) => (
+            <SegmentButton
+              key={label}
+              label={`${label} (${value})`}
+              active={healthFactorOverride === value}
+              onClick={() => setDebugHealthFactorOverride(value)}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div className="space-y-1">
+        <div className="text-xs text-zinc-400">Borrow capacity</div>
+        <div className="flex gap-2">
+          <SegmentButton
+            label="Live"
+            active={borrowCapacityOverride === null}
+            onClick={() => setDebugBorrowCapacityStateOverride(null)}
+          />
+          {(
+            Object.keys(BORROW_CAPACITY_LABELS) as DebugBorrowCapacityState[]
+          ).map((state) => (
+            <SegmentButton
+              key={state}
+              label={BORROW_CAPACITY_LABELS[state]}
+              active={borrowCapacityOverride === state}
+              onClick={() => setDebugBorrowCapacityStateOverride(state)}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function PanelBody({ children }: { children?: ReactNode }) {
   return (
     <div className="space-y-4">
       <ThemeControls />
       <NotificationOverrideControls />
+      <LoansOverrideControls />
       <div className="space-y-2">
-        <div className="tracking-wide text-xs font-semibold uppercase text-zinc-400">
-          Mocks
-        </div>
+        <div className={PANEL_SECTION_TITLE_CLASS}>Mocks</div>
         <DemoControls />
       </div>
       {children}
@@ -551,7 +618,7 @@ export function GodModePanel({ children }: { children?: ReactNode }) {
           <button
             type="button"
             onClick={closePopup}
-            className={CONTROL_BUTTON_CLASS}
+            className={PANEL_BUTTON_CLASS}
           >
             Return ↙
           </button>
@@ -601,14 +668,14 @@ export function GodModePanel({ children }: { children?: ReactNode }) {
           <button
             type="button"
             onClick={openPopup}
-            className={CONTROL_BUTTON_CLASS}
+            className={PANEL_BUTTON_CLASS}
           >
             Pop out ↗
           </button>
           <button
             type="button"
             onClick={() => setCollapsed(true)}
-            className={CONTROL_BUTTON_CLASS}
+            className={PANEL_BUTTON_CLASS}
           >
             Hide
           </button>

--- a/services/vault/src/dev/LiquidationAnalysisDebugPanel.tsx
+++ b/services/vault/src/dev/LiquidationAnalysisDebugPanel.tsx
@@ -14,13 +14,19 @@ import {
   setLiquidationDebugState,
   useLiquidationDebugState,
 } from "./liquidationDebugStore";
+import {
+  PANEL_HINT_CLASS,
+  PANEL_SECTION_CLASS,
+  PANEL_SECTION_TITLE_CLASS,
+  panelSegmentClass,
+} from "./panelChrome";
 
 export function LiquidationAnalysisDebugPanel() {
   const state = useLiquidationDebugState();
 
   return (
-    <details className="rounded-lg border border-dashed border-purple-400 bg-purple-50 p-4 dark:border-purple-700 dark:bg-purple-950/30">
-      <summary className="cursor-pointer text-sm font-semibold text-purple-700 dark:text-purple-300">
+    <details className={PANEL_SECTION_CLASS}>
+      <summary className={PANEL_SECTION_TITLE_CLASS}>
         Liquidation Analysis
         {state !== "auto" && ` (${state})`}
       </summary>
@@ -31,17 +37,13 @@ export function LiquidationAnalysisDebugPanel() {
               key={value}
               type="button"
               onClick={() => setLiquidationDebugState(value)}
-              className={`flex-1 rounded border px-2 py-1 text-xs ${
-                state === value
-                  ? "border-orange-500 bg-orange-500/20 text-orange-700 dark:text-white"
-                  : "border-zinc-400 text-zinc-600 dark:border-zinc-600 dark:text-zinc-300"
-              }`}
+              className={panelSegmentClass(state === value)}
             >
               {label}
             </button>
           ))}
         </div>
-        <p className="text-xs text-gray-500 dark:text-gray-400">
+        <p className={PANEL_HINT_CLASS}>
           Forces the card&apos;s state; Auto follows the live position. The
           chart uses a placeholder cascade — switch on Manual Mode in Position
           Notifications to drive it with your own price and vaults.

--- a/services/vault/src/dev/PositionNotificationsDebugPanel.tsx
+++ b/services/vault/src/dev/PositionNotificationsDebugPanel.tsx
@@ -35,24 +35,32 @@ import {
   useDebugSimulateStalePrice,
 } from "@/dev/debugPositionStore";
 
+import {
+  PANEL_BUTTON_CLASS,
+  PANEL_HINT_CLASS,
+  PANEL_INPUT_CLASS,
+  PANEL_LABEL_CLASS,
+  PANEL_SECTION_CLASS,
+  PANEL_SECTION_TITLE_CLASS,
+} from "./panelChrome";
+
+// Severity tints for the banner preview. Dark-only (no light variants): the
+// god-mode box is a fixed zinc surface regardless of the app's theme.
 const SEVERITY_COLORS: Record<BannerSeverity, string> = {
-  red: "border-red-500 bg-red-50 text-red-900 dark:bg-red-950/30 dark:text-red-200",
-  yellow:
-    "border-yellow-500 bg-yellow-50 text-yellow-900 dark:bg-yellow-950/30 dark:text-yellow-200",
-  soft: "border-gray-300 bg-gray-50 text-gray-600 dark:border-gray-700 dark:bg-gray-900/30 dark:text-gray-400",
-  green:
-    "border-green-500 bg-green-50 text-green-900 dark:bg-green-950/30 dark:text-green-200",
-  hidden:
-    "border-gray-300 bg-gray-50 text-gray-600 dark:border-gray-600 dark:bg-gray-800/30 dark:text-gray-400",
+  red: "border-red-500 bg-red-500/15 text-red-200",
+  yellow: "border-yellow-500 bg-yellow-500/15 text-yellow-200",
+  soft: "border-zinc-600 bg-zinc-800/60 text-zinc-400",
+  green: "border-green-500 bg-green-500/15 text-green-200",
+  hidden: "border-zinc-700 bg-zinc-800/40 text-zinc-500",
 };
 
 const WARNING_TYPE_COLORS: Record<WarningType, string> = {
   urgent: "bg-red-600 text-white",
   cliff: "bg-orange-600 text-white",
   reorder: "bg-yellow-500 text-black",
-  dust: "bg-gray-500 text-white",
+  dust: "bg-zinc-600 text-white",
   "weird-params": "bg-blue-500 text-white",
-  "too-many-vaults": "bg-purple-500 text-white",
+  "too-many-vaults": "bg-teal-600 text-white",
 };
 
 const STATUS_MESSAGES: Record<
@@ -69,12 +77,8 @@ const STATUS_MESSAGES: Record<
 // The panel lives inside the ~420px god-mode box, so every layout here is
 // container-sized: full-width inputs in a fixed 2-column grid. Viewport `md:`
 // breakpoints would fire on a wide window and overflow the narrow box.
-const INPUT_CLASS =
-  "w-full min-w-0 rounded border border-gray-300 px-2 py-1 text-sm font-mono dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200";
-const LABEL_CLASS = "truncate text-xs text-gray-600 dark:text-gray-400";
 const FIELD_GRID_CLASS = "grid grid-cols-2 gap-x-3 gap-y-2";
-const PRESET_BUTTON_CLASS =
-  "rounded bg-purple-100 px-2 py-1 text-xs font-medium text-purple-700 hover:bg-purple-200 dark:bg-purple-900/50 dark:text-purple-300 dark:hover:bg-purple-800/50";
+const PRESET_BUTTON_CLASS = `${PANEL_BUTTON_CLASS} text-zinc-200 hover:bg-zinc-800`;
 
 /** Initial counter for generated vault IDs (avoids collision with default vaults) */
 const INITIAL_VAULT_ID_COUNTER = 100;
@@ -91,16 +95,14 @@ function WarningBadge({ type }: { type: WarningType }) {
 
 function WarningCard({ warning }: { warning: Warning }) {
   return (
-    <div className="rounded border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-800">
+    <div className="rounded border border-zinc-700 bg-zinc-800/60 p-3">
       <div className="mb-1 flex items-center gap-2">
         <WarningBadge type={warning.type} />
         <span className="font-medium">{warning.title}</span>
       </div>
-      <p className="text-sm text-gray-700 dark:text-gray-300">
-        {warning.detail}
-      </p>
+      <p className="text-sm text-zinc-300">{warning.detail}</p>
       {warning.suggestion && (
-        <p className="mt-1 text-sm font-medium text-blue-700 dark:text-blue-400">
+        <p className="mt-1 text-sm font-medium text-sky-300">
           {warning.suggestion}
         </p>
       )}
@@ -110,9 +112,7 @@ function WarningCard({ warning }: { warning: Warning }) {
 
 function GroupRow({ group }: { group: LiquidationGroup }) {
   return (
-    <tr
-      className={group.isFullLiquidation ? "bg-red-50 dark:bg-red-950/30" : ""}
-    >
+    <tr className={group.isFullLiquidation ? "bg-red-950/40" : ""}>
       <td className="px-2 py-1 text-center">{group.index}</td>
       <td className="px-2 py-1">
         {group.vaults.map((v) => v.name).join(", ")}
@@ -200,7 +200,7 @@ function ResultPanel({ result }: { result: CalculatorResult }) {
           <div className="mt-2 overflow-x-auto">
             <table className="w-full text-xs">
               <thead>
-                <tr className="border-b border-gray-200 text-left dark:border-gray-700">
+                <tr className="border-b border-zinc-700 text-left">
                   <th className="px-2 py-1">#</th>
                   <th className="px-2 py-1">Vaults</th>
                   <th className="px-2 py-1 text-right">BTC</th>
@@ -305,15 +305,15 @@ function ManualInputPanel({
   );
 
   return (
-    <div className="space-y-3 rounded border border-purple-200 bg-white p-3 dark:border-purple-800 dark:bg-gray-800/50">
+    <div className="space-y-3 rounded border border-zinc-700 bg-zinc-800/40 p-3">
       {/* Market & Debt */}
       <div className={FIELD_GRID_CLASS}>
         <div>
-          <div className={LABEL_CLASS}>BTC Price ($)</div>
+          <div className={PANEL_LABEL_CLASS}>BTC Price ($)</div>
           <input
             type="number"
             step="100"
-            className={INPUT_CLASS}
+            className={PANEL_INPUT_CLASS}
             value={params.btcPrice}
             onChange={(e) =>
               updateField("btcPrice", parseFloat(e.target.value) || 0)
@@ -321,11 +321,11 @@ function ManualInputPanel({
           />
         </div>
         <div>
-          <div className={LABEL_CLASS}>Total Debt ($)</div>
+          <div className={PANEL_LABEL_CLASS}>Total Debt ($)</div>
           <input
             type="number"
             step="1000"
-            className={INPUT_CLASS}
+            className={PANEL_INPUT_CLASS}
             value={params.totalDebtUsd}
             onChange={(e) =>
               updateField("totalDebtUsd", parseFloat(e.target.value) || 0)
@@ -333,13 +333,13 @@ function ManualInputPanel({
           />
         </div>
         <div>
-          <div className={LABEL_CLASS}>CF</div>
+          <div className={PANEL_LABEL_CLASS}>CF</div>
           <input
             type="number"
             step="0.05"
             min="0.1"
             max="0.99"
-            className={INPUT_CLASS}
+            className={PANEL_INPUT_CLASS}
             value={params.CF}
             onChange={(e) =>
               updateField("CF", parseFloat(e.target.value) || DEBUG_DEFAULT_CF)
@@ -347,13 +347,13 @@ function ManualInputPanel({
           />
         </div>
         <div>
-          <div className={LABEL_CLASS}>THF</div>
+          <div className={PANEL_LABEL_CLASS}>THF</div>
           <input
             type="number"
             step="0.01"
             min="1.01"
             max="2.0"
-            className={INPUT_CLASS}
+            className={PANEL_INPUT_CLASS}
             value={params.THF}
             onChange={(e) =>
               updateField(
@@ -366,13 +366,13 @@ function ManualInputPanel({
       </div>
       <div className={FIELD_GRID_CLASS}>
         <div>
-          <div className={LABEL_CLASS}>LB (maxLB)</div>
+          <div className={PANEL_LABEL_CLASS}>LB (maxLB)</div>
           <input
             type="number"
             step="0.01"
             min="1.0"
             max="1.5"
-            className={INPUT_CLASS}
+            className={PANEL_INPUT_CLASS}
             value={params.maxLB}
             onChange={(e) =>
               updateField(
@@ -383,13 +383,13 @@ function ManualInputPanel({
           />
         </div>
         <div>
-          <div className={LABEL_CLASS}>Expected HF</div>
+          <div className={PANEL_LABEL_CLASS}>Expected HF</div>
           <input
             type="number"
             step="0.01"
             min="0.5"
             max="1.0"
-            className={INPUT_CLASS}
+            className={PANEL_INPUT_CLASS}
             value={params.expectedHF}
             onChange={(e) =>
               updateField(
@@ -404,13 +404,13 @@ function ManualInputPanel({
       {/* Vaults */}
       <div>
         <div className="mb-1 flex items-center gap-2">
-          <span className="text-xs font-medium text-gray-700 dark:text-gray-300">
+          <span className="text-xs font-medium text-zinc-300">
             Vaults ({params.vaults.length})
           </span>
           <button
             type="button"
             onClick={addVault}
-            className="rounded bg-purple-100 px-2 py-0.5 text-xs font-medium text-purple-700 hover:bg-purple-200 dark:bg-purple-900/50 dark:text-purple-300 dark:hover:bg-purple-800/50"
+            className={PRESET_BUTTON_CLASS}
           >
             + Add
           </button>
@@ -418,27 +418,23 @@ function ManualInputPanel({
         <div className="space-y-1">
           {params.vaults.map((vault, i) => (
             <div key={vault.id} className="flex items-center gap-2">
-              <span className="w-16 text-xs text-gray-500 dark:text-gray-400">
-                {vault.name}
-              </span>
+              <span className="w-16 text-xs text-zinc-400">{vault.name}</span>
               <input
                 type="number"
                 step="0.01"
                 min="0.001"
-                className="w-24 rounded border border-gray-300 px-2 py-1 font-mono text-sm dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200"
+                className={`w-24 ${PANEL_INPUT_CLASS}`}
                 value={vault.btc}
                 onChange={(e) =>
                   updateVaultBtc(i, parseFloat(e.target.value) || 0.01)
                 }
               />
-              <span className="text-xs text-gray-500 dark:text-gray-400">
-                BTC
-              </span>
+              <span className="text-xs text-zinc-400">BTC</span>
               {params.vaults.length > 1 && (
                 <button
                   type="button"
                   onClick={() => removeVault(i)}
-                  className="text-xs text-red-500 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
+                  className="text-xs text-red-400 hover:text-red-300"
                 >
                   remove
                 </button>
@@ -488,8 +484,8 @@ export function PositionNotificationsDebugPanel() {
   useEffect(() => () => setDebugPositionOverride(null, null), []);
 
   return (
-    <details className="rounded-lg border border-dashed border-purple-400 bg-purple-50 p-4 dark:border-purple-700 dark:bg-purple-950/30">
-      <summary className="cursor-pointer text-sm font-semibold text-purple-700 dark:text-purple-300">
+    <details className={PANEL_SECTION_CLASS}>
+      <summary className={PANEL_SECTION_TITLE_CLASS}>
         Position Notifications Debug Panel
         {!manualMode && status === "loading" && " (loading...)"}
         {manualMode && " (manual)"}
@@ -534,7 +530,7 @@ export function PositionNotificationsDebugPanel() {
             <button
               type="button"
               onClick={() => resetDebugManualParams()}
-              className="rounded bg-gray-100 px-2 py-0.5 text-xs text-gray-600 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+              className={PANEL_BUTTON_CLASS}
             >
               Reset defaults
             </button>
@@ -551,9 +547,7 @@ export function PositionNotificationsDebugPanel() {
 
         {/* Status message (live mode only) */}
         {!manualMode && status !== "ready" && (
-          <p className="text-sm text-gray-500 dark:text-gray-400">
-            {STATUS_MESSAGES[status]}
-          </p>
+          <p className={PANEL_HINT_CLASS}>{STATUS_MESSAGES[status]}</p>
         )}
 
         {/* Results */}

--- a/services/vault/src/dev/__tests__/GodModePanel.test.tsx
+++ b/services/vault/src/dev/__tests__/GodModePanel.test.tsx
@@ -228,18 +228,25 @@ describe("demoDeposit builders", () => {
     );
   });
 
+  // Fake timers, not a tolerance around a real clock: the builder reads
+  // `Date.now()` itself, so comparing against a timestamp captured in the test
+  // is a race — it went fractionally negative on CI.
   it("dates activity mocks relative to now so the date-group headers apply", () => {
-    const now = Date.now();
-    const rows = ACTIVITY_SCENARIOS.map((_, i) =>
-      buildActivitiesDemo([activityItem(i + 1, i)], false),
-    ).flatMap((demo) => demo.rows);
-
-    // Every row is in the past and within the scenarios' daysAgo span.
-    const maxDaysAgo = Math.max(...ACTIVITY_SCENARIOS.map((s) => s.daysAgo));
-    for (const row of rows) {
-      const daysAgo = (now - row.date.getTime()) / (24 * 60 * 60 * 1000);
-      expect(daysAgo).toBeGreaterThanOrEqual(0);
-      expect(daysAgo).toBeLessThanOrEqual(maxDaysAgo + 1);
+    const fixedNow = new Date("2026-03-15T12:00:00.000Z");
+    vi.useFakeTimers();
+    vi.setSystemTime(fixedNow);
+    try {
+      for (const [index, scenario] of ACTIVITY_SCENARIOS.entries()) {
+        const [row] = buildActivitiesDemo(
+          [activityItem(index + 1, index)],
+          false,
+        ).rows;
+        expect(row.date.getTime()).toBe(
+          fixedNow.getTime() - scenario.daysAgo * 24 * 60 * 60 * 1000,
+        );
+      }
+    } finally {
+      vi.useRealTimers();
     }
   });
 

--- a/services/vault/src/dev/__tests__/GodModePanel.test.tsx
+++ b/services/vault/src/dev/__tests__/GodModePanel.test.tsx
@@ -243,6 +243,21 @@ describe("demoDeposit builders", () => {
     }
   });
 
+  // Regression: borrow / repay rows used to hard-code their debt figure, so
+  // the panel's amount control was inert for exactly those two scenarios.
+  it("drives every activity scenario's headline amount from the item", () => {
+    for (const [index, scenario] of ACTIVITY_SCENARIOS.entries()) {
+      const [row] = buildActivitiesDemo(
+        [activityItem(index + 1, index, "3.5")],
+        false,
+      ).rows;
+      const shown =
+        row.kind === "liquidationGroup" ? row.summary.collateral : row.amount;
+      expect(shown.value).toBe("3.5");
+      expect(shown.symbol).toBe(scenario.unit);
+    }
+  });
+
   it("ignores items of other types when building the activity feed", () => {
     const demo = buildActivitiesDemo(
       [depositItem(1, 0), activityItem(2, 0)],
@@ -465,6 +480,37 @@ describe("GodModePanel", () => {
     });
 
     expect(screen.getByText(ACTIVITY_SCENARIOS[0].label)).toBeInTheDocument();
+  });
+
+  // The amount field must name the unit of the value the selected scenario
+  // actually renders — activity rows are not uniformly BTC.
+  it("re-labels the amount field per activity scenario denomination", () => {
+    renderExpanded();
+    fireEvent.change(screen.getByRole("combobox", { name: "Mock 1 type" }), {
+      target: { value: "activity" },
+    });
+
+    // Two scenarios with different denominations — the field must follow the
+    // selected one, whatever the network's collateral symbol happens to be.
+    const collateralUnit = ACTIVITY_SCENARIOS[0].unit;
+    const debtIndex = ACTIVITY_SCENARIOS.findIndex(
+      (s) => s.unit !== collateralUnit,
+    );
+    const slider = screen.getByRole("slider", { name: "Mock 1 step" });
+
+    fireEvent.change(slider, { target: { value: "0" } });
+    expect(
+      screen.getByRole("spinbutton", {
+        name: `Mock 1 amount (${collateralUnit})`,
+      }),
+    ).toBeInTheDocument();
+
+    fireEvent.change(slider, { target: { value: String(debtIndex) } });
+    expect(
+      screen.getByRole("spinbutton", {
+        name: `Mock 1 amount (${ACTIVITY_SCENARIOS[debtIndex].unit})`,
+      }),
+    ).toBeInTheDocument();
   });
 
   it("forces and releases the Loans summary health factor and capacity state", () => {

--- a/services/vault/src/dev/__tests__/GodModePanel.test.tsx
+++ b/services/vault/src/dev/__tests__/GodModePanel.test.tsx
@@ -14,13 +14,17 @@ import { ContractStatus, PeginAction } from "@/models/peginStateMachine";
 import {
   ACTIVATED_SCENARIO_INDEX,
   ACTIVATION_CONFIRMING_SCENARIO_INDEX,
+  ACTIVITY_SCENARIOS,
+  buildActivitiesDemo,
   buildCollateralsDemo,
   buildDepositsDemo,
+  buildLoansDemo,
   buildWithdrawalsDemo,
   COLLATERAL_SCENARIOS,
   type DemoItem,
   DEPOSIT_SCENARIOS,
   getDemoStepperBatch,
+  LOAN_SCENARIOS,
   READY_TO_ACTIVATE_SCENARIO_INDEX,
   resetDemoState,
   setDemoItemState,
@@ -54,6 +58,18 @@ function depositItem(
   amount = "0.0375",
 ): DemoItem {
   return { key, type: "deposit", stateIndex, amount, batched };
+}
+
+function loanItem(key: number, stateIndex: number, amount: string): DemoItem {
+  return { key, type: "loan", stateIndex, amount, batched: false };
+}
+
+function activityItem(
+  key: number,
+  stateIndex: number,
+  amount = "0.5",
+): DemoItem {
+  return { key, type: "activity", stateIndex, amount, batched: false };
 }
 
 describe("demoDeposit builders", () => {
@@ -144,6 +160,96 @@ describe("demoDeposit builders", () => {
     );
     expect(collateral.vaults[0].amountBtc).toBe(2);
     expect(collateral.vaults[0].inUse).toBe(true);
+  });
+
+  it("builds loan rows the v3 Loans page can render, every one action-inert", () => {
+    const borrowable = LOAN_SCENARIOS.findIndex((s) => s.isBorrowable);
+    const repayOnly = LOAN_SCENARIOS.findIndex((s) => !s.isBorrowable);
+    const demo = buildLoansDemo(
+      [loanItem(1, borrowable, "1500"), loanItem(2, repayOnly, "500")],
+      false,
+    );
+
+    expect(demo.rows.map((row) => row.amount)).toEqual(["1500", "500"]);
+    expect(demo.rows.map((row) => row.isBorrowable)).toEqual([true, false]);
+    // The summary totals the rendered rows, so the mock debt must add up.
+    expect(demo.debtUsd).toBe(2000);
+    // Safety: a mock row must never reach the real borrow/repay overlay.
+    expect(demo.rows.every((row) => row.displayOnly)).toBe(true);
+    // Distinct, non-numeric ids that cannot collide with a real reserveId.
+    expect(new Set(demo.rows.map((row) => row.reserveId)).size).toBe(2);
+    expect(demo.rows.every((row) => Number.isNaN(Number(row.reserveId)))).toBe(
+      true,
+    );
+  });
+
+  it("drops the liquidity and APR reads for the scenarios that mock them missing", () => {
+    const noLiquidity = LOAN_SCENARIOS.findIndex((s) => !s.hasLiquidity);
+    const noRate = LOAN_SCENARIOS.findIndex((s) => !s.hasBorrowRate);
+
+    const [liquidityRow] = buildLoansDemo(
+      [loanItem(1, noLiquidity, "100")],
+      false,
+    ).rows;
+    expect(liquidityRow.availableLiquidity).toBeNull();
+    expect(liquidityRow.utilizationBps).toBeNull();
+
+    const [rateRow] = buildLoansDemo([loanItem(2, noRate, "100")], false).rows;
+    expect(rateRow.borrowRate).toBeUndefined();
+  });
+
+  it("ignores items of other types when building the loan rows", () => {
+    const demo = buildLoansDemo(
+      [depositItem(1, 0), loanItem(2, 0, "10")],
+      true,
+    );
+    expect(demo.rows).toHaveLength(1);
+    expect(demo.hideReal).toBe(true);
+  });
+
+  it("builds one activity row per mock, covering both row kinds", () => {
+    const groupIndex = ACTIVITY_SCENARIOS.findIndex((s) =>
+      s.key.startsWith("act-liquidation"),
+    );
+    const demo = buildActivitiesDemo(
+      [activityItem(1, 0, "0.25"), activityItem(2, groupIndex, "0.75")],
+      false,
+    );
+
+    expect(demo.rows).toHaveLength(2);
+    expect(demo.rows[0].kind).toBe("row");
+    // The liquidation scenarios render as the expandable group card, which is a
+    // different component — the builder must emit that shape, not a flat row.
+    expect(demo.rows[1].kind).toBe("liquidationGroup");
+    // Distinct, non-indexer ids so a mock can never collide with a real event.
+    expect(new Set(demo.rows.map((row) => row.id)).size).toBe(2);
+    expect(demo.rows.every((row) => row.id.startsWith("demo-activity-"))).toBe(
+      true,
+    );
+  });
+
+  it("dates activity mocks relative to now so the date-group headers apply", () => {
+    const now = Date.now();
+    const rows = ACTIVITY_SCENARIOS.map((_, i) =>
+      buildActivitiesDemo([activityItem(i + 1, i)], false),
+    ).flatMap((demo) => demo.rows);
+
+    // Every row is in the past and within the scenarios' daysAgo span.
+    const maxDaysAgo = Math.max(...ACTIVITY_SCENARIOS.map((s) => s.daysAgo));
+    for (const row of rows) {
+      const daysAgo = (now - row.date.getTime()) / (24 * 60 * 60 * 1000);
+      expect(daysAgo).toBeGreaterThanOrEqual(0);
+      expect(daysAgo).toBeLessThanOrEqual(maxDaysAgo + 1);
+    }
+  });
+
+  it("ignores items of other types when building the activity feed", () => {
+    const demo = buildActivitiesDemo(
+      [depositItem(1, 0), activityItem(2, 0)],
+      true,
+    );
+    expect(demo.rows).toHaveLength(1);
+    expect(demo.hideReal).toBe(true);
   });
 
   it("supports different amounts per item", () => {
@@ -338,6 +444,45 @@ describe("GodModePanel", () => {
     expect(screen.getByText(WITHDRAWAL_SCENARIOS[0].label)).toBeInTheDocument();
   });
 
+  it("switches a mock to a loan and re-labels its amount in the borrowed asset", () => {
+    renderExpanded();
+
+    fireEvent.change(screen.getByRole("combobox", { name: "Mock 1 type" }), {
+      target: { value: "loan" },
+    });
+
+    expect(screen.getByText(LOAN_SCENARIOS[0].label)).toBeInTheDocument();
+    expect(
+      screen.getByRole("spinbutton", { name: "Mock 1 amount (USDC)" }),
+    ).toBeInTheDocument();
+  });
+
+  it("switches a mock to an activity row and shows that type's states", () => {
+    renderExpanded();
+
+    fireEvent.change(screen.getByRole("combobox", { name: "Mock 1 type" }), {
+      target: { value: "activity" },
+    });
+
+    expect(screen.getByText(ACTIVITY_SCENARIOS[0].label)).toBeInTheDocument();
+  });
+
+  it("forces and releases the Loans summary health factor and capacity state", () => {
+    renderExpanded();
+
+    fireEvent.click(screen.getByRole("button", { name: "Danger (0.95)" }));
+    fireEvent.click(screen.getByRole("button", { name: "Error" }));
+
+    // Both controls sit under the Loans summary section and have their own
+    // "Live" release button, so releasing one must not release the other.
+    const [healthFactorLive, capacityLive] = screen.getAllByRole("button", {
+      name: "Live",
+    });
+    fireEvent.click(healthFactorLive);
+    expect(healthFactorLive).toBeInTheDocument();
+    fireEvent.click(capacityLive);
+  });
+
   it("exposes hide-real and a per-item amount control", () => {
     renderExpanded();
 
@@ -435,5 +580,7 @@ describe("demoDeposit scenario lists", () => {
     expect(DEPOSIT_SCENARIOS.length).toBeGreaterThan(0);
     expect(WITHDRAWAL_SCENARIOS.length).toBeGreaterThan(0);
     expect(COLLATERAL_SCENARIOS.length).toBeGreaterThan(0);
+    expect(LOAN_SCENARIOS.length).toBeGreaterThan(0);
+    expect(ACTIVITY_SCENARIOS.length).toBeGreaterThan(0);
   });
 });

--- a/services/vault/src/dev/__tests__/debugPositionStore.test.ts
+++ b/services/vault/src/dev/__tests__/debugPositionStore.test.ts
@@ -6,6 +6,7 @@ import {
   deriveBannerState,
   type CalculatorResult,
 } from "@/applications/aave/positionNotifications";
+import { getHealthFactorStatusFromValue } from "@/applications/aave/utils";
 
 // The two non-cascade overrides are read by production components, so the store
 // additionally gates them on the god-mode flag (see debugPositionStore).
@@ -15,15 +16,20 @@ vi.mock("@/config/featureFlags", () => ({ default: featureFlagsMock }));
 import {
   applyDebugPreset,
   DEBUG_FORCED_MAX_VAULTS,
+  DEBUG_HEALTH_FACTORS,
   DEBUG_PRESETS,
   makeDefaultDebugParams,
   resetDebugManualParams,
+  setDebugBorrowCapacityStateOverride,
+  setDebugHealthFactorOverride,
   setDebugManualMode,
   setDebugManualParams,
   setDebugMaxVaultsOverride,
   setDebugPositionOverride,
   setDebugProtocolStatusOverride,
   setDebugSimulateStalePrice,
+  useDebugBorrowCapacityStateOverride,
+  useDebugHealthFactorOverride,
   useDebugManualMode,
   useDebugManualParams,
   useDebugMaxVaultsOverride,
@@ -142,6 +148,61 @@ describe("non-cascade notification overrides", () => {
     const status = renderHook(() => useDebugProtocolStatusOverride());
     expect(cap.result.current).toBeNull();
     expect(status.result.current).toBeNull();
+  });
+});
+
+describe("loans summary overrides", () => {
+  afterEach(() => {
+    featureFlagsMock.isGodModePanelEnabled = true;
+    act(() => setDebugHealthFactorOverride(null));
+    act(() => setDebugBorrowCapacityStateOverride(null));
+  });
+
+  it("publishes the forced health factor and releases it", () => {
+    const { result } = renderHook(() => useDebugHealthFactorOverride());
+    expect(result.current).toBeNull();
+
+    act(() => setDebugHealthFactorOverride(1.02));
+    expect(result.current).toBe(1.02);
+
+    act(() => setDebugHealthFactorOverride(null));
+    expect(result.current).toBeNull();
+  });
+
+  it("publishes each borrow-capacity state and releases back to live", () => {
+    const { result } = renderHook(() => useDebugBorrowCapacityStateOverride());
+
+    act(() => setDebugBorrowCapacityStateOverride("loading"));
+    expect(result.current).toBe("loading");
+
+    act(() => setDebugBorrowCapacityStateOverride("error"));
+    expect(result.current).toBe("error");
+
+    act(() => setDebugBorrowCapacityStateOverride(null));
+    expect(result.current).toBeNull();
+  });
+
+  // These feed a PRODUCTION page (the v3 Loans summary), so the flag gate is
+  // what keeps a stale override out of a real build.
+  it("reports no override when god mode is off, whatever was written", () => {
+    act(() => setDebugHealthFactorOverride(1.02));
+    act(() => setDebugBorrowCapacityStateOverride("error"));
+
+    featureFlagsMock.isGodModePanelEnabled = false;
+
+    const hf = renderHook(() => useDebugHealthFactorOverride());
+    const capacity = renderHook(() => useDebugBorrowCapacityStateOverride());
+    expect(hf.result.current).toBeNull();
+    expect(capacity.result.current).toBeNull();
+  });
+
+  it("bands every offered health factor into a distinct status", () => {
+    // The panel offers one value per production band; if two collapsed to the
+    // same status the control would silently stop covering a state.
+    const statuses = DEBUG_HEALTH_FACTORS.map((hf) =>
+      getHealthFactorStatusFromValue(hf.value),
+    );
+    expect(new Set(statuses).size).toBe(DEBUG_HEALTH_FACTORS.length);
   });
 });
 

--- a/services/vault/src/dev/debugPositionStore.ts
+++ b/services/vault/src/dev/debugPositionStore.ts
@@ -173,6 +173,43 @@ const NO_OVERRIDE: DebugPositionOverride = { result: null, status: null };
  */
 export const DEBUG_FORCED_MAX_VAULTS = 10;
 
+/** Which non-live state to force on the Loans summary's borrow-capacity cards. */
+export type DebugBorrowCapacityState = "loading" | "error";
+
+/** Health-factor values the panel offers, one per production band — safe
+ *  (>= HEALTH_FACTOR_WARNING_THRESHOLD), warning (>= 1.0), danger (< 1.0, i.e.
+ *  liquidatable). See `getHealthFactorStatus`; a test asserts these three still
+ *  land in three distinct bands. */
+export const DEBUG_HEALTH_FACTORS = [
+  { value: 2.4, label: "Safe" },
+  { value: 1.25, label: "Warning" },
+  { value: 0.95, label: "Danger" },
+] as const;
+
+/** What the Loans summary should render for a forced borrow-capacity state.
+ *  Consumers get one of the two frozen snapshots below (never a fresh object,
+ *  which would break `useSyncExternalStore`'s snapshot identity). */
+export interface DebugBorrowCapacity {
+  loading: boolean;
+  error: Error | null;
+}
+
+// Behind `import.meta.env.DEV` so the simulated-failure Error — message string
+// included — is dead code a production build drops, even though the store
+// module itself is reachable from production components.
+const DEBUG_BORROW_CAPACITY_SNAPSHOTS: Record<
+  DebugBorrowCapacityState,
+  DebugBorrowCapacity
+> | null = import.meta.env.DEV
+  ? {
+      loading: { loading: true, error: null },
+      error: {
+        loading: false,
+        error: new Error("God mode: simulated borrow-capacity read failure"),
+      },
+    }
+  : null;
+
 let manualMode = false;
 let simulateStalePrice = false;
 let manualParams: CalculatorParams = makeDefaultDebugParams();
@@ -181,6 +218,12 @@ let override: DebugPositionOverride = NO_OVERRIDE;
 // override, i.e. the component uses live chain state.
 let maxVaultsOverride: number | null = null;
 let protocolStatusOverride: ProtocolStatus | null = null;
+// v3 Loans summary overrides. The health factor is stored as the VALUE, not a
+// status: the page derives the status with the real
+// `getHealthFactorStatusFromValue`, so the forced card can't drift from the
+// production banding. null = live.
+let healthFactorOverride: number | null = null;
+let borrowCapacityStateOverride: DebugBorrowCapacityState | null = null;
 
 const listeners = new Set<() => void>();
 
@@ -241,6 +284,20 @@ export function setDebugProtocolStatusOverride(status: ProtocolStatus | null) {
   emit();
 }
 
+/** Force (a value) or release (null) the Loans summary health factor. */
+export function setDebugHealthFactorOverride(healthFactor: number | null) {
+  healthFactorOverride = healthFactor;
+  emit();
+}
+
+/** Force (loading / error) or release (null) the borrow-capacity cards. */
+export function setDebugBorrowCapacityStateOverride(
+  state: DebugBorrowCapacityState | null,
+) {
+  borrowCapacityStateOverride = state;
+  emit();
+}
+
 function getManualMode() {
   return manualMode;
 }
@@ -287,6 +344,22 @@ function getProtocolStatusOverride(): ProtocolStatus | null {
   return featureFlags.isGodModePanelEnabled ? protocolStatusOverride : null;
 }
 
+function getHealthFactorOverride(): number | null {
+  return featureFlags.isGodModePanelEnabled ? healthFactorOverride : null;
+}
+
+function getBorrowCapacityStateOverride(): DebugBorrowCapacityState | null {
+  return featureFlags.isGodModePanelEnabled
+    ? borrowCapacityStateOverride
+    : null;
+}
+
+function getBorrowCapacity(): DebugBorrowCapacity | null {
+  const state = getBorrowCapacityStateOverride();
+  if (!state || !DEBUG_BORROW_CAPACITY_SNAPSHOTS) return null;
+  return DEBUG_BORROW_CAPACITY_SNAPSHOTS[state];
+}
+
 export function useDebugMaxVaultsOverride(): number | null {
   return useSyncExternalStore(
     subscribe,
@@ -301,4 +374,29 @@ export function useDebugProtocolStatusOverride(): ProtocolStatus | null {
     getProtocolStatusOverride,
     getProtocolStatusOverride,
   );
+}
+
+export function useDebugHealthFactorOverride(): number | null {
+  return useSyncExternalStore(
+    subscribe,
+    getHealthFactorOverride,
+    getHealthFactorOverride,
+  );
+}
+
+export function useDebugBorrowCapacityStateOverride(): DebugBorrowCapacityState | null {
+  return useSyncExternalStore(
+    subscribe,
+    getBorrowCapacityStateOverride,
+    getBorrowCapacityStateOverride,
+  );
+}
+
+/**
+ * The forced borrow-capacity rendering state for the v3 Loans summary, or null
+ * to use the live read. Production reads THIS (not the raw state or the Error
+ * constant) so the simulated-failure message never enters a production build.
+ */
+export function useDebugBorrowCapacity(): DebugBorrowCapacity | null {
+  return useSyncExternalStore(subscribe, getBorrowCapacity, getBorrowCapacity);
 }

--- a/services/vault/src/dev/demoDeposit.ts
+++ b/services/vault/src/dev/demoDeposit.ts
@@ -3,9 +3,11 @@
  *
  * The god-mode panel builds a LIST of mock items that render inside the REAL
  * dashboard sections, so you can preview many states at once. Each item has a
- * TYPE (deposit / withdrawal / collateral) and a STATE; the state decides which
- * section it lands in (e.g. a deposit in an expired state renders under Expired
- * Deposits; a withdrawal in the payout-sent state under Withdrawals).
+ * TYPE (deposit / withdrawal / collateral / loan / activity) and a STATE; the
+ * state decides which section it lands in (e.g. a deposit in an expired state
+ * renders under Expired Deposits; a withdrawal in the payout-sent state under
+ * Withdrawals; a loan under Active Loans on the v3 Loans page; an activity row
+ * in the v3 Activity feed).
  *
  * How it stays safe and fully inert when off:
  *  - States are built by the REAL state machines (getPeginState /
@@ -25,11 +27,13 @@ import { useMemo, useSyncExternalStore } from "react";
 import type { Hex } from "viem";
 
 import type { RedeemedVaultInfo } from "@/applications/aave/hooks/useAaveVaults";
+import type { ActiveLoanRow } from "@/applications/aave/hooks/useActiveLoans";
 import {
   getStepLabel,
   getVisualStep,
 } from "@/components/simple/DepositProgressView/steps";
 import featureFlags from "@/config/featureFlags";
+import { COPY } from "@/copy";
 import { DepositFlowStep } from "@/hooks/deposit/depositFlowSteps/types";
 import type { PegoutPollingResult } from "@/hooks/usePegoutPolling";
 import {
@@ -43,7 +47,10 @@ import {
   getPegoutDisplayState,
   TIMED_OUT_STATE,
 } from "@/models/pegoutStateMachine";
+import { VAULT_COLLATERAL_ASSET } from "@/services/activity/projection";
+import { getCurrencyIconWithFallback } from "@/services/token/tokenService";
 import type { VaultActivity } from "@/types/activity";
+import { type ActivityRow, PENDING_DEPOSIT_TYPE } from "@/types/activityLog";
 import type { CollateralVaultEntry } from "@/types/collateral";
 import type { DepositPollingResult } from "@/types/peginPolling";
 import type { VaultProvider } from "@/types/vaultProvider";
@@ -53,7 +60,12 @@ import { getBatchSiblings } from "@/utils/batchedPegin";
 export type DemoCta = "primary" | "outlined" | "none";
 
 /** The kind of thing a mock item represents. */
-export type DemoType = "deposit" | "withdrawal" | "collateral";
+export type DemoType =
+  | "deposit"
+  | "withdrawal"
+  | "collateral"
+  | "loan"
+  | "activity";
 
 /** One mock item the panel manages. `batched` only applies to deposits. */
 export interface DemoItem {
@@ -458,10 +470,289 @@ export const COLLATERAL_SCENARIOS: CollateralScenario[] = [
   },
 ];
 
+// --- Loan (borrowed asset) scenarios ---------------------------------------
+
+/** One controllable loan row on the v3 Loans page. Loans have no card CTA of
+ *  their own — the row's Borrow/Repay buttons are always disabled for a mock
+ *  (see {@link buildLoansDemo}), so every scenario is `expectedCta: "none"`. */
+export interface LoanScenario extends BaseScenario {
+  symbol: string;
+  /** false → the per-reserve liquidity read is loading or failed (row shows –). */
+  hasLiquidity: boolean;
+  /** false → the reserve no longer accepts borrows (repay-only row). */
+  isBorrowable: boolean;
+  /** false → the borrow-APR read hasn't resolved yet (row shows –). */
+  hasBorrowRate: boolean;
+}
+
+const DEMO_LOAN_SYMBOL = "USDC";
+const DEMO_LOAN_BORROW_RATE = "5.861%";
+const DEMO_LOAN_AVAILABLE_LIQUIDITY = 1_250_000;
+/** 64.20% utilization. */
+const DEMO_LOAN_UTILIZATION_BPS = 6420;
+/** Prefix for a mock row's reserve id. Real ids are decimal `reserveId`
+ *  strings, so this can never collide with one. */
+const DEMO_LOAN_RESERVE_PREFIX = "demo-reserve-";
+
+export const LOAN_SCENARIOS: LoanScenario[] = [
+  {
+    key: "loan-borrowable",
+    label: "Borrowable reserve",
+    expectedCta: "none",
+    symbol: DEMO_LOAN_SYMBOL,
+    hasLiquidity: true,
+    isBorrowable: true,
+    hasBorrowRate: true,
+  },
+  {
+    key: "loan-repay-only",
+    label: "Repay only (reserve frozen)",
+    expectedCta: "none",
+    symbol: DEMO_LOAN_SYMBOL,
+    hasLiquidity: true,
+    isBorrowable: false,
+    hasBorrowRate: true,
+  },
+  {
+    key: "loan-no-liquidity-read",
+    label: "Liquidity / utilization unavailable",
+    expectedCta: "none",
+    symbol: DEMO_LOAN_SYMBOL,
+    hasLiquidity: false,
+    isBorrowable: true,
+    hasBorrowRate: true,
+  },
+  {
+    key: "loan-apr-pending",
+    label: "Borrow APR pending",
+    expectedCta: "none",
+    symbol: DEMO_LOAN_SYMBOL,
+    hasLiquidity: true,
+    isBorrowable: true,
+    hasBorrowRate: false,
+  },
+];
+
+// --- Activity-log scenarios (v3 Activity page) -----------------------------
+
+/**
+ * One controllable row on the Activity page. `build` returns the finished
+ * {@link ActivityRow} because the page renders two different row kinds (a flat
+ * log row and an expandable liquidation group) — a single flat config could not
+ * describe both without inventing a schema neither production type uses.
+ */
+export interface ActivityScenario extends BaseScenario {
+  /** Days back from now, so a multi-mock list also exercises the v3
+   *  Today / Yesterday / dated group headers. */
+  daysAgo: number;
+  build: (id: string, date: Date, amount: string) => ActivityRow;
+}
+
+/** Prefix for a mock activity row's id — real ids are indexer event ids. */
+const DEMO_ACTIVITY_ID_PREFIX = "demo-activity-";
+const DEMO_ACTIVITY_DEBT_SYMBOL = "USDC";
+const DEMO_ACTIVITY_DEBT_AMOUNT = "12,500.00";
+/** BTC txids render without the 0x prefix; EVM event hashes with it. */
+const DEMO_ACTIVITY_BTC_TXID = "b7".repeat(32);
+const DEMO_ACTIVITY_ETH_TX = `0x${"e7".repeat(32)}`;
+
+function demoDebtIcon(): string {
+  return getCurrencyIconWithFallback(undefined, DEMO_ACTIVITY_DEBT_SYMBOL);
+}
+
+/** Flat log row shared by every non-liquidation scenario. */
+function demoActivityLog(
+  id: string,
+  date: Date,
+  fields: Pick<ActivityRow & { kind: "row" }, "type" | "amount" | "chain"> &
+    Partial<Pick<ActivityRow & { kind: "row" }, "isPending" | "isExpired">> & {
+      tokenIcon?: string;
+      transactionHash?: string;
+    },
+): ActivityRow {
+  const { tokenIcon, transactionHash, ...rest } = fields;
+  return {
+    kind: "row",
+    id,
+    date,
+    tokenIcon: tokenIcon ?? VAULT_COLLATERAL_ASSET.icon,
+    transactionHash:
+      transactionHash ??
+      (rest.chain === "BTC" ? DEMO_ACTIVITY_BTC_TXID : DEMO_ACTIVITY_ETH_TX),
+    ...rest,
+  };
+}
+
+function demoBtcAmount(amount: string) {
+  return { value: amount, symbol: VAULT_COLLATERAL_ASSET.symbol };
+}
+
+function demoDebtAmount() {
+  return {
+    value: DEMO_ACTIVITY_DEBT_AMOUNT,
+    symbol: DEMO_ACTIVITY_DEBT_SYMBOL,
+  };
+}
+
+export const ACTIVITY_SCENARIOS: ActivityScenario[] = [
+  {
+    key: "act-deposit",
+    label: "Deposit (confirmed)",
+    expectedCta: "none",
+    daysAgo: 0,
+    build: (id, date, amount) =>
+      demoActivityLog(id, date, {
+        type: "Deposit",
+        amount: demoBtcAmount(amount),
+        chain: "BTC",
+      }),
+  },
+  {
+    key: "act-deposit-pending",
+    label: "Deposit (pending, spinner)",
+    expectedCta: "none",
+    daysAgo: 0,
+    build: (id, date, amount) =>
+      demoActivityLog(id, date, {
+        type: PENDING_DEPOSIT_TYPE,
+        amount: demoBtcAmount(amount),
+        chain: "BTC",
+        isPending: true,
+        transactionHash: "",
+      }),
+  },
+  {
+    key: "act-deposit-expired",
+    label: "Deposit (expired, refunded)",
+    expectedCta: "none",
+    daysAgo: 1,
+    build: (id, date, amount) =>
+      demoActivityLog(id, date, {
+        type: "Deposit",
+        amount: demoBtcAmount(amount),
+        chain: "BTC",
+        isExpired: true,
+      }),
+  },
+  {
+    key: "act-withdraw",
+    label: "Withdraw",
+    expectedCta: "none",
+    daysAgo: 1,
+    build: (id, date, amount) =>
+      demoActivityLog(id, date, {
+        type: "Withdraw",
+        amount: demoBtcAmount(amount),
+        chain: "BTC",
+      }),
+  },
+  {
+    key: "act-borrow",
+    label: "Borrow",
+    expectedCta: "none",
+    daysAgo: 2,
+    build: (id, date) =>
+      demoActivityLog(id, date, {
+        type: "Borrow",
+        amount: demoDebtAmount(),
+        chain: "ETH",
+        tokenIcon: demoDebtIcon(),
+      }),
+  },
+  {
+    key: "act-repay",
+    label: "Repay",
+    expectedCta: "none",
+    daysAgo: 2,
+    build: (id, date) =>
+      demoActivityLog(id, date, {
+        type: "Repay",
+        amount: demoDebtAmount(),
+        chain: "ETH",
+        tokenIcon: demoDebtIcon(),
+      }),
+  },
+  {
+    key: "act-redeem",
+    label: "Redeem",
+    expectedCta: "none",
+    daysAgo: 5,
+    build: (id, date, amount) =>
+      demoActivityLog(id, date, {
+        type: "Redeem",
+        amount: demoBtcAmount(amount),
+        chain: "ETH",
+      }),
+  },
+  {
+    key: "act-liquidation-partial",
+    label: "Partially liquidated (group)",
+    expectedCta: "none",
+    daysAgo: 5,
+    build: (id, date, amount) => ({
+      kind: "liquidationGroup",
+      id,
+      date,
+      type: "Partially Liquidated",
+      tokenIcons: [VAULT_COLLATERAL_ASSET.icon, demoDebtIcon()],
+      summary: { collateral: demoBtcAmount(amount), debt: demoDebtAmount() },
+      children: [
+        {
+          id: `${id}-collateral`,
+          label: COPY.activity.liquidation.collateralLabel,
+          amount: demoBtcAmount(amount),
+          tokenIcon: VAULT_COLLATERAL_ASSET.icon,
+          chain: "ETH",
+          transactionHash: DEMO_ACTIVITY_ETH_TX,
+          date,
+        },
+        {
+          id: `${id}-loan`,
+          label: COPY.activity.liquidation.repaidLabel,
+          amount: demoDebtAmount(),
+          tokenIcon: demoDebtIcon(),
+          chain: "ETH",
+          transactionHash: DEMO_ACTIVITY_ETH_TX,
+          date,
+        },
+      ],
+      transactionHash: DEMO_ACTIVITY_ETH_TX,
+    }),
+  },
+  {
+    key: "act-liquidation-full",
+    label: "Fully liquidated (group, no repay)",
+    expectedCta: "none",
+    daysAgo: 6,
+    build: (id, date, amount) => ({
+      kind: "liquidationGroup",
+      id,
+      date,
+      type: "Fully Liquidated",
+      tokenIcons: [VAULT_COLLATERAL_ASSET.icon, ""],
+      summary: { collateral: demoBtcAmount(amount), debt: null },
+      children: [
+        {
+          id: `${id}-collateral`,
+          label: COPY.activity.liquidation.collateralLabel,
+          amount: demoBtcAmount(amount),
+          tokenIcon: VAULT_COLLATERAL_ASSET.icon,
+          chain: "ETH",
+          transactionHash: DEMO_ACTIVITY_ETH_TX,
+          date,
+        },
+      ],
+      transactionHash: DEMO_ACTIVITY_ETH_TX,
+    }),
+  },
+];
+
 /** Scenario list for a given mock type (drives the panel's state select). */
 export function scenariosForType(type: DemoType): BaseScenario[] {
   if (type === "withdrawal") return WITHDRAWAL_SCENARIOS;
   if (type === "collateral") return COLLATERAL_SCENARIOS;
+  if (type === "loan") return LOAN_SCENARIOS;
+  if (type === "activity") return ACTIVITY_SCENARIOS;
   return DEPOSIT_SCENARIOS;
 }
 
@@ -469,12 +760,18 @@ export function scenariosForType(type: DemoType): BaseScenario[] {
  *  type + state). */
 export function itemSectionHint(item: DemoItem): string {
   if (item.type === "withdrawal") {
+    // v2 only: the v3 /vaults page has no withdrawal section yet (the
+    // relocation step of #2041), so a withdrawal mock renders nothing there.
     const scenario = WITHDRAWAL_SCENARIOS[item.stateIndex];
     return scenario?.claimerStatus === ClaimerPegoutStatusValue.PAYOUT_BROADCAST
-      ? "Withdrawals"
-      : "Pending Withdrawals";
+      ? "Withdrawals (v2 only)"
+      : "Pending Withdrawals (v2 only)";
   }
-  if (item.type === "collateral") return "BTC Vaults (collateral)";
+  if (item.type === "collateral") {
+    return "BTC Vaults (v2) / Active Vaults (v3 Vaults)";
+  }
+  if (item.type === "loan") return "Active Loans (v3 Loans)";
+  if (item.type === "activity") return "Activity feed (v3 Activity)";
   const scenario = DEPOSIT_SCENARIOS[item.stateIndex];
   if (scenario?.contractStatus === ContractStatus.EXPIRED) {
     return "Expired Deposits (v2) / Inactive Vaults (v3)";
@@ -614,6 +911,18 @@ export interface ActiveDemoCollateral {
   hideReal: boolean;
 }
 
+export interface ActiveDemoActivity {
+  rows: ActivityRow[];
+  hideReal: boolean;
+}
+
+export interface ActiveDemoLoan {
+  rows: ActiveLoanRow[];
+  /** Total mock debt in USD — the Loans summary totals the rendered rows. */
+  debtUsd: number;
+  hideReal: boolean;
+}
+
 export function buildDepositsDemo(
   items: DemoItem[],
   hideReal: boolean,
@@ -683,6 +992,65 @@ export function buildCollateralsDemo(
     );
   }
   return { vaults, hideReal };
+}
+
+export function buildLoansDemo(
+  items: DemoItem[],
+  hideReal: boolean,
+): ActiveDemoLoan {
+  const rows: ActiveLoanRow[] = [];
+  let debtUsd = 0;
+  for (const item of items) {
+    if (item.type !== "loan") continue;
+    const scenario = LOAN_SCENARIOS[item.stateIndex] ?? LOAN_SCENARIOS[0];
+    const amount = safeAmount(item.amount);
+    // The mock borrows a stablecoin, so the token amount doubles as its USD
+    // value — enough for the summary to total the rendered rows.
+    debtUsd += Number.parseFloat(amount) || 0;
+    rows.push({
+      reserveId: `${DEMO_LOAN_RESERVE_PREFIX}${item.key}`,
+      symbol: scenario.symbol,
+      name: scenario.symbol,
+      amount,
+      icon: getCurrencyIconWithFallback(undefined, scenario.symbol),
+      borrowRate: scenario.hasBorrowRate ? DEMO_LOAN_BORROW_RATE : undefined,
+      availableLiquidity: scenario.hasLiquidity
+        ? DEMO_LOAN_AVAILABLE_LIQUIDITY
+        : null,
+      utilizationBps: scenario.hasLiquidity ? DEMO_LOAN_UTILIZATION_BPS : null,
+      isBorrowable: scenario.isBorrowable,
+      // Safety: the row's reserveId/symbol resolve to no real reserve, so both
+      // of its actions stay disabled (ActiveLoansList) — a mock can never open
+      // the borrow/repay overlay against a real position.
+      displayOnly: true,
+    });
+  }
+  return { rows, debtUsd, hideReal };
+}
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+export function buildActivitiesDemo(
+  items: DemoItem[],
+  hideReal: boolean,
+): ActiveDemoActivity {
+  const rows: ActivityRow[] = [];
+  for (const item of items) {
+    if (item.type !== "activity") continue;
+    const scenario =
+      ACTIVITY_SCENARIOS[item.stateIndex] ?? ACTIVITY_SCENARIOS[0];
+    // Dates are relative to now (not the fixed DEMO_TIMESTAMP the card mocks
+    // use) so the Today / Yesterday group headers render the way a depositor
+    // would see them.
+    rows.push(
+      scenario.build(
+        `${DEMO_ACTIVITY_ID_PREFIX}${item.key}`,
+        new Date(Date.now() - scenario.daysAgo * MS_PER_DAY),
+        safeAmount(item.amount),
+      ),
+    );
+  }
+  return { rows, hideReal };
 }
 
 // --- Cross-component store (the panel writes; the sections read) ------------
@@ -916,6 +1284,36 @@ export function useDemoWithdrawal(): ActiveDemoWithdrawal | null {
     () =>
       import.meta.env.DEV && flagOn && enabled
         ? buildWithdrawalsDemo(items, hideReal)
+        : null,
+    [flagOn, enabled, items, hideReal],
+  );
+}
+
+/** Aggregate demo activity rows to inject, or null when off. */
+export function useDemoActivity(): ActiveDemoActivity | null {
+  const enabled = useDemoEnabled();
+  const hideReal = useDemoHideReal();
+  const items = useDemoItems();
+  const flagOn = featureFlags.isGodModePanelEnabled;
+  return useMemo(
+    () =>
+      import.meta.env.DEV && flagOn && enabled
+        ? buildActivitiesDemo(items, hideReal)
+        : null,
+    [flagOn, enabled, items, hideReal],
+  );
+}
+
+/** Aggregate demo loans to inject, or null when off. */
+export function useDemoLoan(): ActiveDemoLoan | null {
+  const enabled = useDemoEnabled();
+  const hideReal = useDemoHideReal();
+  const items = useDemoItems();
+  const flagOn = featureFlags.isGodModePanelEnabled;
+  return useMemo(
+    () =>
+      import.meta.env.DEV && flagOn && enabled
+        ? buildLoansDemo(items, hideReal)
         : null,
     [flagOn, enabled, items, hideReal],
   );

--- a/services/vault/src/dev/demoDeposit.ts
+++ b/services/vault/src/dev/demoDeposit.ts
@@ -59,6 +59,16 @@ import { getBatchSiblings } from "@/utils/batchedPegin";
 /** Whether (and how) a scenario is expected to render the action CTA. */
 export type DemoCta = "primary" | "outlined" | "none";
 
+/** Denomination of a mock's amount — what the panel labels its amount field
+ *  with, and the unit of the value that mock actually renders. */
+export type DemoAmountUnit = string;
+
+/** Deposit / withdrawal / collateral cards render the literal "BTC" (see
+ *  `buildActivity`), while activity rows render the network-aware collateral
+ *  symbol ("sBTC" on signet) — so the label a mock's amount field carries has
+ *  to follow whichever list builds it, not one global spelling. */
+const BTC_AMOUNT_UNIT = "BTC";
+
 /** The kind of thing a mock item represents. */
 export type DemoType =
   | "deposit"
@@ -545,13 +555,21 @@ export interface ActivityScenario extends BaseScenario {
   /** Days back from now, so a multi-mock list also exercises the v3
    *  Today / Yesterday / dated group headers. */
   daysAgo: number;
+  /** Denomination of the row's headline amount — the one the panel's amount
+   *  field drives, and the unit it labels that field with. */
+  unit: DemoAmountUnit;
   build: (id: string, date: Date, amount: string) => ActivityRow;
 }
 
 /** Prefix for a mock activity row's id — real ids are indexer event ids. */
 const DEMO_ACTIVITY_ID_PREFIX = "demo-activity-";
+/** What an activity row actually renders for BTC amounts. */
+const ACTIVITY_BTC_UNIT = VAULT_COLLATERAL_ASSET.symbol;
 const DEMO_ACTIVITY_DEBT_SYMBOL = "USDC";
-const DEMO_ACTIVITY_DEBT_AMOUNT = "12,500.00";
+/** Debt figure shown BESIDE the seized collateral on a liquidation card. A
+ *  liquidation row has two amounts and the panel drives only one (the
+ *  collateral, its headline), so this second one stays a fixed sample. */
+const DEMO_LIQUIDATION_DEBT_AMOUNT = "12,500.00";
 /** BTC txids render without the 0x prefix; EVM event hashes with it. */
 const DEMO_ACTIVITY_BTC_TXID = "b7".repeat(32);
 const DEMO_ACTIVITY_ETH_TX = `0x${"e7".repeat(32)}`;
@@ -587,9 +605,15 @@ function demoBtcAmount(amount: string) {
   return { value: amount, symbol: VAULT_COLLATERAL_ASSET.symbol };
 }
 
-function demoDebtAmount() {
+/** Borrow / repay rows are denominated in the debt asset, so the panel's
+ *  amount drives them directly. */
+function demoDebtAmount(amount: string) {
+  return { value: amount, symbol: DEMO_ACTIVITY_DEBT_SYMBOL };
+}
+
+function demoLiquidationDebtAmount() {
   return {
-    value: DEMO_ACTIVITY_DEBT_AMOUNT,
+    value: DEMO_LIQUIDATION_DEBT_AMOUNT,
     symbol: DEMO_ACTIVITY_DEBT_SYMBOL,
   };
 }
@@ -600,6 +624,7 @@ export const ACTIVITY_SCENARIOS: ActivityScenario[] = [
     label: "Deposit (confirmed)",
     expectedCta: "none",
     daysAgo: 0,
+    unit: ACTIVITY_BTC_UNIT,
     build: (id, date, amount) =>
       demoActivityLog(id, date, {
         type: "Deposit",
@@ -612,6 +637,7 @@ export const ACTIVITY_SCENARIOS: ActivityScenario[] = [
     label: "Deposit (pending, spinner)",
     expectedCta: "none",
     daysAgo: 0,
+    unit: ACTIVITY_BTC_UNIT,
     build: (id, date, amount) =>
       demoActivityLog(id, date, {
         type: PENDING_DEPOSIT_TYPE,
@@ -626,6 +652,7 @@ export const ACTIVITY_SCENARIOS: ActivityScenario[] = [
     label: "Deposit (expired, refunded)",
     expectedCta: "none",
     daysAgo: 1,
+    unit: ACTIVITY_BTC_UNIT,
     build: (id, date, amount) =>
       demoActivityLog(id, date, {
         type: "Deposit",
@@ -639,6 +666,7 @@ export const ACTIVITY_SCENARIOS: ActivityScenario[] = [
     label: "Withdraw",
     expectedCta: "none",
     daysAgo: 1,
+    unit: ACTIVITY_BTC_UNIT,
     build: (id, date, amount) =>
       demoActivityLog(id, date, {
         type: "Withdraw",
@@ -651,10 +679,11 @@ export const ACTIVITY_SCENARIOS: ActivityScenario[] = [
     label: "Borrow",
     expectedCta: "none",
     daysAgo: 2,
-    build: (id, date) =>
+    unit: DEMO_ACTIVITY_DEBT_SYMBOL,
+    build: (id, date, amount) =>
       demoActivityLog(id, date, {
         type: "Borrow",
-        amount: demoDebtAmount(),
+        amount: demoDebtAmount(amount),
         chain: "ETH",
         tokenIcon: demoDebtIcon(),
       }),
@@ -664,10 +693,11 @@ export const ACTIVITY_SCENARIOS: ActivityScenario[] = [
     label: "Repay",
     expectedCta: "none",
     daysAgo: 2,
-    build: (id, date) =>
+    unit: DEMO_ACTIVITY_DEBT_SYMBOL,
+    build: (id, date, amount) =>
       demoActivityLog(id, date, {
         type: "Repay",
-        amount: demoDebtAmount(),
+        amount: demoDebtAmount(amount),
         chain: "ETH",
         tokenIcon: demoDebtIcon(),
       }),
@@ -677,6 +707,7 @@ export const ACTIVITY_SCENARIOS: ActivityScenario[] = [
     label: "Redeem",
     expectedCta: "none",
     daysAgo: 5,
+    unit: ACTIVITY_BTC_UNIT,
     build: (id, date, amount) =>
       demoActivityLog(id, date, {
         type: "Redeem",
@@ -689,13 +720,17 @@ export const ACTIVITY_SCENARIOS: ActivityScenario[] = [
     label: "Partially liquidated (group)",
     expectedCta: "none",
     daysAgo: 5,
+    unit: ACTIVITY_BTC_UNIT,
     build: (id, date, amount) => ({
       kind: "liquidationGroup",
       id,
       date,
       type: "Partially Liquidated",
       tokenIcons: [VAULT_COLLATERAL_ASSET.icon, demoDebtIcon()],
-      summary: { collateral: demoBtcAmount(amount), debt: demoDebtAmount() },
+      summary: {
+        collateral: demoBtcAmount(amount),
+        debt: demoLiquidationDebtAmount(),
+      },
       children: [
         {
           id: `${id}-collateral`,
@@ -709,7 +744,7 @@ export const ACTIVITY_SCENARIOS: ActivityScenario[] = [
         {
           id: `${id}-loan`,
           label: COPY.activity.liquidation.repaidLabel,
-          amount: demoDebtAmount(),
+          amount: demoLiquidationDebtAmount(),
           tokenIcon: demoDebtIcon(),
           chain: "ETH",
           transactionHash: DEMO_ACTIVITY_ETH_TX,
@@ -724,6 +759,7 @@ export const ACTIVITY_SCENARIOS: ActivityScenario[] = [
     label: "Fully liquidated (group, no repay)",
     expectedCta: "none",
     daysAgo: 6,
+    unit: ACTIVITY_BTC_UNIT,
     build: (id, date, amount) => ({
       kind: "liquidationGroup",
       id,
@@ -754,6 +790,22 @@ export function scenariosForType(type: DemoType): BaseScenario[] {
   if (type === "loan") return LOAN_SCENARIOS;
   if (type === "activity") return ACTIVITY_SCENARIOS;
   return DEPOSIT_SCENARIOS;
+}
+
+/**
+ * Unit the item's amount is denominated in — the panel labels its amount field
+ * with this. Loans borrow the debt asset; activity rows vary per scenario
+ * (borrow / repay are debt-denominated, the rest are BTC); everything else is
+ * BTC. Kept here rather than in the panel so it can't drift from the scenario
+ * that renders the value.
+ */
+export function amountUnitFor(item: DemoItem): DemoAmountUnit {
+  if (item.type === "loan") return DEMO_LOAN_SYMBOL;
+  if (item.type === "activity") {
+    const scenario = ACTIVITY_SCENARIOS[item.stateIndex];
+    return scenario?.unit ?? ACTIVITY_BTC_UNIT;
+  }
+  return BTC_AMOUNT_UNIT;
 }
 
 /** Which dashboard section a mock item renders in (panel hint, derived from

--- a/services/vault/src/dev/panelChrome.ts
+++ b/services/vault/src/dev/panelChrome.ts
@@ -1,0 +1,41 @@
+/**
+ * Shared chrome for the god-mode panel and every debug section rendered inside
+ * it (dev / QA only).
+ *
+ * The panel box is intentionally theme-independent — fixed zinc surfaces, an
+ * orange accent, no light-mode variants — so a section styled with its own
+ * palette (or with the app's light/dark tokens) reads as a foreign card
+ * floating inside the box. Sections use these classes instead of rolling their
+ * own, which also keeps the popped-out window (same fixed dark background)
+ * looking identical to the floating panel.
+ */
+
+/** Small square button (Prev / Next / Hide / Pop out / Reset). */
+export const PANEL_BUTTON_CLASS =
+  "rounded border border-zinc-600 px-2 py-1 text-xs disabled:opacity-40";
+
+/** Card that groups one section's controls. */
+export const PANEL_SECTION_CLASS = "rounded-lg border border-zinc-700/60 p-3";
+
+/** Section heading — also used as a `<summary>` for collapsible sections. */
+export const PANEL_SECTION_TITLE_CLASS =
+  "cursor-pointer text-xs font-semibold uppercase tracking-wide text-zinc-400";
+
+/** Text input / number input / select. */
+export const PANEL_INPUT_CLASS =
+  "w-full min-w-0 rounded border border-zinc-600 bg-zinc-800 px-2 py-1 font-mono text-xs text-zinc-100";
+
+/** Label above an input. */
+export const PANEL_LABEL_CLASS = "truncate text-xs text-zinc-400";
+
+/** Explanatory sub-text under a control. */
+export const PANEL_HINT_CLASS = "text-xs text-zinc-500";
+
+/** Equal-width segmented control button (theme picker, protocol status, …). */
+export function panelSegmentClass(active: boolean): string {
+  return `flex-1 rounded border px-2 py-1 text-xs ${
+    active
+      ? "border-orange-500 bg-orange-500/20 text-white"
+      : "border-zinc-600 text-zinc-300"
+  }`;
+}

--- a/services/vault/src/hooks/__tests__/useActivitiesWithPending.test.tsx
+++ b/services/vault/src/hooks/__tests__/useActivitiesWithPending.test.tsx
@@ -14,6 +14,7 @@ import { useActivitiesWithPending } from "../useActivitiesWithPending";
 
 const useActivitiesMock = vi.fn();
 const getPendingActivitiesMock = vi.fn();
+const useDemoActivityMock = vi.fn();
 
 vi.mock("../useActivities", () => ({
   useActivities: (arg: unknown) => useActivitiesMock(arg),
@@ -21,6 +22,10 @@ vi.mock("../useActivities", () => ({
 
 vi.mock("../../services/activity", () => ({
   getPendingActivities: (arg: unknown) => getPendingActivitiesMock(arg),
+}));
+
+vi.mock("../../dev/demoDeposit", () => ({
+  useDemoActivity: () => useDemoActivityMock(),
 }));
 
 const ADDR = "0xabc0000000000000000000000000000000000001" as const;
@@ -42,6 +47,7 @@ describe("useActivitiesWithPending", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     useActivitiesMock.mockReturnValue({ data: [], isLoading: false });
+    useDemoActivityMock.mockReturnValue(null);
   });
 
   it("returns [] synchronously when userAddress is undefined, even if pending activities exist for a prior address", () => {
@@ -77,5 +83,66 @@ describe("useActivitiesWithPending", () => {
     expect(
       result.current.data.map((a) => (a.kind === "row" ? a.tokenIcon : null)),
     ).toEqual(["/images/btc.svg", "/images/usdc.svg"]);
+  });
+});
+
+describe("useActivitiesWithPending — god-mode demo rows", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getPendingActivitiesMock.mockReturnValue([]);
+    useActivitiesMock.mockReturnValue({ data: [], isLoading: false });
+    useDemoActivityMock.mockReturnValue(null);
+  });
+
+  it("renders demo rows while disconnected, without waiting on the live query", () => {
+    useActivitiesMock.mockReturnValue({ data: [], isLoading: true });
+    const demoRow = makePending("demo-activity-1", 5_000);
+    useDemoActivityMock.mockReturnValue({ rows: [demoRow], hideReal: false });
+
+    const { result } = renderHook(() => useActivitiesWithPending(undefined));
+
+    expect(result.current.data).toEqual([demoRow]);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  // hide-real with zero mocks is a deliberate empty demo-only feed, so the
+  // page must show it rather than sitting on the live query's spinner.
+  it("resolves to an empty feed when hide-real is set with no mocks", () => {
+    useActivitiesMock.mockReturnValue({
+      data: [makePending("confirmed-1", 1_000)],
+      isLoading: true,
+    });
+    useDemoActivityMock.mockReturnValue({ rows: [], hideReal: true });
+
+    const { result } = renderHook(() => useActivitiesWithPending(ADDR));
+
+    expect(result.current.data).toEqual([]);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("keeps the live loading state when the demo adds nothing to the feed", () => {
+    useActivitiesMock.mockReturnValue({ data: [], isLoading: true });
+    useDemoActivityMock.mockReturnValue({ rows: [], hideReal: false });
+
+    const { result } = renderHook(() => useActivitiesWithPending(ADDR));
+
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it("orders demo rows into the real feed by date, newest first", () => {
+    const confirmed = makePending("confirmed-1", 3_000);
+    const demoOlder = makePending("demo-activity-1", 2_000);
+    useActivitiesMock.mockReturnValue({ data: [confirmed], isLoading: false });
+    useDemoActivityMock.mockReturnValue({
+      rows: [demoOlder],
+      hideReal: false,
+    });
+
+    const { result } = renderHook(() => useActivitiesWithPending(ADDR));
+
+    expect(result.current.data.map((row) => row.id)).toEqual([
+      "confirmed-1",
+      "demo-activity-1",
+    ]);
   });
 });

--- a/services/vault/src/hooks/useActivitiesWithPending.ts
+++ b/services/vault/src/hooks/useActivitiesWithPending.ts
@@ -102,10 +102,12 @@ export function useActivitiesWithPending(userAddress: Address | undefined) {
 
   return {
     data: allActivities,
-    // With mocks injected there is something to render immediately, so the
-    // page must not sit on its spinner waiting for a query that, disconnected,
-    // will never resolve.
-    isLoading: demo && demo.rows.length > 0 ? false : isLoading,
+    // Whenever the demo governs the feed there is a final answer to render
+    // right now, so the page must not sit on its spinner waiting for a query
+    // that, disconnected, will never resolve. `hideReal` counts even with zero
+    // mocks: the feed is then a deliberate empty demo-only list.
+    isLoading:
+      demo && (demo.hideReal || demo.rows.length > 0) ? false : isLoading,
     ...queryResult,
   };
 }

--- a/services/vault/src/hooks/useActivitiesWithPending.ts
+++ b/services/vault/src/hooks/useActivitiesWithPending.ts
@@ -9,6 +9,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import type { Address } from "viem";
 
 import { STORAGE_UPDATE_EVENT } from "../constants";
+import { useDemoActivity } from "../dev/demoDeposit";
 import { getPendingActivities } from "../services/activity";
 import type { ActivityLog, ActivityRow } from "../types/activityLog";
 
@@ -31,6 +32,13 @@ export function useActivitiesWithPending(userAddress: Address | undefined) {
   } = useActivities(userAddress);
   const [pendingActivities, setPendingActivities] = useState<ActivityLog[]>([]);
   const [storageVersion, setStorageVersion] = useState(0);
+  // God-mode demo rows (dev only; null unless the panel's "Inject demo" toggle
+  // is on). Merged into the returned feed — real rows dropped when `hideReal`
+  // is set — so the Activity page can be exercised without a wallet or an
+  // indexed history. Read-only display rows: nothing here is ever polled,
+  // written to localStorage, or deduplicated against real ids. Inert in
+  // production.
+  const demo = useDemoActivity();
 
   // Load pending activities from localStorage
   const loadPendingActivities = useCallback(() => {
@@ -71,7 +79,10 @@ export function useActivitiesWithPending(userAddress: Address | undefined) {
 
   // Merge confirmed and pending activities, deduplicating by ID
   const allActivities = useMemo<ActivityRow[]>(() => {
-    if (!userAddress) return [];
+    // Demo rows lead the feed and are exempt from the wallet guard, so the
+    // page renders them while disconnected (mirrors VaultsPage / Loans).
+    const demoRows = demo?.rows ?? [];
+    if (!userAddress || demo?.hideReal) return demoRows;
 
     const confirmed = confirmedActivities ?? [];
 
@@ -84,14 +95,17 @@ export function useActivitiesWithPending(userAddress: Address | undefined) {
     );
 
     // Combine and sort by date (newest first)
-    return [...uniquePending, ...confirmed].sort(
+    return [...demoRows, ...uniquePending, ...confirmed].sort(
       (a, b) => b.date.getTime() - a.date.getTime(),
     );
-  }, [confirmedActivities, pendingActivities, userAddress]);
+  }, [confirmedActivities, pendingActivities, userAddress, demo]);
 
   return {
     data: allActivities,
-    isLoading,
+    // With mocks injected there is something to render immediately, so the
+    // page must not sit on its spinner waiting for a query that, disconnected,
+    // will never resolve.
+    isLoading: demo && demo.rows.length > 0 ? false : isLoading,
     ...queryResult,
   };
 }

--- a/services/vault/src/router.tsx
+++ b/services/vault/src/router.tsx
@@ -1,5 +1,5 @@
 import { Loader } from "@babylonlabs-io/core-ui";
-import { Suspense, useEffect } from "react";
+import { lazy, Suspense, useEffect } from "react";
 import {
   Navigate,
   Outlet,
@@ -40,6 +40,15 @@ const DashboardPage = lazyWithRetry(() =>
   })),
 );
 
+// Dev-only god-mode panel, lazily imported behind `import.meta.env.DEV` so the
+// whole dev subtree is dropped from production builds (the dynamic import sits
+// in a dead branch the bundler eliminates).
+const GodModeMount = import.meta.env.DEV
+  ? lazy(() =>
+      import("./dev/GodModeMount").then((m) => ({ default: m.GodModeMount })),
+    )
+  : null;
+
 const importAaveReserveDetail = () =>
   import("./applications/aave/components/Detail");
 const AaveReserveDetail = lazyWithRetry(() =>
@@ -55,6 +64,16 @@ const RouteFallback = () => (
     <Loader />
   </div>
 );
+
+/** The dev/QA god-mode panel, or nothing outside a flagged dev build. Rendered
+ *  once per route subtree that mounts the Aave providers its debug sections
+ *  read (see the two call sites below). */
+const GodModePanelSlot = () =>
+  GodModeMount && featureFlags.isGodModePanelEnabled ? (
+    <Suspense fallback={null}>
+      <GodModeMount />
+    </Suspense>
+  ) : null;
 
 const AaveOverlayLayout = () => {
   const outletContext = useOutletContext<RootLayoutContext>();
@@ -93,6 +112,12 @@ const AaveOverlayLayout = () => {
                 <AaveReserveDetail reserveId={reserveId} tab={tab} />
               </Suspense>
             )}
+          {/* One god-mode panel for every tab under this layout (Overview,
+              Vaults, Loans) — mounted here, not per page, so it is present on
+              all three and keeps its open/position state across navigation.
+              This layout supplies the Aave providers its position-notifications
+              section reads. */}
+          <GodModePanelSlot />
         </ReorderOverrideProvider>
       </PendingVaultsProvider>
     </AaveConfigProvider>
@@ -101,7 +126,20 @@ const AaveOverlayLayout = () => {
 
 const ActivityWithProviders = () => (
   <AaveConfigProvider>
-    <Activity />
+    {/* Activity itself needs no reorder override — this is the one provider
+        the god-mode position-notifications section reads (through
+        `useDashboardState`) that this route does not otherwise mount, and it
+        is in-memory-only state, so a second instance here is inert for the
+        page. Without it the panel would throw on /activity.
+
+        The page reads the indexer's activity list directly and does not
+        consume the demo store, so the panel drives theme, the protocol-status
+        / max-vaults overrides and the shared mock list here — no mock rows
+        render on this page. */}
+    <ReorderOverrideProvider>
+      <Activity />
+      <GodModePanelSlot />
+    </ReorderOverrideProvider>
   </AaveConfigProvider>
 );
 

--- a/services/vault/src/router.tsx
+++ b/services/vault/src/router.tsx
@@ -132,6 +132,13 @@ const ActivityWithProviders = () => (
         is in-memory-only state, so a second instance here is inert for the
         page. Without it the panel would throw on /activity.
 
+        The panel's full context dependency set is AaveConfig (mounted here),
+        ReorderOverride (mounted here) and ActivatingVaults (RootLayout).
+        Notably NOT PendingVaults: that context is reached only through
+        `useAaveVaults` and `useWithdrawCollateralTransaction`, neither of
+        which this subtree mounts — so the Aave layout's PendingVaultsProvider
+        is deliberately not duplicated here.
+
         The page reads the indexer's activity list directly and does not
         consume the demo store, so the panel drives theme, the protocol-status
         / max-vaults overrides and the shared mock list here — no mock rows

--- a/services/vault/src/router.tsx
+++ b/services/vault/src/router.tsx
@@ -139,10 +139,10 @@ const ActivityWithProviders = () => (
         which this subtree mounts — so the Aave layout's PendingVaultsProvider
         is deliberately not duplicated here.
 
-        The page reads the indexer's activity list directly and does not
-        consume the demo store, so the panel drives theme, the protocol-status
-        / max-vaults overrides and the shared mock list here — no mock rows
-        render on this page. */}
+        The feed itself is demo-aware: `useActivitiesWithPending` merges the
+        panel's activity mocks into the rows it returns (see dev/demoDeposit),
+        so mock rows DO render on this page — while disconnected too —
+        alongside the theme and protocol-status / max-vaults overrides. */}
     <ReorderOverrideProvider>
       <Activity />
       <GodModePanelSlot />


### PR DESCRIPTION
Add `loan` and `activity` mock types so the panel drives the two v3 pages that had no injectable state. Loan mocks render as Active Loans rows (four scenarios: borrowable, repay-only, missing liquidity read, pending APR) with the summary totalling the rendered rows; activity mocks render in the feed (nine scenarios covering both flat log rows and the expandable liquidation group card), dated relative to now so the Today / Yesterday group headers apply.

Add Loans summary overrides for the states a real position cannot be talked into on demand: a health factor per production band, and the borrow-capacity cards in their loading and error states. The forced health-factor status is derived with the real banding function so it cannot drift from production.

Mount the panel once per route subtree (dev/GodModeMount) rather than a copy per page. Overview, Vaults, Loans and Activity now all get the debug sections as well, and the panel keeps its open/dragged position across navigation within a subtree. This replaces the per-page mounts added in #2124.

Restyle the liquidation-analysis and position-notification debug sections to the panel's zinc chrome; they were light-theme purple cards sitting inside a fixed dark box.

Mock rows are display-only: their ids and symbols resolve to no real reserve or event, both row actions stay disabled, nothing is polled or persisted, and the whole of src/dev is dropped from production builds.