### PR TITLE
fix(vault): show friendly copy for insufficient-ETH-for-gas errors

### DIFF
--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -827,13 +827,15 @@ export const COPY = {
     },
     // Friendly copy for known viem / EIP-1193 / wallet-connector failure
     // categories. Consumed by `sanitizeErrorMessage` in
-    // `src/utils/errors/formatting.ts`. Cross-feature surface (deposit,
-    // refund, activation) so lives under `common` rather than `deposit`.
+    // `src/utils/errors/formatting.ts` and by `mapViemErrorToContractError`
+    // in `src/utils/errors/contract.ts`. Cross-feature surface (deposit,
+    // refund, activation, Aave borrow/repay/withdraw) so lives under
+    // `common` rather than `deposit`.
     classifiedErrors: {
       userRejection:
         "Transaction rejected in your wallet. No changes were made — try again when you're ready.",
       insufficientFunds:
-        "Not enough ETH to cover the deposit fee and gas. Add ETH to your wallet and try again.",
+        "Not enough ETH to cover the network gas fee. Add ETH to your wallet and try again.",
       walletDisconnected:
         "Your wallet was disconnected. Reconnect it and try again.",
       unauthorized:

--- a/services/vault/src/utils/errors/__tests__/contract.test.ts
+++ b/services/vault/src/utils/errors/__tests__/contract.test.ts
@@ -74,6 +74,28 @@ describe("Contract Error Mapping", () => {
       expect(result.code).toBe(ErrorCode.CONTRACT_INSUFFICIENT_GAS);
     });
 
+    it("maps an insufficient-ETH-for-gas send failure to friendly copy, not the raw node dump", () => {
+      const error = new Error(
+        "borrow from Aave Core position failed: The total cost (gas * gas fee + value) of executing this transaction exceeds the balance of the account. insufficient funds for gas * price + value: balance 451223622186226",
+      );
+      const result = mapViemErrorToContractError(error, "Borrow");
+
+      expect(result.code).toBe(ErrorCode.CONTRACT_INSUFFICIENT_GAS);
+      expect(result.message).toBe(
+        COPY.common.classifiedErrors.insufficientFunds,
+      );
+    });
+
+    it("matches the insufficient-funds message case-insensitively", () => {
+      const error = new Error("Insufficient Funds for gas * price + value");
+      const result = mapViemErrorToContractError(error, "Borrow");
+
+      expect(result.code).toBe(ErrorCode.CONTRACT_INSUFFICIENT_GAS);
+      expect(result.message).toBe(
+        COPY.common.classifiedErrors.insufficientFunds,
+      );
+    });
+
     it("should detect nonce errors from message", () => {
       const error = new Error("nonce too low");
       const result = mapViemErrorToContractError(error, "test operation");
@@ -170,6 +192,22 @@ describe("Contract Error Mapping", () => {
       expect(result.code).toBe(ErrorCode.CONTRACT_REVERT);
       expect(result.reason).toBe("DebtMustBeRepaidFirst");
       expect(result.message).toContain("repay all debt");
+    });
+
+    it("keeps a decoded revert even when its wrapper message says 'insufficient funds'", () => {
+      // A real contract revert whose wrapper text happens to contain
+      // "insufficient funds" must not be relabeled as an ETH-gas shortfall.
+      const error = {
+        message: "insufficient funds",
+        data: DEBT_MUST_BE_REPAID_ERROR_DATA,
+      };
+      const result = mapViemErrorToContractError(error, "withdraw", [TEST_ABI]);
+
+      expect(result.code).toBe(ErrorCode.CONTRACT_REVERT);
+      expect(result.reason).toBe("DebtMustBeRepaidFirst");
+      expect(result.message).not.toBe(
+        COPY.common.classifiedErrors.insufficientFunds,
+      );
     });
 
     it("should decode error from nested cause.data", () => {

--- a/services/vault/src/utils/errors/contract.ts
+++ b/services/vault/src/utils/errors/contract.ts
@@ -7,8 +7,11 @@
 
 import { type Abi, type Hash, decodeErrorResult } from "viem";
 
+import { COPY } from "@/copy";
+
 import { COMMON_ERROR_ABI } from "./commonErrorAbi";
 import { CONTRACT_ERROR_MESSAGES } from "./errorMessages";
+import { matchesInsufficientGasFundsMessage } from "./formatting";
 import { ActivationNotPossibleError, ContractError, ErrorCode } from "./types";
 
 /** Minimum length of a revert hex payload: `0x` + a 4-byte (8 hex char) selector. */
@@ -288,11 +291,18 @@ export function mapViemErrorToContractError(
       ) {
         code = ErrorCode.CONTRACT_REVERT;
         reason = reason || message;
-      } else if (
-        message.includes("gas") ||
-        message.includes("insufficient funds for gas") ||
-        message.includes("out of gas")
-      ) {
+      } else if (!decoded && matchesInsufficientGasFundsMessage(message)) {
+        // Wallet can't cover gas * price + value. This fails at send time
+        // (not simulation), so surface friendly copy instead of the raw node
+        // diagnostics dump. Shares the ETH-side matcher with `formatting.ts`
+        // (case-insensitive, one vocabulary). Guarded on `!decoded` so a
+        // genuine contract revert whose wrapper message happens to contain
+        // "insufficient funds" keeps its decoded reason and message rather
+        // than being relabeled as gas.
+        code = ErrorCode.CONTRACT_INSUFFICIENT_GAS;
+        reason = reason || message;
+        enhancedMessage = COPY.common.classifiedErrors.insufficientFunds;
+      } else if (message.includes("gas")) {
         code = ErrorCode.CONTRACT_INSUFFICIENT_GAS;
         reason = reason || message;
       } else if (

--- a/services/vault/src/utils/errors/formatting.ts
+++ b/services/vault/src/utils/errors/formatting.ts
@@ -50,7 +50,7 @@ const INSUFFICIENT_GAS_FUNDS_PATTERN =
 // don't collapse the sats info the user needs.
 const BTC_FUNDS_GUARD_PATTERN = /\bsats\b|\bpegin\b/i;
 
-function matchesInsufficientGasFundsMessage(msg: string): boolean {
+export function matchesInsufficientGasFundsMessage(msg: string): boolean {
   if (BTC_FUNDS_GUARD_PATTERN.test(msg)) return false;
   return INSUFFICIENT_GAS_FUNDS_PATTERN.test(msg);
 }


### PR DESCRIPTION
A borrow (and repay/reorder/withdraw) that fails at send time because the
wallet can't cover gas surfaced viem's raw node dump in the UI. The shared
`mapViemErrorToContractError` already tagged this case but passed the raw
message through; map it to the existing "not enough ETH for gas" copy,
guarded so a decoded contract revert keeps its own message.