### PR TITLE
feat(vault): borrow rate history and interest rate model charts

### DIFF
--- a/packages/babylon-core-ui/src/components/LineChart/LineChart.tsx
+++ b/packages/babylon-core-ui/src/components/LineChart/LineChart.tsx
@@ -6,12 +6,7 @@ import { Bar, Line } from "@visx/shape";
 import { Text } from "@visx/text";
 import { twJoin } from "tailwind-merge";
 import "./LineChart.css";
-import {
-  AXIS_LABEL_GAP_PX,
-  TEXT_LINE_HEIGHT,
-  X_AXIS_MARGIN_TOP_PX,
-  useChartLayout,
-} from "../charts/chartLayout";
+import { TEXT_LINE_HEIGHT, X_AXIS_MARGIN_TOP_PX, useChartLayout } from "../charts/chartLayout";
 import { AXIS_LETTER_SPACING_PX, chartFont, measureText } from "../charts/textMeasure";
 import { layoutCallouts, type CalloutBox } from "./calloutLayout";
 import { buildLinePath, fitDomain, nearestIndex, normalizeSeries, valueAtX } from "./lineSeries";
@@ -72,11 +67,15 @@ export function LineChart({
 }: LineChartProps) {
   const series = useMemo(() => normalizeSeries(data), [data]);
   const hasXAxis = Boolean(xTicks?.length);
+  // Passed even when empty so the gutter is measured from the actual labels
+  // (flush-left column) rather than the fluid clamp other chart families use.
+  const yAxisLabels = useMemo(() => yTicks?.map((tick) => tick.label) ?? [], [yTicks]);
   const { parentRef, layout, collapsed } = useChartLayout({
     axisSide: "left",
     hasTopLegend: false,
     hasXAxis,
     aspectRatio,
+    yAxisLabels,
   });
 
   const resolvedXDomain = useMemo(() => xDomain ?? fitDomain(series.map((p) => p.x)), [xDomain, series]);
@@ -301,9 +300,9 @@ export function LineChart({
             <Text
               key={`y-${tick.value}`}
               className="bbn-line-chart__axis-text"
-              x={layout.gutter - AXIS_LABEL_GAP_PX}
+              x={0}
               y={layout.plotTop + yScale(tick.value)}
-              textAnchor="end"
+              textAnchor="start"
               verticalAnchor="middle"
               fontSize={layout.fontAxis}
               aria-hidden

--- a/packages/babylon-core-ui/src/components/LineChart/__tests__/LineChart.test.tsx
+++ b/packages/babylon-core-ui/src/components/LineChart/__tests__/LineChart.test.tsx
@@ -1,13 +1,23 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import { DEFAULT_PLOT_ASPECT_RATIO } from "../../charts/chartLayout";
+import { DEFAULT_PLOT_ASPECT_RATIO, Y_AXIS_LABEL_PLOT_GAP_PX } from "../../charts/chartLayout";
+import { AXIS_LETTER_SPACING_PX } from "../../charts/textMeasure";
 import { LineChart } from "../LineChart";
 import type { LineChartHover, LineChartProps } from "../types";
 
 // The chart renders from the deterministic fallback width (see setup.ts):
-// chartWidth 1016 → gutter 68, plotWidth 948. jsdom reports a zeroed client
-// rect for the hit area, so clientX reads straight through as the plot-local x.
-const PLOT_WIDTH = 948;
+// chartWidth 1016. None of the tests below pass yTicks, so the y-axis label
+// column is empty and the gutter collapses to 0 (see chartLayout.ts) — the
+// plot spans the full chart width. jsdom reports a zeroed client rect for the
+// hit area, so clientX reads straight through as the plot-local x.
+const PLOT_WIDTH = 1016;
+
+// jsdom has no canvas backend; the test canvas stub in setup.ts measures text
+// at a fixed 7px per character so gutter-sizing assertions stay exact.
+const TEST_CHAR_WIDTH_PX = 7;
+function measuredLabelWidth(label: string): number {
+  return label.length * TEST_CHAR_WIDTH_PX + label.length * AXIS_LETTER_SPACING_PX;
+}
 
 const series = [
   { x: 0, y: 0 },
@@ -25,7 +35,7 @@ function hitArea() {
 
 /** Pointer at `px` from the plot's left edge. Whole pixels only — jsdom
  * coerces MouseEvent coordinates to integers. With an x domain of [0, 100]
- * over 948px, the quarter marks 237 / 474 / 711 land on 25 / 50 / 75. */
+ * over 1016px, the quarter marks 254 / 508 / 762 land on 25 / 50 / 75. */
 function hoverAt(px: number) {
   fireEvent.pointerMove(hitArea(), { clientX: px });
 }
@@ -48,7 +58,7 @@ describe("LineChart", () => {
     const onHoverChange = vi.fn<(hover: LineChartHover | null) => void>();
     renderChart({ onHoverChange });
 
-    hoverAt(237);
+    hoverAt(254);
 
     const hover = onHoverChange.mock.calls.at(-1)?.[0];
     expect(hover?.x).toBeCloseTo(25, 5);
@@ -59,7 +69,7 @@ describe("LineChart", () => {
     const onHoverChange = vi.fn<(hover: LineChartHover | null) => void>();
     renderChart({ hoverMode: "nearest", onHoverChange });
 
-    hoverAt(237);
+    hoverAt(254);
 
     expect(onHoverChange.mock.calls.at(-1)?.[0]).toMatchObject({ x: 0, y: 0, index: 0 });
   });
@@ -68,7 +78,7 @@ describe("LineChart", () => {
     const onHoverChange = vi.fn<(hover: LineChartHover | null) => void>();
     renderChart({ onHoverChange });
 
-    hoverAt(711);
+    hoverAt(762);
 
     const hover = onHoverChange.mock.calls.at(-1)?.[0];
     expect(hover?.point).toEqual({ x: 50, y: 10 });
@@ -79,7 +89,7 @@ describe("LineChart", () => {
     const onHoverChange = vi.fn<(hover: LineChartHover | null) => void>();
     renderChart({ onHoverChange });
 
-    hoverAt(474);
+    hoverAt(508);
     fireEvent.pointerLeave(hitArea(), { pointerType: "mouse" });
 
     expect(onHoverChange).toHaveBeenLastCalledWith(null);
@@ -89,7 +99,7 @@ describe("LineChart", () => {
     const onHoverChange = vi.fn<(hover: LineChartHover | null) => void>();
     renderChart({ onHoverChange });
 
-    fireEvent.pointerDown(hitArea(), { clientX: 474, pointerType: "touch" });
+    fireEvent.pointerDown(hitArea(), { clientX: 508, pointerType: "touch" });
 
     expect(onHoverChange.mock.calls.at(-1)?.[0]?.x).toBeCloseTo(50, 5);
   });
@@ -100,8 +110,8 @@ describe("LineChart", () => {
     const onHoverChange = vi.fn<(hover: LineChartHover | null) => void>();
     renderChart({ onHoverChange });
 
-    fireEvent.pointerDown(hitArea(), { clientX: 474, pointerType: "touch" });
-    fireEvent.pointerUp(hitArea(), { clientX: 474, pointerType: "touch" });
+    fireEvent.pointerDown(hitArea(), { clientX: 508, pointerType: "touch" });
+    fireEvent.pointerUp(hitArea(), { clientX: 508, pointerType: "touch" });
     fireEvent.pointerLeave(hitArea(), { pointerType: "touch" });
 
     expect(onHoverChange.mock.calls.at(-1)?.[0]?.x).toBeCloseTo(50, 5);
@@ -111,9 +121,9 @@ describe("LineChart", () => {
     const onHoverChange = vi.fn<(hover: LineChartHover | null) => void>();
     renderChart({ onHoverChange });
 
-    fireEvent.pointerDown(hitArea(), { clientX: 237, pointerType: "touch" });
+    fireEvent.pointerDown(hitArea(), { clientX: 254, pointerType: "touch" });
     fireEvent.pointerLeave(hitArea(), { pointerType: "touch" });
-    fireEvent.pointerDown(hitArea(), { clientX: 711, pointerType: "touch" });
+    fireEvent.pointerDown(hitArea(), { clientX: 762, pointerType: "touch" });
 
     expect(onHoverChange.mock.calls.at(-1)?.[0]?.x).toBeCloseTo(75, 5);
   });
@@ -122,7 +132,7 @@ describe("LineChart", () => {
     const onHoverChange = vi.fn<(hover: LineChartHover | null) => void>();
     renderChart({ onHoverChange });
 
-    fireEvent.pointerDown(hitArea(), { clientX: 474, pointerType: "touch" });
+    fireEvent.pointerDown(hitArea(), { clientX: 508, pointerType: "touch" });
     fireEvent.pointerCancel(hitArea(), { pointerType: "touch" });
 
     expect(onHoverChange).toHaveBeenLastCalledWith(null);
@@ -131,7 +141,7 @@ describe("LineChart", () => {
   it("renders the caller's tooltip for the hovered position", () => {
     renderChart({ renderTooltip: (hover) => <span>{`value ${hover.y.toFixed(1)}`}</span> });
 
-    hoverAt(474);
+    hoverAt(508);
 
     expect(screen.getByText("value 10.0")).toBeInTheDocument();
   });
@@ -185,5 +195,45 @@ describe("LineChart", () => {
   it("renders an empty series without crashing", () => {
     const { container } = render(<LineChart data={[]} />);
     expect(container.querySelector(".bbn-line-chart__series")?.getAttribute("d")).toBe("");
+  });
+
+  it("left-aligns y-axis tick labels flush with the chart's left edge", () => {
+    const { container } = renderChart({
+      yTicks: [{ value: 0, label: "0%" }, { value: 30, label: "30%" }],
+    });
+
+    // No xTicks in this render, so every `.bbn-line-chart__axis-text` is a
+    // y-axis label.
+    const axisTexts = Array.from(container.querySelectorAll(".bbn-line-chart__axis-text"));
+    expect(axisTexts).toHaveLength(2);
+    for (const text of axisTexts) {
+      expect(text).toHaveAttribute("x", "0");
+      expect(text).toHaveAttribute("text-anchor", "start");
+    }
+  });
+
+  it("sizes the gutter to the widest y-axis label plus the fixed label-to-plot gap", () => {
+    const widestLabel = "100.0%";
+    const { container } = renderChart({
+      yTicks: [{ value: 0, label: "0%" }, { value: 100, label: widestLabel }],
+    });
+
+    const expectedGutter = measuredLabelWidth(widestLabel) + Y_AXIS_LABEL_PLOT_GAP_PX;
+
+    // The plot's <Group left={layout.plotLeft}> — axisSide "left" puts
+    // plotLeft at the gutter — renders as an SVG translate.
+    const plotGroup = container.querySelector("g.visx-group");
+    const translateLeft = Number(plotGroup?.getAttribute("transform")?.match(/translate\(([\d.]+),/)?.[1]);
+    expect(translateLeft).toBeCloseTo(expectedGutter, 5);
+
+    expect(Number(hitArea().getAttribute("width"))).toBeCloseTo(1016 - expectedGutter, 5);
+  });
+
+  it("collapses the gutter to zero and spans the full width when yTicks is empty", () => {
+    const { container } = renderChart({ yTicks: [] });
+
+    const plotGroup = container.querySelector("g.visx-group");
+    expect(plotGroup?.getAttribute("transform")).toBe("translate(0, 0)");
+    expect(Number(hitArea().getAttribute("width"))).toBe(1016);
   });
 });

--- a/packages/babylon-core-ui/src/components/charts/__tests__/chartLayout.test.ts
+++ b/packages/babylon-core-ui/src/components/charts/__tests__/chartLayout.test.ts
@@ -56,6 +56,35 @@ describe("computeChartLayout", () => {
     expect(layout.plotWidth).toBe(948);
   });
 
+  it("replaces the fluid gutter with gutterPx when provided", () => {
+    const layout = computeChartLayout({
+      chartWidth: 1016,
+      axisSide: "left",
+      hasTopLegend: false,
+      hasXAxis: false,
+      gutterPx: 100,
+    });
+    // The fluid clamp would give 68 here (see the 1016px reference test above);
+    // an explicit gutterPx overrides it and everything derived follows.
+    expect(layout.gutter).toBe(100);
+    expect(layout.plotLeft).toBe(100);
+    expect(layout.plotWidth).toBe(916);
+    expect(layout.plotHeight).toBeCloseTo((916 * 350) / 1016, 6);
+  });
+
+  it("spans the full chart width when gutterPx is 0 (no y-axis label column)", () => {
+    const layout = computeChartLayout({
+      chartWidth: 1016,
+      axisSide: "left",
+      hasTopLegend: false,
+      hasXAxis: false,
+      gutterPx: 0,
+    });
+    expect(layout.gutter).toBe(0);
+    expect(layout.plotLeft).toBe(0);
+    expect(layout.plotWidth).toBe(1016);
+  });
+
   it("reserves vertical space for the legend and x-axis only when present", () => {
     const bare = computeChartLayout({ chartWidth: 1016, axisSide: "left", hasTopLegend: false, hasXAxis: false });
     const withLegend = computeChartLayout({ chartWidth: 1016, axisSide: "left", hasTopLegend: true, hasXAxis: false });

--- a/packages/babylon-core-ui/src/components/charts/chartLayout.ts
+++ b/packages/babylon-core-ui/src/components/charts/chartLayout.ts
@@ -7,7 +7,7 @@
 
 import { useMemo, useSyncExternalStore } from "react";
 import { useParentSize } from "@visx/responsive";
-import { getFontEpoch, subscribeFontEpoch } from "./textMeasure";
+import { AXIS_LETTER_SPACING_PX, chartFont, getFontEpoch, measureText, subscribeFontEpoch } from "./textMeasure";
 
 /** The plot's default aspect ratio (was `aspect-ratio: 1016 / 350`). */
 export const DEFAULT_PLOT_ASPECT_RATIO = 1016 / 350;
@@ -50,6 +50,27 @@ export const X_AXIS_MARGIN_TOP_PX = 6; // xaxis margin-top 0.375rem
 const LEGEND_PAD_Y_PX = 6; // legend-seg padding 0.375rem
 const LEGEND_MARGIN_BOTTOM_PX = 12; // top-legend margin-bottom 0.75rem
 
+/** Figma frames' `gap-[24px]` between the flush-left y-axis label column and
+ * the plot (see {@link measureYAxisGutter}). */
+export const Y_AXIS_LABEL_PLOT_GAP_PX = 24;
+
+/** The y-axis font size a given chart width implies. Shared by the fluid
+ * layout and the measured-gutter path so both agree on what size the tick
+ * labels actually render at. */
+function resolveAxisFontPx(chartWidth: number): number {
+  return resolveFluid(FONT_AXIS, chartWidth, rootFontPx());
+}
+
+/** Measures the flush-left y-axis label column: the widest tick label at this
+ * chart's axis font size, plus {@link Y_AXIS_LABEL_PLOT_GAP_PX}. No labels
+ * means no column — the plot spans the full chart width. */
+function measureYAxisGutter(chartWidth: number, labels: readonly string[]): number {
+  if (labels.length === 0) return 0;
+  const font = chartFont(resolveAxisFontPx(chartWidth));
+  const widest = Math.max(...labels.map((label) => measureText(label, font, AXIS_LETTER_SPACING_PX)));
+  return widest + Y_AXIS_LABEL_PLOT_GAP_PX;
+}
+
 /** Approximates a `line-height: normal` line box for Px Grotesk. */
 export const TEXT_LINE_HEIGHT = 1.2;
 
@@ -74,11 +95,14 @@ export function computeChartLayout(input: {
   hasXAxis: boolean;
   /** Plot width / plot height. Defaults to {@link DEFAULT_PLOT_ASPECT_RATIO}. */
   aspectRatio?: number;
+  /** Replaces the fluid gutter clamp when provided (see
+   * {@link measureYAxisGutter}); absent keeps the fluid clamp. */
+  gutterPx?: number;
 }): ChartLayout {
-  const { chartWidth, axisSide, hasTopLegend, hasXAxis, aspectRatio = DEFAULT_PLOT_ASPECT_RATIO } = input;
+  const { chartWidth, axisSide, hasTopLegend, hasXAxis, aspectRatio = DEFAULT_PLOT_ASPECT_RATIO, gutterPx } = input;
   const remPx = rootFontPx();
-  const gutter = resolveFluid(GUTTER, chartWidth, remPx);
-  const fontAxis = resolveFluid(FONT_AXIS, chartWidth, remPx);
+  const gutter = gutterPx ?? resolveFluid(GUTTER, chartWidth, remPx);
+  const fontAxis = resolveAxisFontPx(chartWidth);
   const fontLabel = resolveFluid(FONT_LABEL, chartWidth, remPx);
   const fontAmount = resolveFluid(FONT_AMOUNT, chartWidth, remPx);
 
@@ -115,6 +139,11 @@ export function useChartLayout(input: {
   hasTopLegend: boolean;
   hasXAxis: boolean;
   aspectRatio?: number;
+  /** y-axis tick label text. When provided (even as an empty array), the
+   * gutter is measured from these labels instead of the fluid clamp — pass
+   * `undefined` to keep the fluid gutter (the default for charts that don't
+   * render a flush-left label column). */
+  yAxisLabels?: readonly string[];
 }): {
   parentRef: (node: HTMLDivElement | null) => void;
   layout: ChartLayout;
@@ -126,18 +155,21 @@ export function useChartLayout(input: {
     initialSize: { width: FALLBACK_CHART_WIDTH_PX },
   });
   // Re-render when a webfont finishes loading so text measured against the
-  // fallback font is redone with the real metrics (see textMeasure.ts).
-  useSyncExternalStore(subscribeFontEpoch, getFontEpoch, getFontEpoch);
+  // fallback font is redone with the real metrics (see textMeasure.ts). The
+  // epoch is also a dependency of the layout memo below: measureYAxisGutter
+  // reads measureText, whose cache the font load invalidates outside React's
+  // dependency tracking.
+  const fontEpoch = useSyncExternalStore(subscribeFontEpoch, getFontEpoch, getFontEpoch);
   // `width` starts at the fallback (initialSize) and only becomes 0 when the
   // ResizeObserver reports a genuinely collapsed container — hidden tab,
   // zero-width flex child. Rendering the fallback there would paint a 1016px
   // chart across the siblings (the SVG overflows visibly), so collapse instead.
   const collapsed = width <= 0;
   const chartWidth = collapsed ? FALLBACK_CHART_WIDTH_PX : width;
-  const { axisSide, hasTopLegend, hasXAxis, aspectRatio } = input;
-  const layout = useMemo(
-    () => computeChartLayout({ chartWidth, axisSide, hasTopLegend, hasXAxis, aspectRatio }),
-    [chartWidth, axisSide, hasTopLegend, hasXAxis, aspectRatio],
-  );
+  const { axisSide, hasTopLegend, hasXAxis, aspectRatio, yAxisLabels } = input;
+  const layout = useMemo(() => {
+    const gutterPx = yAxisLabels === undefined ? undefined : measureYAxisGutter(chartWidth, yAxisLabels);
+    return computeChartLayout({ chartWidth, axisSide, hasTopLegend, hasXAxis, aspectRatio, gutterPx });
+  }, [chartWidth, axisSide, hasTopLegend, hasXAxis, aspectRatio, yAxisLabels, fontEpoch]);
   return { parentRef, layout, collapsed };
 }

--- a/services/vault/src/applications/aave/clients/__tests__/aaveIrm.test.ts
+++ b/services/vault/src/applications/aave/clients/__tests__/aaveIrm.test.ts
@@ -1,0 +1,309 @@
+import type { Address } from "viem";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getInterestRateModelCurveSafe } from "../aaveIrm";
+
+// vitest hoists vi.mock above imports; the factory closes over `multicall`,
+// which is initialized before the mocked module is first imported.
+const multicall = vi.fn();
+vi.mock("../../../../clients/eth-contract/client", () => ({
+  ethClient: { getPublicClient: () => ({ multicall }) },
+}));
+
+// aaveHub.ts (whose ABI fragments/helpers this client reuses) imports the SDK
+// rate read; stub it so the module loads without pulling the real package in.
+vi.mock("@babylonlabs-io/ts-sdk/tbv/integrations/aave", () => ({
+  getAssetDrawnRatesSafe: vi.fn(),
+}));
+
+const HUB = "0x0000000000000000000000000000000000000003" as Address;
+const IRM = "0x0000000000000000000000000000000000000004" as Address;
+const RAY = 10n ** 27n;
+
+const PARAMS = {
+  optimalUsageBps: 9000n, // 90%
+  baseDrawnRateBps: 0n,
+  rateGrowthBeforeOptimalBps: 400n, // +4%
+  rateGrowthAfterOptimalBps: 6000n, // +60%
+};
+
+/**
+ * Faithful float port of the on-chain kinked rate model
+ * (AssetInterestRateStrategy.calculateInterestRate), used to give the mocked
+ * Hub a realistic rate curve. Usage is `drawn / (liquidity + drawn + swept)`.
+ */
+function modelRateRay(liquidity: bigint, drawn: bigint, swept: bigint): bigint {
+  const denom = liquidity + drawn + swept;
+  const usage = denom === 0n ? 0 : Number(drawn) / Number(denom);
+  const optimal = Number(PARAMS.optimalUsageBps) / 10_000;
+  const base = Number(PARAMS.baseDrawnRateBps) / 10_000;
+  const growthBefore = Number(PARAMS.rateGrowthBeforeOptimalBps) / 10_000;
+  const growthAfter = Number(PARAMS.rateGrowthAfterOptimalBps) / 10_000;
+  const rate =
+    usage <= optimal
+      ? base + (growthBefore * usage) / optimal
+      : base + growthBefore + (growthAfter * (usage - optimal)) / (1 - optimal);
+  return BigInt(Math.round(rate * Number(RAY)));
+}
+
+/**
+ * Mock Hub + strategy: round 1 returns totals + config, round 2 returns the
+ * kink/rate-shape data, round 3 answers `calculateInterestRate` from whatever
+ * (liquidity, drawn, swept) args it is handed, so the test verifies the
+ * per-sample args the reader builds rather than hardcoding expected rates.
+ */
+function setupHub(
+  totals: {
+    liquidity: bigint;
+    drawn: bigint;
+    swept: bigint;
+    deficitRay?: bigint;
+  },
+  opts: {
+    totalsRevert?: boolean;
+    rateDataRevert?: boolean;
+    curveLegRevertAt?: number;
+    /** Overrides the strategy's optimalUsageRatio (e.g. a RAY-scaled value). */
+    optimalUsageOverride?: bigint;
+    /** Added to every curve leg's rate — simulates a deficit contribution. */
+    rateBumpRay?: bigint;
+  } = {},
+) {
+  multicall.mockImplementation(
+    async ({
+      contracts,
+    }: {
+      contracts: { functionName: string; args: unknown[] }[];
+    }) => {
+      if (contracts[0].functionName === "getAssetLiquidity") {
+        return [
+          opts.totalsRevert
+            ? { status: "failure", error: new Error("reverted") }
+            : { status: "success", result: totals.liquidity },
+          { status: "success", result: [totals.drawn, 0n] },
+          { status: "success", result: totals.swept },
+          { status: "success", result: totals.deficitRay ?? 0n },
+          { status: "success", result: { irStrategy: IRM } },
+        ];
+      }
+      if (contracts[0].functionName === "getInterestRateData") {
+        return [
+          opts.rateDataRevert
+            ? { status: "failure", error: new Error("reverted") }
+            : {
+                status: "success",
+                result: {
+                  optimalUsageRatio:
+                    opts.optimalUsageOverride ?? PARAMS.optimalUsageBps,
+                  baseDrawnRate: PARAMS.baseDrawnRateBps,
+                  rateGrowthBeforeOptimal: PARAMS.rateGrowthBeforeOptimalBps,
+                  rateGrowthAfterOptimal: PARAMS.rateGrowthAfterOptimalBps,
+                },
+              },
+        ];
+      }
+      // Round 3: rate at each (liquidity, drawn, swept) tuple.
+      return contracts.map((c, i) => {
+        if (opts.curveLegRevertAt === i) {
+          return { status: "failure", error: new Error("reverted") };
+        }
+        const [, liquidity, drawn, , swept] = c.args as [
+          bigint,
+          bigint,
+          bigint,
+          bigint,
+          bigint,
+        ];
+        return {
+          status: "success",
+          result:
+            modelRateRay(liquidity, drawn, swept) + (opts.rateBumpRay ?? 0n),
+        };
+      });
+    },
+  );
+}
+
+describe("getInterestRateModelCurveSafe", () => {
+  beforeEach(() => {
+    multicall.mockReset();
+  });
+
+  it("samples every non-current leg as a T-invariant split with swept'=0", async () => {
+    setupHub({ liquidity: 600n, drawn: 400n, swept: 7n });
+
+    const out = await getInterestRateModelCurveSafe({ hub: HUB, assetId: 5 });
+
+    expect(out.error).toBeNull();
+    expect(out.curve).not.toBeNull();
+
+    const total = 600n + 400n + 7n;
+    const curveCall = multicall.mock.calls.find(
+      (c) => c[0].contracts[0].functionName === "calculateInterestRate",
+    )!;
+    const legs = curveCall[0].contracts as { args: readonly bigint[] }[];
+    // Current utilization is 400/1007 ≈ 39.72%, its own extra sample distinct
+    // from every 5%-spaced point and the kink. Exclude that one leg (verbatim
+    // live totals, checked separately below) — every other leg must be a
+    // synthetic T-invariant split.
+    const nonCurrentLegs = legs.filter(
+      (leg) =>
+        !(leg.args[1] === 600n && leg.args[2] === 400n && leg.args[4] === 7n),
+    );
+    expect(nonCurrentLegs.length).toBe(legs.length - 1);
+    for (const leg of nonCurrentLegs) {
+      const [, liquidity, drawn, , swept] = leg.args;
+      expect(liquidity + drawn).toBe(total);
+      expect(swept).toBe(0n);
+    }
+  });
+
+  it("passes the live totals verbatim for the current-utilization leg", async () => {
+    setupHub({ liquidity: 600n, drawn: 400n, swept: 7n });
+
+    await getInterestRateModelCurveSafe({ hub: HUB, assetId: 5 });
+
+    const curveCall = multicall.mock.calls.find(
+      (c) => c[0].contracts[0].functionName === "calculateInterestRate",
+    )!;
+    const legs = curveCall[0].contracts as {
+      args: readonly [bigint, bigint, bigint, bigint, bigint];
+    }[];
+    const currentLeg = legs.find(
+      (leg) =>
+        leg.args[1] === 600n && leg.args[2] === 400n && leg.args[4] === 7n,
+    );
+    expect(currentLeg).toBeDefined();
+  });
+
+  it("includes the exact kink and current utilizations exactly once each", async () => {
+    // liquidity+drawn+swept = 1000, drawn = 900 -> current usage = 90.0%,
+    // exactly the configured kink (90%) -> both land on the same sample.
+    setupHub({ liquidity: 100n, drawn: 900n, swept: 0n });
+
+    await getInterestRateModelCurveSafe({ hub: HUB, assetId: 5 });
+
+    const curveCall = multicall.mock.calls.find(
+      (c) => c[0].contracts[0].functionName === "calculateInterestRate",
+    )!;
+    const utilizations = (
+      curveCall[0].contracts as { args: readonly bigint[] }[]
+    ).map((c) => c.args[2]); // drawn' for each leg
+    const at900 = utilizations.filter((d) => d === 900n);
+    expect(at900).toHaveLength(1);
+  });
+
+  it("returns the curve sorted ascending by utilization", async () => {
+    setupHub({ liquidity: 700n, drawn: 300n, swept: 0n });
+
+    const out = await getInterestRateModelCurveSafe({ hub: HUB, assetId: 5 });
+
+    const utilizations = out.curve!.map((p) => p.utilizationPercent);
+    const sorted = [...utilizations].sort((a, b) => a - b);
+    expect(utilizations).toEqual(sorted);
+    // Strictly ascending: no duplicate sample survives dedup.
+    expect(new Set(utilizations).size).toBe(utilizations.length);
+  });
+
+  it("nulls the whole result when a curve leg reverts", async () => {
+    setupHub(
+      { liquidity: 600n, drawn: 400n, swept: 0n },
+      { curveLegRevertAt: 3 },
+    );
+
+    const out = await getInterestRateModelCurveSafe({ hub: HUB, assetId: 5 });
+
+    expect(out).toEqual({
+      curve: null,
+      kinkUtilizationPercent: null,
+      currentUtilizationPercent: null,
+      currentAprPercent: null,
+      maxAprPercent: null,
+      error: expect.any(Error),
+    });
+  });
+
+  it("nulls the whole result when the totals read reverts", async () => {
+    setupHub(
+      { liquidity: 600n, drawn: 400n, swept: 0n },
+      { totalsRevert: true },
+    );
+
+    const out = await getInterestRateModelCurveSafe({ hub: HUB, assetId: 5 });
+
+    expect(out.curve).toBeNull();
+    expect(out.error).toBeInstanceOf(Error);
+    // Only the totals multicall ran; no rate-data or curve multicall.
+    expect(multicall).toHaveBeenCalledTimes(1);
+  });
+
+  it("nulls the whole result when getInterestRateData reverts", async () => {
+    setupHub(
+      { liquidity: 600n, drawn: 400n, swept: 0n },
+      { rateDataRevert: true },
+    );
+
+    const out = await getInterestRateModelCurveSafe({ hub: HUB, assetId: 5 });
+
+    expect(out.curve).toBeNull();
+    expect(out.kinkUtilizationPercent).toBeNull();
+    expect(out.error).toBeInstanceOf(Error);
+    // No curve multicall issued once the rate-data leg fails.
+    expect(multicall).toHaveBeenCalledTimes(2);
+  });
+
+  it("never throws on a network-level multicall failure", async () => {
+    multicall.mockRejectedValue(new Error("RPC timeout"));
+
+    const out = await getInterestRateModelCurveSafe({ hub: HUB, assetId: 5 });
+
+    expect(out.curve).toBeNull();
+    expect(out.error).toBeInstanceOf(Error);
+  });
+
+  it("nulls the whole result when the strategy's optimalUsageRatio exceeds the BPS scale", async () => {
+    // A RAY-scaled ratio (nothing at decode time rules it out — the ABI is
+    // four bare uint256s) must fail with a named error, not surface as an
+    // opaque viem encoding throw from negative sample liquidity.
+    setupHub(
+      { liquidity: 600n, drawn: 400n, swept: 0n },
+      { optimalUsageOverride: 9n * 10n ** 26n },
+    );
+
+    const out = await getInterestRateModelCurveSafe({ hub: HUB, assetId: 5 });
+
+    expect(out.curve).toBeNull();
+    expect(out.error?.message).toMatch(/optimalUsageRatio/);
+    // No curve multicall issued once the kink fails validation.
+    expect(multicall).toHaveBeenCalledTimes(2);
+  });
+
+  it("raises maxAprPercent to the sampled ceiling when the deficit pushes the curve above the shape max", async () => {
+    // Every sampled leg carries the live deficit; a strategy that charges for
+    // it can exceed base+growthBefore+growthAfter (64% here). +1% on every
+    // leg puts the top sample at 65% — the reported ceiling must follow, or
+    // the consumer's y domain sits below the curve.
+    setupHub(
+      { liquidity: 600n, drawn: 400n, swept: 0n },
+      { rateBumpRay: RAY / 100n },
+    );
+
+    const out = await getInterestRateModelCurveSafe({ hub: HUB, assetId: 5 });
+
+    expect(out.error).toBeNull();
+    expect(out.maxAprPercent).toBeCloseTo(65, 6);
+  });
+
+  it("converts BPS to percent for kink, current and max APR", async () => {
+    setupHub({ liquidity: 600n, drawn: 400n, swept: 0n });
+
+    const out = await getInterestRateModelCurveSafe({ hub: HUB, assetId: 5 });
+
+    expect(out.kinkUtilizationPercent).toBeCloseTo(90, 6);
+    expect(out.currentUtilizationPercent).toBeCloseTo(40, 6);
+    // base(0%) + growthBefore(4%) + growthAfter(60%) = 64%.
+    expect(out.maxAprPercent).toBeCloseTo(64, 6);
+    // Current usage 0.40 (below optimal 0.90): 0.40/0.90 * 4% ≈ 1.778%.
+    expect(out.currentAprPercent).toBeCloseTo(0.04 * (0.4 / 0.9) * 100, 6);
+  });
+});

--- a/services/vault/src/applications/aave/clients/aaveHub.ts
+++ b/services/vault/src/applications/aave/clients/aaveHub.ts
@@ -22,7 +22,7 @@ const RAY = 10n ** 27n;
 const PERCENT_SCALE = 100;
 
 /** Converts a RAY-scaled rate to a percent number (e.g. 3.7 for 3.7%). */
-function rateRayToPercent(rateRay: bigint): number {
+export function rateRayToPercent(rateRay: bigint): number {
   return (Number(rateRay) / Number(RAY)) * PERCENT_SCALE;
 }
 
@@ -128,7 +128,7 @@ const HUB_RATE_ABI = [
   },
 ] as const;
 
-const IR_STRATEGY_ABI = [
+export const IR_STRATEGY_ABI = [
   {
     type: "function",
     name: "calculateInterestRate",
@@ -143,6 +143,109 @@ const IR_STRATEGY_ABI = [
     outputs: [{ name: "", type: "uint256" }],
   },
 ] as const;
+
+/** The totals snapshot the Hub feeds its rate strategy, plus the strategy address. */
+export interface HubAssetTotals {
+  liquidity: bigint;
+  /** getAssetOwed[0] — the strategy curve uses `drawn`; the premium is ignored. */
+  drawn: bigint;
+  swept: bigint;
+  /**
+   * Deficit in asset units. The Hub stores it RAY-scaled and feeds
+   * `deficitRay.fromRayUp()` (ceil-divide by RAY) into the rate call.
+   */
+  deficit: bigint;
+  irStrategy: Address;
+}
+
+export type HubAssetTotalsResult =
+  | { totals: HubAssetTotals; error: null }
+  | { totals: null; error: Error };
+
+/**
+ * One multicall reading the exact figures the Hub itself hands its
+ * interest-rate strategy: liquidity, drawn, swept, deficit and the strategy
+ * address. Shared by `getProjectedBorrowAprPercentsSafe` and the IRM curve
+ * reader (aaveIrm.ts) so both rate computations provably start from the same
+ * denominator. Reads are isolated with `allowFailure`; any revert or
+ * network-level throw comes back as an error rather than a throw.
+ */
+export async function readHubAssetTotalsSafe(
+  hub: Address,
+  assetIdArg: bigint,
+): Promise<HubAssetTotalsResult> {
+  const publicClient = ethClient.getPublicClient();
+
+  let totals;
+  try {
+    totals = await publicClient.multicall({
+      contracts: [
+        {
+          address: hub,
+          abi: HUB_RATE_ABI as Abi,
+          functionName: "getAssetLiquidity" as const,
+          args: [assetIdArg] as const,
+        },
+        {
+          address: hub,
+          abi: HUB_RATE_ABI as Abi,
+          functionName: "getAssetOwed" as const,
+          args: [assetIdArg] as const,
+        },
+        {
+          address: hub,
+          abi: HUB_RATE_ABI as Abi,
+          functionName: "getAssetSwept" as const,
+          args: [assetIdArg] as const,
+        },
+        {
+          address: hub,
+          abi: HUB_RATE_ABI as Abi,
+          functionName: "getAssetDeficitRay" as const,
+          args: [assetIdArg] as const,
+        },
+        {
+          address: hub,
+          abi: HUB_RATE_ABI as Abi,
+          functionName: "getAssetConfig" as const,
+          args: [assetIdArg] as const,
+        },
+      ],
+      allowFailure: true,
+    });
+  } catch (err) {
+    return {
+      totals: null,
+      error: err instanceof Error ? err : new Error(String(err)),
+    };
+  }
+
+  const [liquidityCall, owedCall, sweptCall, deficitCall, configCall] = totals;
+  if (
+    liquidityCall.status !== "success" ||
+    owedCall.status !== "success" ||
+    sweptCall.status !== "success" ||
+    deficitCall.status !== "success" ||
+    configCall.status !== "success"
+  ) {
+    return {
+      totals: null,
+      error: new Error("Hub asset totals read reverted"),
+    };
+  }
+
+  const { irStrategy } = configCall.result as { irStrategy: Address };
+  return {
+    totals: {
+      liquidity: liquidityCall.result as bigint,
+      drawn: (owedCall.result as readonly bigint[])[0],
+      swept: sweptCall.result as bigint,
+      deficit: ceilDivRay(deficitCall.result as bigint),
+      irStrategy,
+    },
+    error: null,
+  };
+}
 
 /** Identifies one Hub asset to read reserve totals for. */
 export interface AssetLiquidityRequest {
@@ -320,72 +423,11 @@ export async function getProjectedBorrowAprPercentsSafe({
   const publicClient = ethClient.getPublicClient();
   const assetIdArg = BigInt(assetId);
 
-  let totals;
-  try {
-    totals = await publicClient.multicall({
-      contracts: [
-        {
-          address: hub,
-          abi: HUB_RATE_ABI as Abi,
-          functionName: "getAssetLiquidity" as const,
-          args: [assetIdArg] as const,
-        },
-        {
-          address: hub,
-          abi: HUB_RATE_ABI as Abi,
-          functionName: "getAssetOwed" as const,
-          args: [assetIdArg] as const,
-        },
-        {
-          address: hub,
-          abi: HUB_RATE_ABI as Abi,
-          functionName: "getAssetSwept" as const,
-          args: [assetIdArg] as const,
-        },
-        {
-          address: hub,
-          abi: HUB_RATE_ABI as Abi,
-          functionName: "getAssetDeficitRay" as const,
-          args: [assetIdArg] as const,
-        },
-        {
-          address: hub,
-          abi: HUB_RATE_ABI as Abi,
-          functionName: "getAssetConfig" as const,
-          args: [assetIdArg] as const,
-        },
-      ],
-      allowFailure: true,
-    });
-  } catch (err) {
-    return {
-      ...NULL_PROJECTION,
-      error: err instanceof Error ? err : new Error(String(err)),
-    };
+  const totalsRead = await readHubAssetTotalsSafe(hub, assetIdArg);
+  if (totalsRead.totals === null) {
+    return { ...NULL_PROJECTION, error: totalsRead.error };
   }
-
-  const [liquidityCall, owedCall, sweptCall, deficitCall, configCall] = totals;
-  if (
-    liquidityCall.status !== "success" ||
-    owedCall.status !== "success" ||
-    sweptCall.status !== "success" ||
-    deficitCall.status !== "success" ||
-    configCall.status !== "success"
-  ) {
-    return {
-      ...NULL_PROJECTION,
-      error: new Error("Hub asset totals read reverted"),
-    };
-  }
-
-  const liquidity = liquidityCall.result as bigint;
-  // getAssetOwed returns [drawn, premium]; the strategy curve uses `drawn`.
-  const drawn = (owedCall.result as readonly bigint[])[0];
-  const swept = sweptCall.result as bigint;
-  // The strategy takes the deficit in asset units; the Hub stores it RAY-scaled
-  // and feeds `deficitRay.fromRayUp()` (ceil-divide by RAY) into the rate call.
-  const deficit = ceilDivRay(deficitCall.result as bigint);
-  const { irStrategy } = configCall.result as { irStrategy: Address };
+  const { liquidity, drawn, swept, deficit, irStrategy } = totalsRead.totals;
 
   // Borrowing moves the drawn amount out of liquidity, so the denominator
   // (liquidity + drawn + swept) is invariant. A borrow can't exceed available

--- a/services/vault/src/applications/aave/clients/aaveIrm.ts
+++ b/services/vault/src/applications/aave/clients/aaveIrm.ts
@@ -1,0 +1,262 @@
+/**
+ * Interest-rate-model (IRM) curve for one Hub asset's on-chain kinked
+ * strategy — the data source for the C2 borrow-rate chart.
+ *
+ * The curve is piecewise-linear in utilization with a single breakpoint (the
+ * kink), so sampling only needs: 21 evenly-spaced points (0%, 5%, …, 100%)
+ * plus the exact kink and exact live-utilization points. With the breakpoint
+ * itself an exact sample, linear interpolation between samples reproduces the
+ * true on-chain curve exactly — no off-chain reimplementation of the rate
+ * math, same stance as `getProjectedBorrowAprPercentsSafe`.
+ *
+ * Sampling exploits that `T = liquidity + drawn + swept` is invariant: for a
+ * synthetic sample at utilization `u`, `drawn' = T·u`, `liquidity' = T − drawn'`,
+ * `swept' = 0` folds the sweep into liquidity without changing `T`. The one
+ * exception is the live-utilization sample, which passes the untouched
+ * `(liquidity, drawn, swept)` so it is bit-identical to the Hub's own
+ * `getAssetDrawnRate`.
+ */
+
+import type { Abi, Address } from "viem";
+
+import { ethClient } from "../../../clients/eth-contract/client";
+
+import {
+  IR_STRATEGY_ABI,
+  rateRayToPercent,
+  readHubAssetTotalsSafe,
+} from "./aaveHub";
+
+/** Utilization sampling step in BPS: 21 even points from 0% to 100%. */
+const IRM_SAMPLE_STEP_BPS = 500;
+/** 100% expressed in basis points. */
+const BPS_SCALE = 10_000n;
+/** BPS per whole percentage point (1% = 100 BPS). */
+const BPS_PER_PERCENT = 100;
+
+const IRM_CURVE_DATA_ABI = [
+  {
+    type: "function",
+    name: "getInterestRateData",
+    stateMutability: "view",
+    inputs: [{ name: "assetId", type: "uint256" }],
+    outputs: [
+      {
+        name: "",
+        type: "tuple",
+        components: [
+          { name: "optimalUsageRatio", type: "uint256" },
+          { name: "baseDrawnRate", type: "uint256" },
+          { name: "rateGrowthBeforeOptimal", type: "uint256" },
+          { name: "rateGrowthAfterOptimal", type: "uint256" },
+        ],
+      },
+    ],
+  },
+] as const;
+
+/** Identifies one Hub asset to read the interest-rate-model curve for. */
+export interface InterestRateModelCurveRequest {
+  /** Hub contract address (from the reserve's `hub` field). */
+  hub: Address;
+  /** Asset identifier on that Hub (from the reserve's `assetId` field). */
+  assetId: number;
+}
+
+export interface IrmCurvePoint {
+  /** Utilization in percent, 0–100. */
+  utilizationPercent: number;
+  /** Borrow APR percent at that utilization, from the on-chain strategy. */
+  aprPercent: number;
+}
+
+export interface InterestRateModelCurveResult {
+  /** Sorted by utilization; null when any leg failed (no half-curve). */
+  curve: IrmCurvePoint[] | null;
+  /** Kink utilization percent from getInterestRateData, or null. */
+  kinkUtilizationPercent: number | null;
+  /** Live utilization percent (drawn / (liquidity+drawn+swept)), or null. */
+  currentUtilizationPercent: number | null;
+  /** APR at the live totals — bit-identical to the Hub's getAssetDrawnRate. */
+  currentAprPercent: number | null;
+  /**
+   * The y-axis ceiling, percent: base+growthBefore+growthAfter, raised to the
+   * highest sampled APR when the live deficit pushes the curve above it.
+   */
+  maxAprPercent: number | null;
+  error: Error | null;
+}
+
+const NULL_CURVE_RESULT: Omit<InterestRateModelCurveResult, "error"> = {
+  curve: null,
+  kinkUtilizationPercent: null,
+  currentUtilizationPercent: null,
+  currentAprPercent: null,
+  maxAprPercent: null,
+};
+
+/**
+ * Reads the on-chain IRM curve for one Hub asset in three sequential
+ * multicalls: (1) Hub totals + strategy address, (2) the strategy's
+ * `getInterestRateData` for the kink and max-rate shape, (3) `calculateInterestRate`
+ * for every sample utilization. Every read is fault-isolated with
+ * `allowFailure: true`; any failed leg (or a network-level throw) nulls the
+ * whole result rather than a half-curve, since a caller can't chart a
+ * partially-sampled strategy.
+ */
+export async function getInterestRateModelCurveSafe({
+  hub,
+  assetId,
+}: InterestRateModelCurveRequest): Promise<InterestRateModelCurveResult> {
+  const publicClient = ethClient.getPublicClient();
+  const assetIdArg = BigInt(assetId);
+
+  const totalsRead = await readHubAssetTotalsSafe(hub, assetIdArg);
+  if (totalsRead.totals === null) {
+    return { ...NULL_CURVE_RESULT, error: totalsRead.error };
+  }
+  const { liquidity, drawn, swept, deficit, irStrategy } = totalsRead.totals;
+
+  // The denominator the Hub feeds its rate strategy; invariant across the
+  // whole sampling sweep (see module doc).
+  const totalLiquidity = liquidity + drawn + swept;
+  if (totalLiquidity === 0n) {
+    return {
+      ...NULL_CURVE_RESULT,
+      error: new Error("Reserve has no supplied liquidity"),
+    };
+  }
+  const currentBps = (drawn * BPS_SCALE) / totalLiquidity;
+
+  let curveData;
+  try {
+    curveData = await publicClient.multicall({
+      contracts: [
+        {
+          address: irStrategy,
+          abi: IRM_CURVE_DATA_ABI as Abi,
+          functionName: "getInterestRateData" as const,
+          args: [assetIdArg] as const,
+        },
+      ],
+      allowFailure: true,
+    });
+  } catch (err) {
+    return {
+      ...NULL_CURVE_RESULT,
+      error: err instanceof Error ? err : new Error(String(err)),
+    };
+  }
+
+  const [rateDataCall] = curveData;
+  if (rateDataCall.status !== "success") {
+    return {
+      ...NULL_CURVE_RESULT,
+      error: new Error("Interest-rate strategy data read reverted"),
+    };
+  }
+
+  const {
+    optimalUsageRatio,
+    baseDrawnRate,
+    rateGrowthBeforeOptimal,
+    rateGrowthAfterOptimal,
+  } = rateDataCall.result as {
+    optimalUsageRatio: bigint;
+    baseDrawnRate: bigint;
+    rateGrowthBeforeOptimal: bigint;
+    rateGrowthAfterOptimal: bigint;
+  };
+
+  const kinkBps = optimalUsageRatio;
+  // The ABI declares four bare uint256s, so nothing at decode time rules out
+  // a strategy returning the ratio on another scale (e.g. RAY). Unchecked,
+  // an oversized kink makes `sampleLiquidity` below go negative and surfaces
+  // as an opaque viem encoding throw from inside the multicall.
+  if (kinkBps > BPS_SCALE) {
+    return {
+      ...NULL_CURVE_RESULT,
+      error: new Error(
+        `Strategy optimalUsageRatio ${kinkBps.toString()} exceeds the BPS scale (${BPS_SCALE.toString()})`,
+      ),
+    };
+  }
+  const shapeMaxAprPercent =
+    Number(baseDrawnRate + rateGrowthBeforeOptimal + rateGrowthAfterOptimal) /
+    BPS_PER_PERCENT;
+
+  // Sample set: 21 even points ∪ { kink, current }, deduplicated and sorted.
+  const sampleBpsSet = new Set<bigint>();
+  for (let bps = 0n; bps <= BPS_SCALE; bps += BigInt(IRM_SAMPLE_STEP_BPS)) {
+    sampleBpsSet.add(bps);
+  }
+  sampleBpsSet.add(kinkBps);
+  sampleBpsSet.add(currentBps);
+  const sortedSampleBps = [...sampleBpsSet].sort((a, b) =>
+    a < b ? -1 : a > b ? 1 : 0,
+  );
+
+  let rateLegs;
+  try {
+    rateLegs = await publicClient.multicall({
+      contracts: sortedSampleBps.map((bps) => {
+        const isCurrent = bps === currentBps;
+        const sampleDrawn = isCurrent
+          ? drawn
+          : (totalLiquidity * bps) / BPS_SCALE;
+        const sampleLiquidity = isCurrent
+          ? liquidity
+          : totalLiquidity - sampleDrawn;
+        const sampleSwept = isCurrent ? swept : 0n;
+        return {
+          address: irStrategy,
+          abi: IR_STRATEGY_ABI as Abi,
+          functionName: "calculateInterestRate" as const,
+          args: [
+            assetIdArg,
+            sampleLiquidity,
+            sampleDrawn,
+            deficit,
+            sampleSwept,
+          ] as const,
+        };
+      }),
+      allowFailure: true,
+    });
+  } catch (err) {
+    return {
+      ...NULL_CURVE_RESULT,
+      error: err instanceof Error ? err : new Error(String(err)),
+    };
+  }
+
+  const failedLeg = rateLegs.find((leg) => leg.status !== "success");
+  if (failedLeg) {
+    return {
+      ...NULL_CURVE_RESULT,
+      error: new Error("Interest-rate strategy curve read reverted"),
+    };
+  }
+
+  const curve: IrmCurvePoint[] = sortedSampleBps.map((bps, i) => ({
+    utilizationPercent: Number(bps) / BPS_PER_PERCENT,
+    aprPercent: rateRayToPercent(rateLegs[i].result as bigint),
+  }));
+
+  const currentIndex = sortedSampleBps.findIndex((bps) => bps === currentBps);
+
+  return {
+    curve,
+    kinkUtilizationPercent: Number(kinkBps) / BPS_PER_PERCENT,
+    currentUtilizationPercent: Number(currentBps) / BPS_PER_PERCENT,
+    currentAprPercent: curve[currentIndex].aprPercent,
+    // The shape ceiling ignores the reserve's live deficit, which every
+    // sampled leg carries — clamp so the consumer's y domain can never sit
+    // below a sampled point (the chart SVG is overflow: visible).
+    maxAprPercent: Math.max(
+      shapeMaxAprPercent,
+      ...curve.map((point) => point.aprPercent),
+    ),
+    error: null,
+  };
+}

--- a/services/vault/src/applications/aave/hooks/__tests__/useBorrowRateHistory.test.tsx
+++ b/services/vault/src/applications/aave/hooks/__tests__/useBorrowRateHistory.test.tsx
@@ -1,0 +1,211 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/clients/indexer/aaveHistoryClient", () => ({
+  fetchBorrowRateHistory: vi.fn(),
+}));
+
+import { fetchBorrowRateHistory } from "@/clients/indexer/aaveHistoryClient";
+
+import { useBorrowRateHistory } from "../useBorrowRateHistory";
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe("useBorrowRateHistory", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the fetched points for the requested reserve and range", async () => {
+    vi.mocked(fetchBorrowRateHistory).mockResolvedValue([
+      { timeMs: 1_000, ratePercent: 3.1 },
+    ]);
+
+    const { result } = renderHook(
+      () => useBorrowRateHistory({ reserveId: 5n, range: "1w" }),
+      { wrapper },
+    );
+
+    await waitFor(() =>
+      expect(result.current.points).toEqual([
+        { timeMs: 1_000, ratePercent: 3.1 },
+      ]),
+    );
+    expect(result.current.error).toBeNull();
+    expect(fetchBorrowRateHistory).toHaveBeenCalledWith({
+      reserveId: 5n,
+      range: "1w",
+      signal: expect.any(AbortSignal),
+    });
+  });
+
+  it("does not fetch while reserveId is null", () => {
+    renderHook(() => useBorrowRateHistory({ reserveId: null, range: "1w" }), {
+      wrapper,
+    });
+
+    expect(fetchBorrowRateHistory).not.toHaveBeenCalled();
+  });
+
+  it("refetches when the range changes for the same reserve", async () => {
+    vi.mocked(fetchBorrowRateHistory).mockResolvedValue([
+      { timeMs: 1_000, ratePercent: 3.1 },
+    ]);
+
+    const { rerender } = renderHook(
+      ({ range }: { range: "1w" | "1m" }) =>
+        useBorrowRateHistory({ reserveId: 5n, range }),
+      { wrapper, initialProps: { range: "1w" } },
+    );
+
+    await waitFor(() =>
+      expect(fetchBorrowRateHistory).toHaveBeenCalledWith({
+        reserveId: 5n,
+        range: "1w",
+        signal: expect.any(AbortSignal),
+      }),
+    );
+
+    rerender({ range: "1m" });
+
+    await waitFor(() =>
+      expect(fetchBorrowRateHistory).toHaveBeenCalledWith({
+        reserveId: 5n,
+        range: "1m",
+        signal: expect.any(AbortSignal),
+      }),
+    );
+  });
+
+  it("holds the previous range's series while the new range loads (same reserve)", async () => {
+    let resolveSecond: (
+      value: { timeMs: number; ratePercent: number }[],
+    ) => void = () => {};
+    vi.mocked(fetchBorrowRateHistory)
+      .mockResolvedValueOnce([{ timeMs: 1_000, ratePercent: 3.1 }])
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveSecond = resolve;
+        }),
+      );
+
+    const { result, rerender } = renderHook(
+      ({ range }: { range: "1w" | "1m" }) =>
+        useBorrowRateHistory({ reserveId: 5n, range }),
+      { wrapper, initialProps: { range: "1w" } },
+    );
+
+    await waitFor(() =>
+      expect(result.current.points).toEqual([
+        { timeMs: 1_000, ratePercent: 3.1 },
+      ]),
+    );
+
+    rerender({ range: "1m" });
+
+    // The new range's fetch is in flight; the previous range's series stays visible.
+    expect(result.current.points).toEqual([
+      { timeMs: 1_000, ratePercent: 3.1 },
+    ]);
+
+    resolveSecond([{ timeMs: 2_000, ratePercent: 4.2 }]);
+    await waitFor(() =>
+      expect(result.current.points).toEqual([
+        { timeMs: 2_000, ratePercent: 4.2 },
+      ]),
+    );
+  });
+
+  it("does not reuse the previous reserve's series when the reserve switches", async () => {
+    let resolveB: (
+      value: { timeMs: number; ratePercent: number }[],
+    ) => void = () => {};
+    vi.mocked(fetchBorrowRateHistory)
+      .mockResolvedValueOnce([{ timeMs: 1_000, ratePercent: 3.1 }])
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveB = resolve;
+        }),
+      );
+
+    const { result, rerender } = renderHook(
+      ({ reserveId }: { reserveId: bigint }) =>
+        useBorrowRateHistory({ reserveId, range: "1w" }),
+      { wrapper, initialProps: { reserveId: 5n } },
+    );
+
+    await waitFor(() =>
+      expect(result.current.points).toEqual([
+        { timeMs: 1_000, ratePercent: 3.1 },
+      ]),
+    );
+
+    rerender({ reserveId: 9n });
+
+    // Reserve 9's fetch is in flight; reserve 5's series must not carry over.
+    await waitFor(() => expect(result.current.points).toBeNull());
+
+    resolveB([{ timeMs: 2_000, ratePercent: 4.2 }]);
+    await waitFor(() =>
+      expect(result.current.points).toEqual([
+        { timeMs: 2_000, ratePercent: 4.2 },
+      ]),
+    );
+  });
+
+  it("surfaces a fetch error with points null", async () => {
+    vi.mocked(fetchBorrowRateHistory).mockRejectedValue(
+      new Error("Borrow rate history request failed"),
+    );
+
+    const { result } = renderHook(
+      () => useBorrowRateHistory({ reserveId: 5n, range: "1w" }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.error).toBeInstanceOf(Error));
+    expect(result.current.points).toBeNull();
+  });
+
+  it("withholds the last-good series once a background refetch fails, instead of showing stale points alongside the error", async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    function refetchWrapper({ children }: { children: ReactNode }) {
+      return (
+        <QueryClientProvider client={client}>{children}</QueryClientProvider>
+      );
+    }
+
+    vi.mocked(fetchBorrowRateHistory)
+      .mockResolvedValueOnce([{ timeMs: 1_000, ratePercent: 3.1 }])
+      .mockRejectedValueOnce(new Error("refetch failed"));
+
+    const { result } = renderHook(
+      () => useBorrowRateHistory({ reserveId: 5n, range: "1w" }),
+      { wrapper: refetchWrapper },
+    );
+
+    await waitFor(() =>
+      expect(result.current.points).toEqual([
+        { timeMs: 1_000, ratePercent: 3.1 },
+      ]),
+    );
+    expect(result.current.error).toBeNull();
+
+    // React Query keeps last-good `data` across a failed refetch for the same
+    // key by default, which is exactly the condition that must not leak
+    // through as visible points.
+    await client.refetchQueries().catch(() => {});
+
+    await waitFor(() => expect(result.current.error).toBeInstanceOf(Error));
+    expect(result.current.points).toBeNull();
+  });
+});

--- a/services/vault/src/applications/aave/hooks/__tests__/useInterestRateModelCurve.test.tsx
+++ b/services/vault/src/applications/aave/hooks/__tests__/useInterestRateModelCurve.test.tsx
@@ -1,0 +1,115 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../clients/aaveIrm", () => ({
+  getInterestRateModelCurveSafe: vi.fn(),
+}));
+
+import { getInterestRateModelCurveSafe } from "../../clients/aaveIrm";
+import type { AaveReserveConfig } from "../../services/fetchConfig";
+import { useInterestRateModelCurve } from "../useInterestRateModelCurve";
+
+const HUB = "0x0000000000000000000000000000000000000003" as const;
+
+function makeReserve(assetId = 0): AaveReserveConfig {
+  return {
+    reserveId: 1n,
+    reserve: {
+      underlying: "0x0000000000000000000000000000000000000010",
+      hub: HUB,
+      assetId,
+      decimals: 6,
+      dynamicConfigKey: 0,
+      paused: false,
+      frozen: false,
+      borrowable: true,
+      collateralRisk: 0,
+      collateralFactor: 8000,
+    },
+    token: {
+      address: "0x0000000000000000000000000000000000000010",
+      symbol: "USDC",
+      name: "USD Coin",
+      decimals: 6,
+    },
+  };
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe("useInterestRateModelCurve", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("maps the Safe result's curve and figures through", async () => {
+    vi.mocked(getInterestRateModelCurveSafe).mockResolvedValue({
+      curve: [
+        { utilizationPercent: 0, aprPercent: 0 },
+        { utilizationPercent: 90, aprPercent: 4 },
+        { utilizationPercent: 100, aprPercent: 64 },
+      ],
+      kinkUtilizationPercent: 90,
+      currentUtilizationPercent: 40,
+      currentAprPercent: 1.78,
+      maxAprPercent: 64,
+      error: null,
+    });
+
+    const { result } = renderHook(
+      () => useInterestRateModelCurve({ reserve: makeReserve() }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.curve).not.toBeNull());
+    expect(result.current.curve).toHaveLength(3);
+    expect(result.current.kinkUtilizationPercent).toBe(90);
+    expect(result.current.currentUtilizationPercent).toBe(40);
+    expect(result.current.currentAprPercent).toBe(1.78);
+    expect(result.current.maxAprPercent).toBe(64);
+    expect(result.current.error).toBeNull();
+    expect(getInterestRateModelCurveSafe).toHaveBeenCalledWith({
+      hub: HUB,
+      assetId: 0,
+    });
+  });
+
+  it("surfaces the Safe result's error with a null curve", async () => {
+    vi.mocked(getInterestRateModelCurveSafe).mockResolvedValue({
+      curve: null,
+      kinkUtilizationPercent: null,
+      currentUtilizationPercent: null,
+      currentAprPercent: null,
+      maxAprPercent: null,
+      error: new Error("Interest-rate strategy curve read reverted"),
+    });
+
+    const { result } = renderHook(
+      () => useInterestRateModelCurve({ reserve: makeReserve() }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.error).toBeInstanceOf(Error));
+    expect(result.current.curve).toBeNull();
+    expect(result.current.kinkUtilizationPercent).toBeNull();
+    expect(result.current.maxAprPercent).toBeNull();
+  });
+
+  it("is disabled when reserve is null", () => {
+    const { result } = renderHook(
+      () => useInterestRateModelCurve({ reserve: null }),
+      { wrapper },
+    );
+
+    expect(result.current.curve).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+    expect(getInterestRateModelCurveSafe).not.toHaveBeenCalled();
+  });
+});

--- a/services/vault/src/applications/aave/hooks/index.ts
+++ b/services/vault/src/applications/aave/hooks/index.ts
@@ -32,9 +32,17 @@ export {
 export { useAaveVaults, type UseAaveVaultsResult } from "./useAaveVaults";
 export { useActiveLoans, type ActiveLoanRow } from "./useActiveLoans";
 export {
+  useBorrowRateHistory,
+  type UseBorrowRateHistoryResult,
+} from "./useBorrowRateHistory";
+export {
   useBorrowTransaction,
   type UseBorrowTransactionResult,
 } from "./useBorrowTransaction";
+export {
+  useInterestRateModelCurve,
+  type UseInterestRateModelCurveResult,
+} from "./useInterestRateModelCurve";
 export { type UseOptimalSplitResult } from "./useOptimalSplit";
 export {
   type PositionNotificationsStatus,

--- a/services/vault/src/applications/aave/hooks/useBorrowRateHistory.ts
+++ b/services/vault/src/applications/aave/hooks/useBorrowRateHistory.ts
@@ -1,0 +1,70 @@
+/**
+ * Historical borrow APR series for a reserve, over a selectable range.
+ *
+ * Reads the vault indexer's stepped history endpoint (a borrow rate is a level
+ * that holds until the next state change, so the series is never averaged).
+ * `staleTime`/`refetchInterval` match the server's 60s Redis TTL.
+ *
+ * `placeholderData` keeps the previous range's series visible while a new
+ * range loads, but only within the SAME reserve — switching reserves must
+ * never flash the outgoing reserve's series (same guard pattern as
+ * `useProjectedBorrowApr`).
+ */
+
+import { skipToken, useQuery } from "@tanstack/react-query";
+
+import {
+  fetchBorrowRateHistory,
+  type BorrowRateHistoryPoint,
+  type HistoryRange,
+} from "@/clients/indexer/aaveHistoryClient";
+
+const QUERY_KEY = "aaveBorrowRateHistory";
+const HISTORY_STALE_TIME_MS = 60_000;
+const HISTORY_REFETCH_INTERVAL_MS = 60_000;
+
+export interface UseBorrowRateHistoryResult {
+  /**
+   * null while loading/failed; [] is a truly empty (young-reserve) series.
+   * Withheld on error so a failed background refetch never surfaces
+   * React Query's stale last-good series alongside the error.
+   */
+  points: BorrowRateHistoryPoint[] | null;
+  isLoading: boolean;
+  error: Error | null;
+}
+
+export function useBorrowRateHistory({
+  reserveId,
+  range,
+}: {
+  reserveId: bigint | null;
+  range: HistoryRange;
+}): UseBorrowRateHistoryResult {
+  const reserveKey = reserveId?.toString() ?? null;
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: [QUERY_KEY, reserveKey, range],
+    // skipToken (rather than `enabled`) both disables the query while there is
+    // no reserve and narrows `reserveId` to bigint for the fetch. Forwarding
+    // React Query's `signal` aborts a superseded request on unmount or a rapid
+    // range switch instead of letting it run to the 30s timeout.
+    queryFn:
+      reserveId === null
+        ? skipToken
+        : ({ signal }) => fetchBorrowRateHistory({ reserveId, range, signal }),
+    staleTime: HISTORY_STALE_TIME_MS,
+    refetchInterval: HISTORY_REFETCH_INTERVAL_MS,
+    placeholderData: (previous, previousQuery) => {
+      const previousReserveKey = previousQuery?.queryKey[1];
+      return previousReserveKey === reserveKey ? previous : undefined;
+    },
+  });
+
+  // Same stale-data guard as useAaveReserveLiquidity: clear `data` on error.
+  return {
+    points: error ? null : (data ?? null),
+    isLoading,
+    error: (error as Error | null) ?? null,
+  };
+}

--- a/services/vault/src/applications/aave/hooks/useInterestRateModelCurve.ts
+++ b/services/vault/src/applications/aave/hooks/useInterestRateModelCurve.ts
@@ -1,0 +1,65 @@
+/**
+ * On-chain interest-rate-model curve for the selected reserve — the data
+ * source for the C2 borrow-rate chart. Wraps `getInterestRateModelCurveSafe`
+ * (three sequential multicalls: Hub totals, strategy shape, per-sample rates)
+ * in a query so the card can render loading/error states like its sibling
+ * Aave hooks.
+ *
+ * There is no "empty but successful" curve: a configured strategy always
+ * yields the full sample set, so `curve === null` is the one empty state,
+ * covering both the loading window and a Safe-result failure.
+ *
+ * Wallet-less: reads go through the app's public RPC client.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  getInterestRateModelCurveSafe,
+  type IrmCurvePoint,
+} from "../clients/aaveIrm";
+import type { AaveReserveConfig } from "../services/fetchConfig";
+
+const QUERY_KEY = "aaveIrmCurve";
+const ONE_MINUTE_MS = 60 * 1000;
+
+export interface UseInterestRateModelCurveResult {
+  curve: IrmCurvePoint[] | null;
+  kinkUtilizationPercent: number | null;
+  currentUtilizationPercent: number | null;
+  currentAprPercent: number | null;
+  maxAprPercent: number | null;
+  isLoading: boolean;
+  error: Error | null;
+}
+
+export function useInterestRateModelCurve({
+  reserve,
+}: {
+  reserve: AaveReserveConfig | null;
+}): UseInterestRateModelCurveResult {
+  const hubKey = reserve === null ? null : reserve.reserve.hub.toLowerCase();
+  const assetId = reserve === null ? null : reserve.reserve.assetId;
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: [QUERY_KEY, hubKey, assetId],
+    queryFn: () =>
+      getInterestRateModelCurveSafe({
+        hub: reserve!.reserve.hub,
+        assetId: reserve!.reserve.assetId,
+      }),
+    enabled: reserve !== null,
+    staleTime: ONE_MINUTE_MS,
+    refetchInterval: ONE_MINUTE_MS,
+  });
+
+  return {
+    curve: data?.curve ?? null,
+    kinkUtilizationPercent: data?.kinkUtilizationPercent ?? null,
+    currentUtilizationPercent: data?.currentUtilizationPercent ?? null,
+    currentAprPercent: data?.currentAprPercent ?? null,
+    maxAprPercent: data?.maxAprPercent ?? null,
+    isLoading: reserve !== null && isLoading,
+    error: (error as Error | null) ?? data?.error ?? null,
+  };
+}

--- a/services/vault/src/clients/graphql/__tests__/client.test.ts
+++ b/services/vault/src/clients/graphql/__tests__/client.test.ts
@@ -105,4 +105,42 @@ describe("graphqlClient timeout", () => {
     await vi.advanceTimersByTimeAsync(30_000);
     await assertion;
   });
+
+  it("times out on a stalled response body, not just stalled headers", async () => {
+    // Regression check: `fetch()` itself resolves right away (headers
+    // received), but reading the body never settles until the request's
+    // controlling signal aborts — exactly how a real stalled body behaves.
+    // The 30s bound must cover this too, not just the time to get a Response
+    // back.
+    mockFetch.mockImplementation(
+      (_url: string, options?: RequestInit) =>
+        new Promise((resolve) => {
+          resolve({
+            status: 200,
+            statusText: "OK",
+            headers: new Headers({ "Content-Type": "application/json" }),
+            text: () =>
+              new Promise((_resolve, reject) => {
+                options?.signal?.addEventListener("abort", () => {
+                  reject(
+                    new DOMException(
+                      "The operation was aborted.",
+                      "AbortError",
+                    ),
+                  );
+                });
+              }),
+          } as unknown as Response);
+        }),
+    );
+
+    const { graphqlClient } = await import("../client");
+
+    const promise = graphqlClient.request("{ vaults { id } }");
+    const assertion = expect(promise).rejects.toThrow(
+      /timed out after 30000ms/,
+    );
+    await vi.advanceTimersByTimeAsync(30_000);
+    await assertion;
+  });
 });

--- a/services/vault/src/clients/graphql/client.ts
+++ b/services/vault/src/clients/graphql/client.ts
@@ -1,85 +1,31 @@
 import { GraphQLClient } from "graphql-request";
 
 import { ENV } from "../../config/env";
-import { combineAbortSignals } from "../../utils/async";
+import { withRequestTimeout } from "../../utils/async";
 
 /** Timeout for GraphQL API requests — prevents indefinite hangs from stalled endpoints */
 const GRAPHQL_REQUEST_TIMEOUT_MS = 30_000;
 
-/**
- * A browser `fetch` rejection carries no endpoint information — the exception is
- * literally `TypeError: Failed to fetch` (`Load failed` on Safari), so every
- * failing query in the app produces an identical, untriageable Sentry issue.
- * Naming the host restores enough context to tell an indexer outage apart from
- * an RPC or mempool one, without leaking the query or its variables.
- */
-function describeFetchFailure(url: string, error: unknown): Error {
-  const host = (() => {
-    try {
-      return new URL(url).host;
-    } catch {
-      return "unknown host";
-    }
-  })();
-  const detail = error instanceof Error ? error.message : String(error);
-  return new Error(`GraphQL request to ${host} failed: ${detail}`, {
-    cause: error,
-  });
-}
-
 export const graphqlClient = new GraphQLClient(ENV.GRAPHQL_ENDPOINT, {
-  fetch: async (url, options) => {
-    const controller = new AbortController();
-    const timeoutId = setTimeout(
-      () => controller.abort(),
-      GRAPHQL_REQUEST_TIMEOUT_MS,
-    );
-
-    // Compose timeout signal with any caller-supplied signal so both can cancel
-    const signals = [controller.signal, options?.signal].filter(
-      Boolean,
-    ) as AbortSignal[];
-    const combined = combineAbortSignals(signals);
-
-    try {
-      const response = await fetch(url, {
-        ...options,
-        signal: combined.signal,
-      });
-      const body = await response.text();
-      clearTimeout(timeoutId);
-      return new Response(body, {
-        status: response.status,
-        statusText: response.statusText,
-        headers: response.headers,
-      });
-    } catch (error) {
-      clearTimeout(timeoutId);
-      if (
-        controller.signal.aborted &&
-        error != null &&
-        typeof error === "object" &&
-        "name" in error &&
-        error.name === "AbortError"
-      ) {
-        throw new Error(
-          `GraphQL request timed out after ${GRAPHQL_REQUEST_TIMEOUT_MS}ms`,
-        );
-      }
-      // A caller-initiated abort (React Query unmount) must stay an AbortError
-      // so downstream `name === "AbortError"` checks keep treating it as a
-      // cancellation rather than a fault.
-      if (
-        error != null &&
-        typeof error === "object" &&
-        "name" in error &&
-        error.name === "AbortError"
-      ) {
-        throw error;
-      }
-      throw describeFetchFailure(String(url), error);
-    } finally {
-      combined.cleanup();
-    }
-  },
+  fetch: async (url, options) =>
+    withRequestTimeout(
+      {
+        timeoutMs: GRAPHQL_REQUEST_TIMEOUT_MS,
+        signal: options?.signal ?? undefined,
+        requestLabel: "GraphQL request",
+        url: String(url),
+      },
+      async (composedSignal) => {
+        const response = await fetch(url, {
+          ...options,
+          signal: composedSignal,
+        });
+        const body = await response.text();
+        return new Response(body, {
+          status: response.status,
+          statusText: response.statusText,
+          headers: response.headers,
+        });
+      },
+    ),
 });

--- a/services/vault/src/clients/indexer/__tests__/aaveHistoryClient.test.ts
+++ b/services/vault/src/clients/indexer/__tests__/aaveHistoryClient.test.ts
@@ -1,0 +1,182 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+const { mockEnv } = vi.hoisted(() => ({
+  mockEnv: { GRAPHQL_ENDPOINT: "https://indexer.test" },
+}));
+vi.mock("../../../config/env", () => ({
+  ENV: mockEnv,
+}));
+
+const mockFetch = vi.fn();
+
+beforeAll(() => {
+  vi.stubGlobal("fetch", mockFetch);
+});
+
+afterEach(() => {
+  mockFetch.mockReset();
+});
+
+afterAll(() => {
+  vi.unstubAllGlobals();
+});
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("indexerRestBaseUrl", () => {
+  it("returns the endpoint unchanged when it is a bare origin", async () => {
+    mockEnv.GRAPHQL_ENDPOINT = "https://indexer.test";
+    const { indexerRestBaseUrl } = await import("../aaveHistoryClient");
+    expect(indexerRestBaseUrl()).toBe("https://indexer.test");
+  });
+
+  it("strips a trailing /graphql suffix", async () => {
+    mockEnv.GRAPHQL_ENDPOINT = "https://indexer.test/graphql";
+    const { indexerRestBaseUrl } = await import("../aaveHistoryClient");
+    expect(indexerRestBaseUrl()).toBe("https://indexer.test");
+  });
+
+  it("preserves a path prefix while stripping the /graphql suffix", async () => {
+    mockEnv.GRAPHQL_ENDPOINT = "https://host/prefix/graphql";
+    const { indexerRestBaseUrl } = await import("../aaveHistoryClient");
+    expect(indexerRestBaseUrl()).toBe("https://host/prefix");
+  });
+});
+
+describe("fetchBorrowRateHistory", () => {
+  beforeEach(() => {
+    mockEnv.GRAPHQL_ENDPOINT = "https://indexer.test";
+  });
+
+  it("builds the request URL from a bare-origin endpoint", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ points: [] }));
+    const { fetchBorrowRateHistory } = await import("../aaveHistoryClient");
+
+    await fetchBorrowRateHistory({ reserveId: 7n, range: "1w" });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://indexer.test/api/aave/reserves/7/history?range=1w&resolution=auto",
+      expect.anything(),
+    );
+  });
+
+  it("builds the request URL from a …/graphql-suffixed endpoint", async () => {
+    mockEnv.GRAPHQL_ENDPOINT = "https://host/prefix/graphql";
+    mockFetch.mockResolvedValueOnce(jsonResponse({ points: [] }));
+    const { fetchBorrowRateHistory } = await import("../aaveHistoryClient");
+
+    await fetchBorrowRateHistory({ reserveId: 42n, range: "1d" });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://host/prefix/api/aave/reserves/42/history?range=1d&resolution=auto",
+      expect.anything(),
+    );
+  });
+
+  it("maps seconds to milliseconds and passes through the rate percent", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        points: [
+          { t: 1_700_000_000, borrowRatePercent: 3.25 },
+          { t: 1_700_003_600, borrowRatePercent: 3.5 },
+        ],
+      }),
+    );
+    const { fetchBorrowRateHistory } = await import("../aaveHistoryClient");
+
+    const points = await fetchBorrowRateHistory({ reserveId: 1n, range: "1m" });
+
+    expect(points).toEqual([
+      { timeMs: 1_700_000_000_000, ratePercent: 3.25 },
+      { timeMs: 1_700_003_600_000, ratePercent: 3.5 },
+    ]);
+  });
+
+  it("returns an empty array for a valid empty-points response", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ points: [] }));
+    const { fetchBorrowRateHistory } = await import("../aaveHistoryClient");
+
+    const points = await fetchBorrowRateHistory({
+      reserveId: 1n,
+      range: "all",
+    });
+
+    expect(points).toEqual([]);
+  });
+
+  it("throws a named error on a non-OK response", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({}, 500));
+    const { fetchBorrowRateHistory } = await import("../aaveHistoryClient");
+
+    await expect(
+      fetchBorrowRateHistory({ reserveId: 1n, range: "1w" }),
+    ).rejects.toThrow(/aave\/reserves\/1\/history.*failed with status 500/);
+  });
+
+  it("throws a parse error — not a network-failure message — on a malformed JSON body", async () => {
+    mockFetch.mockResolvedValueOnce(new Response("not-json{", { status: 200 }));
+    const { fetchBorrowRateHistory } = await import("../aaveHistoryClient");
+
+    await expect(
+      fetchBorrowRateHistory({ reserveId: 1n, range: "1w" }),
+    ).rejects.toThrow(/is not valid JSON/);
+  });
+
+  it("throws when the payload has no points array", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ reserveId: "1" }));
+    const { fetchBorrowRateHistory } = await import("../aaveHistoryClient");
+
+    await expect(
+      fetchBorrowRateHistory({ reserveId: 1n, range: "1w" }),
+    ).rejects.toThrow(/points/);
+  });
+
+  it("throws when a point's borrowRatePercent is not a finite number", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        points: [{ t: 1_700_000_000, borrowRatePercent: "3.25" }],
+      }),
+    );
+    const { fetchBorrowRateHistory } = await import("../aaveHistoryClient");
+
+    await expect(
+      fetchBorrowRateHistory({ reserveId: 1n, range: "1w" }),
+    ).rejects.toThrow(/borrowRatePercent/);
+  });
+
+  it("throws when a point's t is not a finite number", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        points: [{ t: Number.NaN, borrowRatePercent: 3.25 }],
+      }),
+    );
+    const { fetchBorrowRateHistory } = await import("../aaveHistoryClient");
+
+    await expect(
+      fetchBorrowRateHistory({ reserveId: 1n, range: "1w" }),
+    ).rejects.toThrow(/"t"/);
+  });
+
+  it("throws a named error when fetch itself rejects", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("Network error"));
+    const { fetchBorrowRateHistory } = await import("../aaveHistoryClient");
+
+    await expect(
+      fetchBorrowRateHistory({ reserveId: 1n, range: "1w" }),
+    ).rejects.toThrow(/indexer\.test/);
+  });
+});

