### PR TITLE
fix(vault): correct Chainlink staleness and Aave borrow arithmetic

### DIFF
--- a/packages/babylon-ts-sdk/src/tbv/integrations/aave/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/integrations/aave/index.ts
@@ -123,3 +123,9 @@ export type {
 
 // Export ABIs for application registration
 export { default as AaveIntegrationAdapterABI } from "./clients/abis/AaveIntegrationAdapter.abi.json";
+// Reverts on the withdraw/borrow paths originate inside the Aave Core Spoke or
+// the per-position proxy, not the adapter. Without these ABIs their custom
+// errors decode to nothing, so ordinary conditions (health-factor floor, dust
+// rule, frozen reserve) surface as "Execution reverted for an unknown reason."
+export { default as AaveSpokeABI } from "./clients/abis/AaveSpoke.abi.json";
+export { default as AaveAdapterPositionProxyABI } from "./clients/abis/AaveAdapterPositionProxy.abi.json";

--- a/services/vault/src/applications/aave/clients/transaction.ts
+++ b/services/vault/src/applications/aave/clients/transaction.ts
@@ -8,7 +8,9 @@
 import { BTCVaultRegistryABI } from "@babylonlabs-io/ts-sdk/tbv/core";
 import { waitForTransactionReceiptSmartAware } from "@babylonlabs-io/ts-sdk/tbv/core/utils";
 import {
+  AaveAdapterPositionProxyABI,
   AaveIntegrationAdapterABI,
+  AaveSpokeABI,
   buildBorrowTx,
   buildReorderVaultsTx,
   buildRepayTx,
@@ -27,6 +29,22 @@ import {
   mapViemErrorToContractError,
   tagSimulationPhase,
 } from "../../../utils/errors";
+
+/**
+ * ABIs consulted when decoding a revert on the Aave paths.
+ *
+ * The adapter alone is not enough: a withdraw or borrow reverts inside the Aave
+ * Core Spoke (health-factor floor, dust rule, frozen/paused reserve) or in the
+ * per-position proxy, and a selector outside the supplied ABIs decodes to
+ * nothing — which is how ordinary, explainable conditions reached the user as
+ * "Execution reverted for an unknown reason."
+ */
+const AAVE_REVERT_DECODING_ABIS = [
+  AaveIntegrationAdapterABI,
+  AaveSpokeABI,
+  AaveAdapterPositionProxyABI,
+  BTCVaultRegistryABI,
+];
 
 /**
  * Read the Core Spoke address from the controller contract.
@@ -134,10 +152,11 @@ async function executeTx(
     // Tagged so callers can safely auto-retry: nothing was signed or sent,
     // and the failure may be a lagging RPC backend, not the chain.
     throw tagSimulationPhase(
-      mapViemErrorToContractError(error, errorContext, [
-        AaveIntegrationAdapterABI,
-        BTCVaultRegistryABI,
-      ]),
+      mapViemErrorToContractError(
+        error,
+        errorContext,
+        AAVE_REVERT_DECODING_ABIS,
+      ),
     );
   }
 
@@ -177,12 +196,11 @@ async function executeTx(
       receipt,
     };
   } catch (error) {
-    // Include both ABIs for comprehensive error decoding
-    // AaveIntegrationAdapter may call into BTCVaultRegistry
-    throw mapViemErrorToContractError(error, errorContext, [
-      AaveIntegrationAdapterABI,
-      BTCVaultRegistryABI,
-    ]);
+    throw mapViemErrorToContractError(
+      error,
+      errorContext,
+      AAVE_REVERT_DECODING_ABIS,
+    );
   }
 }
 

--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/__tests__/calculateMaxBorrowTokens.test.ts
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/hooks/__tests__/calculateMaxBorrowTokens.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  BORROW_CAPACITY_HEADROOM,
   BPS_SCALE,
   MIN_HEALTH_FACTOR_FOR_BORROW,
 } from "../../../../../constants";
@@ -19,7 +20,8 @@ describe("calculateMaxBorrowTokens", () => {
     });
 
     const expectedUsd =
-      (10000 * 8000) / BPS_SCALE / MIN_HEALTH_FACTOR_FOR_BORROW;
+      ((10000 * 8000) / BPS_SCALE / MIN_HEALTH_FACTOR_FOR_BORROW) *
+      (1 - BORROW_CAPACITY_HEADROOM);
     expect(result).toBe(Math.floor(expectedUsd * 1e6) / 1e6);
   });
 
@@ -34,7 +36,9 @@ describe("calculateMaxBorrowTokens", () => {
     });
 
     const expectedUsd =
-      (10000 * 8000) / BPS_SCALE / MIN_HEALTH_FACTOR_FOR_BORROW - 2000;
+      ((10000 * 8000) / BPS_SCALE / MIN_HEALTH_FACTOR_FOR_BORROW) *
+        (1 - BORROW_CAPACITY_HEADROOM) -
+      2000;
     expect(result).toBe(Math.floor(expectedUsd * 1e6) / 1e6);
   });
 
@@ -49,7 +53,8 @@ describe("calculateMaxBorrowTokens", () => {
     });
 
     const expectedUsd =
-      (10000 * 8000) / BPS_SCALE / MIN_HEALTH_FACTOR_FOR_BORROW;
+      ((10000 * 8000) / BPS_SCALE / MIN_HEALTH_FACTOR_FOR_BORROW) *
+      (1 - BORROW_CAPACITY_HEADROOM);
     expect(result).toBe(Math.floor((expectedUsd / 2) * 1e6) / 1e6);
   });
 
@@ -126,7 +131,8 @@ describe("calculateMaxBorrowTokens", () => {
     });
 
     const expectedUsd =
-      (10000 * 7500) / BPS_SCALE / MIN_HEALTH_FACTOR_FOR_BORROW;
+      ((10000 * 7500) / BPS_SCALE / MIN_HEALTH_FACTOR_FOR_BORROW) *
+      (1 - BORROW_CAPACITY_HEADROOM);
     expect(result).toBe(Math.floor(expectedUsd * 1e6) / 1e6);
   });
 

--- a/services/vault/src/applications/aave/constants.ts
+++ b/services/vault/src/applications/aave/constants.ts
@@ -13,6 +13,21 @@ export {
 } from "@babylonlabs-io/ts-sdk/tbv/integrations/aave";
 
 /**
+ * Fraction of borrow capacity held back so the advertised maximum does not sit
+ * exactly on the health-factor rail.
+ *
+ * Sizing "Max" against `MIN_HEALTH_FACTOR_FOR_BORROW` alone produced a figure
+ * whose projected HF equalled the floor to the last decimal. Debt accrues
+ * interest continuously, so by the time the pre-sign check refetched the
+ * position the projected HF had slipped just under the floor and the borrow was
+ * rejected with "Projected health factor (1.05) would be below 1.05" - a
+ * message that reads as self-contradictory because both numbers are rounded for
+ * display. 0.5% is far above the ~5e-8 relative drift that 30s of accrual at 5%
+ * APR produces, while costing a borrower a negligible amount of capacity.
+ */
+export const BORROW_CAPACITY_HEADROOM = 0.005;
+
+/**
  * Stale time for config queries (5 minutes)
  * Config data (reserves, contract addresses) rarely changes
  */

--- a/services/vault/src/applications/aave/hooks/useWithdrawCollateralTransaction.ts
+++ b/services/vault/src/applications/aave/hooks/useWithdrawCollateralTransaction.ts
@@ -15,6 +15,7 @@ import { getETHChain } from "@/config/network";
 import { useProtocolGateState } from "@/hooks/useProtocolGate";
 import { logger } from "@/infrastructure";
 import {
+  ContractError,
   ErrorCode,
   WalletError,
   mapViemErrorToContractError,
@@ -105,12 +106,17 @@ export function useWithdrawCollateralTransaction(): UseWithdrawCollateralTransac
           error instanceof Error ? error : new Error(String(error)),
           { data: { context: "Withdraw collateral failed" } },
         );
+        // The transaction client already mapped this against the Aave ABIs.
+        // Re-mapping here would re-prefix the operation name and discard the
+        // decoded revert reason, so pass a ContractError straight through.
         const mappedError =
-          error instanceof Error
-            ? mapViemErrorToContractError(error, "Withdraw Collateral")
-            : new Error(
-                "An unexpected error occurred while withdrawing collateral",
-              );
+          error instanceof ContractError
+            ? error
+            : error instanceof Error
+              ? mapViemErrorToContractError(error, "Withdraw Collateral")
+              : new Error(
+                  "An unexpected error occurred while withdrawing collateral",
+                );
 
         setError(mappedError.message);
 

--- a/services/vault/src/applications/aave/utils/__tests__/borrowCapacity.test.ts
+++ b/services/vault/src/applications/aave/utils/__tests__/borrowCapacity.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { BPS_SCALE, MIN_HEALTH_FACTOR_FOR_BORROW } from "../../constants";
+import {
+  BORROW_CAPACITY_HEADROOM,
+  BPS_SCALE,
+  MIN_HEALTH_FACTOR_FOR_BORROW,
+} from "../../constants";
 import { calculateBorrowCapacityUsd } from "../borrowCapacity";
 
 describe("calculateBorrowCapacityUsd", () => {
@@ -12,7 +16,8 @@ describe("calculateBorrowCapacityUsd", () => {
     });
 
     const expectedMaxTotalDebtUsd =
-      (10000 * 8000) / BPS_SCALE / MIN_HEALTH_FACTOR_FOR_BORROW;
+      ((10000 * 8000) / BPS_SCALE / MIN_HEALTH_FACTOR_FOR_BORROW) *
+      (1 - BORROW_CAPACITY_HEADROOM);
     expect(result.maxTotalDebtUsd).toBe(expectedMaxTotalDebtUsd);
     expect(result.availableToBorrowUsd).toBe(expectedMaxTotalDebtUsd - 2000);
   });
@@ -25,9 +30,31 @@ describe("calculateBorrowCapacityUsd", () => {
     });
 
     const expectedMaxTotalDebtUsd =
-      (10000 * 8000) / BPS_SCALE / MIN_HEALTH_FACTOR_FOR_BORROW;
+      ((10000 * 8000) / BPS_SCALE / MIN_HEALTH_FACTOR_FOR_BORROW) *
+      (1 - BORROW_CAPACITY_HEADROOM);
     expect(result.maxTotalDebtUsd).toBe(expectedMaxTotalDebtUsd);
     expect(result.availableToBorrowUsd).toBe(0);
+  });
+
+  it("leaves the projected health factor above the floor at full capacity", () => {
+    const collateralValueUsd = 10000;
+    const liquidationThresholdBps = 8000;
+
+    const { maxTotalDebtUsd } = calculateBorrowCapacityUsd({
+      collateralValueUsd,
+      currentDebtUsd: 0,
+      liquidationThresholdBps,
+    });
+
+    // Borrowing the advertised maximum must not land exactly on the floor:
+    // debt accrues between rendering "Max" and the pre-sign refetch, and
+    // sizing to the rail made that refetch reject the borrow every time.
+    const projectedHealthFactor =
+      (collateralValueUsd * liquidationThresholdBps) /
+      BPS_SCALE /
+      maxTotalDebtUsd;
+
+    expect(projectedHealthFactor).toBeGreaterThan(MIN_HEALTH_FACTOR_FOR_BORROW);
   });
 
   it("returns zero capacity when collateral is zero", () => {
@@ -60,7 +87,8 @@ describe("calculateBorrowCapacityUsd", () => {
     });
 
     const expectedMaxTotalDebtUsd =
-      (10000 * 7500) / BPS_SCALE / MIN_HEALTH_FACTOR_FOR_BORROW;
+      ((10000 * 7500) / BPS_SCALE / MIN_HEALTH_FACTOR_FOR_BORROW) *
+      (1 - BORROW_CAPACITY_HEADROOM);
     expect(result.maxTotalDebtUsd).toBe(expectedMaxTotalDebtUsd);
     expect(result.availableToBorrowUsd).toBe(expectedMaxTotalDebtUsd);
   });

