### PR TITLE
fix(vault): bound the WOTS submission suppression with a TTL

### DIFF
--- a/services/vault/src/components/simple/DepositProgressView/DepositProgressView.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/DepositProgressView.tsx
@@ -228,13 +228,20 @@ export function DepositProgressView(props: DepositProgressViewProps) {
   const showUnlockCta = !started && walletLocked;
 
   // On completion, advance past the last row so every circle renders as ✓.
-  // Before the flow starts, pin visual step 0 so every group collapses and
-  // nothing reads as completed.
-  const visualStep = !started
-    ? 0
-    : isComplete
-      ? TOTAL_VISUAL_STEPS + 1
-      : getVisualStep(currentStep);
+  // The pre-entry state (`!started`) keeps the REAL step: work already done
+  // must still read as done — a WOTS re-offer enters here with the whole
+  // "Register deposit" group genuinely complete, and pinning 0 would show a
+  // confirmed deposit as zero progress. What pre-entry suppresses is how the
+  // CURRENT step reads (see buildStepGroups): no group expands — per-column
+  // on the split path, where sibling lanes keep their polled expansion — and
+  // a current group with none of its own work done reads not-started, so
+  // nothing spins or announces progress while the flow idles awaiting the
+  // click. Flows entering at step 1 have nothing completed, so they render
+  // exactly as before: no bar, no pill, every group a collapsed not-started
+  // header.
+  const visualStep = isComplete
+    ? TOTAL_VISUAL_STEPS + 1
+    : getVisualStep(currentStep);
   // `currentStep` is the active action, but split deposits can have each vault
   // lane land on a different step after a recoverable per-vault failure. The
   // aggregate progress bar and completed-group pill must therefore use the
@@ -245,11 +252,9 @@ export function DepositProgressView(props: DepositProgressViewProps) {
           getVisualStep(step) < getVisualStep(minStep) ? step : minStep,
         )
       : currentStep;
-  const aggregateVisualStep = !started
-    ? 0
-    : isComplete
-      ? TOTAL_VISUAL_STEPS + 1
-      : getVisualStep(aggregateRawStep);
+  const aggregateVisualStep = isComplete
+    ? TOTAL_VISUAL_STEPS + 1
+    : getVisualStep(aggregateRawStep);
   const completedSteps = Math.max(
     0,
     Math.min(TOTAL_VISUAL_STEPS, aggregateVisualStep - 1),
@@ -404,6 +409,7 @@ export function DepositProgressView(props: DepositProgressViewProps) {
             hasError={Boolean(error)}
             renderStepDetail={renderStepDetail}
             perVaultSteps={perVaultSteps}
+            started={started}
           />
         ) : (
           <GroupedProgress
@@ -411,6 +417,7 @@ export function DepositProgressView(props: DepositProgressViewProps) {
             currentStep={visualStep}
             activeStepDetail={activeStepDetail}
             hasError={Boolean(error)}
+            started={started}
           />
         )}
 

--- a/services/vault/src/components/simple/DepositProgressView/GroupedProgress.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/GroupedProgress.tsx
@@ -5,7 +5,8 @@
  * Completed groups are hidden — they fold into the "X of N steps completed" pill
  * — so only the active and upcoming groups render. The active group expands into
  * a filled card revealing its sub-steps; upcoming groups collapse to a header
- * row. Visibility and expansion are derived entirely from `currentStep`.
+ * row. Visibility is derived from `currentStep`; expansion additionally
+ * requires the flow to have `started` (see buildStepGroups).
  */
 
 import type { StepperItem } from "@babylonlabs-io/core-ui";
@@ -23,6 +24,8 @@ interface GroupedProgressProps {
   activeStepDetail?: ReactNode;
   /** When true, the current step failed — render it as an error, not active. */
   hasError?: boolean;
+  /** False in the pre-entry state — no group expands (see buildStepGroups). */
+  started?: boolean;
 }
 
 export function GroupedProgress({
@@ -30,8 +33,9 @@ export function GroupedProgress({
   currentStep,
   activeStepDetail,
   hasError = false,
+  started = true,
 }: GroupedProgressProps) {
-  const groups = buildStepGroups(currentStep);
+  const groups = buildStepGroups(currentStep, started);
 
   // Completed groups are represented by the steps-completed pill, so hide their
   // rows. Original 1-based group numbers are preserved (after group 1 finishes,

--- a/services/vault/src/components/simple/DepositProgressView/SplitGroupedProgress.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/SplitGroupedProgress.tsx
@@ -53,6 +53,12 @@ interface SplitGroupedProgressProps {
    * inferring it from array position.
    */
   perVaultSteps?: DepositFlowStep[];
+  /**
+   * False in the pre-entry state. Columns mirroring the flow's own un-started
+   * step stay collapsed; sibling lanes keep expanding off their polled state
+   * (see the per-column gate below).
+   */
+  started?: boolean;
 }
 
 /** One group list per vault, rendered as the new filled-card / header blocks. */
@@ -116,10 +122,11 @@ export function SplitGroupedProgress({
   hasError = false,
   renderStepDetail,
   perVaultSteps,
+  started = true,
 }: SplitGroupedProgressProps) {
   // Shared trunk groups (Register deposit). Keep original 1-based numbers, hide
   // completed groups (they fold into the steps-completed pill).
-  const trunkGroups = buildStepGroups(currentStep)
+  const trunkGroups = buildStepGroups(currentStep, started)
     .map((group, index) => ({ group, number: index + 1 }))
     .filter(
       ({ group }) =>
@@ -151,7 +158,16 @@ export function SplitGroupedProgress({
             perVaultSteps?.[vaultIndex] ??
             derivePerVaultStep(rawStep, currentVaultIndex, vaultIndex);
           const perVaultVisualStep = getVisualStep(vaultRawStep);
-          const branchGroups = buildStepGroups(perVaultVisualStep)
+          // The pre-entry gate applies only to columns mirroring the flow's
+          // own un-started step. A sibling lane on a different step is driven
+          // by its own polled state — its expansion (and any live detail
+          // panel, e.g. the confirmation-depth counter) reflects a genuinely
+          // running remote process, not the action awaiting this click.
+          const columnStarted = started || vaultRawStep !== rawStep;
+          const branchGroups = buildStepGroups(
+            perVaultVisualStep,
+            columnStarted,
+          )
             .map((group, index) => ({ group, number: index + 1 }))
             .filter(
               ({ group }) =>

--- a/services/vault/src/components/simple/DepositProgressView/__tests__/DepositProgressView.test.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/__tests__/DepositProgressView.test.tsx
@@ -151,6 +151,129 @@ describe("DepositProgressView", () => {
     });
   });
 
+  describe("pre-entry state (started=false)", () => {
+    it("keeps completed work visible when entering un-started mid-flow at the WOTS step", () => {
+      // A WOTS re-offer (suppression TTL lapsed) enters here with the whole
+      // "Register deposit" group genuinely done — Pre-PegIn broadcast and
+      // confirmed. That work must not read as zero progress.
+      render(
+        <DepositProgressView
+          {...baseProps}
+          started={false}
+          onSign={vi.fn()}
+          currentStep={DepositFlowStep.SUBMIT_WOTS_KEYS}
+        />,
+      );
+
+      // The finished first group folds into the pill, same as mid-flow.
+      expect(
+        screen.getByText(COPY.deposit.progress.stepsCompleted(1, 4)),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText(COPY.deposit.groups.registerDeposit),
+      ).not.toBeInTheDocument();
+
+      // SUBMIT_WOTS_KEYS is visual step 7 → 6 of 15 completed → 40%.
+      expect(screen.getByRole("progressbar")).toHaveAttribute(
+        "aria-valuenow",
+        "40",
+      );
+    });
+
+    it("expands no group before the user clicks, so no step reads as in progress", () => {
+      render(
+        <DepositProgressView
+          {...baseProps}
+          started={false}
+          onSign={vi.fn()}
+          currentStep={DepositFlowStep.SUBMIT_WOTS_KEYS}
+          wotsApprovalHint={COPY.deposit.resume.wotsWalletApprovalHint}
+        />,
+      );
+
+      // The current group renders as a collapsed header above the CTA: its
+      // title gives the CTA context, but no sub-step row exists to spin
+      // while the flow is idle awaiting the click.
+      expect(
+        screen.getByText(COPY.deposit.groups.signWots),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText(COPY.deposit.steps.submitWotsKey),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByText(COPY.deposit.resume.wotsWalletApprovalHint),
+      ).not.toBeInTheDocument();
+
+      // Nothing announces "In progress" — the current group has no finished
+      // sub-step, so it reads not-started until the click, visually and to a
+      // screen reader.
+      expect(
+        screen.queryByLabelText(COPY.deposit.a11y.groupStatus.active),
+      ).not.toBeInTheDocument();
+
+      expect(
+        screen.getByRole("button", {
+          name: COPY.deposit.progress.buttons.signTransaction,
+        }),
+      ).toBeInTheDocument();
+    });
+
+    it("keeps the step-1 entry fully collapsed with no progress affordances", () => {
+      // DepositSignContent's entry state: nothing is completed, so the
+      // pre-entry render must look exactly as it always has — four collapsed
+      // group headers, no bar, no pill, no expanded sub-steps.
+      render(
+        <DepositProgressView
+          {...baseProps}
+          started={false}
+          onSign={vi.fn()}
+          currentStep={DepositFlowStep.DERIVE_VAULT_SECRET}
+        />,
+      );
+
+      expect(
+        screen.getByText(COPY.deposit.groups.registerDeposit),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText(COPY.deposit.steps.generateSecret),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
+      expect(screen.queryByText(/steps completed/)).not.toBeInTheDocument();
+
+      // All four groups read not-started — including the first, whose flow
+      // position is "current" but whose work has not begun.
+      expect(
+        screen.getAllByLabelText(COPY.deposit.a11y.groupStatus.upcoming),
+      ).toHaveLength(4);
+    });
+
+    it("keeps a sibling vault's live progress expanded on a split re-offer", () => {
+      // The gate is about the flow's own un-started action. A sibling lane
+      // sitting on a different step is driven by its own polled state — its
+      // wait is genuinely running and must not collapse behind this modal's
+      // idle entry state.
+      render(
+        <DepositProgressView
+          {...baseProps}
+          started={false}
+          onSign={vi.fn()}
+          currentStep={DepositFlowStep.SUBMIT_WOTS_KEYS}
+          vaultCount={2}
+          currentVaultIndex={0}
+          perVaultSteps={[
+            DepositFlowStep.SUBMIT_WOTS_KEYS,
+            DepositFlowStep.AWAIT_PAYOUT_TRANSACTIONS,
+          ]}
+        />,
+      );
+
+      // The sibling's expanded WOTS group shows its active await row.
+      expect(
+        screen.getByText(COPY.deposit.steps.awaitPayoutTransactions),
+      ).toBeInTheDocument();
+    });
+  });
+
   describe("mid-flow progress bar", () => {
     it("renders the overall 'X of N steps completed' pill once a group is done", () => {
       // SUBMIT_WOTS_KEYS lives in the second group, so the first group

--- a/services/vault/src/components/simple/DepositProgressView/__tests__/steps.test.ts
+++ b/services/vault/src/components/simple/DepositProgressView/__tests__/steps.test.ts
@@ -192,6 +192,29 @@ describe("buildStepGroups", () => {
     expect(payout.status).toBe("upcoming");
   });
 
+  it("keeps a pre-entry group collapsed and not-started until its work begins", () => {
+    // Pre-entry (started=false) at the WOTS re-offer: earlier work still
+    // reads done, but the current group has nothing of its own finished —
+    // there is nothing in progress to announce, so it reads upcoming and
+    // stays collapsed until the user's click.
+    const [register, wots] = buildStepGroups(7, false);
+
+    expect(register.status).toBe("completed");
+    expect(wots.status).toBe("upcoming");
+    expect(wots.expanded).toBe(false);
+  });
+
+  it("keeps a pre-entry group active when part of its work is already done", () => {
+    // Mid-group pre-entry (visual step 8): the WOTS group holds one finished
+    // sub-step, so it reads active — but still must not expand while the
+    // flow idles awaiting the click.
+    const [, wots] = buildStepGroups(8, false);
+
+    expect(wots.status).toBe("active");
+    expect(wots.expanded).toBe(false);
+    expect(wots.completedInGroup).toBe(1);
+  });
+
   it("counts completed sub-steps within the active group (mid-group resume)", () => {
     // Step 12 is the last step of the Sign payout group (9..12): 3 done, 1 active.
     const payout = buildStepGroups(12).find(

--- a/services/vault/src/components/simple/DepositProgressView/steps.ts
+++ b/services/vault/src/components/simple/DepositProgressView/steps.ts
@@ -177,8 +177,19 @@ export interface StepGroupView extends StepGroup {
  * Resolve per-group view state from the current visual step. `currentStep` is a
  * 1-based visual step (see {@link getVisualStep}); on completion it is
  * `TOTAL_VISUAL_STEPS + 1`, which leaves every group `completed` and collapsed.
+ *
+ * `started` false is the pre-entry state (the flow is waiting for the user's
+ * click): completed groups and counts still reflect the real step — work
+ * already done must read as done — but no group expands, so no sub-step row
+ * can render as in-progress while nothing is actually running. The current
+ * group likewise reads "active" only if some of its own work is done: with
+ * nothing finished inside it there is nothing in progress to announce,
+ * visually or to a screen reader, so it stays "upcoming" until the click.
  */
-export function buildStepGroups(currentStep: number): StepGroupView[] {
+export function buildStepGroups(
+  currentStep: number,
+  started = true,
+): StepGroupView[] {
   return STEP_GROUPS.map((group) => {
     const totalInGroup = group.endStep - group.startStep + 1;
 
@@ -186,7 +197,7 @@ export function buildStepGroups(currentStep: number): StepGroupView[] {
     if (currentStep > group.endStep) {
       status = "completed";
     } else if (currentStep >= group.startStep) {
-      status = "active";
+      status = started || currentStep > group.startStep ? "active" : "upcoming";
     } else {
       status = "upcoming";
     }
@@ -201,7 +212,7 @@ export function buildStepGroups(currentStep: number): StepGroupView[] {
       status,
       completedInGroup,
       totalInGroup,
-      expanded: status === "active",
+      expanded: status === "active" && started,
     };
   });
 }

--- a/services/vault/src/components/simple/ResumeDepositContent.tsx
+++ b/services/vault/src/components/simple/ResumeDepositContent.tsx
@@ -32,7 +32,10 @@ import { getVaultRegistryReader } from "@/clients/eth-contract/sdk-readers";
 import { computeDepositDerivedState } from "@/components/deposit/DepositSignModal/depositStepHelpers";
 import { usePayoutSigningState } from "@/components/deposit/PayoutSignModal/usePayoutSigningState";
 import { useDepositPollingResult } from "@/context/deposit/PeginPollingContext";
-import { markWotsSubmitted } from "@/context/deposit/optimisticDepositState";
+import {
+  hasWotsSubmissionRecord,
+  markWotsSubmitted,
+} from "@/context/deposit/optimisticDepositState";
 import { COPY } from "@/copy";
 import {
   DepositFlowStep,
@@ -271,10 +274,24 @@ export function ResumeWotsContent({
     null;
   const connectedBtcAddress = btcConnector?.connectedWallet?.account?.address;
 
-  // Starts true: useRunOnce auto-fires handleSubmit on mount, so the
-  // first render must show processing — not a false-success banner from
-  // `isComplete = !loading && !error`.
-  const [loading, setLoading] = useState(true);
+  // A submission already recorded for this deposit means the user has been
+  // through this step in this session, so this mount is the suppression TTL
+  // lapsing and re-offering the action — not a first visit. Auto-submitting
+  // there would fire a wallet prompt at an idle open modal with no user
+  // gesture behind it, so a re-offer waits for an explicit click instead.
+  // Read once at mount: `markWotsSubmitted` below flips it, and re-reading
+  // would swap the component into the wrong mode mid-flight.
+  const [isReoffer] = useState(() => hasWotsSubmissionRecord(activity.id));
+
+  // `started` false parks DepositProgressView on its pre-sign entry state,
+  // where the CTA calls `onSign` — the same seam DepositSignContent uses.
+  const [started, setStarted] = useState(!isReoffer);
+
+  // Starts true on the auto-submit path: useRunOnce fires handleSubmit on
+  // mount, so the first render must show processing — not a false-success
+  // banner from `isComplete = !loading && !error`. A re-offer has not
+  // submitted anything yet, so it starts idle.
+  const [loading, setLoading] = useState(!isReoffer);
   const [error, setError] = useState<string | null>(null);
 
   // Track mount for setState guards after the long async chain below.
@@ -470,7 +487,18 @@ export function ResumeWotsContent({
   // wallet before its account hydrates: in that case useRunOnce (one-shot)
   // would defer rather than fire into the "not connected" guard. When there is
   // genuinely no provider it fires, so the real "not connected" error surfaces.
-  useRunOnce(handleSubmit, !btcWalletProvider || Boolean(connectedBtcAddress));
+  //
+  // `!isReoffer` keeps the auto-run to a first visit; a re-offer submits only
+  // through `handleStart`, behind a click.
+  useRunOnce(
+    handleSubmit,
+    !isReoffer && (!btcWalletProvider || Boolean(connectedBtcAddress)),
+  );
+
+  const handleStart = useCallback(() => {
+    setStarted(true);
+    void handleSubmit();
+  }, [handleSubmit]);
 
   // Reconcile the displayed step with the polled VP status instead of trusting
   // local `loading`/`error` alone. Without this the modal computes its step
@@ -496,7 +524,13 @@ export function ResumeWotsContent({
   // status confirms acceptance. Then the modal sits on the next step as a
   // closeable background wait ("Close & continue later"), matching the other
   // resume waits — no separate success banner needed.
-  const advanced = (!loading && !error) || pastWots;
+  //
+  // `started` gates the local half: a re-offer sits idle (not loading, no
+  // error) until the user clicks, and without this that idle state would read
+  // as "submit resolved" and skip the step entirely. `pastWots` is unguarded
+  // — the VP confirming acceptance advances regardless of what this instance
+  // did.
+  const advanced = pastWots || (started && !loading && !error);
   const renderStep = advanced
     ? DepositFlowStep.AWAIT_PAYOUT_TRANSACTIONS
     : DepositFlowStep.SUBMIT_WOTS_KEYS;
@@ -540,6 +574,8 @@ export function ResumeWotsContent({
       perVaultSteps={perVaultSteps}
       onClose={onClose}
       onRetry={error ? handleSubmit : undefined}
+      started={started}
+      onSign={handleStart}
       btcConfirmationDetail={btcConfirmationDetail}
       wotsApprovalHint={COPY.deposit.resume.wotsWalletApprovalHint}
       offchainParamsVersion={activity.offchainParamsVersion}

--- a/services/vault/src/components/simple/ResumeDepositContent.tsx
+++ b/services/vault/src/components/simple/ResumeDepositContent.tsx
@@ -281,6 +281,15 @@ export function ResumeWotsContent({
   // gesture behind it, so a re-offer waits for an explicit click instead.
   // Read once at mount: `markWotsSubmitted` below flips it, and re-reading
   // would swap the component into the wrong mode mid-flight.
+  //
+  // Deliberately gated even when the user just clicked the re-offered row
+  // action — where that click was already a gesture and this costs a second
+  // one. A re-offer means the VP is still asking after a submission this
+  // session watched resolve, so something may genuinely be wrong; making the
+  // user confirm the fresh wallet popup on that abnormal path is worth more
+  // than the click it saves, and it spares the mount site from having to
+  // report whether this render is a fresh open or a branch swap under an
+  // already-open modal.
   const [isReoffer] = useState(() => hasWotsSubmissionRecord(activity.id));
 
   // `started` false parks DepositProgressView on its pre-sign entry state,

--- a/services/vault/src/components/simple/__tests__/ResumeDepositContent.test.tsx
+++ b/services/vault/src/components/simple/__tests__/ResumeDepositContent.test.tsx
@@ -380,7 +380,7 @@ describe("ResumeWotsContent — submission marker", () => {
 
     await waitFor(() => {
       expect(
-        getOptimisticDepositState().wotsSubmitted.has(baseActivity.id),
+        getOptimisticDepositState().wotsSubmittedAt.has(baseActivity.id),
       ).toBe(true);
     });
   });
@@ -399,9 +399,9 @@ describe("ResumeWotsContent — submission marker", () => {
     await waitFor(() => {
       expect(getByTestId("error").textContent).toContain("VP rejected the key");
     });
-    expect(getOptimisticDepositState().wotsSubmitted.has(baseActivity.id)).toBe(
-      false,
-    );
+    expect(
+      getOptimisticDepositState().wotsSubmittedAt.has(baseActivity.id),
+    ).toBe(false);
   });
 });
 

--- a/services/vault/src/components/simple/__tests__/ResumeDepositContent.test.tsx
+++ b/services/vault/src/components/simple/__tests__/ResumeDepositContent.test.tsx
@@ -6,13 +6,14 @@
  * indexer can ask the wallet to derive over attacker-chosen funding outpoints.
  */
 
-import { render, waitFor } from "@testing-library/react";
+import { fireEvent, render, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { getVaultRegistryReader } from "@/clients/eth-contract/sdk-readers";
 import { usePayoutSigningState } from "@/components/deposit/PayoutSignModal/usePayoutSigningState";
 import {
   getOptimisticDepositState,
+  markWotsSubmitted,
   resetOptimisticDepositState,
 } from "@/context/deposit/optimisticDepositState";
 import { COPY } from "@/copy";
@@ -208,6 +209,8 @@ vi.mock("../DepositProgressView", () => ({
     canContinueInBackground,
     onRetry,
     wotsApprovalHint,
+    started,
+    onSign,
   }: {
     currentStep?: string;
     error?: { title: string; body: string } | null;
@@ -217,8 +220,16 @@ vi.mock("../DepositProgressView", () => ({
     canContinueInBackground?: boolean;
     onRetry?: () => void;
     wotsApprovalHint?: string | null;
+    started?: boolean;
+    onSign?: () => void;
   }) => (
     <div data-testid="progress-view">
+      {/* Mirrors the real prop default so views that never pass it read as
+          started, the same as they render today. */}
+      <span data-testid="started">{String(started !== false)}</span>
+      <button type="button" data-testid="sign" onClick={onSign}>
+        sign
+      </button>
       <span data-testid="wots-hint">{wotsApprovalHint ?? ""}</span>
       <span data-testid="step">{String(currentStep)}</span>
       <span data-testid="error">{error?.body ?? ""}</span>
@@ -266,6 +277,15 @@ function readerWith(prePeginTxHash: string) {
     getVaultProtocolInfo: vi.fn(),
   } as unknown as ReturnType<typeof getVaultRegistryReader>;
 }
+
+// The optimistic store is module-scoped, so it outlives every render here. A
+// leaked WOTS marker is not inert: `ResumeWotsContent` reads it at mount to
+// decide whether it may auto-submit, so one block's marker would silently
+// turn off the auto-submit every later block depends on. Reset for the whole
+// file rather than per-describe.
+beforeEach(() => {
+  resetOptimisticDepositState();
+});
 
 describe("ResumeWotsContent — Pre-PegIn tx hash trust boundary", () => {
   beforeEach(() => {
@@ -402,6 +422,49 @@ describe("ResumeWotsContent — submission marker", () => {
     expect(
       getOptimisticDepositState().wotsSubmittedAt.has(baseActivity.id),
     ).toBe(false);
+  });
+
+  it("submits automatically on a first visit", async () => {
+    render(
+      <ResumeWotsContent
+        activity={baseActivity}
+        onClose={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockSubmitWotsPublicKey).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("waits for a click instead of auto-submitting when the suppression lapsed", async () => {
+    // The TTL expiring re-offers SUBMIT_WOTS_KEY, which remounts this
+    // component. Auto-firing there would open a wallet prompt at a modal the
+    // user left sitting open, with no gesture behind it.
+    markWotsSubmitted(baseActivity.id);
+
+    const { getByTestId } = render(
+      <ResumeWotsContent
+        activity={baseActivity}
+        onClose={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    );
+
+    // `getVaultRegistryReader` is the first thing handleSubmit touches and it
+    // runs synchronously, so it is a reliable "the submit path started" probe.
+    // Asserting on `submitWotsPublicKey` here would not be: it sits behind
+    // several awaits and reads as un-called whether or not the guard holds.
+    expect(mockGetVaultRegistryReader).not.toHaveBeenCalled();
+    expect(getByTestId("started").textContent).toBe("false");
+
+    fireEvent.click(getByTestId("sign"));
+
+    await waitFor(() => {
+      expect(mockSubmitWotsPublicKey).toHaveBeenCalledTimes(1);
+    });
+    expect(getByTestId("started").textContent).toBe("true");
   });
 });
 

--- a/services/vault/src/components/simple/__tests__/ResumeDepositContent.test.tsx
+++ b/services/vault/src/components/simple/__tests__/ResumeDepositContent.test.tsx
@@ -386,7 +386,6 @@ describe("ResumeWotsContent — submission marker", () => {
     mockCalculateBtcTxHash.mockReturnValue(ON_CHAIN_HASH);
     mockGetVaultRegistryReader.mockReturnValue(readerWith(ON_CHAIN_HASH));
     mockDeriveVaultRoot.mockResolvedValue(new Uint8Array(32));
-    resetOptimisticDepositState();
   });
 
   it("records the WOTS submission so the dashboard row stops offering the button", async () => {
@@ -442,7 +441,16 @@ describe("ResumeWotsContent — submission marker", () => {
     // The TTL expiring re-offers SUBMIT_WOTS_KEY, which remounts this
     // component. Auto-firing there would open a wallet prompt at a modal the
     // user left sitting open, with no gesture behind it.
+    //
+    // Record the marker 21 minutes in the past (fake timers only for the
+    // write, real timers restored for the async render below) so the fixture
+    // is the production scenario the title names: a marker that is present
+    // but past the 20-minute TTL — not merely present.
+    const lapsedStamp = Date.now() - 21 * 60 * 1000;
+    vi.useFakeTimers();
+    vi.setSystemTime(lapsedStamp);
     markWotsSubmitted(baseActivity.id);
+    vi.useRealTimers();
 
     const { getByTestId } = render(
       <ResumeWotsContent

--- a/services/vault/src/context/deposit/PeginPollingContext.tsx
+++ b/services/vault/src/context/deposit/PeginPollingContext.tsx
@@ -146,7 +146,7 @@ export function PeginPollingProvider({
   const {
     statuses: optimisticStatuses,
     refundBroadcastAt: optimisticRefundBroadcastAt,
-    wotsSubmitted,
+    wotsSubmittedAt,
   } = useSyncExternalStore(
     subscribeToOptimisticDepositState,
     getOptimisticDepositState,
@@ -476,7 +476,7 @@ export function PeginPollingProvider({
         isLoading,
         optimisticStatuses,
         optimisticRefundBroadcastAt,
-        wotsSubmitted,
+        wotsSubmittedAt,
         btcPublicKey,
       });
     },
@@ -499,7 +499,7 @@ export function PeginPollingProvider({
       isLoading,
       optimisticStatuses,
       optimisticRefundBroadcastAt,
-      wotsSubmitted,
+      wotsSubmittedAt,
       btcPublicKey,
     ],
   );

--- a/services/vault/src/context/deposit/__tests__/PeginPollingContext.test.tsx
+++ b/services/vault/src/context/deposit/__tests__/PeginPollingContext.test.tsx
@@ -336,11 +336,17 @@ describe("PeginPollingContext", () => {
     ).toContain(PeginAction.SUBMIT_WOTS_KEY);
   });
 
-  it("re-offers Submit WOTS Key once the suppression window has elapsed and the vault provider is still asking", () => {
-    // The marker only bridges daemon lag. A VP still asking ten minutes on is
-    // asking for real — a rejected or rotated key, or a submission lost behind
-    // a 200 — and an unbounded marker would leave the row with no action at
-    // all until the user thought to reload.
+  it("recomputes Submit WOTS Key as available once the suppression window has elapsed and the vault provider is still asking", () => {
+    // The marker only bridges daemon lag. A VP still asking twenty minutes on
+    // is asking for real — a rejected or rotated key, or a submission lost
+    // behind a 200 — and an unbounded marker would leave the row with no
+    // action at all until the user thought to reload.
+    //
+    // Scope: this calls `getPollingResult` directly after advancing the clock,
+    // so it pins the COMPUTATION flipping, not a re-render. No dep of that
+    // `useCallback` changes when the clock crosses the boundary, so this would
+    // pass even if nothing re-rendered. What carries it in production is
+    // `refetchInterval` — see `WOTS_SUBMISSION_SUPPRESSION_MS`.
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-07-27T12:00:00Z"));
     mockQueryResult.needsWotsKey = new Set([ACTIVITY_ID]);
@@ -355,7 +361,7 @@ describe("PeginPollingContext", () => {
       result.current.getPollingResult(ACTIVITY_ID)?.peginState.availableActions,
     ).toEqual([PeginAction.NONE]);
 
-    vi.advanceTimersByTime(11 * 60 * 1000);
+    vi.advanceTimersByTime(21 * 60 * 1000);
 
     expect(
       result.current.getPollingResult(ACTIVITY_ID)?.peginState.availableActions,

--- a/services/vault/src/context/deposit/__tests__/PeginPollingContext.test.tsx
+++ b/services/vault/src/context/deposit/__tests__/PeginPollingContext.test.tsx
@@ -1,7 +1,7 @@
 import { act, render, renderHook, waitFor } from "@testing-library/react";
 import type { PropsWithChildren } from "react";
 import type { Hex } from "viem";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { COPY } from "../../../copy";
 import {
@@ -142,6 +142,12 @@ describe("PeginPollingContext", () => {
     // Optimistic completions are app-scoped, so they outlive any single
     // provider — and therefore any single test.
     resetOptimisticDepositState();
+  });
+
+  // Restored here, not at the end of each timer test: a failing assertion would
+  // otherwise leak fake timers into every later `waitFor` and cascade timeouts.
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("trusts an in-memory PAYOUT_SIGNED over a stale-cached transactionsReady so the Sign button hides immediately after signing", () => {
@@ -327,6 +333,32 @@ describe("PeginPollingContext", () => {
 
     expect(
       result.current.getPollingResult(OTHER_ID)?.peginState.availableActions,
+    ).toContain(PeginAction.SUBMIT_WOTS_KEY);
+  });
+
+  it("re-offers Submit WOTS Key once the suppression window has elapsed and the vault provider is still asking", () => {
+    // The marker only bridges daemon lag. A VP still asking ten minutes on is
+    // asking for real — a rejected or rotated key, or a submission lost behind
+    // a 200 — and an unbounded marker would leave the row with no action at
+    // all until the user thought to reload.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-27T12:00:00Z"));
+    mockQueryResult.needsWotsKey = new Set([ACTIVITY_ID]);
+    mockQueryResult.pendingIngestion = new Set();
+
+    const { result } = renderProvider();
+
+    act(() => {
+      markWotsSubmitted(ACTIVITY_ID);
+    });
+    expect(
+      result.current.getPollingResult(ACTIVITY_ID)?.peginState.availableActions,
+    ).toEqual([PeginAction.NONE]);
+
+    vi.advanceTimersByTime(11 * 60 * 1000);
+
+    expect(
+      result.current.getPollingResult(ACTIVITY_ID)?.peginState.availableActions,
     ).toContain(PeginAction.SUBMIT_WOTS_KEY);
   });
 

--- a/services/vault/src/context/deposit/__tests__/computeDepositPollingResult.test.ts
+++ b/services/vault/src/context/deposit/__tests__/computeDepositPollingResult.test.ts
@@ -6,6 +6,7 @@ import {
 } from "@/context/deposit/computeDepositPollingResult";
 import {
   ContractStatus,
+  LocalStorageStatus,
   PEGIN_DISPLAY_LABELS,
   PeginAction,
 } from "@/models/peginStateMachine";
@@ -185,6 +186,49 @@ describe("computeDepositPollingResult — WOTS suppression clock", () => {
     );
     expect(result.peginState.availableActions).toContain(
       PeginAction.SUBMIT_WOTS_KEY,
+    );
+  });
+});
+
+/**
+ * The injected `now` must also reach the refund-broadcast TTL inside
+ * `getPeginState` — one clock for every suppression window a single call
+ * judges. Without the forward, the WOTS decision would honor the injected
+ * time while the refund decision silently read `Date.now()`; the
+ * inside-the-window case below fails in that world, because the real clock
+ * sits years past the fixture's broadcast time.
+ */
+describe("computeDepositPollingResult — refund suppression clock", () => {
+  const BROADCAST_AT = Date.parse("2026-07-27T12:00:00Z");
+  const INSIDE_WINDOW = BROADCAST_AT + 60 * 60 * 1000;
+  const PAST_WINDOW = BROADCAST_AT + 7 * 60 * 60 * 1000;
+
+  function makeBroadcastRefundInputs(now: number): DepositPollingInputs {
+    return makeInputs({
+      optimisticStatuses: new Map([
+        [VAULT_ID, LocalStorageStatus.REFUND_BROADCAST],
+      ]),
+      optimisticRefundBroadcastAt: new Map([[VAULT_ID, BROADCAST_AT]]),
+      now,
+    });
+  }
+
+  it("suppresses the refund action while the broadcast is inside the window", () => {
+    const result = computeDepositPollingResult(
+      makeBroadcastRefundInputs(INSIDE_WINDOW),
+    );
+    expect(result.peginState.availableActions).not.toContain(
+      PeginAction.REFUND_HTLC,
+    );
+    expect(result.peginState.displayLabel).toBe(PEGIN_DISPLAY_LABELS.REFUNDING);
+  });
+
+  it("re-offers the refund action once the injected clock is past the window", () => {
+    const result = computeDepositPollingResult(
+      makeBroadcastRefundInputs(PAST_WINDOW),
+    );
+    expect(result.peginState.availableActions).toContain(
+      PeginAction.REFUND_HTLC,
     );
   });
 });

--- a/services/vault/src/context/deposit/__tests__/computeDepositPollingResult.test.ts
+++ b/services/vault/src/context/deposit/__tests__/computeDepositPollingResult.test.ts
@@ -55,7 +55,7 @@ function makeInputs(
     isLoading: false,
     optimisticStatuses: new Map(),
     optimisticRefundBroadcastAt: new Map(),
-    wotsSubmitted: new Set(),
+    wotsSubmittedAt: new Map(),
     btcPublicKey: PUBKEY,
     ...overrides,
   };

--- a/services/vault/src/context/deposit/__tests__/computeDepositPollingResult.test.ts
+++ b/services/vault/src/context/deposit/__tests__/computeDepositPollingResult.test.ts
@@ -141,3 +141,50 @@ describe("computeDepositPollingResult — activation deadline gate", () => {
     );
   });
 });
+
+/**
+ * Both sides of the WOTS suppression window, driven by the injected `now`
+ * rather than a faked system clock — which is the point of `DepositPollingInputs.now`
+ * existing. The equivalent tests at the provider and store levels need
+ * `vi.useFakeTimers`, because they exercise the `Date.now()` default; these do
+ * not, and that is what makes this module's "pure per-deposit compute" header
+ * true in practice rather than only in the type. Same shape as
+ * `isRefundBroadcastWithinTtl`'s `now`, which `peginStateMachine.test.ts`
+ * exercises the same way.
+ */
+describe("computeDepositPollingResult — WOTS suppression clock", () => {
+  const SUBMITTED_AT = Date.parse("2026-07-27T12:00:00Z");
+  const INSIDE_WINDOW = SUBMITTED_AT + 5 * 60 * 1000;
+  const PAST_WINDOW = SUBMITTED_AT + 21 * 60 * 1000;
+
+  function makeAwaitingWotsInputs(now: number): DepositPollingInputs {
+    return makeInputs({
+      activity: {
+        ...makeExpiredActivity(),
+        displayLabel: PEGIN_DISPLAY_LABELS.PENDING,
+        contractStatus: ContractStatus.PENDING,
+      },
+      needsWotsKey: new Set([VAULT_ID]),
+      wotsSubmittedAt: new Map([[VAULT_ID, SUBMITTED_AT]]),
+      now,
+    });
+  }
+
+  it("suppresses Submit WOTS Key while the submission is inside the window", () => {
+    const result = computeDepositPollingResult(
+      makeAwaitingWotsInputs(INSIDE_WINDOW),
+    );
+    expect(result.peginState.availableActions).not.toContain(
+      PeginAction.SUBMIT_WOTS_KEY,
+    );
+  });
+
+  it("re-offers Submit WOTS Key once the injected clock is past the window", () => {
+    const result = computeDepositPollingResult(
+      makeAwaitingWotsInputs(PAST_WINDOW),
+    );
+    expect(result.peginState.availableActions).toContain(
+      PeginAction.SUBMIT_WOTS_KEY,
+    );
+  });
+});

--- a/services/vault/src/context/deposit/__tests__/optimisticDepositState.test.ts
+++ b/services/vault/src/context/deposit/__tests__/optimisticDepositState.test.ts
@@ -145,7 +145,7 @@ describe("optimisticDepositState", () => {
     vi.setSystemTime(new Date("2026-07-27T12:00:00Z"));
     markWotsSubmitted(DEPOSIT_ID);
 
-    vi.advanceTimersByTime(11 * 60 * 1000);
+    vi.advanceTimersByTime(21 * 60 * 1000);
 
     expect(
       isWotsSubmissionWithinTtl(
@@ -172,5 +172,24 @@ describe("optimisticDepositState", () => {
     expect(getOptimisticDepositState().wotsSubmittedAt.get(DEPOSIT_ID)).toBe(
       first,
     );
+  });
+
+  it("re-arms the suppression when a submission lands after the ttl lapsed", () => {
+    // The recovery path this bound creates has to work more than once. Once
+    // the window lapses the action is back on offer, so the submission that
+    // answers it must record a fresh timestamp — otherwise that second,
+    // successful submission gets zero suppression and the row re-offers the
+    // button for the whole daemon-lag window.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-27T12:00:00Z"));
+    markWotsSubmitted(DEPOSIT_ID);
+    const first = getOptimisticDepositState().wotsSubmittedAt.get(DEPOSIT_ID);
+
+    vi.advanceTimersByTime(21 * 60 * 1000);
+    markWotsSubmitted(DEPOSIT_ID);
+
+    const second = getOptimisticDepositState().wotsSubmittedAt.get(DEPOSIT_ID);
+    expect(second).not.toBe(first);
+    expect(isWotsSubmissionWithinTtl(second)).toBe(true);
   });
 });

--- a/services/vault/src/context/deposit/__tests__/optimisticDepositState.test.ts
+++ b/services/vault/src/context/deposit/__tests__/optimisticDepositState.test.ts
@@ -4,6 +4,7 @@ import { LocalStorageStatus } from "@/models/peginStateMachine";
 
 import {
   getOptimisticDepositState,
+  hasWotsSubmissionRecord,
   isWotsSubmissionWithinTtl,
   markWotsSubmitted,
   resetOptimisticDepositState,
@@ -191,5 +192,33 @@ describe("optimisticDepositState", () => {
     const second = getOptimisticDepositState().wotsSubmittedAt.get(DEPOSIT_ID);
     expect(second).not.toBe(first);
     expect(isWotsSubmissionWithinTtl(second)).toBe(true);
+  });
+
+  it("keeps the submission record after the suppression window lapsed", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-27T12:00:00Z"));
+    markWotsSubmitted(DEPOSIT_ID);
+
+    vi.advanceTimersByTime(21 * 60 * 1000);
+
+    // The action is back on offer, but the user has still been through this
+    // step — which is what tells a re-offer apart from a first visit.
+    expect(hasWotsSubmissionRecord(DEPOSIT_ID)).toBe(true);
+    expect(
+      isWotsSubmissionWithinTtl(
+        getOptimisticDepositState().wotsSubmittedAt.get(DEPOSIT_ID),
+      ),
+    ).toBe(false);
+  });
+
+  it("stops suppressing when the recorded timestamp is ahead of the clock", () => {
+    // A backwards wall-clock jump (NTP step, manual change) leaves the
+    // recorded timestamp in the future. Elapsed then reads negative — inside
+    // the window under a bare `< TTL` for as long as the clock stays behind —
+    // so the suppression would outlast the TTL by the size of the jump.
+    const submittedAt = Date.parse("2026-07-27T12:00:00Z");
+    expect(isWotsSubmissionWithinTtl(submittedAt, submittedAt - 60_000)).toBe(
+      false,
+    );
   });
 });

--- a/services/vault/src/context/deposit/__tests__/optimisticDepositState.test.ts
+++ b/services/vault/src/context/deposit/__tests__/optimisticDepositState.test.ts
@@ -1,9 +1,10 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { LocalStorageStatus } from "@/models/peginStateMachine";
 
 import {
   getOptimisticDepositState,
+  isWotsSubmissionWithinTtl,
   markWotsSubmitted,
   resetOptimisticDepositState,
   setOptimisticDepositStatus,
@@ -15,6 +16,12 @@ const DEPOSIT_ID = "0xdeposit";
 describe("optimisticDepositState", () => {
   beforeEach(() => {
     resetOptimisticDepositState();
+  });
+
+  // Restored here, not at the end of each timer test: a failing assertion would
+  // otherwise leak fake timers into every later test in the run.
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("returns the identical snapshot reference when nothing has been written", () => {
@@ -64,7 +71,7 @@ describe("optimisticDepositState", () => {
 
   it("records a wots submission", () => {
     markWotsSubmitted(DEPOSIT_ID);
-    expect(getOptimisticDepositState().wotsSubmitted.has(DEPOSIT_ID)).toBe(
+    expect(getOptimisticDepositState().wotsSubmittedAt.has(DEPOSIT_ID)).toBe(
       true,
     );
   });
@@ -74,5 +81,96 @@ describe("optimisticDepositState", () => {
     const after = getOptimisticDepositState();
     markWotsSubmitted(DEPOSIT_ID);
     expect(getOptimisticDepositState()).toBe(after);
+  });
+
+  it("keeps the snapshot reference stable when the same status is set twice", () => {
+    // The marker writers are idempotent, so the status writer must be too:
+    // a redundant publish re-renders every mounted provider for a snapshot
+    // that compares equal.
+    setOptimisticDepositStatus(DEPOSIT_ID, LocalStorageStatus.PAYOUT_SIGNED);
+    const after = getOptimisticDepositState();
+    setOptimisticDepositStatus(DEPOSIT_ID, LocalStorageStatus.PAYOUT_SIGNED);
+    expect(getOptimisticDepositState()).toBe(after);
+  });
+
+  it("still publishes when a repeat status write carries a new refund timestamp", () => {
+    setOptimisticDepositStatus(
+      DEPOSIT_ID,
+      LocalStorageStatus.REFUND_BROADCAST,
+      1_700_000_000_000,
+    );
+    const after = getOptimisticDepositState();
+    setOptimisticDepositStatus(
+      DEPOSIT_ID,
+      LocalStorageStatus.REFUND_BROADCAST,
+      1_700_000_999_000,
+    );
+    expect(getOptimisticDepositState()).not.toBe(after);
+    expect(getOptimisticDepositState().refundBroadcastAt.get(DEPOSIT_ID)).toBe(
+      1_700_000_999_000,
+    );
+  });
+
+  it("preserves a stored refund timestamp when a repeat status write omits one", () => {
+    setOptimisticDepositStatus(
+      DEPOSIT_ID,
+      LocalStorageStatus.REFUND_BROADCAST,
+      1_700_000_000_000,
+    );
+    setOptimisticDepositStatus(DEPOSIT_ID, LocalStorageStatus.REFUND_BROADCAST);
+    expect(getOptimisticDepositState().refundBroadcastAt.get(DEPOSIT_ID)).toBe(
+      1_700_000_000_000,
+    );
+  });
+
+  it("suppresses a submission recorded moments ago", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-27T12:00:00Z"));
+    markWotsSubmitted(DEPOSIT_ID);
+
+    vi.advanceTimersByTime(60_000);
+
+    expect(
+      isWotsSubmissionWithinTtl(
+        getOptimisticDepositState().wotsSubmittedAt.get(DEPOSIT_ID),
+      ),
+    ).toBe(true);
+  });
+
+  it("stops suppressing once the submission is older than the ttl", () => {
+    // The whole point of the bound: a vault provider still asking for a key
+    // long after our submission resolved is asking for real, and the user
+    // needs the action back to answer it.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-27T12:00:00Z"));
+    markWotsSubmitted(DEPOSIT_ID);
+
+    vi.advanceTimersByTime(11 * 60 * 1000);
+
+    expect(
+      isWotsSubmissionWithinTtl(
+        getOptimisticDepositState().wotsSubmittedAt.get(DEPOSIT_ID),
+      ),
+    ).toBe(false);
+  });
+
+  it("never suppresses a deposit with no recorded submission", () => {
+    expect(isWotsSubmissionWithinTtl(undefined)).toBe(false);
+  });
+
+  it("keeps the original timestamp when the same submission is recorded twice", () => {
+    // A retry that re-recorded would slide the TTL forward and could keep the
+    // action suppressed indefinitely.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-27T12:00:00Z"));
+    markWotsSubmitted(DEPOSIT_ID);
+    const first = getOptimisticDepositState().wotsSubmittedAt.get(DEPOSIT_ID);
+
+    vi.advanceTimersByTime(5 * 60 * 1000);
+    markWotsSubmitted(DEPOSIT_ID);
+
+    expect(getOptimisticDepositState().wotsSubmittedAt.get(DEPOSIT_ID)).toBe(
+      first,
+    );
   });
 });

--- a/services/vault/src/context/deposit/computeDepositPollingResult.ts
+++ b/services/vault/src/context/deposit/computeDepositPollingResult.ts
@@ -89,6 +89,13 @@ export interface DepositPollingInputs {
    */
   wotsSubmittedAt: ReadonlyMap<string, number>;
   btcPublicKey: string | undefined;
+  /**
+   * Override `Date.now()` for the WOTS suppression TTL (testing only). Mirrors
+   * `PeginStateInputs.now`, and keeps this module's "pure compute" promise
+   * honest — without it the decision tree reads the wall clock transitively
+   * through `isWotsSubmissionWithinTtl` and needs fake timers to pin.
+   */
+  now?: number;
 }
 
 export function computeDepositPollingResult(
@@ -114,6 +121,7 @@ export function computeDepositPollingResult(
     optimisticRefundBroadcastAt,
     wotsSubmittedAt,
     btcPublicKey,
+    now,
   } = inputs;
   const depositId = activity.id;
   const depositIdKey = depositId.toLowerCase();
@@ -147,6 +155,7 @@ export function computeDepositPollingResult(
   // still asking is taken at its word, so the action comes back.
   const justSubmittedWotsThisSession = isWotsSubmissionWithinTtl(
     wotsSubmittedAt.get(depositId),
+    now,
   );
   const stillNeedsWotsKey = justSubmittedWotsThisSession
     ? false

--- a/services/vault/src/context/deposit/computeDepositPollingResult.ts
+++ b/services/vault/src/context/deposit/computeDepositPollingResult.ts
@@ -90,10 +90,13 @@ export interface DepositPollingInputs {
   wotsSubmittedAt: ReadonlyMap<string, number>;
   btcPublicKey: string | undefined;
   /**
-   * Override `Date.now()` for the WOTS suppression TTL (testing only). Mirrors
-   * `PeginStateInputs.now`, and keeps this module's "pure compute" promise
-   * honest — without it the decision tree reads the wall clock transitively
-   * through `isWotsSubmissionWithinTtl` and needs fake timers to pin.
+   * Override `Date.now()` for every suppression TTL this compute touches
+   * (testing only): the WOTS window here, and — forwarded into
+   * `getPeginState` — the refund-broadcast window inside it. One injected
+   * clock must drive both, or a single call would judge the two TTLs at
+   * different times. Keeps this module's "pure compute" promise honest —
+   * without it the decision tree reads the wall clock transitively and needs
+   * fake timers to pin.
    */
   now?: number;
 }
@@ -248,6 +251,7 @@ export function computeDepositPollingResult(
     refundSettlement,
     vpTerminalError,
     refundBroadcastAt,
+    now,
   });
 
   // Coalesce cached at-depth observations into the live count: once a tx

--- a/services/vault/src/context/deposit/computeDepositPollingResult.ts
+++ b/services/vault/src/context/deposit/computeDepositPollingResult.ts
@@ -18,6 +18,8 @@ import { isTerminalPollingError } from "../../utils/peginPolling";
 import { canonicalizeTxid } from "../../utils/txid";
 import { isVaultOwnedByWallet } from "../../utils/vaultWarnings";
 
+import { isWotsSubmissionWithinTtl } from "./optimisticDepositState";
+
 /** Optimistic override wins over persisted `pendingPegins` status. */
 function resolveLocalStatus(
   depositId: string,
@@ -79,12 +81,13 @@ export interface DepositPollingInputs {
   optimisticStatuses: ReadonlyMap<string, LocalStorageStatus>;
   optimisticRefundBroadcastAt: ReadonlyMap<string, number>;
   /**
-   * Deposits whose WOTS submission resolved in this page session. The VP poll
-   * keeps reporting `needsWotsKey` until the daemon advances, so without this
-   * the row would re-offer "Submit WOTS Key" — and a second click re-runs the
-   * whole derivation, including a fresh wallet popup, for a no-op submission.
+   * When each deposit's WOTS submission resolved in this page session. The VP
+   * poll keeps reporting `needsWotsKey` until the daemon advances, so without
+   * this the row would re-offer "Submit WOTS Key" — and a second click re-runs
+   * the whole derivation, including a fresh wallet popup, for a no-op
+   * submission. The suppression expires; see `isWotsSubmissionWithinTtl`.
    */
-  wotsSubmitted: ReadonlySet<string>;
+  wotsSubmittedAt: ReadonlyMap<string, number>;
   btcPublicKey: string | undefined;
 }
 
@@ -109,7 +112,7 @@ export function computeDepositPollingResult(
     isLoading,
     optimisticStatuses,
     optimisticRefundBroadcastAt,
-    wotsSubmitted,
+    wotsSubmittedAt,
     btcPublicKey,
   } = inputs;
   const depositId = activity.id;
@@ -139,8 +142,12 @@ export function computeDepositPollingResult(
     : (pendingDepositorSignatures?.has(depositId) ?? false);
 
   // Same shape as the payout suppression above: a step this session watched
-  // resolve outranks the poll snapshot that has not caught up yet.
-  const justSubmittedWotsThisSession = wotsSubmitted.has(depositId);
+  // resolve outranks the poll snapshot that has not caught up yet — but only
+  // for as long as daemon lag is the plausible explanation. Past the TTL a VP
+  // still asking is taken at its word, so the action comes back.
+  const justSubmittedWotsThisSession = isWotsSubmissionWithinTtl(
+    wotsSubmittedAt.get(depositId),
+  );
   const stillNeedsWotsKey = justSubmittedWotsThisSession
     ? false
     : needsWotsKey?.has(depositId);

--- a/services/vault/src/context/deposit/optimisticDepositState.ts
+++ b/services/vault/src/context/deposit/optimisticDepositState.ts
@@ -172,7 +172,15 @@ export function isWotsSubmissionWithinTtl(
 ): boolean {
   if (submittedAt === undefined) return false;
   const currentTime = now ?? Date.now();
-  return currentTime - submittedAt < WOTS_SUBMISSION_SUPPRESSION_MS;
+  const elapsedMs = currentTime - submittedAt;
+  // A timestamp ahead of the clock means the wall clock jumped backwards
+  // after the submission was recorded (NTP step, manual change). Elapsed then
+  // reads negative — inside the window under a bare `< TTL` — for as long as
+  // the clock stays behind, so suppression would outlast the TTL by the size
+  // of the jump. Treat it as expired instead: the re-offer waits for a click,
+  // a redundant submission is a no-op the VP ignores, and `markWotsSubmitted`
+  // re-arms against the corrected clock.
+  return elapsedMs >= 0 && elapsedMs < WOTS_SUBMISSION_SUPPRESSION_MS;
 }
 
 /**

--- a/services/vault/src/context/deposit/optimisticDepositState.ts
+++ b/services/vault/src/context/deposit/optimisticDepositState.ts
@@ -26,18 +26,36 @@ export interface OptimisticDepositState {
   /** Companion `Date.now()` for REFUND_BROADCAST, anchoring its suppression TTL. */
   refundBroadcastAt: ReadonlyMap<string, number>;
   /**
-   * Deposits whose WOTS public key submission resolved. WOTS has no
-   * `OffChainTrackingStatus` of its own — it is not a status the deposit rests
-   * in — so the completion is recorded as its own set rather than by widening
-   * the status enum.
+   * `Date.now()` per deposit whose WOTS public key submission resolved,
+   * anchoring the suppression TTL below. WOTS has no `OffChainTrackingStatus`
+   * of its own — it is not a status the deposit rests in — so the completion is
+   * recorded separately rather than by widening the status enum.
    */
-  wotsSubmitted: ReadonlySet<string>;
+  wotsSubmittedAt: ReadonlyMap<string, number>;
 }
+
+/**
+ * How long a resolved WOTS submission keeps suppressing "Submit WOTS Key".
+ *
+ * The marker exists to bridge one gap: our submission has resolved but the VP
+ * daemon has not advanced yet, so the poll still reports
+ * `PENDING_DEPOSITOR_WOTS_PK`. That lag is seconds to minutes. Past this bound
+ * the likelier reading of a VP still asking is that it genuinely wants a key —
+ * rejected, rotated, or a write we lost behind a 200 — and an indefinite marker
+ * would leave the row with no action at all and no route back short of a
+ * reload. So the suppression lapses and the user can retry.
+ *
+ * Same reasoning as `REFUND_BROADCAST_SUPPRESSION_MS` in `peginStateMachine`,
+ * which documents why a suppression marker must never be sticky. Generous
+ * against real daemon lag, short enough that a stuck deposit recovers on its
+ * own within one sitting.
+ */
+const WOTS_SUBMISSION_SUPPRESSION_MS = 10 * 60 * 1000;
 
 const EMPTY_STATE: OptimisticDepositState = {
   statuses: new Map(),
   refundBroadcastAt: new Map(),
-  wotsSubmitted: new Set(),
+  wotsSubmittedAt: new Map(),
 };
 
 let currentState: OptimisticDepositState = EMPTY_STATE;
@@ -74,6 +92,18 @@ export function setOptimisticDepositStatus(
   status: LocalStorageStatus,
   refundBroadcastAt?: number,
 ): void {
+  // A repeat write carrying nothing new must not publish: every mounted
+  // provider would re-render and re-memoize `getPollingResult` for a snapshot
+  // that compares equal. Same discipline as `markWotsSubmitted` below. An
+  // omitted `refundBroadcastAt` adds nothing by definition — the publish path
+  // preserves the stored value rather than clearing it.
+  if (
+    currentState.statuses.get(depositId) === status &&
+    (refundBroadcastAt === undefined ||
+      currentState.refundBroadcastAt.get(depositId) === refundBroadcastAt)
+  ) {
+    return;
+  }
   publish({
     statuses: new Map(currentState.statuses).set(depositId, status),
     refundBroadcastAt:
@@ -83,17 +113,42 @@ export function setOptimisticDepositStatus(
             depositId,
             refundBroadcastAt,
           ),
-    wotsSubmitted: currentState.wotsSubmitted,
+    wotsSubmittedAt: currentState.wotsSubmittedAt,
   });
 }
 
 export function markWotsSubmitted(depositId: string): void {
-  if (currentState.wotsSubmitted.has(depositId)) return;
+  // First write wins: a repeat call must not slide the TTL forward, or a retry
+  // loop could keep the action suppressed indefinitely.
+  if (currentState.wotsSubmittedAt.has(depositId)) return;
   publish({
     statuses: currentState.statuses,
     refundBroadcastAt: currentState.refundBroadcastAt,
-    wotsSubmitted: new Set(currentState.wotsSubmitted).add(depositId),
+    wotsSubmittedAt: new Map(currentState.wotsSubmittedAt).set(
+      depositId,
+      Date.now(),
+    ),
   });
+}
+
+/**
+ * Whether a recorded submission is still recent enough to suppress the action.
+ * A deposit with no recorded submission is never suppressed.
+ *
+ * Deliberately time-based rather than driven by an observed poll transition.
+ * Retiring the marker when a poll stops reporting `needsWotsKey` looks tighter
+ * but is not sound: absence is not an affirmative observation — a deposit whose
+ * VP call errored, or that the provider has not polled, is absent too — and
+ * because the store is app-scoped, the first of the two nested providers to
+ * retire it would un-suppress the other's row while that one still holds a
+ * pre-advance snapshot. A clock is read identically everywhere and cannot
+ * disagree between providers.
+ */
+export function isWotsSubmissionWithinTtl(
+  submittedAt: number | undefined,
+): boolean {
+  if (submittedAt === undefined) return false;
+  return Date.now() - submittedAt < WOTS_SUBMISSION_SUPPRESSION_MS;
 }
 
 /**

--- a/services/vault/src/context/deposit/optimisticDepositState.ts
+++ b/services/vault/src/context/deposit/optimisticDepositState.ts
@@ -49,8 +49,22 @@ export interface OptimisticDepositState {
  * which documents why a suppression marker must never be sticky. Generous
  * against real daemon lag, short enough that a stuck deposit recovers on its
  * own within one sitting.
+ *
+ * Sized against the continuation modal, not the dashboard row — it is the
+ * harsher consumer. `PostDepositContinuationView` renders `ResumeWotsContent`
+ * off the same `SUBMIT_WOTS_KEY` action, so a lapse while the VP is merely
+ * slow to leave `PENDING_DEPOSITOR_WOTS_PK` bounces a parked user back to the
+ * WOTS resume screen with nothing actually wrong. Twenty minutes clears
+ * realistic daemon lag for that consumer while still recovering in one sitting.
+ *
+ * Recovery is bounded by this TTL plus one poll interval, not by the TTL
+ * alone: nothing re-renders on the clock crossing the boundary. What carries
+ * it is `refetchInterval` — a deposit stuck at `needsWotsKey` keeps polling
+ * (it only stops at `pendingDepositorSignatures` or a terminal error) and the
+ * queryFn returns fresh `Set`s, which React Query's structural sharing does
+ * not descend into, so the deps change every tick and the row re-renders.
  */
-const WOTS_SUBMISSION_SUPPRESSION_MS = 10 * 60 * 1000;
+const WOTS_SUBMISSION_SUPPRESSION_MS = 20 * 60 * 1000;
 
 const EMPTY_STATE: OptimisticDepositState = {
   statuses: new Map(),
@@ -118,9 +132,17 @@ export function setOptimisticDepositStatus(
 }
 
 export function markWotsSubmitted(depositId: string): void {
-  // First write wins: a repeat call must not slide the TTL forward, or a retry
-  // loop could keep the action suppressed indefinitely.
-  if (currentState.wotsSubmittedAt.has(depositId)) return;
+  // First write wins WITHIN the window: a repeat call must not slide the TTL
+  // forward, or a retry loop could keep the action suppressed indefinitely.
+  // Guard on freshness rather than presence, though — once the window has
+  // lapsed the action is back on offer, and the submission that answers it
+  // must re-arm the marker. Testing `.has()` would leave the expired
+  // timestamp in place, so that second (successful) submission would get zero
+  // suppression and the row would re-offer the button for the whole daemon-lag
+  // window: the #2140 symptom, made permanent for that deposit.
+  if (isWotsSubmissionWithinTtl(currentState.wotsSubmittedAt.get(depositId))) {
+    return;
+  }
   publish({
     statuses: currentState.statuses,
     refundBroadcastAt: currentState.refundBroadcastAt,
@@ -146,9 +168,25 @@ export function markWotsSubmitted(depositId: string): void {
  */
 export function isWotsSubmissionWithinTtl(
   submittedAt: number | undefined,
+  now?: number,
 ): boolean {
   if (submittedAt === undefined) return false;
-  return Date.now() - submittedAt < WOTS_SUBMISSION_SUPPRESSION_MS;
+  const currentTime = now ?? Date.now();
+  return currentTime - submittedAt < WOTS_SUBMISSION_SUPPRESSION_MS;
+}
+
+/**
+ * Whether this deposit's WOTS submission resolved at least once this session,
+ * regardless of whether the suppression window is still open.
+ *
+ * Distinct from {@link isWotsSubmissionWithinTtl}, which asks "should the
+ * action stay hidden". This asks "has the user already been through this
+ * step", which is what tells a re-offer apart from a first visit — the
+ * signal `ResumeWotsContent` needs to decide whether it may auto-submit on
+ * mount or must wait for a click.
+ */
+export function hasWotsSubmissionRecord(depositId: string): boolean {
+  return currentState.wotsSubmittedAt.has(depositId);
 }
 
 /**

--- a/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
@@ -9,6 +9,10 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import type { Address, Hex } from "viem";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import {
+  getOptimisticDepositState,
+  resetOptimisticDepositState,
+} from "@/context/deposit/optimisticDepositState";
 import { COPY } from "@/copy";
 
 import { DepositFlowStep } from "../depositFlowSteps";
@@ -378,6 +382,9 @@ describe("useDepositFlow", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     depositGateMock.value = { protocol: null, aave: null };
+    // The optimistic store is module-scoped, so WOTS markers recorded by one
+    // flow outlive the test that wrote them.
+    resetOptimisticDepositState();
     await setupDefaultMocks();
   });
 
@@ -874,6 +881,41 @@ describe("useDepositFlow", () => {
         DepositFlowStep.SUBMIT_WOTS_KEYS,
         DepositFlowStep.AWAIT_VP_VERIFICATION,
       ]);
+    });
+
+    it("records a WOTS completion marker for every vault whose submission resolved", async () => {
+      // The dashboard row suppresses "Submit WOTS Key" off these markers. The
+      // resume path is covered separately; this pins the first-run path, whose
+      // marker is written per vault inside the retry loop.
+      const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
+
+      await executeDepositFlow(result);
+
+      const { wotsSubmittedAt } = getOptimisticDepositState();
+      expect(wotsSubmittedAt.has("0xVault0Id")).toBe(true);
+      expect(wotsSubmittedAt.has("0xVault1Id")).toBe(true);
+    });
+
+    it("records no WOTS completion marker for a vault whose submission failed", async () => {
+      const { submitWotsPublicKey } = vi.mocked(
+        await import("../depositFlowSteps"),
+      );
+
+      // First vault fails both attempts (retry exhausted); second succeeds.
+      vi.mocked(submitWotsPublicKey)
+        .mockRejectedValueOnce(new Error("WOTS derivation error"))
+        .mockRejectedValueOnce(new Error("WOTS derivation error"))
+        .mockResolvedValueOnce(undefined);
+
+      const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
+
+      await executeDepositFlow(result);
+
+      // Suppressing the button for a submission that never landed would strand
+      // the deposit with no way to retry.
+      const { wotsSubmittedAt } = getOptimisticDepositState();
+      expect(wotsSubmittedAt.has("0xVault0Id")).toBe(false);
+      expect(wotsSubmittedAt.has("0xVault1Id")).toBe(true);
     });
 
     it("waits for shared WOTS readiness before submitting any WOTS key", async () => {

--- a/services/vault/src/models/__tests__/peginStateMachine.test.ts
+++ b/services/vault/src/models/__tests__/peginStateMachine.test.ts
@@ -465,6 +465,22 @@ describe("peginStateMachine", () => {
       expect(state.displayLabel).toBe(PEGIN_DISPLAY_LABELS.EXPIRED);
     });
 
+    it("re-exposes refund action when the recorded timestamp is ahead of the clock", () => {
+      // A backwards wall-clock jump leaves the broadcast timestamp in the
+      // future. Elapsed then reads negative — inside the window under a bare
+      // `< TTL` for as long as the clock stays behind — so the suppression
+      // would outlast the TTL by the size of the jump.
+      const now = 1_700_000_000_000;
+      const state = getPeginState(ContractStatus.EXPIRED, {
+        canRefund: true,
+        localStatus: LocalStorageStatus.REFUND_BROADCAST,
+        refundBroadcastAt: now + 60 * 60 * 1000,
+        now,
+      });
+      expect(state.availableActions).toEqual([PeginAction.REFUND_HTLC]);
+      expect(state.displayLabel).toBe(PEGIN_DISPLAY_LABELS.EXPIRED);
+    });
+
     it("treats legacy REFUND_BROADCAST without timestamp as expired (allows retry)", () => {
       const state = getPeginState(ContractStatus.EXPIRED, {
         canRefund: true,
@@ -744,6 +760,21 @@ describe("peginStateMachine", () => {
           ContractStatus.EXPIRED,
           LocalStorageStatus.REFUND_BROADCAST,
           now - 7 * 60 * 60 * 1000,
+          now,
+        ),
+      ).toBe(true);
+    });
+
+    it("clears REFUND_BROADCAST whose timestamp is ahead of the clock", () => {
+      // Backwards wall-clock jump: a future-dated marker reads as expired —
+      // the same guard as the action suppression — so the stale entry clears
+      // instead of surviving until the clock catches back up past it.
+      const now = 1_700_000_000_000;
+      expect(
+        shouldRemoveFromLocalStorage(
+          ContractStatus.EXPIRED,
+          LocalStorageStatus.REFUND_BROADCAST,
+          now + 60 * 60 * 1000,
           now,
         ),
       ).toBe(true);

--- a/services/vault/src/models/peginStateMachine.ts
+++ b/services/vault/src/models/peginStateMachine.ts
@@ -476,7 +476,14 @@ function isRefundBroadcastWithinTtl(
 ): boolean {
   if (refundBroadcastAt === undefined) return false;
   const currentTime = now ?? Date.now();
-  return currentTime - refundBroadcastAt < REFUND_BROADCAST_SUPPRESSION_MS;
+  const elapsedMs = currentTime - refundBroadcastAt;
+  // A timestamp ahead of the clock (backwards wall-clock jump after the
+  // broadcast was recorded) reads as negative elapsed — inside the window
+  // under a bare `< TTL` for as long as the clock stays behind, so the
+  // suppression would outlast the TTL by the size of the jump. Expired is
+  // the safe reading, same as the missing-timestamp case above: the user
+  // can always retry, and a duplicate broadcast is rejected by the network.
+  return elapsedMs >= 0 && elapsedMs < REFUND_BROADCAST_SUPPRESSION_MS;
 }
 
 interface DisplayInfo {


### PR DESCRIPTION
## The bug

#2140 added a `wotsSubmitted` marker so a row stops re-offering "Submit WOTS Key" while the daemon catches up. The set is **add-only**.

So if a vault provider ever asks for a key *again* — rejected key, rotated key, or a write lost behind a 200 — the button stays hidden for the life of the tab. The row shows "Waiting for vault provider…" with no CTA, and the continuation modal loses its resume branch too (same `availableActions`, only mount site). Reload is the only way out.

## The fix

Record *when* each submission resolved, not just *that* it did, and expire the suppression after **20 minutes**.

`wotsSubmitted: ReadonlySet<string>` → `wotsSubmittedAt: ReadonlyMap<string, number>`, read through `isWotsSubmissionWithinTtl`.

Sized against the continuation modal rather than the dashboard row — it's the harsher consumer, since a premature lapse bounces a parked user back to the WOTS screen with nothing wrong. Reasoning is on the constant.

## Also here

- The suppression **re-arms**: a submission landing after a lapse records a fresh timestamp instead of keeping the expired one.
- A re-offer **waits for a click** instead of auto-firing a wallet prompt at an idle modal.
- `setOptimisticDepositStatus` is idempotent, matching `markWotsSubmitted`.

## Testing

2736 pass, 0 lint errors, typecheck clean. The TTL, re-arm, and no-auto-fire tests were each confirmed to fail without their fix.

Lands cleanly with #2141 — merge verified both directions, no conflicts, order doesn't matter.
