### PR TITLE
ci: publish frontend checksum manifest as immutable release asset (#253)

### DIFF
--- a/.github/actions/publish-integrity-manifest/action.yml
+++ b/.github/actions/publish-integrity-manifest/action.yml
@@ -1,0 +1,60 @@
+name: Publish integrity manifest
+description: >
+  Publish the per-deploy sha256 checksum manifests as an immutable per-sha
+  GitHub release for the frontend integrity checker (devops-backlog#253).
+  One release per (service, environment, sha), tag fm-<service>-<env>-<sha>,
+  files attached at create time (this repo has Immutable Releases enabled, so
+  attach-at-create is the only path that works — and it makes write-once a
+  platform guarantee). Same-sha rebuilds take the next free -rN slot; the
+  checker probes slots upward and verifies against the highest.
+
+inputs:
+  service:
+    description: Service prefix as used in the checksum filenames (simple-staking | vault)
+    required: true
+  environment:
+    description: Matrix environment value — part of the manifest name contract with the checker
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        SERVICE: ${{ inputs.service }}
+        ENVIRONMENT: ${{ inputs.environment }}
+      run: |
+        set -euo pipefail
+        PREFIX="${SERVICE}-${ENVIRONMENT}-${GITHUB_SHA}"
+        FILES=("/tmp/${PREFIX}-files-checksum.txt" "/tmp/${PREFIX}-global-checksum.txt")
+        for i in 1 2 3 4 5 6 7 8 9 10; do
+          TAG="fm-${PREFIX}"; [ "$i" -gt 1 ] && TAG="${TAG}-r${i}"
+          URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/${PREFIX}-files-checksum.txt"
+          if curl -sfIL -o /dev/null "$URL"; then
+            echo "slot ${TAG} already published — trying next"
+            continue
+          fi
+          if ERR=$(gh release create "$TAG" "${FILES[@]}" \
+               --title "Frontend manifest ${PREFIX}" \
+               --notes "sha256 manifest for the frontend integrity checker (devops-backlog#253). Do not delete." \
+               --latest=false 2>&1); then
+            curl -sfIL -o /dev/null "$URL" || { echo "::error::manifest not retrievable at $URL"; exit 1; }
+            echo "published ${TAG}"
+            exit 0
+          fi
+          # Failed create: re-probe the public URL the checker reads. Only a
+          # slot PUBLISHED by a concurrent run is a race worth advancing past —
+          # anything else (transient API error, draft, permission) must fail
+          # loudly. Advancing on it would leave a numbering gap, and the
+          # checker stops at the first missing slot, so later slots would be
+          # silently invisible. This also avoids depending on gh's error text.
+          if curl -sfIL -o /dev/null "$URL"; then
+            echo "slot ${TAG} published by a concurrent run — trying next slot"
+            continue
+          fi
+          echo "::error::gh release create ${TAG} failed and ${URL} is not retrievable: ${ERR}"
+          exit 1
+        done
+        echo "::error::could not publish manifest for ${PREFIX} after 10 slots"
+        exit 1

--- a/.github/workflows/service-release-simple-staking.yml
+++ b/.github/workflows/service-release-simple-staking.yml
@@ -187,3 +187,13 @@ jobs:
               curl -sfIL -o /dev/null "$URL" || { echo "::error::manifest not retrievable at $URL"; exit 1; }
             fi
           done
+          # Keep the release well under GitHub's 1000-asset/release cap. Only the
+          # currently-deployed sha per env is ever looked up, so older manifests
+          # are dead weight — keep the most recent 500, drop the rest. Best-effort
+          # (|| true) so a prune race across the env matrix can't fail the publish.
+          KEEP=500
+          gh release view "$RELEASE_TAG" --json assets \
+            --jq ".assets | sort_by(.createdAt) | reverse | .[${KEEP}:] | .[].name" \
+          | while IFS= read -r OLD; do
+              [ -n "$OLD" ] && gh release delete-asset "$RELEASE_TAG" "$OLD" --yes 2>/dev/null || true
+            done || true

--- a/.github/workflows/service-release-simple-staking.yml
+++ b/.github/workflows/service-release-simple-staking.yml
@@ -40,6 +40,9 @@ jobs:
 
   s3_publish:
     needs: [lint_test]
+    permissions:
+      id-token: write # OIDC assume-role for AWS
+      contents: write # publish checksum manifest as a release asset (#253)
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
@@ -138,6 +141,22 @@ jobs:
           aws s3 cp /tmp/simple-staking-${{ matrix.environment }}-${{ github.sha }}.tar.gz s3://${{ vars.S3_PUBLIC_BUCKET_NEW }}/simple-staking/${{ matrix.environment }}/${{ github.sha }}.tar.gz
           aws s3 cp /tmp/simple-staking-${{ matrix.environment }}-${{ github.sha }}-files-checksum.txt s3://${{ vars.S3_CHECKSUM_BUCKET_NEW }}/simple-staking/${{ matrix.environment }}/${{ github.sha }}-files-checksum.txt
           aws s3 cp /tmp/simple-staking-${{ matrix.environment }}-${{ github.sha }}-global-checksum.txt s3://${{ vars.S3_CHECKSUM_BUCKET_NEW }}/simple-staking/${{ matrix.environment }}/${{ github.sha }}-global-checksum.txt
+
+      - name: Publish checksum manifest as immutable release asset
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Append-only per-deploy sha256 manifest for the frontend integrity
+          # checker (devops-backlog#253). Public + immutable per-sha => the
+          # checker reads it with no credentials, from a different trust domain
+          # than the AWS serving path. One pinned release acts as the store.
+          RELEASE_TAG=frontend-manifests
+          ASSET="/tmp/simple-staking-${{ matrix.environment }}-${{ github.sha }}-files-checksum.txt"
+          gh release create "$RELEASE_TAG" \
+            --title "Frontend integrity manifests" \
+            --notes "Append-only sha256 manifests consumed by the frontend integrity checker (devops-backlog#253). Do not delete." \
+            --latest=false 2>/dev/null || true
+          gh release upload "$RELEASE_TAG" "$ASSET" --clobber
 
       - name: Upload to S3 with Git Tag
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/service-release-simple-staking.yml
+++ b/.github/workflows/service-release-simple-staking.yml
@@ -190,15 +190,23 @@ jobs:
               echo "slot ${TAG} already published — trying next"
               continue
             fi
-            if gh release create "$TAG" "${FILES[@]}" \
+            if ERR=$(gh release create "$TAG" "${FILES[@]}" \
                  --title "Frontend manifest ${PREFIX}" \
                  --notes "sha256 manifest for the frontend integrity checker (devops-backlog#253). Do not delete." \
-                 --latest=false; then
+                 --latest=false 2>&1); then
               curl -sfIL -o /dev/null "$URL" || { echo "::error::manifest not retrievable at $URL"; exit 1; }
               echo "published ${TAG}"
               exit 0
             fi
-            echo "create ${TAG} lost a race — trying next slot"
+            # Advance to the next slot ONLY on a create race ("already exists").
+            # Any other failure must fail the step: skipping it would leave a
+            # numbering gap, and the checker stops at the first missing slot —
+            # the next run's higher slot would never be found (silent gap).
+            if ! grep -qi "already exists" <<<"$ERR"; then
+              echo "::error::gh release create ${TAG} failed: ${ERR}"
+              exit 1
+            fi
+            echo "slot ${TAG} already exists (lost create race) — trying next slot"
           done
           echo "::error::could not publish manifest for ${PREFIX} after 10 slots"
           exit 1

--- a/.github/workflows/service-release-simple-staking.yml
+++ b/.github/workflows/service-release-simple-staking.yml
@@ -154,7 +154,7 @@ jobs:
           aws s3 cp /tmp/simple-staking-${{ matrix.environment }}-${{ github.sha }}-global-checksum.txt s3://${{ vars.S3_CHECKSUM_BUCKET_NEW }}/simple-staking/${{ matrix.environment }}/${{ github.ref_name }}-global-checksum.txt
 
       # Last step: publishing the manifest must not block the S3 uploads above.
-      - name: Publish checksum manifests as write-once release assets
+      - name: Publish checksum manifest as an immutable per-sha release
         # Only real deploy refs — workflow_dispatch can run from any branch, and
         # the public store must hold manifests only for builds that shipped.
         if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release/v1.x' || startsWith(github.ref, 'refs/tags/')
@@ -162,38 +162,36 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          # Append-only per-deploy sha256 manifests for the frontend integrity
-          # checker (devops-backlog#253). Public, so the checker reads them with
-          # no credentials, from a different trust domain than the AWS serving path.
-          RELEASE_TAG=frontend-manifests
-          gh release view "$RELEASE_TAG" >/dev/null 2>&1 || \
-            gh release create "$RELEASE_TAG" \
-              --title "Frontend integrity manifests" \
-              --notes "Append-only sha256 manifests for the frontend integrity checker (devops-backlog#253). Do not delete." \
-              --latest=false || true
-          for ASSET in \
-            "/tmp/simple-staking-${{ matrix.environment }}-${{ github.sha }}-files-checksum.txt" \
-            "/tmp/simple-staking-${{ matrix.environment }}-${{ github.sha }}-global-checksum.txt"; do
-            NAME="$(basename "$ASSET")"
-            URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${RELEASE_TAG}/${NAME}"
-            # Write-once, checked against the URL the checker actually reads (not
-            # the producer's asset list): survives the create race, asset-list
-            # truncation and a draft release. Builds aren't byte-reproducible
-            # (run_id embedded), so a rerun must never swap a published manifest.
+          # Per-deploy sha256 manifests for the frontend integrity checker
+          # (devops-backlog#253). One release per (service, env, sha) with both
+          # files attached at create time: this repo has Immutable Releases
+          # enabled, so assets can't be added after publish — attaching at create
+          # is the immutable-safe path, and it makes write-once a platform
+          # guarantee (published releases can't be modified) and the two-file
+          # publish atomic. No asset-cap pruning needed (2 assets per release).
+          #
+          # Same-sha rebuilds are sanctioned (tag cut on an already-built commit,
+          # redeploy dispatch, job re-run) and are NOT byte-reproducible (run_id
+          # in the bundle), so each rebuild takes the next free -rN slot. The
+          # checker probes slots upward and verifies against the highest one.
+          PREFIX="simple-staking-${{ matrix.environment }}-${{ github.sha }}"
+          FILES=("/tmp/${PREFIX}-files-checksum.txt" "/tmp/${PREFIX}-global-checksum.txt")
+          for i in 1 2 3 4 5 6 7 8 9 10; do
+            TAG="fm-${PREFIX}"; [ "$i" -gt 1 ] && TAG="${TAG}-r${i}"
+            URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/${PREFIX}-files-checksum.txt"
             if curl -sfIL -o /dev/null "$URL"; then
-              echo "manifest $NAME already published — keeping the original"
-            else
-              gh release upload "$RELEASE_TAG" "$ASSET"
-              curl -sfIL -o /dev/null "$URL" || { echo "::error::manifest not retrievable at $URL"; exit 1; }
+              echo "slot ${TAG} already published — trying next"
+              continue
             fi
+            if gh release create "$TAG" "${FILES[@]}" \
+                 --title "Frontend manifest ${PREFIX}" \
+                 --notes "sha256 manifest for the frontend integrity checker (devops-backlog#253). Do not delete." \
+                 --latest=false; then
+              curl -sfIL -o /dev/null "$URL" || { echo "::error::manifest not retrievable at $URL"; exit 1; }
+              echo "published ${TAG}"
+              exit 0
+            fi
+            echo "create ${TAG} lost a race — trying next slot"
           done
-          # Keep the release well under GitHub's 1000-asset/release cap. Only the
-          # currently-deployed sha per env is ever looked up, so older manifests
-          # are dead weight — keep the most recent 500, drop the rest. Best-effort
-          # (|| true) so a prune race across the env matrix can't fail the publish.
-          KEEP=500
-          gh release view "$RELEASE_TAG" --json assets \
-            --jq ".assets | sort_by(.createdAt) | reverse | .[${KEEP}:] | .[].name" \
-          | while IFS= read -r OLD; do
-              [ -n "$OLD" ] && gh release delete-asset "$RELEASE_TAG" "$OLD" --yes 2>/dev/null || true
-            done || true
+          echo "::error::could not publish manifest for ${PREFIX} after 10 slots"
+          exit 1

--- a/.github/workflows/service-release-simple-staking.yml
+++ b/.github/workflows/service-release-simple-staking.yml
@@ -59,8 +59,11 @@ jobs:
             aws_account: 490721144737
             prod: true
 
-    # Prod environments will fail OIDC on feature branches; allow failure so devnet jobs aren't blocked
-    continue-on-error: ${{ matrix.prod == true }}
+    # Prod environments will fail OIDC on feature branches; allow failure there
+    # so devnet jobs aren't blocked. On real deploy refs (main/release/tags) a
+    # prod failure must fail the run — a green run with a failed prod deploy or
+    # missing integrity manifest is a silent gap (#253 review).
+    continue-on-error: ${{ matrix.prod == true && github.ref != 'refs/heads/main' && github.ref != 'refs/heads/release/v1.x' && !startsWith(github.ref, 'refs/tags/') }}
     environment: ${{ matrix.environment }}
     steps:
       - name: Checkout repository
@@ -148,10 +151,14 @@ jobs:
 
       - name: Upload to S3 with Git Tag
         if: startsWith(github.ref, 'refs/tags/')
+        env:
+          # Bound via env, not interpolated into run: — git refnames accept
+          # shell metacharacters and this job holds AWS OIDC + contents:write.
+          GIT_TAG: ${{ github.ref_name }}
         run: |
-          aws s3 cp /tmp/simple-staking-${{ matrix.environment }}-${{ github.sha }}.tar.gz s3://${{ vars.S3_PUBLIC_BUCKET_NEW }}/simple-staking/${{ matrix.environment }}/${{ github.ref_name }}.tar.gz
-          aws s3 cp /tmp/simple-staking-${{ matrix.environment }}-${{ github.sha }}-files-checksum.txt s3://${{ vars.S3_CHECKSUM_BUCKET_NEW }}/simple-staking/${{ matrix.environment }}/${{ github.ref_name }}-files-checksum.txt
-          aws s3 cp /tmp/simple-staking-${{ matrix.environment }}-${{ github.sha }}-global-checksum.txt s3://${{ vars.S3_CHECKSUM_BUCKET_NEW }}/simple-staking/${{ matrix.environment }}/${{ github.ref_name }}-global-checksum.txt
+          aws s3 cp /tmp/simple-staking-${{ matrix.environment }}-${{ github.sha }}.tar.gz "s3://${{ vars.S3_PUBLIC_BUCKET_NEW }}/simple-staking/${{ matrix.environment }}/${GIT_TAG}.tar.gz"
+          aws s3 cp /tmp/simple-staking-${{ matrix.environment }}-${{ github.sha }}-files-checksum.txt "s3://${{ vars.S3_CHECKSUM_BUCKET_NEW }}/simple-staking/${{ matrix.environment }}/${GIT_TAG}-files-checksum.txt"
+          aws s3 cp /tmp/simple-staking-${{ matrix.environment }}-${{ github.sha }}-global-checksum.txt "s3://${{ vars.S3_CHECKSUM_BUCKET_NEW }}/simple-staking/${{ matrix.environment }}/${GIT_TAG}-global-checksum.txt"
 
       # Last step: publishing the manifest must not block the S3 uploads above.
       - name: Publish checksum manifest as an immutable per-sha release

--- a/.github/workflows/service-release-simple-staking.yml
+++ b/.github/workflows/service-release-simple-staking.yml
@@ -65,6 +65,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 https://github.com/actions/checkout/releases/tag/v6.0.2
+        with:
+          # Job holds contents:write; don't leave the token in .git/config while
+          # pnpm install / build run untrusted deps.
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0 https://github.com/actions/setup-node/releases/tag/v4.4.0
@@ -142,34 +146,44 @@ jobs:
           aws s3 cp /tmp/simple-staking-${{ matrix.environment }}-${{ github.sha }}-files-checksum.txt s3://${{ vars.S3_CHECKSUM_BUCKET_NEW }}/simple-staking/${{ matrix.environment }}/${{ github.sha }}-files-checksum.txt
           aws s3 cp /tmp/simple-staking-${{ matrix.environment }}-${{ github.sha }}-global-checksum.txt s3://${{ vars.S3_CHECKSUM_BUCKET_NEW }}/simple-staking/${{ matrix.environment }}/${{ github.sha }}-global-checksum.txt
 
-      - name: Publish checksum manifest as immutable release asset
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          # Append-only per-deploy sha256 manifest for the frontend integrity
-          # checker (devops-backlog#253). Public + immutable per-sha => the
-          # checker reads it with no credentials, from a different trust domain
-          # than the AWS serving path. One pinned release acts as the store.
-          RELEASE_TAG=frontend-manifests
-          ASSET="/tmp/simple-staking-${{ matrix.environment }}-${{ github.sha }}-files-checksum.txt"
-          gh release create "$RELEASE_TAG" \
-            --title "Frontend integrity manifests" \
-            --notes "Append-only sha256 manifests consumed by the frontend integrity checker (devops-backlog#253). Do not delete." \
-            --latest=false 2>/dev/null || true
-          # Write-once: never overwrite an already-published manifest for this
-          # sha. Builds aren't byte-reproducible (run_id embedded), so a rerun
-          # with --clobber could swap the checker's source of truth. Keeping the
-          # original is fail-safe — a stale manifest alerts, it can't hide.
-          ASSET_NAME="$(basename "$ASSET")"
-          if gh release view "$RELEASE_TAG" --json assets --jq '.assets[].name' | grep -qxF "$ASSET_NAME"; then
-            echo "manifest $ASSET_NAME already published — keeping the immutable original"
-          else
-            gh release upload "$RELEASE_TAG" "$ASSET"
-          fi
-
       - name: Upload to S3 with Git Tag
         if: startsWith(github.ref, 'refs/tags/')
         run: |
           aws s3 cp /tmp/simple-staking-${{ matrix.environment }}-${{ github.sha }}.tar.gz s3://${{ vars.S3_PUBLIC_BUCKET_NEW }}/simple-staking/${{ matrix.environment }}/${{ github.ref_name }}.tar.gz
           aws s3 cp /tmp/simple-staking-${{ matrix.environment }}-${{ github.sha }}-files-checksum.txt s3://${{ vars.S3_CHECKSUM_BUCKET_NEW }}/simple-staking/${{ matrix.environment }}/${{ github.ref_name }}-files-checksum.txt
           aws s3 cp /tmp/simple-staking-${{ matrix.environment }}-${{ github.sha }}-global-checksum.txt s3://${{ vars.S3_CHECKSUM_BUCKET_NEW }}/simple-staking/${{ matrix.environment }}/${{ github.ref_name }}-global-checksum.txt
+
+      # Last step: publishing the manifest must not block the S3 uploads above.
+      - name: Publish checksum manifests as write-once release assets
+        # Only real deploy refs — workflow_dispatch can run from any branch, and
+        # the public store must hold manifests only for builds that shipped.
+        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release/v1.x' || startsWith(github.ref, 'refs/tags/')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # Append-only per-deploy sha256 manifests for the frontend integrity
+          # checker (devops-backlog#253). Public, so the checker reads them with
+          # no credentials, from a different trust domain than the AWS serving path.
+          RELEASE_TAG=frontend-manifests
+          gh release view "$RELEASE_TAG" >/dev/null 2>&1 || \
+            gh release create "$RELEASE_TAG" \
+              --title "Frontend integrity manifests" \
+              --notes "Append-only sha256 manifests for the frontend integrity checker (devops-backlog#253). Do not delete." \
+              --latest=false || true
+          for ASSET in \
+            "/tmp/simple-staking-${{ matrix.environment }}-${{ github.sha }}-files-checksum.txt" \
+            "/tmp/simple-staking-${{ matrix.environment }}-${{ github.sha }}-global-checksum.txt"; do
+            NAME="$(basename "$ASSET")"
+            URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${RELEASE_TAG}/${NAME}"
+            # Write-once, checked against the URL the checker actually reads (not
+            # the producer's asset list): survives the create race, asset-list
+            # truncation and a draft release. Builds aren't byte-reproducible
+            # (run_id embedded), so a rerun must never swap a published manifest.
+            if curl -sfIL -o /dev/null "$URL"; then
+              echo "manifest $NAME already published — keeping the original"
+            else
+              gh release upload "$RELEASE_TAG" "$ASSET"
+              curl -sfIL -o /dev/null "$URL" || { echo "::error::manifest not retrievable at $URL"; exit 1; }
+            fi
+          done

--- a/.github/workflows/service-release-simple-staking.yml
+++ b/.github/workflows/service-release-simple-staking.yml
@@ -156,7 +156,16 @@ jobs:
             --title "Frontend integrity manifests" \
             --notes "Append-only sha256 manifests consumed by the frontend integrity checker (devops-backlog#253). Do not delete." \
             --latest=false 2>/dev/null || true
-          gh release upload "$RELEASE_TAG" "$ASSET" --clobber
+          # Write-once: never overwrite an already-published manifest for this
+          # sha. Builds aren't byte-reproducible (run_id embedded), so a rerun
+          # with --clobber could swap the checker's source of truth. Keeping the
+          # original is fail-safe — a stale manifest alerts, it can't hide.
+          ASSET_NAME="$(basename "$ASSET")"
+          if gh release view "$RELEASE_TAG" --json assets --jq '.assets[].name' | grep -qxF "$ASSET_NAME"; then
+            echo "manifest $ASSET_NAME already published — keeping the immutable original"
+          else
+            gh release upload "$RELEASE_TAG" "$ASSET"
+          fi
 
       - name: Upload to S3 with Git Tag
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/service-release-simple-staking.yml
+++ b/.github/workflows/service-release-simple-staking.yml
@@ -64,6 +64,16 @@ jobs:
     # prod failure must fail the run — a green run with a failed prod deploy or
     # missing integrity manifest is a silent gap (#253 review).
     continue-on-error: ${{ matrix.prod == true && github.ref != 'refs/heads/main' && github.ref != 'refs/heads/release/v1.x' && !startsWith(github.ref, 'refs/tags/') }}
+    # Serialize same-(env, sha) runs. Without this, git push --follow-tags or a
+    # redeploy dispatch can overlap two runs on one sha: S3 is last-write-wins
+    # while the manifest slots are first-create-wins, so the highest slot can
+    # belong to a DIFFERENT build than the bytes in S3 — a false tamper page on
+    # a clean deploy. cancel-in-progress stays false so the second run publishes
+    # its S3 write and its slot strictly after the first (a cancelled queued run
+    # writes neither store, which keeps them consistent).
+    concurrency:
+      group: ${{ github.workflow }}-${{ matrix.environment }}-${{ github.sha }}
+      cancel-in-progress: false
     environment: ${{ matrix.environment }}
     steps:
       - name: Checkout repository
@@ -162,51 +172,13 @@ jobs:
 
       # Last step: publishing the manifest must not block the S3 uploads above.
       - name: Publish checksum manifest as an immutable per-sha release
-        # Only real deploy refs — workflow_dispatch can run from any branch, and
-        # the public store must hold manifests only for builds that shipped.
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release/v1.x' || startsWith(github.ref, 'refs/tags/')
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          # Per-deploy sha256 manifests for the frontend integrity checker
-          # (devops-backlog#253). One release per (service, env, sha) with both
-          # files attached at create time: this repo has Immutable Releases
-          # enabled, so assets can't be added after publish — attaching at create
-          # is the immutable-safe path, and it makes write-once a platform
-          # guarantee (published releases can't be modified) and the two-file
-          # publish atomic. No asset-cap pruning needed (2 assets per release).
-          #
-          # Same-sha rebuilds are sanctioned (tag cut on an already-built commit,
-          # redeploy dispatch, job re-run) and are NOT byte-reproducible (run_id
-          # in the bundle), so each rebuild takes the next free -rN slot. The
-          # checker probes slots upward and verifies against the highest one.
-          PREFIX="simple-staking-${{ matrix.environment }}-${{ github.sha }}"
-          FILES=("/tmp/${PREFIX}-files-checksum.txt" "/tmp/${PREFIX}-global-checksum.txt")
-          for i in 1 2 3 4 5 6 7 8 9 10; do
-            TAG="fm-${PREFIX}"; [ "$i" -gt 1 ] && TAG="${TAG}-r${i}"
-            URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/${PREFIX}-files-checksum.txt"
-            if curl -sfIL -o /dev/null "$URL"; then
-              echo "slot ${TAG} already published — trying next"
-              continue
-            fi
-            if ERR=$(gh release create "$TAG" "${FILES[@]}" \
-                 --title "Frontend manifest ${PREFIX}" \
-                 --notes "sha256 manifest for the frontend integrity checker (devops-backlog#253). Do not delete." \
-                 --latest=false 2>&1); then
-              curl -sfIL -o /dev/null "$URL" || { echo "::error::manifest not retrievable at $URL"; exit 1; }
-              echo "published ${TAG}"
-              exit 0
-            fi
-            # Advance to the next slot ONLY on a create race ("already exists").
-            # Any other failure must fail the step: skipping it would leave a
-            # numbering gap, and the checker stops at the first missing slot —
-            # the next run's higher slot would never be found (silent gap).
-            if ! grep -qi "already exists" <<<"$ERR"; then
-              echo "::error::gh release create ${TAG} failed: ${ERR}"
-              exit 1
-            fi
-            echo "slot ${TAG} already exists (lost create race) — trying next slot"
-          done
-          echo "::error::could not publish manifest for ${PREFIX} after 10 slots"
-          exit 1
+        # Only real deploy refs (a dispatch from an arbitrary branch must not
+        # notarize builds), and only envs the integrity checker monitors — the
+        # other envs would mint releases+tags nobody ever reads (~7/push
+        # otherwise). Extend the env list together with the checker's
+        # targets.json.
+        if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release/v1.x' || startsWith(github.ref, 'refs/tags/')) && contains(fromJSON('["mainnet","testnet"]'), matrix.environment)
+        uses: ./.github/actions/publish-integrity-manifest
+        with:
+          service: simple-staking
+          environment: ${{ matrix.environment }}

--- a/.github/workflows/service-release-vault.yml
+++ b/.github/workflows/service-release-vault.yml
@@ -107,10 +107,11 @@ jobs:
       matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
 
     # Prod OIDC fails on feature branches; tolerate it ONLY in the multi-env run
-    # so it can't block devnet. When prod (vault-testnet) is the single requested
-    # environment, fail loud — otherwise a scoped prod dispatch reports success
-    # while publishing nothing.
-    continue-on-error: ${{ matrix.prod == true && needs.setup.outputs.multi == 'true' }}
+    # so it can't block devnet — and only OFF real deploy refs. On main/release/
+    # tags a prod failure must fail the run: a green run with a failed prod
+    # deploy or missing integrity manifest is a silent gap (#253 review). A
+    # scoped single-prod dispatch also fails loud.
+    continue-on-error: ${{ matrix.prod == true && needs.setup.outputs.multi == 'true' && github.ref != 'refs/heads/main' && github.ref != 'refs/heads/release/v1.x' && !startsWith(github.ref, 'refs/tags/') }}
     environment: ${{ matrix.environment }}
     steps:
       - name: Checkout repository
@@ -228,10 +229,14 @@ jobs:
 
       - name: Upload to S3 with Git Tag
         if: startsWith(github.ref, 'refs/tags/')
+        env:
+          # Bound via env, not interpolated into run: — git refnames accept
+          # shell metacharacters and this job holds AWS OIDC + contents:write.
+          GIT_TAG: ${{ github.ref_name }}
         run: |
-          aws s3 cp /tmp/vault-${{ matrix.environment }}-${{ github.sha }}.tar.gz s3://${{ vars.S3_PUBLIC_BUCKET_NEW }}/vault/${{ matrix.environment }}/${{ github.ref_name }}.tar.gz
-          aws s3 cp /tmp/vault-${{ matrix.environment }}-${{ github.sha }}-files-checksum.txt s3://${{ vars.S3_CHECKSUM_BUCKET_NEW }}/vault/${{ matrix.environment }}/${{ github.ref_name }}-files-checksum.txt
-          aws s3 cp /tmp/vault-${{ matrix.environment }}-${{ github.sha }}-global-checksum.txt s3://${{ vars.S3_CHECKSUM_BUCKET_NEW }}/vault/${{ matrix.environment }}/${{ github.ref_name }}-global-checksum.txt
+          aws s3 cp /tmp/vault-${{ matrix.environment }}-${{ github.sha }}.tar.gz "s3://${{ vars.S3_PUBLIC_BUCKET_NEW }}/vault/${{ matrix.environment }}/${GIT_TAG}.tar.gz"
+          aws s3 cp /tmp/vault-${{ matrix.environment }}-${{ github.sha }}-files-checksum.txt "s3://${{ vars.S3_CHECKSUM_BUCKET_NEW }}/vault/${{ matrix.environment }}/${GIT_TAG}-files-checksum.txt"
+          aws s3 cp /tmp/vault-${{ matrix.environment }}-${{ github.sha }}-global-checksum.txt "s3://${{ vars.S3_CHECKSUM_BUCKET_NEW }}/vault/${{ matrix.environment }}/${GIT_TAG}-global-checksum.txt"
 
       # Last step: publishing the manifest must not block the S3 uploads above.
       - name: Publish checksum manifest as an immutable per-sha release

--- a/.github/workflows/service-release-vault.yml
+++ b/.github/workflows/service-release-vault.yml
@@ -98,6 +98,9 @@ jobs:
 
   s3_publish:
     needs: [lint_test, setup]
+    permissions:
+      id-token: write # OIDC assume-role for AWS
+      contents: write # publish checksum manifest as a release asset (#253)
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
@@ -218,6 +221,22 @@ jobs:
           aws s3 cp /tmp/vault-${{ matrix.environment }}-${{ github.sha }}.tar.gz s3://${{ vars.S3_PUBLIC_BUCKET_NEW }}/vault/${{ matrix.environment }}/${{ github.sha }}.tar.gz
           aws s3 cp /tmp/vault-${{ matrix.environment }}-${{ github.sha }}-files-checksum.txt s3://${{ vars.S3_CHECKSUM_BUCKET_NEW }}/vault/${{ matrix.environment }}/${{ github.sha }}-files-checksum.txt
           aws s3 cp /tmp/vault-${{ matrix.environment }}-${{ github.sha }}-global-checksum.txt s3://${{ vars.S3_CHECKSUM_BUCKET_NEW }}/vault/${{ matrix.environment }}/${{ github.sha }}-global-checksum.txt
+
+      - name: Publish checksum manifest as immutable release asset
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Append-only per-deploy sha256 manifest for the frontend integrity
+          # checker (devops-backlog#253). Public + immutable per-sha => the
+          # checker reads it with no credentials, from a different trust domain
+          # than the AWS serving path. One pinned release acts as the store.
+          RELEASE_TAG=frontend-manifests
+          ASSET="/tmp/vault-${{ matrix.environment }}-${{ github.sha }}-files-checksum.txt"
+          gh release create "$RELEASE_TAG" \
+            --title "Frontend integrity manifests" \
+            --notes "Append-only sha256 manifests consumed by the frontend integrity checker (devops-backlog#253). Do not delete." \
+            --latest=false 2>/dev/null || true
+          gh release upload "$RELEASE_TAG" "$ASSET" --clobber
 
       - name: Upload to S3 with Git Tag
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/service-release-vault.yml
+++ b/.github/workflows/service-release-vault.yml
@@ -115,6 +115,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 https://github.com/actions/checkout/releases/tag/v6.0.2
+        with:
+          # Job holds contents:write; don't leave the token in .git/config while
+          # pnpm install / build run untrusted deps.
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0 https://github.com/actions/setup-node/releases/tag/v4.4.0
@@ -222,34 +226,44 @@ jobs:
           aws s3 cp /tmp/vault-${{ matrix.environment }}-${{ github.sha }}-files-checksum.txt s3://${{ vars.S3_CHECKSUM_BUCKET_NEW }}/vault/${{ matrix.environment }}/${{ github.sha }}-files-checksum.txt
           aws s3 cp /tmp/vault-${{ matrix.environment }}-${{ github.sha }}-global-checksum.txt s3://${{ vars.S3_CHECKSUM_BUCKET_NEW }}/vault/${{ matrix.environment }}/${{ github.sha }}-global-checksum.txt
 
-      - name: Publish checksum manifest as immutable release asset
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          # Append-only per-deploy sha256 manifest for the frontend integrity
-          # checker (devops-backlog#253). Public + immutable per-sha => the
-          # checker reads it with no credentials, from a different trust domain
-          # than the AWS serving path. One pinned release acts as the store.
-          RELEASE_TAG=frontend-manifests
-          ASSET="/tmp/vault-${{ matrix.environment }}-${{ github.sha }}-files-checksum.txt"
-          gh release create "$RELEASE_TAG" \
-            --title "Frontend integrity manifests" \
-            --notes "Append-only sha256 manifests consumed by the frontend integrity checker (devops-backlog#253). Do not delete." \
-            --latest=false 2>/dev/null || true
-          # Write-once: never overwrite an already-published manifest for this
-          # sha. Builds aren't byte-reproducible (run_id embedded), so a rerun
-          # with --clobber could swap the checker's source of truth. Keeping the
-          # original is fail-safe — a stale manifest alerts, it can't hide.
-          ASSET_NAME="$(basename "$ASSET")"
-          if gh release view "$RELEASE_TAG" --json assets --jq '.assets[].name' | grep -qxF "$ASSET_NAME"; then
-            echo "manifest $ASSET_NAME already published — keeping the immutable original"
-          else
-            gh release upload "$RELEASE_TAG" "$ASSET"
-          fi
-
       - name: Upload to S3 with Git Tag
         if: startsWith(github.ref, 'refs/tags/')
         run: |
           aws s3 cp /tmp/vault-${{ matrix.environment }}-${{ github.sha }}.tar.gz s3://${{ vars.S3_PUBLIC_BUCKET_NEW }}/vault/${{ matrix.environment }}/${{ github.ref_name }}.tar.gz
           aws s3 cp /tmp/vault-${{ matrix.environment }}-${{ github.sha }}-files-checksum.txt s3://${{ vars.S3_CHECKSUM_BUCKET_NEW }}/vault/${{ matrix.environment }}/${{ github.ref_name }}-files-checksum.txt
           aws s3 cp /tmp/vault-${{ matrix.environment }}-${{ github.sha }}-global-checksum.txt s3://${{ vars.S3_CHECKSUM_BUCKET_NEW }}/vault/${{ matrix.environment }}/${{ github.ref_name }}-global-checksum.txt
+
+      # Last step: publishing the manifest must not block the S3 uploads above.
+      - name: Publish checksum manifests as write-once release assets
+        # Only real deploy refs — workflow_dispatch can run from any branch, and
+        # the public store must hold manifests only for builds that shipped.
+        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release/v1.x' || startsWith(github.ref, 'refs/tags/')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # Append-only per-deploy sha256 manifests for the frontend integrity
+          # checker (devops-backlog#253). Public, so the checker reads them with
+          # no credentials, from a different trust domain than the AWS serving path.
+          RELEASE_TAG=frontend-manifests
+          gh release view "$RELEASE_TAG" >/dev/null 2>&1 || \
+            gh release create "$RELEASE_TAG" \
+              --title "Frontend integrity manifests" \
+              --notes "Append-only sha256 manifests for the frontend integrity checker (devops-backlog#253). Do not delete." \
+              --latest=false || true
+          for ASSET in \
+            "/tmp/vault-${{ matrix.environment }}-${{ github.sha }}-files-checksum.txt" \
+            "/tmp/vault-${{ matrix.environment }}-${{ github.sha }}-global-checksum.txt"; do
+            NAME="$(basename "$ASSET")"
+            URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${RELEASE_TAG}/${NAME}"
+            # Write-once, checked against the URL the checker actually reads (not
+            # the producer's asset list): survives the create race, asset-list
+            # truncation and a draft release. Builds aren't byte-reproducible
+            # (run_id embedded), so a rerun must never swap a published manifest.
+            if curl -sfIL -o /dev/null "$URL"; then
+              echo "manifest $NAME already published — keeping the original"
+            else
+              gh release upload "$RELEASE_TAG" "$ASSET"
+              curl -sfIL -o /dev/null "$URL" || { echo "::error::manifest not retrievable at $URL"; exit 1; }
+            fi
+          done

--- a/.github/workflows/service-release-vault.yml
+++ b/.github/workflows/service-release-vault.yml
@@ -234,7 +234,7 @@ jobs:
           aws s3 cp /tmp/vault-${{ matrix.environment }}-${{ github.sha }}-global-checksum.txt s3://${{ vars.S3_CHECKSUM_BUCKET_NEW }}/vault/${{ matrix.environment }}/${{ github.ref_name }}-global-checksum.txt
 
       # Last step: publishing the manifest must not block the S3 uploads above.
-      - name: Publish checksum manifests as write-once release assets
+      - name: Publish checksum manifest as an immutable per-sha release
         # Only real deploy refs — workflow_dispatch can run from any branch, and
         # the public store must hold manifests only for builds that shipped.
         if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release/v1.x' || startsWith(github.ref, 'refs/tags/')
@@ -242,38 +242,39 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          # Append-only per-deploy sha256 manifests for the frontend integrity
-          # checker (devops-backlog#253). Public, so the checker reads them with
-          # no credentials, from a different trust domain than the AWS serving path.
-          RELEASE_TAG=frontend-manifests
-          gh release view "$RELEASE_TAG" >/dev/null 2>&1 || \
-            gh release create "$RELEASE_TAG" \
-              --title "Frontend integrity manifests" \
-              --notes "Append-only sha256 manifests for the frontend integrity checker (devops-backlog#253). Do not delete." \
-              --latest=false || true
-          for ASSET in \
-            "/tmp/vault-${{ matrix.environment }}-${{ github.sha }}-files-checksum.txt" \
-            "/tmp/vault-${{ matrix.environment }}-${{ github.sha }}-global-checksum.txt"; do
-            NAME="$(basename "$ASSET")"
-            URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${RELEASE_TAG}/${NAME}"
-            # Write-once, checked against the URL the checker actually reads (not
-            # the producer's asset list): survives the create race, asset-list
-            # truncation and a draft release. Builds aren't byte-reproducible
-            # (run_id embedded), so a rerun must never swap a published manifest.
+          # Per-deploy sha256 manifests for the frontend integrity checker
+          # (devops-backlog#253). One release per (service, env, sha) with both
+          # files attached at create time: this repo has Immutable Releases
+          # enabled, so assets can't be added after publish — attaching at create
+          # is the immutable-safe path, and it makes write-once a platform
+          # guarantee (published releases can't be modified) and the two-file
+          # publish atomic. No asset-cap pruning needed (2 assets per release).
+          #
+          # Same-sha rebuilds are sanctioned (tag cut on an already-built commit,
+          # redeploy dispatch, job re-run) and are NOT byte-reproducible (run_id
+          # in the bundle), so each rebuild takes the next free -rN slot. The
+          # checker probes slots upward and verifies against the highest one.
+          # NOTE: vault matrix env values are already service-prefixed
+          # (vault-testnet), so PREFIX is vault-vault-testnet-<sha>; the checker
+          # config uses env "vault-testnet" to derive the same name.
+          PREFIX="vault-${{ matrix.environment }}-${{ github.sha }}"
+          FILES=("/tmp/${PREFIX}-files-checksum.txt" "/tmp/${PREFIX}-global-checksum.txt")
+          for i in 1 2 3 4 5 6 7 8 9 10; do
+            TAG="fm-${PREFIX}"; [ "$i" -gt 1 ] && TAG="${TAG}-r${i}"
+            URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/${PREFIX}-files-checksum.txt"
             if curl -sfIL -o /dev/null "$URL"; then
-              echo "manifest $NAME already published — keeping the original"
-            else
-              gh release upload "$RELEASE_TAG" "$ASSET"
-              curl -sfIL -o /dev/null "$URL" || { echo "::error::manifest not retrievable at $URL"; exit 1; }
+              echo "slot ${TAG} already published — trying next"
+              continue
             fi
+            if gh release create "$TAG" "${FILES[@]}" \
+                 --title "Frontend manifest ${PREFIX}" \
+                 --notes "sha256 manifest for the frontend integrity checker (devops-backlog#253). Do not delete." \
+                 --latest=false; then
+              curl -sfIL -o /dev/null "$URL" || { echo "::error::manifest not retrievable at $URL"; exit 1; }
+              echo "published ${TAG}"
+              exit 0
+            fi
+            echo "create ${TAG} lost a race — trying next slot"
           done
-          # Keep the release well under GitHub's 1000-asset/release cap. Only the
-          # currently-deployed sha per env is ever looked up, so older manifests
-          # are dead weight — keep the most recent 500, drop the rest. Best-effort
-          # (|| true) so a prune race across the env matrix can't fail the publish.
-          KEEP=500
-          gh release view "$RELEASE_TAG" --json assets \
-            --jq ".assets | sort_by(.createdAt) | reverse | .[${KEEP}:] | .[].name" \
-          | while IFS= read -r OLD; do
-              [ -n "$OLD" ] && gh release delete-asset "$RELEASE_TAG" "$OLD" --yes 2>/dev/null || true
-            done || true
+          echo "::error::could not publish manifest for ${PREFIX} after 10 slots"
+          exit 1

--- a/.github/workflows/service-release-vault.yml
+++ b/.github/workflows/service-release-vault.yml
@@ -112,6 +112,16 @@ jobs:
     # deploy or missing integrity manifest is a silent gap (#253 review). A
     # scoped single-prod dispatch also fails loud.
     continue-on-error: ${{ matrix.prod == true && needs.setup.outputs.multi == 'true' && github.ref != 'refs/heads/main' && github.ref != 'refs/heads/release/v1.x' && !startsWith(github.ref, 'refs/tags/') }}
+    # Serialize same-(env, sha) runs. Without this, git push --follow-tags or a
+    # redeploy dispatch can overlap two runs on one sha: S3 is last-write-wins
+    # while the manifest slots are first-create-wins, so the highest slot can
+    # belong to a DIFFERENT build than the bytes in S3 — a false tamper page on
+    # a clean deploy. cancel-in-progress stays false so the second run publishes
+    # its S3 write and its slot strictly after the first (a cancelled queued run
+    # writes neither store, which keeps them consistent).
+    concurrency:
+      group: ${{ github.workflow }}-${{ matrix.environment }}-${{ github.sha }}
+      cancel-in-progress: false
     environment: ${{ matrix.environment }}
     steps:
       - name: Checkout repository
@@ -240,54 +250,15 @@ jobs:
 
       # Last step: publishing the manifest must not block the S3 uploads above.
       - name: Publish checksum manifest as an immutable per-sha release
-        # Only real deploy refs — workflow_dispatch can run from any branch, and
-        # the public store must hold manifests only for builds that shipped.
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release/v1.x' || startsWith(github.ref, 'refs/tags/')
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          # Per-deploy sha256 manifests for the frontend integrity checker
-          # (devops-backlog#253). One release per (service, env, sha) with both
-          # files attached at create time: this repo has Immutable Releases
-          # enabled, so assets can't be added after publish — attaching at create
-          # is the immutable-safe path, and it makes write-once a platform
-          # guarantee (published releases can't be modified) and the two-file
-          # publish atomic. No asset-cap pruning needed (2 assets per release).
-          #
-          # Same-sha rebuilds are sanctioned (tag cut on an already-built commit,
-          # redeploy dispatch, job re-run) and are NOT byte-reproducible (run_id
-          # in the bundle), so each rebuild takes the next free -rN slot. The
-          # checker probes slots upward and verifies against the highest one.
-          # NOTE: vault matrix env values are already service-prefixed
-          # (vault-testnet), so PREFIX is vault-vault-testnet-<sha>; the checker
-          # config uses env "vault-testnet" to derive the same name.
-          PREFIX="vault-${{ matrix.environment }}-${{ github.sha }}"
-          FILES=("/tmp/${PREFIX}-files-checksum.txt" "/tmp/${PREFIX}-global-checksum.txt")
-          for i in 1 2 3 4 5 6 7 8 9 10; do
-            TAG="fm-${PREFIX}"; [ "$i" -gt 1 ] && TAG="${TAG}-r${i}"
-            URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/${PREFIX}-files-checksum.txt"
-            if curl -sfIL -o /dev/null "$URL"; then
-              echo "slot ${TAG} already published — trying next"
-              continue
-            fi
-            if ERR=$(gh release create "$TAG" "${FILES[@]}" \
-                 --title "Frontend manifest ${PREFIX}" \
-                 --notes "sha256 manifest for the frontend integrity checker (devops-backlog#253). Do not delete." \
-                 --latest=false 2>&1); then
-              curl -sfIL -o /dev/null "$URL" || { echo "::error::manifest not retrievable at $URL"; exit 1; }
-              echo "published ${TAG}"
-              exit 0
-            fi
-            # Advance to the next slot ONLY on a create race ("already exists").
-            # Any other failure must fail the step: skipping it would leave a
-            # numbering gap, and the checker stops at the first missing slot —
-            # the next run's higher slot would never be found (silent gap).
-            if ! grep -qi "already exists" <<<"$ERR"; then
-              echo "::error::gh release create ${TAG} failed: ${ERR}"
-              exit 1
-            fi
-            echo "slot ${TAG} already exists (lost create race) — trying next slot"
-          done
-          echo "::error::could not publish manifest for ${PREFIX} after 10 slots"
-          exit 1
+        # Only real deploy refs (a dispatch from an arbitrary branch must not
+        # notarize builds), and only envs the integrity checker monitors — the
+        # other envs would mint releases+tags nobody ever reads. Extend the env
+        # list together with the checker's targets.json. NOTE: vault matrix env
+        # values are service-prefixed (vault-testnet), so the manifest prefix is
+        # vault-vault-testnet-<sha>; the checker config uses env "vault-testnet"
+        # to derive the same name.
+        if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release/v1.x' || startsWith(github.ref, 'refs/tags/')) && contains(fromJSON('["vault-testnet"]'), matrix.environment)
+        uses: ./.github/actions/publish-integrity-manifest
+        with:
+          service: vault
+          environment: ${{ matrix.environment }}

--- a/.github/workflows/service-release-vault.yml
+++ b/.github/workflows/service-release-vault.yml
@@ -271,15 +271,23 @@ jobs:
               echo "slot ${TAG} already published — trying next"
               continue
             fi
-            if gh release create "$TAG" "${FILES[@]}" \
+            if ERR=$(gh release create "$TAG" "${FILES[@]}" \
                  --title "Frontend manifest ${PREFIX}" \
                  --notes "sha256 manifest for the frontend integrity checker (devops-backlog#253). Do not delete." \
-                 --latest=false; then
+                 --latest=false 2>&1); then
               curl -sfIL -o /dev/null "$URL" || { echo "::error::manifest not retrievable at $URL"; exit 1; }
               echo "published ${TAG}"
               exit 0
             fi
-            echo "create ${TAG} lost a race — trying next slot"
+            # Advance to the next slot ONLY on a create race ("already exists").
+            # Any other failure must fail the step: skipping it would leave a
+            # numbering gap, and the checker stops at the first missing slot —
+            # the next run's higher slot would never be found (silent gap).
+            if ! grep -qi "already exists" <<<"$ERR"; then
+              echo "::error::gh release create ${TAG} failed: ${ERR}"
+              exit 1
+            fi
+            echo "slot ${TAG} already exists (lost create race) — trying next slot"
           done
           echo "::error::could not publish manifest for ${PREFIX} after 10 slots"
           exit 1

--- a/.github/workflows/service-release-vault.yml
+++ b/.github/workflows/service-release-vault.yml
@@ -236,7 +236,16 @@ jobs:
             --title "Frontend integrity manifests" \
             --notes "Append-only sha256 manifests consumed by the frontend integrity checker (devops-backlog#253). Do not delete." \
             --latest=false 2>/dev/null || true
-          gh release upload "$RELEASE_TAG" "$ASSET" --clobber
+          # Write-once: never overwrite an already-published manifest for this
+          # sha. Builds aren't byte-reproducible (run_id embedded), so a rerun
+          # with --clobber could swap the checker's source of truth. Keeping the
+          # original is fail-safe — a stale manifest alerts, it can't hide.
+          ASSET_NAME="$(basename "$ASSET")"
+          if gh release view "$RELEASE_TAG" --json assets --jq '.assets[].name' | grep -qxF "$ASSET_NAME"; then
+            echo "manifest $ASSET_NAME already published — keeping the immutable original"
+          else
+            gh release upload "$RELEASE_TAG" "$ASSET"
+          fi
 
       - name: Upload to S3 with Git Tag
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/service-release-vault.yml
+++ b/.github/workflows/service-release-vault.yml
@@ -267,3 +267,13 @@ jobs:
               curl -sfIL -o /dev/null "$URL" || { echo "::error::manifest not retrievable at $URL"; exit 1; }
             fi
           done
+          # Keep the release well under GitHub's 1000-asset/release cap. Only the
+          # currently-deployed sha per env is ever looked up, so older manifests
+          # are dead weight — keep the most recent 500, drop the rest. Best-effort
+          # (|| true) so a prune race across the env matrix can't fail the publish.
+          KEEP=500
+          gh release view "$RELEASE_TAG" --json assets \
+            --jq ".assets | sort_by(.createdAt) | reverse | .[${KEEP}:] | .[].name" \
+          | while IFS= read -r OLD; do
+              [ -n "$OLD" ] && gh release delete-asset "$RELEASE_TAG" "$OLD" --yes 2>/dev/null || true
+            done || true


### PR DESCRIPTION
Companion to babylonlabs-io/babylon-dapp-deployment#321 (the frontend integrity checker) for devops-backlog#253.

## Why
The checker verifies that the JS/CSS a browser downloads from the live staking + vault dApps matches the sha256 manifest this CI produced for the deployed commit. For that it needs a **trusted, public** source of truth for the manifest — one an attacker who poisons the CDN/edge can't also rewrite.

CI already generates `<service>-<env>-<sha>-files-checksum.txt` and uploads it to a **private** S3 bucket. Private S3 forces credentials onto every checker (an AWS key inside the Cloudflare Worker). This PR also publishes it to a **public GitHub release**, so:
- Both checker runtimes (AWS Lambda + Cloudflare Worker) read it with **zero credentials**.
- It lives in a **different trust domain** (GitHub) than the AWS serving path — attacker must break two systems.
- It's literally "a commit from babylon-toolkit", matching the issue.

## What
- New step in both `service-release-*.yml` (staking + vault): after the S3 upload, `gh release upload` the files-checksum to a pinned release **`frontend-manifests`**.
- Deploys fire on push-to-main (per-sha), not tags — so one long-lived release acts as an **append-only, per-sha** asset store. Each `<service>-<env>-<sha>` file is written once ⇒ immutable in practice. `create ... || true` keeps it idempotent across the parallel env matrix.
- `contents: write` scoped to the `s3_publish` job only (lint_test stays read).

No change to the existing S3 upload — this is additive.

## Checker reads
`https://github.com/babylonlabs-io/babylon-toolkit/releases/download/frontend-manifests/<service>-<env>-<sha>-files-checksum.txt`

## Note
Asset store grows one file per deploy per env. Harmless (GitHub handles it); prune old ones later if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)