### PR TITLE
test(core-ui): show the visual regression check catching a real change

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -8,9 +8,41 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# The floor. The capture job below runs the PR's own dependency tree - pnpm
+# lifecycle scripts, Storybook plugins, a browser - so it gets read and
+# nothing else. The write-capable token lives in the `publish` job, which
+# runs none of that. See the note on that job for what the split does and
+# does not defend against.
 permissions:
   contents: read
-  pull-requests: write
+
+env:
+  # Where the before/after images are published so that
+  # raw.githubusercontent.com can serve them into a comment; an artifact
+  # cannot be embedded in Markdown. Orphan: it shares no history with main
+  # and must never be merged anywhere. Named here because the URL baked into
+  # the comment and the branch the images are pushed to have to agree
+  # exactly, and they are built in two different jobs.
+  VISUAL_DIFF_BRANCH: visual-diffs
+
+  # The surfaces that get captured, compared and published, as one list.
+  # Adding a third means editing this and .github/scripts/visual-capture.sh,
+  # and nothing else - the diff loop, the embed step and the publish
+  # allowlist all read it from here. In the publish job it doubles as a
+  # security allowlist, which is why that job takes it from the workflow
+  # file and never from the payload it downloads.
+  VISUAL_SURFACES: vault storybook
+
+  # How much of the head sha names the published image directory. The sha is
+  # for humans reading the branch; uniqueness comes from the run id appended
+  # to it. Both are needed: GitHub proxies comment images through
+  # camo.githubusercontent.com and caches by URL, so a path that repeats
+  # serves the first render forever - and a sha alone repeats on a re-run,
+  # or on a reopen after the images were reaped, where what camo has cached
+  # may be a 404. Shared because the job that builds the URLs and the job
+  # that writes the files are different jobs, and a mismatch would 404 every
+  # image while both steps still exit 0.
+  VISUAL_SHA_PATH_LENGTH: 12
 
 # Advisory to begin with: this reports and comments, it does not fail the
 # build. Promote it to blocking (add --fail-on-change to the diff step)
@@ -18,6 +50,14 @@ permissions:
 jobs:
   visual:
     runs-on: ubuntu-latest
+
+    outputs:
+      report_sha: ${{ steps.refs.outputs.report_sha }}
+      changed_count: ${{ steps.diff.outputs.changed_count }}
+      compared_surfaces: ${{ steps.diff.outputs.compared_surfaces }}
+      missing_surfaces: ${{ steps.diff.outputs.missing_surfaces }}
+      diff_outcome: ${{ steps.diff.outcome }}
+      embed_outcome: ${{ steps.embed.outcome }}
 
     steps:
       - name: Checkout code
@@ -161,11 +201,16 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          mkdir -p "${{ runner.temp }}/visual"
+          # Everything the publish job needs is assembled under one
+          # directory, and that directory is uploaded as the artifact's only
+          # path. Uploading several paths would leave the layout to
+          # upload-artifact's common-ancestor rule, and the publish job has
+          # to hardcode where it looks.
+          mkdir -p "${{ runner.temp }}/visual/payload"
           TOTAL_CHANGED=0
           COMPARED=0
           MISSING=""
-          for SURFACE in vault storybook; do
+          for SURFACE in ${VISUAL_SURFACES}; do
             BASE="${{ runner.temp }}/visual/baseline/${SURFACE}"
             CAND="${{ runner.temp }}/visual/candidate/${SURFACE}"
             OUT="${{ runner.temp }}/visual/report/${SURFACE}"
@@ -174,23 +219,23 @@ jobs:
             # letting the diff die on a bare ENOENT.
             if [ ! -d "$CAND" ] || [ -z "$(ls -A "$CAND" 2>/dev/null)" ]; then
               echo "No candidate captures for ${SURFACE} - capture did not complete." \
-                | tee -a "${{ runner.temp }}/visual/diff-output.txt"
+                | tee -a "${{ runner.temp }}/visual/payload/diff-output.txt"
               MISSING="${MISSING}${MISSING:+ }${SURFACE}"
               continue
             fi
             if [ ! -d "$BASE" ] || [ -z "$(ls -A "$BASE" 2>/dev/null)" ]; then
               echo "No baseline captures for ${SURFACE} - nothing to compare against." \
-                | tee -a "${{ runner.temp }}/visual/diff-output.txt"
+                | tee -a "${{ runner.temp }}/visual/payload/diff-output.txt"
               MISSING="${MISSING}${MISSING:+ }${SURFACE}"
               continue
             fi
             COMPARED=$((COMPARED + 1))
-            echo "### ${SURFACE}" | tee -a "${{ runner.temp }}/visual/diff-output.txt"
+            echo "### ${SURFACE}" | tee -a "${{ runner.temp }}/visual/payload/diff-output.txt"
             node scripts/visual-diff.mjs \
               --baseline "$BASE" --candidate "$CAND" --out "$OUT" \
               --baseline-ref "${{ steps.refs.outputs.merge_base }}" \
               --candidate-ref "${{ steps.refs.outputs.head_sha }}" \
-              | tee -a "${{ runner.temp }}/visual/diff-output.txt"
+              | tee -a "${{ runner.temp }}/visual/payload/diff-output.txt"
             N="$(node -e "console.log(require('${OUT}/summary.json').changedCount)")"
             TOTAL_CHANGED=$((TOTAL_CHANGED + N))
           done
@@ -203,6 +248,45 @@ jobs:
           # sides would hide behind the other's COMPARED and read as green.
           echo "missing_surfaces=${MISSING}" >> "$GITHUB_OUTPUT"
 
