### PR TITLE
chore(vault): name the vault-provider key mocks for the getter they stub

### DIFF
--- a/services/vault/src/hooks/deposit/depositFlowSteps/__tests__/ensureAuthenticatedVpClient.test.ts
+++ b/services/vault/src/hooks/deposit/depositFlowSteps/__tests__/ensureAuthenticatedVpClient.test.ts
@@ -15,11 +15,16 @@ import { ensureAuthenticatedVpClient } from "../ensureAuthenticatedVpClient";
 const ON_CHAIN_PRE_PEGIN_HASH = "0xmatching_pre_pegin_hash";
 const ATTACKER_HASH = "0xattacker_chosen_hash";
 
-const mockGetVaultProviderBtcPubKey = vi.fn();
+// The auth pin resolves the VP's *current operation* key, deliberately — not
+// its genesis key, and not either-of-the-two. Accepting either would hollow out
+// the pin, which exists so a substituted server key cannot be used. See
+// `vpAuthPinnedPubkey.ts` for the reasoning before "correcting" this.
+const mockGetCurrentVaultProviderOperationBtcKey = vi.fn();
 const mockGetVaultProtocolInfo = vi.fn();
 vi.mock("@/clients/eth-contract/sdk-readers", () => ({
   getVaultRegistryReader: () => ({
-    getCurrentVaultProviderOperationBtcKey: mockGetVaultProviderBtcPubKey,
+    getCurrentVaultProviderOperationBtcKey:
+      mockGetCurrentVaultProviderOperationBtcKey,
     getVaultProtocolInfo: mockGetVaultProtocolInfo,
   }),
 }));
