### PR TITLE
fix(wallet-connector): stop gating the ETH AppKit wallet on window.ethereum

### DIFF
--- a/packages/babylon-wallet-connector/src/core/wallets/eth/appkit/__tests__/provider.test.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/eth/appkit/__tests__/provider.test.ts
@@ -1,0 +1,117 @@
+import type { Config } from "wagmi";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { ETHConfig } from "@/core/types";
+
+// The provider is constructed eagerly by `createWallet` (metadata has
+// `wallet: undefined`), so its constructor must tolerate AppKit init not
+// having run yet. The wagmi actions are mocked so the tests can observe
+// whether the constructor attached the account/chain watchers; the AppKit
+// modal module is mocked to keep the heavy `@reown/appkit` graph out of the
+// unit-test environment.
+const wagmiActions = vi.hoisted(() => ({
+  getAccount: vi.fn(() => ({
+    address: undefined,
+    chainId: undefined,
+    status: "disconnected" as const,
+  })),
+  watchAccount: vi.fn(() => () => {}),
+  watchChainId: vi.fn(() => () => {}),
+}));
+
+vi.mock("wagmi/actions", () => ({
+  getAccount: wagmiActions.getAccount,
+  getTransactionCount: vi.fn(),
+  estimateGas: vi.fn(),
+  getBalance: vi.fn(),
+  sendTransaction: vi.fn(),
+  signMessage: vi.fn(),
+  signTypedData: vi.fn(),
+  switchChain: vi.fn(),
+  watchAccount: wagmiActions.watchAccount,
+  watchChainId: wagmiActions.watchChainId,
+  connect: vi.fn(),
+  disconnect: vi.fn(),
+}));
+
+vi.mock("wagmi/connectors", () => ({
+  walletConnect: vi.fn(),
+}));
+
+vi.mock("@/core/wallets/appkit/appKitModal", () => ({
+  getAppKitModal: vi.fn(() => null),
+}));
+
+const ethConfig: ETHConfig = {
+  chainId: 11155111,
+  chainName: "Sepolia",
+  rpcUrl: "https://rpc.example.com",
+  explorerUrl: "https://explorer.example.com",
+  nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
+};
+
+// The shared-config singleton has no reset hook, so each test resets the
+// module registry and imports a fresh provider + sharedConfig pair. The
+// mocked wagmi functions above survive the reset (`vi.hoisted`), so call
+// counts remain observable.
+describe("AppKitProvider — constructed before AppKit init (no shared wagmi config)", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("constructs without throwing and does not start event watchers", async () => {
+    vi.resetModules();
+    const { AppKitProvider } = await import("../provider");
+
+    expect(() => new AppKitProvider(ethConfig)).not.toThrow();
+
+    expect(wagmiActions.getAccount).not.toHaveBeenCalled();
+    expect(wagmiActions.watchAccount).not.toHaveBeenCalled();
+    expect(wagmiActions.watchChainId).not.toHaveBeenCalled();
+  });
+
+  it("connectWallet rejects with the AppKit ETH not-initialized error", async () => {
+    vi.resetModules();
+    const { AppKitProvider } = await import("../provider");
+    const provider = new AppKitProvider(ethConfig);
+
+    // connectWallet logs the failure before rethrowing; keep the suite
+    // output clean without asserting on the log itself.
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      await expect(provider.connectWallet()).rejects.toThrow("AppKit ETH not initialized");
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+});
+
+describe("AppKitProvider — constructed after AppKit init (shared wagmi config set)", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("starts the account and chain watchers against the shared config on construction", async () => {
+    vi.resetModules();
+    const { setSharedWagmiConfig } = await import("../sharedConfig");
+    const { AppKitProvider } = await import("../provider");
+
+    const sharedConfig = {} as Config;
+    setSharedWagmiConfig(sharedConfig);
+
+    const provider = new AppKitProvider(ethConfig);
+
+    expect(wagmiActions.watchAccount).toHaveBeenCalledTimes(1);
+    expect(wagmiActions.watchAccount).toHaveBeenCalledWith(
+      sharedConfig,
+      expect.objectContaining({ onChange: expect.any(Function) }),
+    );
+    expect(wagmiActions.watchChainId).toHaveBeenCalledTimes(1);
+    expect(wagmiActions.watchChainId).toHaveBeenCalledWith(
+      sharedConfig,
+      expect.objectContaining({ onChange: expect.any(Function) }),
+    );
+
+    provider.destroy();
+  });
+});

