### PR TITLE
docs(ts-sdk): correct the assertPayoutOutputLayout JSDoc

### DIFF
--- a/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts
@@ -144,11 +144,13 @@ export interface VaultRegistryReader {
   /**
    * Read a vault's frozen RFC-006 key epochs.
    *
-   * Uses the extended `getBtcVaultProtocolInfo` ABI. Against a registry that
-   * predates RFC-006 this returns silent garbage for a populated vault rather
-   * than throwing, so it must only be called against an RFC-006 registry —
-   * a deployment invariant, not something this call can detect. See
-   * `BTCVaultRegistryKeyEpochs.abi.ts`.
+   * Uses the extended `getBtcVaultProtocolInfo` ABI. Against a registry whose
+   * `BTCVaultProtocolInfo` struct is not extended this returns silent garbage
+   * for a populated vault rather than throwing, so it must only be called
+   * against an RFC-006 registry — a deployment invariant, not something this
+   * call can detect. A registry missing the operation-key getters altogether is
+   * the safer case: key resolution reverts downstream and these epochs are never
+   * used. See `BTCVaultRegistryKeyEpochs.abi.ts`.
    */
   getVaultKeyEpochs(vaultId: Hex): Promise<KeyEpochs>;
   /** {@link getVaultKeyEpochs} for many vaults in one multicall. */

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts
@@ -91,11 +91,24 @@ function mapVaultProtocolInfo(result: RawVaultProtocolInfo): VaultProtocolInfo {
  *
  * viem does not range-check a decoded `uint64`, so a misaligned decode can
  * hand back a value far larger than the field can hold. Rejecting those is
- * cheap defence in depth against reading the extended ABI on a registry that
- * predates RFC-006 — but it is only a backstop, and a weak one: a misaligned
- * decode can also land on a small, plausible-looking integer that this range
- * accepts. Correctness rests on only ever pointing at an RFC-006 registry.
- * See `BTCVaultRegistryKeyEpochs.abi.ts`.
+ * cheap defence in depth against a mis-decode of the extended ABI.
+ *
+ * The state this is load-bearing for is narrower than "a registry that predates
+ * RFC-006". Against a *fully* pre-RFC-006 registry the path fails closed on its
+ * own: `resolveParticipantKeysAtEpochs` goes on to call
+ * `getOperationBtcKeyAtEpochOrGenesis` on ApplicationRegistry and
+ * ProtocolParams, which do not exist there, so the multicall reverts and these
+ * epochs are never used. The reachable gap is a registry that *has* the
+ * operation-key getters but whose `BTCVaultProtocolInfo` struct is not
+ * extended — there the tail-data epochs resolve with no error at all, and this
+ * range check is the only thing looking at them.
+ *
+ * Even for that case it is only a backstop, and a weak one: a misaligned decode
+ * can land on a small, plausible-looking integer this range accepts. Correctness
+ * rests on only ever pointing at an RFC-006 registry, which is a deployment
+ * precondition rather than something this call can establish — see
+ * https://github.com/babylonlabs-io/babylon-toolkit/issues/2192 for where that
+ * check is owned, and `BTCVaultRegistryKeyEpochs.abi.ts` for the decode hazard.
  */
 const UINT64_EXCLUSIVE_UPPER_BOUND = 1n << 64n;
 
@@ -218,11 +231,17 @@ export class ViemVaultRegistryReader implements VaultRegistryReader {
    * Read a vault's frozen RFC-006 operation-key epochs.
    *
    * Reads `getBtcVaultProtocolInfo` through the **extended** ABI, which is only
-   * valid against an RFC-006 registry: against one that predates RFC-006 this
-   * call does not fail for a populated vault, it silently returns three words
-   * of tail data as epochs. Nothing here can detect that, so the guarantee is a
-   * deployment one — every network this ships to has the RFC-006 getters, and
-   * mainnet is a fresh RFC-006 deploy. See `BTCVaultRegistryKeyEpochs.abi.ts`.
+   * valid against an RFC-006 registry: against one whose `BTCVaultProtocolInfo`
+   * struct is not extended this call does not fail for a populated vault, it
+   * silently returns three words of tail data as epochs. Nothing here can detect
+   * that, so the guarantee is a deployment one — every network this ships to has
+   * the RFC-006 getters, and mainnet is a fresh RFC-006 deploy.
+   *
+   * A registry missing the operation-key getters entirely is the *safer* of the
+   * two cases: `resolveParticipantKeysAtEpochs` reverts downstream and these
+   * epochs never reach key resolution. See {@link UINT64_EXCLUSIVE_UPPER_BOUND}
+   * for which state the range check actually guards, and
+   * `BTCVaultRegistryKeyEpochs.abi.ts` for the decode hazard.
    */
   async getVaultKeyEpochs(vaultId: Hex): Promise<KeyEpochs> {
     const result = (await this.publicClient.readContract({

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts
@@ -522,7 +522,8 @@ function matchesAnyScript(script: Buffer, acceptedHexes: string[]): boolean {
 /**
  * Validate a payout transaction's output structure for the claimer's role,
  * keyed on `claimerBtcPubkey`. Pins per role: `outs.length`, `outs[0].script`,
- * `outs[last].value` (anchor dust), and (VP-claimer) `outs[1].value` capped at
+ * `outs[last].value` (anchor dust), and — for the VP-claimer —
+ * `outs[1].script` plus `outs[1].value`, capped at
  * `floor(peginValue × commissionBps / 10_000)`. Canonical layouts: VP-claimer
  * = [payout, commission, anchor]; depositor/VK-claimer = [payout, anchor].
  *
@@ -531,17 +532,26 @@ function matchesAnyScript(script: Buffer, acceptedHexes: string[]): boolean {
  *
  * `outs[1].script` (the VP commission) was unpinned for the same reason.
  * RFC-006 supersedes that rationale: the commission destination is now an
- * operator-registered scriptPubKey we can resolve independently at the vault's
- * frozen `vpKeyEpoch`, so when `vpCommissionScriptPubKey` is supplied it is
- * pinned too. The value cap stays — it is still what bounds exposure — and the
- * script pin is added precision, not a replacement for it.
+ * operator-registered scriptPubKey we resolve independently at the vault's
+ * frozen `vpKeyEpoch`, so it is pinned too — `vpCommissionScriptPubKey` is a
+ * required parameter, so there is no unpinned case. The value cap stays — it is
+ * still what bounds exposure — and the script pin is added precision, not a
+ * replacement for it.
+ *
+ * What counts as a match differs by output.
+ * {@link acceptedPayoutScriptHexes} accepts two candidates — the registered
+ * scriptPubKey and the BIP-86 derivation over the bonded key, the latter as a
+ * transitional allowance — and backs the VK-claimer's `outs[0]` and the VP
+ * commission `outs[1]`. The VP-claimer and depositor-as-claimer `outs[0]` is
+ * pinned to the registered payout script alone.
  *
  * Returns the layout-trusted non-anchor script lengths for the fee band:
- * `out0Len` from the pinned outs[0] script (registered payout script, or
- * derived BIP-86 for the VK-claimer role — see #2150 Stage 6 for the pending
- * registered-script switch); `out1Len` measured from the deliberately
- * unpinned VP-claimer commission output, `undefined` for the other roles.
- * Both are rejected outside the contract's registration cap `[1, 128]`.
+ * `out0Len` from the pinned `outs[0]` script, and `out1Len` from the pinned
+ * VP-claimer commission output, `undefined` for the other roles. Only
+ * `out0Len` is range-checked, against the contract's registration cap
+ * `[1, MAX_PAYOUT_SCRIPT_LEN]`; `outs[1]` carries no length cap of its own
+ * because `assertStandardPayoutScript` already bounds it to a standard output
+ * type, which makes the cap unreachable.
  *
  * @internal Helper invoked by {@link buildPayoutPsbt}.
  */


### PR DESCRIPTION

Closes https://github.com/babylonlabs-io/babylon-toolkit/issues/2190

Comment-only. No logic changes, no test changes, no exported surface touched.

Two doc blocks describe behaviour that https://github.com/babylonlabs-io/babylon-toolkit/pull/2173 changed. One of them is the JSDoc on the payout-output validator, which is on the critical-path list in `CLAUDE.md` and `.github/CODEOWNERS` — the list whose whole premise is that two reviewers can explain every line. The JSDoc is the first thing they read, and it currently describes a validator that no longer exists.

## With / without

| | Without this change | With this change |
|---|---|---|
| A code owner reviewing `payout.ts` | Reads that `outs[1]` is "deliberately unpinned", that the VK-claimer branch derives BIP-86 as its expectation, and that both script lengths are capped at `[1, 128]` — none of which the code does | Reads what the code does |
| A reader of `getVaultKeyEpochs` | Told the hazard is "a registry that predates RFC-006", which is the one case that actually fails closed | Told the hazard is a registry with the getters but an un-extended struct, which is the case that resolves silently |
| `assertEpochInRange` | Justified by a scenario it is not reachable for | Justified by the scenario it is the only guard for |

Nothing here is a live risk. No network is in the state item 2 describes, and the payout validator behaves correctly — it is only documented wrongly.

## Item 1 — `assertPayoutOutputLayout` JSDoc

`packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts`

What the code actually does, which is what the JSDoc now says:

| Role | `outs.length` | `outs[0].script` accepted | `outs[1]` |
|---|---|---|---|
| vp-claimer | 3 | registered payout script only | script pinned (registered **or** BIP-86 over the VP key); value capped at `floor(peginValue × bps / 10_000)` |
| depositor-as-claimer | 2 | registered payout script only | n/a |
| vk-claimer | 2 | registered script **or** BIP-86 over the claimer key | n/a |

Corrections:

1. **"derived BIP-86 for the VK-claimer role"** — the VK branch pins the *registered* script and accepts BIP-86 only as a transitional second candidate, via `acceptedPayoutScriptHexes`. The old wording had it as the expectation rather than the fallback.
2. **"see #2150 Stage 6 for the pending registered-script switch"** — deleted. That switch *was* #2173, so the forward reference pointed backwards.
3. **"`out1Len` measured from the deliberately unpinned VP-claimer commission output"** — `outs[1].script` is pinned now.
4. **"Both are rejected outside the contract's registration cap `[1, 128]`"** — only `out0Len` is. The `out1Len` cap was deliberately deleted in #2173 because `assertStandardPayoutScript` bounds that output to a standard type and makes the cap unreachable; the code already carries that reasoning inline, and the JSDoc now agrees with it.
5. **"when `vpCommissionScriptPubKey` is supplied"** — it is a required field on `PayoutParams`, so there is no absent case.

Two additions beyond correcting what was wrong:

- The summary paragraph listed what is pinned per role and omitted `outs[1].script`. A code owner reading only the summary would not learn that the commission destination is checked at all, so it is listed now.
- A short paragraph on the dual-accept asymmetry: `acceptedPayoutScriptHexes` backs the VK-claimer's `outs[0]` and the VP commission `outs[1]`, while the VP-claimer and depositor-as-claimer `outs[0]` is pinned to the registered script alone. That difference is load-bearing and was not written down anywhere.

The cap is now referred to as `MAX_PAYOUT_SCRIPT_LEN` rather than restating `128`, so a future bump cannot re-stale the prose.

## Item 2 — already fixed, no change here

The issue's second item was a `validateOnChainParticipantKeys.ts` comment saying "Resolve the current operation keys, **if enabled**" after both RFC-006 feature flags were removed. That was fixed incidentally by https://github.com/babylonlabs-io/babylon-toolkit/pull/2197 (`637fe865`); the comment now reads "Resolve the current operation keys. This is what we build the Bitcoin lock with".

I still ran the sweep the issue asked for. A repo-wide grep for `if enabled` / `when enabled` / `opt-in` / `gated` returns a lot, but all of it describes live mechanisms — auth-gated VP RPC methods, current feature flags, conditional UI. Narrowed to the surface where a removed RFC-006 flag could plausibly still be described — `services/participants/`, `services/deposit/`, `clients/eth/` and `services/vault/src/services/vault/` — there are no hits for "enabled" at all, and no residual RFC-006 flag identifier anywhere in either package. So item 2 is closed with nothing left over.

## Item 3 — narrow the partial-upgrade hazard

`packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts` (the `UINT64_EXCLUSIVE_UPPER_BOUND` block and `getVaultKeyEpochs`) and the matching interface doc in `clients/eth/types.ts`.

All three justified the epoch range check with "a registry that predates RFC-006". True but overstated, as @jonybur pointed out: against a *fully* legacy registry the path fails closed on its own, because `resolveParticipantKeysAtEpochs` goes on to call `getOperationBtcKeyAtEpochOrGenesis` on ApplicationRegistry and ProtocolParams, which do not exist there — the multicall reverts and the garbage epochs are never used.

The reachable gap is narrower: a registry that **has** the operation-key getters but whose `BTCVaultProtocolInfo` struct is **not** extended. There the tail-data epochs resolve with no error, and the range check is the only thing looking at them. All three blocks now say that, and the reader block points at https://github.com/babylonlabs-io/babylon-toolkit/issues/2192 for where the deployment-side check is owned.

The existing "only a backstop, and a weak one" caveat is kept — a mis-decode can still land on a small integer the range accepts. That part was accurate, and it is the reason #2192 exists.

## Verification

Comment-only, so the check is that nothing moved:

```
pnpm --filter @babylonlabs-io/ts-sdk run build     # clean
pnpm run build                                     # clean
pnpm --filter @babylonlabs-io/ts-sdk exec vitest run   # 1492 passed (85 files) — unchanged
pnpm --filter vault run test                       # 3187 passed, 6 skipped — unchanged
cd services/vault && npx tsc --noEmit -p tsconfig.lib.json   # clean
pnpm run lint                                      # 0 errors
```

All three files were already prettier-clean, so no `--write` ran and no unrelated region could be reformatted. `git diff` contains only comment lines — every changed line starts with `*`, `/**` or `*/`.
