### PR TITLE
fix(vault): share optimistic step completions across nested polling providers

### DIFF
--- a/services/vault/src/components/simple/ResumeDepositContent.tsx
+++ b/services/vault/src/components/simple/ResumeDepositContent.tsx
@@ -32,6 +32,7 @@ import { getVaultRegistryReader } from "@/clients/eth-contract/sdk-readers";
 import { computeDepositDerivedState } from "@/components/deposit/DepositSignModal/depositStepHelpers";
 import { usePayoutSigningState } from "@/components/deposit/PayoutSignModal/usePayoutSigningState";
 import { useDepositPollingResult } from "@/context/deposit/PeginPollingContext";
+import { markWotsSubmitted } from "@/context/deposit/optimisticDepositState";
 import { COPY } from "@/copy";
 import {
   DepositFlowStep,
@@ -417,6 +418,11 @@ export function ResumeWotsContent({
         btcWallet: btcWalletProvider,
         unsignedPrePeginTxHex: activity.unsignedPrePeginTx,
       });
+
+      // Recorded regardless of mount: the submission landed, so the dashboard
+      // row must stop offering "Submit WOTS Key" even if the user already
+      // closed this modal. The store is app-scoped, not tied to this tree.
+      markWotsSubmitted(activity.id);
 
       if (mountedRef.current) {
         setLoading(false);

--- a/services/vault/src/components/simple/__tests__/ResumeDepositContent.test.tsx
+++ b/services/vault/src/components/simple/__tests__/ResumeDepositContent.test.tsx
@@ -11,6 +11,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { getVaultRegistryReader } from "@/clients/eth-contract/sdk-readers";
 import { usePayoutSigningState } from "@/components/deposit/PayoutSignModal/usePayoutSigningState";
+import {
+  getOptimisticDepositState,
+  resetOptimisticDepositState,
+} from "@/context/deposit/optimisticDepositState";
 import { COPY } from "@/copy";
 import { useActivationState } from "@/hooks/deposit/useActivationState";
 import { shortId } from "@/infrastructure/telemetryEvents";
@@ -352,6 +356,52 @@ describe("ResumeWotsContent — Pre-PegIn tx hash trust boundary", () => {
     await waitFor(() => {
       expect(mockDeriveVaultRoot).toHaveBeenCalledTimes(1);
     });
+  });
+});
+
+describe("ResumeWotsContent — submission marker", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSubmitWotsPublicKey.mockReset();
+    mockCalculateBtcTxHash.mockReturnValue(ON_CHAIN_HASH);
+    mockGetVaultRegistryReader.mockReturnValue(readerWith(ON_CHAIN_HASH));
+    mockDeriveVaultRoot.mockResolvedValue(new Uint8Array(32));
+    resetOptimisticDepositState();
+  });
+
+  it("records the WOTS submission so the dashboard row stops offering the button", async () => {
+    render(
+      <ResumeWotsContent
+        activity={baseActivity}
+        onClose={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        getOptimisticDepositState().wotsSubmitted.has(baseActivity.id),
+      ).toBe(true);
+    });
+  });
+
+  it("does not record a submission that failed", async () => {
+    mockSubmitWotsPublicKey.mockRejectedValue(new Error("VP rejected the key"));
+
+    const { getByTestId } = render(
+      <ResumeWotsContent
+        activity={baseActivity}
+        onClose={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(getByTestId("error").textContent).toContain("VP rejected the key");
+    });
+    expect(getOptimisticDepositState().wotsSubmitted.has(baseActivity.id)).toBe(
+      false,
+    );
   });
 });
 

--- a/services/vault/src/context/deposit/PeginPollingContext.tsx
+++ b/services/vault/src/context/deposit/PeginPollingContext.tsx
@@ -18,6 +18,7 @@ import {
   useEffect,
   useMemo,
   useState,
+  useSyncExternalStore,
 } from "react";
 
 import { useDemoDeposit } from "@/dev/demoDeposit";
@@ -61,6 +62,11 @@ import {
   collectDaemonTerminalEvents,
   getSharedDaemonTerminalTracking,
 } from "./daemonTerminalEvents";
