### PR TITLE
test(ci): flag when a PR changes how the UI looks

### DIFF
--- a/.github/scripts/visual-capture.sh
+++ b/.github/scripts/visual-capture.sh
@@ -23,12 +23,18 @@ mkdir -p "${CAPTURE_ROOT}/vault" "${CAPTURE_ROOT}/storybook"
 # The broadest and cheapest surface: every story renders in isolation with no
 # backend, no wallet and no network. Built static rather than served by
 # `storybook dev` so there is no HMR client injecting itself into the frame.
+# Binaries are invoked directly rather than through the `visual:*` package
+# scripts. Those scripts are added by the PR that introduces this harness, so
+# they do not exist at the merge-base and the baseline side would die with
+# ERR_PNPM_NO_SCRIPT. Calling the binary makes this script independent of the
+# checked-out commit's package.json.
 echo "==> Building static Storybook"
-pnpm --filter @babylonlabs-io/core-ui run visual:build
+pnpm --filter @babylonlabs-io/core-ui exec storybook build -o storybook-static --quiet
 
 echo "==> Capturing Storybook stories"
 VISUAL_OUT_DIR="${CAPTURE_ROOT}/storybook" \
-  pnpm --filter @babylonlabs-io/core-ui run visual:capture
+  pnpm --filter @babylonlabs-io/core-ui exec \
+  playwright test --config=playwright.visual.config.ts
 
 # --- Vault app (pages) ------------------------------------------------------
 # The vault dev server resolves @babylonlabs-io/core-ui (and ts-sdk,
@@ -42,7 +48,8 @@ pnpm exec nx run-many --target=build \
 
 echo "==> Capturing vault routes"
 VISUAL_OUT_DIR="${CAPTURE_ROOT}/vault" \
-  pnpm --filter @services/vault run visual:capture
+  pnpm --filter @services/vault exec \
+  playwright test --config=playwright.visual.config.ts
 
 echo "==> Capture complete for ${CAPTURE_ROOT}"
 ls -1 "${CAPTURE_ROOT}/storybook" | wc -l | xargs echo "    storybook screens:"

--- a/.github/scripts/visual-capture.sh
+++ b/.github/scripts/visual-capture.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# Captures every visual surface at whatever commit is currently checked out.
+#
+# Invoked twice per PR by .github/workflows/visual-regression.yml - once at
+# the PR head, once at the merge-base - with CAPTURE_ROOT pointing at a
+# different directory each time. Both runs happen on the same runner, with
+# the same browser build and the same fonts, which is what removes the
+# "baseline was generated on a different machine" class of false positive.
+#
+# CAPTURE_ROOT is required; each surface writes into its own subdirectory so
+# the diff step can report them separately.
+set -euo pipefail
+
+if [ -z "${CAPTURE_ROOT:-}" ]; then
+  echo "CAPTURE_ROOT must be set (the directory this side's captures go into)." >&2
+  exit 1
+fi
+
+mkdir -p "${CAPTURE_ROOT}/vault" "${CAPTURE_ROOT}/storybook"
+
+# --- Storybook (components) -------------------------------------------------
+# The broadest and cheapest surface: every story renders in isolation with no
+# backend, no wallet and no network. Built static rather than served by
+# `storybook dev` so there is no HMR client injecting itself into the frame.
+echo "==> Building static Storybook"
+pnpm --filter @babylonlabs-io/core-ui run visual:build
+
+echo "==> Capturing Storybook stories"
+VISUAL_OUT_DIR="${CAPTURE_ROOT}/storybook" \
+  pnpm --filter @babylonlabs-io/core-ui run visual:capture
+
+# --- Vault app (pages) ------------------------------------------------------
+# The vault dev server resolves @babylonlabs-io/core-ui (and ts-sdk,
+# wallet-connector) through their package `exports` to `dist/`, which is
+# gitignored and therefore ABSENT on a fresh runner. Without this build the
+# dev server cannot resolve them and every page captures as a blank frame -
+# it only appears to work on a developer machine that has built before.
+echo "==> Building workspace packages the vault resolves from dist/"
+pnpm exec nx run-many --target=build \
+  --projects=@babylonlabs-io/core-ui,@babylonlabs-io/ts-sdk,@babylonlabs-io/wallet-connector
+
+echo "==> Capturing vault routes"
+VISUAL_OUT_DIR="${CAPTURE_ROOT}/vault" \
+  pnpm --filter @services/vault run visual:capture
+
+echo "==> Capture complete for ${CAPTURE_ROOT}"
+ls -1 "${CAPTURE_ROOT}/storybook" | wc -l | xargs echo "    storybook screens:"
+ls -1 "${CAPTURE_ROOT}/vault" | wc -l | xargs echo "    vault screens:"

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -82,6 +82,10 @@ jobs:
           cp -R packages/babylon-core-ui/visual "$H/core-ui-visual"
           cp packages/babylon-core-ui/playwright.visual.config.ts "$H/core-ui-playwright.visual.config.ts"
           cp scripts/visual-diff.mjs "$H/"
+          # The runner script itself. Easy to forget, and forgetting it fails
+          # the baseline side with a bare "No such file or directory": the
+          # script does not exist at the merge-base either.
+          cp .github/scripts/visual-capture.sh "$H/"
 
       - name: Capture candidate (PR head)
         env:
@@ -96,17 +100,25 @@ jobs:
           set -euo pipefail
           H="${{ runner.temp }}/harness"
           rm -rf services/vault/e2e/visual packages/babylon-core-ui/visual
-          mkdir -p services/vault/e2e packages/babylon-core-ui
+          mkdir -p services/vault/e2e packages/babylon-core-ui .github/scripts
           cp -R "$H/vault-visual" services/vault/e2e/visual
           cp "$H/playwright.visual.config.ts" services/vault/
           cp -R "$H/core-ui-visual" packages/babylon-core-ui/visual
           cp "$H/core-ui-playwright.visual.config.ts" packages/babylon-core-ui/playwright.visual.config.ts
+          cp "$H/visual-capture.sh" .github/scripts/visual-capture.sh
+          chmod +x .github/scripts/visual-capture.sh
 
-      # The merge-base may carry a different lockfile, so reinstall: the
-      # baseline must reflect the dependencies that commit actually shipped.
-      - name: Install dependencies at merge-base
-        run: pnpm install --frozen-lockfile --prefer-offline
-
+      # Deliberately NOT reinstalling here. The harness needs tooling this PR
+      # adds (core-ui gains @playwright/test), which the merge-base lockfile
+      # would prune - the baseline could then never run. Keeping HEAD's
+      # node_modules also means both sides are photographed by an identical
+      # instrument, which is the property this whole design is built on.
+      #
+      # The trade-off, stated plainly: the baseline renders merge-base SOURCE
+      # against HEAD's external npm packages. Workspace changes (core-ui,
+      # ts-sdk, wallet-connector) are still compared correctly because those
+      # are rebuilt from the checked-out source. A PR that only bumps an
+      # external UI dependency will not show a diff.
       - name: Capture baseline (merge-base)
         env:
           CAPTURE_ROOT: ${{ runner.temp }}/visual/baseline
@@ -115,14 +127,6 @@ jobs:
       - name: Restore PR head
         if: always()
         run: git checkout --force "${{ steps.refs.outputs.head_sha }}"
