### PR TITLE
fix(vault): anchor risk rail gradient on the liquidation price

### DIFF
--- a/services/vault/src/applications/aave/utils/index.ts
+++ b/services/vault/src/applications/aave/utils/index.ts
@@ -1,5 +1,6 @@
 // Re-export utilities from SDK
 export {
+  HEALTH_FACTOR_WARNING_THRESHOLD,
   aaveRayValueToUsd,
   aaveValueToUsd,
   calculateHealthFactor,

--- a/services/vault/src/components/pages/Loans.tsx
+++ b/services/vault/src/components/pages/Loans.tsx
@@ -12,13 +12,13 @@ import { useOutletContext } from "react-router";
 import { AssetSelectionModal } from "@/applications/aave/components/AssetSelectionModal";
 import { LOAN_TAB } from "@/applications/aave/constants";
 import { useActiveLoans } from "@/applications/aave/hooks";
-import { getHealthFactorStatusFromValue } from "@/applications/aave/utils";
 import type { RootLayoutContext } from "@/components/pages/RootLayout";
 import { EmptyState } from "@/components/shared";
 import { PAGE_CONTENT_CLASS } from "@/components/shared/layoutClasses";
 import { useConnection, useETHWallet } from "@/context/wallet";
 import { COPY } from "@/copy";
 import {
+  resolveShownHealthFactor,
   useDebugBorrowCapacity,
   useDebugHealthFactorOverride,
 } from "@/dev/debugPositionStore";
@@ -69,17 +69,18 @@ export default function Loans() {
   const demoAffectsLoans =
     demoLoans !== null && (demoLoans.rows.length > 0 || demoLoans.hideReal);
 
-  // God-mode summary overrides (dev only; null unless the panel forces them).
-  // The health-factor STATUS is derived from the forced value with the real
-  // banding function, so a forced card can't drift from production. Both are
-  // compile-time null in production builds.
+  // God-mode summary overrides (dev only; null unless the panel forces them,
+  // compile-time null in production builds).
   const healthFactorOverride = useDebugHealthFactorOverride();
   const borrowCapacityOverride = useDebugBorrowCapacity();
-  const shownHealthFactor = healthFactorOverride ?? healthFactor;
-  const shownHealthFactorStatus =
-    healthFactorOverride !== null
-      ? getHealthFactorStatusFromValue(healthFactorOverride)
-      : healthFactorStatus;
+  const {
+    healthFactor: shownHealthFactor,
+    healthFactorStatus: shownHealthFactorStatus,
+  } = resolveShownHealthFactor(
+    healthFactorOverride,
+    healthFactor,
+    healthFactorStatus,
+  );
   // A forced state REPLACES the live one wholesale — combining them field by
   // field would leave "Error" showing the live loader (or "Loading" showing a
   // live error), i.e. never actually render the state that was forced.

--- a/services/vault/src/components/pages/__tests__/Loans.test.tsx
+++ b/services/vault/src/components/pages/__tests__/Loans.test.tsx
@@ -55,7 +55,8 @@ vi.mock("@/dev/demoDeposit", () => ({
   useDemoLoan: () => useDemoLoanMock(),
 }));
 
-vi.mock("@/dev/debugPositionStore", () => ({
+vi.mock("@/dev/debugPositionStore", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/dev/debugPositionStore")>()),
   useDebugHealthFactorOverride: () => useDebugHealthFactorOverrideMock(),
   useDebugBorrowCapacity: () => useDebugBorrowCapacityMock(),
 }));

--- a/services/vault/src/components/simple/DashboardPage.tsx
+++ b/services/vault/src/components/simple/DashboardPage.tsx
@@ -12,12 +12,14 @@ import { AssetSelectionModal } from "@/applications/aave/components/AssetSelecti
 import { useSyncPendingVaults } from "@/applications/aave/context";
 import { useAaveVaults } from "@/applications/aave/hooks";
 import { usePositionNotifications } from "@/applications/aave/hooks/usePositionNotifications";
+import { getHealthFactorStatusFromValue } from "@/applications/aave/utils";
 import type { RootLayoutContext } from "@/components/pages/RootLayout";
 import { PAGE_CONTENT_CLASS } from "@/components/shared/layoutClasses";
 import featureFlags from "@/config/featureFlags";
 import { useConnection, useETHWallet } from "@/context/wallet";
 import { COPY } from "@/copy";
 import {
+  useDebugHealthFactorOverride,
   useDebugManualMode,
   useDebugManualParams,
   useDebugPositionOverride,
@@ -252,9 +254,6 @@ export function DashboardPage() {
     btcMetadata !== undefined &&
     !btcMetadata.isStale &&
     !btcMetadata.fetchFailed;
-  const liquidationPrice = firstLiquidationGroup
-    ? formatUsdPrice(firstLiquidationGroup.liquidationPrice)
-    : COPY.common.emptyValue;
   const usableBtcPriceUsd =
     isBtcPriceUsable && btcPriceUsd !== undefined && btcPriceUsd > 0
       ? btcPriceUsd
@@ -263,10 +262,29 @@ export function DashboardPage() {
     usableBtcPriceUsd !== null
       ? formatUsdPrice(usableBtcPriceUsd)
       : COPY.common.emptyValue;
-  const liquidationPriceUsd = firstLiquidationGroup?.liquidationPrice ?? null;
-  const pctToLiquidation = firstLiquidationGroup
-    ? formatLiquidationDistancePercent(-firstLiquidationGroup.distancePct)
-    : COPY.common.emptyValue;
+  // God-mode override (dev only; null in production). Health factor is
+  // btcPrice / liquidationPrice, so a forced value implies the liquidation
+  // price that produces it — the rail is charted from that price, not the HF.
+  const healthFactorOverride = useDebugHealthFactorOverride();
+  const shownHealthFactor = healthFactorOverride ?? healthFactor;
+  const shownHealthFactorStatus =
+    healthFactorOverride !== null
+      ? getHealthFactorStatusFromValue(healthFactorOverride)
+      : healthFactorStatus;
+  const liquidationPriceUsd =
+    healthFactorOverride !== null && usableBtcPriceUsd !== null
+      ? usableBtcPriceUsd / healthFactorOverride
+      : (firstLiquidationGroup?.liquidationPrice ?? null);
+  const liquidationPrice =
+    liquidationPriceUsd !== null
+      ? formatUsdPrice(liquidationPriceUsd)
+      : COPY.common.emptyValue;
+  const pctToLiquidation =
+    healthFactorOverride !== null
+      ? formatLiquidationDistancePercent(100 * (1 - 1 / healthFactorOverride))
+      : firstLiquidationGroup
+        ? formatLiquidationDistancePercent(-firstLiquidationGroup.distancePct)
+        : COPY.common.emptyValue;
   const collateralFactorText =
     collateralFactorBps !== null
       ? formatBasisPointsAsPercent(collateralFactorBps)
@@ -332,8 +350,8 @@ export function DashboardPage() {
 
         {showOverview && (
           <OverviewSection
-            healthFactor={healthFactor}
-            healthFactorStatus={healthFactorStatus}
+            healthFactor={shownHealthFactor}
+            healthFactorStatus={shownHealthFactorStatus}
             totalCollateralValue={totalCollateralValue}
             totalBorrowed={totalBorrowed}
             liquidationPrice={liquidationPrice}
@@ -357,8 +375,8 @@ export function DashboardPage() {
 
         {featureFlags.isV3UiEnabled && (
           <RiskSection
-            healthFactor={healthFactor}
-            healthFactorStatus={healthFactorStatus}
+            healthFactor={shownHealthFactor}
+            healthFactorStatus={shownHealthFactorStatus}
             hasPosition={hasOverviewData}
             liquidationPriceText={liquidationPrice}
             btcPriceText={btcPrice}

--- a/services/vault/src/components/simple/DashboardPage.tsx
+++ b/services/vault/src/components/simple/DashboardPage.tsx
@@ -12,13 +12,13 @@ import { AssetSelectionModal } from "@/applications/aave/components/AssetSelecti
 import { useSyncPendingVaults } from "@/applications/aave/context";
 import { useAaveVaults } from "@/applications/aave/hooks";
 import { usePositionNotifications } from "@/applications/aave/hooks/usePositionNotifications";
-import { getHealthFactorStatusFromValue } from "@/applications/aave/utils";
 import type { RootLayoutContext } from "@/components/pages/RootLayout";
 import { PAGE_CONTENT_CLASS } from "@/components/shared/layoutClasses";
 import featureFlags from "@/config/featureFlags";
 import { useConnection, useETHWallet } from "@/context/wallet";
 import { COPY } from "@/copy";
 import {
+  resolveShownHealthFactor,
   useDebugHealthFactorOverride,
   useDebugManualMode,
   useDebugManualParams,
@@ -265,26 +265,43 @@ export function DashboardPage() {
   // God-mode override (dev only; null in production). Health factor is
   // btcPrice / liquidationPrice, so a forced value implies the liquidation
   // price that produces it — the rail is charted from that price, not the HF.
+  // A forced card is derived wholesale from the override: with no usable BTC
+  // price there is nothing to imply a liquidation price from, and the stats
+  // read as placeholders rather than mixing a forced HF with live liquidation
+  // numbers (the case you hit inspecting the stale-price path).
   const healthFactorOverride = useDebugHealthFactorOverride();
-  const shownHealthFactor = healthFactorOverride ?? healthFactor;
-  const shownHealthFactorStatus =
-    healthFactorOverride !== null
-      ? getHealthFactorStatusFromValue(healthFactorOverride)
-      : healthFactorStatus;
-  const liquidationPriceUsd =
+  const {
+    healthFactor: shownHealthFactor,
+    healthFactorStatus: shownHealthFactorStatus,
+  } = resolveShownHealthFactor(
+    healthFactorOverride,
+    healthFactor,
+    healthFactorStatus,
+  );
+  const forcedLiquidationPriceUsd =
     healthFactorOverride !== null && usableBtcPriceUsd !== null
       ? usableBtcPriceUsd / healthFactorOverride
+      : null;
+  const liquidationPriceUsd =
+    healthFactorOverride !== null
+      ? forcedLiquidationPriceUsd
       : (firstLiquidationGroup?.liquidationPrice ?? null);
   const liquidationPrice =
     liquidationPriceUsd !== null
       ? formatUsdPrice(liquidationPriceUsd)
       : COPY.common.emptyValue;
-  const pctToLiquidation =
+  const distanceToLiquidationPct =
     healthFactorOverride !== null
-      ? formatLiquidationDistancePercent(100 * (1 - 1 / healthFactorOverride))
-      : firstLiquidationGroup
-        ? formatLiquidationDistancePercent(-firstLiquidationGroup.distancePct)
-        : COPY.common.emptyValue;
+      ? forcedLiquidationPriceUsd !== null
+        ? 100 * (1 - 1 / healthFactorOverride)
+        : null
+      : firstLiquidationGroup !== null
+        ? -firstLiquidationGroup.distancePct
+        : null;
+  const pctToLiquidation =
+    distanceToLiquidationPct !== null
+      ? formatLiquidationDistancePercent(distanceToLiquidationPct)
+      : COPY.common.emptyValue;
   const collateralFactorText =
     collateralFactorBps !== null
       ? formatBasisPointsAsPercent(collateralFactorBps)
@@ -377,7 +394,7 @@ export function DashboardPage() {
           <RiskSection
             healthFactor={shownHealthFactor}
             healthFactorStatus={shownHealthFactorStatus}
-            hasPosition={hasOverviewData}
+            hasPosition={hasOverviewData || healthFactorOverride !== null}
             liquidationPriceText={liquidationPrice}
             btcPriceText={btcPrice}
             pctToLiquidationText={pctToLiquidation}

--- a/services/vault/src/components/simple/RiskSection/RiskPriceRail.tsx
+++ b/services/vault/src/components/simple/RiskSection/RiskPriceRail.tsx
@@ -97,7 +97,6 @@ export function RiskPriceRail({
   const isSolidGreen =
     !isNeutral && (state === "verySafe" || state === "noPosition");
   const showGradient = !isNeutral && !isSolidGreen && liquidationPct !== null;
-  const showLiquidationMarker = showGradient;
   const showGapArrow =
     showGradient &&
     liquidationPct !== null &&
@@ -107,7 +106,9 @@ export function RiskPriceRail({
   const currentRingCss =
     state === "liquidatable"
       ? "rgb(var(--risk-red))"
-      : "rgb(var(--risk-green))";
+      : state === "moderate"
+        ? "rgb(var(--risk-amber))"
+        : "rgb(var(--risk-green))";
 
   const markerHalf = MARKER_LABEL_WIDTH_PX / 2;
   const labelCenters =
@@ -184,7 +185,7 @@ export function RiskPriceRail({
           leftPx={currentLabelPx}
         />
       )}
-      {showLiquidationMarker && labelCenters && (
+      {showGradient && labelCenters && (
         <MarkerLabel
           label={COPY.risk.chart.liquidationPriceLabel}
           value={liquidationPriceText}
@@ -203,7 +204,7 @@ export function RiskPriceRail({
           }}
         />
       )}
-      {showLiquidationMarker && liquidationPct !== null && (
+      {showGradient && liquidationPct !== null && (
         <div
           data-testid="risk-marker-liquidation"
           className="absolute size-3 -translate-x-1/2 -translate-y-1/2 rounded-full bg-white"

--- a/services/vault/src/components/simple/RiskSection/RiskPriceRail.tsx
+++ b/services/vault/src/components/simple/RiskSection/RiskPriceRail.tsx
@@ -103,12 +103,12 @@ export function RiskPriceRail({
     currentPct !== null &&
     Math.abs(currentPct - liquidationPct) >= GAP_MIN_SEPARATION_PCT;
 
-  const currentRingCss =
+  const currentRingClass =
     state === "liquidatable"
-      ? "rgb(var(--risk-red))"
+      ? "border-risk-red"
       : state === "moderate"
-        ? "rgb(var(--risk-amber))"
-        : "rgb(var(--risk-green))";
+        ? "border-risk-amber"
+        : "border-risk-green";
 
   const markerHalf = MARKER_LABEL_WIDTH_PX / 2;
   const labelCenters =
@@ -196,23 +196,15 @@ export function RiskPriceRail({
       {currentPct !== null && (
         <div
           data-testid="risk-marker-current"
-          className="absolute size-3 -translate-x-1/2 -translate-y-1/2 rounded-full bg-white"
-          style={{
-            left: `${currentPct}%`,
-            top: RAIL_CENTER_PX,
-            border: `3px solid ${currentRingCss}`,
-          }}
+          className={`absolute size-3 -translate-x-1/2 -translate-y-1/2 rounded-full border-[3px] bg-white ${currentRingClass}`}
+          style={{ left: `${currentPct}%`, top: RAIL_CENTER_PX }}
         />
       )}
       {showGradient && liquidationPct !== null && (
         <div
           data-testid="risk-marker-liquidation"
-          className="absolute size-3 -translate-x-1/2 -translate-y-1/2 rounded-full bg-white"
-          style={{
-            left: `${liquidationPct}%`,
-            top: RAIL_CENTER_PX,
-            border: "3px solid rgb(var(--risk-red))",
-          }}
+          className="absolute size-3 -translate-x-1/2 -translate-y-1/2 rounded-full border-[3px] border-risk-red bg-white"
+          style={{ left: `${liquidationPct}%`, top: RAIL_CENTER_PX }}
         />
       )}
 

--- a/services/vault/src/components/simple/RiskSection/railLayout.ts
+++ b/services/vault/src/components/simple/RiskSection/railLayout.ts
@@ -46,7 +46,11 @@ const MARKER_EDGE_MARGIN_PCT = 1.5;
 const MAX_TICKS = 8;
 // On this axis the health factor is price / liquidationPrice, so red sits at
 // the liquidation price and green at the price clearing the safe threshold.
-// Far from liquidation that ramp collapses to a hairline, hence the minimum.
+// Far from liquidation that ramp collapses to a hairline, hence the minimum —
+// which trades truthfulness for legibility: once it engages the stops no longer
+// mark the HF bands. At HF 9 ($63,488 / $6,962) the honest green stop is 5.3%
+// but lands at 45.3%, so ~40pp of rail reads amber for comfortably safe prices.
+// The marker keeps its own colour (from `state`), so it still reads green.
 const GRADIENT_MIN_RAMP_PCT = 45;
 
 function isUsablePrice(price: number | null): price is number {
@@ -113,6 +117,14 @@ export function computeRailLayout(
   const currentPct = toPct(currentPriceUsd);
   const liquidationPct = hasLiquidation ? toPct(liquidationPriceUsd) : null;
 
+  // Both stops are derived from the liquidation price, so the red one always
+  // lands exactly on the liquidation marker. That deliberately keeps the rail
+  // internally consistent rather than agreeing with the health factor labelling
+  // the card: the label reads on-chain `accountData.healthFactor` while this
+  // price comes from the cascade (indexed vault rows + the BTC feed). When
+  // those sources diverge the bands can drift from the label by that much —
+  // anchoring the stops on the label instead would move the red stop off the
+  // marker, which is the more visible of the two errors.
   let gradient: string | null = null;
   if (hasLiquidation) {
     const stopPct = (price: number) => clamp(pct(price), 0, 100);

--- a/services/vault/src/components/simple/RiskSection/railLayout.ts
+++ b/services/vault/src/components/simple/RiskSection/railLayout.ts
@@ -1,5 +1,6 @@
 import {
   HEALTH_FACTOR_HEALTHY_THRESHOLD,
+  HEALTH_FACTOR_WARNING_THRESHOLD,
   type HealthFactorStatus,
 } from "@/applications/aave/utils";
 
@@ -43,10 +44,10 @@ export interface RailLayout {
 
 const MARKER_EDGE_MARGIN_PCT = 1.5;
 const MAX_TICKS = 8;
-// Over the rail, red ends at the current-price marker, amber peaks ~21
-// points later, green runs to the end.
-const GRADIENT_AMBER_OFFSET = 21;
-const GRADIENT_GREEN_STOP = 100;
+// On this axis the health factor is price / liquidationPrice, so red sits at
+// the liquidation price and green at the price clearing the safe threshold.
+// Far from liquidation that ramp collapses to a hairline, hence the minimum.
+const GRADIENT_MIN_RAMP_PCT = 45;
 
 function isUsablePrice(price: number | null): price is number {
   return price !== null && isFinite(price) && price > 0;
@@ -103,25 +104,27 @@ export function computeRailLayout(
 
   const ticks = computeTicks(lo, hi);
 
+  const pct = (price: number) => ((price - lo) / (hi - lo)) * 100;
+  const clamp = (value: number, min: number, max: number) =>
+    Math.min(max, Math.max(min, value));
   const toPct = (price: number) =>
-    Math.min(
-      100 - MARKER_EDGE_MARGIN_PCT,
-      Math.max(MARKER_EDGE_MARGIN_PCT, ((price - lo) / (hi - lo)) * 100),
-    );
+    clamp(pct(price), MARKER_EDGE_MARGIN_PCT, 100 - MARKER_EDGE_MARGIN_PCT);
 
   const currentPct = toPct(currentPriceUsd);
   const liquidationPct = hasLiquidation ? toPct(liquidationPriceUsd) : null;
 
-  // The red→amber hand-off sits ON the current-price marker, so the colour
-  // under the dot is the colour the dot's ring reports. Anchoring on the
-  // midpoint instead left the marker sitting in the red band while it was
-  // rendered green.
   let gradient: string | null = null;
-  if (liquidationPct !== null) {
-    const amber = Math.min(currentPct + GRADIENT_AMBER_OFFSET, 100);
+  if (hasLiquidation) {
+    const stopPct = (price: number) => clamp(pct(price), 0, 100);
+    const red = stopPct(liquidationPriceUsd);
+    const green = Math.max(
+      stopPct(liquidationPriceUsd * HEALTH_FACTOR_WARNING_THRESHOLD),
+      Math.min(100, red + GRADIENT_MIN_RAMP_PCT),
+    );
+    const amber = (red + green) / 2;
     gradient =
-      `linear-gradient(90deg, rgb(var(--risk-red)) ${currentPct}%, ` +
-      `rgb(var(--risk-amber)) ${amber}%, rgb(var(--risk-green)) ${GRADIENT_GREEN_STOP}%)`;
+      `linear-gradient(90deg, rgb(var(--risk-red)) ${red}%, ` +
+      `rgb(var(--risk-amber)) ${amber}%, rgb(var(--risk-green)) ${green}%)`;
   }
 
   return { lo, hi, ticks, currentPct, liquidationPct, gradient };

--- a/services/vault/src/components/simple/__tests__/DashboardPage.test.tsx
+++ b/services/vault/src/components/simple/__tests__/DashboardPage.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { COPY } from "@/copy";
+import { setDebugHealthFactorOverride } from "@/dev/debugPositionStore";
 
 import { DashboardPage } from "../DashboardPage";
 
@@ -55,8 +56,13 @@ vi.mock("@/hooks/usePegoutPolling", () => ({
   usePegoutPolling: () => ({ pegoutStatuses: new Map() }),
 }));
 
+const pricesMock = vi.hoisted(() => ({
+  prices: {} as Record<string, number>,
+  metadata: {} as Record<string, { isStale: boolean; fetchFailed: boolean }>,
+}));
+
 vi.mock("@/hooks/usePrices", () => ({
-  usePrices: () => ({ prices: {}, metadata: {} }),
+  usePrices: () => pricesMock,
 }));
 
 vi.mock("@/dev/debugPositionStore", async (importOriginal) => ({
@@ -125,6 +131,10 @@ beforeEach(() => {
   vi.clearAllMocks();
   featureFlagsMock.isV3UiEnabled = false;
   featureFlagsMock.isLiquidationNotificationsEnabled = false;
+  featureFlagsMock.isGodModePanelEnabled = false;
+  pricesMock.prices = {};
+  pricesMock.metadata = {};
+  setDebugHealthFactorOverride(null);
 });
 
 describe("DashboardPage v3 composition", () => {
@@ -155,5 +165,46 @@ describe("DashboardPage v3 composition", () => {
     expect(screen.queryByTestId("supply-cap")).not.toBeInTheDocument();
     expect(screen.queryByTestId("pending-deposits")).not.toBeInTheDocument();
     expect(screen.queryByTestId("pending-withdrawals")).not.toBeInTheDocument();
+  });
+});
+
+describe("DashboardPage risk card under a forced health factor", () => {
+  beforeEach(() => {
+    featureFlagsMock.isV3UiEnabled = true;
+    featureFlagsMock.isGodModePanelEnabled = true;
+    pricesMock.prices = { BTC: 63488 };
+    pricesMock.metadata = { BTC: { isStale: false, fetchFailed: false } };
+  });
+
+  it("charts the liquidation price and distance implied by the forced value", () => {
+    setDebugHealthFactorOverride(2.4);
+
+    render(<DashboardPage />);
+
+    // 63,488 / 2.4, in both the stat cell and the rail's marker label, plus
+    // the distance it implies: 100 * (1 - 1 / 2.4).
+    expect(screen.getAllByText("$26,453")).toHaveLength(2);
+    expect(screen.getByText("58.3%")).toBeInTheDocument();
+  });
+
+  it("clamps the distance to zero when the forced value is below 1", () => {
+    setDebugHealthFactorOverride(0.95);
+
+    render(<DashboardPage />);
+
+    expect(screen.getAllByText("$66,829")).toHaveLength(2);
+    expect(screen.getByText("0.0%")).toBeInTheDocument();
+  });
+
+  it("shows placeholders rather than live stats when no usable BTC price backs the forced value", () => {
+    pricesMock.metadata = { BTC: { isStale: true, fetchFailed: false } };
+    setDebugHealthFactorOverride(2.4);
+
+    render(<DashboardPage />);
+
+    expect(
+      screen.getAllByText(COPY.common.emptyValue).length,
+    ).toBeGreaterThanOrEqual(2);
+    expect(screen.queryByText("58.3%")).not.toBeInTheDocument();
   });
 });

--- a/services/vault/src/components/simple/__tests__/RiskSection.test.tsx
+++ b/services/vault/src/components/simple/__tests__/RiskSection.test.tsx
@@ -203,6 +203,27 @@ describe("computeRailLayout", () => {
     );
   });
 
+  it("anchors the red gradient stop on the liquidation price, not the current price", () => {
+    const layout = computeRailLayout(88400, 77600);
+    const redStop = Number(/risk-red\)\) ([\d.]+)%/.exec(layout.gradient!)![1]);
+    const liquidationStop =
+      ((77600 - layout.lo) / (layout.hi - layout.lo)) * 100;
+    expect(redStop).toBeCloseTo(liquidationStop, 2);
+    expect(redStop).toBeLessThan(layout.currentPct as number);
+  });
+
+  it("keeps a readable ramp, still green under the marker, when liquidation is far below", () => {
+    // Health factor ~9: $63,488 current vs a $6,962 liquidation price. The
+    // truthful safe-threshold stop lands under 6% — it gets stretched.
+    const layout = computeRailLayout(63488, 6962);
+    const redStop = Number(/risk-red\)\) ([\d.]+)%/.exec(layout.gradient!)![1]);
+    const greenStop = Number(
+      /risk-green\)\) ([\d.]+)%/.exec(layout.gradient!)![1],
+    );
+    expect(greenStop - redStop).toBeGreaterThanOrEqual(45);
+    expect(greenStop).toBeLessThan(layout.currentPct as number);
+  });
+
   it("returns null positions when the current price is unavailable", () => {
     const layout = computeRailLayout(null, 77600);
     expect(layout.currentPct).toBeNull();

--- a/services/vault/src/components/simple/__tests__/RiskSection.test.tsx
+++ b/services/vault/src/components/simple/__tests__/RiskSection.test.tsx
@@ -162,6 +162,22 @@ describe("RiskSection rendering", () => {
     expect(currentLeft).toBeLessThan(liquidationLeft);
   });
 
+  it("rings the current marker amber in the moderate state and green when safe", () => {
+    const { unmount } = renderSection({
+      healthFactorStatus: "warning",
+      healthFactor: 1.14,
+    });
+    expect(screen.getByTestId("risk-marker-current").className).toContain(
+      "border-risk-amber",
+    );
+    unmount();
+
+    renderSection();
+    expect(screen.getByTestId("risk-marker-current").className).toContain(
+      "border-risk-green",
+    );
+  });
+
   it("renders the three stat labels, their values, and the collateral-factor tooltip label", () => {
     renderSection();
 

--- a/services/vault/src/dev/debugPositionStore.ts
+++ b/services/vault/src/dev/debugPositionStore.ts
@@ -21,6 +21,10 @@ import type {
   CalculatorParams,
   CalculatorResult,
 } from "@/applications/aave/positionNotifications";
+import {
+  getHealthFactorStatusFromValue,
+  type HealthFactorStatus,
+} from "@/applications/aave/utils";
 import type { ProtocolStatus } from "@/components/shared/protocolStatus";
 import featureFlags from "@/config/featureFlags";
 
@@ -399,4 +403,22 @@ export function useDebugBorrowCapacityStateOverride(): DebugBorrowCapacityState 
  */
 export function useDebugBorrowCapacity(): DebugBorrowCapacity | null {
   return useSyncExternalStore(subscribe, getBorrowCapacity, getBorrowCapacity);
+}
+
+/**
+ * What a page should render for the health factor given a forced value. Shared
+ * by every god-mode consumer so they can't drift on how a forced value maps to
+ * a status: the status is always re-derived with the production banding
+ * function, never carried over from the live read.
+ */
+export function resolveShownHealthFactor(
+  override: number | null,
+  healthFactor: number | null,
+  healthFactorStatus: HealthFactorStatus,
+): { healthFactor: number | null; healthFactorStatus: HealthFactorStatus } {
+  if (override === null) return { healthFactor, healthFactorStatus };
+  return {
+    healthFactor: override,
+    healthFactorStatus: getHealthFactorStatusFromValue(override),
+  };
 }


### PR DESCRIPTION
The gradient stops were placed relative to the current-price marker, so the ramp slid with the marker: at a health factor of 9 the rail rendered red right up to a green marker under a green "Safe" label.

Place the stops by price instead — red at the liquidation price, green at the price clearing the safe threshold, with a minimum ramp width so the scale stays legible when liquidation is far below. The current-marker ring now also reads amber in the moderate state.

Wire the god-mode health-factor override into the risk card so the forced states chart: a forced health factor implies the liquidation price that produces it, and the card derives its price, distance and label from that.

## Screenshot
<img width="1025" height="627" alt="Screenshot 2026-07-28 at 17 22 39" src="https://github.com/user-attachments/assets/4fec97e0-986d-4b79-bd34-6065b940f0a2" />
<img width="1029" height="604" alt="Screenshot 2026-07-28 at 17 22 36" src="https://github.com/user-attachments/assets/242493de-a99f-4e87-85df-18b8e54d7ddb" />
<img width="1048" height="752" alt="Screenshot 2026-07-28 at 17 22 32" src="https://github.com/user-attachments/assets/a40206ea-ff78-415d-9d0c-75f00d38aec7" />