+import {
+  getOptimisticDepositState,
+  setOptimisticDepositStatus,
+  subscribeToOptimisticDepositState,
+} from "./optimisticDepositState";
 import {
   collectTerminalMilestones,
   getSharedTerminalMilestoneTracking,
@@ -133,14 +139,19 @@ export function PeginPollingProvider({
   // controlled results below instead of the live polling decision tree.
   const demo = useDemoDeposit();
 
-  // Optimistic status overrides (for immediate UI feedback after signing)
-  const [optimisticStatuses, setOptimisticStatuses] = useState<
-    Map<string, LocalStorageStatus>
-  >(new Map());
-  // Companion timestamp for REFUND_BROADCAST so the suppression TTL is honored
-  // immediately, before localStorage is read back.
-  const [optimisticRefundBroadcastAt, setOptimisticRefundBroadcastAt] =
-    useState<Map<string, number>>(new Map());
+  // Optimistic step completions (for immediate UI feedback after an action).
+  // App-scoped, not provider-scoped: the modal that drives an action mounts its
+  // own provider, so per-instance state never reached the dashboard row that
+  // offered the button. See `optimisticDepositState`.
+  const {
+    statuses: optimisticStatuses,
+    refundBroadcastAt: optimisticRefundBroadcastAt,
+    wotsSubmitted,
+  } = useSyncExternalStore(
+    subscribeToOptimisticDepositState,
+    getOptimisticDepositState,
+    getOptimisticDepositState,
+  );
 
   // Use the polling query hook
   const {
@@ -406,18 +417,7 @@ export function PeginPollingProvider({
       newStatus: LocalStorageStatus,
       refundBroadcastAt?: number,
     ) => {
-      setOptimisticStatuses((prev) => {
-        const next = new Map(prev);
-        next.set(depositId, newStatus);
-        return next;
-      });
-      if (refundBroadcastAt !== undefined) {
-        setOptimisticRefundBroadcastAt((prev) => {
-          const next = new Map(prev);
-          next.set(depositId, refundBroadcastAt);
-          return next;
-        });
-      }
+      setOptimisticDepositStatus(depositId, newStatus, refundBroadcastAt);
     },
     [],
   );
@@ -474,6 +474,7 @@ export function PeginPollingProvider({
         isLoading,
         optimisticStatuses,
         optimisticRefundBroadcastAt,
+        wotsSubmitted,
         btcPublicKey,
       });
     },
@@ -496,6 +497,7 @@ export function PeginPollingProvider({
       isLoading,
       optimisticStatuses,
       optimisticRefundBroadcastAt,
+      wotsSubmitted,
       btcPublicKey,
     ],
   );

--- a/services/vault/src/context/deposit/__tests__/PeginPollingContext.test.tsx
+++ b/services/vault/src/context/deposit/__tests__/PeginPollingContext.test.tsx
@@ -1,4 +1,4 @@
-import { act, renderHook, waitFor } from "@testing-library/react";
+import { act, render, renderHook, waitFor } from "@testing-library/react";
 import type { PropsWithChildren } from "react";
 import type { Hex } from "viem";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -11,7 +11,12 @@ import {
   PeginAction,
 } from "../../../models/peginStateMachine";
 import type { VaultActivity } from "../../../types/activity";
+import type { PeginPollingContextValue } from "../../../types/peginPolling";
 import { PeginPollingProvider, usePeginPolling } from "../PeginPollingContext";
+import {
+  markWotsSubmitted,
+  resetOptimisticDepositState,
+} from "../optimisticDepositState";
 
 const mockQueryResult = {
   polledIds: undefined as string[] | undefined,
@@ -134,6 +139,9 @@ describe("PeginPollingContext", () => {
     mockVersionedParams.clear();
     // The persistent confirmed-txid cache leaks across tests otherwise.
     localStorage.clear();
+    // Optimistic completions are app-scoped, so they outlive any single
+    // provider — and therefore any single test.
+    resetOptimisticDepositState();
   });
 
   it("trusts an in-memory PAYOUT_SIGNED over a stale-cached transactionsReady so the Sign button hides immediately after signing", () => {
@@ -200,6 +208,126 @@ describe("PeginPollingContext", () => {
     expect(status?.peginState.availableActions).toContain(
       PeginAction.SIGN_PAYOUT_TRANSACTIONS,
     );
+  });
+
+  it("hides Sign Payouts on the dashboard when the signing modal's own nested provider records the completion", () => {
+    // The reported bug. The dashboard mounts a provider over every activity;
+    // the continuation modal mounts a second one, nested, scoped to the viewed
+    // batch — and the payout signing hook runs under THAT one. While the
+    // optimistic status was per-provider state, the dashboard row that offered
+    // the button never learned the signing had succeeded, so "Sign Payouts"
+    // stayed live for the rest of the session (the VP poll halts once every
+    // deposit reports PendingDepositorSignatures, so nothing else corrected it).
+    const OTHER_ID = "0xpeginOther" as Hex;
+    const OTHER_ACTIVITY: VaultActivity = { ...ACTIVITY, id: OTHER_ID };
+    mockQueryResult.pendingDepositorSignatures = new Set([
+      ACTIVITY_ID,
+      OTHER_ID,
+    ]);
+
+    // Captured per render: `getPollingResult` is memoized on the provider's
+    // inputs, so an assertion holding the pre-action context object would read
+    // the pre-action snapshot and pass regardless of the fix.
+    const captured: {
+      outer?: PeginPollingContextValue;
+      nested?: PeginPollingContextValue;
+    } = {};
+    function CaptureOuter() {
+      captured.outer = usePeginPolling();
+      return null;
+    }
+    function CaptureNested() {
+      captured.nested = usePeginPolling();
+      return null;
+    }
+    const outerActions = (id: string) =>
+      captured.outer?.getPollingResult(id)?.peginState.availableActions;
+
+    render(
+      <PeginPollingProvider
+        activities={[ACTIVITY, OTHER_ACTIVITY]}
+        pendingPegins={[]}
+        btcPublicKey={BTC_PUBKEY}
+      >
+        <CaptureOuter />
+        <PeginPollingProvider
+          activities={[ACTIVITY]}
+          pendingPegins={[]}
+          btcPublicKey={BTC_PUBKEY}
+        >
+          <CaptureNested />
+        </PeginPollingProvider>
+      </PeginPollingProvider>,
+    );
+
+    expect(outerActions(ACTIVITY_ID)).toContain(
+      PeginAction.SIGN_PAYOUT_TRANSACTIONS,
+    );
+
+    act(() => {
+      captured.nested?.setOptimisticStatus(
+        ACTIVITY_ID,
+        LocalStorageStatus.PAYOUT_SIGNED,
+      );
+    });
+
+    expect(outerActions(ACTIVITY_ID)).toEqual([PeginAction.NONE]);
+    // The sibling the user has not signed keeps its button.
+    expect(outerActions(OTHER_ID)).toContain(
+      PeginAction.SIGN_PAYOUT_TRANSACTIONS,
+    );
+  });
+
+  it("hides Submit WOTS Key once the submission resolves, before the poll clears needsWotsKey", () => {
+    // The VP keeps reporting PENDING_DEPOSITOR_WOTS_PK until its daemon
+    // advances, so for up to a full poll interval the row re-offered the
+    // button — and clicking it re-runs the whole derivation, wallet popup
+    // included, for a submission that already landed.
+    mockQueryResult.needsWotsKey = new Set([ACTIVITY_ID]);
+    // Real poll shape: the sets are rebuilt each cycle, so a deposit awaiting
+    // its WOTS key is absent from `pendingIngestion` rather than unobserved.
+    mockQueryResult.pendingIngestion = new Set();
+
+    const { result } = renderProvider();
+    expect(
+      result.current.getPollingResult(ACTIVITY_ID)?.peginState.availableActions,
+    ).toContain(PeginAction.SUBMIT_WOTS_KEY);
+
+    act(() => {
+      markWotsSubmitted(ACTIVITY_ID);
+    });
+
+    // Exactly NONE — suppressing the WOTS action must not fall through to
+    // re-offering the Pre-PegIn broadcast the depositor already completed.
+    expect(
+      result.current.getPollingResult(ACTIVITY_ID)?.peginState.availableActions,
+    ).toEqual([PeginAction.NONE]);
+  });
+
+  it("keeps Submit WOTS Key available for a deposit whose submission was never recorded", () => {
+    // Negative control for the suppression above: the marker is per-deposit,
+    // so a sibling still awaiting its key must be unaffected.
+    const OTHER_ID = "0xpeginOther" as Hex;
+    mockQueryResult.needsWotsKey = new Set([ACTIVITY_ID, OTHER_ID]);
+
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <PeginPollingProvider
+        activities={[ACTIVITY, { ...ACTIVITY, id: OTHER_ID }]}
+        pendingPegins={[]}
+        btcPublicKey={BTC_PUBKEY}
+      >
+        {children}
+      </PeginPollingProvider>
+    );
+    const { result } = renderHook(() => usePeginPolling(), { wrapper });
+
+    act(() => {
+      markWotsSubmitted(ACTIVITY_ID);
+    });
+
+    expect(
+      result.current.getPollingResult(OTHER_ID)?.peginState.availableActions,
+    ).toContain(PeginAction.SUBMIT_WOTS_KEY);
   });
 
   it("polls mempool using prePeginTxHash, not peginTxHash", () => {

--- a/services/vault/src/context/deposit/__tests__/computeDepositPollingResult.test.ts
+++ b/services/vault/src/context/deposit/__tests__/computeDepositPollingResult.test.ts
@@ -55,6 +55,7 @@ function makeInputs(
     isLoading: false,
     optimisticStatuses: new Map(),
     optimisticRefundBroadcastAt: new Map(),
+    wotsSubmitted: new Set(),
     btcPublicKey: PUBKEY,
     ...overrides,
   };

--- a/services/vault/src/context/deposit/__tests__/optimisticDepositState.test.ts
+++ b/services/vault/src/context/deposit/__tests__/optimisticDepositState.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { LocalStorageStatus } from "@/models/peginStateMachine";
+
+import {
+  getOptimisticDepositState,
+  markWotsSubmitted,
+  resetOptimisticDepositState,
+  setOptimisticDepositStatus,
+  subscribeToOptimisticDepositState,
+} from "../optimisticDepositState";
+
+const DEPOSIT_ID = "0xdeposit";
+
+describe("optimisticDepositState", () => {
+  beforeEach(() => {
+    resetOptimisticDepositState();
+  });
+
+  it("returns the identical snapshot reference when nothing has been written", () => {
+    // `useSyncExternalStore` re-renders whenever the snapshot identity changes,
+    // so an unchanged read returning a fresh object would loop forever.
+    expect(getOptimisticDepositState()).toBe(getOptimisticDepositState());
+  });
+
+  it("returns a new snapshot reference after a status is set", () => {
+    const before = getOptimisticDepositState();
+    setOptimisticDepositStatus(DEPOSIT_ID, LocalStorageStatus.PAYOUT_SIGNED);
+    expect(getOptimisticDepositState()).not.toBe(before);
+  });
+
+  it("records the status against the deposit id", () => {
+    setOptimisticDepositStatus(DEPOSIT_ID, LocalStorageStatus.PAYOUT_SIGNED);
+    expect(getOptimisticDepositState().statuses.get(DEPOSIT_ID)).toBe(
+      LocalStorageStatus.PAYOUT_SIGNED,
+    );
+  });
+
+  it("records the refund broadcast timestamp when one is supplied", () => {
+    setOptimisticDepositStatus(
+      DEPOSIT_ID,
+      LocalStorageStatus.REFUND_BROADCAST,
+      1_700_000_000_000,
+    );
+    expect(getOptimisticDepositState().refundBroadcastAt.get(DEPOSIT_ID)).toBe(
+      1_700_000_000_000,
+    );
+  });
+
+  it("notifies subscribers when a status is set", () => {
+    const listener = vi.fn();
+    subscribeToOptimisticDepositState(listener);
+    setOptimisticDepositStatus(DEPOSIT_ID, LocalStorageStatus.CONFIRMING);
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops notifying a subscriber after it unsubscribes", () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeToOptimisticDepositState(listener);
+    unsubscribe();
+    setOptimisticDepositStatus(DEPOSIT_ID, LocalStorageStatus.CONFIRMING);
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("records a wots submission", () => {
+    markWotsSubmitted(DEPOSIT_ID);
+    expect(getOptimisticDepositState().wotsSubmitted.has(DEPOSIT_ID)).toBe(
+      true,
+    );
+  });
+
+  it("keeps the snapshot reference stable when the same wots submission is recorded twice", () => {
+    markWotsSubmitted(DEPOSIT_ID);
+    const after = getOptimisticDepositState();
+    markWotsSubmitted(DEPOSIT_ID);
+    expect(getOptimisticDepositState()).toBe(after);
+  });
+});

--- a/services/vault/src/context/deposit/computeDepositPollingResult.ts
+++ b/services/vault/src/context/deposit/computeDepositPollingResult.ts
@@ -21,7 +21,7 @@ import { isVaultOwnedByWallet } from "../../utils/vaultWarnings";
 /** Optimistic override wins over persisted `pendingPegins` status. */
 function resolveLocalStatus(
   depositId: string,
-  optimisticStatuses: Map<string, LocalStorageStatus>,
+  optimisticStatuses: ReadonlyMap<string, LocalStorageStatus>,
   pendingPegins: PendingPeginRequest[],
 ): LocalStorageStatus | undefined {
   const pendingPegin = pendingPegins.find((p) => p.id === depositId);
@@ -35,7 +35,7 @@ function resolveLocalStatus(
  */
 function resolveRefundBroadcastAt(
   depositId: string,
-  optimisticRefundBroadcastAt: Map<string, number>,
+  optimisticRefundBroadcastAt: ReadonlyMap<string, number>,
   pendingPegins: PendingPeginRequest[],
 ): number | undefined {
   return (
@@ -76,8 +76,15 @@ export interface DepositPollingInputs {
    */
   activationDeadlinePassed: boolean;
   isLoading: boolean;
-  optimisticStatuses: Map<string, LocalStorageStatus>;
-  optimisticRefundBroadcastAt: Map<string, number>;
+  optimisticStatuses: ReadonlyMap<string, LocalStorageStatus>;
+  optimisticRefundBroadcastAt: ReadonlyMap<string, number>;
+  /**
+   * Deposits whose WOTS submission resolved in this page session. The VP poll
+   * keeps reporting `needsWotsKey` until the daemon advances, so without this
+   * the row would re-offer "Submit WOTS Key" — and a second click re-runs the
+   * whole derivation, including a fresh wallet popup, for a no-op submission.
+   */
+  wotsSubmitted: ReadonlySet<string>;
   btcPublicKey: string | undefined;
 }
 
@@ -102,6 +109,7 @@ export function computeDepositPollingResult(
     isLoading,
     optimisticStatuses,
     optimisticRefundBroadcastAt,
+    wotsSubmitted,
     btcPublicKey,
   } = inputs;
   const depositId = activity.id;
@@ -129,6 +137,13 @@ export function computeDepositPollingResult(
   const transactionsReady = justSignedPayoutsThisSession
     ? false
     : (pendingDepositorSignatures?.has(depositId) ?? false);
+
+  // Same shape as the payout suppression above: a step this session watched
+  // resolve outranks the poll snapshot that has not caught up yet.
+  const justSubmittedWotsThisSession = wotsSubmitted.has(depositId);
+  const stillNeedsWotsKey = justSubmittedWotsThisSession
+    ? false
+    : needsWotsKey?.has(depositId);
 
   // Cache is OR'd with live count: on refresh, cached txids are
   // filtered out of polling, so the live map is empty for them.
@@ -204,7 +219,7 @@ export function computeDepositPollingResult(
     localStatus,
     transactionsReady,
     isInUse: activity.isInUse,
-    needsWotsKey: needsWotsKey?.has(depositId),
+    needsWotsKey: stillNeedsWotsKey,
     pendingIngestion: pendingIngestion?.has(depositId),
     prePeginBroadcastConfirmed,
     prePeginBroadcastSeen,

--- a/services/vault/src/context/deposit/optimisticDepositState.ts
+++ b/services/vault/src/context/deposit/optimisticDepositState.ts
@@ -1,0 +1,105 @@
+/**
+ * App-scoped store for "the user completed this step in this page session".
+ *
+ * Every mounted `PeginPollingProvider` reads the same snapshot. That scoping is
+ * the whole point: the dashboard section mounts a provider over every activity,
+ * while the continuation modal mounts its own provider scoped to the viewed
+ * batch — nested inside that section. The hooks that drive an action
+ * (`usePayoutSigningState`, `ResumeWotsContent`, …) run under the *modal's*
+ * provider, so per-provider state meant the dashboard row that offered the
+ * button never learned the action had succeeded and kept re-offering it. Same
+ * reasoning, and same fix, as the tracking stores in `terminalMilestones.ts`
+ * and `daemonTerminalEvents.ts`.
+ *
+ * This changes the SCOPE of the signal, not the trust model. It records only
+ * outcomes this session watched resolve — it is never persisted, so a reload
+ * drops it and the vault provider's polled status is ground truth again. The
+ * anti-tamper reconciliation in `applyTrackingOverrides`, which distrusts a
+ * localStorage status the VP contradicts, is deliberately left untouched.
+ */
+
+import type { LocalStorageStatus } from "../../models/peginStateMachine";
+
+export interface OptimisticDepositState {
+  /** Per-deposit status set the moment its action resolved. */
+  statuses: ReadonlyMap<string, LocalStorageStatus>;
+  /** Companion `Date.now()` for REFUND_BROADCAST, anchoring its suppression TTL. */
+  refundBroadcastAt: ReadonlyMap<string, number>;
+  /**
+   * Deposits whose WOTS public key submission resolved. WOTS has no
+   * `OffChainTrackingStatus` of its own — it is not a status the deposit rests
+   * in — so the completion is recorded as its own set rather than by widening
+   * the status enum.
+   */
+  wotsSubmitted: ReadonlySet<string>;
+}
+
+const EMPTY_STATE: OptimisticDepositState = {
+  statuses: new Map(),
+  refundBroadcastAt: new Map(),
+  wotsSubmitted: new Set(),
+};
+
+let currentState: OptimisticDepositState = EMPTY_STATE;
+
+const listeners = new Set<() => void>();
+
+function publish(next: OptimisticDepositState): void {
+  currentState = next;
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+export function subscribeToOptimisticDepositState(
+  listener: () => void,
+): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/**
+ * Stable-identity snapshot getter. `useSyncExternalStore` re-renders whenever
+ * this returns a new reference, so every mutation below must replace the whole
+ * object exactly once and unchanged reads must return the very same one.
+ */
+export function getOptimisticDepositState(): OptimisticDepositState {
+  return currentState;
+}
+
+export function setOptimisticDepositStatus(
+  depositId: string,
+  status: LocalStorageStatus,
+  refundBroadcastAt?: number,
+): void {
+  publish({
+    statuses: new Map(currentState.statuses).set(depositId, status),
+    refundBroadcastAt:
+      refundBroadcastAt === undefined
+        ? currentState.refundBroadcastAt
+        : new Map(currentState.refundBroadcastAt).set(
+            depositId,
+            refundBroadcastAt,
+          ),
+    wotsSubmitted: currentState.wotsSubmitted,
+  });
+}
+
+export function markWotsSubmitted(depositId: string): void {
+  if (currentState.wotsSubmitted.has(depositId)) return;
+  publish({
+    statuses: currentState.statuses,
+    refundBroadcastAt: currentState.refundBroadcastAt,
+    wotsSubmitted: new Set(currentState.wotsSubmitted).add(depositId),
+  });
+}
+
+/**
+ * Test-only reset: the store outlives any single provider, so cases asserting
+ * suppression must start from a clean slate.
+ */
+export function resetOptimisticDepositState(): void {
+  publish(EMPTY_STATE);
+}

--- a/services/vault/src/hooks/deposit/useDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useDepositFlow.ts
@@ -39,6 +39,7 @@ import {
 } from "@/clients/eth-contract/sdk-readers";
 import { isDepositBlocked } from "@/components/shared/protocolStatus";
 import { useProtocolParamsContext } from "@/context/ProtocolParamsContext";
+import { markWotsSubmitted } from "@/context/deposit/optimisticDepositState";
 import { COPY } from "@/copy";
 import { useProtocolGateState } from "@/hooks/useProtocolGate";
 import { UTXOS_QUERY_KEY } from "@/hooks/useUTXOs";
@@ -992,6 +993,10 @@ export function useDepositFlow(
                 signal,
               });
               wotsSuccess = true;
+              // Mirrors the resume path: the dashboard row polls the VP for
+              // `needsWotsKey` and would keep offering "Submit WOTS Key" until
+              // the daemon advances. App-scoped, so it survives this modal.
+              markWotsSubmitted(result.vaultId);
               setPerVaultSteps((prev) =>
                 prev.map((step, index) =>
                   index === result.vaultIndex


### PR DESCRIPTION
## The bug

Reported by QA on the v3 `/vaults` page, with two pending deposits:

1. **"Submit WOTS Key" stayed after submitting.** The row kept the button, and clicking it again fired a fresh wallet approval for a submission that had already landed.
2. **"Sign Payouts" stayed after signing, permanently.** Both rows sat on "Signing required" for the rest of the session. Only a page reload cleared it.

## Root cause

The dashboard mounts a `PeginPollingProvider` over every activity. The continuation modal mounts a **second one, nested**, scoped to the viewed batch. Every action hook — `usePayoutSigningState`, `ResumeWotsContent` — runs under the *inner* provider, because `usePeginPolling` is a plain `useContext`. So the optimistic status written on success landed in state the dashboard row could not read, and the row kept offering the button it had just satisfied.

For payout signing this compounded into something permanent:

- The VP poll halts once every polled deposit reports `PendingDepositorSignatures`, which is exactly the reported state.
- That freezes `transactionsReady` at `true`.
- `applyTrackingOverrides` then discards the correctly-persisted `PAYOUT_SIGNED` as "stale or tampered" — behaving exactly as designed, on a bad input.

WOTS was a shorter version: a successful submission recorded **nothing anywhere** — no localStorage status, no optimistic marker. `getNextLocalStatus` has no `SUBMIT_WOTS_KEY` case. The row could only self-correct on the next 30s poll.

## The fix

Hoist optimistic step completions into an app-scoped store, `context/deposit/optimisticDepositState.ts`. This mirrors `terminalMilestones.ts` and `daemonTerminalEvents.ts`, which were already moved to module scope for this exact nesting — see the rationale comment in `PeginPollingContext`. Adds a WOTS completion marker, recorded on both the resume and first-run paths.

**This changes the scope of the signal, not the trust model.** The store is in-memory only, so a reload drops it and the VP stays ground truth. `applyTrackingOverrides` is untouched and its anti-tamper reconciliation still applies to persisted localStorage exactly as before. No critical-path file is modified — in particular `depositFlowSteps/payoutSigning.ts` is untouched, since the defect was entirely in UI state scoping.

## Not a v3 regression

The defect is identical in v2 and predates the v3 page. `PendingDepositSection` mounts the same outer provider and the same nested `PostDepositContinuationContent` inside it, and `PendingDepositCard` derives its button from the same pair of helpers. v2 only hid it behind a collapsed `ExpandablePanel` that defaults shut, so you had to expand before a per-row button existed on screen. v3 renders every row and its button unconditionally.

So this fixes v2 too, with no v2 edits. Flagging it so nobody bisects to #2095.

## Deliberately not included

`usePeginPollingQuery`'s `refetchInterval` returns `false` once every deposit reports `PendingDepositorSignatures`, permanently stopping the poll. After this PR that can no longer produce a *wrong* button, but a pending deposit that goes bad provider-side (expires, gets rejected) while the dashboard is open will keep a live button until reload — the same symptom, via a route this PR does not close.

Left out to keep this a clean, reviewable state-scoping change. Worth a follow-up: the fix is to drop the `pendingDepositorSignatures` arm of the stop condition and keep the terminal-error arm, since "waiting for your signature" is the one resolved state the user's own action invalidates. Cost is one batched request per vault provider per 30s, not per deposit.

## Testing

- 2695 tests pass, 0 lint errors, no new type errors.
- Two new regression tests were confirmed to **fail without the fix** by stashing the two source files and re-running:
  - `hides Sign Payouts on the dashboard when the signing modal's own nested provider records the completion`
  - `hides Submit WOTS Key once the submission resolves, before the poll clears needsWotsKey`
- Plus a negative control (a sibling deposit keeps its button), store unit tests, and coverage that the WOTS marker is recorded on success and not on failure.

## Review notes

- The store is module-scoped and outlives individual providers, so **any test touching optimistic status needs `resetOptimisticDepositState()` in `beforeEach`**. Added to the existing suite — without it the pre-existing payout tests leak into each other.
- `getSnapshot` must keep a stable reference between writes or `useSyncExternalStore` loops. Covered by a test.
- God-mode demo rows are unaffected: `getPollingResult` short-circuits demo ids before reaching any of this. That also means the demo panel cannot be used to verify this change.