-
-      # MUST reinstall. The merge-base install above prunes any dependency
-      # this PR adds - including pixelmatch/pngjs, which the diff script
-      # imports. Restoring the files does not restore node_modules, so
-      # without this the diff dies with ERR_MODULE_NOT_FOUND every run.
-      - name: Reinstall dependencies for the diff step
-        if: always()
-        run: pnpm install --frozen-lockfile --prefer-offline
 
       - name: Compare baseline against candidate
         id: diff

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -1,0 +1,222 @@
+name: Visual regression
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+# Advisory to begin with: this reports and comments, it does not fail the
+# build. Promote it to blocking (add --fail-on-change to the diff step)
+# once its noise floor is proven on real PRs.
+jobs:
+  visual:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 https://github.com/actions/checkout/releases/tag/v6.0.2
+        with:
+          # Full history so the merge-base with main is resolvable. The
+          # baseline is computed from that commit, not from a stored file.
+          fetch-depth: 0
+
+      - name: Resolve merge-base
+        id: refs
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin "${{ github.base_ref }}"
+          # Compare against the merge-base, NOT origin/main's head. Using
+          # main's head would attribute every UI change merged by someone
+          # else while this PR was open to this PR.
+          MERGE_BASE="$(git merge-base "origin/${{ github.base_ref }}" HEAD)"
+          echo "merge_base=${MERGE_BASE}" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "Baseline will be computed from ${MERGE_BASE}"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0 https://github.com/actions/setup-node/releases/tag/v4.4.0
+        with:
+          node-version: '24.2.0'
+
+      - name: Install Corepack
+        run: npm install -g corepack && corepack enable
+
+      - name: Resolve pnpm store path
+        shell: bash
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
+
+      - name: Cache pnpm store
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0 https://github.com/actions/cache/releases/tag/v4.3.0
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --prefer-offline
+
+      - name: Install Playwright browser
+        run: pnpm --filter @services/vault exec playwright install --with-deps chromium
+
+      # Stash the capture harness BEFORE any checkout juggling. The two
+      # sides must be photographed by the SAME harness, otherwise a change
+      # to the harness itself reads as an app change. It also solves the
+      # bootstrap problem: the merge-base does not have these files at all
+      # until this PR merges.
+      - name: Stash capture harness
+        run: |
+          set -euo pipefail
+          H="${{ runner.temp }}/harness"
+          mkdir -p "$H"
+          cp -R services/vault/e2e/visual "$H/vault-visual"
+          cp services/vault/playwright.visual.config.ts "$H/"
+          cp -R packages/babylon-core-ui/visual "$H/core-ui-visual"
+          cp packages/babylon-core-ui/playwright.visual.config.ts "$H/core-ui-playwright.visual.config.ts"
+          cp scripts/visual-diff.mjs "$H/"
+
+      - name: Capture candidate (PR head)
+        env:
+          CAPTURE_ROOT: ${{ runner.temp }}/visual/candidate
+        run: ./.github/scripts/visual-capture.sh
+
+      - name: Check out merge-base source
+        run: git checkout --force "${{ steps.refs.outputs.merge_base }}"
+
+      - name: Restore capture harness onto merge-base
+        run: |
+          set -euo pipefail
+          H="${{ runner.temp }}/harness"
+          rm -rf services/vault/e2e/visual packages/babylon-core-ui/visual
+          mkdir -p services/vault/e2e packages/babylon-core-ui
+          cp -R "$H/vault-visual" services/vault/e2e/visual
+          cp "$H/playwright.visual.config.ts" services/vault/
+          cp -R "$H/core-ui-visual" packages/babylon-core-ui/visual
+          cp "$H/core-ui-playwright.visual.config.ts" packages/babylon-core-ui/playwright.visual.config.ts
+
+      # The merge-base may carry a different lockfile, so reinstall: the
+      # baseline must reflect the dependencies that commit actually shipped.
+      - name: Install dependencies at merge-base
+        run: pnpm install --frozen-lockfile --prefer-offline
+
+      - name: Capture baseline (merge-base)
+        env:
+          CAPTURE_ROOT: ${{ runner.temp }}/visual/baseline
+        run: ./.github/scripts/visual-capture.sh
+
+      - name: Restore PR head
+        if: always()
+        run: git checkout --force "${{ steps.refs.outputs.head_sha }}"
+
+      # MUST reinstall. The merge-base install above prunes any dependency
+      # this PR adds - including pixelmatch/pngjs, which the diff script
+      # imports. Restoring the files does not restore node_modules, so
+      # without this the diff dies with ERR_MODULE_NOT_FOUND every run.
+      - name: Reinstall dependencies for the diff step
+        if: always()
+        run: pnpm install --frozen-lockfile --prefer-offline
+
+      - name: Compare baseline against candidate
+        id: diff
+        shell: bash
+        run: |
+          set -euo pipefail
+          TOTAL_CHANGED=0
+          for SURFACE in vault storybook; do
+            BASE="${{ runner.temp }}/visual/baseline/${SURFACE}"
+            CAND="${{ runner.temp }}/visual/candidate/${SURFACE}"
+            OUT="${{ runner.temp }}/visual/report/${SURFACE}"
+            [ -d "$CAND" ] || { echo "No candidate captures for ${SURFACE}, skipping."; continue; }
+            echo "### ${SURFACE}" | tee -a "${{ runner.temp }}/visual/diff-output.txt"
+            node scripts/visual-diff.mjs \
+              --baseline "$BASE" --candidate "$CAND" --out "$OUT" \
+              --baseline-ref "${{ steps.refs.outputs.merge_base }}" \
+              --candidate-ref "${{ steps.refs.outputs.head_sha }}" \
+              | tee -a "${{ runner.temp }}/visual/diff-output.txt"
+            N="$(node -e "console.log(require('${OUT}/summary.json').changedCount)")"
+            TOTAL_CHANGED=$((TOTAL_CHANGED + N))
+          done
+          echo "changed_count=${TOTAL_CHANGED}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload visual report
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2 https://github.com/actions/upload-artifact/releases/tag/v4.6.2
+        if: always()
+        with:
+          name: visual-report
+          path: ${{ runner.temp }}/visual/report
+          retention-days: 14
+
+      - name: Summarise
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## Visual regression"
+            echo ""
+            echo "Baseline \`${{ steps.refs.outputs.merge_base }}\` (merge-base) vs candidate \`${{ steps.refs.outputs.head_sha }}\`."
+            echo ""
+            if [ "${{ steps.diff.outputs.changed_count }}" = "0" ]; then
+              echo ":white_check_mark: No visual changes detected."
+            else
+              echo ":framed_picture: **${{ steps.diff.outputs.changed_count }} screen(s) changed.**"
+              echo ""
+              echo '```'
+              cat "${{ runner.temp }}/visual/diff-output.txt" || true
+              echo '```'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Sticky comment: edits the previous one instead of stacking one per
+      # push. Uses the preinstalled gh CLI rather than adding a third-party
+      # action, per the repo's supply-chain policy.
+      - name: Comment on the PR
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CHANGED: ${{ steps.diff.outputs.changed_count }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          MARKER="<!-- visual-regression-report -->"
+          BODY_FILE="${{ runner.temp }}/visual/comment.md"
+          mkdir -p "$(dirname "$BODY_FILE")"
+          {
+            echo "$MARKER"
+            echo "### Visual regression"
+            echo ""
+            if [ "${CHANGED:-0}" = "0" ]; then
+              echo ":white_check_mark: No visual changes against the merge-base."
+            else
+              echo ":framed_picture: **${CHANGED} screen(s) changed** against the merge-base."
+              echo ""
+              echo '```'
+              cat "${{ runner.temp }}/visual/diff-output.txt" || true
+              echo '```'
+              echo ""
+              echo "[Open the run](${RUN_URL}#artifacts), download **visual-report**, and open \`index.html\` for the before / after / diff view."
+              echo ""
+              echo "If these changes are intentional there is nothing to update - this repo stores no baseline images. The baseline is recomputed from the merge-base on every run."
+            fi
+          } > "$BODY_FILE"
+
+          EXISTING="$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+            --jq "map(select(.body | startswith(\"$MARKER\"))) | .[0].id // empty")"
+
+          if [ -n "$EXISTING" ]; then
+            gh api --method PATCH "repos/${{ github.repository }}/issues/comments/${EXISTING}" \
+              -F body=@"$BODY_FILE" > /dev/null
+            echo "Updated existing comment ${EXISTING}."
+          else
+            gh api --method POST "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+              -F body=@"$BODY_FILE" > /dev/null
+            echo "Posted a new comment."
+          fi

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -33,12 +33,24 @@ jobs:
         run: |
           set -euo pipefail
           git fetch --no-tags origin "${{ github.base_ref }}"
-          # Compare against the merge-base, NOT origin/main's head. Using
-          # main's head would attribute every UI change merged by someone
-          # else while this PR was open to this PR.
+          # On `pull_request`, actions/checkout gives us refs/pull/N/merge —
+          # the merge commit — so this resolves to the base branch's TIP, not
+          # to the PR's true merge-base. That is deliberate and is the
+          # property we want: comparing the merge commit against the base tip
+          # isolates this PR's own contribution, because anything merged by
+          # someone else while the PR was open renders identically on both
+          # sides and cancels out. Do not "fix" this to a true merge-base
+          # without re-reasoning about that; it would silently start
+          # attributing other people's UI changes to this PR.
           MERGE_BASE="$(git merge-base "origin/${{ github.base_ref }}" HEAD)"
           echo "merge_base=${MERGE_BASE}" >> "$GITHUB_OUTPUT"
+          # Checked back out after the baseline capture. This is the merge
+          # commit, which is what must be restored to leave the tree as found.
           echo "head_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          # Reported to humans instead of head_sha: the merge commit appears
+          # in none of the PR's own commits, so citing it sends readers
+          # looking for a SHA they will never find in the branch.
+          echo "report_sha=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
           echo "Baseline will be computed from ${MERGE_BASE}"
 
       - name: Setup Node.js
@@ -81,13 +93,20 @@ jobs:
           cp services/vault/playwright.visual.config.ts "$H/"
           cp -R packages/babylon-core-ui/visual "$H/core-ui-visual"
           cp packages/babylon-core-ui/playwright.visual.config.ts "$H/core-ui-playwright.visual.config.ts"
-          cp scripts/visual-diff.mjs "$H/"
+          # NOTE: visual-diff.mjs is deliberately NOT stashed. The diff step
+          # runs after "Restore PR head", so it already reads the tracked
+          # copy from the working tree; a stashed copy would never be read.
           # The runner script itself. Easy to forget, and forgetting it fails
           # the baseline side with a bare "No such file or directory": the
           # script does not exist at the merge-base either.
           cp .github/scripts/visual-capture.sh "$H/"
 
+      # Advisory check: one story that never settles must not cost the whole
+      # report. The diff step reports whichever side is missing instead, and
+      # the summary/comment branch on whether the comparison actually ran.
       - name: Capture candidate (PR head)
+        id: capture-candidate
+        continue-on-error: true
         env:
           CAPTURE_ROOT: ${{ runner.temp }}/visual/candidate
         run: ./.github/scripts/visual-capture.sh
@@ -120,6 +139,8 @@ jobs:
       # are rebuilt from the checked-out source. A PR that only bumps an
       # external UI dependency will not show a diff.
       - name: Capture baseline (merge-base)
+        id: capture-baseline
+        continue-on-error: true
         env:
           CAPTURE_ROOT: ${{ runner.temp }}/visual/baseline
         run: ./.github/scripts/visual-capture.sh
@@ -133,12 +154,27 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          mkdir -p "${{ runner.temp }}/visual"
           TOTAL_CHANGED=0
+          COMPARED=0
           for SURFACE in vault storybook; do
             BASE="${{ runner.temp }}/visual/baseline/${SURFACE}"
             CAND="${{ runner.temp }}/visual/candidate/${SURFACE}"
             OUT="${{ runner.temp }}/visual/report/${SURFACE}"
-            [ -d "$CAND" ] || { echo "No candidate captures for ${SURFACE}, skipping."; continue; }
+            # Either capture may have been cut short (both are
+            # continue-on-error), so name the missing side rather than
+            # letting the diff die on a bare ENOENT.
+            if [ ! -d "$CAND" ] || [ -z "$(ls -A "$CAND" 2>/dev/null)" ]; then
+              echo "No candidate captures for ${SURFACE} - capture did not complete." \
+                | tee -a "${{ runner.temp }}/visual/diff-output.txt"
+              continue
+            fi
+            if [ ! -d "$BASE" ] || [ -z "$(ls -A "$BASE" 2>/dev/null)" ]; then
+              echo "No baseline captures for ${SURFACE} - nothing to compare against." \
+                | tee -a "${{ runner.temp }}/visual/diff-output.txt"
+              continue
+            fi
+            COMPARED=$((COMPARED + 1))
             echo "### ${SURFACE}" | tee -a "${{ runner.temp }}/visual/diff-output.txt"
             node scripts/visual-diff.mjs \
               --baseline "$BASE" --candidate "$CAND" --out "$OUT" \
@@ -149,6 +185,9 @@ jobs:
             TOTAL_CHANGED=$((TOTAL_CHANGED + N))
           done
           echo "changed_count=${TOTAL_CHANGED}" >> "$GITHUB_OUTPUT"
+          # Distinguishes "compared, nothing changed" from "compared nothing".
+          # Without it a zero count reads as a clean run either way.
+          echo "compared_surfaces=${COMPARED}" >> "$GITHUB_OUTPUT"
 
       - name: Upload visual report
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2 https://github.com/actions/upload-artifact/releases/tag/v4.6.2
@@ -160,20 +199,33 @@ jobs:
 
       - name: Summarise
         if: always()
+        env:
+          DIFF_OUTCOME: ${{ steps.diff.outcome }}
+          CHANGED: ${{ steps.diff.outputs.changed_count }}
+          COMPARED: ${{ steps.diff.outputs.compared_surfaces }}
         shell: bash
         run: |
           {
             echo "## Visual regression"
             echo ""
-            echo "Baseline \`${{ steps.refs.outputs.merge_base }}\` (merge-base) vs candidate \`${{ steps.refs.outputs.head_sha }}\`."
+            echo "Baseline \`${{ steps.refs.outputs.merge_base }}\` vs candidate \`${{ steps.refs.outputs.report_sha }}\`."
             echo ""
-            if [ "${{ steps.diff.outputs.changed_count }}" = "0" ]; then
-              echo ":white_check_mark: No visual changes detected."
-            else
-              echo ":framed_picture: **${{ steps.diff.outputs.changed_count }} screen(s) changed.**"
+            # Branch on whether a comparison happened at all. An unset or
+            # empty CHANGED must never render as ":white_check_mark:" —
+            # "nothing was compared" is not "nothing changed".
+            if [ "${DIFF_OUTCOME}" != "success" ] || [ -z "${COMPARED}" ] || [ "${COMPARED}" = "0" ]; then
+              echo ":warning: The capture or comparison did not complete - no visual comparison was made."
               echo ""
               echo '```'
-              cat "${{ runner.temp }}/visual/diff-output.txt" || true
+              cat "${{ runner.temp }}/visual/diff-output.txt" 2>/dev/null || true
+              echo '```'
+            elif [ "${CHANGED}" = "0" ]; then
+              echo ":white_check_mark: No visual changes detected."
+            else
+              echo ":framed_picture: **${CHANGED} screen(s) changed.**"
+              echo ""
+              echo '```'
+              cat "${{ runner.temp }}/visual/diff-output.txt" 2>/dev/null || true
               echo '```'
             fi
           } >> "$GITHUB_STEP_SUMMARY"
@@ -181,11 +233,17 @@ jobs:
       # Sticky comment: edits the previous one instead of stacking one per
       # push. Uses the preinstalled gh CLI rather than adding a third-party
       # action, per the repo's supply-chain policy.
+      # Skipped on fork PRs: `pull_request` hands them a read-only token
+      # regardless of the `permissions:` block above, so the POST would 403
+      # and fail an advisory check for every external contributor. The job
+      # summary carries the same content for those runs.
       - name: Comment on the PR
-        if: always()
+        if: always() && github.event.pull_request.head.repo.full_name == github.repository
         env:
           GH_TOKEN: ${{ github.token }}
+          DIFF_OUTCOME: ${{ steps.diff.outcome }}
           CHANGED: ${{ steps.diff.outputs.changed_count }}
+          COMPARED: ${{ steps.diff.outputs.compared_surfaces }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         shell: bash
         run: |
@@ -197,7 +255,16 @@ jobs:
             echo "$MARKER"
             echo "### Visual regression"
             echo ""
-            if [ "${CHANGED:-0}" = "0" ]; then
+            # `${CHANGED:-0}` substitutes on empty as well as unset, so a
+            # skipped or failed diff step used to collapse to 0 and post an
+            # affirmative "no visual changes". Claiming that when nothing was
+            # compared is worse than staying quiet, so the outcome is checked
+            # first.
+            if [ "${DIFF_OUTCOME}" != "success" ] || [ -z "${COMPARED}" ] || [ "${COMPARED}" = "0" ]; then
+              echo ":warning: The capture or comparison did not complete - no visual comparison was made."
+              echo ""
+              echo "[Open the run](${RUN_URL}) to see which step failed."
+            elif [ "${CHANGED}" = "0" ]; then
               echo ":white_check_mark: No visual changes against the merge-base."
             else
               echo ":framed_picture: **${CHANGED} screen(s) changed** against the merge-base."

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -91,6 +91,12 @@ jobs:
           mkdir -p "$H"
           cp -R services/vault/e2e/visual "$H/vault-visual"
           cp services/vault/playwright.visual.config.ts "$H/"
+          # The visual config imports MOCK_ENV_VARS from playwright.config.ts,
+          # and that export only exists on the PR side. Left unstashed, the
+          # baseline side loads the merge-base copy: the import either fails
+          # outright or resolves to undefined and boots the vault server
+          # with no mock env. Either way the vault baseline is lost.
+          cp services/vault/playwright.config.ts "$H/"
           cp -R packages/babylon-core-ui/visual "$H/core-ui-visual"
           cp packages/babylon-core-ui/playwright.visual.config.ts "$H/core-ui-playwright.visual.config.ts"
           # NOTE: visual-diff.mjs is deliberately NOT stashed. The diff step
@@ -122,6 +128,7 @@ jobs:
           mkdir -p services/vault/e2e packages/babylon-core-ui .github/scripts
           cp -R "$H/vault-visual" services/vault/e2e/visual
           cp "$H/playwright.visual.config.ts" services/vault/
+          cp "$H/playwright.config.ts" services/vault/
           cp -R "$H/core-ui-visual" packages/babylon-core-ui/visual
           cp "$H/core-ui-playwright.visual.config.ts" packages/babylon-core-ui/playwright.visual.config.ts
           cp "$H/visual-capture.sh" .github/scripts/visual-capture.sh
@@ -157,6 +164,7 @@ jobs:
           mkdir -p "${{ runner.temp }}/visual"
           TOTAL_CHANGED=0
           COMPARED=0
+          MISSING=""
           for SURFACE in vault storybook; do
             BASE="${{ runner.temp }}/visual/baseline/${SURFACE}"
             CAND="${{ runner.temp }}/visual/candidate/${SURFACE}"
@@ -167,11 +175,13 @@ jobs:
             if [ ! -d "$CAND" ] || [ -z "$(ls -A "$CAND" 2>/dev/null)" ]; then
               echo "No candidate captures for ${SURFACE} - capture did not complete." \
                 | tee -a "${{ runner.temp }}/visual/diff-output.txt"
+              MISSING="${MISSING}${MISSING:+ }${SURFACE}"
               continue
             fi
             if [ ! -d "$BASE" ] || [ -z "$(ls -A "$BASE" 2>/dev/null)" ]; then
               echo "No baseline captures for ${SURFACE} - nothing to compare against." \
                 | tee -a "${{ runner.temp }}/visual/diff-output.txt"
+              MISSING="${MISSING}${MISSING:+ }${SURFACE}"
               continue
             fi
             COMPARED=$((COMPARED + 1))
@@ -188,6 +198,10 @@ jobs:
           # Distinguishes "compared, nothing changed" from "compared nothing".
           # Without it a zero count reads as a clean run either way.
           echo "compared_surfaces=${COMPARED}" >> "$GITHUB_OUTPUT"
+          # Names every surface that produced no comparison. A run-level
+          # count alone is not enough: one surface capturing empty on both
+          # sides would hide behind the other's COMPARED and read as green.
+          echo "missing_surfaces=${MISSING}" >> "$GITHUB_OUTPUT"
 
       - name: Upload visual report
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2 https://github.com/actions/upload-artifact/releases/tag/v4.6.2
@@ -203,6 +217,7 @@ jobs:
           DIFF_OUTCOME: ${{ steps.diff.outcome }}
           CHANGED: ${{ steps.diff.outputs.changed_count }}
           COMPARED: ${{ steps.diff.outputs.compared_surfaces }}
+          MISSING: ${{ steps.diff.outputs.missing_surfaces }}
         shell: bash
         run: |
           {
@@ -215,6 +230,16 @@ jobs:
             # "nothing was compared" is not "nothing changed".
             if [ "${DIFF_OUTCOME}" != "success" ] || [ -z "${COMPARED}" ] || [ "${COMPARED}" = "0" ]; then
               echo ":warning: The capture or comparison did not complete - no visual comparison was made."
+              echo ""
+              echo '```'
+              cat "${{ runner.temp }}/visual/diff-output.txt" 2>/dev/null || true
+              echo '```'
+            # Every surface must have compared, not just the run overall. A
+            # surface that captured empty on BOTH sides produces no
+            # comparison at all, and folding that into the other surface's
+            # green would report "no changes" for screens nobody looked at.
+            elif [ -n "${MISSING}" ]; then
+              echo ":warning: No comparisons were produced for: ${MISSING}. The result below covers the remaining surface(s) only - this run is not a full comparison."
               echo ""
               echo '```'
               cat "${{ runner.temp }}/visual/diff-output.txt" 2>/dev/null || true
@@ -244,6 +269,7 @@ jobs:
           DIFF_OUTCOME: ${{ steps.diff.outcome }}
           CHANGED: ${{ steps.diff.outputs.changed_count }}
           COMPARED: ${{ steps.diff.outputs.compared_surfaces }}
+          MISSING: ${{ steps.diff.outputs.missing_surfaces }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         shell: bash
         run: |
@@ -264,6 +290,17 @@ jobs:
               echo ":warning: The capture or comparison did not complete - no visual comparison was made."
               echo ""
               echo "[Open the run](${RUN_URL}) to see which step failed."
+            # Per-surface gate, same reasoning as the summary: a surface
+            # that captured empty on both sides must be named, not folded
+            # into the other surface's green.
+            elif [ -n "${MISSING}" ]; then
+              echo ":warning: No comparisons were produced for: ${MISSING}. The remaining surface(s) alone do not make this a clean run."
+              echo ""
+              echo '```'
+              cat "${{ runner.temp }}/visual/diff-output.txt" || true
+              echo '```'
+              echo ""
+              echo "[Open the run](${RUN_URL}) to see why that capture came up empty."
             elif [ "${CHANGED}" = "0" ]; then
               echo ":white_check_mark: No visual changes against the merge-base."
             else

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "nx run-many --target=test --all --verbose",
     "knip": "pnpm dlx knip@5.88.1 --workspace packages/babylon-ts-sdk --workspace services/vault",
     "nx:sync": "nx sync",
+    "visual:diff": "node scripts/visual-diff.mjs",
     "prepare": "husky",
     "ci:release": "nx run @internal/release:run"
   },
@@ -44,6 +45,8 @@
     "husky": "^9.1.7",
     "jsonc-eslint-parser": "^2.4.0",
     "nx": "21.3.7",
+    "pixelmatch": "7.2.0",
+    "pngjs": "7.0.0",
     "prettier": "^3.6.2",
     "syncpack": "^13.0.4",
     "tslib": "^2.3.0",

--- a/packages/babylon-core-ui/.gitignore
+++ b/packages/babylon-core-ui/.gitignore
@@ -1,0 +1,6 @@
+# Storybook build output (the visual-regression capture's input) and the
+# captures themselves. There are no committed baseline images - the
+# baseline is recomputed from the PR's merge-base on every CI run.
+storybook-static/
+visual/__captures__/
+visual/.playwright-output/

--- a/packages/babylon-core-ui/package.json
+++ b/packages/babylon-core-ui/package.json
@@ -30,7 +30,9 @@
     "build-storybook": "storybook build",
     "release": "npm run build && changeset publish",
     "test": "vitest run",
-    "watch": "nodemon --watch src --ext ts,tsx,css --exec \"npm run build\""
+    "watch": "nodemon --watch src --ext ts,tsx,css --exec \"npm run build\"",
+    "visual:capture": "playwright test --config=playwright.visual.config.ts",
+    "visual:build": "storybook build -o storybook-static --quiet"
   },
   "files": [
     "dist",
@@ -48,6 +50,7 @@
     "@commitlint/config-conventional": "^19.8.0",
     "@eslint/js": "^9.31.0",
     "@internal/eslint-config": "workspace:*",
+    "@playwright/test": "^1.55.1",
     "@semantic-release/github": "^11.0.2",
     "@semantic-release/npm": "^12.0.1",
     "@storybook/addon-actions": "^8.6.15",

--- a/packages/babylon-core-ui/package.json
+++ b/packages/babylon-core-ui/package.json
@@ -23,7 +23,7 @@
   },
   "scripts": {
     "dev": "npm run storybook",
-    "build": "tsc -b --noEmit tsconfig.lib.json && vite build",
+    "build": "tsc -b --noEmit tsconfig.lib.json tsconfig.node.json && vite build",
     "format": "prettier . --write",
     "preview": "vite preview",
     "storybook": "storybook dev -p 6006",
@@ -50,7 +50,7 @@
     "@commitlint/config-conventional": "^19.8.0",
     "@eslint/js": "^9.31.0",
     "@internal/eslint-config": "workspace:*",
-    "@playwright/test": "^1.55.1",
+    "@playwright/test": "1.56.1",
     "@semantic-release/github": "^11.0.2",
     "@semantic-release/npm": "^12.0.1",
     "@storybook/addon-actions": "^8.6.15",

--- a/packages/babylon-core-ui/playwright.visual.config.ts
+++ b/packages/babylon-core-ui/playwright.visual.config.ts
@@ -1,0 +1,71 @@
+import { defineConfig, devices } from "@playwright/test";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Storybook visual capture.
+ *
+ * This is the cheapest and broadest visual coverage in the repo: every
+ * story renders in isolation with no backend, no wallet and no network,
+ * so there is almost nothing left to be non-deterministic. Contrast the
+ * vault app capture, which needs a mocked backend to reach even its
+ * unconnected state.
+ *
+ * Captures against a **pre-built static Storybook**, not `storybook dev`.
+ * The build is ~11s and the static server has no HMR client injecting
+ * itself into the frame, which removes a whole class of jitter.
+ */
+
+const VISUAL_PORT = 6007;
+
+/** Where the static Storybook is built to, and served from. */
+export const STORYBOOK_STATIC_DIR =
+  process.env.STORYBOOK_STATIC_DIR ?? path.join(__dirname, "storybook-static");
+
+export default defineConfig({
+  testDir: path.join(__dirname, "visual"),
+  testMatch: "**/*.visual.spec.ts",
+  fullyParallel: false,
+  // Stories are independent, so parallelism is safe here - unlike the
+  // vault capture, which shares one dev server. Kept modest so the
+  // machine's load does not affect render timing.
+  workers: 2,
+  retries: 0,
+  forbidOnly: false,
+  timeout: 120_000,
+  reporter: "list",
+  outputDir: path.join(__dirname, "visual/.playwright-output"),
+
+  use: {
+    headless: true,
+    baseURL: `http://localhost:${VISUAL_PORT}`,
+    // Triggers the global animation/transition reset in src/index.css.
+    reducedMotion: "reduce",
+    colorScheme: "light",
+    deviceScaleFactor: 1,
+    trace: "off",
+    video: "off",
+  },
+
+  projects: [
+    {
+      name: "storybook-visual",
+      use: { ...devices["Desktop Chrome"], deviceScaleFactor: 1 },
+    },
+  ],
+
+  webServer: {
+    // `vite preview` rather than a new static-server dependency - core-ui
+    // already depends on vite, and the repo's policy is to audit every
+    // added package.
+    command: `pnpm exec vite preview --outDir ${STORYBOOK_STATIC_DIR} --port ${VISUAL_PORT} --strictPort`,
+    url: `http://localhost:${VISUAL_PORT}/index.json`,
+    timeout: 120_000,
+    // Must be false in CI: the workflow captures the merge-base and the
+    // PR head in one job, and reusing the first run's server would
+    // photograph the same build twice and pass forever.
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/packages/babylon-core-ui/playwright.visual.config.ts
+++ b/packages/babylon-core-ui/playwright.visual.config.ts
@@ -20,17 +20,26 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const VISUAL_PORT = 6007;
 
-/** Where the static Storybook is built to, and served from. */
-export const STORYBOOK_STATIC_DIR =
-  process.env.STORYBOOK_STATIC_DIR ?? path.join(__dirname, "storybook-static");
+/**
+ * Where the static Storybook is built to, and served from.
+ *
+ * A plain constant rather than an env override: `.github/scripts/
+ * visual-capture.sh` builds with a hardcoded `-o storybook-static`, so an
+ * override would move where the spec and preview server *look* without
+ * moving where the build *writes* - breaking the capture instead of
+ * redirecting it. The spec imports this so the path is defined once.
+ */
+export const STORYBOOK_STATIC_DIR = path.join(__dirname, "storybook-static");
 
 export default defineConfig({
   testDir: path.join(__dirname, "visual"),
   testMatch: "**/*.visual.spec.ts",
-  fullyParallel: false,
-  // Stories are independent, so parallelism is safe here - unlike the
-  // vault capture, which shares one dev server. Kept modest so the
-  // machine's load does not affect render timing.
+  // Stories are independent, so parallelism is safe here - unlike the vault
+  // capture, which shares one dev server. This must be true to have any
+  // effect: with it false Playwright parallelises per FILE, and every story
+  // comes from the single spec below, so the run was silently single-worker.
+  fullyParallel: true,
+  // Kept modest so the machine's load does not affect render timing.
   workers: 2,
   retries: 0,
   forbidOnly: false,
@@ -42,7 +51,10 @@ export default defineConfig({
     headless: true,
     baseURL: `http://localhost:${VISUAL_PORT}`,
     // Triggers the global animation/transition reset in src/index.css.
-    reducedMotion: "reduce",
+    // MUST sit under `contextOptions`: `reducedMotion` is not a top-level
+    // `use` option, so Playwright silently ignores it there and every story
+    // was being photographed with animations still running.
+    contextOptions: { reducedMotion: "reduce" },
     colorScheme: "light",
     deviceScaleFactor: 1,
     trace: "off",

--- a/packages/babylon-core-ui/src/widgets/sections/ValidatorSelector/ValidatorSelector.stories.tsx
+++ b/packages/babylon-core-ui/src/widgets/sections/ValidatorSelector/ValidatorSelector.stories.tsx
@@ -18,7 +18,10 @@ const sampleValidators: ValidatorRow[] = Array.from({ length: 15 }, (_, i) => {
         ),
         name: `Validator ${index}`,
         apr: `${25 + (index % 6)}.${(index * 7) % 100}`.padEnd(6, "0") + "%", // simple varied APR
-        votingPower: `${(Math.random() * 1).toFixed(6)} sBTC`,
+        // Derived from the index, not Math.random(): the story is snapshotted
+        // by the visual-regression capture, and a random value would differ on
+        // every run and report a change that isn't one.
+        votingPower: `0.${String((index * 137) % 1_000_000).padStart(6, "0")} sBTC`,
         commission: `${2 + (index % 5)}%`,
     } as ValidatorRow;
 });

--- a/packages/babylon-core-ui/tsconfig.node.json
+++ b/packages/babylon-core-ui/tsconfig.node.json
@@ -2,7 +2,10 @@
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
     "target": "ES2023",
-    "lib": ["ES2023"],
+    // DOM for the visual spec: its `page.evaluate` / `waitForFunction`
+    // callbacks are authored against browser globals even though the file
+    // itself runs in node.
+    "lib": ["ES2023", "DOM"],
     "module": "ESNext",
     "skipLibCheck": true,
 
@@ -20,5 +23,9 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["vite.config.ts"]
+  // The visual harness lives here rather than in tsconfig.lib.json: it is
+  // node-side tooling, and lib emits declarations into dist/. Without these
+  // entries the spec and its config sit outside every project and are
+  // typechecked by nothing until CI runs the capture.
+  "include": ["vite.config.ts", "playwright.visual.config.ts", "visual"]
 }

--- a/packages/babylon-core-ui/visual/stories.visual.spec.ts
+++ b/packages/babylon-core-ui/visual/stories.visual.spec.ts
@@ -20,11 +20,9 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-const currentDir = path.dirname(fileURLToPath(import.meta.url));
+import { STORYBOOK_STATIC_DIR } from "../playwright.visual.config";
 
-const STORYBOOK_STATIC_DIR =
-  process.env.STORYBOOK_STATIC_DIR ??
-  path.join(currentDir, "..", "storybook-static");
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
 
 const OUTPUT_DIR =
   process.env.VISUAL_OUT_DIR ?? path.join(currentDir, "__captures__");
@@ -161,8 +159,20 @@ for (const storyId of storyIds) {
     // permanently empty. Checking for *any* painted element then fails on
     // stories that intentionally render nothing (TopBanner's `Hidden`).
     // `sb-show-main` is correct for all three.
+    // Waits for ANY terminal mode, not just the successful one. Storybook's
+    // `showMode` removes every other mode class as it adds one, so a story
+    // that throws never gets `sb-show-main` — gating on that alone made this
+    // time out after the full 20s and left the error check below unreachable,
+    // turning an actionable message into an opaque timeout.
     await page.waitForFunction(
-      () => document.body.classList.contains("sb-show-main"),
+      () => {
+        const { classList } = document.body;
+        return (
+          classList.contains("sb-show-main") ||
+          classList.contains("sb-show-errordisplay") ||
+          classList.contains("sb-show-nopreview")
+        );
+      },
       undefined,
       { timeout: STORY_RENDER_TIMEOUT_MS },
     );

--- a/packages/babylon-core-ui/visual/stories.visual.spec.ts
+++ b/packages/babylon-core-ui/visual/stories.visual.spec.ts
@@ -1,0 +1,207 @@
+/**
+ * Photographs every Storybook story.
+ *
+ * The story list is read from the built Storybook's `index.json` at run
+ * time rather than hard-coded, so adding a story automatically adds
+ * visual coverage and deleting one shows up in the diff report as a
+ * removed screen. Nothing to maintain by hand.
+ *
+ * Docs entries (`type: "docs"`) are skipped: an MDX page is prose about
+ * the components, and it re-renders every story inside it, so capturing
+ * it would double the cost and report one change as many.
+ *
+ * Like the vault capture, this asserts nothing about how a story looks.
+ * The judgement happens in the diff step against the same capture taken
+ * at the PR's merge-base.
+ */
+
+import { expect, test, type Page } from "@playwright/test";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+
+const STORYBOOK_STATIC_DIR =
+  process.env.STORYBOOK_STATIC_DIR ??
+  path.join(currentDir, "..", "storybook-static");
+
+const OUTPUT_DIR =
+  process.env.VISUAL_OUT_DIR ?? path.join(currentDir, "__captures__");
+
+/** Height the story frame is rendered at before it is measured. Stories
+ *  are captured full-page, so this only sets the initial layout width /
+ *  minimum height, not the final image height. */
+const STORY_VIEWPORT = { width: 900, height: 600 };
+
+/** Upper bound on waiting for a story's root to paint. */
+const STORY_RENDER_TIMEOUT_MS = 20_000;
+
+/** Gap between rendered-frame samples when waiting for a story to settle. */
+const FRAME_SETTLE_QUIET_MS = 150;
+/** Consecutive identical frames required. */
+const FRAME_SETTLE_CONSECUTIVE_MATCHES = 2;
+/** Upper bound on waiting for the frame to stop changing. */
+const FRAME_SETTLE_TIMEOUT_MS = 15_000;
+
+/**
+ * Storybook keeps the functional loader spinning under reduced motion
+ * (see docs/motion-system.md). Frozen here for the same reason the vault
+ * capture freezes it: otherwise every spinner story lands on a random
+ * rotation and diffs against itself forever.
+ */
+const FREEZE_SPINNER_CSS = `
+  .bbn-loader,
+  .bbn-loader * {
+    animation: none !important;
+  }
+`;
+
+interface StorybookIndexEntry {
+  id: string;
+  type?: string;
+  name?: string;
+  title?: string;
+}
+
+async function readStoryIds(): Promise<string[]> {
+  const indexPath = path.join(STORYBOOK_STATIC_DIR, "index.json");
+  let raw: string;
+  try {
+    raw = await fs.readFile(indexPath, "utf8");
+  } catch {
+    throw new Error(
+      `No built Storybook at ${indexPath}. Run "pnpm --filter @babylonlabs-io/core-ui run build-storybook" first.`,
+    );
+  }
+  const index = JSON.parse(raw) as {
+    entries?: Record<string, StorybookIndexEntry>;
+  };
+  const entries = Object.values(index.entries ?? {});
+  const stories = entries
+    .filter((entry) => entry.type === "story")
+    .map((entry) => entry.id)
+    // Sorted so the capture order - and therefore any partial output on
+    // a failed run - is reproducible.
+    .sort();
+
+  if (stories.length === 0) {
+    throw new Error(
+      `Built Storybook at ${indexPath} contains no stories. The build likely failed silently.`,
+    );
+  }
+  return stories;
+}
+
+/**
+ * Block until the rendered frame stops changing.
+ *
+ * Compares the actual rendered bytes rather than a cheaper proxy. Two
+ * cheaper proxies were tried and both let real flake through:
+ *
+ * - Scroll dimensions alone fixed the visx chart stories (`SeizureMap`
+ *   remeasures its parent and re-renders at a new height) but not the
+ *   overlays: a modal fading in over a fixed-position backdrop does not
+ *   change the page's scroll size at all, so six modal/dialog stories
+ *   kept flaking - and a *different* six each run.
+ * - `sb-show-main` fires when Storybook has rendered the story, which is
+ *   before its enter animation has finished.
+ *
+ * Polling pixels covers layout, animation, late images and lazy content
+ * in one check, and costs one extra screenshot for the ~98% of stories
+ * that are already settled on the first comparison.
+ */
+async function waitForFrameSettled(page: Page): Promise<void> {
+  const deadline = Date.now() + FRAME_SETTLE_TIMEOUT_MS;
+  let previous = await page.screenshot({ fullPage: true });
+  let matches = 0;
+
+  while (Date.now() < deadline) {
+    await page.waitForTimeout(FRAME_SETTLE_QUIET_MS);
+    const current = await page.screenshot({ fullPage: true });
+    if (current.equals(previous)) {
+      matches += 1;
+      if (matches >= FRAME_SETTLE_CONSECUTIVE_MATCHES) return;
+    } else {
+      matches = 0;
+    }
+    previous = current;
+  }
+
+  throw new Error(
+    `Story never reached a stable frame within ${FRAME_SETTLE_TIMEOUT_MS}ms - something ` +
+      `animates or refetches indefinitely. Freeze it here rather than accepting a flaky baseline.`,
+  );
+}
+
+const storyIds = await readStoryIds();
+
+test.beforeAll(async () => {
+  await fs.mkdir(OUTPUT_DIR, { recursive: true });
+});
+
+for (const storyId of storyIds) {
+  test(`capture story ${storyId}`, async ({ page }) => {
+    await page.setViewportSize(STORY_VIEWPORT);
+
+    // `viewMode=story` renders the bare component without the Storybook
+    // chrome (sidebar, toolbar, addon panel), so the screenshot is the
+    // component and nothing else.
+    await page.goto(`/iframe.html?id=${encodeURIComponent(storyId)}&viewMode=story`, {
+      waitUntil: "domcontentloaded",
+    });
+
+    // Gate on Storybook's OWN render signal rather than on the DOM having
+    // content. `sb-show-main` means "the story finished rendering",
+    // which is the question we actually care about.
+    //
+    // Two DOM-based gates were tried first and both were wrong. Checking
+    // `#storybook-root` has children fails on modal/dialog/tooltip
+    // stories, which portal onto `document.body` and leave the root
+    // permanently empty. Checking for *any* painted element then fails on
+    // stories that intentionally render nothing (TopBanner's `Hidden`).
+    // `sb-show-main` is correct for all three.
+    await page.waitForFunction(
+      () => document.body.classList.contains("sb-show-main"),
+      undefined,
+      { timeout: STORY_RENDER_TIMEOUT_MS },
+    );
+
+    // A story that threw renders Storybook's error panel instead. That is
+    // stable, so it would happily become a baseline and the broken story
+    // would never be noticed again. Fail loudly instead.
+    const failureClass = await page.evaluate(() => {
+      const { classList } = document.body;
+      if (classList.contains("sb-show-errordisplay")) return "errordisplay";
+      if (classList.contains("sb-show-nopreview")) return "nopreview";
+      return null;
+    });
+    if (failureClass !== null) {
+      throw new Error(
+        `Story "${storyId}" rendered Storybook's ${failureClass} panel instead of the component. ` +
+          `Fix the story - capturing it would bake the error screen in as the expected look.`,
+      );
+    }
+
+    await page.addStyleTag({ content: FREEZE_SPINNER_CSS });
+    await page.evaluate(async () => {
+      await document.fonts.ready;
+      // Wait for every <img> to be decoded, not merely loaded. Token and
+      // provider icons otherwise land decoded on one run and blank on the
+      // next, which showed up as a small but permanent diff on the icon
+      // area of four stories. `decode()` rejects for a broken image; that
+      // is the story's problem, not the capture's, so it is swallowed.
+      await Promise.all(
+        Array.from(document.images).map((img) =>
+          img.decode().catch(() => undefined),
+        ),
+      );
+    });
+    await waitForFrameSettled(page);
+
+    const buffer = await page.screenshot({ fullPage: true });
+    await fs.writeFile(path.join(OUTPUT_DIR, `${storyId}.png`), buffer);
+
+    expect(buffer.byteLength).toBeGreaterThan(100);
+  });
+}

--- a/packages/babylon-wallet-connector/package.json
+++ b/packages/babylon-wallet-connector/package.json
@@ -96,7 +96,7 @@
     "@commitlint/config-conventional": "^19.8.0",
     "@eslint/js": "^9.31.0",
     "@internal/eslint-config": "workspace:*",
-    "@playwright/test": "^1.55.1",
+    "@playwright/test": "1.56.1",
     "@semantic-release/github": "^11.0.2",
     "@semantic-release/npm": "^12.0.1",
     "@storybook/addon-essentials": "^8.6.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,7 +150,7 @@ importers:
         specifier: workspace:*
         version: link:../../tools/eslint-config
       '@playwright/test':
-        specifier: ^1.55.1
+        specifier: 1.56.1
         version: 1.56.1
       '@semantic-release/github':
         specifier: ^11.0.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,6 +70,12 @@ importers:
       nx:
         specifier: 21.3.7
         version: 21.3.7(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.9.2))(@swc/core@1.5.29(@swc/helpers@0.5.17))
+      pixelmatch:
+        specifier: 7.2.0
+        version: 7.2.0
+      pngjs:
+        specifier: 7.0.0
+        version: 7.0.0
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
@@ -143,6 +149,9 @@ importers:
       '@internal/eslint-config':
         specifier: workspace:*
         version: link:../../tools/eslint-config
+      '@playwright/test':
+        specifier: ^1.55.1
+        version: 1.56.1
       '@semantic-release/github':
         specifier: ^11.0.2
         version: 11.0.3(semantic-release@24.2.7(typescript@5.9.2))
@@ -8712,6 +8721,10 @@ packages:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
 
+  pixelmatch@7.2.0:
+    resolution: {integrity: sha512-xhcb4yHu9sM/G7foGzoLtXYcC0zHEaOXXjRKhGup0fw78Nf2Tkiapv4EQyMzrbcmQPsllAI7DbFY2UT7PlI9Pg==}
+    hasBin: true
+
   pkg-conf@2.1.0:
     resolution: {integrity: sha512-C+VUP+8jis7EsQZIhDYmS5qlNtjv2yP4SNtjXK9AP1ZcTRlnSfuumaTnRfYZnYgUUYVIKqL0fRvmUGDV2fmp6g==}
     engines: {node: '>=4'}
@@ -8747,6 +8760,10 @@ packages:
   pngjs@5.0.0:
     resolution: {integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==}
     engines: {node: '>=10.13.0'}
+
+  pngjs@7.0.0:
+    resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
+    engines: {node: '>=14.19.0'}
 
   polished@4.3.1:
     resolution: {integrity: sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA==}
@@ -22240,6 +22257,10 @@ snapshots:
 
   pirates@4.0.7: {}
 
+  pixelmatch@7.2.0:
+    dependencies:
+      pngjs: 7.0.0
+
   pkg-conf@2.1.0:
     dependencies:
       find-up: 2.1.0
@@ -22278,6 +22299,8 @@ snapshots:
       fsevents: 2.3.2
 
   pngjs@5.0.0: {}
+
+  pngjs@7.0.0: {}
 
   polished@4.3.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -525,7 +525,7 @@ importers:
         specifier: workspace:*
         version: link:../../tools/eslint-config
       '@playwright/test':
-        specifier: ^1.55.1
+        specifier: 1.56.1
         version: 1.56.1
       '@semantic-release/github':
         specifier: ^11.0.2
@@ -793,7 +793,7 @@ importers:
         specifier: ^9.31.0
         version: 9.32.0
       '@playwright/test':
-        specifier: ^1.55.1
+        specifier: 1.56.1
         version: 1.56.1
       '@sentry/vite-plugin':
         specifier: ^2.22.6
@@ -1025,7 +1025,7 @@ importers:
         specifier: ^9.31.0
         version: 9.32.0
       '@playwright/test':
-        specifier: ^1.55.1
+        specifier: 1.56.1
         version: 1.56.1
       '@sentry/vite-plugin':
         specifier: ^2.22.6

--- a/scripts/visual-diff.mjs
+++ b/scripts/visual-diff.mjs
@@ -1,0 +1,316 @@
+/**
+ * Compares two directories of captured PNGs and writes a reviewable report.
+ *
+ *   node scripts/visual-diff.mjs \
+ *     --baseline <dir> --candidate <dir> --out <dir> [--fail-on-change]
+ *
+ * There are no stored baselines in this repo. The `--baseline` directory
+ * is produced by running the same capture against the PR's merge-base in
+ * the same container, so both sides are rendered by identical browser,
+ * fonts and OS. That is what lets the pixel threshold stay at zero-ish
+ * instead of being loosened until real regressions slip through.
+ *
+ * Exit code is 0 unless `--fail-on-change` is passed, so the check can
+ * start out advisory and be promoted to blocking once its noise floor is
+ * proven in practice.
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+
+import pixelmatch from "pixelmatch";
+import { PNG } from "pngjs";
+
+/**
+ * Per-pixel colour distance below which two pixels count as equal.
+ * Both sides render in the same container, so this exists only to
+ * absorb GPU-level antialiasing jitter, not real colour differences.
+ */
+const PIXEL_MATCH_THRESHOLD = 0.1;
+
+/**
+ * Changed pixels below this fraction of the image are reported but do
+ * not mark the run as changed. Guards against a stray subpixel without
+ * hiding anything a reviewer would notice.
+ */
+const CHANGED_RATIO_TOLERANCE = 0.0001;
+
+const STATUS = {
+  UNCHANGED: "unchanged",
+  CHANGED: "changed",
+  ADDED: "added",
+  REMOVED: "removed",
+  SIZE_CHANGED: "size-changed",
+};
+
+function parseArgs(argv) {
+  const args = new Map();
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    // `pnpm run visual:diff -- --baseline ...` forwards a bare `--`.
+    // Without this it parses as an empty-named flag and swallows the
+    // next real argument.
+    if (token === "--") continue;
+    if (!token.startsWith("--")) continue;
+    const key = token.slice(2);
+    const next = argv[i + 1];
+    if (next === undefined || next.startsWith("--")) {
+      args.set(key, "true");
+    } else {
+      args.set(key, next);
+      i += 1;
+    }
+  }
+  return args;
+}
+
+async function listPngs(dir) {
+  try {
+    const entries = await fs.readdir(dir);
+    return entries.filter((name) => name.endsWith(".png")).sort();
+  } catch (error) {
+    if (error.code === "ENOENT") {
+      throw new Error(
+        `Capture directory not found: ${dir}. Run the capture step for this side first.`,
+      );
+    }
+    throw error;
+  }
+}
+
+async function readPng(file) {
+  return PNG.sync.read(await fs.readFile(file));
+}
+
+async function compareOne(name, baselineDir, candidateDir, outDir) {
+  const baseline = await readPng(path.join(baselineDir, name));
+  const candidate = await readPng(path.join(candidateDir, name));
+
+  // Full-page screenshots change height whenever content does. That is a
+  // real visual change, but pixelmatch cannot diff mismatched buffers, so
+  // it is reported on its own terms instead of being force-cropped.
+  if (baseline.width !== candidate.width || baseline.height !== candidate.height) {
+    return {
+      name,
+      status: STATUS.SIZE_CHANGED,
+      baselineSize: `${baseline.width}x${baseline.height}`,
+      candidateSize: `${candidate.width}x${candidate.height}`,
+      changedPixels: null,
+      changedRatio: null,
+    };
+  }
+
+  const { width, height } = baseline;
+  const diff = new PNG({ width, height });
+  const changedPixels = pixelmatch(
+    baseline.data,
+    candidate.data,
+    diff.data,
+    width,
+    height,
+    { threshold: PIXEL_MATCH_THRESHOLD },
+  );
+
+  const changedRatio = changedPixels / (width * height);
+  const changed = changedRatio > CHANGED_RATIO_TOLERANCE;
+
+  if (changed) {
+    await fs.writeFile(path.join(outDir, "diff", name), PNG.sync.write(diff));
+  }
+
+  return {
+    name,
+    status: changed ? STATUS.CHANGED : STATUS.UNCHANGED,
+    baselineSize: `${width}x${height}`,
+    candidateSize: `${width}x${height}`,
+    changedPixels,
+    changedRatio,
+  };
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function renderReport(results, meta) {
+  const interesting = results.filter((r) => r.status !== STATUS.UNCHANGED);
+  const rows = (interesting.length ? interesting : results)
+    .map((result) => {
+      const pct =
+        result.changedRatio === null
+          ? "-"
+          : `${(result.changedRatio * 100).toFixed(3)}%`;
+      const images =
+        result.status === STATUS.ADDED
+          ? `<figure><figcaption>added</figcaption><img src="candidate/${escapeHtml(result.name)}" /></figure>`
+          : result.status === STATUS.REMOVED
+            ? `<figure><figcaption>removed</figcaption><img src="baseline/${escapeHtml(result.name)}" /></figure>`
+            : `
+        <figure><figcaption>baseline (merge-base)</figcaption><img src="baseline/${escapeHtml(result.name)}" /></figure>
+        <figure><figcaption>candidate (this PR)</figcaption><img src="candidate/${escapeHtml(result.name)}" /></figure>
+        ${
+          result.status === STATUS.CHANGED
+            ? `<figure><figcaption>diff</figcaption><img src="diff/${escapeHtml(result.name)}" /></figure>`
+            : ""
+        }`;
+      return `
+      <section class="card ${escapeHtml(result.status)}">
+        <header>
+          <h2>${escapeHtml(result.name)}</h2>
+          <span class="badge">${escapeHtml(result.status)}</span>
+          <span class="meta">${escapeHtml(result.baselineSize ?? "-")} → ${escapeHtml(result.candidateSize ?? "-")} · ${escapeHtml(pct)} of pixels</span>
+        </header>
+        <div class="triptych">${images}</div>
+      </section>`;
+    })
+    .join("\n");
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Visual diff · ${escapeHtml(meta.candidateRef)} vs ${escapeHtml(meta.baselineRef)}</title>
+<style>
+  :root { color-scheme: light dark; }
+  body { font: 14px/1.5 ui-sans-serif, system-ui, sans-serif; margin: 0; padding: 24px; }
+  h1 { font-size: 20px; margin: 0 0 4px; }
+  .summary { color: #666; margin-bottom: 24px; }
+  .card { border: 1px solid #d0d0d0; border-radius: 8px; margin-bottom: 24px; overflow: hidden; }
+  .card header { display: flex; align-items: center; gap: 12px; padding: 12px 16px; background: #f6f6f6; }
+  .card.changed header, .card.size-changed header { background: #fff3cd; }
+  .card.added header { background: #d1f7d6; }
+  .card.removed header { background: #ffd7d7; }
+  .card h2 { font-size: 15px; margin: 0; }
+  .badge { font-size: 11px; text-transform: uppercase; letter-spacing: .04em; border: 1px solid currentColor; border-radius: 999px; padding: 2px 8px; }
+  .meta { margin-left: auto; color: #555; font-variant-numeric: tabular-nums; }
+  .triptych { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 12px; padding: 16px; }
+  figure { margin: 0; }
+  figcaption { font-size: 12px; color: #666; margin-bottom: 6px; }
+  img { width: 100%; height: auto; border: 1px solid #e0e0e0; background: #fff; }
+  @media (prefers-color-scheme: dark) {
+    body { background: #121212; color: #eee; }
+    .card { border-color: #333; }
+    .card header { background: #1e1e1e; }
+    .card.changed header, .card.size-changed header { background: #4a3f16; }
+    .card.added header { background: #17371c; }
+    .card.removed header { background: #4a1f1f; }
+    .meta, .summary, figcaption { color: #aaa; }
+  }
+</style>
+</head>
+<body>
+  <h1>Visual diff</h1>
+  <p class="summary">
+    candidate <code>${escapeHtml(meta.candidateRef)}</code> vs baseline <code>${escapeHtml(meta.baselineRef)}</code><br />
+    ${meta.changedCount} of ${meta.totalCount} screens changed.
+    ${interesting.length === 0 ? "Showing all screens because nothing changed." : ""}
+  </p>
+  ${rows}
+</body>
+</html>`;
+}
+
+async function copyDir(from, to) {
+  await fs.mkdir(to, { recursive: true });
+  for (const name of await listPngs(from)) {
+    await fs.copyFile(path.join(from, name), path.join(to, name));
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const baselineDir = args.get("baseline");
+  const candidateDir = args.get("candidate");
+  const outDir = args.get("out");
+
+  if (!baselineDir || !candidateDir || !outDir) {
+    throw new Error(
+      "Usage: visual-diff.mjs --baseline <dir> --candidate <dir> --out <dir> [--fail-on-change]",
+    );
+  }
+
+  await fs.mkdir(path.join(outDir, "diff"), { recursive: true });
+
+  const baselineNames = await listPngs(baselineDir);
+  const candidateNames = await listPngs(candidateDir);
+  const allNames = [...new Set([...baselineNames, ...candidateNames])].sort();
+
+  const results = [];
+  for (const name of allNames) {
+    const inBaseline = baselineNames.includes(name);
+    const inCandidate = candidateNames.includes(name);
+
+    if (!inBaseline) {
+      results.push({
+        name,
+        status: STATUS.ADDED,
+        changedPixels: null,
+        changedRatio: null,
+      });
+      continue;
+    }
+    if (!inCandidate) {
+      results.push({
+        name,
+        status: STATUS.REMOVED,
+        changedPixels: null,
+        changedRatio: null,
+      });
+      continue;
+    }
+    results.push(await compareOne(name, baselineDir, candidateDir, outDir));
+  }
+
+  await copyDir(baselineDir, path.join(outDir, "baseline"));
+  await copyDir(candidateDir, path.join(outDir, "candidate"));
+
+  const changed = results.filter((r) => r.status !== STATUS.UNCHANGED);
+  const meta = {
+    baselineRef: args.get("baseline-ref") ?? "merge-base",
+    candidateRef: args.get("candidate-ref") ?? "HEAD",
+    totalCount: results.length,
+    changedCount: changed.length,
+  };
+
+  await fs.writeFile(
+    path.join(outDir, "summary.json"),
+    `${JSON.stringify({ ...meta, results }, null, 2)}\n`,
+  );
+  await fs.writeFile(
+    path.join(outDir, "index.html"),
+    renderReport(results, meta),
+  );
+
+  const lines = changed.map(
+    (r) =>
+      `  ${r.status.padEnd(13)} ${r.name}${
+        r.changedRatio === null
+          ? ""
+          : ` (${(r.changedRatio * 100).toFixed(3)}% of pixels)`
+      }`,
+  );
+
+  if (changed.length === 0) {
+    process.stdout.write(
+      `No visual changes across ${results.length} screens.\n`,
+    );
+  } else {
+    process.stdout.write(
+      `${changed.length} of ${results.length} screens changed:\n${lines.join("\n")}\n`,
+    );
+  }
+
+  if (changed.length > 0 && args.get("fail-on-change") === "true") {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error.message}\n`);
+  process.exitCode = 1;
+});

--- a/scripts/visual-diff.mjs
+++ b/scripts/visual-diff.mjs
@@ -18,6 +18,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
+import { fileURLToPath } from "node:url";
 
 import pixelmatch from "pixelmatch";
 import { PNG } from "pngjs";
@@ -30,11 +31,29 @@ import { PNG } from "pngjs";
 const PIXEL_MATCH_THRESHOLD = 0.1;
 
 /**
- * Changed pixels below this fraction of the image are reported but do
- * not mark the run as changed. Guards against a stray subpixel without
- * hiding anything a reviewer would notice.
+ * Changed pixels below this fraction of the image are reported but do not
+ * mark the run as changed. Guards against a stray subpixel without hiding
+ * anything a reviewer would notice.
+ *
+ * A ratio alone loses sensitivity as a page grows: at 1280x4000 it absorbs
+ * ~512 pixels, about a 24x24 icon. `MIN_CHANGED_PIXELS` is the floor that
+ * holds sensitivity constant regardless of capture height, and the effective
+ * cutoff is the larger of the two.
  */
 const CHANGED_RATIO_TOLERANCE = 0.0001;
+
+/**
+ * Absolute floor, in pixels, below which a difference is treated as noise no
+ * matter how large the image. Sized well under a glyph or icon: real diffs
+ * measured on this harness's own runs landed at 0.090%-0.569% of the frame,
+ * hundreds to thousands of pixels, so there is ample headroom above this.
+ */
+const MIN_CHANGED_PIXELS = 24;
+
+/** The cutoff a capture must exceed to count as changed. */
+export function changedPixelCutoff(width, height) {
+  return Math.max(MIN_CHANGED_PIXELS, CHANGED_RATIO_TOLERANCE * width * height);
+}
 
 const STATUS = {
   UNCHANGED: "unchanged",
@@ -44,7 +63,7 @@ const STATUS = {
   SIZE_CHANGED: "size-changed",
 };
 
-function parseArgs(argv) {
+export function parseArgs(argv) {
   const args = new Map();
   for (let i = 0; i < argv.length; i += 1) {
     const token = argv[i];
@@ -83,7 +102,7 @@ async function readPng(file) {
   return PNG.sync.read(await fs.readFile(file));
 }
 
-async function compareOne(name, baselineDir, candidateDir, outDir) {
+export async function compareOne(name, baselineDir, candidateDir, outDir) {
   const baseline = await readPng(path.join(baselineDir, name));
   const candidate = await readPng(path.join(candidateDir, name));
 
@@ -113,7 +132,7 @@ async function compareOne(name, baselineDir, candidateDir, outDir) {
   );
 
   const changedRatio = changedPixels / (width * height);
-  const changed = changedRatio > CHANGED_RATIO_TOLERANCE;
+  const changed = changedPixels > changedPixelCutoff(width, height);
 
   if (changed) {
     await fs.writeFile(path.join(outDir, "diff", name), PNG.sync.write(diff));
@@ -310,7 +329,13 @@ async function main() {
   }
 }
 
-main().catch((error) => {
-  process.stderr.write(`${error.message}\n`);
-  process.exitCode = 1;
-});
+// Only run as a CLI. Importing this module (the unit tests do) must not
+// execute a diff.
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    // Stack, not just message: a PNG.sync.read failure on a truncated
+    // capture is near-undiagnosable from the message alone.
+    process.stderr.write(`${error.stack ?? error.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/services/simple-staking/package.json
+++ b/services/simple-staking/package.json
@@ -72,7 +72,7 @@
     "@babel/preset-react": "^7.24.7",
     "@babel/preset-typescript": "^7.24.7",
     "@eslint/js": "^9.31.0",
-    "@playwright/test": "^1.55.1",
+    "@playwright/test": "1.56.1",
     "@sentry/vite-plugin": "^2.22.6",
     "@tanstack/eslint-plugin-query": "^5.74.7",
     "@tanstack/react-query-devtools": "5.28.14",

--- a/services/vault/.gitignore
+++ b/services/vault/.gitignore
@@ -271,6 +271,12 @@ next-env.d.ts
 /blob-report/
 /playwright/.cache/
 
+# Visual capture output. There are no committed baselines - the baseline
+# is recomputed from the PR's merge-base on every CI run - so nothing
+# under here should ever be checked in.
+/e2e/visual/__captures__/
+/e2e/visual/.playwright-output/
+
 # E2E Chrome Extensions
 extensions
 

--- a/services/vault/e2e/visual/routes.visual.spec.ts
+++ b/services/vault/e2e/visual/routes.visual.spec.ts
@@ -15,7 +15,6 @@
 import type { Page } from "@playwright/test";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 
 import { expect, test } from "../fixtures";
 import { mockEthRpc, mockGraphql } from "../fixtures/networkRoutes";
@@ -27,10 +26,7 @@ import {
   VISUAL_VIEWPORTS,
 } from "./targets";
 
-const currentDir = path.dirname(fileURLToPath(import.meta.url));
-
-const OUTPUT_DIR =
-  process.env.VISUAL_OUT_DIR ?? path.join(currentDir, "__captures__");
+import { VISUAL_OUTPUT_DIR as OUTPUT_DIR } from "../../playwright.visual.config";
 
 /**
  * Nothing may leave the machine during a capture. The mocks below cover

--- a/services/vault/e2e/visual/routes.visual.spec.ts
+++ b/services/vault/e2e/visual/routes.visual.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * Photographs every screen in the capture manifest.
+ *
+ * This spec asserts nothing about how the app *looks* - that judgement
+ * belongs to the diff step, which compares this run's output against the
+ * same capture taken at the PR's merge-base. All this file guarantees is
+ * that each screen renders, settles, and is written to disk under a
+ * stable filename.
+ *
+ * Run it twice on the same commit and the two output directories must be
+ * byte-identical. If they are not, the fix belongs in `stabilize.ts`, not
+ * in a diff threshold.
+ */
+
+import type { Page } from "@playwright/test";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { expect, test } from "../fixtures";
+import { mockEthRpc, mockGraphql } from "../fixtures/networkRoutes";
+
+import { installVisualDeterminism, waitForVisualStability } from "./stabilize";
+import {
+  screenshotFileName,
+  VISUAL_TARGETS,
+  VISUAL_VIEWPORTS,
+} from "./targets";
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+
+const OUTPUT_DIR =
+  process.env.VISUAL_OUT_DIR ?? path.join(currentDir, "__captures__");
+
+/**
+ * Nothing may leave the machine during a capture. The mocks below cover
+ * the endpoints the app actually calls; this catch-all makes anything we
+ * missed fail closed instead of reaching a live host and introducing
+ * run-to-run variance (or, on a fork PR, leaking a request).
+ *
+ * Registered first on purpose - Playwright gives precedence to the most
+ * recently registered matching route, so the specific mocks below win.
+ */
+async function blockOffsiteRequests(page: Page): Promise<void> {
+  await page.route("**/*", (route) => {
+    const { hostname } = new URL(route.request().url());
+    const isLocal = hostname === "localhost" || hostname === "127.0.0.1";
+    return isLocal ? route.continue() : route.abort();
+  });
+}
+
+/**
+ * Deliberately NOT `mockVpProxy`. It answers `/vp-health` with an empty
+ * snapshot list, which the app treats as "no vault provider exists" and
+ * throws on during startup - React never mounts and `#root` stays empty,
+ * so every screen would capture as a blank page. Leaving the VP calls to
+ * `blockOffsiteRequests` lets the app fall back to its error surface and
+ * render the real shell.
+ *
+ * `mockEthRpc` answers `eth_chainId`; the contract reads it cannot answer
+ * fall through to a JSON-RPC error, which the app renders as its
+ * "Something went wrong" card. That is the honest unconnected state this
+ * harness can reach today - the fully-populated dashboard needs the
+ * page-side wallet provider from #1592.
+ */
+test.beforeEach(async ({ page }) => {
+  await blockOffsiteRequests(page);
+  await mockGraphql(page, () => ({ data: {} }));
+  await mockEthRpc(page);
+  await installVisualDeterminism(page);
+});
+
+test.beforeAll(async () => {
+  await fs.mkdir(OUTPUT_DIR, { recursive: true });
+});
+
+for (const target of VISUAL_TARGETS) {
+  for (const viewport of VISUAL_VIEWPORTS) {
+    test(`capture ${target.name} at ${viewport.name}`, async ({ page }) => {
+      await page.setViewportSize({
+        width: viewport.width,
+        height: viewport.height,
+      });
+
+      await page.goto(target.path, { waitUntil: "domcontentloaded" });
+      await waitForVisualStability(page);
+
+      const fileName = screenshotFileName(target, viewport);
+      const buffer = await page.screenshot({ fullPage: true });
+      await fs.writeFile(path.join(OUTPUT_DIR, fileName), buffer);
+
+      // A zero-byte or absurdly small PNG means the screen never
+      // painted; that must fail the capture rather than silently
+      // become an "expected" baseline the next run diffs against.
+      expect(buffer.byteLength).toBeGreaterThan(1000);
+    });
+  }
+}

--- a/services/vault/e2e/visual/stabilize.ts
+++ b/services/vault/e2e/visual/stabilize.ts
@@ -1,0 +1,128 @@
+/**
+ * Determinism controls for visual capture.
+ *
+ * A visual diff is only useful if two runs of the *same* commit produce
+ * byte-identical PNGs. Everything here exists to remove a specific
+ * source of run-to-run variance found in this app:
+ *
+ * - **Animations / transitions** are neutralised by core-ui's global
+ *   `prefers-reduced-motion` reset (`packages/babylon-core-ui/src/index.css`),
+ *   which the capture config triggers with `reducedMotion: "reduce"`.
+ *   That reset is a `*` + `!important` rule, so it beats every component
+ *   rule regardless of source order - no per-component masking needed.
+ * - **The loader spinner** is the one documented exception the reset
+ *   deliberately keeps running (`.bbn-loader`, see docs/motion-system.md).
+ *   A functional spinner is exactly what a screenshot catches mid-frame,
+ *   so `FREEZE_SPINNER_CSS` stops it at a fixed angle.
+ * - **Clock-derived copy** (relative timestamps, countdowns, expiry) is
+ *   pinned with `setFixedTime`. Deliberately NOT `clock.install()`:
+ *   full fake timers stall React Query's retry/refetch scheduling and
+ *   the app never reaches a settled frame.
+ * - **Web fonts** are self-hosted woff2 (`src/globals.css`), so there is
+ *   no CDN race - but the first paint can still land before Px-Grotesk
+ *   swaps in, so we await `document.fonts.ready`.
+ * - **Everything else** (late data, lazy route chunks, layout shift) is
+ *   covered by `waitForVisualStability`, which polls until the rendered
+ *   frame stops changing rather than guessing a fixed delay.
+ */
+
+import type { Page } from "@playwright/test";
+
+/**
+ * Fixed wall-clock for every capture. Any value works as long as it
+ * never changes: it only has to be the *same* instant on the baseline
+ * side and the candidate side.
+ */
+export const VISUAL_FIXED_TIME = new Date("2026-01-01T12:00:00.000Z");
+
+/**
+ * Stops the functional spinner that the reduced-motion reset keeps
+ * running on purpose. Without this every capture lands on a random
+ * rotation angle and each screen diffs against itself forever.
+ */
+const FREEZE_SPINNER_CSS = `
+  .bbn-loader,
+  .bbn-loader * {
+    animation: none !important;
+  }
+`;
+
+/** How long the frame must stay byte-identical before we trust it. */
+const STABILITY_QUIET_MS = 300;
+/** Consecutive identical frames required. */
+const STABILITY_CONSECUTIVE_MATCHES = 2;
+/** Upper bound on waiting for the page to stop changing. */
+const STABILITY_TIMEOUT_MS = 15_000;
+/** Upper bound on waiting for React to paint its first real frame. */
+const RENDER_TIMEOUT_MS = 30_000;
+/**
+ * Minimum rendered text length that counts as "the app painted".
+ * An un-booted page has an empty `#root` (the inlined theme script is
+ * script-only and contributes no text), so anything non-trivial here
+ * means React committed a real tree.
+ */
+const MIN_RENDERED_TEXT_LENGTH = 20;
+
+/**
+ * Install page-level determinism. Must run *before* the navigation that
+ * renders the screen, because the app reads the clock during first
+ * render.
+ */
+export async function installVisualDeterminism(page: Page): Promise<void> {
+  await page.clock.setFixedTime(VISUAL_FIXED_TIME);
+}
+
+/**
+ * Block until the page stops changing, then return.
+ *
+ * Polls the actual rendered bytes instead of waiting on `networkidle`
+ * (which never fires while React Query polls) or a fixed sleep (which
+ * is either flaky or slow). This is the single most important piece of
+ * the harness: it converts "the app is still settling" from a
+ * false-positive diff into a wait.
+ */
+export async function waitForVisualStability(page: Page): Promise<void> {
+  // MUST come before the stability poll below. An empty page is
+  // trivially "stable" - two blank frames in a row match, the loop
+  // returns in ~600ms, and every screen silently becomes a blank white
+  // baseline that diffs against itself forever. Gate on React having
+  // actually painted first.
+  await page.waitForFunction(
+    (minLength) => {
+      const root = document.getElementById("root");
+      if (!root) return false;
+      const hasBox = root.getBoundingClientRect().height > 0;
+      return hasBox && (root.innerText?.trim().length ?? 0) >= minLength;
+    },
+    MIN_RENDERED_TEXT_LENGTH,
+    { timeout: RENDER_TIMEOUT_MS },
+  );
+
+  await page.addStyleTag({ content: FREEZE_SPINNER_CSS });
+  await page.evaluate(async () => {
+    await document.fonts.ready;
+  });
+
+  const deadline = Date.now() + STABILITY_TIMEOUT_MS;
+  let previous = await page.screenshot({ fullPage: true });
+  let matches = 0;
+
+  while (Date.now() < deadline) {
+    await page.waitForTimeout(STABILITY_QUIET_MS);
+    const current = await page.screenshot({ fullPage: true });
+
+    if (current.equals(previous)) {
+      matches += 1;
+      if (matches >= STABILITY_CONSECUTIVE_MATCHES) return;
+    } else {
+      matches = 0;
+    }
+    previous = current;
+  }
+
+  throw new Error(
+    `Page did not reach a stable frame within ${STABILITY_TIMEOUT_MS}ms. ` +
+      `Something on this screen animates or refetches indefinitely - freeze it ` +
+      `in stabilize.ts rather than accepting a flaky baseline.`,
+  );
+}

--- a/services/vault/e2e/visual/targets.ts
+++ b/services/vault/e2e/visual/targets.ts
@@ -1,0 +1,56 @@
+/**
+ * The capture manifest: which screens get photographed, at which sizes.
+ *
+ * Kept as data (not inline in the spec) because the CI job reports on
+ * target names, and because adding a screen should be a one-line change
+ * that needs no Playwright knowledge.
+ *
+ * Every target here must render without a connected wallet. The e2e
+ * harness installs a wallet *sentinel* only (see `fixtures/test.ts`);
+ * page-side provider construction is #1592, so connected-state screens
+ * are not reachable yet and are deliberately absent.
+ *
+ * Paths are written out rather than imported from `src/routes.ts` for
+ * two reasons. Importing app source pulls `tokenService` -> the network
+ * config singleton into the Playwright runner, which throws before any
+ * test is collected. And a literal path is the behaviour we want: if a
+ * route is renamed, this manifest should report the old screen as
+ * removed and the new one as added, not silently follow the rename and
+ * claim nothing changed.
+ */
+
+export interface VisualViewport {
+  readonly name: string;
+  readonly width: number;
+  readonly height: number;
+}
+
+export interface VisualTarget {
+  /** Stable slug - it becomes the screenshot filename, so renaming one
+   *  reads as "screen deleted + screen added" in the diff report. */
+  readonly name: string;
+  readonly path: string;
+}
+
+/** Desktop is the primary review size; mobile catches responsive-only
+ *  regressions that a single width would hide. */
+export const VISUAL_VIEWPORTS: readonly VisualViewport[] = [
+  { name: "desktop", width: 1280, height: 800 },
+  { name: "mobile", width: 390, height: 844 },
+];
+
+export const VISUAL_TARGETS: readonly VisualTarget[] = [
+  { name: "overview", path: "/" },
+  { name: "vaults", path: "/vaults" },
+  { name: "loans", path: "/loans" },
+  { name: "activity", path: "/activity" },
+  { name: "explore", path: "/explore" },
+  { name: "liquidations", path: "/liquidations" },
+];
+
+export function screenshotFileName(
+  target: VisualTarget,
+  viewport: VisualViewport,
+): string {
+  return `${target.name}--${viewport.name}.png`;
+}

--- a/services/vault/package.json
+++ b/services/vault/package.json
@@ -59,7 +59,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.31.0",
-    "@playwright/test": "^1.55.1",
+    "@playwright/test": "1.56.1",
     "@sentry/vite-plugin": "^2.22.6",
     "@tanstack/react-query-devtools": "5.28.14",
     "@testing-library/jest-dom": "6.5.0",

--- a/services/vault/package.json
+++ b/services/vault/package.json
@@ -25,7 +25,8 @@
     "test:e2e:headed": "playwright test --headed",
     "test:e2e:report": "playwright show-report",
     "e2e:env": "node scripts/e2e-env.mjs",
-    "e2e:cli": "pnpm exec tsx e2e/real/cli.ts"
+    "e2e:cli": "pnpm exec tsx e2e/real/cli.ts",
+    "visual:capture": "playwright test --config=playwright.visual.config.ts"
   },
   "dependencies": {
     "@babylonlabs-io/core-ui": "workspace:*",

--- a/services/vault/playwright.config.ts
+++ b/services/vault/playwright.config.ts
@@ -7,7 +7,13 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PORT_MISSING_ENV = 5173;
 const PORT_FULL_ENV = 5175;
 
-const MOCK_ENV_VARS = {
+/**
+ * Mock backend the e2e suite pins so no spec reaches a live host. Exported
+ * because `playwright.visual.config.ts` spreads it: two hand-maintained
+ * copies would drift, and the capture would still pass — just against a
+ * different app than the one under test.
+ */
+export const MOCK_ENV_VARS = {
   NEXT_PUBLIC_TBV_BTC_VAULT_REGISTRY:
     "0x0000000000000000000000000000000000000001",
   NEXT_PUBLIC_TBV_AAVE_ADAPTER: "0x0000000000000000000000000000000000000002",
@@ -44,6 +50,12 @@ export default defineConfig({
   // expect and crashes discovery with a `Symbol($$jest-matchers-object)`
   // collision.
   testMatch: "**/*.spec.ts",
+  // The visual captures are a separate surface with their own config
+  // (`playwright.visual.config.ts`): different port, forced feature flags,
+  // reducedMotion, no retries. Without this they also match `testMatch`
+  // above and run inside the behavioural suite, where `waitForVisualStability`
+  // chases live animations for its full timeout and then retries twice.
+  testIgnore: "**/visual/**",
   fullyParallel: false,
   forbidOnly: false,
   retries: 2,

--- a/services/vault/playwright.visual.config.ts
+++ b/services/vault/playwright.visual.config.ts
@@ -6,6 +6,23 @@ import { MOCK_ENV_VARS } from "./playwright.config";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+// The import above resolves against whichever `playwright.config.ts` sits on
+// disk, and only versions of that file that export the const will do. An ESM
+// load of an older copy fails loudly on its own, but under CJS interop a
+// missing export is not an error: it arrives as `undefined`, `{ ...undefined }`
+// spreads to `{}`, and the dev server silently boots with no mock env - so
+// guard that case loudly here.
+if ((MOCK_ENV_VARS as unknown) === undefined) {
+  throw new Error(
+    "MOCK_ENV_VARS imported from ./playwright.config is undefined - the " +
+      "playwright.config.ts on disk does not export it. In CI this means " +
+      "the visual-regression workflow restored playwright.visual.config.ts " +
+      "onto the merge-base without also restoring playwright.config.ts: " +
+      "stash and restore both files together in the 'Stash capture harness' " +
+      "step of .github/workflows/visual-regression.yml.",
+  );
+}
+
 /**
  * Visual capture config - deliberately separate from `playwright.config.ts`.
  *

--- a/services/vault/playwright.visual.config.ts
+++ b/services/vault/playwright.visual.config.ts
@@ -1,0 +1,102 @@
+import { defineConfig, devices } from "@playwright/test";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Visual capture config - deliberately separate from `playwright.config.ts`.
+ *
+ * The e2e config asserts *behaviour* and is free to retry, run against a
+ * partially-mocked backend, and vary. This config only photographs
+ * screens, so every knob here is set for reproducibility instead:
+ * one worker, no retries, fixed viewport scale, reduced motion.
+ *
+ * It captures against the **dev server**, not a production build. That
+ * is a cost decision and it is safe here: the computed-baseline model
+ * compares dev-render against dev-render, so any dev-only artifact
+ * appears identically on both sides and cancels out. Skipping
+ * `tsc --noEmit && vite build` on both sides is what makes it viable to
+ * run this on every PR.
+ */
+
+const VISUAL_PORT = 5177;
+
+/** Where captured PNGs land. CI sets this per side (baseline vs candidate). */
+export const VISUAL_OUTPUT_DIR =
+  process.env.VISUAL_OUT_DIR ?? path.join(__dirname, "e2e/visual/__captures__");
+
+/**
+ * Same mock backend the e2e config pins, so no screen reaches a live
+ * host. Feature flags are forced ON: the v3 shell and its sections are
+ * the surface worth protecting, and a flag that flips between the two
+ * sides would otherwise read as a visual regression.
+ */
+const VISUAL_ENV_VARS = {
+  NEXT_PUBLIC_TBV_BTC_VAULT_REGISTRY:
+    "0x0000000000000000000000000000000000000001",
+  NEXT_PUBLIC_TBV_AAVE_ADAPTER: "0x0000000000000000000000000000000000000002",
+  NEXT_PUBLIC_TBV_AAVE_ADAPTER_CONFIG:
+    "0x0000000000000000000000000000000000000003",
+  NEXT_PUBLIC_TBV_GRAPHQL_ENDPOINT: "http://localhost:9999/graphql",
+  NEXT_PUBLIC_TBV_VP_PROXY_URL: "http://localhost:9998",
+  NEXT_PUBLIC_ETH_RPC_URL: "http://localhost:9997/rpc",
+  NEXT_PUBLIC_MEMPOOL_API: "http://localhost:9996/mempool",
+  NEXT_PUBLIC_REOWN_PROJECT_ID: "test-project-id-12345",
+  NEXT_PUBLIC_E2E_MODE: "1",
+  // Sentry off: a capture run must not transmit anything.
+  NEXT_PUBLIC_SENTRY_DSN: "",
+  NEXT_PUBLIC_FF_ENABLE_V3_UI: "true",
+  NEXT_PUBLIC_FF_ENABLE_EXPLORE: "true",
+  NEXT_PUBLIC_FF_LIQUIDATION_ANALYSIS_CHART: "true",
+  // Dev-only panel; would overlay every screen it mounts on.
+  NEXT_PUBLIC_FF_GOD_MODE_PANEL: "false",
+};
+
+export default defineConfig({
+  testDir: path.join(__dirname, "e2e/visual"),
+  testMatch: "**/*.visual.spec.ts",
+  // Captures must not race each other for the shared dev server, and a
+  // retry would silently paper over a genuinely unstable screen.
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+  forbidOnly: false,
+  timeout: 120_000,
+  reporter: "list",
+  outputDir: path.join(__dirname, "e2e/visual/.playwright-output"),
+
+  use: {
+    headless: true,
+    baseURL: `http://localhost:${VISUAL_PORT}`,
+    // Triggers core-ui's global animation/transition reset.
+    reducedMotion: "reduce",
+    // Pin both: the OS/browser default would otherwise decide, and the
+    // app themes off `prefers-color-scheme`.
+    colorScheme: "light",
+    // A scale factor of 2 would quadruple PNG bytes for no extra signal.
+    deviceScaleFactor: 1,
+    trace: "off",
+    video: "off",
+  },
+
+  projects: [
+    {
+      name: "visual",
+      use: { ...devices["Desktop Chrome"], deviceScaleFactor: 1 },
+    },
+  ],
+
+  webServer: {
+    command: `pnpm exec vite --port ${VISUAL_PORT} --strictPort`,
+    url: `http://localhost:${VISUAL_PORT}`,
+    timeout: 120_000,
+    // MUST be false in CI. The workflow captures twice in one job - once
+    // at the PR head, once at the merge-base. If the second run reused
+    // the first run's still-listening dev server it would photograph the
+    // *same* code twice, the diff would always be empty, and the check
+    // would silently pass forever. Locally, reuse is just a convenience.
+    reuseExistingServer: !process.env.CI,
+    env: { ...VISUAL_ENV_VARS },
+  },
+});

--- a/services/vault/playwright.visual.config.ts
+++ b/services/vault/playwright.visual.config.ts
@@ -2,6 +2,8 @@ import { defineConfig, devices } from "@playwright/test";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { MOCK_ENV_VARS } from "./playwright.config";
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /**
@@ -22,30 +24,30 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const VISUAL_PORT = 5177;
 
-/** Where captured PNGs land. CI sets this per side (baseline vs candidate). */
+/**
+ * Where captured PNGs land. CI sets this per side (baseline vs candidate).
+ * Exported so `e2e/visual/routes.visual.spec.ts` imports it rather than
+ * recomputing the same default.
+ */
 export const VISUAL_OUTPUT_DIR =
   process.env.VISUAL_OUT_DIR ?? path.join(__dirname, "e2e/visual/__captures__");
 
 /**
- * Same mock backend the e2e config pins, so no screen reaches a live
- * host. Feature flags are forced ON: the v3 shell and its sections are
- * the surface worth protecting, and a flag that flips between the two
- * sides would otherwise read as a visual regression.
+ * The e2e config's mock backend, so no screen reaches a live host, plus the
+ * capture-only overrides. Spread rather than copied: a hand-maintained second
+ * copy would drift silently, and the capture would still pass — against a
+ * different app than the e2e suite tests.
+ *
+ * Feature flags are forced ON because the v3 shell and its sections are the
+ * surface worth protecting, and a flag that flipped between the two sides
+ * would read as a visual regression.
  */
 const VISUAL_ENV_VARS = {
-  NEXT_PUBLIC_TBV_BTC_VAULT_REGISTRY:
-    "0x0000000000000000000000000000000000000001",
-  NEXT_PUBLIC_TBV_AAVE_ADAPTER: "0x0000000000000000000000000000000000000002",
-  NEXT_PUBLIC_TBV_AAVE_ADAPTER_CONFIG:
-    "0x0000000000000000000000000000000000000003",
-  NEXT_PUBLIC_TBV_GRAPHQL_ENDPOINT: "http://localhost:9999/graphql",
-  NEXT_PUBLIC_TBV_VP_PROXY_URL: "http://localhost:9998",
-  NEXT_PUBLIC_ETH_RPC_URL: "http://localhost:9997/rpc",
-  NEXT_PUBLIC_MEMPOOL_API: "http://localhost:9996/mempool",
-  NEXT_PUBLIC_REOWN_PROJECT_ID: "test-project-id-12345",
-  NEXT_PUBLIC_E2E_MODE: "1",
-  // Sentry off: a capture run must not transmit anything.
+  ...MOCK_ENV_VARS,
+  // Sentry off: a capture run must not transmit anything. The e2e suite
+  // needs the opposite (it asserts on tunnelled events).
   NEXT_PUBLIC_SENTRY_DSN: "",
+  NEXT_PUBLIC_SENTRY_TUNNEL_URL: "",
   NEXT_PUBLIC_FF_ENABLE_V3_UI: "true",
   NEXT_PUBLIC_FF_ENABLE_EXPLORE: "true",
   NEXT_PUBLIC_FF_LIQUIDATION_ANALYSIS_CHART: "true",
@@ -69,8 +71,12 @@ export default defineConfig({
   use: {
     headless: true,
     baseURL: `http://localhost:${VISUAL_PORT}`,
-    // Triggers core-ui's global animation/transition reset.
-    reducedMotion: "reduce",
+    // Triggers core-ui's global animation/transition reset. MUST sit under
+    // `contextOptions`: `reducedMotion` is not a top-level `use` option, so
+    // Playwright silently ignores it there and every route was being
+    // photographed with animations still running — which is also what left
+    // `waitForVisualStability` chasing motion for its full timeout.
+    contextOptions: { reducedMotion: "reduce" },
     // Pin both: the OS/browser default would otherwise decide, and the
     // app themes off `prefers-color-scheme`.
     colorScheme: "light",

--- a/services/vault/tsconfig.lib.json
+++ b/services/vault/tsconfig.lib.json
@@ -24,5 +24,11 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["src", "e2e/fixtures", "e2e/pages", "sentry.client.config.ts"]
+  "include": [
+    "src",
+    "e2e/fixtures",
+    "e2e/pages",
+    "e2e/visual",
+    "sentry.client.config.ts"
+  ]
 }

--- a/tools/eslint-config/base.js
+++ b/tools/eslint-config/base.js
@@ -9,7 +9,11 @@ import pkgJson from 'eslint-plugin-package-json';
  * @type {import("eslint").Linter.Config[]}
  * */
 export const baseConfig = defineConfig([
-  globalIgnores(['**/dist/', '**/.storybook']),
+  // `storybook-static/` is Storybook's build output (the input to the
+  // visual-regression capture). It is minified vendor bundles, so linting
+  // it only produces "rule definition not found" errors from directives
+  // baked into third-party code.
+  globalIgnores(['**/dist/', '**/.storybook', '**/storybook-static/']),
   {
     plugins: {
       nx,


### PR DESCRIPTION
> **Lockfile change here is safe** - audited against today's keyv/cacheable npm supply-chain attack. The `pnpm-lock.yaml` diff comes entirely from the 02:23 UTC commit, about 6.5 hours before the attack began at 09:00 UTC; the later 10:16 UTC commit touches CI scripts only. The three additions - `pixelmatch` 7.2.0, `pngjs` 7.0.0 and `@playwright/test` 1.56.1 - are not on the compromised list, were all published months before the attack, and declare no install hooks. Nothing was re-resolved; the diff is purely additive.

## What

CI now flags when a pull request changes how the UI looks.

It photographs 315 Storybook components and 12 vault screens, and posts a comment listing anything that changed, with before / after / diff images attached to the run.

Worth being precise about the vault half: those 12 screens are captured without a connected wallet, so most of them are the app shell plus an error card rather than a populated page. They still catch shell, nav and layout regressions, but they are not yet coverage of the connected states - #1592 is the unblock for that. The Storybook half is the real component coverage today.

## Why

Nothing catches visual regressions today. A stray colour, spacing or layout change ships unnoticed unless a reviewer happens to spot it by eye.

## How

Rather than storing "expected" screenshots in the repo, CI takes the pictures twice on every run: once for the branch this PR started from, once for the PR itself. Then it compares them.

That means there are no baseline images to keep up to date, and nothing to approve when a change is intentional.

The check is advisory for now - it comments, it doesn't block merging.

