### PR TITLE
fix(vault): stop blaming the vault provider for ack-timeout expiries

### DIFF
--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -206,12 +206,12 @@ export const COPY = {
       REFUND_HTLC: "Refund available",
     },
     expiration: {
-      // `ack_timeout` deliberately has no sentence here: the acknowledgment
-      // window can lapse because the depositor never finished their side (for
-      // example, never signed the payouts), not only because the vault
-      // provider was late. Naming a cause would often be wrong, so those
-      // vaults show the heading alone.
       reasons: {
+        // The acknowledgment window can lapse because the depositor never
+        // finished their side (for example, never signed the payouts), not
+        // only because the vault provider was late. Naming a cause would
+        // often be wrong, so these vaults show the heading alone.
+        ack_timeout: null,
         proof_timeout: "The inclusion proof was not submitted in time",
         activation_timeout: "The BTC Vault was not activated in time",
       },

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -206,8 +206,12 @@ export const COPY = {
       REFUND_HTLC: "Refund available",
     },
     expiration: {
+      // `ack_timeout` deliberately has no sentence here: the acknowledgment
+      // window can lapse because the depositor never finished their side (for
+      // example, never signed the payouts), not only because the vault
+      // provider was late. Naming a cause would often be wrong, so those
+      // vaults show the heading alone.
       reasons: {
-        ack_timeout: "The vault provider did not acknowledge in time",
         proof_timeout: "The inclusion proof was not submitted in time",
         activation_timeout: "The BTC Vault was not activated in time",
       },

--- a/services/vault/src/models/__tests__/peginStateMachine.test.ts
+++ b/services/vault/src/models/__tests__/peginStateMachine.test.ts
@@ -566,7 +566,7 @@ describe("peginStateMachine", () => {
 
     it("surfaces a CSV-maturing countdown when refund timelock has not elapsed", () => {
       const state = getPeginState(ContractStatus.EXPIRED, {
-        expirationReason: "ack_timeout",
+        expirationReason: "proof_timeout",
         canRefund: false,
         refundMaturityState: "maturing",
         refundMaturesInBlocks: 24,
@@ -576,7 +576,7 @@ describe("peginStateMachine", () => {
       expect(state.refundMaturesInBlocks).toBe(24);
       // 24 blocks × 10 min = 240 min → ceil(240/60) = 4h.
       // The countdown lives only in `inlineSubtext`; `message` (tooltip)
-      // stays focused on the expiry itself so the user doesn't see the
+      // stays focused on the expired reason so the user doesn't see the
       // same sentence twice.
       expect(state.inlineSubtext).toBe(
         "Your refund will be claimable in ~24 Bitcoin blocks (~4h).",
@@ -598,7 +598,7 @@ describe("peginStateMachine", () => {
 
     it("shows the generic pending message when refund maturity is unknown", () => {
       const state = getPeginState(ContractStatus.EXPIRED, {
-        expirationReason: "ack_timeout",
+        expirationReason: "proof_timeout",
         canRefund: false,
         refundMaturityState: "unknown",
       });
@@ -606,7 +606,7 @@ describe("peginStateMachine", () => {
       expect(state.refundMaturityState).toBe("unknown");
       expect(state.refundMaturesInBlocks).toBeUndefined();
       // Maturing copy lives only in `inlineSubtext`; tooltip stays focused
-      // on the expiry itself.
+      // on the expired reason.
       expect(state.inlineSubtext).toBe(
         "Checking when your refund will be claimable...",
       );

--- a/services/vault/src/models/__tests__/peginStateMachine.test.ts
+++ b/services/vault/src/models/__tests__/peginStateMachine.test.ts
@@ -378,14 +378,11 @@ describe("peginStateMachine", () => {
       expect(state.message).toBe("This BTC Vault has expired.");
     });
 
-    it("shows expired with ack_timeout reason", () => {
+    it("shows only the heading for an ack_timeout expiry", () => {
       const state = getPeginState(ContractStatus.EXPIRED, {
         expirationReason: "ack_timeout",
       });
-      expect(state.message).toContain("This BTC Vault has expired.");
-      expect(state.message).toContain(
-        "The vault provider did not acknowledge in time",
-      );
+      expect(state.message).toBe("This BTC Vault has expired.");
     });
 
     it("shows expired with proof_timeout reason", () => {
@@ -451,12 +448,23 @@ describe("peginStateMachine", () => {
       const now = Date.now();
       vi.useFakeTimers({ now });
       const state = getPeginState(ContractStatus.EXPIRED, {
-        expirationReason: "ack_timeout",
+        expirationReason: "proof_timeout",
         expiredAt: now - 2 * 60 * 60_000,
       });
       expect(state.message).toBe(
-        "This BTC Vault has expired. The vault provider did not acknowledge in time. Expired 2h ago.",
+        "This BTC Vault has expired. The inclusion proof was not submitted in time. Expired 2h ago.",
       );
+      vi.useRealTimers();
+    });
+
+    it("keeps the timestamp but drops the reason sentence for ack_timeout", () => {
+      const now = Date.now();
+      vi.useFakeTimers({ now });
+      const state = getPeginState(ContractStatus.EXPIRED, {
+        expirationReason: "ack_timeout",
+        expiredAt: now - 2 * 60 * 60_000,
+      });
+      expect(state.message).toBe("This BTC Vault has expired. Expired 2h ago.");
       vi.useRealTimers();
     });
 
@@ -568,7 +576,7 @@ describe("peginStateMachine", () => {
       expect(state.refundMaturesInBlocks).toBe(24);
       // 24 blocks × 10 min = 240 min → ceil(240/60) = 4h.
       // The countdown lives only in `inlineSubtext`; `message` (tooltip)
-      // stays focused on the expired reason so the user doesn't see the
+      // stays focused on the expiry itself so the user doesn't see the
       // same sentence twice.
       expect(state.inlineSubtext).toBe(
         "Your refund will be claimable in ~24 Bitcoin blocks (~4h).",
@@ -598,7 +606,7 @@ describe("peginStateMachine", () => {
       expect(state.refundMaturityState).toBe("unknown");
       expect(state.refundMaturesInBlocks).toBeUndefined();
       // Maturing copy lives only in `inlineSubtext`; tooltip stays focused
-      // on the expired reason.
+      // on the expiry itself.
       expect(state.inlineSubtext).toBe(
         "Checking when your refund will be claimable...",
       );

--- a/services/vault/src/models/peginStateMachine.ts
+++ b/services/vault/src/models/peginStateMachine.ts
@@ -206,7 +206,7 @@ const REFUND_BROADCAST_SUPPRESSION_MS = 6 * 60 * 60 * 1000;
 // Expiration helpers
 // ============================================================================
 
-const EXPIRATION_REASON_LABELS: Record<ExpirationReason, string> =
+const EXPIRATION_REASON_LABELS: Partial<Record<ExpirationReason, string>> =
   COPY.pegin.expiration.reasons;
 
 function formatExpiredTimeAgo(timestamp: number): string {

--- a/services/vault/src/models/peginStateMachine.ts
+++ b/services/vault/src/models/peginStateMachine.ts
@@ -206,7 +206,7 @@ const REFUND_BROADCAST_SUPPRESSION_MS = 6 * 60 * 60 * 1000;
 // Expiration helpers
 // ============================================================================
 
-const EXPIRATION_REASON_LABELS: Partial<Record<ExpirationReason, string>> =
+const EXPIRATION_REASON_LABELS: Record<ExpirationReason, string | null> =
   COPY.pegin.expiration.reasons;
 
 function formatExpiredTimeAgo(timestamp: number): string {
@@ -735,9 +735,9 @@ function getDisplay(
           (refundMaturesInBlocks * BTC_BLOCK_TIME_MINS) / MINS_PER_HOUR,
         ),
       );
-      // Tooltip stays focused on the expired reason + when; the countdown
-      // lives in `inlineSubtext` so the user doesn't need to hover to see
-      // the actionable info.
+      // Tooltip stays focused on the expiry itself (the reason, where we
+      // have one to give, and when); the countdown lives in `inlineSubtext`
+      // so the user doesn't need to hover to see the actionable info.
       return {
         displayLabel: PEGIN_DISPLAY_LABELS.EXPIRED,
         displayVariant: "warning",

--- a/services/vault/src/utils/__tests__/vaultTransformers.test.ts
+++ b/services/vault/src/utils/__tests__/vaultTransformers.test.ts
@@ -93,7 +93,7 @@ describe("vaultTransformers", () => {
         depositorSignedPeginTx: "0xsigned" as Hex,
         unsignedPrePeginTx: "0xunsigned" as Hex,
         expiredAt: 1700001000000,
-        expirationReason: "ack_timeout" as any,
+        expirationReason: "ack_timeout",
       });
       const activity = transformVaultToActivity(vault);
 
@@ -104,11 +104,11 @@ describe("vaultTransformers", () => {
       expect(activity.expirationReason).toBe("ack_timeout");
     });
 
-    it("shows expired with ack_timeout reason", () => {
+    it("labels an expired vault as Expired", () => {
       const vault = makeVault({
         status: ContractStatus.EXPIRED,
         expiredAt: 1700001000000,
-        expirationReason: "ack_timeout" as any,
+        expirationReason: "ack_timeout",
       });
       const activity = transformVaultToActivity(vault);
 


### PR DESCRIPTION
## Why

The expired-vault tooltip told every `ack_timeout` vault that "the vault provider did not acknowledge in time". That reason only says the acknowledgment window lapsed - it happens just as often because the depositor never finished their side (never signed the payouts, for example), so the sentence is frequently wrong. Raised by Filippos.

## What

`ack_timeout` vaults now show the heading and expiry time alone: "This BTC Vault has expired. Expired 58d ago." `proof_timeout` and `activation_timeout` keep their explanations, since those name an unambiguous missed step.

## How

Dropped the `ack_timeout` entry from `COPY.pegin.expiration.reasons` and widened the label map to `Partial<Record<ExpirationReason, string>>`. The message builder already skipped a missing reason, so no logic changed. Tests updated for the new tooltip text.
