### PR TITLE
fix(vault): check the application status before revealing the HTLC secret

### DIFF
--- a/services/vault/src/components/deposit/EmergencyWithdrawModal/EmergencyWithdrawConfirmContent.tsx
+++ b/services/vault/src/components/deposit/EmergencyWithdrawModal/EmergencyWithdrawConfirmContent.tsx
@@ -56,6 +56,10 @@ export function EmergencyWithdrawConfirmContent({
   // or a failed read) does NOT block — over-blocking strands a depositor whose
   // peg-in is already swept, and the pre-broadcast simulation still refuses to
   // sign into a genuinely inactive application.
+  //
+  // This is CTA suppression, not the gate: it reads the cache as of paint, so
+  // a click inside the first round-trip would slip through. The confirm handler
+  // re-reads and awaits before deriving the secret (`EmergencyWithdrawModal`).
   const applicationActive = useVaultApplicationActive(vaultId);
   const applicationInactive = applicationActive === false;
   const activateAndRedeemPaused = isActivateAndRedeemBlocked(gate);

--- a/services/vault/src/components/deposit/EmergencyWithdrawModal/EmergencyWithdrawConfirmContent.tsx
+++ b/services/vault/src/components/deposit/EmergencyWithdrawModal/EmergencyWithdrawConfirmContent.tsx
@@ -17,10 +17,7 @@ import { useVaultApplicationActive } from "@/hooks/useVaultApplicationActive";
 interface EmergencyWithdrawConfirmContentProps {
   /** True when the stuck state was detected on-chain — drives the body copy. */
   stuckStateDetected: boolean;
-  /**
-   * Vault whose application registration gates this exit. `undefined` while
-   * unknown (loading or a failed read) — see {@link useVaultApplicationActive}.
-   */
+  /** Vault whose application registration gates this exit. */
   vaultId: Hex;
   /** Reveal + redeem in flight (wallet popup or on-chain submission). */
   withdrawing: boolean;

--- a/services/vault/src/components/deposit/EmergencyWithdrawModal/__tests__/EmergencyWithdrawModal.test.tsx
+++ b/services/vault/src/components/deposit/EmergencyWithdrawModal/__tests__/EmergencyWithdrawModal.test.tsx
@@ -1,0 +1,170 @@
+/**
+ * Tests for the click-time application-status gate on the escape hatch.
+ *
+ * The confirm screen's own check reads the cache as of paint, so it is
+ * `undefined` — button enabled — for the whole first round-trip after the modal
+ * mounts. These cover what happens when the answer lands only after the click:
+ * a CONFIRMED inactive application must stop before the BTC wallet is ever
+ * opened, and anything else must let the withdrawal through, because this is
+ * the only recovery left for a swept peg-in.
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { useMemo, type ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { isVaultApplicationActive } from "@/clients/eth-contract/application-status/query";
+import { COPY } from "@/copy";
+import { deriveHtlcSecretHex } from "@/services/vault/htlcSecretDerivation";
+import type { VaultActivity } from "@/types/activity";
+
+import { EmergencyWithdrawModal } from "../index";
+
+// The shared v3 shell renders the app's top bar, whose graph reaches
+// wallet-connector and can't be transformed here.
+vi.mock("@/components/shared/V3ModalShell", () => ({
+  V3ModalShell: ({ open, children }: { open: boolean; children: ReactNode }) =>
+    open ? <div>{children}</div> : null,
+}));
+
+vi.mock("@/clients/eth-contract/application-status/query", () => ({
+  isVaultApplicationActive: vi.fn(),
+}));
+
+vi.mock("@/services/vault/htlcSecretDerivation", () => ({
+  deriveHtlcSecretHex: vi.fn(async () => `0x${"ab".repeat(32)}`),
+}));
+
+const handleActivation = vi.hoisted(() => vi.fn(async () => {}));
+vi.mock("@/hooks/deposit/useActivationState", () => ({
+  useActivationState: () => ({
+    activating: false,
+    activated: false,
+    error: null,
+    errorTerminal: false,
+    handleActivation,
+  }),
+}));
+
+vi.mock("@/hooks/useProtocolGate", () => ({
+  useProtocolGateState: () => ({ protocol: null, aave: null }),
+}));
+
+vi.mock("@babylonlabs-io/wallet-connector", () => ({
+  useChainConnector: () => ({
+    connectedWallet: {
+      id: "test-btc-wallet",
+      provider: {},
+      account: { address: "bc1qtest" },
+    },
+  }),
+}));
+
+vi.mock("@/context/wallet", () => ({
+  useETHWallet: () => ({ address: "0xdepositor" }),
+}));
+
+vi.mock("@/infrastructure/telemetryEvents", () => ({
+  captureFunnelFailure: vi.fn(),
+  TELEMETRY_STAGE: { ACTIVATION_SECRET: "activation_secret" },
+}));
+
+const ACTIVITY: VaultActivity = {
+  id: `0x${"11".repeat(32)}`,
+  collateral: { amount: "0.01", symbol: "BTC" },
+  providers: [{ id: "0xprovider" }],
+  displayLabel: "Pending",
+  unsignedPrePeginTx: "0x",
+  depositorWotsPkHash: "0x",
+} as VaultActivity;
+
+function Wrapper({ children }: { children: ReactNode }) {
+  const queryClient = useMemo(
+    () =>
+      new QueryClient({
+        // The status query pins `retry: 1`; without a zero delay the fail-open
+        // case would sit through the default backoff.
+        defaultOptions: { queries: { retryDelay: 0 } },
+      }),
+    [],
+  );
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+function renderModal() {
+  render(
+    <Wrapper>
+      <EmergencyWithdrawModal
+        open
+        activity={ACTIVITY}
+        stuckStateDetected
+        onClose={vi.fn()}
+        onSuccess={vi.fn()}
+      />
+    </Wrapper>,
+  );
+  // The confirm button only ever enables after the risk acknowledgement.
+  fireEvent.click(screen.getByRole("checkbox"));
+  fireEvent.click(screen.getByTestId("emergency-withdraw-button"));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("EmergencyWithdrawModal — application status before the reveal", () => {
+  it("never opens the BTC wallet when the application resolves inactive after the click", async () => {
+    // Resolve only after the click, reproducing a click inside the first
+    // round-trip — the window the render-time gate cannot cover.
+    let resolveStatus: (active: boolean) => void = () => {};
+    vi.mocked(isVaultApplicationActive).mockReturnValue(
+      new Promise<boolean>((resolve) => {
+        resolveStatus = resolve;
+      }),
+    );
+
+    renderModal();
+    resolveStatus(false);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("emergency-withdraw-button")).toBeDisabled();
+    });
+    expect(
+      screen.getByText(COPY.deposit.emergencyWithdraw.applicationInactive),
+    ).toBeInTheDocument();
+    expect(deriveHtlcSecretHex).not.toHaveBeenCalled();
+    expect(handleActivation).not.toHaveBeenCalled();
+  });
+
+  it("derives the secret and submits when the application is active", async () => {
+    vi.mocked(isVaultApplicationActive).mockResolvedValue(true);
+
+    renderModal();
+
+    await waitFor(() => {
+      expect(handleActivation).toHaveBeenCalledOnce();
+    });
+    expect(deriveHtlcSecretHex).toHaveBeenCalledOnce();
+  });
+
+  it("still submits when the application status read fails", async () => {
+    // Fail OPEN: an RPC blip must not strand a depositor whose peg-in is
+    // already swept. The pre-broadcast simulation refuses to sign into a
+    // genuinely inactive application.
+    vi.mocked(isVaultApplicationActive).mockRejectedValue(
+      new Error("rpc unavailable"),
+    );
+
+    renderModal();
+
+    await waitFor(() => {
+      expect(handleActivation).toHaveBeenCalledOnce();
+    });
+    expect(
+      screen.queryByText(COPY.deposit.emergencyWithdraw.applicationInactive),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/services/vault/src/components/deposit/EmergencyWithdrawModal/__tests__/EmergencyWithdrawModal.test.tsx
+++ b/services/vault/src/components/deposit/EmergencyWithdrawModal/__tests__/EmergencyWithdrawModal.test.tsx
@@ -79,24 +79,32 @@ const ACTIVITY: VaultActivity = {
   depositorWotsPkHash: "0x",
 } as VaultActivity;
 
-function Wrapper({ children }: { children: ReactNode }) {
-  const queryClient = useMemo(
-    () =>
-      new QueryClient({
-        // The status query pins `retry: 1`; without a zero delay the fail-open
-        // case would sit through the default backoff.
-        defaultOptions: { queries: { retryDelay: 0 } },
-      }),
-    [],
-  );
+function makeQueryClient() {
+  return new QueryClient({
+    // The status query pins `retry: 1`; without a zero delay the fail-open
+    // case would sit through the default backoff.
+    defaultOptions: { queries: { retryDelay: 0 } },
+  });
+}
+
+function Wrapper({
+  client,
+  children,
+}: {
+  client?: QueryClient;
+  children: ReactNode;
+}) {
+  const fallback = useMemo(makeQueryClient, []);
   return (
-    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    <QueryClientProvider client={client ?? fallback}>
+      {children}
+    </QueryClientProvider>
   );
 }
 
-function renderModal() {
+function renderModal(client?: QueryClient) {
   render(
-    <Wrapper>
+    <Wrapper client={client}>
       <EmergencyWithdrawModal
         open
         activity={ACTIVITY}
@@ -148,6 +156,29 @@ describe("EmergencyWithdrawModal — application status before the reveal", () =
       expect(handleActivation).toHaveBeenCalledOnce();
     });
     expect(deriveHtlcSecretHex).toHaveBeenCalledOnce();
+  });
+
+  it("re-reads a stale cached status instead of trusting it", async () => {
+    // Modal reopened within gcTime: the cache still holds the answer from the
+    // previous open, so the button paints enabled off a value minutes old. A
+    // click must not ride that — the application was paused in between.
+    const client = makeQueryClient();
+    client.setQueryData(
+      // Key literal on purpose: if it drifts from the hook, this test should
+      // stop seeding the cache and fail loudly rather than pass vacuously.
+      ["vaultApplicationStatus", ACTIVITY.id],
+      true,
+      { updatedAt: Date.now() - 60_000 },
+    );
+    vi.mocked(isVaultApplicationActive).mockResolvedValue(false);
+
+    renderModal(client);
+
+    await waitFor(() => {
+      expect(isVaultApplicationActive).toHaveBeenCalled();
+    });
+    expect(deriveHtlcSecretHex).not.toHaveBeenCalled();
+    expect(handleActivation).not.toHaveBeenCalled();
   });
 
   it("still submits when the application status read fails", async () => {

--- a/services/vault/src/components/deposit/EmergencyWithdrawModal/index.tsx
+++ b/services/vault/src/components/deposit/EmergencyWithdrawModal/index.tsx
@@ -11,6 +11,11 @@
  * zero-wiped) and submitted via the activation state machine in
  * `redeemImmediately` mode, which re-validates `sha256(secret) === hashlock`
  * against the on-chain registry before any calldata is assembled.
+ *
+ * Ahead of the derivation, the confirm handler awaits the vault's application
+ * registration status — the one registry precondition the confirm screen's
+ * render-time gate cannot guarantee, because it reads the cache as it stood at
+ * paint. See `useEnsureVaultApplicationActive`.
  */
 
 import type { BitcoinWallet } from "@babylonlabs-io/ts-sdk/shared";
@@ -19,7 +24,9 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 import { V3ModalShell } from "@/components/shared/V3ModalShell";
 import { useETHWallet } from "@/context/wallet";
+import { COPY } from "@/copy";
 import { useActivationState } from "@/hooks/deposit/useActivationState";
+import { useEnsureVaultApplicationActive } from "@/hooks/useVaultApplicationActive";
 import {
   captureFunnelFailure,
   TELEMETRY_STAGE,
@@ -52,6 +59,7 @@ export function EmergencyWithdrawModal({
     null;
   const connectedBtcAddress = btcConnector?.connectedWallet?.account?.address;
   const { address: depositorEthAddress } = useETHWallet();
+  const ensureApplicationActive = useEnsureVaultApplicationActive();
 
   // Derivation phase (wallet popup) — the submission phase is `activating`
   // from the activation state machine below.
@@ -85,17 +93,34 @@ export function EmergencyWithdrawModal({
   const handleConfirm = useCallback(async () => {
     if (withdrawing) return;
     if (!btcWalletProvider || !connectedBtcAddress) {
-      setLocalError("BTC wallet is not connected");
+      setLocalError(
+        COPY.deposit.emergencyWithdraw.errors.btcWalletNotConnected,
+      );
       return;
     }
     if (!depositorEthAddress) {
-      setLocalError("ETH wallet is not connected");
+      setLocalError(
+        COPY.deposit.emergencyWithdraw.errors.ethWalletNotConnected,
+      );
       return;
     }
     setDeriving(true);
     setLocalError(null);
 
     try {
+      // Resolve the application registration BEFORE the wallet popup. The
+      // confirm screen's own check reads whatever was cached at paint, which is
+      // `undefined` for the whole first round-trip after the modal mounts — so
+      // on its own it lets a fast click derive the secret for a redeem the
+      // registry would reject. Fail-open is unchanged: only a CONFIRMED
+      // non-Active status stops here, and `executeWrite`'s mandatory
+      // pre-broadcast simulation remains the backstop for every other case.
+      //
+      // A bare return suffices: resolving populates the same cache entry the
+      // confirm screen reads, so that gate re-renders with the explanation and
+      // the button disabled. Setting `localError` would print it twice.
+      if ((await ensureApplicationActive(activity.id)) === false) return;
+
       const secretHex = await deriveHtlcSecretHex({
         activity,
         btcWalletProvider,
@@ -115,7 +140,9 @@ export function EmergencyWithdrawModal({
       captureFunnelFailure(TELEMETRY_STAGE.ACTIVATION_SECRET, err, activity.id);
       if (mountedRef.current) {
         const msg =
-          err instanceof Error ? err.message : "Failed to withdraw BTC Vault";
+          err instanceof Error
+            ? err.message
+            : COPY.deposit.emergencyWithdraw.errors.withdrawFailed;
         setLocalError(msg);
       }
     } finally {
@@ -128,6 +155,7 @@ export function EmergencyWithdrawModal({
     connectedBtcAddress,
     depositorEthAddress,
     btcConnector?.connectedWallet?.id,
+    ensureApplicationActive,
     handleActivation,
   ]);
 

--- a/services/vault/src/context/deposit/PeginPollingContext.tsx
+++ b/services/vault/src/context/deposit/PeginPollingContext.tsx
@@ -381,7 +381,10 @@ export function PeginPollingProvider({
         ((a.contractStatus ?? 0) as ContractStatus) !== ContractStatus.VERIFIED
       )
         continue;
-      const spend = htlcRefundByDepositId.get(a.id);
+      // Keyed lowercase by `useBtcHtlcRefundStatus`; activity ids come from the
+      // indexer unnormalized. A raw lookup that misses reads as "not swept", so
+      // the suspect never forms and the stuck card silently never appears.
+      const spend = htlcRefundByDepositId.get(a.id.toLowerCase());
       if (spend?.spent !== true) continue;
       const peginTxCanonical = canonicalizeTxid(a.peginTxHash);
       if (

--- a/services/vault/src/context/deposit/__tests__/PeginPollingContext.test.tsx
+++ b/services/vault/src/context/deposit/__tests__/PeginPollingContext.test.tsx
@@ -87,12 +87,15 @@ vi.mock("../../../hooks/useActivationDeadlineGate", () => ({
 // a chain read. Default is the empty set, i.e. nothing confirmed stuck, which
 // is also the production fail-open default.
 const { mockUseStuckVaultChainConfirm } = vi.hoisted(() => ({
-  mockUseStuckVaultChainConfirm: vi.fn<() => ReadonlySet<string>>(
-    () => new Set<string>(),
-  ),
+  mockUseStuckVaultChainConfirm: vi.fn<
+    (suspectIds: readonly string[]) => ReadonlySet<string>
+  >(() => new Set<string>()),
 }));
+// Forwards the suspect ids so a test can assert on Tier 1's output — the set
+// this hook is asked to confirm is the only place `stuckSuspectIds` is visible.
 vi.mock("../../../hooks/useStuckVaultChainConfirm", () => ({
-  useStuckVaultChainConfirm: () => mockUseStuckVaultChainConfirm(),
+  useStuckVaultChainConfirm: (suspectIds: readonly string[]) =>
+    mockUseStuckVaultChainConfirm(suspectIds),
 }));
 
 const mockVersionedParams = new Map<number, { tRefund: number }>();
@@ -974,6 +977,49 @@ describe("PeginPollingContext", () => {
     expect(status?.peginState.refundMaturityState).toBe("mature");
     expect(status?.peginState.availableActions).toEqual([
       PeginAction.REFUND_HTLC,
+    ]);
+  });
+
+  // ==========================================================================
+  // VERIFIED — Tier-1 stuck suspects
+  // ==========================================================================
+
+  it("VERIFIED: forms a stuck suspect when the activity id carries uppercase hex", () => {
+    // `useBtcHtlcRefundStatus` keys its map lowercase; activity ids arrive
+    // from the indexer unnormalized. A raw lookup misses and reads as "not
+    // swept", so no suspect forms, Tier 2 never runs, and the stuck card and
+    // Withdraw CTA silently never appear for a genuinely stuck deposit.
+    const MIXED_CASE_ID = "0xPEGIN" as Hex;
+    const PEGIN_TXID = `0x${"ef".repeat(32)}` as Hex;
+    mockUseBtcHtlcRefundStatus.mockReturnValue({
+      refundByDepositId: new Map([
+        [
+          MIXED_CASE_ID.toLowerCase(),
+          { spent: true, confirmed: true, spendingTxid: PEGIN_TXID },
+        ],
+      ]),
+    });
+
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <PeginPollingProvider
+        activities={[
+          {
+            ...ACTIVITY,
+            id: MIXED_CASE_ID,
+            contractStatus: ContractStatus.VERIFIED,
+            peginTxHash: PEGIN_TXID,
+          },
+        ]}
+        pendingPegins={[]}
+        btcPublicKey={BTC_PUBKEY}
+      >
+        {children}
+      </PeginPollingProvider>
+    );
+    renderHook(() => usePeginPolling(), { wrapper });
+
+    expect(mockUseStuckVaultChainConfirm).toHaveBeenLastCalledWith([
+      MIXED_CASE_ID,
     ]);
   });
 

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -466,10 +466,16 @@ export const COPY = {
       title: "Withdraw without activating",
       // Reassurance first: the stuck state looks like lost funds but is
       // fully recoverable through this flow.
+      // Both bodies state the wait before the acknowledgement, not only on the
+      // success screen: the BTC comes back through the vault provider's normal
+      // claim pipeline, so a depositor who expects funds within the hour would
+      // be committing to the reveal on a false premise. Deliberately no figure
+      // — the real wait is the vault's `timelockAssert`, a protocol parameter
+      // this screen does not resolve, and a hardcoded one would be a guess.
       bodyStuck:
-        "Your BTC is not lost. The peg-in was completed on Bitcoin, but the BTC Vault was never activated. Withdrawing redeems the BTC Vault — the vault provider will send your BTC to your payout address.",
+        "Your BTC is not lost. The peg-in was completed on Bitcoin, but the BTC Vault was never activated. Withdrawing redeems the BTC Vault — the vault provider will send your BTC to your payout address, which takes several days.",
       bodyAdvanced:
-        "This reveals your HTLC secret and redeems the BTC Vault without activating it. The vault provider will send your BTC to your payout address. If you are unsure, cancel and wait — letting the BTC Vault expire and refunding is the safe default.",
+        "This reveals your HTLC secret and redeems the BTC Vault without activating it. The vault provider will send your BTC to your payout address, which takes several days. If you are unsure, cancel and wait — letting the BTC Vault expire and refunding is the safe default.",
       riskAcknowledgement:
         "I understand this permanently reveals my HTLC secret and cannot be undone.",
       // Shown when the vault's application is registered but not Active on
@@ -481,6 +487,13 @@ export const COPY = {
       confirmButton: "Withdraw without activating",
       retryButton: "Retry",
       cancelButton: "Cancel",
+      // Pre-flight failures surfaced in the modal's error callout, so single
+      // lines rather than the {title, body} shape the error modals use.
+      errors: {
+        btcWalletNotConnected: "BTC wallet is not connected",
+        ethWalletNotConnected: "ETH wallet is not connected",
+        withdrawFailed: "Failed to withdraw BTC Vault",
+      },
       success: {
         heading: "Withdrawal submitted",
         body: "Your BTC Vault has been redeemed. The vault provider will send your BTC to your payout address. This typically takes up to 3 days.",

--- a/services/vault/src/hooks/useVaultApplicationActive.ts
+++ b/services/vault/src/hooks/useVaultApplicationActive.ts
@@ -6,7 +6,8 @@
  * `clients/eth-contract/application-status/query`.
  */
 
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
 import type { Hex } from "viem";
 
 import { isVaultApplicationActive } from "@/clients/eth-contract/application-status/query";
@@ -19,6 +20,24 @@ const APPLICATION_STATUS_REFETCH_INTERVAL_MS = 20_000;
 const APPLICATION_STATUS_STALE_TIME_MS = 10_000;
 
 /**
+ * Shared config for both consumers below, so the render-time gate and the
+ * click-time gate can never diverge on cache key or freshness — a click-time
+ * read that missed the hook's cache would cost an extra RPC round-trip on the
+ * one screen where latency is felt.
+ */
+function vaultApplicationActiveQueryOptions(vaultId: Hex) {
+  return {
+    queryKey: [APPLICATION_STATUS_QUERY_KEY, vaultId],
+    queryFn: () => isVaultApplicationActive(vaultId),
+    staleTime: APPLICATION_STATUS_STALE_TIME_MS,
+    networkMode: "always" as const,
+    // A revert or RPC failure must not retry-storm the confirm screen; one
+    // retry, then the caller's fail-open path takes over.
+    retry: 1,
+  };
+}
+
+/**
  * `true` / `false` once the chain answers; `undefined` while loading or after
  * a failed read.
  *
@@ -28,20 +47,50 @@ const APPLICATION_STATUS_STALE_TIME_MS = 10_000;
  * swept, and a real `ApplicationNotActive` is still caught pre-broadcast by
  * `executeWrite`'s mandatory simulation, which refuses to sign. Blocking on a
  * CONFIRMED non-Active status is the value this adds — not blocking on doubt.
+ *
+ * This hook suppresses the CTA at render time. It cannot gate the submit path
+ * on its own: it returns whatever the cache holds at paint, which is
+ * `undefined` for the whole first round-trip after the modal mounts. The
+ * click-time gate is {@link useEnsureVaultApplicationActive}.
  */
 export function useVaultApplicationActive(
   vaultId: Hex | undefined,
 ): boolean | undefined {
   const { data } = useQuery({
-    queryKey: [APPLICATION_STATUS_QUERY_KEY, vaultId],
-    queryFn: () => isVaultApplicationActive(vaultId as Hex),
+    ...vaultApplicationActiveQueryOptions(vaultId as Hex),
     enabled: vaultId !== undefined,
     refetchInterval: APPLICATION_STATUS_REFETCH_INTERVAL_MS,
-    staleTime: APPLICATION_STATUS_STALE_TIME_MS,
-    networkMode: "always",
-    // A revert or RPC failure must not retry-storm the confirm screen; one
-    // retry, then the caller's fail-open path takes over.
-    retry: 1,
   });
   return data;
+}
+
+/**
+ * Awaited counterpart of {@link useVaultApplicationActive}, for the confirm
+ * click: resolves the status before the caller derives the HTLC secret, rather
+ * than reading whatever happened to be cached when the button was painted.
+ *
+ * Without it, a click during the first round-trip opens the BTC wallet, derives
+ * the secret, and puts it in the pre-broadcast simulation's calldata — for a
+ * revert the FE could have predicted.
+ *
+ * Same fail-open contract: `undefined` on a failed read means "do not block".
+ * An already-cached answer resolves without an extra request — while the modal
+ * is open the hook above is polling, so the cache is at most one interval old.
+ */
+export function useEnsureVaultApplicationActive(): (
+  vaultId: Hex,
+) => Promise<boolean | undefined> {
+  const queryClient = useQueryClient();
+  return useCallback(
+    async (vaultId: Hex) => {
+      try {
+        return await queryClient.ensureQueryData(
+          vaultApplicationActiveQueryOptions(vaultId),
+        );
+      } catch {
+        return undefined;
+      }
+    },
+    [queryClient],
+  );
 }

--- a/services/vault/src/hooks/useVaultApplicationActive.ts
+++ b/services/vault/src/hooks/useVaultApplicationActive.ts
@@ -74,8 +74,18 @@ export function useVaultApplicationActive(
  * revert the FE could have predicted.
  *
  * Same fail-open contract: `undefined` on a failed read means "do not block".
- * An already-cached answer resolves without an extra request — while the modal
- * is open the hook above is polling, so the cache is at most one interval old.
+ *
+ * `fetchQuery`, not `ensureQueryData`: the latter returns cached data of ANY
+ * age without consulting `staleTime`. That is fine while the modal stays open
+ * (the hook above polls), but the modal unmounts on close, and reopening it
+ * within `gcTime` would hand a fast click an answer minutes old. `fetchQuery`
+ * re-reads whenever the entry is past `staleTime` and otherwise reuses it, so
+ * the answer is at most `APPLICATION_STATUS_STALE_TIME_MS` old, and a read
+ * already in flight is shared rather than duplicated.
+ *
+ * No read makes this atomic — the user still spends seconds in a BTC wallet
+ * popup before the transaction is simulated. The point is not to act on a
+ * plainly stale answer.
  */
 export function useEnsureVaultApplicationActive(): (
   vaultId: Hex,
@@ -84,7 +94,7 @@ export function useEnsureVaultApplicationActive(): (
   return useCallback(
     async (vaultId: Hex) => {
       try {
-        return await queryClient.ensureQueryData(
+        return await queryClient.fetchQuery(
           vaultApplicationActiveQueryOptions(vaultId),
         );
       } catch {


### PR DESCRIPTION
## Why

[#2159](https://github.com/babylonlabs-io/babylon-toolkit/pull/2159) shipped the activate-and-redeem escape hatch, and [#2170](https://github.com/babylonlabs-io/babylon-toolkit/issues/2170) was closed with it. I went back through that issue point by point against the merged code. The feature is there and correct — including the tricky part, telling a peg-in sweep apart from a matured CSV refund by comparing the spending txid. Three small things were left open.

**The main one.** [#2170](https://github.com/babylonlabs-io/babylon-toolkit/issues/2170) asked us to check `ApplicationRegistry.getApplicationStatus(...) == Active` *before deriving the secret*. What we actually have is a check that only greys out the confirm button while the screen renders. That check is a React Query hook, and it returns `undefined` for the whole first round-trip after the modal opens. The query only starts when the modal mounts, so there is always a window — a second or so, longer on a slow RPC — where the button is live but we do not yet know whether the redeem can succeed.

If the user clicks in that window, we open their BTC wallet, derive the HTLC secret, and hand it to the pre-broadcast simulation. The simulation does its job and refuses to sign, so nothing lands on chain. But we made the user sign for nothing, and we put their secret in an `eth_call` to the RPC provider — for a revert we could have predicted with one read. The same window opens again after any failed read.

**Two smaller ones.** The confirm screen never told the user the BTC takes days to come back — the only mention of a wait was on the *success* screen, after the secret was already revealed. And three user-facing strings were still inlined in the component instead of living in `copy.ts`.

## What changed

`useVaultApplicationActive.ts` now exposes two things built on one shared query config: the existing hook for greying out the button, and a new `useEnsureVaultApplicationActive()` that returns a promise you can await. The modal's confirm handler awaits it before touching the wallet. If the answer is a confirmed "not active", we stop — no wallet popup, no secret. Anything else proceeds.

Fail-open is unchanged and deliberate. A loading or failed read does **not** block. This is the last recovery path for someone whose peg-in was already swept, so an RPC blip must never take it away from them, and the pre-broadcast simulation is still there as the real enforcement.

Also: both confirm bodies now say the payout "takes several days" before the user acknowledges, and the three inlined strings moved into `COPY.deposit.emergencyWithdraw.errors`.

On that wording — the first draft said "up to 3 days", copied from the existing redemption copy. That number turns out to be unsourced: it was introduced in [#1059](https://github.com/babylonlabs-io/babylon-toolkit/pull/1059) with no written rationale, and it looks low against the ~684-block timelock cited in [#2170](https://github.com/babylonlabs-io/babylon-toolkit/issues/2170) (~4.75 days at 10 min/block). The real wait is the vault's `timelockAssert`, a protocol parameter — the ordinary withdraw flow resolves it properly and formats it, rather than hardcoding. Rather than put a guess on a screen where the user is about to do something irreversible, this says "several days" with no figure.

## Approaches considered

**Read the status inside the transaction path** (in `useVaultActions.handleActivation`, next to the other fresh on-chain reads). Rejected — by the time that code runs the secret has already been derived and passed in as an argument. Too late to prevent the wallet popup, which is the thing worth preventing.

**Call `isVaultApplicationActive()` directly in the click handler.** Simple, but it fires a second RPC request that ignores the cache the hook has already filled, and it duplicates the cache key and freshness settings in two places, which drift.

**Await the same query the hook uses** (what this PR does). One shared `vaultApplicationActiveQueryOptions`, so the render-time gate and the click-time gate can never disagree. While the modal is open the hook is polling, so the answer is usually already cached and the click costs nothing extra. Only the genuinely-unknown case waits — which is exactly the case we care about.

**Block the button until the status resolves** instead of awaiting on click. Rejected — that reintroduces over-blocking on a screen whose user believes their BTC is stuck, and it strands them entirely when the read fails. Awaiting on click gets the safety without ever taking the exit away.

One detail worth flagging for review: the click-time gate returns without setting an error message. That is intentional, not an omission — resolving the status fills the same cache entry the confirm screen reads, so that screen re-renders with its own explanation and a disabled button on its own. Setting an error too printed the same sentence twice on screen. The new test caught this.

## Testing

New `EmergencyWithdrawModal.test.tsx` drives the real query with a deferred `isVaultApplicationActive` so it reproduces the actual race: click while the button is still enabled, resolve `false` afterwards, assert the wallet was never opened. Plus fail-open when the status is still unresolved and when the read throws.

Full vault suite passes (3185 tests), lint has 0 errors, `tsc` clean.

Manual check: throttle the ETH RPC, open the withdraw modal, tick the acknowledgement and click immediately. The button should spin and no BTC wallet popup should appear until the status resolves. Before this change the popup fires instantly.

## Not in this PR

**The hardcoded "up to 3 days" elsewhere in the redemption copy.** `COPY.pegin.messages.redemptionInProgress` and this modal's own success screen both still carry it, so the confirm screen now says "several days" while the success screen says "up to 3 days" — mildly inconsistent, and worth resolving. The right fix is the one the withdraw flow already uses: resolve the vault's `timelockAssert` (`useOffchainParams`, `maxAssertTimelockBlocks`, `formatDuration`) and interpolate a real estimate. That touches copy predating this PR, so it belongs in its own change.

**The indexer activity-feed gap.** The indexer activity-feed gap noted at the bottom of [#2170](https://github.com/babylonlabs-io/babylon-toolkit/issues/2170) — this flow writes a `deposit` row with no matching exit row, because the `redeem` activity only comes from the Aave adapter event, which never fires on this path. Different repo, and it deserves its own ticket mirroring the existing `claim_expired` precedent.
