### PR TITLE
fix(ts-sdk): assert operation-key multicall results are roster-aligned

### DIFF
--- a/packages/babylon-ts-sdk/src/tbv/core/clients/eth/__tests__/operation-key-reader.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/eth/__tests__/operation-key-reader.test.ts
@@ -1,0 +1,139 @@
+import type { Address, Hex } from "viem";
+import { describe, expect, it, vi } from "vitest";
+
+import { ViemOperationKeyReader } from "../operation-key-reader";
+import type { KeyEpochs, OperationKeyQuery } from "../types";
+
+const MOCK_CONTRACTS = {
+  btcVaultRegistry: "0x1111111111111111111111111111111111111111" as Address,
+  applicationRegistry: "0x2222222222222222222222222222222222222222" as Address,
+  protocolParams: "0x3333333333333333333333333333333333333333" as Address,
+};
+
+const VP_GENESIS_KEY =
+  "0xaaaa000000000000000000000000000000000000000000000000000000000000" as Hex;
+
+/** Two keepers and one challenger, so a short read is unambiguous. */
+const QUERY: OperationKeyQuery = {
+  vaultProviderEthAddress:
+    "0x4444444444444444444444444444444444444444" as Address,
+  vaultProviderGenesisBtcPubkey: VP_GENESIS_KEY,
+  applicationEntryPoint:
+    "0x5555555555555555555555555555555555555555" as Address,
+  vaultKeepers: [
+    {
+      ethAddress: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" as Address,
+      btcPubKey:
+        "0xbbbb000000000000000000000000000000000000000000000000000000000000" as Hex,
+    },
+    {
+      ethAddress: "0xcccccccccccccccccccccccccccccccccccccccc" as Address,
+      btcPubKey:
+        "0xdddd000000000000000000000000000000000000000000000000000000000000" as Hex,
+    },
+  ],
+  universalChallengers: [
+    {
+      ethAddress: "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee" as Address,
+      btcPubKey:
+        "0xffff000000000000000000000000000000000000000000000000000000000000" as Hex,
+    },
+  ],
+};
+
+const EPOCHS: KeyEpochs = {
+  vpKeyEpoch: 3n,
+  appKeeperKeyEpoch: 4n,
+  ucKeyEpoch: 5n,
+};
+
+const VP_PAYOUT_SCRIPT = "0x0014aaaa" as Hex;
+const KEEPER_0_PAYOUT_SCRIPT = "0x0014bbbb" as Hex;
+const KEEPER_1_PAYOUT_SCRIPT = "0x0014cccc" as Hex;
+
+/** The subset of viem's `multicall` argument these tests assert on. */
+type MulticallArgs = { contracts: { functionName: string }[] };
+
+/** Stubs `multicall` with a fixed result, bypassing ABI encoding entirely. */
+function createReader(multicallResult: readonly Hex[]) {
+  const multicall = vi.fn(async (_args: MulticallArgs) => multicallResult);
+  const reader = new ViemOperationKeyReader(
+    { multicall } as never,
+    MOCK_CONTRACTS,
+  );
+  return { reader, multicall };
+}
+
+describe("ViemOperationKeyReader.getPayoutScriptsAtEpochs", () => {
+  it("returns the VP script and the keeper scripts in roster order", async () => {
+    const { reader } = createReader([
+      VP_PAYOUT_SCRIPT,
+      KEEPER_0_PAYOUT_SCRIPT,
+      KEEPER_1_PAYOUT_SCRIPT,
+    ]);
+
+    const scripts = await reader.getPayoutScriptsAtEpochs(QUERY, EPOCHS);
+
+    expect(scripts.vaultProvider).toBe(VP_PAYOUT_SCRIPT);
+    expect(scripts.vaultKeepers).toEqual([
+      KEEPER_0_PAYOUT_SCRIPT,
+      KEEPER_1_PAYOUT_SCRIPT,
+    ]);
+  });
+
+  it("throws naming both counts when the multicall comes back short", async () => {
+    // One keeper script missing: without the length check this returns a
+    // one-element keeper array and the caller later blames keeper 1 for having
+    // no registered payout script.
+    const { reader } = createReader([VP_PAYOUT_SCRIPT, KEEPER_0_PAYOUT_SCRIPT]);
+
+    await expect(
+      reader.getPayoutScriptsAtEpochs(QUERY, EPOCHS),
+    ).rejects.toThrow(
+      "getPayoutScriptsAtEpochs: multicall returned 2 results for 3 calls",
+    );
+  });
+
+  it("issues one call per keeper plus one for the VP, and none for challengers", async () => {
+    const { reader, multicall } = createReader([
+      VP_PAYOUT_SCRIPT,
+      KEEPER_0_PAYOUT_SCRIPT,
+      KEEPER_1_PAYOUT_SCRIPT,
+    ]);
+
+    await reader.getPayoutScriptsAtEpochs(QUERY, EPOCHS);
+
+    const { contracts } = multicall.mock.calls[0][0];
+    expect(contracts).toHaveLength(1 + QUERY.vaultKeepers.length);
+    expect(
+      contracts.every((c) => c.functionName === "getPayoutScriptAtEpoch"),
+    ).toBe(true);
+  });
+});
+
+describe("ViemOperationKeyReader.getOperationKeysAtEpochs", () => {
+  it("throws naming both counts when the multicall comes back short", async () => {
+    // Expected length is 1 VP + 2 keepers + 1 challenger.
+    const { reader } = createReader([
+      "0x1111" as Hex,
+      "0x2222" as Hex,
+      "0x3333" as Hex,
+    ]);
+
+    await expect(
+      reader.getOperationKeysAtEpochs(QUERY, EPOCHS),
+    ).rejects.toThrow(
+      "getOperationKeysAtEpochs: multicall returned 3 results for 4 calls",
+    );
+  });
+});
+
+describe("ViemOperationKeyReader.getCurrentOperationKeys", () => {
+  it("throws naming both counts when the multicall comes back short", async () => {
+    const { reader } = createReader(["0x1111" as Hex, "0x2222" as Hex]);
+
+    await expect(reader.getCurrentOperationKeys(QUERY)).rejects.toThrow(
+      "getCurrentOperationKeys: multicall returned 2 results for 4 calls",
+    );
+  });
+});

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/eth/operation-key-reader.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/eth/operation-key-reader.ts
@@ -34,6 +34,29 @@ type Call = {
 };
 
 /**
+ * Reject a multicall result that is not one-per-call.
+ *
+ * Every method here relies on positional alignment between calls and results,
+ * so a short array does not fail — it silently hands back `undefined` for the
+ * tail entries. Downstream that surfaces as a complaint about whichever
+ * operator happens to occupy the missing slot, blaming a participant that is
+ * perfectly fine for a read that came back incomplete. Assert the length where
+ * the array arrives so the error names the real fault.
+ */
+function assertMulticallLength(
+  actual: number,
+  expected: number,
+  label: string,
+): void {
+  if (actual !== expected) {
+    throw new Error(
+      `${label}: multicall returned ${actual} results for ${expected} calls, ` +
+        `so the results are not roster-aligned; refusing to use them`,
+    );
+  }
+}
+
+/**
  * Split a flat multicall result into VP / keepers / challengers.
  *
  * Every method below builds its calls in the same order — vault provider
@@ -75,11 +98,22 @@ export class ViemOperationKeyReader implements OperationKeyReader {
    * otherwise produce a mixed-epoch key set and a lock no counterparty agrees
    * with.
    */
