### PR TITLE
fix(vault): stop reporting wallet cancellations and extension errors to Sentry

### DIFF
--- a/services/vault/index.html
+++ b/services/vault/index.html
@@ -5,6 +5,13 @@
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="32x32" />
     <link rel="canonical" href="%NEXT_PUBLIC_CANONICAL%" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!--
+      Opt out of page translation. Translation extensions replace React-owned
+      text nodes with their own wrappers; React's next commit then calls
+      removeChild on a node that is no longer its child, which throws
+      NotFoundError and unmounts the whole app via the error boundary.
+    -->
+    <meta name="google" content="notranslate" />
     <meta property="og:title" content="Babylon - Vault" />
     <meta name="description" content="Vault Dashboard" key="desc" />
     <meta property="og:description" content="Vault Dashboard" />

--- a/services/vault/index.html
+++ b/services/vault/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" translate="no">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="32x32" />

--- a/services/vault/sentry.client.config.ts
+++ b/services/vault/sentry.client.config.ts
@@ -13,6 +13,10 @@ import * as Sentry from "@sentry/react";
 import { v4 as uuidv4 } from "uuid";
 
 import { getCommitHash } from "@/config";
+import {
+  hasTranslationExtensionMarkers,
+  isReactDomMutationError,
+} from "@/utils/errors/domMutationErrors";
 import { isUserCancellation } from "@/utils/errors/userCancellation";
 import { redactData, scrubSentryEvent, scrubString } from "@/utils/telemetry";
 
