### PR TITLE
fix(ts-sdk, vault): read the vault provider genesis key at epoch 0

### DIFF
--- a/packages/babylon-ts-sdk/src/tbv/core/clients/eth/__tests__/vault-registry-reader.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/eth/__tests__/vault-registry-reader.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it, vi } from "vitest";
 import type { Address, Hex } from "viem";
+import { describe, expect, it, vi } from "vitest";
 
 import { ViemVaultRegistryReader } from "../vault-registry-reader";
 
@@ -47,7 +47,7 @@ function createMockPublicClient(overrides?: {
       if (functionName === "getBtcVaultProtocolInfo") {
         return overrides?.protocolInfoResult ?? MOCK_PROTOCOL_INFO_RESULT;
       }
-      if (functionName === "getVaultProviderBTCKey") {
+      if (functionName === "getOperationBtcKeyAtEpoch") {
         return overrides?.vpBtcKeyResult;
       }
       if (functionName === "getVaultProviderCommission") {
@@ -70,8 +70,7 @@ function createMockPublicClient(overrides?: {
           }
           if (c.functionName === "getBtcVaultProtocolInfo") {
             const id = c.args?.[0] as Hex | undefined;
-            const byId =
-              id && overrides?.protocolInfoByVaultId?.get(id);
+            const byId = id && overrides?.protocolInfoByVaultId?.get(id);
             return (
               byId ?? overrides?.protocolInfoResult ?? MOCK_PROTOCOL_INFO_RESULT
             );
@@ -202,7 +201,7 @@ describe("ViemVaultRegistryReader", () => {
     );
   });
 
-  it("getVaultProviderBtcPubKey returns the prefix-stripped lowercase hex for a valid x-only point", async () => {
+  it("getVaultProviderGenesisBtcPubKey returns the prefix-stripped lowercase hex for a valid x-only point", async () => {
     const publicClient = createMockPublicClient({
       vpBtcKeyResult: `0x${VALID_XONLY_HEX}` as Hex,
     });
@@ -211,11 +210,56 @@ describe("ViemVaultRegistryReader", () => {
       MOCK_ADDRESS,
     );
 
-    const key = await reader.getVaultProviderBtcPubKey(MOCK_ADDRESS);
+    const key = await reader.getVaultProviderGenesisBtcPubKey(MOCK_ADDRESS);
     expect(key).toBe(VALID_XONLY_HEX);
   });
 
-  it("getVaultProviderBtcPubKey throws on a malformed (non-hex / wrong length) value", async () => {
+  // The genesis key is read as "the operation key at epoch 0" because
+  // vault-contracts-aave-v4#539 removes the dedicated `getVaultProviderBTCKey`
+  // getter. Both halves matter and neither is checked by the assertions above:
+  // the wrong function name reverts on selector mismatch once #539 deploys, and
+  // a non-zero epoch would silently return a *rotated* key, which would then be
+  // used as the genesis fallback for epoch resolution.
+  it("getVaultProviderGenesisBtcPubKey reads getOperationBtcKeyAtEpoch at epoch 0", async () => {
+    const publicClient = createMockPublicClient({
+      vpBtcKeyResult: `0x${VALID_XONLY_HEX}` as Hex,
+    });
+    const reader = new ViemVaultRegistryReader(
+      publicClient as never,
+      MOCK_ADDRESS,
+    );
+
+    await reader.getVaultProviderGenesisBtcPubKey(MOCK_ADDRESS);
+
+    expect(publicClient.readContract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        functionName: "getOperationBtcKeyAtEpoch",
+        args: [MOCK_ADDRESS, 0n],
+      }),
+    );
+  });
+
+  // A registry that predates RFC-006 has no `getOperationBtcKeyAtEpoch`, so the
+  // read reverts rather than returning a plausible-looking key. That is the
+  // intended failure: every caller of this method also resolves keys through
+  // `OperationKeyReader`, so all of them already require an RFC-006 registry.
+  it("getVaultProviderGenesisBtcPubKey surfaces a revert from a pre-RFC-006 registry", async () => {
+    const publicClient = {
+      readContract: vi.fn(async () => {
+        throw new Error('Unknown function: "getOperationBtcKeyAtEpoch"');
+      }),
+    };
+    const reader = new ViemVaultRegistryReader(
+      publicClient as never,
+      MOCK_ADDRESS,
+    );
+
+    await expect(
+      reader.getVaultProviderGenesisBtcPubKey(MOCK_ADDRESS),
+    ).rejects.toThrow(/getOperationBtcKeyAtEpoch/);
+  });
+
+  it("getVaultProviderGenesisBtcPubKey throws on a malformed (non-hex / wrong length) value", async () => {
     const publicClient = createMockPublicClient({
       vpBtcKeyResult: "0xdeadbeef" as Hex,
     });
@@ -225,11 +269,11 @@ describe("ViemVaultRegistryReader", () => {
     );
 
     await expect(
-      reader.getVaultProviderBtcPubKey(MOCK_ADDRESS),
+      reader.getVaultProviderGenesisBtcPubKey(MOCK_ADDRESS),
     ).rejects.toThrow(/unexpected value/);
   });
 
-  it("getVaultProviderBtcPubKey throws when the bytes32 is not a valid x-only secp256k1 point", async () => {
+  it("getVaultProviderGenesisBtcPubKey throws when the bytes32 is not a valid x-only secp256k1 point", async () => {
     // 32-byte all-zeros is well-formed bytes32 but not on the curve.
     // Without the curve check, this would have branded as a trusted
     // OnChainBtcPubkey and degraded into a generic BIP-322 verify
@@ -243,7 +287,7 @@ describe("ViemVaultRegistryReader", () => {
     );
 
     await expect(
-      reader.getVaultProviderBtcPubKey(MOCK_ADDRESS),
+      reader.getVaultProviderGenesisBtcPubKey(MOCK_ADDRESS),
     ).rejects.toThrow(/not on the secp256k1 curve/);
   });
 
@@ -255,9 +299,9 @@ describe("ViemVaultRegistryReader", () => {
         MOCK_ADDRESS,
       );
 
-      await expect(reader.getVaultProviderCommission(MOCK_ADDRESS)).resolves.toBe(
-        150,
-      );
+      await expect(
+        reader.getVaultProviderCommission(MOCK_ADDRESS),
+      ).resolves.toBe(150);
     });
 
     it("accepts the inclusive 0 lower bound", async () => {
@@ -267,9 +311,9 @@ describe("ViemVaultRegistryReader", () => {
         MOCK_ADDRESS,
       );
 
-      await expect(reader.getVaultProviderCommission(MOCK_ADDRESS)).resolves.toBe(
-        0,
-      );
+      await expect(
+        reader.getVaultProviderCommission(MOCK_ADDRESS),
+      ).resolves.toBe(0);
     });
 
     it("accepts the inclusive 9999 upper bound", async () => {
@@ -279,13 +323,15 @@ describe("ViemVaultRegistryReader", () => {
         MOCK_ADDRESS,
       );
 
-      await expect(reader.getVaultProviderCommission(MOCK_ADDRESS)).resolves.toBe(
-        9999,
-      );
+      await expect(
+        reader.getVaultProviderCommission(MOCK_ADDRESS),
+      ).resolves.toBe(9999);
     });
 
     it("throws when the contract value exceeds 9999 (signals wrong address or ABI drift)", async () => {
-      const publicClient = createMockPublicClient({ vpCommissionResult: 10000 });
+      const publicClient = createMockPublicClient({
+        vpCommissionResult: 10000,
+      });
       const reader = new ViemVaultRegistryReader(
         publicClient as never,
         MOCK_ADDRESS,
@@ -348,8 +394,14 @@ describe("ViemVaultRegistryReader", () => {
     it("returns versions in input order via a single multicall", async () => {
       const publicClient = createMockPublicClient({
         protocolInfoByVaultId: new Map([
-          [VAULT_ID_A, { ...MOCK_PROTOCOL_INFO_RESULT, offchainParamsVersion: 7 }],
-          [VAULT_ID_B, { ...MOCK_PROTOCOL_INFO_RESULT, offchainParamsVersion: 3 }],
+          [
+            VAULT_ID_A,
+            { ...MOCK_PROTOCOL_INFO_RESULT, offchainParamsVersion: 7 },
+          ],
+          [
+            VAULT_ID_B,
+            { ...MOCK_PROTOCOL_INFO_RESULT, offchainParamsVersion: 3 },
+          ],
         ]),
       });
       const reader = new ViemVaultRegistryReader(
@@ -386,7 +438,10 @@ describe("ViemVaultRegistryReader", () => {
           [VAULT_ID_A, MOCK_PROTOCOL_INFO_RESULT],
           [
             VAULT_ID_B,
-            { ...MOCK_PROTOCOL_INFO_RESULT, depositorSignedPeginTx: "0x" as Hex },
+            {
+              ...MOCK_PROTOCOL_INFO_RESULT,
+              depositorSignedPeginTx: "0x" as Hex,
+            },
           ],
         ]),
       });

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/eth/onChainBtcPubkey.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/eth/onChainBtcPubkey.ts
@@ -1,7 +1,7 @@
 /**
  * The single validator that mints {@link OnChainBtcPubkey}.
  *
- * Extracted from `ViemVaultRegistryReader.getVaultProviderBtcPubKey` so that
+ * Extracted from `ViemVaultRegistryReader.getVaultProviderGenesisBtcPubKey` so that
  * RFC-006 operation-key resolution can produce branded keys through exactly
  * the same checks, rather than casting past the brand. Every producer of an
  * `OnChainBtcPubkey` must go through here.
@@ -19,8 +19,8 @@ import type { OnChainBtcPubkey } from "./types";
  * 64-char lowercase hex without the `0x` prefix.
  *
  * `label` identifies the read site in error messages (e.g.
- * `getVaultProviderBTCKey (vp=0x…)`), so a failure names which participant and
- * which getter produced it.
+ * `getOperationBtcKeyAtEpoch (vp=0x…, epoch=0)`), so a failure names which
+ * participant and which getter produced it.
  *
  * A zero hash fails the curve check, so an unregistered operator or an epoch
  * with no bonded key surfaces as an error rather than a silent all-zero key.

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts
@@ -17,7 +17,7 @@ declare const onChainBtcPubkeyBrand: unique symbol;
  * 64-char lowercase hex (no `0x`) x-only BTC pubkey sourced from an on-chain
  * registry. Minted only by `assertOnChainBtcPubkey`, which is the shared
  * validator behind both producers:
- * {@link VaultRegistryReader.getVaultProviderBtcPubKey} (the fixed
+ * {@link VaultRegistryReader.getVaultProviderGenesisBtcPubKey} (the fixed
  * registration key) and {@link OperationKeyReader} (RFC-006 operation keys,
  * resolved current or at a vault's frozen epoch).
  *
@@ -110,7 +110,20 @@ export interface VaultRegistryReader {
   getVaultProtocolInfo(vaultId: Hex): Promise<VaultProtocolInfo>;
   getProtocolInfoBatch(vaultIds: readonly Hex[]): Promise<VaultProtocolInfo[]>;
   getVaultData(vaultId: Hex): Promise<VaultData>;
-  getVaultProviderBtcPubKey(vpAddress: Address): Promise<OnChainBtcPubkey>;
+  /**
+   * Read a vault provider's *genesis* (registration) BTC key — the key bonded
+   * at version 0, which never moves when the operator rotates.
+   *
+   * Used only as the genesis fallback for epoch-based resolution and as a
+   * candidate when cross-checking an indexer hint. Never the key to build a
+   * Bitcoin lock with; that comes from `OperationKeyReader`.
+   *
+   * Resolves via `getOperationBtcKeyAtEpoch` at epoch 0, so it requires an
+   * RFC-006 registry — as does every caller.
+   */
+  getVaultProviderGenesisBtcPubKey(
+    vpAddress: Address,
+  ): Promise<OnChainBtcPubkey>;
   /** Read the protocol pegin fee (in wei) for a given vault provider. */
   getPegInFee(vaultProvider: Address): Promise<bigint>;
   /**
@@ -314,7 +327,8 @@ export interface UniversalChallengerReader {
 export interface OperationKeyQuery {
   vaultProviderEthAddress: Address;
   /**
-   * The VP's genesis (registration) key, from `getVaultProviderBTCKey`.
+   * The VP's genesis (registration) key, from
+   * {@link VaultRegistryReader.getVaultProviderGenesisBtcPubKey}.
    *
    * The VP has no roster entry to carry a genesis key the way keepers and
    * challengers do, so it is supplied here. Every call site already reads it:

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts
@@ -99,6 +99,16 @@ function mapVaultProtocolInfo(result: RawVaultProtocolInfo): VaultProtocolInfo {
  */
 const UINT64_EXCLUSIVE_UPPER_BOUND = 1n << 64n;
 
+/**
+ * The epoch a vault provider's registration key is bonded at.
+ *
+ * A provider's operation-key history is append-only and every appended version
+ * is stamped at epoch 1 or later, so epoch 0 always resolves to the key set at
+ * registration. This is what lets `getOperationBtcKeyAtEpoch` stand in for the
+ * removed `getVaultProviderBTCKey` getter.
+ */
+const VP_GENESIS_KEY_EPOCH = 0n;
+
 function assertEpochInRange(
   value: bigint,
   field: string,
@@ -141,23 +151,40 @@ export class ViemVaultRegistryReader implements VaultRegistryReader {
   ) {}
 
   /**
-   * Read the VP's persistent x-only BTC pubkey from the on-chain
-   * registry. Validates length, hex form, and secp256k1 curve
-   * membership before minting the brand. Returns 64-char lowercase
-   * hex without the `0x` prefix.
+   * Read the VP's **genesis** (registration) x-only BTC pubkey — the key bonded
+   * at version 0, which never moves when the operator rotates.
+   *
+   * Resolved as "the operation key at epoch 0" rather than through the
+   * dedicated `getVaultProviderBTCKey` getter, which
+   * https://github.com/babylonlabs-io/vault-contracts-aave-v4/pull/539 removes.
+   * Epoch 0 predates any rotation — appended versions are stamped at epoch 1 or
+   * later — so it resolves to the registration key, and the contracts team has
+   * confirmed that is a property we can rely on rather than an implementation
+   * detail. The devnet comparison behind that claim — both getters returning the
+   * identical key for a provider that *has* rotated, while
+   * `getCurrentOperationBtcKey` differed — is recorded in
+   * https://github.com/babylonlabs-io/babylon-toolkit/issues/2188.
+   *
+   * This makes the read RFC-006-only, where the removed getter also existed on a
+   * legacy registry. That costs nothing: every caller of this method already
+   * resolves participant keys through `OperationKeyReader`, so all of them
+   * require an RFC-006 registry regardless.
+   *
+   * Validates length, hex form, and secp256k1 curve membership before minting
+   * the brand. Returns 64-char lowercase hex without the `0x` prefix.
    */
-  async getVaultProviderBtcPubKey(
+  async getVaultProviderGenesisBtcPubKey(
     vpAddress: Address,
   ): Promise<OnChainBtcPubkey> {
     const result = (await this.publicClient.readContract({
       address: this.contractAddress,
       abi: BTCVaultRegistryABI,
-      functionName: "getVaultProviderBTCKey",
-      args: [vpAddress],
+      functionName: "getOperationBtcKeyAtEpoch",
+      args: [vpAddress, VP_GENESIS_KEY_EPOCH],
     })) as Hex;
     return assertOnChainBtcPubkey(
       result,
-      `getVaultProviderBTCKey (vp=${vpAddress})`,
+      `getOperationBtcKeyAtEpoch (vp=${vpAddress}, epoch=${VP_GENESIS_KEY_EPOCH})`,
     );
   }
 
@@ -165,8 +192,8 @@ export class ViemVaultRegistryReader implements VaultRegistryReader {
    * Read a vault provider's *current* RFC-006 operation BTC key.
    *
    * Falls back on-chain to the registration key when the provider has never
-   * rotated, so this returns the same value as `getVaultProviderBtcPubKey`
-   * until the first rotation.
+   * rotated, so this returns the same value as
+   * `getVaultProviderGenesisBtcPubKey` until the first rotation.
    *
    * This is the key the VP's server signs its BIP-322 auth tokens with — a
    * live per-operator identity, not a per-vault binding, so the auth pin uses

--- a/packages/babylon-ts-sdk/src/tbv/core/contracts/abis/BTCVaultRegistry.abi.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/contracts/abis/BTCVaultRegistry.abi.ts
@@ -246,19 +246,18 @@ export const BTCVaultRegistryABI = [
     ],
     stateMutability: "view",
   },
-  {
-    type: "function",
-    name: "getVaultProviderBTCKey",
-    inputs: [{ name: "vpAddr", type: "address", internalType: "address" }],
-    outputs: [{ name: "", type: "bytes32", internalType: "bytes32" }],
-    stateMutability: "view",
-  },
   // --- RFC-006 operation-key resolution ---------------------------------
-  // A vault provider's BTC key is no longer the fixed registration key
-  // returned by `getVaultProviderBTCKey` above: it is an append-only history
-  // of *operation* keys, rotated by the provider's cold ETH admin key. Each
-  // vault freezes a `vpKeyEpoch` at `submitPeginRequest` and resolves the key
-  // bonded at that epoch, so a later rotation never invalidates a live vault.
+  // A vault provider's BTC key is not a fixed registration key: it is an
+  // append-only history of *operation* keys, rotated by the provider's cold ETH
+  // admin key. Each vault freezes a `vpKeyEpoch` at `submitPeginRequest` and
+  // resolves the key bonded at that epoch, so a later rotation never
+  // invalidates a live vault.
+  //
+  // The dedicated `getVaultProviderBTCKey` / `getVaultProviderKeyPair` getters
+  // are deliberately absent: vault-contracts-aave-v4#539 removes them, and
+  // keeping them here would let a call compile against a selector the registry
+  // no longer exposes. The registration key is read as the operation key at
+  // epoch 0 instead — see `getVaultProviderGenesisBtcPubKey`.
   //
   // `getCurrentOperationBtcKey` falls back on-chain to the registration key at
   // version 0, so adopting it is a no-op for a provider that never rotated.

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/validateOnChainParticipantKeys.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/validateOnChainParticipantKeys.test.ts
@@ -71,7 +71,7 @@ function buildReaders({
     getVaultProtocolInfo: vi.fn(),
     getProtocolInfoBatch: vi.fn(),
     getVaultData: vi.fn(),
-    getVaultProviderBtcPubKey: vi
+    getVaultProviderGenesisBtcPubKey: vi
       .fn()
       .mockResolvedValue(vpKey.toLowerCase() as OnChainBtcPubkey),
     getPegInFee: vi.fn(),
@@ -169,9 +169,8 @@ describe("validateOnChainParticipantKeys", () => {
   it("propagates the original error when the on-chain VP key read rejects", async () => {
     const readers = buildReaders();
     (
-      readers.vaultRegistryReader.getVaultProviderBtcPubKey as ReturnType<
-        typeof vi.fn
-      >
+      readers.vaultRegistryReader
+        .getVaultProviderGenesisBtcPubKey as ReturnType<typeof vi.fn>
     ).mockRejectedValue(
       new Error("Vault provider 0xVP has no registered BTC pubkey on-chain"),
     );
@@ -325,7 +324,7 @@ describe("validateOnChainParticipantKeys with operation-key resolution", () => {
         getVaultProtocolInfo: vi.fn(),
         getProtocolInfoBatch: vi.fn(),
         getVaultData: vi.fn(),
-        getVaultProviderBtcPubKey: vi
+        getVaultProviderGenesisBtcPubKey: vi
           .fn()
           .mockResolvedValue(KEYS.vpGenesis as OnChainBtcPubkey),
         getPegInFee: vi.fn(),

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/verifyRegisteredParticipantKeys.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/verifyRegisteredParticipantKeys.test.ts
@@ -24,7 +24,7 @@ function registryReaderReturning(epoch: bigint): VaultRegistryReader {
     getVaultProtocolInfo: vi.fn(),
     getProtocolInfoBatch: vi.fn(),
     getVaultData: vi.fn(),
-    getVaultProviderBtcPubKey: vi.fn(),
+    getVaultProviderGenesisBtcPubKey: vi.fn(),
     getPegInFee: vi.fn(),
     getVaultProviderCommission: vi.fn(),
     getOffchainParamsVersionsByVaultIds: vi.fn(),

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/verifyRegisteredVaultVersions.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/verifyRegisteredVaultVersions.test.ts
@@ -53,7 +53,7 @@ function buildRegistryReader(
     getVaultProtocolInfo: vi.fn(),
     getProtocolInfoBatch,
     getVaultData: vi.fn(),
-    getVaultProviderBtcPubKey: vi.fn(),
+    getVaultProviderGenesisBtcPubKey: vi.fn(),
     getPegInFee: vi.fn(),
     getVaultProviderCommission: vi.fn(),
     getOffchainParamsVersionsByVaultIds: vi.fn(),

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts
@@ -95,7 +95,9 @@ export async function validateOnChainParticipantKeys(
     expectedAppVaultKeepersVersion,
     expectedUniversalChallengersVersion,
   ] = await Promise.all([
-    vaultRegistryReader.getVaultProviderBtcPubKey(vaultProviderEthAddress),
+    vaultRegistryReader.getVaultProviderGenesisBtcPubKey(
+      vaultProviderEthAddress,
+    ),
     vaultKeeperReader.getCurrentVaultKeepersVersion(applicationEntryPoint),
     universalChallengerReader.getLatestUniversalChallengersVersion(),
   ]);

--- a/services/vault/src/clients/eth-contract/btc-vault-registry/query.ts
+++ b/services/vault/src/clients/eth-contract/btc-vault-registry/query.ts
@@ -113,16 +113,21 @@ export async function getVaultKeyEpochsFromChain(
 }
 
 /**
- * Read a vault provider's registered BTC public key from BTCVaultRegistry,
- * returning a 0x-prefixed `Hex` string for compatibility with existing
- * callers (the SDK reader returns the 64-char lowercase form without the
- * prefix; this wrapper re-attaches `0x`).
+ * Read a vault provider's *genesis* (registration) BTC public key from
+ * BTCVaultRegistry, returning a 0x-prefixed `Hex` string for compatibility with
+ * existing callers (the SDK reader returns the 64-char lowercase form without
+ * the prefix; this wrapper re-attaches `0x`).
+ *
+ * This is the key that seeds epoch-based resolution, never the key to sign or
+ * build with — see `getVaultProviderGenesisBtcPubKey` in the SDK.
  */
-export async function getVaultProviderBtcPubkeyFromChain(
+export async function getVaultProviderGenesisBtcPubkeyFromChain(
   vaultProvider: Address,
 ): Promise<Hex> {
   const xOnly =
-    await getVaultRegistryReader().getVaultProviderBtcPubKey(vaultProvider);
+    await getVaultRegistryReader().getVaultProviderGenesisBtcPubKey(
+      vaultProvider,
+    );
   return `0x${xOnly}` as Hex;
 }
 

--- a/services/vault/src/components/simple/__tests__/ResumeDepositContent.test.tsx
+++ b/services/vault/src/components/simple/__tests__/ResumeDepositContent.test.tsx
@@ -273,7 +273,7 @@ function readerWith(prePeginTxHash: string) {
         prePeginTxHash,
       },
     }),
-    getVaultProviderBtcPubKey: vi.fn().mockResolvedValue(null),
+    getVaultProviderGenesisBtcPubKey: vi.fn().mockResolvedValue(null),
     getVaultBasicInfo: vi.fn(),
     getVaultProtocolInfo: vi.fn(),
   } as unknown as ReturnType<typeof getVaultRegistryReader>;

--- a/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
@@ -36,7 +36,7 @@ vi.mock("@/utils/rpc", async (importOriginal) => ({
 
 vi.mock("@/clients/eth-contract/sdk-readers", () => ({
   getVaultRegistryReader: vi.fn(() => ({
-    getVaultProviderBtcPubKey: vi.fn(async () => "ab".repeat(32)),
+    getVaultProviderGenesisBtcPubKey: vi.fn(async () => "ab".repeat(32)),
   })),
   getVaultKeeperReader: vi.fn(async () => ({})),
   getUniversalChallengerReader: vi.fn(async () => ({})),

--- a/services/vault/src/services/vault/__tests__/vaultPayoutSignatureService.payoutScripts.test.ts
+++ b/services/vault/src/services/vault/__tests__/vaultPayoutSignatureService.payoutScripts.test.ts
@@ -19,7 +19,7 @@ vi.mock("@babylonlabs-io/ts-sdk/tbv/core", async (importOriginal) => ({
 
 vi.mock("../../../clients/eth-contract/btc-vault-registry/query", () => ({
   getVaultFromChain: vi.fn(),
-  getVaultProviderBtcPubkeyFromChain: vi.fn(),
+  getVaultProviderGenesisBtcPubkeyFromChain: vi.fn(),
   getVaultKeyEpochsFromChain: vi.fn(),
 }));
 
@@ -56,7 +56,7 @@ vi.mock("../../../clients/eth-contract/sdk-readers", () => ({
 import {
   getVaultFromChain,
   getVaultKeyEpochsFromChain,
-  getVaultProviderBtcPubkeyFromChain,
+  getVaultProviderGenesisBtcPubkeyFromChain,
 } from "../../../clients/eth-contract/btc-vault-registry/query";
 import { prepareSigningContext } from "../vaultPayoutSignatureService";
 
@@ -96,7 +96,7 @@ beforeEach(() => {
     vaultProvider: "0xprovider",
     vaultProviderCommissionBps: 50,
   } as never);
-  vi.mocked(getVaultProviderBtcPubkeyFromChain).mockResolvedValue(
+  vi.mocked(getVaultProviderGenesisBtcPubkeyFromChain).mockResolvedValue(
     `0x${VP_KEY}` as never,
   );
   vi.mocked(getVaultKeyEpochsFromChain).mockResolvedValue({

--- a/services/vault/src/services/vault/__tests__/vaultPayoutSignatureService.test.ts
+++ b/services/vault/src/services/vault/__tests__/vaultPayoutSignatureService.test.ts
@@ -11,7 +11,7 @@ import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 
 vi.mock("../../../clients/eth-contract/btc-vault-registry/query", () => ({
   getVaultFromChain: vi.fn(),
-  getVaultProviderBtcPubkeyFromChain: vi.fn(),
+  getVaultProviderGenesisBtcPubkeyFromChain: vi.fn(),
   getVaultKeyEpochsFromChain: vi.fn().mockResolvedValue({
     vpKeyEpoch: 0n,
     appKeeperKeyEpoch: 0n,
@@ -66,7 +66,7 @@ vi.mock("../../../clients/eth-contract/sdk-readers", () => ({
 
 import {
   getVaultFromChain,
-  getVaultProviderBtcPubkeyFromChain,
+  getVaultProviderGenesisBtcPubkeyFromChain,
 } from "../../../clients/eth-contract/btc-vault-registry/query";
 import {
   prepareSigningContext,
@@ -85,7 +85,7 @@ describe("vaultPayoutSignatureService", () => {
     });
 
     it("returns the on-chain key when the provided hint matches", async () => {
-      (getVaultProviderBtcPubkeyFromChain as Mock).mockResolvedValue(
+      (getVaultProviderGenesisBtcPubkeyFromChain as Mock).mockResolvedValue(
         `0x${ON_CHAIN_VP_PUBKEY}`,
       );
 
@@ -95,13 +95,13 @@ describe("vaultPayoutSignatureService", () => {
       );
 
       expect(result).toBe(ON_CHAIN_VP_PUBKEY);
-      expect(getVaultProviderBtcPubkeyFromChain).toHaveBeenCalledWith(
+      expect(getVaultProviderGenesisBtcPubkeyFromChain).toHaveBeenCalledWith(
         "0xprovider",
       );
     });
 
     it("accepts a compressed hint that matches the on-chain x-only key", async () => {
-      (getVaultProviderBtcPubkeyFromChain as Mock).mockResolvedValue(
+      (getVaultProviderGenesisBtcPubkeyFromChain as Mock).mockResolvedValue(
         `0x${ON_CHAIN_VP_PUBKEY}`,
       );
 
@@ -114,7 +114,7 @@ describe("vaultPayoutSignatureService", () => {
     });
 
     it("accepts an uncompressed hint that matches the on-chain x-only key", async () => {
-      (getVaultProviderBtcPubkeyFromChain as Mock).mockResolvedValue(
+      (getVaultProviderGenesisBtcPubkeyFromChain as Mock).mockResolvedValue(
         `0x${ON_CHAIN_VP_PUBKEY}`,
       );
 
@@ -127,20 +127,20 @@ describe("vaultPayoutSignatureService", () => {
     });
 
     it("reads from chain when no hint is provided", async () => {
-      (getVaultProviderBtcPubkeyFromChain as Mock).mockResolvedValue(
+      (getVaultProviderGenesisBtcPubkeyFromChain as Mock).mockResolvedValue(
         `0x${ON_CHAIN_VP_PUBKEY}`,
       );
 
       const result = await resolveVaultProviderBtcPubkey("0xprovider");
 
       expect(result).toBe(ON_CHAIN_VP_PUBKEY);
-      expect(getVaultProviderBtcPubkeyFromChain).toHaveBeenCalledWith(
+      expect(getVaultProviderGenesisBtcPubkeyFromChain).toHaveBeenCalledWith(
         "0xprovider",
       );
     });
 
     it("throws when the hint matches neither the registration nor the current operation key", async () => {
-      (getVaultProviderBtcPubkeyFromChain as Mock).mockResolvedValue(
+      (getVaultProviderGenesisBtcPubkeyFromChain as Mock).mockResolvedValue(
         `0x${ON_CHAIN_VP_PUBKEY}`,
       );
       mockGetCurrentVaultProviderOperationBtcKey.mockResolvedValue(
@@ -159,7 +159,7 @@ describe("vaultPayoutSignatureService", () => {
     // would break payout signing for every depositor of a rotated provider,
     // triggered by an indexer deploy rather than one of ours.
     it("accepts a hint matching the current operation key after a rotation", async () => {
-      (getVaultProviderBtcPubkeyFromChain as Mock).mockResolvedValue(
+      (getVaultProviderGenesisBtcPubkeyFromChain as Mock).mockResolvedValue(
         `0x${ON_CHAIN_VP_PUBKEY}`,
       );
       mockGetCurrentVaultProviderOperationBtcKey.mockResolvedValue(
@@ -178,7 +178,7 @@ describe("vaultPayoutSignatureService", () => {
 
     // The extra read is a fallback, not a second unconditional RPC.
     it("does not read the current operation key when the hint matches registration", async () => {
-      (getVaultProviderBtcPubkeyFromChain as Mock).mockResolvedValue(
+      (getVaultProviderGenesisBtcPubkeyFromChain as Mock).mockResolvedValue(
         `0x${ON_CHAIN_VP_PUBKEY}`,
       );
 
@@ -220,7 +220,7 @@ describe("vaultPayoutSignatureService", () => {
       mockGetUniversalChallengersByVersion.mockResolvedValue([
         { btcPubKey: "uc1" },
       ]);
-      (getVaultProviderBtcPubkeyFromChain as Mock).mockResolvedValue(
+      (getVaultProviderGenesisBtcPubkeyFromChain as Mock).mockResolvedValue(
         `0x${ON_CHAIN_VP_PUBKEY}`,
       );
       mockResolveParticipantKeysAtEpochs.mockResolvedValue({
@@ -322,7 +322,7 @@ describe("vaultPayoutSignatureService", () => {
     });
 
     it("accepts a caller-provided VP pubkey hint when it matches on-chain", async () => {
-      (getVaultProviderBtcPubkeyFromChain as Mock).mockResolvedValue(
+      (getVaultProviderGenesisBtcPubkeyFromChain as Mock).mockResolvedValue(
         `0x${ON_CHAIN_VP_PUBKEY}`,
       );
 
@@ -334,13 +334,13 @@ describe("vaultPayoutSignatureService", () => {
       });
 
       expect(context.vaultProviderBtcPubkey).toBe(ON_CHAIN_VP_PUBKEY);
-      expect(getVaultProviderBtcPubkeyFromChain).toHaveBeenCalledWith(
+      expect(getVaultProviderGenesisBtcPubkeyFromChain).toHaveBeenCalledWith(
         ON_CHAIN_VAULT.vaultProvider,
       );
     });
 
     it("throws when a poisoned GraphQL VP pubkey hint differs from on-chain", async () => {
-      (getVaultProviderBtcPubkeyFromChain as Mock).mockResolvedValue(
+      (getVaultProviderGenesisBtcPubkeyFromChain as Mock).mockResolvedValue(
         `0x${ON_CHAIN_VP_PUBKEY}`,
       );
       // Un-rotated provider: the operation key is the registration key, so the

--- a/services/vault/src/services/vault/__tests__/vaultRefundService.test.ts
+++ b/services/vault/src/services/vault/__tests__/vaultRefundService.test.ts
@@ -116,7 +116,7 @@ vi.mock("../../../clients/eth-contract/sdk-readers", () => ({
       mockGetUniversalChallengersByVersion(...args),
   }),
   getVaultRegistryReader: vi.fn().mockReturnValue({
-    getVaultProviderBtcPubKey: (...args: unknown[]) =>
+    getVaultProviderGenesisBtcPubKey: (...args: unknown[]) =>
       mockGetVaultProviderBtcPubKey(...args),
     getCurrentVaultProviderOperationBtcKey: (...args: unknown[]) =>
       mockGetCurrentVaultProviderOperationBtcKey(...args),

--- a/services/vault/src/services/vault/vaultPayoutSignatureService.ts
+++ b/services/vault/src/services/vault/vaultPayoutSignatureService.ts
@@ -29,7 +29,7 @@ import type { Address, Hex } from "viem";
 import {
   getVaultFromChain,
   getVaultKeyEpochsFromChain,
-  getVaultProviderBtcPubkeyFromChain,
+  getVaultProviderGenesisBtcPubkeyFromChain,
 } from "../../clients/eth-contract/btc-vault-registry/query";
 import {
   getOperationKeyReader,
@@ -142,7 +142,7 @@ export async function resolveVaultProviderBtcPubkey(
   btcPubKey?: string,
 ): Promise<string> {
   const registrationBtcPubkey = canonicalizeBtcPubkey(
-    await getVaultProviderBtcPubkeyFromChain(address),
+    await getVaultProviderGenesisBtcPubkeyFromChain(address),
   );
 
   await assertVaultProviderHintAccepted({

--- a/services/vault/src/services/vault/vaultRefundService.ts
+++ b/services/vault/src/services/vault/vaultRefundService.ts
@@ -402,7 +402,7 @@ async function readPrePeginContext(
   ] = await Promise.all([
     protocolReader.getOffchainParamsByVersion(vault.offchainParamsVersion),
     fetchVaultProviderById(vault.vaultProvider),
-    getVaultRegistryReader().getVaultProviderBtcPubKey(
+    getVaultRegistryReader().getVaultProviderGenesisBtcPubKey(
       vault.vaultProvider as Address,
     ),
     keeperReader.getVaultKeepersByVersion(

--- a/services/vault/src/services/vault/verifyResumeParticipantKeys.ts
+++ b/services/vault/src/services/vault/verifyResumeParticipantKeys.ts
@@ -21,7 +21,7 @@ import type { Address, Hex } from "viem";
 import {
   getVaultFromChain,
   getVaultKeyEpochsFromChain,
-  getVaultProviderBtcPubkeyFromChain,
+  getVaultProviderGenesisBtcPubkeyFromChain,
 } from "@/clients/eth-contract/btc-vault-registry/query";
 import {
   getOperationKeyReader,
@@ -87,7 +87,7 @@ export async function verifyResumeParticipantKeys(params: {
       challengerReader.getUniversalChallengersByVersion(
         vault.universalChallengersVersion,
       ),
-      getVaultProviderBtcPubkeyFromChain(vault.vaultProvider as Address),
+      getVaultProviderGenesisBtcPubkeyFromChain(vault.vaultProvider as Address),
       getVaultKeyEpochsFromChain(vaultId),
     ]);
 


### PR DESCRIPTION
fix(ts-sdk, vault): read the vault provider genesis key at epoch 0

Closes https://github.com/babylonlabs-io/babylon-toolkit/issues/2188.

## TL;DR — this changes nothing today, and prevents a future outage

We read the vault provider's registration key through a contract getter that [vault-contracts-aave-v4#539](https://github.com/babylonlabs-io/vault-contracts-aave-v4/pull/539) **deletes**. That PR merged on 2026-08-06 (`182e178e`) and is now waiting on deployment. This PR moves us to a different getter that reaches the *identical* storage slot, before the deletion ships.

| | devnet / testnet **today** | **after #539 is deployed** |
|---|---|---|
| **without this PR** | ✅ works | ❌ **deposit, payout, resume and refund all break** |
| **with this PR merged** | ✅ works — byte-identical values, measured below | ✅ works |

Read the "today" column first: **both rows work.** Both getters exist on devnet and testnet right now and return the same bytes, so merging is not observable on any network we point at. The only failing cell is the future one, and it is the reason this PR exists — **not something this PR introduces.**

Two doors to the same room: the getter being deleted and the one we switch to reach the same storage read (proved from the merged contract source under [Why](#why)). We are walking through the other door before the first is bricked up.

Nothing about key material, signing, or script construction changes. The value fetched is used only as the genesis baseline for epoch resolution and as a candidate when cross-checking an indexer hint — never as a key to build a Bitcoin lock with.

## Why

`#539` removes `getVaultProviderBTCKey` and `getVaultProviderKeyPair` from `BTCVaultRegistry`. We call the first one, and all four flows above read it during validation — so when it goes, they go together.

There is no way to sit it out: `BTCVaultRegistry` is a UUPS proxy (`ProtocolTemplateUpg`, `upgradeToAndCall` present), so the upgrade lands **at the address we already point at**. We do not get to keep working by declining to repoint — the new code arrives under us, on a schedule the contracts team controls.

Landing the replacement now is possible because `getOperationBtcKeyAtEpoch` already exists on today's registry, so the new read is valid both before and after #539 ships. Waiting would mean fixing four broken paths *during* an outage instead of ahead of one.

@gitferry confirmed on the #539 Slack thread that epoch 0 resolving to the registration key is something we can rely on, which rules out the alternative (`vaultProviders(vp).btcPubKey`) and the positional struct decode it would have needed.

Reading the merged contract, it is stronger than a convention — the two reads are the **same code path**:

- `vpKeyEpoch` is a registry-wide `uint64` starting at 0, and every rotation stamps `++vpKeyEpoch` (`BTCVaultRegistry.setOperationBtcKey`). Pre-increment, so the first rotation is epoch **1** and no version can ever carry epoch 0.
- `OpKeyVersionSearch.findAtEpoch` returns the greatest version in `[1, latest]` with `epoch <= 0`, so at epoch 0 it finds nothing and returns version 0.
- `VPKeyRegistryLogic.operationBtcKeyAtEpoch` then hits `if (v == 0) return vaultProviders[provider].btcPubKey;` — which is exactly what the removed `getVaultProviderBTCKey` returned.

So `getOperationBtcKeyAtEpoch(vp, 0)` is not merely equivalent to the deleted getter; it reaches the identical storage read.

## The change

One read moves. `ViemVaultRegistryReader` now resolves the genesis key as *the operation key at epoch 0*:

```diff
-      functionName: "getVaultProviderBTCKey",
-      args: [vpAddress],
+      functionName: "getOperationBtcKeyAtEpoch",
+      args: [vpAddress, VP_GENESIS_KEY_EPOCH],
```

The four consumers listed in the issue needed no call-site changes — deposit and refund call the reader directly, payout and resume go through `getVaultProviderGenesisBtcPubkeyFromChain`, and that wrapper calls the same reader method. Fixing it in one place fixes all four.

The ABI change is a **deletion only**. `getOperationBtcKeyAtEpoch(address, uint64)` was already present — it is what `getOperationKeysAtEpochs` uses — so nothing needed adding. `getVaultProviderKeyPair` was never in our ABI. I left a comment where the entry was, saying the getters are deliberately absent, so nobody re-adds one and compiles a call against a selector the registry no longer exposes.

## Rename

`getVaultProviderBtcPubKey` → `getVaultProviderGenesisBtcPubKey`, and the vault wrapper alongside it. This is most of the line count and is mechanical, compiler-verified, and separable if a reviewer would rather see it split out.

It is worth doing here specifically because the re-point makes the old name *worse*. `getVaultProviderBTCKey` at least named a getter you could go read; after this change a call site says `getVaultProviderBtcPubKey()` with nothing indicating it means the genesis key rather than the live one. That exact ambiguity is what caused the bug #2173 fixed. The new name also finally agrees with the parameter it feeds, `vaultProviderGenesisBtcPubkey`.

## One behaviour change worth reviewing

The removed getter existed on pre-RFC-006 registries; `getOperationBtcKeyAtEpoch` does not. So this read now **requires an RFC-006 registry** and reverts against an older one.

That costs nothing, and I checked all four callers rather than assuming:

| path | already RFC-006-only because |
|---|---|
| deposit — `validateOnChainParticipantKeys` | calls `resolveCurrentParticipantKeys` → `getCurrentOperationBtcKey` |
| payout — `prepareSigningContext` | `resolveParticipantKeysAtEpochs` + `getPayoutScriptsAtEpochs` |
| refund — `readPrePeginContext` | `resolveParticipantKeysAtEpochs` |
| resume — `verifyResumeParticipantKeys` | `getVaultKeyEpochsFromChain` + `resolveParticipantKeysAtEpochs` |

Every one of them already fails against a legacy registry, so requiring RFC-006 for this read adds no new deployment constraint. A test pins the revert as intended behaviour rather than a regression.

**No network we point at is affected:** devnet and testnet both expose `getOperationBtcKeyAtEpoch` today (measured below). The revert case is hypothetical for us — the only pre-RFC-006 registry I could find is `mock-testnet`, which nothing in this repo references.

## Tests

Two new cases in `vault-registry-reader.test.ts`, both covering things the existing assertions could not:

- **the epoch argument is 0** — the pre-existing tests only checked the returned value, so a non-zero epoch would have passed while silently returning a *rotated* key and feeding it in as the genesis fallback. That is the failure mode this change could plausibly introduce, so it gets an explicit assertion on `functionName` and `args`.
- **a pre-RFC-006 registry surfaces the revert** rather than degrading.

Everything else is the rename, which the compiler verifies. No behavioural test changed.

## Verification

`pnpm run build` clean across 7 projects. ts-sdk 1471 passing (1469 + 2 new). vault 3042 passing, no failures. `tsc --noEmit -p tsconfig.lib.json` clean. `pnpm run lint` 0 errors.

Grepped for stragglers: no `getVaultProviderBTCKey` or `getVaultProviderKeyPair` reference survives outside the comments that explain their removal.

## Verified on-chain

Ran the comparison against the canonical registries in [tbv-networks](https://github.com/babylonlabs-io/tbv-networks), rather than the addresses in local `.env` files — one of which turned out to be a stale devnet deployment.

| network | registry | `getVaultProviderBTCKey` vs `getOperationBtcKeyAtEpoch(vp, 0)` | rotated? |
|---|---|---|---|
| devnet | `0x43DB…8500` | **identical** — `0x1db08a…008e` | **yes** — current key is `0x4a9c87…835b` |
| testnet | `0xE976…C750` | **identical** for all 4 registered VPs | none |

devnet is the load-bearing case: a provider that has actually rotated, where epoch 0 still returns the registration key while the current operation key differs. So this PR is a **no-op on every network we point at** — byte-identical values before and after — and its entire effect is to survive #539.

`getVaultProviderBTCKey` is still present on both, so #539 has merged but not yet deployed.

Two incidental confirmations:

- **Unregistered VPs behave identically.** Querying a registry for a VP registered on a different network returns zero from *both* getters, and `assertOnChainBtcPubkey` rejects a zero hash as off-curve — so both fail loudly rather than opening a silent-zero path.
- **The RFC-006-only claim above is measured, not argued.** `mock-testnet` (`0x3d81…64b6`) is a pre-RFC-006 registry: `getOperationBtcKeyAtEpoch` *and* `getCurrentOperationBtcKey` both revert there. Since `main` already calls the latter on every deposit, that registry is already unusable today — this PR does not narrow network support, #2173 did. Nothing in babylon-toolkit references mock-testnet.

What remains unexercised outside mocks is viem encoding the new `uint64` epoch argument in the running app — though `cast` made that same call successfully against both registries using this PR's exact ABI signature, and that signature is byte-for-byte the one in the merged contract source (`address provider, uint64 epoch` → `bytes32`).