--- a/services/vault/src/clients/indexer/aaveHistoryClient.ts
+++ b/services/vault/src/clients/indexer/aaveHistoryClient.ts
@@ -1,0 +1,138 @@
+import { ENV } from "../../config/env";
+import { withRequestTimeout } from "../../utils/async";
+
+/** Timeout for the borrow-rate history request — prevents indefinite hangs from a stalled indexer. */
+const HISTORY_REQUEST_TIMEOUT_MS = 30_000;
+
+/** The server picks the bucket size per range (vs a fixed resolution). */
+const HISTORY_RESOLUTION = "auto";
+
+const MS_PER_SECOND = 1_000;
+
+export type HistoryRange = "1d" | "1w" | "1m" | "6m" | "1y" | "all";
+
+export interface BorrowRateHistoryPoint {
+  /** Sample time, unix ms (the endpoint's `t` is unix seconds). */
+  timeMs: number;
+  /** Borrow APR percent at that time. */
+  ratePercent: number;
+}
+
+/**
+ * REST root of the vault indexer. The history API is served by the same Hono app
+ * as GraphQL (`/api` vs `/` + `/graphql`), so the base derives from the GraphQL
+ * endpoint rather than adding a second env var that could point elsewhere.
+ */
+export function indexerRestBaseUrl(): string {
+  return ENV.GRAPHQL_ENDPOINT.replace(/\/graphql\/?$/, "");
+}
+
+function assertFiniteNumber(
+  value: unknown,
+  field: string,
+  index: number,
+  endpoint: string,
+): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(
+      `Borrow rate history point ${index} from ${endpoint} has a non-finite "${field}": ${JSON.stringify(value)}`,
+    );
+  }
+  return value;
+}
+
+/**
+ * Validate the external payload before use — this is a required financial
+ * series, so a malformed shape must throw (never a silent empty chart). An
+ * empty `points` array is the one valid-empty case (a young reserve).
+ */
+function parseHistoryPayload(
+  payload: unknown,
+  endpoint: string,
+): BorrowRateHistoryPoint[] {
+  if (payload === null || typeof payload !== "object") {
+    throw new Error(
+      `Borrow rate history response from ${endpoint} is not an object`,
+    );
+  }
+
+  const { points } = payload as { points?: unknown };
+  if (!Array.isArray(points)) {
+    throw new Error(
+      `Borrow rate history response from ${endpoint} is missing a "points" array`,
+    );
+  }
+
+  return points.map((point, index) => {
+    if (point === null || typeof point !== "object") {
+      throw new Error(
+        `Borrow rate history point ${index} from ${endpoint} is not an object`,
+      );
+    }
+    const { t, borrowRatePercent } = point as {
+      t?: unknown;
+      borrowRatePercent?: unknown;
+    };
+    const seconds = assertFiniteNumber(t, "t", index, endpoint);
+    const ratePercent = assertFiniteNumber(
+      borrowRatePercent,
+      "borrowRatePercent",
+      index,
+      endpoint,
+    );
+    return { timeMs: seconds * MS_PER_SECOND, ratePercent };
+  });
+}
+
+export async function fetchBorrowRateHistory({
+  reserveId,
+  range,
+  signal,
+}: {
+  reserveId: bigint;
+  range: HistoryRange;
+  signal?: AbortSignal;
+}): Promise<BorrowRateHistoryPoint[]> {
+  const endpoint = `${indexerRestBaseUrl()}/api/aave/reserves/${reserveId.toString()}/history?range=${range}&resolution=${HISTORY_RESOLUTION}`;
+
+  // The status check and body read both need to happen inside the timeout
+  // window — a stalled body on an otherwise-200 response is exactly the hang
+  // the timeout exists to bound — but the non-ok and JSON-parse throws are
+  // raised *outside* withRequestTimeout's callback (via this result), so
+  // neither is reclassified as a generic network failure.
+  const result = await withRequestTimeout<
+    { ok: true; body: string } | { ok: false; status: number }
+  >(
+    {
+      timeoutMs: HISTORY_REQUEST_TIMEOUT_MS,
+      signal,
+      requestLabel: "Borrow rate history request",
+      url: endpoint,
+      includeUrlInTimeoutMessage: true,
+    },
+    async (composedSignal) => {
+      const response = await fetch(endpoint, { signal: composedSignal });
+      if (!response.ok) {
+        return { ok: false, status: response.status };
+      }
+      return { ok: true, body: await response.text() };
+    },
+  );
+
+  if (!result.ok) {
+    throw new Error(
+      `Borrow rate history request to ${endpoint} failed with status ${result.status}`,
+    );
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(result.body);
+  } catch {
+    throw new Error(
+      `Borrow rate history response from ${endpoint} is not valid JSON`,
+    );
+  }
+
+  return parseHistoryPayload(payload, endpoint);
+}

