### PR TITLE
test(ts-sdk): rfc006 resume key guard

### DIFF
--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/signDepositorGraphImportBoundary.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/signDepositorGraphImportBoundary.test.ts
@@ -1,29 +1,12 @@
 /**
- * `signDepositorGraph` must not read contract state.
+ * `signDepositorGraph` must not read contract state: its challenger-set
+ * assertion is only correct under RFC-006 because every key arrives already
+ * resolved at the vault's frozen epochs. A registry read added here would
+ * silently revert that, with the rest of the suite still green.
  *
- * It derives `LocalChallengers` and asserts the VP-returned
- * `challenger_presign_data` set equals `local ∪ universal`. Under RFC-006 that
- * is only correct because every key it works with arrives already resolved at
- * the vault's frozen epochs, through the context object `prepareSigningContext`
- * builds. The module itself resolves nothing, and nor does any module it
- * imports directly.
- *
- * Nothing in the type system says so. If someone needing "the VP's key" reached
- * for a registry read here — the natural move, and the reason #2206 renamed the
- * genesis getter — epoch resolution would silently revert for the challenger
- * set, and every other test in the suite would still pass. The failure would
- * surface as a payout signed against a challenger key the protocol does not
- * recognise, which `CLAUDE.md` lists as the asymmetric-failure case on this
- * path.
- *
- * This is a structural assertion rather than a behavioural one, deliberately.
- * The behavioural half of the same guard lives in
- * `services/vault/src/services/vault/__tests__/vaultPayoutSignatureService.payoutScripts.test.ts`,
- * whose fixture rotates the VP so that resolving the registration key instead of
- * the operation key fails a real assertion about a real return value. What that
- * test cannot express is the *absence* of a read in a module that has no
- * observable output tied to it — so this one asserts over the import graph, and
- * is the only test here allowed to do that.
+ * Structural rather than behavioural, deliberately — the absence of a read has
+ * no observable output to assert on. The behavioural half is the rotated-VP
+ * fixture in vault's `vaultPayoutSignatureService.payoutScripts.test.ts`.
  */
 
 import { readFileSync } from "fs";