@@ -57,7 +62,7 @@ const fakeWallet = {
 describe("ensureAuthenticatedVpClient", () => {
   beforeEach(() => {
     (vpTokenRegistry as VpTokenRegistry).clear();
-    mockGetVaultProviderBtcPubKey.mockResolvedValue(VALID_XONLY);
+    mockGetCurrentVaultProviderOperationBtcKey.mockResolvedValue(VALID_XONLY);
     mockGetVaultProtocolInfo.mockResolvedValue({
       prePeginTxHash: ON_CHAIN_PRE_PEGIN_HASH,
     });
@@ -88,7 +93,7 @@ describe("ensureAuthenticatedVpClient", () => {
     expect(mockGetVaultProtocolInfo).toHaveBeenCalledOnce();
     expect(mockGetVaultProtocolInfo).toHaveBeenCalledWith(VAULT_ID);
     expect(deriveVaultRoot).toHaveBeenCalledOnce();
-    expect(mockGetVaultProviderBtcPubKey).toHaveBeenCalledOnce();
+    expect(mockGetCurrentVaultProviderOperationBtcKey).toHaveBeenCalledOnce();
     expect(vpTokenRegistry.peek(PEGIN_TXID)).toBeDefined();
   });
 
@@ -108,7 +113,7 @@ describe("ensureAuthenticatedVpClient", () => {
 
     expect(mockGetVaultProtocolInfo).toHaveBeenCalledOnce();
     expect(deriveVaultRoot).not.toHaveBeenCalled();
-    expect(mockGetVaultProviderBtcPubKey).not.toHaveBeenCalled();
+    expect(mockGetCurrentVaultProviderOperationBtcKey).not.toHaveBeenCalled();
     expect(vpTokenRegistry.peek(PEGIN_TXID)).toBeUndefined();
   });
 
@@ -134,6 +139,6 @@ describe("ensureAuthenticatedVpClient", () => {
 
     expect(deriveVaultRoot).not.toHaveBeenCalled();
     expect(mockGetVaultProtocolInfo).not.toHaveBeenCalled();
-    expect(mockGetVaultProviderBtcPubKey).not.toHaveBeenCalled();
+    expect(mockGetCurrentVaultProviderOperationBtcKey).not.toHaveBeenCalled();
   });
 });

--- a/services/vault/src/services/vault/__tests__/vaultRefundService.test.ts
+++ b/services/vault/src/services/vault/__tests__/vaultRefundService.test.ts
@@ -85,7 +85,7 @@ vi.mock("../../../config/pegin", () => ({
 const mockGetOffchainParamsByVersion = vi.fn();
 const mockGetVaultKeepersByVersion = vi.fn();
 const mockGetUniversalChallengersByVersion = vi.fn();
-const mockGetVaultProviderBtcPubKey = vi.fn();
+const mockGetVaultProviderGenesisBtcPubKey = vi.fn();
 const mockGetCurrentVaultProviderOperationBtcKey = vi.fn();
 // Lean sibling pre-filter used by discoverBatch. Defaults to deriving
 // prePeginTxHash from the same getVaultFromChain fixtures each test
@@ -117,7 +117,7 @@ vi.mock("../../../clients/eth-contract/sdk-readers", () => ({
   }),
   getVaultRegistryReader: vi.fn().mockReturnValue({
     getVaultProviderGenesisBtcPubKey: (...args: unknown[]) =>
-      mockGetVaultProviderBtcPubKey(...args),
+      mockGetVaultProviderGenesisBtcPubKey(...args),
     getCurrentVaultProviderOperationBtcKey: (...args: unknown[]) =>
       mockGetCurrentVaultProviderOperationBtcKey(...args),
     getProtocolInfoBatch: (ids: readonly string[]) =>
@@ -252,7 +252,9 @@ describe("vaultRefundService - adapter wiring", () => {
     (fetchVaultIdsByDepositor as Mock).mockResolvedValue([VAULT_ID]);
     mockGetOffchainParamsByVersion.mockResolvedValue(OFFCHAIN_PARAMS);
     (fetchVaultProviderById as Mock).mockResolvedValue(VAULT_PROVIDER);
-    mockGetVaultProviderBtcPubKey.mockResolvedValue(VP_BTC_PUBKEY_X_ONLY);
+    mockGetVaultProviderGenesisBtcPubKey.mockResolvedValue(
+      VP_BTC_PUBKEY_X_ONLY,
+    );
     // Default: an un-rotated provider, whose current operation key is its
     // registration key. The rotation cases below override this.
     mockGetCurrentVaultProviderOperationBtcKey.mockResolvedValue(
@@ -809,7 +811,9 @@ describe("vaultRefundService - sibling batch discovery", () => {
     (fetchVaultRefundData as Mock).mockResolvedValue(INDEXER_VAULT);
     mockGetOffchainParamsByVersion.mockResolvedValue(OFFCHAIN_PARAMS);
     (fetchVaultProviderById as Mock).mockResolvedValue(VAULT_PROVIDER);
-    mockGetVaultProviderBtcPubKey.mockResolvedValue(VP_BTC_PUBKEY_X_ONLY);
+    mockGetVaultProviderGenesisBtcPubKey.mockResolvedValue(
+      VP_BTC_PUBKEY_X_ONLY,
+    );
     mockGetVaultKeepersByVersion.mockResolvedValue(VAULT_KEEPERS);
     mockGetUniversalChallengersByVersion.mockResolvedValue(
       UNIVERSAL_CHALLENGERS,


### PR DESCRIPTION
Follow-up to https://github.com/babylonlabs-io/babylon-toolkit/pull/2206. Test-local identifiers only — no production code, no assertions, no behaviour change.

## Why

@jonybur flagged one leftover while approving #2206: `vaultRefundService.test.ts` still named its mock `mockGetVaultProviderBtcPubKey` after the property it stubs became `getVaultProviderGenesisBtcPubKey`.

The rename sweep in #2206 matched `getVaultProviderBtcPubKey` with a lowercase `g`. These identifiers carry a capital `G` after the `mock` prefix, so a case-sensitive substring rename skipped them — and would skip any `mockXxx`-prefixed identifier the same way.

Chasing it turned up a second site that is **not** cosmetic and **predates #2206**.

## The two sites

**`vaultRefundService.test.ts`** — the variable was stale relative to the property it stubs. Cosmetic, exactly as reported. It now reads `mockGetVaultProviderGenesisBtcPubKey`, which also distinguishes it from `mockGetCurrentVaultProviderOperationBtcKey` in the same file — two different getters, two different keys, and the file now says which is which.

**`ensureAuthenticatedVpClient.test.ts`** — actively misleading. It read:

```ts
getCurrentVaultProviderOperationBtcKey: mockGetVaultProviderBtcPubKey,
```

A variable named for the *genesis* key stubbing the *current operation* key getter — a different value for any provider that has rotated. This is precisely the naming ambiguity that caused the bug #2173 fixed and that #2206 renamed the reader method to prevent, sitting in a test for the VP auth pin. A reader would reasonably conclude the pin resolves the registration key. It does not, deliberately.

Note the two renames are **not** the same: each takes the name of the getter it actually stubs. Renaming both toward "Genesis" would have preserved the defect.

Also added four lines above that mock recording why the auth pin is operation-key-only — accepting either key would hollow out the pin — with a pointer to `vpAuthPinnedPubkey.ts`. The rename makes the pairing correct; the comment stops someone "fixing" it toward the genesis key later.

## Verification

Both files pass with unchanged case counts — 33 + 3 = 36, rename-only. `tsc --noEmit -p tsconfig.lib.json` clean, `pnpm run lint` 0 errors.

```
git grep -in "getVaultProviderBtcPubKey" -- '*.ts' '*.tsx' | grep -vi GenesisBtcPubKey
```

No hits. The only remaining references to the old name are in the generated `docs/api/clients.md`, deliberately left alone — that is #2196, which needs the source-link churn fix first or the regeneration diff is four figures of noise.

Full suite not run: nothing outside two test files changed, and no exported or production surface is touched.

## Note for whoever hits this next

The vault typecheck fails on fresh `main` until `ts-sdk` is rebuilt — `activateVaultAndRedeem` and `PeginAction.ACTIVATE_AND_REDEEM` from #2159 exist in SDK source but not in a stale `dist/`. Not related to this change; `pnpm --filter @babylonlabs-io/ts-sdk run build` first.
