### PR TITLE
feat(ts-sdk, vault): resolve participant BTC keys by epoch (RFC-006)

### DIFF
--- a/packages/babylon-ts-sdk/src/tbv/core/clients/eth/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/eth/index.ts
@@ -2,25 +2,34 @@ export {
   resolveProtocolAddresses,
   type ProtocolAddresses,
 } from "./contract-address-resolver";
+export { assertOnChainBtcPubkey } from "./onChainBtcPubkey";
+export {
+  ViemOperationKeyReader,
+  type OperationKeyContracts,
+} from "./operation-key-reader";
+export { ViemProtocolParamsReader } from "./protocol-params-reader";
 export {
   validateOffchainParams,
   validatePegInConfiguration,
   validateTBVProtocolParams,
 } from "./protocol-params-validation";
-export { ViemProtocolParamsReader } from "./protocol-params-reader";
 export {
   ViemUniversalChallengerReader,
   ViemVaultKeeperReader,
 } from "./signer-set-reader";
-export { ViemVaultRegistryReader } from "./vault-registry-reader";
 export { OnChainBtcVaultStatus } from "./types";
 export type {
   AddressBTCKeyPair,
   AllOffchainParamsData,
+  KeyEpochs,
   OnChainBtcPubkey,
   OnSkippedOffchainParamsVersion,
+  OperationKeyQuery,
+  OperationKeyReader,
   PegInConfiguration,
   ProtocolParamsReader,
+  RawOperationKeys,
+  RawPayoutScripts,
   TBVProtocolParams,
   UniversalChallengerReader,
   VaultBasicInfo,
@@ -30,3 +39,4 @@ export type {
   VaultRegistryReader,
   VersionedOffchainParams,
 } from "./types";
+export { ViemVaultRegistryReader } from "./vault-registry-reader";

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/eth/onChainBtcPubkey.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/eth/onChainBtcPubkey.ts
@@ -1,0 +1,45 @@
+/**
+ * The single validator that mints {@link OnChainBtcPubkey}.
+ *
+ * Extracted from `ViemVaultRegistryReader.getVaultProviderBtcPubKey` so that
+ * RFC-006 operation-key resolution can produce branded keys through exactly
+ * the same checks, rather than casting past the brand. Every producer of an
+ * `OnChainBtcPubkey` must go through here.
+ */
+
+import * as ecc from "@bitcoin-js/tiny-secp256k1-asmjs";
+import type { Hex } from "viem";
+
+import { hexToUint8Array } from "../../primitives/utils/bitcoin";
+import type { OnChainBtcPubkey } from "./types";
+
+/**
+ * Validate a registry-returned `bytes32` as an x-only BTC pubkey and mint the
+ * brand. Checks length, hex form, and secp256k1 curve membership. Returns
+ * 64-char lowercase hex without the `0x` prefix.
+ *
+ * `label` identifies the read site in error messages (e.g.
+ * `getVaultProviderBTCKey (vp=0x…)`), so a failure names which participant and
+ * which getter produced it.
+ *
+ * A zero hash fails the curve check, so an unregistered operator or an epoch
+ * with no bonded key surfaces as an error rather than a silent all-zero key.
+ */
+export function assertOnChainBtcPubkey(
+  value: Hex,
+  label: string,
+): OnChainBtcPubkey {
+  const lowered = value.toLowerCase();
+  if (!/^0x[0-9a-f]{64}$/.test(lowered)) {
+    throw new Error(
+      `${label} returned an unexpected value (length ${lowered.length}, prefix "${lowered.slice(0, 2)}")`,
+    );
+  }
+  const stripped = lowered.slice(2);
+  if (!ecc.isXOnlyPoint(hexToUint8Array(stripped))) {
+    throw new Error(
+      `${label} returned a value that is not on the secp256k1 curve`,
+    );
+  }
+  return stripped as OnChainBtcPubkey;
+}

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/eth/operation-key-reader.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/eth/operation-key-reader.ts
@@ -1,0 +1,188 @@
+/**
+ * Concrete RFC-006 operation-key reader spanning all three registries.
+ *
+ * This is an optional utility — callers can use their own implementation of
+ * the {@link OperationKeyReader} interface.
+ */
+
+import type { Abi, Address, Hex, PublicClient } from "viem";
+
+import { ApplicationRegistryABI } from "../../contracts/abis/ApplicationRegistry.abi";
+import { BTCVaultRegistryABI } from "../../contracts/abis/BTCVaultRegistry.abi";
+import { ProtocolParamsABI } from "../../contracts/abis/ProtocolParams.abi";
+import type {
+  KeyEpochs,
+  OperationKeyQuery,
+  OperationKeyReader,
+  RawOperationKeys,
+  RawPayoutScripts,
+} from "./types";
+
+/** Addresses of the three registries an operation-key resolution spans. */
+export interface OperationKeyContracts {
+  btcVaultRegistry: Address;
+  applicationRegistry: Address;
+  protocolParams: Address;
+}
+
+/** One `multicall` entry. Loosely typed because the three ABIs differ. */
+type Call = {
+  address: Address;
+  abi: Abi;
+  functionName: string;
+  args: readonly unknown[];
+};
+
+/**
+ * Split a flat multicall result into VP / keepers / challengers.
+ *
+ * Every method below builds its calls in the same order — vault provider
+ * first, then keepers in roster order, then challengers in roster order — so
+ * the results stay index-aligned with `query.vaultKeepers` /
+ * `query.universalChallengers`. That alignment is what lets the resolver pair
+ * a resolved key back to its admin address; the sorted key arrays it exposes
+ * are derived from those pairs, never the other way round.
+ */
+function partition<T>(
+  results: readonly T[],
+  keeperCount: number,
+): { vaultProvider: T; vaultKeepers: T[]; universalChallengers: T[] } {
+  return {
+    vaultProvider: results[0],
+    vaultKeepers: results.slice(1, 1 + keeperCount),
+    universalChallengers: results.slice(1 + keeperCount),
+  };
+}
+
+/**
+ * Reads RFC-006 operation keys and payout scripts.
+ *
+ * Usage:
+ * ```ts
+ * const reader = new ViemOperationKeyReader(publicClient, contracts);
+ * const keys = await reader.getCurrentOperationKeys(query);
+ * ```
+ */
+export class ViemOperationKeyReader implements OperationKeyReader {
+  constructor(
+    private publicClient: PublicClient,
+    private contracts: OperationKeyContracts,
+  ) {}
+
+  /**
+   * One multicall, `allowFailure: false`, so every key in the set is read at
+   * the same block. A rotation landing between two separate `eth_call`s would
+   * otherwise produce a mixed-epoch key set and a lock no counterparty agrees
+   * with.
+   */
+  private async readAll<T>(calls: Call[], keeperCount: number) {
+    const results = (await this.publicClient.multicall({
+      contracts: calls,
+      allowFailure: false,
+    })) as readonly T[];
+
+    return partition(results, keeperCount);
+  }
+
+  async getCurrentOperationKeys(
+    query: OperationKeyQuery,
+  ): Promise<RawOperationKeys> {
+    const calls: Call[] = [
+      {
+        address: this.contracts.btcVaultRegistry,
+        abi: BTCVaultRegistryABI as Abi,
+        functionName: "getCurrentOperationBtcKey",
+        args: [query.vaultProviderEthAddress],
+      },
+      ...query.vaultKeepers.map((keeper) => ({
+        address: this.contracts.applicationRegistry,
+        abi: ApplicationRegistryABI as Abi,
+        functionName: "getCurrentOperationBtcKey",
+        args: [query.applicationEntryPoint, keeper.ethAddress],
+      })),
+      ...query.universalChallengers.map((challenger) => ({
+        address: this.contracts.protocolParams,
+        abi: ProtocolParamsABI as Abi,
+        functionName: "getCurrentOperationBtcKey",
+        args: [challenger.ethAddress],
+      })),
+    ];
+
+    return this.readAll<Hex>(calls, query.vaultKeepers.length);
+  }
+
+  async getOperationKeysAtEpochs(
+    query: OperationKeyQuery,
+    epochs: KeyEpochs,
+  ): Promise<RawOperationKeys> {
+    const calls: Call[] = [
+      // The VP takes the plain `AtEpoch` variant: it has no membership
+      // version, so its genesis (the registration key at version 0) is
+      // unambiguous and the contract resolves it internally.
+      {
+        address: this.contracts.btcVaultRegistry,
+        abi: BTCVaultRegistryABI as Abi,
+        functionName: "getOperationBtcKeyAtEpoch",
+        args: [query.vaultProviderEthAddress, epochs.vpKeyEpoch],
+      },
+      // Keepers and challengers take `...OrGenesis` with their roster key
+      // passed explicitly, because the correct genesis for them is their key
+      // in *this vault's frozen membership version*. An operator dropped from
+      // the current roster, or listed under a different key in an older
+      // version, would otherwise resolve against the wrong genesis.
+      ...query.vaultKeepers.map((keeper) => ({
+        address: this.contracts.applicationRegistry,
+        abi: ApplicationRegistryABI as Abi,
+        functionName: "getOperationBtcKeyAtEpochOrGenesis",
+        args: [
+          query.applicationEntryPoint,
+          keeper.ethAddress,
+          epochs.appKeeperKeyEpoch,
+          keeper.btcPubKey,
+        ],
+      })),
+      ...query.universalChallengers.map((challenger) => ({
+        address: this.contracts.protocolParams,
+        abi: ProtocolParamsABI as Abi,
+        functionName: "getOperationBtcKeyAtEpochOrGenesis",
+        args: [challenger.ethAddress, epochs.ucKeyEpoch, challenger.btcPubKey],
+      })),
+    ];
+
+    return this.readAll<Hex>(calls, query.vaultKeepers.length);
+  }
+
+  async getPayoutScriptsAtEpochs(
+    query: OperationKeyQuery,
+    epochs: KeyEpochs,
+  ): Promise<RawPayoutScripts> {
+    // Universal challengers are never claimers, so they have no payout script
+    // and no call here.
+    const results = (await this.publicClient.multicall({
+      contracts: [
+        {
+          address: this.contracts.btcVaultRegistry,
+          abi: BTCVaultRegistryABI as Abi,
+          functionName: "getPayoutScriptAtEpoch",
+          args: [query.vaultProviderEthAddress, epochs.vpKeyEpoch],
+        },
+        ...query.vaultKeepers.map((keeper) => ({
+          address: this.contracts.applicationRegistry,
+          abi: ApplicationRegistryABI as Abi,
+          functionName: "getPayoutScriptAtEpoch",
+          args: [
+            query.applicationEntryPoint,
+            keeper.ethAddress,
+            epochs.appKeeperKeyEpoch,
+          ],
+        })),
+      ],
+      allowFailure: false,
+    })) as readonly Hex[];
+
+    return {
+      vaultProvider: results[0],
+      vaultKeepers: [...results.slice(1)],
+    };
+  }
+}

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts
@@ -96,7 +96,7 @@ export interface VaultData {
  *
  * Only ever read through {@link VaultRegistryReader.getVaultKeyEpochs}, which
  * uses the extended ABI. See `BTCVaultRegistryKeyEpochs.abi.ts` for why that
- * read is quarantined behind a capability check.
+ * read is quarantined to its own ABI.
  */
 export interface KeyEpochs {
   vpKeyEpoch: bigint;
@@ -133,8 +133,9 @@ export interface VaultRegistryReader {
    *
    * Uses the extended `getBtcVaultProtocolInfo` ABI. Against a registry that
    * predates RFC-006 this returns silent garbage for a populated vault rather
-   * than throwing, so it must only be called once the capability check has
-   * passed. See `BTCVaultRegistryKeyEpochs.abi.ts`.
+   * than throwing, so it must only be called against an RFC-006 registry —
+   * a deployment invariant, not something this call can detect. See
+   * `BTCVaultRegistryKeyEpochs.abi.ts`.
    */
   getVaultKeyEpochs(vaultId: Hex): Promise<KeyEpochs>;
   /** {@link getVaultKeyEpochs} for many vaults in one multicall. */

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts
@@ -14,9 +14,12 @@ import type { Address, Hex } from "viem";
 declare const onChainBtcPubkeyBrand: unique symbol;
 
 /**
- * 64-char lowercase hex (no `0x`) x-only BTC pubkey sourced from the
- * on-chain BTCVaultRegistry. The only legitimate producer is
- * {@link VaultRegistryReader.getVaultProviderBtcPubKey}.
+ * 64-char lowercase hex (no `0x`) x-only BTC pubkey sourced from an on-chain
+ * registry. Minted only by `assertOnChainBtcPubkey`, which is the shared
+ * validator behind both producers:
+ * {@link VaultRegistryReader.getVaultProviderBtcPubKey} (the fixed
+ * registration key) and {@link OperationKeyReader} (RFC-006 operation keys,
+ * resolved current or at a vault's frozen epoch).
  *
  * @stability frozen
  */
@@ -79,6 +82,28 @@ export interface VaultData {
   protocol: VaultProtocolInfo;
 }
 
+/**
+ * RFC-006 operation-key epochs a vault froze at `submitPeginRequest`.
+ *
+ * Each registry keeps a monotonic epoch counter that every key/payout setter
+ * pre-increments. A vault stamps the counters live at its creation, and every
+ * participant resolves "which key did this vault bond?" by asking the registry
+ * for the key whose appended version is the latest stamped `<=` this epoch. A
+ * rotation after the vault was created therefore never moves its keys.
+ *
+ * `uint64` — kept as `bigint` end-to-end and passed straight back to the
+ * `...AtEpoch` getters, never narrowed through `Number`.
+ *
+ * Only ever read through {@link VaultRegistryReader.getVaultKeyEpochs}, which
+ * uses the extended ABI. See `BTCVaultRegistryKeyEpochs.abi.ts` for why that
+ * read is quarantined behind a capability check.
+ */
+export interface KeyEpochs {
+  vpKeyEpoch: bigint;
+  appKeeperKeyEpoch: bigint;
+  ucKeyEpoch: bigint;
+}
+
 /** Interface for reading vault data from the BTCVaultRegistry contract. */
 export interface VaultRegistryReader {
   getVaultBasicInfo(vaultId: Hex): Promise<VaultBasicInfo>;
@@ -103,6 +128,25 @@ export interface VaultRegistryReader {
   getOffchainParamsVersionsByVaultIds(
     vaultIds: readonly Hex[],
   ): Promise<number[]>;
+  /**
+   * Read a vault's frozen RFC-006 key epochs.
+   *
+   * Uses the extended `getBtcVaultProtocolInfo` ABI. Against a registry that
+   * predates RFC-006 this returns silent garbage for a populated vault rather
+   * than throwing, so it must only be called once the capability check has
+   * passed. See `BTCVaultRegistryKeyEpochs.abi.ts`.
+   */
+  getVaultKeyEpochs(vaultId: Hex): Promise<KeyEpochs>;
+  /** {@link getVaultKeyEpochs} for many vaults in one multicall. */
+  getVaultKeyEpochsBatch(vaultIds: readonly Hex[]): Promise<KeyEpochs[]>;
+  /**
+   * Read a vault provider's *current* RFC-006 operation BTC key — the key its
+   * server signs auth tokens with. Falls back to the registration key when the
+   * provider has never rotated.
+   */
+  getCurrentVaultProviderOperationBtcKey(
+    vpAddress: Address,
+  ): Promise<OnChainBtcPubkey>;
 }
 
 // ============================================================================
@@ -238,9 +282,7 @@ export interface VaultKeeperReader {
     appEntryPoint: Address,
     version: number,
   ): Promise<AddressBTCKeyPair[]>;
-  getCurrentVaultKeepers(
-    appEntryPoint: Address,
-  ): Promise<AddressBTCKeyPair[]>;
+  getCurrentVaultKeepers(appEntryPoint: Address): Promise<AddressBTCKeyPair[]>;
   getCurrentVaultKeepersVersion(appEntryPoint: Address): Promise<number>;
 }
 
@@ -251,4 +293,95 @@ export interface UniversalChallengerReader {
   ): Promise<AddressBTCKeyPair[]>;
   getCurrentUniversalChallengers(): Promise<AddressBTCKeyPair[]>;
   getLatestUniversalChallengersVersion(): Promise<number>;
+}
+
+// ============================================================================
+// RFC-006 Operation-Key Types
+// ============================================================================
+
+/**
+ * The participants whose operation keys are being resolved, and the roster
+ * they are resolved against.
+ *
+ * A roster entry's `ethAddress` is the operator's **admin** address — the
+ * lookup key for its key history — and its `btcPubKey` is the operator's
+ * **genesis** key. Both are needed: the `...AtEpochOrGenesis` getters take the
+ * roster key explicitly because the correct genesis for a keeper/challenger is
+ * its key in the vault's *frozen membership version*, which an operator that
+ * was later dropped from the roster no longer has a current entry for.
+ */
+export interface OperationKeyQuery {
+  vaultProviderEthAddress: Address;
+  /**
+   * The VP's genesis (registration) key, from `getVaultProviderBTCKey`.
+   *
+   * The VP has no roster entry to carry a genesis key the way keepers and
+   * challengers do, so it is supplied here. Every call site already reads it:
+   * it is what the indexer hint is compared against, and what makes the VP's
+   * `rotated` flag mean the same thing as everyone else's.
+   */
+  vaultProviderGenesisBtcPubkey: Hex;
+  applicationEntryPoint: Address;
+  /** Keeper roster at the membership version being resolved against. */
+  vaultKeepers: readonly AddressBTCKeyPair[];
+  /** Challenger roster at the membership version being resolved against. */
+  universalChallengers: readonly AddressBTCKeyPair[];
+}
+
+/** Raw registry-returned operation keys, index-aligned with the query rosters. */
+export interface RawOperationKeys {
+  vaultProvider: Hex;
+  vaultKeepers: Hex[];
+  universalChallengers: Hex[];
+}
+
+/**
+ * Registry-returned payout scriptPubKeys, index-aligned with the query
+ * rosters. `universalChallengers` has no counterpart: a UC is never a claimer,
+ * so it has no payout script.
+ */
+export interface RawPayoutScripts {
+  vaultProvider: Hex;
+  vaultKeepers: Hex[];
+}
+
+/**
+ * Reads RFC-006 operation keys and payout scripts across all three registries
+ * (BTCVaultRegistry, ApplicationRegistry, ProtocolParams).
+ *
+ * Every method resolves the whole participant set in a **single** multicall so
+ * the keys are pinned to one block. That atomicity is load-bearing: a rotation
+ * landing between two `eth_call`s would yield a self-inconsistent key set that
+ * builds a lock no counterparty agrees with.
+ */
+export interface OperationKeyReader {
+  /**
+   * Resolve every participant's *current* operation key.
+   *
+   * Used for new peg-ins and for the VP auth pin. Needs no epoch read at all —
+   * each registry's `getCurrentOperationBtcKey` resolves its own genesis
+   * fallback, so an operator that never rotated yields its registration key.
+   */
+  getCurrentOperationKeys(query: OperationKeyQuery): Promise<RawOperationKeys>;
+  /**
+   * Resolve every participant's operation key bonded at a vault's frozen
+   * epochs. Used for every existing-vault path (resume, payout, refund).
+   */
+  getOperationKeysAtEpochs(
+    query: OperationKeyQuery,
+    epochs: KeyEpochs,
+  ): Promise<RawOperationKeys>;
+  /**
+   * Resolve the VP's commission payout script and each keeper's payout script
+   * at a vault's frozen epochs.
+   *
+   * The registry backfills BIP-86 P2TR of the epoch's operation key for any
+   * operator that never called `setPayoutScript`, so this returns byte-identical
+   * results to local BIP-86 derivation until an operator registers a custom
+   * script.
+   */
+  getPayoutScriptsAtEpochs(
+    query: OperationKeyQuery,
+    epochs: KeyEpochs,
+  ): Promise<RawPayoutScripts>;
 }

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts
@@ -92,9 +92,10 @@ function mapVaultProtocolInfo(result: RawVaultProtocolInfo): VaultProtocolInfo {
  * viem does not range-check a decoded `uint64`, so a misaligned decode can
  * hand back a value far larger than the field can hold. Rejecting those is
  * cheap defence in depth against reading the extended ABI on a registry that
- * predates RFC-006 — but it is only a backstop, not a substitute for the
- * capability check: a misaligned decode can also land on a small,
- * plausible-looking integer. See `BTCVaultRegistryKeyEpochs.abi.ts`.
+ * predates RFC-006 — but it is only a backstop, and a weak one: a misaligned
+ * decode can also land on a small, plausible-looking integer that this range
+ * accepts. Correctness rests on only ever pointing at an RFC-006 registry.
+ * See `BTCVaultRegistryKeyEpochs.abi.ts`.
  */
 const UINT64_EXCLUSIVE_UPPER_BOUND = 1n << 64n;
 
@@ -189,10 +190,12 @@ export class ViemVaultRegistryReader implements VaultRegistryReader {
   /**
    * Read a vault's frozen RFC-006 operation-key epochs.
    *
-   * Reads `getBtcVaultProtocolInfo` through the **extended** ABI. Callers must
-   * have passed the capability check first: against a registry that predates
-   * RFC-006 this call does not fail for a populated vault, it silently returns
-   * three words of tail data as epochs. See `BTCVaultRegistryKeyEpochs.abi.ts`.
+   * Reads `getBtcVaultProtocolInfo` through the **extended** ABI, which is only
+   * valid against an RFC-006 registry: against one that predates RFC-006 this
+   * call does not fail for a populated vault, it silently returns three words
+   * of tail data as epochs. Nothing here can detect that, so the guarantee is a
+   * deployment one — every network this ships to has the RFC-006 getters, and
+   * mainnet is a fresh RFC-006 deploy. See `BTCVaultRegistryKeyEpochs.abi.ts`.
    */
   async getVaultKeyEpochs(vaultId: Hex): Promise<KeyEpochs> {
     const result = (await this.publicClient.readContract({

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts
@@ -5,13 +5,14 @@
  * of the VaultRegistryReader interface.
  */
 
-import * as ecc from "@bitcoin-js/tiny-secp256k1-asmjs";
 import type { Abi, Address, Hex, PublicClient } from "viem";
 
-import { hexToUint8Array } from "../../primitives/utils/bitcoin";
 import { BTCVaultRegistryABI } from "../../contracts/abis/BTCVaultRegistry.abi";
+import { BTCVaultRegistryKeyEpochsABI } from "../../contracts/abis/BTCVaultRegistryKeyEpochs.abi";
+import { assertOnChainBtcPubkey } from "./onChainBtcPubkey";
 import { assertValidOffchainParamsVersion } from "./protocol-params-validation";
 import type {
+  KeyEpochs,
   OnChainBtcPubkey,
   VaultBasicInfo,
   VaultData,
@@ -86,6 +87,44 @@ function mapVaultProtocolInfo(result: RawVaultProtocolInfo): VaultProtocolInfo {
 }
 
 /**
+ * Exclusive upper bound for a `uint64` epoch.
+ *
+ * viem does not range-check a decoded `uint64`, so a misaligned decode can
+ * hand back a value far larger than the field can hold. Rejecting those is
+ * cheap defence in depth against reading the extended ABI on a registry that
+ * predates RFC-006 — but it is only a backstop, not a substitute for the
+ * capability check: a misaligned decode can also land on a small,
+ * plausible-looking integer. See `BTCVaultRegistryKeyEpochs.abi.ts`.
+ */
+const UINT64_EXCLUSIVE_UPPER_BOUND = 1n << 64n;
+
+function assertEpochInRange(
+  value: bigint,
+  field: string,
+  vaultId: Hex,
+): bigint {
+  if (value < 0n || value >= UINT64_EXCLUSIVE_UPPER_BOUND) {
+    throw new Error(
+      `getBtcVaultProtocolInfo returned ${field}=${value} for vault ${vaultId}, ` +
+        `outside the uint64 range — the registry may predate RFC-006`,
+    );
+  }
+  return value;
+}
+
+function mapKeyEpochs(result: KeyEpochs, vaultId: Hex): KeyEpochs {
+  return {
+    vpKeyEpoch: assertEpochInRange(result.vpKeyEpoch, "vpKeyEpoch", vaultId),
+    appKeeperKeyEpoch: assertEpochInRange(
+      result.appKeeperKeyEpoch,
+      "appKeeperKeyEpoch",
+      vaultId,
+    ),
+    ucKeyEpoch: assertEpochInRange(result.ucKeyEpoch, "ucKeyEpoch", vaultId),
+  };
+}
+
+/**
  * Concrete vault registry reader using viem.
  *
  * Usage:
@@ -115,19 +154,73 @@ export class ViemVaultRegistryReader implements VaultRegistryReader {
       functionName: "getVaultProviderBTCKey",
       args: [vpAddress],
     })) as Hex;
-    const lowered = result.toLowerCase();
-    if (!/^0x[0-9a-f]{64}$/.test(lowered)) {
-      throw new Error(
-        `getVaultProviderBTCKey returned an unexpected value (vp=${vpAddress}, length ${lowered.length}, prefix "${lowered.slice(0, 2)}")`,
-      );
-    }
-    const stripped = lowered.slice(2);
-    if (!ecc.isXOnlyPoint(hexToUint8Array(stripped))) {
-      throw new Error(
-        `getVaultProviderBTCKey returned a value that is not on the secp256k1 curve (vp=${vpAddress})`,
-      );
-    }
-    return stripped as OnChainBtcPubkey;
+    return assertOnChainBtcPubkey(
+      result,
+      `getVaultProviderBTCKey (vp=${vpAddress})`,
+    );
+  }
+
+  /**
+   * Read a vault provider's *current* RFC-006 operation BTC key.
+   *
+   * Falls back on-chain to the registration key when the provider has never
+   * rotated, so this returns the same value as `getVaultProviderBtcPubKey`
+   * until the first rotation.
+   *
+   * This is the key the VP's server signs its BIP-322 auth tokens with — a
+   * live per-operator identity, not a per-vault binding, so the auth pin uses
+   * the current key rather than any vault's frozen epoch.
+   */
+  async getCurrentVaultProviderOperationBtcKey(
+    vpAddress: Address,
+  ): Promise<OnChainBtcPubkey> {
+    const result = (await this.publicClient.readContract({
+      address: this.contractAddress,
+      abi: BTCVaultRegistryABI,
+      functionName: "getCurrentOperationBtcKey",
+      args: [vpAddress],
+    })) as Hex;
+    return assertOnChainBtcPubkey(
+      result,
+      `getCurrentOperationBtcKey (vp=${vpAddress})`,
+    );
+  }
+
+  /**
+   * Read a vault's frozen RFC-006 operation-key epochs.
+   *
+   * Reads `getBtcVaultProtocolInfo` through the **extended** ABI. Callers must
+   * have passed the capability check first: against a registry that predates
+   * RFC-006 this call does not fail for a populated vault, it silently returns
+   * three words of tail data as epochs. See `BTCVaultRegistryKeyEpochs.abi.ts`.
+   */
+  async getVaultKeyEpochs(vaultId: Hex): Promise<KeyEpochs> {
+    const result = (await this.publicClient.readContract({
+      address: this.contractAddress,
+      abi: BTCVaultRegistryKeyEpochsABI,
+      functionName: "getBtcVaultProtocolInfo",
+      args: [vaultId],
+    })) as unknown as KeyEpochs;
+
+    return mapKeyEpochs(result, vaultId);
+  }
+
+  async getVaultKeyEpochsBatch(vaultIds: readonly Hex[]): Promise<KeyEpochs[]> {
+    if (vaultIds.length === 0) return [];
+
+    const results = await this.publicClient.multicall({
+      contracts: vaultIds.map((vaultId) => ({
+        address: this.contractAddress,
+        abi: BTCVaultRegistryKeyEpochsABI as Abi,
+        functionName: "getBtcVaultProtocolInfo" as const,
+        args: [vaultId] as const,
+      })),
+      allowFailure: false,
+    });
+
+    return results.map((info, i) =>
+      mapKeyEpochs(info as unknown as KeyEpochs, vaultIds[i]),
+    );
   }
 
   async getVaultBasicInfo(vaultId: Hex): Promise<VaultBasicInfo> {
@@ -168,21 +261,7 @@ export class ViemVaultRegistryReader implements VaultRegistryReader {
     });
 
     return results.map((info, i) => {
-      const result = info as unknown as {
-        depositorSignedPeginTx: Hex;
-        universalChallengersVersion: number;
-        appVaultKeepersVersion: number;
-        offchainParamsVersion: number;
-        verifiedAt: bigint;
-        depositorWotsPkHash: Hex;
-        hashlock: Hex;
-        htlcVout: number;
-        depositorPopSignature: Hex;
-        prePeginTxHash: Hex;
-        vaultProviderCommissionBps: number;
-        claimExpiredUntil: bigint;
-        vaultCoreVersion: number;
-      };
+      const result = info as unknown as RawVaultProtocolInfo;
       if (
         !result.depositorSignedPeginTx ||
         result.depositorSignedPeginTx === "0x"
@@ -191,23 +270,7 @@ export class ViemVaultRegistryReader implements VaultRegistryReader {
           `Vault ${vaultIds[i]} not found on-chain or has no pegin transaction`,
         );
       }
-      const offchainParamsVersion = Number(result.offchainParamsVersion);
-      assertValidOffchainParamsVersion(offchainParamsVersion);
-      return {
-        depositorSignedPeginTx: result.depositorSignedPeginTx,
-        universalChallengersVersion: result.universalChallengersVersion,
-        appVaultKeepersVersion: result.appVaultKeepersVersion,
-        offchainParamsVersion,
-        verifiedAt: result.verifiedAt,
-        depositorWotsPkHash: result.depositorWotsPkHash,
-        hashlock: result.hashlock,
-        htlcVout: result.htlcVout,
-        depositorPopSignature: result.depositorPopSignature,
-        prePeginTxHash: result.prePeginTxHash,
-        vaultProviderCommissionBps: result.vaultProviderCommissionBps,
-        claimExpiredUntil: result.claimExpiredUntil,
-        vaultCoreVersion: result.vaultCoreVersion,
-      };
+      return mapVaultProtocolInfo(result);
     });
   }
 

--- a/packages/babylon-ts-sdk/src/tbv/core/contracts/__tests__/BTCVaultRegistryKeyEpochs.abi.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/contracts/__tests__/BTCVaultRegistryKeyEpochs.abi.test.ts
@@ -1,0 +1,173 @@
+import { decodeFunctionResult, encodeFunctionResult } from "viem";
+import { describe, expect, it } from "vitest";
+
+import { BTCVaultRegistryABI } from "../abis/BTCVaultRegistry.abi";
+import { BTCVaultRegistryKeyEpochsABI } from "../abis/BTCVaultRegistryKeyEpochs.abi";
+
+/**
+ * `getBtcVaultProtocolInfo` is declared twice on purpose: the shared ABI keeps
+ * the 13-field shape that decodes against every deployed registry, and the
+ * key-epochs ABI carries the three RFC-006 epoch fields. These tests pin the
+ * two properties that make that split safe.
+ */
+
+type AbiComponent = { readonly name: string; readonly type: string };
+
+function protocolInfoComponents(
+  abi: typeof BTCVaultRegistryABI | typeof BTCVaultRegistryKeyEpochsABI,
+): AbiComponent[] {
+  const entry = abi.find(
+    (item) =>
+      item.type === "function" && item.name === "getBtcVaultProtocolInfo",
+  );
+  if (!entry || !("outputs" in entry)) {
+    throw new Error("getBtcVaultProtocolInfo not found in ABI");
+  }
+  const output = entry.outputs[0] as { components?: readonly AbiComponent[] };
+  if (!output.components) {
+    throw new Error("getBtcVaultProtocolInfo output has no components");
+  }
+  return [...output.components];
+}
+
+/** A legacy (pre-RFC-006) protocol-info tuple, as a 13-field registry returns it. */
+const LEGACY_PROTOCOL_INFO = {
+  depositorSignedPeginTx: "0xdeadbeef",
+  universalChallengersVersion: 1,
+  appVaultKeepersVersion: 2,
+  offchainParamsVersion: 3,
+  verifiedAt: 4n,
+  depositorWotsPkHash: `0x${"11".repeat(32)}`,
+  hashlock: `0x${"22".repeat(32)}`,
+  htlcVout: 0,
+  depositorPopSignature: "0xc0ffee",
+  prePeginTxHash: `0x${"33".repeat(32)}`,
+  vaultProviderCommissionBps: 100,
+  claimExpiredUntil: 0n,
+  vaultCoreVersion: 1,
+} as const;
+
+const RFC006_PROTOCOL_INFO = {
+  ...LEGACY_PROTOCOL_INFO,
+  vpKeyEpoch: 7n,
+  appKeeperKeyEpoch: 8n,
+  ucKeyEpoch: 9n,
+} as const;
+
+describe("BTCVaultRegistryKeyEpochsABI", () => {
+  it("declares the 13 shared components as an exact prefix of its 16", () => {
+    const shared = protocolInfoComponents(BTCVaultRegistryABI);
+    const extended = protocolInfoComponents(BTCVaultRegistryKeyEpochsABI);
+
+    expect(shared).toHaveLength(13);
+    expect(extended).toHaveLength(16);
+
+    // Name AND type, in order. The tuple is positional, so a rename or a
+    // widened type in one copy and not the other silently misaligns every
+    // field after it.
+    expect(extended.slice(0, shared.length)).toEqual(shared);
+  });
+
+  it("appends exactly the three RFC-006 uint64 key epochs", () => {
+    const extended = protocolInfoComponents(BTCVaultRegistryKeyEpochsABI);
+
+    expect(extended.slice(13)).toEqual([
+      { name: "vpKeyEpoch", type: "uint64", internalType: "uint64" },
+      { name: "appKeeperKeyEpoch", type: "uint64", internalType: "uint64" },
+      { name: "ucKeyEpoch", type: "uint64", internalType: "uint64" },
+    ]);
+  });
+
+  it("silently mis-decodes a populated pre-RFC-006 registry response", () => {
+    // The hazard, stated exactly. `BTCVaultProtocolInfo` is a *dynamic* tuple
+    // (it contains `bytes`), so its encoding is a 13-word head followed by the
+    // tail holding the dynamic payloads. Asking for 16 head words does not run
+    // off the end of the returndata — it reads three words of *tail* and hands
+    // them back as epochs. No throw, no warning, plausible-looking small
+    // integers.
+    //
+    // So the extended ABI must never be read on a registry that has not been
+    // upgraded. Being careful with the values is not enough; the capability
+    // probe below is the only thing standing between this and resolving
+    // participant keys at a fabricated epoch.
+    const legacyReturndata = encodeFunctionResult({
+      abi: BTCVaultRegistryABI,
+      functionName: "getBtcVaultProtocolInfo",
+      result: LEGACY_PROTOCOL_INFO,
+    });
+
+    const decoded = decodeFunctionResult({
+      abi: BTCVaultRegistryKeyEpochsABI,
+      functionName: "getBtcVaultProtocolInfo",
+      data: legacyReturndata,
+    }) as unknown as Record<string, bigint>;
+
+    // Garbage, not an error — and not the zeros a real pre-rotation vault has.
+    expect(decoded.vpKeyEpoch).not.toBe(0n);
+  });
+
+  it("throws on an empty response from a legacy registry", () => {
+    // A *nonexistent* vault has empty `bytes` fields, so its tail is only two
+    // length words — too short to satisfy a 16-word head, and viem throws.
+    // Contrast with the populated-vault case above, where a legacy registry
+    // decodes silently into garbage epochs instead of failing.
+    //
+    // On an upgraded registry the same call decodes cleanly to all-zero.
+    const emptyLegacyReturndata = encodeFunctionResult({
+      abi: BTCVaultRegistryABI,
+      functionName: "getBtcVaultProtocolInfo",
+      result: {
+        ...LEGACY_PROTOCOL_INFO,
+        depositorSignedPeginTx: "0x",
+        depositorPopSignature: "0x",
+      },
+    });
+
+    expect(() =>
+      decodeFunctionResult({
+        abi: BTCVaultRegistryKeyEpochsABI,
+        functionName: "getBtcVaultProtocolInfo",
+        data: emptyLegacyReturndata,
+      }),
+    ).toThrow();
+  });
+
+  it("lets the shared ABI keep decoding an upgraded registry response", () => {
+    // The other direction must NOT throw: the 13-field shared entry is read on
+    // every legacy code path and has to keep working after a registry is
+    // upgraded, ignoring the trailing epoch fields.
+    const rfc006Returndata = encodeFunctionResult({
+      abi: BTCVaultRegistryKeyEpochsABI,
+      functionName: "getBtcVaultProtocolInfo",
+      result: RFC006_PROTOCOL_INFO,
+    });
+
+    const decoded = decodeFunctionResult({
+      abi: BTCVaultRegistryABI,
+      functionName: "getBtcVaultProtocolInfo",
+      data: rfc006Returndata,
+    });
+
+    expect(decoded).toMatchObject(LEGACY_PROTOCOL_INFO);
+  });
+
+  it("decodes the epochs from an upgraded registry response", () => {
+    const rfc006Returndata = encodeFunctionResult({
+      abi: BTCVaultRegistryKeyEpochsABI,
+      functionName: "getBtcVaultProtocolInfo",
+      result: RFC006_PROTOCOL_INFO,
+    });
+
+    const decoded = decodeFunctionResult({
+      abi: BTCVaultRegistryKeyEpochsABI,
+      functionName: "getBtcVaultProtocolInfo",
+      data: rfc006Returndata,
+    });
+
+    expect(decoded).toMatchObject({
+      vpKeyEpoch: 7n,
+      appKeeperKeyEpoch: 8n,
+      ucKeyEpoch: 9n,
+    });
+  });
+});

--- a/packages/babylon-ts-sdk/src/tbv/core/contracts/__tests__/BTCVaultRegistryKeyEpochs.abi.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/contracts/__tests__/BTCVaultRegistryKeyEpochs.abi.test.ts
@@ -87,9 +87,13 @@ describe("BTCVaultRegistryKeyEpochsABI", () => {
     // integers.
     //
     // So the extended ABI must never be read on a registry that has not been
-    // upgraded. Being careful with the values is not enough; the capability
-    // probe below is the only thing standing between this and resolving
-    // participant keys at a fabricated epoch.
+    // upgraded, and being careful with the decoded values is not enough — the
+    // `uint64` range check in `vault-registry-reader.ts` rejects the wild
+    // values but not the plausible ones. What stands between this and resolving
+    // participant keys at a fabricated epoch is a deployment invariant: every
+    // network this ships to already has the RFC-006 getters, and mainnet is a
+    // fresh RFC-006 deploy. This test pins the hazard so that invariant stays
+    // a conscious one.
     const legacyReturndata = encodeFunctionResult({
       abi: BTCVaultRegistryABI,
       functionName: "getBtcVaultProtocolInfo",

--- a/packages/babylon-ts-sdk/src/tbv/core/contracts/abis/ApplicationRegistry.abi.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/contracts/abis/ApplicationRegistry.abi.ts
@@ -94,4 +94,49 @@ export const ApplicationRegistryABI = [
     ],
     stateMutability: "view",
   },
+  // --- RFC-006 operation-key resolution ---------------------------------
+  // A keeper's roster entry (`AddressBTCKeyPair` above) carries its *admin*
+  // ETH address and its *genesis* BTC key. The key that actually goes into
+  // the scripts is the operation key bonded at the vault's frozen
+  // `appKeeperKeyEpoch`, which the admin address keys the lookup for.
+  //
+  // The `...OrGenesis` variant takes the roster key explicitly because the
+  // correct genesis for a keeper is its key in the vault's *frozen membership
+  // version* — a keeper may have been dropped from the current roster, or
+  // listed under a different key in an older version. The plain
+  // `getOperationBtcKeyAtEpoch` variant resolves genesis version-agnostically
+  // and can therefore pick the wrong one; do not use it for a frozen vault.
+  {
+    type: "function",
+    name: "getCurrentOperationBtcKey",
+    inputs: [
+      { name: "appEntryPoint", type: "address", internalType: "address" },
+      { name: "keeperAdmin", type: "address", internalType: "address" },
+    ],
+    outputs: [{ name: "", type: "bytes32", internalType: "bytes32" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "getOperationBtcKeyAtEpochOrGenesis",
+    inputs: [
+      { name: "appEntryPoint", type: "address", internalType: "address" },
+      { name: "keeperAdmin", type: "address", internalType: "address" },
+      { name: "epoch", type: "uint64", internalType: "uint64" },
+      { name: "rosterGenesisKey", type: "bytes32", internalType: "bytes32" },
+    ],
+    outputs: [{ name: "", type: "bytes32", internalType: "bytes32" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "getPayoutScriptAtEpoch",
+    inputs: [
+      { name: "appEntryPoint", type: "address", internalType: "address" },
+      { name: "keeperAdmin", type: "address", internalType: "address" },
+      { name: "epoch", type: "uint64", internalType: "uint64" },
+    ],
+    outputs: [{ name: "", type: "bytes", internalType: "bytes" }],
+    stateMutability: "view",
+  },
 ] as const;

--- a/packages/babylon-ts-sdk/src/tbv/core/contracts/abis/BTCVaultRegistry.abi.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/contracts/abis/BTCVaultRegistry.abi.ts
@@ -171,15 +171,31 @@ export const BTCVaultRegistryABI = [
         type: "tuple[]",
         internalType: "struct BTCVaultRegistryTypes.BatchPeginRequest[]",
         components: [
-          { name: "depositorBtcPubKey", type: "bytes32", internalType: "bytes32" },
+          {
+            name: "depositorBtcPubKey",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
           { name: "btcPopSignature", type: "bytes", internalType: "bytes" },
           { name: "unsignedPrePeginTx", type: "bytes", internalType: "bytes" },
-          { name: "depositorSignedPeginTx", type: "bytes", internalType: "bytes" },
+          {
+            name: "depositorSignedPeginTx",
+            type: "bytes",
+            internalType: "bytes",
+          },
           { name: "hashlock", type: "bytes32", internalType: "bytes32" },
           { name: "htlcVout", type: "uint8", internalType: "uint8" },
           { name: "referralCode", type: "uint32", internalType: "uint32" },
-          { name: "depositorPayoutBtcAddress", type: "bytes", internalType: "bytes" },
-          { name: "depositorWotsPkHash", type: "bytes32", internalType: "bytes32" },
+          {
+            name: "depositorPayoutBtcAddress",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "depositorWotsPkHash",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
         ],
       },
     ],
@@ -233,23 +249,54 @@ export const BTCVaultRegistryABI = [
   {
     type: "function",
     name: "getVaultProviderBTCKey",
+    inputs: [{ name: "vpAddr", type: "address", internalType: "address" }],
+    outputs: [{ name: "", type: "bytes32", internalType: "bytes32" }],
+    stateMutability: "view",
+  },
+  // --- RFC-006 operation-key resolution ---------------------------------
+  // A vault provider's BTC key is no longer the fixed registration key
+  // returned by `getVaultProviderBTCKey` above: it is an append-only history
+  // of *operation* keys, rotated by the provider's cold ETH admin key. Each
+  // vault freezes a `vpKeyEpoch` at `submitPeginRequest` and resolves the key
+  // bonded at that epoch, so a later rotation never invalidates a live vault.
+  //
+  // Both getters fall back on-chain when the provider never rotated:
+  // `getCurrentOperationBtcKey` returns the registration key at version 0, and
+  // `getPayoutScriptAtEpoch` returns the BIP-86 P2TR of the epoch's operation
+  // key when no explicit payout script was registered. That is what makes
+  // adopting them a no-op until the first rotation on a network.
+  {
+    type: "function",
+    name: "getCurrentOperationBtcKey",
+    inputs: [{ name: "provider", type: "address", internalType: "address" }],
+    outputs: [{ name: "", type: "bytes32", internalType: "bytes32" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "getOperationBtcKeyAtEpoch",
     inputs: [
-      { name: "vpAddr", type: "address", internalType: "address" },
+      { name: "provider", type: "address", internalType: "address" },
+      { name: "epoch", type: "uint64", internalType: "uint64" },
     ],
-    outputs: [
-      { name: "", type: "bytes32", internalType: "bytes32" },
+    outputs: [{ name: "", type: "bytes32", internalType: "bytes32" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "getPayoutScriptAtEpoch",
+    inputs: [
+      { name: "provider", type: "address", internalType: "address" },
+      { name: "epoch", type: "uint64", internalType: "uint64" },
     ],
+    outputs: [{ name: "", type: "bytes", internalType: "bytes" }],
     stateMutability: "view",
   },
   {
     type: "function",
     name: "getVaultProviderCommission",
-    inputs: [
-      { name: "vpAddr", type: "address", internalType: "address" },
-    ],
-    outputs: [
-      { name: "", type: "uint16", internalType: "uint16" },
-    ],
+    inputs: [{ name: "vpAddr", type: "address", internalType: "address" }],
+    outputs: [{ name: "", type: "uint16", internalType: "uint16" }],
     stateMutability: "view",
   },
   {
@@ -361,8 +408,7 @@ export const BTCVaultRegistryABI = [
       {
         name: "vProtocol",
         type: "tuple",
-        internalType:
-          "struct BTCVaultRegistryTypes.BTCVaultProtocolInfo",
+        internalType: "struct BTCVaultRegistryTypes.BTCVaultProtocolInfo",
         components: [
           {
             name: "depositorSignedPeginTx",

--- a/packages/babylon-ts-sdk/src/tbv/core/contracts/abis/BTCVaultRegistry.abi.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/contracts/abis/BTCVaultRegistry.abi.ts
@@ -260,11 +260,23 @@ export const BTCVaultRegistryABI = [
   // vault freezes a `vpKeyEpoch` at `submitPeginRequest` and resolves the key
   // bonded at that epoch, so a later rotation never invalidates a live vault.
   //
-  // Both getters fall back on-chain when the provider never rotated:
-  // `getCurrentOperationBtcKey` returns the registration key at version 0, and
-  // `getPayoutScriptAtEpoch` returns the BIP-86 P2TR of the epoch's operation
-  // key when no explicit payout script was registered. That is what makes
-  // adopting them a no-op until the first rotation on a network.
+  // `getCurrentOperationBtcKey` falls back on-chain to the registration key at
+  // version 0, so adopting it is a no-op for a provider that never rotated.
+  //
+  // `getPayoutScriptAtEpoch` does NOT behave that way, and assuming it did was
+  // wrong in an earlier revision of this comment. A payout script is mandatory
+  // at registration and stored as version 1, so on an RFC-006 registry this
+  // returns the operator's own registered script from the very first epoch —
+  // not a BIP-86 derivation of its key. The contract's BIP-86 branch is a
+  // migration default for pre-RFC-006 rows and is not reachable from
+  // registration. An operator whose registered script happens to equal
+  // bip86(key) is a coincidence of what it chose to register, not a fallback.
+  //
+  // This is why depositor payout validation must accept the legacy BIP-86 form
+  // alongside the registered one: a payout graph is built once at BaBe Setup
+  // and never rebuilt, so a vault whose graph predates its network's
+  // btc-vault#2440 upgrade pays BIP-86 for the rest of its life. See
+  // `acceptedPayoutScriptHexes` in `primitives/psbt/payout.ts`.
   {
     type: "function",
     name: "getCurrentOperationBtcKey",

--- a/packages/babylon-ts-sdk/src/tbv/core/contracts/abis/BTCVaultRegistryKeyEpochs.abi.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/contracts/abis/BTCVaultRegistryKeyEpochs.abi.ts
@@ -1,0 +1,138 @@
+/**
+ * BTCVaultRegistry ABI — RFC-006 key-epoch view of `getBtcVaultProtocolInfo`.
+ *
+ * This is a deliberate second copy of a single function entry, NOT a
+ * convenience re-export, and it must never be merged into
+ * `BTCVaultRegistryABI`.
+ *
+ * `getBtcVaultProtocolInfo` returns a *positional* tuple. RFC-006 appended
+ * three `uint64` epoch fields (`vpKeyEpoch`, `appKeeperKeyEpoch`,
+ * `ucKeyEpoch`) after `vaultCoreVersion`. Declaring those three components
+ * against a registry that predates RFC-006 makes viem read past the end of
+ * the returndata and throw — and because the shared reader batches this call
+ * through `multicall({ allowFailure: false })`, one bad decode fails the
+ * whole batch. That would break vault status, resume, payout and refund
+ * app-wide, on every network whose registry has not been upgraded yet.
+ *
+ * So the shared `BTCVaultRegistryABI` keeps the 13-field shape that decodes
+ * against every deployed registry, and the extended shape lives here, read
+ * only by `ViemVaultRegistryReader.getVaultKeyEpochs*` on the epoch-aware
+ * path. Reading the same call through two ABIs is the price of keeping the
+ * shared decode path independent of the registry version.
+ *
+ * The 13 shared components must stay an exact prefix of the 16 below;
+ * `__tests__/abi-key-epochs.test.ts` pins that.
+ *
+ * Generated from vault-contracts-aave-v4
+ * `src/protocol/lib/types/BTCVaultRegistryTypes.sol`.
+ *
+ * @module contracts/abis/BTCVaultRegistryKeyEpochs
+ */
+
+export const BTCVaultRegistryKeyEpochsABI = [
+  {
+    type: "function",
+    name: "getBtcVaultProtocolInfo",
+    inputs: [
+      {
+        name: "vaultId",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+    ],
+    outputs: [
+      {
+        name: "vProtocol",
+        type: "tuple",
+        internalType: "struct BTCVaultRegistryTypes.BTCVaultProtocolInfo",
+        components: [
+          {
+            name: "depositorSignedPeginTx",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "universalChallengersVersion",
+            type: "uint16",
+            internalType: "uint16",
+          },
+          {
+            name: "appVaultKeepersVersion",
+            type: "uint16",
+            internalType: "uint16",
+          },
+          {
+            name: "offchainParamsVersion",
+            type: "uint16",
+            internalType: "uint16",
+          },
+          {
+            name: "verifiedAt",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "depositorWotsPkHash",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+          {
+            name: "hashlock",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+          {
+            name: "htlcVout",
+            type: "uint8",
+            internalType: "uint8",
+          },
+          {
+            name: "depositorPopSignature",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "prePeginTxHash",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+          {
+            name: "vaultProviderCommissionBps",
+            type: "uint16",
+            internalType: "uint16",
+          },
+          {
+            name: "claimExpiredUntil",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "vaultCoreVersion",
+            type: "uint16",
+            internalType: "uint16",
+          },
+          // RFC-006: per-pegin operation-key epochs, frozen at
+          // `submitPeginRequest`. All three pack into one storage slot and were
+          // appended after `vaultCoreVersion` so pre-existing rows decode
+          // unchanged.
+          {
+            name: "vpKeyEpoch",
+            type: "uint64",
+            internalType: "uint64",
+          },
+          {
+            name: "appKeeperKeyEpoch",
+            type: "uint64",
+            internalType: "uint64",
+          },
+          {
+            name: "ucKeyEpoch",
+            type: "uint64",
+            internalType: "uint64",
+          },
+        ],
+      },
+    ],
+    stateMutability: "view",
+  },
+] as const;

--- a/packages/babylon-ts-sdk/src/tbv/core/contracts/abis/ProtocolParams.abi.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/contracts/abis/ProtocolParams.abi.ts
@@ -314,4 +314,29 @@ export const ProtocolParamsABI = [
     ],
     stateMutability: "view",
   },
+  // --- RFC-006 operation-key resolution ---------------------------------
+  // Universal challengers get the reduced RFC-006 model: an operation key
+  // that goes into the challenge scripts, resolved against the vault's frozen
+  // `ucKeyEpoch`, but no payout script (a UC is never a claimer, so its only
+  // BTC output is the NoPayout anchor) and no per-UC setter — key changes go
+  // through a roster version bump. The roster entry's `ethAddress` is the
+  // `ucAdmin` lookup key and its `btcPubKey` is the genesis key.
+  {
+    type: "function",
+    name: "getCurrentOperationBtcKey",
+    inputs: [{ name: "ucAdmin", type: "address", internalType: "address" }],
+    outputs: [{ name: "", type: "bytes32", internalType: "bytes32" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "getOperationBtcKeyAtEpochOrGenesis",
+    inputs: [
+      { name: "ucAdmin", type: "address", internalType: "address" },
+      { name: "epoch", type: "uint64", internalType: "uint64" },
+      { name: "rosterGenesisKey", type: "bytes32", internalType: "bytes32" },
+    ],
+    outputs: [{ name: "", type: "bytes32", internalType: "bytes32" }],
+    stateMutability: "view",
+  },
 ] as const;

--- a/packages/babylon-ts-sdk/src/tbv/core/contracts/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/contracts/index.ts
@@ -9,13 +9,13 @@
 
 export { ApplicationRegistryABI } from "./abis/ApplicationRegistry.abi";
 export { BTCVaultRegistryABI } from "./abis/BTCVaultRegistry.abi";
+export { BTCVaultRegistryKeyEpochsABI } from "./abis/BTCVaultRegistryKeyEpochs.abi";
 export { ProtocolParamsABI } from "./abis/ProtocolParams.abi";
 
 export {
   CONTRACT_ERRORS,
   extractErrorData,
   getContractErrorMessage,
-  isKnownContractError,
   handleContractError,
+  isKnownContractError,
 } from "./errors";
-

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts
@@ -117,6 +117,15 @@ interface SignPayoutBaseParams {
 
   /** Security council member count; forwarded to the fee floor (see PayoutParams). */
   councilSize: number;
+
+  /**
+   * RFC-006 resolved payout destinations, keyed by lowercased x-only operation
+   * pubkey. Forwarded verbatim to {@link buildPayoutPsbt}; every VK claimer
+   * must be present.
+   */
+  vkClaimerPayoutScriptPubKeys: Readonly<Record<string, string>>;
+  /** RFC-006 VP commission destination. Forwarded to {@link buildPayoutPsbt}. */
+  vpCommissionScriptPubKey: string;
 }
 
 /**
@@ -238,6 +247,8 @@ export class PayoutManager {
       commissionBps: params.commissionBps,
       protocolFeeRate: params.protocolFeeRate,
       councilSize: params.councilSize,
+      vkClaimerPayoutScriptPubKeys: params.vkClaimerPayoutScriptPubKeys,
+      vpCommissionScriptPubKey: params.vpCommissionScriptPubKey,
     });
 
     // Sign PSBT via wallet (Taproot script-path spend, input 0 only)
@@ -341,6 +352,8 @@ export class PayoutManager {
         commissionBps: tx.commissionBps,
         protocolFeeRate: tx.protocolFeeRate,
         councilSize: tx.councilSize,
+        vkClaimerPayoutScriptPubKeys: tx.vkClaimerPayoutScriptPubKeys,
+        vpCommissionScriptPubKey: tx.vpCommissionScriptPubKey,
       });
       psbtsToSign.push(payoutPsbt.psbtHex);
       signOptions.push(createTaprootScriptPathSignOptions(walletPubkeyRaw, 1));

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PayoutManager.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PayoutManager.test.ts
@@ -25,6 +25,7 @@ import {
 } from "../../primitives/psbt/__tests__/constants";
 import { initializeWasmForTests } from "../../primitives/psbt/__tests__/helpers";
 import { PAYOUT_ANCHOR_DUST_SATS } from "../../primitives/psbt/constants";
+import { deriveBip86ScriptPubKeyHex } from "../../primitives/utils/bitcoin";
 import { PayoutManager, type PayoutManagerConfig } from "../PayoutManager";
 
 // These tests inject synthetic signatures into otherwise-real payout PSBTs to
@@ -49,6 +50,18 @@ const TEST_KEYS = {
 
 /** Valid P2WPKH scriptPubKey for payout output address validation tests */
 const TEST_PAYOUT_SCRIPT_PUBKEY = P2WPKH_PREFIX + "d".repeat(40);
+
+/**
+ * VP commission destination of the test payout transactions (outs[1]), and the
+ * keeper payout map for an un-rotated operator set where the registry backfills
+ * BIP-86 — the same bytes local derivation would produce.
+ */
+const TEST_VP_COMMISSION_SCRIPT = createDummyP2WPKH("e").toString("hex");
+const TEST_VK_PAYOUT_SCRIPTS: Readonly<Record<string, string>> = {
+  [TEST_KEYS.VAULT_KEEPER_1.toLowerCase()]: deriveBip86ScriptPubKeyHex(
+    TEST_KEYS.VAULT_KEEPER_1,
+  ),
+};
 
 describe("PayoutManager", () => {
   beforeAll(async () => {
@@ -245,6 +258,8 @@ describe("PayoutManager", () => {
           commissionBps: 500,
           protocolFeeRate: 10n,
           councilSize: 3,
+          vkClaimerPayoutScriptPubKeys: TEST_VK_PAYOUT_SCRIPTS,
+          vpCommissionScriptPubKey: TEST_VP_COMMISSION_SCRIPT,
         },
         {
           vaultCoreVersion: 1,
@@ -261,6 +276,8 @@ describe("PayoutManager", () => {
           commissionBps: 500,
           protocolFeeRate: 10n,
           councilSize: 3,
+          vkClaimerPayoutScriptPubKeys: TEST_VK_PAYOUT_SCRIPTS,
+          vpCommissionScriptPubKey: TEST_VP_COMMISSION_SCRIPT,
         },
       ]);
 
@@ -312,6 +329,8 @@ describe("PayoutManager", () => {
             commissionBps: 500,
             protocolFeeRate: 10n,
             councilSize: 3,
+            vkClaimerPayoutScriptPubKeys: TEST_VK_PAYOUT_SCRIPTS,
+            vpCommissionScriptPubKey: TEST_VP_COMMISSION_SCRIPT,
           },
         ]),
       ).rejects.toThrow(
@@ -360,6 +379,8 @@ describe("PayoutManager", () => {
             commissionBps: 500,
             protocolFeeRate: 10n,
             councilSize: 3,
+            vkClaimerPayoutScriptPubKeys: TEST_VK_PAYOUT_SCRIPTS,
+            vpCommissionScriptPubKey: TEST_VP_COMMISSION_SCRIPT,
           },
         ]),
       ).rejects.toThrow();
@@ -423,6 +444,8 @@ describe("PayoutManager", () => {
             commissionBps: 500,
             protocolFeeRate: 10n,
             councilSize: 3,
+            vkClaimerPayoutScriptPubKeys: TEST_VK_PAYOUT_SCRIPTS,
+            vpCommissionScriptPubKey: TEST_VP_COMMISSION_SCRIPT,
           },
           {
             vaultCoreVersion: 1,
@@ -439,6 +462,8 @@ describe("PayoutManager", () => {
             commissionBps: 500,
             protocolFeeRate: 10n,
             councilSize: 3,
+            vkClaimerPayoutScriptPubKeys: TEST_VK_PAYOUT_SCRIPTS,
+            vpCommissionScriptPubKey: TEST_VP_COMMISSION_SCRIPT,
           },
         ]),
       ).rejects.toThrow("Expected 2 signed PSBTs but received 1");
@@ -504,6 +529,8 @@ describe("PayoutManager", () => {
             commissionBps: 500,
             protocolFeeRate: 10n,
             councilSize: 3,
+            vkClaimerPayoutScriptPubKeys: TEST_VK_PAYOUT_SCRIPTS,
+            vpCommissionScriptPubKey: TEST_VP_COMMISSION_SCRIPT,
           },
           {
             vaultCoreVersion: 1,
@@ -520,6 +547,8 @@ describe("PayoutManager", () => {
             commissionBps: 500,
             protocolFeeRate: 10n,
             councilSize: 3,
+            vkClaimerPayoutScriptPubKeys: TEST_VK_PAYOUT_SCRIPTS,
+            vpCommissionScriptPubKey: TEST_VP_COMMISSION_SCRIPT,
           },
         ]),
       ).rejects.toThrow("Expected 2 signed PSBTs but received 3");
@@ -611,6 +640,8 @@ describe("PayoutManager", () => {
           commissionBps: 500,
           protocolFeeRate: 10n,
           councilSize: 3,
+          vkClaimerPayoutScriptPubKeys: TEST_VK_PAYOUT_SCRIPTS,
+          vpCommissionScriptPubKey: TEST_VP_COMMISSION_SCRIPT,
         }),
       ).rejects.toThrow(
         "Payout transaction output 0 does not pay the expected scriptPubKey for role vp-claimer",
@@ -652,6 +683,8 @@ describe("PayoutManager", () => {
           commissionBps: 500,
           protocolFeeRate: 10n,
           councilSize: 3,
+          vkClaimerPayoutScriptPubKeys: TEST_VK_PAYOUT_SCRIPTS,
+          vpCommissionScriptPubKey: TEST_VP_COMMISSION_SCRIPT,
         }),
       ).rejects.not.toThrow(
         "output 0 does not pay the expected scriptPubKey for role vp-claimer",
@@ -688,6 +721,8 @@ describe("PayoutManager", () => {
           commissionBps: 500,
           protocolFeeRate: 10n,
           councilSize: 3,
+          vkClaimerPayoutScriptPubKeys: TEST_VK_PAYOUT_SCRIPTS,
+          vpCommissionScriptPubKey: TEST_VP_COMMISSION_SCRIPT,
         }),
       ).rejects.toThrow("Invalid registeredPayoutScriptPubKey: not valid hex");
     });
@@ -750,6 +785,8 @@ describe("PayoutManager", () => {
           commissionBps: 500,
           protocolFeeRate: 10n,
           councilSize: 3,
+          vkClaimerPayoutScriptPubKeys: TEST_VK_PAYOUT_SCRIPTS,
+          vpCommissionScriptPubKey: TEST_VP_COMMISSION_SCRIPT,
         }),
       ).rejects.toThrow(/has 4 output\(s\), expected exactly 3/);
     });
@@ -811,6 +848,8 @@ describe("PayoutManager", () => {
           commissionBps: 500,
           protocolFeeRate: 10n,
           councilSize: 3,
+          vkClaimerPayoutScriptPubKeys: TEST_VK_PAYOUT_SCRIPTS,
+          vpCommissionScriptPubKey: TEST_VP_COMMISSION_SCRIPT,
         }),
       ).rejects.toThrow(/output 0 script/);
     });
@@ -849,6 +888,8 @@ describe("PayoutManager", () => {
             commissionBps: 500,
             protocolFeeRate: 10n,
             councilSize: 3,
+            vkClaimerPayoutScriptPubKeys: TEST_VK_PAYOUT_SCRIPTS,
+            vpCommissionScriptPubKey: TEST_VP_COMMISSION_SCRIPT,
           },
         ]),
       ).rejects.toThrow(

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/assertPayoutFeeBand.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/assertPayoutFeeBand.test.ts
@@ -189,7 +189,7 @@ describe("assertPayoutFeeInBand", () => {
     ).rejects.toThrow(/exceeds the safety cap/);
   });
 
-  it("does not widen the ceiling for the unpinned commission script length", async () => {
+  it("does not widen the ceiling for the commission script length", async () => {
     // out1 is VP-controlled; a 128-byte pad must buy zero extra headroom —
     // the ceiling stays at the flat 10 * 610 = 6_100.
     const measured = { out0Len: P2WPKH_LEN, out1Len: 128 };

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/payout.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/payout.test.ts
@@ -63,6 +63,24 @@ const TEST_PROTOCOL_FEE_RATE = 10n;
 const TEST_COUNCIL_SIZE = 3;
 
 /**
+ * VP commission destination of the canonical test payout transaction
+ * (see {@link createTestPayoutTransaction}, outs[1]).
+ */
+const CANONICAL_VP_COMMISSION_SCRIPT_HEX =
+  createDummyP2WPKH("e").toString("hex");
+
+/**
+ * Keeper payout destinations for an operator that never called
+ * `setPayoutScript`, where the registry backfills BIP-86 — so the registered
+ * script and the local derivation are the same bytes.
+ */
+const DEFAULT_VK_PAYOUT_SCRIPTS: Readonly<Record<string, string>> = {
+  [TEST_KEYS.VAULT_KEEPER_1.toLowerCase()]: deriveBip86ScriptPubKeyHex(
+    TEST_KEYS.VAULT_KEEPER_1,
+  ),
+};
+
+/**
  * Encodes a non-negative integer as a Bitcoin compact-size varint.
  * Matches the subset of varints supported by parseWitnessStack.
  */
@@ -208,6 +226,11 @@ function baseParams(overrides: Partial<PayoutParams>): PayoutParams {
     commissionBps: TEST_COMMISSION_BPS,
     protocolFeeRate: TEST_PROTOCOL_FEE_RATE,
     councilSize: TEST_COUNCIL_SIZE,
+    // Defaults mirror an un-rotated network with no custom scripts, where the
+    // registry backfills BIP-86 — the state testnet is in today. Tests that
+    // care about a custom registration override these.
+    vkClaimerPayoutScriptPubKeys: DEFAULT_VK_PAYOUT_SCRIPTS,
+    vpCommissionScriptPubKey: CANONICAL_VP_COMMISSION_SCRIPT_HEX,
     ...overrides,
   };
 }
@@ -260,6 +283,8 @@ describe("buildPayoutPsbt", () => {
         commissionBps: TEST_COMMISSION_BPS,
         protocolFeeRate: TEST_PROTOCOL_FEE_RATE,
         councilSize: TEST_COUNCIL_SIZE,
+        vkClaimerPayoutScriptPubKeys: DEFAULT_VK_PAYOUT_SCRIPTS,
+        vpCommissionScriptPubKey: CANONICAL_VP_COMMISSION_SCRIPT_HEX,
       };
 
       const result = await buildPayoutPsbt(params);
@@ -315,6 +340,8 @@ describe("buildPayoutPsbt", () => {
           commissionBps: TEST_COMMISSION_BPS,
           protocolFeeRate: TEST_PROTOCOL_FEE_RATE,
           councilSize: TEST_COUNCIL_SIZE,
+          vkClaimerPayoutScriptPubKeys: DEFAULT_VK_PAYOUT_SCRIPTS,
+          vpCommissionScriptPubKey: CANONICAL_VP_COMMISSION_SCRIPT_HEX,
         };
 
         const result = await buildPayoutPsbt(params);
@@ -349,6 +376,8 @@ describe("buildPayoutPsbt", () => {
         commissionBps: TEST_COMMISSION_BPS,
         protocolFeeRate: TEST_PROTOCOL_FEE_RATE,
         councilSize: TEST_COUNCIL_SIZE,
+        vkClaimerPayoutScriptPubKeys: DEFAULT_VK_PAYOUT_SCRIPTS,
+        vpCommissionScriptPubKey: CANONICAL_VP_COMMISSION_SCRIPT_HEX,
       };
 
       const result = await buildPayoutPsbt(params);
@@ -392,6 +421,8 @@ describe("buildPayoutPsbt", () => {
         commissionBps: TEST_COMMISSION_BPS,
         protocolFeeRate: TEST_PROTOCOL_FEE_RATE,
         councilSize: TEST_COUNCIL_SIZE,
+        vkClaimerPayoutScriptPubKeys: DEFAULT_VK_PAYOUT_SCRIPTS,
+        vpCommissionScriptPubKey: CANONICAL_VP_COMMISSION_SCRIPT_HEX,
       };
 
       await expect(buildPayoutPsbt(params)).rejects.toThrow(
@@ -441,6 +472,8 @@ describe("buildPayoutPsbt", () => {
         commissionBps: TEST_COMMISSION_BPS,
         protocolFeeRate: TEST_PROTOCOL_FEE_RATE,
         councilSize: TEST_COUNCIL_SIZE,
+        vkClaimerPayoutScriptPubKeys: DEFAULT_VK_PAYOUT_SCRIPTS,
+        vpCommissionScriptPubKey: CANONICAL_VP_COMMISSION_SCRIPT_HEX,
       };
 
       await expect(buildPayoutPsbt(params)).rejects.toThrow(
@@ -489,6 +522,8 @@ describe("buildPayoutPsbt", () => {
         commissionBps: TEST_COMMISSION_BPS,
         protocolFeeRate: TEST_PROTOCOL_FEE_RATE,
         councilSize: TEST_COUNCIL_SIZE,
+        vkClaimerPayoutScriptPubKeys: DEFAULT_VK_PAYOUT_SCRIPTS,
+        vpCommissionScriptPubKey: CANONICAL_VP_COMMISSION_SCRIPT_HEX,
       };
 
       await expect(buildPayoutPsbt(params)).rejects.toThrow(
@@ -519,6 +554,8 @@ describe("buildPayoutPsbt", () => {
         commissionBps: TEST_COMMISSION_BPS,
         protocolFeeRate: TEST_PROTOCOL_FEE_RATE,
         councilSize: TEST_COUNCIL_SIZE,
+        vkClaimerPayoutScriptPubKeys: DEFAULT_VK_PAYOUT_SCRIPTS,
+        vpCommissionScriptPubKey: CANONICAL_VP_COMMISSION_SCRIPT_HEX,
       };
 
       const result = await buildPayoutPsbt(params);
@@ -1091,6 +1128,241 @@ describe("buildPayoutPsbt — per-role output validation", () => {
     );
   });
 
+  it("vk-claimer: pays the registered payout script instead of bip86(vk)", async () => {
+    // The RFC-006 case that breaks the legacy path: a keeper whose payouts go
+    // to cold custody, not to the BIP-86 address of its operation key.
+    const peginTxHex = createTestPeginTransaction();
+    const assertTxHex = createTestAssertTransaction();
+    const registeredScript = createDummyP2WPKH("d");
+    const payoutTxHex = buildPayoutTxWithOutputs(peginTxHex, assertTxHex, [
+      { script: registeredScript, value: 144_454 },
+      { script: createDummyP2WPKH("c"), value: PAYOUT_ANCHOR_DUST_SATS },
+    ]);
+
+    await expect(
+      buildPayoutPsbt(
+        baseParams({
+          payoutTxHex,
+          peginTxHex,
+          assertTxHex,
+          claimerBtcPubkey: TEST_KEYS.VAULT_KEEPER_1,
+          vkClaimerPayoutScriptPubKeys: {
+            [TEST_KEYS.VAULT_KEEPER_1.toLowerCase()]:
+              registeredScript.toString("hex"),
+          },
+        }),
+      ),
+    ).resolves.toBeDefined();
+  });
+
+  it("vk-claimer: accepts bip86(vk) when a different script is registered", async () => {
+    // Legacy graph: built before btc-vault#2440, so the daemon derived the
+    // keeper destination locally. Graphs are never rebuilt, so rejecting this
+    // would strand the vault permanently.
+    const peginTxHex = createTestPeginTransaction();
+    const assertTxHex = createTestAssertTransaction();
+    const bip86Script = Buffer.from(
+      deriveBip86ScriptPubKeyHex(TEST_KEYS.VAULT_KEEPER_1).replace(/^0x/, ""),
+      "hex",
+    );
+    const payoutTxHex = buildPayoutTxWithOutputs(peginTxHex, assertTxHex, [
+      { script: bip86Script, value: 144_454 },
+      { script: createDummyP2WPKH("c"), value: PAYOUT_ANCHOR_DUST_SATS },
+    ]);
+
+    const result = await buildPayoutPsbt(
+      baseParams({
+        payoutTxHex,
+        peginTxHex,
+        assertTxHex,
+        claimerBtcPubkey: TEST_KEYS.VAULT_KEEPER_1,
+        vkClaimerPayoutScriptPubKeys: {
+          [TEST_KEYS.VAULT_KEEPER_1.toLowerCase()]:
+            createDummyP2WPKH("d").toString("hex"),
+        },
+      }),
+    );
+
+    expect(result.psbtHex).toBeTruthy();
+  });
+
+  it("vk-claimer: rejects a script that is neither registered nor bip86(vk)", async () => {
+    // Dual-accept widens the accepted set to exactly two operator-controlled
+    // destinations. A third script is still a diversion.
+    const peginTxHex = createTestPeginTransaction();
+    const assertTxHex = createTestAssertTransaction();
+    const payoutTxHex = buildPayoutTxWithOutputs(peginTxHex, assertTxHex, [
+      { script: createDummyP2WPKH("f"), value: 144_454 },
+      { script: createDummyP2WPKH("c"), value: PAYOUT_ANCHOR_DUST_SATS },
+    ]);
+
+    await expect(
+      buildPayoutPsbt(
+        baseParams({
+          payoutTxHex,
+          peginTxHex,
+          assertTxHex,
+          claimerBtcPubkey: TEST_KEYS.VAULT_KEEPER_1,
+          vkClaimerPayoutScriptPubKeys: {
+            [TEST_KEYS.VAULT_KEEPER_1.toLowerCase()]:
+              createDummyP2WPKH("d").toString("hex"),
+          },
+        }),
+      ),
+    ).rejects.toThrow(
+      /output 0 does not pay the expected scriptPubKey for role vk-claimer/,
+    );
+  });
+
+  it("vk-claimer: rejects a claimer missing from the resolved script map", async () => {
+    // Must never silently fall back to BIP-86 — a gap means the resolution was
+    // incomplete, not that this keeper is on the default.
+    const peginTxHex = createTestPeginTransaction();
+    const assertTxHex = createTestAssertTransaction();
+    const payoutTxHex = buildPayoutTxWithOutputs(peginTxHex, assertTxHex, [
+      { script: createDummyP2WPKH("d"), value: 144_454 },
+      { script: createDummyP2WPKH("c"), value: PAYOUT_ANCHOR_DUST_SATS },
+    ]);
+
+    await expect(
+      buildPayoutPsbt(
+        baseParams({
+          payoutTxHex,
+          peginTxHex,
+          assertTxHex,
+          claimerBtcPubkey: TEST_KEYS.VAULT_KEEPER_1,
+          vkClaimerPayoutScriptPubKeys: {},
+        }),
+      ),
+    ).rejects.toThrow(/No registered payout script resolved for vault keeper/);
+  });
+
+  it("vk-claimer: rejects an unspendable registered payout script", async () => {
+    // The registry stores whatever the operator wrote. Pinning outs[0] to an
+    // OP_RETURN would have the depositor pre-sign an unclaimable payout.
+    const peginTxHex = createTestPeginTransaction();
+    const assertTxHex = createTestAssertTransaction();
+    const opReturn = Buffer.from("6a0401020304", "hex");
+    const payoutTxHex = buildPayoutTxWithOutputs(peginTxHex, assertTxHex, [
+      { script: opReturn, value: 144_454 },
+      { script: createDummyP2WPKH("c"), value: PAYOUT_ANCHOR_DUST_SATS },
+    ]);
+
+    await expect(
+      buildPayoutPsbt(
+        baseParams({
+          payoutTxHex,
+          peginTxHex,
+          assertTxHex,
+          claimerBtcPubkey: TEST_KEYS.VAULT_KEEPER_1,
+          vkClaimerPayoutScriptPubKeys: {
+            [TEST_KEYS.VAULT_KEEPER_1.toLowerCase()]: opReturn.toString("hex"),
+          },
+        }),
+      ),
+    ).rejects.toThrow(/provably unspendable/);
+  });
+
+  it("vp-claimer: pins outs[1] to the registered commission script", async () => {
+    const peginTxHex = createTestPeginTransaction();
+    const assertTxHex = createTestAssertTransaction();
+    const commissionScript = createDummyP2WPKH("e");
+    const payoutTxHex = buildPayoutTxWithOutputs(peginTxHex, assertTxHex, [
+      { script: createDummyP2WPKH("a"), value: 144_454 },
+      { script: commissionScript, value: 100 },
+      { script: createDummyP2WPKH("c"), value: PAYOUT_ANCHOR_DUST_SATS },
+    ]);
+
+    await expect(
+      buildPayoutPsbt(
+        baseParams({
+          payoutTxHex,
+          peginTxHex,
+          assertTxHex,
+          claimerBtcPubkey: TEST_KEYS.VAULT_PROVIDER,
+          vpCommissionScriptPubKey: commissionScript.toString("hex"),
+        }),
+      ),
+    ).resolves.toBeDefined();
+  });
+
+  it("vp-claimer: rejects a substituted commission destination", async () => {
+    const peginTxHex = createTestPeginTransaction();
+    const assertTxHex = createTestAssertTransaction();
+    const payoutTxHex = buildPayoutTxWithOutputs(peginTxHex, assertTxHex, [
+      { script: createDummyP2WPKH("a"), value: 144_454 },
+      { script: createDummyP2WPKH("f"), value: 100 },
+      { script: createDummyP2WPKH("c"), value: PAYOUT_ANCHOR_DUST_SATS },
+    ]);
+
+    await expect(
+      buildPayoutPsbt(
+        baseParams({
+          payoutTxHex,
+          peginTxHex,
+          assertTxHex,
+          claimerBtcPubkey: TEST_KEYS.VAULT_PROVIDER,
+          vpCommissionScriptPubKey: createDummyP2WPKH("e").toString("hex"),
+        }),
+      ),
+    ).rejects.toThrow(
+      /output 1 does not pay the vault provider's commission scriptPubKey/,
+    );
+  });
+
+  it("vp-claimer: accepts a bip86(vp) commission when a custom script is registered", async () => {
+    // Legacy graph: built before btc-vault#2440, so the daemon derived the
+    // commission destination locally. Graphs are never rebuilt, so rejecting
+    // this would strand the vault permanently.
+    const peginTxHex = createTestPeginTransaction();
+    const assertTxHex = createTestAssertTransaction();
+    const bip86VpScript = Buffer.from(
+      deriveBip86ScriptPubKeyHex(TEST_KEYS.VAULT_PROVIDER).replace(/^0x/, ""),
+      "hex",
+    );
+    const payoutTxHex = buildPayoutTxWithOutputs(peginTxHex, assertTxHex, [
+      { script: createDummyP2WPKH("a"), value: 144_454 },
+      { script: bip86VpScript, value: 100 },
+      { script: createDummyP2WPKH("c"), value: PAYOUT_ANCHOR_DUST_SATS },
+    ]);
+
+    const result = await buildPayoutPsbt(
+      baseParams({
+        payoutTxHex,
+        peginTxHex,
+        assertTxHex,
+        claimerBtcPubkey: TEST_KEYS.VAULT_PROVIDER,
+        vpCommissionScriptPubKey: createDummyP2WPKH("e").toString("hex"),
+      }),
+    );
+
+    expect(result.psbtHex).toBeTruthy();
+  });
+
+  it("vp-claimer: still enforces the commission value cap when the script matches", async () => {
+    // The script pin is added precision, not a replacement for the value cap.
+    const peginTxHex = createTestPeginTransaction();
+    const assertTxHex = createTestAssertTransaction();
+    const commissionScript = createDummyP2WPKH("e");
+    const payoutTxHex = buildPayoutTxWithOutputs(peginTxHex, assertTxHex, [
+      { script: createDummyP2WPKH("a"), value: 144_454 },
+      { script: commissionScript, value: 999_999_999 },
+      { script: createDummyP2WPKH("c"), value: PAYOUT_ANCHOR_DUST_SATS },
+    ]);
+
+    await expect(
+      buildPayoutPsbt(
+        baseParams({
+          payoutTxHex,
+          peginTxHex,
+          assertTxHex,
+          claimerBtcPubkey: TEST_KEYS.VAULT_PROVIDER,
+          vpCommissionScriptPubKey: commissionScript.toString("hex"),
+        }),
+      ),
+    ).rejects.toThrow(/exceeds cap/);
+  });
+
   it("unknown claimer: rejects pubkey not matching VP, depositor, or any registered VK", async () => {
     const peginTxHex = createTestPeginTransaction();
     const assertTxHex = createTestAssertTransaction();
@@ -1324,61 +1596,6 @@ describe("buildPayoutPsbt — fee-band and domain wiring", () => {
     ).rejects.toThrow(/exceeds the safety cap/);
   });
 
-  it("gives a padded commission script no extra ceiling headroom", async () => {
-    // out1 is VP-controlled and unpinned; a 128-byte commission script must
-    // not widen the ceiling — flat 10 * 610 = 6_100 still applies.
-    const bigCommissionScript = Buffer.alloc(128, 0x51);
-    const peginTxHex = createTestPeginTransaction();
-    const assertTxHex = createTestAssertTransaction();
-    const inputTotal = Number(TEST_PEGIN_VALUE) + Number(TEST_CLAIM_VALUE);
-    const makePaddedCommissionPayout = (feeSats: number) =>
-      makeDeflatedPayoutTxHex(peginTxHex, assertTxHex, [
-        {
-          script: createDummyP2WPKH("a"),
-          value: inputTotal - feeSats - 1_000 - PAYOUT_ANCHOR_DUST_SATS,
-        },
-        { script: bigCommissionScript, value: 1_000 },
-        { script: createDummyP2WPKH("c"), value: PAYOUT_ANCHOR_DUST_SATS },
-      ]);
-
-    await expect(
-      buildPayoutPsbt(
-        baseParams({
-          payoutTxHex: makePaddedCommissionPayout(6_100),
-          assertTxHex,
-          peginTxHex,
-        }),
-      ),
-    ).resolves.toBeDefined();
-    await expect(
-      buildPayoutPsbt(
-        baseParams({
-          payoutTxHex: makePaddedCommissionPayout(6_101),
-          assertTxHex,
-          peginTxHex,
-        }),
-      ),
-    ).rejects.toThrow(/exceeds the safety cap/);
-  });
-
-  it("rejects a commission scriptPubKey outside the contract registration cap", async () => {
-    const peginTxHex = createTestPeginTransaction();
-    const assertTxHex = createTestAssertTransaction();
-    const inputTotal = Number(TEST_PEGIN_VALUE) + Number(TEST_CLAIM_VALUE);
-    const payoutTxHex = makeDeflatedPayoutTxHex(peginTxHex, assertTxHex, [
-      {
-        script: createDummyP2WPKH("a"),
-        value: inputTotal - 5_000 - 1_000 - PAYOUT_ANCHOR_DUST_SATS,
-      },
-      { script: Buffer.alloc(129, 0x51), value: 1_000 },
-      { script: createDummyP2WPKH("c"), value: PAYOUT_ANCHOR_DUST_SATS },
-    ]);
-
-    await expect(
-      buildPayoutPsbt(baseParams({ payoutTxHex, assertTxHex, peginTxHex })),
-    ).rejects.toThrow(/registration cap/);
-  });
-
   it("rejects participant counts outside the device range", async () => {
     const peginTxHex = createTestPeginTransaction();
     const assertTxHex = createTestAssertTransaction();
@@ -1389,6 +1606,8 @@ describe("buildPayoutPsbt — fee-band and domain wiring", () => {
       buildPayoutPsbt({
         ...params,
         vaultKeeperBtcPubkeys: generateXOnlyKeys(33, 3_000),
+        vkClaimerPayoutScriptPubKeys: DEFAULT_VK_PAYOUT_SCRIPTS,
+        vpCommissionScriptPubKey: CANONICAL_VP_COMMISSION_SCRIPT_HEX,
       }),
     ).rejects.toThrow(/device range/);
     await expect(
@@ -1453,6 +1672,8 @@ describe("buildPayoutPsbt — fee-band and domain wiring", () => {
         commissionBps: TEST_COMMISSION_BPS,
         protocolFeeRate: TEST_PROTOCOL_FEE_RATE,
         councilSize: TEST_COUNCIL_SIZE,
+        vkClaimerPayoutScriptPubKeys: DEFAULT_VK_PAYOUT_SCRIPTS,
+        vpCommissionScriptPubKey: CANONICAL_VP_COMMISSION_SCRIPT_HEX,
       }),
     ).rejects.toThrow(/outputs \(200000 sats\) exceed inputs/);
   });

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/standardPayoutScript.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/standardPayoutScript.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { assertStandardPayoutScript } from "../standardPayoutScript";
+
+const LABEL = "Vault keeper payout script";
+
+describe("assertStandardPayoutScript", () => {
+  it.each([
+    ["P2WPKH", `0014${"ab".repeat(20)}`],
+    ["P2WSH", `0020${"cd".repeat(32)}`],
+    ["P2TR", `5120${"ef".repeat(32)}`],
+    ["P2PKH", `76a914${"11".repeat(20)}88ac`],
+    ["P2SH", `a914${"22".repeat(20)}87`],
+  ])("accepts a standard %s script", (_type, script) => {
+    expect(() => assertStandardPayoutScript(script, LABEL)).not.toThrow();
+  });
+
+  it("accepts a 0x-prefixed script", () => {
+    expect(() =>
+      assertStandardPayoutScript(`0x0014${"ab".repeat(20)}`, LABEL),
+    ).not.toThrow();
+  });
+
+  it("rejects an OP_RETURN script", () => {
+    // The depositor pre-signs this destination; an OP_RETURN payout would be
+    // unclaimable by anyone.
+    expect(() => assertStandardPayoutScript("6a0401020304", LABEL)).toThrow(
+      /provably unspendable/,
+    );
+  });
+
+  it("rejects an empty script", () => {
+    expect(() => assertStandardPayoutScript("0x", LABEL)).toThrow(/is empty/);
+  });
+
+  it("rejects non-hex input", () => {
+    expect(() => assertStandardPayoutScript("zzzz", LABEL)).toThrow(
+      /not valid hex/,
+    );
+  });
+
+  it("rejects a truncated P2WPKH", () => {
+    expect(() =>
+      assertStandardPayoutScript(`0014${"ab".repeat(19)}`, LABEL),
+    ).toThrow(/not a standard scriptPubKey/);
+  });
+
+  it("rejects an unrecognised script shape", () => {
+    expect(() =>
+      assertStandardPayoutScript(`0099${"ab".repeat(20)}`, LABEL),
+    ).toThrow(/not a standard scriptPubKey/);
+  });
+
+  it("names the source in the error", () => {
+    expect(() =>
+      assertStandardPayoutScript("6a00", "VP commission script"),
+    ).toThrow(/^VP commission script/);
+  });
+});

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/assertPayoutFeeBand.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/assertPayoutFeeBand.ts
@@ -15,11 +15,11 @@
  * - `assertPayoutFeeBandDomain` has accepted the rate and participant counts,
  *   so the band runs exactly over the domain its dominance proof was swept.
  * - `out0Len` is the layout-trusted length of the PINNED outs[0] script.
- *   `out1Len` is measured from the deliberately-unpinned VP commission
- *   output and is UNTRUSTED: it feeds only the floor, where padding cannot
- *   raise it (the fixed-34 model saturates the minimum) and shortening only
- *   lowers it. It must never widen the ceiling — a VP-controlled length
- *   there would buy burnable headroom.
+ *   `out1Len` is the VP commission output's length. RFC-006 pins that output
+ *   to the operator's registered scriptPubKey, so it is now layout-trusted
+ *   too and bounded to a standard type. It still feeds only the floor and
+ *   must never widen the ceiling: that separation is kept deliberately, so
+ *   the bound holds even if a future change unpins the output again.
  * - `implicitFeeSats` is `inputs − outputs` over verified prevouts, `>= 0`.
  *
  * @module primitives/psbt/assertPayoutFeeBand
@@ -154,12 +154,13 @@ export async function assertPayoutFeeInBand(
   const implicitFee = BigInt(implicitFeeSats);
 
   // Ceiling first: synchronous arithmetic, no WASM round-trip.
-  // Only the PINNED outs[0] script extends the ceiling. out1Len is
-  // VP-controlled (commission script deliberately unpinned) — including it
-  // would let a padded script widen the burnable band by up to 94 vB x rate.
-  // Honest long-commission builds still fit: the flat model's >=175 vB
-  // headroom over the exact estimator vsize absorbs the 94 vB with >=81 vB
-  // to spare across the entire accepted domain.
+  // Only outs[0] extends the ceiling; out1Len never does. RFC-006 now pins the
+  // commission script, so a padded one can no longer reach here — but the
+  // separation is kept so the bound does not silently depend on that pin.
+  // Including out1Len would let a padded script widen the burnable band by up
+  // to 94 vB x rate. Honest long-commission builds still fit: the flat model's
+  // >=175 vB headroom over the exact estimator vsize absorbs the 94 vB with
+  // >=81 vB to spare across the entire accepted domain.
   const scriptExcess = Math.max(0, out0Len - PAYOUT_BOUND_ASSUMED_SCRIPT_LEN);
   const maxPayoutVsize =
     MAX_PAYOUT_VSIZE_BASE +

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts
@@ -40,6 +40,7 @@ import {
   PEGIN_VAULT_OUTPUT_INDEX,
   VP_CLAIMER_PAYOUT_OUTPUT_COUNT,
 } from "./constants";
+import { assertStandardPayoutScript } from "./standardPayoutScript";
 
 /**
  * Number of items in a Taproot script-path spend witness stack for a
@@ -149,6 +150,31 @@ export interface PayoutParams {
    * pinned models.
    */
   councilSize: number;
+
+  /**
+   * RFC-006. Expected `outs[0].script` per vault-keeper claimer, keyed by
+   * lowercased x-only **operation** pubkey (no `0x`), resolved from
+   * `ApplicationRegistry.getPayoutScriptAtEpoch` at the vault's frozen
+   * `appKeeperKeyEpoch`.
+   *
+   * Every VK claimer must be present: a claimer missing from the map is an
+   * error rather than a cue to derive BIP-86, because a gap means resolution
+   * was incomplete and we do not know what that keeper registered.
+   *
+   * Each entry accepts either that registered script or the BIP-86 default of
+   * the same bonded key, so graphs built before btc-vault#2440 remain signable
+   * — see {@link acceptedPayoutScriptHexes} for why that is required and when
+   * it can be dropped.
+   */
+  vkClaimerPayoutScriptPubKeys: Readonly<Record<string, string>>;
+
+  /**
+   * RFC-006. Expected `outs[1].script` for the VP-claimer commission output,
+   * from `BTCVaultRegistry.getPayoutScriptAtEpoch` at the vault's frozen
+   * `vpKeyEpoch`. The BIP-86 default of the bonded VP key is accepted alongside
+   * it — see {@link acceptedPayoutScriptHexes}.
+   */
+  vpCommissionScriptPubKey: string;
 }
 
 /**
@@ -383,15 +409,94 @@ function assemblePayoutPsbt(
 }
 
 /**
+ * The scriptPubKeys a payout output may legitimately pay for `bondedPubkey`.
+ *
+ * ## What this is
+ *
+ * A deliberate dual-accept: both the operator's RFC-006 **registered** payout
+ * script and the **BIP-86 default** of its bonded operation key are treated as
+ * valid destinations for the same output.
+ *
+ * ## Why both forms exist
+ *
+ * A vault provider running a daemon that predates btc-vault#2440 computes
+ * operator payout destinations itself, via BIP-86 over the bonded operation
+ * key. From #2440 onward it reads them from the registry instead
+ * (`getPayoutScriptAtEpoch`), so an operator can point payouts at cold custody.
+ *
+ * The two forms are not a transition state that resolves on its own. A payout
+ * graph is built once, at BaBe Setup, and is **never rebuilt** — so a vault
+ * whose graph was built before its network's #2440 upgrade pays BIP-86 for the
+ * rest of its life. Accepting only the registered form makes every such vault
+ * permanently unsignable: the depositor can never complete the deposit, and
+ * the BTC is already committed by then. Confirmed on devnet 2026-08-04, where
+ * a pre-upgrade vault failed exactly this way.
+ *
+ * ## Why this is not a weakening
+ *
+ * Both candidates are derived here from on-chain state — the registry read and
+ * a local BIP-86 derivation over the bonded key. Neither is taken from the VP's
+ * response, so a substituted or attacker-chosen script still fails.
+ *
+ * The only substitution this permits is between two destinations the *same
+ * operator* already controls, which moves that operator's own funds between its
+ * own addresses. It cannot redirect value to a third party, and it cannot touch
+ * the depositor's output. For the VP commission the value cap
+ * (`floor(peginValue × commissionBps / 10_000)`) still bounds depositor
+ * exposure independently of where the commission goes. The BIP-86 branch is
+ * also precisely what every pre-RFC-006 client pinned, so this is the older
+ * rule retained alongside the newer one, not a laxer rule invented for it.
+ *
+ * ## When this can be removed
+ *
+ * This validation runs at one point in the lifecycle: depositor payout signing
+ * (`PENDING` → `VERIFIED`). It is not re-run on refund or withdrawal. So the
+ * BIP-86 branch stops being reachable for a network once every vault
+ * registered before that network's #2440 upgrade has left
+ * `PendingDepositorSignatures` — signed and activated, or expired past its
+ * activation deadline. That is bounded by the vault lifetime, not indefinite.
+ *
+ * Removal is therefore gated by the **last** network to upgrade, since this
+ * code is shared. Concretely: drop the BIP-86 branch only once devnet, testnet
+ * and mainnet have all been on #2440 for longer than the activation deadline,
+ * and no vault registered before those upgrades is still awaiting signatures.
+ * Deleting it earlier strands deposits with BTC already locked; there is no
+ * recovery path short of the refund timelock.
+ *
+ * @internal Helper invoked by {@link assertPayoutOutputLayout}.
+ */
+function acceptedPayoutScriptHexes(
+  registeredScriptPubKey: string,
+  bondedPubkey: string,
+): string[] {
+  const registered = stripHexPrefix(registeredScriptPubKey).toLowerCase();
+  const legacyBip86 = stripHexPrefix(
+    deriveBip86ScriptPubKeyHex(bondedPubkey),
+  ).toLowerCase();
+  return registered === legacyBip86 ? [registered] : [registered, legacyBip86];
+}
+
+/** Whether `script` matches any of `acceptedHexes`. */
+function matchesAnyScript(script: Buffer, acceptedHexes: string[]): boolean {
+  return acceptedHexes.some((hex) => script.equals(Buffer.from(hex, "hex")));
+}
+
+/**
  * Validate a payout transaction's output structure for the claimer's role,
  * keyed on `claimerBtcPubkey`. Pins per role: `outs.length`, `outs[0].script`,
  * `outs[last].value` (anchor dust), and (VP-claimer) `outs[1].value` capped at
  * `floor(peginValue × commissionBps / 10_000)`. Canonical layouts: VP-claimer
  * = [payout, commission, anchor]; depositor/VK-claimer = [payout, anchor].
  *
- * `outs[1].script` and `outs[last].script` are intentionally not pinned: the
- * value pins above bound depositor exposure regardless of where those outputs
- * are sent, so the value pins — not script pins — are load-bearing.
+ * `outs[last].script` (the CPFP anchor) is intentionally not pinned: the value
+ * pin above bounds depositor exposure regardless of where that dust goes.
+ *
+ * `outs[1].script` (the VP commission) was unpinned for the same reason.
+ * RFC-006 supersedes that rationale: the commission destination is now an
+ * operator-registered scriptPubKey we can resolve independently at the vault's
+ * frozen `vpKeyEpoch`, so when `vpCommissionScriptPubKey` is supplied it is
+ * pinned too. The value cap stays — it is still what bounds exposure — and the
+ * script pin is added precision, not a replacement for it.
  *
  * Returns the layout-trusted non-anchor script lengths for the fee band:
  * `out0Len` from the pinned outs[0] script (registered payout script, or
@@ -414,6 +519,8 @@ function assertPayoutOutputLayout(
     vaultKeeperBtcPubkeys,
     registeredPayoutScriptPubKey,
     commissionBps,
+    vkClaimerPayoutScriptPubKeys,
+    vpCommissionScriptPubKey,
   } = params;
 
   if (!isValidHex(registeredPayoutScriptPubKey)) {
@@ -430,20 +537,39 @@ function assertPayoutOutputLayout(
   type Role = "vp-claimer" | "depositor-as-claimer" | "vk-claimer";
   let role: Role;
   let expectedOutCount: number;
-  let expectedOut0ScriptHex: string;
+  let acceptedOut0ScriptHexes: string[];
 
   if (claimer === vp) {
     role = "vp-claimer";
     expectedOutCount = VP_CLAIMER_PAYOUT_OUTPUT_COUNT;
-    expectedOut0ScriptHex = stripHexPrefix(registeredPayoutScriptPubKey);
+    acceptedOut0ScriptHexes = [stripHexPrefix(registeredPayoutScriptPubKey)];
   } else if (claimer === dep) {
     role = "depositor-as-claimer";
     expectedOutCount = NON_VP_CLAIMER_PAYOUT_OUTPUT_COUNT;
-    expectedOut0ScriptHex = stripHexPrefix(registeredPayoutScriptPubKey);
+    acceptedOut0ScriptHexes = [stripHexPrefix(registeredPayoutScriptPubKey)];
   } else if (keepers.includes(claimer)) {
     role = "vk-claimer";
     expectedOutCount = NON_VP_CLAIMER_PAYOUT_OUTPUT_COUNT;
-    expectedOut0ScriptHex = stripHexPrefix(deriveBip86ScriptPubKeyHex(claimer));
+    // RFC-006: a keeper's payout goes to the scriptPubKey it registered
+    // on-chain, resolved at the vault's frozen keeper epoch. Deriving BIP-86
+    // locally as the sole expectation would reject a valid payout the moment a
+    // keeper points its payouts at cold custody.
+    //
+    // A missing entry is an error, never a BIP-86 fallback: the registry
+    // backfills BIP-86 itself for keepers that never registered a script, so a
+    // gap here means the resolution was incomplete, not that this keeper is on
+    // the default.
+    const registered = vkClaimerPayoutScriptPubKeys[claimer];
+    if (registered === undefined) {
+      throw new Error(
+        `No registered payout script resolved for vault keeper claimer ${claimer}`,
+      );
+    }
+    assertStandardPayoutScript(
+      registered,
+      `Vault keeper payout script for claimer ${claimer}`,
+    );
+    acceptedOut0ScriptHexes = acceptedPayoutScriptHexes(registered, claimer);
   } else {
     throw new Error(
       `Unknown claimer pubkey ${claimer}: not VP, depositor, or a registered vault keeper`,
@@ -457,10 +583,11 @@ function assertPayoutOutputLayout(
     );
   }
 
-  const expectedOut0Script = Buffer.from(expectedOut0ScriptHex, "hex");
-  if (!payoutTx.outs[0].script.equals(expectedOut0Script)) {
+  if (!matchesAnyScript(payoutTx.outs[0].script, acceptedOut0ScriptHexes)) {
     throw new Error(
-      `Payout transaction output 0 does not pay the expected scriptPubKey for role ${role}`,
+      `Payout transaction output 0 does not pay the expected scriptPubKey for role ${role}. ` +
+        `Accepted: ${acceptedOut0ScriptHexes.join(" or ")}; ` +
+        `got ${payoutTx.outs[0].script.toString("hex")}`,
     );
   }
 
@@ -473,6 +600,27 @@ function assertPayoutOutputLayout(
   }
 
   if (role === "vp-claimer") {
+    // RFC-006 commission destination. Checked before the value cap so a
+    // substituted destination reports as such rather than surfacing later as a
+    // confusing amount error.
+    assertStandardPayoutScript(
+      vpCommissionScriptPubKey,
+      "Vault provider commission payout script",
+    );
+    const acceptedCommissionScriptHexes = acceptedPayoutScriptHexes(
+      vpCommissionScriptPubKey,
+      vp,
+    );
+    if (
+      !matchesAnyScript(payoutTx.outs[1].script, acceptedCommissionScriptHexes)
+    ) {
+      throw new Error(
+        `Payout transaction output 1 does not pay the vault provider's commission scriptPubKey. ` +
+          `Accepted: ${acceptedCommissionScriptHexes.join(" or ")}; ` +
+          `got ${payoutTx.outs[1].script.toString("hex")}`,
+      );
+    }
+
     // Structural guard only — a non-negative integer below the bps
     // denominator, so the cap math `floor(peginValue * bps / 10_000)` is
     // meaningful. The protocol minimum is enforced at the trust boundary
@@ -499,7 +647,10 @@ function assertPayoutOutputLayout(
     }
   }
 
-  const out0Len = expectedOut0Script.length;
+  // The accepted-script set can hold more than one candidate (dual-accept), so
+  // the length the fee band consumes is that of the output actually present —
+  // which the check above has already pinned to one of the accepted values.
+  const out0Len = payoutTx.outs[0].script.length;
   if (out0Len === 0 || out0Len > MAX_PAYOUT_SCRIPT_LEN) {
     throw new Error(
       `Payout receiver scriptPubKey length ${out0Len} is outside the ` +
@@ -507,18 +658,14 @@ function assertPayoutOutputLayout(
         `refusing to sign payout.`,
     );
   }
+  // No length cap on outs[1]: under RFC-006 the commission output is pinned to
+  // the operator's registered script, and `assertStandardPayoutScript` above
+  // already bounds that to a standard type (34 bytes at most). A separate
+  // 128-byte cap here would be unreachable. Still measured, because the fee
+  // floor consumes it — and now from a pinned source rather than a
+  // VP-controlled one.
   const out1Len =
     role === "vp-claimer" ? payoutTx.outs[1].script.length : undefined;
-  if (
-    out1Len !== undefined &&
-    (out1Len === 0 || out1Len > MAX_PAYOUT_SCRIPT_LEN)
-  ) {
-    throw new Error(
-      `Payout commission scriptPubKey length ${out1Len} is outside the ` +
-        `contract's registration cap [1, ${MAX_PAYOUT_SCRIPT_LEN}]; ` +
-        `refusing to sign payout.`,
-    );
-  }
 
   return { out0Len, out1Len };
 }

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/standardPayoutScript.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/standardPayoutScript.ts
@@ -7,9 +7,25 @@
  * shape would let a keeper that registered a garbage or unspendable script get
  * the depositor to pre-sign a payout nobody can ever claim.
  *
- * The registry accepts anything; the protocol only makes sense for outputs
- * that are spendable and representable as an address, which is the same gate
- * `vaultd` applies before it will build a graph.
+ * This bound is ours alone — it is deliberately NOT parity with `vaultd`.
+ * `vaultd` uses registry scripts verbatim at graph-build time and documents
+ * why: applying a predicate the contract does not apply would block every
+ * peg-in for an operator the instant the two disagreed. The registry itself
+ * only bounds length to 1..128 bytes, and the registration CLI has an
+ * `--allow-non-standard` escape hatch.
+ *
+ * We hold the stricter line because we occupy a different position: we are the
+ * party being asked to *pre-sign* against these bytes, and a depositor
+ * signature pinned to a provably unspendable output is not recoverable. The
+ * bound is also load-bearing for the payout fee band — capping a standard
+ * output at 34 bytes is what lets `assertPayoutFeeBand` reason about `outs[1]`
+ * without a separate length cap.
+ *
+ * The deliberate consequence: an operator that registers a non-standard script
+ * via `--allow-non-standard` can have its graphs built by `vaultd` and still be
+ * refused here, blocking deposits against that operator in this dApp. That is
+ * fail-closed by choice — the alternative is pre-signing into a destination we
+ * cannot verify is spendable.
  *
  * @module primitives/psbt/standardPayoutScript
  */

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/standardPayoutScript.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/standardPayoutScript.ts
@@ -1,0 +1,86 @@
+/**
+ * Standard-scriptPubKey validation for registry-supplied payout destinations.
+ *
+ * RFC-006 lets an operator register an arbitrary payout scriptPubKey, so the
+ * bytes we pin a `PayoutTx` output against are now chosen by that operator
+ * rather than derived by us. Pinning an output to them without checking the
+ * shape would let a keeper that registered a garbage or unspendable script get
+ * the depositor to pre-sign a payout nobody can ever claim.
+ *
+ * The registry accepts anything; the protocol only makes sense for outputs
+ * that are spendable and representable as an address, which is the same gate
+ * `vaultd` applies before it will build a graph.
+ *
+ * @module primitives/psbt/standardPayoutScript
+ */
+
+import { stripHexPrefix } from "../utils/bitcoin";
+
+/** `OP_0 <20>` — P2WPKH. */
+const P2WPKH_LEN = 22;
+/** `OP_0 <32>` — P2WSH. */
+const P2WSH_LEN = 34;
+/** `OP_1 <32>` — P2TR. */
+const P2TR_LEN = 34;
+/** `OP_DUP OP_HASH160 <20> OP_EQUALVERIFY OP_CHECKSIG` — P2PKH. */
+const P2PKH_LEN = 25;
+/** `OP_HASH160 <20> OP_EQUAL` — P2SH. */
+const P2SH_LEN = 23;
+
+function isP2wpkh(s: string): boolean {
+  return s.length === P2WPKH_LEN * 2 && s.startsWith("0014");
+}
+function isP2wsh(s: string): boolean {
+  return s.length === P2WSH_LEN * 2 && s.startsWith("0020");
+}
+function isP2tr(s: string): boolean {
+  return s.length === P2TR_LEN * 2 && s.startsWith("5120");
+}
+function isP2pkh(s: string): boolean {
+  return (
+    s.length === P2PKH_LEN * 2 && s.startsWith("76a914") && s.endsWith("88ac")
+  );
+}
+function isP2sh(s: string): boolean {
+  return s.length === P2SH_LEN * 2 && s.startsWith("a914") && s.endsWith("87");
+}
+
+/**
+ * Assert a registry-supplied scriptPubKey is a standard, spendable output type
+ * (P2TR, P2WPKH, P2WSH, P2PKH, or P2SH).
+ *
+ * Rejects empty scripts, `OP_RETURN` (provably unspendable), and anything else
+ * that is not one of the five standard forms. `label` names the source in the
+ * error, e.g. `vault keeper payout script (admin=0x…)`.
+ */
+export function assertStandardPayoutScript(
+  scriptHex: string,
+  label: string,
+): void {
+  const script = stripHexPrefix(scriptHex).toLowerCase();
+
+  if (script.length === 0) {
+    throw new Error(`${label} is empty`);
+  }
+  if (!/^[0-9a-f]+$/.test(script) || script.length % 2 !== 0) {
+    throw new Error(`${label} is not valid hex`);
+  }
+  if (script.startsWith("6a")) {
+    throw new Error(
+      `${label} is an OP_RETURN output, which is provably unspendable`,
+    );
+  }
+
+  if (
+    !isP2tr(script) &&
+    !isP2wpkh(script) &&
+    !isP2wsh(script) &&
+    !isP2pkh(script) &&
+    !isP2sh(script)
+  ) {
+    throw new Error(
+      `${label} is not a standard scriptPubKey ` +
+        `(expected P2TR, P2WPKH, P2WSH, P2PKH, or P2SH; got ${script.length / 2} bytes: ${script})`,
+    );
+  }
+}

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/runDepositorPresignFlow.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/runDepositorPresignFlow.test.ts
@@ -181,6 +181,13 @@ const DEPOSIT_TERMS: DepositTerms = {
 
 function createSigningContext(): PayoutSigningContext {
   return {
+    // Un-rotated operator set: the registry backfills BIP-86, so these match
+    // what local derivation would produce. Threaded through to buildPayoutPsbt,
+    // which is mocked here — the values only need to be well-formed.
+    vkClaimerPayoutScriptPubKeys: {
+      [VK_PUBKEY.toLowerCase()]: `0x5120${VK_PUBKEY}`,
+    },
+    vpCommissionScriptPubKey: `0x5120${VP_PUBKEY}`,
     vaultCoreVersion: 1,
     peginTxHex: "01000000" + "00".repeat(60),
     vaultProviderBtcPubkey: VP_PUBKEY,

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/signDepositorGraph.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/signDepositorGraph.test.ts
@@ -266,6 +266,10 @@ function createSigningContext(
   // excluded) ∪ UniversalChallengers. Default fixture uses 2 VKs and 0 UCs
   // so most tests can build a 2-entry graph; tests that need a UC override.
   return {
+    // Unused by the depositor-as-claimer role, but required by the shared
+    // `buildPayoutPsbt` shape.
+    vkClaimerPayoutScriptPubKeys: {},
+    vpCommissionScriptPubKey: "0x0014" + "00".repeat(20),
     // Non-default on purpose: a re-hardcoded version anywhere in the
     // signing path would fail the threading assertions below.
     vaultCoreVersion: 2,
@@ -309,6 +313,8 @@ describe("signDepositorGraph", () => {
     expect(builder).toHaveBeenCalledOnce();
     expect(builder).toHaveBeenCalledWith({
       vaultCoreVersion: 2,
+      vkClaimerPayoutScriptPubKeys: ctx.vkClaimerPayoutScriptPubKeys,
+      vpCommissionScriptPubKey: ctx.vpCommissionScriptPubKey,
       payoutTxHex: graph.payout_tx.tx_hex,
       peginTxHex: ctx.peginTxHex,
       assertTxHex: graph.assert_tx.tx_hex,

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/validateOnChainParticipantKeys.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/validateOnChainParticipantKeys.test.ts
@@ -423,6 +423,28 @@ describe("validateOnChainParticipantKeys with operation-key resolution", () => {
     ).rejects.toThrow(/internally inconsistent/i);
   });
 
+  // The block clears only when the indexer converges, so it must be reported
+  // rather than surfacing as user reports of a provider nobody can deposit to.
+  it("reports a half-applied indexer view before throwing", async () => {
+    const readers = buildRotationReaders();
+    const onIndexerHintsInconsistent = vi.fn();
+
+    await expect(
+      validateOnChainParticipantKeys({
+        ...readers,
+        expectedVaultProviderBtcPubkey: REGISTRATION.vp,
+        expectedVaultKeeperBtcPubkeys: REGISTRATION.keepers,
+        expectedUniversalChallengerBtcPubkeys: OPERATION.challengers,
+        onIndexerHintsInconsistent,
+      }),
+    ).rejects.toThrow(/internally inconsistent/i);
+
+    expect(onIndexerHintsInconsistent).toHaveBeenCalledTimes(1);
+    expect(onIndexerHintsInconsistent).toHaveBeenCalledWith(
+      expect.stringContaining(ADDRESSES.vaultProvider),
+    );
+  });
+
   it("rejects a hint matching neither key set", async () => {
     const readers = buildRotationReaders();
 

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/validateOnChainParticipantKeys.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/validateOnChainParticipantKeys.test.ts
@@ -4,25 +4,43 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   AddressBTCKeyPair,
   OnChainBtcPubkey,
+  OperationKeyQuery,
+  OperationKeyReader,
+  RawOperationKeys,
   UniversalChallengerReader,
   VaultKeeperReader,
   VaultRegistryReader,
 } from "../../../clients/eth/types";
+import {
+  ADDRESSES,
+  FakeOperationKeyReader,
+  KEYS,
+  buildQuery,
+  xOnlyFromSeed,
+} from "../../participants/__tests__/fixtures/rotation";
 import { validateOnChainParticipantKeys } from "../validateOnChainParticipantKeys";
 
-const VP_KEY = "a".repeat(64);
+// Real secp256k1 x-only keys: operation-key resolution asserts every roster
+// key is a curve point, so placeholder hex will not survive it. Keeper and
+// challenger names are assigned in sorted order so the lex-ordering
+// expectations below hold by construction rather than by luck.
+const VP_KEY = xOnlyFromSeed(101);
 const VP_KEY_COMPRESSED = `02${VP_KEY}`;
-const VP_KEY_UPPERCASE = "A".repeat(64);
-const VP_KEY_DIFFERENT = "b".repeat(64);
+const VP_KEY_UPPERCASE = VP_KEY.toUpperCase();
+const VP_KEY_DIFFERENT = xOnlyFromSeed(102);
 
-const KEEPER_1 = "1".repeat(64);
-const KEEPER_2 = "2".repeat(64);
-const KEEPER_3 = "3".repeat(64);
-const KEEPER_OTHER = "9".repeat(64);
+const [KEEPER_1, KEEPER_2, KEEPER_3, KEEPER_OTHER] = [
+  xOnlyFromSeed(103),
+  xOnlyFromSeed(104),
+  xOnlyFromSeed(105),
+  xOnlyFromSeed(106),
+].sort();
 
-const CHALLENGER_1 = "4".repeat(64);
-const CHALLENGER_2 = "5".repeat(64);
-const CHALLENGER_OTHER = "8".repeat(64);
+const [CHALLENGER_1, CHALLENGER_2, CHALLENGER_OTHER] = [
+  xOnlyFromSeed(107),
+  xOnlyFromSeed(108),
+  xOnlyFromSeed(109),
+].sort();
 
 const APP_ENTRY_POINT = "0xApp" as Address;
 const VP_ETH_ADDRESS = "0xVP" as Address;
@@ -31,7 +49,12 @@ const KEEPERS_VERSION = 7;
 const CHALLENGERS_VERSION = 11;
 
 function pair(btcPubKey: string): AddressBTCKeyPair {
-  return { ethAddress: "0x0" as Address, btcPubKey: btcPubKey as `0x${string}` };
+  // The registry always returns roster keys 0x-prefixed; the bare constants in
+  // this file are for readability only.
+  return {
+    ethAddress: "0x0" as Address,
+    btcPubKey: `0x${btcPubKey}` as `0x${string}`,
+  };
 }
 
 function buildReaders({
@@ -54,6 +77,9 @@ function buildReaders({
     getPegInFee: vi.fn(),
     getVaultProviderCommission: vi.fn(),
     getOffchainParamsVersionsByVaultIds: vi.fn(),
+    getVaultKeyEpochs: vi.fn(),
+    getVaultKeyEpochsBatch: vi.fn(),
+    getCurrentVaultProviderOperationBtcKey: vi.fn(),
   };
   const vaultKeeperReader: VaultKeeperReader = {
     getVaultKeepersByVersion: vi.fn().mockResolvedValue(keeperKeys.map(pair)),
@@ -69,7 +95,31 @@ function buildReaders({
       .fn()
       .mockResolvedValue(CHALLENGERS_VERSION),
   };
-  return { vaultRegistryReader, vaultKeeperReader, universalChallengerReader };
+  return {
+    vaultRegistryReader,
+    vaultKeeperReader,
+    universalChallengerReader,
+    operationKeyReader: unrotatedOperationKeyReader(),
+  };
+}
+
+/**
+ * Operation-key reader for an operator set that has never rotated: every
+ * participant's current operation key is its genesis/roster key. Mirrors what
+ * the registry's own genesis fallback returns, so these cases stay focused on
+ * the indexer-hint and sorting behaviour rather than on rotation.
+ */
+function unrotatedOperationKeyReader(): OperationKeyReader {
+  const echo = async (query: OperationKeyQuery): Promise<RawOperationKeys> => ({
+    vaultProvider: query.vaultProviderGenesisBtcPubkey,
+    vaultKeepers: query.vaultKeepers.map((k) => k.btcPubKey),
+    universalChallengers: query.universalChallengers.map((c) => c.btcPubKey),
+  });
+  return {
+    getCurrentOperationKeys: echo,
+    getOperationKeysAtEpochs: echo,
+    getPayoutScriptsAtEpochs: vi.fn(),
+  };
 }
 
 describe("validateOnChainParticipantKeys", () => {
@@ -139,7 +189,9 @@ describe("validateOnChainParticipantKeys", () => {
   });
 
   it("rejects when the keeper count differs from the on-chain set", async () => {
-    const readers = buildReaders({ keeperKeys: [KEEPER_1, KEEPER_2, KEEPER_3] });
+    const readers = buildReaders({
+      keeperKeys: [KEEPER_1, KEEPER_2, KEEPER_3],
+    });
 
     await expect(
       validateOnChainParticipantKeys({
@@ -240,5 +292,147 @@ describe("validateOnChainParticipantKeys", () => {
 
     expect(result.vaultProviderBtcPubkeyXOnly).toBe(VP_KEY);
     expect(result.vaultProviderBtcPubkeyXOnly).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+describe("validateOnChainParticipantKeys with operation-key resolution", () => {
+  // Real secp256k1 points, because resolution validates curve membership —
+  // the placeholder keys above would be rejected before any hint comparison.
+  const REGISTRATION = {
+    vp: KEYS.vpGenesis,
+    keepers: [
+      KEYS.keeperAGenesis,
+      KEYS.keeperBGenesis,
+      KEYS.keeperCGenesis,
+    ].sort(),
+    challengers: [KEYS.challenger1Genesis, KEYS.challenger2Genesis].sort(),
+  };
+  const OPERATION = {
+    vp: KEYS.vpRotated,
+    keepers: [
+      KEYS.keeperAGenesis,
+      KEYS.keeperBRotated,
+      KEYS.keeperCGenesis,
+    ].sort(),
+    challengers: [KEYS.challenger1Rotated, KEYS.challenger2Genesis].sort(),
+  };
+
+  function buildRotationReaders() {
+    const query = buildQuery();
+    return {
+      vaultRegistryReader: {
+        getVaultBasicInfo: vi.fn(),
+        getVaultProtocolInfo: vi.fn(),
+        getProtocolInfoBatch: vi.fn(),
+        getVaultData: vi.fn(),
+        getVaultProviderBtcPubKey: vi
+          .fn()
+          .mockResolvedValue(KEYS.vpGenesis as OnChainBtcPubkey),
+        getPegInFee: vi.fn(),
+        getVaultProviderCommission: vi.fn(),
+        getOffchainParamsVersionsByVaultIds: vi.fn(),
+        getVaultKeyEpochs: vi.fn(),
+        getVaultKeyEpochsBatch: vi.fn(),
+        getCurrentVaultProviderOperationBtcKey: vi.fn(),
+      } as VaultRegistryReader,
+      vaultKeeperReader: {
+        getVaultKeepersByVersion: vi.fn().mockResolvedValue(query.vaultKeepers),
+        getCurrentVaultKeepers: vi.fn(),
+        getCurrentVaultKeepersVersion: vi.fn().mockResolvedValue(3),
+      } as VaultKeeperReader,
+      universalChallengerReader: {
+        getUniversalChallengersByVersion: vi
+          .fn()
+          .mockResolvedValue(query.universalChallengers),
+        getCurrentUniversalChallengers: vi.fn(),
+        getLatestUniversalChallengersVersion: vi.fn().mockResolvedValue(5),
+      } as UniversalChallengerReader,
+      operationKeyReader: new FakeOperationKeyReader(),
+      vaultProviderEthAddress: ADDRESSES.vaultProvider,
+      applicationEntryPoint: ADDRESSES.applicationEntryPoint,
+    };
+  }
+
+  it("builds with the operation keys, not the registration keys", async () => {
+    const readers = buildRotationReaders();
+
+    const result = await validateOnChainParticipantKeys({
+      ...readers,
+      expectedVaultProviderBtcPubkey: REGISTRATION.vp,
+      expectedVaultKeeperBtcPubkeys: REGISTRATION.keepers,
+      expectedUniversalChallengerBtcPubkeys: REGISTRATION.challengers,
+    });
+
+    expect(result.vaultProviderBtcPubkeyXOnly).toBe(OPERATION.vp);
+    expect(result.vaultKeeperBtcPubkeysSorted).toEqual(OPERATION.keepers);
+    expect(result.universalChallengerBtcPubkeysSorted).toEqual(
+      OPERATION.challengers,
+    );
+    // The registration keys stay available for diagnostics.
+    expect(result.registrationKeys.vaultProvider).toBe(REGISTRATION.vp);
+    expect(result.participantKeys).not.toBeNull();
+  });
+
+  it("accepts an indexer hint that still serves the registration keys", async () => {
+    const readers = buildRotationReaders();
+    const onIndexerServingOperationKeys = vi.fn();
+
+    await expect(
+      validateOnChainParticipantKeys({
+        ...readers,
+        expectedVaultProviderBtcPubkey: REGISTRATION.vp,
+        expectedVaultKeeperBtcPubkeys: REGISTRATION.keepers,
+        expectedUniversalChallengerBtcPubkeys: REGISTRATION.challengers,
+        onIndexerServingOperationKeys,
+      }),
+    ).resolves.toBeDefined();
+
+    expect(onIndexerServingOperationKeys).not.toHaveBeenCalled();
+  });
+
+  it("accepts an indexer hint that has caught up to the operation keys", async () => {
+    const readers = buildRotationReaders();
+    const onIndexerServingOperationKeys = vi.fn();
+
+    await expect(
+      validateOnChainParticipantKeys({
+        ...readers,
+        expectedVaultProviderBtcPubkey: OPERATION.vp,
+        expectedVaultKeeperBtcPubkeys: OPERATION.keepers,
+        expectedUniversalChallengerBtcPubkeys: OPERATION.challengers,
+        onIndexerServingOperationKeys,
+      }),
+    ).resolves.toBeDefined();
+
+    expect(onIndexerServingOperationKeys).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects a hint that mixes registration and operation keys across roles", async () => {
+    // A half-applied indexer view: the VP is still pre-rotation while the
+    // challengers have caught up. No single snapshot of the indexer ever held
+    // this combination.
+    const readers = buildRotationReaders();
+
+    await expect(
+      validateOnChainParticipantKeys({
+        ...readers,
+        expectedVaultProviderBtcPubkey: REGISTRATION.vp,
+        expectedVaultKeeperBtcPubkeys: REGISTRATION.keepers,
+        expectedUniversalChallengerBtcPubkeys: OPERATION.challengers,
+      }),
+    ).rejects.toThrow(/internally inconsistent/i);
+  });
+
+  it("rejects a hint matching neither key set", async () => {
+    const readers = buildRotationReaders();
+
+    await expect(
+      validateOnChainParticipantKeys({
+        ...readers,
+        expectedVaultProviderBtcPubkey: KEYS.outsider,
+        expectedVaultKeeperBtcPubkeys: REGISTRATION.keepers,
+        expectedUniversalChallengerBtcPubkeys: REGISTRATION.challengers,
+      }),
+    ).rejects.toThrow(/Vault provider BTC pubkey/);
   });
 });

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/verifyRegisteredParticipantKeys.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/verifyRegisteredParticipantKeys.test.ts
@@ -1,0 +1,115 @@
+import type { Hex } from "viem";
+import { describe, expect, it, vi } from "vitest";
+
+import type { VaultRegistryReader } from "../../../clients/eth/types";
+import {
+  EPOCH_AFTER_ROTATION,
+  EPOCH_GENESIS,
+  FakeOperationKeyReader,
+  buildQuery,
+  epochsAt,
+} from "../../participants/__tests__/fixtures/rotation";
+import { resolveParticipantKeysAtEpochs } from "../../participants/resolveParticipantKeys";
+import { verifyRegisteredParticipantKeys } from "../verifyRegisteredParticipantKeys";
+import { isRegisteredVaultVersionMismatchError } from "../verifyRegisteredVaultVersions";
+
+const VAULT_ID = `0x${"11".repeat(32)}` as Hex;
+
+function registryReaderReturning(epoch: bigint): VaultRegistryReader {
+  return {
+    getVaultBasicInfo: vi.fn(),
+    getVaultProtocolInfo: vi.fn(),
+    getProtocolInfoBatch: vi.fn(),
+    getVaultData: vi.fn(),
+    getVaultProviderBtcPubKey: vi.fn(),
+    getPegInFee: vi.fn(),
+    getVaultProviderCommission: vi.fn(),
+    getOffchainParamsVersionsByVaultIds: vi.fn(),
+    getVaultKeyEpochs: vi.fn(),
+    getVaultKeyEpochsBatch: vi.fn().mockResolvedValue([epochsAt(epoch)]),
+    getCurrentVaultProviderOperationBtcKey: vi.fn(),
+  } as VaultRegistryReader;
+}
+
+async function keySetAt(epoch: bigint) {
+  return resolveParticipantKeysAtEpochs({
+    operationKeyReader: new FakeOperationKeyReader(),
+    query: buildQuery(),
+    epochs: epochsAt(epoch),
+  });
+}
+
+describe("verifyRegisteredParticipantKeys", () => {
+  it("passes when the frozen epochs resolve to the keys we built with", async () => {
+    const expected = await keySetAt(EPOCH_AFTER_ROTATION);
+
+    await expect(
+      verifyRegisteredParticipantKeys({
+        vaultRegistryReader: registryReaderReturning(EPOCH_AFTER_ROTATION),
+        operationKeyReader: new FakeOperationKeyReader(),
+        vaultIds: [VAULT_ID],
+        expected,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("aborts the broadcast when a rotation landed during registration", async () => {
+    // Built against the pre-rotation keys, but the vault froze an epoch that
+    // resolves to the rotated ones — exactly the race this check exists for.
+    const expected = await keySetAt(EPOCH_GENESIS);
+
+    await expect(
+      verifyRegisteredParticipantKeys({
+        vaultRegistryReader: registryReaderReturning(EPOCH_AFTER_ROTATION),
+        operationKeyReader: new FakeOperationKeyReader(),
+        vaultIds: [VAULT_ID],
+        expected,
+      }),
+    ).rejects.toThrow(/vault provider key expected/i);
+  });
+
+  it("throws an error the existing cleanup path recognises", async () => {
+    // The orchestrator removes pending pegin entries on this error class only,
+    // so it must survive the module boundary the same way the sibling does.
+    const expected = await keySetAt(EPOCH_GENESIS);
+
+    const error = await verifyRegisteredParticipantKeys({
+      vaultRegistryReader: registryReaderReturning(EPOCH_AFTER_ROTATION),
+      operationKeyReader: new FakeOperationKeyReader(),
+      vaultIds: [VAULT_ID],
+      expected,
+    }).catch((e: unknown) => e);
+
+    expect(isRegisteredVaultVersionMismatchError(error)).toBe(true);
+    expect((error as Error).message).toMatch(/was not broadcast/i);
+  });
+
+  it("reports a keeper-set drift naming the vault", async () => {
+    const expected = await keySetAt(EPOCH_GENESIS);
+
+    await expect(
+      verifyRegisteredParticipantKeys({
+        vaultRegistryReader: registryReaderReturning(EPOCH_AFTER_ROTATION),
+        operationKeyReader: new FakeOperationKeyReader(),
+        vaultIds: [VAULT_ID],
+        expected,
+      }),
+    ).rejects.toThrow(new RegExp(`vault ${VAULT_ID}: vault keeper keys`, "i"));
+  });
+
+  it("does nothing for an empty vault list", async () => {
+    const reader = registryReaderReturning(EPOCH_GENESIS);
+    const expected = await keySetAt(EPOCH_GENESIS);
+
+    await expect(
+      verifyRegisteredParticipantKeys({
+        vaultRegistryReader: reader,
+        operationKeyReader: new FakeOperationKeyReader(),
+        vaultIds: [],
+        expected,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(reader.getVaultKeyEpochsBatch).not.toHaveBeenCalled();
+  });
+});

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/verifyRegisteredParticipantKeys.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/verifyRegisteredParticipantKeys.test.ts
@@ -10,7 +10,10 @@ import {
   epochsAt,
 } from "../../participants/__tests__/fixtures/rotation";
 import { resolveParticipantKeysAtEpochs } from "../../participants/resolveParticipantKeys";
-import { verifyRegisteredParticipantKeys } from "../verifyRegisteredParticipantKeys";
+import {
+  isParticipantKeyDriftError,
+  verifyRegisteredParticipantKeys,
+} from "../verifyRegisteredParticipantKeys";
 import { isRegisteredVaultVersionMismatchError } from "../verifyRegisteredVaultVersions";
 
 const VAULT_ID = `0x${"11".repeat(32)}` as Hex;
@@ -68,9 +71,12 @@ describe("verifyRegisteredParticipantKeys", () => {
     ).rejects.toThrow(/vault provider key expected/i);
   });
 
-  it("throws an error the existing cleanup path recognises", async () => {
-    // The orchestrator removes pending pegin entries on this error class only,
-    // so it must survive the module boundary the same way the sibling does.
+  it("throws a key-drift error that is not a version mismatch", async () => {
+    // The distinction drives cleanup: the orchestrator drops the local pending
+    // record on a version mismatch, but must keep it on key drift — the record
+    // holds the build-time key stamp that lets a later resume re-detect the
+    // drift instead of falling back to the indexer's copy and broadcasting it.
+    // Recognition must also survive the module boundary, as the sibling does.
     const expected = await keySetAt(EPOCH_GENESIS);
 
     const error = await verifyRegisteredParticipantKeys({
@@ -80,7 +86,8 @@ describe("verifyRegisteredParticipantKeys", () => {
       expected,
     }).catch((e: unknown) => e);
 
-    expect(isRegisteredVaultVersionMismatchError(error)).toBe(true);
+    expect(isParticipantKeyDriftError(error)).toBe(true);
+    expect(isRegisteredVaultVersionMismatchError(error)).toBe(false);
     expect((error as Error).message).toMatch(/was not broadcast/i);
   });
 

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/verifyRegisteredVaultVersions.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/verifyRegisteredVaultVersions.test.ts
@@ -57,6 +57,9 @@ function buildRegistryReader(
     getPegInFee: vi.fn(),
     getVaultProviderCommission: vi.fn(),
     getOffchainParamsVersionsByVaultIds: vi.fn(),
+    getVaultKeyEpochs: vi.fn(),
+    getVaultKeyEpochsBatch: vi.fn(),
+    getCurrentVaultProviderOperationBtcKey: vi.fn(),
   };
 }
 
@@ -144,7 +147,9 @@ describe("verifyRegisteredVaultVersions", () => {
         expectedUniversalChallengersVersion: CHALLENGERS,
         expectedVaultCoreVersion: CORE,
       }),
-    ).rejects.toThrow(/vaultCoreVersion expected v1 \(build-time active\), got v2/);
+    ).rejects.toThrow(
+      /vaultCoreVersion expected v1 \(build-time active\), got v2/,
+    );
   });
 
   it("resolves without RPC for empty vaultIds", async () => {

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/index.ts
@@ -1,27 +1,9 @@
 export type {
-  PeginStatusReader,
-  WotsKeySubmitter,
-  PresignClient,
   ClaimerArtifactsReader,
+  PeginStatusReader,
+  PresignClient,
+  WotsKeySubmitter,
 } from "./interfaces";
-export {
-  waitForPeginStatus,
-  type WaitForPeginStatusParams,
-} from "./waitForPeginStatus";
-export {
-  submitWotsPublicKey,
-  type SubmitWotsPublicKeyParams,
-} from "./submitWotsPublicKey";
-export {
-  signDepositorGraph,
-  type DepositorGraphSigningContext,
-  type SignDepositorGraphParams,
-} from "./signDepositorGraph";
-export {
-  runDepositorPresignFlow,
-  type PayoutSigningContext,
-  type RunDepositorPresignFlowParams,
-} from "./runDepositorPresignFlow";
 export {
   ContractStatus,
   PeginAction,
@@ -33,26 +15,48 @@ export {
   type PeginProtocolState,
 } from "./peginState";
 export {
-  isDepositAmountValid,
-  validateDepositAmount,
-  validateRemainingCapacity,
-  validateProviderSelection,
-  validateVaultAmounts,
-  validateVaultProviderPubkey,
-  validateMultiVaultDepositInputs,
-  type ValidationResult,
-  type DepositFormValidityParams,
-  type RemainingCapacityParams,
-  type MultiVaultDepositFlowInputs,
-} from "./validation";
+  runDepositorPresignFlow,
+  type PayoutSigningContext,
+  type RunDepositorPresignFlowParams,
+} from "./runDepositorPresignFlow";
+export {
+  signDepositorGraph,
+  type DepositorGraphSigningContext,
+  type SignDepositorGraphParams,
+} from "./signDepositorGraph";
+export {
+  submitWotsPublicKey,
+  type SubmitWotsPublicKeyParams,
+} from "./submitWotsPublicKey";
 export {
   validateOnChainParticipantKeys,
   type ValidateOnChainParticipantKeysParams,
   type ValidatedOnChainParticipantKeys,
 } from "./validateOnChainParticipantKeys";
 export {
+  isDepositAmountValid,
+  validateDepositAmount,
+  validateMultiVaultDepositInputs,
+  validateProviderSelection,
+  validateRemainingCapacity,
+  validateVaultAmounts,
+  validateVaultProviderPubkey,
+  type DepositFormValidityParams,
+  type MultiVaultDepositFlowInputs,
+  type RemainingCapacityParams,
+  type ValidationResult,
+} from "./validation";
+export {
+  verifyRegisteredParticipantKeys,
+  type VerifyRegisteredParticipantKeysParams,
+} from "./verifyRegisteredParticipantKeys";
+export {
   RegisteredVaultVersionMismatchError,
   isRegisteredVaultVersionMismatchError,
   verifyRegisteredVaultVersions,
   type VerifyRegisteredVaultVersionsParams,
 } from "./verifyRegisteredVaultVersions";
+export {
+  waitForPeginStatus,
+  type WaitForPeginStatusParams,
+} from "./waitForPeginStatus";

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/index.ts
@@ -47,6 +47,8 @@ export {
   type ValidationResult,
 } from "./validation";
 export {
+  ParticipantKeyDriftError,
+  isParticipantKeyDriftError,
   verifyRegisteredParticipantKeys,
   type VerifyRegisteredParticipantKeysParams,
 } from "./verifyRegisteredParticipantKeys";

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts
@@ -90,6 +90,17 @@ export interface PayoutSigningContext {
    * graph with. Bounds every payout's implicit fee (device fee-bound model).
    */
   protocolFeeRate: bigint;
+
+  /**
+   * RFC-006 resolved keeper payout destinations at the vault's frozen
+   * `appKeeperKeyEpoch`, keyed by lowercased x-only operation pubkey.
+   */
+  vkClaimerPayoutScriptPubKeys: Readonly<Record<string, string>>;
+  /**
+   * RFC-006 resolved VP commission destination at the vault's frozen
+   * `vpKeyEpoch`.
+   */
+  vpCommissionScriptPubKey: string;
 }
 
 export interface RunDepositorPresignFlowParams {
@@ -254,6 +265,8 @@ function buildPayoutSigningInput(
     commissionBps: context.commissionBps,
     protocolFeeRate: context.protocolFeeRate,
     councilSize: context.councilMembers.length,
+    vkClaimerPayoutScriptPubKeys: context.vkClaimerPayoutScriptPubKeys,
+    vpCommissionScriptPubKey: context.vpCommissionScriptPubKey,
   };
 }
 
@@ -443,6 +456,8 @@ export async function runDepositorPresignFlow(
       network: signingContext.network,
       registeredPayoutScriptPubKey: signingContext.registeredPayoutScriptPubKey,
       protocolFeeRate: signingContext.protocolFeeRate,
+      vkClaimerPayoutScriptPubKeys: signingContext.vkClaimerPayoutScriptPubKeys,
+      vpCommissionScriptPubKey: signingContext.vpCommissionScriptPubKey,
     },
   });
 

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts
@@ -31,6 +31,7 @@ import type {
   DepositorPreSigsPerChallenger,
   PresignDataPerChallenger,
 } from "../../clients/vault-provider/types";
+import { signPsbtsWithFallback } from "../../managers/pegin/signPsbtsWithFallback";
 import {
   assertPsbtUnsignedTxMatches,
   type AssertPsbtUnsignedTxMatchesParams,
@@ -44,7 +45,6 @@ import {
   extractPayoutSignature,
 } from "../../primitives/psbt/payout";
 import { assertScriptPathSchnorrSignature } from "../../primitives/psbt/verifyScriptPathSchnorrSignature";
-import { signPsbtsWithFallback } from "../../managers/pegin/signPsbtsWithFallback";
 import {
   stripHexPrefix,
   uint8ArrayToHex,
@@ -250,6 +250,8 @@ async function collectDepositorGraphPsbts(
   //    buildPayoutPsbt also runs the per-role output validation.
   const builtPayout = await buildPayoutPsbt({
     vaultCoreVersion: ctx.vaultCoreVersion,
+    vkClaimerPayoutScriptPubKeys: ctx.vkClaimerPayoutScriptPubKeys,
+    vpCommissionScriptPubKey: ctx.vpCommissionScriptPubKey,
     payoutTxHex: depositorGraph.payout_tx.tx_hex,
     peginTxHex: ctx.peginTxHex,
     assertTxHex: depositorGraph.assert_tx.tx_hex,
@@ -543,6 +545,15 @@ export interface DepositorGraphSigningContext {
    * the depositor's registered address before the wallet produces a signature.
    */
   registeredPayoutScriptPubKey: string;
+  /**
+   * RFC-006 operator payout destinations. Forwarded to `buildPayoutPsbt` for
+   * shape completeness only: this graph is signed under the
+   * `depositor-as-claimer` role, whose payout has two outputs and reads
+   * neither the keeper map nor the VP commission destination.
+   */
+  vkClaimerPayoutScriptPubKeys: Readonly<Record<string, string>>;
+  /** See {@link vkClaimerPayoutScriptPubKeys} — unused for this role. */
+  vpCommissionScriptPubKey: string;
 }
 
 export interface SignDepositorGraphParams {

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts
@@ -1,11 +1,14 @@
-import type { Address } from "viem";
+import type { Address, Hex } from "viem";
 
 import type {
+  OperationKeyReader,
   UniversalChallengerReader,
   VaultKeeperReader,
   VaultRegistryReader,
 } from "../../clients/eth/types";
 import { processPublicKeyToXOnly } from "../../primitives/utils/bitcoin";
+import { resolveCurrentParticipantKeys } from "../participants/resolveParticipantKeys";
+import type { ParticipantKeySet } from "../participants/types";
 
 export interface ValidateOnChainParticipantKeysParams {
   vaultRegistryReader: VaultRegistryReader;
@@ -16,14 +19,48 @@ export interface ValidateOnChainParticipantKeysParams {
   expectedVaultProviderBtcPubkey: string;
   expectedVaultKeeperBtcPubkeys: string[];
   expectedUniversalChallengerBtcPubkeys: string[];
+  /**
+   * RFC-006. Participant keys are resolved to their *current operation* keys,
+   * and those are what the returned key fields carry.
+   */
+  operationKeyReader: OperationKeyReader;
+  /**
+   * Optional observer for the case where the indexer hint matched the
+   * operation keys rather than the registration keys — i.e. the indexer is
+   * ahead of us, not wrong. Called at most once.
+   */
+  onIndexerServingOperationKeys?: (message: string) => void;
 }
 
 export interface ValidatedOnChainParticipantKeys {
+  /** The VP key to build with: its current operation key. */
   vaultProviderBtcPubkeyXOnly: string;
   vaultKeeperBtcPubkeysSorted: string[];
   universalChallengerBtcPubkeysSorted: string[];
   expectedAppVaultKeepersVersion: number;
   expectedUniversalChallengersVersion: number;
+  /**
+   * The registration / roster keys, sorted. These are what indexer hints are
+   * compared against first, and they stay available for diagnostics after
+   * resolution.
+   */
+  registrationKeys: {
+    vaultProvider: string;
+    vaultKeepers: string[];
+    universalChallengers: string[];
+  };
+  /**
+   * The full resolution, including the admin↔key pairing. Feeds the
+   * post-registration read-after-mine verification.
+   */
+  participantKeys: ParticipantKeySet;
+}
+
+const canonical = (k: string) => processPublicKeyToXOnly(k).toLowerCase();
+const sortedSet = (keys: string[]) => keys.map(canonical).sort();
+
+function setsEqual(a: string[], b: string[]): boolean {
+  return a.length === b.length && a.every((k, i) => k === b[i]);
 }
 
 export async function validateOnChainParticipantKeys(
@@ -38,6 +75,8 @@ export async function validateOnChainParticipantKeys(
     expectedVaultProviderBtcPubkey,
     expectedVaultKeeperBtcPubkeys,
     expectedUniversalChallengerBtcPubkeys,
+    operationKeyReader,
+    onIndexerServingOperationKeys,
   } = params;
 
   const [
@@ -60,47 +99,126 @@ export async function validateOnChainParticipantKeys(
     ),
   ]);
 
-  const canonical = (k: string) => processPublicKeyToXOnly(k).toLowerCase();
-  const sortedSet = (keys: string[]) => keys.map(canonical).sort();
+  const registrationKeys = {
+    vaultProvider: canonical(onChainVpKey),
+    vaultKeepers: sortedSet(onChainKeepers.map((p) => p.btcPubKey)),
+    universalChallengers: sortedSet(onChainChallengers.map((p) => p.btcPubKey)),
+  };
 
-  const expectedVpKeyXOnly = canonical(expectedVaultProviderBtcPubkey);
-  if (expectedVpKeyXOnly !== onChainVpKey) {
+  // Resolve the current operation keys, if enabled. This is what we build the
+  // Bitcoin lock with; the registration keys above stay only as the primary
+  // comparison target for indexer hints.
+  const participantKeys: ParticipantKeySet =
+    await resolveCurrentParticipantKeys({
+      operationKeyReader,
+      query: {
+        vaultProviderEthAddress,
+        vaultProviderGenesisBtcPubkey: `0x${onChainVpKey}` as Hex,
+        applicationEntryPoint,
+        vaultKeepers: onChainKeepers,
+        universalChallengers: onChainChallengers,
+      },
+    });
+
+  const operationKeys = {
+    vaultProvider: participantKeys.vaultProvider.operationBtcPubkey as string,
+    vaultKeepers: [...participantKeys.vaultKeeperOperationKeysSorted],
+    universalChallengers: [
+      ...participantKeys.universalChallengerOperationKeysSorted,
+    ],
+  };
+
+  // --- Indexer hint cross-check -----------------------------------------
+  //
+  // The hint never influences the resolved key — resolution is chain-only.
+  // Its job is to catch a wrong VP address, a wrong application entry point,
+  // or a stale roster version, and it still does that.
+  //
+  // Once rotation is possible the indexer may legitimately serve either the
+  // registration keys (it has not caught up) or the operation keys (it has),
+  // so each role is accepted against both candidates. For a role that never
+  // rotated the two candidates are identical, so this is strictly the old
+  // check until someone rotates.
+  //
+  // Each role is compared as a *whole set*, never as per-element membership of
+  // the union: a keeper set holding one registration key and one operation key
+  // is an indexer inconsistency, and union membership would wave it through.
+  // The cross-role check below closes the same hole one level up.
+  const hintVp = canonical(expectedVaultProviderBtcPubkey);
+  const hintKeepers = sortedSet(expectedVaultKeeperBtcPubkeys);
+  const hintChallengers = sortedSet(expectedUniversalChallengerBtcPubkeys);
+
+  /** Which of the two candidate sets a role's hint matched. */
+  interface RoleMatch {
+    registration: boolean;
+    operation: boolean;
+  }
+
+  const vpMatch: RoleMatch = {
+    registration: hintVp === registrationKeys.vaultProvider,
+    operation: hintVp === operationKeys.vaultProvider,
+  };
+  const keeperMatch: RoleMatch = {
+    registration: setsEqual(hintKeepers, registrationKeys.vaultKeepers),
+    operation: setsEqual(hintKeepers, operationKeys.vaultKeepers),
+  };
+  const challengerMatch: RoleMatch = {
+    registration: setsEqual(
+      hintChallengers,
+      registrationKeys.universalChallengers,
+    ),
+    operation: setsEqual(hintChallengers, operationKeys.universalChallengers),
+  };
+
+  const accepted = (m: RoleMatch) => m.registration || m.operation;
+
+  if (!accepted(vpMatch)) {
     throw new Error(
       `Vault provider BTC pubkey indexer hint does not match BTCVaultRegistry for ${vaultProviderEthAddress}. Refresh and try again.`,
     );
   }
-
-  const expectedKeepers = sortedSet(expectedVaultKeeperBtcPubkeys);
-  const onChainKeepersSorted = sortedSet(
-    onChainKeepers.map((p) => p.btcPubKey),
-  );
-  if (
-    expectedKeepers.length !== onChainKeepersSorted.length ||
-    expectedKeepers.some((k, i) => k !== onChainKeepersSorted[i])
-  ) {
+  if (!accepted(keeperMatch)) {
     throw new Error(
       `Vault keeper BTC pubkeys (v${expectedAppVaultKeepersVersion}) indexer set does not match ApplicationRegistry on-chain set. Refresh and try again.`,
     );
   }
-
-  const expectedChallengers = sortedSet(expectedUniversalChallengerBtcPubkeys);
-  const onChainChallengersSorted = sortedSet(
-    onChainChallengers.map((p) => p.btcPubKey),
-  );
-  if (
-    expectedChallengers.length !== onChainChallengersSorted.length ||
-    expectedChallengers.some((k, i) => k !== onChainChallengersSorted[i])
-  ) {
+  if (!accepted(challengerMatch)) {
     throw new Error(
       `Universal challenger BTC pubkeys (v${expectedUniversalChallengersVersion}) indexer set does not match ProtocolParams on-chain set. Refresh and try again.`,
     );
   }
 
+  // Cross-role consistency. A role whose two candidates are identical (nobody
+  // in it rotated) matches both and constrains nothing. But if one role can
+  // *only* be explained by the registration keys while another can *only* be
+  // explained by the operation keys, the indexer is serving a half-applied
+  // view — accepting that would mean building with a key set no single
+  // snapshot of the indexer ever held.
+  const roles = [vpMatch, keeperMatch, challengerMatch];
+  const pinsRegistration = roles.some((m) => m.registration && !m.operation);
+  const pinsOperation = roles.some((m) => m.operation && !m.registration);
+
+  if (pinsRegistration && pinsOperation) {
+    throw new Error(
+      `Indexer participant hints are internally inconsistent for vault provider ` +
+        `${vaultProviderEthAddress}: some roles match the registration keys while ` +
+        `others match the rotated operation keys. Refresh and try again.`,
+    );
+  }
+
+  if (pinsOperation) {
+    onIndexerServingOperationKeys?.(
+      `Indexer is serving rotated operation keys for vault provider ${vaultProviderEthAddress}`,
+    );
+  }
+
   return {
-    vaultProviderBtcPubkeyXOnly: onChainVpKey,
-    vaultKeeperBtcPubkeysSorted: onChainKeepersSorted,
-    universalChallengerBtcPubkeysSorted: onChainChallengersSorted,
+    vaultProviderBtcPubkeyXOnly: operationKeys.vaultProvider,
+    vaultKeeperBtcPubkeysSorted: operationKeys.vaultKeepers,
+    universalChallengerBtcPubkeysSorted: operationKeys.universalChallengers,
     expectedAppVaultKeepersVersion,
     expectedUniversalChallengersVersion,
+    registrationKeys,
+    participantKeys,
   };
 }

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts
@@ -30,6 +30,15 @@ export interface ValidateOnChainParticipantKeysParams {
    * ahead of us, not wrong. Called at most once.
    */
   onIndexerServingOperationKeys?: (message: string) => void;
+  /**
+   * Optional observer for the case where the indexer is serving a half-applied
+   * view — one role explainable only by the registration keys, another only by
+   * the operation keys. That blocks every deposit for the provider until the
+   * indexer converges, and "Refresh and try again" cannot help, so the block
+   * needs to be visible rather than showing up only as user reports. Called
+   * immediately before the throw.
+   */
+  onIndexerHintsInconsistent?: (message: string) => void;
 }
 
 export interface ValidatedOnChainParticipantKeys {
@@ -77,6 +86,7 @@ export async function validateOnChainParticipantKeys(
     expectedUniversalChallengerBtcPubkeys,
     operationKeyReader,
     onIndexerServingOperationKeys,
+    onIndexerHintsInconsistent,
   } = params;
 
   const [
@@ -199,11 +209,15 @@ export async function validateOnChainParticipantKeys(
   const pinsOperation = roles.some((m) => m.operation && !m.registration);
 
   if (pinsRegistration && pinsOperation) {
-    throw new Error(
+    const message =
       `Indexer participant hints are internally inconsistent for vault provider ` +
-        `${vaultProviderEthAddress}: some roles match the registration keys while ` +
-        `others match the rotated operation keys. Refresh and try again.`,
-    );
+      `${vaultProviderEthAddress}: some roles match the registration keys while ` +
+      `others match the rotated operation keys.`;
+    // Report before throwing. This state blocks every deposit for the provider
+    // and clears only when the indexer converges across all three registries —
+    // nothing the user does resolves it, so it has to be observable to us.
+    onIndexerHintsInconsistent?.(message);
+    throw new Error(`${message} Refresh and try again.`);
   }
 
   if (pinsOperation) {

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredParticipantKeys.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredParticipantKeys.ts
@@ -1,0 +1,133 @@
+/**
+ * RFC-006 read-after-mine verification for a freshly registered vault.
+ *
+ * A new peg-in is built with each participant's *current* operation key, but
+ * the vault does not freeze its key epochs until `submitPeginRequest` executes.
+ * An operator rotating in that window would leave the registered vault bonded
+ * to keys other than the ones baked into the Bitcoin lock we are about to
+ * broadcast — BTC locked into a script no counterparty will presign.
+ *
+ * So after the registration mines and before the BTC broadcast, re-read the
+ * vault's frozen epochs, re-resolve every participant against them, and assert
+ * the result is byte-identical to what we built with.
+ *
+ * Deliberately a sibling of `verifyRegisteredVaultVersions` rather than an
+ * extension of it: that function reads `getProtocolInfoBatch` through the
+ * shared 13-field ABI and must stay there, while this one needs the extended
+ * key-epoch ABI. They throw the same error class so the orchestrator's
+ * pending-entry cleanup covers both.
+ *
+ * @module services/deposit/verifyRegisteredParticipantKeys
+ */
+
+import type { Hex } from "viem";
+
+import type {
+  OperationKeyReader,
+  VaultRegistryReader,
+} from "../../clients/eth/types";
+import { resolveParticipantKeysAtEpochs } from "../participants/resolveParticipantKeys";
+import type { ParticipantKeySet } from "../participants/types";
+import { RegisteredVaultVersionMismatchError } from "./verifyRegisteredVaultVersions";
+
+export interface VerifyRegisteredParticipantKeysParams {
+  vaultRegistryReader: VaultRegistryReader;
+  operationKeyReader: OperationKeyReader;
+  vaultIds: readonly Hex[];
+  /**
+   * The exact key set the BTC artifacts were built with. Its `query` supplies
+   * the rosters to re-resolve against — deliberately reused rather than
+   * accepted as a separate argument, so the two can never disagree and a
+   * roster that moved since the build cannot be misreported as a key drift.
+   */
+  expected: ParticipantKeySet;
+}
+
+function diffKeys(
+  label: string,
+  expected: readonly string[],
+  actual: readonly string[],
+): string | null {
+  if (
+    expected.length === actual.length &&
+    expected.every((k, i) => k === actual[i])
+  ) {
+    return null;
+  }
+  return `${label} expected [${expected.join(", ")}], got [${actual.join(", ")}]`;
+}
+
+export async function verifyRegisteredParticipantKeys(
+  params: VerifyRegisteredParticipantKeysParams,
+): Promise<void> {
+  const { vaultRegistryReader, operationKeyReader, vaultIds, expected } =
+    params;
+  const query = expected.query;
+
+  if (vaultIds.length === 0) return;
+
+  // Batch registration gives every sibling vault the same epochs, so these
+  // reads are redundant across siblings. Kept per-vault anyway: it is one
+  // multicall, and asserting each vault individually is what makes the error
+  // name the vault that drifted.
+  const epochsPerVault =
+    await vaultRegistryReader.getVaultKeyEpochsBatch(vaultIds);
+
+  const mismatches: string[] = [];
+
+  for (const [i, epochs] of epochsPerVault.entries()) {
+    const vaultId = vaultIds[i];
+
+    let resolved: ParticipantKeySet;
+    try {
+      resolved = await resolveParticipantKeysAtEpochs({
+        operationKeyReader,
+        query,
+        epochs,
+      });
+    } catch (error) {
+      // A resolution failure here is itself a mismatch signal: the frozen
+      // epochs point at a key set we cannot reconstruct, so broadcasting
+      // would be worse than aborting.
+      mismatches.push(
+        `vault ${vaultId}: could not resolve participants at frozen epochs ` +
+          `(vp=${epochs.vpKeyEpoch}, keeper=${epochs.appKeeperKeyEpoch}, ` +
+          `uc=${epochs.ucKeyEpoch}): ${(error as Error).message}`,
+      );
+      continue;
+    }
+
+    if (
+      resolved.vaultProvider.operationBtcPubkey !==
+      expected.vaultProvider.operationBtcPubkey
+    ) {
+      mismatches.push(
+        `vault ${vaultId}: vault provider key expected ` +
+          `${expected.vaultProvider.operationBtcPubkey}, got ` +
+          `${resolved.vaultProvider.operationBtcPubkey}`,
+      );
+    }
+
+    const keeperDiff = diffKeys(
+      `vault ${vaultId}: vault keeper keys`,
+      expected.vaultKeeperOperationKeysSorted,
+      resolved.vaultKeeperOperationKeysSorted,
+    );
+    if (keeperDiff) mismatches.push(keeperDiff);
+
+    const challengerDiff = diffKeys(
+      `vault ${vaultId}: universal challenger keys`,
+      expected.universalChallengerOperationKeysSorted,
+      resolved.universalChallengerOperationKeysSorted,
+    );
+    if (challengerDiff) mismatches.push(challengerDiff);
+  }
+
+  if (mismatches.length > 0) {
+    throw new RegisteredVaultVersionMismatchError(
+      `Aborting BTC broadcast: participant operation keys changed during registration ` +
+        `(${mismatches.join("; ")}). The Pre-PegIn was not broadcast; the registered ` +
+        `ETH vault will time out per protocol rules.`,
+    );
+  }
+}

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredParticipantKeys.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredParticipantKeys.ts
@@ -14,8 +14,7 @@
  * Deliberately a sibling of `verifyRegisteredVaultVersions` rather than an
  * extension of it: that function reads `getProtocolInfoBatch` through the
  * shared 13-field ABI and must stay there, while this one needs the extended
- * key-epoch ABI. They throw the same error class so the orchestrator's
- * pending-entry cleanup covers both.
+ * key-epoch ABI.
  *
  * @module services/deposit/verifyRegisteredParticipantKeys
  */
@@ -28,7 +27,45 @@ import type {
 } from "../../clients/eth/types";
 import { resolveParticipantKeysAtEpochs } from "../participants/resolveParticipantKeys";
 import type { ParticipantKeySet } from "../participants/types";
-import { RegisteredVaultVersionMismatchError } from "./verifyRegisteredVaultVersions";
+
+/**
+ * Participant operation keys drifted between building the Bitcoin artifacts
+ * and the vault freezing its epochs.
+ *
+ * A *sibling* of `RegisteredVaultVersionMismatchError`, never a subclass, and
+ * the distinction is load-bearing. On a version mismatch the orchestrator drops
+ * the local pending-pegin record, because the on-chain `prePeginTxHash` is
+ * still the authoritative copy of the transaction and a later resume can safely
+ * broadcast it from the indexer.
+ *
+ * Key drift breaks exactly that assumption. The registered hash commits to a
+ * transaction whose scripts embed the *pre-rotation* keys, while the vault
+ * froze the *post-rotation* epoch — so every counterparty resolves a different
+ * funding output and the deposit can never activate. Dropping the record would
+ * discard `buildParticipantOperationKeys`, the only thing that lets the resume
+ * path re-detect the drift; the next attempt would fall back to the indexer's
+ * copy, pass the hash check, and broadcast the very transaction this refused,
+ * locking BTC until the refund timelock.
+ *
+ * So: callers must keep the pending record when they catch this.
+ */
+export class ParticipantKeyDriftError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ParticipantKeyDriftError";
+  }
+}
+
+// `instanceof` alone fails across module boundaries (duplicate SDK copies,
+// test mocks). Fall back to the name field, as the version guard does.
+export function isParticipantKeyDriftError(
+  err: unknown,
+): err is ParticipantKeyDriftError {
+  return (
+    err instanceof ParticipantKeyDriftError ||
+    (err instanceof Error && err.name === "ParticipantKeyDriftError")
+  );
+}
 
 export interface VerifyRegisteredParticipantKeysParams {
   vaultRegistryReader: VaultRegistryReader;
@@ -124,7 +161,7 @@ export async function verifyRegisteredParticipantKeys(
   }
 
   if (mismatches.length > 0) {
-    throw new RegisteredVaultVersionMismatchError(
+    throw new ParticipantKeyDriftError(
       `Aborting BTC broadcast: participant operation keys changed during registration ` +
         `(${mismatches.join("; ")}). The Pre-PegIn was not broadcast; the registered ` +
         `ETH vault will time out per protocol rules.`,

--- a/packages/babylon-ts-sdk/src/tbv/core/services/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/index.ts
@@ -8,5 +8,6 @@
 export * from "./activation";
 export * from "./deposit";
 export * from "./htlc";
+export * from "./participants";
 export * from "./pegout";
 export * from "./refund";

--- a/packages/babylon-ts-sdk/src/tbv/core/services/participants/__tests__/fixtures/rotation.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/participants/__tests__/fixtures/rotation.ts
@@ -1,0 +1,289 @@
+/**
+ * Two-epoch rotation fixture for RFC-006 participant key resolution.
+ *
+ * Models one application across two epochs:
+ *
+ * | operator | genesis | at epoch 5 | note |
+ * |---|---|---|---|
+ * | VP        | vpGenesis | rotated | |
+ * | keeper A  | static | static | control: never rotates |
+ * | keeper B  | static | rotated | rotated key sorts **before** its genesis |
+ * | keeper C  | static | static | registers a custom P2WPKH payout script |
+ * | UC 1      | static | rotated | |
+ * | UC 2      | static | static | control |
+ *
+ * Keeper B is the load-bearing case. Rotation changes a key, and therefore
+ * changes where it lands in the lexicographic sort that feeds script
+ * construction — so the fixture deliberately makes B's rotated key sort ahead
+ * of its genesis. Any code that index-joins a sorted key array back to a
+ * roster entry breaks on exactly this input and passes on every other one.
+ *
+ * Keeper C exercises the payout path: the registry returns a registered script
+ * for C and the on-chain BIP-86 backfill for everyone else, which is what
+ * makes adopting registry reads a no-op until an operator opts in.
+ */
+
+import * as ecc from "@bitcoin-js/tiny-secp256k1-asmjs";
+import type { Address, Hex } from "viem";
+
+import type {
+  AddressBTCKeyPair,
+  KeyEpochs,
+  OperationKeyQuery,
+  OperationKeyReader,
+  RawOperationKeys,
+  RawPayoutScripts,
+} from "../../../../clients/eth/types";
+import { deriveBip86ScriptPubKeyHex } from "../../../../primitives/utils/bitcoin";
+
+/** Epoch every operator's genesis key is bonded at. */
+export const EPOCH_GENESIS = 0n;
+/** Epoch after the rotations above have landed. */
+export const EPOCH_AFTER_ROTATION = 5n;
+
+/** Derive a deterministic, real secp256k1 x-only pubkey (lowercase, no `0x`). */
+export function xOnlyFromSeed(seed: number): string {
+  const scalar = Buffer.alloc(32);
+  scalar.writeUInt32BE(seed, 28);
+  const point = ecc.pointFromScalar(scalar, true);
+  if (!point) throw new Error(`seed ${seed} did not yield a curve point`);
+  return Buffer.from(point.subarray(1)).toString("hex");
+}
+
+const KEY_POOL = Array.from({ length: 12 }, (_, i) => xOnlyFromSeed(i + 1));
+
+// Pick B's pair so the rotated key sorts strictly before the genesis key,
+// rather than hoping two arbitrary keys happen to land that way.
+const [KEEPER_B_ROTATED, KEEPER_B_GENESIS] = [KEY_POOL[4], KEY_POOL[5]].sort();
+
+export const KEYS = {
+  vpGenesis: KEY_POOL[0],
+  vpRotated: KEY_POOL[1],
+  keeperAGenesis: KEY_POOL[2],
+  keeperBGenesis: KEEPER_B_GENESIS,
+  keeperBRotated: KEEPER_B_ROTATED,
+  keeperCGenesis: KEY_POOL[6],
+  challenger1Genesis: KEY_POOL[7],
+  challenger1Rotated: KEY_POOL[8],
+  challenger2Genesis: KEY_POOL[9],
+  /** Unrelated key, for collision and unknown-participant cases. */
+  outsider: KEY_POOL[10],
+} as const;
+
+export const ADDRESSES = {
+  vaultProvider: "0x00000000000000000000000000000000000000v1" as Address,
+  applicationEntryPoint:
+    "0x0000000000000000000000000000000000000app" as Address,
+  keeperA: "0x000000000000000000000000000000000000000a" as Address,
+  keeperB: "0x000000000000000000000000000000000000000b" as Address,
+  keeperC: "0x000000000000000000000000000000000000000c" as Address,
+  challenger1: "0x0000000000000000000000000000000000000001" as Address,
+  challenger2: "0x0000000000000000000000000000000000000002" as Address,
+} as const;
+
+/** Keeper C's registered payout script — a P2WPKH, deliberately not BIP-86. */
+export const KEEPER_C_PAYOUT_SCRIPT = `0x0014${"ab".repeat(20)}` as Hex;
+
+/** An operator's append-only key history, as the registry stores it. */
+interface OperatorHistory {
+  adminAddress: Address;
+  genesisKey: string;
+  /** Appended operation-key versions, each stamped with the epoch it landed at. */
+  rotations: { epoch: bigint; key: string }[];
+  /** Registered payout script, stamped with its epoch. Absent = BIP-86 backfill. */
+  payoutScript?: { epoch: bigint; script: Hex };
+}
+
+const VAULT_PROVIDER: OperatorHistory = {
+  adminAddress: ADDRESSES.vaultProvider,
+  genesisKey: KEYS.vpGenesis,
+  rotations: [{ epoch: 1n, key: KEYS.vpRotated }],
+};
+
+const KEEPERS: OperatorHistory[] = [
+  {
+    adminAddress: ADDRESSES.keeperA,
+    genesisKey: KEYS.keeperAGenesis,
+    rotations: [],
+  },
+  {
+    adminAddress: ADDRESSES.keeperB,
+    genesisKey: KEYS.keeperBGenesis,
+    rotations: [{ epoch: 2n, key: KEYS.keeperBRotated }],
+  },
+  {
+    adminAddress: ADDRESSES.keeperC,
+    genesisKey: KEYS.keeperCGenesis,
+    rotations: [],
+    payoutScript: { epoch: 3n, script: KEEPER_C_PAYOUT_SCRIPT },
+  },
+];
+
+const CHALLENGERS: OperatorHistory[] = [
+  {
+    adminAddress: ADDRESSES.challenger1,
+    genesisKey: KEYS.challenger1Genesis,
+    rotations: [{ epoch: 1n, key: KEYS.challenger1Rotated }],
+  },
+  {
+    adminAddress: ADDRESSES.challenger2,
+    genesisKey: KEYS.challenger2Genesis,
+    rotations: [],
+  },
+];
+
+/** `findAtEpoch`: the latest appended version stamped `<=` epoch, else genesis. */
+function resolveKeyAtEpoch(operator: OperatorHistory, epoch: bigint): string {
+  const applicable = operator.rotations.filter((r) => r.epoch <= epoch);
+  return applicable.length === 0
+    ? operator.genesisKey
+    : applicable[applicable.length - 1].key;
+}
+
+function resolveCurrentKey(operator: OperatorHistory): string {
+  return operator.rotations.length === 0
+    ? operator.genesisKey
+    : operator.rotations[operator.rotations.length - 1].key;
+}
+
+/**
+ * Mirrors `getPayoutScriptAtEpoch`: a registered script if one was stamped at
+ * or before the epoch, otherwise the on-chain BIP-86 backfill of the operation
+ * key bonded at that epoch.
+ */
+function resolvePayoutScriptAtEpoch(
+  operator: OperatorHistory,
+  epoch: bigint,
+): Hex {
+  if (operator.payoutScript && operator.payoutScript.epoch <= epoch) {
+    return operator.payoutScript.script;
+  }
+  return deriveBip86ScriptPubKeyHex(resolveKeyAtEpoch(operator, epoch)) as Hex;
+}
+
+function toPair(operator: OperatorHistory): AddressBTCKeyPair {
+  return {
+    ethAddress: operator.adminAddress,
+    btcPubKey: `0x${operator.genesisKey}` as Hex,
+  };
+}
+
+/** The roster + VP genesis, as every call site supplies them. */
+export function buildQuery(
+  overrides: Partial<OperationKeyQuery> = {},
+): OperationKeyQuery {
+  return {
+    vaultProviderEthAddress: ADDRESSES.vaultProvider,
+    vaultProviderGenesisBtcPubkey: `0x${KEYS.vpGenesis}` as Hex,
+    applicationEntryPoint: ADDRESSES.applicationEntryPoint,
+    vaultKeepers: KEEPERS.map(toPair),
+    universalChallengers: CHALLENGERS.map(toPair),
+    ...overrides,
+  };
+}
+
+export function epochsAt(epoch: bigint): KeyEpochs {
+  return {
+    vpKeyEpoch: epoch,
+    appKeeperKeyEpoch: epoch,
+    ucKeyEpoch: epoch,
+  };
+}
+
+/**
+ * An {@link OperationKeyReader} backed by the histories above.
+ *
+ * Resolves the same way the contracts do, so tests exercise the resolver's own
+ * logic rather than a viem mock's. `calls` records what was asked, which is how
+ * "current mode never issues an epoch read" is asserted.
+ */
+export class FakeOperationKeyReader implements OperationKeyReader {
+  readonly calls: string[] = [];
+
+  constructor(
+    private overrides: {
+      /** Force a specific raw key for one admin address, e.g. to test collisions. */
+      forceKey?: Map<Address, Hex>;
+    } = {},
+  ) {}
+
+  private apply(operator: OperatorHistory, resolved: string): Hex {
+    const forced = this.overrides.forceKey?.get(operator.adminAddress);
+    return forced ?? (`0x${resolved}` as Hex);
+  }
+
+  async getCurrentOperationKeys(
+    query: OperationKeyQuery,
+  ): Promise<RawOperationKeys> {
+    this.calls.push("getCurrentOperationKeys");
+    return {
+      vaultProvider: this.apply(
+        VAULT_PROVIDER,
+        resolveCurrentKey(VAULT_PROVIDER),
+      ),
+      vaultKeepers: query.vaultKeepers.map((pair) => {
+        const operator = operatorFor(KEEPERS, pair.ethAddress);
+        return this.apply(operator, resolveCurrentKey(operator));
+      }),
+      universalChallengers: query.universalChallengers.map((pair) => {
+        const operator = operatorFor(CHALLENGERS, pair.ethAddress);
+        return this.apply(operator, resolveCurrentKey(operator));
+      }),
+    };
+  }
+
+  async getOperationKeysAtEpochs(
+    query: OperationKeyQuery,
+    epochs: KeyEpochs,
+  ): Promise<RawOperationKeys> {
+    this.calls.push("getOperationKeysAtEpochs");
+    return {
+      vaultProvider: this.apply(
+        VAULT_PROVIDER,
+        resolveKeyAtEpoch(VAULT_PROVIDER, epochs.vpKeyEpoch),
+      ),
+      vaultKeepers: query.vaultKeepers.map((pair) => {
+        const operator = operatorFor(KEEPERS, pair.ethAddress);
+        return this.apply(
+          operator,
+          resolveKeyAtEpoch(operator, epochs.appKeeperKeyEpoch),
+        );
+      }),
+      universalChallengers: query.universalChallengers.map((pair) => {
+        const operator = operatorFor(CHALLENGERS, pair.ethAddress);
+        return this.apply(
+          operator,
+          resolveKeyAtEpoch(operator, epochs.ucKeyEpoch),
+        );
+      }),
+    };
+  }
+
+  async getPayoutScriptsAtEpochs(
+    query: OperationKeyQuery,
+    epochs: KeyEpochs,
+  ): Promise<RawPayoutScripts> {
+    this.calls.push("getPayoutScriptsAtEpochs");
+    return {
+      vaultProvider: resolvePayoutScriptAtEpoch(
+        VAULT_PROVIDER,
+        epochs.vpKeyEpoch,
+      ),
+      vaultKeepers: query.vaultKeepers.map((pair) =>
+        resolvePayoutScriptAtEpoch(
+          operatorFor(KEEPERS, pair.ethAddress),
+          epochs.appKeeperKeyEpoch,
+        ),
+      ),
+    };
+  }
+}
+
+function operatorFor(
+  operators: OperatorHistory[],
+  adminAddress: Address,
+): OperatorHistory {
+  const found = operators.find((o) => o.adminAddress === adminAddress);
+  if (!found) throw new Error(`no fixture operator for ${adminAddress}`);
+  return found;
+}

--- a/packages/babylon-ts-sdk/src/tbv/core/services/participants/__tests__/resolveParticipantKeys.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/participants/__tests__/resolveParticipantKeys.test.ts
@@ -1,0 +1,240 @@
+import type { Address, Hex } from "viem";
+import { describe, expect, it } from "vitest";
+
+import {
+  resolveCurrentParticipantKeys,
+  resolveParticipantKeysAtEpochs,
+} from "../resolveParticipantKeys";
+import {
+  ADDRESSES,
+  EPOCH_AFTER_ROTATION,
+  EPOCH_GENESIS,
+  FakeOperationKeyReader,
+  KEYS,
+  buildQuery,
+  epochsAt,
+} from "./fixtures/rotation";
+
+describe("resolveParticipantKeysAtEpochs", () => {
+  it("resolves every participant to its genesis key at epoch 0", async () => {
+    // The proof that turning the flag on before anyone rotates is a no-op:
+    // epoch-aware resolution must reproduce the registration/roster keys
+    // byte-for-byte.
+    const result = await resolveParticipantKeysAtEpochs({
+      operationKeyReader: new FakeOperationKeyReader(),
+      query: buildQuery(),
+      epochs: epochsAt(EPOCH_GENESIS),
+    });
+
+    expect(result.vaultProvider.operationBtcPubkey).toBe(KEYS.vpGenesis);
+    expect(result.vaultProvider.rotated).toBe(false);
+    expect(result.vaultKeeperOperationKeysSorted).toEqual(
+      [KEYS.keeperAGenesis, KEYS.keeperBGenesis, KEYS.keeperCGenesis].sort(),
+    );
+    expect(result.universalChallengerOperationKeysSorted).toEqual(
+      [KEYS.challenger1Genesis, KEYS.challenger2Genesis].sort(),
+    );
+    expect(result.vaultKeepers.every((k) => !k.rotated)).toBe(true);
+  });
+
+  it("resolves rotated participants to their new keys after the rotation epoch", async () => {
+    const result = await resolveParticipantKeysAtEpochs({
+      operationKeyReader: new FakeOperationKeyReader(),
+      query: buildQuery(),
+      epochs: epochsAt(EPOCH_AFTER_ROTATION),
+    });
+
+    expect(result.vaultProvider.operationBtcPubkey).toBe(KEYS.vpRotated);
+    expect(result.vaultProvider.rotated).toBe(true);
+
+    const keeperB = result.vaultKeepers.find(
+      (k) => k.adminAddress === ADDRESSES.keeperB,
+    );
+    expect(keeperB?.operationBtcPubkey).toBe(KEYS.keeperBRotated);
+    expect(keeperB?.rotated).toBe(true);
+
+    // Keeper A never rotated and must be untouched by B's rotation.
+    const keeperA = result.vaultKeepers.find(
+      (k) => k.adminAddress === ADDRESSES.keeperA,
+    );
+    expect(keeperA?.operationBtcPubkey).toBe(KEYS.keeperAGenesis);
+    expect(keeperA?.rotated).toBe(false);
+  });
+
+  it("keeps each resolved key paired with its own admin address after a reorder", async () => {
+    // Keeper B's rotated key sorts ahead of its genesis, so the sorted array
+    // reorders between the two epochs while the roster order does not. The
+    // pairs must follow the operator, not the sort position — anything that
+    // index-joins a sorted array back to the roster breaks here.
+    const reader = new FakeOperationKeyReader();
+    const query = buildQuery();
+
+    const atGenesis = await resolveParticipantKeysAtEpochs({
+      operationKeyReader: reader,
+      query,
+      epochs: epochsAt(EPOCH_GENESIS),
+    });
+    const afterRotation = await resolveParticipantKeysAtEpochs({
+      operationKeyReader: reader,
+      query,
+      epochs: epochsAt(EPOCH_AFTER_ROTATION),
+    });
+
+    const positionOf = (keys: string[], key: string) => keys.indexOf(key);
+    expect(
+      positionOf(atGenesis.vaultKeeperOperationKeysSorted, KEYS.keeperBGenesis),
+    ).not.toBe(
+      positionOf(
+        afterRotation.vaultKeeperOperationKeysSorted,
+        KEYS.keeperBRotated,
+      ),
+    );
+
+    // Roster order is unchanged, and every pair still names its own operator.
+    expect(afterRotation.vaultKeepers.map((k) => k.adminAddress)).toEqual([
+      ADDRESSES.keeperA,
+      ADDRESSES.keeperB,
+      ADDRESSES.keeperC,
+    ]);
+    expect(
+      afterRotation.vaultKeepers.find(
+        (k) => k.adminAddress === ADDRESSES.keeperB,
+      )?.genesisBtcPubkey,
+    ).toBe(KEYS.keeperBGenesis);
+  });
+
+  it("rejects two participants resolving to the same operation key", async () => {
+    // Registration guarantees distinct registered keys, but nothing stops two
+    // operators rotating onto the same key. A duplicate would collapse the
+    // sorted script key set and silently build the wrong lock.
+    const reader = new FakeOperationKeyReader({
+      forceKey: new Map<Address, Hex>([
+        [ADDRESSES.keeperA, `0x${KEYS.keeperCGenesis}` as Hex],
+      ]),
+    });
+
+    await expect(
+      resolveParticipantKeysAtEpochs({
+        operationKeyReader: reader,
+        query: buildQuery(),
+        epochs: epochsAt(EPOCH_GENESIS),
+      }),
+    ).rejects.toThrow(/operation key collision/i);
+  });
+
+  it("rejects a keeper that rotated onto the vault provider's key", async () => {
+    const reader = new FakeOperationKeyReader({
+      forceKey: new Map<Address, Hex>([
+        [ADDRESSES.keeperA, `0x${KEYS.vpGenesis}` as Hex],
+      ]),
+    });
+
+    await expect(
+      resolveParticipantKeysAtEpochs({
+        operationKeyReader: reader,
+        query: buildQuery(),
+        epochs: epochsAt(EPOCH_GENESIS),
+      }),
+    ).rejects.toThrow(/operation key collision/i);
+  });
+
+  it("rejects a key that is not on the secp256k1 curve", async () => {
+    const reader = new FakeOperationKeyReader({
+      forceKey: new Map<Address, Hex>([
+        [ADDRESSES.keeperA, `0x${"ff".repeat(32)}` as Hex],
+      ]),
+    });
+
+    await expect(
+      resolveParticipantKeysAtEpochs({
+        operationKeyReader: reader,
+        query: buildQuery(),
+        epochs: epochsAt(EPOCH_GENESIS),
+      }),
+    ).rejects.toThrow(/secp256k1 curve/i);
+  });
+
+  it("rejects a zero-hash key rather than treating it as absent", async () => {
+    const reader = new FakeOperationKeyReader({
+      forceKey: new Map<Address, Hex>([
+        [ADDRESSES.keeperA, `0x${"00".repeat(32)}` as Hex],
+      ]),
+    });
+
+    await expect(
+      resolveParticipantKeysAtEpochs({
+        operationKeyReader: reader,
+        query: buildQuery(),
+        epochs: epochsAt(EPOCH_GENESIS),
+      }),
+    ).rejects.toThrow(/secp256k1 curve/i);
+  });
+
+  it("records the epochs it resolved against", async () => {
+    const result = await resolveParticipantKeysAtEpochs({
+      operationKeyReader: new FakeOperationKeyReader(),
+      query: buildQuery(),
+      epochs: epochsAt(EPOCH_AFTER_ROTATION),
+    });
+
+    expect(result.resolvedAt).toEqual({
+      mode: "epochs",
+      epochs: epochsAt(EPOCH_AFTER_ROTATION),
+    });
+  });
+});
+
+describe("resolveCurrentParticipantKeys", () => {
+  it("matches the latest epoch resolution without issuing an epoch read", async () => {
+    // The new-pegin and VP-auth paths use this, and must never touch the
+    // extended `getBtcVaultProtocolInfo` ABI to do so.
+    const currentReader = new FakeOperationKeyReader();
+    const current = await resolveCurrentParticipantKeys({
+      operationKeyReader: currentReader,
+      query: buildQuery(),
+    });
+
+    const atLatest = await resolveParticipantKeysAtEpochs({
+      operationKeyReader: new FakeOperationKeyReader(),
+      query: buildQuery(),
+      epochs: epochsAt(EPOCH_AFTER_ROTATION),
+    });
+
+    expect(current.vaultProvider.operationBtcPubkey).toBe(
+      atLatest.vaultProvider.operationBtcPubkey,
+    );
+    expect(current.vaultKeeperOperationKeysSorted).toEqual(
+      atLatest.vaultKeeperOperationKeysSorted,
+    );
+    expect(current.universalChallengerOperationKeysSorted).toEqual(
+      atLatest.universalChallengerOperationKeysSorted,
+    );
+
+    expect(currentReader.calls).toEqual(["getCurrentOperationKeys"]);
+    expect(currentReader.calls).not.toContain("getOperationKeysAtEpochs");
+    expect(current.resolvedAt).toEqual({ mode: "current" });
+  });
+
+  it("rejects a registry response whose length does not match the roster", async () => {
+    const shortReader = {
+      getCurrentOperationKeys: async () => ({
+        vaultProvider: `0x${KEYS.vpGenesis}` as Hex,
+        vaultKeepers: [`0x${KEYS.keeperAGenesis}` as Hex],
+        universalChallengers: [],
+      }),
+      getOperationKeysAtEpochs: async () => {
+        throw new Error("unused");
+      },
+      getPayoutScriptsAtEpochs: async () => {
+        throw new Error("unused");
+      },
+    };
+
+    await expect(
+      resolveCurrentParticipantKeys({
+        operationKeyReader: shortReader,
+        query: buildQuery(),
+      }),
+    ).rejects.toThrow(/for a roster of/i);
+  });
+});

--- a/packages/babylon-ts-sdk/src/tbv/core/services/participants/__tests__/resolveParticipantKeys.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/participants/__tests__/resolveParticipantKeys.test.ts
@@ -17,9 +17,8 @@ import {
 
 describe("resolveParticipantKeysAtEpochs", () => {
   it("resolves every participant to its genesis key at epoch 0", async () => {
-    // The proof that turning the flag on before anyone rotates is a no-op:
-    // epoch-aware resolution must reproduce the registration/roster keys
-    // byte-for-byte.
+    // The proof that epoch-aware resolution is a no-op before anyone rotates:
+    // it must reproduce the registration/roster keys byte-for-byte.
     const result = await resolveParticipantKeysAtEpochs({
       operationKeyReader: new FakeOperationKeyReader(),
       query: buildQuery(),

--- a/packages/babylon-ts-sdk/src/tbv/core/services/participants/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/participants/index.ts
@@ -1,0 +1,15 @@
+/**
+ * RFC-006 participant operation-key resolution.
+ *
+ * @module services/participants
+ */
+
+export {
+  resolveCurrentParticipantKeys,
+  resolveParticipantKeysAtEpochs,
+} from "./resolveParticipantKeys";
+export type {
+  KeyResolutionMode,
+  ParticipantKeySet,
+  ResolvedParticipant,
+} from "./types";

--- a/packages/babylon-ts-sdk/src/tbv/core/services/participants/resolveParticipantKeys.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/participants/resolveParticipantKeys.ts
@@ -1,0 +1,178 @@
+/**
+ * RFC-006 participant operation-key resolution.
+ *
+ * Under RFC-006 an operator's BTC key is no longer fixed at registration: it
+ * is an append-only history of *operation* keys, rotated by the operator's
+ * cold ETH admin key. Every consumer that needs "the key this participant
+ * signs with" must resolve it, in one of two modes:
+ *
+ * - **current** — for a peg-in being built now, and for the VP auth pin.
+ *   Needs no epoch read; each registry resolves its own genesis fallback, so
+ *   an operator that never rotated yields its registration key.
+ * - **at epochs** — for any vault that already exists. The vault froze its
+ *   epochs at `submitPeginRequest`, and resolving against them is what keeps
+ *   an old vault signable after a later rotation.
+ *
+ * Both modes go through the same `finalize` pass, which is where the
+ * rotation-specific safety checks live.
+ *
+ * @module services/participants/resolveParticipantKeys
+ */
+
+import { assertOnChainBtcPubkey } from "../../clients/eth/onChainBtcPubkey";
+import type {
+  KeyEpochs,
+  OperationKeyQuery,
+  OperationKeyReader,
+  RawOperationKeys,
+} from "../../clients/eth/types";
+import type {
+  KeyResolutionMode,
+  ParticipantKeySet,
+  ResolvedParticipant,
+} from "./types";
+
+/** Role label used in validation error messages. */
+type Role = "vault provider" | "vault keeper" | "universal challenger";
+
+function resolveOne(
+  role: Role,
+  rosterEntry: { ethAddress: `0x${string}`; btcPubKey: `0x${string}` },
+  rawOperationKey: `0x${string}`,
+): ResolvedParticipant {
+  const label = `${role} operation key (admin=${rosterEntry.ethAddress})`;
+  const genesisBtcPubkey = assertOnChainBtcPubkey(
+    rosterEntry.btcPubKey,
+    `${role} roster key (admin=${rosterEntry.ethAddress})`,
+  );
+  const operationBtcPubkey = assertOnChainBtcPubkey(rawOperationKey, label);
+
+  return {
+    adminAddress: rosterEntry.ethAddress,
+    genesisBtcPubkey,
+    operationBtcPubkey,
+    rotated: operationBtcPubkey !== genesisBtcPubkey,
+  };
+}
+
+/**
+ * Assert no two participants resolved to the same operation key.
+ *
+ * Registration-time checks guarantee distinctness across the *registered*
+ * keys, but nothing on-chain prevents two operators from rotating onto the
+ * same key, or a keeper from rotating onto the VP's key. A duplicate would
+ * collapse two entries in the sorted script key set and silently build a lock
+ * with the wrong participant count, so it is rejected here — before any script
+ * is constructed — rather than surfacing as a confusing signature mismatch
+ * much later.
+ */
+function assertDistinctOperationKeys(
+  participants: ResolvedParticipant[],
+): void {
+  const seen = new Map<string, string>();
+  for (const participant of participants) {
+    const previousOwner = seen.get(participant.operationBtcPubkey);
+    if (previousOwner) {
+      throw new Error(
+        `Participant operation key collision: ${previousOwner} and ` +
+          `${participant.adminAddress} both resolve to operation key ` +
+          `${participant.operationBtcPubkey}`,
+      );
+    }
+    seen.set(participant.operationBtcPubkey, participant.adminAddress);
+  }
+}
+
+function finalize(
+  query: OperationKeyQuery,
+  raw: RawOperationKeys,
+  resolvedAt: KeyResolutionMode,
+): ParticipantKeySet {
+  if (
+    raw.vaultKeepers.length !== query.vaultKeepers.length ||
+    raw.universalChallengers.length !== query.universalChallengers.length
+  ) {
+    throw new Error(
+      `Operation-key resolution returned ${raw.vaultKeepers.length} keeper and ` +
+        `${raw.universalChallengers.length} challenger keys for a roster of ` +
+        `${query.vaultKeepers.length} keepers and ` +
+        `${query.universalChallengers.length} challengers`,
+    );
+  }
+
+  const vaultProvider = resolveOne(
+    "vault provider",
+    {
+      ethAddress: query.vaultProviderEthAddress,
+      btcPubKey: query.vaultProviderGenesisBtcPubkey,
+    },
+    raw.vaultProvider,
+  );
+
+  const vaultKeepers = query.vaultKeepers.map((keeper, i) =>
+    resolveOne("vault keeper", keeper, raw.vaultKeepers[i]),
+  );
+  const universalChallengers = query.universalChallengers.map((challenger, i) =>
+    resolveOne("universal challenger", challenger, raw.universalChallengers[i]),
+  );
+
+  assertDistinctOperationKeys([
+    vaultProvider,
+    ...vaultKeepers,
+    ...universalChallengers,
+  ]);
+
+  return {
+    vaultProvider,
+    vaultKeepers,
+    universalChallengers,
+    // Derived from the pairs, never the reverse — see ParticipantKeySet.
+    vaultKeeperOperationKeysSorted: vaultKeepers
+      .map((p) => p.operationBtcPubkey as string)
+      .sort(),
+    universalChallengerOperationKeysSorted: universalChallengers
+      .map((p) => p.operationBtcPubkey as string)
+      .sort(),
+    resolvedAt,
+    query,
+  };
+}
+
+/**
+ * Resolve every participant's *current* operation key.
+ *
+ * Use for a peg-in being built now. Issues no epoch read, so it never touches
+ * the extended `getBtcVaultProtocolInfo` ABI.
+ */
+export async function resolveCurrentParticipantKeys(params: {
+  operationKeyReader: OperationKeyReader;
+  query: OperationKeyQuery;
+}): Promise<ParticipantKeySet> {
+  const raw = await params.operationKeyReader.getCurrentOperationKeys(
+    params.query,
+  );
+  return finalize(params.query, raw, { mode: "current" });
+}
+
+/**
+ * Resolve every participant's operation key bonded at a vault's frozen epochs.
+ *
+ * Use for every existing-vault path: resume, payout signing, refund. The
+ * rosters in `query` must be read at the vault's frozen *membership* versions,
+ * because those roster keys are the genesis the keeper/challenger getters fall
+ * back to.
+ */
+export async function resolveParticipantKeysAtEpochs(params: {
+  operationKeyReader: OperationKeyReader;
+  query: OperationKeyQuery;
+  epochs: KeyEpochs;
+}): Promise<ParticipantKeySet> {
+  const raw = await params.operationKeyReader.getOperationKeysAtEpochs(
+    params.query,
+    params.epochs,
+  );
+  return finalize(params.query, raw, {
+    mode: "epochs",
+    epochs: params.epochs,
+  });
+}

--- a/packages/babylon-ts-sdk/src/tbv/core/services/participants/resolveParticipantKeys.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/participants/resolveParticipantKeys.ts
@@ -58,13 +58,20 @@ function resolveOne(
 /**
  * Assert no two participants resolved to the same operation key.
  *
- * Registration-time checks guarantee distinctness across the *registered*
- * keys, but nothing on-chain prevents two operators from rotating onto the
- * same key, or a keeper from rotating onto the VP's key. A duplicate would
- * collapse two entries in the sorted script key set and silently build a lock
- * with the wrong participant count, so it is rejected here — before any script
- * is constructed — rather than surfacing as a confusing signature mismatch
- * much later.
+ * The on-chain guarantees are narrower than "registration keys are distinct",
+ * and narrower than an earlier revision of this comment claimed. Each registry
+ * enforces uniqueness *within its own role*, on rotation as well as
+ * registration, and a VP rotation additionally rejects any key held in the
+ * current vault-keeper or universal-challenger rosters.
+ *
+ * What no contract checks is the cross-role direction those rules leave open:
+ * a keeper or challenger rotating **onto** the VP's key (the VP-side check runs
+ * at VP rotation time and does not run again when a keeper moves), a keeper and
+ * a challenger colliding with each other, and keepers of different applications
+ * colliding. Any of those would collapse two entries in the sorted script key
+ * set and silently build a lock with the wrong participant count, so they are
+ * rejected here — before any script is constructed — rather than surfacing as a
+ * confusing signature mismatch much later.
  */
 function assertDistinctOperationKeys(
   participants: ResolvedParticipant[],

--- a/packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts
@@ -1,0 +1,72 @@
+/**
+ * Types for RFC-006 participant operation-key resolution.
+ *
+ * @module services/participants/types
+ */
+
+import type { Address } from "viem";
+
+import type {
+  KeyEpochs,
+  OnChainBtcPubkey,
+  OperationKeyQuery,
+} from "../../clients/eth/types";
+
+/** One operator's resolved identity: who it is, and which key it signs with. */
+export interface ResolvedParticipant {
+  /**
+   * The operator's admin ETH address — its stable identity and the lookup key
+   * for its operation-key history. This is the roster entry's `ethAddress`.
+   */
+  adminAddress: Address;
+  /**
+   * The operator's genesis BTC key: its roster entry / registration key.
+   * x-only, lowercase, no `0x`. Retained because indexer hints are still
+   * expressed in these, and because a keeper's genesis is the fallback the
+   * `...OrGenesis` getters resolve to.
+   */
+  genesisBtcPubkey: OnChainBtcPubkey;
+  /**
+   * The operation key this resolution produced — the key that actually goes
+   * into the Bitcoin scripts. Equals `genesisBtcPubkey` until the operator
+   * rotates.
+   */
+  operationBtcPubkey: OnChainBtcPubkey;
+  /** Whether the operation key differs from the genesis key. */
+  rotated: boolean;
+}
+
+/** How a {@link ParticipantKeySet} was resolved. Carried for diagnostics. */
+export type KeyResolutionMode =
+  | { mode: "current" }
+  | { mode: "epochs"; epochs: KeyEpochs };
+
+/**
+ * Every participant's resolved operation key for one vault (or one about to be
+ * created).
+ *
+ * The pairs are the source of truth; the sorted arrays are derived from them.
+ * Never invert that. Rotation changes a key, and therefore changes where it
+ * lands in the lexicographic sort, so an index-join from a sorted array back
+ * to a roster entry is wrong the moment anyone rotates.
+ */
+export interface ParticipantKeySet {
+  vaultProvider: ResolvedParticipant;
+  vaultKeepers: ResolvedParticipant[];
+  universalChallengers: ResolvedParticipant[];
+  /** Sorted keeper operation keys — what script construction consumes. */
+  vaultKeeperOperationKeysSorted: string[];
+  /** Sorted challenger operation keys — what script construction consumes. */
+  universalChallengerOperationKeysSorted: string[];
+  /** Provenance of this resolution. */
+  resolvedAt: KeyResolutionMode;
+  /**
+   * The rosters and addresses this set was resolved against.
+   *
+   * Carried so a later re-resolution — notably the post-registration
+   * read-after-mine check — reuses the *same* roster rather than re-deriving
+   * one that may since have moved, which would report a roster drift as a key
+   * drift.
+   */
+  query: OperationKeyQuery;
+}

--- a/services/vault/src/clients/eth-contract/__tests__/sdk-readers.test.ts
+++ b/services/vault/src/clients/eth-contract/__tests__/sdk-readers.test.ts
@@ -23,6 +23,7 @@ const mockProtocolParamsReaderCtor = vi.fn();
 const mockVaultKeeperReaderCtor = vi.fn();
 const mockUniversalChallengerReaderCtor = vi.fn();
 const mockVaultRegistryReaderCtor = vi.fn();
+const mockOperationKeyReaderCtor = vi.fn();
 
 vi.mock("@babylonlabs-io/ts-sdk/tbv/core/clients", () => {
   // Constructable classes must be declared inside the factory because
@@ -59,6 +60,14 @@ vi.mock("@babylonlabs-io/ts-sdk/tbv/core/clients", () => {
       this.args = args;
     }
   }
+  class MockOperationKeyReader {
+    args: unknown[];
+    kind = "operation-key" as const;
+    constructor(...args: unknown[]) {
+      mockOperationKeyReaderCtor(...args);
+      this.args = args;
+    }
+  }
 
   return {
     resolveProtocolAddresses: (...args: unknown[]) =>
@@ -67,6 +76,7 @@ vi.mock("@babylonlabs-io/ts-sdk/tbv/core/clients", () => {
     ViemVaultKeeperReader: MockVaultKeeperReader,
     ViemUniversalChallengerReader: MockUniversalChallengerReader,
     ViemVaultRegistryReader: MockVaultRegistryReader,
+    ViemOperationKeyReader: MockOperationKeyReader,
   };
 });
 

--- a/services/vault/src/clients/eth-contract/btc-vault-registry/query.ts
+++ b/services/vault/src/clients/eth-contract/btc-vault-registry/query.ts
@@ -103,7 +103,8 @@ export async function getVaultFromChain(
  * of those depend on the registry having been upgraded. See
  * `BTCVaultRegistryKeyEpochs.abi.ts`.
  *
- * Only call once the capability check has passed.
+ * Only valid against an RFC-006 registry: on an older one it returns plausible
+ * garbage rather than throwing.
  */
 export async function getVaultKeyEpochsFromChain(
   vaultId: Hex,

--- a/services/vault/src/clients/eth-contract/btc-vault-registry/query.ts
+++ b/services/vault/src/clients/eth-contract/btc-vault-registry/query.ts
@@ -7,6 +7,7 @@
  */
 
 import { assertValidVaultCoreVersion } from "@babylonlabs-io/ts-sdk/tbv/core";
+import type { KeyEpochs } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
 import { type Address, type Hex, zeroAddress } from "viem";
 
 import { getVaultRegistryReader } from "../sdk-readers";
@@ -90,6 +91,24 @@ export async function getVaultFromChain(
     vaultProviderCommissionBps: Number(protocol.vaultProviderCommissionBps),
     status: basic.status,
   };
+}
+
+/**
+ * Read a vault's frozen RFC-006 operation-key epochs.
+ *
+ * Deliberately a **separate** read from {@link getVaultFromChain} rather than
+ * three more fields on `OnChainVaultData`. It goes through the extended
+ * `getBtcVaultProtocolInfo` ABI, and `getVaultFromChain` is on the status,
+ * resume, refund and payout paths — folding the epochs into it would make all
+ * of those depend on the registry having been upgraded. See
+ * `BTCVaultRegistryKeyEpochs.abi.ts`.
+ *
+ * Only call once the capability check has passed.
+ */
+export async function getVaultKeyEpochsFromChain(
+  vaultId: Hex,
+): Promise<KeyEpochs> {
+  return getVaultRegistryReader().getVaultKeyEpochs(vaultId);
 }
 
 /**

--- a/services/vault/src/clients/eth-contract/sdk-readers.ts
+++ b/services/vault/src/clients/eth-contract/sdk-readers.ts
@@ -161,9 +161,9 @@ export async function getUniversalChallengerReader(): Promise<ViemUniversalChall
 /**
  * Get the RFC-006 operation-key reader (contract-based).
  *
- * Only call on the epoch-aware path — the flag must be on and the capability
- * check must have passed. Against a registry that predates RFC-006 these
- * getters do not exist and every call reverts on selector mismatch.
+ * Only valid against an RFC-006 registry: on one that predates RFC-006 these
+ * getters do not exist and every call reverts on selector mismatch. Unlike the
+ * extended `getBtcVaultProtocolInfo` read, that failure is loud.
  */
 export async function getOperationKeyReader(): Promise<ViemOperationKeyReader> {
   return (await getResolvedReaders()).operationKeyReader;

--- a/services/vault/src/clients/eth-contract/sdk-readers.ts
+++ b/services/vault/src/clients/eth-contract/sdk-readers.ts
@@ -11,6 +11,7 @@
 
 import {
   resolveProtocolAddresses,
+  ViemOperationKeyReader,
   ViemProtocolParamsReader,
   ViemUniversalChallengerReader,
   ViemVaultKeeperReader,
@@ -34,6 +35,7 @@ interface ResolvedReaders {
   protocolParamsReader: ViemProtocolParamsReader;
   vaultKeeperReader: ViemVaultKeeperReader;
   universalChallengerReader: ViemUniversalChallengerReader;
+  operationKeyReader: ViemOperationKeyReader;
   fetchedAt: number;
 }
 
@@ -88,6 +90,15 @@ async function getResolvedReaders(): Promise<ResolvedReaders> {
           publicClient,
           addresses.protocolParams,
         ),
+        // RFC-006 operation-key resolution spans all three registries, so it
+        // is built here alongside the others rather than constructed ad hoc —
+        // it needs the same resolved ProtocolParams / ApplicationRegistry
+        // addresses.
+        operationKeyReader: new ViemOperationKeyReader(publicClient, {
+          btcVaultRegistry: CONTRACTS.BTC_VAULT_REGISTRY,
+          applicationRegistry: addresses.applicationRegistry,
+          protocolParams: addresses.protocolParams,
+        }),
         fetchedAt: Date.now(),
       };
 
@@ -145,6 +156,17 @@ export async function getVaultKeeperReader(): Promise<ViemVaultKeeperReader> {
  */
 export async function getUniversalChallengerReader(): Promise<ViemUniversalChallengerReader> {
   return (await getResolvedReaders()).universalChallengerReader;
+}
+
+/**
+ * Get the RFC-006 operation-key reader (contract-based).
+ *
+ * Only call on the epoch-aware path — the flag must be on and the capability
+ * check must have passed. Against a registry that predates RFC-006 these
+ * getters do not exist and every call reverts on selector mismatch.
+ */
+export async function getOperationKeyReader(): Promise<ViemOperationKeyReader> {
+  return (await getResolvedReaders()).operationKeyReader;
 }
 
 /**

--- a/services/vault/src/components/simple/ResumeDepositContent.tsx
+++ b/services/vault/src/components/simple/ResumeDepositContent.tsx
@@ -57,6 +57,7 @@ import {
   ContractStatus,
   getPeginDisplayStep,
 } from "@/models/peginStateMachine";
+import { resolveVpAuthPinnedPubkey } from "@/services/vault/vpAuthPinnedPubkey";
 import type { VaultActivity } from "@/types/activity";
 import {
   shouldProbeWalletLiveness,
@@ -355,15 +356,15 @@ export function ResumeWotsContent({
 
       // Best-effort priming: VP pubkey fetch can fail without blocking the
       // resume flow because submitWotsPublicKey re-derives on cache miss.
-      const pinnedServerPubkeyPromise = reader
-        .getVaultProviderBtcPubKey(providerAddress as Address)
-        .catch((err: unknown) => {
-          logger.warn("Failed to fetch VP pubkey for registry priming", {
-            peginTxHash,
-            error: err instanceof Error ? err.message : String(err),
-          });
-          return null;
+      const pinnedServerPubkeyPromise = resolveVpAuthPinnedPubkey(
+        providerAddress as Address,
+      ).catch((err: unknown) => {
+        logger.warn("Failed to fetch VP pubkey for registry priming", {
+          peginTxHash,
+          error: err instanceof Error ? err.message : String(err),
         });
+        return null;
+      });
 
       // Indexer-supplied tx is untrusted. Verify against on-chain
       // prePeginTxHash before deriveVaultRoot fires the wallet popup.

--- a/services/vault/src/components/simple/__tests__/ResumeDepositContent.test.tsx
+++ b/services/vault/src/components/simple/__tests__/ResumeDepositContent.test.tsx
@@ -50,6 +50,7 @@ vi.mock("@babylonlabs-io/ts-sdk/tbv/core", () => ({
   hexToUint8Array: vi.fn(() => new Uint8Array(32)),
   isWotsMismatchError: vi.fn(() => false),
   isRegisteredVaultVersionMismatchError: vi.fn(() => false),
+  isParticipantKeyDriftError: vi.fn(() => false),
   parseFundingOutpointsFromTx: mockParseFundingOutpointsFromTx,
   stripHexPrefix: vi.fn((hex: string) => hex.replace(/^0x/, "")),
   uint8ArrayToHex: vi.fn(() => "00".repeat(32)),

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -739,6 +739,10 @@ export const COPY = {
         title: "Protocol parameters changed",
         body: "The protocol parameters changed while preparing your deposit. Please restart the deposit.",
       },
+      participantKeyDrift: {
+        title: "Vault operator keys changed",
+        body: "A vault operator rotated its Bitcoin key while your deposit was being registered, so the registered vault no longer matches the transaction we prepared. Your Pre-PegIn was not broadcast and no Bitcoin was spent. The registered vault will time out on its own — please start a new deposit.",
+      },
       wrongWalletAccount: {
         title: "Wrong wallet account",
         body: WRONG_WALLET_BODY,

--- a/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
@@ -40,6 +40,7 @@ vi.mock("@/clients/eth-contract/sdk-readers", () => ({
   })),
   getVaultKeeperReader: vi.fn(async () => ({})),
   getUniversalChallengerReader: vi.fn(async () => ({})),
+  getOperationKeyReader: vi.fn(async () => ({})),
 }));
 
 vi.mock("@babylonlabs-io/wallet-connector", () => ({
@@ -172,8 +173,15 @@ vi.mock("@babylonlabs-io/ts-sdk/tbv/core", async (importOriginal) => ({
     universalChallengerBtcPubkeysSorted: ["uc1pubkey"],
     expectedAppVaultKeepersVersion: 3,
     expectedUniversalChallengersVersion: 5,
+    participantKeys: {
+      vaultProvider: { operationBtcPubkey: "ab".repeat(32) },
+      vaultKeepers: [{ operationBtcPubkey: "keeper1pubkey" }],
+      vaultKeeperOperationKeysSorted: ["keeper1pubkey"],
+      universalChallengerOperationKeysSorted: ["uc1pubkey"],
+    },
   }),
   verifyRegisteredVaultVersions: vi.fn().mockResolvedValue(undefined),
+  verifyRegisteredParticipantKeys: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("../depositFlowSteps", async () => {

--- a/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
+++ b/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
@@ -33,9 +33,16 @@ vi.mock("@/hooks/useProtocolGate", () => ({
 
 vi.mock("@/config/network", () => ({
   getETHChain: vi.fn(() => ({ id: 11155111 })),
-  // Reached transitively: the resume broadcast's RFC-006 capability probe
-  // pulls in the shared ETHClient, which reads the RPC config at construction.
+  // Reached transitively: the resume broadcast's RFC-006 key resolution pulls
+  // in the shared ETHClient, which reads the RPC config at construction.
   getNetworkConfigETH: vi.fn(() => ({ rpcUrl: "http://localhost:8545" })),
+}));
+
+const mockVerifyResumeParticipantKeys = vi.hoisted(() =>
+  vi.fn().mockResolvedValue(undefined),
+);
+vi.mock("@/services/vault/verifyResumeParticipantKeys", () => ({
+  verifyResumeParticipantKeys: mockVerifyResumeParticipantKeys,
 }));
 
 // `captureFunnelFailure` reaches the logger through this barrel, so mocking it
@@ -245,6 +252,7 @@ describe("useVaultActions — handleBroadcast transaction integrity", () => {
     mockGetVaultRegistryReader.mockReturnValue({
       getProtocolInfoBatch: makeMatchingProtocolInfoBatch(),
     } as unknown as ReturnType<typeof getVaultRegistryReader>);
+    mockVerifyResumeParticipantKeys.mockResolvedValue(undefined);
   });
 
   it("broadcasts using local tx when it matches GraphQL", async () => {
@@ -754,6 +762,69 @@ describe("useVaultActions — handleBroadcast version drift guard", () => {
     expect(result.current.broadcastError).toContain("eth_call failed");
     expect(removePendingPegin).not.toHaveBeenCalled();
     expect(mockBroadcastPrePeginTransaction).not.toHaveBeenCalled();
+  });
+
+  // The key stamp is the guard's only real precondition. A record that carries
+  // the stamp but predates the build-version fields must still be checked —
+  // the versions say nothing about whether an operator rotated.
+  it("runs the RFC-006 key guard when the stamp is present but build versions are missing", async () => {
+    const { result } = renderHook(() => useVaultActions());
+
+    await act(async () => {
+      await result.current.handleBroadcast({
+        ...baseBroadcastParams,
+        pendingPegin: {
+          ...basePendingPegin,
+          buildOffchainParamsVersion: undefined,
+          buildAppVaultKeepersVersion: undefined,
+          buildUniversalChallengersVersion: undefined,
+          buildParticipantOperationKeys: {
+            vaultProvider: "aa".repeat(32),
+            vaultKeepers: ["bb".repeat(32)],
+            universalChallengers: ["cc".repeat(32)],
+          },
+        },
+      });
+    });
+
+    expect(mockVerifyResumeParticipantKeys).toHaveBeenCalledTimes(1);
+    expect(result.current.broadcastError).toBeNull();
+    expect(mockBroadcastPrePeginTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  // Key drift must NOT clear the entry. The stamp it holds is the only thing
+  // that makes this guard re-fire; without it the next attempt finds no local
+  // copy, falls back to the indexer's transaction, passes the prePeginTxHash
+  // check — it is the registered transaction — and broadcasts the Pre-PegIn
+  // this just refused, locking BTC until the refund timelock.
+  it("keeps the pending entry when the RFC-006 key guard reports drift", async () => {
+    const drift = new Error(
+      "Aborting Pre-PegIn broadcast: the vault keeper set changed since this deposit was built",
+    );
+    drift.name = "ParticipantKeyDriftError";
+    mockVerifyResumeParticipantKeys.mockRejectedValue(drift);
+
+    const removePendingPegin = vi.fn();
+    const { result } = renderHook(() => useVaultActions());
+
+    await act(async () => {
+      await result.current.handleBroadcast({
+        ...baseBroadcastParams,
+        pendingPegin: {
+          ...basePendingPegin,
+          buildParticipantOperationKeys: {
+            vaultProvider: "aa".repeat(32),
+            vaultKeepers: ["bb".repeat(32)],
+            universalChallengers: ["cc".repeat(32)],
+          },
+        },
+        removePendingPegin,
+      });
+    });
+
+    expect(removePendingPegin).not.toHaveBeenCalled();
+    expect(mockBroadcastPrePeginTransaction).not.toHaveBeenCalled();
+    expect(result.current.broadcastError).toBeTruthy();
   });
 });
 

--- a/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
+++ b/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
@@ -33,6 +33,9 @@ vi.mock("@/hooks/useProtocolGate", () => ({
 
 vi.mock("@/config/network", () => ({
   getETHChain: vi.fn(() => ({ id: 11155111 })),
+  // Reached transitively: the resume broadcast's RFC-006 capability probe
+  // pulls in the shared ETHClient, which reads the RPC config at construction.
+  getNetworkConfigETH: vi.fn(() => ({ rpcUrl: "http://localhost:8545" })),
 }));
 
 // `captureFunnelFailure` reaches the logger through this barrel, so mocking it

--- a/services/vault/src/hooks/deposit/depositFlowSteps/__tests__/ensureAuthenticatedVpClient.test.ts
+++ b/services/vault/src/hooks/deposit/depositFlowSteps/__tests__/ensureAuthenticatedVpClient.test.ts
@@ -19,7 +19,7 @@ const mockGetVaultProviderBtcPubKey = vi.fn();
 const mockGetVaultProtocolInfo = vi.fn();
 vi.mock("@/clients/eth-contract/sdk-readers", () => ({
   getVaultRegistryReader: () => ({
-    getVaultProviderBtcPubKey: mockGetVaultProviderBtcPubKey,
+    getCurrentVaultProviderOperationBtcKey: mockGetVaultProviderBtcPubKey,
     getVaultProtocolInfo: mockGetVaultProtocolInfo,
   }),
 }));

--- a/services/vault/src/hooks/deposit/depositFlowSteps/ensureAuthenticatedVpClient.ts
+++ b/services/vault/src/hooks/deposit/depositFlowSteps/ensureAuthenticatedVpClient.ts
@@ -28,6 +28,7 @@ import { calculateBtcTxHash } from "@babylonlabs-io/ts-sdk/tbv/core/utils";
 import type { Address, Hex } from "viem";
 
 import { getVaultRegistryReader } from "@/clients/eth-contract/sdk-readers";
+import { resolveVpAuthPinnedPubkey } from "@/services/vault/vpAuthPinnedPubkey";
 import { getVpProxyUrl } from "@/utils/rpc";
 
 export interface EnsureAuthenticatedVpClientParams {
@@ -90,7 +91,7 @@ export async function ensureAuthenticatedVpClient(
     root.fill(0);
     root = null;
 
-    const pinnedServerPubkey = await reader.getVaultProviderBtcPubKey(
+    const pinnedServerPubkey = await resolveVpAuthPinnedPubkey(
       params.providerAddress as Address,
     );
 

--- a/services/vault/src/hooks/deposit/useDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useDepositFlow.ts
@@ -19,6 +19,7 @@ import {
   isRegisteredVaultVersionMismatchError,
   stripHexPrefix,
   validateOnChainParticipantKeys,
+  verifyRegisteredParticipantKeys,
   verifyRegisteredVaultVersions,
   type DepositTermsApprover,
 } from "@babylonlabs-io/ts-sdk/tbv/core";
@@ -35,6 +36,7 @@ import { v4 as uuidv4 } from "uuid";
 import type { Address, Hex } from "viem";
 
 import {
+  getOperationKeyReader,
   getUniversalChallengerReader,
   getVaultKeeperReader,
   getVaultRegistryReader,
@@ -63,6 +65,7 @@ import {
   type PeginSigningProgress,
 } from "@/services/vault/vaultTransactionService";
 import { assertUtxosAvailable } from "@/services/vault/vaultUtxoValidationService";
+import { resolveVpAuthPinnedPubkey } from "@/services/vault/vpAuthPinnedPubkey";
 import {
   addPendingPegin,
   removePendingPegin,
@@ -492,20 +495,26 @@ export function useDepositFlow(
         // — both register, only one Pre-PegIn can broadcast, the other
         // strands until expiry.
 
-        const [vaultKeeperReader, universalChallengerReader] =
-          await Promise.all([
-            getVaultKeeperReader(),
-            getUniversalChallengerReader(),
-          ]);
+        const [
+          vaultKeeperReader,
+          universalChallengerReader,
+          operationKeyReader,
+        ] = await Promise.all([
+          getVaultKeeperReader(),
+          getUniversalChallengerReader(),
+          getOperationKeyReader(),
+        ]);
         const validatedKeys = await validateOnChainParticipantKeys({
           vaultRegistryReader: getVaultRegistryReader(),
           vaultKeeperReader,
           universalChallengerReader,
+          operationKeyReader,
           vaultProviderEthAddress: selectedProviders[0] as Address,
           applicationEntryPoint: selectedApplication as Address,
           expectedVaultProviderBtcPubkey: vaultProviderBtcPubkey,
           expectedVaultKeeperBtcPubkeys: vaultKeeperBtcPubkeys,
           expectedUniversalChallengerBtcPubkeys: universalChallengerBtcPubkeys,
+          onIndexerServingOperationKeys: (message) => logger.info(message),
         });
 
         // Prime the peg-in signing sub-counter (one tx per vault) before the
@@ -695,6 +704,14 @@ export function useDepositFlow(
             buildUniversalChallengersVersion:
               validatedKeys.expectedUniversalChallengersVersion,
             buildVaultCoreVersion: config.activeVaultCoreVersion,
+            // RFC-006: pin the keys the scripts were actually built with, so a
+            // rotation landing before a later resume can't be broadcast over.
+            buildParticipantOperationKeys: {
+              vaultProvider: validatedKeys.vaultProviderBtcPubkeyXOnly,
+              vaultKeepers: validatedKeys.vaultKeeperBtcPubkeysSorted,
+              universalChallengers:
+                validatedKeys.universalChallengerBtcPubkeysSorted,
+            },
           };
           // Persist the resume record. A localStorage failure (quota /
           // private browsing) must NOT abort: the vault is already
@@ -737,6 +754,22 @@ export function useDepositFlow(
             expectedUniversalChallengersVersion:
               validatedKeys.expectedUniversalChallengersVersion,
             expectedVaultCoreVersion: config.activeVaultCoreVersion,
+          });
+
+          // RFC-006 read-after-mine. The vault froze its key epochs when
+          // `submitPeginRequest` executed, so an operator rotating between our
+          // key read and that execution would leave the registered vault bonded
+          // to keys other than the ones baked into the Pre-PegIn we are about to
+          // broadcast. Re-resolve against the frozen epochs and fail closed.
+          //
+          // Runs after the version check on purpose: a version mismatch has the
+          // clearer message, and re-resolving against an already-drifted roster
+          // version would report a key diff caused by a version diff.
+          await verifyRegisteredParticipantKeys({
+            vaultRegistryReader: getVaultRegistryReader(),
+            operationKeyReader,
+            vaultIds: batchRegistration.vaults.map((v) => v.vaultId as Hex),
+            expected: validatedKeys.participantKeys,
           });
         } catch (err) {
           // Only a confirmed mismatch removes pending entries — transient RPC
@@ -827,10 +860,9 @@ export function useDepositFlow(
         // the pubkey once and seed each per-vault registry entry.
         const vpBaseUrl = getVpProxyUrl(provider.id);
         try {
-          const pinnedServerPubkey =
-            await getVaultRegistryReader().getVaultProviderBtcPubKey(
-              provider.id as Address,
-            );
+          const pinnedServerPubkey = await resolveVpAuthPinnedPubkey(
+            provider.id as Address,
+          );
           for (const r of broadcastedResults) {
             const peginTxid = stripHexPrefix(r.peginTxHash);
             primeVpTokenRegistry({

--- a/services/vault/src/hooks/deposit/useDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useDepositFlow.ts
@@ -515,6 +515,13 @@ export function useDepositFlow(
           expectedVaultKeeperBtcPubkeys: vaultKeeperBtcPubkeys,
           expectedUniversalChallengerBtcPubkeys: universalChallengerBtcPubkeys,
           onIndexerServingOperationKeys: (message) => logger.info(message),
+          onIndexerHintsInconsistent: (message) =>
+            logger.error(new Error(message), {
+              tags: {
+                component: "useDepositFlow",
+                phase: "validate-participant-keys",
+              },
+            }),
         });
 
         // Prime the peg-in signing sub-counter (one tx per vault) before the
@@ -755,22 +762,6 @@ export function useDepositFlow(
               validatedKeys.expectedUniversalChallengersVersion,
             expectedVaultCoreVersion: config.activeVaultCoreVersion,
           });
-
-          // RFC-006 read-after-mine. The vault froze its key epochs when
-          // `submitPeginRequest` executed, so an operator rotating between our
-          // key read and that execution would leave the registered vault bonded
-          // to keys other than the ones baked into the Pre-PegIn we are about to
-          // broadcast. Re-resolve against the frozen epochs and fail closed.
-          //
-          // Runs after the version check on purpose: a version mismatch has the
-          // clearer message, and re-resolving against an already-drifted roster
-          // version would report a key diff caused by a version diff.
-          await verifyRegisteredParticipantKeys({
-            vaultRegistryReader: getVaultRegistryReader(),
-            operationKeyReader,
-            vaultIds: batchRegistration.vaults.map((v) => v.vaultId as Hex),
-            expected: validatedKeys.participantKeys,
-          });
         } catch (err) {
           // Only a confirmed mismatch removes pending entries — transient RPC
           // failures keep them so the user can resume.
@@ -781,6 +772,28 @@ export function useDepositFlow(
           }
           throw err;
         }
+
+        // RFC-006 read-after-mine. The vault froze its key epochs when
+        // `submitPeginRequest` executed, so an operator rotating between our
+        // key read and that execution would leave the registered vault bonded
+        // to keys other than the ones baked into the Pre-PegIn we are about to
+        // broadcast. Re-resolve against the frozen epochs and fail closed.
+        //
+        // Runs after the version check on purpose: a version mismatch has the
+        // clearer message, and re-resolving against an already-drifted roster
+        // version would report a key diff caused by a version diff.
+        //
+        // Outside the cleanup above by design. Key drift must leave the pending
+        // records in place: they hold the build-time key stamp, which is the
+        // only thing that lets a later resume re-detect the drift. Dropping
+        // them would let the resume path fall back to the indexer's copy, pass
+        // the `prePeginTxHash` check, and broadcast the Pre-PegIn this refused.
+        await verifyRegisteredParticipantKeys({
+          vaultRegistryReader: getVaultRegistryReader(),
+          operationKeyReader,
+          vaultIds: batchRegistration.vaults.map((v) => v.vaultId as Hex),
+          expected: validatedKeys.participantKeys,
+        });
 
         // ========================================================================
         // Step 4b: Broadcast Pre-PegIn transaction to Bitcoin

--- a/services/vault/src/hooks/deposit/useVaultActions.ts
+++ b/services/vault/src/hooks/deposit/useVaultActions.ts
@@ -61,6 +61,7 @@ import {
 } from "../../services/vault";
 import { activateVaultWithSecret } from "../../services/vault/vaultActivationService";
 import { utxosToExpectedRecord } from "../../services/vault/vaultPeginBroadcastService";
+import { verifyResumeParticipantKeys } from "../../services/vault/verifyResumeParticipantKeys";
 import type { PendingPeginRequest } from "../../storage/peginStorage";
 import {
   shouldProbeWalletLiveness,
@@ -316,6 +317,16 @@ export function useVaultActions(): UseVaultActionsReturn {
               buildUniversalChallengersVersion,
             expectedVaultCoreVersion: buildVaultCoreVersion,
           });
+
+          // RFC-006: the same guard the inline deposit path applies before
+          // broadcast. Gated on the stamp being present — records written with
+          // the flag off, or before it shipped, simply skip it.
+          if (pendingPegin?.buildParticipantOperationKeys) {
+            await verifyResumeParticipantKeys({
+              vaultId,
+              expected: pendingPegin.buildParticipantOperationKeys,
+            });
+          }
         } catch (err) {
           // Only a confirmed mismatch drops the entry — transient RPC
           // failures keep it so the user can retry. Mirrors the inline

--- a/services/vault/src/hooks/deposit/useVaultActions.ts
+++ b/services/vault/src/hooks/deposit/useVaultActions.ts
@@ -317,16 +317,6 @@ export function useVaultActions(): UseVaultActionsReturn {
               buildUniversalChallengersVersion,
             expectedVaultCoreVersion: buildVaultCoreVersion,
           });
-
-          // RFC-006: the same guard the inline deposit path applies before
-          // broadcast. Gated on the stamp being present — records written with
-          // the flag off, or before it shipped, simply skip it.
-          if (pendingPegin?.buildParticipantOperationKeys) {
-            await verifyResumeParticipantKeys({
-              vaultId,
-              expected: pendingPegin.buildParticipantOperationKeys,
-            });
-          }
         } catch (err) {
           // Only a confirmed mismatch drops the entry — transient RPC
           // failures keep it so the user can retry. Mirrors the inline
@@ -336,6 +326,26 @@ export function useVaultActions(): UseVaultActionsReturn {
           }
           throw err;
         }
+      }
+
+      // RFC-006: the same guard the inline deposit path applies before
+      // broadcast. Its only precondition is the stamp — a missing build
+      // version says nothing about participant keys, so this sits outside the
+      // version block rather than inheriting its conditions. Records written
+      // before this shipped carry no stamp and skip the check.
+      //
+      // Deliberately NOT wrapped in the cleanup above: dropping the record on
+      // drift would discard the stamp, and the next attempt would find no
+      // local copy, fall back to the indexer's transaction, pass the
+      // `prePeginTxHash` check — it is the registered transaction — and
+      // broadcast the very Pre-PegIn this just refused. The hash proves the
+      // transaction was not substituted; it does not prove the vault's frozen
+      // epochs still resolve to the keys inside its scripts.
+      if (pendingPegin?.buildParticipantOperationKeys) {
+        await verifyResumeParticipantKeys({
+          vaultId,
+          expected: pendingPegin.buildParticipantOperationKeys,
+        });
       }
 
       await broadcastPrePeginTransaction({

--- a/services/vault/src/services/vault/__tests__/vaultPayoutSignatureService.payoutScripts.test.ts
+++ b/services/vault/src/services/vault/__tests__/vaultPayoutSignatureService.payoutScripts.test.ts
@@ -1,0 +1,159 @@
+/**
+ * RFC-006 payout-destination resolution in `prepareSigningContext`.
+ *
+ * Operator payout destinations come from the registry at the vault's frozen
+ * epochs rather than from a local BIP-86 derivation, and the keeper map must be
+ * keyed by operation key using the roster-ordered pairs.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetPayoutScriptsAtEpochs = vi.hoisted(() => vi.fn());
+const mockResolveParticipantKeysAtEpochs = vi.hoisted(() => vi.fn());
+
+vi.mock("@babylonlabs-io/ts-sdk/tbv/core", async (importOriginal) => ({
+  ...((await importOriginal()) as object),
+  resolveParticipantKeysAtEpochs: (...args: unknown[]) =>
+    mockResolveParticipantKeysAtEpochs(...args),
+}));
+
+vi.mock("../../../clients/eth-contract/btc-vault-registry/query", () => ({
+  getVaultFromChain: vi.fn(),
+  getVaultProviderBtcPubkeyFromChain: vi.fn(),
+  getVaultKeyEpochsFromChain: vi.fn(),
+}));
+
+vi.mock("../../../config/pegin", () => ({
+  getBTCNetworkForWASM: vi.fn().mockReturnValue("testnet"),
+}));
+
+vi.mock("../../../clients/eth-contract/sdk-readers", () => ({
+  getProtocolParamsReader: vi.fn().mockResolvedValue({
+    getTimelockPeginByVersion: vi.fn().mockResolvedValue(100),
+    getOffchainParamsByVersion: vi.fn().mockResolvedValue({
+      timelockAssert: 144n,
+      securityCouncilKeys: ["0xcouncil"],
+      councilQuorum: 1,
+      minVpCommissionBps: 10,
+    }),
+  }),
+  getVaultKeeperReader: vi.fn().mockResolvedValue({
+    getVaultKeepersByVersion: vi
+      .fn()
+      .mockResolvedValue([{ btcPubKey: "vk1" }, { btcPubKey: "vk2" }]),
+  }),
+  getUniversalChallengerReader: vi.fn().mockResolvedValue({
+    getUniversalChallengersByVersion: vi
+      .fn()
+      .mockResolvedValue([{ btcPubKey: "uc1" }]),
+  }),
+  getOperationKeyReader: vi.fn().mockResolvedValue({
+    getPayoutScriptsAtEpochs: (...args: unknown[]) =>
+      mockGetPayoutScriptsAtEpochs(...args),
+  }),
+}));
+
+import {
+  getVaultFromChain,
+  getVaultKeyEpochsFromChain,
+  getVaultProviderBtcPubkeyFromChain,
+} from "../../../clients/eth-contract/btc-vault-registry/query";
+import { prepareSigningContext } from "../vaultPayoutSignatureService";
+
+const VP_KEY = "a".repeat(64);
+
+/**
+ * Two keeper operation keys whose *roster* order is the reverse of their
+ * *sorted* order. The registry returns payout scripts index-aligned with the
+ * roster, so joining them against the sorted key array would pair each keeper
+ * with the other one's destination.
+ */
+const KEEPER_ROSTER_FIRST = "f".repeat(64);
+const KEEPER_ROSTER_SECOND = "1".repeat(64);
+
+const SCRIPT_FOR_ROSTER_FIRST = "0xaaaa";
+const SCRIPT_FOR_ROSTER_SECOND = "0xbbbb";
+
+/** A registered non-BIP-86 destination — what devnet's VP actually has set. */
+const VP_REGISTERED_P2WPKH = "0x00142bbccc132d605bd10a4b0e14275b260c46f00d2f";
+
+const signingArgs = {
+  vaultId: "vault_id",
+  depositorBtcPubkey: "depositor_pubkey",
+  registeredPayoutScriptPubKey: "0xdepositorScript",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  vi.mocked(getVaultFromChain).mockResolvedValue({
+    depositorSignedPeginTx: "0xpegin",
+    offchainParamsVersion: 1,
+    vaultCoreVersion: 2,
+    appVaultKeepersVersion: 2,
+    universalChallengersVersion: 3,
+    applicationEntryPoint: "0xapp",
+    vaultProvider: "0xprovider",
+    vaultProviderCommissionBps: 50,
+  } as never);
+  vi.mocked(getVaultProviderBtcPubkeyFromChain).mockResolvedValue(
+    `0x${VP_KEY}` as never,
+  );
+  vi.mocked(getVaultKeyEpochsFromChain).mockResolvedValue({
+    vpKeyEpoch: 12n,
+    appKeeperKeyEpoch: 16n,
+    ucKeyEpoch: 12n,
+  } as never);
+
+  mockResolveParticipantKeysAtEpochs.mockResolvedValue({
+    vaultProvider: { operationBtcPubkey: VP_KEY },
+    // Roster order — index-aligned with the payout scripts below.
+    vaultKeepers: [
+      { operationBtcPubkey: KEEPER_ROSTER_FIRST },
+      { operationBtcPubkey: KEEPER_ROSTER_SECOND },
+    ],
+    // Sorted order — deliberately the reverse of the roster.
+    vaultKeeperOperationKeysSorted: [KEEPER_ROSTER_SECOND, KEEPER_ROSTER_FIRST],
+    universalChallengerOperationKeysSorted: ["uc1"],
+  });
+  mockGetPayoutScriptsAtEpochs.mockResolvedValue({
+    vaultProvider: VP_REGISTERED_P2WPKH,
+    vaultKeepers: [SCRIPT_FOR_ROSTER_FIRST, SCRIPT_FOR_ROSTER_SECOND],
+  });
+});
+
+describe("prepareSigningContext — registered payout scripts", () => {
+  it("pins the VP commission output to the registered scriptPubKey", async () => {
+    const { context } = await prepareSigningContext(signingArgs);
+
+    expect(context.vpCommissionScriptPubKey).toBe(VP_REGISTERED_P2WPKH);
+  });
+
+  it("keys each keeper payout script by its operation key from the roster-ordered pairs", async () => {
+    const { context } = await prepareSigningContext(signingArgs);
+
+    expect(context.vkClaimerPayoutScriptPubKeys).toEqual({
+      [KEEPER_ROSTER_FIRST]: SCRIPT_FOR_ROSTER_FIRST,
+      [KEEPER_ROSTER_SECOND]: SCRIPT_FOR_ROSTER_SECOND,
+    });
+  });
+
+  it("resolves payout scripts at the vault's frozen epochs", async () => {
+    await prepareSigningContext(signingArgs);
+
+    expect(mockGetPayoutScriptsAtEpochs).toHaveBeenCalledWith(
+      expect.anything(),
+      { vpKeyEpoch: 12n, appKeeperKeyEpoch: 16n, ucKeyEpoch: 12n },
+    );
+  });
+
+  it("builds with the epoch-bonded participant keys", async () => {
+    const { context } = await prepareSigningContext(signingArgs);
+
+    expect(context.vaultProviderBtcPubkey).toBe(VP_KEY);
+    expect(context.vaultKeeperBtcPubkeys).toEqual([
+      KEEPER_ROSTER_SECOND,
+      KEEPER_ROSTER_FIRST,
+    ]);
+  });
+});

--- a/services/vault/src/services/vault/__tests__/vaultPayoutSignatureService.test.ts
+++ b/services/vault/src/services/vault/__tests__/vaultPayoutSignatureService.test.ts
@@ -12,6 +12,21 @@ import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 vi.mock("../../../clients/eth-contract/btc-vault-registry/query", () => ({
   getVaultFromChain: vi.fn(),
   getVaultProviderBtcPubkeyFromChain: vi.fn(),
+  getVaultKeyEpochsFromChain: vi.fn().mockResolvedValue({
+    vpKeyEpoch: 0n,
+    appKeeperKeyEpoch: 0n,
+    ucKeyEpoch: 0n,
+  }),
+}));
+
+// Un-rotated operator set: every participant's bonded key is its roster key and
+// the registry backfills BIP-86, so resolution is a pass-through here and these
+// cases stay about the surrounding context wiring.
+const mockResolveParticipantKeysAtEpochs = vi.hoisted(() => vi.fn());
+vi.mock("@babylonlabs-io/ts-sdk/tbv/core", async (importOriginal) => ({
+  ...((await importOriginal()) as object),
+  resolveParticipantKeysAtEpochs: (...args: unknown[]) =>
+    mockResolveParticipantKeysAtEpochs(...args),
 }));
 
 vi.mock("../../../config/pegin", () => ({
@@ -36,6 +51,11 @@ vi.mock("../../../clients/eth-contract/sdk-readers", () => ({
   getUniversalChallengerReader: vi.fn().mockResolvedValue({
     getUniversalChallengersByVersion: (...args: unknown[]) =>
       mockGetUniversalChallengersByVersion(...args),
+  }),
+  getOperationKeyReader: vi.fn().mockResolvedValue({
+    getPayoutScriptsAtEpochs: vi
+      .fn()
+      .mockResolvedValue({ vaultProvider: "0xvpScript", vaultKeepers: [] }),
   }),
 }));
 
@@ -162,6 +182,15 @@ describe("vaultPayoutSignatureService", () => {
       (getVaultProviderBtcPubkeyFromChain as Mock).mockResolvedValue(
         `0x${ON_CHAIN_VP_PUBKEY}`,
       );
+      mockResolveParticipantKeysAtEpochs.mockResolvedValue({
+        vaultProvider: { operationBtcPubkey: ON_CHAIN_VP_PUBKEY },
+        vaultKeepers: [
+          { operationBtcPubkey: "vk1" },
+          { operationBtcPubkey: "vk2" },
+        ],
+        vaultKeeperOperationKeysSorted: ["vk1", "vk2"],
+        universalChallengerOperationKeysSorted: ["uc1"],
+      });
     });
 
     it("builds a SigningContext from on-chain data and returns provider address", async () => {

--- a/services/vault/src/services/vault/__tests__/vaultPayoutSignatureService.test.ts
+++ b/services/vault/src/services/vault/__tests__/vaultPayoutSignatureService.test.ts
@@ -37,6 +37,7 @@ const mockGetTimelockPeginByVersion = vi.fn();
 const mockGetOffchainParamsByVersion = vi.fn();
 const mockGetVaultKeepersByVersion = vi.fn();
 const mockGetUniversalChallengersByVersion = vi.fn();
+const mockGetCurrentVaultProviderOperationBtcKey = vi.fn();
 vi.mock("../../../clients/eth-contract/sdk-readers", () => ({
   getProtocolParamsReader: vi.fn().mockResolvedValue({
     getTimelockPeginByVersion: (...args: unknown[]) =>
@@ -57,6 +58,10 @@ vi.mock("../../../clients/eth-contract/sdk-readers", () => ({
       .fn()
       .mockResolvedValue({ vaultProvider: "0xvpScript", vaultKeepers: [] }),
   }),
+  getVaultRegistryReader: vi.fn(() => ({
+    getCurrentVaultProviderOperationBtcKey: (...args: unknown[]) =>
+      mockGetCurrentVaultProviderOperationBtcKey(...args),
+  })),
 }));
 
 import {
@@ -134,16 +139,52 @@ describe("vaultPayoutSignatureService", () => {
       );
     });
 
-    it("throws when the provided hint does not match the on-chain key", async () => {
+    it("throws when the hint matches neither the registration nor the current operation key", async () => {
       (getVaultProviderBtcPubkeyFromChain as Mock).mockResolvedValue(
+        `0x${ON_CHAIN_VP_PUBKEY}`,
+      );
+      mockGetCurrentVaultProviderOperationBtcKey.mockResolvedValue(
         `0x${ON_CHAIN_VP_PUBKEY}`,
       );
 
       await expect(
         resolveVaultProviderBtcPubkey("0xprovider", DIFFERENT_VP_PUBKEY),
       ).rejects.toThrow(
-        "Vault provider BTC pubkey mismatch for 0xprovider: indexer hint does not match on-chain registry",
+        "indexer hint matches neither the registration key nor the current operation key",
       );
+    });
+
+    // An indexer that has caught up to a rotation serves the operation key
+    // while the registration getter still returns the original. Rejecting that
+    // would break payout signing for every depositor of a rotated provider,
+    // triggered by an indexer deploy rather than one of ours.
+    it("accepts a hint matching the current operation key after a rotation", async () => {
+      (getVaultProviderBtcPubkeyFromChain as Mock).mockResolvedValue(
+        `0x${ON_CHAIN_VP_PUBKEY}`,
+      );
+      mockGetCurrentVaultProviderOperationBtcKey.mockResolvedValue(
+        `0x${DIFFERENT_VP_PUBKEY}`,
+      );
+
+      const result = await resolveVaultProviderBtcPubkey(
+        "0xprovider",
+        DIFFERENT_VP_PUBKEY,
+      );
+
+      // Still returns the registration key: it is the genesis fallback for
+      // epoch resolution, never the key we sign with.
+      expect(result).toBe(ON_CHAIN_VP_PUBKEY);
+    });
+
+    // The extra read is a fallback, not a second unconditional RPC.
+    it("does not read the current operation key when the hint matches registration", async () => {
+      (getVaultProviderBtcPubkeyFromChain as Mock).mockResolvedValue(
+        `0x${ON_CHAIN_VP_PUBKEY}`,
+      );
+
+      await resolveVaultProviderBtcPubkey("0xprovider", ON_CHAIN_VP_PUBKEY);
+
+      expect(mockGetCurrentVaultProviderOperationBtcKey).not.toHaveBeenCalled();
     });
   });
 
@@ -302,6 +343,11 @@ describe("vaultPayoutSignatureService", () => {
       (getVaultProviderBtcPubkeyFromChain as Mock).mockResolvedValue(
         `0x${ON_CHAIN_VP_PUBKEY}`,
       );
+      // Un-rotated provider: the operation key is the registration key, so the
+      // poisoned hint matches neither candidate.
+      mockGetCurrentVaultProviderOperationBtcKey.mockResolvedValue(
+        `0x${ON_CHAIN_VP_PUBKEY}`,
+      );
 
       await expect(
         prepareSigningContext({
@@ -311,7 +357,7 @@ describe("vaultPayoutSignatureService", () => {
           registeredPayoutScriptPubKey: "0xscript",
         }),
       ).rejects.toThrow(
-        "Vault provider BTC pubkey mismatch for 0xprovider: indexer hint does not match on-chain registry",
+        "indexer hint matches neither the registration key nor the current operation key",
       );
     });
 

--- a/services/vault/src/services/vault/__tests__/vaultRefundService.test.ts
+++ b/services/vault/src/services/vault/__tests__/vaultRefundService.test.ts
@@ -18,10 +18,43 @@ vi.mock("@babylonlabs-io/ts-sdk/tbv/core/services", () => ({
   },
 }));
 
+// Un-rotated operator set: each participant's bonded key at the vault's frozen
+// epochs is its roster key, so resolution is a pass-through and these cases
+// stay about the refund adapter wiring.
+const mockResolveParticipantKeysAtEpochs = vi.hoisted(() =>
+  vi.fn(async (...args: unknown[]) => {
+    const q = (
+      args[0] as {
+        query: {
+          vaultProviderGenesisBtcPubkey: string;
+          vaultKeepers: { btcPubKey: string }[];
+          universalChallengers: { btcPubKey: string }[];
+        };
+      }
+    ).query;
+    const strip = (k: string) => (k.startsWith("0x") ? k.slice(2) : k);
+    return {
+      vaultProvider: {
+        operationBtcPubkey: strip(q.vaultProviderGenesisBtcPubkey),
+      },
+      vaultKeepers: q.vaultKeepers.map((k) => ({
+        operationBtcPubkey: strip(k.btcPubKey),
+      })),
+      vaultKeeperOperationKeysSorted: q.vaultKeepers
+        .map((k) => strip(k.btcPubKey))
+        .sort(),
+      universalChallengerOperationKeysSorted: q.universalChallengers
+        .map((c) => strip(c.btcPubKey))
+        .sort(),
+    };
+  }),
+);
 vi.mock("@babylonlabs-io/ts-sdk/tbv/core", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@babylonlabs-io/ts-sdk/tbv/core")>()),
   getNetworkFees: vi.fn().mockResolvedValue({ halfHourFee: 10 }),
   pushTx: vi.fn().mockResolvedValue("broadcast_txid"),
+  resolveParticipantKeysAtEpochs: (...args: unknown[]) =>
+    mockResolveParticipantKeysAtEpochs(...args),
 }));
 
 vi.mock("../../../clients/btc/config", () => ({
@@ -38,6 +71,11 @@ vi.mock("@babylonlabs-io/ts-sdk/tbv/core/utils", () => ({
 
 vi.mock("../../../clients/eth-contract/btc-vault-registry/query", () => ({
   getVaultFromChain: vi.fn(),
+  getVaultKeyEpochsFromChain: vi.fn().mockResolvedValue({
+    vpKeyEpoch: 0n,
+    appKeeperKeyEpoch: 0n,
+    ucKeyEpoch: 0n,
+  }),
 }));
 
 vi.mock("../../../config/pegin", () => ({
@@ -82,6 +120,7 @@ vi.mock("../../../clients/eth-contract/sdk-readers", () => ({
     getProtocolInfoBatch: (ids: readonly string[]) =>
       mockGetProtocolInfoBatch(ids),
   }),
+  getOperationKeyReader: vi.fn().mockResolvedValue({}),
 }));
 
 vi.mock("../fetchVaultProviders", () => ({

--- a/services/vault/src/services/vault/vaultPayoutSignatureService.ts
+++ b/services/vault/src/services/vault/vaultPayoutSignatureService.ts
@@ -18,8 +18,8 @@
  */
 
 import {
-  getSortedXOnlyPubkeys,
   processPublicKeyToXOnly,
+  resolveParticipantKeysAtEpochs,
   stripHexPrefix,
   type Network,
 } from "@babylonlabs-io/ts-sdk/tbv/core";
@@ -27,9 +27,11 @@ import type { Address, Hex } from "viem";
 
 import {
   getVaultFromChain,
+  getVaultKeyEpochsFromChain,
   getVaultProviderBtcPubkeyFromChain,
 } from "../../clients/eth-contract/btc-vault-registry/query";
 import {
+  getOperationKeyReader,
   getProtocolParamsReader,
   getUniversalChallengerReader,
   getVaultKeeperReader,
@@ -90,6 +92,14 @@ export interface SigningContext {
    * implicit fee (device fee-bound model).
    */
   protocolFeeRate: bigint;
+
+  /**
+   * RFC-006 keeper payout destinations at the vault's frozen
+   * `appKeeperKeyEpoch`, keyed by lowercased x-only operation pubkey.
+   */
+  vkClaimerPayoutScriptPubKeys: Readonly<Record<string, string>>;
+  /** RFC-006 VP commission destination at the vault's frozen `vpKeyEpoch`. */
+  vpCommissionScriptPubKey: string;
 }
 
 export interface PreparedSigningData {
@@ -206,17 +216,46 @@ export async function prepareSigningContext(
     );
   }
 
-  const vaultProviderBtcPubkey = await resolveVaultProviderBtcPubkey(
+  const registrationVpBtcPubkey = await resolveVaultProviderBtcPubkey(
     vault.vaultProvider,
     vaultProviderBtcPubKey,
   );
 
-  const vaultKeeperBtcPubkeys = getSortedXOnlyPubkeys(
-    vaultKeepers.map((vk) => vk.btcPubKey),
+  // RFC-006. This vault froze its key epochs at creation, so it must be signed
+  // with the keys bonded *then* — not whatever the operators hold now. The
+  // rosters above are already at the vault's frozen membership versions, which
+  // is what supplies the genesis fallback for keepers and challengers.
+  const operationKeyReader = await getOperationKeyReader();
+  const epochs = await getVaultKeyEpochsFromChain(vaultId as Hex);
+  const query = {
+    vaultProviderEthAddress: vault.vaultProvider,
+    vaultProviderGenesisBtcPubkey: `0x${registrationVpBtcPubkey}` as Hex,
+    applicationEntryPoint: vault.applicationEntryPoint,
+    vaultKeepers,
+    universalChallengers,
+  };
+
+  const [participantKeys, payoutScripts] = await Promise.all([
+    resolveParticipantKeysAtEpochs({ operationKeyReader, query, epochs }),
+    operationKeyReader.getPayoutScriptsAtEpochs(query, epochs),
+  ]);
+
+  const vaultProviderBtcPubkey =
+    participantKeys.vaultProvider.operationBtcPubkey;
+  const vaultKeeperBtcPubkeys = participantKeys.vaultKeeperOperationKeysSorted;
+  const universalChallengerBtcPubkeys =
+    participantKeys.universalChallengerOperationKeysSorted;
+
+  // Keyed by the *operation* key, which is what arrives as `claimer_pubkey`.
+  // Built from the roster-ordered pairs, never by index-joining a sorted
+  // array — a rotated key sorts somewhere else.
+  const vkClaimerPayoutScriptPubKeys = Object.fromEntries(
+    participantKeys.vaultKeepers.map((keeper, i) => [
+      keeper.operationBtcPubkey.toLowerCase(),
+      payoutScripts.vaultKeepers[i],
+    ]),
   );
-  const universalChallengerBtcPubkeys = getSortedXOnlyPubkeys(
-    universalChallengers.map((uc) => uc.btcPubKey),
-  );
+  const vpCommissionScriptPubKey = payoutScripts.vaultProvider;
 
   return {
     context: {
@@ -237,6 +276,8 @@ export async function prepareSigningContext(
       commissionBps: vault.vaultProviderCommissionBps,
       // Version-locked graph-build rate — same fetch as timelockAssert above.
       protocolFeeRate: offchainParams.feeRate,
+      vkClaimerPayoutScriptPubKeys,
+      vpCommissionScriptPubKey,
     },
     vaultProviderAddress: vault.vaultProvider,
   };

--- a/services/vault/src/services/vault/vaultPayoutSignatureService.ts
+++ b/services/vault/src/services/vault/vaultPayoutSignatureService.ts
@@ -35,6 +35,7 @@ import {
   getProtocolParamsReader,
   getUniversalChallengerReader,
   getVaultKeeperReader,
+  getVaultRegistryReader,
 } from "../../clients/eth-contract/sdk-readers";
 import { getBTCNetworkForWASM } from "../../config/pegin";
 
@@ -117,28 +118,52 @@ export interface PayoutSigningProgress {
 }
 
 /**
- * Resolve vault provider's BTC public key.
- * Reads the authoritative value from BTCVaultRegistry and treats the provided
- * value only as an untrusted hint that must match.
+ * Resolve a vault provider's *registration* BTC public key.
+ *
+ * Reads the authoritative value from BTCVaultRegistry and treats the caller's
+ * value only as an untrusted hint. The hint never influences the result — it is
+ * returned from chain either way — so its job is to catch a wrong VP address or
+ * a stale indexer view, not to supply key material.
+ *
+ * Under RFC-006 the hint is accepted against *either* the registration key or
+ * the provider's current operation key, mirroring the policy
+ * `validateOnChainParticipantKeys` applies on the deposit path. Comparing only
+ * against the registration key would hard-fail payout signing for every
+ * depositor of a rotated provider the day the indexer starts serving operation
+ * keys — an indexer-side change, with no deploy on our side and no user
+ * workaround. For a provider that never rotated the two candidates are
+ * identical, so this is exactly the old check until someone rotates.
+ *
+ * The returned registration key is only used as the genesis fallback for
+ * epoch-based resolution; the keys actually signed with come from
+ * `resolveParticipantKeysAtEpochs`.
  */
 export async function resolveVaultProviderBtcPubkey(
   address: Address,
   btcPubKey?: string,
 ): Promise<string> {
-  const onChainBtcPubkey = processPublicKeyToXOnly(
+  const registrationBtcPubkey = processPublicKeyToXOnly(
     await getVaultProviderBtcPubkeyFromChain(address),
   ).toLowerCase();
 
   if (btcPubKey) {
     const hintedBtcPubkey = processPublicKeyToXOnly(btcPubKey).toLowerCase();
-    if (hintedBtcPubkey !== onChainBtcPubkey) {
-      throw new Error(
-        `Vault provider BTC pubkey mismatch for ${address}: indexer hint does not match on-chain registry`,
-      );
+    if (hintedBtcPubkey !== registrationBtcPubkey) {
+      const currentOperationBtcPubkey = processPublicKeyToXOnly(
+        await getVaultRegistryReader().getCurrentVaultProviderOperationBtcKey(
+          address,
+        ),
+      ).toLowerCase();
+      if (hintedBtcPubkey !== currentOperationBtcPubkey) {
+        throw new Error(
+          `Vault provider BTC pubkey mismatch for ${address}: indexer hint matches ` +
+            `neither the registration key nor the current operation key on-chain`,
+        );
+      }
     }
   }
 
-  return onChainBtcPubkey;
+  return registrationBtcPubkey;
 }
 
 /**

--- a/services/vault/src/services/vault/vaultRefundService.ts
+++ b/services/vault/src/services/vault/vaultRefundService.ts
@@ -14,9 +14,9 @@
 import type { SignPsbtOptions } from "@babylonlabs-io/ts-sdk/shared";
 import {
   getNetworkFees,
-  getSortedXOnlyPubkeys,
   processPublicKeyToXOnly,
   pushTx,
+  resolveParticipantKeysAtEpochs,
   stripHexPrefix,
 } from "@babylonlabs-io/ts-sdk/tbv/core";
 import {
@@ -33,8 +33,12 @@ import { assertVaultCoreVersionSupported } from "@/utils/vaultCoreVersionSupport
 
 import { getMempoolApiUrl } from "../../clients/btc/config";
 import { fetchHtlcSpend } from "../../clients/btc/outspend";
-import { getVaultFromChain } from "../../clients/eth-contract/btc-vault-registry/query";
 import {
+  getVaultFromChain,
+  getVaultKeyEpochsFromChain,
+} from "../../clients/eth-contract/btc-vault-registry/query";
+import {
+  getOperationKeyReader,
   getProtocolParamsReader,
   getUniversalChallengerReader,
   getVaultKeeperReader,
@@ -381,6 +385,7 @@ async function readVaultForRefund(
 
 async function readPrePeginContext(
   vault: VaultRefundData,
+  vaultId: Hex,
 ): Promise<RefundPrePeginContext> {
   const [protocolReader, keeperReader, challengerReader] = await Promise.all([
     getProtocolParamsReader(),
@@ -438,17 +443,29 @@ async function readPrePeginContext(
     );
   }
 
-  const vaultKeeperPubkeys = getSortedXOnlyPubkeys(
-    vaultKeepers.map((vk) => vk.btcPubKey),
-  );
-  const universalChallengerPubkeys = getSortedXOnlyPubkeys(
-    universalChallengersList.map((uc) => uc.btcPubKey),
-  );
+  // RFC-006. A refund rebuilds this vault's Pre-PegIn script tree, so it must
+  // use the keys bonded at the vault's frozen epochs — not whatever the
+  // operators hold now. The rosters above are already at the vault's frozen
+  // membership versions, which supply the genesis fallback.
+  const participantKeys = await resolveParticipantKeysAtEpochs({
+    operationKeyReader: await getOperationKeyReader(),
+    query: {
+      vaultProviderEthAddress: vault.vaultProvider as Address,
+      vaultProviderGenesisBtcPubkey: `0x${vaultProviderOnChainPubkey}` as Hex,
+      applicationEntryPoint: vault.applicationEntryPoint,
+      vaultKeepers,
+      universalChallengers: universalChallengersList,
+    },
+    epochs: await getVaultKeyEpochsFromChain(vaultId),
+  });
+
+  const vaultKeeperPubkeys = participantKeys.vaultKeeperOperationKeysSorted;
 
   return {
-    vaultProviderPubkey: vaultProviderOnChainPubkey,
+    vaultProviderPubkey: participantKeys.vaultProvider.operationBtcPubkey,
     vaultKeeperPubkeys,
-    universalChallengerPubkeys,
+    universalChallengerPubkeys:
+      participantKeys.universalChallengerOperationKeysSorted,
     timelockRefund: offchainParams.tRefund,
     feeRate: offchainParams.feeRate,
     minPeginFeeRate: offchainParams.minPeginFeeRate,
@@ -556,7 +573,7 @@ export async function buildAndBroadcastRefundTransaction(
       const data = await readVaultForRefund(vaultId, depositorAddress);
       return { ...data, depositorBtcPubkey };
     },
-    readPrePeginContext: (vault) => readPrePeginContext(vault),
+    readPrePeginContext: (vault) => readPrePeginContext(vault, vaultId as Hex),
     feeRate,
     signPsbt: (psbtHex, options) =>
       btcWalletProvider.signPsbt(psbtHex, options),

--- a/services/vault/src/services/vault/verifyResumeParticipantKeys.ts
+++ b/services/vault/src/services/vault/verifyResumeParticipantKeys.ts
@@ -12,8 +12,8 @@
  */
 
 import {
+  ParticipantKeyDriftError,
   processPublicKeyToXOnly,
-  RegisteredVaultVersionMismatchError,
   resolveParticipantKeysAtEpochs,
 } from "@babylonlabs-io/ts-sdk/tbv/core";
 import type { Address, Hex } from "viem";
@@ -45,7 +45,7 @@ function assertSameSet(
     expected.length !== actual.length ||
     expected.some((k, i) => k !== actual[i])
   ) {
-    throw new RegisteredVaultVersionMismatchError(
+    throw new ParticipantKeyDriftError(
       `Aborting Pre-PegIn broadcast: ${label} changed since this deposit was built ` +
         `(expected [${expected.join(", ")}], got [${actual.join(", ")}]). ` +
         `The Pre-PegIn was not broadcast; the registered ETH vault will time out ` +
@@ -56,8 +56,13 @@ function assertSameSet(
 
 /**
  * Throw when the vault's frozen epochs no longer resolve to the keys the
- * Pre-PegIn was built with. A no-op when the flag is off or the record predates
- * the stamp.
+ * Pre-PegIn was built with.
+ *
+ * Callers gate on the stamp being present: records written before this shipped
+ * carry no `buildParticipantOperationKeys` and simply skip the check.
+ *
+ * Throws `ParticipantKeyDriftError`, which callers must NOT treat as a reason
+ * to drop the pending record — see the class docs in the SDK.
  */
 export async function verifyResumeParticipantKeys(params: {
   vaultId: Hex;
@@ -102,7 +107,7 @@ export async function verifyResumeParticipantKeys(params: {
     expected.vaultProvider,
   ).toLowerCase();
   if (resolved.vaultProvider.operationBtcPubkey !== expectedVp) {
-    throw new RegisteredVaultVersionMismatchError(
+    throw new ParticipantKeyDriftError(
       `Aborting Pre-PegIn broadcast: the vault provider's operation key changed ` +
         `since this deposit was built (expected ${expectedVp}, got ` +
         `${resolved.vaultProvider.operationBtcPubkey}). The Pre-PegIn was not ` +

--- a/services/vault/src/services/vault/verifyResumeParticipantKeys.ts
+++ b/services/vault/src/services/vault/verifyResumeParticipantKeys.ts
@@ -1,0 +1,123 @@
+/**
+ * Pre-broadcast participant-key guard for the resume path.
+ *
+ * The inline deposit flow verifies participant keys right after registration
+ * mines and before the BTC broadcast. A resume broadcasts the *same* Pre-PegIn
+ * later — potentially days later, from another session — so it needs the same
+ * assertion against the keys the scripts were actually built with, otherwise a
+ * rotation that landed in between would be broadcast over.
+ *
+ * Reads the vault's frozen epochs and frozen membership rosters and re-resolves
+ * from them, exactly as the payout and refund paths do.
+ */
+
+import {
+  processPublicKeyToXOnly,
+  RegisteredVaultVersionMismatchError,
+  resolveParticipantKeysAtEpochs,
+} from "@babylonlabs-io/ts-sdk/tbv/core";
+import type { Address, Hex } from "viem";
+
+import {
+  getVaultFromChain,
+  getVaultKeyEpochsFromChain,
+  getVaultProviderBtcPubkeyFromChain,
+} from "@/clients/eth-contract/btc-vault-registry/query";
+import {
+  getOperationKeyReader,
+  getUniversalChallengerReader,
+  getVaultKeeperReader,
+} from "@/clients/eth-contract/sdk-readers";
+
+/** The build-time keys persisted on the pending-pegin record. */
+export interface ExpectedParticipantOperationKeys {
+  vaultProvider: string;
+  vaultKeepers: string[];
+  universalChallengers: string[];
+}
+
+function assertSameSet(
+  label: string,
+  expected: readonly string[],
+  actual: readonly string[],
+): void {
+  if (
+    expected.length !== actual.length ||
+    expected.some((k, i) => k !== actual[i])
+  ) {
+    throw new RegisteredVaultVersionMismatchError(
+      `Aborting Pre-PegIn broadcast: ${label} changed since this deposit was built ` +
+        `(expected [${expected.join(", ")}], got [${actual.join(", ")}]). ` +
+        `The Pre-PegIn was not broadcast; the registered ETH vault will time out ` +
+        `per protocol rules.`,
+    );
+  }
+}
+
+/**
+ * Throw when the vault's frozen epochs no longer resolve to the keys the
+ * Pre-PegIn was built with. A no-op when the flag is off or the record predates
+ * the stamp.
+ */
+export async function verifyResumeParticipantKeys(params: {
+  vaultId: Hex;
+  expected: ExpectedParticipantOperationKeys;
+}): Promise<void> {
+  const { vaultId, expected } = params;
+  const vault = await getVaultFromChain(vaultId);
+
+  const [keeperReader, challengerReader, operationKeyReader] =
+    await Promise.all([
+      getVaultKeeperReader(),
+      getUniversalChallengerReader(),
+      getOperationKeyReader(),
+    ]);
+
+  const [vaultKeepers, universalChallengers, registrationVpBtcPubkey, epochs] =
+    await Promise.all([
+      keeperReader.getVaultKeepersByVersion(
+        vault.applicationEntryPoint,
+        vault.appVaultKeepersVersion,
+      ),
+      challengerReader.getUniversalChallengersByVersion(
+        vault.universalChallengersVersion,
+      ),
+      getVaultProviderBtcPubkeyFromChain(vault.vaultProvider as Address),
+      getVaultKeyEpochsFromChain(vaultId),
+    ]);
+
+  const resolved = await resolveParticipantKeysAtEpochs({
+    operationKeyReader,
+    query: {
+      vaultProviderEthAddress: vault.vaultProvider as Address,
+      vaultProviderGenesisBtcPubkey: registrationVpBtcPubkey,
+      applicationEntryPoint: vault.applicationEntryPoint,
+      vaultKeepers,
+      universalChallengers,
+    },
+    epochs,
+  });
+
+  const expectedVp = processPublicKeyToXOnly(
+    expected.vaultProvider,
+  ).toLowerCase();
+  if (resolved.vaultProvider.operationBtcPubkey !== expectedVp) {
+    throw new RegisteredVaultVersionMismatchError(
+      `Aborting Pre-PegIn broadcast: the vault provider's operation key changed ` +
+        `since this deposit was built (expected ${expectedVp}, got ` +
+        `${resolved.vaultProvider.operationBtcPubkey}). The Pre-PegIn was not ` +
+        `broadcast; the registered ETH vault will time out per protocol rules.`,
+    );
+  }
+
+  assertSameSet(
+    "the vault keeper set",
+    expected.vaultKeepers,
+    resolved.vaultKeeperOperationKeysSorted,
+  );
+  assertSameSet(
+    "the universal challenger set",
+    expected.universalChallengers,
+    resolved.universalChallengerOperationKeysSorted,
+  );
+}

--- a/services/vault/src/services/vault/vpAuthPinnedPubkey.ts
+++ b/services/vault/src/services/vault/vpAuthPinnedPubkey.ts
@@ -1,0 +1,39 @@
+/**
+ * The BTC key a vault provider's server identity is pinned to for RPC auth.
+ *
+ * The VP issues BIP-322-signed tokens from its **operation** key, so once
+ * RFC-006 rotation is live the pin has to follow that key rather than the
+ * fixed registration key. This is deliberately the *current* key, not any
+ * vault's frozen epoch: it is a per-operator server identity, not a per-vault
+ * binding (RFC-006 open question 5).
+ *
+ * Consequence worth knowing: `VpTokenRegistry` binds a `peginTxid` to one
+ * pinned pubkey and refuses to rebind. A VP that rotates mid-session
+ * invalidates its outstanding tokens, which surfaces as an auth failure the
+ * user resolves by retrying — the flow re-reads the key on the next cold path.
+ * That is the intended behaviour: accepting either key would hollow out the
+ * pin, which exists precisely so a substituted server key cannot be used.
+ *
+ * Centralised here because all three auth-priming call sites must agree; a
+ * site left on the registration key would break auth for every vault of a
+ * rotated provider, including already-active ones.
+ */
+
+import type { OnChainBtcPubkey } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
+import type { Address } from "viem";
+
+import { getVaultRegistryReader } from "@/clients/eth-contract/sdk-readers";
+
+/**
+ * Resolve the pubkey to pin a VP's auth session to.
+ *
+ * Before the first rotation on a network the two reads return the same bytes,
+ * so this is a no-op until an operator rotates.
+ */
+export async function resolveVpAuthPinnedPubkey(
+  vpAddress: Address,
+): Promise<OnChainBtcPubkey> {
+  return getVaultRegistryReader().getCurrentVaultProviderOperationBtcKey(
+    vpAddress,
+  );
+}

--- a/services/vault/src/storage/__tests__/peginStorage.test.ts
+++ b/services/vault/src/storage/__tests__/peginStorage.test.ts
@@ -215,6 +215,103 @@ describe("getPendingPegins integrity validation", () => {
     expect(result[0].id).toBe(VALID_VAULT_ID_2);
   });
 
+  // RFC-006: the build-time operation keys are read back before a resume
+  // broadcast and compared against what the vault's frozen epochs resolve to.
+  // A tampered or malformed value here would feed that equality check, so the
+  // field is optional but strictly validated whenever it is present.
+
+  it("accepts an entry with no operation keys (written with the flag off)", () => {
+    localStorage.setItem(storageKey, JSON.stringify([validPegin]));
+
+    expect(getPendingPegins(ETH_ADDRESS)).toHaveLength(1);
+  });
+
+  it("accepts an entry carrying well-formed operation keys", () => {
+    const withKeys: PendingPeginRequest = {
+      ...validPegin,
+      buildParticipantOperationKeys: {
+        vaultProvider: "a".repeat(64),
+        vaultKeepers: ["b".repeat(64), "c".repeat(64)],
+        universalChallengers: ["d".repeat(64)],
+      },
+    };
+    localStorage.setItem(storageKey, JSON.stringify([withKeys]));
+
+    const result = getPendingPegins(ETH_ADDRESS);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].buildParticipantOperationKeys?.vaultProvider).toBe(
+      "a".repeat(64),
+    );
+  });
+
+  it("filters entries whose operation keys are not an object", () => {
+    const tampered = {
+      ...validPegin,
+      buildParticipantOperationKeys: "not-an-object",
+    };
+    localStorage.setItem(storageKey, JSON.stringify([tampered]));
+
+    expect(getPendingPegins(ETH_ADDRESS)).toHaveLength(0);
+  });
+
+  it("filters entries whose vault provider operation key is not 32-byte hex", () => {
+    const tampered = {
+      ...validPegin,
+      buildParticipantOperationKeys: {
+        vaultProvider: "tooshort",
+        vaultKeepers: ["b".repeat(64)],
+        universalChallengers: ["d".repeat(64)],
+      },
+    };
+    localStorage.setItem(storageKey, JSON.stringify([tampered]));
+
+    expect(getPendingPegins(ETH_ADDRESS)).toHaveLength(0);
+  });
+
+  it("filters entries whose keeper key set is empty", () => {
+    // An empty set is never a valid vault configuration, and would make the
+    // pre-broadcast comparison vacuously pass.
+    const tampered = {
+      ...validPegin,
+      buildParticipantOperationKeys: {
+        vaultProvider: "a".repeat(64),
+        vaultKeepers: [],
+        universalChallengers: ["d".repeat(64)],
+      },
+    };
+    localStorage.setItem(storageKey, JSON.stringify([tampered]));
+
+    expect(getPendingPegins(ETH_ADDRESS)).toHaveLength(0);
+  });
+
+  it("filters entries where one key in a set is malformed", () => {
+    const tampered = {
+      ...validPegin,
+      buildParticipantOperationKeys: {
+        vaultProvider: "a".repeat(64),
+        vaultKeepers: ["b".repeat(64), "NOT_HEX"],
+        universalChallengers: ["d".repeat(64)],
+      },
+    };
+    localStorage.setItem(storageKey, JSON.stringify([tampered]));
+
+    expect(getPendingPegins(ETH_ADDRESS)).toHaveLength(0);
+  });
+
+  it("filters entries whose challenger keys are missing entirely", () => {
+    const tampered = {
+      ...validPegin,
+      buildParticipantOperationKeys: {
+        vaultProvider: "a".repeat(64),
+        vaultKeepers: ["b".repeat(64)],
+      },
+    };
+    localStorage.setItem(storageKey, JSON.stringify([tampered]));
+
+    expect(getPendingPegins(ETH_ADDRESS)).toHaveLength(0);
+  });
+
   it("filters entries whose id is a non-string (DoS protection)", () => {
     // A non-string id would throw in normalizeTransactionId, fall into the
     // outer catch block, and wipe the entire storage key. This test guards

--- a/services/vault/src/storage/__tests__/peginStorage.test.ts
+++ b/services/vault/src/storage/__tests__/peginStorage.test.ts
@@ -220,7 +220,7 @@ describe("getPendingPegins integrity validation", () => {
   // A tampered or malformed value here would feed that equality check, so the
   // field is optional but strictly validated whenever it is present.
 
-  it("accepts an entry with no operation keys (written with the flag off)", () => {
+  it("accepts an entry with no operation keys (written before the stamp shipped)", () => {
     localStorage.setItem(storageKey, JSON.stringify([validPegin]));
 
     expect(getPendingPegins(ETH_ADDRESS)).toHaveLength(1);

--- a/services/vault/src/storage/peginStorage.ts
+++ b/services/vault/src/storage/peginStorage.ts
@@ -67,6 +67,24 @@ export interface PendingPeginRequest {
   buildAppVaultKeepersVersion?: number;
   buildUniversalChallengersVersion?: number;
   buildVaultCoreVersion?: number;
+  /**
+   * RFC-006 participant operation keys the Pre-PegIn scripts were built with
+   * (x-only, lowercase, no `0x`; the two sets lex-sorted).
+   *
+   * Stored as *keys* rather than the vault's key epochs on purpose: keys are
+   * directly comparable, whereas epochs would need the frozen roster re-derived
+   * before they meant anything. Asserted before a resume broadcast so a
+   * rotation that landed after the build cannot be broadcast against.
+   *
+   * Optional: absent on records written with the flag off, on legacy records,
+   * and on REFUND_BROADCAST tracking entries. Absent simply skips the check —
+   * the versions guard above still applies.
+   */
+  buildParticipantOperationKeys?: {
+    vaultProvider: string;
+    vaultKeepers: string[];
+    universalChallengers: string[];
+  };
 }
 
 // Hex with optional 0x prefix and at least one byte (even-length).
@@ -222,6 +240,28 @@ function hasValidSecurityFields(entry: unknown): entry is PendingPeginRequest {
     // ≥ 0 acceptance.
     const min = field === "buildVaultCoreVersion" ? 1 : 0;
     if (typeof v !== "number" || !Number.isInteger(v) || v < min) {
+      return false;
+    }
+  }
+
+  // RFC-006 build-time operation keys. Optional, but if present the shape must
+  // hold — this is untrusted storage feeding a pre-broadcast equality check.
+  const opKeys = pegin.buildParticipantOperationKeys;
+  if (opKeys !== undefined) {
+    if (!opKeys || typeof opKeys !== "object") return false;
+    const { vaultProvider, vaultKeepers, universalChallengers } =
+      opKeys as Record<string, unknown>;
+    const isXOnly = (k: unknown) =>
+      typeof k === "string" && /^[0-9a-f]{64}$/.test(k);
+    if (
+      !isXOnly(vaultProvider) ||
+      !Array.isArray(vaultKeepers) ||
+      !Array.isArray(universalChallengers) ||
+      vaultKeepers.length === 0 ||
+      universalChallengers.length === 0 ||
+      !vaultKeepers.every(isXOnly) ||
+      !universalChallengers.every(isXOnly)
+    ) {
       return false;
     }
   }

--- a/services/vault/src/storage/peginStorage.ts
+++ b/services/vault/src/storage/peginStorage.ts
@@ -76,7 +76,7 @@ export interface PendingPeginRequest {
    * before they meant anything. Asserted before a resume broadcast so a
    * rotation that landed after the build cannot be broadcast against.
    *
-   * Optional: absent on records written with the flag off, on legacy records,
+   * Optional: absent on records written before this shipped, on legacy records,
    * and on REFUND_BROADCAST tracking entries. Absent simply skips the check —
    * the versions guard above still applies.
    */

--- a/services/vault/src/utils/errors/depositErrors.ts
+++ b/services/vault/src/utils/errors/depositErrors.ts
@@ -27,7 +27,10 @@
  *    "Transaction failed" title (preserves prior behavior, no info hidden).
  */
 
-import { isRegisteredVaultVersionMismatchError } from "@babylonlabs-io/ts-sdk/tbv/core";
+import {
+  isParticipantKeyDriftError,
+  isRegisteredVaultVersionMismatchError,
+} from "@babylonlabs-io/ts-sdk/tbv/core";
 import { JsonRpcError } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
 import { type ReactNode } from "react";
 
@@ -112,6 +115,14 @@ export function mapDepositError(err: unknown): DepositErrorContent {
   // 3. Protocol-parameter version mismatch (registered vault drifted).
   if (isRegisteredVaultVersionMismatchError(err)) {
     return ERRORS.versionMismatch;
+  }
+
+  // 3b. RFC-006 participant key drift. Distinct from the version mismatch
+  // above: retrying cannot help, because the registered vault is bonded to
+  // keys the prepared Pre-PegIn does not use. The copy says so rather than
+  // inviting a retry.
+  if (isParticipantKeyDriftError(err)) {
+    return ERRORS.participantKeyDrift;
   }
 
   const msg = lowerMessage(err);


### PR DESCRIPTION
Closes https://github.com/babylonlabs-io/babylon-toolkit/issues/2150

**Follow-up:** #2182 — remove the dual-accept BIP-86 fallback once every network is past btc-vault#2440.
**Related:** #2181 — a VP token rejection is unrecoverable in-app (Retry does nothing, only a reload works). Pre-existing, but key rotation makes it far likelier to be hit; found during this testing.

## The problem in one sentence

Operators can now change their Bitcoin key without re-registering, and our frontend still reads the **old, fixed** key — so the Bitcoin locks we build no longer match what the protocol expects.

## Background

Every participant in a vault — the Vault Provider (VP), the Application Vault Keepers (VK), the Universal Challengers (UC) — has a Bitcoin public key. That key is baked into the taproot scripts of the Bitcoin lock we build at deposit time, and into the set of challengers we pre-sign payout / no-payout transactions for.

Until RFC-006 each operator had exactly **one** BTC key, fixed at registration forever. RFC-006 splits that into a cold **ETH admin key** (identity and authority) and a hot, rotatable **BTC operation key** (the thing that actually goes into scripts and signs). Rotation is append-only: `setOperationBtcKey` adds a new version and old versions stay readable forever. So that existing vaults don't break when someone rotates, each vault **freezes an epoch number** when it is created, and everyone answers "which key did this vault bond?" by asking the contract for the key at that frozen epoch.

That is exactly what happened on devnet: a VP's operation key was rotated, our frontend kept building locks with the registration key, and every new peg-in was rejected. The rotation was reverted and is waiting on this PR.

**RFC-006 contains two independent breaking changes**, and separating them is the single most important thing to understand about this PR:

| | **A — key rotation** | **B — registered payout scripts** |
|---|---|---|
| What breaks | scripts built with the pre-rotation key | payouts pinned to a locally-derived BIP-86 address |
| Triggered by | `setOperationBtcKey` | `setPayoutScript` |
| Contract side | shipped | shipped |
| Daemon side | [btc-vault#2304](https://github.com/babylonlabs-io/btc-vault/issues/2304), **in v0.7.0** | [btc-vault#2440](https://github.com/babylonlabs-io/btc-vault/pull/2440), **in no release — `main` only** |

They have different triggers and different deployment timelines. An earlier revision shipped them behind two feature flags; devnet testing showed neither was needed — see *No feature flags* below.

## What changed

| Area | Change |
|---|---|
| New peg-ins | Build with each participant's **current** operation key, then after registration mines, re-read the vault's frozen epochs, re-resolve, and fail closed **before the BTC broadcast** if anything drifted |
| Existing vaults (resume / payout / refund) | Resolve keys at the epochs **that vault** froze, so an old vault stays signable after a later rotation |
| VP authentication | Pin the VP's **current** operation key — that is what its server signs its auth tokens with |
| Payout transactions | Take keeper payout destinations and the VP commission destination from the registry instead of deriving BIP-86 locally, accepting the BIP-86 default alongside it so graphs built before btc-vault#2440 stay signable |
| Rollout | No flags and no ordering constraint — the client is correct against a vaultd fleet on either side of #2440 |

## No feature flags

An earlier revision of this PR shipped two: `NEXT_PUBLIC_FF_ENABLE_OPERATION_KEY_ROTATION` and `NEXT_PUBLIC_FF_ENABLE_REGISTERED_PAYOUT_SCRIPTS`. Devnet testing removed the case for both.

**The rotation flag guarded nothing.** Its purpose was to protect a registry that predates RFC-006 — and no network we ship to is in that state. devnet and testnet both have all four getters; mainnet will be a fresh RFC-006 deploy. On devnet, flag-*off* was already the broken setting. Its fail-closed capability probe went with it (see *Known issues*, item 1 in the previous revision): the classifier could never return `false`, so the entire negative path was unreachable.

**The payout flag's off state was the dangerous one.** With dual-accept in place, flag-on is never worse than flag-off and strictly better in one case: once a keeper registers a custom payout script, flag-off fails while flag-on passes. A flag whose innocuous-looking default is the unsafe setting is a trap.

Both are gone, along with the legacy BIP-86-only branch in `assertPayoutOutputLayout` and the `if (vpCommissionScriptPubKey !== undefined)` skip — which was the last configuration in which the VP commission destination went unvalidated. `vkClaimerPayoutScriptPubKeys` and `vpCommissionScriptPubKey` are now required on `PayoutParams`.

## Approaches considered

### 1. The ABI: extend the existing entry, or isolate it?

The obvious approach is to add the three new epoch fields to our existing `getBtcVaultProtocolInfo` ABI entry. **This is unsafe.** That function returns a *positional* tuple. If we declare 16 fields but point at a network whose registry has not been upgraded yet, the decode goes wrong. Worse, `getProtocolInfoBatch` and `getVaultData` read it through `multicall({ allowFailure: false })`, so one bad decode fails the entire batch — which would break vault status, resume, payout and refund **app-wide**. A feature flag would **not** have saved us here either, because the ABI shape is not flag-gated.

**Chosen:** put the extended 16-field shape in its own ABI file (`BTCVaultRegistryKeyEpochs.abi.ts`), read only on the epoch-aware path. The shared entry keeps the 13-field shape that decodes against every deployed registry. A test pins that the 13 fields are an exact prefix of the 16, so the two hand-maintained copies cannot drift apart.

**One finding that changed the design.** A not-yet-upgraded registry does **not** fail loudly under the extended ABI. Because the struct contains `bytes`, a real vault's response carries enough trailing data to satisfy the three extra fields — so viem returns garbage as epochs with no error. It only throws for a **nonexistent** vault, whose byte fields are empty. That asymmetry is why the earlier revision probed with a *nonexistent* vault id. The probe is gone now — it guarded a registry state no network we ship to is in, and its classifier could never actually match — but `assertEpochInRange` still bounds a garbage decode, and the ABI-decode tests pin both directions.

### 2. Where does the switch live?

The SDK has no feature flags and we kept it that way. Epoch resolution is driven by **passing the reader in**, and the payout destinations are ordinary required params. With the app-side flags now removed too, there is exactly one path through this code on every network — which is the main reason the test matrix shrank rather than grew.

### 3. Indexer hints: throw, warn, or accept either?

We cross-check the keys the indexer gives us against the chain. Once a VP rotates, the indexer will still be serving the old registration key for a while, so a strict equality check would throw and **block every deposit for that provider**.

**Chosen:** accept **either** the registration keys or the operation keys. The hint never influences which key we actually use — that is always read from chain. The check still catches a wrong VP address, a wrong application entry point, or a stale roster version, which is its real value. Each role is compared as a whole set, and there is an extra check that rejects a *mixed* answer, which means the indexer is serving a half-applied view.

### 4. Which epoch — current or frozen?

Both, depending on the situation. A peg-in being built right now uses **current** keys, because it has not frozen an epoch yet. Everything about an existing vault uses **that vault's frozen** epoch.

VP authentication deliberately uses **current**, because the VP's server signs its auth tokens with its live key — it is a per-operator server identity, not a per-vault binding. Confirmed against `vaultd`: its `AuthService` is bound to `wallet_expected_pubkey`, which the config docs define as the current operation key, and `getVaultProviderBTCKey` has zero live call sites in the daemon.

### 5. Payout commission: keep the cap, don't switch to exact equality

The issue suggested asserting the commission output value "matches" the frozen commission rate. We already assert it is **at most** the entitled amount. An upper bound is the right posture for a depositor — a VP taking *less* than it is owed harms nobody, and strict equality would reject that. Kept the cap and added the destination check on top.

## Things rotation newly makes possible

None of these were reachable before, and they shaped several decisions:

- **Sort order is no longer stable.** Keys are sorted before going into scripts, and a rotated key sorts somewhere else. So the code carries `(admin address → key)` **pairs** as the source of truth and derives the sorted arrays from them, never the other way round. The test fixture deliberately includes a keeper whose rotated key sorts *before* its original one.
- **Two operators can end up with the same key.** Nothing on-chain stops two keepers rotating onto the same key, or a keeper rotating onto the VP's key. That would silently collapse the participant set, so it is rejected at resolve time, before any script is built.
- **The registry now returns operator-chosen bytes.** Pinning a payout output to it without checking would let a bad script get the depositor to pre-sign an unspendable payout, so there is a new check that it is a standard, spendable output type. The accepted set (P2TR/P2WPKH/P2WSH/P2SH/P2PKH) matches `vaultd`'s registration-time gate exactly.
- **VP auth can break mid-session.** A provider that rotates while a session is open invalidates its outstanding tokens. Devnet testing showed this is *not* recoverable in-app: the client's re-auth path matches on a `data.kind` the daemon never sends, so **Retry does nothing and only a page reload recovers**. Tracked separately in #2181 — it is pre-existing, not introduced here, but rotation makes it far likelier to be hit.

## Devnet verification

Two rounds, on either side of the devnet fleet upgrade. Full logs and per-test baselines are in `markdown/rfc006/`.

### Round 1 — before the rotation (daemon `02d7c353`, pre-#2440)

Four full deposits through to activation, with temporary instrumentation capturing the resolved key material at each decision point (since removed).

| Run | Rotation | Payout | Result |
|---|---|---|---|
| 1 | off | off | Full deposit to active. **Zero** new contract-call selectors. Baseline. |
| 2 | on | on | Build, read-after-mine verify and BTC broadcast all passed. **Failed at payout signing** — see below. |
| 3 | on | off | Resume of run 2's vault. Payout signing proceeded. |
| 4 | on | off | Full deposit to active. |

Across runs 1 and 4 — one on the legacy path, one resolving through frozen epochs `12 / 16 / 12` — the resolved key material was **byte-identical**: VP `1db08a11…0008e`, the same 4 keepers and 4 challengers in the same sort order, frozen versions `1 / 1 / 2 / 2`, commission `10` bps. That is the "no-op until someone rotates" claim demonstrated end to end against a live chain rather than argued from source.

**Why run 2 failed.** The devnet VP has called `setPayoutScript` at least three times:

```
getPayoutScriptAtEpoch(VP, 0)  → 0x5120f436aa9c…   P2TR (BIP-86 backfill)
getPayoutScriptAtEpoch(VP, 1)  → 0x00142bbccc13…   P2WPKH
getPayoutScriptAtEpoch(VP, 8)  → 0x001438481735…   P2WPKH
getPayoutScriptAtEpoch(VP, 12) → 0x00142bbccc13…   P2WPKH
```

That daemon predates #2440, so it built output 1 as P2TR of the VP's operation key and ignored the registry. This **falsified a claim in an earlier revision of this description** — that the payout change is a no-op because the contract backfills BIP-86. That holds only for an operator who never called `setPayoutScript`.

### Round 2 — after the rotation and the fleet upgrade

devops rotated the devnet VP operation key at 05:31 UTC on 2026-08-04, then upgraded the fleet to `bf3e6719` (btc-vault#2488, which contains #2440) at 13:46 UTC. The VP's key history:

```
epoch  0–9   1db08a1171aa…0008e   original / registration key
epoch 10     8d93ed5c7b7c…2421f   first rotation (this is what broke pegins and prompted #2150)
epoch 11–12  1db08a1171aa…0008e   the "revert" — an append, not a rollback
epoch 13+    4a9c87a094b9…9835b   current
```

An epoch is **not** a rotation count: one per-operator counter also advances on `setPayoutScript`, which is why a vault created before any rotation froze `vpKeyEpoch 12` rather than 0.

| Test | Vault | Frozen epochs | Outcome |
|---|---|---|---|
| **A** — pre-rotation vault, post-rotation signing | `0xbcf3061d…85b3` | 12 / 16 / 12 | **Passed frontend-side.** Resolved to the superseded key `1db08a11…` and the VP accepted the signatures. Then blocked at the VP→keeper ACK by a daemon-side gap (below) — not a frontend failure |
| **B** — post-rotation vault | `0xc740c567…85f5` | **13** / 16 / 12 | **Passed.** Built with `4a9c87a0…` and was ingested. A control deposit from a client without this PR (`6e29c7bc…`) was `IngestionRejected` under the same conditions. **This is the bug being fixed, reproduced and then fixed on a live chain** |
| **C** — auth across the rotation | both cohorts | — | **Passed.** The pin follows `getCurrentOperationBtcKey`, so both pre- and post-rotation vaults authenticate against the rotated key |
| **D** — resume drift guard | `0x25991e0f…deaf` | 12 / 16 / 12 | **Premise was wrong.** Epochs freeze at registration, so a later rotation cannot create drift for an already-registered vault. The guard correctly resolved at the frozen epoch. The abort branch remains unexercised on-chain |

### Round 2b — registered payout scripts, after #2440 landed

| Subject | Payout resolution | `outs[1]` the daemon built | Outcome |
|---|---|---|---|
| Vault B — graph built ~3h **before** the upgrade | registered script expected | `51201d5e2825b587…` = `bip86(4a9c87a0…)` | **Rejected** — this is what proved dual-accept is mandatory |
| Vault B — same graph, legacy derivation | BIP-86 derived locally | same | Accepted; vault completed |
| Fresh deposit `0xa5b3e51b…190d` — graph built **after** the upgrade | registered script expected | `00142bbccc132d605bd10a4b0e14275b260c46f00d2f` | **Accepted and activated** |

The third row is the confirmation that **#2440 is live** on devnet — nothing else observable from outside distinguishes the two daemon builds, because `payout.ts` on `main` only length-checks `outs[1]` for the VP claimer, so a 22-byte P2WPKH and a 34-byte P2TR both pass there.

The first two rows together are why `acceptedPayoutScriptHexes` exists. Both runs returned **identical payout txids**, which independently confirms the protocol team's statement that a graph is never rebuilt once set.

### Round 3 — flags removed, review fixes applied (`bc5b2679`)

A full deposit on the final build: no feature flags, single unconditional epoch-aware path, and the review fixes below already in place. **Completed successfully.**

This closes the last open item in the plan. It matters for two reasons:

- It is the first end-to-end run where nothing is conditional. Rounds 1 and 2 exercised the flag-on path; this confirms the unconditional path behaves identically now that the flag-off branch no longer exists to fall back to.
- It exercises the review fixes on the happy path. All three are unreachable without drift, a rotation mid-deposit, or a split indexer, so the expectation was **no observable change** — and that is what happened. A regression here would have meant one of the fixes altered the normal path, which none of them should.

### Deployment facts established while testing

These correct #2150 and earlier revisions of this description:

- **#2440 was in no release** at the time of writing. It merged to `main` on 2026-07-29; the `v0.7.0` tag is 2026-08-03 and does not contain it. Any plan gated on "v0.7 vaultd" for the payout half was wrong.
- `tbv-networks/devnet/network_info.json` pins `btcVaultRef: 666112c8`, which is stale — that is where `release/v0.7.x` forked from `main`. The daemon's live `health_check` `commit` field is authoritative.
- **`vaultd` does not validate peg-in ingestion via `getCurrentOperationBtcKey`**, contrary to #2150. Ingestion resolves at the vault's **frozen** epoch. The observed rejection is still fully explained — the contract freezes `vpKeyEpoch` at `submitPeginRequest`, so a frontend building with the stale registration key produced scripts that did not match — but the stated mechanism was wrong, and it is the justification for the build-current-then-verify design.
- **testnet** is on the RFC-006 contracts, is un-rotated, and `getPayoutScriptAtEpoch` returns exactly the BIP-86 backfill (verified: `bip86(90e4d34b…7133) == 0x512029ce1605…7941`). The RFC-006 path is provably a no-op there today.

### Still not exercised on-chain

| Gap | Why it is acceptable |
|---|---|
| A **keeper** rotating, and the sort reordering that follows | Only the VP has ever rotated on devnet. The pairs-are-source-of-truth invariant only bites here; fixture-tested, with a keeper whose rotated key deliberately sorts before its original |
| The read-after-mine **abort** branch | It ran and passed on every run; the abort itself never fired. Unit-tested |
| The resume drift-guard **abort** branch | Same — test D's premise turned out to be unreachable by construction |
| Key-collision and off-curve rejection | Unit only |
| Refund | `tRefund` on devnet is 2016 blocks (~14 days on signet). It calls the same `resolveParticipantKeysAtEpochs` with the same frozen epochs as payout |

## What still needs to be done

- Nothing. The three known issues below are tracked as #2185, #2186 and #2187; none blocks merge.

One standing operational ask: **a keeper must not call `setPayoutScript` on a network whose vaultd fleet predates #2440 until this PR has shipped there.** The VP's own custom script is survivable, because `payout.ts` on `main` only length-checks `outs[1]`; a keeper's is not, because keeper destinations are compared exactly.

## Addressed in review (`bc5b2679`)

Review by @jrwbabylonlab found one live defect that the description had recorded only as a nested-condition smell, plus five documentation claims that were factually wrong. All are fixed; neither critical-path file changed.

**The resume path could broadcast a Pre-PegIn the key guard had just refused.** `verifyResumeParticipantKeys` threw `RegisteredVaultVersionMismatchError`, so the catch dropped the pending record. On retry that record — and with it the build-time key stamp — was gone, so `localUnsignedTxHex` was undefined, the transaction fell back to the indexer's copy, the whole guarded block was skipped, and the `prePeginTxHash` check passed because it *is* the registered transaction. `useDepositFlow.ts` had the identical bypass.

The hash proves the transaction was not substituted. It does not prove the vault's frozen epochs still resolve to the keys inside its scripts — and on drift they do not, because the registered hash commits to a transaction built with pre-rotation keys while the vault froze the post-rotation epoch. So the retry converted a clean no-loss abort into BTC locked until the refund timelock, while the error message still claimed "The Pre-PegIn was not broadcast".

Key drift now throws `ParticipantKeyDriftError`, a **sibling** of `RegisteredVaultVersionMismatchError` and deliberately not a subclass — subclassing would keep satisfying the type guard and preserve the bug. Cleanup now differs by design: a version mismatch still drops the record, key drift keeps it. `mapDepositError` gained its own copy for it, since rendering key drift as "Protocol parameters changed" invited exactly the retry that cannot help.

Also fixed:

- **Known issue 1** — `resolveVaultProviderBtcPubkey` now accepts the indexer hint against the registration key *or* `getCurrentOperationBtcKey`, matching the deposit path. The extra read is a fallback, not an unconditional second RPC.
- **Known issue 2** — the resume key guard moved out of the version block; its only precondition is the stamp.
- **Half-applied indexer telemetry** — `onIndexerHintsInconsistent` fires before the throw, wired to `logger.error`. The block clears only when the indexer converges, so "Refresh and try again" cannot help and it needs to be observable.
- **Five wrong doc claims**, checks unchanged: `getPayoutScriptAtEpoch` is *not* a no-op (a payout script is mandatory at registration and stored as v1, so it returns the operator's own script from epoch one — which is why dual-accept is required, not merely convenient); `standardPayoutScript` is *not* parity with `vaultd`, which uses registry scripts verbatim, so it is now justified on its own terms as a pre-signing bound that is also load-bearing for the fee band; the operation-key collision claim was overstated, since intra-role uniqueness is enforced on-chain.
- **Stale prose from the draft** — seven references to the removed capability probe and to "when the flag is off", across five files. Flagged by Greptile at one site; the sweep found the rest.

## Known issues, not yet fixed

These were found reviewing the change. All three are now tracked separately, so nothing here depends on this PR staying open — the list is kept for reviewers who want the reasoning inline. **None blocks merge:** one is test hardening, one harms only the VP, and one is a diagnosis defect on a path that still fails closed.

Two issues from the previous revision are gone by deletion rather than by fix: the capability probe's unreachable classifier, and the never-rendered `operationKeyRotationUnsupported.title` — both removed with the flags.

1. **Test coverage is thin app-side** — #2185. `vpAuthPinnedPubkey.ts` and `verifyResumeParticipantKeys.ts` still have no tests of their own. Separately, the challenger-set derivation is correct only *transitively* — `signDepositorGraph.ts` has no contract imports and receives keys through the context object — so a future refactor reintroducing a registration-key read in `prepareSigningContext` would break it with a green suite.

2. **No absolute dust floor on the commission value** — #2186. #2169 added a *rate* floor at the trust boundary — `max(offchainParams.minVpCommissionBps, MIN_REALIZABLE_VP_COMMISSION_BPS)`, the latter being `1` — so the bps is now bounded on both sides. But `vaultd` rejects a commission below the **546-sat dust limit**, and 1 bps of a small peg-in is well under that, so the sat-level gap remains. Harms only the VP, but it is an asymmetry with the protocol.

3. **On resume, a spent-input error preempts the key-drift diagnosis** — #2187. `useVaultActions.ts` calls `assertUtxosAvailable` (line 263) unconditionally, well before `verifyResumeParticipantKeys` (line 345). If the pending Pre-PegIn's inputs were spent by an unrelated transaction, the resume throws "UTXOs unavailable" and the drift check never runs — so in exactly the scenario the guard exists for, the user is told the wrong thing and the key drift is never surfaced or recorded. It still fails closed and never broadcasts, so this is a diagnosis defect rather than a safety one. It also makes the drift guard awkward to test: any deposit created between staging a pending peg-in and resuming it can consume that peg-in's inputs and mask the result.

## Rollout — no ordering constraint

Both feature flags were removed after devnet testing. There is no network where the flag-off path was correct and the flag-on path was wrong:

- **devnet** — RFC-006 contracts, VP rotated to epoch 13. Flag-off was already *broken* here: a deposit built with the registration key is rejected at ingestion because the vault freezes epoch 13.
- **testnet** — registry `0xE976a4f2…` has all four RFC-006 getters, is un-rotated, and `getPayoutScriptAtEpoch` returns exactly the BIP-86 backfill (verified: `bip86(90e4d34b…7133) == 0x512029ce1605…7941`). The RFC-006 path is provably a no-op there.
- **mainnet** — not deployed; it will be a fresh RFC-006 deploy.

With dual-accept for legacy payout graphs (below), the client is correct against a vaultd fleet on **either** side of #2440. So per network: land this, then upgrade the fleet and call `setOperationBtcKey` / `setPayoutScript` in any order.

The one operational caution left: a **keeper** calling `setPayoutScript` breaks every client that predates this PR, because the pre-RFC-006 code derives keeper destinations with BIP-86 and compares them exactly. The VP's own custom script does not, since `payout.ts` on `main` only length-checks `outs[1]`.

## Legacy payout graphs — deliberate dual-accept

A payout graph is built once at BaBe Setup and is **never rebuilt**, so a vault whose graph predates its network's #2440 upgrade pays BIP-86 for the rest of its life. Accepting only the registered script makes every such vault permanently unsignable, with the BTC already committed — observed on devnet, where vault `0xc740c567…` failed with `outs[1]` = `51201d5e2825b587…`, exactly `bip86(4a9c87a0…)`.

`acceptedPayoutScriptHexes` therefore accepts the registered script **or** the BIP-86 default of the same bonded key. Both candidates are derived from on-chain state, never from the VP's response, so the only substitution permitted is between two destinations the same operator already controls — and the commission value cap still bounds depositor exposure independently. Removal conditions are documented on the function and tracked in #2182.

## Rebase onto #2169 — what was removed from it, and why

[#2169](https://github.com/babylonlabs-io/babylon-toolkit/pull/2169) (payout implicit-fee band) landed on `main` while this was in review and changed the same function, `assertPayoutOutputLayout`. The rebase keeps both changes, but **one of #2169's checks became unreachable** and was removed. Flagging it here because it is someone else's just-landed invariant.

#2169 states its own premise in the `assertPayoutFeeBand` module doc:

> `out1Len` is measured from the **deliberately-unpinned** VP commission output and is **UNTRUSTED**: it feeds only the floor […] It must never widen the ceiling — a VP-controlled length there would buy burnable headroom.

This PR pins `outs[1]` to the operator's registered scriptPubKey, so that premise no longer holds. Only part of what it justified becomes dead:

| Element of #2169 | Kept? | Reason |
|---|---|---|
| `out1Len`'s `[1, 128]` cap | **removed** | `assertStandardPayoutScript` bounds the registered script to P2TR/P2WPKH/P2WSH/P2PKH/P2SH — 34 bytes at most. A 128-byte cap on `outs[1]` can no longer fire under any input |
| `out1Len` feeding the fee **floor** | kept | Still correct, and now read from a pinned value rather than a VP-controlled one — strictly more trustworthy than when #2169 shipped |
| `out1Len` excluded from the **ceiling** | kept | No longer strictly required once the output is pinned, but the separation is kept deliberately so the bound does not silently depend on that pin |
| `out0Len`'s cap and ceiling-excess term | kept — **still live** | vp-claimer and depositor-as-claimer `outs[0]` is `registeredPayoutScriptPubKey`, which we only hex-check, so it genuinely reaches 128 bytes. Only the vk-claimer's `outs[0]` is standard-gated |

Two of #2169's integration tests in `payout.test.ts` were deleted, because their premise — a paddable `outs[1]` — no longer exists:

- `gives a padded commission script no extra ceiling headroom`
- `rejects a commission scriptPubKey outside the contract registration cap`

**No coverage is lost.** The first one's property is already pinned at unit level by `does not widen the ceiling for the commission script length` in `assertPayoutFeeBand.test.ts`, which calls `assertPayoutFeeInBand` directly and so is unaffected by the pin. That test is kept; only its name changed, since it called the output "unpinned". The second test asserted a bound that is now enforced earlier and more strictly by the standard-script gate.

`assertPayoutFeeBand.ts`'s module doc and the inline comment above `scriptExcess` were also corrected — both described `outs[1]` as unpinned and VP-controlled.

One knock-on inside `assertPayoutOutputLayout`: #2169 computed `out0Len` from `expectedOut0Script.length`, which was sound when exactly one script was expected. Dual-accept means the accepted set can hold two candidates, so it now reads `payoutTx.outs[0].script.length` — the output actually present, which the equality check above has already pinned to one of the accepted values. Same value, and it mirrors how `out1Len` was already computed.

## Testing

- ts-sdk: 1448 tests across 83 files, all passing.
- vault: 3105 tests across 274 files, all passing.
- Typecheck, lint, and `pnpm run build` (all 8 nx targets) clean.
- All contract ABI entries verified byte-for-byte against the compiled forge artifacts in `vault-contracts-aave-v4`, including full tuple component types and 4-byte selectors, cross-checked against that repo's `snapshots/selectors.md`.

New tests worth looking at:

- A **two-epoch rotation fixture** with real secp256k1 keys: a VP that rotates, a keeper that rotates to a key sorting *before* its original, a keeper with a custom payout script, and controls that never rotate. It pins that resolving at epoch 0 reproduces today's keys exactly, that the sorted order reorders after rotation, and that collisions and off-curve keys are rejected.
- ABI decode tests pinning **both** directions: the shared 13-field entry keeps working against an upgraded registry, and the extended entry mis-decodes a populated legacy response (documenting the hazard) while throwing on the empty response the capability probe relies on.
- **Payout-destination resolution** — that destinations are always resolved, and that the keeper map is keyed from the roster-ordered pairs rather than index-joined against the sorted array, using a fixture whose roster order is the reverse of its sorted order.
- **Dual-accept** — that a BIP-86 destination is accepted when a different script is registered (the legacy-graph case), and that a third script is still rejected.

## If we split this into several PRs

Both halves are now verified on devnet, so urgency no longer separates them — but file count and code ownership still argue for a split. The rebase onto #2169 strengthens the case: `payout.ts` now carries two independent changes to the same validator, which is exactly the kind of file that benefits from a reviewer looking at it alone. `.github/workflows/critical-path-check.yml` matches a literal path list, and **two** changed files are on it: `packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts` and `packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts`. Both carry the same small change — the two RFC-006 payout-destination params and their forwarding — so isolating them together means the two required code owners spend their attention on payout logic rather than on 900 lines of ABI JSON. `signDepositorGraph.ts` also picks up a one-line import reorder: `prettier-plugin-organize-imports` requires it, and the file was drifted on `main` (it only checks clean outside the TS project, where the plugin cannot resolve module paths).

The natural seam is the payout-script work:

| # | Title | Behavior change | Reviewers |
|---|---|---|---|
| 1 | `feat(ts-sdk): add RFC-006 operation-key ABIs and chain readers` | none — nothing calls it | 1 |
| 2 | `feat(ts-sdk): resolve participant operation keys and validate them for new peg-ins` | none until wired | 1 |
| 3 | `feat(ts-sdk): pin payout destinations to registered scripts, accepting BIP-86 for legacy graphs` | none until wired | **2** (auto-labelled) |
|   | ↳ carries **both** critical-path files: `payout.ts` and `signDepositorGraph.ts` | | |
| 4 | `feat(vault): resolve participant keys by epoch across build, resume, payout and refund` | the behaviour change | 1 |

PR 3 has no dependencies and can open immediately in parallel, which helps because it needs two approvals and is the likely scheduling bottleneck.

**Do not go below three.** PR 3 should never merge into anything else — the moment `payout.ts` or `signDepositorGraph.ts` shares a PR with unrelated work, the two required code owners cannot realistically read the whole diff. Keeping both in PR 3 is what leaves PR 4 at a single reviewer.

## Note for reviewers

This touches the presigning and payout paths, which are on the critical-path list in `CLAUDE.md` and need two reviewers.

Beyond the deployment-fact corrections above, a few claims in https://github.com/babylonlabs-io/babylon-toolkit/issues/2150 did not survive checking against the contracts and this codebase:

- "The ABI sync is additive with no behaviour change" is **not** true for `getBtcVaultProtocolInfo` — see the ABI section.
- The issue references a payout fee band keyed on output script lengths (`out0Len`/`out1Len`). **No such code exists in this repo**; payout has only a 10%-of-inputs implicit fee cap.
- The issue's Stage 0 asks for `vpKeyEpochCurrent` / `appKeeperKeyEpochCurrent` / `ucKeyEpochCurrent`. **`vpKeyEpochCurrent` does not exist on the deployed contract** — it reverts. The "current" mode calls `getCurrentOperationBtcKey` directly and never needs an epoch number.
- The payout change is smaller than described and pointed at the wrong output: output 0 was **already** correct for VP and depositor claimers. The only wrong derivation was the vault-keeper branch. Pinning the VP commission destination is new hardening.

One naming note that cost some confusion: **an epoch is not a rotation count.** Devnet's VP had rotated only twice when its vaults were already freezing `vpKeyEpoch: 12`, because a single per-operator counter advances on `setPayoutScript` too. Key resolution is unaffected — the contract returns the latest version at or before the epoch — but note that `getOperationBtcKeyAtEpoch` never reverts on an out-of-range epoch (verified up to `2^64-1`), so a garbage epoch resolves silently rather than failing. `assertEpochInRange` is what bounds that.