-  private async readAll<T>(calls: Call[], keeperCount: number) {
+  private async readAll<T>(
+    calls: Call[],
+    keeperCount: number,
+    challengerCount: number,
+    label: string,
+  ) {
     const results = (await this.publicClient.multicall({
       contracts: calls,
       allowFailure: false,
     })) as readonly T[];
+
+    assertMulticallLength(
+      results.length,
+      1 + keeperCount + challengerCount,
+      label,
+    );
 
     return partition(results, keeperCount);
   }
@@ -108,7 +142,12 @@ export class ViemOperationKeyReader implements OperationKeyReader {
       })),
     ];
 
-    return this.readAll<Hex>(calls, query.vaultKeepers.length);
+    return this.readAll<Hex>(
+      calls,
+      query.vaultKeepers.length,
+      query.universalChallengers.length,
+      "getCurrentOperationKeys",
+    );
   }
 
   async getOperationKeysAtEpochs(
@@ -149,7 +188,12 @@ export class ViemOperationKeyReader implements OperationKeyReader {
       })),
     ];
 
-    return this.readAll<Hex>(calls, query.vaultKeepers.length);
+    return this.readAll<Hex>(
+      calls,
+      query.vaultKeepers.length,
+      query.universalChallengers.length,
+      "getOperationKeysAtEpochs",
+    );
   }
 
   async getPayoutScriptsAtEpochs(
@@ -179,6 +223,14 @@ export class ViemOperationKeyReader implements OperationKeyReader {
       ],
       allowFailure: false,
     })) as readonly Hex[];
