### PR TITLE
fix(vault): restore network requests on browsers without AbortSignal.any

### DIFF
--- a/packages/babylon-ts-sdk/README.md
+++ b/packages/babylon-ts-sdk/README.md
@@ -51,7 +51,7 @@ targets — see the [Troubleshooting Guide](./docs/get-started/troubleshooting.m
 
 ### Requirements
 
-- **Node.js ≥ 20.3.0** (for `AbortSignal.any()`). Works on Node 20 LTS, 22 LTS, 24 LTS.
+- **Node.js ≥ 20.3.0** — the supported baseline. Works on Node 20 LTS, 22 LTS, 24 LTS.
 - Package manager: npm, yarn, or pnpm
 
 ### Install

--- a/packages/babylon-ts-sdk/docs/get-started/README.md
+++ b/packages/babylon-ts-sdk/docs/get-started/README.md
@@ -142,7 +142,7 @@ Each maps to a public subpath like `@babylonlabs-io/ts-sdk/tbv/core/<name>` (see
 
 ### Runtime
 
-- **Node.js ≥ 20.3.0** (`AbortSignal.any()` is required). Works on Node 20 LTS, 22 LTS, 24 LTS.
+- **Node.js ≥ 20.3.0** — the supported baseline. Works on Node 20 LTS, 22 LTS, 24 LTS.
 - For browser targets: a bundler that handles `.wasm` assets (Vite, webpack, Next.js, Rollup) and a `Buffer` polyfill. See [Troubleshooting](./troubleshooting.md).
 
 ### Packages

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts
@@ -7,6 +7,7 @@
  * @module clients/mempool/mempoolApi
  */
 
+import { combineAbortSignals } from "../../utils/abortSignals";
 import {
   BITCOIN_ADDRESS_RE,
   HEX_RE,
@@ -46,15 +47,20 @@ async function fetchWithTimeout(
   const signals = [controller.signal, options?.signal].filter(
     Boolean,
   ) as AbortSignal[];
+  const combined = combineAbortSignals(signals);
 
   try {
-    // Don't clear timeout here — let it cover body consumption by callers
+    // Don't clear timeout here — let it cover body consumption by callers.
+    // For the same reason the composed signal keeps its listeners attached on
+    // the success path: detaching them would stop the timeout from aborting a
+    // stalled body read.
     return await fetch(url, {
       ...options,
-      signal: AbortSignal.any(signals),
+      signal: combined.signal,
     });
   } catch (error) {
     clearTimeout(timeoutId);
+    combined.cleanup();
     if (
       error != null &&
       typeof error === "object" &&

--- a/packages/babylon-ts-sdk/src/tbv/core/utils/__tests__/abortSignals.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/utils/__tests__/abortSignals.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Guards the browser-compatibility fix for `combineAbortSignals`.
+ *
+ * The regression this protects against: the mempool client used to call
+ * `AbortSignal.any`, which is absent on Safari < 17.4 and Chrome < 116. It
+ * threw before `fetch` was reached, so UTXO fetches, fee estimation and
+ * transaction broadcast all failed outright on those browsers. The last test
+ * deletes `AbortSignal.any` outright to prove the helper never reaches for it.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { combineAbortSignals } from "../abortSignals";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("combineAbortSignals", () => {
+  it("aborts the composed signal when the first input aborts", () => {
+    const first = new AbortController();
+    const second = new AbortController();
+
+    const { signal } = combineAbortSignals([first.signal, second.signal]);
+    expect(signal.aborted).toBe(false);
+
+    first.abort();
+
+    expect(signal.aborted).toBe(true);
+  });
+
+  it("aborts the composed signal when the second input aborts", () => {
+    const first = new AbortController();
+    const second = new AbortController();
+
+    const { signal } = combineAbortSignals([first.signal, second.signal]);
+    second.abort();
+
+    expect(signal.aborted).toBe(true);
+  });
+
+  it("propagates the abort reason of whichever input fired", () => {
+    const first = new AbortController();
+    const second = new AbortController();
+    const reason = new DOMException("caller went away", "AbortError");
+
+    const { signal } = combineAbortSignals([first.signal, second.signal]);
+    second.abort(reason);
+
+    expect(signal.reason).toBe(reason);
+  });
+
+  it("returns an already-aborted input directly", () => {
+    const aborted = new AbortController();
+    aborted.abort();
+    const live = new AbortController();
+
+    const { signal } = combineAbortSignals([aborted.signal, live.signal]);
+
+    expect(signal).toBe(aborted.signal);
+    expect(signal.aborted).toBe(true);
+  });
+
+  it("returns a lone input directly rather than wrapping it", () => {
+    const only = new AbortController();
+
+    const { signal } = combineAbortSignals([only.signal]);
+
+    expect(signal).toBe(only.signal);
+  });
+
+  it("stops propagating aborts once cleanup has run", () => {
+    const first = new AbortController();
+    const second = new AbortController();
+
+    const { signal, cleanup } = combineAbortSignals([
+      first.signal,
+      second.signal,
+    ]);
+    cleanup();
+    first.abort();
+
+    expect(signal.aborted).toBe(false);
+  });
+
+  it("works on a runtime with no AbortSignal.any", () => {
+    const original = AbortSignal.any;
+    // @ts-expect-error - deliberately emulating a browser that predates the API
+    delete AbortSignal.any;
+
+    try {
+      const first = new AbortController();
+      const second = new AbortController();
+
+      const { signal } = combineAbortSignals([first.signal, second.signal]);
+      second.abort();
+
+      expect(signal.aborted).toBe(true);
+    } finally {
+      AbortSignal.any = original;
+    }
+  });
+});

--- a/packages/babylon-ts-sdk/src/tbv/core/utils/abortSignals.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/utils/abortSignals.ts
@@ -1,0 +1,47 @@
+/**
+ * AbortSignal composition helpers.
+ *
+ * @module utils/abortSignals
+ */
+
+export interface CombinedAbortSignal {
+  signal: AbortSignal;
+  /** Remove listeners from the source signals. Call once the request settles. */
+  cleanup: () => void;
+}
+
+/**
+ * Compose several AbortSignals into one that aborts when any input aborts,
+ * propagating the reason of whichever fired first.
+ *
+ * Deliberately does NOT use `AbortSignal.any`: that shipped in Chrome 116 /
+ * Safari 17.4, newer than the browsers this SDK is consumed from, and it is a
+ * runtime API so no transpile step can backfill it. Calling it directly threw
+ * `TypeError: AbortSignal.any is not a function` before `fetch` was ever
+ * reached, which failed UTXO fetches, fee estimation and transaction broadcast
+ * outright on those browsers.
+ */
+export function combineAbortSignals(
+  signals: AbortSignal[],
+): CombinedAbortSignal {
+  const noop = () => {};
+
+  const alreadyAborted = signals.find((signal) => signal.aborted);
+  if (alreadyAborted) return { signal: alreadyAborted, cleanup: noop };
+  if (signals.length === 1) return { signal: signals[0], cleanup: noop };
+
+  const controller = new AbortController();
+  const listeners = signals.map((source) => {
+    const onAbort = () => controller.abort(source.reason);
+    source.addEventListener("abort", onAbort, { once: true });
+    return { source, onAbort };
+  });
+
+  const cleanup = () => {
+    for (const { source, onAbort } of listeners) {
+      source.removeEventListener("abort", onAbort);
+    }
+  };
+
+  return { signal: controller.signal, cleanup };
+}

--- a/packages/babylon-ts-sdk/src/tbv/core/utils/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/utils/index.ts
@@ -4,6 +4,7 @@
  * @module utils
  */
 
+export * from "./abortSignals";
 export * from "./fee";
 export * from "./utxo";
 export * from "./transaction";

--- a/services/vault/src/clients/graphql/client.ts
+++ b/services/vault/src/clients/graphql/client.ts
@@ -1,9 +1,31 @@
 import { GraphQLClient } from "graphql-request";
 
 import { ENV } from "../../config/env";
+import { combineAbortSignals } from "../../utils/async";
 
 /** Timeout for GraphQL API requests — prevents indefinite hangs from stalled endpoints */
 const GRAPHQL_REQUEST_TIMEOUT_MS = 30_000;
+
+/**
+ * A browser `fetch` rejection carries no endpoint information — the exception is
+ * literally `TypeError: Failed to fetch` (`Load failed` on Safari), so every
+ * failing query in the app produces an identical, untriageable Sentry issue.
+ * Naming the host restores enough context to tell an indexer outage apart from
+ * an RPC or mempool one, without leaking the query or its variables.
+ */
+function describeFetchFailure(url: string, error: unknown): Error {
+  const host = (() => {
+    try {
+      return new URL(url).host;
+    } catch {
+      return "unknown host";
+    }
+  })();
+  const detail = error instanceof Error ? error.message : String(error);
+  return new Error(`GraphQL request to ${host} failed: ${detail}`, {
+    cause: error,
+  });
+}
 
 export const graphqlClient = new GraphQLClient(ENV.GRAPHQL_ENDPOINT, {
   fetch: async (url, options) => {
@@ -17,11 +39,12 @@ export const graphqlClient = new GraphQLClient(ENV.GRAPHQL_ENDPOINT, {
     const signals = [controller.signal, options?.signal].filter(
       Boolean,
     ) as AbortSignal[];
+    const combined = combineAbortSignals(signals);
 
     try {
       const response = await fetch(url, {
         ...options,
-        signal: AbortSignal.any(signals),
+        signal: combined.signal,
       });
       const body = await response.text();
       clearTimeout(timeoutId);
@@ -43,7 +66,20 @@ export const graphqlClient = new GraphQLClient(ENV.GRAPHQL_ENDPOINT, {
           `GraphQL request timed out after ${GRAPHQL_REQUEST_TIMEOUT_MS}ms`,
         );
       }
-      throw error;
+      // A caller-initiated abort (React Query unmount) must stay an AbortError
+      // so downstream `name === "AbortError"` checks keep treating it as a
+      // cancellation rather than a fault.
+      if (
+        error != null &&
+        typeof error === "object" &&
+        "name" in error &&
+        error.name === "AbortError"
+      ) {
+        throw error;
+      }
+      throw describeFetchFailure(String(url), error);
+    } finally {
+      combined.cleanup();
     }
   },
 });

--- a/services/vault/src/utils/async.ts
+++ b/services/vault/src/utils/async.ts
@@ -1,3 +1,43 @@
+export interface CombinedAbortSignal {
+  signal: AbortSignal;
+  /** Remove listeners from the source signals. Call once the request settles. */
+  cleanup: () => void;
+}
+
+/**
+ * Compose several AbortSignals into one that aborts when any input aborts.
+ *
+ * Deliberately does NOT use `AbortSignal.any`: that shipped in Chrome 116 /
+ * Safari 17.4, which is newer than this app's build target, and it is a runtime
+ * API so no transpile step can backfill it. Calling it directly threw
+ * `TypeError: AbortSignal.any is not a function` before `fetch` was ever
+ * reached, failing every request on older browsers.
+ */
+export function combineAbortSignals(
+  signals: AbortSignal[],
+): CombinedAbortSignal {
+  const noop = () => {};
+
+  const alreadyAborted = signals.find((signal) => signal.aborted);
+  if (alreadyAborted) return { signal: alreadyAborted, cleanup: noop };
+  if (signals.length === 1) return { signal: signals[0], cleanup: noop };
+
+  const controller = new AbortController();
+  const listeners = signals.map((source) => {
+    const onAbort = () => controller.abort(source.reason);
+    source.addEventListener("abort", onAbort, { once: true });
+    return { source, onAbort };
+  });
+
+  const cleanup = () => {
+    for (const { source, onAbort } of listeners) {
+      source.removeEventListener("abort", onAbort);
+    }
+  };
+
+  return { signal: controller.signal, cleanup };
+}
+
 export function abortableSleep(
   ms: number,
   signal?: AbortSignal,


### PR DESCRIPTION
## What

Replaces `AbortSignal.any` with a local `combineAbortSignals` helper in the GraphQL and mempool fetch wrappers. Also names the endpoint host on GraphQL network failures.

## Why

`AbortSignal.any` shipped in Chrome 116 / Safari 17.4. This app's resolved build target is Safari 14 / Chrome 87, and it's a runtime API, so no transpile backfills it. It sat on the first line of both fetch wrappers, so on an older browser it threw before `fetch` was ever called — killing every GraphQL query plus UTXO fetch, fee estimation and broadcast. A deposit could not be constructed.

Proof it's this and not a dependency: the old bundle contains `AbortSignal.any(Va)`, matching the Sentry message `(In 'AbortSignal.any(Va)', ...)` character for character. A fresh build now has zero occurrences.

Separately, a bare `fetch` rejection carries no context, so failures arrived as an untriageable `Failed to fetch`.

## How

Compose signals with plain event listeners, propagate the reason of whichever fired first, return a `cleanup` handle. Two details worth a look:

- The mempool client keeps listeners attached on the **success** path — its timeout deliberately covers body consumption, and detaching would break that.
- Caller aborts are re-thrown unchanged so downstream `AbortError` checks still see a cancellation.

7 new tests, one of which deletes `AbortSignal.any` to emulate an old browser. Vault 3088 and SDK 1378 pass; lint clean; production build succeeds.
