### PR TITLE
fix(vault): resolve loan reserves by on-chain id, not indexer symbol

### DIFF
--- a/services/vault/eslint.config.js
+++ b/services/vault/eslint.config.js
@@ -137,6 +137,26 @@ export default tseslint.config(
       "@typescript-eslint/ban-ts-comment": "error",
     },
   },
+  // Indexer metadata boundary on the loan screens. `selectedReserve.token` is
+  // symbol/name/decimals copied verbatim from the GraphQL indexer; the borrow
+  // and repay surfaces must read `LoanContext.tokenIdentity` instead, which is
+  // proven on-chain before the screen renders. Reading the indexer's copy here
+  // is how a mislabelled asset or a wrong "Max" gets in front of a signature.
+  {
+    files: ["src/applications/aave/components/**/*.{ts,tsx}"],
+    ignores: ["**/__tests__/**", "**/*.test.{ts,tsx}"],
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector:
+            "MemberExpression[object.object.name='selectedReserve'][object.property.name='token']",
+          message:
+            "Indexer-supplied metadata. Use LoanContext.tokenIdentity (proven on-chain) for the address, symbol, name and decimals.",
+        },
+      ],
+    },
+  },
   // Dev-only tooling boundary — production code must not import `src/dev` (the
   // god-mode / demo / debug tooling), so it stays an evident, self-contained
   // subtree that never leaks into the app except at the sanctioned mount seams