@@ -23,10 +27,14 @@ const SENTRY_DEVICE_ID_KEY = "sentry_device_id";
  *
  * Every entry was confirmed absent from our source: they come from competing
  * wallet extensions racing over `window.ethereum` (we never write to it - the
- * connector uses AppKit/EIP-6963 discovery), from a wallet extension's own
- * message channel after it reloads mid-session, or from page-translation
- * extensions swapping React-owned text nodes (the `removeChild`/`insertBefore`
- * family). None is actionable and together they crowd out real reports.
+ * connector uses AppKit/EIP-6963 discovery), or from a wallet extension's own
+ * message channel after it reloads mid-session. None is actionable and together
+ * they crowd out real reports.
+ *
+ * `ignoreErrors` runs ahead of `beforeSend`, so anything listed here is dropped
+ * before a tag could rescue it. Only put errors here that our own code can
+ * never throw. The React DOM-mutation family is deliberately NOT here - it is
+ * classified in `beforeSend` instead, see `utils/errors/domMutationErrors.ts`.
  */
 const THIRD_PARTY_EXTENSION_ERRORS = [
   // Injected-provider collisions between wallet extensions
@@ -36,10 +44,15 @@ const THIRD_PARTY_EXTENSION_ERRORS = [
   // Extension messaging after the extension reloaded or was disabled
   "Could not establish connection. Receiving end does not exist.",
   "Extension context invalidated.",
-  // Page-translation extensions mutating nodes React owns
-  "The node to be removed is not a child of this node",
-  /Failed to execute '(removeChild|insertBefore)' on 'Node'/,
 ];
+
+/** The error text of an event, from either an exception or a message event. */
+function eventText(event: Sentry.ErrorEvent): string {
+  return (
+    event.exception?.values?.[0]?.value ??
+    (typeof event.message === "string" ? event.message : "")
+  );
+}
 
 const sentryDsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
 
@@ -134,8 +147,29 @@ Sentry.init({
     // not a fault. Dropped here as well as at the call sites so a cancellation
     // reaching Sentry through a global handler (rather than logger.error) is
     // filtered too.
-    if (isUserCancellation(hint?.originalException)) {
+    //
+    // Exempt events the flow explicitly tagged as a partial failure. The
+    // multi-vault deposit path logs and then CONTINUES with the remaining
+    // vaults, so a depositor rejecting one prompt mid-batch leaves that vault
+    // short of recovery material while the deposit proceeds - CLAUDE.md
+    // critical-path #3 ("undersigning leaves recovery material missing for an
+    // active challenger"). The outer message does not read as a cancellation
+    // but the wrapped cause does, so an untagged drop swallows exactly the
+    // event worth keeping.
+    if (
+      isUserCancellation(hint?.originalException) &&
+      !event.tags?.partialFailure
+    ) {
       return null;
+    }
+
+    // React DOM-mutation failures: drop only with a translation extension
+    // actually present, otherwise keep at warning so our own reconciliation
+    // bugs stay visible and the opt-out's effect stays measurable.
+    if (isReactDomMutationError(eventText(event))) {
+      if (hasTranslationExtensionMarkers()) return null;
+      event.level = "warning";
+      event.tags = { ...event.tags, domMutation: "unattributed" };
     }
 
     event.extra = {

--- a/services/vault/sentry.client.config.ts
+++ b/services/vault/sentry.client.config.ts
@@ -13,9 +13,33 @@ import * as Sentry from "@sentry/react";
 import { v4 as uuidv4 } from "uuid";
 
 import { getCommitHash } from "@/config";
+import { isUserCancellation } from "@/utils/errors/userCancellation";
 import { redactData, scrubSentryEvent, scrubString } from "@/utils/telemetry";
 
 const SENTRY_DEVICE_ID_KEY = "sentry_device_id";
+
+/**
+ * Errors thrown by browser extensions in the page, not by this app.
+ *
+ * Every entry was confirmed absent from our source: they come from competing
+ * wallet extensions racing over `window.ethereum` (we never write to it - the
+ * connector uses AppKit/EIP-6963 discovery), from a wallet extension's own
+ * message channel after it reloads mid-session, or from page-translation
+ * extensions swapping React-owned text nodes (the `removeChild`/`insertBefore`
+ * family). None is actionable and together they crowd out real reports.
+ */
+const THIRD_PARTY_EXTENSION_ERRORS = [
+  // Injected-provider collisions between wallet extensions
+  "Cannot redefine property: ethereum",
+  /Cannot set property ethereum of .* which has only a getter/,
+  "trap returned falsish for property 'tronlinkParams'",
+  // Extension messaging after the extension reloaded or was disabled
+  "Could not establish connection. Receiving end does not exist.",
+  "Extension context invalidated.",
+  // Page-translation extensions mutating nodes React owns
+  "The node to be removed is not a child of this node",
+  /Failed to execute '(removeChild|insertBefore)' on 'Node'/,
+];
 
 const sentryDsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
 
@@ -85,6 +109,8 @@ Sentry.init({
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
 
+  ignoreErrors: THIRD_PARTY_EXTENSION_ERRORS,
+
   beforeBreadcrumb(breadcrumb) {
     if (breadcrumb.message) {
       breadcrumb.message = scrubString(breadcrumb.message);
@@ -104,6 +130,14 @@ Sentry.init({
   // redaction hook (URL + href masking).
 
   beforeSend(event, hint) {
+    // A depositor declining or dismissing a wallet prompt is routine drop-off,
+    // not a fault. Dropped here as well as at the call sites so a cancellation
+    // reaching Sentry through a global handler (rather than logger.error) is
+    // filtered too.
+    if (isUserCancellation(hint?.originalException)) {
+      return null;
+    }
+
     event.extra = {
       ...(event.extra || {}),
       version: getCommitHash(),

--- a/services/vault/src/config/__tests__/queryClient.test.ts
+++ b/services/vault/src/config/__tests__/queryClient.test.ts
@@ -2,14 +2,20 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockLoggerError = vi.hoisted(() => vi.fn());
 const mockLoggerWarn = vi.hoisted(() => vi.fn());
+const mockLoggerEvent = vi.hoisted(() => vi.fn());
 vi.mock("@/infrastructure", () => ({
-  logger: { error: mockLoggerError, warn: mockLoggerWarn },
+  logger: {
+    error: mockLoggerError,
+    warn: mockLoggerWarn,
+    event: mockLoggerEvent,
+  },
 }));
 
 import {
   createQueryClient,
   isExpectedQueryError,
   reportQueryCacheError,
+  resetGeoBlockReportingForTests,
 } from "../queryClient";
 
 /**
@@ -68,9 +74,37 @@ describe("default query retry policy", () => {
     expect(retryFor(httpError(451))).toBe(false);
   });
 
-  it("does not retry other permanent statuses", () => {
-    expect(retryFor(httpError(403))).toBe(false);
-    expect(retryFor(httpError(404))).toBe(false);
+  it("still retries 401/403/404, which are routinely transient here", () => {
+    // A just-broadcast tx isn't indexed yet, a subgraph is mid-redeploy, an RPC
+    // provider returns 401/403 for a rate limit. The in-fetch retries are what
+    // bridge that lag, and this predicate governs mutations too — so treating
+    // these as permanent would also stop retrying ETH submissions.
+    expect(retryFor(httpError(401))).toBe(true);
+    expect(retryFor(httpError(403))).toBe(true);
+    expect(retryFor(httpError(404))).toBe(true);
+  });
+
+  it("does not retry a 410, which is permanent by definition", () => {
+    expect(retryFor(httpError(410))).toBe(false);
+  });
+
+  it("ignores a non-HTTP numeric status", () => {
+    // A contract receipt carries `status: 1`; without a range check that reads
+    // as an HTTP status and lands in whatever set happens to contain it.
+    expect(
+      retryFor(Object.assign(new Error("receipt reverted"), { status: 1 })),
+    ).toBe(true);
+  });
+
+  it("prefers response.status over a colliding top-level status", () => {
+    // graphql-request's ClientError is the more specific shape; a stray
+    // top-level `status` must not win over it.
+    const error = Object.assign(new Error("GraphQL Error (Code: 451)"), {
+      status: 200,
+      response: { status: 451 },
+    });
+
+    expect(retryFor(error)).toBe(false);
   });
 
   it("does not retry a 501, despite it being 5xx", () => {
@@ -102,6 +136,8 @@ describe("reportQueryCacheError", () => {
   beforeEach(() => {
     mockLoggerError.mockReset();
     mockLoggerWarn.mockReset();
+    mockLoggerEvent.mockReset();
+    resetGeoBlockReportingForTests();
   });
 
   it("records an expected query error as a breadcrumb, not a captured error", () => {
@@ -113,17 +149,39 @@ describe("reportQueryCacheError", () => {
     expect(message).toContain("OrdinalsClassifierUnavailableError");
   });
 
-  it("records a permanent HTTP failure as a breadcrumb, not a captured error", () => {
+  const geoBlockError = () =>
+    Object.assign(new Error("GraphQL Error (Code: 451)"), {
+      response: { status: 451 },
+    });
+
+  it("captures the geo-block once, not per settled query", () => {
+    // A breadcrumb only ships if some other error is captured in the same
+    // session, so a geo-blocked user produced no signal at all. One captured
+    // event keeps it visible; the latch keeps the volume flat.
+    reportQueryCacheError(geoBlockError(), "Query");
+    reportQueryCacheError(geoBlockError(), "Query");
+    reportQueryCacheError(geoBlockError(), "Mutation");
+
+    expect(mockLoggerError).not.toHaveBeenCalled();
+    expect(mockLoggerEvent).toHaveBeenCalledTimes(1);
+    expect(mockLoggerEvent.mock.calls[0][0]).toContain("451");
+    expect(mockLoggerEvent.mock.calls[0][1].level).toBe("warning");
+  });
+
+  it("keeps the raw message out of the geo-block event", () => {
+    // A graphql-request ClientError stringifies the whole response AND request,
+    // so the message can carry query variables — BTC/ETH addresses included.
     reportQueryCacheError(
-      Object.assign(new Error("GraphQL Error (Code: 451)"), {
+      Object.assign(new Error('GraphQL Error: {"address":"bc1qexampleaddr"}'), {
         response: { status: 451 },
       }),
       "Query",
+      "vault.status",
     );
 
-    expect(mockLoggerError).not.toHaveBeenCalled();
-    expect(mockLoggerWarn).toHaveBeenCalledTimes(1);
-    expect(mockLoggerWarn.mock.calls[0][0]).toContain("451");
+    const [, context] = mockLoggerEvent.mock.calls[0];
+    expect(JSON.stringify(context)).not.toContain("bc1qexampleaddr");
+    expect(context.source).toBe("vault.status");
   });
 
   it("still captures a 400, which is a defect rather than a location", () => {

--- a/services/vault/src/config/__tests__/queryClient.test.ts
+++ b/services/vault/src/config/__tests__/queryClient.test.ts
@@ -73,6 +73,13 @@ describe("default query retry policy", () => {
     expect(retryFor(httpError(404))).toBe(false);
   });
 
+  it("does not retry a 501, despite it being 5xx", () => {
+    // 501 means the server does not implement the operation, which retrying
+    // cannot change. Pinned because the neighbouring 5xx rule says the
+    // opposite and the two are easy to conflate.
+    expect(retryFor(httpError(501))).toBe(false);
+  });
+
   it("still retries a rate limit and a server error", () => {
     expect(retryFor(httpError(429))).toBe(true);
     expect(retryFor(httpError(503))).toBe(true);
@@ -117,6 +124,44 @@ describe("reportQueryCacheError", () => {
     expect(mockLoggerError).not.toHaveBeenCalled();
     expect(mockLoggerWarn).toHaveBeenCalledTimes(1);
     expect(mockLoggerWarn.mock.calls[0][0]).toContain("451");
+  });
+
+  it("still captures a 400, which is a defect rather than a location", () => {
+    // Not retrying and not reporting are separate decisions. A malformed query
+    // is pointless to retry but someone needs to see it.
+    reportQueryCacheError(
+      Object.assign(new Error("GraphQL Error (Code: 400)"), {
+        response: { status: 400 },
+      }),
+      "Query",
+    );
+
+    expect(mockLoggerWarn).not.toHaveBeenCalled();
+    expect(mockLoggerError).toHaveBeenCalledTimes(1);
+  });
+
+  it("still captures a 501, which signals a frontend/backend skew", () => {
+    reportQueryCacheError(
+      Object.assign(new Error("GraphQL Error (Code: 501)"), {
+        response: { status: 501 },
+      }),
+      "Query",
+    );
+
+    expect(mockLoggerWarn).not.toHaveBeenCalled();
+    expect(mockLoggerError).toHaveBeenCalledTimes(1);
+  });
+
+  it("captures a viem-shaped error carrying a top-level status", () => {
+    // viem's HttpRequestError puts the status on the error itself rather than
+    // under `response`, and it does reach this handler.
+    reportQueryCacheError(
+      Object.assign(new Error("HTTP request failed"), { status: 401 }),
+      "Query",
+    );
+
+    expect(mockLoggerWarn).not.toHaveBeenCalled();
+    expect(mockLoggerError).toHaveBeenCalledTimes(1);
   });
 
   it("captures a genuine query error with the query context tag", () => {

--- a/services/vault/src/config/__tests__/queryClient.test.ts
+++ b/services/vault/src/config/__tests__/queryClient.test.ts
@@ -6,7 +6,11 @@ vi.mock("@/infrastructure", () => ({
   logger: { error: mockLoggerError, warn: mockLoggerWarn },
 }));
 
-import { isExpectedQueryError, reportQueryCacheError } from "../queryClient";
+import {
+  createQueryClient,
+  isExpectedQueryError,
+  reportQueryCacheError,
+} from "../queryClient";
 
 /**
  * A structural copy of the wallet-connector's error, constructed here so the
@@ -37,6 +41,56 @@ describe("isExpectedQueryError", () => {
   });
 });
 
+/**
+ * The retry predicate is exercised through the wired client rather than
+ * exported directly, so these tests pin the behaviour production actually gets.
+ */
+describe("default query retry policy", () => {
+  const retryFor = (error: Error, failureCount = 0): boolean => {
+    const retry = createQueryClient().getDefaultOptions().queries?.retry;
+    if (typeof retry !== "function") {
+      throw new Error(
+        "expected a retry predicate on the default query options",
+      );
+    }
+    return retry(failureCount, error) as boolean;
+  };
+
+  /** graphql-request's ClientError shape. */
+  const httpError = (status: number): Error =>
+    Object.assign(new Error(`GraphQL Error (Code: ${status})`), {
+      response: { status },
+    });
+
+  it("does not retry a 451, which is permanent for the session", () => {
+    // A geo-block previously retried on every poll cycle, forever, and each
+    // settled failure billed a separate Sentry issue.
+    expect(retryFor(httpError(451))).toBe(false);
+  });
+
+  it("does not retry other permanent statuses", () => {
+    expect(retryFor(httpError(403))).toBe(false);
+    expect(retryFor(httpError(404))).toBe(false);
+  });
+
+  it("still retries a rate limit and a server error", () => {
+    expect(retryFor(httpError(429))).toBe(true);
+    expect(retryFor(httpError(503))).toBe(true);
+  });
+
+  it("still retries a transient network failure", () => {
+    expect(retryFor(new Error("Failed to fetch"))).toBe(true);
+  });
+
+  it("does not retry a user-cancelled wallet prompt", () => {
+    expect(retryFor(new Error("User rejected the request."))).toBe(false);
+  });
+
+  it("gives up after three failures", () => {
+    expect(retryFor(new Error("Failed to fetch"), 3)).toBe(false);
+  });
+});
+
 describe("reportQueryCacheError", () => {
   beforeEach(() => {
     mockLoggerError.mockReset();
@@ -50,6 +104,19 @@ describe("reportQueryCacheError", () => {
     expect(mockLoggerWarn).toHaveBeenCalledTimes(1);
     const [message] = mockLoggerWarn.mock.calls[0];
     expect(message).toContain("OrdinalsClassifierUnavailableError");
+  });
+
+  it("records a permanent HTTP failure as a breadcrumb, not a captured error", () => {
+    reportQueryCacheError(
+      Object.assign(new Error("GraphQL Error (Code: 451)"), {
+        response: { status: 451 },
+      }),
+      "Query",
+    );
+
+    expect(mockLoggerError).not.toHaveBeenCalled();
+    expect(mockLoggerWarn).toHaveBeenCalledTimes(1);
+    expect(mockLoggerWarn.mock.calls[0][0]).toContain("451");
   });
 
   it("captures a genuine query error with the query context tag", () => {

--- a/services/vault/src/config/queryClient.ts
+++ b/services/vault/src/config/queryClient.ts
@@ -1,9 +1,41 @@
 import { MutationCache, QueryCache, QueryClient } from "@tanstack/react-query";
 
 import { logger } from "@/infrastructure";
+import { isUserCancellation } from "@/utils/errors/userCancellation";
 
 const calculateRetryDelay = (attemptIndex: number): number => {
   return Math.min(1000 * 2 ** attemptIndex, 30000);
+};
+
+/**
+ * HTTP statuses that will not change by trying again with the same request.
+ * 451 is the one that hurt in production: a geo-block made every poll cycle
+ * issue four doomed requests, and two independent 30s-interval queries then
+ * alternated for over an hour, each settled failure billing a Sentry issue.
+ * 408 and 429 stay retryable, as does everything 5xx.
+ */
+const PERMANENT_HTTP_STATUSES = new Set([400, 401, 403, 404, 410, 451, 501]);
+
+/**
+ * Pull an HTTP status off the error shapes this app actually throws:
+ * graphql-request's `ClientError` (`response.status`) and the app's own
+ * `ApiError` (`status`).
+ */
+const httpStatusOf = (error: unknown): number | undefined => {
+  if (!error || typeof error !== "object") return undefined;
+
+  const { status, response } = error as {
+    status?: unknown;
+    response?: { status?: unknown };
+  };
+  if (typeof status === "number") return status;
+  if (typeof response?.status === "number") return response.status;
+  return undefined;
+};
+
+const isPermanentHttpError = (error: unknown): boolean => {
+  const status = httpStatusOf(error);
+  return status !== undefined && PERMANENT_HTTP_STATUSES.has(status);
 };
 
 const shouldRetry = (failureCount: number, error: Error): boolean => {
@@ -11,11 +43,18 @@ const shouldRetry = (failureCount: number, error: Error): boolean => {
     return false;
   }
 
-  if (error.message?.includes("rejected")) {
+  if (isPermanentHttpError(error)) {
     return false;
   }
 
-  if (error.message?.includes("User rejected")) {
+  if (isUserCancellation(error)) {
+    return false;
+  }
+
+  // Kept deliberately broad for the retry decision only: any rejection wording
+  // (including a deterministic contract rejection, which `isUserCancellation`
+  // intentionally does not match) reproduces on retry, so re-sending is waste.
+  if (error.message?.includes("rejected")) {
     return false;
   }
 
@@ -53,6 +92,21 @@ export function reportQueryCacheError(
     });
     return;
   }
+
+  // A permanent status is a property of where the user is, not a fault we can
+  // act on, and it repeats on every poll for the rest of the session. Recorded
+  // as a breadcrumb so it still attaches to any genuine error captured later.
+  const permanentStatus = httpStatusOf(error);
+  if (permanentStatus !== undefined && isPermanentHttpError(error)) {
+    logger.warn(
+      `Permanent ${kind.toLowerCase()} failure: HTTP ${permanentStatus}`,
+      {
+        detail: error.message,
+      },
+    );
+    return;
+  }
+
   logger.error(error, {
     data: { context: `React Query Error [${kind}]` },
   });

--- a/services/vault/src/config/queryClient.ts
+++ b/services/vault/src/config/queryClient.ts
@@ -1,6 +1,11 @@
 import { MutationCache, QueryCache, QueryClient } from "@tanstack/react-query";
 
 import { logger } from "@/infrastructure";
+import {
+  HTTP_GEO_BLOCKED,
+  httpStatusOf,
+  isError451,
+} from "@/utils/errors/types";
 import { isUserCancellation } from "@/utils/errors/userCancellation";
 
 const calculateRetryDelay = (attemptIndex: number): number => {
@@ -16,42 +21,16 @@ const calculateRetryDelay = (attemptIndex: number): number => {
  *
  * 501 is here deliberately. It is 5xx by number but it means "this server does
  * not implement this operation", which no amount of retrying changes.
- */
-const NON_RETRYABLE_HTTP_STATUSES = new Set([
-  400, 401, 403, 404, 410, 451, 501,
-]);
-
-/**
- * Statuses that are also not worth a standalone Sentry issue.
  *
- * Deliberately narrower than {@link NON_RETRYABLE_HTTP_STATUSES}: not retrying
- * and not reporting are different decisions. A geo-block (451) is a property of
- * where the user is and repeats every poll for the rest of the session, so it
- * is breadcrumbed. Everything else - a 400 from a malformed query, a 501 from a
- * frontend/backend version skew - is a real defect someone should see, so it
- * still reaches `logger.error` even though it is never retried.
+ * Deliberately narrow. 401/403/404 are NOT here, because on this app's
+ * endpoints they are routinely transient: a just-broadcast transaction is not
+ * indexed yet, a subgraph is mid-redeploy, an RPC provider returns 401/403 for
+ * a rate limit or an edge condition, and a rotated key clears its own 401.
+ * The in-fetch retries are what bridge that propagation lag. This predicate
+ * also governs mutations, so a status added here stops retrying ETH
+ * submissions too.
  */
-const UNREPORTABLE_HTTP_STATUSES = new Set([451]);
-
-/**
- * Pull an HTTP status off the error shapes that actually reach this handler:
- * graphql-request's `ClientError` (`response.status`) and viem's
- * `HttpRequestError` (`status`).
- *
- * Note the app's own `ApiError` does NOT reach here - every throw site is
- * caught inside `healthCheckService`.
- */
-const httpStatusOf = (error: unknown): number | undefined => {
-  if (!error || typeof error !== "object") return undefined;
-
-  const { status, response } = error as {
-    status?: unknown;
-    response?: { status?: unknown };
-  };
-  if (typeof status === "number") return status;
-  if (typeof response?.status === "number") return response.status;
-  return undefined;
-};
+const NON_RETRYABLE_HTTP_STATUSES = new Set([400, 410, 451, 501]);
 
 const isNonRetryableHttpError = (error: unknown): boolean => {
   const status = httpStatusOf(error);
@@ -67,14 +46,10 @@ const shouldRetry = (failureCount: number, error: Error): boolean => {
     return false;
   }
 
-  if (isUserCancellation(error)) {
-    return false;
-  }
-
   // Kept deliberately broad for the retry decision only: any rejection wording
   // (including a deterministic contract rejection, which `isUserCancellation`
   // intentionally does not match) reproduces on retry, so re-sending is waste.
-  if (error.message?.includes("rejected")) {
+  if (isUserCancellation(error) || error.message?.includes("rejected")) {
     return false;
   }
 
@@ -102,9 +77,32 @@ export function isExpectedQueryError(error: Error): boolean {
   return EXPECTED_QUERY_ERROR_NAMES.has(error.name);
 }
 
+/**
+ * Whether this session has already reported the geo-block.
+ *
+ * A 451 is a property of where the user is: it repeats on every poll for the
+ * rest of the session and nothing the user does clears it. Reporting each
+ * settled query was what billed an issue per failure; breadcrumbing it instead
+ * went too far the other way, because a breadcrumb only ships if some *other*
+ * error is captured in the same session — so a geo-blocked user got a broken
+ * app and we learned nothing. Worse, two 30s-interval queries at four requests
+ * per cycle evict Sentry's 100-breadcrumb buffer in about 25 minutes, taking
+ * the surrounding context with them.
+ *
+ * One captured event per session is the middle: the geo-block stays visible
+ * while the volume stays flat. Module scope, so it resets with the page.
+ */
+let geoBlockReported = false;
+
+/** Reset the once-per-session geo-block latch. Test seam only. */
+export function resetGeoBlockReportingForTests(): void {
+  geoBlockReported = false;
+}
+
 export function reportQueryCacheError(
   error: Error,
   kind: "Query" | "Mutation",
+  source?: string,
 ): void {
   if (isExpectedQueryError(error)) {
     logger.warn(`Expected ${kind.toLowerCase()} condition: ${error.name}`, {
@@ -113,17 +111,22 @@ export function reportQueryCacheError(
     return;
   }
 
-  // An unreportable status is a property of where the user is, not a fault we
-  // can act on, and it repeats on every poll for the rest of the session.
-  // Recorded as a breadcrumb so it still attaches to any genuine error captured
-  // later. Note this set is NOT the non-retryable set: a 400 or 501 is equally
-  // pointless to retry but is a real defect, so it falls through to
-  // `logger.error` below.
-  const status = httpStatusOf(error);
-  if (status !== undefined && UNREPORTABLE_HTTP_STATUSES.has(status)) {
-    logger.warn(`Unreportable ${kind.toLowerCase()} failure: HTTP ${status}`, {
-      detail: error.message,
-    });
+  // Note this is NOT the non-retryable set: a 400 or 501 is equally pointless
+  // to retry but is a real defect, so it falls through to `logger.error` below.
+  if (isError451(error)) {
+    if (!geoBlockReported) {
+      geoBlockReported = true;
+      // Deliberately no `error.message`: a graphql-request `ClientError`
+      // stringifies the whole response *and* request, so the message can carry
+      // query variables (BTC/ETH addresses). The status plus the query key is
+      // smaller and safer, and `scrubString` is then a backstop rather than the
+      // only thing standing between us and an address in telemetry.
+      logger.event("Geo-blocked data plane (HTTP 451)", {
+        level: "warning",
+        tags: { httpStatus: String(HTTP_GEO_BLOCKED), kind },
+        ...(source ? { source } : {}),
+      });
+    }
     return;
   }
 
@@ -134,11 +137,17 @@ export function reportQueryCacheError(
 
 export const createQueryClient = (): QueryClient => {
   const queryCache = new QueryCache({
-    onError: (error) => reportQueryCacheError(error, "Query"),
+    onError: (error, query) =>
+      reportQueryCacheError(error, "Query", query.queryHash),
   });
 
   const mutationCache = new MutationCache({
-    onError: (error) => reportQueryCacheError(error, "Mutation"),
+    onError: (error, _variables, _context, mutation) =>
+      reportQueryCacheError(
+        error,
+        "Mutation",
+        mutation.options.mutationKey?.join("."),
+      ),
   });
 
   return new QueryClient({

--- a/services/vault/src/config/queryClient.ts
+++ b/services/vault/src/config/queryClient.ts
@@ -12,14 +12,34 @@ const calculateRetryDelay = (attemptIndex: number): number => {
  * 451 is the one that hurt in production: a geo-block made every poll cycle
  * issue four doomed requests, and two independent 30s-interval queries then
  * alternated for over an hour, each settled failure billing a Sentry issue.
- * 408 and 429 stay retryable, as does everything 5xx.
+ * 408 and 429 stay retryable.
+ *
+ * 501 is here deliberately. It is 5xx by number but it means "this server does
+ * not implement this operation", which no amount of retrying changes.
  */
-const PERMANENT_HTTP_STATUSES = new Set([400, 401, 403, 404, 410, 451, 501]);
+const NON_RETRYABLE_HTTP_STATUSES = new Set([
+  400, 401, 403, 404, 410, 451, 501,
+]);
 
 /**
- * Pull an HTTP status off the error shapes this app actually throws:
- * graphql-request's `ClientError` (`response.status`) and the app's own
- * `ApiError` (`status`).
+ * Statuses that are also not worth a standalone Sentry issue.
+ *
+ * Deliberately narrower than {@link NON_RETRYABLE_HTTP_STATUSES}: not retrying
+ * and not reporting are different decisions. A geo-block (451) is a property of
+ * where the user is and repeats every poll for the rest of the session, so it
+ * is breadcrumbed. Everything else - a 400 from a malformed query, a 501 from a
+ * frontend/backend version skew - is a real defect someone should see, so it
+ * still reaches `logger.error` even though it is never retried.
+ */
+const UNREPORTABLE_HTTP_STATUSES = new Set([451]);
+
+/**
+ * Pull an HTTP status off the error shapes that actually reach this handler:
+ * graphql-request's `ClientError` (`response.status`) and viem's
+ * `HttpRequestError` (`status`).
+ *
+ * Note the app's own `ApiError` does NOT reach here - every throw site is
+ * caught inside `healthCheckService`.
  */
 const httpStatusOf = (error: unknown): number | undefined => {
   if (!error || typeof error !== "object") return undefined;
@@ -33,9 +53,9 @@ const httpStatusOf = (error: unknown): number | undefined => {
   return undefined;
 };
 
-const isPermanentHttpError = (error: unknown): boolean => {
+const isNonRetryableHttpError = (error: unknown): boolean => {
   const status = httpStatusOf(error);
-  return status !== undefined && PERMANENT_HTTP_STATUSES.has(status);
+  return status !== undefined && NON_RETRYABLE_HTTP_STATUSES.has(status);
 };
 
 const shouldRetry = (failureCount: number, error: Error): boolean => {
@@ -43,7 +63,7 @@ const shouldRetry = (failureCount: number, error: Error): boolean => {
     return false;
   }
 
-  if (isPermanentHttpError(error)) {
+  if (isNonRetryableHttpError(error)) {
     return false;
   }
 
@@ -93,17 +113,17 @@ export function reportQueryCacheError(
     return;
   }
 
-  // A permanent status is a property of where the user is, not a fault we can
-  // act on, and it repeats on every poll for the rest of the session. Recorded
-  // as a breadcrumb so it still attaches to any genuine error captured later.
-  const permanentStatus = httpStatusOf(error);
-  if (permanentStatus !== undefined && isPermanentHttpError(error)) {
-    logger.warn(
-      `Permanent ${kind.toLowerCase()} failure: HTTP ${permanentStatus}`,
-      {
-        detail: error.message,
-      },
-    );
+  // An unreportable status is a property of where the user is, not a fault we
+  // can act on, and it repeats on every poll for the rest of the session.
+  // Recorded as a breadcrumb so it still attaches to any genuine error captured
+  // later. Note this set is NOT the non-retryable set: a 400 or 501 is equally
+  // pointless to retry but is a real defect, so it falls through to
+  // `logger.error` below.
+  const status = httpStatusOf(error);
+  if (status !== undefined && UNREPORTABLE_HTTP_STATUSES.has(status)) {
+    logger.warn(`Unreportable ${kind.toLowerCase()} failure: HTTP ${status}`, {
+      detail: error.message,
+    });
     return;
   }
 

--- a/services/vault/src/context/wallet/VaultWalletConnectionProvider.tsx
+++ b/services/vault/src/context/wallet/VaultWalletConnectionProvider.tsx
@@ -21,6 +21,7 @@ import { getNetworkConfigBTC } from "@/config";
 import featureFlags from "@/config/featureFlags";
 import { getNetworkConfigETH } from "@/config/network";
 import { logger } from "@/infrastructure";
+import { isUserCancellation } from "@/utils/errors/userCancellation";
 
 // Vault deposits need the BTC wallet's `deriveContextHash` (docs/specs/derive-context-hash.md).
 // ALWAYS_DISABLED_WALLETS keeps non-conforming adapters (appkit/injectable/ledger) permanently out
@@ -222,8 +223,8 @@ export const WalletConnectionProvider = ({ children }: PropsWithChildren) => {
   );
 
   const onError = useCallback((error: Error) => {
-    // User rejections are expected, don't log them
-    if (error?.message?.includes("rejected")) {
+    // Declining or dismissing a wallet prompt is routine drop-off, not a fault.
+    if (isUserCancellation(error)) {
       return;
     }
     logger.error(error, { data: { context: "Wallet connection error" } });

--- a/services/vault/src/hooks/deposit/useDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useDepositFlow.ts
@@ -1055,6 +1055,12 @@ export function useDepositFlow(
               logger.error(
                 error instanceof Error ? error : new Error(String(error)),
                 {
+                  // Tagged so the Sentry-side cancellation drop keeps it: the
+                  // loop continues to the next vault, so a rejected prompt here
+                  // leaves THIS vault without its WOTS key while the deposit
+                  // proceeds. That partial state is the reportable event even
+                  // though the cause is a user cancellation.
+                  tags: { partialFailure: "multi-vault" },
                   data: {
                     context:
                       "[Multi-Vault] Failed to submit WOTS key for vault",
@@ -1201,6 +1207,10 @@ export function useDepositFlow(
             logger.error(
               error instanceof Error ? error : new Error(String(error)),
               {
+                // See the WOTS site above: the loop continues, so a rejected
+                // prompt leaves this vault under-signed while the deposit
+                // proceeds. Exempt from the cancellation drop.
+                tags: { partialFailure: "multi-vault" },
                 data: {
                   context:
                     "[Multi-Vault] Failed to sign or submit payouts for vault",

--- a/services/vault/src/utils/errors/__tests__/domMutationErrors.test.ts
+++ b/services/vault/src/utils/errors/__tests__/domMutationErrors.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Pins which DOM failures are attributed to a page-translation extension.
+ *
+ * These errors used to sit in Sentry's `ignoreErrors`, which runs ahead of
+ * `beforeSend` — so an app-boundary crash carrying the same message was dropped
+ * before any tag could rescue it. The predicates here are what let `beforeSend`
+ * drop only the attributable ones.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  hasTranslationExtensionMarkers,
+  isReactDomMutationError,
+} from "../domMutationErrors";
+
+describe("isReactDomMutationError", () => {
+  it.each([
+    "NotFoundError: The node to be removed is not a child of this node.",
+    "Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.",
+    "Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.",
+    // Safari's wording for the same failure — previously uncovered.
+    "NotFoundError: The object can not be found here.",
+  ])("matches the DOM-mutation failure %#", (message) => {
+    expect(isReactDomMutationError(message)).toBe(true);
+  });
+
+  it.each([
+    "Cannot redefine property: ethereum",
+    "Failed to fetch",
+    "The node to be removed is fine actually",
+  ])("does not match the unrelated error %#", (message) => {
+    expect(isReactDomMutationError(message)).toBe(false);
+  });
+});
+
+describe("hasTranslationExtensionMarkers", () => {
+  afterEach(() => {
+    document.documentElement.className = "";
+    document.body.innerHTML = "";
+  });
+
+  it("reports false on an untouched document", () => {
+    expect(hasTranslationExtensionMarkers()).toBe(false);
+  });
+
+  it("detects Google Translate's html class", () => {
+    document.documentElement.classList.add("translated-ltr");
+
+    expect(hasTranslationExtensionMarkers()).toBe(true);
+  });
+
+  it("detects a right-to-left Google translation", () => {
+    document.documentElement.classList.add("translated-rtl");
+
+    expect(hasTranslationExtensionMarkers()).toBe(true);
+  });
+
+  it("detects Edge/Bing Translate's font wrapper", () => {
+    document.body.innerHTML = '<font _msttexthash="123">Deposit</font>';
+
+    expect(hasTranslationExtensionMarkers()).toBe(true);
+  });
+
+  it("does not treat an ordinary font element as a translation", () => {
+    document.body.innerHTML = "<font>Deposit</font>";
+
+    expect(hasTranslationExtensionMarkers()).toBe(false);
+  });
+});

--- a/services/vault/src/utils/errors/__tests__/formatting.test.ts
+++ b/services/vault/src/utils/errors/__tests__/formatting.test.ts
@@ -225,6 +225,28 @@ describe("Error Formatting", () => {
       expect(sanitizeErrorMessage(err)).toMatch(/Transaction rejected/);
     });
 
+    it.each(["Connection to Keystone was canceled", "Proposal expired"])(
+      "classifies the telemetry-suppressed wording %#: %s",
+      (message) => {
+        // These were dropped from Sentry as cancellations while the classifier
+        // still returned null, so the depositor got generic copy for an error
+        // we had already decided was a cancellation. One shared vocabulary now.
+        expect(sanitizeErrorMessage(new Error(message))).toMatch(
+          /Transaction rejected/,
+        );
+      },
+    );
+
+    it("keeps the outermost category when an inner frame is a cancellation", () => {
+      // Precedence (b): depth-first, outermost wins. The shared predicate is
+      // per-frame precisely so it cannot reach past this.
+      const err = Object.assign(new Error("Insufficient funds for gas"), {
+        cause: new Error("User rejected the request"),
+      });
+
+      expect(sanitizeErrorMessage(err)).not.toMatch(/Transaction rejected/);
+    });
+
     it("does not collapse non-rejection errors", () => {
       const err = new Error("execution reverted: bad signature");
       expect(sanitizeErrorMessage(err)).toBe(

--- a/services/vault/src/utils/errors/__tests__/userCancellation.test.ts
+++ b/services/vault/src/utils/errors/__tests__/userCancellation.test.ts
@@ -10,7 +10,10 @@
 
 import { describe, expect, it } from "vitest";
 
-import { isUserCancellation } from "../userCancellation";
+import {
+  isUserCancellation,
+  isUserCancellationFrame,
+} from "../userCancellation";
 
 describe("isUserCancellation", () => {
   it("matches an EIP-1193 user-rejected code", () => {
@@ -58,6 +61,16 @@ describe("isUserCancellation", () => {
   });
 
   it.each([
+    "Transaction rejected by user",
+    "Action cancelled by user",
+    "denied by the user",
+    "User closed modal",
+  ])("matches the reversed word order %#: %s", (message) => {
+    // Trezor, Ledger APDU 0x6985 and WalletConnect all put the subject last.
+    expect(isUserCancellation(new Error(message))).toBe(true);
+  });
+
+  it.each([
     "Failed to connect wallet: Connection timeout",
     "The contract rejected this transaction",
     "Transaction creation failed.",
@@ -65,6 +78,51 @@ describe("isUserCancellation", () => {
     "Chainlink price data is stale. Using last known price.",
   ])("does not match the genuine failure %#: %s", (message) => {
     expect(isUserCancellation(new Error(message))).toBe(false);
+  });
+
+  it.each([
+    "The contract rejected the borrow request",
+    "The node rejected the signing request",
+    "RPC error: server rejected the transaction request",
+  ])("requires a wallet subject, so %#: %s still reports", (message) => {
+    // The `rejected the <noun> request` arm used to carry no subject, so any
+    // actor rejecting any noun-request read as a user cancellation.
+    expect(isUserCancellation(new Error(message))).toBe(false);
+  });
+
+  it("does not let the connection arm span unrelated clauses", () => {
+    // `connection to .+ was rejected` allowed `.+` to run across the whole
+    // message; the wallet name is now bounded to at most three words.
+    expect(
+      isUserCancellation(
+        new Error(
+          "Connection to indexer failed after the tx was rejected by the network",
+        ),
+      ),
+    ).toBe(false);
+  });
+
+  it("matches a bare-string cause nested under a wrapper", () => {
+    // The walk's `typeof === object` guard stopped at the first string cause,
+    // so a wrapper around a string-throwing adapter reported as a fault.
+    expect(
+      isUserCancellation(
+        new Error("Failed to broadcast", {
+          cause: "User rejected the request",
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not walk the cause chain when checking a single frame", () => {
+    // `classifyError` is depth-first with the outermost match winning, so the
+    // per-frame predicate must not reach into causes on its behalf.
+    const error = new Error("Insufficient funds", {
+      cause: new Error("User rejected the request"),
+    });
+
+    expect(isUserCancellationFrame(error)).toBe(false);
+    expect(isUserCancellation(error)).toBe(true);
   });
 
   it("matches a bare string rejection, which some adapters throw", () => {

--- a/services/vault/src/utils/errors/__tests__/userCancellation.test.ts
+++ b/services/vault/src/utils/errors/__tests__/userCancellation.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Pins which wallet failures count as the depositor cancelling.
+ *
+ * This predicate decides what does NOT reach Sentry, so it is load-bearing in
+ * both directions: the wordings below were all captured in production as
+ * errors, and the negative cases are genuine faults that must keep reporting.
+ * The previous check was `message.includes("rejected")`, which matched only
+ * one of the four vocabularies wallets actually use.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { isUserCancellation } from "../userCancellation";
+
+describe("isUserCancellation", () => {
+  it("matches an EIP-1193 user-rejected code", () => {
+    expect(
+      isUserCancellation(Object.assign(new Error("nope"), { code: 4001 })),
+    ).toBe(true);
+  });
+
+  it("matches viem's UserRejectedRequestError by name", () => {
+    const error = new Error("User rejected the request.");
+    error.name = "UserRejectedRequestError";
+
+    expect(isUserCancellation(error)).toBe(true);
+  });
+
+  it("matches the wallet-connector CONNECTION_REJECTED code", () => {
+    expect(
+      isUserCancellation(
+        Object.assign(new Error("connection failed"), {
+          code: "CONNECTION_REJECTED",
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it.each([
+    "Connection to Keystone was canceled",
+    "Failed to connect wallet: Connection cancelled",
+    "Request Signature: User denied request signature.",
+    "User rejected the PSBT signing request in Unisat Wallet",
+    "Connection to Unisat Wallet was rejected",
+    "ContractError: borrow from Aave Core position was rejected by the wallet.",
+    "Error: Unisat Wallet rejected the deriveContextHash approval",
+    "Proposal expired",
+  ])("matches the production wording %#: %s", (message) => {
+    expect(isUserCancellation(new Error(message))).toBe(true);
+  });
+
+  it("matches a cancellation wrapped as a cause", () => {
+    const error = new Error("Failed to broadcast batch Pre-PegIn transaction", {
+      cause: new Error("User rejected the PSBT signing request"),
+    });
+
+    expect(isUserCancellation(error)).toBe(true);
+  });
+
+  it.each([
+    "Failed to connect wallet: Connection timeout",
+    "The contract rejected this transaction",
+    "Transaction creation failed.",
+    "Failed to fetch",
+    "Chainlink price data is stale. Using last known price.",
+  ])("does not match the genuine failure %#: %s", (message) => {
+    expect(isUserCancellation(new Error(message))).toBe(false);
+  });
+
+  it("matches a bare string rejection, which some adapters throw", () => {
+    expect(isUserCancellation("User rejected the request")).toBe(true);
+    expect(isUserCancellation("Failed to fetch")).toBe(false);
+  });
+
+  it("does not match null or undefined", () => {
+    expect(isUserCancellation(null)).toBe(false);
+    expect(isUserCancellation(undefined)).toBe(false);
+  });
+
+  it("terminates on a self-referencing cause chain", () => {
+    const error = new Error("boom") as Error & { cause?: unknown };
+    error.cause = error;
+
+    expect(isUserCancellation(error)).toBe(false);
+  });
+});

--- a/services/vault/src/utils/errors/depositErrors.ts
+++ b/services/vault/src/utils/errors/depositErrors.ts
@@ -36,10 +36,10 @@ import { COPY } from "@/copy";
 import {
   classifyError,
   formatErrorDiagnostics,
-  isWalletRejectionError,
   mapVpRpcError,
   sanitizeErrorMessage,
 } from "./formatting";
+import { isUserCancellation, isWalletRejectionError } from "./userCancellation";
 
 export interface DepositErrorContent {
   title: string;
@@ -179,16 +179,13 @@ export function mapDepositError(err: unknown): DepositErrorContent {
 
   // 6. Wallet signing rejection. The coded path (step 1) misses rejections that
   // happen inside the broadcast step, because that catch re-wraps them in a
-  // fresh Error (losing the code). Match the phrasing before the broadcast
-  // bucket so "Failed to broadcast ...: user rejected" reads as a rejection.
-  // Scope to wallet phrases ("user rejected/denied/cancelled") so unrelated
-  // "access denied"/"permission denied" errors don't get mislabeled.
-  if (
-    msg.includes("user rejected") ||
-    msg.includes("user denied") ||
-    msg.includes("user cancelled") ||
-    msg.includes("user canceled")
-  ) {
+  // fresh Error (losing the code). Checked before the broadcast bucket so
+  // "Failed to broadcast ...: user rejected" reads as a rejection.
+  //
+  // Shares its vocabulary with the Sentry-side drop rather than keeping a local
+  // wording list: a cancellation that telemetry correctly suppressed used to
+  // fall through to generic copy here, which is the same drift on the UX side.
+  if (isUserCancellation(err)) {
     return ERRORS.signingRejected;
   }
 

--- a/services/vault/src/utils/errors/domMutationErrors.ts
+++ b/services/vault/src/utils/errors/domMutationErrors.ts
@@ -1,0 +1,67 @@
+/**
+ * Classification of React DOM-mutation failures by likely cause.
+ *
+ * React throws these when a node it owns was moved or removed by something
+ * else. Page-translation extensions cause them by swapping React-owned text
+ * nodes, and that is the common case - but React throws the *same* errors when
+ * our own tree has a reconciliation bug (portal misuse, a `createPortal`
+ * container removed out from under it).
+ *
+ * Filtering them outright via Sentry's `ignoreErrors` hid both: `ignoreErrors`
+ * runs ahead of `beforeSend`, so a crash reported by the global error boundary
+ * was dropped before any tag could rescue it - and the rate of these errors is
+ * also the only metric that shows whether the `translate="no"` opt-out in
+ * `index.html` is working.
+ *
+ * Split into its own dependency-free module (like `userCancellation.ts`) so the
+ * predicates are unit-testable without importing `sentry.client.config.ts`,
+ * which runs `Sentry.init` on import.
+ *
+ * @module utils/errors/domMutationErrors
+ */
+
+/**
+ * Error text React (or the browser) produces when a node it owns has already
+ * been detached or reparented.
+ */
+const REACT_DOM_MUTATION_ERRORS: readonly (string | RegExp)[] = [
+  "The node to be removed is not a child of this node",
+  /Failed to execute '(removeChild|insertBefore)' on 'Node'/,
+  // Safari's wording for the same DOM failure.
+  "The object can not be found here.",
+];
+
+/** Whether `text` is one of the DOM-mutation failures described above. */
+export function isReactDomMutationError(text: string): boolean {
+  return REACT_DOM_MUTATION_ERRORS.some((pattern) =>
+    typeof pattern === "string" ? text.includes(pattern) : pattern.test(text),
+  );
+}
+
+/**
+ * Whether a page-translation extension has visibly rewritten the document.
+ *
+ * Google Translate (the extension and Chrome's built-in translator) stamps
+ * `translated-ltr` / `translated-rtl` on `<html>`; Edge/Bing Translate wraps
+ * translated runs in `<font _msttexthash=…>`. Both are observable from the
+ * page.
+ *
+ * A detection miss is safe by construction: callers keep the event rather than
+ * dropping it, so an undetected translator costs a warning-level issue, never a
+ * hidden crash. That is the intended bias - Firefox and Safari expose no
+ * comparable marker, and `translate="no"` is what covers them at the source.
+ */
+export function hasTranslationExtensionMarkers(): boolean {
+  if (typeof document === "undefined") return false;
+  try {
+    const root = document.documentElement;
+    return (
+      root.classList.contains("translated-ltr") ||
+      root.classList.contains("translated-rtl") ||
+      document.querySelector("font[_msttexthash]") !== null
+    );
+  } catch {
+    // A hostile or partially-torn-down document must not break the report path.
+    return false;
+  }
+}

--- a/services/vault/src/utils/errors/formatting.ts
+++ b/services/vault/src/utils/errors/formatting.ts
@@ -11,15 +11,10 @@ import {
 
 import { COPY } from "@/copy";
 
-/**
- * Wallet-connector error code emitted by BTC providers when the user rejects
- * a signing prompt. Mirrors `ERROR_CODES.CONNECTION_REJECTED` from
- * `@babylonlabs-io/wallet-connector`. Inlined to avoid pulling the full
- * wallet-connector bundle into this file (and its test transform); the
- * constant is the public contract - if it ever changes upstream, this string
- * must change too.
- */
-const WALLET_CONNECTION_REJECTED_CODE = "CONNECTION_REJECTED";
+import {
+  EIP1193_USER_REJECTED,
+  WALLET_CONNECTION_REJECTED_CODE,
+} from "./userCancellation";
 
 export function isWalletRejectionError(error: unknown): boolean {
   return (
@@ -31,7 +26,7 @@ export function isWalletRejectionError(error: unknown): boolean {
 
 /** EIP-1193 provider error codes used by the classifier below. */
 const EIP1193 = {
-  USER_REJECTED: 4001,
+  USER_REJECTED: EIP1193_USER_REJECTED,
   UNAUTHORIZED: 4100,
   PROVIDER_DISCONNECTED: 4900,
   CHAIN_DISCONNECTED: 4901,

--- a/services/vault/src/utils/errors/formatting.ts
+++ b/services/vault/src/utils/errors/formatting.ts
@@ -12,21 +12,12 @@ import {
 import { COPY } from "@/copy";
 
 import {
-  EIP1193_USER_REJECTED,
-  WALLET_CONNECTION_REJECTED_CODE,
+  isUserCancellationFrame,
+  isWalletRejectionError,
 } from "./userCancellation";
-
-export function isWalletRejectionError(error: unknown): boolean {
-  return (
-    error instanceof Error &&
-    "code" in error &&
-    (error as { code: unknown }).code === WALLET_CONNECTION_REJECTED_CODE
-  );
-}
 
 /** EIP-1193 provider error codes used by the classifier below. */
 const EIP1193 = {
-  USER_REJECTED: EIP1193_USER_REJECTED,
   UNAUTHORIZED: 4100,
   PROVIDER_DISCONNECTED: 4900,
   CHAIN_DISCONNECTED: 4901,
@@ -142,13 +133,12 @@ export function classifyError(err: unknown): ErrorKind | null {
     };
 
     // User rejection — MUST stay first within the frame; see precedence (a).
-    if (
-      obj.code === EIP1193.USER_REJECTED ||
-      obj.name === "UserRejectedRequestError"
-    ) {
-      return "user-rejection";
-    }
-    if (isWalletRejectionError(cur)) return "user-rejection";
+    // Shared with the telemetry-side drop so the two cannot drift: a wording
+    // this recognises but the classifier did not used to (e.g. "Connection to
+    // Keystone was canceled") was dropped from Sentry while still rendering
+    // generic error copy. `isUserCancellationFrame` deliberately does not walk
+    // `cause` — the walk here is what enforces precedence (b).
+    if (isUserCancellationFrame(cur)) return "user-rejection";
 
     // Insufficient ETH for gas + value
     if (obj.name === "InsufficientFundsError") return "insufficient-funds";

--- a/services/vault/src/utils/errors/types.ts
+++ b/services/vault/src/utils/errors/types.ts
@@ -121,12 +121,46 @@ export class ActivationNotPossibleError extends Error {
   }
 }
 
-export const isError451 = (error: unknown): boolean => {
+/** HTTP 451 — the data plane is geo-blocked for this client. */
+export const HTTP_GEO_BLOCKED = 451;
+
+/** Bounds of the HTTP status range, used to reject unrelated numeric fields. */
+const HTTP_STATUS_MIN = 100;
+const HTTP_STATUS_MAX = 599;
+
+const isHttpStatus = (value: unknown): value is number =>
+  Number.isInteger(value) &&
+  (value as number) >= HTTP_STATUS_MIN &&
+  (value as number) <= HTTP_STATUS_MAX;
+
+/**
+ * Pull an HTTP status off the error shapes that actually reach the app:
+ * graphql-request's `ClientError` (`response.status`) and viem's
+ * `HttpRequestError` (`status`).
+ *
+ * `response.status` wins when both are present - it is the more specific shape,
+ * and a bare top-level `status` is the one that collides with unrelated fields
+ * (a contract receipt status, a socket state, a wrapped daemon status). The
+ * range check rejects those regardless of which key they arrive under, so a
+ * receipt `status: 1` is never read as an HTTP status.
+ */
+export const httpStatusOf = (error: unknown): number | undefined => {
   if (!error || typeof error !== "object") {
-    return false;
+    return undefined;
   }
-  const maybeWithStatus = error as { status?: unknown };
-  return (
-    typeof maybeWithStatus.status === "number" && maybeWithStatus.status === 451
-  );
+  const { status, response } = error as {
+    status?: unknown;
+    response?: { status?: unknown };
+  };
+  if (isHttpStatus(response?.status)) return response.status;
+  if (isHttpStatus(status)) return status;
+  return undefined;
 };
+
+/**
+ * The single 451 predicate. Reads `response.status` as well as the top-level
+ * `status` so a graphql-request `ClientError` is recognised - the geo-block
+ * reaches the app through both shapes.
+ */
+export const isError451 = (error: unknown): boolean =>
+  httpStatusOf(error) === HTTP_GEO_BLOCKED;

--- a/services/vault/src/utils/errors/userCancellation.ts
+++ b/services/vault/src/utils/errors/userCancellation.ts
@@ -1,0 +1,80 @@
+/**
+ * Detection of user-cancelled wallet prompts, for deciding what NOT to report.
+ *
+ * Deliberately dependency-free: `sentry.client.config.ts` imports this at
+ * telemetry-init time, and pulling COPY or the SDK in there would put more
+ * module-init surface ahead of `Sentry.init` than the report path can afford.
+ */
+
+/** EIP-1193 `userRejectedRequest`. */
+export const EIP1193_USER_REJECTED = 4001;
+
+/**
+ * Wallet-connector error code emitted by BTC providers when the user rejects
+ * a signing prompt. Mirrors `ERROR_CODES.CONNECTION_REJECTED` from
+ * `@babylonlabs-io/wallet-connector`. Inlined to avoid pulling the full
+ * wallet-connector bundle into this file (and its test transform); the
+ * constant is the public contract - if it ever changes upstream, this string
+ * must change too.
+ */
+export const WALLET_CONNECTION_REJECTED_CODE = "CONNECTION_REJECTED";
+
+/**
+ * Wallet cancellation wording.
+ *
+ * A depositor closing a wallet popup is routine drop-off, not a fault, but
+ * wallets express it in at least four vocabularies (rejected / cancelled /
+ * canceled / denied) plus WalletConnect's "Proposal expired". The previous
+ * bare `includes("rejected")` caught only one of them, which is why
+ * cancellations were the single largest category of captured errors.
+ *
+ * Deliberately narrow: each alternative anchors on wallet-interaction phrasing
+ * rather than the bare word, so a genuine failure like "transaction was
+ * rejected by the node" is still reported. Connection *timeouts* are excluded
+ * on purpose - those are not user actions and may be real defects.
+ */
+const USER_CANCELLATION_PATTERN =
+  /user (?:rejected|denied|cancell?ed)|rejected by the wallet|rejected the \w+ (?:approval|request)|connection (?:cancell?ed|rejected)|connection to .+ was (?:cancell?ed|rejected)|denied request signature|proposal expired/i;
+
+/** How far to walk a `cause` chain before giving up. */
+const MAX_CAUSE_DEPTH = 10;
+
+/**
+ * True when the error is the user declining or dismissing a wallet prompt.
+ * Checks the typed signals first (EIP-1193 4001, viem's
+ * `UserRejectedRequestError`, the wallet-connector `CONNECTION_REJECTED`
+ * code), then falls back to wording for the wallets that only throw strings.
+ */
+export function isUserCancellation(error: unknown): boolean {
+  // Some wallet adapters reject with a bare string rather than an Error.
+  if (typeof error === "string") return USER_CANCELLATION_PATTERN.test(error);
+
+  let cur: unknown = error;
+
+  for (
+    let depth = 0;
+    depth <= MAX_CAUSE_DEPTH && cur && typeof cur === "object";
+    depth++
+  ) {
+    const { code, name, message, cause } = cur as {
+      code?: unknown;
+      name?: unknown;
+      message?: unknown;
+      cause?: unknown;
+    };
+
+    if (code === EIP1193_USER_REJECTED) return true;
+    if (code === WALLET_CONNECTION_REJECTED_CODE) return true;
+    if (name === "UserRejectedRequestError") return true;
+    if (
+      typeof message === "string" &&
+      USER_CANCELLATION_PATTERN.test(message)
+    ) {
+      return true;
+    }
+
+    cur = cause;
+  }
+
+  return false;
+}

--- a/services/vault/src/utils/errors/userCancellation.ts
+++ b/services/vault/src/utils/errors/userCancellation.ts
@@ -1,9 +1,18 @@
 /**
- * Detection of user-cancelled wallet prompts, for deciding what NOT to report.
+ * Detection of user-cancelled wallet prompts.
+ *
+ * The single definition of "the depositor declined this prompt", used for both
+ * decisions that depend on it: what NOT to report to Sentry, and which
+ * user-facing copy to render. `classifyError` and `mapDepositError` both call
+ * in here rather than carrying their own wording lists, so the two cannot drift
+ * apart — they had, and a cancellation that was correctly dropped from
+ * telemetry could still surface generic error copy to the depositor.
  *
  * Deliberately dependency-free: `sentry.client.config.ts` imports this at
  * telemetry-init time, and pulling COPY or the SDK in there would put more
  * module-init surface ahead of `Sentry.init` than the report path can afford.
+ * Nothing in this module may import from `formatting.ts` or `depositErrors.ts`;
+ * the dependency runs the other way.
  */
 
 /** EIP-1193 `userRejectedRequest`. */
@@ -23,57 +32,99 @@ export const WALLET_CONNECTION_REJECTED_CODE = "CONNECTION_REJECTED";
  * Wallet cancellation wording.
  *
  * A depositor closing a wallet popup is routine drop-off, not a fault, but
- * wallets express it in at least four vocabularies (rejected / cancelled /
- * canceled / denied) plus WalletConnect's "Proposal expired". The previous
- * bare `includes("rejected")` caught only one of them, which is why
- * cancellations were the single largest category of captured errors.
+ * wallets express it in several vocabularies (rejected / cancelled / canceled /
+ * denied), in both word orders ("user rejected" and "rejected by user"), plus
+ * WalletConnect's "Proposal expired" and "User closed modal". The previous bare
+ * `includes("rejected")` caught only one of them, which is why cancellations
+ * were the single largest category of captured errors.
  *
- * Deliberately narrow: each alternative anchors on wallet-interaction phrasing
- * rather than the bare word, so a genuine failure like "transaction was
- * rejected by the node" is still reported. Connection *timeouts* are excluded
- * on purpose - those are not user actions and may be real defects.
+ * Every alternative requires a wallet-interaction subject rather than the bare
+ * verb, so a genuine failure keeps reporting. Two arms are worth spelling out
+ * because they are the ones that previously over-matched:
+ *
+ * - The `rejected the <noun> approval/request` arm is anchored on
+ *   `wallet|user|you`. Unanchored it matched any actor rejecting any noun
+ *   request, so `The contract rejected the borrow request` and `The node
+ *   rejected the signing request` were both suppressed as cancellations.
+ * - The `connection to <name> was cancelled` arm bounds the wallet name to at
+ *   most three words. With `.+` it spanned unrelated clauses, so
+ *   `Connection to indexer failed after the tx was rejected by the network`
+ *   matched.
+ *
+ * Connection *timeouts* are excluded on purpose - those are not user actions
+ * and may be real defects.
+ *
+ * Known residue: `rejected by the wallet` also matches a hardware-wallet
+ * *policy* rejection (Ledger with blind signing off), which is a real UX defect
+ * worth seeing. The arm is kept because it backs a captured production wording
+ * where the user did decline - `borrow from Aave Core position was rejected by
+ * the wallet` - and the two are not separable by wording alone. The typed
+ * signals below are what carry the coded paths.
  */
 const USER_CANCELLATION_PATTERN =
-  /user (?:rejected|denied|cancell?ed)|rejected by the wallet|rejected the \w+ (?:approval|request)|connection (?:cancell?ed|rejected)|connection to .+ was (?:cancell?ed|rejected)|denied request signature|proposal expired/i;
+  /(?:user|you) (?:rejected|denied|cancell?ed)|(?:rejected|denied|cancell?ed) by (?:the )?user|rejected by the wallet|(?:wallet|user|you) rejected the \w+ (?:approval|request)|user closed (?:the )?modal|connection (?:cancell?ed|rejected)|connection to \w+(?: \w+){0,2} was (?:cancell?ed|rejected)|denied request signature|proposal expired/i;
 
 /** How far to walk a `cause` chain before giving up. */
 const MAX_CAUSE_DEPTH = 10;
 
 /**
- * True when the error is the user declining or dismissing a wallet prompt.
- * Checks the typed signals first (EIP-1193 4001, viem's
- * `UserRejectedRequestError`, the wallet-connector `CONNECTION_REJECTED`
- * code), then falls back to wording for the wallets that only throw strings.
+ * True when `error` carries the wallet-connector `CONNECTION_REJECTED` code.
+ *
+ * Lives here rather than in `formatting.ts` so the code constant and the
+ * predicate that reads it stay in the same dependency-free module.
+ */
+export function isWalletRejectionError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    (error as { code: unknown }).code === WALLET_CONNECTION_REJECTED_CODE
+  );
+}
+
+/**
+ * True when this single error frame is a user cancellation - typed signals
+ * (EIP-1193 4001, viem's `UserRejectedRequestError`, the wallet-connector
+ * `CONNECTION_REJECTED` code) first, then wording.
+ *
+ * Deliberately does NOT walk `cause`. Callers that classify per frame need to
+ * decide precedence across frames themselves: `classifyError` is depth-first
+ * with the outermost match winning, so a walking predicate there would let an
+ * inner cancellation shadow an outer category. Use {@link isUserCancellation}
+ * when you want the whole chain.
+ */
+export function isUserCancellationFrame(frame: unknown): boolean {
+  if (typeof frame === "string") return USER_CANCELLATION_PATTERN.test(frame);
+  if (!frame || typeof frame !== "object") return false;
+
+  const { code, name, message } = frame as {
+    code?: unknown;
+    name?: unknown;
+    message?: unknown;
+  };
+
+  if (code === EIP1193_USER_REJECTED) return true;
+  if (code === WALLET_CONNECTION_REJECTED_CODE) return true;
+  if (name === "UserRejectedRequestError") return true;
+  return typeof message === "string" && USER_CANCELLATION_PATTERN.test(message);
+}
+
+/**
+ * True when the error - or anything in its `cause` chain - is the user
+ * declining or dismissing a wallet prompt.
  */
 export function isUserCancellation(error: unknown): boolean {
-  // Some wallet adapters reject with a bare string rather than an Error.
-  if (typeof error === "string") return USER_CANCELLATION_PATTERN.test(error);
-
   let cur: unknown = error;
 
-  for (
-    let depth = 0;
-    depth <= MAX_CAUSE_DEPTH && cur && typeof cur === "object";
-    depth++
-  ) {
-    const { code, name, message, cause } = cur as {
-      code?: unknown;
-      name?: unknown;
-      message?: unknown;
-      cause?: unknown;
-    };
+  for (let depth = 0; depth <= MAX_CAUSE_DEPTH && cur != null; depth++) {
+    if (isUserCancellationFrame(cur)) return true;
 
-    if (code === EIP1193_USER_REJECTED) return true;
-    if (code === WALLET_CONNECTION_REJECTED_CODE) return true;
-    if (name === "UserRejectedRequestError") return true;
-    if (
-      typeof message === "string" &&
-      USER_CANCELLATION_PATTERN.test(message)
-    ) {
-      return true;
-    }
+    // The string check is inside the loop, not only ahead of it: some wallet
+    // adapters reject with a bare string, and that string can be the `cause`
+    // of a wrapper Error rather than the top-level throw. A `typeof === object`
+    // loop guard stopped the walk at the first string cause and missed those.
+    if (typeof cur !== "object") return false;
 
-    cur = cause;
+    cur = (cur as { cause?: unknown }).cause;
   }
 
   return false;


### PR DESCRIPTION
## What

Four changes that stop routine and third-party events being captured as errors:

- a real user-cancellation predicate, replacing an `includes("rejected")` substring test
- `ignoreErrors` for wallet/translation extension errors
- `notranslate` meta
- permanent HTTP statuses no longer retried or captured

## Why

Wallets express cancellation as rejected **and** cancelled / canceled / denied, plus WalletConnect's "Proposal expired". The old check caught one of them, so most cancellations — a depositor closing a popup — became error events, the single largest category in the project.

A 451 geo-block was retried on every poll cycle indefinitely, with two 30s-interval queries alternating for over an hour and each settled failure billing an issue.

The `removeChild` crashes come from translation extensions mutating React-owned text nodes; `notranslate` is the standard mitigation.

## How

`isUserCancellation` checks typed signals first (EIP-1193 4001, viem's `UserRejectedRequestError`, wallet-connector `CONNECTION_REJECTED`), then narrow wording, walking the `cause` chain. Applied at the wallet-connection boundary and again in `beforeSend`.

Deliberately narrow — these still report:

```
Failed to connect wallet: Connection timeout   # not a user action
The contract rejected this transaction         # deterministic failure
```

It lives in a dependency-free leaf module because `sentry.client.config.ts` imports it at init time; pulling in COPY or the SDK would put module-init surface ahead of `Sentry.init`.

22 new tests pinning both directions. Vault suite 3088 passes; lint clean; build succeeds.

## Not fixed here

A 451 still doesn't flip the app into its geo-blocked UI — the boot probe hits `/health`, which stays 200 while the data plane 451s. Downgrading the report doesn't worsen that, but doesn't fix it. Follow-up.
