### PR TITLE
fix(vault): align v3 activity, loan and modal 

### DIFF
--- a/services/vault/src/__tests__/router.test.tsx
+++ b/services/vault/src/__tests__/router.test.tsx
@@ -148,6 +148,34 @@ vi.mock("../services/activity/claimTxResolver", () => ({
   resolveRedeemClaimTxids: vi.fn(async () => new Map()),
 }));
 
+// The Activity page reuses the deposit lifecycle to offer the expired
+// deposit's refund; that graph reaches the built wallet-connector bundle,
+// which vitest cannot evaluate. Routing is what this suite checks.
+vi.mock("@/hooks/usePendingDeposits", () => ({
+  usePendingDeposits: () => ({
+    expiredActivities: [],
+    allActivities: [],
+    pendingPegins: [],
+    btcPublicKey: undefined,
+    ethAddress: undefined,
+    broadcastModal: {},
+    refundModal: { handleRefundClick: vi.fn() },
+  }),
+}));
+
+vi.mock("@/context/ProtocolParamsContext", () => ({
+  ProtocolParamsProvider: ({ children }: { children: ReactNode }) => children,
+}));
+
+vi.mock("@/context/deposit/PeginPollingContext", () => ({
+  PeginPollingProvider: ({ children }: { children: ReactNode }) => children,
+  useDepositPollingResult: () => undefined,
+}));
+
+vi.mock("@/components/simple/PendingDepositModals", () => ({
+  PendingDepositModals: () => null,
+}));
+
 function renderAt(path: string): RenderResult {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },

--- a/services/vault/src/applications/aave/components/AssetSelectionModal/AssetSelectionModal.tsx
+++ b/services/vault/src/applications/aave/components/AssetSelectionModal/AssetSelectionModal.tsx
@@ -8,9 +8,10 @@
  * repaying). Selecting a row routes into the reserve detail.
  */
 
-import { Avatar, FullScreenDialog } from "@babylonlabs-io/core-ui";
+import { Avatar } from "@babylonlabs-io/core-ui";
 import { useMemo } from "react";
 