--- a/packages/babylon-wallet-connector/src/core/wallets/eth/appkit/index.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/eth/appkit/index.ts
@@ -24,7 +24,13 @@ const metadata: WalletMetadata<IETHProvider, ETHConfig> = {
   name: WALLET_PROVIDER_NAME,
   icon: "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzIiIGhlaWdodD0iMzIiIHZpZXdCb3g9IjAgMCAzMiAzMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8Y2lyY2xlIGN4PSIxNiIgY3k9IjE2IiByPSIxNiIgZmlsbD0iIzYyN0VFQSIvPgogIDxwYXRoIGQ9Ik0xNiA0TDcuNSAxNi4yNUwxNiAyMkwyNC41IDE2LjI1TDE2IDR6IiBmaWxsPSJ3aGl0ZSIvPgogIDxwYXRoIGQ9Ik0xNiAyMi43NUw3LjUgMTdMMTYgMjhMMjQuNSAxN0wxNiAyMi43NXoiIGZpbGw9IndoaXRlIiBmaWxsLW9wYWNpdHk9IjAuNiIvPgo8L3N2Zz4=",
   docs: "https://docs.reown.com/appkit/overview",
-  wallet: "ethereum", // Global identifier for Ethereum providers
+  // No `wallet` global: AppKit reaches wallets through its own EIP-6963,
+  // WalletConnect and hardware transports, none of which require an injected
+  // `window.ethereum`. Gating on that global made every user without an EVM
+  // browser extension (Safari, WalletConnect-QR, hardware-only) fail with
+  // "Provider not found" before the AppKit modal could open — and ETH is a
+  // required chain for deposit. Mirrors the BTC AppKit entry.
+  wallet: undefined,
   createProvider: (_wallet: any, config: ETHConfig) => new AppKitProvider(config),
   networks: [
     Network.MAINNET, // ETH mainnet (chainId: 1)

--- a/packages/babylon-wallet-connector/src/core/wallets/eth/appkit/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/eth/appkit/provider.ts
@@ -54,6 +54,21 @@ export class AppKitProvider implements IETHProvider {
 
   constructor(config: ETHConfig) {
     this.config = config;
+    this.ensureEventWatchers();
+  }
+
+  /**
+   * Attach the wagmi watchers exactly once, and only when the shared config
+   * exists. The provider is now constructed unconditionally (it no longer
+   * waits on an injected `window.ethereum`), so construction must not throw
+   * when AppKit init has not run or has fallen back — that would take down the
+   * BTC connector alongside the ETH one. `connectWallet` re-checks and still
+   * surfaces the actionable "AppKit ETH not initialized" error, and calling
+   * this again there picks the watchers up if init landed late.
+   */
+  private ensureEventWatchers(): void {
+    if (this.unwatchFunctions.length > 0) return;
+    if (!hasSharedWagmiConfig()) return;
     this.setupEventWatchers();
   }
 
@@ -122,6 +137,8 @@ export class AppKitProvider implements IETHProvider {
   async connectWallet(): Promise<void> {
     try {
       const config = this.getWagmiConfig();
+      // Init may have completed after this provider was constructed.
+      this.ensureEventWatchers();
 
       // First check if already connected (from previous session)
       const currentAccount = getAccount(config);


### PR DESCRIPTION
> **Verification status:** the constructor guard — the load-bearing safety claim of this PR — is pinned by unit tests: constructing the ETH provider with no shared wagmi config does not throw and starts no watchers, `connectWallet` in that state surfaces the actionable not-initialized error, and watchers wire exactly once against the shared config when AppKit is initialized. Full wallet-connector suites and build pass. What remains is the live-browser matrix at the bottom (no-EVM-extension browser, WalletConnect QR, MetaMask regression, deposit through `deposit.registered`) — flagging for reviewer judgment on whether any of it should gate merge.

## What

Sets `wallet: undefined` on the ETH AppKit entry, mirroring the BTC one, and makes `AppKitProvider`'s constructor tolerant of a missing shared wagmi config.

## Why

The entry declared `wallet: "ethereum"`, so the connector only built a provider when `window.ethereum` existed — then discarded the injected object and constructed `AppKitProvider(config)` anyway. AppKit reaches wallets through its own EIP-6963, WalletConnect and hardware transports and needs no injected global, so the gate excluded exactly the users who depend on those: Safari and plain Chrome without an EVM extension, EIP-6963-only wallets, and WalletConnect-QR or hardware-only users.

They got `Provider not found` before the AppKit modal could open, and **ETH is a required chain for deposit** — so those users cannot deposit at all. ~22 occurrences in Sentry, frequently paired with "Connection to Keystone was canceled", which fits: Keystone users are precisely the cohort with no browser EVM extension.

## How

`wallet: undefined` sends `createWallet` down the branch that constructs the provider **eagerly**, at connector-creation time. That is why the constructor guard comes first: without it, a failed or fallen-back AppKit init would throw inside `ChainProvider.init` and take down the **BTC** connector alongside the ETH one. `connectWallet` still re-checks and surfaces the actionable "AppKit ETH not initialized" error, and retries watcher setup in case init landed late.

Deliberately **not** included: hardening `Chains/container.tsx` on `appkitWallet?.installed`. After this change `installed` is always true, so it is a no-op — and applied without this change it would render the ETH row as a dead "Uninstalled" link instead of an error.

## To verify

The vault runs wallet-connector's built `dist`, so the rebuild is mandatory or you will test the old code:

```bash
pnpm --filter @babylonlabs-io/wallet-connector build
pnpm --filter vault dev
```

In a browser where `window.ethereum` is `undefined` (Safari, or `open -na "Google Chrome" --args --user-data-dir=/tmp/clean`):

1. Ethereum row opens the AppKit modal — no `Provider not found`
2. **BTC still connects** — guards against the regression described above
3. WalletConnect QR completes an ETH connection
4. A browser *with* MetaMask still works
5. Deposit reaches `deposit.registered` — the dialog opening is not proof the provider signs
