### PR TITLE
test(vault): raise waitFor ceiling for cold async-gated renders

### DIFF
--- a/services/vault/src/test/setup.ts
+++ b/services/vault/src/test/setup.ts
@@ -3,7 +3,13 @@
  */
 
 import "@testing-library/jest-dom";
+import { configure } from "@testing-library/react";
 import { afterAll, beforeAll, vi } from "vitest";
+
+// Cold async-gated page renders (e.g. /activity behind AaveConfigProvider)
+// exceed the 1000ms waitFor default under CI load; a passing assertion still
+// returns immediately, so raising the ceiling only helps flakes.
+configure({ asyncUtilTimeout: 4000 });
 
 // Mock the local `@/config` adapter so tests don't pull in env.ts (which
 // reads NEXT_PUBLIC_* and triggers the live network runtime).


### PR DESCRIPTION
`router.test.tsx > AaveConfigProvider wiring > renders the Activity page
heading` went red on main, failing `Unable to find ... "Activity"`. It passes
locally every time.

The heading is gated behind `AaveConfigProvider`, which shows a spinner until
its react-query fetch resolves. The test waits for the heading with `waitFor`
(1000ms default). On CI the first cold render of that heavy graph took 1102ms —
just over the ceiling — while the identical assertion later in the file ran
warm at 56ms and passed. Nothing in the failing code changed; added tests
elsewhere shifted vitest's worker distribution and raised contention enough to
tip the cold render past 1s.

Fix: set `asyncUtilTimeout: 4000` in the test setup. `waitFor` returns the
instant an assertion passes, so green tests don't slow; only a failing
assertion's wait extends, kept under vitest's 5000ms testTimeout so the
descriptive error still surfaces first.