--- a/services/vault/src/components/pages/BorrowingMarketsData/BorrowRateHistoryCard.tsx
+++ b/services/vault/src/components/pages/BorrowingMarketsData/BorrowRateHistoryCard.tsx
@@ -1,0 +1,220 @@
+/**
+ * Borrow-APR history card (C3, Figma node 10088-61052). Range selection is
+ * local, ephemeral state (D6) — it never persists across visits.
+ */
+
+import { Hint, LineChart, type ChartAxisTick } from "@babylonlabs-io/core-ui";
+import { useMemo, useState } from "react";
+
+import { useBorrowRateHistory } from "@/applications/aave/hooks";
+import type {
+  BorrowRateHistoryPoint,
+  HistoryRange,
+} from "@/clients/indexer/aaveHistoryClient";
+import { COPY } from "@/copy";
+import { formatAprPercent } from "@/utils/formatting";
+
+import {
+  fittedRateDomain,
+  hasSubDailySpacing,
+  historyTooltipDate,
+  rateTicks,
+} from "./borrowChartData";
+
+/** Figma's card chrome: `bg-background-secondary rounded-2xl`, pt-6/px-6/pb-10, 24px gap. */
+const CARD_CLASS =
+  "flex w-full flex-col gap-6 rounded-2xl bg-background-secondary pt-6 px-6 pb-10";
+/** Frame's plot box is 1070x156 (see the C3 LineChart mapping table). */
+const CHART_ASPECT_RATIO = 1070 / 156;
+/** The frame shows 3 horizontal gridlines. */
+const Y_TICK_COUNT = 3;
+
+const ACTIVE_RANGE_CLASS =
+  "rounded-lg bg-background-contrast px-2 py-0.5 text-accent-primary";
+const INACTIVE_RANGE_CLASS = "px-2 py-0.5 text-accent-secondary";
+
+const DEFAULT_RANGE: HistoryRange = "1w";
+const RANGE_OPTIONS: HistoryRange[] = ["1d", "1w", "1m", "6m", "1y", "all"];
+
+function rangeLabel(range: HistoryRange): string {
+  const { ranges } = COPY.marketData.charts;
+  switch (range) {
+    case "1d":
+      return ranges.d1;
+    case "1w":
+      return ranges.w1;
+    case "1m":
+      return ranges.m1;
+    case "6m":
+      return ranges.m6;
+    case "1y":
+      return ranges.y1;
+    case "all":
+      return ranges.all;
+  }
+}
+
+/** Range over the loaded series; a single figure (no dash) when it's flat. */
+function headerFigure(points: BorrowRateHistoryPoint[]): string {
+  const rates = points.map((p) => p.ratePercent);
+  const min = Math.min(...rates);
+  const max = Math.max(...rates);
+  return min === max
+    ? formatAprPercent(min)
+    : COPY.marketData.charts.rateRange(
+        formatAprPercent(min),
+        formatAprPercent(max),
+      );
+}
+
+function CardShell({
+  range,
+  onRangeChange,
+  value,
+  children,
+}: {
+  range: HistoryRange;
+  onRangeChange: (range: HistoryRange) => void;
+  /** The big header figure — grouped 4px below the caption-label row (Figma header block). */
+  value?: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className={CARD_CLASS} data-testid="borrow-rate-history-card">
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex flex-col gap-1">
+          <div className="flex items-center gap-1">
+            <span className="text-xs leading-[1.66] tracking-[0.4px] text-accent-secondary">
+              {COPY.marketData.charts.borrowAprLabel}
+            </span>
+            <Hint tooltip={COPY.loans.borrowAprTooltip} />
+          </div>
+          {value}
+        </div>
+        <div className="flex items-center gap-1">
+          {RANGE_OPTIONS.map((option) => (
+            <button
+              key={option}
+              type="button"
+              aria-pressed={option === range}
+              data-testid={`history-range-${option}`}
+              onClick={() => onRangeChange(option)}
+              className={`text-xs leading-[1.66] tracking-[0.4px] ${
+                option === range ? ACTIVE_RANGE_CLASS : INACTIVE_RANGE_CLASS
+              }`}
+            >
+              {rangeLabel(option)}
+            </button>
+          ))}
+        </div>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function CenteredMessage({ message }: { message: string }) {
+  return (
+    <div className="flex flex-1 items-center justify-center py-12">
+      <span className="text-accent-secondary">{message}</span>
+    </div>
+  );
+}
+
+export function BorrowRateHistoryCard({
+  reserveId,
+  symbol,
+}: {
+  reserveId: bigint;
+  symbol: string;
+}) {
+  const [range, setRange] = useState<HistoryRange>(DEFAULT_RANGE);
+  const { points, isLoading, error } = useBorrowRateHistory({
+    reserveId,
+    range,
+  });
+
+  // Hooks run before the early returns below (rules-of-hooks), so these
+  // memos tolerate the null/empty states those returns handle — the
+  // fallback values are never rendered, since those branches bail before
+  // reaching the chart.
+  const chartData = useMemo(
+    () => points?.map((p) => ({ x: p.timeMs, y: p.ratePercent })) ?? [],
+    [points],
+  );
+
+  const domain = useMemo<[number, number]>(
+    () => (points && points.length > 0 ? fittedRateDomain(points) : [0, 0]),
+    [points],
+  );
+
+  const yTicks = useMemo<ChartAxisTick[]>(
+    () => (points && points.length > 0 ? rateTicks(domain, Y_TICK_COUNT) : []),
+    [points, domain],
+  );
+
+  // The tooltip shows the time whenever the served buckets are sub-daily —
+  // the indexer's `resolution=auto` decides that, not the range button.
+  const tooltipWithTime = useMemo(
+    () => (points !== null ? hasSubDailySpacing(points) : false),
+    [points],
+  );
+
+  if (isLoading) {
+    return (
+      <CardShell range={range} onRangeChange={setRange}>
+        <CenteredMessage message={COPY.common.loading} />
+      </CardShell>
+    );
+  }
+
+  if (error || points === null) {
+    return (
+      <CardShell range={range} onRangeChange={setRange}>
+        <CenteredMessage message={COPY.marketData.charts.chartUnavailable} />
+      </CardShell>
+    );
+  }
+
+  if (points.length === 0) {
+    return (
+      <CardShell range={range} onRangeChange={setRange}>
+        <CenteredMessage message={COPY.marketData.charts.historyEmpty} />
+      </CardShell>
+    );
+  }
+
+  return (
+    <CardShell
+      range={range}
+      onRangeChange={setRange}
+      value={
+        <span
+          data-testid="borrow-rate-history-figure"
+          className="text-2xl leading-[1.334] text-accent-primary"
+        >
+          {headerFigure(points)}
+        </span>
+      }
+    >
+      <LineChart
+        data={chartData}
+        interpolation="step"
+        yDomain={domain}
+        yTicks={yTicks}
+        aspectRatio={CHART_ASPECT_RATIO}
+        grid={{ lines: "horizontal", style: "solid" }}
+        hoverMode="nearest"
+        renderTooltip={(hover) => (
+          <>
+            <div>{historyTooltipDate(hover.point.x, tooltipWithTime)}</div>
+            <div>{formatAprPercent(hover.point.y)}</div>
+          </>
+        )}
+        ariaLabel={COPY.marketData.charts.historyAriaLabel(symbol)}
+        color="currentColor"
+        className="text-accent-primary"
+      />
+    </CardShell>
+  );
+}

--- a/services/vault/src/components/pages/BorrowingMarketsData/InterestRateModelCard.tsx
+++ b/services/vault/src/components/pages/BorrowingMarketsData/InterestRateModelCard.tsx
@@ -1,0 +1,258 @@
+/**
+ * C2 — the interest-rate-model chart (Figma node 10088-61091). One curve:
+ * on-chain borrow APR against utilization, with the kink (optimal usage) and
+ * the reserve's live utilization called out. The header row also carries the
+ * frame's "Borrow APR / Utilization Rate" legend, top right — utilization is
+ * still the marker, not a second series; the legend just labels the curve's
+ * color and the shared marker color for the callouts.
+ */
+
+import {
+  Hint,
+  LineChart,
+  type ChartAxisTick,
+  type LineChartMarker,
+} from "@babylonlabs-io/core-ui";
+import { useMemo } from "react";
+
+import { useInterestRateModelCurve } from "@/applications/aave/hooks";
+import type { AaveReserveConfig } from "@/applications/aave/services/fetchConfig";
+import { COPY } from "@/copy";
+import { formatAprPercent } from "@/utils/formatting";
+
+import { percentAxis } from "./borrowChartData";
+
+/** Theme tokens (globals.css) shared by the chart marks and the legend dots
+ *  so they can never drift apart. LineChart pipes the `var()` references into
+ *  its CSS custom properties, so they resolve per theme; the dot classes are
+ *  the same tokens as Tailwind arbitrary values. */
+const MARKER_COLOR = "var(--chart-irm-marker)";
+const SERIES_COLOR = "var(--chart-irm-series)";
+const MARKER_DOT_CLASS = "bg-[color:var(--chart-irm-marker)]";
+const SERIES_DOT_CLASS = "bg-[color:var(--chart-irm-series)]";
+/** Frame plot box is 1070×228 (`10088:61091`). */
+const CHART_ASPECT_RATIO = 1070 / 228;
+/** Frame's x-axis labels row. */
+const X_TICK_VALUES = [0, 25, 50, 75, 100];
+const X_TICKS: ChartAxisTick[] = X_TICK_VALUES.map((value) => ({
+  value,
+  label: `${value}%`,
+}));
+/** Utilization always spans the full 0–100% axis. */
+const X_DOMAIN: [number, number] = [0, 100];
+/** Frame shows 5 rows of y-axis ticks. */
+const Y_TICK_COUNT = 5;
+
+const CARD_CLASS =
+  "flex w-full flex-col gap-6 rounded-2xl bg-background-secondary pt-6 px-6 pb-10";
+/** Shared by every caption in the card (label row, legend entries). */
+const CAPTION_CLASS =
+  "text-xs leading-[1.66] tracking-[0.4px] text-accent-secondary";
+
+/** Utilization percents from the hook are plain 0–100 numbers — round to a
+ *  whole percent for the callout text ("Current 68%", "Optimal (Kink) 80%"). */
+function formatWholeUtilizationPercent(percent: number): string {
+  return `${Math.round(percent)}%`;
+}
+
+function LegendDot({ colorClass }: { colorClass: string }) {
+  return <span className={`size-3 rounded-full ${colorClass}`} />;
+}
+
+/** Top-right header legend (Figma's "Borrow APR / Utilization Rate" pair). */
+function Legend() {
+  return (
+    <div className="flex items-center gap-6">
+      <div className="flex items-center gap-2">
+        <LegendDot colorClass={SERIES_DOT_CLASS} />
+        <span className={CAPTION_CLASS}>
+          {COPY.marketData.charts.borrowAprLabel}
+        </span>
+      </div>
+      <div className="flex items-center gap-2">
+        <LegendDot colorClass={MARKER_DOT_CLASS} />
+        <span className={CAPTION_CLASS}>
+          {COPY.marketData.charts.utilizationRateLabel}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export function InterestRateModelCard({
+  reserve,
+  utilizationValue,
+  symbol,
+}: {
+  reserve: AaveReserveConfig;
+  /** Pre-formatted current-utilization figure the page already derives, e.g. "68%". */
+  utilizationValue: string;
+  symbol: string;
+}) {
+  const {
+    curve,
+    kinkUtilizationPercent,
+    currentUtilizationPercent,
+    currentAprPercent,
+    maxAprPercent,
+    isLoading,
+  } = useInterestRateModelCurve({ reserve });
+
+  // Hooks run before either early return below (rules-of-hooks), so every
+  // memo here must tolerate the null states those returns handle — the
+  // fallback values are never rendered, since the null-curve branch bails
+  // before reaching the chart.
+  const chartData = useMemo(
+    () =>
+      curve?.map((point) => ({
+        x: point.utilizationPercent,
+        y: point.aprPercent,
+      })) ?? [],
+    [curve],
+  );
+
+  // Domain and ticks derive from one rounded ceiling (see percentAxis), so
+  // the top gridline can never land outside the plot.
+  const { domain: yDomain, ticks: yTicks } = useMemo(
+    () =>
+      maxAprPercent !== null && maxAprPercent > 0
+        ? percentAxis(maxAprPercent, Y_TICK_COUNT)
+        : { domain: [0, 0] as [number, number], ticks: [] as ChartAxisTick[] },
+    [maxAprPercent],
+  );
+
+  // The curve always includes an exact sample at the kink utilization (see
+  // useInterestRateModelCurve module doc) — looked up by equality, never
+  // interpolated. That invariant is load-bearing, so its failure throws
+  // rather than degrading to a chart with no kink marker.
+  const markers = useMemo<LineChartMarker[]>(() => {
+    if (
+      curve === null ||
+      kinkUtilizationPercent === null ||
+      currentUtilizationPercent === null ||
+      currentAprPercent === null
+    ) {
+      return [];
+    }
+
+    const kinkPoint = curve.find(
+      (point) => point.utilizationPercent === kinkUtilizationPercent,
+    );
+    if (kinkPoint === undefined) {
+      throw new Error(
+        `IRM curve is missing its exact kink sample at ${kinkUtilizationPercent}% utilization`,
+      );
+    }
+
+    return [
+      {
+        key: "kink",
+        x: kinkUtilizationPercent,
+        title: COPY.marketData.charts.optimalCallout(
+          formatWholeUtilizationPercent(kinkUtilizationPercent),
+        ),
+        lines: [
+          COPY.marketData.charts.calloutApr(
+            formatAprPercent(kinkPoint.aprPercent),
+          ),
+        ],
+        style: "dashed",
+        color: MARKER_COLOR,
+      },
+      {
+        key: "current",
+        x: currentUtilizationPercent,
+        title: COPY.marketData.charts.currentCallout(
+          formatWholeUtilizationPercent(currentUtilizationPercent),
+        ),
+        lines: [
+          COPY.marketData.charts.calloutApr(
+            formatAprPercent(currentAprPercent),
+          ),
+        ],
+        style: "solid",
+        color: MARKER_COLOR,
+      },
+    ];
+  }, [
+    curve,
+    kinkUtilizationPercent,
+    currentUtilizationPercent,
+    currentAprPercent,
+  ]);
+
+  const header = (
+    <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-col gap-1">
+        <div className="flex items-center gap-1">
+          <span className={CAPTION_CLASS}>
+            {COPY.marketData.charts.utilizationRateLabel}
+          </span>
+          <Hint tooltip={COPY.marketData.charts.utilizationRateTooltip} />
+        </div>
+        <span className="text-2xl leading-[1.334] text-accent-primary">
+          {utilizationValue}
+        </span>
+      </div>
+      <Legend />
+    </div>
+  );
+
+  if (isLoading) {
+    return (
+      <div className={CARD_CLASS} data-testid="interest-rate-model-card">
+        {header}
+        <p className="text-accent-secondary">{COPY.common.loading}</p>
+      </div>
+    );
+  }
+
+  // A configured strategy always yields the full sample set plus the kink and
+  // current figures (see useInterestRateModelCurve); anything null here means
+  // the read failed, not that the market genuinely has no rate. A max of 0
+  // (a strategy with every rate param zeroed) is folded in: it admits no
+  // usable y scale, only a degenerate [0, 0] domain.
+  if (
+    curve === null ||
+    kinkUtilizationPercent === null ||
+    currentUtilizationPercent === null ||
+    currentAprPercent === null ||
+    maxAprPercent === null ||
+    maxAprPercent === 0
+  ) {
+    return (
+      <div className={CARD_CLASS} data-testid="interest-rate-model-card">
+        {header}
+        <p className="text-accent-secondary">
+          {COPY.marketData.charts.chartUnavailable}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={CARD_CLASS} data-testid="interest-rate-model-card">
+      {header}
+      <LineChart
+        data={chartData}
+        interpolation="linear"
+        xDomain={X_DOMAIN}
+        yDomain={yDomain}
+        yTicks={yTicks}
+        xTicks={X_TICKS}
+        markers={markers}
+        color={SERIES_COLOR}
+        aspectRatio={CHART_ASPECT_RATIO}
+        grid={{ lines: "horizontal", style: "solid" }}
+        hoverMode="interpolate"
+        renderTooltip={(hover) => (
+          <div className="flex flex-col gap-0.5">
+            <span>{formatWholeUtilizationPercent(hover.x)}</span>
+            <span>{formatAprPercent(hover.y)}</span>
+          </div>
+        )}
+        ariaLabel={COPY.marketData.charts.irmAriaLabel(symbol)}
+      />
+    </div>
+  );
+}

--- a/services/vault/src/components/pages/BorrowingMarketsData/__tests__/BorrowRateHistoryCard.test.tsx
+++ b/services/vault/src/components/pages/BorrowingMarketsData/__tests__/BorrowRateHistoryCard.test.tsx
@@ -1,0 +1,185 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// core-ui's dist is built in this worktree, so the real LineChart renders;
+// only Hint is swapped for a no-op (matches the sibling cards' convention),
+// since the brief requires exercising the real chart output, not a mock.
+vi.mock("@babylonlabs-io/core-ui", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@babylonlabs-io/core-ui")>();
+  return { ...actual, Hint: () => null };
+});
+
+vi.mock("@/applications/aave/hooks", () => ({
+  useBorrowRateHistory: vi.fn(),
+}));
+
+import { useBorrowRateHistory } from "@/applications/aave/hooks";
+import { COPY } from "@/copy";
+
+import { BorrowRateHistoryCard } from "../BorrowRateHistoryCard";
+
+const mockedUseBorrowRateHistory = vi.mocked(useBorrowRateHistory);
+
+function hitArea() {
+  return screen.getByTestId("line-chart-hit");
+}
+
+describe("BorrowRateHistoryCard", () => {
+  beforeEach(() => {
+    mockedUseBorrowRateHistory.mockReset();
+  });
+
+  it("opens on the 1W range and queries the hook with it", () => {
+    mockedUseBorrowRateHistory.mockReturnValue({
+      points: [{ timeMs: 1_000, ratePercent: 3.5 }],
+      isLoading: false,
+      error: null,
+    });
+
+    render(<BorrowRateHistoryCard reserveId={5n} symbol="vBTC" />);
+
+    expect(mockedUseBorrowRateHistory).toHaveBeenCalledWith({
+      reserveId: 5n,
+      range: "1w",
+    });
+    const activeButton = screen.getByTestId("history-range-1w");
+    expect(activeButton.className).toContain("bg-background-contrast");
+    // The selection is also exposed non-visually.
+    expect(activeButton).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByTestId("history-range-1d")).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+  });
+
+  it("draws the history line in the theme's primary text color, not the series default", () => {
+    mockedUseBorrowRateHistory.mockReturnValue({
+      points: [{ timeMs: 1_000, ratePercent: 3.5 }],
+      isLoading: false,
+      error: null,
+    });
+
+    const { container } = render(
+      <BorrowRateHistoryCard reserveId={5n} symbol="vBTC" />,
+    );
+
+    const chartRoot = container.querySelector(".bbn-line-chart");
+    expect(chartRoot?.className).toContain("text-accent-primary");
+
+    const seriesPath = chartRoot?.querySelector(".bbn-line-chart__series");
+    const seriesGroup = seriesPath?.closest("g");
+    expect(seriesGroup?.getAttribute("style")).toContain(
+      "--bbn-line-chart-series: currentColor",
+    );
+  });
+
+  it("re-queries with 6m and recomputes the header range when 6M is clicked", () => {
+    mockedUseBorrowRateHistory.mockImplementation(({ range }) =>
+      range === "1w"
+        ? {
+            points: [{ timeMs: 1_000, ratePercent: 3.5 }],
+            isLoading: false,
+            error: null,
+          }
+        : {
+            points: [
+              { timeMs: 1_000, ratePercent: 2.0 },
+              { timeMs: 2_000, ratePercent: 4.0 },
+            ],
+            isLoading: false,
+            error: null,
+          },
+    );
+
+    render(<BorrowRateHistoryCard reserveId={5n} symbol="vBTC" />);
+
+    expect(screen.getByTestId("borrow-rate-history-figure")).toHaveTextContent(
+      "3.5%",
+    );
+
+    fireEvent.click(screen.getByTestId("history-range-6m"));
+
+    expect(mockedUseBorrowRateHistory).toHaveBeenLastCalledWith({
+      reserveId: 5n,
+      range: "6m",
+    });
+    expect(screen.getByTestId("borrow-rate-history-figure")).toHaveTextContent(
+      "2% – 4%",
+    );
+    const active = screen.getByTestId("history-range-6m");
+    expect(active.className).toContain("bg-background-contrast");
+  });
+
+  it("shows the loading copy while the hook is loading", () => {
+    mockedUseBorrowRateHistory.mockReturnValue({
+      points: null,
+      isLoading: true,
+      error: null,
+    });
+
+    render(<BorrowRateHistoryCard reserveId={5n} symbol="vBTC" />);
+
+    expect(screen.getByText(COPY.common.loading)).toBeInTheDocument();
+  });
+
+  it("shows the unavailable copy on a hook error", () => {
+    mockedUseBorrowRateHistory.mockReturnValue({
+      points: null,
+      isLoading: false,
+      error: new Error("indexer down"),
+    });
+
+    render(<BorrowRateHistoryCard reserveId={5n} symbol="vBTC" />);
+
+    expect(
+      screen.getByText(COPY.marketData.charts.chartUnavailable),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the empty copy when the reserve has no history", () => {
+    mockedUseBorrowRateHistory.mockReturnValue({
+      points: [],
+      isLoading: false,
+      error: null,
+    });
+
+    render(<BorrowRateHistoryCard reserveId={5n} symbol="vBTC" />);
+
+    expect(
+      screen.getByText(COPY.marketData.charts.historyEmpty),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the hovered datum's date and rate — proving coordinate-driven selection, not an index-0 fallback", () => {
+    mockedUseBorrowRateHistory.mockReturnValue({
+      points: [
+        { timeMs: new Date(2026, 6, 4, 14, 0).getTime(), ratePercent: 3.0 },
+        { timeMs: new Date(2026, 6, 5, 14, 0).getTime(), ratePercent: 4.0 },
+      ],
+      isLoading: false,
+      error: null,
+    });
+
+    const { container } = render(
+      <BorrowRateHistoryCard reserveId={5n} symbol="vBTC" />,
+    );
+
+    // jsdom reports an all-zero client rect for the hit area, so `clientX`
+    // reads straight through as the plot-local x (see LineChart's own
+    // tests). The fallback chart width is 1016px; this repo's test setup has
+    // no canvas backend, so measureText returns 0 and the measured gutter
+    // collapses to the fixed 24px label gap, leaving a 992px plot. 948 sits
+    // well past its midpoint, selecting the SECOND datum in "nearest" mode.
+    // A NaN-coordinate bug (no PointerEvent polyfill) would instead always
+    // resolve to index 0, i.e. the first datum's date/rate, so asserting the
+    // second proves real coordinates drove the selection.
+    fireEvent.pointerMove(hitArea(), { clientX: 948 });
+
+    const tooltip = container.querySelector(".bbn-line-chart__tooltip");
+    expect(tooltip).toHaveTextContent("Jul 5, 2026");
+    expect(tooltip).toHaveTextContent("4%");
+    expect(tooltip?.textContent).not.toContain("Jul 4");
+    expect(tooltip?.textContent).not.toContain("3%");
+  });
+});

--- a/services/vault/src/components/pages/BorrowingMarketsData/__tests__/BorrowingMarketsData.test.tsx
+++ b/services/vault/src/components/pages/BorrowingMarketsData/__tests__/BorrowingMarketsData.test.tsx
@@ -3,9 +3,13 @@
  *
  * The page turns raw hook data (liquidity, APR, oracle price, on-chain split
  * params) into the display strings shown in the stats bar, the collateral
- * card, and the markets table. Child components are real (only `core-ui` is
- * mocked, matching the sibling tests in this directory) so these tests lock
- * in the page's own formatting/routing logic, not markup.
+ * card, and the markets table. Most child components are real (only `core-ui`
+ * is mocked, matching the sibling tests in this directory) so these tests
+ * lock in the page's own formatting/routing logic, not markup. The two chart
+ * cards (`BorrowRateHistoryCard`, `InterestRateModelCard`) are the exception —
+ * stubbed here since their own internals (hooks, chart rendering, hover) are
+ * already covered by their dedicated test files; this suite only locks in
+ * that the page passes them the right props and gates them correctly.
  *
  * Routing is by on-chain reserve id, not token symbol (audit F7 — a symbol
  * comes from the indexer, so routing by it lets a compromised indexer decide
@@ -18,7 +22,7 @@
 import { render, screen, within } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { MemoryRouter, Route, Routes } from "react-router";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Component tests mock core-ui (its dist isn't built in the test run) —
 // consistent with BorrowMarketsTable.test.tsx / CollateralInfoCard.test.tsx.
@@ -67,6 +71,29 @@ const useDemoMarketDataMock = vi.fn();
 
 vi.mock("@/dev/demoMarketData", () => ({
   useDemoMarketData: () => useDemoMarketDataMock(),
+}));
+
+// The two chart cards have their own dedicated test files (chart internals,
+// hover, hooks); here they're stubbed to lock in only the page's own wiring —
+// which props reach them and the `selectedReserve !== null` gate.
+const borrowRateHistoryCardMock = vi.fn();
+vi.mock("../BorrowRateHistoryCard", () => ({
+  BorrowRateHistoryCard: (props: { reserveId: bigint; symbol: string }) => {
+    borrowRateHistoryCardMock(props);
+    return <div data-testid="borrow-rate-history-card-stub" />;
+  },
+}));
+
+const interestRateModelCardMock = vi.fn();
+vi.mock("../InterestRateModelCard", () => ({
+  InterestRateModelCard: (props: {
+    reserve: { reserveId: bigint };
+    utilizationValue: string;
+    symbol: string;
+  }) => {
+    interestRateModelCardMock(props);
+    return <div data-testid="interest-rate-model-card-stub" />;
+  },
 }));
 
 const useAaveConfigMock = vi.fn();
@@ -249,6 +276,52 @@ function renderPage(reserveIdParam: string) {
 }
 
 describe("BorrowingMarketsData", () => {
+  beforeEach(() => {
+    borrowRateHistoryCardMock.mockClear();
+    interestRateModelCardMock.mockClear();
+  });
+
+  it("wires the routed reserve's id, config, and market-utilization figure into the two chart cards", () => {
+    setUpHooks();
+
+    renderPage("1");
+
+    expect(borrowRateHistoryCardMock).toHaveBeenCalledWith({
+      reserveId: 1n,
+      symbol: "USDC-VERIFIED",
+    });
+    expect(interestRateModelCardMock).toHaveBeenCalledWith({
+      reserve: USDC_RESERVE,
+      // Same "68%" the stats bar shows for reserve 1's utilizationBps (6800).
+      utilizationValue: "68%",
+      symbol: "USDC-VERIFIED",
+    });
+  });
+
+  // `selectedReserve` is typed `AaveReserveConfig | null`, and identity is a
+  // separate mocked read the type system can't tie back to it — this forces
+  // that decoupling (identity resolved, but no reserve matches the route) to
+  // prove the page's own null-check gates the cards rather than a non-null
+  // assertion that would crash instead of degrading.
+  it("renders neither chart card when no reserve resolves for the route", () => {
+    setUpHooks({ borrowableReserves: [] });
+
+    renderPage("1");
+
+    expect(borrowRateHistoryCardMock).not.toHaveBeenCalled();
+    expect(interestRateModelCardMock).not.toHaveBeenCalled();
+    expect(
+      screen.queryByTestId("borrow-rate-history-card-stub"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("interest-rate-model-card-stub"),
+    ).not.toBeInTheDocument();
+    // The testid wrapper itself must survive regardless (E2E hook).
+    expect(
+      screen.getByTestId("market-section-borrow-apr-chart"),
+    ).toBeInTheDocument();
+  });
+
   it("shows the routed reserve's figures in the stats bar, in uppercase compact form", () => {
     setUpHooks();
 

--- a/services/vault/src/components/pages/BorrowingMarketsData/__tests__/InterestRateModelCard.test.tsx
+++ b/services/vault/src/components/pages/BorrowingMarketsData/__tests__/InterestRateModelCard.test.tsx
@@ -1,0 +1,312 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+// core-ui's dist is built in this worktree, so the real LineChart renders;
+// only Hint is swapped for a stub that surfaces its `tooltip` prop as text
+// (real Hint renders its tooltip via a floating-ui portal on hover, which
+// isn't worth exercising here — the card's job is just to pass the right
+// copy through).
+vi.mock("@babylonlabs-io/core-ui", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@babylonlabs-io/core-ui")>();
+  return {
+    ...actual,
+    Hint: ({ tooltip }: { tooltip?: React.ReactNode }) => (
+      <span data-testid="utilization-rate-hint">{tooltip}</span>
+    ),
+  };
+});
+
+vi.mock("@/applications/aave/hooks", () => ({
+  useInterestRateModelCurve: vi.fn(),
+}));
+
+import type { IrmCurvePoint } from "@/applications/aave/clients/aaveIrm";
+import { useInterestRateModelCurve } from "@/applications/aave/hooks";
+import type { AaveReserveConfig } from "@/applications/aave/services/fetchConfig";
+import { COPY } from "@/copy";
+
+import { InterestRateModelCard } from "../InterestRateModelCard";
+
+// The chart renders from the deterministic jsdom fallback width (chartWidth
+// 1016), but the y-axis gutter is now measured from the widest rendered tick
+// label + a fixed 24px gap (see chartLayout.ts's measureYAxisGutter) rather
+// than a fluid clamp — and this repo's test setup, unlike core-ui's own,
+// stubs no canvas backend, so the exact gutter isn't a value worth
+// hardcoding here. Read the plot width straight off the rendered hit rect
+// instead (see `measuredPlotWidth`), which is exactly `layout.plotWidth`.
+// The card's own aspectRatio (frame plot box 1070x228, see the brief's D4/C2
+// mapping table). Kept in sync with the constant of the same name in
+// InterestRateModelCard.tsx.
+const CHART_ASPECT_RATIO = 1070 / 228;
+
+const MOCK_KINK_APR = 12;
+const MOCK_CURRENT_APR = 9;
+const MOCK_MAX_APR = 24;
+
+const MOCK_CURVE: IrmCurvePoint[] = [
+  { utilizationPercent: 0, aprPercent: 0 },
+  { utilizationPercent: 50, aprPercent: 5 },
+  { utilizationPercent: 68, aprPercent: MOCK_CURRENT_APR },
+  { utilizationPercent: 80, aprPercent: MOCK_KINK_APR },
+  { utilizationPercent: 100, aprPercent: MOCK_MAX_APR },
+];
+
+const FULL_HOOK_RESULT = {
+  curve: MOCK_CURVE,
+  kinkUtilizationPercent: 80,
+  currentUtilizationPercent: 68,
+  currentAprPercent: MOCK_CURRENT_APR,
+  maxAprPercent: MOCK_MAX_APR,
+  isLoading: false,
+  error: null,
+};
+
+function makeReserve(
+  overrides: Partial<AaveReserveConfig["reserve"]> = {},
+): AaveReserveConfig {
+  return {
+    reserveId: 1n,
+    reserve: {
+      underlying: "0x0000000000000000000000000000000000000010",
+      hub: "0x0000000000000000000000000000000000000003",
+      assetId: 0,
+      decimals: 6,
+      dynamicConfigKey: 0,
+      paused: false,
+      frozen: false,
+      borrowable: true,
+      collateralRisk: 0,
+      collateralFactor: 8000,
+      ...overrides,
+    },
+    token: {
+      address: "0x0000000000000000000000000000000000000010",
+      symbol: "USDC",
+      name: "USD Coin",
+      decimals: 6,
+    },
+  };
+}
+
+function renderCard(
+  reserveOverrides: Partial<AaveReserveConfig["reserve"]> = {},
+) {
+  return render(
+    <InterestRateModelCard
+      reserve={makeReserve(reserveOverrides)}
+      utilizationValue="68%"
+      symbol="USDC"
+    />,
+  );
+}
+
+function hitArea() {
+  return screen.getByTestId("line-chart-hit");
+}
+
+/** The rendered plot's width in px — exactly `layout.plotWidth` (see
+ * LineChart.tsx's `<Bar className="bbn-line-chart__hit" width={...} />`). */
+function measuredPlotWidth(): number {
+  return Number(hitArea().getAttribute("width"));
+}
+
+describe("InterestRateModelCard", () => {
+  it("renders the utilization-rate header caption and value", () => {
+    vi.mocked(useInterestRateModelCurve).mockReturnValue(FULL_HOOK_RESULT);
+
+    renderCard();
+
+    // Header caption and legend entry share the one copy string.
+    expect(
+      screen.getAllByText(COPY.marketData.charts.utilizationRateLabel),
+    ).toHaveLength(2);
+    expect(screen.getByText("68%")).toBeInTheDocument();
+  });
+
+  it("shows the utilization-rate info tooltip copy next to the header label", () => {
+    vi.mocked(useInterestRateModelCurve).mockReturnValue(FULL_HOOK_RESULT);
+
+    renderCard();
+
+    expect(screen.getByTestId("utilization-rate-hint")).toHaveTextContent(
+      COPY.marketData.charts.utilizationRateTooltip,
+    );
+  });
+
+  it("renders the header legend with a dot and label for each series", () => {
+    vi.mocked(useInterestRateModelCurve).mockReturnValue(FULL_HOOK_RESULT);
+
+    const { container } = renderCard();
+
+    // jsdom doesn't resolve custom properties, so the assertions check the
+    // theme-token reference itself (globals.css owns the per-theme values).
+    const dots = container.querySelectorAll(".size-3.rounded-full");
+    expect(dots).toHaveLength(2);
+    expect(dots[0].className).toContain("bg-[color:var(--chart-irm-series)]");
+    expect(dots[1].className).toContain("bg-[color:var(--chart-irm-marker)]");
+    expect(
+      screen.getByText(COPY.marketData.charts.borrowAprLabel),
+    ).toBeInTheDocument();
+    // The legend's second entry shares the header caption's copy string.
+    expect(
+      screen.getAllByText(COPY.marketData.charts.utilizationRateLabel).length,
+    ).toBeGreaterThan(0);
+  });
+
+  it("passes the curve's series color as the legend's token, not the core-ui default implicitly", () => {
+    vi.mocked(useInterestRateModelCurve).mockReturnValue(FULL_HOOK_RESULT);
+
+    const { container } = renderCard();
+
+    const seriesPath = container.querySelector(".bbn-line-chart__series");
+    const seriesGroup = seriesPath?.closest("g");
+    expect(seriesGroup?.getAttribute("style")).toContain(
+      "--bbn-line-chart-series: var(--chart-irm-series)",
+    );
+  });
+
+  it("passes markers in kink-first order with the dashed/solid styles and shared marker color", () => {
+    vi.mocked(useInterestRateModelCurve).mockReturnValue(FULL_HOOK_RESULT);
+
+    const { container } = renderCard();
+
+    const rules = container.querySelectorAll(".bbn-line-chart__rule");
+    expect(rules).toHaveLength(2);
+    expect(rules[0].classList.contains("bbn-line-chart__rule--dashed")).toBe(
+      true,
+    );
+    expect(rules[1].classList.contains("bbn-line-chart__rule--dashed")).toBe(
+      false,
+    );
+
+    // Both markers share the design's accent-orange token (D3).
+    for (const rule of rules) {
+      const group = rule.closest("g");
+      expect(group?.getAttribute("style")).toContain(
+        "--bbn-line-chart-marker: var(--chart-irm-marker)",
+      );
+    }
+
+    const titles = Array.from(
+      container.querySelectorAll(".bbn-line-chart__callout-title"),
+    ).map((el) => el.textContent);
+    expect(titles).toEqual(["Optimal (Kink) 80%", "Current 68%"]);
+  });
+
+  it("builds callout APR lines from the on-chain kink and current figures", () => {
+    vi.mocked(useInterestRateModelCurve).mockReturnValue(FULL_HOOK_RESULT);
+
+    const { container } = renderCard();
+
+    const lines = Array.from(
+      container.querySelectorAll(".bbn-line-chart__callout-line"),
+    ).map((el) => el.textContent);
+    // kink apr = 12 (curve sample at utilization 80), current apr = 9.
+    expect(lines).toEqual(["APR ~ 12%", "APR ~ 9%"]);
+  });
+
+  it("scales the y-axis to the on-chain maxAprPercent, not a fixed ceiling", () => {
+    vi.mocked(useInterestRateModelCurve).mockReturnValue(FULL_HOOK_RESULT);
+
+    const { container } = renderCard();
+
+    const plotHeight = measuredPlotWidth() / CHART_ASPECT_RATIO;
+    const dots = container.querySelectorAll(".bbn-line-chart__dot");
+    expect(dots).toHaveLength(2);
+    // kink dot: apr 12 of max 24 -> halfway up the plot.
+    expect(Number(dots[0].getAttribute("cy"))).toBeCloseTo(
+      plotHeight * (1 - MOCK_KINK_APR / MOCK_MAX_APR),
+      5,
+    );
+    // current dot: apr 9 of max 24.
+    expect(Number(dots[1].getAttribute("cy"))).toBeCloseTo(
+      plotHeight * (1 - MOCK_CURRENT_APR / MOCK_MAX_APR),
+      5,
+    );
+
+    const axisTexts = Array.from(
+      container.querySelectorAll(".bbn-line-chart__axis-text"),
+    ).map((el) => el.textContent);
+    expect(axisTexts).toContain("24%");
+    expect(axisTexts).not.toContain("8%");
+  });
+
+  it("shows the hovered utilization and interpolated APR in the tooltip", () => {
+    vi.mocked(useInterestRateModelCurve).mockReturnValue(FULL_HOOK_RESULT);
+
+    const { container } = renderCard();
+
+    // Half the measured plot width lands on utilization 50% (domain [0,100]),
+    // an exact curve sample (aprPercent 5), so no interpolation rounding to
+    // account for.
+    fireEvent.pointerMove(hitArea(), { clientX: measuredPlotWidth() / 2 });
+
+    const tooltip = container.querySelector(".bbn-line-chart__tooltip");
+    expect(tooltip?.textContent).toContain("50%");
+    expect(tooltip?.textContent).toContain("5%");
+  });
+
+  it("renders normally for a paused reserve, with no special casing", () => {
+    vi.mocked(useInterestRateModelCurve).mockReturnValue(FULL_HOOK_RESULT);
+
+    renderCard({ paused: true });
+
+    expect(screen.getByText("Optimal (Kink) 80%")).toBeInTheDocument();
+    expect(
+      screen.queryByText(COPY.marketData.charts.chartUnavailable),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the unavailable message when the curve is null", () => {
+    vi.mocked(useInterestRateModelCurve).mockReturnValue({
+      curve: null,
+      kinkUtilizationPercent: null,
+      currentUtilizationPercent: null,
+      currentAprPercent: null,
+      maxAprPercent: null,
+      isLoading: false,
+      error: new Error("Interest-rate strategy curve read reverted"),
+    });
+
+    const { container } = renderCard();
+
+    expect(
+      screen.getByText(COPY.marketData.charts.chartUnavailable),
+    ).toBeInTheDocument();
+    expect(container.querySelector("svg")).not.toBeInTheDocument();
+  });
+
+  it("shows the unavailable message for an all-zero rate shape instead of a degenerate [0, 0] scale", () => {
+    vi.mocked(useInterestRateModelCurve).mockReturnValue({
+      ...FULL_HOOK_RESULT,
+      maxAprPercent: 0,
+    });
+
+    const { container } = renderCard();
+
+    expect(
+      screen.getByText(COPY.marketData.charts.chartUnavailable),
+    ).toBeInTheDocument();
+    expect(container.querySelector("svg")).not.toBeInTheDocument();
+  });
+
+  it("shows the loading message while the hook is loading", () => {
+    vi.mocked(useInterestRateModelCurve).mockReturnValue({
+      curve: null,
+      kinkUtilizationPercent: null,
+      currentUtilizationPercent: null,
+      currentAprPercent: null,
+      maxAprPercent: null,
+      isLoading: true,
+      error: null,
+    });
+
+    renderCard();
+
+    expect(screen.getByText(COPY.common.loading)).toBeInTheDocument();
+    expect(
+      screen.queryByText(COPY.marketData.charts.chartUnavailable),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/services/vault/src/components/pages/BorrowingMarketsData/__tests__/borrowChartData.test.ts
+++ b/services/vault/src/components/pages/BorrowingMarketsData/__tests__/borrowChartData.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  fittedRateDomain,
+  hasSubDailySpacing,
+  historyTooltipDate,
+  percentAxis,
+  rateTicks,
+} from "../borrowChartData";
+
+describe("fittedRateDomain", () => {
+  it("pads a multi-point domain by 5% of its span", () => {
+    const points = [
+      { timeMs: 0, ratePercent: 3.0 },
+      { timeMs: 1, ratePercent: 3.5 },
+      { timeMs: 2, ratePercent: 4.0 },
+    ];
+
+    expect(fittedRateDomain(points)).toEqual([2.95, 4.05]);
+  });
+
+  it("pads a flat non-zero series to a visible band sized off the value", () => {
+    const points = [
+      { timeMs: 0, ratePercent: 5.0 },
+      { timeMs: 1, ratePercent: 5.0 },
+    ];
+
+    expect(fittedRateDomain(points)).toEqual([4.75, 5.25]);
+  });
+
+  it("clamps the floor band at 0 for an exactly-zero flat series — a rate is never negative", () => {
+    const points = [
+      { timeMs: 0, ratePercent: 0 },
+      { timeMs: 1, ratePercent: 0 },
+    ];
+
+    expect(fittedRateDomain(points)).toEqual([0, 0.1]);
+  });
+
+  it("clamps a low flat series' domain at 0 rather than padding below zero", () => {
+    const points = [
+      { timeMs: 0, ratePercent: 0.02 },
+      { timeMs: 1, ratePercent: 0.02 },
+    ];
+
+    // Unclamped this would be [0.02 - 0.1, 0.02 + 0.1] = [-0.08, 0.12].
+    const [lo, hi] = fittedRateDomain(points);
+    expect(lo).toBe(0);
+    expect(hi).toBeCloseTo(0.12, 10);
+  });
+
+  it("treats a single point as a flat series", () => {
+    const points = [{ timeMs: 0, ratePercent: 2.0 }];
+
+    expect(fittedRateDomain(points)).toEqual([1.9, 2.1]);
+  });
+
+  it("throws on an empty series rather than returning a fake domain", () => {
+    expect(() => fittedRateDomain([])).toThrow();
+  });
+});
+
+describe("rateTicks", () => {
+  it("returns count evenly spaced ticks with formatted labels", () => {
+    expect(rateTicks([3, 4], 3)).toEqual([
+      { value: 3, label: "3%" },
+      { value: 3.5, label: "3.5%" },
+      { value: 4, label: "4%" },
+    ]);
+  });
+
+  it("spans exactly the two domain endpoints when count is 2", () => {
+    expect(rateTicks([1, 5], 2)).toEqual([
+      { value: 1, label: "1%" },
+      { value: 5, label: "5%" },
+    ]);
+  });
+
+  it("returns a single tick at the domain minimum when count is 1", () => {
+    expect(rateTicks([2, 8], 1)).toEqual([{ value: 2, label: "2%" }]);
+  });
+
+  it("produces distinct labels when chained from an all-zero-rate series' fitted domain", () => {
+    // Regression: an idle reserve's rate is genuinely 0% for the whole
+    // window. If fittedRateDomain let the lower bound dip below 0, the two
+    // lowest ticks would both round through formatAprPercent's `percent <= 0`
+    // branch to the same "0%" label — an indistinguishable gridline pair.
+    const points = [
+      { timeMs: 0, ratePercent: 0 },
+      { timeMs: 1, ratePercent: 0 },
+    ];
+
+    const ticks = rateTicks(fittedRateDomain(points), 3);
+
+    expect(ticks.map((t) => t.label)).toEqual(["0%", "0.05%", "0.1%"]);
+    expect(new Set(ticks.map((t) => t.label)).size).toBe(ticks.length);
+  });
+});
+
+describe("percentAxis", () => {
+  it("produces 5 even whole-percent ticks and a matching domain for an evenly divisible max", () => {
+    expect(percentAxis(24, 5)).toEqual({
+      domain: [0, 24],
+      ticks: [
+        { value: 0, label: "0%" },
+        { value: 6, label: "6%" },
+        { value: 12, label: "12%" },
+        { value: 18, label: "18%" },
+        { value: 24, label: "24%" },
+      ],
+    });
+  });
+
+  it("rounds the ceiling up so the top tick never lands outside the domain", () => {
+    // Independently-rounded steps would put the top tick (65) above a
+    // [0, 64.5] domain — and the chart SVG is overflow: visible.
+    const { domain, ticks } = percentAxis(64.5, 5);
+
+    expect(domain).toEqual([0, 68]);
+    expect(ticks.map((t) => t.value)).toEqual([0, 17, 34, 51, 68]);
+  });
+
+  it("keeps every tick distinct for a max smaller than the tick count", () => {
+    // Whole-percent rounding of 5 steps across [0, 2] would emit duplicate
+    // values — duplicate React keys and overlapping gridlines downstream.
+    const { domain, ticks } = percentAxis(2, 5);
+
+    expect(domain).toEqual([0, 4]);
+    expect(ticks.map((t) => t.value)).toEqual([0, 1, 2, 3, 4]);
+    expect(new Set(ticks.map((t) => t.value)).size).toBe(ticks.length);
+  });
+
+  it("returns a single zero tick when count is 1", () => {
+    expect(percentAxis(24, 1)).toEqual({
+      domain: [0, 24],
+      ticks: [{ value: 0, label: "0%" }],
+    });
+  });
+});
+
+describe("hasSubDailySpacing", () => {
+  const HOUR_MS = 60 * 60 * 1_000;
+
+  it("is true when any adjacent samples sit less than a day apart", () => {
+    const points = [
+      { timeMs: 0, ratePercent: 3 },
+      { timeMs: 24 * HOUR_MS, ratePercent: 3.2 },
+      { timeMs: 25 * HOUR_MS, ratePercent: 3.4 },
+    ];
+
+    expect(hasSubDailySpacing(points)).toBe(true);
+  });
+
+  it("is false for daily-or-coarser buckets", () => {
+    const points = [
+      { timeMs: 0, ratePercent: 3 },
+      { timeMs: 24 * HOUR_MS, ratePercent: 3.2 },
+      { timeMs: 72 * HOUR_MS, ratePercent: 3.4 },
+    ];
+
+    expect(hasSubDailySpacing(points)).toBe(false);
+  });
+
+  it("is false for a single point — there is no adjacent pair to collide", () => {
+    expect(hasSubDailySpacing([{ timeMs: 0, ratePercent: 3 }])).toBe(false);
+  });
+});
+
+describe("historyTooltipDate", () => {
+  it("renders date and time for sub-daily buckets", () => {
+    const timeMs = new Date(2026, 6, 4, 14, 0).getTime();
+
+    expect(historyTooltipDate(timeMs, true)).toBe("Jul 4, 14:00");
+  });
+
+  it("renders date and year (no time) for daily-or-coarser buckets", () => {
+    const timeMs = new Date(2026, 6, 4, 14, 0).getTime();
+
+    expect(historyTooltipDate(timeMs, false)).toBe("Jul 4, 2026");
+  });
+
+  it("pads single-digit hours and minutes", () => {
+    const timeMs = new Date(2026, 0, 9, 4, 5).getTime();
+
+    expect(historyTooltipDate(timeMs, true)).toBe("Jan 9, 04:05");
+  });
+});

--- a/services/vault/src/components/pages/BorrowingMarketsData/__tests__/identity.test.tsx
+++ b/services/vault/src/components/pages/BorrowingMarketsData/__tests__/identity.test.tsx
@@ -71,6 +71,12 @@ const mockUseAaveBorrowAprs = vi.fn();
 const mockUseAaveReserveLiquidity = vi.fn();
 const mockUseAaveReservesPrices = vi.fn();
 const mockUseVaultSplitParams = vi.fn();
+// This suite isn't about the two chart cards (see BorrowRateHistoryCard.test.tsx
+// / InterestRateModelCard.test.tsx for their own behavior) — stubbed to their
+// empty/unavailable states so mounting the real page doesn't need a chart data
+// fixture or a LineChart mock here too.
+const mockUseBorrowRateHistory = vi.fn();
+const mockUseInterestRateModelCurve = vi.fn();
 vi.mock("@/applications/aave/hooks", () => ({
   useVerifiedReserveIdentity: (args: unknown) =>
     mockUseVerifiedReserveIdentity(args),
@@ -78,6 +84,8 @@ vi.mock("@/applications/aave/hooks", () => ({
   useAaveReserveLiquidity: () => mockUseAaveReserveLiquidity(),
   useAaveReservesPrices: () => mockUseAaveReservesPrices(),
   useVaultSplitParams: () => mockUseVaultSplitParams(),
+  useBorrowRateHistory: () => mockUseBorrowRateHistory(),
+  useInterestRateModelCurve: () => mockUseInterestRateModelCurve(),
 }));
 
 const mockUseDemoMarketData = vi.fn();
@@ -115,6 +123,20 @@ describe("BorrowingMarketsData", () => {
     mockUseAaveReservesPrices.mockReturnValue({ pricesByReserveId: {} });
     mockUseVaultSplitParams.mockReturnValue({ params: null });
     mockUseDemoMarketData.mockReturnValue(null);
+    mockUseBorrowRateHistory.mockReturnValue({
+      points: [],
+      isLoading: false,
+      error: null,
+    });
+    mockUseInterestRateModelCurve.mockReturnValue({
+      curve: null,
+      kinkUtilizationPercent: null,
+      currentUtilizationPercent: null,
+      currentAprPercent: null,
+      maxAprPercent: null,
+      isLoading: false,
+      error: null,
+    });
   });
 
   it("verifies the reserve the id resolves to, against its on-chain underlying", () => {

--- a/services/vault/src/components/pages/BorrowingMarketsData/borrowChartData.ts
+++ b/services/vault/src/components/pages/BorrowingMarketsData/borrowChartData.ts
@@ -1,0 +1,124 @@
+/**
+ * Pure chart helpers shared by the Aave market-data charts: the borrow-APR
+ * history card (C3, Figma node 10088-61052) and the interest-rate-model card
+ * (C2, Figma node 10088-61091). Kept free of React so the domain/tick/date
+ * math is testable without rendering `LineChart`.
+ */
+
+import type { ChartAxisTick } from "@babylonlabs-io/core-ui";
+
+import type { BorrowRateHistoryPoint } from "@/clients/indexer/aaveHistoryClient";
+import { formatAprPercent } from "@/utils/formatting";
+
+/** Headroom added to a non-flat domain, as a fraction of its span. */
+const RATE_DOMAIN_PAD_FRACTION = 0.05;
+
+/**
+ * Minimum band half-width (in APR percent) for a flat series, so an
+ * exactly-zero rate still gets a visible, non-degenerate y domain.
+ */
+const FLAT_SERIES_MIN_BAND_PERCENT = 0.1;
+
+/**
+ * Explicit fitted domain for C3 so app-computed ticks always match: [min,max]
+ * padded 5% of span; flat series padded to a visible band. Never zero-based
+ * for a series clear of zero — but a borrow rate can never be negative, so
+ * the lower bound is clamped at 0 rather than let a low/flat series pad into
+ * negative territory (which also collapses distinct low ticks onto the same
+ * "0%" label, since `formatAprPercent` treats every non-positive input as 0).
+ */
+export function fittedRateDomain(
+  points: BorrowRateHistoryPoint[],
+): [number, number] {
+  if (points.length === 0) {
+    throw new Error("fittedRateDomain requires at least one point");
+  }
+
+  const rates = points.map((p) => p.ratePercent);
+  const min = Math.min(...rates);
+  const max = Math.max(...rates);
+  const span = max - min;
+
+  const padding =
+    span > 0
+      ? span * RATE_DOMAIN_PAD_FRACTION
+      : Math.max(min * RATE_DOMAIN_PAD_FRACTION, FLAT_SERIES_MIN_BAND_PERCENT);
+
+  return [Math.max(0, min - padding), max + padding];
+}
+
+/** `count` evenly spaced ticks across a domain, labels via formatAprPercent. */
+export function rateTicks(
+  domain: [number, number],
+  count: number,
+): ChartAxisTick[] {
+  const [lo, hi] = domain;
+  if (count <= 1) {
+    return [{ value: lo, label: formatAprPercent(lo) }];
+  }
+
+  const step = (hi - lo) / (count - 1);
+  return Array.from({ length: count }, (_, i) => {
+    const value = lo + i * step;
+    return { value, label: formatAprPercent(value) };
+  });
+}
+
+/**
+ * Y-axis domain and ticks for the IRM chart: the top is the on-chain max
+ * rounded UP to a multiple of `count - 1`, so every tick is a distinct whole
+ * percent and the highest gridline never lands outside the domain (D4 — the
+ * axis tops at the on-chain max, never a hardcoded figure).
+ */
+export function percentAxis(
+  maxAprPercent: number,
+  count: number,
+): { domain: [number, number]; ticks: ChartAxisTick[] } {
+  if (count <= 1) {
+    return {
+      domain: [0, maxAprPercent],
+      ticks: [{ value: 0, label: "0%" }],
+    };
+  }
+
+  const steps = count - 1;
+  const top = Math.ceil(maxAprPercent / steps) * steps;
+  const ticks = Array.from({ length: count }, (_, i) => {
+    const value = (top * i) / steps;
+    return { value, label: `${value}%` };
+  });
+  return { domain: [0, top], ticks };
+}
+
+const MS_PER_DAY = 24 * 60 * 60 * 1_000;
+
+/**
+ * True when any adjacent samples sit less than a day apart — a date-only
+ * tooltip would render identical labels for neighboring points, so the
+ * tooltip must show the time. Spacing-driven rather than range-driven: the
+ * indexer's `resolution=auto` decides the bucket size, not the range button.
+ */
+export function hasSubDailySpacing(points: BorrowRateHistoryPoint[]): boolean {
+  return points.some(
+    (point, i) => i > 0 && point.timeMs - points[i - 1].timeMs < MS_PER_DAY,
+  );
+}
+
+function pad2(value: number): string {
+  return String(value).padStart(2, "0");
+}
+
+/** Tooltip date: sub-daily buckets → "Jul 4, 14:00"; daily+ → "Jul 4, 2026". */
+export function historyTooltipDate(timeMs: number, withTime: boolean): string {
+  const date = new Date(timeMs);
+  const monthDay = date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+  });
+
+  if (withTime) {
+    return `${monthDay}, ${pad2(date.getHours())}:${pad2(date.getMinutes())}`;
+  }
+
+  return `${monthDay}, ${date.getFullYear()}`;
+}

--- a/services/vault/src/components/pages/BorrowingMarketsData/index.tsx
+++ b/services/vault/src/components/pages/BorrowingMarketsData/index.tsx
@@ -3,10 +3,10 @@
  *
  * Everything on the page reads from the same three batched Hub queries over
  * `borrowableReserves`: the stats bar and the collateral card show the routed
- * symbol's slice, the table shows every reserve. The two charts are still
- * placeholders — the borrow-APR chart needs a rate time series and the
- * interest-rate-model chart needs the IRM curve parameters, and no source in
- * the app exposes either today.
+ * symbol's slice, the table shows every reserve. The two charts fetch their
+ * own data independently of that batch: `BorrowRateHistoryCard` queries the
+ * indexer for a rate time series and `InterestRateModelCard` reads the
+ * on-chain IRM curve — both keyed off the page's own `selectedReserve`.
  */
 
 import { Avatar, Container, Heading, Text } from "@babylonlabs-io/core-ui";
@@ -43,15 +43,11 @@ import {
 
 import type { BorrowMarketRow } from "./BorrowMarketsTable";
 import { BorrowMarketsTable } from "./BorrowMarketsTable";
+import { BorrowRateHistoryCard } from "./BorrowRateHistoryCard";
 import { CollateralInfoCard } from "./CollateralInfoCard";
+import { InterestRateModelCard } from "./InterestRateModelCard";
 import type { MarketStat } from "./MarketStatsBar";
 import { MarketStatsBar } from "./MarketStatsBar";
-
-/** Figma's card chrome and heights, so the page's rhythm is already right
- *  when the real charts land. */
-const CHART_CARD_CLASS = "w-full rounded-2xl bg-background-secondary";
-const BORROW_APR_CHART_HEIGHT_CLASS = "h-[300px]";
-const INTEREST_RATE_MODEL_CHART_HEIGHT_CLASS = "h-[392px]";
 
 /** Every USD figure here sits beside an always-uppercase token amount. */
 const UPPERCASE_MAGNITUDE_SUFFIX = true;
@@ -293,6 +289,18 @@ export default function BorrowingMarketsData() {
       ? COPY.common.emptyValue
       : formatBasisPointsAsPercent(effectiveCollateralFactor * BPS_SCALE);
 
+  // Same derivation the stats bar's "Market utilization" figure reads —
+  // reused rather than re-fetched so the IRM card's header always agrees
+  // with the stats bar above it.
+  const marketUtilizationValue = useMemo(() => {
+    const key = selectedReserve?.reserveId.toString();
+    const liquidity =
+      key === undefined ? null : effectiveLiquidityByReserveId[key];
+    return liquidity?.utilizationBps == null
+      ? COPY.common.emptyValue
+      : formatBasisPointsAsPercent(liquidity.utilizationBps);
+  }, [selectedReserve, effectiveLiquidityByReserveId]);
+
   const centered = (message: string) => (
     <Container className={`${PAGE_CONTENT_CLASS} pb-6`}>
       <div className="flex items-center justify-center py-12">
@@ -399,10 +407,14 @@ export default function BorrowingMarketsData() {
             assetName={COPY.marketData.collateral.assetName}
             collateralFactor={collateralFactor}
           />
-          <div
-            className={`${CHART_CARD_CLASS} ${BORROW_APR_CHART_HEIGHT_CLASS}`}
-            data-testid="market-section-borrow-apr-chart"
-          />
+          <div data-testid="market-section-borrow-apr-chart">
+            {selectedReserve !== null && (
+              <BorrowRateHistoryCard
+                reserveId={selectedReserve.reserveId}
+                symbol={symbol}
+              />
+            )}
+          </div>
         </section>
 
         <section
@@ -413,9 +425,13 @@ export default function BorrowingMarketsData() {
             title={COPY.marketData.interestRateModel.title}
             description={COPY.marketData.interestRateModel.description}
           />
-          <div
-            className={`${CHART_CARD_CLASS} ${INTEREST_RATE_MODEL_CHART_HEIGHT_CLASS}`}
-          />
+          {selectedReserve !== null && (
+            <InterestRateModelCard
+              reserve={selectedReserve}
+              utilizationValue={marketUtilizationValue}
+              symbol={symbol}
+            />
+          )}
         </section>
 
         <section

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -1222,6 +1222,28 @@ export const COPY = {
       },
       empty: "No borrow markets available.",
     },
+    // Borrow APR history + interest rate model charts (Figma node
+    // 10088-61056). Labels follow this file's sentence-case rule;
+    // "Utilisation" is respelled to the American form this file mandates.
+    charts: {
+      borrowAprLabel: "Borrow APR",
+      // Header caption and the IRM card's legend entry — one string so the
+      // two can't drift apart in case.
+      utilizationRateLabel: "Utilization rate",
+      utilizationRateTooltip:
+        "The share of supplied liquidity currently borrowed. Higher utilization moves the market up this curve, raising the borrow rate.",
+      ranges: { d1: "1D", w1: "1W", m1: "1M", m6: "6M", y1: "1Y", all: "All" },
+      rateRange: (min: string, max: string) => `${min} – ${max}`,
+      currentCallout: (pct: string) => `Current ${pct}`,
+      optimalCallout: (pct: string) => `Optimal (Kink) ${pct}`,
+      calloutApr: (pct: string) => `APR ~ ${pct}`,
+      historyAriaLabel: (symbol: string) => `${symbol} borrow APR history`,
+      irmAriaLabel: (symbol: string) =>
+        `${symbol} borrow rate against utilization`,
+      chartUnavailable:
+        "Chart data is unavailable right now. Please try again shortly.",
+      historyEmpty: "No rate history yet for this market.",
+    },
   },
   nav: {
     overview: "Overview",

--- a/services/vault/src/globals.css
+++ b/services/vault/src/globals.css
@@ -32,6 +32,12 @@ html {
    * fully liquidated dot. Distinct from --risk-amber, which reads as caution
    * rather than a liquidation that already happened. */
   --risk-orange: 248 97 42;
+  /* C2 interest-rate-model chart (Figma 10088-61091): the curve/legend green
+   * and the marker/legend orange. Both values come off the dark frame — when
+   * the design ships light-theme values, override them in the .light block
+   * below. */
+  --chart-irm-series: #518665;
+  --chart-irm-marker: #ce6533;
   /* Motion spec — Modals (Figma 7831:25100 §1) */
   --motion-duration-modal: 220ms;
   --motion-duration-modal-out: 180ms;

--- a/services/vault/src/services/token/tokenService.ts
+++ b/services/vault/src/services/token/tokenService.ts
@@ -85,13 +85,29 @@ const TOKEN_REGISTRY: Record<string, TokenMetadata> = {
     decimals: 6,
     icon: TOKEN_ICONS.USDC,
   },
-  // USDC - Vault Devnet
-  "0xc137E7382AA220D59Cc25f76f9aD72De962020Db": {
-    address: "0xc137E7382AA220D59Cc25f76f9aD72De962020Db" as Address,
+  // USDC - Vault Devnet (2026-08 redeploy)
+  "0xB588C1bd8A6cd3F114A52a0AD916778B419ECf48": {
+    address: "0xB588C1bd8A6cd3F114A52a0AD916778B419ECf48" as Address,
     symbol: "USDC",
     name: "USD Coin",
     decimals: 6,
     icon: TOKEN_ICONS.USDC,
+  },
+  // USDT - Vault Devnet (2026-08 redeploy)
+  "0xCFf21358114814258635524588f74521762A6c04": {
+    address: "0xCFf21358114814258635524588f74521762A6c04" as Address,
+    symbol: "USDT",
+    name: "Tether USD",
+    decimals: 6,
+    icon: TOKEN_ICONS.USDT,
+  },
+  // WBTC - Vault Devnet (2026-08 redeploy)
+  "0x504579d0424B7B7cB4b17e16626f6A2f67bCa054": {
+    address: "0x504579d0424B7B7cB4b17e16626f6A2f67bCa054" as Address,
+    symbol: "WBTC",
+    name: "Wrapped BTC",
+    decimals: 8,
+    icon: TOKEN_ICONS.WBTC,
   },
   // USDT
   "0x94b008aA00579c1307B0EF2c499aD98a8ce58e58": {

--- a/services/vault/src/test/setup.ts
+++ b/services/vault/src/test/setup.ts
@@ -125,6 +125,29 @@ class ResizeObserverStub {
 }
 global.ResizeObserver = ResizeObserverStub as unknown as typeof ResizeObserver;
 
+// jsdom implements no PointerEvent, so @testing-library falls back to a plain
+// Event and silently drops clientX/clientY — every pointer-driven interaction
+// (e.g. LineChart hover) would read NaN coordinates. MouseEvent carries them
+// and is what React's synthetic pointer events read. Mirrors core-ui's own
+// test setup (packages/babylon-core-ui/src/test/setup.ts).
+if (
+  typeof window !== "undefined" &&
+  typeof window.PointerEvent === "undefined"
+) {
+  class PointerEventStub extends MouseEvent {
+    readonly pointerId: number;
+    readonly pointerType: string;
+
+    constructor(type: string, init: PointerEventInit = {}) {
+      super(type, init);
+      this.pointerId = init.pointerId ?? 1;
+      this.pointerType = init.pointerType ?? "mouse";
+    }
+  }
+
+  window.PointerEvent = PointerEventStub as unknown as typeof PointerEvent;
+}
+
 // Mock crypto for testing
 if (!global.crypto) {
   global.crypto = {

--- a/services/vault/src/utils/__tests__/async.test.ts
+++ b/services/vault/src/utils/__tests__/async.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { withRequestTimeout } from "@/utils/async";
+
+// Both API clients (graphql/client.ts, indexer/aaveHistoryClient.ts) already
+// exercise withRequestTimeout's caller-abort passthrough and generic-failure
+// classification through their own test suites. graphqlClient's suite covers
+// the timeout path too (including a stalled-body regression case — see
+// clients/graphql/__tests__/client.test.ts), but only with
+// `includeUrlInTimeoutMessage` unset — aaveHistoryClient sets it and has no
+// timeout test of its own, so that's the one behavior worth covering here.
+describe("withRequestTimeout", () => {
+  it("includes the request URL in the timeout message when includeUrlInTimeoutMessage is set", async () => {
+    vi.useFakeTimers();
+
+    const promise = withRequestTimeout(
+      {
+        timeoutMs: 5_000,
+        requestLabel: "Borrow rate history request",
+        url: "https://indexer.test/history",
+        includeUrlInTimeoutMessage: true,
+      },
+      (composedSignal) =>
+        new Promise((_resolve, reject) => {
+          composedSignal.addEventListener("abort", () => {
+            reject(
+              new DOMException("The operation was aborted.", "AbortError"),
+            );
+          });
+        }),
+    );
+    const assertion = expect(promise).rejects.toThrow(
+      "Borrow rate history request to https://indexer.test/history timed out after 5000ms",
+    );
+    await vi.advanceTimersByTimeAsync(5_000);
+    await assertion;
+    vi.useRealTimers();
+  });
+});

--- a/services/vault/src/utils/async.ts
+++ b/services/vault/src/utils/async.ts
@@ -38,6 +38,109 @@ export function combineAbortSignals(
   return { signal: controller.signal, cleanup };
 }
 
+function isAbortError(error: unknown): boolean {
+  return (
+    error != null &&
+    typeof error === "object" &&
+    "name" in error &&
+    error.name === "AbortError"
+  );
+}
+
+/**
+ * A browser `fetch` rejection carries no endpoint information — the exception is
+ * literally `TypeError: Failed to fetch` (`Load failed` on Safari), so every
+ * failing request produces an identical, untriageable Sentry issue. Naming the
+ * host restores enough context to tell an indexer outage apart from an RPC or
+ * mempool one, without leaking the query or its variables.
+ */
+function describeFetchFailure(
+  requestLabel: string,
+  url: string,
+  error: unknown,
+): Error {
+  const host = (() => {
+    try {
+      return new URL(url).host;
+    } catch {
+      return "unknown host";
+    }
+  })();
+  const detail = error instanceof Error ? error.message : String(error);
+  return new Error(`${requestLabel} to ${host} failed: ${detail}`, {
+    cause: error,
+  });
+}
+
+export interface WithRequestTimeoutOptions {
+  /** Abort the request after this many ms and classify the failure as a timeout. */
+  timeoutMs: number;
+  /** Caller-supplied abort signal (e.g. React Query unmount), composed with the timeout signal. */
+  signal?: AbortSignal;
+  /** Prefixes every thrown error, e.g. "GraphQL request" or "Borrow rate history request". */
+  requestLabel: string;
+  /** Request URL — named in a generic-failure message always, in the timeout message when `includeUrlInTimeoutMessage` is set. */
+  url: string;
+  /** Include the full request URL in the timeout error message. Off by default. */
+  includeUrlInTimeoutMessage?: boolean;
+}
+
+/**
+ * Run `request` under a timeout composed with an optional caller-supplied
+ * abort signal, classifying a failure as one of a fired timeout, a
+ * caller-initiated abort (rethrown as-is so downstream `name ===
+ * "AbortError"` checks still see a cancellation, not a fault), or a generic
+ * network failure (renamed with the request's host — see
+ * `describeFetchFailure`).
+ *
+ * `request` gets the composed signal and must do its ENTIRE request inside
+ * it — the fetch call and any body consumption (`.text()`/`.json()`) both
+ * need to run under the same signal/timer, since a stalled body is exactly
+ * the kind of hang a request timeout exists to bound. Callers keep whatever
+ * they do around that (rebuilding the Response, parsing JSON, validating the
+ * payload) — this only owns the timer/signal/abort-classification core that
+ * both API clients used to duplicate.
+ */
+export async function withRequestTimeout<T>(
+  {
+    timeoutMs,
+    signal,
+    requestLabel,
+    url,
+    includeUrlInTimeoutMessage = false,
+  }: WithRequestTimeoutOptions,
+  request: (composedSignal: AbortSignal) => Promise<T>,
+): Promise<T> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+  const signals = [controller.signal, signal].filter(
+    (s): s is AbortSignal => s != null,
+  );
+  const combined = combineAbortSignals(signals);
+
+  try {
+    return await request(combined.signal);
+  } catch (error) {
+    if (controller.signal.aborted && isAbortError(error)) {
+      throw new Error(
+        includeUrlInTimeoutMessage
+          ? `${requestLabel} to ${url} timed out after ${timeoutMs}ms`
+          : `${requestLabel} timed out after ${timeoutMs}ms`,
+      );
+    }
+    // A caller-initiated abort (e.g. React Query unmount) must stay an
+    // AbortError so downstream `name === "AbortError"` checks keep treating
+    // it as a cancellation rather than a fault.
+    if (isAbortError(error)) {
+      throw error;
+    }
+    throw describeFetchFailure(requestLabel, url, error);
+  } finally {
+    clearTimeout(timeoutId);
+    combined.cleanup();
+  }
+}
+
 export function abortableSleep(
   ms: number,
   signal?: AbortSignal,


### PR DESCRIPTION
<img width="1217" height="720" alt="Screenshot 2026-08-06 at 05 45 15" src="https://github.com/user-attachments/assets/503b0437-b225-4aa4-9cfd-0b20e24c0294" />
<img width="1221" height="865" alt="Screenshot 2026-08-06 at 05 45 08" src="https://github.com/user-attachments/assets/ebde5418-8902-499a-9897-99c32c8c2e01" />

## Summary

Adds the two remaining charts to the borrowing markets data page, built on the `LineChart` primitive from #2194.

- **Borrow APR history**: stepped line from the indexer's `/api/aave/reserves/:reserveId/history` endpoint. Six range buttons (opens on 1W). The header shows the min–max over the selected range. Hover reads date + rate. The line is stepped because the indexer buckets by last sample: a borrow rate is a level that holds until the next state change.
- **Interest rate model**: the live on-chain curve, sampled through the asset's own `irStrategy.calculateInterestRate` — 21 even utilization points plus the exact kink (from `getInterestRateData`) and the live totals. The utilization denominator stays invariant across the sweep. The y-axis runs to the strategy's real max rate. `Current` and `Optimal (Kink)` markers use collision-aware callouts; hover interpolates anywhere on the curve.

## Implementation notes

- No new env var. The history client derives its REST base from `NEXT_PUBLIC_TBV_GRAPHQL_ENDPOINT` — the same Hono app serves both APIs.
- `LineChart` now measures its y-label column and renders labels flush left, matching the frames. Other chart families keep the fluid gutter.
- A shared request-timeout helper in `utils/async.ts` now backs both the GraphQL and history clients. The timeout bounds the full request, including body streaming.
- The devnet token registry gains the post-redeploy USDC/USDT/WBTC addresses, so `/markets/usdc` resolves again.

## Verification

- Vault suite: 3161 tests green. core-ui suite green. `tsc`, lint, and build clean in both packages.
- Live devnet check: the sampled curve's current APR matches the Hub's `getAssetDrawnRate` exactly; all six history ranges serve; the indexer's latest bucket equals the live Hub rate.
- Rendering verified in the browser against the Figma frames (node 10088-60956), including hover, tap persistence, range switching, and the callout collision cases.
