### PR TITLE
fix(ts-sdk, vault): recover from rejected vault provider tokens without a page reload

### DIFF
--- a/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/__tests__/json-rpc-client.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/__tests__/json-rpc-client.test.ts
@@ -386,12 +386,14 @@ describe("JsonRpcClient", () => {
 
     vi.stubGlobal(
       "fetch",
-      vi.fn().mockResolvedValue(
-        createJsonResponse(
-          { jsonrpc: "2.0", result: artifactResponse, id: 1 },
-          { headers: { "Content-Length": "512" } },
+      vi
+        .fn()
+        .mockResolvedValue(
+          createJsonResponse(
+            { jsonrpc: "2.0", result: artifactResponse, id: 1 },
+            { headers: { "Content-Length": "512" } },
+          ),
         ),
-      ),
     );
 
     const client = new VaultProviderRpcClient(TEST_BASE_URL, {
@@ -476,9 +478,9 @@ describe("JsonRpcClient", () => {
         createJsonResponse({
           jsonrpc: "2.0",
           error: {
-            code: -32001,
-            message: "token expired",
-            data: { kind: "auth_expired", expiresAt: 123 },
+            code: -32602,
+            message: "invalid pubkey encoding",
+            data: { field: "pubkey" },
           },
           id: 1,
         }),
@@ -492,11 +494,8 @@ describe("JsonRpcClient", () => {
     } catch (err) {
       expect(err).toBeInstanceOf(JsonRpcError);
       expect((err as JsonRpcError).source).toBe("wire");
-      expect((err as JsonRpcError).code).toBe(-32001);
-      expect((err as JsonRpcError).data).toEqual({
-        kind: "auth_expired",
-        expiresAt: 123,
-      });
+      expect((err as JsonRpcError).code).toBe(-32602);
+      expect((err as JsonRpcError).data).toEqual({ field: "pubkey" });
     }
   });
 
@@ -564,16 +563,19 @@ describe("JsonRpcClient", () => {
   });
 
   // -----------------------------------------------------------------
-  // Reactive refresh on auth_expired wire error
+  // Reactive re-auth when the server rejects the bearer.
+  //
+  // The daemon collapses all eight token-rejection variants onto code
+  // -32001 with no `data` payload (btc-vault `crates/btc-auth/src/rpc.rs`
+  // passes `None::<()>`), so every fixture below matches that shape.
   // -----------------------------------------------------------------
 
-  it("invalidates token and retries once on wire error with data.kind=auth_expired", async () => {
+  it("invalidates token and retries once when the server rejects the bearer", async () => {
     const expiredResponse = createJsonResponse({
       jsonrpc: "2.0",
       error: {
         code: -32001,
-        message: "token expired",
-        data: { kind: "auth_expired" },
+        message: "invalid token signature",
       },
       id: 1,
     });
@@ -616,20 +618,30 @@ describe("JsonRpcClient", () => {
     expect(secondAuth).toBe("Bearer token-2");
   });
 
-  it("does NOT retry on wire error with code -32001 but no auth_expired data", async () => {
-    // Covers the "server sent -32001 for a non-auth reason" path. The
-    // SDK must not blindly retry just because the code is -32001 —
-    // the `data.kind` marker is required.
-    const response = createJsonResponse({
-      jsonrpc: "2.0",
-      error: {
-        code: -32001,
-        message: "provider not found",
-      },
-      id: 1,
-    });
-
-    const mockFetch = vi.fn().mockResolvedValue(response);
+  // Every message the daemon's `AuthError` Display can produce for a
+  // -32001 (btc-vault `crates/btc-auth/src/error.rs`). All eight mean the
+  // same thing operationally — this bearer is dead — so all eight must
+  // trigger the same invalidate-and-retry.
+  it.each([
+    ["invalid signature", "invalid token signature"],
+    ["expiry", "token expired at 1754300000 (now: 1754300400)"],
+    ["not yet valid", "token not yet valid (nbf: 1754300000, now: 1754299000)"],
+    ["malformed structure", "invalid token structure: cose_sign1"],
+    ["missing claim", "invalid token claim: aud"],
+    ["subject mismatch", "subject mismatch: expected jsonrpc, got grpc"],
+    ["issuer mismatch", "issuer mismatch: expected abcd, got ef01"],
+    ["missing bearer", "missing or malformed Bearer token"],
+  ])("re-auths on -32001 %s", async (_label, message) => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        createJsonResponse({
+          jsonrpc: "2.0",
+          error: { code: -32001, message },
+          id: 1,
+        }),
+      )
+      .mockResolvedValueOnce(createSuccessResponse("ok", 2));
     vi.stubGlobal("fetch", mockFetch);
 
     const tokenProvider = {
@@ -640,33 +652,24 @@ describe("JsonRpcClient", () => {
     const client = createClient({ tokenProvider });
     await expect(
       client.call("vaultProvider_submitDepositorWotsKey", {}),
-    ).rejects.toThrow(JsonRpcError);
+    ).resolves.toBe("ok");
 
-    expect(tokenProvider.invalidate).not.toHaveBeenCalled();
-    expect(mockFetch).toHaveBeenCalledOnce();
+    expect(tokenProvider.invalidate).toHaveBeenCalledOnce();
+    expect(mockFetch).toHaveBeenCalledTimes(2);
   });
 
-  // Malformed `error.data` payloads (string, number, array). The
-  // `isAuthExpiredError` helper must treat anything that isn't an
-  // object with `kind === "auth_expired"` as not-an-auth-expired error,
-  // so a server bug (or a hostile proxy) can't trigger the reactive
-  // refresh path with junk data.
-  it.each([
-    ["string error.data", "auth_expired"],
-    ["number error.data", 42],
-    ["array error.data", ["auth_expired"]],
-    ["null error.data", null],
-    ["object without kind", { other: "field" }],
-    ["object with non-string kind", { kind: 42 }],
-    ["object with wrong kind value", { kind: "something_else" }],
-  ])("does NOT retry on -32001 with %s", async (_label, malformedData) => {
-    const response = createJsonResponse({
-      jsonrpc: "2.0",
-      error: { code: -32001, message: "x", data: malformedData },
-      id: 1,
-    });
+  it("retries at most once — a second rejection propagates", async () => {
+    const rejected = (id: number) =>
+      createJsonResponse({
+        jsonrpc: "2.0",
+        error: { code: -32001, message: "invalid token signature" },
+        id,
+      });
 
-    const mockFetch = vi.fn().mockResolvedValue(response);
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(rejected(1))
+      .mockResolvedValueOnce(rejected(2));
     vi.stubGlobal("fetch", mockFetch);
 
     const tokenProvider = {
@@ -677,7 +680,34 @@ describe("JsonRpcClient", () => {
     const client = createClient({ tokenProvider });
     await expect(
       client.call("vaultProvider_submitDepositorWotsKey", {}),
-    ).rejects.toThrow(JsonRpcError);
+    ).rejects.toThrow("invalid token signature");
+
+    expect(tokenProvider.invalidate).toHaveBeenCalledOnce();
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("does NOT re-auth on -32001 when the request carried no bearer", async () => {
+    // The token-issuing calls are themselves unauthenticated, so a -32001
+    // on them can't be a bearer rejection — it's the proxy's colliding
+    // "Provider not found". Re-minting would burn a round-trip for nothing.
+    const response = createJsonResponse({
+      jsonrpc: "2.0",
+      error: { code: -32001, message: "Provider not found" },
+      id: 1,
+    });
+
+    const mockFetch = vi.fn().mockResolvedValue(response);
+    vi.stubGlobal("fetch", mockFetch);
+
+    const tokenProvider = {
+      getToken: vi.fn().mockResolvedValue(null),
+      invalidate: vi.fn(),
+    };
+
+    const client = createClient({ tokenProvider });
+    await expect(client.call("auth_createDepositorToken", {})).rejects.toThrow(
+      JsonRpcError,
+    );
 
     expect(tokenProvider.invalidate).not.toHaveBeenCalled();
     expect(mockFetch).toHaveBeenCalledOnce();
@@ -706,22 +736,18 @@ describe("JsonRpcClient", () => {
     expect(tokenProvider.invalidate).not.toHaveBeenCalled();
   });
 
-  it("two concurrent auth_expired calls share one re-acquire when provider single-flights", async () => {
+  it("two concurrent rejected calls share one re-acquire when provider single-flights", async () => {
     // Models the realistic race: two auth-gated calls fire in parallel
-    // with the same cached (now-expired) token, the server returns
-    // auth_expired for both, both reach the catch block and call
-    // invalidate(). A correctly-implemented VpTokenProvider single-flights
-    // the re-acquire — this test asserts JsonRpcClient does not depend
-    // on the provider doing so (both invalidate calls land, both retries
-    // proceed) AND verifies the contract the provider should honor.
+    // with the same cached (now-stale) token, the server rejects both,
+    // both reach the catch block and call invalidate(). A
+    // correctly-implemented VpTokenProvider single-flights the re-acquire —
+    // this test asserts JsonRpcClient does not depend on the provider
+    // doing so (both invalidate calls land, both retries proceed) AND
+    // verifies the contract the provider should honor.
     const expired = (id: number) =>
       createJsonResponse({
         jsonrpc: "2.0",
-        error: {
-          code: -32001,
-          message: "token expired",
-          data: { kind: "auth_expired" },
-        },
+        error: { code: -32001, message: "token expired at 1 (now: 2)" },
         id,
       });
 
@@ -765,7 +791,7 @@ describe("JsonRpcClient", () => {
 
     expect(a).toBe("ok-A");
     expect(b).toBe("ok-B");
-    // Both calls saw auth_expired and both invalidated.
+    // Both calls saw the rejection and both invalidated.
     expect(tokenProvider.invalidate).toHaveBeenCalledTimes(2);
     expect(mockFetch).toHaveBeenCalledTimes(4);
   });
@@ -774,11 +800,7 @@ describe("JsonRpcClient", () => {
     const expiredRaw = new Response(
       JSON.stringify({
         jsonrpc: "2.0",
-        error: {
-          code: -32001,
-          message: "token expired",
-          data: { kind: "auth_expired" },
-        },
+        error: { code: -32001, message: "invalid token signature" },
         id: 1,
       }),
       { status: HTTP_OK, headers: { "Content-Type": "application/json" } },

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/index.ts
@@ -1,24 +1,25 @@
 export { VaultProviderRpcClient } from "./api";
 export type { VaultProviderRpcClientOptions } from "./api";
+export * from "./auth";
+export type { BatchResultEntry } from "./batchAttribution";
 export {
-  AUTH_EXPIRED_DATA_KIND,
+  batchPollByProvider,
+  type BatchPollByProviderOptions,
+} from "./batchPoll";
+export {
+  AUTH_REJECTED_RPC_CODE,
+  JSON_RPC_ERROR_CODES,
   JsonRpcClient,
   JsonRpcError,
-  JSON_RPC_ERROR_CODES,
+  isAuthRejectedError,
 } from "./json-rpc-client";
 export type {
   BearerTokenProvider,
   JsonRpcClientConfig,
   JsonRpcErrorSource,
 } from "./json-rpc-client";
+export * from "./types";
 export {
   VpResponseValidationError,
   validateRequestDepositorClaimerArtifactsResponse,
 } from "./validators";
-export type { BatchResultEntry } from "./batchAttribution";
-export {
-  batchPollByProvider,
-  type BatchPollByProviderOptions,
-} from "./batchPoll";
-export * from "./types";
-export * from "./auth";

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts
@@ -34,7 +34,7 @@ export type JsonRpcResponse<T = unknown> =
 
 /**
  * Injects bearer tokens into requests for auth-gated methods, and is
- * notified on auth-expired responses so it can invalidate its cache.
+ * notified when the server rejects a bearer so it can invalidate its cache.
  *
  * The `JsonRpcClient` is agnostic to which methods are auth-gated —
  * the provider's `getToken(method)` decides. Returning `null` means
@@ -81,8 +81,9 @@ export interface JsonRpcClientConfig {
   /**
    * Per-request bearer-token source. A non-null return attaches
    * `Authorization: Bearer <token>`; `null` skips auth. `call`
-   * additionally retries once on wire `auth_expired` (invalidate +
-   * refetch + retry). `callRaw` skips reactive refresh.
+   * additionally retries once when the server rejects the bearer
+   * (invalidate + refetch + retry) — see {@link isAuthRejectedError}.
+   * `callRaw` skips reactive refresh.
    */
   tokenProvider?: BearerTokenProvider;
 }
@@ -160,24 +161,52 @@ function defaultRetryableFor(method: string): boolean {
 }
 
 /**
- * Token-expired marker the server emits in `error.data.kind`. When
- * present on a wire-origin error, the client invalidates its cached
- * token and retries the request once with a freshly-acquired bearer.
+ * JSON-RPC error code the vault provider returns for every bearer-token
+ * rejection: expired, not-yet-valid, missing bearer, invalid signature,
+ * invalid claims, invalid structure, subject mismatch, issuer mismatch.
+ * All eight variants collapse onto this one code, distinguished only by
+ * message text — see btc-vault `crates/btc-auth/src/rpc.rs`
+ * (`auth_error_to_rpc_error`). Operationally they all mean the same
+ * thing: this bearer is dead, mint a new one.
  *
- * Kept in sync with btc-vault's auth middleware. Absence of the marker
- * means the server does not support reactive refresh yet; we fall back
- * to proactive-only refresh via `BearerTokenProvider.getToken()` TTL
- * checks.
+ * Numerically equal to {@link JSON_RPC_ERROR_CODES.NETWORK}, which this
+ * client throws for local network failures. `source` is what separates
+ * them — see {@link isAuthRejectedError}.
  */
-export const AUTH_EXPIRED_DATA_KIND = "auth_expired";
+export const AUTH_REJECTED_RPC_CODE = -32001;
 
-function isAuthExpiredError(error: unknown): boolean {
-  if (!(error instanceof JsonRpcError)) return false;
-  if (error.source !== "wire") return false;
-  const data = error.data;
-  if (data === null || typeof data !== "object") return false;
-  const kind = (data as { kind?: unknown }).kind;
-  return kind === AUTH_EXPIRED_DATA_KIND;
+/**
+ * True when `error` is the vault provider rejecting our bearer token.
+ *
+ * Classified on the error code, which is the only thing the server
+ * guarantees: its auth errors carry `data: null` unconditionally
+ * (`rpc_error` passes `None::<()>`), so any predicate keyed on an
+ * `error.data` field can never match a real response.
+ *
+ * `source === "wire"` is load-bearing: this client reuses -32001
+ * internally as {@link JSON_RPC_ERROR_CODES.NETWORK}, always with
+ * source "local".
+ *
+ * Known, bounded collision: the vault-provider proxy reuses -32001 for
+ * "Provider not found". A call to a deregistered provider therefore
+ * costs one wasted token-mint round-trip, which fails against the same
+ * registry check and surfaces the same message.
+ */
+export function isAuthRejectedError(error: unknown): boolean {
+  return (
+    error instanceof JsonRpcError &&
+    error.source === "wire" &&
+    error.code === AUTH_REJECTED_RPC_CODE
+  );
+}
+
+/**
+ * Per-`call` record of whether a bearer was actually attached to the
+ * request. Scoped to one `call` (not client state) so concurrent
+ * requests can't observe each other's auth state.
+ */
+interface AttemptAuthState {
+  bearerAttached: boolean;
 }
 
 /**
@@ -212,12 +241,16 @@ export class JsonRpcClient {
     this.tokenProvider = config.tokenProvider;
   }
 
-  private async buildHeaders(method: string): Promise<Record<string, string>> {
+  private async buildHeaders(
+    method: string,
+    authState?: AttemptAuthState,
+  ): Promise<Record<string, string>> {
     const headers: Record<string, string> = { ...this.headers };
     if (this.tokenProvider) {
       const token = await this.tokenProvider.getToken(method);
       if (token) {
         headers.Authorization = `Bearer ${token}`;
+        if (authState) authState.bearerAttached = true;
       }
     }
     return headers;
@@ -226,9 +259,9 @@ export class JsonRpcClient {
   /**
    * Make a JSON-RPC request with optional retry for safe methods.
    *
-   * If the request fails with a wire-origin `auth_expired` error and a
-   * `tokenProvider` is configured, the client invalidates its cached
-   * token and retries the request once with a freshly-acquired bearer.
+   * If the server rejects the bearer token and a `tokenProvider` is
+   * configured, the client invalidates its cached token and retries the
+   * request once with a freshly-acquired bearer.
    *
    * @param method - The RPC method name
    * @param params - The method parameters
@@ -241,20 +274,40 @@ export class JsonRpcClient {
     params: TParams,
     signal?: AbortSignal,
   ): Promise<TResult> {
+    const authState: AttemptAuthState = { bearerAttached: false };
     try {
-      return await this.callOnce<TParams, TResult>(method, params, signal);
+      return await this.callOnce<TParams, TResult>(
+        method,
+        params,
+        signal,
+        authState,
+      );
     } catch (error) {
-      // The auth-expired retry fires for ALL methods, including mutating
-      // ones. This is intentional and safe: the server's auth middleware
-      // validates the bearer token BEFORE dispatching to the method
-      // handler, so an `auth_expired` error means the handler never ran
-      // and no state was mutated. Confirmed against btc-vault at
-      // `crates/btc-auth/src/middleware/jsonrpc.rs` — token validation
-      // is pre-handler only. The `retryableFor` guard on
-      // HTTP-transient-error retries doesn't apply here because that
-      // guard is about retrying after a request the server may have
-      // started processing; auth_expired is categorically different.
-      if (this.tokenProvider && isAuthExpiredError(error)) {
+      // The re-auth retry fires for ALL methods, including mutating ones.
+      // This is intentional and safe: the server's auth middleware rejects
+      // the request BEFORE dispatching to the method handler, so a
+      // rejected bearer means the handler never ran and no state was
+      // mutated. Confirmed against btc-vault
+      // `crates/btc-auth/src/middleware/jsonrpc.rs` — `unauthorized_response`
+      // returns without ever calling `service.call(req)`, in both `call`
+      // and `batch`. The `retryableFor` guard on HTTP-transient-error
+      // retries doesn't apply here because that guard is about retrying
+      // after a request the server may have started processing.
+      //
+      // `bearerAttached` keeps this off methods that sent no token — most
+      // importantly the token-issuing calls themselves, which would
+      // otherwise burn a round-trip re-minting against the proxy's
+      // colliding -32001 "Provider not found".
+      //
+      // Bounded to one retry: the retried call is not wrapped in this
+      // handler. If the freshly-minted token is rejected too, the problem
+      // is the pinned server key rather than the token, and that surfaces
+      // instead of looping.
+      if (
+        this.tokenProvider &&
+        authState.bearerAttached &&
+        isAuthRejectedError(error)
+      ) {
         this.tokenProvider.invalidate();
         return await this.callOnce<TParams, TResult>(method, params, signal);
       }
@@ -266,8 +319,14 @@ export class JsonRpcClient {
     method: string,
     params: TParams,
     signal: AbortSignal | undefined,
+    authState?: AttemptAuthState,
   ): Promise<TResult> {
-    const response = await this.fetchWithRetry(method, params, signal);
+    const response = await this.fetchWithRetry(
+      method,
+      params,
+      signal,
+      authState,
+    );
 
     let jsonResponse: unknown;
     try {
@@ -347,6 +406,7 @@ export class JsonRpcClient {
     method: string,
     params: TParams,
     callerSignal?: AbortSignal,
+    authState?: AttemptAuthState,
   ): Promise<Response> {
     const requestId = ++this.requestId;
     const maxRetries = this.retryableFor(method) ? this.retries : 0;
@@ -379,7 +439,7 @@ export class JsonRpcClient {
         // Build headers per-attempt so the token provider can return a
         // freshly-acquired bearer after a prior invalidate() on this
         // request (retry loop path) without plumbing state through.
-        const headers = await this.buildHeaders(method);
+        const headers = await this.buildHeaders(method, authState);
 
         const response = await fetch(this.baseUrl, {
           method: "POST",

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -778,6 +778,11 @@ export const COPY = {
           message:
             "Unable to connect to the vault provider. Please check your connection and try again.",
         },
+        sessionExpired: {
+          title: "Session expired",
+          message:
+            "Your session with the vault provider is no longer valid and could not be renewed automatically. Please reload the page and try again.",
+        },
         providerTimeout: {
           title: "Vault provider timeout",
           message:

--- a/services/vault/src/hooks/deposit/__tests__/useArtifactDownload.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useArtifactDownload.test.tsx
@@ -518,9 +518,11 @@ describe("useArtifactDownload — prime then fetch", () => {
 
     fetchMock
       .mockRejectedValueOnce(
-        new JsonRpcError(-32001, "auth expired", "wire", {
-          kind: "auth_expired",
-        }),
+        new JsonRpcError(
+          -32001,
+          "token expired at 1754300000 (now: 1754300400)",
+          "wire",
+        ),
       )
       .mockResolvedValueOnce(OUTCOME);
     ensureAuthMock.mockResolvedValueOnce(
@@ -538,7 +540,7 @@ describe("useArtifactDownload — prime then fetch", () => {
     await waitFor(() => expect(result.current.downloaded).toBe(true));
     expect(invalidateSpy).toHaveBeenCalledTimes(1);
     // Upfront prime skipped (hot cache); ensureAuth called only on the
-    // retry path after auth_expired.
+    // retry path after the bearer was rejected.
     expect(ensureAuthMock).toHaveBeenCalledTimes(1);
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
@@ -574,8 +576,10 @@ describe("useArtifactDownload — prime then fetch", () => {
 
   it("does not prime on a non-auth wire error", async () => {
     seedHotCache();
+    // -32603, not -32001: the daemon reserves -32001 for bearer
+    // rejections, so a wire -32001 is by definition an auth failure.
     fetchMock.mockRejectedValueOnce(
-      new JsonRpcError(-32001, "internal error", "wire"),
+      new JsonRpcError(-32603, "internal error", "wire"),
     );
 
     const { result } = renderHook(() => useArtifactDownload({ primeContext }));

--- a/services/vault/src/hooks/deposit/useArtifactDownload.ts
+++ b/services/vault/src/hooks/deposit/useArtifactDownload.ts
@@ -1,8 +1,7 @@
 import type { BitcoinWallet } from "@babylonlabs-io/ts-sdk/shared";
 import { stripHexPrefix } from "@babylonlabs-io/ts-sdk/tbv/core";
 import {
-  AUTH_EXPIRED_DATA_KIND,
-  JsonRpcError,
+  isAuthRejectedError,
   vpTokenRegistry,
 } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
 import { useCallback, useRef, useState } from "react";
@@ -89,32 +88,6 @@ interface PrimeContext {
   vaultId: Hex;
   unsignedPrePeginTxHex: string;
   btcWallet: BitcoinWallet;
-}
-
-/**
- * Returns true when the failure looks like the VP rejected the request
- * because the bearer token was missing, malformed, or expired - i.e.
- * the request can succeed if we re-prime the registry and retry.
- *
- * The structured `auth_expired` marker is the only contractually-defined
- * signal; missing-bearer rejections currently come through as a free-form
- * message, so we accept that case heuristically.
- */
-function isAuthFailure(err: unknown): boolean {
-  if (!(err instanceof JsonRpcError)) return false;
-  if (err.source !== "wire") return false;
-
-  const data = err.data;
-  if (
-    data !== null &&
-    typeof data === "object" &&
-    !Array.isArray(data) &&
-    (data as { kind?: unknown }).kind === AUTH_EXPIRED_DATA_KIND
-  ) {
-    return true;
-  }
-
-  return /bearer/i.test(err.message);
 }
 
 export function useArtifactDownload(options?: {
@@ -475,7 +448,12 @@ export function useArtifactDownload(options?: {
             continue;
           }
 
-          if (!primeAttempted && isAuthFailure(err)) {
+          // Artifact download goes through `callRaw`, which deliberately
+          // skips the client's reactive re-auth (the body may be unbounded,
+          // so it is never parsed to detect an auth error). This is that
+          // recovery, done by hand: re-prime the token registry once and
+          // retry the stream.
+          if (!primeAttempted && isAuthRejectedError(err)) {
             primeAttempted = true;
             try {
               const primed = await tryPrimeAndRetry();

--- a/services/vault/src/services/artifacts/artifactDownloadService.ts
+++ b/services/vault/src/services/artifacts/artifactDownloadService.ts
@@ -126,9 +126,10 @@ export async function fetchAndDownloadArtifacts(
   // The caller (useArtifactDownload) primes the bearer before invoking
   // this service when the registry is cold, so peek() returns the active
   // provider and the request goes out with a valid Authorization header
-  // for this auth-gated RPC. `callRaw` does not reactively refresh on
-  // `auth_expired`, so a token that expires mid-download bubbles up as
-  // an error and the caller's auth-failure retry path handles re-priming.
+  // for this auth-gated RPC. `callRaw` does not reactively refresh when the
+  // server rejects the bearer, so a token that goes stale mid-download
+  // bubbles up as an error and the caller's auth-failure retry path handles
+  // re-priming.
   const tokenProvider = vpTokenRegistry.peek(normalizedPeginTxid);
 
   const client = new JsonRpcClient({

--- a/services/vault/src/utils/errors/__tests__/formatting.test.ts
+++ b/services/vault/src/utils/errors/__tests__/formatting.test.ts
@@ -22,6 +22,7 @@ import {
   formatErrorDiagnostics,
   formatErrorMessage,
   formatPayoutSignatureError,
+  mapVpRpcError,
   sanitizeErrorMessage,
 } from "../formatting";
 
@@ -548,6 +549,44 @@ describe("Error Formatting", () => {
     it("collapses Safari 'Importing a module script failed'", () => {
       const err = new TypeError("Importing a module script failed.");
       expect(sanitizeErrorMessage(err)).toMatch(/out of date/i);
+    });
+  });
+
+  describe("mapVpRpcError", () => {
+    // -32001 has three producers: the SDK's own network failure (local),
+    // the proxy's "Provider not found", and the daemon rejecting our
+    // bearer. Each must reach different copy.
+    it("reads a local -32001 as a connectivity failure", () => {
+      const result = mapVpRpcError(
+        new JsonRpcError(-32001, "Network error: Failed to fetch", "local"),
+      );
+      expect(result.title).toBe("Connection failed");
+    });
+
+    it("reads a wire -32001 saying 'Provider not found' as a deregistered provider", () => {
+      const result = mapVpRpcError(
+        new JsonRpcError(-32001, "Provider not found", "wire"),
+      );
+      expect(result.title).toBe("Vault provider not found");
+    });
+
+    it("reads any other wire -32001 as an expired session, not a connectivity failure", () => {
+      const result = mapVpRpcError(
+        new JsonRpcError(-32001, "invalid token signature", "wire"),
+      );
+      expect(result.title).toBe("Session expired");
+      expect(result.message).toContain("reload the page");
+    });
+
+    it("reads a wire -32001 token expiry as an expired session", () => {
+      const result = mapVpRpcError(
+        new JsonRpcError(
+          -32001,
+          "token expired at 1754300000 (now: 1754300400)",
+          "wire",
+        ),
+      );
+      expect(result.title).toBe("Session expired");
     });
   });
 

--- a/services/vault/src/utils/errors/formatting.ts
+++ b/services/vault/src/utils/errors/formatting.ts
@@ -298,21 +298,29 @@ export function mapVpRpcError(error: JsonRpcError): {
   if (error.code === JSON_RPC_ERROR_CODES.TIMEOUT) {
     return vp.requestTimeout;
   }
-  // -32001: proxy "Provider not found" (message-specific) vs FE client "Network error" (generic)
-  if (
-    error.code === JSON_RPC_ERROR_CODES.NETWORK &&
-    error.message.toLowerCase().includes("provider not found")
-  ) {
-    return vp.providerNotFound;
-  }
+  // -32001 has three distinct producers. `source` separates the SDK's own
+  // network failure (always "local") from the two wire producers; the
+  // proxy's single -32001 emitter has one fixed message ("Provider not
+  // found"), so anything else arriving over the wire is the daemon
+  // rejecting our bearer.
   if (error.code === JSON_RPC_ERROR_CODES.NETWORK) {
-    return vp.connectionFailed;
+    if (error.source !== "wire") {
+      return vp.connectionFailed;
+    }
+    if (error.message.toLowerCase().includes("provider not found")) {
+      return vp.providerNotFound;
+    }
+    return vp.sessionExpired;
   }
-  // Proxy-specific: VP request timed out at the proxy level
+  // -32002 / -32003 collide the same way, but undecidably: the proxy sends
+  // them for transport failures and the daemon sends them for NonceReplay /
+  // UnauthorizedCaller during token issuance, both over the wire and with
+  // free-form messages. The proxy's meanings are the common case, so they
+  // stay — disambiguating would mean matching message text, which is the
+  // classification bug this mapping just stopped doing.
   if (error.code === JSON_RPC_ERROR_CODES.PROXY_TIMEOUT) {
     return vp.providerTimeout;
   }
-  // Proxy-specific: VP unreachable, DNS failure, or response too large
   if (error.code === JSON_RPC_ERROR_CODES.PROXY_UNAVAILABLE) {
     return vp.providerUnavailable;
   }
@@ -511,28 +519,13 @@ export function formatPayoutSignatureError(error: unknown): {
         message: "Please reconnect your Bitcoin wallet to continue.",
       };
     }
-    if (
-      error.message.includes("Vault or pegin transaction not found") ||
-      error.message.includes("not found on-chain")
-    ) {
+    // Produced by the registry reader: "Vault <id> not found on-chain or has
+    // no pegin transaction".
+    if (error.message.includes("not found on-chain")) {
       return {
         title: "Deposit not found",
         message:
           "The deposit transaction could not be found. It may have been processed already.",
-      };
-    }
-    if (error.message.includes("Failed to sign Payout transaction")) {
-      return {
-        title: "Signing failed",
-        message:
-          "Failed to sign the payout transaction. Please try again or reconnect your wallet.",
-      };
-    }
-    if (error.message.includes("Failed to batch sign payout transactions")) {
-      return {
-        title: "Batch signing failed",
-        message:
-          "Failed to sign payout transactions. Please try again or reconnect your wallet.",
       };
     }
     // Contract call errors (viem) — surface a meaningful message instead of swallowing


### PR DESCRIPTION
Closes https://github.com/babylonlabs-io/babylon-toolkit/issues/2181

## The problem

When you deposit, the app gets a short-lived bearer token from the vault provider (VP) and attaches it to every signing-related call. If that token goes stale mid-deposit, the next call fails — and **the app could not recover**. Pressing "Retry" failed exactly the same way. The only thing that worked was a full page reload, and nothing on screen told you to do that. On top of that, the error was shown as **"Connection failed"**, which sent people off to check their internet when their internet was fine.

This was hit on devnet on 2026-08-04: a token was minted at 09:55, payout signing failed at 11:13 with `invalid token signature`, Retry failed identically 10 seconds later, and a hard reload at 11:19 fixed it immediately.

**Why this matters now:** redeploying `vaultd` restarts every VP, and a restart rotates the key that signs these tokens. So every depositor with a session open across the next deploy would hit this, Retry would do nothing, and the UI would blame their network.

Nothing was ever at risk here — the flow fails closed, so nothing gets signed or broadcast. It just blocks the deposit.

## Why it happened

The SDK already had recovery logic for exactly this: notice the token is dead, throw it away, get a fresh one, retry once. That code was correct — and **completely unreachable**.

It only ran when the server's error contained a field `data.kind = "auth_expired"`. **No server has ever sent that field.** I checked the actual `btc-vault` and `vault-provider-proxy` source: the string `auth_expired` does not appear anywhere in either codebase, and the daemon's error builder passes `None` for the data field unconditionally — so `data` is always empty. The check could never be true, so the recovery never ran, not even for an ordinary token expiry.

The token cache is also a module-level singleton, which is why only a reload cleared it: Retry re-entered with the same dead token still cached.

## What the server actually sends

```
HTTP 200 {"jsonrpc":"2.0","error":{"code":-32001,"message":"invalid token signature"},"id":N}
```

The daemon has eight different ways to reject a token — expired, not yet valid, missing, bad signature, bad claims, bad structure, wrong subject, wrong issuer — and **all eight come back as code `-32001` with no extra data**, differing only in the message text. All eight mean the same thing in practice: *this token is dead, go get a new one.*

Two things worth knowing: the daemon returns HTTP **200** for these (the auth check happens at the RPC layer, not the HTTP layer), so the client's `!response.ok` handling never fires. And the proxy forwards the daemon's response body through untouched, so the error arrives at the frontend exactly as written above.

## Approaches considered

**1. Ask the backend to start sending `data.kind = "auth_expired"`.** Rejected. It needs a coordinated backend change and deploy before the frontend can recover at all, and the deploy that would ship it is the same deploy that triggers the bug. It also leaves every already-deployed VP broken.

**2. Match on the error message text** (look for "token", "bearer", "expired", etc.). Rejected. This is the same class of mistake as the original bug — guessing at a shape the server never promised. The eight messages have no common word, and the one that matters most (plain expiry, `token expired at ...`) does not contain "bearer" at all. Message text is not a contract; it changes whenever someone rewords an error.

**3. Match on the error code the server actually guarantees.** ✅ Taken. `-32001` over the wire is a documented, stable contract, and it covers all eight rejection reasons at once with no backend change and no new deploy dependency.

## What changed

**Classify on the code, not on an invented field.** [`json-rpc-client.ts`](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts) now treats a wire `-32001` as "the token was rejected" and runs the invalidate-and-retry that was already there. WOTS submission, payout presigning and artifact download all recover in-session now — no reload.

Two guards keep this tight. `source === "wire"` matters because the client also uses `-32001` internally for its own network failures — those are always tagged `"local"`, so a genuine connection problem never triggers a pointless token refresh. And the retry only fires **if a token was actually attached to the failed request**, tracked per-call so parallel requests can't confuse each other. That second guard is a small addition beyond what the issue proposed, and it earns its keep: the proxy also uses `-32001` for "Provider not found", and without it a call to a deregistered provider would waste a round-trip trying to re-mint a token it never had.

**Retrying is safe.** I confirmed this in the daemon source rather than assuming it: when auth fails, the middleware returns the error *without ever calling the request handler* — in both the single and batch paths. The handler never ran, so nothing was created, changed or double-submitted. That is why the retry is safe even for write calls like submitting signatures.

**Fix the misleading error message.** [`formatting.ts`](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/services/vault/src/utils/errors/formatting.ts) now tells the three different `-32001` senders apart: a local `-32001` is still "Connection failed", the proxy's "Provider not found" is still the deregistered-provider message, and anything else arriving over the wire is a new **"Session expired"** message instead of blaming the user's connection. After this fix that message should be rare, because recovery is automatic — it now only shows up if the *fresh* token is also rejected.

**Use one shared check everywhere.** Artifact download had its own copy of this logic that caught **1 of the 8** rejection reasons (it looked for the word "bearer", which only the missing-token case contains — plain expiry, the most common case, was missed). It now uses the same shared check as everything else. It needs its own copy of the retry because artifact downloads stream a potentially huge response body that the client deliberately never parses.

**Delete two dead error branches.** Two branches in the payout error formatter matched messages that no longer exist anywhere in the monorepo — they were left behind when payout signing moved into the SDK, so they had quietly stopped working. Removed under the zero-dead-code policy.

## Tests

The old tests are the reason this survived so long. They built fake server responses containing `data.kind = "auth_expired"` — a shape production never produces — and then **asserted that the real-world case must not recover**. There was a test literally named *"does NOT retry on wire error with code -32001 but no auth_expired data"*, pinning the bug in place as intended behaviour.

All of those fixtures now use the real wire shape. The test that asserted the bug is now **eight test cases, one per real daemon rejection message**, all asserting that recovery happens. Added on top: retry happens at most once, a local `-32001` must not trigger a refresh, and a request that carried no token must not trigger one either. Plus four cases covering the three-way `-32001` split in the error message mapping.

## Verification

- Full SDK suite: **1451 passed** (was 1449)
- Full vault suite: **3113 passed** (was 3109)
- `pnpm run build` ✅
- `tsc --noEmit -p tsconfig.lib.json` ✅
- `pnpm run lint` ✅ — 0 errors

Every claim about server behaviour in this PR was checked against the actual `btc-vault` and `vault-provider-proxy` source, not taken from the issue description.

## Deliberately not in this PR

**Refreshing a stale pinned VP key** (Part 2 of the issue). The VP has two keys: a long-lived **operation key** that we pin from the on-chain registry, and a short-lived **ephemeral key** that actually signs tokens. A VP *restart* only rotates the ephemeral key — the pin still matches, so this PR fully fixes it. A VP rotating its *operation key* is a different situation: the new token gets rejected on our side, before it's ever sent, because it no longer matches our pin. That needs a way to re-read the pin from chain, which is a separate change. A reload still works for that case, which is exactly what the new "Session expired" message tells the user to do.

**`-32004` from the gRPC artifact path.** Only reachable if `ENABLE_GRPC_ARTIFACTS` is turned on, which defaults to off on both the proxy and the frontend. Out of scope per the issue.

**Regenerating the SDK API docs.** The generated docs still mention the deleted `AUTH_EXPIRED_DATA_KIND`. Regenerating touches 5 files and ~1,550 lines, of which only 8 lines relate to this change — the rest is pre-existing line-number drift from earlier work. Going out as its own chore PR so this one stays reviewable.

## Possible separate bug found while verifying

Not touched here, but worth a look: artifact download routes its token request to the **gRPC** token endpoint unconditionally, with no feature flag. But the proxy rejects that endpoint with `METHOD_NOT_FOUND` when `ENABLE_GRPC_ARTIFACTS` is off — which is the default. The proxy's own comment says it does this "so the frontend can fall back to its JSON-RPC bearer", but **the SDK has no such fallback**. So unless the deployed proxy has that flag switched on, artifact download can't get a token at all. Worth confirming against the deployed config; happy to file it separately.

## How to sanity-check this by hand

1. Start a deposit and let it mint a VP token.
2. Restart the VP daemon (or wait for its key to rotate).
3. Continue the deposit.

**Before:** the call fails, Retry fails identically, only a page reload gets you moving again — and the error says "Connection failed".
**After:** the call recovers on its own and the deposit continues. If it somehow can't recover, you get "Session expired" telling you to reload, instead of being told to check your internet.
