### PR TITLE
fix(vault): stop two expected conditions from flooding Sentry

### DIFF
--- a/services/vault/src/clients/eth-contract/chainlink/__tests__/query.test.ts
+++ b/services/vault/src/clients/eth-contract/chainlink/__tests__/query.test.ts
@@ -36,7 +36,11 @@ vi.mock("@/config/network", () => ({
 }));
 
 import type { ChainlinkRoundData } from "../query";
-import { getTokenPrices, isPriceFresh } from "../query";
+import {
+  getTokenPrices,
+  isPriceFresh,
+  resetStaleFeedReporting,
+} from "../query";
 
 /** Simulated Chainlink round ID for test fixtures */
 const ROUND_ID = 100n;
@@ -117,6 +121,8 @@ describe("isPriceFresh", () => {
 describe("getTokenPrices", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // The stale-feed dedup store is module-scoped and outlives a single test.
+    resetStaleFeedReporting();
   });
 
   /**
@@ -247,6 +253,65 @@ describe("getTokenPrices", () => {
     const result = await getTokenPrices(["BTC"]);
 
     expect(result.metadata["BTC"].isStale).toBe(true);
+  });
+
+  it("emits the stale event once per stale episode, not on every read", async () => {
+    const { logger } = await import("@/infrastructure");
+    const nowSeconds = BigInt(Math.floor(Date.now() / 1000));
+    const staleFeed = () =>
+      makeFeedResult(BTC_ANSWER_8_DECIMALS, STANDARD_DECIMALS, {
+        updatedAt: nowSeconds - TWO_HOURS_SECONDS,
+      });
+
+    mockMulticall.mockResolvedValueOnce(staleFeed());
+    await getTokenPrices(["BTC"]);
+    mockMulticall.mockResolvedValueOnce(staleFeed());
+    await getTokenPrices(["BTC"]);
+
+    const staleEvents = vi
+      .mocked(logger.event)
+      .mock.calls.filter(([m]) => typeof m === "string" && m.includes("stale"));
+    expect(staleEvents).toHaveLength(1);
+  });
+
+  it("still marks metadata stale on a deduped read (only the event is suppressed)", async () => {
+    const nowSeconds = BigInt(Math.floor(Date.now() / 1000));
+    const staleFeed = () =>
+      makeFeedResult(BTC_ANSWER_8_DECIMALS, STANDARD_DECIMALS, {
+        updatedAt: nowSeconds - TWO_HOURS_SECONDS,
+      });
+
+    mockMulticall.mockResolvedValueOnce(staleFeed());
+    await getTokenPrices(["BTC"]);
+    mockMulticall.mockResolvedValueOnce(staleFeed());
+    const second = await getTokenPrices(["BTC"]);
+
+    // The UI's stale badge reads metadata, which must still report stale even
+    // though the second read emitted no event.
+    expect(second.metadata["BTC"].isStale).toBe(true);
+  });
+
+  it("re-emits the stale event after the feed recovers then goes stale again", async () => {
+    const { logger } = await import("@/infrastructure");
+    const nowSeconds = BigInt(Math.floor(Date.now() / 1000));
+    const staleFeed = () =>
+      makeFeedResult(BTC_ANSWER_8_DECIMALS, STANDARD_DECIMALS, {
+        updatedAt: nowSeconds - TWO_HOURS_SECONDS,
+      });
+
+    mockMulticall.mockResolvedValueOnce(staleFeed());
+    await getTokenPrices(["BTC"]); // stale → emit
+    mockMulticall.mockResolvedValueOnce(
+      makeFeedResult(BTC_ANSWER_8_DECIMALS, STANDARD_DECIMALS),
+    );
+    await getTokenPrices(["BTC"]); // fresh → clears the dedup flag
+    mockMulticall.mockResolvedValueOnce(staleFeed());
+    await getTokenPrices(["BTC"]); // stale again → emit
+
+    const staleEvents = vi
+      .mocked(logger.event)
+      .mock.calls.filter(([m]) => typeof m === "string" && m.includes("stale"));
+    expect(staleEvents).toHaveLength(2);
   });
 
   it("stores error metadata when multicall fails", async () => {

--- a/services/vault/src/clients/eth-contract/chainlink/query.ts
+++ b/services/vault/src/clients/eth-contract/chainlink/query.ts
@@ -202,6 +202,21 @@ function emitForSymbol(
 }
 
 /**
+ * Feeds already reported stale this session. A stale price feed is a legitimate
+ * signal (bad collateral valuation), but every component that reads the price
+ * re-runs this, so an undeduped event fires dozens of times per stale episode.
+ * Emit once when a feed goes stale and clear the flag when it reports fresh
+ * again, so a later stale episode re-alerts. Module-scoped — the signal is about
+ * the feed, not any caller.
+ */
+const reportedStaleFeeds = new Set<string>();
+
+/** Test-only: the dedup store outlives any single call. */
+export function resetStaleFeedReporting(): void {
+  reportedStaleFeeds.clear();
+}
+
+/**
  * Translate one feed's raw multicall results into a price + metadata, or an
  * error metadata entry if either call failed or the price is invalid.
  */
@@ -256,17 +271,25 @@ function readoutForFeed(
   const ageSeconds = Math.floor(Date.now() / 1000) - Number(updatedAt);
   const isStale = !isPriceFresh(roundData);
 
+  const feedKey = feedAddress.toLowerCase();
   if (isStale) {
-    if (answeredInRound < roundId) {
-      logger.event(
-        `Chainlink price data is stale: incomplete round (answeredInRound=${answeredInRound} < roundId=${roundId}). Using last known price.`,
-      );
-    } else {
-      const ageHours = (ageSeconds / SECONDS_PER_HOUR).toFixed(1);
-      logger.event(
-        `Chainlink price data is stale (${ageHours} hours old). Using last known price.`,
-      );
+    // One event per stale episode; subsequent reads while still stale are silent.
+    if (!reportedStaleFeeds.has(feedKey)) {
+      reportedStaleFeeds.add(feedKey);
+      if (answeredInRound < roundId) {
+        logger.event(
+          `Chainlink price data is stale: incomplete round (answeredInRound=${answeredInRound} < roundId=${roundId}). Using last known price.`,
+        );
+      } else {
+        const ageHours = (ageSeconds / SECONDS_PER_HOUR).toFixed(1);
+        logger.event(
+          `Chainlink price data is stale (${ageHours} hours old). Using last known price.`,
+        );
+      }
     }
+  } else {
+    // Recovered — allow the next stale episode for this feed to re-alert.
+    reportedStaleFeeds.delete(feedKey);
   }
 
   return {

--- a/services/vault/src/config/__tests__/queryClient.test.ts
+++ b/services/vault/src/config/__tests__/queryClient.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockLoggerError = vi.hoisted(() => vi.fn());
+const mockLoggerWarn = vi.hoisted(() => vi.fn());
+vi.mock("@/infrastructure", () => ({
+  logger: { error: mockLoggerError, warn: mockLoggerWarn },
+}));
+
+import { isExpectedQueryError, reportQueryCacheError } from "../queryClient";
+
+/**
+ * A structural copy of the wallet-connector's error, constructed here so the
+ * class identity differs from the real one — proving the match keys on
+ * `error.name`, which survives bundling across the package boundary, rather
+ * than `instanceof`.
+ */
+class OrdinalsClassifierUnavailableError extends Error {
+  constructor() {
+    super("Ordinals classifier unavailable: no ordinalsApiUrl configured");
+    this.name = "OrdinalsClassifierUnavailableError";
+  }
+}
+
+describe("isExpectedQueryError", () => {
+  it("matches the ordinals classifier error by name, not by identity", () => {
+    expect(isExpectedQueryError(new OrdinalsClassifierUnavailableError())).toBe(
+      true,
+    );
+
+    const bareByName = new Error("whatever");
+    bareByName.name = "OrdinalsClassifierUnavailableError";
+    expect(isExpectedQueryError(bareByName)).toBe(true);
+  });
+
+  it("does not match an ordinary error", () => {
+    expect(isExpectedQueryError(new Error("RPC 500"))).toBe(false);
+  });
+});
+
+describe("reportQueryCacheError", () => {
+  beforeEach(() => {
+    mockLoggerError.mockReset();
+    mockLoggerWarn.mockReset();
+  });
+
+  it("records an expected query error as a breadcrumb, not a captured error", () => {
+    reportQueryCacheError(new OrdinalsClassifierUnavailableError(), "Query");
+
+    expect(mockLoggerError).not.toHaveBeenCalled();
+    expect(mockLoggerWarn).toHaveBeenCalledTimes(1);
+    const [message] = mockLoggerWarn.mock.calls[0];
+    expect(message).toContain("OrdinalsClassifierUnavailableError");
+  });
+
+  it("captures a genuine query error with the query context tag", () => {
+    reportQueryCacheError(new Error("RPC timeout"), "Query");
+
+    expect(mockLoggerWarn).not.toHaveBeenCalled();
+    expect(mockLoggerError).toHaveBeenCalledTimes(1);
+    const [err, ctx] = mockLoggerError.mock.calls[0];
+    expect(err).toBeInstanceOf(Error);
+    expect(ctx.data.context).toBe("React Query Error [Query]");
+  });
+
+  it("captures a genuine mutation error with the mutation context tag", () => {
+    reportQueryCacheError(new Error("write failed"), "Mutation");
+
+    expect(mockLoggerError).toHaveBeenCalledTimes(1);
+    expect(mockLoggerError.mock.calls[0][1].data.context).toBe(
+      "React Query Error [Mutation]",
+    );
+  });
+});

--- a/services/vault/src/config/queryClient.ts
+++ b/services/vault/src/config/queryClient.ts
@@ -22,24 +22,49 @@ const shouldRetry = (failureCount: number, error: Error): boolean => {
   return true;
 };
 
-const logError = (error: Error, context?: string): void => {
-  const errorContext = context ? `[${context}]` : "";
+/**
+ * Query errors that reflect an expected, non-actionable condition rather than a
+ * fault — e.g. an optional API not configured in this environment. Recorded as
+ * a breadcrumb (so they still attach to any genuine error captured afterwards)
+ * instead of a standalone Sentry issue, so they don't drown the signal. This
+ * onError handler fires for EVERY query failure, so an unfiltered logger.error
+ * here turns any transient blip into a captured issue. Matched by error name so
+ * the match survives bundling across the wallet-connector package boundary.
+ */
+const EXPECTED_QUERY_ERROR_NAMES = new Set<string>([
+  // The wallet-connector ordinals hook throws this when inscription filtering
+  // has no data source (no ordinalsApiUrl configured). The vault already treats
+  // missing ordinals data as non-fatal (every UTXO available, see useUTXOs), so
+  // it is an expected environment condition, not a captured error.
+  "OrdinalsClassifierUnavailableError",
+]);
+
+export function isExpectedQueryError(error: Error): boolean {
+  return EXPECTED_QUERY_ERROR_NAMES.has(error.name);
+}
+
+export function reportQueryCacheError(
+  error: Error,
+  kind: "Query" | "Mutation",
+): void {
+  if (isExpectedQueryError(error)) {
+    logger.warn(`Expected ${kind.toLowerCase()} condition: ${error.name}`, {
+      detail: error.message,
+    });
+    return;
+  }
   logger.error(error, {
-    data: { context: `React Query Error ${errorContext}` },
+    data: { context: `React Query Error [${kind}]` },
   });
-};
+}
 
 export const createQueryClient = (): QueryClient => {
   const queryCache = new QueryCache({
-    onError: (error) => {
-      logError(error, "Query");
-    },
+    onError: (error) => reportQueryCacheError(error, "Query"),
   });
 
   const mutationCache = new MutationCache({
-    onError: (error) => {
-      logError(error, "Mutation");
-    },
+    onError: (error) => reportQueryCacheError(error, "Mutation"),
   });
 
   return new QueryClient({


### PR DESCRIPTION
## Context

A Discover export of the `tbv` Sentry project showed **~60% of all events** were two expected, non-actionable conditions - drowning the depositor-funnel signal the Sentry epic just built across five phases. With alerts about to be configured, that noise is alert-fatigue fuel. This is the companion cleanup: build the signal, then clear the channel.

## The two sources (traced, not guessed)

**1. `OrdinalsClassifierUnavailableError` (~33% of events).** The root cause isn't the ordinals code - it's [queryClient.ts](services/vault/src/config/queryClient.ts): `QueryCache.onError` `logger.error`s **every** React Query failure, turning any blip into a captured issue. The wallet-connector ordinals hook throws this whenever no `ordinalsApiUrl` is configured (devnet/testnet), and it's retried up to 3×, so every deposit-form mount produces several captured errors. The vault already treats missing ordinals data as non-fatal (all UTXOs available, see `useUTXOs`).

**2. `Chainlink price data is stale …` (~30%).** A `logger.event` at [chainlink/query.ts](services/vault/src/clients/eth-contract/chainlink/query.ts#L259) fired on **every** price read while a feed was stale - dozens of identical events per stale episode (devnet feeds are permanently stale).

## The fix

- **Query firehose**: known-expected query conditions (matched by `error.name`, so the match survives bundling across the package boundary) route to a **breadcrumb** instead of a captured error. They still attach to any genuine error captured afterwards - not erased, just not standalone issues. Starts with `OrdinalsClassifierUnavailableError`; the list is trivially extensible.
- **Chainlink stale**: **deduped to one event per stale episode per feed**, cleared when the feed reports fresh again (so a later stale episode re-alerts). The `metadata.isStale` flag is untouched, so the UI's stale badge is unaffected.

## Why not just `ignoreErrors`

Both are **legitimate signals on mainnet** - a stale price feed means bad collateral valuation; a missing ordinals classifier means the app can't filter inscription UTXOs (risk of spending an ordinal). A blunt global drop would erase them everywhere. Downgrading / deduping keeps the mainnet signal while removing only the expected-condition flood from environments that produce it. That's the difference between reducing noise and going blind.

## Testing

- `queryClient.test.ts` (5): expected error → breadcrumb not capture, genuine error → capture with the right context tag (Query/Mutation), and the by-`name` match across a distinct class identity.
- `chainlink/query.test.ts` (+3): stale event emitted once per episode, re-emitted after recovery→stale, and `metadata.isStale` still true on a deduped read. Existing stale-logging tests updated to reset the module-scoped dedup store.
- Full vault suite green: **247 files, 2612 tests**. eslint clean; `tsc -p tsconfig.lib.json` clean.

Note: this is independent of the funnel epic and of the still-pending testnet release - it improves the signal in every environment that already transmits (devnet today, testnet once promoted).