--- a/services/vault/src/__tests__/router.test.tsx
+++ b/services/vault/src/__tests__/router.test.tsx
@@ -403,14 +403,14 @@ describe("Router — reserve detail stays over the dashboard", () => {
   });
 
   it("renders the reserve detail as an overlay over the dashboard", async () => {
-    renderAt(getReserveDetailRoute("USDC", "borrow", false));
+    renderAt(getReserveDetailRoute(5n, "borrow", false));
 
     await waitFor(() => {
       expect(screen.getByTestId(RESERVE_DETAIL_TESTID)).toBeInTheDocument();
     });
     expect(screen.getByTestId(RESERVE_DETAIL_TESTID)).toHaveAttribute(
       "data-reserve-id",
-      "usdc",
+      "5",
     );
     expect(screen.getByTestId(RESERVE_DETAIL_TESTID)).toHaveAttribute(
       "data-tab",
@@ -420,7 +420,7 @@ describe("Router — reserve detail stays over the dashboard", () => {
   });
 
   it("defaults to borrow when the tab is omitted", async () => {
-    renderAt("/?reserve=usdc");
+    renderAt("/?reserve=5");
 
     await waitFor(() => {
       expect(screen.getByTestId(RESERVE_DETAIL_TESTID)).toHaveAttribute(
@@ -442,19 +442,19 @@ describe("Router — flag-aware reserve-detail routing", () => {
     });
 
     it("generates v2 reserve-detail URL (/ base)", () => {
-      const route = getReserveDetailRoute("USDC", "borrow", false);
-      expect(route).toBe("/?reserve=usdc&tab=borrow");
+      const route = getReserveDetailRoute(5n, "borrow", false);
+      expect(route).toBe("/?reserve=5&tab=borrow");
     });
 
     it("renders reserve detail overlay over dashboard at / with query params", async () => {
-      renderAt("/?reserve=usdc&tab=repay");
+      renderAt("/?reserve=5&tab=repay");
 
       await waitFor(() => {
         expect(screen.getByTestId(RESERVE_DETAIL_TESTID)).toBeInTheDocument();
       });
       expect(screen.getByTestId(RESERVE_DETAIL_TESTID)).toHaveAttribute(
         "data-reserve-id",
-        "usdc",
+        "5",
       );
       expect(screen.getByTestId(RESERVE_DETAIL_TESTID)).toHaveAttribute(
         "data-tab",
@@ -470,19 +470,19 @@ describe("Router — flag-aware reserve-detail routing", () => {
     });
 
     it("generates v3 reserve-detail URL (/loans base)", () => {
-      const route = getReserveDetailRoute("USDC", "borrow", true);
-      expect(route).toBe("/loans?reserve=usdc&tab=borrow");
+      const route = getReserveDetailRoute(5n, "borrow", true);
+      expect(route).toBe("/loans?reserve=5&tab=borrow");
     });
 
     it("renders reserve detail overlay when /loans has reserve query params", async () => {
-      renderAt("/loans?reserve=usdc&tab=repay");
+      renderAt("/loans?reserve=5&tab=repay");
 
       await waitFor(() => {
         expect(screen.getByTestId(RESERVE_DETAIL_TESTID)).toBeInTheDocument();
       });
       expect(screen.getByTestId(RESERVE_DETAIL_TESTID)).toHaveAttribute(
         "data-reserve-id",
-        "usdc",
+        "5",
       );
       expect(screen.getByTestId(RESERVE_DETAIL_TESTID)).toHaveAttribute(
         "data-tab",
@@ -496,7 +496,7 @@ describe("Router — flag-aware reserve-detail routing", () => {
     });
 
     it("does NOT open reserve detail overlay on /loans when flag is off", async () => {
-      renderAt("/loans?reserve=usdc&tab=repay");
+      renderAt("/loans?reserve=5&tab=repay");
 
       await waitFor(() => {
         expect(screen.getByTestId(DASHBOARD_TESTID)).toBeInTheDocument();
@@ -513,7 +513,7 @@ describe("Router — flag-aware reserve-detail routing", () => {
     });
 
     it("does NOT open reserve detail overlay on / when flag is on", async () => {
-      renderAt("/?reserve=usdc&tab=repay");
+      renderAt("/?reserve=5&tab=repay");
 
       await waitFor(() => {
         expect(screen.getByTestId(DASHBOARD_TESTID)).toBeInTheDocument();
@@ -530,7 +530,7 @@ describe("Router — flag-aware reserve-detail routing", () => {
     });
 
     it("does NOT open reserve detail overlay on /vaults when flag is on", async () => {
-      renderAt("/vaults?reserve=usdc&tab=repay");
+      renderAt("/vaults?reserve=5&tab=repay");
 
       await waitFor(() => {
         expect(screen.getByTestId(VAULTS_PAGE_TESTID)).toBeInTheDocument();

--- a/services/vault/src/__tests__/routes.test.ts
+++ b/services/vault/src/__tests__/routes.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Reserve-detail route building and `?reserve=` parsing.
+ *
+ * The reserve detail is addressed by the reserve's on-chain id, never by its
+ * token symbol: the symbol comes from the indexer, so a symbol-keyed link lets
+ * a compromised indexer decide which reserve opens (audit F7).
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { getReserveDetailRoute, parseReserveId } from "../routes";
+
+describe("getReserveDetailRoute", () => {
+  it("writes the reserve id into the v2 route", () => {
+    expect(getReserveDetailRoute(5n, "borrow", false)).toBe(
+      "/?reserve=5&tab=borrow",
+    );
+  });
+
+  it("writes the reserve id into the v3 route", () => {
+    expect(getReserveDetailRoute(5n, "repay", true)).toBe(
+      "/loans?reserve=5&tab=repay",
+    );
+  });
+
+  it("preserves a large reserve id exactly", () => {
+    expect(getReserveDetailRoute(18446744073709551617n, "borrow", true)).toBe(
+      "/loans?reserve=18446744073709551617&tab=borrow",
+    );
+  });
+});
+
+describe("parseReserveId", () => {
+  it("parses a plain decimal id", () => {
+    expect(parseReserveId("5")).toBe(5n);
+  });
+
+  it("parses zero", () => {
+    expect(parseReserveId("0")).toBe(0n);
+  });
+
+  it("rejects a legacy symbol param", () => {
+    expect(parseReserveId("usdc")).toBeNull();
+  });
+
+  it.each(["0x5", " 5 ", "-1", "5.0", "5e3", "", "abc"])(
+    "rejects %j rather than coercing it",
+    (param) => {
+      expect(parseReserveId(param)).toBeNull();
+    },
+  );
+
+  it("returns null for a missing param", () => {
+    expect(parseReserveId(null)).toBeNull();
+    expect(parseReserveId(undefined)).toBeNull();
+  });
+});

--- a/services/vault/src/applications/aave/components/AssetPill/AssetPill.tsx
+++ b/services/vault/src/applications/aave/components/AssetPill/AssetPill.tsx
@@ -49,10 +49,13 @@ export function AssetPill({
     return () => cancelAnimationFrame(frame);
   }, [isOpen]);
 
-  const handleSelect = (assetSymbol: string) => {
+  // Navigate by the reserve's on-chain id, never by its symbol: the symbol is
+  // indexer-supplied, so routing on it lets a compromised indexer decide which
+  // reserve the click opens (audit F7).
+  const handleSelect = (reserveId: bigint) => {
     setIsOpen(false);
     navigate(
-      getReserveDetailRoute(assetSymbol, mode, FeatureFlags.isV3UiEnabled),
+      getReserveDetailRoute(reserveId, mode, FeatureFlags.isV3UiEnabled),
     );
   };
 
@@ -92,7 +95,7 @@ export function AssetPill({
               name={reserve.token.name}
               icon={getTokenByAddress(reserve.token.address)?.icon}
               selected={reserve.token.symbol === symbol}
-              onClick={() => handleSelect(reserve.token.symbol)}
+              onClick={() => handleSelect(reserve.reserveId)}
             />
           ))}
         </div>

--- a/services/vault/src/applications/aave/components/AssetPill/AssetPill.tsx
+++ b/services/vault/src/applications/aave/components/AssetPill/AssetPill.tsx
@@ -14,6 +14,8 @@ import { AssetListItem } from "../AssetSelectionPanel/AssetListItem";
 interface AssetPillProps {
   symbol: string;
   icon: string;
+  /** Reserve currently open, so the list can mark its row. */
+  selectedReserveId: bigint;
   /**
    * Reserves to offer in the switcher. Borrow passes the borrowable reserves;
    * repay passes the user's borrowed reserves (the assets that can be repaid).
@@ -28,6 +30,7 @@ interface AssetPillProps {
 export function AssetPill({
   symbol,
   icon,
+  selectedReserveId,
   reserves,
   mode,
   disabled = false,
@@ -94,7 +97,10 @@ export function AssetPill({
               symbol={reserve.token.symbol}
               name={reserve.token.name}
               icon={getTokenByAddress(reserve.token.address)?.icon}
-              selected={reserve.token.symbol === symbol}
+              // By id, not by symbol: `symbol` is the proven label of the open
+              // reserve, while the rows carry indexer labels, so comparing the
+              // two could mark the wrong row (or none).
+              selected={reserve.reserveId === selectedReserveId}
               onClick={() => handleSelect(reserve.reserveId)}
             />
           ))}

--- a/services/vault/src/applications/aave/components/AssetPill/__tests__/AssetPill.test.tsx
+++ b/services/vault/src/applications/aave/components/AssetPill/__tests__/AssetPill.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * AssetPill — the in-form asset switcher.
+ *
+ * Guards that picking a row navigates by the reserve's on-chain id rather than
+ * its indexer-supplied symbol, so two reserves sharing a symbol can't steer the
+ * switch to the wrong one (audit F7).
+ */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import type { Address } from "viem";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { LOAN_TAB } from "../../../constants";
+import type { AaveReserveConfig } from "../../../services/fetchConfig";
+import { AssetPill } from "../AssetPill";
+
+const navigate = vi.fn();
+
+vi.mock("react-router", () => ({
+  useNavigate: () => navigate,
+}));
+
+vi.mock("@babylonlabs-io/core-ui", () => ({
+  Popover: ({ open, children }: { open: boolean; children: ReactNode }) =>
+    open ? <div>{children}</div> : null,
+  Avatar: ({ alt }: { alt: string }) => <img alt={alt} />,
+}));
+
+vi.mock("@/config", () => ({
+  FeatureFlags: { isV3UiEnabled: true },
+  // AssetListItem pulls in @/utils/formatting, which reads BTC network config
+  // at module scope.
+  getNetworkConfigBTC: () => ({ coinSymbol: "sBTC", displayUSD: false }),
+}));
+
+vi.mock("@/services/token/tokenService", () => ({
+  getTokenByAddress: () => ({ icon: "icon.png" }),
+  getCurrencyIconWithFallback: () => "icon.png",
+}));
+
+// Two reserves deliberately share the symbol "USDC"; only their ids differ.
+// Only the fields AssetPill reads are populated.
+const reserves = [
+  {
+    reserveId: 2n,
+    reserve: { underlying: "0xUSDC" as Address },
+    token: {
+      symbol: "USDC",
+      name: "USD Coin",
+      address: "0xUSDC" as Address,
+      decimals: 6,
+    },
+  },
+  {
+    reserveId: 9n,
+    reserve: { underlying: "0xIMPOSTOR" as Address },
+    token: {
+      symbol: "USDC",
+      name: "USD Coin (impostor)",
+      address: "0xIMPOSTOR" as Address,
+      decimals: 18,
+    },
+  },
+] as unknown as AaveReserveConfig[];
+
+describe("AssetPill", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("navigates by the clicked row's reserve id, not its symbol", () => {
+    render(
+      <AssetPill
+        symbol="USDC"
+        icon="icon.png"
+        reserves={reserves}
+        mode={LOAN_TAB.BORROW}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /USDC/ }));
+    fireEvent.click(screen.getByText("USD Coin (impostor)"));
+
+    expect(navigate).toHaveBeenCalledWith("/loans?reserve=9&tab=borrow");
+  });
+
+  it("keeps the current tab when switching asset", () => {
+    render(
+      <AssetPill
+        symbol="USDC"
+        icon="icon.png"
+        reserves={reserves}
+        mode={LOAN_TAB.REPAY}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /USDC/ }));
+    fireEvent.click(screen.getByText("USD Coin"));
+
+    expect(navigate).toHaveBeenCalledWith("/loans?reserve=2&tab=repay");
+  });
+});

--- a/services/vault/src/applications/aave/components/AssetPill/__tests__/AssetPill.test.tsx
+++ b/services/vault/src/applications/aave/components/AssetPill/__tests__/AssetPill.test.tsx
@@ -74,6 +74,7 @@ describe("AssetPill", () => {
       <AssetPill
         symbol="USDC"
         icon="icon.png"
+        selectedReserveId={2n}
         reserves={reserves}
         mode={LOAN_TAB.BORROW}
       />,
@@ -90,6 +91,7 @@ describe("AssetPill", () => {
       <AssetPill
         symbol="USDC"
         icon="icon.png"
+        selectedReserveId={2n}
         reserves={reserves}
         mode={LOAN_TAB.REPAY}
       />,

--- a/services/vault/src/applications/aave/components/AssetSelectionPanel/AssetSelectionPanel.tsx
+++ b/services/vault/src/applications/aave/components/AssetSelectionPanel/AssetSelectionPanel.tsx
@@ -39,15 +39,24 @@ import {
 } from "../../hooks";
 import type { Asset } from "../../types";
 
+/**
+ * An asset the picker can route to. The reserve id is what selection emits —
+ * the symbol is a label only, so a compromised indexer can't steer the click
+ * to a different reserve (audit F7).
+ */
+export interface SelectableAsset extends Asset {
+  reserveId: bigint;
+}
+
 interface AssetSelectionPanelProps {
-  onSelectAsset: (assetSymbol: string) => void;
+  onSelectAsset: (reserveId: bigint) => void;
   /** Mode determines which columns render and the empty-state copy. */
   mode?: LoanTab;
   /**
    * Optional list of assets to display.
    * When provided, these assets are shown instead of the default borrowable reserves.
    */
-  assets?: Asset[];
+  assets?: SelectableAsset[];
   /** Whether `assets` is still resolving; repay rows come from a query the
    *  panel does not own, so it can't infer this from an empty list. */
   assetsLoading?: boolean;
@@ -56,6 +65,7 @@ interface AssetSelectionPanelProps {
 /** Normalized row, mode-agnostic, so the table render stays declarative. */
 interface AssetRow {
   key: string;
+  reserveId: bigint;
   symbol: string;
   name: string;
   icon?: string;
@@ -126,27 +136,20 @@ export function AssetSelectionPanel({
     reserves: isRepay ? [] : borrowableReserves,
   });
 
-  // Oracle prices are keyed by reserve id; repay rows arrive as plain assets
-  // (no reserve id), so index the fetched prices by symbol to show them too.
-  const priceBySymbol = useMemo(() => {
-    const map = new Map<string, number>();
-    for (const reserve of pricedReserves) {
-      const price = pricesByReserveId[reserve.reserveId.toString()];
-      if (price != null) map.set(reserve.token.symbol, price);
-    }
-    return map;
-  }, [pricedReserves, pricesByReserveId]);
-
-  const handleMarketInfoClick = (assetSymbol: string) => {
-    navigate(getMarketDataRoute(assetSymbol));
+  const handleMarketInfoClick = (reserveId: bigint) => {
+    navigate(getMarketDataRoute(reserveId));
   };
 
   const rows: AssetRow[] = useMemo(() => {
     if (assets) {
       return assets.map((asset) => {
-        const price = priceBySymbol.get(asset.symbol) ?? asset.priceUsd;
+        // Repay rows carry their own reserve id, so the oracle prices fetched
+        // for the borrowable set index cleanly by id here too.
+        const reserveKey = asset.reserveId.toString();
+        const price = pricesByReserveId[reserveKey] ?? asset.priceUsd;
         return {
-          key: asset.symbol,
+          key: reserveKey,
+          reserveId: asset.reserveId,
           symbol: asset.symbol,
           name: asset.name,
           icon: asset.icon,
@@ -163,6 +166,7 @@ export function AssetSelectionPanel({
       const liquidity = liquidityByReserveId[reserveKey];
       return {
         key: reserveKey,
+        reserveId: reserve.reserveId,
         symbol: reserve.token.symbol,
         name: reserve.token.name,
         icon: getTokenByAddress(reserve.token.address)?.icon,
@@ -184,7 +188,6 @@ export function AssetSelectionPanel({
     pricesByReserveId,
     aprPercentByReserveId,
     liquidityByReserveId,
-    priceBySymbol,
   ]);
 
   const renderBody = () => {
@@ -243,7 +246,7 @@ export function AssetSelectionPanel({
               className="flex w-full items-center gap-4 rounded-xl bg-secondary-highlight p-4 transition-colors hover:bg-secondary-strokeLight dark:bg-primary-main dark:hover:bg-secondary-strokeDark"
             >
               <button
-                onClick={() => onSelectAsset(row.symbol)}
+                onClick={() => onSelectAsset(row.reserveId)}
                 className="flex min-w-0 flex-1 cursor-pointer items-center text-left"
                 data-testid={`asset-select-row-${row.symbol.toLowerCase()}`}
               >
@@ -279,7 +282,7 @@ export function AssetSelectionPanel({
               {showMarketInfo && (
                 <button
                   type="button"
-                  onClick={() => handleMarketInfoClick(row.symbol)}
+                  onClick={() => handleMarketInfoClick(row.reserveId)}
                   aria-label={COPY.loans.assetSelection.marketInfoAriaLabel(
                     row.symbol,
                   )}

--- a/services/vault/src/applications/aave/components/AssetSelectionPanel/__tests__/AssetSelectionPanel.test.tsx
+++ b/services/vault/src/applications/aave/components/AssetSelectionPanel/__tests__/AssetSelectionPanel.test.tsx
@@ -121,7 +121,15 @@ describe("AssetSelectionPanel", () => {
       <AssetSelectionPanel
         onSelectAsset={vi.fn()}
         mode={LOAN_TAB.REPAY}
-        assets={[{ symbol: "USDC", name: "USD Coin", icon: "i", priceUsd: 1 }]}
+        assets={[
+          {
+            reserveId: 1n,
+            symbol: "USDC",
+            name: "USD Coin",
+            icon: "i",
+            priceUsd: 1,
+          },
+        ]}
       />,
     );
 
@@ -136,7 +144,15 @@ describe("AssetSelectionPanel", () => {
       <AssetSelectionPanel
         onSelectAsset={vi.fn()}
         mode={LOAN_TAB.REPAY}
-        assets={[{ symbol: "USDC", name: "USD Coin", icon: "i", priceUsd: 1 }]}
+        assets={[
+          {
+            reserveId: 1n,
+            symbol: "USDC",
+            name: "USD Coin",
+            icon: "i",
+            priceUsd: 1,
+          },
+        ]}
       />,
     );
 
@@ -154,7 +170,7 @@ describe("AssetSelectionPanel", () => {
 
     screen.getByText("Wrapped BTC").click();
 
-    expect(onSelectAsset).toHaveBeenCalledWith("WBTC");
+    expect(onSelectAsset).toHaveBeenCalledWith(2n);
   });
 
   it("routes to the asset's markets data page when Market Info is clicked", () => {
@@ -168,7 +184,7 @@ describe("AssetSelectionPanel", () => {
 
     fireEvent.click(screen.getByTestId("asset-market-info-wbtc"));
 
-    expect(screen.getByTestId("location")).toHaveTextContent("/markets/wbtc");
+    expect(screen.getByTestId("location")).toHaveTextContent("/markets/2");
     expect(onSelectAsset).not.toHaveBeenCalled();
   });
 
@@ -177,7 +193,7 @@ describe("AssetSelectionPanel", () => {
       <AssetSelectionPanel
         onSelectAsset={vi.fn()}
         mode={LOAN_TAB.REPAY}
-        assets={[{ symbol: "DAI", name: "Dai", icon: "i" }]}
+        assets={[{ reserveId: 3n, symbol: "DAI", name: "Dai", icon: "i" }]}
       />,
     );
 

--- a/services/vault/src/applications/aave/components/AssetSelectionPanel/index.tsx
+++ b/services/vault/src/applications/aave/components/AssetSelectionPanel/index.tsx
@@ -1,4 +1,5 @@
 export {
   AssetSelectionPanel,
   getAssetPickerWidthClass,
+  type SelectableAsset,
 } from "./AssetSelectionPanel";

--- a/services/vault/src/applications/aave/components/Detail/PositionGate.tsx
+++ b/services/vault/src/applications/aave/components/Detail/PositionGate.tsx
@@ -10,6 +10,8 @@
 import { Button, Text } from "@babylonlabs-io/core-ui";
 import type { ReactNode } from "react";
 
+import { COPY } from "@/copy";
+
 export interface PositionGateProps {
   positionError: Error | null;
   ancillaryError: Error | null;
@@ -27,9 +29,11 @@ export function PositionGate({
     return (
       <div className="flex flex-col items-center gap-3">
         <Text variant="body2" className="text-center text-warning-main">
-          Couldn&apos;t load your position. Please try again.
+          {COPY.loans.detail.positionLoadError}
         </Text>
-        <Button onClick={() => void refetchPosition()}>Retry</Button>
+        <Button onClick={() => void refetchPosition()}>
+          {COPY.loans.detail.retry}
+        </Button>
       </div>
     );
   }
@@ -38,8 +42,7 @@ export function PositionGate({
     <>
       {ancillaryError ? (
         <Text variant="body2" className="text-center text-warning-main">
-          Some data couldn&apos;t be loaded. Borrow may be unavailable; repay
-          still works from your loaded debt.
+          {COPY.loans.detail.ancillaryLoadWarning}
         </Text>
       ) : null}
       {children}

--- a/services/vault/src/applications/aave/components/Detail/ReserveDetailPanel.tsx
+++ b/services/vault/src/applications/aave/components/Detail/ReserveDetailPanel.tsx
@@ -13,6 +13,7 @@ import { useAaveConfig } from "../../context";
 import { useAaveOracleAddress } from "../../hooks";
 import { LoanProvider } from "../context/LoanContext";
 import { LoanCard } from "../LoanCard";
+import { ReserveIdentityBlock } from "../ReserveIdentityBlock";
 
 import { useAaveReserveDetail } from "./hooks";
 import { PositionGate } from "./PositionGate";
@@ -31,6 +32,7 @@ export interface LoanSuccessState {
 }
 
 interface ReserveDetailPanelProps {
+  /** Raw `?reserve=` value — the reserve's on-chain id as a decimal string. */
   reserveId: string;
   tab: LoanTab;
   onProcessingChange: (isProcessing: boolean) => void;
@@ -54,6 +56,7 @@ export function ReserveDetailPanel({
   const {
     isLoading,
     selectedReserve,
+    tokenIdentity,
     assetConfig,
     vbtcReserve,
     liquidationThresholdBps,
@@ -66,19 +69,35 @@ export function ReserveDetailPanel({
     isPriceStale,
     positionError,
     ancillaryError,
+    identityError,
+    isIdentityCompromised,
+    retryIdentity,
+    isLegacyReserveParam,
     isPositionDataStale,
     refetchPosition,
     refetchSplitParams,
   } = useAaveReserveDetail({ reserveId, address });
 
-  if (isLoading) {
-    return (
-      <div className="flex items-center justify-center py-12">
-        <p className="text-accent-secondary">{COPY.common.loading}</p>
-      </div>
-    );
-  }
+  // One narrowing point for everything that depends on a proven identity, so
+  // the context value below cannot be assembled from a half-verified reserve.
+  const verified =
+    selectedReserve &&
+    tokenIdentity &&
+    assetConfig &&
+    vbtcReserve &&
+    currentDebtAmount != null
+      ? {
+          selectedReserve,
+          tokenIdentity,
+          assetConfig,
+          vbtcReserve,
+          currentDebtAmount,
+        }
+      : null;
 
+  // First: this branch renders no reserve-derived label or number, and the
+  // identity query runs without a wallet — leaving it below the gate would park
+  // a disconnected user behind an RPC before telling them to connect.
   if (!isConnected) {
     return (
       <EmptyState
@@ -93,24 +112,60 @@ export function ReserveDetailPanel({
     );
   }
 
-  // Don't gate on oracleAddress — repay doesn't need it; lookup failure
-  // surfaces via ancillaryError on Borrow.
-  if (!selectedReserve || !assetConfig || !vbtcReserve) {
+  // Before `isLoading`: that flag ORs four sources, so a still-pending price
+  // query would otherwise pin a spinner over a resolved integrity failure.
+  if (identityError) {
+    return (
+      <ReserveIdentityBlock
+        compromised={isIdentityCompromised}
+        onRetry={() => void retryIdentity()}
+      />
+    );
+  }
+
+  if (isLoading) {
     return (
       <div className="flex items-center justify-center py-12">
-        <p className="text-accent-secondary">{COPY.loans.reserveNotFound}</p>
+        <p className="text-accent-secondary">{COPY.common.loading}</p>
       </div>
     );
   }
 
+  // Unresolvable: missing/legacy/non-numeric param, no id match, more than one
+  // id match, or a missing vBTC reserve. Don't gate on oracleAddress — repay
+  // doesn't need it; lookup failure surfaces via ancillaryError on Borrow.
+  if (!verified) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <p className="text-accent-secondary">
+          {isLegacyReserveParam
+            ? COPY.loans.detail.reserveLinkOutdated
+            : COPY.loans.reserveNotFound}
+        </p>
+      </div>
+    );
+  }
+
+  const settled = (variant: "borrow" | "repay", amount: number) => ({
+    reserveId,
+    variant,
+    amount,
+    symbol: verified.assetConfig.symbol,
+    // Proven decimals, so the success screen can't report a different amount
+    // than the one that was signed.
+    decimals: verified.tokenIdentity.decimals,
+    assetIcon: verified.assetConfig.icon,
+  });
+
   const loanContextValue = {
     collateralValueUsd,
-    currentDebtAmount,
+    currentDebtAmount: verified.currentDebtAmount,
     totalDebtValueUsd,
     healthFactor,
     liquidationThresholdBps,
-    selectedReserve,
-    assetConfig,
+    selectedReserve: verified.selectedReserve,
+    tokenIdentity: verified.tokenIdentity,
+    assetConfig: verified.assetConfig,
     proxyContract,
     oracleAddress,
     tokenPriceUsd,
@@ -118,24 +173,9 @@ export function ReserveDetailPanel({
     isPositionDataStale,
     refetchPosition,
     refetchSplitParams,
-    onBorrowSuccess: (amount: number) =>
-      onSuccess({
-        reserveId,
-        variant: "borrow",
-        amount,
-        symbol: assetConfig.symbol,
-        decimals: selectedReserve.token.decimals,
-        assetIcon: assetConfig.icon,
-      }),
+    onBorrowSuccess: (amount: number) => onSuccess(settled("borrow", amount)),
     onRepaySuccess: (repayAmount: number) =>
-      onSuccess({
-        reserveId,
-        variant: "repay",
-        amount: repayAmount,
-        symbol: assetConfig.symbol,
-        decimals: selectedReserve.token.decimals,
-        assetIcon: assetConfig.icon,
-      }),
+      onSuccess(settled("repay", repayAmount)),
     onProcessingChange,
   };
 

--- a/services/vault/src/applications/aave/components/Detail/ReserveIdentityBlock.tsx
+++ b/services/vault/src/applications/aave/components/Detail/ReserveIdentityBlock.tsx
@@ -1,0 +1,53 @@
+/**
+ * ReserveIdentityBlock
+ *
+ * Shown in place of the entire reserve detail when the reserve's asset can't be
+ * proven on-chain (audit F7). Two distinct cases, deliberately worded apart:
+ *
+ * - `compromised` — verification completed and *failed*: the on-chain reserve
+ *   maps to a different token than the indexer claimed, or no trusted label
+ *   exists for it. Deterministic, so no Retry is offered; retrying a proven
+ *   mismatch only trains the user to click past a security warning.
+ * - otherwise — verification couldn't complete (RPC/network). Neutral copy and
+ *   a Retry button.
+ */
+
+import { Button, Text } from "@babylonlabs-io/core-ui";
+
+import { COPY } from "@/copy";
+
+export interface ReserveIdentityBlockProps {
+  /** True when the failure is a proven mismatch rather than an RPC fault. */
+  compromised: boolean;
+  /** Re-run verification. Only rendered when `compromised` is false. */
+  onRetry: () => void;
+}
+
+export function ReserveIdentityBlock({
+  compromised,
+  onRetry,
+}: ReserveIdentityBlockProps) {
+  const { title, description } = compromised
+    ? {
+        title: COPY.loans.detail.identityBlockedTitle,
+        description: COPY.loans.detail.identityBlockedDescription,
+      }
+    : {
+        title: COPY.loans.detail.identityUnavailableTitle,
+        description: COPY.loans.detail.identityUnavailableDescription,
+      };
+
+  return (
+    <div className="flex flex-col items-center gap-3 py-12">
+      <Text variant="body1" className="text-center text-accent-primary">
+        {title}
+      </Text>
+      <Text variant="body2" className="text-center text-warning-main">
+        {description}
+      </Text>
+      {!compromised && (
+        <Button onClick={onRetry}>{COPY.loans.detail.retry}</Button>
+      )}
+    </div>
+  );
+}

--- a/services/vault/src/applications/aave/components/Detail/__tests__/AaveReserveDetail.test.tsx
+++ b/services/vault/src/applications/aave/components/Detail/__tests__/AaveReserveDetail.test.tsx
@@ -1,0 +1,281 @@
+/**
+ * AaveReserveDetail — branch order of the reserve-detail overlay.
+ *
+ * The ordering is load-bearing, not cosmetic: nothing derived from the reserve
+ * may reach the DOM before its asset is proven on-chain (audit F7). In
+ * particular the identity block must win over the loading spinner, since
+ * `isLoading` ORs four sources and a still-pending price query would otherwise
+ * hide a resolved integrity failure.
+ */
+
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import type { Address } from "viem";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { COPY } from "@/copy";
+
+import { AaveReserveDetail } from "..";
+import { LOAN_TAB } from "../../../constants";
+
+vi.mock("@babylonlabs-io/core-ui", () => ({
+  Button: ({
+    children,
+    onClick,
+  }: {
+    children: ReactNode;
+    onClick: () => void;
+  }) => <button onClick={onClick}>{children}</button>,
+  Text: ({ children }: { children: ReactNode }) => <p>{children}</p>,
+}));
+
+vi.mock("react-router", () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock("@/components/shared", () => ({
+  EmptyState: ({ title }: { title: string }) => <div>{title}</div>,
+}));
+
+vi.mock("@/components/shared/V3ModalShell", () => ({
+  V3ModalShell: ({ open, children }: { open: boolean; children: ReactNode }) =>
+    open ? <div>{children}</div> : null,
+}));
+
+vi.mock("@/config", () => ({
+  FeatureFlags: { isV3UiEnabled: true },
+  getNetworkConfigBTC: () => ({ icon: "btc.png", name: "sBTC" }),
+}));
+
+const mockUseConnection = vi.fn(() => ({ isConnected: true }));
+vi.mock("@/context/wallet", () => ({
+  useConnection: () => mockUseConnection(),
+  useETHWallet: () => ({ address: "0xUser" }),
+}));
+
+vi.mock("../../../context", () => ({
+  useAaveConfig: () => ({ config: { coreSpokeAddress: "0xSpoke" } }),
+}));
+
+vi.mock("../../../hooks", () => ({
+  useAaveOracleAddress: () => ({ oracleAddress: "0xOracle" }),
+}));
+
+// The borrow/repay form itself is out of scope here; its presence is the
+// assertion that the overlay reached the proven branch.
+vi.mock("../../LoanCard", () => ({
+  LoanCard: () => <div data-testid="loan-card" />,
+}));
+
+vi.mock("../../LoanCard/LoanSuccessModal", () => ({
+  LoanSuccessModal: () => null,
+}));
+
+const mockUseAaveReserveDetail = vi.fn();
+vi.mock("../hooks", () => ({
+  useAaveReserveDetail: () => mockUseAaveReserveDetail(),
+  useBorrowRepayModals: () => ({
+    showBorrowSuccess: false,
+    borrowSuccessData: { amount: 0 },
+    openBorrowSuccess: vi.fn(),
+    closeBorrowSuccess: vi.fn(),
+    showRepaySuccess: false,
+    repaySuccessData: { repayAmount: 0, withdrawAmount: 0 },
+    openRepaySuccess: vi.fn(),
+    closeRepaySuccess: vi.fn(),
+  }),
+}));
+
+const RESERVE = {
+  reserveId: 2n,
+  reserve: { collateralFactor: 0, underlying: "0xUSDC" as Address },
+  token: {
+    symbol: "USDC",
+    name: "USD Coin",
+    decimals: 6,
+    address: "0xUSDC" as Address,
+  },
+};
+
+const IDENTITY = {
+  address: "0xUSDC" as Address,
+  symbol: "USDC",
+  name: "USD Coin",
+  decimals: 6,
+  icon: undefined,
+  source: "registry" as const,
+};
+
+function detailState(overrides: Record<string, unknown> = {}) {
+  return {
+    isLoading: false,
+    selectedReserve: RESERVE,
+    tokenIdentity: IDENTITY,
+    assetConfig: { symbol: "USDC", name: "USD Coin", icon: "icon.png" },
+    vbtcReserve: { reserveId: 1n },
+    liquidationThresholdBps: 7500,
+    proxyContract: "0xProxy",
+    collateralValueUsd: 15000,
+    currentDebtAmount: 0,
+    totalDebtValueUsd: 0,
+    healthFactor: null,
+    tokenPriceUsd: 1,
+    isPriceStale: false,
+    positionError: null,
+    ancillaryError: null,
+    identityError: null,
+    isIdentityCompromised: false,
+    retryIdentity: vi.fn(),
+    isLegacyReserveParam: false,
+    isPositionDataStale: false,
+    refetchPosition: vi.fn(),
+    refetchSplitParams: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("AaveReserveDetail", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseConnection.mockReturnValue({ isConnected: true });
+    mockUseAaveReserveDetail.mockReturnValue(detailState());
+  });
+
+  it("renders the loan form once the reserve's identity is proven", () => {
+    render(<AaveReserveDetail reserveId="2" tab={LOAN_TAB.BORROW} />);
+
+    expect(screen.getByTestId("loan-card")).toBeInTheDocument();
+  });
+
+  it("blocks with integrity copy and no retry when the asset can't be verified", () => {
+    mockUseAaveReserveDetail.mockReturnValue(
+      detailState({
+        identityError: new Error("reserve maps to a different token"),
+        isIdentityCompromised: true,
+        tokenIdentity: null,
+        assetConfig: null,
+        currentDebtAmount: null,
+      }),
+    );
+
+    render(<AaveReserveDetail reserveId="2" tab={LOAN_TAB.BORROW} />);
+
+    expect(
+      screen.getByText(COPY.loans.detail.identityBlockedTitle),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("loan-card")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: COPY.loans.detail.retry }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("blocks with retryable copy when verification couldn't complete", () => {
+    mockUseAaveReserveDetail.mockReturnValue(
+      detailState({
+        identityError: new Error("rpc connection lost"),
+        isIdentityCompromised: false,
+        tokenIdentity: null,
+        assetConfig: null,
+        currentDebtAmount: null,
+      }),
+    );
+
+    render(<AaveReserveDetail reserveId="2" tab={LOAN_TAB.BORROW} />);
+
+    expect(
+      screen.getByText(COPY.loans.detail.identityUnavailableTitle),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: COPY.loans.detail.retry }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the identity block rather than the spinner while other sources still load", () => {
+    mockUseAaveReserveDetail.mockReturnValue(
+      detailState({
+        isLoading: true,
+        identityError: new Error("reserve maps to a different token"),
+        isIdentityCompromised: true,
+        tokenIdentity: null,
+        assetConfig: null,
+        currentDebtAmount: null,
+      }),
+    );
+
+    render(<AaveReserveDetail reserveId="2" tab={LOAN_TAB.BORROW} />);
+
+    expect(
+      screen.getByText(COPY.loans.detail.identityBlockedTitle),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(COPY.loans.detail.loading),
+    ).not.toBeInTheDocument();
+  });
+
+  it("prompts to connect without waiting on the identity round-trip", () => {
+    mockUseConnection.mockReturnValue({ isConnected: false });
+    mockUseAaveReserveDetail.mockReturnValue(
+      detailState({
+        isLoading: true,
+        tokenIdentity: null,
+        assetConfig: null,
+        currentDebtAmount: null,
+      }),
+    );
+
+    render(<AaveReserveDetail reserveId="2" tab={LOAN_TAB.BORROW} />);
+
+    expect(
+      screen.getByText(COPY.loans.detail.connectTitle),
+    ).toBeInTheDocument();
+  });
+
+  it("tells the user a legacy symbol link is outdated", () => {
+    mockUseAaveReserveDetail.mockReturnValue(
+      detailState({
+        selectedReserve: null,
+        tokenIdentity: null,
+        assetConfig: null,
+        currentDebtAmount: null,
+        isLegacyReserveParam: true,
+      }),
+    );
+
+    render(<AaveReserveDetail reserveId="usdc" tab={LOAN_TAB.BORROW} />);
+
+    expect(
+      screen.getByText(COPY.loans.detail.reserveLinkOutdated),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("loan-card")).not.toBeInTheDocument();
+  });
+
+  it("reports an unresolvable reserve id as not found", () => {
+    mockUseAaveReserveDetail.mockReturnValue(
+      detailState({
+        selectedReserve: null,
+        tokenIdentity: null,
+        assetConfig: null,
+        currentDebtAmount: null,
+      }),
+    );
+
+    render(<AaveReserveDetail reserveId="99999" tab={LOAN_TAB.BORROW} />);
+
+    expect(
+      screen.getByText(COPY.loans.detail.reserveNotFound),
+    ).toBeInTheDocument();
+  });
+
+  it("withholds the loan form while the debt figure is still unproven", () => {
+    mockUseAaveReserveDetail.mockReturnValue(
+      detailState({ currentDebtAmount: null }),
+    );
+
+    render(<AaveReserveDetail reserveId="2" tab={LOAN_TAB.BORROW} />);
+
+    expect(screen.queryByTestId("loan-card")).not.toBeInTheDocument();
+    expect(
+      screen.getByText(COPY.loans.detail.reserveNotFound),
+    ).toBeInTheDocument();
+  });
+});

--- a/services/vault/src/applications/aave/components/Detail/__tests__/LoanFlowOverlay.test.tsx
+++ b/services/vault/src/applications/aave/components/Detail/__tests__/LoanFlowOverlay.test.tsx
@@ -40,12 +40,9 @@ vi.mock("../../AssetSelectionPanel", () => ({
     onSelectAsset,
   }: {
     mode: string;
-    onSelectAsset: (symbol: string) => void;
+    onSelectAsset: (reserveId: bigint) => void;
   }) => (
-    <button
-      data-testid={`picker-${mode}`}
-      onClick={() => onSelectAsset("WBTC")}
-    >
+    <button data-testid={`picker-${mode}`} onClick={() => onSelectAsset(2n)}>
       picker
     </button>
   ),
@@ -137,7 +134,7 @@ describe("LoanFlowOverlay", () => {
     fireEvent.click(screen.getByTestId("picker-borrow"));
 
     expect(screen.getByTestId("location")).toHaveTextContent(
-      "/loans?reserve=wbtc&tab=borrow",
+      "/loans?reserve=2&tab=borrow",
     );
   });
 
@@ -145,22 +142,19 @@ describe("LoanFlowOverlay", () => {
     renderOverlay(
       <LoanFlowOverlay
         picker={LOAN_TAB.BORROW}
-        reserveId="wbtc"
+        reserveId="2"
         tab={LOAN_TAB.BORROW}
       />,
     );
 
-    expect(screen.getByTestId("form")).toHaveAttribute(
-      "data-reserve-id",
-      "wbtc",
-    );
+    expect(screen.getByTestId("form")).toHaveAttribute("data-reserve-id", "2");
     expect(screen.queryByTestId("picker-borrow")).not.toBeInTheDocument();
     expect(screen.getAllByTestId(SHELL_TESTID)).toHaveLength(1);
   });
 
   it("shows the success step once the transaction settles on that reserve", () => {
     renderOverlay(
-      <LoanFlowOverlay picker={null} reserveId="wbtc" tab={LOAN_TAB.BORROW} />,
+      <LoanFlowOverlay picker={null} reserveId="2" tab={LOAN_TAB.BORROW} />,
     );
 
     fireEvent.click(screen.getByTestId("form"));
@@ -170,7 +164,7 @@ describe("LoanFlowOverlay", () => {
 
   it("drops a settled success when the step navigates back to the picker", () => {
     const { rerender } = renderOverlay(
-      <LoanFlowOverlay picker={null} reserveId="wbtc" tab={LOAN_TAB.BORROW} />,
+      <LoanFlowOverlay picker={null} reserveId="2" tab={LOAN_TAB.BORROW} />,
     );
 
     fireEvent.click(screen.getByTestId("form"));
@@ -197,10 +191,10 @@ describe("LoanFlowOverlay", () => {
     renderOverlay(
       <LoanFlowOverlay
         picker={LOAN_TAB.BORROW}
-        reserveId="wbtc"
+        reserveId="2"
         tab={LOAN_TAB.BORROW}
       />,
-      "/loans?reserve=wbtc&tab=borrow",
+      "/loans?reserve=2&tab=borrow",
     );
 
     fireEvent.click(screen.getByText("close"));
@@ -211,7 +205,7 @@ describe("LoanFlowOverlay", () => {
 
   it("locks every dismiss path while a transaction is in flight", () => {
     renderOverlay(
-      <LoanFlowOverlay picker={null} reserveId="wbtc" tab={LOAN_TAB.BORROW} />,
+      <LoanFlowOverlay picker={null} reserveId="2" tab={LOAN_TAB.BORROW} />,
     );
 
     fireEvent.click(screen.getByTestId("sign"));
@@ -221,7 +215,7 @@ describe("LoanFlowOverlay", () => {
 
   it("restores the close control on the success step after a tx settles", () => {
     renderOverlay(
-      <LoanFlowOverlay picker={null} reserveId="wbtc" tab={LOAN_TAB.BORROW} />,
+      <LoanFlowOverlay picker={null} reserveId="2" tab={LOAN_TAB.BORROW} />,
     );
 
     // The form reports processing, then settles in the same interaction the

--- a/services/vault/src/applications/aave/components/Detail/__tests__/ReserveDetailPanel.test.tsx
+++ b/services/vault/src/applications/aave/components/Detail/__tests__/ReserveDetailPanel.test.tsx
@@ -1,5 +1,5 @@
 /**
- * AaveReserveDetail — branch order of the reserve-detail overlay.
+ * ReserveDetailPanel — branch order of the loan overlay's borrow/repay step.
  *
  * The ordering is load-bearing, not cosmetic: nothing derived from the reserve
  * may reach the DOM before its asset is proven on-chain (audit F7). In
@@ -15,8 +15,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { COPY } from "@/copy";
 
-import { AaveReserveDetail } from "..";
 import { LOAN_TAB } from "../../../constants";
+import { ReserveDetailPanel } from "../ReserveDetailPanel";
 
 vi.mock("@babylonlabs-io/core-ui", () => ({
   Button: ({
@@ -35,11 +35,6 @@ vi.mock("react-router", () => ({
 
 vi.mock("@/components/shared", () => ({
   EmptyState: ({ title }: { title: string }) => <div>{title}</div>,
-}));
-
-vi.mock("@/components/shared/V3ModalShell", () => ({
-  V3ModalShell: ({ open, children }: { open: boolean; children: ReactNode }) =>
-    open ? <div>{children}</div> : null,
 }));
 
 vi.mock("@/config", () => ({
@@ -67,23 +62,9 @@ vi.mock("../../LoanCard", () => ({
   LoanCard: () => <div data-testid="loan-card" />,
 }));
 
-vi.mock("../../LoanCard/LoanSuccessModal", () => ({
-  LoanSuccessModal: () => null,
-}));
-
 const mockUseAaveReserveDetail = vi.fn();
 vi.mock("../hooks", () => ({
   useAaveReserveDetail: () => mockUseAaveReserveDetail(),
-  useBorrowRepayModals: () => ({
-    showBorrowSuccess: false,
-    borrowSuccessData: { amount: 0 },
-    openBorrowSuccess: vi.fn(),
-    closeBorrowSuccess: vi.fn(),
-    showRepaySuccess: false,
-    repaySuccessData: { repayAmount: 0, withdrawAmount: 0 },
-    openRepaySuccess: vi.fn(),
-    closeRepaySuccess: vi.fn(),
-  }),
 }));
 
 const RESERVE = {
@@ -134,7 +115,7 @@ function detailState(overrides: Record<string, unknown> = {}) {
   };
 }
 
-describe("AaveReserveDetail", () => {
+describe("ReserveDetailPanel", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockUseConnection.mockReturnValue({ isConnected: true });
@@ -142,7 +123,14 @@ describe("AaveReserveDetail", () => {
   });
 
   it("renders the loan form once the reserve's identity is proven", () => {
-    render(<AaveReserveDetail reserveId="2" tab={LOAN_TAB.BORROW} />);
+    render(
+      <ReserveDetailPanel
+        reserveId="2"
+        tab={LOAN_TAB.BORROW}
+        onProcessingChange={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    );
 
     expect(screen.getByTestId("loan-card")).toBeInTheDocument();
   });
@@ -158,7 +146,14 @@ describe("AaveReserveDetail", () => {
       }),
     );
 
-    render(<AaveReserveDetail reserveId="2" tab={LOAN_TAB.BORROW} />);
+    render(
+      <ReserveDetailPanel
+        reserveId="2"
+        tab={LOAN_TAB.BORROW}
+        onProcessingChange={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    );
 
     expect(
       screen.getByText(COPY.loans.detail.identityBlockedTitle),
@@ -180,7 +175,14 @@ describe("AaveReserveDetail", () => {
       }),
     );
 
-    render(<AaveReserveDetail reserveId="2" tab={LOAN_TAB.BORROW} />);
+    render(
+      <ReserveDetailPanel
+        reserveId="2"
+        tab={LOAN_TAB.BORROW}
+        onProcessingChange={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    );
 
     expect(
       screen.getByText(COPY.loans.detail.identityUnavailableTitle),
@@ -202,14 +204,19 @@ describe("AaveReserveDetail", () => {
       }),
     );
 
-    render(<AaveReserveDetail reserveId="2" tab={LOAN_TAB.BORROW} />);
+    render(
+      <ReserveDetailPanel
+        reserveId="2"
+        tab={LOAN_TAB.BORROW}
+        onProcessingChange={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    );
 
     expect(
       screen.getByText(COPY.loans.detail.identityBlockedTitle),
     ).toBeInTheDocument();
-    expect(
-      screen.queryByText(COPY.loans.detail.loading),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText(COPY.common.loading)).not.toBeInTheDocument();
   });
 
   it("prompts to connect without waiting on the identity round-trip", () => {
@@ -223,10 +230,17 @@ describe("AaveReserveDetail", () => {
       }),
     );
 
-    render(<AaveReserveDetail reserveId="2" tab={LOAN_TAB.BORROW} />);
+    render(
+      <ReserveDetailPanel
+        reserveId="2"
+        tab={LOAN_TAB.BORROW}
+        onProcessingChange={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    );
 
     expect(
-      screen.getByText(COPY.loans.detail.connectTitle),
+      screen.getByText(COPY.loans.connectToManage.title),
     ).toBeInTheDocument();
   });
 
@@ -241,7 +255,14 @@ describe("AaveReserveDetail", () => {
       }),
     );
 
-    render(<AaveReserveDetail reserveId="usdc" tab={LOAN_TAB.BORROW} />);
+    render(
+      <ReserveDetailPanel
+        reserveId="usdc"
+        tab={LOAN_TAB.BORROW}
+        onProcessingChange={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    );
 
     expect(
       screen.getByText(COPY.loans.detail.reserveLinkOutdated),
@@ -259,11 +280,16 @@ describe("AaveReserveDetail", () => {
       }),
     );
 
-    render(<AaveReserveDetail reserveId="99999" tab={LOAN_TAB.BORROW} />);
+    render(
+      <ReserveDetailPanel
+        reserveId="99999"
+        tab={LOAN_TAB.BORROW}
+        onProcessingChange={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    );
 
-    expect(
-      screen.getByText(COPY.loans.detail.reserveNotFound),
-    ).toBeInTheDocument();
+    expect(screen.getByText(COPY.loans.reserveNotFound)).toBeInTheDocument();
   });
 
   it("withholds the loan form while the debt figure is still unproven", () => {
@@ -271,11 +297,16 @@ describe("AaveReserveDetail", () => {
       detailState({ currentDebtAmount: null }),
     );
 
-    render(<AaveReserveDetail reserveId="2" tab={LOAN_TAB.BORROW} />);
+    render(
+      <ReserveDetailPanel
+        reserveId="2"
+        tab={LOAN_TAB.BORROW}
+        onProcessingChange={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    );
 
     expect(screen.queryByTestId("loan-card")).not.toBeInTheDocument();
-    expect(
-      screen.getByText(COPY.loans.detail.reserveNotFound),
-    ).toBeInTheDocument();
+    expect(screen.getByText(COPY.loans.reserveNotFound)).toBeInTheDocument();
   });
 });

--- a/services/vault/src/applications/aave/components/Detail/hooks/__tests__/useAaveReserveDetail.test.tsx
+++ b/services/vault/src/applications/aave/components/Detail/hooks/__tests__/useAaveReserveDetail.test.tsx
@@ -61,48 +61,41 @@ vi.mock("@/clients/eth-contract/client", () => ({
 }));
 
 vi.mock("@/services/token/tokenService", () => ({
-  getTokenByAddress: vi.fn(() => ({ icon: "usdc-icon" })),
   getCurrencyIconWithFallback: vi.fn(
     (icon: string | undefined) => icon ?? "fallback-icon",
   ),
 }));
 
 // Mock useAaveConfig
-const mockUseAaveConfig = vi.fn(() => ({
-  config: {
-    coreSpokeAddress: "0xSpokeAddress",
-    vaultBtcReserveId: 1n,
+/** Reserve 2 = USDC. `token.*` is indexer-supplied; the hook must not read it. */
+const usdcReserve = {
+  reserveId: 2n,
+  reserve: { collateralFactor: 0, underlying: "0xUSDC" as Address },
+  token: {
+    symbol: "USDC",
+    name: "USD Coin",
+    decimals: 6,
+    address: "0xUSDC" as Address,
   },
-  vbtcReserve: {
-    reserveId: 1n,
-    reserve: { collateralFactor: 8000 },
-    token: { symbol: "vBTC", name: "vBTC", decimals: 8, address: "0xvBTC" },
-  },
-  borrowableReserves: [
-    {
-      reserveId: 2n,
-      reserve: { collateralFactor: 0 },
-      token: {
-        symbol: "USDC",
-        name: "USD Coin",
-        decimals: 6,
-        address: "0xUSDC" as Address,
-      },
+};
+
+function defaultAaveConfig() {
+  return {
+    config: {
+      coreSpokeAddress: "0xSpokeAddress",
+      vaultBtcReserveId: 1n,
     },
-  ],
-  allBorrowReserves: [
-    {
-      reserveId: 2n,
-      reserve: { collateralFactor: 0 },
-      token: {
-        symbol: "USDC",
-        name: "USD Coin",
-        decimals: 6,
-        address: "0xUSDC" as Address,
-      },
+    vbtcReserve: {
+      reserveId: 1n,
+      reserve: { collateralFactor: 8000 },
+      token: { symbol: "vBTC", name: "vBTC", decimals: 8, address: "0xvBTC" },
     },
-  ],
-}));
+    borrowableReserves: [usdcReserve],
+    allBorrowReserves: [usdcReserve],
+  };
+}
+
+const mockUseAaveConfig = vi.fn(defaultAaveConfig);
 
 vi.mock("../../../../context", () => ({
   useAaveConfig: () => mockUseAaveConfig(),
@@ -144,6 +137,40 @@ const mockUseAaveReservePrice = vi.fn<
   error: null,
 }));
 
+/**
+ * Identity of the selected reserve, proven on-chain. Defaults to a resolved
+ * USDC identity with 6 decimals; individual tests override it to exercise the
+ * spoofed-label, wrong-decimals and integrity-failure paths.
+ */
+const mockUseVerifiedReserveIdentity = vi.fn<
+  (args: {
+    reserveId: bigint | undefined;
+    underlying: Address | undefined;
+  }) => {
+    identity: {
+      address: Address;
+      symbol: string;
+      name: string;
+      decimals: number;
+      icon: string | undefined;
+      source: "registry" | "onchain";
+    } | null;
+    isLoading: boolean;
+    error: Error | null;
+    isIntegrityViolation: boolean;
+    retry: () => Promise<unknown>;
+  }
+>();
+
+const USDC_IDENTITY = {
+  address: "0xUSDC" as Address,
+  symbol: "USDC",
+  name: "USD Coin",
+  decimals: 6,
+  icon: "usdc-icon",
+  source: "registry" as const,
+};
+
 vi.mock("../../../../hooks", () => ({
   useAaveUserPosition: (addr?: string) => mockUseAaveUserPosition(addr),
   useVaultSplitParams: (addr?: string) => mockUseVaultSplitParams(addr),
@@ -151,6 +178,10 @@ vi.mock("../../../../hooks", () => ({
     spokeAddress: Address | undefined;
     reserveId: bigint | undefined;
   }) => mockUseAaveReservePrice(args),
+  useVerifiedReserveIdentity: (args: {
+    reserveId: bigint | undefined;
+    underlying: Address | undefined;
+  }) => mockUseVerifiedReserveIdentity(args),
 }));
 
 // Import after mocks
@@ -173,6 +204,14 @@ describe("useAaveReserveDetail", () => {
 
     mockGetBTCNetwork.mockReturnValue("signet");
 
+    mockUseAaveConfig.mockReturnValue(defaultAaveConfig());
+    mockUseVerifiedReserveIdentity.mockReturnValue({
+      identity: USDC_IDENTITY,
+      isLoading: false,
+      error: null,
+      isIntegrityViolation: false,
+      retry: vi.fn(),
+    });
     mockUseAaveReservePrice.mockReturnValue({
       priceUsd: null,
       isLoading: false,
@@ -207,7 +246,7 @@ describe("useAaveReserveDetail", () => {
     });
 
     const { result } = renderHook(
-      () => useAaveReserveDetail({ reserveId: "USDC", address: "0xUser" }),
+      () => useAaveReserveDetail({ reserveId: "2", address: "0xUser" }),
       { wrapper },
     );
 
@@ -222,7 +261,7 @@ describe("useAaveReserveDetail", () => {
     });
 
     const { result } = renderHook(
-      () => useAaveReserveDetail({ reserveId: "USDC", address: "0xUser" }),
+      () => useAaveReserveDetail({ reserveId: "2", address: "0xUser" }),
       { wrapper },
     );
 
@@ -237,7 +276,7 @@ describe("useAaveReserveDetail", () => {
     });
 
     const { result } = renderHook(
-      () => useAaveReserveDetail({ reserveId: "USDC", address: "0xUser" }),
+      () => useAaveReserveDetail({ reserveId: "2", address: "0xUser" }),
       { wrapper },
     );
 
@@ -263,7 +302,7 @@ describe("useAaveReserveDetail", () => {
       borrowableReserves: [
         {
           reserveId: 3n,
-          reserve: { collateralFactor: 0 },
+          reserve: { collateralFactor: 0, underlying: "0xWBTC" as Address },
           token: {
             symbol: "WBTC",
             name: "Wrapped Bitcoin",
@@ -275,7 +314,7 @@ describe("useAaveReserveDetail", () => {
       allBorrowReserves: [
         {
           reserveId: 3n,
-          reserve: { collateralFactor: 0 },
+          reserve: { collateralFactor: 0, underlying: "0xWBTC" as Address },
           token: {
             symbol: "WBTC",
             name: "Wrapped Bitcoin",
@@ -292,7 +331,7 @@ describe("useAaveReserveDetail", () => {
     });
 
     const { result } = renderHook(
-      () => useAaveReserveDetail({ reserveId: "WBTC", address: "0xUser" }),
+      () => useAaveReserveDetail({ reserveId: "3", address: "0xUser" }),
       { wrapper },
     );
 
@@ -320,7 +359,7 @@ describe("useAaveReserveDetail", () => {
     });
 
     const { result } = renderHook(
-      () => useAaveReserveDetail({ reserveId: "USDC", address: "0xUser" }),
+      () => useAaveReserveDetail({ reserveId: "2", address: "0xUser" }),
       { wrapper },
     );
 
@@ -335,7 +374,7 @@ describe("useAaveReserveDetail", () => {
     });
 
     const { result } = renderHook(
-      () => useAaveReserveDetail({ reserveId: "USDC", address: "0xUser" }),
+      () => useAaveReserveDetail({ reserveId: "2", address: "0xUser" }),
       { wrapper },
     );
 
@@ -350,7 +389,7 @@ describe("useAaveReserveDetail", () => {
     });
 
     const { result } = renderHook(
-      () => useAaveReserveDetail({ reserveId: "USDC", address: "0xUser" }),
+      () => useAaveReserveDetail({ reserveId: "2", address: "0xUser" }),
       { wrapper },
     );
 
@@ -367,7 +406,7 @@ describe("useAaveReserveDetail", () => {
     });
 
     const { result } = renderHook(
-      () => useAaveReserveDetail({ reserveId: "USDC", address: "0xUser" }),
+      () => useAaveReserveDetail({ reserveId: "2", address: "0xUser" }),
       { wrapper },
     );
 
@@ -382,7 +421,7 @@ describe("useAaveReserveDetail", () => {
     });
 
     const { result } = renderHook(
-      () => useAaveReserveDetail({ reserveId: "USDC", address: "0xUser" }),
+      () => useAaveReserveDetail({ reserveId: "2", address: "0xUser" }),
       { wrapper },
     );
 
@@ -414,7 +453,7 @@ describe("useAaveReserveDetail", () => {
     });
 
     const { result } = renderHook(
-      () => useAaveReserveDetail({ reserveId: "USDC", address: "0xUser" }),
+      () => useAaveReserveDetail({ reserveId: "2", address: "0xUser" }),
       { wrapper },
     );
 
@@ -425,8 +464,7 @@ describe("useAaveReserveDetail", () => {
 
   it("passes user address to useVaultSplitParams for position-specific CF lookup", () => {
     renderHook(
-      () =>
-        useAaveReserveDetail({ reserveId: "USDC", address: "0xUserAddress" }),
+      () => useAaveReserveDetail({ reserveId: "2", address: "0xUserAddress" }),
       { wrapper },
     );
 
@@ -450,7 +488,7 @@ describe("useAaveReserveDetail", () => {
     });
 
     const { result } = renderHook(
-      () => useAaveReserveDetail({ reserveId: "USDC", address: "0xUser" }),
+      () => useAaveReserveDetail({ reserveId: "2", address: "0xUser" }),
       { wrapper },
     );
 
@@ -467,7 +505,7 @@ describe("useAaveReserveDetail", () => {
     });
 
     const { result } = renderHook(
-      () => useAaveReserveDetail({ reserveId: "USDC", address: "0xUser" }),
+      () => useAaveReserveDetail({ reserveId: "2", address: "0xUser" }),
       { wrapper },
     );
 
@@ -484,7 +522,7 @@ describe("useAaveReserveDetail", () => {
     });
 
     const { result } = renderHook(
-      () => useAaveReserveDetail({ reserveId: "USDC", address: "0xUser" }),
+      () => useAaveReserveDetail({ reserveId: "2", address: "0xUser" }),
       { wrapper },
     );
 
@@ -494,7 +532,7 @@ describe("useAaveReserveDetail", () => {
 
   it("returns null for both errors when no hooks have errors", () => {
     const { result } = renderHook(
-      () => useAaveReserveDetail({ reserveId: "USDC", address: "0xUser" }),
+      () => useAaveReserveDetail({ reserveId: "2", address: "0xUser" }),
       { wrapper },
     );
 
@@ -518,7 +556,7 @@ describe("useAaveReserveDetail", () => {
     });
 
     const { result } = renderHook(
-      () => useAaveReserveDetail({ reserveId: "USDC", address: "0xUser" }),
+      () => useAaveReserveDetail({ reserveId: "2", address: "0xUser" }),
       { wrapper },
     );
 
@@ -540,10 +578,287 @@ describe("useAaveReserveDetail", () => {
     });
 
     const { result } = renderHook(
-      () => useAaveReserveDetail({ reserveId: "USDC", address: "0xUser" }),
+      () => useAaveReserveDetail({ reserveId: "2", address: "0xUser" }),
       { wrapper },
     );
 
     expect(result.current.refetchPosition).toBe(mockRefetch);
+  });
+
+  // --- Reserve resolution by on-chain id, not indexer symbol ---
+
+  it("resolves the reserve whose id matches, even when another shares its symbol", () => {
+    const duplicateSymbolReserve = {
+      reserveId: 9n,
+      reserve: { collateralFactor: 0, underlying: "0xIMPOSTOR" as Address },
+      token: {
+        symbol: "USDC",
+        name: "USD Coin",
+        decimals: 18,
+        address: "0xIMPOSTOR" as Address,
+      },
+    };
+    mockUseAaveConfig.mockReturnValue({
+      ...defaultAaveConfig(),
+      // Impostor listed first, so a symbol `.find` would return it.
+      borrowableReserves: [duplicateSymbolReserve, usdcReserve],
+      allBorrowReserves: [duplicateSymbolReserve, usdcReserve],
+    });
+
+    const { result } = renderHook(
+      () => useAaveReserveDetail({ reserveId: "2", address: "0xUser" }),
+      { wrapper },
+    );
+
+    expect(result.current.selectedReserve?.reserveId).toBe(2n);
+    expect(result.current.selectedReserve?.reserve.underlying).toBe("0xUSDC");
+  });
+
+  it("blocks when two reserves claim the same id", () => {
+    const collidingReserve = {
+      ...usdcReserve,
+      reserve: { collateralFactor: 0, underlying: "0xIMPOSTOR" as Address },
+    };
+    mockUseAaveConfig.mockReturnValue({
+      ...defaultAaveConfig(),
+      borrowableReserves: [usdcReserve, collidingReserve],
+      allBorrowReserves: [usdcReserve, collidingReserve],
+    });
+
+    const { result } = renderHook(
+      () => useAaveReserveDetail({ reserveId: "2", address: "0xUser" }),
+      { wrapper },
+    );
+
+    expect(result.current.selectedReserve).toBeNull();
+  });
+
+  it("blocks a legacy symbol link and flags it as outdated", () => {
+    const { result } = renderHook(
+      () => useAaveReserveDetail({ reserveId: "usdc", address: "0xUser" }),
+      { wrapper },
+    );
+
+    expect(result.current.selectedReserve).toBeNull();
+    expect(result.current.assetConfig).toBeNull();
+    expect(result.current.currentDebtAmount).toBeNull();
+    expect(result.current.isLegacyReserveParam).toBe(true);
+  });
+
+  it.each(["abc", "0x2", " 2 ", "-1", "2.0"])(
+    "blocks the non-numeric reserve param %j",
+    (param) => {
+      const { result } = renderHook(
+        () => useAaveReserveDetail({ reserveId: param, address: "0xUser" }),
+        { wrapper },
+      );
+
+      expect(result.current.selectedReserve).toBeNull();
+    },
+  );
+
+  it("does not flag a missing reserve param as an outdated link", () => {
+    const { result } = renderHook(
+      () => useAaveReserveDetail({ reserveId: undefined, address: "0xUser" }),
+      { wrapper },
+    );
+
+    expect(result.current.isLegacyReserveParam).toBe(false);
+  });
+
+  // --- Display metadata comes from the proven identity ---
+
+  it("labels the asset from the proven identity, not the indexer's spoofed symbol", () => {
+    const spoofedReserve = {
+      reserveId: 2n,
+      reserve: { collateralFactor: 0, underlying: "0xWETH" as Address },
+      token: {
+        // Indexer claims USDC for what is really WETH.
+        symbol: "USDC",
+        name: "USD Coin",
+        decimals: 6,
+        address: "0xWETH" as Address,
+      },
+    };
+    mockUseAaveConfig.mockReturnValue({
+      ...defaultAaveConfig(),
+      borrowableReserves: [spoofedReserve],
+      allBorrowReserves: [spoofedReserve],
+    });
+    mockUseVerifiedReserveIdentity.mockReturnValue({
+      identity: {
+        address: "0xWETH" as Address,
+        symbol: "WETH",
+        name: "Wrapped Ether",
+        decimals: 18,
+        icon: "weth-icon",
+        source: "registry",
+      },
+      isLoading: false,
+      error: null,
+      isIntegrityViolation: false,
+      retry: vi.fn(),
+    });
+
+    const { result } = renderHook(
+      () => useAaveReserveDetail({ reserveId: "2", address: "0xUser" }),
+      { wrapper },
+    );
+
+    expect(result.current.assetConfig).toEqual({
+      symbol: "WETH",
+      name: "Wrapped Ether",
+      icon: "weth-icon",
+    });
+  });
+
+  it("verifies the reserve against its on-chain underlying, not the indexer's token address", () => {
+    const divergentReserve = {
+      reserveId: 2n,
+      reserve: { collateralFactor: 0, underlying: "0xREAL" as Address },
+      token: {
+        symbol: "USDC",
+        name: "USD Coin",
+        decimals: 6,
+        address: "0xDECOY" as Address,
+      },
+    };
+    mockUseAaveConfig.mockReturnValue({
+      ...defaultAaveConfig(),
+      borrowableReserves: [divergentReserve],
+      allBorrowReserves: [divergentReserve],
+    });
+
+    renderHook(
+      () => useAaveReserveDetail({ reserveId: "2", address: "0xUser" }),
+      { wrapper },
+    );
+
+    expect(mockUseVerifiedReserveIdentity).toHaveBeenCalledWith({
+      reserveId: 2n,
+      underlying: "0xREAL",
+    });
+  });
+
+  it("formats debt with the proven decimals, not the indexer's", () => {
+    const wrongDecimalsReserve = {
+      ...usdcReserve,
+      // Indexer claims 18 for a token that really has 6.
+      token: { ...usdcReserve.token, decimals: 18 },
+    };
+    mockUseAaveConfig.mockReturnValue({
+      ...defaultAaveConfig(),
+      borrowableReserves: [wrongDecimalsReserve],
+      allBorrowReserves: [wrongDecimalsReserve],
+    });
+    mockUseAaveUserPosition.mockReturnValue({
+      position: {
+        debtPositions: new Map([[2n, { totalDebt: 1_500_000n }]]),
+      },
+      collateralValueUsd: 15000,
+      debtValueUsd: 1.5,
+      healthFactor: null,
+      healthFactorStatus: "healthy",
+      isPositionDataStale: false,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    const { result } = renderHook(
+      () => useAaveReserveDetail({ reserveId: "2", address: "0xUser" }),
+      { wrapper },
+    );
+
+    // 1_500_000 at the proven 6 decimals is 1.5, not 0.0000000000015.
+    expect(result.current.currentDebtAmount).toBe(1.5);
+  });
+
+  it("reports zero debt only once the identity is proven", () => {
+    const { result } = renderHook(
+      () => useAaveReserveDetail({ reserveId: "2", address: "0xUser" }),
+      { wrapper },
+    );
+
+    expect(result.current.currentDebtAmount).toBe(0);
+  });
+
+  // --- Identity failure hard-blocks the screen ---
+
+  it("withholds the label and the debt figure while the identity is unproven", () => {
+    mockUseVerifiedReserveIdentity.mockReturnValue({
+      identity: null,
+      isLoading: true,
+      error: null,
+      isIntegrityViolation: false,
+      retry: vi.fn(),
+    });
+
+    const { result } = renderHook(
+      () => useAaveReserveDetail({ reserveId: "2", address: "0xUser" }),
+      { wrapper },
+    );
+
+    expect(result.current.assetConfig).toBeNull();
+    expect(result.current.currentDebtAmount).toBeNull();
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it("surfaces a proven mismatch as identityError, separate from positionError", () => {
+    const mismatch = new Error("reserve resolves to a different token");
+    mockUseVerifiedReserveIdentity.mockReturnValue({
+      identity: null,
+      isLoading: false,
+      error: mismatch,
+      isIntegrityViolation: true,
+      retry: vi.fn(),
+    });
+
+    const { result } = renderHook(
+      () => useAaveReserveDetail({ reserveId: "2", address: "0xUser" }),
+      { wrapper },
+    );
+
+    expect(result.current.identityError).toBe(mismatch);
+    expect(result.current.isIdentityCompromised).toBe(true);
+    expect(result.current.positionError).toBeNull();
+    expect(result.current.ancillaryError).toBeNull();
+    expect(result.current.assetConfig).toBeNull();
+    expect(result.current.currentDebtAmount).toBeNull();
+  });
+
+  it("marks a transient verification failure as not compromised", () => {
+    mockUseVerifiedReserveIdentity.mockReturnValue({
+      identity: null,
+      isLoading: false,
+      error: new Error("rpc connection lost"),
+      isIntegrityViolation: false,
+      retry: vi.fn(),
+    });
+
+    const { result } = renderHook(
+      () => useAaveReserveDetail({ reserveId: "2", address: "0xUser" }),
+      { wrapper },
+    );
+
+    expect(result.current.isIdentityCompromised).toBe(false);
+  });
+
+  it("exposes the identity retry so a transient failure can be re-run", () => {
+    const retry = vi.fn();
+    mockUseVerifiedReserveIdentity.mockReturnValue({
+      identity: null,
+      isLoading: false,
+      error: new Error("rpc connection lost"),
+      isIntegrityViolation: false,
+      retry,
+    });
+
+    const { result } = renderHook(
+      () => useAaveReserveDetail({ reserveId: "2", address: "0xUser" }),
+      { wrapper },
+    );
+
+    expect(result.current.retryIdentity).toBe(retry);
   });
 });

--- a/services/vault/src/applications/aave/components/Detail/hooks/useAaveReserveDetail.ts
+++ b/services/vault/src/applications/aave/components/Detail/hooks/useAaveReserveDetail.ts
@@ -2,19 +2,23 @@
  * Hook for Aave reserve detail page data
  *
  * Fetches and combines:
- * - Reserve config from Aave
+ * - Reserve config from Aave, resolved by on-chain reserve id
+ * - The reserve's on-chain-proven token identity (label + decimals)
  * - User position data (with position-specific collateral factor)
  * - Aave on-chain oracle price for the selected borrow token
- * - Asset metadata for display
+ *
+ * Nothing on this screen reads the indexer's `token.symbol/name/decimals`: a
+ * compromised indexer could otherwise mislabel a genuine reserve or report
+ * decimals that make the displayed figures disagree with the signed amount
+ * (audit F7). Label and decimals both come from `tokenIdentity`, and every
+ * derived value stays null until that identity is proven.
  */
 
 import { useMemo } from "react";
 import { formatUnits } from "viem";
 
-import {
-  getCurrencyIconWithFallback,
-  getTokenByAddress,
-} from "@/services/token/tokenService";
+import { parseReserveId } from "@/routes";
+import { getCurrencyIconWithFallback } from "@/services/token/tokenService";
 
 import { BPS_SCALE } from "../../../constants";
 import { useAaveConfig } from "../../../context";
@@ -22,14 +26,22 @@ import {
   useAaveReservePrice,
   useAaveUserPosition,
   useVaultSplitParams,
+  useVerifiedReserveIdentity,
 } from "../../../hooks";
 import type { VaultSplitParams } from "../../../hooks/useVaultSplitParams";
-import type { AavePositionWithLiveData } from "../../../services";
+import type {
+  AavePositionWithLiveData,
+  VerifiedReserveIdentity,
+} from "../../../services";
 import type { AaveReserveConfig } from "../../../services/fetchConfig";
 import type { Asset } from "../../../types";
 
 export interface UseAaveReserveDetailProps {
-  /** Reserve symbol from the URL query */
+  /**
+   * Raw `?reserve=` query value — the reserve's on-chain id as a decimal
+   * string. Anything else (including legacy `?reserve=<symbol>` links) resolves
+   * to null and hard-blocks; it is never matched against an indexer symbol.
+   */
   reserveId: string | undefined;
   /** User's wallet address */
   address: string | undefined;
@@ -40,7 +52,12 @@ export interface UseAaveReserveDetailResult {
   isLoading: boolean;
   /** Selected reserve config (null if not found) */
   selectedReserve: AaveReserveConfig | null;
-  /** Asset display config (null if reserve not found) */
+  /**
+   * On-chain-proven identity for `selectedReserve` — label and decimals. Null
+   * until proven; nothing derived from the reserve may render before then.
+   */
+  tokenIdentity: VerifiedReserveIdentity | null;
+  /** Asset display config (null until the reserve's identity is proven) */
   assetConfig: Asset | null;
   /** vBTC reserve config (for liquidation threshold) */
   vbtcReserve: AaveReserveConfig | null;
@@ -50,8 +67,12 @@ export interface UseAaveReserveDetailResult {
   proxyContract: string | undefined;
   /** Collateral value in USD */
   collateralValueUsd: number;
-  /** Current debt amount for selected reserve in token units */
-  currentDebtAmount: number;
+  /**
+   * Current debt for the selected reserve in token units, at proven decimals.
+   * Null until the identity resolves — `0` here would conflate "no debt" with
+   * "not computed yet", and this figure drives the repay form's Max.
+   */
+  currentDebtAmount: number | null;
   /** Total debt value in USD across all reserves */
   totalDebtValueUsd: number;
   /** Health factor (null if no debt) */
@@ -76,6 +97,25 @@ export interface UseAaveReserveDetailResult {
    * so unrelated infra failures should not remove the action path.
    */
   ancillaryError: Error | null;
+  /**
+   * Reserve-identity failure — the strongest block on this screen, above
+   * `positionError`. That one means we can't trust the debt figure; this one
+   * means we can't trust *which asset the page is about*, so no label, no
+   * amount and no action may render beneath it (audit F7).
+   */
+  identityError: Error | null;
+  /**
+   * True when `identityError` is a proven mismatch or an unlabelable token
+   * rather than an RPC fault. Selects integrity copy over retry copy.
+   */
+  isIdentityCompromised: boolean;
+  /** Re-run identity verification. Only meaningful for a transient failure. */
+  retryIdentity: () => Promise<unknown>;
+  /**
+   * True when `?reserve=` carries a token symbol instead of a reserve id — an
+   * outdated link. Display-only: selects "outdated link" over "not found".
+   */
+  isLegacyReserveParam: boolean;
   /** Whether position data may be stale (oracle-derived values possibly outdated) */
   isPositionDataStale: boolean;
   /** Refetch position data — returns fresh position (or null if unavailable) */
@@ -95,31 +135,57 @@ export function useAaveReserveDetail({
 }: UseAaveReserveDetailProps): UseAaveReserveDetailResult {
   const { config, vbtcReserve, allBorrowReserves } = useAaveConfig();
 
-  // Find the selected reserve by symbol from the URL query. Match against the
-  // full reserve set, not just borrowable ones - a user reaching this page
-  // for repay may have debt in a reserve that is no longer borrowable.
+  // A `?reserve=` value that isn't a reserve id is an outdated symbol link.
+  // Surfaced so the blocked state can say so instead of "not found".
+  const isLegacyReserveParam =
+    reserveId != null && reserveId !== "" && parseReserveId(reserveId) === null;
+
+  // Resolve by on-chain reserve id. Match against the full reserve set, not
+  // just borrowable ones - a user reaching this page for repay may have debt in
+  // a reserve that is no longer borrowable.
   const selectedReserve = useMemo(() => {
-    if (!reserveId) return null;
-    return (
-      allBorrowReserves.find(
-        (r) => r.token.symbol.toLowerCase() === reserveId.toLowerCase(),
-      ) ?? null
-    );
+    const target = parseReserveId(reserveId);
+    if (target === null) return null;
+    const matches = allBorrowReserves.filter((r) => r.reserveId === target);
+    // Exactly one, or nothing. `.find` would silently take whichever duplicate
+    // the indexer happened to order first — the steering primitive this fix
+    // removes. The id is a primary key, so a second match means the reserve set
+    // itself can't be trusted.
+    return matches.length === 1 ? matches[0] : null;
   }, [allBorrowReserves, reserveId]);
 
-  // Build asset config from reserve
+  // Prove what this reserve actually is before any label or amount renders.
+  // Pass `reserve.underlying`, not `token.address`: those are two independent
+  // indexer fields, and the one we prove is the one downstream may then trust.
+  const {
+    identity: verifiedIdentity,
+    isLoading: identityLoading,
+    error: identityError,
+    isIntegrityViolation,
+    retry: retryIdentity,
+  } = useVerifiedReserveIdentity({
+    reserveId: selectedReserve?.reserveId,
+    underlying: selectedReserve?.reserve.underlying,
+  });
+
+  // Bind the identity to the reserve it belongs to: an identity without a
+  // resolved reserve would let a label exist for a page that resolved nothing.
+  const tokenIdentity = selectedReserve ? verifiedIdentity : null;
+
+  // Build asset config from the proven identity, never from the indexer's
+  // metadata. The icon fallback keys off the trusted symbol too, so a spoofed
+  // "USDC" can't pull the USDC glyph onto a different token.
   const assetConfig = useMemo((): Asset | null => {
-    if (!selectedReserve) return null;
-    const tokenMetadata = getTokenByAddress(selectedReserve.token.address);
+    if (!tokenIdentity) return null;
     return {
-      name: selectedReserve.token.name,
-      symbol: selectedReserve.token.symbol,
+      name: tokenIdentity.name,
+      symbol: tokenIdentity.symbol,
       icon: getCurrencyIconWithFallback(
-        tokenMetadata?.icon,
-        selectedReserve.token.symbol,
+        tokenIdentity.icon,
+        tokenIdentity.symbol,
       ),
     };
-  }, [selectedReserve]);
+  }, [tokenIdentity]);
 
   // Fetch user position from Aave (uses Aave oracle for USD values)
   const {
@@ -159,22 +225,23 @@ export function useAaveReserveDetail({
   // inside `useVaultSplitParams` keeps `CONFIG_RETRY_COUNT` for resilience.
   const refetchSplitParams = () => refetchSplitParamsRaw({ retry: 0 });
 
-  // Calculate debt amount for selected reserve in token units
-  const currentDebtAmount = useMemo(() => {
-    if (!selectedReserve || !position?.debtPositions) {
-      return 0;
+  // Debt for the selected reserve in token units, at proven decimals. Null
+  // until the identity resolves: a `0` rendered against unverified decimals is
+  // exactly the wrong-number failure this screen must not produce.
+  const currentDebtAmount = useMemo((): number | null => {
+    if (!selectedReserve || !tokenIdentity) {
+      return null;
     }
 
-    const debtPosition = position.debtPositions.get(selectedReserve.reserveId);
+    const debtPosition = position?.debtPositions?.get(
+      selectedReserve.reserveId,
+    );
     if (!debtPosition) {
       return 0;
     }
 
-    // Convert from bigint to number using token decimals
-    return Number(
-      formatUnits(debtPosition.totalDebt, selectedReserve.token.decimals),
-    );
-  }, [selectedReserve, position]);
+    return Number(formatUnits(debtPosition.totalDebt, tokenIdentity.decimals));
+  }, [selectedReserve, tokenIdentity, position]);
 
   // Position-specific liquidation threshold from contract.
   // Uses the user's stored dynamicConfigKey (not the indexer's reserve config)
@@ -194,8 +261,10 @@ export function useAaveReserveDetail({
   );
 
   return {
-    isLoading: positionLoading || pricesLoading || splitParamsLoading,
+    isLoading:
+      identityLoading || positionLoading || pricesLoading || splitParamsLoading,
     selectedReserve,
+    tokenIdentity,
     assetConfig,
     vbtcReserve,
     liquidationThresholdBps,
@@ -208,6 +277,10 @@ export function useAaveReserveDetail({
     isPriceStale,
     positionError: positionError ?? null,
     ancillaryError: pricesError ?? splitParamsError ?? null,
+    identityError,
+    isIdentityCompromised: isIntegrityViolation,
+    retryIdentity,
+    isLegacyReserveParam,
     isPositionDataStale,
     refetchPosition,
     refetchSplitParams,

--- a/services/vault/src/applications/aave/components/Detail/index.tsx
+++ b/services/vault/src/applications/aave/components/Detail/index.tsx
@@ -18,10 +18,10 @@ import { getReserveDetailBaseRoute, getReserveDetailRoute } from "@/routes";
 
 import { LOAN_TAB, type LoanTab } from "../../constants";
 import { useAaveBorrowedAssets, useAaveUserPosition } from "../../hooks";
-import type { Asset } from "../../types";
 import {
   AssetSelectionPanel,
   getAssetPickerWidthClass,
+  type SelectableAsset,
 } from "../AssetSelectionPanel";
 import {
   LOAN_SUCCESS_WIDTH_CLASS,
@@ -63,9 +63,16 @@ export function LoanFlowOverlay({
     isLoading: isPositionLoading,
   } = useAaveUserPosition(isConnected ? address : undefined);
   const { borrowedAssets } = useAaveBorrowedAssets({ position, debtValueUsd });
+  // The reserve id rides along so selecting a repay row routes by id rather
+  // than by the indexer's symbol (audit F7).
   const repayAssets = useMemo(
-    (): Asset[] =>
-      borrowedAssets.map(({ symbol, name, icon }) => ({ symbol, name, icon })),
+    (): SelectableAsset[] =>
+      borrowedAssets.map(({ reserveId: id, symbol, name, icon }) => ({
+        reserveId: BigInt(id),
+        symbol,
+        name,
+        icon,
+      })),
     [borrowedAssets],
   );
 
@@ -131,8 +138,10 @@ export function LoanFlowOverlay({
         // `replace` so the picker leaves no entry behind the form: browser Back
         // from the form returns to the page, and Back after closing can't drop
         // the user into the flow again.
-        onSelectAsset={(symbol) =>
-          navigate(getReserveDetailRoute(symbol, mode, isV3), { replace: true })
+        onSelectAsset={(selectedReserveId) =>
+          navigate(getReserveDetailRoute(selectedReserveId, mode, isV3), {
+            replace: true,
+          })
         }
       />
     );

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/index.tsx
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/index.tsx
@@ -300,6 +300,7 @@ export function Borrow() {
                   assetConfig.icon,
                   assetConfig.symbol,
                 )}
+                selectedReserveId={selectedReserve.reserveId}
                 reserves={borrowableReserves}
                 mode={LOAN_TAB.BORROW}
                 disabled={isProcessing}

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/index.tsx
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/index.tsx
@@ -70,6 +70,7 @@ export function Borrow() {
     healthFactor,
     liquidationThresholdBps,
     selectedReserve,
+    tokenIdentity,
     assetConfig,
     oracleAddress,
     tokenPriceUsd,
@@ -94,7 +95,7 @@ export function Borrow() {
       currentDebtUsd: totalDebtValueUsd,
       liquidationThresholdBps,
       tokenPriceUsd,
-      tokenDecimals: selectedReserve.token.decimals,
+      tokenDecimals: tokenIdentity.decimals,
     });
 
   // Live available liquidity for the selected reserve (Aave Hub reserve totals);
@@ -157,7 +158,7 @@ export function Borrow() {
     borrowAmount,
     metrics.healthFactorValue,
     effectiveMaxBorrowAmount,
-    selectedReserve.token.decimals,
+    tokenIdentity.decimals,
     assetConfig.symbol,
     isPositionDataStale,
     limitedByLiquidity,
@@ -171,7 +172,7 @@ export function Borrow() {
   const sliderTrackMax =
     effectiveMaxBorrowAmount > 0 ? effectiveMaxBorrowAmount : MIN_SLIDER_MAX;
   const displayDecimals = Math.min(
-    selectedReserve.token.decimals,
+    tokenIdentity.decimals,
     SAFE_TOFIXED_PRECISION,
   );
 

--- a/services/vault/src/applications/aave/components/LoanCard/Repay/index.tsx
+++ b/services/vault/src/applications/aave/components/LoanCard/Repay/index.tsx
@@ -62,6 +62,7 @@ export function Repay() {
     healthFactor,
     liquidationThresholdBps,
     selectedReserve,
+    tokenIdentity,
     assetConfig,
     proxyContract,
     tokenPriceUsd,
@@ -86,17 +87,16 @@ export function Repay() {
     [allBorrowReserves, position],
   );
 
-  // Fetch user's token balance for repayment
+  // Fetch user's token balance for repayment. Read at the proven underlying,
+  // not the indexer's `token.address` — those are separate indexer fields, and
+  // a balance read against a token the user doesn't owe would produce a wrong
+  // Max.
   const {
     balance: userTokenBalance,
     error: balanceError,
     hasBalanceData,
     refetch: refetchUserBalance,
-  } = useERC20Balance(
-    selectedReserve.token.address,
-    address,
-    selectedReserve.token.decimals,
-  );
+  } = useERC20Balance(tokenIdentity.address, address, tokenIdentity.decimals);
 
   // "Known" = a balance has loaded at least once (`hasBalanceData`), NOT "the
   // latest fetch had no error". React Query keeps the last good balance across a
@@ -161,7 +161,7 @@ export function Repay() {
 
   // Token's own precision so dust (e.g. 0.00000003 WBTC) isn't rounded to "0.00".
   const displayDecimals = Math.min(
-    selectedReserve.token.decimals,
+    tokenIdentity.decimals,
     SAFE_TOFIXED_PRECISION,
   );
 
@@ -226,7 +226,7 @@ export function Repay() {
           refetchPosition,
           refetchUserBalance,
           reserveId: selectedReserve.reserveId,
-          tokenDecimals: selectedReserve.token.decimals,
+          tokenDecimals: tokenIdentity.decimals,
         });
         if (params.kind === "error") {
           setRefetchError(params.message);

--- a/services/vault/src/applications/aave/components/LoanCard/Repay/index.tsx
+++ b/services/vault/src/applications/aave/components/LoanCard/Repay/index.tsx
@@ -314,6 +314,7 @@ export function Repay() {
                   assetConfig.icon,
                   assetConfig.symbol,
                 )}
+                selectedReserveId={selectedReserve.reserveId}
                 reserves={borrowedReserves}
                 mode={LOAN_TAB.REPAY}
                 disabled={isProcessing || isSubmitting}

--- a/services/vault/src/applications/aave/components/ReserveIdentityBlock.tsx
+++ b/services/vault/src/applications/aave/components/ReserveIdentityBlock.tsx
@@ -1,8 +1,9 @@
 /**
  * ReserveIdentityBlock
  *
- * Shown in place of the entire reserve detail when the reserve's asset can't be
- * proven on-chain (audit F7). Two distinct cases, deliberately worded apart:
+ * Shown in place of a whole reserve surface — the loan overlay's form step, or
+ * the borrowing markets data page — when the reserve's asset can't be proven
+ * on-chain (audit F7). Two distinct cases, deliberately worded apart:
  *
  * - `compromised` — verification completed and *failed*: the on-chain reserve
  *   maps to a different token than the indexer claimed, or no trusted label

--- a/services/vault/src/applications/aave/components/context/LoanContext.tsx
+++ b/services/vault/src/applications/aave/components/context/LoanContext.tsx
@@ -9,7 +9,10 @@ import { createContext, useContext } from "react";
 import type { Address } from "viem";
 
 import type { VaultSplitParams } from "../../hooks/useVaultSplitParams";
-import type { AavePositionWithLiveData } from "../../services";
+import type {
+  AavePositionWithLiveData,
+  VerifiedReserveIdentity,
+} from "../../services";
 import type { AaveReserveConfig } from "../../services/fetchConfig";
 import type { Asset } from "../../types";
 
@@ -24,9 +27,20 @@ export interface LoanContextValue {
   healthFactor: number | null;
   /** Liquidation threshold in BPS (e.g., 8000 = 80%) */
   liquidationThresholdBps: number;
-  /** Selected reserve to borrow from */
+  /**
+   * Selected reserve to borrow from.
+   *
+   * Its `token` sub-object is indexer-supplied and MUST NOT be read — use
+   * `tokenIdentity` for the address, symbol, name and decimals (audit F7).
+   */
   selectedReserve: AaveReserveConfig;
-  /** Asset display config (icon, name, symbol) */
+  /**
+   * On-chain-proven identity for `selectedReserve`. Non-optional: the detail
+   * screen hard-blocks rather than mounting this provider without it, so
+   * consumers get proven values with no null handling and no `?? 18` fallback.
+   */
+  tokenIdentity: VerifiedReserveIdentity;
+  /** Asset display config (icon, name, symbol), derived from `tokenIdentity` */
   assetConfig: Asset;
   /** User's proxy contract address (for debt queries) */
   proxyContract: string | undefined;

--- a/services/vault/src/applications/aave/hooks/__tests__/useVerifiedReserveIdentity.test.tsx
+++ b/services/vault/src/applications/aave/hooks/__tests__/useVerifiedReserveIdentity.test.tsx
@@ -1,0 +1,127 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import type { Address } from "viem";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const ADAPTER = "0x000000000000000000000000000000000000ada9" as Address;
+const TOKEN_USDC = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" as Address;
+const RESERVE_ID = 7n;
+
+vi.mock("../../config", () => ({
+  getAaveAdapterAddress: () => ADAPTER,
+}));
+
+vi.mock("../../services/verifyReserveIdentity", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../services/verifyReserveIdentity")
+  >("../../services/verifyReserveIdentity");
+  return { ...actual, verifyReserveIdentity: vi.fn() };
+});
+
+import {
+  UnknownReserveTokenError,
+  verifyReserveIdentity,
+} from "../../services/verifyReserveIdentity";
+import { useVerifiedReserveIdentity } from "../useVerifiedReserveIdentity";
+
+const mockVerifyReserveIdentity = vi.mocked(verifyReserveIdentity);
+
+const IDENTITY = {
+  address: TOKEN_USDC,
+  symbol: "USDC",
+  name: "USD Coin",
+  decimals: 6,
+  icon: undefined,
+  source: "registry" as const,
+};
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retryDelay: 0 } },
+  });
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+function render() {
+  return renderHook(
+    () =>
+      useVerifiedReserveIdentity({
+        reserveId: RESERVE_ID,
+        underlying: TOKEN_USDC,
+      }),
+    { wrapper },
+  );
+}
+
+describe("useVerifiedReserveIdentity", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the verified identity once the on-chain proof resolves", async () => {
+    mockVerifyReserveIdentity.mockResolvedValue(IDENTITY);
+
+    const { result } = render();
+
+    await waitFor(() => expect(result.current.identity).toEqual(IDENTITY));
+    expect(result.current.error).toBeNull();
+    expect(mockVerifyReserveIdentity).toHaveBeenCalledWith(
+      ADAPTER,
+      RESERVE_ID,
+      TOKEN_USDC,
+    );
+  });
+
+  it("stays disabled until both the reserve id and the underlying are known", () => {
+    const { result } = renderHook(
+      () =>
+        useVerifiedReserveIdentity({
+          reserveId: undefined,
+          underlying: TOKEN_USDC,
+        }),
+      { wrapper },
+    );
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.identity).toBeNull();
+    expect(mockVerifyReserveIdentity).not.toHaveBeenCalled();
+  });
+
+  it("does not retry a proven integrity failure", async () => {
+    mockVerifyReserveIdentity.mockRejectedValue(
+      new UnknownReserveTokenError("no trusted label"),
+    );
+
+    const { result } = render();
+
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect(mockVerifyReserveIdentity).toHaveBeenCalledTimes(1);
+    expect(result.current.isIntegrityViolation).toBe(true);
+  });
+
+  it("retries a transient RPC failure twice before giving up", async () => {
+    mockVerifyReserveIdentity.mockRejectedValue(
+      new Error("rpc connection lost"),
+    );
+
+    const { result } = render();
+
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect(mockVerifyReserveIdentity).toHaveBeenCalledTimes(3);
+    expect(result.current.isIntegrityViolation).toBe(false);
+  });
+
+  it("withholds the identity whenever an error is present", async () => {
+    mockVerifyReserveIdentity.mockRejectedValue(
+      new UnknownReserveTokenError("no trusted label"),
+    );
+
+    const { result } = render();
+
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect(result.current.identity).toBeNull();
+  });
+});

--- a/services/vault/src/applications/aave/hooks/index.ts
+++ b/services/vault/src/applications/aave/hooks/index.ts
@@ -59,4 +59,8 @@ export {
   type UseVaultSplitParamsResult,
   type VaultSplitParams,
 } from "./useVaultSplitParams";
+export {
+  useVerifiedReserveIdentity,
+  type UseVerifiedReserveIdentityResult,
+} from "./useVerifiedReserveIdentity";
 export { type UseWithdrawCollateralTransactionResult } from "./useWithdrawCollateralTransaction";

--- a/services/vault/src/applications/aave/hooks/useVerifiedReserveIdentity.ts
+++ b/services/vault/src/applications/aave/hooks/useVerifiedReserveIdentity.ts
@@ -1,0 +1,114 @@
+/**
+ * On-chain-proven identity for the reserve a loan screen is about.
+ *
+ * Wraps `verifyReserveIdentity` in a query so the detail screen can withhold
+ * every label and every amount until the reserve's underlying token is proven
+ * against the chain (audit F7). Until `identity` is non-null, nothing derived
+ * from the reserve may render.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import { useCallback } from "react";
+import type { Address } from "viem";
+
+import { getAaveAdapterAddress } from "../config";
+import {
+  isIntegrityFailure,
+  verifyReserveIdentity,
+  type VerifiedReserveIdentity,
+} from "../services/verifyReserveIdentity";
+
+const QUERY_KEY = "aaveReserveIdentity";
+/**
+ * This query gates first paint, so cap the worst case near 3s (1s + 2s
+ * backoff) instead of the global retry budget — a stuck RPC should surface a
+ * Retry affordance, not an open-ended spinner.
+ */
+const TRANSIENT_RETRY_COUNT = 2;
+
+export interface UseVerifiedReserveIdentityResult {
+  /** Null until proven. Never render a label or an amount while this is null. */
+  identity: VerifiedReserveIdentity | null;
+  isLoading: boolean;
+  /** Non-null means hard-block the screen. */
+  error: Error | null;
+  /**
+   * True when `error` is a proven mismatch or an unlabelable token rather than
+   * an RPC fault. Drives integrity copy with no retry affordance; false drives
+   * neutral copy with one.
+   */
+  isIntegrityViolation: boolean;
+  /** Re-run verification, bypassing retry backoff. Pointless for integrity failures. */
+  retry: () => Promise<unknown>;
+}
+
+export function useVerifiedReserveIdentity({
+  reserveId,
+  underlying,
+}: {
+  reserveId: bigint | undefined;
+  /**
+   * The reserve's underlying token address. Must be `reserve.underlying`, not
+   * `token.address`: those are two independent indexer fields, and the one we
+   * prove is the one downstream code may then trust.
+   */
+  underlying: Address | undefined;
+}): UseVerifiedReserveIdentityResult {
+  // Read the adapter here rather than accepting it as a prop: the guard is only
+  // meaningful against the env-pinned address the transaction is actually sent
+  // to. Taking it from a caller would let an attacker-controlled adapter/spoke
+  // pair prove a mapping the real transaction never uses.
+  const adapterAddress = getAaveAdapterAddress();
+  const enabled = reserveId != null && underlying != null;
+
+  const { data, isLoading, error, refetch } = useQuery({
+    queryKey: [
+      QUERY_KEY,
+      adapterAddress,
+      reserveId == null ? null : reserveId.toString(),
+      underlying?.toLowerCase() ?? null,
+    ],
+    queryFn: () =>
+      verifyReserveIdentity(adapterAddress, reserveId!, underlying!),
+    enabled,
+
+    // Every input is immutable: the spoke's reserveId -> underlying mapping is
+    // fixed at listing, ERC20 decimals never change, and the token registry is
+    // a compile-time table. Refetching buys nothing and risks flipping a
+    // mounted, mid-typing borrow form into a hard block on a transient blip.
+    staleTime: Infinity,
+    gcTime: Infinity,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    refetchInterval: false,
+    // An errored query holds no data and is stale regardless of `staleTime`, so
+    // this recovers a user who dropped connectivity without them clicking
+    // anything. Successful entries stay pinned.
+    refetchOnReconnect: true,
+
+    // A proven spoof is a conclusion, not a fault — retrying only delays the
+    // warning. Overrides the global retry policy for that case only.
+    retry: (failureCount, err) =>
+      !isIntegrityFailure(err) && failureCount < TRANSIENT_RETRY_COUNT,
+
+    // Deliberately no `placeholderData: keepPreviousData` (unlike
+    // useAaveReservePrice): carrying the previous reserve's symbol and decimals
+    // across an asset switch would paint one asset's label over another's
+    // numbers, which is the exact failure this hook exists to prevent.
+  });
+
+  // Mirror `refetchSplitParams`: a user-initiated retry should answer in one
+  // round-trip rather than stalling through the backoff schedule.
+  const retry = useCallback(() => refetch({ retry: 0 } as never), [refetch]);
+
+  const identityError = (error as Error | null) ?? null;
+  return {
+    // Never show a proven-stale identity next to a fresh error.
+    identity: identityError ? null : (data ?? null),
+    isLoading: enabled && isLoading,
+    error: identityError,
+    isIntegrityViolation:
+      identityError != null && isIntegrityFailure(identityError),
+    retry,
+  };
+}

--- a/services/vault/src/applications/aave/services/__tests__/verifyReserveIdentity.test.ts
+++ b/services/vault/src/applications/aave/services/__tests__/verifyReserveIdentity.test.ts
@@ -177,6 +177,31 @@ describe("verifyReserveIdentity", () => {
     expect(identity.name).toBe("TUSDC");
   });
 
+  it("falls back to the symbol when the token has no name() method", async () => {
+    mockGetERC20Symbol.mockResolvedValue("TUSDC");
+    mockGetERC20Name.mockRejectedValue(new Error('function "name" reverted'));
+
+    const identity = await verifyReserveIdentity(
+      ADAPTER,
+      RESERVE_ID,
+      TOKEN_USDC,
+    );
+
+    expect(identity.symbol).toBe("TUSDC");
+    expect(identity.name).toBe("TUSDC");
+  });
+
+  it("hard-blocks rather than retrying when the token has no symbol() method", async () => {
+    mockGetERC20Symbol.mockRejectedValue(
+      new Error('function "symbol" reverted'),
+    );
+    mockGetERC20Name.mockResolvedValue("Test USD Coin");
+
+    await expect(
+      verifyReserveIdentity(ADAPTER, RESERVE_ID, TOKEN_USDC),
+    ).rejects.toBeInstanceOf(UnknownReserveTokenError);
+  });
+
   it("throws UnknownReserveTokenError when neither the registry nor the contract can name the token", async () => {
     mockGetERC20Symbol.mockResolvedValue(null);
 

--- a/services/vault/src/applications/aave/services/__tests__/verifyReserveIdentity.test.ts
+++ b/services/vault/src/applications/aave/services/__tests__/verifyReserveIdentity.test.ts
@@ -177,31 +177,6 @@ describe("verifyReserveIdentity", () => {
     expect(identity.name).toBe("TUSDC");
   });
 
-  it("falls back to the symbol when the token has no name() method", async () => {
-    mockGetERC20Symbol.mockResolvedValue("TUSDC");
-    mockGetERC20Name.mockRejectedValue(new Error('function "name" reverted'));
-
-    const identity = await verifyReserveIdentity(
-      ADAPTER,
-      RESERVE_ID,
-      TOKEN_USDC,
-    );
-
-    expect(identity.symbol).toBe("TUSDC");
-    expect(identity.name).toBe("TUSDC");
-  });
-
-  it("hard-blocks rather than retrying when the token has no symbol() method", async () => {
-    mockGetERC20Symbol.mockRejectedValue(
-      new Error('function "symbol" reverted'),
-    );
-    mockGetERC20Name.mockResolvedValue("Test USD Coin");
-
-    await expect(
-      verifyReserveIdentity(ADAPTER, RESERVE_ID, TOKEN_USDC),
-    ).rejects.toBeInstanceOf(UnknownReserveTokenError);
-  });
-
   it("throws UnknownReserveTokenError when neither the registry nor the contract can name the token", async () => {
     mockGetERC20Symbol.mockResolvedValue(null);
 
@@ -234,6 +209,21 @@ describe("verifyReserveIdentity", () => {
     await expect(
       verifyReserveIdentity(ADAPTER, RESERVE_ID, TOKEN_USDC),
     ).rejects.toThrow("rpc connection lost");
+  });
+
+  it("reports a transient failure from the label reads as retryable, not as a spoof", async () => {
+    mockGetERC20Symbol.mockRejectedValue(new Error("rpc connection lost"));
+
+    const error = await verifyReserveIdentity(
+      ADAPTER,
+      RESERVE_ID,
+      TOKEN_USDC,
+    ).catch((err: unknown) => err);
+
+    // A dropped connection must not read as "this token can't be named", which
+    // would hard-block the screen with no way back short of a reload.
+    expect(error).not.toBeInstanceOf(UnknownReserveTokenError);
+    expect(isIntegrityFailure(error)).toBe(false);
   });
 });
 

--- a/services/vault/src/applications/aave/services/__tests__/verifyReserveIdentity.test.ts
+++ b/services/vault/src/applications/aave/services/__tests__/verifyReserveIdentity.test.ts
@@ -1,0 +1,235 @@
+import type { Address } from "viem";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the leaf clients only, so the real assertReserveMatchesOnChain runs and
+// the real ReserveMismatchError instance reaches isIntegrityFailure.
+vi.mock("../../clients/spoke", () => ({
+  getReserve: vi.fn(),
+}));
+
+vi.mock("../../clients/transaction", () => ({
+  getCoreSpokeAddress: vi.fn(),
+}));
+
+vi.mock("@/clients/eth-contract/erc20", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/clients/eth-contract/erc20")
+  >("@/clients/eth-contract/erc20");
+  return {
+    ...actual,
+    getERC20Decimals: vi.fn(),
+    getERC20Symbol: vi.fn(),
+    getERC20Name: vi.fn(),
+  };
+});
+
+vi.mock("@/services/token/tokenService", () => ({
+  getRegisteredTokenByAddress: vi.fn(),
+}));
+
+import {
+  InvalidTokenDecimalsError,
+  getERC20Decimals,
+  getERC20Name,
+  getERC20Symbol,
+} from "@/clients/eth-contract/erc20";
+import { getRegisteredTokenByAddress } from "@/services/token/tokenService";
+
+import { getReserve } from "../../clients/spoke";
+import { getCoreSpokeAddress } from "../../clients/transaction";
+import {
+  ReserveMismatchError,
+  _resetCoreSpokeCacheForTests,
+} from "../assertReserveMatchesOnChain";
+import {
+  UnknownReserveTokenError,
+  isIntegrityFailure,
+  verifyReserveIdentity,
+} from "../verifyReserveIdentity";
+
+const mockGetReserve = vi.mocked(getReserve);
+const mockGetCoreSpokeAddress = vi.mocked(getCoreSpokeAddress);
+const mockGetERC20Decimals = vi.mocked(getERC20Decimals);
+const mockGetERC20Symbol = vi.mocked(getERC20Symbol);
+const mockGetERC20Name = vi.mocked(getERC20Name);
+const mockGetRegisteredTokenByAddress = vi.mocked(getRegisteredTokenByAddress);
+
+const ADAPTER = "0x000000000000000000000000000000000000ada9" as Address;
+const SPOKE = "0x000000000000000000000000000000000000fa11" as Address;
+const TOKEN_USDC = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" as Address;
+const TOKEN_WBTC = "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599" as Address;
+const RESERVE_ID = 7n;
+
+function reserveResult(underlying: Address) {
+  return {
+    underlying,
+    hub: "0x000000000000000000000000000000000000beef" as Address,
+    assetId: 1,
+    decimals: 6,
+    collateralRisk: 0,
+    flags: 0,
+    dynamicConfigKey: 0,
+  };
+}
+
+describe("verifyReserveIdentity", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _resetCoreSpokeCacheForTests();
+    mockGetCoreSpokeAddress.mockResolvedValue(SPOKE);
+    mockGetReserve.mockResolvedValue(reserveResult(TOKEN_USDC));
+    mockGetERC20Decimals.mockResolvedValue(6);
+    mockGetRegisteredTokenByAddress.mockReturnValue(null);
+    mockGetERC20Symbol.mockResolvedValue(null);
+    mockGetERC20Name.mockResolvedValue(null);
+  });
+
+  it("labels a registered token from the registry and marks the source", async () => {
+    mockGetRegisteredTokenByAddress.mockReturnValue({
+      address: TOKEN_USDC,
+      symbol: "USDC",
+      name: "USD Coin",
+      decimals: 18,
+      icon: "usdc.svg",
+    });
+
+    const identity = await verifyReserveIdentity(
+      ADAPTER,
+      RESERVE_ID,
+      TOKEN_USDC,
+    );
+
+    expect(identity).toEqual({
+      address: TOKEN_USDC,
+      symbol: "USDC",
+      name: "USD Coin",
+      decimals: 6,
+      icon: "usdc.svg",
+      source: "registry",
+    });
+  });
+
+  it("takes decimals from the chain even when the registry has its own copy", async () => {
+    mockGetRegisteredTokenByAddress.mockReturnValue({
+      address: TOKEN_USDC,
+      symbol: "USDC",
+      name: "USD Coin",
+      // Stale hand-maintained value; the signing path parses against 6.
+      decimals: 18,
+      icon: undefined,
+    });
+    mockGetERC20Decimals.mockResolvedValue(6);
+
+    const identity = await verifyReserveIdentity(
+      ADAPTER,
+      RESERVE_ID,
+      TOKEN_USDC,
+    );
+
+    expect(identity.decimals).toBe(6);
+  });
+
+  it("does not read the token contract's symbol when the registry knows the address", async () => {
+    mockGetRegisteredTokenByAddress.mockReturnValue({
+      address: TOKEN_USDC,
+      symbol: "USDC",
+      name: "USD Coin",
+      decimals: 6,
+      icon: undefined,
+    });
+
+    await verifyReserveIdentity(ADAPTER, RESERVE_ID, TOKEN_USDC);
+
+    expect(mockGetERC20Symbol).not.toHaveBeenCalled();
+    expect(mockGetERC20Name).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the token contract's own symbol and name for an unregistered address", async () => {
+    mockGetERC20Symbol.mockResolvedValue("TUSDC");
+    mockGetERC20Name.mockResolvedValue("Test USD Coin");
+
+    const identity = await verifyReserveIdentity(
+      ADAPTER,
+      RESERVE_ID,
+      TOKEN_USDC,
+    );
+
+    expect(identity).toEqual({
+      address: TOKEN_USDC,
+      symbol: "TUSDC",
+      name: "Test USD Coin",
+      decimals: 6,
+      icon: undefined,
+      source: "onchain",
+    });
+  });
+
+  it("uses the on-chain symbol as the name when the token has no usable name", async () => {
+    mockGetERC20Symbol.mockResolvedValue("TUSDC");
+    mockGetERC20Name.mockResolvedValue(null);
+
+    const identity = await verifyReserveIdentity(
+      ADAPTER,
+      RESERVE_ID,
+      TOKEN_USDC,
+    );
+
+    expect(identity.name).toBe("TUSDC");
+  });
+
+  it("throws UnknownReserveTokenError when neither the registry nor the contract can name the token", async () => {
+    mockGetERC20Symbol.mockResolvedValue(null);
+
+    await expect(
+      verifyReserveIdentity(ADAPTER, RESERVE_ID, TOKEN_USDC),
+    ).rejects.toBeInstanceOf(UnknownReserveTokenError);
+  });
+
+  it("throws ReserveMismatchError when the reserve maps to a different token on-chain", async () => {
+    mockGetReserve.mockResolvedValue(reserveResult(TOKEN_WBTC));
+
+    await expect(
+      verifyReserveIdentity(ADAPTER, RESERVE_ID, TOKEN_USDC),
+    ).rejects.toBeInstanceOf(ReserveMismatchError);
+  });
+
+  it("does not read decimals or labels once the reserve mismatch is proven", async () => {
+    mockGetReserve.mockResolvedValue(reserveResult(TOKEN_WBTC));
+
+    await expect(
+      verifyReserveIdentity(ADAPTER, RESERVE_ID, TOKEN_USDC),
+    ).rejects.toBeInstanceOf(ReserveMismatchError);
+    expect(mockGetERC20Decimals).not.toHaveBeenCalled();
+    expect(mockGetRegisteredTokenByAddress).not.toHaveBeenCalled();
+  });
+
+  it("propagates a transient RPC failure from the decimals read", async () => {
+    mockGetERC20Decimals.mockRejectedValue(new Error("rpc connection lost"));
+
+    await expect(
+      verifyReserveIdentity(ADAPTER, RESERVE_ID, TOKEN_USDC),
+    ).rejects.toThrow("rpc connection lost");
+  });
+});
+
+describe("isIntegrityFailure", () => {
+  it("treats a proven reserve mismatch as an integrity failure", () => {
+    expect(isIntegrityFailure(new ReserveMismatchError("mismatch"))).toBe(true);
+  });
+
+  it("treats an unlabelable token as an integrity failure", () => {
+    expect(isIntegrityFailure(new UnknownReserveTokenError("no label"))).toBe(
+      true,
+    );
+  });
+
+  it("treats implausible decimals as an integrity failure", () => {
+    expect(
+      isIntegrityFailure(new InvalidTokenDecimalsError("42 decimals")),
+    ).toBe(true);
+  });
+
+  it("treats an RPC error as transient, not an integrity failure", () => {
+    expect(isIntegrityFailure(new Error("rpc connection lost"))).toBe(false);
+  });
+});

--- a/services/vault/src/applications/aave/services/index.ts
+++ b/services/vault/src/applications/aave/services/index.ts
@@ -46,3 +46,9 @@ export {
   ReserveMismatchError,
   assertReserveMatchesOnChain,
 } from "./assertReserveMatchesOnChain";
+export {
+  UnknownReserveTokenError,
+  isIntegrityFailure,
+  verifyReserveIdentity,
+  type VerifiedReserveIdentity,
+} from "./verifyReserveIdentity";

--- a/services/vault/src/applications/aave/services/verifyReserveIdentity.ts
+++ b/services/vault/src/applications/aave/services/verifyReserveIdentity.ts
@@ -118,9 +118,17 @@ export async function verifyReserveIdentity(
   // Unknown address (typically a testnet deployment). The address is proven and
   // is what drives value, so a misleading `symbol()` here is a display concern
   // only — but it is still bound to the address, unlike the indexer's string.
+  //
+  // `symbol()` and `name()` are both optional in ERC-20, so a read that fails
+  // here is almost certainly an absent method rather than a dead RPC: the
+  // `getERC20Decimals` call above is uncaught and already completed a
+  // successful read against this same address, so the transport is known good.
+  // Treat a failure as "the token doesn't provide it" — a missing name falls
+  // back to the symbol below, and a missing symbol leaves nothing trustworthy
+  // to label with, which is a hard block rather than a retryable fault.
   const [symbol, name] = await Promise.all([
-    getERC20Symbol(underlying),
-    getERC20Name(underlying),
+    getERC20Symbol(underlying).catch(() => null),
+    getERC20Name(underlying).catch(() => null),
   ]);
 
   if (!symbol) {

--- a/services/vault/src/applications/aave/services/verifyReserveIdentity.ts
+++ b/services/vault/src/applications/aave/services/verifyReserveIdentity.ts
@@ -119,16 +119,13 @@ export async function verifyReserveIdentity(
   // is what drives value, so a misleading `symbol()` here is a display concern
   // only — but it is still bound to the address, unlike the indexer's string.
   //
-  // `symbol()` and `name()` are both optional in ERC-20, so a read that fails
-  // here is almost certainly an absent method rather than a dead RPC: the
-  // `getERC20Decimals` call above is uncaught and already completed a
-  // successful read against this same address, so the transport is known good.
-  // Treat a failure as "the token doesn't provide it" — a missing name falls
-  // back to the symbol below, and a missing symbol leaves nothing trustworthy
-  // to label with, which is a hard block rather than a retryable fault.
+  // Both reads resolve to null when the token simply doesn't implement the
+  // method, and throw when the RPC couldn't be reached. That split is what
+  // keeps a transient blip from being reported as a spoof: it propagates as an
+  // ordinary error, which `isIntegrityFailure` rejects, so the query retries.
   const [symbol, name] = await Promise.all([
-    getERC20Symbol(underlying).catch(() => null),
-    getERC20Name(underlying).catch(() => null),
+    getERC20Symbol(underlying),
+    getERC20Name(underlying),
   ]);
 
   if (!symbol) {

--- a/services/vault/src/applications/aave/services/verifyReserveIdentity.ts
+++ b/services/vault/src/applications/aave/services/verifyReserveIdentity.ts
@@ -1,0 +1,155 @@
+/**
+ * Prove what asset a reserve actually is, before its label or any of its
+ * amounts reach the screen.
+ *
+ * The loan detail screen used to take the reserve's symbol, name and decimals
+ * straight from the GraphQL indexer. A compromised indexer could keep a real
+ * `reserveId`/`underlying` pair but spoof the symbol, so the page labelled one
+ * asset while the transaction targeted another — and report decimals that made
+ * the displayed debt and Max differ from the amount actually signed.
+ *
+ * This resolves the identity from sources the indexer does not control:
+ *  1. `assertReserveMatchesOnChain` proves `reserveId -> underlying` against
+ *     the env-pinned adapter's spoke — the only authority on which token the
+ *     page is about.
+ *  2. `getERC20Decimals(underlying)` supplies decimals. This is the exact
+ *     helper the borrow/repay signing paths use, so display and signing can't
+ *     disagree.
+ *  3. The address-keyed token registry supplies the label, falling back to the
+ *     token contract's own `symbol()`/`name()` for addresses it doesn't know
+ *     (testnet/devnet deployments).
+ *
+ * The indexer's `token.symbol/name/decimals` are never consulted. If no
+ * trusted label can be produced, this throws rather than borrowing one.
+ */
+
+import type { Address } from "viem";
+
+import {
+  InvalidTokenDecimalsError,
+  getERC20Decimals,
+  getERC20Name,
+  getERC20Symbol,
+} from "@/clients/eth-contract/erc20";
+import { getRegisteredTokenByAddress } from "@/services/token/tokenService";
+
+import {
+  ReserveMismatchError,
+  assertReserveMatchesOnChain,
+} from "./assertReserveMatchesOnChain";
+
+/**
+ * The underlying is proven, but nothing trustworthy can name it: it is absent
+ * from the token registry and its contract returned no usable `symbol()`.
+ * Falling back to the indexer's string here is exactly the substitution this
+ * module exists to prevent, so callers must hard-block instead.
+ */
+export class UnknownReserveTokenError extends Error {
+  readonly code = "UNKNOWN_RESERVE_TOKEN";
+}
+
+export interface VerifiedReserveIdentity {
+  /**
+   * The proven underlying token address. Identical to the address passed in —
+   * the assert throws unless the on-chain `underlying` matches it — so callers
+   * may treat this as the on-chain value and should use it in place of the
+   * indexer-supplied `reserve.token.address`.
+   */
+  address: Address;
+  /** Registry label for `address`, or the token's own `symbol()` as last resort. */
+  symbol: string;
+  /** Registry name, the token's own `name()`, or the symbol. */
+  name: string;
+  /** On-chain `decimals()` — the same source the signing path parses against. */
+  decimals: number;
+  /** Registry icon; undefined for on-chain-derived identities. */
+  icon: string | undefined;
+  /**
+   * Where the label came from. `"onchain"` strings are attacker-influenceable
+   * display text (a token contract may return anything); `"registry"` labels
+   * are curated in this codebase.
+   */
+  source: "registry" | "onchain";
+}
+
+/**
+ * Prove a reserve's identity from on-chain and locally-curated sources.
+ *
+ * @param trustedAdapterAddress - Env-pinned Aave adapter, the same address the
+ *   borrow/repay tx is sent to. Never accept this from a caller-supplied config.
+ * @param reserveId - Reserve id being displayed.
+ * @param underlying - The reserve's underlying token address as claimed by the
+ *   indexer. Proven against the chain before anything is derived from it.
+ * @throws {ReserveMismatchError} the claimed underlying isn't what the spoke maps
+ *   `reserveId` to.
+ * @throws {InvalidTokenDecimalsError} the token reports implausible decimals.
+ * @throws {UnknownReserveTokenError} no trusted label exists for the underlying.
+ */
+export async function verifyReserveIdentity(
+  trustedAdapterAddress: Address,
+  reserveId: bigint,
+  underlying: Address,
+): Promise<VerifiedReserveIdentity> {
+  // Assert first, matching the borrow path's ordering, so a mismatch surfaces
+  // its own error instead of being masked by a parallel RPC rejection.
+  await assertReserveMatchesOnChain(
+    trustedAdapterAddress,
+    reserveId,
+    underlying,
+  );
+
+  // Read decimals before the registry branch, deliberately: even on a registry
+  // hit we never use the registry's copy. The registry is a hand-maintained
+  // table; on-chain decimals are what the signed transaction parses against.
+  const decimals = await getERC20Decimals(underlying);
+
+  const registered = getRegisteredTokenByAddress(underlying);
+  if (registered) {
+    return {
+      address: underlying,
+      symbol: registered.symbol,
+      name: registered.name,
+      decimals,
+      icon: registered.icon,
+      source: "registry",
+    };
+  }
+
+  // Unknown address (typically a testnet deployment). The address is proven and
+  // is what drives value, so a misleading `symbol()` here is a display concern
+  // only — but it is still bound to the address, unlike the indexer's string.
+  const [symbol, name] = await Promise.all([
+    getERC20Symbol(underlying),
+    getERC20Name(underlying),
+  ]);
+
+  if (!symbol) {
+    throw new UnknownReserveTokenError(
+      `No trusted label for underlying ${underlying}: it is absent from the ` +
+        `token registry and its contract returned no usable symbol(). ` +
+        `Refusing to fall back to indexer-supplied metadata.`,
+    );
+  }
+
+  return {
+    address: underlying,
+    symbol,
+    name: name ?? symbol,
+    decimals,
+    icon: undefined,
+    source: "onchain",
+  };
+}
+
+/**
+ * Whether a failure is a deterministic conclusion about the reserve rather than
+ * a transient fault. Retrying these only delays the warning, and the UI must
+ * present them as an integrity problem rather than "try again".
+ */
+export function isIntegrityFailure(error: unknown): boolean {
+  return (
+    error instanceof ReserveMismatchError ||
+    error instanceof UnknownReserveTokenError ||
+    error instanceof InvalidTokenDecimalsError
+  );
+}

--- a/services/vault/src/clients/eth-contract/erc20/__tests__/query.test.ts
+++ b/services/vault/src/clients/eth-contract/erc20/__tests__/query.test.ts
@@ -1,3 +1,9 @@
+import {
+  ContractFunctionExecutionError,
+  ContractFunctionRevertedError,
+  ContractFunctionZeroDataError,
+  HttpRequestError,
+} from "viem";
 import { describe, expect, it, vi } from "vitest";
 
 const mockReadContract = vi.fn();
@@ -18,6 +24,40 @@ import {
 } from "../query";
 
 const TOKEN_ADDRESS = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+
+/**
+ * viem wraps the contract's own answer in a `ContractFunctionExecutionError`,
+ * so the readers have to walk the cause chain rather than match the outer
+ * class. Build the real nesting so these tests fail if that changes.
+ */
+function contractExecutionError(cause: Error) {
+  return new ContractFunctionExecutionError(cause as never, {
+    abi: [],
+    functionName: "symbol",
+  });
+}
+
+/** A token that does not implement the method: the call returns no data. */
+function missingMethodError(functionName: string) {
+  return contractExecutionError(
+    new ContractFunctionZeroDataError({ functionName }),
+  );
+}
+
+/** A token whose method exists but reverts. */
+function revertedError(functionName: string) {
+  return contractExecutionError(
+    new ContractFunctionRevertedError({ abi: [], functionName }),
+  );
+}
+
+/** Couldn't reach the node at all — not the contract's answer. */
+function transportError() {
+  return new HttpRequestError({
+    url: "https://rpc.example",
+    details: "socket hang up",
+  });
+}
 
 describe("getERC20Decimals", () => {
   it("returns decimals from the contract", async () => {
@@ -113,6 +153,30 @@ describe("getERC20Symbol", () => {
 
     expect(result).toBeNull();
   });
+
+  it("returns null when the token does not implement symbol()", async () => {
+    mockReadContract.mockRejectedValue(missingMethodError("symbol"));
+
+    const result = await getERC20Symbol(TOKEN_ADDRESS);
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when symbol() reverts", async () => {
+    mockReadContract.mockRejectedValue(revertedError("symbol"));
+
+    const result = await getERC20Symbol(TOKEN_ADDRESS);
+
+    expect(result).toBeNull();
+  });
+
+  it("throws on a transport failure so the caller can retry it", async () => {
+    mockReadContract.mockRejectedValue(transportError());
+
+    await expect(getERC20Symbol(TOKEN_ADDRESS)).rejects.toBeInstanceOf(
+      HttpRequestError,
+    );
+  });
 });
 
 describe("getERC20Name", () => {
@@ -138,5 +202,21 @@ describe("getERC20Name", () => {
     const result = await getERC20Name(TOKEN_ADDRESS);
 
     expect(result).toBeNull();
+  });
+
+  it("returns null when the token does not implement name()", async () => {
+    mockReadContract.mockRejectedValue(missingMethodError("name"));
+
+    const result = await getERC20Name(TOKEN_ADDRESS);
+
+    expect(result).toBeNull();
+  });
+
+  it("throws on a transport failure so the caller can retry it", async () => {
+    mockReadContract.mockRejectedValue(transportError());
+
+    await expect(getERC20Name(TOKEN_ADDRESS)).rejects.toBeInstanceOf(
+      HttpRequestError,
+    );
   });
 });

--- a/services/vault/src/clients/eth-contract/erc20/__tests__/query.test.ts
+++ b/services/vault/src/clients/eth-contract/erc20/__tests__/query.test.ts
@@ -10,7 +10,12 @@ vi.mock("@/clients/eth-contract/client", () => ({
   },
 }));
 
-import { getERC20Decimals } from "../query";
+import {
+  InvalidTokenDecimalsError,
+  getERC20Decimals,
+  getERC20Name,
+  getERC20Symbol,
+} from "../query";
 
 const TOKEN_ADDRESS = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
 
@@ -45,11 +50,93 @@ describe("getERC20Decimals", () => {
     );
   });
 
+  it("throws InvalidTokenDecimalsError, not a plain Error, when decimals exceed 18", async () => {
+    mockReadContract.mockResolvedValue(19);
+
+    await expect(getERC20Decimals(TOKEN_ADDRESS)).rejects.toBeInstanceOf(
+      InvalidTokenDecimalsError,
+    );
+  });
+
   it("accepts decimals equal to 18", async () => {
     mockReadContract.mockResolvedValue(18);
 
     const result = await getERC20Decimals(TOKEN_ADDRESS);
 
     expect(result).toBe(18);
+  });
+});
+
+describe("getERC20Symbol", () => {
+  it("returns the symbol from the contract", async () => {
+    mockReadContract.mockResolvedValue("USDC");
+
+    const result = await getERC20Symbol(TOKEN_ADDRESS);
+
+    expect(result).toBe("USDC");
+  });
+
+  it("calls readContract with the correct address and function", async () => {
+    mockReadContract.mockResolvedValue("USDC");
+
+    await getERC20Symbol(TOKEN_ADDRESS);
+
+    expect(mockReadContract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        address: TOKEN_ADDRESS,
+        functionName: "symbol",
+        args: [],
+      }),
+    );
+  });
+
+  it("strips zero-width joiners a hostile token could use to spoof a symbol", async () => {
+    mockReadContract.mockResolvedValue("US\u200BDC");
+
+    const result = await getERC20Symbol(TOKEN_ADDRESS);
+
+    expect(result).toBe("USDC");
+  });
+
+  it("truncates an oversized symbol to 16 characters", async () => {
+    mockReadContract.mockResolvedValue("A".repeat(500));
+
+    const result = await getERC20Symbol(TOKEN_ADDRESS);
+
+    expect(result).toBe("A".repeat(16));
+  });
+
+  it("returns null when the symbol is only whitespace and zero-width characters", async () => {
+    mockReadContract.mockResolvedValue(" \u200B\u200B ");
+
+    const result = await getERC20Symbol(TOKEN_ADDRESS);
+
+    expect(result).toBeNull();
+  });
+});
+
+describe("getERC20Name", () => {
+  it("returns the name from the contract", async () => {
+    mockReadContract.mockResolvedValue("USD Coin");
+
+    const result = await getERC20Name(TOKEN_ADDRESS);
+
+    expect(result).toBe("USD Coin");
+  });
+
+  it("truncates an oversized name to 64 characters", async () => {
+    mockReadContract.mockResolvedValue("B".repeat(500));
+
+    const result = await getERC20Name(TOKEN_ADDRESS);
+
+    expect(result).toBe("B".repeat(64));
+  });
+
+  it("returns null when the name is empty after sanitizing", async () => {
+    mockReadContract.mockResolvedValue("");
+
+    const result = await getERC20Name(TOKEN_ADDRESS);
+
+    expect(result).toBeNull();
   });
 });

--- a/services/vault/src/clients/eth-contract/erc20/query.ts
+++ b/services/vault/src/clients/eth-contract/erc20/query.ts
@@ -49,6 +49,33 @@ const ERC20_ABI = [
 ] as const;
 
 /**
+ * A token whose on-chain `decimals()` is outside the range any real ERC20 uses.
+ * Named so callers can classify it as an integrity conclusion (do not retry)
+ * rather than a transient RPC fault.
+ */
+export class InvalidTokenDecimalsError extends Error {
+  readonly code = "INVALID_TOKEN_DECIMALS";
+}
+
+/** No real ERC20 exceeds 18; anything above is a misconfigured or hostile token. */
+const MAX_REASONABLE_DECIMALS = 18;
+/** Display caps for `symbol()` / `name()` — a hostile token can return megabytes. */
+const MAX_SYMBOL_LENGTH = 16;
+const MAX_NAME_LENGTH = 64;
+
+/**
+ * Make an on-chain string safe to render. Strips Unicode "other" code points
+ * (control characters, zero-width joiners) that a hostile token could use to
+ * spoof a homoglyph of a legitimate symbol, then caps the length.
+ *
+ * @returns The sanitized string, or null when nothing usable remains.
+ */
+function sanitizeTokenString(raw: string, maxLength: number): string | null {
+  const cleaned = raw.replace(/\p{C}/gu, "").trim();
+  return cleaned ? cleaned.slice(0, maxLength) : null;
+}
+
+/**
  * Get ERC20 token balance for an address
  * @param tokenAddress - ERC20 token contract address
  * @param holderAddress - Address to check balance for
@@ -91,14 +118,62 @@ export async function getERC20Decimals(tokenAddress: Address): Promise<number> {
     args: [],
   });
 
-  const MAX_REASONABLE_DECIMALS = 18;
   if (decimals > MAX_REASONABLE_DECIMALS) {
-    throw new Error(
+    throw new InvalidTokenDecimalsError(
       `Token ${tokenAddress} reported ${decimals} decimals, expected at most ${MAX_REASONABLE_DECIMALS}`,
     );
   }
 
   return decimals as number;
+}
+
+/**
+ * Get an ERC20 token's symbol from the contract on-chain.
+ *
+ * Only for display, and only as a fallback when the address-keyed token
+ * registry has no entry: a token contract can return any string it likes, so
+ * this is trustworthy exactly as far as the address is — never treat it as
+ * proof of what the token is. It is still strictly better than an
+ * indexer-supplied symbol, which isn't bound to the address at all.
+ *
+ * @param tokenAddress - ERC20 token contract address
+ * @returns Sanitized symbol, or null when the token returns nothing usable
+ */
+export async function getERC20Symbol(
+  tokenAddress: Address,
+): Promise<string | null> {
+  const publicClient = ethClient.getPublicClient();
+
+  const symbol = await publicClient.readContract({
+    address: tokenAddress,
+    abi: ERC20_ABI,
+    functionName: "symbol",
+    args: [],
+  });
+
+  return sanitizeTokenString(symbol as string, MAX_SYMBOL_LENGTH);
+}
+
+/**
+ * Get an ERC20 token's name from the contract on-chain. Same trust caveats as
+ * {@link getERC20Symbol} — display-only, registry-miss fallback.
+ *
+ * @param tokenAddress - ERC20 token contract address
+ * @returns Sanitized name, or null when the token returns nothing usable
+ */
+export async function getERC20Name(
+  tokenAddress: Address,
+): Promise<string | null> {
+  const publicClient = ethClient.getPublicClient();
+
+  const name = await publicClient.readContract({
+    address: tokenAddress,
+    abi: ERC20_ABI,
+    functionName: "name",
+    args: [],
+  });
+
+  return sanitizeTokenString(name as string, MAX_NAME_LENGTH);
 }
 
 /**

--- a/services/vault/src/clients/eth-contract/erc20/query.ts
+++ b/services/vault/src/clients/eth-contract/erc20/query.ts
@@ -1,6 +1,11 @@
 // ERC20 - Read operations (queries)
 
-import type { Address } from "viem";
+import {
+  BaseError,
+  ContractFunctionRevertedError,
+  ContractFunctionZeroDataError,
+  type Address,
+} from "viem";
 
 import { ethClient } from "../client";
 
@@ -76,6 +81,59 @@ function sanitizeTokenString(raw: string, maxLength: number): string | null {
 }
 
 /**
+ * Whether a failed read is the contract's answer rather than a failure to
+ * reach it: the method is absent (the call returns no data) or it reverted.
+ *
+ * The distinction matters because `symbol()` and `name()` are optional in
+ * ERC-20. A caller must be able to conclude "this token has no symbol" — a
+ * permanent fact worth failing closed on — without a dropped connection
+ * producing the same conclusion, which would turn one blip into a permanent
+ * error state. viem wraps both in `ContractFunctionExecutionError`, so walk
+ * the cause chain rather than matching on the outer class.
+ */
+function isContractLevelFailure(error: unknown): boolean {
+  if (!(error instanceof BaseError)) return false;
+  return (
+    error.walk(
+      (cause) =>
+        cause instanceof ContractFunctionZeroDataError ||
+        cause instanceof ContractFunctionRevertedError,
+    ) !== null
+  );
+}
+
+/**
+ * Read an optional string-returning ERC-20 method.
+ *
+ * @returns The sanitized value, or null when the token does not implement the
+ *   method, reverts, or returns nothing usable.
+ * @throws Whatever the transport threw, when the read failed for any reason
+ *   other than the contract itself — so a caller can retry it.
+ */
+async function readOptionalTokenString(
+  tokenAddress: Address,
+  functionName: "symbol" | "name",
+  maxLength: number,
+): Promise<string | null> {
+  const publicClient = ethClient.getPublicClient();
+
+  let raw: string;
+  try {
+    raw = (await publicClient.readContract({
+      address: tokenAddress,
+      abi: ERC20_ABI,
+      functionName,
+      args: [],
+    })) as string;
+  } catch (error) {
+    if (isContractLevelFailure(error)) return null;
+    throw error;
+  }
+
+  return sanitizeTokenString(raw, maxLength);
+}
+
+/**
  * Get ERC20 token balance for an address
  * @param tokenAddress - ERC20 token contract address
  * @param holderAddress - Address to check balance for
@@ -136,44 +194,32 @@ export async function getERC20Decimals(tokenAddress: Address): Promise<number> {
  * proof of what the token is. It is still strictly better than an
  * indexer-supplied symbol, which isn't bound to the address at all.
  *
+ * `symbol()` is optional in ERC-20, so a token that doesn't implement it is a
+ * legitimate case, not an error — hence null rather than a throw. A transport
+ * failure is a different thing and still throws, so the caller can retry it.
+ *
  * @param tokenAddress - ERC20 token contract address
- * @returns Sanitized symbol, or null when the token returns nothing usable
+ * @returns Sanitized symbol, or null when the token has no usable symbol
+ * @throws On transport failure (network, timeout, rate limit)
  */
 export async function getERC20Symbol(
   tokenAddress: Address,
 ): Promise<string | null> {
-  const publicClient = ethClient.getPublicClient();
-
-  const symbol = await publicClient.readContract({
-    address: tokenAddress,
-    abi: ERC20_ABI,
-    functionName: "symbol",
-    args: [],
-  });
-
-  return sanitizeTokenString(symbol as string, MAX_SYMBOL_LENGTH);
+  return readOptionalTokenString(tokenAddress, "symbol", MAX_SYMBOL_LENGTH);
 }
 
 /**
- * Get an ERC20 token's name from the contract on-chain. Same trust caveats as
- * {@link getERC20Symbol} — display-only, registry-miss fallback.
+ * Get an ERC20 token's name from the contract on-chain. Same trust caveats and
+ * the same null-vs-throw split as {@link getERC20Symbol}.
  *
  * @param tokenAddress - ERC20 token contract address
- * @returns Sanitized name, or null when the token returns nothing usable
+ * @returns Sanitized name, or null when the token has no usable name
+ * @throws On transport failure (network, timeout, rate limit)
  */
 export async function getERC20Name(
   tokenAddress: Address,
 ): Promise<string | null> {
-  const publicClient = ethClient.getPublicClient();
-
-  const name = await publicClient.readContract({
-    address: tokenAddress,
-    abi: ERC20_ABI,
-    functionName: "name",
-    args: [],
-  });
-
-  return sanitizeTokenString(name as string, MAX_NAME_LENGTH);
+  return readOptionalTokenString(tokenAddress, "name", MAX_NAME_LENGTH);
 }
 
 /**

--- a/services/vault/src/components/pages/BorrowingMarketsData.tsx
+++ b/services/vault/src/components/pages/BorrowingMarketsData.tsx
@@ -9,8 +9,10 @@ import { useMemo } from "react";
 import { IoChevronBack } from "react-icons/io5";
 import { useLocation, useNavigate, useParams } from "react-router";
 
+import { ReserveIdentityBlock } from "@/applications/aave/components/ReserveIdentityBlock";
 import { LOAN_TAB } from "@/applications/aave/constants";
 import { useAaveConfig } from "@/applications/aave/context";
+import { useVerifiedReserveIdentity } from "@/applications/aave/hooks";
 import { NEUTRAL_BUTTON_CLASS } from "@/components/shared/buttonClasses";
 import {
   CARD_SHELL_CLASS,
@@ -18,11 +20,12 @@ import {
 } from "@/components/shared/layoutClasses";
 import featureFlags from "@/config/featureFlags";
 import { COPY } from "@/copy";
-import { getAssetPickerRoute, MARKET_SYMBOL_PARAM } from "@/routes";
 import {
-  getCurrencyIconWithFallback,
-  getTokenByAddress,
-} from "@/services/token/tokenService";
+  getAssetPickerRoute,
+  MARKET_RESERVE_PARAM,
+  parseReserveId,
+} from "@/routes";
+import { getCurrencyIconWithFallback } from "@/services/token/tokenService";
 
 const SECTION_BODY_CLASS = "min-h-[120px]";
 const CHART_BODY_CLASS = "min-h-[240px]";
@@ -66,40 +69,82 @@ export default function BorrowingMarketsData() {
   const location = useLocation();
   const params = useParams();
   const { borrowableReserves } = useAaveConfig();
-  const symbol = (params[MARKET_SYMBOL_PARAM] ?? "").toUpperCase();
 
-  // Icon resolves from the symbol alone, so the header still renders while the
-  // config loads or for a symbol matching no reserve.
-  const { name, icon } = useMemo(() => {
-    const reserve = borrowableReserves.find(
-      (r) => r.token.symbol.toUpperCase() === symbol,
+  // Resolve by the reserve's on-chain id, never by a token symbol from the URL:
+  // the symbol is indexer-supplied, so labelling this page from it lets a
+  // compromised indexer decide which market the user is reading (audit F7).
+  // Exactly one match or none — `.find` would take whichever duplicate the
+  // indexer ordered first.
+  const selectedReserve = useMemo(() => {
+    const target = parseReserveId(params[MARKET_RESERVE_PARAM]);
+    if (target === null) return null;
+    const matches = borrowableReserves.filter((r) => r.reserveId === target);
+    return matches.length === 1 ? matches[0] : null;
+  }, [borrowableReserves, params]);
+
+  const {
+    identity,
+    isLoading: identityLoading,
+    error: identityError,
+    isIntegrityViolation,
+    retry: retryIdentity,
+  } = useVerifiedReserveIdentity({
+    reserveId: selectedReserve?.reserveId,
+    underlying: selectedReserve?.reserve.underlying,
+  });
+
+  const symbol = identity?.symbol ?? "";
+  const name = identity?.name ?? symbol;
+  const icon = getCurrencyIconWithFallback(identity?.icon, symbol);
+
+  const backToAssets = () =>
+    // This URL is shareable: opened directly there is no in-app entry to go
+    // back to, and history back would leave the app.
+    location.key === "default"
+      ? navigate(
+          getAssetPickerRoute(LOAN_TAB.BORROW, featureFlags.isV3UiEnabled),
+        )
+      : navigate(-1);
+
+  if (identityError) {
+    return (
+      <Container className={`${PAGE_CONTENT_CLASS} pb-6`}>
+        <ReserveIdentityBlock
+          compromised={isIntegrityViolation}
+          onRetry={() => void retryIdentity()}
+        />
+      </Container>
     );
-    return {
-      name: reserve?.token.name ?? symbol,
-      icon: getCurrencyIconWithFallback(
-        reserve && getTokenByAddress(reserve.token.address)?.icon,
-        symbol,
-      ),
-    };
-  }, [borrowableReserves, symbol]);
+  }
+
+  // Nothing below may render before the asset is proven — the header is the
+  // whole point of the page, and an unverified one is the mislabeling F7 stops.
+  if (identityLoading) {
+    return (
+      <Container className={`${PAGE_CONTENT_CLASS} pb-6`}>
+        <div className="flex items-center justify-center py-12">
+          <p className="text-accent-secondary">{COPY.common.loading}</p>
+        </div>
+      </Container>
+    );
+  }
+
+  if (!identity) {
+    return (
+      <Container className={`${PAGE_CONTENT_CLASS} pb-6`}>
+        <div className="flex items-center justify-center py-12">
+          <p className="text-accent-secondary">{COPY.loans.reserveNotFound}</p>
+        </div>
+      </Container>
+    );
+  }
 
   return (
     <Container className={`${PAGE_CONTENT_CLASS} pb-6`}>
       <div className="space-y-5">
         <button
           type="button"
-          onClick={() =>
-            // This URL is shareable: opened directly there is no in-app entry
-            // to go back to, and history back would leave the app.
-            location.key === "default"
-              ? navigate(
-                  getAssetPickerRoute(
-                    LOAN_TAB.BORROW,
-                    featureFlags.isV3UiEnabled,
-                  ),
-                )
-              : navigate(-1)
-          }
+          onClick={backToAssets}
           className="flex w-fit cursor-pointer items-center gap-1 text-sm leading-[1.43] tracking-[0.17px] text-accent-secondary transition-colors hover:text-accent-primary"
         >
           <IoChevronBack size={16} aria-hidden />

--- a/services/vault/src/components/pages/Loans.tsx
+++ b/services/vault/src/components/pages/Loans.tsx
@@ -2,14 +2,14 @@
  * Loans page (v3)
  * Dedicated `/loans` route: borrow-capacity + health-factor summary and the
  * list of active loans, reusing the existing Aave data hooks and the
- * reserve-detail borrow/repay overlay (route-driven via `?reserve=&tab=`).
+ * reserve-detail borrow/repay overlay (route-driven via `?reserve=<id>&tab=`).
  */
 
 import { Container, Loader } from "@babylonlabs-io/core-ui";
 import { useMemo } from "react";
 import { useOutletContext } from "react-router";
 
-import { LOAN_TAB } from "@/applications/aave/constants";
+import { LOAN_TAB, type LoanTab } from "@/applications/aave/constants";
 import { useActiveLoans } from "@/applications/aave/hooks";
 import type { RootLayoutContext } from "@/components/pages/RootLayout";
 import { EmptyState } from "@/components/shared";
@@ -24,6 +24,7 @@ import {
 import { useDemoLoan } from "@/dev/demoDeposit";
 import { useDashboardState } from "@/hooks/useDashboardState";
 import { useLoanActions } from "@/hooks/useLoanActions";
+import { parseReserveId } from "@/routes";
 import { formatUsdValue } from "@/utils/formatting";
 
 import { ActiveLoansList } from "../simple/ActiveLoansList";
@@ -52,6 +53,14 @@ export default function Loans() {
   const { openBorrowPicker, openRepay, goToReserve } = useLoanActions({
     borrowedAssets,
   });
+
+  // Row actions carry the reserve id. A god-mode demo row's id doesn't parse,
+  // but `ActiveLoansList` already disables both of its buttons — this guard
+  // only makes that unreachable path explicit rather than throwing on BigInt().
+  const goToRowReserve = (reserveId: string, tab: LoanTab) => {
+    const parsed = parseReserveId(reserveId);
+    if (parsed != null) goToReserve(parsed, tab);
+  };
 
   const activeLoans = useActiveLoans(borrowedAssets);
 
@@ -177,8 +186,8 @@ export default function Loans() {
           <ActiveLoansList
             rows={displayLoans}
             canBorrow={canBorrow}
-            onBorrow={(symbol) => goToReserve(symbol, LOAN_TAB.BORROW)}
-            onRepay={(symbol) => goToReserve(symbol, LOAN_TAB.REPAY)}
+            onBorrow={(reserveId) => goToRowReserve(reserveId, LOAN_TAB.BORROW)}
+            onRepay={(reserveId) => goToRowReserve(reserveId, LOAN_TAB.REPAY)}
           />
         ) : (
           // Has collateral but no borrows yet: the Borrow action lives in the

--- a/services/vault/src/components/pages/__tests__/BorrowingMarketsData.test.tsx
+++ b/services/vault/src/components/pages/__tests__/BorrowingMarketsData.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * BorrowingMarketsData — reserve resolution and header labelling.
+ *
+ * The page is addressed by the reserve's on-chain id and labelled from the
+ * proven identity, so a spoofed indexer symbol can neither steer which market
+ * opens nor name the one that does (audit F7).
+ */
+
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import type { Address } from "viem";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { COPY } from "@/copy";
+
+import BorrowingMarketsData from "../BorrowingMarketsData";
+
+const mockParams = vi.fn<() => Record<string, string>>();
+
+vi.mock("react-router", () => ({
+  useNavigate: () => vi.fn(),
+  useLocation: () => ({ key: "default" }),
+  useParams: () => mockParams(),
+}));
+
+vi.mock("@babylonlabs-io/core-ui", () => ({
+  Avatar: ({ alt }: { alt: string }) => <img alt={alt} />,
+  Container: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Heading: ({ children }: { children: ReactNode }) => <h1>{children}</h1>,
+  Text: ({ children }: { children: ReactNode }) => <p>{children}</p>,
+  Button: ({
+    children,
+    onClick,
+  }: {
+    children: ReactNode;
+    onClick: () => void;
+  }) => <button onClick={onClick}>{children}</button>,
+}));
+
+vi.mock("@/config/featureFlags", () => ({
+  default: { isV3UiEnabled: true },
+}));
+
+vi.mock("@/services/token/tokenService", () => ({
+  getCurrencyIconWithFallback: () => "icon.png",
+}));
+
+// Reserve 2 is genuinely WETH; the indexer labels it "USDC".
+const spoofedReserve = {
+  reserveId: 2n,
+  reserve: { underlying: "0xWETH" as Address },
+  token: {
+    symbol: "USDC",
+    name: "USD Coin",
+    address: "0xWETH" as Address,
+    decimals: 6,
+  },
+};
+
+vi.mock("@/applications/aave/context", () => ({
+  useAaveConfig: () => ({ borrowableReserves: [spoofedReserve] }),
+}));
+
+const mockUseVerifiedReserveIdentity = vi.fn();
+vi.mock("@/applications/aave/hooks", () => ({
+  useVerifiedReserveIdentity: (args: unknown) =>
+    mockUseVerifiedReserveIdentity(args),
+}));
+
+const WETH_IDENTITY = {
+  address: "0xWETH" as Address,
+  symbol: "WETH",
+  name: "Wrapped Ether",
+  decimals: 18,
+  icon: undefined,
+  source: "registry" as const,
+};
+
+function resolved(overrides: Record<string, unknown> = {}) {
+  return {
+    identity: WETH_IDENTITY,
+    isLoading: false,
+    error: null,
+    isIntegrityViolation: false,
+    retry: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("BorrowingMarketsData", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockParams.mockReturnValue({ reserveId: "2" });
+    mockUseVerifiedReserveIdentity.mockReturnValue(resolved());
+  });
+
+  it("verifies the reserve the id resolves to, against its on-chain underlying", () => {
+    render(<BorrowingMarketsData />);
+
+    expect(mockUseVerifiedReserveIdentity).toHaveBeenCalledWith({
+      reserveId: 2n,
+      underlying: "0xWETH",
+    });
+  });
+
+  it("labels the header from the proven identity, not the indexer's symbol", () => {
+    render(<BorrowingMarketsData />);
+
+    expect(screen.getByText("Wrapped Ether")).toBeInTheDocument();
+    expect(screen.getByText("WETH")).toBeInTheDocument();
+    expect(screen.queryByText("USD Coin")).not.toBeInTheDocument();
+  });
+
+  it("blocks a legacy symbol URL instead of resolving it", () => {
+    mockParams.mockReturnValue({ reserveId: "usdc" });
+    mockUseVerifiedReserveIdentity.mockReturnValue(
+      resolved({ identity: null }),
+    );
+
+    render(<BorrowingMarketsData />);
+
+    expect(screen.getByText(COPY.loans.reserveNotFound)).toBeInTheDocument();
+    expect(mockUseVerifiedReserveIdentity).toHaveBeenCalledWith({
+      reserveId: undefined,
+      underlying: undefined,
+    });
+  });
+
+  it("reports an id matching no reserve as not found", () => {
+    mockParams.mockReturnValue({ reserveId: "99999" });
+    mockUseVerifiedReserveIdentity.mockReturnValue(
+      resolved({ identity: null }),
+    );
+
+    render(<BorrowingMarketsData />);
+
+    expect(screen.getByText(COPY.loans.reserveNotFound)).toBeInTheDocument();
+  });
+
+  it("blocks with integrity copy when the asset can't be verified", () => {
+    mockUseVerifiedReserveIdentity.mockReturnValue(
+      resolved({
+        identity: null,
+        error: new Error("reserve maps to a different token"),
+        isIntegrityViolation: true,
+      }),
+    );
+
+    render(<BorrowingMarketsData />);
+
+    expect(
+      screen.getByText(COPY.loans.detail.identityBlockedTitle),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Wrapped Ether")).not.toBeInTheDocument();
+  });
+
+  it("withholds the header while verification is still in flight", () => {
+    mockUseVerifiedReserveIdentity.mockReturnValue(
+      resolved({ identity: null, isLoading: true }),
+    );
+
+    render(<BorrowingMarketsData />);
+
+    expect(screen.getByText(COPY.common.loading)).toBeInTheDocument();
+    expect(screen.queryByText("Wrapped Ether")).not.toBeInTheDocument();
+  });
+});

--- a/services/vault/src/components/simple/ActiveLoansList.tsx
+++ b/services/vault/src/components/simple/ActiveLoansList.tsx
@@ -20,8 +20,9 @@ interface ActiveLoansListProps {
   rows: ActiveLoanRow[];
   /** Whether there is remaining borrow capacity (disables per-row Borrow at 0). */
   canBorrow: boolean;
-  onBorrow: (symbol: string) => void;
-  onRepay: (symbol: string) => void;
+  /** Receives the row's reserve id — the overlay routes by id, not by symbol. */
+  onBorrow: (reserveId: string) => void;
+  onRepay: (reserveId: string) => void;
 }
 
 export function ActiveLoansList({
@@ -70,13 +71,13 @@ export function ActiveLoansList({
               />
 
               {/* A god-mode demo row (`displayOnly`) is a preview of the row
-                  layout only — its symbol resolves to no reserve, so both
+                  layout only — its reserve id resolves to no reserve, so both
                   actions stay disabled rather than dead-ending in (or worse,
                   colliding with) the real borrow/repay overlay. */}
               <div className="ml-auto flex shrink-0 gap-2">
                 <button
                   type="button"
-                  onClick={() => onBorrow(row.symbol)}
+                  onClick={() => onBorrow(row.reserveId)}
                   disabled={!canBorrow || !row.isBorrowable || row.displayOnly}
                   className={NEUTRAL_ROW_BUTTON_CLASS}
                 >
@@ -84,7 +85,7 @@ export function ActiveLoansList({
                 </button>
                 <button
                   type="button"
-                  onClick={() => onRepay(row.symbol)}
+                  onClick={() => onRepay(row.reserveId)}
                   disabled={row.displayOnly}
                   className={NEUTRAL_ROW_BUTTON_CLASS}
                 >

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -1184,6 +1184,34 @@ export const COPY = {
       integrityError:
         "Position integrity check failed: your position details returned by the indexer don't match what's registered on-chain. Refresh and try again. If this persists, do not proceed.",
     },
+    // Reserve detail overlay (applications/aave/components/Detail).
+    detail: {
+      loading: "Loading...",
+      connectTitle: "Connect to manage position",
+      connectDescription: "Please connect your wallet to manage your position.",
+      reserveNotFound: "Reserve not found",
+      // Older links carried the token symbol (`?reserve=usdc`) rather than the
+      // reserve's on-chain id. Those are blocked rather than resolved by symbol.
+      reserveLinkOutdated:
+        "This link uses an outdated format. Please select the asset again from Loans.",
+      // The reserve's asset could not be confirmed on-chain. Deliberately
+      // alarming, and offered without a retry: the result is deterministic, so
+      // a retry button would only invite the user to click past the warning.
+      identityBlockedTitle: "Asset could not be verified",
+      identityBlockedDescription:
+        "The asset shown for this market doesn't match what's registered on-chain. For your safety, this position can't be managed here. Do not proceed — return to Loans and select the asset again.",
+      // Verification couldn't complete (network or RPC failure), as opposed to
+      // completing and failing. Neutral, and retryable.
+      identityUnavailableTitle: "Couldn't verify this asset",
+      identityUnavailableDescription:
+        "We couldn't confirm this market's asset on-chain. Check your connection and try again.",
+      retry: "Retry",
+      // Position load failure (hard-block) and the ancillary soft-warn, both in
+      // Detail/PositionGate.tsx.
+      positionLoadError: "Couldn't load your position. Please try again.",
+      ancillaryLoadWarning:
+        "Some data couldn't be loaded. Borrow may be unavailable; repay still works from your loaded debt.",
+    },
   },
   // Borrowing markets data page (Figma node 10088-60956).
   marketData: {

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -1185,13 +1185,13 @@ export const COPY = {
         "Position integrity check failed: your position details returned by the indexer don't match what's registered on-chain. Refresh and try again. If this persists, do not proceed.",
     },
     // Reserve detail overlay (applications/aave/components/Detail).
+    // Reserve-identity states shared by the loan overlay's form step and the
+    // borrowing markets data page. Loading / connect / not-found copy is the
+    // flat `loans.*` set above; these are the audit-F7 additions.
     detail: {
-      loading: "Loading...",
-      connectTitle: "Connect to manage position",
-      connectDescription: "Please connect your wallet to manage your position.",
-      reserveNotFound: "Reserve not found",
-      // Older links carried the token symbol (`?reserve=usdc`) rather than the
-      // reserve's on-chain id. Those are blocked rather than resolved by symbol.
+      // Older links carried the token symbol (`?reserve=usdc`, `/markets/usdc`)
+      // rather than the reserve's on-chain id. Those are blocked, never
+      // resolved by symbol.
       reserveLinkOutdated:
         "This link uses an outdated format. Please select the asset again from Loans.",
       // The reserve's asset could not be confirmed on-chain. Deliberately
@@ -1199,7 +1199,7 @@ export const COPY = {
       // a retry button would only invite the user to click past the warning.
       identityBlockedTitle: "Asset could not be verified",
       identityBlockedDescription:
-        "The asset shown for this market doesn't match what's registered on-chain. For your safety, this position can't be managed here. Do not proceed — return to Loans and select the asset again.",
+        "The asset shown for this market doesn't match what's registered on-chain. For your safety, this market can't be used here. Do not proceed — return to Loans and select the asset again.",
       // Verification couldn't complete (network or RPC failure), as opposed to
       // completing and failing. Neutral, and retryable.
       identityUnavailableTitle: "Couldn't verify this asset",

--- a/services/vault/src/hooks/useLoanActions.ts
+++ b/services/vault/src/hooks/useLoanActions.ts
@@ -14,11 +14,19 @@ import { useNavigate } from "react-router";
 
 import { LOAN_TAB, type LoanTab } from "@/applications/aave/constants";
 import featureFlags from "@/config/featureFlags";
-import { getAssetPickerRoute, getReserveDetailRoute } from "@/routes";
+import {
+  getAssetPickerRoute,
+  getReserveDetailRoute,
+  parseReserveId,
+} from "@/routes";
 
 interface UseLoanActionsProps {
-  /** Borrowed assets (used to resolve the single-asset repay shortcut). */
-  borrowedAssets: { symbol: string }[];
+  /**
+   * Borrowed assets (used to resolve the single-asset repay shortcut). Keyed by
+   * reserve id, so the shortcut can't be pointed at a different reserve by a
+   * spoofed symbol.
+   */
+  borrowedAssets: { reserveId: string }[];
 }
 
 export function useLoanActions({ borrowedAssets }: UseLoanActionsProps) {
@@ -26,8 +34,8 @@ export function useLoanActions({ borrowedAssets }: UseLoanActionsProps) {
   const isV3 = featureFlags.isV3UiEnabled;
 
   const goToReserve = useCallback(
-    (assetSymbol: string, tab: LoanTab) => {
-      navigate(getReserveDetailRoute(assetSymbol, tab, isV3));
+    (reserveId: bigint, tab: LoanTab) => {
+      navigate(getReserveDetailRoute(reserveId, tab, isV3));
     },
     [navigate, isV3],
   );
@@ -38,9 +46,14 @@ export function useLoanActions({ borrowedAssets }: UseLoanActionsProps) {
 
   const openRepay = useCallback(() => {
     // A single borrowed asset has no choice to make — skip the picker and open
-    // its repay form directly.
-    if (borrowedAssets.length === 1) {
-      goToReserve(borrowedAssets[0].symbol, LOAN_TAB.REPAY);
+    // its repay form directly. Fall through to the picker if that one row's id
+    // doesn't parse (a god-mode demo row), rather than routing nowhere.
+    const soleReserveId =
+      borrowedAssets.length === 1
+        ? parseReserveId(borrowedAssets[0].reserveId)
+        : null;
+    if (soleReserveId != null) {
+      goToReserve(soleReserveId, LOAN_TAB.REPAY);
       return;
     }
     navigate(getAssetPickerRoute(LOAN_TAB.REPAY, isV3));

--- a/services/vault/src/router.tsx
+++ b/services/vault/src/router.tsx
@@ -26,7 +26,7 @@ import RootLayout, {
 } from "./components/pages/RootLayout";
 import {
   getReserveDetailBaseRoute,
-  MARKET_SYMBOL_PARAM,
+  MARKET_RESERVE_PARAM,
   RESERVE_QUERY_KEYS,
   ROUTES,
 } from "./routes";
@@ -202,7 +202,7 @@ export const Router = () => (
           }
         />
         <Route
-          path={`${ROUTES.MARKETS}/:${MARKET_SYMBOL_PARAM}`}
+          path={`${ROUTES.MARKETS}/:${MARKET_RESERVE_PARAM}`}
           element={
             featureFlags.isV3UiEnabled ? (
               <Suspense fallback={<RouteFallback />}>

--- a/services/vault/src/routes.ts
+++ b/services/vault/src/routes.ts
@@ -10,7 +10,8 @@ export const ROUTES = {
   MARKETS: "/markets",
 } as const;
 
-export const MARKET_SYMBOL_PARAM = "symbol";
+/** Path segment of `/markets/:reserveId` — the reserve's on-chain id. */
+export const MARKET_RESERVE_PARAM = "reserveId";
 
 export const RESERVE_QUERY_KEYS = {
   RESERVE_ID: "reserve",
@@ -28,19 +29,53 @@ export function getAssetPickerRoute(tab: LoanTab, isV3Enabled: boolean) {
   return `${getReserveDetailBaseRoute(isV3Enabled)}?${params.toString()}`;
 }
 
+/**
+ * Only decimal digits. `BigInt` would happily accept `"0x5"`, `" 5 "` and
+ * `"-1"`, and the reserve screens must treat anything that is not a plain
+ * on-chain reserve id as unresolvable rather than coercing it.
+ */
+const NUMERIC_RESERVE_ID = /^\d+$/;
+
+/**
+ * Parse a reserve id out of a URL — either the `?reserve=` query value or the
+ * `/markets/:reserveId` segment.
+ *
+ * Legacy links carry a token symbol (`?reserve=usdc`, `/markets/usdc`) rather
+ * than an id. Those resolve to null and must hard-block: matching a symbol
+ * would reopen the indexer-steering path this identifier replaced (audit F7).
+ *
+ * @returns The reserve id, or null when the value is absent or not a plain id.
+ */
+export function parseReserveId(
+  param: string | null | undefined,
+): bigint | null {
+  if (!param || !NUMERIC_RESERVE_ID.test(param)) {
+    return null;
+  }
+  return BigInt(param);
+}
+
+/**
+ * Build the reserve detail route.
+ *
+ * The `reserve` query value is the reserve's on-chain id, never its token
+ * symbol: the symbol comes from the indexer, so routing by it lets a
+ * compromised indexer decide which reserve a link opens.
+ */
 export function getReserveDetailRoute(
-  reserveId: string,
+  reserveId: bigint,
   tab: LoanTab,
   isV3Enabled: boolean,
 ) {
   const baseRoute = getReserveDetailBaseRoute(isV3Enabled);
   const params = new URLSearchParams({
-    [RESERVE_QUERY_KEYS.RESERVE_ID]: reserveId.toLowerCase(),
+    [RESERVE_QUERY_KEYS.RESERVE_ID]: reserveId.toString(),
     [RESERVE_QUERY_KEYS.TAB]: tab,
   });
   return `${baseRoute}?${params.toString()}`;
 }
 
-export function getMarketDataRoute(assetSymbol: string) {
-  return `${ROUTES.MARKETS}/${encodeURIComponent(assetSymbol.toLowerCase())}`;
+/** Keyed by reserve id for the same reason as {@link getReserveDetailRoute}. */
+export function getMarketDataRoute(reserveId: bigint) {
+  return `${ROUTES.MARKETS}/${reserveId.toString()}`;
 }

--- a/services/vault/src/services/token/tokenService.ts
+++ b/services/vault/src/services/token/tokenService.ts
@@ -160,13 +160,17 @@ export function getTokenIconBySymbol(symbol: string): string | undefined {
 }
 
 /**
- * Get token metadata by address (sync version for immediate use)
- * Only checks cache and registry, doesn't fetch from blockchain
+ * Strict address-keyed metadata lookup: cache or registry hit only, never a
+ * placeholder. Use this wherever a wrong label is a security problem rather
+ * than a cosmetic one, so the caller can hard-block on a miss instead of
+ * rendering a fabricated symbol (audit F7).
  *
  * @param address - Token contract address
- * @returns Token metadata or null if not found
+ * @returns Token metadata, or null when the address is invalid or unknown
  */
-export function getTokenByAddress(address: string): TokenMetadata | null {
+export function getRegisteredTokenByAddress(
+  address: string,
+): TokenMetadata | null {
   if (!isAddress(address)) {
     logger.warn(`[TokenService] Invalid token address: ${address}`);
     return null;
@@ -174,18 +178,37 @@ export function getTokenByAddress(address: string): TokenMetadata | null {
 
   const checksumAddress = getAddress(address);
 
-  // Check cache first
-  if (tokenMetadataCache.has(checksumAddress)) {
-    return tokenMetadataCache.get(checksumAddress)!;
-  }
+  return (
+    tokenMetadataCache.get(checksumAddress) ??
+    TOKEN_REGISTRY[checksumAddress] ??
+    null
+  );
+}
 
-  // Check registry
-  const token = TOKEN_REGISTRY[checksumAddress];
-  if (token) {
-    return token;
+/**
+ * Get token metadata by address (sync version for immediate use)
+ * Only checks cache and registry, doesn't fetch from blockchain
+ *
+ * On a miss for a valid address this returns a *placeholder* (truncated
+ * address as the symbol, "Loading..." as the name, 18 decimals) so display
+ * surfaces have something to render. Callers that must not render a fabricated
+ * label — anything on a signing path — should use
+ * {@link getRegisteredTokenByAddress} and hard-block on null instead.
+ *
+ * @param address - Token contract address
+ * @returns Token metadata, a placeholder for unknown valid addresses, or null
+ */
+export function getTokenByAddress(address: string): TokenMetadata | null {
+  const registered = getRegisteredTokenByAddress(address);
+  if (registered) {
+    return registered;
+  }
+  if (!isAddress(address)) {
+    return null;
   }
 
   // Return a temporary placeholder
+  const checksumAddress = getAddress(address);
   const truncatedAddress = `${checksumAddress.slice(0, 6)}...${checksumAddress.slice(-4)}`;
   return {
     address: checksumAddress as Address,


### PR DESCRIPTION
Closes [babylonlabs-io/baby-auditor#40](https://github.com/babylonlabs-io/baby-auditor/issues/40) (audit finding F7).

> **Rebased onto `main` after [#2148](https://github.com/babylonlabs-io/babylon-toolkit/pull/2148).** That PR renamed and restructured most of the files this one touches, so the conflicts were resolved by taking `main` and re-applying F7 on top — never the reverse. It also added a new symbol-keyed `/markets/:symbol` route, which is now folded into this change. See "What changed since the first review" at the bottom.

## The problem

The borrow/repay screen figured out *which asset it was about* by asking the GraphQL indexer. Two things flowed from that.

**1. The URL identified the reserve by its token symbol.** Clicking USDC in the picker navigated to `?reserve=usdc`, and the screen then looked for the reserve whose indexer-reported symbol was `"usdc"`. The indexer decides what that string maps to. If it serves two reserves both claiming `USDC`, the code took whichever one the indexer happened to list first — so the indexer could steer you to a different, genuine reserve than the row you clicked.

**2. The label and every number on the screen came from the indexer too** — symbol, name, and decimals, copied straight out of GraphQL. So a compromised indexer could keep a real reserve but label it as a safer token, and the page would show that label right up to the moment you signed.

The second point turned out to matter more than the audit write-up said. The repay form computed the displayed debt, your wallet balance and the **Max** button using the indexer's decimals, while the actual transaction used decimals read from the token contract. If the indexer reported 18 for a token that really has 6, "Max" would render a trillion times too small. You click Max, sign, repay dust — and the success screen tells you the position is cleared while it is still fully liquidatable.

Separately, the repay form read your wallet balance at `token.address` while the transaction guard proved `reserve.underlying`. Those are two independent indexer fields with nothing forcing them to be equal, so the balance could be read from a token you don't actually owe.

## What this PR does

The screen now proves what the reserve is before it renders anything.

Only three things are trusted after this change: the numeric reserve id in the URL, the `underlying` token address read from the chain via the env-pinned adapter, and our own address-keyed token registry. The indexer's `token.symbol`, `token.name` and `token.decimals` are no longer read anywhere on these screens.

**Routing and resolution by reserve id.** The URL is now `?reserve=5` — the reserve's on-chain id, which the indexer cannot reinterpret. Every place that navigates already had the id in hand and was throwing it away; they now pass it. Resolution takes the single matching reserve or nothing at all, so a duplicate can never be silently picked.

**A new verification step.** `verifyReserveIdentity` asserts that the reserve id maps to the expected token on-chain (reusing the existing `assertReserveMatchesOnChain` from the F8/F9 fixes), reads decimals from the token contract, and gets the symbol and name from our address-keyed registry — falling back to the token contract's own `symbol()`/`name()` for testnet addresses we don't know. If nothing trustworthy can name the token, it refuses rather than falling back to the indexer's string.

Decimals always come from the chain, even when the registry has its own copy. The registry is a hand-maintained table; the chain is what the signed transaction parses against, and the two must not disagree.

**Proven values flow to the forms.** `LoanContext` now carries a `tokenIdentity` object, so Borrow, Repay and the success step read proven symbol, name, address and decimals instead of the indexer's. An ESLint rule blocks `selectedReserve.token.*` in those components so this can't quietly regress in a later feature.

**Failing closed, with the right message.** If verification *completes and fails*, the screen blocks with a deliberately alarming message and **no Retry button** — the result is deterministic, and a Retry button would just train people to click through a security warning. If verification *can't complete* (network or RPC problem), the message is neutral and Retry is offered. Those are genuinely different events and shouldn't look the same.

The order of the render branches matters and is commented as such: the identity block sits above the loading spinner, because `isLoading` combines four sources and a still-pending price query would otherwise hide a resolved integrity failure behind a spinner.

**Copy cleanup.** The strings this adds live in `COPY.loans.detail`; the pre-existing inline strings in `Detail/` were migrated as part of the change, which was overdue per the copy rule.

## Approaches considered

**On the URL format:**

- *Keep the symbol, add the id alongside* (`?reserve=usdc&rid=5`). Readable URLs, but it keeps two parameters in sync and leaves a symbol somewhere in the path.
- *Numeric id, but accept old symbol links when exactly one reserve matches.* Old bookmarks keep working. But it keeps a symbol-keyed lookup alive, which is the thing being removed.
- **Chosen: numeric id, old symbol links blocked** with a "this link is outdated, please select the asset again" message. It's the only option where no symbol lookup survives anywhere in the resolution path. The cost is small: these are deep links into a modal, not pages people bookmark, and all in-app navigation regenerates from the route builder.

**On how far the trusted-metadata part should reach:**

- *Label only.* Verify the reserve and fix the page title, but leave the forms computing debt, balance and Max from indexer decimals. This is the literal reading of the maintainer's comment on the issue, and it's the smallest diff — but it leaves the wrong-Max-on-repay problem open, on the same screen, one click before a signature.
- *Everything, including the picker and dashboard rows.* Closest to the auditor's recommendation, but gating a list behind one RPC per row would be a real performance regression, and unknown testnet tokens would drop out of the list entirely.
- **Chosen: every surface that names a specific reserve** — the borrow/repay overlay and the borrowing markets data page. Label and every number come from proven sources. This matches the maintainer's "one on-chain read at the consequence point, not storage-layer metadata validation", while treating the numbers as part of the consequence rather than just the title.

**On failing closed vs. failing open for repay.** Blocking a repay is uncomfortable — someone near liquidation needs that button. But the repay path *already* makes these same two on-chain calls before signing, so an RPC outage blocks repay today too, just thirty seconds later after you've read a number and typed an amount. And failing open is strictly worse here: wrong decimals produce a wrong Max, you repay dust, and the success screen tells you a still-liquidatable position is cleared. Failing closed with a fast Retry keeps you engaged; a silently underpaid repay does not.

## Deliberately not in this PR

- **The asset picker and dashboard loan rows still show indexer labels.** Under an active spoof the list could say "USDC" while the detail screen blocks or says "WETH". That contradiction is intended — the detail screen is the last surface before a signature and is where the truth has to win. The follow-up is to move those surfaces onto the address-keyed registry and show "Unknown asset" for addresses we don't know.
- **No prefetching of the identity from the Loans list.** The spoke address is already cached per adapter and the result is cached for the session, so the cost is roughly two RPC calls the first time you open a reserve. If that proves noticeable, prefetching against the same cache key is the fix.
- **`fetchConfig` still doesn't cross-check that `reserve.underlying` equals `underlyingToken.address`.** Not needed now that the screens prove `reserve.underlying` directly, but worth a follow-up issue.

## Files worth reviewing closely

- `services/vault/src/applications/aave/services/verifyReserveIdentity.ts` — the new proof; note that on-chain decimals win over the registry's copy even on a registry hit.
- `services/vault/src/clients/eth-contract/erc20/query.ts` — `getERC20Symbol`/`getERC20Name` return null only for a contract-level failure and rethrow transport errors (see the review fix below).
- `services/vault/src/applications/aave/hooks/useVerifiedReserveIdentity.ts` — caching and retry policy; note it deliberately does *not* use `keepPreviousData`, unlike the price hook, because carrying the previous reserve's decimals across an asset switch is the exact bug being fixed.
- `services/vault/src/applications/aave/components/Detail/ReserveDetailPanel.tsx` — branch order, and the single `verified` narrowing that the success step shares so it can't report a label the form refused.
- `services/vault/src/applications/aave/components/LoanCard/Repay/index.tsx` — the balance read moving to the proven address.

## What changed since the first review

**1. `jrwbabylonlab`'s P1 on the symbol/name fallback.** `.catch(() => null)` treated an RPC failure identically to a token with no `symbol()`. A null symbol throws `UnknownReserveTokenError`, which `isIntegrityFailure` classifies as a conclusion — so the query didn't retry and the screen rendered integrity copy with no retry affordance. One transient blip became a permanent spoof warning until reload.

The handling moved into the readers, where the ABI knowledge already is: `getERC20Symbol`/`getERC20Name` return null only when the failure is the contract's own answer (viem's `ContractFunctionZeroDataError` for an absent method, or a revert), and rethrow anything else. `symbol()` and `name()` are optional in ERC-20, so an absent method is a legitimate null; a dropped connection is not, and now propagates as an ordinary error that retries and offers Retry. `verifyReserveIdentity` drops both catches and the comment that justified them.

**2. `jrwbabylonlab`'s note on `routes.ts` conflicting with #2148.** Confirmed and handled: every conflict was resolved by taking `main` and re-applying F7, so none of the symbol routing came back. `useDashboardState.selectableBorrowedAssets` was deleted by #2148 and stays deleted; the picker's repay rows now carry their own reserve id, which also let the symbol-keyed `priceBySymbol` workaround go away.

**3. Market Info folded in.** #2148 added a per-row Market Info button routing to `/markets/:symbol`, resolved by `borrowableReserves.find(r => r.token.symbol === ...)` — the same pattern F7 removes. It now routes by reserve id, resolves to exactly one reserve or none, and renders its header only from the verified identity. `ReserveIdentityBlock` moved up to the shared components directory since two surfaces use it.

## Testing

- New: `verifyReserveIdentity.test.ts`, `useVerifiedReserveIdentity.test.tsx`, `routes.test.ts`, `AssetPill.test.tsx`, `ReserveDetailPanel.test.tsx`, `BorrowingMarketsData.test.tsx`.
- Extended: `useAaveReserveDetail.test.tsx` covers duplicate symbols, duplicate ids, a spoofed symbol, wrong indexer decimals, garbage and legacy URL params, and the integrity hard-block. `query.test.ts` covers the sanitizing of hostile `symbol()` values plus the missing-method vs transport-failure split.
- Updated for the id-based route: `router.test.tsx`, `AssetSelectionPanel.test.tsx`, `LoanFlowOverlay.test.tsx`.
- Full vault suite: 2834 passing across 263 files. Typecheck and lint clean.

Manual checks:

1. Loans → Borrow → pick an asset. The URL should read `?reserve=<number>`, and the label, debt and Max should match the real token. The picker, form and success screen stay in one dialog (#2148's fix must survive).
2. Market Info on a picker row → `/markets/<number>`, header labelled from the verified identity; Back to assets returns to the picker.
3. Change the URL to `?reserve=usdc` → outdated-link message, no numbers rendered. `?reserve=99999`, `?reserve=abc`, `?reserve=0x5`, `/markets/usdc` → blocked, no crash.
4. Switch assets with the pill — no flash of the previous asset's symbol or decimals, and the open asset's row is the one marked.
5. Repay with exactly one loan → still skips the picker and opens the repay form directly.
6. Go offline in devtools and open a reserve → neutral "Couldn't verify this asset" **with** a working Retry (not the alarming no-Retry copy); restore the network and it recovers on reconnect.
7. God-mode demo loan rows still render with both actions disabled and never navigate.

To see the compromised state (the alarming, retry-less block), temporarily throw from `verifyReserveIdentity` — there is no way to trigger it from the UI, which is the point.
