### PR TITLE
fix(vault): name the deposit action in the locked-wallet CTA

### DIFF
--- a/services/vault/src/components/simple/DepositForm.tsx
+++ b/services/vault/src/components/simple/DepositForm.tsx
@@ -131,8 +131,8 @@ export interface DepositWalletState {
   /**
    * True when the silent lock poll flagged the BTC wallet as locked. The CTA is
    * already promoted to a recovery action via `hasWalletConnectionError`; this
-   * relabels it "Unlock wallet" (vs "Reconnect Wallet" for a liveness failure)
-   * so the button matches what the user must do.
+   * relabels it "Unlock Wallet to Deposit" (vs "Reconnect Wallet" for a
+   * liveness failure) so the button matches what the user must do.
    */
   isWalletLocked?: boolean;
   /**
@@ -387,14 +387,14 @@ export function DepositForm({
   });
 
   // A locked wallet reuses the same recovery CTA as a liveness failure (both
-  // reconnect on click), but reads "Unlock wallet" so the action matches the
-  // cause. `getDepositCtaState` already handled `disabled`; only the label
-  // differs here.
+  // reconnect on click), but reads "Unlock Wallet to Deposit" so the action
+  // matches the cause. `getDepositCtaState` already handled `disabled`; only
+  // the label differs here.
   const ctaLabel =
     isWalletLocked && hasWalletConnectionError
       ? isReconnectingWallet
         ? COPY.wallet.locked.unlocking
-        : COPY.wallet.locked.unlockButton
+        : COPY.wallet.locked.unlockToDepositButton
       : cta.label;
 
   return (
@@ -492,8 +492,9 @@ export function DepositForm({
       <VaultProviderSelectorV3 {...providerSelectorProps} />
 
       {/* CTA button. A locked wallet shows no inline message — the relabeled CTA
-          ("Unlock wallet") is the affordance. A liveness failure still surfaces
-          its detail string so the user sees the underlying cause. */}
+          ("Unlock Wallet to Deposit") is the affordance. A liveness failure
+          still surfaces its detail string so the user sees the underlying
+          cause. */}
       {hasWalletConnectionError &&
         !isWalletLocked &&
         walletConnectionErrorMessage && (

--- a/services/vault/src/components/simple/SimpleDeposit.tsx
+++ b/services/vault/src/components/simple/SimpleDeposit.tsx
@@ -494,9 +494,9 @@ function SimpleDepositContent({
                   isWalletConnected,
                   // A click-time liveness failure OR the proactive lock poll
                   // promotes the CTA to the reconnect/unlock action. A lock
-                  // relabels the CTA to "Unlock wallet" (see DepositForm) instead
-                  // of showing a red inline string; a liveness failure keeps its
-                  // detail message.
+                  // relabels the CTA to "Unlock Wallet to Deposit" (see
+                  // DepositForm) instead of showing a red inline string; a
+                  // liveness failure keeps its detail message.
                   hasWalletConnectionError:
                     Boolean(walletConnectionError) ||
                     isBtcWalletLocked ||

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -880,6 +880,9 @@ export const COPY = {
       title: "Bitcoin wallet locked",
       description: "Unlock your Bitcoin wallet in your extension to continue.",
       unlockButton: "Unlock wallet",
+      // Deposit-form CTA: names the action the unlock unblocks, unlike the
+      // navbar / progress-modal button which is just "Unlock wallet".
+      unlockToDepositButton: "Unlock Wallet to Deposit",
       unlocking: "Unlocking wallet...",
     },
     publicKeyUnavailable:


### PR DESCRIPTION

<img width="1400" height="1678" alt="unlock-cta" src="https://github.com/user-attachments/assets/12785e06-2357-4572-bab7-8238425323c5" />


## What

The deposit form's button now reads **"Unlock Wallet to Deposit"** instead of "Unlock wallet" when the depositor's Bitcoin wallet is locked.

## Screenshot

<!-- drop the image here -->

## Why

The old label said what the click does but not why the user is being asked to do it. On the deposit screen the unlock is a step towards depositing, so the button now names that outcome.

## How

Added a deposit-specific string (`wallet.locked.unlockToDepositButton`) in `copy.ts` and used it in the deposit form's CTA.

The existing short "Unlock wallet" label is shared with two other buttons - the navbar unlock button and the unlock button inside the deposit progress modal - where the longer wording would not fit the context, so those keep the original string.

No behaviour changes: same click handler, same disabled/loading states.