+import { V3ModalShell } from "@/components/shared/V3ModalShell";
 import { COPY } from "@/copy";
 import {
   getCurrencyIconWithFallback,
@@ -239,11 +240,7 @@ export function AssetSelectionModal({
   };
 
   return (
-    <FullScreenDialog
-      open={isOpen}
-      onClose={onClose}
-      className="items-center justify-center p-6"
-    >
+    <V3ModalShell open={isOpen} onClose={onClose}>
       <div className="mx-auto w-full max-w-[612px] rounded-2xl border border-secondary-strokeLight">
         <div className="border-b border-secondary-strokeLight p-6">
           <h3 className="text-2xl text-accent-primary">
@@ -252,6 +249,6 @@ export function AssetSelectionModal({
         </div>
         <div className="flex flex-col gap-4 px-6 pb-6 pt-4">{renderBody()}</div>
       </div>
-    </FullScreenDialog>
+    </V3ModalShell>
   );
 }

--- a/services/vault/src/applications/aave/components/AssetSelectionModal/__tests__/AssetSelectionModal.test.tsx
+++ b/services/vault/src/applications/aave/components/AssetSelectionModal/__tests__/AssetSelectionModal.test.tsx
@@ -15,14 +15,15 @@ import { LOAN_TAB } from "../../../constants";
 import { AssetSelectionModal } from "../AssetSelectionModal";
 
 vi.mock("@babylonlabs-io/core-ui", () => ({
-  FullScreenDialog: ({
-    open,
-    children,
-  }: {
-    open: boolean;
-    children: ReactNode;
-  }) => (open ? <div>{children}</div> : null),
   Avatar: ({ alt }: { alt: string }) => <img alt={alt} />,
+}));
+
+// The shared v3 modal shell renders the app's top bar (network badge +
+// settings), whose graph reaches wallet-connector and can't be transformed
+// here. This suite is about the table inside it.
+vi.mock("@/components/shared/V3ModalShell", () => ({
+  V3ModalShell: ({ open, children }: { open: boolean; children: ReactNode }) =>
+    open ? <div>{children}</div> : null,
 }));
 
 const borrowableReserves = [

--- a/services/vault/src/applications/aave/components/LoanCard/LoanSuccessModal.tsx
+++ b/services/vault/src/applications/aave/components/LoanCard/LoanSuccessModal.tsx
@@ -1,11 +1,6 @@
-import {
-  Avatar,
-  Button,
-  FullScreenDialog,
-  Heading,
-  Text,
-} from "@babylonlabs-io/core-ui";
+import { Avatar, Button, Heading, Text } from "@babylonlabs-io/core-ui";
 
+import { V3ModalShell } from "@/components/shared/V3ModalShell";
 import { COPY } from "@/copy";
 import { formatAmount } from "@/utils/formatting";
 
@@ -29,9 +24,9 @@ const COPY_BY_VARIANT = {
 /**
  * Full-screen success screen shown after a successful borrow or repay. The
  * layout is identical for both operations; only the copy differs, selected by
- * `variant`. Confirms the amount and dismisses via the "Done" CTA — the sole
- * control. `onClose` is intentionally withheld from the dialog so there is no
- * close (X), backdrop, or escape dismissal competing with the single button.
+ * `variant`. Confirms the amount and dismisses via the "Done" CTA, the close
+ * (X), the backdrop, or escape — all four land on the same `onDone`, since
+ * there is nothing left to cancel once the transaction has settled.
  */
 export function LoanSuccessModal({
   open,
@@ -46,7 +41,7 @@ export function LoanSuccessModal({
   const formattedAmount = formatAmount(amount, decimals);
 
   return (
-    <FullScreenDialog open={open} className="items-center justify-center p-6">
+    <V3ModalShell open={open} onClose={onDone}>
       <div className="mx-auto flex w-full max-w-[564px] flex-col gap-10 rounded-3xl border border-secondary-strokeLight px-6 pb-6 pt-[72px] text-center text-accent-primary">
         <div className="flex flex-col items-center gap-6">
           <Avatar
@@ -84,6 +79,6 @@ export function LoanSuccessModal({
           {copy.doneButton}
         </Button>
       </div>
-    </FullScreenDialog>
+    </V3ModalShell>
   );
 }

--- a/services/vault/src/components/Activity/ActivityHashLink.tsx
+++ b/services/vault/src/components/Activity/ActivityHashLink.tsx
@@ -1,0 +1,54 @@
+/**
+ * ActivityHashLink — the v3 activity row's transaction-hash cell.
+ *
+ * The v3 design drops copy-to-clipboard in favour of a single open-in-explorer
+ * affordance: the truncated hash, underlined, followed by an external-link
+ * arrow (Figma 10233:50689). The whole thing is one link. Rows outside the v3
+ * activity list keep using CopyableHash.
+ *
+ * BTC hashes are displayed without the 0x prefix (Bitcoin convention); EVM
+ * hashes keep it.
+ */
+
+import { stripHexPrefix } from "@babylonlabs-io/ts-sdk/tbv/core";
+import { RiArrowRightUpLine } from "react-icons/ri";
+
+import type { HashChain } from "@/components/shared/CopyableHash";
+import { COPY } from "@/copy";
+import { truncateHash } from "@/utils/addressUtils";
+
+const EXTERNAL_ICON_SIZE = 16;
+
+interface ActivityHashLinkProps {
+  /** Raw hash (may have 0x prefix) */
+  hash: string;
+  /** Source chain — determines whether the 0x prefix is stripped for display */
+  chain: HashChain;
+  /** Explorer URL the row opens in a new tab. */
+  explorerUrl: string;
+}
+
+export function ActivityHashLink({
+  hash,
+  chain,
+  explorerUrl,
+}: ActivityHashLinkProps) {
+  const truncated = truncateHash(chain === "BTC" ? stripHexPrefix(hash) : hash);
+
+  return (
+    <a
+      href={explorerUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label={COPY.activity.viewTransaction(chain, truncated)}
+      className="flex items-center gap-2 text-sm leading-[1.43] tracking-[0.17px] text-accent-primary underline transition-colors hover:text-accent-secondary"
+    >
+      {truncated}
+      <RiArrowRightUpLine
+        size={EXTERNAL_ICON_SIZE}
+        aria-hidden
+        className="shrink-0 no-underline"
+      />
+    </a>
+  );
+}

--- a/services/vault/src/components/Activity/ActivityHashLink.tsx
+++ b/services/vault/src/components/Activity/ActivityHashLink.tsx
@@ -41,13 +41,15 @@ export function ActivityHashLink({
       target="_blank"
       rel="noopener noreferrer"
       aria-label={COPY.activity.viewTransaction(chain, truncated)}
-      className="flex items-center gap-2 text-sm leading-[1.43] tracking-[0.17px] text-accent-primary underline transition-colors hover:text-accent-secondary"
+      className="flex items-center gap-2 text-sm leading-[1.43] tracking-[0.17px] text-accent-primary transition-colors hover:text-accent-secondary"
     >
-      {truncated}
+      {/* The underline sits on the text alone: on the anchor it propagates to
+          the arrow, and a descendant `no-underline` does not lift it. */}
+      <span className="underline">{truncated}</span>
       <RiArrowRightUpLine
         size={EXTERNAL_ICON_SIZE}
         aria-hidden
-        className="shrink-0 no-underline"
+        className="shrink-0"
       />
     </a>
   );

--- a/services/vault/src/components/Activity/ActivityList.tsx
+++ b/services/vault/src/components/Activity/ActivityList.tsx
@@ -1,7 +1,8 @@
-import { Avatar, Heading, useIsMobile } from "@babylonlabs-io/core-ui";
+import { Heading, useIsMobile } from "@babylonlabs-io/core-ui";
 import { useEffect, useState } from "react";
 import { twJoin } from "tailwind-merge";
 
+import { ListRowCard } from "@/components/shared/ListRow";
 import { FeatureFlags } from "@/config";
 import { COPY } from "@/copy";
 import { useMidnightTick } from "@/hooks/useMidnightTick";
@@ -11,8 +12,10 @@ import { formatActivityDateGroup } from "@/utils/formatting";
 import { ActivityCard } from "./ActivityCard";
 import { ActivityEmptyState } from "./ActivityEmptyState";
 import { ActivityRowV3 } from "./ActivityRowV3";
+import { ExpiredWithdrawButton } from "./ExpiredWithdrawButton";
 import { FilterDropdown } from "./FilterDropdown";
 import { LiquidationGroupCard } from "./LiquidationGroupCard";
+import { LiquidationGroupCardV3 } from "./LiquidationGroupCardV3";
 
 interface ActivityDateGroup {
   label: string;
@@ -44,18 +47,6 @@ function groupByDate(
   return ordered;
 }
 
-function ActivityRow({ row }: { row: ActivityRow }) {
-  return row.kind === "liquidationGroup" ? (
-    <LiquidationGroupCard row={row} />
-  ) : (
-    <ActivityRowV3 row={row} />
-  );
-}
-
-// Single-app surface today. When multi-app ships this becomes an app picker
-// fed from the applications registry.
-const AAVE_LOGO_URL = "/images/aave.svg";
-
 // Only the ActivityTypes that appear as filter options in the Figma menu.
 // `Redeem` and `Pending Deposit` rows still render in the list but are not
 // directly filterable. `claim_expired` is remapped to a refunded Deposit
@@ -67,9 +58,18 @@ const FILTER_OPTIONS = (
 interface ActivityListProps {
   activities: ActivityRow[];
   isConnected: boolean;
+  /** Vault ids of expired deposits whose HTLC refund is still outstanding —
+   *  those rows get the Withdraw action. Omitted by the v2 surface. */
+  refundableDepositIds?: ReadonlySet<string>;
+  onWithdraw?: (depositId: string) => void;
 }
 
-export function ActivityList({ activities, isConnected }: ActivityListProps) {
+export function ActivityList({
+  activities,
+  isConnected,
+  refundableDepositIds,
+  onWithdraw,
+}: ActivityListProps) {
   const isMobile = useIsMobile();
   const isV3 = FeatureFlags.isV3UiEnabled;
   // v3 desktop replaces this in-page heading with the persistent header's
@@ -99,7 +99,7 @@ export function ActivityList({ activities, isConnected }: ActivityListProps) {
         <div
           className={twJoin(
             "flex items-center gap-4",
-            hideHeading ? "justify-end" : "justify-between",
+            !hideHeading && "justify-between",
           )}
         >
           {!hideHeading && (
@@ -112,15 +112,12 @@ export function ActivityList({ activities, isConnected }: ActivityListProps) {
             </Heading>
           )}
           {isConnected && (
-            <div className="flex items-center gap-4">
-              <Avatar url={AAVE_LOGO_URL} alt="Aave" size="small" />
-              <FilterDropdown
-                value={filter}
-                placeholder={COPY.activity.filterAll}
-                options={FILTER_OPTIONS}
-                onChange={setFilter}
-              />
-            </div>
+            <FilterDropdown
+              value={filter}
+              placeholder={COPY.activity.filterAll}
+              options={FILTER_OPTIONS}
+              onChange={setFilter}
+            />
           )}
         </div>
       )}
@@ -131,28 +128,35 @@ export function ActivityList({ activities, isConnected }: ActivityListProps) {
           isFiltered={filter !== null}
         />
       ) : isV3 ? (
-        // v3: rows grouped under date headers, each group a rounded card with
-        // divider-separated rows (matches the Figma "after deposit" frame).
+        // v3: rows grouped under date headers. Each row is its own card, the
+        // same one the Vaults tab uses — except a liquidation, whose child
+        // events share one card with divider-separated rows.
         <div className="flex flex-col gap-6">
           {groupByDate(visible, new Date()).map((group) => (
             <div key={group.label} className="flex flex-col gap-3">
               <p className="text-sm leading-[1.43] tracking-[0.17px] text-accent-secondary">
                 {group.label}
               </p>
-              <ul
-                role="list"
-                className="overflow-hidden rounded-lg bg-secondary-highlight"
-              >
-                {group.rows.map((r, index) => (
-                  <li
-                    key={r.id}
-                    className={
-                      index > 0
-                        ? "border-t border-secondary-strokeLight dark:border-secondary-strokeDark"
-                        : ""
-                    }
-                  >
-                    <ActivityRow row={r} />
+              <ul role="list" className="flex flex-col gap-2">
+                {group.rows.map((r) => (
+                  <li key={r.id}>
+                    {r.kind === "liquidationGroup" ? (
+                      <LiquidationGroupCardV3 row={r} />
+                    ) : (
+                      <ListRowCard>
+                        <ActivityRowV3
+                          row={r}
+                          action={
+                            refundableDepositIds?.has(r.id) && onWithdraw ? (
+                              <ExpiredWithdrawButton
+                                depositId={r.id}
+                                onWithdraw={onWithdraw}
+                              />
+                            ) : undefined
+                          }
+                        />
+                      </ListRowCard>
+                    )}
                   </li>
                 ))}
               </ul>

--- a/services/vault/src/components/Activity/ActivityList.tsx
+++ b/services/vault/src/components/Activity/ActivityList.tsx
@@ -59,15 +59,16 @@ interface ActivityListProps {
   activities: ActivityRow[];
   isConnected: boolean;
   /** Vault ids of expired deposits whose HTLC refund is still outstanding —
-   *  those rows get the Withdraw action. Omitted by the v2 surface. */
-  refundableDepositIds?: ReadonlySet<string>;
-  onWithdraw?: (depositId: string) => void;
+   *  those rows get the Withdraw action. Matched against a row's `vaultId`,
+   *  never its `id` (see ActivityLog). Omitted by the v2 surface. */
+  refundableVaultIds?: ReadonlySet<string>;
+  onWithdraw?: (vaultId: string) => void;
 }
 
 export function ActivityList({
   activities,
   isConnected,
-  refundableDepositIds,
+  refundableVaultIds,
   onWithdraw,
 }: ActivityListProps) {
   const isMobile = useIsMobile();
@@ -147,9 +148,11 @@ export function ActivityList({
                         <ActivityRowV3
                           row={r}
                           action={
-                            refundableDepositIds?.has(r.id) && onWithdraw ? (
+                            r.vaultId &&
+                            refundableVaultIds?.has(r.vaultId) &&
+                            onWithdraw ? (
                               <ExpiredWithdrawButton
-                                depositId={r.id}
+                                vaultId={r.vaultId}
                                 onWithdraw={onWithdraw}
                               />
                             ) : undefined

--- a/services/vault/src/components/Activity/ActivityList.tsx
+++ b/services/vault/src/components/Activity/ActivityList.tsx
@@ -125,6 +125,9 @@ export function ActivityList({
                 placeholder={COPY.activity.filterAll}
                 options={FILTER_OPTIONS}
                 onChange={setFilter}
+                // v3 moves the trigger to the left of the row, so the menu
+                // opens rightward from it; v2 keeps it right-aligned.
+                align={isV3 ? "start" : "end"}
               />
             </div>
           )}

--- a/services/vault/src/components/Activity/ActivityList.tsx
+++ b/services/vault/src/components/Activity/ActivityList.tsx
@@ -1,4 +1,4 @@
-import { Heading, useIsMobile } from "@babylonlabs-io/core-ui";
+import { Avatar, Heading, useIsMobile } from "@babylonlabs-io/core-ui";
 import { useEffect, useState } from "react";
 import { twJoin } from "tailwind-merge";
 
@@ -46,6 +46,10 @@ function groupByDate(
   }
   return ordered;
 }
+
+// Single-app surface today. When multi-app ships this becomes an app picker
+// fed from the applications registry. v3 drops it from the header entirely.
+const AAVE_LOGO_URL = "/images/aave.svg";
 
 // Only the ActivityTypes that appear as filter options in the Figma menu.
 // `Redeem` and `Pending Deposit` rows still render in the list but are not
@@ -113,12 +117,16 @@ export function ActivityList({
             </Heading>
           )}
           {isConnected && (
-            <FilterDropdown
-              value={filter}
-              placeholder={COPY.activity.filterAll}
-              options={FILTER_OPTIONS}
-              onChange={setFilter}
-            />
+            <div className="flex items-center gap-4">
+              {/* v3 drops the app logo from the header; v2 keeps it. */}
+              {!isV3 && <Avatar url={AAVE_LOGO_URL} alt="Aave" size="small" />}
+              <FilterDropdown
+                value={filter}
+                placeholder={COPY.activity.filterAll}
+                options={FILTER_OPTIONS}
+                onChange={setFilter}
+              />
+            </div>
           )}
         </div>
       )}

--- a/services/vault/src/components/Activity/ActivityListWithRefund.tsx
+++ b/services/vault/src/components/Activity/ActivityListWithRefund.tsx
@@ -1,0 +1,97 @@
+/**
+ * ActivityListWithRefund — the v3 activity feed, plus the expired deposit's
+ * HTLC refund.
+ *
+ * Split out of the page so it is the v3 branch alone that mounts the deposit
+ * lifecycle: `usePendingDeposits`, the polling providers and the refund
+ * modals. v2 renders ActivityList directly and keeps its original behaviour —
+ * a refundable-expired deposit still reads "Pending" there, and none of this
+ * scaffolding is instantiated.
+ */
+
+import { useCallback, useMemo } from "react";
+
+import { PendingDepositModals } from "@/components/simple/PendingDepositModals";
+import { ProtocolParamsProvider } from "@/context/ProtocolParamsContext";
+import { PeginPollingProvider } from "@/context/deposit/PeginPollingContext";
+import { usePendingDeposits } from "@/hooks/usePendingDeposits";
+import type { ActivityRow } from "@/types/activityLog";
+
+import { ActivityList } from "./ActivityList";
+
+interface ActivityListWithRefundProps {
+  activities: ActivityRow[];
+  isConnected: boolean;
+}
+
+export function ActivityListWithRefund({
+  activities,
+  isConnected,
+}: ActivityListWithRefundProps) {
+  const {
+    expiredActivities,
+    allActivities,
+    pendingPegins,
+    btcPublicKey,
+    ethAddress,
+    broadcastModal,
+    refundModal,
+  } = usePendingDeposits();
+
+  // Deposits that expired before activation and have not been reclaimed yet,
+  // keyed by vault id. Correlate these against a row's `vaultId` and never its
+  // `id`: an indexed row's id is its event, not its vault (see ActivityLog).
+  const refundableVaultIds = useMemo(
+    () => new Set<string>(expiredActivities.map((a) => a.id)),
+    [expiredActivities],
+  );
+
+  // Such a row arrives from localStorage still marked pending; the contract
+  // status says otherwise, so correct it before it reaches the status column.
+  const rows = useMemo<ActivityRow[]>(
+    () =>
+      activities.map((row) =>
+        row.kind === "row" && row.vaultId && refundableVaultIds.has(row.vaultId)
+          ? { ...row, isPending: false, isExpired: true }
+          : row,
+      ),
+    [activities, refundableVaultIds],
+  );
+
+  const handleWithdraw = useCallback(
+    (vaultId: string) => refundModal.handleRefundClick(vaultId),
+    [refundModal],
+  );
+
+  const list = (
+    <ActivityList
+      activities={rows}
+      isConnected={isConnected}
+      refundableVaultIds={refundableVaultIds}
+      onWithdraw={handleWithdraw}
+    />
+  );
+
+  // No refund to offer: render the feed bare. ProtocolParamsProvider below
+  // BLOCKS its children until the contract params resolve, so mounting it
+  // unconditionally would hold the whole feed — including the disconnected
+  // empty state — behind a network read the feed does not need.
+  if (refundableVaultIds.size === 0) return list;
+
+  return (
+    <ProtocolParamsProvider>
+      <PeginPollingProvider
+        activities={allActivities}
+        pendingPegins={pendingPegins}
+        btcPublicKey={btcPublicKey}
+      >
+        {list}
+        <PendingDepositModals
+          broadcastModal={broadcastModal}
+          refundModal={refundModal}
+          ethAddress={ethAddress}
+        />
+      </PeginPollingProvider>
+    </ProtocolParamsProvider>
+  );
+}

--- a/services/vault/src/components/Activity/ActivityRowV3.tsx
+++ b/services/vault/src/components/Activity/ActivityRowV3.tsx
@@ -1,23 +1,41 @@
 /**
  * ActivityRowV3
- * A single row inside a v3 date-group card (behind ENABLE_V3_UI). Columns:
- * token icon + amount, a status indicator, the transaction type, the tx-hash
- * link/copy, and a time-only timestamp (the calendar day lives in the group
- * header). The status is derived from the row type plus pending/expired (see
- * `getActivityStatus`). Per-row USD value and the Withdraw button from the
- * Figma frame are deferred (not backed by current activity data).
+ * The v3 activity row body (behind ENABLE_V3_UI): token icon + amount, a status
+ * indicator, the transaction type, the tx-hash explorer link, and a time-only
+ * timestamp (the calendar day lives in the group header), with an optional
+ * action slot pinned right. Renders the columns only — the caller supplies the
+ * card and its padding, so the same row works standalone (one card per row) and
+ * stacked inside a liquidation group's shared card. Per-row USD value from the
+ * Figma frame is deferred (not backed by current activity data).
  */
 
 import { Avatar } from "@babylonlabs-io/core-ui";
+import type { ReactNode } from "react";
 
-import { CopyableHash } from "@/components/shared/CopyableHash";
 import { COPY } from "@/copy";
 import { type ActivityLog, PENDING_DEPOSIT_TYPE } from "@/types/activityLog";
 import { getExplorerTxUrl } from "@/utils/explorer";
 import { formatActivityTime } from "@/utils/formatting";
 
+import { ActivityHashLink } from "./ActivityHashLink";
+import { STATUS_DOT } from "./statusDot";
+
+/** Fixed column width shared by every cell, so rows line up across cards
+ *  regardless of amount length (Figma: 180px). */
+const COLUMN_CLASS = "flex w-[180px] shrink-0 items-center";
+
+/** Figma body 2 — every cell's text except the deferred USD sub-line. */
+const CELL_TEXT_CLASS = "text-sm leading-[1.43] tracking-[0.17px]";
+
+export interface ActivityStatus {
+  dotClass: string;
+  label: string;
+}
+
 interface ActivityRowV3Props {
   row: ActivityLog;
+  /** Rendered flush right — the expired deposit's Withdraw, when refundable. */
+  action?: ReactNode;
 }
 
 /**
@@ -28,83 +46,110 @@ interface ActivityRowV3Props {
  * type, not a live collateral check. Liquidation rows render separately and
  * never reach here.
  */
-function getActivityStatus(row: ActivityLog): {
-  dotClass: string;
-  label: string;
-} {
+function getActivityStatus(row: ActivityLog): ActivityStatus {
   if (row.isExpired) {
-    return { dotClass: "bg-error-main", label: COPY.activity.statusExpired };
+    return { dotClass: STATUS_DOT.expired, label: COPY.activity.statusExpired };
   }
   if (row.isPending) {
-    return { dotClass: "bg-warning-main", label: COPY.activity.statusPending };
+    return { dotClass: STATUS_DOT.pending, label: COPY.activity.statusPending };
   }
   const type = row.type === PENDING_DEPOSIT_TYPE ? "Deposit" : row.type;
   if (type === "Deposit") {
-    return { dotClass: "bg-success-main", label: COPY.activity.statusInUse };
+    return { dotClass: STATUS_DOT.settled, label: COPY.activity.statusInUse };
   }
-  return { dotClass: "bg-success-main", label: COPY.activity.statusDone };
+  return { dotClass: STATUS_DOT.settled, label: COPY.activity.statusDone };
 }
 
-function StatusIndicator({
-  dotClass,
-  label,
-}: {
-  dotClass: string;
-  label: string;
-}) {
+export function ActivityRowV3({ row, action }: ActivityRowV3Props) {
   return (
-    <span className="flex items-center gap-2">
-      <span className={`inline-block size-2 rounded-full ${dotClass}`} />
-      <span className="text-base text-accent-primary">{label}</span>
-    </span>
-  );
-}
-
-export function ActivityRowV3({ row }: ActivityRowV3Props) {
-  const showHash = row.transactionHash !== "";
-  const status = getActivityStatus(row);
-
-  // The type column label comes from the copy catalog; "Pending Deposit" (an
-  // internal type kept out of the filter menu) maps to a normal "Deposit".
-  const displayLabel = COPY.activity.typeLabels[row.type];
-
-  return (
-    // A shared grid template (not content-sized flex) so every row's columns
-    // line up regardless of amount length — a long "0.00705306 WBTC" no longer
-    // pushes the type/hash/time columns out of alignment with shorter rows.
-    <div className="grid grid-cols-1 gap-2 p-6 lg:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)_minmax(0,1fr)_minmax(0,1.1fr)_auto] lg:items-center lg:gap-6">
-      <div className="flex min-w-0 items-center gap-3">
-        <Avatar url={row.tokenIcon} alt={row.amount.symbol} size="medium" />
-        <span className="whitespace-nowrap text-xl text-accent-primary">
-          {row.amount.value} {row.amount.symbol}
-        </span>
-      </div>
-
-      <div className="min-w-0">
-        <StatusIndicator dotClass={status.dotClass} label={status.label} />
-      </div>
-
-      <span className="min-w-0 text-base text-accent-primary">
-        {displayLabel}
-      </span>
-
-      <div className="min-w-0">
-        {showHash ? (
-          <CopyableHash
+    <ActivityRowLayout
+      icon={row.tokenIcon}
+      iconAlt={row.amount.symbol}
+      amount={`${row.amount.value} ${row.amount.symbol}`}
+      status={getActivityStatus(row)}
+      // The type column label comes from the copy catalog; "Pending Deposit"
+      // (an internal type kept out of the filter menu) maps to a "Deposit".
+      typeLabel={COPY.activity.typeLabels[row.type]}
+      hash={
+        row.transactionHash !== "" ? (
+          <ActivityHashLink
             hash={row.transactionHash}
             chain={row.chain}
             explorerUrl={getExplorerTxUrl(row.chain, row.transactionHash)}
           />
         ) : (
-          <span className="text-sm italic text-accent-secondary">
+          <span className={`${CELL_TEXT_CLASS} italic text-accent-secondary`}>
             {COPY.activity.hashPending}
           </span>
-        )}
+        )
+      }
+      time={formatActivityTime(row.date)}
+      action={action}
+    />
+  );
+}
+
+interface ActivityRowLayoutProps {
+  icon: string;
+  iconAlt: string;
+  amount: string;
+  status: ActivityStatus;
+  typeLabel: string;
+  hash: ReactNode;
+  time: string;
+  action?: ReactNode;
+}
+
+/** The bare five-column row, without padding. Exported so the liquidation
+ *  group can lay its child events out identically without going through
+ *  ActivityLog. */
+export function ActivityRowLayout({
+  icon,
+  iconAlt,
+  amount,
+  status,
+  typeLabel,
+  hash,
+  time,
+  action,
+}: ActivityRowLayoutProps) {
+  return (
+    <div className="flex w-full flex-wrap items-center gap-4">
+      <div className={`${COLUMN_CLASS} gap-2`}>
+        <Avatar url={icon} alt={iconAlt} size="medium" />
+        <span
+          className={`min-w-0 truncate ${CELL_TEXT_CLASS} text-accent-primary`}
+        >
+          {amount}
+        </span>
       </div>
 
-      <span className="whitespace-nowrap text-sm text-accent-secondary lg:justify-self-end">
-        {formatActivityTime(row.date)}
+      <div className={`${COLUMN_CLASS} gap-1`}>
+        <span className={`size-3 shrink-0 rounded-full ${status.dotClass}`} />
+        <span
+          className={`min-w-0 truncate ${CELL_TEXT_CLASS} text-accent-primary`}
+        >
+          {status.label}
+        </span>
+      </div>
+
+      <span
+        className={`${COLUMN_CLASS} ${CELL_TEXT_CLASS} text-accent-primary`}
+      >
+        {typeLabel}
       </span>
+
+      <div className={COLUMN_CLASS}>{hash}</div>
+
+      <span
+        className={`${COLUMN_CLASS} ${CELL_TEXT_CLASS} text-accent-secondary`}
+      >
+        {time}
+      </span>
+
+      {action && (
+        <div className="ml-auto flex shrink-0 items-center">{action}</div>
+      )}
     </div>
   );
 }

--- a/services/vault/src/components/Activity/ExpiredWithdrawButton.tsx
+++ b/services/vault/src/components/Activity/ExpiredWithdrawButton.tsx
@@ -1,25 +1,19 @@
 /**
  * ExpiredWithdrawButton
  * The Withdraw action on an expired deposit's activity row. Performs the HTLC
- * refund, gated exactly as the Vaults page's inactive-vault row is (#2041): the
- * button only surfaces while the refund is actually available, and renders
- * disabled-with-tooltip while it is blocked but not yet in flight. Must be
- * rendered inside a PeginPollingProvider — it reads that deposit's poll result.
+ * refund, offered on exactly the terms the Vaults page's inactive-vault row
+ * uses — both read `useRefundRowAction`, so the two cannot drift. Must be
+ * rendered inside a PeginPollingProvider, which that hook requires.
  */
 
 import { Hint } from "@babylonlabs-io/core-ui";
 
-import { getActionStatus } from "@/components/deposit/actionStatus";
 import {
   ERROR_ROW_BUTTON_CLASS,
   NEUTRAL_ROW_BUTTON_CLASS,
 } from "@/components/shared/buttonClasses";
-import { useDepositPollingResult } from "@/context/deposit/PeginPollingContext";
 import { COPY } from "@/copy";
-import {
-  isRefundInFlightOrSettled,
-  PeginAction,
-} from "@/models/peginStateMachine";
+import { useRefundRowAction } from "@/hooks/deposit/useRefundRowAction";
 
 interface ExpiredWithdrawButtonProps {
   /** Vault id of the expired deposit — the refund modal's lookup key. */
@@ -31,15 +25,9 @@ export function ExpiredWithdrawButton({
   vaultId,
   onWithdraw,
 }: ExpiredWithdrawButtonProps) {
-  const result = useDepositPollingResult(vaultId);
-  const actionStatus: ReturnType<typeof getActionStatus> = result
-    ? getActionStatus(result)
-    : { type: "noAction" };
+  const { available, blockedTooltip } = useRefundRowAction(vaultId);
 
-  if (
-    actionStatus.type === "available" &&
-    actionStatus.action.action === PeginAction.REFUND_HTLC
-  ) {
+  if (available) {
     return (
       <button
         type="button"
@@ -51,17 +39,10 @@ export function ExpiredWithdrawButton({
     );
   }
 
-  const isBlocked =
-    actionStatus.type === "disabled" &&
-    actionStatus.action?.action === PeginAction.REFUND_HTLC &&
-    !(result?.peginState
-      ? isRefundInFlightOrSettled(result.peginState)
-      : false);
-
-  if (!isBlocked) return null;
+  if (!blockedTooltip) return null;
 
   return (
-    <Hint tooltip={actionStatus.tooltip} attachToChildren>
+    <Hint tooltip={blockedTooltip} attachToChildren>
       <button type="button" disabled className={NEUTRAL_ROW_BUTTON_CLASS}>
         {COPY.vaults.actions.withdraw}
       </button>

--- a/services/vault/src/components/Activity/ExpiredWithdrawButton.tsx
+++ b/services/vault/src/components/Activity/ExpiredWithdrawButton.tsx
@@ -1,0 +1,70 @@
+/**
+ * ExpiredWithdrawButton
+ * The Withdraw action on an expired deposit's activity row. Performs the HTLC
+ * refund, gated exactly as the Vaults page's inactive-vault row is (#2041): the
+ * button only surfaces while the refund is actually available, and renders
+ * disabled-with-tooltip while it is blocked but not yet in flight. Must be
+ * rendered inside a PeginPollingProvider — it reads that deposit's poll result.
+ */
+
+import { Hint } from "@babylonlabs-io/core-ui";
+
+import { getActionStatus } from "@/components/deposit/actionStatus";
+import {
+  ERROR_ROW_BUTTON_CLASS,
+  NEUTRAL_ROW_BUTTON_CLASS,
+} from "@/components/shared/buttonClasses";
+import { useDepositPollingResult } from "@/context/deposit/PeginPollingContext";
+import { COPY } from "@/copy";
+import {
+  isRefundInFlightOrSettled,
+  PeginAction,
+} from "@/models/peginStateMachine";
+
+interface ExpiredWithdrawButtonProps {
+  /** Vault id of the expired deposit — the refund modal's lookup key. */
+  depositId: string;
+  onWithdraw: (depositId: string) => void;
+}
+
+export function ExpiredWithdrawButton({
+  depositId,
+  onWithdraw,
+}: ExpiredWithdrawButtonProps) {
+  const result = useDepositPollingResult(depositId);
+  const actionStatus: ReturnType<typeof getActionStatus> = result
+    ? getActionStatus(result)
+    : { type: "noAction" };
+
+  if (
+    actionStatus.type === "available" &&
+    actionStatus.action.action === PeginAction.REFUND_HTLC
+  ) {
+    return (
+      <button
+        type="button"
+        onClick={() => onWithdraw(depositId)}
+        className={ERROR_ROW_BUTTON_CLASS}
+      >
+        {COPY.vaults.actions.withdraw}
+      </button>
+    );
+  }
+
+  const isBlocked =
+    actionStatus.type === "disabled" &&
+    actionStatus.action?.action === PeginAction.REFUND_HTLC &&
+    !(result?.peginState
+      ? isRefundInFlightOrSettled(result.peginState)
+      : false);
+
+  if (!isBlocked) return null;
+
+  return (
+    <Hint tooltip={actionStatus.tooltip} attachToChildren>
+      <button type="button" disabled className={NEUTRAL_ROW_BUTTON_CLASS}>
+        {COPY.vaults.actions.withdraw}
+      </button>
+    </Hint>
+  );
+}

--- a/services/vault/src/components/Activity/ExpiredWithdrawButton.tsx
+++ b/services/vault/src/components/Activity/ExpiredWithdrawButton.tsx
@@ -23,15 +23,15 @@ import {
 
 interface ExpiredWithdrawButtonProps {
   /** Vault id of the expired deposit — the refund modal's lookup key. */
-  depositId: string;
-  onWithdraw: (depositId: string) => void;
+  vaultId: string;
+  onWithdraw: (vaultId: string) => void;
 }
 
 export function ExpiredWithdrawButton({
-  depositId,
+  vaultId,
   onWithdraw,
 }: ExpiredWithdrawButtonProps) {
-  const result = useDepositPollingResult(depositId);
+  const result = useDepositPollingResult(vaultId);
   const actionStatus: ReturnType<typeof getActionStatus> = result
     ? getActionStatus(result)
     : { type: "noAction" };
@@ -43,7 +43,7 @@ export function ExpiredWithdrawButton({
     return (
       <button
         type="button"
-        onClick={() => onWithdraw(depositId)}
+        onClick={() => onWithdraw(vaultId)}
         className={ERROR_ROW_BUTTON_CLASS}
       >
         {COPY.vaults.actions.withdraw}

--- a/services/vault/src/components/Activity/FilterDropdown.tsx
+++ b/services/vault/src/components/Activity/FilterDropdown.tsx
@@ -17,6 +17,9 @@ interface FilterDropdownProps<V extends string> {
   options: ReadonlyArray<FilterDropdownOption<V>>;
   /** Pass `null` to clear the filter (reset row or click the active option). */
   onChange: (value: V | null) => void;
+  /** Which edge the menu aligns to. Follows the trigger's own position: v3
+   *  puts it at the left of the row, v2 at the right. */
+  align?: "start" | "end";
 }
 
 export function FilterDropdown<V extends string>({
@@ -24,6 +27,7 @@ export function FilterDropdown<V extends string>({
   placeholder,
   options,
   onChange,
+  align = "end",
 }: FilterDropdownProps<V>) {
   const [open, setOpen] = useState(false);
   const anchorRef = useRef<HTMLButtonElement>(null);
@@ -52,7 +56,7 @@ export function FilterDropdown<V extends string>({
       <Popover
         open={open}
         anchorEl={anchorRef.current}
-        placement="bottom-start"
+        placement={align === "start" ? "bottom-start" : "bottom-end"}
         offset={[0, 8]}
         onClickOutside={() => setOpen(false)}
         className="w-[200px] rounded-lg border border-secondary-strokeLight bg-neutral-200 p-4 shadow-[0px_8px_8px_rgba(0,0,0,0.12)]"

--- a/services/vault/src/components/Activity/FilterDropdown.tsx
+++ b/services/vault/src/components/Activity/FilterDropdown.tsx
@@ -52,7 +52,7 @@ export function FilterDropdown<V extends string>({
       <Popover
         open={open}
         anchorEl={anchorRef.current}
-        placement="bottom-end"
+        placement="bottom-start"
         offset={[0, 8]}
         onClickOutside={() => setOpen(false)}
         className="w-[200px] rounded-lg border border-secondary-strokeLight bg-neutral-200 p-4 shadow-[0px_8px_8px_rgba(0,0,0,0.12)]"

--- a/services/vault/src/components/Activity/LiquidationGroupCardV3.tsx
+++ b/services/vault/src/components/Activity/LiquidationGroupCardV3.tsx
@@ -1,0 +1,62 @@
+/**
+ * LiquidationGroupCardV3
+ * The v3 rendering of a liquidation: the group's child events (collateral
+ * liquidated / loan repaid) stacked as divider-separated rows inside ONE card,
+ * rather than a card per row. This grouped treatment is reserved for
+ * liquidations — every other activity renders as its own standalone card.
+ * Each child reuses the standard row layout, so the columns line up with the
+ * standalone rows above and below it.
+ */
+
+import { CARD_SHELL_CLASS } from "@/components/shared/layoutClasses";
+import { COPY } from "@/copy";
+import type { LiquidationGroupRow } from "@/types/activityLog";
+import { getExplorerTxUrl } from "@/utils/explorer";
+import { formatActivityTime } from "@/utils/formatting";
+
+import { ActivityHashLink } from "./ActivityHashLink";
+import { ActivityRowLayout } from "./ActivityRowV3";
+import { STATUS_DOT } from "./statusDot";
+
+interface LiquidationGroupCardV3Props {
+  row: LiquidationGroupRow;
+}
+
+export function LiquidationGroupCardV3({ row }: LiquidationGroupCardV3Props) {
+  // Every child of a liquidation shares the parent's outcome, so the status
+  // column repeats the group's type rather than deriving one per child.
+  const status = {
+    dotClass: STATUS_DOT.liquidated,
+    label: COPY.activity.typeLabels[row.type],
+  };
+
+  return (
+    <div className={`${CARD_SHELL_CLASS} flex flex-col gap-4 p-4`}>
+      {row.children.map((child, index) => (
+        <div key={child.id} className="flex flex-col gap-4">
+          {index > 0 && (
+            <hr className="border-t border-secondary-strokeLight dark:border-secondary-strokeDark" />
+          )}
+          <ActivityRowLayout
+            icon={child.tokenIcon}
+            iconAlt={child.amount.symbol}
+            amount={`${child.amount.value} ${child.amount.symbol}`}
+            status={status}
+            typeLabel={child.label}
+            hash={
+              <ActivityHashLink
+                hash={child.transactionHash}
+                chain={child.chain}
+                explorerUrl={getExplorerTxUrl(
+                  child.chain,
+                  child.transactionHash,
+                )}
+              />
+            }
+            time={formatActivityTime(child.date)}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/services/vault/src/components/Activity/__tests__/ActivityList.test.tsx
+++ b/services/vault/src/components/Activity/__tests__/ActivityList.test.tsx
@@ -163,6 +163,16 @@ describe("ActivityList", () => {
     ).toBeInTheDocument();
   });
 
+  it("renders the Aave logo next to the dropdown when connected", () => {
+    renderList({ activities: [], isConnected: true });
+    expect(screen.getByAltText("Aave")).toBeInTheDocument();
+  });
+
+  it("hides the Aave logo when disconnected", () => {
+    renderList({ activities: [], isConnected: false });
+    expect(screen.queryByAltText("Aave")).not.toBeInTheDocument();
+  });
+
   it("resets an active filter on disconnect so the disconnected empty state shows", () => {
     const rows = [
       makeRow({ id: "a", type: "Deposit" }),
@@ -208,6 +218,7 @@ describe("ActivityList", () => {
     expect(
       screen.queryByRole("heading", { name: COPY.activity.pageTitle }),
     ).not.toBeInTheDocument();
+    expect(screen.queryByAltText("Aave")).not.toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: /show all/i }),
     ).not.toBeInTheDocument();
@@ -232,7 +243,7 @@ describe("ActivityList", () => {
     ).toBeInTheDocument();
   });
 
-  it("v3 UI + connected: renders no in-page heading but keeps the filter dropdown", () => {
+  it("v3 UI + connected: keeps the filter dropdown but drops the Aave logo the v2 header shows", () => {
     featureFlagsMock.isV3UiEnabled = true;
     const rows = [makeRow({ id: "a", type: "Deposit" })];
     renderList({ activities: rows, isConnected: true });
@@ -240,6 +251,7 @@ describe("ActivityList", () => {
     expect(
       screen.queryByRole("heading", { name: COPY.activity.pageTitle }),
     ).not.toBeInTheDocument();
+    expect(screen.queryByAltText("Aave")).not.toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: /show all/i }),
     ).toBeInTheDocument();

--- a/services/vault/src/components/Activity/__tests__/ActivityList.test.tsx
+++ b/services/vault/src/components/Activity/__tests__/ActivityList.test.tsx
@@ -23,6 +23,23 @@ vi.mock("@/components/Wallet", () => ({
   Connect: () => <button type="button">Connect</button>,
 }));
 
+// The real button reads the deposit-polling context to decide whether the
+// refund is available — that gating is the Vaults page's, covered there. These
+// tests are about which row the list hands the action to, and with which id.
+vi.mock("../ExpiredWithdrawButton", () => ({
+  ExpiredWithdrawButton: ({
+    vaultId,
+    onWithdraw,
+  }: {
+    vaultId: string;
+    onWithdraw: (vaultId: string) => void;
+  }) => (
+    <button type="button" onClick={() => onWithdraw(vaultId)}>
+      Withdraw
+    </button>
+  ),
+}));
+
 import { ActivityList } from "../ActivityList";
 
 beforeEach(() => {
@@ -42,6 +59,7 @@ const makeRow = (overrides: Partial<ActivityLog>): ActivityLog => ({
   chain: overrides.chain ?? "BTC",
   transactionHash: overrides.transactionHash ?? "abc",
   tokenIcon: overrides.tokenIcon ?? "test://btc.svg",
+  vaultId: overrides.vaultId,
   isPending: overrides.isPending,
   isExpired: overrides.isExpired,
 });
@@ -49,6 +67,8 @@ const makeRow = (overrides: Partial<ActivityLog>): ActivityLog => ({
 function renderList(props: {
   activities: ActivityLog[];
   isConnected: boolean;
+  refundableVaultIds?: ReadonlySet<string>;
+  onWithdraw?: (vaultId: string) => void;
 }) {
   return render(
     <MemoryRouter initialEntries={["/activity"]}>
@@ -263,5 +283,58 @@ describe("ActivityList", () => {
 
     expect(screen.getByText(COPY.activity.emptyFiltered)).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /deposit/i })).toBeNull();
+  });
+  it("v3 UI: offers Withdraw on the row whose vaultId is refundable, matching on vaultId not the row id", () => {
+    featureFlagsMock.isV3UiEnabled = true;
+    const onWithdraw = vi.fn();
+    // An indexed row: its id is the event (txHash-logIndex-type), NOT the
+    // vault. Matching on `id` would never fire here.
+    const rows = [
+      makeRow({
+        id: "0xabc-3-deposit",
+        vaultId: "0xvault1",
+        isPending: true,
+      }),
+    ];
+
+    renderList({
+      activities: rows,
+      isConnected: true,
+      refundableVaultIds: new Set(["0xvault1"]),
+      onWithdraw,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /withdraw/i }));
+    expect(onWithdraw).toHaveBeenCalledWith("0xvault1");
+  });
+
+  it("v3 UI: leaves a row alone when its vaultId is not refundable", () => {
+    featureFlagsMock.isV3UiEnabled = true;
+    const rows = [makeRow({ id: "0xabc-3-deposit", vaultId: "0xvault2" })];
+
+    renderList({
+      activities: rows,
+      isConnected: true,
+      refundableVaultIds: new Set(["0xvault1"]),
+      onWithdraw: vi.fn(),
+    });
+
+    expect(screen.queryByRole("button", { name: /withdraw/i })).toBeNull();
+  });
+
+  it("v3 UI: never matches a refundable vault id against a row id that happens to equal it", () => {
+    featureFlagsMock.isV3UiEnabled = true;
+    // Row carries no vaultId (the indexer does not scope borrows to a vault),
+    // but its event id collides with a refundable vault id.
+    const rows = [makeRow({ id: "0xvault1", type: "Borrow" })];
+
+    renderList({
+      activities: rows,
+      isConnected: true,
+      refundableVaultIds: new Set(["0xvault1"]),
+      onWithdraw: vi.fn(),
+    });
+
+    expect(screen.queryByRole("button", { name: /withdraw/i })).toBeNull();
   });
 });

--- a/services/vault/src/components/Activity/__tests__/ActivityList.test.tsx
+++ b/services/vault/src/components/Activity/__tests__/ActivityList.test.tsx
@@ -143,16 +143,6 @@ describe("ActivityList", () => {
     ).toBeInTheDocument();
   });
 
-  it("renders the Aave logo next to the dropdown when connected", () => {
-    renderList({ activities: [], isConnected: true });
-    expect(screen.getByAltText("Aave")).toBeInTheDocument();
-  });
-
-  it("hides the Aave logo when disconnected", () => {
-    renderList({ activities: [], isConnected: false });
-    expect(screen.queryByAltText("Aave")).not.toBeInTheDocument();
-  });
-
   it("resets an active filter on disconnect so the disconnected empty state shows", () => {
     const rows = [
       makeRow({ id: "a", type: "Deposit" }),
@@ -191,14 +181,13 @@ describe("ActivityList", () => {
     ).toBeInTheDocument();
   });
 
-  it("v3 UI + disconnected: renders no in-page heading and no avatar/filter row", () => {
+  it("v3 UI + disconnected: renders no in-page heading and no filter row", () => {
     featureFlagsMock.isV3UiEnabled = true;
     renderList({ activities: [], isConnected: false });
 
     expect(
       screen.queryByRole("heading", { name: COPY.activity.pageTitle }),
     ).not.toBeInTheDocument();
-    expect(screen.queryByAltText("Aave")).not.toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: /show all/i }),
     ).not.toBeInTheDocument();
@@ -223,7 +212,7 @@ describe("ActivityList", () => {
     ).toBeInTheDocument();
   });
 
-  it("v3 UI + connected: renders no in-page heading but keeps the avatar and filter dropdown", () => {
+  it("v3 UI + connected: renders no in-page heading but keeps the filter dropdown", () => {
     featureFlagsMock.isV3UiEnabled = true;
     const rows = [makeRow({ id: "a", type: "Deposit" })];
     renderList({ activities: rows, isConnected: true });
@@ -231,7 +220,6 @@ describe("ActivityList", () => {
     expect(
       screen.queryByRole("heading", { name: COPY.activity.pageTitle }),
     ).not.toBeInTheDocument();
-    expect(screen.getByAltText("Aave")).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: /show all/i }),
     ).toBeInTheDocument();

--- a/services/vault/src/components/Activity/__tests__/ExpiredWithdrawButton.test.tsx
+++ b/services/vault/src/components/Activity/__tests__/ExpiredWithdrawButton.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * ExpiredWithdrawButton — the three states of the expired deposit's refund
+ * action. The gating itself lives in useRefundRowAction (shared with the
+ * Vaults page's inactive row); these lock in what this row renders for each
+ * of its answers.
+ */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { COPY } from "@/copy";
+import type { RefundRowAction } from "@/hooks/deposit/useRefundRowAction";
+
+const refundRowActionMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/hooks/deposit/useRefundRowAction", () => ({
+  useRefundRowAction: (vaultId: string) => refundRowActionMock(vaultId),
+}));
+
+import { ExpiredWithdrawButton } from "../ExpiredWithdrawButton";
+
+function renderButton(action: RefundRowAction, onWithdraw = vi.fn()) {
+  refundRowActionMock.mockReturnValue(action);
+  render(<ExpiredWithdrawButton vaultId="0xvault1" onWithdraw={onWithdraw} />);
+  return onWithdraw;
+}
+
+describe("ExpiredWithdrawButton", () => {
+  it("performs the refund for that vault when it is available", () => {
+    const onWithdraw = renderButton({ available: true, blockedTooltip: null });
+
+    const button = screen.getByRole("button", {
+      name: COPY.vaults.actions.withdraw,
+    });
+    expect(button).toBeEnabled();
+
+    fireEvent.click(button);
+    expect(onWithdraw).toHaveBeenCalledWith("0xvault1");
+  });
+
+  it("renders a disabled control while the refund is blocked", () => {
+    renderButton({ available: false, blockedTooltip: "Not matured yet" });
+
+    expect(
+      screen.getByRole("button", { name: COPY.vaults.actions.withdraw }),
+    ).toBeDisabled();
+  });
+
+  it("renders nothing when the row has no refund to offer", () => {
+    renderButton({ available: false, blockedTooltip: null });
+
+    expect(
+      screen.queryByRole("button", { name: COPY.vaults.actions.withdraw }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("asks about the vault it was given", () => {
+    renderButton({ available: false, blockedTooltip: null });
+
+    expect(refundRowActionMock).toHaveBeenCalledWith("0xvault1");
+  });
+});

--- a/services/vault/src/components/Activity/statusDot.ts
+++ b/services/vault/src/components/Activity/statusDot.ts
@@ -1,0 +1,11 @@
+/**
+ * Status dot colors for the v3 activity rows, from the Figma v3 foundation
+ * palette (foundation red/a400, amber/600, green/a400, warning/dark) — the same
+ * `--risk-*` channels the v3 risk card uses, so the two surfaces can't drift.
+ */
+export const STATUS_DOT = {
+  expired: "bg-risk-red",
+  pending: "bg-risk-amber",
+  settled: "bg-risk-green",
+  liquidated: "bg-risk-orange",
+} as const;

--- a/services/vault/src/components/deposit/RefundModal/__tests__/RefundModal.test.tsx
+++ b/services/vault/src/components/deposit/RefundModal/__tests__/RefundModal.test.tsx
@@ -8,6 +8,14 @@ import type { VaultActivity } from "@/types/activity";
 
 import { RefundModal } from "../index";
 
+// The shared v3 modal shell renders the app's top bar (network badge +
+// settings), whose graph reaches wallet-connector and can't be transformed
+// here. This suite is about the refund content inside it.
+vi.mock("@/components/shared/V3ModalShell", () => ({
+  V3ModalShell: ({ open, children }: { open: boolean; children: ReactNode }) =>
+    open ? <div>{children}</div> : null,
+}));
+
 vi.mock("@/services/vault/vaultRefundService", async (importOriginal) => {
   const actual =
     await importOriginal<

--- a/services/vault/src/components/deposit/RefundModal/index.tsx
+++ b/services/vault/src/components/deposit/RefundModal/index.tsx
@@ -66,7 +66,13 @@ export function RefundModal({
   // the wrong screen.
   if (previewQuery.isLoading) {
     return (
-      <V3ModalShell open={open} onClose={onClose}>
+      // The shell stretches its content box to full width; the spinner is a
+      // fixed-size inline element, so it needs centering of its own.
+      <V3ModalShell
+        open={open}
+        onClose={onClose}
+        contentClassName="flex justify-center"
+      >
         <Loader />
       </V3ModalShell>
     );

--- a/services/vault/src/components/deposit/RefundModal/index.tsx
+++ b/services/vault/src/components/deposit/RefundModal/index.tsx
@@ -1,6 +1,7 @@
-import { FullScreenDialog, Loader } from "@babylonlabs-io/core-ui";
+import { Loader } from "@babylonlabs-io/core-ui";
 import { useQuery } from "@tanstack/react-query";
 
+import { V3ModalShell } from "@/components/shared/V3ModalShell";
 import { useRefundState } from "@/hooks/deposit/useRefundState";
 import { getRefundPreview } from "@/services/vault/vaultRefundService";
 import type { VaultActivity } from "@/types/activity";
@@ -53,13 +54,9 @@ export function RefundModal({
       onClose();
     };
     return (
-      <FullScreenDialog
-        open={open}
-        onClose={handleDone}
-        className="items-center justify-center p-6"
-      >
+      <V3ModalShell open={open} onClose={handleDone}>
         <RefundSuccessContent refundTxId={refundTxId} onDone={handleDone} />
-      </FullScreenDialog>
+      </V3ModalShell>
     );
   }
 
@@ -69,13 +66,9 @@ export function RefundModal({
   // the wrong screen.
   if (previewQuery.isLoading) {
     return (
-      <FullScreenDialog
-        open={open}
-        onClose={onClose}
-        className="items-center justify-center p-6"
-      >
+      <V3ModalShell open={open} onClose={onClose}>
         <Loader />
-      </FullScreenDialog>
+      </V3ModalShell>
     );
   }
 
@@ -84,24 +77,16 @@ export function RefundModal({
   // letting the user sign a doomed transaction.
   if (previewQuery.data?.prePeginOnChain === false) {
     return (
-      <FullScreenDialog
-        open={open}
-        onClose={onClose}
-        className="items-center justify-center p-6"
-      >
+      <V3ModalShell open={open} onClose={onClose}>
         <RefundNotBroadcastContent onClose={onClose} />
-      </FullScreenDialog>
+      </V3ModalShell>
     );
   }
 
   // Block close while a broadcast is in flight to avoid dismissing the dialog
   // mid-signing.
   return (
-    <FullScreenDialog
-      open={open}
-      onClose={refunding ? undefined : onClose}
-      className="items-center justify-center p-6"
-    >
+    <V3ModalShell open={open} onClose={refunding ? undefined : onClose}>
       <RefundReviewContent
         amountSats={previewQuery.data?.amountSats ?? null}
         feeCapBasisSats={previewQuery.data?.feeCapBasisSats ?? null}
@@ -111,6 +96,6 @@ export function RefundModal({
         error={error}
         onConfirm={handleRefund}
       />
-    </FullScreenDialog>
+    </V3ModalShell>
   );
 }

--- a/services/vault/src/components/pages/Activity.tsx
+++ b/services/vault/src/components/pages/Activity.tsx
@@ -1,12 +1,8 @@
 import { Container, Loader } from "@babylonlabs-io/core-ui";
-import { useCallback, useMemo } from "react";
 import type { Hex } from "viem";
 
-import { PendingDepositModals } from "@/components/simple/PendingDepositModals";
-import { ProtocolParamsProvider } from "@/context/ProtocolParamsContext";
-import { PeginPollingProvider } from "@/context/deposit/PeginPollingContext";
-import { usePendingDeposits } from "@/hooks/usePendingDeposits";
-import type { ActivityRow } from "@/types/activityLog";
+import { ActivityListWithRefund } from "@/components/Activity/ActivityListWithRefund";
+import { FeatureFlags } from "@/config";
 
 import { useConnection, useETHWallet } from "../../context/wallet";
 import { useActivitiesWithPending } from "../../hooks/useActivitiesWithPending";
@@ -23,53 +19,7 @@ export default function Activity() {
     isConnected ? (address as Hex) : undefined,
   );
 
-  // The deposit lifecycle the Vaults page owns, reused here so an expired
-  // deposit's row can offer the same HTLC refund instead of sending the
-  // depositor to another page for it.
-  const deposits = usePendingDeposits();
-  const {
-    expiredActivities,
-    allActivities,
-    pendingPegins,
-    btcPublicKey,
-    ethAddress,
-    broadcastModal,
-    refundModal,
-  } = deposits;
-
-  // Deposits that expired before activation and have not been reclaimed yet,
-  // keyed by vault id. Correlate these against a row's `vaultId` and never its
-  // `id`: an indexed row's id is its event, not its vault (see ActivityLog).
-  const refundableVaultIds = useMemo(
-    () => new Set<string>(expiredActivities.map((a) => a.id)),
-    [expiredActivities],
-  );
-
-  // Such a row arrives from localStorage still marked pending; the contract
-  // status says otherwise, so correct it before it reaches the status column.
-  const rows = useMemo<ActivityRow[]>(
-    () =>
-      (activities ?? []).map((row) =>
-        row.kind === "row" && row.vaultId && refundableVaultIds.has(row.vaultId)
-          ? { ...row, isPending: false, isExpired: true }
-          : row,
-      ),
-    [activities, refundableVaultIds],
-  );
-
-  const handleWithdraw = useCallback(
-    (vaultId: string) => refundModal.handleRefundClick(vaultId),
-    [refundModal],
-  );
-
-  const list = (
-    <ActivityList
-      activities={rows}
-      isConnected={isConnected}
-      refundableVaultIds={refundableVaultIds}
-      onWithdraw={handleWithdraw}
-    />
-  );
+  const rows = activities ?? [];
 
   return (
     <Container
@@ -81,28 +31,12 @@ export default function Activity() {
           <div className="flex items-center justify-center py-12">
             <Loader />
           </div>
-        ) : refundableVaultIds.size === 0 ? (
-          // No refund to offer: render the feed bare. ProtocolParamsProvider
-          // below BLOCKS its children until the contract params resolve, so
-          // wrapping it around the list unconditionally would hold the whole
-          // page — including the disconnected empty state — behind a network
-          // read the feed does not need.
-          list
+        ) : FeatureFlags.isV3UiEnabled ? (
+          // Only v3 offers the expired deposit's refund from this page, so
+          // only v3 mounts the deposit lifecycle behind it.
+          <ActivityListWithRefund activities={rows} isConnected={isConnected} />
         ) : (
-          <ProtocolParamsProvider>
-            <PeginPollingProvider
-              activities={allActivities}
-              pendingPegins={pendingPegins}
-              btcPublicKey={btcPublicKey}
-            >
-              {list}
-              <PendingDepositModals
-                broadcastModal={broadcastModal}
-                refundModal={refundModal}
-                ethAddress={ethAddress}
-              />
-            </PeginPollingProvider>
-          </ProtocolParamsProvider>
+          <ActivityList activities={rows} isConnected={isConnected} />
         )}
       </div>
     </Container>

--- a/services/vault/src/components/pages/Activity.tsx
+++ b/services/vault/src/components/pages/Activity.tsx
@@ -37,10 +37,10 @@ export default function Activity() {
     refundModal,
   } = deposits;
 
-  // Expired deposits are keyed by vault id, the same id the localStorage-backed
-  // pending rows carry — so a row in this set is a deposit that expired before
-  // activation and has not been reclaimed yet.
-  const refundableDepositIds = useMemo(
+  // Deposits that expired before activation and have not been reclaimed yet,
+  // keyed by vault id. Correlate these against a row's `vaultId` and never its
+  // `id`: an indexed row's id is its event, not its vault (see ActivityLog).
+  const refundableVaultIds = useMemo(
     () => new Set<string>(expiredActivities.map((a) => a.id)),
     [expiredActivities],
   );
@@ -50,15 +50,15 @@ export default function Activity() {
   const rows = useMemo<ActivityRow[]>(
     () =>
       (activities ?? []).map((row) =>
-        row.kind === "row" && refundableDepositIds.has(row.id)
+        row.kind === "row" && row.vaultId && refundableVaultIds.has(row.vaultId)
           ? { ...row, isPending: false, isExpired: true }
           : row,
       ),
-    [activities, refundableDepositIds],
+    [activities, refundableVaultIds],
   );
 
   const handleWithdraw = useCallback(
-    (depositId: string) => refundModal.handleRefundClick(depositId),
+    (vaultId: string) => refundModal.handleRefundClick(vaultId),
     [refundModal],
   );
 
@@ -66,7 +66,7 @@ export default function Activity() {
     <ActivityList
       activities={rows}
       isConnected={isConnected}
-      refundableDepositIds={refundableDepositIds}
+      refundableVaultIds={refundableVaultIds}
       onWithdraw={handleWithdraw}
     />
   );
@@ -81,7 +81,7 @@ export default function Activity() {
           <div className="flex items-center justify-center py-12">
             <Loader />
           </div>
-        ) : refundableDepositIds.size === 0 ? (
+        ) : refundableVaultIds.size === 0 ? (
           // No refund to offer: render the feed bare. ProtocolParamsProvider
           // below BLOCKS its children until the contract params resolve, so
           // wrapping it around the list unconditionally would hold the whole

--- a/services/vault/src/components/pages/Activity.tsx
+++ b/services/vault/src/components/pages/Activity.tsx
@@ -1,5 +1,12 @@
 import { Container, Loader } from "@babylonlabs-io/core-ui";
+import { useCallback, useMemo } from "react";
 import type { Hex } from "viem";
+
+import { PendingDepositModals } from "@/components/simple/PendingDepositModals";
+import { ProtocolParamsProvider } from "@/context/ProtocolParamsContext";
+import { PeginPollingProvider } from "@/context/deposit/PeginPollingContext";
+import { usePendingDeposits } from "@/hooks/usePendingDeposits";
+import type { ActivityRow } from "@/types/activityLog";
 
 import { useConnection, useETHWallet } from "../../context/wallet";
 import { useActivitiesWithPending } from "../../hooks/useActivitiesWithPending";
@@ -16,6 +23,54 @@ export default function Activity() {
     isConnected ? (address as Hex) : undefined,
   );
 
+  // The deposit lifecycle the Vaults page owns, reused here so an expired
+  // deposit's row can offer the same HTLC refund instead of sending the
+  // depositor to another page for it.
+  const deposits = usePendingDeposits();
+  const {
+    expiredActivities,
+    allActivities,
+    pendingPegins,
+    btcPublicKey,
+    ethAddress,
+    broadcastModal,
+    refundModal,
+  } = deposits;
+
+  // Expired deposits are keyed by vault id, the same id the localStorage-backed
+  // pending rows carry — so a row in this set is a deposit that expired before
+  // activation and has not been reclaimed yet.
+  const refundableDepositIds = useMemo(
+    () => new Set<string>(expiredActivities.map((a) => a.id)),
+    [expiredActivities],
+  );
+
+  // Such a row arrives from localStorage still marked pending; the contract
+  // status says otherwise, so correct it before it reaches the status column.
+  const rows = useMemo<ActivityRow[]>(
+    () =>
+      (activities ?? []).map((row) =>
+        row.kind === "row" && refundableDepositIds.has(row.id)
+          ? { ...row, isPending: false, isExpired: true }
+          : row,
+      ),
+    [activities, refundableDepositIds],
+  );
+
+  const handleWithdraw = useCallback(
+    (depositId: string) => refundModal.handleRefundClick(depositId),
+    [refundModal],
+  );
+
+  const list = (
+    <ActivityList
+      activities={rows}
+      isConnected={isConnected}
+      refundableDepositIds={refundableDepositIds}
+      onWithdraw={handleWithdraw}
+    />
+  );
+
   return (
     <Container
       as="main"
@@ -26,11 +81,28 @@ export default function Activity() {
           <div className="flex items-center justify-center py-12">
             <Loader />
           </div>
+        ) : refundableDepositIds.size === 0 ? (
+          // No refund to offer: render the feed bare. ProtocolParamsProvider
+          // below BLOCKS its children until the contract params resolve, so
+          // wrapping it around the list unconditionally would hold the whole
+          // page — including the disconnected empty state — behind a network
+          // read the feed does not need.
+          list
         ) : (
-          <ActivityList
-            activities={activities ?? []}
-            isConnected={isConnected}
-          />
+          <ProtocolParamsProvider>
+            <PeginPollingProvider
+              activities={allActivities}
+              pendingPegins={pendingPegins}
+              btcPublicKey={btcPublicKey}
+            >
+              {list}
+              <PendingDepositModals
+                broadcastModal={broadcastModal}
+                refundModal={refundModal}
+                ethAddress={ethAddress}
+              />
+            </PeginPollingProvider>
+          </ProtocolParamsProvider>
         )}
       </div>
     </Container>

--- a/services/vault/src/components/pages/__tests__/Activity.test.tsx
+++ b/services/vault/src/components/pages/__tests__/Activity.test.tsx
@@ -46,16 +46,21 @@ vi.mock("@/components/Wallet", () => ({
 // whose graph reaches the WASM package and cannot be transformed here. Stub
 // the hook, its polling/params providers and the modals — the refund flow has
 // its own coverage; these tests are about wallet gating.
+const usePendingDepositsMock = vi.hoisted(() => vi.fn());
+
 vi.mock("@/hooks/usePendingDeposits", () => ({
-  usePendingDeposits: () => ({
-    expiredActivities: [],
-    allActivities: [],
-    pendingPegins: [],
-    btcPublicKey: undefined,
-    ethAddress: undefined,
-    broadcastModal: {},
-    refundModal: { handleRefundClick: vi.fn() },
-  }),
+  usePendingDeposits: () => {
+    usePendingDepositsMock();
+    return {
+      expiredActivities: [],
+      allActivities: [],
+      pendingPegins: [],
+      btcPublicKey: undefined,
+      ethAddress: undefined,
+      broadcastModal: {},
+      refundModal: { handleRefundClick: vi.fn() },
+    };
+  },
 }));
 
 vi.mock("@/context/ProtocolParamsContext", () => ({
@@ -244,5 +249,39 @@ describe("Activity page — wallet gating", () => {
     expect(
       screen.queryByTestId("activity-empty-state"),
     ).not.toBeInTheDocument();
+  });
+
+  it("v2: does not mount the deposit lifecycle behind the expired-deposit refund", () => {
+    featureFlagsMock.isV3UiEnabled = false;
+    useConnectionMock.mockReturnValue({
+      isConnected: true,
+      btcConnected: true,
+      ethConnected: true,
+    });
+    useETHWalletMock.mockReturnValue({
+      address: "0xabc0000000000000000000000000000000000001",
+      connected: true,
+    });
+
+    renderActivity();
+
+    expect(usePendingDepositsMock).not.toHaveBeenCalled();
+  });
+
+  it("v3: mounts the deposit lifecycle so an expired deposit can offer its refund", () => {
+    featureFlagsMock.isV3UiEnabled = true;
+    useConnectionMock.mockReturnValue({
+      isConnected: true,
+      btcConnected: true,
+      ethConnected: true,
+    });
+    useETHWalletMock.mockReturnValue({
+      address: "0xabc0000000000000000000000000000000000001",
+      connected: true,
+    });
+
+    renderActivity();
+
+    expect(usePendingDepositsMock).toHaveBeenCalled();
   });
 });

--- a/services/vault/src/components/pages/__tests__/Activity.test.tsx
+++ b/services/vault/src/components/pages/__tests__/Activity.test.tsx
@@ -42,6 +42,37 @@ vi.mock("@/components/Wallet", () => ({
   Connect: () => <button type="button">Connect</button>,
 }));
 
+// The expired-deposit Withdraw reuses the Vaults page's refund machinery,
+// whose graph reaches the WASM package and cannot be transformed here. Stub
+// the hook, its polling/params providers and the modals — the refund flow has
+// its own coverage; these tests are about wallet gating.
+vi.mock("@/hooks/usePendingDeposits", () => ({
+  usePendingDeposits: () => ({
+    expiredActivities: [],
+    allActivities: [],
+    pendingPegins: [],
+    btcPublicKey: undefined,
+    ethAddress: undefined,
+    broadcastModal: {},
+    refundModal: { handleRefundClick: vi.fn() },
+  }),
+}));
+
+vi.mock("@/context/ProtocolParamsContext", () => ({
+  ProtocolParamsProvider: ({ children }: { children: React.ReactNode }) =>
+    children,
+}));
+
+vi.mock("@/context/deposit/PeginPollingContext", () => ({
+  PeginPollingProvider: ({ children }: { children: React.ReactNode }) =>
+    children,
+  useDepositPollingResult: () => undefined,
+}));
+
+vi.mock("@/components/simple/PendingDepositModals", () => ({
+  PendingDepositModals: () => null,
+}));
+
 import Activity from "../Activity";
 
 function renderActivity() {

--- a/services/vault/src/components/shared/ListRow.tsx
+++ b/services/vault/src/components/shared/ListRow.tsx
@@ -10,6 +10,8 @@
 
 import type { ReactNode } from "react";
 
+import { CARD_SHELL_CLASS } from "@/components/shared/layoutClasses";
+
 /** Bordered row card shared by the vault and loan lists. */
 export function ListRowCard({
   children,
@@ -21,7 +23,7 @@ export function ListRowCard({
   return (
     <div
       data-testid={testId}
-      className="flex w-full flex-wrap items-center gap-x-4 gap-y-3 rounded-lg border border-secondary-strokeLight bg-secondary-highlight p-4 dark:bg-[#202020]"
+      className={`${CARD_SHELL_CLASS} flex flex-wrap items-center gap-x-4 gap-y-3 p-4`}
     >
       {children}
     </div>

--- a/services/vault/src/components/shared/V3ModalShell.tsx
+++ b/services/vault/src/components/shared/V3ModalShell.tsx
@@ -21,7 +21,7 @@ import { IoClose } from "react-icons/io5";
 import { twJoin } from "tailwind-merge";
 
 import { NetworkBadge } from "@/components/shared/NetworkBadge";
-import { PAGE_CONTENT_CLASS } from "@/components/shared/layoutClasses";
+import { MODAL_TOP_BAR_GUTTER_CLASS } from "@/components/shared/layoutClasses";
 import { FeatureFlags } from "@/config";
 import { COPY } from "@/copy";
 
@@ -64,16 +64,18 @@ export function V3ModalShell({
       open={open}
       onClose={onClose}
       disableEscapeClose={disableEscapeClose}
-      // The shell renders its own header aligned to the page column, so hide
-      // FullScreenDialog's fixed built-in close/back button (onClose is still
-      // wired for backdrop + Escape dismissal).
+      // The shell renders its own header, so hide FullScreenDialog's fixed
+      // built-in close/back button (onClose is still wired for backdrop +
+      // Escape dismissal).
       closeButtonClassName="!hidden"
     >
-      {/* Header row: close on the left, network + settings on the right, both
-          on the page's content column so the modal chrome lines up with the
-          page underneath. */}
+      {/* Header row: close on the left, network + settings on the right, on
+          the design's 120px inset so every modal's chrome lands in the same
+          place. As a stretched flex child the row fills the dialog minus that
+          gutter on its own — it needs no width class, which
+          MODAL_TOP_BAR_GUTTER_CLASS explains is just as well. */}
       <div
-        className={`mx-auto flex w-full items-center justify-between py-4 ${PAGE_CONTENT_CLASS}`}
+        className={`flex items-center justify-between py-4 ${MODAL_TOP_BAR_GUTTER_CLASS}`}
       >
         {onClose ? (
           <button

--- a/services/vault/src/components/shared/buttonClasses.ts
+++ b/services/vault/src/components/shared/buttonClasses.ts
@@ -14,6 +14,10 @@ export const PRIMARY_BUTTON_CLASS =
 export const NEUTRAL_ROW_BUTTON_CLASS =
   "ml-auto flex h-9 min-w-[120px] shrink-0 items-center justify-center whitespace-nowrap rounded-lg bg-secondary-strokeLight px-4 text-sm leading-[1.43] tracking-[0.17px] text-accent-primary transition-[filter] enabled:hover:brightness-110 disabled:cursor-not-allowed disabled:text-accent-disabled";
 
+/** 36px-tall destructive (red) action button — the expired deposit's Withdraw. */
+export const ERROR_ROW_BUTTON_CLASS =
+  "ml-auto flex h-9 min-w-[120px] shrink-0 items-center justify-center whitespace-nowrap rounded-lg bg-error-dark px-4 text-sm leading-[1.43] tracking-[0.17px] text-accent-contrast transition-[filter] enabled:hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-30";
+
 /** 36px-tall primary (orange) action button. */
 export const PRIMARY_ROW_BUTTON_CLASS =
   "ml-auto flex h-9 min-w-[120px] shrink-0 items-center justify-center whitespace-nowrap rounded-lg bg-secondary-main px-4 text-sm leading-[1.43] tracking-[0.17px] text-accent-contrast transition-[filter] enabled:hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-30";

--- a/services/vault/src/components/shared/buttonClasses.ts
+++ b/services/vault/src/components/shared/buttonClasses.ts
@@ -14,9 +14,12 @@ export const PRIMARY_BUTTON_CLASS =
 export const NEUTRAL_ROW_BUTTON_CLASS =
   "ml-auto flex h-9 min-w-[120px] shrink-0 items-center justify-center whitespace-nowrap rounded-lg bg-secondary-strokeLight px-4 text-sm leading-[1.43] tracking-[0.17px] text-accent-primary transition-[filter] enabled:hover:brightness-110 disabled:cursor-not-allowed disabled:text-accent-disabled";
 
-/** 36px-tall destructive (red) action button — the expired deposit's Withdraw. */
+/** 36px-tall destructive (red) action button — the expired deposit's Withdraw
+ *  (Figma 10176:27509 puts this one row action on #C62828, unlike the Vaults
+ *  page's orange). Only ever rendered enabled: a blocked refund falls back to
+ *  the disabled NEUTRAL_ROW_BUTTON_CLASS, so this carries no disabled styles. */
 export const ERROR_ROW_BUTTON_CLASS =
-  "ml-auto flex h-9 min-w-[120px] shrink-0 items-center justify-center whitespace-nowrap rounded-lg bg-error-dark px-4 text-sm leading-[1.43] tracking-[0.17px] text-accent-contrast transition-[filter] enabled:hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-30";
+  "ml-auto flex h-9 min-w-[120px] shrink-0 items-center justify-center whitespace-nowrap rounded-lg bg-error-dark px-4 text-sm leading-[1.43] tracking-[0.17px] text-accent-contrast transition-[filter] hover:brightness-110";
 
 /** 36px-tall primary (orange) action button. */
 export const PRIMARY_ROW_BUTTON_CLASS =

--- a/services/vault/src/components/shared/layoutClasses.ts
+++ b/services/vault/src/components/shared/layoutClasses.ts
@@ -6,6 +6,19 @@
 import featureFlags from "@/config/featureFlags";
 
 /**
+ * Horizontal inset of a full-screen modal's top bar. Figma's shared Header
+ * component puts its content 120px from each edge, unchanged across the 1440
+ * and 1512 frames, so every modal's close / network / settings land in the
+ * same place. Below `md` that gutter would swallow a phone screen, so it drops
+ * to the page gutter there.
+ *
+ * A margin, and deliberately not PAGE_CONTENT_CLASS: that class carries
+ * `!w-auto` to undo a core-ui `container`, and on an ordinary element the
+ * `!important` beats `w-full` and collapses the box to its content width.
+ */
+export const MODAL_TOP_BAR_GUTTER_CLASS = "mx-10 md:mx-[120px]";
+
+/**
  * Content width + horizontal inset shared by the navbar and every top-level page
  * container; `!` overrides core-ui `<Container>`/`Header`'s default `container`
  * width so the navbar and body stay the same width.

--- a/services/vault/src/components/shared/layoutClasses.ts
+++ b/services/vault/src/components/shared/layoutClasses.ts
@@ -22,3 +22,12 @@ export const PAGE_CONTENT_CLASS = featureFlags.isV3UiEnabled
 
 /** Width + vertical padding for the dashboard section summary cards. */
 export const SUMMARY_CARD_CLASS = "w-full border-0 !py-[34px]";
+
+/**
+ * Chrome of a v3 list card — border, radius, surface — with no padding or
+ * layout of its own. For a single row prefer `ListRowCard`, which adds that
+ * row's padding and flex; this is for a card holding several
+ * divider-separated rows, where the padding belongs to the card.
+ */
+export const CARD_SHELL_CLASS =
+  "w-full overflow-hidden rounded-lg border border-secondary-strokeLight bg-secondary-highlight dark:bg-[#202020]";

--- a/services/vault/src/components/simple/PendingDepositSection.tsx
+++ b/services/vault/src/components/simple/PendingDepositSection.tsx
@@ -8,17 +8,13 @@
  *  - When expanded, shows individual deposit sub-cards
  */
 
-import {
-  Avatar,
-  Card,
-  FullScreenDialog,
-  Heading,
-} from "@babylonlabs-io/core-ui";
+import { Avatar, Card, Heading } from "@babylonlabs-io/core-ui";
 import { useCallback, useMemo, useState } from "react";
 import type { Address, Hex } from "viem";
 
 import { ExpandablePanel, ExpandMenuButton } from "@/components/shared";
 import { SUMMARY_CARD_CLASS } from "@/components/shared/layoutClasses";
+import { V3ModalShell } from "@/components/shared/V3ModalShell";
 import { getNetworkConfigBTC } from "@/config";
 import { PeginPollingProvider } from "@/context/deposit/PeginPollingContext";
 import { ProtocolParamsProvider } from "@/context/ProtocolParamsContext";
@@ -225,11 +221,7 @@ export function PendingDepositSection() {
 
         {/* Multistepper view — opened by clicking a pending deposit card. */}
         {viewingBatch && ethAddress && (
-          <FullScreenDialog
-            open
-            onClose={handleViewingClose}
-            className="items-center justify-center p-6"
-          >
+          <V3ModalShell open onClose={handleViewingClose}>
             <div className="mx-auto w-full max-w-[520px]">
               <PostDepositContinuationContent
                 vaultIds={viewingBatch}
@@ -237,7 +229,7 @@ export function PendingDepositSection() {
                 onClose={handleViewingClose}
               />
             </div>
-          </FullScreenDialog>
+          </V3ModalShell>
         )}
       </PeginPollingProvider>
     </ProtocolParamsProvider>

--- a/services/vault/src/components/vaults/VaultsLifecycleSections.tsx
+++ b/services/vault/src/components/vaults/VaultsLifecycleSections.tsx
@@ -15,19 +15,15 @@
  * is instantiated once.
  */
 
-import {
-  FullScreenDialog,
-  Heading,
-  Hint,
-  InfoIcon,
-  Loader,
-} from "@babylonlabs-io/core-ui";
+import { Heading, Hint, InfoIcon, Loader } from "@babylonlabs-io/core-ui";
 import { type ReactNode, useCallback, useState } from "react";
 import type { Address, Hex } from "viem";
 
 import { ApplicationLogo } from "@/components/ApplicationLogo";
 import { getActionStatus } from "@/components/deposit/actionStatus";
 import { CopyableHash } from "@/components/shared/CopyableHash";
+import { ListRowCard } from "@/components/shared/ListRow";
+import { V3ModalShell } from "@/components/shared/V3ModalShell";
 import {
   NEUTRAL_ROW_BUTTON_CLASS,
   PRIMARY_ROW_BUTTON_CLASS,
@@ -295,7 +291,7 @@ function InactiveRow({
   const hash = activity.prePeginTxHash ?? activity.peginTxHash;
 
   return (
-    <div className="flex w-full flex-wrap items-center gap-x-4 gap-y-3 rounded-lg border border-secondary-strokeLight bg-secondary-highlight p-4 dark:bg-[#202020]">
+    <ListRowCard>
       {/* Amount + refund maturity */}
       <div className="flex w-[180px] shrink-0 items-center gap-2">
         <ApplicationLogo
@@ -374,7 +370,7 @@ function InactiveRow({
           </button>
         </Hint>
       )}
-    </div>
+    </ListRowCard>
   );
 }
 
@@ -534,11 +530,7 @@ export function VaultsLifecycleSections({
         />
 
         {viewingBatch && ethAddress && (
-          <FullScreenDialog
-            open
-            onClose={handleViewingClose}
-            className="items-center justify-center p-6"
-          >
+          <V3ModalShell open onClose={handleViewingClose}>
             <div className="mx-auto w-full max-w-[520px]">
               <PostDepositContinuationContent
                 vaultIds={viewingBatch}
@@ -546,7 +538,7 @@ export function VaultsLifecycleSections({
                 onClose={handleViewingClose}
               />
             </div>
-          </FullScreenDialog>
+          </V3ModalShell>
         )}
       </PeginPollingProvider>
     </ProtocolParamsProvider>

--- a/services/vault/src/components/vaults/VaultsLifecycleSections.tsx
+++ b/services/vault/src/components/vaults/VaultsLifecycleSections.tsx
@@ -43,11 +43,11 @@ import {
 } from "@/context/deposit/PeginPollingContext";
 import { COPY } from "@/copy";
 import { getDemoStepperBatch } from "@/dev/demoDeposit";
+import { useRefundRowAction } from "@/hooks/deposit/useRefundRowAction";
 import type { usePendingDeposits } from "@/hooks/usePendingDeposits";
 import {
   canPerformAction,
   getPeginDisplayStep,
-  isRefundInFlightOrSettled,
   PeginAction,
   type PeginState,
 } from "@/models/peginStateMachine";
@@ -268,23 +268,11 @@ function InactiveRow({
     provider?.name ?? truncateHash(activity.providers[0]?.id ?? "");
 
   const peginState = result?.peginState;
-  const actionStatus: ReturnType<typeof getActionStatus> = result
-    ? getActionStatus(result)
-    : { type: "noAction" };
   // Product decision (#2041): the inactive vault's Withdraw performs the HTLC
-  // refund. Only the refund action surfaces here — a refund already in flight
-  // (or settled) leaves the row without an action.
-  const isRefundAvailable =
-    actionStatus.type === "available" &&
-    actionStatus.action.action === PeginAction.REFUND_HTLC;
-  // The narrowed disabled status, kept whole so the JSX below can read its
-  // tooltip without re-checking the discriminant.
-  const blockedRefundStatus =
-    actionStatus.type === "disabled" &&
-    actionStatus.action?.action === PeginAction.REFUND_HTLC &&
-    !(peginState ? isRefundInFlightOrSettled(peginState) : false)
-      ? actionStatus
-      : null;
+  // refund, on the same terms the Activity feed's expired row offers it.
+  const { available: isRefundAvailable, blockedTooltip } = useRefundRowAction(
+    activity.id,
+  );
 
   // Pre-PegIn first: an expired deposit never activated, so the Pre-PegIn tx
   // is the one that exists (active rows prefer the opposite).
@@ -363,8 +351,8 @@ function InactiveRow({
           {COPY.vaults.actions.withdraw}
         </button>
       )}
-      {blockedRefundStatus && (
-        <Hint tooltip={blockedRefundStatus.tooltip} attachToChildren>
+      {blockedTooltip && (
+        <Hint tooltip={blockedTooltip} attachToChildren>
           <button type="button" disabled className={NEUTRAL_ROW_BUTTON_CLASS}>
             {COPY.vaults.actions.withdraw}
           </button>

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -1426,6 +1426,9 @@ export const COPY = {
     } satisfies Record<ActivityType, string>,
     hashPending: "Pending…",
     expiredTooltip: "Deposit expired",
+    // Accessible name for the v3 row's hash link, which opens the explorer.
+    viewTransaction: (chain: string, hash: string) =>
+      `View ${chain} transaction ${hash} in explorer`,
     // Labels for the two child rows nested inside a LiquidationGroupRow.
     liquidation: {
       collateralLabel: "Collateral Liquidated",

--- a/services/vault/src/globals.css
+++ b/services/vault/src/globals.css
@@ -28,6 +28,10 @@ html {
   --risk-amber: 247 147 26;
   --risk-green: 21 183 104;
   --risk-muted: 176 176 176;
+  /* Liquidation status (Figma warning/dark) — the activity feed's partially /
+   * fully liquidated dot. Distinct from --risk-amber, which reads as caution
+   * rather than a liquidation that already happened. */
+  --risk-orange: 248 97 42;
   /* Motion spec — Modals (Figma 7831:25100 §1) */
   --motion-duration-modal: 220ms;
   --motion-duration-modal-out: 180ms;

--- a/services/vault/src/hooks/deposit/useRefundRowAction.ts
+++ b/services/vault/src/hooks/deposit/useRefundRowAction.ts
@@ -1,0 +1,54 @@
+/**
+ * useRefundRowAction — whether a list row may offer the HTLC refund.
+ *
+ * The Vaults page's inactive-vault row and the Activity feed's expired-deposit
+ * row present the same protocol action, so they must agree on when it is
+ * offered. That decision lives here rather than in either row (#2041):
+ *
+ *  - `available` — the refund can be performed now.
+ *  - `blockedTooltip` — the refund is the row's action but is not performable
+ *    yet; the row shows a disabled control explaining why. Null once a refund
+ *    is in flight or settled, which leaves the row with no action at all
+ *    rather than a permanently disabled button.
+ *
+ * Must be called inside a PeginPollingProvider — it reads that deposit's poll
+ * result.
+ */
+
+import { getActionStatus } from "@/components/deposit/actionStatus";
+import { useDepositPollingResult } from "@/context/deposit/PeginPollingContext";
+import {
+  isRefundInFlightOrSettled,
+  PeginAction,
+} from "@/models/peginStateMachine";
+
+export interface RefundRowAction {
+  available: boolean;
+  blockedTooltip: string | null;
+}
+
+export function useRefundRowAction(vaultId: string): RefundRowAction {
+  const result = useDepositPollingResult(vaultId);
+  const actionStatus: ReturnType<typeof getActionStatus> = result
+    ? getActionStatus(result)
+    : { type: "noAction" };
+
+  if (
+    actionStatus.type === "available" &&
+    actionStatus.action.action === PeginAction.REFUND_HTLC
+  ) {
+    return { available: true, blockedTooltip: null };
+  }
+
+  const isBlocked =
+    actionStatus.type === "disabled" &&
+    actionStatus.action?.action === PeginAction.REFUND_HTLC &&
+    !(result?.peginState
+      ? isRefundInFlightOrSettled(result.peginState)
+      : false);
+
+  return {
+    available: false,
+    blockedTooltip: isBlocked ? actionStatus.tooltip : null,
+  };
+}

--- a/services/vault/src/services/activity/pendingActivities.ts
+++ b/services/vault/src/services/activity/pendingActivities.ts
@@ -30,6 +30,8 @@ function convertPendingPeginToActivity(
   return {
     kind: "row",
     id: pending.id,
+    // A pending peg-in's storage id IS the derived vault id.
+    vaultId: pending.id,
     date: new Date(pending.timestamp),
     type: PENDING_DEPOSIT_TYPE,
     tokenIcon: btcConfig.icon,

--- a/services/vault/src/services/activity/projection.ts
+++ b/services/vault/src/services/activity/projection.ts
@@ -207,6 +207,7 @@ export function projectRefundedDeposit(
   return {
     kind: "row",
     id: item.id,
+    vaultId: item.vaultId,
     date: new Date(parseInt(item.timestamp, 10) * 1000),
     tokenIcon: VAULT_COLLATERAL_ASSET.icon,
     type: "Deposit",
@@ -256,6 +257,7 @@ export function projectStandardRow(
   return {
     kind: "row",
     id: item.id,
+    vaultId: item.vaultId,
     date: new Date(parseInt(item.timestamp, 10) * 1000),
     tokenIcon,
     type: STANDARD_TYPE_LABEL[item.type],

--- a/services/vault/src/types/activityLog.ts
+++ b/services/vault/src/types/activityLog.ts
@@ -47,8 +47,20 @@ export interface ActivityAmount {
  */
 export interface ActivityLog {
   kind: "row";
-  /** Unique identifier for the activity */
+  /**
+   * Unique identifier for the activity. NOT a stable id space across sources:
+   * an indexed row is keyed by its event (`txHash-logIndex-type`), a pending
+   * row from localStorage by the derived vault id. Never match it against a
+   * vault id — use `vaultId` for that.
+   */
   id: string;
+  /**
+   * The on-chain vault this row belongs to, where the source knows it. The
+   * only field safe to correlate with vault-keyed state (e.g. the deposit
+   * lifecycle's refundable-expired set). Null on rows the indexer does not
+   * scope to a vault, such as a borrow or repay against the position.
+   */
+  vaultId?: string | null;
   /** Timestamp of the activity */
   date: Date;
   /** Source URL for the left avatar. BTC icon for native rows, reserve token icon for borrow/repay. */

--- a/services/vault/tailwind.config.ts
+++ b/services/vault/tailwind.config.ts
@@ -23,6 +23,7 @@ const config: Config = {
         "risk-amber": "rgb(var(--risk-amber) / <alpha-value>)",
         "risk-green": "rgb(var(--risk-green) / <alpha-value>)",
         "risk-muted": "rgb(var(--risk-muted) / <alpha-value>)",
+        "risk-orange": "rgb(var(--risk-orange) / <alpha-value>)",
       },
     },
   },


### PR DESCRIPTION
## Screenshot
<img width="1216" height="548" alt="Screenshot 2026-07-23 at 22 01 42" src="https://github.com/user-attachments/assets/5a77b679-aece-41d9-b8b7-19eb4472bb36" />
<img width="1217" height="836" alt="Screenshot 2026-07-23 at 22 01 39" src="https://github.com/user-attachments/assets/5c036fb1-f0e3-4c8f-be46-2a7a83346faf" />

Activity page:
- Move the "Show all" filter to the left of the row and drop the Aave avatar beside it; the dropdown opens bottom-start so its 200px menu no longer runs off-screen from a left-aligned trigger.
- Give each row its own card, the same one the Vaults tab uses, instead of bundling a whole date group into one divider-separated card. The grouped treatment is now reserved for a liquidation's child events, which is the only place the design uses it.
- Rebuild the row on the Figma column spec: 180px cells, body-2 text, 12px status dot with a 4px gap, timestamp in the secondary colour.
- Replace copy-to-clipboard on the row hash with a single open-in-explorer link (ActivityHashLink). CopyableHash is unchanged and still used everywhere else; the new component is reached only from the v3 rows.
- Offer the HTLC refund on an expired deposit's row. The button reuses the Vaults inactive-row gating, so it appears only while the refund is actually available and renders disabled-with-tooltip while blocked. Rows matching a refundable deposit report "Expired" rather than "Pending".

Loans page:
- Rebuild the active-loan card on the shared row card. The metrics group now shrinks before the actions do, so Borrow / Repay stay on the row instead of wrapping underneath.

Full-screen modals:
- Add FullScreenModal, the base every full-screen surface now goes through. It supplies the top bar the success screens had lost entirely — close on the left, network badge and settings on the right — and insets it to the 120px the design's shared Header uses, correcting a bar that was flush at 16px on every modal.

Status dots resolve to the v3 foundation palette by hex, reusing the existing --risk-* channels; the liquidation orange had no token, so --risk-orange joins them. The row card class the Vaults sections had duplicated moves to layoutClasses so the three lists cannot drift.