### PR TITLE
fix(ts-sdk, vault): accept a rotated vault provider key on the refund path

### DIFF
--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/index.ts
@@ -157,6 +157,7 @@ export type { PayoutScriptParams, PayoutScriptResult } from "./scripts/payout";
 
 // Bitcoin utilities
 export {
+  canonicalizeBtcPubkey,
   deriveBip86ScriptPubKeyHex,
   deriveNativeSegwitAddress,
   deriveTaprootAddress,

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts
@@ -194,6 +194,23 @@ export function processPublicKeyToXOnly(publicKeyHex: string): string {
 }
 
 /**
+ * Normalize a public key to the one form two keys can be compared in:
+ * lowercase x-only hex, no `0x`.
+ *
+ * `processPublicKeyToXOnly` returns already-x-only input untouched, so it
+ * preserves case on that path — comparing its output directly is a latent
+ * false mismatch for any source that serves uppercase hex. Every comparison
+ * site therefore has to pair it with `.toLowerCase()`, and that pairing is
+ * what this function exists to stop people re-deriving by hand.
+ *
+ * @param publicKeyHex - x-only, compressed, or uncompressed key, `0x` optional
+ * @throws If the key is not valid hex or has an unexpected length
+ */
+export function canonicalizeBtcPubkey(publicKeyHex: string): string {
+  return processPublicKeyToXOnly(publicKeyHex).toLowerCase();
+}
+
+/**
  * Validate hex string format.
  *
  * Checks that the string contains only valid hexadecimal characters (0-9, a-f, A-F)

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts
@@ -6,7 +6,13 @@ import type {
   VaultKeeperReader,
   VaultRegistryReader,
 } from "../../clients/eth/types";
-import { processPublicKeyToXOnly } from "../../primitives/utils/bitcoin";
+import { canonicalizeBtcPubkey } from "../../primitives/utils/bitcoin";
+import {
+  type HintMatch,
+  isHintAccepted,
+  matchKeyHint,
+  matchKeySetHint,
+} from "../participants/indexerKeyHint";
 import { resolveCurrentParticipantKeys } from "../participants/resolveParticipantKeys";
 import type { ParticipantKeySet } from "../participants/types";
 
@@ -65,12 +71,7 @@ export interface ValidatedOnChainParticipantKeys {
   participantKeys: ParticipantKeySet;
 }
 
-const canonical = (k: string) => processPublicKeyToXOnly(k).toLowerCase();
-const sortedSet = (keys: string[]) => keys.map(canonical).sort();
-
-function setsEqual(a: string[], b: string[]): boolean {
-  return a.length === b.length && a.every((k, i) => k === b[i]);
-}
+const sortedSet = (keys: string[]) => keys.map(canonicalizeBtcPubkey).sort();
 
 export async function validateOnChainParticipantKeys(
   params: ValidateOnChainParticipantKeysParams,
@@ -110,14 +111,18 @@ export async function validateOnChainParticipantKeys(
   ]);
 
   const registrationKeys = {
-    vaultProvider: canonical(onChainVpKey),
+    vaultProvider: canonicalizeBtcPubkey(onChainVpKey),
     vaultKeepers: sortedSet(onChainKeepers.map((p) => p.btcPubKey)),
     universalChallengers: sortedSet(onChainChallengers.map((p) => p.btcPubKey)),
   };
 
-  // Resolve the current operation keys, if enabled. This is what we build the
-  // Bitcoin lock with; the registration keys above stay only as the primary
-  // comparison target for indexer hints.
+  // Resolve the current operation keys. This is what we build the Bitcoin lock
+  // with; the registration keys above stay only as the primary comparison
+  // target for indexer hints.
+  //
+  // Read unconditionally, which is why this path cannot use
+  // `assertVaultProviderHintAccepted` — that helper reads the operation key
+  // lazily, for callers that only need it to explain a hint mismatch.
   const participantKeys: ParticipantKeySet =
     await resolveCurrentParticipantKeys({
       operationKeyReader,
@@ -146,53 +151,36 @@ export async function validateOnChainParticipantKeys(
   //
   // Once rotation is possible the indexer may legitimately serve either the
   // registration keys (it has not caught up) or the operation keys (it has),
-  // so each role is accepted against both candidates. For a role that never
-  // rotated the two candidates are identical, so this is strictly the old
-  // check until someone rotates.
-  //
-  // Each role is compared as a *whole set*, never as per-element membership of
-  // the union: a keeper set holding one registration key and one operation key
-  // is an indexer inconsistency, and union membership would wave it through.
-  // The cross-role check below closes the same hole one level up.
-  const hintVp = canonical(expectedVaultProviderBtcPubkey);
-  const hintKeepers = sortedSet(expectedVaultKeeperBtcPubkeys);
-  const hintChallengers = sortedSet(expectedUniversalChallengerBtcPubkeys);
+  // so each role is accepted against both candidates — see `indexerKeyHint`,
+  // which owns that policy and the whole-set matching rule. The cross-role
+  // check below closes the same hole one level up.
+  const vpMatch: HintMatch = matchKeyHint(
+    expectedVaultProviderBtcPubkey,
+    registrationKeys.vaultProvider,
+    operationKeys.vaultProvider,
+  );
+  const keeperMatch: HintMatch = matchKeySetHint(
+    expectedVaultKeeperBtcPubkeys,
+    registrationKeys.vaultKeepers,
+    operationKeys.vaultKeepers,
+  );
+  const challengerMatch: HintMatch = matchKeySetHint(
+    expectedUniversalChallengerBtcPubkeys,
+    registrationKeys.universalChallengers,
+    operationKeys.universalChallengers,
+  );
 
-  /** Which of the two candidate sets a role's hint matched. */
-  interface RoleMatch {
-    registration: boolean;
-    operation: boolean;
-  }
-
-  const vpMatch: RoleMatch = {
-    registration: hintVp === registrationKeys.vaultProvider,
-    operation: hintVp === operationKeys.vaultProvider,
-  };
-  const keeperMatch: RoleMatch = {
-    registration: setsEqual(hintKeepers, registrationKeys.vaultKeepers),
-    operation: setsEqual(hintKeepers, operationKeys.vaultKeepers),
-  };
-  const challengerMatch: RoleMatch = {
-    registration: setsEqual(
-      hintChallengers,
-      registrationKeys.universalChallengers,
-    ),
-    operation: setsEqual(hintChallengers, operationKeys.universalChallengers),
-  };
-
-  const accepted = (m: RoleMatch) => m.registration || m.operation;
-
-  if (!accepted(vpMatch)) {
+  if (!isHintAccepted(vpMatch)) {
     throw new Error(
       `Vault provider BTC pubkey indexer hint does not match BTCVaultRegistry for ${vaultProviderEthAddress}. Refresh and try again.`,
     );
   }
-  if (!accepted(keeperMatch)) {
+  if (!isHintAccepted(keeperMatch)) {
     throw new Error(
       `Vault keeper BTC pubkeys (v${expectedAppVaultKeepersVersion}) indexer set does not match ApplicationRegistry on-chain set. Refresh and try again.`,
     );
   }
-  if (!accepted(challengerMatch)) {
+  if (!isHintAccepted(challengerMatch)) {
     throw new Error(
       `Universal challenger BTC pubkeys (v${expectedUniversalChallengersVersion}) indexer set does not match ProtocolParams on-chain set. Refresh and try again.`,
     );

--- a/packages/babylon-ts-sdk/src/tbv/core/services/participants/__tests__/indexerKeyHint.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/participants/__tests__/indexerKeyHint.test.ts
@@ -1,0 +1,201 @@
+/**
+ * The RFC-006 accept-either policy, tested at the level it is defined.
+ *
+ * The three call sites (deposit, payout, refund) each have their own tests for
+ * how they wire this in; these cases pin the policy itself, so a change to it
+ * fails here first rather than as three unrelated downstream surprises.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  assertVaultProviderHintAccepted,
+  isHintAccepted,
+  matchKeyHint,
+  matchKeySetHint,
+} from "../indexerKeyHint";
+import { ADDRESSES, KEYS } from "./fixtures/rotation";
+
+describe("isHintAccepted", () => {
+  it("accepts a hint explained by the registration key", () => {
+    expect(isHintAccepted({ registration: true, operation: false })).toBe(true);
+  });
+
+  // The case the whole module exists for: the indexer has caught up to a
+  // rotation while the registration getter still returns the original key.
+  it("accepts a hint explained by the current operation key", () => {
+    expect(isHintAccepted({ registration: false, operation: true })).toBe(true);
+  });
+
+  it("accepts a hint for an operator that never rotated", () => {
+    expect(isHintAccepted({ registration: true, operation: true })).toBe(true);
+  });
+
+  it("rejects a hint no on-chain state explains", () => {
+    expect(isHintAccepted({ registration: false, operation: false })).toBe(
+      false,
+    );
+  });
+});
+
+describe("matchKeyHint", () => {
+  it("reports which candidate a rotated provider's hint matched", () => {
+    expect(
+      matchKeyHint(KEYS.vpRotated, KEYS.vpGenesis, KEYS.vpRotated),
+    ).toEqual({ registration: false, operation: true });
+  });
+
+  it("reports both candidates for an operator that never rotated", () => {
+    expect(
+      matchKeyHint(KEYS.vpGenesis, KEYS.vpGenesis, KEYS.vpGenesis),
+    ).toEqual({ registration: true, operation: true });
+  });
+
+  it("reports neither candidate for an unrelated key", () => {
+    expect(matchKeyHint(KEYS.outsider, KEYS.vpGenesis, KEYS.vpRotated)).toEqual(
+      { registration: false, operation: false },
+    );
+  });
+
+  // The indexer serves 0x-prefixed keys and the schema validator lets
+  // uppercase hex through; the on-chain reader returns bare lowercase. Without
+  // canonicalization these three spellings of one key compare unequal.
+  it("matches across 0x prefixes, compressed form, and letter case", () => {
+    expect(
+      matchKeyHint(
+        `0x${KEYS.vpGenesis.toUpperCase()}`,
+        `02${KEYS.vpGenesis}`,
+        KEYS.vpRotated,
+      ).registration,
+    ).toBe(true);
+  });
+});
+
+describe("matchKeySetHint", () => {
+  const registration = [KEYS.keeperAGenesis, KEYS.keeperBGenesis];
+  const operation = [KEYS.keeperAGenesis, KEYS.keeperBRotated];
+
+  it("matches a set regardless of the order it arrives in", () => {
+    expect(
+      matchKeySetHint([...registration].reverse(), registration, operation)
+        .registration,
+    ).toBe(true);
+  });
+
+  it("matches a set that has caught up to a rotation", () => {
+    expect(matchKeySetHint(operation, registration, operation)).toEqual({
+      registration: false,
+      operation: true,
+    });
+  });
+
+  // A set holding one registration key and one operation key is an indexer
+  // halfway through applying a rotation. Per-element membership of the union
+  // would wave that through; whole-set equality is what rejects it.
+  it("rejects a set mixing registration and operation keys", () => {
+    const mixed = [KEYS.keeperBGenesis, KEYS.keeperBRotated];
+
+    expect(matchKeySetHint(mixed, registration, operation)).toEqual({
+      registration: false,
+      operation: false,
+    });
+  });
+
+  it("rejects a set of the wrong length", () => {
+    expect(
+      isHintAccepted(
+        matchKeySetHint([KEYS.keeperAGenesis], registration, operation),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("assertVaultProviderHintAccepted", () => {
+  const readCurrentOperationBtcPubkey = (key: string) =>
+    vi.fn().mockResolvedValue(key);
+
+  it("resolves when the hint matches the registration key", async () => {
+    const readOperation = readCurrentOperationBtcPubkey(KEYS.vpRotated);
+
+    await expect(
+      assertVaultProviderHintAccepted({
+        vaultProviderEthAddress: ADDRESSES.vaultProvider,
+        hintBtcPubkey: KEYS.vpGenesis,
+        registrationBtcPubkey: KEYS.vpGenesis,
+        readCurrentOperationBtcPubkey: readOperation,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  // The fallback read is what keeps a rotated provider's depositors working.
+  it("resolves when the hint matches the current operation key", async () => {
+    await expect(
+      assertVaultProviderHintAccepted({
+        vaultProviderEthAddress: ADDRESSES.vaultProvider,
+        hintBtcPubkey: KEYS.vpRotated,
+        registrationBtcPubkey: KEYS.vpGenesis,
+        readCurrentOperationBtcPubkey: readCurrentOperationBtcPubkey(
+          KEYS.vpRotated,
+        ),
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("throws when the hint matches neither key", async () => {
+    await expect(
+      assertVaultProviderHintAccepted({
+        vaultProviderEthAddress: ADDRESSES.vaultProvider,
+        hintBtcPubkey: KEYS.outsider,
+        registrationBtcPubkey: KEYS.vpGenesis,
+        readCurrentOperationBtcPubkey: readCurrentOperationBtcPubkey(
+          KEYS.vpRotated,
+        ),
+      }),
+    ).rejects.toThrow(
+      "indexer hint matches neither the registration key nor the current operation key",
+    );
+  });
+
+  it("names the operation that was aborted when given a context", async () => {
+    await expect(
+      assertVaultProviderHintAccepted({
+        vaultProviderEthAddress: ADDRESSES.vaultProvider,
+        hintBtcPubkey: KEYS.outsider,
+        registrationBtcPubkey: KEYS.vpGenesis,
+        readCurrentOperationBtcPubkey: readCurrentOperationBtcPubkey(
+          KEYS.vpRotated,
+        ),
+        context: "Aborting refund.",
+      }),
+    ).rejects.toThrow("Aborting refund.");
+  });
+
+  // The fallback is a second RPC, so it must stay a fallback: the common case
+  // is an un-rotated provider whose hint matches on the first compare.
+  it("does not read the operation key when the hint matches registration", async () => {
+    const readOperation = readCurrentOperationBtcPubkey(KEYS.vpRotated);
+
+    await assertVaultProviderHintAccepted({
+      vaultProviderEthAddress: ADDRESSES.vaultProvider,
+      hintBtcPubkey: KEYS.vpGenesis,
+      registrationBtcPubkey: KEYS.vpGenesis,
+      readCurrentOperationBtcPubkey: readOperation,
+    });
+
+    expect(readOperation).not.toHaveBeenCalled();
+  });
+
+  // Callers that have no indexer value to check pass nothing; the cross-check
+  // is an extra guard, never a precondition for reading the chain.
+  it("does not read the operation key when there is no hint", async () => {
+    const readOperation = readCurrentOperationBtcPubkey(KEYS.vpRotated);
+
+    await assertVaultProviderHintAccepted({
+      vaultProviderEthAddress: ADDRESSES.vaultProvider,
+      registrationBtcPubkey: KEYS.vpGenesis,
+      readCurrentOperationBtcPubkey: readOperation,
+    });
+
+    expect(readOperation).not.toHaveBeenCalled();
+  });
+});

--- a/packages/babylon-ts-sdk/src/tbv/core/services/participants/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/participants/index.ts
@@ -5,6 +5,16 @@
  */
 
 export {
+  assertVaultProviderHintAccepted,
+  isHintAccepted,
+  matchKeyHint,
+  matchKeySetHint,
+} from "./indexerKeyHint";
+export type {
+  AssertVaultProviderHintAcceptedParams,
+  HintMatch,
+} from "./indexerKeyHint";
+export {
   resolveCurrentParticipantKeys,
   resolveParticipantKeysAtEpochs,
 } from "./resolveParticipantKeys";

--- a/packages/babylon-ts-sdk/src/tbv/core/services/participants/indexerKeyHint.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/participants/indexerKeyHint.ts
@@ -1,0 +1,161 @@
+/**
+ * RFC-006 indexer-hint acceptance policy — the single definition.
+ *
+ * Every path that builds against a vault takes participant keys from chain and
+ * treats the indexer's copy as an untrusted *hint*. The hint never supplies key
+ * material; its job is to catch a wrong vault provider address, a wrong
+ * application entry point, or a stale roster version.
+ *
+ * Under RFC-006 an operator's BTC key is an append-only history of operation
+ * keys, so there are two values the indexer may legitimately be serving at any
+ * moment: the **registration** key (it has not caught up to a rotation) or the
+ * **current operation** key (it has). Accepting only the first hard-fails every
+ * depositor of a rotated provider the day the indexer catches up — an
+ * indexer-side deploy, with nothing to deploy on our side and no user
+ * workaround. Hence: accept either.
+ *
+ * For an operator that never rotated the two candidates are identical, so this
+ * is exactly the old strict check until someone rotates.
+ *
+ * This module exists because the policy had already been written three times —
+ * deposit, payout, and (missing) refund — and drifted each time. Callers differ
+ * in shape and cannot share one entry point:
+ *
+ * - the deposit path compares three roles as whole sets and resolves operation
+ *   keys **eagerly**, because it builds the Bitcoin lock with them;
+ * - payout and refund compare one scalar key and must read the operation key
+ *   **lazily**, because on the happy path it is a second RPC for nothing.
+ *
+ * So what is shared is the predicate — {@link isHintAccepted} and the two
+ * matchers — plus {@link assertVaultProviderHintAccepted} for the two scalar
+ * callers. Anything that needs a different acceptance rule does not belong
+ * here; see `vpAuthPinnedPubkey`, which is deliberately operation-key-only
+ * because accepting either would hollow out the pin.
+ *
+ * @module services/participants/indexerKeyHint
+ */
+
+import type { Address } from "viem";
+
+import { canonicalizeBtcPubkey } from "../../primitives/utils/bitcoin";
+
+/**
+ * Which of the two legitimate on-chain candidates a role's hint matched.
+ *
+ * Both true means the role never rotated, so the hint constrains nothing.
+ * Both false means the hint is not explainable by any state the chain is in.
+ */
+export interface HintMatch {
+  registration: boolean;
+  operation: boolean;
+}
+
+/**
+ * The accept-either policy itself.
+ *
+ * Kept as a named function rather than inlined at each call site so that
+ * changing the policy is a one-line change in one file, and so a reader can
+ * find every path governed by it.
+ */
+export function isHintAccepted(match: HintMatch): boolean {
+  return match.registration || match.operation;
+}
+
+/** Match a single hinted key against both candidates. */
+export function matchKeyHint(
+  hint: string,
+  registrationKey: string,
+  operationKey: string,
+): HintMatch {
+  const canonicalHint = canonicalizeBtcPubkey(hint);
+  return {
+    registration: canonicalHint === canonicalizeBtcPubkey(registrationKey),
+    operation: canonicalHint === canonicalizeBtcPubkey(operationKey),
+  };
+}
+
+/**
+ * Match a hinted key *set* against both candidate sets.
+ *
+ * Compared as whole sets, never as per-element membership of the union: a
+ * roster holding one registration key and one operation key is an indexer that
+ * is halfway through applying a rotation, and union membership would wave that
+ * through. Order is normalized, so this is set equality and not list equality.
+ */
+export function matchKeySetHint(
+  hints: readonly string[],
+  registrationKeys: readonly string[],
+  operationKeys: readonly string[],
+): HintMatch {
+  const canonicalHints = sortedCanonical(hints);
+  return {
+    registration: setsEqual(canonicalHints, sortedCanonical(registrationKeys)),
+    operation: setsEqual(canonicalHints, sortedCanonical(operationKeys)),
+  };
+}
+
+function sortedCanonical(keys: readonly string[]): string[] {
+  return keys.map(canonicalizeBtcPubkey).sort();
+}
+
+function setsEqual(a: readonly string[], b: readonly string[]): boolean {
+  return a.length === b.length && a.every((key, i) => key === b[i]);
+}
+
+export interface AssertVaultProviderHintAcceptedParams {
+  /** Vault provider's admin address, named in the error. */
+  vaultProviderEthAddress: Address;
+  /** The untrusted hint. Absent means there is nothing to cross-check. */
+  hintBtcPubkey?: string;
+  /** The vault provider's registration key, already read from chain. */
+  registrationBtcPubkey: string;
+  /**
+   * Reads the vault provider's *current* operation key.
+   *
+   * Invoked only when the hint fails against the registration key, so a
+   * provider that never rotated — and an indexer that has not caught up — cost
+   * no extra RPC. Callers must not pre-read this.
+   */
+  readCurrentOperationBtcPubkey: () => Promise<string>;
+  /**
+   * Sentence appended to the error naming what was aborted, e.g.
+   * `"Aborting refund."`. The shared half of the message says which keys
+   * failed to match; this says which operation the user just lost.
+   */
+  context?: string;
+}
+
+/**
+ * Assert an indexer-hinted vault provider key is one the chain can explain.
+ *
+ * Resolves silently when there is no hint, or when the hint matches either
+ * candidate. Throws otherwise — the caller's key material is unaffected either
+ * way, since resolution is chain-only.
+ */
+export async function assertVaultProviderHintAccepted(
+  params: AssertVaultProviderHintAcceptedParams,
+): Promise<void> {
+  const {
+    vaultProviderEthAddress,
+    hintBtcPubkey,
+    registrationBtcPubkey,
+    readCurrentOperationBtcPubkey,
+    context,
+  } = params;
+
+  if (!hintBtcPubkey) return;
+
+  const canonicalHint = canonicalizeBtcPubkey(hintBtcPubkey);
+  if (canonicalHint === canonicalizeBtcPubkey(registrationBtcPubkey)) return;
+
+  const canonicalOperation = canonicalizeBtcPubkey(
+    await readCurrentOperationBtcPubkey(),
+  );
+  if (canonicalHint === canonicalOperation) return;
+
+  throw new Error(
+    `Vault provider BTC pubkey mismatch for ${vaultProviderEthAddress}: ` +
+      `indexer hint matches neither the registration key nor the current ` +
+      `operation key on-chain.${context ? ` ${context}` : ""}`,
+  );
+}

--- a/services/vault/src/services/vault/__tests__/vaultRefundService.test.ts
+++ b/services/vault/src/services/vault/__tests__/vaultRefundService.test.ts
@@ -86,6 +86,7 @@ const mockGetOffchainParamsByVersion = vi.fn();
 const mockGetVaultKeepersByVersion = vi.fn();
 const mockGetUniversalChallengersByVersion = vi.fn();
 const mockGetVaultProviderBtcPubKey = vi.fn();
+const mockGetCurrentVaultProviderOperationBtcKey = vi.fn();
 // Lean sibling pre-filter used by discoverBatch. Defaults to deriving
 // prePeginTxHash from the same getVaultFromChain fixtures each test
 // configures, so sibling scenarios keep one source of truth. Tests that
@@ -117,6 +118,8 @@ vi.mock("../../../clients/eth-contract/sdk-readers", () => ({
   getVaultRegistryReader: vi.fn().mockReturnValue({
     getVaultProviderBtcPubKey: (...args: unknown[]) =>
       mockGetVaultProviderBtcPubKey(...args),
+    getCurrentVaultProviderOperationBtcKey: (...args: unknown[]) =>
+      mockGetCurrentVaultProviderOperationBtcKey(...args),
     getProtocolInfoBatch: (ids: readonly string[]) =>
       mockGetProtocolInfoBatch(ids),
   }),
@@ -185,6 +188,10 @@ const OFFCHAIN_PARAMS = {
 // 32 bytes as bare lowercase x-only hex. Both must agree for the cross-check.
 const VP_BTC_PUBKEY_X_ONLY = "f".repeat(64);
 const VAULT_PROVIDER = { btcPubKey: `0x${VP_BTC_PUBKEY_X_ONLY}` };
+/** The key a rotated provider's operation getter returns. */
+const VP_ROTATED_BTC_PUBKEY_X_ONLY = "e".repeat(64);
+/** Matches neither candidate — a stale or poisoned indexer. */
+const VP_UNRELATED_BTC_PUBKEY_X_ONLY = "d".repeat(64);
 const VAULT_KEEPERS = [{ btcPubKey: "vk1" }, { btcPubKey: "vk2" }];
 const UNIVERSAL_CHALLENGERS = [{ btcPubKey: "uc1" }];
 // Funded Pre-PegIn tx whose HTLC output (vout 0, matching ON_CHAIN_VAULT
@@ -246,6 +253,11 @@ describe("vaultRefundService - adapter wiring", () => {
     mockGetOffchainParamsByVersion.mockResolvedValue(OFFCHAIN_PARAMS);
     (fetchVaultProviderById as Mock).mockResolvedValue(VAULT_PROVIDER);
     mockGetVaultProviderBtcPubKey.mockResolvedValue(VP_BTC_PUBKEY_X_ONLY);
+    // Default: an un-rotated provider, whose current operation key is its
+    // registration key. The rotation cases below override this.
+    mockGetCurrentVaultProviderOperationBtcKey.mockResolvedValue(
+      VP_BTC_PUBKEY_X_ONLY,
+    );
     mockGetVaultKeepersByVersion.mockResolvedValue(VAULT_KEEPERS);
     mockGetUniversalChallengersByVersion.mockResolvedValue(
       UNIVERSAL_CHALLENGERS,
@@ -455,12 +467,16 @@ describe("vaultRefundService - adapter wiring", () => {
     );
   });
 
-  // Audit #216: indexer-provided VP key is cross-checked against the
-  // on-chain registry. A stale or compromised indexer that substitutes a
-  // different key must not produce a refund signed against a wrong Taproot
-  // script tree.
-  it("throws when indexer VP pubkey does not match the on-chain registry", async () => {
-    mockGetVaultProviderBtcPubKey.mockResolvedValue("a".repeat(64));
+  // The indexer-provided VP key is cross-checked against the chain. A stale or
+  // compromised indexer that substitutes a key the registry cannot account for
+  // must not produce a refund signed against a wrong Taproot script tree.
+  it("throws when the indexer VP pubkey matches neither on-chain key", async () => {
+    (fetchVaultProviderById as Mock).mockResolvedValue({
+      btcPubKey: `0x${VP_UNRELATED_BTC_PUBKEY_X_ONLY}`,
+    });
+    mockGetCurrentVaultProviderOperationBtcKey.mockResolvedValue(
+      VP_ROTATED_BTC_PUBKEY_X_ONLY,
+    );
 
     await expect(
       buildAndBroadcastRefundTransaction({
@@ -470,7 +486,54 @@ describe("vaultRefundService - adapter wiring", () => {
         depositorBtcPubkey: DEPOSITOR_PUBKEY,
         feeRate: 10,
       }),
-    ).rejects.toThrow(/does not match on-chain registry/);
+    ).rejects.toThrow(/Aborting refund/);
+  });
+
+  // RFC-006. Once the indexer catches up to a rotation it serves the operation
+  // key while the registration getter still returns the original. Rejecting
+  // that would strand every depositor of a rotated provider on the recovery
+  // path of last resort, triggered by an indexer deploy rather than one of ours.
+  it("accepts an indexer VP pubkey matching the current operation key", async () => {
+    (fetchVaultProviderById as Mock).mockResolvedValue({
+      btcPubKey: `0x${VP_ROTATED_BTC_PUBKEY_X_ONLY}`,
+    });
+    mockGetCurrentVaultProviderOperationBtcKey.mockResolvedValue(
+      VP_ROTATED_BTC_PUBKEY_X_ONLY,
+    );
+
+    await expect(
+      buildAndBroadcastRefundTransaction({
+        vaultId: VAULT_ID,
+        depositorAddress: DEPOSITOR_ADDRESS,
+        btcWalletProvider: BTC_WALLET_PROVIDER,
+        depositorBtcPubkey: DEPOSITOR_PUBKEY,
+        feeRate: 10,
+      }),
+    ).resolves.toBe("broadcast_txid");
+
+    // The registration key still seeds epoch resolution — accepting the hint
+    // must not swap which key the script tree is rebuilt from.
+    expect(mockResolveParticipantKeysAtEpochs).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: expect.objectContaining({
+          vaultProviderGenesisBtcPubkey: `0x${VP_BTC_PUBKEY_X_ONLY}`,
+        }),
+      }),
+    );
+  });
+
+  // The operation-key read is a fallback, not a second unconditional RPC on
+  // every refund.
+  it("does not read the operation key when the hint matches registration", async () => {
+    await buildAndBroadcastRefundTransaction({
+      vaultId: VAULT_ID,
+      depositorAddress: DEPOSITOR_ADDRESS,
+      btcWalletProvider: BTC_WALLET_PROVIDER,
+      depositorBtcPubkey: DEPOSITOR_PUBKEY,
+      feeRate: 10,
+    });
+
+    expect(mockGetCurrentVaultProviderOperationBtcKey).not.toHaveBeenCalled();
   });
 
   it("uses the on-chain VP pubkey in the returned refund context", async () => {

--- a/services/vault/src/services/vault/vaultPayoutSignatureService.ts
+++ b/services/vault/src/services/vault/vaultPayoutSignatureService.ts
@@ -18,7 +18,8 @@
  */
 
 import {
-  processPublicKeyToXOnly,
+  assertVaultProviderHintAccepted,
+  canonicalizeBtcPubkey,
   resolveParticipantKeysAtEpochs,
   stripHexPrefix,
   type Network,
@@ -126,13 +127,11 @@ export interface PayoutSigningProgress {
  * a stale indexer view, not to supply key material.
  *
  * Under RFC-006 the hint is accepted against *either* the registration key or
- * the provider's current operation key, mirroring the policy
- * `validateOnChainParticipantKeys` applies on the deposit path. Comparing only
- * against the registration key would hard-fail payout signing for every
- * depositor of a rotated provider the day the indexer starts serving operation
- * keys — an indexer-side change, with no deploy on our side and no user
- * workaround. For a provider that never rotated the two candidates are
- * identical, so this is exactly the old check until someone rotates.
+ * the provider's current operation key — the policy owned by
+ * `assertVaultProviderHintAccepted`, which the deposit and refund paths share.
+ * Comparing only against the registration key would hard-fail payout signing
+ * for every depositor of a rotated provider the day the indexer starts serving
+ * operation keys.
  *
  * The returned registration key is only used as the genesis fallback for
  * epoch-based resolution; the keys actually signed with come from
@@ -142,26 +141,17 @@ export async function resolveVaultProviderBtcPubkey(
   address: Address,
   btcPubKey?: string,
 ): Promise<string> {
-  const registrationBtcPubkey = processPublicKeyToXOnly(
+  const registrationBtcPubkey = canonicalizeBtcPubkey(
     await getVaultProviderBtcPubkeyFromChain(address),
-  ).toLowerCase();
+  );
 
-  if (btcPubKey) {
-    const hintedBtcPubkey = processPublicKeyToXOnly(btcPubKey).toLowerCase();
-    if (hintedBtcPubkey !== registrationBtcPubkey) {
-      const currentOperationBtcPubkey = processPublicKeyToXOnly(
-        await getVaultRegistryReader().getCurrentVaultProviderOperationBtcKey(
-          address,
-        ),
-      ).toLowerCase();
-      if (hintedBtcPubkey !== currentOperationBtcPubkey) {
-        throw new Error(
-          `Vault provider BTC pubkey mismatch for ${address}: indexer hint matches ` +
-            `neither the registration key nor the current operation key on-chain`,
-        );
-      }
-    }
-  }
+  await assertVaultProviderHintAccepted({
+    vaultProviderEthAddress: address,
+    hintBtcPubkey: btcPubKey,
+    registrationBtcPubkey,
+    readCurrentOperationBtcPubkey: () =>
+      getVaultRegistryReader().getCurrentVaultProviderOperationBtcKey(address),
+  });
 
   return registrationBtcPubkey;
 }

--- a/services/vault/src/services/vault/vaultRefundService.ts
+++ b/services/vault/src/services/vault/vaultRefundService.ts
@@ -13,8 +13,8 @@
 
 import type { SignPsbtOptions } from "@babylonlabs-io/ts-sdk/shared";
 import {
+  assertVaultProviderHintAccepted,
   getNetworkFees,
-  processPublicKeyToXOnly,
   pushTx,
   resolveParticipantKeysAtEpochs,
   stripHexPrefix,
@@ -434,14 +434,23 @@ async function readPrePeginContext(
   // value. A stale or compromised indexer could otherwise substitute a
   // different key and produce a refund signed against a Taproot script tree
   // that doesn't match the actual vault.
-  const indexerXOnly = processPublicKeyToXOnly(
-    vaultProvider.btcPubKey,
-  ).toLowerCase();
-  if (indexerXOnly !== vaultProviderOnChainPubkey.toLowerCase()) {
-    throw new Error(
-      `Indexer vault provider key for ${vault.vaultProvider} does not match on-chain registry. Aborting refund.`,
-    );
-  }
+  //
+  // RFC-006. Accepted against the registration key *or* the provider's current
+  // operation key, the shared policy the deposit and payout paths apply. This
+  // is the recovery path of last resort, with BTC already committed, and the
+  // trigger is an indexer deploy rather than one of ours — comparing against
+  // the registration key alone would strand every depositor of a rotated
+  // provider with no workaround.
+  await assertVaultProviderHintAccepted({
+    vaultProviderEthAddress: vault.vaultProvider as Address,
+    hintBtcPubkey: vaultProvider.btcPubKey,
+    registrationBtcPubkey: vaultProviderOnChainPubkey,
+    readCurrentOperationBtcPubkey: () =>
+      getVaultRegistryReader().getCurrentVaultProviderOperationBtcKey(
+        vault.vaultProvider as Address,
+      ),
+    context: "Aborting refund.",
+  });
 
   // RFC-006. A refund rebuilds this vault's Pre-PegIn script tree, so it must
   // use the keys bonded at the vault's frozen epochs — not whatever the


### PR DESCRIPTION
Part of https://github.com/babylonlabs-io/babylon-toolkit/issues/2188 — the refund half. That issue tracks two independent bugs and stays open for the second one, the `getVaultProviderBTCKey` re-point, so this PR intentionally uses no closing keyword.

## The bug

`vaultRefundService.readPrePeginContext` compared the indexer's vault provider BTC key against the **registration** key alone. Under RFC-006 a provider's key is an append-only history of operation keys, and the indexer will eventually serve the current operation key rather than the registration key. When it does, every refund for a rotated provider throws `Aborting refund`.

Three things make this worse than the same defect on the other paths:

- The trigger is an **indexer** deploy. Nothing ships on our side, and there is no user workaround.
- It sits on the **broadcast** path, not the preview path — the depositor sees a valid refund preview, confirms, and only then hits the failure.
- Refund is the recovery path of last resort, with BTC already committed.

devnet's vault provider is already rotated to epoch 13, so this is armed today and fires the moment the indexer catches up.

The comparison predates RFC-006 (unchanged since `a6cdf287`). https://github.com/babylonlabs-io/babylon-toolkit/pull/2173 added `resolveParticipantKeysAtEpochs` into the same function without revisiting it, which is how it survived two passes.

## What changed

@jonybur asked for the accept-either policy to be extracted into one shared helper rather than copy-pasted a third time, and that is what this does.

New: `packages/babylon-ts-sdk/src/tbv/core/services/participants/indexerKeyHint.ts`. It owns the policy — `isHintAccepted` is now the single place `registration || operation` is written down — plus `matchKeyHint` / `matchKeySetHint` and an `assertVaultProviderHintAccepted` for the scalar callers.

All three sites now go through it:

| path | before | after |
|---|---|---|
| deposit (`validateOnChainParticipantKeys`) | private `canonical` / `RoleMatch` / `accepted` | shared matchers + `isHintAccepted` |
| payout (`resolveVaultProviderBtcPubkey`) | inline nested compare | `assertVaultProviderHintAccepted` |
| refund (`readPrePeginContext`) | **registration-only hard-compare** | `assertVaultProviderHintAccepted` |

Two sites were deliberately left alone. `vpAuthPinnedPubkey` is operation-key-only on purpose — accepting either would hollow out the pin that stops a substituted server key being used. `verifyResumeParticipantKeys` and `verifyRegisteredParticipantKeys` are exact-match drift guards against locally persisted keys, strict by design.

Also exported `canonicalizeBtcPubkey` from `primitives/utils/bitcoin.ts`. `processPublicKeyToXOnly` preserves case on already-x-only input, so every comparison site has to remember to pair it with `.toLowerCase()`; that pairing was copy-pasted five times. The refund path had in fact drifted here too — it normalized the hint but only lowercased the chain value, relying on the `OnChainBtcPubkey` brand invariant instead of normalizing.

## What this does not change

No key material moves. `vaultProviderOnChainPubkey` never reached script construction — the keys that rebuild the Taproot tree come from `resolveParticipantKeysAtEpochs` at the vault's frozen epochs. The registration key is still what seeds that resolution as the genesis fallback, and there is a test asserting accepting a rotated hint does not swap it.

The operation-key read stays a **fallback**, invoked only when the registration compare fails, so an un-rotated provider costs no extra RPC. Tests on both the payout and refund paths assert it is not called on the happy path.

## Tests

18 new cases in `participants/__tests__/indexerKeyHint.test.ts` covering the policy itself, including the whole-set rule that rejects a roster mixing registration and operation keys.

On the refund path, the test at `vaultRefundService.test.ts:474` was locking in the buggy behaviour (`rejects.toThrow(/does not match on-chain registry/)`). It is replaced by three cases mirroring the payout ones: rejects a hint matching neither key, accepts a hint matching the rotated operation key, and does not read the operation key when the hint matches registration.

The payout and deposit tests pass **unchanged**, which is the regression check on the extraction. To confirm the new tests are load-bearing rather than decorative, I temporarily reverted the helper to registration-only: exactly two tests failed, the rotation-acceptance case on each of the refund and payout paths.

## Verification

`pnpm run build` clean. ts-sdk 1469 passing (1451 + 18 new). vault 2982 passing. `tsc --noEmit -p tsconfig.lib.json` clean. `pnpm run lint` 0 errors.

Two vault tests flake under full-suite parallel load — `demoArtifactDownload` (a known one) and `VaultWalletConnectionProvider.disabledWallets`. The failing pair differed between runs and both pass in isolation; neither touches key validation.

No devnet run: the accept-either branch is unreachable until the indexer serves operation keys.

## Not in this PR — refund is not yet safe from contracts#539

Refund can break in two independent ways, and this PR fixes one of them.

| | Trigger | Mechanism | Status |
|---|---|---|---|
| this PR | **indexer** deploy | indexer serves the rotated key; the check only accepted the registration key | fixed |
| #2188's other half | **contracts** deploy | https://github.com/babylonlabs-io/vault-contracts-aave-v4/pull/539 deletes `getVaultProviderBTCKey`; the call reverts on selector mismatch | open |

`readPrePeginContext` still reads `getVaultProviderBtcPubKey` → Solidity `getVaultProviderBTCKey`, so once #539 deploys refund breaks again — along with deposit, payout and resume, which make the same read. That is deliberately out of scope here: the two failures share no code, and the indexer one is armed on devnet today while #539 is not yet merged.

The fallback this PR adds reads `getCurrentOperationBtcKey`, which #539 keeps, so it introduces no new exposure.

Worth noting for whoever picks up the other half: it is not actually blocked on #539 merging. The intended replacement `getOperationBtcKeyAtEpoch(vp, 0)` is a getter we already call for the vault provider on every existing-vault path, so it adds no new ABI surface and works against both the current and post-#539 registries — meaning it can land before the contracts change ships, rather than during the outage it would otherwise cause.