+      # The reviewer-facing half of the change: stitch each of the
+      # most-changed screens into one before/after PNG and write the comment
+      # body that embeds them. A plain-text list of filenames and
+      # percentages is only actionable to someone willing to download and
+      # unzip the artifact below, which in practice is nobody.
+      #
+      # Gated on a clean, complete comparison. The partial and failed
+      # variants of the comment are warnings about the run itself, and
+      # illustrating them with pictures of the surface that did work would
+      # undercut the warning.
+      - name: Compose before/after images
+        id: embed
+        if: >-
+          steps.diff.outcome == 'success'
+          && steps.diff.outputs.missing_surfaces == ''
+          && steps.diff.outputs.changed_count != '0'
+        continue-on-error: true
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          # The head sha, not the merge commit: it is what the published
+          # path is keyed on, and it must match what the publish job
+          # computes from the same output.
+          REPORT_SHA: ${{ steps.refs.outputs.report_sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          VISUAL_DIR: ${{ runner.temp }}/visual
+        shell: bash
+        run: |
+          set -euo pipefail
+          RUN_DIR="${REPORT_SHA:0:${VISUAL_SHA_PATH_LENGTH}}-${GITHUB_RUN_ID}"
+          node scripts/visual-embed.mjs \
+            --report "${VISUAL_DIR}/report" \
+            --surfaces "${VISUAL_SURFACES// /,}" \
+            --out "${VISUAL_DIR}/payload/images" \
+            --base-url "https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${VISUAL_DIFF_BRANCH}/pr${PR_NUMBER}/${RUN_DIR}" \
+            --body "${VISUAL_DIR}/payload/comment-images.md" \
+            --run-url "${RUN_URL}" \
+            --candidate-ref "${REPORT_SHA}" \
+            --diff-text "${VISUAL_DIR}/payload/diff-output.txt"
+
       - name: Upload visual report
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2 https://github.com/actions/upload-artifact/releases/tag/v4.6.2
         if: always()
@@ -210,6 +294,18 @@ jobs:
           name: visual-report
           path: ${{ runner.temp }}/visual/report
           retention-days: 14
+
+      # Transport to the publish job, not a deliverable. Kept separate from
+      # `visual-report` so the reviewer-facing artifact keeps its 14-day
+      # retention while this one expires straight away.
+      - name: Upload comment payload
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2 https://github.com/actions/upload-artifact/releases/tag/v4.6.2
+        if: always()
+        with:
+          name: visual-comment-payload
+          path: ${{ runner.temp }}/visual/payload
+          if-no-files-found: ignore
+          retention-days: 1
 
       - name: Summarise
         if: always()
@@ -232,7 +328,7 @@ jobs:
               echo ":warning: The capture or comparison did not complete - no visual comparison was made."
               echo ""
               echo '```'
-              cat "${{ runner.temp }}/visual/diff-output.txt" 2>/dev/null || true
+              cat "${{ runner.temp }}/visual/payload/diff-output.txt" 2>/dev/null || true
               echo '```'
             # Every surface must have compared, not just the run overall. A
             # surface that captured empty on BOTH sides produces no
@@ -242,7 +338,7 @@ jobs:
               echo ":warning: No comparisons were produced for: ${MISSING}. The result below covers the remaining surface(s) only - this run is not a full comparison."
               echo ""
               echo '```'
-              cat "${{ runner.temp }}/visual/diff-output.txt" 2>/dev/null || true
+              cat "${{ runner.temp }}/visual/payload/diff-output.txt" 2>/dev/null || true
               echo '```'
             elif [ "${CHANGED}" = "0" ]; then
               echo ":white_check_mark: No visual changes detected."
@@ -250,64 +346,312 @@ jobs:
               echo ":framed_picture: **${CHANGED} screen(s) changed.**"
               echo ""
               echo '```'
-              cat "${{ runner.temp }}/visual/diff-output.txt" 2>/dev/null || true
+              cat "${{ runner.temp }}/visual/payload/diff-output.txt" 2>/dev/null || true
               echo '```'
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
-      # Sticky comment: edits the previous one instead of stacking one per
-      # push. Uses the preinstalled gh CLI rather than adding a third-party
-      # action, per the repo's supply-chain policy.
-      # Skipped on fork PRs: `pull_request` hands them a read-only token
-      # regardless of the `permissions:` block above, so the POST would 403
-      # and fail an advisory check for every external contributor. The job
-      # summary carries the same content for those runs.
-      - name: Comment on the PR
-        if: always() && github.event.pull_request.head.repo.full_name == github.repository
+  # The only job holding a token that can write anything, and deliberately
+  # the only one with no `actions/checkout`: the pull request's source and
+  # its dependency tree never land here, and this job runs none of it. What
+  # does cross is inert - the PNG bytes and the Markdown body out of the
+  # artifact - and both are treated as untrusted below.
+  #
+  # Be precise about what that buys. It is NOT protection against a
+  # malicious PR author - on `pull_request` the workflow file itself comes
+  # from the PR branch, so an author can move this permission wherever they
+  # like. What it protects against is the realistic threat: a compromised
+  # transitive dependency running inside the capture job, which installs and
+  # executes the PR's whole tree. That code reaches a read-only token here
+  # instead of one that can force-push over other people's branches.
+  # `main` and `release/*` are out of reach either way - the org ruleset
+  # requires signed commits and a pull request, and GITHUB_TOKEN cannot
+  # bypass it.
+  publish:
+    needs: visual
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    # `!cancelled()` rather than `always()`: a failed capture still gets a
+    # comment explaining itself, but a run cancelled by the concurrency
+    # group above does not. That cancellation means a newer push superseded
+    # this run, and letting it write would replace the report with a
+    # "capture did not complete" notice describing a commit nobody is
+    # looking at any more.
+    #
+    # Fork PRs are excluded because `pull_request` hands them a read-only
+    # token regardless of the `permissions:` block, so both the push and the
+    # comment would 403 and fail an advisory check for every external
+    # contributor - the job summary carries the same content for those runs.
+    # Dependabot is excluded for exactly the same reason and is easy to
+    # miss: its branches live in this repository, so the fork test passes,
+    # but GitHub scopes its token like a fork's.
+    if: >-
+      !cancelled()
+      && github.event.pull_request.head.repo.full_name == github.repository
+      && github.actor != 'dependabot[bot]'
+
+    steps:
+      - name: Download comment payload
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0 https://github.com/actions/download-artifact/releases/tag/v4.3.0
+        continue-on-error: true
+        with:
+          name: visual-comment-payload
+          path: ${{ runner.temp }}/payload
+
+      # Advisory, like everything else here: if the push fails the comment
+      # still posts, it just falls back to the text listing.
+      - name: Publish before/after images
+        id: publish
+        if: needs.visual.outputs.embed_outcome == 'success'
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
-          DIFF_OUTCOME: ${{ steps.diff.outcome }}
-          CHANGED: ${{ steps.diff.outputs.changed_count }}
-          COMPARED: ${{ steps.diff.outputs.compared_surfaces }}
-          MISSING: ${{ steps.diff.outputs.missing_surfaces }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPORT_SHA: ${{ needs.visual.outputs.report_sha }}
+          EMBED_DIR: ${{ runner.temp }}/payload/images
+          WORK_DIR: ${{ runner.temp }}/visual-diffs-branch
         shell: bash
         run: |
           set -euo pipefail
+
+          # Ceiling on what one PR may add to the branch. Every `git clone`
+          # of this repository fetches every branch, so this tree lands in
+          # each developer's checkout - against a ~31MB repo, an unbounded
+          # publish would make the diff images the largest thing in it.
+          # Normal runs land far below this; tripping it means the caps in
+          # visual-embed.mjs are misconfigured, and refusing loudly beats
+          # quietly bloating everyone's clone. It bounds one PR's
+          # contribution, not the branch: what bounds the branch is the reap
+          # of closed pull requests below, so the live tree stays
+          # proportional to how many are open at once.
+          MAX_PUBLISHED_BYTES=$(( 4 * 1024 * 1024 ))
+          # The publish path is not serialised across pull requests -
+          # `concurrency` above is keyed on github.ref, which only serialises
+          # a PR against itself - so two PRs finishing together will collide.
+          MAX_PUSH_ATTEMPTS=5
+          PUSH_RETRY_BACKOFF_SECONDS=5
+          # The images were produced by a job that ran the PR's own code, so
+          # their names are attacker-controlled. Only the surface directories
+          # named above are read, and a basename outside this pattern is
+          # DROPPED rather than rewritten: a renamed file would publish at a
+          # URL the comment does not reference, which reads as a broken
+          # image rather than as a refused one.
+          #
+          # Matched with bash's =~ rather than grep: grep is line-oriented,
+          # so a filename containing a newline - legal on Linux - would pass
+          # as soon as any one of its lines matched.
+          SAFE_NAME='^[A-Za-z0-9][A-Za-z0-9._-]*\.png$'
+
+          RUN_DIR="${REPORT_SHA:0:${VISUAL_SHA_PATH_LENGTH}}-${GITHUB_RUN_ID}"
+          PR_DIR="pr${PR_NUMBER}"
+          REMOTE="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+          if [ ! -d "${EMBED_DIR}" ] || [ -z "$(find "${EMBED_DIR}" -name '*.png' -print -quit)" ]; then
+            echo "No composed images to publish."
+            exit 1
+          fi
+
+          TOTAL_BYTES="$(find "${EMBED_DIR}" -name '*.png' -printf '%s\n' | awk '{ n += $1 } END { print n + 0 }')"
+          if [ "${TOTAL_BYTES}" -gt "${MAX_PUBLISHED_BYTES}" ]; then
+            echo "::error::Composed images total ${TOTAL_BYTES} bytes, over the ${MAX_PUBLISHED_BYTES}-byte per-PR ceiling. Refusing to publish - check the caps in scripts/visual-embed.mjs."
+            exit 1
+          fi
+
+          # One request rather than one per directory. Best-effort on
+          # purpose: if the listing fails every directory is kept, because
+          # deleting the images of a PR that is still open is the only
+          # outcome here that actually costs a reviewer anything.
+          OPEN_PRS="${RUNNER_TEMP}/open-prs.txt"
+          REAP=1
+          if ! gh pr list --repo "${GITHUB_REPOSITORY}" --state open --limit 1000 \
+               --json number --jq '.[].number' > "${OPEN_PRS}"; then
+            echo "::warning::Could not list open pull requests - keeping every published directory this run."
+            REAP=0
+          fi
+
+          ATTEMPT=1
+          while [ "${ATTEMPT}" -le "${MAX_PUSH_ATTEMPTS}" ]; do
+            # The whole read-modify-write repeats on every attempt, not just
+            # the push. The tree built below is a snapshot of the branch as
+            # it was BEFORE a competing publish landed; re-pushing it with a
+            # refreshed lease would succeed and silently delete the other
+            # PR's images.
+            rm -rf "${WORK_DIR}"
+            if git clone --quiet --depth 1 --branch "${VISUAL_DIFF_BRANCH}" --single-branch \
+                 "${REMOTE}" "${WORK_DIR}"; then
+              LEASE="$(git -C "${WORK_DIR}" rev-parse HEAD)"
+            else
+              # First run ever: the branch does not exist. An empty lease
+              # asserts exactly that, so a branch created in between by
+              # another run is a rejection rather than an overwrite.
+              rm -rf "${WORK_DIR}"
+              mkdir -p "${WORK_DIR}"
+              git -C "${WORK_DIR}" init --quiet --initial-branch="${VISUAL_DIFF_BRANCH}"
+              LEASE=""
+            fi
+
+            if [ "${REAP}" = "1" ]; then
+              for DIR in "${WORK_DIR}"/pr*/; do
+                [ -d "${DIR}" ] || continue
+                NUMBER="$(basename "${DIR}")"
+                NUMBER="${NUMBER#pr}"
+                # Anything that is not pr<digits> was not written by this
+                # job. Leave it rather than guess at it.
+                case "${NUMBER}" in ""|*[!0-9]*) continue ;; esac
+                if ! grep -qx "${NUMBER}" "${OPEN_PRS}"; then
+                  rm -rf "${DIR}"
+                  echo "Reaped pr${NUMBER} - that pull request is closed."
+                fi
+              done
+            fi
+
+            # The whole PR directory, not just this sha's: exactly one
+            # comment exists per PR and it always points at the newest push,
+            # so every earlier sha under it is already unreferenced.
+            rm -rf "${WORK_DIR:?}/${PR_DIR}"
+            for SURFACE in ${VISUAL_SURFACES}; do
+              [ -d "${EMBED_DIR}/${SURFACE}" ] || continue
+              mkdir -p "${WORK_DIR}/${PR_DIR}/${RUN_DIR}/${SURFACE}"
+              for SRC in "${EMBED_DIR}/${SURFACE}"/*.png; do
+                [ -f "${SRC}" ] || continue
+                NAME="$(basename "${SRC}")"
+                if [[ ! "${NAME}" =~ ${SAFE_NAME} ]]; then
+                  echo "::warning::Refusing to publish '${NAME}' - outside the allowed filename pattern."
+                  continue
+                fi
+                cp "${SRC}" "${WORK_DIR}/${PR_DIR}/${RUN_DIR}/${SURFACE}/${NAME}"
+              done
+            done
+
+            # Someone will find this branch in the branch list and wonder
+            # whether it is safe to delete. Answer that in the branch
+            # itself. Written with printf rather than a heredoc because a
+            # heredoc nested in this block scalar would carry the YAML
+            # indentation into the file and render as a code block.
+            printf '%s\n' \
+              '# visual-diffs' \
+              '' \
+              'Machine-written. Holds the before/after PNGs that the Visual regression' \
+              'check embeds in pull request comments, and nothing else.' \
+              '' \
+              '- Written only by `.github/workflows/visual-regression.yml`.' \
+              '- Shares no history with `main`. Never merge it anywhere.' \
+              '- Rewritten as one parentless commit per publish, so the branch has no' \
+              '  history to grow and a fresh clone transfers only the live tree.' \
+              '- `pr<number>/<head-sha>/` is deleted once that pull request closes, so' \
+              '  images in comments on closed pull requests will 404.' \
+              '- Safe to delete outright. The next run recreates it.' \
+              > "${WORK_DIR}/README.md"
+
+            git -C "${WORK_DIR}" add --all
+            TREE="$(git -C "${WORK_DIR}" write-tree)"
+            # No -p, so the commit has no parent and the force-push below
+            # replaces the branch's entire history with this one commit.
+            # That is the whole retention policy: incremental commits would
+            # keep every PNG ever published reachable, and `git clone`
+            # fetches all branches.
+            COMMIT="$(git -C "${WORK_DIR}" \
+              -c user.name="github-actions[bot]" \
+              -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
+              commit-tree "${TREE}" -m "visual diffs for PR #${PR_NUMBER} at ${RUN_DIR}")"
+
+            # --force-with-lease, never a bare --force: a plain force would
+            # silently drop a publish that landed between the clone above
+            # and this push.
+            set +e
+            git -C "${WORK_DIR}" push --quiet \
+              --force-with-lease="${VISUAL_DIFF_BRANCH}:${LEASE}" \
+              "${REMOTE}" "${COMMIT}:refs/heads/${VISUAL_DIFF_BRANCH}"
+            PUSH_STATUS=$?
+            set -e
+
+            if [ "${PUSH_STATUS}" -eq 0 ]; then
+              echo "Published ${PR_DIR}/${RUN_DIR} on ${VISUAL_DIFF_BRANCH}."
+              exit 0
+            fi
+
+            echo "Push attempt ${ATTEMPT} lost the race - retrying."
+            sleep $(( PUSH_RETRY_BACKOFF_SECONDS * ATTEMPT ))
+            ATTEMPT=$(( ATTEMPT + 1 ))
+          done
+
+          echo "::error::Could not publish before/after images after ${MAX_PUSH_ATTEMPTS} attempts."
+          exit 1
+
+      # Sticky comment: exactly one per pull request, edited in place rather
+      # than stacked one per push, so what a reviewer reads is always this
+      # run's result. Uses the preinstalled gh CLI rather than adding a
+      # third-party action, per the repo's supply-chain policy.
+      - name: Comment on the PR
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DIFF_OUTCOME: ${{ needs.visual.outputs.diff_outcome }}
+          CHANGED: ${{ needs.visual.outputs.changed_count }}
+          COMPARED: ${{ needs.visual.outputs.compared_surfaces }}
+          MISSING: ${{ needs.visual.outputs.missing_surfaces }}
+          PUBLISH_OUTCOME: ${{ steps.publish.outcome }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          PAYLOAD_DIR: ${{ runner.temp }}/payload
+        shell: bash
+        run: |
+          set -euo pipefail
+          # GitHub rejects a comment body over 65536 characters with a 422.
+          # The body is built from a capped set of screens so it lands near
+          # 8KB, but it is assembled by a job that ran the PR's own code - if
+          # it ever comes back oversized this must fall back to the text
+          # listing, not fail and leave the pull request with no report.
+          MAX_COMMENT_BYTES=60000
           MARKER="<!-- visual-regression-report -->"
-          BODY_FILE="${{ runner.temp }}/visual/comment.md"
-          mkdir -p "$(dirname "$BODY_FILE")"
+          BODY_FILE="${RUNNER_TEMP}/comment.md"
           {
             echo "$MARKER"
-            echo "### Visual regression"
-            echo ""
             # `${CHANGED:-0}` substitutes on empty as well as unset, so a
             # skipped or failed diff step used to collapse to 0 and post an
             # affirmative "no visual changes". Claiming that when nothing was
             # compared is worse than staying quiet, so the outcome is checked
             # first.
             if [ "${DIFF_OUTCOME}" != "success" ] || [ -z "${COMPARED}" ] || [ "${COMPARED}" = "0" ]; then
+              echo "### Visual regression"
+              echo ""
               echo ":warning: The capture or comparison did not complete - no visual comparison was made."
               echo ""
               echo "[Open the run](${RUN_URL}) to see which step failed."
-            # Per-surface gate, same reasoning as the summary: a surface
-            # that captured empty on both sides must be named, not folded
-            # into the other surface's green.
+            # Per-surface gate: a surface that captured empty on both sides
+            # must be named, not folded into the other surface's green.
             elif [ -n "${MISSING}" ]; then
+              echo "### Visual regression"
+              echo ""
               echo ":warning: No comparisons were produced for: ${MISSING}. The remaining surface(s) alone do not make this a clean run."
               echo ""
               echo '```'
-              cat "${{ runner.temp }}/visual/diff-output.txt" || true
+              cat "${PAYLOAD_DIR}/diff-output.txt" || true
               echo '```'
               echo ""
               echo "[Open the run](${RUN_URL}) to see why that capture came up empty."
             elif [ "${CHANGED}" = "0" ]; then
+              echo "### Visual regression"
+              echo ""
               echo ":white_check_mark: No visual changes against the merge-base."
+            # The body with the pictures in it, used only once the images it
+            # points at are actually being served. Composing or publishing
+            # them is allowed to fail; posting URLs that 404 is not.
+            elif [ "${PUBLISH_OUTCOME}" = "success" ] \
+              && [ -s "${PAYLOAD_DIR}/comment-images.md" ] \
+              && [ "$(wc -c < "${PAYLOAD_DIR}/comment-images.md")" -le "${MAX_COMMENT_BYTES}" ]; then
+              cat "${PAYLOAD_DIR}/comment-images.md"
             else
+              echo "### Visual regression"
+              echo ""
               echo ":framed_picture: **${CHANGED} screen(s) changed** against the merge-base."
               echo ""
               echo '```'
-              cat "${{ runner.temp }}/visual/diff-output.txt" || true
+              cat "${PAYLOAD_DIR}/diff-output.txt" || true
               echo '```'
               echo ""
               echo "[Open the run](${RUN_URL}#artifacts), download **visual-report**, and open \`index.html\` for the before / after / diff view."
@@ -316,15 +660,39 @@ jobs:
             fi
           } > "$BODY_FILE"
 
-          EXISTING="$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+          # --paginate because the default page holds 30 comments: on a
+          # busy pull request the marker scrolls off it, the lookup comes
+          # back empty and the job posts a SECOND report instead of editing
+          # the first.
+          #
+          # The first line is taken with a parameter expansion rather than
+          # `| head -n1`, which would be a trap here: --jq runs per page, so
+          # head exits after page one, gh takes SIGPIPE writing page two,
+          # and `set -o pipefail` turns that into a failed step - losing the
+          # comment on precisely the busy pull requests --paginate is for.
+          MATCHES="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate \
             --jq "map(select(.body | startswith(\"$MARKER\"))) | .[0].id // empty")"
+          EXISTING="${MATCHES%%$'\n'*}"
 
           if [ -n "$EXISTING" ]; then
-            gh api --method PATCH "repos/${{ github.repository }}/issues/comments/${EXISTING}" \
+            gh api --method PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${EXISTING}" \
               -F body=@"$BODY_FILE" > /dev/null
             echo "Updated existing comment ${EXISTING}."
           else
-            gh api --method POST "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+            gh api --method POST "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
               -F body=@"$BODY_FILE" > /dev/null
             echo "Posted a new comment."
+          fi
+
+          # There must be exactly one of these on a pull request, and only
+          # the one patched above is current. A second can exist from a run
+          # whose lookup missed - the un-paginated lookup this replaced left
+          # some behind - and it would sit there forever showing a result
+          # from a commit that has since been rewritten. Reap rather than
+          # leave two contradictory reports.
+          if [ "${MATCHES}" != "${EXISTING}" ]; then
+            for STALE in ${MATCHES#*$'\n'}; do
+              gh api --method DELETE "repos/${GITHUB_REPOSITORY}/issues/comments/${STALE}" > /dev/null
+              echo "Deleted duplicate report comment ${STALE}."
+            done
           fi

--- a/packages/babylon-core-ui/src/components/Button/Button.css
+++ b/packages/babylon-core-ui/src/components/Button/Button.css
@@ -7,7 +7,7 @@
 
   &-contained {
     &.bbn-btn-primary {
-      @apply text-accent-contrast bg-primary-light hover:brightness-110 disabled:bg-primary-light/30;
+      @apply text-accent-contrast bg-error-main hover:brightness-110 disabled:bg-error-main/30;
     }
 
     &.bbn-btn-secondary {

--- a/scripts/visual-diff.mjs
+++ b/scripts/visual-diff.mjs
@@ -55,7 +55,13 @@ export function changedPixelCutoff(width, height) {
   return Math.max(MIN_CHANGED_PIXELS, CHANGED_RATIO_TOLERANCE * width * height);
 }
 
-const STATUS = {
+/**
+ * The statuses a compared screen can end up in. Exported because
+ * `scripts/visual-embed.mjs` groups and captions by them: with the strings
+ * restated there, renaming one here would leave that script silently
+ * mis-captioning the screen rather than failing.
+ */
+export const STATUS = {
   UNCHANGED: "unchanged",
   CHANGED: "changed",
   ADDED: "added",

--- a/scripts/visual-embed.mjs
+++ b/scripts/visual-embed.mjs
@@ -1,0 +1,781 @@
+/**
+ * Turns a visual-diff report into something a reviewer can read without
+ * leaving the pull request.
+ *
+ *   node scripts/visual-embed.mjs \
+ *     --report <dir> --surfaces vault,storybook --out <dir> \
+ *     --base-url <url> --body <file> --run-url <url> \
+ *     --candidate-ref <sha> --diff-text <file>
+ *
+ * `scripts/visual-diff.mjs` already writes, per surface, a `summary.json`
+ * plus full-resolution `baseline/`, `candidate/` and `diff/` directories.
+ * That report is complete but it only ships as a zipped CI artifact, so in
+ * practice nobody looks at it and the PR comment degrades to a list of
+ * filenames and percentages.
+ *
+ * This script closes that gap. For the most-changed screens it stitches the
+ * two sides into one before/after PNG under `--out`, and writes a Markdown
+ * body under `--body` that embeds those PNGs from `--base-url`. The workflow
+ * pushes `--out` to a branch that raw.githubusercontent.com serves, which is
+ * what makes the images renderable inside a comment - GitHub cannot embed an
+ * image out of a run artifact.
+ *
+ * Only a slice of the changed screens is embedded (see the caps below). The
+ * body always also carries the complete text list, so the reviewer can see
+ * that the pictures are a sample rather than the whole story.
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { PNG } from "pngjs";
+
+import { parseArgs, STATUS } from "./visual-diff.mjs";
+
+/**
+ * How many groups get pictures, and how many screens are pictured within
+ * each.
+ *
+ * Both caps exist for the same reason: eight Button stories changing is ONE
+ * fact about the Button component, and showing all eight would crowd out the
+ * single vault route that also moved. Two per group is enough to see whether
+ * a group's screens all changed the same way, and a repaint of a shared
+ * component routinely changes 40+ screens here (12 vault screens, 329
+ * stories), so the alternative is a comment nobody scrolls to the end of.
+ * Their product is the ceiling, not the count - a group holding one screen
+ * spends one slot.
+ *
+ * Deliberately just these two, with no separate ceiling on the total: a
+ * third cap could only bite by quietly giving the lowest-ranked groups
+ * fewer pictures than the promise above.
+ */
+const MAX_EMBEDDED_GROUPS = 5;
+const MAX_EMBEDDED_SCREENS_PER_GROUP = 2;
+
+/**
+ * Groups each surface is guaranteed, before the rest of the budget is
+ * handed out on rank alone.
+ *
+ * Rank alone is not enough. Repainting one shared component moves a
+ * Storybook story by 17% of its small frame and a vault route by 1% of a
+ * tall page, so a purely global ranking spends every slot on stories and
+ * shows the reviewer nothing of the app that ships. This floor is what
+ * keeps a vault screen in the comment.
+ */
+const MIN_EMBEDDED_GROUPS_PER_SURFACE = 2;
+
+/**
+ * Gap between the before and after panels, and the colour it is painted.
+ * Mid grey so it reads as a divider against both the light chrome of the
+ * app and the dark backdrop of the overlay stories, neither of which it
+ * could be mistaken for.
+ */
+const PANEL_GUTTER_WIDTH = 8;
+const PANEL_GUTTER_COLOUR = [120, 120, 120];
+
+/**
+ * Fill for the area a panel does not cover. Only reachable when the two
+ * sides differ in size, which is itself the finding - the padding marks how
+ * much taller or wider one side got, so it must not look like page content.
+ */
+const PANEL_PADDING_COLOUR = [232, 232, 232];
+
+/**
+ * Rows of unchanged context kept above and below the changed band.
+ *
+ * Full-page captures are tall - a vault route at 390px wide runs past
+ * 2000px - and a repaint usually moves a few hundred rows of that. Sending
+ * the whole page makes the change a speck; cropping to the band that
+ * actually differs makes it the subject. The context rows are what keep it
+ * recognisable as a place in the page rather than a floating fragment.
+ */
+const CROP_CONTEXT_ROWS = 96;
+
+/**
+ * Crop only when at least a fifth of the image goes with it. Trimming a
+ * sliver costs a reviewer the page's full shape and buys nothing, and a
+ * change that really is spread down the whole page is itself worth seeing
+ * whole.
+ */
+const CROP_MAX_KEPT_FRACTION = 0.8;
+
+/**
+ * Width the composite is reduced to before it is published.
+ *
+ * A comment body is about 800px wide, and GitHub scales any wider image
+ * down to fit, so pixels past this point are never shown - they are paid
+ * for only in clone weight, because every `git clone` of this repo fetches
+ * the branch these images live on. Two side-by-side 900px Storybook frames
+ * come to 1808px, so this halves them to roughly what the browser was going
+ * to render anyway.
+ */
+const EMBED_MAX_WIDTH = 1000;
+
+/**
+ * Ceiling on the composite's height, enforced by taking fewer rows rather
+ * than by scaling.
+ *
+ * Width alone does not bound the file. A change spread down a whole page -
+ * a font swap, a token recolour - leaves nothing to crop, and a vault route
+ * captured full-page at 390px wide runs past 3000px, so the composite stays
+ * tall no matter how narrow it is.
+ *
+ * Feeding that height into the reduction factor instead would be the wrong
+ * trade: two 390px panels side by side already come to 788px, well inside
+ * EMBED_MAX_WIDTH, so halving them to fit a height budget would render each
+ * phone screen at under 200px - small enough that the change being reported
+ * is no longer visible. Cutting rows keeps what is shown at full size.
+ */
+const MAX_COMPOSITE_HEIGHT = 2400;
+
+/** Separates a Storybook title path from its story name, and a vault route
+ *  from its viewport: `components-inputs-actions-button--fluid`,
+ *  `overview--mobile`. Storybook collapses runs of non-alphanumerics to a
+ *  single hyphen when it builds an id, so the first occurrence is the
+ *  separator and any later one cannot exist. */
+const GROUP_SEPARATOR = "--";
+
+/**
+ * Ranked above every percentage: a screen that appeared, disappeared or
+ * changed shape is a structural change, and `summary.json` carries no ratio
+ * for one. Finite on purpose - two structural changes tie, and `Infinity -
+ * Infinity` is `NaN`, which makes `Array.prototype.sort` order undefined.
+ * A ratio cannot exceed 1, so 2 sits above every real value.
+ */
+const STRUCTURAL_CHANGE_RANK = 2;
+
+function splitScreenName(fileName) {
+  const stem = fileName.replace(/\.png$/, "");
+  const index = stem.indexOf(GROUP_SEPARATOR);
+  if (index === -1) return { group: stem, variant: stem };
+  return {
+    group: stem.slice(0, index),
+    variant: stem.slice(index + GROUP_SEPARATOR.length),
+  };
+}
+
+/**
+ * Ranks one result. Structural changes float to the top, everything else
+ * sorts on how much of the frame moved.
+ */
+function changeRank(result) {
+  return result.changedRatio === null
+    ? STRUCTURAL_CHANGE_RANK
+    : result.changedRatio;
+}
+
+function formatPercent(ratio) {
+  return `${(ratio * 100).toFixed(3)}%`;
+}
+
+/**
+ * Orders by how much changed, then by name. The name is not decoration: two
+ * screens routinely tie (a shared component repainted in both), and without
+ * a tiebreak the comment would reshuffle between re-runs of the same commit
+ * and read as though something had moved.
+ */
+function byChangeThenName(a, b) {
+  return changeRank(b) - changeRank(a) || a.name.localeCompare(b.name);
+}
+
+/**
+ * Groups a surface's changed results and orders them, most-changed first.
+ * Grouping is what stops one component's story sweep from crowding out
+ * every other finding: eight Button stories become one entry.
+ */
+function groupChangedResults(surface, results) {
+  const groups = new Map();
+
+  for (const result of results) {
+    if (result.status === STATUS.UNCHANGED) continue;
+    const { group, variant } = splitScreenName(result.name);
+    const key = `${surface}/${group}`;
+    if (!groups.has(key)) {
+      groups.set(key, { surface, group, key, screens: [] });
+    }
+    groups.get(key).screens.push({ ...result, variant });
+  }
+
+  for (const group of groups.values()) {
+    group.screens.sort(byChangeThenName);
+    group.topRank = changeRank(group.screens[0]);
+  }
+
+  return [...groups.values()];
+}
+
+/** Same ordering as the screens, applied to whole groups. */
+function rankGroups(groups) {
+  return [...groups].sort(
+    (a, b) => b.topRank - a.topRank || a.key.localeCompare(b.key),
+  );
+}
+
+/**
+ * Picks which groups get pictures: each surface's own best few first, then
+ * the remaining slots by rank across everything.
+ */
+function selectEmbeddedGroups(ranked) {
+  const chosen = new Set();
+  const surfaces = new Set(ranked.map((group) => group.surface));
+
+  for (const surface of surfaces) {
+    const reserved = ranked
+      .filter((group) => group.surface === surface)
+      .slice(0, MIN_EMBEDDED_GROUPS_PER_SURFACE);
+    for (const group of reserved) {
+      // The reservations can only outrun the cap if a third surface is
+      // ever captured. Stopping here rather than letting the total drift
+      // means the comment length stays bounded by one constant; the
+      // surface that loses out is the last one in rank order.
+      if (chosen.size >= MAX_EMBEDDED_GROUPS) break;
+      chosen.add(group);
+    }
+  }
+
+  for (const group of ranked) {
+    if (chosen.size >= MAX_EMBEDDED_GROUPS) break;
+    chosen.add(group);
+  }
+  return rankGroups([...chosen]);
+}
+
+/**
+ * Names the publish step will copy onto the branch. Restated from the
+ * workflow rather than shared, because there it is a security allowlist
+ * applied to bytes this script produced; here it is the check that stops
+ * the comment linking to a file that got dropped on the way and rendering
+ * as a broken image.
+ */
+const PUBLISHABLE_SCREEN_NAME = /^[A-Za-z0-9][A-Za-z0-9._-]*\.png$/;
+
+/** Picks which screens get a picture, within the chosen groups. */
+function selectEmbeddedScreens(ranked) {
+  return selectEmbeddedGroups(ranked).flatMap((group) =>
+    group.screens
+      .filter((screen) => PUBLISHABLE_SCREEN_NAME.test(screen.name))
+      .slice(0, MAX_EMBEDDED_SCREENS_PER_GROUP)
+      .map((screen) => ({ surface: group.surface, screen })),
+  );
+}
+
+async function readPngIfPresent(file) {
+  try {
+    return PNG.sync.read(await fs.readFile(file));
+  } catch (error) {
+    if (error.code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+/**
+ * First and last row that differ, byte for byte.
+ *
+ * Deliberately exact rather than reusing the diff's antialiasing
+ * threshold: this only decides where to crop, and over-including a row of
+ * jitter costs a reviewer nothing while dropping a genuinely changed row
+ * would hide the finding.
+ */
+function changedRowBand(baseline, candidate) {
+  if (baseline.width !== candidate.width || baseline.height !== candidate.height) {
+    return null;
+  }
+  const rowBytes = baseline.width * 4;
+  let first = -1;
+  let last = -1;
+  for (let y = 0; y < baseline.height; y += 1) {
+    const start = y * rowBytes;
+    const end = start + rowBytes;
+    if (baseline.data.compare(candidate.data, start, end, start, end) !== 0) {
+      if (first === -1) first = y;
+      last = y;
+    }
+  }
+  return first === -1 ? null : { first, last };
+}
+
+/**
+ * The slice of rows the composite covers.
+ *
+ * Two rules, and the second one exists because breaking it publishes a
+ * picture that is worse than no picture at all:
+ *
+ * 1. Crop to the changed band when that removes a real slice of the page,
+ *    otherwise show the page from the top, where it is recognisable.
+ * 2. When the height ceiling has to bite, anchor the window on the change
+ *    rather than on row 0. Anchoring on row 0 looked harmless and was not:
+ *    a 12000px capture whose band starts at row 2450 would publish rows
+ *    0-2399, two byte-identical panels, under a caption reading "78% of
+ *    pixels changed".
+ *
+ * `clipped` says the ceiling bit, so the caption can admit the picture is
+ * a slice instead of letting the reviewer assume they saw all of it.
+ */
+function cropWindow(band, height) {
+  if (band === null) {
+    return {
+      top: 0,
+      height: Math.min(height, MAX_COMPOSITE_HEIGHT),
+      clipped: height > MAX_COMPOSITE_HEIGHT,
+    };
+  }
+
+  const bandTop = Math.max(0, band.first - CROP_CONTEXT_ROWS);
+  const bandBottom = Math.min(height, band.last + 1 + CROP_CONTEXT_ROWS);
+  const keepWholePage =
+    bandBottom - bandTop > height * CROP_MAX_KEPT_FRACTION;
+
+  const wantedTop = keepWholePage ? 0 : bandTop;
+  const wantedHeight = keepWholePage ? height : bandBottom - bandTop;
+  if (wantedHeight <= MAX_COMPOSITE_HEIGHT) {
+    return { top: wantedTop, height: wantedHeight, clipped: false };
+  }
+
+  // Rule 2. Start at the band, pulled back only as far as is needed to
+  // fill the window against the bottom of the page.
+  return {
+    top: Math.min(bandTop, Math.max(0, height - MAX_COMPOSITE_HEIGHT)),
+    height: MAX_COMPOSITE_HEIGHT,
+    clipped: true,
+  };
+}
+
+function fill(target, colour) {
+  for (let i = 0; i < target.data.length; i += 4) {
+    target.data[i] = colour[0];
+    target.data[i + 1] = colour[1];
+    target.data[i + 2] = colour[2];
+    target.data[i + 3] = 255;
+  }
+}
+
+/** Copies `window` rows of `source` into `target` with its left edge at `x`. */
+function blit(source, target, x, window) {
+  const rows = Math.min(window.height, Math.max(0, source.height - window.top));
+  for (let row = 0; row < rows; row += 1) {
+    const from = (window.top + row) * source.width * 4;
+    const to = (row * target.width + x) * 4;
+    source.data.copy(target.data, to, from, from + source.width * 4);
+  }
+}
+
+/**
+ * Stitches the two sides into one image, before on the left, and reports how
+ * much of the screen's height that image ended up covering.
+ *
+ * Side by side rather than stacked because the panels are then the same
+ * distance from the eye at every scroll position, and because a stacked
+ * pair of full-page captures is twice as tall as an already-tall page.
+ * A missing side (an added or removed screen) renders as one panel.
+ */
+function composeBeforeAfter(baseline, candidate) {
+  const present = [baseline, candidate].filter((png) => png !== null);
+  if (present.length === 0) throw new Error("Neither side of the pair was readable.");
+
+  const panelWidth = Math.max(...present.map((png) => png.width));
+  const band = baseline && candidate ? changedRowBand(baseline, candidate) : null;
+  const fullHeight = Math.max(...present.map((png) => png.height));
+  const window = cropWindow(band, fullHeight);
+
+  const width =
+    present.length === 2 ? panelWidth * 2 + PANEL_GUTTER_WIDTH : panelWidth;
+  const composite = new PNG({ width, height: window.height });
+  fill(composite, PANEL_PADDING_COLOUR);
+
+  if (present.length === 2) {
+    for (let y = 0; y < window.height; y += 1) {
+      for (let x = 0; x < PANEL_GUTTER_WIDTH; x += 1) {
+        const i = (y * width + panelWidth + x) * 4;
+        composite.data[i] = PANEL_GUTTER_COLOUR[0];
+        composite.data[i + 1] = PANEL_GUTTER_COLOUR[1];
+        composite.data[i + 2] = PANEL_GUTTER_COLOUR[2];
+        composite.data[i + 3] = 255;
+      }
+    }
+    blit(baseline, composite, 0, window);
+    blit(candidate, composite, panelWidth + PANEL_GUTTER_WIDTH, window);
+  } else {
+    blit(present[0], composite, 0, window);
+  }
+
+  return {
+    composite,
+    coverage: { shown: window.height, total: fullHeight, clipped: window.clipped },
+  };
+}
+
+/**
+ * Shrinks by an integer factor, averaging each block of source pixels.
+ *
+ * Averaging rather than dropping pixels: nearest-neighbour would sample a
+ * one-pixel-wide border change on some rows and miss it on others, so a
+ * hairline that moved would flicker in and out of the published image.
+ * An average always carries some of the new colour into the block.
+ */
+function downscale(source, maxWidth) {
+  const factor = Math.ceil(source.width / maxWidth);
+  if (factor <= 1) return source;
+
+  const width = Math.ceil(source.width / factor);
+  const height = Math.ceil(source.height / factor);
+  const target = new PNG({ width, height });
+
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      let red = 0;
+      let green = 0;
+      let blue = 0;
+      let sampled = 0;
+      for (let dy = 0; dy < factor; dy += 1) {
+        const sourceY = y * factor + dy;
+        if (sourceY >= source.height) break;
+        for (let dx = 0; dx < factor; dx += 1) {
+          const sourceX = x * factor + dx;
+          if (sourceX >= source.width) break;
+          const i = (sourceY * source.width + sourceX) * 4;
+          red += source.data[i];
+          green += source.data[i + 1];
+          blue += source.data[i + 2];
+          sampled += 1;
+        }
+      }
+      const i = (y * width + x) * 4;
+      target.data[i] = Math.round(red / sampled);
+      target.data[i + 1] = Math.round(green / sampled);
+      target.data[i + 2] = Math.round(blue / sampled);
+      target.data[i + 3] = 255;
+    }
+  }
+  return target;
+}
+
+async function writeComposite(reportDir, outDir, surface, name) {
+  const baseline = await readPngIfPresent(
+    path.join(reportDir, surface, "baseline", name),
+  );
+  const candidate = await readPngIfPresent(
+    path.join(reportDir, surface, "candidate", name),
+  );
+  const { composite, coverage } = composeBeforeAfter(baseline, candidate);
+  const target = path.join(outDir, surface, name);
+  await fs.mkdir(path.dirname(target), { recursive: true });
+  await fs.writeFile(target, PNG.sync.write(downscale(composite, EMBED_MAX_WIDTH)));
+  return coverage;
+}
+
+/**
+ * How a screen's caption describes what the picture below it shows.
+ *
+ * Which panel is which is spelled out rather than left to a convention.
+ * Nothing is drawn into the image itself to say so, and "before / after"
+ * on its own reads as a pair of alternatives as easily as an ordering.
+ */
+const PANEL_ORDER_NOTE = "before on the left, after on the right";
+
+function screenCaption(result, coverage) {
+  const clipped =
+    coverage && coverage.clipped
+      ? ` (picture trimmed to ${coverage.shown}px of ${coverage.total}px)`
+      : "";
+  if (result.status === STATUS.ADDED) {
+    return `added by this PR - after only${clipped}`;
+  }
+  if (result.status === STATUS.REMOVED) {
+    return `removed by this PR - before only${clipped}`;
+  }
+  if (result.status === STATUS.SIZE_CHANGED) {
+    return `${result.baselineSize} to ${result.candidateSize} - ${PANEL_ORDER_NOTE}${clipped}`;
+  }
+  return `${formatPercent(result.changedRatio)} of pixels - ${PANEL_ORDER_NOTE}${clipped}`;
+}
+
+/**
+ * The one-line summary on a collapsed group.
+ *
+ * Reports the structural changes and the worst percentage separately rather
+ * than just describing the top-ranked screen: a group holding one added
+ * story and a 17% repaint would otherwise summarise as "added" and hide the
+ * repaint behind a fold nobody opens.
+ */
+function groupHeadline(group) {
+  const parts = [
+    `${group.screens.length} screen${group.screens.length === 1 ? "" : "s"}`,
+  ];
+  for (const status of [STATUS.ADDED, STATUS.REMOVED, STATUS.SIZE_CHANGED]) {
+    const count = group.screens.filter((s) => s.status === status).length;
+    if (count > 0) parts.push(`${count} ${status}`);
+  }
+  const measured = group.screens.filter((s) => s.changedRatio !== null);
+  if (measured.length > 0) {
+    parts.push(`up to ${formatPercent(measured[0].changedRatio)} changed`);
+  }
+  return parts.join(", ");
+}
+
+/** Describes the picture for a reader who cannot see it. */
+function screenAltText(screen) {
+  const stem = screen.name.replace(/\.png$/, "");
+  if (screen.status === STATUS.ADDED) return `${stem}, this PR only`;
+  if (screen.status === STATUS.REMOVED) return `${stem}, merge-base only`;
+  return `${stem}, merge-base on the left and this PR on the right`;
+}
+
+function renderGroup(group, embeddedNames, coverage, baseUrl, expanded) {
+  const lines = [
+    `<details${expanded ? " open" : ""}><summary><code>${group.group}</code> - ${groupHeadline(group)}</summary>`,
+    "",
+  ];
+
+  const shown = group.screens.filter((screen) =>
+    embeddedNames.has(`${group.surface}/${screen.name}`),
+  );
+
+  for (const screen of shown) {
+    const url = `${baseUrl}/${group.surface}/${encodeURIComponent(screen.name)}`;
+    lines.push(
+      `**${screen.variant}** - ${screenCaption(screen, coverage.get(`${group.surface}/${screen.name}`))}`,
+    );
+    lines.push("");
+    lines.push(`![${screenAltText(screen)}](${url})`);
+    lines.push("");
+  }
+
+  const remaining = group.screens.length - shown.length;
+  if (remaining > 0) {
+    lines.push(
+      `<sub>${remaining} more changed screen${remaining === 1 ? "" : "s"} in this group - listed in full below.</sub>`,
+    );
+    lines.push("");
+  }
+
+  lines.push("</details>");
+  lines.push("");
+  return lines;
+}
+
+/**
+ * The comment body for a run that did produce a comparison and found
+ * changes. The workflow keeps owning the "nothing was compared" and
+ * "nothing changed" wordings, because those are facts about the job's own
+ * steps rather than about the report.
+ */
+function renderBody({
+  surfaces,
+  ranked,
+  embedded,
+  coverage,
+  baseUrl,
+  runUrl,
+  candidateRef,
+  diffText,
+}) {
+  const changedTotal = surfaces.reduce((sum, s) => sum + s.changedCount, 0);
+  const screenTotal = surfaces.reduce((sum, s) => sum + s.totalCount, 0);
+  const embeddedNames = new Set(
+    embedded.map((entry) => `${entry.surface}/${entry.screen.name}`),
+  );
+
+  const lines = [
+    "### Visual regression",
+    "",
+    `:framed_picture: **${changedTotal} of ${screenTotal} screens render differently** than the merge-base.`,
+    "",
+  ];
+
+  // Groups are ranked across both surfaces, but the SECTIONS keep the order
+  // the surfaces were passed in, which puts the vault app above Storybook
+  // even on a run where a story moved more. That is deliberate and is the
+  // same judgement as MIN_EMBEDDED_GROUPS_PER_SURFACE: a component story
+  // changing is evidence, a shipped route changing is the thing itself.
+  // Each section opens on its own worst group, so neither surface is more
+  // than one heading away.
+  for (const surface of surfaces) {
+    const pictured = ranked.filter(
+      (group) =>
+        group.surface === surface.name &&
+        group.screens.some((screen) => embeddedNames.has(`${surface.name}/${screen.name}`)),
+    );
+    if (pictured.length === 0) continue;
+    const groupCount = ranked.filter((group) => group.surface === surface.name).length;
+    lines.push(
+      `#### ${surface.name} - ${surface.changedCount} of ${surface.totalCount} screens changed`,
+    );
+    lines.push("");
+    // Say outright when the sections below are not all of them. The heading
+    // counts screens and the sections count groups, so without this a
+    // reviewer reading "40 changed" under three collapsed sections has no
+    // way to tell whether the other groups were fine or merely unprinted.
+    if (pictured.length < groupCount) {
+      lines.push(
+        `<sub>Showing ${pictured.length} of ${groupCount} changed groups. The rest are in the full list at the end.</sub>`,
+      );
+      lines.push("");
+    }
+    // Each surface opens on its worst group and folds the rest away, so the
+    // comment lands on one picture per surface instead of a wall of them.
+    for (const [index, group] of pictured.entries()) {
+      lines.push(
+        ...renderGroup(group, embeddedNames, coverage, baseUrl, index === 0),
+      );
+    }
+  }
+
+  lines.push(`<details><summary>All ${changedTotal} changed screens</summary>`);
+  lines.push("");
+  lines.push("```");
+  lines.push(diffText.trimEnd());
+  lines.push("```");
+  lines.push("");
+  lines.push("</details>");
+  lines.push("");
+  // Deliberately not "the N most-changed": the selection reserves slots per
+  // surface, so a pictured vault screen can have moved less than a Storybook
+  // story that got no picture. Claiming a strict ranking would send a
+  // reviewer looking for a worst offender that is not there.
+  lines.push(
+    `<sub>${embedded.length} screen${embedded.length === 1 ? "" : "s"} pictured, cropped to the part that changed - a sample across the ` +
+      `worst-hit groups on each surface, not a ranking. Full-resolution before / after / diff for every screen: ` +
+      `[open the run](${runUrl}#artifacts), download **visual-report**, open \`index.html\`.</sub>`,
+  );
+  lines.push("");
+  lines.push(
+    "<sub>If these changes are intentional there is nothing to update - this repo stores no baseline images. " +
+      "The baseline is recomputed from the merge-base on every run.</sub>",
+  );
+  lines.push("");
+  // Names the commit this describes. There is one of these comments per
+  // pull request and it is rewritten in place on every push, so without the
+  // sha a reader has no way to tell a current report from one left behind
+  // by a run that failed to update it.
+  lines.push(
+    `<sub>Compared \`${candidateRef}\` against the merge-base. Images are pruned when this pull request closes.</sub>`,
+  );
+  lines.push("");
+  return lines.join("\n");
+}
+
+async function readSummary(reportDir, surface) {
+  const file = path.join(reportDir, surface, "summary.json");
+  try {
+    return JSON.parse(await fs.readFile(file, "utf8"));
+  } catch (error) {
+    if (error.code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const reportDir = args.get("report");
+  const outDir = args.get("out");
+  const baseUrl = args.get("base-url");
+  const bodyFile = args.get("body");
+  const runUrl = args.get("run-url");
+  const candidateRef = args.get("candidate-ref");
+  const diffTextFile = args.get("diff-text");
+  const surfaceNames = (args.get("surfaces") ?? "").split(",").filter(Boolean);
+
+  const usage =
+    "Usage: visual-embed.mjs --report <dir> --surfaces <a,b> --out <dir> " +
+    "--base-url <url> --body <file> --run-url <url> --candidate-ref <sha> " +
+    "--diff-text <file>";
+
+  // Checked one flag at a time so the error names the one that is wrong.
+  //
+  // `value === "true"` is not paranoia: `parseArgs` stores the string "true"
+  // for a flag whose value is missing, and "true" is truthy. Without it a
+  // dropped `--base-url` value embeds every picture at the relative URL
+  // "true/<surface>/<name>.png" - a comment full of broken images, exit code
+  // 0, and nothing in the run saying so. None of these flags legitimately
+  // takes "true" as a value.
+  for (const [flag, value] of [
+    ["--report", reportDir],
+    ["--out", outDir],
+    ["--base-url", baseUrl],
+    ["--body", bodyFile],
+    ["--run-url", runUrl],
+    ["--candidate-ref", candidateRef],
+    ["--diff-text", diffTextFile],
+  ]) {
+    if (!value || value === "true") {
+      throw new Error(`${flag} needs a value. ${usage}`);
+    }
+  }
+
+  // Shape, not just presence: these two are pasted into Markdown, where a
+  // relative or malformed URL renders as a broken image rather than as an
+  // error anybody sees.
+  for (const [flag, value] of [
+    ["--base-url", baseUrl],
+    ["--run-url", runUrl],
+  ]) {
+    if (!value.startsWith("https://")) {
+      throw new Error(`${flag} must be an absolute https URL, got "${value}".`);
+    }
+  }
+  if (surfaceNames.length === 0) {
+    throw new Error("--surfaces must name at least one captured surface.");
+  }
+
+  const surfaces = [];
+  for (const name of surfaceNames) {
+    const summary = await readSummary(reportDir, name);
+    // A surface whose capture never completed has no summary at all. The
+    // workflow already names it as missing in the comment; skipping it here
+    // keeps this script from inventing a zero.
+    if (summary === null) continue;
+    const groups = groupChangedResults(name, summary.results);
+    surfaces.push({
+      name,
+      totalCount: summary.totalCount,
+      // Counted from the screens this comment actually describes, not read
+      // from summary.changedCount. The two agree today because visual-diff
+      // derives that field the same way, but a header that disagreed with
+      // the list under it would be the worst kind of wrong here - the
+      // reviewer would trust the number and stop looking.
+      changedCount: groups.reduce((total, group) => total + group.screens.length, 0),
+      groups,
+    });
+  }
+
+  if (surfaces.length === 0) {
+    throw new Error(
+      `No summary.json found under ${reportDir} for: ${surfaceNames.join(", ")}. Run visual-diff.mjs first.`,
+    );
+  }
+
+  const ranked = rankGroups(surfaces.flatMap((surface) => surface.groups));
+  const embedded = selectEmbeddedScreens(ranked);
+
+  await fs.mkdir(outDir, { recursive: true });
+  const coverage = new Map();
+  for (const entry of embedded) {
+    coverage.set(
+      `${entry.surface}/${entry.screen.name}`,
+      await writeComposite(reportDir, outDir, entry.surface, entry.screen.name),
+    );
+  }
+
+  const body = renderBody({
+    surfaces,
+    ranked,
+    embedded,
+    coverage,
+    baseUrl: baseUrl.replace(/\/+$/, ""),
+    runUrl,
+    candidateRef,
+    diffText: await fs.readFile(diffTextFile, "utf8"),
+  });
+  await fs.writeFile(bodyFile, `${body}\n`);
+
+  process.stdout.write(
+    `Composed ${embedded.length} before/after image(s) into ${outDir}.\n`,
+  );
+}
+
+main().catch((error) => {
+  // Stack, not just message: a PNG.sync.read failure on a truncated capture
+  // is near-undiagnosable from the message alone.
+  process.stderr.write(`${error.stack ?? error.message}\n`);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
> **Demo, not a change.** Opened to watch the visual regression check catch
> something on a real pull request. Closed rather than merged - the button
> repaint is not wanted on main.

## What
Repaints the primary button from teal to red. One line, one file.

## Why
The check had been green on every pull request since it landed, so nobody had
seen what it looks like when it actually finds something.

## How
One line of shared CSS moves buttons across dozens of component screens and
every route of the app - two surfaces, neither of them named in the diff. That
reach is what a normal code review cannot see, and it is the reason the check
exists.

The report it produced is the comment below.