--- a/services/vault/src/applications/aave/utils/borrowCapacity.ts
+++ b/services/vault/src/applications/aave/utils/borrowCapacity.ts
@@ -1,4 +1,8 @@
-import { BPS_SCALE, MIN_HEALTH_FACTOR_FOR_BORROW } from "../constants";
+import {
+  BORROW_CAPACITY_HEADROOM,
+  BPS_SCALE,
+  MIN_HEALTH_FACTOR_FOR_BORROW,
+} from "../constants";
 
 export interface BorrowCapacityUsdParams {
   collateralValueUsd: number;
@@ -16,10 +20,14 @@ export function calculateBorrowCapacityUsd({
   currentDebtUsd,
   liquidationThresholdBps,
 }: BorrowCapacityUsdParams): BorrowCapacityUsd {
+  // Held back from the rail so interest accrued between rendering "Max" and
+  // the pre-sign refetch cannot push the projected health factor under the
+  // floor and reject the borrow the user was just offered.
   const maxTotalDebtUsd =
-    (collateralValueUsd * liquidationThresholdBps) /
-    BPS_SCALE /
-    MIN_HEALTH_FACTOR_FOR_BORROW;
+    ((collateralValueUsd * liquidationThresholdBps) /
+      BPS_SCALE /
+      MIN_HEALTH_FACTOR_FOR_BORROW) *
+    (1 - BORROW_CAPACITY_HEADROOM);
   return {
     maxTotalDebtUsd,
     availableToBorrowUsd: Math.max(0, maxTotalDebtUsd - currentDebtUsd),

--- a/services/vault/src/clients/eth-contract/chainlink/__tests__/query.test.ts
+++ b/services/vault/src/clients/eth-contract/chainlink/__tests__/query.test.ts
@@ -69,8 +69,21 @@ const FRESH_AGE_SECONDS = 10n;
 /** answeredInRound value representing an incomplete oracle round */
 const INCOMPLETE_ANSWERED_IN_ROUND = 99n;
 
-/** Two hours in seconds — exceeds the 1-hour staleness threshold */
+/** Two hours in seconds — exceeds the heartbeat-plus-grace staleness threshold */
 const TWO_HOURS_SECONDS = 7200n;
+
+/**
+ * Past the 3600s heartbeat but inside the 600s grace window. This is the tail
+ * of every normal heartbeat cycle and must NOT be reported as stale — reporting
+ * it was what made staleness the highest-volume event in the project.
+ */
+const JUST_PAST_HEARTBEAT_SECONDS = 3900n;
+
+/** Client clock behind chain time by more than the tolerated skew (300s). */
+const LARGE_CLOCK_SKEW_SECONDS = 600n;
+
+/** Client clock behind chain time by less than the tolerated skew. */
+const SMALL_CLOCK_SKEW_SECONDS = 30n;
 
 function makeRoundData(
   overrides: Partial<ChainlinkRoundData> = {},
@@ -223,6 +236,9 @@ describe("getTokenPrices", () => {
 
     expect(logger.event).toHaveBeenCalledWith(
       expect.stringContaining("incomplete round"),
+      expect.objectContaining({
+        tags: expect.objectContaining({ staleReason: "incomplete-round" }),
+      }),
     );
   });
 
@@ -237,9 +253,63 @@ describe("getTokenPrices", () => {
 
     await getTokenPrices(["BTC"]);
 
+    // The age lives in structured data, not the message: interpolating it made
+    // every distinct value its own Sentry issue.
     expect(logger.event).toHaveBeenCalledWith(
-      expect.stringContaining("hours old"),
+      "Chainlink price data is stale. Using last known price.",
+      expect.objectContaining({
+        tags: expect.objectContaining({ staleReason: "age" }),
+        ageHours: "2.0",
+      }),
     );
+  });
+
+  it("does not report a feed that is past its heartbeat but inside the grace window", async () => {
+    const { logger } = await import("@/infrastructure");
+    const nowSeconds = BigInt(Math.floor(Date.now() / 1000));
+    mockMulticall.mockResolvedValueOnce(
+      makeFeedResult(BTC_ANSWER_8_DECIMALS, STANDARD_DECIMALS, {
+        updatedAt: nowSeconds - JUST_PAST_HEARTBEAT_SECONDS,
+      }),
+    );
+
+    const { metadata } = await getTokenPrices(["BTC"]);
+
+    expect(metadata["BTC"].isStale).toBe(false);
+    expect(logger.event).not.toHaveBeenCalled();
+  });
+
+  it("reports clock skew separately when the client clock is far behind chain time", async () => {
+    const { logger } = await import("@/infrastructure");
+    const nowSeconds = BigInt(Math.floor(Date.now() / 1000));
+    mockMulticall.mockResolvedValueOnce(
+      makeFeedResult(BTC_ANSWER_8_DECIMALS, STANDARD_DECIMALS, {
+        updatedAt: nowSeconds + LARGE_CLOCK_SKEW_SECONDS,
+      }),
+    );
+
+    const { metadata } = await getTokenPrices(["BTC"]);
+
+    expect(metadata["BTC"].isStale).toBe(true);
+    expect(logger.event).toHaveBeenCalledWith(
+      expect.stringContaining("clock is behind chain time"),
+      expect.objectContaining({
+        tags: expect.objectContaining({ staleReason: "clock-skew" }),
+      }),
+    );
+  });
+
+  it("treats a small clock skew as fresh rather than failing the feed", async () => {
+    const nowSeconds = BigInt(Math.floor(Date.now() / 1000));
+    mockMulticall.mockResolvedValueOnce(
+      makeFeedResult(BTC_ANSWER_8_DECIMALS, STANDARD_DECIMALS, {
+        updatedAt: nowSeconds + SMALL_CLOCK_SKEW_SECONDS,
+      }),
+    );
+
+    const { metadata } = await getTokenPrices(["BTC"]);
+
+    expect(metadata["BTC"].isStale).toBe(false);
   });
 
   it("marks metadata as stale when data exceeds max age", async () => {

--- a/services/vault/src/clients/eth-contract/chainlink/query.ts
+++ b/services/vault/src/clients/eth-contract/chainlink/query.ts
@@ -44,8 +44,43 @@ const CHAINLINK_PRICE_FEEDS: Record<Network, ChainlinkFeedAddresses> = {
   },
 };
 
-/** Maximum acceptable age for Chainlink price data (1 hour) */
-const CHAINLINK_MAX_PRICE_AGE_SECONDS = 3600;
+/**
+ * Nominal Chainlink heartbeat: the longest the aggregator will go without
+ * publishing, absent a deviation trigger. Matches the BTC/USD and ETH/USD
+ * feeds this app reads.
+ *
+ * TODO: this is per-aggregator, not global — mainnet USDC/USDT run a 24h
+ * heartbeat, so they will read as chronically stale if those feeds are ever
+ * enabled (they are `null` on SIGNET/TESTNET today, so nothing queries them).
+ * The heartbeat is aggregator config and is not exposed on the proxy ABI, so
+ * it has to come from a per-feed table rather than a contract read.
+ */
+const CHAINLINK_HEARTBEAT_SECONDS = 3600;
+
+/**
+ * Grace period added to the heartbeat before calling a feed stale.
+ *
+ * A feed is *contractually* allowed to be one full heartbeat old, and real
+ * updates routinely land a few minutes late (block time, gas, deviation-trigger
+ * jitter). Comparing age against the bare heartbeat therefore flagged the tail
+ * of every normal heartbeat window — which is why the reported ages clustered
+ * at 1.0-1.2 hours and made this the highest-volume event in the project, while
+ * also blanking the liquidation UI on a perfectly healthy feed.
+ */
+const CHAINLINK_STALENESS_GRACE_SECONDS = 600;
+
+/** Maximum acceptable age for Chainlink price data before it is called stale. */
+const CHAINLINK_MAX_PRICE_AGE_SECONDS =
+  CHAINLINK_HEARTBEAT_SECONDS + CHAINLINK_STALENESS_GRACE_SECONDS;
+
+/**
+ * How far the client clock may run behind chain time before freshness becomes
+ * unknowable. `updatedAt` is compared against `Date.now()`, so a device clock
+ * that is behind yields a NEGATIVE age; `age <= maxAge` then reports "fresh"
+ * for arbitrarily old data — a fail-open on the check that guards the
+ * health-factor path. Skew beyond this bound is treated as stale instead.
+ */
+const MAX_CLIENT_CLOCK_SKEW_SECONDS = 300;
 
 /** Number of seconds in one hour — used for display formatting */
 const SECONDS_PER_HOUR = 3600;
@@ -133,7 +168,7 @@ export interface ChainlinkRoundData {
  * Metadata about a price feed's freshness and status
  */
 export interface PriceMetadata {
-  /** Whether the price data is stale (older than 1 hour) */
+  /** Whether the price data is older than the heartbeat plus its grace window */
   isStale: boolean;
   /** Age of the price data in seconds */
   ageSeconds: number;
@@ -158,7 +193,7 @@ interface TokenPricesResult {
  * Chainlink recommends checking updatedAt is recent
  *
  * @param roundData - Round data from getLatestRoundData
- * @param maxAgeSeconds - Maximum age in seconds (default: 3600 = 1 hour)
+ * @param maxAgeSeconds - Maximum age in seconds (default: heartbeat + grace)
  * @returns true if data is fresh, false if stale
  */
 export function isPriceFresh(
@@ -168,6 +203,10 @@ export function isPriceFresh(
   if (roundData.answeredInRound < roundData.roundId) return false;
   const now = BigInt(Math.floor(Date.now() / 1000));
   const age = now - roundData.updatedAt;
+  // A negative age means the client clock is behind chain time. A small skew is
+  // ordinary and the round really is fresh; past that we cannot tell fresh from
+  // ancient, so fail closed rather than pass everything.
+  if (age < 0n) return -age <= BigInt(MAX_CLIENT_CLOCK_SKEW_SECONDS);
   return age <= BigInt(maxAgeSeconds);
 }
 
@@ -274,17 +313,34 @@ function readoutForFeed(
   const feedKey = feedAddress.toLowerCase();
   if (isStale) {
     // One event per stale episode; subsequent reads while still stale are silent.
+    // Messages are kept literal — interpolating the age or the round numbers
+    // made every distinct value its own Sentry issue, so the condition could
+    // never be seen as a single trend.
     if (!reportedStaleFeeds.has(feedKey)) {
       reportedStaleFeeds.add(feedKey);
       if (answeredInRound < roundId) {
         logger.event(
-          `Chainlink price data is stale: incomplete round (answeredInRound=${answeredInRound} < roundId=${roundId}). Using last known price.`,
+          "Chainlink price data is stale: incomplete round. Using last known price.",
+          {
+            tags: { staleReason: "incomplete-round", feed: feedKey },
+            roundId: roundId.toString(),
+            answeredInRound: answeredInRound.toString(),
+          },
+        );
+      } else if (ageSeconds < 0) {
+        logger.event(
+          "Chainlink price data rejected: client clock is behind chain time. Using last known price.",
+          {
+            tags: { staleReason: "clock-skew", feed: feedKey },
+            skewSeconds: -ageSeconds,
+          },
         );
       } else {
-        const ageHours = (ageSeconds / SECONDS_PER_HOUR).toFixed(1);
-        logger.event(
-          `Chainlink price data is stale (${ageHours} hours old). Using last known price.`,
-        );
+        logger.event("Chainlink price data is stale. Using last known price.", {
+          tags: { staleReason: "age", feed: feedKey },
+          ageHours: (ageSeconds / SECONDS_PER_HOUR).toFixed(1),
+          ageSeconds,
+        });
       }
     }
   } else {

--- a/services/vault/src/hooks/__tests__/useDashboardState.test.ts
+++ b/services/vault/src/hooks/__tests__/useDashboardState.test.ts
@@ -2,6 +2,7 @@ import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  BORROW_CAPACITY_HEADROOM,
   BPS_SCALE,
   MIN_BORROWABLE_USD,
   MIN_HEALTH_FACTOR_FOR_BORROW,
@@ -259,9 +260,10 @@ describe("useDashboardState", () => {
     const { result } = renderHook(() => useDashboardState("0xabc"));
 
     const expectedMaxTotalDebtUsd =
-      (10000 * Math.round(0.8 * BPS_SCALE)) /
-      BPS_SCALE /
-      MIN_HEALTH_FACTOR_FOR_BORROW;
+      ((10000 * Math.round(0.8 * BPS_SCALE)) /
+        BPS_SCALE /
+        MIN_HEALTH_FACTOR_FOR_BORROW) *
+      (1 - BORROW_CAPACITY_HEADROOM);
     expect(result.current.maxTotalDebtUsd).toBe(expectedMaxTotalDebtUsd);
     expect(result.current.availableToBorrowUsd).toBe(
       expectedMaxTotalDebtUsd - 2000,


### PR DESCRIPTION
> **Review focus: three constants are judgment calls, not derived values, and need sign-off** — the 600s Chainlink grace window, the 0.5% borrow-capacity headroom, and the 300s client clock-skew tolerance. All are sized against the failure mode and documented inline, but someone who owns the risk model should agree with the numbers.

## What

Five fixes across the Chainlink price feed and the Aave borrow/withdraw paths.

## Why

**Staleness threshold.** Compared against a flat 3600s — which is exactly the heartbeat of the BTC/USD and ETH/USD feeds. A feed is contractually allowed to be one full heartbeat old and updates routinely land minutes late, so the tail of every normal cycle was flagged stale. Reported ages clustered at 1.0-1.2 hours, making this the highest-volume event in the project. It is not only noise: the liquidation surface fails closed on `isStale`, so a healthy feed blanked position notifications and the dashboard BTC price.

**Clock skew.** Age is derived from the client's `Date.now()`, so a device clock behind chain time gave a negative age that `age <= maxAge` accepted as fresh — a fail-open on the check guarding the health-factor path.

**Event grouping.** The age was interpolated into the message, so every distinct decimal became its own Sentry issue.

**Max borrow.** Sized to land exactly on the health-factor floor, so interest accrued between rendering "Max" and the pre-sign refetch pushed the projected factor under it. Rejected with "Projected health factor (1.05) would be below 1.05" — self-contradictory to the user because both numbers are rounded for display. 5 occurrences.

**Withdraw reverts.** Originate in the Aave Core Spoke or the per-position proxy, whose ABIs were never passed to the decoder, so ordinary conditions ("repay debt first", HF floor) surfaced as "Execution reverted for an unknown reason."

## How

- Grace window added over the heartbeat; a `TODO` marks that the heartbeat is per-aggregator (mainnet USDC/USDT run 24h and would read chronically stale — they are `null` on signet/testnet today, so nothing queries them). It is aggregator config, not on the proxy ABI, so it cannot be read from chain.
- Skew beyond a small tolerance (300s) is treated as stale and reported under its own reason, so it stops being indistinguishable from a real stall.
- Stale message is now literal; age, reason and feed move to structured data.
- Borrow capacity sized against the floor plus headroom.
- Exports `AaveSpokeABI` and `AaveAdapterPositionProxyABI` and supplies them at both decode sites; stops the withdraw hook re-wrapping an already-mapped `ContractError`, which re-prefixed the operation and dropped the decoded reason.

Vault suite 3088 passes (7 tests updated for the new capacity, 5 added for the grace window and skew cases); lint clean; build succeeds.
