### PR TITLE
fix(vault): line up the vault list rows and let their text fit

### DIFF
--- a/services/vault/src/components/Activity/ActivityRowV3.tsx
+++ b/services/vault/src/components/Activity/ActivityRowV3.tsx
@@ -12,6 +12,7 @@
 import { Avatar } from "@babylonlabs-io/core-ui";
 import type { ReactNode } from "react";
 
+import { LIST_ROW_COLUMN_CLASS } from "@/components/shared/ListRow";
 import { COPY } from "@/copy";
 import { type ActivityLog, PENDING_DEPOSIT_TYPE } from "@/types/activityLog";
 import { getExplorerTxUrl } from "@/utils/explorer";
@@ -20,9 +21,9 @@ import { formatActivityTime } from "@/utils/formatting";
 import { ActivityHashLink } from "./ActivityHashLink";
 import { STATUS_DOT } from "./statusDot";
 
-/** Fixed column width shared by every cell, so rows line up across cards
- *  regardless of amount length (Figma: 180px). */
-const COLUMN_CLASS = "flex w-[180px] shrink-0 items-center";
+/** Column shared by every cell, so rows line up across cards regardless of
+ *  amount length. */
+const COLUMN_CLASS = `flex items-center ${LIST_ROW_COLUMN_CLASS}`;
 
 /** Figma body 2 — every cell's text except the deferred USD sub-line. */
 const CELL_TEXT_CLASS = "text-sm leading-[1.43] tracking-[0.17px]";

--- a/services/vault/src/components/Activity/ActivityRowV3.tsx
+++ b/services/vault/src/components/Activity/ActivityRowV3.tsx
@@ -12,7 +12,10 @@
 import { Avatar } from "@babylonlabs-io/core-ui";
 import type { ReactNode } from "react";
 
-import { LIST_ROW_COLUMN_CLASS } from "@/components/shared/ListRow";
+import {
+  LIST_ROW_ACTION_SLOT_CLASS,
+  LIST_ROW_COLUMN_CLASS,
+} from "@/components/shared/ListRow";
 import { COPY } from "@/copy";
 import { type ActivityLog, PENDING_DEPOSIT_TYPE } from "@/types/activityLog";
 import { getExplorerTxUrl } from "@/utils/explorer";