+
+    // Expected length is `1 + keepers`, with no challenger term — see the
+    // comment above on why universal challengers have no call here.
+    assertMulticallLength(
+      results.length,
+      1 + query.vaultKeepers.length,
+      "getPayoutScriptsAtEpochs",
+    );
 
     return {
       vaultProvider: results[0],


### PR DESCRIPTION
Closes https://github.com/babylonlabs-io/babylon-toolkit/issues/2191

`ViemOperationKeyReader` reads RFC-006 operation keys and payout scripts with one `multicall` per method and then splits the flat result positionally — vault provider first, then keepers in roster order, then challengers. That positional alignment is the whole contract of the class: it is what lets the resolver pair a resolved key back to its admin address. None of the three methods checked that the result was actually as long as the roster it is being aligned against.

A short result does not throw. `results.slice(1)` just returns fewer elements, and the missing tail entries become `undefined`.

## With / without

| | Without this change | With this change |
|---|---|---|
| Short payout-script read | `vaultPayoutSignatureService` builds a claimer→script map with an `undefined` value, and `payout.ts` later throws **"No registered payout script resolved for vault keeper claimer `<pubkey>`"** | `getPayoutScriptsAtEpochs: multicall returned 2 results for 3 calls, so the results are not roster-aligned; refusing to use them` |
| Who gets blamed | A keeper that is perfectly fine — the one that happened to land in the missing slot | The read that came back incomplete |
| Short operation-key read via `resolveParticipantKeys` | Caught downstream by `finalize` | Caught at the reader, before partitioning |
| Short operation-key read by a direct `OperationKeyReader` consumer | Not caught at all | Caught at the reader |

Both cases already fail closed — nothing gets signed against a wrong or missing destination. What was wrong is the attribution, and on a value-movement path where the operator response is the least trusted input, an error naming the wrong party costs real debugging time.

## What changed

`packages/babylon-ts-sdk/src/tbv/core/clients/eth/operation-key-reader.ts`

A single `assertMulticallLength(actual, expected, label)` helper, called from the two places an untrusted array arrives:

- `readAll`, which backs `getCurrentOperationKeys` and `getOperationKeysAtEpochs`. Expected length is `1 + keepers + challengers`, so `readAll` now takes the challenger count and a label alongside the keeper count it already had.
- `getPayoutScriptsAtEpochs`, which does not go through `readAll`. Expected length is `1 + keepers`, with **no** challenger term — a universal challenger is never a claimer, so it has no payout script and no call in that multicall. That asymmetry is now commented, because it looks like an omission and isn't.

The error message follows the style of `finalize` in `resolveParticipantKeys.ts`, which already guards the equivalent case for keys: name both the expected and the actual count, and name the operation.

## Beyond the issue as filed

The issue scoped this to `getPayoutScriptsAtEpochs`. The `partition` helper behind the other two methods has the identical hole. Today that is covered downstream by `finalize`, but `OperationKeyReader` is public SDK surface — its own docs say "callers can use their own implementation" — so a consumer reading keys without going through `resolveParticipantKeys` gets no guard at all. Same defect class, same file, same helper, so all three are fixed here rather than leaving two-thirds of it for later.

The assertion sits in `readAll` rather than in `partition` itself: `readAll` is where the multicall result arrives, and keeping `partition` a pure slice means the guard cannot be bypassed by a future method that calls `partition` directly. Coverage is identical — `partition` has exactly one caller.

## Tests

New `packages/babylon-ts-sdk/src/tbv/core/clients/eth/__tests__/operation-key-reader.test.ts`, following the hand-rolled-stub style of the three sibling reader tests in that directory. `multicall` is stubbed directly, so no ABI encoding is involved.

- `getPayoutScriptsAtEpochs` returns the VP script and keeper scripts in roster order on a full-length result
- `getPayoutScriptsAtEpochs` throws naming both counts on a short result
- `getPayoutScriptsAtEpochs` issues `1 + keepers` calls and none for challengers — pins the asymmetry above
- `getOperationKeysAtEpochs` throws on a short result
- `getCurrentOperationKeys` throws on a short result

## Verification

```
pnpm --filter @babylonlabs-io/ts-sdk run build     # clean
pnpm run build                                     # clean
pnpm --filter @babylonlabs-io/ts-sdk exec vitest run   # 1497 passed (86 files), +5 from this PR
pnpm --filter vault run test                       # 3187 passed, 6 skipped
cd services/vault && npx tsc --noEmit -p tsconfig.lib.json   # clean
pnpm run lint                                      # 0 errors
```

No behaviour change for a well-formed multicall response, which is every response the reader has ever seen in practice — this only adds an error where there was previously a silent `undefined`.