@@ -34,21 +17,15 @@ import { describe, expect, it } from "vitest";
 const MODULE_PATH = path.resolve(__dirname, "../signDepositorGraph.ts");
 
 /**
- * Path segments that mean contract access.
- *
- * `clients/` as a whole is deliberately not banned: the module legitimately
- * imports `clients/vault-provider/types`, which is the VP's wire format rather
- * than chain state.
+ * Not all of `clients/`: the module legitimately imports
+ * `clients/vault-provider/types`, which is wire format, not chain state.
  */
 const CONTRACT_STATE_SEGMENTS = ["clients/eth", "contracts/"];
 
 /**
- * Every module specifier the file pulls in, in any form.
- *
- * Matching only `from "…"` would leave `await import("…")` and `require("…")` as
- * unwatched ways to reach the same registries — a plausible route in, since a
- * dynamic import is exactly what someone would reach for to dodge a circular
- * dependency.
+ * Static, type-only, bare, dynamic and `require` forms. Matching only
+ * `from "…"` would leave `await import("…")` as an unwatched route in — the
+ * obvious one, for dodging a circular dependency.
  */
 const MODULE_SPECIFIER =
   /(?:\bfrom\s*|\bimport\s*\(\s*|\brequire\s*\(\s*|\bimport\s+)["']([^"']+)["']/g;

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/signDepositorGraphImportBoundary.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/signDepositorGraphImportBoundary.test.ts
@@ -1,0 +1,59 @@
+/**
+ * `signDepositorGraph` must not read contract state.
+ *
+ * It derives `LocalChallengers` and asserts the VP-returned
+ * `challenger_presign_data` set equals `local ∪ universal`. Under RFC-006 that
+ * is only correct because every key it works with arrives already resolved at
+ * the vault's frozen epochs, through the context object `prepareSigningContext`
+ * builds. The module itself resolves nothing.
+ *
+ * Nothing in the type system says so. If someone needing "the VP's key" reached
+ * for a registry read here — the natural move, and the reason #2206 renamed the
+ * genesis getter — epoch resolution would silently revert for the challenger
+ * set, and every other test in the suite would still pass. The failure would
+ * surface as a payout signed against a challenger key the protocol does not
+ * recognise, which `CLAUDE.md` lists as the asymmetric-failure case on this
+ * path.
+ *
+ * So the invariant is asserted the only way it can be: over the import list.
+ */
+
+import { readFileSync } from "fs";
+import path from "path";
+
+import { describe, expect, it } from "vitest";
+
+const MODULE_PATH = path.resolve(__dirname, "../signDepositorGraph.ts");
+
+/**
+ * Import specifiers that would give this module contract access.
+ *
+ * `clients/` as a whole is deliberately not banned: the module legitimately
+ * imports `clients/vault-provider/types`, which is the VP's wire format, not
+ * chain state.
+ */
+const FORBIDDEN_SEGMENTS = ["clients/eth", "contracts/"];
+
+/** Every `from "…"` specifier in the file, `import type` included. */
+function importSpecifiers(source: string): string[] {
+  return [...source.matchAll(/\bfrom\s+["']([^"']+)["']/g)].map((m) => m[1]);
+}
+
+describe("signDepositorGraph import boundary", () => {
+  it("imports nothing that reads contract state", () => {
+    const specifiers = importSpecifiers(readFileSync(MODULE_PATH, "utf-8"));
+
+    const violations = specifiers.filter((specifier) =>
+      FORBIDDEN_SEGMENTS.some((segment) => specifier.includes(segment)),
+    );
+
+    expect(violations).toEqual([]);
+  });
+
+  it("reads a non-empty import list, so the check above cannot pass vacuously", () => {
+    const specifiers = importSpecifiers(readFileSync(MODULE_PATH, "utf-8"));
+
+    expect(specifiers.length).toBeGreaterThan(0);
+    expect(specifiers).toContain("../../clients/vault-provider/types");
+  });
+});

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/signDepositorGraphImportBoundary.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/signDepositorGraphImportBoundary.test.ts
@@ -5,7 +5,8 @@
  * `challenger_presign_data` set equals `local ∪ universal`. Under RFC-006 that
  * is only correct because every key it works with arrives already resolved at
  * the vault's frozen epochs, through the context object `prepareSigningContext`
- * builds. The module itself resolves nothing.
+ * builds. The module itself resolves nothing, and nor does any module it
+ * imports directly.
  *
  * Nothing in the type system says so. If someone needing "the VP's key" reached
  * for a registry read here — the natural move, and the reason #2206 renamed the
@@ -15,7 +16,14 @@
  * recognise, which `CLAUDE.md` lists as the asymmetric-failure case on this
  * path.
  *
- * So the invariant is asserted the only way it can be: over the import list.
+ * This is a structural assertion rather than a behavioural one, deliberately.
+ * The behavioural half of the same guard lives in
+ * `services/vault/src/services/vault/__tests__/vaultPayoutSignatureService.payoutScripts.test.ts`,
+ * whose fixture rotates the VP so that resolving the registration key instead of
+ * the operation key fails a real assertion about a real return value. What that
+ * test cannot express is the *absence* of a read in a module that has no
+ * observable output tied to it — so this one asserts over the import graph, and
+ * is the only test here allowed to do that.
  */
 
 import { readFileSync } from "fs";
@@ -26,34 +34,60 @@ import { describe, expect, it } from "vitest";
 const MODULE_PATH = path.resolve(__dirname, "../signDepositorGraph.ts");
 
 /**
- * Import specifiers that would give this module contract access.
+ * Path segments that mean contract access.
  *
  * `clients/` as a whole is deliberately not banned: the module legitimately
- * imports `clients/vault-provider/types`, which is the VP's wire format, not
- * chain state.
+ * imports `clients/vault-provider/types`, which is the VP's wire format rather
+ * than chain state.
  */
-const FORBIDDEN_SEGMENTS = ["clients/eth", "contracts/"];
+const CONTRACT_STATE_SEGMENTS = ["clients/eth", "contracts/"];
 
-/** Every `from "…"` specifier in the file, `import type` included. */
-function importSpecifiers(source: string): string[] {
-  return [...source.matchAll(/\bfrom\s+["']([^"']+)["']/g)].map((m) => m[1]);
+/**
+ * Every module specifier the file pulls in, in any form.
+ *
+ * Matching only `from "…"` would leave `await import("…")` and `require("…")` as
+ * unwatched ways to reach the same registries — a plausible route in, since a
+ * dynamic import is exactly what someone would reach for to dodge a circular
+ * dependency.
+ */
+const MODULE_SPECIFIER =
+  /(?:\bfrom\s*|\bimport\s*\(\s*|\brequire\s*\(\s*|\bimport\s+)["']([^"']+)["']/g;
+
+/** The specifiers in `source` that would give the module contract access. */
+function contractStateImports(source: string): string[] {
+  return [...source.matchAll(MODULE_SPECIFIER)]
+    .map((match) => match[1])
+    .filter((specifier) =>
+      CONTRACT_STATE_SEGMENTS.some((segment) => specifier.includes(segment)),
+    );
 }
 
 describe("signDepositorGraph import boundary", () => {
   it("imports nothing that reads contract state", () => {
-    const specifiers = importSpecifiers(readFileSync(MODULE_PATH, "utf-8"));
-
-    const violations = specifiers.filter((specifier) =>
-      FORBIDDEN_SEGMENTS.some((segment) => specifier.includes(segment)),
+    expect(contractStateImports(readFileSync(MODULE_PATH, "utf-8"))).toEqual(
+      [],
     );
-
-    expect(violations).toEqual([]);
   });
 
-  it("reads a non-empty import list, so the check above cannot pass vacuously", () => {
-    const specifiers = importSpecifiers(readFileSync(MODULE_PATH, "utf-8"));
+  it("detects a contract import written as a static, type-only, dynamic or required form", () => {
+    // Guards the test above against passing vacuously: a broken pattern would
+    // report a clean file no matter what it contained. Asserted against a
+    // sample rather than the real import list, so moving a file the module
+    // legitimately imports cannot fail this.
+    const sample = [
+      `import { ViemVaultRegistryReader } from "../../clients/eth/vault-registry-reader";`,
+      `import type { KeyEpochs } from "../../clients/eth/types";`,
+      `const { BTCVaultRegistryABI } = await import("../../contracts/abis/BTCVaultRegistry.abi");`,
+      `const legacy = require("../../contracts/abis/ApplicationRegistry.abi");`,
+      `import { Transaction } from "bitcoinjs-lib";`,
+      `import type { BitcoinWallet } from "../../../../shared/wallets/interfaces";`,
+    ].join("\n");
 
-    expect(specifiers.length).toBeGreaterThan(0);
-    expect(specifiers).toContain("../../clients/vault-provider/types");
+    expect(contractStateImports(sample)).toEqual([
+      "../../clients/eth/vault-registry-reader",
+      "../../clients/eth/types",
+      "../../contracts/abis/BTCVaultRegistry.abi",
+      "../../contracts/abis/ApplicationRegistry.abi",
+    ]);
   });
 });

--- a/services/vault/src/services/vault/__tests__/vaultPayoutSignatureService.payoutScripts.test.ts
+++ b/services/vault/src/services/vault/__tests__/vaultPayoutSignatureService.payoutScripts.test.ts
@@ -60,7 +60,17 @@ import {
 } from "../../../clients/eth-contract/btc-vault-registry/query";
 import { prepareSigningContext } from "../vaultPayoutSignatureService";
 
-const VP_KEY = "a".repeat(64);
+/**
+ * The VP is rotated in this fixture: its registration key and the key its
+ * frozen `vpKeyEpoch` resolves to are deliberately different values.
+ *
+ * That difference is what gives "builds with the epoch-bonded participant keys"
+ * below any force. With both set to the same key, a regression that reached for
+ * the registration key — the natural mistake, since `prepareSigningContext`
+ * already reads it as the genesis fallback — would still pass.
+ */
+const VP_GENESIS_KEY = "a".repeat(64);
+const VP_OPERATION_KEY = "b".repeat(64);
 
 /**
  * Two keeper operation keys whose *roster* order is the reverse of their
@@ -97,7 +107,7 @@ beforeEach(() => {
     vaultProviderCommissionBps: 50,
   } as never);
   vi.mocked(getVaultProviderGenesisBtcPubkeyFromChain).mockResolvedValue(
-    `0x${VP_KEY}` as never,
+    `0x${VP_GENESIS_KEY}` as never,
   );
   vi.mocked(getVaultKeyEpochsFromChain).mockResolvedValue({
     vpKeyEpoch: 12n,
@@ -106,7 +116,7 @@ beforeEach(() => {
   } as never);
 
   mockResolveParticipantKeysAtEpochs.mockResolvedValue({
-    vaultProvider: { operationBtcPubkey: VP_KEY },
+    vaultProvider: { operationBtcPubkey: VP_OPERATION_KEY },
     // Roster order — index-aligned with the payout scripts below.
     vaultKeepers: [
       { operationBtcPubkey: KEEPER_ROSTER_FIRST },
@@ -147,13 +157,30 @@ describe("prepareSigningContext — registered payout scripts", () => {
     );
   });
 
-  it("builds with the epoch-bonded participant keys", async () => {
+  it("builds with the epoch-bonded participant keys, not the registration key", async () => {
     const { context } = await prepareSigningContext(signingArgs);
 
-    expect(context.vaultProviderBtcPubkey).toBe(VP_KEY);
+    expect(context.vaultProviderBtcPubkey).toBe(VP_OPERATION_KEY);
+    expect(context.vaultProviderBtcPubkey).not.toBe(VP_GENESIS_KEY);
     expect(context.vaultKeeperBtcPubkeys).toEqual([
       KEEPER_ROSTER_SECOND,
       KEEPER_ROSTER_FIRST,
     ]);
+  });
+
+  it("passes the registration key to resolution as the genesis fallback", async () => {
+    // The registration key still has one job — it is the genesis the VP's
+    // epoch lookup falls back to when the provider never rotated. A change
+    // that stopped reading it would break un-rotated providers rather than
+    // rotated ones, which is the harder failure to notice.
+    await prepareSigningContext(signingArgs);
+
+    expect(mockResolveParticipantKeysAtEpochs).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: expect.objectContaining({
+          vaultProviderGenesisBtcPubkey: `0x${VP_GENESIS_KEY}`,
+        }),
+      }),
+    );
   });
 });

--- a/services/vault/src/services/vault/__tests__/vaultPayoutSignatureService.payoutScripts.test.ts
+++ b/services/vault/src/services/vault/__tests__/vaultPayoutSignatureService.payoutScripts.test.ts
@@ -61,13 +61,10 @@ import {
 import { prepareSigningContext } from "../vaultPayoutSignatureService";
 
 /**
- * The VP is rotated in this fixture: its registration key and the key its
- * frozen `vpKeyEpoch` resolves to are deliberately different values.
- *
- * That difference is what gives "builds with the epoch-bonded participant keys"
- * below any force. With both set to the same key, a regression that reached for
- * the registration key — the natural mistake, since `prepareSigningContext`
- * already reads it as the genesis fallback — would still pass.
+ * The VP is rotated here: these two are deliberately different values. Setting
+ * both to the same key is what let a regression to the registration key — the
+ * natural mistake, since it is read as the genesis fallback — pass the
+ * epoch-bonded-keys test below.
  */
 const VP_GENESIS_KEY = "a".repeat(64);
 const VP_OPERATION_KEY = "b".repeat(64);
@@ -169,10 +166,9 @@ describe("prepareSigningContext — registered payout scripts", () => {
   });
 
   it("passes the registration key to resolution as the genesis fallback", async () => {
-    // The registration key still has one job — it is the genesis the VP's
-    // epoch lookup falls back to when the provider never rotated. A change
-    // that stopped reading it would break un-rotated providers rather than
-    // rotated ones, which is the harder failure to notice.
+    // The registration key still has one job: the genesis the VP's epoch lookup
+    // falls back to when the provider never rotated. Losing it would break
+    // un-rotated providers — the harder failure to notice.
     await prepareSigningContext(signingArgs);
 
     expect(mockResolveParticipantKeysAtEpochs).toHaveBeenCalledWith(

--- a/services/vault/src/services/vault/__tests__/verifyResumeParticipantKeys.test.ts
+++ b/services/vault/src/services/vault/__tests__/verifyResumeParticipantKeys.test.ts
@@ -1,11 +1,10 @@
 /**
  * The pre-broadcast key-drift guard on the resume path.
  *
- * `resolveParticipantKeysAtEpochs` is mocked: resolution itself is SDK-side and
- * covered by `resolveParticipantKeys.test.ts`. What has no coverage anywhere is
- * the comparison body in this module, which is the only thing standing between a
- * rotated key set and a Pre-PegIn broadcast, and whose abort branch cannot be
- * reached on a real network (an unrelated spend fires first — see #2187).
+ * `resolveParticipantKeysAtEpochs` is mocked — resolution is covered SDK-side by
+ * `resolveParticipantKeys.test.ts`. What had no coverage is this module's
+ * comparison body, whose abort branch is unreachable on a real network (an
+ * unrelated spend fires first, see #2187).
  */
 
 import {
@@ -154,8 +153,7 @@ describe("verifyResumeParticipantKeys", () => {
 
   it("aborts when the keeper set matches but the order does not", async () => {
     // Same two keys, opposite order. Both sides are the sorted arrays script
-    // construction consumes, so this is a genuine mismatch — and this module is
-    // the only place it is caught.
+    // construction consumes, so this is a real mismatch — caught only here.
     resolvesTo({ ...STAMPED, vaultKeepers: [KEEPER_HIGH, KEEPER_LOW] });
 
     await expect(
@@ -164,10 +162,9 @@ describe("verifyResumeParticipantKeys", () => {
   });
 
   it("throws a key-drift error and not a version mismatch", async () => {
-    // The distinction is load-bearing: `handleBroadcast` drops the pending
-    // record on a version mismatch, but must keep it on key drift, because the
-    // record holds the stamp that lets a later resume re-detect the drift
-    // instead of falling back to the indexer's copy and broadcasting it.
+    // `handleBroadcast` drops the pending record on a version mismatch but must
+    // keep it on key drift — the record holds the stamp that lets a later resume
+    // re-detect the drift instead of broadcasting the indexer's copy.
     resolvesTo({ ...STAMPED, vaultProvider: VP_KEY_ROTATED });
 
     const error = await verifyResumeParticipantKeys({
@@ -182,9 +179,7 @@ describe("verifyResumeParticipantKeys", () => {
 
   it("accepts stamped keys that differ from the resolved ones only in encoding", async () => {
     // `peginStorage` writes bare lowercase hex, so this cannot happen today.
-    // The guard normalises anyway: an encoding difference must never read as
-    // drift, or a second writer of the stamp would abort deposits whose keys
-    // are identical.
+    // Normalised anyway so an encoding difference can never read as drift.
     await expect(
       verifyResumeParticipantKeys({
         vaultId: VAULT_ID,

--- a/services/vault/src/services/vault/__tests__/verifyResumeParticipantKeys.test.ts
+++ b/services/vault/src/services/vault/__tests__/verifyResumeParticipantKeys.test.ts
@@ -1,0 +1,211 @@
+/**
+ * The pre-broadcast key-drift guard on the resume path.
+ *
+ * `resolveParticipantKeysAtEpochs` is mocked: resolution itself is SDK-side and
+ * covered by `resolveParticipantKeys.test.ts`. What has no coverage anywhere is
+ * the comparison body in this module, which is the only thing standing between a
+ * rotated key set and a Pre-PegIn broadcast, and whose abort branch cannot be
+ * reached on a real network (an unrelated spend fires first — see #2187).
+ */
+
+import {
+  isParticipantKeyDriftError,
+  isRegisteredVaultVersionMismatchError,
+} from "@babylonlabs-io/ts-sdk/tbv/core";
+import type { Hex } from "viem";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockResolveParticipantKeysAtEpochs = vi.hoisted(() => vi.fn());
+
+vi.mock("@babylonlabs-io/ts-sdk/tbv/core", async (importOriginal) => ({
+  ...((await importOriginal()) as object),
+  resolveParticipantKeysAtEpochs: (...args: unknown[]) =>
+    mockResolveParticipantKeysAtEpochs(...args),
+}));
+
+vi.mock("@/clients/eth-contract/btc-vault-registry/query", () => ({
+  getVaultFromChain: vi.fn(),
+  getVaultKeyEpochsFromChain: vi.fn(),
+  getVaultProviderGenesisBtcPubkeyFromChain: vi.fn(),
+}));
+
+vi.mock("@/clients/eth-contract/sdk-readers", () => ({
+  getVaultKeeperReader: vi.fn().mockResolvedValue({
+    getVaultKeepersByVersion: vi.fn().mockResolvedValue([
+      { ethAddress: "0xkeeperA", btcPubKey: "0xvk1" },
+      { ethAddress: "0xkeeperB", btcPubKey: "0xvk2" },
+    ]),
+  }),
+  getUniversalChallengerReader: vi.fn().mockResolvedValue({
+    getUniversalChallengersByVersion: vi
+      .fn()
+      .mockResolvedValue([{ ethAddress: "0xucA", btcPubKey: "0xuc1" }]),
+  }),
+  getOperationKeyReader: vi.fn().mockResolvedValue({}),
+}));
+
+import {
+  getVaultFromChain,
+  getVaultKeyEpochsFromChain,
+  getVaultProviderGenesisBtcPubkeyFromChain,
+} from "@/clients/eth-contract/btc-vault-registry/query";
+
+import { verifyResumeParticipantKeys } from "../verifyResumeParticipantKeys";
+
+const VAULT_ID = `0x${"11".repeat(32)}` as Hex;
+
+const VP_KEY = "a".repeat(64);
+const VP_KEY_ROTATED = "b".repeat(64);
+
+/** Sorted, as both sides of the comparison always are. */
+const KEEPER_LOW = "1".repeat(64);
+const KEEPER_HIGH = "f".repeat(64);
+const KEEPER_HIGH_ROTATED = "e".repeat(64);
+
+const CHALLENGER_KEY = "c".repeat(64);
+const CHALLENGER_KEY_ROTATED = "d".repeat(64);
+
+/** What the vault's frozen epochs currently resolve to. */
+function resolvesTo(keys: {
+  vaultProvider: string;
+  vaultKeepers: string[];
+  universalChallengers: string[];
+}) {
+  mockResolveParticipantKeysAtEpochs.mockResolvedValue({
+    vaultProvider: { operationBtcPubkey: keys.vaultProvider },
+    vaultKeeperOperationKeysSorted: keys.vaultKeepers,
+    universalChallengerOperationKeysSorted: keys.universalChallengers,
+  });
+}
+
+const STAMPED = {
+  vaultProvider: VP_KEY,
+  vaultKeepers: [KEEPER_LOW, KEEPER_HIGH],
+  universalChallengers: [CHALLENGER_KEY],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  vi.mocked(getVaultFromChain).mockResolvedValue({
+    vaultProvider: "0xprovider",
+    applicationEntryPoint: "0xapp",
+    appVaultKeepersVersion: 2,
+    universalChallengersVersion: 3,
+  } as never);
+  vi.mocked(getVaultProviderGenesisBtcPubkeyFromChain).mockResolvedValue(
+    `0x${VP_KEY}` as never,
+  );
+  vi.mocked(getVaultKeyEpochsFromChain).mockResolvedValue({
+    vpKeyEpoch: 7n,
+    appKeeperKeyEpoch: 7n,
+    ucKeyEpoch: 7n,
+  } as never);
+
+  resolvesTo(STAMPED);
+});
+
+describe("verifyResumeParticipantKeys", () => {
+  it("passes when the vault's frozen epochs resolve to the stamped keys", async () => {
+    await expect(
+      verifyResumeParticipantKeys({ vaultId: VAULT_ID, expected: STAMPED }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("resolves against the vault's frozen epochs, not the current ones", async () => {
+    await verifyResumeParticipantKeys({ vaultId: VAULT_ID, expected: STAMPED });
+
+    expect(mockResolveParticipantKeysAtEpochs).toHaveBeenCalledWith(
+      expect.objectContaining({
+        epochs: { vpKeyEpoch: 7n, appKeeperKeyEpoch: 7n, ucKeyEpoch: 7n },
+      }),
+    );
+  });
+
+  it("aborts when the vault provider's operation key drifted", async () => {
+    resolvesTo({ ...STAMPED, vaultProvider: VP_KEY_ROTATED });
+
+    await expect(
+      verifyResumeParticipantKeys({ vaultId: VAULT_ID, expected: STAMPED }),
+    ).rejects.toThrow(/vault provider's operation key changed/i);
+  });
+
+  it("aborts naming the keeper set when a keeper key drifted", async () => {
+    resolvesTo({
+      ...STAMPED,
+      vaultKeepers: [KEEPER_LOW, KEEPER_HIGH_ROTATED],
+    });
+
+    await expect(
+      verifyResumeParticipantKeys({ vaultId: VAULT_ID, expected: STAMPED }),
+    ).rejects.toThrow(/the vault keeper set changed/i);
+  });
+
+  it("aborts naming the challenger set when a challenger key drifted", async () => {
+    resolvesTo({
+      ...STAMPED,
+      universalChallengers: [CHALLENGER_KEY_ROTATED],
+    });
+
+    await expect(
+      verifyResumeParticipantKeys({ vaultId: VAULT_ID, expected: STAMPED }),
+    ).rejects.toThrow(/the universal challenger set changed/i);
+  });
+
+  it("aborts when the keeper set matches but the order does not", async () => {
+    // Same two keys, opposite order. Both sides are the sorted arrays script
+    // construction consumes, so this is a genuine mismatch — and this module is
+    // the only place it is caught.
+    resolvesTo({ ...STAMPED, vaultKeepers: [KEEPER_HIGH, KEEPER_LOW] });
+
+    await expect(
+      verifyResumeParticipantKeys({ vaultId: VAULT_ID, expected: STAMPED }),
+    ).rejects.toThrow(/the vault keeper set changed/i);
+  });
+
+  it("throws a key-drift error and not a version mismatch", async () => {
+    // The distinction is load-bearing: `handleBroadcast` drops the pending
+    // record on a version mismatch, but must keep it on key drift, because the
+    // record holds the stamp that lets a later resume re-detect the drift
+    // instead of falling back to the indexer's copy and broadcasting it.
+    resolvesTo({ ...STAMPED, vaultProvider: VP_KEY_ROTATED });
+
+    const error = await verifyResumeParticipantKeys({
+      vaultId: VAULT_ID,
+      expected: STAMPED,
+    }).catch((e: unknown) => e);
+
+    expect(isParticipantKeyDriftError(error)).toBe(true);
+    expect(isRegisteredVaultVersionMismatchError(error)).toBe(false);
+    expect((error as Error).message).toMatch(/was not broadcast/i);
+  });
+
+  it("accepts stamped keys that differ from the resolved ones only in encoding", async () => {
+    // `peginStorage` writes bare lowercase hex, so this cannot happen today.
+    // The guard normalises anyway: an encoding difference must never read as
+    // drift, or a second writer of the stamp would abort deposits whose keys
+    // are identical.
+    await expect(
+      verifyResumeParticipantKeys({
+        vaultId: VAULT_ID,
+        expected: {
+          vaultProvider: `0x${VP_KEY.toUpperCase()}`,
+          vaultKeepers: [`0x${KEEPER_LOW}`, KEEPER_HIGH.toUpperCase()],
+          universalChallengers: [`0x${CHALLENGER_KEY}`],
+        },
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("reports which stamped key is unreadable rather than reporting drift", async () => {
+    const error = await verifyResumeParticipantKeys({
+      vaultId: VAULT_ID,
+      expected: { ...STAMPED, vaultKeepers: [KEEPER_LOW, "not-hex"] },
+    }).catch((e: unknown) => e);
+
+    expect((error as Error).message).toMatch(
+      /the vault keeper set at index 1 is not a readable BTC public key/i,
+    );
+    expect(isParticipantKeyDriftError(error)).toBe(false);
+  });
+});

--- a/services/vault/src/services/vault/__tests__/vpAuthPinnedPubkey.test.ts
+++ b/services/vault/src/services/vault/__tests__/vpAuthPinnedPubkey.test.ts
@@ -1,12 +1,9 @@
 /**
- * Which BTC key a vault provider's RPC auth session is pinned to.
- *
- * The pin follows the VP's *current operation* key, deliberately — not the
- * registration key and not the vault's frozen epoch, because auth is a
- * per-operator server identity rather than a per-vault binding (RFC-006 open
- * question 5). That reasoning is documented on the module but was not tested, so
- * nothing stopped a future reader "correcting" it toward the genesis key and
- * breaking auth for every vault of a rotated provider.
+ * The VP auth pin follows the *current operation* key, deliberately — auth is a
+ * per-operator server identity, not a per-vault binding (RFC-006 open question
+ * 5). Documented on the module but untested, so nothing stopped a future reader
+ * "correcting" it toward the genesis key and breaking auth for every vault of a
+ * rotated provider.
  */
 
 import type { Address } from "viem";

--- a/services/vault/src/services/vault/__tests__/vpAuthPinnedPubkey.test.ts
+++ b/services/vault/src/services/vault/__tests__/vpAuthPinnedPubkey.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Which BTC key a vault provider's RPC auth session is pinned to.
+ *
+ * The pin follows the VP's *current operation* key, deliberately — not the
+ * registration key and not the vault's frozen epoch, because auth is a
+ * per-operator server identity rather than a per-vault binding (RFC-006 open
+ * question 5). That reasoning is documented on the module but was not tested, so
+ * nothing stopped a future reader "correcting" it toward the genesis key and
+ * breaking auth for every vault of a rotated provider.
+ */
+
+import type { Address } from "viem";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetCurrentVaultProviderOperationBtcKey = vi.hoisted(() => vi.fn());
+const mockGetVaultProviderGenesisBtcPubKey = vi.hoisted(() => vi.fn());
+const mockGetVaultKeyEpochs = vi.hoisted(() => vi.fn());
+
+vi.mock("@/clients/eth-contract/sdk-readers", () => ({
+  getVaultRegistryReader: () => ({
+    getCurrentVaultProviderOperationBtcKey:
+      mockGetCurrentVaultProviderOperationBtcKey,
+    getVaultProviderGenesisBtcPubKey: mockGetVaultProviderGenesisBtcPubKey,
+    getVaultKeyEpochs: mockGetVaultKeyEpochs,
+  }),
+}));
+
+import { resolveVpAuthPinnedPubkey } from "../vpAuthPinnedPubkey";
+
+const VP_ADDRESS = `0x${"1".repeat(40)}` as Address;
+const CURRENT_OPERATION_KEY = "a".repeat(64);
+const GENESIS_KEY = "b".repeat(64);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetCurrentVaultProviderOperationBtcKey.mockResolvedValue(
+    CURRENT_OPERATION_KEY,
+  );
+  mockGetVaultProviderGenesisBtcPubKey.mockResolvedValue(GENESIS_KEY);
+});
+
+describe("resolveVpAuthPinnedPubkey", () => {
+  it("returns the provider's current operation key", async () => {
+    await expect(resolveVpAuthPinnedPubkey(VP_ADDRESS)).resolves.toBe(
+      CURRENT_OPERATION_KEY,
+    );
+
+    expect(mockGetCurrentVaultProviderOperationBtcKey).toHaveBeenCalledWith(
+      VP_ADDRESS,
+    );
+  });
+
+  it("does not read the registration key or any frozen epoch", async () => {
+    await resolveVpAuthPinnedPubkey(VP_ADDRESS);
+
+    expect(mockGetVaultProviderGenesisBtcPubKey).not.toHaveBeenCalled();
+    expect(mockGetVaultKeyEpochs).not.toHaveBeenCalled();
+  });
+});

--- a/services/vault/src/services/vault/verifyResumeParticipantKeys.ts
+++ b/services/vault/src/services/vault/verifyResumeParticipantKeys.ts
@@ -37,24 +37,13 @@ export interface ExpectedParticipantOperationKeys {
 }
 
 /**
- * Bring a stamped key into the one form the resolved side is already in.
+ * Normalize a stamped key to the lowercase bare x-only form the resolved side
+ * already has. A no-op for stamps written through `@/storage/peginStorage`,
+ * which validates that shape — done here anyway so an encoding difference can
+ * never read as drift if a second writer of the stamp appears.
  *
- * The resolved keys come from `assertOnChainBtcPubkey`, which mints lowercase
- * x-only hex with no `0x`. The stamped keys come from localStorage, and
- * `isValidPeginRecord` in `@/storage/peginStorage` requires that same shape of
- * all three fields — so this is a no-op for anything written through the
- * sanctioned path.
- *
- * It runs anyway so that the comparison below does not silently depend on a
- * validator two modules away. A second writer of the stamp, or a relaxed
- * validator, would otherwise turn an encoding difference into a phantom
- * "keys changed" abort on a deposit whose keys are in fact identical.
- *
- * A key that cannot be canonicalized is reported with its field and index
- * rather than surfacing `canonicalizeBtcPubkey`'s bare hex complaint. The
- * resulting error is deliberately not a `ParticipantKeyDriftError`: nothing
- * drifted, the stamp is unreadable. Either way the caller keeps the pending
- * record and skips the broadcast.
+ * Not a `ParticipantKeyDriftError` on failure: nothing drifted, the stamp is
+ * unreadable.
  */
 function canonicalizeStamped(
   label: string,
@@ -74,12 +63,10 @@ function canonicalizeStamped(
 }
 
 /**
- * Compare two key sets element-by-element, in order.
- *
- * Order matters: both sides are the lexicographically sorted operation-key
- * arrays that script construction consumes, so a set that matches in a
- * different order is still a mismatch — and this is the only place that is
- * caught. Canonicalization below must therefore not reorder anything.
+ * Compare two key sets element-by-element, in order. Both sides are the sorted
+ * arrays script construction consumes, so a set matching in a different order
+ * is still a mismatch, and this is the only place that is caught — normalizing
+ * below must not reorder anything.
  */
 function assertSameSet(
   label: string,

--- a/services/vault/src/services/vault/verifyResumeParticipantKeys.ts
+++ b/services/vault/src/services/vault/verifyResumeParticipantKeys.ts
@@ -13,7 +13,7 @@
 
 import {
   ParticipantKeyDriftError,
-  processPublicKeyToXOnly,
+  canonicalizeBtcPubkey,
   resolveParticipantKeysAtEpochs,
 } from "@babylonlabs-io/ts-sdk/tbv/core";
 import type { Address, Hex } from "viem";
@@ -36,18 +36,67 @@ export interface ExpectedParticipantOperationKeys {
   universalChallengers: string[];
 }
 
+/**
+ * Bring a stamped key into the one form the resolved side is already in.
+ *
+ * The resolved keys come from `assertOnChainBtcPubkey`, which mints lowercase
+ * x-only hex with no `0x`. The stamped keys come from localStorage, and
+ * `isValidPeginRecord` in `@/storage/peginStorage` requires that same shape of
+ * all three fields — so this is a no-op for anything written through the
+ * sanctioned path.
+ *
+ * It runs anyway so that the comparison below does not silently depend on a
+ * validator two modules away. A second writer of the stamp, or a relaxed
+ * validator, would otherwise turn an encoding difference into a phantom
+ * "keys changed" abort on a deposit whose keys are in fact identical.
+ *
+ * A key that cannot be canonicalized is reported with its field and index
+ * rather than surfacing `canonicalizeBtcPubkey`'s bare hex complaint. The
+ * resulting error is deliberately not a `ParticipantKeyDriftError`: nothing
+ * drifted, the stamp is unreadable. Either way the caller keeps the pending
+ * record and skips the broadcast.
+ */
+function canonicalizeStamped(
+  label: string,
+  key: string,
+  index?: number,
+): string {
+  try {
+    return canonicalizeBtcPubkey(key);
+  } catch (cause) {
+    const at = index === undefined ? "" : ` at index ${index}`;
+    throw new Error(
+      `Cannot verify participant keys: the stamped value for ${label}${at} is ` +
+        `not a readable BTC public key (${key}). The Pre-PegIn was not broadcast.`,
+      { cause },
+    );
+  }
+}
+
+/**
+ * Compare two key sets element-by-element, in order.
+ *
+ * Order matters: both sides are the lexicographically sorted operation-key
+ * arrays that script construction consumes, so a set that matches in a
+ * different order is still a mismatch — and this is the only place that is
+ * caught. Canonicalization below must therefore not reorder anything.
+ */
 function assertSameSet(
   label: string,
   expected: readonly string[],
   actual: readonly string[],
 ): void {
+  const expectedCanonical = expected.map((key, i) =>
+    canonicalizeStamped(label, key, i),
+  );
+
   if (
-    expected.length !== actual.length ||
-    expected.some((k, i) => k !== actual[i])
+    expectedCanonical.length !== actual.length ||
+    expectedCanonical.some((k, i) => k !== actual[i])
   ) {
     throw new ParticipantKeyDriftError(
       `Aborting Pre-PegIn broadcast: ${label} changed since this deposit was built ` +
-        `(expected [${expected.join(", ")}], got [${actual.join(", ")}]). ` +
+        `(expected [${expectedCanonical.join(", ")}], got [${actual.join(", ")}]). ` +
         `The Pre-PegIn was not broadcast; the registered ETH vault will time out ` +
         `per protocol rules.`,
     );
@@ -103,9 +152,10 @@ export async function verifyResumeParticipantKeys(params: {
     epochs,
   });
 
-  const expectedVp = processPublicKeyToXOnly(
+  const expectedVp = canonicalizeStamped(
+    "the vault provider's operation key",
     expected.vaultProvider,
-  ).toLowerCase();
+  );
   if (resolved.vaultProvider.operationBtcPubkey !== expectedVp) {
     throw new ParticipantKeyDriftError(
       `Aborting Pre-PegIn broadcast: the vault provider's operation key changed ` +


### PR DESCRIPTION
Closes https://github.com/babylonlabs-io/babylon-toolkit/issues/2185

Three RFC-006 correctness properties shipped in https://github.com/babylonlabs-io/babylon-toolkit/pull/2173 were true but unguarded — each one would survive a refactor that broke it with a fully green suite. This adds the guards, and makes one comparison uniform along the way.

## With / without

| Property | Without this change | With this change |
|---|---|---|
| The resume path aborts a broadcast when a rotation landed mid-deposit | `verifyResumeParticipantKeys`'s body never runs in any test — the one test touching it mocks the module wholesale, and the abort branch is unreachable on a real network (an unrelated spend fires first, see #2187) | 9 tests over the real comparison body, including the ordering case that nothing else catches |
| `prepareSigningContext` builds with the *operation* key, not the registration key | The test named "builds with the epoch-bonded participant keys" sets genesis and operation key to the **same** value, so a reversion to the registration key still passes it | The fixture is rotated; that reversion fails the test |
| `signDepositorGraph` resolves no keys of its own | Holds only because the file happens not to import `clients/eth`. Reintroducing that import silently reverts epoch resolution for the challenger set | An import-boundary test fails on any contract import, type-only included |
| The VP auth pin follows the *current* operation key | Documented, untested. Nothing stops a future reader "correcting" it toward the genesis key and breaking auth for every vault of a rotated provider | 2 tests pin the getter it reads and the two it must not |

Each guard was verified to actually fail — see **Proving the guards work** below. A guard nobody has seen go red isn't a guard.

## The one behaviour change: uniform key normalisation

`services/vault/src/services/vault/verifyResumeParticipantKeys.ts`

The three comparisons inside the untested body were not written the same way. The VP key was canonicalised before comparison; the keeper and challenger arrays were compared raw:

```ts
// before
const expectedVp = processPublicKeyToXOnly(expected.vaultProvider).toLowerCase();
// ...but assertSameSet compared the arrays byte-for-byte, unnormalised
```

So the VP comparison tolerated a `0x` prefix or a different encoding and the array comparisons did not. Harmless today, and only by coincidence of a distant file: `isValidPeginRecord` in `storage/peginStorage.ts` validates all three stamped fields against `/^[0-9a-f]{64}$/`, so nothing that reaches the comparison can exercise the difference. That coupling is invisible from either file.

All three now go through **`canonicalizeBtcPubkey`**. Worth noting this is not a behaviour change for the VP: `canonicalizeBtcPubkey` is *literally* `processPublicKeyToXOnly(x).toLowerCase()` (`primitives/utils/bitcoin.ts:207-209`). It is the named helper `vaultPayoutSignatureService.resolveVaultProviderBtcPubkey` already uses, so all three comparisons now share one code path.

Normalising rather than dropping the VP's normalisation, because the two directions fail differently. Canonicalising makes two encodings of the *same* key compare equal, which cannot mask real drift. Comparing raw means that if a second writer of the stamp ever appears, or the storage validator is relaxed, the guard aborts a deposit whose keys are in fact identical. For a check whose only job is to refuse a broadcast, its failures should be real ones.

Two details that matter to a reviewer:

- **Nothing is sorted.** Both sides are the lexicographically sorted arrays script construction consumes, so a set that matches in a different order is still a mismatch — and this module is the only place that is caught. Canonicalisation is in-place and index-preserving, and there is a test asserting the ordering case still fails.
- **A malformed stamp is reported, not mistaken for drift.** `canonicalizeBtcPubkey` throws on bad input, so the three call sites go through a small wrapper that names the field and index. That error is deliberately *not* a `ParticipantKeyDriftError` — nothing drifted, the stamp is unreadable. Either way `handleBroadcast` keeps the pending record and skips the broadcast, since it does not wrap this call in the version-mismatch cleanup.

## Tests

**`__tests__/verifyResumeParticipantKeys.test.ts`** (new, 9 tests). `resolveParticipantKeysAtEpochs` is mocked, following `__tests__/vaultPayoutSignatureService.payoutScripts.test.ts` in the same directory. Resolution correctness is SDK-side and already covered by `resolveParticipantKeys.test.ts`; what had no coverage anywhere is this module's comparison body, and that is what runs under the mock. Covers the happy path, resolution at the vault's frozen epochs, VP drift, keeper-set drift, challenger-set drift, ordering-only drift, the `isParticipantKeyDriftError` / not-`isRegisteredVaultVersionMismatchError` distinction, encoding tolerance, and the unreadable-stamp error.

**`__tests__/vpAuthPinnedPubkey.test.ts`** (new, 2 tests). Asserts `resolveVpAuthPinnedPubkey` reads `getCurrentVaultProviderOperationBtcKey` and that neither the genesis getter nor any frozen-epoch getter is touched.

**`__tests__/vaultPayoutSignatureService.payoutScripts.test.ts`** (strengthened). `VP_KEY` split into distinct `VP_GENESIS_KEY` and `VP_OPERATION_KEY` so the VP is genuinely rotated in the fixture, plus a test asserting the registration key is still passed into resolution as the genesis fallback — that read has a real remaining job, and losing it would break un-rotated providers, which is the harder failure to notice.

**`packages/babylon-ts-sdk/.../__tests__/signDepositorGraphImportBoundary.test.ts`** (new, 2 tests). Asserts no import specifier in `signDepositorGraph.ts` reaches into `clients/eth` or `contracts/`. `clients/` as a whole is deliberately *not* banned — the module legitimately imports `clients/vault-provider/types`, which is the VP's wire format rather than chain state. A second test asserts the import list is non-empty and contains that known-good specifier, so the first cannot pass vacuously if the regex or the path ever breaks.

This is why the PR spans both packages: the property being guarded is SDK-side even though the rest of the work is vault-side.

### A note on why the vault test hand-rolls its fixtures

The SDK's rotation fixture (`services/participants/__tests__/fixtures/rotation.ts` — `FakeOperationKeyReader`, `buildQuery`, `epochsAt`) is not reachable from `services/vault`: test fixtures are not published in `dist/`. `verifyRegisteredParticipantKeys.test.ts` is a shape template for the new test, not an importable one.

## Proving the guards work

Each new guard was temporarily broken to confirm it goes red, then the probe reverted:

| Probe | Result |
|---|---|
| Point `prepareSigningContext` at `registrationVpBtcPubkey` | `builds with the epoch-bonded participant keys, not the registration key` fails; the other 4 pass |
| Add `import type { KeyEpochs } from "../../clients/eth/types"` to `signDepositorGraph.ts` | `imports nothing that reads contract state` fails, naming the specifier |
| Remove the array canonicalisation from `assertSameSet` | The 2 normalisation tests fail; the other 7 — including ordering-only drift — still pass, which is the evidence canonicalisation does not mask drift |

## Verification

```
pnpm --filter @babylonlabs-io/ts-sdk run build     # clean
pnpm run build                                     # clean
pnpm --filter @babylonlabs-io/ts-sdk exec vitest run   # 1494 passed (86 files), +2
pnpm --filter vault run test                       # 3199 passed, 6 skipped (280 files), +12
cd services/vault && npx tsc --noEmit -p tsconfig.lib.json   # clean
pnpm run lint                                      # 0 errors
```

Counts reconcile exactly: SDK +2 (import boundary), vault +12 (9 resume guard, 2 auth pin, 1 net from the strengthened fixture).

`hooks/deposit/__tests__/useVaultActions.test.ts` needed no changes — it mocks `verifyResumeParticipantKeys` wholesale, so the normalisation is invisible to it. That was the check that the behaviour change stayed inside its module.

No file here is on the `.github/CODEOWNERS` critical-path list, and there is no overlap with #2224 or #2225.
