### PR TITLE
fix(vault): don't label RPC/node errors

### DIFF
--- a/services/vault/src/components/simple/__tests__/PostDepositContinuationView.test.tsx
+++ b/services/vault/src/components/simple/__tests__/PostDepositContinuationView.test.tsx
@@ -194,6 +194,8 @@ vi.mock("@/copy", () => ({
         chainSwitchFailed: "Could not switch network.",
         receiptTimeout: "Confirmation timed out.",
         network: "Network error.",
+        rpcError: "Please wait a moment and try again.",
+        alreadySubmitted: "Already submitted.",
         staleDeploy: "Reload the page.",
       },
     },

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -847,6 +847,8 @@ export const COPY = {
       network: "Network error. Check your connection and try again.",
       rpcError:
         "We couldn't complete your request right now. Please wait a moment and try again.",
+      alreadySubmitted:
+        "This transaction was already submitted. Check your wallet or a block explorer for its status.",
       staleDeploy:
         "This page is out of date — a newer version of the app was deployed. Refresh the page and try again.",
     },

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -845,6 +845,8 @@ export const COPY = {
       receiptTimeout:
         "We couldn't confirm your transaction. Check your wallet or a block explorer for the latest status.",
       network: "Network error. Check your connection and try again.",
+      rpcError:
+        "We couldn't complete your request right now. Please wait a moment and try again.",
       staleDeploy:
         "This page is out of date — a newer version of the app was deployed. Refresh the page and try again.",
     },

--- a/services/vault/src/utils/errors/__tests__/formatting.test.ts
+++ b/services/vault/src/utils/errors/__tests__/formatting.test.ts
@@ -11,6 +11,7 @@ import { resolve } from "path";
 import {
   HttpRequestError,
   InsufficientFundsError,
+  RpcRequestError,
   UserRejectedRequestError,
 } from "viem";
 import { describe, expect, it } from "vitest";
@@ -278,7 +279,30 @@ describe("Error Formatting", () => {
         cause: revertWrap,
         walk: () => {},
       });
-      expect(sanitizeErrorMessage(outer)).not.toMatch(/Network error/i);
+      // Pin the fall-through: the `0x` guard sends the walker to
+      // `revertRpc.cause` (undefined) → classifyError returns null →
+      // sanitizeErrorMessage surfaces the outer message. Asserting the exact
+      // string keeps the guard protected (the `rpcError` copy also lacks
+      // "Network error", so a looser matcher would pass without it).
+      expect(sanitizeErrorMessage(outer)).toBe("execution reverted");
+    });
+
+    it("falls through a data-less revert (code 3, no 0x data) to the real reason", () => {
+      // Some providers return a revert with no data. `code === 3` still marks
+      // it a revert, so it must surface the reason — not "wait and retry".
+      const revertRpc = Object.assign(new Error("RPC Request failed."), {
+        name: "RpcRequestError",
+        code: 3,
+        walk: () => {},
+      });
+      const outer = Object.assign(new Error("execution reverted: SomeReason"), {
+        name: "ContractFunctionExecutionError",
+        cause: revertRpc,
+        walk: () => {},
+      });
+      const msg = sanitizeErrorMessage(outer);
+      expect(msg).not.toMatch(/wait a moment and try again/i);
+      expect(msg).toBe("execution reverted: SomeReason");
     });
 
     it("classifies RpcRequestError without revert data as an rpc-error, not the user's connection", () => {
@@ -295,12 +319,27 @@ describe("Error Formatting", () => {
       expect(msg).toMatch(/wait a moment and try again/i);
     });
 
-    it("collapses HttpRequestError (RPC transport failure)", () => {
+    it("collapses a status-less HttpRequestError (fetch threw) as network", () => {
+      // No `status` = the request never got a response = a real transport
+      // failure, so "check your connection" is honest.
       const err = Object.assign(
         new Error("HTTP request failed.\nURL: https://eth-rpc.example/key"),
         { name: "HttpRequestError" },
       );
       expect(sanitizeErrorMessage(err)).toMatch(/Network error/i);
+    });
+
+    it("routes an HttpRequestError WITH a status (429/5xx) to rpc-error, not the connection", () => {
+      // viem sets `status` when the server answered (rate limit / outage) —
+      // a provider problem, so it must NOT tell the user to check their
+      // connection. This is the most likely RPC failure over `http()`.
+      const err = Object.assign(new Error("HTTP request failed."), {
+        name: "HttpRequestError",
+        status: 429,
+      });
+      const msg = sanitizeErrorMessage(err);
+      expect(msg).not.toMatch(/check your connection/i);
+      expect(msg).toMatch(/wait a moment and try again/i);
     });
 
     it("collapses TimeoutError (request timed out) — viem shape", () => {
@@ -335,11 +374,12 @@ describe("Error Formatting", () => {
       expect(sanitizeErrorMessage(err)).toMatch(/Network error/i);
     });
 
-    it("does NOT tell the user to check their connection for a nonce error wrapped in RpcRequestError", () => {
-      // Regression: viem's chain for "already known" / nonce errors is
+    it("classifies a nonce-too-low / already-known chain as already-submitted, not a retry", () => {
+      // viem's chain for "already known" / nonce errors is
       // TransactionExecutionError -> NonceTooLowError -> RpcRequestError. The
-      // inner RpcRequestError carries no `0x` revert data, so before the
-      // transport/RPC split the walker labeled it "Check your connection".
+      // NonceTooLowError frame (above the RpcRequestError frame) means the tx
+      // is already in the mempool, so the copy must send the user to their
+      // wallet / an explorer rather than invite a retry.
       const inner = Object.assign(new Error("already known"), {
         name: "RpcRequestError",
         code: -32000,
@@ -357,11 +397,18 @@ describe("Error Formatting", () => {
       });
       const msg = sanitizeErrorMessage(outer);
       expect(msg).not.toMatch(/check your connection/i);
-      expect(msg).toMatch(/wait a moment and try again/i);
+      expect(msg).not.toMatch(/wait a moment and try again/i);
+      expect(msg).toMatch(/already submitted/i);
+    });
+
+    it("classifies a raw 'already known' provider message as already-submitted", () => {
+      // No viem class wrapping — just the geth mempool string.
+      const msg = sanitizeErrorMessage(new Error("already known"));
+      expect(msg).toMatch(/already submitted/i);
     });
 
     // The rest of the suite builds synthetic errors via Object.assign so we
-    // can construct arbitrary cause chains. The three smoke tests below
+    // can construct arbitrary cause chains. The four smoke tests below
     // instead use real viem class constructors — if viem renames a class
     // in a future version (e.g. `InsufficientFundsError` →
     // `InsufficientFundsRpcError`), CI fails here loudly rather than
@@ -384,6 +431,18 @@ describe("Error Formatting", () => {
         url: "https://rpc.example/",
       });
       expect(sanitizeErrorMessage(err)).toMatch(/Network error/);
+    });
+
+    it("matches a real viem RpcRequestError instance (node/provider error)", () => {
+      // A JSON-RPC error the node returned. `walk` comes from BaseError so
+      // `isViemShape` passes; `data` is undefined and code is not 3, so it
+      // lands in `rpc-error` — not "check your connection".
+      const err = new RpcRequestError({
+        body: { method: "eth_call" },
+        error: { code: -32603, message: "internal error" },
+        url: "https://rpc.example/",
+      });
+      expect(sanitizeErrorMessage(err)).toMatch(/wait a moment and try again/i);
     });
 
     it("collapses Vite chunk 404 (Chrome/Edge wording) wrapped in viem error", () => {

--- a/services/vault/src/utils/errors/__tests__/formatting.test.ts
+++ b/services/vault/src/utils/errors/__tests__/formatting.test.ts
@@ -281,15 +281,18 @@ describe("Error Formatting", () => {
       expect(sanitizeErrorMessage(outer)).not.toMatch(/Network error/i);
     });
 
-    it("still classifies RpcRequestError without revert data as network", () => {
-      // Pure transport failure — no `.data`, no revert. Should hit the
-      // network bucket.
+    it("classifies RpcRequestError without revert data as an rpc-error, not the user's connection", () => {
+      // A JSON-RPC error the node returned (here -32603 InternalRpcError).
+      // It's a provider/node failure, not transport, so it must NOT tell the
+      // user to check their connection.
       const err = Object.assign(new Error("RPC Request failed."), {
         name: "RpcRequestError",
         code: -32603,
         walk: () => {},
       });
-      expect(sanitizeErrorMessage(err)).toMatch(/Network error/i);
+      const msg = sanitizeErrorMessage(err);
+      expect(msg).not.toMatch(/check your connection/i);
+      expect(msg).toMatch(/wait a moment and try again/i);
     });
 
     it("collapses HttpRequestError (RPC transport failure)", () => {
@@ -323,6 +326,38 @@ describe("Error Formatting", () => {
         name: "WebSocketRequestError",
       });
       expect(sanitizeErrorMessage(err)).toMatch(/Network error/i);
+    });
+
+    it("classifies SocketClosedError as network (transport failure)", () => {
+      const err = Object.assign(new Error("The socket has been closed."), {
+        name: "SocketClosedError",
+      });
+      expect(sanitizeErrorMessage(err)).toMatch(/Network error/i);
+    });
+
+    it("does NOT tell the user to check their connection for a nonce error wrapped in RpcRequestError", () => {
+      // Regression: viem's chain for "already known" / nonce errors is
+      // TransactionExecutionError -> NonceTooLowError -> RpcRequestError. The
+      // inner RpcRequestError carries no `0x` revert data, so before the
+      // transport/RPC split the walker labeled it "Check your connection".
+      const inner = Object.assign(new Error("already known"), {
+        name: "RpcRequestError",
+        code: -32000,
+        walk: () => {},
+      });
+      const nonce = Object.assign(new Error("nonce too low"), {
+        name: "NonceTooLowError",
+        cause: inner,
+        walk: () => {},
+      });
+      const outer = Object.assign(new Error("nonce too low"), {
+        name: "TransactionExecutionError",
+        cause: nonce,
+        walk: () => {},
+      });
+      const msg = sanitizeErrorMessage(outer);
+      expect(msg).not.toMatch(/check your connection/i);
+      expect(msg).toMatch(/wait a moment and try again/i);
     });
 
     // The rest of the suite builds synthetic errors via Object.assign so we

--- a/services/vault/src/utils/errors/formatting.ts
+++ b/services/vault/src/utils/errors/formatting.ts
@@ -84,7 +84,8 @@ type ErrorKind =
   | "unauthorized" // EIP-1193 4100 / UnauthorizedProviderError
   | "chain-switch-failed" // EIP-1193 4902 / viem SwitchChainError
   | "receipt-timeout" // viem WaitForTransactionReceiptTimeoutError
-  | "network" // HttpRequestError / WebSocketRequestError / TimeoutError / RpcRequestError
+  | "network" // transport failure: HttpRequestError / WebSocketRequestError / SocketClosedError / viem TimeoutError
+  | "rpc-error" // node/provider JSON-RPC failure via RpcRequestError (rate limit, resource unavailable, tx rejected, internal, nonce) — not the user's connection
   | "stale-deploy"; // Vite dynamic-import 404 after redeploy
 
 const FRIENDLY_MESSAGES: Record<ErrorKind, string> = {
@@ -95,6 +96,7 @@ const FRIENDLY_MESSAGES: Record<ErrorKind, string> = {
   "chain-switch-failed": COPY.common.classifiedErrors.chainSwitchFailed,
   "receipt-timeout": COPY.common.classifiedErrors.receiptTimeout,
   network: COPY.common.classifiedErrors.network,
+  "rpc-error": COPY.common.classifiedErrors.rpcError,
   "stale-deploy": COPY.common.classifiedErrors.staleDeploy,
 };
 
@@ -174,33 +176,40 @@ export function classifyError(err: unknown): ErrorKind | null {
       return "receipt-timeout";
     }
 
-    // RPC / network transport failures.
-    //
-    // `RpcRequestError` is a special case: viem also uses it to wrap
-    // node-level errors that carry contract-revert data (the node returns
-    // `{ code: 3, data: "0x..." }`, viem forwards it on the wrapper's
-    // `.data` field). Those aren't transport failures and should fall
-    // through so the underlying revert message bubbles up.
-    if (obj.name === "RpcRequestError" && isViemShape(obj)) {
-      const data = (obj as { data?: unknown }).data;
-      if (typeof data === "string" && data.startsWith("0x")) {
-        // Contract revert dressed as RPC error — don't classify as network.
-        cur = obj.cause;
-        continue;
-      }
-      return "network";
-    }
-    // `HttpRequestError` / `WebSocketRequestError` names are viem-specific
-    // enough not to collide; `TimeoutError` is generic (AbortSignal.timeout,
-    // `ky`, DOM APIs) and must be gated on viem shape.
+    // Transport failures — the request never got a usable response. These
+    // are the only errors where "check your connection" is honest.
+    // `HttpRequestError` / `WebSocketRequestError` / `SocketClosedError`
+    // names are viem-specific enough not to collide; `TimeoutError` is
+    // generic (AbortSignal.timeout, `ky`, DOM APIs) and must be gated on
+    // viem shape.
     if (
       obj.name === "HttpRequestError" ||
-      obj.name === "WebSocketRequestError"
+      obj.name === "WebSocketRequestError" ||
+      obj.name === "SocketClosedError"
     ) {
       return "network";
     }
     if (obj.name === "TimeoutError" && isViemShape(obj)) {
       return "network";
+    }
+
+    // `RpcRequestError` wraps a JSON-RPC error the node/provider returned:
+    // rate limit (-32005), resource unavailable (-32002), tx rejected
+    // (-32003), internal (-32603), and node-execution errors (nonce /
+    // "already known") whose inner frame is an RpcRequestError. None of
+    // these are the user's connection, so they get their own copy — never
+    // "check your connection".
+    //
+    // Exception: viem also reuses `RpcRequestError` to carry contract-revert
+    // data (`{ code: 3, data: "0x..." }`). That's a real revert, not an RPC
+    // failure — fall through so the underlying reason bubbles up.
+    if (obj.name === "RpcRequestError" && isViemShape(obj)) {
+      const data = (obj as { data?: unknown }).data;
+      if (typeof data === "string" && data.startsWith("0x")) {
+        cur = obj.cause;
+        continue;
+      }
+      return "rpc-error";
     }
 
     // Vite chunk 404 after a redeploy — the underlying error is a browser

--- a/services/vault/src/utils/errors/formatting.ts
+++ b/services/vault/src/utils/errors/formatting.ts
@@ -38,6 +38,15 @@ const EIP1193 = {
   CHAIN_SWITCH_FAILED: 4902,
 } as const;
 
+/** viem `ExecutionRevertedError.code` — a node revert even without `0x` data. */
+const EXECUTION_REVERTED_RPC_CODE = 3;
+
+// viem `NonceTooLowError.nodeMessage`: the tx is already in the mempool (or
+// mined), so a retry just re-sends and reproduces it. Raw providers surface
+// this unwrapped, so match the message as well as the viem class name.
+const ALREADY_SUBMITTED_PATTERN =
+  /nonce too low|transaction already imported|already known/i;
+
 // ETH-side insufficient-funds wording. Mirrors viem's own
 // `InsufficientFundsError.nodeMessage` regex; callers must first filter out
 // the BTC selector's "Insufficient funds: need N sats" via the sats/pegin
@@ -85,7 +94,8 @@ type ErrorKind =
   | "chain-switch-failed" // EIP-1193 4902 / viem SwitchChainError
   | "receipt-timeout" // viem WaitForTransactionReceiptTimeoutError
   | "network" // transport failure: HttpRequestError / WebSocketRequestError / SocketClosedError / viem TimeoutError
-  | "rpc-error" // node/provider JSON-RPC failure via RpcRequestError (rate limit, resource unavailable, tx rejected, internal, nonce) — not the user's connection
+  | "rpc-error" // node/provider JSON-RPC failure via RpcRequestError — not the user's connection
+  | "already-submitted" // nonce-too-low / "already known" — the tx is already in the mempool
   | "stale-deploy"; // Vite dynamic-import 404 after redeploy
 
 const FRIENDLY_MESSAGES: Record<ErrorKind, string> = {
@@ -97,6 +107,7 @@ const FRIENDLY_MESSAGES: Record<ErrorKind, string> = {
   "receipt-timeout": COPY.common.classifiedErrors.receiptTimeout,
   network: COPY.common.classifiedErrors.network,
   "rpc-error": COPY.common.classifiedErrors.rpcError,
+  "already-submitted": COPY.common.classifiedErrors.alreadySubmitted,
   "stale-deploy": COPY.common.classifiedErrors.staleDeploy,
 };
 
@@ -176,19 +187,44 @@ export function classifyError(err: unknown): ErrorKind | null {
       return "receipt-timeout";
     }
 
-    // Transport failures — the request never got a usable response. These
-    // are the only errors where "check your connection" is honest.
-    // `HttpRequestError` / `WebSocketRequestError` / `SocketClosedError`
-    // names are viem-specific enough not to collide; `TimeoutError` is
-    // generic (AbortSignal.timeout, `ky`, DOM APIs) and must be gated on
-    // viem shape.
+    // Nonce-too-low / "already known" — the tx is already in the mempool (or
+    // mined). "Retry" would re-send and reproduce it, so point the user at
+    // their wallet / an explorer. viem folds these into NonceTooLowError; raw
+    // providers surface the message unwrapped. (NonceTooHigh is a gap, not a
+    // duplicate, so it stays in the generic rpc-error retry bucket.)
     if (
-      obj.name === "HttpRequestError" ||
+      obj.name === "NonceTooLowError" ||
+      (typeof obj.message === "string" &&
+        ALREADY_SUBMITTED_PATTERN.test(obj.message))
+    ) {
+      return "already-submitted";
+    }
+
+    // Transport failures — "check your connection" is only honest here.
+    //
+    // `HttpRequestError` covers TWO cases (viem `utils/rpc/http`): with a
+    // numeric `status` the server DID answer (429 rate limit, 5xx outage) —
+    // a provider problem, not the user's connection — so route those to
+    // `rpc-error`. A status-less HttpRequestError (fetch threw) is a real
+    // transport failure. Since the app wires `http()` exclusively, a
+    // provider 429/503 is the most likely RPC failure a depositor hits.
+    if (obj.name === "HttpRequestError") {
+      return typeof (obj as { status?: unknown }).status === "number"
+        ? "rpc-error"
+        : "network";
+    }
+    // `WebSocketRequestError` / `SocketClosedError` are genuine transport
+    // failures; the names are viem-specific enough not to collide.
+    // `SocketClosedError` is forward-looking — the app wires `http()` today,
+    // so it only becomes reachable if a WS transport lands later.
+    if (
       obj.name === "WebSocketRequestError" ||
       obj.name === "SocketClosedError"
     ) {
       return "network";
     }
+    // `TimeoutError` is generic (AbortSignal.timeout, `ky`, DOM APIs) — gate
+    // on viem shape.
     if (obj.name === "TimeoutError" && isViemShape(obj)) {
       return "network";
     }
@@ -200,12 +236,16 @@ export function classifyError(err: unknown): ErrorKind | null {
     // these are the user's connection, so they get their own copy — never
     // "check your connection".
     //
-    // Exception: viem also reuses `RpcRequestError` to carry contract-revert
-    // data (`{ code: 3, data: "0x..." }`). That's a real revert, not an RPC
-    // failure — fall through so the underlying reason bubbles up.
+    // Exception: viem also reuses `RpcRequestError` to carry contract reverts.
+    // A `0x` payload is a revert; so is `code === 3` even when the provider
+    // returns no revert data (some don't). Either is a real revert, not an
+    // RPC failure — fall through so the underlying reason bubbles up.
     if (obj.name === "RpcRequestError" && isViemShape(obj)) {
       const data = (obj as { data?: unknown }).data;
-      if (typeof data === "string" && data.startsWith("0x")) {
+      if (
+        (typeof data === "string" && data.startsWith("0x")) ||
+        obj.code === EXECUTION_REVERTED_RPC_CODE
+      ) {
         cur = obj.cause;
         continue;
       }


### PR DESCRIPTION
## What
`classifyError` labeled every `RpcRequestError` without revert data as a
`network` error → *"Check your connection."* But viem wraps every JSON-RPC error
(rate limit, `-32603` internal, `-32002` already-pending, nonce/"already known")
in an inner `RpcRequestError`, so non-connection failures blamed the user's
connection.

## Fix
Split the classifier: `network` now covers only true transport failures
(`HttpRequestError`, `WebSocketRequestError`, `SocketClosedError`, viem
`TimeoutError`); a new `rpc-error` kind handles `RpcRequestError` → *"We couldn't
complete your request right now. Please wait a moment and try again."* Contract-revert
fall-through preserved.