### PR TITLE
fix(vault): validate, bind and durably save the recovery artifact bundle

### DIFF
--- a/services/vault/src/components/deposit/ArtifactDownloadModal/__tests__/ArtifactDownloadModal.test.tsx
+++ b/services/vault/src/components/deposit/ArtifactDownloadModal/__tests__/ArtifactDownloadModal.test.tsx
@@ -2,7 +2,11 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { forwardRef, useImperativeHandle, type ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { markArtifactsDownloaded } from "@/utils/artifactDownloadStorage";
+import {
+  ARTIFACT_RECEIPT_VERSION,
+  normalizePeginTxid,
+  saveArtifactDownloadReceipt,
+} from "@/utils/artifactDownloadStorage";
 
 import { ArtifactDownloadModal } from "..";
 
@@ -58,6 +62,19 @@ const COMMON_PROPS = {
   peginTxid: "0xpegin",
   depositorPk: "0xpk",
 } as const;
+
+/** A receipt bound to COMMON_PROPS.peginTxid, as a real download writes. */
+function seedReceipt(peginTxid: string = COMMON_PROPS.peginTxid) {
+  saveArtifactDownloadReceipt(VAULT_ID, {
+    version: ARTIFACT_RECEIPT_VERSION,
+    peginTxid: normalizePeginTxid(peginTxid),
+    filename: "babylon-vault-artifacts-pegin.json",
+    byteLength: 1024,
+    sha256: "9".repeat(64),
+    savedAt: 1_700_000_000_000,
+    method: "file-system-access",
+  });
+}
 
 describe("ArtifactDownloadModal", () => {
   beforeEach(() => {
@@ -122,7 +139,7 @@ describe("ArtifactDownloadModal", () => {
   });
 
   it("shows Cancel and Done in the downloaded state, with Done firing onComplete", () => {
-    markArtifactsDownloaded(VAULT_ID);
+    seedReceipt();
     const onClose = vi.fn();
     const onComplete = vi.fn();
     render(
@@ -139,5 +156,22 @@ describe("ArtifactDownloadModal", () => {
 
     fireEvent.click(screen.getByText("Cancel"));
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not show the downloaded state when the receipt is for a different pegin", () => {
+    // A stale receipt, or one belonging to another vault's deposit, is not
+    // evidence that this deposit's recovery bundle is on disk.
+    seedReceipt("0xsomeotherpegin");
+    render(
+      <ArtifactDownloadModal
+        open
+        {...COMMON_PROPS}
+        onClose={vi.fn()}
+        onComplete={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText("Artifacts downloaded")).toBeNull();
+    expect(screen.queryByText("Done")).toBeNull();
   });
 });

--- a/services/vault/src/components/deposit/ArtifactDownloadModal/index.tsx
+++ b/services/vault/src/components/deposit/ArtifactDownloadModal/index.tsx
@@ -135,6 +135,12 @@ export function ArtifactDownloadModal({
           vaultId={vaultId}
           unsignedPrePeginTxHex={unsignedPrePeginTxHex}
           onDownloaded={() => setDownloaded(true)}
+          // This dialog is informational — it gates nothing, and the card
+          // itself explains that an unverifiable save leaves the warning in
+          // place. Without this the user would be stuck with no way to close
+          // it after a fallback download. The activation modal deliberately
+          // does not do this: there the acknowledgement must stay required.
+          onDelivered={() => setDownloaded(true)}
           onLoadingChange={setIsDownloading}
         />
       </DialogBody>

--- a/services/vault/src/components/deposit/ArtifactDownloadModal/index.tsx
+++ b/services/vault/src/components/deposit/ArtifactDownloadModal/index.tsx
@@ -53,7 +53,7 @@ export function ArtifactDownloadModal({
   // its green "Downloaded" state via the same check). Re-seeded whenever the
   // modal opens against a different vault.
   const [downloaded, setDownloaded] = useState(() =>
-    hasArtifactsDownloaded(vaultId),
+    hasArtifactsDownloaded(vaultId, peginTxid),
   );
   // Mirrors RecoveryArtifactsCard's internal `loading` flag via onLoadingChange
   // so the whole modal (title, body, footer button) reads as a single
@@ -62,10 +62,10 @@ export function ArtifactDownloadModal({
 
   useEffect(() => {
     if (open) {
-      setDownloaded(hasArtifactsDownloaded(vaultId));
+      setDownloaded(hasArtifactsDownloaded(vaultId, peginTxid));
       setIsDownloading(false);
     }
-  }, [open, vaultId]);
+  }, [open, vaultId, peginTxid]);
 
   const cardRef = useRef<RecoveryArtifactsCardHandle>(null);
 

--- a/services/vault/src/components/deposit/RecoveryArtifactsCard.tsx
+++ b/services/vault/src/components/deposit/RecoveryArtifactsCard.tsx
@@ -89,8 +89,20 @@ interface RecoveryArtifactsCardProps {
    * a page reload) by deriving a fresh auth anchor.
    */
   unsignedPrePeginTxHex?: string;
-  /** Fired the first time the artifact download completes within this card. */
+  /**
+   * Fired the first time a download within this card completes with proof:
+   * a validated bundle written to a file the user chose, and receipted. This
+   * is what satisfies the activation gate, so the unverifiable anchor
+   * fallback deliberately does NOT fire it — see `onDelivered`.
+   */
   onDownloaded?: () => void;
+  /**
+   * Fired the first time a download finishes without proof — the anchor
+   * fallback, where the browser reports nothing about whether the file was
+   * saved. Parents may use it to offer a way out of an informational dialog,
+   * but it must never stand in for `onDownloaded` on an activation gate.
+   */
+  onDelivered?: () => void;
   /**
    * Fired whenever the in-card download flag flips. Lets a parent modal
    * swap its own title/body/footer copy in lockstep with the card so the
@@ -119,6 +131,7 @@ export const RecoveryArtifactsCard = forwardRef<
     vaultId,
     unsignedPrePeginTxHex,
     onDownloaded,
+    onDelivered,
     onLoadingChange,
   },
   ref,
@@ -138,6 +151,7 @@ export const RecoveryArtifactsCard = forwardRef<
     progress,
     error,
     downloaded,
+    delivered,
     receivedBytes,
     totalBytes,
     download,
@@ -151,6 +165,12 @@ export const RecoveryArtifactsCard = forwardRef<
   const persisted = hasArtifactsDownloaded(vaultId, peginTxid);
   const isDownloaded = downloaded || persisted;
 
+  // A finished-but-unprovable save (the anchor fallback). Deliberately not
+  // folded into `isDownloaded`: that flag drives the success presentation and,
+  // through onDownloaded, the activation gate. A receipt from an earlier
+  // Chromium download still wins, so this never downgrades a proven state.
+  const isUnverified = delivered && !isDownloaded;
+
   // Browsers without the File System Access API cannot stream to a chosen
   // file, so the user is warned before starting a multi-minute transfer.
   const usesFallbackSave = !isFileSystemAccessSupported();
@@ -162,6 +182,14 @@ export const RecoveryArtifactsCard = forwardRef<
       onDownloaded?.();
     }
   }, [downloaded, onDownloaded]);
+
+  const deliveredNotifiedRef = useRef(false);
+  useEffect(() => {
+    if (delivered && !deliveredNotifiedRef.current) {
+      deliveredNotifiedRef.current = true;
+      onDelivered?.();
+    }
+  }, [delivered, onDelivered]);
 
   useEffect(() => {
     onLoadingChange?.(loading);
@@ -243,6 +271,22 @@ export const RecoveryArtifactsCard = forwardRef<
         </div>
       </div>
 
+      {/* The save finished but this browser cannot confirm it reached disk, so
+          the card stops short of the green "downloaded" state: the warning
+          copy stays, the download stays available for a retry on a browser
+          that can prove it, and no proof is reported upward. */}
+      {isUnverified && (
+        <span
+          data-testid="artifact-unverified-notice"
+          className="text-sm leading-[1.43] tracking-[0.17px] text-accent-secondary"
+        >
+          <span className="text-accent-primary">
+            {COPY.deposit.recoveryArtifacts.unverifiedSaveTitle}
+          </span>{" "}
+          {COPY.deposit.recoveryArtifacts.unverifiedSaveNotice}
+        </span>
+      )}
+
       {!isDownloaded && (
         <div className="flex flex-col items-stretch">
           <button
@@ -254,7 +298,9 @@ export const RecoveryArtifactsCard = forwardRef<
             <span className="text-sm leading-[1.43] tracking-[0.17px]">
               {error
                 ? COPY.deposit.recoveryArtifacts.retryButton
-                : COPY.deposit.recoveryArtifacts.downloadButton}
+                : isUnverified
+                  ? COPY.deposit.recoveryArtifacts.downloadAgainButton
+                  : COPY.deposit.recoveryArtifacts.downloadButton}
             </span>
           </button>
           {!error && (
@@ -262,7 +308,8 @@ export const RecoveryArtifactsCard = forwardRef<
               {COPY.deposit.recoveryArtifacts.walletSignatureHint}
             </span>
           )}
-          {usesFallbackSave && (
+          {/* Already spelled out at length by the unverified notice above. */}
+          {usesFallbackSave && !isUnverified && (
             <span className="mt-2.5 text-center text-xs text-accent-secondary">
               {COPY.deposit.recoveryArtifacts.fallbackSaveHint}
             </span>

--- a/services/vault/src/components/deposit/RecoveryArtifactsCard.tsx
+++ b/services/vault/src/components/deposit/RecoveryArtifactsCard.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, Loader } from "@babylonlabs-io/core-ui";
+import { Loader } from "@babylonlabs-io/core-ui";
 import type { BitcoinWallet } from "@babylonlabs-io/ts-sdk/shared";
 import { useChainConnector } from "@babylonlabs-io/wallet-connector";
 import {
@@ -138,12 +138,10 @@ export const RecoveryArtifactsCard = forwardRef<
     progress,
     error,
     downloaded,
-    awaitingSaveConfirmation,
     receivedBytes,
     totalBytes,
     download,
     cancel,
-    confirmSaved,
   } = useArtifactDownload({ vaultId, primeContext });
 
   useImperativeHandle(ref, () => ({ cancel }), [cancel]);
@@ -245,21 +243,7 @@ export const RecoveryArtifactsCard = forwardRef<
         </div>
       </div>
 
-      {awaitingSaveConfirmation && (
-        <label className="flex w-full cursor-pointer items-start gap-3">
-          <Checkbox
-            checked={false}
-            onChange={confirmSaved}
-            variant="default"
-            showLabel={false}
-          />
-          <span className="text-sm leading-[1.43] tracking-[0.17px] text-accent-primary">
-            {COPY.deposit.recoveryArtifacts.saveConfirmation}
-          </span>
-        </label>
-      )}
-
-      {!isDownloaded && !awaitingSaveConfirmation && (
+      {!isDownloaded && (
         <div className="flex flex-col items-stretch">
           <button
             type="button"

--- a/services/vault/src/components/deposit/RecoveryArtifactsCard.tsx
+++ b/services/vault/src/components/deposit/RecoveryArtifactsCard.tsx
@@ -1,4 +1,4 @@
-import { Loader } from "@babylonlabs-io/core-ui";
+import { Checkbox, Loader } from "@babylonlabs-io/core-ui";
 import type { BitcoinWallet } from "@babylonlabs-io/ts-sdk/shared";
 import { useChainConnector } from "@babylonlabs-io/wallet-connector";
 import {
@@ -14,6 +14,7 @@ import type { Hex } from "viem";
 import { ProgressBar } from "@/components/simple/DepositProgressView/ProgressBar";
 import { COPY } from "@/copy";
 import { useArtifactDownload } from "@/hooks/deposit/useArtifactDownload";
+import { isFileSystemAccessSupported } from "@/services/artifacts";
 import { hasArtifactsDownloaded } from "@/utils/artifactDownloadStorage";
 
 // Decimal (SI) units, matching the design's "742 MB / 1.00 GB" presentation
@@ -137,16 +138,24 @@ export const RecoveryArtifactsCard = forwardRef<
     progress,
     error,
     downloaded,
+    awaitingSaveConfirmation,
     receivedBytes,
     totalBytes,
     download,
     cancel,
+    confirmSaved,
   } = useArtifactDownload({ vaultId, primeContext });
 
   useImperativeHandle(ref, () => ({ cancel }), [cancel]);
 
-  const persisted = hasArtifactsDownloaded(vaultId);
+  // Bound to this pegin: a receipt stored for a different pegin (a stale
+  // record, or another vault's) must not read as downloaded here.
+  const persisted = hasArtifactsDownloaded(vaultId, peginTxid);
   const isDownloaded = downloaded || persisted;
+
+  // Browsers without the File System Access API cannot stream to a chosen
+  // file, so the user is warned before starting a multi-minute transfer.
+  const usesFallbackSave = !isFileSystemAccessSupported();
 
   const notifiedRef = useRef(false);
   useEffect(() => {
@@ -236,7 +245,21 @@ export const RecoveryArtifactsCard = forwardRef<
         </div>
       </div>
 
-      {!isDownloaded && (
+      {awaitingSaveConfirmation && (
+        <label className="flex w-full cursor-pointer items-start gap-3">
+          <Checkbox
+            checked={false}
+            onChange={confirmSaved}
+            variant="default"
+            showLabel={false}
+          />
+          <span className="text-sm leading-[1.43] tracking-[0.17px] text-accent-primary">
+            {COPY.deposit.recoveryArtifacts.saveConfirmation}
+          </span>
+        </label>
+      )}
+
+      {!isDownloaded && !awaitingSaveConfirmation && (
         <div className="flex flex-col items-stretch">
           <button
             type="button"
@@ -253,6 +276,11 @@ export const RecoveryArtifactsCard = forwardRef<
           {!error && (
             <span className="mt-2.5 text-center text-xs text-accent-secondary">
               {COPY.deposit.recoveryArtifacts.walletSignatureHint}
+            </span>
+          )}
+          {usesFallbackSave && (
+            <span className="mt-2.5 text-center text-xs text-accent-secondary">
+              {COPY.deposit.recoveryArtifacts.fallbackSaveHint}
             </span>
           )}
         </div>

--- a/services/vault/src/components/deposit/__tests__/RecoveryArtifactsCard.test.tsx
+++ b/services/vault/src/components/deposit/__tests__/RecoveryArtifactsCard.test.tsx
@@ -8,6 +8,7 @@ const IDLE_HOOK_STATE = {
   progress: "",
   error: null as string | null,
   downloaded: false,
+  delivered: false,
   receivedBytes: 0,
   totalBytes: 0,
   download: vi.fn(),
@@ -93,5 +94,54 @@ describe("RecoveryArtifactsCard — byte-progress panel", () => {
       screen.getByText("Fetching artifacts from vault provider..."),
     ).toBeTruthy();
     expect(screen.queryByRole("progressbar")).toBeNull();
+  });
+});
+
+describe("RecoveryArtifactsCard — unverifiable save", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    hookState.current = { ...IDLE_HOOK_STATE };
+  });
+
+  it("does not report a download upward when the save could not be verified", () => {
+    // onDownloaded is what removes the activation modal's risk acknowledgement
+    // and enables Activate. The anchor fallback proves only that a link was
+    // clicked, so firing it there would unlock activation for a save the
+    // browser may have blocked or the user may have dismissed.
+    const onDownloaded = vi.fn();
+    const onDelivered = vi.fn();
+    hookState.current = { ...IDLE_HOOK_STATE, delivered: true };
+
+    render(
+      <RecoveryArtifactsCard
+        {...COMMON_PROPS}
+        onDownloaded={onDownloaded}
+        onDelivered={onDelivered}
+      />,
+    );
+
+    expect(onDownloaded).not.toHaveBeenCalled();
+    expect(onDelivered).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the download available and warns that the save is unconfirmed", () => {
+    hookState.current = { ...IDLE_HOOK_STATE, delivered: true };
+
+    render(<RecoveryArtifactsCard {...COMMON_PROPS} />);
+
+    expect(screen.getByTestId("artifact-unverified-notice")).toBeTruthy();
+    expect(screen.getByText("Download Again")).toBeTruthy();
+  });
+
+  it("reports a download upward once there is real evidence", () => {
+    const onDownloaded = vi.fn();
+    hookState.current = { ...IDLE_HOOK_STATE, downloaded: true };
+
+    render(
+      <RecoveryArtifactsCard {...COMMON_PROPS} onDownloaded={onDownloaded} />,
+    );
+
+    expect(onDownloaded).toHaveBeenCalledTimes(1);
+    expect(screen.queryByTestId("artifact-unverified-notice")).toBeNull();
   });
 });

--- a/services/vault/src/components/simple/ActivateConfirmationModal.tsx
+++ b/services/vault/src/components/simple/ActivateConfirmationModal.tsx
@@ -45,8 +45,13 @@ export function ActivateConfirmationModal({
   onClose,
   onConfirm,
 }: ActivateConfirmationModalProps) {
+  // Bound to the pegin, so a receipt stored for a different one does not
+  // satisfy the gate. When `peginTxid` is absent we cannot prove the stored
+  // receipt belongs to this deposit, so this reads as not-downloaded and the
+  // risk acknowledgement stays required — the same condition under which
+  // `canRenderCard` below is false, so the two states agree.
   const [downloaded, setDownloaded] = useState(() =>
-    hasArtifactsDownloaded(vaultId),
+    hasArtifactsDownloaded(vaultId, peginTxid ?? ""),
   );
   const [acknowledged, setAcknowledged] = useState(false);
   // Mirrors RecoveryArtifactsCard's internal `loading` flag via
@@ -56,10 +61,10 @@ export function ActivateConfirmationModal({
 
   useEffect(() => {
     if (!open) return;
-    setDownloaded(hasArtifactsDownloaded(vaultId));
+    setDownloaded(hasArtifactsDownloaded(vaultId, peginTxid ?? ""));
     setAcknowledged(false);
     setIsDownloading(false);
-  }, [open, vaultId]);
+  }, [open, vaultId, peginTxid]);
 
   const cardRef = useRef<RecoveryArtifactsCardHandle>(null);
 

--- a/services/vault/src/components/simple/__tests__/ActivateConfirmationModal.test.tsx
+++ b/services/vault/src/components/simple/__tests__/ActivateConfirmationModal.test.tsx
@@ -45,7 +45,11 @@ vi.mock("@babylonlabs-io/core-ui", () => ({
 vi.mock("@/components/deposit/RecoveryArtifactsCard", () => ({
   RecoveryArtifactsCard: forwardRef<
     { cancel: () => void },
-    { onDownloaded?: () => void; onLoadingChange?: (loading: boolean) => void }
+    {
+      onDownloaded?: () => void;
+      onDelivered?: () => void;
+      onLoadingChange?: (loading: boolean) => void;
+    }
   >((props, ref) => {
     useImperativeHandle(ref, () => ({ cancel: cardCancelSpy }));
     return (
@@ -56,6 +60,13 @@ vi.mock("@/components/deposit/RecoveryArtifactsCard", () => ({
           onClick={() => props.onDownloaded?.()}
         >
           download
+        </button>
+        <button
+          type="button"
+          data-testid="card-download-delivered"
+          onClick={() => props.onDelivered?.()}
+        >
+          delivered
         </button>
         <button
           type="button"
@@ -229,5 +240,41 @@ describe("ActivateConfirmationModal", () => {
 
     expect(screen.getByText("Activate vault")).not.toBeDisabled();
     expect(screen.queryByTestId("risk-checkbox")).not.toBeInTheDocument();
+  });
+
+  it("keeps the checkbox and Activate disabled when the card reports only a delivered download", () => {
+    // The anchor fallback (Firefox/Safari) cannot prove the file reached
+    // disk, so it must not stand in for the acknowledgement: a blocked or
+    // dismissed save would otherwise unlock activation with no evidence and
+    // no attestation, which is what the fallback hint promises it will not do.
+    render(
+      <ActivateConfirmationModal
+        open
+        {...COMMON_PROPS}
+        onClose={vi.fn()}
+        onConfirm={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("card-download-delivered"));
+
+    expect(screen.getByText("Activate vault")).toBeDisabled();
+    expect(screen.getByTestId("risk-checkbox")).toBeInTheDocument();
+  });
+
+  it("enables Activate vault after an unverified download only once the risk is acknowledged", () => {
+    render(
+      <ActivateConfirmationModal
+        open
+        {...COMMON_PROPS}
+        onClose={vi.fn()}
+        onConfirm={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("card-download-delivered"));
+    fireEvent.click(screen.getByTestId("risk-checkbox"));
+
+    expect(screen.getByText("Activate vault")).not.toBeDisabled();
   });
 });

--- a/services/vault/src/components/simple/__tests__/ActivateConfirmationModal.test.tsx
+++ b/services/vault/src/components/simple/__tests__/ActivateConfirmationModal.test.tsx
@@ -2,7 +2,11 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { forwardRef, useImperativeHandle, type ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { markArtifactsDownloaded } from "@/utils/artifactDownloadStorage";
+import {
+  ARTIFACT_RECEIPT_VERSION,
+  normalizePeginTxid,
+  saveArtifactDownloadReceipt,
+} from "@/utils/artifactDownloadStorage";
 
 import { ActivateConfirmationModal } from "../ActivateConfirmationModal";
 
@@ -72,6 +76,19 @@ const COMMON_PROPS = {
   peginTxid: "0xpegin",
   depositorPk: "0xpk",
 } as const;
+
+/** A receipt bound to COMMON_PROPS.peginTxid, as a real download writes. */
+function seedReceipt(peginTxid: string = COMMON_PROPS.peginTxid) {
+  saveArtifactDownloadReceipt(VAULT_ID, {
+    version: ARTIFACT_RECEIPT_VERSION,
+    peginTxid: normalizePeginTxid(peginTxid),
+    filename: "babylon-vault-artifacts-pegin.json",
+    byteLength: 1024,
+    sha256: "9".repeat(64),
+    savedAt: 1_700_000_000_000,
+    method: "file-system-access",
+  });
+}
 
 describe("ActivateConfirmationModal", () => {
   beforeEach(() => {
@@ -163,7 +180,7 @@ describe("ActivateConfirmationModal", () => {
   });
 
   it("enables Activate vault, hides the checkbox, and shows the downloaded heading when artifacts were already downloaded", () => {
-    markArtifactsDownloaded(VAULT_ID);
+    seedReceipt();
     render(
       <ActivateConfirmationModal
         open
@@ -176,6 +193,23 @@ describe("ActivateConfirmationModal", () => {
     expect(screen.getByText("Artifacts downloaded")).toBeInTheDocument();
     expect(screen.getByText("Activate vault")).not.toBeDisabled();
     expect(screen.queryByTestId("risk-checkbox")).not.toBeInTheDocument();
+  });
+
+  it("still requires the acknowledgement when the receipt is for a different pegin", () => {
+    // A stale receipt, or one belonging to another vault's deposit, is not
+    // evidence that this deposit's recovery bundle is on disk.
+    seedReceipt("0xsomeotherpegin");
+    render(
+      <ActivateConfirmationModal
+        open
+        {...COMMON_PROPS}
+        onClose={vi.fn()}
+        onConfirm={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Activate vault")).toBeDisabled();
+    expect(screen.getByTestId("risk-checkbox")).toBeInTheDocument();
   });
 
   it("enables Activate vault and removes the checkbox once the card reports a download", () => {

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -501,6 +501,28 @@ export const COPY = {
       authenticationFailed: "Authentication failed",
       reauthenticationFailed: "Re-authentication failed",
       downloadFailed: "Download failed",
+      unknownRpcError: "Unknown RPC error",
+      // Shown while the browser's save-location dialog is open. The picker is
+      // opened before the wallet prompt, so this is the first status a user
+      // sees after pressing Download.
+      choosingSaveLocation: "Choose where to save your artifacts...",
+      savePickerDescription: "BTC Vault recovery artifacts",
+      // The browser refused the chosen location, or the write failed partway
+      // through (permission revoked, disk full).
+      fileAccessDenied:
+        "Could not write to the selected location. Choose a different folder and try again.",
+      // Browsers without the File System Access API must hold the whole file
+      // in memory, which a full-size bundle does not survive.
+      tooLargeForBrowser:
+        "This browser cannot save a file this large. Please use a Chromium-based browser, such as Chrome or Brave, to download your artifacts.",
+      // Rendered on those same browsers before the download starts, so the
+      // size ceiling is not a surprise partway through a long transfer.
+      fallbackSaveHint:
+        "This browser saves the file to your downloads folder and cannot confirm the save. For large artifacts, use a Chromium-based browser.",
+      // Attestation shown after the fallback download fires: without the File
+      // System Access API the browser gives no save/cancel signal, so the
+      // user confirming is the only evidence the file reached disk.
+      saveConfirmation: "I have saved the artifacts file to my device.",
     },
     form: {
       computingAllocation: "Computing allocation...",

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -521,6 +521,17 @@ export const COPY = {
       // nothing back about whether it was saved.
       fallbackSaveHint:
         "This browser must hold the entire file in memory and may run out on a smaller device. It also cannot confirm the file was saved, so your BTC Vault will keep showing the artifact warning. For a reliable download, use a Chromium-based browser such as Chrome or Brave.",
+      // Shown after that same fallback path finishes. The transfer is done and
+      // the file was handed to the browser, but a blocked or dismissed save
+      // looks identical to a successful one from here, so this state stops
+      // short of claiming the download succeeded — the risk acknowledgement
+      // stays required and the vault keeps warning.
+      unverifiedSaveTitle: "Download finished, but we cannot confirm it saved",
+      unverifiedSaveNotice:
+        "Check your downloads folder for the file. Because this browser does not report whether the save completed, your BTC Vault will keep showing the artifact warning. To clear it, download again using a Chromium-based browser such as Chrome or Brave.",
+      // The fallback path may well have worked; this offers a retry without
+      // implying the first attempt failed.
+      downloadAgainButton: "Download Again",
     },
     form: {
       computingAllocation: "Computing allocation...",

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -516,13 +516,11 @@ export const COPY = {
       tooLargeForBrowser:
         "This browser cannot save a file this large. Please use a Chromium-based browser, such as Chrome or Brave, to download your artifacts.",
       // Rendered on those same browsers before the download starts, so the
-      // size ceiling is not a surprise partway through a long transfer.
+      // limits are not a surprise partway through a long transfer. This path
+      // must hold the whole ~1 GB file in memory, and the browser reports
+      // nothing back about whether it was saved.
       fallbackSaveHint:
-        "This browser saves the file to your downloads folder and cannot confirm the save. For large artifacts, use a Chromium-based browser.",
-      // Attestation shown after the fallback download fires: without the File
-      // System Access API the browser gives no save/cancel signal, so the
-      // user confirming is the only evidence the file reached disk.
-      saveConfirmation: "I have saved the artifacts file to my device.",
+        "This browser must hold the entire file in memory and may run out on a smaller device. It also cannot confirm the file was saved, so your BTC Vault will keep showing the artifact warning. For a reliable download, use a Chromium-based browser such as Chrome or Brave.",
     },
     form: {
       computingAllocation: "Computing allocation...",

--- a/services/vault/src/dev/GodModePanel.tsx
+++ b/services/vault/src/dev/GodModePanel.tsx
@@ -26,6 +26,7 @@ import {
 import { createPortal } from "react-dom";
 
 import type { ProtocolStatus } from "@/components/shared/protocolStatus";
+import { clearArtifactDownloadReceipts } from "@/utils/artifactDownloadStorage";
 
 import {
   DEBUG_FORCED_MAX_VAULTS,
@@ -41,8 +42,13 @@ import {
   useDebugProtocolStatusOverride,
 } from "./debugPositionStore";
 import {
+  DEMO_ARTIFACT_SCENARIO_LABELS,
+  DEMO_ARTIFACT_SCENARIOS,
+  type DemoArtifactScenario,
   setArtifactDownloadMockEnabled,
+  setArtifactDownloadScenario,
   useArtifactDownloadMockEnabled,
+  useArtifactDownloadScenario,
 } from "./demoArtifactDownload";
 import {
   addDemoItem,
@@ -287,6 +293,8 @@ function DemoControls() {
   const hideReal = useDemoHideReal();
   const items = useDemoItems();
   const mockArtifactDownload = useArtifactDownloadMockEnabled();
+  const artifactScenario = useArtifactDownloadScenario();
+  const [clearedReceipts, setClearedReceipts] = useState<number | null>(null);
 
   return (
     <div className="space-y-3">
@@ -309,6 +317,45 @@ function DemoControls() {
           onChange={(e) => setArtifactDownloadMockEnabled(e.target.checked)}
         />
       </label>
+
+      {/* The mock drives the real validator and file sink, so these pick what
+          a hostile or broken vault provider sends back. */}
+      <label
+        className={`flex items-center justify-between gap-2 text-sm ${
+          mockArtifactDownload ? "" : "opacity-40"
+        }`}
+      >
+        <span>Artifact response</span>
+        <select
+          disabled={!mockArtifactDownload}
+          value={artifactScenario}
+          onChange={(e) =>
+            setArtifactDownloadScenario(e.target.value as DemoArtifactScenario)
+          }
+          className="rounded bg-neutral-800 px-2 py-1 text-xs"
+        >
+          {DEMO_ARTIFACT_SCENARIOS.map((scenario) => (
+            <option key={scenario} value={scenario}>
+              {DEMO_ARTIFACT_SCENARIO_LABELS[scenario]}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      {/* A satisfied gate hides the card's download button, so re-testing the
+          flow against the same vault needs the receipts gone. */}
+      <button
+        type="button"
+        onClick={() => {
+          const cleared = clearArtifactDownloadReceipts();
+          setClearedReceipts(cleared);
+        }}
+        className="w-full rounded bg-neutral-800 px-2 py-1 text-left text-sm hover:bg-neutral-700"
+      >
+        {clearedReceipts === null
+          ? "Clear artifact receipts"
+          : `Cleared ${clearedReceipts} artifact receipt(s) — reload`}
+      </button>
 
       <fieldset
         disabled={!enabled}

--- a/services/vault/src/dev/__tests__/demoArtifactDownload.test.ts
+++ b/services/vault/src/dev/__tests__/demoArtifactDownload.test.ts
@@ -1,59 +1,125 @@
+import { VpResponseValidationError } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { ArtifactDownloadCancelledError } from "@/services/artifacts";
+import {
+  ArtifactDownloadCancelledError,
+  type ArtifactSaveTarget,
+} from "@/services/artifacts";
 
-import { demoFetchAndDownloadArtifacts } from "../demoArtifactDownload";
+import {
+  demoFetchAndDownloadArtifacts,
+  setArtifactDownloadScenario,
+} from "../demoArtifactDownload";
+
+const BINDING = {
+  peginTxid: "aa".repeat(32),
+  depositorPk: "bb".repeat(32),
+};
+
+/** Records what the demo writes, the same way the real service's target does. */
+function fakeSaveTarget() {
+  const written: Uint8Array[] = [];
+  const write = vi.fn(async (chunk: Uint8Array<ArrayBuffer>) => {
+    written.push(chunk);
+  });
+  const commit = vi.fn(async () => undefined);
+  const discard = vi.fn(async () => undefined);
+  const target: ArtifactSaveTarget = {
+    method: "file-system-access",
+    filename: "demo.json",
+    maxBytes: Number.POSITIVE_INFINITY,
+    open: vi.fn(async () => ({ write, commit, discard })),
+  };
+  return { target, write, commit, discard, written };
+}
 
 describe("demoFetchAndDownloadArtifacts", () => {
   beforeEach(() => {
+    setArtifactDownloadScenario("valid");
+    // The mock paces itself to be watchable in a browser; fake timers keep
+    // that from costing ~12 s per case here.
     vi.useFakeTimers();
   });
 
   afterEach(() => {
     vi.useRealTimers();
+    setArtifactDownloadScenario("valid");
+    vi.restoreAllMocks();
   });
 
-  it("reports monotonic byte progress up to the full simulated total", async () => {
-    const onProgress = vi.fn();
-    const promise = demoFetchAndDownloadArtifacts(
-      "0xprovider",
-      "0xtxid",
-      "0xpk",
-      { onProgress },
+  /** Drive the mock's paced stream to completion under fake timers. */
+  async function run(promise: Promise<unknown>): Promise<unknown> {
+    const settled = promise.then(
+      (value) => ({ ok: true, value }) as const,
+      (error) => ({ ok: false, error }) as const,
     );
-
     await vi.runAllTimersAsync();
-    await promise;
+    return settled;
+  }
 
-    const received = onProgress.mock.calls.map(
-      ([receivedBytes]) => receivedBytes as number,
-    );
-    expect(received.at(-1)).toBe(1_000_000_000);
+  it("streams a valid bundle through the real pipeline and commits it", async () => {
+    const { target, commit, discard, written } = fakeSaveTarget();
+    const onProgress = vi.fn();
+
+    await run(demoFetchAndDownloadArtifacts(target, BINDING, { onProgress }));
+
+    expect(commit).toHaveBeenCalledTimes(1);
+    expect(discard).not.toHaveBeenCalled();
+    // Many chunks, not one blob — the point of the mock is to exercise the
+    // streaming path rather than hand the sink a finished buffer.
+    expect(written.length).toBeGreaterThan(1);
+
+    const received = onProgress.mock.calls.map(([bytes]) => bytes as number);
     for (let i = 1; i < received.length; i++) {
       expect(received[i]).toBeGreaterThanOrEqual(received[i - 1]);
     }
-    expect(
-      onProgress.mock.calls.every(
-        ([, totalBytes]) => totalBytes === 1_000_000_000,
-      ),
-    ).toBe(true);
   });
 
-  it("throws the cancellation sentinel when the signal aborts mid-simulation", async () => {
-    const abortController = new AbortController();
-    // Cancel as soon as the first progress tick lands.
-    const onProgress = vi.fn(() => abortController.abort());
-    const promise = demoFetchAndDownloadArtifacts(
-      "0xprovider",
-      "0xtxid",
-      "0xpk",
-      { signal: abortController.signal, onProgress },
-    );
+  it.each([["truncated"], ["garbage"], ["non-hex"], ["wrong-vault"]] as const)(
+    "rejects the %s scenario and discards the partial file",
+    async (scenario) => {
+      setArtifactDownloadScenario(scenario);
+      const { target, commit, discard } = fakeSaveTarget();
 
-    const assertion = expect(promise).rejects.toBeInstanceOf(
-      ArtifactDownloadCancelledError,
-    );
-    await vi.runAllTimersAsync();
-    await assertion;
+      const outcome = (await run(
+        demoFetchAndDownloadArtifacts(target, BINDING, {}),
+      )) as { ok: boolean; error?: unknown };
+
+      expect(outcome.ok).toBe(false);
+      expect(outcome.error).toBeInstanceOf(VpResponseValidationError);
+      expect(commit).not.toHaveBeenCalled();
+      expect(discard).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("throws the cancellation sentinel when the signal is already aborted", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const { target, commit } = fakeSaveTarget();
+
+    const outcome = (await run(
+      demoFetchAndDownloadArtifacts(target, BINDING, {
+        signal: controller.signal,
+      }),
+    )) as { ok: boolean; error?: unknown };
+
+    expect(outcome.ok).toBe(false);
+    expect(outcome.error).toBeInstanceOf(ArtifactDownloadCancelledError);
+    expect(commit).not.toHaveBeenCalled();
+  });
+
+  it("throws the cancellation sentinel when cancelled mid-stream", async () => {
+    const { target, commit } = fakeSaveTarget();
+    let chunks = 0;
+    // Cancel once bytes are genuinely flowing, not before the stream starts.
+    const isCancelled = () => ++chunks > 3;
+
+    const outcome = (await run(
+      demoFetchAndDownloadArtifacts(target, BINDING, { isCancelled }),
+    )) as { ok: boolean; error?: unknown };
+
+    expect(outcome.ok).toBe(false);
+    expect(outcome.error).toBeInstanceOf(ArtifactDownloadCancelledError);
+    expect(commit).not.toHaveBeenCalled();
   });
 });

--- a/services/vault/src/dev/demoArtifactDownload.ts
+++ b/services/vault/src/dev/demoArtifactDownload.ts
@@ -30,6 +30,7 @@ import {
   type ArtifactSaveTarget,
   downloadArtifactsFromResponse,
   type FetchArtifactsOptions,
+  MAX_ERROR_VALUE_BYTES,
   type VaultBindingContext,
 } from "@/services/artifacts";
 
@@ -61,6 +62,15 @@ const DEMO_TRUNCATION_FRACTION = 0.4;
 
 /** Padding for the scenarios that must exceed any plausible prefix window. */
 const DEMO_PADDING_CHARS = 500_000;
+
+/**
+ * Padding for the error envelope. Must stay well past any prefix window but
+ * comfortably UNDER the validator's error-value cap: above that cap the
+ * capture buffer fails closed with a VpResponseValidationError, so the
+ * scenario would exercise the cap instead of the padded-error handling it
+ * exists to demonstrate. Derived from the cap so the two cannot drift.
+ */
+const DEMO_ERROR_PADDING_CHARS = Math.floor(MAX_ERROR_VALUE_BYTES / 4);
 
 /** A syntactically valid x-only challenger pubkey for the synthetic sessions. */
 const DEMO_CHALLENGER_PUBKEY = "ab".repeat(32);
@@ -201,8 +211,11 @@ function demoBodyFor(
       jsonrpc: "2.0",
       id: 1,
       error: {
+        // Deliberately not a "still processing" state string: those match
+        // isPreDepositorSignaturesError and would route this into the
+        // wait-and-retry loop instead of the padded-error handling.
         code: -32011,
-        message: `Invalid state: PendingBabeSetup ${"x".repeat(DEMO_PADDING_CHARS)}`,
+        message: `Vault provider rejected the request ${"x".repeat(DEMO_ERROR_PADDING_CHARS)}`,
       },
     });
   }

--- a/services/vault/src/dev/demoArtifactDownload.ts
+++ b/services/vault/src/dev/demoArtifactDownload.ts
@@ -3,15 +3,23 @@
  * NEXT_PUBLIC_FF_GOD_MODE_PANEL and opted into per session via the god-mode
  * panel's "Mock artifact download" toggle).
  *
- * Simulates the vault-provider artifact fetch so the artifact dialogs'
- * fetching / progress-bar / downloaded states can be exercised without a
- * reachable vault provider or a real ~1 GB transfer. Matches the real
- * service's contract — byte progress via onProgress, cancellation via
- * isCancelled / signal normalized to ArtifactDownloadCancelledError — but
- * never talks to a VP and never saves a file; it exists purely to drive
- * the UI. When the panel flag or the toggle is off the enabled check
- * returns false and every caller uses the real service — zero behavioural
- * change.
+ * Synthesizes a vault-provider response and feeds it through the *real*
+ * download pipeline — the same streaming validator, digest, and file sink the
+ * production path uses. Only the network and the bearer-auth prime are
+ * skipped. A mock that stubbed out validation and the save target would
+ * exercise nothing worth exercising, so instead the scenario selector lets a
+ * developer reproduce a hostile or broken provider on demand: a truncated
+ * stream, junk in a success envelope, a padded error, a corrupt hex payload.
+ *
+ * What it deliberately does NOT do is produce a download outcome. The
+ * activation gate is satisfied only by a receipt, and a receipt is written
+ * only from an outcome — so no simulated download can ever unlock a real
+ * vault's activation, however convincing the file it wrote looks. Use the
+ * panel's "Clear artifact receipts" action to get back to a pre-download
+ * state for re-testing.
+ *
+ * When the panel flag or the toggle is off, every caller uses the real
+ * service — zero behavioural change.
  */
 
 import { useSyncExternalStore } from "react";
@@ -19,21 +27,76 @@ import { useSyncExternalStore } from "react";
 import featureFlags from "@/config/featureFlags";
 import {
   ArtifactDownloadCancelledError,
+  type ArtifactSaveTarget,
+  downloadArtifactsFromResponse,
   type FetchArtifactsOptions,
+  type VaultBindingContext,
 } from "@/services/artifacts";
 
-/** Simulated payload size; renders as "1.00 GB" in the progress panel. */
-const DEMO_TOTAL_BYTES = 1_000_000_000;
-/** Progress ticks; with DEMO_TICK_MS the simulated download takes ~15 s. */
-const DEMO_TICK_COUNT = 100;
-const DEMO_TICK_MS = 150;
+/**
+ * Size of the synthetic decryptor payload, in hex characters.
+ *
+ * Large enough that the body spans many chunks (so chunk-boundary handling,
+ * progress, and backpressure are genuinely exercised) but far below the real
+ * ~1.3 GB, which would make every dev iteration a multi-minute wait. Use a
+ * real devnet download to test true full-size behaviour.
+ */
+const DEMO_HEX_CHARS = 8 * 1024 * 1024;
+
+/** Bytes emitted per stream chunk, roughly matching a network read. */
+const DEMO_CHUNK_BYTES = 64 * 1024;
+
+/**
+ * Pause between chunks. With the size and chunk constants above this makes a
+ * simulated transfer run ~12 s — long enough to watch the progress bar, cancel
+ * mid-flight, or see where a scenario fails, without being a chore.
+ */
+const DEMO_CHUNK_DELAY_MS = 90;
+
 /** Pre-byte pause so the indeterminate "Fetching artifacts..." chip shows. */
 const DEMO_PRE_BYTE_DELAY_MS = 1_200;
+
+/** Fraction of the body emitted before the `truncated` scenario cuts off. */
+const DEMO_TRUNCATION_FRACTION = 0.4;
+
+/** Padding for the scenarios that must exceed any plausible prefix window. */
+const DEMO_PADDING_CHARS = 500_000;
+
+/** A syntactically valid x-only challenger pubkey for the synthetic sessions. */
+const DEMO_CHALLENGER_PUBKEY = "ab".repeat(32);
+
+/** Stands in for a bundle built against somebody else's deposit. */
+const DEMO_FOREIGN_TXID = "ff".repeat(32);
+
+export const DEMO_ARTIFACT_SCENARIOS = [
+  "valid",
+  "truncated",
+  "garbage",
+  "error-envelope",
+  "non-hex",
+  "wrong-vault",
+] as const;
+
+export type DemoArtifactScenario = (typeof DEMO_ARTIFACT_SCENARIOS)[number];
+
+/** Human-readable labels for the god-mode selector. */
+export const DEMO_ARTIFACT_SCENARIO_LABELS: Record<
+  DemoArtifactScenario,
+  string
+> = {
+  valid: "Valid bundle",
+  truncated: "Truncated stream (connection dropped)",
+  garbage: "Junk inside a success envelope",
+  "error-envelope": "Padded JSON-RPC error",
+  "non-hex": "Corrupt hex payload",
+  "wrong-vault": "Valid bundle for a different deposit",
+};
 
 // The mock starts OFF: merely enabling the god-mode panel must not change
 // how downloads behave. The panel's "Mock artifact download" toggle opts in
 // for the session.
 let storeMockEnabled = false;
+let storeScenario: DemoArtifactScenario = "valid";
 const listeners = new Set<() => void>();
 
 function emit() {
@@ -51,8 +114,17 @@ function getMockEnabledSnapshot() {
   return storeMockEnabled;
 }
 
+function getScenarioSnapshot() {
+  return storeScenario;
+}
+
 export function setArtifactDownloadMockEnabled(enabled: boolean) {
   storeMockEnabled = enabled;
+  emit();
+}
+
+export function setArtifactDownloadScenario(scenario: DemoArtifactScenario) {
+  storeScenario = scenario;
   emit();
 }
 
@@ -62,6 +134,15 @@ export function useArtifactDownloadMockEnabled(): boolean {
     subscribe,
     getMockEnabledSnapshot,
     getMockEnabledSnapshot,
+  );
+}
+
+/** The panel selector's reactive view of the chosen scenario. */
+export function useArtifactDownloadScenario(): DemoArtifactScenario {
+  return useSyncExternalStore(
+    subscribe,
+    getScenarioSnapshot,
+    getScenarioSnapshot,
   );
 }
 
@@ -78,31 +159,141 @@ function sleep(ms: number): Promise<void> {
 }
 
 /**
- * Drop-in stand-in for fetchAndDownloadArtifacts. The routing params are
- * accepted (and ignored) so callers can swap the two functions without
- * branching at the call site.
+ * Build the wire text for a scenario. The `valid` body is a faithful
+ * JSON-RPC envelope: the small fields first, then one oversized
+ * `decryptor_artifacts_hex` value, mirroring what the proxy emits.
+ */
+function demoTxGraph(
+  binding: VaultBindingContext,
+  scenario: DemoArtifactScenario,
+) {
+  // `wrong-vault` keeps everything else intact and only swaps the funding
+  // transaction, which is the shape of a provider serving another
+  // depositor's bundle.
+  const peginTxid =
+    scenario === "wrong-vault" ? DEMO_FOREIGN_TXID : binding.peginTxid;
+  const spend = (vout: number) => ({
+    tx: { input: [{ previous_output: `${peginTxid}:${vout}` }] },
+  });
+  return {
+    demo: true,
+    claim_tx: spend(1),
+    payout_tx: spend(0),
+    depositor_pubkey: binding.depositorPk,
+    challenger_pubkeys: { local: [DEMO_CHALLENGER_PUBKEY], universal: [] },
+  };
+}
+
+function demoBodyFor(
+  scenario: DemoArtifactScenario,
+  binding: VaultBindingContext,
+): string {
+  if (scenario === "garbage") {
+    return JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      result: { junk: "x".repeat(DEMO_PADDING_CHARS) },
+    });
+  }
+
+  if (scenario === "error-envelope") {
+    return JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      error: {
+        code: -32011,
+        message: `Invalid state: PendingBabeSetup ${"x".repeat(DEMO_PADDING_CHARS)}`,
+      },
+    });
+  }
+
+  const hex =
+    scenario === "non-hex"
+      ? // A single invalid character deep inside an otherwise valid payload,
+        // which only a validator that reads the whole body can catch.
+        `${"ab".repeat(DEMO_HEX_CHARS / 4)}zz${"ab".repeat(DEMO_HEX_CHARS / 4)}`
+      : "ab".repeat(DEMO_HEX_CHARS / 2);
+
+  return JSON.stringify({
+    jsonrpc: "2.0",
+    id: 1,
+    result: {
+      tx_graph_json: JSON.stringify(demoTxGraph(binding, scenario)),
+      verifying_key_hex: "abcdef01",
+      babe_sessions: {
+        [DEMO_CHALLENGER_PUBKEY]: { decryptor_artifacts_hex: hex },
+      },
+    },
+  });
+}
+
+/**
+ * Wrap the synthetic body in a Response that streams in chunks, so the
+ * consumer sees the same shape as a real transfer. The `truncated` scenario
+ * closes the stream partway through, which is how a destroyed upstream
+ * connection presents to the reader.
+ */
+function demoResponse(
+  scenario: DemoArtifactScenario,
+  binding: VaultBindingContext,
+): Response {
+  const bytes = new TextEncoder().encode(demoBodyFor(scenario, binding));
+  const emitBytes =
+    scenario === "truncated"
+      ? Math.floor(bytes.byteLength * DEMO_TRUNCATION_FRACTION)
+      : bytes.byteLength;
+
+  let offset = 0;
+  const stream = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      if (offset >= emitBytes) {
+        controller.close();
+        return;
+      }
+      await sleep(DEMO_CHUNK_DELAY_MS);
+      const end = Math.min(offset + DEMO_CHUNK_BYTES, emitBytes);
+      controller.enqueue(bytes.slice(offset, end));
+      offset = end;
+    },
+  });
+
+  return new Response(stream, {
+    status: 200,
+    headers: {
+      "Content-Type": "application/json",
+      // Real streamed responses carry no length, so the progress bar's
+      // no-Content-Length fallback is what gets exercised.
+    },
+  });
+}
+
+/**
+ * Run the selected scenario through the production download pipeline.
+ *
+ * Returns nothing: the caller gets no outcome, so no receipt is written and
+ * the activation gate stays unsatisfied. That is the point — see the module
+ * header.
  */
 export async function demoFetchAndDownloadArtifacts(
-  _providerAddress: string,
-  _peginTxid: string,
-  _depositorPk: string,
+  target: ArtifactSaveTarget,
+  binding: VaultBindingContext,
   options?: FetchArtifactsOptions,
 ): Promise<void> {
-  const throwIfCancelled = () => {
-    if (options?.signal?.aborted || options?.isCancelled?.()) {
-      throw new ArtifactDownloadCancelledError();
-    }
-  };
+  if (options?.signal?.aborted || options?.isCancelled?.()) {
+    throw new ArtifactDownloadCancelledError();
+  }
 
   await sleep(DEMO_PRE_BYTE_DELAY_MS);
-  throwIfCancelled();
 
-  for (let tick = 1; tick <= DEMO_TICK_COUNT; tick++) {
-    await sleep(DEMO_TICK_MS);
-    throwIfCancelled();
-    options?.onProgress?.(
-      Math.round((tick / DEMO_TICK_COUNT) * DEMO_TOTAL_BYTES),
-      DEMO_TOTAL_BYTES,
-    );
+  if (options?.signal?.aborted || options?.isCancelled?.()) {
+    throw new ArtifactDownloadCancelledError();
   }
+
+  // The outcome is deliberately discarded rather than returned.
+  await downloadArtifactsFromResponse(
+    demoResponse(storeScenario, binding),
+    target,
+    options,
+    binding,
+  );
 }

--- a/services/vault/src/hooks/deposit/__tests__/useArtifactDownload.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useArtifactDownload.test.tsx
@@ -18,12 +18,15 @@ vi.mock("@/services/artifacts", async () => {
   return {
     ...actual,
     fetchAndDownloadArtifacts: vi.fn(),
+    openArtifactSaveTarget: vi.fn(),
   };
 });
 
 vi.mock("@/utils/artifactDownloadStorage", () => ({
-  markArtifactsDownloaded: vi.fn(),
+  ARTIFACT_RECEIPT_VERSION: 1,
+  saveArtifactDownloadReceipt: vi.fn(),
   hasArtifactsDownloaded: vi.fn(() => false),
+  normalizePeginTxid: (txid: string) => txid.toLowerCase(),
 }));
 
 const mockLoggerError = vi.hoisted(() => vi.fn());
@@ -54,22 +57,48 @@ import {
 } from "@/dev/demoArtifactDownload";
 import {
   ArtifactDownloadCancelledError,
+  type ArtifactDownloadOutcome,
+  ArtifactDownloadTooLargeError,
+  ArtifactFileAccessError,
+  type ArtifactSaveTarget,
   fetchAndDownloadArtifacts,
+  openArtifactSaveTarget,
 } from "@/services/artifacts";
 import {
   hasArtifactsDownloaded,
-  markArtifactsDownloaded,
+  saveArtifactDownloadReceipt,
 } from "@/utils/artifactDownloadStorage";
 
 import { ensureAuthenticatedVpClient } from "../depositFlowSteps/ensureAuthenticatedVpClient";
 import { useArtifactDownload } from "../useArtifactDownload";
 
 const fetchMock = vi.mocked(fetchAndDownloadArtifacts);
+const openTargetMock = vi.mocked(openArtifactSaveTarget);
 const ensureAuthMock = vi.mocked(ensureAuthenticatedVpClient);
 const demoEnabledMock = vi.mocked(isArtifactDownloadDemoEnabled);
 const demoFetchMock = vi.mocked(demoFetchAndDownloadArtifacts);
-const markDownloadedMock = vi.mocked(markArtifactsDownloaded);
+const saveReceiptMock = vi.mocked(saveArtifactDownloadReceipt);
 const hasDownloadedMock = vi.mocked(hasArtifactsDownloaded);
+
+/** A completed streaming save, as the service reports one. */
+const OUTCOME: ArtifactDownloadOutcome = {
+  filename: "babylon-vault-artifacts-aaaaaaaa.json",
+  byteLength: 1_048_576,
+  sha256: "9".repeat(64),
+  method: "file-system-access",
+};
+
+const FALLBACK_OUTCOME: ArtifactDownloadOutcome = {
+  ...OUTCOME,
+  method: "browser-download",
+};
+
+const SAVE_TARGET = {
+  method: "file-system-access",
+  filename: OUTCOME.filename,
+  maxBytes: Number.POSITIVE_INFINITY,
+  open: vi.fn(),
+} as unknown as ArtifactSaveTarget;
 
 const PROVIDER_ADDRESS = "0x1234";
 const PEGIN_TXID =
@@ -106,7 +135,10 @@ describe("useArtifactDownload — prime then fetch", () => {
     ensureAuthMock.mockReset();
     demoEnabledMock.mockReturnValue(false);
     demoFetchMock.mockReset();
-    markDownloadedMock.mockReset();
+    saveReceiptMock.mockReset();
+    hasDownloadedMock.mockReturnValue(false);
+    openTargetMock.mockReset();
+    openTargetMock.mockResolvedValue(SAVE_TARGET);
     (vpTokenRegistry as unknown as { clear?: () => void }).clear?.();
   });
 
@@ -120,7 +152,7 @@ describe("useArtifactDownload — prime then fetch", () => {
         ReturnType<typeof ensureAuthenticatedVpClient>
       >,
     );
-    fetchMock.mockResolvedValueOnce(undefined);
+    fetchMock.mockResolvedValueOnce(OUTCOME);
 
     const { result } = renderHook(() => useArtifactDownload({ primeContext }));
 
@@ -142,11 +174,171 @@ describe("useArtifactDownload — prime then fetch", () => {
     expect(result.current.error).toBeNull();
   });
 
-  it("does not persist the risk-ack gate for a mocked (god-mode) download", async () => {
-    // The demo simulates the fetch and never saves a file, so a mocked download
-    // must NOT call markArtifactsDownloaded — otherwise mocking a download on a
-    // real vault permanently satisfies its risk-ack gate with no artifact saved.
-    // It still shows the downloaded UI so the demo flow can be exercised.
+  it("opens the save picker before prompting the wallet", async () => {
+    // showSaveFilePicker() needs transient user activation, which the wallet
+    // signature prompt would consume first. If a refactor ever reorders these
+    // two, the picker silently stops opening — nothing else catches it.
+    ensureAuthMock.mockResolvedValueOnce(
+      undefined as unknown as Awaited<
+        ReturnType<typeof ensureAuthenticatedVpClient>
+      >,
+    );
+    fetchMock.mockResolvedValueOnce(OUTCOME);
+
+    const { result } = renderHook(() => useArtifactDownload({ primeContext }));
+
+    await act(async () => {
+      await result.current.download(PROVIDER_ADDRESS, PEGIN_TXID, DEPOSITOR_PK);
+    });
+
+    expect(openTargetMock).toHaveBeenCalledWith(PEGIN_TXID);
+    expect(openTargetMock.mock.invocationCallOrder[0]).toBeLessThan(
+      ensureAuthMock.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("writes a bound receipt once a validated bundle is saved", async () => {
+    seedHotCache();
+    fetchMock.mockResolvedValueOnce(OUTCOME);
+
+    const { result } = renderHook(() =>
+      useArtifactDownload({ vaultId: VAULT_ID, primeContext }),
+    );
+
+    await act(async () => {
+      await result.current.download(PROVIDER_ADDRESS, PEGIN_TXID, DEPOSITOR_PK);
+    });
+
+    expect(saveReceiptMock).toHaveBeenCalledTimes(1);
+    expect(saveReceiptMock).toHaveBeenCalledWith(VAULT_ID, {
+      version: 1,
+      peginTxid: PEGIN_TXID,
+      filename: OUTCOME.filename,
+      byteLength: OUTCOME.byteLength,
+      sha256: OUTCOME.sha256,
+      savedAt: expect.any(Number),
+      method: "file-system-access",
+    });
+  });
+
+  it("resets without an error when the user dismisses the save picker", async () => {
+    openTargetMock.mockRejectedValueOnce(new ArtifactDownloadCancelledError());
+
+    const { result } = renderHook(() =>
+      useArtifactDownload({ vaultId: VAULT_ID, primeContext }),
+    );
+
+    await act(async () => {
+      await result.current.download(PROVIDER_ADDRESS, PEGIN_TXID, DEPOSITOR_PK);
+    });
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.loading).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(saveReceiptMock).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a refused save location without fetching", async () => {
+    openTargetMock.mockRejectedValueOnce(
+      new ArtifactFileAccessError("Could not write to the selected location."),
+    );
+
+    const { result } = renderHook(() =>
+      useArtifactDownload({ vaultId: VAULT_ID, primeContext }),
+    );
+
+    await act(async () => {
+      await result.current.download(PROVIDER_ADDRESS, PEGIN_TXID, DEPOSITOR_PK);
+    });
+
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(saveReceiptMock).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a too-large body without retrying or writing a receipt", async () => {
+    seedHotCache();
+    fetchMock.mockRejectedValueOnce(
+      new ArtifactDownloadTooLargeError(2_000_000_000, 536_870_912),
+    );
+
+    const { result } = renderHook(() =>
+      useArtifactDownload({ vaultId: VAULT_ID, primeContext }),
+    );
+
+    await act(async () => {
+      await result.current.download(PROVIDER_ADDRESS, PEGIN_TXID, DEPOSITOR_PK);
+    });
+
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(saveReceiptMock).not.toHaveBeenCalled();
+  });
+
+  it("withholds the receipt on the fallback path until the user attests", async () => {
+    // An anchor download gives no save/cancel signal, so a resolved fetch is
+    // not evidence the file reached disk.
+    seedHotCache();
+    fetchMock.mockResolvedValueOnce(FALLBACK_OUTCOME);
+
+    const { result } = renderHook(() =>
+      useArtifactDownload({ vaultId: VAULT_ID, primeContext }),
+    );
+
+    await act(async () => {
+      await result.current.download(PROVIDER_ADDRESS, PEGIN_TXID, DEPOSITOR_PK);
+    });
+
+    await waitFor(() =>
+      expect(result.current.awaitingSaveConfirmation).toBe(true),
+    );
+    expect(result.current.downloaded).toBe(false);
+    expect(saveReceiptMock).not.toHaveBeenCalled();
+
+    act(() => {
+      result.current.confirmSaved();
+    });
+
+    expect(result.current.downloaded).toBe(true);
+    expect(saveReceiptMock).toHaveBeenCalledTimes(1);
+    expect(saveReceiptMock).toHaveBeenCalledWith(
+      VAULT_ID,
+      expect.objectContaining({ method: "browser-download" }),
+    );
+  });
+
+  it("does not write a receipt when a fallback download is cancelled before attestation", async () => {
+    seedHotCache();
+    fetchMock.mockResolvedValueOnce(FALLBACK_OUTCOME);
+
+    const { result } = renderHook(() =>
+      useArtifactDownload({ vaultId: VAULT_ID, primeContext }),
+    );
+
+    await act(async () => {
+      await result.current.download(PROVIDER_ADDRESS, PEGIN_TXID, DEPOSITOR_PK);
+    });
+    await waitFor(() =>
+      expect(result.current.awaitingSaveConfirmation).toBe(true),
+    );
+
+    act(() => {
+      result.current.cancel();
+    });
+    act(() => {
+      result.current.confirmSaved();
+    });
+
+    expect(saveReceiptMock).not.toHaveBeenCalled();
+    expect(result.current.downloaded).toBe(false);
+  });
+
+  it("runs a mocked (god-mode) download through a real save target but writes no receipt", async () => {
+    // The mock drives the real validator and file sink, so it opens a save
+    // target like any download. What it must never do is satisfy the risk-ack
+    // gate: the file it wrote is synthetic, so mocking a download on a real
+    // vault must not leave that vault looking recoverable. It still shows the
+    // downloaded UI so the demo flow can be exercised.
     demoEnabledMock.mockReturnValue(true);
     demoFetchMock.mockResolvedValueOnce(undefined);
 
@@ -160,13 +352,19 @@ describe("useArtifactDownload — prime then fetch", () => {
 
     await waitFor(() => expect(result.current.downloaded).toBe(true));
     expect(demoFetchMock).toHaveBeenCalledTimes(1);
+    expect(demoFetchMock).toHaveBeenCalledWith(
+      SAVE_TARGET,
+      { peginTxid: PEGIN_TXID, depositorPk: DEPOSITOR_PK },
+      expect.anything(),
+    );
+    expect(openTargetMock).toHaveBeenCalledTimes(1);
     expect(fetchMock).not.toHaveBeenCalled();
-    expect(markDownloadedMock).not.toHaveBeenCalled();
+    expect(saveReceiptMock).not.toHaveBeenCalled();
   });
 
   it("skips the upfront prime when the registry is already hot", async () => {
     seedHotCache();
-    fetchMock.mockResolvedValueOnce(undefined);
+    fetchMock.mockResolvedValueOnce(OUTCOME);
 
     const { result } = renderHook(() => useArtifactDownload({ primeContext }));
 
@@ -262,7 +460,7 @@ describe("useArtifactDownload — prime then fetch", () => {
           typeof ensureAuthenticatedVpClient
         >,
     );
-    fetchMock.mockResolvedValueOnce(undefined);
+    fetchMock.mockResolvedValueOnce(OUTCOME);
 
     const { result } = renderHook(() => useArtifactDownload({ primeContext }));
 
@@ -296,7 +494,7 @@ describe("useArtifactDownload — prime then fetch", () => {
         new Error("Invalid state: PendingBabeSetup"),
       );
       // Flow #2 (started after cancelling #1): succeeds.
-      fetchMock.mockResolvedValueOnce(undefined);
+      fetchMock.mockResolvedValueOnce(OUTCOME);
 
       const { result } = renderHook(() =>
         useArtifactDownload({ primeContext }),
@@ -359,7 +557,7 @@ describe("useArtifactDownload — prime then fetch", () => {
           kind: "auth_expired",
         }),
       )
-      .mockResolvedValueOnce(undefined);
+      .mockResolvedValueOnce(OUTCOME);
     ensureAuthMock.mockResolvedValueOnce(
       undefined as unknown as Awaited<
         ReturnType<typeof ensureAuthenticatedVpClient>
@@ -469,8 +667,8 @@ describe("useArtifactDownload — prime then fetch", () => {
     // caller aborts the signal. This exercises both the abort wiring and the
     // hook's `instanceof ArtifactDownloadCancelledError` swallow path.
     fetchMock.mockImplementationOnce(
-      (_provider, _txid, _pk, options) =>
-        new Promise<void>((_resolve, reject) => {
+      (_provider, _txid, _pk, _target, options) =>
+        new Promise<ArtifactDownloadOutcome>((_resolve, reject) => {
           options?.signal?.addEventListener("abort", () =>
             reject(new ArtifactDownloadCancelledError()),
           );
@@ -507,12 +705,14 @@ describe("useArtifactDownload — prime then fetch", () => {
   it("propagates received/total bytes from the in-flight progress callback", async () => {
     seedHotCache();
     let resolveFetch: () => void = () => {};
-    fetchMock.mockImplementationOnce((_provider, _txid, _pk, options) => {
-      options?.onProgress?.(500, 1000);
-      return new Promise<void>((resolve) => {
-        resolveFetch = resolve;
-      });
-    });
+    fetchMock.mockImplementationOnce(
+      (_provider, _txid, _pk, _target, options) => {
+        options?.onProgress?.(500, 1000);
+        return new Promise<ArtifactDownloadOutcome>((resolve) => {
+          resolveFetch = () => resolve(OUTCOME);
+        });
+      },
+    );
 
     const { result } = renderHook(() => useArtifactDownload({ primeContext }));
 
@@ -544,9 +744,11 @@ describe("useArtifactDownload — funnel telemetry", () => {
     fetchMock.mockReset();
     ensureAuthMock.mockReset();
     demoEnabledMock.mockReturnValue(false);
-    markDownloadedMock.mockReset();
+    saveReceiptMock.mockReset();
     hasDownloadedMock.mockReset();
     hasDownloadedMock.mockReturnValue(false);
+    openTargetMock.mockReset();
+    openTargetMock.mockResolvedValue(SAVE_TARGET);
     mockLoggerError.mockReset();
     mockLoggerEvent.mockReset();
     (vpTokenRegistry as unknown as { clear?: () => void }).clear?.();
@@ -620,7 +822,7 @@ describe("useArtifactDownload — funnel telemetry", () => {
 
   it("emits the downloaded milestone once, on the first real download only", async () => {
     seedHotCache();
-    fetchMock.mockResolvedValue(undefined);
+    fetchMock.mockResolvedValue(OUTCOME);
 
     const { result } = renderHook(() =>
       useArtifactDownload({ vaultId: VAULT_ID, primeContext }),

--- a/services/vault/src/hooks/deposit/__tests__/useArtifactDownload.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useArtifactDownload.test.tsx
@@ -275,9 +275,11 @@ describe("useArtifactDownload — prime then fetch", () => {
     expect(saveReceiptMock).not.toHaveBeenCalled();
   });
 
-  it("withholds the receipt on the fallback path until the user attests", async () => {
-    // An anchor download gives no save/cancel signal, so a resolved fetch is
-    // not evidence the file reached disk.
+  it("never writes a receipt on the anchor-download fallback", async () => {
+    // That path only proves a link was clicked — the browser reports nothing
+    // about whether the file reached disk, and it may have been blocked or
+    // the save dialog dismissed. The file is shown as delivered, but the
+    // activation gate stays unsatisfied because there is no evidence.
     seedHotCache();
     fetchMock.mockResolvedValueOnce(FALLBACK_OUTCOME);
 
@@ -289,48 +291,8 @@ describe("useArtifactDownload — prime then fetch", () => {
       await result.current.download(PROVIDER_ADDRESS, PEGIN_TXID, DEPOSITOR_PK);
     });
 
-    await waitFor(() =>
-      expect(result.current.awaitingSaveConfirmation).toBe(true),
-    );
-    expect(result.current.downloaded).toBe(false);
+    await waitFor(() => expect(result.current.downloaded).toBe(true));
     expect(saveReceiptMock).not.toHaveBeenCalled();
-
-    act(() => {
-      result.current.confirmSaved();
-    });
-
-    expect(result.current.downloaded).toBe(true);
-    expect(saveReceiptMock).toHaveBeenCalledTimes(1);
-    expect(saveReceiptMock).toHaveBeenCalledWith(
-      VAULT_ID,
-      expect.objectContaining({ method: "browser-download" }),
-    );
-  });
-
-  it("does not write a receipt when a fallback download is cancelled before attestation", async () => {
-    seedHotCache();
-    fetchMock.mockResolvedValueOnce(FALLBACK_OUTCOME);
-
-    const { result } = renderHook(() =>
-      useArtifactDownload({ vaultId: VAULT_ID, primeContext }),
-    );
-
-    await act(async () => {
-      await result.current.download(PROVIDER_ADDRESS, PEGIN_TXID, DEPOSITOR_PK);
-    });
-    await waitFor(() =>
-      expect(result.current.awaitingSaveConfirmation).toBe(true),
-    );
-
-    act(() => {
-      result.current.cancel();
-    });
-    act(() => {
-      result.current.confirmSaved();
-    });
-
-    expect(saveReceiptMock).not.toHaveBeenCalled();
-    expect(result.current.downloaded).toBe(false);
   });
 
   it("runs a mocked (god-mode) download through a real save target but writes no receipt", async () => {

--- a/services/vault/src/hooks/deposit/__tests__/useArtifactDownload.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useArtifactDownload.test.tsx
@@ -275,11 +275,12 @@ describe("useArtifactDownload — prime then fetch", () => {
     expect(saveReceiptMock).not.toHaveBeenCalled();
   });
 
-  it("never writes a receipt on the anchor-download fallback", async () => {
+  it("reports the anchor-download fallback as delivered, never downloaded", async () => {
     // That path only proves a link was clicked — the browser reports nothing
     // about whether the file reached disk, and it may have been blocked or
-    // the save dialog dismissed. The file is shown as delivered, but the
-    // activation gate stays unsatisfied because there is no evidence.
+    // the save dialog dismissed. `downloaded` is what the activation gate
+    // reads, so it must stay false; `delivered` carries the "we handed the
+    // browser a file but cannot confirm it" state the card renders.
     seedHotCache();
     fetchMock.mockResolvedValueOnce(FALLBACK_OUTCOME);
 
@@ -291,7 +292,8 @@ describe("useArtifactDownload — prime then fetch", () => {
       await result.current.download(PROVIDER_ADDRESS, PEGIN_TXID, DEPOSITOR_PK);
     });
 
-    await waitFor(() => expect(result.current.downloaded).toBe(true));
+    await waitFor(() => expect(result.current.delivered).toBe(true));
+    expect(result.current.downloaded).toBe(false);
     expect(saveReceiptMock).not.toHaveBeenCalled();
   });
 
@@ -299,8 +301,8 @@ describe("useArtifactDownload — prime then fetch", () => {
     // The mock drives the real validator and file sink, so it opens a save
     // target like any download. What it must never do is satisfy the risk-ack
     // gate: the file it wrote is synthetic, so mocking a download on a real
-    // vault must not leave that vault looking recoverable. It still shows the
-    // downloaded UI so the demo flow can be exercised.
+    // vault must not leave that vault looking recoverable, so it reports
+    // `delivered` (which drives the UI) and never `downloaded`.
     demoEnabledMock.mockReturnValue(true);
     demoFetchMock.mockResolvedValueOnce(undefined);
 
@@ -312,7 +314,8 @@ describe("useArtifactDownload — prime then fetch", () => {
       await result.current.download(PROVIDER_ADDRESS, PEGIN_TXID, DEPOSITOR_PK);
     });
 
-    await waitFor(() => expect(result.current.downloaded).toBe(true));
+    await waitFor(() => expect(result.current.delivered).toBe(true));
+    expect(result.current.downloaded).toBe(false);
     expect(demoFetchMock).toHaveBeenCalledTimes(1);
     expect(demoFetchMock).toHaveBeenCalledWith(
       SAVE_TARGET,

--- a/services/vault/src/hooks/deposit/useArtifactDownload.ts
+++ b/services/vault/src/hooks/deposit/useArtifactDownload.ts
@@ -54,12 +54,6 @@ interface ArtifactDownloadState {
   progress: string;
   error: string | null;
   downloaded: boolean;
-  /**
-   * True after a fallback (anchor) download fired. That path gives no
-   * save/cancel signal from the browser, so the receipt is withheld until the
-   * user confirms via `confirmSaved`.
-   */
-  awaitingSaveConfirmation: boolean;
   /** Bytes received so far from the in-flight artifact stream. */
   receivedBytes: number;
   /**
@@ -75,16 +69,9 @@ const INITIAL_STATE: ArtifactDownloadState = {
   progress: "",
   error: null,
   downloaded: false,
-  awaitingSaveConfirmation: false,
   receivedBytes: 0,
   totalBytes: 0,
 };
-
-/** A validated, saved bundle waiting to be turned into a stored receipt. */
-interface PendingReceipt {
-  peginTxid: string;
-  outcome: ArtifactDownloadOutcome;
-}
 
 interface PrimeContext {
   vaultId: Hex;
@@ -134,17 +121,13 @@ export function useArtifactDownload(options?: {
   // instead of letting it run to completion in the background.
   const abortControllerRef = useRef<AbortController | null>(null);
 
-  // Held outside React state so `confirmSaved` can persist it without a
-  // side effect inside a state updater.
-  const pendingReceiptRef = useRef<PendingReceipt | null>(null);
-
   /**
    * Turn a completed download into the stored receipt that the activation
    * gate reads. Only ever called with an outcome from a validated, saved
    * bundle — never from a fetch that merely resolved.
    */
   const persistReceipt = useCallback(
-    ({ peginTxid, outcome }: PendingReceipt) => {
+    (peginTxid: string, outcome: ArtifactDownloadOutcome) => {
       if (!vaultId) return;
       // Milestone only on the first real download — re-downloads are a
       // routine user action, not funnel progress.
@@ -197,7 +180,6 @@ export function useArtifactDownload(options?: {
       const isStale = () =>
         abortController.signal.aborted ||
         abortControllerRef.current !== abortController;
-      pendingReceiptRef.current = null;
       setState({
         ...INITIAL_STATE,
         loading: true,
@@ -408,15 +390,18 @@ export function useArtifactDownload(options?: {
           }
 
           if (outcome.method === "browser-download") {
-            // The anchor path gives no save/cancel signal, so the file may or
-            // may not have reached disk. Hold the receipt until the user says
-            // it did — see `confirmSaved`.
-            pendingReceiptRef.current = { peginTxid, outcome };
-            setState({ ...INITIAL_STATE, awaitingSaveConfirmation: true });
+            // The anchor path only proves a link was clicked: the browser
+            // reports nothing about whether the file reached disk, and it may
+            // have been blocked or the save dialog dismissed. Asking the user
+            // to attest would let a click satisfy the activation gate, which
+            // is the exact substitution this flow exists to remove. Show the
+            // file as delivered, but withhold the receipt so the vault keeps
+            // warning until there is real evidence.
+            setState({ ...INITIAL_STATE, downloaded: true });
             return;
           }
 
-          persistReceipt({ peginTxid, outcome });
+          persistReceipt(peginTxid, outcome);
           setState({
             ...INITIAL_STATE,
             downloaded: true,
@@ -527,27 +512,12 @@ export function useArtifactDownload(options?: {
 
   const cancel = useCallback(() => {
     abortControllerRef.current?.abort();
-    pendingReceiptRef.current = null;
     setState(INITIAL_STATE);
   }, []);
-
-  /**
-   * Record that the user saved the file on a browser that cannot tell us
-   * itself. Attestation is weaker evidence than a confirmed write, but on the
-   * anchor-download path it is the only evidence available.
-   */
-  const confirmSaved = useCallback(() => {
-    const pending = pendingReceiptRef.current;
-    if (!pending) return;
-    pendingReceiptRef.current = null;
-    persistReceipt(pending);
-    setState({ ...INITIAL_STATE, downloaded: true });
-  }, [persistReceipt]);
 
   return {
     ...state,
     download,
     cancel,
-    confirmSaved,
   };
 }

--- a/services/vault/src/hooks/deposit/useArtifactDownload.ts
+++ b/services/vault/src/hooks/deposit/useArtifactDownload.ts
@@ -53,7 +53,18 @@ interface ArtifactDownloadState {
   loading: boolean;
   progress: string;
   error: string | null;
+  /**
+   * A validated bundle reached disk and a receipt was written. This is the
+   * only success signal the activation gate accepts, so it must never be set
+   * from a path that cannot prove the file was saved.
+   */
   downloaded: boolean;
+  /**
+   * The file was handed to the browser but we cannot prove it was saved (the
+   * anchor fallback, or a mocked download). Drives the card's "we can't
+   * confirm this" state and nothing else — it must never satisfy the gate.
+   */
+  delivered: boolean;
   /** Bytes received so far from the in-flight artifact stream. */
   receivedBytes: number;
   /**
@@ -69,6 +80,7 @@ const INITIAL_STATE: ArtifactDownloadState = {
   progress: "",
   error: null,
   downloaded: false,
+  delivered: false,
   receivedBytes: 0,
   totalBytes: 0,
 };
@@ -383,24 +395,27 @@ export function useArtifactDownload(options?: {
 
           // No outcome means a mocked download: nothing was validated and no
           // file was written, so it must not satisfy the real activation gate.
-          // The demo still shows the downloaded UI.
+          // `delivered` drives the demo UI without ever claiming proof.
           if (!outcome) {
-            setState({ ...INITIAL_STATE, downloaded: true });
+            setState({ ...INITIAL_STATE, delivered: true });
             return;
           }
 
           if (outcome.method === "browser-download") {
             // The anchor path only proves a link was clicked: the browser
             // reports nothing about whether the file reached disk, and it may
-            // have been blocked or the save dialog dismissed. Asking the user
-            // to attest would let a click satisfy the activation gate, which
-            // is the exact substitution this flow exists to remove. Show the
-            // file as delivered, but withhold the receipt so the vault keeps
-            // warning until there is real evidence.
-            setState({ ...INITIAL_STATE, downloaded: true });
+            // have been blocked or the save dialog dismissed. So this reports
+            // `delivered`, not `downloaded` — the card says the save could not
+            // be confirmed, the risk acknowledgement stays required, and the
+            // vault keeps warning until there is real evidence. Setting
+            // `downloaded` here would let a click satisfy the activation gate,
+            // which is the exact substitution this flow exists to remove.
+            setState({ ...INITIAL_STATE, delivered: true });
             return;
           }
 
+          // The one path with real evidence: validated, streamed to a file the
+          // user chose, and receipted.
           persistReceipt(peginTxid, outcome);
           setState({
             ...INITIAL_STATE,

--- a/services/vault/src/hooks/deposit/useArtifactDownload.ts
+++ b/services/vault/src/hooks/deposit/useArtifactDownload.ts
@@ -24,11 +24,19 @@ import {
 import { isPreDepositorSignaturesError } from "@/models/peginStateMachine";
 import {
   ArtifactDownloadCancelledError,
+  type ArtifactDownloadOutcome,
+  ArtifactDownloadTooLargeError,
+  ArtifactFileAccessError,
+  type ArtifactSaveTarget,
   fetchAndDownloadArtifacts,
+  type FetchArtifactsOptions,
+  openArtifactSaveTarget,
 } from "@/services/artifacts";
 import {
+  ARTIFACT_RECEIPT_VERSION,
   hasArtifactsDownloaded,
-  markArtifactsDownloaded,
+  normalizePeginTxid,
+  saveArtifactDownloadReceipt,
 } from "@/utils/artifactDownloadStorage";
 
 const ARTIFACT_RETRY_INTERVAL_MS = 10_000;
@@ -46,6 +54,12 @@ interface ArtifactDownloadState {
   progress: string;
   error: string | null;
   downloaded: boolean;
+  /**
+   * True after a fallback (anchor) download fired. That path gives no
+   * save/cancel signal from the browser, so the receipt is withheld until the
+   * user confirms via `confirmSaved`.
+   */
+  awaitingSaveConfirmation: boolean;
   /** Bytes received so far from the in-flight artifact stream. */
   receivedBytes: number;
   /**
@@ -61,9 +75,16 @@ const INITIAL_STATE: ArtifactDownloadState = {
   progress: "",
   error: null,
   downloaded: false,
+  awaitingSaveConfirmation: false,
   receivedBytes: 0,
   totalBytes: 0,
 };
+
+/** A validated, saved bundle waiting to be turned into a stored receipt. */
+interface PendingReceipt {
+  peginTxid: string;
+  outcome: ArtifactDownloadOutcome;
+}
 
 interface PrimeContext {
   vaultId: Hex;
@@ -113,8 +134,59 @@ export function useArtifactDownload(options?: {
   // instead of letting it run to completion in the background.
   const abortControllerRef = useRef<AbortController | null>(null);
 
+  // Held outside React state so `confirmSaved` can persist it without a
+  // side effect inside a state updater.
+  const pendingReceiptRef = useRef<PendingReceipt | null>(null);
+
+  /**
+   * Turn a completed download into the stored receipt that the activation
+   * gate reads. Only ever called with an outcome from a validated, saved
+   * bundle — never from a fetch that merely resolved.
+   */
+  const persistReceipt = useCallback(
+    ({ peginTxid, outcome }: PendingReceipt) => {
+      if (!vaultId) return;
+      // Milestone only on the first real download — re-downloads are a
+      // routine user action, not funnel progress.
+      const firstDownload = !hasArtifactsDownloaded(vaultId, peginTxid);
+      saveArtifactDownloadReceipt(vaultId, {
+        version: ARTIFACT_RECEIPT_VERSION,
+        peginTxid: normalizePeginTxid(peginTxid),
+        filename: outcome.filename,
+        byteLength: outcome.byteLength,
+        sha256: outcome.sha256,
+        savedAt: Date.now(),
+        method: outcome.method,
+      });
+      if (firstDownload) {
+        logger.event(TELEMETRY_EVENT.ACTIVATION_ARTIFACTS_DOWNLOADED, {
+          level: "info",
+          category: "activation",
+          tags: { vaultId: shortId(vaultId) },
+        });
+      }
+    },
+    [vaultId],
+  );
+
   const download = useCallback(
     async (providerAddress: string, peginTxid: string, depositorPk: string) => {
+      // Dev/QA-only simulation of the artifact fetch (never reaches a VP),
+      // so the dialogs' progress states can be exercised. Opted into via the
+      // god-mode panel's "Mock artifact download" toggle; off in production
+      // builds, where the god-mode gate is compile-time false.
+      const demoDownload = isArtifactDownloadDemoEnabled();
+
+      // DO NOT REORDER: showSaveFilePicker() requires transient user
+      // activation, which any preceding `await` destroys. Opening the save
+      // target has to be the first thing this handler does, while the click
+      // that triggered it is still the active gesture. The promise is awaited
+      // further down, once the synchronous setup is out of the way.
+      //
+      // The demo path opens a real save target too — it writes a real (if
+      // synthetic) file through the real pipeline, and only skips the network.
+      const saveTargetPromise = openArtifactSaveTarget(peginTxid);
+
       // Each invocation owns its controller, and staleness is derived from
       // it rather than a shared flag: a cancelled flow parked in a
       // non-abortable await (wallet prime, retry sleep) stays permanently
@@ -125,10 +197,13 @@ export function useArtifactDownload(options?: {
       const isStale = () =>
         abortController.signal.aborted ||
         abortControllerRef.current !== abortController;
+      pendingReceiptRef.current = null;
       setState({
         ...INITIAL_STATE,
         loading: true,
-        progress: COPY.deposit.recoveryArtifacts.fetchingArtifacts,
+        // The save dialog is already open at this point, so the first status
+        // the user sees names it rather than the fetch behind it.
+        progress: COPY.deposit.recoveryArtifacts.choosingSaveLocation,
       });
 
       const normalizedPeginTxid = stripHexPrefix(peginTxid);
@@ -138,15 +213,6 @@ export function useArtifactDownload(options?: {
       // deposit and is public on-chain data (shortened before emission anyway).
       const telemetryVaultId = vaultId ?? normalizedPeginTxid;
 
-      // Dev/QA-only simulation of the artifact fetch (never reaches a VP),
-      // so the dialogs' progress states can be exercised. Opted into via the
-      // god-mode panel's "Mock artifact download" toggle; off in production
-      // builds, where the god-mode gate is compile-time false.
-      const demoDownload = isArtifactDownloadDemoEnabled();
-      const fetchArtifacts = demoDownload
-        ? demoFetchAndDownloadArtifacts
-        : fetchAndDownloadArtifacts;
-
       // Stop the flow with an error message. Used by every fail path
       // below so the rendered modal state stays consistent.
       const setError = (message: string) =>
@@ -154,6 +220,56 @@ export function useArtifactDownload(options?: {
           ...INITIAL_STATE,
           error: message,
         });
+
+      // Resolve the save location before priming, so the user answers the
+      // file dialog and the wallet prompt in that order rather than both at
+      // once.
+      let saveTarget: ArtifactSaveTarget;
+      try {
+        saveTarget = await saveTargetPromise;
+      } catch (err) {
+        if (err instanceof ArtifactDownloadCancelledError) {
+          setState(INITIAL_STATE);
+          return;
+        }
+        if (isStale()) return;
+        captureFunnelFailure(
+          TELEMETRY_STAGE.ACTIVATION_ARTIFACTS,
+          err,
+          telemetryVaultId,
+          { tags: { site: "save_target" } },
+        );
+        setError(
+          err instanceof Error
+            ? err.message
+            : COPY.deposit.recoveryArtifacts.fileAccessDenied,
+        );
+        return;
+      }
+      if (isStale()) return;
+      setState((prev) => ({
+        ...prev,
+        progress: COPY.deposit.recoveryArtifacts.fetchingArtifacts,
+      }));
+
+      // The demo yields no outcome, which is what keeps a simulated download
+      // from ever writing the receipt that satisfies the activation gate.
+      const runDownload = (
+        fetchOptions: FetchArtifactsOptions,
+      ): Promise<ArtifactDownloadOutcome | null> =>
+        demoDownload
+          ? demoFetchAndDownloadArtifacts(
+              saveTarget,
+              { peginTxid: normalizedPeginTxid, depositorPk },
+              fetchOptions,
+            ).then(() => null)
+          : fetchAndDownloadArtifacts(
+              providerAddress,
+              peginTxid,
+              depositorPk,
+              saveTarget,
+              fetchOptions,
+            );
 
       // Ensure the bearer is in cache before any artifact request. The
       // RPC is auth-gated server-side (AUTH_GATED_METHODS), so a
@@ -268,7 +384,7 @@ export function useArtifactDownload(options?: {
         if (isStale()) return;
 
         try {
-          await fetchArtifacts(providerAddress, peginTxid, depositorPk, {
+          const outcome = await runDownload({
             onProgress: (receivedBytes, totalBytes) => {
               // Drop progress events that arrive after cancel — they would
               // otherwise re-show the bar after the UI has reset.
@@ -282,23 +398,25 @@ export function useArtifactDownload(options?: {
           });
 
           if (isStale()) return;
-          // A mocked download never wrote a real artifact file, so it must not
-          // persist the real risk-ack gate — otherwise a demo "download" on a
-          // real vault permanently satisfies its gate with no file saved. The
-          // demo still shows the downloaded UI via `downloaded: true` below.
-          if (vaultId && !demoDownload) {
-            // Milestone only on the first real download — re-downloads are a
-            // routine user action, not funnel progress.
-            const firstDownload = !hasArtifactsDownloaded(vaultId);
-            markArtifactsDownloaded(vaultId);
-            if (firstDownload) {
-              logger.event(TELEMETRY_EVENT.ACTIVATION_ARTIFACTS_DOWNLOADED, {
-                level: "info",
-                category: "activation",
-                tags: { vaultId: shortId(vaultId) },
-              });
-            }
+
+          // No outcome means a mocked download: nothing was validated and no
+          // file was written, so it must not satisfy the real activation gate.
+          // The demo still shows the downloaded UI.
+          if (!outcome) {
+            setState({ ...INITIAL_STATE, downloaded: true });
+            return;
           }
+
+          if (outcome.method === "browser-download") {
+            // The anchor path gives no save/cancel signal, so the file may or
+            // may not have reached disk. Hold the receipt until the user says
+            // it did — see `confirmSaved`.
+            pendingReceiptRef.current = { peginTxid, outcome };
+            setState({ ...INITIAL_STATE, awaitingSaveConfirmation: true });
+            return;
+          }
+
+          persistReceipt({ peginTxid, outcome });
           setState({
             ...INITIAL_STATE,
             downloaded: true,
@@ -307,6 +425,29 @@ export function useArtifactDownload(options?: {
         } catch (err) {
           if (err instanceof ArtifactDownloadCancelledError) return;
           if (isStale()) return;
+
+          // Terminal by nature: neither re-priming nor waiting changes a
+          // refused file handle or a body too large for this browser.
+          if (err instanceof ArtifactDownloadTooLargeError) {
+            captureFunnelFailure(
+              TELEMETRY_STAGE.ACTIVATION_ARTIFACTS,
+              err,
+              telemetryVaultId,
+              { tags: { site: "too_large" } },
+            );
+            setError(COPY.deposit.recoveryArtifacts.tooLargeForBrowser);
+            return;
+          }
+          if (err instanceof ArtifactFileAccessError) {
+            captureFunnelFailure(
+              TELEMETRY_STAGE.ACTIVATION_ARTIFACTS,
+              err,
+              telemetryVaultId,
+              { tags: { site: "file_sink" } },
+            );
+            setError(err.message);
+            return;
+          }
 
           if (isPreDepositorSignaturesError(err)) {
             stillProcessingAttempts += 1;
@@ -381,17 +522,32 @@ export function useArtifactDownload(options?: {
         }
       }
     },
-    [vaultId, primeContext],
+    [vaultId, primeContext, persistReceipt],
   );
 
   const cancel = useCallback(() => {
     abortControllerRef.current?.abort();
+    pendingReceiptRef.current = null;
     setState(INITIAL_STATE);
   }, []);
+
+  /**
+   * Record that the user saved the file on a browser that cannot tell us
+   * itself. Attestation is weaker evidence than a confirmed write, but on the
+   * anchor-download path it is the only evidence available.
+   */
+  const confirmSaved = useCallback(() => {
+    const pending = pendingReceiptRef.current;
+    if (!pending) return;
+    pendingReceiptRef.current = null;
+    persistReceipt(pending);
+    setState({ ...INITIAL_STATE, downloaded: true });
+  }, [persistReceipt]);
 
   return {
     ...state,
     download,
     cancel,
+    confirmSaved,
   };
 }

--- a/services/vault/src/services/artifacts/__tests__/artifactBinding.test.ts
+++ b/services/vault/src/services/artifacts/__tests__/artifactBinding.test.ts
@@ -1,0 +1,149 @@
+import { VpResponseValidationError } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
+import { describe, expect, it } from "vitest";
+
+import { assertBundleBoundToVault } from "../artifactBinding";
+
+const PEGIN_TXID =
+  "f545b4a379becea9bd3ed30809c6b568e4035217391791d5408150b15023d64c";
+const DEPOSITOR_PK =
+  "3f8f4496a7367a7c3fe78f95c084578b228e20325697cfe423936b905f7ac062";
+const LOCAL_CHALLENGER = "a0".repeat(32);
+const UNIVERSAL_CHALLENGER = "47".repeat(32);
+const FOREIGN_TXID = "ff".repeat(32);
+
+const BINDING = { peginTxid: PEGIN_TXID, depositorPk: DEPOSITOR_PK };
+const SESSION_KEYS = [LOCAL_CHALLENGER, UNIVERSAL_CHALLENGER];
+
+/**
+ * Mirrors the shape of a real vault-devnet tx graph: claim and payout each
+ * spend an output of the pegin transaction, and the challenger set is split
+ * into local and universal.
+ */
+function txGraph(overrides: Record<string, unknown> = {}) {
+  const spend = (txid: string, vout: number) => ({
+    tx: { input: [{ previous_output: `${txid}:${vout}` }] },
+  });
+  return {
+    claim_tx: spend(PEGIN_TXID, 1),
+    payout_tx: spend(PEGIN_TXID, 0),
+    depositor_pubkey: DEPOSITOR_PK,
+    challenger_pubkeys: {
+      local: [LOCAL_CHALLENGER],
+      universal: [UNIVERSAL_CHALLENGER],
+    },
+    ...overrides,
+  };
+}
+
+describe("assertBundleBoundToVault", () => {
+  it("accepts a bundle whose graph matches the requested deposit", () => {
+    expect(() =>
+      assertBundleBoundToVault(txGraph(), SESSION_KEYS, BINDING),
+    ).not.toThrow();
+  });
+
+  it("accepts a pegin txid supplied with an 0x prefix and mixed case", () => {
+    expect(() =>
+      assertBundleBoundToVault(txGraph(), SESSION_KEYS, {
+        peginTxid: `0x${PEGIN_TXID.toUpperCase()}`,
+        depositorPk: `0x${DEPOSITOR_PK.toUpperCase()}`,
+      }),
+    ).not.toThrow();
+  });
+
+  it("rejects a graph whose claim_tx spends a different pegin", () => {
+    const graph = txGraph({
+      claim_tx: { tx: { input: [{ previous_output: `${FOREIGN_TXID}:1` }] } },
+    });
+
+    expect(() =>
+      assertBundleBoundToVault(graph, SESSION_KEYS, BINDING),
+    ).toThrow(VpResponseValidationError);
+  });
+
+  it("rejects a graph whose payout_tx spends a different pegin", () => {
+    const graph = txGraph({
+      payout_tx: { tx: { input: [{ previous_output: `${FOREIGN_TXID}:0` }] } },
+    });
+
+    expect(() =>
+      assertBundleBoundToVault(graph, SESSION_KEYS, BINDING),
+    ).toThrow(VpResponseValidationError);
+  });
+
+  it("rejects a bundle built for a different depositor", () => {
+    const graph = txGraph({ depositor_pubkey: "cc".repeat(32) });
+
+    expect(() =>
+      assertBundleBoundToVault(graph, SESSION_KEYS, BINDING),
+    ).toThrow(VpResponseValidationError);
+  });
+
+  it("rejects a session set missing one of the graph's challengers", () => {
+    // Undersupply leaves the depositor without recovery material for an
+    // active challenger, which is the asymmetric failure that matters.
+    expect(() =>
+      assertBundleBoundToVault(txGraph(), [LOCAL_CHALLENGER], BINDING),
+    ).toThrow(VpResponseValidationError);
+  });
+
+  it("rejects a session keyed by a challenger the graph does not name", () => {
+    expect(() =>
+      assertBundleBoundToVault(
+        txGraph(),
+        [...SESSION_KEYS, "de".repeat(32)],
+        BINDING,
+      ),
+    ).toThrow(VpResponseValidationError);
+  });
+
+  it("rejects a challenger claimed as both local and universal", () => {
+    const graph = txGraph({
+      challenger_pubkeys: {
+        local: [LOCAL_CHALLENGER],
+        universal: [LOCAL_CHALLENGER],
+      },
+    });
+
+    expect(() =>
+      assertBundleBoundToVault(graph, [LOCAL_CHALLENGER], BINDING),
+    ).toThrow(VpResponseValidationError);
+  });
+
+  it.each([
+    ["claim_tx", { claim_tx: undefined }],
+    ["payout_tx", { payout_tx: undefined }],
+    ["depositor_pubkey", { depositor_pubkey: undefined }],
+    ["challenger_pubkeys", { challenger_pubkeys: undefined }],
+  ])("rejects a graph missing %s", (_field, overrides) => {
+    expect(() =>
+      assertBundleBoundToVault(txGraph(overrides), SESSION_KEYS, BINDING),
+    ).toThrow(VpResponseValidationError);
+  });
+
+  it("rejects a transaction with no inputs", () => {
+    const graph = txGraph({ claim_tx: { tx: { input: [] } } });
+
+    expect(() =>
+      assertBundleBoundToVault(graph, SESSION_KEYS, BINDING),
+    ).toThrow(VpResponseValidationError);
+  });
+
+  it("matches the pegin on any input, not only the first", () => {
+    // Guards against a false reject if input ordering ever changes.
+    const graph = txGraph({
+      claim_tx: {
+        tx: {
+          input: [
+            { previous_output: `${FOREIGN_TXID}:3` },
+            { previous_output: `${PEGIN_TXID}:1` },
+          ],
+        },
+      },
+    });
+
+    expect(() =>
+      assertBundleBoundToVault(graph, SESSION_KEYS, BINDING),
+    ).not.toThrow();
+  });
+});

--- a/services/vault/src/services/artifacts/__tests__/artifactDownloadService.test.ts
+++ b/services/vault/src/services/artifacts/__tests__/artifactDownloadService.test.ts
@@ -642,6 +642,30 @@ describe("fetchAndDownloadArtifacts", () => {
       expect(discard).toHaveBeenCalledTimes(1);
     });
 
+    it("discards the writable when the final commit fails", async () => {
+      // A rejected close leaves the transaction open, so its temporary file
+      // would otherwise linger until the browser reclaims it.
+      vi.mocked(fetch).mockResolvedValueOnce(
+        streamingResponse(validEnvelope()),
+      );
+      const { target, commit, discard } = fakeSaveTarget();
+      commit.mockRejectedValueOnce(
+        new ArtifactFileAccessError("close failed", {
+          cause: new Error("EIO"),
+        }),
+      );
+
+      await expect(
+        fetchAndDownloadArtifacts(
+          PROVIDER_ADDRESS,
+          PEGIN_TXID,
+          DEPOSITOR_PK,
+          target,
+        ),
+      ).rejects.toBeInstanceOf(ArtifactFileAccessError);
+      expect(discard).toHaveBeenCalledTimes(1);
+    });
+
     it("surfaces a write failure and discards the partial file", async () => {
       vi.mocked(fetch).mockResolvedValueOnce(
         streamingResponse(validEnvelope()),

--- a/services/vault/src/services/artifacts/__tests__/artifactDownloadService.test.ts
+++ b/services/vault/src/services/artifacts/__tests__/artifactDownloadService.test.ts
@@ -489,7 +489,9 @@ describe("fetchAndDownloadArtifacts", () => {
       // Padding past the old 4096-byte threshold used to route an error
       // envelope down the unvalidated large-payload branch, which also cost
       // the caller its auth-expired retry (that only triggers on
-      // JsonRpcError). Size no longer changes the verdict.
+      // JsonRpcError). Padding no longer changes the verdict below the
+      // error-value cap; past that cap we fail closed instead — see the
+      // oversized-error test below.
       vi.mocked(fetch).mockResolvedValueOnce(
         streamingResponse(
           JSON.stringify({

--- a/services/vault/src/services/artifacts/__tests__/artifactDownloadService.test.ts
+++ b/services/vault/src/services/artifacts/__tests__/artifactDownloadService.test.ts
@@ -2,16 +2,22 @@ import {
   JsonRpcError,
   VpResponseValidationError,
 } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
+import { sha256 } from "@noble/hashes/sha2.js";
+import { bytesToHex } from "@noble/hashes/utils.js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/utils/rpc", () => ({
   getVpProxyUrl: (address: string) => `https://proxy.example.com/vp/${address}`,
 }));
 
+import { fetchAndDownloadArtifacts } from "../artifactDownloadService";
+import type { ArtifactSaveTarget } from "../artifactSaveTarget";
+import { openArtifactSaveTarget } from "../artifactSaveTarget";
 import {
   ArtifactDownloadCancelledError,
-  fetchAndDownloadArtifacts,
-} from "../artifactDownloadService";
+  ArtifactDownloadTooLargeError,
+  ArtifactFileAccessError,
+} from "../errors";
 
 const PROVIDER_ADDRESS = "0x0000000000000000000000000000000000000000";
 const PEGIN_TXID =
@@ -21,28 +27,49 @@ const DEPOSITOR_PK =
 const CHALLENGER_PUBKEY =
   "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
 
+/**
+ * Mirrors a real bundle's tx graph: claim and payout spend outputs of the
+ * requested pegin, and the challenger set matches the supplied sessions.
+ * Without this the bundle is schema-valid but unbound, which the service
+ * now rejects.
+ */
+function txGraphJson(
+  overrides: Record<string, unknown> = {},
+  peginTxid = PEGIN_TXID,
+): string {
+  const spend = (vout: number) => ({
+    tx: { input: [{ previous_output: `${peginTxid}:${vout}` }] },
+  });
+  return JSON.stringify({
+    claim_tx: spend(1),
+    payout_tx: spend(0),
+    depositor_pubkey: DEPOSITOR_PK,
+    challenger_pubkeys: { local: [CHALLENGER_PUBKEY], universal: [] },
+    ...overrides,
+  });
+}
+
 const VALID_ARTIFACT_RESULT = {
-  tx_graph_json: "{}",
+  tx_graph_json: txGraphJson(),
   verifying_key_hex: "aabb",
   babe_sessions: {
     [CHALLENGER_PUBKEY]: { decryptor_artifacts_hex: "ccdd" },
   },
 };
 
-function responseFor(body: unknown): Response {
-  return new Response(JSON.stringify(body), {
-    status: 200,
-    headers: { "Content-Type": "application/json" },
+function validEnvelope(): string {
+  return JSON.stringify({
+    jsonrpc: "2.0",
+    result: VALID_ARTIFACT_RESULT,
+    id: 1,
   });
 }
 
 /**
- * Build a Response backed by a real ReadableStream so the streaming path
- * (readBodyWithProgress) is exercised, with Content-Length present only when
- * asked. A stream body never auto-populates Content-Length, which lets us
- * test the header-absent fallback deterministically. `chunkSizeBytes` splits
- * the body across multiple stream chunks (default: one chunk) so multi-chunk
- * assembly paths can be exercised.
+ * Build a Response backed by a real ReadableStream, with Content-Length only
+ * when asked. A stream body never auto-populates the header, which is what
+ * lets the header-absent fallback be tested deterministically.
+ * `chunkSizeBytes` splits the body so multi-chunk paths are exercised.
  */
 function streamingResponse(
   body: string,
@@ -68,502 +95,655 @@ function streamingResponse(
   return new Response(stream, { status: 200, headers });
 }
 
-describe("fetchAndDownloadArtifacts", () => {
-  const triggerDownloadSpy = vi.fn();
+/** A Response whose stream ends early, as a destroyed connection would. */
+function truncatedResponse(body: string, keepBytes: number): Response {
+  const bytes = new TextEncoder().encode(body).subarray(0, keepBytes);
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(bytes);
+      controller.close();
+    },
+  });
+  return new Response(stream, { status: 200 });
+}
 
+/** Records everything the service does to its save target. */
+function fakeSaveTarget(
+  overrides: Partial<Pick<ArtifactSaveTarget, "method" | "maxBytes">> = {},
+) {
+  const written: Uint8Array[] = [];
+  const write = vi.fn(async (chunk: Uint8Array<ArrayBuffer>) => {
+    written.push(chunk);
+  });
+  const commit = vi.fn(async () => undefined);
+  const discard = vi.fn(async () => undefined);
+  const target: ArtifactSaveTarget = {
+    method: "file-system-access",
+    filename: "babylon-vault-artifacts-aaaaaaaa.json",
+    maxBytes: Number.POSITIVE_INFINITY,
+    open: vi.fn(async () => ({ write, commit, discard })),
+    ...overrides,
+  };
+  const savedBytes = () =>
+    new Uint8Array(written.flatMap((chunk) => Array.from(chunk)));
+  return { target, write, commit, discard, savedBytes };
+}
+
+describe("fetchAndDownloadArtifacts", () => {
   beforeEach(() => {
     vi.stubGlobal("fetch", vi.fn());
-
-    // Spy on the DOM bits that triggerBlobDownload uses so we can assert
-    // whether a download was actually triggered without writing a file.
-    const anchor = document.createElement("a");
-    anchor.click = triggerDownloadSpy;
-    vi.spyOn(document, "createElement").mockReturnValue(anchor);
-    vi.spyOn(document.body, "appendChild").mockImplementation(
-      (node) => node as Node,
-    );
-    vi.spyOn(document.body, "removeChild").mockImplementation(
-      (node) => node as Node,
-    );
-    vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:mock");
-    vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => undefined);
   });
 
   afterEach(() => {
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
-    triggerDownloadSpy.mockReset();
   });
 
-  it("triggers download after successful validation", async () => {
-    vi.mocked(fetch).mockResolvedValueOnce(
-      responseFor({ jsonrpc: "2.0", result: VALID_ARTIFACT_RESULT, id: 1 }),
-    );
+  describe("a valid response", () => {
+    it("writes the whole body and commits it", async () => {
+      const body = validEnvelope();
+      vi.mocked(fetch).mockResolvedValueOnce(streamingResponse(body));
+      const { target, commit, discard, savedBytes } = fakeSaveTarget();
 
-    await fetchAndDownloadArtifacts(PROVIDER_ADDRESS, PEGIN_TXID, DEPOSITOR_PK);
+      await fetchAndDownloadArtifacts(
+        PROVIDER_ADDRESS,
+        PEGIN_TXID,
+        DEPOSITOR_PK,
+        target,
+      );
 
-    expect(triggerDownloadSpy).toHaveBeenCalledTimes(1);
-  });
-
-  it("triggers download for a large success envelope without full parsing", async () => {
-    // Above ERROR_RESPONSE_SIZE_THRESHOLD: the body is not schema-validated,
-    // but the envelope prefix is checked and looks like a JSON-RPC success.
-    const largeResult = {
-      ...VALID_ARTIFACT_RESULT,
-      verifying_key_hex: "ab".repeat(4096),
-    };
-    vi.mocked(fetch).mockResolvedValueOnce(
-      responseFor({ jsonrpc: "2.0", result: largeResult, id: 1 }),
-    );
-
-    await fetchAndDownloadArtifacts(PROVIDER_ADDRESS, PEGIN_TXID, DEPOSITOR_PK);
-
-    expect(triggerDownloadSpy).toHaveBeenCalledTimes(1);
-  });
-
-  it("triggers download for a large success envelope whose body nests error keys", async () => {
-    // The prefix scan counts only top-level envelope keys: `"error":`
-    // appearing inside the result body is artifact data, not an error
-    // envelope, and must not fail the download.
-    const largeResult = {
-      ...VALID_ARTIFACT_RESULT,
-      metadata: { error: "artifact body text, not an envelope error" },
-      padding: "x".repeat(8192),
-    };
-    vi.mocked(fetch).mockResolvedValueOnce(
-      responseFor({ jsonrpc: "2.0", result: largeResult, id: 1 }),
-    );
-
-    await fetchAndDownloadArtifacts(PROVIDER_ADDRESS, PEGIN_TXID, DEPOSITOR_PK);
-
-    expect(triggerDownloadSpy).toHaveBeenCalledTimes(1);
-  });
-
-  it("triggers download for a body larger than the validation prefix when result precedes the cut", async () => {
-    // Body exceeds PREFIX_VALIDATION_BYTES (64 KiB), so validation sees only
-    // the truncated prefix. Streaming in 10 000-byte chunks exercises the
-    // prefix-copy loop in readBodyWithProgress across chunk boundaries,
-    // including the final-chunk clamp at the 64 KiB cut. The top-level
-    // `result` key sits well before the cut, so the envelope reads as
-    // success and the full body must still download.
-    const body = JSON.stringify({
-      jsonrpc: "2.0",
-      result: {
-        ...VALID_ARTIFACT_RESULT,
-        verifying_key_hex: "ab".repeat(48 * 1024),
-      },
-      id: 1,
+      expect(new TextDecoder().decode(savedBytes())).toBe(body);
+      expect(commit).toHaveBeenCalledTimes(1);
+      expect(discard).not.toHaveBeenCalled();
     });
-    expect(new TextEncoder().encode(body).byteLength).toBeGreaterThan(
-      64 * 1024,
-    );
-    vi.mocked(fetch).mockResolvedValueOnce(
-      streamingResponse(body, { chunkSizeBytes: 10_000 }),
-    );
 
-    await fetchAndDownloadArtifacts(PROVIDER_ADDRESS, PEGIN_TXID, DEPOSITOR_PK);
+    it("returns a receipt describing what was saved", async () => {
+      const body = validEnvelope();
+      const byteLength = new TextEncoder().encode(body).byteLength;
+      vi.mocked(fetch).mockResolvedValueOnce(streamingResponse(body));
+      const { target } = fakeSaveTarget();
 
-    expect(triggerDownloadSpy).toHaveBeenCalledTimes(1);
-  });
+      const outcome = await fetchAndDownloadArtifacts(
+        PROVIDER_ADDRESS,
+        PEGIN_TXID,
+        DEPOSITOR_PK,
+        target,
+      );
 
-  it("rejects an error envelope whose top-level keys are padded past the validation prefix", async () => {
-    // Padding pushes both the top-level `result` and `error` keys past
-    // PREFIX_VALIDATION_BYTES (64 KiB), so the truncated prefix scan sees
-    // neither. Missing `result` rejects fail-closed — the padded error must
-    // not download as a successful artifact.
-    const body = JSON.stringify({
-      jsonrpc: "2.0",
-      id: 1,
-      padding: "x".repeat(80 * 1024),
-      result: null,
-      error: { code: -32011, message: "hidden past the prefix cut" },
+      expect(outcome).toEqual({
+        filename: "babylon-vault-artifacts-aaaaaaaa.json",
+        byteLength,
+        sha256: bytesToHex(sha256(new TextEncoder().encode(body))),
+        method: "file-system-access",
+      });
     });
-    vi.mocked(fetch).mockResolvedValueOnce(
-      streamingResponse(body, { chunkSizeBytes: 10_000 }),
-    );
 
-    await expect(
-      fetchAndDownloadArtifacts(PROVIDER_ADDRESS, PEGIN_TXID, DEPOSITOR_PK),
-    ).rejects.toBeInstanceOf(VpResponseValidationError);
-    expect(triggerDownloadSpy).not.toHaveBeenCalled();
-  });
-
-  it("rejects a large non-JSON payload without triggering download", async () => {
-    const garbage = "x".repeat(8192);
-    vi.mocked(fetch).mockResolvedValueOnce(
-      new Response(garbage, {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      }),
-    );
-
-    await expect(
-      fetchAndDownloadArtifacts(PROVIDER_ADDRESS, PEGIN_TXID, DEPOSITOR_PK),
-    ).rejects.toBeInstanceOf(VpResponseValidationError);
-    expect(triggerDownloadSpy).not.toHaveBeenCalled();
-  });
-
-  it("rejects a JSON-RPC error envelope padded past the size threshold", async () => {
-    // A malicious VP can pad an error past ERROR_RESPONSE_SIZE_THRESHOLD so it
-    // skips the parsed small-response path; the envelope prefix must still
-    // catch it instead of downloading it as a successful artifact.
-    vi.mocked(fetch).mockResolvedValueOnce(
-      responseFor({
+    it("reassembles a body split across many chunks", async () => {
+      const body = JSON.stringify({
         jsonrpc: "2.0",
-        error: { code: -32011, message: "x".repeat(8192) },
-        id: 1,
-      }),
-    );
-
-    await expect(
-      fetchAndDownloadArtifacts(PROVIDER_ADDRESS, PEGIN_TXID, DEPOSITOR_PK),
-    ).rejects.toBeInstanceOf(VpResponseValidationError);
-    expect(triggerDownloadSpy).not.toHaveBeenCalled();
-  });
-
-  it("rejects a large envelope missing the result field", async () => {
-    vi.mocked(fetch).mockResolvedValueOnce(
-      responseFor({ jsonrpc: "2.0", id: 1, padding: "x".repeat(8192) }),
-    );
-
-    await expect(
-      fetchAndDownloadArtifacts(PROVIDER_ADDRESS, PEGIN_TXID, DEPOSITOR_PK),
-    ).rejects.toBeInstanceOf(VpResponseValidationError);
-    expect(triggerDownloadSpy).not.toHaveBeenCalled();
-  });
-
-  it("rejects a padded error envelope that also declares result null", async () => {
-    // A malicious VP can serialize `result` before `error` so that a
-    // first-substring-wins check would classify the envelope as success.
-    // A non-null top-level error must reject regardless of key order.
-    vi.mocked(fetch).mockResolvedValueOnce(
-      responseFor({
-        jsonrpc: "2.0",
-        result: null,
-        error: { code: -32011, message: "x".repeat(8192) },
-        id: 1,
-      }),
-    );
-
-    await expect(
-      fetchAndDownloadArtifacts(PROVIDER_ADDRESS, PEGIN_TXID, DEPOSITOR_PK),
-    ).rejects.toBeInstanceOf(VpResponseValidationError);
-    expect(triggerDownloadSpy).not.toHaveBeenCalled();
-  });
-
-  it("rejects a padded envelope declaring both a result object and an error", async () => {
-    vi.mocked(fetch).mockResolvedValueOnce(
-      responseFor({
-        jsonrpc: "2.0",
-        result: VALID_ARTIFACT_RESULT,
-        error: { code: -32011, message: "x".repeat(8192) },
-        id: 1,
-      }),
-    );
-
-    await expect(
-      fetchAndDownloadArtifacts(PROVIDER_ADDRESS, PEGIN_TXID, DEPOSITOR_PK),
-    ).rejects.toBeInstanceOf(VpResponseValidationError);
-    expect(triggerDownloadSpy).not.toHaveBeenCalled();
-  });
-
-  it("rejects a padded error envelope whose body nests a result key", async () => {
-    // A nested `"result":` before the top-level `error` must not make the
-    // envelope read as success — only top-level keys count.
-    vi.mocked(fetch).mockResolvedValueOnce(
-      responseFor({
-        jsonrpc: "2.0",
-        meta: { result: "nested, not the envelope result" },
-        error: { code: -32011, message: "x".repeat(8192) },
-        id: 1,
-      }),
-    );
-
-    await expect(
-      fetchAndDownloadArtifacts(PROVIDER_ADDRESS, PEGIN_TXID, DEPOSITOR_PK),
-    ).rejects.toBeInstanceOf(VpResponseValidationError);
-    expect(triggerDownloadSpy).not.toHaveBeenCalled();
-  });
-
-  it("routes a payload at exactly the size threshold to the prefix validation path", async () => {
-    // ERROR_RESPONSE_SIZE_THRESHOLD is 4096 bytes and the size check is
-    // inclusive (>=): at exactly 4096 the parsed small-response path must
-    // not run, so an error envelope surfaces as the prefix path's
-    // VpResponseValidationError rather than a parsed JsonRpcError.
-    const errorEnvelope = (message: string) =>
-      JSON.stringify({
-        jsonrpc: "2.0",
-        error: { code: -32011, message },
+        result: {
+          ...VALID_ARTIFACT_RESULT,
+          babe_sessions: {
+            [CHALLENGER_PUBKEY]: {
+              decryptor_artifacts_hex: "ab".repeat(20_000),
+            },
+          },
+        },
         id: 1,
       });
-    const paddingLength =
-      4096 - new TextEncoder().encode(errorEnvelope("")).byteLength;
-    const body = errorEnvelope("x".repeat(paddingLength));
-    expect(new TextEncoder().encode(body).byteLength).toBe(4096);
+      vi.mocked(fetch).mockResolvedValueOnce(
+        streamingResponse(body, { chunkSizeBytes: 997 }),
+      );
+      const { target, savedBytes } = fakeSaveTarget();
 
-    vi.mocked(fetch).mockResolvedValueOnce(
-      new Response(body, {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      }),
-    );
+      await fetchAndDownloadArtifacts(
+        PROVIDER_ADDRESS,
+        PEGIN_TXID,
+        DEPOSITOR_PK,
+        target,
+      );
 
-    await expect(
-      fetchAndDownloadArtifacts(PROVIDER_ADDRESS, PEGIN_TXID, DEPOSITOR_PK),
-    ).rejects.toBeInstanceOf(VpResponseValidationError);
-    expect(triggerDownloadSpy).not.toHaveBeenCalled();
-  });
-
-  it("rejects an empty result object without triggering download", async () => {
-    vi.mocked(fetch).mockResolvedValueOnce(
-      responseFor({ jsonrpc: "2.0", result: {}, id: 1 }),
-    );
-
-    await expect(
-      fetchAndDownloadArtifacts(PROVIDER_ADDRESS, PEGIN_TXID, DEPOSITOR_PK),
-    ).rejects.toBeInstanceOf(VpResponseValidationError);
-    expect(triggerDownloadSpy).not.toHaveBeenCalled();
-  });
-
-  it("rejects empty tx_graph_json without triggering download", async () => {
-    vi.mocked(fetch).mockResolvedValueOnce(
-      responseFor({
-        jsonrpc: "2.0",
-        result: { ...VALID_ARTIFACT_RESULT, tx_graph_json: "" },
-        id: 1,
-      }),
-    );
-
-    await expect(
-      fetchAndDownloadArtifacts(PROVIDER_ADDRESS, PEGIN_TXID, DEPOSITOR_PK),
-    ).rejects.toBeInstanceOf(VpResponseValidationError);
-    expect(triggerDownloadSpy).not.toHaveBeenCalled();
-  });
-
-  it("rejects non-hex verifying_key_hex without triggering download", async () => {
-    vi.mocked(fetch).mockResolvedValueOnce(
-      responseFor({
-        jsonrpc: "2.0",
-        result: { ...VALID_ARTIFACT_RESULT, verifying_key_hex: "not-hex!" },
-        id: 1,
-      }),
-    );
-
-    await expect(
-      fetchAndDownloadArtifacts(PROVIDER_ADDRESS, PEGIN_TXID, DEPOSITOR_PK),
-    ).rejects.toBeInstanceOf(VpResponseValidationError);
-    expect(triggerDownloadSpy).not.toHaveBeenCalled();
-  });
-
-  it("rejects babe_sessions entry with non-hex decryptor_artifacts_hex without triggering download", async () => {
-    vi.mocked(fetch).mockResolvedValueOnce(
-      responseFor({
-        jsonrpc: "2.0",
-        result: {
-          ...VALID_ARTIFACT_RESULT,
-          babe_sessions: {
-            [CHALLENGER_PUBKEY]: { decryptor_artifacts_hex: "not-hex!" },
-          },
-        },
-        id: 1,
-      }),
-    );
-
-    await expect(
-      fetchAndDownloadArtifacts(PROVIDER_ADDRESS, PEGIN_TXID, DEPOSITOR_PK),
-    ).rejects.toBeInstanceOf(VpResponseValidationError);
-    expect(triggerDownloadSpy).not.toHaveBeenCalled();
-  });
-
-  it("rejects empty babe_sessions without triggering download", async () => {
-    vi.mocked(fetch).mockResolvedValueOnce(
-      responseFor({
-        jsonrpc: "2.0",
-        result: { ...VALID_ARTIFACT_RESULT, babe_sessions: {} },
-        id: 1,
-      }),
-    );
-
-    await expect(
-      fetchAndDownloadArtifacts(PROVIDER_ADDRESS, PEGIN_TXID, DEPOSITOR_PK),
-    ).rejects.toBeInstanceOf(VpResponseValidationError);
-    expect(triggerDownloadSpy).not.toHaveBeenCalled();
-  });
-
-  it("rejects babe_sessions keyed by an arbitrary non-pubkey label without triggering download", async () => {
-    vi.mocked(fetch).mockResolvedValueOnce(
-      responseFor({
-        jsonrpc: "2.0",
-        result: {
-          ...VALID_ARTIFACT_RESULT,
-          babe_sessions: {
-            attacker_label: { decryptor_artifacts_hex: "deadbeef" },
-          },
-        },
-        id: 1,
-      }),
-    );
-
-    await expect(
-      fetchAndDownloadArtifacts(PROVIDER_ADDRESS, PEGIN_TXID, DEPOSITOR_PK),
-    ).rejects.toBeInstanceOf(VpResponseValidationError);
-    expect(triggerDownloadSpy).not.toHaveBeenCalled();
-  });
-
-  it("rejects envelope missing result field", async () => {
-    vi.mocked(fetch).mockResolvedValueOnce(
-      responseFor({ jsonrpc: "2.0", id: 1 }),
-    );
-
-    await expect(
-      fetchAndDownloadArtifacts(PROVIDER_ADDRESS, PEGIN_TXID, DEPOSITOR_PK),
-    ).rejects.toBeInstanceOf(VpResponseValidationError);
-    expect(triggerDownloadSpy).not.toHaveBeenCalled();
-  });
-
-  it("rejects non-JSON payload", async () => {
-    vi.mocked(fetch).mockResolvedValueOnce(
-      new Response("not json", {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      }),
-    );
-
-    await expect(
-      fetchAndDownloadArtifacts(PROVIDER_ADDRESS, PEGIN_TXID, DEPOSITOR_PK),
-    ).rejects.toBeInstanceOf(VpResponseValidationError);
-    expect(triggerDownloadSpy).not.toHaveBeenCalled();
-  });
-
-  it("surfaces RPC error responses as JsonRpcError", async () => {
-    vi.mocked(fetch).mockResolvedValueOnce(
-      responseFor({
-        jsonrpc: "2.0",
-        error: { code: -32011, message: "Invalid state: PendingBabeSetup" },
-        id: 1,
-      }),
-    );
-
-    await expect(
-      fetchAndDownloadArtifacts(PROVIDER_ADDRESS, PEGIN_TXID, DEPOSITOR_PK),
-    ).rejects.toBeInstanceOf(JsonRpcError);
-    expect(triggerDownloadSpy).not.toHaveBeenCalled();
-  });
-
-  it("propagates wire source and structured error.data on RPC error envelopes", async () => {
-    vi.mocked(fetch).mockResolvedValueOnce(
-      responseFor({
-        jsonrpc: "2.0",
-        error: {
-          code: -32001,
-          message: "auth token expired",
-          data: { kind: "auth_expired", expiresAt: 1700000000 },
-        },
-        id: 1,
-      }),
-    );
-
-    const err = await fetchAndDownloadArtifacts(
-      PROVIDER_ADDRESS,
-      PEGIN_TXID,
-      DEPOSITOR_PK,
-    ).catch((e: unknown) => e);
-
-    expect(err).toBeInstanceOf(JsonRpcError);
-    const jsonRpcErr = err as JsonRpcError;
-    expect(jsonRpcErr.source).toBe("wire");
-    expect(jsonRpcErr.data).toEqual({
-      kind: "auth_expired",
-      expiresAt: 1700000000,
+      expect(new TextDecoder().decode(savedBytes())).toBe(body);
     });
-    expect(triggerDownloadSpy).not.toHaveBeenCalled();
-  });
 
-  it("streams the body and reports progress against Content-Length", async () => {
-    const body = JSON.stringify({
-      jsonrpc: "2.0",
-      result: VALID_ARTIFACT_RESULT,
-      id: 1,
+    it("accepts a result body that nests an error key", async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(
+        streamingResponse(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            result: {
+              ...VALID_ARTIFACT_RESULT,
+              tx_graph_json: txGraphJson({ error: "not the envelope's" }),
+            },
+            id: 1,
+          }),
+        ),
+      );
+      const { target, commit } = fakeSaveTarget();
+
+      await fetchAndDownloadArtifacts(
+        PROVIDER_ADDRESS,
+        PEGIN_TXID,
+        DEPOSITOR_PK,
+        target,
+      );
+
+      expect(commit).toHaveBeenCalledTimes(1);
     });
-    const byteLength = new TextEncoder().encode(body).byteLength;
-    vi.mocked(fetch).mockResolvedValueOnce(
-      streamingResponse(body, { withContentLength: true }),
-    );
-    const onProgress = vi.fn();
-
-    await fetchAndDownloadArtifacts(
-      PROVIDER_ADDRESS,
-      PEGIN_TXID,
-      DEPOSITOR_PK,
-      {
-        onProgress,
-      },
-    );
-
-    expect(triggerDownloadSpy).toHaveBeenCalledTimes(1);
-    // Final progress event reports the full payload against the real total.
-    expect(onProgress).toHaveBeenLastCalledWith(byteLength, byteLength);
   });
 
-  it("falls back to an estimated total when Content-Length is absent", async () => {
-    const body = JSON.stringify({
-      jsonrpc: "2.0",
-      result: VALID_ARTIFACT_RESULT,
-      id: 1,
-    });
-    const byteLength = new TextEncoder().encode(body).byteLength;
-    vi.mocked(fetch).mockResolvedValueOnce(streamingResponse(body));
-    const onProgress = vi.fn();
-
-    await fetchAndDownloadArtifacts(
-      PROVIDER_ADDRESS,
-      PEGIN_TXID,
-      DEPOSITOR_PK,
-      {
-        onProgress,
-      },
-    );
-
-    expect(triggerDownloadSpy).toHaveBeenCalledTimes(1);
-    const [received, total] = onProgress.mock.calls.at(-1)!;
-    expect(received).toBe(byteLength);
-    // No header -> total is the fixed fallback estimate, far above the tiny
-    // actual payload.
-    expect(total).toBeGreaterThan(byteLength);
-  });
-
-  it("throws the cancellation sentinel and skips download when isCancelled is set", async () => {
-    vi.mocked(fetch).mockResolvedValueOnce(
-      streamingResponse(
+  describe("invalid responses discard rather than commit", () => {
+    const cases: [name: string, body: string][] = [
+      ["non-JSON garbage", "<html>gateway timeout</html>".repeat(500)],
+      ["a missing result", JSON.stringify({ jsonrpc: "2.0", id: 1 })],
+      [
+        "an empty result",
+        JSON.stringify({ jsonrpc: "2.0", result: {}, id: 1 }),
+      ],
+      [
+        "an empty tx_graph_json",
         JSON.stringify({
           jsonrpc: "2.0",
-          result: VALID_ARTIFACT_RESULT,
+          result: { ...VALID_ARTIFACT_RESULT, tx_graph_json: "" },
           id: 1,
         }),
-        { withContentLength: true },
-      ),
-    );
+      ],
+      [
+        "a tx_graph_json that is not a JSON object",
+        JSON.stringify({
+          jsonrpc: "2.0",
+          result: { ...VALID_ARTIFACT_RESULT, tx_graph_json: "garbage" },
+          id: 1,
+        }),
+      ],
+      [
+        "a non-hex verifying_key_hex",
+        JSON.stringify({
+          jsonrpc: "2.0",
+          result: { ...VALID_ARTIFACT_RESULT, verifying_key_hex: "zzzz" },
+          id: 1,
+        }),
+      ],
+      [
+        "a non-hex decryptor_artifacts_hex",
+        JSON.stringify({
+          jsonrpc: "2.0",
+          result: {
+            ...VALID_ARTIFACT_RESULT,
+            babe_sessions: {
+              [CHALLENGER_PUBKEY]: { decryptor_artifacts_hex: "zzzz" },
+            },
+          },
+          id: 1,
+        }),
+      ],
+      [
+        "empty babe_sessions",
+        JSON.stringify({
+          jsonrpc: "2.0",
+          result: { ...VALID_ARTIFACT_RESULT, babe_sessions: {} },
+          id: 1,
+        }),
+      ],
+      [
+        "a session keyed by something other than a pubkey",
+        JSON.stringify({
+          jsonrpc: "2.0",
+          result: {
+            ...VALID_ARTIFACT_RESULT,
+            babe_sessions: { label: { decryptor_artifacts_hex: "ccdd" } },
+          },
+          id: 1,
+        }),
+      ],
+    ];
 
-    await expect(
-      fetchAndDownloadArtifacts(PROVIDER_ADDRESS, PEGIN_TXID, DEPOSITOR_PK, {
-        isCancelled: () => true,
-      }),
-    ).rejects.toBeInstanceOf(ArtifactDownloadCancelledError);
-    expect(triggerDownloadSpy).not.toHaveBeenCalled();
+    for (const [name, body] of cases) {
+      it(`rejects ${name}`, async () => {
+        vi.mocked(fetch).mockResolvedValueOnce(streamingResponse(body));
+        const { target, commit, discard } = fakeSaveTarget();
+
+        await expect(
+          fetchAndDownloadArtifacts(
+            PROVIDER_ADDRESS,
+            PEGIN_TXID,
+            DEPOSITOR_PK,
+            target,
+          ),
+        ).rejects.toBeInstanceOf(VpResponseValidationError);
+        expect(commit).not.toHaveBeenCalled();
+        expect(discard).toHaveBeenCalledTimes(1);
+      });
+    }
+
+    it("rejects a truncated stream", async () => {
+      // The proxy signals a mid-stream backend failure by destroying the
+      // connection, so a half-received bundle arrives as valid-looking bytes
+      // that simply stop. Nothing distinguishes it but the missing tail.
+      const body = validEnvelope();
+      vi.mocked(fetch).mockResolvedValueOnce(
+        truncatedResponse(body, body.length - 10),
+      );
+      const { target, commit, discard } = fakeSaveTarget();
+
+      await expect(
+        fetchAndDownloadArtifacts(
+          PROVIDER_ADDRESS,
+          PEGIN_TXID,
+          DEPOSITOR_PK,
+          target,
+        ),
+      ).rejects.toBeInstanceOf(VpResponseValidationError);
+      expect(commit).not.toHaveBeenCalled();
+      expect(discard).toHaveBeenCalledTimes(1);
+    });
+
+    it("rejects a schema-valid bundle built for a different deposit", async () => {
+      // The envelope names no deposit, so a provider can return a perfectly
+      // well-formed bundle belonging to someone else. Only the tx graph
+      // distinguishes them.
+      vi.mocked(fetch).mockResolvedValueOnce(
+        streamingResponse(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            result: {
+              ...VALID_ARTIFACT_RESULT,
+              tx_graph_json: txGraphJson({}, "ff".repeat(32)),
+            },
+            id: 1,
+          }),
+        ),
+      );
+      const { target, commit, discard } = fakeSaveTarget();
+
+      await expect(
+        fetchAndDownloadArtifacts(
+          PROVIDER_ADDRESS,
+          PEGIN_TXID,
+          DEPOSITOR_PK,
+          target,
+        ),
+      ).rejects.toBeInstanceOf(VpResponseValidationError);
+      expect(commit).not.toHaveBeenCalled();
+      expect(discard).toHaveBeenCalledTimes(1);
+    });
+
+    it("rejects a bundle whose sessions do not cover the graph's challengers", async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(
+        streamingResponse(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            result: {
+              ...VALID_ARTIFACT_RESULT,
+              tx_graph_json: txGraphJson({
+                challenger_pubkeys: {
+                  local: [CHALLENGER_PUBKEY],
+                  // Declared by the graph but never given a session, so the
+                  // depositor would be missing recovery material for it.
+                  universal: ["ee".repeat(32)],
+                },
+              }),
+            },
+            id: 1,
+          }),
+        ),
+      );
+      const { target, commit, discard } = fakeSaveTarget();
+
+      await expect(
+        fetchAndDownloadArtifacts(
+          PROVIDER_ADDRESS,
+          PEGIN_TXID,
+          DEPOSITOR_PK,
+          target,
+        ),
+      ).rejects.toBeInstanceOf(VpResponseValidationError);
+      expect(commit).not.toHaveBeenCalled();
+      expect(discard).toHaveBeenCalledTimes(1);
+    });
+
+    it("rejects a garbage body far larger than any prefix window", async () => {
+      // Previously anything at or above 4096 bytes skipped body validation
+      // entirely, so a large junk payload downloaded "successfully".
+      const body = JSON.stringify({
+        jsonrpc: "2.0",
+        result: { junk: "x".repeat(200_000) },
+        id: 1,
+      });
+      vi.mocked(fetch).mockResolvedValueOnce(streamingResponse(body));
+      const { target, commit, discard } = fakeSaveTarget();
+
+      await expect(
+        fetchAndDownloadArtifacts(
+          PROVIDER_ADDRESS,
+          PEGIN_TXID,
+          DEPOSITOR_PK,
+          target,
+        ),
+      ).rejects.toBeInstanceOf(VpResponseValidationError);
+      expect(commit).not.toHaveBeenCalled();
+      expect(discard).toHaveBeenCalledTimes(1);
+    });
   });
 
-  it("maps an aborted request to the cancellation sentinel", async () => {
-    const controller = new AbortController();
-    controller.abort();
-    vi.mocked(fetch).mockRejectedValue(
-      new DOMException("The operation was aborted.", "AbortError"),
+  describe("JSON-RPC error envelopes", () => {
+    it("surfaces RPC error responses as JsonRpcError", async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(
+        streamingResponse(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            error: { code: -32011, message: "Invalid state: PendingBabeSetup" },
+            id: 1,
+          }),
+        ),
+      );
+      const { target, commit, discard } = fakeSaveTarget();
+
+      await expect(
+        fetchAndDownloadArtifacts(
+          PROVIDER_ADDRESS,
+          PEGIN_TXID,
+          DEPOSITOR_PK,
+          target,
+        ),
+      ).rejects.toBeInstanceOf(JsonRpcError);
+      expect(commit).not.toHaveBeenCalled();
+      expect(discard).toHaveBeenCalledTimes(1);
+    });
+
+    it("propagates wire source and structured error.data", async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(
+        streamingResponse(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            error: {
+              code: -32001,
+              message: "auth token expired",
+              data: { kind: "auth_expired", expiresAt: 1700000000 },
+            },
+            id: 1,
+          }),
+        ),
+      );
+      const { target } = fakeSaveTarget();
+
+      const err = await fetchAndDownloadArtifacts(
+        PROVIDER_ADDRESS,
+        PEGIN_TXID,
+        DEPOSITOR_PK,
+        target,
+      ).catch((e: unknown) => e);
+
+      expect(err).toBeInstanceOf(JsonRpcError);
+      const jsonRpcErr = err as JsonRpcError;
+      expect(jsonRpcErr.source).toBe("wire");
+      expect(jsonRpcErr.data).toEqual({
+        kind: "auth_expired",
+        expiresAt: 1700000000,
+      });
+    });
+
+    it("surfaces a padded error envelope as JsonRpcError, not a payload", async () => {
+      // Padding past the old 4096-byte threshold used to route an error
+      // envelope down the unvalidated large-payload branch, which also cost
+      // the caller its auth-expired retry (that only triggers on
+      // JsonRpcError). Size no longer changes the verdict.
+      vi.mocked(fetch).mockResolvedValueOnce(
+        streamingResponse(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            error: {
+              code: -32001,
+              message: "auth token expired",
+              data: { kind: "auth_expired", padding: "x".repeat(10_000) },
+            },
+            id: 1,
+          }),
+        ),
+      );
+      const { target } = fakeSaveTarget();
+
+      await expect(
+        fetchAndDownloadArtifacts(
+          PROVIDER_ADDRESS,
+          PEGIN_TXID,
+          DEPOSITOR_PK,
+          target,
+        ),
+      ).rejects.toBeInstanceOf(JsonRpcError);
+    });
+
+    it("fails closed on an error object too large to be plausible", async () => {
+      // Beyond the error-value cap we stop buffering and reject outright
+      // rather than let an unbounded "error" be used as a memory sink. The
+      // download fails either way; only the error type differs.
+      vi.mocked(fetch).mockResolvedValueOnce(
+        streamingResponse(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            error: { code: -32011, message: "x".repeat(200_000) },
+            id: 1,
+          }),
+        ),
+      );
+      const { target, commit } = fakeSaveTarget();
+
+      await expect(
+        fetchAndDownloadArtifacts(
+          PROVIDER_ADDRESS,
+          PEGIN_TXID,
+          DEPOSITOR_PK,
+          target,
+        ),
+      ).rejects.toBeInstanceOf(VpResponseValidationError);
+      expect(commit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("progress reporting", () => {
+    it("reports progress against Content-Length when present", async () => {
+      const body = validEnvelope();
+      const byteLength = new TextEncoder().encode(body).byteLength;
+      vi.mocked(fetch).mockResolvedValueOnce(
+        streamingResponse(body, { withContentLength: true }),
+      );
+      const onProgress = vi.fn();
+      const { target } = fakeSaveTarget();
+
+      await fetchAndDownloadArtifacts(
+        PROVIDER_ADDRESS,
+        PEGIN_TXID,
+        DEPOSITOR_PK,
+        target,
+        { onProgress },
+      );
+
+      expect(onProgress).toHaveBeenLastCalledWith(byteLength, byteLength);
+    });
+
+    it("falls back to an estimated total when Content-Length is absent", async () => {
+      const body = validEnvelope();
+      const byteLength = new TextEncoder().encode(body).byteLength;
+      vi.mocked(fetch).mockResolvedValueOnce(streamingResponse(body));
+      const onProgress = vi.fn();
+      const { target } = fakeSaveTarget();
+
+      await fetchAndDownloadArtifacts(
+        PROVIDER_ADDRESS,
+        PEGIN_TXID,
+        DEPOSITOR_PK,
+        target,
+        { onProgress },
+      );
+
+      const [received, total] = onProgress.mock.calls.at(-1)!;
+      expect(received).toBe(byteLength);
+      expect(total).toBeGreaterThan(byteLength);
+    });
+  });
+
+  describe("cancellation", () => {
+    it("throws the sentinel and discards when isCancelled is set", async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(
+        streamingResponse(validEnvelope(), { withContentLength: true }),
+      );
+      const { target, commit, discard } = fakeSaveTarget();
+
+      await expect(
+        fetchAndDownloadArtifacts(
+          PROVIDER_ADDRESS,
+          PEGIN_TXID,
+          DEPOSITOR_PK,
+          target,
+          { isCancelled: () => true },
+        ),
+      ).rejects.toBeInstanceOf(ArtifactDownloadCancelledError);
+      expect(commit).not.toHaveBeenCalled();
+      expect(discard).toHaveBeenCalledTimes(1);
+    });
+
+    it("maps an aborted request to the sentinel", async () => {
+      const controller = new AbortController();
+      controller.abort();
+      vi.mocked(fetch).mockRejectedValue(
+        new DOMException("The operation was aborted.", "AbortError"),
+      );
+      const { target, commit } = fakeSaveTarget();
+
+      await expect(
+        fetchAndDownloadArtifacts(
+          PROVIDER_ADDRESS,
+          PEGIN_TXID,
+          DEPOSITOR_PK,
+          target,
+          { signal: controller.signal },
+        ),
+      ).rejects.toBeInstanceOf(ArtifactDownloadCancelledError);
+      expect(commit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("save-target failures", () => {
+    it("rejects a body larger than the target can hold", async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(
+        streamingResponse(validEnvelope()),
+      );
+      const { target, commit, discard } = fakeSaveTarget({ maxBytes: 8 });
+
+      await expect(
+        fetchAndDownloadArtifacts(
+          PROVIDER_ADDRESS,
+          PEGIN_TXID,
+          DEPOSITOR_PK,
+          target,
+        ),
+      ).rejects.toBeInstanceOf(ArtifactDownloadTooLargeError);
+      expect(commit).not.toHaveBeenCalled();
+      expect(discard).toHaveBeenCalledTimes(1);
+    });
+
+    it("surfaces a write failure and discards the partial file", async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(
+        streamingResponse(validEnvelope()),
+      );
+      const { target, write, commit, discard } = fakeSaveTarget();
+      write.mockRejectedValueOnce(
+        new ArtifactFileAccessError("disk full", {
+          cause: new Error("ENOSPC"),
+        }),
+      );
+
+      await expect(
+        fetchAndDownloadArtifacts(
+          PROVIDER_ADDRESS,
+          PEGIN_TXID,
+          DEPOSITOR_PK,
+          target,
+        ),
+      ).rejects.toBeInstanceOf(ArtifactFileAccessError);
+      expect(commit).not.toHaveBeenCalled();
+      expect(discard).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+
+describe("openArtifactSaveTarget", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  function stubSecureContext(isSecure: boolean) {
+    Object.defineProperty(window, "isSecureContext", {
+      value: isSecure,
+      configurable: true,
+    });
+  }
+
+  it("returns a streaming target when the File System Access API is present", async () => {
+    stubSecureContext(true);
+    const writable = { write: vi.fn(), close: vi.fn(), abort: vi.fn() };
+    vi.stubGlobal(
+      "showSaveFilePicker",
+      vi.fn(async () => ({ createWritable: vi.fn(async () => writable) })),
     );
 
-    await expect(
-      fetchAndDownloadArtifacts(PROVIDER_ADDRESS, PEGIN_TXID, DEPOSITOR_PK, {
-        signal: controller.signal,
+    const target = await openArtifactSaveTarget(`0x${PEGIN_TXID}`);
+
+    expect(target.method).toBe("file-system-access");
+    expect(target.filename).toBe("babylon-vault-artifacts-aaaaaaaa.json");
+    expect(target.maxBytes).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  it("maps a dismissed picker to the cancellation sentinel", async () => {
+    stubSecureContext(true);
+    vi.stubGlobal(
+      "showSaveFilePicker",
+      vi.fn(async () => {
+        throw new DOMException("The user aborted a request.", "AbortError");
       }),
-    ).rejects.toBeInstanceOf(ArtifactDownloadCancelledError);
-    expect(triggerDownloadSpy).not.toHaveBeenCalled();
+    );
+
+    await expect(openArtifactSaveTarget(PEGIN_TXID)).rejects.toBeInstanceOf(
+      ArtifactDownloadCancelledError,
+    );
+  });
+
+  it("maps a denied picker to a file-access error", async () => {
+    stubSecureContext(true);
+    vi.stubGlobal(
+      "showSaveFilePicker",
+      vi.fn(async () => {
+        throw new DOMException("Permission denied.", "NotAllowedError");
+      }),
+    );
+
+    await expect(openArtifactSaveTarget(PEGIN_TXID)).rejects.toBeInstanceOf(
+      ArtifactFileAccessError,
+    );
+  });
+
+  it("falls back to an anchor download with a size ceiling when unsupported", async () => {
+    stubSecureContext(true);
+    vi.stubGlobal("showSaveFilePicker", undefined);
+
+    const target = await openArtifactSaveTarget(PEGIN_TXID);
+
+    expect(target.method).toBe("browser-download");
+    // A full-size bundle cannot be held as a Blob, so the fallback refuses it
+    // loudly rather than killing the tab.
+    expect(target.maxBytes).toBeLessThan(1_000_000_000);
+  });
+
+  it("falls back when the page is not a secure context", async () => {
+    stubSecureContext(false);
+    vi.stubGlobal(
+      "showSaveFilePicker",
+      vi.fn(async () => ({ createWritable: vi.fn() })),
+    );
+
+    const target = await openArtifactSaveTarget(PEGIN_TXID);
+
+    expect(target.method).toBe("browser-download");
   });
 });

--- a/services/vault/src/services/artifacts/__tests__/artifactDownloadService.test.ts
+++ b/services/vault/src/services/artifacts/__tests__/artifactDownloadService.test.ts
@@ -18,6 +18,7 @@ import {
   ArtifactDownloadTooLargeError,
   ArtifactFileAccessError,
 } from "../errors";
+import { MIN_DECRYPTOR_HEX_CHARS } from "../streamingArtifactValidator";
 
 const PROVIDER_ADDRESS = "0x0000000000000000000000000000000000000000";
 const PEGIN_TXID =
@@ -49,11 +50,14 @@ function txGraphJson(
   });
 }
 
+/** Clears the artifact floor so fixtures exercise the path under test. */
+const VALID_HEX = "cd".repeat(MIN_DECRYPTOR_HEX_CHARS / 2);
+
 const VALID_ARTIFACT_RESULT = {
   tx_graph_json: txGraphJson(),
   verifying_key_hex: "aabb",
   babe_sessions: {
-    [CHALLENGER_PUBKEY]: { decryptor_artifacts_hex: "ccdd" },
+    [CHALLENGER_PUBKEY]: { decryptor_artifacts_hex: VALID_HEX },
   },
 };
 
@@ -184,9 +188,7 @@ describe("fetchAndDownloadArtifacts", () => {
         result: {
           ...VALID_ARTIFACT_RESULT,
           babe_sessions: {
-            [CHALLENGER_PUBKEY]: {
-              decryptor_artifacts_hex: "ab".repeat(20_000),
-            },
+            [CHALLENGER_PUBKEY]: { decryptor_artifacts_hex: VALID_HEX },
           },
         },
         id: 1,
@@ -291,7 +293,7 @@ describe("fetchAndDownloadArtifacts", () => {
           jsonrpc: "2.0",
           result: {
             ...VALID_ARTIFACT_RESULT,
-            babe_sessions: { label: { decryptor_artifacts_hex: "ccdd" } },
+            babe_sessions: { label: { decryptor_artifacts_hex: VALID_HEX } },
           },
           id: 1,
         }),
@@ -754,9 +756,10 @@ describe("openArtifactSaveTarget", () => {
     const target = await openArtifactSaveTarget(PEGIN_TXID);
 
     expect(target.method).toBe("browser-download");
-    // A full-size bundle cannot be held as a Blob, so the fallback refuses it
-    // loudly rather than killing the tab.
-    expect(target.maxBytes).toBeLessThan(1_000_000_000);
+    // Bounded, but above a real bundle (~1.41 GB) — a cap below that would
+    // make this path fail every time, after spending the user's bandwidth.
+    expect(target.maxBytes).toBeGreaterThan(1_410_824_702);
+    expect(target.maxBytes).toBeLessThan(Number.POSITIVE_INFINITY);
   });
 
   it("falls back when the page is not a secure context", async () => {

--- a/services/vault/src/services/artifacts/__tests__/streamingArtifactValidator.test.ts
+++ b/services/vault/src/services/artifacts/__tests__/streamingArtifactValidator.test.ts
@@ -1,0 +1,498 @@
+import {
+  JsonRpcError,
+  VpResponseValidationError,
+} from "@babylonlabs-io/ts-sdk/tbv/core/clients";
+import { describe, expect, it } from "vitest";
+
+import {
+  ArtifactStreamValidator,
+  type ArtifactStreamValidationResult,
+} from "../streamingArtifactValidator";
+
+const CHALLENGER_PUBKEY = "ab".repeat(32);
+const OTHER_CHALLENGER_PUBKEY = "cd".repeat(32);
+
+const VALID_RESULT = {
+  tx_graph_json: JSON.stringify({ nodes: [], edges: [] }),
+  verifying_key_hex: "abcdef01",
+  babe_sessions: {
+    [CHALLENGER_PUBKEY]: { decryptor_artifacts_hex: "aabbccdd" },
+  },
+};
+
+const encoder = new TextEncoder();
+
+/**
+ * Feed `wire` through the validator. `chunkSize` slices the bytes so a test
+ * can prove the verdict does not depend on where chunk boundaries land.
+ */
+function validate(
+  wire: string,
+  chunkSize?: number,
+): ArtifactStreamValidationResult {
+  const validator = new ArtifactStreamValidator();
+  const bytes = encoder.encode(wire);
+  const size = chunkSize ?? bytes.length;
+  for (let offset = 0; offset < bytes.length; offset += size) {
+    validator.update(bytes.subarray(offset, offset + size));
+  }
+  return validator.finish();
+}
+
+function envelope(result: unknown): string {
+  return JSON.stringify({ jsonrpc: "2.0", id: 7, result });
+}
+
+describe("ArtifactStreamValidator — accepts well-formed responses", () => {
+  it("returns the parsed payload for a valid envelope", () => {
+    const { result, txGraph, sessionHexLengths } = validate(
+      envelope(VALID_RESULT),
+    );
+
+    expect(result.verifying_key_hex).toBe("abcdef01");
+    expect(Object.keys(result.babe_sessions)).toEqual([CHALLENGER_PUBKEY]);
+    expect(txGraph).toEqual({ nodes: [], edges: [] });
+    expect(sessionHexLengths).toEqual({ [CHALLENGER_PUBKEY]: 8 });
+  });
+
+  it("accepts result fields in any order", () => {
+    const reordered = JSON.stringify({
+      result: {
+        babe_sessions: VALID_RESULT.babe_sessions,
+        verifying_key_hex: VALID_RESULT.verifying_key_hex,
+        tx_graph_json: VALID_RESULT.tx_graph_json,
+      },
+      id: 7,
+      jsonrpc: "2.0",
+    });
+
+    expect(() => validate(reordered)).not.toThrow();
+  });
+
+  it("accepts a null top-level error alongside a valid result", () => {
+    const wire = JSON.stringify({
+      jsonrpc: "2.0",
+      id: 7,
+      error: null,
+      result: VALID_RESULT,
+    });
+
+    expect(() => validate(wire)).not.toThrow();
+  });
+
+  it("accepts multiple challenger sessions and reports each hex length", () => {
+    const { sessionHexLengths } = validate(
+      envelope({
+        ...VALID_RESULT,
+        babe_sessions: {
+          [CHALLENGER_PUBKEY]: { decryptor_artifacts_hex: "aabb" },
+          [OTHER_CHALLENGER_PUBKEY]: { decryptor_artifacts_hex: "00112233" },
+        },
+      }),
+    );
+
+    expect(sessionHexLengths).toEqual({
+      [CHALLENGER_PUBKEY]: 4,
+      [OTHER_CHALLENGER_PUBKEY]: 8,
+    });
+  });
+
+  it("ignores an `error` key nested inside the result body", () => {
+    const wire = envelope({
+      ...VALID_RESULT,
+      tx_graph_json: JSON.stringify({ error: { code: -1 } }),
+    });
+
+    expect(() => validate(wire)).not.toThrow();
+  });
+
+  it("accepts whitespace-formatted (pretty-printed) responses", () => {
+    const wire = JSON.stringify(
+      { jsonrpc: "2.0", id: 7, result: VALID_RESULT },
+      null,
+      2,
+    );
+
+    expect(() => validate(wire)).not.toThrow();
+  });
+
+  it("returns only a bounded prefix of each decryptor_artifacts_hex value", () => {
+    const longHex = "ab".repeat(500);
+    const { result, sessionHexLengths } = validate(
+      envelope({
+        ...VALID_RESULT,
+        babe_sessions: {
+          [CHALLENGER_PUBKEY]: { decryptor_artifacts_hex: longHex },
+        },
+      }),
+    );
+
+    // The full value is never buffered — the skeleton carries a real prefix
+    // while the observed length is reported separately.
+    expect(
+      result.babe_sessions[CHALLENGER_PUBKEY].decryptor_artifacts_hex,
+    ).toHaveLength(64);
+    expect(
+      longHex.startsWith(
+        result.babe_sessions[CHALLENGER_PUBKEY].decryptor_artifacts_hex,
+      ),
+    ).toBe(true);
+    expect(sessionHexLengths[CHALLENGER_PUBKEY]).toBe(1000);
+  });
+});
+
+describe("ArtifactStreamValidator — chunk boundaries", () => {
+  // tx_graph_json is JSON-inside-a-JSON-string, so its content reaches the
+  // wire double-escaped. This fixture additionally carries a raw multi-byte
+  // character (✓) and a literal \uXXXX escape — the é is rewritten to its
+  // escape form below, which is an equivalent encoding of the same document.
+  // Both are places a naive byte scanner or a per-chunk TextDecoder breaks.
+  const TX_GRAPH = { note: 'café ✓ "quoted" back\\slash' };
+  const ESCAPED_WIRE = envelope({
+    ...VALID_RESULT,
+    tx_graph_json: JSON.stringify(TX_GRAPH),
+  }).replace("é", "\\u00e9");
+
+  it("decodes escapes and multi-byte characters in one chunk", () => {
+    expect(ESCAPED_WIRE).toContain("\\u00e9");
+    expect(validate(ESCAPED_WIRE).txGraph).toEqual(TX_GRAPH);
+  });
+
+  it("reaches the identical verdict when fed one byte at a time", () => {
+    expect(validate(ESCAPED_WIRE, 1).txGraph).toEqual(TX_GRAPH);
+  });
+
+  it("splits a long hex value across chunks without losing bytes", () => {
+    const longHex = "ab".repeat(5_000);
+    const wire = envelope({
+      ...VALID_RESULT,
+      babe_sessions: {
+        [CHALLENGER_PUBKEY]: { decryptor_artifacts_hex: longHex },
+      },
+    });
+
+    expect(validate(wire, 7).sessionHexLengths[CHALLENGER_PUBKEY]).toBe(10_000);
+  });
+});
+
+describe("ArtifactStreamValidator — rejects malformed documents", () => {
+  it("rejects a stream truncated mid-hex", () => {
+    const wire = envelope(VALID_RESULT);
+    const truncated = wire.slice(0, wire.length - 20);
+
+    expect(() => validate(truncated)).toThrow(VpResponseValidationError);
+  });
+
+  it("rejects a stream truncated at the final closing brace", () => {
+    const wire = envelope(VALID_RESULT);
+
+    expect(() => validate(wire.slice(0, -1))).toThrow(
+      VpResponseValidationError,
+    );
+  });
+
+  it("rejects an empty body", () => {
+    expect(() => validate("")).toThrow(VpResponseValidationError);
+  });
+
+  it("rejects non-JSON garbage", () => {
+    expect(() => validate("<html>gateway timeout</html>")).toThrow(
+      VpResponseValidationError,
+    );
+  });
+
+  it("rejects a top-level value that is not an object", () => {
+    expect(() => validate("[1,2,3]")).toThrow(VpResponseValidationError);
+  });
+
+  it("rejects trailing content after the top-level value", () => {
+    expect(() => validate(`${envelope(VALID_RESULT)}{"more":1}`)).toThrow(
+      VpResponseValidationError,
+    );
+  });
+
+  it("rejects a trailing comma", () => {
+    expect(() =>
+      validate(`{"jsonrpc":"2.0","result":${JSON.stringify(VALID_RESULT)},}`),
+    ).toThrow(VpResponseValidationError);
+  });
+
+  it("rejects a malformed number", () => {
+    expect(() =>
+      validate(`{"id":01,"result":${JSON.stringify(VALID_RESULT)}}`),
+    ).toThrow(VpResponseValidationError);
+  });
+
+  it("rejects a dangling exponent", () => {
+    expect(() =>
+      validate(`{"id":1e,"result":${JSON.stringify(VALID_RESULT)}}`),
+    ).toThrow(VpResponseValidationError);
+  });
+
+  it("rejects an unescaped control character inside a string", () => {
+    expect(() =>
+      validate(`{"jsonrpc":"2.\n0","result":${JSON.stringify(VALID_RESULT)}}`),
+    ).toThrow(VpResponseValidationError);
+  });
+
+  it("rejects an invalid string escape", () => {
+    expect(() =>
+      validate(`{"jsonrpc":"2\\q0","result":${JSON.stringify(VALID_RESULT)}}`),
+    ).toThrow(VpResponseValidationError);
+  });
+
+  it("rejects a malformed \\u escape", () => {
+    expect(() =>
+      validate(
+        `{"jsonrpc":"\\u00zz","result":${JSON.stringify(VALID_RESULT)}}`,
+      ),
+    ).toThrow(VpResponseValidationError);
+  });
+
+  it("rejects a mismatched bracket", () => {
+    expect(() =>
+      validate(`{"result":${JSON.stringify(VALID_RESULT)}]`),
+    ).toThrow(VpResponseValidationError);
+  });
+
+  it("rejects an object key longer than the cap", () => {
+    expect(() =>
+      validate(
+        `{"${"k".repeat(300)}":1,"result":${JSON.stringify(VALID_RESULT)}}`,
+      ),
+    ).toThrow(VpResponseValidationError);
+  });
+
+  it("rejects a duplicate top-level result key", () => {
+    const good = JSON.stringify(VALID_RESULT);
+    expect(() => validate(`{"result":${good},"result":${good}}`)).toThrow(
+      VpResponseValidationError,
+    );
+  });
+
+  it("rejects a duplicate key inside a session object", () => {
+    const wire =
+      `{"result":{"tx_graph_json":${JSON.stringify(VALID_RESULT.tx_graph_json)},` +
+      `"verifying_key_hex":"abcdef01","babe_sessions":{"${CHALLENGER_PUBKEY}":` +
+      `{"decryptor_artifacts_hex":"aabb","decryptor_artifacts_hex":"ccdd"}}}}`;
+
+    expect(() => validate(wire)).toThrow(VpResponseValidationError);
+  });
+});
+
+describe("ArtifactStreamValidator — rejects invalid artifact payloads", () => {
+  it("rejects a missing result", () => {
+    expect(() => validate('{"jsonrpc":"2.0","id":7}')).toThrow(
+      VpResponseValidationError,
+    );
+  });
+
+  it("rejects a null result", () => {
+    expect(() => validate('{"jsonrpc":"2.0","id":7,"result":null}')).toThrow(
+      VpResponseValidationError,
+    );
+  });
+
+  it("rejects an empty result", () => {
+    expect(() => validate(envelope({}))).toThrow(VpResponseValidationError);
+  });
+
+  it("rejects an empty tx_graph_json", () => {
+    expect(() =>
+      validate(envelope({ ...VALID_RESULT, tx_graph_json: "" })),
+    ).toThrow(VpResponseValidationError);
+  });
+
+  it("rejects a tx_graph_json that is not valid JSON", () => {
+    expect(() =>
+      validate(envelope({ ...VALID_RESULT, tx_graph_json: "not json" })),
+    ).toThrow(VpResponseValidationError);
+  });
+
+  it("rejects a tx_graph_json that parses to an array", () => {
+    expect(() =>
+      validate(envelope({ ...VALID_RESULT, tx_graph_json: "[]" })),
+    ).toThrow(VpResponseValidationError);
+  });
+
+  it("rejects a tx_graph_json that parses to a number", () => {
+    expect(() =>
+      validate(envelope({ ...VALID_RESULT, tx_graph_json: "5" })),
+    ).toThrow(VpResponseValidationError);
+  });
+
+  it("rejects a non-hex verifying_key_hex", () => {
+    expect(() =>
+      validate(envelope({ ...VALID_RESULT, verifying_key_hex: "zzzz" })),
+    ).toThrow(VpResponseValidationError);
+  });
+
+  it("rejects empty babe_sessions", () => {
+    expect(() =>
+      validate(envelope({ ...VALID_RESULT, babe_sessions: {} })),
+    ).toThrow(VpResponseValidationError);
+  });
+
+  it("rejects a session keyed by something that is not a pubkey", () => {
+    expect(() =>
+      validate(
+        envelope({
+          ...VALID_RESULT,
+          babe_sessions: {
+            "not-a-pubkey": { decryptor_artifacts_hex: "aabb" },
+          },
+        }),
+      ),
+    ).toThrow(VpResponseValidationError);
+  });
+
+  it("rejects a session entry that is not an object", () => {
+    expect(() =>
+      validate(
+        envelope({
+          ...VALID_RESULT,
+          babe_sessions: { [CHALLENGER_PUBKEY]: "aabb" },
+        }),
+      ),
+    ).toThrow(VpResponseValidationError);
+  });
+
+  it("rejects a session with no decryptor_artifacts_hex", () => {
+    expect(() =>
+      validate(
+        envelope({
+          ...VALID_RESULT,
+          babe_sessions: { [CHALLENGER_PUBKEY]: {} },
+        }),
+      ),
+    ).toThrow(VpResponseValidationError);
+  });
+
+  it("rejects an empty decryptor_artifacts_hex", () => {
+    expect(() =>
+      validate(
+        envelope({
+          ...VALID_RESULT,
+          babe_sessions: {
+            [CHALLENGER_PUBKEY]: { decryptor_artifacts_hex: "" },
+          },
+        }),
+      ),
+    ).toThrow(VpResponseValidationError);
+  });
+
+  it("rejects a non-hex character in decryptor_artifacts_hex", () => {
+    expect(() =>
+      validate(
+        envelope({
+          ...VALID_RESULT,
+          babe_sessions: {
+            [CHALLENGER_PUBKEY]: { decryptor_artifacts_hex: "aabbzz" },
+          },
+        }),
+      ),
+    ).toThrow(VpResponseValidationError);
+  });
+
+  it("rejects an escape sequence inside decryptor_artifacts_hex", () => {
+    const wire =
+      `{"result":{"tx_graph_json":${JSON.stringify(VALID_RESULT.tx_graph_json)},` +
+      `"verifying_key_hex":"abcdef01","babe_sessions":{"${CHALLENGER_PUBKEY}":` +
+      `{"decryptor_artifacts_hex":"aa\\u0062b"}}}}`;
+
+    expect(() => validate(wire)).toThrow(VpResponseValidationError);
+  });
+
+  it("rejects an odd-length decryptor_artifacts_hex", () => {
+    expect(() =>
+      validate(
+        envelope({
+          ...VALID_RESULT,
+          babe_sessions: {
+            [CHALLENGER_PUBKEY]: { decryptor_artifacts_hex: "aab" },
+          },
+        }),
+      ),
+    ).toThrow(VpResponseValidationError);
+  });
+});
+
+describe("ArtifactStreamValidator — JSON-RPC error envelopes", () => {
+  it("throws JsonRpcError for an error envelope", () => {
+    const wire = JSON.stringify({
+      jsonrpc: "2.0",
+      id: 7,
+      error: { code: -32000, message: "pegin not found" },
+    });
+
+    expect(() => validate(wire)).toThrow(JsonRpcError);
+  });
+
+  it("preserves the code, wire source, and structured data", () => {
+    const wire = JSON.stringify({
+      jsonrpc: "2.0",
+      id: 7,
+      error: {
+        code: -32001,
+        message: "bearer expired",
+        data: { kind: "auth_expired", retryAfterMs: 500 },
+      },
+    });
+
+    try {
+      validate(wire);
+      expect.unreachable("expected a JsonRpcError");
+    } catch (err) {
+      expect(err).toBeInstanceOf(JsonRpcError);
+      const rpcError = err as JsonRpcError;
+      expect(rpcError.code).toBe(-32001);
+      expect(rpcError.source).toBe("wire");
+      expect(rpcError.data).toEqual({
+        kind: "auth_expired",
+        retryAfterMs: 500,
+      });
+    }
+  });
+
+  it("throws JsonRpcError when the error follows a valid result", () => {
+    const wire = `{"jsonrpc":"2.0","result":${JSON.stringify(VALID_RESULT)},"error":{"code":-1,"message":"late"}}`;
+
+    expect(() => validate(wire)).toThrow(JsonRpcError);
+  });
+
+  it("throws JsonRpcError when the error precedes a null result", () => {
+    const wire =
+      '{"jsonrpc":"2.0","error":{"code":-1,"message":"early"},"result":null}';
+
+    expect(() => validate(wire)).toThrow(JsonRpcError);
+  });
+
+  it("throws JsonRpcError for an error envelope padded far past any prefix window", () => {
+    const wire = JSON.stringify({
+      jsonrpc: "2.0",
+      id: 7,
+      error: { code: -32000, message: "x".repeat(10_000) },
+    });
+
+    expect(() => validate(wire)).toThrow(JsonRpcError);
+  });
+
+  it("falls back to a default code when the error object omits one", () => {
+    const wire = '{"jsonrpc":"2.0","error":{"message":"no code"}}';
+
+    expect(() => validate(wire)).toThrow(JsonRpcError);
+  });
+
+  it("rejects a top-level error that is neither null nor an object", () => {
+    expect(() => validate('{"jsonrpc":"2.0","error":"boom"}')).toThrow(
+      VpResponseValidationError,
+    );
+  });
+
+  it("ignores a `result` key nested inside the error object", () => {
+    const wire =
+      '{"jsonrpc":"2.0","error":{"code":-1,"message":"m","data":{"result":{}}}}';
+
+    expect(() => validate(wire)).toThrow(JsonRpcError);
+  });
+});

--- a/services/vault/src/services/artifacts/__tests__/streamingArtifactValidator.test.ts
+++ b/services/vault/src/services/artifacts/__tests__/streamingArtifactValidator.test.ts
@@ -46,6 +46,33 @@ function validate(
   return validator.finish();
 }
 
+/**
+ * Feed raw bytes through the validator. `validate` goes through TextEncoder,
+ * which cannot emit invalid UTF-8 (lone surrogates come out as U+FFFD), so
+ * encoding-level cases have to build the byte array by hand.
+ */
+function validateBytes(bytes: Uint8Array): ArtifactStreamValidationResult {
+  const validator = new ArtifactStreamValidator();
+  validator.update(bytes);
+  return validator.finish();
+}
+
+/** Splice a raw byte into `wire` at the placeholder character. */
+function withRawByte(
+  wire: string,
+  placeholder: string,
+  raw: number,
+): Uint8Array {
+  const index = wire.indexOf(placeholder);
+  const head = encoder.encode(wire.slice(0, index));
+  const tail = encoder.encode(wire.slice(index + placeholder.length));
+  const bytes = new Uint8Array(head.length + 1 + tail.length);
+  bytes.set(head, 0);
+  bytes[head.length] = raw;
+  bytes.set(tail, head.length + 1);
+  return bytes;
+}
+
 function envelope(result: unknown): string {
   return JSON.stringify({ jsonrpc: "2.0", id: 7, result });
 }
@@ -250,6 +277,45 @@ describe("ArtifactStreamValidator — rejects malformed documents", () => {
         `{"jsonrpc":"\\u00zz","result":${JSON.stringify(VALID_RESULT)}}`,
       ),
     ).toThrow(VpResponseValidationError);
+  });
+
+  it("rejects invalid UTF-8 in an untracked string value", () => {
+    // The byte machine only rejects control characters, and untracked values
+    // are discarded rather than decoded — so a lone 0x80 here used to reach
+    // finish() and commit a bundle no strict JSON parser can read, while the
+    // UI reported success. The validator claims the WHOLE document is
+    // well-formed, and RFC 8259 makes UTF-8 part of that.
+    expect(() =>
+      validateBytes(
+        withRawByte(
+          `{"jsonrpc":"2@0","result":${JSON.stringify(VALID_RESULT)}}`,
+          "@",
+          0x80,
+        ),
+      ),
+    ).toThrow(VpResponseValidationError);
+  });
+
+  it("rejects invalid UTF-8 in an unknown forward-compat field", () => {
+    expect(() =>
+      validateBytes(
+        withRawByte(
+          `{"jsonrpc":"2.0","unknown_field":"a@b","result":${JSON.stringify(VALID_RESULT)}}`,
+          "@",
+          0x80,
+        ),
+      ),
+    ).toThrow(VpResponseValidationError);
+  });
+
+  it("accepts valid multibyte UTF-8 in an untracked string value", () => {
+    // The encoding check must not reject honest non-ASCII: only sequences
+    // that are not valid UTF-8 at all.
+    const { result } = validate(
+      `{"jsonrpc":"2.0","note":"café ✓","result":${JSON.stringify(VALID_RESULT)}}`,
+    );
+
+    expect(result.verifying_key_hex).toBe(VALID_RESULT.verifying_key_hex);
   });
 
   it("rejects a mismatched bracket", () => {

--- a/services/vault/src/services/artifacts/__tests__/streamingArtifactValidator.test.ts
+++ b/services/vault/src/services/artifacts/__tests__/streamingArtifactValidator.test.ts
@@ -6,17 +6,24 @@ import { describe, expect, it } from "vitest";
 
 import {
   ArtifactStreamValidator,
+  MIN_DECRYPTOR_HEX_CHARS,
   type ArtifactStreamValidationResult,
 } from "../streamingArtifactValidator";
 
 const CHALLENGER_PUBKEY = "ab".repeat(32);
 const OTHER_CHALLENGER_PUBKEY = "cd".repeat(32);
 
+/**
+ * Hex long enough to clear the artifact floor. Fixtures build from the
+ * constant rather than a literal so the floor can move without a sweep.
+ */
+const VALID_HEX = "ab".repeat(MIN_DECRYPTOR_HEX_CHARS / 2);
+
 const VALID_RESULT = {
   tx_graph_json: JSON.stringify({ nodes: [], edges: [] }),
   verifying_key_hex: "abcdef01",
   babe_sessions: {
-    [CHALLENGER_PUBKEY]: { decryptor_artifacts_hex: "aabbccdd" },
+    [CHALLENGER_PUBKEY]: { decryptor_artifacts_hex: VALID_HEX },
   },
 };
 
@@ -45,14 +52,11 @@ function envelope(result: unknown): string {
 
 describe("ArtifactStreamValidator — accepts well-formed responses", () => {
   it("returns the parsed payload for a valid envelope", () => {
-    const { result, txGraph, sessionHexLengths } = validate(
-      envelope(VALID_RESULT),
-    );
+    const { result, txGraph } = validate(envelope(VALID_RESULT));
 
     expect(result.verifying_key_hex).toBe("abcdef01");
     expect(Object.keys(result.babe_sessions)).toEqual([CHALLENGER_PUBKEY]);
     expect(txGraph).toEqual({ nodes: [], edges: [] });
-    expect(sessionHexLengths).toEqual({ [CHALLENGER_PUBKEY]: 8 });
   });
 
   it("accepts result fields in any order", () => {
@@ -80,21 +84,20 @@ describe("ArtifactStreamValidator — accepts well-formed responses", () => {
     expect(() => validate(wire)).not.toThrow();
   });
 
-  it("accepts multiple challenger sessions and reports each hex length", () => {
-    const { sessionHexLengths } = validate(
+  it("accepts multiple challenger sessions", () => {
+    const { result } = validate(
       envelope({
         ...VALID_RESULT,
         babe_sessions: {
-          [CHALLENGER_PUBKEY]: { decryptor_artifacts_hex: "aabb" },
-          [OTHER_CHALLENGER_PUBKEY]: { decryptor_artifacts_hex: "00112233" },
+          [CHALLENGER_PUBKEY]: { decryptor_artifacts_hex: VALID_HEX },
+          [OTHER_CHALLENGER_PUBKEY]: { decryptor_artifacts_hex: VALID_HEX },
         },
       }),
     );
 
-    expect(sessionHexLengths).toEqual({
-      [CHALLENGER_PUBKEY]: 4,
-      [OTHER_CHALLENGER_PUBKEY]: 8,
-    });
+    expect(Object.keys(result.babe_sessions).sort()).toEqual(
+      [CHALLENGER_PUBKEY, OTHER_CHALLENGER_PUBKEY].sort(),
+    );
   });
 
   it("ignores an `error` key nested inside the result body", () => {
@@ -117,8 +120,8 @@ describe("ArtifactStreamValidator — accepts well-formed responses", () => {
   });
 
   it("returns only a bounded prefix of each decryptor_artifacts_hex value", () => {
-    const longHex = "ab".repeat(500);
-    const { result, sessionHexLengths } = validate(
+    const longHex = "ab".repeat(MIN_DECRYPTOR_HEX_CHARS);
+    const { result } = validate(
       envelope({
         ...VALID_RESULT,
         babe_sessions: {
@@ -128,7 +131,7 @@ describe("ArtifactStreamValidator — accepts well-formed responses", () => {
     );
 
     // The full value is never buffered — the skeleton carries a real prefix
-    // while the observed length is reported separately.
+    // of what streamed past, not the whole value.
     expect(
       result.babe_sessions[CHALLENGER_PUBKEY].decryptor_artifacts_hex,
     ).toHaveLength(64);
@@ -137,7 +140,6 @@ describe("ArtifactStreamValidator — accepts well-formed responses", () => {
         result.babe_sessions[CHALLENGER_PUBKEY].decryptor_artifacts_hex,
       ),
     ).toBe(true);
-    expect(sessionHexLengths[CHALLENGER_PUBKEY]).toBe(1000);
   });
 });
 
@@ -163,15 +165,16 @@ describe("ArtifactStreamValidator — chunk boundaries", () => {
   });
 
   it("splits a long hex value across chunks without losing bytes", () => {
-    const longHex = "ab".repeat(5_000);
     const wire = envelope({
       ...VALID_RESULT,
       babe_sessions: {
-        [CHALLENGER_PUBKEY]: { decryptor_artifacts_hex: longHex },
+        [CHALLENGER_PUBKEY]: { decryptor_artifacts_hex: VALID_HEX },
       },
     });
 
-    expect(validate(wire, 7).sessionHexLengths[CHALLENGER_PUBKEY]).toBe(10_000);
+    // Chunked at a size that lands mid-value repeatedly; a byte lost at a
+    // boundary would drop the total under the floor and reject.
+    expect(() => validate(wire, 7)).not.toThrow();
   });
 });
 
@@ -274,7 +277,7 @@ describe("ArtifactStreamValidator — rejects malformed documents", () => {
     const wire =
       `{"result":{"tx_graph_json":${JSON.stringify(VALID_RESULT.tx_graph_json)},` +
       `"verifying_key_hex":"abcdef01","babe_sessions":{"${CHALLENGER_PUBKEY}":` +
-      `{"decryptor_artifacts_hex":"aabb","decryptor_artifacts_hex":"ccdd"}}}}`;
+      `{"decryptor_artifacts_hex":"${VALID_HEX}","decryptor_artifacts_hex":"${VALID_HEX}"}}}}`;
 
     expect(() => validate(wire)).toThrow(VpResponseValidationError);
   });
@@ -387,7 +390,7 @@ describe("ArtifactStreamValidator — rejects invalid artifact payloads", () => 
         envelope({
           ...VALID_RESULT,
           babe_sessions: {
-            [CHALLENGER_PUBKEY]: { decryptor_artifacts_hex: "aabbzz" },
+            [CHALLENGER_PUBKEY]: { decryptor_artifacts_hex: `${VALID_HEX}zz` },
           },
         }),
       ),
@@ -398,9 +401,54 @@ describe("ArtifactStreamValidator — rejects invalid artifact payloads", () => 
     const wire =
       `{"result":{"tx_graph_json":${JSON.stringify(VALID_RESULT.tx_graph_json)},` +
       `"verifying_key_hex":"abcdef01","babe_sessions":{"${CHALLENGER_PUBKEY}":` +
-      `{"decryptor_artifacts_hex":"aa\\u0062b"}}}}`;
+      `{"decryptor_artifacts_hex":"${VALID_HEX}\\u0062b"}}}}`;
 
     expect(() => validate(wire)).toThrow(VpResponseValidationError);
+  });
+
+  it("rejects a token-sized decryptor_artifacts_hex", () => {
+    // Charset, non-emptiness and even length all pass here. Without a floor
+    // this is a structurally perfect, materially empty bundle that would earn
+    // a download receipt.
+    expect(() =>
+      validate(
+        envelope({
+          ...VALID_RESULT,
+          babe_sessions: {
+            [CHALLENGER_PUBKEY]: { decryptor_artifacts_hex: "ab" },
+          },
+        }),
+      ),
+    ).toThrow(VpResponseValidationError);
+  });
+
+  it("rejects a session one character below the artifact floor", () => {
+    expect(() =>
+      validate(
+        envelope({
+          ...VALID_RESULT,
+          babe_sessions: {
+            [CHALLENGER_PUBKEY]: {
+              decryptor_artifacts_hex: "a".repeat(MIN_DECRYPTOR_HEX_CHARS - 2),
+            },
+          },
+        }),
+      ),
+    ).toThrow(VpResponseValidationError);
+  });
+
+  it("rejects when only one of several sessions is undersized", () => {
+    expect(() =>
+      validate(
+        envelope({
+          ...VALID_RESULT,
+          babe_sessions: {
+            [CHALLENGER_PUBKEY]: { decryptor_artifacts_hex: VALID_HEX },
+            [OTHER_CHALLENGER_PUBKEY]: { decryptor_artifacts_hex: "abcd" },
+          },
+        }),
+      ),
+    ).toThrow(VpResponseValidationError);
   });
 
   it("rejects an odd-length decryptor_artifacts_hex", () => {
@@ -409,7 +457,7 @@ describe("ArtifactStreamValidator — rejects invalid artifact payloads", () => 
         envelope({
           ...VALID_RESULT,
           babe_sessions: {
-            [CHALLENGER_PUBKEY]: { decryptor_artifacts_hex: "aab" },
+            [CHALLENGER_PUBKEY]: { decryptor_artifacts_hex: `${VALID_HEX}a` },
           },
         }),
       ),

--- a/services/vault/src/services/artifacts/artifactBinding.ts
+++ b/services/vault/src/services/artifacts/artifactBinding.ts
@@ -1,0 +1,162 @@
+/**
+ * Binds a downloaded artifact bundle to the deposit it was requested for.
+ *
+ * The response envelope echoes neither the pegin txid nor the depositor key,
+ * so on its own "schema-valid" only means "shaped like a bundle" — it could
+ * belong to a different vault entirely. The transaction graph inside
+ * `tx_graph_json` does carry that identity, and every expected value is
+ * already in hand as a parameter of the request we just made, so no on-chain
+ * read is needed.
+ *
+ * Checked here (all derived from a real vault-devnet bundle):
+ * - `claim_tx` and `payout_tx` each spend an output of the requested pegin
+ *   transaction, which is what ties the graph to *this* deposit
+ * - `depositor_pubkey` is the depositor we asked on behalf of
+ * - the `babe_sessions` keys are exactly the graph's own
+ *   `challenger_pubkeys.local ∪ .universal`
+ *
+ * What this does NOT establish: that the artifact bytes decrypt correctly, or
+ * that a hostile provider could not fabricate a self-consistent bundle. The
+ * expected values here are all public, so a determined provider can satisfy
+ * every check while returning garbage payloads. This catches a provider
+ * serving the wrong deposit's bundle, a stale or mis-keyed cache, and an
+ * internally inconsistent graph — not a targeted forgery. Proving the payload
+ * itself needs a BaBe verifier, which does not exist client-side.
+ */
+
+import { stripHexPrefix } from "@babylonlabs-io/ts-sdk/tbv/core";
+import { VpResponseValidationError } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
+
+/** The deposit a bundle must belong to, taken from the request parameters. */
+export interface VaultBindingContext {
+  peginTxid: string;
+  depositorPk: string;
+}
+
+/**
+ * Transactions whose inputs must spend the pegin. `claim_tx` spends the
+ * depositor-claim output and `payout_tx` the payout output, so both are
+ * anchored to the same funding transaction.
+ */
+const PEGIN_SPENDING_TX_KEYS = ["claim_tx", "payout_tx"] as const;
+
+function normalizeHex(value: string): string {
+  return stripHexPrefix(value).toLowerCase();
+}
+
+function asRecord(value: unknown, field: string): Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new VpResponseValidationError(
+      `Artifact tx graph is missing the "${field}" object`,
+    );
+  }
+  return value as Record<string, unknown>;
+}
+
+/**
+ * Collect the txids referenced by a transaction's inputs.
+ *
+ * `previous_output` is serialized as `<txid>:<vout>` in display byte order —
+ * the same order the pegin txid is supplied in.
+ */
+function inputTxids(txNode: unknown, field: string): string[] {
+  const inputs = asRecord(asRecord(txNode, field).tx, `${field}.tx`).input;
+  if (!Array.isArray(inputs) || inputs.length === 0) {
+    throw new VpResponseValidationError(
+      `Artifact tx graph "${field}" has no inputs`,
+    );
+  }
+  return inputs.map((input, index) => {
+    const outpoint = asRecord(
+      input,
+      `${field}.tx.input[${index}]`,
+    ).previous_output;
+    if (typeof outpoint !== "string") {
+      throw new VpResponseValidationError(
+        `Artifact tx graph "${field}" input ${index} has no previous_output`,
+      );
+    }
+    return normalizeHex(outpoint.split(":")[0] ?? "");
+  });
+}
+
+function challengerSetFromGraph(graph: Record<string, unknown>): Set<string> {
+  const pubkeys = asRecord(graph.challenger_pubkeys, "challenger_pubkeys");
+  const combined: string[] = [];
+  for (const role of ["local", "universal"] as const) {
+    const entry = pubkeys[role];
+    if (!Array.isArray(entry)) {
+      throw new VpResponseValidationError(
+        `Artifact tx graph challenger_pubkeys.${role} is not an array`,
+      );
+    }
+    for (const key of entry) {
+      if (typeof key !== "string") {
+        throw new VpResponseValidationError(
+          `Artifact tx graph challenger_pubkeys.${role} contains a non-string key`,
+        );
+      }
+      combined.push(normalizeHex(key));
+    }
+  }
+  const unique = new Set(combined);
+  if (unique.size !== combined.length) {
+    throw new VpResponseValidationError(
+      "Artifact tx graph declares a challenger in both the local and universal sets",
+    );
+  }
+  return unique;
+}
+
+/**
+ * Throw unless the bundle demonstrably belongs to `expected`.
+ *
+ * @param txGraph        Parsed `tx_graph_json` from the response.
+ * @param sessionPubkeys Challenger keys the response supplied sessions for.
+ */
+export function assertBundleBoundToVault(
+  txGraph: Record<string, unknown>,
+  sessionPubkeys: string[],
+  expected: VaultBindingContext,
+): void {
+  const peginTxid = normalizeHex(expected.peginTxid);
+
+  for (const field of PEGIN_SPENDING_TX_KEYS) {
+    const txids = inputTxids(txGraph[field], field);
+    if (!txids.includes(peginTxid)) {
+      throw new VpResponseValidationError(
+        `Artifact bundle is for a different deposit: "${field}" spends ${txids.join(", ")}, expected ${peginTxid}`,
+      );
+    }
+  }
+
+  const depositorPubkey = txGraph.depositor_pubkey;
+  if (typeof depositorPubkey !== "string") {
+    throw new VpResponseValidationError(
+      "Artifact tx graph is missing depositor_pubkey",
+    );
+  }
+  const expectedDepositor = normalizeHex(expected.depositorPk);
+  if (normalizeHex(depositorPubkey) !== expectedDepositor) {
+    throw new VpResponseValidationError(
+      `Artifact bundle is for a different depositor: graph declares ${normalizeHex(depositorPubkey)}, expected ${expectedDepositor}`,
+    );
+  }
+
+  // Self-consistency: the provider must have supplied a session for exactly
+  // the challengers its own graph names — no missing entry that would leave
+  // recovery material incomplete, no extra key the graph does not recognize.
+  const graphChallengers = challengerSetFromGraph(txGraph);
+  const supplied = new Set(sessionPubkeys.map(normalizeHex));
+  const missing = [...graphChallengers].filter((key) => !supplied.has(key));
+  const unexpected = [...supplied].filter((key) => !graphChallengers.has(key));
+  if (missing.length > 0 || unexpected.length > 0) {
+    throw new VpResponseValidationError(
+      "Artifact bundle session set does not match the tx graph's challengers" +
+        (missing.length > 0 ? ` (missing: ${missing.join(", ")})` : "") +
+        (unexpected.length > 0
+          ? ` (unexpected: ${unexpected.join(", ")})`
+          : ""),
+    );
+  }
+}

--- a/services/vault/src/services/artifacts/artifactDownloadService.ts
+++ b/services/vault/src/services/artifacts/artifactDownloadService.ts
@@ -241,7 +241,15 @@ export async function downloadArtifactsFromResponse(
     reader.releaseLock();
   }
 
-  await stream.commit();
+  try {
+    await stream.commit();
+  } catch (err) {
+    // A rejected close leaves the writable un-aborted, so its temporary file
+    // can linger until the browser reclaims it. Abandon the transaction
+    // explicitly rather than relying on that.
+    await discardQuietly(stream);
+    throw err;
+  }
 
   return {
     filename: target.filename,

--- a/services/vault/src/services/artifacts/artifactDownloadService.ts
+++ b/services/vault/src/services/artifacts/artifactDownloadService.ts
@@ -1,52 +1,69 @@
 /**
- * Service for fetching and downloading BaBe Decryptor artifacts.
+ * Service for fetching and saving BaBe Decryptor artifacts.
  *
- * These artifacts are required for the depositor to independently claim
- * their vault funds. They are retrieved from the vault provider after
- * the WOTS key has been submitted and the vault is fully set up.
+ * These artifacts are what lets a depositor claim their vault funds without
+ * the vault provider's cooperation, so a download that "succeeded" without
+ * producing a valid, complete file on disk is a silent loss of that recovery
+ * path. Two things follow from that:
  *
- * Artifacts can be very large (~1 GB today). The raw response body is
- * retained as a Blob so the download step does not need to re-serialize
- * it, and payloads above an RPC-error-sized threshold are not parsed on
- * the main thread (doing so would risk exceeding V8's string length limit
- * or freezing the tab). Full schema validation of the artifact body is
- * deferred until the backend delivers artifacts via streaming; for now
- * small responses (expected to be JSON-RPC error envelopes) are parsed and
- * validated, and large responses are structurally checked via their
- * JSON-RPC envelope prefix.
+ * - **Validation is mandatory and covers the whole body.** The payload is
+ *   ~1.3 GB and cannot be parsed with `JSON.parse`, so it is checked
+ *   incrementally by {@link ArtifactStreamValidator} as it streams. Nothing
+ *   is skipped on the basis of size.
+ * - **Success means the bytes are durably saved**, not that a fetch resolved.
+ *   The body is piped into an {@link ArtifactSaveTarget} and only committed
+ *   after the validator has seen the closing brace.
+ *
+ * Bytes are validated, hashed, and written chunk-by-chunk in a single pass,
+ * so the full body is never held in memory on the File System Access path.
+ *
+ * What this does NOT establish: that the artifact bytes decrypt correctly, or
+ * that the bundle belongs to this vault. The response carries no pegin txid or
+ * depositor key to bind against, and no client-side BaBe verifier exists. A
+ * provider returning a well-formed bundle for the wrong vault is not detected
+ * here.
  */
 
 import { stripHexPrefix } from "@babylonlabs-io/ts-sdk/tbv/core";
 import {
-  JSON_RPC_ERROR_CODES,
   JsonRpcClient,
-  JsonRpcError,
-  validateRequestDepositorClaimerArtifactsResponse,
   VpResponseValidationError,
   vpTokenRegistry,
 } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
+import { sha256 } from "@noble/hashes/sha2.js";
+import { bytesToHex } from "@noble/hashes/utils.js";
 
+import { logger } from "@/infrastructure";
 import { getVpProxyUrl } from "@/utils/rpc";
+
+import {
+  assertBundleBoundToVault,
+  type VaultBindingContext,
+} from "./artifactBinding";
+import type {
+  ArtifactSaveMethod,
+  ArtifactSaveStream,
+  ArtifactSaveTarget,
+} from "./artifactSaveTarget";
+import {
+  ArtifactDownloadCancelledError,
+  ArtifactDownloadTooLargeError,
+} from "./errors";
+import { ArtifactStreamValidator } from "./streamingArtifactValidator";
 
 /** Timeout for the artifact request RPC call (artifacts can be large). */
 const RPC_TIMEOUT_MS = 120 * 1000;
 
 /**
- * Error responses are typically small; artifact payloads can be around a
- * gigabyte. Only responses under this threshold are parsed on the main thread.
- */
-const ERROR_RESPONSE_SIZE_THRESHOLD = 4096;
-
-/** MIME type for the assembled artifact Blob (the payload is JSON). */
-const ARTIFACT_BLOB_TYPE = "application/json";
-
-/**
  * Fallback total used by the progress bar when the server omits
- * Content-Length. Artifact payloads are currently ~1 GB; 1.3 GB leaves
- * comfortable headroom so the displayed percentage stays under 100% for
- * a typical response.
+ * Content-Length — which the streaming proxy always does.
+ *
+ * A measured vault-devnet bundle is 1,410,824,702 bytes (8 challengers at
+ * ~176 MB of hex each). The estimate sits above that so the displayed
+ * percentage does not saturate before the transfer finishes; the card clamps
+ * to 100% regardless, so an undershoot is cosmetic rather than harmful.
  */
-const ARTIFACT_TOTAL_FALLBACK_BYTES = 1_395_864_371;
+const ARTIFACT_TOTAL_FALLBACK_BYTES = 1_600_000_000;
 
 export interface FetchArtifactsOptions {
   /**
@@ -71,51 +88,36 @@ export interface FetchArtifactsOptions {
   signal?: AbortSignal;
 }
 
-/**
- * Sentinel thrown when the caller cancels the download via
- * `FetchArtifactsOptions.isCancelled` or `FetchArtifactsOptions.signal`.
- * Callers should swallow this instead of surfacing it as an error.
- */
-export class ArtifactDownloadCancelledError extends Error {
-  constructor() {
-    super("Artifact download was cancelled");
-    this.name = "ArtifactDownloadCancelledError";
-  }
+/** Evidence that a validated bundle was written to disk. */
+export interface ArtifactDownloadOutcome {
+  filename: string;
+  byteLength: number;
+  /** SHA-256 of the response body, computed during the same streaming pass. */
+  sha256: string;
+  method: ArtifactSaveMethod;
 }
 
 /**
- * How many leading bytes of a large response we decode to structurally check
- * its JSON-RPC envelope. A genuine success envelope's top-level keys
- * (`jsonrpc`, `id`, `result`) plus separators occupy well under a hundred
- * bytes before the huge artifact value begins, so 64 KiB gives roughly three
- * orders of magnitude of headroom for benign variation (pretty-printing,
- * extra metadata fields) while staying a trivial allocation. An envelope
- * whose top-level `result` key sits past this bound is not a plausible
- * honest response and is rejected fail-closed.
- */
-const PREFIX_VALIDATION_BYTES = 64 * 1024;
-
-/**
- * Fetch artifacts from the vault provider and trigger a browser file download.
+ * Fetch artifacts from the vault provider, validate them as they stream, and
+ * save them to `target`.
  *
- * Uses JsonRpcClient.callRaw() so the raw response body can be preserved as
- * a Blob for download without a separate re-serialization pass. Small
- * responses (JSON-RPC error envelopes) are fully parsed and schema-validated
- * before the download fires. Large artifact payloads cannot be parsed on the
- * main thread, so they are validated structurally via their JSON-RPC envelope
- * prefix; full validation of the artifact body is deferred to the streaming
- * work.
+ * Resolves only when the whole body has been validated and durably written.
+ * Throws `JsonRpcError` for an error envelope, `VpResponseValidationError` for
+ * a malformed or truncated payload, `ArtifactFileAccessError` when the save
+ * fails, and `ArtifactDownloadCancelledError` when the caller cancels.
  *
  * @param providerAddress - Vault provider's Ethereum address.
  * @param peginTxid       - Bitcoin pegin transaction ID (hex, with or without 0x prefix).
  * @param depositorPk     - Depositor's Bitcoin public key.
+ * @param target          - Where to write; obtained from `openArtifactSaveTarget`.
  */
 export async function fetchAndDownloadArtifacts(
   providerAddress: string,
   peginTxid: string,
   depositorPk: string,
+  target: ArtifactSaveTarget,
   options?: FetchArtifactsOptions,
-): Promise<void> {
+): Promise<ArtifactDownloadOutcome> {
   const normalizedPeginTxid = stripHexPrefix(peginTxid);
 
   // The caller (useArtifactDownload) primes the bearer before invoking
@@ -134,9 +136,9 @@ export async function fetchAndDownloadArtifacts(
     tokenProvider,
   });
 
-  let body: ReadBodyResult;
+  let response: Response;
   try {
-    const response = await client.callRaw(
+    response = await client.callRaw(
       "vaultProvider_requestDepositorClaimerArtifacts",
       {
         pegin_txid: normalizedPeginTxid,
@@ -144,59 +146,40 @@ export async function fetchAndDownloadArtifacts(
       },
       options?.signal,
     );
-
-    body = await readBodyWithProgress(response, options);
   } catch (err) {
-    // A cancellation can surface here as our own sentinel, the client's
-    // "Request aborted", or a DOM AbortError. Normalize all of them to the
-    // sentinel so the caller's catch swallows the cancel instead of
-    // rendering it as a download failure.
-    if (err instanceof ArtifactDownloadCancelledError) throw err;
-    if (options?.signal?.aborted || options?.isCancelled?.()) {
-      throw new ArtifactDownloadCancelledError();
-    }
-    throw err;
+    throw normalizeCancellation(err, options);
   }
 
-  // Validation runs outside the cancel-normalizing catch above so a genuine
-  // payload error still surfaces as VpResponseValidationError / JsonRpcError.
-  validateArtifactPayload(body.validationBytes, body.byteLength);
-
-  triggerBlobDownload(body.blob, peginTxid);
-}
-
-interface ReadBodyResult {
-  /** The full payload, assembled without an intermediate contiguous copy. */
-  blob: Blob;
-  /** Exact number of bytes received. */
-  byteLength: number;
-  /**
-   * Contiguous bytes for validation: the full body for sub-threshold
-   * payloads (see ERROR_RESPONSE_SIZE_THRESHOLD), or only the leading
-   * PREFIX_VALIDATION_BYTES for real (large) artifact payloads, which are
-   * never fully decoded on the main thread — the prefix is enough for the
-   * envelope check and skips the extra full-size allocation on that path.
-   */
-  validationBytes: Uint8Array;
+  return downloadArtifactsFromResponse(response, target, options, {
+    peginTxid: normalizedPeginTxid,
+    depositorPk,
+  });
 }
 
 /**
- * Stream the response body so the UI can show a real byte-level progress
- * bar, assembling the chunks straight into a Blob. Building the Blob from
- * the chunk array avoids allocating a second full-size contiguous buffer
- * (and the copy loop that fills it) — material on the ~1 GB path, where the
- * old chunks + merged-buffer + Blob sequence held three full copies live at
- * once. Falls back to `Response.arrayBuffer()` when the body is not a
- * ReadableStream (e.g. some test doubles).
+ * Read the body once, feeding every chunk through the validator, the digest,
+ * and the save stream in that order. Validating before writing means a
+ * rejected chunk never reaches disk.
  *
- * Returns the assembled Blob plus its exact byte length, and a contiguous
- * byte copy for validation: the full body for sub-threshold payloads, only
- * the leading PREFIX_VALIDATION_BYTES for large ones.
+ * Exported so the dev-only artifact mock can drive the real pipeline from a
+ * synthetic response: a simulation that skipped validation and the file sink
+ * would not exercise anything worth exercising.
  */
-async function readBodyWithProgress(
+export async function downloadArtifactsFromResponse(
   response: Response,
+  target: ArtifactSaveTarget,
   options: FetchArtifactsOptions | undefined,
-): Promise<ReadBodyResult> {
+  binding: VaultBindingContext,
+): Promise<ArtifactDownloadOutcome> {
+  if (!response.body) {
+    // Every real transport gives a readable stream; without one we cannot
+    // validate incrementally, and silently buffering instead would reinstate
+    // the unbounded-memory path this service exists to remove.
+    throw new VpResponseValidationError(
+      "Artifact response body is not readable as a stream",
+    );
+  }
+
   const contentLengthHeader = response.headers.get("content-length");
   const headerTotal = contentLengthHeader ? Number(contentLengthHeader) : NaN;
   const totalBytes =
@@ -204,25 +187,10 @@ async function readBodyWithProgress(
       ? headerTotal
       : ARTIFACT_TOTAL_FALLBACK_BYTES;
 
-  if (!response.body) {
-    if (options?.isCancelled?.()) {
-      throw new ArtifactDownloadCancelledError();
-    }
-    const buffer = await response.arrayBuffer();
-    options?.onProgress?.(buffer.byteLength, totalBytes);
-    return {
-      blob: new Blob([buffer], { type: ARTIFACT_BLOB_TYPE }),
-      byteLength: buffer.byteLength,
-      validationBytes: new Uint8Array(
-        buffer,
-        0,
-        Math.min(buffer.byteLength, PREFIX_VALIDATION_BYTES),
-      ),
-    };
-  }
-
+  const stream = await target.open();
+  const validator = new ArtifactStreamValidator();
+  const hasher = sha256.create();
   const reader = response.body.getReader();
-  const chunks: Uint8Array<ArrayBuffer>[] = [];
   let received = 0;
 
   options?.onProgress?.(0, totalBytes);
@@ -233,291 +201,80 @@ async function readBodyWithProgress(
         await reader.cancel().catch(() => undefined);
         throw new ArtifactDownloadCancelledError();
       }
-      const { done, value } = await reader.read();
-      if (done) break;
-      if (value) {
-        chunks.push(value);
-        received += value.byteLength;
-        options?.onProgress?.(received, totalBytes);
+
+      let chunk: ReadableStreamReadResult<Uint8Array<ArrayBuffer>>;
+      try {
+        chunk = await reader.read();
+      } catch (err) {
+        throw normalizeCancellation(err, options);
       }
+      if (chunk.done) break;
+      if (!chunk.value) continue;
+
+      received += chunk.value.byteLength;
+      if (received > target.maxBytes) {
+        throw new ArtifactDownloadTooLargeError(received, target.maxBytes);
+      }
+
+      validator.update(chunk.value);
+      hasher.update(chunk.value);
+      await stream.write(chunk.value);
+
+      options?.onProgress?.(received, totalBytes);
     }
+
+    // Rejects a truncated document — the proxy signals a mid-stream backend
+    // failure by destroying the connection, not by sending an error envelope.
+    const validated = validator.finish();
+
+    // Schema-valid is not the same as ours: nothing in the envelope names the
+    // deposit, so the tx graph is what proves the bundle belongs to it.
+    assertBundleBoundToVault(
+      validated.txGraph,
+      Object.keys(validated.result.babe_sessions),
+      binding,
+    );
+  } catch (err) {
+    await discardQuietly(stream);
+    throw err;
   } finally {
     reader.releaseLock();
   }
 
-  // Small payloads need their full body for parsing; large artifact payloads
-  // only need the leading PREFIX_VALIDATION_BYTES for the envelope check
-  // (ERROR_RESPONSE_SIZE_THRESHOLD < PREFIX_VALIDATION_BYTES, so one bound
-  // covers both), keeping the copy far below full payload size on that path.
-  const validationLength = Math.min(received, PREFIX_VALIDATION_BYTES);
-  const validationBytes = new Uint8Array(validationLength);
-  let offset = 0;
-  for (const chunk of chunks) {
-    if (offset >= validationLength) break;
-    const remaining = validationLength - offset;
-    const source =
-      chunk.byteLength > remaining ? chunk.subarray(0, remaining) : chunk;
-    validationBytes.set(source, offset);
-    offset += source.byteLength;
-  }
+  await stream.commit();
 
   return {
-    blob: new Blob(chunks, { type: ARTIFACT_BLOB_TYPE }),
+    filename: target.filename,
     byteLength: received,
-    validationBytes,
+    sha256: bytesToHex(hasher.digest()),
+    method: target.method,
   };
 }
 
 /**
- * Parse the raw JSON-RPC response and validate the artifact payload against
- * its runtime schema. Throws JsonRpcError for RPC-level errors and
- * VpResponseValidationError for malformed or incomplete artifact data.
- *
- * Payloads at or above ERROR_RESPONSE_SIZE_THRESHOLD cannot be parsed on the
- * main thread - turning a ~1 GB payload into a string would exceed V8's max
- * string length or freeze the tab - so they are validated structurally via
- * their envelope prefix (see validateLargePayloadEnvelopePrefix) instead of
- * being passed through unchecked. For those, `validationBytes` holds only
- * the leading PREFIX_VALIDATION_BYTES of the body.
+ * A cancellation can surface as our own sentinel, the RPC client's "Request
+ * aborted", or a DOM AbortError. Normalize all of them so the caller's catch
+ * swallows the cancel instead of rendering it as a download failure.
  */
-function validateArtifactPayload(
-  validationBytes: Uint8Array,
-  byteLength: number,
-): void {
-  if (byteLength >= ERROR_RESPONSE_SIZE_THRESHOLD) {
-    validateLargePayloadEnvelopePrefix(validationBytes);
-    return;
+function normalizeCancellation(
+  err: unknown,
+  options: FetchArtifactsOptions | undefined,
+): unknown {
+  if (err instanceof ArtifactDownloadCancelledError) return err;
+  if (options?.signal?.aborted || options?.isCancelled?.()) {
+    return new ArtifactDownloadCancelledError();
   }
+  return err;
+}
 
-  const text = new TextDecoder("utf-8").decode(validationBytes);
-
-  let envelope: unknown;
+/** Never let a cleanup failure mask the error that caused the cleanup. */
+async function discardQuietly(stream: ArtifactSaveStream): Promise<void> {
   try {
-    envelope = JSON.parse(text);
-  } catch {
-    throw new VpResponseValidationError(
-      "Artifact response body is not valid JSON",
-    );
+    await stream.discard();
+  } catch (discardErr) {
+    logger.warn("Failed to discard the partial artifact download", {
+      category: "activation",
+      reason: String(discardErr),
+    });
   }
-
-  if (
-    envelope === null ||
-    typeof envelope !== "object" ||
-    Array.isArray(envelope)
-  ) {
-    throw new VpResponseValidationError(
-      "Artifact response envelope is not a JSON object",
-    );
-  }
-
-  const record = envelope as Record<string, unknown>;
-
-  if ("error" in record && record.error != null) {
-    const err = record.error as Record<string, unknown>;
-    const code =
-      typeof err.code === "number"
-        ? err.code
-        : JSON_RPC_ERROR_CODES.INVALID_RESPONSE;
-    const message =
-      typeof err.message === "string" ? err.message : "Unknown RPC error";
-    throw new JsonRpcError(code, message, "wire", err.data);
-  }
-
-  if (!("result" in record)) {
-    throw new VpResponseValidationError(
-      "Artifact response envelope is missing the result field",
-    );
-  }
-
-  validateRequestDepositorClaimerArtifactsResponse(record.result);
-}
-
-/**
- * Structural validation for payloads too large to parse on the main thread.
- * Decodes only the envelope prefix and rejects anything that isn't a JSON-RPC
- * success envelope: non-JSON garbage, or an error envelope padded past
- * ERROR_RESPONSE_SIZE_THRESHOLD to slip past the parsed small-response path.
- *
- * The prefix is scanned with a depth-aware tokenizer so only keys of the
- * top-level envelope object count — `"result"`/`"error"` text nested inside
- * the artifact body cannot flip the verdict, and key order is irrelevant.
- * Within the prefix the verdict matches the parsed small-response path: any
- * non-null top-level `error` rejects (even alongside a `result` key), and a
- * missing top-level `result` rejects. The match is not exact under
- * truncation, though: an envelope that declares `result` early and pads a
- * top-level `error` past the prefix window passes here where the parsed
- * path would reject. That divergence adds nothing exploitable — the body is
- * not validated on this path, so a malicious VP already passes with a plain
- * `{"result": <garbage>}` envelope (see below).
- *
- * This does NOT prove the (unparsed) artifact body is well-formed - a VP that
- * returns a success-shaped envelope wrapping a corrupt artifact still passes.
- * Validating the body itself needs the deferred streaming/verification work.
- */
-function validateLargePayloadEnvelopePrefix(bytes: Uint8Array): void {
-  const slice =
-    bytes.byteLength > PREFIX_VALIDATION_BYTES
-      ? bytes.subarray(0, PREFIX_VALIDATION_BYTES)
-      : bytes;
-  // Default (non-fatal) decoding tolerates a multi-byte char clipped at the
-  // slice boundary rather than throwing.
-  const prefix = new TextDecoder("utf-8").decode(slice);
-
-  const scan = scanEnvelopePrefix(prefix);
-
-  if (!scan.isJsonObject) {
-    throw new VpResponseValidationError(
-      "Artifact response is not a JSON object",
-    );
-  }
-
-  if (scan.hasNonNullTopLevelError) {
-    throw new VpResponseValidationError(
-      "Artifact response is a JSON-RPC error envelope, not artifact data",
-    );
-  }
-
-  if (!scan.hasTopLevelResult) {
-    throw new VpResponseValidationError(
-      "Artifact response envelope is missing the result field",
-    );
-  }
-}
-
-/** JSON whitespace per RFC 8259: space, tab, line feed, carriage return. */
-const JSON_WHITESPACE = new Set([" ", "\t", "\n", "\r"]);
-
-interface EnvelopePrefixScan {
-  /** The first non-whitespace character opens a JSON object. */
-  isJsonObject: boolean;
-  /** The top-level object declares a `result` key within the prefix. */
-  hasTopLevelResult: boolean;
-  /**
-   * The top-level object declares an `error` key whose value is anything
-   * other than the literal `null` — the same condition the parsed
-   * small-response path treats as an error envelope.
-   */
-  hasNonNullTopLevelError: boolean;
-}
-
-/**
- * Structurally scan a (possibly truncated) JSON document prefix for the
- * top-level `result`/`error` keys. Tracks string/escape state and nesting
- * depth instead of substring matching, so occurrences nested inside values
- * are ignored. Under truncation, keys seen before the cut are reliable and
- * anything cut off stays unreported: callers treat a missing `result` as a
- * rejection, so truncation fails closed for `result` — but an `error` key
- * pushed past the cut goes unseen, so its absence from the scan does not
- * prove the envelope is error-free.
- */
-function scanEnvelopePrefix(prefix: string): EnvelopePrefixScan {
-  const scan: EnvelopePrefixScan = {
-    isJsonObject: false,
-    hasTopLevelResult: false,
-    hasNonNullTopLevelError: false,
-  };
-
-  const start = skipJsonWhitespace(prefix, 0);
-  if (prefix[start] !== "{") {
-    return scan;
-  }
-  scan.isJsonObject = true;
-
-  let depth = 0;
-  let inString = false;
-  let escaped = false;
-  let stringValue = "";
-  let stringDepth = 0;
-
-  for (let index = start; index < prefix.length; index++) {
-    const char = prefix[index];
-
-    if (inString) {
-      if (escaped) {
-        escaped = false;
-        continue;
-      }
-      if (char === "\\") {
-        escaped = true;
-        continue;
-      }
-      if (char !== '"') {
-        stringValue += char;
-        continue;
-      }
-      inString = false;
-      if (stringDepth !== 1) {
-        continue;
-      }
-      // A string directly inside the top-level object is a key only when
-      // followed by a colon; otherwise it is a top-level value string.
-      const colonIndex = skipJsonWhitespace(prefix, index + 1);
-      if (prefix[colonIndex] !== ":") {
-        continue;
-      }
-      if (stringValue === "result") {
-        scan.hasTopLevelResult = true;
-      }
-      if (
-        stringValue === "error" &&
-        !isNullLiteral(prefix, skipJsonWhitespace(prefix, colonIndex + 1))
-      ) {
-        scan.hasNonNullTopLevelError = true;
-      }
-      continue;
-    }
-
-    if (char === '"') {
-      inString = true;
-      escaped = false;
-      stringValue = "";
-      stringDepth = depth;
-    } else if (char === "{" || char === "[") {
-      depth++;
-    } else if (char === "}" || char === "]") {
-      depth--;
-    }
-  }
-
-  return scan;
-}
-
-function skipJsonWhitespace(text: string, from: number): number {
-  let index = from;
-  while (index < text.length && JSON_WHITESPACE.has(text[index])) {
-    index++;
-  }
-  return index;
-}
-
-/**
- * True when `text` holds the JSON literal `null` at `from`, i.e. followed by
- * a value delimiter or the end of the (truncated) prefix. A truncated
- * `null` reads as non-null, which fails closed on the error-envelope check.
- */
-function isNullLiteral(text: string, from: number): boolean {
-  if (!text.startsWith("null", from)) {
-    return false;
-  }
-  const next = text[from + "null".length];
-  return (
-    next === undefined ||
-    next === "," ||
-    next === "}" ||
-    JSON_WHITESPACE.has(next)
-  );
-}
-
-/**
- * Trigger a browser file download from a Blob.
- */
-function triggerBlobDownload(blob: Blob, peginTxid: string): void {
-  const url = URL.createObjectURL(blob);
-  const anchor = document.createElement("a");
-  anchor.href = url;
-  anchor.download = `babylon-vault-artifacts-${stripHexPrefix(peginTxid).slice(0, 8)}.json`;
-  document.body.appendChild(anchor);
-  anchor.click();
-  document.body.removeChild(anchor);
-  URL.revokeObjectURL(url);
 }

--- a/services/vault/src/services/artifacts/artifactDownloadService.ts
+++ b/services/vault/src/services/artifacts/artifactDownloadService.ts
@@ -17,11 +17,14 @@
  * Bytes are validated, hashed, and written chunk-by-chunk in a single pass,
  * so the full body is never held in memory on the File System Access path.
  *
- * What this does NOT establish: that the artifact bytes decrypt correctly, or
- * that the bundle belongs to this vault. The response carries no pegin txid or
- * depositor key to bind against, and no client-side BaBe verifier exists. A
- * provider returning a well-formed bundle for the wrong vault is not detected
- * here.
+ * The bundle is also bound to the deposit it was requested for: the envelope
+ * names no vault, but the transaction graph inside it does, so its claim and
+ * payout transactions are checked against the requested pegin txid and its
+ * depositor key against the requested one. See `artifactBinding.ts`.
+ *
+ * What this does NOT establish: that the artifact bytes decrypt correctly. No
+ * client-side BaBe verifier exists, so the payload is proven well-formed and
+ * addressed to this deposit, never proven usable.
  */
 
 import { stripHexPrefix } from "@babylonlabs-io/ts-sdk/tbv/core";

--- a/services/vault/src/services/artifacts/artifactSaveTarget.ts
+++ b/services/vault/src/services/artifacts/artifactSaveTarget.ts
@@ -45,12 +45,18 @@ const ARTIFACT_PICKER_ID = "babylon-vault-artifacts";
 /**
  * Ceiling for the in-memory fallback path.
  *
- * A full-size bundle (~1.3 GB) cannot be held as a Blob without killing the
- * tab, so the fallback refuses anything above this and the caller surfaces
- * copy pointing at a Chromium browser. Failing loudly beats an out-of-memory
- * crash or a silently truncated recovery bundle.
+ * This path has to hold the whole body before it can hand the browser a Blob,
+ * so it needs a bound — but the bound has to sit *above* a real bundle or the
+ * path is guaranteed to fail after wasting the user's bandwidth. A measured
+ * vault-devnet body is 1,410,824,702 bytes, so 2 GiB leaves headroom while
+ * still refusing an implausible response outright.
+ *
+ * This is best-effort, not reliable: the chunk array and the resulting Blob
+ * can both be resident, so a full-size bundle may still exhaust memory on a
+ * constrained machine. Callers warn before starting. The durable fix is a
+ * streaming sink that works outside Chromium — see the OPFS follow-up.
  */
-const FALLBACK_MAX_BODY_BYTES = 512 * 1024 * 1024;
+const FALLBACK_MAX_BODY_BYTES = 2 * 1024 * 1024 * 1024;
 
 export type ArtifactSaveMethod = "file-system-access" | "browser-download";
 

--- a/services/vault/src/services/artifacts/artifactSaveTarget.ts
+++ b/services/vault/src/services/artifacts/artifactSaveTarget.ts
@@ -1,0 +1,273 @@
+/**
+ * Where a downloaded artifact bundle is written.
+ *
+ * Two implementations, chosen by browser capability:
+ *
+ * - **File System Access** (Chromium): the user picks a location up front and
+ *   bytes stream straight to disk. `createWritable()` writes to a swap file
+ *   that only replaces the target on `close()`, so aborting a failed download
+ *   leaves nothing behind. This is the only path that can tell a completed
+ *   save from a cancelled one, and the only one that avoids holding the whole
+ *   ~1.3 GB bundle in memory.
+ * - **Anchor download** (everything else): the historical behavior — buffer
+ *   the body, hand the browser a Blob, click a synthetic link. The browser
+ *   gives no save/cancel signal here, so the caller must fall back to user
+ *   attestation, and a size ceiling applies because the body must fit in
+ *   memory.
+ *
+ * The split between *target* (one picker prompt, one permission grant) and
+ * *stream* (one writable per attempt) exists so the download hook's auth-retry
+ * loop can restart a transfer without re-prompting: `createWritable()` needs
+ * no user activation, unlike `showSaveFilePicker()`.
+ */
+
+import { stripHexPrefix } from "@babylonlabs-io/ts-sdk/tbv/core";
+
+import { COPY } from "@/copy";
+
+import {
+  ArtifactDownloadCancelledError,
+  ArtifactFileAccessError,
+} from "./errors";
+
+/** MIME type for the assembled artifact file (the payload is JSON). */
+const ARTIFACT_BLOB_TYPE = "application/json";
+
+/** Characters of the pegin txid used to disambiguate the filename. */
+const FILENAME_TXID_PREFIX_CHARS = 8;
+
+/**
+ * Identifier Chrome uses to remember the last directory chosen for artifact
+ * saves, so a user with several vaults is not re-navigated every time.
+ */
+const ARTIFACT_PICKER_ID = "babylon-vault-artifacts";
+
+/**
+ * Ceiling for the in-memory fallback path.
+ *
+ * A full-size bundle (~1.3 GB) cannot be held as a Blob without killing the
+ * tab, so the fallback refuses anything above this and the caller surfaces
+ * copy pointing at a Chromium browser. Failing loudly beats an out-of-memory
+ * crash or a silently truncated recovery bundle.
+ */
+const FALLBACK_MAX_BODY_BYTES = 512 * 1024 * 1024;
+
+export type ArtifactSaveMethod = "file-system-access" | "browser-download";
+
+/**
+ * A destination the caller may write to. `open()` may be called more than
+ * once — each call starts a fresh, empty write attempt.
+ */
+export interface ArtifactSaveTarget {
+  readonly method: ArtifactSaveMethod;
+  readonly filename: string;
+  /** Largest body this target can accept; Infinity when it streams to disk. */
+  readonly maxBytes: number;
+  open(): Promise<ArtifactSaveStream>;
+}
+
+export interface ArtifactSaveStream {
+  // Pinned to a non-shared ArrayBuffer because the File System Access write
+  // API does not accept views over a SharedArrayBuffer.
+  write(chunk: Uint8Array<ArrayBuffer>): Promise<void>;
+  /** Durably persist what was written. Resolves only once the save is done. */
+  commit(): Promise<void>;
+  /** Abandon the attempt, leaving no partial file behind. */
+  discard(): Promise<void>;
+}
+
+interface SaveFilePickerOptions {
+  suggestedName?: string;
+  id?: string;
+  startIn?: "downloads";
+  types?: { description: string; accept: Record<string, string[]> }[];
+}
+
+type ShowSaveFilePicker = (
+  options?: SaveFilePickerOptions,
+) => Promise<FileSystemFileHandle>;
+
+/**
+ * `showSaveFilePicker` is not in TypeScript's DOM lib, so it is resolved
+ * dynamically rather than declared globally.
+ */
+function getShowSaveFilePicker(): ShowSaveFilePicker | null {
+  if (typeof window === "undefined" || !window.isSecureContext) return null;
+  const picker = (window as unknown as { showSaveFilePicker?: unknown })
+    .showSaveFilePicker;
+  return typeof picker === "function" ? (picker as ShowSaveFilePicker) : null;
+}
+
+/**
+ * True when the browser can stream the bundle straight to a user-chosen file.
+ * Callers use this to warn about the fallback path's limitations *before* a
+ * multi-minute download starts.
+ */
+export function isFileSystemAccessSupported(): boolean {
+  return getShowSaveFilePicker() !== null;
+}
+
+function artifactFilename(peginTxid: string): string {
+  const shortId = stripHexPrefix(peginTxid).slice(
+    0,
+    FILENAME_TXID_PREFIX_CHARS,
+  );
+  return `babylon-vault-artifacts-${shortId}.json`;
+}
+
+/**
+ * Resolve where this download will be saved.
+ *
+ * IMPORTANT: on the File System Access path this shows the browser's save
+ * dialog, which requires transient user activation. It must therefore be
+ * called before any `await` in the click handler that triggers the download.
+ */
+export async function openArtifactSaveTarget(
+  peginTxid: string,
+): Promise<ArtifactSaveTarget> {
+  const filename = artifactFilename(peginTxid);
+  const showSaveFilePicker = getShowSaveFilePicker();
+
+  if (!showSaveFilePicker) {
+    return new BrowserDownloadTarget(filename);
+  }
+
+  let handle: FileSystemFileHandle;
+  try {
+    handle = await showSaveFilePicker({
+      suggestedName: filename,
+      id: ARTIFACT_PICKER_ID,
+      startIn: "downloads",
+      types: [
+        {
+          description: COPY.deposit.recoveryArtifacts.savePickerDescription,
+          accept: { [ARTIFACT_BLOB_TYPE]: [".json"] },
+        },
+      ],
+    });
+  } catch (err) {
+    // Dismissing the dialog is a user action, not a failure.
+    if (err instanceof DOMException && err.name === "AbortError") {
+      throw new ArtifactDownloadCancelledError();
+    }
+    throw new ArtifactFileAccessError(
+      COPY.deposit.recoveryArtifacts.fileAccessDenied,
+      { cause: err },
+    );
+  }
+
+  return new FileSystemAccessTarget(handle, filename);
+}
+
+class FileSystemAccessTarget implements ArtifactSaveTarget {
+  readonly method = "file-system-access" as const;
+  /** Bytes never accumulate in memory, so there is nothing to cap. */
+  readonly maxBytes = Number.POSITIVE_INFINITY;
+
+  constructor(
+    private readonly handle: FileSystemFileHandle,
+    readonly filename: string,
+  ) {}
+
+  async open(): Promise<ArtifactSaveStream> {
+    try {
+      // keepExistingData: false so a retry overwrites rather than patching
+      // the previous attempt's bytes.
+      const writable = await this.handle.createWritable({
+        keepExistingData: false,
+      });
+      return new FileSystemAccessStream(writable);
+    } catch (err) {
+      throw new ArtifactFileAccessError(
+        COPY.deposit.recoveryArtifacts.fileAccessDenied,
+        { cause: err },
+      );
+    }
+  }
+}
+
+class FileSystemAccessStream implements ArtifactSaveStream {
+  constructor(private readonly writable: FileSystemWritableFileStream) {}
+
+  async write(chunk: Uint8Array<ArrayBuffer>): Promise<void> {
+    try {
+      // Awaited so disk I/O backpressures the network reader instead of
+      // letting chunks pile up in memory.
+      await this.writable.write(chunk);
+    } catch (err) {
+      throw new ArtifactFileAccessError(
+        COPY.deposit.recoveryArtifacts.fileAccessDenied,
+        { cause: err },
+      );
+    }
+  }
+
+  async commit(): Promise<void> {
+    try {
+      // Atomically swaps the temporary file into the user's chosen path.
+      await this.writable.close();
+    } catch (err) {
+      throw new ArtifactFileAccessError(
+        COPY.deposit.recoveryArtifacts.fileAccessDenied,
+        { cause: err },
+      );
+    }
+  }
+
+  async discard(): Promise<void> {
+    // Discards the swap file; the user's chosen path is left untouched.
+    await this.writable.abort();
+  }
+}
+
+class BrowserDownloadTarget implements ArtifactSaveTarget {
+  readonly method = "browser-download" as const;
+  readonly maxBytes = FALLBACK_MAX_BODY_BYTES;
+
+  constructor(readonly filename: string) {}
+
+  async open(): Promise<ArtifactSaveStream> {
+    return new BrowserDownloadStream(this.filename);
+  }
+}
+
+class BrowserDownloadStream implements ArtifactSaveStream {
+  private chunks: Uint8Array<ArrayBuffer>[] | null = [];
+
+  constructor(private readonly filename: string) {}
+
+  async write(chunk: Uint8Array<ArrayBuffer>): Promise<void> {
+    this.chunks?.push(chunk);
+  }
+
+  async commit(): Promise<void> {
+    if (!this.chunks) {
+      throw new ArtifactFileAccessError(
+        COPY.deposit.recoveryArtifacts.fileAccessDenied,
+      );
+    }
+    // The Blob is built from the chunk array directly so no second full-size
+    // contiguous copy is allocated alongside it.
+    const blob = new Blob(this.chunks as BlobPart[], {
+      type: ARTIFACT_BLOB_TYPE,
+    });
+    this.chunks = null;
+
+    const url = URL.createObjectURL(blob);
+    try {
+      const anchor = document.createElement("a");
+      anchor.href = url;
+      anchor.download = this.filename;
+      document.body.appendChild(anchor);
+      anchor.click();
+      document.body.removeChild(anchor);
+    } finally {
+      URL.revokeObjectURL(url);
+    }
+  }
+
+  async discard(): Promise<void> {
+    // Nothing was handed to the browser yet, so dropping the buffer is enough.
+    this.chunks = null;
+  }
+}

--- a/services/vault/src/services/artifacts/errors.ts
+++ b/services/vault/src/services/artifacts/errors.ts
@@ -1,0 +1,56 @@
+/**
+ * Error types for the artifact download flow.
+ *
+ * Payload-shape rejections deliberately reuse the SDK's
+ * `VpResponseValidationError` (it already carries a user-safe `.message` plus
+ * a technical `.detail`), and JSON-RPC wire errors reuse `JsonRpcError`. Only
+ * the failure modes with no existing home — cancellation, the file sink, and
+ * the fallback size ceiling — get their own class here.
+ */
+
+/**
+ * Sentinel thrown when the caller cancels the download via
+ * `FetchArtifactsOptions.isCancelled` / `FetchArtifactsOptions.signal`, or
+ * when the user dismisses the save-location picker. Callers should swallow
+ * this instead of surfacing it as an error.
+ */
+export class ArtifactDownloadCancelledError extends Error {
+  constructor() {
+    super("Artifact download was cancelled");
+    this.name = "ArtifactDownloadCancelledError";
+  }
+}
+
+/**
+ * Thrown when the browser refuses the save target or the write itself fails:
+ * a denied File System Access permission, a revoked handle, or a disk error
+ * mid-stream. Distinct from a cancellation — the user asked for the file and
+ * did not get it, so the flow must surface an error rather than reset quietly.
+ */
+export class ArtifactFileAccessError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "ArtifactFileAccessError";
+  }
+}
+
+/**
+ * Thrown when the response exceeds what the active save target can hold.
+ *
+ * Only reachable on the anchor-download fallback, which must buffer the whole
+ * body in memory before it can hand a Blob to the browser. Failing loudly
+ * beats an out-of-memory tab kill or a silently truncated recovery bundle.
+ */
+export class ArtifactDownloadTooLargeError extends Error {
+  readonly receivedBytes: number;
+  readonly maxBytes: number;
+
+  constructor(receivedBytes: number, maxBytes: number) {
+    super(
+      `Artifact response exceeds the ${maxBytes}-byte limit of this browser's download path (received at least ${receivedBytes} bytes)`,
+    );
+    this.name = "ArtifactDownloadTooLargeError";
+    this.receivedBytes = receivedBytes;
+    this.maxBytes = maxBytes;
+  }
+}

--- a/services/vault/src/services/artifacts/index.ts
+++ b/services/vault/src/services/artifacts/index.ts
@@ -19,3 +19,7 @@ export {
   ArtifactDownloadTooLargeError,
   ArtifactFileAccessError,
 } from "./errors";
+// The validator itself stays internal to this service; only the error-value
+// cap is published, so fixtures that must sit under it (the god-mode demo)
+// can derive their size instead of hardcoding one that silently drifts.
+export { MAX_ERROR_VALUE_BYTES } from "./streamingArtifactValidator";

--- a/services/vault/src/services/artifacts/index.ts
+++ b/services/vault/src/services/artifacts/index.ts
@@ -1,5 +1,21 @@
 export {
-  ArtifactDownloadCancelledError,
+  assertBundleBoundToVault,
+  type VaultBindingContext,
+} from "./artifactBinding";
+export {
+  downloadArtifactsFromResponse,
   fetchAndDownloadArtifacts,
+  type ArtifactDownloadOutcome,
   type FetchArtifactsOptions,
 } from "./artifactDownloadService";
+export {
+  isFileSystemAccessSupported,
+  openArtifactSaveTarget,
+  type ArtifactSaveMethod,
+  type ArtifactSaveTarget,
+} from "./artifactSaveTarget";
+export {
+  ArtifactDownloadCancelledError,
+  ArtifactDownloadTooLargeError,
+  ArtifactFileAccessError,
+} from "./errors";

--- a/services/vault/src/services/artifacts/streamingArtifactValidator.ts
+++ b/services/vault/src/services/artifacts/streamingArtifactValidator.ts
@@ -79,7 +79,7 @@ const MAX_BABE_SESSIONS = 1024;
  * A JSON-RPC error object is small by construction. Anything larger is not a
  * plausible honest error response, so we fail closed rather than buffer it.
  */
-const MAX_ERROR_VALUE_BYTES = 64 * 1024;
+export const MAX_ERROR_VALUE_BYTES = 64 * 1024;
 
 /**
  * Ceiling for string values we do not consume (`jsonrpc`, `id`, and any
@@ -739,6 +739,15 @@ export class ArtifactStreamValidator {
         break;
       }
       default:
+        // Untracked values (jsonrpc, id, any forward-compat field) are
+        // discarded, but they are still part of the document this validator
+        // claims is well-formed, and RFC 8259 makes UTF-8 part of that. The
+        // byte machine only rejects control characters, so without this a raw
+        // 0x80 here would commit a bundle no strict JSON parser can read.
+        // The capture is already populated and bounded, so this only pays for
+        // the decode. `decryptor_artifacts_hex` never reaches here — its
+        // capture is null and the hex table already rejects bytes >= 0x80.
+        decodeJsonString(this.stringCapture, "string value");
         break;
     }
 

--- a/services/vault/src/services/artifacts/streamingArtifactValidator.ts
+++ b/services/vault/src/services/artifacts/streamingArtifactValidator.ts
@@ -1,0 +1,993 @@
+/**
+ * Single-pass streaming validator for the depositor-claimer artifact response.
+ *
+ * The recovery bundle is ~1.3 GB, so it can never be turned into a string or a
+ * contiguous buffer — `JSON.parse` on a body that size exceeds V8's maximum
+ * string length and freezes the tab. This validator consumes the response one
+ * chunk at a time and proves the whole document is a well-formed JSON-RPC
+ * success envelope wrapping a schema-valid artifact payload, while holding
+ * only a few KB of state.
+ *
+ * Why a byte-level machine rather than an incremental `TextDecoder`: every
+ * JSON structural character is ASCII, and every byte of a multi-byte UTF-8
+ * sequence is >= 0x80, so a byte scanner can never mistake payload text for
+ * structure. Decoding to strings first would allocate ~1.3 GB of transient
+ * strings for no benefit. The small fields that we *do* need as text are
+ * captured as raw JSON source (quotes included) and handed to `JSON.parse`
+ * once, so escape and surrogate handling stays V8's job rather than ours.
+ *
+ * Two properties this buys that the previous prefix-scan could not:
+ * - **Truncation is caught.** The vault-provider proxy signals a mid-stream
+ *   backend failure by destroying the connection, which yields a syntactically
+ *   incomplete document rather than an error envelope. `finish()` rejects
+ *   unless the parse reached the closing brace.
+ * - **Key order is irrelevant.** The proxy only guarantees field ordering on
+ *   its gRPC path (off by default); otherwise the body is a byte-for-byte
+ *   passthrough of the Rust serializer, and `babe_sessions` key order is
+ *   explicitly unspecified. Nothing here depends on order.
+ */
+
+import {
+  JSON_RPC_ERROR_CODES,
+  JsonRpcError,
+  type RequestDepositorClaimerArtifactsResponse,
+  validateRequestDepositorClaimerArtifactsResponse,
+  VpResponseValidationError,
+} from "@babylonlabs-io/ts-sdk/tbv/core/clients";
+
+import { COPY } from "@/copy";
+
+/**
+ * Nesting limit. The envelope needs exactly four levels
+ * (envelope -> result -> babe_sessions -> session), so this is ~8x headroom
+ * for forward-compatible fields while bounding the frame stack against a
+ * deeply nested payload designed to exhaust memory.
+ */
+const JSON_MAX_DEPTH = 32;
+
+/**
+ * Longest object key we will hold. The longest legitimate key is a 66-char
+ * compressed pubkey; 256 leaves room for future field names without letting a
+ * hostile payload stream an unbounded "key" into memory.
+ */
+const MAX_JSON_KEY_BYTES = 256;
+
+/**
+ * Serialized TxGraph ceiling. A real vault-devnet bundle (4 vault keepers + 4
+ * universal challengers) carries a 1.79 MB graph, and the graph grows roughly
+ * with the challenger count, so 32 MiB covers an order of magnitude more
+ * challengers while still bounding the allocation to a rounding error against
+ * the ~1.4 GB body.
+ */
+const MAX_TX_GRAPH_JSON_BYTES = 32 * 1024 * 1024;
+
+/**
+ * Groth16 verifying key ceiling. The measured ark-serialized key is 528 hex
+ * characters (264 bytes) and is fixed-size for a given circuit, so 64 KiB is
+ * ~124x headroom for a circuit change.
+ */
+const MAX_VERIFYING_KEY_HEX_BYTES = 64 * 1024;
+
+/**
+ * Challenger-count ceiling. A real bundle carries 8 sessions (4 local + 4
+ * universal); 1024 is far above any plausible signer set and exists only to
+ * stop an unbounded session map being used as a memory sink.
+ */
+const MAX_BABE_SESSIONS = 1024;
+
+/**
+ * A JSON-RPC error object is small by construction. Anything larger is not a
+ * plausible honest error response, so we fail closed rather than buffer it.
+ */
+const MAX_ERROR_VALUE_BYTES = 64 * 1024;
+
+/**
+ * Ceiling for string values we do not consume (`jsonrpc`, `id`, and any
+ * forward-compatible field a future VP adds). They are discarded as they
+ * stream, but the length is still bounded so an unknown field cannot be used
+ * as an unbounded sink.
+ */
+const MAX_UNKNOWN_STRING_BYTES = 1024 * 1024;
+
+/**
+ * How much of each `decryptor_artifacts_hex` value is retained.
+ *
+ * The full values are hundreds of megabytes and are never buffered. This
+ * prefix exists solely so the reconstructed skeleton carries a *real* hex
+ * substring for the SDK validator to assert on — see `finish()`.
+ */
+const DECRYPTOR_HEX_PREVIEW_CHARS = 64;
+
+/** Initial capacity for a growable capture buffer, doubled on demand. */
+const CAPTURE_BUFFER_INITIAL_BYTES = 256;
+
+// ASCII bytes the structural machine tests against.
+const BYTE_TAB = 0x09;
+const BYTE_LF = 0x0a;
+const BYTE_CR = 0x0d;
+const BYTE_SPACE = 0x20;
+const BYTE_QUOTE = 0x22;
+const BYTE_PLUS = 0x2b;
+const BYTE_COMMA = 0x2c;
+const BYTE_MINUS = 0x2d;
+const BYTE_DOT = 0x2e;
+const BYTE_ZERO = 0x30;
+const BYTE_NINE = 0x39;
+const BYTE_COLON = 0x3a;
+const BYTE_UPPER_E = 0x45;
+const BYTE_BACKSLASH = 0x5c;
+const BYTE_OPEN_BRACKET = 0x5b;
+const BYTE_CLOSE_BRACKET = 0x5d;
+const BYTE_LOWER_E = 0x65;
+const BYTE_LOWER_F = 0x66;
+const BYTE_LOWER_N = 0x6e;
+const BYTE_LOWER_T = 0x74;
+const BYTE_LOWER_U = 0x75;
+const BYTE_OPEN_BRACE = 0x7b;
+const BYTE_CLOSE_BRACE = 0x7d;
+
+/** Lowest byte that may appear unescaped inside a JSON string (RFC 8259). */
+const MIN_UNESCAPED_STRING_BYTE = 0x20;
+
+/** Lookup table for the hex fast path: 1 when the byte is `[0-9a-fA-F]`. */
+const IS_HEX_BYTE = (() => {
+  const table = new Uint8Array(256);
+  for (const char of "0123456789abcdefABCDEF") {
+    table[char.charCodeAt(0)] = 1;
+  }
+  return table;
+})();
+
+/** Escape characters permitted after a backslash inside a JSON string. */
+const SIMPLE_ESCAPES = new Set<number>([
+  BYTE_QUOTE,
+  BYTE_BACKSLASH,
+  0x2f, // /
+  0x62, // b
+  BYTE_LOWER_F,
+  BYTE_LOWER_N,
+  0x72, // r
+  BYTE_LOWER_T,
+]);
+
+type ParserState =
+  | "expect_value"
+  | "expect_value_or_close"
+  | "expect_key_or_close"
+  | "expect_key"
+  | "expect_colon"
+  | "in_string"
+  | "in_string_escape"
+  | "in_string_unicode"
+  | "in_number"
+  | "in_literal"
+  | "after_value"
+  | "done";
+
+type NumberState =
+  | "minus"
+  | "zero"
+  | "int"
+  | "frac_start"
+  | "frac"
+  | "exp_start"
+  | "exp_sign"
+  | "exp";
+
+/** Number sub-states that may legally end the number. */
+const ACCEPTING_NUMBER_STATES = new Set<NumberState>([
+  "zero",
+  "int",
+  "frac",
+  "exp",
+]);
+
+/** Where the string currently being scanned should go. */
+type StringTarget =
+  | "key"
+  | "tx_graph_json"
+  | "verifying_key_hex"
+  | "decryptor_artifacts_hex"
+  | "ignored";
+
+interface Frame {
+  kind: "object" | "array";
+  /** Key whose value is currently being read; null inside arrays. */
+  currentKey: string | null;
+  /** Populated only for the four tracked object levels. */
+  seenKeys: Set<string> | null;
+}
+
+export interface ArtifactStreamValidationResult {
+  /**
+   * The reconstructed payload handed to the SDK validator. Its
+   * `decryptor_artifacts_hex` values are verified prefixes, not full values —
+   * see the note on `finish()`.
+   */
+  result: RequestDepositorClaimerArtifactsResponse;
+  /** `tx_graph_json` parsed, already proven to be a JSON object. */
+  txGraph: Record<string, unknown>;
+  /** Full hex length observed per challenger pubkey. */
+  sessionHexLengths: Readonly<Record<string, number>>;
+}
+
+/** Growable byte buffer for capturing small JSON source spans. */
+class CaptureBuffer {
+  private bytes = new Uint8Array(CAPTURE_BUFFER_INITIAL_BYTES);
+  private length = 0;
+
+  constructor(
+    private readonly max: number,
+    private readonly field: string,
+  ) {}
+
+  push(byte: number): void {
+    if (this.length >= this.max) {
+      throw new VpResponseValidationError(
+        `Artifact response field "${this.field}" exceeds its ${this.max}-byte limit`,
+      );
+    }
+    if (this.length === this.bytes.length) {
+      const grown = new Uint8Array(
+        Math.min(this.bytes.length * 2, this.max + 1),
+      );
+      grown.set(this.bytes);
+      this.bytes = grown;
+    }
+    this.bytes[this.length++] = byte;
+  }
+
+  /** Decodes as strict UTF-8; invalid sequences are a validation failure. */
+  decode(): string {
+    try {
+      return new TextDecoder("utf-8", { fatal: true }).decode(
+        this.bytes.subarray(0, this.length),
+      );
+    } catch {
+      throw new VpResponseValidationError(
+        `Artifact response field "${this.field}" is not valid UTF-8`,
+      );
+    }
+  }
+}
+
+/** Per-challenger accounting for a `decryptor_artifacts_hex` value. */
+interface SessionHex {
+  /** Total hex characters observed on the wire. */
+  length: number;
+  /** First DECRYPTOR_HEX_PREVIEW_CHARS characters, as observed. */
+  preview: string;
+}
+
+export class ArtifactStreamValidator {
+  private state: ParserState = "expect_value";
+  private readonly frames: Frame[] = [];
+
+  private numberState: NumberState = "int";
+  private literalExpected = "";
+  private literalIndex = 0;
+  private unicodeDigitsSeen = 0;
+
+  private stringIsKey = false;
+  private stringTarget: StringTarget = "ignored";
+  private stringCapture: CaptureBuffer | null = null;
+  private hexCount = 0;
+  private hexPreview = "";
+
+  private errorCapture: CaptureBuffer | null = null;
+
+  private resultSeen = false;
+  private txGraphJson: string | null = null;
+  private verifyingKeyHex: string | null = null;
+  private babeSessionsSeen = false;
+  private readonly sessionKeys: string[] = [];
+  private readonly sessionHex = new Map<string, SessionHex>();
+
+  /**
+   * Feed the next chunk of the response body.
+   *
+   * Throws synchronously — `JsonRpcError` for a JSON-RPC error envelope,
+   * `VpResponseValidationError` for anything malformed — so the caller can
+   * abort the file write before the offending bytes are committed to disk.
+   */
+  update(chunk: Uint8Array): void {
+    let index = 0;
+    while (index < chunk.length) {
+      // Hot path: inside a decryptor_artifacts_hex value, consume the run of
+      // hex bytes with a table lookup per byte and never touch the structural
+      // machine. This is where ~99.99% of the 1.3 GB is spent.
+      if (
+        this.state === "in_string" &&
+        this.stringTarget === "decryptor_artifacts_hex"
+      ) {
+        const start = index;
+        while (index < chunk.length && IS_HEX_BYTE[chunk[index]] === 1) {
+          index++;
+        }
+        const consumed = index - start;
+        if (consumed > 0) {
+          this.hexCount += consumed;
+          if (this.hexPreview.length < DECRYPTOR_HEX_PREVIEW_CHARS) {
+            const wanted = DECRYPTOR_HEX_PREVIEW_CHARS - this.hexPreview.length;
+            // Hex characters are ASCII, so a byte-wise slice is a safe decode.
+            this.hexPreview += String.fromCharCode(
+              ...chunk.subarray(start, start + Math.min(consumed, wanted)),
+            );
+          }
+          continue;
+        }
+        // Not a hex byte: only the closing quote is legal here. Anything else
+        // (including a backslash escape) means this is not a hex string.
+        if (chunk[index] !== BYTE_QUOTE) {
+          throw new VpResponseValidationError(
+            "Artifact response contains a non-hex character in decryptor_artifacts_hex",
+          );
+        }
+      }
+
+      const byte = chunk[index++];
+      if (this.errorCapture !== null) {
+        this.errorCapture.push(byte);
+      }
+      this.processByte(byte);
+    }
+  }
+
+  /**
+   * Complete the parse and validate the reconstructed payload.
+   *
+   * Note for reviewers: the `decryptor_artifacts_hex` values on the returned
+   * object are the first {@link DECRYPTOR_HEX_PREVIEW_CHARS} characters that
+   * actually appeared on the wire, not the full values — those are hundreds of
+   * megabytes and are deliberately never buffered. The properties the SDK
+   * validator asserts about them (non-empty, hex charset) are enforced here
+   * over *every* byte as it streams, so the prefix is a faithful stand-in and
+   * not a fabricated placeholder. This is not proof the artifact bytes decrypt
+   * correctly; that requires a BaBe verifier we do not have.
+   */
+  finish(): ArtifactStreamValidationResult {
+    if (this.state !== "done") {
+      throw new VpResponseValidationError(
+        "Artifact response ended before its JSON document was complete (truncated stream)",
+      );
+    }
+    if (!this.resultSeen) {
+      throw new VpResponseValidationError(
+        "Artifact response envelope is missing the result field",
+      );
+    }
+
+    const babeSessions: Record<string, { decryptor_artifacts_hex: string }> =
+      {};
+    for (const pubkey of this.sessionKeys) {
+      const hex = this.sessionHex.get(pubkey);
+      // A session that never produced a decryptor_artifacts_hex value yields
+      // an empty entry, which the SDK validator rejects by name.
+      babeSessions[pubkey] = {
+        decryptor_artifacts_hex: hex ? hex.preview : "",
+      };
+    }
+
+    // Typed `unknown` so the SDK validator's assertion signature is what
+    // narrows it — the fields it checks are exactly the ones we may be
+    // missing, and it owns those error messages.
+    const skeleton: unknown = {
+      tx_graph_json: this.txGraphJson,
+      verifying_key_hex: this.verifyingKeyHex,
+      babe_sessions: this.babeSessionsSeen ? babeSessions : undefined,
+    };
+
+    validateRequestDepositorClaimerArtifactsResponse(skeleton);
+
+    const txGraph = parseTxGraphJson(skeleton.tx_graph_json);
+
+    const sessionHexLengths: Record<string, number> = {};
+    for (const [pubkey, hex] of this.sessionHex) {
+      sessionHexLengths[pubkey] = hex.length;
+    }
+
+    return { result: skeleton, txGraph, sessionHexLengths };
+  }
+
+  private processByte(byte: number): void {
+    switch (this.state) {
+      case "in_string":
+        this.consumeStringByte(byte);
+        return;
+
+      case "in_string_escape":
+        if (byte === BYTE_LOWER_U) {
+          this.unicodeDigitsSeen = 0;
+          this.state = "in_string_unicode";
+        } else if (SIMPLE_ESCAPES.has(byte)) {
+          this.state = "in_string";
+        } else {
+          throw new VpResponseValidationError(
+            "Artifact response contains an invalid string escape",
+          );
+        }
+        this.stringCapture?.push(byte);
+        return;
+
+      case "in_string_unicode":
+        if (IS_HEX_BYTE[byte] !== 1) {
+          throw new VpResponseValidationError(
+            "Artifact response contains a malformed \\u escape",
+          );
+        }
+        this.stringCapture?.push(byte);
+        if (++this.unicodeDigitsSeen === 4) {
+          this.state = "in_string";
+        }
+        return;
+
+      case "in_number":
+        if (isValueTerminator(byte)) {
+          if (!ACCEPTING_NUMBER_STATES.has(this.numberState)) {
+            throw new VpResponseValidationError(
+              "Artifact response contains a malformed number",
+            );
+          }
+          this.state = "after_value";
+          this.processByte(byte);
+          return;
+        }
+        this.advanceNumber(byte);
+        return;
+
+      case "in_literal":
+        if (byte !== this.literalExpected.charCodeAt(this.literalIndex)) {
+          throw new VpResponseValidationError(
+            "Artifact response contains a malformed JSON literal",
+          );
+        }
+        if (++this.literalIndex === this.literalExpected.length) {
+          this.state = "after_value";
+        }
+        return;
+
+      case "expect_value":
+      case "expect_value_or_close":
+        if (isWhitespace(byte)) return;
+        if (
+          byte === BYTE_CLOSE_BRACKET &&
+          this.state === "expect_value_or_close"
+        ) {
+          this.popFrame("array");
+          return;
+        }
+        this.beginValue(byte);
+        return;
+
+      case "expect_key_or_close":
+        if (isWhitespace(byte)) return;
+        if (byte === BYTE_CLOSE_BRACE) {
+          this.popFrame("object");
+          return;
+        }
+        this.beginKey(byte);
+        return;
+
+      case "expect_key":
+        if (isWhitespace(byte)) return;
+        // Note the absence of a `}` branch: reaching here means a comma was
+        // just consumed, so a closing brace would be a trailing comma.
+        this.beginKey(byte);
+        return;
+
+      case "expect_colon":
+        if (isWhitespace(byte)) return;
+        if (byte !== BYTE_COLON) {
+          throw new VpResponseValidationError(
+            "Artifact response is missing a colon after an object key",
+          );
+        }
+        this.state = "expect_value";
+        return;
+
+      case "after_value":
+        if (isWhitespace(byte)) return;
+        if (byte === BYTE_COMMA) {
+          const frame = this.frames[this.frames.length - 1];
+          if (!frame) {
+            throw new VpResponseValidationError(
+              "Artifact response has trailing content after the top-level value",
+            );
+          }
+          this.state = frame.kind === "object" ? "expect_key" : "expect_value";
+          return;
+        }
+        if (byte === BYTE_CLOSE_BRACE) {
+          this.popFrame("object");
+          return;
+        }
+        if (byte === BYTE_CLOSE_BRACKET) {
+          this.popFrame("array");
+          return;
+        }
+        throw new VpResponseValidationError(
+          "Artifact response contains an unexpected character after a value",
+        );
+
+      case "done":
+        if (isWhitespace(byte)) return;
+        throw new VpResponseValidationError(
+          "Artifact response has trailing content after the top-level value",
+        );
+    }
+  }
+
+  private beginKey(byte: number): void {
+    if (byte !== BYTE_QUOTE) {
+      throw new VpResponseValidationError(
+        "Artifact response contains an object key that is not a string",
+      );
+    }
+    this.stringIsKey = true;
+    this.stringTarget = "key";
+    this.stringCapture = new CaptureBuffer(MAX_JSON_KEY_BYTES, "object key");
+    this.stringCapture.push(byte);
+    this.state = "in_string";
+  }
+
+  private beginValue(byte: number): void {
+    if (this.frames.length === 0 && byte !== BYTE_OPEN_BRACE) {
+      throw new VpResponseValidationError(
+        "Artifact response is not a JSON object",
+      );
+    }
+
+    const path = this.classifyValuePath();
+
+    // A `result` or a babe_sessions entry that is not an object can never
+    // satisfy the schema, and rejecting here keeps the skeleton honest rather
+    // than silently omitting the field.
+    if (
+      (path === "result" || path === "babe_session_entry") &&
+      byte !== BYTE_OPEN_BRACE
+    ) {
+      throw new VpResponseValidationError(
+        path === "result"
+          ? "Artifact response result is not a JSON object"
+          : "Artifact response contains a babe_sessions entry that is not a JSON object",
+      );
+    }
+
+    if (path === "error") {
+      // JSON-RPC allows only null or an object here. Restricting it to those
+      // two shapes keeps the raw-capture span unambiguous.
+      if (byte === BYTE_LOWER_N) {
+        this.beginLiteral(byte);
+        return;
+      }
+      if (byte !== BYTE_OPEN_BRACE) {
+        throw new VpResponseValidationError(
+          "Artifact response contains a top-level error that is neither null nor an object",
+        );
+      }
+      this.errorCapture = new CaptureBuffer(MAX_ERROR_VALUE_BYTES, "error");
+      this.errorCapture.push(byte);
+      this.pushFrame("object");
+      return;
+    }
+
+    if (byte === BYTE_OPEN_BRACE) {
+      if (path === "result") this.resultSeen = true;
+      if (path === "babe_sessions") this.babeSessionsSeen = true;
+      this.pushFrame("object");
+      return;
+    }
+    if (byte === BYTE_OPEN_BRACKET) {
+      this.pushFrame("array");
+      return;
+    }
+    if (byte === BYTE_QUOTE) {
+      this.beginStringValue(path);
+      this.stringCapture?.push(byte);
+      return;
+    }
+    if (byte === BYTE_MINUS || isDigit(byte)) {
+      this.state = "in_number";
+      this.numberState =
+        byte === BYTE_MINUS ? "minus" : byte === BYTE_ZERO ? "zero" : "int";
+      return;
+    }
+    if (
+      byte === BYTE_LOWER_T ||
+      byte === BYTE_LOWER_F ||
+      byte === BYTE_LOWER_N
+    ) {
+      this.beginLiteral(byte);
+      return;
+    }
+    if (this.frames.length === 0) {
+      throw new VpResponseValidationError(
+        "Artifact response is not a JSON object",
+      );
+    }
+    throw new VpResponseValidationError(
+      "Artifact response contains an unexpected character where a value was expected",
+    );
+  }
+
+  private beginLiteral(byte: number): void {
+    this.literalExpected =
+      byte === BYTE_LOWER_T ? "true" : byte === BYTE_LOWER_F ? "false" : "null";
+    this.literalIndex = 1;
+    this.state = "in_literal";
+  }
+
+  private beginStringValue(path: ValuePath): void {
+    this.stringIsKey = false;
+    this.state = "in_string";
+    this.hexCount = 0;
+    this.hexPreview = "";
+
+    switch (path) {
+      case "tx_graph_json":
+        this.stringTarget = "tx_graph_json";
+        this.stringCapture = new CaptureBuffer(
+          MAX_TX_GRAPH_JSON_BYTES,
+          "tx_graph_json",
+        );
+        return;
+      case "verifying_key_hex":
+        this.stringTarget = "verifying_key_hex";
+        this.stringCapture = new CaptureBuffer(
+          MAX_VERIFYING_KEY_HEX_BYTES,
+          "verifying_key_hex",
+        );
+        return;
+      case "decryptor_artifacts_hex":
+        this.stringTarget = "decryptor_artifacts_hex";
+        this.stringCapture = null;
+        return;
+      default:
+        this.stringTarget = "ignored";
+        this.stringCapture = new CaptureBuffer(
+          MAX_UNKNOWN_STRING_BYTES,
+          "string value",
+        );
+    }
+  }
+
+  private consumeStringByte(byte: number): void {
+    if (byte === BYTE_QUOTE) {
+      this.stringCapture?.push(byte);
+      this.closeString();
+      return;
+    }
+    if (byte === BYTE_BACKSLASH) {
+      this.stringCapture?.push(byte);
+      this.state = "in_string_escape";
+      return;
+    }
+    if (byte < MIN_UNESCAPED_STRING_BYTE) {
+      throw new VpResponseValidationError(
+        "Artifact response contains an unescaped control character in a string",
+      );
+    }
+    if (this.stringTarget === "decryptor_artifacts_hex") {
+      // Unreachable via update()'s fast path, which consumes hex runs and
+      // rejects any non-hex byte other than the closing quote. Kept as a
+      // belt-and-braces guard so the machine is correct in isolation.
+      throw new VpResponseValidationError(
+        "Artifact response contains a non-hex character in decryptor_artifacts_hex",
+      );
+    }
+    this.stringCapture?.push(byte);
+  }
+
+  private closeString(): void {
+    if (this.stringIsKey) {
+      const key = decodeJsonString(this.stringCapture, "object key");
+      const frame = this.frames[this.frames.length - 1];
+      if (frame.seenKeys) {
+        if (frame.seenKeys.has(key)) {
+          // First-wins scanning and JSON.parse's last-wins would disagree, so
+          // a duplicated key is rejected rather than silently resolved.
+          throw new VpResponseValidationError(
+            `Artifact response contains a duplicate "${key}" key`,
+          );
+        }
+        frame.seenKeys.add(key);
+      }
+      frame.currentKey = key;
+      if (this.isBabeSessionsFrame(this.frames.length - 1)) {
+        if (this.sessionKeys.length >= MAX_BABE_SESSIONS) {
+          throw new VpResponseValidationError(
+            `Artifact response declares more than ${MAX_BABE_SESSIONS} babe_sessions entries`,
+          );
+        }
+        this.sessionKeys.push(key);
+      }
+      this.stringCapture = null;
+      this.state = "expect_colon";
+      return;
+    }
+
+    switch (this.stringTarget) {
+      case "tx_graph_json":
+        this.txGraphJson = decodeJsonString(
+          this.stringCapture,
+          "tx_graph_json",
+        );
+        break;
+      case "verifying_key_hex":
+        this.verifyingKeyHex = decodeJsonString(
+          this.stringCapture,
+          "verifying_key_hex",
+        );
+        break;
+      case "decryptor_artifacts_hex": {
+        if (this.hexCount % 2 !== 0) {
+          // Odd-length hex cannot decode to bytes. Stricter than the SDK
+          // validator, which only checks the charset.
+          throw new VpResponseValidationError(
+            "Artifact response contains an odd-length decryptor_artifacts_hex value",
+          );
+        }
+        const pubkey = this.frames[this.frames.length - 2]?.currentKey;
+        if (pubkey) {
+          this.sessionHex.set(pubkey, {
+            length: this.hexCount,
+            preview: this.hexPreview,
+          });
+        }
+        break;
+      }
+      default:
+        break;
+    }
+
+    this.stringCapture = null;
+    this.stringTarget = "ignored";
+    this.state = "after_value";
+  }
+
+  private advanceNumber(byte: number): void {
+    switch (this.numberState) {
+      case "minus":
+        if (!isDigit(byte)) break;
+        this.numberState = byte === BYTE_ZERO ? "zero" : "int";
+        return;
+      case "zero":
+        // A leading zero may only be followed by a fraction or an exponent.
+        if (byte === BYTE_DOT) {
+          this.numberState = "frac_start";
+          return;
+        }
+        if (byte === BYTE_LOWER_E || byte === BYTE_UPPER_E) {
+          this.numberState = "exp_start";
+          return;
+        }
+        break;
+      case "int":
+        if (isDigit(byte)) return;
+        if (byte === BYTE_DOT) {
+          this.numberState = "frac_start";
+          return;
+        }
+        if (byte === BYTE_LOWER_E || byte === BYTE_UPPER_E) {
+          this.numberState = "exp_start";
+          return;
+        }
+        break;
+      case "frac_start":
+        if (!isDigit(byte)) break;
+        this.numberState = "frac";
+        return;
+      case "frac":
+        if (isDigit(byte)) return;
+        if (byte === BYTE_LOWER_E || byte === BYTE_UPPER_E) {
+          this.numberState = "exp_start";
+          return;
+        }
+        break;
+      case "exp_start":
+        if (byte === BYTE_PLUS || byte === BYTE_MINUS) {
+          this.numberState = "exp_sign";
+          return;
+        }
+        if (!isDigit(byte)) break;
+        this.numberState = "exp";
+        return;
+      case "exp_sign":
+        if (!isDigit(byte)) break;
+        this.numberState = "exp";
+        return;
+      case "exp":
+        if (isDigit(byte)) return;
+        break;
+    }
+    throw new VpResponseValidationError(
+      "Artifact response contains a malformed number",
+    );
+  }
+
+  private pushFrame(kind: "object" | "array"): void {
+    if (this.frames.length >= JSON_MAX_DEPTH) {
+      throw new VpResponseValidationError(
+        `Artifact response nests deeper than ${JSON_MAX_DEPTH} levels`,
+      );
+    }
+    this.frames.push({
+      kind,
+      currentKey: null,
+      seenKeys:
+        kind === "object" && this.isTrackedObjectDepth() ? new Set() : null,
+    });
+    this.state =
+      kind === "object" ? "expect_key_or_close" : "expect_value_or_close";
+  }
+
+  private popFrame(kind: "object" | "array"): void {
+    const frame = this.frames.pop();
+    if (!frame || frame.kind !== kind) {
+      throw new VpResponseValidationError(
+        "Artifact response contains a mismatched bracket",
+      );
+    }
+    if (this.errorCapture !== null && this.frames.length === 1) {
+      this.throwWireError(this.errorCapture);
+    }
+    this.state = this.frames.length === 0 ? "done" : "after_value";
+  }
+
+  /** True when the frame about to be pushed is one of the four we read. */
+  private isTrackedObjectDepth(): boolean {
+    const depth = this.frames.length;
+    if (depth === 0) return true; // envelope
+    if (depth === 1) return this.frames[0].currentKey === "result";
+    if (depth === 2) {
+      return (
+        this.frames[0].currentKey === "result" &&
+        this.frames[1].currentKey === "babe_sessions"
+      );
+    }
+    if (depth === 3) return this.isBabeSessionsFrame(2);
+    return false;
+  }
+
+  private isBabeSessionsFrame(index: number): boolean {
+    return (
+      index === 2 &&
+      this.frames[0]?.currentKey === "result" &&
+      this.frames[1]?.currentKey === "babe_sessions"
+    );
+  }
+
+  private classifyValuePath(): ValuePath {
+    const depth = this.frames.length;
+    if (depth === 1) {
+      const key = this.frames[0].currentKey;
+      if (key === "result") return "result";
+      if (key === "error") return "error";
+      return "other";
+    }
+    if (depth === 2 && this.frames[0].currentKey === "result") {
+      const key = this.frames[1].currentKey;
+      if (key === "tx_graph_json") return "tx_graph_json";
+      if (key === "verifying_key_hex") return "verifying_key_hex";
+      if (key === "babe_sessions") return "babe_sessions";
+      return "other";
+    }
+    if (depth === 3 && this.isBabeSessionsFrame(2)) {
+      return "babe_session_entry";
+    }
+    if (
+      depth === 4 &&
+      this.isBabeSessionsFrame(2) &&
+      this.frames[3].currentKey === "decryptor_artifacts_hex"
+    ) {
+      return "decryptor_artifacts_hex";
+    }
+    return "other";
+  }
+
+  /**
+   * A non-null top-level `error` is a JSON-RPC error envelope regardless of
+   * where it sits relative to `result`, so this fires the moment the error
+   * object closes rather than waiting for the document to end.
+   */
+  private throwWireError(capture: CaptureBuffer): never {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(capture.decode());
+    } catch {
+      throw new VpResponseValidationError(
+        "Artifact response contains a malformed JSON-RPC error object",
+      );
+    }
+    const error = parsed as Record<string, unknown>;
+    throw new JsonRpcError(
+      typeof error.code === "number"
+        ? error.code
+        : JSON_RPC_ERROR_CODES.INVALID_RESPONSE,
+      typeof error.message === "string"
+        ? error.message
+        : COPY.deposit.recoveryArtifacts.unknownRpcError,
+      "wire",
+      error.data,
+    );
+  }
+}
+
+type ValuePath =
+  | "result"
+  | "error"
+  | "tx_graph_json"
+  | "verifying_key_hex"
+  | "babe_sessions"
+  | "babe_session_entry"
+  | "decryptor_artifacts_hex"
+  | "other";
+
+function isWhitespace(byte: number): boolean {
+  return (
+    byte === BYTE_SPACE ||
+    byte === BYTE_TAB ||
+    byte === BYTE_LF ||
+    byte === BYTE_CR
+  );
+}
+
+function isDigit(byte: number): boolean {
+  return byte >= BYTE_ZERO && byte <= BYTE_NINE;
+}
+
+/** Bytes that may legally follow a number. */
+function isValueTerminator(byte: number): boolean {
+  return (
+    isWhitespace(byte) ||
+    byte === BYTE_COMMA ||
+    byte === BYTE_CLOSE_BRACE ||
+    byte === BYTE_CLOSE_BRACKET
+  );
+}
+
+/**
+ * Decode a captured JSON string span (quotes included) via `JSON.parse`, so
+ * escape sequences and surrogate pairs are handled by V8 rather than by a
+ * hand-rolled unescaper.
+ */
+function decodeJsonString(
+  capture: CaptureBuffer | null,
+  field: string,
+): string {
+  if (!capture) {
+    throw new VpResponseValidationError(
+      `Artifact response field "${field}" was not captured`,
+    );
+  }
+  const parsed: unknown = JSON.parse(capture.decode());
+  if (typeof parsed !== "string") {
+    throw new VpResponseValidationError(
+      `Artifact response field "${field}" is not a string`,
+    );
+  }
+  return parsed;
+}
+
+/**
+ * `tx_graph_json` carries a JSON document as a string. Its internal schema is
+ * owned by the Rust side and is not published anywhere we can validate
+ * against, so the only structural claim we can make is that it parses to an
+ * object rather than being arbitrary text.
+ */
+function parseTxGraphJson(raw: string): Record<string, unknown> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new VpResponseValidationError(
+      "Artifact response tx_graph_json is not valid JSON",
+    );
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new VpResponseValidationError(
+      "Artifact response tx_graph_json is not a JSON object",
+    );
+  }
+  return parsed as Record<string, unknown>;
+}

--- a/services/vault/src/services/artifacts/streamingArtifactValidator.ts
+++ b/services/vault/src/services/artifacts/streamingArtifactValidator.ts
@@ -98,6 +98,19 @@ const MAX_UNKNOWN_STRING_BYTES = 1024 * 1024;
  */
 const DECRYPTOR_HEX_PREVIEW_CHARS = 64;
 
+/**
+ * Smallest `decryptor_artifacts_hex` value that could plausibly be a BaBe
+ * garbled-circuit artifact.
+ *
+ * Charset, non-emptiness and even length are all satisfied by a two-character
+ * payload, so without a floor a provider can return a bundle that is
+ * structurally perfect and materially empty — and it would earn a download
+ * receipt. A measured vault-devnet session carries ~176,129,340 characters;
+ * this floor sits ~2700x below that, leaving room for a smaller circuit while
+ * making a token payload impossible.
+ */
+export const MIN_DECRYPTOR_HEX_CHARS = 64 * 1024;
+
 /** Initial capacity for a growable capture buffer, doubled on demand. */
 const CAPTURE_BUFFER_INITIAL_BYTES = 256;
 
@@ -207,8 +220,6 @@ export interface ArtifactStreamValidationResult {
   result: RequestDepositorClaimerArtifactsResponse;
   /** `tx_graph_json` parsed, already proven to be a JSON object. */
   txGraph: Record<string, unknown>;
-  /** Full hex length observed per challenger pubkey. */
-  sessionHexLengths: Readonly<Record<string, number>>;
 }
 
 /** Growable byte buffer for capturing small JSON source spans. */
@@ -251,14 +262,6 @@ class CaptureBuffer {
   }
 }
 
-/** Per-challenger accounting for a `decryptor_artifacts_hex` value. */
-interface SessionHex {
-  /** Total hex characters observed on the wire. */
-  length: number;
-  /** First DECRYPTOR_HEX_PREVIEW_CHARS characters, as observed. */
-  preview: string;
-}
-
 export class ArtifactStreamValidator {
   private state: ParserState = "expect_value";
   private readonly frames: Frame[] = [];
@@ -281,7 +284,8 @@ export class ArtifactStreamValidator {
   private verifyingKeyHex: string | null = null;
   private babeSessionsSeen = false;
   private readonly sessionKeys: string[] = [];
-  private readonly sessionHex = new Map<string, SessionHex>();
+  /** Per-challenger hex prefix, keyed by challenger pubkey. */
+  private readonly sessionHex = new Map<string, string>();
 
   /**
    * Feed the next chunk of the response body.
@@ -360,11 +364,10 @@ export class ArtifactStreamValidator {
     const babeSessions: Record<string, { decryptor_artifacts_hex: string }> =
       {};
     for (const pubkey of this.sessionKeys) {
-      const hex = this.sessionHex.get(pubkey);
       // A session that never produced a decryptor_artifacts_hex value yields
       // an empty entry, which the SDK validator rejects by name.
       babeSessions[pubkey] = {
-        decryptor_artifacts_hex: hex ? hex.preview : "",
+        decryptor_artifacts_hex: this.sessionHex.get(pubkey) ?? "",
       };
     }
 
@@ -381,12 +384,7 @@ export class ArtifactStreamValidator {
 
     const txGraph = parseTxGraphJson(skeleton.tx_graph_json);
 
-    const sessionHexLengths: Record<string, number> = {};
-    for (const [pubkey, hex] of this.sessionHex) {
-      sessionHexLengths[pubkey] = hex.length;
-    }
-
-    return { result: skeleton, txGraph, sessionHexLengths };
+    return { result: skeleton, txGraph };
   }
 
   private processByte(byte: number): void {
@@ -727,12 +725,16 @@ export class ArtifactStreamValidator {
             "Artifact response contains an odd-length decryptor_artifacts_hex value",
           );
         }
+        if (this.hexCount < MIN_DECRYPTOR_HEX_CHARS) {
+          // Charset and non-emptiness alone would accept a token payload like
+          // "ab", which is not recovery material by any measure.
+          throw new VpResponseValidationError(
+            `Artifact response decryptor_artifacts_hex is ${this.hexCount} characters, below the ${MIN_DECRYPTOR_HEX_CHARS}-character minimum for a real artifact`,
+          );
+        }
         const pubkey = this.frames[this.frames.length - 2]?.currentKey;
         if (pubkey) {
-          this.sessionHex.set(pubkey, {
-            length: this.hexCount,
-            preview: this.hexPreview,
-          });
+          this.sessionHex.set(pubkey, this.hexPreview);
         }
         break;
       }

--- a/services/vault/src/utils/__tests__/artifactDownloadStorage.test.ts
+++ b/services/vault/src/utils/__tests__/artifactDownloadStorage.test.ts
@@ -1,11 +1,32 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  ARTIFACT_RECEIPT_VERSION,
+  type ArtifactDownloadReceipt,
+  clearArtifactDownloadReceipts,
   hasArtifactsDownloaded,
-  markArtifactsDownloaded,
+  saveArtifactDownloadReceipt,
 } from "../artifactDownloadStorage";
 
 const VAULT_ID = "0xABC123";
+const PEGIN_TXID = "ab".repeat(32);
+const OTHER_PEGIN_TXID = "cd".repeat(32);
+const STORAGE_KEY = `tbv:artifacts-downloaded:${VAULT_ID.toLowerCase()}`;
+
+function receipt(
+  overrides: Partial<ArtifactDownloadReceipt> = {},
+): ArtifactDownloadReceipt {
+  return {
+    version: ARTIFACT_RECEIPT_VERSION,
+    peginTxid: PEGIN_TXID,
+    filename: "babylon-vault-artifacts-abababab.json",
+    byteLength: 1_048_576,
+    sha256: "9".repeat(64),
+    savedAt: 1_700_000_000_000,
+    method: "file-system-access",
+    ...overrides,
+  };
+}
 
 describe("artifactDownloadStorage", () => {
   beforeEach(() => {
@@ -16,29 +37,106 @@ describe("artifactDownloadStorage", () => {
     vi.restoreAllMocks();
   });
 
-  it("returns false when nothing has been marked", () => {
-    expect(hasArtifactsDownloaded(VAULT_ID)).toBe(false);
+  it("reports not-downloaded when no receipt has been stored", () => {
+    expect(hasArtifactsDownloaded(VAULT_ID, PEGIN_TXID)).toBe(false);
   });
 
-  it("returns true after marking", () => {
-    markArtifactsDownloaded(VAULT_ID);
-    expect(hasArtifactsDownloaded(VAULT_ID)).toBe(true);
+  it("reports downloaded for the pegin the receipt was written for", () => {
+    saveArtifactDownloadReceipt(VAULT_ID, receipt());
+    expect(hasArtifactsDownloaded(VAULT_ID, PEGIN_TXID)).toBe(true);
+  });
+
+  it("reports not-downloaded for a different pegin on the same vault", () => {
+    saveArtifactDownloadReceipt(VAULT_ID, receipt());
+    expect(hasArtifactsDownloaded(VAULT_ID, OTHER_PEGIN_TXID)).toBe(false);
+  });
+
+  it("matches a pegin txid regardless of 0x prefix and casing", () => {
+    saveArtifactDownloadReceipt(VAULT_ID, receipt());
+    expect(
+      hasArtifactsDownloaded(VAULT_ID, `0x${PEGIN_TXID.toUpperCase()}`),
+    ).toBe(true);
+  });
+
+  it("reports not-downloaded when no pegin txid is supplied", () => {
+    saveArtifactDownloadReceipt(VAULT_ID, receipt());
+    expect(hasArtifactsDownloaded(VAULT_ID, "")).toBe(false);
   });
 
   it("treats vaultId case-insensitively", () => {
-    markArtifactsDownloaded("0xABC123");
-    expect(hasArtifactsDownloaded("0xabc123")).toBe(true);
-    expect(hasArtifactsDownloaded("0xABC123")).toBe(true);
+    saveArtifactDownloadReceipt("0xABC123", receipt());
+    expect(hasArtifactsDownloaded("0xabc123", PEGIN_TXID)).toBe(true);
   });
 
-  it("scopes the flag per vaultId", () => {
-    markArtifactsDownloaded("0xaaa");
-    expect(hasArtifactsDownloaded("0xbbb")).toBe(false);
+  it("scopes receipts per vaultId", () => {
+    saveArtifactDownloadReceipt("0xaaa", receipt());
+    expect(hasArtifactsDownloaded("0xbbb", PEGIN_TXID)).toBe(false);
   });
 
-  it("returns false for an empty vaultId", () => {
-    markArtifactsDownloaded("");
-    expect(hasArtifactsDownloaded("")).toBe(false);
+  it("ignores an empty vaultId", () => {
+    saveArtifactDownloadReceipt("", receipt());
+    expect(hasArtifactsDownloaded("", PEGIN_TXID)).toBe(false);
+  });
+
+  it('rejects the legacy bare "true" flag and clears it', () => {
+    // JSON.parse("true") returns a boolean rather than throwing, so this is
+    // the case a naive parse-and-trust would silently keep honoring.
+    window.localStorage.setItem(STORAGE_KEY, "true");
+
+    expect(hasArtifactsDownloaded(VAULT_ID, PEGIN_TXID)).toBe(false);
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it("rejects a corrupt record and clears it", () => {
+    window.localStorage.setItem(STORAGE_KEY, "{not json");
+
+    expect(hasArtifactsDownloaded(VAULT_ID, PEGIN_TXID)).toBe(false);
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it("rejects a receipt written by a different schema version", () => {
+    saveArtifactDownloadReceipt(
+      VAULT_ID,
+      receipt({ version: ARTIFACT_RECEIPT_VERSION + 1 }),
+    );
+    expect(hasArtifactsDownloaded(VAULT_ID, PEGIN_TXID)).toBe(false);
+  });
+
+  it("rejects a receipt whose digest is not a 64-character hex string", () => {
+    saveArtifactDownloadReceipt(VAULT_ID, receipt({ sha256: "abc" }));
+    expect(hasArtifactsDownloaded(VAULT_ID, PEGIN_TXID)).toBe(false);
+  });
+
+  it("rejects a receipt with a zero byte length", () => {
+    saveArtifactDownloadReceipt(VAULT_ID, receipt({ byteLength: 0 }));
+    expect(hasArtifactsDownloaded(VAULT_ID, PEGIN_TXID)).toBe(false);
+  });
+
+  it("rejects a receipt with an unrecognized save method", () => {
+    saveArtifactDownloadReceipt(
+      VAULT_ID,
+      receipt({ method: "carrier-pigeon" as never }),
+    );
+    expect(hasArtifactsDownloaded(VAULT_ID, PEGIN_TXID)).toBe(false);
+  });
+
+  it("accepts a receipt written via the browser-download fallback", () => {
+    saveArtifactDownloadReceipt(
+      VAULT_ID,
+      receipt({ method: "browser-download" }),
+    );
+    expect(hasArtifactsDownloaded(VAULT_ID, PEGIN_TXID)).toBe(true);
+  });
+
+  it("clears every stored receipt and leaves unrelated keys alone", () => {
+    saveArtifactDownloadReceipt(VAULT_ID, receipt());
+    saveArtifactDownloadReceipt("0xotherVault", receipt());
+    window.localStorage.setItem("unrelated:key", "keep me");
+
+    expect(clearArtifactDownloadReceipts()).toBe(2);
+    expect(hasArtifactsDownloaded(VAULT_ID, PEGIN_TXID)).toBe(false);
+    expect(hasArtifactsDownloaded("0xotherVault", PEGIN_TXID)).toBe(false);
+    expect(window.localStorage.getItem("unrelated:key")).toBe("keep me");
   });
 
   it("does not throw when localStorage.setItem fails (quota / private mode)", () => {
@@ -47,8 +145,10 @@ describe("artifactDownloadStorage", () => {
         throw new Error("QuotaExceededError");
       },
     );
-    expect(() => markArtifactsDownloaded(VAULT_ID)).not.toThrow();
-    expect(hasArtifactsDownloaded(VAULT_ID)).toBe(false);
+    expect(() =>
+      saveArtifactDownloadReceipt(VAULT_ID, receipt()),
+    ).not.toThrow();
+    expect(hasArtifactsDownloaded(VAULT_ID, PEGIN_TXID)).toBe(false);
   });
 
   it("does not throw when localStorage.getItem fails", () => {
@@ -57,6 +157,6 @@ describe("artifactDownloadStorage", () => {
         throw new Error("SecurityError");
       },
     );
-    expect(hasArtifactsDownloaded(VAULT_ID)).toBe(false);
+    expect(hasArtifactsDownloaded(VAULT_ID, PEGIN_TXID)).toBe(false);
   });
 });

--- a/services/vault/src/utils/artifactDownloadStorage.ts
+++ b/services/vault/src/utils/artifactDownloadStorage.ts
@@ -1,4 +1,48 @@
+/**
+ * Local record of which vaults have their recovery artifacts saved to disk.
+ *
+ * This is a *receipt*, not a flag. Storing a bare "true" could not distinguish
+ * a bundle downloaded for this pegin from a stale one, from a different
+ * vault's, or from a fetch that resolved without a file ever reaching disk —
+ * so it asserted more than it knew. A receipt records what was saved, and
+ * {@link hasArtifactsDownloaded} only reports true when the record matches the
+ * pegin being asked about.
+ *
+ * Receipts written by earlier builds were bare `"true"` strings. Those are
+ * deliberately not honored: the whole point is that the old signal was not
+ * evidence. Affected users see the artifact warning again and can re-download.
+ */
+
+import { stripHexPrefix } from "@babylonlabs-io/ts-sdk/tbv/core";
+
+import { logger } from "@/infrastructure";
+import type { ArtifactSaveMethod } from "@/services/artifacts";
+
 const ARTIFACTS_DOWNLOADED_KEY_PREFIX = "tbv:artifacts-downloaded:";
+
+/**
+ * Bumped whenever the receipt shape changes. A receipt from a different
+ * version is discarded rather than migrated — re-downloading is safe, and
+ * guessing at an old record's meaning is not.
+ */
+export const ARTIFACT_RECEIPT_VERSION = 1;
+
+/** Length of a hex-encoded SHA-256 digest. */
+const SHA256_HEX_LENGTH = 64;
+
+const SHA256_HEX_PATTERN = /^[0-9a-f]+$/;
+
+export interface ArtifactDownloadReceipt {
+  version: number;
+  /** Pegin txid the bundle was fetched for, without 0x prefix, lowercased. */
+  peginTxid: string;
+  filename: string;
+  byteLength: number;
+  /** SHA-256 of the response body, lowercase hex. */
+  sha256: string;
+  savedAt: number;
+  method: ArtifactSaveMethod;
+}
 
 function isBrowserStorageAvailable(): boolean {
   return (
@@ -10,21 +54,126 @@ function storageKey(vaultId: string): string {
   return `${ARTIFACTS_DOWNLOADED_KEY_PREFIX}${vaultId.toLowerCase()}`;
 }
 
-export function hasArtifactsDownloaded(vaultId: string): boolean {
-  if (!isBrowserStorageAvailable() || !vaultId) return false;
-  try {
-    return window.localStorage.getItem(storageKey(vaultId)) === "true";
-  } catch {
+export function normalizePeginTxid(peginTxid: string): string {
+  return stripHexPrefix(peginTxid).toLowerCase();
+}
+
+function isValidReceipt(value: unknown): value is ArtifactDownloadReceipt {
+  // `JSON.parse("true")` returns the boolean true rather than throwing, so a
+  // legacy flag reaches here as a non-object. This check is what invalidates
+  // it; without it every stale flag would survive.
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
     return false;
+  }
+  const receipt = value as Record<string, unknown>;
+  return (
+    receipt.version === ARTIFACT_RECEIPT_VERSION &&
+    typeof receipt.peginTxid === "string" &&
+    receipt.peginTxid.length > 0 &&
+    typeof receipt.filename === "string" &&
+    typeof receipt.byteLength === "number" &&
+    Number.isFinite(receipt.byteLength) &&
+    receipt.byteLength > 0 &&
+    typeof receipt.sha256 === "string" &&
+    receipt.sha256.length === SHA256_HEX_LENGTH &&
+    SHA256_HEX_PATTERN.test(receipt.sha256) &&
+    typeof receipt.savedAt === "number" &&
+    Number.isFinite(receipt.savedAt) &&
+    (receipt.method === "file-system-access" ||
+      receipt.method === "browser-download")
+  );
+}
+
+/**
+ * Read the stored receipt for a vault, discarding anything unreadable,
+ * outdated, or malformed so a bad record cannot linger.
+ */
+function readArtifactDownloadReceipt(
+  vaultId: string,
+): ArtifactDownloadReceipt | null {
+  if (!isBrowserStorageAvailable() || !vaultId) return null;
+
+  const key = storageKey(vaultId);
+  let raw: string | null;
+  try {
+    raw = window.localStorage.getItem(key);
+  } catch {
+    // Storage unavailable (private browsing, blocked cookies). Reporting "no
+    // receipt" keeps the user on the warn-and-acknowledge path, which is the
+    // safe direction to fail.
+    return null;
+  }
+  if (raw === null) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    parsed = null;
+  }
+
+  if (!isValidReceipt(parsed)) {
+    // Self-heal: a legacy flag or corrupt record is removed so it is not
+    // re-examined on every render.
+    try {
+      window.localStorage.removeItem(key);
+    } catch {
+      // Nothing more to do — the read already reports "no receipt".
+    }
+    return null;
+  }
+
+  return parsed;
+}
+
+/**
+ * True only when this vault has a receipt for *this* pegin. A receipt for a
+ * different pegin, or none at all, reads as not-downloaded.
+ */
+export function hasArtifactsDownloaded(
+  vaultId: string,
+  peginTxid: string,
+): boolean {
+  if (!peginTxid) return false;
+  const receipt = readArtifactDownloadReceipt(vaultId);
+  return receipt?.peginTxid === normalizePeginTxid(peginTxid);
+}
+
+/**
+ * Drop every stored receipt, returning how many were removed.
+ *
+ * Dev-only affordance: once a vault's gate is satisfied the card hides its
+ * download button, so there is otherwise no way to re-run the flow against
+ * the same vault. Exposed through the god-mode panel.
+ */
+export function clearArtifactDownloadReceipts(): number {
+  if (!isBrowserStorageAvailable()) return 0;
+  try {
+    const keys = Object.keys(window.localStorage).filter((key) =>
+      key.startsWith(ARTIFACTS_DOWNLOADED_KEY_PREFIX),
+    );
+    for (const key of keys) {
+      window.localStorage.removeItem(key);
+    }
+    return keys.length;
+  } catch {
+    return 0;
   }
 }
 
-export function markArtifactsDownloaded(vaultId: string): void {
+export function saveArtifactDownloadReceipt(
+  vaultId: string,
+  receipt: ArtifactDownloadReceipt,
+): void {
   if (!isBrowserStorageAvailable() || !vaultId) return;
   try {
-    window.localStorage.setItem(storageKey(vaultId), "true");
-  } catch {
-    // Quota exceeded or private browsing — fall through; the gate will
-    // simply continue to warn the user, which is the safe default.
+    window.localStorage.setItem(storageKey(vaultId), JSON.stringify(receipt));
+  } catch (err) {
+    // Quota exceeded or private browsing. The gate will simply continue to
+    // warn the user, which is the safe default, but it is worth knowing about.
+    logger.warn("Failed to persist the artifact download receipt", {
+      category: "activation",
+      reason: String(err),
+    });
   }
 }


### PR DESCRIPTION
# Validate, bind and durably save the recovery artifact bundle

Closes https://github.com/babylonlabs-io/baby-auditor/issues/39

## Background

When someone deposits BTC, the vault provider (VP) holds the material they would need to claim their funds **without** the provider's help. The app downloads that material — a ~1.4 GB bundle — saves it to disk, and then tells the user their vault is protected.

The problem: the app had almost no basis for that claim. It asked the VP for the bundle, waited for the HTTP response to finish, wrote `"true"` to localStorage, and showed the green "Artifacts downloaded" state. Nothing verified that the response was a real bundle, that it belonged to this vault, or that a file ever reached disk.

Net effect: you could activate a vault believing you held an independent escape hatch when you didn't. If the provider later stopped cooperating, that path was gone.

## Summary

| # | What we had | The problem | What we do now |
|---|---|---|---|
| 1 | Bodies ≥ 4096 bytes skipped schema validation | Real bundles are ~1.4 GB, so validation *never* ran on a real download | Stream-validate every byte in one pass |
| 2 | A dropped connection looked like a finished download | Half a bundle was recorded as success | Parser must reach the closing brace |
| 3 | Nothing linked the bundle to your deposit | A bundle for someone else's vault passed | Check the tx graph against the request |
| 4 | An `<a download>` click, then mark it done | A cancelled save was invisible; 1.4 GB sat in memory | Stream to a user-picked file, detect cancel |
| 5 | localStorage held the string `"true"` | Couldn't tell a correct bundle from a stale one | Store a receipt bound to the pegin txid |

## The problems in detail

### 1. Large responses skipped validation entirely

**What we had.** `artifactDownloadService.ts` had a rule: if the body is 4096 bytes or larger, don't parse it — just glance at the first 64 KB to check it looks like a JSON-RPC success envelope.

**Why that's a problem.** Real bundles are ~1.4 GB, so they *always* took that branch. The schema validator only ever ran on tiny error responses. The old code documented this about itself: a VP returning `{"result": <garbage>}` passed. Worth saying clearly — this was deliberate, and for a real reason. You cannot `JSON.parse` a 1.4 GB body: turning it into one JS string blows past V8's ~512 MB string limit and freezes the tab.

**What we did.** A byte-level JSON state machine (`streamingArtifactValidator.ts`) reads the whole body in one pass while holding only a few KB of state. The small fields (`tx_graph_json`, `verifying_key_hex`, the challenger keys) are buffered normally; the huge `decryptor_artifacts_hex` values are checked character-by-character as they fly past and never held. The reconstructed small object then goes through the existing SDK validator. No size branch remains anywhere.

It also never assumes field order, which matters: the proxy only guarantees ordering on its gRPC path, which is off by default — otherwise the body is a byte-for-byte passthrough of the Rust serializer.

### 2. A truncated download counted as success

**What we had.** Nothing checked that the response was complete.

**Why that's a problem.** When the backend fails partway through, the proxy signals it by destroying the connection. You get a syntactically incomplete bundle and no error — valid-looking bytes that simply stop. The app treated that as a completed download and recorded it as such.

**What we did.** This one is free once the parser exists: it must reach the closing brace, so an incomplete document fails. No extra check needed.

### 3. Nothing tied the bundle to your vault

**What we had.** The response echoes back neither the pegin txid nor the depositor key — the only correlation field is the JSON-RPC `id`.

**Why that's a problem.** "Valid JSON of the right shape" did not mean "yours". A provider serving another deposit's bundle, or a stale cache entry, was indistinguishable from a correct response.

**What we did.** `artifactBinding.ts` checks, before anything is recorded: `claim_tx` and `payout_tx` each spend an output of the **requested** pegin transaction; `depositor_pubkey` is the depositor we asked on behalf of; and the `babe_sessions` keys are exactly the graph's own `challenger_pubkeys.local ∪ .universal`. Every expected value is a parameter of the request we just made, so this needs no on-chain read.

### 4. "Downloaded" meant "the fetch resolved"

**What we had.** `useArtifactDownload` marked the download complete as soon as the fetch resolved. The download itself was an `<a download>` click, which hands the browser a blob and returns immediately. The whole 1.4 GB was buffered in memory as a chunk array first.

**Why that's a problem.** If you cancelled the save dialog, the app never found out and still recorded success. And holding 1.4 GB in memory is its own risk.

**What we did.** The body now streams straight to a user-chosen file via the File System Access API. That API writes to a temporary swap file and only commits on close, so a validation failure mid-download leaves nothing behind, and a cancelled save is detectable. The write is awaited, so disk I/O applies backpressure to the network and the body never accumulates in memory. Browsers without the API (Firefox, Safari) fall back to the old anchor download plus an explicit "I saved the file" confirmation, with a size ceiling instead of an out-of-memory tab kill.

Because `showSaveFilePicker` needs transient user activation, the picker has to open before the wallet signature prompt — there's a comment in the hook saying so, since it looks reorderable and isn't.

### 5. The stored flag couldn't tell bundles apart

**What we had.** `tbv:artifacts-downloaded:<vaultId>` held the string `"true"`.

**Why that's a problem.** That records "something happened once for this vault" — not which bundle, or whether it was the right one. A stale record, or one from a different deposit, counted just the same.

**What we did.** We store `{ peginTxid, sha256, byteLength, filename, savedAt, method }`, written only from a validated and saved bundle. `hasArtifactsDownloaded(vaultId, peginTxid)` returns true only for a matching record. The activation modal's existing `(downloaded || acknowledged)` gate then keeps the risk checkbox until a real bound receipt exists — that logic needed no change, just the extra argument.

### Bonus: god mode can now test all of this

**What we had.** The artifact mock ticked a progress bar and touched none of the real code.

**Why that's a problem.** All the interesting logic now lives in the validator and the file sink, so a mock that skips both tests nothing.

**What we did.** The mock feeds a synthetic response through the *real* pipeline, with a scenario selector: valid bundle / truncated stream / junk in a success envelope / padded JSON-RPC error / corrupt hex / bundle for a different deposit. Plus a "Clear artifact receipts" button, because once a vault's gate is satisfied the card hides its download button and there was no way to re-run the flow. A simulated download still writes no receipt, so it can never satisfy a real vault's gate.

## Approaches considered

**Validating a 1.4 GB body.** Three options: keep the size threshold (status quo — leaves the hole open); parse it in a Web Worker (keeps the UI responsive but does not beat V8's string limit, so it does not actually work); or a streaming parser. Only the third is possible, so that is what shipped. Measured throughput is **255 MB/s** — the full 1.4 GB validates in 5.5 s, about 2% of a 4.5-minute download, so the Web Worker turned out to be unnecessary anyway.

**Binding — and a correction worth flagging.** I initially concluded this was *impossible* and wrote it up as such. The reasoning: `tx_graph_json` is opaque — no schema, no golden file, no sample anywhere in babylon-toolkit, vault-provider-proxy or app-babylon-vault, and the proxy's proto explicitly calls it "serialized at the Rust boundary". Every example in every repo is an invented placeholder like `{"nodes":[],"edges":[]}`.

Then we did a real download and looked at the file. The graph has 14 top-level keys, and its claim and payout transactions spend the pegin outpoint in display order. **It was knowable all along — just not from the repos.** So binding is implemented rather than deferred, and it is cheaper than planned: because the expected values come from the request, none of the on-chain reader plumbing originally budgeted for is needed.

**Challenger-set binding against on-chain data** was the alternative, and is *not* implemented. The expected challenger set is public on-chain data, so a malicious VP reads the same contracts and puts the correct keys on a decoy bundle for the cost of one call — it stops no real attacker, while a wrong assumption about the set would hard-block honest users from their recovery bundle. Instead we check the set for internal consistency against the graph's own declaration, which catches the case that actually matters (a missing session leaving recovery material incomplete) at no cost and no false-reject risk.

**Detecting a cancelled save.** Either attestation everywhere (a checkbox — simple, but weak evidence and keeps the memory problem), or File System Access with attestation as the fallback. We took the second: it is the only way to get a real save/cancel signal, and it fixes the memory issue at the same time. Chromium-only is acceptable here — Chromium is the only browser this repo e2e-tests and every supported wallet is a Chrome extension — and the fallback warns the user up front.

**Old localStorage flags** are invalidated rather than migrated. The whole point is that the old signal was not evidence, so carrying it forward would defeat the change. Affected users see the artifact warning again and can re-download. Note `JSON.parse("true")` returns a boolean rather than throwing, so this needed an explicit shape check — without it every legacy flag would have silently survived.

## What this does not do

Every value checked is public, so a determined provider can satisfy all of it while returning garbage payloads. The `decryptor_artifacts_hex` bytes are charset- and length-validated, **never proven to decrypt correctly** — that needs a BaBe verifier, which does not exist client-side. What this catches is a broken or careless provider, a bundle for the wrong deposit, a stale cache, a dropped connection, and a save that never happened. Not a targeted forgery.

## Testing

- `pnpm --filter vault run test` — 2929 passing. New: 50 parser tests (key-order permutations, escapes and multi-byte characters, truncation, malformed numbers, duplicate keys, and a case proving 1-byte chunking gives an identical verdict), 13 binding tests, plus service, storage, hook and modal coverage.
- **Verified against the real 1.4 GB bundle**: it passes the validator and the binding, and the same data with a foreign pegin txid is rejected.
- **Manual, in Chrome against devnet**: save dialog appears before the wallet prompt, file lands at the chosen path, receipt written with `method: "file-system-access"`. Cancelling the picker persists nothing.
- **Hostile paths** via the god-mode scenario selector: each one rejected, nothing committed, no receipt, risk checkbox still required.

The real bundle also grounded three things that had been guesses: the parser's size caps (measured 1.79 MB tx graph, 528-char verifying key, 8 sessions), the CPU cost above, and a **bug it exposed** — the progress bar's fallback estimate was 1,395,864,371 bytes against a real 1,410,824,702-byte body, so it saturated before the download finished.

## Notes for reviewers

This is critical-path recovery-material code and the parser is the risky part in both directions: a bug that falsely rejects locks honest users out of their bundle, and one that falsely accepts waves a bad bundle through. Worth two reviewers.

Two behaviour changes to be aware of:

- Error envelopes now always surface as `JsonRpcError`, including padded ones that previously became `VpResponseValidationError`. This is also a fix: the auth-expired retry only triggers on `JsonRpcError`, so a padded `auth_expired` used to defeat it.
- In `ActivateConfirmationModal`, `peginTxid` is optional. A vault without one now always reads as not-downloaded and requires the acknowledgement. That is the correct fail-closed reading, and it matches `canRenderCard`, which is already false in exactly that case.

Two things still open:

- Binding reads `claim_tx`, `payout_tx`, `depositor_pubkey` and `challenger_pubkeys` by name. A tx-graph schema change would falsely reject, so these should be treated as a compatibility surface and confirmed against tx-graph v2.
- The claim that `FileSystemWritableFileStream.write()` applies real backpressure rather than buffering held up on a real download, but has not been deliberately memory-profiled.