@@ -117,7 +120,10 @@ export function ActivityRowLayout({
   return (
     <div className="flex w-full flex-wrap items-center gap-4">
       <div className={`${COLUMN_CLASS} gap-2`}>
-        <Avatar url={icon} alt={iconAlt} size="medium" />
+        {/* `.bbn-avatar` is inline-flex with no shrink-0 of its own, and this
+            cell can now shrink to its 120px floor — without this a long amount
+            squashes the circle into an ellipse. */}
+        <Avatar url={icon} alt={iconAlt} size="medium" className="shrink-0" />
         <span
           className={`min-w-0 truncate ${CELL_TEXT_CLASS} text-accent-primary`}
         >
@@ -148,9 +154,14 @@ export function ActivityRowLayout({
         {time}
       </span>
 
-      {action && (
-        <div className="ml-auto flex shrink-0 items-center">{action}</div>
-      )}
+      {/* Reserved even when there is no action. Only refundable expired
+          deposits get a button and liquidation-group children never do, so
+          without the empty slot those rows would hand the button's width back
+          to the five cells and start their columns tens of pixels off the rows
+          around them. */}
+      <div className={`${LIST_ROW_ACTION_SLOT_CLASS} items-center`}>
+        {action}
+      </div>
     </div>
   );
 }

--- a/services/vault/src/components/ApplicationLogo.tsx
+++ b/services/vault/src/components/ApplicationLogo.tsx
@@ -8,14 +8,17 @@ interface ApplicationLogoProps {
   shape?: "circle" | "rounded";
 }
 
+// `shrink-0` on every size: the logo sits beside truncating text in flex rows,
+// where without it flexbox squashes the circle into an ellipse instead of
+// letting the text shrink.
 const SIZE_CLASSES: Record<
   NonNullable<ApplicationLogoProps["size"]>,
   string
 > = {
-  xs: "h-4 w-4",
-  sm: "h-6 w-6",
-  small: "h-8 w-8",
-  large: "h-10 w-10",
+  xs: "h-4 w-4 shrink-0",
+  sm: "h-6 w-6 shrink-0",
+  small: "h-8 w-8 shrink-0",
+  large: "h-10 w-10 shrink-0",
 };
 
 const FALLBACK_TEXT_CLASSES: Record<

--- a/services/vault/src/components/ApplicationLogo.tsx
+++ b/services/vault/src/components/ApplicationLogo.tsx
@@ -8,18 +8,20 @@ interface ApplicationLogoProps {
   shape?: "circle" | "rounded";
 }
 
-// `shrink-0` on every size: the logo sits beside truncating text in flex rows,
-// where without it flexbox squashes the circle into an ellipse instead of
-// letting the text shrink.
 const SIZE_CLASSES: Record<
   NonNullable<ApplicationLogoProps["size"]>,
   string
 > = {
-  xs: "h-4 w-4 shrink-0",
-  sm: "h-6 w-6 shrink-0",
-  small: "h-8 w-8 shrink-0",
-  large: "h-10 w-10 shrink-0",
+  xs: "h-4 w-4",
+  sm: "h-6 w-6",
+  small: "h-8 w-8",
+  large: "h-10 w-10",
 };
+
+// A layout invariant rather than a size, so it sits outside SIZE_CLASSES: the
+// logo sits beside truncating text in flex rows, where without it flexbox
+// squashes the circle into an ellipse instead of letting the text shrink.
+const LOGO_LAYOUT_CLASS = "shrink-0";
 
 const FALLBACK_TEXT_CLASSES: Record<
   NonNullable<ApplicationLogoProps["size"]>,
@@ -39,7 +41,7 @@ export function ApplicationLogo({
 }: ApplicationLogoProps) {
   const [imageError, setImageError] = useState(false);
 
-  const sizeClasses = SIZE_CLASSES[size];
+  const sizeClasses = `${SIZE_CLASSES[size]} ${LOGO_LAYOUT_CLASS}`;
   const shapeClasses = shape === "circle" ? "rounded-full" : "rounded-2xl";
 
   if (imageError || !logoUrl) {

--- a/services/vault/src/components/shared/ListRow.tsx
+++ b/services/vault/src/components/shared/ListRow.tsx
@@ -12,6 +12,50 @@ import type { ReactNode } from "react";
 
 import { CARD_SHELL_CLASS } from "@/components/shared/layoutClasses";
 
+/**
+ * A lifecycle-row cell other than the leading one. Every cell grows, so the
+ * card's slack spreads evenly across the row instead of pooling in the last
+ * cell and opening a gap before the trailing action button.
+ *
+ * The basis is the widest cell's intrinsic content — the status cell's 12px
+ * dot, 108px label and 16px info icon with their 4px gaps. Keeping it that
+ * tight matters: `flex-wrap` breaks lines on the basis and never shrinks to
+ * avoid a break, so every extra pixel here raises the viewport width at which
+ * the action button drops onto a second line. 120px is the floor below which
+ * wrapping is preferable to squashing.
+ */
+export const LIST_ROW_COLUMN_CLASS = "min-w-[120px] shrink grow basis-[144px]";
+
+/**
+ * The leading cell — a logo beside a two-line amount / sub-line block. Its
+ * basis fits the longest sub-line the rows produce (the refund-maturity
+ * notice, measured at 343px in the app's 12px face) plus the 32px logo and its
+ * 8px gap, so that copy reads in full rather than ellipsing. It takes a double
+ * share of any remaining slack, and gives width back proportionally when the
+ * viewport is too narrow for every cell to sit at its basis.
+ */
+export const LIST_ROW_LEADING_COLUMN_CLASS =
+  "min-w-[120px] shrink grow-[2] basis-[384px]";
+
+/**
+ * Trailing action cell. Rows whose action is conditional reserve it anyway, so
+ * a row without a button still lines its cells up with the rows that have one.
+ * The width matches `ROW_BUTTON_MIN_WIDTH_PX`, spelled literally because
+ * Tailwind only emits classes it can find as whole strings in the source.
+ */
+export const LIST_ROW_ACTION_SLOT_CLASS =
+  "flex min-w-[120px] shrink-0 justify-end";
+
+/**
+ * Every lifecycle row stands the same height so the Pending / Active /
+ * Inactive sections read as one table rather than three — otherwise a row
+ * whose leading cell has no sub-line, or whose status cell has no progress
+ * bar, sits shorter than its neighbours. The tallest cell is two lines (a 24px
+ * amount over a 20px sub-line); this is that 44px plus the card's 16px padding
+ * and 1px border on each side, since the box is border-box.
+ */
+export const LIST_ROW_MIN_HEIGHT_CLASS = "min-h-[78px]";
+
 /** Bordered row card shared by the vault and loan lists. */
 export function ListRowCard({
   children,
@@ -23,7 +67,7 @@ export function ListRowCard({
   return (
     <div
       data-testid={testId}
-      className={`${CARD_SHELL_CLASS} flex flex-wrap items-center gap-x-4 gap-y-3 p-4`}
+      className={`${CARD_SHELL_CLASS} ${LIST_ROW_MIN_HEIGHT_CLASS} flex flex-wrap items-center gap-x-4 gap-y-3 p-4`}
     >
       {children}
     </div>

--- a/services/vault/src/components/shared/ListRow.tsx
+++ b/services/vault/src/components/shared/ListRow.tsx
@@ -24,27 +24,42 @@ import { CARD_SHELL_CLASS } from "@/components/shared/layoutClasses";
  * the action button drops onto a second line. 120px is the floor below which
  * wrapping is preferable to squashing.
  */
-export const LIST_ROW_COLUMN_CLASS = "min-w-[120px] shrink grow basis-[144px]";
+export const LIST_ROW_COLUMN_CLASS = "min-w-[120px] grow basis-[144px]";
 
 /**
  * The leading cell — a logo beside a two-line amount / sub-line block. Its
  * basis fits the longest sub-line the rows produce (the refund-maturity
- * notice, measured at 343px in the app's 12px face) plus the 32px logo and its
- * 8px gap, so that copy reads in full rather than ellipsing. It takes a double
- * share of any remaining slack, and gives width back proportionally when the
- * viewport is too narrow for every cell to sit at its basis.
+ * notice from `COPY.vaults.statusHints.refundMaturing`, measured at 343px in
+ * the app's 12px face) plus the 32px logo and its 8px gap, so that copy reads
+ * in full rather than ellipsing. It takes a double share of any remaining
+ * slack.
+ *
+ * That 343px is one measurement of an interpolated string — the block count,
+ * the hours and the block/blocks plural all vary — so a longer combination
+ * ellipses again. `copy.ts` points back here for that reason; re-measure both
+ * together.
  */
 export const LIST_ROW_LEADING_COLUMN_CLASS =
-  "min-w-[120px] shrink grow-[2] basis-[384px]";
+  "min-w-[120px] grow-[2] basis-[384px]";
 
 /**
- * Trailing action cell. Rows whose action is conditional reserve it anyway, so
- * a row without a button still lines its cells up with the rows that have one.
- * The width matches `ROW_BUTTON_MIN_WIDTH_PX`, spelled literally because
- * Tailwind only emits classes it can find as whole strings in the source.
+ * Trailing action cell. Every lifecycle and activity row routes its action
+ * through this slot — including rows that have no action at all — and the slot
+ * neither grows nor shrinks. That is what keeps the columns aligned: the slack
+ * the data cells divide is `card width - gaps - bases - 168`, identical in
+ * every row, so a row whose button says "Broadcast Pre-Pegin" starts its
+ * columns in the same place as one that says "Withdraw" or has no button.
+ *
+ * Sizing an auto-width slot to its own button instead would hand each row a
+ * different amount of slack and skew that row's columns by tens of pixels.
+ *
+ * The 168px basis is the widest 36px row action rounded up: "Broadcast
+ * Pre-Pegin" measures 167px at `text-sm` + `tracking-[0.17px]` + `px-4` in Px
+ * Grotesk Regular. Adding a longer label to `COPY.pegin.primaryAction` or
+ * `COPY.vaults.actions` means re-measuring and widening this.
  */
 export const LIST_ROW_ACTION_SLOT_CLASS =
-  "flex min-w-[120px] shrink-0 justify-end";
+  "flex shrink-0 grow-0 basis-[168px] justify-end";
 
 /**
  * Every lifecycle row stands the same height so the Pending / Active /
@@ -53,21 +68,32 @@ export const LIST_ROW_ACTION_SLOT_CLASS =
  * bar, sits shorter than its neighbours. The tallest cell is two lines (a 24px
  * amount over a 20px sub-line); this is that 44px plus the card's 16px padding
  * and 1px border on each side, since the box is border-box.
+ *
+ * Applied per row rather than inside `ListRowCard`, because that card is also
+ * the Activity list's and Active Loans' row. Those are single-line rows that
+ * sit at ~70px, and pinning them to 78px would silently retitle two other
+ * pages' layout.
  */
 export const LIST_ROW_MIN_HEIGHT_CLASS = "min-h-[78px]";
 
-/** Bordered row card shared by the vault and loan lists. */
+/**
+ * Bordered row card shared by the vault, activity and loan lists. `className`
+ * carries per-surface layout — the vault lifecycle rows pass
+ * `LIST_ROW_MIN_HEIGHT_CLASS`; the single-line lists pass nothing.
+ */
 export function ListRowCard({
   children,
   testId,
+  className = "",
 }: {
   children: ReactNode;
   testId?: string;
+  className?: string;
 }) {
   return (
     <div
       data-testid={testId}
-      className={`${CARD_SHELL_CLASS} ${LIST_ROW_MIN_HEIGHT_CLASS} flex flex-wrap items-center gap-x-4 gap-y-3 p-4`}
+      className={`${CARD_SHELL_CLASS} flex flex-wrap items-center gap-x-4 gap-y-3 p-4 ${className}`}
     >
       {children}
     </div>

--- a/services/vault/src/components/vaults/VaultsActiveSection.tsx
+++ b/services/vault/src/components/vaults/VaultsActiveSection.tsx
@@ -15,7 +15,11 @@ import type { ReactNode } from "react";
 import { ApplicationLogo } from "@/components/ApplicationLogo";
 import { NEUTRAL_ROW_BUTTON_CLASS } from "@/components/shared/buttonClasses";
 import { CopyableHash } from "@/components/shared/CopyableHash";
-import { ListRowCard } from "@/components/shared/ListRow";
+import {
+  LIST_ROW_COLUMN_CLASS,
+  LIST_ROW_LEADING_COLUMN_CLASS,
+  ListRowCard,
+} from "@/components/shared/ListRow";
 import { COPY } from "@/copy";
 import type { CollateralVaultEntry } from "@/types/collateral";
 import { getBtcExplorerTxUrl } from "@/utils/explorer";
@@ -46,7 +50,9 @@ function ActiveVaultRow({
   return (
     <ListRowCard>
       {/* Amount + liquidation ordinal */}
-      <div className="flex w-[180px] shrink-0 items-center gap-2">
+      <div
+        className={`flex items-center gap-2 ${LIST_ROW_LEADING_COLUMN_CLASS}`}
+      >
         <ApplicationLogo
           logoUrl={vault.providerIconUrl ?? null}
           name={vault.providerName}
@@ -67,7 +73,7 @@ function ActiveVaultRow({
       </div>
 
       {/* Status */}
-      <div className="flex w-[180px] shrink-0 items-center">
+      <div className={`flex items-center ${LIST_ROW_COLUMN_CLASS}`}>
         {vault.isActivating ? (
           <span className="flex items-center gap-2 text-sm text-accent-secondary">
             <Loader size={16} />
@@ -90,7 +96,7 @@ function ActiveVaultRow({
       </div>
 
       {/* Provider */}
-      <div className="flex w-[180px] shrink-0 items-center gap-2">
+      <div className={`flex items-center gap-2 ${LIST_ROW_COLUMN_CLASS}`}>
         <ApplicationLogo
           logoUrl={vault.providerIconUrl ?? null}
           name={vault.providerName}
@@ -102,7 +108,9 @@ function ActiveVaultRow({
       </div>
 
       {/* Transaction hash */}
-      <div className="flex min-w-[180px] flex-1 items-center [&_a]:underline">
+      <div
+        className={`flex items-center [&_a]:underline ${LIST_ROW_COLUMN_CLASS}`}
+      >
         {hash && (
           <CopyableHash
             hash={hash}

--- a/services/vault/src/components/vaults/VaultsActiveSection.tsx
+++ b/services/vault/src/components/vaults/VaultsActiveSection.tsx
@@ -16,8 +16,10 @@ import { ApplicationLogo } from "@/components/ApplicationLogo";
 import { NEUTRAL_ROW_BUTTON_CLASS } from "@/components/shared/buttonClasses";
 import { CopyableHash } from "@/components/shared/CopyableHash";
 import {
+  LIST_ROW_ACTION_SLOT_CLASS,
   LIST_ROW_COLUMN_CLASS,
   LIST_ROW_LEADING_COLUMN_CLASS,
+  LIST_ROW_MIN_HEIGHT_CLASS,
   ListRowCard,
 } from "@/components/shared/ListRow";
 import { COPY } from "@/copy";
@@ -48,7 +50,7 @@ function ActiveVaultRow({
   const hash = vault.peginTxHash ?? vault.prePeginTxHash;
 
   return (
-    <ListRowCard>
+    <ListRowCard className={LIST_ROW_MIN_HEIGHT_CLASS}>
       {/* Amount + liquidation ordinal */}
       <div
         className={`flex items-center gap-2 ${LIST_ROW_LEADING_COLUMN_CLASS}`}
@@ -120,19 +122,21 @@ function ActiveVaultRow({
         )}
       </div>
 
-      <button
-        type="button"
-        onClick={() => onWithdraw(vault.vaultId)}
-        disabled={
-          isWithdrawDisabled ||
-          !vault.inUse ||
-          vault.displayOnly ||
-          vault.isActivating
-        }
-        className={NEUTRAL_ROW_BUTTON_CLASS}
-      >
-        {COPY.vaults.actions.withdraw}
-      </button>
+      <div className={LIST_ROW_ACTION_SLOT_CLASS}>
+        <button
+          type="button"
+          onClick={() => onWithdraw(vault.vaultId)}
+          disabled={
+            isWithdrawDisabled ||
+            !vault.inUse ||
+            vault.displayOnly ||
+            vault.isActivating
+          }
+          className={NEUTRAL_ROW_BUTTON_CLASS}
+        >
+          {COPY.vaults.actions.withdraw}
+        </button>
+      </div>
     </ListRowCard>
   );
 }

--- a/services/vault/src/components/vaults/VaultsLifecycleSections.tsx
+++ b/services/vault/src/components/vaults/VaultsLifecycleSections.tsx
@@ -237,34 +237,39 @@ function PendingRow({
         )}
       </div>
 
-      {/* Primary action or details */}
-      {actionStatus.type === "available" ? (
-        // This control's data-testid is a real-wallet E2E hook
-        // (e2e/real/actions/resume.ts) — carry it over if you move or rename
-        // the element. It replaces the v2 pending-deposit card's resume CTA.
-        <button
-          type="button"
-          onClick={() => routeAction(actionStatus.action.action)}
-          className={PRIMARY_ROW_BUTTON_CLASS}
-          data-testid="pending-deposit-resume-cta"
-        >
-          {actionStatus.action.label}
-        </button>
-      ) : actionStatus.type === "disabled" ? (
-        <Hint tooltip={actionStatus.tooltip} attachToChildren>
-          <button type="button" disabled className={NEUTRAL_ROW_BUTTON_CLASS}>
-            {actionStatus.action?.label ?? COPY.vaults.actions.viewDetails}
+      {/* Primary action or details. Pending labels are the widest the rows
+          produce ("Broadcast Pre-Pegin"), which is what the slot's fixed basis
+          is sized to — routing them through it keeps this row's columns level
+          with the Active and Inactive rows. */}
+      <div className={LIST_ROW_ACTION_SLOT_CLASS}>
+        {actionStatus.type === "available" ? (
+          // This control's data-testid is a real-wallet E2E hook
+          // (e2e/real/actions/resume.ts) — carry it over if you move or rename
+          // the element. It replaces the v2 pending-deposit card's resume CTA.
+          <button
+            type="button"
+            onClick={() => routeAction(actionStatus.action.action)}
+            className={PRIMARY_ROW_BUTTON_CLASS}
+            data-testid="pending-deposit-resume-cta"
+          >
+            {actionStatus.action.label}
           </button>
-        </Hint>
-      ) : (
-        <button
-          type="button"
-          onClick={() => onOpenDetails(activity.id)}
-          className={NEUTRAL_ROW_BUTTON_CLASS}
-        >
-          {COPY.vaults.actions.viewDetails}
-        </button>
-      )}
+        ) : actionStatus.type === "disabled" ? (
+          <Hint tooltip={actionStatus.tooltip} attachToChildren>
+            <button type="button" disabled className={NEUTRAL_ROW_BUTTON_CLASS}>
+              {actionStatus.action?.label ?? COPY.vaults.actions.viewDetails}
+            </button>
+          </Hint>
+        ) : (
+          <button
+            type="button"
+            onClick={() => onOpenDetails(activity.id)}
+            className={NEUTRAL_ROW_BUTTON_CLASS}
+          >
+            {COPY.vaults.actions.viewDetails}
+          </button>
+        )}
+      </div>
     </div>
   );
 }
@@ -295,7 +300,7 @@ function InactiveRow({
   const hash = activity.prePeginTxHash ?? activity.peginTxHash;
 
   return (
-    <ListRowCard>
+    <ListRowCard className={LIST_ROW_MIN_HEIGHT_CLASS}>
       {/* Amount + refund maturity */}
       <div
         className={`flex items-center gap-2 ${LIST_ROW_LEADING_COLUMN_CLASS}`}

--- a/services/vault/src/components/vaults/VaultsLifecycleSections.tsx
+++ b/services/vault/src/components/vaults/VaultsLifecycleSections.tsx
@@ -22,7 +22,13 @@ import type { Address, Hex } from "viem";
 import { ApplicationLogo } from "@/components/ApplicationLogo";
 import { getActionStatus } from "@/components/deposit/actionStatus";
 import { CopyableHash } from "@/components/shared/CopyableHash";
-import { ListRowCard } from "@/components/shared/ListRow";
+import {
+  LIST_ROW_ACTION_SLOT_CLASS,
+  LIST_ROW_COLUMN_CLASS,
+  LIST_ROW_LEADING_COLUMN_CLASS,
+  LIST_ROW_MIN_HEIGHT_CLASS,
+  ListRowCard,
+} from "@/components/shared/ListRow";
 import { V3ModalShell } from "@/components/shared/V3ModalShell";
 import {
   NEUTRAL_ROW_BUTTON_CLASS,
@@ -147,9 +153,13 @@ function PendingRow({
   const hash = activity.prePeginTxHash ?? activity.peginTxHash;
 
   return (
-    <div className="flex w-full flex-wrap items-center gap-x-4 gap-y-3 rounded-lg border border-secondary-strokeLight p-4">
+    <div
+      className={`${LIST_ROW_MIN_HEIGHT_CLASS} flex w-full flex-wrap items-center gap-x-4 gap-y-3 rounded-lg border border-secondary-strokeLight p-4`}
+    >
       {/* Amount + step position */}
-      <div className="flex w-[180px] shrink-0 items-center gap-2">
+      <div
+        className={`flex items-center gap-2 ${LIST_ROW_LEADING_COLUMN_CLASS}`}
+      >
         <ApplicationLogo
           logoUrl={provider?.iconUrl ?? null}
           name={providerName}
@@ -171,7 +181,7 @@ function PendingRow({
       </div>
 
       {/* Status + progress */}
-      <div className="flex w-[180px] shrink-0 flex-col gap-1">
+      <div className={`flex flex-col gap-1 ${LIST_ROW_COLUMN_CLASS}`}>
         {peginState ? (
           <span className="flex items-center gap-1">
             <span
@@ -203,7 +213,7 @@ function PendingRow({
       </div>
 
       {/* Provider */}
-      <div className="flex w-[180px] shrink-0 items-center gap-2">
+      <div className={`flex items-center gap-2 ${LIST_ROW_COLUMN_CLASS}`}>
         <ApplicationLogo
           logoUrl={provider?.iconUrl ?? null}
           name={providerName}
@@ -215,7 +225,9 @@ function PendingRow({
       </div>
 
       {/* Transaction hash */}
-      <div className="flex min-w-[180px] flex-1 items-center [&_a]:underline">
+      <div
+        className={`flex items-center [&_a]:underline ${LIST_ROW_COLUMN_CLASS}`}
+      >
         {hash && (
           <CopyableHash
             hash={hash}
@@ -285,7 +297,9 @@ function InactiveRow({
   return (
     <ListRowCard>
       {/* Amount + refund maturity */}
-      <div className="flex w-[180px] shrink-0 items-center gap-2">
+      <div
+        className={`flex items-center gap-2 ${LIST_ROW_LEADING_COLUMN_CLASS}`}
+      >
         <ApplicationLogo
           logoUrl={provider?.iconUrl ?? null}
           name={providerName}
@@ -302,7 +316,7 @@ function InactiveRow({
       </div>
 
       {/* Status */}
-      <div className="flex w-[180px] shrink-0 items-center">
+      <div className={`flex items-center ${LIST_ROW_COLUMN_CLASS}`}>
         {peginState ? (
           <span className="flex items-center gap-1">
             <span
@@ -324,7 +338,7 @@ function InactiveRow({
       </div>
 
       {/* Provider */}
-      <div className="flex w-[180px] shrink-0 items-center gap-2">
+      <div className={`flex items-center gap-2 ${LIST_ROW_COLUMN_CLASS}`}>
         <ApplicationLogo
           logoUrl={provider?.iconUrl ?? null}
           name={providerName}
@@ -336,7 +350,9 @@ function InactiveRow({
       </div>
 
       {/* Transaction hash */}
-      <div className="flex min-w-[180px] flex-1 items-center [&_a]:underline">
+      <div
+        className={`flex items-center [&_a]:underline ${LIST_ROW_COLUMN_CLASS}`}
+      >
         {hash && (
           <CopyableHash
             hash={hash}
@@ -346,22 +362,26 @@ function InactiveRow({
         )}
       </div>
 
-      {isRefundAvailable && (
-        <button
-          type="button"
-          onClick={() => onRefund(activity.id)}
-          className={PRIMARY_ROW_BUTTON_CLASS}
-        >
-          {COPY.vaults.actions.withdraw}
-        </button>
-      )}
-      {blockedTooltip && (
-        <Hint tooltip={blockedTooltip} attachToChildren>
-          <button type="button" disabled className={NEUTRAL_ROW_BUTTON_CLASS}>
+      {/* Reserved even when the refund is neither available nor blocked, so an
+          actionless row still aligns with the rows that carry a button. */}
+      <div className={LIST_ROW_ACTION_SLOT_CLASS}>
+        {isRefundAvailable && (
+          <button
+            type="button"
+            onClick={() => onRefund(activity.id)}
+            className={PRIMARY_ROW_BUTTON_CLASS}
+          >
             {COPY.vaults.actions.withdraw}
           </button>
-        </Hint>
-      )}
+        )}
+        {blockedTooltip && (
+          <Hint tooltip={blockedTooltip} attachToChildren>
+            <button type="button" disabled className={NEUTRAL_ROW_BUTTON_CLASS}>
+              {COPY.vaults.actions.withdraw}
+            </button>
+          </Hint>
+        )}
+      </div>
     </ListRowCard>
   );
 }

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -152,6 +152,9 @@ export const COPY = {
         "Refund transaction has been broadcast to Bitcoin. Waiting for on-chain confirmation...",
       refundComplete:
         "Your refund has been confirmed on Bitcoin. The locked BTC has returned to your wallet.",
+      // Longest sub-line the lifecycle rows render, so it sizes
+      // LIST_ROW_LEADING_COLUMN_CLASS's basis (components/shared/ListRow.tsx).
+      // Lengthening it here ellipses that cell unless the basis moves too.
       refundMaturing: (blocks: number, hours: number) =>
         `Your refund will be claimable in ~${blocks} Bitcoin ${blocks === 1 ? "block" : "blocks"} (~${hours}h).`,
       refundMaturingUnknown: "Checking when your refund will be claimable...",


### PR DESCRIPTION

<img width="1211" height="468" alt="Screenshot 2026-08-06 at 03 34 08" src="https://github.com/user-attachments/assets/86976d42-f730-43dc-87f6-e08a5fe656db" />


## What

The rows on the Vaults page — Pending Deposit, Active Vaults and Inactive Vaults — now read as one table. Before this, each row sized itself independently, so:

- Rows sat at slightly different heights.
- Columns started at different places from one row to the next, so "Pending", "Available" and "Expired" did not line up down the page.
- The refund notice on an inactive vault was cut off mid-sentence with an ellipsis.
- A large gap opened up between the last column and the button on the right.
- The round provider logo was squeezed into an oval whenever the text next to it ran long.

The Activity page rows had the same spacing problem and are included.

## Why

All five symptoms came from how the row shared out its width. Four of the five cells were pinned to a fixed size and only one was allowed to stretch, so every spare pixel piled into that single cell — which is where the empty gap came from. The text next to the logo had nowhere to go, so the browser shrank the logo instead. And because a row without a button did not reserve the button's space, its columns slid left and stopped matching its neighbours.

## How

Every cell now stretches, so spare width is shared out along the row rather than collecting in one place.

The first cell, which holds the amount and the line beneath it, is given enough room for the longest message these rows can show — measured in the app at its real font size rather than guessed. That sentence now reads in full.

Rows share a minimum height so they stand level, and a row whose button only appears in certain states reserves that space regardless, keeping its columns aligned with the rest. The logo is no longer allowed to shrink.

Rows stay on a single line down to 1366px wide. Below that they wrap onto two lines, as they already did on narrow screens, rather than cramming the content.

## Testing

Checked in the running app at 1366, 1440 and 1512 wide, measuring the live page rather than eyeballing it: row heights identical, column positions identical across all three sections, no cut-off text, and every logo perfectly round. Lint and typecheck clean; the full vault suite passes (3042 tests).